### PR TITLE
Review each selected PR in its own item shard

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -312,7 +312,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: clawsweeper-review-${{ github.event.client_payload.repo_slug || github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
+      group: clawsweeper-review-${{ github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
       cancel-in-progress: true
     permissions:
       actions: write
@@ -1358,7 +1358,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: clawsweeper-mutation-${{ github.event.client_payload.repo_slug || github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
+      group: clawsweeper-mutation-${{ github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
       cancel-in-progress: false
     permissions:
       actions: write
@@ -2839,7 +2839,9 @@ jobs:
     timeout-minutes: 75
     continue-on-error: true
     concurrency:
-      group: clawsweeper-review-${{ matrix.repo_slug }}-${{ matrix.item_number }}
+      # GitHub accepts owner/repo in concurrency groups. Keep that canonical
+      # identity so lossy state-path slugs cannot collide across repositories.
+      group: clawsweeper-review-${{ matrix.repo }}-${{ matrix.item_number }}
       # Background matrix entries are not generation-claimed by the durable queue.
       # They share the item group but only queue-backed exact work may cancel an owner.
       cancel-in-progress: false

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2859,11 +2859,11 @@ jobs:
     timeout-minutes: 75
     continue-on-error: true
     concurrency:
-      # GitHub accepts owner/repo in concurrency groups. Keep that canonical
-      # identity so lossy state-path slugs cannot collide across repositories.
-      group: clawsweeper-review-${{ matrix.repo }}-${{ matrix.item_number }}
-      # Background matrix entries are not generation-claimed by the durable queue.
-      # They share the item group but only queue-backed exact work may cancel an owner.
+      # Background entries are not generation-claimed. Keep their canonical
+      # per-item group separate because GitHub replaces a pending same-group job
+      # even when cancel-in-progress is false; background work must not displace
+      # a queue-backed exact generation before it claims its durable lease.
+      group: clawsweeper-background-review-${{ matrix.repo }}-${{ matrix.item_number }}
       cancel-in-progress: false
     permissions:
       actions: read

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1678,7 +1678,7 @@ jobs:
             --header "content-type: application/json" \
             --header "x-clawsweeper-exact-review-signature: $signature" \
             --data "$payload" \
-            "${QUEUE_URL%/}/internal/exact-review/mutation/acquire")"
+            "${QUEUE_URL%/}/internal/exact-review/mutation/acquire")" || status="000"
           if [ "$status" = "409" ]; then
             reason="$(jq -r '.error // "mutation_busy"' "$response_file")"
             echo "reason=$reason" >> "$GITHUB_OUTPUT"
@@ -1687,9 +1687,12 @@ jobs:
             exit 0
           fi
           if [ "$status" != "200" ]; then
-            cat "$response_file" >&2
+            echo "::warning::Mutation permit service returned HTTP $status; publication will retry."
+            cat "$response_file" >&2 || true
+            echo "reason=mutation_busy" >> "$GITHUB_OUTPUT"
+            echo "acquired=false" >> "$GITHUB_OUTPUT"
             rm -f "$response_file"
-            exit 1
+            exit 0
           fi
           rm -f "$response_file"
           echo "owner=$owner" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1357,9 +1357,6 @@ jobs:
     if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '' && github.event.client_payload.source_action == 'exact_review_artifact_publish' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    concurrency:
-      group: clawsweeper-mutation-${{ github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
-      cancel-in-progress: false
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -491,6 +491,9 @@ jobs:
                   `claim_generation=${responseProtocol >= 2 ? claimGeneration : ""}`,
                   `generation=${responseProtocol === 3 ? response.generation : ""}`,
                   `operation_id=${responseProtocol === 3 ? response.operation_id : ""}`,
+                  `queued_at=${String(dispatch.queue_claim?.queued_at || "")}`,
+                  `dispatched_at=${String(dispatch.queue_claim?.dispatched_at || "")}`,
+                  `claimed_at=${new Date().toISOString()}`,
                   `protocol_version=${responseProtocol}`,
                   `decision=${JSON.stringify(decision)}`,
                 ];
@@ -691,6 +694,33 @@ jobs:
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outcome == 'success' }}
         with:
           build-script: ${{ steps.live-item.outputs.proceed == 'true' && 'build:all' || 'build:repair' }}
+
+      - name: Start exact item review telemetry
+        id: exact-review-telemetry-start
+        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' }}
+        continue-on-error: true
+        env:
+          REVIEW_TELEMETRY_ACTION: start
+          REVIEW_TELEMETRY_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_TELEMETRY_REPO: ${{ steps.target.outputs.target_repo }}
+          REVIEW_TELEMETRY_ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          REVIEW_TELEMETRY_RUN_ID: ${{ github.run_id }}
+          REVIEW_TELEMETRY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          REVIEW_TELEMETRY_GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
+          REVIEW_TELEMETRY_OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
+          REVIEW_TELEMETRY_EXACT: "true"
+          REVIEW_TELEMETRY_SOURCE_EVENT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceEvent }}
+          REVIEW_TELEMETRY_SOURCE_ACTION: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction }}
+          REVIEW_TELEMETRY_QUEUED_AT: ${{ steps.claim-exact-review-queue.outputs.queued_at }}
+          REVIEW_TELEMETRY_DISPATCHED_AT: ${{ steps.claim-exact-review-queue.outputs.dispatched_at }}
+          REVIEW_TELEMETRY_CLAIMED_AT: ${{ steps.claim-exact-review-queue.outputs.claimed_at }}
+          REVIEW_TELEMETRY_LEASE_MS: "7200000"
+        run: |
+          review_started_at="$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')"
+          echo "review_started_at=$review_started_at" >> "$GITHUB_OUTPUT"
+          REVIEW_TELEMETRY_REVIEW_STARTED_AT="$review_started_at" \
+            node scripts/review-item-telemetry.mjs
 
       - name: React to target item review start
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
@@ -1003,6 +1033,28 @@ jobs:
             args=(--interrupt-open-attempts --reason workflow_failed)
           fi
           pnpm run --silent finalize-action-events -- "${args[@]}"
+
+      - name: Update exact item review telemetry
+        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.exact-review-telemetry-start.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          REVIEW_TELEMETRY_ACTION: heartbeat
+          REVIEW_TELEMETRY_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_TELEMETRY_REPO: ${{ steps.target.outputs.target_repo }}
+          REVIEW_TELEMETRY_ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          REVIEW_TELEMETRY_RUN_ID: ${{ github.run_id }}
+          REVIEW_TELEMETRY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          REVIEW_TELEMETRY_GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
+          REVIEW_TELEMETRY_OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
+          REVIEW_TELEMETRY_EXACT: "true"
+          REVIEW_TELEMETRY_SOURCE_EVENT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceEvent }}
+          REVIEW_TELEMETRY_SOURCE_ACTION: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction }}
+          REVIEW_TELEMETRY_REVIEW_STARTED_AT: ${{ steps.exact-review-telemetry-start.outputs.review_started_at }}
+          REVIEW_TELEMETRY_LEASE_MS: "7200000"
+        run: |
+          REVIEW_TELEMETRY_REVIEW_COMPLETED_AT="$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')" \
+            node scripts/review-item-telemetry.mjs
 
       - name: Create exact review artifact bundle
         id: create-exact-review-bundle
@@ -1446,6 +1498,7 @@ jobs:
                   publisher_claim_generation: claimGeneration,
                   publisher_generation: response.generation ?? "",
                   publisher_operation_id: response.operation_id ?? "",
+                  publication_started_at: new Date().toISOString(),
                 };
                 fs.appendFileSync(process.env.GITHUB_OUTPUT, "claimed=true\n");
                 for (const [key, value] of Object.entries(values)) {
@@ -2120,6 +2173,42 @@ jobs:
             echo "failure_kind=$FAILURE_KIND" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Complete exact item review telemetry
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' }}
+        continue-on-error: true
+        env:
+          REVIEW_TELEMETRY_ACTION: terminal
+          REVIEW_TELEMETRY_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_TELEMETRY_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          REVIEW_TELEMETRY_ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          REVIEW_TELEMETRY_RUN_ID: ${{ steps.publication-context.outputs.producer_run_id }}
+          REVIEW_TELEMETRY_RUN_ATTEMPT: ${{ steps.publication-context.outputs.generation_attempt }}
+          REVIEW_TELEMETRY_GENERATION: ${{ steps.publication-context.outputs.generation }}
+          REVIEW_TELEMETRY_OPERATION_ID: ${{ steps.publication-context.outputs.operation_id }}
+          REVIEW_TELEMETRY_EXACT: "true"
+          REVIEW_TELEMETRY_SOURCE_EVENT: ${{ fromJSON(steps.publication-context.outputs.decision).sourceEvent }}
+          REVIEW_TELEMETRY_SOURCE_ACTION: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction }}
+          REVIEW_TELEMETRY_PUBLICATION_STARTED_AT: ${{ steps.publication-context.outputs.publication_started_at }}
+        run: |
+          result="${{ steps.exact-review-publication-result.outputs.outcome || 'failure' }}"
+          completion_kind="${{ steps.exact-review-publication-result.outputs.completion_kind || 'permanent_failure' }}"
+          reason="${{ steps.exact-review-publication-result.outputs.reason_code || 'unknown_failure' }}"
+          if [ "$completion_kind" = "superseded" ]; then
+            export REVIEW_TELEMETRY_OUTCOME=superseded
+            export REVIEW_TELEMETRY_TERMINAL_REASON=generation_superseded
+          elif [ "$result" = "success" ]; then
+            export REVIEW_TELEMETRY_OUTCOME=succeeded
+            export REVIEW_TELEMETRY_TERMINAL_REASON="$reason"
+          elif [ "$result" = "cancelled" ]; then
+            export REVIEW_TELEMETRY_OUTCOME=cancelled
+            export REVIEW_TELEMETRY_TERMINAL_REASON=workflow_cancelled
+          else
+            export REVIEW_TELEMETRY_OUTCOME=failed
+            export REVIEW_TELEMETRY_TERMINAL_REASON="$reason"
+          fi
+          node scripts/review-item-telemetry.mjs
+
       - name: Release generation-bound mutation permit
         if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.mutation-permit.outputs.acquired == 'true' && steps.publication-context.outputs.protocol_version == '3' }}
         env:
@@ -2769,7 +2858,9 @@ jobs:
     steps:
       - name: Mark item job start
         id: item-job-start
-        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+          echo "started_at=$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v7
         with:
@@ -2886,6 +2977,30 @@ jobs:
           echo "compute_started_at_ms=$compute_started_at_ms" >> "$GITHUB_OUTPUT"
           echo "item_job_setup_ms=$((compute_started_at_ms - JOB_STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
 
+      - name: Start matrix item review telemetry
+        id: matrix-review-telemetry-start
+        continue-on-error: true
+        env:
+          REVIEW_TELEMETRY_ACTION: start
+          REVIEW_TELEMETRY_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_TELEMETRY_REPO: ${{ matrix.repo }}
+          REVIEW_TELEMETRY_ITEM_NUMBER: ${{ matrix.item_number }}
+          REVIEW_TELEMETRY_RUN_ID: ${{ github.run_id }}
+          REVIEW_TELEMETRY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          REVIEW_TELEMETRY_GENERATION: ${{ matrix.generation }}
+          REVIEW_TELEMETRY_OPERATION_ID: matrix-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.item_number }}
+          REVIEW_TELEMETRY_EXACT: ${{ (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') && 'true' || 'false' }}
+          REVIEW_TELEMETRY_HOT_INTAKE: ${{ needs.plan.outputs.hot_intake }}
+          REVIEW_TELEMETRY_SOURCE_EVENT: ${{ github.event.client_payload.source_event || github.event_name }}
+          REVIEW_TELEMETRY_SOURCE_ACTION: ${{ github.event.client_payload.source_action || github.event.action || '' }}
+          REVIEW_TELEMETRY_QUEUED_AT: ${{ steps.item-job-start.outputs.started_at }}
+          REVIEW_TELEMETRY_CLAIMED_AT: ${{ steps.shard-start.outputs.started_at }}
+          REVIEW_TELEMETRY_REVIEW_STARTED_AT: ${{ steps.shard-start.outputs.started_at }}
+          REVIEW_TELEMETRY_LEASE_MS: "4500000"
+        working-directory: clawsweeper
+        run: node scripts/review-item-telemetry.mjs
+
       - name: Review item
         id: review-shard
         continue-on-error: true
@@ -2987,6 +3102,30 @@ jobs:
           fi
           node dist/clawsweeper.js finalize-action-events "${args[@]}"
 
+      - name: Update matrix item review telemetry
+        if: ${{ always() && steps.matrix-review-telemetry-start.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          REVIEW_TELEMETRY_ACTION: heartbeat
+          REVIEW_TELEMETRY_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_TELEMETRY_REPO: ${{ matrix.repo }}
+          REVIEW_TELEMETRY_ITEM_NUMBER: ${{ matrix.item_number }}
+          REVIEW_TELEMETRY_RUN_ID: ${{ github.run_id }}
+          REVIEW_TELEMETRY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          REVIEW_TELEMETRY_GENERATION: ${{ matrix.generation }}
+          REVIEW_TELEMETRY_OPERATION_ID: matrix-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.item_number }}
+          REVIEW_TELEMETRY_EXACT: ${{ (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') && 'true' || 'false' }}
+          REVIEW_TELEMETRY_HOT_INTAKE: ${{ needs.plan.outputs.hot_intake }}
+          REVIEW_TELEMETRY_SOURCE_EVENT: ${{ github.event.client_payload.source_event || github.event_name }}
+          REVIEW_TELEMETRY_SOURCE_ACTION: ${{ github.event.client_payload.source_action || github.event.action || '' }}
+          REVIEW_TELEMETRY_REVIEW_STARTED_AT: ${{ steps.shard-start.outputs.started_at }}
+          REVIEW_TELEMETRY_LEASE_MS: "4500000"
+        working-directory: clawsweeper
+        run: |
+          REVIEW_TELEMETRY_REVIEW_COMPLETED_AT="$(date -u '+%Y-%m-%dT%H:%M:%S.%3NZ')" \
+            node scripts/review-item-telemetry.mjs
+
       - name: Record item metrics
         if: always()
         env:
@@ -3025,6 +3164,7 @@ jobs:
               kind: $kind,
               source_revision: $source_revision,
               generation: ($generation | tonumber),
+              operation_id: ("matrix-${{ github.run_id }}-${{ github.run_attempt }}-" + $item_numbers),
               item_job_setup_ms: $item_job_setup_ms,
               runner_duration_ms: $runner_duration_ms,
               codex_cancel_latency_ms: $codex_cancel_latency_ms,
@@ -3374,6 +3514,46 @@ jobs:
             --message "chore: update sweep status" \
             --path "results/sweep-status/${target_slug}.json" \
             --rebase-strategy theirs
+
+      - name: Complete matrix item review telemetry
+        if: ${{ always() && steps.download-review-metrics.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          REVIEW_TELEMETRY_ACTION: terminal
+          REVIEW_TELEMETRY_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_TELEMETRY_RUN_ID: ${{ github.run_id }}
+          REVIEW_TELEMETRY_RUN_ATTEMPT: ${{ github.run_attempt }}
+          REVIEW_TELEMETRY_EXACT: ${{ (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') && 'true' || 'false' }}
+          REVIEW_TELEMETRY_HOT_INTAKE: ${{ needs.plan.outputs.hot_intake }}
+          REVIEW_TELEMETRY_SOURCE_EVENT: ${{ github.event.client_payload.source_event || github.event_name }}
+          REVIEW_TELEMETRY_SOURCE_ACTION: ${{ github.event.client_payload.source_action || github.event.action || '' }}
+          RECORDS_PUBLISHED: ${{ steps.commit-review-records.outputs.records_published || 'false' }}
+          ARTIFACTS_APPLIED: ${{ steps.apply-review-artifacts.outputs.artifacts_applied || 'false' }}
+        run: |
+          shopt -s nullglob
+          for metric in review-metrics/*.json; do
+            export REVIEW_TELEMETRY_REPO="$(jq -r '.target_repo' "$metric")"
+            export REVIEW_TELEMETRY_ITEM_NUMBER="$(jq -r '.item_number' "$metric")"
+            export REVIEW_TELEMETRY_GENERATION="$(jq -r '.generation' "$metric")"
+            export REVIEW_TELEMETRY_OPERATION_ID="$(jq -r '.operation_id' "$metric")"
+            export REVIEW_TELEMETRY_PUBLICATION_STARTED_AT="$(jq -r '.completed_at' "$metric")"
+            review_outcome="$(jq -r '.review_outcome' "$metric")"
+            if [ "$review_outcome" = "success" ] && [ "$RECORDS_PUBLISHED" = "true" ] && [ "$ARTIFACTS_APPLIED" = "true" ]; then
+              export REVIEW_TELEMETRY_OUTCOME=succeeded
+              export REVIEW_TELEMETRY_TERMINAL_REASON=publication_applied
+            elif [ "$review_outcome" = "cancelled" ]; then
+              export REVIEW_TELEMETRY_OUTCOME=cancelled
+              export REVIEW_TELEMETRY_TERMINAL_REASON=workflow_cancelled
+            elif [ "$review_outcome" != "success" ]; then
+              export REVIEW_TELEMETRY_OUTCOME=failed
+              export REVIEW_TELEMETRY_TERMINAL_REASON=review_failed
+            else
+              export REVIEW_TELEMETRY_OUTCOME=failed
+              export REVIEW_TELEMETRY_TERMINAL_REASON=publication_failed
+            fi
+            node scripts/review-item-telemetry.mjs
+          done
 
       - name: Dispatch reproducible bug implementation candidates
         if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && needs.plan.outputs.target_repo == 'openclaw/openclaw' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_REPRO_BUGS == '1' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2193,6 +2193,7 @@ jobs:
           REVIEW_TELEMETRY_SOURCE_EVENT: ${{ fromJSON(steps.publication-context.outputs.decision).sourceEvent }}
           REVIEW_TELEMETRY_SOURCE_ACTION: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction }}
           REVIEW_TELEMETRY_PUBLICATION_STARTED_AT: ${{ steps.publication-context.outputs.publication_started_at }}
+          REVIEW_TELEMETRY_LEASE_MS: "7200000"
         run: |
           result="${{ steps.exact-review-publication-result.outputs.outcome || 'failure' }}"
           completion_kind="${{ steps.exact-review-publication-result.outputs.completion_kind || 'permanent_failure' }}"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2194,7 +2194,13 @@ jobs:
           result="${{ steps.exact-review-publication-result.outputs.outcome || 'failure' }}"
           completion_kind="${{ steps.exact-review-publication-result.outputs.completion_kind || 'permanent_failure' }}"
           reason="${{ steps.exact-review-publication-result.outputs.reason_code || 'unknown_failure' }}"
-          if [ "$completion_kind" = "superseded" ]; then
+          if [ "$completion_kind" = "retryable_failure" ]; then
+            # The durable publication queue will retry this same review attempt.
+            # Keep its first terminal slot open for the eventual immutable result.
+            export REVIEW_TELEMETRY_ACTION=heartbeat
+            node scripts/review-item-telemetry.mjs
+            exit 0
+          elif [ "$completion_kind" = "superseded" ]; then
             export REVIEW_TELEMETRY_OUTCOME=superseded
             export REVIEW_TELEMETRY_TERMINAL_REASON=generation_superseded
           elif [ "$result" = "success" ]; then

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2227,13 +2227,24 @@ jobs:
             --arg owner "$OWNER" \
             '{item_key:$item_key,generation:$generation,operation_id:$operation_id,owner:$owner,purpose:"review"}')"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          response_file="$RUNNER_TEMP/exact-review-mutation-release.json"
+          trap 'rm -f "$response_file"' EXIT
           for attempt in 1 2 3; do
-            if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            http_status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
               --request POST \
               --header "content-type: application/json" \
               --header "x-clawsweeper-exact-review-signature: $signature" \
               --data "$payload" \
-              "${QUEUE_URL%/}/internal/exact-review/mutation/release" >/dev/null; then
+              "${QUEUE_URL%/}/internal/exact-review/mutation/release")" || http_status="000"
+            if [[ "$http_status" == 2* ]]; then
+              exit 0
+            fi
+            # This step runs only after the same workflow acquired the tuple. A
+            # missing tuple on retry means the first response was lost or terminal
+            # reconciliation already performed the requested release.
+            if [ "$http_status" = "409" ] && [ "$(jq -r '.error // empty' "$response_file" 2>/dev/null)" = "mutation_not_owned" ]; then
               exit 0
             fi
             [ "$attempt" -eq 3 ] || sleep "$((attempt * 5))"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -137,7 +137,7 @@ on:
         required: false
         default: "20"
       batch_size:
-        description: "Items per worker job"
+        description: "Maximum items selected by the planner"
         required: false
         default: "3"
       codex_timeout_ms:
@@ -145,7 +145,7 @@ on:
         required: false
         default: "1200000"
       shard_count:
-        description: "Parallel shards (capped by config/automation-limits.json)"
+        description: "Parallel item jobs (capped by config/automation-limits.json)"
         required: false
         default: "89"
       item_number:
@@ -212,7 +212,7 @@ env:
   CLAWSWEEPER_MODEL: internal
 
 concurrency:
-  group: ${{ (github.event_name == 'schedule' && (github.event.schedule == '4/15 * * * *' || github.event.schedule == '41 * * * *' || github.event.schedule == '37 */6 * * *')) && format('clawsweeper-target-fanout-{0}', github.event.schedule || github.run_id) || github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.queue_lease_id || github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', (github.event_name == 'schedule' && github.event.schedule == '13 * * * *') && 'clawsweeper-failed-review-retry' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && format('clawsweeper-comment-sync-{0}', github.run_id) || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && 'clawsweeper-comment-sync' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') && format('clawsweeper-apply-{0}', github.run_id) || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *')) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-{0}', github.event.inputs.item_number || github.event.inputs.item_numbers) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'clawsweeper-intake-v2' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || 'clawsweeper-review', github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
+  group: ${{ (github.event_name == 'schedule' && (github.event.schedule == '4/15 * * * *' || github.event.schedule == '41 * * * *' || github.event.schedule == '37 */6 * * *')) && format('clawsweeper-target-fanout-{0}', github.event.schedule || github.run_id) || github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.queue_lease_id || github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', (github.event_name == 'schedule' && github.event.schedule == '13 * * * *') && 'clawsweeper-failed-review-retry' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && format('clawsweeper-comment-sync-{0}', github.run_id) || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && 'clawsweeper-comment-sync' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') && format('clawsweeper-apply-{0}', github.run_id) || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *')) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-run-{0}', github.run_id) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'clawsweeper-intake-v2' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || 'clawsweeper-review', github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
   cancel-in-progress: false
 
 jobs:
@@ -312,8 +312,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: clawsweeper-event-review-${{ github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || github.run_id }}
-      cancel-in-progress: false
+      group: clawsweeper-review-${{ github.event.client_payload.repo_slug || github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
+      cancel-in-progress: true
     permissions:
       actions: write
       checks: read
@@ -329,6 +329,8 @@ jobs:
           ITEM_KEY: ${{ github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_LEASE_REVISION: ${{ github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision }}
+          QUEUE_GENERATION: ${{ github.event.client_payload.queue_claim.generation || '' }}
+          QUEUE_OPERATION_ID: ${{ github.event.client_payload.queue_claim.operation_id || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
@@ -343,12 +345,17 @@ jobs:
             const rawLeaseRevision = String(process.env.QUEUE_LEASE_REVISION || "").trim();
             const hasTuple = Boolean(itemKey || rawLeaseRevision);
             const leaseRevision = Number(rawLeaseRevision);
+            const generation = Number(process.env.QUEUE_GENERATION);
+            const operationId = String(process.env.QUEUE_OPERATION_ID || "").trim();
             if (hasTuple && (!itemKey || !Number.isInteger(leaseRevision) || leaseRevision < 1)) {
               process.exit(1);
             }
+            const hasGeneration = Boolean(process.env.QUEUE_GENERATION || operationId);
+            if (hasGeneration && (!Number.isInteger(generation) || generation < 1 || !operationId)) process.exit(1);
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
               ...(hasTuple ? { item_key: itemKey, lease_revision: leaseRevision } : {}),
+              ...(hasGeneration ? { generation, operation_id: operationId } : {}),
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
             }));
@@ -397,8 +404,10 @@ jobs:
                 const dispatch = JSON.parse(process.env.DISPATCH_PAYLOAD || "{}");
                 const requestedItemKey = String(process.env.ITEM_KEY || "").trim();
                 const requestedLeaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
+                const requestedGeneration = Number(process.env.QUEUE_GENERATION);
+                const requestedOperationId = String(process.env.QUEUE_OPERATION_ID || "");
                 const responseProtocol = Number(response.protocol_version || 1);
-                if (responseProtocol !== 1 && responseProtocol !== 2) process.exit(1);
+                if (responseProtocol !== 1 && responseProtocol !== 2 && responseProtocol !== 3) process.exit(1);
                 if (response.claimed !== true) process.exit(1);
 
                 const reviewOptions =
@@ -437,7 +446,7 @@ jobs:
                 const itemNumber = Number(decision?.itemNumber);
                 const itemKey = `${targetRepo}#${itemNumber}`;
                 const leaseRevision =
-                  responseProtocol === 2
+                  responseProtocol >= 2
                     ? Number(response.lease_revision)
                     : Number(
                         response.revision ||
@@ -459,7 +468,7 @@ jobs:
                 if (response.item_key && response.item_key !== itemKey) process.exit(1);
                 if (requestedItemKey && requestedItemKey !== itemKey) process.exit(1);
                 if (
-                  responseProtocol === 2 &&
+                  responseProtocol >= 2 &&
                   (!response.decision ||
                     typeof response.decision !== "object" ||
                     response.item_key !== requestedItemKey ||
@@ -469,12 +478,19 @@ jobs:
                 ) {
                   process.exit(1);
                 }
+                if (
+                  responseProtocol === 3 &&
+                  (response.generation !== requestedGeneration ||
+                    response.operation_id !== requestedOperationId)
+                ) process.exit(1);
                 const output = [
                   "claimed=true",
                   `lease_id=${process.env.QUEUE_LEASE_ID}`,
                   `item_key=${itemKey}`,
                   `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
-                  `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
+                  `claim_generation=${responseProtocol >= 2 ? claimGeneration : ""}`,
+                  `generation=${responseProtocol === 3 ? response.generation : ""}`,
+                  `operation_id=${responseProtocol === 3 ? response.operation_id : ""}`,
                   `protocol_version=${responseProtocol}`,
                   `decision=${JSON.stringify(decision)}`,
                 ];
@@ -785,6 +801,11 @@ jobs:
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
           CODEX_TIMEOUT_MS: ${{ steps.target.outputs.codex_timeout_ms }}
           MEDIA_PROOF_TIMEOUT_MS: ${{ steps.target.outputs.media_proof_timeout_ms }}
+          CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_REQUIRE_MUTATION_PERMIT: "1"
+          EXACT_REVIEW_GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
+          EXACT_REVIEW_OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -849,6 +870,8 @@ jobs:
           EXACT_REVIEW_ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
           EXACT_REVIEW_LEASE_ID: ${{ steps.claim-exact-review-queue.outputs.lease_id }}
           EXACT_REVIEW_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
+          EXACT_REVIEW_GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
+          EXACT_REVIEW_OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           REVIEW_LEASE_OWNER: ${{ steps.reserve-exact-review-lease.outputs.owner }}
           REVIEW_LEASE_COMMENT_ID: ${{ steps.reserve-exact-review-lease.outputs.comment_id }}
@@ -877,12 +900,15 @@ jobs:
             # claim/complete), so this Codex-adjacent step never sees the webhook secret.
             heartbeat_payload="$(node -e '
               const leaseRevision = Number(process.env.EXACT_REVIEW_LEASE_REVISION);
+              const generation = Number(process.env.EXACT_REVIEW_GENERATION);
+              const operationId = String(process.env.EXACT_REVIEW_OPERATION_ID || "");
               if (!process.env.EXACT_REVIEW_ITEM_KEY || !process.env.EXACT_REVIEW_LEASE_ID) process.exit(1);
               if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
               process.stdout.write(JSON.stringify({
                 item_key: process.env.EXACT_REVIEW_ITEM_KEY,
                 lease_id: process.env.EXACT_REVIEW_LEASE_ID,
                 lease_revision: leaseRevision,
+                ...(operationId ? { generation, operation_id: operationId } : {}),
                 run_id: process.env.GITHUB_RUN_ID,
               }));
             ')" || return 0
@@ -987,6 +1013,7 @@ jobs:
           EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
           EXACT_REVIEW_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
           EXACT_REVIEW_GENERATION_ATTEMPT: ${{ github.run_attempt }}
+          EXACT_REVIEW_GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
           EXACT_REVIEW_ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
           EXACT_REVIEW_ITEM_KIND: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).itemKind }}
           EXACT_REVIEW_ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
@@ -995,6 +1022,7 @@ jobs:
           EXACT_REVIEW_LIVE_PROCEEDED: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'false' || steps.live-item.outputs.proceed }}
           EXACT_REVIEW_LIVE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
           EXACT_REVIEW_LIVE_TERMINAL_NOOP: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'true' || steps.live-item.outputs.terminal_noop }}
+          EXACT_REVIEW_OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
           EXACT_REVIEW_PRODUCER_JOB: event-review-apply
           EXACT_REVIEW_PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
           EXACT_REVIEW_REPORT_PATH: artifacts/event/${{ steps.target.outputs.item_number }}.md
@@ -1028,8 +1056,10 @@ jobs:
           ARTIFACT_NAME: ${{ steps.create-exact-review-bundle.outputs.artifact_name }}
           CLAIM_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
           CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
+          GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
           ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
           LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
+          OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
           LIVE_GUARDED_OPEN: ${{ steps.live-item.outputs.guarded_open }}
           LIVE_PROCEEDED: ${{ steps.review-exact-event-item.outputs.terminal_during_review == 'true' && 'false' || steps.live-item.outputs.proceed }}
           LIVE_TERMINAL_MISSING: ${{ steps.live-item.outputs.terminal_missing }}
@@ -1047,6 +1077,8 @@ jobs:
           const protocolVersion = Number(process.env.PROTOCOL_VERSION);
           const leaseRevision = process.env.LEASE_REVISION ? Number(process.env.LEASE_REVISION) : null;
           const claimGeneration = process.env.CLAIM_GENERATION ? Number(process.env.CLAIM_GENERATION) : null;
+          const generation = process.env.GENERATION ? Number(process.env.GENERATION) : null;
+          const operationId = String(process.env.OPERATION_ID || "").trim();
           const flag = (name) => {
             const value = process.env[name];
             if (value === "true") return true;
@@ -1069,6 +1101,7 @@ jobs:
                 protocolVersion,
                 leaseRevision,
                 claimGeneration,
+                ...(protocolVersion === 3 ? { generation, operationId } : {}),
                 liveProceeded: flag("LIVE_PROCEEDED"),
                 liveTerminalNoop: flag("LIVE_TERMINAL_NOOP"),
                 liveTerminalMissing: flag("LIVE_TERMINAL_MISSING"),
@@ -1184,7 +1217,9 @@ jobs:
         env:
           PRIMARY_OUTCOME: ${{ steps.exact-review-generation-result.outputs.outcome || 'failure' }}
           CLAIM_GENERATION: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
+          GENERATION: ${{ steps.claim-exact-review-queue.outputs.generation }}
           ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
+          OPERATION_ID: ${{ steps.claim-exact-review-queue.outputs.operation_id }}
           PROTOCOL_VERSION: ${{ steps.claim-exact-review-queue.outputs.protocol_version }}
           QUEUE_LEASE_ID: ${{ steps.claim-exact-review-queue.outputs.lease_id }}
           QUEUE_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
@@ -1200,16 +1235,19 @@ jobs:
             const protocolVersion = Number(process.env.PROTOCOL_VERSION);
             const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
+            const generation = Number(process.env.GENERATION);
+            const operationId = String(process.env.OPERATION_ID || "");
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
-            if (protocolVersion !== 1 && protocolVersion !== 2) process.exit(1);
+            if (protocolVersion !== 1 && protocolVersion !== 2 && protocolVersion !== 3) process.exit(1);
             if (
-              protocolVersion === 2 &&
+              protocolVersion >= 2 &&
               (!process.env.ITEM_KEY ||
                 !Number.isInteger(leaseRevision) ||
                 leaseRevision < 1 ||
                 !Number.isInteger(claimGeneration) ||
                 claimGeneration < 1)
             ) process.exit(1);
+            if (protocolVersion === 3 && (!Number.isInteger(generation) || generation < 1 || !operationId)) process.exit(1);
             const primaryOutcome = String(process.env.PRIMARY_OUTCOME || "");
             const outcome = ["success", "cancelled", "failure"].includes(primaryOutcome)
               ? primaryOutcome
@@ -1217,13 +1255,14 @@ jobs:
             const retryAt = String(process.env.RETRY_AT || "").trim();
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
-              ...(protocolVersion === 2
+              ...(protocolVersion >= 2
                 ? {
                     item_key: process.env.ITEM_KEY,
                     lease_revision: leaseRevision,
                     claim_generation: claimGeneration,
                   }
                 : {}),
+              ...(protocolVersion === 3 ? { generation, operation_id: operationId } : {}),
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,
@@ -1266,6 +1305,9 @@ jobs:
     if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '' && github.event.client_payload.source_action == 'exact_review_artifact_publish' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: clawsweeper-mutation-${{ github.event.client_payload.repo_slug || github.event.client_payload.target_repo || 'unknown-repo' }}-${{ github.event.client_payload.item_number || github.run_id }}
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: write
@@ -1279,6 +1321,8 @@ jobs:
           ITEM_KEY: ${{ github.event.client_payload.queue_claim.item_key }}
           QUEUE_LEASE_ID: ${{ github.event.client_payload.queue_lease_id }}
           QUEUE_LEASE_REVISION: ${{ github.event.client_payload.queue_claim.lease_revision }}
+          QUEUE_GENERATION: ${{ github.event.client_payload.queue_claim.generation || '' }}
+          QUEUE_OPERATION_ID: ${{ github.event.client_payload.queue_claim.operation_id || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
@@ -1288,6 +1332,8 @@ jobs:
           payload="$(node -e '
             const leaseRevision = Number(process.env.QUEUE_LEASE_REVISION);
             const runAttempt = Number(process.env.RUN_ATTEMPT);
+            const generation = Number(process.env.QUEUE_GENERATION);
+            const operationId = String(process.env.QUEUE_OPERATION_ID || "");
             if (!process.env.QUEUE_LEASE_ID || !process.env.ITEM_KEY) process.exit(1);
             if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
@@ -1295,6 +1341,7 @@ jobs:
               lease_id: process.env.QUEUE_LEASE_ID,
               item_key: process.env.ITEM_KEY,
               lease_revision: leaseRevision,
+              ...(operationId ? { generation, operation_id: operationId } : {}),
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
             }));
@@ -1346,7 +1393,7 @@ jobs:
                 const expectedItemKey = `${decision?.targetRepo}#${decision?.itemNumber}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
                 if (
                   response.claimed !== true ||
-                  response.protocol_version !== 2 ||
+                  (response.protocol_version !== 2 && response.protocol_version !== 3) ||
                   response.item_key !== process.env.ITEM_KEY ||
                   response.item_key !== expectedItemKey ||
                   decision?.sourceAction !== "exact_review_artifact_publish" ||
@@ -1361,6 +1408,11 @@ jobs:
                 const claimGeneration = Number(response.claim_generation);
                 if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
                 if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
+                if (
+                  response.protocol_version === 3 &&
+                  (response.generation !== Number(process.env.QUEUE_GENERATION) ||
+                    response.operation_id !== process.env.QUEUE_OPERATION_ID)
+                ) process.exit(1);
                 const targetRepo = String(decision.targetRepo);
                 const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
                 const values = {
@@ -1373,6 +1425,8 @@ jobs:
                   protocol_version: publication.protocolVersion,
                   lease_revision: publication.leaseRevision ?? "",
                   claim_generation: publication.claimGeneration ?? "",
+                  generation: publication.generation ?? "",
+                  operation_id: publication.operationId ?? "",
                   target_repo: targetRepo,
                   target_repo_owner: targetRepoOwner,
                   target_repo_name: targetRepoName,
@@ -1390,6 +1444,8 @@ jobs:
                   publisher_item_key: response.item_key,
                   publisher_lease_revision: leaseRevision,
                   publisher_claim_generation: claimGeneration,
+                  publisher_generation: response.generation ?? "",
+                  publisher_operation_id: response.operation_id ?? "",
                 };
                 fs.appendFileSync(process.env.GITHUB_OUTPUT, "claimed=true\n");
                 for (const [key, value] of Object.entries(values)) {
@@ -1536,8 +1592,58 @@ jobs:
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 
-      - name: Publish event result and apply safe close
+      - name: Acquire generation-bound mutation permit
+        id: mutation-permit
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
+        env:
+          ITEM_KEY: ${{ steps.publication-context.outputs.item_key }}
+          GENERATION: ${{ steps.publication-context.outputs.generation }}
+          OPERATION_ID: ${{ steps.publication-context.outputs.publisher_operation_id }}
+          PROTOCOL_VERSION: ${{ steps.publication-context.outputs.protocol_version }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ "$PROTOCOL_VERSION" != "3" ]; then
+            echo "acquired=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
+          owner="github-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          payload="$(jq -cn \
+            --arg item_key "$ITEM_KEY" \
+            --argjson generation "$GENERATION" \
+            --arg operation_id "$OPERATION_ID" \
+            --arg owner "$owner" \
+            '{item_key:$item_key,generation:$generation,operation_id:$operation_id,owner:$owner,purpose:"review"}')"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          response_file="$(mktemp)"
+          status="$(curl --silent --show-error --connect-timeout 5 --max-time 20 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "x-clawsweeper-exact-review-signature: $signature" \
+            --data "$payload" \
+            "${QUEUE_URL%/}/internal/exact-review/mutation/acquire")"
+          if [ "$status" = "409" ]; then
+            reason="$(jq -r '.error // "mutation_busy"' "$response_file")"
+            echo "reason=$reason" >> "$GITHUB_OUTPUT"
+            echo "acquired=false" >> "$GITHUB_OUTPUT"
+            rm -f "$response_file"
+            exit 0
+          fi
+          if [ "$status" != "200" ]; then
+            cat "$response_file" >&2
+            rm -f "$response_file"
+            exit 1
+          fi
+          rm -f "$response_file"
+          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+          echo "acquired=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish event result and apply safe close
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' && steps.mutation-permit.outputs.acquired == 'true' }}
         id: publish-event-result
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -1934,6 +2040,8 @@ jobs:
           VALIDATE_OUTCOME: ${{ steps.validate-exact-review-bundle.outcome }}
           PUBLISH_COMPLETION_KIND: ${{ steps.publish-event-result.outputs.completion_kind }}
           PUBLISH_REASON_CODE: ${{ steps.publish-event-result.outputs.reason_code }}
+          MUTATION_ACQUIRED: ${{ steps.mutation-permit.outputs.acquired }}
+          MUTATION_REASON: ${{ steps.mutation-permit.outputs.reason }}
           ERROR_FINGERPRINT: ${{ steps.publish-event-result.outputs.error_fingerprint }}
           REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
         run: |
@@ -1941,7 +2049,15 @@ jobs:
           outcome=failure
           completion_kind=permanent_failure
           reason_code=unknown_failure
-          if [ "$PUBLISH_COMPLETION_KIND" = "superseded" ] && { [ "$PUBLISH_REASON_CODE" = "remote_newer_tuple" ] || [ "$PUBLISH_REASON_CODE" = "remote_closed" ]; }; then
+          if [ "$MUTATION_ACQUIRED" = "false" ] && [ "$MUTATION_REASON" = "generation_superseded" ]; then
+            outcome=success
+            completion_kind=superseded
+            reason_code=remote_newer_tuple
+          elif [ "$MUTATION_ACQUIRED" = "false" ] && [ "$MUTATION_REASON" = "mutation_busy" ]; then
+            outcome=failure
+            completion_kind=retryable_failure
+            reason_code=mutation_busy
+          elif [ "$PUBLISH_COMPLETION_KIND" = "superseded" ] && { [ "$PUBLISH_REASON_CODE" = "remote_newer_tuple" ] || [ "$PUBLISH_REASON_CODE" = "remote_closed" ]; }; then
             outcome=success
             completion_kind=superseded
             reason_code="$PUBLISH_REASON_CODE"
@@ -2004,14 +2120,48 @@ jobs:
             echo "failure_kind=$FAILURE_KIND" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Release generation-bound mutation permit
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.mutation-permit.outputs.acquired == 'true' && steps.publication-context.outputs.protocol_version == '3' }}
+        env:
+          ITEM_KEY: ${{ steps.publication-context.outputs.item_key }}
+          GENERATION: ${{ steps.publication-context.outputs.generation }}
+          OPERATION_ID: ${{ steps.publication-context.outputs.publisher_operation_id }}
+          OWNER: ${{ steps.mutation-permit.outputs.owner }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -cn \
+            --arg item_key "$ITEM_KEY" \
+            --argjson generation "$GENERATION" \
+            --arg operation_id "$OPERATION_ID" \
+            --arg owner "$OWNER" \
+            '{item_key:$item_key,generation:$generation,operation_id:$operation_id,owner:$owner,purpose:"review"}')"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          for attempt in 1 2 3; do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "${QUEUE_URL%/}/internal/exact-review/mutation/release" >/dev/null; then
+              exit 0
+            fi
+            [ "$attempt" -eq 3 ] || sleep "$((attempt * 5))"
+          done
+          exit 1
+
       - name: Complete durable exact review publication
         id: complete-exact-review-publication
         if: ${{ steps.publication-context.outputs.claimed == 'true' && always() }}
         continue-on-error: true
         env:
           CLAIM_GENERATION: ${{ steps.publication-context.outputs.publisher_claim_generation }}
+          GENERATION: ${{ steps.publication-context.outputs.publisher_generation }}
           ITEM_KEY: ${{ steps.publication-context.outputs.publisher_item_key }}
           LEASE_REVISION: ${{ steps.publication-context.outputs.publisher_lease_revision }}
+          OPERATION_ID: ${{ steps.publication-context.outputs.publisher_operation_id }}
+          PROTOCOL_VERSION: ${{ github.event.client_payload.queue_claim.protocol_version || '2' }}
           OUTCOME: ${{ steps.exact-review-publication-result.outputs.outcome || 'failure' }}
           FAILURE_KIND: ${{ steps.exact-review-publication-result.outputs.failure_kind }}
           COMPLETION_KIND: ${{ steps.exact-review-publication-result.outputs.completion_kind }}
@@ -2027,10 +2177,14 @@ jobs:
             const leaseRevision = Number(process.env.LEASE_REVISION);
             const claimGeneration = Number(process.env.CLAIM_GENERATION);
             const runAttempt = Number(process.env.RUN_ATTEMPT);
+            const protocolVersion = Number(process.env.PROTOCOL_VERSION);
+            const generation = Number(process.env.GENERATION);
+            const operationId = String(process.env.OPERATION_ID || "");
             if (!process.env.QUEUE_LEASE_ID || !process.env.ITEM_KEY) process.exit(1);
             if (!Number.isInteger(leaseRevision) || leaseRevision < 1) process.exit(1);
             if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
             if (!Number.isInteger(runAttempt) || runAttempt < 1) process.exit(1);
+            if (protocolVersion === 3 && (!Number.isInteger(generation) || generation < 1 || !operationId)) process.exit(1);
             const outcome = ["success", "failure", "cancelled"].includes(process.env.OUTCOME)
               ? process.env.OUTCOME
               : "failure";
@@ -2040,7 +2194,7 @@ jobs:
             const completionKind = ["published", "superseded", "deferred", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
               ? process.env.COMPLETION_KIND
               : undefined;
-            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
+            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "mutation_busy", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
               ? process.env.REASON_CODE
               : undefined;
             const errorFingerprint = /^[A-Za-z0-9:._-]{1,200}$/.test(process.env.ERROR_FINGERPRINT || "")
@@ -2052,6 +2206,7 @@ jobs:
               item_key: process.env.ITEM_KEY,
               lease_revision: leaseRevision,
               claim_generation: claimGeneration,
+              ...(protocolVersion === 3 ? { generation, operation_id: operationId } : {}),
               run_id: process.env.GITHUB_RUN_ID,
               run_attempt: runAttempt,
               outcome,
@@ -2319,10 +2474,10 @@ jobs:
               if [ "$status" = "in_progress" ]; then
                 jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
                 active_shards="$(printf '%s' "$jobs_json" \
-                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  | jq '[.jobs[]? | select(.name | startswith("Review item ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
                   || printf '0')"
                 total_shards="$(printf '%s' "$jobs_json" \
-                  | jq '[.jobs[]? | select(.name | startswith("Review shard "))] | length' 2>/dev/null \
+                  | jq '[.jobs[]? | select(.name | startswith("Review item "))] | length' 2>/dev/null \
                   || printf '0')"
               fi
               if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
@@ -2378,10 +2533,10 @@ jobs:
               if [ "$status" = "in_progress" ]; then
                 jobs_json="$(gh run view "$id" --repo "${{ github.repository }}" --json jobs 2>/dev/null || printf '{"jobs":[]}')"
                 active_shards="$(printf '%s' "$jobs_json" \
-                  | jq '[.jobs[]? | select(.name | startswith("Review shard ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
+                  | jq '[.jobs[]? | select(.name | startswith("Review item ")) | select(.status == "in_progress" or .status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested")] | length' 2>/dev/null \
                   || printf '0')"
                 total_shards="$(printf '%s' "$jobs_json" \
-                  | jq '[.jobs[]? | select(.name | startswith("Review shard "))] | length' 2>/dev/null \
+                  | jq '[.jobs[]? | select(.name | startswith("Review item "))] | length' 2>/dev/null \
                   || printf '0')"
               fi
               if ! [[ "$active_shards" =~ ^[0-9]+$ ]]; then
@@ -2589,11 +2744,16 @@ jobs:
             --rebase-strategy theirs || echo "::warning::Skipped slow in-progress dashboard publish so review shards can start."
 
   review:
-    name: Review shard ${{ matrix.shard }} · ${{ needs.plan.outputs.target_repo }}#${{ matrix.item_numbers }}
+    name: Review item ${{ matrix.shard }} · ${{ matrix.repo }}#${{ matrix.item_number }}
     needs: plan
     runs-on: ${{ vars.CLAWSWEEPER_REVIEW_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 75
     continue-on-error: true
+    concurrency:
+      group: clawsweeper-review-${{ matrix.repo_slug }}-${{ matrix.item_number }}
+      # Background matrix entries are not generation-claimed by the durable queue.
+      # They share the item group but only queue-backed exact work may cancel an owner.
+      cancel-in-progress: false
     permissions:
       actions: read
       checks: read
@@ -2603,9 +2763,14 @@ jobs:
       statuses: read
     strategy:
       fail-fast: false
+      max-parallel: ${{ fromJson(needs.plan.outputs.shard_count) }}
       matrix:
         include: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
+      - name: Mark item job start
+        id: item-job-start
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v7
         with:
           path: clawsweeper
@@ -2711,11 +2876,17 @@ jobs:
           fi
           git -C "$checkout_dir" rev-parse --short HEAD
 
-      - name: Mark shard start
+      - name: Mark item setup start
         id: shard-start
-        run: echo "started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+        env:
+          JOB_STARTED_AT_MS: ${{ steps.item-job-start.outputs.started_at_ms }}
+        run: |
+          compute_started_at_ms="$(date +%s%3N)"
+          echo "started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "compute_started_at_ms=$compute_started_at_ms" >> "$GITHUB_OUTPUT"
+          echo "item_job_setup_ms=$((compute_started_at_ms - JOB_STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
 
-      - name: Review shard
+      - name: Review item
         id: review-shard
         continue-on-error: true
         working-directory: clawsweeper
@@ -2743,34 +2914,57 @@ jobs:
             planned_automatic_review_arg=(--planned-automatic-review)
           fi
           codex_timeout_seconds=$(((${{ needs.plan.outputs.codex_timeout_ms }} + 999) / 1000))
-          review_timeout_seconds=$(((codex_timeout_seconds + 180) * ${{ needs.plan.outputs.batch_size }}))
+          review_timeout_seconds=$((codex_timeout_seconds + 180))
           if [ "$review_timeout_seconds" -lt 300 ]; then
             review_timeout_seconds=300
           fi
           if [ "$review_timeout_seconds" -gt 4200 ]; then
             review_timeout_seconds=4200
           fi
-          echo "::notice::Review shard timeout is ${review_timeout_seconds}s for batch size ${{ needs.plan.outputs.batch_size }} and per-item Codex timeout ${codex_timeout_seconds}s."
+          echo "::notice::Item review timeout is ${review_timeout_seconds}s for per-item Codex timeout ${codex_timeout_seconds}s."
+          cancellation_marker="../review-artifacts/metrics/cancel-${{ matrix.item_number }}.json"
+          mkdir -p "$(dirname "$cancellation_marker")"
+          review_pid=""
+          on_cancel() {
+            requested_at_ms="$(date +%s%3N)"
+            if [ -n "$review_pid" ]; then
+              kill -TERM "$review_pid" 2>/dev/null || true
+              wait "$review_pid" 2>/dev/null || true
+            fi
+            completed_at_ms="$(date +%s%3N)"
+            rm -rf "../review-artifacts/item-${{ matrix.item_number }}"
+            jq -n \
+              --argjson requested_at_ms "$requested_at_ms" \
+              --argjson completed_at_ms "$completed_at_ms" \
+              '{requested_at_ms:$requested_at_ms,completed_at_ms:$completed_at_ms,codex_cancel_latency_ms:($completed_at_ms-$requested_at_ms)}' \
+              > "$cancellation_marker"
+            exit 143
+          }
+          trap on_cancel TERM INT
           set +e
           timeout --kill-after=30s "${review_timeout_seconds}s" node dist/clawsweeper.js review \
             --target-repo "${{ needs.plan.outputs.target_repo }}" \
             --target-dir "../${{ needs.plan.outputs.target_checkout_dir }}" \
-            --artifact-dir ../review-artifacts/shard-${{ matrix.shard }} \
-            --batch-size ${{ needs.plan.outputs.batch_size }} \
+            --artifact-dir ../review-artifacts/item-${{ matrix.item_number }} \
+            --batch-size 1 \
             --max-pages ${{ needs.plan.outputs.max_pages }} \
             --codex-model internal \
             --codex-reasoning-effort high \
             --codex-sandbox read-only \
             --codex-timeout-ms ${{ needs.plan.outputs.codex_timeout_ms }} \
-            --item-numbers "${{ matrix.item_numbers }}" \
+            --item-numbers "${{ matrix.item_number }}" \
             "${planned_automatic_review_arg[@]}" \
             "${hot_intake_arg[@]}" \
             --readonly-openclaw \
-            --shard-index ${{ matrix.shard }} \
-            --shard-count ${{ needs.plan.outputs.planned_shards }} \
+            --shard-index 0 \
+            --shard-count 1 \
             "${additional_prompt_arg[@]}" \
-            "${expected_source_revision_arg[@]}"
+            "${expected_source_revision_arg[@]}" &
+          review_pid=$!
+          wait "$review_pid"
           review_exit_code=$?
+          review_pid=""
+          trap - TERM INT
           set -e
           echo "exit_code=$review_exit_code" >> "$GITHUB_OUTPUT"
           exit "$review_exit_code"
@@ -2793,16 +2987,24 @@ jobs:
           fi
           node dist/clawsweeper.js finalize-action-events "${args[@]}"
 
-      - name: Record shard metrics
+      - name: Record item metrics
         if: always()
         env:
-          ITEM_NUMBERS: ${{ matrix.item_numbers }}
+          ITEM_NUMBERS: ${{ matrix.item_number }}
           REVIEW_OUTCOME: ${{ steps.review-shard.outcome || 'not_started' }}
           STARTED_AT: ${{ steps.shard-start.outputs.started_at || '' }}
+          JOB_STARTED_AT_MS: ${{ steps.item-job-start.outputs.started_at_ms || '0' }}
+          ITEM_JOB_SETUP_MS: ${{ steps.shard-start.outputs.item_job_setup_ms || '0' }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
           set -euo pipefail
           mkdir -p review-artifacts/metrics
+          completed_at_ms="$(date +%s%3N)"
+          cancel_marker="review-artifacts/metrics/cancel-${{ matrix.item_number }}.json"
+          codex_cancel_latency_ms=null
+          if [ -f "$cancel_marker" ]; then
+            codex_cancel_latency_ms="$(jq -r '.codex_cancel_latency_ms' "$cancel_marker")"
+          fi
           jq -n \
             --arg shard "${{ matrix.shard }}" \
             --arg item_numbers "$ITEM_NUMBERS" \
@@ -2810,23 +3012,38 @@ jobs:
             --arg started_at "$STARTED_AT" \
             --arg completed_at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             --arg target_repo "$TARGET_REPO" \
+            --arg kind "${{ matrix.kind }}" \
+            --arg source_revision "${{ matrix.source_revision }}" \
+            --arg generation "${{ matrix.generation }}" \
+            --argjson item_job_setup_ms "$ITEM_JOB_SETUP_MS" \
+            --argjson runner_duration_ms "$((completed_at_ms - JOB_STARTED_AT_MS))" \
+            --argjson codex_cancel_latency_ms "$codex_cancel_latency_ms" \
             '{
               shard: ($shard | tonumber),
               item_numbers: $item_numbers,
+              item_number: ($item_numbers | tonumber),
+              kind: $kind,
+              source_revision: $source_revision,
+              generation: ($generation | tonumber),
+              item_job_setup_ms: $item_job_setup_ms,
+              runner_duration_ms: $runner_duration_ms,
+              codex_cancel_latency_ms: $codex_cancel_latency_ms,
+              cancelled_review_consumed_tokens: null,
+              avoided_tokens: null,
               review_outcome: $review_outcome,
               started_at: $started_at,
               completed_at: $completed_at,
               target_repo: $target_repo
             }' > review-artifacts/metrics/shard-${{ matrix.shard }}.json
 
-      - name: Record failed review shard
+      - name: Record failed item review
         if: ${{ failure() || steps.review-shard.outcome == 'failure' }}
         run: |
           mkdir -p review-artifacts/failed-shards
           cat > review-artifacts/failed-shards/shard-${{ matrix.shard }}.json <<JSON
           {
             "shard": ${{ matrix.shard }},
-            "item_numbers": "${{ matrix.item_numbers }}"
+            "item_numbers": "${{ matrix.item_number }}"
           }
           JSON
 
@@ -2835,8 +3052,8 @@ jobs:
         with:
           name: review-shard-${{ matrix.shard }}
           path: |
-            review-artifacts/shard-${{ matrix.shard }}/*.md
-            review-artifacts/shard-${{ matrix.shard }}/review-cache-metrics.json
+            review-artifacts/item-${{ matrix.item_number }}/*.md
+            review-artifacts/item-${{ matrix.item_number }}/review-cache-metrics.json
           if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v7
@@ -2865,7 +3082,7 @@ jobs:
         if: ${{ always() && github.event_name == 'repository_dispatch' && github.event.client_payload.expected_source_revision != '' }}
         with:
           name: review-source-revision-mismatch-${{ matrix.shard }}
-          path: review-artifacts/shard-${{ matrix.shard }}/source-revision-mismatch.json
+          path: review-artifacts/item-${{ matrix.item_number }}/source-revision-mismatch.json
           if-no-files-found: ignore
 
   requeue-source-revision-drift:
@@ -2943,6 +3160,10 @@ jobs:
       group: clawsweeper-target-review-publish-${{ needs.plan.outputs.target_repo }}
       cancel-in-progress: false
       queue: max
+    env:
+      CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+      CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+      CLAWSWEEPER_REQUIRE_MUTATION_PERMIT: "1"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -3559,9 +3780,9 @@ jobs:
             failed_shards="$(
               gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --json jobs --jq '
                 .jobs[]
-                | select((.conclusion == "failure" or .conclusion == "cancelled") and (.name | startswith("Review shard ")))
+                | select((.conclusion == "failure" or .conclusion == "cancelled") and (.name | startswith("Review item ")))
                 | .name
-                | sub("^Review shard ([0-9]+).*$"; "\\1")
+                | sub("^Review item ([0-9]+).*$"; "\\1")
               ' | paste -sd, -
             )"
           fi
@@ -3931,6 +4152,9 @@ jobs:
       issues: read
       pull-requests: read
     env:
+      CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+      CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+      CLAWSWEEPER_REQUIRE_MUTATION_PERMIT: "1"
       CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
       CLAWSWEEPER_UNSPONSORED_FEATURE_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNSPONSORED_FEATURE_CLOSE_ENABLED || 'false' }}
       CLAWSWEEPER_IDEA_REVIVAL_REACTIONS: ${{ vars.CLAWSWEEPER_IDEA_REVIVAL_REACTIONS || '5' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,10 @@ not split reports into issue/PR subtrees.
   closing only unchanged, high-confidence proposals.
 - Repository-specific rules live in `src/repository-profiles.ts`; ClawHub apply
   may close only PRs that are certainly implemented on `main`.
-- Worker concurrency is shard-level: each shard processes its selected items
-  sequentially. Maximum parallel Codex sessions equals `shard_count`, not
-  `batch_size * shard_count`.
+- Review compute is item-sharded: every matrix job handles exactly one item.
+  `batch_size` limits planner selection, `shard_count` maps to matrix
+  `max-parallel`, and the durable queue permit is the authoritative cross-run
+  Codex concurrency limit.
 - `openclaw/clawsweeper-state` is the live status surface and generated state
   store. Check current Actions and that repo before trusting local generated
   timestamps.

--- a/README.md
+++ b/README.md
@@ -380,10 +380,14 @@ scheduling, capacity, and monitoring behavior is documented in
 
 Review is proposal-only. It never closes items.
 
-- A planner scans open issues and PRs, then assigns exact item numbers to shards.
+- A planner scans open issues and PRs, then emits one matrix entry and one
+  cancellable compute job per item. `batch_size` limits planner selection;
+  `shard_count` controls matrix `max-parallel`.
 - Manual runs can pass `item_number` or comma-separated `item_numbers` to review
   exact Audit Health findings without scanning for a normal batch.
-- Each shard checks out the selected target repository at `main`.
+- Each item job checks out the selected target repository at `main`. Jobs for
+  different items have distinct concurrency groups; a newer generation cancels
+  only the older compute job for the same item.
 - Codex reviews with the internal model, high reasoning, the default service tier, and a
   10-minute per-item timeout.
 - Each item becomes a flat report under
@@ -777,7 +781,7 @@ ClawSweeper has one main capacity knob:
 This is a Codex worker budget, not a GitHub Actions runner limit. Deterministic
 exact-review publishers, comment routers, and lease reconcilers are
 control-plane workflows and do not consume these 128 slots.
-Lane limits are derived from that number: normal review defaults to 89 shards
+Lane limits are derived from that number: normal review defaults to 89 parallel item jobs
 for manual/backstop and scheduled runs, hot intake up to 44 shards, commit
 review 6 commits per page, and existing repair/issue implementation lanes use
 40% of `workers.max`, currently 51 live
@@ -785,8 +789,10 @@ workers. Imported gitcrawl cluster repair allows 2 live workers by default.
 Exact-item review, repair, and issue implementation are priority work; normal
 review, hot intake, and commit review are background work and automatically
 yield when priority work is active. Exact-item runs use a durable Worker queue
-that coalesces item deliveries, leases at most 64 concurrent reviews, and admits
-up to 60 active exact reviews per target repository. Other lanes retain the
+that coalesces item deliveries and is the authoritative admission layer across
+batch, webhook, and re-review workflow runs. It leases at most 64 concurrent reviews
+and admits up to 60 active exact reviews per target repository; matrix
+`max-parallel` only bounds one workflow run. Other lanes retain the
 checked-in 128-worker scheduling model.
 Use `workers.max` first when turning total Codex usage up or down; use
 `lanes.repair.cluster_max_live_runs` to tune the imported legacy cluster-repair

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1053,26 +1053,29 @@ export class ExactReviewQueue {
     if (request.method === "POST" && url.pathname === "/mutation/release") {
       const tuple = exactReviewMutationTuple(await request.json().catch(() => null));
       if (!tuple) return json({ error: "invalid_mutation_tuple" }, 400);
-      const released = Array.from(
-        this.storage.sql.exec(
-          `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
-            WHERE item_key = ? AND generation = ? AND operation_id = ? AND owner = ?
-              AND purpose = ?
-          RETURNING item_key`,
-          tuple.itemKey,
-          tuple.generation,
-          tuple.operationId,
-          tuple.owner,
-          tuple.purpose,
-        ),
-      ).length;
-      if (!released) return json({ error: "mutation_not_owned" }, 409);
       const now = Date.now();
-      const state = this.readStateSync();
-      if (resumeMutationBlockedReview(state, tuple.itemKey, now)) {
-        await this.writeState(state);
-        await this.scheduleNext(state, now);
-      }
+      const result = this.storage.transactionSync(() => {
+        const released = Array.from(
+          this.storage.sql.exec(
+            `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+              WHERE item_key = ? AND generation = ? AND operation_id = ? AND owner = ?
+                AND purpose = ?
+            RETURNING item_key`,
+            tuple.itemKey,
+            tuple.generation,
+            tuple.operationId,
+            tuple.owner,
+            tuple.purpose,
+          ),
+        ).length;
+        if (!released) return { released: false as const };
+        const state = this.readStateSync();
+        const resumed = this.resumeMutationBlockedReviewSync(state, tuple.itemKey, now);
+        if (resumed) this.writeStateSync(state);
+        return { released: true as const, resumed, state };
+      });
+      if (!result.released) return json({ error: "mutation_not_owned" }, 409);
+      if (result.resumed) await this.scheduleNext(result.state, now);
       return json({ ok: true, released: true });
     }
 
@@ -2710,6 +2713,24 @@ export class ExactReviewQueue {
     return Math.max(0, Number(row?.generation || 0));
   }
 
+  private resumeMutationBlockedReviewSync(
+    state: ExactReviewQueueState,
+    itemKey: string,
+    now: number,
+  ) {
+    const item = state.items[itemKey];
+    if (!item || item.state !== "parked" || item.parkedReason !== "mutation_active") return false;
+    // Intake deliberately leaves the mutation owner's generation current while
+    // its GitHub write is in flight. Advance the fence in the same transaction
+    // that releases that owner, before the retained revision can dispatch.
+    item.generation = this.reserveReviewGenerationSync(itemKey, true, now);
+    item.state = "pending";
+    item.parkedReason = undefined;
+    item.nextAttemptAt = now;
+    item.updatedAt = now;
+    return true;
+  }
+
   private reviewComputeActiveSync(itemKey: string) {
     const item = this.readStateSync().items[itemKey];
     return Boolean(item && item.state !== "parked");
@@ -2752,7 +2773,7 @@ export class ExactReviewQueue {
         item.operationId,
       ),
     ).length;
-    if (released && state) resumeMutationBlockedReview(state, itemKey, now);
+    if (released && state) this.resumeMutationBlockedReviewSync(state, itemKey, now);
   }
 
   private readStorageMetaSync() {
@@ -4379,16 +4400,6 @@ function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.operationId = undefined;
   item.dispatchedAt = undefined;
   item.claimedAt = undefined;
-}
-
-function resumeMutationBlockedReview(state: ExactReviewQueueState, itemKey: string, now: number) {
-  const item = state.items[itemKey];
-  if (!item || item.state !== "parked" || item.parkedReason !== "mutation_active") return false;
-  item.state = "pending";
-  item.parkedReason = undefined;
-  item.nextAttemptAt = now;
-  item.updatedAt = now;
-  return true;
 }
 
 export function exactReviewEffectiveLeaseExpiresAt(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -952,6 +952,24 @@ export class ExactReviewQueue {
         observedLease.purpose === "apply" &&
         (await exactReviewMutationOwnerTerminal(this.env, observedLease.owner));
       const result = this.storage.transactionSync(() => {
+        // The Actions owner lookup above yields the Durable Object. Revalidate
+        // both fences in this transaction so a newer enqueue cannot grant stale
+        // review publication or let apply overlap newly active review compute.
+        const transactionalGeneration = this.currentReviewGenerationSync(tuple.itemKey);
+        if (tuple.purpose === "review" && transactionalGeneration !== tuple.generation) {
+          return {
+            acquired: false as const,
+            error: "generation_superseded" as const,
+            currentGeneration: transactionalGeneration,
+          };
+        }
+        if (tuple.purpose === "apply" && this.reviewComputeActiveSync(tuple.itemKey)) {
+          return {
+            acquired: false as const,
+            error: "review_active" as const,
+            currentGeneration: transactionalGeneration,
+          };
+        }
         let existing = this.mutationLeaseSync(tuple.itemKey);
         if (existing) {
           if (
@@ -967,7 +985,9 @@ export class ExactReviewQueue {
               existing.operation_id === observedLease.operation_id &&
               existing.owner === observedLease.owner &&
               existing.purpose === observedLease.purpose;
-            if (!observedLeaseStillOwns) return { acquired: false as const, existing };
+            if (!observedLeaseStillOwns) {
+              return { acquired: false as const, error: "mutation_busy" as const, existing };
+            }
 
             // Mutation leases never expire by age: a slow GitHub write must retain
             // exclusivity. Recovery is safe only after GitHub confirms the exact
@@ -1007,6 +1027,9 @@ export class ExactReviewQueue {
         return { acquired: true as const, resumed: false as const };
       });
       if (!result.acquired) {
+        if (result.error !== "mutation_busy") {
+          return json({ error: result.error, current_generation: result.currentGeneration }, 409);
+        }
         return json(
           {
             error: "mutation_busy",

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -92,7 +92,7 @@ export type ExactReviewQueueItem = {
   operationId?: string;
   dispatchedAt?: number;
   claimedAt?: number;
-  parkedReason?: "dead_letter_capacity";
+  parkedReason?: "dead_letter_capacity" | "mutation_active";
   lastFailureReason?: ExactReviewPublicationReasonCode;
   firstFailureAt?: number;
   publicationFailureAttempts?: number;
@@ -380,17 +380,22 @@ export class ExactReviewQueue {
           return { superseded: true as const };
         }
         let current = state.items[key];
+        // A mutation permit serializes the current GitHub write with intake for
+        // this item. Retain the newer decision, but do not advance or dispatch a
+        // generation until the permit owner releases its atomic mutation window.
+        const mutationBlocked = !decision.publication && Boolean(this.mutationLeaseSync(key));
+        const supersedesInProgress = decision.supersedesInProgress && !mutationBlocked;
         const nextGeneration = decision.publication
           ? decision.publication.generation
           : this.reserveReviewGenerationSync(
               key,
-              Boolean(!current || decision.supersedesInProgress),
+              Boolean(!current || supersedesInProgress) && !mutationBlocked,
               now,
             );
         if (
           current &&
           !decision.publication &&
-          decision.supersedesInProgress &&
+          supersedesInProgress &&
           current.state === "dispatching" &&
           Boolean(current.generation && current.operationId)
         ) {
@@ -403,7 +408,7 @@ export class ExactReviewQueue {
         } else if (
           current &&
           !decision.publication &&
-          decision.supersedesInProgress &&
+          supersedesInProgress &&
           current.state === "leased" &&
           current.claimProtocolVersion === 3
         ) {
@@ -450,8 +455,8 @@ export class ExactReviewQueue {
                 )
               : exactReviewQueueEnqueueAttemptAt(state, now);
             if (mergeable) {
-              current.state = "pending";
-              current.parkedReason = undefined;
+              current.state = mutationBlocked ? "parked" : "pending";
+              current.parkedReason = mutationBlocked ? "mutation_active" : undefined;
               current.attempts = 0;
               current.publicationFailureAttempts = 0;
               current.firstFailureAt = undefined;
@@ -471,7 +476,8 @@ export class ExactReviewQueue {
           state.items[key] = {
             key,
             decision,
-            state: "pending",
+            state: mutationBlocked ? "parked" : "pending",
+            ...(mutationBlocked ? { parkedReason: "mutation_active" } : {}),
             revision: 1,
             ...(nextGeneration ? { generation: nextGeneration } : {}),
             createdAt: now,
@@ -864,7 +870,7 @@ export class ExactReviewQueue {
               parked: false,
               deadLetter: undefined,
             };
-      this.releaseMutationLeaseForQueueItemSync(item);
+      this.releaseMutationLeaseForQueueItemSync(item, state, now);
       const { requeued } = completionResult;
       // A successful workflow can still request requeue_latest after source
       // drift. That work did not leave its lane, so it must not improve the
@@ -1061,6 +1067,12 @@ export class ExactReviewQueue {
         ),
       ).length;
       if (!released) return json({ error: "mutation_not_owned" }, 409);
+      const now = Date.now();
+      const state = this.readStateSync();
+      if (resumeMutationBlockedReview(state, tuple.itemKey, now)) {
+        await this.writeState(state);
+        await this.scheduleNext(state, now);
+      }
       return json({ ok: true, released: true });
     }
 
@@ -1221,7 +1233,7 @@ export class ExactReviewQueue {
         );
         if (matches.length !== 1) continue;
         const item = matches[0];
-        this.releaseMutationLeaseForQueueItemSync(item);
+        this.releaseMutationLeaseForQueueItemSync(item, state, now);
         const didRequeue = finishExactReviewQueueItem(state, item, now, run.outcome);
         reconciled += 1;
         if (didRequeue) {
@@ -2722,16 +2734,25 @@ export class ExactReviewQueue {
       | undefined;
   }
 
-  private releaseMutationLeaseForQueueItemSync(item: ExactReviewQueueItem) {
+  private releaseMutationLeaseForQueueItemSync(
+    item: ExactReviewQueueItem,
+    state?: ExactReviewQueueState,
+    now = Date.now(),
+  ) {
     if (!item.leaseGeneration || !item.operationId) return;
-    const itemKey = item.decision.publication?.itemKey || item.key.replace(/@compute:.*$/, "");
-    this.storage.sql.exec(
-      `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+    const publication = item.decision.publication;
+    const itemKey = publication?.itemKey || item.key.replace(/@compute:.*$/, "");
+    const generation = publication?.generation || item.leaseGeneration;
+    const released = Array.from(
+      this.storage.sql.exec(
+        `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
         WHERE item_key = ? AND generation = ? AND operation_id = ? AND purpose = 'review'`,
-      itemKey,
-      item.leaseGeneration,
-      item.operationId,
-    );
+        itemKey,
+        generation,
+        item.operationId,
+      ),
+    ).length;
+    if (released && state) resumeMutationBlockedReview(state, itemKey, now);
   }
 
   private readStorageMetaSync() {
@@ -4358,6 +4379,16 @@ function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.operationId = undefined;
   item.dispatchedAt = undefined;
   item.claimedAt = undefined;
+}
+
+function resumeMutationBlockedReview(state: ExactReviewQueueState, itemKey: string, now: number) {
+  const item = state.items[itemKey];
+  if (!item || item.state !== "parked" || item.parkedReason !== "mutation_active") return false;
+  item.state = "pending";
+  item.parkedReason = undefined;
+  item.nextAttemptAt = now;
+  item.updatedAt = now;
+  return true;
 }
 
 export function exactReviewEffectiveLeaseExpiresAt(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -252,6 +252,7 @@ const DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS = 130 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS = 20 * 60 * 1000;
 const DEFAULT_EXACT_REVIEW_RETRY_MS = 30_000;
 const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
+const DEFAULT_EXACT_REVIEW_MUTATION_RECONCILE_MS = 60_000;
 const DEFAULT_EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = 45_000;
 const DEFAULT_EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = 3 * 60_000;
 const DEFAULT_EXACT_REVIEW_PENDING_SOFT_LIMIT = 300;
@@ -1380,6 +1381,7 @@ export class ExactReviewQueue {
       this.reconcileStoredReviewRunsSync(startedAt);
       this.syncLegacyCompatibilitySync(this.readStateSync());
     });
+    await this.reconcileTerminalApplyMutationOwners(startedAt);
     const snapshot = this.readStateSync();
     const reclaimedSnapshot = reclaimExpiredExactReviewLeases(
       snapshot,
@@ -2711,6 +2713,57 @@ export class ExactReviewQueue {
       ),
     )[0] as { generation?: number } | undefined;
     return Math.max(0, Number(row?.generation || 0));
+  }
+
+  private async reconcileTerminalApplyMutationOwners(now: number) {
+    const snapshot = this.readStateSync();
+    const candidates = Object.values(snapshot.items)
+      .filter((item) => item.state === "parked" && item.parkedReason === "mutation_active")
+      .flatMap((item) => {
+        const lease = this.mutationLeaseSync(item.key);
+        return lease?.purpose === "apply" ? [{ itemKey: item.key, ...lease }] : [];
+      })
+      .slice(0, EXACT_REVIEW_RECONCILE_CONCURRENCY);
+    if (!candidates.length) return 0;
+
+    const terminal = await Promise.all(
+      candidates.map(async (candidate) => ({
+        candidate,
+        terminal: await exactReviewMutationOwnerTerminal(this.env, candidate.owner),
+      })),
+    );
+    return this.storage.transactionSync(() => {
+      const state = this.readStateSync();
+      let resumed = 0;
+      for (const { candidate, terminal: ownerTerminal } of terminal) {
+        if (!ownerTerminal) continue;
+        const current = this.mutationLeaseSync(candidate.itemKey);
+        if (
+          !current ||
+          current.generation !== candidate.generation ||
+          current.operation_id !== candidate.operation_id ||
+          current.owner !== candidate.owner ||
+          current.purpose !== "apply"
+        ) {
+          continue;
+        }
+        // The Actions lookup yields the Durable Object. Delete only the exact
+        // owner observed before that lookup, then advance the retained revision
+        // before it becomes dispatchable.
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+            WHERE item_key = ? AND generation = ? AND operation_id = ? AND owner = ?
+              AND purpose = 'apply'`,
+          candidate.itemKey,
+          candidate.generation,
+          candidate.operation_id,
+          candidate.owner,
+        );
+        if (this.resumeMutationBlockedReviewSync(state, candidate.itemKey, now)) resumed += 1;
+      }
+      if (resumed) this.writeStateSync(state);
+      return resumed;
+    });
   }
 
   private resumeMutationBlockedReviewSync(
@@ -5123,6 +5176,11 @@ export function exactReviewQueueNextWakeAt(
     }
   }
   const times = items.flatMap((item) => {
+    if (item.state === "parked" && item.parkedReason === "mutation_active") {
+      // Apply permits have no TTL. Periodically prove their workflow owner
+      // terminal so a lost release response cannot strand retained intake.
+      return [now + DEFAULT_EXACT_REVIEW_MUTATION_RECONCILE_MS];
+    }
     if (item.state === "pending") {
       if (dispatcherPaused) return [dispatcherRetryAt];
       if (exactReviewQueueIsPublication(item)) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -426,10 +426,7 @@ export class ExactReviewQueue {
           // so can leave either ordinary work or another recovery as a stale follow-up revision.
           // Ordinary source events retain normal replacement behavior, including the
           // command-context merge for pending items.
-          if (
-            !ignoredRecovery &&
-            (decision.supersedesInProgress || Boolean(decision.publication))
-          ) {
+          if (!ignoredRecovery) {
             const mergeable = current.state === "pending" || current.state === "parked";
             current.decision = mergeable
               ? mergePendingExactReviewDecision(current.decision, decision)

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -54,9 +54,11 @@ export type ExactReviewPublication = {
   producerRunAttempt: number;
   sourceSha: string;
   itemKey: string;
-  protocolVersion: 1 | 2;
+  protocolVersion: 1 | 2 | 3;
   leaseRevision: number | null;
   claimGeneration: number | null;
+  generation?: number;
+  operationId?: string;
   liveProceeded: boolean;
   liveTerminalNoop: boolean;
   liveTerminalMissing: boolean;
@@ -72,6 +74,8 @@ export type ExactReviewQueueItem = {
   leaseDecision?: ExactReviewDecision;
   state: "pending" | "dispatching" | "leased" | "parked";
   revision: number;
+  generation?: number;
+  supersededByGeneration?: number;
   createdAt: number;
   updatedAt: number;
   nextAttemptAt: number;
@@ -83,7 +87,9 @@ export type ExactReviewQueueItem = {
   claimedRunId?: string;
   claimedRunAttempt?: number;
   claimGeneration?: number;
-  claimProtocolVersion?: 1 | 2;
+  claimProtocolVersion?: 1 | 2 | 3;
+  leaseGeneration?: number;
+  operationId?: string;
   dispatchedAt?: number;
   claimedAt?: number;
   parkedReason?: "dead_letter_capacity";
@@ -112,6 +118,7 @@ type ExactReviewPublicationReasonCode =
   | "artifact_expired"
   | "close_coverage_retry"
   | "close_coverage_deferred"
+  | "mutation_busy"
   | "invalid_artifact"
   | "missing_record_tuple"
   | "tuple_protocol_invalid"
@@ -188,7 +195,7 @@ type ExactReviewQueueStorageMeta = {
   shed_since_reset?: number;
 };
 type ExactReviewQueueMetricTotals = {
-  review: { enqueued: number; completed: number };
+  review: { enqueued: number; completed: number; generationSuperseded: number };
   publication: {
     enqueued: number;
     completed: number;
@@ -204,6 +211,7 @@ type ExactReviewQueueMetricDelta = {
   reviewCompleted?: number;
   reviewRetried?: number;
   reviewShed?: number;
+  reviewGenerationSuperseded?: number;
   publicationEnqueued?: number;
   publicationCompleted?: number;
   publicationPublished?: number;
@@ -282,6 +290,8 @@ const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
 const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
 const REVIEW_OBSERVABILITY_SCAN_LIMIT = 10_000;
+const EXACT_REVIEW_GENERATION_TABLE = "exact_review_generations";
+const EXACT_REVIEW_MUTATION_LEASE_TABLE = "exact_review_mutation_leases";
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT = 5_000;
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS = 5 * 60 * 1000;
@@ -352,6 +362,7 @@ export class ExactReviewQueue {
         }
 
         const state = this.readStateSync();
+        let supersededCompute = false;
         // A delayed or lost alarm must not let an expired one-shot recovery
         // suppress the next failed shard's recovery delivery.
         reclaimExpiredExactReviewLeases(
@@ -361,7 +372,52 @@ export class ExactReviewQueue {
           exactReviewHeartbeatGraceMs(this.env),
         );
         const key = exactReviewItemKey(decision);
-        const current = state.items[key];
+        if (
+          decision.publication?.generation &&
+          this.currentReviewGenerationSync(decision.publication.itemKey) !==
+            decision.publication.generation
+        ) {
+          return { superseded: true as const };
+        }
+        let current = state.items[key];
+        const nextGeneration = decision.publication
+          ? decision.publication.generation
+          : this.reserveReviewGenerationSync(
+              key,
+              Boolean(!current || decision.supersedesInProgress),
+              now,
+            );
+        if (
+          current &&
+          !decision.publication &&
+          decision.supersedesInProgress &&
+          current.state === "dispatching" &&
+          Boolean(current.generation && current.operationId)
+        ) {
+          // A dispatched-but-unclaimed compute has no process to preserve. Revoke
+          // the tuple so its late claim fails, then reuse the canonical slot for
+          // the newer generation.
+          clearExactReviewLease(current);
+          current.state = "pending";
+          supersededCompute = true;
+        } else if (
+          current &&
+          !decision.publication &&
+          decision.supersedesInProgress &&
+          current.state === "leased" &&
+          current.claimProtocolVersion === 3
+        ) {
+          // Keep the old tuple addressable until its cancelled workflow reports a
+          // terminal outcome. The canonical key is immediately available for the
+          // replacement generation, which is what triggers GitHub job cancellation.
+          const supersededKey = `${key}@compute:${current.generation || 1}:${current.claimGeneration || 1}`;
+          delete state.items[key];
+          current.key = supersededKey;
+          current.supersededByGeneration = nextGeneration;
+          state.items[supersededKey] = current;
+          current = undefined;
+          supersededCompute = true;
+        }
         if (current) {
           const ignoredRecovery =
             decision.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION;
@@ -370,12 +426,19 @@ export class ExactReviewQueue {
           // so can leave either ordinary work or another recovery as a stale follow-up revision.
           // Ordinary source events retain normal replacement behavior, including the
           // command-context merge for pending items.
-          if (!ignoredRecovery) {
+          if (
+            !ignoredRecovery &&
+            (decision.supersedesInProgress || Boolean(decision.publication))
+          ) {
             const mergeable = current.state === "pending" || current.state === "parked";
             current.decision = mergeable
               ? mergePendingExactReviewDecision(current.decision, decision)
               : decision;
             current.revision += 1;
+            // The active lease keeps its immutable generation in leaseGeneration.
+            // Advance the queue generation for the newer revision even during a
+            // v1/v2 lease so its eventual v3 requeue is not permanently fenced.
+            if (nextGeneration) current.generation = nextGeneration;
             current.updatedAt = now;
             // Immediacy must come from the merged decision: a pending explicit command
             // keeps its command marker through the merge, and a later plain webhook
@@ -413,6 +476,7 @@ export class ExactReviewQueue {
             decision,
             state: "pending",
             revision: 1,
+            ...(nextGeneration ? { generation: nextGeneration } : {}),
             createdAt: now,
             updatedAt: now,
             nextAttemptAt: exactReviewQueueDebouncedAttemptAt(state, decision, now, now, this.env),
@@ -420,10 +484,16 @@ export class ExactReviewQueue {
           };
         }
         this.writeStateSync(state);
+        if (supersededCompute) {
+          this.incrementQueueMetricsSync({ reviewGenerationSuperseded: 1 });
+        }
         return { deduped: false as const, key, state };
       });
       if (accepted.deduped) {
         return json({ ok: true, deduped: true, item_key: exactReviewItemKey(decision) }, 202);
+      }
+      if (accepted.superseded) {
+        return json({ error: "generation_superseded" }, 409);
       }
       if (accepted.shed) {
         return json({ ok: true, shed: true, reason: "backpressure" }, 202);
@@ -437,6 +507,8 @@ export class ExactReviewQueue {
       const leaseId = String(body.lease_id || "").trim();
       const itemKey = String(body.item_key || "").trim();
       const leaseRevision = Number(body.lease_revision);
+      const requestedGeneration = Number(body.generation);
+      const requestedOperationId = String(body.operation_id || "").trim();
       const runId = String(body.run_id || "").trim();
       if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
       if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
@@ -444,7 +516,16 @@ export class ExactReviewQueue {
       if (tupleClaim && (!itemKey || !Number.isInteger(leaseRevision) || leaseRevision < 1)) {
         return json({ error: "invalid_lease_revision" }, 400);
       }
-      const claimProtocolVersion: 1 | 2 = tupleClaim ? 2 : 1;
+      const generationClaim = body.generation !== undefined || body.operation_id !== undefined;
+      if (
+        generationClaim &&
+        (!Number.isSafeInteger(requestedGeneration) ||
+          requestedGeneration < 1 ||
+          !/^[A-Za-z0-9-]{20,100}$/.test(requestedOperationId))
+      ) {
+        return json({ error: "invalid_generation_claim" }, 400);
+      }
+      const claimProtocolVersion: 1 | 2 | 3 = generationClaim ? 3 : tupleClaim ? 2 : 1;
       const runAttempt = exactReviewRunAttempt(body.run_attempt);
       if (body.run_attempt !== undefined && runAttempt === null) {
         return json({ error: "invalid_run_attempt" }, 400);
@@ -452,7 +533,9 @@ export class ExactReviewQueue {
 
       const now = Date.now();
       const state = this.readStateSync();
-      const item = tupleClaim ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
+      const item = tupleClaim
+        ? exactReviewItemForTuple(state, itemKey, leaseId)
+        : exactReviewItemForLease(state, leaseId);
       if (
         item &&
         reclaimExpiredExactReviewLease(
@@ -472,6 +555,8 @@ export class ExactReviewQueue {
         !item ||
         item.leaseId !== leaseId ||
         (tupleClaim && item.leaseRevision !== leaseRevision) ||
+        (generationClaim && item.leaseGeneration !== requestedGeneration) ||
+        (generationClaim && item.operationId !== requestedOperationId) ||
         !isLiveExactReviewLease(
           item,
           now,
@@ -554,6 +639,8 @@ export class ExactReviewQueue {
       const itemKey = String(body.item_key || "").trim();
       const leaseId = String(body.lease_id || "").trim();
       const leaseRevision = Number(body.lease_revision);
+      const generation = Number(body.generation);
+      const operationId = String(body.operation_id || "").trim();
       const runId = String(body.run_id || "").trim();
       if (!itemKey || !leaseId || !runId) return json({ error: "missing_lease_tuple" }, 400);
       if (!Number.isInteger(leaseRevision) || leaseRevision < 1) {
@@ -562,13 +649,20 @@ export class ExactReviewQueue {
       if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
 
       const now = Date.now();
+      const generationHeartbeat = body.generation !== undefined || body.operation_id !== undefined;
+      if (
+        generationHeartbeat &&
+        (!Number.isSafeInteger(generation) || generation < 1 || !operationId)
+      ) {
+        return json({ error: "invalid_generation_tuple" }, 400);
+      }
       const state = this.readStateSync();
-      const item = state.items[itemKey];
+      const item = exactReviewItemForTuple(state, itemKey, leaseId);
       if (
         item &&
         reclaimExpiredExactReviewLease(
           state,
-          itemKey,
+          item.key,
           item,
           now,
           exactReviewPublicationDispatchLeaseMs(this.env),
@@ -584,6 +678,8 @@ export class ExactReviewQueue {
         item.state !== "leased" ||
         item.leaseId !== leaseId ||
         item.leaseRevision !== leaseRevision ||
+        (generationHeartbeat && item.leaseGeneration !== generation) ||
+        (generationHeartbeat && item.operationId !== operationId) ||
         item.claimedRunId !== runId ||
         !isLiveExactReviewLease(
           item,
@@ -607,6 +703,8 @@ export class ExactReviewQueue {
       const itemKey = String(body.item_key || "").trim();
       const leaseRevision = Number(body.lease_revision);
       const claimGeneration = Number(body.claim_generation);
+      const generation = Number(body.generation);
+      const operationId = String(body.operation_id || "").trim();
       const runId = String(body.run_id || "").trim();
       if (!leaseId || !runId) return json({ error: "missing_lease_or_run" }, 400);
       if (!/^\d+$/.test(runId)) return json({ error: "invalid_run_id" }, 400);
@@ -614,6 +712,7 @@ export class ExactReviewQueue {
         Boolean(itemKey) ||
         body.lease_revision !== undefined ||
         body.claim_generation !== undefined;
+      const generationCompletion = body.generation !== undefined || body.operation_id !== undefined;
       if (tupleCompletion) {
         if (!itemKey || !Number.isInteger(leaseRevision) || leaseRevision < 1) {
           return json({ error: "invalid_lease_revision" }, 400);
@@ -622,7 +721,17 @@ export class ExactReviewQueue {
           return json({ error: "invalid_claim_generation" }, 400);
         }
       }
-      const completionProtocolVersion: 1 | 2 = tupleCompletion ? 2 : 1;
+      if (
+        generationCompletion &&
+        (!Number.isSafeInteger(generation) || generation < 1 || !operationId)
+      ) {
+        return json({ error: "invalid_generation_tuple" }, 400);
+      }
+      const completionProtocolVersion: 1 | 2 | 3 = generationCompletion
+        ? 3
+        : tupleCompletion
+          ? 2
+          : 1;
       const runAttempt = exactReviewRunAttempt(body.run_attempt);
       if (body.run_attempt !== undefined && runAttempt === null) {
         return json({ error: "invalid_run_attempt" }, 400);
@@ -685,12 +794,16 @@ export class ExactReviewQueue {
         return json({ error: "invalid_retry_at" }, 400);
       }
       const state = this.readStateSync();
-      const item = tupleCompletion ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
+      const item = tupleCompletion
+        ? exactReviewItemForTuple(state, itemKey, leaseId)
+        : exactReviewItemForLease(state, leaseId);
       if (
         !item ||
         item.leaseId !== leaseId ||
         (tupleCompletion && item.leaseRevision !== leaseRevision) ||
         (tupleCompletion && exactReviewClaimGeneration(item.claimGeneration) !== claimGeneration) ||
+        (generationCompletion && item.leaseGeneration !== generation) ||
+        (generationCompletion && item.operationId !== operationId) ||
         item.claimedRunId !== runId
       ) {
         return json({ error: "lease_not_claimed" }, 409);
@@ -754,6 +867,7 @@ export class ExactReviewQueue {
               parked: false,
               deadLetter: undefined,
             };
+      this.releaseMutationLeaseForQueueItemSync(item);
       const { requeued } = completionResult;
       // A successful workflow can still request requeue_latest after source
       // drift. That work did not leave its lane, so it must not improve the
@@ -798,6 +912,136 @@ export class ExactReviewQueue {
       );
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
+    }
+
+    if (request.method === "POST" && url.pathname === "/generation/check") {
+      const tuple = exactReviewGenerationTuple(await request.json().catch(() => null));
+      if (!tuple) return json({ error: "invalid_generation_tuple" }, 400);
+      const currentGeneration = this.currentReviewGenerationSync(tuple.itemKey);
+      if (currentGeneration !== tuple.generation) {
+        return json(
+          {
+            error: "generation_superseded",
+            item_key: tuple.itemKey,
+            generation: tuple.generation,
+            current_generation: currentGeneration,
+          },
+          409,
+        );
+      }
+      return json({ ok: true, current: true, current_generation: currentGeneration });
+    }
+
+    if (request.method === "POST" && url.pathname === "/mutation/acquire") {
+      const tuple = exactReviewMutationTuple(await request.json().catch(() => null));
+      if (!tuple) return json({ error: "invalid_mutation_tuple" }, 400);
+      const currentGeneration = this.currentReviewGenerationSync(tuple.itemKey);
+      if (tuple.purpose === "review" && currentGeneration !== tuple.generation) {
+        return json({ error: "generation_superseded", current_generation: currentGeneration }, 409);
+      }
+      if (tuple.purpose === "apply" && this.reviewComputeActiveSync(tuple.itemKey)) {
+        return json({ error: "review_active", current_generation: currentGeneration }, 409);
+      }
+      const now = Date.now();
+      const observedLease = this.mutationLeaseSync(tuple.itemKey);
+      const observedLeaseConflicts =
+        observedLease &&
+        (observedLease.generation !== tuple.generation ||
+          observedLease.operation_id !== tuple.operationId ||
+          observedLease.owner !== tuple.owner ||
+          observedLease.purpose !== tuple.purpose);
+      const observedApplyOwnerTerminal =
+        observedLeaseConflicts &&
+        observedLease.purpose === "apply" &&
+        (await exactReviewMutationOwnerTerminal(this.env, observedLease.owner));
+      const result = this.storage.transactionSync(() => {
+        let existing = this.mutationLeaseSync(tuple.itemKey);
+        if (existing) {
+          if (
+            existing.generation !== tuple.generation ||
+            existing.operation_id !== tuple.operationId ||
+            existing.owner !== tuple.owner ||
+            existing.purpose !== tuple.purpose
+          ) {
+            const observedLeaseStillOwns =
+              observedApplyOwnerTerminal &&
+              observedLease &&
+              existing.generation === observedLease.generation &&
+              existing.operation_id === observedLease.operation_id &&
+              existing.owner === observedLease.owner &&
+              existing.purpose === observedLease.purpose;
+            if (!observedLeaseStillOwns) return { acquired: false as const, existing };
+
+            // Mutation leases never expire by age: a slow GitHub write must retain
+            // exclusivity. Recovery is safe only after GitHub confirms the exact
+            // workflow attempt encoded by the apply owner has reached terminal state.
+            this.storage.sql.exec(
+              `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+                WHERE item_key = ? AND generation = ? AND operation_id = ? AND owner = ?
+                  AND purpose = 'apply'`,
+              tuple.itemKey,
+              existing.generation,
+              existing.operation_id,
+              existing.owner,
+            );
+            existing = undefined;
+          }
+          if (existing)
+            this.storage.sql.exec(
+              `UPDATE ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+                SET heartbeat_at = ? WHERE item_key = ?`,
+              now,
+              tuple.itemKey,
+            );
+          if (existing) return { acquired: true as const, resumed: true as const };
+        }
+        this.storage.sql.exec(
+          `INSERT INTO ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+             (item_key, generation, operation_id, owner, purpose, acquired_at, heartbeat_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          tuple.itemKey,
+          tuple.generation,
+          tuple.operationId,
+          tuple.owner,
+          tuple.purpose,
+          now,
+          now,
+        );
+        return { acquired: true as const, resumed: false as const };
+      });
+      if (!result.acquired) {
+        return json(
+          {
+            error: "mutation_busy",
+            owner: result.existing.owner,
+            purpose: result.existing.purpose,
+            generation: result.existing.generation,
+            acquired_at: new Date(result.existing.acquired_at).toISOString(),
+          },
+          409,
+        );
+      }
+      return json({ ok: true, acquired: true, resumed: result.resumed });
+    }
+
+    if (request.method === "POST" && url.pathname === "/mutation/release") {
+      const tuple = exactReviewMutationTuple(await request.json().catch(() => null));
+      if (!tuple) return json({ error: "invalid_mutation_tuple" }, 400);
+      const released = Array.from(
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+            WHERE item_key = ? AND generation = ? AND operation_id = ? AND owner = ?
+              AND purpose = ?
+          RETURNING item_key`,
+          tuple.itemKey,
+          tuple.generation,
+          tuple.operationId,
+          tuple.owner,
+          tuple.purpose,
+        ),
+      ).length;
+      if (!released) return json({ error: "mutation_not_owned" }, 409);
+      return json({ ok: true, released: true });
     }
 
     if (request.method === "POST" && url.pathname === "/claimed-runs") {
@@ -957,6 +1201,7 @@ export class ExactReviewQueue {
         );
         if (matches.length !== 1) continue;
         const item = matches[0];
+        this.releaseMutationLeaseForQueueItemSync(item);
         const didRequeue = finishExactReviewQueueItem(state, item, now, run.outcome);
         reconciled += 1;
         if (didRequeue) {
@@ -1055,6 +1300,7 @@ export class ExactReviewQueue {
             ...stats.lanes.review,
             enqueued_total: metrics.review.enqueued,
             completed_total: metrics.review.completed,
+            generation_superseded_total: metrics.review.generationSuperseded,
             flow: reviewFlow,
           },
           publication: {
@@ -1206,6 +1452,8 @@ export class ExactReviewQueue {
       item.state = "dispatching";
       item.leaseId = crypto.randomUUID();
       item.leaseRevision = item.revision;
+      item.leaseGeneration = item.generation;
+      item.operationId = item.generation ? crypto.randomUUID() : undefined;
       item.leaseDecision = { ...item.decision };
       item.leaseExpiresAt =
         now +
@@ -1234,6 +1482,8 @@ export class ExactReviewQueue {
           itemKey: item.key,
           leaseId: item.leaseId,
           leaseRevision: item.leaseRevision,
+          generation: item.leaseGeneration,
+          operationId: item.operationId,
         });
       } catch {
         failures.push({ key: item.key, leaseId: String(item.leaseId || "") });
@@ -2181,6 +2431,7 @@ export class ExactReviewQueue {
     for (const column of [
       "review_enqueued_total",
       "review_completed_total",
+      "review_generation_superseded_total",
       "publication_enqueued_total",
       "publication_published_total",
       "publication_superseded_total",
@@ -2353,6 +2604,105 @@ export class ExactReviewQueue {
       `CREATE INDEX IF NOT EXISTS exact_review_run_telemetry_aggregate
          ON ${EXACT_REVIEW_RUN_TELEMETRY_TABLE}
          (trigger_lane, target_repo, completed_at, workflow_outcome)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_GENERATION_TABLE} (
+         item_key TEXT PRIMARY KEY,
+         generation INTEGER NOT NULL CHECK (generation >= 1),
+         updated_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_MUTATION_LEASE_TABLE} (
+         item_key TEXT PRIMARY KEY,
+         generation INTEGER NOT NULL CHECK (generation >= 1),
+         operation_id TEXT NOT NULL,
+         owner TEXT NOT NULL,
+         purpose TEXT NOT NULL DEFAULT 'review' CHECK (purpose IN ('review', 'apply')),
+         acquired_at INTEGER NOT NULL,
+         heartbeat_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    const hasMutationPurpose = Array.from(
+      this.storage.sql.exec(
+        `SELECT name FROM pragma_table_info('${EXACT_REVIEW_MUTATION_LEASE_TABLE}')
+          WHERE name = 'purpose'`,
+      ),
+    ).length;
+    if (!hasMutationPurpose) {
+      this.storage.sql.exec(
+        `ALTER TABLE ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+           ADD COLUMN purpose TEXT NOT NULL DEFAULT 'review'
+             CHECK (purpose IN ('review', 'apply'))`,
+      );
+    }
+  }
+
+  private reserveReviewGenerationSync(itemKey: string, advance: boolean, now: number) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT generation FROM ${EXACT_REVIEW_GENERATION_TABLE} WHERE item_key = ?`,
+        itemKey,
+      ),
+    )[0] as { generation?: number } | undefined;
+    const current = Math.max(0, Number(row?.generation || 0));
+    const generation = current === 0 ? 1 : advance ? current + 1 : current;
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_GENERATION_TABLE} (item_key, generation, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(item_key) DO UPDATE SET
+         generation = excluded.generation,
+         updated_at = excluded.updated_at`,
+      itemKey,
+      generation,
+      now,
+    );
+    return generation;
+  }
+
+  private currentReviewGenerationSync(itemKey: string) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT generation FROM ${EXACT_REVIEW_GENERATION_TABLE} WHERE item_key = ?`,
+        itemKey,
+      ),
+    )[0] as { generation?: number } | undefined;
+    return Math.max(0, Number(row?.generation || 0));
+  }
+
+  private reviewComputeActiveSync(itemKey: string) {
+    const item = this.readStateSync().items[itemKey];
+    return Boolean(item && item.state !== "parked");
+  }
+
+  private mutationLeaseSync(itemKey: string) {
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT generation, operation_id, owner, purpose, acquired_at, heartbeat_at
+           FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE} WHERE item_key = ?`,
+        itemKey,
+      ),
+    )[0] as
+      | {
+          generation: number;
+          operation_id: string;
+          owner: string;
+          purpose: "review" | "apply";
+          acquired_at: number;
+          heartbeat_at: number;
+        }
+      | undefined;
+  }
+
+  private releaseMutationLeaseForQueueItemSync(item: ExactReviewQueueItem) {
+    if (!item.leaseGeneration || !item.operationId) return;
+    const itemKey = item.decision.publication?.itemKey || item.key.replace(/@compute:.*$/, "");
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
+        WHERE item_key = ? AND generation = ? AND operation_id = ? AND purpose = 'review'`,
+      itemKey,
+      item.leaseGeneration,
+      item.operationId,
     );
   }
 
@@ -2640,6 +2990,7 @@ export class ExactReviewQueue {
     const row = Array.from(
       this.storage.sql.exec(
         `SELECT review_enqueued_total, review_completed_total,
+                review_generation_superseded_total,
                 publication_enqueued_total, publication_completed_total,
                 publication_published_total, publication_superseded_total,
                 publication_retried_total, publication_dead_lettered_total,
@@ -2651,6 +3002,7 @@ export class ExactReviewQueue {
       | {
           review_enqueued_total?: number;
           review_completed_total?: number;
+          review_generation_superseded_total?: number;
           publication_enqueued_total?: number;
           publication_completed_total?: number;
           publication_published_total?: number;
@@ -2664,6 +3016,7 @@ export class ExactReviewQueue {
       review: {
         enqueued: exactReviewMetricTotal(row?.review_enqueued_total),
         completed: exactReviewMetricTotal(row?.review_completed_total),
+        generationSuperseded: exactReviewMetricTotal(row?.review_generation_superseded_total),
       },
       publication: {
         enqueued: exactReviewMetricTotal(row?.publication_enqueued_total),
@@ -2682,6 +3035,7 @@ export class ExactReviewQueue {
     const reviewCompleted = exactReviewMetricDelta(delta.reviewCompleted);
     const reviewRetried = exactReviewMetricDelta(delta.reviewRetried);
     const reviewShed = exactReviewMetricDelta(delta.reviewShed);
+    const reviewGenerationSuperseded = exactReviewMetricDelta(delta.reviewGenerationSuperseded);
     const publicationEnqueued = exactReviewMetricDelta(delta.publicationEnqueued);
     const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
     const publicationPublished = exactReviewMetricDelta(delta.publicationPublished);
@@ -2694,6 +3048,7 @@ export class ExactReviewQueue {
       !reviewCompleted &&
       !reviewRetried &&
       !reviewShed &&
+      !reviewGenerationSuperseded &&
       !publicationEnqueued &&
       !publicationCompleted &&
       !publicationPublished &&
@@ -2708,6 +3063,7 @@ export class ExactReviewQueue {
       `UPDATE ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
           SET review_enqueued_total = review_enqueued_total + ?,
               review_completed_total = review_completed_total + ?,
+              review_generation_superseded_total = review_generation_superseded_total + ?,
               publication_enqueued_total = publication_enqueued_total + ?,
               publication_completed_total = publication_completed_total + ?,
               publication_published_total = publication_published_total + ?,
@@ -2718,6 +3074,7 @@ export class ExactReviewQueue {
         WHERE singleton_id = 1`,
       reviewEnqueued,
       reviewCompleted,
+      reviewGenerationSuperseded,
       publicationEnqueued,
       publicationCompleted,
       publicationPublished,
@@ -3337,6 +3694,8 @@ function exactReviewPublicationFrom(value): ExactReviewPublication | null {
     publication.leaseRevision === null ? null : Number(publication.leaseRevision);
   const claimGeneration =
     publication.claimGeneration === null ? null : Number(publication.claimGeneration);
+  const generation = Number(publication.generation);
+  const operationId = String(publication.operationId || "").trim();
   const producerDecision = exactReviewBaseDecisionFrom(publication.producerDecision);
   const liveProceeded = publication.liveProceeded;
   const liveTerminalNoop = publication.liveTerminalNoop;
@@ -3348,7 +3707,7 @@ function exactReviewPublicationFrom(value): ExactReviewPublication | null {
   if (artifactName !== `exact-review-${producerRunId}-${producerRunAttempt}`) return null;
   if (!/^[0-9a-f]{40}$/.test(sourceSha)) return null;
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey)) return null;
-  if (protocolVersion !== 1 && protocolVersion !== 2) return null;
+  if (protocolVersion !== 1 && protocolVersion !== 2 && protocolVersion !== 3) return null;
   if (
     (leaseRevision !== null && (!Number.isSafeInteger(leaseRevision) || leaseRevision < 1)) ||
     (claimGeneration !== null && (!Number.isSafeInteger(claimGeneration) || claimGeneration < 1))
@@ -3356,6 +3715,16 @@ function exactReviewPublicationFrom(value): ExactReviewPublication | null {
     return null;
   }
   if (protocolVersion === 2 && (leaseRevision === null || claimGeneration === null)) return null;
+  if (
+    protocolVersion === 3 &&
+    (leaseRevision === null ||
+      claimGeneration === null ||
+      !Number.isSafeInteger(generation) ||
+      generation < 1 ||
+      !/^[A-Za-z0-9-]{20,100}$/.test(operationId))
+  ) {
+    return null;
+  }
   if (!producerDecision) return null;
   const liveOutcomes = [liveProceeded, liveTerminalNoop, liveTerminalMissing, liveGuardedOpen];
   if (liveOutcomes.some((outcome) => typeof outcome !== "boolean")) return null;
@@ -3369,6 +3738,7 @@ function exactReviewPublicationFrom(value): ExactReviewPublication | null {
     protocolVersion,
     leaseRevision,
     claimGeneration,
+    ...(protocolVersion === 3 ? { generation, operationId } : {}),
     liveProceeded,
     liveTerminalNoop,
     liveTerminalMissing,
@@ -3410,9 +3780,16 @@ function exactReviewItemForLease(state: ExactReviewQueueState, leaseId: string) 
   return Object.values(state.items).find((item) => item.leaseId === leaseId) || null;
 }
 
+function exactReviewItemForTuple(state: ExactReviewQueueState, itemKey: string, leaseId: string) {
+  const direct = state.items[itemKey];
+  if (direct?.leaseId === leaseId) return direct;
+  const superseded = exactReviewItemForLease(state, leaseId);
+  return superseded?.key.startsWith(`${itemKey}@compute:`) ? superseded : null;
+}
+
 function exactReviewClaimResponse(
   item: ExactReviewQueueItem,
-  protocolVersion: 1 | 2,
+  protocolVersion: 1 | 2 | 3,
   claimGeneration: number,
 ) {
   return {
@@ -3423,6 +3800,9 @@ function exactReviewClaimResponse(
     ...(protocolVersion === 1 ? { revision: item.leaseRevision } : {}),
     lease_revision: item.leaseRevision,
     claim_generation: claimGeneration,
+    ...(protocolVersion === 3
+      ? { generation: item.leaseGeneration, operation_id: item.operationId }
+      : {}),
     decision: item.leaseDecision,
   };
 }
@@ -3471,6 +3851,7 @@ function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCo
     "artifact_expired",
     "close_coverage_retry",
     "close_coverage_deferred",
+    "mutation_busy",
     "invalid_artifact",
     "missing_record_tuple",
     "tuple_protocol_invalid",
@@ -3501,6 +3882,7 @@ function exactReviewPublicationCompletion(
       "github_transient",
       "workflow_cancelled",
       "artifact_unavailable",
+      "mutation_busy",
       "unknown_failure",
     ]),
     // Accept the pre-deployment tuple while an old publisher can still finish.
@@ -3902,7 +4284,9 @@ function finishExactReviewQueueItem(
   // the queue, so only a newer source revision may supersede that recovery.
   const oneShotRecovery =
     item.leaseDecision?.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION;
-  const requeued = (!oneShotRecovery && retryingFailure) || hasNewerRevision || requeueLatest;
+  const requeued =
+    !item.supersededByGeneration &&
+    ((!oneShotRecovery && retryingFailure) || hasNewerRevision || requeueLatest);
   if (requeued) {
     clearExactReviewLease(item);
     item.state = "pending";
@@ -3942,6 +4326,8 @@ function clearExactReviewLease(item: ExactReviewQueueItem) {
   item.claimedRunAttempt = undefined;
   item.claimGeneration = undefined;
   item.claimProtocolVersion = undefined;
+  item.leaseGeneration = undefined;
+  item.operationId = undefined;
   item.dispatchedAt = undefined;
   item.claimedAt = undefined;
 }
@@ -4562,6 +4948,7 @@ function exactReviewQueueLaneStats(
     parked: parkedItems.length,
     capacity,
     active,
+    permit_utilization: Number.isFinite(capacity) && capacity > 0 ? active / capacity : 0,
     available_slots: Math.max(0, capacity - active),
     oldest_pending_at: oldestPendingAt === null ? null : new Date(oldestPendingAt).toISOString(),
     oldest_pending_age_seconds:
@@ -5130,6 +5517,28 @@ export async function exactReviewActionsReadToken(env) {
   return exactReviewRepositoryToken(env, { actions: "read" });
 }
 
+export async function exactReviewMutationOwnerTerminal(env, owner: string) {
+  const match = /^github-run-(\d+)-([1-9]\d*)(?:-\d+)?$/.exec(owner);
+  if (!match) return false;
+  const [, runId, runAttemptText] = match;
+  const runAttempt = Number(runAttemptText);
+  try {
+    const token = await exactReviewActionsReadToken(env);
+    return Boolean(
+      await exactReviewTerminalRun(token, {
+        runId,
+        runAttempt,
+        requestedRunAttempt: runAttempt,
+        claimGeneration: 1,
+      }),
+    );
+  } catch {
+    // Unavailable credentials or Actions reads must fail closed. The existing
+    // mutation keeps ownership until a later request can prove its attempt terminal.
+    return false;
+  }
+}
+
 async function exactReviewRepositoryToken(env, permissions) {
   const credentials = githubAppCredentials(env);
   if (!credentials) throw new Error("github app is not configured");
@@ -5290,12 +5699,16 @@ async function dispatchClawsweeperItem({
   itemKey,
   leaseId,
   leaseRevision,
+  generation,
+  operationId,
 }: {
   token: string;
   decision: ExactReviewDecision;
   itemKey: string;
   leaseId: string;
   leaseRevision: number;
+  generation?: number;
+  operationId?: string;
 }) {
   // Keep the v1 fields during the rolling-upgrade window. Old workflows consume
   // this immutable dispatch snapshot, while v2 workflows ignore it after claim
@@ -5321,10 +5734,12 @@ async function dispatchClawsweeperItem({
       client_payload: {
         queue_lease_id: leaseId,
         queue_claim: {
-          protocol_version: 2,
+          protocol_version: generation && operationId ? 3 : 2,
           item_key: itemKey,
           lease_revision: leaseRevision,
+          ...(generation && operationId ? { generation, operation_id: operationId } : {}),
         },
+        repo_slug: decision.targetRepo.replace(/[^A-Za-z0-9_.-]+/g, "-"),
         target_repo: decision.targetRepo,
         target_branch: decision.targetBranch,
         item_number: decision.itemNumber,
@@ -5368,6 +5783,40 @@ async function githubTokenJson({ token, path, method = "GET", body, errorLabel }
 
 function objectValue(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function exactReviewGenerationTuple(value: unknown) {
+  const body = objectValue(value);
+  const itemKey = String(body.item_key || "").trim();
+  const generation = Number(body.generation);
+  if (
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
+    !Number.isSafeInteger(generation) ||
+    generation < 1
+  ) {
+    return null;
+  }
+  return { itemKey, generation };
+}
+
+function exactReviewMutationTuple(value: unknown) {
+  const body = objectValue(value);
+  const itemKey = String(body.item_key || "").trim();
+  const purpose = body.purpose === "apply" ? "apply" : body.purpose === "review" ? "review" : null;
+  const generation = Number(body.generation);
+  const operationId = String(body.operation_id || "").trim();
+  const owner = String(body.owner || "").trim();
+  if (
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
+    !purpose ||
+    !Number.isSafeInteger(generation) ||
+    generation < 1 ||
+    !/^[A-Za-z0-9:._-]{8,200}$/.test(operationId) ||
+    !/^[A-Za-z0-9:._-]{3,200}$/.test(owner)
+  ) {
+    return null;
+  }
+  return { itemKey, generation, operationId, owner, purpose };
 }
 
 function repoName(repo) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1019,6 +1019,12 @@ export class ExactReviewQueue {
             );
           if (existing) return { acquired: true as const, resumed: true as const };
         }
+        if (tuple.purpose === "apply") {
+          // Apply starts a newer GitHub mutation epoch. Advance the fence before
+          // granting ownership so a queued publication from the preceding review
+          // cannot acquire its review permit after apply completes.
+          this.reserveReviewGenerationSync(tuple.itemKey, true, now);
+        }
         this.storage.sql.exec(
           `INSERT INTO ${EXACT_REVIEW_MUTATION_LEASE_TABLE}
              (item_key, generation, operation_id, owner, purpose, acquired_at, heartbeat_at)

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1484,6 +1484,8 @@ export class ExactReviewQueue {
           leaseRevision: item.leaseRevision,
           generation: item.leaseGeneration,
           operationId: item.operationId,
+          queuedAt: item.createdAt,
+          dispatchedAt: item.dispatchedAt ?? now,
         });
       } catch {
         failures.push({ key: item.key, leaseId: String(item.leaseId || "") });
@@ -1975,7 +1977,11 @@ export class ExactReviewQueue {
         ? attributableJob.conclusion === "success"
           ? "succeeded"
           : attributableJob.conclusion === "cancelled"
-            ? "cancelled"
+            ? record.generation !== undefined &&
+              this.currentReviewGenerationSync(`${record.repo}#${record.item_number}`) >
+                record.generation
+              ? "superseded"
+              : "cancelled"
             : "interrupted"
         : null;
       // A workflow terminal proves wave health, not which unattributed matrix
@@ -1991,9 +1997,11 @@ export class ExactReviewQueue {
         terminal_reason:
           outcome === "succeeded"
             ? "workflow_job_succeeded"
-            : outcome === "cancelled"
-              ? "workflow_cancelled"
-              : "workflow_terminal",
+            : outcome === "superseded"
+              ? "generation_superseded"
+              : outcome === "cancelled"
+                ? "workflow_cancelled"
+                : "workflow_terminal",
       };
       this.recordReviewTelemetrySync(terminal);
     }
@@ -5701,6 +5709,8 @@ async function dispatchClawsweeperItem({
   leaseRevision,
   generation,
   operationId,
+  queuedAt,
+  dispatchedAt,
 }: {
   token: string;
   decision: ExactReviewDecision;
@@ -5709,6 +5719,8 @@ async function dispatchClawsweeperItem({
   leaseRevision: number;
   generation?: number;
   operationId?: string;
+  queuedAt: number;
+  dispatchedAt: number;
 }) {
   // Keep the v1 fields during the rolling-upgrade window. Old workflows consume
   // this immutable dispatch snapshot, while v2 workflows ignore it after claim
@@ -5738,6 +5750,8 @@ async function dispatchClawsweeperItem({
           item_key: itemKey,
           lease_revision: leaseRevision,
           ...(generation && operationId ? { generation, operation_id: operationId } : {}),
+          queued_at: new Date(queuedAt).toISOString(),
+          dispatched_at: new Date(dispatchedAt).toISOString(),
         },
         repo_slug: decision.targetRepo.replace(/[^A-Za-z0-9_.-]+/g, "-"),
         target_repo: decision.targetRepo,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -507,6 +507,12 @@ export default {
       return exactReviewQueueRequest(env, "/heartbeat", request);
     if (url.pathname === "/internal/exact-review/complete" && request.method === "POST")
       return exactReviewQueueRequest(env, "/complete", request);
+    if (url.pathname === "/internal/exact-review/generation/check" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/generation/check");
+    if (url.pathname === "/internal/exact-review/mutation/acquire" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/mutation/acquire");
+    if (url.pathname === "/internal/exact-review/mutation/release" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/mutation/release");
     if (url.pathname === "/internal/exact-review/claimed-runs" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/claimed-runs");
     if (url.pathname === "/internal/exact-review/dead-letters/list" && request.method === "POST")

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -27,10 +27,16 @@ Each synced comment includes the durable identity marker:
 ClawSweeper edits that comment in place instead of posting repeated comments.
 Report front matter stores the synced comment id, URL, hash, and sync time.
 
-When review starts and no ClawSweeper-owned comment exists yet, the review
-shard posts a short status placeholder with the same durable identity marker.
-The placeholder is intentionally light and crustacean-friendly, then the final
-review sync edits that exact comment in place.
+The review shard uses a separate transient status comment as its coordination
+lease. When a durable review already exists, acquiring that lease also edits
+the durable comment to show that a fresh review is in progress, marks the old
+review stale, and collapses it as previous context. The status projection has
+no active verdict or action markers, so downstream automation cannot act on the
+displaced review. A matching apply run replaces the projection with the new
+completed review; an abandoned or expired lease marks the refresh interrupted.
+
+When no durable review exists yet, the transient lease comment remains the only
+start status until the first completed review is published.
 
 For a PR that needs work, the visible comment starts with:
 

--- a/scripts/review-item-telemetry.mjs
+++ b/scripts/review-item-telemetry.mjs
@@ -215,6 +215,9 @@ function nowIso(now) {
 if (import.meta.url === `file://${process.argv[1]}`) {
   runReviewTelemetryProducer().catch((error) => {
     console.log(`::warning::Review telemetry producer skipped: ${error?.message || error}`);
-    process.exitCode = 0;
+    // Workflow steps use continue-on-error so telemetry remains fail-open for
+    // review, while a nonzero outcome prevents dependent heartbeats from
+    // pretending that the refreshing row exists.
+    process.exitCode = 1;
   });
 }

--- a/scripts/review-item-telemetry.mjs
+++ b/scripts/review-item-telemetry.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { createHmac } from "node:crypto";
+
+const PHASES = ["queue", "claim", "review", "publication", "total"];
+
+export function reviewTelemetryAttribution(input) {
+  const sourceAction = String(input.sourceAction || "").toLowerCase();
+  const sourceEvent = String(input.sourceEvent || "").toLowerCase();
+  const eventName = String(input.eventName || "").toLowerCase();
+  const recovery = sourceAction.includes("recovery") || input.recovery === true;
+  const command =
+    sourceAction.includes("command") ||
+    sourceAction.includes("router") ||
+    sourceEvent === "issue_comment";
+  const lane = recovery
+    ? "recovery"
+    : input.exact === true
+      ? "exact_event"
+      : input.hotIntake === true
+        ? "hot_intake"
+        : "normal_backfill";
+  const origin = command
+    ? "command"
+    : eventName === "schedule"
+      ? "schedule"
+      : eventName === "workflow_dispatch"
+        ? "manual"
+        : eventName === "repository_dispatch" &&
+            (sourceEvent === "issues" || sourceEvent === "pull_request")
+          ? "webhook"
+          : "system";
+  return { lane, origin };
+}
+
+export function buildReviewTelemetryRecord(input, existing, now = new Date()) {
+  const nowIso = now.toISOString();
+  const startedAt = existing?.started_at || input.startedAt || nowIso;
+  const phaseDurations = { ...existing?.phase_durations_ms };
+  for (const phase of PHASES) {
+    const value = input.phaseDurations?.[phase];
+    if (Number.isSafeInteger(value) && value >= 0) phaseDurations[phase] = value;
+  }
+  // Total is a live wall-clock duration, so carrying the start payload's value
+  // forward would make healthy heartbeats look permanently stalled.
+  phaseDurations.total =
+    input.phaseDurations?.total ?? Math.max(0, now.getTime() - Date.parse(startedAt));
+  const terminal = input.action === "terminal";
+  return {
+    repo: input.repo,
+    item_number: input.itemNumber,
+    run_id: input.runId,
+    run_attempt: input.runAttempt,
+    status: terminal ? "completed" : "refreshing",
+    outcome: terminal ? input.outcome : null,
+    started_at: startedAt,
+    updated_at: nowIso,
+    lease_expires_at: terminal ? null : input.leaseExpiresAt,
+    phase_durations_ms: phaseDurations,
+    generation: input.generation,
+    operation_id: input.operationId,
+    trigger_lane: input.triggerLane,
+    trigger_origin: input.triggerOrigin,
+    ...(input.sourceEvent && { source_event: input.sourceEvent }),
+    ...(input.sourceAction && { source_action: input.sourceAction }),
+    ...(terminal ? { terminal_reason: input.terminalReason, terminal_at: nowIso } : {}),
+  };
+}
+
+function elapsed(start, end) {
+  const startMs = Date.parse(String(start || ""));
+  const endMs = Date.parse(String(end || ""));
+  return Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs
+    ? endMs - startMs
+    : undefined;
+}
+
+function positiveInteger(name, value) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${name} must be positive`);
+  return parsed;
+}
+
+function optionalDuration(name) {
+  const value = process.env[name];
+  if (value === undefined || value === "") return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function required(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function existingRecord(queueUrl, input) {
+  if (input.action === "start") return undefined;
+  const url = new URL("/api/exact-review-queue/reviews", queueUrl);
+  url.searchParams.set("repo", input.repo);
+  url.searchParams.set("item_number", String(input.itemNumber));
+  url.searchParams.set("limit", "100");
+  const response = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+  if (!response.ok) throw new Error(`telemetry read returned HTTP ${response.status}`);
+  const body = await response.json();
+  return body.reviews?.find(
+    (record) => record.run_id === input.runId && Number(record.run_attempt) === input.runAttempt,
+  );
+}
+
+async function writeRecord(queueUrl, secret, record) {
+  const payload = JSON.stringify(record);
+  const signature = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+  const response = await fetch(new URL("/internal/exact-review/review-telemetry", queueUrl), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body: payload,
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    throw new Error(`telemetry write returned HTTP ${response.status}: ${await response.text()}`);
+  }
+}
+
+export async function runReviewTelemetryProducer() {
+  const action = required("REVIEW_TELEMETRY_ACTION");
+  if (!["start", "heartbeat", "terminal"].includes(action)) {
+    throw new Error("REVIEW_TELEMETRY_ACTION must be start, heartbeat, or terminal");
+  }
+  const sourceEvent = String(process.env.REVIEW_TELEMETRY_SOURCE_EVENT || "").trim();
+  const sourceAction = String(process.env.REVIEW_TELEMETRY_SOURCE_ACTION || "").trim();
+  const attribution = reviewTelemetryAttribution({
+    sourceEvent,
+    sourceAction,
+    eventName: process.env.GITHUB_EVENT_NAME,
+    exact: process.env.REVIEW_TELEMETRY_EXACT === "true",
+    hotIntake: process.env.REVIEW_TELEMETRY_HOT_INTAKE === "true",
+    recovery: process.env.REVIEW_TELEMETRY_RECOVERY === "true",
+  });
+  const leaseMs = optionalDuration("REVIEW_TELEMETRY_LEASE_MS");
+  const now = new Date();
+  const input = {
+    action,
+    repo: required("REVIEW_TELEMETRY_REPO"),
+    itemNumber: positiveInteger("item number", process.env.REVIEW_TELEMETRY_ITEM_NUMBER),
+    runId: required("REVIEW_TELEMETRY_RUN_ID"),
+    runAttempt: positiveInteger("run attempt", process.env.REVIEW_TELEMETRY_RUN_ATTEMPT),
+    generation: process.env.REVIEW_TELEMETRY_GENERATION
+      ? positiveInteger("generation", process.env.REVIEW_TELEMETRY_GENERATION)
+      : undefined,
+    operationId: String(process.env.REVIEW_TELEMETRY_OPERATION_ID || "").trim() || undefined,
+    triggerLane: String(process.env.REVIEW_TELEMETRY_TRIGGER_LANE || attribution.lane),
+    triggerOrigin: String(process.env.REVIEW_TELEMETRY_TRIGGER_ORIGIN || attribution.origin),
+    sourceEvent,
+    sourceAction,
+    startedAt:
+      String(
+        process.env.REVIEW_TELEMETRY_STARTED_AT || process.env.REVIEW_TELEMETRY_QUEUED_AT || "",
+      ).trim() || undefined,
+    leaseExpiresAt: leaseMs === undefined ? null : new Date(now.getTime() + leaseMs).toISOString(),
+    outcome: String(process.env.REVIEW_TELEMETRY_OUTCOME || "").trim(),
+    terminalReason: String(process.env.REVIEW_TELEMETRY_TERMINAL_REASON || "").trim(),
+    phaseDurations: Object.fromEntries(
+      PHASES.map((phase) => [
+        phase,
+        optionalDuration(`REVIEW_TELEMETRY_${phase.toUpperCase()}_MS`),
+      ]).filter(([, value]) => value !== undefined),
+    ),
+  };
+  const derivedPhases = {
+    queue: elapsed(
+      process.env.REVIEW_TELEMETRY_QUEUED_AT,
+      process.env.REVIEW_TELEMETRY_DISPATCHED_AT,
+    ),
+    claim: elapsed(
+      process.env.REVIEW_TELEMETRY_DISPATCHED_AT || process.env.REVIEW_TELEMETRY_QUEUED_AT,
+      process.env.REVIEW_TELEMETRY_CLAIMED_AT,
+    ),
+    review: elapsed(
+      process.env.REVIEW_TELEMETRY_REVIEW_STARTED_AT,
+      process.env.REVIEW_TELEMETRY_REVIEW_COMPLETED_AT,
+    ),
+    publication: elapsed(process.env.REVIEW_TELEMETRY_PUBLICATION_STARTED_AT, nowIso(now)),
+  };
+  for (const [phase, duration] of Object.entries(derivedPhases)) {
+    if (input.phaseDurations[phase] === undefined && duration !== undefined) {
+      input.phaseDurations[phase] = duration;
+    }
+  }
+  if (action === "terminal" && (!input.outcome || !input.terminalReason)) {
+    throw new Error("terminal telemetry requires outcome and terminal reason");
+  }
+  const queueUrl = required("REVIEW_TELEMETRY_QUEUE_URL").replace(/\/$/, "");
+  const existing = await existingRecord(queueUrl, input);
+  // First terminal truth is immutable in the Durable Object. Avoid a redundant
+  // write so retries also preserve that decision before crossing the network.
+  if (existing?.status === "completed") return;
+  if (action !== "start" && !existing) {
+    throw new Error("refreshing telemetry row is unavailable for update");
+  }
+  await writeRecord(
+    queueUrl,
+    required("CLAWSWEEPER_WEBHOOK_SECRET"),
+    buildReviewTelemetryRecord(input, existing, now),
+  );
+}
+
+function nowIso(now) {
+  return now.toISOString();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runReviewTelemetryProducer().catch((error) => {
+    console.log(`::warning::Review telemetry producer skipped: ${error?.message || error}`);
+    process.exitCode = 0;
+  });
+}

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 import {
   chmodSync,
   closeSync,
@@ -1118,6 +1118,7 @@ interface PlanCandidateResult {
 const DEFAULT_PLAN_BATCH_SIZE = 3;
 const DEFAULT_PLAN_SHARD_COUNT = AUTOMATION_LIMITS.review_shards.normal_default;
 const MAX_PLAN_SHARD_COUNT = AUTOMATION_LIMITS.review_shards.hard_cap;
+const MAX_REVIEW_MATRIX_ITEMS = 256;
 
 type DueCandidate = SchedulerDueCandidate<Item, ExistingReview>;
 
@@ -2774,6 +2775,118 @@ class ApplyMutationReviewGuardError extends Error {
 
 let activeApplyMutationRunner: MutationRunner | null = null;
 let activeReviewMutationRunner: MutationRunner | null = null;
+
+type QueueMutationPurpose = "review" | "apply";
+
+type QueueMutationPermit = {
+  itemKey: string;
+  generation: number;
+  operationId: string;
+  owner: string;
+  purpose: QueueMutationPurpose;
+};
+
+type QueueMutationPermitResult =
+  | { status: "disabled" }
+  | { status: "acquired"; permit: QueueMutationPermit }
+  | { status: "deferred"; reason: string };
+
+function queueMutationRequest(
+  path: "/mutation/acquire" | "/mutation/release",
+  permit: QueueMutationPermit,
+): { status: number; body: Record<string, unknown> } {
+  const queueUrl = String(process.env.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL ?? "").replace(/\/$/, "");
+  const secret = String(process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "");
+  if (!/^https:\/\/[^\s]+$/.test(queueUrl) || !secret) {
+    throw new Error("mutation queue URL or webhook secret is missing");
+  }
+  const payload = JSON.stringify({
+    item_key: permit.itemKey,
+    generation: permit.generation,
+    operation_id: permit.operationId,
+    owner: permit.owner,
+    purpose: permit.purpose,
+  });
+  const signature = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+  const result = spawnSync(
+    "curl",
+    [
+      "--silent",
+      "--show-error",
+      "--connect-timeout",
+      "5",
+      "--max-time",
+      "20",
+      "--request",
+      "POST",
+      "--header",
+      "content-type: application/json",
+      "--header",
+      `x-clawsweeper-exact-review-signature: ${signature}`,
+      "--data-binary",
+      payload,
+      "--write-out",
+      "\n%{http_code}",
+      `${queueUrl}/internal/exact-review${path}`,
+    ],
+    { cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `mutation queue request failed: ${String(result.stderr || "curl failed").trim()}`,
+    );
+  }
+  const output = String(result.stdout ?? "");
+  const splitAt = output.lastIndexOf("\n");
+  const status = Number(output.slice(splitAt + 1));
+  if (splitAt < 0 || !Number.isInteger(status)) {
+    throw new Error("mutation queue returned an invalid HTTP response");
+  }
+  const responseText = output.slice(0, splitAt).trim();
+  const body = responseText ? asRecord(JSON.parse(responseText) as unknown) : {};
+  return { status, body };
+}
+
+function acquireQueueMutationPermit(options: {
+  repo: string;
+  number: number;
+  purpose: QueueMutationPurpose;
+  generation?: number;
+  operationId?: string;
+}): QueueMutationPermitResult {
+  const required = process.env.CLAWSWEEPER_REQUIRE_MUTATION_PERMIT === "1";
+  const configured = Boolean(
+    process.env.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL && process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+  );
+  if (!configured) {
+    if (required) throw new Error("required per-item mutation queue is not configured");
+    return { status: "disabled" };
+  }
+  const generation = options.generation ?? 1;
+  const permit: QueueMutationPermit = {
+    itemKey: `${options.repo}#${options.number}`,
+    generation,
+    operationId: options.operationId ?? randomUUID(),
+    owner: `github-run-${process.env.GITHUB_RUN_ID || "local"}-${process.env.GITHUB_RUN_ATTEMPT || "1"}-${process.pid}`,
+    purpose: options.purpose,
+  };
+  const response = queueMutationRequest("/mutation/acquire", permit);
+  if (response.status === 200) return { status: "acquired", permit };
+  const reason =
+    typeof response.body.error === "string" ? response.body.error : `http_${response.status}`;
+  if (response.status === 409) return { status: "deferred", reason };
+  throw new Error(`mutation queue acquire failed with HTTP ${response.status}: ${reason}`);
+}
+
+function releaseQueueMutationPermit(permit: QueueMutationPermit | null): void {
+  if (!permit) return;
+  const response = queueMutationRequest("/mutation/release", permit);
+  if (response.status !== 200 && response.body.error !== "mutation_not_owned") {
+    const reason = typeof response.body.error === "string" ? response.body.error : "unknown";
+    throw new Error(`mutation queue release failed with HTTP ${response.status}: ${reason}`);
+  }
+}
 
 function mutationErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -8877,6 +8990,10 @@ function planCapacityReason(options: {
   return "under capacity: due backlog below planned capacity";
 }
 
+export function planItemReviewCapacity(batchSize: number): number {
+  return Math.min(MAX_REVIEW_MATRIX_ITEMS, Math.max(1, batchSize));
+}
+
 function planCandidates(options: {
   batchSize: number;
   maxPages: number;
@@ -8891,7 +9008,10 @@ function planCandidates(options: {
 }): PlanCandidateResult {
   const shardCount = planShardCount(options.shardCount);
   const batchSize = Math.max(1, options.batchSize);
-  const capacity = batchSize * shardCount;
+  // Item shards make batch size the total planner selection budget. Shard count
+  // now controls only matrix parallelism; multiplying them would exceed GitHub's
+  // 256-job matrix limit under the production defaults.
+  const capacity = planItemReviewCapacity(batchSize);
   const activeFloor =
     options.hotIntake || options.itemNumber || options.itemNumbers
       ? 0
@@ -20730,29 +20850,18 @@ function patchDurableReviewStatusBody(options: {
   const currentBody = commentBody(options.comment);
   const id = commentId(options.comment);
   if (!currentBody || id === null || !options.nextBody || options.nextBody === currentBody) return;
+  // GitHub's issue-comment PATCH endpoint does not implement If-Match. Re-read
+  // the durable comment immediately before the mutation instead; the caller's
+  // per-item mutation permit is what excludes another ClawSweeper writer from
+  // the check/write interval.
+  const liveComment = issueReviewCommentState(options.itemNumber).reviewComment;
+  if (commentId(liveComment) !== id || commentBody(liveComment) !== currentBody) return;
   const endpoint = `repos/${targetRepo()}/issues/comments/${id}`;
-  const snapshot = ghWithRetry(["api", "--include", endpoint]);
-  const etag = snapshot.match(/^etag:\s*(.+)\r?$/im)?.[1]?.trim();
-  const jsonStart = snapshot.lastIndexOf("\n{");
-  const liveComment =
-    jsonStart >= 0 ? asRecord(JSON.parse(snapshot.slice(jsonStart + 1)) as unknown) : {};
-  if (!etag || commentBody(liveComment) !== currentBody) return;
   const payload = writeCommentPayload(options.itemNumber, options.nextBody);
-  const args = [
-    "api",
-    endpoint,
-    "--method",
-    "PATCH",
-    "-H",
-    `If-Match: ${etag}`,
-    "--input",
-    payload,
-  ];
+  const args = ["api", endpoint, "--method", "PATCH", "--input", payload];
   ghObservedMutationCommand({
     identity: options.identity,
     args,
-    knownNoMutation: (error) =>
-      /(?:\b412\b|precondition failed)/i.test(mutationErrorMessage(error)),
   });
 }
 
@@ -21729,6 +21838,31 @@ ${renderReviewContextBudget(options.context)}
   `;
 }
 
+export function planItemMatrix(
+  candidates: readonly {
+    repo: string;
+    number: number;
+    kind: ItemKind;
+    updatedAt: string;
+  }[],
+) {
+  if (candidates.length > MAX_REVIEW_MATRIX_ITEMS) {
+    throw new UserFacingCommandError(
+      `Review plan selected ${candidates.length} items; GitHub Actions supports at most ${MAX_REVIEW_MATRIX_ITEMS} matrix jobs. Reduce --batch-size or the explicit item list.`,
+    );
+  }
+  return candidates.map((item, index) => ({
+    shard: index,
+    repo: item.repo,
+    repo_slug: item.repo.replace(/[^A-Za-z0-9_.-]+/g, "-"),
+    item_number: item.number,
+    item_numbers: String(item.number),
+    kind: item.kind,
+    source_revision: item.updatedAt,
+    generation: Math.max(1, Date.parse(item.updatedAt) || 1),
+  }));
+}
+
 function planCommand(args: Args): void {
   repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
@@ -21760,15 +21894,17 @@ function planCommand(args: Args): void {
   if (hasItemNumbersInput || itemNumbers.length > 0) planOptions.itemNumbers = itemNumbers;
   if (hotIntake) planOptions.hotIntake = true;
   const plan = planCandidates(planOptions);
+  // The planner's list response does not expose a uniform exact revision for
+  // issues and pull requests. Keep its updated_at snapshot in the matrix for
+  // observability; the item job still binds the authoritative live revision
+  // immediately before review.
+  const matrix = planItemMatrix(plan.candidates);
   console.log(
     JSON.stringify(
       {
         ...plan,
         reviewPolicy,
-        matrix: plan.shards.map((shard) => ({
-          shard: shard.shard,
-          item_numbers: shard.itemNumbers.join(",") || "none",
-        })),
+        matrix,
       },
       null,
       2,
@@ -22657,15 +22793,40 @@ function reserveReviewLeaseCommand(args: Args): void {
       `Could not resolve the current review revision for #${itemNumber}.`,
     );
   }
-  const result = postReviewStartStatusComment({
-    item,
-    headSha: currentRevision,
-    reviewTimeoutMs,
-    position: 1,
-    total: 1,
-    shardIndex: 0,
-    shardCount: 1,
+  const generation = Number(process.env.EXACT_REVIEW_GENERATION);
+  const operationId = String(process.env.EXACT_REVIEW_OPERATION_ID ?? "").trim();
+  const queueResult = acquireQueueMutationPermit({
+    repo: targetRepo(),
+    number: itemNumber,
+    purpose: "review",
+    ...(Number.isSafeInteger(generation) && generation > 0 ? { generation } : {}),
+    ...(operationId ? { operationId } : {}),
   });
+  if (queueResult.status === "deferred") {
+    console.log(
+      JSON.stringify({
+        status: "held",
+        retryAt: new Date(Date.now() + 60_000).toISOString(),
+        reason: queueResult.reason,
+      }),
+    );
+    return;
+  }
+  const queuePermit = queueResult.status === "acquired" ? queueResult.permit : null;
+  let result: ReturnType<typeof postReviewStartStatusComment>;
+  try {
+    result = postReviewStartStatusComment({
+      item,
+      headSha: currentRevision,
+      reviewTimeoutMs,
+      position: 1,
+      total: 1,
+      shardIndex: 0,
+      shardCount: 1,
+    });
+  } finally {
+    releaseQueueMutationPermit(queuePermit);
+  }
   if (result.status === "held") {
     console.log(JSON.stringify({ status: "held", retryAt: result.retryAt }));
     return;
@@ -26620,6 +26781,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   let activeApplyMutationLease: {
     itemNumber: number;
     lease: AcquiredReviewStartLease;
+    queuePermit: QueueMutationPermit | null;
   } | null = null;
   const releaseActiveApplyMutationLease = (): void => {
     const active = activeApplyMutationLease;
@@ -26633,6 +26795,14 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       console.error(
         `[apply] could not delete owned review lease comment ${active.lease.commentId}: ${mutationErrorMessage(error)}`,
       );
+    } finally {
+      try {
+        releaseQueueMutationPermit(active.queuePermit);
+      } catch (error) {
+        console.error(
+          `[apply] could not release mutation permit for #${active.itemNumber}: ${mutationErrorMessage(error)}`,
+        );
+      }
     }
   };
   runtimeBudget.onFailure = (error: unknown): void => {
@@ -27159,34 +27329,47 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       leaseState: ReturnType<typeof refreshReviewStartLeaseState>,
     ): string | null => {
       if (dryRun || !requiresApplyMutationLease) return null;
-      let lease: AcquiredReviewStartLease | null = null;
-      if (leaseState.lease && !leaseState.preserve) {
-        if (!leaseState.lease.owner || leaseState.lease.commentId === null) {
-          return "matching review lease lacks a server-confirmed owner and comment id";
-        }
-        lease = {
-          owner: leaseState.lease.owner,
-          commentId: leaseState.lease.commentId,
-          headSha: leaseState.headSha,
-        };
-      } else {
-        const posted = postReviewStartStatusComment({
-          item,
-          headSha: leaseState.headSha,
-          reviewTimeoutMs: Math.max(5 * 60 * 1000, closeDelayMs + 60 * 1000),
-          position: 1,
-          total: 1,
-          shardIndex: 1,
-          shardCount: 1,
-          purpose: "apply",
-        });
-        if (posted.status !== "posted") {
-          return `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`;
-        }
-        lease = posted.lease;
+      const queueResult = acquireQueueMutationPermit({
+        repo,
+        number,
+        purpose: "apply",
+      });
+      if (queueResult.status === "deferred") {
+        return `per-item mutation lane deferred apply: ${queueResult.reason}`;
       }
-      activeApplyMutationLease = { itemNumber: number, lease };
-      return ownedApplyMutationLeaseBlockReason(lease);
+      const queuePermit = queueResult.status === "acquired" ? queueResult.permit : null;
+      let lease: AcquiredReviewStartLease | null = null;
+      try {
+        if (leaseState.lease && !leaseState.preserve) {
+          if (!leaseState.lease.owner || leaseState.lease.commentId === null) {
+            return "matching review lease lacks a server-confirmed owner and comment id";
+          }
+          lease = {
+            owner: leaseState.lease.owner,
+            commentId: leaseState.lease.commentId,
+            headSha: leaseState.headSha,
+          };
+        } else {
+          const posted = postReviewStartStatusComment({
+            item,
+            headSha: leaseState.headSha,
+            reviewTimeoutMs: Math.max(5 * 60 * 1000, closeDelayMs + 60 * 1000),
+            position: 1,
+            total: 1,
+            shardIndex: 1,
+            shardCount: 1,
+            purpose: "apply",
+          });
+          if (posted.status !== "posted") {
+            return `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper lease was acquired concurrently`;
+          }
+          lease = posted.lease;
+        }
+        activeApplyMutationLease = { itemNumber: number, lease, queuePermit };
+        return ownedApplyMutationLeaseBlockReason(lease);
+      } finally {
+        if (!activeApplyMutationLease) releaseQueueMutationPermit(queuePermit);
+      }
     };
     const currentApplyMutationLeaseBlockReason = (): string | null => {
       const reviewActivityBlock = currentReviewActivityBlock();

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -27380,6 +27380,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         activeApplyMutationLease = { itemNumber: number, lease, queuePermit };
         return ownedApplyMutationLeaseBlockReason(lease);
       } finally {
+        // A block reason makes the caller skip this item before mutation. Only
+        // the successful path transfers permit cleanup to the active lease.
         if (!activeApplyMutationLease) releaseQueueMutationPermit(queuePermit);
       }
     };

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -22166,6 +22166,17 @@ function actionLedgerFileEvidence(kind: string, filePath: string): ActionEventEv
   };
 }
 
+function actionLedgerFileDigestEvidence(
+  kind: string,
+  filePath: string,
+): ActionEventEvidence | null {
+  if (!existsSync(filePath)) return null;
+  return {
+    kind,
+    sha256: sha256(readFileSync(filePath, "utf8")),
+  };
+}
+
 function actionLedgerItemSubject(
   item: Item,
   options: { sourceRevision?: string; recordPath?: string } = {},
@@ -26502,7 +26513,9 @@ function recordApplyActionEvents(options: {
     },
     privacy: actionLedgerPrivacy(),
   });
-  const reportEvidence = actionLedgerFileEvidence("apply_report", options.reportPath);
+  // apply-report.json is a local workflow artifact, so only its digest is
+  // durable evidence; report_path is reserved for namespaced state data.
+  const reportEvidence = actionLedgerFileDigestEvidence("apply_report", options.reportPath);
   const reportPublicationPhaseSeq = nextApplyPhaseSeq(options.ledger);
   recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyPublish,
@@ -26525,9 +26538,8 @@ function recordApplyActionEvents(options: {
     subject: {
       repository: targetRepo(),
       kind: "publication",
-      // apply-report.json is a local workflow artifact, not a durable namespaced
-      // state path. Its evidence digest binds the publication without inventing a
-      // record path that the action-ledger schema must reject.
+      // Its evidence digest binds the publication without inventing a durable
+      // subject path that the action-ledger schema must reject.
     },
     evidence: [...workflowRunEvidence(), ...(reportEvidence ? [reportEvidence] : [])],
     attributes: {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -26525,9 +26525,9 @@ function recordApplyActionEvents(options: {
     subject: {
       repository: targetRepo(),
       kind: "publication",
-      ...(repoRelativePath(options.reportPath).startsWith("../")
-        ? {}
-        : { recordPath: repoRelativePath(options.reportPath) }),
+      // apply-report.json is a local workflow artifact, not a durable namespaced
+      // state path. Its evidence digest binds the publication without inventing a
+      // record path that the action-ledger schema must reject.
     },
     evidence: [...workflowRunEvidence(), ...(reportEvidence ? [reportEvidence] : [])],
     attributes: {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -187,6 +187,11 @@ import {
   type ReviewHistoryCycle,
   type ReviewHistoryLedger,
 } from "./review-history.js";
+import {
+  parseDurableReviewStatusProjection,
+  renderDurableReviewRefreshProjection,
+  renderInterruptedDurableReviewProjection,
+} from "./review-comment-status.js";
 import { trailingHtmlComments } from "./review-comment-markers.js";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
@@ -5716,29 +5721,41 @@ function extractLatestClawSweeperReview(
   if (!latest) return null;
   const comment = asRecord(latest);
   const body = rawCommentBody(latest);
-  const verdictMarker = htmlMarkerWithPrefix(body, "clawsweeper-verdict:");
-  const actionMarker = htmlMarkerWithPrefix(body, "clawsweeper-action:");
-  const history = parseReviewHistory(body);
-  const currentCycle = reviewHistoryCycleFromCommentBody(body);
+  const projection = parseDurableReviewStatusProjection(body, number);
+  const reviewBody = projection?.previousBody ?? body;
+  const verdictMarker = projection
+    ? null
+    : htmlMarkerWithPrefix(reviewBody, "clawsweeper-verdict:");
+  const actionMarker = projection ? null : htmlMarkerWithPrefix(reviewBody, "clawsweeper-action:");
+  const history = parseReviewHistory(reviewBody);
+  const currentCycle = reviewHistoryCycleFromCommentBody(reviewBody, {
+    reviewedAt: projection?.previousReviewedAt,
+    sha: projection?.previousSha,
+  });
   const latestCompletedCycle = currentCycle ?? history.cycles.at(-1);
   const earlierReviewCycles = currentCycle ? history.cycles : history.cycles.slice(0, -1);
   return {
-    status: previousReviewStatus(body),
-    verdictDigest: reviewCommentBodyDigest(body),
-    reviewedAt: previousReviewReviewedAt(body) ?? latestCompletedCycle?.reviewedAt ?? null,
+    status: previousReviewStatus(reviewBody),
+    verdictDigest: projection?.previousDigest ?? reviewCommentBodyDigest(reviewBody),
+    reviewedAt:
+      projection?.previousReviewedAt ??
+      previousReviewReviewedAt(reviewBody) ??
+      latestCompletedCycle?.reviewedAt ??
+      null,
     reviewedSha:
+      projection?.previousSha ??
       markerAttribute(verdictMarker, "sha") ??
       markerAttribute(actionMarker, "sha") ??
       latestCompletedCycle?.sha ??
       null,
     verdictMarker,
     actionMarker,
-    summary: firstNonEmptyLine(markdownSection(body, "Summary")),
-    proofStatus: previousReviewProofStatus(body),
-    rating: previousReviewRating(body),
+    summary: firstNonEmptyLine(markdownSection(reviewBody, "Summary")),
+    proofStatus: previousReviewProofStatus(reviewBody),
+    rating: previousReviewRating(reviewBody),
     nextStep:
-      firstNonEmptyLine(markdownSection(body, "Next step before merge")) ||
-      firstNonEmptyLine(markdownSection(body, "Next step")),
+      firstNonEmptyLine(markdownSection(reviewBody, "Next step before merge")) ||
+      firstNonEmptyLine(markdownSection(reviewBody, "Next step")),
     findings: reviewHistoryFindings(latestCompletedCycle),
     earlierReviewCycles,
     completedReviewCycles: history.totalCompletedCycles + (currentCycle ? 1 : 0),
@@ -18634,8 +18651,13 @@ function reviewHistoryForRender(
   }
   const body = previousReviewCommentBody ?? "";
   if (!body.trim()) return { cycles: [], totalCompletedCycles: 0 };
-  const history = parseReviewHistory(body);
-  const previousCycle = reviewHistoryCycleFromCommentBody(body);
+  const projection = parseDurableReviewStatusProjection(body);
+  const reviewBody = projection?.previousBody ?? body;
+  const history = parseReviewHistory(reviewBody);
+  const previousCycle = reviewHistoryCycleFromCommentBody(reviewBody, {
+    reviewedAt: projection?.previousReviewedAt,
+    sha: projection?.previousSha,
+  });
   if (!previousCycle) return history;
   const reviewedAt = frontMatterValue(markdown, "reviewed_at");
   if (reviewedAt && previousCycle.reviewedAt === reviewedAt) return history;
@@ -18646,8 +18668,16 @@ function reviewHistoryForStaleComment(
   previousReviewCommentBody: string | undefined,
 ): ReviewHistoryLedger {
   const body = previousReviewCommentBody ?? "";
-  const history = parseReviewHistory(body);
-  return appendReviewHistoryCycle(history, reviewHistoryCycleFromCommentBody(body));
+  const projection = parseDurableReviewStatusProjection(body);
+  const reviewBody = projection?.previousBody ?? body;
+  const history = parseReviewHistory(reviewBody);
+  return appendReviewHistoryCycle(
+    history,
+    reviewHistoryCycleFromCommentBody(reviewBody, {
+      reviewedAt: projection?.previousReviewedAt,
+      sha: projection?.previousSha,
+    }),
+  );
 }
 
 function renderKeepOpenCommentFromReport(
@@ -19975,6 +20005,18 @@ function durableReviewVersion(
   if (!canPatchReviewComment(comment)) return null;
   const body = commentBody(comment);
   if (!body) return null;
+  const projection = parseDurableReviewStatusProjection(body, number);
+  if (projection) {
+    // The projection's lease tuple is the publication fence: only the report
+    // produced by that exact refresh may replace the visible pending state.
+    return {
+      reviewedAt: projection.startedAt,
+      headSha: projection.targetRevision,
+      sourceRevision: projection.targetRevision,
+      leaseOwner: projection.state === "refreshing" ? projection.leaseOwner : null,
+      leaseCommentId: String(projection.leaseCommentId),
+    };
+  }
   const identity = reviewCommentMarker(number);
   const identityIndex = body.lastIndexOf(identity);
   if (identityIndex < 0 || body.slice(identityIndex + identity.length).trim()) return null;
@@ -20563,13 +20605,14 @@ function postReviewStartStatusComment(options: {
   purpose?: "review" | "apply";
 }): ReviewStartStatusCommentResult {
   const startedAtMs = Date.now();
+  const startedAt = new Date(startedAtMs).toISOString();
   const leaseOwner = newReviewStartLeaseOwner();
   const leaseOptions: ReviewStartStatusCommentOptions = {
     number: options.item.number,
     kind: options.item.kind,
     title: options.item.title,
     ...(options.headSha ? { headSha: options.headSha } : {}),
-    startedAt: new Date(startedAtMs).toISOString(),
+    startedAt,
     leaseExpiresAt: new Date(startedAtMs + options.reviewTimeoutMs + 10 * 60 * 1000).toISOString(),
     leaseOwner,
     position: options.position,
@@ -20651,11 +20694,132 @@ function postReviewStartStatusComment(options: {
     deleteOwnedDedicatedReviewStartLease(options.item.number, acquired);
     return heldReviewStartStatusCommentResult(winner.expiresAt, true);
   }
+  projectExistingDurableReviewForLease({
+    itemNumber: options.item.number,
+    targetRevision: normalizedHead,
+    startedAt,
+    leaseOwner,
+    leaseCommentId: createdCommentId,
+  });
   return {
     status: "posted",
     lease: { ...acquired, comment: winner.comment },
     didMutate: true,
   };
+}
+
+function currentWorkflowRunUrl(): string | null {
+  const serverUrl = String(process.env.GITHUB_SERVER_URL ?? "https://github.com").replace(
+    /\/$/,
+    "",
+  );
+  const repository = String(process.env.GITHUB_REPOSITORY ?? "").trim();
+  const runId = String(process.env.GITHUB_RUN_ID ?? "").trim();
+  if (!/^https:\/\/[^\s]+$/.test(serverUrl) || !/^[\w.-]+\/[\w.-]+$/.test(repository)) {
+    return null;
+  }
+  return /^[1-9]\d*$/.test(runId) ? `${serverUrl}/${repository}/actions/runs/${runId}` : null;
+}
+
+function patchDurableReviewStatusBody(options: {
+  itemNumber: number;
+  comment: Record<string, unknown> | undefined;
+  nextBody: string | null;
+  identity: string;
+}): void {
+  const currentBody = commentBody(options.comment);
+  const id = commentId(options.comment);
+  if (!currentBody || id === null || !options.nextBody || options.nextBody === currentBody) return;
+  const endpoint = `repos/${targetRepo()}/issues/comments/${id}`;
+  const snapshot = ghWithRetry(["api", "--include", endpoint]);
+  const etag = snapshot.match(/^etag:\s*(.+)\r?$/im)?.[1]?.trim();
+  const jsonStart = snapshot.lastIndexOf("\n{");
+  const liveComment =
+    jsonStart >= 0 ? asRecord(JSON.parse(snapshot.slice(jsonStart + 1)) as unknown) : {};
+  if (!etag || commentBody(liveComment) !== currentBody) return;
+  const payload = writeCommentPayload(options.itemNumber, options.nextBody);
+  const args = [
+    "api",
+    endpoint,
+    "--method",
+    "PATCH",
+    "-H",
+    `If-Match: ${etag}`,
+    "--input",
+    payload,
+  ];
+  ghObservedMutationCommand({
+    identity: options.identity,
+    args,
+    knownNoMutation: (error) =>
+      /(?:\b412\b|precondition failed)/i.test(mutationErrorMessage(error)),
+  });
+}
+
+function projectExistingDurableReviewForLease(options: {
+  itemNumber: number;
+  targetRevision: string;
+  startedAt: string;
+  leaseOwner: string;
+  leaseCommentId: number;
+}): void {
+  try {
+    const durable = issueReviewCommentState(options.itemNumber).reviewComment;
+    const body = commentBody(durable);
+    if (!body || !canPatchReviewComment(durable) || commentId(durable) === options.leaseCommentId) {
+      return;
+    }
+    const previous = extractLatestClawSweeperReview([durable], options.itemNumber);
+    const nextBody = renderDurableReviewRefreshProjection(body, {
+      ...options,
+      previousReviewedAt: previous?.reviewedAt,
+      previousSha: previous?.reviewedSha,
+      workflowUrl: currentWorkflowRunUrl(),
+    });
+    patchDurableReviewStatusBody({
+      itemNumber: options.itemNumber,
+      comment: durable,
+      nextBody,
+      identity: `durable_review_refresh:${options.itemNumber}:${options.leaseCommentId}`,
+    });
+  } catch (error) {
+    // The dedicated lease remains authoritative. A presentation-only patch must
+    // never prevent the already-coordinated review from producing a new verdict.
+    console.error(
+      `[review] could not project durable review refresh for #${options.itemNumber}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function interruptDurableReviewProjectionForLease(
+  itemNumber: number,
+  lease: Pick<AcquiredReviewStartLease, "owner" | "commentId" | "headSha">,
+): void {
+  try {
+    const durable = issueReviewCommentState(itemNumber).reviewComment;
+    const body = commentBody(durable);
+    if (!body || !canPatchReviewComment(durable)) return;
+    const nextBody = renderInterruptedDurableReviewProjection(body, {
+      itemNumber,
+      leaseOwner: lease.owner,
+      leaseCommentId: lease.commentId,
+      targetRevision: lease.headSha,
+    });
+    patchDurableReviewStatusBody({
+      itemNumber,
+      comment: durable,
+      nextBody,
+      identity: `durable_review_interrupted:${itemNumber}:${lease.commentId}`,
+    });
+  } catch (error) {
+    console.error(
+      `[review] could not mark durable review refresh interrupted for #${itemNumber}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
 function deleteOwnedDedicatedReviewStartLease(
@@ -20671,6 +20835,7 @@ function deleteOwnedDedicatedReviewStartLease(
         (commentBody(comment) ?? "").includes(`sha=${lease.headSha}`),
     );
     if (!matching) return false;
+    interruptDurableReviewProjectionForLease(itemNumber, lease);
     ghObservedMutationCommand({
       identity: `review_lease_delete:${itemNumber}:${lease.commentId}`,
       args: [
@@ -20707,6 +20872,20 @@ function reapExpiredDedicatedReviewStartLeases(
   });
   for (const lease of expired) {
     try {
+      const matchingComment = dedicatedLeaseComments.find(
+        (comment) => commentId(comment) === lease.commentId,
+      );
+      const owner = reviewStartLeaseOwner(matchingComment);
+      const headSha = (commentBody(matchingComment) ?? "").match(
+        /<!--\s*clawsweeper-review-status:started\b[^>]*\bsha=([^\s>]+)/i,
+      )?.[1];
+      if (owner && headSha) {
+        interruptDurableReviewProjectionForLease(itemNumber, {
+          owner,
+          commentId: lease.commentId,
+          headSha,
+        });
+      }
       ghObservedMutationCommand({
         identity: `review_lease_reap:${itemNumber}:${lease.commentId}`,
         args: [

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1,4 +1,5 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
+import { isDurableReviewStatusProjection } from "../review-comment-status.js";
 import { clawsweeperCoAuthorKey, coAuthorKey } from "./co-author-credit.js";
 import {
   extractClawSweeperCommandLine,
@@ -1704,6 +1705,7 @@ export function parseTrustedAutomation(
 
   const body = String(comment?.body ?? "");
   if (canonicalReviewStartStatusMarker(body)) return null;
+  if (isDurableReviewStatusProjection(body)) return null;
   if (isProofNudgeCommentBody(body)) return null;
   const verdict = clawsweeperMarker(body, "verdict");
   const actionMarker = clawsweeperMarker(body, "action");

--- a/src/repair/exact-review-bundle-cli.ts
+++ b/src/repair/exact-review-bundle-cli.ts
@@ -31,8 +31,8 @@ if (command === "create") {
 
 function contextFromEnv(env: NodeJS.ProcessEnv): ExactReviewBundleContext {
   const protocolVersion = positiveIntegerEnv(env, "EXACT_REVIEW_PROTOCOL_VERSION");
-  if (protocolVersion !== 1 && protocolVersion !== 2) {
-    throw new Error("EXACT_REVIEW_PROTOCOL_VERSION must be 1 or 2");
+  if (protocolVersion !== 1 && protocolVersion !== 2 && protocolVersion !== 3) {
+    throw new Error("EXACT_REVIEW_PROTOCOL_VERSION must be 1, 2, or 3");
   }
   return {
     repository: requiredEnv(env, "GITHUB_REPOSITORY"),
@@ -49,6 +49,12 @@ function contextFromEnv(env: NodeJS.ProcessEnv): ExactReviewBundleContext {
     protocolVersion,
     leaseRevision: optionalPositiveIntegerEnv(env, "EXACT_REVIEW_LEASE_REVISION"),
     claimGeneration: optionalPositiveIntegerEnv(env, "EXACT_REVIEW_CLAIM_GENERATION"),
+    ...(protocolVersion === 3
+      ? {
+          generation: positiveIntegerEnv(env, "EXACT_REVIEW_GENERATION"),
+          operationId: requiredEnv(env, "EXACT_REVIEW_OPERATION_ID"),
+        }
+      : {}),
     liveProceeded: booleanEnv(env, "EXACT_REVIEW_LIVE_PROCEEDED"),
     liveTerminalNoop: booleanEnv(env, "EXACT_REVIEW_LIVE_TERMINAL_NOOP"),
     liveTerminalMissing: booleanEnv(env, "EXACT_REVIEW_LIVE_TERMINAL_MISSING"),

--- a/src/repair/exact-review-bundle.ts
+++ b/src/repair/exact-review-bundle.ts
@@ -26,9 +26,11 @@ export interface ExactReviewBundleContext {
   itemNumber: number;
   itemKind: "issue" | "pull_request";
   itemKey: string;
-  protocolVersion: 1 | 2;
+  protocolVersion: 1 | 2 | 3;
   leaseRevision: number | null;
   claimGeneration: number | null;
+  generation?: number;
+  operationId?: string;
   liveProceeded: boolean;
   liveTerminalNoop: boolean;
   liveTerminalMissing: boolean;
@@ -53,9 +55,11 @@ export interface ExactReviewBundleManifest {
   };
   queue: {
     item_key: string;
-    protocol_version: 1 | 2;
+    protocol_version: 1 | 2 | 3;
     lease_revision: number | null;
     claim_generation: number | null;
+    generation?: number;
+    operation_id?: string;
   };
   target: {
     repo: string;
@@ -129,6 +133,9 @@ export function createExactReviewBundle(
       protocol_version: context.protocolVersion,
       lease_revision: context.leaseRevision,
       claim_generation: context.claimGeneration,
+      ...(context.protocolVersion === 3
+        ? { generation: context.generation, operation_id: context.operationId }
+        : {}),
     },
     target: {
       repo: context.targetRepo,
@@ -211,12 +218,18 @@ function assertExpectedManifest(
     protocolVersion: manifest.queue.protocol_version,
     leaseRevision: manifest.queue.lease_revision,
     claimGeneration: manifest.queue.claim_generation,
+    ...(manifest.queue.protocol_version === 3
+      ? {
+          generation: manifest.queue.generation,
+          operationId: manifest.queue.operation_id,
+        }
+      : {}),
     liveProceeded: manifest.review.live_proceeded,
     liveTerminalNoop: manifest.review.live_terminal_noop,
     liveTerminalMissing: manifest.review.live_terminal_missing,
     liveGuardedOpen: manifest.review.live_guarded_open,
   } satisfies ExactReviewBundleContext;
-  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
     throw new Error("exact review bundle does not match the trusted workflow context");
   }
 }
@@ -244,16 +257,24 @@ function validateContext(value: ExactReviewBundleContext): ExactReviewBundleCont
   if (value.itemKey !== `${value.targetRepo}#${value.itemNumber}`) {
     throw new Error("item key does not match the target");
   }
-  if (value.protocolVersion !== 1 && value.protocolVersion !== 2) {
+  if (value.protocolVersion !== 1 && value.protocolVersion !== 2 && value.protocolVersion !== 3) {
     throw new Error("queue protocol version is invalid");
   }
   nullablePositiveInteger(value.leaseRevision, "lease revision");
   nullablePositiveInteger(value.claimGeneration, "claim generation");
   if (
-    value.protocolVersion === 2 &&
+    value.protocolVersion >= 2 &&
     (value.leaseRevision === null || value.claimGeneration === null)
   ) {
     throw new Error("queue protocol v2 requires the full claim tuple");
+  }
+  if (
+    value.protocolVersion === 3 &&
+    (!Number.isSafeInteger(value.generation) ||
+      Number(value.generation) < 1 ||
+      !/^[A-Za-z0-9-]{20,100}$/.test(value.operationId || ""))
+  ) {
+    throw new Error("queue protocol v3 requires generation and operation ID");
   }
   for (const [label, flag] of [
     ["live proceeded", value.liveProceeded],
@@ -292,7 +313,20 @@ function validateManifest(value: unknown): ExactReviewBundleManifest {
   const workflow = record(manifest.workflow, "workflow");
   exactKeys(workflow, ["repository", "source_sha", "run_id", "run_attempt", "producer_job"]);
   const queue = record(manifest.queue, "queue");
-  exactKeys(queue, ["item_key", "protocol_version", "lease_revision", "claim_generation"]);
+  const queueProtocolVersion = numberValue(queue.protocol_version, "queue.protocol_version");
+  exactKeys(
+    queue,
+    queueProtocolVersion === 3
+      ? [
+          "item_key",
+          "protocol_version",
+          "lease_revision",
+          "claim_generation",
+          "generation",
+          "operation_id",
+        ]
+      : ["item_key", "protocol_version", "lease_revision", "claim_generation"],
+  );
   const target = record(manifest.target, "target");
   exactKeys(target, ["repo", "branch", "item_number", "item_kind"]);
   const review = record(manifest.review, "review");
@@ -317,9 +351,15 @@ function validateManifest(value: unknown): ExactReviewBundleManifest {
     itemNumber: numberValue(target.item_number, "target.item_number"),
     itemKind: target.item_kind as "issue" | "pull_request",
     itemKey: stringValue(queue.item_key, "queue.item_key"),
-    protocolVersion: queue.protocol_version as 1 | 2,
+    protocolVersion: queueProtocolVersion as 1 | 2 | 3,
     leaseRevision: nullableNumber(queue.lease_revision, "queue.lease_revision"),
     claimGeneration: nullableNumber(queue.claim_generation, "queue.claim_generation"),
+    ...(queueProtocolVersion === 3
+      ? {
+          generation: numberValue(queue.generation, "queue.generation"),
+          operationId: stringValue(queue.operation_id, "queue.operation_id"),
+        }
+      : {}),
     liveProceeded: booleanValue(review.live_proceeded, "review.live_proceeded"),
     liveTerminalNoop: booleanValue(review.live_terminal_noop, "review.live_terminal_noop"),
     liveTerminalMissing: booleanValue(review.live_terminal_missing, "review.live_terminal_missing"),
@@ -375,6 +415,9 @@ function validateManifest(value: unknown): ExactReviewBundleManifest {
       protocol_version: context.protocolVersion,
       lease_revision: context.leaseRevision,
       claim_generation: context.claimGeneration,
+      ...(context.protocolVersion === 3
+        ? { generation: context.generation, operation_id: context.operationId }
+        : {}),
     },
     target: {
       repo: context.targetRepo,

--- a/src/review-comment-status.ts
+++ b/src/review-comment-status.ts
@@ -1,0 +1,248 @@
+import { createHash } from "node:crypto";
+
+const COMMENT_MAX_BYTES = 65_536;
+const PREVIOUS_START = "<!-- clawsweeper-review-previous:start v=1 -->";
+const PREVIOUS_END = "<!-- clawsweeper-review-previous:end v=1 -->";
+const IDENTITY_PATTERN = /<!--\s*clawsweeper-review\s+item=(\d+)\s*-->\s*$/i;
+const STATUS_PATTERN = /<!--\s*clawsweeper-review-status:(refreshing|interrupted)\b([^>]*)-->\s*$/i;
+
+export interface DurableReviewStatusProjection {
+  state: "refreshing" | "interrupted";
+  itemNumber: number;
+  targetRevision: string;
+  startedAt: string;
+  leaseOwner: string;
+  leaseCommentId: number;
+  previousDigest: string;
+  previousVisibleDigest: string;
+  previousReviewedAt: string | null;
+  previousSha: string | null;
+  previousBody: string;
+}
+
+export interface DurableReviewRefreshOptions {
+  itemNumber: number;
+  targetRevision: string;
+  startedAt: string;
+  leaseOwner: string;
+  leaseCommentId: number;
+  previousReviewedAt?: string | null | undefined;
+  previousSha?: string | null | undefined;
+  workflowUrl?: string | null;
+}
+
+function digest(body: string): string {
+  return createHash("sha256").update(body.trim()).digest("hex");
+}
+
+function markerValue(value: string): string {
+  return value.trim().replace(/[^\w./:@-]/g, "_") || "unknown";
+}
+
+function markerAttributes(source: string): Map<string, string> {
+  const attributes = new Map<string, string>();
+  for (const token of source.trim().split(/\s+/)) {
+    const separator = token.indexOf("=");
+    if (separator > 0) attributes.set(token.slice(0, separator), token.slice(separator + 1));
+  }
+  return attributes;
+}
+
+function validTimestamp(value: string): boolean {
+  return Boolean(value) && Number.isFinite(Date.parse(value));
+}
+
+function sanitizePreviousBody(body: string): string {
+  return body
+    .replace(/<!--\s*clawsweeper-(?!review-history\b)[\s\S]*?-->/gi, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length <= maxBytes) return value;
+  return `${bytes
+    .subarray(0, maxBytes)
+    .toString("utf8")
+    .replace(/\uFFFD$/, "")
+    .trimEnd()}\n\n_[Previous review truncated while a fresh review runs.]_`;
+}
+
+function safeWorkflowUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length <= 512 && /^https:\/\/[^\s()[\]]+$/.test(trimmed) ? trimmed : null;
+}
+
+export function parseDurableReviewStatusProjection(
+  body: string,
+  expectedItemNumber?: number,
+): DurableReviewStatusProjection | null {
+  const normalized = body.replace(/\r\n?/g, "\n").trim();
+  const identity = normalized.match(IDENTITY_PATTERN);
+  const itemNumber = Number(identity?.[1]);
+  if (!identity || !Number.isInteger(itemNumber) || itemNumber <= 0) return null;
+  if (expectedItemNumber !== undefined && itemNumber !== expectedItemNumber) return null;
+
+  const beforeIdentity = normalized.slice(0, identity.index).trimEnd();
+  const status = beforeIdentity.match(STATUS_PATTERN);
+  if (!status?.[1]) return null;
+  const attributes = markerAttributes(status[2] ?? "");
+  const leaseCommentId = Number(attributes.get("lease_comment_id"));
+  const targetRevision = attributes.get("target_revision") ?? "";
+  const startedAt = attributes.get("started_at") ?? "";
+  const leaseOwner = attributes.get("lease_owner") ?? "";
+  const previousDigest = attributes.get("previous_digest") ?? "";
+  const previousVisibleDigest = attributes.get("previous_visible_digest") ?? "";
+  if (
+    attributes.get("v") !== "1" ||
+    Number(attributes.get("item")) !== itemNumber ||
+    !/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(targetRevision) ||
+    !validTimestamp(startedAt) ||
+    !/^[\w./:@-]+$/.test(leaseOwner) ||
+    !Number.isSafeInteger(leaseCommentId) ||
+    leaseCommentId <= 0 ||
+    !/^[0-9a-f]{64}$/.test(previousDigest) ||
+    !/^[0-9a-f]{64}$/.test(previousVisibleDigest)
+  ) {
+    return null;
+  }
+
+  const visible = beforeIdentity.slice(0, status.index).trimEnd();
+  const previousStart = visible.indexOf(PREVIOUS_START);
+  const previousEnd = visible.indexOf(PREVIOUS_END);
+  if (
+    previousStart < 0 ||
+    previousEnd <= previousStart ||
+    visible.indexOf(PREVIOUS_START, previousStart + PREVIOUS_START.length) >= 0 ||
+    visible.indexOf(PREVIOUS_END, previousEnd + PREVIOUS_END.length) >= 0
+  ) {
+    return null;
+  }
+  const previousBody = visible.slice(previousStart + PREVIOUS_START.length, previousEnd).trim();
+  if (!previousBody || digest(previousBody) !== previousVisibleDigest) return null;
+
+  const nullableAttribute = (name: string): string | null => {
+    const value = attributes.get(name);
+    return !value || value === "na" || value === "unknown" ? null : value;
+  };
+  const previousReviewedAt = nullableAttribute("previous_reviewed_at");
+  const previousSha = nullableAttribute("previous_sha");
+  if (previousReviewedAt && !validTimestamp(previousReviewedAt)) return null;
+  if (previousSha && !/^[\w./:@-]+$/.test(previousSha)) return null;
+  return {
+    state: status[1].toLowerCase() as DurableReviewStatusProjection["state"],
+    itemNumber,
+    targetRevision,
+    startedAt,
+    leaseOwner,
+    leaseCommentId,
+    previousDigest,
+    previousVisibleDigest,
+    previousReviewedAt,
+    previousSha,
+    previousBody,
+  };
+}
+
+function renderProjection(
+  projection: Omit<DurableReviewStatusProjection, "state" | "previousVisibleDigest"> & {
+    state: DurableReviewStatusProjection["state"];
+  },
+  workflowUrl?: string | null,
+): string | null {
+  const previousVisibleDigest = digest(projection.previousBody);
+  const interrupted = projection.state === "interrupted";
+  const title = interrupted
+    ? `Review refresh for \`${projection.targetRevision.slice(0, 12)}\` was interrupted.`
+    : `Fresh ClawSweeper review in progress for \`${projection.targetRevision.slice(0, 12)}\`.`;
+  const explanation = interrupted
+    ? "The previous review below is stale. A new review must complete before it can be used for merge decisions."
+    : "The previous review below is stale and must not be used for merge decisions.";
+  const workflow = !interrupted && workflowUrl ? ` [View workflow](${workflowUrl})` : "";
+  const attributes = [
+    `item=${projection.itemNumber}`,
+    `target_revision=${projection.targetRevision}`,
+    `started_at=${markerValue(projection.startedAt)}`,
+    `lease_owner=${markerValue(projection.leaseOwner)}`,
+    `lease_comment_id=${projection.leaseCommentId}`,
+    `previous_digest=${projection.previousDigest}`,
+    `previous_visible_digest=${previousVisibleDigest}`,
+    `previous_reviewed_at=${markerValue(projection.previousReviewedAt ?? "na")}`,
+    `previous_sha=${markerValue(projection.previousSha ?? "na")}`,
+    "v=1",
+  ].join(" ");
+  const body = [
+    interrupted ? "> [!CAUTION]" : "> [!WARNING]",
+    `> **${title}**`,
+    `> ${explanation}`,
+    `> Started ${projection.startedAt}.${workflow}`,
+    "",
+    "<details>",
+    `<summary>Previous review (stale${interrupted ? " after interrupted refresh" : " while refresh runs"})</summary>`,
+    "",
+    PREVIOUS_START,
+    projection.previousBody,
+    PREVIOUS_END,
+    "",
+    "</details>",
+    "",
+    `<!-- clawsweeper-review-status:${projection.state} ${attributes} -->`,
+    "",
+    `<!-- clawsweeper-review item=${projection.itemNumber} -->`,
+  ].join("\n");
+  return Buffer.byteLength(body, "utf8") <= COMMENT_MAX_BYTES ? body : null;
+}
+
+export function renderDurableReviewRefreshProjection(
+  previousBody: string,
+  options: DurableReviewRefreshOptions,
+): string | null {
+  const existing = parseDurableReviewStatusProjection(previousBody, options.itemNumber);
+  const originalPreviousBody = existing?.previousBody ?? previousBody;
+  const visiblePreviousBody = sanitizePreviousBody(originalPreviousBody);
+  if (!visiblePreviousBody) return null;
+  const projection = {
+    state: "refreshing" as const,
+    itemNumber: options.itemNumber,
+    targetRevision: options.targetRevision.trim().toLowerCase(),
+    startedAt: options.startedAt,
+    leaseOwner: options.leaseOwner,
+    leaseCommentId: options.leaseCommentId,
+    previousDigest: existing?.previousDigest ?? digest(originalPreviousBody),
+    previousReviewedAt: existing?.previousReviewedAt ?? options.previousReviewedAt ?? null,
+    previousSha: existing?.previousSha ?? options.previousSha ?? null,
+    previousBody: existing?.previousBody ?? visiblePreviousBody,
+  };
+  const workflowUrl = safeWorkflowUrl(options.workflowUrl);
+  return (
+    renderProjection(projection, workflowUrl) ??
+    renderProjection({ ...projection, previousBody: truncateUtf8(projection.previousBody, 48_000) })
+  );
+}
+
+export function renderInterruptedDurableReviewProjection(
+  body: string,
+  expected: {
+    itemNumber: number;
+    leaseOwner: string;
+    leaseCommentId: number;
+    targetRevision: string;
+  },
+): string | null {
+  const projection = parseDurableReviewStatusProjection(body, expected.itemNumber);
+  if (
+    !projection ||
+    projection.state !== "refreshing" ||
+    projection.leaseOwner !== expected.leaseOwner ||
+    projection.leaseCommentId !== expected.leaseCommentId ||
+    projection.targetRevision !== expected.targetRevision.trim().toLowerCase()
+  ) {
+    return null;
+  }
+  return renderProjection({ ...projection, state: "interrupted" });
+}
+
+export function isDurableReviewStatusProjection(body: string): boolean {
+  return parseDurableReviewStatusProjection(body) !== null;
+}

--- a/src/review-history.ts
+++ b/src/review-history.ts
@@ -300,7 +300,10 @@ function commentBodyFindings(body: string): string[] {
   return [...new Set(findings)].slice(0, MAX_CYCLE_FINDINGS);
 }
 
-export function reviewHistoryCycleFromCommentBody(body: string): ReviewHistoryCycle | null {
+export function reviewHistoryCycleFromCommentBody(
+  body: string,
+  metadata: { reviewedAt?: string | null | undefined; sha?: string | null | undefined } = {},
+): ReviewHistoryCycle | null {
   if (
     !body.trim() ||
     body.includes(REVIEW_START_PLACEHOLDER) ||
@@ -322,7 +325,11 @@ export function reviewHistoryCycleFromCommentBody(body: string): ReviewHistoryCy
   if (freshnessIndex >= 0) verdict = verdict.slice(0, freshnessIndex).trim();
   if (!verdict || verdict === FAILED_REVIEW_VERDICT) return null;
   const inlineReviewedAt = body.match(/_reviewed ([^_]+?)\.?_/i)?.[1]?.trim();
-  const reviewedAt = reviewMarkerAttribute(body, "reviewed_at") ?? inlineReviewedAt ?? "unknown";
-  const sha = reviewMarkerAttribute(body, "sha") ?? "unknown";
+  const reviewedAt =
+    metadata.reviewedAt ??
+    reviewMarkerAttribute(body, "reviewed_at") ??
+    inlineReviewedAt ??
+    "unknown";
+  const sha = metadata.sha ?? reviewMarkerAttribute(body, "sha") ?? "unknown";
   return { reviewedAt, sha, verdict, findings: commentBodyFindings(body) };
 }

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -701,14 +701,20 @@ test("apply failure finalization survives report publication errors", () => {
   );
 });
 
-test("apply report publication does not claim a durable record path", () => {
+test("apply report publication uses digest-only evidence without a durable record path", () => {
   const source = readText("src/clawsweeper.ts");
+  const evidenceStart = source.indexOf(
+    'const reportEvidence = actionLedgerFileDigestEvidence("apply_report", options.reportPath)',
+  );
   const publicationStart = source.indexOf('identity: { slot: "apply_report_publication" }');
   const publicationEnd = source.indexOf("attributes:", publicationStart);
+  const evidence = source.slice(evidenceStart, publicationStart);
   const publication = source.slice(publicationStart, publicationEnd);
 
+  assert.ok(evidenceStart >= 0);
   assert.ok(publicationStart >= 0);
   assert.ok(publicationEnd > publicationStart);
+  assert.doesNotMatch(evidence, /actionLedgerFileEvidence\("apply_report"/);
   assert.match(publication, /kind: "publication"/);
   assert.doesNotMatch(publication, /recordPath/);
   assert.match(publication, /reportEvidence/);

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -701,6 +701,19 @@ test("apply failure finalization survives report publication errors", () => {
   );
 });
 
+test("apply report publication does not claim a durable record path", () => {
+  const source = readText("src/clawsweeper.ts");
+  const publicationStart = source.indexOf('identity: { slot: "apply_report_publication" }');
+  const publicationEnd = source.indexOf("attributes:", publicationStart);
+  const publication = source.slice(publicationStart, publicationEnd);
+
+  assert.ok(publicationStart >= 0);
+  assert.ok(publicationEnd > publicationStart);
+  assert.match(publication, /kind: "publication"/);
+  assert.doesNotMatch(publication, /recordPath/);
+  assert.match(publication, /reportEvidence/);
+});
+
 test("retry and review publication lanes finalize unexpected failures", () => {
   const source = readText("src/clawsweeper.ts");
   const retryStart = source.indexOf("const retryLedger = startFailedReviewRetryLedger({");

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -738,7 +738,7 @@ test("retry and review publication lanes finalize unexpected failures", () => {
 
 test("sweep publishes complete immutable shards for every review and apply producer", () => {
   const workflow = readText(".github/workflows/sweep.yml");
-  const reviewStep = workflow.indexOf("- name: Review shard");
+  const reviewStep = workflow.indexOf("- name: Review item");
   const reviewFinalizer = workflow.indexOf("- name: Finalize review action ledger");
   const reviewUpload = workflow.indexOf("name: action-ledger-review-${{ matrix.shard }}");
   const applyProofStep = workflow.indexOf("- name: Generate bound close coverage proofs");

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -25,6 +25,8 @@ import {
   itemNumbersArg,
   lockedConversationApplyReason,
   parseDecision,
+  planItemMatrix,
+  planItemReviewCapacity,
   relatedGitHubIssueSearchQueryForTest,
   relatedTitleSearchTerms,
   recordedLabelSyncCoversUpdate,
@@ -1266,6 +1268,20 @@ test("planned review shards stay within the Codex worker cap", () => {
   );
 });
 
+test("item-shard planning separates selection capacity from matrix parallelism", () => {
+  assert.equal(planItemReviewCapacity(3), 3);
+  assert.equal(planItemReviewCapacity(300), 256);
+
+  const candidates = Array.from({ length: 256 }, (_, index) => ({
+    repo: "openclaw/clawsweeper",
+    number: index + 1,
+    kind: "pull_request" as const,
+    updatedAt: "2026-07-18T00:00:00.000Z",
+  }));
+  assert.equal(planItemMatrix(candidates).length, 256);
+  assert.throws(() => planItemMatrix([...candidates, candidates[0]]), /at most 256 matrix jobs/);
+});
+
 test("apply mode prioritizes matching close proposals before comment sync", () => {
   const issueClose = reportFrontMatter({
     decision: "close",
@@ -2191,8 +2207,9 @@ test("sweep workflow executes only durable queue leases without runner-side admi
 
   assert.match(
     eventReviewBlock,
-    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.queue_claim\.item_key \|\| github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
+    /group: clawsweeper-review-\$\{\{ github\.event\.client_payload\.repo_slug \|\| github\.event\.client_payload\.target_repo \|\| 'unknown-repo' \}\}-\$\{\{ github\.event\.client_payload\.item_number \|\| github\.run_id \}\}/,
   );
+  assert.match(eventReviewBlock, /cancel-in-progress: true/);
   assert.match(eventReviewBlock, /github\.event\.client_payload\.queue_lease_id != ''/);
   assert.match(legacyIntakeBlock, /Queue legacy exact-review event/);
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
@@ -2204,7 +2221,6 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /commandStatusMarker: payload\.command_status_marker/);
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
-  assert.match(eventReviewBlock, /cancel-in-progress: false/);
   assert.match(exactReviewStep, /GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/);
   assert.match(exactReviewStep, /--readonly-openclaw/);
   assert.match(exactReviewStep, /--skip-start-comment/);
@@ -2550,17 +2566,17 @@ test("sweep review recovery uses explicit failed shard artifacts", () => {
 
   assert.match(
     workflow,
-    /name: Review shard \$\{\{ matrix\.shard \}\} · \$\{\{ needs\.plan\.outputs\.target_repo \}\}#\$\{\{ matrix\.item_numbers \}\}/,
+    /name: Review item \$\{\{ matrix\.shard \}\} · \$\{\{ matrix\.repo \}\}#\$\{\{ matrix\.item_number \}\}/,
   );
   assert.match(
     workflow,
-    /- name: Review shard\r?\n\s+id: review-shard\r?\n\s+continue-on-error: true/,
+    /- name: Review item\r?\n\s+id: review-shard\r?\n\s+continue-on-error: true/,
   );
-  assert.match(workflow, /- name: Record failed review shard/);
+  assert.match(workflow, /- name: Record failed item review/);
   assert.match(workflow, /steps\.review-shard\.outcome == 'failure'/);
   assert.match(workflow, /name: review-failed-shard-\$\{\{ matrix\.shard \}\}/);
   assert.match(workflow, /pattern: review-failed-shard-\*/);
-  assert.ok(workflow.includes('sub("^Review shard ([0-9]+).*$"; "\\\\1")'));
+  assert.ok(workflow.includes('sub("^Review item ([0-9]+).*$"; "\\\\1")'));
   assert.match(workflow, /needs\.review\.result != 'skipped'/);
   assert.doesNotMatch(
     workflow,

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2207,7 +2207,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
 
   assert.match(
     eventReviewBlock,
-    /group: clawsweeper-review-\$\{\{ github\.event\.client_payload\.repo_slug \|\| github\.event\.client_payload\.target_repo \|\| 'unknown-repo' \}\}-\$\{\{ github\.event\.client_payload\.item_number \|\| github\.run_id \}\}/,
+    /group: clawsweeper-review-\$\{\{ github\.event\.client_payload\.target_repo \|\| 'unknown-repo' \}\}-\$\{\{ github\.event\.client_payload\.item_number \|\| github\.run_id \}\}/,
   );
   assert.match(eventReviewBlock, /cancel-in-progress: true/);
   assert.match(eventReviewBlock, /github\.event\.client_payload\.queue_lease_id != ''/);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3779,8 +3779,27 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
     items: Record<string, { state: string; generation?: number; parkedReason?: string }>;
   };
   assert.equal(resumed.items[idleItemKey].state, "pending");
-  assert.equal(resumed.items[idleItemKey].generation, 1);
+  assert.equal(resumed.items[idleItemKey].generation, 2);
   assert.equal(resumed.items[idleItemKey].parkedReason, undefined);
+  assert.equal(
+    Array.from(
+      storage.sql.exec(
+        "SELECT generation FROM exact_review_generations WHERE item_key = ?",
+        idleItemKey,
+      ),
+    )[0].generation,
+    2,
+  );
+  assert.equal(
+    (
+      await mutationRequest("/mutation/acquire", {
+        ...applyTuple,
+        purpose: "review",
+        operation_id: "77777777-7777-4777-8777-777777777777",
+      })
+    ).status,
+    409,
+  );
 
   const cancelled = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/complete", {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4045,6 +4045,9 @@ test("exact-review mutation acquire reclaims only terminal apply owners", async 
     if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/7002") {
       return jsonResponse({ id: 7002, run_attempt: 1, status: "in_progress" });
     }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
+      return jsonResponse({ state: "disabled_manually" });
+    }
     throw new Error(`unexpected fetch ${url}`);
   };
 
@@ -4138,6 +4141,42 @@ test("exact-review mutation acquire reclaims only terminal apply owners", async 
     const unknown = await acquire();
     assert.equal(unknown.status, 409);
     assert.equal((await unknown.json()).error, "mutation_busy");
+    storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+
+    const parked = unclaimedExactReviewQueueItem(629);
+    Object.assign(parked, {
+      state: "parked",
+      parkedReason: "mutation_active",
+      generation: 1,
+      leaseId: undefined,
+      leaseRevision: undefined,
+      leaseDecision: undefined,
+      leaseExpiresAt: undefined,
+      leaseGeneration: undefined,
+      operationId: undefined,
+      dispatchedAt: undefined,
+    });
+    await storage.put("exact-review-queue", {
+      deliveries: {},
+      items: { [itemKey]: parked },
+    });
+    insertApplyLease("github-run-7001-1-44");
+    await queue.alarm();
+    const autonomouslyResumed = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { state: string; generation?: number; parkedReason?: string }>;
+    };
+    assert.equal(autonomouslyResumed.items[itemKey].state, "pending");
+    assert.equal(autonomouslyResumed.items[itemKey].generation, 2);
+    assert.equal(autonomouslyResumed.items[itemKey].parkedReason, undefined);
+    assert.equal(
+      Array.from(
+        storage.sql.exec(
+          "SELECT owner FROM exact_review_mutation_leases WHERE item_key = ?",
+          itemKey,
+        ),
+      ).length,
+      0,
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2748,8 +2748,11 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
     const leaseId = String(payload.queue_lease_id || "");
     const queueClaim = payload.queue_claim as Record<string, unknown>;
     const operationId = String(queueClaim.operation_id || "");
+    const queuedAt = String(queueClaim.queued_at || "");
+    const dispatchedAt = String(queueClaim.dispatched_at || "");
     assert.match(leaseId, /^[0-9a-f-]{36}$/);
     assert.match(operationId, /^[0-9a-f-]{36}$/);
+    assert.ok(Date.parse(queuedAt) <= Date.parse(dispatchedAt));
     assert.deepEqual(payload, {
       queue_lease_id: leaseId,
       queue_claim: {
@@ -2758,6 +2761,8 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
         lease_revision: 2,
         generation: 2,
         operation_id: operationId,
+        queued_at: queuedAt,
+        dispatched_at: dispatchedAt,
       },
       repo_slug: "openclaw-gogcli",
       target_repo: "openclaw/gogcli",
@@ -11941,6 +11946,79 @@ test("terminal workflow observer conservatively completes only unleased refreshi
   ).json()) as { reviews: Array<Record<string, unknown>> };
   assert.equal(reconciled.reviews[0].outcome, "cancelled");
   assert.equal(reconciled.reviews[0].terminal_reason, "workflow_cancelled");
+});
+
+test("terminal workflow observer classifies a cancelled stale generation as superseded", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, { REVIEW_OBSERVABILITY_REQUIRED: "1" });
+  const now = Date.now();
+  const record = {
+    repo: "openclaw/openclaw",
+    item_number: 674,
+    run_id: "57777",
+    run_attempt: 1,
+    status: "refreshing",
+    outcome: null,
+    started_at: new Date(now - 60_000).toISOString(),
+    updated_at: new Date(now - 30_000).toISOString(),
+    lease_expires_at: null,
+    phase_durations_ms: { queue: 100, claim: 100 },
+    generation: 1,
+    operation_id: "operation-12345678901234567890",
+    trigger_lane: "exact_event",
+    trigger_origin: "webhook",
+  };
+  assert.equal(
+    (
+      await queue.fetch(
+        new Request("https://queue/review-telemetry", {
+          method: "POST",
+          body: JSON.stringify(record),
+        }),
+      )
+    ).status,
+    200,
+  );
+  storage.sql.exec(
+    "INSERT INTO exact_review_generations (item_key, generation, updated_at) VALUES (?, ?, ?)",
+    "openclaw/openclaw#674",
+    2,
+    now,
+  );
+  assert.equal(
+    (
+      await queue.fetch(
+        new Request("https://queue/review-run-telemetry", {
+          method: "POST",
+          body: JSON.stringify({
+            run_id: "57777",
+            run_attempt: 1,
+            workflow_outcome: "cancelled",
+            trigger_lane: "exact_event",
+            trigger_origin: "webhook",
+            target_repo: "openclaw/openclaw",
+            started_at: record.started_at,
+            completed_at: new Date(now).toISOString(),
+            run_url: "https://github.com/openclaw/clawsweeper/actions/runs/57777",
+            plan_count: 1,
+            item_count: 1,
+            publication_count: 0,
+            review_jobs: [
+              { name: "Review exact event item", conclusion: "cancelled", item_number: 674 },
+            ],
+          }),
+        }),
+      )
+    ).status,
+    200,
+  );
+  const telemetry = (await (
+    await queue.fetch(
+      new Request("https://queue/review-telemetry?repo=openclaw%2Fopenclaw&item_number=674"),
+    )
+  ).json()) as { reviews: Array<Record<string, unknown>> };
+  assert.equal(telemetry.reviews[0].outcome, "superseded");
+  assert.equal(telemetry.reviews[0].terminal_reason, "generation_superseded");
 });
 
 test("terminal workflow evidence reconciles telemetry that arrives later", async () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3738,6 +3738,35 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
     purpose: "apply",
   };
   assert.equal((await mutationRequest("/mutation/acquire", applyTuple)).status, 200);
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "edited-while-mutating-626",
+          626,
+          "edited",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+  const mutationBlocked = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; generation?: number; parkedReason?: string }>;
+  };
+  assert.equal(mutationBlocked.items[idleItemKey].state, "parked");
+  assert.equal(mutationBlocked.items[idleItemKey].generation, 1);
+  assert.equal(mutationBlocked.items[idleItemKey].parkedReason, "mutation_active");
+  assert.equal(
+    Array.from(
+      storage.sql.exec(
+        "SELECT generation FROM exact_review_generations WHERE item_key = ?",
+        idleItemKey,
+      ),
+    )[0].generation,
+    1,
+  );
   const reviewWhileApplyMutates = await mutationRequest("/mutation/acquire", {
     ...applyTuple,
     purpose: "review",
@@ -3746,6 +3775,12 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
   assert.equal(reviewWhileApplyMutates.status, 409);
   assert.equal((await reviewWhileApplyMutates.json()).error, "mutation_busy");
   assert.equal((await mutationRequest("/mutation/release", applyTuple)).status, 200);
+  const resumed = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; generation?: number; parkedReason?: string }>;
+  };
+  assert.equal(resumed.items[idleItemKey].state, "pending");
+  assert.equal(resumed.items[idleItemKey].generation, 1);
+  assert.equal(resumed.items[idleItemKey].parkedReason, undefined);
 
   const cancelled = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/complete", {
@@ -3878,6 +3913,7 @@ test("exact-review terminal callbacks release matching review mutation leases", 
     operationId: publicationOperationId,
     claimProtocolVersion: 3,
   });
+  publication.decision.publication.generation = 7;
   await completeStorage.put("exact-review-queue", {
     deliveries: {},
     items: { [publication.key]: publication },
@@ -3886,7 +3922,7 @@ test("exact-review terminal callbacks release matching review mutation leases", 
   completeStorage.sql.exec(
     `INSERT INTO exact_review_mutation_leases
        (item_key, generation, operation_id, owner, purpose, acquired_at, heartbeat_at)
-     VALUES (?, 1, ?, 'github-run-6270-1', 'review', ?, ?)`,
+     VALUES (?, 7, ?, 'github-run-6270-1', 'review', ?, ?)`,
     publication.decision.publication.itemKey,
     publicationOperationId,
     Date.now(),

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3449,6 +3449,54 @@ test("exact-review claim preserves its immutable decision across a newer enqueue
   assert.equal(requeued.items["openclaw/openclaw#620"].leaseDecision, undefined);
 });
 
+test("exact-review retains an ordinary non-superseding update behind an active lease", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = unclaimedExactReviewQueueItem(621);
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { "openclaw/openclaw#621": item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "ordinary-newer-621",
+          621,
+          "reopened",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      {
+        revision: number;
+        decision: { sourceAction: string; supersedesInProgress: boolean };
+        leaseDecision: { sourceAction: string };
+      }
+    >;
+  };
+  const updated = state.items["openclaw/openclaw#621"];
+  assert.equal(updated.revision, 2);
+  assert.deepEqual(updated.decision, {
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: 621,
+    itemKind: "pull_request",
+    sourceEvent: "pull_request",
+    sourceAction: "reopened",
+    supersedesInProgress: false,
+  });
+  assert.equal(updated.leaseDecision.sourceAction, item.leaseDecision.sourceAction);
+});
+
 test("new exact-review queue serves legacy workflow claims during rolling deploys", async () => {
   const storage = new MemoryDurableStorage();
   const item = unclaimedExactReviewQueueItem(624);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -841,6 +841,7 @@ test("dashboard status reads the exact-review handoff model from the durable que
   assert.equal(status.pressure.active, status.lanes.review.active);
   assert.equal(status.pressure.pending, status.lanes.review.pending);
   assert.equal(status.pressure.capacity, status.lanes.review.capacity);
+  assert.equal(status.lanes.review.permit_utilization, 1 / 64);
   assert.deepEqual(status.bay_projection.stages, {
     arriving: 2,
     "setting-up": 1,
@@ -2745,14 +2746,20 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
     assert.ok(nextAlarm && nextAlarm > Date.now() + 60_000);
     const payload = dispatched[0].client_payload as Record<string, unknown>;
     const leaseId = String(payload.queue_lease_id || "");
+    const queueClaim = payload.queue_claim as Record<string, unknown>;
+    const operationId = String(queueClaim.operation_id || "");
     assert.match(leaseId, /^[0-9a-f-]{36}$/);
+    assert.match(operationId, /^[0-9a-f-]{36}$/);
     assert.deepEqual(payload, {
       queue_lease_id: leaseId,
       queue_claim: {
-        protocol_version: 2,
+        protocol_version: 3,
         item_key: "openclaw/gogcli#597",
         lease_revision: 2,
+        generation: 2,
+        operation_id: operationId,
       },
+      repo_slug: "openclaw-gogcli",
       target_repo: "openclaw/gogcli",
       target_branch: "main",
       item_number: 597,
@@ -2768,7 +2775,7 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
         additional_prompt: "Check the maintainer-requested regression path.",
       },
     });
-    assert.equal(Object.keys(payload).length, 10);
+    assert.equal(Object.keys(payload).length, 11);
 
     const newer = buildExactReviewQueueRequest("delivery-4", 597, "synchronize", "pull_request");
     assert.equal((await queue.fetch(newer)).status, 202);
@@ -2785,77 +2792,28 @@ test("exact-review queue coalesces deliveries, dispatches a bound rollout snapsh
         }),
       }),
     );
-    assert.equal(claimed.status, 200);
-    assert.deepEqual(await claimed.json(), {
-      ok: true,
-      claimed: true,
-      protocol_version: 2,
-      item_key: "openclaw/gogcli#597",
-      lease_revision: 2,
-      claim_generation: 1,
-      decision: {
-        targetRepo: "openclaw/gogcli",
-        targetBranch: "main",
-        itemNumber: 597,
-        itemKind: "issue",
-        sourceEvent: "issues",
-        sourceAction: "edited",
-        supersedesInProgress: true,
-        commandStatusMarker,
-        statusCommentId: 9001,
-        additionalPrompt: "Check the maintainer-requested regression path.",
-        codexTimeoutMs: 1_200_000,
-        mediaProofTimeoutMs: 480_000,
-      },
-    });
+    assert.equal(claimed.status, 409);
+    assert.equal((await claimed.json()).error, "lease_not_active");
     stats = await (
       await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
     ).json();
     assert.equal(stats.dispatching, 0);
-    assert.equal(stats.leased, 1);
-    assert.equal(stats.handoff_health.phases.leased.count, 1);
-    assert.equal(typeof stats.oldest_leased_age_seconds, "number");
-    assert.equal(
-      (
-        await queue.fetch(
-          new Request("https://clawsweeper-exact-review-queue/claim", {
-            method: "POST",
-            body: JSON.stringify({
-              lease_id: leaseId,
-              item_key: "openclaw/gogcli#597",
-              lease_revision: 2,
-              run_id: "101",
-              run_attempt: 1,
-            }),
-          }),
-        )
-      ).status,
-      409,
-    );
-
-    const completed = await queue.fetch(
-      new Request("https://clawsweeper-exact-review-queue/complete", {
-        method: "POST",
-        body: JSON.stringify({
-          lease_id: leaseId,
-          item_key: "openclaw/gogcli#597",
-          lease_revision: 2,
-          claim_generation: 1,
-          run_id: "100",
-          run_attempt: 1,
-        }),
-      }),
-    );
-    assert.deepEqual(await completed.json(), { ok: true, requeued: true });
+    assert.equal(stats.leased, 0);
     const requeued = (await storage.get("exact-review-queue")) as {
       items: Record<
         string,
         { attempts: number; nextAttemptAt: number; decision: Record<string, unknown> }
       >;
     };
-    assert.equal(requeued.items["openclaw/gogcli#597"].decision.commandStatusMarker, undefined);
-    assert.equal(requeued.items["openclaw/gogcli#597"].decision.statusCommentId, undefined);
-    assert.equal(requeued.items["openclaw/gogcli#597"].decision.additionalPrompt, undefined);
+    assert.equal(
+      requeued.items["openclaw/gogcli#597"].decision.commandStatusMarker,
+      commandStatusMarker,
+    );
+    assert.equal(requeued.items["openclaw/gogcli#597"].decision.statusCommentId, 9001);
+    assert.equal(
+      requeued.items["openclaw/gogcli#597"].decision.additionalPrompt,
+      "Check the maintainer-requested regression path.",
+    );
     assert.equal(requeued.items["openclaw/gogcli#597"].attempts, 0);
     assert.ok(requeued.items["openclaw/gogcli#597"].nextAttemptAt <= Date.now());
     stats = await (
@@ -3571,6 +3529,470 @@ test("new exact-review queue serves legacy workflow claims during rolling deploy
     (requeued.items["openclaw/openclaw#624"].decision as { sourceAction: string }).sourceAction,
     "edited",
   );
+});
+
+test("exact-review protocol v3 supersedes only the same item generation and fences mutations", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "opened-625",
+          625,
+          "opened",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+
+  const itemKey = "openclaw/openclaw#625";
+  const operationId = "11111111-1111-4111-8111-111111111111";
+  const row = Array.from(
+    storage.sql.exec("SELECT item_json FROM exact_review_queue_items WHERE item_key = ?", itemKey),
+  )[0] as { item_json: string };
+  const item = JSON.parse(row.item_json);
+  Object.assign(item, {
+    state: "dispatching",
+    leaseId: "lease-v3-625",
+    leaseRevision: 1,
+    leaseGeneration: 1,
+    operationId,
+    leaseDecision: structuredClone(item.decision),
+    leaseExpiresAt: Date.now() + 60_000,
+  });
+  storage.sql.exec(
+    "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+    JSON.stringify(item),
+    itemKey,
+  );
+
+  const claim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-v3-625",
+        item_key: itemKey,
+        lease_revision: 1,
+        generation: 1,
+        operation_id: operationId,
+        run_id: "6250",
+        run_attempt: 1,
+      }),
+    }),
+  );
+  assert.equal(claim.status, 200);
+  assert.deepEqual(await claim.json(), {
+    ok: true,
+    claimed: true,
+    protocol_version: 3,
+    item_key: itemKey,
+    lease_revision: 1,
+    claim_generation: 1,
+    generation: 1,
+    operation_id: operationId,
+    decision: item.leaseDecision,
+  });
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "edited-625",
+          625,
+          "edited",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { generation?: number; state: string; supersededByGeneration?: number }>;
+  };
+  assert.equal(state.items[itemKey].generation, 2);
+  assert.equal(state.items[itemKey].state, "pending");
+  const supersededKey = `${itemKey}@compute:1:1`;
+  assert.equal(state.items[supersededKey].supersededByGeneration, 2);
+
+  const generationCheck = (generation: number) =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/generation/check", {
+        method: "POST",
+        body: JSON.stringify({ item_key: itemKey, generation }),
+      }),
+    );
+  assert.equal((await generationCheck(1)).status, 409);
+  assert.equal((await generationCheck(2)).status, 200);
+
+  const mutationTuple = {
+    item_key: itemKey,
+    generation: 2,
+    operation_id: "22222222-2222-4222-8222-222222222222",
+    owner: "github-run-6251-1",
+    purpose: "review",
+  };
+  const mutationRequest = (path: string, body: Record<string, unknown>) =>
+    queue.fetch(
+      new Request(`https://clawsweeper-exact-review-queue${path}`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    );
+  assert.equal(
+    (await mutationRequest("/mutation/acquire", { ...mutationTuple, generation: 1 })).status,
+    409,
+  );
+  assert.equal((await mutationRequest("/mutation/acquire", mutationTuple)).status, 200);
+  assert.equal(
+    (
+      await mutationRequest("/mutation/acquire", {
+        ...mutationTuple,
+        operation_id: "33333333-3333-4333-8333-333333333333",
+        owner: "github-run-6252-1",
+      })
+    ).status,
+    409,
+  );
+  assert.equal(
+    (await mutationRequest("/mutation/release", { ...mutationTuple, owner: "wrong-owner" })).status,
+    409,
+  );
+  assert.equal((await mutationRequest("/mutation/release", mutationTuple)).status, 200);
+  const applyWhileReviewActive = await mutationRequest("/mutation/acquire", {
+    ...mutationTuple,
+    purpose: "apply",
+    operation_id: "44444444-4444-4444-8444-444444444444",
+  });
+  assert.equal(applyWhileReviewActive.status, 409);
+  assert.equal((await applyWhileReviewActive.json()).error, "review_active");
+
+  const idleItemKey = "openclaw/openclaw#626";
+  storage.sql.exec(
+    "INSERT INTO exact_review_generations (item_key, generation, updated_at) VALUES (?, 1, ?)",
+    idleItemKey,
+    Date.now(),
+  );
+  const applyTuple = {
+    item_key: idleItemKey,
+    generation: 1,
+    operation_id: "55555555-5555-4555-8555-555555555555",
+    owner: "github-run-6260-1",
+    purpose: "apply",
+  };
+  assert.equal((await mutationRequest("/mutation/acquire", applyTuple)).status, 200);
+  const reviewWhileApplyMutates = await mutationRequest("/mutation/acquire", {
+    ...applyTuple,
+    purpose: "review",
+    operation_id: "66666666-6666-4666-8666-666666666666",
+  });
+  assert.equal(reviewWhileApplyMutates.status, 409);
+  assert.equal((await reviewWhileApplyMutates.json()).error, "mutation_busy");
+  assert.equal((await mutationRequest("/mutation/release", applyTuple)).status, 200);
+
+  const cancelled = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-v3-625",
+        item_key: itemKey,
+        lease_revision: 1,
+        claim_generation: 1,
+        generation: 1,
+        operation_id: operationId,
+        run_id: "6250",
+        run_attempt: 1,
+        outcome: "cancelled",
+      }),
+    }),
+  );
+  assert.equal(cancelled.status, 200);
+  assert.deepEqual(await cancelled.json(), { ok: true, requeued: false });
+  const terminal = (await storage.get("exact-review-queue")) as {
+    items: Record<string, unknown>;
+  };
+  assert.equal(terminal.items[supersededKey], undefined);
+  assert.ok(terminal.items[itemKey]);
+});
+
+test("superseding a v2 lease carries the new generation onto its requeue", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "opened-v2-626",
+          626,
+          "opened",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+
+  const itemKey = "openclaw/openclaw#626";
+  const row = Array.from(
+    storage.sql.exec("SELECT item_json FROM exact_review_queue_items WHERE item_key = ?", itemKey),
+  )[0] as { item_json: string };
+  const item = JSON.parse(row.item_json);
+  Object.assign(item, {
+    state: "dispatching",
+    leaseId: "lease-v2-626",
+    leaseRevision: 1,
+    leaseGeneration: 1,
+    operationId: "12121212-1212-4212-8212-121212121212",
+    leaseDecision: structuredClone(item.decision),
+    leaseExpiresAt: Date.now() + 60_000,
+  });
+  storage.sql.exec(
+    "UPDATE exact_review_queue_items SET item_json = ? WHERE item_key = ?",
+    JSON.stringify(item),
+    itemKey,
+  );
+
+  const claim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-v2-626",
+        item_key: itemKey,
+        lease_revision: 1,
+        run_id: "6260",
+        run_attempt: 1,
+      }),
+    }),
+  );
+  assert.equal(claim.status, 200);
+  assert.equal((await claim.json()).protocol_version, 2);
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "edited-v2-626",
+          626,
+          "edited",
+          "pull_request",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+  const superseded = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { generation?: number; leaseGeneration?: number }>;
+  };
+  assert.equal(superseded.items[itemKey].generation, 2);
+  assert.equal(superseded.items[itemKey].leaseGeneration, 1);
+
+  const complete = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: "lease-v2-626",
+        item_key: itemKey,
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: "6260",
+        run_attempt: 1,
+        outcome: "success",
+      }),
+    }),
+  );
+  assert.equal(complete.status, 200);
+  const requeued = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; generation?: number; leaseGeneration?: number }>;
+  };
+  assert.equal(requeued.items[itemKey].state, "pending");
+  assert.equal(requeued.items[itemKey].generation, 2);
+  assert.equal(requeued.items[itemKey].leaseGeneration, undefined);
+});
+
+test("exact-review terminal callbacks release matching review mutation leases", async () => {
+  const completeStorage = new MemoryDurableStorage();
+  const publication = leasedExactReviewPublicationItem(627, "6270");
+  const publicationOperationId = "77777777-7777-4777-8777-777777777777";
+  Object.assign(publication, {
+    generation: 1,
+    leaseGeneration: 1,
+    operationId: publicationOperationId,
+    claimProtocolVersion: 3,
+  });
+  await completeStorage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [publication.key]: publication },
+  });
+  const completeQueue = new ExactReviewQueue({ storage: completeStorage }, {});
+  completeStorage.sql.exec(
+    `INSERT INTO exact_review_mutation_leases
+       (item_key, generation, operation_id, owner, purpose, acquired_at, heartbeat_at)
+     VALUES (?, 1, ?, 'github-run-6270-1', 'review', ?, ?)`,
+    publication.decision.publication.itemKey,
+    publicationOperationId,
+    Date.now(),
+    Date.now(),
+  );
+  const completed = await completeQueue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: publication.leaseId,
+        item_key: publication.key,
+        lease_revision: 1,
+        claim_generation: 1,
+        generation: 1,
+        operation_id: publicationOperationId,
+        run_id: "6270",
+        run_attempt: 1,
+        outcome: "success",
+      }),
+    }),
+  );
+  assert.equal(completed.status, 200);
+  assert.equal(
+    Array.from(completeStorage.sql.exec("SELECT item_key FROM exact_review_mutation_leases"))
+      .length,
+    0,
+  );
+
+  const reconcileStorage = new MemoryDurableStorage();
+  const review = leasedExactReviewQueueItem(628, "6280");
+  const reviewOperationId = "88888888-8888-4888-8888-888888888888";
+  Object.assign(review, {
+    generation: 1,
+    leaseGeneration: 1,
+    operationId: reviewOperationId,
+    claimProtocolVersion: 3,
+  });
+  await reconcileStorage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [review.key]: review },
+  });
+  const reconcileQueue = new ExactReviewQueue({ storage: reconcileStorage }, {});
+  reconcileStorage.sql.exec(
+    `INSERT INTO exact_review_mutation_leases
+       (item_key, generation, operation_id, owner, purpose, acquired_at, heartbeat_at)
+     VALUES (?, 1, ?, 'github-run-6280-1', 'review', ?, ?)`,
+    review.key,
+    reviewOperationId,
+    Date.now(),
+    Date.now(),
+  );
+  const reconciled = await reconcileQueue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/reconcile", {
+      method: "POST",
+      body: JSON.stringify({
+        runs: [
+          {
+            run_id: "6280",
+            run_attempt: 1,
+            claimed_run_attempt: 1,
+            claim_generation: 1,
+            outcome: "cancelled",
+          },
+        ],
+      }),
+    }),
+  );
+  assert.equal(reconciled.status, 200);
+  assert.equal(
+    Array.from(reconcileStorage.sql.exec("SELECT item_key FROM exact_review_mutation_leases"))
+      .length,
+    0,
+  );
+});
+
+test("exact-review mutation acquire reclaims only terminal apply owners", async () => {
+  const originalFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return jsonResponse({ id: 999 });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      assert.deepEqual(JSON.parse(String(init?.body)).permissions, { actions: "read" });
+      return jsonResponse({ token: "t" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/7001") {
+      return jsonResponse({ id: 7001, run_attempt: 1, status: "completed" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/7001/attempts/1") {
+      return jsonResponse({ id: 7001, run_attempt: 1, status: "completed", conclusion: "failure" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/7002") {
+      return jsonResponse({ id: 7002, run_attempt: 1, status: "in_progress" });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  try {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+      },
+    );
+    const itemKey = "openclaw/openclaw#629";
+    storage.sql.exec(
+      "INSERT INTO exact_review_generations (item_key, generation, updated_at) VALUES (?, 1, ?)",
+      itemKey,
+      Date.now(),
+    );
+    const insertApplyLease = (owner: string) =>
+      storage.sql.exec(
+        `INSERT INTO exact_review_mutation_leases
+           (item_key, generation, operation_id, owner, purpose, acquired_at, heartbeat_at)
+         VALUES (?, 1, '99999999-9999-4999-8999-999999999999', ?, 'apply', ?, ?)`,
+        itemKey,
+        owner,
+        Date.now(),
+        Date.now(),
+      );
+    const acquire = () =>
+      queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/mutation/acquire", {
+          method: "POST",
+          body: JSON.stringify({
+            item_key: itemKey,
+            generation: 1,
+            operation_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            owner: "github-run-7003-1",
+            purpose: "review",
+          }),
+        }),
+      );
+
+    insertApplyLease("github-run-7001-1-42");
+    assert.equal((await acquire()).status, 200);
+    storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+
+    insertApplyLease("github-run-7002-1-43");
+    const active = await acquire();
+    assert.equal(active.status, 409);
+    assert.equal((await active.json()).error, "mutation_busy");
+    storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+
+    insertApplyLease("local-process-without-run");
+    const unknown = await acquire();
+    assert.equal(unknown.status, 409);
+    assert.equal((await unknown.json()).error, "mutation_busy");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("exact-review claims advance generations only for newer run attempts", async () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3964,6 +3964,7 @@ test("exact-review terminal callbacks release matching review mutation leases", 
 
 test("exact-review mutation acquire reclaims only terminal apply owners", async () => {
   const originalFetch = globalThis.fetch;
+  let terminalReadHook: (() => void | Promise<void>) | undefined;
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -3982,6 +3983,8 @@ test("exact-review mutation acquire reclaims only terminal apply owners", async 
       return jsonResponse({ id: 7001, run_attempt: 1, status: "completed" });
     }
     if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/7001/attempts/1") {
+      await terminalReadHook?.();
+      terminalReadHook = undefined;
       return jsonResponse({ id: 7001, run_attempt: 1, status: "completed", conclusion: "failure" });
     }
     if (url.pathname === "/repos/openclaw/clawsweeper/actions/runs/7002") {
@@ -4015,7 +4018,7 @@ test("exact-review mutation acquire reclaims only terminal apply owners", async 
         Date.now(),
         Date.now(),
       );
-    const acquire = () =>
+    const acquire = (purpose: "review" | "apply" = "review") =>
       queue.fetch(
         new Request("https://clawsweeper-exact-review-queue/mutation/acquire", {
           method: "POST",
@@ -4024,14 +4027,51 @@ test("exact-review mutation acquire reclaims only terminal apply owners", async 
             generation: 1,
             operation_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
             owner: "github-run-7003-1",
-            purpose: "review",
+            purpose,
           }),
         }),
       );
 
     insertApplyLease("github-run-7001-1-42");
+    terminalReadHook = () => {
+      storage.sql.exec(
+        "UPDATE exact_review_generations SET generation = 2, updated_at = ? WHERE item_key = ?",
+        Date.now(),
+        itemKey,
+      );
+    };
+    const superseded = await acquire();
+    assert.equal(superseded.status, 409);
+    assert.equal((await superseded.json()).error, "generation_superseded");
+    assert.equal(
+      Array.from(
+        storage.sql.exec(
+          "SELECT owner FROM exact_review_mutation_leases WHERE item_key = ?",
+          itemKey,
+        ),
+      )[0].owner,
+      "github-run-7001-1-42",
+    );
+    storage.sql.exec(
+      "UPDATE exact_review_generations SET generation = 1, updated_at = ? WHERE item_key = ?",
+      Date.now(),
+      itemKey,
+    );
     assert.equal((await acquire()).status, 200);
     storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+
+    insertApplyLease("github-run-7001-1-42");
+    terminalReadHook = async () => {
+      await storage.put("exact-review-queue", {
+        deliveries: {},
+        items: { [itemKey]: leasedExactReviewQueueItem(629, "6290") },
+      });
+    };
+    const reviewActive = await acquire("apply");
+    assert.equal(reviewActive.status, 409);
+    assert.equal((await reviewActive.json()).error, "review_active");
+    storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+    await storage.put("exact-review-queue", { deliveries: {}, items: {} });
 
     insertApplyLease("github-run-7002-1-43");
     const active = await acquire();

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3756,7 +3756,7 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
     items: Record<string, { state: string; generation?: number; parkedReason?: string }>;
   };
   assert.equal(mutationBlocked.items[idleItemKey].state, "parked");
-  assert.equal(mutationBlocked.items[idleItemKey].generation, 1);
+  assert.equal(mutationBlocked.items[idleItemKey].generation, 2);
   assert.equal(mutationBlocked.items[idleItemKey].parkedReason, "mutation_active");
   assert.equal(
     Array.from(
@@ -3765,7 +3765,7 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
         idleItemKey,
       ),
     )[0].generation,
-    1,
+    2,
   );
   const reviewWhileApplyMutates = await mutationRequest("/mutation/acquire", {
     ...applyTuple,
@@ -3773,13 +3773,13 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
     operation_id: "66666666-6666-4666-8666-666666666666",
   });
   assert.equal(reviewWhileApplyMutates.status, 409);
-  assert.equal((await reviewWhileApplyMutates.json()).error, "mutation_busy");
+  assert.equal((await reviewWhileApplyMutates.json()).error, "generation_superseded");
   assert.equal((await mutationRequest("/mutation/release", applyTuple)).status, 200);
   const resumed = (await storage.get("exact-review-queue")) as {
     items: Record<string, { state: string; generation?: number; parkedReason?: string }>;
   };
   assert.equal(resumed.items[idleItemKey].state, "pending");
-  assert.equal(resumed.items[idleItemKey].generation, 2);
+  assert.equal(resumed.items[idleItemKey].generation, 3);
   assert.equal(resumed.items[idleItemKey].parkedReason, undefined);
   assert.equal(
     Array.from(
@@ -3788,7 +3788,7 @@ test("exact-review protocol v3 supersedes only the same item generation and fenc
         idleItemKey,
       ),
     )[0].generation,
-    2,
+    3,
   );
   assert.equal(
     (
@@ -4142,6 +4142,31 @@ test("exact-review mutation acquire reclaims only terminal apply owners", async 
     assert.equal(unknown.status, 409);
     assert.equal((await unknown.json()).error, "mutation_busy");
     storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+
+    const stalePublication = leasedExactReviewPublicationItem(629, "6999");
+    await storage.put("exact-review-queue", {
+      deliveries: {},
+      items: { [stalePublication.key]: stalePublication },
+    });
+    assert.equal((await acquire("apply")).status, 200);
+    assert.equal(
+      Array.from(
+        storage.sql.exec(
+          "SELECT generation FROM exact_review_generations WHERE item_key = ?",
+          itemKey,
+        ),
+      )[0].generation,
+      2,
+    );
+    const stalePublicationPermit = await acquire();
+    assert.equal(stalePublicationPermit.status, 409);
+    assert.equal((await stalePublicationPermit.json()).error, "generation_superseded");
+    storage.sql.exec("DELETE FROM exact_review_mutation_leases WHERE item_key = ?", itemKey);
+    storage.sql.exec(
+      "UPDATE exact_review_generations SET generation = 1, updated_at = ? WHERE item_key = ?",
+      Date.now(),
+      itemKey,
+    );
 
     const parked = unclaimedExactReviewQueueItem(629);
     Object.assign(parked, {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1312,6 +1312,41 @@ test("parseTrustedAutomation accepts only trusted ClawSweeper repair signals", (
   );
 });
 
+test("parseTrustedAutomation ignores durable review refresh projections", async () => {
+  const { renderDurableReviewRefreshProjection, renderInterruptedDurableReviewProjection } =
+    await import("../../dist/review-comment-status.js");
+  const trustedAuthors = new Set(["clawsweeper[bot]"]);
+  const projection = renderDurableReviewRefreshProjection(
+    [
+      "Codex review: needs changes before merge.",
+      "",
+      "- **[P1] Old finding:** must not trigger repair while stale.",
+      "",
+      "<!-- clawsweeper-verdict:needs-changes item=42 -->",
+      "<!-- clawsweeper-action:fix-required item=42 -->",
+      "<!-- clawsweeper-review item=42 -->",
+    ].join("\n"),
+    {
+      itemNumber: 42,
+      targetRevision: "0123456789abcdef0123456789abcdef01234567",
+      startedAt: "2026-07-17T03:50:00.000Z",
+      leaseOwner: "github-run-123-1",
+      leaseCommentId: 987,
+    },
+  );
+  assert.ok(projection);
+  const comment = { user: { login: "clawsweeper[bot]" }, body: projection };
+  assert.equal(parseTrustedAutomation(comment, { trustedAuthors }), null);
+  const interrupted = renderInterruptedDurableReviewProjection(projection, {
+    itemNumber: 42,
+    targetRevision: "0123456789abcdef0123456789abcdef01234567",
+    leaseOwner: "github-run-123-1",
+    leaseCommentId: 987,
+  });
+  assert.ok(interrupted);
+  assert.equal(parseTrustedAutomation({ ...comment, body: interrupted }, { trustedAuthors }), null);
+});
+
 test("parseRoutedCommentCommand ignores proof-nudge marker comments", () => {
   const trustedAuthors = new Set(["clawsweeper[bot]"]);
   const comment = {

--- a/test/repair/exact-review-bundle.test.ts
+++ b/test/repair/exact-review-bundle.test.ts
@@ -72,6 +72,30 @@ test("exact review bundle binds immutable workflow and queue context", () => {
   );
 });
 
+test("exact review bundle binds protocol v3 generation and operation identity", () => {
+  const value = fixture();
+  const context: ExactReviewBundleContext = {
+    ...value.context,
+    protocolVersion: 3,
+    generation: 9,
+    operationId: "11111111-1111-4111-8111-111111111111",
+  };
+  const created = createExactReviewBundle({
+    bundleDir: value.bundleDir,
+    reviewPath: value.report,
+    createdAt: "2026-07-15T12:00:00Z",
+    context,
+  });
+
+  assert.equal(created.queue.generation, 9);
+  assert.equal(created.queue.operation_id, context.operationId);
+  assert.deepEqual(validateExactReviewBundle(value.bundleDir, context), created);
+  assert.throws(
+    () => validateExactReviewBundle(value.bundleDir, { ...context, generation: 10 }),
+    /trusted workflow context/,
+  );
+});
+
 test("exact review bundle rejects redirected and modified publication", () => {
   const value = fixture();
   createExactReviewBundle({

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -183,7 +183,7 @@ test("structural cache probes before hydration but acquires a lease before carry
   const workflow = readFileSync(".github/workflows/sweep.yml", "utf8");
   assert.match(
     workflow,
-    /review-artifacts\/shard-\$\{\{ matrix\.shard \}\}\/review-cache-metrics\.json/,
+    /review-artifacts\/item-\$\{\{ matrix\.item_number \}\}\/review-cache-metrics\.json/,
   );
 });
 
@@ -303,8 +303,8 @@ test("spoofed durable markers cannot suppress a bot-owned start lease", () => {
   assert.match(postStart, /projectExistingDurableReviewForLease\(\{/);
   assert.match(postStart, /durable_review_refresh/);
   assert.match(postStart, /renderInterruptedDurableReviewProjection/);
-  assert.match(postStart, /If-Match/);
-  assert.match(postStart, /precondition failed/);
+  assert.doesNotMatch(postStart, /`If-Match:/);
+  assert.match(postStart, /per-item mutation permit/);
 });
 
 test("review start status comment is marker-backed and crustacean-friendly", () => {

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -300,6 +300,11 @@ test("spoofed durable markers cannot suppress a bot-owned start lease", () => {
   assert.match(postStart, /heldReviewStartStatusCommentResult\(initialLease\.expiresAt, false\)/);
   assert.match(postStart, /heldReviewStartStatusCommentResult\(winner\.expiresAt, true\)/);
   assert.match(postStart, /issues\/\$\{options\.item\.number\}\/comments/);
+  assert.match(postStart, /projectExistingDurableReviewForLease\(\{/);
+  assert.match(postStart, /durable_review_refresh/);
+  assert.match(postStart, /renderInterruptedDurableReviewProjection/);
+  assert.match(postStart, /If-Match/);
+  assert.match(postStart, /precondition failed/);
 });
 
 test("review start status comment is marker-backed and crustacean-friendly", () => {

--- a/test/review-comment-status.test.ts
+++ b/test/review-comment-status.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseDurableReviewStatusProjection,
+  renderDurableReviewRefreshProjection,
+  renderInterruptedDurableReviewProjection,
+} from "../dist/review-comment-status.js";
+
+const options = {
+  itemNumber: 74453,
+  targetRevision: "0123456789abcdef0123456789abcdef01234567",
+  startedAt: "2026-07-17T03:50:00.000Z",
+  leaseOwner: "github-run-123-1",
+  leaseCommentId: 987,
+  previousReviewedAt: "2026-07-16T12:00:00.000Z",
+  previousSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  workflowUrl: "https://github.com/openclaw/clawsweeper/actions/runs/123",
+};
+
+function previousReview(): string {
+  return [
+    "Codex review: needs changes before merge.",
+    "",
+    "**Review findings**",
+    "- [P1] Fix the stale cache",
+    "",
+    "<details>",
+    "<summary>Review history (1 earlier review cycle)</summary>",
+    "",
+    "<!-- clawsweeper-review-history v=1 total=1 -->",
+    "- reviewed 2026-07-15T10:00:00.000Z sha bbb222 :: passed. :: none",
+    "",
+    "</details>",
+    "",
+    "<!-- clawsweeper-verdict:needs-changes item=74453 sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->",
+    "<!-- clawsweeper-action:fix-required item=74453 -->",
+    "<!-- clawsweeper-security:security-sensitive item=74453 -->",
+    "<!-- clawsweeper-review-version item=74453 reviewed_at=2026-07-16T12:00:00.000Z v=1 -->",
+    "<!-- clawsweeper-review item=74453 -->",
+  ].join("\n");
+}
+
+test("refresh projection visibly stales the previous review without actionable markers", () => {
+  const body = renderDurableReviewRefreshProjection(previousReview(), options);
+  assert.ok(body);
+  assert.match(body, /Fresh ClawSweeper review in progress/);
+  assert.match(body, /Previous review \(stale while refresh runs\)/);
+  assert.match(body, /Started 2026-07-17T03:50:00.000Z/);
+  assert.match(body, /View workflow/);
+  assert.match(body, /clawsweeper-review-history/);
+  assert.doesNotMatch(body, /clawsweeper-verdict:/);
+  assert.doesNotMatch(body, /clawsweeper-action:/);
+  assert.doesNotMatch(body, /clawsweeper-security:/);
+  assert.doesNotMatch(body, /clawsweeper-review-version/);
+  assert.equal(body.match(/<!-- clawsweeper-review item=74453 -->/g)?.length, 1);
+
+  const parsed = parseDurableReviewStatusProjection(body, 74453);
+  assert.equal(parsed?.state, "refreshing");
+  assert.equal(parsed?.previousReviewedAt, options.previousReviewedAt);
+  assert.equal(parsed?.previousSha, options.previousSha);
+});
+
+test("refresh projection unwraps an existing projection instead of nesting it", () => {
+  const first = renderDurableReviewRefreshProjection(previousReview(), options);
+  assert.ok(first);
+  const second = renderDurableReviewRefreshProjection(first, {
+    ...options,
+    targetRevision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    leaseCommentId: 988,
+  });
+  assert.ok(second);
+  assert.equal(second.match(/clawsweeper-review-previous:start/g)?.length, 1);
+  assert.equal(
+    parseDurableReviewStatusProjection(second)?.previousDigest,
+    parseDurableReviewStatusProjection(first)?.previousDigest,
+  );
+});
+
+test("parser rejects malformed, mismatched, and forged projections", () => {
+  const body = renderDurableReviewRefreshProjection(previousReview(), options);
+  assert.ok(body);
+  assert.equal(parseDurableReviewStatusProjection(body, 1), null);
+  assert.equal(
+    parseDurableReviewStatusProjection(body.replace("Fix the stale cache", "Forged")),
+    null,
+  );
+  assert.equal(parseDurableReviewStatusProjection("ordinary prose"), null);
+});
+
+test("marker-like prior prose cannot forge projection delimiters", () => {
+  const body = renderDurableReviewRefreshProjection(
+    `${previousReview()}\n\nSpoof <!-- clawsweeper-review-previous:end v=1 -->`,
+    options,
+  );
+  assert.ok(body);
+  assert.equal(body.match(/clawsweeper-review-previous:end/g)?.length, 1);
+  assert.ok(parseDurableReviewStatusProjection(body));
+});
+
+test("interrupted transition is tuple-bound and keeps the stale prior review inert", () => {
+  const refreshing = renderDurableReviewRefreshProjection(previousReview(), options);
+  assert.ok(refreshing);
+  assert.equal(
+    renderInterruptedDurableReviewProjection(refreshing, {
+      itemNumber: options.itemNumber,
+      leaseOwner: options.leaseOwner,
+      leaseCommentId: 999,
+      targetRevision: options.targetRevision,
+    }),
+    null,
+  );
+  const interrupted = renderInterruptedDurableReviewProjection(refreshing, options);
+  assert.ok(interrupted);
+  assert.match(interrupted, /was interrupted/);
+  assert.equal(parseDurableReviewStatusProjection(interrupted)?.state, "interrupted");
+  assert.doesNotMatch(interrupted, /clawsweeper-verdict:/);
+});
+
+test("over-limit prior reviews produce a bounded inert projection", () => {
+  const body = renderDurableReviewRefreshProjection(
+    `Codex review: passed.\n${"x".repeat(70_000)}\n<!-- clawsweeper-verdict:pass -->`,
+    options,
+  );
+  assert.ok(body);
+  assert.ok(Buffer.byteLength(body, "utf8") <= 65_536);
+  assert.match(body, /Previous review truncated/);
+  assert.doesNotMatch(body, /clawsweeper-verdict:/);
+  assert.ok(parseDurableReviewStatusProjection(body));
+});

--- a/test/review-history.test.ts
+++ b/test/review-history.test.ts
@@ -19,6 +19,7 @@ import {
   renderReviewCommentFromReport,
 } from "../dist/clawsweeper.js";
 import { reviewSemanticPriorReviewDigest } from "../dist/review-semantic-cache.js";
+import { renderDurableReviewRefreshProjection } from "../dist/review-comment-status.js";
 import {
   changelogReviewDecision,
   markedReviewCommentForTest,
@@ -564,6 +565,27 @@ test("keep-open PR comment carries the previous review as an earlier cycle", () 
   assert.equal(parsed.cycles.length, 1);
 });
 
+test("publishing after a refresh projection carries the displaced review exactly once", () => {
+  const projection = renderDurableReviewRefreshProjection(previousDurableComment(), {
+    itemNumber: 101,
+    targetRevision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    startedAt: "2026-07-17T03:50:00.000Z",
+    leaseOwner: "github-run-123-1",
+    leaseCommentId: 987,
+    previousReviewedAt: "2026-06-20T10:00:00.000Z",
+    previousSha: "abc1234def",
+  });
+  assert.ok(projection);
+  const comment = renderReviewCommentFromReport(keepOpenPullReport(), "none", {
+    prStatusKind: "ready_for_maintainer_look",
+    previousReviewCommentBody: projection,
+  });
+  const parsed = parseReviewHistory(comment);
+  assert.equal(parsed.totalCompletedCycles, 1);
+  assert.equal(parsed.cycles.length, 1);
+  assert.equal(parsed.cycles[0]?.sha, "abc1234def");
+});
+
 test("re-syncing the same review does not add a duplicate cycle", () => {
   const reviewedAt = "2026-06-24T12:00:00.000Z";
   const comment = renderReviewCommentFromReport(
@@ -665,6 +687,46 @@ test("latest review extraction exposes earlier cycles and a cycle count", () => 
   assert.equal(review?.earlierReviewCycles.length, 1);
   assert.equal(review?.earlierReviewCycles[0]?.sha, "aaa111");
   assert.deepEqual(review?.findings, [
+    { priority: "P1", title: "Drop the stale cache before rebuild" },
+  ]);
+});
+
+test("refresh projections preserve prior review identity and history context", () => {
+  const previousBody = previousDurableComment({
+    reviewedAt: "2026-06-20T10:00:00.000Z",
+    sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  });
+  const projection = renderDurableReviewRefreshProjection(previousBody, {
+    itemNumber: 101,
+    targetRevision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    startedAt: "2026-07-17T03:50:00.000Z",
+    leaseOwner: "github-run-123-1",
+    leaseCommentId: 987,
+    previousReviewedAt: "2026-06-20T10:00:00.000Z",
+    previousSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  });
+  assert.ok(projection);
+  const review = extractLatestClawSweeperReviewForTest(
+    [
+      {
+        id: 11,
+        user: { login: "clawsweeper" },
+        body: projection,
+        created_at: "2026-06-20T10:05:00Z",
+        updated_at: "2026-07-17T03:50:00Z",
+      },
+    ],
+    101,
+  );
+  assert.ok(review);
+  assert.equal(
+    review.verdictDigest,
+    createHash("sha256").update(previousBody.trim()).digest("hex"),
+  );
+  assert.equal(review.reviewedAt, "2026-06-20T10:00:00.000Z");
+  assert.equal(review.reviewedSha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  assert.equal(review.completedReviewCycles, 1);
+  assert.deepEqual(review.findings, [
     { priority: "P1", title: "Drop the stale cache before rebuild" },
   ]);
 });

--- a/test/review-item-telemetry.test.ts
+++ b/test/review-item-telemetry.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import {
@@ -87,4 +89,15 @@ test("review telemetry heartbeat advances total wall-clock duration", () => {
   );
 
   assert.deepEqual(record.phase_durations_ms, { total: 2_000, queue: 120, review: 900 });
+});
+
+test("review telemetry CLI warns and reports a failed optional write", () => {
+  const script = fileURLToPath(new URL("../scripts/review-item-telemetry.mjs", import.meta.url));
+  const result = spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    env: {},
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /::warning::Review telemetry producer skipped:/);
 });

--- a/test/review-item-telemetry.test.ts
+++ b/test/review-item-telemetry.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildReviewTelemetryRecord,
+  reviewTelemetryAttribution,
+} from "../scripts/review-item-telemetry.mjs";
+
+test("review telemetry producer attributes all review lanes independently", () => {
+  assert.deepEqual(
+    reviewTelemetryAttribution({
+      exact: true,
+      sourceEvent: "pull_request",
+      eventName: "repository_dispatch",
+    }),
+    { lane: "exact_event", origin: "webhook" },
+  );
+  assert.deepEqual(reviewTelemetryAttribution({ hotIntake: true, eventName: "schedule" }), {
+    lane: "hot_intake",
+    origin: "schedule",
+  });
+  assert.deepEqual(reviewTelemetryAttribution({ eventName: "schedule" }), {
+    lane: "normal_backfill",
+    origin: "schedule",
+  });
+  assert.deepEqual(reviewTelemetryAttribution({ sourceAction: "failed_review_shard_recovery" }), {
+    lane: "recovery",
+    origin: "system",
+  });
+});
+
+test("review telemetry terminal preserves identity, start time, and accumulated phases", () => {
+  const existing = {
+    started_at: "2026-07-19T00:00:00.000Z",
+    phase_durations_ms: { queue: 120, claim: 40, review: 900 },
+  };
+  const record = buildReviewTelemetryRecord(
+    {
+      action: "terminal",
+      repo: "openclaw/clawsweeper",
+      itemNumber: 674,
+      runId: "123",
+      runAttempt: 2,
+      generation: 7,
+      operationId: "operation-12345678901234567890",
+      triggerLane: "exact_event",
+      triggerOrigin: "command",
+      sourceEvent: "issue_comment",
+      sourceAction: "review_command",
+      outcome: "superseded",
+      terminalReason: "generation_superseded",
+      phaseDurations: { publication: 300 },
+    },
+    existing,
+    new Date("2026-07-19T00:00:02.000Z"),
+  );
+  assert.equal(record.status, "completed");
+  assert.equal(record.started_at, existing.started_at);
+  assert.equal(record.outcome, "superseded");
+  assert.equal(record.terminal_reason, "generation_superseded");
+  assert.deepEqual(record.phase_durations_ms, {
+    queue: 120,
+    claim: 40,
+    review: 900,
+    publication: 300,
+    total: 2_000,
+  });
+});
+
+test("review telemetry heartbeat advances total wall-clock duration", () => {
+  const record = buildReviewTelemetryRecord(
+    {
+      action: "heartbeat",
+      repo: "openclaw/clawsweeper",
+      itemNumber: 674,
+      runId: "123",
+      runAttempt: 2,
+      triggerLane: "normal_backfill",
+      triggerOrigin: "schedule",
+      phaseDurations: { review: 900 },
+    },
+    {
+      started_at: "2026-07-19T00:00:00.000Z",
+      phase_durations_ms: { total: 1, queue: 120 },
+    },
+    new Date("2026-07-19T00:00:02.000Z"),
+  );
+
+  assert.deepEqual(record.phase_durations_ms, { total: 2_000, queue: 120, review: 900 });
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2397,6 +2397,38 @@ test("per-item review jobs expose setup, runner, and cancellation metrics", () =
   assert.match(reviewJob, /cancel-in-progress: false/);
 });
 
+test("review producers publish attributed immutable item telemetry", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<
+      string,
+      { steps: Array<{ name?: string; run?: string; env?: Record<string, string>; if?: string }> }
+    >;
+  };
+  const namedStep = (jobName: string, name: string) => {
+    const value = workflow.jobs[jobName]?.steps.find((candidate) => candidate.name === name);
+    assert.ok(value, `missing ${jobName} step ${name}`);
+    return value;
+  };
+  const exactStart = namedStep("event-review-apply", "Start exact item review telemetry");
+  const exactTerminal = namedStep("event-review-publish", "Complete exact item review telemetry");
+  const matrixStart = namedStep("review", "Start matrix item review telemetry");
+  const matrixTerminal = namedStep("publish", "Complete matrix item review telemetry");
+
+  assert.equal(exactStart.env?.REVIEW_TELEMETRY_EXACT, "true");
+  assert.match(exactStart.if ?? "", /always\(\)/);
+  assert.match(exactStart.env?.REVIEW_TELEMETRY_GENERATION ?? "", /claim-exact-review-queue/);
+  assert.match(exactStart.env?.REVIEW_TELEMETRY_OPERATION_ID ?? "", /claim-exact-review-queue/);
+  assert.match(exactTerminal.run ?? "", /generation_superseded/);
+  assert.match(exactTerminal.run ?? "", /workflow_cancelled/);
+  assert.match(matrixStart.env?.REVIEW_TELEMETRY_HOT_INTAKE ?? "", /needs\.plan\.outputs/);
+  assert.match(matrixStart.env?.REVIEW_TELEMETRY_OPERATION_ID ?? "", /matrix-/);
+  assert.match(matrixTerminal.run ?? "", /publication_applied/);
+  assert.match(matrixTerminal.run ?? "", /publication_failed/);
+  for (const producer of [exactStart, exactTerminal, matrixStart, matrixTerminal]) {
+    assert.match(producer.run ?? "", /review-item-telemetry\.mjs/);
+  }
+});
+
 test("planned background reviews allow safe content-cache reuse without weakening exact reviews", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const eventReviewJobStart = workflow.indexOf("\n  event-review-apply:");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -360,6 +360,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.equal(reviewer.permissions?.contents, "read");
   assert.equal(reviewer["timeout-minutes"], 120);
   assert.equal(reviewer.permissions?.issues, "read");
+  assert.equal(publisher.concurrency, undefined);
   assert.equal(
     reviewer.steps.some((candidate) => candidate.uses?.endsWith("/setup-state")),
     false,
@@ -434,8 +435,6 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
     step(publisher, "Claim durable exact review publication").run ?? "",
     /internal\/exact-review\/claim/,
   );
-  assert.equal(publisher.concurrency?.["cancel-in-progress"], false);
-  assert.match(publisher.concurrency?.group ?? "", /clawsweeper-mutation-/);
   assert.equal(publisher.permissions?.actions, "write");
   assert.equal(
     batchPublisher.concurrency?.group,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -482,6 +482,8 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(mutationPermit.run ?? "", /generation_superseded|mutation_busy/);
   assert.match(publish.if ?? "", /mutation-permit\.outputs\.acquired == 'true'/);
   assert.match(mutationRelease.run ?? "", /internal\/exact-review\/mutation\/release/);
+  assert.match(mutationRelease.run ?? "", /mutation_not_owned/);
+  assert.match(mutationRelease.run ?? "", /--write-out '%\{http_code\}'/);
   assert.ok(publisher.steps.indexOf(mutationPermit) < publisher.steps.indexOf(publish));
   assert.match(publish.run ?? "", /live_state=.*gh api/);
   assert.match(publish.run ?? "", /LIVE_TERMINAL_NOOP.*LIVE_TERMINAL_MISSING/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -478,12 +478,15 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   const publish = step(publisher, "Publish event result and apply safe close");
   const mutationPermit = step(publisher, "Acquire generation-bound mutation permit");
   const mutationRelease = step(publisher, "Release generation-bound mutation permit");
+  const publicationTelemetry = step(publisher, "Complete exact item review telemetry");
   assert.match(mutationPermit.run ?? "", /internal\/exact-review\/mutation\/acquire/);
   assert.match(mutationPermit.run ?? "", /generation_superseded|mutation_busy/);
   assert.match(publish.if ?? "", /mutation-permit\.outputs\.acquired == 'true'/);
   assert.match(mutationRelease.run ?? "", /internal\/exact-review\/mutation\/release/);
   assert.match(mutationRelease.run ?? "", /mutation_not_owned/);
   assert.match(mutationRelease.run ?? "", /--write-out '%\{http_code\}'/);
+  assert.match(publicationTelemetry.run ?? "", /completion_kind.*retryable_failure/);
+  assert.match(publicationTelemetry.run ?? "", /REVIEW_TELEMETRY_ACTION=heartbeat/);
   assert.ok(publisher.steps.indexOf(mutationPermit) < publisher.steps.indexOf(publish));
   assert.match(publish.run ?? "", /live_state=.*gh api/);
   assert.match(publish.run ?? "", /LIVE_TERMINAL_NOOP.*LIVE_TERMINAL_MISSING/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2399,7 +2399,7 @@ test("per-item review jobs expose setup, runner, and cancellation metrics", () =
   assert.match(reviewJob, /rm -rf "\.\.\/review-artifacts\/item-/);
   assert.match(
     reviewJob,
-    /group: clawsweeper-review-\$\{\{ matrix\.repo \}\}-\$\{\{ matrix\.item_number \}\}/,
+    /group: clawsweeper-background-review-\$\{\{ matrix\.repo \}\}-\$\{\{ matrix\.item_number \}\}/,
   );
   assert.match(reviewJob, /cancel-in-progress: false/);
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -481,6 +481,8 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   const publicationTelemetry = step(publisher, "Complete exact item review telemetry");
   assert.match(mutationPermit.run ?? "", /internal\/exact-review\/mutation\/acquire/);
   assert.match(mutationPermit.run ?? "", /generation_superseded|mutation_busy/);
+  assert.match(mutationPermit.run ?? "", /\|\| status="000"/);
+  assert.match(mutationPermit.run ?? "", /publication will retry/);
   assert.match(publish.if ?? "", /mutation-permit\.outputs\.acquired == 'true'/);
   assert.match(mutationRelease.run ?? "", /internal\/exact-review\/mutation\/release/);
   assert.match(mutationRelease.run ?? "", /mutation_not_owned/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -489,6 +489,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(mutationRelease.run ?? "", /--write-out '%\{http_code\}'/);
   assert.match(publicationTelemetry.run ?? "", /completion_kind.*retryable_failure/);
   assert.match(publicationTelemetry.run ?? "", /REVIEW_TELEMETRY_ACTION=heartbeat/);
+  assert.equal(publicationTelemetry.env?.REVIEW_TELEMETRY_LEASE_MS, "7200000");
   assert.ok(publisher.steps.indexOf(mutationPermit) < publisher.steps.indexOf(publish));
   assert.match(publish.run ?? "", /live_state=.*gh api/);
   assert.match(publish.run ?? "", /LIVE_TERMINAL_NOOP.*LIVE_TERMINAL_MISSING/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -434,7 +434,8 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
     step(publisher, "Claim durable exact review publication").run ?? "",
     /internal\/exact-review\/claim/,
   );
-  assert.equal(publisher.concurrency, undefined);
+  assert.equal(publisher.concurrency?.["cancel-in-progress"], false);
+  assert.match(publisher.concurrency?.group ?? "", /clawsweeper-mutation-/);
   assert.equal(publisher.permissions?.actions, "write");
   assert.equal(
     batchPublisher.concurrency?.group,
@@ -475,6 +476,13 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(stateSetup.if ?? "", /legacy-exact-artifact\.outputs\.legacy_tupleless != 'true'/);
 
   const publish = step(publisher, "Publish event result and apply safe close");
+  const mutationPermit = step(publisher, "Acquire generation-bound mutation permit");
+  const mutationRelease = step(publisher, "Release generation-bound mutation permit");
+  assert.match(mutationPermit.run ?? "", /internal\/exact-review\/mutation\/acquire/);
+  assert.match(mutationPermit.run ?? "", /generation_superseded|mutation_busy/);
+  assert.match(publish.if ?? "", /mutation-permit\.outputs\.acquired == 'true'/);
+  assert.match(mutationRelease.run ?? "", /internal\/exact-review\/mutation\/release/);
+  assert.ok(publisher.steps.indexOf(mutationPermit) < publisher.steps.indexOf(publish));
   assert.match(publish.run ?? "", /live_state=.*gh api/);
   assert.match(publish.run ?? "", /LIVE_TERMINAL_NOOP.*LIVE_TERMINAL_MISSING/);
   assert.match(publish.run ?? "", /LIVE_GUARDED_OPEN/);
@@ -550,6 +558,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.env?.DOWNLOAD_OUTCOME ?? "", /download-exact-review-bundle/);
   assert.match(publishResult.env?.VALIDATE_OUTCOME ?? "", /validate-exact-review-bundle/);
   assert.match(publishResult.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
+  assert.match(publishResult.env?.MUTATION_REASON ?? "", /mutation-permit/);
   assert.match(publicationPressure.if ?? "", /failure\(\)/);
   assert.match(publicationPressure.run ?? "", /gh api rate_limit/);
   assert.match(publicationPressure.run ?? "", /failure_kind=github_rate_limit/);
@@ -561,6 +570,9 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.run ?? "", /completion_kind=superseded/);
   assert.match(publishResult.run ?? "", /completion_kind=deferred/);
   assert.match(publishResult.run ?? "", /completion_kind=refresh_required/);
+  assert.match(publishResult.run ?? "", /MUTATION_REASON.*generation_superseded/);
+  assert.match(publishResult.run ?? "", /completion_kind=retryable_failure/);
+  assert.match(publishResult.run ?? "", /reason_code=mutation_busy/);
   assert.match(publishResult.run ?? "", /reason_code=close_coverage_retry/);
   assert.match(publishResult.run ?? "", /reason_code=close_coverage_deferred/);
   assert.match(
@@ -632,7 +644,12 @@ test("exact event workflow binds all work to the canonical queue claim", () => {
   assert.match(claimStep, /response\.item_key !== requestedItemKey/);
   assert.match(claimStep, /response\.lease_revision !== requestedLeaseRevision/);
   assert.match(claimStep, /const itemKey = `\$\{targetRepo\}#\$\{itemNumber\}`/);
-  assert.match(claimStep, /claim_generation=\$\{responseProtocol === 2 \? claimGeneration : ""\}/);
+  assert.match(claimStep, /claim_generation=\$\{responseProtocol >= 2 \? claimGeneration : ""\}/);
+  assert.match(claimStep, /generation=\$\{responseProtocol === 3 \? response\.generation : ""\}/);
+  assert.match(
+    claimStep,
+    /operation_id=\$\{responseProtocol === 3 \? response\.operation_id : ""\}/,
+  );
   assert.match(claimStep, /protocol_version=\$\{responseProtocol\}/);
   assert.match(claimStep, /decision=\$\{JSON\.stringify\(decision\)\}/);
   assert.doesNotMatch(claimedWork, /github\.event\.client_payload/);
@@ -753,7 +770,7 @@ test("exact-review lease competition skips only known conflicts and gates both o
   }
 });
 
-test("exact event workflow keeps both queue protocol versions live during rolling deploys", () => {
+test("exact event workflow keeps queue protocol v1-v3 live during rolling deploys", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const eventStart = workflow.indexOf("\n  event-review-apply:");
   const eventEnd = workflow.indexOf("\n  target-fanout:", eventStart);
@@ -770,9 +787,13 @@ test("exact event workflow keeps both queue protocol versions live during rollin
   assert.match(claimStep, /const legacyDecision = \{/);
   assert.match(claimStep, /response\.decision && typeof response\.decision === "object"/);
   assert.match(claimStep, /reviewOptions\.command_status_marker/);
-  assert.match(claimStep, /responseProtocol === 2/);
-  assert.match(completeStep, /protocolVersion !== 1 && protocolVersion !== 2/);
-  assert.match(completeStep, /protocolVersion === 2/);
+  assert.match(claimStep, /responseProtocol !== 3/);
+  assert.match(
+    completeStep,
+    /protocolVersion !== 1 && protocolVersion !== 2 && protocolVersion !== 3/,
+  );
+  assert.match(completeStep, /protocolVersion >= 2/);
+  assert.match(completeStep, /protocolVersion === 3/);
   assert.match(completeStep, /: \{\}\),/);
 });
 
@@ -1996,7 +2017,7 @@ test("manual exact-item review dispatches reserve their live shard capacity", ()
 
   assert.match(
     workflow,
-    /github\.event_name == 'workflow_dispatch' && \(github\.event\.inputs\.item_number != '' \|\| github\.event\.inputs\.item_numbers != ''\)\) && format\('clawsweeper-intake-exact-\{0\}'/,
+    /github\.event_name == 'workflow_dispatch' && \(github\.event\.inputs\.item_number != '' \|\| github\.event\.inputs\.item_numbers != ''\)\) && format\('clawsweeper-intake-exact-run-\{0\}', github\.run_id\)/,
   );
   assert.doesNotMatch(
     workflow,
@@ -2354,6 +2375,28 @@ test("scheduled normal review uses one item per shard for lease coverage", () =>
   );
 });
 
+test("per-item review jobs expose setup, runner, and cancellation metrics", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const reviewJob = workflow.slice(
+    workflow.indexOf("\n  review:"),
+    workflow.indexOf("\n  requeue-source-revision-drift:"),
+  );
+
+  assert.match(reviewJob, /Mark item job start/);
+  assert.match(reviewJob, /item_job_setup_ms/);
+  assert.match(reviewJob, /runner_duration_ms/);
+  assert.match(reviewJob, /codex_cancel_latency_ms/);
+  assert.match(reviewJob, /cancelled_review_consumed_tokens/);
+  assert.match(reviewJob, /avoided_tokens/);
+  assert.match(reviewJob, /trap on_cancel TERM INT/);
+  assert.match(reviewJob, /rm -rf "\.\.\/review-artifacts\/item-/);
+  assert.match(
+    reviewJob,
+    /group: clawsweeper-review-\$\{\{ matrix\.repo_slug \}\}-\$\{\{ matrix\.item_number \}\}/,
+  );
+  assert.match(reviewJob, /cancel-in-progress: false/);
+});
+
 test("planned background reviews allow safe content-cache reuse without weakening exact reviews", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const eventReviewJobStart = workflow.indexOf("\n  event-review-apply:");
@@ -2371,7 +2414,7 @@ test("planned background reviews allow safe content-cache reuse without weakenin
   assert.match(reviewJob, /planned_automatic_review_arg=\(--planned-automatic-review\)/);
   assert.match(
     reviewJob,
-    /--item-numbers "\$\{\{ matrix\.item_numbers \}\}" \\\n+\s+"\$\{planned_automatic_review_arg\[@\]\}"/,
+    /--item-numbers "\$\{\{ matrix\.item_number \}\}" \\\n+\s+"\$\{planned_automatic_review_arg\[@\]\}"/,
   );
   assert.doesNotMatch(eventReviewJob, /--planned-automatic-review/);
 });
@@ -2391,14 +2434,14 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(eventBlock, /concurrency:/);
   assert.match(
     eventBlock,
-    /group: clawsweeper-event-review-\$\{\{ github\.event\.client_payload\.queue_claim\.item_key \|\| github\.event\.client_payload\.item_key \|\| github\.run_id \}\}/,
+    /group: clawsweeper-review-\$\{\{ github\.event\.client_payload\.repo_slug/,
   );
   assert.match(eventBlock, /queue_lease_id != ''/);
   assert.match(eventBlock, /item_key: process\.env\.ITEM_KEY/);
   assert.match(eventBlock, /lease_revision: leaseRevision/);
   assert.match(eventBlock, /claim_generation: claimGeneration/);
   assert.match(eventBlock, /decision=\$\{JSON\.stringify\(decision\)\}/);
-  assert.match(eventBlock, /cancel-in-progress: false/);
+  assert.match(eventBlock, /cancel-in-progress: true/);
   assert.match(legacyIntakeBlock, /legacy-event-queue-intake:/);
   assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
   assert.match(legacyIntakeBlock, /gh api "repos\/\$target_repo" --jq \.default_branch/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2392,7 +2392,7 @@ test("per-item review jobs expose setup, runner, and cancellation metrics", () =
   assert.match(reviewJob, /rm -rf "\.\.\/review-artifacts\/item-/);
   assert.match(
     reviewJob,
-    /group: clawsweeper-review-\$\{\{ matrix\.repo_slug \}\}-\$\{\{ matrix\.item_number \}\}/,
+    /group: clawsweeper-review-\$\{\{ matrix\.repo \}\}-\$\{\{ matrix\.item_number \}\}/,
   );
   assert.match(reviewJob, /cancel-in-progress: false/);
 });
@@ -2466,7 +2466,7 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(eventBlock, /concurrency:/);
   assert.match(
     eventBlock,
-    /group: clawsweeper-review-\$\{\{ github\.event\.client_payload\.repo_slug/,
+    /group: clawsweeper-review-\$\{\{ github\.event\.client_payload\.target_repo/,
   );
   assert.match(eventBlock, /queue_lease_id != ''/);
   assert.match(eventBlock, /item_key: process\.env\.ITEM_KEY/);


### PR DESCRIPTION
## Summary

- replace multi-item sequential review shards with one matrix job per selected item
- use per-item compute concurrency and generation-bound queue claims so newer exact reviews cancel only stale compute for the same item
- serialize durable publication, apply, and comment sync through a non-cancelling per-item mutation lane
- add protocol v3 rolling compatibility, terminal reconciliation, cancellation cleanup, and item-level cost/concurrency telemetry

This draft supersedes https://github.com/openclaw/clawsweeper/pull/645. It stays draft until the isolated canary and the two-item live validation complete.

## Why

The previous shard model reviewed several PRs sequentially in one long-running job. A new generation for one PR could not cancel only that PR's stale Codex work without also affecting unrelated items. The new execution unit is one item job, while the durable queue remains the cross-workflow admission and generation authority.

## Safety and compatibility

- `batch_size` is the total planner selection budget; `shard_count` maps to matrix `max-parallel`
- queue protocol v1/v2 claims remain non-preemptible during rollout and requeue onto the current v3 generation
- publication checks generation before GitHub mutation and acquires a generation-bound mutation permit
- mutation leases are never reclaimed by TTL; terminal queue reconciliation or a verified terminal GitHub Actions attempt releases abandoned ownership
- no live apply or close command is part of this validation

## Validation

- Node `v24.15.0`
- `pnpm run check`
- focused item-shard, queue, workflow, and bundle tests (291/291)
- `/data/code/openclaw/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
  - final result: clean, no accepted/actionable findings

## Draft exit criteria

- deploy an isolated canary Worker and Durable Object namespace with no production binding or data migration
- run a two-item batch using this PR and https://github.com/openclaw/clawsweeper/pull/646
- verify same-item generation cancellation, unaffected sibling work, durable handoff/comment identity, stale publication rejection, refreshing-to-interrupted behavior, terminal reconciliation, and telemetry evidence
