### PR TITLE
test(repair): model OpenClaw install-managed links

### DIFF
--- a/docs/repair/automerge-e2e.md
+++ b/docs/repair/automerge-e2e.md
@@ -35,8 +35,10 @@ Two target fixtures keep different failure signals independent:
   injection with the smallest real Git repository possible.
 - `openclaw-shaped` preserves the production repository contracts that affect
   repair: OpenClaw's pinned pnpm and Node range, workspace layout and links,
-  changed-surface gate, tracked policy symlink, release-owned changelog, and a
-  contributor branch that is behind current `main`.
+  tracked cross-workspace and package-bin links under `node_modules`, Git-mode
+  executable normalization, changed-surface gate, tracked policy symlink,
+  release-owned changelog, and a contributor branch that is behind current
+  `main`.
 
 Neither fixture clones the full OpenClaw repository. That keeps the required PR
 lane deterministic and bounded while still exercising the `openclaw/openclaw`
@@ -130,9 +132,10 @@ Across both target shapes, the scenarios cover the complete success path, a real
 dependency-install mutation, planning-to-execution head drift, pending checks
 that later turn green, stale exact-head verdicts, replay idempotency, and the
 reconstructed 2026-07-18 runtime-identity regression. The OpenClaw-shaped runs
-also prove a real workspace install/link graph, `check:changed` package routing,
-base ancestry synchronization, the `CLAUDE.md -> AGENTS.md` symlink, and
-`CHANGELOG.md` preservation.
+also prove a real workspace install/link graph, `check:changed` root-source routing,
+base ancestry synchronization, tracked workspace/bin links maintained by pnpm,
+Git-equivalent `0775 -> 0755` executable normalization, the
+`CLAUDE.md -> AGENTS.md` symlink, and `CHANGELOG.md` preservation.
 
 ## Exact 2026-07-18 CI regression
 
@@ -167,6 +170,19 @@ read-only into the clean image. To validate the image's current candidate fix
 against the same reconstructed setup, omit `--candidate-root` and `--expect`.
 A successful candidate must continue beyond dependency setup and reach the
 normal exact-head merge terminal state.
+
+The OpenClaw-shaped fixture also provides a direct before/after proof for the
+tracked workspace-link and executable-mode install contract. Point the same
+harness at a built pre-fix candidate to assert the exact failure without
+changing the fixture or treating a non-zero harness exit as success:
+
+```bash
+pnpm e2e:automerge:container -- \
+  --scenario happy-path \
+  --fixture openclaw-shaped \
+  --candidate-root /path/to/clawsweeper-before-fix \
+  --expect setup-identity-failure
+```
 
 ## Scenario contract
 

--- a/scripts/e2e/automerge-container.mjs
+++ b/scripts/e2e/automerge-container.mjs
@@ -27,7 +27,9 @@ Description:
 Options:
   --scenario <name>       Scenario name or all (default: all)
   --fixture <name>        tiny, openclaw-shaped, or all (default: all)
-  --expect <outcome>      success or setup-identity-failure (default: success)
+  --expect <outcome>      success or setup-identity-failure (default: success);
+                          failure proof supports the historical regression and
+                          openclaw-shaped happy-path
   --candidate-root <dir>  Built candidate checkout mounted read-only
   --output <dir>          Host artifact directory (default: test-results/automerge-container)
   --image <tag>           Local image tag (default: clawsweeper-automerge-e2e:local)
@@ -44,6 +46,8 @@ Examples:
   pnpm e2e:automerge:container -- --scenario planning-head-drift --fixture openclaw-shaped
   pnpm e2e:automerge:container -- --scenario ci-regression-29623139111 \\
     --candidate-root ../clawsweeper-ci-regression --expect setup-identity-failure
+  pnpm e2e:automerge:container -- --scenario happy-path --fixture openclaw-shaped \\
+    --candidate-root ../clawsweeper-before-fix --expect setup-identity-failure
 `);
   process.exit(0);
 }

--- a/scripts/e2e/automerge.mjs
+++ b/scripts/e2e/automerge.mjs
@@ -27,7 +27,9 @@ Options:
   --scenario <name>       Scenario to run; use all for the full suite
                           (default: happy-path)
   --fixture <name>        tiny, openclaw-shaped, or all (default: tiny)
-  --expect <outcome>      success or setup-identity-failure (default: success)
+  --expect <outcome>      success or setup-identity-failure (default: success);
+                          failure proof supports the historical regression and
+                          openclaw-shaped happy-path
   --list-scenarios        Print supported scenario names
   --list-fixtures         Print supported target fixture names
   --candidate-root <dir>  Built ClawSweeper checkout to validate (default: cwd)
@@ -43,6 +45,7 @@ Examples:
   pnpm e2e:automerge
   pnpm e2e:automerge -- --scenario all --fixture all --output test-results/automerge
   pnpm e2e:automerge -- --scenario ci-regression-29623139111 --candidate-root ../clawsweeper-ci-regression --expect setup-identity-failure
+  pnpm e2e:automerge -- --scenario happy-path --fixture openclaw-shaped --candidate-root ../clawsweeper-before-fix --expect setup-identity-failure
 `);
   process.exit(0);
 }

--- a/test/e2e/automerge/fake-codex.mjs
+++ b/test/e2e/automerge/fake-codex.mjs
@@ -54,6 +54,8 @@ function optionValue(name) {
 }
 
 function fixtureEditPath() {
+  const openClawRootFixture = path.join(process.cwd(), "src", "repair-target.txt");
+  if (fs.existsSync(openClawRootFixture)) return openClawRootFixture;
   const openClawShapedFixture = path.join(
     process.cwd(),
     "packages",
@@ -62,11 +64,9 @@ function fixtureEditPath() {
     "repair-target.txt",
   );
   if (fs.existsSync(openClawShapedFixture)) return openClawShapedFixture;
-  const minimalFixture = path.join(process.cwd(), "src", "repair-target.txt");
-  if (fs.existsSync(minimalFixture)) return minimalFixture;
   const ciRegressionFixture = path.join(process.cwd(), "src", "hooks", "gmail-watcher.ts");
   if (fs.existsSync(ciRegressionFixture)) return ciRegressionFixture;
-  return minimalFixture;
+  return openClawRootFixture;
 }
 
 function fail(message) {

--- a/test/e2e/automerge/fake-gh.mjs
+++ b/test/e2e/automerge/fake-gh.mjs
@@ -25,7 +25,15 @@ if (args[0] === "repo" && args[1] === "clone") {
   // Production `gh repo clone` transfers a complete repository. Avoid both a
   // shallow boundary and Git's local hardlink shortcut: either can make this
   // fixture exercise object-availability behavior that GitHub never creates.
-  git(["clone", "--no-local", state.remote, destination]);
+  // GitHub-hosted workspaces are group-writable. Recreate that checkout mode so
+  // a real pnpm install must normalize tracked executable files to Git's 0755
+  // semantics while maintaining tracked OpenClaw workspace/bin links.
+  const previousUmask = process.umask(0o002);
+  try {
+    git(["clone", "--no-local", state.remote, destination]);
+  } finally {
+    process.umask(previousUmask);
+  }
   const shallow = gitText(["-C", destination, "rev-parse", "--is-shallow-repository"]);
   if (shallow !== "false") fail(`target clone unexpectedly shallow: ${destination}`);
   process.exit(0);

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -37,8 +37,16 @@ export function runAutomergeE2E({
   if (!["success", "setup-identity-failure"].includes(expectedOutcome)) {
     throw new Error(`unsupported expected outcome: ${expectedOutcome}`);
   }
-  if (expectedOutcome !== "success" && scenario !== "ci-regression-29623139111") {
-    throw new Error(`${expectedOutcome} is only valid for ci-regression-29623139111`);
+  if (
+    expectedOutcome !== "success" &&
+    !(
+      scenario === "ci-regression-29623139111" ||
+      (scenario === "happy-path" && fixture === "openclaw-shaped")
+    )
+  ) {
+    throw new Error(
+      `${expectedOutcome} is only valid for ci-regression-29623139111 or the openclaw-shaped happy-path`,
+    );
   }
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-automerge-e2e-"));
   const artifacts = path.resolve(outputRoot, fixture, scenario);
@@ -127,6 +135,17 @@ export function runAutomergeE2E({
 
     if (scenario === "ci-regression-29623139111" && expectedOutcome === "setup-identity-failure") {
       return runCiRegressionFailureScenario({
+        artifacts,
+        baseEnv,
+        fixture: targetFixture,
+        jobPath,
+        resultPath,
+        runtimeRoot,
+        targetDir,
+      });
+    }
+    if (scenario === "happy-path" && expectedOutcome === "setup-identity-failure") {
+      return runSetupIdentityFailureScenario({
         artifacts,
         baseEnv,
         fixture: targetFixture,
@@ -584,6 +603,57 @@ function runCiRegressionFailureScenario({
     status: "passed",
     fixture: fixture.fixture,
     scenario: "ci-regression-29623139111",
+    artifacts,
+  };
+}
+
+function runSetupIdentityFailureScenario({
+  artifacts,
+  baseEnv,
+  fixture,
+  jobPath,
+  resultPath,
+  runtimeRoot,
+  targetDir,
+}) {
+  const originalHead = currentRef(fixture.remote, fixture.headRef);
+  const child = runCliExpectFailure(
+    runtimeRoot,
+    [
+      "dist/repair/execute-fix-artifact.js",
+      jobPath,
+      resultPath,
+      "--target-dir",
+      targetDir,
+      "--defer-publication",
+    ],
+    baseEnv,
+    "write-token",
+    artifacts,
+    "04-execute-setup-identity-regression",
+  );
+  assert.match(
+    `${child.stderr ?? ""}\n${child.stdout ?? ""}`,
+    /target dependency setup mutated checkout identity: worktreeSha256/,
+  );
+  assert.equal(currentRef(fixture.remote, fixture.headRef), originalHead);
+  assert.equal(
+    fs.readFileSync(path.join(targetDir, fixture.repairTarget), "utf8"),
+    "broken\n",
+    "setup identity failure must stop before Codex edits or branch push",
+  );
+  writeJson(path.join(artifacts, "summary.json"), {
+    status: "passed",
+    fixture: fixture.fixture,
+    scenario: "happy-path",
+    expected_outcome: "setup-identity-failure",
+    reproduced_error: "target dependency setup mutated checkout identity: worktreeSha256",
+    mutation: "blocked before Codex or push",
+  });
+  return {
+    status: "passed",
+    fixture: fixture.fixture,
+    scenario: "happy-path",
     artifacts,
   };
 }

--- a/test/e2e/automerge/target-fixtures.mjs
+++ b/test/e2e/automerge/target-fixtures.mjs
@@ -8,7 +8,7 @@ export const OPENCLAW_SHAPED_CONTRACT = Object.freeze({
   node: ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0",
   packageManager:
     "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
-  repairTarget: "packages/fixture-core/src/repair-target.txt",
+  repairTarget: "src/repair-target.txt",
 });
 
 export function createTargetFixture(
@@ -66,7 +66,14 @@ function createOpenClawShapedFixture(root, { dependencySetupMutation }) {
     fixture: "openclaw-shaped",
     repairTarget,
     forcedTrackedFiles: dependencySetupMutation ? ["node_modules/.modules.yaml"] : [],
-    trackedSymlinks: { "CLAUDE.md": "AGENTS.md" },
+    trackedExecutableFiles: ["openclaw.mjs"],
+    trackedSymlinks: {
+      "CLAUDE.md": "AGENTS.md",
+      "extensions/fixture-extension/node_modules/@openclaw/fixture-core":
+        "../../../../packages/fixture-core",
+      "packages/fixture-cli-consumer/node_modules/.bin/openclaw": "../openclaw/openclaw.mjs",
+      "packages/fixture-cli-consumer/node_modules/openclaw": "../../..",
+    },
     files: {
       ".gitignore": [
         "node_modules/",
@@ -83,6 +90,7 @@ function createOpenClawShapedFixture(root, { dependencySetupMutation }) {
         "# OpenClaw-shaped fixture\n\nUse workspace-aware validation. CHANGELOG.md is release-owned and must not be edited by repair automation.\n",
       "CHANGELOG.md":
         "# Changelog\n\n## Unreleased\n\nRelease maintainers own this file; automerge repair must preserve it.\n",
+      "openclaw.mjs": "#!/usr/bin/env node\nconsole.log('openclaw-shaped fixture');\n",
       "package.json": openClawRootPackage(),
       "pnpm-workspace.yaml": openClawWorkspace(),
       "pnpm-lock.yaml": openClawLockfile(),
@@ -93,8 +101,18 @@ function createOpenClawShapedFixture(root, { dependencySetupMutation }) {
         "@openclaw/fixture-core": "workspace:*",
       }),
       "ui/src/index.js": "export const uiFixture = true;\n",
-      "packages/fixture-core/package.json": workspacePackage("@openclaw/fixture-core"),
+      "packages/fixture-cli-consumer/package.json": workspacePackage(
+        "@openclaw/fixture-cli-consumer",
+        {
+          openclaw: "workspace:*",
+        },
+      ),
+      "packages/fixture-core/package.json": workspacePackage("@openclaw/fixture-core", {
+        "@openclaw/fixture-leaf": "workspace:*",
+      }),
       "packages/fixture-core/src/index.js": "export const coreFixture = true;\n",
+      "packages/fixture-leaf/package.json": workspacePackage("@openclaw/fixture-leaf"),
+      "packages/fixture-leaf/src/index.js": "export const leafFixture = true;\n",
       [repairTarget]: "base\n",
       "extensions/fixture-extension/package.json": workspacePackage("@openclaw/fixture-extension", {
         "@openclaw/fixture-core": "workspace:*",
@@ -123,7 +141,14 @@ function createOpenClawShapedFixture(root, { dependencySetupMutation }) {
 
 function initializeRepository(
   root,
-  { fixture, files, repairTarget, forcedTrackedFiles = [], trackedSymlinks = {} },
+  {
+    fixture,
+    files,
+    repairTarget,
+    forcedTrackedFiles = [],
+    trackedExecutableFiles = [],
+    trackedSymlinks = {},
+  },
 ) {
   const remote = path.join(root, "target.git");
   const seed = path.join(root, "target-seed");
@@ -132,10 +157,13 @@ function initializeRepository(
   git(["config", "user.name", "E2E Contributor"], seed);
   git(["config", "user.email", "contributor@example.invalid"], seed);
   for (const [relative, contents] of Object.entries(files)) writeFile(seed, relative, contents);
+  for (const relative of trackedExecutableFiles) fs.chmodSync(path.join(seed, relative), 0o775);
   for (const [relative, target] of Object.entries(trackedSymlinks)) {
+    fs.mkdirSync(path.dirname(path.join(seed, relative)), { recursive: true });
     fs.symlinkSync(target, path.join(seed, relative));
   }
   git(["add", "."], seed);
+  for (const relative of Object.keys(trackedSymlinks)) git(["add", "--force", relative], seed);
   // The mutation scenario deliberately tracks package-manager metadata even
   // though production repositories ignore node_modules. pnpm must rewrite it,
   // giving the containment assertion a deterministic real filesystem mutation.
@@ -165,12 +193,13 @@ function initializeRepository(
 function openClawRootPackage() {
   return `${JSON.stringify(
     {
-      name: "openclaw-shaped-automerge-e2e",
+      name: "openclaw",
       version: "0.0.0",
       private: true,
       type: "module",
       engines: { node: OPENCLAW_SHAPED_CONTRACT.node },
       packageManager: OPENCLAW_SHAPED_CONTRACT.packageManager,
+      bin: { openclaw: "openclaw.mjs" },
       scripts: {
         "check:changed": "node scripts/check-changed.mjs",
         "check:test-types": "node scripts/fixture-gate.mjs test-types",
@@ -258,7 +287,19 @@ importers:
         specifier: workspace:*
         version: link:../../packages/fixture-core
 
-  packages/fixture-core: {}
+  packages/fixture-cli-consumer:
+    dependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
+  packages/fixture-core:
+    dependencies:
+      '@openclaw/fixture-leaf':
+        specifier: workspace:*
+        version: link:../fixture-leaf
+
+  packages/fixture-leaf: {}
 
   ui:
     dependencies:
@@ -285,8 +326,8 @@ const changed = execFileSync("/usr/bin/git", ["diff", "--name-only", "origin/mai
   .trim()
   .split("\\n")
   .filter(Boolean);
-const repairTarget = "packages/fixture-core/src/repair-target.txt";
-assert.ok(changed.includes(repairTarget), "check:changed did not select the repaired package");
+const repairTarget = "src/repair-target.txt";
+assert.ok(changed.includes(repairTarget), "check:changed did not select the repaired root source");
 assert.ok(!changed.includes("CHANGELOG.md"), "ordinary automerge repair changed CHANGELOG.md");
 assert.equal(fs.readFileSync(repairTarget, "utf8"), "fixed\\n");
 assert.equal(

--- a/test/repair/automerge-openclaw-shaped-fixture.test.ts
+++ b/test/repair/automerge-openclaw-shaped-fixture.test.ts
@@ -21,6 +21,7 @@ test("openclaw-shaped automerge fixture preserves production repository contract
 
     assert.equal(packageJson.engines.node, OPENCLAW_SHAPED_CONTRACT.node);
     assert.equal(packageJson.packageManager, OPENCLAW_SHAPED_CONTRACT.packageManager);
+    assert.deepEqual(packageJson.bin, { openclaw: "openclaw.mjs" });
     assert.deepEqual(Object.keys(packageJson.scripts).sort(), [
       "check:changed",
       "check:test-types",
@@ -36,9 +37,49 @@ test("openclaw-shaped automerge fixture preserves production repository contract
     assert.match(workspace, /allowBuilds:/);
     assert.match(lockfile, /version: link:packages\/fixture-core/);
     assert.match(lockfile, /version: link:\.\.\/\.\.\/packages\/fixture-core/);
+    assert.match(lockfile, /version: link:\.\.\/fixture-leaf/);
     assert.equal(fixture.repairTarget, OPENCLAW_SHAPED_CONTRACT.repairTarget);
     assert.deepEqual(fixture.files, [OPENCLAW_SHAPED_CONTRACT.repairTarget]);
     assert.equal(fs.readlinkSync(path.join(fixture.seed, "CLAUDE.md")), "AGENTS.md");
+    assert.equal(
+      fs.readlinkSync(
+        path.join(fixture.seed, "extensions/fixture-extension/node_modules/@openclaw/fixture-core"),
+      ),
+      "../../../../packages/fixture-core",
+    );
+    assert.equal(
+      fs.readlinkSync(
+        path.join(fixture.seed, "packages/fixture-cli-consumer/node_modules/openclaw"),
+      ),
+      "../../..",
+    );
+    assert.equal(
+      fs.readlinkSync(
+        path.join(fixture.seed, "packages/fixture-cli-consumer/node_modules/.bin/openclaw"),
+      ),
+      "../openclaw/openclaw.mjs",
+    );
+    assert.equal(fs.statSync(path.join(fixture.seed, "openclaw.mjs")).mode & 0o777, 0o775);
+    assert.match(
+      spawnSync("/usr/bin/git", ["-C", fixture.seed, "ls-files", "-s", "openclaw.mjs"], {
+        encoding: "utf8",
+      }).stdout,
+      /^100755 /,
+    );
+    assert.match(
+      spawnSync(
+        "/usr/bin/git",
+        [
+          "-C",
+          fixture.seed,
+          "ls-files",
+          "-s",
+          "extensions/fixture-extension/node_modules/@openclaw/fixture-core",
+        ],
+        { encoding: "utf8" },
+      ).stdout,
+      /^120000 /,
+    );
     assert.equal(fixture.behindMain, true);
     assert.notEqual(
       spawnSync(


### PR DESCRIPTION
## Summary

- strengthen the OpenClaw-shaped automerge fixture with tracked workspace, root self, and bin links created by pnpm-style installs
- exercise root and workspace repair targets under GitHub-like checkout permissions
- add an explicit pre-fix setup identity failure expectation that proves the run stops before Codex or push
- document the local-container regression workflow and evidence

## Why

The tiny fixture proves the generic automerge state machine, but it did not model the install-managed symlink and executable-mode topology used by OpenClaw. That gap allowed dependency setup checkout-identity regressions to reach production before the E2E suite detected them.

On the pre-fix main candidate, the OpenClaw-shaped happy path reproduces: target dependency setup mutated checkout identity: worktreeSha256. The harness verifies this happens before Codex or any push. With the merged identity fix, the same happy path and the complete fixture matrix pass.

## Validation

- local container matrix: 12/12 scenarios passed (6 tiny, 6 OpenClaw-shaped)
- observed container usage: 167.5 MiB of 8 GiB and 36 PIDs
- focused fixture/container tests: 9/9 passed
- pnpm run check: passed
- branch-level autoreview: clean, confidence 0.86
- commit autoreview: clean, confidence 0.87
- gitleaks commit range: clean

This PR changes only E2E fixtures, harness assertions, and documentation; it contains no production repair fix.