### PR TITLE
fix(repair): bind pnpm workspace runtime links safely

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -2489,6 +2489,11 @@ function gitFileMode(mode: number) {
 function validationRuntimeInputsSha256(cwd: string, deadlineAt: number) {
   const hash = createHash("sha256");
   const root = fs.realpathSync(cwd);
+  const trackedPaths = new Set(
+    runIdentityGit(cwd, ["ls-files", "-z"], deadlineAt, "tracked runtime input listing")
+      .split("\0")
+      .filter(Boolean),
+  );
   const runtimePaths = validationRuntimeInputPaths(cwd, deadlineAt);
   updateIdentityHash(hash, "runtime-input-paths", runtimePaths.join("\0"));
   const coveredEntries = new Map<string, string>();
@@ -2503,7 +2508,15 @@ function validationRuntimeInputsSha256(cwd: string, deadlineAt: number) {
       updateIdentityHash(hash, "runtime-state", "absent");
       continue;
     }
-    updateRuntimeInputDigest(hash, root, entryPath, relativePath, deadlineAt, coveredEntries);
+    updateRuntimeInputDigest(
+      hash,
+      root,
+      entryPath,
+      relativePath,
+      deadlineAt,
+      coveredEntries,
+      trackedPaths,
+    );
   }
   assertValidationIdentityDeadline(deadlineAt, "runtime input digest");
   return hash.digest("hex");
@@ -2572,6 +2585,7 @@ function updateRuntimeInputDigest(
   logicalPath: string,
   deadlineAt: number,
   coveredEntries: Map<string, string>,
+  trackedPaths: ReadonlySet<string>,
 ) {
   assertValidationIdentityDeadline(deadlineAt, logicalPath);
   const stat = fs.lstatSync(entryPath);
@@ -2582,6 +2596,20 @@ function updateRuntimeInputDigest(
     const targetPath = fs.realpathSync(entryPath);
     assertPathWithin(root, targetPath, logicalPath);
     updateIdentityHash(hash, "runtime-symlink-target", path.relative(root, targetPath));
+    const workspaceReference = trackedSymlinkTargetReference(
+      root,
+      entryPath,
+      targetPath,
+      trackedPaths,
+      { allowInstallManagedWorkspaceLink: true },
+    );
+    if (workspaceReference) {
+      // pnpm creates ignored node_modules links back to tracked workspaces. The
+      // checkout identity already binds their source, while traversing them here
+      // would also absorb mutable .git state and make a read-only fetch stale the runtime.
+      updateIdentityHash(hash, "runtime-workspace-reference", workspaceReference);
+      return;
+    }
     updateRuntimeInputDigest(
       hash,
       root,
@@ -2589,6 +2617,7 @@ function updateRuntimeInputDigest(
       `${logicalPath}\0target`,
       deadlineAt,
       coveredEntries,
+      trackedPaths,
     );
     return;
   }
@@ -2616,6 +2645,7 @@ function updateRuntimeInputDigest(
       `${logicalPath}/${child}`,
       deadlineAt,
       coveredEntries,
+      trackedPaths,
     );
   }
 }
@@ -3282,13 +3312,15 @@ function trackedSymlinkTargetReference(
   symlinkPath: string,
   targetPath: string,
   trackedPaths: ReadonlySet<string>,
+  { allowInstallManagedWorkspaceLink = false }: { allowInstallManagedWorkspaceLink?: boolean } = {},
 ) {
   const relativeLink = path.relative(root, symlinkPath).split(path.sep).join("/");
-  if (!trackedPaths.has(relativeLink)) return null;
+  const linkIsTracked = trackedPaths.has(relativeLink);
+  if (!linkIsTracked && !allowInstallManagedWorkspaceLink) return null;
   const targetRelative = path.relative(root, targetPath).split(path.sep).join("/");
   const targetStat = fs.statSync(targetPath);
   if (targetStat.isFile()) {
-    return trackedPaths.has(targetRelative) ? `file\0${targetRelative}` : null;
+    return linkIsTracked && trackedPaths.has(targetRelative) ? `file\0${targetRelative}` : null;
   }
   if (!targetStat.isDirectory()) return null;
   const linkParts = relativeLink.split("/");

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -5355,6 +5355,78 @@ fs.writeFileSync(${JSON.stringify(runtimeInput)}, "installed\\n");
 );
 
 test(
+  "prepared pnpm validation accepts install-managed links to tracked workspaces",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    const packagePath = path.join(cwd, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    packageJson.name = "openclaw";
+    fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    const consumerDir = path.join(cwd, "packages", "consumer");
+    fs.mkdirSync(consumerDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(consumerDir, "package.json"),
+      `${JSON.stringify({ name: "@fixture/consumer", dependencies: { openclaw: "workspace:*" } }, null, 2)}\n`,
+    );
+    const sourcePath = path.join(cwd, "source.ts");
+    fs.writeFileSync(sourcePath, "export const value = 1;\n");
+    fs.writeFileSync(path.join(cwd, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workspace-runtime-"));
+    const corepackPath = path.join(binDir, "corepack.js");
+    const pnpmPath = path.join(binDir, "pnpm.js");
+    const workspaceLink = path.join(consumerDir, "node_modules", "openclaw");
+    fs.writeFileSync(corepackPath, "");
+    fs.writeFileSync(
+      pnpmPath,
+      `const fs = require("node:fs");
+const path = require("node:path");
+if (process.argv.includes("install")) {
+  fs.mkdirSync(path.dirname(${JSON.stringify(workspaceLink)}), { recursive: true });
+  if (!fs.existsSync(${JSON.stringify(workspaceLink)})) {
+    fs.symlinkSync("../../..", ${JSON.stringify(workspaceLink)});
+  }
+}
+`,
+    );
+    const options = {
+      ...validationOptions("steipete/example", {
+        toolchain: {
+          packageManager: "pnpm",
+          baseValidationCommands: ["pnpm check"],
+          changedGate: null,
+        },
+      }),
+      installTargetDeps: true,
+      installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+      setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+    };
+
+    withMockCommand("corepack", corepackPath, () =>
+      withMockCommand("pnpm", pnpmPath, () => {
+        prepareTargetToolchain(cwd, options);
+        assert.deepEqual(runAllowedValidationCommands(["pnpm check"], cwd, options), [
+          "pnpm check:changed",
+        ]);
+        fs.writeFileSync(sourcePath, "export const value = 2;\n");
+        assert.throws(
+          () => runAllowedValidationCommands(["pnpm check"], cwd, options),
+          /prepared target pnpm toolchain is stale;.*(?:contentTreeSha|worktreeSha256)/,
+        );
+        prepareTargetToolchain(cwd, options);
+        assert.deepEqual(runAllowedValidationCommands(["pnpm check"], cwd, options), [
+          "pnpm check:changed",
+        ]);
+      }),
+    );
+  },
+);
+
+test(
   "dependency setup accepts Git-equivalent tracked executable mode normalization",
   { skip: process.platform === "win32" },
   () => {


### PR DESCRIPTION
## Summary

- represent pnpm-created ignored `node_modules` links to tracked workspaces as authenticated workspace references
- keep tracked source content, ignored runtime inputs, symlink paths, and non-workspace dependency targets bound independently
- add an OpenClaw-shaped regression that reproduces the exact stale `runtimeInputsSha256` failure found by the real-repository smoke

## Root cause

OpenClaw workspaces link packages such as `openclaw` back to the repository root. Runtime identity recursively followed those ignored install-managed links, absorbing tracked source and mutable `.git` state into `runtimeInputsSha256`. A normal base fetch after dependency preparation therefore made the prepared pnpm runtime appear stale.

The reference optimization is limited to a directory link under `node_modules` whose target `package.json` is tracked and whose package name matches the link name. File links and unrecognized or external targets retain the existing recursive binding.

## Proof

- before fix: focused regression fails with `prepared target pnpm toolchain is stale; refresh dependencies before validation: runtimeInputsSha256`
- `pnpm run check`
- focused workspace-link and adversarial symlink tests: 8/8 passed
- `gitleaks detect --pipe` over the complete patch: no leaks
- autoreview (Codex, local diff): clean, no accepted/actionable findings

Follow-up to the real OpenClaw local-container smoke; independent from the smoke harness PR.
