### PR TITLE
fix(repair): tolerate procfs exit races

### DIFF
--- a/src/repair/process-tree-containment.ts
+++ b/src/repair/process-tree-containment.ts
@@ -666,7 +666,10 @@ def process_rows():
         try:
             with open("/proc/" + entry + "/stat", "r", encoding="utf-8") as handle:
                 stat = handle.read()
-        except FileNotFoundError:
+        # procfs may report either ENOENT or ESRCH when a task exits between
+        # directory enumeration and opening its stat file. Both mean the
+        # observed task is already gone; every other read failure stays fatal.
+        except (FileNotFoundError, ProcessLookupError):
             continue
         fields = stat[stat.rfind(")") + 2:].split()
         if len(fields) >= 2:

--- a/test/repair/process-tree-containment.test.ts
+++ b/test/repair/process-tree-containment.test.ts
@@ -99,6 +99,17 @@ test("embedded containment runtime imports without executing its production entr
   assert.deepEqual(result, { status: "imported" });
 });
 
+test("procfs enumeration tolerates only tasks that disappear during stat reads", () => {
+  assert.deepEqual(runLandlockScenario("process_rows_esrch"), {
+    rows: [[102, 1]],
+    status: "ok",
+  });
+  assert.deepEqual(runLandlockScenario("process_rows_eacces"), {
+    errno: 13,
+    status: "error",
+  });
+});
+
 test("Landlock capability probe selects fallback only for unsupported syscalls", () => {
   for (const scenario of ["probe_enosys", "probe_eopnotsupp"]) {
     const result = runLandlockScenario(scenario);
@@ -219,6 +230,7 @@ function runLandlockScenario(scenario: string): Record<string, unknown> {
     const harness = String.raw`
 import errno
 import importlib.util
+import io
 import json
 import sys
 
@@ -228,6 +240,23 @@ module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 if scenario == "import":
     print(json.dumps({"status": "imported"}, separators=(",", ":")))
+    raise SystemExit(0)
+
+if scenario in {"process_rows_esrch", "process_rows_eacces"}:
+    module.os.listdir = lambda _path: ["101", "102", "self"]
+    def fake_open(path, _mode, encoding=None):
+        if path == "/proc/101/stat":
+            error_number = errno.ESRCH if scenario == "process_rows_esrch" else errno.EACCES
+            raise OSError(error_number, "simulated procfs race")
+        if path == "/proc/102/stat":
+            return io.StringIO("102 (worker) S 1 0 0 0")
+        raise AssertionError("unexpected procfs path: " + path)
+    module.open = fake_open
+    try:
+        payload = {"rows": module.process_rows(), "status": "ok"}
+    except OSError as error:
+        payload = {"errno": error.errno, "status": "error"}
+    print(json.dumps(payload, separators=(",", ":")))
     raise SystemExit(0)
 
 def error_payload(error):


### PR DESCRIPTION
## Summary

- tolerate the procfs `ESRCH` race when a short-lived validation process exits between `/proc` enumeration and reading its `stat` file
- keep all unrelated procfs read errors fail-closed
- add focused regression coverage for both `ESRCH` and an `EACCES` control case

## Root cause

The containment subreaper enumerates `/proc/<pid>/stat` while dependency validation runs. Large pnpm workloads create many short-lived processes. Linux can report either `ENOENT` or `ESRCH` when one disappears during that observation window, but the runtime handled only `ENOENT`, turning a normal exit race into `validation process containment failed: stage=unknown errno=3`.

This was reproduced by the offline real-OpenClaw automerge smoke for openclaw/openclaw#108974 after the earlier runtime-identity issue was fixed.

## Validation

- `pnpm run check`
- `node --test test/repair/process-tree-containment.test.ts`
- staged-patch `gitleaks protect --staged --redact --no-banner`
- autoreview (Codex): clean, 0 accepted/actionable findings

The fix does not relax mount, Landlock, capability, PID-namespace, or network containment.
