### PR TITLE
fix(automerge): merge ready behind heads directly

### DIFF
--- a/src/repair/automerge-shepherd.ts
+++ b/src/repair/automerge-shepherd.ts
@@ -1,5 +1,5 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import { parseTrustedAutomation } from "./comment-router-core.js";
+import { isAutomergeMergeStateReady, parseTrustedAutomation } from "./comment-router-core.js";
 
 const DEFAULT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_POLL_MS = 15 * 1000;
@@ -74,7 +74,7 @@ export function automergeShepherdReadiness({
   const mergeStateStatus = String(view.mergeStateStatus ?? "");
   if (
     mergeStateStatus &&
-    !["CLEAN", "HAS_HOOKS"].includes(mergeStateStatus) &&
+    !isAutomergeMergeStateReady(mergeStateStatus) &&
     mergeStateStatus !== "UNSTABLE"
   ) {
     return { status: "waiting", reason: `merge state status is ${mergeStateStatus}` };

--- a/src/repair/comment-router-core.test.ts
+++ b/src/repair/comment-router-core.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   automergeMergeFailureRepairReason,
   automergeRebaseRepairReason,
+  isAutomergeMergeStateReady,
 } from "./comment-router-core.js";
 
 test("automerge rebase repair reason detects dirty merge state", () => {
@@ -13,20 +14,28 @@ test("automerge rebase repair reason detects dirty merge state", () => {
   );
 });
 
-test("automerge rebase repair reason detects behind merge state", () => {
-  assert.match(
-    automergeRebaseRepairReason({ mergeStateStatus: "BEHIND" }) ?? "",
-    /behind the base branch/,
-  );
+test("automerge rebase repair reason ignores an otherwise mergeable behind head", () => {
+  assert.equal(automergeRebaseRepairReason({ mergeStateStatus: "BEHIND" }), null);
 });
 
 test("automerge rebase repair reason detects conflicting mergeable state", () => {
   assert.match(automergeRebaseRepairReason({ mergeable: "CONFLICTING" }) ?? "", /merge conflicts/);
+  assert.match(
+    automergeRebaseRepairReason({ mergeStateStatus: "BEHIND", mergeable: "CONFLICTING" }) ?? "",
+    /merge conflicts/,
+  );
 });
 
 test("automerge rebase repair reason ignores clean merge state", () => {
   assert.equal(automergeRebaseRepairReason({ merge_state_status: "CLEAN" }), null);
   assert.equal(automergeRebaseRepairReason({ mergeStateStatus: "HAS_HOOKS" }), null);
+});
+
+test("automerge merge readiness allows an exact reviewed head to remain behind", () => {
+  assert.equal(isAutomergeMergeStateReady("BEHIND"), true);
+  assert.equal(isAutomergeMergeStateReady("CLEAN"), true);
+  assert.equal(isAutomergeMergeStateReady("HAS_HOOKS"), true);
+  assert.equal(isAutomergeMergeStateReady("DIRTY"), false);
 });
 
 test("automerge merge failure repair reason detects GitHub merge conflict errors", () => {

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -629,15 +629,18 @@ export function automergeRebaseRepairReason(target: LooseRecord = {}): string | 
     .trim()
     .toUpperCase();
   if (mergeStateStatus === "DIRTY")
-    return "PR is behind or has merge conflicts and needs a cloud rebase repair before automerge";
-  if (mergeStateStatus === "BEHIND")
-    return "PR is behind the base branch and needs a cloud rebase repair before automerge";
+    return "PR has merge conflicts and needs a cloud rebase repair before automerge";
 
   const mergeable = String(target.mergeable ?? "")
     .trim()
     .toUpperCase();
   if (mergeable === "CONFLICTING")
     return "PR has merge conflicts and needs a cloud rebase repair before automerge";
+
+  // GitHub can safely merge an otherwise-ready BEHIND head with a three-way
+  // merge. Let the exact-head merge call enforce repository policy instead of
+  // rewriting a contributor branch solely because main advanced.
+  if (mergeStateStatus === "BEHIND") return null;
   return null;
 }
 
@@ -685,12 +688,17 @@ export function automergeReadinessRepairReason(reason: JsonValue): string | null
     return "PR has merge conflicts and needs a cloud rebase repair before automerge";
   }
   if (text === "merge state status is dirty") {
-    return "PR is behind or has merge conflicts and needs a cloud rebase repair before automerge";
-  }
-  if (text === "merge state status is behind") {
-    return "PR is behind the base branch and needs a cloud rebase repair before automerge";
+    return "PR has merge conflicts and needs a cloud rebase repair before automerge";
   }
   return null;
+}
+
+export function isAutomergeMergeStateReady(value: JsonValue): boolean {
+  return ["BEHIND", "CLEAN", "HAS_HOOKS"].includes(
+    String(value ?? "")
+      .trim()
+      .toUpperCase(),
+  );
 }
 
 export function isCanonicalLandingNeedsHumanText(value: JsonValue) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -55,6 +55,7 @@ import {
   isAuthorReadOnlyCommandAllowed,
   isMaintainerCommandAllowed,
   isIssueImplementationCommandAllowed,
+  isAutomergeMergeStateReady,
   issueImplementationClusterId,
   issueImplementationJobPath,
   isReadyHumanReviewPause,
@@ -4077,7 +4078,7 @@ function validateAutomergeReadiness({ command, view, target }: LooseRecord) {
   if (checks.total === 0) return "no PR checks found";
   const mergeStateStatus = String(view.mergeStateStatus ?? "");
   if (
-    !["CLEAN", "HAS_HOOKS"].includes(mergeStateStatus) &&
+    !isAutomergeMergeStateReady(mergeStateStatus) &&
     !(mergeStateStatus === "UNSTABLE" && checks.blockers.length === 0)
   ) {
     return `merge state status is ${view.mergeStateStatus || "unknown"}`;

--- a/test/automerge-e2e-fake-gh.test.ts
+++ b/test/automerge-e2e-fake-gh.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const fakeGhPath = fileURLToPath(new URL("./e2e/automerge/fake-gh.mjs", import.meta.url));
+
+test("fake GitHub serializes concurrent state updates", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-fake-gh-state-"));
+  const statePath = path.join(root, "github-state.json");
+  const processCount = 32;
+  fs.writeFileSync(
+    statePath,
+    `${JSON.stringify({
+      tokens: { read: "read-token", write: "write-token", post: "post-token" },
+      calls: [],
+    })}\n`,
+  );
+
+  try {
+    await Promise.all(
+      Array.from({ length: processCount }, () =>
+        runFakeGh(statePath, ["auth", "token"], "read-token"),
+      ),
+    );
+    const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(state.calls.length, processCount);
+    assert.ok(state.calls.every((call: { token: string }) => call.token === "read"));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runFakeGh(statePath: string, args: string[], token: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [fakeGhPath, ...args], {
+      env: {
+        ...process.env,
+        CLAWSWEEPER_E2E_GITHUB_STATE: statePath,
+        GH_TOKEN: token,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`fake gh exited with code ${code} signal ${signal}: ${stderr}`));
+    });
+  });
+}

--- a/test/e2e/automerge/fake-gh.mjs
+++ b/test/e2e/automerge/fake-gh.mjs
@@ -8,6 +8,10 @@ import path from "node:path";
 const statePath = process.env.CLAWSWEEPER_E2E_GITHUB_STATE;
 if (!statePath) fail("CLAWSWEEPER_E2E_GITHUB_STATE is required");
 const args = process.argv.slice(2);
+// One fake `gh` command can read and mutate state several times. Hold the lock
+// for the whole process so a later command never writes back a stale snapshot.
+const releaseStateLock = acquireStateLock();
+process.on("exit", releaseStateLock);
 const state = loadState();
 const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
 
@@ -472,7 +476,35 @@ function loadState() {
 }
 
 function saveState() {
-  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+  const temporaryPath = `${statePath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`);
+    fs.renameSync(temporaryPath, statePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function acquireStateLock() {
+  const lockPath = `${statePath}.lock`;
+  const deadline = Date.now() + 30_000;
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (Date.now() >= deadline) fail(`timed out waiting for fake GitHub state lock: ${lockPath}`);
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    fs.rmdirSync(lockPath);
+  };
 }
 
 function respondJson(value, { paged = false } = {}) {

--- a/test/repair/automerge-shepherd.test.ts
+++ b/test/repair/automerge-shepherd.test.ts
@@ -91,6 +91,29 @@ test("automerge shepherd waits for an exact-head trusted pass", () => {
   );
 });
 
+test("automerge shepherd accepts a behind head after exact-head review and checks pass", () => {
+  const headSha = "abc123";
+  assert.deepEqual(
+    automergeShepherdReadiness({
+      view: {
+        state: "OPEN",
+        headRefOid: headSha,
+        mergeable: "MERGEABLE",
+        mergeStateStatus: "BEHIND",
+        statusCheckRollup: [{ name: "check", status: "COMPLETED", conclusion: "SUCCESS" }],
+      },
+      comments: [
+        {
+          user: { login: "clawsweeper[bot]" },
+          body: "passed\n<!-- clawsweeper-verdict:pass sha=abc123 -->",
+        },
+      ],
+      headSha,
+    }),
+    { status: "ready", reason: "checks and exact-head review are ready" },
+  );
+});
+
 test("automerge shepherd treats head movement as terminal for the current repair", () => {
   assert.deepEqual(
     automergeShepherdReadiness({

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1102,6 +1102,17 @@ test("automerge activation does not send missing changelog to repair", () => {
     }),
     null,
   );
+
+  assert.equal(
+    automergeActivationRepairReason({
+      intent: "automerge",
+      repo: "openclaw/openclaw",
+      title: "fix(memory): preserve session corpus labels",
+      files: [{ path: "extensions/memory-core/src/tools.ts" }],
+      target: { checks: { blockers: [] }, merge_state_status: "BEHIND", mergeable: "MERGEABLE" },
+    }),
+    null,
+  );
 });
 
 test("renderAutomergeJob documents autofix as repair-only", () => {
@@ -3686,12 +3697,9 @@ test("automerge live readiness blocks become repair reasons", () => {
   );
   assert.equal(
     automergeReadinessRepairReason("merge state status is DIRTY"),
-    "PR is behind or has merge conflicts and needs a cloud rebase repair before automerge",
+    "PR has merge conflicts and needs a cloud rebase repair before automerge",
   );
-  assert.equal(
-    automergeReadinessRepairReason("merge state status is BEHIND"),
-    "PR is behind the base branch and needs a cloud rebase repair before automerge",
-  );
+  assert.equal(automergeReadinessRepairReason("merge state status is BEHIND"), null);
   assert.equal(automergeReadinessRepairReason("pull request is draft"), null);
 });
 


### PR DESCRIPTION
## Summary

- stop treating an otherwise-ready `BEHIND` head as an automatic repair/rebase request
- allow exact-head automerge readiness and the repair shepherd to proceed for `BEHIND`
- keep `DIRTY` and `CONFLICTING` states on the fail-closed repair path, including mixed `BEHIND + CONFLICTING` observations

## Root cause

ClawSweeper treated ordinary base drift as a required contributor-branch rewrite before attempting GitHub squash merge. A real local-container smoke with OpenClaw PR 108974 reproduced the consequence: rebasing the already-green PR onto current main made it inherit four unrelated typecheck failures that also reproduce on the exact main base alone.

GitHub can merge an otherwise-ready behind head with its normal three-way squash merge. The merge call remains pinned with `--match-head-commit`; required checks, exact-head ClawSweeper review, review decisions, conflicts, and GitHub repository policy are unchanged.

## Validation

- focused automerge router/shepherd tests: 138 passed
- `pnpm run check`
- staged-only gitleaks: no leaks
- autoreview: clean, no accepted/actionable findings

## Follow-up

The independent real-OpenClaw smoke PR will add a direct-automerge scenario because the current repair-only harness cannot exercise this route.