### PR TITLE
fix(automerge): preserve maintainer resume intent

### DIFF
--- a/src/repair/comment-router-core.test.ts
+++ b/src/repair/comment-router-core.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 import {
   automergeMergeFailureRepairReason,
   automergeRebaseRepairReason,
+  existingRepairLoopModeOutcome,
   isAutomergeMergeStateReady,
+  latestRepairLoopResumeTime,
+  maintainerAutomergeOptInApprovesNeedsHuman,
 } from "./comment-router-core.js";
 
 test("automerge rebase repair reason detects dirty merge state", () => {
@@ -36,6 +39,39 @@ test("automerge merge readiness allows an exact reviewed head to remain behind",
   assert.equal(isAutomergeMergeStateReady("CLEAN"), true);
   assert.equal(isAutomergeMergeStateReady("HAS_HOOKS"), true);
   assert.equal(isAutomergeMergeStateReady("DIRTY"), false);
+});
+
+test("explicit maintainer replay records resume intent for an enabled automerge", () => {
+  assert.deepEqual(existingRepairLoopModeOutcome({ intent: "automerge", trustedBot: false }), {
+    status: "executed",
+    reason: "automerge already enabled for this PR; maintainer resume intent recorded",
+  });
+  assert.deepEqual(existingRepairLoopModeOutcome({ intent: "automerge", trustedBot: true }), {
+    status: "skipped",
+    reason: "automerge already enabled for this PR",
+  });
+
+  const resumeTime = latestRepairLoopResumeTime(
+    [
+      {
+        repo: "openclaw/openclaw",
+        issue_number: 108974,
+        intent: "automerge",
+        ...existingRepairLoopModeOutcome({ intent: "automerge", trustedBot: false }),
+        comment_updated_at: "2026-07-18T21:22:08Z",
+      },
+    ],
+    { repo: "openclaw/openclaw", issue_number: 108974 },
+  );
+  assert.equal(
+    maintainerAutomergeOptInApprovesNeedsHuman({
+      reason:
+        "No repair lane is needed; the member-sponsored automerge path should make the final exact-head decision.",
+      commentCreatedAt: "2026-07-18T21:31:21Z",
+      optInTime: resumeTime,
+    }),
+    true,
+  );
 });
 
 test("automerge merge failure repair reason detects GitHub merge conflict errors", () => {

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -701,6 +701,19 @@ export function isAutomergeMergeStateReady(value: JsonValue): boolean {
   );
 }
 
+export function existingRepairLoopModeOutcome({ intent, trustedBot }: LooseRecord) {
+  const mode = intent === "autofix" ? "autofix" : "automerge";
+  // Only an authorized human command renews landing intent. A label sweep must
+  // not manufacture the maintainer signal consumed by needs-human approval.
+  if (trustedBot) {
+    return { status: "skipped", reason: `${mode} already enabled for this PR` };
+  }
+  return {
+    status: "executed",
+    reason: `${mode} already enabled for this PR; maintainer resume intent recorded`,
+  };
+}
+
 export function isCanonicalLandingNeedsHumanText(value: JsonValue) {
   const text = String(value ?? "");
   if (!text) return false;

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -51,6 +51,7 @@ import {
   commandStatusMarkerPrefix,
   existingCommandStatusBlocksReplay,
   existingModeStatusBlocksReplay,
+  existingRepairLoopModeOutcome,
   freshExactHeadReviewStartLease,
   isAuthorReadOnlyCommandAllowed,
   isMaintainerCommandAllowed,
@@ -401,7 +402,7 @@ if (execute && !exactCommentVersionFastPath.suppress) {
       for (const command of claimedCommands) recordCommandClaimed(command);
     }
     for (const command of commands) convergePrecreatedCommandAckComments(command);
-    for (const command of commands) acknowledgeSkippedMaintainerCommand(command);
+    for (const command of commands) acknowledgeTerminalNoopMaintainerCommand(command);
     for (const command of commands) {
       if (command.status !== "ready") {
         recordCommandOutcome(command);
@@ -1070,7 +1071,13 @@ function classifyCommand(command: LooseRecord): JsonValue {
         forceReprocess,
       })
     ) {
-      return { ...next, status: "skipped", reason: `${mode} already enabled for this PR` };
+      return {
+        ...next,
+        ...existingRepairLoopModeOutcome({
+          intent: command.intent,
+          trustedBot: command.trusted_bot,
+        }),
+      };
     }
     const approvedProofOverride =
       command.intent === "automerge" && !activationRepairReason
@@ -2754,8 +2761,10 @@ function applyRepairLoopOptIn(command: LooseRecord) {
   command.target = { ...command.target, labels: [...labels] };
 }
 
-function acknowledgeSkippedMaintainerCommand(command: LooseRecord) {
-  if (command.trusted_bot || command.status !== "skipped") return;
+function acknowledgeTerminalNoopMaintainerCommand(command: LooseRecord) {
+  if (command.trusted_bot || !["executed", "skipped"].includes(String(command.status ?? ""))) {
+    return;
+  }
   const reason = String(command.reason ?? "");
   if (reason === SUPERSEDED_RE_REVIEW_REASON) {
     clearTerminalMaintainerCommandReaction(command);


### PR DESCRIPTION
## Root cause

When automerge was already labeled and had an existing job/status, a fresh authorized `@clawsweeper automerge` command was recorded as `skipped`. Canonical `needs-human` exact reviews only recognize `executed` or `waiting` maintainer automerge ledger entries, so the explicit retry could not resume landing and the PR was paused for human review.

## Fix

Record an authorized human replay as an executed no-op resume intent. Keep trusted-bot label sweeps skipped so automation cannot manufacture maintainer approval. All exact-head, checks, merge-state, security, and match-head gates remain unchanged.

## Proof

- Focused old/new production-flow E2E: the #679 candidate returns `skipped`; this candidate records resume intent and merges the same direct-behind canonical-verdict scenario.
- `pnpm run build:repair`
- `node --test dist/repair/comment-router-core.test.js`
- `pnpm run check` (local run started; all completed stages green at PR creation)
- autoreview: clean, 0 actionable findings, `patch is correct` (0.87)
- gitleaks: no finding in the three changed files; repository-wide existing findings are outside this diff.