### PR TITLE
fix(repair): merge concurrent router ledgers

### DIFF
--- a/src/repair/comment-router-ledger-merge.ts
+++ b/src/repair/comment-router-ledger-merge.ts
@@ -1,0 +1,92 @@
+type JsonRecord = Record<string, unknown>;
+
+const MAX_COMMANDS = 1000;
+
+export function mergeCommentRouterLedgers(localText: string, remoteText: string): string {
+  const local = parseLedger(localText, "local");
+  const remote = parseLedger(remoteText, "remote");
+  const byKey = new Map<string, JsonRecord>();
+
+  // A router run publishes a bounded snapshot. Unioning by durable command
+  // identity prevents a later stale snapshot from erasing commands that a
+  // concurrent run already committed.
+  for (const entry of [...remote.commands, ...local.commands]) {
+    const key = ledgerEntryKey(entry);
+    const previous = byKey.get(key);
+    if (!previous || compareEntries(previous, entry) < 0) byKey.set(key, entry);
+  }
+
+  const commands = [...byKey.values()]
+    .sort((left, right) => compareLedgerOrder(left, right))
+    .slice(-MAX_COMMANDS);
+  const updatedAt = latestTimestamp(local.updated_at, remote.updated_at);
+  return `${JSON.stringify({ updated_at: updatedAt, commands }, null, 2)}\n`;
+}
+
+function parseLedger(
+  text: string,
+  side: string,
+): { updated_at: string | null; commands: JsonRecord[] } {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`failed to parse ${side} comment router ledger`, { cause: error });
+  }
+  if (!isRecord(value) || !Array.isArray(value.commands) || !value.commands.every(isRecord)) {
+    throw new Error(`${side} comment router ledger must contain a commands array`);
+  }
+  const updatedAt = typeof value.updated_at === "string" ? value.updated_at : null;
+  return { updated_at: updatedAt, commands: value.commands };
+}
+
+function ledgerEntryKey(entry: JsonRecord): string {
+  if (
+    !entry.comment_version_key &&
+    entry.automation_source === "repair_loop_label_sweep" &&
+    entry.idempotency_key
+  ) {
+    return `idempotency:${String(entry.idempotency_key)}`;
+  }
+  return String(
+    entry.comment_version_key ??
+      `${String(entry.comment_id ?? "unknown")}:${String(entry.comment_updated_at ?? "unknown")}`,
+  );
+}
+
+function compareEntries(left: JsonRecord, right: JsonRecord): number {
+  const status = statusRank(left.status) - statusRank(right.status);
+  if (status !== 0) return status;
+  const processed = timestamp(left.processed_at) - timestamp(right.processed_at);
+  if (processed !== 0) return processed;
+  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}
+
+function compareLedgerOrder(left: JsonRecord, right: JsonRecord): number {
+  const processed = timestamp(left.processed_at) - timestamp(right.processed_at);
+  if (processed !== 0) return processed;
+  return ledgerEntryKey(left).localeCompare(ledgerEntryKey(right));
+}
+
+function statusRank(value: unknown): number {
+  if (value === "executed") return 4;
+  if (value === "skipped") return 3;
+  if (value === "waiting") return 2;
+  if (value === "claimed") return 1;
+  return 0;
+}
+
+function latestTimestamp(left: string | null, right: string | null): string | null {
+  if (!left) return right;
+  if (!right) return left;
+  return timestamp(left) >= timestamp(right) ? left : right;
+}
+
+function timestamp(value: unknown): number {
+  const parsed = typeof value === "string" ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -28,6 +28,7 @@ import {
   type RecordTupleWinner,
 } from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
+import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
 
 export type GitRunResult = {
   status: number;
@@ -979,16 +980,24 @@ export function pushCommit(options: {
     }
     const remoteCommit = runGit(["rev-parse", `${remote}/${branch}`], { quiet: true }).trim();
     const statusMerges = planSweepStatusMerges({ localCommit, remoteCommit });
+    const ledgerMerge = planCommentRouterLedgerMerge({ localCommit, remoteCommit });
     const rebaseArgs =
       rebaseStrategy === "theirs" || rebaseStrategy === "apply-records"
         ? ["rebase", "-X", "theirs", `${remote}/${branch}`]
         : ["rebase", `${remote}/${branch}`];
     if (spawnGit(rebaseArgs).status === 0) {
       applySweepStatusMerges({ statusMerges, remoteCommit, localCommitMessage });
+      applyCommentRouterLedgerMerge({ ledgerMerge, remoteCommit, localCommitMessage });
+      continue;
+    }
+    if (resolveCommentRouterLedgerConflict(ledgerMerge)) {
+      applySweepStatusMerges({ statusMerges, remoteCommit, localCommitMessage });
+      applyCommentRouterLedgerMerge({ ledgerMerge, remoteCommit, localCommitMessage });
       continue;
     }
     if (rebaseStrategy === "apply-records" && resolveApplyRecordConflicts(statusMerges)) {
       applySweepStatusMerges({ statusMerges, remoteCommit, localCommitMessage });
+      applyCommentRouterLedgerMerge({ ledgerMerge, remoteCommit, localCommitMessage });
       continue;
     } else {
       runGit(["rebase", "--abort"], { allowFailure: true });
@@ -1430,6 +1439,13 @@ function rebuildPublishCommit(options: {
     includeIndependent: true,
     pathspecs: options.paths,
   });
+  const ledgerMerge = planCommentRouterLedgerMerge({
+    baseCommit: runGit(["rev-parse", `${options.sourceCommit}^`], { quiet: true }).trim(),
+    localCommit: options.sourceCommit,
+    remoteCommit,
+    includeIndependent: true,
+    pathspecs: options.paths,
+  });
   runGit(["reset", "--hard", remoteCommit]);
 
   for (const path of uniqueNonEmpty(options.paths)) {
@@ -1446,6 +1462,7 @@ function rebuildPublishCommit(options: {
   }
 
   applySweepStatusMergeFiles(statusMerges);
+  applyCommentRouterLedgerMergeFiles(ledgerMerge ? [ledgerMerge] : []);
   stagePaths(options.paths);
   if (!hasStagedChanges()) {
     console.log("No publish changes after syncing remote");
@@ -1562,6 +1579,90 @@ function readGitPath(commit: string, path: string): string | null {
     quiet: true,
   });
   return result.status === 0 ? result.stdout : null;
+}
+
+type CommentRouterLedgerMerge = { path: string; content: string };
+
+function planCommentRouterLedgerMerge(options: {
+  baseCommit?: string;
+  localCommit: string;
+  remoteCommit: string;
+  includeIndependent?: boolean;
+  pathspecs?: readonly string[];
+}): CommentRouterLedgerMerge | null {
+  const path = "results/comment-router.json";
+  if (options.pathspecs && !gitPathspecsInclude(options.pathspecs, path)) {
+    return null;
+  }
+  const baseCommit =
+    options.baseCommit ??
+    runGit(["merge-base", options.localCommit, options.remoteCommit], { quiet: true }).trim();
+  if (!baseCommit)
+    throw new Error("Refusing comment router ledger merge without a common Git base");
+  const base = readGitPath(baseCommit, path);
+  const local = readGitPath(options.localCommit, path);
+  const remote = readGitPath(options.remoteCommit, path);
+  if (!local || !remote) return null;
+  const localChanged = local !== base;
+  const remoteChanged = remote !== base;
+  if (!localChanged || (!options.includeIndependent && !remoteChanged)) return null;
+  return { path, content: mergeCommentRouterLedgers(local, remote) };
+}
+
+function gitPathspecsInclude(pathspecs: readonly string[], path: string): boolean {
+  // Publish accepts Git pathspec syntax, including root and magic forms. Ask
+  // Git to evaluate that contract so semantic merges cannot be bypassed by a
+  // broader spelling than the literal generated path.
+  return runGit(["ls-files", "-z", "--", ...uniqueNonEmpty(pathspecs)], { quiet: true })
+    .split("\0")
+    .includes(path);
+}
+
+function applyCommentRouterLedgerMergeFiles(merges: readonly CommentRouterLedgerMerge[]): void {
+  const root = publishRoot() ?? resolve(".");
+  for (const merge of merges) {
+    const destination = resolve(root, merge.path);
+    if (!isPathInsideOrEqual(root, destination)) {
+      throw new Error(
+        `Refusing to merge comment router ledger outside publish root: ${merge.path}`,
+      );
+    }
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, merge.content, "utf8");
+    runGit(["add", "--", merge.path]);
+  }
+}
+
+function resolveCommentRouterLedgerConflict(ledgerMerge: CommentRouterLedgerMerge | null): boolean {
+  if (!ledgerMerge) return false;
+  const conflicts = runGit(["diff", "--name-only", "--diff-filter=U"], { allowFailure: true })
+    .split(/\r?\n/)
+    .map((path) => path.trim())
+    .filter(Boolean);
+  if (!conflicts.includes(ledgerMerge.path)) return false;
+  applyCommentRouterLedgerMergeFiles([ledgerMerge]);
+  if (conflicts.length > 1) return false;
+  return spawnGit(["-c", "core.editor=true", "rebase", "--continue"]).status === 0;
+}
+
+function applyCommentRouterLedgerMerge(options: {
+  ledgerMerge: CommentRouterLedgerMerge | null;
+  remoteCommit: string;
+  localCommitMessage: string;
+}): void {
+  if (!options.ledgerMerge) return;
+  applyCommentRouterLedgerMergeFiles([options.ledgerMerge]);
+  if (!hasStagedChanges()) return;
+  if (spawnGit(["diff", "--cached", "--quiet", options.remoteCommit]).status === 0) {
+    runGit(["reset", "--hard", options.remoteCommit]);
+    return;
+  }
+  const commitsAhead = Number(
+    runGit(["rev-list", "--count", `${options.remoteCommit}..HEAD`], { quiet: true }).trim(),
+  );
+  if (Number.isInteger(commitsAhead) && commitsAhead > 0)
+    runGit(["commit", "--amend", "--no-edit"]);
+  else runGit(["commit", "-m", options.localCommitMessage]);
 }
 
 function applySweepStatusMergeFiles(statusMerges: readonly SweepStatusMerge[]): void {

--- a/test/e2e/automerge/fake-gh.mjs
+++ b/test/e2e/automerge/fake-gh.mjs
@@ -166,6 +166,10 @@ function handleApi() {
     assertReadToken();
     respondJson({ default_branch: state.pr.baseRef });
   }
+  if (endpoint === `repos/${state.repo}/collaborators/fixture-maintainer/permission`) {
+    assertReadToken();
+    respondJson({ permission: "maintain", user: { id: 2, login: "fixture-maintainer" } });
+  }
   if (/^repos\/openclaw\/clawsweeper\/actions\/workflows\/[^/]+\/runs\?/.test(endpoint)) {
     assertReadToken();
     respondJson([]);

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -16,6 +16,7 @@ export const AUTOMERGE_E2E_SCENARIOS = [
   "happy-path",
   "pending-checks",
   "planning-head-drift",
+  "resume-intent-persistence",
   "verdict-head-drift",
   "ci-regression-29623139111",
 ];
@@ -232,7 +233,41 @@ export function runAutomergeE2E({
 
     const repairedHead = currentRef(targetFixture.remote, targetFixture.headRef);
     assertFixturePostRepair(targetFixture, repairedHead);
-    addExactHeadVerdict(statePath, repairedHead);
+    if (scenario === "resume-intent-persistence") {
+      const activeJob = path.join(
+        runtimeRoot,
+        "jobs/openclaw/inbox/automerge-openclaw-openclaw-42.md",
+      );
+      fs.mkdirSync(path.dirname(activeJob), { recursive: true });
+      fs.copyFileSync(jobPath, activeJob);
+      addMaintainerAutomergeCommand(statePath);
+      runCommentRouter(runtimeRoot, baseEnv, artifacts, "08-comment-router-resume-command");
+      const resumeReport = readRouterReport(runtimeRoot);
+      const resume = resumeReport.commands.find(
+        (command) => command.intent === "automerge" && command.trusted_bot === false,
+      );
+      assert.equal(
+        resume?.status,
+        "executed",
+        "maintainer replay must record active resume intent",
+      );
+      const persistedLedger = JSON.parse(
+        fs.readFileSync(path.join(runtimeRoot, "results", "comment-router.json"), "utf8"),
+      );
+      assert.equal(
+        persistedLedger.commands.some(
+          (command) =>
+            command.intent === "automerge" &&
+            command.status === "executed" &&
+            command.author === "fixture-maintainer",
+        ),
+        true,
+        "a later router invocation must be able to hydrate the resume command",
+      );
+      addCanonicalNeedsHumanVerdict(statePath, repairedHead);
+    } else {
+      addExactHeadVerdict(statePath, repairedHead);
+    }
     if (scenario === "verdict-head-drift") {
       const driftedHead = advanceRemoteContributorHead(root, targetFixture, "verdict head drift");
       runCommentRouter(runtimeRoot, baseEnv, artifacts, "08-comment-router-stale-verdict");
@@ -313,8 +348,11 @@ export function runAutomergeE2E({
     assert.equal(fixReport.actions.at(-1)?.status, "pushed");
     assert.equal(repairPostFlight.actions.at(-1)?.status, "blocked");
     assert.equal(repairPostFlight.actions.at(-1)?.reason, "job does not allow merge");
+    const mergedCommand = routerReport.commands.find((command) =>
+      command.actions.some((action) => action.action === "merge"),
+    );
     assert.equal(
-      routerReport.commands.at(-1)?.actions.find((action) => action.action === "merge")?.status,
+      mergedCommand?.actions.find((action) => action.action === "merge")?.status,
       "executed",
     );
     assert.equal(idempotentRouterReport.actionable, 0);
@@ -401,6 +439,57 @@ function addExactHeadVerdict(statePath, headSha) {
     author_association: "MEMBER",
     created_at: now,
     updated_at: now,
+  });
+  writeJson(statePath, state);
+}
+
+function addMaintainerAutomergeCommand(statePath) {
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  addFixtureComment(statePath, {
+    author: "clawsweeper[bot]",
+    authorId: 1,
+    body: `Automerge is already active.\n<!-- clawsweeper-command-status:${state.pr.number}:automerge:active -->`,
+  });
+  addFixtureComment(statePath, {
+    author: "fixture-maintainer",
+    authorId: 2,
+    body: "@clawsweeper automerge\n\nResume the exact current head after the repair fix landed.",
+  });
+}
+
+function addCanonicalNeedsHumanVerdict(statePath, headSha) {
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  const now = new Date(Date.now() + 1000).toISOString();
+  addFixtureComment(statePath, {
+    author: "clawsweeper[bot]",
+    authorId: 1,
+    body: [
+      "ClawSweeper needs maintainer judgment.",
+      "",
+      "**Next step before merge**",
+      "The PR is an active automerge candidate with no code finding, but missing real behavior proof needs maintainer handling.",
+      "",
+      `<!-- clawsweeper-verdict:needs-human item=${state.pr.number} sha=${headSha} reviewed_at=${now} -->`,
+    ].join("\n"),
+    timestamp: now,
+  });
+}
+
+function addFixtureComment(
+  statePath,
+  { author, authorId, body, timestamp = new Date().toISOString() },
+) {
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  const id = state.nextCommentId++;
+  state.comments.push({
+    id,
+    body,
+    issue_url: `https://api.github.com/repos/${state.repo}/issues/${state.pr.number}`,
+    html_url: `https://github.com/${state.repo}/pull/${state.pr.number}#issuecomment-${id}`,
+    user: { id: authorId, login: author },
+    author_association: "MEMBER",
+    created_at: timestamp,
+    updated_at: timestamp,
   });
   writeJson(statePath, state);
 }

--- a/test/repair/comment-router-ledger-merge.test.ts
+++ b/test/repair/comment-router-ledger-merge.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mergeCommentRouterLedgers } from "../../dist/repair/comment-router-ledger-merge.js";
+
+test("comment router ledger merge preserves disjoint concurrent commands", () => {
+  const local = ledger([
+    command("base", "2026-07-18T22:00:00Z"),
+    command("local", "2026-07-18T22:10:31Z"),
+  ]);
+  const remote = ledger([
+    command("base", "2026-07-18T22:00:00Z"),
+    command("remote", "2026-07-18T22:10:32Z"),
+  ]);
+
+  const merged = JSON.parse(mergeCommentRouterLedgers(local, remote));
+
+  assert.deepEqual(
+    merged.commands.map((entry: { comment_version_key: string }) => entry.comment_version_key),
+    ["base", "local", "remote"],
+  );
+});
+
+test("comment router ledger merge keeps terminal progress for the same command", () => {
+  const claimed = { ...command("same", "2026-07-18T22:10:31Z"), status: "claimed" };
+  const executed = { ...claimed, status: "executed", processed_at: "2026-07-18T22:10:32Z" };
+
+  const merged = JSON.parse(mergeCommentRouterLedgers(ledger([claimed]), ledger([executed])));
+
+  assert.equal(merged.commands[0].status, "executed");
+});
+
+test("comment router ledger merge never regresses executed evidence to a later skip", () => {
+  const executed = { ...command("same", "2026-07-18T22:10:31Z"), status: "executed" };
+  const skipped = { ...executed, status: "skipped", processed_at: "2026-07-18T22:10:32Z" };
+
+  const merged = JSON.parse(mergeCommentRouterLedgers(ledger([executed]), ledger([skipped])));
+
+  assert.equal(merged.commands[0].status, "executed");
+});
+
+test("comment router ledger merge compacts by durable processing time", () => {
+  const old = Array.from({ length: 1000 }, (_, index) =>
+    command(
+      `old-${index}`,
+      `2026-07-18T21:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}Z`,
+    ),
+  );
+  const recent = command("resume", "2026-07-18T22:10:31Z");
+
+  const merged = JSON.parse(mergeCommentRouterLedgers(ledger([...old, recent]), ledger(old)));
+
+  assert.equal(merged.commands.length, 1000);
+  assert.equal(
+    merged.commands.some(
+      (entry: { comment_version_key: string }) => entry.comment_version_key === "resume",
+    ),
+    true,
+  );
+});
+
+function ledger(commands: Record<string, unknown>[]): string {
+  return JSON.stringify({ updated_at: "2026-07-18T22:10:32Z", commands });
+}
+
+function command(key: string, processedAt: string): Record<string, unknown> {
+  return {
+    comment_version_key: key,
+    comment_id: key,
+    comment_updated_at: processedAt,
+    status: "executed",
+    processed_at: processedAt,
+  };
+}

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1507,6 +1507,63 @@ test("publishMainCommit publishes generated paths to state branch when state roo
   assert.throws(() => run("git", ["--git-dir", origin, "show", "main:results/ledger.txt"], root));
 });
 
+test("publishMainCommit preserves concurrent comment router ledger commands", () => {
+  for (const rebaseStrategy of ["normal", "theirs"]) {
+    assertConcurrentCommentRouterLedgerPublish(rebaseStrategy);
+  }
+});
+
+function assertConcurrentCommentRouterLedgerPublish(rebaseStrategy) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const ledgerFile = "results/comment-router.json";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeJson(path.join(work, ledgerFile), commentRouterLedger([commentRouterCommand("base", 1)]));
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  writeJson(
+    path.join(other, ledgerFile),
+    commentRouterLedger([
+      commentRouterCommand("base", 1),
+      commentRouterCommand("remote-resume", 2),
+    ]),
+  );
+  run("git", ["commit", "-am", "remote router command"], other);
+
+  writeJson(
+    path.join(work, ledgerFile),
+    commentRouterLedger([commentRouterCommand("base", 1), commentRouterCommand("local-resume", 3)]),
+  );
+  installFirstPushRaceHook(work, other);
+
+  const result = withCwd(work, () =>
+    publishMainCommit({
+      message: "chore: publish router command",
+      paths: ["."],
+      maxAttempts: 1,
+      pushAttempts: 2,
+      rebaseStrategy,
+    }),
+  );
+
+  assert.equal(result, "committed");
+  const published = readOriginJson(origin, `main:${ledgerFile}`, root);
+  assert.deepEqual(
+    published.commands.map((entry) => entry.comment_version_key),
+    ["base", "remote-resume", "local-resume"],
+  );
+}
+
 test("publishMainCommit refreshes merged health before the next state-root status publish", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
@@ -2337,6 +2394,21 @@ if test "$count" -eq 2; then git -C "${other}" push origin HEAD:main; fi
 `,
   );
   fs.chmodSync(hook, 0o755);
+}
+
+function commentRouterLedger(commands) {
+  return { updated_at: "2026-07-18T22:10:32Z", commands };
+}
+
+function commentRouterCommand(key, second) {
+  const timestamp = `2026-07-18T22:10:${String(second).padStart(2, "0")}Z`;
+  return {
+    comment_version_key: key,
+    comment_id: key,
+    comment_updated_at: timestamp,
+    status: "executed",
+    processed_at: timestamp,
+  };
 }
 
 function installFirstPushRaceHook(work, other, branch = "main") {


### PR DESCRIPTION
## Summary

- semantically union concurrent `comment-router.json` command records after state push races
- preserve terminal command progress and bound the durable ledger to the latest 1000 entries
- add real two-clone push-race tests plus an automerge resume-intent E2E regression

## Root cause

Comment-router workflows publish one shared durable JSON ledger from independent snapshots. When two runs raced, the later rebase/push could overwrite a command already published by the other run. Both workflows then reported success while one automerge command disappeared from durable state.

## Validation

- `pnpm run check`
- `pnpm e2e:automerge:container -- --scenario resume-intent-persistence --fixture tiny --base-image clawsweeper-automerge-e2e-base:local`
- focused repair build and tests for ledger merge and Git publish races
- branch autoreview: 0 findings, patch correct
- diff-scoped gitleaks: no leaks found

## Safety

This does not widen filesystem, network, capability, Git alternates, or repository-write boundaries. Semantic merging is limited to the canonical comment-router ledger path selected for publication.