### PR TITLE
test(apply): keep promotion fixtures recent

### DIFF
--- a/test/apply-pr-supersession-promotion.test.ts
+++ b/test/apply-pr-supersession-promotion.test.ts
@@ -13,6 +13,12 @@ import {
   withMockGh,
 } from "./helpers.ts";
 
+function recentItemCreatedAt() {
+  // These cases isolate relationship classification, so keep age-based stale
+  // promotion out of scope without a calendar date that eventually expires.
+  return new Date().toISOString();
+}
+
 test("apply-decisions does not promote PRs superseded by PRs already proposed for close", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -207,7 +213,7 @@ test("apply-decisions does not promote unrelated linked open PRs", () => {
       promotionGhMock({
         number: 333,
         title: "Related activity PR",
-        itemCreatedAt: "2026-05-20T00:00:00Z",
+        itemCreatedAt: recentItemCreatedAt(),
         comment: synced.comment,
         linkedPulls: {
           401: {
@@ -275,7 +281,7 @@ test("apply-decisions does not promote unrelated linked merged PRs", () => {
       promotionGhMock({
         number: 334,
         title: "Related merged activity PR",
-        itemCreatedAt: "2026-05-20T00:00:00Z",
+        itemCreatedAt: recentItemCreatedAt(),
         comment: synced.comment,
         linkedPulls: {
           402: {


### PR DESCRIPTION
## Summary

- make the two relationship-classification fixtures explicitly recent at test runtime
- prevent the unrelated-linked-PR tests from crossing the production 60-day stale threshold as the calendar advances

## Root cause

The fixtures used `2026-05-20` as a supposedly recent creation date. On 2026-07-19 they became 60 days old, so production stale-promotion policy correctly activated and the tests began failing on unchanged code.

## Validation

- `node --test test/apply-pr-supersession-promotion.test.ts` (4/4)
- `pnpm run check`
- local autoreview: 0 findings, patch correct (0.96)
- staged gitleaks: no leaks found