### PR TITLE
fix(repair): isolate deferred verdict routing

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -81,7 +81,9 @@ env:
   CLAWSWEEPER_AUTHOR_PR_BUDGET_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_AUTHOR_PR_BUDGET_CLOSE_ENABLED || 'false' }}
 
 concurrency:
-  group: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.comment_id && format('repair-comment-router-{0}-comment-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.comment_id) || format('repair-comment-router-{0}', github.event.inputs.target_repo || github.event.client_payload.target_repo || 'openclaw/openclaw') }}
+  # GitHub retains only one pending run per concurrency group. Exact-item verdict
+  # handoffs need their own group so unrelated router traffic cannot replace them.
+  group: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.comment_id && format('repair-comment-router-{0}-comment-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.comment_id) || github.event_name == 'workflow_dispatch' && github.event.inputs.item_numbers != '' && format('repair-comment-router-{0}-items-{1}', github.event.inputs.target_repo || 'openclaw/openclaw', github.event.inputs.item_numbers) || format('repair-comment-router-{0}', github.event.inputs.target_repo || github.event.client_payload.target_repo || 'openclaw/openclaw') }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1682,6 +1682,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
           TARGET_BRANCH: ${{ steps.publication-context.outputs.target_branch }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
           CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
           CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
         run: |
@@ -1691,6 +1692,7 @@ jobs:
             -f execute=true \
             -f target_repo="$TARGET_REPO" \
             -f target_branch="$TARGET_BRANCH" \
+            -f item_numbers="$ITEM_NUMBER" \
             -f lookback_minutes="$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
             -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS"
 

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -56,6 +56,9 @@ export function runAutomergeE2E({
 
   try {
     const runtimeRoot = createCandidateRuntime(root, candidateRoot);
+    if (scenario === "resume-intent-persistence") {
+      assertDeferredVerdictHandoffIsolation(candidateRoot);
+    }
     const targetFixture =
       scenario === "ci-regression-29623139111"
         ? createCiRegressionFixture(root, { fixture })
@@ -403,6 +406,24 @@ export function runAutomergeE2E({
   } finally {
     if (!keep) fs.rmSync(root, { recursive: true, force: true });
   }
+}
+
+function assertDeferredVerdictHandoffIsolation(candidateRoot) {
+  const sweep = fs.readFileSync(path.join(candidateRoot, ".github/workflows/sweep.yml"), "utf8");
+  const router = fs.readFileSync(
+    path.join(candidateRoot, ".github/workflows/repair-comment-router.yml"),
+    "utf8",
+  );
+  assert.match(
+    sweep,
+    /Queue deferred exact verdict router[\s\S]*-f item_numbers="\$ITEM_NUMBER"/,
+    "the exact review publisher must identify the PR in its deferred router handoff",
+  );
+  assert.match(
+    router,
+    /github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.item_numbers != '' && format\('repair-comment-router-\{0\}-items-\{1\}'/,
+    "deferred verdict handoffs must not share the replaceable repository-wide pending group",
+  );
 }
 
 function createCandidateRuntime(root, candidateRoot) {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -497,6 +497,11 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(deferredRoute.if ?? "", /publish-event-result\.outcome == 'success'/);
   assert.match(deferredRoute.if ?? "", /routing_deferred == 'true'/);
   assert.match(deferredRoute.run ?? "", /repair-comment-router\.yml/);
+  assert.equal(
+    deferredRoute.env?.ITEM_NUMBER,
+    "${{ steps.publication-context.outputs.item_number }}",
+  );
+  assert.match(deferredRoute.run ?? "", /-f item_numbers="\$ITEM_NUMBER"/);
   const drift = step(publisher, "Queue fresh review after source drift");
   assert.match(drift.if ?? "", /requeue_latest == 'true'/);
   assert.match(drift.if ?? "", /legacy-exact-artifact\.outputs\.legacy_tupleless == 'true'/);
@@ -1911,6 +1916,21 @@ test("trusted comment router owns command ledger capacity retries", () => {
   assert.match(routerWorkflow, /Detect waiting repair dispatches/);
   assert.match(routerWorkflow, /--status waiting,active/);
   assert.match(routerWorkflow, /--wait-for-capacity/);
+});
+
+test("deferred exact verdict routers cannot replace each other's pending runs", () => {
+  const workflow = readText(".github/workflows/repair-comment-router.yml");
+  const concurrency = workflow.slice(workflow.indexOf("concurrency:"), workflow.indexOf("\njobs:"));
+
+  // GitHub keeps only one pending run per group even when cancel-in-progress is false.
+  // Binding exact workflow dispatches to their item preserves both handoffs under load.
+  assert.match(concurrency, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(concurrency, /github\.event\.inputs\.item_numbers != ''/);
+  assert.match(
+    concurrency,
+    /format\('repair-comment-router-\{0\}-items-\{1\}'[\s\S]*github\.event\.inputs\.item_numbers/,
+  );
+  assert.match(concurrency, /cancel-in-progress: false/);
 });
 
 test("comment commands keep the router-to-sweep dispatch contract", () => {


### PR DESCRIPTION
## Summary

- scope deferred exact-verdict router dispatches to their target item
- preserve repository-scoped concurrency for broad scans
- add workflow and automerge E2E regression coverage for pending-run replacement

## Root cause

GitHub keeps only one pending run per concurrency group even when `cancel-in-progress` is false. Exact verdict handoffs shared the broad repository router group, so unrelated router traffic could replace a pending automerge verdict before it obtained a job.

## Validation

- `pnpm run check`
- local container: `resume-intent-persistence` with the tiny fixture
- local autoreview: 0 findings, patch correct (0.94)
- gitleaks: no leaks