### PR TITLE
Add PR review observability foundation

### DIFF
--- a/dashboard/dashboard-health.ts
+++ b/dashboard/dashboard-health.ts
@@ -1,0 +1,97 @@
+export type DashboardHealth = {
+  conclusion: "all_clear" | "needs_attention";
+  severity: "green" | "amber" | "red";
+  reasons: string[];
+};
+
+export function summarizeDashboardHealth(snapshot: Record<string, unknown>): DashboardHealth {
+  const reasons: string[] = [];
+  let severity: DashboardHealth["severity"] = "green";
+  const raise = (next: DashboardHealth["severity"], reason: string) => {
+    reasons.push(reason);
+    if (next === "red" || (next === "amber" && severity === "green")) severity = next;
+  };
+
+  const diagnostics = objectValue(snapshot.diagnostics);
+  const queue = objectValue(snapshot.exact_review_queue);
+  const queueUnavailable =
+    snapshot.exact_review_queue == null || Boolean(diagnostics.exact_review_queue_error);
+  if (queueUnavailable) raise("amber", "queue_telemetry_unavailable");
+  if (!queueUnavailable) {
+    const handoffStatus = String(objectValue(queue.handoff_health).status || "");
+    if (handoffStatus === "stalled") raise("red", "queue_handoff_stalled");
+    else if (handoffStatus === "degraded") raise("amber", "queue_handoff_degraded");
+    else if (!["healthy", "idle"].includes(handoffStatus)) {
+      raise("amber", "queue_handoff_unavailable");
+    }
+
+    const publication = objectValue(objectValue(objectValue(queue.lanes).publication).health);
+    const publicationStatus = String(publication.status || "");
+    if (publicationStatus === "critical") raise("red", "publication_critical");
+    else if (publicationStatus === "degraded") raise("amber", "publication_degraded");
+    else if (!["healthy", "idle"].includes(publicationStatus)) {
+      raise("amber", "publication_health_unavailable");
+    }
+
+    const openDeadLetters = nonNegativeNumber(
+      objectValue(objectValue(objectValue(queue.lanes).publication).dead_letters).open,
+    );
+    if (openDeadLetters > 0) raise("amber", "publication_dlq_open");
+
+    const reviewTelemetry = objectValue(queue.review_telemetry_health);
+    const reviewTelemetryStatus = String(reviewTelemetry.status || "");
+    if (reviewTelemetryStatus === "critical") raise("red", "orphan_review_status");
+    else if (reviewTelemetryStatus === "degraded") raise("amber", "slow_review_status");
+    else if (reviewTelemetryStatus !== "healthy") {
+      raise("amber", "review_telemetry_unavailable");
+    }
+  }
+
+  const operationalStatus = String(objectValue(snapshot.operational_health).status || "");
+  if (operationalStatus === "stalled") raise("red", "workflow_execution_stalled");
+  else if (!["healthy", "idle"].includes(operationalStatus)) {
+    raise("amber", "workflow_execution_degraded");
+  }
+
+  const workerHealth = objectValue(snapshot.health);
+  if (nonNegativeNumber(workerHealth.unresolved_failures) > 0) {
+    raise("amber", "worker_failures_unresolved");
+  }
+  const recent = objectValue(snapshot.recent);
+  const applyItems = arrayValue(objectValue(recent.apply_health).items);
+  if (applyItems.some((item) => applyHealthNeedsAttention(objectValue(item).status))) {
+    raise("amber", "apply_health_attention");
+  }
+  const automerge = objectValue(recent.automerge_reliability);
+  if (
+    nonNegativeNumber(automerge.unresolved_failures) > 0 ||
+    nonNegativeNumber(automerge.stalled_attempts) > 0
+  ) {
+    raise("amber", "automerge_attention");
+  }
+
+  return {
+    conclusion: reasons.length ? "needs_attention" : "all_clear",
+    severity,
+    reasons: [...new Set(reasons)],
+  };
+}
+
+function applyHealthNeedsAttention(value: unknown) {
+  return ["attention", "blocked", "degraded", "failed", "needs_attention", "warning"].includes(
+    String(value || "").toLowerCase(),
+  );
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function nonNegativeNumber(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, number) : 0;
+}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -3,6 +3,14 @@ import {
   summarizeExactReviewHandoff,
   summarizeExactReviewPressure,
 } from "./exact-review-health.ts";
+import {
+  REVIEW_TELEMETRY_DEGRADED_MS,
+  REVIEW_TELEMETRY_ORPHAN_MS,
+  REVIEW_TELEMETRY_RETENTION_MS,
+  type DurableReviewTelemetry,
+  type ReviewTelemetryHealth,
+  normalizeReviewTelemetry,
+} from "./review-telemetry.ts";
 
 type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
 const GITHUB_TIMEOUT_MS = 4500;
@@ -263,6 +271,7 @@ const EXACT_REVIEW_QUEUE_DELIVERY_TABLE = "exact_review_queue_deliveries";
 const EXACT_REVIEW_QUEUE_METRICS_TABLE = "exact_review_queue_metrics";
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE = "exact_review_queue_metric_buckets";
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
+const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT = 5_000;
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS = 5 * 60 * 1000;
@@ -847,6 +856,14 @@ export class ExactReviewQueue {
       return this.supersedePublicationCandidates(await request.json().catch(() => null));
     }
 
+    if (request.method === "POST" && url.pathname === "/review-telemetry") {
+      return this.recordReviewTelemetry(await request.json().catch(() => null));
+    }
+
+    if (request.method === "GET" && url.pathname === "/review-telemetry") {
+      return this.listReviewTelemetry(url.searchParams);
+    }
+
     if (request.method === "GET" && url.pathname === "/item-status") {
       const targetRepo = String(url.searchParams.get("target_repo") || "").trim();
       const itemNumber = Number(url.searchParams.get("item_number"));
@@ -956,6 +973,7 @@ export class ExactReviewQueue {
       const snapshot = this.storage.transactionSync(() => {
         this.pruneDeliveryReceiptsSync(now);
         this.pruneQueueTelemetrySync(now);
+        this.pruneReviewTelemetrySync(now);
         const current = this.readStateSync();
         // Dashboard reads are also the operational heartbeat. Reclaim leases and
         // restore the alarm here so a deploy or lost alarm cannot strand backlog.
@@ -973,9 +991,11 @@ export class ExactReviewQueue {
           reviewFlow: this.reviewFlowSummarySync(now),
           publicationFlow: this.publicationFlowSummarySync(now),
           deadLetters: this.deadLetterStatsSync(),
+          reviewTelemetryHealth: this.reviewTelemetryHealthSync(now),
         };
       });
-      const { state, metrics, reviewFlow, publicationFlow, deadLetters } = snapshot;
+      const { state, metrics, reviewFlow, publicationFlow, deadLetters, reviewTelemetryHealth } =
+        snapshot;
       const publicationControl = this.refreshPublicationControlSync(state, now);
       await this.scheduleNext(state, now);
       const stats = exactReviewQueueStats(
@@ -1026,6 +1046,7 @@ export class ExactReviewQueue {
           },
         },
         delivery_receipts: this.deliveryReceiptCountSync(),
+        review_telemetry_health: reviewTelemetryHealth,
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
         legacy_rollback_available:
           !this.legacyMirrorDisabled &&
@@ -1543,6 +1564,159 @@ export class ExactReviewQueue {
     });
   }
 
+  private recordReviewTelemetry(value: unknown) {
+    const record = normalizeReviewTelemetry(value);
+    if (!record) return json({ error: "invalid_review_telemetry" }, 400);
+    const updatedAt = Date.parse(record.updated_at);
+    this.storage.transactionSync(() => {
+      this.pruneReviewTelemetrySync(Date.now());
+      // Terminal truth is first-writer immutable. Retries may replay the same
+      // payload, but neither a heartbeat nor a conflicting terminal delivery
+      // may make durable observations depend on arrival order.
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}
+           (repo, item_number, run_id, run_attempt, status, updated_at, lease_expires_at,
+            record_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(repo, item_number, run_id, run_attempt) DO UPDATE SET
+           status = excluded.status,
+           updated_at = excluded.updated_at,
+           lease_expires_at = excluded.lease_expires_at,
+           record_json = excluded.record_json
+         WHERE ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}.status != 'completed'
+           AND (excluded.status = 'completed'
+                OR excluded.updated_at >= ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}.updated_at)`,
+        record.repo,
+        record.item_number,
+        record.run_id,
+        record.run_attempt,
+        record.status,
+        updatedAt,
+        record.lease_expires_at === null ? null : Date.parse(record.lease_expires_at),
+        JSON.stringify(record),
+      );
+    });
+    return json({ ok: true });
+  }
+
+  private listReviewTelemetry(search: URLSearchParams) {
+    const repo = String(search.get("repo") || "").trim();
+    const itemNumber = Number(search.get("item_number"));
+    const limit = search.has("limit") ? Number(search.get("limit")) : 20;
+    if (
+      !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) ||
+      !Number.isInteger(itemNumber) ||
+      itemNumber < 1 ||
+      !Number.isInteger(limit) ||
+      limit < 1 ||
+      limit > 100
+    ) {
+      return json({ error: "invalid_review_telemetry_query" }, 400);
+    }
+    this.pruneReviewTelemetrySync(Date.now());
+    return json({
+      ok: true,
+      repo,
+      item_number: itemNumber,
+      reviews: this.reviewTelemetryRowsSync({ repo, itemNumber, limit }),
+    });
+  }
+
+  private reviewTelemetryRowsSync(options: {
+    repo?: string;
+    itemNumber?: number;
+    status?: DurableReviewTelemetry["status"];
+    limit?: number;
+  }) {
+    const predicates: string[] = [];
+    const bindings: unknown[] = [];
+    if (options.repo !== undefined) {
+      predicates.push("repo = ?");
+      bindings.push(options.repo);
+    }
+    if (options.itemNumber !== undefined) {
+      predicates.push("item_number = ?");
+      bindings.push(options.itemNumber);
+    }
+    if (options.status !== undefined) {
+      predicates.push("status = ?");
+      bindings.push(options.status);
+    }
+    const rows = this.storage.sql.exec(
+      `SELECT record_json
+         FROM ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}
+        ${predicates.length ? `WHERE ${predicates.join(" AND ")}` : ""}
+        ORDER BY updated_at DESC, repo, item_number, run_id, run_attempt
+        LIMIT ?`,
+      ...bindings,
+      options.limit ?? 100,
+    ) as Iterable<{ record_json?: unknown }>;
+    return Array.from(rows)
+      .map((row) => normalizeReviewTelemetry(JSON.parse(String(row.record_json || "null"))))
+      .filter((record): record is DurableReviewTelemetry => record !== null);
+  }
+
+  private reviewTelemetryHealthSync(now: number): ReviewTelemetryHealth {
+    const counts = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS refreshing,
+                COALESCE(SUM(CASE WHEN updated_at <= ? THEN 1 ELSE 0 END), 0)
+                  AS slow_refreshing,
+                COALESCE(SUM(CASE
+                  WHEN updated_at <= ?
+                   AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
+                  THEN 1 ELSE 0 END), 0) AS orphan_refreshing
+           FROM ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}
+          WHERE status = 'refreshing'`,
+        now - REVIEW_TELEMETRY_DEGRADED_MS,
+        now - REVIEW_TELEMETRY_ORPHAN_MS,
+        now,
+      ),
+    )[0] as Record<string, unknown> | undefined;
+    const orphanCount = Number(counts?.orphan_refreshing || 0);
+    const orphanRows = this.storage.sql.exec(
+      `SELECT record_json
+         FROM ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}
+        WHERE status = 'refreshing'
+          AND updated_at <= ?
+          AND (lease_expires_at IS NULL OR lease_expires_at <= ?)
+        ORDER BY updated_at, repo, item_number, run_id, run_attempt
+        LIMIT 20`,
+      now - REVIEW_TELEMETRY_ORPHAN_MS,
+      now,
+    ) as Iterable<{ record_json?: unknown }>;
+    const orphans = Array.from(orphanRows)
+      .map((row) => normalizeReviewTelemetry(JSON.parse(String(row.record_json || "null")), now))
+      .filter((record): record is DurableReviewTelemetry => record !== null)
+      .map((record) => ({
+        repo: record.repo,
+        item_number: record.item_number,
+        run_id: record.run_id,
+        run_attempt: record.run_attempt,
+        updated_at: record.updated_at,
+        age_seconds: Math.floor(Math.max(0, now - Date.parse(record.updated_at)) / 1000),
+        lease_expires_at: record.lease_expires_at,
+      }));
+    const slowCount = Number(counts?.slow_refreshing || 0);
+    return {
+      status: orphanCount ? "critical" : slowCount ? "degraded" : "healthy",
+      refreshing: Number(counts?.refreshing || 0),
+      slow_refreshing: slowCount,
+      orphan_refreshing: orphanCount,
+      degraded_after_seconds: REVIEW_TELEMETRY_DEGRADED_MS / 1000,
+      orphan_after_seconds: REVIEW_TELEMETRY_ORPHAN_MS / 1000,
+      orphans,
+    };
+  }
+
+  private pruneReviewTelemetrySync(now: number) {
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}
+        WHERE status = 'completed' AND updated_at <= ?`,
+      now - REVIEW_TELEMETRY_RETENTION_MS,
+    );
+  }
+
   private async supersedePublicationCandidates(value: unknown) {
     const body = objectValue(value);
     const candidates = exactReviewPublicationCandidates(body.items);
@@ -1789,6 +1963,38 @@ export class ExactReviewQueue {
       `CREATE INDEX IF NOT EXISTS exact_review_queue_dead_letters_status
          ON ${EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE}
          (status, last_failed_at, dead_letter_id)`,
+    );
+    // Review telemetry is intentionally additive to the v1 queue protocol.
+    // PR 674 can populate generation and operation_id inside record_json
+    // without coupling this observation schema to its queue tuple rollout.
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE} (
+         repo TEXT NOT NULL,
+         item_number INTEGER NOT NULL CHECK (item_number >= 1),
+         run_id TEXT NOT NULL,
+         run_attempt INTEGER NOT NULL CHECK (run_attempt >= 1),
+         status TEXT NOT NULL CHECK (status IN ('refreshing', 'completed')),
+         updated_at INTEGER NOT NULL,
+         lease_expires_at INTEGER,
+         record_json TEXT NOT NULL,
+         PRIMARY KEY (repo, item_number, run_id, run_attempt)
+       ) STRICT`,
+    );
+    const hasLeaseExpiry = Array.from(
+      this.storage.sql.exec(
+        `SELECT name FROM pragma_table_info('${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}')
+          WHERE name = 'lease_expires_at'`,
+      ),
+    ).length;
+    if (!hasLeaseExpiry) {
+      this.storage.sql.exec(
+        `ALTER TABLE ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE}
+           ADD COLUMN lease_expires_at INTEGER`,
+      );
+    }
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_review_telemetry_status
+         ON ${EXACT_REVIEW_REVIEW_TELEMETRY_TABLE} (status, updated_at)`,
     );
   }
 

--- a/dashboard/review-telemetry.ts
+++ b/dashboard/review-telemetry.ts
@@ -1,0 +1,168 @@
+export const REVIEW_TELEMETRY_DEGRADED_MS = 30 * 60 * 1000;
+export const REVIEW_TELEMETRY_ORPHAN_MS = 150 * 60 * 1000;
+export const REVIEW_TELEMETRY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+export const REVIEW_TELEMETRY_CLOCK_SKEW_MS = 5 * 60 * 1000;
+export const REVIEW_TELEMETRY_MAX_LEASE_HORIZON_MS = 24 * 60 * 60 * 1000;
+
+const OUTCOMES = new Set(["succeeded", "failed", "cancelled", "interrupted", "superseded"]);
+const PHASES = ["queue", "claim", "review", "publication", "total"] as const;
+
+export type DurableReviewTelemetry = {
+  repo: string;
+  item_number: number;
+  run_id: string;
+  run_attempt: number;
+  status: "refreshing" | "completed";
+  outcome: "succeeded" | "failed" | "cancelled" | "interrupted" | "superseded" | null;
+  started_at: string;
+  updated_at: string;
+  lease_expires_at: string | null;
+  phase_durations_ms: Partial<Record<(typeof PHASES)[number], number>>;
+  generation?: number;
+  operation_id?: string;
+};
+
+export type ReviewTelemetryHealth = {
+  status: "healthy" | "degraded" | "critical";
+  refreshing: number;
+  slow_refreshing: number;
+  orphan_refreshing: number;
+  degraded_after_seconds: number;
+  orphan_after_seconds: number;
+  orphans: Array<{
+    repo: string;
+    item_number: number;
+    run_id: string;
+    run_attempt: number;
+    updated_at: string;
+    age_seconds: number;
+    lease_expires_at: string | null;
+  }>;
+};
+
+export function normalizeReviewTelemetry(
+  value: unknown,
+  now = Date.now(),
+): DurableReviewTelemetry | null {
+  const record = objectValue(value);
+  const repo = String(record.repo || "").trim();
+  const itemNumber = Number(record.item_number);
+  const runId = String(record.run_id || "").trim();
+  const runAttempt = Number(record.run_attempt);
+  const status = String(record.status || "");
+  const outcome = record.outcome == null ? null : String(record.outcome);
+  const startedAt = timestamp(record.started_at);
+  const updatedAt = timestamp(record.updated_at);
+  const leaseExpiresAt =
+    record.lease_expires_at == null ? null : timestamp(record.lease_expires_at);
+  if (
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) ||
+    !Number.isSafeInteger(itemNumber) ||
+    itemNumber < 1 ||
+    !runId ||
+    runId.length > 100 ||
+    !Number.isSafeInteger(runAttempt) ||
+    runAttempt < 1 ||
+    !["refreshing", "completed"].includes(status) ||
+    (status === "refreshing" ? outcome !== null : !OUTCOMES.has(String(outcome))) ||
+    !startedAt ||
+    !updatedAt ||
+    Date.parse(updatedAt) < Date.parse(startedAt) ||
+    Date.parse(startedAt) > now + REVIEW_TELEMETRY_CLOCK_SKEW_MS ||
+    Date.parse(updatedAt) > now + REVIEW_TELEMETRY_CLOCK_SKEW_MS ||
+    (leaseExpiresAt !== null &&
+      Date.parse(leaseExpiresAt) > now + REVIEW_TELEMETRY_MAX_LEASE_HORIZON_MS) ||
+    (record.lease_expires_at != null && !leaseExpiresAt)
+  ) {
+    return null;
+  }
+  const generation = optionalPositiveInteger(record.generation);
+  const operationId = optionalBoundedString(record.operation_id, 200);
+  if (generation === null || operationId === null) return null;
+  const phaseDurations = normalizePhaseDurations(record.phase_durations_ms);
+  if (!phaseDurations) return null;
+  return {
+    repo,
+    item_number: itemNumber,
+    run_id: runId,
+    run_attempt: runAttempt,
+    status: status as DurableReviewTelemetry["status"],
+    outcome: outcome as DurableReviewTelemetry["outcome"],
+    started_at: startedAt,
+    updated_at: updatedAt,
+    lease_expires_at: leaseExpiresAt,
+    phase_durations_ms: phaseDurations,
+    ...(generation === undefined ? {} : { generation }),
+    ...(operationId === undefined ? {} : { operation_id: operationId }),
+  };
+}
+
+export function summarizeReviewTelemetryHealth(
+  records: readonly DurableReviewTelemetry[],
+  now = Date.now(),
+): ReviewTelemetryHealth {
+  const refreshing = records.filter((record) => record.status === "refreshing");
+  const aged = refreshing.map((record) => ({
+    record,
+    age: Math.max(0, now - Date.parse(record.updated_at)),
+    leaseActive: record.lease_expires_at !== null && Date.parse(record.lease_expires_at) > now,
+  }));
+  const slow = aged.filter(({ age }) => age >= REVIEW_TELEMETRY_DEGRADED_MS);
+  const orphanRecords = aged.filter(
+    ({ age, leaseActive }) => age >= REVIEW_TELEMETRY_ORPHAN_MS && !leaseActive,
+  );
+  const orphans = orphanRecords
+    .sort((left, right) => right.age - left.age)
+    .slice(0, 20)
+    .map(({ record, age }) => ({
+      repo: record.repo,
+      item_number: record.item_number,
+      run_id: record.run_id,
+      run_attempt: record.run_attempt,
+      updated_at: record.updated_at,
+      age_seconds: Math.floor(age / 1000),
+      lease_expires_at: record.lease_expires_at,
+    }));
+  return {
+    status: orphanRecords.length ? "critical" : slow.length ? "degraded" : "healthy",
+    refreshing: refreshing.length,
+    slow_refreshing: slow.length,
+    orphan_refreshing: orphanRecords.length,
+    degraded_after_seconds: REVIEW_TELEMETRY_DEGRADED_MS / 1000,
+    orphan_after_seconds: REVIEW_TELEMETRY_ORPHAN_MS / 1000,
+    orphans,
+  };
+}
+
+function normalizePhaseDurations(value: unknown) {
+  const durations = objectValue(value);
+  const result: DurableReviewTelemetry["phase_durations_ms"] = {};
+  for (const phase of PHASES) {
+    if (durations[phase] === undefined) continue;
+    const duration = Number(durations[phase]);
+    if (!Number.isSafeInteger(duration) || duration < 0) return null;
+    result[phase] = duration;
+  }
+  return result;
+}
+
+function timestamp(value: unknown) {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function optionalPositiveInteger(value: unknown) {
+  if (value === undefined || value === null) return undefined;
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : null;
+}
+
+function optionalBoundedString(value: unknown, maxLength: number) {
+  if (value === undefined || value === null) return undefined;
+  const string = String(value).trim();
+  return string && string.length <= maxLength ? string : null;
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -4,6 +4,7 @@ import {
 } from "../src/repair/comment-command-text.ts";
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
 import { bayHtml } from "./bay-page.ts";
+import { summarizeDashboardHealth } from "./dashboard-health.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
   exactReviewHistorySample,
@@ -526,12 +527,16 @@ export default {
       request.method === "POST"
     )
       return authenticatedExactReviewQueueRequest(request, env, "/publications/supersede");
+    if (url.pathname === "/internal/exact-review/review-telemetry" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/review-telemetry");
     if (url.pathname === "/internal/exact-review/reconcile" && request.method === "POST")
       return authenticatedExactReviewReconcile(request, env);
     if (url.pathname === "/api/exact-review-queue" && request.method === "GET")
       return exactReviewQueueRequest(env, "/stats");
     if (url.pathname === "/api/exact-review-queue/item" && request.method === "GET")
       return exactReviewQueueRequest(env, `/item-status?${url.searchParams.toString()}`);
+    if (url.pathname === "/api/exact-review-queue/reviews" && request.method === "GET")
+      return exactReviewQueueRequest(env, `/review-telemetry?${url.searchParams.toString()}`);
     if (url.pathname === "/api/health-history" && request.method === "GET")
       return healthHistoryJson(request, env);
     if (url.pathname === "/api/automerge-metrics" && request.method === "GET")
@@ -2033,7 +2038,7 @@ async function attachExactReviewQueueStatus(snapshot, env) {
   } catch (error) {
     exactReviewQueueError = error instanceof Error ? error.message : String(error);
   }
-  return {
+  const attached = {
     ...snapshot,
     exact_review_queue: exactReviewQueue,
     diagnostics: {
@@ -2041,6 +2046,7 @@ async function attachExactReviewQueueStatus(snapshot, env) {
       exact_review_queue_error: exactReviewQueueError,
     },
   };
+  return { ...attached, dashboard_health: summarizeDashboardHealth(attached) };
 }
 
 async function triageSnapshot(env) {
@@ -8895,25 +8901,27 @@ async function load() {
 }
 
 function renderDashboard(data, note) {
-  const unresolved = data.health?.unresolved_failures || 0;
-  const applyAttention = (data.recent?.apply_health?.items || []).filter(item =>
-    applyHealthNeedsAttention(item.status)
-  ).length;
   const handoffStatus = data.exact_review_queue?.handoff_health?.status;
-  const handoffTelemetryFailed = Boolean(data.diagnostics?.exact_review_queue_error);
-  const handoffAttention =
-    handoffTelemetryFailed || handoffStatus === "degraded" || handoffStatus === "stalled";
   const operationalStatus = data.operational_health?.status;
-  const operationalAttention = ["degraded", "stalled", "unknown"].includes(operationalStatus);
-  const automergeReliability = data.recent?.automerge_reliability;
-  const automergeAttention =
-    (automergeReliability?.unresolved_failures || 0) > 0 ||
-    (automergeReliability?.stalled_attempts || 0) > 0;
-  const needsAttention =
-    unresolved || applyAttention || handoffAttention || operationalAttention || automergeAttention;
+  const serverHealth = data.dashboard_health;
+  // Cached snapshots from before the observation contract remain readable
+  // during rollout; new snapshots use the server-owned aggregate exclusively.
+  const needsAttention = serverHealth
+    ? serverHealth.conclusion === "needs_attention"
+    : Boolean(
+        (data.health?.unresolved_failures || 0) ||
+        (data.recent?.apply_health?.items || []).some(item => applyHealthNeedsAttention(item.status)) ||
+        Boolean(data.diagnostics?.exact_review_queue_error) ||
+        ["degraded", "stalled"].includes(handoffStatus) ||
+        ["degraded", "stalled", "unknown"].includes(operationalStatus) ||
+        (data.recent?.automerge_reliability?.unresolved_failures || 0) > 0 ||
+        (data.recent?.automerge_reliability?.stalled_attempts || 0) > 0
+      );
+  const severity = serverHealth?.severity ||
+    (handoffStatus === "stalled" || operationalStatus === "stalled" ? "red" : needsAttention ? "amber" : "green");
   const workerCount = (data.workers || []).length;
   const repoCount = (data.source.target_repositories || []).length;
-  document.getElementById("hero-dot").className = "hero-dot " + (handoffStatus === "stalled" || operationalStatus === "stalled" ? "red" : needsAttention ? "amber" : "ok");
+  document.getElementById("hero-dot").className = "hero-dot " + (severity === "green" ? "ok" : severity);
   document.getElementById("hero-headline").textContent =
     (needsAttention ? "Needs attention" : "All clear") + " — " +
     fmt.format(workerCount) + " claw worker" + (workerCount === 1 ? "" : "s") + " sweeping " +

--- a/docs/pr-674-observation-runbook.md
+++ b/docs/pr-674-observation-runbook.md
@@ -1,0 +1,62 @@
+# PR 674 observation-layer rollout
+
+This observation layer must land before
+[ClawSweeper PR 674](https://github.com/openclaw/clawsweeper/pull/674). It does not copy that
+PR's per-item shard implementation or generation-bound queue protocol. Instead it provides the
+backward-compatible contract that the later PR can populate.
+
+## Health policy
+
+The dashboard hero is green (`All clear`) only when every known signal is healthy. The aggregate
+uses these stable rules:
+
+| Signal                   | Green                      | Amber                       | Red                                                          |
+| ------------------------ | -------------------------- | --------------------------- | ------------------------------------------------------------ |
+| Publication health       | `idle` or `healthy`        | `degraded`                  | `critical`                                                   |
+| Publication DLQ          | no open entries            | one or more open entries    | publication health is `critical`                             |
+| Queue telemetry          | current snapshot available | unavailable or incomplete   | n/a                                                          |
+| Durable review status    | refreshing under 30m       | refreshing for at least 30m | refreshing for at least 150m without a provably active lease |
+| Queue/workflow execution | healthy or idle            | degraded/unknown            | stalled                                                      |
+
+Open DLQ is amber even when another compatibility producer has not populated publication health.
+`critical` and `stalled` always dominate and render the top-level indicator red.
+
+## Durable review telemetry contract
+
+Authenticated producers write one row per `(repo, item_number, run_id, run_attempt)` through
+`POST /internal/exact-review/review-telemetry`. Operators and dashboards query an item's newest
+attempts through:
+
+```text
+GET /api/exact-review-queue/reviews?repo=openclaw/openclaw&item_number=123&limit=20
+```
+
+Every row carries `status`, terminal `outcome`, `started_at`, `updated_at`, optional lease expiry,
+and bounded phase durations for `queue`, `claim`, `review`, `publication`, and `total`.
+`generation` and `operation_id` are optional until PR 674 supplies authoritative values. Terminal
+rows cannot be reopened by a delayed refreshing heartbeat. Completed rows are retained for 30
+days; active refreshing rows are retained until a producer records a terminal result.
+
+The watchdog is deliberately read-only. An aged refreshing row without an active lease appears in
+`review_telemetry_health.orphans` and turns dashboard health red, but observation alone never
+changes the outcome to `interrupted`. A producer may record `interrupted` only after it proves the
+GitHub run is terminal and no current lease owns the attempt.
+
+## Rollout and rollback
+
+1. Deploy this change and verify `/api/status` includes `dashboard_health` and
+   `exact_review_queue.review_telemetry_health` while existing review traffic remains unchanged.
+2. Confirm healthy traffic remains green, then exercise fixture or staging records at the 30m and
+   150m boundaries. Do not create synthetic records in the live queue.
+3. Land PR 674 and have each item shard write `refreshing` after its authoritative claim, update
+   phase durations at transitions, then write exactly one terminal outcome. Populate its generation
+   and operation identity without changing this endpoint shape.
+4. Compare each sampled row with its full GitHub Actions run URL and verify repo, item, run attempt,
+   generation, terminal outcome, and total duration. Confirm a live lease keeps an old heartbeat out
+   of the orphan list.
+5. Verify publication backlog, open DLQ, queue read failure, one degraded sample, and one
+   critical/stalled sample all reach the dashboard hero with the expected amber/red severity.
+
+If PR 674 must roll back, stop its telemetry writes only; this additive table and query remain safe
+for older producers. Do not pause the live sweep. Investigate an orphan from its repo/item/run tuple,
+then record `interrupted` only with terminal-run and lease evidence.

--- a/test/dashboard-health.test.ts
+++ b/test/dashboard-health.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { summarizeDashboardHealth } from "../dashboard/dashboard-health.ts";
+
+function healthySnapshot(): Record<string, unknown> {
+  return {
+    diagnostics: { exact_review_queue_error: null },
+    exact_review_queue: {
+      handoff_health: { status: "healthy" },
+      lanes: {
+        publication: {
+          health: { status: "healthy" },
+          dead_letters: { open: 0 },
+        },
+      },
+      review_telemetry_health: { status: "healthy" },
+    },
+    operational_health: { status: "healthy" },
+    health: { unresolved_failures: 0 },
+    recent: {
+      apply_health: { items: [] },
+      automerge_reliability: { unresolved_failures: 0, stalled_attempts: 0 },
+    },
+  };
+}
+
+test("dashboard health is green only when every top-level signal is healthy", () => {
+  assert.deepEqual(summarizeDashboardHealth(healthySnapshot()), {
+    conclusion: "all_clear",
+    severity: "green",
+    reasons: [],
+  });
+  const idle = healthySnapshot();
+  idle.operational_health = { status: "idle" };
+  assert.equal(summarizeDashboardHealth(idle).severity, "green");
+});
+
+test("dashboard health rolls publication, DLQ, and missing queue telemetry upward", () => {
+  const degraded = healthySnapshot();
+  const queue = degraded.exact_review_queue as Record<string, any>;
+  queue.lanes.publication.health.status = "degraded";
+  queue.lanes.publication.dead_letters.open = 2;
+  assert.deepEqual(summarizeDashboardHealth(degraded), {
+    conclusion: "needs_attention",
+    severity: "amber",
+    reasons: ["publication_degraded", "publication_dlq_open"],
+  });
+
+  const unavailable = healthySnapshot();
+  unavailable.exact_review_queue = null;
+  assert.deepEqual(summarizeDashboardHealth(unavailable), {
+    conclusion: "needs_attention",
+    severity: "amber",
+    reasons: ["queue_telemetry_unavailable"],
+  });
+});
+
+test("dashboard health maps critical and stalled signals to red", () => {
+  const snapshot = healthySnapshot();
+  const queue = snapshot.exact_review_queue as Record<string, any>;
+  queue.lanes.publication.health.status = "critical";
+  queue.review_telemetry_health.status = "critical";
+  assert.deepEqual(summarizeDashboardHealth(snapshot), {
+    conclusion: "needs_attention",
+    severity: "red",
+    reasons: ["publication_critical", "orphan_review_status"],
+  });
+});
+
+test("dashboard health fails amber when a required signal is absent", () => {
+  const snapshot = healthySnapshot();
+  const queue = snapshot.exact_review_queue as Record<string, any>;
+  delete queue.review_telemetry_health;
+  delete queue.lanes.publication.health;
+  delete snapshot.operational_health;
+  assert.deepEqual(summarizeDashboardHealth(snapshot), {
+    conclusion: "needs_attention",
+    severity: "amber",
+    reasons: [
+      "publication_health_unavailable",
+      "review_telemetry_unavailable",
+      "workflow_execution_degraded",
+    ],
+  });
+});

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -11205,3 +11205,141 @@ function unclaimedExactReviewQueueItem(itemNumber: number) {
     claimProtocolVersion: undefined,
   };
 }
+
+test("exact-review queue durably stores and queries per-item review telemetry", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const now = Date.now();
+  const refreshing = {
+    repo: "openclaw/openclaw",
+    item_number: 674,
+    run_id: "12345",
+    run_attempt: 2,
+    status: "refreshing",
+    outcome: null,
+    started_at: new Date(now - 60_000).toISOString(),
+    updated_at: new Date(now).toISOString(),
+    lease_expires_at: new Date(now + 60 * 60_000).toISOString(),
+    phase_durations_ms: { queue: 10_000, claim: 2_000 },
+  };
+  const recorded = await queue.fetch(
+    new Request("https://queue/review-telemetry", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(refreshing),
+    }),
+  );
+  assert.equal(recorded.status, 200);
+
+  const completed = {
+    ...refreshing,
+    status: "completed",
+    outcome: "succeeded",
+    updated_at: new Date(now - 10_000).toISOString(),
+    lease_expires_at: null,
+    phase_durations_ms: { ...refreshing.phase_durations_ms, review: 180_000, total: 250_000 },
+    generation: 7,
+    operation_id: "review:674:7",
+  };
+  await queue.fetch(
+    new Request("https://queue/review-telemetry", {
+      method: "POST",
+      body: JSON.stringify(completed),
+    }),
+  );
+  // Neither a delayed heartbeat nor a conflicting terminal retry can rewrite
+  // the first terminal truth.
+  await queue.fetch(
+    new Request("https://queue/review-telemetry", {
+      method: "POST",
+      body: JSON.stringify({ ...refreshing, updated_at: new Date(now).toISOString() }),
+    }),
+  );
+  await queue.fetch(
+    new Request("https://queue/review-telemetry", {
+      method: "POST",
+      body: JSON.stringify({
+        ...completed,
+        outcome: "failed",
+        updated_at: new Date(now + 1_000).toISOString(),
+      }),
+    }),
+  );
+
+  const response = await queue.fetch(
+    new Request("https://queue/review-telemetry?repo=openclaw%2Fopenclaw&item_number=674"),
+  );
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { reviews: unknown[] };
+  assert.deepEqual(body.reviews, [completed]);
+
+  const restarted = new ExactReviewQueue({ storage }, {});
+  const afterRestart = await restarted.fetch(
+    new Request("https://queue/review-telemetry?repo=openclaw%2Fopenclaw&item_number=674"),
+  );
+  assert.deepEqual((await afterRestart.json()) as { reviews: unknown[] }, {
+    ok: true,
+    repo: "openclaw/openclaw",
+    item_number: 674,
+    reviews: [completed],
+  });
+});
+
+test("exact-review health includes the oldest refreshing row beyond operator page bounds", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(new Request("https://queue/stats"));
+  const now = Date.now();
+  for (let index = 0; index <= 10_000; index += 1) {
+    const old = index === 0;
+    const updatedAt = old ? now - 151 * 60_000 : now - 60_000;
+    const record = {
+      repo: "openclaw/openclaw",
+      item_number: index + 1,
+      run_id: String(index + 1),
+      run_attempt: 1,
+      status: "refreshing",
+      outcome: null,
+      started_at: new Date(updatedAt - 60_000).toISOString(),
+      updated_at: new Date(updatedAt).toISOString(),
+      lease_expires_at: null,
+      phase_durations_ms: {},
+    };
+    storage.sql.exec(
+      `INSERT INTO exact_review_review_telemetry
+       (repo, item_number, run_id, run_attempt, status, updated_at, record_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      record.repo,
+      record.item_number,
+      record.run_id,
+      record.run_attempt,
+      record.status,
+      updatedAt,
+      JSON.stringify(record),
+    );
+  }
+
+  const response = await queue.fetch(new Request("https://queue/stats"));
+  const stats = (await response.json()) as {
+    review_telemetry_health: { status: string; refreshing: number; orphan_refreshing: number };
+  };
+  assert.deepEqual(stats.review_telemetry_health, {
+    status: "critical",
+    refreshing: 10_001,
+    slow_refreshing: 1,
+    orphan_refreshing: 1,
+    degraded_after_seconds: 1800,
+    orphan_after_seconds: 9000,
+    orphans: [
+      {
+        repo: "openclaw/openclaw",
+        item_number: 1,
+        run_id: "1",
+        run_attempt: 1,
+        updated_at: new Date(now - 151 * 60_000).toISOString(),
+        age_seconds: 9060,
+        lease_expires_at: null,
+      },
+    ],
+  });
+});

--- a/test/review-telemetry.test.ts
+++ b/test/review-telemetry.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeReviewTelemetry,
+  summarizeReviewTelemetryHealth,
+} from "../dashboard/review-telemetry.ts";
+
+const NOW = Date.parse("2026-07-19T12:00:00.000Z");
+
+function telemetry(overrides: Record<string, unknown> = {}) {
+  return {
+    repo: "openclaw/openclaw",
+    item_number: 123,
+    run_id: "9001",
+    run_attempt: 2,
+    status: "refreshing",
+    outcome: null,
+    started_at: "2026-07-19T10:00:00.000Z",
+    updated_at: "2026-07-19T11:50:00.000Z",
+    lease_expires_at: "2026-07-19T12:10:00.000Z",
+    phase_durations_ms: { queue: 1000, claim: 2000 },
+    ...overrides,
+  };
+}
+
+test("review telemetry contract accepts optional generation and operation identity", () => {
+  assert.deepEqual(
+    normalizeReviewTelemetry(telemetry({ generation: 4, operation_id: "review:123:4" }), NOW),
+    telemetry({ generation: 4, operation_id: "review:123:4" }),
+  );
+  assert.equal(normalizeReviewTelemetry(telemetry({ outcome: "succeeded" }), NOW), null);
+  assert.equal(
+    normalizeReviewTelemetry(
+      telemetry({ status: "completed", outcome: "succeeded", phase_durations_ms: { total: -1 } }),
+      NOW,
+    ),
+    null,
+  );
+});
+
+test("review telemetry rejects identifiers outside SQLite's reliable integer range", () => {
+  assert.equal(normalizeReviewTelemetry(telemetry({ item_number: 1e20 }), NOW), null);
+  assert.equal(normalizeReviewTelemetry(telemetry({ run_attempt: 1e20 }), NOW), null);
+});
+
+test("review telemetry watchdog uses green, amber, and red thresholds", () => {
+  const fresh = normalizeReviewTelemetry(telemetry(), NOW)!;
+  assert.equal(summarizeReviewTelemetryHealth([fresh], NOW).status, "healthy");
+
+  const slow = normalizeReviewTelemetry(
+    telemetry({ updated_at: "2026-07-19T11:29:59.000Z", lease_expires_at: null }),
+    NOW,
+  )!;
+  assert.equal(summarizeReviewTelemetryHealth([slow], NOW).status, "degraded");
+
+  const orphan = normalizeReviewTelemetry(
+    telemetry({
+      started_at: "2026-07-19T08:00:00.000Z",
+      updated_at: "2026-07-19T09:29:59.000Z",
+      lease_expires_at: null,
+    }),
+    NOW,
+  )!;
+  const critical = summarizeReviewTelemetryHealth([orphan], NOW);
+  assert.equal(critical.status, "critical");
+  assert.equal(critical.orphan_refreshing, 1);
+  assert.deepEqual(critical.orphans[0], {
+    repo: "openclaw/openclaw",
+    item_number: 123,
+    run_id: "9001",
+    run_attempt: 2,
+    updated_at: "2026-07-19T09:29:59.000Z",
+    age_seconds: 9001,
+    lease_expires_at: null,
+  });
+});
+
+test("an explicitly active lease prevents orphan classification", () => {
+  const active = normalizeReviewTelemetry(
+    telemetry({
+      started_at: "2026-07-19T08:00:00.000Z",
+      updated_at: "2026-07-19T09:00:00.000Z",
+      lease_expires_at: "2026-07-19T12:01:00.000Z",
+    }),
+    NOW,
+  )!;
+  const health = summarizeReviewTelemetryHealth([active], NOW);
+  assert.equal(health.status, "degraded");
+  assert.equal(health.orphan_refreshing, 0);
+});
+
+test("review telemetry rejects producer clocks that could pin an attempt in the future", () => {
+  assert.equal(
+    normalizeReviewTelemetry(
+      telemetry({ updated_at: "2026-07-19T12:05:01.000Z", lease_expires_at: null }),
+      NOW,
+    ),
+    null,
+  );
+  assert.equal(
+    normalizeReviewTelemetry(telemetry({ lease_expires_at: "2026-07-20T12:00:01.000Z" }), NOW),
+    null,
+  );
+});
+
+test("review telemetry reports every orphan while bounding the locator list", () => {
+  const records = Array.from({ length: 25 }, (_, index) =>
+    normalizeReviewTelemetry(
+      telemetry({
+        item_number: index + 1,
+        run_id: String(index + 1),
+        started_at: "2026-07-19T08:00:00.000Z",
+        updated_at: "2026-07-19T09:00:00.000Z",
+        lease_expires_at: null,
+      }),
+      NOW,
+    ),
+  ).filter((record) => record !== null);
+  const health = summarizeReviewTelemetryHealth(records, NOW);
+  assert.equal(health.orphan_refreshing, 25);
+  assert.equal(health.orphans.length, 20);
+});


### PR DESCRIPTION
## Summary

- make the dashboard's top-level health verdict include publication health, open DLQ state, and queue telemetry availability, with degraded states shown as amber and critical/stalled states as red
- add a durable per-item review telemetry contract and bounded query surface keyed by repository, item number, workflow run, and attempt, including terminal outcome and phase durations
- add a conservative orphan watchdog for stale `refreshing` records, with exact health counts and a bounded locator list, without automatically rewriting uncertain attempts to `interrupted`
- document green/amber/red thresholds, rollout, and the post-674 verification runbook

## Dependency and scope

This PR is a prerequisite for https://github.com/openclaw/clawsweeper/pull/674 and should merge first.

It was built from current `origin/main`, not from the PR 674 branch. It does not copy PR 674's generation-bound queue protocol or per-PR shard implementation. Instead, it establishes a backward-compatible observation contract that PR 674 can adopt:

- post signed telemetry transitions to the internal review telemetry endpoint
- populate the optional `generation` and `operation_id` fields once those identities exist
- report queue, claim, review, publication, and total phase durations at the corresponding lifecycle transitions
- use the per-item query and aggregate health surfaces during rollout verification

Terminal outcomes are first-writer immutable. A watchdog observation by itself is not sufficient evidence to write `interrupted`.

## Isolated Worker / Durable Object proof

Ran the exact PR head with `wrangler@4.107.0 dev --local` on localhost, using a fresh temporary persistence directory and a synthetic webhook secret. No remote bindings, deployment, live queue, or production credentials were used. The repository and run identities below are synthetic.

Redacted terminal transcript:

```text
unsigned POST /internal/exact-review/review-telemetry
=> HTTP 401 {"error":"invalid_signature"}

signed POST terminal attempt 1
=> HTTP 200 {"ok":true}
signed POST stale refreshing attempt 2, no lease
=> HTTP 200 {"ok":true}

GET /api/exact-review-queue/reviews?repo=example/proof&item_number=684&limit=1
=> HTTP 200, review_count=1
=> run_id=isolated-run-2 run_attempt=2 status=refreshing outcome=null
=> generation=8 operation_id=proof:684:2
=> phase_durations_ms={queue:500,claim:750,review:1500}

GET the same endpoint with limit=101
=> HTTP 400 {"error":"invalid_review_telemetry_query"}

GET /api/exact-review-queue
=> review_telemetry_health.status=critical
=> refreshing=1 slow_refreshing=1 orphan_refreshing=1
=> degraded_after_seconds=1800 orphan_after_seconds=9000
=> orphan locator={repo:example/proof,item_number:684,run_id:isolated-run-2,run_attempt:2,lease_expires_at:null}

GET /api/status
=> dashboard_health.conclusion=needs_attention
=> dashboard_health.severity=red
=> dashboard_health.reasons includes orphan_review_status
=> exact_review_queue.review_telemetry_health.status=critical

GET bounded item telemetry after both health reads
=> isolated-run-2 remains status=refreshing outcome=null
=> isolated-run-1 remains status=completed outcome=succeeded
```

The local `/api/status` snapshot also reported degraded workflow execution because the isolated Worker intentionally had no GitHub credentials. The review-telemetry signal independently reached the top-level red verdict through `orphan_review_status`, and reading the watchdog did not mutate the stale attempt to `interrupted`.

## Validation

- Node `v24.15.0`
- `pnpm run check`
- `/data/code/openclaw/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
  - accepted and fixed unsafe integer ingestion validation
  - final result: no accepted/actionable findings
- isolated `wrangler@4.107.0 dev --local` Worker/Durable Object lifecycle proof above

The rollout and post-674 verification steps are in `docs/pr-674-observation-runbook.md`.
