### PR TITLE
test(automerge): model scheduler convergence

### DIFF
--- a/test/automerge-workflow-scheduler.test.ts
+++ b/test/automerge-workflow-scheduler.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  repairCommentRouterGroup,
+  replayWorkflowTrace,
+  WorkflowScheduler,
+} from "./e2e/automerge/workflow-scheduler.mjs";
+
+const fixtureRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "e2e/automerge/fixtures",
+);
+
+test("router concurrency groups isolate exact workflow handoffs only", () => {
+  assert.equal(
+    repairCommentRouterGroup({
+      repository: "openclaw/openclaw",
+      eventName: "workflow_dispatch",
+      itemNumbers: "104054",
+    }),
+    "repair-comment-router-openclaw/openclaw-items-104054",
+  );
+  assert.equal(
+    repairCommentRouterGroup({
+      repository: "openclaw/openclaw",
+      eventName: "repository_dispatch",
+      itemNumbers: "104054",
+    }),
+    "repair-comment-router-openclaw/openclaw",
+  );
+  assert.equal(
+    repairCommentRouterGroup({
+      repository: "openclaw/openclaw",
+      eventName: "workflow_dispatch",
+    }),
+    "repair-comment-router-openclaw/openclaw",
+  );
+});
+
+test("workflow scheduler keeps one running and replaces one pending run per group", () => {
+  const scheduler = new WorkflowScheduler();
+  scheduler.dispatch({ id: "running", group: "repo" });
+  scheduler.dispatch({ id: "old-pending", group: "repo" });
+  scheduler.dispatch({ id: "new-pending", group: "repo" });
+
+  assert.deepEqual(
+    scheduler.records().map(({ id, status, replacedBy }) => ({ id, status, replacedBy })),
+    [
+      { id: "running", status: "running", replacedBy: undefined },
+      { id: "old-pending", status: "replaced", replacedBy: "new-pending" },
+      { id: "new-pending", status: "pending", replacedBy: undefined },
+    ],
+  );
+  scheduler.complete("running");
+  assert.equal(scheduler.records().find((run) => run.id === "new-pending")?.status, "running");
+});
+
+test("workflow scheduler isolates concurrency groups and records cancellation", () => {
+  const scheduler = new WorkflowScheduler();
+  scheduler.dispatch({ id: "item-1", group: "items-1" });
+  scheduler.dispatch({ id: "item-2", group: "items-2" });
+  scheduler.cancel("item-1", "test interruption");
+  scheduler.complete("item-2");
+
+  assert.deepEqual(
+    scheduler.records().map(({ id, status }) => ({ id, status })),
+    [
+      { id: "item-1", status: "cancelled" },
+      { id: "item-2", status: "executed" },
+    ],
+  );
+});
+
+test("production trace reproduces the old loss and preserves both item-scoped verdicts", () => {
+  const trace = JSON.parse(
+    fs.readFileSync(path.join(fixtureRoot, "deferred-verdict-pending-replacement.json"), "utf8"),
+  );
+  const oldRecords = replayWorkflowTrace(
+    trace,
+    (run: { repository: string }) => `repair-comment-router-${run.repository}`,
+  );
+  assert.equal(oldRecords.find((run) => run.id === "verdict-104054")?.status, "replaced");
+
+  const fixedRecords = replayWorkflowTrace(
+    trace,
+    (run: { kind: string; repository: string; item?: number }) =>
+      repairCommentRouterGroup({
+        repository: run.repository,
+        eventName: run.kind === "exact-verdict" ? "workflow_dispatch" : "schedule",
+        itemNumbers: run.item ? String(run.item) : "",
+      }),
+    { completeRemaining: true },
+  );
+  assert.equal(fixedRecords.find((run) => run.id === "verdict-104054")?.status, "executed");
+  assert.equal(fixedRecords.find((run) => run.id === "verdict-108974")?.status, "executed");
+});

--- a/test/e2e/automerge/fixtures/deferred-verdict-pending-replacement.json
+++ b/test/e2e/automerge/fixtures/deferred-verdict-pending-replacement.json
@@ -1,0 +1,29 @@
+{
+  "name": "production deferred verdict pending replacement",
+  "events": [
+    {
+      "action": "dispatch",
+      "run": { "id": "background-router", "kind": "background", "repository": "openclaw/openclaw" }
+    },
+    {
+      "action": "dispatch",
+      "run": {
+        "id": "verdict-104054",
+        "kind": "exact-verdict",
+        "repository": "openclaw/openclaw",
+        "item": 104054
+      }
+    },
+    {
+      "action": "dispatch",
+      "run": {
+        "id": "verdict-108974",
+        "kind": "exact-verdict",
+        "repository": "openclaw/openclaw",
+        "item": 108974
+      }
+    },
+    { "action": "complete", "runId": "background-router" },
+    { "action": "complete", "runId": "verdict-108974" }
+  ]
+}

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -9,6 +9,7 @@ import {
   createCiRegressionFixture,
   createTargetFixture,
 } from "./target-fixtures.mjs";
+import { repairCommentRouterGroup, WorkflowScheduler } from "./workflow-scheduler.mjs";
 
 const helperRoot = path.dirname(fileURLToPath(import.meta.url));
 export const AUTOMERGE_E2E_SCENARIOS = [
@@ -17,6 +18,7 @@ export const AUTOMERGE_E2E_SCENARIOS = [
   "pending-checks",
   "planning-head-drift",
   "resume-intent-persistence",
+  "workflow-scheduler-convergence",
   "verdict-head-drift",
   "ci-regression-29623139111",
 ];
@@ -27,6 +29,7 @@ export function runAutomergeE2E({
   scenario = "happy-path",
   fixture = "tiny",
   expectedOutcome = "success",
+  targetPrNumber = 42,
   keep = false,
 } = {}) {
   if (!AUTOMERGE_E2E_SCENARIOS.includes(scenario)) {
@@ -37,6 +40,10 @@ export function runAutomergeE2E({
   }
   if (!["success", "setup-identity-failure"].includes(expectedOutcome)) {
     throw new Error(`unsupported expected outcome: ${expectedOutcome}`);
+  }
+  if (scenario === "workflow-scheduler-convergence") {
+    assert.equal(expectedOutcome, "success", "scheduler convergence supports only success");
+    return runWorkflowSchedulerConvergence({ candidateRoot, outputRoot, fixture, keep });
   }
   if (
     expectedOutcome !== "success" &&
@@ -66,11 +73,20 @@ export function runAutomergeE2E({
             fixture,
             dependencySetupMutation: scenario === "dependency-setup-mutation",
           });
+    if (targetPrNumber !== 42) {
+      execFileSync("/usr/bin/git", [
+        "--git-dir",
+        targetFixture.remote,
+        "update-ref",
+        `refs/pull/${targetPrNumber}/head`,
+        targetFixture.headSha,
+      ]);
+    }
     const statePath = path.join(root, "github-state.json");
     const binDir = createCommandBin(root);
     const realCorepack = execFileSync("which", ["corepack"], { encoding: "utf8" }).trim();
-    const jobPath = createJob(root, targetFixture.headSha);
-    writeJson(statePath, initialGitHubState(targetFixture));
+    const jobPath = createJob(root, targetFixture.headSha, targetPrNumber);
+    writeJson(statePath, initialGitHubState(targetFixture, targetPrNumber));
 
     const baseEnv = {
       ...process.env,
@@ -406,6 +422,66 @@ export function runAutomergeE2E({
   } finally {
     if (!keep) fs.rmSync(root, { recursive: true, force: true });
   }
+}
+
+function runWorkflowSchedulerConvergence({ candidateRoot, outputRoot, fixture, keep }) {
+  assertDeferredVerdictHandoffIsolation(candidateRoot);
+  const artifacts = path.resolve(outputRoot, fixture, "workflow-scheduler-convergence");
+  fs.rmSync(artifacts, { recursive: true, force: true });
+  fs.mkdirSync(artifacts, { recursive: true });
+  const scheduler = new WorkflowScheduler();
+  const repository = "openclaw/openclaw";
+  const dispatches = [
+    { id: "background-running", eventName: "schedule", itemNumbers: "" },
+    { id: "background-replaced", eventName: "workflow_dispatch", itemNumbers: "" },
+    { id: "background-survivor", eventName: "repository_dispatch", itemNumbers: "" },
+    { id: "verdict-104054", eventName: "workflow_dispatch", itemNumbers: "104054" },
+    { id: "verdict-108974", eventName: "workflow_dispatch", itemNumbers: "108974" },
+  ];
+  for (const dispatch of dispatches) {
+    scheduler.dispatch({
+      ...dispatch,
+      group: repairCommentRouterGroup({ repository, ...dispatch }),
+    });
+  }
+
+  const results = new Map();
+  while (true) {
+    const running = scheduler.active().flatMap((group) => (group.running ? [group.running] : []));
+    if (running.length === 0) break;
+    for (const runId of running) {
+      if (runId.startsWith("verdict-")) {
+        results.set(
+          runId,
+          runAutomergeE2E({
+            candidateRoot,
+            outputRoot: path.join(artifacts, runId),
+            scenario: "happy-path",
+            fixture,
+            keep,
+            targetPrNumber: Number(runId.slice("verdict-".length)),
+          }),
+        );
+      }
+      scheduler.complete(runId);
+    }
+  }
+
+  const records = scheduler.records();
+  assert.equal(records.find((run) => run.id === "background-replaced")?.status, "replaced");
+  for (const runId of ["verdict-104054", "verdict-108974"]) {
+    assert.equal(records.find((run) => run.id === runId)?.status, "executed");
+    assert.equal(results.get(runId)?.status, "passed");
+  }
+  writeJson(path.join(artifacts, "scheduler-trace.json"), { dispatches, records });
+  writeJson(path.join(artifacts, "summary.json"), {
+    status: "passed",
+    fixture,
+    scenario: "workflow-scheduler-convergence",
+    exact_verdicts: ["verdict-104054", "verdict-108974"],
+    background_interference: "one pending broad router replaced",
+  });
+  return { status: "passed", fixture, scenario: "workflow-scheduler-convergence", artifacts };
 }
 
 function assertDeferredVerdictHandoffIsolation(candidateRoot) {
@@ -769,6 +845,9 @@ function runSetupIdentityFailureScenario({
 }
 
 function runCommentRouter(runtimeRoot, baseEnv, artifacts, label) {
+  const statePath = baseEnv.CLAWSWEEPER_E2E_GITHUB_STATE;
+  assert.equal(typeof statePath, "string", "router requires the fake GitHub state path");
+  const itemNumber = JSON.parse(fs.readFileSync(statePath, "utf8")).pr.number;
   runCli(
     runtimeRoot,
     [
@@ -776,7 +855,7 @@ function runCommentRouter(runtimeRoot, baseEnv, artifacts, label) {
       "--repo",
       "openclaw/openclaw",
       "--item-number",
-      "42",
+      String(itemNumber),
       "--max-comments",
       "20",
       "--execute",
@@ -800,7 +879,7 @@ function updateGitHubState(statePath, update) {
   writeJson(statePath, state);
 }
 
-function initialGitHubState(fixture) {
+function initialGitHubState(fixture, targetPrNumber = 42) {
   const now = new Date().toISOString();
   return {
     repo: "openclaw/openclaw",
@@ -812,7 +891,7 @@ function initialGitHubState(fixture) {
     dispatches: [],
     calls: [],
     pr: {
-      number: 42,
+      number: targetPrNumber,
       state: "open",
       title: "fix: repair the deterministic fixture",
       body: "Exercise the ClawSweeper automerge repair flow.",
@@ -891,11 +970,11 @@ function assertIndexStatMutation({ child, marker }) {
   }
 }
 
-function createJob(root, headSha) {
+function createJob(root, headSha, targetPrNumber = 42) {
   const jobPath = path.join(root, "automerge-job.md");
   fs.writeFileSync(
     jobPath,
-    `---\nrepo: openclaw/openclaw\ncluster_id: automerge-openclaw-openclaw-42\nmode: autonomous\njob_intent: pr_repair\nallowed_actions: [comment, label, fix, raise_pr]\nblocked_actions: [merge, close]\nrequire_human_for: [merge]\ncanonical: [#42]\ncandidates: [#42]\ncluster_refs: [#42]\nallow_fix_pr: true\nallow_merge: false\nallow_post_merge_close: false\nrequire_fix_before_close: true\nsecurity_policy: central_security_only\nsecurity_sensitive: false\ntarget_branch: clawsweeper/automerge-openclaw-openclaw-42\nsource: pr_automerge\nrepair_mode: automerge\nexpected_head_sha: ${headSha}\n---\n\nRepair the opted-in pull request and preserve contributor credit.\n`,
+    `---\nrepo: openclaw/openclaw\ncluster_id: automerge-openclaw-openclaw-${targetPrNumber}\nmode: autonomous\njob_intent: pr_repair\nallowed_actions: [comment, label, fix, raise_pr]\nblocked_actions: [merge, close]\nrequire_human_for: [merge]\ncanonical: [#${targetPrNumber}]\ncandidates: [#${targetPrNumber}]\ncluster_refs: [#${targetPrNumber}]\nallow_fix_pr: true\nallow_merge: false\nallow_post_merge_close: false\nrequire_fix_before_close: true\nsecurity_policy: central_security_only\nsecurity_sensitive: false\ntarget_branch: clawsweeper/automerge-openclaw-openclaw-${targetPrNumber}\nsource: pr_automerge\nrepair_mode: automerge\nexpected_head_sha: ${headSha}\n---\n\nRepair the opted-in pull request and preserve contributor credit.\n`,
   );
   return jobPath;
 }

--- a/test/e2e/automerge/workflow-scheduler.mjs
+++ b/test/e2e/automerge/workflow-scheduler.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+
+export function repairCommentRouterGroup({ repository, eventName, itemNumbers = "" }) {
+  assert.match(repository, /^[^/]+\/[^/]+$/, "repository must use owner/name form");
+  if (eventName === "workflow_dispatch" && itemNumbers !== "") {
+    return `repair-comment-router-${repository}-items-${itemNumbers}`;
+  }
+  return `repair-comment-router-${repository}`;
+}
+
+export class WorkflowScheduler {
+  #groups = new Map();
+  #runs = new Map();
+
+  dispatch(run) {
+    assert.equal(typeof run?.id, "string", "workflow run id is required");
+    assert.equal(typeof run?.group, "string", "workflow concurrency group is required");
+    assert.ok(run.id.length > 0, "workflow run id must not be empty");
+    assert.ok(run.group.length > 0, "workflow concurrency group must not be empty");
+    assert.equal(this.#runs.has(run.id), false, `duplicate workflow run id: ${run.id}`);
+
+    const group = this.#groups.get(run.group) ?? { running: null, pending: null };
+    const record = { ...run, status: group.running ? "pending" : "running" };
+    this.#runs.set(run.id, record);
+
+    if (!group.running) {
+      group.running = run.id;
+    } else {
+      if (group.pending) {
+        const replaced = this.#runs.get(group.pending);
+        assert.ok(replaced);
+        replaced.status = "replaced";
+        replaced.replacedBy = run.id;
+      }
+      group.pending = run.id;
+    }
+    this.#groups.set(run.group, group);
+    return structuredClone(record);
+  }
+
+  complete(runId) {
+    const record = this.#requiredRun(runId);
+    const group = this.#groups.get(record.group);
+    assert.equal(group?.running, runId, `workflow run is not running: ${runId}`);
+    record.status = "executed";
+    group.running = group.pending;
+    group.pending = null;
+    if (group.running) this.#requiredRun(group.running).status = "running";
+    return structuredClone(record);
+  }
+
+  cancel(runId, reason = "cancelled") {
+    const record = this.#requiredRun(runId);
+    assert.ok(["running", "pending"].includes(record.status), `workflow run is terminal: ${runId}`);
+    const group = this.#groups.get(record.group);
+    assert.ok(group);
+    if (group.running === runId) {
+      group.running = group.pending;
+      group.pending = null;
+      if (group.running) this.#requiredRun(group.running).status = "running";
+    } else {
+      assert.equal(group.pending, runId, `workflow run is not active: ${runId}`);
+      group.pending = null;
+    }
+    record.status = "cancelled";
+    record.reason = reason;
+    return structuredClone(record);
+  }
+
+  active() {
+    return [...this.#groups.entries()].map(([group, state]) => ({ group, ...state }));
+  }
+
+  records() {
+    return [...this.#runs.values()].map((run) => structuredClone(run));
+  }
+
+  #requiredRun(runId) {
+    const record = this.#runs.get(runId);
+    assert.ok(record, `unknown workflow run id: ${runId}`);
+    return record;
+  }
+}
+
+export function replayWorkflowTrace(trace, groupFor, { completeRemaining = false } = {}) {
+  const scheduler = new WorkflowScheduler();
+  for (const event of trace.events) {
+    if (event.action === "dispatch") {
+      scheduler.dispatch({ ...event.run, group: groupFor(event.run) });
+    } else if (event.action === "complete") {
+      scheduler.complete(event.runId);
+    } else if (event.action === "cancel") {
+      scheduler.cancel(event.runId, event.reason);
+    } else {
+      assert.fail(`unsupported workflow trace action: ${event.action}`);
+    }
+  }
+  if (completeRemaining) {
+    while (true) {
+      const running = scheduler.active().flatMap((group) => (group.running ? [group.running] : []));
+      if (running.length === 0) break;
+      for (const runId of running) scheduler.complete(runId);
+    }
+  }
+  return scheduler.records();
+}


### PR DESCRIPTION
## Summary

- add a lightweight workflow scheduler model for GitHub concurrency groups
- replay the production pending-replacement sequence and prove exact verdict dispatches remain isolated
- extend the real Git/fake GitHub/router/verdict/merge E2E to run pull requests 104054 and 108974 alongside background router traffic

## Why

GitHub keeps one running and one pending workflow per concurrency group. Exact verdict handoffs previously shared the broad router group, so a later pending run could replace an earlier verdict before it executed. This test model captures that scheduler behavior locally and exercises the fixed item-scoped groups before production smoke.

## Validation

- local autoreview: 0 accepted/actionable findings
- pnpm run check
- local-container automerge E2E using clawsweeper-automerge-e2e-base:local
- host automerge E2E
- focused scheduler unit tests: 4/4
- invalid expected outcome fails closed
- gitleaks staged and complete patch scan: no leaks found