### PR TITLE
fix(repair): batch immutable ledger rebuilds

### DIFF
--- a/src/action-ledger-paths.ts
+++ b/src/action-ledger-paths.ts
@@ -1,0 +1,6 @@
+const ACTION_EVENT_PUBLISH_PATH_PATTERN =
+  /^ledger\/v1\/(?:events\/\d{4}\/\d{2}\/\d{2}\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.jsonl|import-bindings\/(?:producer-runs|events|shard-sets|completed-shard-sets)\/[a-f0-9]{64}\.json)$/;
+
+export function isActionEventPublishPath(path: string): boolean {
+  return ACTION_EVENT_PUBLISH_PATH_PATTERN.test(path);
+}

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -215,6 +215,7 @@ import {
   recordWorkflowPhaseEvent,
   workflowActionProducer,
 } from "./action-ledger-runtime.js";
+import { isActionEventPublishPath } from "./action-ledger-paths.js";
 import { publishMainCommit } from "./repair/git-publish.js";
 
 export {
@@ -32016,8 +32017,6 @@ function publishActionEventsCommand(args: Args): void {
   console.log(JSON.stringify(result, null, 2));
 }
 
-const ACTION_EVENT_PUBLISH_PATH_PATTERN =
-  /^ledger\/v1\/(?:events\/\d{4}\/\d{2}\/\d{2}\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.jsonl|import-bindings\/(?:producer-runs|events|shard-sets|completed-shard-sets)\/[a-f0-9]{64}\.json)$/;
 const ACTION_EVENT_PUBLISH_PATH_FILE_MAX_BYTES = ACTION_EVENT_SHARD_IMPORT_MAX_PUBLISH_PATHS * 512;
 
 export function actionEventPublishPathsForTest(content: string): string[] {
@@ -32035,7 +32034,7 @@ export function actionEventPublishPathsForTest(content: string): string[] {
   }
   let previous = "";
   for (const path of paths) {
-    if (!ACTION_EVENT_PUBLISH_PATH_PATTERN.test(path)) {
+    if (!isActionEventPublishPath(path)) {
       throw new Error(`invalid action event publish path: ${path}`);
     }
     if (previous && path <= previous) {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -29,6 +29,7 @@ import {
 } from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
+import { isActionEventPublishPath } from "../action-ledger-paths.js";
 
 export type GitRunResult = {
   status: number;
@@ -1448,16 +1449,24 @@ function rebuildPublishCommit(options: {
   });
   runGit(["reset", "--hard", remoteCommit]);
 
-  for (const path of uniqueNonEmpty(options.paths)) {
-    const preserved = preserveStateOnlyCommitFiles({ path, sourceCommit: options.sourceCommit });
-    try {
-      runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
-      if (commitHasPath(options.sourceCommit, path)) {
-        runGit(["checkout", options.sourceCommit, "--", path]);
+  const publishPaths = uniqueNonEmpty(options.paths);
+  if (publishPaths.every(isActionEventPublishPath)) {
+    // Action-ledger imports are create-only and already validate every exact path.
+    // Restore them as one batch so state-branch contention cannot multiply Git
+    // startup and pack-index costs by the number of imported binding files.
+    applyPathsFromCommit(publishPaths, options.sourceCommit);
+  } else {
+    for (const path of publishPaths) {
+      const preserved = preserveStateOnlyCommitFiles({ path, sourceCommit: options.sourceCommit });
+      try {
+        runGit(["rm", "-r", "--ignore-unmatch", "--", path], { allowFailure: true });
+        if (commitHasPath(options.sourceCommit, path)) {
+          runGit(["checkout", options.sourceCommit, "--", path]);
+        }
+        restorePreservedFiles(preserved, resolve(path));
+      } finally {
+        rmSync(preserved.root, { force: true, recursive: true });
       }
-      restorePreservedFiles(preserved, resolve(path));
-    } finally {
-      rmSync(preserved.root, { force: true, recursive: true });
     }
   }
 
@@ -1471,6 +1480,20 @@ function rebuildPublishCommit(options: {
 
   runGit(["commit", "-m", options.message]);
   return "committed";
+}
+
+function applyPathsFromCommit(paths: readonly string[], commit: string): void {
+  for (const batch of chunked(paths, GIT_PATHSPEC_BATCH_SIZE)) {
+    runGit(["rm", "-r", "--ignore-unmatch", "--", ...batch], {
+      allowFailure: true,
+      quiet: true,
+    });
+  }
+  const existing = gitObjectExistence(paths.map((path) => ({ commit, path })));
+  const checkoutPaths = paths.filter((path) => existing.has(gitObjectSpec(commit, path)));
+  for (const batch of chunked(checkoutPaths, GIT_PATHSPEC_BATCH_SIZE)) {
+    runGit(["checkout", commit, "--", ...batch]);
+  }
 }
 
 function commitHasPath(commit: string, path: string): boolean {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1470,6 +1470,68 @@ test("publishMainCommit rebuilds generated state commits without deleting concur
   assert.equal(run("git", ["--git-dir", origin, "show", "main:keep.txt"], root), "keep remote\n");
 });
 
+test("publishMainCommit rebuilds immutable ledger batches within the router process budget", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const ledgerPaths = Array.from(
+    { length: 25 },
+    (_, index) => `ledger/v1/import-bindings/events/${index.toString(16).padStart(64, "0")}.json`,
+  );
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  write(path.join(work, "keep.txt"), "base\n");
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, "remote.txt"), "concurrent\n");
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "concurrent state update"], other);
+  for (const ledgerPath of ledgerPaths) {
+    write(path.join(work, ledgerPath), `{"path":"${ledgerPath}"}\n`);
+  }
+  installFirstTwoPushRaceHook(work, other);
+
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: append command action ledger",
+        paths: ledgerPaths,
+        maxAttempts: 1,
+        pushAttempts: 1,
+      }),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  const metrics = lines.find((line) => line.startsWith("Git publish metrics:"));
+  assert.ok(metrics, "ledger race publish emits metrics");
+  const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
+  assert.ok(
+    Number.isInteger(processCount) && processCount <= 40,
+    `ledger race rebuild used ${processCount} git subprocesses; expected at most 40`,
+  );
+  for (const ledgerPath of ledgerPaths) {
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `main:${ledgerPath}`], root),
+      `{"path":"${ledgerPath}"}\n`,
+    );
+  }
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
+    "concurrent\nsecond race\n",
+  );
+});
+
 test("publishMainCommit publishes generated paths to state branch when state root is configured", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
@@ -2422,6 +2484,29 @@ if test -f "${counter}"; then count=$(cat "${counter}"); fi
 count=$((count + 1))
 printf '%s\\n' "$count" > "${counter}"
 if test "$count" -eq 1; then git -C "${other}" push origin HEAD:${branch}; fi
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+}
+
+function installFirstTwoPushRaceHook(work, other, branch = "main") {
+  const hook = path.join(work, ".git/hooks/pre-push");
+  const counter = path.join(work, ".git/hooks/pre-push-count");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+count=0
+if test -f "${counter}"; then count=$(cat "${counter}"); fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "${counter}"
+if test "$count" -eq 1; then
+  git -C "${other}" push origin HEAD:${branch}
+elif test "$count" -eq 2; then
+  printf 'second race\\n' >> "${path.join(other, "remote.txt")}"
+  git -C "${other}" add remote.txt
+  git -C "${other}" commit -m 'second concurrent state update'
+  git -C "${other}" push origin HEAD:${branch}
+fi
 `,
   );
   fs.chmodSync(hook, 0o755);


### PR DESCRIPTION
## Root cause

Production router runs rebuilt 25 immutable command action-ledger paths one at a time after state push races. Each path paid separate cat-file, rm, and checkout process costs; repeated races amplified Git startup and pack-index work until the 25-minute job timeout terminated ledger publication.

Failed production evidence:
- https://github.com/openclaw/clawsweeper/actions/runs/29667785551
- https://github.com/openclaw/clawsweeper/actions/runs/29667785856

## Fix

- share the existing strict canonical action-ledger publish-path predicate
- batch remove, existence checks, and checkout only when every requested path satisfies that immutable ledger contract
- preserve the existing per-path preservation algorithm for records, jobs, status, and mixed path sets

## Deterministic proof

The new real-Git integration test creates 25 ledger bindings and two deterministic pre-push state races. The old implementation used 109 Git subprocesses and failed the process-budget assertion; the fixed implementation completes within 40 while retaining both concurrent remote updates and every immutable ledger file.

## Validation

- local autoreview --mode local: 0 accepted/actionable findings
- focused git-publish tests: 32 passed
- related action-ledger tests: 23 passed
- pnpm run check: passed
- gitleaks protect --staged: no leaks found

This PR does not retry production or modify contributor branches.