### PR TITLE
fix(text): bound trimMiddle for small caps

### DIFF
--- a/src/clawsweeper-text.ts
+++ b/src/clawsweeper-text.ts
@@ -11,6 +11,7 @@ export function truncateText(value: unknown, maxLength: number): string {
 export function trimMiddle(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
   const edge = Math.floor((maxLength - 120) / 2);
+  if (edge <= 0) return text.slice(0, Math.max(0, maxLength));
   return `${text.slice(0, edge)}\n\n... truncated ${text.length - edge * 2} chars ...\n\n${text.slice(-edge)}`;
 }
 

--- a/test/clawsweeper-text.test.ts
+++ b/test/clawsweeper-text.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { trimMiddle } from "../dist/clawsweeper-text.js";
+
+test("trimMiddle keeps small-cap output within the requested length", () => {
+  assert.equal(trimMiddle("x".repeat(25), 20), "x".repeat(20));
+  assert.equal(trimMiddle("x".repeat(125), 120), "x".repeat(120));
+  assert.equal(trimMiddle("x".repeat(125), 121), "x".repeat(121));
+  assert.equal(trimMiddle("x".repeat(25), 0), "");
+  assert.equal(trimMiddle("x".repeat(25), -1), "");
+});
+
+test("trimMiddle reports a valid removed count for the middle-elision path", () => {
+  const text = "y".repeat(5000);
+  const output = trimMiddle(text, 4000);
+  const match = output.match(/truncated (\d+) chars/);
+  assert.ok(match);
+  const removed = Number(match[1]);
+  assert.ok(removed >= 0 && removed <= text.length);
+  assert.ok(output.length <= 4000);
+  assert.ok(output.startsWith("y") && output.endsWith("y"));
+});


### PR DESCRIPTION
## Summary

- bound `trimMiddle` for small and non-positive caps
- preserve the existing middle-elision path for larger caps
- add regression coverage for the reported reverse-slice and impossible-count behavior

Thanks @anagnorisis2peripeteia for the report and original diagnosis.

## Proof

- `pnpm run build`
- `node --test test/clawsweeper-text.test.ts`
- AutoReview branch review: clean (0.99)

Closes #571
