### PR TITLE
fix(repair): keep truncated slugs idempotent

### DIFF
--- a/src/repair/text-utils.ts
+++ b/src/repair/text-utils.ts
@@ -27,6 +27,7 @@ export function slug(value: unknown, fallback = "unknown", maxLength = 120) {
       .toLowerCase()
       .replace(/[^a-z0-9_.-]+/g, "-")
       .replace(/^-+|-+$/g, "")
-      .slice(0, maxLength) || fallback
+      .slice(0, maxLength)
+      .replace(/-+$/g, "") || fallback
   );
 }

--- a/test/repair/text-utils.test.ts
+++ b/test/repair/text-utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { compactText } from "../../dist/repair/text-utils.js";
+import { compactText, slug } from "../../dist/repair/text-utils.js";
 
 test("compactText never exceeds maxLength, even for tiny caps", () => {
   for (const n of [0, 1, 2, 3, 5, 16]) {
@@ -16,4 +16,20 @@ test("compactText never exceeds maxLength, even for tiny caps", () => {
   assert.equal(compactText("abcdefghijklmnopqrstuvwxyz", 4), "a...");
   assert.equal(compactText("abcdefghijklmnopqrstuvwxyz", 16), "abcdefghijklm...");
   assert.equal(compactText("abcdefghijklmnopqrstuvwxyz", 17), "abcdef ... uvwxyz");
+});
+
+test("slug remains idempotent when truncation lands on a dash", () => {
+  for (const [value, maxLength] of [
+    ["a a", 2],
+    ["aa----bb", 3],
+    ["My Repo Name!!", 6],
+    ["a---b", 3],
+  ] as const) {
+    const result = slug(value, "fallback", maxLength);
+    assert.equal(result.endsWith("-"), false);
+    assert.equal(slug(result, "fallback", maxLength), result);
+  }
+
+  assert.equal(slug("a a", "fallback", 2), "a");
+  assert.equal(slug("---", "fallback", 2), "fallback");
 });


### PR DESCRIPTION
## Summary

- remove trailing dashes after applying the slug length cap
- preserve the existing fallback behavior for empty normalized values
- add regression coverage for truncation boundaries and idempotence

Thanks @anagnorisis2peripeteia for the report and original diagnosis.

## Proof

- `pnpm run build`
- `node --test test/repair/text-utils.test.ts`
- live repeated-normalization matrix for single and repeated dash boundaries
- AutoReview local and branch reviews: clean (0.99)

Closes #572
