### PR TITLE
fix(repair): flatten immutable ledger retries

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -334,6 +334,20 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
     return completeStatePublish("committed", options.paths, stateBaseCommit);
   }
 
+  const publishPaths = uniqueNonEmpty(options.paths);
+  if (publishPaths.length > 0 && publishPaths.every(isActionEventPublishPath)) {
+    const result = pushImmutableActionLedgerCommit({
+      remote,
+      branch,
+      message: commitMessage,
+      paths: publishPaths,
+      sourceCommit,
+      maxAttempts,
+      pushAttempts,
+    });
+    return completeStatePublish(result, options.paths, stateBaseCommit);
+  }
+
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     if (
       pushCommit({
@@ -374,6 +388,38 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
     return completeStatePublish("committed", options.paths, stateBaseCommit);
   }
   throw new Error(`Failed to publish commit after ${maxAttempts} attempts`);
+}
+
+function pushImmutableActionLedgerCommit(options: {
+  remote: string;
+  branch: string;
+  message: string;
+  paths: readonly string[];
+  sourceCommit: string;
+  maxAttempts: number;
+  pushAttempts: number;
+}): PublishResult {
+  // Keep both retry knobs additive. Their former nesting multiplied every
+  // state race into another complete rebase loop.
+  const pushBudget = options.maxAttempts + options.pushAttempts + 1;
+  for (let attempt = 1; attempt <= pushBudget; attempt += 1) {
+    if (spawnGit(["push", options.remote, `HEAD:${options.branch}`]).status === 0) {
+      return "committed";
+    }
+    if (attempt === pushBudget) break;
+
+    // These paths are immutable and create-only, so rebuilding their exact batch
+    // is cheaper and safer than multiplying rebase probes inside nested retries.
+    const rebuildResult = rebuildPublishCommit({
+      remote: options.remote,
+      branch: options.branch,
+      message: options.message,
+      paths: options.paths,
+      sourceCommit: options.sourceCommit,
+    });
+    if (rebuildResult === "unchanged") return "unchanged";
+  }
+  throw new Error(`Failed to publish commit after ${pushBudget} push attempts`);
 }
 
 function pushReconciliationCommit(options: {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1532,6 +1532,67 @@ test("publishMainCommit rebuilds immutable ledger batches within the router proc
   );
 });
 
+test("publishMainCommit bounds immutable ledger work across sustained state races", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const ledgerPaths = Array.from(
+    { length: 25 },
+    (_, index) => `ledger/v1/import-bindings/events/${index.toString(16).padStart(64, "0")}.json`,
+  );
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  write(path.join(work, "keep.txt"), "base\n");
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  for (const ledgerPath of ledgerPaths) {
+    write(path.join(work, ledgerPath), `{"path":"${ledgerPath}"}\n`);
+  }
+  installPushRaceHook(work, other, 7);
+
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: append command action ledger",
+        paths: ledgerPaths,
+        maxAttempts: 8,
+        pushAttempts: 3,
+      }),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  const metrics = lines.find((line) => line.startsWith("Git publish metrics:"));
+  assert.ok(metrics, "sustained ledger race publish emits metrics");
+  const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
+  assert.ok(
+    Number.isInteger(processCount) && processCount <= 125,
+    `sustained ledger races used ${processCount} git subprocesses; expected at most 125`,
+  );
+  assert.match(metrics, /actions=.*push:8(?:,|$)/, "one push is attempted per bounded retry");
+  assert.doesNotMatch(metrics, /actions=.*rebase:/, "immutable ledger retries never nest rebases");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
+    Array.from({ length: 7 }, (_, index) => `race ${index + 1}\n`).join(""),
+  );
+  for (const ledgerPath of ledgerPaths) {
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `main:${ledgerPath}`], root),
+      `{"path":"${ledgerPath}"}\n`,
+    );
+  }
+});
+
 test("publishMainCommit publishes generated paths to state branch when state root is configured", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
@@ -2505,6 +2566,27 @@ elif test "$count" -eq 2; then
   printf 'second race\\n' >> "${path.join(other, "remote.txt")}"
   git -C "${other}" add remote.txt
   git -C "${other}" commit -m 'second concurrent state update'
+  git -C "${other}" push origin HEAD:${branch}
+fi
+`,
+  );
+  fs.chmodSync(hook, 0o755);
+}
+
+function installPushRaceHook(work, other, raceCount, branch = "main") {
+  const hook = path.join(work, ".git/hooks/pre-push");
+  const counter = path.join(work, ".git/hooks/pre-push-count");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh
+count=0
+if test -f "${counter}"; then count=$(cat "${counter}"); fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "${counter}"
+if test "$count" -le ${raceCount}; then
+  printf 'race %s\\n' "$count" >> "${path.join(other, "remote.txt")}"
+  git -C "${other}" add remote.txt
+  git -C "${other}" commit -m "concurrent state update $count"
   git -C "${other}" push origin HEAD:${branch}
 fi
 `,


### PR DESCRIPTION
## Summary

- route strictly validated immutable action-ledger batches through one additive push budget
- rebuild the exact create-only batch after each state-branch race without entering nested rebase retries
- preserve the existing publication algorithm for records, jobs, status, reconciliation, and mixed paths

## Production evidence

The one authorized production retry, https://github.com/openclaw/clawsweeper/actions/runs/29670681237, used the earlier batch rebuild fix but timed out in `Publish immutable command action ledger` after 1,166,857 ms. Its Git metrics showed 488 subprocesses: 36 pushes, 35 fetches, and 27 rebases. Continuous state-branch writers exposed multiplicative nesting between the outer publish retry and inner rebase retry.

## Deterministic local proof

A real-Git test publishes 25 immutable ledger paths while a pre-push hook creates seven consecutive remote state races.

- Before this fix, the deterministic reproduction entered `rebase:6`.
- With this fix, the eighth push succeeds, all seven concurrent remote updates and all 25 ledger paths survive, no rebase occurs, and total Git subprocesses stay at or below 125.

The optimized path is enabled only when every requested path passes the existing strict `isActionEventPublishPath` validation. No canonical-path or mutation safety boundary is relaxed.

## Validation

- local autoreview: 0 accepted/actionable findings; correctness 0.84
- focused real-Git suite: 33/33 passed
- `pnpm run check`: passed, including full coverage and formatting checks
- `git diff --check`: passed
- `gitleaks protect --staged --redact --no-banner`: no leaks found

No additional production retry was sent.