### PR TITLE
Resume completed automerge verdicts safely

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -749,8 +749,20 @@ export function latestRepairLoopResumeTime(entries: JsonValue, command: LooseRec
     if (!entry || typeof entry !== "object") continue;
     if (entry.repo !== command.repo) continue;
     if (Number(entry.issue_number) !== Number(command.issue_number)) continue;
-    if (!["autofix", "automerge"].includes(String(entry.intent ?? ""))) continue;
+    const intent = String(entry.intent ?? "");
+    if (!["autofix", "automerge", "maintainer_approve_automerge"].includes(intent)) continue;
     if (!["executed", "waiting"].includes(String(entry.status ?? ""))) continue;
+    if (intent === "maintainer_approve_automerge") {
+      const approvedHead = String(entry.expected_head_sha ?? entry.target?.head_sha ?? "")
+        .trim()
+        .toLowerCase();
+      const reviewedHead = String(command.expected_head_sha ?? command.target?.head_sha ?? "")
+        .trim()
+        .toLowerCase();
+      // An approval is stronger than a mode opt-in, so preserve it only for the
+      // exact reviewed head it authorized. A later contributor push must reopen the gate.
+      if (!approvedHead || approvedHead !== reviewedHead) continue;
+    }
     latest = Math.max(latest, Date.parse(String(entry.comment_updated_at ?? "")) || 0);
   }
   return latest;
@@ -1979,13 +1991,14 @@ export function trustedExactHeadReviewCompletionSince({
   headSha: string;
   trustedAuthors?: ReadonlySet<string>;
   sinceMs: number;
-}): { reviewedAt: string | null; publishedAt: string | null } | null {
+}): { commentId: number; reviewedAt: string | null; publishedAt: string | null } | null {
   const normalizedHead = String(headSha ?? "")
     .trim()
     .toLowerCase();
   if (!normalizedHead || !Number.isFinite(sinceMs)) return null;
 
   let newest: {
+    commentId: number;
     observedAtMs: number;
     reviewedAt: string | null;
     publishedAt: string | null;
@@ -1993,6 +2006,8 @@ export function trustedExactHeadReviewCompletionSince({
   for (const comment of comments) {
     const completed = parseTrustedAutomation(comment, { trustedAuthors });
     if (!completed) continue;
+    const commentId = Number(comment?.id);
+    if (!Number.isInteger(commentId) || commentId <= 0) continue;
     if (
       String(completed.expected_head_sha ?? "")
         .trim()
@@ -2018,10 +2033,16 @@ export function trustedExactHeadReviewCompletionSince({
     );
     if (observedAtMs < sinceMs || observedAtMs <= 0) continue;
     if (!newest || observedAtMs > newest.observedAtMs) {
-      newest = { observedAtMs, reviewedAt, publishedAt };
+      newest = { commentId, observedAtMs, reviewedAt, publishedAt };
     }
   }
-  return newest && { reviewedAt: newest.reviewedAt, publishedAt: newest.publishedAt };
+  return (
+    newest && {
+      commentId: newest.commentId,
+      reviewedAt: newest.reviewedAt,
+      publishedAt: newest.publishedAt,
+    }
+  );
 }
 
 export function parseRoutedCommentCommand(

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -2093,6 +2093,10 @@ function executeCommand(command: LooseRecord) {
       );
       const dispatchDecision = reviewDispatchDecisionForCommand(command);
       if (dispatchDecision.action !== "dispatch") {
+        const verdictRouter =
+          dispatchDecision.action === "reuse_completed_review"
+            ? dispatchCompletedReviewVerdict(command, dispatchDecision)
+            : null;
         const dispatchStatus = markCoordinatedReviewDispatchActions({
           command,
           job,
@@ -2106,6 +2110,7 @@ function executeCommand(command: LooseRecord) {
               status: dispatchStatus,
               coordination_action: dispatchDecision.action,
               reason: dispatchDecision.reason,
+              ...(verdictRouter ? { verdict_router: verdictRouter } : {}),
             },
           };
         }
@@ -2991,6 +2996,7 @@ function reviewDispatchDecisionForCommand(
         headAfter: headBefore,
         activeLeaseExpiresAt: null,
         completedReviewAt: null,
+        completedReviewCommentId: null,
       });
     }
     const comments = ghPaged<JsonValue>(
@@ -3026,6 +3032,7 @@ function reviewDispatchDecisionForCommand(
         completedReview?.publishedAt ??
         completedReview?.reviewedAt ??
         (completedReview ? "recently" : null),
+      completedReviewCommentId: completedReview?.commentId ?? null,
     });
   } catch (error) {
     return {
@@ -3036,6 +3043,7 @@ function reviewDispatchDecisionForCommand(
 }
 
 function reviewDispatchActionStatus(decision: ReviewDispatchCoordinationDecision) {
+  if (decision.action === "reuse_completed_review") return "executed";
   return ["wait_for_active_review", "retry"].includes(decision.action) ? "waiting" : "skipped";
 }
 
@@ -3330,6 +3338,53 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
     repo: reviewRepo,
     item_number: command.issue_number,
     dispatch_key: dispatchKey,
+  };
+}
+
+function dispatchCompletedReviewVerdict(
+  command: LooseRecord,
+  decision: Extract<ReviewDispatchCoordinationDecision, { action: "reuse_completed_review" }>,
+) {
+  const attemptId = `completed-review-${command.comment_id ?? "sweep"}-${decision.commentId}`;
+  const payload = JSON.stringify({
+    event_type: "clawsweeper_comment",
+    client_payload: {
+      target_repo: command.repo,
+      ...(command.target_branch ? { target_branch: String(command.target_branch) } : {}),
+      item_number: String(command.issue_number),
+      comment_id: String(decision.commentId),
+      max_comments: "1",
+      force_reprocess: "true",
+      attempt_id: attemptId,
+      source_event: "comment_router",
+      source_action: "reuse_completed_review",
+    },
+  });
+  const result = runGitHubSpawnMutation(
+    command,
+    "review_verdict_dispatch",
+    {
+      repository: reviewRepo,
+      workflow: "repair-comment-router.yml",
+      event: "repository_dispatch",
+      commentId: decision.commentId,
+      attemptId,
+    },
+    ["api", `repos/${reviewRepo}/dispatches`, "--method", "POST", "--input", "-"],
+    { env: dispatchTokenEnv(), input: payload },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to requeue completed ClawSweeper verdict for #${command.issue_number}: ${stripAnsi(result.stderr || result.stdout).trim()}`,
+    );
+  }
+  return {
+    workflow: "repair-comment-router.yml",
+    event: "repository_dispatch",
+    repo: reviewRepo,
+    item_number: command.issue_number,
+    comment_id: decision.commentId,
+    attempt_id: attemptId,
   };
 }
 

--- a/src/repair/review-dispatch-coordination.ts
+++ b/src/repair/review-dispatch-coordination.ts
@@ -1,7 +1,7 @@
 export type ReviewDispatchCoordinationDecision =
   | { action: "dispatch" }
   | { action: "wait_for_active_review"; reason: string }
-  | { action: "reuse_completed_review"; reason: string }
+  | { action: "reuse_completed_review"; commentId: number; reason: string }
   | { action: "retry"; reason: string }
   | { action: "stop"; reason: string };
 
@@ -12,6 +12,7 @@ export type ReviewDispatchCoordinationInput = {
   headAfter: string;
   activeLeaseExpiresAt: string | null;
   completedReviewAt: string | null;
+  completedReviewCommentId: number | null;
 };
 
 export function decideReviewDispatchCoordination({
@@ -21,6 +22,7 @@ export function decideReviewDispatchCoordination({
   headAfter,
   activeLeaseExpiresAt,
   completedReviewAt,
+  completedReviewCommentId,
 }: ReviewDispatchCoordinationInput): ReviewDispatchCoordinationDecision {
   if (!isOpen(stateBefore) || !isOpen(stateAfter)) {
     return { action: "stop", reason: "target is no longer an open PR" };
@@ -39,9 +41,10 @@ export function decideReviewDispatchCoordination({
       reason: `same-head ClawSweeper review is active until ${activeLeaseExpiresAt}`,
     };
   }
-  if (completedReviewAt) {
+  if (completedReviewAt && completedReviewCommentId) {
     return {
       action: "reuse_completed_review",
+      commentId: completedReviewCommentId,
       reason: `same-head ClawSweeper review completed at ${completedReviewAt}; its result will be reused`,
     };
   }

--- a/test/e2e/automerge/fake-gh.mjs
+++ b/test/e2e/automerge/fake-gh.mjs
@@ -76,7 +76,7 @@ if (args[0] === "pr" && args[1] === "view") {
     labels: state.pr.labels.map((name) => ({ name })),
     mergeable: "MERGEABLE",
     mergeCommit: state.pr.mergeCommitSha ? { oid: state.pr.mergeCommitSha } : null,
-    mergeStateStatus: "CLEAN",
+    mergeStateStatus: state.pr.mergeStateStatus,
     mergedAt: state.pr.mergedAt,
     reviewDecision: "APPROVED",
     state: state.pr.mergedAt ? "MERGED" : state.pr.state.toUpperCase(),
@@ -351,6 +351,9 @@ function mergePullRequest(expectedHead) {
   const head = currentHead();
   if (expectedHead && expectedHead !== head)
     fail(`head branch was modified: expected ${expectedHead}, found ${head}`);
+  if (state.pr.mergeStateStatus === "BEHIND") {
+    fail("pull request is not mergeable: the head branch is not up to date with the base branch");
+  }
   if (state.pr.mergedAt) return;
   const work = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-e2e-merge-"));
   try {
@@ -388,6 +391,7 @@ function addComment(body) {
 
 function readInput() {
   const inputPath = optionValue("--input");
+  if (inputPath === "-") return JSON.parse(fs.readFileSync(0, "utf8"));
   return inputPath ? JSON.parse(fs.readFileSync(inputPath, "utf8")) : {};
 }
 

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -13,6 +13,8 @@ import { repairCommentRouterGroup, WorkflowScheduler } from "./workflow-schedule
 
 const helperRoot = path.dirname(fileURLToPath(import.meta.url));
 export const AUTOMERGE_E2E_SCENARIOS = [
+  "approve-intent-persistence",
+  "completed-verdict-resume",
   "dependency-setup-mutation",
   "happy-path",
   "pending-checks",
@@ -252,13 +254,66 @@ export function runAutomergeE2E({
 
     const repairedHead = currentRef(targetFixture.remote, targetFixture.headRef);
     assertFixturePostRepair(targetFixture, repairedHead);
-    if (scenario === "resume-intent-persistence") {
+    if (
+      scenario === "approve-intent-persistence" ||
+      scenario === "completed-verdict-resume" ||
+      scenario === "resume-intent-persistence"
+    ) {
       const activeJob = path.join(
         runtimeRoot,
         "jobs/openclaw/inbox/automerge-openclaw-openclaw-42.md",
       );
       fs.mkdirSync(path.dirname(activeJob), { recursive: true });
       fs.copyFileSync(jobPath, activeJob);
+    }
+    let completedVerdictAlreadyRouted = false;
+    if (scenario === "approve-intent-persistence") {
+      updateGitHubState(statePath, (state) => {
+        state.pr.mergeStateStatus = "BEHIND";
+        state.pr.labels.push("clawsweeper:human-review");
+      });
+      const approvalId = addMaintainerApproveCommand(statePath);
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "08-comment-router-approve", {
+        commentId: approvalId,
+      });
+      assert.equal(
+        JSON.parse(fs.readFileSync(statePath, "utf8")).pr.mergedAt,
+        null,
+        "a behind branch must remain open after the first exact-head approval",
+      );
+      updateGitHubState(statePath, (state) => {
+        state.pr.mergeStateStatus = "CLEAN";
+      });
+      addCanonicalNeedsHumanVerdict(statePath, repairedHead);
+    } else if (scenario === "completed-verdict-resume") {
+      const commandId = addMaintainerAutomergeCommand(statePath);
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "08-comment-router-command", {
+        commentId: commandId,
+      });
+      const verdictId = addExactHeadVerdict(statePath, repairedHead);
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "09-comment-router-command-replay", {
+        commentId: commandId,
+        forceReprocess: true,
+        attemptId: "completed-verdict-resume",
+      });
+      const replayState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      const verdictHandoff = replayState.dispatches.findLast(
+        (dispatch) =>
+          dispatch.event_type === "clawsweeper_comment" &&
+          dispatch.client_payload?.comment_id === String(verdictId),
+      );
+      assert.ok(
+        verdictHandoff,
+        "reusing a completed review must requeue its exact verdict after an earlier handoff was lost",
+      );
+      assert.equal(verdictHandoff.client_payload.force_reprocess, "true");
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "10-comment-router-verdict-handoff", {
+        commentId: verdictId,
+        forceReprocess: true,
+        attemptId: String(verdictHandoff.client_payload.attempt_id),
+      });
+      completedVerdictAlreadyRouted = true;
+    } else if (scenario === "resume-intent-persistence") {
       addMaintainerAutomergeCommand(statePath);
       runCommentRouter(runtimeRoot, baseEnv, artifacts, "08-comment-router-resume-command");
       const resumeReport = readRouterReport(runtimeRoot);
@@ -284,7 +339,7 @@ export function runAutomergeE2E({
         "a later router invocation must be able to hydrate the resume command",
       );
       addCanonicalNeedsHumanVerdict(statePath, repairedHead);
-    } else {
+    } else if (!completedVerdictAlreadyRouted) {
       addExactHeadVerdict(statePath, repairedHead);
     }
     if (scenario === "verdict-head-drift") {
@@ -336,7 +391,7 @@ export function runAutomergeE2E({
       );
       assert.equal(JSON.parse(fs.readFileSync(statePath, "utf8")).pr.mergedAt, null);
       runCommentRouter(runtimeRoot, baseEnv, artifacts, "09-comment-router-checks-green");
-    } else {
+    } else if (!completedVerdictAlreadyRouted) {
       runCommentRouter(runtimeRoot, baseEnv, artifacts, "08-comment-router");
     }
     const routerReport = readRouterReport(runtimeRoot);
@@ -377,7 +432,7 @@ export function runAutomergeE2E({
     assert.equal(idempotentRouterReport.actionable, 0);
     assert.equal(
       state.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "merge").length,
-      1,
+      scenario === "approve-intent-persistence" ? 2 : 1,
       "an idempotent router replay must not attempt a second merge",
     );
     assert.ok(state.calls.some((call) => call.token === "read"));
@@ -538,6 +593,7 @@ function addExactHeadVerdict(statePath, headSha) {
     updated_at: now,
   });
   writeJson(statePath, state);
+  return state.nextCommentId - 1;
 }
 
 function addMaintainerAutomergeCommand(statePath) {
@@ -547,10 +603,18 @@ function addMaintainerAutomergeCommand(statePath) {
     authorId: 1,
     body: `Automerge is already active.\n<!-- clawsweeper-command-status:${state.pr.number}:automerge:active -->`,
   });
-  addFixtureComment(statePath, {
+  return addFixtureComment(statePath, {
     author: "fixture-maintainer",
     authorId: 2,
     body: "@clawsweeper automerge\n\nResume the exact current head after the repair fix landed.",
+  });
+}
+
+function addMaintainerApproveCommand(statePath) {
+  return addFixtureComment(statePath, {
+    author: "fixture-maintainer",
+    authorId: 2,
+    body: "@clawsweeper approve",
   });
 }
 
@@ -589,6 +653,7 @@ function addFixtureComment(
     updated_at: timestamp,
   });
   writeJson(statePath, state);
+  return id;
 }
 
 function runPlanningHeadDriftScenario({
@@ -867,6 +932,39 @@ function runCommentRouter(runtimeRoot, baseEnv, artifacts, label) {
   );
 }
 
+function runCommentRouterExact(
+  runtimeRoot,
+  baseEnv,
+  artifacts,
+  label,
+  { commentId, forceReprocess = false, attemptId = "" },
+) {
+  const statePath = baseEnv.CLAWSWEEPER_E2E_GITHUB_STATE;
+  assert.equal(typeof statePath, "string", "router requires the fake GitHub state path");
+  const itemNumber = JSON.parse(fs.readFileSync(statePath, "utf8")).pr.number;
+  const replayArgs = forceReprocess ? ["--force-reprocess", "--attempt-id", attemptId] : [];
+  runCli(
+    runtimeRoot,
+    [
+      "dist/repair/comment-router.js",
+      "--repo",
+      "openclaw/openclaw",
+      "--item-number",
+      String(itemNumber),
+      "--comment-id",
+      String(commentId),
+      "--max-comments",
+      "1",
+      ...replayArgs,
+      "--execute",
+    ],
+    baseEnv,
+    "post-token",
+    artifacts,
+    label,
+  );
+}
+
 function readRouterReport(runtimeRoot) {
   return JSON.parse(
     fs.readFileSync(path.join(runtimeRoot, "results", "comment-router-latest.json"), "utf8"),
@@ -903,6 +1001,7 @@ function initialGitHubState(fixture, targetPrNumber = 42) {
       updatedAt: now,
       mergedAt: null,
       mergeCommitSha: null,
+      mergeStateStatus: "CLEAN",
       files: fixture.files ?? ["src/repair-target.txt"],
     },
   };

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1780,6 +1780,7 @@ test("review start leases reject malformed, future, and overlong markers", () =>
 test("same-head completion freshness uses durable publication time", () => {
   const headSha = "0123456789abcdef0123456789abcdef01234567";
   const comment = {
+    id: 1234,
     user: { login: "clawsweeper[bot]" },
     created_at: "2026-07-09T21:00:00.000Z",
     updated_at: "2026-07-09T21:05:30.000Z",
@@ -1794,6 +1795,7 @@ test("same-head completion freshness uses durable publication time", () => {
       sinceMs: Date.parse("2026-07-09T21:05:00.000Z"),
     }),
     {
+      commentId: 1234,
       reviewedAt: "2026-07-09T21:04:30.000Z",
       publishedAt: "2026-07-09T21:05:30.000Z",
     },
@@ -2640,6 +2642,43 @@ test("canonical landing needs-human accepts waiting automerge opt-in as active r
       optInTime,
     }),
     true,
+  );
+});
+
+test("canonical landing needs-human keeps an exact-head maintainer approval active", () => {
+  const headSha = "0123456789abcdef0123456789abcdef01234567";
+  const command = {
+    repo: "openclaw/openclaw",
+    issue_number: 104054,
+    expected_head_sha: headSha,
+  };
+  const approvedAt = latestRepairLoopResumeTime(
+    [
+      {
+        ...command,
+        intent: "maintainer_approve_automerge",
+        status: "executed",
+        comment_updated_at: "2026-07-19T04:07:56Z",
+      },
+    ],
+    command,
+  );
+
+  assert.equal(approvedAt, Date.parse("2026-07-19T04:07:56Z"));
+  assert.equal(
+    latestRepairLoopResumeTime(
+      [
+        {
+          ...command,
+          intent: "maintainer_approve_automerge",
+          status: "executed",
+          comment_updated_at: "2026-07-19T04:07:56Z",
+        },
+      ],
+      { ...command, expected_head_sha: "f".repeat(40) },
+    ),
+    0,
+    "a maintainer approval must not survive a contributor head change",
   );
 });
 

--- a/test/repair/review-dispatch-coordination.test.ts
+++ b/test/repair/review-dispatch-coordination.test.ts
@@ -13,6 +13,7 @@ function decision(overrides: Partial<Parameters<typeof decideReviewDispatchCoord
     headAfter: head,
     activeLeaseExpiresAt: null,
     completedReviewAt: null,
+    completedReviewCommentId: null,
     ...overrides,
   });
 }
@@ -39,8 +40,12 @@ test("waits for an active exact-head review", () => {
 });
 
 test("reuses a same-head review completed since the command", () => {
-  const result = decision({ completedReviewAt: "2026-07-17T14:10:00.000Z" });
+  const result = decision({
+    completedReviewAt: "2026-07-17T14:10:00.000Z",
+    completedReviewCommentId: 1234,
+  });
   assert.equal(result.action, "reuse_completed_review");
+  assert.equal(result.commentId, 1234);
   assert.match(result.reason, /result will be reused/);
 });
 
@@ -49,6 +54,7 @@ test("an active lease wins over a completed marker", () => {
     decision({
       activeLeaseExpiresAt: "2026-07-17T14:13:17.000Z",
       completedReviewAt: "2026-07-17T14:10:00.000Z",
+      completedReviewCommentId: 1234,
     }).action,
     "wait_for_active_review",
   );


### PR DESCRIPTION
## Summary

- re-dispatch the exact durable verdict when an automerge command reuses a completed review
- preserve an exact-head maintainer approval across later verdict processing on the same head
- add deterministic host/container E2E scenarios for lost verdict handoff and behind-then-resume approval

## Root cause

Completed-review reuse only updated the repair timeline and did not requeue the already-published exact verdict. Separately, the repair-loop resume watermark ignored `maintainer_approve_automerge`, so a later `needs-human` verdict on the same reviewed head could close a gate the maintainer had already approved.

The new dispatch attempt is deterministic and remains bound to the exact item and durable verdict comment. Approval persistence remains bound to the explicitly approved head SHA and expires when the contributor head changes.

## Validation

- focused repair unit tests: 127/127 passed
- host automerge E2E: `approve-intent-persistence` and `completed-verdict-resume` passed
- Node 24 local-container E2E using `clawsweeper-automerge-e2e-base:local`: both scenarios passed
- `pnpm run check` passed, including unit, repair, changed/full coverage, and formatting
- local autoreview: 0 accepted/actionable findings
- staged gitleaks scan: no leaks found