### PR TITLE
fix(repair): prevent immutable ledger publish starvation

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -53,6 +53,7 @@ export type RebaseStrategy = "normal" | "theirs" | "apply-records" | "reconcile-
 export type GitRunOptions = {
   allowFailure?: boolean;
   displayArgs?: readonly string[];
+  input?: string;
   quiet?: boolean;
 };
 
@@ -123,6 +124,7 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     cwd: publishRoot(),
     env: process.env,
     encoding: "utf8",
+    input: options.input,
     maxBuffer: 16 * 1024 * 1024,
   });
   if (!options.quiet && child.stdout) process.stdout.write(child.stdout);
@@ -156,6 +158,8 @@ function safeGitDisplayAction(action: string | undefined): string {
     case "cat-file":
     case "clean":
     case "ls-files":
+    case "ls-tree":
+    case "mktree":
     case "push":
     case "read-tree":
     case "rebase":
@@ -406,25 +410,46 @@ function pushImmutableActionLedgerCommit(options: {
 }): PublishResult {
   // Keep both retry knobs additive. Their former nesting multiplied every
   // state race into another complete rebase loop.
-  const pushBudget = options.maxAttempts + options.pushAttempts + 1;
+  const pushBudget = Math.max(options.maxAttempts + options.pushAttempts + 1, 16);
+  const previousCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
   const protectedWorktreePaths = captureDirtyWorktreePaths();
+  let candidateCommit = options.sourceCommit;
   for (let attempt = 1; attempt <= pushBudget; attempt += 1) {
-    if (spawnGit(["push", options.remote, `HEAD:${options.branch}`]).status === 0) {
+    if (
+      spawnGit(["push", options.remote, `${candidateCommit}:${options.branch}`], {
+        displayArgs: ["push", options.remote, `<commit>:${options.branch}`],
+      }).status === 0
+    ) {
+      finalizeImmutableActionLedgerCheckout({
+        previousCommit,
+        publishedCommit: candidateCommit,
+        paths: options.paths,
+        protectedWorktreePaths,
+      });
       return "committed";
     }
     if (attempt === pushBudget) break;
 
-    // These paths are immutable and create-only, so rebuilding their exact batch
-    // is cheaper and safer than multiplying rebase probes inside nested retries.
-    const rebuildResult = rebuildPublishCommit({
+    // Build only the affected ancestor trees. The state checkout has hundreds
+    // of thousands of entries, so rebuilding its full index is slower than the
+    // production write rate and guarantees that every retry starts stale.
+    const rebuilt = rebuildImmutableActionLedgerCommit({
       remote: options.remote,
       branch: options.branch,
       message: options.message,
       paths: options.paths,
       sourceCommit: options.sourceCommit,
-      protectedWorktreePaths,
     });
-    if (rebuildResult === "unchanged") return "unchanged";
+    candidateCommit = rebuilt.commit;
+    if (rebuilt.result === "unchanged") {
+      finalizeImmutableActionLedgerCheckout({
+        previousCommit,
+        publishedCommit: candidateCommit,
+        paths: options.paths,
+        protectedWorktreePaths,
+      });
+      return "unchanged";
+    }
   }
   throw new Error(`Failed to publish commit after ${pushBudget} push attempts`);
 }
@@ -1480,7 +1505,6 @@ function rebuildPublishCommit(options: {
   message: string;
   paths: readonly string[];
   sourceCommit: string;
-  protectedWorktreePaths?: ReadonlySet<string>;
 }): PublishResult {
   console.log(`Rebuilding publish commit on ${options.remote}/${options.branch}`);
   runGit(["fetch", options.remote, options.branch]);
@@ -1488,15 +1512,6 @@ function rebuildPublishCommit(options: {
     quiet: true,
   }).trim();
   const publishPaths = uniqueNonEmpty(options.paths);
-  if (publishPaths.length > 0 && publishPaths.every(isActionEventPublishPath)) {
-    return rebuildImmutableActionLedgerCommit({
-      remoteCommit,
-      message: options.message,
-      paths: publishPaths,
-      sourceCommit: options.sourceCommit,
-      protectedWorktreePaths: options.protectedWorktreePaths ?? new Set(),
-    });
-  }
   const statusMerges = planSweepStatusMerges({
     baseCommit: runGit(["rev-parse", `${options.sourceCommit}^`], { quiet: true }).trim(),
     localCommit: options.sourceCommit,
@@ -1539,50 +1554,136 @@ function rebuildPublishCommit(options: {
 }
 
 function rebuildImmutableActionLedgerCommit(options: {
-  remoteCommit: string;
+  remote: string;
+  branch: string;
   message: string;
   paths: readonly string[];
   sourceCommit: string;
+}): { result: PublishResult; commit: string } {
+  runGit(["fetch", options.remote, options.branch]);
+  const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
+    quiet: true,
+  }).trim();
+  const remoteTree = runGit(["rev-parse", `${remoteCommit}^{tree}`], { quiet: true }).trim();
+  const tree = rewriteImmutableActionLedgerTree({
+    remoteTree,
+    sourceCommit: options.sourceCommit,
+    paths: options.paths,
+  });
+  if (tree === remoteTree) {
+    console.log("No immutable action-ledger changes after syncing remote");
+    return { result: "unchanged", commit: remoteCommit };
+  }
+
+  const commit = runGit(["commit-tree", tree, "-p", remoteCommit, "-m", options.message]).trim();
+  return { result: "committed", commit };
+}
+
+type GitTreeEntry = {
+  mode: string;
+  type: string;
+  oid: string;
+  name: string;
+};
+
+type GitTreePatch = {
+  files: Map<string, GitTreeEntry>;
+  directories: Map<string, GitTreePatch>;
+};
+
+function rewriteImmutableActionLedgerTree(options: {
+  remoteTree: string;
+  sourceCommit: string;
+  paths: readonly string[];
+}): string {
+  const patch: GitTreePatch = { files: new Map(), directories: new Map() };
+  const sourceEntries = chunked(options.paths, GIT_PATHSPEC_BATCH_SIZE).flatMap((paths) =>
+    readGitTreeEntries(["ls-tree", "-z", "--full-tree", options.sourceCommit, "--", ...paths]),
+  );
+  const sourceByPath = new Map(sourceEntries.map((entry) => [entry.name, entry]));
+  for (const path of options.paths) {
+    const entry = sourceByPath.get(path);
+    if (!entry || entry.type !== "blob") {
+      throw new Error(`Immutable action-ledger source path is not a blob: ${path}`);
+    }
+    addGitTreePatch(patch, path.split("/"), entry);
+  }
+  return writePatchedGitTree(options.remoteTree, patch);
+}
+
+function addGitTreePatch(patch: GitTreePatch, parts: readonly string[], entry: GitTreeEntry): void {
+  const [name, ...rest] = parts;
+  if (!name) throw new Error("Immutable action-ledger path is empty");
+  if (rest.length === 0) {
+    patch.files.set(name, { ...entry, name });
+    return;
+  }
+  const child = patch.directories.get(name) ?? { files: new Map(), directories: new Map() };
+  patch.directories.set(name, child);
+  addGitTreePatch(child, rest, entry);
+}
+
+function writePatchedGitTree(baseTree: string | null, patch: GitTreePatch): string {
+  const entries = new Map(
+    (baseTree ? readGitTreeEntries(["ls-tree", "-z", baseTree]) : []).map((entry) => [
+      entry.name,
+      entry,
+    ]),
+  );
+  for (const [name, childPatch] of patch.directories) {
+    const existing = entries.get(name);
+    if (existing && existing.type !== "tree") {
+      throw new Error(`Immutable action-ledger directory collides with ${existing.type}: ${name}`);
+    }
+    const oid = writePatchedGitTree(existing?.oid ?? null, childPatch);
+    entries.set(name, { mode: "040000", type: "tree", oid, name });
+  }
+  for (const [name, entry] of patch.files) entries.set(name, entry);
+  const input = [...entries.values()]
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((entry) => `${entry.mode} ${entry.type} ${entry.oid}\t${entry.name}\0`)
+    .join("");
+  return runGit(["mktree", "-z"], { input, quiet: true }).trim();
+}
+
+function readGitTreeEntries(args: readonly string[]): GitTreeEntry[] {
+  return runGit(args, { quiet: true })
+    .split("\0")
+    .filter(Boolean)
+    .map((record) => {
+      const separator = record.indexOf("\t");
+      const match = /^(\d+) ([a-z]+) ([a-f0-9]+)$/.exec(record.slice(0, separator));
+      if (separator < 0 || !match) throw new Error("Git tree entry is malformed");
+      return {
+        mode: match[1]!,
+        type: match[2]!,
+        oid: match[3]!,
+        name: record.slice(separator + 1),
+      };
+    });
+}
+
+function finalizeImmutableActionLedgerCheckout(options: {
+  previousCommit: string;
+  publishedCommit: string;
+  paths: readonly string[];
   protectedWorktreePaths: ReadonlySet<string>;
-}): PublishResult {
-  const previousCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
-  const remoteWorktreePaths = changedPathsBetween(previousCommit, options.remoteCommit).filter(
+}): void {
+  const remoteWorktreePaths = changedPathsBetween(
+    options.previousCommit,
+    options.publishedCommit,
+  ).filter(
     (path) =>
       !options.paths.includes(path) &&
       ![...options.protectedWorktreePaths].some(
         (protectedPath) => pathIsWithin(path, protectedPath) || pathIsWithin(protectedPath, path),
       ),
   );
-  // The state checkout can contain hundreds of thousands of files. Replacing
-  // only the index avoids rewriting that entire worktree after every push race.
-  // The synchronous publish lane has already committed all staged entries, so
-  // only pre-existing worktree dirt—not caller staging—can reach this rebuild.
-  runGit(["read-tree", "--reset", options.remoteCommit]);
-  applyPathsFromCommit(options.paths, options.sourceCommit);
-  const tree = runGit(["write-tree"], { quiet: true }).trim();
-  const remoteTree = runGit(["rev-parse", `${options.remoteCommit}^{tree}`], {
-    quiet: true,
-  }).trim();
-  if (tree === remoteTree) {
-    runGit(["update-ref", "HEAD", options.remoteCommit]);
-    syncRemoteWorktreePaths(remoteWorktreePaths, options.remoteCommit);
-    console.log("No immutable action-ledger changes after syncing remote");
-    return "unchanged";
-  }
-
-  // commit-tree binds the exact rebuilt tree directly to the fetched remote
-  // parent; moving HEAD afterwards is constant-time and keeps the next push exact.
-  const commit = runGit([
-    "commit-tree",
-    tree,
-    "-p",
-    options.remoteCommit,
-    "-m",
-    options.message,
-  ]).trim();
-  runGit(["update-ref", "HEAD", commit]);
-  syncRemoteWorktreePaths(remoteWorktreePaths, commit);
-  return "committed";
+  // Refresh the large checkout once, after the remote ref accepted the commit.
+  // Its cost can no longer make the compare-and-swap candidate stale.
+  runGit(["read-tree", "--reset", options.publishedCommit]);
+  runGit(["update-ref", "HEAD", options.publishedCommit]);
+  syncRemoteWorktreePaths(remoteWorktreePaths, options.publishedCommit);
 }
 
 function captureDirtyWorktreePaths(): ReadonlySet<string> {
@@ -1605,20 +1706,6 @@ function syncRemoteWorktreePaths(paths: readonly string[], commit: string): void
   }
   for (const batch of chunked(deletedPaths, GIT_PATHSPEC_BATCH_SIZE)) {
     runGit(["clean", "-f", "-d", "-x", "--", ...batch]);
-  }
-}
-
-function applyPathsFromCommit(paths: readonly string[], commit: string): void {
-  for (const batch of chunked(paths, GIT_PATHSPEC_BATCH_SIZE)) {
-    runGit(["rm", "-r", "--ignore-unmatch", "--", ...batch], {
-      allowFailure: true,
-      quiet: true,
-    });
-  }
-  const existing = gitObjectExistence(paths.map((path) => ({ commit, path })));
-  const checkoutPaths = paths.filter((path) => existing.has(gitObjectSpec(commit, path)));
-  for (const batch of chunked(checkoutPaths, GIT_PATHSPEC_BATCH_SIZE)) {
-    runGit(["checkout", commit, "--", ...batch]);
   }
 }
 

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1476,7 +1476,7 @@ test("publishMainCommit rebuilds immutable ledger batches within the router proc
   const work = path.join(root, "work");
   const other = path.join(root, "other");
   const ledgerPaths = Array.from(
-    { length: 25 },
+    { length: 257 },
     (_, index) => `ledger/v1/import-bindings/events/${index.toString(16).padStart(64, "0")}.json`,
   );
   run("git", ["init", "--bare", origin], root);
@@ -1517,8 +1517,8 @@ test("publishMainCommit rebuilds immutable ledger batches within the router proc
   assert.ok(metrics, "ledger race publish emits metrics");
   const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
   assert.ok(
-    Number.isInteger(processCount) && processCount <= 40,
-    `ledger race rebuild used ${processCount} git subprocesses; expected at most 40`,
+    Number.isInteger(processCount) && processCount <= 50,
+    `ledger race rebuild used ${processCount} git subprocesses; expected at most 50`,
   );
   for (const ledgerPath of ledgerPaths) {
     assert.equal(
@@ -1532,7 +1532,7 @@ test("publishMainCommit rebuilds immutable ledger batches within the router proc
   );
 });
 
-test("publishMainCommit bounds immutable ledger work across sustained state races", () => {
+test("publishMainCommit converges after production-sized immutable ledger races", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
   const work = path.join(root, "work");
@@ -1564,7 +1564,7 @@ test("publishMainCommit bounds immutable ledger work across sustained state race
   write(path.join(work, "unrelated/0000.txt"), "local scratch remains\n");
   write(path.join(work, "scratch/dirty.txt"), "nested local scratch remains\n");
   write(path.join(work, "ignored/secret.txt"), "ignored local scratch remains\n");
-  installPushRaceHook(work, other, 7);
+  installPushRaceHook(work, other, 12);
 
   const lines = [];
   let result;
@@ -1584,22 +1584,22 @@ test("publishMainCommit bounds immutable ledger work across sustained state race
   assert.ok(metrics, "sustained ledger race publish emits metrics");
   const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
   assert.ok(
-    Number.isInteger(processCount) && processCount <= 125,
-    `sustained ledger races used ${processCount} git subprocesses; expected at most 125`,
+    Number.isInteger(processCount) && processCount <= 180,
+    `sustained ledger races used ${processCount} git subprocesses; expected at most 180`,
   );
-  assert.match(metrics, /actions=.*push:8(?:,|$)/, "one push is attempted per bounded retry");
+  assert.match(metrics, /actions=.*push:13(?:,|$)/, "the publish survives twelve lost pushes");
   assert.doesNotMatch(metrics, /actions=.*rebase:/, "immutable ledger retries never nest rebases");
   assert.doesNotMatch(
     metrics,
     /actions=.*reset:/,
     "immutable ledger retries never reset the worktree",
   );
-  assert.match(metrics, /actions=.*read-tree:7(?:,|$)/, "each rebuild replaces only the index");
   assert.match(
     metrics,
-    /actions=.*restore:7(?:,|$)/,
-    "each rebuild refreshes remote worktree paths",
+    /actions=.*read-tree:1(?:,|$)/,
+    "the full index refresh happens only after push",
   );
+  assert.match(metrics, /actions=.*restore:1(?:,|$)/, "worktree paths refresh only after push");
   assert.equal(
     fs.readFileSync(path.join(work, "unrelated/0000.txt"), "utf8"),
     "local scratch remains\n",
@@ -1616,26 +1616,26 @@ test("publishMainCommit bounds immutable ledger work across sustained state race
   );
   assert.equal(
     fs.readFileSync(path.join(work, "remote.txt"), "utf8"),
-    Array.from({ length: 7 }, (_, index) => `race ${index + 1}\n`).join(""),
+    Array.from({ length: 12 }, (_, index) => `race ${index + 1}\n`).join(""),
     "clean worktree paths follow every fetched remote parent",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
-    Array.from({ length: 7 }, (_, index) => `race ${index + 1}\n`).join(""),
+    Array.from({ length: 12 }, (_, index) => `race ${index + 1}\n`).join(""),
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:unrelated/0000.txt"], root),
-    "remote scratch 7\n",
+    "remote scratch 12\n",
     "the rebuilt commit keeps the remote version of a locally dirty path",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:scratch"], root),
-    "remote parent 7\n",
+    "remote parent 12\n",
     "the rebuilt commit keeps a remote file that replaced a dirty local directory",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:ignored"], root),
-    "remote ignored parent 7\n",
+    "remote ignored parent 12\n",
     "the rebuilt commit keeps a remote file that replaced an ignored local directory",
   );
   for (const ledgerPath of ledgerPaths) {


### PR DESCRIPTION
## Summary

- rebuild immutable action-ledger retry commits by rewriting only affected Git trees
- push candidate commit SHAs before refreshing the large state checkout
- preserve bounded pathspec batching and dirty worktree paths
- cover twelve consecutive production-sized push races plus a 257-path batch

## Root cause

Each retry rebuilt the full index with `git read-tree --reset`. In production that took about 67 seconds while the state branch advanced more frequently, so every candidate was stale before push and the bounded retry loop starved.

## Validation

- `pnpm run build:repair && node --test test/repair/git-publish.test.ts` (33/33)
- `pnpm run check`
- `/data/code/openclaw/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local` (0 findings)
- `gitleaks protect --staged --redact --no-banner` (0 leaks)