### PR TITLE
fix(repair): resume armed automerge verdicts

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -717,7 +717,11 @@ export function existingRepairLoopModeOutcome({ intent, trustedBot }: LooseRecor
 export function isCanonicalLandingNeedsHumanText(value: JsonValue) {
   const text = String(value ?? "");
   if (!text) return false;
-  if (/security-sensitive|needs attention|review finding|\[P[0-3]\]/i.test(text)) return false;
+  if (/security-sensitive|needs attention|review finding/i.test(text)) return false;
+  // Review prose sometimes prefixes its non-finding landing conclusion with a
+  // priority token. Keep rejecting actual prioritized findings while allowing
+  // the canonical "No repair lane" conclusion to reach the exact-head gate.
+  if (/\[P[0-3]\](?!\s*No repair lane is needed\b)/i.test(text)) return false;
   return (
     /no repair lane is needed|maintainer action is to land|land .*canonical|canonical .*fix/i.test(
       text,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -1057,7 +1057,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
       const alreadyPlanned = autoRepairAlreadyPlanned(next);
       if (alreadyPlanned) return { ...next, status: "skipped", reason: alreadyPlanned };
     }
-    if (
+    const existingEnabledMode =
       !activationRepairReason &&
       existingModeStatusBlocksReplay({
         hasModeLabel: hasLabel(target, modeLabel),
@@ -1069,8 +1069,10 @@ function classifyCommand(command: LooseRecord): JsonValue {
           command.intent,
         ),
         forceReprocess,
-      })
-    ) {
+      });
+    if (existingEnabledMode && command.trusted_bot) {
+      // Label sweeps may stop at an already-armed plan, but a fresh maintainer
+      // resume must still coordinate an exact-head completed or active review.
       return {
         ...next,
         ...existingRepairLoopModeOutcome({
@@ -1079,6 +1081,7 @@ function classifyCommand(command: LooseRecord): JsonValue {
         }),
       };
     }
+    if (existingEnabledMode) next.reuse_prior_exact_head_review = true;
     const approvedProofOverride =
       command.intent === "automerge" && !activationRepairReason
         ? approvedMissingProofNeedsHuman(command, target)
@@ -3013,9 +3016,11 @@ function reviewDispatchDecisionForCommand(
       trustedAuthors: trustedBots,
       nowMs: Date.now(),
     });
-    const commandStartedAtMs = Date.parse(
-      String(command.comment_updated_at ?? command.comment_created_at ?? ""),
-    );
+    // An already-armed exact-head plan can have completed before the maintainer
+    // resume comment. Its head binding, rather than comment order, makes reuse safe.
+    const commandStartedAtMs = command.reuse_prior_exact_head_review
+      ? 0
+      : Date.parse(String(command.comment_updated_at ?? command.comment_created_at ?? ""));
     const completedReview = trustedExactHeadReviewCompletionSince({
       comments: comments as LooseRecord[],
       headSha: headAfter,

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -286,25 +286,25 @@ export function runAutomergeE2E({
       });
       addCanonicalNeedsHumanVerdict(statePath, repairedHead);
     } else if (scenario === "completed-verdict-resume") {
+      updateGitHubState(statePath, (state) => {
+        if (!state.pr.labels.includes("clawsweeper:automerge")) {
+          state.pr.labels.push("clawsweeper:automerge");
+        }
+      });
+      const verdictId = addExactHeadVerdict(statePath, repairedHead);
       const commandId = addMaintainerAutomergeCommand(statePath);
       runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "08-comment-router-command", {
         commentId: commandId,
       });
-      const verdictId = addExactHeadVerdict(statePath, repairedHead);
-      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "09-comment-router-command-replay", {
-        commentId: commandId,
-        forceReprocess: true,
-        attemptId: "completed-verdict-resume",
-      });
-      const replayState = JSON.parse(fs.readFileSync(statePath, "utf8"));
-      const verdictHandoff = replayState.dispatches.findLast(
+      const resumedState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      const verdictHandoff = resumedState.dispatches.findLast(
         (dispatch) =>
           dispatch.event_type === "clawsweeper_comment" &&
           dispatch.client_payload?.comment_id === String(verdictId),
       );
       assert.ok(
         verdictHandoff,
-        "reusing a completed review must requeue its exact verdict after an earlier handoff was lost",
+        "an armed-plan resume must requeue an exact verdict that completed before the command",
       );
       assert.equal(verdictHandoff.client_payload.force_reprocess, "true");
       runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "10-comment-router-verdict-handoff", {
@@ -628,7 +628,7 @@ function addCanonicalNeedsHumanVerdict(statePath, headSha) {
       "ClawSweeper needs maintainer judgment.",
       "",
       "**Next step before merge**",
-      "The PR is an active automerge candidate with no code finding, but missing real behavior proof needs maintainer handling.",
+      "- [P2] No repair lane is needed: the PR already contains the narrow fix, but missing real behavior proof needs maintainer handling.",
       "",
       `<!-- clawsweeper-verdict:needs-human item=${state.pr.number} sha=${headSha} reviewed_at=${now} -->`,
     ].join("\n"),

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2550,6 +2550,12 @@ test("parseTrustedAutomation treats trusted ClawSweeper needs-human as a pause",
 test("canonical landing needs-human text can be approved by active automerge opt-in", () => {
   assert.equal(
     isCanonicalLandingNeedsHumanText(
+      "- [P2] No repair lane is needed: the PR already contains the narrow fix and should proceed through normal merge gates.",
+    ),
+    true,
+  );
+  assert.equal(
+    isCanonicalLandingNeedsHumanText(
       "No repair lane is needed because the PR already contains the narrow fix; maintainer action is to land one canonical fix.",
     ),
     true,


### PR DESCRIPTION
## Summary

- let a fresh maintainer resume coordinate a completed trusted review when the exact-head automerge plan is already armed
- keep trusted label sweeps idempotent at the existing-plan boundary
- recognize production priority-prefixed `No repair lane is needed` conclusions without accepting actual P0-P3 findings
- update host and local-container E2E to reproduce both production states

## Root cause

An existing label + durable job + status response caused manual automerge commands to return before review coordination. Separately, canonical landing prose was rejected solely because the non-finding line carried a `[P2]` prefix.

## Validation

- failing-first host E2E: `completed-verdict-resume` failed before the fix and passed after
- failing-first unit: production-form `[P2] No repair lane is needed` failed before the fix and passed after
- host E2E: `completed-verdict-resume`, `approve-intent-persistence` (openclaw-shaped)
- local-container E2E: both scenarios using `clawsweeper-automerge-e2e-base:local`
- focused core/E2E contract tests (137/137)
- `pnpm run check`
- local autoreview (0 findings)
- staged gitleaks (0 leaks)