### PR TITLE
fix(spam-scanner): tolerate comments deleted mid-scan

### DIFF
--- a/src/repair/spam-scanner-core.ts
+++ b/src/repair/spam-scanner-core.ts
@@ -240,6 +240,26 @@ export function legitimateTechnicalContextSignals(comment: SpamScanComment) {
   return signals;
 }
 
+export function graphqlNodesToleratingNotFound(response: JsonValue): LooseRecord[] {
+  const root = (response ?? {}) as LooseRecord;
+  const errors = Array.isArray(root.errors) ? (root.errors as LooseRecord[]) : [];
+  const fatal = errors.filter(
+    (error) => String((error as LooseRecord | null)?.type ?? "").toUpperCase() !== "NOT_FOUND",
+  );
+  if (fatal.length > 0) {
+    const summary = fatal
+      .map((error) => compactText((error as LooseRecord | null)?.message ?? "unknown error", 200))
+      .join("; ");
+    throw new Error(`GraphQL nodes query failed: ${summary}`);
+  }
+  const nodes = (root.data as LooseRecord | undefined)?.nodes;
+  if (!Array.isArray(nodes)) {
+    throw new Error("GraphQL nodes query returned no data payload");
+  }
+  // Deleted comments come back as null nodes alongside NOT_FOUND errors; skip them.
+  return nodes.filter((node): node is LooseRecord => Boolean(node));
+}
+
 export function normalizeModelResults(value: JsonValue): SpamModelResult[] {
   const root = value as LooseRecord;
   const rows = Array.isArray(root?.results) ? root.results : [];

--- a/src/repair/spam-scanner.ts
+++ b/src/repair/spam-scanner.ts
@@ -3,11 +3,16 @@ import fs from "node:fs";
 import path from "node:path";
 import { parseArgs, repoRoot } from "./lib.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import { ghJsonWithRetry as ghJson, ghPagedLimitWithRetry as ghPagedLimit } from "./github-cli.js";
+import {
+  ghJsonWithRetry as ghJson,
+  ghPagedLimitWithRetry as ghPagedLimit,
+  ghStdoutFromError,
+} from "./github-cli.js";
 import { assertRepo, commaSet, positiveInteger } from "./comment-router-utils.js";
 import {
   buildSpamModelInput,
   commentVersionKey,
+  graphqlNodesToleratingNotFound,
   normalizeModelResults,
   normalizeSpamComment,
   prioritizeSpamScanComments,
@@ -190,22 +195,38 @@ function hydrateMinimization(comments: SpamScanComment[]) {
         ... on PullRequestReviewComment { id isMinimized minimizedReason }
       }
     }`;
-    const response = ghJson<LooseRecord>([
-      "api",
-      "graphql",
-      "-f",
-      `query=${query}`,
-      ...batch.flatMap((id) => ["-F", `ids[]=${id}`]),
-    ]);
+    const response = fetchMinimizationBatch(query, batch);
     const byId = new Map(
-      ((response.data as LooseRecord | undefined)?.nodes as LooseRecord[] | undefined)
-        ?.filter(Boolean)
-        .map((node) => [String(node.id ?? ""), node]) ?? [],
+      graphqlNodesToleratingNotFound(response).map((node) => [String(node.id ?? ""), node]),
     );
     for (const comment of comments) {
       const node = comment.node_id ? byId.get(comment.node_id) : null;
       if (!node) continue;
       if (node.isMinimized) comment.minimized_reason = String(node.minimizedReason ?? "minimized");
+    }
+  }
+}
+
+// gh exits non-zero on partial GraphQL errors (e.g. NOT_FOUND for comments deleted between
+// listing and this batch query) even though stdout still carries the full data payload.
+// Recover that payload; graphqlNodesToleratingNotFound decides whether the errors are fatal.
+function fetchMinimizationBatch(query: string, ids: string[]): LooseRecord {
+  const ghArgs = [
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    ...ids.flatMap((id) => ["-F", `ids[]=${id}`]),
+  ];
+  try {
+    return ghJson<LooseRecord>(ghArgs);
+  } catch (error) {
+    const stdout = ghStdoutFromError(error);
+    if (!stdout) throw error;
+    try {
+      return JSON.parse(stdout) as LooseRecord;
+    } catch {
+      throw error;
     }
   }
 }

--- a/test/repair/spam-scanner-core.test.ts
+++ b/test/repair/spam-scanner-core.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildSpamModelInput,
   commentVersionKey,
+  graphqlNodesToleratingNotFound,
   deterministicSpamSignals,
   isProtectedSpamAuthor,
   legitimateTechnicalContextSignals,
@@ -216,4 +217,49 @@ test("model results are normalized and clamped", () => {
       should_investigate: true,
     },
   ]);
+});
+
+test("graphql nodes tolerate comments deleted mid-scan (NOT_FOUND -> null nodes)", () => {
+  const nodes = graphqlNodesToleratingNotFound({
+    data: {
+      nodes: [{ id: "IC_alive", isMinimized: true, minimizedReason: "spam" }, null],
+    },
+    errors: [
+      {
+        type: "NOT_FOUND",
+        message: "Could not resolve to a node with the global id of 'IC_gone'",
+      },
+    ],
+  });
+  assert.deepEqual(nodes, [{ id: "IC_alive", isMinimized: true, minimizedReason: "spam" }]);
+});
+
+test("graphql nodes without errors pass through unchanged", () => {
+  const nodes = graphqlNodesToleratingNotFound({
+    data: { nodes: [{ id: "IC_1", isMinimized: false, minimizedReason: null }] },
+  });
+  assert.equal(nodes.length, 1);
+  assert.equal(nodes[0]?.id, "IC_1");
+});
+
+test("graphql nodes fail on non-NOT_FOUND error types", () => {
+  assert.throws(
+    () =>
+      graphqlNodesToleratingNotFound({
+        data: { nodes: [null] },
+        errors: [
+          { type: "NOT_FOUND", message: "Could not resolve to a node" },
+          { type: "FORBIDDEN", message: "Resource not accessible by integration" },
+        ],
+      }),
+    /GraphQL nodes query failed: Resource not accessible by integration/,
+  );
+});
+
+test("graphql nodes fail when the payload carries no data", () => {
+  assert.throws(
+    () => graphqlNodesToleratingNotFound({ errors: [{ type: "NOT_FOUND", message: "gone" }] }),
+    /no data payload/,
+  );
+  assert.throws(() => graphqlNodesToleratingNotFound(null), /no data payload/);
 });


### PR DESCRIPTION
The spam-scanner workflow failed 3x on 2026-07-19 (01:58Z, 03:26Z, 05:26Z). The scanner lists candidate comments, then hydrates minimization state via a GraphQL `nodes(ids:)` batch query. Comments deleted between listing and that batch yield partial GraphQL errors:

```
{"type":"NOT_FOUND","message":"Could not resolve to a node with the global id of 'IC_...'"}
```

`gh` exits non-zero on partial GraphQL errors even though stdout still carries the full data payload (deleted nodes come back as `null`), and the scanner treated that exit as fatal.

## Change

- `src/repair/spam-scanner.ts`: the minimization batch now recovers stdout from a failed `gh api graphql` call (via the existing `ghStdoutFromError`) and parses it; the original error is rethrown when stdout has no parseable JSON.
- `src/repair/spam-scanner-core.ts`: new pure helper `graphqlNodesToleratingNotFound` — drops `null` nodes (deleted comments are simply skipped), tolerates `NOT_FOUND` errors, and still fails on any non-`NOT_FOUND` error type or a payload without `data.nodes`.

## Validation

- New unit tests in `test/repair/spam-scanner-core.test.ts` cover: NOT_FOUND + null node tolerated, clean payload pass-through, non-NOT_FOUND error still fatal, missing data payload still fatal.
- Local smoke run against a fake `gh` that exits 1 on the graphql batch while printing the NOT_FOUND payload: scanner recovers, hydrates the surviving node (minimized-as-spam comment becomes a deterministic candidate), exits 0.
- Lint, format:check, build:all green. Full `pnpm run check` currently trips 8-10 timing-budget tests (git-repo-utils, target-validation, process-tree-containment, action-ledger-runtime) that fail identically on a pristine `origin/main` checkout on this machine — pre-existing/environmental, unrelated to this change.
