### PR TITLE
chore(recovery): log recovered item numbers in placeholder sweep

### DIFF
--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -253,6 +253,7 @@ export async function runReviewPlaceholderRecovery(
       const itemKind = candidate.pull_request ? "pull_request" : "issue";
       await enqueue(number, itemKind);
       enqueued += 1;
+      console.log(`review-placeholder recovery: enqueued #${number} (${itemKind})`);
     } catch (error) {
       errors += 1;
       console.warn(

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -74,9 +74,13 @@ test("review placeholder detection considers only the latest ClawSweeper bot com
   assert.equal(isOrphanedReviewPlaceholder(latest, now, 2), false);
 });
 
-test("review placeholder runner fails open and sends a signed exact-review decision", async () => {
+test("review placeholder runner fails open and sends a signed exact-review decision", async (t) => {
   const enqueueBodies: string[] = [];
   const commentChecks: number[] = [];
+  const logged: string[] = [];
+  t.mock.method(console, "log", (...parts: unknown[]) => {
+    logged.push(parts.join(" "));
+  });
   const { WEBHOOK: webhookSecret = "test-token-placeholder" } = {} as Record<string, string>;
   const mockFetch = async (
     input: string | URL | Request,
@@ -155,6 +159,7 @@ test("review placeholder runner fails open and sends a signed exact-review decis
   });
 
   assert.deepEqual(summary, { checked: 3, orphaned: 1, enqueued: 1, errors: 1 });
+  assert.ok(logged.includes("review-placeholder recovery: enqueued #103 (pull_request)"));
   assert.deepEqual(commentChecks, [101, 102, 103]);
   assert.equal(enqueueBodies.length, 1);
   assert.deepEqual(JSON.parse(enqueueBodies[0] ?? ""), {


### PR DESCRIPTION
Adds a per-item log line when the placeholder-recovery sweep enqueues a recovery, so operators can identify which issues/PRs were recovered without digging.

Motivation: the 2026-07-18 04:44Z sweep enqueued 4 recoveries and the logs only showed the aggregate summary line.

Test: captures console.log in the runner test and asserts the per-item line for the enqueued item.
