### PR TITLE
fix(repair): handle production-sized ledger trees

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -54,6 +54,7 @@ export type GitRunOptions = {
   allowFailure?: boolean;
   displayArgs?: readonly string[];
   input?: string;
+  maxBuffer?: number;
   quiet?: boolean;
 };
 
@@ -70,6 +71,7 @@ const GENERATED_PUBLISH_PATHS = [
 const GIT_PATHSPEC_BATCH_SIZE = 256;
 const GIT_OBJECT_BATCH_SIZE = 512;
 const GIT_OBJECT_BATCH_MAX_BUFFER = 64 * 1024 * 1024;
+const GIT_TREE_LIST_MAX_BUFFER = 64 * 1024 * 1024;
 const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
@@ -125,7 +127,7 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     env: process.env,
     encoding: "utf8",
     input: options.input,
-    maxBuffer: 16 * 1024 * 1024,
+    maxBuffer: options.maxBuffer ?? 16 * 1024 * 1024,
   });
   if (!options.quiet && child.stdout) process.stdout.write(child.stdout);
   if (!options.quiet && child.stderr) process.stderr.write(child.stderr);
@@ -1647,7 +1649,10 @@ function writePatchedGitTree(baseTree: string | null, patch: GitTreePatch): stri
 }
 
 function readGitTreeEntries(args: readonly string[]): GitTreeEntry[] {
-  return runGit(args, { quiet: true })
+  // Immutable ledger directories are intentionally flat and can exceed the
+  // general Git command cap. A lost push must still be able to rebuild their
+  // containing tree without mistaking a truncated listing for a Git failure.
+  return runGit(args, { maxBuffer: GIT_TREE_LIST_MAX_BUFFER, quiet: true })
     .split("\0")
     .filter(Boolean)
     .map((record) => {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1646,6 +1646,85 @@ test("publishMainCommit converges after production-sized immutable ledger races"
   }
 });
 
+test("publishMainCommit rebuilds a production-sized flat immutable ledger tree", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-large-tree-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const localPath =
+    "ledger/v1/import-bindings/events/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.json";
+  run("git", ["init", "--bare", origin], root);
+  configureUser(origin);
+
+  const blob = runWithInput(
+    "git",
+    ["--git-dir", origin, "hash-object", "-w", "--stdin"],
+    root,
+    "{}\n",
+  ).trim();
+  const flatTree = runWithInput(
+    "git",
+    ["--git-dir", origin, "mktree", "-z"],
+    root,
+    Array.from(
+      { length: 150_000 },
+      (_, index) => `100644 blob ${blob}\t${index.toString(16).padStart(64, "0")}.json\0`,
+    ).join(""),
+  ).trim();
+  const importBindingsTree = singleEntryTree(origin, "events", flatTree, root);
+  const v1Tree = singleEntryTree(origin, "import-bindings", importBindingsTree, root);
+  const ledgerTree = singleEntryTree(origin, "v1", v1Tree, root);
+  const remoteBlob = runWithInput(
+    "git",
+    ["--git-dir", origin, "hash-object", "-w", "--stdin"],
+    root,
+    "base\n",
+  ).trim();
+  const rootTree = runWithInput(
+    "git",
+    ["--git-dir", origin, "mktree", "-z"],
+    root,
+    `040000 tree ${ledgerTree}\tledger\0` + `100644 blob ${remoteBlob}\tremote.txt\0`,
+  ).trim();
+  const initialCommit = runWithInput(
+    "git",
+    ["--git-dir", origin, "commit-tree", rootTree, "-m", "initial large ledger"],
+    root,
+    "",
+  ).trim();
+  run("git", ["--git-dir", origin, "update-ref", "refs/heads/main", initialCommit], root);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+
+  for (const checkout of [work, other]) {
+    run("git", ["clone", "--no-checkout", origin, checkout], root);
+    configureUser(checkout);
+    run("git", ["sparse-checkout", "init", "--no-cone"], checkout);
+    run("git", ["sparse-checkout", "set", "--no-cone", "remote.txt", localPath], checkout);
+    run("git", ["checkout", "-B", "main", "origin/main"], checkout);
+  }
+  write(path.join(other, "remote.txt"), "concurrent\n");
+  run("git", ["add", "remote.txt"], other);
+  run("git", ["commit", "-m", "concurrent state update"], other);
+  installFirstPushRaceHook(work, other);
+  write(path.join(work, localPath), '{"local":true}\n');
+
+  const result = withCwd(work, () =>
+    publishMainCommit({
+      message: "chore: append command action ledger",
+      paths: [localPath],
+      maxAttempts: 1,
+      pushAttempts: 1,
+    }),
+  );
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${localPath}`], root),
+    '{"local":true}\n',
+  );
+  assert.equal(run("git", ["--git-dir", origin, "show", "main:remote.txt"], root), "concurrent\n");
+});
+
 test("publishMainCommit publishes generated paths to state branch when state root is configured", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
@@ -2432,6 +2511,25 @@ function run(command, args, cwd) {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
+}
+
+function runWithInput(command, args, cwd, input) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    input,
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+function singleEntryTree(gitDir, name, oid, cwd) {
+  return runWithInput(
+    "git",
+    ["--git-dir", gitDir, "mktree", "-z"],
+    cwd,
+    `040000 tree ${oid}\t${name}\0`,
+  ).trim();
 }
 
 function configureUser(cwd) {


### PR DESCRIPTION
## Summary

- allow bounded per-command Git output buffers and use 64 MiB for immutable tree listings
- keep the general Git command cap at 16 MiB
- add a deterministic 150,000-entry flat-ledger push-race regression

## Root cause

After a normal concurrent state push rejection, immutable ledger rebuild listed the production flat events tree through the general 16 MiB spawn buffer. The listing exceeded that cap, `git ls-tree` terminated with ENOBUFS, and command publication failed after routing had already succeeded.

Production evidence:
- https://github.com/openclaw/clawsweeper/actions/runs/29678621793
- https://github.com/openclaw/clawsweeper/actions/runs/29678623407

## Validation

- failing-first: the production-sized local race fails at 16 MiB with `spawnSync git ENOBUFS`
- fixed focused regression passes at 64 MiB
- full `test/repair/git-publish.test.ts` passes
- `pnpm run check` passes
- local autoreview: 0 findings
- staged gitleaks: 0 leaks

No contributor branches, OpenClaw CHANGELOG, live retries, or safety gates were changed.