### PR TITLE
fix(repair): outlast immutable ledger write storms

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -411,8 +411,10 @@ function pushImmutableActionLedgerCommit(options: {
   pushAttempts: number;
 }): PublishResult {
   // Keep both retry knobs additive. Their former nesting multiplied every
-  // state race into another complete rebase loop.
-  const pushBudget = Math.max(options.maxAttempts + options.pushAttempts + 1, 16);
+  // state race into another complete rebase loop. The floor must also outlast
+  // sustained state writers: production exhausted 16 races while the same
+  // immutable rebuild remained safe to retry.
+  const pushBudget = Math.max(options.maxAttempts + options.pushAttempts + 1, 64);
   const previousCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
   const protectedWorktreePaths = captureDirtyWorktreePaths();
   let candidateCommit = options.sourceCommit;

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1564,7 +1564,7 @@ test("publishMainCommit converges after production-sized immutable ledger races"
   write(path.join(work, "unrelated/0000.txt"), "local scratch remains\n");
   write(path.join(work, "scratch/dirty.txt"), "nested local scratch remains\n");
   write(path.join(work, "ignored/secret.txt"), "ignored local scratch remains\n");
-  installPushRaceHook(work, other, 12);
+  installPushRaceHook(work, other, 20);
 
   const lines = [];
   let result;
@@ -1584,10 +1584,10 @@ test("publishMainCommit converges after production-sized immutable ledger races"
   assert.ok(metrics, "sustained ledger race publish emits metrics");
   const processCount = Number(/processes=(\d+)/.exec(metrics)?.[1]);
   assert.ok(
-    Number.isInteger(processCount) && processCount <= 180,
-    `sustained ledger races used ${processCount} git subprocesses; expected at most 180`,
+    Number.isInteger(processCount) && processCount <= 280,
+    `sustained ledger races used ${processCount} git subprocesses; expected at most 280`,
   );
-  assert.match(metrics, /actions=.*push:13(?:,|$)/, "the publish survives twelve lost pushes");
+  assert.match(metrics, /actions=.*push:21(?:,|$)/, "the publish survives twenty lost pushes");
   assert.doesNotMatch(metrics, /actions=.*rebase:/, "immutable ledger retries never nest rebases");
   assert.doesNotMatch(
     metrics,
@@ -1616,26 +1616,26 @@ test("publishMainCommit converges after production-sized immutable ledger races"
   );
   assert.equal(
     fs.readFileSync(path.join(work, "remote.txt"), "utf8"),
-    Array.from({ length: 12 }, (_, index) => `race ${index + 1}\n`).join(""),
+    Array.from({ length: 20 }, (_, index) => `race ${index + 1}\n`).join(""),
     "clean worktree paths follow every fetched remote parent",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
-    Array.from({ length: 12 }, (_, index) => `race ${index + 1}\n`).join(""),
+    Array.from({ length: 20 }, (_, index) => `race ${index + 1}\n`).join(""),
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:unrelated/0000.txt"], root),
-    "remote scratch 12\n",
+    "remote scratch 20\n",
     "the rebuilt commit keeps the remote version of a locally dirty path",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:scratch"], root),
-    "remote parent 12\n",
+    "remote parent 20\n",
     "the rebuilt commit keeps a remote file that replaced a dirty local directory",
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:ignored"], root),
-    "remote ignored parent 12\n",
+    "remote ignored parent 20\n",
     "the rebuilt commit keeps a remote file that replaced an ignored local directory",
   );
   for (const ledgerPath of ledgerPaths) {


### PR DESCRIPTION
## Summary

- raise the immutable action-ledger push floor from 16 to 64
- extend the deterministic production-sized race test from 12 to 20 lost pushes
- preserve exact immutable rebuild, CAS, and worktree safety behavior

## Production evidence

The post-#697 recovery run for openclaw/openclaw#108974 exhausted all 16 immutable publish attempts while the state branch advanced on every retry: https://github.com/openclaw/clawsweeper/actions/runs/29680199403

The same code path succeeded for openclaw/openclaw#104054 when it found a window inside the previous budget: https://github.com/openclaw/clawsweeper/actions/runs/29680198085

## Verification

- failing-first: 20 deterministic races fail on the old 16-attempt floor with `Failed to publish commit after 16 push attempts`
- focused race test passes after the change (push 21 succeeds)
- full git-publish test file: 34/34 pass
- `pnpm run check`
- local autoreview: 0 findings
- staged gitleaks: 0 leaks