### PR TITLE
fix(repair): refresh stale automerge verdicts

### DIFF
--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -1995,7 +1995,12 @@ export function trustedExactHeadReviewCompletionSince({
   headSha: string;
   trustedAuthors?: ReadonlySet<string>;
   sinceMs: number;
-}): { commentId: number; reviewedAt: string | null; publishedAt: string | null } | null {
+}): {
+  commentId: number;
+  reviewedAt: string | null;
+  publishedAt: string | null;
+  sourceRevision: string | null;
+} | null {
   const normalizedHead = String(headSha ?? "")
     .trim()
     .toLowerCase();
@@ -2006,6 +2011,7 @@ export function trustedExactHeadReviewCompletionSince({
     observedAtMs: number;
     reviewedAt: string | null;
     publishedAt: string | null;
+    sourceRevision: string | null;
   } | null = null;
   for (const comment of comments) {
     const completed = parseTrustedAutomation(comment, { trustedAuthors });
@@ -2030,6 +2036,7 @@ export function trustedExactHeadReviewCompletionSince({
           .toLowerCase() === normalizedHead,
     );
     const reviewedAt = String(reviewMarker?.attrs?.reviewed_at ?? "").trim() || null;
+    const sourceRevision = String(reviewMarker?.attrs?.source_revision ?? "").trim() || null;
     const publishedAt = String(comment?.updated_at ?? comment?.created_at ?? "").trim() || null;
     const observedAtMs = Math.max(
       Number.isFinite(Date.parse(reviewedAt ?? "")) ? Date.parse(reviewedAt ?? "") : 0,
@@ -2037,7 +2044,7 @@ export function trustedExactHeadReviewCompletionSince({
     );
     if (observedAtMs < sinceMs || observedAtMs <= 0) continue;
     if (!newest || observedAtMs > newest.observedAtMs) {
-      newest = { commentId, observedAtMs, reviewedAt, publishedAt };
+      newest = { commentId, observedAtMs, reviewedAt, publishedAt, sourceRevision };
     }
   }
   return (
@@ -2045,6 +2052,7 @@ export function trustedExactHeadReviewCompletionSince({
       commentId: newest.commentId,
       reviewedAt: newest.reviewedAt,
       publishedAt: newest.publishedAt,
+      sourceRevision: newest.sourceRevision,
     }
   );
 }

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -3000,17 +3000,23 @@ function reviewDispatchDecisionForCommand(
         activeLeaseExpiresAt: null,
         completedReviewAt: null,
         completedReviewCommentId: null,
+        completedReviewSourceRevision: null,
+        sourceRevisionBefore: issueSourceRevisionSha256(before, []),
+        sourceRevisionAfter: issueSourceRevisionSha256(before, []),
       });
     }
-    const comments = ghPaged<JsonValue>(
+    const commentsBefore = ghPaged<JsonValue>(
       `repos/${targetRepo}/issues/${number}/comments?per_page=100`,
     );
     const after = fetchPullRequestView(number);
+    const commentsAfter = ghPaged<JsonValue>(
+      `repos/${targetRepo}/issues/${number}/comments?per_page=100`,
+    );
     const headAfter = String(after.headRefOid ?? "")
       .trim()
       .toLowerCase();
     const activeReviewLease = freshExactHeadReviewStartLease({
-      comments: comments as LooseRecord[],
+      comments: commentsAfter as LooseRecord[],
       itemNumber: number,
       headSha: headAfter,
       trustedAuthors: trustedBots,
@@ -3022,7 +3028,7 @@ function reviewDispatchDecisionForCommand(
       ? 0
       : Date.parse(String(command.comment_updated_at ?? command.comment_created_at ?? ""));
     const completedReview = trustedExactHeadReviewCompletionSince({
-      comments: comments as LooseRecord[],
+      comments: commentsAfter as LooseRecord[],
       headSha: headAfter,
       trustedAuthors: trustedBots,
       sinceMs: commandStartedAtMs,
@@ -3038,6 +3044,9 @@ function reviewDispatchDecisionForCommand(
         completedReview?.reviewedAt ??
         (completedReview ? "recently" : null),
       completedReviewCommentId: completedReview?.commentId ?? null,
+      completedReviewSourceRevision: completedReview?.sourceRevision ?? null,
+      sourceRevisionBefore: issueSourceRevisionSha256(before, commentsBefore),
+      sourceRevisionAfter: issueSourceRevisionSha256(after, commentsAfter),
     });
   } catch (error) {
     return {

--- a/src/repair/review-dispatch-coordination.ts
+++ b/src/repair/review-dispatch-coordination.ts
@@ -13,6 +13,9 @@ export type ReviewDispatchCoordinationInput = {
   activeLeaseExpiresAt: string | null;
   completedReviewAt: string | null;
   completedReviewCommentId: number | null;
+  completedReviewSourceRevision: string | null;
+  sourceRevisionBefore: string;
+  sourceRevisionAfter: string;
 };
 
 export function decideReviewDispatchCoordination({
@@ -23,6 +26,9 @@ export function decideReviewDispatchCoordination({
   activeLeaseExpiresAt,
   completedReviewAt,
   completedReviewCommentId,
+  completedReviewSourceRevision,
+  sourceRevisionBefore,
+  sourceRevisionAfter,
 }: ReviewDispatchCoordinationInput): ReviewDispatchCoordinationDecision {
   if (!isOpen(stateBefore) || !isOpen(stateAfter)) {
     return { action: "stop", reason: "target is no longer an open PR" };
@@ -31,6 +37,17 @@ export function decideReviewDispatchCoordination({
     return {
       action: "retry",
       reason: "PR head changed during the dispatch-time review check; next router pass will retry",
+    };
+  }
+  if (
+    !sourceRevisionBefore ||
+    !sourceRevisionAfter ||
+    sourceRevisionBefore !== sourceRevisionAfter
+  ) {
+    return {
+      action: "retry",
+      reason:
+        "PR source changed during the dispatch-time review check; next router pass will retry",
     };
   }
   // At-least-once command delivery makes an active exact-head lease a normal
@@ -42,6 +59,17 @@ export function decideReviewDispatchCoordination({
     };
   }
   if (completedReviewAt && completedReviewCommentId) {
+    const reviewedRevision = String(completedReviewSourceRevision ?? "")
+      .trim()
+      .toLowerCase();
+    // Only a truly missing revision belongs to the legacy compatibility path.
+    // Any present but unverifiable marker needs a new review.
+    if (
+      reviewedRevision &&
+      (!/^[0-9a-f]{64}$/.test(reviewedRevision) || reviewedRevision !== sourceRevisionAfter)
+    ) {
+      return { action: "dispatch" };
+    }
     return {
       action: "reuse_completed_review",
       commentId: completedReviewCommentId,

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +16,7 @@ const helperRoot = path.dirname(fileURLToPath(import.meta.url));
 export const AUTOMERGE_E2E_SCENARIOS = [
   "approve-intent-persistence",
   "completed-verdict-resume",
+  "completed-verdict-source-drift",
   "dependency-setup-mutation",
   "happy-path",
   "pending-checks",
@@ -257,6 +259,7 @@ export function runAutomergeE2E({
     if (
       scenario === "approve-intent-persistence" ||
       scenario === "completed-verdict-resume" ||
+      scenario === "completed-verdict-source-drift" ||
       scenario === "resume-intent-persistence"
     ) {
       const activeJob = path.join(
@@ -311,6 +314,41 @@ export function runAutomergeE2E({
         commentId: verdictId,
         forceReprocess: true,
         attemptId: String(verdictHandoff.client_payload.attempt_id),
+      });
+      completedVerdictAlreadyRouted = true;
+    } else if (scenario === "completed-verdict-source-drift") {
+      const beforeCommand = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      const staleVerdictId = addExactHeadVerdict(
+        statePath,
+        repairedHead,
+        fixtureSourceRevision(beforeCommand),
+      );
+      const commandId = addMaintainerAutomergeCommand(statePath);
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "08-comment-router-source-drift", {
+        commentId: commandId,
+      });
+      const refreshedState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(
+        refreshedState.dispatches.some(
+          (dispatch) =>
+            dispatch.event_type === "clawsweeper_comment" &&
+            dispatch.client_payload?.comment_id === String(staleVerdictId),
+        ),
+        false,
+        "a source-stale exact-head verdict must not be replayed",
+      );
+      assert.equal(
+        refreshedState.dispatches.some((dispatch) => dispatch.event_type === "clawsweeper_item"),
+        true,
+        "source drift must queue a fresh exact-head review",
+      );
+      const freshVerdictId = addExactHeadVerdict(
+        statePath,
+        repairedHead,
+        fixtureSourceRevision(refreshedState),
+      );
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "10-comment-router-fresh-verdict", {
+        commentId: freshVerdictId,
       });
       completedVerdictAlreadyRouted = true;
     } else if (scenario === "resume-intent-persistence") {
@@ -579,12 +617,12 @@ function createCandidateRuntime(root, candidateRoot) {
   return runtime;
 }
 
-function addExactHeadVerdict(statePath, headSha) {
+function addExactHeadVerdict(statePath, headSha, sourceRevision = null) {
   const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
   const now = new Date().toISOString();
   state.comments.push({
     id: state.nextCommentId++,
-    body: `ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass item=${state.pr.number} sha=${headSha} reviewed_at=${now} -->`,
+    body: `ClawSweeper review passed.\n<!-- clawsweeper-verdict:pass item=${state.pr.number} sha=${headSha}${sourceRevision ? ` source_revision=${sourceRevision}` : ""} reviewed_at=${now} -->`,
     issue_url: `https://api.github.com/repos/${state.repo}/issues/${state.pr.number}`,
     html_url: `https://github.com/${state.repo}/pull/${state.pr.number}#issuecomment-${state.nextCommentId - 1}`,
     user: { id: 1, login: "clawsweeper[bot]" },
@@ -594,6 +632,41 @@ function addExactHeadVerdict(statePath, headSha) {
   });
   writeJson(statePath, state);
   return state.nextCommentId - 1;
+}
+
+function fixtureSourceRevision(state) {
+  const snapshot = {
+    title: state.pr.title,
+    body: state.pr.body,
+    labels: state.pr.labels
+      .map((label) => String(label).trim().toLowerCase())
+      .filter((label) => !label.startsWith("clawsweeper:"))
+      .sort(),
+    comments: state.comments
+      .filter(
+        (comment) =>
+          ![
+            "clawsweeper",
+            "clawsweeper[bot]",
+            "openclaw-clawsweeper",
+            "openclaw-clawsweeper[bot]",
+          ].includes(
+            String(comment.user?.login ?? "")
+              .trim()
+              .toLowerCase(),
+          ),
+      )
+      .map((comment) => ({
+        id: String(comment.id ?? ""),
+        author: String(comment.user?.login ?? ""),
+        body: String(comment.body ?? ""),
+        updated_at: String(comment.updated_at ?? comment.created_at ?? ""),
+      }))
+      .sort((left, right) =>
+        `${left.id}:${left.updated_at}`.localeCompare(`${right.id}:${right.updated_at}`),
+      ),
+  };
+  return crypto.createHash("sha256").update(JSON.stringify(snapshot)).digest("hex");
 }
 
 function addMaintainerAutomergeCommand(statePath) {

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -1779,12 +1779,13 @@ test("review start leases reject malformed, future, and overlong markers", () =>
 
 test("same-head completion freshness uses durable publication time", () => {
   const headSha = "0123456789abcdef0123456789abcdef01234567";
+  const sourceRevision = "1".repeat(64);
   const comment = {
     id: 1234,
     user: { login: "clawsweeper[bot]" },
     created_at: "2026-07-09T21:00:00.000Z",
     updated_at: "2026-07-09T21:05:30.000Z",
-    body: `<!-- clawsweeper-verdict:pass item=103109 sha=${headSha} reviewed_at=2026-07-09T21:04:30.000Z -->`,
+    body: `<!-- clawsweeper-verdict:pass item=103109 sha=${headSha} source_revision=${sourceRevision} reviewed_at=2026-07-09T21:04:30.000Z -->`,
   };
 
   assert.deepEqual(
@@ -1798,6 +1799,7 @@ test("same-head completion freshness uses durable publication time", () => {
       commentId: 1234,
       reviewedAt: "2026-07-09T21:04:30.000Z",
       publishedAt: "2026-07-09T21:05:30.000Z",
+      sourceRevision,
     },
   );
   assert.equal(
@@ -1913,7 +1915,15 @@ test("review dispatch coordination guards label sweeps and maintainer mode comma
     /automation_source !== "repair_loop_label_sweep"[\s\S]*?return \{ action: "dispatch" \}/,
   );
   assert.equal(dispatchGuard.match(/fetchPullRequestView\(number\)/g)?.length, 2);
-  assert.match(dispatchGuard, /issues\/\$\{number\}\/comments\?per_page=100/);
+  assert.equal(dispatchGuard.match(/issues\/\$\{number\}\/comments\?per_page=100/g)?.length, 2);
+  assert.match(
+    dispatchGuard,
+    /sourceRevisionBefore: issueSourceRevisionSha256\(before, commentsBefore\)/,
+  );
+  assert.match(
+    dispatchGuard,
+    /sourceRevisionAfter: issueSourceRevisionSha256\(after, commentsAfter\)/,
+  );
   assert.match(dispatchGuard, /nowMs:\s*Date\.now\(\)/);
   assert.match(dispatchGuard, /trustedExactHeadReviewCompletionSince\(\{/);
   assert.match(dispatchGuard, /sinceMs:\s*commandStartedAtMs/);

--- a/test/repair/review-dispatch-coordination.test.ts
+++ b/test/repair/review-dispatch-coordination.test.ts
@@ -14,6 +14,9 @@ function decision(overrides: Partial<Parameters<typeof decideReviewDispatchCoord
     activeLeaseExpiresAt: null,
     completedReviewAt: null,
     completedReviewCommentId: null,
+    completedReviewSourceRevision: null,
+    sourceRevisionBefore: "1".repeat(64),
+    sourceRevisionAfter: "1".repeat(64),
     ...overrides,
   });
 }
@@ -43,10 +46,37 @@ test("reuses a same-head review completed since the command", () => {
   const result = decision({
     completedReviewAt: "2026-07-17T14:10:00.000Z",
     completedReviewCommentId: 1234,
+    completedReviewSourceRevision: "1".repeat(64),
   });
   assert.equal(result.action, "reuse_completed_review");
   assert.equal(result.commentId, 1234);
   assert.match(result.reason, /result will be reused/);
+});
+
+test("dispatches a fresh review when a same-head verdict has stale source", () => {
+  assert.deepEqual(
+    decision({
+      completedReviewAt: "2026-07-17T14:10:00.000Z",
+      completedReviewCommentId: 1234,
+      completedReviewSourceRevision: "2".repeat(64),
+    }),
+    { action: "dispatch" },
+  );
+});
+
+test("dispatches a fresh review when a verdict source is unknown", () => {
+  assert.deepEqual(
+    decision({
+      completedReviewAt: "2026-07-17T14:10:00.000Z",
+      completedReviewCommentId: 1234,
+      completedReviewSourceRevision: "unknown",
+    }),
+    { action: "dispatch" },
+  );
+});
+
+test("retries when source changes during review coordination", () => {
+  assert.equal(decision({ sourceRevisionAfter: "2".repeat(64) }).action, "retry");
 });
 
 test("an active lease wins over a completed marker", () => {


### PR DESCRIPTION
## Summary

- bind completed-review reuse to the verdict source revision as well as the exact PR head
- double-read source comments so coordination detects comment drift during its read window
- dispatch a fresh exact-head review for stale, malformed, or unknown source revisions while preserving truly legacy markers
- add a deterministic real Git/fake GitHub/router E2E that reproduces the production source-drift skip and then reaches merge with a fresh verdict

## Evidence

- failing-first: the E2E against pre-fix origin/main replays the source-stale verdict and fails `a source-stale exact-head verdict must not be replayed`
- focused unit tests: 130 passed
- `pnpm run check`
- local autoreview: 0 findings
- staged gitleaks: 0 leaks
- local-container E2E: tiny and openclaw-shaped fixtures both passed and merged

## Production context

The completed-verdict replay for https://github.com/openclaw/openclaw/pull/108974 was skipped because its trusted verdict source revision no longer matched the current source revision, even though the exact head was unchanged. This keeps the execution-side source guard intact and prevents coordination from selecting an unusable verdict.