### PR TITLE
fix(repair): read checkout v7 state credentials

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -488,9 +488,13 @@ function immutableLedgerStateRepository(): string | null {
 }
 
 function stateRepositoryToken(): string {
-  const config = runGit(["config", "--local", "--get-regexp", "^http\\..*\\.extraheader$"], {
-    quiet: true,
-  });
+  // actions/checkout v7 keeps credentials in a separate config selected by a
+  // repository-local includeIf. Follow those includes explicitly while
+  // retaining local scope so unrelated user or system credentials stay out.
+  const config = runGit(
+    ["config", "--includes", "--local", "--get-regexp", "^http\\..*\\.extraheader$"],
+    { quiet: true },
+  );
   for (const line of config.split("\n")) {
     const header = line.slice(line.indexOf(" ") + 1);
     const match = /^AUTHORIZATION:\s*basic\s+(\S+)$/i.exec(header);

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -2888,7 +2888,17 @@ function installCheckoutHeader(work) {
     "utf8",
   ).toString("base64");
   const header = [`${"AUTH"}ORIZATION:`, `${"bas"}ic`, encoded].join(" ");
-  run("git", ["config", "--local", "http.https://github.com/.extraheader", header], work);
+  const credentialsConfig = path.join(path.dirname(work), "checkout-credentials.config");
+  run(
+    "git",
+    ["config", "--file", credentialsConfig, "http.https://github.com/.extraheader", header],
+    work,
+  );
+  run(
+    "git",
+    ["config", "--local", `includeIf.gitdir:${path.join(work, ".git")}.path`, credentialsConfig],
+    work,
+  );
 }
 
 function installCheckpointFailureHook(work, other, branch) {


### PR DESCRIPTION
## Summary

- follow actions/checkout v7 repository-local credential includes when reading the state token
- retain local config scope so unrelated user or system credentials remain excluded
- reproduce the checkout v7 includeIf layout in the immutable server-merge E2E

## Root cause

The immutable ledger server-merge fallback queried only entries stored directly in `.git/config`. actions/checkout v7 stores the HTTP authorization header in a separate credentials config and selects it with a repository-local `includeIf.gitdir`, so the production fallback exited before calling the GitHub merge API.

## Verification

- failing-first focused E2E reproduced `git config ... exited 1` on current main
- focused immutable server-merge E2E passes after the fix
- full `test/repair/git-publish.test.ts` passes
- `pnpm run check`
- local autoreview: 0 findings
- `gitleaks protect --staged --redact --no-banner`: 0 leaks