### PR TITLE
fix(repair): rebase protected behind automerge heads

### DIFF
--- a/src/repair/comment-router-core.test.ts
+++ b/src/repair/comment-router-core.test.ts
@@ -83,6 +83,15 @@ test("automerge merge failure repair reason detects GitHub merge conflict errors
   );
 });
 
+test("automerge merge failure repair reason detects protected behind heads", () => {
+  assert.match(
+    automergeMergeFailureRepairReason(
+      "merge command failed: pull request is not mergeable: the head branch is not up to date with the base branch",
+    ) ?? "",
+    /cloud rebase repair/,
+  );
+});
+
 test("automerge merge failure repair reason ignores unrelated merge failures", () => {
   assert.equal(
     automergeMergeFailureRepairReason("merge command failed: GraphQL: Head sha mismatch"),

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -667,6 +667,13 @@ export function automergeMergeFailureRepairReason(reason: JsonValue): string | n
     .trim()
     .toLowerCase();
   if (!text) return null;
+  // A BEHIND head is mergeable in repositories that allow GitHub to create a
+  // merge commit, but protected linear-history targets reject it at the final
+  // merge command. Hand that concrete policy failure to the existing rebase
+  // repair lane instead of leaving an armed PR permanently blocked.
+  if (text.includes("head branch is not up to date with the base branch")) {
+    return "PR head is behind base and needs a cloud rebase repair before automerge";
+  }
   if (text.includes("mergepullrequest") && text.includes("merge conflict")) {
     return "PR has merge conflicts and needs a cloud rebase repair before automerge";
   }

--- a/test/e2e/automerge/fake-gh.mjs
+++ b/test/e2e/automerge/fake-gh.mjs
@@ -126,6 +126,23 @@ if (args[0] === "label" && args[1] === "create") {
   respondText("");
 }
 
+if (args[0] === "workflow" && args[1] === "run") {
+  assertMutationToken();
+  const workflow = args[2];
+  const repo = optionValue("--repo");
+  const inputs = Object.fromEntries(optionValues("-f").map((entry) => entry.split(/=(.*)/s, 2)));
+  if (workflow !== "repair-cluster-worker.yml" || repo !== "openclaw/clawsweeper") {
+    fail(`unsupported workflow dispatch: ${args.join(" ")}`);
+  }
+  const expectedJob = `jobs/openclaw/inbox/automerge-openclaw-openclaw-${state.pr.number}.md`;
+  if (inputs.job !== expectedJob || inputs.mode !== "autonomous") {
+    fail(`invalid repair workflow dispatch: ${args.join(" ")}`);
+  }
+  state.workflowDispatches.push({ workflow, repo, inputs });
+  saveState();
+  respondText("");
+}
+
 if (args[0] === "api") handleApi();
 
 fail(`unexpected gh args: ${args.join(" ")}`);
@@ -420,6 +437,14 @@ function optionValue(name) {
   if (direct >= 0) return args[direct + 1] ?? "";
   const assignment = args.find((arg) => arg.startsWith(`${name}=`));
   return assignment ? assignment.slice(name.length + 1) : "";
+}
+
+function optionValues(name) {
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name) values.push(args[index + 1] ?? "");
+  }
+  return values;
 }
 
 function apiEndpoint() {

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -279,8 +279,30 @@ export function runAutomergeE2E({
       runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "08-comment-router-approve", {
         commentId: approvalId,
       });
+      const behindReport = readRouterReport(runtimeRoot);
+      const behindCommand = behindReport.commands.find(
+        (command) => command.intent === "maintainer_approve_automerge",
+      );
+      const behindMerge = behindCommand?.actions.find((action) => action.action === "merge");
+      assert.equal(behindMerge?.status, "repair_needed");
+      assert.match(String(behindMerge?.repair_reason ?? ""), /cloud rebase repair/);
       assert.equal(
-        JSON.parse(fs.readFileSync(statePath, "utf8")).pr.mergedAt,
+        behindCommand?.actions.find((action) => action.action === "dispatch_repair")?.status,
+        "executed",
+      );
+      const behindState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      const repairDispatch = behindState.workflowDispatches.at(-1);
+      assert.equal(
+        repairDispatch?.inputs.job,
+        "jobs/openclaw/inbox/automerge-openclaw-openclaw-42.md",
+        "a protected behind rejection must dispatch the existing cloud rebase repair lane",
+      );
+      assert.equal(repairDispatch?.inputs.mode, "autonomous");
+      assert.equal(repairDispatch?.inputs.runner, "blacksmith-4vcpu-ubuntu-2404");
+      assert.equal(repairDispatch?.inputs.execution_runner, "blacksmith-16vcpu-ubuntu-2404");
+      assert.equal(repairDispatch?.inputs.model, "e2e-codex");
+      assert.equal(
+        behindState.pr.mergedAt,
         null,
         "a behind branch must remain open after the first exact-head approval",
       );
@@ -1060,6 +1082,7 @@ function initialGitHubState(fixture, targetPrNumber = 42) {
     nextCommentId: 100,
     comments: [],
     dispatches: [],
+    workflowDispatches: [],
     calls: [],
     pr: {
       number: targetPrNumber,


### PR DESCRIPTION
## Summary

- recognize GitHub's protected-branch rejection for behind PR heads
- route that concrete final-merge failure into the existing cloud rebase repair lane
- keep unrelated merge failures blocked and preserve all exact-head gates

## Production evidence

Both https://github.com/openclaw/openclaw/pull/104054 and https://github.com/openclaw/openclaw/pull/108974 reached an exact-head passing review, then the final squash merge failed with `the head branch is not up to date with the base branch`. The router currently recognizes only merge-conflict text as repairable, so these armed PRs were left permanently `merge-ready` without a repair dispatch.

## Verification

- failing-first unit reproduces the exact production error text
- focused comment-router core tests: 9/9
- `pnpm run check`
- local autoreview: 0 findings
- staged gitleaks: 0 leaks