### PR TITLE
fix(workflow): make direct PR webhook intake canonical

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -228,7 +228,10 @@ jobs:
 
   legacy-event-queue-intake:
     name: Queue legacy exact-review event
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep' && github.event.client_payload.queue_lease_id == '' && !(github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
+    # Pull-request events arrive through the direct GitHub App webhook. The
+    # legacy pull_request_target dispatch is a compatibility duplicate and must
+    # not create a second durable exact-review intent.
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep' && github.event.client_payload.queue_lease_id == '' && (github.event.client_payload.source_event != 'pull_request_target' || github.event.client_payload.item_kind != 'pull_request') && !(github.event.client_payload.target_repo == 'openclaw/clawhub' && vars.CLAWSWEEPER_ENABLE_CLAWHUB != '1') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2276,6 +2276,28 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.doesNotMatch(exactReviewStep, /--codex-timeout-ms 600000/);
 });
 
+test("sweep workflow suppresses only legacy pull_request_target PR duplicate ingress", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const legacyIntakeBlock = workflow.slice(
+    workflow.indexOf("\n  legacy-event-queue-intake:"),
+    workflow.indexOf("\n  event-review-apply:"),
+  );
+  const legacyIngressWouldQueue = (sourceEvent: string, itemKind: string) =>
+    sourceEvent !== "pull_request_target" || itemKind !== "pull_request";
+
+  assert.equal(legacyIngressWouldQueue("pull_request_target", "pull_request"), false);
+  assert.equal(legacyIngressWouldQueue("pull_request", "pull_request"), true);
+  assert.equal(legacyIngressWouldQueue("issues", "issue"), true);
+  assert.equal(legacyIngressWouldQueue("issue_comment", "pull_request"), true);
+  assert.match(
+    legacyIntakeBlock,
+    /github\.event\.client_payload\.source_event != 'pull_request_target' \|\| github\.event\.client_payload\.item_kind != 'pull_request'/,
+  );
+  assert.match(legacyIntakeBlock, /\/internal\/exact-review\/enqueue/);
+  assert.doesNotMatch(legacyIntakeBlock, /source_event != 'pull_request'/);
+  assert.doesNotMatch(legacyIntakeBlock, /source_event != 'issue_comment'/);
+});
+
 test("sweep workflow gives high-context Codex reviews twenty minutes by default", () => {
   const workflow = readText(".github/workflows/sweep.yml");
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -10392,6 +10392,59 @@ test("hosted webhook enqueues item events with the repository default branch", a
   });
 });
 
+test("hosted webhook preserves pull-request revision and body updates", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const repository = {
+    full_name: "openclaw/gogcli",
+    default_branch: "trunk",
+    private: false,
+    archived: false,
+    fork: false,
+    has_issues: true,
+  };
+
+  for (const [deliveryId, action] of [
+    ["pr-revision", "synchronize"],
+    ["pr-body", "edited"],
+  ] as const) {
+    const response = await worker.fetch(
+      signedGithubWebhookRequest({
+        event: "pull_request",
+        secret: "test-secret",
+        deliveryId,
+        payload: {
+          action,
+          repository,
+          pull_request: { number: 597 },
+          installation: { id: 123 },
+        },
+      }),
+      env,
+    );
+    assert.equal(response.status, 202);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      queued: true,
+      item_key: "openclaw/gogcli#597",
+    });
+  }
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { revision: number; decision: { sourceEvent: string; sourceAction: string } }
+    >;
+  };
+  assert.equal(state.items["openclaw/gogcli#597"].revision, 2);
+  assert.equal(state.items["openclaw/gogcli#597"].decision.sourceEvent, "pull_request");
+  assert.equal(state.items["openclaw/gogcli#597"].decision.sourceAction, "edited");
+});
+
 test("hosted webhook requeues unlocked and close-guard removal events", async () => {
   const closeGuardLabels = [
     "security",
@@ -11103,23 +11156,27 @@ function signedGithubWebhookRequest({
   event,
   secret,
   payload,
+  deliveryId,
 }: {
   event: string;
   secret: string;
   payload: unknown;
+  deliveryId?: string;
 }) {
   const body = JSON.stringify(payload);
-  return signedGithubWebhookBodyRequest({ event, secret, body });
+  return signedGithubWebhookBodyRequest({ event, secret, body, deliveryId });
 }
 
 function signedGithubWebhookBodyRequest({
   event,
   secret,
   body,
+  deliveryId = "test-delivery",
 }: {
   event: string;
   secret: string;
   body: string;
+  deliveryId?: string;
 }) {
   const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
   return new Request("https://clawsweeper.openclaw.ai/github/webhook", {
@@ -11127,7 +11184,7 @@ function signedGithubWebhookBodyRequest({
     headers: {
       "content-type": "application/json",
       "x-github-event": event,
-      "x-github-delivery": "test-delivery",
+      "x-github-delivery": deliveryId,
       "x-hub-signature-256": signature,
     },
     body,


### PR DESCRIPTION
## Summary

- Makes the direct GitHub App `pull_request` webhook the canonical exact-review ingress for PR events.
- Prevents the legacy `pull_request_target` repository-dispatch compatibility path from creating a second durable review intent, runner, and queue handoff.
- Keeps distinct later PR deliveries (`synchronize` and `edited`) and maintainer `issue_comment` commands eligible.

## Problem and evidence

One OpenClaw PR push entered the durable exact-review control plane twice:

- [`openclaw/openclaw#110767`](https://github.com/openclaw/openclaw/pull/110767) received head `a1e94e165a58a0ac86ec30744ddca8499937e3d3` at 10:19 UTC.
- The direct GitHub App webhook run ([29683139308](https://github.com/openclaw/clawsweeper/actions/runs/29683139308)) had `sourceEvent=pull_request`, `sourceAction=synchronize`, performed the real review, and queued publication.
- The legacy compatibility run ([29683141001](https://github.com/openclaw/clawsweeper/actions/runs/29683141001)) originated from `pull_request_target` and durably enqueued the same intent again.
- A later duplicate ([29683229621](https://github.com/openclaw/clawsweeper/actions/runs/29683229621)) deferred on the same-head lease, but only after consuming control-plane work.

This is ingress duplication, not a head-SHA dedupe problem: later body edits, revisions, and maintainer commands can be meaningful and must continue to enqueue.

## Implementation

The legacy queue-intake job now skips only a repository-dispatch payload whose pair is:

```text
source_event = pull_request_target
item_kind    = pull_request
```

The guard is at the job condition, before runner allocation and before the durable enqueue request. It does not suppress direct `pull_request` webhook deliveries, `issues`, or `issue_comment` command flows.

The regression coverage:

- models the direct-plus-legacy route boundary and asserts that only the legacy `pull_request_target` PR route is excluded;
- sends two independent direct GitHub webhook deliveries for the same PR: `synchronize` followed by `edited`, and verifies the queue records revision 2 with the later body-update decision;
- retains the existing command-path tests for `issue_comment` maintainer review commands.

## Relationship to #674 and terminal behavior

Draft [#674](https://github.com/openclaw/clawsweeper/pull/674) owns the per-item generation, live terminal-target checks, and terminal reconciliation work. It does not address duplicate direct-plus-legacy ingress. This PR deliberately avoids duplicating or conflicting with #674; prompt terminalization/supersession of closed or merged targets remains its dependency and should land through #674.

## Validation

```text
pnpm run build:all
node --test test/clawsweeper.test.ts test/dashboard-worker.test.ts
# 230 passed, 0 failed

pnpm exec oxfmt --check .github/workflows/sweep.yml test/clawsweeper.test.ts test/dashboard-worker.test.ts
git diff --check
# YAML parse and extracted legacy-intake Bash syntax check passed
```

`actionlint` is unavailable on this host. The workflow change is a GitHub-expression-only job guard; the existing legacy intake script was extracted from YAML and passed `bash -n`.

Codex review closeout:

```text
codex review --uncommitted
codex review --base origin/main
```

Both completed with no accepted or actionable findings. The second review ran after rebasing onto current `origin/main` (`639d459f22`).

## Risk and rollout

The direct GitHub App webhook is already the source that completed the observed PR review. After deployment, only the redundant legacy `pull_request_target` compatibility delivery is skipped; a new direct webhook delivery remains a separate durable intent. No gate, dispatch, review, label, or merge behavior changes.

This touches `.github/workflows/sweep.yml`, so GitHub OAuth/workflow-scope policy may require a maintainer-owned replacement branch in environments that reject workflow-file updates. No new permissions or token scopes are requested.
