### PR TITLE
fix(repair): disable immutable ledger server merges

### DIFF
--- a/.github/actions/setup-state/action.yml
+++ b/.github/actions/setup-state/action.yml
@@ -48,9 +48,9 @@ runs:
 
     - name: Export state root
       shell: bash
-      run: |
-        echo "CLAWSWEEPER_STATE_DIR=$GITHUB_WORKSPACE/${{ inputs.state-path }}" >> "$GITHUB_ENV"
-        echo "CLAWSWEEPER_STATE_REPOSITORY=openclaw/clawsweeper-state" >> "$GITHUB_ENV"
+      # Keep immutable ledger server merges dormant until state publishers can
+      # fetch a merge-heavy shallow branch without hydrating its ancestry.
+      run: echo "CLAWSWEEPER_STATE_DIR=$GITHUB_WORKSPACE/${{ inputs.state-path }}" >> "$GITHUB_ENV"
 
     - uses: actions/setup-node@v6
       with:

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2415,7 +2415,7 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
 
 test("setup-state defaults to an auth-safe shallow checkout", () => {
   const action = readText(".github/actions/setup-state/action.yml");
-  assert.match(action, /CLAWSWEEPER_STATE_REPOSITORY=openclaw\/clawsweeper-state/);
+  assert.doesNotMatch(action, /CLAWSWEEPER_STATE_REPOSITORY=/);
   assert.doesNotMatch(action, /CLAWSWEEPER_STATE_TOKEN/);
   const filterBlock = action.slice(action.indexOf("filter:"), action.indexOf("fetch-depth:"));
   const fetchDepthBlock = action.slice(action.indexOf("fetch-depth:"), action.indexOf("runs:"));


### PR DESCRIPTION
## Summary

- stop exporting CLAWSWEEPER_STATE_REPOSITORY from setup-state
- leave the server-merge implementation and immutable-path conflict checks intact but dormant
- assert the production setup contract keeps server merges disabled

## Why

https://github.com/openclaw/clawsweeper/pull/700 introduced server-side immutable ledger merges and https://github.com/openclaw/clawsweeper/pull/701 made their checkout-v7 credentials available in production. The resulting two-parent commits make shallow state publishers hydrate merge ancestry on their next ordinary fetch. Production publisher runs have remained inside that fetch until their one-hour workflow cancellation.

This is a narrow rollback of the production activation point. It stops new merge-DAG growth without reverting the safety checks or checkout-v7 credential parsing. The client-side immutable ledger fallback remains active while a merge-DAG-safe publisher design is developed separately.

## Evidence

- production run 29687240385 entered git fetch at 12:36:28 UTC and was cancelled at 13:34:38 UTC
- production run 29687930347 entered the same fetch at 12:58:22 UTC and was cancelled at 13:56:56 UTC
- state commits created by the server fallback have two parents

## Validation

- node --test test/sweep-workflow.test.ts: 67/67 passed
- pnpm run check: passed
- autoreview local: 0 findings
- gitleaks diff scan: 0 leaks
