### PR TITLE
fix(publish): bound stalled state fetches

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1993,6 +1993,9 @@ jobs:
           elif [ "$outcome" != "success" ] && [ "$PUBLISH_COMPLETION_KIND" = "permanent_failure" ]; then
             completion_kind=permanent_failure
             reason_code="${PUBLISH_REASON_CODE:-unknown_failure}"
+          elif [ "$outcome" != "success" ] && [ "$PUBLISH_COMPLETION_KIND" = "retryable_failure" ]; then
+            completion_kind=retryable_failure
+            reason_code="${PUBLISH_REASON_CODE:-unknown_failure}"
           fi
           echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
           echo "completion_kind=$completion_kind" >> "$GITHUB_OUTPUT"

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -35,6 +35,7 @@ export type GitRunResult = {
   status: number;
   stdout: string;
   stderr: string;
+  timedOut: boolean;
 };
 
 export type GitPublishOptions = {
@@ -56,6 +57,7 @@ export type GitRunOptions = {
   input?: string;
   maxBuffer?: number;
   quiet?: boolean;
+  timeout?: number;
 };
 
 export type PublishResult = "committed" | "unchanged";
@@ -73,6 +75,7 @@ const GIT_OBJECT_BATCH_SIZE = 512;
 const GIT_OBJECT_BATCH_MAX_BUFFER = 64 * 1024 * 1024;
 const GIT_TREE_LIST_MAX_BUFFER = 64 * 1024 * 1024;
 const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
+const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
 
@@ -109,6 +112,9 @@ export function setTokenOrigin(token: string, repository: string): void {
 
 export function runGit(args: readonly string[], options: GitRunOptions = {}): string {
   const result = spawnGit(args, options);
+  if (result.timedOut) {
+    throw new GitCommandTimeoutError(args, options.timeout ?? 0);
+  }
   if (result.status !== 0 && !options.allowFailure) {
     const detail =
       result.stderr ||
@@ -128,6 +134,7 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer ?? 16 * 1024 * 1024,
+    timeout: options.timeout,
   });
   if (!options.quiet && child.stdout) process.stdout.write(child.stdout);
   if (!options.quiet && child.stderr) process.stderr.write(child.stderr);
@@ -135,7 +142,15 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     status: child.status ?? 1,
     stdout: child.stdout ?? "",
     stderr: child.stderr ?? "",
+    timedOut: (child.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT",
   };
+}
+
+export class GitCommandTimeoutError extends Error {
+  constructor(args: readonly string[], timeoutMs: number) {
+    super(`git ${safeGitDisplayAction(args[0])} timed out after ${timeoutMs}ms`);
+    this.name = "GitCommandTimeoutError";
+  }
 }
 
 function recordGitProcess(action: string | undefined): void {
@@ -556,7 +571,7 @@ function mergeImmutableActionLedgerOnGitHub(options: {
         options.repository,
         options.token,
       );
-      runGit(["fetch", options.remote, options.branch]);
+      fetchPublishRemote(options.remote, options.branch);
       const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
         quiet: true,
       }).trim();
@@ -602,6 +617,7 @@ function spawnGitHubApi(args: readonly string[], repository: string, token: stri
     status: child.status ?? 1,
     stdout: child.stdout ?? "",
     stderr: child.stderr ?? "",
+    timedOut: false,
   };
 }
 
@@ -716,7 +732,7 @@ function prepareReconciliationStateRoot(
     return;
   }
   gitPublishPhase("prepare");
-  runGit(["fetch", remote, branch]);
+  fetchPublishRemote(remote, branch);
   const remoteRef = `${remote}/${branch}`;
   if (spawnGit(["merge-base", "--is-ancestor", "HEAD", remoteRef], { quiet: true }).status === 0) {
     return;
@@ -752,7 +768,7 @@ function publishReconciliationChunks(options: {
   let committed = false;
   for (const [index, tupleKeys] of chunks.entries()) {
     gitPublishPhase("checkpoint", `chunk=${index + 1}/${chunks.length} tuples=${tupleKeys.length}`);
-    runGit(["fetch", options.remote, options.branch]);
+    fetchPublishRemote(options.remote, options.branch);
     const remoteRef = `${options.remote}/${options.branch}`;
     const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
     const allowedTupleKeys = new Set(tupleKeys);
@@ -1213,7 +1229,7 @@ export function pushCommit(options: {
     console.log(`Push attempt ${pushAttempt} lost the ${branch} race; rebasing`);
     const localCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
     const localCommitMessage = runGit(["log", "-1", "--format=%B"], { quiet: true });
-    runGit(["fetch", remote, branch], { allowFailure: true });
+    fetchPublishRemote(remote, branch, { allowFailure: true });
     if (rebaseStrategy === "reconcile-records") {
       const remoteRef = `${remote}/${branch}`;
       const overlaps = reconciliationChangesOverlap(
@@ -1689,7 +1705,7 @@ function rebuildPublishCommit(options: {
   sourceCommit: string;
 }): PublishResult {
   console.log(`Rebuilding publish commit on ${options.remote}/${options.branch}`);
-  runGit(["fetch", options.remote, options.branch]);
+  fetchPublishRemote(options.remote, options.branch);
   const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
     quiet: true,
   }).trim();
@@ -1742,7 +1758,7 @@ function rebuildImmutableActionLedgerCommit(options: {
   paths: readonly string[];
   sourceCommit: string;
 }): { result: PublishResult; commit: string } {
-  runGit(["fetch", options.remote, options.branch]);
+  fetchPublishRemote(options.remote, options.branch);
   const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
     quiet: true,
   }).trim();
@@ -1912,8 +1928,12 @@ function commitHasPath(commit: string, path: string): boolean {
 }
 
 export function hardResetToRemoteMain(remote = "origin", branch = publishDefaultBranch()): void {
-  runGit(["fetch", remote, branch]);
+  fetchPublishRemote(remote, branch);
   runGit(["reset", "--hard", `${remote}/${branch}`]);
+}
+
+function fetchPublishRemote(remote: string, branch: string, options: GitRunOptions = {}): string {
+  return runGit(["fetch", remote, branch], { ...options, timeout: PUBLISH_FETCH_TIMEOUT_MS });
 }
 
 export function uniqueNonEmpty(values: readonly string[]): string[] {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -24,6 +24,7 @@ import {
   captureStatePublishBaseline,
   commitMessageForPublishedPaths,
   configureGitUser,
+  GitCommandTimeoutError,
   hardResetToRemoteMain,
   hasStagedChanges,
   publishRoot,
@@ -92,13 +93,20 @@ const options = eventOptionsFromEnv();
 try {
   await publishEventResult(options);
 } catch (error) {
-  const reasonCode =
-    error instanceof PublicationResultError
+  const retryableTimeout = error instanceof GitCommandTimeoutError;
+  const reasonCode = retryableTimeout
+    ? "github_transient"
+    : error instanceof PublicationResultError
       ? error.reasonCode
       : error instanceof RecordTupleError
         ? "tuple_protocol_invalid"
         : "unknown_failure";
-  writePublicationCompletionOutputs("permanent_failure", reasonCode, errorFingerprint(error));
+  writePublicationCompletionOutputs(
+    retryableTimeout ? "retryable_failure" : "permanent_failure",
+    reasonCode,
+    errorFingerprint(error),
+    retryableTimeout ? "github_transient" : undefined,
+  );
   throw error;
 }
 
@@ -491,6 +499,7 @@ function publishSnapshot({
     return complete(true);
   } catch (error) {
     if (
+      error instanceof GitCommandTimeoutError ||
       error instanceof RecordTupleError ||
       error instanceof GuardedOpenPublishRaceError ||
       error instanceof RoutableSyncPublishRaceError ||
@@ -621,16 +630,18 @@ function writeLegacyRefreshRequiredOutputs(): void {
 }
 
 function writePublicationCompletionOutputs(
-  completionKind: "superseded" | "deferred" | "permanent_failure",
+  completionKind: "superseded" | "deferred" | "retryable_failure" | "permanent_failure",
   reasonCode:
     | "remote_newer_tuple"
     | "remote_closed"
     | "close_coverage_deferred"
+    | "github_transient"
     | "missing_record_tuple"
     | "tuple_protocol_invalid"
     | "policy_invariant"
     | "unknown_failure",
   fingerprint?: string,
+  failureKind?: "github_transient",
 ): void {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) return;
@@ -639,6 +650,7 @@ function writePublicationCompletionOutputs(
     [
       `completion_kind=${completionKind}`,
       `reason_code=${reasonCode}`,
+      ...(failureKind ? [`failure_kind=${failureKind}`] : []),
       ...(fingerprint ? [`error_fingerprint=${fingerprint}`] : []),
       "",
     ].join("\n"),

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -9,10 +9,12 @@ import test from "node:test";
 import {
   captureStatePublishBaseline,
   commitMessageForPublishedPaths,
+  GitCommandTimeoutError,
   hardResetToRemoteMain,
   publishMainCommit,
   refreshSourceAfterStatePublish,
   setTokenOrigin,
+  spawnGit,
   stagePaths,
   uniqueNonEmpty,
 } from "../../dist/repair/git-publish.js";
@@ -31,6 +33,36 @@ test("uniqueNonEmpty trims, drops blanks, and deduplicates paths", () => {
     "jobs",
     "results",
   ]);
+});
+
+test("spawnGit reports an elapsed command timeout", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-git-timeout-"));
+  run("git", ["init"], root);
+  const result = withEnv(
+    {
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "alias.wait",
+      GIT_CONFIG_VALUE_0: '!node -e "setTimeout(() => {}, 5000)"',
+    },
+    () => withCwd(root, () => spawnGit(["wait"], { quiet: true, timeout: 25 })),
+  );
+
+  assert.equal(result.timedOut, true);
+  assert.equal(
+    new GitCommandTimeoutError(["fetch"], 60_000).message,
+    "git fetch timed out after 60000ms",
+  );
+});
+
+test("publisher fetches share the bounded fetch helper", () => {
+  const source = fs.readFileSync(path.resolve("src/repair/git-publish.ts"), "utf8");
+
+  assert.match(source, /const PUBLISH_FETCH_TIMEOUT_MS = 60_000/);
+  assert.match(
+    source,
+    /function fetchPublishRemote\([\s\S]*runGit\(\["fetch", remote, branch\], \{ \.\.\.options, timeout: PUBLISH_FETCH_TIMEOUT_MS \}\)/,
+  );
+  assert.equal(source.match(/runGit\(\["fetch"/g)?.length, 1);
 });
 
 test("commitMessageForPublishedPaths skips CI for generated-only publishes", () => {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -13,6 +13,7 @@ import {
   hardResetToRemoteMain,
   publishMainCommit,
   refreshSourceAfterStatePublish,
+  runGit,
   setTokenOrigin,
   spawnGit,
   stagePaths,
@@ -35,23 +36,62 @@ test("uniqueNonEmpty trims, drops blanks, and deduplicates paths", () => {
   ]);
 });
 
-test("spawnGit reports an elapsed command timeout", () => {
+test("runGit reports a stalled fetch transport timeout", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-git-timeout-"));
   run("git", ["init"], root);
-  const result = withEnv(
-    {
-      GIT_CONFIG_COUNT: "1",
-      GIT_CONFIG_KEY_0: "alias.wait",
-      GIT_CONFIG_VALUE_0: '!node -e "setTimeout(() => {}, 5000)"',
-    },
-    () => withCwd(root, () => spawnGit(["wait"], { quiet: true, timeout: 25 })),
+  // The ext transport stalls during fetch protocol negotiation without depending on
+  // GitHub or wall-clock races, matching the production failure before any tuple work.
+  const stalledFetch = ["fetch", "ext::node -e setTimeout(()=>{},5000)", "main"];
+  const result = withEnv({ GIT_ALLOW_PROTOCOL: "ext" }, () =>
+    withCwd(root, () => spawnGit(stalledFetch, { quiet: true, timeout: 100 })),
   );
 
   assert.equal(result.timedOut, true);
+  assert.throws(
+    () =>
+      withEnv({ GIT_ALLOW_PROTOCOL: "ext" }, () =>
+        withCwd(root, () =>
+          runGit(stalledFetch, { allowFailure: true, quiet: true, timeout: 100 }),
+        ),
+      ),
+    GitCommandTimeoutError,
+  );
   assert.equal(
     new GitCommandTimeoutError(["fetch"], 60_000).message,
     "git fetch timed out after 60000ms",
   );
+});
+
+test("publisher reset applies the production fetch timeout before touching state", () => {
+  const script = String.raw`
+    import childProcess from "node:child_process";
+    import { syncBuiltinESMExports } from "node:module";
+
+    const calls = [];
+    childProcess.spawnSync = (command, args, options) => {
+      calls.push({ command, args, timeout: options.timeout ?? null });
+      return { status: 0, stdout: "", stderr: "" };
+    };
+    syncBuiltinESMExports();
+    console.log = () => {};
+
+    const { hardResetToRemoteMain } = await import("./dist/repair/git-publish.js");
+    hardResetToRemoteMain("origin", "state");
+    process.stdout.write(JSON.stringify(calls));
+  `;
+
+  assert.deepEqual(JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd())), [
+    {
+      command: "git",
+      args: ["fetch", "origin", "state"],
+      timeout: 60_000,
+    },
+    {
+      command: "git",
+      args: ["reset", "--hard", "origin/state"],
+      timeout: null,
+    },
+  ]);
 });
 
 test("publisher fetches share the bounded fetch helper", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -603,6 +603,9 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(reviewSource, /CLAWSWEEPER_BOT_AUTHORS\.has/);
   const completeStart = publisherSource.indexOf("const complete =");
   assert.ok(publisherSource.indexOf("hardResetToRemoteMain();", completeStart) > completeStart);
+  assert.match(publisherSource, /GitCommandTimeoutError/);
+  assert.match(publisherSource, /retryable_failure/);
+  assert.match(publisherSource, /error instanceof GitCommandTimeoutError/);
   assert.ok(
     publisherSource.indexOf("eventSnapshotMatchesCurrent(paths)", completeStart) > completeStart,
   );


### PR DESCRIPTION
## Incident

openclaw/clawsweeper#700 introduced server-side immutable-ledger merges and openclaw/clawsweeper#701 enabled that path under checkout v7. The resulting merge-heavy `clawsweeper-state/state` history caused depth-1 publisher checkouts to stall in later `git fetch` calls and exhaust all publication slots.

openclaw/clawsweeper#705 stopped creating new server-side ledger merges. That restored some throughput, but historical merge ancestry still leaves new-head publishers stuck in `Publish event result`; for example:

- https://github.com/openclaw/clawsweeper/actions/runs/29690773946
- https://github.com/openclaw/clawsweeper/actions/runs/29690774345
- https://github.com/openclaw/clawsweeper/actions/runs/29690779556

Other publishers on the same `c48d3e0` workflow head complete, so the remaining failure is an unbounded fetch holding a capacity slot, not a total state outage.

## Fix

- Route every publisher state fetch through one 60-second bounded helper.
- Surface elapsed commands as `GitCommandTimeoutError`, including fetches whose caller otherwise allows ordinary Git failures.
- Let fetch timeouts escape the local publication retry loop.
- Complete them as `retryable_failure/github_transient` so the durable queue owns backoff and retry.
- Preserve tuple reconciliation, exact-head, CAS, immutable-ledger, routing, and merge safety behavior.

This carries forward the useful implementation from the now-closed openclaw/clawsweeper#704. Commit authorship remains with `brokemac79`; the follow-up regression proof was added on a separate commit after the base moved.

## Deterministic local proof

The regression uses Git's local `ext` transport to stall a real `git fetch` during protocol negotiation without GitHub or timing races. It proves:

1. `spawnGit` marks the elapsed fetch as timed out.
2. `runGit` throws `GitCommandTimeoutError` even with `allowFailure`.
3. The real publisher reset entry point runs `git fetch origin state` with the production 60,000 ms timeout before any state reset.
4. All publisher fetch sites remain centralized through the bounded helper.

## Validation

- Focused build and publisher/workflow regressions: 4 passed, 0 failed.
- `pnpm run check`: passed.
- Local container `clawsweeper-automerge-e2e-base:local` (Node 24.15.0, Git 2.39.5): 4 passed, 0 failed.
- Autoreview final run: 0 accepted/actionable findings.
- Gitleaks over `origin/main..HEAD`: no leaks.
