### PR TITLE
fix(publish): preserve shallow state fetches

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1933,7 +1933,16 @@ export function hardResetToRemoteMain(remote = "origin", branch = publishDefault
 }
 
 function fetchPublishRemote(remote: string, branch: string, options: GitRunOptions = {}): string {
-  return runGit(["fetch", remote, branch], { ...options, timeout: PUBLISH_FETCH_TIMEOUT_MS });
+  // Server-side immutable-ledger merges left merge-heavy ancestry on the state
+  // branch. Preserve an existing shallow boundary without truncating complete
+  // repositories whose reconciliation logic still needs full ancestry.
+  const shallow =
+    runGit(["rev-parse", "--is-shallow-repository"], { quiet: true }).trim() === "true";
+  const depthArgs = shallow ? ["--depth=1"] : [];
+  return runGit(["fetch", ...depthArgs, remote, branch], {
+    ...options,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
 }
 
 export function uniqueNonEmpty(values: readonly string[]): string[] {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -70,7 +70,8 @@ test("publisher reset applies the production fetch timeout before touching state
     const calls = [];
     childProcess.spawnSync = (command, args, options) => {
       calls.push({ command, args, timeout: options.timeout ?? null });
-      return { status: 0, stdout: "", stderr: "" };
+      const stdout = args[0] === "rev-parse" ? "true\n" : "";
+      return { status: 0, stdout, stderr: "" };
     };
     syncBuiltinESMExports();
     console.log = () => {};
@@ -83,7 +84,12 @@ test("publisher reset applies the production fetch timeout before touching state
   assert.deepEqual(JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd())), [
     {
       command: "git",
-      args: ["fetch", "origin", "state"],
+      args: ["rev-parse", "--is-shallow-repository"],
+      timeout: null,
+    },
+    {
+      command: "git",
+      args: ["fetch", "--depth=1", "origin", "state"],
       timeout: 60_000,
     },
     {
@@ -100,7 +106,7 @@ test("publisher fetches share the bounded fetch helper", () => {
   assert.match(source, /const PUBLISH_FETCH_TIMEOUT_MS = 60_000/);
   assert.match(
     source,
-    /function fetchPublishRemote\([\s\S]*runGit\(\["fetch", remote, branch\], \{ \.\.\.options, timeout: PUBLISH_FETCH_TIMEOUT_MS \}\)/,
+    /function fetchPublishRemote\([\s\S]*runGit\(\["rev-parse", "--is-shallow-repository"\][\s\S]*runGit\(\["fetch", \.\.\.depthArgs, remote, branch\], \{/,
   );
   assert.equal(source.match(/runGit\(\["fetch"/g)?.length, 1);
 });


### PR DESCRIPTION
## Incident

PR #700 introduced server-side immutable-ledger merges and PR #701 enabled them in production. PR #705 stopped new merge-DAG growth, while PR #707 bounded stalled publisher fetches, but ordinary refreshes from depth-1 state checkouts can still hydrate the historical merge ancestry and consume every publication slot.

## Fix

- Detect whether the publication state checkout is already shallow.
- Keep each refresh at `--depth=1` only for shallow checkouts.
- Preserve ordinary fetch semantics for complete repositories so tuple reconciliation retains full ancestry.
- Retain the existing 60-second fetch timeout and retry classification.

## Production proof

Against a fresh depth-1 clone of `openclaw/clawsweeper-state/state`, the new fetch shape completed in 5.09 seconds and retained a one-commit shallow boundary.

## Validation

- three TypeScript builds passed
- focused timeout and helper tests passed
- 10 publish/reconcile race regressions passed after proving that unconditional depth truncation was unsafe
- `git diff --check` passed
- autoreview finding about `options.cwd` rejected because `GitRunOptions` has no `cwd`; both commands resolve the same `publishRoot()`

This does not rewrite state history, change queue protocol, weaken tuple/CAS guards, pause sweep, or run live apply/close.
