### PR TITLE
test(action-ledger): make cleanup-stuck projection tests robust under host load

### DIFF
--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -3258,15 +3258,18 @@ test("cleanup-stuck projection rejection is scoped to the affected spool root", 
     CLAWSWEEPER_CRABFLEET_TIMEOUT_MS: "30000",
   });
   const cleanupResolvers: Array<() => void> = [];
+  let releaseCleanups = false;
   const blockedFetch = (async () =>
     ({
       ok: true,
       status: 204,
       body: {
         cancel: () =>
-          new Promise<void>((resolve) => {
-            cleanupResolvers.push(resolve);
-          }),
+          releaseCleanups
+            ? Promise.resolve()
+            : new Promise<void>((resolve) => {
+                cleanupResolvers.push(resolve);
+              }),
       },
     }) as unknown as Response) as typeof fetch;
   for (let index = 0; index < CRABFLEET_PROJECTION_LIMITS.maxConcurrent + 1; index += 1) {
@@ -3301,7 +3304,9 @@ test("cleanup-stuck projection rejection is scoped to the affected spool root", 
     }
   } finally {
     // Release held slots even on failure so later tests do not inherit a starved pool.
-    for (const resolve of cleanupResolvers) resolve();
+    // The flag makes any cleanup registered after this point resolve immediately.
+    releaseCleanups = true;
+    while (cleanupResolvers.length > 0) cleanupResolvers.shift()!();
     await flushPendingCrabFleetPosts();
   }
   assert.equal(independentStarted, 1);

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -3254,7 +3254,8 @@ test("cleanup-stuck projection rejection is scoped to the affected spool root", 
   const independentEnv = workflowEnv({
     CLAWSWEEPER_CRABFLEET_AGENT_TOKEN: "agent-token",
     CLAWSWEEPER_CRABFLEET_SESSION_ID: "session-1",
-    CLAWSWEEPER_CRABFLEET_TIMEOUT_MS: "1000",
+    // Also bounds queue wait; must outlast the polling below on a loaded host.
+    CLAWSWEEPER_CRABFLEET_TIMEOUT_MS: "30000",
   });
   const cleanupResolvers: Array<() => void> = [];
   const blockedFetch = (async () =>
@@ -3279,26 +3280,30 @@ test("cleanup-stuck projection rejection is scoped to the affected spool root", 
     }) as typeof fetch),
   );
 
-  const blockedDeadline = Date.now() + 500;
-  while (cleanupResolvers.length < CRABFLEET_PROJECTION_LIMITS.maxConcurrent) {
-    if (Date.now() >= blockedDeadline) {
-      throw new Error("blocked root did not enter response cleanup");
+  try {
+    const blockedDeadline = Date.now() + 5000;
+    while (cleanupResolvers.length < CRABFLEET_PROJECTION_LIMITS.maxConcurrent) {
+      if (Date.now() >= blockedDeadline) {
+        throw new Error("blocked root did not enter response cleanup");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  await new Promise((resolve) => setTimeout(resolve, 20));
-  assert.equal(independentStarted, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(independentStarted, 0);
 
-  cleanupResolvers.shift()!();
-  const independentDeadline = Date.now() + 500;
-  while (independentStarted === 0) {
-    if (Date.now() >= independentDeadline) {
-      throw new Error("independent root did not start after a projection slot recovered");
+    cleanupResolvers.shift()!();
+    const independentDeadline = Date.now() + 5000;
+    while (independentStarted === 0) {
+      if (Date.now() >= independentDeadline) {
+        throw new Error("independent root did not start after a projection slot recovered");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
     }
-    await new Promise((resolve) => setTimeout(resolve, 5));
+  } finally {
+    // Release held slots even on failure so later tests do not inherit a starved pool.
+    for (const resolve of cleanupResolvers) resolve();
+    await flushPendingCrabFleetPosts();
   }
-  for (const resolve of cleanupResolvers) resolve();
-  await flushPendingCrabFleetPosts();
   assert.equal(independentStarted, 1);
 });
 


### PR DESCRIPTION
## Summary

Fixes the two `test/action-ledger-runtime.test.ts` failures reported on main:

- `cleanup-stuck projection rejection is scoped to the affected spool root` — "independent root did not start after a projection slot recovered"
- `CrabFleet timeouts hold slots until response cleanup settles` — `started` 1 !== 4

## Analysis: timing-budget encoding, not a product regression

The failures are load-sensitive, not deterministic. On this host (load averages 60–160 from concurrent sessions) the pair failed roughly 1 in 4 runs on pristine main; the same tree passes repeatedly when load subsides. They always fail **together**, which is the tell:

1. **First test** gives the independent root `CLAWSWEEPER_CRABFLEET_TIMEOUT_MS=1000`. That value also bounds projection **queue wait** (`src/action-ledger-runtime.ts`, "CrabFleet projection queue timed out" timer uses `request.config.timeoutMs`). Under load, the test's 5 ms polling loops plus the 20 ms settle sleep consume more than 1 s of wall clock while all four global projection slots are still held by the stuck-cleanup posts. The queue timer settles the independent request with `queue timed out after 1000ms` (visible verbatim in the failing run's stderr), so when the test finally frees a slot there is nothing left to start and `independentStarted` can never reach 1.
2. **Second test's** failure is pure fallout. When the first test throws, its resolver-release line was unreachable, leaking 3 of the 4 stuck cleanups. Those hold 3 of the 4 module-global projection slots forever, so the next test's first wave of 4 posts gets exactly 1 slot: `started` 1 !== 4.

No runtime commit is at fault; the product's slot-hold semantics behave as designed.

## Fix (test-only)

- Raise the independent root's timeout to 30 s so the queue-wait budget outlasts polling on a loaded host (its mock fetch resolves instantly, so nothing actually waits that long).
- Widen the two 500 ms poll deadlines to 5 s.
- Release cleanup resolvers in a `finally` block, gated by a release flag so a cleanup registered on a late microtask after teardown begins resolves immediately — a failure now stays scoped to its own test instead of starving the global slot pool for the rest of the file.

## Validation

- Both tests: 10/10 green after the fix at load avg 60–90, plus 5/5 green with 8 extra busy-loop processes pinning cores.
- Full file: `pnpm run build:all && node --test test/action-ledger-runtime.test.ts` — 84 tests, 82 pass, 2 skipped (pre-existing skips), 0 fail.
- `pnpm run check`: lint, builds, format, repair suite green; unit run had 1396/1406 pass with 8 failures, all pre-existing load flakes in unrelated suites (`apply-runtime-budget`, `dashboard-worker`, `failed-review-retry`, and the same-second process-identity test in `action-ledger-runtime`). Both tests fixed here passed inside the check run, and each of the 8 flaky suites passes on isolated rerun on the same host (they fail nondeterministically under load avg 60-160; previously documented as environmental on this machine).
- Autoreview (commit mode): clean after addressing one P2 (late-registered-resolver race, now covered by the release flag).
