### PR TITLE
fix(review): clean up superseded review-started placeholder comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Stopped stale "review started" placeholder comments from accumulating on reviewed items: retries refresh a surviving placeholder in place, and publishing the durable review comment sweeps superseded placeholders.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Stopped stale "review started" placeholder comments from accumulating on reviewed items: retries refresh a surviving placeholder in place, and publishing the durable review comment sweeps superseded placeholders.
+- Stopped stale "review started" placeholder comments from accumulating on reviewed items: publishing the durable review comment now sweeps superseded placeholders.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.
 - Kept exact-review handoff health live when the dashboard serves a stale fleet snapshot, so recovered claims no longer leave the operator rail stuck in a delayed or stalled state.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -20596,40 +20596,26 @@ function postReviewStartStatusComment(options: {
   if (initialLease) {
     return heldReviewStartStatusCommentResult(initialLease.expiresAt, false);
   }
-  const reapedLeaseCommentIds = reapExpiredDedicatedReviewStartLeases(
+  reapExpiredDedicatedReviewStartLeases(
     options.item.number,
     initialState.dedicatedLeaseComments,
     startedAtMs,
   );
   const body = renderReviewStartStatusComment(leaseOptions);
   const payload = writeCommentPayload(options.item.number, body);
-  // A leftover bot placeholder from a superseded attempt (typically an
-  // unexpired lease for an older head revision) is refreshed in place instead
-  // of stacking one new "review started" comment per retry. Lowest server id
-  // wins lease election, so reusing the oldest surviving comment also keeps
-  // the refreshed lease electable.
-  const reusableLeaseCommentId = initialState.dedicatedLeaseComments
-    .map((comment) => commentId(comment))
-    .filter((id): id is number => id !== null && !reapedLeaseCommentIds.has(id))
-    .sort((left, right) => left - right)[0];
-  const createArgs =
-    reusableLeaseCommentId === undefined
-      ? [
-          "api",
-          `repos/${targetRepo()}/issues/${options.item.number}/comments`,
-          "--method",
-          "POST",
-          "--input",
-          payload,
-        ]
-      : [
-          "api",
-          `repos/${targetRepo()}/issues/comments/${reusableLeaseCommentId}`,
-          "--method",
-          "PATCH",
-          "--input",
-          payload,
-        ];
+  // Every acquisition POSTs a fresh comment: the lowest-server-id election
+  // needs distinct ids per contender, so refreshing a leftover placeholder in
+  // place would let two racing workers both validate ownership of the same
+  // comment. Superseded placeholders are swept when the durable review
+  // comment is published instead.
+  const createArgs = [
+    "api",
+    `repos/${targetRepo()}/issues/${options.item.number}/comments`,
+    "--method",
+    "POST",
+    "--input",
+    payload,
+  ];
   const created = reviewCommentFromMutationResponse(
     ghObservedMutationCommand({
       identity: `review_lease_post:${options.item.number}:${leaseOwner}`,
@@ -20715,8 +20701,7 @@ function reapExpiredDedicatedReviewStartLeases(
   itemNumber: number,
   dedicatedLeaseComments: Record<string, unknown>[],
   nowMs: number,
-): Set<number> {
-  const reapedCommentIds = new Set<number>();
+): void {
   const expired = expiredReviewStartStatusLeases({
     comments: dedicatedLeaseComments,
     itemNumber,
@@ -20739,7 +20724,6 @@ function reapExpiredDedicatedReviewStartLeases(
       console.error(
         `[review] reaped expired review lease comment ${lease.commentId} for #${itemNumber} (lease expired ${lease.expiresAt})`,
       );
-      reapedCommentIds.add(lease.commentId);
     } catch (error) {
       // A failed reap must never block acquiring the new lease.
       console.error(
@@ -20749,7 +20733,6 @@ function reapExpiredDedicatedReviewStartLeases(
       );
     }
   }
-  return reapedCommentIds;
 }
 
 const REVIEW_PLACEHOLDER_BODY_PATTERN = /^ClawSweeper status: review started\./i;

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -19863,6 +19863,7 @@ function issueReviewCommentState(
   number: number,
   fallbackBodies: readonly string[] = [],
 ): {
+  comments: Record<string, unknown>[];
   reviewComment: Record<string, unknown> | undefined;
   leaseComment: Record<string, unknown> | undefined;
   leaseComments: Record<string, unknown>[];
@@ -19885,6 +19886,7 @@ function issueReviewCommentState(
       : []),
   ];
   return {
+    comments,
     reviewComment,
     leaseComment: leaseComments[0],
     leaseComments,
@@ -20769,24 +20771,16 @@ export function supersededReviewPlaceholderCommentIds(options: {
 
 function cleanupSupersededReviewPlaceholderComments(options: {
   number: number;
+  // Pre-mutation snapshot from the apply flow; the sweep must not refetch the
+  // comment list after the durable-comment mutation (API-budget invariant).
+  comments: readonly Record<string, unknown>[];
   keepCommentIds: ReadonlySet<number>;
 }): void {
-  let ids: number[];
-  try {
-    ids = supersededReviewPlaceholderCommentIds({
-      number: options.number,
-      comments: fetchIssueReviewComments(options.number),
-      keepCommentIds: options.keepCommentIds,
-    });
-  } catch (error) {
-    if (error instanceof GitHubRuntimeBudgetError) throw error;
-    console.error(
-      `[apply] could not enumerate superseded review placeholder comments for #${options.number}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return;
-  }
+  const ids = supersededReviewPlaceholderCommentIds({
+    number: options.number,
+    comments: options.comments,
+    keepCommentIds: options.keepCommentIds,
+  });
   for (const id of ids) {
     try {
       ghObservedMutationCommand({
@@ -26969,6 +26963,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         if (!headBefore || headBefore !== headAfter || headAfter !== initialReviewHeadSha) {
           return {
             comment: refreshed.reviewComment,
+            comments: refreshed.comments,
             leaseComments: refreshed.leaseComments,
             headSha: headAfter,
             lease: null,
@@ -26979,6 +26974,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         if (item.kind === "issue" && reportReviewRevision && headAfter !== reportReviewRevision) {
           return {
             comment: refreshed.reviewComment,
+            comments: refreshed.comments,
             leaseComments: refreshed.leaseComments,
             headSha: headAfter,
             lease: null,
@@ -26986,11 +26982,14 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             blockReason: `live issue source revision ${headAfter} differs from reviewed revision ${reportReviewRevision}`,
           };
         }
-        return reviewStartLeaseStateForComments(
-          refreshed.leaseComments,
-          refreshed.reviewComment,
-          headAfter,
-        );
+        return {
+          ...reviewStartLeaseStateForComments(
+            refreshed.leaseComments,
+            refreshed.reviewComment,
+            headAfter,
+          ),
+          comments: refreshed.comments,
+        };
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         const detail = trimMiddle(
@@ -26999,6 +26998,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         );
         return {
           comment: undefined,
+          comments: [] as Record<string, unknown>[],
           leaseComments: [],
           headSha: "",
           lease: null,
@@ -28996,6 +28996,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             }
             cleanupSupersededReviewPlaceholderComments({
               number,
+              comments: latestLeaseState.comments,
               keepCommentIds: placeholderKeepCommentIds,
             });
           } catch (error) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -20596,21 +20596,40 @@ function postReviewStartStatusComment(options: {
   if (initialLease) {
     return heldReviewStartStatusCommentResult(initialLease.expiresAt, false);
   }
-  reapExpiredDedicatedReviewStartLeases(
+  const reapedLeaseCommentIds = reapExpiredDedicatedReviewStartLeases(
     options.item.number,
     initialState.dedicatedLeaseComments,
     startedAtMs,
   );
   const body = renderReviewStartStatusComment(leaseOptions);
   const payload = writeCommentPayload(options.item.number, body);
-  const createArgs = [
-    "api",
-    `repos/${targetRepo()}/issues/${options.item.number}/comments`,
-    "--method",
-    "POST",
-    "--input",
-    payload,
-  ];
+  // A leftover bot placeholder from a superseded attempt (typically an
+  // unexpired lease for an older head revision) is refreshed in place instead
+  // of stacking one new "review started" comment per retry. Lowest server id
+  // wins lease election, so reusing the oldest surviving comment also keeps
+  // the refreshed lease electable.
+  const reusableLeaseCommentId = initialState.dedicatedLeaseComments
+    .map((comment) => commentId(comment))
+    .filter((id): id is number => id !== null && !reapedLeaseCommentIds.has(id))
+    .sort((left, right) => left - right)[0];
+  const createArgs =
+    reusableLeaseCommentId === undefined
+      ? [
+          "api",
+          `repos/${targetRepo()}/issues/${options.item.number}/comments`,
+          "--method",
+          "POST",
+          "--input",
+          payload,
+        ]
+      : [
+          "api",
+          `repos/${targetRepo()}/issues/comments/${reusableLeaseCommentId}`,
+          "--method",
+          "PATCH",
+          "--input",
+          payload,
+        ];
   const created = reviewCommentFromMutationResponse(
     ghObservedMutationCommand({
       identity: `review_lease_post:${options.item.number}:${leaseOwner}`,
@@ -20696,7 +20715,8 @@ function reapExpiredDedicatedReviewStartLeases(
   itemNumber: number,
   dedicatedLeaseComments: Record<string, unknown>[],
   nowMs: number,
-): void {
+): Set<number> {
+  const reapedCommentIds = new Set<number>();
   const expired = expiredReviewStartStatusLeases({
     comments: dedicatedLeaseComments,
     itemNumber,
@@ -20719,10 +20739,85 @@ function reapExpiredDedicatedReviewStartLeases(
       console.error(
         `[review] reaped expired review lease comment ${lease.commentId} for #${itemNumber} (lease expired ${lease.expiresAt})`,
       );
+      reapedCommentIds.add(lease.commentId);
     } catch (error) {
       // A failed reap must never block acquiring the new lease.
       console.error(
         `[review] could not reap expired review lease comment ${lease.commentId} for #${itemNumber}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  return reapedCommentIds;
+}
+
+const REVIEW_PLACEHOLDER_BODY_PATTERN = /^ClawSweeper status: review started\./i;
+
+export function supersededReviewPlaceholderCommentIds(options: {
+  number: number;
+  comments: readonly Record<string, unknown>[];
+  keepCommentIds: ReadonlySet<number>;
+  nowMs?: number;
+}): number[] {
+  const nowMs = options.nowMs ?? Date.now();
+  const ids: number[] = [];
+  for (const comment of options.comments) {
+    const id = commentId(comment);
+    if (id === null || options.keepCommentIds.has(id)) continue;
+    if (!canPatchReviewComment(comment)) continue;
+    const body = (commentBody(comment) ?? "").trimStart();
+    // Placeholder bodies start with the status line; the durable review
+    // comment never does, and its marker is an extra guard against deletion.
+    if (!REVIEW_PLACEHOLDER_BODY_PATTERN.test(body)) continue;
+    if (body.includes(reviewCommentMarker(options.number))) continue;
+    // An unexpired lease may belong to a racing worker on a newer revision;
+    // only provably superseded placeholders (expired lease or marker-less
+    // legacy body) are swept after the durable review comment is published.
+    const marker = body.match(/<!--\s*clawsweeper-review-status:started\b([^>]*)-->/i);
+    if (marker) {
+      const expiresAtMs = Date.parse(marker[1]?.match(/\blease_expires_at=([^\s>]+)/i)?.[1] ?? "");
+      if (Number.isFinite(expiresAtMs) && expiresAtMs >= nowMs) continue;
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
+function cleanupSupersededReviewPlaceholderComments(options: {
+  number: number;
+  keepCommentIds: ReadonlySet<number>;
+}): void {
+  let ids: number[];
+  try {
+    ids = supersededReviewPlaceholderCommentIds({
+      number: options.number,
+      comments: fetchIssueReviewComments(options.number),
+      keepCommentIds: options.keepCommentIds,
+    });
+  } catch (error) {
+    if (error instanceof GitHubRuntimeBudgetError) throw error;
+    console.error(
+      `[apply] could not enumerate superseded review placeholder comments for #${options.number}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+  for (const id of ids) {
+    try {
+      ghObservedMutationCommand({
+        identity: `review_placeholder_sweep:${options.number}:${id}`,
+        args: ["api", `repos/${targetRepo()}/issues/comments/${id}`, "--method", "DELETE"],
+      });
+      console.error(
+        `[apply] deleted superseded review placeholder comment ${id} for #${options.number}`,
+      );
+    } catch (error) {
+      if (error instanceof GitHubRuntimeBudgetError) throw error;
+      // A failed sweep must never fail the publish; the next apply retries it.
+      console.error(
+        `[apply] could not delete superseded review placeholder comment ${id} for #${options.number}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -28902,6 +28997,24 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
               allowedSelfMutationUpdatedAts.add(syncedCommentUpdatedAt);
             }
             syncReasons.push("updated durable Codex review comment");
+            // The durable review comment is now published, so stale "review
+            // started" placeholders from failed earlier attempts are clutter.
+            const placeholderKeepCommentIds = new Set<number>();
+            const syncedCommentId = commentId(syncedComment);
+            if (syncedCommentId !== null) placeholderKeepCommentIds.add(syncedCommentId);
+            // Closures assign the active lease, so read it through a cast to
+            // defeat TypeScript's stale null narrowing at this use site.
+            const heldMutationLease = activeApplyMutationLease as {
+              itemNumber: number;
+              lease: AcquiredReviewStartLease;
+            } | null;
+            if (heldMutationLease?.itemNumber === number) {
+              placeholderKeepCommentIds.add(heldMutationLease.lease.commentId);
+            }
+            cleanupSupersededReviewPlaceholderComments({
+              number,
+              keepCommentIds: placeholderKeepCommentIds,
+            });
           } catch (error) {
             const commentAuthError = isGitHubRequiresAuthenticationError(error);
             if (!commentAuthError && !isLockedConversationCommentError(error)) throw error;

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -11,6 +11,7 @@ import {
   renderReviewStartStatusComment,
   reviewAutomationMarkersFromReport,
   reviewStartLeaseWinnerCommentIdForTest,
+  supersededReviewPlaceholderCommentIds,
   shouldPreserveReviewStartLease,
   withReviewStartStatusLease,
 } from "../dist/clawsweeper.js";
@@ -1233,4 +1234,97 @@ Full review comments:
 
   assert.match(markers, /clawsweeper-verdict:needs-human/);
   assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
+});
+
+test("superseded review placeholder sweep deletes only stale bot placeholder comments", () => {
+  const nowMs = Date.parse("2026-07-18T22:13:00.000Z");
+  const bot = { login: "openclaw-clawsweeper[bot]" };
+  const expiredPlaceholder = renderReviewStartStatusComment({
+    number: 110918,
+    kind: "pull_request",
+    title: "fix webhook limiter",
+    headSha: "0123456789abcdef0123456789abcdef01234567",
+    startedAt: "2026-07-18T21:41:00.000Z",
+    leaseExpiresAt: "2026-07-18T22:11:00.000Z",
+  });
+  const freshPlaceholder = renderReviewStartStatusComment({
+    number: 110918,
+    kind: "pull_request",
+    title: "fix webhook limiter",
+    headSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    startedAt: "2026-07-18T22:06:00.000Z",
+    leaseExpiresAt: "2026-07-18T22:36:00.000Z",
+  });
+  const comments = [
+    {
+      id: 1,
+      user: bot,
+      body: "Codex review: keep open.\n\n<!-- clawsweeper-review item=110918 -->",
+    },
+    { id: 2, user: bot, body: expiredPlaceholder },
+    { id: 3, user: bot, body: freshPlaceholder },
+    {
+      id: 4,
+      user: bot,
+      body: "ClawSweeper status: review started.\n\nLegacy placeholder without a lease marker.",
+    },
+    { id: 5, user: { login: "steipete" }, body: expiredPlaceholder },
+    { id: 6, user: bot, body: expiredPlaceholder },
+  ];
+
+  assert.deepEqual(
+    supersededReviewPlaceholderCommentIds({
+      number: 110918,
+      comments,
+      keepCommentIds: new Set([6]),
+      nowMs,
+    }),
+    [2, 4],
+  );
+});
+
+test("superseded review placeholder sweep never selects the durable review comment", () => {
+  const nowMs = Date.parse("2026-07-18T22:13:00.000Z");
+  const comments = [
+    {
+      id: 7,
+      user: { login: "clawsweeper[bot]" },
+      body: [
+        "ClawSweeper status: review started.",
+        "",
+        "Codex review: keep open.",
+        "",
+        "<!-- clawsweeper-review item=110918 -->",
+      ].join("\n"),
+    },
+  ];
+
+  assert.deepEqual(
+    supersededReviewPlaceholderCommentIds({
+      number: 110918,
+      comments,
+      keepCommentIds: new Set(),
+      nowMs,
+    }),
+    [],
+  );
+});
+
+test("review lease retries refresh a surviving placeholder instead of posting a new one", () => {
+  const source = readFileSync("src/clawsweeper.ts", "utf8");
+  const functionStart = source.indexOf("function postReviewStartStatusComment");
+  const postStart = source.slice(
+    functionStart,
+    source.indexOf("function deleteOwnedDedicatedReviewStartLease", functionStart),
+  );
+  assert.match(postStart, /const reapedLeaseCommentIds = reapExpiredDedicatedReviewStartLeases\(/);
+  assert.match(postStart, /reusableLeaseCommentId/);
+  assert.match(postStart, /issues\/comments\/\$\{reusableLeaseCommentId\}/);
+  assert.match(postStart, /"PATCH"/);
+  assert.match(postStart, /issues\/\$\{options\.item\.number\}\/comments/);
+
+  const applyStart = source.indexOf('syncReasons.push("updated durable Codex review comment")');
+  assert.ok(applyStart >= 0);
+  const applyWindow = source.slice(applyStart, applyStart + 1200);
+  assert.match(applyWindow, /cleanupSupersededReviewPlaceholderComments\(\{/);
 });

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -1310,18 +1310,17 @@ test("superseded review placeholder sweep never selects the durable review comme
   );
 });
 
-test("review lease retries refresh a surviving placeholder instead of posting a new one", () => {
+test("publishing the durable review comment sweeps superseded placeholders", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
   const functionStart = source.indexOf("function postReviewStartStatusComment");
   const postStart = source.slice(
     functionStart,
     source.indexOf("function deleteOwnedDedicatedReviewStartLease", functionStart),
   );
-  assert.match(postStart, /const reapedLeaseCommentIds = reapExpiredDedicatedReviewStartLeases\(/);
-  assert.match(postStart, /reusableLeaseCommentId/);
-  assert.match(postStart, /issues\/comments\/\$\{reusableLeaseCommentId\}/);
-  assert.match(postStart, /"PATCH"/);
+  // Lease acquisition must keep POSTing a fresh comment per contender: the
+  // lowest-server-id election needs distinct ids, so no in-place PATCH reuse.
   assert.match(postStart, /issues\/\$\{options\.item\.number\}\/comments/);
+  assert.doesNotMatch(postStart, /"PATCH"/);
 
   const applyStart = source.indexOf('syncReasons.push("updated durable Codex review comment")');
   assert.ok(applyStart >= 0);


### PR DESCRIPTION
Stops stale "ClawSweeper status: review started." placeholder comments from piling up on reviewed items.

Motivating case: openclaw/openclaw#110918 (2026-07-18) — after the durable review comment (created 19:32Z) was updated in place at 22:13Z, two stale placeholders from failed retry attempts (21:41Z, 22:06Z) remained as separate comments. Correctness was unaffected (placeholder recovery keys on the latest bot comment), but the clutter is user-visible on busy PRs.

## Change

After `upsertReviewComment` successfully publishes the durable review comment in the apply flow, `cleanupSupersededReviewPlaceholderComments` deletes superseded placeholder comments via `DELETE /repos/{owner}/{repo}/issues/comments/{id}` — the same issues:write surface the existing expired-lease reap already uses.

Safety rails (`supersededReviewPlaceholderCommentIds`):

- only comments from the ClawSweeper bot login set (`canPatchReviewComment`);
- only bodies that *start* with the placeholder status line — the durable review comment never does, and its `<!-- clawsweeper-review item=N -->` marker is an additional exclusion;
- skips the just-upserted durable comment and the currently held apply mutation lease comment;
- keeps any placeholder with an unexpired lease (it may belong to a racing worker on a newer revision); only provably superseded placeholders — expired lease or marker-less legacy body — are deleted;
- sweep failures log and never fail the publish (runtime-budget errors still propagate).

### Why no placeholder reuse on retry

Refreshing a surviving placeholder in place (PATCH) was considered and rejected: the review-start lease election picks the lowest server-assigned comment id, so it needs a distinct comment per contender. Two racing workers PATCHing the same comment could both validate ownership and both proceed. Acquisition keeps POSTing a fresh comment; a source comment and a structural test now pin that down. Accumulation stays bounded because every durable-comment publish sweeps the leftovers (a placeholder's lease TTL is ~review timeout + 10 min, so earlier failed attempts are provably expired by then).

## Tests

- `supersededReviewPlaceholderCommentIds` unit coverage: deletes expired/legacy bot placeholders only; keeps unexpired leases, non-bot authors, keep-listed ids, and never the durable review comment (including a durable body that opens with the placeholder line).
- Structural test: lease acquisition still POSTs per contender (no PATCH reuse), and the apply publish path calls the sweep right after the durable comment sync.

Build, lint, format, and all touched suites green (`review-comment-rendering`, `clawsweeper-action-ledger`, `review-placeholder-recovery`). Full `pnpm run check` runs tripped only the known host-load timing flake in `failed-review-retry` (2.2s runtime-budget test, host load avg 200+ from concurrent workers; same class #709 hardens) — passes on isolated rerun. Autoreview (Codex) clean on the branch diff.

Changelog: one-line Fixed entry under Unreleased.
