### PR TITLE
fix(repair): retry state-repo pushes on concurrent-writer rejection

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -174,8 +174,10 @@ function safeGitDisplayAction(action: string | undefined): string {
     case "checkout":
     case "cat-file":
     case "clean":
+    case "log":
     case "ls-files":
     case "ls-tree":
+    case "merge-base":
     case "mktree":
     case "push":
     case "read-tree":
@@ -1256,8 +1258,20 @@ export function pushCommit(options: {
       continue;
     }
     const remoteCommit = runGit(["rev-parse", `${remote}/${branch}`], { quiet: true }).trim();
-    const statusMerges = planSweepStatusMerges({ localCommit, remoteCommit });
-    const ledgerMerge = planCommentRouterLedgerMerge({ localCommit, remoteCommit });
+    const mergeBase = spawnGit(["merge-base", localCommit, remoteCommit], { quiet: true });
+    if (mergeBase.status !== 0) {
+      // A shallow state checkout fetches racing pushes with --depth=1, so the
+      // new remote head can share no local ancestry. Rebasing is impossible;
+      // hand the race back to the caller, whose rebuild path re-applies this
+      // publish directly on the fetched remote head.
+      console.log(
+        `No common Git base with ${remote}/${branch} after a lost push race; deferring to a remote-head rebuild`,
+      );
+      return false;
+    }
+    const baseCommit = mergeBase.stdout.trim();
+    const statusMerges = planSweepStatusMerges({ baseCommit, localCommit, remoteCommit });
+    const ledgerMerge = planCommentRouterLedgerMerge({ baseCommit, localCommit, remoteCommit });
     const rebaseArgs =
       rebaseStrategy === "theirs" || rebaseStrategy === "apply-records"
         ? ["rebase", "-X", "theirs", `${remote}/${branch}`]

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -436,6 +436,57 @@ test("publishMainCommit preserves latest health when a second race forces commit
   assert.deepEqual(merged.last_close_apply_health, secondCloseHealth);
 });
 
+test("publishMainCommit survives a shallow-checkout push race without a common Git base", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  write(path.join(seed, "results/spam-scanner.json"), '{"scans":0}\n');
+  write(path.join(seed, "results/other.txt"), "remote\n");
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial"], seed);
+  run("git", ["push", "origin", "HEAD:main"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+
+  // Production state checkouts are shallow, so the racing writer's commits
+  // arrive through a --depth=1 fetch that shares no ancestry with local HEAD.
+  run("git", ["clone", "--depth", "1", `file://${origin}`, work], root);
+  configureUser(work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, "results/other.txt"), "remote update one\n");
+  run("git", ["commit", "-am", "remote update one"], other);
+  write(path.join(other, "results/other.txt"), "remote update two\n");
+  run("git", ["commit", "-am", "remote update two"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+
+  write(path.join(work, "results/spam-scanner.json"), '{"scans":1}\n');
+  const result = withCwd(work, () =>
+    publishMainCommit({
+      message: "chore: record ClawSweeper spam scan",
+      paths: ["results/spam-scanner.json"],
+      maxAttempts: 1,
+      pushAttempts: 1,
+      rebaseStrategy: "theirs",
+    }),
+  );
+
+  assert.equal(result, "committed");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:results/spam-scanner.json"], root),
+    '{"scans":1}\n',
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:results/other.txt"], root),
+    "remote update two\n",
+  );
+});
+
 test("publishMainCommit fails closed when a racing sweep status is malformed", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");
@@ -1231,7 +1282,7 @@ test("reconcile-records fails closed when state and remote have no common base",
           ),
         lines,
       ),
-    /git command <redacted-args> exited 1/,
+    /git merge-base <redacted-args> exited 1/,
   );
   assert.equal(
     lines.some((line) => line.includes("Git publish failure: phase=prepare")),


### PR DESCRIPTION
## Problem

The spam scanner workflow failed twice on 2026-07-19 while publishing its audit to the state repo:

- https://github.com/openclaw/clawsweeper/actions/runs/29701094002 (19:41Z)
- https://github.com/openclaw/clawsweeper/actions/runs/29702697623 (20:32Z)

Both logs show the same shape: the state push loses a race to a concurrent workflow (`error: failed to push some refs to 'https://github.com/openclaw/clawsweeper-state'`), and then the publish aborts with

```
Git publish failure: phase=push processes=15 duration_ms=6484 error=git command <redacted-args> exited 1
```

## Root cause

`publishMainCommit` already has bounded, jittered retry loops for lost push races. The failure is in the recovery path itself: after the rejected push, `pushCommit` fetches the new remote head and plans sweep-status/ledger merges, which runs `git merge-base <local> <remote>` through `runGit` without `allowFailure`.

Production state checkouts are shallow, and `fetchPublishRemote` deliberately preserves that with `--depth=1`. A depth-1 fetch of the racing writer's tip records it as a new shallow boundary, so it shares no visible ancestry with local HEAD. `merge-base` exits 1 with no output, `runGit` throws, and the exception escapes every retry loop. The metrics line from the failed runs (`merge-base:1`, displayed as the anonymous `git command`) confirms exactly this sequence.

## Fix

In `pushCommit`'s post-rejection recovery, probe the merge base with `spawnGit` instead of `runGit`. When there is no common base (the shallow-race signature), log it and return `false` instead of throwing. The caller's existing bounded retry loop (`maxAttempts`, jittered backoff, `Git publish failure:` diagnostic preserved) then falls through to `rebuildPublishCommit`, which re-applies the publish directly on the fetched remote head - that path never needs shared ancestry (its merge base is the source commit's parent, always local). Genuine auth/network push failures behave as before, and the reconcile-records no-common-base publish still fails closed.

Also adds `log` and `merge-base` to the redaction display safelist so future failures name the failing git action instead of `git command`.

All callers of the shared helper benefit: every workflow publishing through `repair:publish-main` (spam-scanner, sweep, repair-publish-results, comment-router, cluster intake/worker, self-heal, finalize-open-prs, commit-review, proof-nudges, issue-implementation intake, conflict self-heal) plus in-process users of `publishMainCommit`.

## Validation

- New regression test `publishMainCommit survives a shallow-checkout push race without a common Git base` reproduces production exactly: shallow (depth-1) checkout, concurrent two-commit remote push, `theirs` strategy. Without the fix it fails with the production error (`Git publish failure: phase=push ... error=git command <redacted-args> exited 1`); with the fix it publishes both the local and the concurrent changes.
- `pnpm run build:all` plus the full `test/repair/git-publish.test.ts` suite.
- `pnpm run check` locally (one pre-existing host-specific failure: the immutable-ledger server-merge test fails identically on unmodified `main` on macOS because `includeIf.gitdir` does not match the symlinked tmpdir realpath; unrelated to this diff).

Internal-only reliability fix; no changelog entry.
