### PR TITLE
fix(repair): recover unavailable state objects in ledger publish

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -435,12 +435,42 @@ function pushImmutableActionLedgerCommit(options: {
   const previousCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
   const protectedWorktreePaths = captureDirtyWorktreePaths();
   let candidateCommit = options.sourceCommit;
+  let unavailableObjectRecoveryUsed = false;
   for (let attempt = 1; attempt <= pushBudget; attempt += 1) {
-    if (
-      spawnGit(["push", options.remote, `${candidateCommit}:${options.branch}`], {
-        displayArgs: ["push", options.remote, `<commit>:${options.branch}`],
-      }).status === 0
-    ) {
+    const pushArgs = ["push", options.remote, `${candidateCommit}:${options.branch}`];
+    const pushDisplayArgs = ["push", options.remote, `<commit>:${options.branch}`];
+    let pushResult = spawnGit(pushArgs, { displayArgs: pushDisplayArgs });
+    if (pushResult.status !== 0 && unavailableGitObjectIds(pushResult).length > 0) {
+      if (unavailableObjectRecoveryUsed) {
+        throw gitRunError(pushResult, pushArgs, pushDisplayArgs);
+      }
+      recoverUnavailableGitObjects(options.remote, options.branch, pushResult);
+      unavailableObjectRecoveryUsed = true;
+      const rebuilt = rebuildImmutableActionLedgerCommit({
+        remote: options.remote,
+        branch: options.branch,
+        message: options.message,
+        paths: options.paths,
+        sourceCommit: options.sourceCommit,
+      });
+      candidateCommit = rebuilt.commit;
+      if (rebuilt.result === "unchanged") {
+        finalizeImmutableActionLedgerCheckout({
+          previousCommit,
+          publishedCommit: candidateCommit,
+          paths: options.paths,
+          protectedWorktreePaths,
+        });
+        return "unchanged";
+      }
+      pushResult = spawnGit(["push", options.remote, `${candidateCommit}:${options.branch}`], {
+        displayArgs: pushDisplayArgs,
+      });
+      if (pushResult.status !== 0 && unavailableGitObjectIds(pushResult).length > 0) {
+        throw gitRunError(pushResult, pushArgs, pushDisplayArgs);
+      }
+    }
+    if (pushResult.status === 0) {
       finalizeImmutableActionLedgerCheckout({
         previousCommit,
         publishedCommit: candidateCommit,
@@ -474,13 +504,27 @@ function pushImmutableActionLedgerCommit(options: {
     // Build only the affected ancestor trees. The state checkout has hundreds
     // of thousands of entries, so rebuilding its full index is slower than the
     // production write rate and guarantees that every retry starts stale.
-    const rebuilt = rebuildImmutableActionLedgerCommit({
-      remote: options.remote,
-      branch: options.branch,
-      message: options.message,
-      paths: options.paths,
-      sourceCommit: options.sourceCommit,
-    });
+    let rebuilt;
+    try {
+      rebuilt = rebuildImmutableActionLedgerCommit({
+        remote: options.remote,
+        branch: options.branch,
+        message: options.message,
+        paths: options.paths,
+        sourceCommit: options.sourceCommit,
+      });
+    } catch (error) {
+      if (unavailableObjectRecoveryUsed || unavailableGitObjectIds(error).length === 0) throw error;
+      recoverUnavailableGitObjects(options.remote, options.branch, error);
+      unavailableObjectRecoveryUsed = true;
+      rebuilt = rebuildImmutableActionLedgerCommit({
+        remote: options.remote,
+        branch: options.branch,
+        message: options.message,
+        paths: options.paths,
+        sourceCommit: options.sourceCommit,
+      });
+    }
     candidateCommit = rebuilt.commit;
     if (rebuilt.result === "unchanged") {
       finalizeImmutableActionLedgerCheckout({
@@ -493,6 +537,63 @@ function pushImmutableActionLedgerCommit(options: {
     }
   }
   throw new Error(`Failed to publish commit after ${pushBudget} push attempts`);
+}
+
+function unavailableGitObjectIds(value: unknown): string[] {
+  const message =
+    typeof value === "object" && value && "stderr" in value
+      ? `${String(value.stderr ?? "")}\n${String("stdout" in value ? value.stdout : "")}`
+      : errorMessage(value);
+  return [
+    ...new Set(
+      [...message.matchAll(/object ([a-f0-9]{40,64}) is unavailable/gi)].map((match) =>
+        match[1]!.toLowerCase(),
+      ),
+    ),
+  ];
+}
+
+function recoverUnavailableGitObjects(remote: string, branch: string, failure: unknown): void {
+  const objectIds = unavailableGitObjectIds(failure);
+  console.log(
+    `Recovering ${objectIds.length || "unidentified"} unavailable Git object(s) from ${remote}`,
+  );
+  if (objectIds.length > 0) {
+    objectIds.every(
+      (objectId) =>
+        spawnGit(["fetch", remote, objectId], {
+          quiet: true,
+          timeout: PUBLISH_FETCH_TIMEOUT_MS,
+        }).status === 0,
+    );
+  }
+
+  const shallow = isShallowRepository();
+  const refetchDepth = shallow ? ["--depth=1"] : [];
+  const refetched = spawnGit(["fetch", "--refetch", ...refetchDepth, remote, branch], {
+    quiet: true,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
+  if (refetched.status === 0 && gitObjectIdsAvailable(objectIds)) return;
+  if (!shallow) return;
+  const deepened = spawnGit(["fetch", "--deepen=1", remote, branch], {
+    quiet: true,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
+  if (deepened.status === 0 && (objectIds.length === 0 || gitObjectIdsAvailable(objectIds))) {
+    return;
+  }
+  if (!isShallowRepository()) return;
+  spawnGit(["fetch", "--unshallow", remote, branch], {
+    quiet: true,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
+}
+
+function gitObjectIdsAvailable(objectIds: readonly string[]): boolean {
+  return objectIds.every(
+    (objectId) => spawnGit(["cat-file", "-e", objectId], { quiet: true }).status === 0,
+  );
 }
 
 function immutableLedgerStateRepository(): string | null {
@@ -720,6 +821,54 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message.replace(/[\r\n]+/g, " ") : String(error);
 }
 
+function gitRunError(
+  result: GitRunResult,
+  args: readonly string[],
+  displayArgs: readonly string[] = args,
+): Error {
+  const detail =
+    result.stderr ||
+    result.stdout ||
+    `${formatGitDisplayCommand(displayArgs)} exited ${result.status}`;
+  return new Error(detail.trim());
+}
+
+function mergeBaseWithShallowRecovery(
+  left: string,
+  right: string,
+  remote: string,
+  branch: string,
+): { base: string; recoveredShallowMiss: boolean } {
+  const args = ["merge-base", left, right];
+  let result = spawnGit(args, { quiet: true });
+  if (result.status === 0) {
+    return { base: result.stdout.trim(), recoveredShallowMiss: false };
+  }
+  if (result.status !== 1 || !isShallowRepository()) throw gitRunError(result, args);
+
+  spawnGit(["fetch", "--deepen=32", remote, branch], {
+    quiet: true,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
+  result = spawnGit(args, { quiet: true });
+  if (result.status === 0) {
+    return { base: result.stdout.trim(), recoveredShallowMiss: true };
+  }
+  if (result.status !== 1) throw gitRunError(result, args);
+
+  if (isShallowRepository()) {
+    spawnGit(["fetch", "--unshallow", remote, branch], {
+      quiet: true,
+      timeout: PUBLISH_FETCH_TIMEOUT_MS,
+    });
+    result = spawnGit(args, { quiet: true });
+    if (result.status === 0) {
+      return { base: result.stdout.trim(), recoveredShallowMiss: true };
+    }
+  }
+  throw gitRunError(result, args);
+}
+
 function prepareReconciliationStateRoot(
   remote: string,
   branch: string,
@@ -739,9 +888,14 @@ function prepareReconciliationStateRoot(
   if (spawnGit(["merge-base", "--is-ancestor", "HEAD", remoteRef], { quiet: true }).status === 0) {
     return;
   }
-  const semanticBase = runGit(["merge-base", "HEAD", remoteRef], { quiet: true }).trim();
+  const semanticBase = mergeBaseWithShallowRecovery("HEAD", remoteRef, remote, branch);
+  if (semanticBase.recoveredShallowMiss) {
+    console.log(
+      `Recovered the common Git base with ${remoteRef} after hydrating the shallow state checkout`,
+    );
+  }
   console.log("Discarding an unpublished reconciliation checkpoint before retry");
-  runGit(["reset", "--hard", semanticBase]);
+  runGit(["reset", "--hard", semanticBase.base]);
 }
 
 function reconciliationTupleKeysForCommit(sourceCommit: string): string[] {
@@ -774,7 +928,14 @@ function publishReconciliationChunks(options: {
     const remoteRef = `${options.remote}/${options.branch}`;
     const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
     const allowedTupleKeys = new Set(tupleKeys);
-    if (!rebuildReconciliationCommit(remoteRef, options.sourceCommit, allowedTupleKeys)) {
+    if (
+      !rebuildReconciliationCommit(
+        options.remote,
+        options.branch,
+        options.sourceCommit,
+        allowedTupleKeys,
+      )
+    ) {
       throw new Error(`Failed to build reconciliation checkpoint ${index + 1}/${chunks.length}`);
     }
     const checkpointCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
@@ -1248,7 +1409,8 @@ export function pushCommit(options: {
       }
       if (
         !rebuildReconciliationCommit(
-          remoteRef,
+          remote,
+          branch,
           options.reconciliationSourceCommit,
           options.reconciliationTupleKeys,
         )
@@ -1304,7 +1466,16 @@ function reconciliationChangesOverlap(
   allowedTupleKeys?: ReadonlySet<string>,
 ): boolean {
   const sourceCommit = reconciliationSourceCommit ?? "HEAD";
-  const baseCommit = runGit(["merge-base", sourceCommit, remoteRef], { quiet: true }).trim();
+  const args = ["merge-base", sourceCommit, remoteRef];
+  const mergeBase = spawnGit(args, { quiet: true });
+  if (mergeBase.status !== 0) {
+    if (mergeBase.status !== 1 || !isShallowRepository()) throw gitRunError(mergeBase, args);
+    console.log(
+      `No common Git base with ${remoteRef} after a shallow fetch; deferring overlap detection to a remote-head rebuild`,
+    );
+    return true;
+  }
+  const baseCommit = mergeBase.stdout.trim();
   const localKeys = recordTupleKeysForPaths(changedPathsBetween(baseCommit, sourceCommit));
   const remoteKeys = recordTupleKeysForPaths(changedPathsBetween(baseCommit, remoteRef), true);
   for (const key of localKeys) {
@@ -1327,12 +1498,18 @@ function recordTupleKeysForPaths(paths: readonly string[], ignoreUnsupported = f
 }
 
 function rebuildReconciliationCommit(
-  remoteRef: string,
+  remote: string,
+  branch: string,
   reconciliationSourceCommit?: string,
   allowedTupleKeys?: ReadonlySet<string>,
 ): boolean {
+  const remoteRef = `${remote}/${branch}`;
   const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
-  const baseCommit = runGit(["merge-base", sourceCommit, remoteRef]).trim();
+  const mergeBase = mergeBaseWithShallowRecovery(sourceCommit, remoteRef, remote, branch);
+  const baseCommit = mergeBase.base;
+  if (mergeBase.recoveredShallowMiss) {
+    console.log(`Rebuilding reconciliation directly on ${remoteRef} after a shallow fetch`);
+  }
   const localPaths = changedPathsBetween(baseCommit, sourceCommit);
   const localIdentities = new Map<string, RecordTupleIdentity>();
   for (const path of localPaths) {
@@ -1950,13 +2127,16 @@ function fetchPublishRemote(remote: string, branch: string, options: GitRunOptio
   // Server-side immutable-ledger merges left merge-heavy ancestry on the state
   // branch. Preserve an existing shallow boundary without truncating complete
   // repositories whose reconciliation logic still needs full ancestry.
-  const shallow =
-    runGit(["rev-parse", "--is-shallow-repository"], { quiet: true }).trim() === "true";
+  const shallow = isShallowRepository();
   const depthArgs = shallow ? ["--depth=1"] : [];
   return runGit(["fetch", ...depthArgs, remote, branch], {
     ...options,
     timeout: PUBLISH_FETCH_TIMEOUT_MS,
   });
+}
+
+function isShallowRepository(): boolean {
+  return runGit(["rev-parse", "--is-shallow-repository"], { quiet: true }).trim() === "true";
 }
 
 export function uniqueNonEmpty(values: readonly string[]): string[] {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -106,7 +106,7 @@ test("publisher fetches share the bounded fetch helper", () => {
   assert.match(source, /const PUBLISH_FETCH_TIMEOUT_MS = 60_000/);
   assert.match(
     source,
-    /function fetchPublishRemote\([\s\S]*runGit\(\["rev-parse", "--is-shallow-repository"\][\s\S]*runGit\(\["fetch", \.\.\.depthArgs, remote, branch\], \{/,
+    /function fetchPublishRemote\([\s\S]*const shallow = isShallowRepository\(\)[\s\S]*runGit\(\["fetch", \.\.\.depthArgs, remote, branch\], \{/,
   );
   assert.equal(source.match(/runGit\(\["fetch"/g)?.length, 1);
 });
@@ -1294,6 +1294,250 @@ test("reconcile-records fails closed when state and remote have no common base",
   );
 });
 
+test("reconcile-records fails closed when shallow state and remote are truly unrelated", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-shallow-unrelated-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  writeRecordTuple(seed, {
+    number: 42,
+    marker: "remote base",
+    reviewedAt: "2026-07-19T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-19T22:59:00Z",
+  });
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial state"], seed);
+  run("git", ["push", "origin", "HEAD:state"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, state], root);
+  configureUser(state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "candidate update",
+    reviewedAt: "2026-07-19T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-19T23:01:00Z",
+  });
+
+  run("git", ["checkout", "--orphan", "replacement"], seed);
+  run("git", ["read-tree", "--empty"], seed);
+  fs.rmSync(path.join(seed, "records"), { force: true, recursive: true });
+  write(path.join(seed, "replacement.txt"), "replacement history\n");
+  run("git", ["add", "-A"], seed);
+  run("git", ["commit", "-m", "replace state history"], seed);
+  run("git", ["push", "--force", "origin", "HEAD:state"], seed);
+
+  const lines = [];
+  assert.throws(
+    () =>
+      captureConsoleLog(
+        () =>
+          withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+            withCwd(work, () =>
+              publishMainCommit({
+                message: "chore: reject unrelated shallow state",
+                paths: [recordsRoot],
+                maxAttempts: 1,
+                pushAttempts: 1,
+                rebaseStrategy: "reconcile-records",
+              }),
+            ),
+          ),
+        lines,
+      ),
+    /git merge-base <redacted-args> exited 1/,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("Git publish failure: phase=prepare")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:replacement.txt"], root),
+    "replacement history\n",
+  );
+});
+
+test("reconcile-records prepares a shallow state checkout from the remote head", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-shallow-prepare-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  writeRecordTuple(seed, {
+    number: 42,
+    marker: "remote base",
+    reviewedAt: "2026-07-19T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-19T22:59:00Z",
+  });
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial state"], seed);
+  run("git", ["push", "origin", "HEAD:state"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, state], root);
+  configureUser(state);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, "remote.txt"), "remote update one\n");
+  const remoteTuple = writeRecordTuple(other, {
+    number: 42,
+    marker: "remote winner",
+    reviewedAt: "2026-07-19T23:05:00.000Z",
+    itemUpdatedAt: "2026-07-19T23:04:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "remote update one"], other);
+  write(path.join(other, "remote.txt"), "remote update two\n");
+  run("git", ["commit", "-am", "remote update two"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "candidate close",
+    reviewedAt: "2026-07-19T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-19T23:02:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+  });
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: prepare shallow state",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
+      ),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  assert.equal(
+    lines.some((line) =>
+      line.includes(
+        "Recovered the common Git base with origin/state after hydrating the shallow state checkout",
+      ),
+    ),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
+    remoteTuple.primary,
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/closed/42.md`], root),
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:remote.txt"], root),
+    "remote update two\n",
+  );
+});
+
+test("reconcile-records rebuilds on a shallow remote head without local ancestry", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-shallow-reconcile-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  writeRecordTuple(seed, {
+    number: 42,
+    marker: "local base",
+    reviewedAt: "2026-07-19T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-19T22:59:00Z",
+  });
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial state"], seed);
+  run("git", ["push", "origin", "HEAD:main"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, work], root);
+  configureUser(work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  const remoteTuple = writeRecordTuple(other, {
+    number: 43,
+    marker: "remote update one",
+    reviewedAt: "2026-07-19T23:01:00.000Z",
+    itemUpdatedAt: "2026-07-19T23:00:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "remote update one"], other);
+  write(path.join(other, "remote.txt"), "remote update two\n");
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "remote update two"], other);
+  run("git", ["push", "origin", "HEAD:main"], other);
+
+  const localTuple = writeRecordTuple(work, {
+    number: 42,
+    marker: "local close",
+    reviewedAt: "2026-07-19T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-19T23:02:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+  });
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: reconcile shallow state",
+        paths: [recordsRoot],
+        maxAttempts: 1,
+        pushAttempts: 2,
+        rebaseStrategy: "reconcile-records",
+      }),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  assert.equal(
+    lines.some((line) => line.includes("deferring overlap detection to a remote-head rebuild")),
+    true,
+  );
+  assert.equal(
+    lines.some(
+      (line) => line === "Rebuilding reconciliation directly on origin/main after a shallow fetch",
+    ),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/closed/42.md`], root),
+    localTuple.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/43.md`], root),
+    remoteTuple.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
+    "remote update two\n",
+  );
+});
+
 test("reconcile-records bounds git subprocesses for a 516-tuple publish", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-scale-"));
   const origin = path.join(root, "origin.git");
@@ -1774,6 +2018,77 @@ test("publishMainCommit converges after production-sized immutable ledger races"
       `{"path":"${ledgerPath}"}\n`,
     );
   }
+});
+
+test("publishMainCommit refetches an unavailable immutable ledger object and retries once", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-missing-object-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const fakeBin = path.join(root, "bin");
+  const localPath =
+    "ledger/v1/import-bindings/events/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.json";
+  const remotePaths = [
+    "ledger/v1/import-bindings/events/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json",
+    "ledger/v1/import-bindings/events/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json",
+  ];
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  write(path.join(seed, "base.txt"), "base\n");
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial"], seed);
+  run("git", ["push", "origin", "HEAD:main"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, work], root);
+  configureUser(work);
+  run("git", ["config", "fetch.unpackLimit", "9999"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  for (const [index, remotePath] of remotePaths.entries()) {
+    write(path.join(other, remotePath), `{"remote":${index + 1}}\n`);
+  }
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "concurrent ledger event"], other);
+  const missingObjects = remotePaths.map((remotePath) =>
+    run("git", ["rev-parse", `HEAD:${remotePath}`], other).trim(),
+  );
+  installFirstPushRaceHook(work, other);
+  installMissingObjectFetchShim(fakeBin, work, missingObjects);
+  write(path.join(work, localPath), '{"local":true}\n');
+
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: append command action ledger",
+          paths: [localPath],
+          maxAttempts: 1,
+          pushAttempts: 1,
+        }),
+      ),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  assert.equal(
+    lines.some((line) => line === "Recovering 1 unavailable Git object(s) from origin"),
+    true,
+  );
+  for (const [index, remotePath] of remotePaths.entries()) {
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `main:${remotePath}`], root),
+      `{"remote":${index + 1}}\n`,
+    );
+  }
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${localPath}`], root),
+    '{"local":true}\n',
+  );
 });
 
 test("publishMainCommit escapes sustained immutable ledger races through a server merge", () => {
@@ -2891,6 +3206,34 @@ if test "$count" -eq 1; then git -C "${other}" push origin HEAD:${branch}; fi
 `,
   );
   fs.chmodSync(hook, 0o755);
+}
+
+function installMissingObjectFetchShim(fakeBin, work, objectIds) {
+  fs.mkdirSync(fakeBin, { recursive: true });
+  const git = path.join(fakeBin, "git");
+  const marker = path.join(work, ".git", "missing-object-removed");
+  const objectPaths = objectIds.map((objectId) =>
+    path.join(work, ".git", "objects", objectId.slice(0, 2), objectId.slice(2)),
+  );
+  const realGit = run("/usr/bin/env", ["which", "git"], process.cwd()).trim();
+  fs.writeFileSync(
+    git,
+    `#!/bin/sh
+set -eu
+if test "$1" = fetch && test "$3" = "${objectIds[0]}"; then
+  printf '%s\n' 'fatal: remote rejected direct object want' >&2
+  exit 128
+fi
+"${realGit}" "$@"
+result=$?
+if test "$result" -eq 0 && test "$1" = fetch && test ! -e "${marker}"; then
+${objectPaths.map((objectPath) => `  test -f "${objectPath}"\n  rm "${objectPath}"`).join("\n")}
+  : > "${marker}"
+fi
+exit "$result"
+`,
+  );
+  fs.chmodSync(git, 0o755);
 }
 
 function installFirstTwoPushRaceHook(work, other, branch = "main") {


### PR DESCRIPTION
Restores the apply/close pipeline, down since 2026-07-19 ~23:30Z.

Every "Apply default ClawSweeper closures" run failed publishing the immutable apply-proof ledger to clawsweeper-state: `fatal: entry '<hash>.json' object <sha> is unavailable` — the shallow state checkout (preserved by #708) holds tree entries whose blobs were never fetched, so the ledger tree rebuild references locally-missing objects and the push dies, aborting the apply before any closes. The latest runs additionally hit an unguarded throwing `git merge-base` in the prepare phase (the sibling of the site #711 guarded).

Changes (src/repair/git-publish.ts):
- Ledger publish now recovers unavailable objects once per publish: targeted `git fetch <remote> <sha>`, then `--refetch`, then `--deepen=1`, then `--unshallow` as last resort; rebuilds the ledger commit and retries the push. Happy path stays shallow (#708 preserved).
- `mergeBaseWithShallowRecovery` guards the prepare/overlap/reconcile merge-base sites — shallow no-common-ancestry defers to the remote-head rebuild; genuinely unrelated histories still fail closed. Sweep-status/comment-router sites keep their exceptional throwing behavior.

Validation: build/lint/format green; focused regressions 5/5; full git-publish suite 42/42 excluding the documented CI-token-only server-merge fixture (fails identically on pristine main locally; passes on CI); autoreview clean.
