### PR TITLE
fix(publish): avoid global throttle on state fetch timeout

### DIFF
--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -105,7 +105,6 @@ try {
     retryableTimeout ? "retryable_failure" : "permanent_failure",
     reasonCode,
     errorFingerprint(error),
-    retryableTimeout ? "github_transient" : undefined,
   );
   throw error;
 }
@@ -641,7 +640,6 @@ function writePublicationCompletionOutputs(
     | "policy_invariant"
     | "unknown_failure",
   fingerprint?: string,
-  failureKind?: "github_transient",
 ): void {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) return;
@@ -650,7 +648,6 @@ function writePublicationCompletionOutputs(
     [
       `completion_kind=${completionKind}`,
       `reason_code=${reasonCode}`,
-      ...(failureKind ? [`failure_kind=${failureKind}`] : []),
       ...(fingerprint ? [`error_fingerprint=${fingerprint}`] : []),
       "",
     ].join("\n"),

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4774,6 +4774,45 @@ test("exact-review publication capacity backs off on GitHub pressure and recover
   }
 });
 
+test("exact-review publication retries a state fetch timeout without throttling capacity", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7801, "78010");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "retryable_failure",
+        reason_code: "github_transient",
+        error_fingerprint: "sha256:state-fetch-timeout",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; lastFailureReason?: string }>;
+  };
+  assert.equal(state.items[item.key]?.state, "pending");
+  assert.equal(state.items[item.key]?.lastFailureReason, "github_transient");
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.capacity_control.mode, "adaptive");
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 48);
+  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
+});
+
 test("exact-review publication supersedes stale tuples without counting a publish", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(781, "7810");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -606,6 +606,11 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publisherSource, /GitCommandTimeoutError/);
   assert.match(publisherSource, /retryable_failure/);
   assert.match(publisherSource, /error instanceof GitCommandTimeoutError/);
+  assert.match(
+    publisherSource,
+    /writePublicationCompletionOutputs\(\s*retryableTimeout \? "retryable_failure" : "permanent_failure",\s*reasonCode,\s*errorFingerprint\(error\),\s*\);/,
+  );
+  assert.doesNotMatch(publisherSource, /retryableTimeout \? "github_transient" : undefined/);
   assert.ok(
     publisherSource.indexOf("eventSnapshotMatchesCurrent(paths)", completeStart) > completeStart,
   );


### PR DESCRIPTION
## Summary

Keep a bounded local state-checkout fetch timeout retryable without treating it as evidence of GitHub API pressure. This prevents one publisher timeout from lowering capacity for every issue and PR publication.

## Problem and causal proof

At `2026-07-20T07:02:01Z`, the durable publication queue recorded `last_failure_kind=github_transient`, entered a cooldown, and lowered its pressure ceiling after a publisher run timed out in `hardResetToRemoteMain -> fetchPublishRemote`:

- [run 29720961813](https://github.com/openclaw/clawsweeper/actions/runs/29720961813) logged `GitCommandTimeoutError: git fetch timed out after 60000ms`.
- The result publisher converted that local timeout directly into `failure_kind=github_transient`.
- The queue correctly responds to that field by throttling cross-target publication capacity, but the timeout itself contains no HTTP 5xx or rate-limit evidence.

The workflow already has an explicit GitHub-pressure probe that emits `failure_kind` only for HTTP 429, API rate-limit, or HTTP 5xx evidence. This change leaves that path intact and removes the conflicting local-timeout assertion.

CSW-049 also investigated [#712](https://github.com/openclaw/clawsweeper/pull/712), authored by [Peter Steinberger](https://github.com/steipete). It was merged at `2026-07-20T06:04:34Z`, after the new publication backlog had already grown from 0 to 10 at `05:50:56Z`, 21 at `05:55:56Z`, and 30 at `06:00:56Z`. Parent-SHA [run 29720024571](https://github.com/openclaw/clawsweeper/actions/runs/29720024571) had started losing `clawsweeper-state` push races at `05:53:08Z`. #712 is therefore not reverted here; it did not start this incident, and a revert would restore its missing-state-object failure.

## Implementation

- Preserve `retryable_failure`, `github_transient` reason code, fingerprint, and normal publication retry behavior for `GitCommandTimeoutError`.
- Do not write `failure_kind` for that local timeout.
- Cover the queue outcome: the item is requeued, retains the reason code, and capacity control remains adaptive at its normal ceiling.
- Assert that the publisher source no longer emits the timeout-derived `failure_kind`.

## Validation

- `git diff --check`
- Docker-backed Crabbox local-container, lease `cbx_10587a86449e`:

  ```text
  pnpm run build:all
  node --test --test-name-pattern=timeout.*throttling\|immutable.*queue-bounded test/dashboard-worker.test.ts test/sweep-workflow.test.ts
  ```

  Result: build passed; 2 passed, 0 failed.

- `codex review --uncommitted` — clean, no accepted/actionable findings.
- `git fetch origin main --prune && codex review --base origin/main` — clean, no accepted/actionable findings.
- Normal `@clawsweeper review` completed in [run 29726050754](https://github.com/openclaw/clawsweeper/actions/runs/29726050754). Its directly inspected artifact reports high confidence, zero findings, a sufficient terminal proof, and `keep_open` for ordinary maintainer review. The publisher incident prevents the expected PR comment from being delivered; no dispatcher, retry, or gate was invoked to work around that.
- Remaining review rank-up: let normal checks complete, with particular attention to coverage that keeps explicit HTTP 429/rate-limit/5xx pressure as the sole capacity-throttling signal.

Baseline noise: running the full `test/sweep-workflow.test.ts` file in the Linux Docker container also exposes existing CRLF failures in `scripts/apply-workflow-helpers.sh` and unrelated fixture assertions. The two affected tests passed in the same container after the full TypeScript build.

## Risks and rollout

This does not make state fetches succeed; it keeps their existing bounded retry behavior while preventing a local checkout failure from suppressing unrelated targets. Real GitHub API pressure still reaches the capacity controller through the workflow's explicit HTTP/rate-limit probe. Watch publication pending depth, `last_failure_kind`, and net drain rate after deployment; no gate changes, queue resets, dispatches, or retries are included.

## Attribution

Incident evidence and #712 attribution are preserved above. This patch specifically corrects the timeout-to-capacity-feedback contract introduced by [#707](https://github.com/openclaw/clawsweeper/pull/707).
