### PR TITLE
fix(repair): build ledger trees with --missing for remote-known objects

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -436,6 +436,7 @@ function pushImmutableActionLedgerCommit(options: {
   const protectedWorktreePaths = captureDirtyWorktreePaths();
   let candidateCommit = options.sourceCommit;
   let unavailableObjectRecoveryUsed = false;
+  const verifiedSourceObjectIds = new Set<string>();
   for (let attempt = 1; attempt <= pushBudget; attempt += 1) {
     const pushArgs = ["push", options.remote, `${candidateCommit}:${options.branch}`];
     const pushDisplayArgs = ["push", options.remote, `<commit>:${options.branch}`];
@@ -452,6 +453,7 @@ function pushImmutableActionLedgerCommit(options: {
         message: options.message,
         paths: options.paths,
         sourceCommit: options.sourceCommit,
+        verifiedSourceObjectIds,
       });
       candidateCommit = rebuilt.commit;
       if (rebuilt.result === "unchanged") {
@@ -512,6 +514,7 @@ function pushImmutableActionLedgerCommit(options: {
         message: options.message,
         paths: options.paths,
         sourceCommit: options.sourceCommit,
+        verifiedSourceObjectIds,
       });
     } catch (error) {
       if (unavailableObjectRecoveryUsed || unavailableGitObjectIds(error).length === 0) throw error;
@@ -523,6 +526,7 @@ function pushImmutableActionLedgerCommit(options: {
         message: options.message,
         paths: options.paths,
         sourceCommit: options.sourceCommit,
+        verifiedSourceObjectIds,
       });
     }
     candidateCommit = rebuilt.commit;
@@ -1469,9 +1473,9 @@ function reconciliationChangesOverlap(
   const args = ["merge-base", sourceCommit, remoteRef];
   const mergeBase = spawnGit(args, { quiet: true });
   if (mergeBase.status !== 0) {
-    if (mergeBase.status !== 1 || !isShallowRepository()) throw gitRunError(mergeBase, args);
+    if (mergeBase.status !== 1) throw gitRunError(mergeBase, args);
     console.log(
-      `No common Git base with ${remoteRef} after a shallow fetch; deferring overlap detection to a remote-head rebuild`,
+      `No common Git base with ${remoteRef}; deferring overlap detection to a remote-head rebuild`,
     );
     return true;
   }
@@ -1948,6 +1952,7 @@ function rebuildImmutableActionLedgerCommit(options: {
   message: string;
   paths: readonly string[];
   sourceCommit: string;
+  verifiedSourceObjectIds: Set<string>;
 }): { result: PublishResult; commit: string } {
   fetchPublishRemote(options.remote, options.branch);
   const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
@@ -1958,6 +1963,7 @@ function rebuildImmutableActionLedgerCommit(options: {
     remoteTree,
     sourceCommit: options.sourceCommit,
     paths: options.paths,
+    verifiedSourceObjectIds: options.verifiedSourceObjectIds,
   });
   if (tree === remoteTree) {
     console.log("No immutable action-ledger changes after syncing remote");
@@ -1984,6 +1990,7 @@ function rewriteImmutableActionLedgerTree(options: {
   remoteTree: string;
   sourceCommit: string;
   paths: readonly string[];
+  verifiedSourceObjectIds: Set<string>;
 }): string {
   const patch: GitTreePatch = { files: new Map(), directories: new Map() };
   const sourceEntries = chunked(options.paths, GIT_PATHSPEC_BATCH_SIZE).flatMap((paths) =>
@@ -1997,7 +2004,7 @@ function rewriteImmutableActionLedgerTree(options: {
     }
     addGitTreePatch(patch, path.split("/"), entry);
   }
-  return writePatchedGitTree(options.remoteTree, patch);
+  return writePatchedGitTree(options.remoteTree, patch, options.verifiedSourceObjectIds);
 }
 
 function addGitTreePatch(patch: GitTreePatch, parts: readonly string[], entry: GitTreeEntry): void {
@@ -2012,7 +2019,11 @@ function addGitTreePatch(patch: GitTreePatch, parts: readonly string[], entry: G
   addGitTreePatch(child, rest, entry);
 }
 
-function writePatchedGitTree(baseTree: string | null, patch: GitTreePatch): string {
+function writePatchedGitTree(
+  baseTree: string | null,
+  patch: GitTreePatch,
+  verifiedSourceObjectIds: Set<string>,
+): string {
   const entries = new Map(
     (baseTree ? readGitTreeEntries(["ls-tree", "-z", baseTree]) : []).map((entry) => [
       entry.name,
@@ -2024,9 +2035,19 @@ function writePatchedGitTree(baseTree: string | null, patch: GitTreePatch): stri
     if (existing && existing.type !== "tree") {
       throw new Error(`Immutable action-ledger directory collides with ${existing.type}: ${name}`);
     }
-    const oid = writePatchedGitTree(existing?.oid ?? null, childPatch);
+    const oid = writePatchedGitTree(existing?.oid ?? null, childPatch, verifiedSourceObjectIds);
     entries.set(name, { mode: "040000", type: "tree", oid, name });
   }
+  const locallyRequiredEntries = [...patch.files].flatMap(([name, entry]) => {
+    const existing = entries.get(name);
+    return !existing ||
+      existing.type !== entry.type ||
+      existing.mode !== entry.mode ||
+      existing.oid !== entry.oid
+      ? [entry]
+      : [];
+  });
+  assertLocalGitTreeEntries(locallyRequiredEntries, verifiedSourceObjectIds);
   for (const [name, entry] of patch.files) {
     const existing = entries.get(name);
     if (
@@ -2041,7 +2062,37 @@ function writePatchedGitTree(baseTree: string | null, patch: GitTreePatch): stri
     .sort((left, right) => left.name.localeCompare(right.name))
     .map((entry) => `${entry.mode} ${entry.type} ${entry.oid}\t${entry.name}\0`)
     .join("");
-  return runGit(["mktree", "-z"], { input, quiet: true }).trim();
+  // Unchanged entries came directly from the fetched remote tree. Their
+  // objects may be omitted by a partial checkout, but the remote already has
+  // them and does not need the client to include them in the push pack.
+  return runGit(["mktree", "--missing", "-z"], { input, quiet: true }).trim();
+}
+
+function assertLocalGitTreeEntries(
+  entries: readonly GitTreeEntry[],
+  verifiedSourceObjectIds: Set<string>,
+): void {
+  const uniqueEntries = [
+    ...new Map(
+      entries
+        .filter((entry) => !verifiedSourceObjectIds.has(entry.oid))
+        .map((entry) => [entry.oid, entry]),
+    ).values(),
+  ];
+  if (uniqueEntries.length === 0) return;
+  const output = runGit(["cat-file", "--batch-check=%(objectname) %(objecttype)"], {
+    input: uniqueEntries.map((entry) => `${entry.oid}\n`).join(""),
+    quiet: true,
+  });
+  const results = output.trimEnd().split("\n");
+  for (const [index, entry] of uniqueEntries.entries()) {
+    if (results[index] !== `${entry.oid} ${entry.type}`) {
+      throw new Error(
+        `Immutable action-ledger source object is unavailable locally: ${entry.name} (${entry.oid})`,
+      );
+    }
+    verifiedSourceObjectIds.add(entry.oid);
+  }
 }
 
 function readGitTreeEntries(args: readonly string[]): GitTreeEntry[] {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1538,6 +1538,99 @@ test("reconcile-records rebuilds on a shallow remote head without local ancestry
   );
 });
 
+test("checkpoint merge-base misses defer to a remote-head rebuild", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-checkpoint-merge-base-"));
+  const origin = path.join(root, "origin.git");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const fakeBin = path.join(root, "bin");
+  const recordsRoot = "records/openclaw-openclaw";
+  const numbers = Array.from({ length: 129 }, (_, index) => 120_000 + index);
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  for (const number of numbers) {
+    writeRecordTuple(state, {
+      number,
+      marker: `base ${number}`,
+      reviewedAt: "2026-07-20T06:00:00.000Z",
+      itemUpdatedAt: "2026-07-20T05:59:00Z",
+      packet: false,
+      plan: false,
+    });
+  }
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "initial state"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+
+  fs.mkdirSync(work);
+  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  for (const number of numbers) {
+    writeRecordTuple(work, {
+      number,
+      marker: `closed ${number}`,
+      reviewedAt: "2026-07-20T06:02:00.000Z",
+      itemUpdatedAt: "2026-07-20T06:01:00Z",
+      location: "closed",
+      packet: false,
+      plan: false,
+    });
+  }
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  const remoteTuple = writeRecordTuple(other, {
+    number: 130_000,
+    marker: "concurrent remote tuple",
+    reviewedAt: "2026-07-20T06:03:00.000Z",
+    itemUpdatedAt: "2026-07-20T06:02:00Z",
+    packet: false,
+    plan: false,
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "concurrent remote tuple"], other);
+  installFirstPushRaceHook(state, other, "state");
+  installCheckpointMergeBaseFailureShim(fakeBin, state);
+
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ CLAWSWEEPER_STATE_DIR: state, PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: publish checkpoint records",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 2,
+          rebaseStrategy: "reconcile-records",
+        }),
+      ),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  assert.equal(fs.existsSync(path.join(state, ".git", "checkpoint-merge-base-failed")), true);
+  assert.equal(
+    lines.some((line) => line.includes("deferring overlap detection to a remote-head rebuild")),
+    true,
+  );
+  assert.equal(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/closed/${numbers[0]}.md`],
+      root,
+    ).includes(`# closed ${numbers[0]}`),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/130000.md`], root),
+    remoteTuple.primary,
+  );
+});
+
 test("reconcile-records bounds git subprocesses for a 516-tuple publish", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-scale-"));
   const origin = path.join(root, "origin.git");
@@ -2020,7 +2113,7 @@ test("publishMainCommit converges after production-sized immutable ledger races"
   }
 });
 
-test("publishMainCommit refetches an unavailable immutable ledger object and retries once", () => {
+test("publishMainCommit rebuilds with unavailable unchanged remote ledger objects", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-missing-object-"));
   const origin = path.join(root, "origin.git");
   const seed = path.join(root, "seed");
@@ -2077,9 +2170,11 @@ test("publishMainCommit refetches an unavailable immutable ledger object and ret
   assert.equal(result, "committed");
   assert.equal(
     lines.some((line) => line === "Recovering 1 unavailable Git object(s) from origin"),
-    true,
+    false,
   );
+  assert.equal(fs.existsSync(path.join(work, ".git", "missing-object-removed")), true);
   for (const [index, remotePath] of remotePaths.entries()) {
+    assert.throws(() => run("git", ["cat-file", "-e", missingObjects[index]], work));
     assert.equal(
       run("git", ["--git-dir", origin, "show", `main:${remotePath}`], root),
       `{"remote":${index + 1}}\n`,
@@ -2089,6 +2184,51 @@ test("publishMainCommit refetches an unavailable immutable ledger object and ret
     run("git", ["--git-dir", origin, "show", `main:${localPath}`], root),
     '{"local":true}\n',
   );
+});
+
+test("publishMainCommit fails closed when a written ledger object is unavailable locally", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-missing-written-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const fakeBin = path.join(root, "bin");
+  const localPath =
+    "ledger/v1/import-bindings/events/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.json";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  write(path.join(work, "remote.txt"), "base\n");
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  write(path.join(other, "remote.txt"), "concurrent\n");
+  run("git", ["add", "remote.txt"], other);
+  run("git", ["commit", "-m", "concurrent state update"], other);
+  installFirstPushRaceHook(work, other);
+  installMissingWrittenObjectFetchShim(fakeBin, work, localPath);
+  write(path.join(work, localPath), '{"local":true}\n');
+
+  assert.throws(
+    () =>
+      withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+        withCwd(work, () =>
+          publishMainCommit({
+            message: "chore: append command action ledger",
+            paths: [localPath],
+            maxAttempts: 1,
+            pushAttempts: 1,
+          }),
+        ),
+      ),
+    /Immutable action-ledger source object is unavailable locally/,
+  );
+  assert.equal(run("git", ["--git-dir", origin, "show", "main:remote.txt"], root), "concurrent\n");
+  assert.throws(() => run("git", ["--git-dir", origin, "show", `main:${localPath}`], root));
 });
 
 test("publishMainCommit escapes sustained immutable ledger races through a server merge", () => {
@@ -3231,6 +3371,51 @@ ${objectPaths.map((objectPath) => `  test -f "${objectPath}"\n  rm "${objectPath
   : > "${marker}"
 fi
 exit "$result"
+`,
+  );
+  fs.chmodSync(git, 0o755);
+}
+
+function installMissingWrittenObjectFetchShim(fakeBin, work, localPath) {
+  fs.mkdirSync(fakeBin, { recursive: true });
+  const git = path.join(fakeBin, "git");
+  const marker = path.join(work, ".git", "missing-written-object-removed");
+  const pushCounter = path.join(work, ".git", "hooks", "pre-push-count");
+  const realGit = run("/usr/bin/env", ["which", "git"], process.cwd()).trim();
+  fs.writeFileSync(
+    git,
+    `#!/bin/sh
+set -u
+"${realGit}" "$@"
+result=$?
+if test "$result" -eq 0 && test "$1" = fetch && test -e "${pushCounter}" && test ! -e "${marker}"; then
+  object_id=$("${realGit}" -C "${work}" rev-parse "HEAD:${localPath}")
+  object_path="${path.join(work, ".git", "objects")}/$(printf '%s' "$object_id" | cut -c1-2)/$(printf '%s' "$object_id" | cut -c3-)"
+  test -f "$object_path"
+  rm "$object_path"
+  printf '%s\n' "$object_id" > "${marker}"
+fi
+exit "$result"
+`,
+  );
+  fs.chmodSync(git, 0o755);
+}
+
+function installCheckpointMergeBaseFailureShim(fakeBin, state) {
+  fs.mkdirSync(fakeBin, { recursive: true });
+  const git = path.join(fakeBin, "git");
+  const pushCounter = path.join(state, ".git", "hooks", "pre-push-count");
+  const marker = path.join(state, ".git", "checkpoint-merge-base-failed");
+  const realGit = run("/usr/bin/env", ["which", "git"], process.cwd()).trim();
+  fs.writeFileSync(
+    git,
+    `#!/bin/sh
+set -u
+if test "$1" = merge-base && test -e "${pushCounter}" && test ! -e "${marker}"; then
+  : > "${marker}"
+  exit 1
+fi
+exec "${realGit}" "$@"
 `,
   );
   fs.chmodSync(git, 0o755);


### PR DESCRIPTION
Second (root-cause) fix for the apply/close pipeline outage. #712's recovery ladder fired in prod ("Recovering 1 unavailable Git object(s)") but the publish still failed — arbitrary blob SHAs are not reliably fetchable from GitHub, so no fetch strategy can materialize the missing objects.

Root cause: the immutable-ledger tree rebuild reuses unchanged entries from the fetched remote branch tree; a shallow/partial state checkout may not hold those blobs locally, and plain `git mktree` refuses trees referencing absent objects — even though the push never needs to send them (the remote already has them, by definition).

Changes (src/repair/git-publish.ts):
- Ledger trees are now built with `git mktree --missing`. Safety: entries we add or modify are batch-verified locally via `cat-file --batch-check` (cached per source commit) and fail closed with a named error if absent — only remote-known unchanged entries may be locally missing.
- The no-common-ancestor defer in `reconciliationChangesOverlap` (the checkpoint-phase path that threw in run 29724509329) now applies on merge-base exit 1 unconditionally, not only for shallow checkouts; other fatal git errors still throw.

Validation: build/lint/format green; git-publish suite 44/45 — the one failure is the documented CI-token-only server-merge fixture (fails identically on pristine main locally; passes on CI). Autoreview clean ("patch is correct", 0.9).
