### PR TITLE
fix(publish): defer active review lease collisions

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1980,7 +1980,7 @@ jobs:
               outcome=success
             fi
           fi
-          if [ "$outcome" = "success" ] && [ "$completion_kind" != "superseded" ] && [ "$completion_kind" != "deferred" ] && [ "$completion_kind" != "refresh_required" ]; then
+          if [ "$outcome" = "success" ] && [ "$completion_kind" != "superseded" ] && [ "$completion_kind" != "deferred" ] && [ "$completion_kind" != "refresh_required" ] && [ "$completion_kind" != "retryable_failure" ]; then
             if [ "$PUBLISH_COMPLETION_KIND" = "published" ] && [ "$PUBLISH_REASON_CODE" = "publication_applied" ]; then
               completion_kind=published
               reason_code=publication_applied

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1776,7 +1776,7 @@ jobs:
           echo "confirmed=true" >> "$GITHUB_OUTPUT"
 
       - name: Mark re-review complete
-        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.has_command_context == 'true' }}
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.has_command_context == 'true' && !(steps.publish-event-result.outputs.completion_kind == 'retryable_failure' && steps.publish-event-result.outputs.reason_code == 'review_lease_active') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -1934,6 +1934,7 @@ jobs:
           VALIDATE_OUTCOME: ${{ steps.validate-exact-review-bundle.outcome }}
           PUBLISH_COMPLETION_KIND: ${{ steps.publish-event-result.outputs.completion_kind }}
           PUBLISH_REASON_CODE: ${{ steps.publish-event-result.outputs.reason_code }}
+          PUBLISH_RETRY_AT: ${{ steps.publish-event-result.outputs.retry_at }}
           ERROR_FINGERPRINT: ${{ steps.publish-event-result.outputs.error_fingerprint }}
           REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
         run: |
@@ -1941,6 +1942,7 @@ jobs:
           outcome=failure
           completion_kind=permanent_failure
           reason_code=unknown_failure
+          retry_at=
           if [ "$PUBLISH_COMPLETION_KIND" = "superseded" ] && { [ "$PUBLISH_REASON_CODE" = "remote_newer_tuple" ] || [ "$PUBLISH_REASON_CODE" = "remote_closed" ]; }; then
             outcome=success
             completion_kind=superseded
@@ -1956,6 +1958,11 @@ jobs:
             outcome=success
             completion_kind=refresh_required
             reason_code=close_coverage_retry
+          elif [ "$PUBLISH_COMPLETION_KIND" = "retryable_failure" ] && [ "$PUBLISH_REASON_CODE" = "review_lease_active" ] && [ -n "$PUBLISH_RETRY_AT" ]; then
+            outcome=success
+            completion_kind=retryable_failure
+            reason_code=review_lease_active
+            retry_at="$PUBLISH_RETRY_AT"
           elif [ "$LEGACY_TUPLELESS" = "true" ] && [ "$SOURCE_DRIFT_OUTCOME" = "success" ]; then
             outcome=success
             completion_kind=superseded
@@ -2003,6 +2010,9 @@ jobs:
           if [ -n "$ERROR_FINGERPRINT" ]; then
             echo "error_fingerprint=$ERROR_FINGERPRINT" >> "$GITHUB_OUTPUT"
           fi
+          if [ -n "$retry_at" ]; then
+            echo "retry_at=$retry_at" >> "$GITHUB_OUTPUT"
+          fi
           if [ "$outcome" = "failure" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
             echo "failure_kind=$FAILURE_KIND" >> "$GITHUB_OUTPUT"
           fi
@@ -2020,6 +2030,7 @@ jobs:
           COMPLETION_KIND: ${{ steps.exact-review-publication-result.outputs.completion_kind }}
           REASON_CODE: ${{ steps.exact-review-publication-result.outputs.reason_code }}
           ERROR_FINGERPRINT: ${{ steps.exact-review-publication-result.outputs.error_fingerprint }}
+          RETRY_AT: ${{ steps.exact-review-publication-result.outputs.retry_at }}
           QUEUE_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -2043,12 +2054,14 @@ jobs:
             const completionKind = ["published", "superseded", "deferred", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
               ? process.env.COMPLETION_KIND
               : undefined;
-            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
+            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "review_lease_active", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
               ? process.env.REASON_CODE
               : undefined;
             const errorFingerprint = /^[A-Za-z0-9:._-]{1,200}$/.test(process.env.ERROR_FINGERPRINT || "")
               ? process.env.ERROR_FINGERPRINT
               : undefined;
+            const retryAt = String(process.env.RETRY_AT || "").trim();
+            if (retryAt && !Number.isFinite(Date.parse(retryAt))) process.exit(1);
             if (!completionKind || !reasonCode) process.exit(1);
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
@@ -2061,6 +2074,7 @@ jobs:
               completion_kind: completionKind,
               reason_code: reasonCode,
               ...(errorFingerprint ? { error_fingerprint: errorFingerprint } : {}),
+              ...(retryAt ? { retry_at: retryAt } : {}),
               ...(outcome === "failure" && failureKind ? { failure_kind: failureKind } : {}),
             }));
           ')"
@@ -2077,6 +2091,26 @@ jobs:
             fi
           done
           exit 1
+
+      - name: Mark active lease retry waiting
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.has_command_context == 'true' && steps.exact-review-publication-result.outputs.outcome == 'success' && steps.exact-review-publication-result.outputs.completion_kind == 'retryable_failure' && steps.exact-review-publication-result.outputs.reason_code == 'review_lease_active' && steps.complete-exact-review-publication.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          COMMAND_STATUS_MARKER: ${{ fromJSON(steps.publication-context.outputs.decision).commandStatusMarker || '' }}
+          STATUS_COMMENT_ID: ${{ fromJSON(steps.publication-context.outputs.decision).statusCommentId || '' }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          pnpm run repair:update-command-status -- \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --marker "$COMMAND_STATUS_MARKER" \
+            --status-comment-id "$STATUS_COMMENT_ID" \
+            --state "Waiting" \
+            --detail "Another same-revision review is active; durable publication will retry after its lease expires." \
+            --run-url "$RUN_URL"
 
       - name: Fail unsuccessful exact review publication
         if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && (steps.exact-review-publication-result.outputs.outcome != 'success' || steps.complete-exact-review-publication.outcome != 'success') }}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -107,6 +107,7 @@ type ExactReviewPublicationReasonCode =
   | "live_terminal"
   | "github_rate_limit"
   | "github_transient"
+  | "review_lease_active"
   | "workflow_cancelled"
   | "artifact_unavailable"
   | "artifact_expired"
@@ -653,14 +654,15 @@ export class ExactReviewQueue {
       if (hasStructuredCompletion && !publicationCompletion) {
         return json({ error: "invalid_publication_completion" }, 400);
       }
-      if (
+      const completionSucceeds =
         publicationCompletion &&
         (publicationCompletion.kind === "published" ||
           publicationCompletion.kind === "superseded" ||
           publicationCompletion.kind === "refresh_required" ||
-          publicationCompletion.kind === "deferred") !==
-          (outcome === "success")
-      ) {
+          publicationCompletion.kind === "deferred" ||
+          (publicationCompletion.kind === "retryable_failure" &&
+            publicationCompletion.reasonCode === "review_lease_active"));
+      if (publicationCompletion && completionSucceeds !== (outcome === "success")) {
         return json({ error: "completion_outcome_mismatch" }, 400);
       }
       if (
@@ -3466,6 +3468,7 @@ function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCo
     "live_terminal",
     "github_rate_limit",
     "github_transient",
+    "review_lease_active",
     "workflow_cancelled",
     "artifact_unavailable",
     "artifact_expired",
@@ -3499,6 +3502,7 @@ function exactReviewPublicationCompletion(
     retryable_failure: new Set([
       "github_rate_limit",
       "github_transient",
+      "review_lease_active",
       "workflow_cancelled",
       "artifact_unavailable",
       "unknown_failure",

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1127,6 +1127,8 @@ interface ApplyResult {
   terminalMissingVerified?: boolean;
   terminalStateVerified?: boolean;
   guardedOpenStateVerified?: boolean;
+  activeReviewLeaseVerified?: boolean;
+  activeReviewLeaseExpiresAt?: string;
   terminalPolicyNoopVerified?: boolean;
   sourceDriftVerified?: boolean;
 }
@@ -27100,6 +27102,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       action: "kept_open" | "skipped_stale_review_comment_sync",
       reason: string,
       restoreOriginal = true,
+      activeReviewLeaseExpiresAt?: string,
     ): boolean => {
       markdown = replaceFrontMatterValue(
         restoreOriginal ? markdownBeforeApplyDecisionMutations : markdown,
@@ -27107,7 +27110,17 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         new Date().toISOString(),
       );
       if (!dryRun) writeReportMarkdown(path, markdown);
-      results.push({ number, action, reason });
+      results.push({
+        number,
+        action,
+        reason,
+        ...(emitEventApplyProof && action === "kept_open" && activeReviewLeaseExpiresAt
+          ? {
+              activeReviewLeaseVerified: true,
+              activeReviewLeaseExpiresAt,
+            }
+          : {}),
+      });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: ${reason}`);
       return processedCount >= processedLimit;
@@ -27117,7 +27130,11 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       reason === "pull request review activity exceeds the bounded reviewed cursor";
     const exactEventSourceRevisionChanged = (reason: string): boolean =>
       exactEventPublication && isExactEventSourceRevisionChange(item.kind, reason);
-    const recordReviewLeaseSkip = (reason: string, restoreOriginal = true): boolean =>
+    const recordReviewLeaseSkip = (
+      reason: string,
+      restoreOriginal = true,
+      activeReviewLeaseExpiresAt?: string,
+    ): boolean =>
       reviewActivitySourceChanged(reason) || exactEventSourceRevisionChanged(reason)
         ? markApplySkipped("skipped_changed_since_review", reason)
         : staleCanonicalCommentSyncPending
@@ -27125,11 +27142,13 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
             "retry_stale_canonical_comment_sync",
             `${reason}; stale canonical comment correction remains pending`,
           )
-        : recordReviewGuardSkip("kept_open", reason, restoreOriginal);
+        : recordReviewGuardSkip("kept_open", reason, restoreOriginal, activeReviewLeaseExpiresAt);
     recordApplyMutationGuardReason = (reason) => recordReviewLeaseSkip(reason, false);
     const recordActiveReviewLeaseSkip = (expiresAt: string): boolean =>
       recordReviewLeaseSkip(
         `${item.kind === "pull_request" ? "same-head" : "same-revision"} ClawSweeper review is active until ${expiresAt}`,
+        true,
+        expiresAt,
       );
     let existingReviewComment: Record<string, unknown> | undefined;
     const pendingStaleCanonicalCommentReason = staleCanonicalCommentSyncPending

--- a/src/repair/event-apply-proof.ts
+++ b/src/repair/event-apply-proof.ts
@@ -157,8 +157,7 @@ export function exactEventApplyProof(
     terminalCount === 0 &&
     exactActions[0]?.terminalMissingVerified !== true;
   const activeReviewLeaseRetryAt =
-    soleExactAction === "kept_open" &&
-    soleExactResult?.activeReviewLeaseVerified === true
+    soleExactAction === "kept_open" && soleExactResult?.activeReviewLeaseVerified === true
       ? normalizedReviewLeaseRetryAt(soleExactResult.activeReviewLeaseExpiresAt)
       : null;
   return {
@@ -196,7 +195,9 @@ export function exactEventApplyProof(
 function normalizedReviewLeaseRetryAt(value: string): string | null {
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp)
-    ? new Date(Math.min(timestamp, Date.now() + ACTIVE_REVIEW_LEASE_RETRY_MAX_DELAY_MS)).toISOString()
+    ? new Date(
+        Math.min(timestamp, Date.now() + ACTIVE_REVIEW_LEASE_RETRY_MAX_DELAY_MS),
+      ).toISOString()
     : null;
 }
 

--- a/src/repair/event-apply-proof.ts
+++ b/src/repair/event-apply-proof.ts
@@ -8,6 +8,8 @@ export type EventApplyAction = {
   terminalMissingVerified: boolean;
   terminalStateVerified: boolean;
   guardedOpenStateVerified: boolean;
+  activeReviewLeaseVerified: boolean;
+  activeReviewLeaseExpiresAt: string;
   terminalPolicyNoopVerified: boolean;
   sourceDriftVerified: boolean;
 };
@@ -30,6 +32,10 @@ const GUARDED_OPEN_ACTIONS = new Set([
 ]);
 
 const LEGACY_TUPLELESS_REVIEW_LEASE_REASON = "local report has no durable lease identity";
+// The durable queue rejects retry deadlines beyond two hours. Leave a small
+// margin for worker/queue clock skew; a still-active long lease is sampled
+// again at this bounded deadline instead of rejecting the completion.
+const ACTIVE_REVIEW_LEASE_RETRY_MAX_DELAY_MS = 110 * 60 * 1000;
 
 export function exactEventPublishDisposition({
   candidateMatchesCurrentTuple,
@@ -112,6 +118,7 @@ export function exactEventApplyProof(
   terminalMissingCount: number;
   terminalCount: number;
   guardedOpenAction: string | null;
+  activeReviewLeaseRetryAt: string | null;
   latestRevisionRequeueRequired: boolean;
   legacyTuplelessReviewLease: boolean;
   disposition: ExactEventApplyDisposition;
@@ -149,6 +156,11 @@ export function exactEventApplyProof(
     syncedCount === 0 &&
     terminalCount === 0 &&
     exactActions[0]?.terminalMissingVerified !== true;
+  const activeReviewLeaseRetryAt =
+    soleExactAction === "kept_open" &&
+    soleExactResult?.activeReviewLeaseVerified === true
+      ? normalizedReviewLeaseRetryAt(soleExactResult.activeReviewLeaseExpiresAt)
+      : null;
   return {
     exactActions,
     syncedCount,
@@ -160,6 +172,7 @@ export function exactEventApplyProof(
       GUARDED_OPEN_ACTIONS.has(soleExactAction)
         ? soleExactAction
         : null,
+    activeReviewLeaseRetryAt,
     latestRevisionRequeueRequired:
       snapshotActionTaken === "skipped_changed_since_review" &&
       soleExactAction === "skipped_changed_since_review",
@@ -178,6 +191,13 @@ export function exactEventApplyProof(
             ? "applied"
             : "unproven",
   };
+}
+
+function normalizedReviewLeaseRetryAt(value: string): string | null {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp)
+    ? new Date(Math.min(timestamp, Date.now() + ACTIVE_REVIEW_LEASE_RETRY_MAX_DELAY_MS)).toISOString()
+    : null;
 }
 
 export function eventRecordActionTaken(markdown: string | null): string | null {
@@ -202,6 +222,9 @@ export function eventApplyAction(value: LooseRecord): EventApplyAction {
     terminalMissingVerified: value.terminalMissingVerified === true,
     terminalStateVerified: value.terminalStateVerified === true,
     guardedOpenStateVerified: value.guardedOpenStateVerified === true,
+    activeReviewLeaseVerified: value.activeReviewLeaseVerified === true,
+    activeReviewLeaseExpiresAt:
+      typeof value.activeReviewLeaseExpiresAt === "string" ? value.activeReviewLeaseExpiresAt : "",
     terminalPolicyNoopVerified: value.terminalPolicyNoopVerified === true,
     sourceDriftVerified: value.sourceDriftVerified === true,
   };

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -206,6 +206,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     terminalMissingCount: missingCount,
     terminalCount: closedCount,
     guardedOpenAction,
+    activeReviewLeaseRetryAt,
     legacyTuplelessReviewLease,
     disposition: applyDisposition,
   } = exactEventApplyProof(actions, Number(options.itemNumber), snapshotActionTaken);
@@ -220,6 +221,18 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     );
   }
   const deferredCloseCoverageExpected = applyDisposition === "close_coverage_deferred";
+  if (activeReviewLeaseRetryAt !== null) {
+    console.log(
+      `Deferring ${options.targetRepo}#${options.itemNumber}: active review lease remains active until ${activeReviewLeaseRetryAt}`,
+    );
+    writePublicationCompletionOutputs(
+      "retryable_failure",
+      "review_lease_active",
+      undefined,
+      activeReviewLeaseRetryAt,
+    );
+    return;
+  }
   const deferredCloseCoverageEnabled = process.env.EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED === "true";
   if (deferredCloseCoverageExpected) {
     console.log(
@@ -635,11 +648,13 @@ function writePublicationCompletionOutputs(
     | "remote_closed"
     | "close_coverage_deferred"
     | "github_transient"
+    | "review_lease_active"
     | "missing_record_tuple"
     | "tuple_protocol_invalid"
     | "policy_invariant"
     | "unknown_failure",
   fingerprint?: string,
+  retryAt?: string,
 ): void {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) return;
@@ -649,6 +664,7 @@ function writePublicationCompletionOutputs(
       `completion_kind=${completionKind}`,
       `reason_code=${reasonCode}`,
       ...(fingerprint ? [`error_fingerprint=${fingerprint}`] : []),
+      ...(retryAt ? [`retry_at=${retryAt}`] : []),
       "",
     ].join("\n"),
     "utf8",

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4813,6 +4813,47 @@ test("exact-review publication retries a state fetch timeout without throttling 
   assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
 });
 
+test("exact-review publication defers an active review lease without throttling capacity", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7802, "78020");
+  const retryAt = Date.now() + 12 * 60_000;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "retryable_failure",
+        reason_code: "review_lease_active",
+        retry_at: new Date(retryAt).toISOString(),
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { state: string; lastFailureReason?: string; nextAttemptAt?: number }>;
+  };
+  assert.equal(state.items[item.key]?.state, "pending");
+  assert.equal(state.items[item.key]?.lastFailureReason, "review_lease_active");
+  assert.ok(Number(state.items[item.key]?.nextAttemptAt) >= retryAt);
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.capacity_control.mode, "adaptive");
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 48);
+  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
+});
+
 test("exact-review publication supersedes stale tuples without counting a publish", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(781, "7810");

--- a/test/repair/event-apply-proof.test.ts
+++ b/test/repair/event-apply-proof.test.ts
@@ -319,7 +319,8 @@ test("exact event proof defers a close-coverage retry to the proof-capable apply
 });
 
 test("exact event proof defers only a verified active review lease until its expiry", () => {
-  const snapshot = "---\nrepository: openclaw/openclaw\nnumber: 42\naction_taken: proposed_close\n---\n";
+  const snapshot =
+    "---\nrepository: openclaw/openclaw\nnumber: 42\naction_taken: proposed_close\n---\n";
   const retryAt = "2026-07-20T08:44:43.900Z";
   const verified = exactEventApplyProof(
     [

--- a/test/repair/event-apply-proof.test.ts
+++ b/test/repair/event-apply-proof.test.ts
@@ -317,6 +317,55 @@ test("exact event proof defers a close-coverage retry to the proof-capable apply
     false,
   );
 });
+
+test("exact event proof defers only a verified active review lease until its expiry", () => {
+  const snapshot = "---\nrepository: openclaw/openclaw\nnumber: 42\naction_taken: proposed_close\n---\n";
+  const retryAt = "2026-07-20T08:44:43.900Z";
+  const verified = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "kept_open",
+        activeReviewLeaseVerified: true,
+        activeReviewLeaseExpiresAt: retryAt,
+      }),
+    ],
+    42,
+    eventRecordActionTaken(snapshot),
+  );
+  assert.equal(verified.activeReviewLeaseRetryAt, retryAt);
+
+  for (const action of ["skipped_locked_conversation", "kept_open"]) {
+    const proof = exactEventApplyProof(
+      [
+        eventApplyAction({
+          number: 42,
+          action,
+          activeReviewLeaseVerified: action === "kept_open",
+          activeReviewLeaseExpiresAt: "not-a-timestamp",
+        }),
+      ],
+      42,
+      eventRecordActionTaken(snapshot),
+    );
+    assert.equal(proof.activeReviewLeaseRetryAt, null, action);
+  }
+
+  const tooLong = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "kept_open",
+        activeReviewLeaseVerified: true,
+        activeReviewLeaseExpiresAt: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      }),
+    ],
+    42,
+    eventRecordActionTaken(snapshot),
+  ).activeReviewLeaseRetryAt;
+  assert.ok(tooLong !== null);
+  assert.ok(Date.parse(tooLong) <= Date.now() + 2 * 60 * 60 * 1000);
+});
 test("exact event proof completes live-shaped deterministic guarded-open results", () => {
   for (const action of [
     "skipped_same_author_pair",

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -586,7 +586,10 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.ok(publisher.steps.indexOf(publishResult) < publisher.steps.indexOf(publishComplete));
   assert.ok(publisher.steps.indexOf(publishComplete) < publisher.steps.indexOf(activeLeaseWaiting));
   assert.match(activeLeaseWaiting.if ?? "", /reason_code == 'review_lease_active'/);
-  assert.match(activeLeaseWaiting.if ?? "", /complete-exact-review-publication\.outcome == 'success'/);
+  assert.match(
+    activeLeaseWaiting.if ?? "",
+    /complete-exact-review-publication\.outcome == 'success'/,
+  );
   assert.match(activeLeaseWaiting.run ?? "", /--state "Waiting"/);
 
   const publisherSource = readText("src/repair/publish-event-result.ts");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -514,6 +514,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.equal(status.env?.LIVE_TERMINAL_MISSING, undefined);
   assert.equal(status.env?.LIVE_GUARDED_OPEN, undefined);
   assert.match(status.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
+  assert.match(status.if ?? "", /reason_code == 'review_lease_active'/);
   assert.match(status.run ?? "", /PUBLISH_COMPLETION_KIND.*superseded/);
   const commandComplete = step(publisher, "Mark re-review complete");
   assert.doesNotMatch(commandComplete.if ?? "", /completion_kind != 'deferred'/);
@@ -531,6 +532,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   );
   const publishResult = step(publisher, "Export exact review publication result");
   const publishComplete = step(publisher, "Complete durable exact review publication");
+  const activeLeaseWaiting = step(publisher, "Mark active lease retry waiting");
   const publicationPressure = step(publisher, "Probe GitHub pressure after publication failure");
   const releaseTerminal = step(publisher, "Release terminal review leases");
   const releaseUnsuccessful = step(
@@ -550,6 +552,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.env?.DOWNLOAD_OUTCOME ?? "", /download-exact-review-bundle/);
   assert.match(publishResult.env?.VALIDATE_OUTCOME ?? "", /validate-exact-review-bundle/);
   assert.match(publishResult.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
+  assert.match(publishResult.env?.PUBLISH_RETRY_AT ?? "", /publish-event-result/);
   assert.match(publicationPressure.if ?? "", /failure\(\)/);
   assert.match(publicationPressure.run ?? "", /gh api rate_limit/);
   assert.match(publicationPressure.run ?? "", /failure_kind=github_rate_limit/);
@@ -563,6 +566,9 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.run ?? "", /completion_kind=refresh_required/);
   assert.match(publishResult.run ?? "", /reason_code=close_coverage_retry/);
   assert.match(publishResult.run ?? "", /reason_code=close_coverage_deferred/);
+  assert.match(publishResult.run ?? "", /reason_code=review_lease_active/);
+  assert.match(publishResult.run ?? "", /reason_code=review_lease_active[\s\S]*?outcome=success/);
+  assert.match(publishResult.run ?? "", /retry_at=\"\$PUBLISH_RETRY_AT\"/);
   assert.match(
     publishResult.run ?? "",
     /completion_kind" != "superseded".*completion_kind" != "deferred".*completion_kind" != "refresh_required"/,
@@ -572,10 +578,16 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.doesNotMatch(publishResult.run ?? "", /LIVE_TERMINAL_NOOP/);
   assert.match(publishComplete.run ?? "", /internal\/exact-review\/complete/);
   assert.match(publishComplete.env?.FAILURE_KIND ?? "", /exact-review-publication-result/);
+  assert.match(publishComplete.env?.RETRY_AT ?? "", /exact-review-publication-result/);
   assert.match(publishComplete.run ?? "", /failure_kind: failureKind/);
   assert.match(publishComplete.run ?? "", /completion_kind: completionKind/);
   assert.match(publishComplete.run ?? "", /reason_code: reasonCode/);
+  assert.match(publishComplete.run ?? "", /retry_at: retryAt/);
   assert.ok(publisher.steps.indexOf(publishResult) < publisher.steps.indexOf(publishComplete));
+  assert.ok(publisher.steps.indexOf(publishComplete) < publisher.steps.indexOf(activeLeaseWaiting));
+  assert.match(activeLeaseWaiting.if ?? "", /reason_code == 'review_lease_active'/);
+  assert.match(activeLeaseWaiting.if ?? "", /complete-exact-review-publication\.outcome == 'success'/);
+  assert.match(activeLeaseWaiting.run ?? "", /--state "Waiting"/);
 
   const publisherSource = readText("src/repair/publish-event-result.ts");
   assert.match(
@@ -584,6 +596,8 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   );
   assert.match(publisherSource, /"--exact-event-publication"/);
   assert.match(publisherSource, /legacyTuplelessReviewLease/);
+  assert.match(publisherSource, /activeReviewLeaseRetryAt/);
+  assert.match(publisherSource, /review_lease_active/);
   assert.match(publisherSource, /applyDisposition === "close_coverage_deferred"/);
   assert.match(publisherSource, /EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED/);
   assert.match(publisherSource, /writeLegacyRefreshRequiredOutputs/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -571,7 +571,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.run ?? "", /retry_at="\$PUBLISH_RETRY_AT"/);
   assert.match(
     publishResult.run ?? "",
-    /completion_kind" != "superseded".*completion_kind" != "deferred".*completion_kind" != "refresh_required"/,
+    /completion_kind" != "superseded".*completion_kind" != "deferred".*completion_kind" != "refresh_required".*completion_kind" != "retryable_failure"/,
   );
   assert.match(publishResult.run ?? "", /reason_code=artifact_unavailable/);
   assert.match(publishResult.run ?? "", /reason_code=invalid_artifact/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -568,7 +568,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publishResult.run ?? "", /reason_code=close_coverage_deferred/);
   assert.match(publishResult.run ?? "", /reason_code=review_lease_active/);
   assert.match(publishResult.run ?? "", /reason_code=review_lease_active[\s\S]*?outcome=success/);
-  assert.match(publishResult.run ?? "", /retry_at=\"\$PUBLISH_RETRY_AT\"/);
+  assert.match(publishResult.run ?? "", /retry_at="\$PUBLISH_RETRY_AT"/);
   assert.match(
     publishResult.run ?? "",
     /completion_kind" != "superseded".*completion_kind" != "deferred".*completion_kind" != "refresh_required"/,


### PR DESCRIPTION
## Summary

Defer a publisher that collides with a verified same-revision ClawSweeper review lease, then requeue it at that lease's expiry. This prevents a known temporary coordination state from being reported as a generic publication failure and consuming publisher capacity repeatedly.

## Problem and causal proof

At the incident peak, review generation continued while result publication was saturated: all 32 publisher slots were leased and pending work grew. The representative lifecycle was:

```text
same-head/same-revision ClawSweeper review is active until <expiry>
  -> apply-decisions records kept_open
  -> publish-event-result throws "was not applied; actions: kept_open"
  -> durable queue records a generic failure and retries
```

The lease guard itself was introduced by [#462](https://github.com/openclaw/clawsweeper/pull/462) (`d43deab4b78d0e58ecc7525cef175106b2fc559d`), but it is a correct safety invariant. Its publisher classification was latent until same-revision review overlap occurred; it is not evidence that the July 10 merge immediately caused the later backlog.

The same signature, including workflow URLs, was recorded in [#635](https://github.com/openclaw/clawsweeper/issues/635) on July 16, before #707 and #712. That excludes timing-only attribution to [#712](https://github.com/openclaw/clawsweeper/pull/712): #712 repairs unavailable state objects in ledger publication, and [#714](https://github.com/openclaw/clawsweeper/pull/714) repairs remote-known ledger trees. Neither changes the active-review `kept_open` lifecycle.

Thanks to Peter Steinberger for the lease invariant in #462 and the independent ledger recovery work in #712/#714, and to @brokemac79 for the incident evidence in #635.

## Scope and implementation

- Carry a typed, verified active-review lease expiry from `apply-decisions` into the exact-event apply proof. Only a sole `kept_open` result from the live lease guard qualifies.
- Bound the retry timestamp to 110 minutes, inside the queue's two-hour acceptance window.
- Emit `retryable_failure/review_lease_active` from the publisher, while completing the workflow successfully so it is not classified as GitHub pressure or an unknown publisher failure.
- Preserve that typed retry through the generic workflow completion normalizer; without this final narrow guard, it would be overwritten as `superseded/live_terminal` and removed instead of deferred.
- Let the durable queue accept the typed completion, retain the artifact, and schedule it for lease expiry without capacity-control failure feedback.
- Avoid reporting the command as failed for this typed deferral; update it to `Waiting` only after durable completion succeeds.

This deliberately does not change queue capacity, retry budgets, the dashboard, dispatch/gates, or unrelated `kept_open` reasons.

## Validation

All executable proof ran through Docker-backed local Crabbox (`mcr.microsoft.com/playwright:v1.60.0-noble`). The final functional proof used lease `cbx_d9709b7b46bb`:

```text
corepack pnpm install --frozen-lockfile
./node_modules/.bin/tsc -p tsconfig.json
./node_modules/.bin/tsc -p tsconfig.repair.json
./node_modules/.bin/tsc -p tsconfig.dashboard.json
./node_modules/.bin/oxlint src ...
./node_modules/.bin/oxlint src/repair ...
./node_modules/.bin/oxlint scripts test ...
./node_modules/.bin/oxlint dashboard ...
node --test test/repair/event-apply-proof.test.ts test/dashboard-worker.test.ts
```

Result: all builds and four lint surfaces clean; 171 focused tests passed. The explicit workflow contract proves the repair lifecycle: verified active lease -> typed retry with timestamp -> preserved past generic normalization -> queue retry timestamp -> successful completion reaches `Waiting`.

Scoped Actionlint on the changed workflow passed in Crabbox lease `cbx_749bcda5a05b`:

```text
actionlint -shellcheck= -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/sweep.yml
```

`git diff --check` passed. Baseline noise: repository-wide Actionlint also reports custom Blacksmith/Crabbox runner labels in unrelated workflows; the raw Windows `test/sweep-workflow.test.ts` suite lacks `jq` for an unrelated Bash fixture. The exact changed workflow assertion passed during Codex review. The synced Windows checkout also has pre-existing mixed/CRLF formatting differences, so no broad formatter rewrite is included.

Codex review closeout:

- `codex review --uncommitted` found the completion-normalizer overwrite; it was fixed, Docker proof was rerun, and the final dirty review was clean with no actionable findings.
- `codex review --base origin/main` was clean with no actionable findings for head `dd68cdb4762b1e8812c5766129e7580384c5f08f`.

## Risks and rollout

The live review lease remains authoritative: this delays publication rather than overriding, dropping, or duplicating a review. A malformed or unverified lease result still follows the existing failure path. The only new typed queue completion is `review_lease_active`; it neither reports a GitHub failure kind nor increases capacity.

Normal CI for this head is pending. After deployment, monitor publisher pending depth, lease utilization, net drain, and `review_lease_active` completions. Do not merge automatically; this requires Martin's explicit merge decision.
