### PR TITLE
fix(repair): rebuild reconciliation on remote head for unrelated histories

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -842,18 +842,24 @@ function mergeBaseWithShallowRecovery(
   right: string,
   remote: string,
   branch: string,
-): { base: string; recoveredShallowMiss: boolean } {
+): { base: string | null; recoveredShallowMiss: boolean } {
   const args = ["merge-base", left, right];
   let result = spawnGit(args, { quiet: true });
   if (result.status === 0) {
     return { base: result.stdout.trim(), recoveredShallowMiss: false };
   }
-  if (result.status !== 1 || !isShallowRepository()) throw gitRunError(result, args);
+  if (result.status !== 1) throw gitRunError(result, args);
+  if (!isShallowRepository()) {
+    return { base: null, recoveredShallowMiss: false };
+  }
 
-  spawnGit(["fetch", "--deepen=32", remote, branch], {
+  const deepenArgs = ["fetch", "--deepen=32", remote, branch];
+  const deepen = spawnGit(deepenArgs, {
     quiet: true,
     timeout: PUBLISH_FETCH_TIMEOUT_MS,
   });
+  if (deepen.timedOut) throw new GitCommandTimeoutError(deepenArgs, PUBLISH_FETCH_TIMEOUT_MS);
+  if (deepen.status !== 0) throw gitRunError(deepen, deepenArgs);
   result = spawnGit(args, { quiet: true });
   if (result.status === 0) {
     return { base: result.stdout.trim(), recoveredShallowMiss: true };
@@ -861,16 +867,23 @@ function mergeBaseWithShallowRecovery(
   if (result.status !== 1) throw gitRunError(result, args);
 
   if (isShallowRepository()) {
-    spawnGit(["fetch", "--unshallow", remote, branch], {
+    const unshallowArgs = ["fetch", "--unshallow", remote, branch];
+    const unshallow = spawnGit(unshallowArgs, {
       quiet: true,
       timeout: PUBLISH_FETCH_TIMEOUT_MS,
     });
+    if (unshallow.timedOut) {
+      throw new GitCommandTimeoutError(unshallowArgs, PUBLISH_FETCH_TIMEOUT_MS);
+    }
+    if (unshallow.status !== 0) throw gitRunError(unshallow, unshallowArgs);
     result = spawnGit(args, { quiet: true });
     if (result.status === 0) {
       return { base: result.stdout.trim(), recoveredShallowMiss: true };
     }
   }
-  throw gitRunError(result, args);
+  if (result.status !== 1) throw gitRunError(result, args);
+  if (isShallowRepository()) throw gitRunError(result, args);
+  return { base: null, recoveredShallowMiss: true };
 }
 
 function prepareReconciliationStateRoot(
@@ -893,13 +906,17 @@ function prepareReconciliationStateRoot(
     return;
   }
   const semanticBase = mergeBaseWithShallowRecovery("HEAD", remoteRef, remote, branch);
-  if (semanticBase.recoveredShallowMiss) {
+  if (!semanticBase.base) {
+    console.log(
+      `No common Git base with ${remoteRef}; resetting the unpublished reconciliation checkpoint to the remote head`,
+    );
+  } else if (semanticBase.recoveredShallowMiss) {
     console.log(
       `Recovered the common Git base with ${remoteRef} after hydrating the shallow state checkout`,
     );
   }
   console.log("Discarding an unpublished reconciliation checkpoint before retry");
-  runGit(["reset", "--hard", semanticBase.base]);
+  runGit(["reset", "--hard", semanticBase.base ?? remoteRef]);
 }
 
 function reconciliationTupleKeysForCommit(sourceCommit: string): string[] {
@@ -1510,11 +1527,30 @@ function rebuildReconciliationCommit(
   const remoteRef = `${remote}/${branch}`;
   const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
   const mergeBase = mergeBaseWithShallowRecovery(sourceCommit, remoteRef, remote, branch);
-  const baseCommit = mergeBase.base;
-  if (mergeBase.recoveredShallowMiss) {
-    console.log(`Rebuilding reconciliation directly on ${remoteRef} after a shallow fetch`);
+  let baseCommit: string;
+  let localPaths: string[];
+  if (!mergeBase.base) {
+    if (!reconciliationSourceCommit || !allowedTupleKeys) {
+      console.log(
+        `No common Git base with ${remoteRef}; refusing an unbounded reconciliation rebuild`,
+      );
+      return false;
+    }
+    const sourceBaseCommit = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
+    // The rebuilt commit is rooted on remoteRef below, but tuple arbitration
+    // still needs the publication's real parent to recognize remote changes.
+    baseCommit = sourceBaseCommit;
+    localPaths = changedPathsBetween(sourceBaseCommit, sourceCommit);
+    console.log(
+      `No common Git base with ${remoteRef}; rebuilding reconciliation on the remote head`,
+    );
+  } else {
+    baseCommit = mergeBase.base;
+    localPaths = changedPathsBetween(baseCommit, sourceCommit);
+    if (mergeBase.recoveredShallowMiss) {
+      console.log(`Rebuilding reconciliation directly on ${remoteRef} after a shallow fetch`);
+    }
   }
-  const localPaths = changedPathsBetween(baseCommit, sourceCommit);
   const localIdentities = new Map<string, RecordTupleIdentity>();
   for (const path of localPaths) {
     const identity = recordTupleIdentityForPath(path);

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1536,7 +1536,14 @@ function rebuildReconciliationCommit(
       );
       return false;
     }
-    const sourceBaseCommit = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
+    // A root checkpoint has no parent; the empty tree is the correct baseline
+    // there (every publication path is new), so the initial-publication race
+    // still reconciles instead of crashing on `<root>^`.
+    const sourceParent = spawnGit(["rev-parse", `${sourceCommit}^`], { quiet: true });
+    const sourceBaseCommit =
+      sourceParent.status === 0
+        ? sourceParent.stdout.trim()
+        : runGit(["hash-object", "-t", "tree", "/dev/null"], { quiet: true }).trim();
     // The rebuilt commit is rooted on remoteRef below, but tuple arbitration
     // still needs the publication's real parent to recognize remote changes.
     baseCommit = sourceBaseCommit;

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1543,7 +1543,7 @@ function rebuildReconciliationCommit(
     const sourceBaseCommit =
       sourceParent.status === 0
         ? sourceParent.stdout.trim()
-        : runGit(["hash-object", "-t", "tree", "/dev/null"], { quiet: true }).trim();
+        : runGit(["hash-object", "-w", "-t", "tree", "/dev/null"], { quiet: true }).trim();
     // The rebuilt commit is rooted on remoteRef below, but tuple arbitration
     // still needs the publication's real parent to recognize remote changes.
     baseCommit = sourceBaseCommit;

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1229,7 +1229,7 @@ test("reconcile-records fails closed on a concurrent tuple filename alias", () =
   );
 });
 
-test("reconcile-records fails closed when state and remote have no common base", () => {
+test("reconcile-records preserves a newer remote tuple after resetting unrelated state", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-unrelated-"));
   const origin = path.join(root, "origin.git");
   const state = path.join(root, "state");
@@ -1238,11 +1238,11 @@ test("reconcile-records fails closed when state and remote have no common base",
   run("git", ["init", "--bare", origin], root);
   run("git", ["clone", origin, state], root);
   configureUser(state);
-  const baseTuple = writeRecordTuple(state, {
+  const remoteTuple = writeRecordTuple(state, {
     number: 42,
-    marker: "remote base",
-    reviewedAt: "2026-07-09T23:00:00.000Z",
-    itemUpdatedAt: "2026-07-09T22:59:00Z",
+    marker: "newer remote tuple",
+    reviewedAt: "2026-07-09T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:02:00Z",
   });
   run("git", ["add", "."], state);
   run("git", ["commit", "-m", "remote base"], state);
@@ -1265,36 +1265,38 @@ test("reconcile-records fails closed when state and remote have no common base",
   run("git", ["commit", "-m", "unrelated local history"], state);
 
   const lines = [];
-  assert.throws(
-    () =>
-      captureConsoleLog(
-        () =>
-          withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
-            withCwd(work, () =>
-              publishMainCommit({
-                message: "chore: reject unrelated state",
-                paths: [recordsRoot],
-                maxAttempts: 1,
-                pushAttempts: 1,
-                rebaseStrategy: "reconcile-records",
-              }),
-            ),
-          ),
-        lines,
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: publish from unrelated state",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
       ),
-    /git merge-base <redacted-args> exited 1/,
-  );
+    );
+  }, lines);
+
+  assert.equal(result, "unchanged");
   assert.equal(
-    lines.some((line) => line.includes("Git publish failure: phase=prepare")),
+    lines.some((line) =>
+      line.includes(
+        "No common Git base with origin/state; resetting the unpublished reconciliation checkpoint to the remote head",
+      ),
+    ),
     true,
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
-    baseTuple.primary,
+    remoteTuple.primary,
   );
+  assert.throws(() => run("git", ["--git-dir", origin, "show", "state:unrelated.txt"], root));
 });
 
-test("reconcile-records fails closed when shallow state and remote are truly unrelated", () => {
+test("reconcile-records resets shallow state to a truly unrelated remote head", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-shallow-unrelated-"));
   const origin = path.join(root, "origin.git");
   const seed = path.join(root, "seed");
@@ -1319,7 +1321,7 @@ test("reconcile-records fails closed when shallow state and remote are truly unr
 
   fs.mkdirSync(work);
   fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
-  writeRecordTuple(work, {
+  const candidateTuple = writeRecordTuple(work, {
     number: 42,
     marker: "candidate update",
     reviewedAt: "2026-07-19T23:02:00.000Z",
@@ -1335,33 +1337,39 @@ test("reconcile-records fails closed when shallow state and remote are truly unr
   run("git", ["push", "--force", "origin", "HEAD:state"], seed);
 
   const lines = [];
-  assert.throws(
-    () =>
-      captureConsoleLog(
-        () =>
-          withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
-            withCwd(work, () =>
-              publishMainCommit({
-                message: "chore: reject unrelated shallow state",
-                paths: [recordsRoot],
-                maxAttempts: 1,
-                pushAttempts: 1,
-                rebaseStrategy: "reconcile-records",
-              }),
-            ),
-          ),
-        lines,
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: publish from unrelated shallow state",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+        }),
       ),
-    /git merge-base <redacted-args> exited 1/,
-  );
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
   assert.equal(
-    lines.some((line) => line.includes("Git publish failure: phase=prepare")),
+    lines.some((line) =>
+      line.includes(
+        "No common Git base with origin/state; resetting the unpublished reconciliation checkpoint to the remote head",
+      ),
+    ),
     true,
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "state:replacement.txt"], root),
     "replacement history\n",
   );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
+    candidateTuple.primary,
+  );
+  assert.equal(run("git", ["rev-parse", "--is-shallow-repository"], state).trim(), "false");
 });
 
 test("reconcile-records prepares a shallow state checkout from the remote head", () => {
@@ -1538,20 +1546,19 @@ test("reconcile-records rebuilds on a shallow remote head without local ancestry
   );
 });
 
-test("checkpoint merge-base misses defer to a remote-head rebuild", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-checkpoint-merge-base-"));
+test("checkpoint publish rebuilds on the remote head when histories are unrelated", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-checkpoint-unrelated-"));
   const origin = path.join(root, "origin.git");
-  const state = path.join(root, "state");
   const work = path.join(root, "work");
   const other = path.join(root, "other");
-  const fakeBin = path.join(root, "bin");
   const recordsRoot = "records/openclaw-openclaw";
   const numbers = Array.from({ length: 129 }, (_, index) => 120_000 + index);
+  const overlapNumber = numbers[0];
   run("git", ["init", "--bare", origin], root);
-  run("git", ["clone", origin, state], root);
-  configureUser(state);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
   for (const number of numbers) {
-    writeRecordTuple(state, {
+    writeRecordTuple(work, {
       number,
       marker: `base ${number}`,
       reviewedAt: "2026-07-20T06:00:00.000Z",
@@ -1560,14 +1567,12 @@ test("checkpoint merge-base misses defer to a remote-head rebuild", () => {
       plan: false,
     });
   }
-  run("git", ["add", "."], state);
-  run("git", ["commit", "-m", "initial state"], state);
-  run("git", ["push", "origin", "HEAD:state"], state);
+  write(path.join(work, "old-history-only.txt"), "must not be resurrected\n");
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial state"], work);
+  run("git", ["push", "origin", "HEAD:state"], work);
   run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
-  run("git", ["checkout", "-B", "state", "origin/state"], state);
-
-  fs.mkdirSync(work);
-  fs.cpSync(path.join(state, "records"), path.join(work, "records"), { recursive: true });
+  run("git", ["checkout", "-B", "state", "origin/state"], work);
   for (const number of numbers) {
     writeRecordTuple(work, {
       number,
@@ -1582,51 +1587,240 @@ test("checkpoint merge-base misses defer to a remote-head rebuild", () => {
 
   run("git", ["clone", origin, other], root);
   configureUser(other);
+  run("git", ["checkout", "--orphan", "replacement"], other);
+  run("git", ["read-tree", "--empty"], other);
+  fs.rmSync(path.join(other, "records"), { force: true, recursive: true });
+  fs.rmSync(path.join(other, "old-history-only.txt"));
+  let remoteOverlapTuple;
+  for (const number of numbers) {
+    const tuple = writeRecordTuple(other, {
+      number,
+      marker: number === overlapNumber ? `newer remote ${number}` : `base ${number}`,
+      reviewedAt:
+        number === overlapNumber ? "2026-07-20T06:04:00.000Z" : "2026-07-20T06:00:00.000Z",
+      itemUpdatedAt: number === overlapNumber ? "2026-07-20T06:03:00Z" : "2026-07-20T05:59:00Z",
+      packet: false,
+      plan: false,
+    });
+    if (number === overlapNumber) remoteOverlapTuple = tuple;
+  }
   const remoteTuple = writeRecordTuple(other, {
     number: 130_000,
-    marker: "concurrent remote tuple",
+    marker: "replacement-history remote tuple",
     reviewedAt: "2026-07-20T06:03:00.000Z",
     itemUpdatedAt: "2026-07-20T06:02:00Z",
     packet: false,
     plan: false,
   });
   run("git", ["add", "."], other);
-  run("git", ["commit", "-m", "concurrent remote tuple"], other);
-  installFirstPushRaceHook(state, other, "state");
-  installCheckpointMergeBaseFailureShim(fakeBin, state);
+  run("git", ["commit", "-m", "replacement state history"], other);
+  run("git", ["push", "--force", "origin", "HEAD:state"], other);
 
   const lines = [];
   let result;
   captureConsoleLog(() => {
-    result = withEnv({ CLAWSWEEPER_STATE_DIR: state, PATH: `${fakeBin}:${process.env.PATH}` }, () =>
-      withCwd(work, () =>
-        publishMainCommit({
-          message: "chore: publish checkpoint records",
-          paths: [recordsRoot],
-          maxAttempts: 1,
-          pushAttempts: 2,
-          rebaseStrategy: "reconcile-records",
-        }),
-      ),
+    result = withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: publish checkpoint records",
+        paths: [recordsRoot],
+        branch: "state",
+        maxAttempts: 1,
+        pushAttempts: 2,
+        rebaseStrategy: "reconcile-records",
+      }),
     );
   }, lines);
 
   assert.equal(result, "committed");
-  assert.equal(fs.existsSync(path.join(state, ".git", "checkpoint-merge-base-failed")), true);
   assert.equal(
-    lines.some((line) => line.includes("deferring overlap detection to a remote-head rebuild")),
+    lines.some(
+      (line) =>
+        line ===
+        "No common Git base with origin/state; rebuilding reconciliation on the remote head",
+    ),
     true,
   );
   assert.equal(
     run(
       "git",
-      ["--git-dir", origin, "show", `state:${recordsRoot}/closed/${numbers[0]}.md`],
+      ["--git-dir", origin, "show", `state:${recordsRoot}/closed/${numbers[1]}.md`],
       root,
-    ).includes(`# closed ${numbers[0]}`),
+    ).includes(`# closed ${numbers[1]}`),
     true,
   );
   assert.equal(
+    run(
+      "git",
+      ["--git-dir", origin, "show", `state:${recordsRoot}/items/${overlapNumber}.md`],
+      root,
+    ),
+    remoteOverlapTuple.primary,
+  );
+  assert.equal(
     run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/130000.md`], root),
+    remoteTuple.primary,
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", "state:old-history-only.txt"], root),
+  );
+});
+
+test("reconcile-records keeps non-1 merge-base failures fatal", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-merge-base-error-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const fakeBin = path.join(root, "bin");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "local base",
+    reviewedAt: "2026-07-20T06:00:00.000Z",
+    itemUpdatedAt: "2026-07-20T05:59:00Z",
+    packet: false,
+    plan: false,
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial state"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "local close",
+    reviewedAt: "2026-07-20T06:02:00.000Z",
+    itemUpdatedAt: "2026-07-20T06:01:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+  });
+
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  run("git", ["checkout", "--orphan", "replacement"], other);
+  run("git", ["read-tree", "--empty"], other);
+  fs.rmSync(path.join(other, "records"), { force: true, recursive: true });
+  const remoteTuple = writeRecordTuple(other, {
+    number: 43,
+    marker: "replacement remote tuple",
+    reviewedAt: "2026-07-20T06:03:00.000Z",
+    itemUpdatedAt: "2026-07-20T06:02:00Z",
+    packet: false,
+    plan: false,
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "replacement state history"], other);
+  run("git", ["push", "--force", "origin", "HEAD:main"], other);
+  installSecondMergeBaseFailureShim(fakeBin, work);
+
+  const lines = [];
+  assert.throws(
+    () =>
+      captureConsoleLog(
+        () =>
+          withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+            withCwd(work, () =>
+              publishMainCommit({
+                message: "chore: reject broken merge-base",
+                paths: [recordsRoot],
+                maxAttempts: 1,
+                pushAttempts: 2,
+                rebaseStrategy: "reconcile-records",
+              }),
+            ),
+          ),
+        lines,
+      ),
+    /fatal: synthetic merge-base failure/,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("Git publish failure: phase=push")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/43.md`], root),
+    remoteTuple.primary,
+  );
+});
+
+test("reconcile-records keeps shallow hydration failures fatal", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-shallow-hydration-error-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const work = path.join(root, "work");
+  const fakeBin = path.join(root, "bin");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  writeRecordTuple(seed, {
+    number: 42,
+    marker: "local base",
+    reviewedAt: "2026-07-20T06:00:00.000Z",
+    itemUpdatedAt: "2026-07-20T05:59:00Z",
+    packet: false,
+    plan: false,
+  });
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial state"], seed);
+  run("git", ["push", "origin", "HEAD:main"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, work], root);
+  configureUser(work);
+  writeRecordTuple(work, {
+    number: 42,
+    marker: "local close",
+    reviewedAt: "2026-07-20T06:02:00.000Z",
+    itemUpdatedAt: "2026-07-20T06:01:00Z",
+    location: "closed",
+    packet: false,
+    plan: false,
+  });
+
+  run("git", ["checkout", "--orphan", "replacement"], seed);
+  run("git", ["read-tree", "--empty"], seed);
+  fs.rmSync(path.join(seed, "records"), { force: true, recursive: true });
+  const remoteTuple = writeRecordTuple(seed, {
+    number: 43,
+    marker: "replacement remote tuple",
+    reviewedAt: "2026-07-20T06:03:00.000Z",
+    itemUpdatedAt: "2026-07-20T06:02:00Z",
+    packet: false,
+    plan: false,
+  });
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "replacement state history"], seed);
+  run("git", ["push", "--force", "origin", "HEAD:main"], seed);
+  installDeepenFetchFailureShim(fakeBin);
+
+  const lines = [];
+  assert.throws(
+    () =>
+      captureConsoleLog(
+        () =>
+          withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+            withCwd(work, () =>
+              publishMainCommit({
+                message: "chore: reject failed shallow hydration",
+                paths: [recordsRoot],
+                maxAttempts: 1,
+                pushAttempts: 2,
+                rebaseStrategy: "reconcile-records",
+              }),
+            ),
+          ),
+        lines,
+      ),
+    /fatal: synthetic deepen failure/,
+  );
+  assert.equal(
+    lines.some((line) => line.includes("Git publish failure: phase=push")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/43.md`], root),
     remoteTuple.primary,
   );
 });
@@ -3401,19 +3595,42 @@ exit "$result"
   fs.chmodSync(git, 0o755);
 }
 
-function installCheckpointMergeBaseFailureShim(fakeBin, state) {
+function installSecondMergeBaseFailureShim(fakeBin, work) {
   fs.mkdirSync(fakeBin, { recursive: true });
   const git = path.join(fakeBin, "git");
-  const pushCounter = path.join(state, ".git", "hooks", "pre-push-count");
-  const marker = path.join(state, ".git", "checkpoint-merge-base-failed");
+  const counter = path.join(work, ".git", "merge-base-count");
   const realGit = run("/usr/bin/env", ["which", "git"], process.cwd()).trim();
   fs.writeFileSync(
     git,
     `#!/bin/sh
 set -u
-if test "$1" = merge-base && test -e "${pushCounter}" && test ! -e "${marker}"; then
-  : > "${marker}"
-  exit 1
+if test "$1" = merge-base; then
+  count=0
+  if test -f "${counter}"; then count=$(cat "${counter}"); fi
+  count=$((count + 1))
+  printf '%s\n' "$count" > "${counter}"
+  if test "$count" -eq 2; then
+    printf '%s\n' 'fatal: synthetic merge-base failure' >&2
+    exit 2
+  fi
+fi
+exec "${realGit}" "$@"
+`,
+  );
+  fs.chmodSync(git, 0o755);
+}
+
+function installDeepenFetchFailureShim(fakeBin) {
+  fs.mkdirSync(fakeBin, { recursive: true });
+  const git = path.join(fakeBin, "git");
+  const realGit = run("/usr/bin/env", ["which", "git"], process.cwd()).trim();
+  fs.writeFileSync(
+    git,
+    `#!/bin/sh
+set -u
+if test "$1" = fetch && test "$2" = --deepen=32; then
+  printf '%s\n' 'fatal: synthetic deepen failure' >&2
+  exit 2
 fi
 exec "${realGit}" "$@"
 `,


### PR DESCRIPTION
Third and final fix for the apply/close pipeline outage. After #714, prod run 29732302720 showed the ledger publish succeeding but "Apply close proposals" still dying: `Git publish failure: phase=checkpoint ... git merge-base exited 1` — the reconciliation checkpoint's merge-base recovery ladder (deepen → unshallow, 374s in the log) exhausted and the local state history is genuinely unrelated to the remote branch head (orphaned local root after 30h of crashed publishes).

Changes (src/repair/git-publish.ts):
- `mergeBaseWithShallowRecovery` returns `base: null` only for confirmed-unrelated, fully hydrated histories; non-1 errors, failed hydration, and still-shallow states keep throwing.
- The reconciliation caller rebuilds directly on the remote head for no-base: bounded publications replay only their delta (tuple arbitration against the publication's real parent); unbounded rebuilds fail closed. The preparation caller resets unrelated state to the remote head.
- Root checkpoints (no parent commit) use a written empty-tree object as the baseline instead of crashing on `<root>^` (autoreview-caught edge, two follow-up commits).

Validation: build/lint/format green; git-publish suite 46/47 (the miss is the documented CI-token-only server-merge fixture); new tests cover unrelated preparation, orphaned checkpoint publishing, overlap arbitration, old-history non-resurrection, non-1 errors, and hydration failures; commit-mode autoreview clean (0.99 on final commit).
