### PR TITLE
fix(apply): sync labels across truncated activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Synchronized review-derived labels on high-activity pull requests when complete hydration proves omitted activity is automation-only, while continuing to fail closed on hidden human activity or incomplete hydration. Thanks @veteranbv.
 - Stopped stale "review started" placeholder comments from accumulating on reviewed items: publishing the durable review comment now sweeps superseded placeholders.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.
 - Removed the synthetic Codex write preflight that could block repair before Codex saw the real task.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -818,7 +818,16 @@ interface AgentsPolicyStatus {
 
 type GoodFirstIssueHumanLabelState = "removed" | "added" | "unknown";
 
+const completeActivityContextSymbol = Symbol("completeActivityContext");
+
+interface CompleteActivityContext {
+  comments: unknown[];
+  timeline: unknown[];
+  pullReviewComments: unknown[];
+}
+
 interface ItemContext {
+  [completeActivityContextSymbol]?: CompleteActivityContext;
   issue: unknown;
   comments: unknown[];
   timeline: unknown[];
@@ -9160,6 +9169,8 @@ function collectItemContext(
   let pullReviewComments: unknown[] | null = null;
   let filteredPullReviewComments: { included: unknown[]; filtered: number } | null = null;
   let digestPullReviewComments: { included: unknown[]; filtered: number } | null = null;
+  let completePullReviewComments: { included: unknown[]; filtered: number } | null = null;
+  let completePullReviewCommentsHydrated = item.kind !== "pull_request";
   if (item.kind === "issue") {
     const closingPullRequests = closingPullRequestsForIssue(item.number);
     if (closingPullRequests.length > 0) {
@@ -9210,13 +9221,20 @@ function collectItemContext(
     pullReviewComments = pullReviewCommentsWindow.items;
     filteredPullReviewComments = filterReviewContextComments(pullReviewComments, item.number);
     const fullPullReviewComments =
-      options.reviewCacheDigest && pullReviewCommentsWindow.truncated
+      (options.reviewCacheDigest || options.fullTimelineForRelations) &&
+      pullReviewCommentsWindow.truncated
         ? ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/comments`)
         : pullReviewComments;
     digestPullReviewComments =
+      !options.reviewCacheDigest || fullPullReviewComments === pullReviewComments
+        ? filteredPullReviewComments
+        : filterReviewContextComments(fullPullReviewComments, item.number);
+    completePullReviewComments =
       fullPullReviewComments === pullReviewComments
         ? filteredPullReviewComments
         : filterReviewContextComments(fullPullReviewComments, item.number);
+    completePullReviewCommentsHydrated =
+      fullPullReviewComments.length >= pullReviewCommentsWindow.total;
     context.pullRequest = compactPullRequest(pullRequest);
     context.pullFiles = compactMappedWindow(pullFiles, pullFilesWindow.total, 80, compactPullFile);
     context.semanticPullFiles =
@@ -9347,6 +9365,19 @@ function collectItemContext(
     if (context.counts?.closingPullRequests !== undefined)
       counts.closingPullRequests = context.counts.closingPullRequests;
     context.counts = counts;
+  }
+  const completeActivityHydrated =
+    sourceRevisionComments.length >= commentsWindow.total &&
+    (fullTimeline ?? timeline).length >= timelineWindow.total &&
+    completePullReviewCommentsHydrated;
+  if (options.fullTimelineForRelations && completeActivityHydrated) {
+    context[completeActivityContextSymbol] = {
+      comments: filterReviewContextComments(sourceRevisionComments, item.number).included.map(
+        compactComment,
+      ),
+      timeline: (fullTimeline ?? timeline).map(compactTimelineEvent),
+      pullReviewComments: (completePullReviewComments?.included ?? []).map(compactComment),
+    };
   }
   return context;
 }
@@ -16312,6 +16343,7 @@ function contextHasNonAutomationActivityAfter(
   reviewedAtMs: number,
   options: {
     truncationCountsAsActivity?: boolean;
+    useCompleteActivityContext?: boolean;
     ignoreTimelineCommentsThroughMs?: number;
     ignoreTrustedTimelineComment?: {
       authors: ReadonlySet<string>;
@@ -16320,12 +16352,15 @@ function contextHasNonAutomationActivityAfter(
   } = {},
 ): boolean {
   const truncationCountsAsActivity = options.truncationCountsAsActivity ?? true;
-  if (
-    truncationCountsAsActivity &&
-    (context.counts?.commentsTruncated ||
-      context.counts?.timelineTruncated ||
-      context.counts?.pullReviewCommentsTruncated)
-  ) {
+  const activityContextTruncated = Boolean(
+    context.counts?.commentsTruncated ||
+    context.counts?.timelineTruncated ||
+    context.counts?.pullReviewCommentsTruncated,
+  );
+  const completeActivityContext = options.useCompleteActivityContext
+    ? context[completeActivityContextSymbol]
+    : undefined;
+  if (truncationCountsAsActivity && activityContextTruncated && !completeActivityContext) {
     return true;
   }
   const hasNonAutomationComment = (comment: unknown): boolean => {
@@ -16363,29 +16398,53 @@ function contextHasNonAutomationActivityAfter(
     );
   };
   return (
-    context.comments.some(hasNonAutomationComment) ||
-    (context.pullReviewComments ?? []).some(hasNonAutomationComment) ||
-    context.timeline.some(hasNonAutomationEvent)
+    (completeActivityContext?.comments ?? context.comments).some(hasNonAutomationComment) ||
+    (completeActivityContext?.pullReviewComments ?? context.pullReviewComments ?? []).some(
+      hasNonAutomationComment,
+    ) ||
+    (completeActivityContext?.timeline ?? context.timeline).some(hasNonAutomationEvent)
   );
 }
 
 export function contextHasNonAutomationActivityAfterForTest(options: {
   comments?: unknown[];
   timeline?: unknown[];
+  pullReviewComments?: unknown[];
+  truncated?: {
+    comments?: boolean;
+    timeline?: boolean;
+    pullReviewComments?: boolean;
+  };
+  completeActivityContext?: Partial<CompleteActivityContext>;
   activityAfterMs: number;
   ignoreTimelineCommentsThroughMs?: number;
 }): boolean {
-  return contextHasNonAutomationActivityAfter(
-    {
-      issue: {},
-      comments: options.comments ?? [],
-      timeline: options.timeline ?? [],
+  const context: ItemContext = {
+    issue: {},
+    comments: options.comments ?? [],
+    timeline: options.timeline ?? [],
+    pullReviewComments: options.pullReviewComments ?? [],
+    counts: {
+      comments: options.comments?.length ?? 0,
+      commentsTruncated: options.truncated?.comments ?? false,
+      timeline: options.timeline?.length ?? 0,
+      timelineTruncated: options.truncated?.timeline ?? false,
+      pullReviewCommentsTruncated: options.truncated?.pullReviewComments ?? false,
     },
-    options.activityAfterMs,
-    options.ignoreTimelineCommentsThroughMs === undefined
+  };
+  if (options.completeActivityContext) {
+    context[completeActivityContextSymbol] = {
+      comments: options.completeActivityContext.comments ?? [],
+      timeline: options.completeActivityContext.timeline ?? [],
+      pullReviewComments: options.completeActivityContext.pullReviewComments ?? [],
+    };
+  }
+  return contextHasNonAutomationActivityAfter(context, options.activityAfterMs, {
+    ...(options.completeActivityContext ? { useCompleteActivityContext: true } : {}),
+    ...(options.ignoreTimelineCommentsThroughMs === undefined
       ? {}
-      : { ignoreTimelineCommentsThroughMs: options.ignoreTimelineCommentsThroughMs },
-  );
+      : { ignoreTimelineCommentsThroughMs: options.ignoreTimelineCommentsThroughMs }),
+  });
 }
 
 function pullRequestUrlForNumber(number: number): string {
@@ -28107,7 +28166,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       return !contextHasNonAutomationActivityAfter(
         currentItemContext(),
         storedUpdatedAtMs,
-        reviewedAtMs === null ? {} : { ignoreTimelineCommentsThroughMs: reviewedAtMs },
+        {
+          useCompleteActivityContext: true,
+          ...(reviewedAtMs === null ? {} : { ignoreTimelineCommentsThroughMs: reviewedAtMs }),
+        },
       );
     };
     const stalePrReviewHead =

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -51,6 +51,65 @@ test("command-only timeline activity is ignored only through the completed revie
   );
 });
 
+test("complete activity hydration distinguishes truncation from hidden human activity", () => {
+  const activityAfterMs = Date.parse("2026-07-03T21:42:48Z");
+  const surfaces = [
+    {
+      name: "comments",
+      automation: { author: "fixture[bot]", createdAt: "2026-07-03T21:45:00Z" },
+      human: { author: "maintainer", createdAt: "2026-07-03T21:46:00Z" },
+    },
+    {
+      name: "timeline",
+      automation: {
+        event: "labeled",
+        actor: "fixture[bot]",
+        createdAt: "2026-07-03T21:45:00Z",
+      },
+      human: {
+        event: "labeled",
+        actor: "maintainer",
+        createdAt: "2026-07-03T21:46:00Z",
+      },
+    },
+    {
+      name: "pullReviewComments",
+      automation: { author: "fixture[bot]", createdAt: "2026-07-03T21:45:00Z" },
+      human: { author: "maintainer", createdAt: "2026-07-03T21:46:00Z" },
+    },
+  ] as const;
+
+  for (const surface of surfaces) {
+    assert.equal(
+      contextHasNonAutomationActivityAfterForTest({
+        truncated: { [surface.name]: true },
+        completeActivityContext: { [surface.name]: [surface.automation] },
+        activityAfterMs,
+      }),
+      false,
+      `${surface.name} automation-only hydration should permit reconciliation`,
+    );
+    assert.equal(
+      contextHasNonAutomationActivityAfterForTest({
+        truncated: { [surface.name]: true },
+        completeActivityContext: { [surface.name]: [surface.automation, surface.human] },
+        activityAfterMs,
+      }),
+      true,
+      `${surface.name} hydration must preserve hidden human activity`,
+    );
+  }
+
+  assert.equal(
+    contextHasNonAutomationActivityAfterForTest({
+      truncated: { comments: true },
+      activityAfterMs,
+    }),
+    true,
+    "truncation without complete hydration must remain fail closed",
+  );
+});
+
 test("apply-decisions publishes a detected bulk-filer label from a failed exact review artifact", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
@@ -1665,6 +1724,42 @@ Full review comments:
 const { appendFileSync, readFileSync } = require("fs");
 const logPath = ${JSON.stringify(logPath)};
 const comment = ${JSON.stringify(synced.comment)};
+const comments = [
+  {
+    id: 987482,
+    html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987482",
+    body: comment,
+    user: { login: "clawsweeper[bot]" },
+    created_at: "2026-07-03T21:33:21Z",
+    updated_at: "2026-07-03T21:33:21Z"
+  },
+  {
+    id: 987483,
+    html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987483",
+    body: "Pushed a new head, please take another look.",
+    user: { login: "contributor" },
+    author_association: "CONTRIBUTOR",
+    created_at: "2026-07-03T21:42:28Z",
+    updated_at: "2026-07-03T21:42:28Z"
+  },
+  {
+    id: 987484,
+    html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987484",
+    body: "@clawsweeper re-review",
+    user: { login: "contributor" },
+    author_association: "CONTRIBUTOR",
+    created_at: "2026-07-03T21:43:00Z",
+    updated_at: "2026-07-03T21:43:00Z"
+  },
+  ...Array.from({ length: 22 }, (_, index) => ({
+    id: 987500 + index,
+    html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-" + (987500 + index),
+    body: "automation update " + (index + 1),
+    user: { login: "fixture[bot]" },
+    created_at: "2026-07-03T21:45:00Z",
+    updated_at: "2026-07-03T21:45:00Z"
+  }))
+];
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
@@ -1688,6 +1783,7 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "contributor" },
+    comments: comments.length,
     labels: ["status: 📣 needs proof", "rating: 🦪 silver shellfish"],
     pull_request: {}
   }));
@@ -1710,34 +1806,7 @@ if (args[0] === "api" && /\\/issues\\/74482$/.test(path)) {
 } else if (args[0] === "api" && /\\/pulls\\/74482\\/(files|commits|comments|reviews)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74482\\/comments(?:\\?|$)/.test(path)) {
-  console.log(JSON.stringify([[
-    {
-      id: 987482,
-      html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987482",
-      body: comment,
-      user: { login: "clawsweeper[bot]" },
-      created_at: "2026-07-03T21:33:21Z",
-      updated_at: "2026-07-03T21:33:21Z"
-    },
-    {
-      id: 987483,
-      html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987483",
-      body: "Pushed a new head, please take another look.",
-      user: { login: "contributor" },
-      author_association: "CONTRIBUTOR",
-      created_at: "2026-07-03T21:42:28Z",
-      updated_at: "2026-07-03T21:42:28Z"
-    },
-    {
-      id: 987484,
-      html_url: "https://github.com/openclaw/openclaw/pull/74482#issuecomment-987484",
-      body: "@clawsweeper re-review",
-      user: { login: "contributor" },
-      author_association: "CONTRIBUTOR",
-      created_at: "2026-07-03T21:43:00Z",
-      updated_at: "2026-07-03T21:43:00Z"
-    }
-  ]]));
+  console.log(JSON.stringify(args.includes("--paginate") ? [comments] : comments));
 } else if (args[0] === "api" && /\\/issues\\/comments\\/987482$/.test(path)) {
   const input = args[args.indexOf("--input") + 1];
   appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");
@@ -1891,6 +1960,35 @@ Full review comments:
 const { appendFileSync, readFileSync } = require("fs");
 const logPath = ${JSON.stringify(logPath)};
 const comment = ${JSON.stringify(synced.comment)};
+const automationComments = Array.from({ length: 23 }, (_, index) => ({
+  id: 987500 + index,
+  html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-" + (987500 + index),
+  body: "automation update " + (index + 1),
+  user: { login: "fixture[bot]" },
+  created_at: "2026-07-03T21:45:00Z",
+  updated_at: "2026-07-03T21:45:00Z"
+}));
+const comments = [
+  {
+    id: 987484,
+    html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987484",
+    body: comment,
+    user: { login: "clawsweeper[bot]" },
+    created_at: "2026-07-03T21:33:21Z",
+    updated_at: "2026-07-03T21:33:21Z"
+  },
+  ...automationComments.slice(0, 11),
+  {
+    id: 987485,
+    html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987485",
+    body: "I already relabeled this myself, leave the labels alone.",
+    user: { login: "maintainer" },
+    author_association: "MEMBER",
+    created_at: "2026-07-03T21:44:00Z",
+    updated_at: "2026-07-03T21:44:00Z"
+  },
+  ...automationComments.slice(11)
+];
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
@@ -1908,6 +2006,7 @@ if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "contributor" },
+    comments: comments.length,
     labels: [],
     pull_request: {}
   }));
@@ -1930,25 +2029,7 @@ if (args[0] === "api" && /\\/issues\\/74483$/.test(path)) {
 } else if (args[0] === "api" && /\\/pulls\\/74483\\/(files|commits|comments|reviews)(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/74483\\/comments(?:\\?|$)/.test(path)) {
-  console.log(JSON.stringify([[
-    {
-      id: 987484,
-      html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987484",
-      body: comment,
-      user: { login: "clawsweeper[bot]" },
-      created_at: "2026-07-03T21:33:21Z",
-      updated_at: "2026-07-03T21:33:21Z"
-    },
-    {
-      id: 987485,
-      html_url: "https://github.com/openclaw/openclaw/pull/74483#issuecomment-987485",
-      body: "I already relabeled this myself, leave the labels alone.",
-      user: { login: "maintainer" },
-      author_association: "MEMBER",
-      created_at: "2026-07-03T21:44:00Z",
-      updated_at: "2026-07-03T21:44:00Z"
-    }
-  ]]));
+  console.log(JSON.stringify(args.includes("--paginate") ? [comments] : comments));
 } else if (args[0] === "api" && /\\/issues\\/comments\\/987484$/.test(path)) {
   const input = args[args.indexOf("--input") + 1];
   appendFileSync(logPath, JSON.stringify(["patched-review-body", JSON.parse(readFileSync(input, "utf8")).body]) + "\\n");


### PR DESCRIPTION
Fixes #717

## What Problem This Solves

On busy pull requests, ClawSweeper can publish a current-head durable review while leaving every review-derived label stale. The label freshness gate treats a truncated issue-comment, timeline, or inline-review-comment window as post-review human activity, even when complete hydration shows that the omitted entries are automation-only.

That is what happened on [openclaw/openclaw#91268](https://github.com/openclaw/openclaw/pull/91268): the exact-head review upgraded the verdict to platinum with sufficient proof, but the successful [publisher run](https://github.com/openclaw/clawsweeper/actions/runs/29713005794) only updated the durable comment. The state record remained gold / needs-proof because its 39 comments and 188 timeline events exceeded the prompt windows.

This is label and state drift, not a review or merge-safety bypass. The existing behavior fails closed; it just fails closed permanently for high-activity PRs.

## Why This Change Was Made

Prompt context stays bounded exactly as before. Apply-time collection now retains a complete activity view behind symbol-keyed runtime metadata, so it cannot enter serialized review context or inflate prompts.

Only `labelSyncFreshEnough` opts into that complete view. It is accepted only when issue comments, timeline events, and inline review comments all hydrate to at least their advertised counts. If any collection is incomplete, or if complete hydration was not requested, the existing fail-closed truncation behavior remains.

This avoids the unsafe shortcut of ignoring truncation: a human comment hidden in the omitted middle still blocks label changes.

## User Impact

A complete review pinned to the live PR head can once again reconcile proof, rating, status, and merge-risk labels on busy PRs when all post-review activity is automation-owned.

Human activity after the review snapshot remains authoritative regardless of whether it appears in the bounded head/tail window.

## Evidence

### Production reproduction

- affected PR head: `6724506a4ea7e24d4cdd667e8a54cef88308dccd`
- durable review: [current-head ClawSweeper verdict](https://github.com/openclaw/openclaw/pull/91268#issuecomment-4644454662)
- successful apply: [run 29713005794](https://github.com/openclaw/clawsweeper/actions/runs/29713005794)
- baseline source: `846b73c666c01b1c29d8a65a93549fca5742b404`
- fixed PR head: `12228184bbf34aab227c3e1f087eec9c4a8ed0fb`

### Live non-mocked GitHub proof

The live proof uses a synthetic draft PR, [veteranbv/clawsweeper#1](https://github.com/veteranbv/clawsweeper/pull/1), with synthetic comments and labels only. The workflow checks out the exact baseline or PR-head SHA, builds it, and runs the real `dist/clawsweeper.js apply-decisions` entrypoint against GitHub with the repository workflow token.

The only harness adapter is target allowlisting for the synthetic fork fixture: `target allowlist only: veteranbv/* synthetic fixture profile`. It does not change the production patch in this PR.

```json
[
  {
    "case": "before fix: automation-only activity after review",
    "run": "https://github.com/veteranbv/clawsweeper/actions/runs/29764036339",
    "executed_sha": "846b73c666c01b1c29d8a65a93549fca5742b404",
    "fixture_head": "1323dd2816ca6654d29eceddf5eb5949ac61e833",
    "activity_counts": {
      "issue_comments": 28,
      "timeline_events": 136,
      "inline_review_comments": 42
    },
    "action_report": [
      {
        "action": "review_comment_synced",
        "reason": "would create durable Codex review comment"
      }
    ],
    "labels_after": [
      "rating: 🦐 gold shrimp"
    ]
  },
  {
    "case": "after fix: same automation-only activity",
    "run": "https://github.com/veteranbv/clawsweeper/actions/runs/29764101269",
    "executed_sha": "12228184bbf34aab227c3e1f087eec9c4a8ed0fb",
    "fixture_head": "1323dd2816ca6654d29eceddf5eb5949ac61e833",
    "activity_counts": {
      "issue_comments": 29,
      "timeline_events": 142,
      "inline_review_comments": 42
    },
    "action_report": [
      {
        "action": "review_comment_synced",
        "reason": "updated durable Codex review comment"
      }
    ],
    "labels_after": [
      "P3",
      "merge-risk: 🚨 automation",
      "rating: 🐚 platinum hermit",
      "status: 👀 ready for maintainer look"
    ],
    "report_receipt": "labels_synced_at: 2026-07-20T17:34:00.154Z"
  },
  {
    "case": "after fix: human activity hidden behind later bot activity",
    "run": "https://github.com/veteranbv/clawsweeper/actions/runs/29764340163",
    "executed_sha": "12228184bbf34aab227c3e1f087eec9c4a8ed0fb",
    "fixture_head": "1323dd2816ca6654d29eceddf5eb5949ac61e833",
    "activity_counts": {
      "issue_comments": 43,
      "timeline_events": 186,
      "inline_review_comments": 42
    },
    "human_guard_comment": "https://github.com/veteranbv/clawsweeper/pull/1#issuecomment-5025221992",
    "action_report": [
      {
        "action": "review_comment_synced",
        "reason": "updated durable Codex review comment"
      }
    ],
    "labels_after": [
      "P3",
      "merge-risk: 🚨 automation",
      "rating: 🦐 gold shrimp",
      "status: 👀 ready for maintainer look"
    ],
    "report_receipt": "no labels_synced_at field was written"
  }
]
```

Result: the baseline leaves the stale gold label in place; the fixed head synchronizes the live label to platinum when complete hydration proves the post-review activity is automation-only; and the fixed head withholds label sync when a synthetic human comment exists after the review even though later bot activity pushes it out of the bounded tail.

### Supplemental CLI media proof

The earlier SHA-pinned CLI recording is still useful as a local before/after matrix, but it is supplemental because it uses mocked GitHub transport.

![SHA-pinned before/after apply-decisions proof](https://vhs.charm.sh/vhs-FMIQSdHxdKEkHI7ksMp0Z.gif)

### Regression coverage

- complete-activity matrix covers issue comments, timeline events, and inline review comments;
- automation-only omitted activity permits reconciliation;
- hidden human activity blocks reconciliation on every surface;
- incomplete hydration remains fail closed;
- end-to-end apply tests prove both label mutation and no-mutation outcomes.

### Data hygiene

- all public proof data is synthetic;
- no credentials, real accounts, private email addresses, local hostnames, local paths, or private network addresses are in the fixture evidence;
- GitHub Actions redacted the workflow token;
- the live proof used bot-authored synthetic fixture activity plus one clearly marked synthetic owner comment for the human-activity guard.

## Test Plan

- [x] RED on `846b73c666c01b1c29d8a65a93549fca5742b404`: live GitHub apply run [29764036339](https://github.com/veteranbv/clawsweeper/actions/runs/29764036339) left the stale `rating: 🦐 gold shrimp` label in place after automation-only post-review activity.
- [x] GREEN on `12228184bbf34aab227c3e1f087eec9c4a8ed0fb`: live GitHub apply run [29764101269](https://github.com/veteranbv/clawsweeper/actions/runs/29764101269) synchronized labels to `rating: 🐚 platinum hermit` and `status: 👀 ready for maintainer look`.
- [x] Fail-closed guard on `12228184bbf34aab227c3e1f087eec9c4a8ed0fb`: live GitHub apply run [29764340163](https://github.com/veteranbv/clawsweeper/actions/runs/29764340163) kept `rating: 🦐 gold shrimp` when a synthetic owner comment existed after review.
- [x] `node --test test/apply-label-sync.test.ts` — 25 passed, 0 failed.
- [x] `pnpm run build`
- [x] `pnpm run format:check`
- [x] `pnpm run lint:src`
- [x] `pnpm run lint:scripts`
- [x] `git diff --check`
- [x] Upstream PR checks currently shown by GitHub: `notify`, `Socket Security: Pull Request Alerts`, and `Socket Security: Project Report` are passing.
- [ ] Fork Linux full CI is noisy in this fork context: the PR-head run and an unmodified-main baseline run both fail the same `test/failed-review-retry.test.ts` expectations because the fork repository is `veteranbv/clawsweeper` while those tests expect `openclaw/clawsweeper`. The matching failures are not introduced by this patch.
