### PR TITLE
fix(publish): prevent state races from timing out result delivery

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1402,6 +1402,7 @@ export function pushCommit(options: {
   rebaseStrategy?: RebaseStrategy;
   reconciliationSourceCommit?: string;
   reconciliationTupleKeys?: ReadonlySet<string>;
+  boundedRemoteHeadRebuild?: boolean;
 }): boolean {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
@@ -1434,6 +1435,7 @@ export function pushCommit(options: {
           branch,
           options.reconciliationSourceCommit,
           options.reconciliationTupleKeys,
+          options.boundedRemoteHeadRebuild,
         )
       ) {
         return false;
@@ -1481,6 +1483,30 @@ export function pushCommit(options: {
   return spawnGit(["push", remote, `HEAD:${branch}`]).status === 0;
 }
 
+export function pushSingleRecordTupleCommit(options: {
+  paths: readonly string[];
+  remote?: string;
+  branch?: string;
+  pushAttempts?: number;
+}): boolean {
+  const reconciliationTupleKeys = recordTupleKeysForPaths(options.paths);
+  if (reconciliationTupleKeys.size !== 1) {
+    throw new Error(
+      `Single-record reconciliation requires exactly one tuple; received ${reconciliationTupleKeys.size}`,
+    );
+  }
+  const reconciliationSourceCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+  return pushCommit({
+    ...(options.remote !== undefined ? { remote: options.remote } : {}),
+    ...(options.branch !== undefined ? { branch: options.branch } : {}),
+    ...(options.pushAttempts !== undefined ? { pushAttempts: options.pushAttempts } : {}),
+    rebaseStrategy: "reconcile-records",
+    reconciliationSourceCommit,
+    reconciliationTupleKeys,
+    boundedRemoteHeadRebuild: true,
+  });
+}
+
 function reconciliationChangesOverlap(
   remoteRef: string,
   reconciliationSourceCommit?: string,
@@ -1523,10 +1549,13 @@ function rebuildReconciliationCommit(
   branch: string,
   reconciliationSourceCommit?: string,
   allowedTupleKeys?: ReadonlySet<string>,
+  boundedRemoteHeadRebuild = false,
 ): boolean {
   const remoteRef = `${remote}/${branch}`;
   const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
-  const mergeBase = mergeBaseWithShallowRecovery(sourceCommit, remoteRef, remote, branch);
+  const mergeBase = boundedRemoteHeadRebuild
+    ? mergeBaseWithoutHydration(sourceCommit, remoteRef)
+    : mergeBaseWithShallowRecovery(sourceCommit, remoteRef, remote, branch);
   let baseCommit: string;
   let localPaths: string[];
   if (!mergeBase.base) {
@@ -1618,6 +1647,19 @@ function rebuildReconciliationCommit(
 
   runGit(["commit", "-C", sourceCommit]);
   return true;
+}
+
+function mergeBaseWithoutHydration(
+  left: string,
+  right: string,
+): { base: string | null; recoveredShallowMiss: false } {
+  const args = ["merge-base", left, right];
+  const result = spawnGit(args, { quiet: true });
+  if (result.status === 0) {
+    return { base: result.stdout.trim(), recoveredShallowMiss: false };
+  }
+  if (result.status !== 1) throw gitRunError(result, args);
+  return { base: null, recoveredShallowMiss: false };
 }
 
 function normalizeReconciliationCommit(sourceCommit: string): {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -28,7 +28,7 @@ import {
   hardResetToRemoteMain,
   hasStagedChanges,
   publishRoot,
-  pushCommit,
+  pushSingleRecordTupleCommit,
   refreshSourceAfterStatePublish,
   runGit,
   setTokenOrigin,
@@ -507,7 +507,7 @@ function publishSnapshot({
         commitPaths,
       ),
     ]);
-    if (!pushCommit({ pushAttempts: 3, rebaseStrategy: "reconcile-records" })) return null;
+    if (!pushSingleRecordTupleCommit({ paths: commitPaths, pushAttempts: 3 })) return null;
     return complete(true);
   } catch (error) {
     if (

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -12,6 +12,7 @@ import {
   GitCommandTimeoutError,
   hardResetToRemoteMain,
   publishMainCommit,
+  pushSingleRecordTupleCommit,
   refreshSourceAfterStatePublish,
   runGit,
   setTokenOrigin,
@@ -1543,6 +1544,92 @@ test("reconcile-records rebuilds on a shallow remote head without local ancestry
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
     "remote update two\n",
+  );
+});
+
+test("single-record publisher rebuilds a shallow losing writer without hydrating history", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-single-record-race-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const publisher = path.join(root, "publisher");
+  const other = path.join(root, "other");
+  const fakeBin = path.join(root, "bin");
+  const recordsRoot = "records/openclaw-openclaw";
+  const publisherPaths = [
+    `${recordsRoot}/items/42.md`,
+    `${recordsRoot}/closed/42.md`,
+    `${recordsRoot}/plans/42.md`,
+    `${recordsRoot}/decision-packets/42.json`,
+  ];
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  writeRecordTuple(seed, {
+    number: 42,
+    marker: "shared base",
+    reviewedAt: "2026-07-20T11:00:00.000Z",
+    itemUpdatedAt: "2026-07-20T10:59:00Z",
+  });
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial state"], seed);
+  run("git", ["push", "origin", "HEAD:state"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, publisher], root);
+  configureUser(publisher);
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+
+  const localTuple = writeRecordTuple(publisher, {
+    number: 42,
+    marker: "publisher update",
+    reviewedAt: "2026-07-20T11:02:00.000Z",
+    itemUpdatedAt: "2026-07-20T11:01:00Z",
+  });
+  run("git", ["add", "."], publisher);
+  run("git", ["commit", "-m", "publisher update"], publisher);
+
+  const remoteTuple = writeRecordTuple(other, {
+    number: 43,
+    marker: "concurrent remote update",
+    reviewedAt: "2026-07-20T11:03:00.000Z",
+    itemUpdatedAt: "2026-07-20T11:02:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "concurrent remote update"], other);
+  run("git", ["push", "origin", "HEAD:state"], other);
+  installDeepenFetchFailureShim(fakeBin);
+
+  const lines = [];
+  let published;
+  captureConsoleLog(() => {
+    published = withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+      withCwd(publisher, () =>
+        pushSingleRecordTupleCommit({
+          paths: publisherPaths,
+          branch: "state",
+          pushAttempts: 2,
+        }),
+      ),
+    );
+  }, lines);
+
+  assert.equal(published, true);
+  assert.equal(
+    lines.some(
+      (line) =>
+        line ===
+        "No common Git base with origin/state; rebuilding reconciliation on the remote head",
+    ),
+    true,
+  );
+  assert.equal(run("git", ["rev-parse", "--is-shallow-repository"], publisher).trim(), "true");
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
+    localTuple.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/43.md`], root),
+    remoteTuple.primary,
   );
 });
 


### PR DESCRIPTION
Related: #712
Related: #714
Related: #716

## What Problem This Solves

Fixes an issue where completed issue and PR reviews remain queued when concurrent exact-result publishers race to update the shared state branch.

The incident began immediately after #712 merged at 2026-07-20 06:04:34Z. That change made a shallow publisher hydrate Git history when `merge-base` could not see common ancestry. Under the normal 32-writer publication load, losing writers repeatedly entered `--deepen` / `--unshallow`; many timed out after 60 seconds and held their publication lease through the failed attempt. The queue was still at 215 publication items with all 32 slots active at 2026-07-20 13:21Z.

This is not a label-only or dashboard-only issue: the failure occurs in the exact-result publication step before the durable result can finish its comment/label/application lifecycle.

## Why This Change Was Made

Exact event publication commits one known record tuple. This change gives that path a dedicated `pushSingleRecordTupleCommit` entry point which:

- captures the source commit and derives the one allowed tuple key from the staged publication paths;
- opts only that bounded path into #716's remote-head rebuild when shallow history hides the merge base;
- avoids history hydration in the hot two-writer race; and
- keeps the existing tuple arbitration, including preservation of a newer concurrent remote tuple.

All generic `pushCommit` callers retain the existing #714/#716 hydration behavior. This does not change queue capacity, add retries, reset state, alter gates, dispatch Actions, or weaken reconciliation safety.

## User Impact

Issue and PR result publishers that lose a state-branch push race can reconcile immediately on the fetched remote head instead of spending up to 60 seconds hydrating history and failing. This should release publication leases promptly and let the backlog drain while preserving both independent record tuples and the newer winner for same-tuple races.

GitHub API rate limiting remains a separate possible failure mode; this patch intentionally addresses the dominant Git fetch timeout signature rather than masking it with capacity or retry changes.

## Evidence

### Production causal proof

- Representative post-#716 failure: [workflow run 29741488075](https://github.com/openclaw/clawsweeper/actions/runs/29741488075), job [88349031217](https://github.com/openclaw/clawsweeper/actions/runs/29741488075/job/88349031217), on default-branch SHA `846b73c666c01b1c29d8a65a93549fca5742b404`.
- The job entered `Publish event result and apply safe close` at 2026-07-20 12:17:06Z and failed after 9m24s. Its log shows rejected state pushes, no visible common base, #712's shallow-recovery helper, `fatal: shallow file has changed`, and `GitCommandTimeoutError: git fetch timed out after 60000ms` before retryable completion.
- A read-only sample of 20 completed publisher failures during the incident found 18 with this direct 60-second Git fetch timeout signature and 2 with GitHub rate-limit failures.
- `git log -S mergeBaseWithShallowRecovery` traces the failing helper to #712 (`25135198f921b062b6d276931ca794d0222129c6`). Timing alone is not the proof: the runtime stack and exact failing command both enter that helper.
- #716 correctly added a bounded remote-head rebuild, but the exact event publisher did not provide its source commit and tuple bound, so it still had to hydrate first. This PR supplies that missing bound instead of reverting #714/#716's correctness work.

### Real behavior proof

Environment: Crabbox `local-container`, Docker image `mcr.microsoft.com/playwright:v1.60.0-noble`.

Focused lease: `cbx_00f30e0daaa8` (`pearl-shrimp`). The Docker run built `tsconfig.repair.json`, ran the exact two-writer regression plus the existing shallow/unrelated-history guards, checked the production call-site contract, and ran scoped oxlint, oxfmt, and `git diff --check`.

```text
tests 4
pass 4
fail 0
Found 0 warnings and 0 errors.
All matched files use the correct format.
exitCode: 0
```

The new integration case creates a depth-1 publisher and a second writer against a real bare Git remote. The second writer wins the first push; a shim fails the test if `git fetch --deepen` is attempted. The publisher then rebuilds on the fetched remote head, pushes successfully, remains shallow, and the remote contains both the publisher's tuple and the concurrent writer's tuple.

Broad lease: `cbx_53da04c5a2c5` (`golden-krill`). The Docker run rebuilt all three TypeScript targets and ran the complete repair suite:

```text
tests 987
pass 980
fail 0
skipped 7
duration_ms 48006.822504
Found 0 warnings and 0 errors.
All matched files use the correct format.
exitCode: 0
```

The broad Crabbox setup materialized untouched files from Git's LF index because raw Windows-to-Linux sync otherwise presents repository-wide CRLF fixture noise. The initial raw-sync failure was entirely in workflow text/contained `pnpm` harness expectations; after Linux checkout normalization and a Corepack `pnpm` shim, the unchanged full suite passed without exclusions.

Not proven pre-merge: production backlog drain. The deterministic test proves the exact failed two-writer lifecycle and removes the 60-second hydration command from that bounded path; live drain must be observed after deployment.

### Review gates

- Dirty patch: `codex-review --mode local --full-access` — clean, no accepted/actionable findings.
- Committed branch vs actual base: `codex-review --mode branch --base origin/main --full-access` — clean, no accepted/actionable findings.
- The branch review also exercised the same-tuple shallow race and confirmed the newer remote tuple remains the winner.
- `git diff --check` passed on the host and on the scoped Linux patch.

## Risks And Rollout

The behavior change is opt-in and limited to exact single-record result publication. A guard rejects zero or multiple tuple identities before enabling the bounded rebuild. Generic checkpoint, ledger, and other reconciliation callers are unchanged.

The main rollout signal is the publication queue: the active-lease timeout signature should disappear first, then leased duration and ready depth should fall. A remaining GitHub rate-limit signature would be separate evidence rather than a reason to broaden this patch.

No automerge is requested. A maintainer should make the explicit merge decision after normal CI and review-stage evidence.

## Attribution

This repair builds on Peter Steinberger's state recovery and remote-head reconciliation work in #712, #714, and #716. It preserves those correctness changes while narrowing the exact event publisher's contention path.
