### PR TITLE
fix(publish): serialize exact state mutations

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2054,7 +2054,7 @@ jobs:
             const completionKind = ["published", "superseded", "deferred", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
               ? process.env.COMPLETION_KIND
               : undefined;
-            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "review_lease_active", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
+            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "state_contention", "review_lease_active", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
               ? process.env.REASON_CODE
               : undefined;
             const errorFingerprint = /^[A-Za-z0-9:._-]{1,200}$/.test(process.env.ERROR_FINGERPRINT || "")

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -107,6 +107,7 @@ type ExactReviewPublicationReasonCode =
   | "live_terminal"
   | "github_rate_limit"
   | "github_transient"
+  | "state_contention"
   | "review_lease_active"
   | "workflow_cancelled"
   | "artifact_unavailable"
@@ -3468,6 +3469,7 @@ function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCo
     "live_terminal",
     "github_rate_limit",
     "github_transient",
+    "state_contention",
     "review_lease_active",
     "workflow_cancelled",
     "artifact_unavailable",
@@ -3502,6 +3504,7 @@ function exactReviewPublicationCompletion(
     retryable_failure: new Set([
       "github_rate_limit",
       "github_transient",
+      "state_contention",
       "review_lease_active",
       "workflow_cancelled",
       "artifact_unavailable",

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import {
   cpSync,
   existsSync,
@@ -80,6 +81,11 @@ const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
 // one-time repairs but move far more data than an ordinary publish fetch; a
 // 60s budget times out on the grown state repo (prod run 29745570319).
 const RECOVERY_FETCH_TIMEOUT_MS = 300_000;
+const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
+const STATE_PUBLISH_LEASE_TTL_MS = 2 * 60_000;
+const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = 3 * 60_000;
+const STATE_PUBLISH_LEASE_WAIT_MS = 1_000;
+const STATE_PUBLISH_LEASE_MAX_WAIT_MS = 5_000;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
 
@@ -90,7 +96,32 @@ type GitPublishMetrics = {
   phase: string;
 };
 
+type StatePublishLease = {
+  ref: string;
+  oid: string;
+  owner: string;
+  expiresAtMs: number;
+  ttlMs: number;
+  remote: string;
+  branch: string;
+};
+
+type ObservedStatePublishLease = {
+  oid: string;
+  owner: string;
+  expiresAtMs: number;
+};
+
+export type StatePublishLeaseOptions = {
+  remote?: string;
+  branch?: string;
+  acquireTimeoutMs?: number;
+  ttlMs?: number;
+  waitMs?: number;
+};
+
 let activeGitPublishMetrics: GitPublishMetrics | null = null;
+let activeStatePublishLease: StatePublishLease | null = null;
 
 export function configureGitUser(): void {
   runGit(["config", "user.name", clawsweeperGitUserName()]);
@@ -154,6 +185,13 @@ export class GitCommandTimeoutError extends Error {
   constructor(args: readonly string[], timeoutMs: number) {
     super(`git ${safeGitDisplayAction(args[0])} timed out after ${timeoutMs}ms`);
     this.name = "GitCommandTimeoutError";
+  }
+}
+
+export class StatePublishContentionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StatePublishContentionError";
   }
 }
 
@@ -1399,6 +1437,245 @@ function listFiles(root: string): string[] {
   return files;
 }
 
+export function withStatePublishLease<T>(
+  operation: () => T,
+  options: StatePublishLeaseOptions = {},
+): T {
+  if (!publishRoot()) return operation();
+  if (activeStatePublishLease) {
+    throw new Error("Nested state publication leases are not supported");
+  }
+  const remote = options.remote ?? "origin";
+  const branch = options.branch ?? publishDefaultBranch();
+  const lease = acquireStatePublishLease(remote, branch, options);
+  activeStatePublishLease = lease;
+  try {
+    return operation();
+  } finally {
+    activeStatePublishLease = null;
+    releaseStatePublishLease(lease);
+  }
+}
+
+function acquireStatePublishLease(
+  remote: string,
+  branch: string,
+  options: StatePublishLeaseOptions,
+): StatePublishLease {
+  const leaseRef = `${STATE_PUBLISH_LEASE_REF_ROOT}/${branch}`;
+  runGit(["check-ref-format", leaseRef], { quiet: true });
+  const owner = randomUUID();
+  const ttlMs = Math.min(
+    positiveInt(options.ttlMs, STATE_PUBLISH_LEASE_TTL_MS),
+    STATE_PUBLISH_LEASE_TTL_MS,
+  );
+  const acquireTimeoutMs = positiveInt(
+    options.acquireTimeoutMs,
+    STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS,
+  );
+  const waitMs = positiveInt(options.waitMs, STATE_PUBLISH_LEASE_WAIT_MS);
+  const deadlineAtMs = Date.now() + acquireTimeoutMs;
+  const observedByOid = new Map<string, ObservedStatePublishLease>();
+  let attempt = 0;
+
+  // Spread a newly admitted publisher cohort before any of them attempts the
+  // empty-ref compare-and-swap. Once an owner exists, later contenders only
+  // poll the tiny lease ref instead of creating another state-branch push storm.
+  sleep(Math.floor(Math.random() * waitMs));
+
+  while (Date.now() < deadlineAtMs) {
+    attempt += 1;
+    const observed = observeStatePublishLease(remote, leaseRef, ttlMs, observedByOid);
+    const now = Date.now();
+    if (!observed || observed.expiresAtMs <= now) {
+      const expiresAtMs = now + ttlMs;
+      const oid = createStatePublishLeaseCommit({ branch, owner, ttlMs });
+      const expectedOid = observed?.oid ?? "";
+      const acquired =
+        spawnGit(
+          ["push", `--force-with-lease=${leaseRef}:${expectedOid}`, remote, `${oid}:${leaseRef}`],
+          { allowFailure: true, quiet: true, timeout: PUBLISH_FETCH_TIMEOUT_MS },
+        ).status === 0;
+      if (acquired) {
+        console.log(
+          `Acquired state publish lease owner=${owner} attempt=${attempt} stale_recovery=${observed ? "true" : "false"}`,
+        );
+        return { ref: leaseRef, oid, owner, expiresAtMs, ttlMs, remote, branch };
+      }
+    } else {
+      console.log(
+        `State publish lease busy owner=${observed.owner} attempt=${attempt} remaining_ms=${Math.max(0, observed.expiresAtMs - now)}`,
+      );
+    }
+
+    const remainingMs = deadlineAtMs - Date.now();
+    if (remainingMs <= 0) break;
+    const backoffMs = Math.min(
+      waitMs * 2 ** Math.min(attempt - 1, 3),
+      STATE_PUBLISH_LEASE_MAX_WAIT_MS,
+    );
+    sleep(Math.min(remainingMs, backoffMs + Math.floor(Math.random() * waitMs)));
+  }
+
+  throw new StatePublishContentionError(
+    `Failed to acquire the ${branch} state publish lease within ${acquireTimeoutMs}ms`,
+  );
+}
+
+function observeStatePublishLease(
+  remote: string,
+  leaseRef: string,
+  ttlMs: number,
+  observedByOid: Map<string, ObservedStatePublishLease>,
+): ObservedStatePublishLease | null {
+  const oid = remoteRefOid(remote, leaseRef);
+  if (!oid) return null;
+  const cached = observedByOid.get(oid);
+  if (cached) return cached;
+
+  const fetched = spawnGit(["fetch", "--no-tags", "--quiet", remote, leaseRef], {
+    allowFailure: true,
+    quiet: true,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
+  if (fetched.timedOut) {
+    throw new GitCommandTimeoutError(["fetch"], PUBLISH_FETCH_TIMEOUT_MS);
+  }
+  if (fetched.status !== 0) {
+    if (!remoteRefOid(remote, leaseRef)) return null;
+    throw new Error(fetched.stderr.trim() || `Failed to fetch state publish lease ${leaseRef}`);
+  }
+  const raw = runGit(["show", "-s", "--format=%H%x00%ct%x00%B", "FETCH_HEAD"], {
+    quiet: true,
+  });
+  const [fetchedOid, committedAtRaw, ...messageParts] = raw.split("\0");
+  if (!fetchedOid || !/^[a-f0-9]{40,64}$/.test(fetchedOid)) {
+    throw new Error("Remote state publish lease did not resolve to a commit");
+  }
+  const committedAtMs = Number(committedAtRaw) * 1_000;
+  const message = messageParts.join("\0");
+  const owner = /^owner: ([0-9a-f-]+)$/m.exec(message)?.[1] ?? "unknown";
+  const advertisedTtlMs = Number(/^ttl_ms: ([0-9]+)$/m.exec(message)?.[1] ?? "");
+  const boundedTtlMs =
+    Number.isSafeInteger(advertisedTtlMs) && advertisedTtlMs > 0
+      ? Math.min(advertisedTtlMs, STATE_PUBLISH_LEASE_TTL_MS)
+      : ttlMs;
+  const expiresAtMs =
+    Number.isFinite(committedAtMs) && committedAtMs > 0
+      ? Math.min(committedAtMs + boundedTtlMs, Date.now() + STATE_PUBLISH_LEASE_TTL_MS)
+      : Date.now() + STATE_PUBLISH_LEASE_TTL_MS;
+  const observed = { oid: fetchedOid, owner, expiresAtMs };
+  observedByOid.set(oid, observed);
+  return observed;
+}
+
+function createStatePublishLeaseCommit(options: {
+  branch: string;
+  owner: string;
+  ttlMs: number;
+}): string {
+  const tree = runGit(["mktree"], { input: "", quiet: true }).trim();
+  if (!tree) throw new Error("Failed to create the state publish lease tree");
+  return runGit(["commit-tree", tree], {
+    input: [
+      "ClawSweeper state publish lease",
+      "",
+      `owner: ${options.owner}`,
+      `branch: ${options.branch}`,
+      `ttl_ms: ${options.ttlMs}`,
+      "",
+    ].join("\n"),
+    quiet: true,
+  }).trim();
+}
+
+function releaseStatePublishLease(lease: StatePublishLease): void {
+  try {
+    const released = spawnGit(
+      ["push", `--force-with-lease=${lease.ref}:${lease.oid}`, lease.remote, `:${lease.ref}`],
+      { allowFailure: true, quiet: true, timeout: PUBLISH_FETCH_TIMEOUT_MS },
+    );
+    if (released.status === 0) {
+      console.log(`Released state publish lease owner=${lease.owner}`);
+    } else {
+      console.log(
+        `State publish lease release skipped owner=${lease.owner}; ownership changed or cleanup failed`,
+      );
+    }
+  } catch (error) {
+    console.log(
+      `State publish lease release failed owner=${lease.owner}; expiry will recover it: ${errorMessage(error)}`,
+    );
+  }
+}
+
+function remoteRefOid(remote: string, ref: string): string | null {
+  const result = spawnGit(["ls-remote", "--refs", remote, ref], {
+    allowFailure: true,
+    quiet: true,
+    timeout: PUBLISH_FETCH_TIMEOUT_MS,
+  });
+  if (result.timedOut) throw new GitCommandTimeoutError(["ls-remote"], PUBLISH_FETCH_TIMEOUT_MS);
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `Failed to inspect remote ref ${ref}`);
+  }
+  const output = result.stdout.trim();
+  if (!output) return null;
+  const match = /^([a-f0-9]{40,64})\s+(.+)$/.exec(output);
+  if (!match || match[2] !== ref) throw new Error(`Malformed remote ref response for ${ref}`);
+  return match[1]!;
+}
+
+function pushPublishedBranch(remote: string, branch: string): GitRunResult {
+  const lease = activeStatePublishLease;
+  if (!lease) return spawnGit(["push", remote, `HEAD:${branch}`]);
+  if (lease.remote !== remote || lease.branch !== branch) {
+    throw new StatePublishContentionError(
+      `Active state publish lease does not cover ${remote}/${branch}`,
+    );
+  }
+
+  const renewedOid = createStatePublishLeaseCommit({
+    branch: lease.branch,
+    owner: lease.owner,
+    ttlMs: lease.ttlMs,
+  });
+  const pushed = spawnGit(
+    [
+      "push",
+      "--atomic",
+      `--force-with-lease=${lease.ref}:${lease.oid}`,
+      lease.remote,
+      `HEAD:${branch}`,
+      `${renewedOid}:${lease.ref}`,
+    ],
+    { allowFailure: true },
+  );
+  if (pushed.status !== 0) {
+    const currentLeaseOid = remoteRefOid(remote, lease.ref);
+    if (currentLeaseOid === renewedOid) {
+      const localHead = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+      if (remoteRefOid(remote, `refs/heads/${branch}`) === localHead) {
+        lease.oid = renewedOid;
+        lease.expiresAtMs = Date.now() + lease.ttlMs;
+        return { ...pushed, status: 0 };
+      }
+      throw new Error("Atomic state publish updated its lease without the branch");
+    }
+    if (currentLeaseOid !== lease.oid) {
+      throw new StatePublishContentionError(
+        "State publish lease ownership changed before branch publication",
+      );
+    }
+    return pushed;
+  }
+
+  lease.oid = renewedOid;
+  lease.expiresAtMs = Date.now() + lease.ttlMs;
+  console.log(`Renewed state publish lease owner=${lease.owner} with atomic branch update`);
+  return pushed;
+}
+
 export function pushCommit(options: {
   remote?: string;
   branch?: string;
@@ -1414,7 +1691,7 @@ export function pushCommit(options: {
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
 
   for (let pushAttempt = 1; pushAttempt <= pushAttempts; pushAttempt += 1) {
-    if (spawnGit(["push", remote, `HEAD:${branch}`]).status === 0) return true;
+    if (pushPublishedBranch(remote, branch).status === 0) return true;
     console.log(`Push attempt ${pushAttempt} lost the ${branch} race; rebasing`);
     const localCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
     const localCommitMessage = runGit(["log", "-1", "--format=%B"], { quiet: true });
@@ -1484,7 +1761,7 @@ export function pushCommit(options: {
       return false;
     }
   }
-  return spawnGit(["push", remote, `HEAD:${branch}`]).status === 0;
+  return pushPublishedBranch(remote, branch).status === 0;
 }
 
 export function pushSingleRecordTupleCommit(options: {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -33,7 +33,9 @@ import {
   runGit,
   setTokenOrigin,
   stagePaths,
+  StatePublishContentionError,
   syncPublishPaths,
+  withStatePublishLease,
 } from "./git-publish.js";
 import { isJsonObject } from "./json-types.js";
 import { RecordTupleError } from "./record-tuple.js";
@@ -93,16 +95,20 @@ const options = eventOptionsFromEnv();
 try {
   await publishEventResult(options);
 } catch (error) {
-  const retryableTimeout = error instanceof GitCommandTimeoutError;
-  const reasonCode = retryableTimeout
-    ? "github_transient"
-    : error instanceof PublicationResultError
-      ? error.reasonCode
-      : error instanceof RecordTupleError
-        ? "tuple_protocol_invalid"
-        : "unknown_failure";
+  const retryableFailure =
+    error instanceof GitCommandTimeoutError || error instanceof StatePublishContentionError;
+  const reasonCode =
+    error instanceof GitCommandTimeoutError
+      ? "github_transient"
+      : error instanceof StatePublishContentionError
+        ? "state_contention"
+        : error instanceof PublicationResultError
+          ? error.reasonCode
+          : error instanceof RecordTupleError
+            ? "tuple_protocol_invalid"
+            : "unknown_failure";
   writePublicationCompletionOutputs(
-    retryableTimeout ? "retryable_failure" : "permanent_failure",
+    retryableFailure ? "retryable_failure" : "permanent_failure",
     reasonCode,
     errorFingerprint(error),
   );
@@ -470,49 +476,54 @@ function publishSnapshot({
       summary();
       return published;
     };
-    hardResetToRemoteMain();
-    const stateRoot = publishRoot();
-    const snapshotResult = applyEventSnapshot(paths, stateRoot ? { remoteRoot: stateRoot } : {});
-    if (snapshotResult === "remote-closed") {
-      console.log(
-        `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
-      );
-      return complete(false, "remote_closed");
-    }
-    if (snapshotResult === "remote-newer") {
-      console.log(
-        `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
-      );
-      return complete(false, "remote_newer_tuple");
-    }
-    if (snapshotResult === "missing") {
-      throw new PublicationResultError(
-        "missing_record_tuple",
-        `No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`,
-      );
-    }
+    const mutation = withStatePublishLease(() => {
+      hardResetToRemoteMain();
+      const stateRoot = publishRoot();
+      const snapshotResult = applyEventSnapshot(paths, stateRoot ? { remoteRoot: stateRoot } : {});
+      if (snapshotResult === "remote-closed") {
+        console.log(
+          `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
+        );
+        return { candidateApplied: false, supersededReason: "remote_closed" as const };
+      }
+      if (snapshotResult === "remote-newer") {
+        console.log(
+          `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
+        );
+        return { candidateApplied: false, supersededReason: "remote_newer_tuple" as const };
+      }
+      if (snapshotResult === "missing") {
+        throw new PublicationResultError(
+          "missing_record_tuple",
+          `No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`,
+        );
+      }
 
-    syncPublishPaths(commitPaths);
-    stagePaths(commitPaths);
-    if (!hasStagedChanges()) {
-      console.log("No event result changes");
-      return complete(true);
-    }
+      syncPublishPaths(commitPaths);
+      stagePaths(commitPaths);
+      if (!hasStagedChanges()) {
+        console.log("No event result changes");
+        return { candidateApplied: true, supersededReason: undefined };
+      }
 
-    runGit([
-      "commit",
-      "-m",
-      commitMessageForPublishedPaths(
-        `chore: apply event sweep result for ${paths.targetSlug}#${options.itemNumber}`,
-        commitPaths,
-      ),
-    ]);
-    if (!pushSingleRecordTupleCommit({ paths: commitPaths, pushAttempts: 3 })) return null;
-    return complete(true);
+      runGit([
+        "commit",
+        "-m",
+        commitMessageForPublishedPaths(
+          `chore: apply event sweep result for ${paths.targetSlug}#${options.itemNumber}`,
+          commitPaths,
+        ),
+      ]);
+      if (!pushSingleRecordTupleCommit({ paths: commitPaths, pushAttempts: 3 })) return null;
+      return { candidateApplied: true, supersededReason: undefined };
+    });
+    if (!mutation) return null;
+    return complete(mutation.candidateApplied, mutation.supersededReason);
   } catch (error) {
     if (
       error instanceof GitCommandTimeoutError ||
       error instanceof RecordTupleError ||
+      error instanceof StatePublishContentionError ||
       error instanceof GuardedOpenPublishRaceError ||
       error instanceof RoutableSyncPublishRaceError ||
       error instanceof SourceDriftPublishRaceError ||
@@ -648,6 +659,7 @@ function writePublicationCompletionOutputs(
     | "remote_closed"
     | "close_coverage_deferred"
     | "github_transient"
+    | "state_contention"
     | "review_lease_active"
     | "missing_record_tuple"
     | "tuple_protocol_invalid"

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -2342,7 +2342,7 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   assert.ok(releaseDead);
   const deadStartedAt = Date.now();
   assert.ok(recordReviewNumber(deadRoot, 42));
-  assert.ok(Date.now() - deadStartedAt < 1_000);
+  assert.ok(Date.now() - deadStartedAt < 5_000);
   assert.doesNotThrow(releaseDead);
 
   const reusedRoot = tempRoot();
@@ -2368,7 +2368,7 @@ test("producer locks reclaim fresh dead owners and never evict a live holder by 
   assert.ok(releaseReused);
   const reusedStartedAt = Date.now();
   assert.ok(recordReviewNumber(reusedRoot, 46));
-  assert.ok(Date.now() - reusedStartedAt < 1_000);
+  assert.ok(Date.now() - reusedStartedAt < 5_000);
   assert.doesNotThrow(releaseReused);
 
   const liveRoot = tempRoot();
@@ -2515,7 +2515,7 @@ test(
     try {
       const startedAt = Date.now();
       assert.ok(recordReviewNumber(root, 82));
-      assert.ok(Date.now() - startedAt < 1_000);
+      assert.ok(Date.now() - startedAt < 5_000);
     } finally {
       fs.readFileSync = originalReadFileSync;
       processIncarnationIdentitySha256(process.pid, { fresh: true });
@@ -2581,7 +2581,7 @@ test(
       assert.ok(releaseZombie);
       const startedAt = Date.now();
       assert.ok(recordReviewNumber(root, 92));
-      assert.ok(Date.now() - startedAt < 1_000);
+      assert.ok(Date.now() - startedAt < 5_000);
       assert.doesNotThrow(releaseZombie);
     } finally {
       keeper.kill("SIGTERM");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4813,6 +4813,52 @@ test("exact-review publication retries a state fetch timeout without throttling 
   assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
 });
 
+test("exact-review publication gives state contention the transient retry budget", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7803, "78030");
+  item.publicationFailureAttempts = 4;
+  item.firstFailureAt = Date.now() - 30 * 60_000;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "retryable_failure",
+        reason_code: "state_contention",
+        error_fingerprint: "sha256:state-publish-contention",
+      }),
+    }),
+  );
+
+  assert.deepEqual(await response.json(), { ok: true, requeued: true });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { state: string; lastFailureReason?: string; publicationFailureAttempts?: number }
+    >;
+  };
+  assert.equal(state.items[item.key]?.state, "pending");
+  assert.equal(state.items[item.key]?.lastFailureReason, "state_contention");
+  assert.equal(state.items[item.key]?.publicationFailureAttempts, 5);
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.dead_letters.open, 0);
+  assert.equal(stats.lanes.publication.capacity_control.mode, "adaptive");
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 48);
+  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
+});
+
 test("exact-review publication defers an active review lease without throttling capacity", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(7802, "78020");

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -19,6 +19,7 @@ import {
   spawnGit,
   stagePaths,
   uniqueNonEmpty,
+  withStatePublishLease,
 } from "../../dist/repair/git-publish.js";
 
 for (const key of [
@@ -1630,6 +1631,291 @@ test("single-record publisher rebuilds a shallow losing writer without hydrating
   assert.equal(
     run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/43.md`], root),
     remoteTuple.primary,
+  );
+});
+
+test(
+  "state publish lease serializes concurrent exact record tuple writers",
+  { timeout: 60_000 },
+  async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-race-"));
+    const origin = path.join(root, "origin.git");
+    const seed = path.join(root, "seed");
+    const barrier = path.join(root, "barrier");
+    const writerCount = 8;
+    run("git", ["init", "--bare", origin], root);
+    run("git", ["clone", origin, seed], root);
+    configureUser(seed);
+    write(path.join(seed, "README.md"), "state\n");
+    run("git", ["add", "."], seed);
+    run("git", ["commit", "-m", "initial state"], seed);
+    run("git", ["push", "origin", "HEAD:state"], seed);
+    run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+    fs.mkdirSync(barrier);
+
+    const writers = Array.from({ length: writerCount }, (_, index) => {
+      const number = 10_000 + index;
+      const work = path.join(root, `writer-${index}`);
+      const candidate = path.join(root, `candidate-${index}`);
+      run("git", ["clone", "--depth", "1", `file://${origin}`, work], root);
+      configureUser(work);
+      const tuple = writeRecordTuple(candidate, {
+        number,
+        marker: `leased writer ${index}`,
+        reviewedAt: `2026-07-20T14:${String(index).padStart(2, "0")}:00.000Z`,
+        itemUpdatedAt: `2026-07-20T14:${String(index).padStart(2, "0")}:00Z`,
+      });
+      return { index, number, work, candidate, tuple };
+    });
+
+    const childScript = String.raw`
+      import fs from "node:fs";
+      import path from "node:path";
+      const [work, candidate, barrier, writerCountRaw, indexRaw, numberRaw] = process.argv.slice(1);
+      const writerCount = Number(writerCountRaw);
+      const index = Number(indexRaw);
+      const number = Number(numberRaw);
+      const recordRoot = "records/openclaw-openclaw";
+      const paths = [
+        recordRoot + "/items/" + number + ".md",
+        recordRoot + "/closed/" + number + ".md",
+        recordRoot + "/plans/" + number + ".md",
+        recordRoot + "/decision-packets/" + number + ".json",
+      ];
+      fs.writeFileSync(path.join(barrier, String(index)), "ready\n");
+      const wait = new Int32Array(new SharedArrayBuffer(4));
+      while (fs.readdirSync(barrier).length < writerCount) Atomics.wait(wait, 0, 0, 10);
+
+      const {
+        commitMessageForPublishedPaths,
+        hardResetToRemoteMain,
+        pushSingleRecordTupleCommit,
+        runGit,
+        stagePaths,
+        withStatePublishLease,
+      } = await import("./dist/repair/git-publish.js");
+      withStatePublishLease(
+        () => {
+          hardResetToRemoteMain("origin", "state");
+          fs.cpSync(path.join(candidate, "records"), path.join(work, "records"), { recursive: true });
+          stagePaths(paths);
+          runGit([
+            "commit",
+            "-m",
+            commitMessageForPublishedPaths("chore: leased exact tuple " + number, paths),
+          ]);
+          if (!pushSingleRecordTupleCommit({ paths, branch: "state", pushAttempts: 1 })) {
+            throw new Error("leased exact tuple push lost the state race");
+          }
+        },
+        { branch: "state", acquireTimeoutMs: 30_000, ttlMs: 30_000, waitMs: 25 },
+      );
+    `;
+
+    const results = await Promise.all(
+      writers.map((writer) =>
+        runAsync(
+          "node",
+          [
+            "--input-type=module",
+            "-e",
+            childScript,
+            writer.work,
+            writer.candidate,
+            barrier,
+            String(writerCount),
+            String(writer.index),
+            String(writer.number),
+          ],
+          process.cwd(),
+          {
+            CLAWSWEEPER_PUBLISH_ROOT: writer.work,
+            CLAWSWEEPER_PUBLISH_BRANCH: "state",
+          },
+        ),
+      ),
+    );
+
+    for (const output of results) {
+      assert.match(output, /Acquired state publish lease/);
+      assert.match(output, /Released state publish lease/);
+      assert.doesNotMatch(output, /lost the state race/);
+    }
+    for (const writer of writers) {
+      assert.equal(
+        run(
+          "git",
+          [
+            "--git-dir",
+            origin,
+            "show",
+            `state:records/openclaw-openclaw/items/${writer.number}.md`,
+          ],
+          root,
+        ),
+        writer.tuple.primary,
+      );
+    }
+    assert.equal(
+      run("git", ["--git-dir", origin, "log", "--format=%s", "state"], root).trim().split("\n")
+        .length,
+      writerCount + 1,
+    );
+    assert.equal(
+      run(
+        "git",
+        [
+          "--git-dir",
+          origin,
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/clawsweeper-publish-lease",
+        ],
+        root,
+      ),
+      "",
+    );
+  },
+);
+
+test("state publish lease recovers an abandoned owner after its bounded TTL", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-stale-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  write(path.join(work, "README.md"), "state\n");
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial state"], work);
+  run("git", ["push", "origin", "HEAD:state"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+
+  const staleEnv = {
+    ...process.env,
+    GIT_AUTHOR_DATE: "2026-07-20T12:00:00Z",
+    GIT_COMMITTER_DATE: "2026-07-20T12:00:00Z",
+  };
+  const tree = execFileSync("git", ["mktree"], {
+    cwd: work,
+    env: staleEnv,
+    input: "",
+    encoding: "utf8",
+  }).trim();
+  const staleCommit = execFileSync("git", ["commit-tree", tree], {
+    cwd: work,
+    env: staleEnv,
+    input: "ClawSweeper state publish lease\n\nowner: abandoned\nbranch: state\nttl_ms: 30000\n",
+    encoding: "utf8",
+  }).trim();
+  run("git", ["push", "origin", `${staleCommit}:refs/heads/clawsweeper-publish-lease/state`], work);
+
+  let operated = false;
+  const lines = captureConsoleLog(() => {
+    withEnv(
+      {
+        CLAWSWEEPER_PUBLISH_ROOT: work,
+        CLAWSWEEPER_PUBLISH_BRANCH: "state",
+      },
+      () =>
+        withStatePublishLease(
+          () => {
+            operated = true;
+          },
+          { branch: "state", acquireTimeoutMs: 1_000, ttlMs: 30_000, waitMs: 10 },
+        ),
+    );
+  });
+
+  assert.equal(operated, true);
+  assert.equal(
+    lines.some((line) => line.includes("stale_recovery=true")),
+    true,
+  );
+  assert.equal(
+    run(
+      "git",
+      [
+        "--git-dir",
+        origin,
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads/clawsweeper-publish-lease",
+      ],
+      root,
+    ),
+    "",
+  );
+});
+
+test("state publish lease renews and fences a push after the original TTL", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-renew-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const candidate = path.join(root, "candidate");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  write(path.join(work, "README.md"), "state\n");
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial state"], work);
+  run("git", ["push", "origin", "HEAD:state"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  const number = 10_100;
+  const tuple = writeRecordTuple(candidate, {
+    number,
+    marker: "renewed writer",
+    reviewedAt: "2026-07-20T15:00:00.000Z",
+    itemUpdatedAt: "2026-07-20T15:00:00Z",
+  });
+  const recordRoot = "records/openclaw-openclaw";
+  const paths = [
+    `${recordRoot}/items/${number}.md`,
+    `${recordRoot}/closed/${number}.md`,
+    `${recordRoot}/plans/${number}.md`,
+    `${recordRoot}/decision-packets/${number}.json`,
+  ];
+
+  let published = false;
+  const lines = captureConsoleLog(() => {
+    withEnv(
+      {
+        CLAWSWEEPER_PUBLISH_ROOT: work,
+        CLAWSWEEPER_PUBLISH_BRANCH: "state",
+      },
+      () =>
+        withStatePublishLease(
+          () => {
+            hardResetToRemoteMain("origin", "state");
+            fs.cpSync(path.join(candidate, "records"), path.join(work, "records"), {
+              recursive: true,
+            });
+            stagePaths(paths);
+            runGit([
+              "commit",
+              "-m",
+              commitMessageForPublishedPaths("chore: renewed exact tuple", paths),
+            ]);
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_100);
+            published = pushSingleRecordTupleCommit({
+              paths,
+              branch: "state",
+              pushAttempts: 1,
+            });
+          },
+          { branch: "state", acquireTimeoutMs: 5_000, ttlMs: 2_000, waitMs: 10 },
+        ),
+    );
+  });
+
+  assert.equal(published, true);
+  assert.equal(
+    lines.some((line) => line.includes("Renewed state publish lease")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordRoot}/items/${number}.md`], root),
+    tuple.primary,
   );
 });
 
@@ -3879,6 +4165,29 @@ esac
 `,
   );
   fs.chmodSync(hook, 0o755);
+}
+
+function runAsync(command, args, cwd, env = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      {
+        cwd,
+        env: { ...process.env, ...env },
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+        timeout: 55_000,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`${error.message}\n${stdout}\n${stderr}`));
+          return;
+        }
+        resolve(`${stdout}${stderr}`);
+      },
+    );
+  });
 }
 
 function captureConsoleLog(callback, lines = []) {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -621,13 +621,20 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   const completeStart = publisherSource.indexOf("const complete =");
   assert.ok(publisherSource.indexOf("hardResetToRemoteMain();", completeStart) > completeStart);
   assert.match(publisherSource, /GitCommandTimeoutError/);
+  assert.match(publisherSource, /StatePublishContentionError/);
+  assert.match(publisherSource, /StatePublishContentionError\s*\? "state_contention"/);
+  assert.match(
+    publisherSource,
+    /const mutation = withStatePublishLease\(\(\) => \{\s*hardResetToRemoteMain\(\)/,
+  );
   assert.match(publisherSource, /retryable_failure/);
   assert.match(publisherSource, /error instanceof GitCommandTimeoutError/);
   assert.match(
     publisherSource,
-    /writePublicationCompletionOutputs\(\s*retryableTimeout \? "retryable_failure" : "permanent_failure",\s*reasonCode,\s*errorFingerprint\(error\),\s*\);/,
+    /writePublicationCompletionOutputs\(\s*retryableFailure \? "retryable_failure" : "permanent_failure",\s*reasonCode,\s*errorFingerprint\(error\),\s*\);/,
   );
-  assert.doesNotMatch(publisherSource, /retryableTimeout \? "github_transient" : undefined/);
+  assert.doesNotMatch(publisherSource, /retryableFailure \? "github_transient" : undefined/);
+  assert.match(publishComplete.run ?? "", /"state_contention"/);
   assert.ok(
     publisherSource.indexOf("eventSnapshotMatchesCurrent(paths)", completeStart) > completeStart,
   );


### PR DESCRIPTION
## Summary

- serialize the exact-result state mutation with a short remote lease
- atomically renew/fence that lease in the same push that updates `state`
- classify lease contention as a bounded transient publication failure

## Problem and causal proof

Exact review generation and some GitHub publication calls still complete, but the queue is not draining because many exact publishers independently mutate the single `state` ref. A representative run on current `main`, [29750012187](https://github.com/openclaw/clawsweeper/actions/runs/29750012187), spent 12.8 minutes in result publication, repeatedly lost state pushes, and performed repeated 13–41 second state fetches before eventually succeeding. Comparable observed runs scaled from 2.8 minutes with no rejection to 5.6/10.6/20.6 minutes with 5/11/19 rejections. These were non-fast-forward/CAS losses, not GitHub authentication failures; the affected logs contained no 401/403 signature.

At 2026-07-20T15:49:33Z the live publication lane still had 323 pending, 318 ready, 39 of 40 leases occupied, an oldest item age of 4h06m, and net drain of -88/hour over 15 minutes and -60/hour over 60 minutes.

The concurrency originated when [#614](https://github.com/openclaw/clawsweeper/pull/614) parallelized exact publication and [#641](https://github.com/openclaw/clawsweeper/pull/641) added adaptive capacity. [#711](https://github.com/openclaw/clawsweeper/pull/711) and [#712](https://github.com/openclaw/clawsweeper/pull/712) made losing state writers perform more recovery work, while [#713](https://github.com/openclaw/clawsweeper/pull/713) stopped those state-fetch timeouts from lowering global capacity. [#714](https://github.com/openclaw/clawsweeper/pull/714), [#716](https://github.com/openclaw/clawsweeper/pull/716), [#720](https://github.com/openclaw/clawsweeper/pull/720), and [#721](https://github.com/openclaw/clawsweeper/pull/721) repaired object/history recovery, but they do not prevent the 40 admitted exact publishers from colliding on the same ref. Thus #712 amplified/exposed this failure path; it did not create the underlying parallel-writer topology.

## Implementation

- Acquire `refs/heads/clawsweeper-publish-lease/state` before resetting/applying the exact record tuple.
- Update the exact tuple and renew the lease in one atomic two-ref push. The lease CAS fences an expired or stolen owner at the same server transaction that updates `state`, so there is no check/push gap.
- Release after the mutation; keep remote completion verification outside the critical section. Abandoned owners expire after two minutes, and acquisition is bounded to three minutes.
- Return `state_contention` through the existing transient publication retry budget (12 attempts/24 hours) without reporting a GitHub failure kind or reducing global capacity.

The lock covers only the exact tuple mutation. It does not serialize review generation, GitHub comment/label calls, routing, or broad state publishers.

## Validation

- Crabbox Docker focused proof, `local-container` / `node:24-bookworm`, lease `cbx_80097db415d4` (exit 0):
  - all 51 `test/repair/git-publish.test.ts` cases passed
  - eight simultaneously released exact writers each landed their tuple with one state push and no lost race
  - an owner held beyond its original TTL renewed and fenced the state update atomically
  - abandoned-owner recovery passed
  - exact workflow wiring and `state_contention` queue-budget tests passed
  - all three TypeScript builds, Oxlint, and Oxfmt passed
- Crabbox Docker aggregate proof, `local-container` / `node:24-bookworm`, lease `cbx_b793a71f332b` (exit 0): `pnpm run check` passed, including all unit/repair suites, both coverage gates, builds, lint, formatting, active-surface, dashboard-boundary, and limits checks. The disposable proof environment normalized host-synced CRLF text and supplied checksum-verified `jq`; neither adjustment is in this patch.
- Native focused proof: `pnpm run build:all`; the lease, queue, and workflow tests; Oxlint; and `git diff --check` passed. Native aggregate failures were unrelated Windows-host baseline constraints (Linux/Bash integrations, symlink privilege, and POSIX filesystem fixtures), so the authoritative aggregate proof ran in Crabbox Linux.
- `actionlint` is not installed locally; workflow source assertions, YAML formatting, the aggregate Linux suite, and normal CI cover the one completion-reason allowlist edit.

### CI timing follow-up

The first #722 [`pnpm check`](https://github.com/openclaw/clawsweeper/actions/runs/29757016437/job/88401878182) failed only two pre-existing action-ledger timing assertions: dead-owner reclamation took 3.64 seconds and Linux zombie-owner reclamation took 1.25 seconds against hard-coded one-second limits. The same tests passed on the immediately preceding main run in 361 ms and 66 ms. #722 does not change action-ledger runtime behavior; the limits originated in [#511](https://github.com/openclaw/clawsweeper/pull/511), while [#709](https://github.com/openclaw/clawsweeper/pull/709) had already widened comparable host-load-sensitive tests.

The test-only follow-up widens all four prompt-reclamation guards from one second to five seconds. This remains below the production lock-wait fallback of ten seconds, so the tests still distinguish prompt dead-owner reclamation from the fallback path.

- `pnpm run build:all`: passed.
- `node --test --test-name-pattern 'producer locks reclaim fresh dead owners|Linux stale-lock checks bypass cached identities|Linux producer locks reclaim zombie owners' test/action-ledger-runtime.test.ts`: one applicable Windows test passed in 1.475 seconds; two Linux-only tests skipped on Windows as designed.
- `pnpm exec oxfmt --check test/action-ledger-runtime.test.ts`: passed.
- `git diff --check`: passed.
- A second Crabbox attempt for this test-only follow-up was explicitly waived after an unprivileged Corepack harness setup failure; the earlier exact-head focused and aggregate Crabbox proofs above remain valid for the production patch.

## Review closeout

- `codex review --uncommitted` first identified that a generic reason would use the poison-item budget. Accepted: added `state_contention`, its transient queue classification, and regression proof.
- A repeated `codex review --uncommitted` identified expiry between ownership validation and a slow push. Accepted: changed renewal plus state update to an atomic fenced push and added post-expiry proof.
- Final production-patch `codex review --uncommitted`: no actionable defects; lease, atomic publish, and retry-classification paths internally consistent.
- Final production-patch `codex review --base origin/main`: no actionable correctness issues; focused build, lease, queue, and workflow tests passed.
- Test-only CI follow-up `codex review --uncommitted`: clean, no accepted/actionable findings.
- Test-only CI follow-up `codex review --base origin/main`: clean, no accepted/actionable findings; state-publish lease fencing and retry classification remain consistent across publisher, queue, and workflow contracts.

## Risk and rollout

- Pre-merge exact publishers do not know about the lease, so isolated collisions can continue until those executions drain. Post-merge executions serialize only the short state mutation.
- A crashed publisher may leave the lease ref temporarily present; bounded TTL recovery is tested. Release uses compare-and-swap and cannot delete a newer owner's lease.
- The atomic push deliberately fails closed if lease ownership changes. That item is retried as `state_contention` rather than dead-lettered early or fed into GitHub pressure control.
- No queue capacity, gate, state reset, replay, direct Actions dispatch, token scope, or GitHub API behavior changes.
- The CI follow-up changes test timing tolerance only; it does not change production lock behavior.

## Credit

The remote-lease design builds on Vincent Koc's earlier state-publication serialization work in `b72380fa711171e6d8cc0025ce8285472f25230e`. It is narrowed here to exact result mutation and strengthened with atomic fencing. Peter Steinberger's recovery work in #711, #712, #714, #716, and #721 remains intact.
