### PR TITLE
fix(publish): recover exact state races without full reset

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -75,6 +75,7 @@ const GIT_PATHSPEC_BATCH_SIZE = 256;
 const GIT_OBJECT_BATCH_SIZE = 512;
 const GIT_OBJECT_BATCH_MAX_BUFFER = 64 * 1024 * 1024;
 const GIT_TREE_LIST_MAX_BUFFER = 64 * 1024 * 1024;
+const GIT_STATE_DIFF_MAX_BUFFER = 256 * 1024 * 1024;
 const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
 const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
 // Recovery fetches (deepen/unshallow/refetch of the state history) are rare
@@ -83,6 +84,7 @@ const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
 const RECOVERY_FETCH_TIMEOUT_MS = 300_000;
 const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
 const STATE_PUBLISH_LEASE_TTL_MS = 2 * 60_000;
+const STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS = PUBLISH_FETCH_TIMEOUT_MS;
 const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = 3 * 60_000;
 const STATE_PUBLISH_LEASE_WAIT_MS = 1_000;
 const STATE_PUBLISH_LEASE_MAX_WAIT_MS = 5_000;
@@ -1583,6 +1585,7 @@ function createStatePublishLeaseCommit(options: {
       `owner: ${options.owner}`,
       `branch: ${options.branch}`,
       `ttl_ms: ${options.ttlMs}`,
+      `generation: ${randomUUID()}`,
       "",
     ].join("\n"),
     quiet: true,
@@ -1607,6 +1610,40 @@ function releaseStatePublishLease(lease: StatePublishLease): void {
       `State publish lease release failed owner=${lease.owner}; expiry will recover it: ${errorMessage(error)}`,
     );
   }
+}
+
+function renewStatePublishLease(lease: StatePublishLease, reason: string): void {
+  const renewedOid = createStatePublishLeaseCommit({
+    branch: lease.branch,
+    owner: lease.owner,
+    ttlMs: lease.ttlMs,
+  });
+  const renewed = spawnGit(
+    [
+      "push",
+      `--force-with-lease=${lease.ref}:${lease.oid}`,
+      lease.remote,
+      `${renewedOid}:${lease.ref}`,
+    ],
+    { allowFailure: true, quiet: true, timeout: PUBLISH_FETCH_TIMEOUT_MS },
+  );
+  if (renewed.timedOut) {
+    throw new GitCommandTimeoutError(["push"], PUBLISH_FETCH_TIMEOUT_MS);
+  }
+  if (renewed.status !== 0) {
+    const currentLeaseOid = remoteRefOid(lease.remote, lease.ref);
+    if (currentLeaseOid !== renewedOid) {
+      if (currentLeaseOid !== lease.oid) {
+        throw new StatePublishContentionError(
+          `State publish lease ownership changed while renewing ${reason}`,
+        );
+      }
+      throw new StatePublishContentionError(`Failed to renew state publish lease ${reason}`);
+    }
+  }
+  lease.oid = renewedOid;
+  lease.expiresAtMs = Date.now() + lease.ttlMs;
+  console.log(`Renewed state publish lease owner=${lease.owner} ${reason}`);
 }
 
 function remoteRefOid(remote: string, ref: string): string | null {
@@ -1635,6 +1672,10 @@ function pushPublishedBranch(remote: string, branch: string): GitRunResult {
     );
   }
 
+  if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
+    renewStatePublishLease(lease, "before branch publication");
+  }
+
   const renewedOid = createStatePublishLeaseCommit({
     branch: lease.branch,
     owner: lease.owner,
@@ -1660,7 +1701,12 @@ function pushPublishedBranch(remote: string, branch: string): GitRunResult {
         lease.expiresAtMs = Date.now() + lease.ttlMs;
         return { ...pushed, status: 0 };
       }
-      throw new Error("Atomic state publish updated its lease without the branch");
+      lease.oid = renewedOid;
+      lease.expiresAtMs = Date.now() + lease.ttlMs;
+      console.log(
+        "State publish renewed its owner lease without the branch; recovering the lost state race",
+      );
+      return pushed;
     }
     if (currentLeaseOid !== lease.oid) {
       throw new StatePublishContentionError(
@@ -1692,6 +1738,9 @@ export function pushCommit(options: {
 
   for (let pushAttempt = 1; pushAttempt <= pushAttempts; pushAttempt += 1) {
     if (pushPublishedBranch(remote, branch).status === 0) return true;
+    if (activeStatePublishLease && options.boundedRemoteHeadRebuild) {
+      renewStatePublishLease(activeStatePublishLease, "before state race recovery");
+    }
     console.log(`Push attempt ${pushAttempt} lost the ${branch} race; rebasing`);
     const localCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
     const localCommitMessage = runGit(["log", "-1", "--format=%B"], { quiet: true });
@@ -1917,17 +1966,62 @@ function rebuildReconciliationCommit(
     );
   }
 
-  runGit(["reset", "--hard", remoteRef]);
-  const selectedPaths = applyRecordTupleSelections(selectedTuples);
-
-  if (selectedPaths.length > 0) stagePaths(selectedPaths);
-  if (!hasStagedChanges()) {
-    console.log("No reconciliation changes remain after preserving concurrent record tuples");
+  if (!boundedRemoteHeadRebuild) {
+    runGit(["reset", "--hard", remoteRef]);
+    const selectedPaths = applyRecordTupleSelections(selectedTuples);
+    if (selectedPaths.length > 0) stagePaths(selectedPaths);
+    if (!hasStagedChanges()) {
+      console.log("No reconciliation changes remain after preserving concurrent record tuples");
+      return true;
+    }
+    runGit(["commit", "-C", sourceCommit]);
     return true;
   }
 
-  runGit(["commit", "-C", sourceCommit]);
+  const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
+  const remoteTree = runGit(["rev-parse", `${remoteCommit}^{tree}`], { quiet: true }).trim();
+  const tree = rewriteRecordTupleSelectionsTree(remoteTree, selectedTuples);
+  if (tree === remoteTree) {
+    console.log("No reconciliation changes remain after preserving concurrent record tuples");
+    setReconciliationHead(remoteCommit);
+    return true;
+  }
+
+  const message = runGit(["log", "-1", "--format=%B", sourceCommit], { quiet: true });
+  const commit = runGit(["commit-tree", tree, "-p", remoteCommit], {
+    input: message,
+    quiet: true,
+  }).trim();
+  setReconciliationHead(commit);
+  console.log("Rebuilt reconciliation as a bounded record-tuple tree patch");
   return true;
+}
+
+function setReconciliationHead(commit: string): void {
+  // The bounded rebuild deliberately leaves the huge state worktree alone.
+  // Refresh the index and only materialize paths whose trees differ so a
+  // subsequent publish or source refresh cannot reuse stale record files.
+  const changedPaths = runGit(["diff", "--no-renames", "--name-only", "-z", "HEAD", commit], {
+    quiet: true,
+    maxBuffer: GIT_STATE_DIFF_MAX_BUFFER,
+  })
+    .split("\0")
+    .filter(Boolean);
+  runGit(["read-tree", commit]);
+  runGit(["update-ref", "HEAD", commit]);
+  const root = resolve(publishRoot() ?? ".");
+  for (const path of changedPaths) {
+    const target = resolve(root, path);
+    if (!isPathInsideOrEqual(root, target)) {
+      throw new Error(`Refusing to refresh reconciliation path outside publish root: ${path}`);
+    }
+    rmSync(target, { force: true, recursive: true });
+  }
+  const existing = gitObjectExistence(changedPaths.map((path) => ({ commit, path })));
+  const checkoutPaths = changedPaths.filter((path) => existing.has(gitObjectSpec(commit, path)));
+  for (const batch of chunked(checkoutPaths, GIT_PATHSPEC_BATCH_SIZE)) {
+    runGit(["checkout", commit, "--", ...batch]);
+  }
 }
 
 function mergeBaseWithoutHydration(
@@ -2348,9 +2442,32 @@ type GitTreeEntry = {
 };
 
 type GitTreePatch = {
-  files: Map<string, GitTreeEntry>;
+  files: Map<string, GitTreeEntry | null>;
   directories: Map<string, GitTreePatch>;
 };
+
+function rewriteRecordTupleSelectionsTree(
+  remoteTree: string,
+  selections: readonly { paths: RecordTuplePaths; commit: string }[],
+): string {
+  const patch: GitTreePatch = { files: new Map(), directories: new Map() };
+  for (const selection of selections) {
+    const paths = recordTuplePathList(selection.paths);
+    const entries = readGitTreeEntries([
+      "ls-tree",
+      "-z",
+      "--full-tree",
+      selection.commit,
+      "--",
+      ...paths,
+    ]);
+    const sourceByPath = new Map(entries.map((entry) => [entry.name, entry]));
+    for (const path of paths) {
+      addGitTreePatch(patch, path.split("/"), sourceByPath.get(path) ?? null);
+    }
+  }
+  return writePatchedGitTree(remoteTree, patch, new Set(), { allowReplace: true });
+}
 
 function rewriteImmutableActionLedgerTree(options: {
   remoteTree: string;
@@ -2373,11 +2490,15 @@ function rewriteImmutableActionLedgerTree(options: {
   return writePatchedGitTree(options.remoteTree, patch, options.verifiedSourceObjectIds);
 }
 
-function addGitTreePatch(patch: GitTreePatch, parts: readonly string[], entry: GitTreeEntry): void {
+function addGitTreePatch(
+  patch: GitTreePatch,
+  parts: readonly string[],
+  entry: GitTreeEntry | null,
+): void {
   const [name, ...rest] = parts;
-  if (!name) throw new Error("Immutable action-ledger path is empty");
+  if (!name) throw new Error("Git tree patch path is empty");
   if (rest.length === 0) {
-    patch.files.set(name, { ...entry, name });
+    patch.files.set(name, entry ? { ...entry, name } : null);
     return;
   }
   const child = patch.directories.get(name) ?? { files: new Map(), directories: new Map() };
@@ -2389,6 +2510,7 @@ function writePatchedGitTree(
   baseTree: string | null,
   patch: GitTreePatch,
   verifiedSourceObjectIds: Set<string>,
+  options: { allowReplace?: boolean } = {},
 ): string {
   const entries = new Map(
     (baseTree ? readGitTreeEntries(["ls-tree", "-z", baseTree]) : []).map((entry) => [
@@ -2401,10 +2523,16 @@ function writePatchedGitTree(
     if (existing && existing.type !== "tree") {
       throw new Error(`Immutable action-ledger directory collides with ${existing.type}: ${name}`);
     }
-    const oid = writePatchedGitTree(existing?.oid ?? null, childPatch, verifiedSourceObjectIds);
+    const oid = writePatchedGitTree(
+      existing?.oid ?? null,
+      childPatch,
+      verifiedSourceObjectIds,
+      options,
+    );
     entries.set(name, { mode: "040000", type: "tree", oid, name });
   }
   const locallyRequiredEntries = [...patch.files].flatMap(([name, entry]) => {
+    if (!entry) return [];
     const existing = entries.get(name);
     return !existing ||
       existing.type !== entry.type ||
@@ -2415,8 +2543,13 @@ function writePatchedGitTree(
   });
   assertLocalGitTreeEntries(locallyRequiredEntries, verifiedSourceObjectIds);
   for (const [name, entry] of patch.files) {
+    if (!entry) {
+      entries.delete(name);
+      continue;
+    }
     const existing = entries.get(name);
     if (
+      !options.allowReplace &&
       existing &&
       (existing.type !== entry.type || existing.mode !== entry.mode || existing.oid !== entry.oid)
     ) {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1919,6 +1919,135 @@ test("state publish lease renews and fences a push after the original TTL", () =
   );
 });
 
+test("state publish lease survives a lost race without resetting the state worktree", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-rebuild-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  const candidate = path.join(root, "candidate");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  write(path.join(seed, "README.md"), "state\n");
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial state"], seed);
+  run("git", ["push", "origin", "HEAD:state"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, work], root);
+  configureUser(work);
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+
+  const localNumber = 10_101;
+  const remoteNumber = 10_102;
+  const localTuple = writeRecordTuple(candidate, {
+    number: localNumber,
+    marker: "leased local result",
+    reviewedAt: "2026-07-20T16:00:00.000Z",
+    itemUpdatedAt: "2026-07-20T15:59:00Z",
+  });
+  const remoteTuple = writeRecordTuple(other, {
+    number: remoteNumber,
+    marker: "unleased concurrent state writer",
+    reviewedAt: "2026-07-20T16:01:00.000Z",
+    itemUpdatedAt: "2026-07-20T16:00:00Z",
+  });
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "concurrent state update"], other);
+  const recordRoot = "records/openclaw-openclaw";
+  const paths = [
+    `${recordRoot}/items/${localNumber}.md`,
+    `${recordRoot}/closed/${localNumber}.md`,
+    `${recordRoot}/plans/${localNumber}.md`,
+    `${recordRoot}/decision-packets/${localNumber}.json`,
+  ];
+
+  let published = false;
+  let advertisedLease = "";
+  const lines = captureConsoleLog(() => {
+    withEnv(
+      {
+        CLAWSWEEPER_PUBLISH_ROOT: work,
+        CLAWSWEEPER_PUBLISH_BRANCH: "state",
+      },
+      () =>
+        withStatePublishLease(
+          () => {
+            advertisedLease = run(
+              "git",
+              [
+                "--git-dir",
+                origin,
+                "show",
+                "-s",
+                "--format=%B",
+                "refs/heads/clawsweeper-publish-lease/state",
+              ],
+              root,
+            );
+            hardResetToRemoteMain("origin", "state");
+            fs.cpSync(path.join(candidate, "records"), path.join(work, "records"), {
+              recursive: true,
+            });
+            stagePaths(paths);
+            runGit([
+              "commit",
+              "-m",
+              commitMessageForPublishedPaths("chore: publish leased tuple", paths),
+            ]);
+            run("git", ["push", "origin", "HEAD:state"], other);
+            published = pushSingleRecordTupleCommit({
+              paths,
+              branch: "state",
+              pushAttempts: 2,
+            });
+          },
+          { branch: "state", acquireTimeoutMs: 5_000, waitMs: 10 },
+        ),
+    );
+  });
+
+  assert.equal(published, true);
+  assert.match(advertisedLease, /ttl_ms: 120000/);
+  assert.equal(
+    lines.some(
+      (line) =>
+        line.includes("Renewed state publish lease") && line.includes("before state race recovery"),
+    ),
+    true,
+  );
+  assert.equal(
+    lines.some((line) => line === "Rebuilt reconciliation as a bounded record-tuple tree patch"),
+    true,
+  );
+  const recoveryStart = lines.findIndex((line) =>
+    line.includes("Push attempt 1 lost the state race"),
+  );
+  assert.notEqual(recoveryStart, -1);
+  assert.equal(
+    lines.slice(recoveryStart).some((line) => line.startsWith("$ git reset")),
+    false,
+  );
+  assert.equal(
+    lines.slice(recoveryStart).some((line) => line.startsWith("$ git read-tree")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordRoot}/items/${localNumber}.md`], root),
+    localTuple.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordRoot}/items/${remoteNumber}.md`], root),
+    remoteTuple.primary,
+  );
+  assert.equal(fs.readFileSync(path.join(work, paths[0]), "utf8"), localTuple.primary);
+  assert.equal(
+    fs.readFileSync(path.join(work, `${recordRoot}/items/${remoteNumber}.md`), "utf8"),
+    remoteTuple.primary,
+  );
+});
+
 test("checkpoint publish rebuilds on the remote head when histories are unrelated", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-checkpoint-unrelated-"));
   const origin = path.join(root, "origin.git");


### PR DESCRIPTION
## Summary

- rebuild an exact publication tuple directly on the latest remote `state` tree
- renew the exact-state publication lease after a lost push race
- update only paths changed by that tuple instead of resetting the production-sized state worktree

## Problem and causal proof

[#722](https://github.com/openclaw/clawsweeper/pull/722) serialized exact state mutations, but it did not restore publication throughput. At the 2026-07-20T16:29:45Z post-merge baseline the publication lane still had 354 pending, 352 ready, 40/40 leases occupied, an oldest item age of 13,786 seconds, and net drain of -52/hour over 15 minutes and -56/hour over 60 minutes.

A 2026-07-20T16:40:52Z workflow inventory separated the 40 occupied publication slots into 28 pre-#722 publishers, 12 post-#722 executions, and one dispatch reservation. Thirty-seven of the 39 running publishers were already inside `Publish event result and apply safe close`. Ten post-#722 publishers then exhausted the new 180-second lease acquisition bound.

The lease was not deadlocked and GitHub access was not failing. The active owner repeatedly lost `state` compare-and-swap races to pre-lease publishers, then ran `git reset --hard` across a 434,644-file state worktree. Individual resets took roughly 25-30 seconds; one observed owner recorded 22 state races and 21 `cannot lock ref` failures. That work allowed its two-minute lease to expire while it was still recovering, leaving new writers queued behind an owner that could no longer complete under its lease. Affected logs contained no 401/403 or token-access signature.

The incident predates [#712](https://github.com/openclaw/clawsweeper/pull/712), and high publication concurrency predates the #711/#712 window. However, the renewed capacity stall immediately after #712 is high-confidence attributable to #712's synchronous missing-object/history recovery: every losing publisher could perform serial 60-second refetch, deepen, and unshallow operations before retrying. [#714](https://github.com/openclaw/clawsweeper/pull/714) showed the object-fetch premise was invalid, [#716](https://github.com/openclaw/clawsweeper/pull/716) moved no-base reconciliation onto the remote head, and [#720](https://github.com/openclaw/clawsweeper/pull/720) removed hydration from one exact path. The remaining full-worktree reset in exact race recovery is the first fault addressed here.

## Implementation

- For bounded exact-tuple reconciliation, resolve the latest remote commit/tree and rewrite only the selected tuple entries with `mktree --missing`, then create a child commit with `commit-tree`. Arbitrary remote sibling paths are preserved.
- Reconcile the local checkout with `read-tree`, `update-ref`, and materialization/removal of only paths changed between the prior and replacement trees. The exact recovery path no longer performs a full `git reset --hard`.
- Give every lease commit a unique generation and renew ownership with a compare-and-swap push when an exact state push loses a race. Ambiguous atomic-push results remain recoverable only when the same owner still controls the lease.
- Keep the existing two-minute lease TTL, three-minute acquisition bound, state-contention retry classification, and broad reconciliation behavior unchanged.

This does not repair #711's separate broad no-common-base replacement risk. That path is not required to release the currently blocked exact publication leases and should be handled independently.

## Validation

### Crabbox Docker behavioral proof

Crabbox local-container, `node:24-bookworm`, lease `cbx_d76c6b7f57f2`, exit 0:

- copied the new forced-race regression onto unmodified `origin/main`; it failed as expected
- patched branch passed the forced exact race, eight-writer serialization, and shallow-losing-writer focused cases
- all 52 `test/repair/git-publish.test.ts` cases passed
- the forced race proves the default `ttl_ms: 120000`, a lease renewal before recovery, no post-race `git reset`, the bounded tuple-tree rebuild, and preservation/materialization of both the local tuple and an unleased concurrent remote sibling

Proof command:

```powershell
C:\Users\marti\.local\bin\crabbox.exe run --provider local-container --local-container-image node:24-bookworm --no-hydrate --timing-json --script C:\clawsweeper-work\orchestrator\csw-049-crabbox-proof.sh
```

### Static and build proof

- `pnpm run build:all`
- `pnpm run lint:repair`
- `pnpm exec oxlint test/repair/git-publish.test.ts --deny-warnings --report-unused-disable-directives -D correctness`
- `pnpm exec oxfmt --check src/repair/git-publish.ts test/repair/git-publish.test.ts`
- `git diff --check`

All passed. A separate `test/sweep-workflow.test.ts` probe passed 66/67 cases; its only failure was an untouched fixture requiring `jq`, which is absent from the stock unprivileged Node/Playwright Crabbox images. The authoritative widened proof is the complete 52-case publisher suite in Crabbox.

## Retrospective #712 review

- `codex review --commit 25135198f921b062b6d276931ca794d0222129c6` identified the synchronous recovery/history-fetch amplification, the invalid assumption that GitHub would serve unavailable object IDs, and a Windows-only historical test portability defect.
- A read-only local ClawSweeper range review of exact merge `25135198f921b062b6d276931ca794d0222129c6` against parent `611b3f165d05254c9ec20ee69953167c517e6c7b` completed with high confidence but reported no actionable finding and rated the patch correct. Production evidence and the retrospective Codex review therefore expose a review gap; the local review added no further code requirement.
- This patch addresses the relevant runtime findings. The hard-coded `/usr/bin/git` test portability defect is unrelated to the production incident and is intentionally excluded.

## Codex review closeout

- First `codex review --uncommitted` found three actionable issues: an overlong lease TTL weakened crash recovery, that TTL still could not cover every broad recovery fetch, and the state-tree diff used Git's default 16 MiB output buffer.
- Accepted fixes restored the original 120-second TTL, scoped renewal and tree-only reconciliation strictly to the bounded exact path while preserving the broad path, and raised the state-tree diff buffer to 256 MiB.
- Focused and full Crabbox proofs were repeated after those fixes.
- Final `codex review --uncommitted`: clean; no actionable findings.
- Final `codex review --base origin/main`: clean; "The bounded reconciliation rebuild and lease-renewal changes preserve the selected record tuples and maintain the lease across a lost push race. No actionable regressions were identified in the diff."

## Risk and rollout

- Pre-merge/legacy publishers do not respect the lease and may continue colliding until they time out or finish. This repair makes a new exact publisher's recovery bounded and prevents a full state checkout reset from consuming its lease.
- A crashed owner still becomes recoverable after the unchanged two-minute TTL. Renewal uses compare-and-swap and cannot extend or delete a different owner's lease.
- Remote siblings are preserved by construction; the new regression forces an unleased concurrent sibling write and verifies both tuples in the resulting remote tree and local checkout.
- No capacity, queue budget, retry count, gate, token scope, workflow dispatch, state reset, replay, requeue, or GitHub API behavior changes.

## Credit

This repair preserves and narrows the remote-head reconciliation work from Peter Steinberger's [#711](https://github.com/openclaw/clawsweeper/pull/711), [#712](https://github.com/openclaw/clawsweeper/pull/712), [#714](https://github.com/openclaw/clawsweeper/pull/714), [#716](https://github.com/openclaw/clawsweeper/pull/716), and [#721](https://github.com/openclaw/clawsweeper/pull/721), together with the bounded exact recovery from #720 and lease fencing from #722.
