### PR TITLE
fix(publish): coordinate every state branch writer

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   cpSync,
@@ -106,6 +106,12 @@ type StatePublishLease = {
   ttlMs: number;
   remote: string;
   branch: string;
+  cleanup: StatePublishLeaseCleanup | null;
+};
+
+type StatePublishLeaseCleanup = {
+  track: (oid: string) => void;
+  close: () => void;
 };
 
 type ObservedStatePublishLease = {
@@ -484,7 +490,7 @@ function pushImmutableActionLedgerCommit(options: {
   for (let attempt = 1; attempt <= pushBudget; attempt += 1) {
     const pushArgs = ["push", options.remote, `${candidateCommit}:${options.branch}`];
     const pushDisplayArgs = ["push", options.remote, `<commit>:${options.branch}`];
-    let pushResult = spawnGit(pushArgs, { displayArgs: pushDisplayArgs });
+    let pushResult = pushPublishedCommit(candidateCommit, options.remote, options.branch);
     if (pushResult.status !== 0 && unavailableGitObjectIds(pushResult).length > 0) {
       if (unavailableObjectRecoveryUsed) {
         throw gitRunError(pushResult, pushArgs, pushDisplayArgs);
@@ -509,9 +515,7 @@ function pushImmutableActionLedgerCommit(options: {
         });
         return "unchanged";
       }
-      pushResult = spawnGit(["push", options.remote, `${candidateCommit}:${options.branch}`], {
-        displayArgs: pushDisplayArgs,
-      });
+      pushResult = pushPublishedCommit(candidateCommit, options.remote, options.branch);
       if (pushResult.status !== 0 && unavailableGitObjectIds(pushResult).length > 0) {
         throw gitRunError(pushResult, pushArgs, pushDisplayArgs);
       }
@@ -705,39 +709,42 @@ function mergeImmutableActionLedgerOnGitHub(options: {
     // GitHub resolves the merge against the live base ref in one server-side
     // transaction, so a fast state writer cannot invalidate a locally rebuilt
     // commit between fetch and push.
-    for (let attempt = 1; attempt <= 8; attempt += 1) {
-      spawnGitHubApi(
-        [
-          "api",
-          `repos/${options.repository}/merges`,
-          "--method",
-          "POST",
-          "-f",
-          `base=${options.branch}`,
-          "-f",
-          `head=${temporaryBranch}`,
-          "-f",
-          `commit_message=${options.message}`,
-        ],
-        options.repository,
-        options.token,
-      );
-      fetchPublishRemote(options.remote, options.branch);
-      const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
-        quiet: true,
-      }).trim();
-      if (
-        immutableActionLedgerPathsPresent({
-          commit: remoteCommit,
-          sourceCommit: options.sourceCommit,
-          paths: options.paths,
-        })
-      ) {
-        return remoteCommit;
+    return withStatePublishMutationLease(options.remote, options.branch, () => {
+      for (let attempt = 1; attempt <= 8; attempt += 1) {
+        renewStatePublishLeaseIfNeeded("before immutable ledger server merge");
+        spawnGitHubApi(
+          [
+            "api",
+            `repos/${options.repository}/merges`,
+            "--method",
+            "POST",
+            "-f",
+            `base=${options.branch}`,
+            "-f",
+            `head=${temporaryBranch}`,
+            "-f",
+            `commit_message=${options.message}`,
+          ],
+          options.repository,
+          options.token,
+        );
+        fetchPublishRemote(options.remote, options.branch);
+        const remoteCommit = runGit(["rev-parse", `${options.remote}/${options.branch}`], {
+          quiet: true,
+        }).trim();
+        if (
+          immutableActionLedgerPathsPresent({
+            commit: remoteCommit,
+            sourceCommit: options.sourceCommit,
+            paths: options.paths,
+          })
+        ) {
+          return remoteCommit;
+        }
+        console.log(`Server merge attempt ${attempt} did not publish the immutable ledger batch`);
       }
-      console.log(`Server merge attempt ${attempt} did not publish the immutable ledger batch`);
-    }
-    throw new Error("Failed to publish immutable ledger through GitHub server merge");
+      throw new Error("Failed to publish immutable ledger through GitHub server merge");
+    });
   } finally {
     if (pushed) {
       spawnGitHubApi(
@@ -1450,13 +1457,28 @@ export function withStatePublishLease<T>(
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
   const lease = acquireStatePublishLease(remote, branch, options);
+  lease.cleanup = startStatePublishLeaseCleanup(lease);
   activeStatePublishLease = lease;
   try {
     return operation();
   } finally {
     activeStatePublishLease = null;
     releaseStatePublishLease(lease);
+    lease.cleanup?.close();
   }
+}
+
+function withStatePublishMutationLease<T>(remote: string, branch: string, operation: () => T): T {
+  if (!publishRoot()) return operation();
+  if (!activeStatePublishLease) {
+    return withStatePublishLease(operation, { remote, branch });
+  }
+  if (activeStatePublishLease.remote !== remote || activeStatePublishLease.branch !== branch) {
+    throw new StatePublishContentionError(
+      `Active state publish lease does not cover ${remote}/${branch}`,
+    );
+  }
+  return operation();
 }
 
 function acquireStatePublishLease(
@@ -1500,9 +1522,9 @@ function acquireStatePublishLease(
         ).status === 0;
       if (acquired) {
         console.log(
-          `Acquired state publish lease owner=${owner} attempt=${attempt} stale_recovery=${observed ? "true" : "false"}`,
+          `Acquired state publish lease owner=${owner} attempt=${attempt} stale_recovery=${observed ? "true" : "false"} ttl_ms=${ttlMs}`,
         );
-        return { ref: leaseRef, oid, owner, expiresAtMs, ttlMs, remote, branch };
+        return { ref: leaseRef, oid, owner, expiresAtMs, ttlMs, remote, branch, cleanup: null };
       }
     } else {
       console.log(
@@ -1592,6 +1614,76 @@ function createStatePublishLeaseCommit(options: {
   }).trim();
 }
 
+function startStatePublishLeaseCleanup(lease: StatePublishLease): StatePublishLeaseCleanup {
+  const cleanupScript = String.raw`
+    import { spawnSync } from "node:child_process";
+
+    const [remote, leaseRef, workdir] = process.argv.slice(1);
+    const candidates = [];
+    let pending = "";
+    const capture = (value) => {
+      for (const line of value.split("\n")) {
+        const oid = line.trim();
+        if (/^[a-f0-9]{40,64}$/.test(oid) && !candidates.includes(oid)) candidates.push(oid);
+      }
+    };
+
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      pending += chunk;
+      const newline = pending.lastIndexOf("\n");
+      if (newline < 0) return;
+      capture(pending.slice(0, newline));
+      pending = pending.slice(newline + 1);
+    });
+    process.stdin.on("end", () => {
+      capture(pending);
+      for (const oid of candidates.reverse()) {
+        const deleted = spawnSync(
+          "git",
+          ["push", "--quiet", "--force-with-lease=" + leaseRef + ":" + oid, remote, ":" + leaseRef],
+          { cwd: workdir, stdio: "ignore", timeout: 60000 },
+        );
+        if (deleted.status === 0) break;
+      }
+    });
+    process.stdin.resume();
+  `;
+  const child = spawn(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      cleanupScript,
+      lease.remote,
+      lease.ref,
+      resolve(publishRoot() ?? "."),
+    ],
+    {
+      detached: true,
+      windowsHide: true,
+      stdio: ["pipe", "ignore", "ignore"],
+    },
+  );
+  child.on("error", () => {});
+  child.stdin.on("error", () => {});
+  child.unref();
+
+  let closed = false;
+  const track = (oid: string) => {
+    if (!closed && !child.stdin.destroyed) child.stdin.write(`${oid}\n`);
+  };
+  track(lease.oid);
+  return {
+    track,
+    close: () => {
+      if (closed) return;
+      closed = true;
+      child.stdin.end();
+    },
+  };
+}
+
 function releaseStatePublishLease(lease: StatePublishLease): void {
   try {
     const released = spawnGit(
@@ -1618,6 +1710,7 @@ function renewStatePublishLease(lease: StatePublishLease, reason: string): void 
     owner: lease.owner,
     ttlMs: lease.ttlMs,
   });
+  lease.cleanup?.track(renewedOid);
   const renewed = spawnGit(
     [
       "push",
@@ -1646,6 +1739,14 @@ function renewStatePublishLease(lease: StatePublishLease, reason: string): void 
   console.log(`Renewed state publish lease owner=${lease.owner} ${reason}`);
 }
 
+function renewStatePublishLeaseIfNeeded(reason: string): void {
+  const lease = activeStatePublishLease;
+  if (!lease) throw new Error("State publish mutation is missing its owner lease");
+  if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
+    renewStatePublishLease(lease, reason);
+  }
+}
+
 function remoteRefOid(remote: string, ref: string): string | null {
   const result = spawnGit(["ls-remote", "--refs", remote, ref], {
     allowFailure: true,
@@ -1664,8 +1765,17 @@ function remoteRefOid(remote: string, ref: string): string | null {
 }
 
 function pushPublishedBranch(remote: string, branch: string): GitRunResult {
+  return pushPublishedCommit("HEAD", remote, branch);
+}
+
+function pushPublishedCommit(source: string, remote: string, branch: string): GitRunResult {
   const lease = activeStatePublishLease;
-  if (!lease) return spawnGit(["push", remote, `HEAD:${branch}`]);
+  if (!lease && publishRoot()) {
+    return withStatePublishMutationLease(remote, branch, () =>
+      pushPublishedCommit(source, remote, branch),
+    );
+  }
+  if (!lease) return spawnGit(["push", remote, `${source}:${branch}`]);
   if (lease.remote !== remote || lease.branch !== branch) {
     throw new StatePublishContentionError(
       `Active state publish lease does not cover ${remote}/${branch}`,
@@ -1681,13 +1791,14 @@ function pushPublishedBranch(remote: string, branch: string): GitRunResult {
     owner: lease.owner,
     ttlMs: lease.ttlMs,
   });
+  lease.cleanup?.track(renewedOid);
   const pushed = spawnGit(
     [
       "push",
       "--atomic",
       `--force-with-lease=${lease.ref}:${lease.oid}`,
       lease.remote,
-      `HEAD:${branch}`,
+      `${source}:${branch}`,
       `${renewedOid}:${lease.ref}`,
     ],
     { allowFailure: true },
@@ -1695,8 +1806,8 @@ function pushPublishedBranch(remote: string, branch: string): GitRunResult {
   if (pushed.status !== 0) {
     const currentLeaseOid = remoteRefOid(remote, lease.ref);
     if (currentLeaseOid === renewedOid) {
-      const localHead = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
-      if (remoteRefOid(remote, `refs/heads/${branch}`) === localHead) {
+      const sourceCommit = runGit(["rev-parse", source], { quiet: true }).trim();
+      if (remoteRefOid(remote, `refs/heads/${branch}`) === sourceCommit) {
         lease.oid = renewedOid;
         lease.expiresAtMs = Date.now() + lease.ttlMs;
         return { ...pushed, status: 0 };

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1778,6 +1778,237 @@ test(
   },
 );
 
+test(
+  "state publish lease also serializes ordinary state branch writers",
+  { timeout: 60_000 },
+  async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-global-lease-"));
+    const origin = path.join(root, "origin.git");
+    const seed = path.join(root, "seed");
+    const exact = path.join(root, "exact");
+    const ordinary = path.join(root, "ordinary");
+    const ordinarySource = path.join(root, "ordinary-source");
+    const candidate = path.join(root, "candidate");
+    const exactReady = path.join(root, "exact-ready");
+    const releaseExact = path.join(root, "release-exact");
+    run("git", ["init", "--bare", origin], root);
+    run("git", ["clone", origin, seed], root);
+    configureUser(seed);
+    write(path.join(seed, "README.md"), "state\n");
+    run("git", ["add", "."], seed);
+    run("git", ["commit", "-m", "initial state"], seed);
+    run("git", ["push", "origin", "HEAD:state"], seed);
+    run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+    run("git", ["clone", "--depth", "1", `file://${origin}`, exact], root);
+    run("git", ["clone", "--depth", "1", `file://${origin}`, ordinary], root);
+    configureUser(exact);
+    configureUser(ordinary);
+
+    const number = 10_050;
+    const tuple = writeRecordTuple(candidate, {
+      number,
+      marker: "exact writer",
+      reviewedAt: "2026-07-20T19:00:00.000Z",
+      itemUpdatedAt: "2026-07-20T19:00:00Z",
+    });
+    const recordRoot = "records/openclaw-openclaw";
+    const ordinaryPath = "results/ordinary-writer.json";
+
+    const exactScript = String.raw`
+      import fs from "node:fs";
+      import path from "node:path";
+      const [work, candidate, ready, release, numberRaw] = process.argv.slice(1);
+      const number = Number(numberRaw);
+      const recordRoot = "records/openclaw-openclaw";
+      const paths = [
+        recordRoot + "/items/" + number + ".md",
+        recordRoot + "/closed/" + number + ".md",
+        recordRoot + "/plans/" + number + ".md",
+        recordRoot + "/decision-packets/" + number + ".json",
+      ];
+      const wait = new Int32Array(new SharedArrayBuffer(4));
+      const {
+        commitMessageForPublishedPaths,
+        hardResetToRemoteMain,
+        pushSingleRecordTupleCommit,
+        runGit,
+        stagePaths,
+        withStatePublishLease,
+      } = await import("./dist/repair/git-publish.js");
+      withStatePublishLease(
+        () => {
+          fs.writeFileSync(ready, "ready\n");
+          while (!fs.existsSync(release)) Atomics.wait(wait, 0, 0, 10);
+          hardResetToRemoteMain("origin", "state");
+          fs.cpSync(path.join(candidate, "records"), path.join(work, "records"), { recursive: true });
+          stagePaths(paths);
+          runGit([
+            "commit",
+            "-m",
+            commitMessageForPublishedPaths("chore: publish exact tuple " + number, paths),
+          ]);
+          if (!pushSingleRecordTupleCommit({ paths, branch: "state", pushAttempts: 1 })) {
+            throw new Error("exact tuple push lost the state race");
+          }
+        },
+        { branch: "state", acquireTimeoutMs: 10_000, ttlMs: 30_000, waitMs: 25 },
+      );
+    `;
+    const ordinaryScript = String.raw`
+      import fs from "node:fs";
+      import path from "node:path";
+      const [sourceRoot] = process.argv.slice(1);
+      const publishPath = "results/ordinary-writer.json";
+      const { publishMainCommit } = await import("./dist/repair/git-publish.js");
+      fs.mkdirSync(path.join(sourceRoot, "results"), { recursive: true });
+      fs.writeFileSync(path.join(sourceRoot, publishPath), '{"writer":"ordinary"}\n');
+      process.chdir(sourceRoot);
+      publishMainCommit({
+        message: "chore: publish ordinary state update",
+        paths: [publishPath],
+        branch: "state",
+        maxAttempts: 2,
+        pushAttempts: 1,
+      });
+    `;
+
+    const exactResult = runAsync(
+      "node",
+      [
+        "--input-type=module",
+        "-e",
+        exactScript,
+        exact,
+        candidate,
+        exactReady,
+        releaseExact,
+        String(number),
+      ],
+      process.cwd(),
+      { CLAWSWEEPER_PUBLISH_ROOT: exact, CLAWSWEEPER_PUBLISH_BRANCH: "state" },
+    );
+    const wait = new Int32Array(new SharedArrayBuffer(4));
+    const readyDeadline = Date.now() + 10_000;
+    while (!fs.existsSync(exactReady) && Date.now() < readyDeadline) {
+      Atomics.wait(wait, 0, 0, 10);
+    }
+    assert.equal(fs.existsSync(exactReady), true, "exact writer did not acquire its lease");
+
+    const ordinaryRun = startAsync(
+      "node",
+      ["--input-type=module", "-e", ordinaryScript, ordinarySource],
+      process.cwd(),
+      { CLAWSWEEPER_PUBLISH_ROOT: ordinary, CLAWSWEEPER_PUBLISH_BRANCH: "state" },
+    );
+    const ordinaryDeadline = Date.now() + 10_000;
+    while (
+      !ordinaryRun.output().includes("State publish lease busy") &&
+      !ordinaryRun.settled() &&
+      Date.now() < ordinaryDeadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const ordinaryWaitedOnLease = ordinaryRun.output().includes("State publish lease busy");
+    fs.writeFileSync(releaseExact, "release\n");
+    const [exactOutput, ordinaryOutput] = await Promise.all([exactResult, ordinaryRun.result]);
+
+    assert.equal(
+      ordinaryWaitedOnLease,
+      true,
+      "ordinary state writer did not reach and wait on the exact owner's lease",
+    );
+    assert.match(exactOutput, /Acquired state publish lease/);
+    assert.match(ordinaryOutput, /Acquired state publish lease/);
+    assert.match(ordinaryOutput, /Released state publish lease/);
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `state:${recordRoot}/items/${number}.md`], root),
+      tuple.primary,
+    );
+    assert.equal(
+      run("git", ["--git-dir", origin, "show", `state:${ordinaryPath}`], root),
+      '{"writer":"ordinary"}\n',
+    );
+  },
+);
+
+test(
+  "state publish watchdog releases an owner terminated during a synchronous mutation",
+  {
+    timeout: 15_000,
+    skip:
+      process.platform === "win32" ? "POSIX signal cleanup runs in hosted Linux workflows" : false,
+  },
+  async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-watchdog-"));
+    const origin = path.join(root, "origin.git");
+    const work = path.join(root, "work");
+    run("git", ["init", "--bare", origin], root);
+    run("git", ["clone", origin, work], root);
+    configureUser(work);
+    write(path.join(work, "README.md"), "state\n");
+    run("git", ["add", "."], work);
+    run("git", ["commit", "-m", "initial state"], work);
+    run("git", ["push", "origin", "HEAD:state"], work);
+    run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+
+    const childScript = String.raw`
+      import { spawnSync } from "node:child_process";
+      const { withStatePublishLease } = await import("./dist/repair/git-publish.js");
+      withStatePublishLease(
+        () => {
+          process.stdout.write("lease-held\n");
+          spawnSync(process.execPath, ["-e", "setTimeout(() => {}, 5000)"]);
+        },
+        { branch: "state", acquireTimeoutMs: 5_000, ttlMs: 30_000, waitMs: 10 },
+      );
+    `;
+    const childRun = startAsync("node", ["--input-type=module", "-e", childScript], process.cwd(), {
+      CLAWSWEEPER_PUBLISH_ROOT: work,
+      CLAWSWEEPER_PUBLISH_BRANCH: "state",
+    });
+    const readyDeadline = Date.now() + 5_000;
+    while (!childRun.output().includes("lease-held") && Date.now() < readyDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.match(childRun.output(), /lease-held/);
+    assert.match(
+      run(
+        "git",
+        [
+          "--git-dir",
+          origin,
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/clawsweeper-publish-lease",
+        ],
+        root,
+      ),
+      /refs\/heads\/clawsweeper-publish-lease\/state/,
+    );
+
+    childRun.child.kill("SIGTERM");
+    await assert.rejects(childRun.result, /Process exited SIGTERM/);
+    const cleanupDeadline = Date.now() + 5_000;
+    let leaseRefs = "";
+    do {
+      leaseRefs = run(
+        "git",
+        [
+          "--git-dir",
+          origin,
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/clawsweeper-publish-lease",
+        ],
+        root,
+      );
+      if (!leaseRefs) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    } while (Date.now() < cleanupDeadline);
+    assert.equal(leaseRefs, "");
+  },
+);
+
 test("state publish lease recovers an abandoned owner after its bounded TTL", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-stale-"));
   const origin = path.join(root, "origin.git");
@@ -2931,6 +3162,7 @@ test("publishMainCommit escapes sustained immutable ledger races through a serve
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-server-merge-"));
   const origin = path.join(root, "origin.git");
   const work = path.join(root, "work");
+  const source = path.join(root, "source");
   const other = path.join(root, "other");
   const fakeBin = path.join(root, "bin");
   const ledgerPath =
@@ -2948,7 +3180,7 @@ test("publishMainCommit escapes sustained immutable ledger races through a serve
 
   run("git", ["clone", origin, other], root);
   configureUser(other);
-  write(path.join(work, ledgerPath), '{"local":true}\n');
+  write(path.join(source, ledgerPath), '{"local":true}\n');
   installSimplePushRaceHook(work, other, 65);
   installFakeGitHubMerge(fakeBin, origin);
 
@@ -2958,12 +3190,14 @@ test("publishMainCommit escapes sustained immutable ledger races through a serve
     result = withEnv(
       {
         CLAWSWEEPER_STATE_REPOSITORY: "openclaw/clawsweeper-state",
+        CLAWSWEEPER_PUBLISH_ROOT: work,
+        CLAWSWEEPER_PUBLISH_BRANCH: "main",
         GITHUB_RUN_ID: "12345",
         GITHUB_RUN_ATTEMPT: "1",
         PATH: `${fakeBin}:${process.env.PATH}`,
       },
       () =>
-        withCwd(work, () =>
+        withCwd(source, () =>
           publishMainCommit({
             message: "chore: append command action ledger",
             paths: [ledgerPath],
@@ -2981,12 +3215,30 @@ test("publishMainCommit escapes sustained immutable ledger races through a serve
   );
   assert.equal(
     run("git", ["--git-dir", origin, "show", "main:remote.txt"], root),
-    "base\nrace 1\nrace 2\n",
-    "the server merge preserves state writes that beat both client pushes",
+    "base\nrace 1\n",
+    "the server merge preserves the state write that beat the client push",
   );
   const metrics = lines.find((line) => line.startsWith("Git publish metrics:"));
   assert.match(metrics, /actions=.*gh-api:2(?:,|$)/, "merge and cleanup use the GitHub API");
-  assert.match(metrics, /actions=.*push:2(?:,|$)/, "the client stops racing the state ref");
+  assert.equal(
+    lines.filter((line) => line.includes("Acquired state publish lease")).length,
+    2,
+    "the direct push and server merge each coordinate their state mutation",
+  );
+  assert.equal(
+    run(
+      "git",
+      [
+        "--git-dir",
+        origin,
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads/clawsweeper-publish-lease",
+      ],
+      root,
+    ),
+    "",
+  );
 });
 
 test("publishMainCommit rebuilds a production-sized flat immutable ledger tree", () => {
@@ -4195,6 +4447,12 @@ function installSimplePushRaceHook(work, other, raceCount, branch = "main") {
     hook,
     `#!/bin/sh
 set -e
+target_ref="refs/heads/${branch}"
+targets_branch=false
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if test "$remote_ref" = "$target_ref"; then targets_branch=true; fi
+done
+if test "$targets_branch" != true; then exit 0; fi
 count=0
 if test -f "${counter}"; then count=$(cat "${counter}"); fi
 count=$((count + 1))
@@ -4283,6 +4541,12 @@ function installCheckpointFailureHook(work, other, branch) {
   fs.writeFileSync(
     hook,
     `#!/bin/sh
+target_ref="refs/heads/${branch}"
+targets_branch=false
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if test "$remote_ref" = "$target_ref"; then targets_branch=true; fi
+done
+if test "$targets_branch" != true; then exit 0; fi
 count=0
 if test -f "${counter}"; then count=$(cat "${counter}"); fi
 count=$((count + 1))
@@ -4317,6 +4581,39 @@ function runAsync(command, args, cwd, env = {}) {
       },
     );
   });
+}
+
+function startAsync(command, args, cwd, env = {}) {
+  let output = "";
+  let settled = false;
+  const child = execFile(command, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 55_000,
+  });
+  const result = new Promise((resolve, reject) => {
+    child.stdout?.on("data", (chunk) => {
+      output += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      output += String(chunk);
+    });
+    child.on("error", (error) => {
+      settled = true;
+      reject(new Error(`${error.message}\n${output}`));
+    });
+    child.on("close", (code, signal) => {
+      settled = true;
+      if (code !== 0) {
+        reject(new Error(`Process exited ${code ?? signal}\n${output}`));
+        return;
+      }
+      resolve(output);
+    });
+  });
+  return { child, result, output: () => output, settled: () => settled };
 }
 
 function captureConsoleLog(callback, lines = []) {


### PR DESCRIPTION
## Summary

- coordinate every mutation of the shared `state` branch with the existing state-publish lease
- serialize ordinary status/comment/action-ledger writers with exact-result publishers
- clean an acquired lease when a publisher is externally terminated, without shortening the existing lease TTL or acquisition budget

## Problem

Exact-result publishers and ordinary state writers advance the same `state` branch. The exact publisher lease introduced in the recent publication repairs only fenced exact publishers; comment-router, action-ledger, sweep-status, and apply-status writes could still advance `state` outside that lease.

In production after #723, exact publishers successfully acquired and renewed the lease, then repeatedly lost their expected state SHA while those ordinary writers advanced `state`. New publishers queued behind the lease holder, timed out, and filled publication capacity. The sampled failures were not GitHub authentication failures: no 401/403 signature was present.

## Causal proof

- post-#723 publication run `29769864078` acquired and renewed the state-publish lease around 2026-07-20 19:00:29Z
- during the held lease, comment/router/action-ledger/status commits advanced the same `state` ref
- the exact publisher's atomic push then lost its expected state SHA, while later publishers waited behind that holder
- a deterministic multi-process reproduction on pristine `origin/main` showed an ordinary state writer did not wait for an exact publisher lease
- the same reproduction with this patch showed the ordinary writer waiting and both state updates surviving
- a terminated synchronous lease owner left its lease behind on pristine `origin/main`; with this patch the watchdog removed that exact owner OID in about 220 ms

PR #712's synchronous recovery/history-fetch work amplified the later capacity stall, but it did not introduce the shared-writer race. PR #711's broad no-common-base replacement path remains a separate correctness risk and is intentionally not changed here.

## Implementation

- wrap shared `state` mutations in `withStatePublishMutationLease`
- reuse a matching active lease when the exact publisher already owns it; otherwise acquire the lease for ordinary writers
- route direct immutable action-ledger commits through the same atomic commit-push helper
- hold the lease across GitHub's immutable-ledger server merge path
- start a detached cleanup watchdog for acquired leases; it tracks the owner's possible lease OIDs and CAS-deletes only a matching OID when the owner process disappears
- keep preparation and temporary immutable-branch work outside the shared-state critical section
- preserve the existing 120-second lease TTL, renewal behavior, and 180-second acquisition budget

## Validation

### Crabbox Docker proof

Provider: `local-container` using Docker-backed Crabbox and Node 24.

- A/B causal proof, lease `cbx_8326f7aa23ea` (`amber-crayfish`): pristine `origin/main` failed all three causal cases; the patch passed ordinary-writer serialization, terminated-owner cleanup, and immutable server-merge coordination
- focused watchdog proof, lease `cbx_da0a05d5fee7` (`amber-prawn`): main retained the terminated owner's lease after about five seconds; the patch removed it in about 220 ms
- complete publication suite, lease `cbx_af0df260d8b5` (`jade-hermit`): `pnpm run build:repair`, `pnpm run lint:repair`, and all 54 `test/repair/git-publish.test.ts` tests passed (79.5 seconds)

### Local focused proof

- `pnpm run build:repair`
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- focused ordinary-writer serialization test
- `pnpm exec oxfmt --check src/repair/git-publish.ts test/repair/git-publish.test.ts`
- `git diff --check`

## Baseline noise

An aggregate Crabbox `pnpm run check` completed all builds and all four lint groups, then hit unrelated CRLF fixtures copied from the Windows worktree into Linux (`pipefail\r` / `$'\r'`) and downstream sweep-workflow assertions. This patch does not touch those scripts or line-ending policy. The authoritative changed publication suite is clean: 54/54 tests on Linux Crabbox.

The Linux-only immutable server-merge test also has a pre-existing native-Windows `includeIf gitdir` path failure on pristine main; the Docker-backed Linux proof passes.

## Risks and rollout

- shared state-ref mutations are serialized; repository preparation remains concurrent
- the watchdog cannot delete a successor's lease because cleanup is conditional on a tracked owner OID
- no capacity, retry, gate, queue, dashboard, or workflow-dispatch behavior changes
- production recovery should be judged only from post-merge/default-branch publishers and at least two consecutive samples with declining pending depth and positive net drain

## Attribution and related work

This builds on Peter's state correctness and reconciliation work in #714 and #716, and on the publication lease work in #722 and #723. It preserves those repairs while closing the remaining unfenced-writer gap. Related incident work: #711, #712, #713, #715, #720, #721, #722, and #723.

## Codex review closeout

- dirty-patch review: `codex review --uncommitted`
- accepted findings: make the multi-process barrier observe real child output, remove an unused test variable, and clean leases after externally terminated synchronous Git work
- proof was rerun after each accepted fix
- final dirty-patch result: `No actionable change-induced defects were found. Targeted state publish lease tests passed.`
- committed branch review: `codex review --base origin/main`
- committed branch result: `The diff consistently fences state-branch mutations with the lease and adds targeted coverage for ordinary writers and terminated owners. No actionable correctness issues were identified.`
