### PR TITLE
fix(dashboard): bound Bay terminal records to tide

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -82,6 +82,7 @@ const BAY_TIDE_THRESHOLD = 20;
 const BAY_SEEN_EVENT_LIMIT = 256;
 const BAY_WASH_VISIBLE_MS = 60_000;
 const BAY_TIMING_WINDOW_MS = 60 * 60 * 1000;
+const BAY_INITIAL_TERMINAL_LOOKBACK_MS = BAY_TIMING_WINDOW_MS;
 const BAY_TIMING_MAX_SAMPLE_MS = 24 * 60 * 60 * 1000;
 const BAY_JOURNEY_LIMIT = 100;
 const BAY_JOURNEY_TTL_SECONDS = 24 * 60 * 60;
@@ -3537,18 +3538,34 @@ export function mergeBayTerminalState(
 ) {
   const now = Date.parse(generatedAt);
   const source = previous && previous.schema_version === 1 ? previous : {};
+  const storedWindowStartedAt = nullableString(source.terminal_window_started_at);
+  const bootstrapWindowStartedAt = Number.isFinite(Date.parse(storedWindowStartedAt || ""))
+    ? storedWindowStartedAt
+    : bayTerminalBootstrapWindowStartedAt(now);
   const activeKeys = new Set(
     (Array.isArray(activeItemKeys) ? activeItemKeys : []).map((value) => String(value)),
   );
-  const buffer = Array.isArray(source.terminal_buffer)
+  const bootstrapBuffer = Array.isArray(source.terminal_buffer)
     ? source.terminal_buffer.filter(
-        (item) => item?.event_id && item?.item_key && !activeKeys.has(String(item.item_key)),
+        (item) =>
+          item?.event_id &&
+          item?.item_key &&
+          isBayTerminalAtOrAfterWindowStart(item, bootstrapWindowStartedAt) &&
+          !activeKeys.has(String(item.item_key)),
       )
     : [];
+  let terminalWindowStartedAt = bayTerminalWindowStartedAt(source, now, bootstrapBuffer);
+  const buffer = bootstrapBuffer.filter((item) =>
+    isBayTerminalAtOrAfterWindowStart(item, terminalWindowStartedAt),
+  );
   const seenEvents = Array.isArray(source.seen_events)
     ? source.seen_events.filter((item) => item?.event_id)
     : [];
   const seenIds = new Set(seenEvents.map((item) => item.event_id));
+  let terminalWindowEventIds = Array.isArray(source.terminal_window_event_ids)
+    ? source.terminal_window_event_ids.map((eventId) => String(eventId)).filter(Boolean)
+    : [];
+  let terminalWindowEventIdSet = new Set(terminalWindowEventIds);
   const recentlyWashed =
     Array.isArray(source.recently_washed) &&
     Number.isFinite(now) &&
@@ -3561,6 +3578,10 @@ export function mergeBayTerminalState(
 
   for (const candidate of bayTerminalCandidates(attempts, closedItems)) {
     if (activeKeys.has(candidate.item_key)) continue;
+    if (
+      !isBayTerminalAfterWindowStart(candidate, terminalWindowStartedAt, terminalWindowEventIdSet)
+    )
+      continue;
     if (seenIds.has(candidate.event_id)) continue;
     seenIds.add(candidate.event_id);
     seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
@@ -3585,6 +3606,11 @@ export function mergeBayTerminalState(
     washed = buffer.splice(0, BAY_TIDE_THRESHOLD);
     washedAt = generatedAt;
     lastTideAt = generatedAt;
+    terminalWindowStartedAt = nullableString(washed.at(-1)?.completed_at) || generatedAt;
+    terminalWindowEventIds = washed
+      .filter((item) => item.completed_at === terminalWindowStartedAt)
+      .map((item) => String(item.event_id));
+    terminalWindowEventIdSet = new Set(terminalWindowEventIds);
     tideGeneration += 1;
   }
 
@@ -3593,6 +3619,8 @@ export function mergeBayTerminalState(
     tide_threshold: BAY_TIDE_THRESHOLD,
     tide_generation: tideGeneration,
     last_tide_at: lastTideAt,
+    terminal_window_started_at: terminalWindowStartedAt,
+    terminal_window_event_ids: terminalWindowEventIds,
     terminal_count: buffer.length,
     terminal_buffer: buffer,
     washed_at: washedAt,
@@ -3608,12 +3636,50 @@ function bayTerminalStateSignature(state) {
     tide_threshold: state?.tide_threshold,
     tide_generation: state?.tide_generation,
     last_tide_at: state?.last_tide_at,
+    terminal_window_started_at: state?.terminal_window_started_at,
+    terminal_window_event_ids: state?.terminal_window_event_ids,
     terminal_count: state?.terminal_count,
     terminal_buffer: state?.terminal_buffer,
     washed_at: state?.washed_at,
     recently_washed: state?.recently_washed,
     seen_events: state?.seen_events,
   });
+}
+
+function bayTerminalWindowStartedAt(source, now, bootstrapBuffer = []) {
+  const storedWindowStart = nullableString(source?.terminal_window_started_at);
+  if (Number.isFinite(Date.parse(storedWindowStart || ""))) return storedWindowStart;
+  const bufferedWindowStart = [...bootstrapBuffer]
+    .map((item) => nullableString(item?.completed_at))
+    .filter((value) => Number.isFinite(Date.parse(value || "")))
+    .sort()[0];
+  if (bufferedWindowStart) return bufferedWindowStart;
+  const lastTideAt = nullableString(source?.last_tide_at);
+  if (Number.isFinite(Date.parse(lastTideAt || ""))) return lastTideAt;
+  return bayTerminalBootstrapWindowStartedAt(now);
+}
+
+function bayTerminalBootstrapWindowStartedAt(now) {
+  if (!Number.isFinite(now)) return null;
+  return new Date(now - BAY_INITIAL_TERMINAL_LOOKBACK_MS).toISOString();
+}
+
+function isBayTerminalAfterWindowStart(
+  candidate,
+  terminalWindowStartedAt,
+  terminalWindowEventIds = new Set(),
+) {
+  const completedAt = Date.parse(String(candidate?.completed_at || ""));
+  const windowStart = Date.parse(String(terminalWindowStartedAt || ""));
+  if (!Number.isFinite(completedAt) || !Number.isFinite(windowStart)) return false;
+  if (completedAt > windowStart) return true;
+  return completedAt === windowStart && !terminalWindowEventIds.has(String(candidate?.event_id));
+}
+
+function isBayTerminalAtOrAfterWindowStart(candidate, terminalWindowStartedAt) {
+  const completedAt = Date.parse(String(candidate?.completed_at || ""));
+  const windowStart = Date.parse(String(terminalWindowStartedAt || ""));
+  return Number.isFinite(completedAt) && Number.isFinite(windowStart) && completedAt >= windowStart;
 }
 
 function bayTerminalCandidates(attempts, closedItems) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1263,10 +1263,55 @@ test("OpenClaw Bay shares a bounded 20-outcome tide buffer", () => {
   assert.equal(tide.tide_generation, 1);
   assert.equal(tide.recently_washed.length, 20);
   assert.equal(tide.last_tide_at, "2026-07-10T20:00:20Z");
+  assert.equal(tide.terminal_window_started_at, "2026-07-10T20:00:19Z");
+  assert.deepEqual(tide.terminal_window_event_ids, [
+    "worker:20:1019:openclaw/openclaw#9019:cancelled:2026-07-10T20:00:19Z",
+  ]);
   assert.deepEqual(
     tide.recently_washed.slice(-2).map((item: { outcome: string }) => item.outcome),
     ["failure", "cancelled"],
   );
+
+  const staleAfterTide = {
+    ...attempts[0],
+    run_id: 10_001,
+    job_id: 20_001,
+    completed_at: "2026-07-10T20:00:18Z",
+  };
+  const distinctBoundaryEvent = {
+    ...attempts[0],
+    run_id: 10_003,
+    job_id: 20_003,
+    item_numbers: [9_999],
+    completed_at: "2026-07-10T20:00:19Z",
+  };
+  const freshAfterTide = {
+    ...attempts[0],
+    run_id: 10_002,
+    job_id: 20_002,
+    completed_at: "2026-07-10T20:00:21Z",
+  };
+  const afterTide = mergeBayTerminalState(
+    tide,
+    [staleAfterTide, distinctBoundaryEvent, freshAfterTide],
+    [],
+    "2026-07-10T20:00:21Z",
+  );
+  assert.deepEqual(
+    afterTide.terminal_buffer.map((item: { run_id: number }) => item.run_id),
+    [10_003, 10_002],
+  );
+  assert.equal(
+    afterTide.seen_events.some((item: { event_id: string }) => item.event_id.includes(":10001:")),
+    false,
+  );
+  const boundaryReplay = mergeBayTerminalState(
+    { ...tide, seen_events: [] },
+    attempts.slice(-1),
+    [],
+    "2026-07-10T20:00:21Z",
+  );
+  assert.equal(boundaryReplay.terminal_count, 0);
 
   const burst = Array.from({ length: 50 }, (_, index) => ({
     run_id: 2000 + index,
@@ -1282,8 +1327,14 @@ test("OpenClaw Bay shares a bounded 20-outcome tide buffer", () => {
   assert.equal(burstTides.tide_generation, 2);
   assert.equal(burstTides.terminal_count, 10);
   assert.equal(burstTides.recently_washed.length, 20);
+  assert.equal(burstTides.terminal_window_started_at, "2026-07-10T21:00:39Z");
   assert.deepEqual(
     burstTides.terminal_buffer.map((item: { number: number }) => item.number),
+    Array.from({ length: 10 }, (_, index) => 10_040 + index),
+  );
+  const retainedBurstTail = mergeBayTerminalState(burstTides, [], [], "2026-07-10T21:00:51Z");
+  assert.deepEqual(
+    retainedBurstTail.terminal_buffer.map((item: { number: number }) => item.number),
     Array.from({ length: 10 }, (_, index) => 10_040 + index),
   );
 
@@ -1291,7 +1342,7 @@ test("OpenClaw Bay shares a bounded 20-outcome tide buffer", () => {
     null,
     attempts.slice(0, 1),
     [],
-    "2026-07-10T21:01:00Z",
+    "2026-07-10T20:00:00.500Z",
     ["openclaw/openclaw#9000"],
   );
   assert.equal(deferredWhileActive.terminal_count, 0);
@@ -1300,7 +1351,7 @@ test("OpenClaw Bay shares a bounded 20-outcome tide buffer", () => {
     deferredWhileActive,
     attempts.slice(0, 1),
     [],
-    "2026-07-10T21:01:01Z",
+    "2026-07-10T20:00:01Z",
   );
   assert.equal(visibleAfterActiveFeedSettles.terminal_count, 1);
   assert.equal(visibleAfterActiveFeedSettles.seen_events.length, 1);
@@ -1367,6 +1418,69 @@ test("OpenClaw Bay shares a bounded 20-outcome tide buffer", () => {
   const expiredWash = mergeBayTerminalState(replay, attempts, [], "2026-07-10T20:01:21Z");
   assert.equal(expiredWash.tide_generation, 1);
   assert.equal(expiredWash.recently_washed.length, 0);
+
+  const legacyNoTide = {
+    schema_version: 1,
+    tide_threshold: 20,
+    tide_generation: 0,
+    last_tide_at: null,
+    terminal_count: 1,
+    terminal_buffer: [
+      {
+        event_id: "worker:old",
+        item_key: "openclaw/openclaw#8000",
+        completed_at: "2026-07-10T17:00:00Z",
+      },
+    ],
+    washed_at: null,
+    recently_washed: [],
+    seen_events: [],
+    updated_at: "2026-07-10T17:00:00Z",
+  };
+  const migratedNoTide = mergeBayTerminalState(
+    legacyNoTide,
+    [
+      { ...attempts[0], run_id: 11_000, job_id: 21_000, completed_at: "2026-07-10T17:00:00Z" },
+      { ...attempts[0], run_id: 11_001, job_id: 21_001, completed_at: "2026-07-10T19:30:01Z" },
+    ],
+    [],
+    "2026-07-10T20:00:00Z",
+  );
+  assert.equal(migratedNoTide.terminal_window_started_at, "2026-07-10T19:00:00.000Z");
+  assert.deepEqual(
+    migratedNoTide.terminal_buffer.map((item: { run_id: number }) => item.run_id),
+    [11_001],
+  );
+
+  const legacyTideTail = {
+    schema_version: 1,
+    tide_threshold: 20,
+    tide_generation: 1,
+    last_tide_at: "2026-07-10T20:00:20Z",
+    terminal_count: 2,
+    terminal_buffer: [
+      {
+        event_id: "worker:stale",
+        item_key: "openclaw/openclaw#8001",
+        completed_at: "2026-07-10T17:00:00Z",
+      },
+      {
+        event_id: "worker:tail",
+        item_key: "openclaw/openclaw#8002",
+        completed_at: "2026-07-10T20:00:19.900Z",
+      },
+    ],
+    washed_at: "2026-07-10T20:00:20Z",
+    recently_washed: [],
+    seen_events: [],
+    updated_at: "2026-07-10T20:00:20Z",
+  };
+  const migratedTideTail = mergeBayTerminalState(legacyTideTail, [], [], "2026-07-10T20:00:21Z");
+  assert.equal(migratedTideTail.terminal_window_started_at, "2026-07-10T20:00:19.900Z");
+  assert.deepEqual(
+    migratedTideTail.terminal_buffer.map((item: { item_key: string }) => item.item_key),
+    ["openclaw/openclaw#8002"],
+  );
 });
 
 test("OpenClaw Bay averages completed trigger-to-summary journeys from the last hour", () => {


### PR DESCRIPTION
## Summary

Stop OpenClaw Bay from replaying terminal outcomes from earlier tide windows. The terminal pools now retain only records admitted after the last completed wash, so old completed/failed entries cannot reappear after the bounded recent-event dedupe rolls over.

## Problem

The public Bay snapshot was showing historical terminal rows even though the visible tide was recent. At 2026-07-20T21:35Z, the live `bay-demo` status contained success and failure outcomes approximately 238–316 hours old while `last_tide_at` was 2026-07-20T20:13:57Z.

The previous projection relied on a bounded `seen_events` list. Once that list rolled over, an old immutable completed GitHub run could be admitted into the terminal buffer again.

## Implementation

- Persist a terminal-window watermark when a tide washes a batch.
- Persist the event IDs on the exact watermark timestamp, so a replay of the washed boundary event is still rejected while a distinct event completed in the same second is retained.
- Filter stored and incoming terminal records to the current tide window before the normal bounded buffer logic.
- Safely migrate existing state that has no stored watermark: retain its recent tail, discard historical stale records with a one-hour bootstrap cutoff, and then switch to the exact persistent watermark on subsequent updates.

`last_tide_at` remains the physical tide timestamp shown to users. The new internal watermark is the completion time of the last washed item; this preserves terminal items that arrive later in the same collection batch instead of accidentally discarding them.

## API impact

No new GitHub API, GraphQL, or dashboard refresh calls are added. This is a local state-projection and persistence fix over the terminal evidence already collected for OpenClaw Bay.

## Validation

```text
pnpm run build:dashboard
pnpm run lint:dashboard
node --test test/dashboard-worker.test.ts
git diff --check
```

- Build and dashboard lint passed.
- Focused dashboard worker suite passed: 156/156.
- Live public-status simulation reduced a stale terminal snapshot from 18 records to 4 current-window records (14 historical replays removed).
- Added coverage for stale replay rejection, a valid same-second boundary event, bounded dedupe rollover, two tides in one merge, migration of legacy state, and preservation of a legitimate legacy tail.

## Review closeout

```text
codex review --uncommitted
codex review --base origin/main
```

Both reviews completed clean. Earlier accepted review findings on post-tide tails, legacy-state tails, and same-second watermark boundaries were fixed and the focused proof was rerun after each change.

## Rollout / caveat

On the first state merge after deployment, old Bay state without the new watermark uses a conservative one-hour bootstrap. This deliberately clears historic terminal rows that were already stale; a genuinely current legacy tail is preserved. Thereafter, terminal eligibility is exact and tide-window based.

After deployment, verify that Bay terminal entries are newer than the current tide window, that current outcomes continue to enter the pools, and that a tide clears only its threshold batch without allowing washed rows to return.
