### PR TITLE
fix(publish): bound serialized writer contention

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -92,7 +92,10 @@ export type ExactReviewQueueItem = {
   publicationFailureAttempts?: number;
 };
 export type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
-type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
+type ExactReviewPublicationFailureKind =
+  | "github_rate_limit"
+  | "github_transient"
+  | "state_contention";
 export type ExactReviewPublicationCompletionKind =
   | "published"
   | "superseded"
@@ -225,6 +228,7 @@ const DEFAULT_EXACT_REVIEW_TARGET_MAX_CONCURRENT = 60;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT = 4;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT = 24;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT = 48;
+const EXACT_REVIEW_PUBLICATION_STATE_CONTENTION_CONCURRENT = 4;
 const EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP = 8;
 const EXACT_REVIEW_PUBLICATION_RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -681,6 +685,12 @@ export class ExactReviewQueue {
       if (requeueLatest && outcome !== "success") {
         return json({ error: "invalid_requeue_latest_outcome" }, 400);
       }
+      const capacityFailureKind =
+        failureKind ??
+        (publicationCompletion?.kind === "retryable_failure" &&
+        publicationCompletion.reasonCode === "state_contention"
+          ? "state_contention"
+          : undefined);
 
       const now = Date.now();
       const requestedRetryAt = exactReviewCompletionRetryAt(body.retry_at, now);
@@ -784,7 +794,7 @@ export class ExactReviewQueue {
           ((publicationCompletion
             ? publicationCompletion.kind === "published" && !requeued
             : outcome === "success" && !requeued) ||
-            failureKind)
+            capacityFailureKind)
           ? {
               at: now,
               capacity: publicationDesiredCapacity,
@@ -794,7 +804,7 @@ export class ExactReviewQueue {
                   : outcome === "success") && !requeued
                   ? "success"
                   : "failure",
-              ...(failureKind ? { failureKind } : {}),
+              ...(capacityFailureKind ? { failureKind: capacityFailureKind } : {}),
             }
           : undefined,
         completionResult.deadLetter,
@@ -3443,7 +3453,9 @@ function exactReviewCompletionOutcome(
 
 function exactReviewPublicationFailureKind(value): ExactReviewPublicationFailureKind | null {
   const normalized = String(value || "");
-  return normalized === "github_rate_limit" || normalized === "github_transient"
+  return normalized === "github_rate_limit" ||
+    normalized === "github_transient" ||
+    normalized === "state_contention"
     ? normalized
     : null;
 }
@@ -4828,9 +4840,12 @@ function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicat
   const rawRecoverySuccesses = Number(control.recoverySuccesses);
   const rawLastFailureAt = Number(control.lastFailureAt);
   const lastFailureKind = exactReviewPublicationFailureKind(control.lastFailureKind);
+  // A configured adaptive minimum must not erase a lower incident cap. Only
+  // clean recovery feedback is allowed to reopen capacity after contention.
+  const capacityFloor = Math.min(minimum, EXACT_REVIEW_PUBLICATION_STATE_CONTENTION_CONCURRENT);
   return {
     capacityCeiling: Number.isSafeInteger(rawCeiling)
-      ? Math.max(minimum, Math.min(maximum, rawCeiling))
+      ? Math.max(capacityFloor, Math.min(maximum, rawCeiling))
       : maximum,
     demandCapacity: Number.isSafeInteger(rawDemandCapacity)
       ? Math.max(minimum, Math.min(maximum, rawDemandCapacity))
@@ -4862,9 +4877,17 @@ function exactReviewPublicationControlAfterFeedback(
     const failureKind = feedback.failureKind || "github_transient";
     const rateLimited = failureKind === "github_rate_limit";
     const currentCapacity = Math.max(minimum, Math.min(control.capacityCeiling, feedback.capacity));
-    const ceiling = rateLimited
-      ? Math.max(minimum, Math.floor(currentCapacity / 2))
-      : Math.max(minimum, currentCapacity - EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP);
+    // A state lease timeout proves that the admitted publisher cohort is larger
+    // than the single serialized writer can drain. Stop admitting replacements
+    // immediately; clean publications can reopen capacity through the existing
+    // gradual recovery path.
+    const failureCeiling =
+      failureKind === "state_contention"
+        ? Math.min(maximum, EXACT_REVIEW_PUBLICATION_STATE_CONTENTION_CONCURRENT)
+        : rateLimited
+          ? Math.max(minimum, Math.floor(currentCapacity / 2))
+          : Math.max(minimum, currentCapacity - EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP);
+    const ceiling = Math.min(control.capacityCeiling, failureCeiling);
     return {
       ...control,
       capacityCeiling: ceiling,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8821,7 +8821,11 @@ function renderExactReviewLanes(queue) {
       : "";
     const capacityNote = publicationControl?.mode === "throttled"
       ? " · target " + fmt.format(publicationControl.demand_capacity || capacity) + " · pressure ceiling " + fmt.format(publicationControl.ceiling || capacity) + " after " +
-        (publicationControl.last_failure_kind === "github_rate_limit" ? "GitHub rate limit" : "GitHub 5xx")
+        (publicationControl.last_failure_kind === "github_rate_limit"
+          ? "GitHub rate limit"
+          : publicationControl.last_failure_kind === "state_contention"
+            ? "state publish contention"
+            : "GitHub 5xx")
       : laneKey === "publication"
         ? " · target " + fmt.format(publicationControl?.demand_capacity || capacity) + " · adaptive " + fmt.format(publicationControl?.base || 24) + "–" + fmt.format(publicationControl?.maximum || capacity)
         : "";

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -85,9 +85,13 @@ const RECOVERY_FETCH_TIMEOUT_MS = 300_000;
 const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
 const STATE_PUBLISH_LEASE_TTL_MS = 2 * 60_000;
 const STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS = PUBLISH_FETCH_TIMEOUT_MS;
-const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = 3 * 60_000;
 const STATE_PUBLISH_LEASE_WAIT_MS = 1_000;
 const STATE_PUBLISH_LEASE_MAX_WAIT_MS = 5_000;
+// Publication admission backs state contention down to four active workers.
+// Let one waiter observe a full lease TTL for each of the other three members
+// plus one complete jittered poll before returning the item to the durable queue.
+const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS =
+  3 * STATE_PUBLISH_LEASE_TTL_MS + STATE_PUBLISH_LEASE_MAX_WAIT_MS + STATE_PUBLISH_LEASE_WAIT_MS;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4930,10 +4930,17 @@ test("exact-review publication retries a state fetch timeout without throttling 
 test("exact-review publication gives state contention the transient retry budget", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(7803, "78030");
+  const laterFailure = leasedExactReviewPublicationItem(7804, "78040");
   item.publicationFailureAttempts = 4;
   item.firstFailureAt = Date.now() - 30 * 60_000;
-  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
-  const queue = new ExactReviewQueue({ storage }, {});
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [item.key]: item, [laterFailure.key]: laterFailure },
+  });
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT: "12" },
+  );
 
   const response = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/complete", {
@@ -4968,9 +4975,41 @@ test("exact-review publication gives state contention the transient retry budget
     await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
   assert.equal(stats.lanes.publication.dead_letters.open, 0);
-  assert.equal(stats.lanes.publication.capacity_control.mode, "adaptive");
-  assert.equal(stats.lanes.publication.capacity_control.ceiling, 48);
-  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
+  assert.equal(stats.lanes.publication.capacity, 4);
+  assert.equal(stats.lanes.publication.capacity_control.mode, "throttled");
+  assert.equal(stats.lanes.publication.capacity_control.minimum, 12);
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 4);
+  assert.equal(stats.lanes.publication.capacity_control.recovery_successes, 0);
+  assert.ok(
+    Date.parse(stats.lanes.publication.capacity_control.cooldown_until) > Date.now(),
+    "state contention should pause capacity recovery",
+  );
+  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, "state_contention");
+
+  const laterResponse = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: laterFailure.leaseId,
+        item_key: laterFailure.key,
+        lease_revision: laterFailure.leaseRevision,
+        claim_generation: laterFailure.claimGeneration,
+        run_id: laterFailure.claimedRunId,
+        run_attempt: laterFailure.claimedRunAttempt,
+        outcome: "failure",
+        failure_kind: "github_transient",
+        completion_kind: "retryable_failure",
+        reason_code: "github_transient",
+        error_fingerprint: "sha256:state-fetch-timeout",
+      }),
+    }),
+  );
+  assert.deepEqual(await laterResponse.json(), { ok: true, requeued: true });
+  const laterStats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(laterStats.lanes.publication.capacity_control.ceiling, 4);
+  assert.equal(laterStats.lanes.publication.capacity_control.last_failure_kind, "github_transient");
 });
 
 test("exact-review publication defers an active review lease without throttling capacity", async () => {
@@ -7233,6 +7272,13 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     elementFor("exact-review-lanes").innerHTML,
     /target 32 · pressure ceiling 24 after GitHub rate limit/,
   );
+  status.exact_review_queue.lanes.publication.capacity_control.last_failure_kind =
+    "state_contention";
+  context.renderDashboard(status, "");
+  assert.match(elementFor("exact-review-lanes").innerHTML, /after state publish contention/);
+  assert.doesNotMatch(elementFor("exact-review-lanes").innerHTML, /after GitHub 5xx/);
+  status.exact_review_queue.lanes.publication.capacity_control.last_failure_kind =
+    "github_rate_limit";
   assert.match(elementFor("exact-review-lanes").innerHTML, /No backlog history in this range/);
   status.workers = Array.from({ length: 130 }, (_, id) => ({ id, status: "in_progress" }));
   context.renderSystemMap(status);


### PR DESCRIPTION
## Summary

- Feed structured `state_contention` publication completions into the existing adaptive capacity controller.
- Clamp serialized state publication to a four-worker incident cohort, independently of a higher configured adaptive minimum, and never let another failure raise that cap.
- Give that four-worker cohort a bounded 366-second acquisition budget: three two-minute predecessor lease TTLs plus one complete jittered poll.
- Show `state publish contention` in the operator dashboard instead of mislabeling the condition as GitHub 5xx pressure.

## Problem and causal proof

PR #722 added one global remote-ref lease around state mutation, but publication admission retained its adaptive 24–48 worker range. The two controls were not coordinated: healthy publishers serialized behind one owner, while later members of the 48-worker cohort exhausted the old 180-second acquisition budget and returned `retryable_failure/state_contention`.

This is not a GitHub-token failure. Post-#724 run [29781604190](https://github.com/openclaw/clawsweeper/actions/runs/29781604190) eventually published `openclaw/openclaw#111766`: it waited about 186 seconds through earlier owners, acquired the state lease, held it for about 44 seconds, released it cleanly, and completed as `publication_applied`. In the same post-merge period, other publishers failed at 180 seconds while the observed owner continued renewing normally. Those failures were then retried or dead-lettered, so apparent queue resolution could be dominated by disposal rather than delivery.

The production baseline immediately after #724 was 607 pending, 47/48 active, -40/hour 15-minute net drain, and zero publications in the prior 15 minutes. The lane later showed successful publications again, but state-contention retries and dead letters continued to dominate enough resolutions that delivery was not recovered.

Related issue #725 independently identified the same single global lease bottleneck and proposes broader per-item sharding. This PR is the narrow incident repair and remains compatible with that future architecture. Credit to @yetval for that independent report, and to the authors of #722/#724 for the serialization and state-safety work this patch coordinates.

## Implementation

1. A structured `retryable_failure` with reason `state_contention` becomes publication-capacity failure feedback.
2. State contention sets the admission ceiling to four even when `EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT` is configured higher.
3. A later GitHub transient/rate-limit failure cannot raise an existing lower ceiling; only the established clean-success recovery path may reopen capacity.
4. The default state lease acquisition timeout becomes 366 seconds. Four admitted workers means the last waiter can observe three full 120-second predecessor TTLs plus the acquisition loop's maximum five-second backoff and one-second jitter.
5. Dashboard pressure text names state contention directly.

No workflow dispatch, queue replay/reset, dead-letter replay, gate change, state layout change, retry-budget increase, or broad refactor is included.

## Validation

### Focused and broad checks

```text
pnpm run build:repair
pnpm run build:dashboard
node --test test/dashboard-worker.test.ts
  156 passed, 0 failed
node --test --test-name-pattern "state publish lease" test/repair/git-publish.test.ts
  5 passed, 0 failed
pnpm run lint:repair
pnpm run lint:dashboard
pnpm run lint:scripts
pnpm exec oxfmt --check dashboard/exact-review-queue.ts dashboard/worker.ts src/repair/git-publish.ts test/dashboard-worker.test.ts
git diff --check origin/main...HEAD
```

The controller regression uses `EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT=12`, proves state contention still sets capacity/ceiling to 4, then completes another publisher with `github_transient` and proves the ceiling remains 4. The renderer regression proves the dashboard says `state publish contention`, not `GitHub 5xx`.

### Docker-backed Crabbox contention proof

Provider: `local-container` (Docker, `mcr.microsoft.com/playwright:v1.60.0-noble`)

- Lease `cbx_447c46b1810a`: ran the production commit and patched checkout in parallel against separate bare Git origins with four simultaneous real remote-ref lease writers, each holding the critical section for 70 seconds.
- Production 180-second baseline: 3/4 writers completed; the fourth failed with `StatePublishContentionError` at 180,051 ms.
- Patched checkout: 4/4 writers acquired and released; the final writer completed at 281,187 ms. `CRABBOX_PROOF=PASS`.
- The new capacity assertion failed on the production commit (`adaptive`, expected `throttled`) and passed on the patch.
- Lease `cbx_9469821b180a`: the complete `test/repair/git-publish.test.ts` production-surface file passed in Linux (exit 0).

The final 366-second value is six seconds safer than the successful Crabbox checkout: committed review identified that an exact 360-second deadline could miss the boundary because the loop starts before jitter and polls strictly before its deadline.

## Review closeout

- `codex review --uncommitted` reviewed the initial dirty patch.
- Accepted findings added full-TTL polling slack, made the four-worker cap independent of configured minimum, preserved a lower cap across later failure kinds, and labeled the dashboard reason accurately. Focused proof and the full dashboard suite were rerun after the fixes.
- The branch was rebased onto actual `origin/main` commit `6444e678dccb3cce1505827674b05a1f2f7ce397` after #726 landed, and overlapping dashboard tests were rerun.
- Final command: `codex review --base origin/main`
- Final result: no actionable finding; contention feedback, capacity cap, recovery behavior, lease timeout, and dashboard rendering are internally consistent.

## Risks and rollout

- Existing active publishers are not cancelled. On deployment, the first structured state-contention completion contracts new admission; already-running work drains naturally.
- Four workers still serialize state writes, but keep non-critical publication work overlapped. The measured post-#724 critical section was about 44 seconds, which is below the observed arrival interval needed to begin draining the backlog.
- The existing clean-success recovery controller may probe upward after its cooldown and success threshold. Any renewed state contention immediately returns the ceiling to four, and no failure path can raise it.
- Recovery must be judged by successful `published + superseded` delivery matching arrivals with declining pending depth; dead-letter disposal is not recovery.
- Broader sharding from #725 can replace this coordination later without changing record semantics.

## Baseline noise

The native-Windows aggregate Git-publish file contains pre-existing mixed-platform fixture failures, including `/usr/bin/env` assumptions and shared Git/CWD race cases. Per the platform-scope policy, this PR does not port that Linux-hosted surface. The same complete file passed in Docker-backed Crabbox Linux, and the native focused lease subset passed 5/5.
