### PR TITLE
revert: bound serialized writer contention

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -92,10 +92,7 @@ export type ExactReviewQueueItem = {
   publicationFailureAttempts?: number;
 };
 export type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
-type ExactReviewPublicationFailureKind =
-  | "github_rate_limit"
-  | "github_transient"
-  | "state_contention";
+type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 export type ExactReviewPublicationCompletionKind =
   | "published"
   | "superseded"
@@ -228,7 +225,6 @@ const DEFAULT_EXACT_REVIEW_TARGET_MAX_CONCURRENT = 60;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT = 4;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT = 24;
 const DEFAULT_EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT = 48;
-const EXACT_REVIEW_PUBLICATION_STATE_CONTENTION_CONCURRENT = 4;
 const EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP = 8;
 const EXACT_REVIEW_PUBLICATION_RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_TRANSIENT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -685,12 +681,6 @@ export class ExactReviewQueue {
       if (requeueLatest && outcome !== "success") {
         return json({ error: "invalid_requeue_latest_outcome" }, 400);
       }
-      const capacityFailureKind =
-        failureKind ??
-        (publicationCompletion?.kind === "retryable_failure" &&
-        publicationCompletion.reasonCode === "state_contention"
-          ? "state_contention"
-          : undefined);
 
       const now = Date.now();
       const requestedRetryAt = exactReviewCompletionRetryAt(body.retry_at, now);
@@ -794,7 +784,7 @@ export class ExactReviewQueue {
           ((publicationCompletion
             ? publicationCompletion.kind === "published" && !requeued
             : outcome === "success" && !requeued) ||
-            capacityFailureKind)
+            failureKind)
           ? {
               at: now,
               capacity: publicationDesiredCapacity,
@@ -804,7 +794,7 @@ export class ExactReviewQueue {
                   : outcome === "success") && !requeued
                   ? "success"
                   : "failure",
-              ...(capacityFailureKind ? { failureKind: capacityFailureKind } : {}),
+              ...(failureKind ? { failureKind } : {}),
             }
           : undefined,
         completionResult.deadLetter,
@@ -3453,9 +3443,7 @@ function exactReviewCompletionOutcome(
 
 function exactReviewPublicationFailureKind(value): ExactReviewPublicationFailureKind | null {
   const normalized = String(value || "");
-  return normalized === "github_rate_limit" ||
-    normalized === "github_transient" ||
-    normalized === "state_contention"
+  return normalized === "github_rate_limit" || normalized === "github_transient"
     ? normalized
     : null;
 }
@@ -4840,12 +4828,9 @@ function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicat
   const rawRecoverySuccesses = Number(control.recoverySuccesses);
   const rawLastFailureAt = Number(control.lastFailureAt);
   const lastFailureKind = exactReviewPublicationFailureKind(control.lastFailureKind);
-  // A configured adaptive minimum must not erase a lower incident cap. Only
-  // clean recovery feedback is allowed to reopen capacity after contention.
-  const capacityFloor = Math.min(minimum, EXACT_REVIEW_PUBLICATION_STATE_CONTENTION_CONCURRENT);
   return {
     capacityCeiling: Number.isSafeInteger(rawCeiling)
-      ? Math.max(capacityFloor, Math.min(maximum, rawCeiling))
+      ? Math.max(minimum, Math.min(maximum, rawCeiling))
       : maximum,
     demandCapacity: Number.isSafeInteger(rawDemandCapacity)
       ? Math.max(minimum, Math.min(maximum, rawDemandCapacity))
@@ -4877,17 +4862,9 @@ function exactReviewPublicationControlAfterFeedback(
     const failureKind = feedback.failureKind || "github_transient";
     const rateLimited = failureKind === "github_rate_limit";
     const currentCapacity = Math.max(minimum, Math.min(control.capacityCeiling, feedback.capacity));
-    // A state lease timeout proves that the admitted publisher cohort is larger
-    // than the single serialized writer can drain. Stop admitting replacements
-    // immediately; clean publications can reopen capacity through the existing
-    // gradual recovery path.
-    const failureCeiling =
-      failureKind === "state_contention"
-        ? Math.min(maximum, EXACT_REVIEW_PUBLICATION_STATE_CONTENTION_CONCURRENT)
-        : rateLimited
-          ? Math.max(minimum, Math.floor(currentCapacity / 2))
-          : Math.max(minimum, currentCapacity - EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP);
-    const ceiling = Math.min(control.capacityCeiling, failureCeiling);
+    const ceiling = rateLimited
+      ? Math.max(minimum, Math.floor(currentCapacity / 2))
+      : Math.max(minimum, currentCapacity - EXACT_REVIEW_PUBLICATION_CONCURRENT_SCALE_STEP);
     return {
       ...control,
       capacityCeiling: ceiling,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8821,11 +8821,7 @@ function renderExactReviewLanes(queue) {
       : "";
     const capacityNote = publicationControl?.mode === "throttled"
       ? " · target " + fmt.format(publicationControl.demand_capacity || capacity) + " · pressure ceiling " + fmt.format(publicationControl.ceiling || capacity) + " after " +
-        (publicationControl.last_failure_kind === "github_rate_limit"
-          ? "GitHub rate limit"
-          : publicationControl.last_failure_kind === "state_contention"
-            ? "state publish contention"
-            : "GitHub 5xx")
+        (publicationControl.last_failure_kind === "github_rate_limit" ? "GitHub rate limit" : "GitHub 5xx")
       : laneKey === "publication"
         ? " · target " + fmt.format(publicationControl?.demand_capacity || capacity) + " · adaptive " + fmt.format(publicationControl?.base || 24) + "–" + fmt.format(publicationControl?.maximum || capacity)
         : "";

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -85,13 +85,9 @@ const RECOVERY_FETCH_TIMEOUT_MS = 300_000;
 const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
 const STATE_PUBLISH_LEASE_TTL_MS = 2 * 60_000;
 const STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS = PUBLISH_FETCH_TIMEOUT_MS;
+const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = 3 * 60_000;
 const STATE_PUBLISH_LEASE_WAIT_MS = 1_000;
 const STATE_PUBLISH_LEASE_MAX_WAIT_MS = 5_000;
-// Publication admission backs state contention down to four active workers.
-// Let one waiter observe a full lease TTL for each of the other three members
-// plus one complete jittered poll before returning the item to the durable queue.
-const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS =
-  3 * STATE_PUBLISH_LEASE_TTL_MS + STATE_PUBLISH_LEASE_MAX_WAIT_MS + STATE_PUBLISH_LEASE_WAIT_MS;
 const SKIP_CI_DIRECTIVE_PATTERN =
   /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|^skip-checks:\s*true$/im;
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4930,17 +4930,10 @@ test("exact-review publication retries a state fetch timeout without throttling 
 test("exact-review publication gives state contention the transient retry budget", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(7803, "78030");
-  const laterFailure = leasedExactReviewPublicationItem(7804, "78040");
   item.publicationFailureAttempts = 4;
   item.firstFailureAt = Date.now() - 30 * 60_000;
-  await storage.put("exact-review-queue", {
-    deliveries: {},
-    items: { [item.key]: item, [laterFailure.key]: laterFailure },
-  });
-  const queue = new ExactReviewQueue(
-    { storage },
-    { EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT: "12" },
-  );
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
 
   const response = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/complete", {
@@ -4975,41 +4968,9 @@ test("exact-review publication gives state contention the transient retry budget
     await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
   assert.equal(stats.lanes.publication.dead_letters.open, 0);
-  assert.equal(stats.lanes.publication.capacity, 4);
-  assert.equal(stats.lanes.publication.capacity_control.mode, "throttled");
-  assert.equal(stats.lanes.publication.capacity_control.minimum, 12);
-  assert.equal(stats.lanes.publication.capacity_control.ceiling, 4);
-  assert.equal(stats.lanes.publication.capacity_control.recovery_successes, 0);
-  assert.ok(
-    Date.parse(stats.lanes.publication.capacity_control.cooldown_until) > Date.now(),
-    "state contention should pause capacity recovery",
-  );
-  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, "state_contention");
-
-  const laterResponse = await queue.fetch(
-    new Request("https://clawsweeper-exact-review-queue/complete", {
-      method: "POST",
-      body: JSON.stringify({
-        lease_id: laterFailure.leaseId,
-        item_key: laterFailure.key,
-        lease_revision: laterFailure.leaseRevision,
-        claim_generation: laterFailure.claimGeneration,
-        run_id: laterFailure.claimedRunId,
-        run_attempt: laterFailure.claimedRunAttempt,
-        outcome: "failure",
-        failure_kind: "github_transient",
-        completion_kind: "retryable_failure",
-        reason_code: "github_transient",
-        error_fingerprint: "sha256:state-fetch-timeout",
-      }),
-    }),
-  );
-  assert.deepEqual(await laterResponse.json(), { ok: true, requeued: true });
-  const laterStats = await (
-    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
-  ).json();
-  assert.equal(laterStats.lanes.publication.capacity_control.ceiling, 4);
-  assert.equal(laterStats.lanes.publication.capacity_control.last_failure_kind, "github_transient");
+  assert.equal(stats.lanes.publication.capacity_control.mode, "adaptive");
+  assert.equal(stats.lanes.publication.capacity_control.ceiling, 48);
+  assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, null);
 });
 
 test("exact-review publication defers an active review lease without throttling capacity", async () => {
@@ -7272,13 +7233,6 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     elementFor("exact-review-lanes").innerHTML,
     /target 32 · pressure ceiling 24 after GitHub rate limit/,
   );
-  status.exact_review_queue.lanes.publication.capacity_control.last_failure_kind =
-    "state_contention";
-  context.renderDashboard(status, "");
-  assert.match(elementFor("exact-review-lanes").innerHTML, /after state publish contention/);
-  assert.doesNotMatch(elementFor("exact-review-lanes").innerHTML, /after GitHub 5xx/);
-  status.exact_review_queue.lanes.publication.capacity_control.last_failure_kind =
-    "github_rate_limit";
   assert.match(elementFor("exact-review-lanes").innerHTML, /No backlog history in this range/);
   status.workers = Array.from({ length: 130 }, (_, id) => ({ id, status: "in_progress" }));
   context.renderSystemMap(status);


### PR DESCRIPTION
## Summary

Revert [#727](https://github.com/openclaw/clawsweeper/pull/727) in full and restore the exact publication controller and state-lease timeout from immediately before that merge.

## Why this rollback

#727 deliberately clamped state-contention publication to four workers. The control activated as designed, but the immediate production samples moved in the wrong direction for the incident:

- pending: `498 -> 518 -> 531 -> 536 -> 539`
- latest 15-minute net drain: `-12/hour`
- latest useful delivery: `published 20/hour + superseded 4/hour` versus arrivals of `52/hour`

The first fully constrained cohort did produce one successful `publication_applied` result, so this rollback is an operator-directed emergency decision rather than proof that every #727 mechanism was incorrect.

## Scope

- exact Git revert of merge commit `74ccb2ecab50916f7a4372b823dac25d1c7d11f3`
- restores the complete tree from pre-#727 main commit `6444e678dccb3cce1505827674b05a1f2f7ce397`
- no changes to #722/#723/#724 state-writer serialization and fencing
- no queue replay/reset, dead-letter replay, gate change, workflow dispatch, or retry mutation

## Validation

```text
pnpm run build:repair
pnpm run build:dashboard
node --test test/dashboard-worker.test.ts
  156 passed, 0 failed
node --test --test-name-pattern "state publish lease" test/repair/git-publish.test.ts
  5 passed, 0 failed
pnpm run lint:repair
pnpm run lint:dashboard
pnpm run lint:scripts
git diff --cached --check
git write-tree == 6444e678dccb3cce1505827674b05a1f2f7ce397^{tree}
```

The Windows checkout formatter reported the established line-ending noise on the four reverted files. The staged tree was independently verified to equal the already-green pre-#727 tree exactly.

At the maintainer's explicit emergency direction, the normal additional Codex-review and Crabbox rerun gates were waived for this exact rollback. The focused tests above had already completed successfully.

## Rollback risk

This restores the pre-#727 behavior:

- adaptive publication can again admit 24–48 publishers;
- state-lease acquisition returns to 180 seconds;
- the prior high-contention retry/dead-letter storm may return while all publishers serialize behind the one state writer.

Post-merge monitoring must compare successful `published + superseded` delivery with arrivals and must not mistake dead-letter disposal for recovery.

## Attribution

This reverts the narrow CSW-049 follow-up authored in #727. It leaves the earlier state-safety work and contributor attribution in #722, #723, and #724 intact.

No automerge is requested.
