### PR TITLE
fix(publish): extend state lease wait to eight minutes

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -86,7 +86,7 @@ const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
 const STATE_PUBLISH_LEASE_TTL_MS = 2 * 60_000;
 const STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS = PUBLISH_FETCH_TIMEOUT_MS;
 const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = (() => {
-  const fallback = 3 * 60_000;
+  const fallback = 8 * 60_000;
   // Rare, high-value publishers (the apply lane) starve behind the review
   // herd inside the default window; their workflows may raise the budget so
   // one apply publish out-waits contention instead of failing the run.


### PR DESCRIPTION
## Summary

- preserve #730's configurable state-lease timeout and 900-second apply-lane overrides
- extend the normal review/result publisher fallback from 180 seconds to 480 seconds
- leave the temporary exact-publication capacity fixed at 50 workers

## Problem

PR #730 repairs the separate apply-lane starvation by setting a 900-second override on three rare apply jobs. It intentionally leaves normal review/event result publishers on the 180-second fallback. Post-#729 production evidence showed those normal publishers still dominated by 180-second `StatePublishContentionError` failures.

## Implementation

After rebasing onto #730's merge commit, this changes only its fallback from `3 * 60_000` to `8 * 60_000`. The `CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS` override, three `900000` apply-lane settings, 30-minute cap, publication capacity, lease TTL, polling, queue state, retries, gates, and dispatch behavior remain unchanged.

## Validation

- branch diff versus current `origin/main`: one line in `src/repair/git-publish.ts`
- verified all three #730 workflow overrides remain `900000`
- verified #730's configured-timeout cap remains 30 minutes
- normal required GitHub checks run on the rebased head

No additional local test, Codex review, or ClawSweeper review was run at the maintainer's explicit request.

## Risk and rollout

Normal contending publishers may remain leased for up to eight minutes before returning to the durable queue. Apply-lane publishers retain #730's 15-minute override. Queue depth, useful GitHub delivery, retry amplification, and state-contention failures remain under active monitoring.

Related: #729, #730, and CSW-049.
