### PR TITLE
Add durable exact-review publication batches

### DIFF
--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -1,0 +1,468 @@
+export const EXACT_REVIEW_PUBLICATION_BATCH_TABLE = "exact_review_publication_batches";
+export const EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE = "exact_review_publication_batch_items";
+const EXACT_REVIEW_PUBLICATION_BATCH_GENERATION_TABLE =
+  "exact_review_publication_batch_generations";
+
+const DEFAULT_COMPLETED_BATCH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_CLEANUP_LIMIT = 100;
+
+type SqlStorage = {
+  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
+};
+
+type DurableStorage = {
+  sql: SqlStorage;
+  transactionSync: <T>(callback: () => T) => T;
+};
+
+export type PublicationBatchCandidate = {
+  itemKey: string;
+  revision: number;
+};
+
+export type PublicationBatchTerminalOutcome = "published" | "superseded" | "lease_expired";
+
+export type PublicationBatchItem = PublicationBatchCandidate & {
+  claimGeneration: number;
+  terminalOutcome: PublicationBatchTerminalOutcome | null;
+};
+
+export type PublicationBatch = {
+  batchId: string;
+  state: "leased" | "completed" | "expired";
+  leaseOwner: string;
+  leaseExpiresAt: number;
+  attempt: number;
+  createdAt: number;
+  completedAt: number | null;
+  stateCommitSha: string | null;
+  failureFingerprint: string | null;
+  items: PublicationBatchItem[];
+};
+
+export type PublicationBatchCompletion = PublicationBatchCandidate & {
+  claimGeneration: number;
+  terminalOutcome: Exclude<PublicationBatchTerminalOutcome, "lease_expired">;
+};
+
+export type PublicationBatchStats = {
+  leased: number;
+  completed: number;
+  expired: number;
+  activeItems: number;
+  activeItemKeys: string[];
+  nextLeaseExpiresAt: number | null;
+  oldestActiveAt: number | null;
+  reclaimedItemsRetained: number;
+  cleanup: {
+    deletedThisPass: number;
+    eligibleRemaining: number;
+    limit: number;
+  };
+};
+
+export class ExactReviewPublicationBatchStore {
+  private readonly storage: DurableStorage;
+
+  constructor(storage: DurableStorage) {
+    this.storage = storage;
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} (
+         batch_id TEXT PRIMARY KEY,
+         state TEXT NOT NULL CHECK (state IN ('leased', 'completed', 'expired')),
+         lease_owner TEXT NOT NULL,
+         lease_expires_at INTEGER NOT NULL,
+         attempt INTEGER NOT NULL CHECK (attempt >= 1),
+         created_at INTEGER NOT NULL,
+         completed_at INTEGER,
+         state_commit_sha TEXT,
+         failure_fingerprint TEXT
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} (
+         batch_id TEXT NOT NULL,
+         item_key TEXT NOT NULL,
+         revision INTEGER NOT NULL CHECK (revision >= 1),
+         claim_generation INTEGER NOT NULL CHECK (claim_generation >= 1),
+         terminal_outcome TEXT CHECK (
+           terminal_outcome IS NULL OR terminal_outcome IN (
+             'published', 'superseded', 'lease_expired'
+           )
+         ),
+         PRIMARY KEY (batch_id, item_key),
+         FOREIGN KEY (batch_id) REFERENCES ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} (batch_id)
+           ON DELETE CASCADE
+       ) STRICT`,
+    );
+    // Only unfinished membership owns an item. Expiry terminalizes that membership,
+    // preserving its fencing generation while allowing a later batch to reclaim the item.
+    this.storage.sql.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS exact_review_publication_batch_items_active
+         ON ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} (item_key)
+       WHERE terminal_outcome IS NULL`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_publication_batches_cleanup
+         ON ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} (state, completed_at, batch_id)`,
+    );
+    // Cleanup may delete batch receipts, but fencing must outlive those receipts so
+    // delayed completions can never match a later lease after an ID is reused.
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_PUBLICATION_BATCH_GENERATION_TABLE} (
+         item_key TEXT PRIMARY KEY,
+         claim_generation INTEGER NOT NULL CHECK (claim_generation >= 1)
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_PUBLICATION_BATCH_GENERATION_TABLE}
+         (item_key, claim_generation)
+       SELECT item_key, MAX(claim_generation)
+         FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+        GROUP BY item_key
+       ON CONFLICT (item_key) DO UPDATE SET claim_generation = MAX(
+         claim_generation,
+         excluded.claim_generation
+       )`,
+    );
+  }
+
+  claim(input: {
+    batchId: string;
+    leaseOwner: string;
+    leaseExpiresAt: number;
+    now: number;
+    maxItems: number;
+    candidates: PublicationBatchCandidate[];
+  }): PublicationBatch | null {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(input.now);
+      const existing = this.readBatchSync(input.batchId);
+      if (existing) {
+        return existing.state === "leased" && existing.leaseOwner === input.leaseOwner
+          ? existing
+          : null;
+      }
+      const activeBatch = Array.from(
+        this.storage.sql.exec(
+          `SELECT batch_id FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            WHERE state = 'leased' LIMIT 1`,
+        ),
+      )[0];
+      // The rollout has one serial publisher. Same-id retries return above; a distinct
+      // claim must wait so racing dispatch requests cannot create parallel publishers.
+      if (activeBatch) return null;
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+           (batch_id, state, lease_owner, lease_expires_at, attempt, created_at)
+         VALUES (?, 'leased', ?, ?, 1, ?)`,
+        input.batchId,
+        input.leaseOwner,
+        input.leaseExpiresAt,
+        input.now,
+      );
+      for (const candidate of input.candidates) {
+        if (this.countUnfinishedItemsSync(input.batchId) >= input.maxItems) break;
+        const generation = this.nextClaimGenerationSync(candidate.itemKey);
+        this.storage.sql.exec(
+          `INSERT OR IGNORE INTO ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+             (batch_id, item_key, revision, claim_generation)
+           VALUES (?, ?, ?, ?)`,
+          input.batchId,
+          candidate.itemKey,
+          candidate.revision,
+          generation,
+        );
+      }
+      const batch = this.readBatchSync(input.batchId);
+      if (!batch?.items.length) {
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} WHERE batch_id = ?`,
+          input.batchId,
+        );
+        return null;
+      }
+      return batch;
+    });
+  }
+
+  fetch(batchId: string, leaseOwner: string, now: number): PublicationBatch | null {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      const batch = this.readBatchSync(batchId);
+      return batch &&
+        batch.leaseOwner === leaseOwner &&
+        (batch.state === "leased" || batch.state === "completed")
+        ? batch
+        : null;
+    });
+  }
+
+  activeLeaseSnapshot(now: number) {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      return this.activeLeaseSnapshotSync();
+    });
+  }
+
+  complete(
+    batchId: string,
+    leaseOwner: string,
+    completions: PublicationBatchCompletion[],
+    now: number,
+    metadata: { stateCommitSha?: string; failureFingerprint?: string } = {},
+    onAccepted?: (completions: PublicationBatchCompletion[]) => void,
+  ): PublicationBatch | null {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      const batch = this.readBatchSync(batchId);
+      if (!batch || batch.leaseOwner !== leaseOwner) return null;
+      if (batch.state === "completed") {
+        const membersByKey = new Map(batch.items.map((item) => [item.itemKey, item]));
+        const matchesReceipt = completions.every((completion) => {
+          const member = membersByKey.get(completion.itemKey);
+          return (
+            member?.revision === completion.revision &&
+            member.claimGeneration === completion.claimGeneration &&
+            member.terminalOutcome === completion.terminalOutcome
+          );
+        });
+        return matchesReceipt ? batch : null;
+      }
+      if (batch.state !== "leased") return null;
+      const unfinishedByKey = new Map(
+        batch.items
+          .filter((item) => item.terminalOutcome === null)
+          .map((item) => [item.itemKey, item]),
+      );
+      const accepted = completions.filter((completion) => {
+        const current = unfinishedByKey.get(completion.itemKey);
+        return (
+          current?.revision === completion.revision &&
+          current.claimGeneration === completion.claimGeneration
+        );
+      });
+      onAccepted?.(accepted);
+      for (const completion of accepted) {
+        this.storage.sql.exec(
+          `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+              SET terminal_outcome = ?
+            WHERE batch_id = ? AND item_key = ? AND revision = ?
+              AND claim_generation = ? AND terminal_outcome IS NULL`,
+          completion.terminalOutcome,
+          batchId,
+          completion.itemKey,
+          completion.revision,
+          completion.claimGeneration,
+        );
+      }
+      if (accepted.length) {
+        this.storage.sql.exec(
+          `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+              SET state_commit_sha = COALESCE(state_commit_sha, ?),
+                  failure_fingerprint = COALESCE(failure_fingerprint, ?)
+            WHERE batch_id = ? AND state = 'leased'`,
+          metadata.stateCommitSha ?? null,
+          metadata.failureFingerprint ?? null,
+          batchId,
+        );
+      }
+      const unfinished = this.countUnfinishedItemsSync(batchId);
+      if (unfinished === 0) {
+        this.storage.sql.exec(
+          `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+              SET state = 'completed', completed_at = ?
+            WHERE batch_id = ? AND state = 'leased'`,
+          now,
+          batchId,
+        );
+      }
+      return this.readBatchSync(batchId);
+    });
+  }
+
+  stats(
+    now: number,
+    options: { completedTtlMs?: number; cleanupLimit?: number } = {},
+  ): PublicationBatchStats {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      const completedTtlMs = options.completedTtlMs ?? DEFAULT_COMPLETED_BATCH_TTL_MS;
+      const cleanupLimit = options.cleanupLimit ?? DEFAULT_CLEANUP_LIMIT;
+      const cutoff = now - completedTtlMs;
+      const cleanupIds = Array.from(
+        this.storage.sql.exec(
+          `SELECT batch_id FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            WHERE state IN ('completed', 'expired') AND completed_at <= ?
+            ORDER BY completed_at, batch_id LIMIT ?`,
+          cutoff,
+          cleanupLimit,
+        ),
+        (row) => String(row.batch_id),
+      );
+      for (const batchId of cleanupIds) {
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} WHERE batch_id = ?`,
+          batchId,
+        );
+        this.storage.sql.exec(
+          `DELETE FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            WHERE batch_id = ? AND state IN ('completed', 'expired')`,
+          batchId,
+        );
+      }
+      const rows = Array.from(
+        this.storage.sql.exec(
+          `SELECT state, COUNT(*) AS count, MIN(created_at) AS oldest_at
+             FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} GROUP BY state`,
+        ),
+      );
+      const counts = new Map(rows.map((row) => [String(row.state), Number(row.count)]));
+      const leased = rows.find((row) => row.state === "leased");
+      const activeLease = this.activeLeaseSnapshotSync();
+      const reclaimedItemsRetained = Number(
+        Array.from(
+          this.storage.sql.exec(
+            `SELECT COUNT(*) AS count FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+              WHERE terminal_outcome = 'lease_expired'`,
+          ),
+        )[0]?.count ?? 0,
+      );
+      const eligibleRemaining = Number(
+        Array.from(
+          this.storage.sql.exec(
+            `SELECT COUNT(*) AS count FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+              WHERE state IN ('completed', 'expired') AND completed_at <= ?`,
+            cutoff,
+          ),
+        )[0]?.count ?? 0,
+      );
+      return {
+        leased: counts.get("leased") ?? 0,
+        completed: counts.get("completed") ?? 0,
+        expired: counts.get("expired") ?? 0,
+        activeItems: activeLease.itemKeys.length,
+        activeItemKeys: activeLease.itemKeys,
+        nextLeaseExpiresAt: activeLease.nextLeaseExpiresAt,
+        oldestActiveAt: leased ? Number(leased.oldest_at) : null,
+        reclaimedItemsRetained,
+        cleanup: { deletedThisPass: cleanupIds.length, eligibleRemaining, limit: cleanupLimit },
+      };
+    });
+  }
+
+  private reclaimExpiredSync(now: number) {
+    const expired = Array.from(
+      this.storage.sql.exec(
+        `SELECT batch_id FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+          WHERE state = 'leased' AND lease_expires_at <= ?`,
+        now,
+      ),
+      (row) => String(row.batch_id),
+    );
+    for (const batchId of expired) {
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+            SET terminal_outcome = 'lease_expired'
+          WHERE batch_id = ? AND terminal_outcome IS NULL`,
+        batchId,
+      );
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            SET state = 'expired', completed_at = ?
+          WHERE batch_id = ? AND state = 'leased'`,
+        now,
+        batchId,
+      );
+    }
+  }
+
+  private activeLeaseSnapshotSync() {
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT membership.item_key, batch.lease_expires_at
+           FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} AS membership
+           JOIN ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} AS batch
+             ON batch.batch_id = membership.batch_id
+          WHERE batch.state = 'leased' AND membership.terminal_outcome IS NULL
+          ORDER BY membership.item_key`,
+      ),
+    );
+    return {
+      itemKeys: rows.map((row) => String(row.item_key)),
+      nextLeaseExpiresAt: rows.length
+        ? Math.min(...rows.map((row) => Number(row.lease_expires_at)))
+        : null,
+    };
+  }
+
+  private nextClaimGenerationSync(itemKey: string) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_PUBLICATION_BATCH_GENERATION_TABLE}
+           (item_key, claim_generation) VALUES (?, 1)
+         ON CONFLICT (item_key) DO UPDATE
+           SET claim_generation = claim_generation + 1
+         RETURNING claim_generation`,
+        itemKey,
+      ),
+    )[0];
+    return Number(row?.claim_generation);
+  }
+
+  private countUnfinishedItemsSync(batchId: string) {
+    return Number(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT COUNT(*) AS count FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+            WHERE batch_id = ? AND terminal_outcome IS NULL`,
+          batchId,
+        ),
+      )[0]?.count ?? 0,
+    );
+  }
+
+  private readBatchSync(batchId: string): PublicationBatch | null {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT batch_id, state, lease_owner, lease_expires_at, attempt, created_at,
+                completed_at, state_commit_sha, failure_fingerprint
+           FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} WHERE batch_id = ?`,
+        batchId,
+      ),
+    )[0];
+    if (!row) return null;
+    const items = Array.from(
+      this.storage.sql.exec(
+        `SELECT item_key, revision, claim_generation, terminal_outcome
+           FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
+          WHERE batch_id = ? ORDER BY item_key`,
+        batchId,
+      ),
+      (item) => ({
+        itemKey: String(item.item_key),
+        revision: Number(item.revision),
+        claimGeneration: Number(item.claim_generation),
+        terminalOutcome:
+          item.terminal_outcome === null
+            ? null
+            : (String(item.terminal_outcome) as PublicationBatchTerminalOutcome),
+      }),
+    );
+    return {
+      batchId: String(row.batch_id),
+      state: row.state as PublicationBatch["state"],
+      leaseOwner: String(row.lease_owner),
+      leaseExpiresAt: Number(row.lease_expires_at),
+      attempt: Number(row.attempt),
+      createdAt: Number(row.created_at),
+      completedAt: row.completed_at === null ? null : Number(row.completed_at),
+      stateCommitSha: row.state_commit_sha === null ? null : String(row.state_commit_sha),
+      failureFingerprint: row.failure_fingerprint === null ? null : String(row.failure_fingerprint),
+      items,
+    };
+  }
+}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -10,6 +10,10 @@ import {
   summarizeExactReviewPressure,
 } from "./exact-review-health.ts";
 import {
+  ExactReviewPublicationBatchStore,
+  type PublicationBatchCompletion,
+} from "./exact-review-publication-batches.ts";
+import {
   REVIEW_TELEMETRY_DEGRADED_MS,
   REVIEW_TELEMETRY_ORPHAN_MS,
   REVIEW_TELEMETRY_RETENTION_MS,
@@ -304,6 +308,9 @@ export const EXACT_REVIEW_QUEUE_NAME = "global";
 const EXACT_REVIEW_COMMAND_STATUS_MARKER_PATTERN =
   /^<!-- clawsweeper-command-status:[^<>\r\n]{1,200} -->$/;
 const EXACT_REVIEW_ADDITIONAL_PROMPT_MAX_CHARS = 5000;
+const DEFAULT_EXACT_REVIEW_PUBLICATION_BATCH_SIZE = 8;
+const MAX_EXACT_REVIEW_PUBLICATION_BATCH_SIZE = 32;
+const DEFAULT_EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS = 30 * 60 * 1000;
 
 export class ExactReviewQueue {
   private storage;
@@ -312,11 +319,13 @@ export class ExactReviewQueue {
   private migratedAt = 0;
   private legacyMirrorDisabled = false;
   private legacyMirrorWarningReported = false;
+  private batchStore;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
 
   constructor(state, env) {
     this.storage = state.storage;
     this.env = env;
+    this.batchStore = new ExactReviewPublicationBatchStore(this.storage);
     const initialize = () => this.initializeStorage();
     this.ready =
       typeof state.blockConcurrencyWhile === "function"
@@ -946,6 +955,18 @@ export class ExactReviewQueue {
       return this.reviewObservability(url.searchParams);
     }
 
+    if (request.method === "POST" && url.pathname === "/publication-batches/claim") {
+      return this.claimPublicationBatch(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/publication-batches/fetch") {
+      return this.fetchPublicationBatch(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/publication-batches/complete") {
+      return this.completePublicationBatch(await request.json().catch(() => null));
+    }
+
     if (request.method === "GET" && url.pathname === "/item-status") {
       const targetRepo = String(url.searchParams.get("target_repo") || "").trim();
       const itemNumber = Number(url.searchParams.get("item_number"));
@@ -1093,6 +1114,8 @@ export class ExactReviewQueue {
         reviewExecutionHealth,
         stateWriter,
       } = snapshot;
+      const publicationBatches = this.batchStore.stats(now);
+      const batchOwnedItemKeys = new Set<string>(publicationBatches.activeItemKeys);
       const publicationControl = this.refreshPublicationControlSync(state, now);
       await this.scheduleNext(state, now);
       const stats = exactReviewQueueStats(
@@ -1112,6 +1135,8 @@ export class ExactReviewQueue {
         exactReviewExecutionLeaseMs(this.env),
         exactReviewPublicationDispatchLeaseMs(this.env),
         exactReviewHeartbeatGraceMs(this.env),
+        batchOwnedItemKeys,
+        publicationBatches.nextLeaseExpiresAt,
       );
       return json({
         ...stats,
@@ -1140,6 +1165,27 @@ export class ExactReviewQueue {
               deadLetters,
             ),
             capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
+            batches: {
+              enabled: exactReviewPublicationBatchingEnabled(this.env),
+              leased: publicationBatches.leased,
+              completed: publicationBatches.completed,
+              expired: publicationBatches.expired,
+              active_items: publicationBatches.activeItems,
+              oldest_active_at:
+                publicationBatches.oldestActiveAt === null
+                  ? null
+                  : new Date(publicationBatches.oldestActiveAt).toISOString(),
+              oldest_active_age_seconds:
+                publicationBatches.oldestActiveAt === null
+                  ? null
+                  : Math.max(0, Math.floor((now - publicationBatches.oldestActiveAt) / 1000)),
+              reclaimed_items_retained: publicationBatches.reclaimedItemsRetained,
+              cleanup: {
+                deleted_this_pass: publicationBatches.cleanup.deletedThisPass,
+                eligible_remaining: publicationBatches.cleanup.eligibleRemaining,
+                limit: publicationBatches.cleanup.limit,
+              },
+            },
           },
         },
         delivery_receipts: this.deliveryReceiptCountSync(),
@@ -1167,6 +1213,7 @@ export class ExactReviewQueue {
       this.syncLegacyCompatibilitySync(this.readStateSync());
     });
     const snapshot = this.readStateSync();
+    const snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(startedAt);
     const reclaimedSnapshot = reclaimExpiredExactReviewLeases(
       snapshot,
       startedAt,
@@ -1192,6 +1239,8 @@ export class ExactReviewQueue {
       capacity,
       targetCapacity,
       snapshotPublicationCapacity,
+      new Set<string>(snapshotBatchOwnership.itemKeys),
+      snapshotBatchOwnership.itemKeys.length > 0,
     );
     if (!snapshotAdmission.length) {
       if (snapshotChanged) await this.writeState(snapshot);
@@ -1213,6 +1262,7 @@ export class ExactReviewQueue {
     // write so concurrent enqueue, claim, or complete requests cannot be lost.
     const now = Date.now();
     const state = this.readStateSync();
+    const batchOwnership = this.batchStore.activeLeaseSnapshot(now);
     reclaimExpiredExactReviewLeases(
       state,
       now,
@@ -1237,6 +1287,8 @@ export class ExactReviewQueue {
       capacity,
       targetCapacity,
       publicationCapacity,
+      new Set<string>(batchOwnership.itemKeys),
+      batchOwnership.itemKeys.length > 0,
     );
     if (!preflight.ok) {
       const retryAt = now + exactReviewWorkflowPausedRetryMs(this.env);
@@ -2119,8 +2171,190 @@ export class ExactReviewQueue {
     return json({ ok: true, superseded, skipped: candidates.length - superseded });
   }
 
+  private claimPublicationBatch(value: unknown) {
+    // The rollout switch closes only new admission. Fetch and complete stay available so
+    // disabling the flag cannot strand ownership that was leased before the config change.
+    if (!exactReviewPublicationBatchingEnabled(this.env)) {
+      return json({ error: "publication_batching_disabled" }, 409);
+    }
+    const body = objectValue(value);
+    const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
+    const claimId = exactReviewPublicationBatchId(body.claim_id);
+    if (!leaseOwner) return json({ error: "invalid_lease_owner" }, 400);
+    if (!claimId) return json({ error: "invalid_claim_id" }, 400);
+    const requestedSize =
+      body.max_items === undefined
+        ? exactReviewPublicationBatchSize(this.env)
+        : Number(body.max_items);
+    if (
+      !Number.isInteger(requestedSize) ||
+      requestedSize < 1 ||
+      requestedSize > MAX_EXACT_REVIEW_PUBLICATION_BATCH_SIZE
+    ) {
+      return json({ error: "invalid_max_items" }, 400);
+    }
+    const now = Date.now();
+    const state = this.readStateSync();
+    const batchOwnership = this.batchStore.activeLeaseSnapshot(now);
+    const publicationControl = this.refreshPublicationControlSync(state, now);
+    const publicationCapacity = exactReviewPublicationCapacityForState(
+      this.env,
+      state,
+      now,
+      publicationControl.capacityCeiling,
+      true,
+      publicationControl.demandCapacity,
+    );
+    // One batch consumes one publisher slot regardless of membership count. Reuse
+    // normal readiness/pause admission, but charge capacity once for the whole claim.
+    const activePublishers = exactReviewQueueActivePublicationCount(state);
+    const candidates =
+      activePublishers >= publicationCapacity
+        ? []
+        : exactReviewQueueAdmittedItems(
+            state,
+            now,
+            exactReviewQueueCapacity(this.env),
+            exactReviewTargetCapacity(this.env),
+            activePublishers + requestedSize,
+            new Set<string>(batchOwnership.itemKeys),
+          )
+            .filter(exactReviewQueueIsPublication)
+            .slice(0, requestedSize)
+            .map((item) => ({ itemKey: item.key, revision: item.revision }));
+    const batch = this.batchStore.claim({
+      batchId: claimId,
+      leaseOwner,
+      leaseExpiresAt: now + exactReviewPublicationBatchLeaseMs(this.env),
+      now,
+      maxItems: requestedSize,
+      candidates,
+    });
+    if (!batch) return json({ ok: true, claimed: false, batch: null });
+    return json({ ok: true, claimed: true, batch: exactReviewPublicationBatchJson(batch) });
+  }
+
+  private async fetchPublicationBatch(value: unknown) {
+    const body = objectValue(value);
+    const batchId = exactReviewPublicationBatchId(body.batch_id);
+    const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
+    if (!batchId || !leaseOwner) return json({ error: "invalid_batch_identity" }, 400);
+    const now = Date.now();
+    let batch = this.batchStore.fetch(batchId, leaseOwner, now);
+    if (!batch) return json({ error: "batch_lease_not_active" }, 409);
+    const state = this.readStateSync();
+    const stale: PublicationBatchCompletion[] = batch.items
+      .filter((membership) => {
+        if (membership.terminalOutcome !== null) return false;
+        const item = state.items[membership.itemKey];
+        return (
+          !item || item.revision !== membership.revision || !exactReviewQueueIsPublication(item)
+        );
+      })
+      .map((membership) => ({
+        itemKey: membership.itemKey,
+        revision: membership.revision,
+        claimGeneration: membership.claimGeneration,
+        terminalOutcome: "superseded",
+      }));
+    if (stale.length) {
+      batch = this.batchStore.complete(batchId, leaseOwner, stale, now);
+      if (!batch) return json({ error: "batch_lease_not_active" }, 409);
+      await this.scheduleNext(state, now);
+    }
+    const items = batch.items.flatMap((membership) => {
+      if (membership.terminalOutcome !== null) return [];
+      const item = state.items[membership.itemKey];
+      if (!item || item.revision !== membership.revision) return [];
+      return [
+        {
+          item_key: membership.itemKey,
+          revision: membership.revision,
+          claim_generation: membership.claimGeneration,
+          decision: item.decision,
+        },
+      ];
+    });
+    return json({
+      ok: true,
+      batch: exactReviewPublicationBatchJson(batch),
+      items,
+      superseded: batch.items.filter((item) => item.terminalOutcome === "superseded").length,
+    });
+  }
+
+  private async completePublicationBatch(value: unknown) {
+    const body = objectValue(value);
+    const batchId = exactReviewPublicationBatchId(body.batch_id);
+    const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
+    const completions = exactReviewPublicationBatchCompletions(body.items);
+    if (!batchId || !leaseOwner) return json({ error: "invalid_batch_identity" }, 400);
+    if (!completions) return json({ error: "invalid_batch_completions" }, 400);
+    const stateCommitSha = String(body.state_commit_sha || "").trim();
+    if (stateCommitSha && !/^[0-9a-f]{40}$/i.test(stateCommitSha)) {
+      return json({ error: "invalid_state_commit_sha" }, 400);
+    }
+    const failureFingerprint = String(body.failure_fingerprint || "").trim();
+    if (failureFingerprint.length > 500) {
+      return json({ error: "invalid_failure_fingerprint" }, 400);
+    }
+    let acceptedCount = 0;
+    const batch = this.batchStore.complete(
+      batchId,
+      leaseOwner,
+      completions,
+      Date.now(),
+      {
+        ...(stateCommitSha ? { stateCommitSha } : {}),
+        ...(failureFingerprint ? { failureFingerprint } : {}),
+      },
+      (accepted) => {
+        acceptedCount = accepted.length;
+        if (!accepted.length) return;
+        const state = this.readStateSync();
+        let published = 0;
+        let superseded = 0;
+        for (const completion of accepted) {
+          if (
+            completion.terminalOutcome !== "published" &&
+            completion.terminalOutcome !== "superseded"
+          ) {
+            continue;
+          }
+          const item = state.items[completion.itemKey];
+          if (
+            !item ||
+            item.revision !== completion.revision ||
+            !exactReviewQueueIsPublication(item)
+          ) {
+            continue;
+          }
+          delete state.items[completion.itemKey];
+          if (completion.terminalOutcome === "published") published += 1;
+          else superseded += 1;
+        }
+        if (!published && !superseded) return;
+        this.writeStateSync(state);
+        this.incrementQueueMetricsSync({
+          publicationCompleted: published + superseded,
+          publicationPublished: published,
+          publicationSuperseded: superseded,
+        });
+      },
+    );
+    if (!batch) return json({ error: "batch_lease_not_active" }, 409);
+    if (acceptedCount) await this.scheduleNext(this.readStateSync(), Date.now());
+    return json({
+      ok: true,
+      accepted: acceptedCount,
+      skipped: completions.length - acceptedCount,
+      batch: exactReviewPublicationBatchJson(batch),
+    });
+  }
+
   private async initializeStorage() {
     this.ensureStorageSchemaSync();
+    this.batchStore.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
     const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as
@@ -3630,6 +3864,7 @@ export class ExactReviewQueue {
 
   private async scheduleNext(state: ExactReviewQueueState, now: number) {
     const publicationControl = this.refreshPublicationControlSync(state, now);
+    const batchOwnership = this.batchStore.activeLeaseSnapshot(now);
     const queueNext = exactReviewQueueNextWakeAt(
       state,
       now,
@@ -3645,14 +3880,16 @@ export class ExactReviewQueue {
       ),
       exactReviewPublicationDispatchLeaseMs(this.env),
       exactReviewHeartbeatGraceMs(this.env),
+      new Set<string>(batchOwnership.itemKeys),
+      batchOwnership.nextLeaseExpiresAt,
     );
     const reviewNext = this.nextReviewReconcileAtSync(now);
-    const next =
-      queueNext === null
-        ? reviewNext
-        : reviewNext === null
-          ? queueNext
-          : Math.min(queueNext, reviewNext);
+    const next = [queueNext, reviewNext, batchOwnership.nextLeaseExpiresAt]
+      .filter((candidate): candidate is number => candidate !== null)
+      .reduce<number | null>(
+        (earliest, candidate) => (earliest === null ? candidate : Math.min(earliest, candidate)),
+        null,
+      );
     if (next === null) {
       await this.storage.deleteAlarm();
       return;
@@ -4740,12 +4977,22 @@ function exactReviewQueueActiveReviewCount(state: ExactReviewQueueState) {
   ).length;
 }
 
+function exactReviewQueueActivePublicationCount(state: ExactReviewQueueState) {
+  return Object.values(state.items).filter(
+    (item) =>
+      exactReviewQueueIsPublication(item) &&
+      (item.state === "dispatching" || item.state === "leased"),
+  ).length;
+}
+
 export function exactReviewQueueAdmittedItems(
   state: ExactReviewQueueState,
   now: number,
   capacity: number,
   targetCapacity: number,
   publicationCapacity: number,
+  excludedItemKeys: ReadonlySet<string> = new Set(),
+  publicationAdmissionBlocked = false,
 ) {
   const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
   if (
@@ -4769,11 +5016,15 @@ export function exactReviewQueueAdmittedItems(
   const admitted: ExactReviewQueueItem[] = [];
   let admittedReviews = 0;
   const pending = Object.values(state.items)
-    .filter((item) => item.state === "pending" && item.nextAttemptAt <= now)
+    .filter(
+      (item) =>
+        item.state === "pending" && item.nextAttemptAt <= now && !excludedItemKeys.has(item.key),
+    )
     .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
   for (const item of pending) {
     const publication = exactReviewQueueIsPublication(item);
     if (publication) {
+      if (publicationAdmissionBlocked) continue;
       if (activePublishers >= publicationCapacity) continue;
       activePublishers += 1;
       admitted.push(item);
@@ -4819,6 +5070,8 @@ function exactReviewQueueStats(
   executionLeaseMs = DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS,
   publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
   heartbeatGraceMs = DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
+  excludedItemKeys: ReadonlySet<string> = new Set(),
+  publicationBlockedUntil: number | null = null,
 ) {
   const items = Object.values(state.items);
   const handoffItems = items.filter(
@@ -4895,6 +5148,8 @@ function exactReviewQueueStats(
     publicationCapacity,
     publicationDispatchLeaseMs,
     heartbeatGraceMs,
+    excludedItemKeys,
+    publicationBlockedUntil,
   );
   const lanes = {
     review: exactReviewQueueLaneStats(
@@ -4918,6 +5173,8 @@ function exactReviewQueueStats(
     Number.MAX_SAFE_INTEGER,
     targetCapacity,
     publicationCapacity,
+    excludedItemKeys,
+    publicationBlockedUntil !== null && publicationBlockedUntil > now,
   );
   const admissiblePending = admissibleItems.length;
   const reviewAdmissiblePending = admissibleItems.filter(
@@ -5064,6 +5321,8 @@ export function exactReviewQueueNextWakeAt(
   publicationCapacity = Number.POSITIVE_INFINITY,
   publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
   heartbeatGraceMs = DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
+  excludedItemKeys: ReadonlySet<string> = new Set(),
+  publicationBlockedUntil: number | null = null,
 ) {
   const items = Object.values(state.items);
   if (!items.length) return null;
@@ -5116,8 +5375,12 @@ export function exactReviewQueueNextWakeAt(
   }
   const times = items.flatMap((item) => {
     if (item.state === "pending") {
+      if (excludedItemKeys.has(item.key)) return [];
       if (dispatcherPaused) return [dispatcherRetryAt];
       if (exactReviewQueueIsPublication(item)) {
+        if (publicationBlockedUntil !== null && publicationBlockedUntil > now) {
+          return [Math.max(item.nextAttemptAt, publicationBlockedUntil)];
+        }
         let blockedUntil = item.nextAttemptAt;
         if (activePublishers.length >= publicationCapacity) {
           const capacityWakeAt = [...activePublisherWakeAt];
@@ -5505,6 +5768,36 @@ function exactReviewPublicationDispatchLeaseMs(env) {
   );
 }
 
+function exactReviewPublicationBatchingEnabled(env) {
+  return String(env.EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED || "").trim() === "1";
+}
+
+function exactReviewPublicationBatchSize(env) {
+  return Math.max(
+    1,
+    Math.min(
+      MAX_EXACT_REVIEW_PUBLICATION_BATCH_SIZE,
+      numberFrom(
+        env.EXACT_REVIEW_PUBLICATION_BATCH_SIZE,
+        DEFAULT_EXACT_REVIEW_PUBLICATION_BATCH_SIZE,
+      ),
+    ),
+  );
+}
+
+function exactReviewPublicationBatchLeaseMs(env) {
+  return Math.max(
+    60_000,
+    Math.min(
+      2 * 60 * 60 * 1000,
+      numberFrom(
+        env.EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS,
+        DEFAULT_EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS,
+      ),
+    ),
+  );
+}
+
 function exactReviewExecutionLeaseMs(env) {
   return Math.max(
     60_000,
@@ -5813,6 +6106,73 @@ async function githubTokenJson({ token, path, method = "GET", body, errorLabel }
   }
   if (response.status === 204) return {};
   return response.json();
+}
+
+function exactReviewPublicationBatchId(value) {
+  const text = String(value || "").trim();
+  return /^[A-Za-z0-9._:-]{1,200}$/.test(text) ? text : "";
+}
+
+function exactReviewPublicationBatchOwner(value) {
+  const text = String(value || "").trim();
+  return /^[A-Za-z0-9._:@/-]{1,200}$/.test(text) ? text : "";
+}
+
+function exactReviewPublicationBatchCompletions(value): PublicationBatchCompletion[] | null {
+  if (!Array.isArray(value) || value.length > MAX_EXACT_REVIEW_PUBLICATION_BATCH_SIZE) return null;
+  // PR1 only exposes outcomes whose existing queue terminal semantics are complete.
+  // Retry and dead-letter classifications stay on the legacy path until PR3 wires
+  // per-item batch failures through finishExactReviewPublicationQueueItem.
+  const outcomes = new Set(["published", "superseded"]);
+  const seen = new Set<string>();
+  const completions: PublicationBatchCompletion[] = [];
+  for (const raw of value) {
+    const item = objectValue(raw);
+    const itemKey = String(item.item_key || "").trim();
+    const revision = Number(item.revision);
+    const claimGeneration = Number(item.claim_generation);
+    const terminalOutcome = String(item.terminal_outcome || "").trim();
+    if (
+      !itemKey ||
+      itemKey.length > 500 ||
+      seen.has(itemKey) ||
+      !Number.isInteger(revision) ||
+      revision < 1 ||
+      !Number.isInteger(claimGeneration) ||
+      claimGeneration < 1 ||
+      !outcomes.has(terminalOutcome)
+    ) {
+      return null;
+    }
+    seen.add(itemKey);
+    completions.push({
+      itemKey,
+      revision,
+      claimGeneration,
+      terminalOutcome: terminalOutcome as PublicationBatchCompletion["terminalOutcome"],
+    });
+  }
+  return completions;
+}
+
+function exactReviewPublicationBatchJson(batch) {
+  return {
+    batch_id: batch.batchId,
+    state: batch.state,
+    lease_owner: batch.leaseOwner,
+    lease_expires_at: new Date(batch.leaseExpiresAt).toISOString(),
+    attempt: batch.attempt,
+    created_at: new Date(batch.createdAt).toISOString(),
+    completed_at: batch.completedAt === null ? null : new Date(batch.completedAt).toISOString(),
+    state_commit_sha: batch.stateCommitSha,
+    failure_fingerprint: batch.failureFingerprint,
+    items: batch.items.map((item) => ({
+      item_key: item.itemKey,
+      revision: item.revision,
+      claim_generation: item.claimGeneration,
+      terminal_outcome: item.terminalOutcome,
+    })),
+  };
 }
 
 function objectValue(value) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -541,6 +541,21 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/review-telemetry");
     if (url.pathname === "/internal/exact-review/review-run-telemetry" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/review-run-telemetry");
+    if (
+      url.pathname === "/internal/exact-review/publication-batches/claim" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/publication-batches/claim");
+    if (
+      url.pathname === "/internal/exact-review/publication-batches/fetch" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/publication-batches/fetch");
+    if (
+      url.pathname === "/internal/exact-review/publication-batches/complete" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/publication-batches/complete");
     if (url.pathname === "/internal/exact-review/reconcile" && request.method === "POST")
       return authenticatedExactReviewReconcile(request, env);
     if (url.pathname === "/api/exact-review-queue" && request.method === "GET")

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1,0 +1,786 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { ExactReviewPublicationBatchStore } from "../dashboard/exact-review-publication-batches.ts";
+import { ExactReviewQueue } from "../dashboard/exact-review-queue.ts";
+import worker from "../dashboard/worker.ts";
+
+class SqlCursor<T extends Record<string, unknown>> implements Iterable<T> {
+  private readonly rows: T[];
+
+  constructor(rows: T[]) {
+    this.rows = rows;
+  }
+
+  *[Symbol.iterator]() {
+    yield* this.rows;
+  }
+}
+
+class TestStorage {
+  private readonly database = new DatabaseSync(":memory:");
+  private readonly values = new Map<string, unknown>();
+  private alarmAt: number | null = null;
+  readonly sql = {
+    exec: (query: string, ...bindings: unknown[]) => {
+      const statement = this.database.prepare(query);
+      if (/^\s*(?:SELECT|WITH)\b/i.test(query) || /\bRETURNING\b/i.test(query)) {
+        return new SqlCursor(statement.all(...bindings) as Record<string, unknown>[]);
+      }
+      statement.run(...bindings);
+      return new SqlCursor<Record<string, unknown>>([]);
+    },
+  };
+  readonly kv = {
+    get: (key: string) => this.values.get(key),
+    put: (key: string, value: unknown) => this.values.set(key, structuredClone(value)),
+    delete: (key: string) => this.values.delete(key),
+  };
+
+  transactionSync<T>(callback: () => T) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const result = callback();
+      this.database.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  scalar(query: string) {
+    return Number((this.database.prepare(query).get() as { value: number }).value);
+  }
+
+  exec(query: string) {
+    this.database.exec(query);
+  }
+
+  async get(key: string) {
+    return this.values.get(key);
+  }
+
+  async put(key: string, value: unknown) {
+    this.values.set(key, structuredClone(value));
+  }
+
+  async delete(key: string) {
+    this.values.delete(key);
+  }
+
+  async getAlarm() {
+    return this.alarmAt;
+  }
+
+  async setAlarm(at: number) {
+    this.alarmAt = at;
+  }
+
+  async deleteAlarm() {
+    this.alarmAt = null;
+  }
+
+  scheduledAlarm() {
+    return this.alarmAt;
+  }
+}
+
+const candidates = [
+  { itemKey: "openclaw/openclaw#1@publish:10:1", revision: 1 },
+  { itemKey: "openclaw/openclaw#2@publish:20:1", revision: 2 },
+  { itemKey: "openclaw/openclaw#3@publish:30:1", revision: 3 },
+];
+
+test("publication batches atomically select ready items without duplicate active ownership", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+
+  const first = batches.claim({
+    batchId: "batch-1",
+    leaseOwner: "worker-1",
+    leaseExpiresAt: 2_000,
+    now: 1_000,
+    maxItems: 2,
+    candidates,
+  });
+  const second = batches.claim({
+    batchId: "batch-2",
+    leaseOwner: "worker-2",
+    leaseExpiresAt: 2_000,
+    now: 1_000,
+    maxItems: 2,
+    candidates,
+  });
+
+  assert.deepEqual(
+    first?.items.map((item) => item.itemKey),
+    candidates.slice(0, 2).map((item) => item.itemKey),
+  );
+  assert.equal(second, null);
+  assert.deepEqual(batches.activeLeaseSnapshot(1_500), {
+    itemKeys: candidates.slice(0, 2).map((item) => item.itemKey),
+    nextLeaseExpiresAt: 2_000,
+  });
+  assert.equal(batches.fetch("batch-1", "wrong-worker", 1_500), null);
+});
+
+test("expired unfinished membership is reclaimable with a new fencing generation", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  const first = batches.claim({
+    batchId: "batch-expiring",
+    leaseOwner: "worker-1",
+    leaseExpiresAt: 2_000,
+    now: 1_000,
+    maxItems: 1,
+    candidates,
+  });
+  assert.equal(first?.items[0].claimGeneration, 1);
+
+  const reclaimed = batches.claim({
+    batchId: "batch-reclaimed",
+    leaseOwner: "worker-2",
+    leaseExpiresAt: 4_000,
+    now: 2_001,
+    maxItems: 1,
+    candidates,
+  });
+  assert.equal(reclaimed?.items[0].itemKey, candidates[0].itemKey);
+  assert.equal(reclaimed?.items[0].claimGeneration, 2);
+  assert.equal(batches.fetch("batch-expiring", "worker-1", 2_001), null);
+
+  const staleCompletion = batches.complete(
+    "batch-reclaimed",
+    "worker-2",
+    [
+      {
+        ...candidates[0],
+        claimGeneration: 1,
+        terminalOutcome: "published",
+      },
+    ],
+    2_100,
+  );
+  assert.equal(staleCompletion?.state, "leased");
+  assert.equal(staleCompletion?.items[0].terminalOutcome, null);
+});
+
+test("batch completion is fenced per item and retains publication metadata", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  const batch = batches.claim({
+    batchId: "batch-complete",
+    leaseOwner: "worker-1",
+    leaseExpiresAt: 5_000,
+    now: 1_000,
+    maxItems: 2,
+    candidates,
+  });
+  assert.ok(batch);
+
+  const rejected = batches.complete(
+    batch.batchId,
+    batch.leaseOwner,
+    [
+      {
+        ...batch.items[0],
+        claimGeneration: batch.items[0].claimGeneration + 1,
+        terminalOutcome: "published",
+      },
+    ],
+    1_500,
+    { stateCommitSha: "c".repeat(40), failureFingerprint: "stale" },
+  );
+  assert.equal(rejected?.stateCommitSha, null);
+  assert.equal(rejected?.failureFingerprint, null);
+
+  const completed = batches.complete(
+    batch.batchId,
+    batch.leaseOwner,
+    batch.items.map((item, index) => ({
+      itemKey: item.itemKey,
+      revision: item.revision,
+      claimGeneration: item.claimGeneration,
+      terminalOutcome: index === 0 ? "published" : "superseded",
+    })),
+    2_000,
+    { stateCommitSha: "a".repeat(40), failureFingerprint: "none" },
+  );
+
+  assert.equal(completed?.state, "completed");
+  assert.equal(completed?.completedAt, 2_000);
+  assert.equal(completed?.stateCommitSha, "a".repeat(40));
+  assert.deepEqual(
+    completed?.items.map((item) => item.terminalOutcome),
+    ["published", "superseded"],
+  );
+
+  const retried = batches.complete(
+    batch.batchId,
+    batch.leaseOwner,
+    batch.items.map((item, index) => ({
+      itemKey: item.itemKey,
+      revision: item.revision,
+      claimGeneration: item.claimGeneration,
+      terminalOutcome: index === 0 ? "published" : "superseded",
+    })),
+    2_100,
+  );
+  assert.deepEqual(retried, completed);
+  assert.equal(
+    batches.complete(
+      batch.batchId,
+      batch.leaseOwner,
+      [{ ...batch.items[0], terminalOutcome: "superseded" }],
+      2_100,
+    ),
+    null,
+  );
+});
+
+test("bounded cleanup preserves active batches and open dead letters", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  storage.exec(
+    "CREATE TABLE exact_review_queue_dead_letters (dead_letter_id TEXT PRIMARY KEY, status TEXT)",
+  );
+  storage.exec(
+    "INSERT INTO exact_review_queue_dead_letters (dead_letter_id, status) VALUES ('dlq-1', 'open')",
+  );
+
+  for (let index = 0; index < 3; index += 1) {
+    const batch = batches.claim({
+      batchId: `completed-${index}`,
+      leaseOwner: "worker",
+      leaseExpiresAt: 5_000,
+      now: 1_000 + index,
+      maxItems: 1,
+      candidates: [{ itemKey: `item-${index}`, revision: 1 }],
+    });
+    assert.ok(batch);
+    batches.complete(
+      batch.batchId,
+      batch.leaseOwner,
+      [
+        {
+          itemKey: batch.items[0].itemKey,
+          revision: 1,
+          claimGeneration: 1,
+          terminalOutcome: "published",
+        },
+      ],
+      2_000 + index,
+    );
+  }
+  batches.claim({
+    batchId: "still-active",
+    leaseOwner: "worker",
+    leaseExpiresAt: 20_000,
+    now: 3_000,
+    maxItems: 1,
+    candidates: [{ itemKey: "active-item", revision: 1 }],
+  });
+
+  const stats = batches.stats(10_000, { completedTtlMs: 1_000, cleanupLimit: 2 });
+  assert.equal(stats.cleanup.deletedThisPass, 2);
+  assert.equal(stats.cleanup.eligibleRemaining, 1);
+  assert.equal(stats.leased, 1);
+  assert.equal(stats.activeItems, 1);
+  assert.equal(storage.scalar("SELECT COUNT(*) AS value FROM exact_review_queue_dead_letters"), 1);
+});
+
+test("cleanup retains fencing generations when a batch id is reused", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  const candidate = { itemKey: "item-reclaimed-after-cleanup", revision: 1 };
+  const first = batches.claim({
+    batchId: "reused-batch",
+    leaseOwner: "worker",
+    leaseExpiresAt: 5_000,
+    now: 1_000,
+    maxItems: 1,
+    candidates: [candidate],
+  });
+  assert.ok(first);
+  batches.complete(
+    first.batchId,
+    first.leaseOwner,
+    [
+      {
+        ...candidate,
+        claimGeneration: first.items[0].claimGeneration,
+        terminalOutcome: "published",
+      },
+    ],
+    2_000,
+  );
+  batches.stats(10_000, { completedTtlMs: 1_000, cleanupLimit: 1 });
+
+  const reclaimed = batches.claim({
+    batchId: "reused-batch",
+    leaseOwner: "worker",
+    leaseExpiresAt: 20_000,
+    now: 10_000,
+    maxItems: 1,
+    candidates: [candidate],
+  });
+  assert.equal(reclaimed?.items[0].claimGeneration, 2);
+
+  const staleCompletion = batches.complete(
+    "reused-batch",
+    "worker",
+    [
+      {
+        ...candidate,
+        claimGeneration: 1,
+        terminalOutcome: "published",
+      },
+    ],
+    11_000,
+  );
+  assert.equal(staleCompletion?.state, "leased");
+  assert.equal(staleCompletion?.items[0].terminalOutcome, null);
+});
+
+function publicationRequest(deliveryId: string, number: number, producerRunId: string) {
+  const producerDecision = {
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: number,
+    itemKind: "issue",
+    sourceEvent: "issues",
+    sourceAction: "opened",
+    supersedesInProgress: false,
+  };
+  return new Request("https://queue/enqueue", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      delivery_id: deliveryId,
+      decision: {
+        ...producerDecision,
+        sourceAction: "exact_review_artifact_publish",
+        publication: {
+          artifactName: `exact-review-${producerRunId}-1`,
+          producerRunId,
+          producerRunAttempt: 1,
+          sourceSha: "a".repeat(40),
+          itemKey: `openclaw/openclaw#${number}`,
+          protocolVersion: 2,
+          leaseRevision: 1,
+          claimGeneration: 1,
+          liveProceeded: true,
+          liveTerminalNoop: false,
+          liveTerminalMissing: false,
+          liveGuardedOpen: false,
+          producerDecision,
+        },
+      },
+    }),
+  });
+}
+
+function batchRequest(path: string, body: unknown) {
+  return new Request(`https://queue${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("queue batch claim defaults off and additive schema keeps the legacy version", async () => {
+  const queue = new ExactReviewQueue({ storage: new TestStorage() }, {});
+  await queue.fetch(publicationRequest("delivery-1", 101, "1001"));
+  const claim = await queue.fetch(
+    batchRequest("/publication-batches/claim", {
+      claim_id: "claim-disabled",
+      lease_owner: "worker-1",
+    }),
+  );
+  assert.equal(claim.status, 409);
+  assert.deepEqual(await claim.json(), { error: "publication_batching_disabled" });
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.storage_schema_version, 1);
+  assert.equal(stats.lanes.publication.batches.enabled, false);
+  assert.equal(stats.lanes.publication.batches.leased, 0);
+});
+
+test("legacy queue migration preserves receipts while adding empty batch tables", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 3_000_000;
+  try {
+    const storage = new TestStorage();
+    await storage.put("exact-review-queue", {
+      items: {},
+      deliveries: { "legacy-delivery": 3_000_000 },
+    });
+    const queue = new ExactReviewQueue({ storage }, {});
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+
+    assert.equal(stats.delivery_receipts, 1);
+    assert.equal(stats.storage_schema_version, 1);
+    assert.equal(stats.lanes.publication.batches.active_items, 0);
+    assert.equal(
+      storage.scalar("SELECT COUNT(*) AS value FROM exact_review_publication_batches"),
+      0,
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("batch claim honors the existing dispatcher pause gate", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 4_000_000;
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    await queue.fetch(publicationRequest("delivery-paused", 104, "1004"));
+    Array.from(
+      storage.sql.exec(
+        "UPDATE exact_review_queue_meta SET dispatcher_json = ? WHERE singleton_id = 1",
+        JSON.stringify({
+          state: "paused",
+          checkedAt: 4_000_000,
+          retryAt: 4_060_000,
+          reason: "workflow_not_active",
+        }),
+      ),
+    );
+
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-paused",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, false);
+    assert.equal(claim.batch, null);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("an active batch blocks the legacy publisher until its lease expires", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 5_000_000;
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+        EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT: "1",
+        EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT: "1",
+        EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT: "1",
+      },
+    );
+    await queue.fetch(publicationRequest("delivery-owned", 105, "1005"));
+    await queue.fetch(publicationRequest("delivery-unowned", 106, "1006"));
+    await queue.fetch(publicationRequest("delivery-unowned-2", 107, "1007"));
+
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-blocks-legacy",
+          lease_owner: "worker-1",
+          max_items: 2,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true, JSON.stringify(claim));
+    assert.equal(claim.batch.items.length, 2);
+
+    await queue.alarm();
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 3);
+    assert.equal(stats.lanes.publication.dispatching, 0);
+    assert.equal(stats.admissible_pending, 0);
+    assert.equal(storage.scheduledAlarm(), 5_060_000);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("batch protocol routes require the shared internal signature", async () => {
+  const secret = "test-secret";
+  const body = JSON.stringify({ claim_id: "claim-authenticated", lease_owner: "worker-1" });
+  let forwardedPath = "";
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: {
+      idFromName: () => "global",
+      get: () => ({
+        fetch: async (request: Request) => {
+          forwardedPath = new URL(request.url).pathname;
+          return new Response(JSON.stringify({ ok: true }));
+        },
+      }),
+    },
+  };
+  const url = "https://clawsweeper.openclaw.ai/internal/exact-review/publication-batches/claim";
+  const unauthorized = await worker.fetch(new Request(url, { method: "POST", body }), env);
+  assert.equal(unauthorized.status, 401);
+
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  const authorized = await worker.fetch(
+    new Request(url, {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": signature },
+      body,
+    }),
+    env,
+  );
+  assert.equal(authorized.status, 200);
+  assert.equal(forwardedPath, "/publication-batches/claim");
+});
+
+test("queue fetch terminalizes a stale batch revision before dispatch", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1_000_000;
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+      },
+    );
+    const enqueued = await queue.fetch(publicationRequest("delivery-stale-1", 102, "1002"));
+    assert.equal(enqueued.status, 202, JSON.stringify(await enqueued.clone().json()));
+    const beforeClaim = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(beforeClaim.lanes.publication.pending, 1, JSON.stringify(beforeClaim));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-stale-revision-1",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true, JSON.stringify(claim));
+    assert.equal(claim.batch.items[0].revision, 1);
+
+    const retriedClaim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-stale-revision-1",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.deepEqual(retriedClaim, claim);
+
+    const competingClaim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-competing",
+          lease_owner: "worker-2",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(competingClaim.claimed, false);
+    assert.equal(competingClaim.batch, null);
+
+    await queue.alarm();
+    const ownedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(ownedStats.lanes.publication.pending, 1);
+    assert.equal(ownedStats.lanes.publication.dispatching, 0);
+    assert.equal(storage.scheduledAlarm(), 1_060_000);
+
+    await queue.fetch(publicationRequest("delivery-stale-2", 102, "1002"));
+    const fetched = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/fetch", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+        }),
+      )
+    ).json();
+    assert.equal(fetched.superseded, 1);
+    assert.equal(fetched.items.length, 0);
+    assert.equal(fetched.batch.state, "completed");
+    assert.equal(fetched.batch.items[0].terminal_outcome, "superseded");
+    assert.equal(storage.scheduledAlarm(), 1_001_000);
+
+    const retriedFetch = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/fetch", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+        }),
+      )
+    ).json();
+    assert.equal(retriedFetch.batch.state, "completed");
+    assert.equal(retriedFetch.superseded, 1);
+
+    const next = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-stale-revision-2",
+          lease_owner: "worker-2",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(next.batch.items[0].revision, 2);
+    assert.equal(next.batch.items[0].claim_generation, 2);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("queue completion atomically removes only the owned publication revision", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 2_000_000;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    const enqueued = await queue.fetch(publicationRequest("delivery-complete", 103, "1003"));
+    assert.equal(enqueued.status, 202, JSON.stringify(await enqueued.clone().json()));
+    const beforeClaim = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(beforeClaim.lanes.publication.pending, 1, JSON.stringify(beforeClaim));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-complete",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true, JSON.stringify(claim));
+    const member = claim.batch.items[0];
+    const unsupportedFailure = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+          },
+        ],
+      }),
+    );
+    assert.equal(unsupportedFailure.status, 400);
+    const completion = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          state_commit_sha: "b".repeat(40),
+          items: [
+            {
+              item_key: member.item_key,
+              revision: member.revision,
+              claim_generation: member.claim_generation,
+              terminal_outcome: "published",
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(completion.accepted, 1);
+    assert.equal(completion.batch.state, "completed");
+
+    const retriedCompletion = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          state_commit_sha: "b".repeat(40),
+          items: [
+            {
+              item_key: member.item_key,
+              revision: member.revision,
+              claim_generation: member.claim_generation,
+              terminal_outcome: "published",
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(retriedCompletion.accepted, 0);
+    assert.equal(retriedCompletion.batch.state, "completed");
+
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 0);
+    assert.equal(stats.lanes.publication.published_total, 1);
+    assert.equal(stats.lanes.publication.batches.completed, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("batch completion wakes publications that were blocked by its lease", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 6_000_000;
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+      },
+    );
+    await queue.fetch(publicationRequest("delivery-completing", 108, "1008"));
+    await queue.fetch(publicationRequest("delivery-waiting", 109, "1009"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-wakes-legacy",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    await queue.alarm();
+    assert.equal(storage.scheduledAlarm(), 6_060_000);
+
+    const member = claim.batch.items[0];
+    const completion = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "published",
+          },
+        ],
+      }),
+    );
+    assert.equal(completion.status, 200);
+    assert.equal(storage.scheduledAlarm(), 6_001_000);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

- add an additive SQLite batch, membership, and durable fencing-generation schema for exact-review publication work
- add fenced, retry-safe batch claim, fetch, completion, lease reclamation, and bounded cleanup operations
- expose authenticated internal batch protocol routes and batch health in queue stats
- keep admission behind `EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED=1`, defaulting off, with no workflow dispatch changes

## Why

CSW-049 showed that one-workflow-per-item publication serializes every result through an expensive Git critical section. This PR establishes the durable ownership protocol needed to safely group existing SQLite publication items before later PRs add a multi-item Git commit primitive and workflow integration.

Batch membership references the existing queue item key and revision; it does not copy publication payloads or create another authoritative queue.

## Safety

- one unfinished membership per item is enforced by a partial unique index
- expired memberships are terminalized and reclaimed with a higher, cleanup-stable claim generation
- stable caller-provided claim IDs and terminal receipts make lost-response retries recoverable
- stale queue revisions are superseded before payload fetch
- completion is fenced by batch owner, item key, revision, claim generation, and matching terminal outcome
- rejected completions cannot mutate first-writer receipt metadata
- an active batch blocks legacy publication admission and wakes the queue when ownership ends
- cleanup is bounded and cannot select leased batches or dead letters
- disabling the feature flag blocks only new claims, allowing already-leased batches to drain
- the existing queue schema version remains unchanged and no GitHub Actions workflow is added or modified

## Integration

- rebased onto `3d05cb4bab` (`feat: add State writer observability panel (#735)`); PR1 remains ownership-only and does not add a competing telemetry schema or batch committer
- later batch-committer PRs must populate the established state-writer telemetry v1 recorder with `mode: batch`

## Validation

- clean local `autoreview` result after rebase: no actionable findings, patch correct
- `pnpm run build:dashboard`
- dashboard lint and focused test lint
- `node --test test/dashboard-worker.test.ts test/dashboard-operational-health.test.ts test/state-writer-telemetry.test.ts test/exact-review-publication-batches.test.ts` — 181 passed
- `pnpm run check:dashboard-queue-boundary`
- `pnpm run check:limits`
- `pnpm run format:check`
