### PR TITLE
feat: add State writer observability panel

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1553,6 +1553,11 @@ jobs:
           LIVE_TERMINAL_NOOP: ${{ steps.publication-context.outputs.live_terminal_noop }}
           LIVE_TERMINAL_MISSING: ${{ steps.publication-context.outputs.live_terminal_missing }}
           LIVE_GUARDED_OPEN: ${{ steps.publication-context.outputs.live_guarded_open }}
+          EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          EXACT_REVIEW_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
+          EXACT_REVIEW_ITEM_KEY: ${{ steps.publication-context.outputs.publisher_item_key }}
+          EXACT_REVIEW_LEASE_REVISION: ${{ steps.publication-context.outputs.publisher_lease_revision }}
+          EXACT_REVIEW_CLAIM_GENERATION: ${{ steps.publication-context.outputs.publisher_claim_generation }}
         run: |
           set -euo pipefail
           record_publication_failure_kind() {
@@ -1936,6 +1941,7 @@ jobs:
           PUBLISH_REASON_CODE: ${{ steps.publish-event-result.outputs.reason_code }}
           PUBLISH_RETRY_AT: ${{ steps.publish-event-result.outputs.retry_at }}
           ERROR_FINGERPRINT: ${{ steps.publish-event-result.outputs.error_fingerprint }}
+          STATE_WRITER_JSON: ${{ steps.publish-event-result.outputs.state_writer_json }}
           REVIEW_ONLY: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && 'true' || 'false' }}
         run: |
           set -euo pipefail
@@ -2016,6 +2022,9 @@ jobs:
           if [ "$outcome" = "failure" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
             echo "failure_kind=$FAILURE_KIND" >> "$GITHUB_OUTPUT"
           fi
+          if [ -n "$STATE_WRITER_JSON" ]; then
+            echo "state_writer_json=$STATE_WRITER_JSON" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Complete durable exact review publication
         id: complete-exact-review-publication
@@ -2031,6 +2040,7 @@ jobs:
           REASON_CODE: ${{ steps.exact-review-publication-result.outputs.reason_code }}
           ERROR_FINGERPRINT: ${{ steps.exact-review-publication-result.outputs.error_fingerprint }}
           RETRY_AT: ${{ steps.exact-review-publication-result.outputs.retry_at }}
+          STATE_WRITER_JSON: ${{ steps.exact-review-publication-result.outputs.state_writer_json }}
           QUEUE_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -2063,6 +2073,11 @@ jobs:
             const retryAt = String(process.env.RETRY_AT || "").trim();
             if (retryAt && !Number.isFinite(Date.parse(retryAt))) process.exit(1);
             if (!completionKind || !reasonCode) process.exit(1);
+            let stateWriter;
+            try {
+              const parsed = JSON.parse(process.env.STATE_WRITER_JSON || "");
+              if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) stateWriter = parsed;
+            } catch {}
             process.stdout.write(JSON.stringify({
               lease_id: process.env.QUEUE_LEASE_ID,
               item_key: process.env.ITEM_KEY,
@@ -2076,6 +2091,7 @@ jobs:
               ...(errorFingerprint ? { error_fingerprint: errorFingerprint } : {}),
               ...(retryAt ? { retry_at: retryAt } : {}),
               ...(outcome === "failure" && failureKind ? { failure_kind: failureKind } : {}),
+              ...(stateWriter ? { state_writer: stateWriter } : {}),
             }));
           ')"
           for attempt in 1 2 3; do

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1,5 +1,11 @@
 import { stableJson } from "../src/stable-json.ts";
 import {
+  normalizeStateWriterOperation,
+  normalizeStateWriterProgress,
+  payloadHash,
+  type StateWriterOperation,
+} from "../src/state-writer-telemetry.ts";
+import {
   summarizeExactReviewHandoff,
   summarizeExactReviewPressure,
 } from "./exact-review-health.ts";
@@ -283,6 +289,11 @@ const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE = "exact_review_queue_metric_bucket
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
 const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
+const EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE = "exact_review_state_writer_operations";
+const EXACT_REVIEW_STATE_WRITER_LIVE_TABLE = "exact_review_state_writer_live";
+const EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE = "exact_review_state_writer_diagnostics";
+const EXACT_REVIEW_STATE_WRITER_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_STATE_WRITER_LIVE_MS = 90 * 1000;
 const REVIEW_OBSERVABILITY_SCAN_LIMIT = 10_000;
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT = 5_000;
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
@@ -605,6 +616,10 @@ export class ExactReviewQueue {
 
     if (request.method === "POST" && url.pathname === "/complete") {
       const body = objectValue(await request.json().catch(() => null));
+      const stateWriter =
+        body.state_writer === undefined
+          ? undefined
+          : normalizeStateWriterOperation(body.state_writer);
       const leaseId = String(body.lease_id || "").trim();
       const itemKey = String(body.item_key || "").trim();
       const leaseRevision = Number(body.lease_revision);
@@ -701,6 +716,13 @@ export class ExactReviewQueue {
       if ((item.claimProtocolVersion ?? 1) !== completionProtocolVersion) {
         return json({ error: "lease_protocol_not_claimed" }, 409);
       }
+      // Optional observability cannot alter a valid publication completion.
+      // Store only after the claim tuple has been authenticated.
+      this.recordStateWriterOperationSafely(
+        body.state_writer === undefined ? undefined : stateWriter,
+        body.state_writer !== undefined && !stateWriter,
+        now,
+      );
       const publicationItem = exactReviewQueueIsPublication(item);
       if (failureKind && !publicationItem) {
         return json({ error: "failure_kind_outside_publication" }, 400);
@@ -801,6 +823,40 @@ export class ExactReviewQueue {
       );
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
+    }
+
+    if (request.method === "POST" && url.pathname === "/state-writer-progress") {
+      const body = objectValue(await request.json().catch(() => null));
+      const progress = normalizeStateWriterProgress(body);
+      const itemKey = String(body.item_key || "").trim();
+      const leaseId = String(body.lease_id || "").trim();
+      const leaseRevision = Number(body.lease_revision);
+      const claimGeneration = Number(body.claim_generation);
+      const runId = String(body.run_id || "").trim();
+      const runAttempt = exactReviewRunAttempt(body.run_attempt);
+      const now = Date.now();
+      const item = this.readStateSync().items[itemKey];
+      const valid =
+        progress &&
+        item &&
+        item.state === "leased" &&
+        item.leaseId === leaseId &&
+        item.leaseRevision === leaseRevision &&
+        exactReviewClaimGeneration(item.claimGeneration) === claimGeneration &&
+        item.claimedRunId === runId &&
+        (item.claimedRunAttempt ?? null) === runAttempt &&
+        isLiveExactReviewLease(
+          item,
+          now,
+          exactReviewPublicationDispatchLeaseMs(this.env),
+          exactReviewHeartbeatGraceMs(this.env),
+        );
+      if (!valid) {
+        this.incrementStateWriterDiagnosticSafely("rejected_progress_total");
+        return json({ ok: false, accepted: false }, 202);
+      }
+      this.recordStateWriterProgressSafely(progress, now);
+      return json({ ok: true, accepted: true }, 202);
     }
 
     if (request.method === "POST" && url.pathname === "/claimed-runs") {
@@ -1019,6 +1075,7 @@ export class ExactReviewQueue {
             repo: null,
             now,
           }),
+          stateWriter: this.stateWriterSummarySync(now),
         };
       });
       const {
@@ -1029,6 +1086,7 @@ export class ExactReviewQueue {
         deadLetters,
         reviewTelemetryHealth,
         reviewExecutionHealth,
+        stateWriter,
       } = snapshot;
       const publicationControl = this.refreshPublicationControlSync(state, now);
       await this.scheduleNext(state, now);
@@ -1082,6 +1140,7 @@ export class ExactReviewQueue {
         delivery_receipts: this.deliveryReceiptCountSync(),
         review_telemetry_health: reviewTelemetryHealth,
         review_execution_health: reviewExecutionHealth,
+        state_writer: stateWriter,
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
         legacy_rollback_available:
           !this.legacyMirrorDisabled &&
@@ -2357,6 +2416,64 @@ export class ExactReviewQueue {
          ON ${EXACT_REVIEW_RUN_TELEMETRY_TABLE}
          (trigger_lane, target_repo, completed_at, workflow_outcome)`,
     );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} (
+         operation_id TEXT PRIMARY KEY,
+         observed_at INTEGER NOT NULL,
+         mode TEXT NOT NULL CHECK (mode IN ('single_item', 'batch')),
+         started_at INTEGER NOT NULL,
+         finished_at INTEGER NOT NULL,
+         wait_ms INTEGER NOT NULL,
+         acquire_attempts INTEGER NOT NULL,
+         acquired INTEGER NOT NULL,
+         hold_ms INTEGER,
+         renewals INTEGER NOT NULL,
+         released INTEGER,
+         git_duration_ms INTEGER NOT NULL,
+         git_processes INTEGER NOT NULL,
+         commit_count INTEGER NOT NULL,
+         materialized_items INTEGER NOT NULL,
+         configured_batch_size INTEGER NOT NULL,
+         actual_batch_size INTEGER NOT NULL,
+         batch_wait_ms INTEGER,
+         outcome TEXT NOT NULL,
+         payload_hash TEXT NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_state_writer_operations_finished
+         ON ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} (finished_at, mode)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE} (
+         operation_id TEXT PRIMARY KEY,
+         mode TEXT NOT NULL,
+         phase TEXT NOT NULL,
+         sequence INTEGER NOT NULL,
+         observed_at INTEGER NOT NULL,
+         configured_batch_size INTEGER NOT NULL,
+         actual_batch_size INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_state_writer_live_observed
+         ON ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE} (observed_at)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         accepted_terminal_total INTEGER NOT NULL DEFAULT 0,
+         duplicate_terminal_total INTEGER NOT NULL DEFAULT 0,
+         rejected_terminal_total INTEGER NOT NULL DEFAULT 0,
+         conflicted_terminal_total INTEGER NOT NULL DEFAULT 0,
+         accepted_progress_total INTEGER NOT NULL DEFAULT 0,
+         rejected_progress_total INTEGER NOT NULL DEFAULT 0,
+         last_observed_at INTEGER
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `INSERT OR IGNORE INTO ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE} (singleton_id) VALUES (1)`,
+    );
   }
 
   private readStorageMetaSync() {
@@ -2942,6 +3059,266 @@ export class ExactReviewQueue {
         WHERE status != 'open' AND resolved_at < ?`,
       now - EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS,
     );
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} WHERE observed_at < ?`,
+      now - EXACT_REVIEW_STATE_WRITER_RETENTION_MS,
+    );
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE} WHERE observed_at < ?`,
+      now - EXACT_REVIEW_STATE_WRITER_LIVE_MS,
+    );
+  }
+
+  private recordStateWriterOperationSafely(
+    operation: StateWriterOperation | undefined,
+    rejected: boolean,
+    now: number,
+  ) {
+    try {
+      this.storage.transactionSync(() => {
+        if (rejected) {
+          this.incrementStateWriterDiagnosticSync("rejected_terminal_total");
+          return;
+        }
+        if (!operation) return;
+        const hash = payloadHash(operation);
+        const inserted = Array.from(
+          this.storage.sql.exec(
+            `INSERT OR IGNORE INTO ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE}
+             (operation_id, observed_at, mode, started_at, finished_at, wait_ms, acquire_attempts,
+              acquired, hold_ms, renewals, released, git_duration_ms, git_processes, commit_count,
+              materialized_items, configured_batch_size, actual_batch_size, batch_wait_ms, outcome, payload_hash)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             RETURNING operation_id`,
+            operation.operation_id,
+            now,
+            operation.mode,
+            Date.parse(operation.started_at),
+            Date.parse(operation.finished_at),
+            operation.wait_ms,
+            operation.acquire_attempts,
+            operation.acquired ? 1 : 0,
+            operation.hold_ms,
+            operation.renewals,
+            operation.released === null ? null : operation.released ? 1 : 0,
+            operation.git_duration_ms,
+            operation.git_processes,
+            operation.commit_count,
+            operation.materialized_items,
+            operation.configured_batch_size,
+            operation.actual_batch_size,
+            operation.batch_wait_ms,
+            operation.outcome,
+            hash,
+          ),
+        );
+        if (inserted.length) {
+          this.incrementStateWriterDiagnosticSync("accepted_terminal_total", now);
+          return;
+        }
+        const existing = Array.from(
+          this.storage.sql.exec(
+            `SELECT payload_hash FROM ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} WHERE operation_id = ?`,
+            operation.operation_id,
+          ),
+        )[0] as { payload_hash?: string } | undefined;
+        this.incrementStateWriterDiagnosticSync(
+          existing?.payload_hash === hash
+            ? "duplicate_terminal_total"
+            : "conflicted_terminal_total",
+        );
+      });
+    } catch {
+      // Completion remains authoritative if telemetry storage is unavailable.
+    }
+  }
+
+  private recordStateWriterProgressSafely(progress, now: number) {
+    try {
+      this.storage.transactionSync(() => {
+        const existing = Array.from(
+          this.storage.sql.exec(
+            `SELECT phase, sequence, observed_at FROM ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE}
+              WHERE operation_id = ?`,
+            progress.operation_id,
+          ),
+        )[0] as { phase?: string; sequence?: number; observed_at?: number } | undefined;
+        if (
+          existing &&
+          (Number(existing.sequence) >= progress.sequence ||
+            (existing.phase === progress.phase && now - Number(existing.observed_at) < 30 * 1000))
+        ) {
+          return;
+        }
+        this.storage.sql.exec(
+          `INSERT INTO ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE}
+             (operation_id, mode, phase, sequence, observed_at, configured_batch_size, actual_batch_size)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(operation_id) DO UPDATE SET
+             mode = excluded.mode, phase = excluded.phase, sequence = excluded.sequence,
+             observed_at = excluded.observed_at, configured_batch_size = excluded.configured_batch_size,
+             actual_batch_size = excluded.actual_batch_size`,
+          progress.operation_id,
+          progress.mode,
+          progress.phase,
+          progress.sequence,
+          now,
+          progress.configured_batch_size,
+          progress.actual_batch_size,
+        );
+        this.incrementStateWriterDiagnosticSync("accepted_progress_total", now);
+      });
+    } catch {
+      // Progress is deliberately best effort.
+    }
+  }
+
+  private incrementStateWriterDiagnosticSafely(column: string) {
+    try {
+      this.storage.transactionSync(() => this.incrementStateWriterDiagnosticSync(column));
+    } catch {
+      // Diagnostics must not make an endpoint fail.
+    }
+  }
+
+  private incrementStateWriterDiagnosticSync(column: string, observedAt?: number) {
+    const allowed = new Set([
+      "accepted_terminal_total",
+      "duplicate_terminal_total",
+      "rejected_terminal_total",
+      "conflicted_terminal_total",
+      "accepted_progress_total",
+      "rejected_progress_total",
+    ]);
+    if (!allowed.has(column)) return;
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE}
+          SET ${column} = ${column} + 1,
+              last_observed_at = COALESCE(?, last_observed_at)
+        WHERE singleton_id = 1`,
+      observedAt ?? null,
+    );
+  }
+
+  private stateWriterSummarySync(now: number) {
+    const diagnostics = (Array.from(
+      this.storage.sql.exec(
+        `SELECT * FROM ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE} WHERE singleton_id = 1`,
+      ),
+    )[0] || {}) as Record<string, unknown>;
+    const liveRows = Array.from(
+      this.storage.sql.exec(
+        `SELECT mode, phase, observed_at FROM ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE}
+          WHERE observed_at >= ?`,
+        now - EXACT_REVIEW_STATE_WRITER_LIVE_MS,
+      ),
+    ) as Array<{ mode: string; phase: string; observed_at: number }>;
+    const summarize = (windowMs: number) => {
+      const rows = Array.from(
+        this.storage.sql.exec(
+          `SELECT * FROM ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} WHERE finished_at >= ?`,
+          now - windowMs,
+        ),
+      ) as Array<Record<string, number | string | null>>;
+      const values = (field: string) =>
+        rows
+          .map((row) => row[field])
+          .filter((value): value is number => typeof value === "number")
+          .sort((left, right) => left - right);
+      const percentile = (field: string) => {
+        const sample = values(field);
+        const at = (ratio: number) =>
+          sample.length
+            ? sample[Math.min(sample.length - 1, Math.ceil(sample.length * ratio) - 1)]
+            : null;
+        return { p50: at(0.5), p95: at(0.95), samples: sample.length };
+      };
+      const sum = (field: string) =>
+        rows.reduce(
+          (total, row) => total + (typeof row[field] === "number" ? Number(row[field]) : 0),
+          0,
+        );
+      const commits = sum("commit_count");
+      const batch = rows.filter((row) => row.mode === "batch");
+      return {
+        operations: rows.length,
+        acquired: rows.filter((row) => row.acquired === 1).length,
+        contention_timeouts: rows.filter((row) => row.outcome === "contention_timeout").length,
+        state_commits: commits,
+        materialized_items: sum("materialized_items"),
+        items_per_commit: commits ? sum("materialized_items") / commits : null,
+        wait_ms: percentile("wait_ms"),
+        hold_ms: percentile("hold_ms"),
+        git_duration_ms: percentile("git_duration_ms"),
+        actual_batch_size: {
+          average: batch.length ? sumFor(batch, "actual_batch_size") / batch.length : null,
+          ...percentileFor(batch, "actual_batch_size"),
+        },
+        batch_wait_ms: percentileFor(batch, "batch_wait_ms"),
+        batch_fullness: batch.length
+          ? sumFor(batch, "actual_batch_size") / sumFor(batch, "configured_batch_size")
+          : null,
+      };
+    };
+    const recent = summarize(15 * 60 * 1000);
+    const modes = new Set([
+      ...liveRows.map((row) => row.mode),
+      ...(
+        Array.from(
+          this.storage.sql.exec(
+            `SELECT DISTINCT mode FROM ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} WHERE finished_at >= ?`,
+            now - 15 * 60 * 1000,
+          ),
+        ) as Array<{ mode: string }>
+      ).map((row) => row.mode),
+    ]);
+    const lastObserved = Number(diagnostics.last_observed_at || 0);
+    const lastSuccessful = Array.from(
+      this.storage.sql.exec(
+        `SELECT MAX(finished_at) AS finished_at
+           FROM ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE}
+          WHERE outcome = 'materialized'`,
+      ),
+    )[0] as { finished_at?: number } | undefined;
+    const lastSuccessfulAt = Number(lastSuccessful?.finished_at || 0);
+    return {
+      schema_version: 1,
+      collection: {
+        status: lastObserved
+          ? now - lastObserved <= 15 * 60 * 1000
+            ? "fresh"
+            : "stale"
+          : "unknown",
+        last_observed_at: lastObserved ? new Date(lastObserved).toISOString() : null,
+        rejected_total: Number(diagnostics.rejected_terminal_total || 0),
+        conflicted_total: Number(diagnostics.conflicted_terminal_total || 0),
+      },
+      mode: modes.size === 0 ? "unknown" : modes.size === 1 ? [...modes][0] : "mixed",
+      live: {
+        tracked_holding: liveRows.filter((row) => row.phase === "holding").length,
+        tracked_waiting: liveRows.filter((row) => row.phase === "waiting").length,
+        tracked_releasing: liveRows.filter((row) => row.phase === "releasing").length,
+        freshness_seconds: liveRows.length
+          ? Math.max(
+              0,
+              Math.round((now - Math.max(...liveRows.map((row) => row.observed_at))) / 1000),
+            )
+          : null,
+      },
+      last_15_minutes: recent,
+      last_60_minutes: summarize(60 * 60 * 1000),
+      last_successful_materialization_at: lastSuccessfulAt
+        ? new Date(lastSuccessfulAt).toISOString()
+        : null,
+      diagnostics: {
+        accepted_terminal_total: Number(diagnostics.accepted_terminal_total || 0),
+        duplicate_terminal_total: Number(diagnostics.duplicate_terminal_total || 0),
+        rejected_terminal_total: Number(diagnostics.rejected_terminal_total || 0),
+        conflicted_terminal_total: Number(diagnostics.conflicted_terminal_total || 0),
+        accepted_progress_total: Number(diagnostics.accepted_progress_total || 0),
+        rejected_progress_total: Number(diagnostics.rejected_progress_total || 0),
+      },
+    };
   }
 
   private publicationFlowSummarySync(now: number) {
@@ -4365,6 +4742,25 @@ export function exactReviewQueueAdmittedItems(
     admitted.push(item);
   }
   return admitted;
+}
+
+function sumFor(rows: Array<Record<string, number | string | null>>, field: string) {
+  return rows.reduce(
+    (total, row) => total + (typeof row[field] === "number" ? Number(row[field]) : 0),
+    0,
+  );
+}
+
+function percentileFor(rows: Array<Record<string, number | string | null>>, field: string) {
+  const values = rows
+    .map((row) => row[field])
+    .filter((value): value is number => typeof value === "number")
+    .sort((left, right) => left - right);
+  const at = (ratio: number) =>
+    values.length
+      ? values[Math.min(values.length - 1, Math.ceil(values.length * ratio) - 1)]
+      : null;
+  return { p50: at(0.5), p95: at(0.95), samples: values.length };
 }
 
 function exactReviewQueueStats(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -716,14 +716,18 @@ export class ExactReviewQueue {
       if ((item.claimProtocolVersion ?? 1) !== completionProtocolVersion) {
         return json({ error: "lease_protocol_not_claimed" }, 409);
       }
-      // Optional observability cannot alter a valid publication completion.
-      // Store only after the claim tuple has been authenticated.
-      this.recordStateWriterOperationSafely(
-        body.state_writer === undefined ? undefined : stateWriter,
-        body.state_writer !== undefined && !stateWriter,
-        now,
-      );
       const publicationItem = exactReviewQueueIsPublication(item);
+      // Optional observability cannot alter a valid publication completion.
+      // Accept writer telemetry only from currently claimed publication items.
+      if (publicationItem) {
+        this.recordStateWriterOperationSafely(
+          body.state_writer === undefined ? undefined : stateWriter,
+          body.state_writer !== undefined && !stateWriter,
+          now,
+        );
+      } else if (body.state_writer !== undefined) {
+        this.incrementStateWriterDiagnosticSafely("rejected_terminal_total");
+      }
       if (failureKind && !publicationItem) {
         return json({ error: "failure_kind_outside_publication" }, 400);
       }
@@ -839,6 +843,7 @@ export class ExactReviewQueue {
       const valid =
         progress &&
         item &&
+        exactReviewQueueIsPublication(item) &&
         item.state === "leased" &&
         item.leaseId === leaseId &&
         item.leaseRevision === leaseRevision &&

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2468,12 +2468,38 @@ export class ExactReviewQueue {
          conflicted_terminal_total INTEGER NOT NULL DEFAULT 0,
          accepted_progress_total INTEGER NOT NULL DEFAULT 0,
          rejected_progress_total INTEGER NOT NULL DEFAULT 0,
+         state_commits_total INTEGER NOT NULL DEFAULT 0,
+         materialized_items_total INTEGER NOT NULL DEFAULT 0,
+         contention_timeouts_total INTEGER NOT NULL DEFAULT 0,
          last_observed_at INTEGER
        ) STRICT`,
     );
+    this.ensureStateWriterDiagnosticColumnsSync();
     this.storage.sql.exec(
       `INSERT OR IGNORE INTO ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE} (singleton_id) VALUES (1)`,
     );
+  }
+
+  private ensureStateWriterDiagnosticColumnsSync() {
+    const columns = new Set(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE}')`,
+        ),
+      ).map((row) => String((row as { name?: string }).name || "")),
+    );
+    for (const column of [
+      "state_commits_total",
+      "materialized_items_total",
+      "contention_timeouts_total",
+    ]) {
+      if (!columns.has(column)) {
+        this.storage.sql.exec(
+          `ALTER TABLE ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE}
+             ADD COLUMN ${column} INTEGER NOT NULL DEFAULT 0`,
+        );
+      }
+    }
   }
 
   private readStorageMetaSync() {
@@ -3113,7 +3139,19 @@ export class ExactReviewQueue {
           ),
         );
         if (inserted.length) {
-          this.incrementStateWriterDiagnosticSync("accepted_terminal_total", now);
+          this.storage.sql.exec(
+            `UPDATE ${EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE}
+                SET accepted_terminal_total = accepted_terminal_total + 1,
+                    state_commits_total = state_commits_total + ?,
+                    materialized_items_total = materialized_items_total + ?,
+                    contention_timeouts_total = contention_timeouts_total + ?,
+                    last_observed_at = ?
+              WHERE singleton_id = 1`,
+            operation.commit_count,
+            operation.materialized_items,
+            operation.outcome === "contention_timeout" ? 1 : 0,
+            now,
+          );
           return;
         }
         const existing = Array.from(
@@ -3317,6 +3355,9 @@ export class ExactReviewQueue {
         conflicted_terminal_total: Number(diagnostics.conflicted_terminal_total || 0),
         accepted_progress_total: Number(diagnostics.accepted_progress_total || 0),
         rejected_progress_total: Number(diagnostics.rejected_progress_total || 0),
+        state_commits_total: Number(diagnostics.state_commits_total || 0),
+        materialized_items_total: Number(diagnostics.materialized_items_total || 0),
+        contention_timeouts_total: Number(diagnostics.contention_timeouts_total || 0),
       },
     };
   }

--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -179,9 +179,9 @@ export function stateWriterHistorySample(value: unknown): StateWriterHistorySamp
     tracked_waiting: nonNegativeInteger(live.tracked_waiting) ?? 0,
     tracked_releasing: nonNegativeInteger(live.tracked_releasing) ?? 0,
     accepted_operations_total: nonNegativeInteger(diagnostics.accepted_terminal_total) ?? 0,
-    state_commits_total: nonNegativeInteger(window.state_commits) ?? 0,
-    materialized_items_total: nonNegativeInteger(window.materialized_items) ?? 0,
-    contention_timeouts_total: nonNegativeInteger(window.contention_timeouts) ?? 0,
+    state_commits_total: nonNegativeInteger(diagnostics.state_commits_total) ?? 0,
+    materialized_items_total: nonNegativeInteger(diagnostics.materialized_items_total) ?? 0,
+    contention_timeouts_total: nonNegativeInteger(diagnostics.contention_timeouts_total) ?? 0,
     wait_ms: historyPercentiles(window.wait_ms),
     hold_ms: historyPercentiles(window.hold_ms),
     last_successful_materialization_at:

--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -36,6 +36,7 @@ export type HealthHistorySample = {
   oldest_running_minutes?: number;
   collection_ok?: boolean;
   exact_review?: ExactReviewHistorySample;
+  state_writer?: StateWriterHistorySample;
 };
 
 export type ExactReviewHistorySample = {
@@ -49,6 +50,21 @@ export type ExactReviewLaneHistorySample = {
   enqueued_total?: number;
   completed_total?: number;
   shed_total?: number;
+};
+
+export type StateWriterHistorySample = {
+  collection_ok: boolean;
+  mode?: "single_item" | "batch" | "mixed" | "unknown";
+  tracked_holding?: number;
+  tracked_waiting?: number;
+  tracked_releasing?: number;
+  accepted_operations_total?: number;
+  state_commits_total?: number;
+  materialized_items_total?: number;
+  contention_timeouts_total?: number;
+  wait_ms?: { p50: number | null; p95: number | null; samples: number };
+  hold_ms?: { p50: number | null; p95: number | null; samples: number };
+  last_successful_materialization_at?: string | null;
 };
 
 export function summarizeOperationalHealth(
@@ -115,7 +131,7 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
   const hasOperationalFields = ["status", "collection_ok", ...countFields].some((field) =>
     Object.hasOwn(sample, field),
   );
-  let operational: Omit<HealthHistorySample, "at" | "exact_review"> = {};
+  let operational: Omit<HealthHistorySample, "at" | "exact_review" | "state_writer"> = {};
   if (hasOperationalFields) {
     const rawStatus = String(sample.status || "");
     if (!["healthy", "degraded", "stalled", "unknown"].includes(rawStatus)) return null;
@@ -136,11 +152,42 @@ export function normalizeHealthHistorySample(value: unknown): HealthHistorySampl
     };
   }
   const exactReview = normalizeExactReviewHistorySample(sample.exact_review);
-  if (!hasOperationalFields && !exactReview) return null;
+  const stateWriter = normalizeStateWriterHistorySample(sample.state_writer);
+  if (!hasOperationalFields && !exactReview && !stateWriter) return null;
   return {
     at,
     ...operational,
     ...(exactReview ? { exact_review: exactReview } : {}),
+    ...(stateWriter ? { state_writer: stateWriter } : {}),
+  };
+}
+
+export function stateWriterHistorySample(value: unknown): StateWriterHistorySample {
+  const writer = objectValue(value);
+  const collection = objectValue(writer.collection);
+  const live = objectValue(writer.live);
+  const window = objectValue(writer.last_15_minutes);
+  const diagnostics = objectValue(writer.diagnostics);
+  const mode = ["single_item", "batch", "mixed", "unknown"].includes(String(writer.mode))
+    ? (writer.mode as StateWriterHistorySample["mode"])
+    : "unknown";
+  const collectionOk = collection.status === "fresh";
+  return {
+    collection_ok: collectionOk,
+    mode,
+    tracked_holding: nonNegativeInteger(live.tracked_holding) ?? 0,
+    tracked_waiting: nonNegativeInteger(live.tracked_waiting) ?? 0,
+    tracked_releasing: nonNegativeInteger(live.tracked_releasing) ?? 0,
+    accepted_operations_total: nonNegativeInteger(diagnostics.accepted_terminal_total) ?? 0,
+    state_commits_total: nonNegativeInteger(window.state_commits) ?? 0,
+    materialized_items_total: nonNegativeInteger(window.materialized_items) ?? 0,
+    contention_timeouts_total: nonNegativeInteger(window.contention_timeouts) ?? 0,
+    wait_ms: historyPercentiles(window.wait_ms),
+    hold_ms: historyPercentiles(window.hold_ms),
+    last_successful_materialization_at:
+      typeof writer.last_successful_materialization_at === "string"
+        ? writer.last_successful_materialization_at
+        : null,
   };
 }
 
@@ -170,6 +217,64 @@ function normalizeExactReviewHistorySample(value: unknown): ExactReviewHistorySa
     review,
     publication,
   };
+}
+
+function normalizeStateWriterHistorySample(value: unknown): StateWriterHistorySample | null {
+  if (value === undefined) return null;
+  const sample = objectValue(value);
+  if (typeof sample.collection_ok !== "boolean") return null;
+  if (!sample.collection_ok) return { collection_ok: false };
+  const mode = ["single_item", "batch", "mixed", "unknown"].includes(String(sample.mode))
+    ? (sample.mode as StateWriterHistorySample["mode"])
+    : null;
+  const integerFields = [
+    "tracked_holding",
+    "tracked_waiting",
+    "tracked_releasing",
+    "accepted_operations_total",
+    "state_commits_total",
+    "materialized_items_total",
+    "contention_timeouts_total",
+  ] as const;
+  const values = Object.fromEntries(
+    integerFields.map((field) => [field, optionalNonNegativeInteger(sample[field])]),
+  ) as Record<(typeof integerFields)[number], number | undefined | null>;
+  if (!mode || Object.values(values).some((entry) => entry === null)) return null;
+  const wait = normalizeHistoryPercentiles(sample.wait_ms);
+  const hold = normalizeHistoryPercentiles(sample.hold_ms);
+  if (!wait || !hold) return null;
+  const lastSuccessfulMaterialization =
+    sample.last_successful_materialization_at === null ||
+    (typeof sample.last_successful_materialization_at === "string" &&
+      Number.isFinite(Date.parse(sample.last_successful_materialization_at)))
+      ? (sample.last_successful_materialization_at as string | null)
+      : null;
+  return {
+    collection_ok: true,
+    mode,
+    ...values,
+    wait_ms: wait,
+    hold_ms: hold,
+    last_successful_materialization_at: lastSuccessfulMaterialization,
+  };
+}
+
+function historyPercentiles(value: unknown) {
+  const input = objectValue(value);
+  return {
+    p50: optionalNonNegativeInteger(input.p50) ?? null,
+    p95: optionalNonNegativeInteger(input.p95) ?? null,
+    samples: nonNegativeInteger(input.samples) ?? 0,
+  };
+}
+
+function normalizeHistoryPercentiles(value: unknown) {
+  if (value === undefined) return { p50: null, p95: null, samples: 0 };
+  const input = objectValue(value);
+  const p50 = input.p50 === null ? null : optionalNonNegativeInteger(input.p50);
+  const p95 = input.p95 === null ? null : optionalNonNegativeInteger(input.p95);
+  const samples = nonNegativeInteger(input.samples);
+  return p50 === undefined || p95 === undefined || samples === null ? null : { p50, p95, samples };
 }
 
 function queueLaneHistorySample(value: unknown, includeShed: boolean) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8858,6 +8858,33 @@ function renderSystemMap(data) {
     ? "Live jobs with " + fallbacks + " workflow fallback" + (fallbacks === 1 ? "" : "s")
     : "Live GitHub job and step telemetry";
 }
+function stateWriterHistorySamples() {
+  return healthHistorySamples.flatMap((sample) => {
+    const writer = sample?.state_writer;
+    if (!writer || writer.collection_ok !== true) return [];
+    return [{
+      at: sample.at,
+      accepted: Number(writer.accepted_operations_total || 0),
+      commits: Number(writer.state_commits_total || 0),
+      items: Number(writer.materialized_items_total || 0),
+      wait: writer.wait_ms,
+      hold: writer.hold_ms,
+    }];
+  });
+}
+
+function stateWriterRateFromHistory(samples, field) {
+  if (samples.length < 2) return null;
+  let start = samples[0];
+  for (let index = 1; index < samples.length; index += 1) {
+    if (samples[index][field] < start[field]) start = samples[index];
+  }
+  const end = samples[samples.length - 1];
+  const elapsedHours = (Date.parse(end.at) - Date.parse(start.at)) / 3_600_000;
+  if (!(elapsedHours > 0) || end[field] < start[field]) return null;
+  return Math.round(((end[field] - start[field]) / elapsedHours) * 10) / 10;
+}
+
 function renderStateWriter(writer) {
   const target = document.getElementById("state-writer-health");
   if (!target) return;
@@ -8869,6 +8896,20 @@ function renderStateWriter(writer) {
   const live = writer.live || {};
   const lease = writer.global_lease || {};
   const hour = writer.last_60_minutes || {};
+  const history = stateWriterHistorySamples();
+  const latestHistory = history.at(-1);
+  const itemsPerHour = stateWriterRateFromHistory(history, "items");
+  const commitsPerHour = stateWriterRateFromHistory(history, "commits");
+  const itemsPerCommit =
+    history.length >= 2 &&
+    latestHistory &&
+    history[0] &&
+    latestHistory.commits > history[0].commits
+      ? Math.round(((latestHistory.items - history[0].items) / (latestHistory.commits - history[0].commits)) * 100) / 100
+      : hour.items_per_commit;
+  const wait = latestHistory?.wait || hour.wait_ms;
+  const hold = latestHistory?.hold || hour.hold_ms;
+  const rangeLabel = activeHealthRange === "7d" ? "7d" : activeHealthRange;
   const mode =
     writer.mode === "mixed"
       ? "Mixed · legacy draining + batch active"
@@ -8880,18 +8921,21 @@ function renderStateWriter(writer) {
   const metric = (value, fallback = "unknown") => value === null || value === undefined ? fallback : value;
   const percentile = (value) =>
     value?.samples ? "p50 " + metric(value.p50) + "ms · p95 " + metric(value.p95) + "ms · n=" + value.samples : "unknown";
+  const itemTrend = history.map((sample) => ({ at: sample.at, pending: sample.items }));
   target.innerHTML =
     '<section class="exact-lane">' +
-    '<h3>State writer <span class="muted">' + mode + " · " + metric(collection.status) + "</span></h3>" +
+    '<h3>State writer <span class="muted">' + mode + " · " + metric(collection.status) + " · " + esc(rangeLabel) + "</span></h3>" +
     '<p>Global state lease: <strong>' + metric(lease.status) + '</strong> · 1 writer maximum</p>' +
-    '<p>Tracked exact publishers: ' + metric(live.tracked_holding) + " holding · " + metric(live.tracked_waiting) + " waiting</p>" +
+    '<p>Tracked exact publishers: ' + metric(live.tracked_holding, "unknown") + " holding · " + metric(live.tracked_waiting, "unknown") + " waiting</p>" +
+    exactReviewTrend(itemTrend, "Materialized items") +
     '<dl class="lane-metrics">' +
-    "<div><dt>Materialized</dt><dd>" + metric(hour.materialized_items) + " items/hour</dd></div>" +
-    "<div><dt>State commits</dt><dd>" + metric(hour.state_commits) + "/hour</dd></div>" +
-    "<div><dt>Items / commit</dt><dd>" + metric(hour.items_per_commit) + "</dd></div>" +
-    "<div><dt>Lease wait</dt><dd>" + percentile(hour.wait_ms) + "</dd></div>" +
-    "<div><dt>Lease hold</dt><dd>" + percentile(hour.hold_ms) + "</dd></div>" +
+    "<div><dt>Materialized</dt><dd>" + metric(itemsPerHour ?? hour.materialized_items) + " items/hour</dd></div>" +
+    "<div><dt>State commits</dt><dd>" + metric(commitsPerHour ?? hour.state_commits) + "/hour</dd></div>" +
+    "<div><dt>Items / commit</dt><dd>" + metric(itemsPerCommit) + "</dd></div>" +
+    "<div><dt>Lease wait</dt><dd>" + percentile(wait) + "</dd></div>" +
+    "<div><dt>Lease hold</dt><dd>" + percentile(hold) + "</dd></div>" +
     "</dl>" +
+    '<p class="muted">Live holding/waiting come from current progress. Throughput uses the selected ' + esc(rangeLabel) + " history when available; otherwise the rolling hour.</p>" +
     '<p class="muted">Publication workflows can run concurrently, but they feed one serialized state-ref writer.</p>' +
     "</section>";
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -10,6 +10,7 @@ import {
   exactReviewHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
+  stateWriterHistorySample,
   summarizeOperationalHealth,
 } from "./operational-health.ts";
 import { TRIAGE_ROUTING_GROUPS, triageRoutingGroupsForLabels } from "./triage-routing-groups.ts";
@@ -98,6 +99,9 @@ const HEALTH_HISTORY_KEY_PREFIX = "health-history:";
 const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
 const CLAWSWEEPER_STATE_REPO = "openclaw/clawsweeper-state";
 const CLAWSWEEPER_STATE_REF = "state";
+const STATE_WRITER_LEASE_CACHE_MS = 20_000;
+const STATE_WRITER_LEASE_TTL_MAX_MS = 2 * 60_000;
+let stateWriterLeaseCache: { expiresAt: number; value: unknown } | null = null;
 const DEFAULT_CRABFLEET_URL = "https://crabfleet.openclaw.ai";
 const CLUSTER_REPAIR_INTAKE_WORKFLOW = "repair-cluster-intake.yml";
 const CLAWSWEEPER_ALLOWED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
@@ -506,6 +510,11 @@ export default {
     // the review job that runs Codex over untrusted content.
     if (url.pathname === "/internal/exact-review/heartbeat" && request.method === "POST")
       return exactReviewQueueRequest(env, "/heartbeat", request);
+    if (
+      url.pathname === "/internal/exact-review/state-writer-progress" &&
+      request.method === "POST"
+    )
+      return exactReviewQueueRequest(env, "/state-writer-progress", request);
     if (url.pathname === "/internal/exact-review/complete" && request.method === "POST")
       return exactReviewQueueRequest(env, "/complete", request);
     if (url.pathname === "/internal/exact-review/claimed-runs" && request.method === "POST")
@@ -645,6 +654,7 @@ async function recordScheduledHealthSample(env) {
   await appendHealthHistorySample(env, {
     at: new Date().toISOString(),
     exact_review: exactReviewHistorySample(queue),
+    state_writer: stateWriterHistorySample(objectValue(queue).state_writer),
   });
 }
 
@@ -2043,6 +2053,19 @@ async function attachExactReviewQueueStatus(snapshot, env) {
   } catch (error) {
     exactReviewQueueError = error instanceof Error ? error.message : String(error);
   }
+  if (
+    exactReviewQueue &&
+    typeof exactReviewQueue === "object" &&
+    exactReviewQueue.state_writer &&
+    typeof exactReviewQueue.state_writer === "object"
+  ) {
+    const stateWriterLease = await cachedStateWriterLeaseProbe(env);
+    const writer = objectValue(exactReviewQueue.state_writer);
+    exactReviewQueue = {
+      ...exactReviewQueue,
+      state_writer: { ...writer, global_lease: stateWriterLease },
+    };
+  }
   const attached = {
     ...snapshot,
     exact_review_queue: exactReviewQueue,
@@ -2052,6 +2075,52 @@ async function attachExactReviewQueueStatus(snapshot, env) {
     },
   };
   return { ...attached, dashboard_health: summarizeDashboardHealth(attached) };
+}
+
+async function cachedStateWriterLeaseProbe(env) {
+  if (stateWriterLeaseCache && stateWriterLeaseCache.expiresAt > Date.now()) {
+    return stateWriterLeaseCache.value;
+  }
+  const observedAt = new Date().toISOString();
+  let value: unknown;
+  try {
+    const repo = String(env.CLAWSWEEPER_STATE_REPO || CLAWSWEEPER_STATE_REPO);
+    const branch = String(env.CLAWSWEEPER_STATE_REF || CLAWSWEEPER_STATE_REF);
+    const ref = `heads/clawsweeper-publish-lease/${branch}`;
+    const refPayload = await githubJson(env, `/repos/${repo}/git/ref/${ref}`);
+    const sha = String(objectValue(refPayload.object).sha || "");
+    if (!/^[a-f0-9]{40,64}$/i.test(sha)) throw new Error("invalid lease ref");
+    const commit = objectValue(await githubJson(env, `/repos/${repo}/git/commits/${sha}`));
+    const committedAt = Date.parse(String(objectValue(commit.committer).date || ""));
+    const message = String(objectValue(commit).message || "");
+    const advertised = Number(/^ttl_ms: (\d+)$/m.exec(message)?.[1] || "");
+    const ttlMs =
+      Number.isSafeInteger(advertised) && advertised > 0
+        ? Math.min(advertised, STATE_WRITER_LEASE_TTL_MAX_MS)
+        : STATE_WRITER_LEASE_TTL_MAX_MS;
+    const expiresAt = Number.isFinite(committedAt) ? committedAt + ttlMs : NaN;
+    value =
+      Number.isFinite(expiresAt) && expiresAt > Date.now()
+        ? {
+            status: "held",
+            expires_at: new Date(expiresAt).toISOString(),
+            observed_at: observedAt,
+            freshness: "fresh",
+          }
+        : {
+            status: "free",
+            expires_at: Number.isFinite(expiresAt) ? new Date(expiresAt).toISOString() : null,
+            observed_at: observedAt,
+            freshness: "stale",
+          };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    value = /404|not found/i.test(message)
+      ? { status: "free", expires_at: null, observed_at: observedAt, freshness: "fresh" }
+      : { status: "unknown", expires_at: null, observed_at: observedAt, freshness: "unknown" };
+  }
+  stateWriterLeaseCache = { expiresAt: Date.now() + STATE_WRITER_LEASE_CACHE_MS, value };
+  return value;
 }
 
 async function triageSnapshot(env) {
@@ -8176,6 +8245,7 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
       </div>
     </div>
     <div class="exact-lanes" id="exact-review-lanes" aria-live="polite"></div>
+    <div id="state-writer-health" aria-live="polite"></div>
     <h3 class="overview-section-title">Handoff Health</h3>
     <div id="exact-review-handoff" aria-live="polite"></div>
     <div id="apply-health"></div>
@@ -8669,6 +8739,7 @@ function formatAgeMinutes(value) {
 async function loadHealthHistory(range, force) {
   if (!force && range === activeHealthRange && Date.now() - healthHistoryLoadedAt < 60000) {
     renderExactReviewLanes(lastData?.exact_review_queue);
+    renderStateWriter(lastData?.exact_review_queue?.state_writer);
     return;
   }
   activeHealthRange = range;
@@ -8685,6 +8756,7 @@ async function loadHealthHistory(range, force) {
     healthHistorySamples = [];
   }
   renderExactReviewLanes(lastData?.exact_review_queue);
+  renderStateWriter(lastData?.exact_review_queue?.state_writer);
 }
 
 function workerGroup(worker) {
@@ -8786,6 +8858,44 @@ function renderSystemMap(data) {
     ? "Live jobs with " + fallbacks + " workflow fallback" + (fallbacks === 1 ? "" : "s")
     : "Live GitHub job and step telemetry";
 }
+function renderStateWriter(writer) {
+  const target = document.getElementById("state-writer-health");
+  if (!target) return;
+  if (!writer || !writer.collection) {
+    target.innerHTML = '<section class="exact-lane"><h3>State writer</h3><p class="muted">Unavailable — writer telemetry has not been collected.</p></section>';
+    return;
+  }
+  const collection = writer.collection || {};
+  const live = writer.live || {};
+  const lease = writer.global_lease || {};
+  const hour = writer.last_60_minutes || {};
+  const mode =
+    writer.mode === "mixed"
+      ? "Mixed · legacy draining + batch active"
+      : writer.mode === "batch"
+        ? "Batch"
+        : writer.mode === "single_item"
+          ? "Single-item"
+          : "Unknown";
+  const metric = (value, fallback = "unknown") => value === null || value === undefined ? fallback : value;
+  const percentile = (value) =>
+    value?.samples ? "p50 " + metric(value.p50) + "ms · p95 " + metric(value.p95) + "ms · n=" + value.samples : "unknown";
+  target.innerHTML =
+    '<section class="exact-lane">' +
+    '<h3>State writer <span class="muted">' + mode + " · " + metric(collection.status) + "</span></h3>" +
+    '<p>Global state lease: <strong>' + metric(lease.status) + '</strong> · 1 writer maximum</p>' +
+    '<p>Tracked exact publishers: ' + metric(live.tracked_holding) + " holding · " + metric(live.tracked_waiting) + " waiting</p>" +
+    '<dl class="lane-metrics">' +
+    "<div><dt>Materialized</dt><dd>" + metric(hour.materialized_items) + " items/hour</dd></div>" +
+    "<div><dt>State commits</dt><dd>" + metric(hour.state_commits) + "/hour</dd></div>" +
+    "<div><dt>Items / commit</dt><dd>" + metric(hour.items_per_commit) + "</dd></div>" +
+    "<div><dt>Lease wait</dt><dd>" + percentile(hour.wait_ms) + "</dd></div>" +
+    "<div><dt>Lease hold</dt><dd>" + percentile(hour.hold_ms) + "</dd></div>" +
+    "</dl>" +
+    '<p class="muted">Publication workflows can run concurrently, but they feed one serialized state-ref writer.</p>' +
+    "</section>";
+}
+
 function renderExactReviewLanes(queue) {
   const target = document.getElementById("exact-review-lanes");
   if (!target) return;
@@ -9105,6 +9215,7 @@ function renderDashboard(data, note) {
   populateReviewRepoFilter(data.source?.target_repositories || []);
   renderSystemMap(data);
   renderExactReviewLanes(data.exact_review_queue);
+  renderStateWriter(data.exact_review_queue?.state_writer);
   renderExactReviewHandoff(data.exact_review_queue);
   renderApplyHealth(data);
   renderAutomaticWork(data.automatic_work || []);

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2086,9 +2086,28 @@ async function cachedStateWriterLeaseProbe(env) {
   try {
     const repo = String(env.CLAWSWEEPER_STATE_REPO || CLAWSWEEPER_STATE_REPO);
     const branch = String(env.CLAWSWEEPER_STATE_REF || CLAWSWEEPER_STATE_REF);
+    // Prove repository access before treating a lease-ref 404 as "free". GitHub
+    // also returns 404 for private repos the token cannot see.
+    await githubJson(env, `/repos/${repo}`);
     const ref = `heads/clawsweeper-publish-lease/${branch}`;
-    const refPayload = await githubJson(env, `/repos/${repo}/git/ref/${ref}`);
-    const sha = String(objectValue(refPayload.object).sha || "");
+    let refPayload: unknown;
+    try {
+      refPayload = await githubJson(env, `/repos/${repo}/git/ref/${ref}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (/404|not found/i.test(message)) {
+        value = {
+          status: "free",
+          expires_at: null,
+          observed_at: observedAt,
+          freshness: "fresh",
+        };
+        stateWriterLeaseCache = { expiresAt: Date.now() + STATE_WRITER_LEASE_CACHE_MS, value };
+        return value;
+      }
+      throw error;
+    }
+    const sha = String(objectValue(objectValue(refPayload).object).sha || "");
     if (!/^[a-f0-9]{40,64}$/i.test(sha)) throw new Error("invalid lease ref");
     const commit = objectValue(await githubJson(env, `/repos/${repo}/git/commits/${sha}`));
     const committedAt = Date.parse(String(objectValue(commit.committer).date || ""));
@@ -2113,11 +2132,8 @@ async function cachedStateWriterLeaseProbe(env) {
             observed_at: observedAt,
             freshness: "stale",
           };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "";
-    value = /404|not found/i.test(message)
-      ? { status: "free", expires_at: null, observed_at: observedAt, freshness: "fresh" }
-      : { status: "unknown", expires_at: null, observed_at: observedAt, freshness: "unknown" };
+  } catch {
+    value = { status: "unknown", expires_at: null, observed_at: observedAt, freshness: "unknown" };
   }
   stateWriterLeaseCache = { expiresAt: Date.now() + STATE_WRITER_LEASE_CACHE_MS, value };
   return value;
@@ -8873,13 +8889,21 @@ function stateWriterHistorySamples() {
   });
 }
 
-function stateWriterRateFromHistory(samples, field) {
+function stateWriterHistorySegment(samples, field) {
   if (samples.length < 2) return null;
-  let start = samples[0];
+  let startIndex = 0;
   for (let index = 1; index < samples.length; index += 1) {
-    if (samples[index][field] < start[field]) start = samples[index];
+    if (samples[index][field] < samples[index - 1][field]) startIndex = index;
   }
-  const end = samples[samples.length - 1];
+  if (samples.length - startIndex < 2) return null;
+  return samples.slice(startIndex);
+}
+
+function stateWriterRateFromHistory(samples, field) {
+  const segment = stateWriterHistorySegment(samples, field);
+  if (!segment) return null;
+  const start = segment[0];
+  const end = segment[segment.length - 1];
   const elapsedHours = (Date.parse(end.at) - Date.parse(start.at)) / 3_600_000;
   if (!(elapsedHours > 0) || end[field] < start[field]) return null;
   return Math.round(((end[field] - start[field]) / elapsedHours) * 10) / 10;
@@ -8900,16 +8924,23 @@ function renderStateWriter(writer) {
   const latestHistory = history.at(-1);
   const itemsPerHour = stateWriterRateFromHistory(history, "items");
   const commitsPerHour = stateWriterRateFromHistory(history, "commits");
+  const commitSegment = stateWriterHistorySegment(history, "commits");
   const itemsPerCommit =
-    history.length >= 2 &&
-    latestHistory &&
-    history[0] &&
-    latestHistory.commits > history[0].commits
-      ? Math.round(((latestHistory.items - history[0].items) / (latestHistory.commits - history[0].commits)) * 100) / 100
+    commitSegment &&
+    commitSegment.length >= 2 &&
+    commitSegment[commitSegment.length - 1].commits > commitSegment[0].commits
+      ? Math.round(
+          ((commitSegment[commitSegment.length - 1].items - commitSegment[0].items) /
+            (commitSegment[commitSegment.length - 1].commits - commitSegment[0].commits)) *
+            100,
+        ) / 100
       : hour.items_per_commit;
   const wait = latestHistory?.wait || hour.wait_ms;
   const hold = latestHistory?.hold || hour.hold_ms;
   const rangeLabel = activeHealthRange === "7d" ? "7d" : activeHealthRange;
+  const liveFresh =
+    collection.status === "fresh" &&
+    (live.freshness_seconds == null || Number(live.freshness_seconds) <= 90);
   const mode =
     writer.mode === "mixed"
       ? "Mixed · legacy draining + batch active"
@@ -8926,7 +8957,11 @@ function renderStateWriter(writer) {
     '<section class="exact-lane">' +
     '<h3>State writer <span class="muted">' + mode + " · " + metric(collection.status) + " · " + esc(rangeLabel) + "</span></h3>" +
     '<p>Global state lease: <strong>' + metric(lease.status) + '</strong> · 1 writer maximum</p>' +
-    '<p>Tracked exact publishers: ' + metric(live.tracked_holding, "unknown") + " holding · " + metric(live.tracked_waiting, "unknown") + " waiting</p>" +
+    '<p>Tracked exact publishers: ' +
+    (liveFresh
+      ? metric(live.tracked_holding, "unknown") + " holding · " + metric(live.tracked_waiting, "unknown") + " waiting"
+      : "unknown holding · unknown waiting") +
+    "</p>" +
     exactReviewTrend(itemTrend, "Materialized items") +
     '<dl class="lane-metrics">' +
     "<div><dt>Materialized</dt><dd>" + metric(itemsPerHour ?? hour.materialized_items) + " items/hour</dd></div>" +
@@ -8935,7 +8970,7 @@ function renderStateWriter(writer) {
     "<div><dt>Lease wait</dt><dd>" + percentile(wait) + "</dd></div>" +
     "<div><dt>Lease hold</dt><dd>" + percentile(hold) + "</dd></div>" +
     "</dl>" +
-    '<p class="muted">Live holding/waiting come from current progress. Throughput uses the selected ' + esc(rangeLabel) + " history when available; otherwise the rolling hour.</p>" +
+    '<p class="muted">Live holding/waiting require fresh progress. Throughput uses the selected ' + esc(rangeLabel) + " history when available; otherwise the rolling hour.</p>" +
     '<p class="muted">Publication workflows can run concurrently, but they feed one serialized state-ref writer.</p>' +
     "</section>";
 }

--- a/docs/state-writer-observability-plan.md
+++ b/docs/state-writer-observability-plan.md
@@ -1,0 +1,1044 @@
+# State writer observability plan
+
+**Status:** proposed, observability only  
+**Incident:** CSW-049  
+**Related implementation plan:**
+[`docs/state-publication-batching-plan.md`](./state-publication-batching-plan.md)
+
+## Decision
+
+Add a separate **State writer** panel to the live dashboard. Do not rename or
+reinterpret the existing **Result publication** panel.
+
+The two panels answer different questions:
+
+| Panel              | Question answered                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Result publication | How many publication queue items and workflows are pending, active, retrying, superseded, or dead-lettered?                          |
+| State writer       | How many real state-ref writers exist, how long they wait and hold the state lease, and how many items each Git commit materializes? |
+
+The panel and telemetry contract must support both publication modes from the
+first release:
+
+| Stage            | Writer mode   | Expected interpretation                                                                                                    |
+| ---------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Before batching  | `single_item` | One successful writer operation normally materializes at most one item in one state commit.                                |
+| Batching rollout | `mixed`       | Already-running single-item workflows drain while the batch writer begins operating. Keep the modes separate in telemetry. |
+| After batching   | `batch`       | State writes remain serial, but one writer operation may materialize several items in one state commit.                    |
+
+This is one observability design, not a dashboard that must be redesigned after
+batching. The batch publisher must populate the same versioned contract with a
+larger `actual_batch_size` and `materialized_items` value.
+
+## Delivery coordination
+
+Treat this as an independent task and development branch. It can be developed
+in parallel with publication batching because it changes observation, not queue
+or writer behavior.
+
+Parallel development still needs one explicit integration rule:
+
+1. Freeze the telemetry v1 field meanings in this document before either task
+   changes them.
+2. Keep the observability implementation additive and batching disabled.
+3. Prefer merging the observability pull request first.
+4. Rebase the batching branch once onto that merge and make the batch committer
+   populate the established recorder instead of replacing its hooks.
+5. Do not develop a second batch-only dashboard schema.
+
+The tasks may be coded concurrently; only their final integration is ordered.
+The batch ownership and Git primitive proofs can proceed without waiting for UI
+work, while production batch enablement must wait until the writer telemetry is
+available.
+
+If parallel development is impractical because the same implementer cannot
+safely manage conflicts in `git-publish.ts`, `sweep.yml`, and the queue Durable
+Object, use this serial fallback:
+
+```text
+state-writer observability
+  -> batching PR 1: durable batch ownership
+  -> batching PR 2: multi-item Git primitive
+  -> batching PR 3: end-to-end batch publisher
+  -> batching PR 4: production enablement
+```
+
+Observability goes first in the serial fallback. That produces a measured
+single-item baseline and lets every later batch pull request use one stable
+contract. Do not postpone observability until after production batching, because
+that would remove the before/after evidence needed for the rollout decision.
+
+## Why this panel is needed
+
+The current dashboard can show, for example, `50 of 50 active` under **Result
+publication**. That number is publication workflow admission. It is not Git
+write concurrency.
+
+On current production `main`, ordinary state-branch mutations coordinate on one
+state publish lease. CSW-049 observed successful holders keeping that lease for
+roughly 49–71 seconds while dozens of publication workflows waited. Increasing
+the publication lane to 50 therefore increased waiting and retries without
+creating 50 state writers.
+
+The existing dashboard exposes queue pressure well, but it cannot directly
+answer these incident questions:
+
+- Is the global state lease free or held?
+- How many exact-result publishers are currently waiting for it?
+- What are lease wait and hold p50/p95?
+- How many state commits are produced per hour?
+- How many items are materialized per commit?
+- After batching, is useful item throughput increasing even if commits/hour
+  decreases?
+
+The incident handoff also showed that a GitHub review comment may become visible
+before durable state publication finishes. Therefore this panel must measure
+state materialization, not infer it from GitHub-visible comments or whole
+workflow conclusions.
+
+## Scope
+
+This task includes:
+
+- a small, versioned state-writer telemetry contract;
+- structured lease and Git publication measurement on the exact-result path;
+- best-effort live writer progress reporting;
+- durable, bounded telemetry storage in the existing exact-review SQLite
+  Durable Object;
+- current and historical state-writer summaries in dashboard APIs;
+- a standalone dashboard panel with single-item, mixed, batch, stale, and
+  unavailable states;
+- tests for validation, deduplication, history compatibility, rendering, and
+  the batch transition.
+
+## Non-goals
+
+This task must not:
+
+- enable publication batching;
+- change publication capacity, dispatch, retry, timeout, lease, cooldown, or
+  dead-letter behavior;
+- change the state tree, record tuple, flat `items/` or `closed/` layouts;
+- move authoritative state into SQLite;
+- replay, resolve, delete, or reclassify dead letters;
+- make telemetry delivery a prerequisite for publication completion;
+- parse GitHub Actions log text to derive metrics;
+- expose the raw state-lease owner UUID, tokens, error messages, or queue lease
+  capabilities on a public API;
+- claim that exact-result progress covers every ordinary state-branch writer.
+
+The first version tracks exact-result publishers in detail because that is the
+incident-dominant queue and already has a durable identity and completion
+endpoint. Global lease occupancy is observed separately from the state repo, so
+the UI can still show that another ordinary writer is holding the one shared
+lease.
+
+## Current implementation entry points
+
+Implement against the latest `origin/main`, not only the current working-tree
+version. The state publish lease used in production is present on `origin/main`
+in `src/repair/git-publish.ts`.
+
+| Responsibility                            | Current entry point                                                                                                                                                                        |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| State lease acquire, renew, and release   | `src/repair/git-publish.ts`: `withStatePublishLease`, `acquireStatePublishLease`, renewal and release helpers                                                                              |
+| Existing Git process/duration log metrics | `src/repair/git-publish.ts`: `GitPublishMetrics`, `recordGitProcess`, `publishMainCommit`                                                                                                  |
+| Exact-result state mutation               | `src/repair/publish-event-result.ts`: the `withStatePublishLease` block around bounded record-tuple publication                                                                            |
+| Workflow result export                    | `.github/workflows/sweep.yml`: `publish-event-result` and `exact-review-publication-result` steps                                                                                          |
+| Durable completion request                | `.github/workflows/sweep.yml`: `Complete durable exact review publication` posting to `/internal/exact-review/complete`                                                                    |
+| Queue completion and SQLite metrics       | `dashboard/exact-review-queue.ts`: `/complete`, `/stats`, metric tables and bounded pruning                                                                                                |
+| Public status composition                 | `dashboard/worker.ts`: `exactReviewQueueStatusSnapshot`, `attachExactReviewQueueStatus`                                                                                                    |
+| Five-minute history                       | `dashboard/worker.ts`: `recordScheduledHealthSample`, `appendHealthHistorySample`                                                                                                          |
+| History normalization                     | `dashboard/operational-health.ts`: `HealthHistorySample`, `exactReviewHistorySample`, `normalizeHealthHistorySample`                                                                       |
+| Existing lane UI                          | `dashboard/worker.ts`: `id="exact-review-lanes"`, `loadHealthHistory`, `renderExactReviewLanes`                                                                                            |
+| Primary tests                             | `test/repair/git-publish.test.ts`, `test/repair/publish-event-result.test.ts`, `test/sweep-workflow.test.ts`, `test/dashboard-worker.test.ts`, `test/dashboard-operational-health.test.ts` |
+
+Do not duplicate the lease algorithm in dashboard code. Instrument the existing
+lease implementation and keep its behavior unchanged.
+
+## Data flow
+
+```text
+exact-result publisher
+  -> state lease recorder in git-publish.ts
+  -> optional best-effort live progress event
+  -> compact terminal state_writer object in queue completion payload
+  -> exact-review SQLite telemetry tables
+  -> /stats current and rolling summaries
+  -> five-minute health-history sample
+  -> standalone State writer dashboard panel
+
+global lease ref in clawsweeper-state
+  -> safe GitHub ref/commit metadata probe
+  -> held/free/unknown in the same panel
+```
+
+Neither progress reporting nor terminal telemetry may alter the publication
+result. If telemetry is unavailable or malformed, publication completion keeps
+its current semantics and the panel reports partial or unavailable collection.
+
+## Stable telemetry contract
+
+### Pure contract module
+
+Create a pure module such as `src/state-writer-telemetry.ts`. It must have no
+Node-only, Cloudflare-only, Git, filesystem, or network dependency. It owns:
+
+- schema version and string unions;
+- TypeScript types;
+- strict normalization of untrusted JSON;
+- cross-field invariants;
+- helpers shared by the publisher and queue receiver.
+
+Keep recording and transport in separate files. Suggested responsibilities:
+
+- `src/state-writer-telemetry.ts`: pure contract and validation;
+- `src/repair/state-writer-telemetry-recorder.ts`: Node-side timing and progress
+  recorder;
+- optional `src/repair/state-writer-progress-reporter.ts`: one-shot,
+  best-effort progress delivery if a detached reporter is used.
+
+This extraction limits merge conflicts with the batch Git primitive, which is
+expected to modify `src/repair/git-publish.ts` heavily.
+
+### Terminal operation schema
+
+Add one optional `state_writer` object to the exact-review publication
+completion payload:
+
+```json
+{
+  "state_writer": {
+    "schema_version": 1,
+    "operation_id": "single:29792754219:1",
+    "mode": "single_item",
+    "started_at": "2026-07-21T01:18:21.000Z",
+    "finished_at": "2026-07-21T01:20:09.000Z",
+    "wait_ms": 43210,
+    "acquire_attempts": 9,
+    "acquired": true,
+    "hold_ms": 50120,
+    "renewals": 0,
+    "released": true,
+    "git_duration_ms": 93330,
+    "git_processes": 18,
+    "commit_count": 1,
+    "materialized_items": 1,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": null,
+    "outcome": "materialized"
+  }
+}
+```
+
+An acquisition timeout is represented without inventing a hold duration:
+
+```json
+{
+  "schema_version": 1,
+  "operation_id": "single:29792754482:1",
+  "mode": "single_item",
+  "started_at": "2026-07-21T01:18:24.000Z",
+  "finished_at": "2026-07-21T01:26:24.000Z",
+  "wait_ms": 480000,
+  "acquire_attempts": 97,
+  "acquired": false,
+  "hold_ms": null,
+  "renewals": 0,
+  "released": null,
+  "git_duration_ms": 480000,
+  "git_processes": 195,
+  "commit_count": 0,
+  "materialized_items": 0,
+  "configured_batch_size": 1,
+  "actual_batch_size": 1,
+  "batch_wait_ms": null,
+  "outcome": "contention_timeout"
+}
+```
+
+The batch publisher later emits the same schema once per batch operation:
+
+```json
+{
+  "schema_version": 1,
+  "operation_id": "batch:01J3BATCHIDENTITY",
+  "mode": "batch",
+  "started_at": "2026-07-21T03:00:00.000Z",
+  "finished_at": "2026-07-21T03:01:18.000Z",
+  "wait_ms": 1800,
+  "acquire_attempts": 2,
+  "acquired": true,
+  "hold_ms": 74200,
+  "renewals": 0,
+  "released": true,
+  "git_duration_ms": 76000,
+  "git_processes": 22,
+  "commit_count": 1,
+  "materialized_items": 6,
+  "configured_batch_size": 8,
+  "actual_batch_size": 6,
+  "batch_wait_ms": 60000,
+  "outcome": "materialized"
+}
+```
+
+### Field semantics
+
+| Field                        | Required meaning                                                                                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `operation_id`               | Stable idempotency key for one writer operation. A workflow retry keeps the same batch identity where the batch protocol requires it. Never use the raw lease-owner UUID. |
+| `mode`                       | `single_item` or `batch`. API summaries may derive `mixed`, but producers never emit `mixed`.                                                                             |
+| `started_at` / `finished_at` | Bounds of this state-writer operation, excluding earlier review generation and unrelated GitHub side effects.                                                             |
+| `wait_ms`                    | Time from entering state-lease acquisition until acquisition succeeds or the acquisition attempt terminates.                                                              |
+| `acquire_attempts`           | Number of compare-and-swap acquisition attempts made by this operation.                                                                                                   |
+| `acquired`                   | Whether this operation acquired the shared state lease.                                                                                                                   |
+| `hold_ms`                    | Local time from successful acquisition until release handling finishes. It is `null` if never acquired.                                                                   |
+| `renewals`                   | Successful lease renewals by this operation.                                                                                                                              |
+| `released`                   | `true` for confirmed release, `false` for a failed release attempt, `null` when no lease was acquired.                                                                    |
+| `git_duration_ms`            | Total time inside the measured state materialization path, including acquisition and release, but excluding queue/batch waiting.                                          |
+| `git_processes`              | Git subprocesses executed in the measured operation. Do not count unrelated setup or GitHub API commands.                                                                 |
+| `commit_count`               | Number of state commits actually published by this operation. The initial invariant is `0` or `1`. Lease metadata commits are not state commits.                          |
+| `materialized_items`         | Items newly materialized by this operation. Do not count an item merely because a newer tuple already existed remotely.                                                   |
+| `configured_batch_size`      | Configured item cap. It is `1` in legacy mode.                                                                                                                            |
+| `actual_batch_size`          | Eligible items selected into this writer operation after preflight. It is `1` in legacy mode.                                                                             |
+| `batch_wait_ms`              | Time from first eligible buffered item until batch departure. It is `null` in single-item mode.                                                                           |
+| `outcome`                    | One of `materialized`, `unchanged`, `superseded`, `contention_timeout`, or `failed`. This describes state writing only and does not replace queue `completion_kind`.      |
+
+Required invariants include:
+
+- all counts and durations are finite, non-negative integers within a documented
+  upper bound;
+- `finished_at >= started_at`;
+- `actual_batch_size <= configured_batch_size`;
+- `materialized_items <= actual_batch_size`;
+- `acquired=false` requires `hold_ms=null`, `released=null`, `renewals=0`,
+  `commit_count=0`, and `materialized_items=0`;
+- `commit_count=1` requires `acquired=true` and
+  `materialized_items >= 1`;
+- `mode=single_item` requires configured and actual batch sizes of one and
+  `batch_wait_ms=null`;
+- `mode=batch` requires non-null `batch_wait_ms`;
+- `outcome=contention_timeout` requires `acquired=false`;
+- unknown schema versions are ignored as unavailable telemetry, not partially
+  interpreted.
+
+Choose defensive upper bounds large enough for a 60-minute workflow but small
+enough to reject nonsensical payloads. Keep those bounds in the pure contract
+module and cover them with tests.
+
+### Operation-level deduplication is mandatory
+
+Telemetry is about a Git writer operation, not a queue-item completion.
+
+In legacy mode there is normally one operation and one item completion. In batch
+mode, one operation may lead to six separate item completions. If the same
+`state_writer` object accompanies all six completion calls, SQLite must insert
+the operation only once by `operation_id`.
+
+Never increment commits, materialized items, or duration six times. A batch of
+six with one commit must appear as:
+
+```text
+writer operations = 1
+state commits = 1
+materialized items = 6
+items / commit = 6.00
+```
+
+If an existing `operation_id` arrives with the same normalized payload, treat it
+as an idempotent duplicate. If it arrives with different data, preserve the
+first accepted row, increment a telemetry-conflict diagnostic, and still allow
+the queue item to complete.
+
+## Live progress contract
+
+Terminal completion metrics are sufficient for rates and percentiles but not
+for a truthful current `waiting` count. Do not estimate waiting by subtracting
+one from `50 active`; publication workflows can be in setup, GitHub mutation,
+post-processing, or terminal cleanup.
+
+Use a separate best-effort progress payload:
+
+```json
+{
+  "schema_version": 1,
+  "operation_id": "single:29792754219:1",
+  "mode": "single_item",
+  "phase": "waiting",
+  "sequence": 1,
+  "observed_at": "2026-07-21T01:18:21.000Z",
+  "configured_batch_size": 1,
+  "actual_batch_size": 1
+}
+```
+
+Allowed phases are:
+
+- `waiting`: entered lease acquisition but has not acquired;
+- `holding`: acquired the state lease and is inside the critical section;
+- `releasing`: state work finished and lease release is in progress;
+- `finished`: operation ended; the terminal completion payload remains the
+  durable source for metrics.
+
+Add an internal route such as
+`POST /internal/exact-review/state-writer-progress`. Forward it to a dedicated
+Durable Object handler. Authenticate it using the full existing publication
+claim tuple:
+
+- queue lease id;
+- item key and lease revision;
+- claim generation;
+- GitHub run id and run attempt.
+
+The endpoint must verify that the item is a currently claimed publication item.
+It must not renew, complete, retry, or otherwise mutate queue ownership.
+
+For batch mode, extend the endpoint to accept the batch claim identity created
+by the batching protocol. Do not pretend one arbitrary member item owns the
+batch writer.
+
+Progress transport is deliberately best effort:
+
+- recorder callbacks must never throw into the lease path;
+- network requests must not block while the state lease is held;
+- a small detached one-shot reporter or equivalent non-blocking transport may
+  deliver each phase;
+- include a monotonic `sequence`, and ignore older or equal sequences;
+- reject a delayed report after its queue or batch claim is no longer active;
+- expire live rows after 90 seconds without a fresh observation;
+- while a phase remains unchanged, refresh it at most every 30 seconds;
+- any reporter exit, timeout, or 4xx/5xx must leave the publication outcome
+  unchanged.
+
+If reliable non-blocking progress cannot be implemented narrowly, ship terminal
+telemetry first and render live waiting as `unknown`. Do not ship a guessed
+number.
+
+## Global lease occupancy
+
+Detailed progress covers exact-result publishers. Other ordinary state writers
+can still hold the global state lease.
+
+Add a safe, cached GitHub metadata probe in `dashboard/worker.ts` for the lease
+ref in the configured state repository and state branch. Use only:
+
+- whether the lease ref exists;
+- lease commit timestamp;
+- advertised TTL, clamped to the same maximum as the lease implementation;
+- dashboard observation timestamp.
+
+Return only `held`, `free`, or `unknown`, expiry, and collection freshness. Do
+not expose the lease owner or raw commit message. A missing ref means free. A
+ref whose bounded expiry is past means stale/free. An authentication, rate-limit,
+or parsing failure means unknown, not free.
+
+Cache the result with the normal dashboard snapshot; do not poll GitHub from
+browser JavaScript.
+
+This allows the panel to distinguish:
+
+```text
+Global state lease: held (1 writer maximum)
+Tracked exact-result writers: 1 holding, 37 waiting
+```
+
+from:
+
+```text
+Global state lease: held (1 writer maximum)
+Tracked exact-result writers: 0 holding, 37 waiting
+```
+
+The latter can occur when an ordinary non-exact writer owns the global lease.
+
+## Recorder integration
+
+Instrument the existing state lease instead of parsing its console messages.
+
+The recorder must observe these decisions without changing them:
+
+1. Record `started_at`, emit `waiting`, and start the wait timer before initial
+   jitter.
+2. Increment `acquire_attempts` for each actual acquire attempt.
+3. On successful compare-and-swap, set `acquired`, close `wait_ms`, start the
+   hold timer, and emit `holding`.
+4. Increment `renewals` only after a renewal succeeds.
+5. Count Git subprocesses through the existing central `recordGitProcess`
+   hook while the recorder is active.
+6. Record a state commit only after the remote result is verified. Do not infer
+   it from running `git commit`, because lease metadata also uses Git commits.
+7. Emit `releasing` immediately before release handling.
+8. Close `hold_ms`, record `released`, and emit `finished` in `finally`.
+9. Finalize a compact terminal object on success or exception and export it as
+   one-line JSON.
+
+Keep `withStatePublishLease`'s return type and caller behavior unchanged. Pass an
+optional recorder/observer through options or a narrowly scoped wrapper. Avoid
+a new process-global telemetry singleton unless it is protected against nested
+or concurrent use in the same Node process.
+
+For the exact-result path:
+
+- `configured_batch_size=1`;
+- `actual_batch_size=1` only when the operation reaches state materialization;
+- omit `state_writer` entirely for a workflow that terminalizes before entering
+  the state writer path;
+- call the explicit `recordMaterializedCommit(1)`-style hook only after the
+  remote tuple is verified;
+- emit `unchanged` or `superseded` with zero new materialized items when the
+  remote already contains the winning tuple.
+
+The batch committer later creates one recorder per batch, supplies the actual
+batch size and batch wait, and records one verified commit with the number of
+items it newly materialized.
+
+## Workflow plumbing
+
+In `.github/workflows/sweep.yml`:
+
+1. Give the exact-result publish step the existing publication claim tuple and
+   queue URL needed by the best-effort reporter. Do not add a shared webhook
+   secret.
+2. Export compact terminal telemetry from `publish-event-result` as a step
+   output such as `state_writer_json`.
+3. Pass it through `exact-review-publication-result` without shell evaluation.
+4. Parse and validate it in the existing Node payload builder for
+   `Complete durable exact review publication`.
+5. Include the parsed object as optional `state_writer` in the JSON request.
+6. If the output is absent or invalid, omit it and continue sending the existing
+   completion fields.
+
+Do not interpolate JSON into a shell command. Pass it through an environment
+variable and use `JSON.parse` inside the existing Node payload builder. The pure
+contract is authoritative again at the server boundary.
+
+Older in-flight workflows will send no field. The receiver and dashboard must
+remain compatible with them.
+
+## SQLite storage and cleanup
+
+Use compact additive tables rather than adding telemetry to the queue item JSON
+or copying full completion payloads.
+
+Suggested terminal table:
+
+```text
+exact_review_state_writer_operations
+  operation_id                 primary key
+  observed_at                  server receipt time
+  mode                         single_item | batch
+  started_at
+  finished_at
+  wait_ms
+  acquire_attempts
+  acquired
+  hold_ms                      nullable
+  renewals
+  released                     nullable
+  git_duration_ms
+  git_processes
+  commit_count
+  materialized_items
+  configured_batch_size
+  actual_batch_size
+  batch_wait_ms                nullable
+  outcome
+  payload_hash                 detects conflicting duplicates
+```
+
+Suggested live table:
+
+```text
+exact_review_state_writer_live
+  operation_id                 primary key
+  mode
+  phase
+  sequence
+  observed_at                  server receipt time
+  configured_batch_size
+  actual_batch_size
+  run identity or batch claim identity needed for validation
+```
+
+Add cumulative diagnostics to the existing metrics singleton or a dedicated
+small singleton:
+
+- accepted terminal operations;
+- idempotent duplicate terminal operations;
+- rejected terminal telemetry;
+- conflicting operation payloads;
+- accepted and rejected progress events.
+
+Retention:
+
+- keep compact terminal operation rows for seven days so 6h, 24h, and 7d
+  percentile views are exact and bounded;
+- remove stale live rows after 90 seconds;
+- prune terminal rows in a bounded batch during existing queue telemetry
+  cleanup;
+- never couple telemetry cleanup to queue item deletion or DLQ cleanup;
+- expose oldest retained row, last accepted observation, and rejected/conflict
+  counters so collection quality is visible.
+
+At the expected pre-batch rate, seven days of compact operation rows is small
+enough for exact percentile queries and is simpler than maintaining a custom
+histogram schema. If measured SQLite growth disproves that assumption, add
+aggregated histograms in a later evidence-backed change.
+
+Malformed optional telemetry must not reject `/complete`. Normalize it, count a
+rejection diagnostic, omit the telemetry row, and continue the existing queue
+completion transaction. Observability cannot strand publication work.
+
+## Queue status API
+
+Add an optional `state_writer` object to the exact-review `/stats` response:
+
+```json
+{
+  "state_writer": {
+    "schema_version": 1,
+    "collection": {
+      "status": "fresh",
+      "last_observed_at": "2026-07-21T03:01:18.000Z",
+      "rejected_total": 0,
+      "conflicted_total": 0
+    },
+    "mode": "batch",
+    "live": {
+      "tracked_holding": 1,
+      "tracked_waiting": 0,
+      "tracked_releasing": 0,
+      "freshness_seconds": 12
+    },
+    "last_15_minutes": {
+      "operations": 8,
+      "acquired": 8,
+      "contention_timeouts": 0,
+      "state_commits": 8,
+      "materialized_items": 48,
+      "items_per_commit": 6,
+      "wait_ms": { "p50": 1100, "p95": 2400 },
+      "hold_ms": { "p50": 68000, "p95": 78000 },
+      "git_duration_ms": { "p50": 70000, "p95": 81000 },
+      "actual_batch_size": { "average": 6, "p50": 6, "p95": 8 },
+      "batch_wait_ms": { "p50": 32000, "p95": 60000 },
+      "batch_fullness": 0.75
+    },
+    "last_60_minutes": {},
+    "last_successful_materialization_at": "2026-07-21T03:01:18.000Z"
+  }
+}
+```
+
+Calculation rules:
+
+- derive `mode=single_item` or `batch` when all fresh operations use that mode;
+- derive `mode=mixed` when both modes occur in the current 15-minute window or
+  live set;
+- use `unknown` when there are no usable samples;
+- calculate `items_per_commit` as
+  `sum(materialized_items) / sum(commit_count)`, never as an average of
+  per-operation ratios;
+- calculate batch fullness as
+  `sum(actual_batch_size) / sum(configured_batch_size)` for batch operations;
+- do not include operations that never entered the state writer path;
+- exclude `null` hold and batch-wait values from their percentile populations;
+- include acquisition timeouts in wait percentiles and contention counts;
+- return `null`, not zero, when a metric is unknown;
+- report sample counts beside percentiles so a p95 from one sample is not
+  presented as strong evidence.
+
+Keep current queue API fields unchanged. The new object is additive and
+optional during rolling deployment.
+
+## History compatibility
+
+Extend `HealthHistorySample` with an optional `state_writer` sample. Do not make
+it a required child of `exact_review`; old seven-day history already lacks it.
+
+Persist at each existing five-minute sample:
+
+- collection status and sample time;
+- mode;
+- tracked holding/waiting/releasing counts;
+- cumulative accepted operation, state commit, materialized item, and
+  contention-timeout totals;
+- current 15-minute wait and hold p50/p95 with sample counts;
+- configured batch size and average actual batch size when batch mode exists;
+- last successful materialization time.
+
+Normalization requirements:
+
+- a valid legacy sample without `state_writer` remains valid;
+- an invalid optional `state_writer` child is dropped without discarding the
+  valid exact-review history in the same sample;
+- unknown future nested schema versions are ignored;
+- counter resets create a new rate segment instead of a negative spike;
+- 6h, 24h, and 7d switches continue to discard stale asynchronous responses,
+  matching `loadHealthHistory` today.
+
+Do not backfill invented pre-deployment values. The panel should say when
+history starts.
+
+## Dashboard UI
+
+Add a standalone mount such as `id="state-writer-health"` immediately after the
+existing exact-review lane cards and before handoff/apply health. Keep
+`renderExactReviewLanes` responsible only for admission/publication lanes; add a
+separate `renderStateWriter` function.
+
+### Single-item example
+
+```text
+State writer                         Single-item · fresh 18s ago
+Global state lease                  Held · 1 writer maximum
+Tracked exact publishers            1 holding · 37 waiting
+
+Materialized                        24 items/hour
+State commits                       24/hour
+Items / commit                      1.00
+
+Lease wait                          p50 3m 12s · p95 8m 00s · n=41
+Lease hold                          p50 58s · p95 71s · n=24
+Contention timeouts                 17 in the last hour
+Last materialization                2m ago
+```
+
+### Batch example
+
+```text
+State writer                         Batch · configured 8 · fresh 12s ago
+Global state lease                  Held · 1 writer maximum
+Tracked batch publishers            1 holding · 0 waiting
+
+Materialized                        192 items/hour
+State commits                       32/hour
+Items / commit                      6.00
+
+Actual batch                        avg 6.0 · fullness 75%
+Batch wait                          p50 32s · p95 60s · n=8
+Lease wait                          p50 1.1s · p95 2.4s · n=8
+Lease hold                          p50 68s · p95 78s · n=8
+Last materialization                20s ago
+```
+
+### Rendering rules
+
+- Label the existing `50 active` value as publication workflows; do not move it
+  into this panel.
+- State explicitly that writer maximum is one for the current shared ref.
+- Use `unknown` when global lease collection or progress collection failed. Do
+  not render unknown as zero/free.
+- Mark progress stale after 90 seconds and show the last observation age.
+- During rolling rollout, show `Mixed · legacy draining + batch active`.
+- In batch mode, make **materialized items/hour** and **items/commit** the primary
+  throughput values.
+- Do not mark lower commits/hour as a regression after batching. Fewer commits
+  with more items per commit is the desired result.
+- Keep queue `Published` and `Superseded` rates separate. Superseded queue work
+  can be useful without creating a new state commit.
+- Do not show raw operation ids, run ids, lease ids, owner UUIDs, or failure text
+  in the public panel.
+- Add concise help text explaining that `50 active` workflows still feed one
+  serialized state-ref writer.
+
+Use one compact trend for materialized items/hour. A second small trend for
+tracked waiting is acceptable if it remains legible. Avoid adding charts for
+every percentile.
+
+## Behavior after batching is enabled
+
+The panel must change automatically from producer data; no dashboard feature
+flag or second schema migration is required.
+
+The batch implementation must do all of the following before its production
+flag is enabled:
+
+1. Create one stable `operation_id` per batch.
+2. Emit `mode=batch`.
+3. Populate configured and actual batch sizes.
+4. Measure time from the first eligible buffered item to batch departure.
+5. Record one state commit after remote verification.
+6. Record the number of items newly materialized by that commit.
+7. Reuse that operation telemetry on per-item completions, relying on
+   operation-level deduplication.
+8. Emit live progress using the batch claim identity.
+
+Expected metric movement:
+
+| Metric                                  | Before batching                          | After healthy batching                                |
+| --------------------------------------- | ---------------------------------------- | ----------------------------------------------------- |
+| Writer maximum                          | 1                                        | 1                                                     |
+| Publication workflows waiting for lease | Many                                     | Near zero                                             |
+| State commits/hour                      | Similar to item throughput               | Lower than item throughput                            |
+| Materialized items/hour                 | Limited by one item per critical section | Higher by average batch size                          |
+| Items/commit                            | About 1                                  | Greater than 1                                        |
+| Lease wait                              | High and bursty                          | Low with one batch writer                             |
+| Batch wait                              | Not applicable                           | Bounded by the departure policy, initially 60 seconds |
+
+During the cutover, already-running legacy workflows are not cancelled. The
+panel may show `mixed` until they drain. The batch rollout is not considered
+observable or ready if it still emits only single-item defaults.
+
+## Implementation sequence
+
+### Step 1: contract and recorder
+
+- Add the pure schema/normalizer.
+- Add a recorder that measures wait, hold, renewal, release, Git process count,
+  and terminal outcome.
+- Add minimal hooks to the existing state lease.
+- Instrument exact-result publication with single-item defaults.
+- Unit-test success, unchanged, superseded, contention timeout, renewal, failed
+  release, and recorder failure isolation.
+
+**Manual checkpoint:** run a local fake-remote publication and inspect one
+normalized terminal object. Verify no lease timing, retry, or Git result changes
+when recording is disabled or its sink throws.
+
+### Step 2: receiver and durable summaries
+
+- Deploy additive SQLite tables and bounded pruning.
+- Accept optional terminal telemetry on `/complete`.
+- Add idempotent operation insertion and conflict diagnostics.
+- Add the progress endpoint and live expiry.
+- Expose 15-minute and 60-minute summaries from `/stats`.
+- Keep malformed telemetry non-blocking for queue completion.
+
+**Manual checkpoint:** submit synthetic telemetry to a test Durable Object,
+repeat the same operation, then submit a conflicting duplicate. Verify one
+operation/commit is counted, diagnostics change correctly, and the publication
+item still completes.
+
+### Step 3: workflow producer
+
+- Plumb claim identity to the recorder/reporter.
+- Export compact JSON from the exact publish step.
+- Safely add it to the existing completion payload.
+- Confirm older payloads without the field still complete.
+
+**Manual checkpoint:** inspect a workflow fixture payload. It must contain no
+secret or owner UUID and must omit telemetry cleanly for preflight terminal
+no-ops.
+
+### Step 4: history and panel
+
+- Add optional history types and normalization.
+- Persist five-minute samples.
+- Add the cached global lease probe.
+- Add the standalone panel and its loading/stale/unavailable states.
+- Add single-item, mixed, and batch rendering fixtures.
+
+**Manual checkpoint:** render all modes locally from fixtures and verify that
+`50 active` remains under Result publication while State writer shows one
+maximum writer and independent wait/hold/materialization data.
+
+### Step 5: batch handoff gate
+
+- Give the batching implementer the final contract and recorder API.
+- Add a batch fixture with one operation, one commit, and multiple item
+  completions.
+- Make batch telemetry population a rollout prerequisite in
+  `docs/state-publication-batching-plan.md` implementation evidence.
+
+**Manual checkpoint:** six item completions for one batch must produce exactly
+one writer operation, one state commit, and six materialized items.
+
+## Pull request strategy and task size
+
+This is a medium-to-large observability task because it crosses the Node
+publisher, workflow payload, SQLite receiver, history API, and dashboard. The
+change is nevertheless one responsibility: making the serialized writer
+visible.
+
+Preferred delivery is **one observability pull request with reviewable commits**
+because every added behavior is optional and inert with respect to publication.
+Suggested commit boundaries are:
+
+1. contract, recorder, and receiver;
+2. workflow producer;
+3. history, global lease probe, and UI.
+
+If repository review limits require two pull requests, split only here:
+
+1. **Telemetry substrate:** contract, recorder, workflow field, receiver,
+   storage, and `/stats`. Manual verification is the API and deduplication gate.
+2. **Dashboard presentation:** history normalization, global lease probe, panel,
+   and UI tests. Manual verification is the visual single/mixed/batch gate.
+
+Do not split individual SQLite tables, type files, or CSS into standalone pull
+requests. Those pieces have no independent operator decision.
+
+The telemetry PR should merge before the batching Git primitive if possible. If
+batching work lands first, rebase this work and reapply only the narrow recorder
+hooks. Never resolve a conflict by replacing the new batch committer or by
+restoring the old single-item implementation wholesale.
+
+Expected conflict areas are:
+
+- `src/repair/git-publish.ts` in the batch Git primitive;
+- `src/repair/publish-event-result.ts` in the publisher integration;
+- `.github/workflows/sweep.yml` in the batch workflow;
+- `dashboard/exact-review-queue.ts` in the batch ownership protocol.
+
+The extracted pure contract, dedicated telemetry tables, and standalone render
+function are intentional conflict boundaries.
+
+## Automated test matrix
+
+### Contract tests
+
+- valid single-item success;
+- valid single-item contention timeout;
+- valid partial batch;
+- every cross-field invariant rejection;
+- excessive duration/count rejection;
+- unknown schema version;
+- normalization produces stable canonical data/hash.
+
+### Git/recorder tests
+
+- acquisition attempt count includes failed compare-and-swap attempts;
+- wait duration closes on success and timeout;
+- hold duration starts only after acquisition;
+- renewal increments only on success;
+- confirmed and failed release are distinct;
+- lease metadata commits do not increment `commit_count`;
+- verified state commit increments once;
+- Git subprocesses are scoped to the operation;
+- a throwing progress sink cannot fail or delay publication;
+- existing lease and publisher tests remain byte-for-byte behavior compatible.
+
+### Workflow tests
+
+- claim tuple reaches only the internal reporter/payload builder;
+- compact JSON is parsed rather than shell-evaluated;
+- valid telemetry appears in `/complete`;
+- missing or invalid telemetry is omitted;
+- existing outcome, completion kind, reason, retry, and fingerprint fields are
+  unchanged;
+- no secret or raw lease owner enters the payload.
+
+### Queue and SQLite tests
+
+- additive schema initializes on an existing queue database;
+- legacy completion without telemetry succeeds;
+- malformed telemetry is counted and completion still succeeds;
+- identical operation replay is idempotent;
+- conflicting replay preserves first data and does not block item completion;
+- six batch member completions count one operation/commit;
+- percentile and ratio calculations use correct populations;
+- `items_per_commit` uses sums;
+- progress sequence ordering and stale expiry;
+- expired live rows disappear from holding/waiting counts;
+- seven-day pruning is bounded and cannot touch queue/DLQ rows.
+
+### History tests
+
+- legacy samples without `state_writer` survive unchanged;
+- invalid optional state-writer data does not invalidate exact-review data;
+- single, mixed, and batch mode samples normalize;
+- counter reset starts a new segment;
+- 6h, 24h, and 7d range selection remains race-safe.
+
+### Dashboard tests
+
+- standalone mount exists and ordering is stable;
+- Result publication still renders workflow active/capacity;
+- single-item panel labels one-item semantics;
+- mixed panel explains legacy drain;
+- batch panel renders configured/actual size and batch wait;
+- unknown and stale states never render as zero/free;
+- lower batch commits/hour is not given an error style when item throughput is
+  healthy;
+- no identifier or secret is rendered;
+- global lease held by an untracked ordinary writer is distinguishable from a
+  tracked exact writer.
+
+## Manual verification checklist
+
+No live workflow dispatch, DLQ replay, or state mutation is required for the
+observability pull request proof.
+
+1. Run unit tests with Node 24 or newer.
+2. Use a local bare remote to produce one successful single-item operation and
+   one acquisition timeout.
+3. Inspect normalized telemetry and verify timings against the test clock/log.
+4. Exercise a test queue completion without telemetry and confirm its outcome.
+5. Exercise one with telemetry and confirm one terminal row.
+6. Repeat the same operation and confirm totals do not change.
+7. Complete multiple synthetic batch members using one operation id and confirm
+   one commit and multiple materialized items.
+8. Advance time past live expiry and confirm waiting/holding becomes stale or
+   zero only with a fresh successful collection.
+9. Render dashboard fixtures for single-item, mixed, batch, stale, and
+   unavailable modes.
+10. Confirm the public JSON/HTML contains no queue lease id, owner UUID, token,
+    or raw error text.
+11. Run `pnpm run check` before handoff because this task changes code, tests,
+    workflow, and dashboard.
+
+## Rollout order
+
+Use receiver-before-producer order:
+
+1. deploy additive SQLite schema, receiver, API, and UI capable of showing
+   unavailable telemetry;
+2. confirm old completion payloads still work;
+3. enable terminal telemetry from single-item publishers;
+4. enable best-effort progress reporting;
+5. wait for two complete five-minute samples;
+6. verify API totals against a small set of completed workflow runs;
+7. only then use the panel as evidence for batching rollout.
+
+The first samples may be `unknown` or `mixed` during a rolling deployment. That
+is expected. Do not backfill or coerce them to zero.
+
+When batching is deployed later:
+
+1. deploy the batch producer with telemetry while batching remains disabled;
+2. prove the one-operation/many-item fixture;
+3. enable batch size 2 according to the batching plan;
+4. expect `mixed` while legacy workflows drain;
+5. verify items/commit rises above one and materialized items/hour improves;
+6. do not judge the rollout by commits/hour alone.
+
+## Rollback
+
+Telemetry is additive and optional.
+
+- Disable progress reporting first if it creates unexpected load.
+- Stop attaching `state_writer` to completion payloads if producer data is
+  suspect.
+- The receiver continues accepting legacy payloads.
+- The panel changes to partial/unavailable instead of affecting publication.
+- Leave additive telemetry tables in place for diagnosis; bounded pruning will
+  remove old samples.
+- Do not roll back queue items, state commits, or publication outcomes because
+  of an observability fault.
+
+After batch rollout, disabling batching returns new operations to
+`single_item`; the panel follows producer mode automatically and retains prior
+batch history for the selected time range.
+
+## Acceptance criteria
+
+The task is complete when:
+
+- the dashboard no longer invites readers to interpret `50 active` as 50 Git
+  writers;
+- one shared state writer is shown separately from publication workflows;
+- current exact-result waiting/holding is measured or explicitly unknown, never
+  guessed;
+- lease wait/hold, contention, state commits, materialized items, and
+  items/commit are available with sample counts and freshness;
+- legacy history and completion payloads remain compatible;
+- telemetry loss cannot fail or strand publication;
+- one batch operation is deduplicated across all member completions;
+- the same panel renders single-item, mixed, and batch modes;
+- healthy batching is evaluated primarily by materialized items/hour and
+  items/commit, not by commits/hour;
+- the observability PR contains no batching enablement or production-control
+  change.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -31,6 +31,7 @@ import {
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
+import type { StateWriterTelemetryRecorder } from "./state-writer-telemetry-recorder.js";
 
 export type GitRunResult = {
   status: number;
@@ -136,10 +137,20 @@ export type StatePublishLeaseOptions = {
   acquireTimeoutMs?: number;
   ttlMs?: number;
   waitMs?: number;
+  observer?: StateWriterTelemetryRecorder;
 };
 
 let activeGitPublishMetrics: GitPublishMetrics | null = null;
 let activeStatePublishLease: StatePublishLease | null = null;
+let activeStateWriterTelemetry: StateWriterTelemetryRecorder | null = null;
+
+export function setStatePublishTelemetryObserver(observer: StateWriterTelemetryRecorder | null) {
+  const previous = activeStateWriterTelemetry;
+  activeStateWriterTelemetry = observer;
+  return () => {
+    activeStateWriterTelemetry = previous;
+  };
+}
 
 export function configureGitUser(): void {
   runGit(["config", "user.name", clawsweeperGitUserName()]);
@@ -214,6 +225,7 @@ export class StatePublishContentionError extends Error {
 }
 
 function recordGitProcess(action: string | undefined): void {
+  activeStateWriterTelemetry?.recordGitProcess();
   if (!activeGitPublishMetrics) return;
   const key = action || "command";
   activeGitPublishMetrics.processes += 1;
@@ -1466,15 +1478,30 @@ export function withStatePublishLease<T>(
   }
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
-  const lease = acquireStatePublishLease(remote, branch, options);
+  const previousTelemetry = activeStateWriterTelemetry;
+  activeStateWriterTelemetry = options.observer ?? previousTelemetry;
+  let lease: StatePublishLease;
+  try {
+    lease = acquireStatePublishLease(remote, branch, options);
+  } catch (error) {
+    options.observer?.finalize(
+      error instanceof StatePublishContentionError ? "contention_timeout" : "failed",
+    );
+    activeStateWriterTelemetry = previousTelemetry;
+    throw error;
+  }
   lease.cleanup = startStatePublishLeaseCleanup(lease);
   activeStatePublishLease = lease;
   try {
     return operation();
   } finally {
     activeStatePublishLease = null;
-    releaseStatePublishLease(lease);
+    options.observer?.enteredReleasing();
+    const released = releaseStatePublishLease(lease);
+    options.observer?.releasedLease(released);
+    options.observer?.finished();
     lease.cleanup?.close();
+    activeStateWriterTelemetry = previousTelemetry;
   }
 }
 
@@ -1511,6 +1538,7 @@ function acquireStatePublishLease(
   const deadlineAtMs = Date.now() + acquireTimeoutMs;
   const observedByOid = new Map<string, ObservedStatePublishLease>();
   let attempt = 0;
+  options.observer?.enteredWaiting();
 
   // Spread a newly admitted publisher cohort before any of them attempts the
   // empty-ref compare-and-swap. Once an owner exists, later contenders only
@@ -1519,6 +1547,7 @@ function acquireStatePublishLease(
 
   while (Date.now() < deadlineAtMs) {
     attempt += 1;
+    options.observer?.recordAcquireAttempt();
     const observed = observeStatePublishLease(remote, leaseRef, ttlMs, observedByOid);
     const now = Date.now();
     if (!observed || observed.expiresAtMs <= now) {
@@ -1694,7 +1723,7 @@ function startStatePublishLeaseCleanup(lease: StatePublishLease): StatePublishLe
   };
 }
 
-function releaseStatePublishLease(lease: StatePublishLease): void {
+function releaseStatePublishLease(lease: StatePublishLease): boolean {
   try {
     const released = spawnGit(
       ["push", `--force-with-lease=${lease.ref}:${lease.oid}`, lease.remote, `:${lease.ref}`],
@@ -1702,15 +1731,18 @@ function releaseStatePublishLease(lease: StatePublishLease): void {
     );
     if (released.status === 0) {
       console.log(`Released state publish lease owner=${lease.owner}`);
+      return true;
     } else {
       console.log(
         `State publish lease release skipped owner=${lease.owner}; ownership changed or cleanup failed`,
       );
+      return false;
     }
   } catch (error) {
     console.log(
       `State publish lease release failed owner=${lease.owner}; expiry will recover it: ${errorMessage(error)}`,
     );
+    return false;
   }
 }
 
@@ -1746,6 +1778,7 @@ function renewStatePublishLease(lease: StatePublishLease, reason: string): void 
   }
   lease.oid = renewedOid;
   lease.expiresAtMs = Date.now() + lease.ttlMs;
+  activeStateWriterTelemetry?.recordRenewal();
   console.log(`Renewed state publish lease owner=${lease.owner} ${reason}`);
 }
 

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -1480,11 +1480,12 @@ export function withStatePublishLease<T>(
   const branch = options.branch ?? publishDefaultBranch();
   const previousTelemetry = activeStateWriterTelemetry;
   activeStateWriterTelemetry = options.observer ?? previousTelemetry;
+  const telemetry = () => activeStateWriterTelemetry;
   let lease: StatePublishLease;
   try {
     lease = acquireStatePublishLease(remote, branch, options);
   } catch (error) {
-    options.observer?.finalize(
+    telemetry()?.finalize(
       error instanceof StatePublishContentionError ? "contention_timeout" : "failed",
     );
     activeStateWriterTelemetry = previousTelemetry;
@@ -1496,10 +1497,10 @@ export function withStatePublishLease<T>(
     return operation();
   } finally {
     activeStatePublishLease = null;
-    options.observer?.enteredReleasing();
+    telemetry()?.enteredReleasing();
     const released = releaseStatePublishLease(lease);
-    options.observer?.releasedLease(released);
-    options.observer?.finished();
+    telemetry()?.releasedLease(released);
+    telemetry()?.finished();
     lease.cleanup?.close();
     activeStateWriterTelemetry = previousTelemetry;
   }
@@ -1538,7 +1539,7 @@ function acquireStatePublishLease(
   const deadlineAtMs = Date.now() + acquireTimeoutMs;
   const observedByOid = new Map<string, ObservedStatePublishLease>();
   let attempt = 0;
-  options.observer?.enteredWaiting();
+  activeStateWriterTelemetry?.enteredWaiting();
 
   // Spread a newly admitted publisher cohort before any of them attempts the
   // empty-ref compare-and-swap. Once an owner exists, later contenders only
@@ -1547,7 +1548,7 @@ function acquireStatePublishLease(
 
   while (Date.now() < deadlineAtMs) {
     attempt += 1;
-    options.observer?.recordAcquireAttempt();
+    activeStateWriterTelemetry?.recordAcquireAttempt();
     const observed = observeStatePublishLease(remote, leaseRef, ttlMs, observedByOid);
     const now = Date.now();
     if (!observed || observed.expiresAtMs <= now) {
@@ -1560,6 +1561,7 @@ function acquireStatePublishLease(
           { allowFailure: true, quiet: true, timeout: PUBLISH_FETCH_TIMEOUT_MS },
         ).status === 0;
       if (acquired) {
+        activeStateWriterTelemetry?.acquiredLease();
         console.log(
           `Acquired state publish lease owner=${owner} attempt=${attempt} stale_recovery=${observed ? "true" : "false"} ttl_ms=${ttlMs}`,
         );

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -491,63 +491,69 @@ function publishSnapshot({
       summary();
       return published;
     };
-    const mutation = withStatePublishLease(() => {
-      hardResetToRemoteMain();
-      const stateRoot = publishRoot();
-      const snapshotResult = applyEventSnapshot(paths, stateRoot ? { remoteRoot: stateRoot } : {});
-      if (snapshotResult === "remote-closed") {
-        console.log(
-          `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
+    const mutation = withStatePublishLease(
+      () => {
+        hardResetToRemoteMain();
+        const stateRoot = publishRoot();
+        const snapshotResult = applyEventSnapshot(
+          paths,
+          stateRoot ? { remoteRoot: stateRoot } : {},
         );
-        return {
-          candidateApplied: false,
-          supersededReason: "remote_closed" as const,
-          writerOutcome: "superseded" as const,
-        };
-      }
-      if (snapshotResult === "remote-newer") {
-        console.log(
-          `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
-        );
-        return {
-          candidateApplied: false,
-          supersededReason: "remote_newer_tuple" as const,
-          writerOutcome: "superseded" as const,
-        };
-      }
-      if (snapshotResult === "missing") {
-        throw new PublicationResultError(
-          "missing_record_tuple",
-          `No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`,
-        );
-      }
+        if (snapshotResult === "remote-closed") {
+          console.log(
+            `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
+          );
+          return {
+            candidateApplied: false,
+            supersededReason: "remote_closed" as const,
+            writerOutcome: "superseded" as const,
+          };
+        }
+        if (snapshotResult === "remote-newer") {
+          console.log(
+            `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
+          );
+          return {
+            candidateApplied: false,
+            supersededReason: "remote_newer_tuple" as const,
+            writerOutcome: "superseded" as const,
+          };
+        }
+        if (snapshotResult === "missing") {
+          throw new PublicationResultError(
+            "missing_record_tuple",
+            `No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`,
+          );
+        }
 
-      syncPublishPaths(commitPaths);
-      stagePaths(commitPaths);
-      if (!hasStagedChanges()) {
-        console.log("No event result changes");
+        syncPublishPaths(commitPaths);
+        stagePaths(commitPaths);
+        if (!hasStagedChanges()) {
+          console.log("No event result changes");
+          return {
+            candidateApplied: true,
+            supersededReason: undefined,
+            writerOutcome: "unchanged" as const,
+          };
+        }
+
+        runGit([
+          "commit",
+          "-m",
+          commitMessageForPublishedPaths(
+            `chore: apply event sweep result for ${paths.targetSlug}#${options.itemNumber}`,
+            commitPaths,
+          ),
+        ]);
+        if (!pushSingleRecordTupleCommit({ paths: commitPaths, pushAttempts: 3 })) return null;
         return {
           candidateApplied: true,
           supersededReason: undefined,
-          writerOutcome: "unchanged" as const,
+          writerOutcome: "materialized" as const,
         };
-      }
-
-      runGit([
-        "commit",
-        "-m",
-        commitMessageForPublishedPaths(
-          `chore: apply event sweep result for ${paths.targetSlug}#${options.itemNumber}`,
-          commitPaths,
-        ),
-      ]);
-      if (!pushSingleRecordTupleCommit({ paths: commitPaths, pushAttempts: 3 })) return null;
-      return {
-        candidateApplied: true,
-        supersededReason: undefined,
-        writerOutcome: "materialized" as const,
-      };
-    });
+      },
+      { observer: recorder },
+    );
     if (!mutation) {
       recorder.finalize("failed");
       writeStateWriterOutput(recorder);
@@ -557,9 +563,13 @@ function publishSnapshot({
     if (mutation.writerOutcome === "materialized" && published.remoteTupleVerified) {
       recorder.recordMaterializedCommit(1);
     }
-    recorder.finalize(
-      published.completionKind === "superseded" ? "superseded" : mutation.writerOutcome,
-    );
+    const writerOutcome =
+      published.completionKind === "superseded"
+        ? "superseded"
+        : mutation.writerOutcome === "materialized" && !published.remoteTupleVerified
+          ? "failed"
+          : mutation.writerOutcome;
+    recorder.finalize(writerOutcome);
     const stateWriter = recorder.toTerminalObject();
     return { ...published, ...(stateWriter ? { stateWriter } : {}) };
   } catch (error) {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -32,6 +32,7 @@ import {
   refreshSourceAfterStatePublish,
   runGit,
   setTokenOrigin,
+  setStatePublishTelemetryObserver,
   stagePaths,
   StatePublishContentionError,
   syncPublishPaths,
@@ -39,6 +40,12 @@ import {
 } from "./git-publish.js";
 import { isJsonObject } from "./json-types.js";
 import { RecordTupleError } from "./record-tuple.js";
+import {
+  StateWriterTelemetryRecorder,
+  type StateWriterTelemetryObserver,
+} from "./state-writer-telemetry-recorder.js";
+import { stateWriterProgressReporter } from "./state-writer-progress-reporter.js";
+import type { StateWriterOperation } from "../state-writer-telemetry.js";
 import {
   staleEventDisposition,
   staleEventDispositionOutputLines,
@@ -71,6 +78,7 @@ type PublishedEventSnapshot = {
   routingDeferred: boolean;
   terminalClosed: boolean;
   terminalMissing: boolean;
+  stateWriter?: StateWriterOperation;
 };
 
 class GuardedOpenPublishRaceError extends Error {}
@@ -382,12 +390,19 @@ function publishSnapshot({
   terminalClosedExpected: boolean;
   terminalMissingExpected: boolean;
 }): PublishedEventSnapshot | null {
+  const observer = stateWriterObserver();
+  const recorder = new StateWriterTelemetryRecorder({
+    ...(process.env.GITHUB_RUN_ID ? { runId: process.env.GITHUB_RUN_ID } : {}),
+    ...(process.env.GITHUB_RUN_ATTEMPT ? { runAttempt: process.env.GITHUB_RUN_ATTEMPT } : {}),
+    ...(observer ? { observer } : {}),
+  });
   const commitPaths = [
     paths.itemRecord,
     paths.closedRecord,
     paths.planRecord,
     paths.decisionPacket,
   ];
+  const resetTelemetry = setStatePublishTelemetryObserver(recorder);
   try {
     const complete = (
       candidateApplied: boolean,
@@ -484,13 +499,21 @@ function publishSnapshot({
         console.log(
           `Remote already has closed record for ${paths.targetSlug}#${options.itemNumber}; skipping open-record publish`,
         );
-        return { candidateApplied: false, supersededReason: "remote_closed" as const };
+        return {
+          candidateApplied: false,
+          supersededReason: "remote_closed" as const,
+          writerOutcome: "superseded" as const,
+        };
       }
       if (snapshotResult === "remote-newer") {
         console.log(
           `Remote has newer record tuple for ${paths.targetSlug}#${options.itemNumber}; skipping stale event publish`,
         );
-        return { candidateApplied: false, supersededReason: "remote_newer_tuple" as const };
+        return {
+          candidateApplied: false,
+          supersededReason: "remote_newer_tuple" as const,
+          writerOutcome: "superseded" as const,
+        };
       }
       if (snapshotResult === "missing") {
         throw new PublicationResultError(
@@ -503,7 +526,11 @@ function publishSnapshot({
       stagePaths(commitPaths);
       if (!hasStagedChanges()) {
         console.log("No event result changes");
-        return { candidateApplied: true, supersededReason: undefined };
+        return {
+          candidateApplied: true,
+          supersededReason: undefined,
+          writerOutcome: "unchanged" as const,
+        };
       }
 
       runGit([
@@ -515,11 +542,31 @@ function publishSnapshot({
         ),
       ]);
       if (!pushSingleRecordTupleCommit({ paths: commitPaths, pushAttempts: 3 })) return null;
-      return { candidateApplied: true, supersededReason: undefined };
+      return {
+        candidateApplied: true,
+        supersededReason: undefined,
+        writerOutcome: "materialized" as const,
+      };
     });
-    if (!mutation) return null;
-    return complete(mutation.candidateApplied, mutation.supersededReason);
+    if (!mutation) {
+      recorder.finalize("failed");
+      writeStateWriterOutput(recorder);
+      return null;
+    }
+    const published = complete(mutation.candidateApplied, mutation.supersededReason);
+    if (mutation.writerOutcome === "materialized" && published.remoteTupleVerified) {
+      recorder.recordMaterializedCommit(1);
+    }
+    recorder.finalize(
+      published.completionKind === "superseded" ? "superseded" : mutation.writerOutcome,
+    );
+    const stateWriter = recorder.toTerminalObject();
+    return { ...published, ...(stateWriter ? { stateWriter } : {}) };
   } catch (error) {
+    recorder.finalize(
+      error instanceof StatePublishContentionError ? "contention_timeout" : "failed",
+    );
+    writeStateWriterOutput(recorder);
     if (
       error instanceof GitCommandTimeoutError ||
       error instanceof RecordTupleError ||
@@ -533,6 +580,8 @@ function publishSnapshot({
       throw error;
     console.error(error instanceof Error ? error.message : String(error));
     return null;
+  } finally {
+    resetTelemetry();
   }
 }
 
@@ -625,10 +674,36 @@ function writeEventDispositionOutputs(published: PublishedEventSnapshot): void {
       `policy_noop=${published.policyNoop ? "true" : "false"}`,
       `requeue_latest=${published.requeueLatest ? "true" : "false"}`,
       `routing_deferred=${published.routingDeferred ? "true" : "false"}`,
+      ...(published.stateWriter
+        ? [`state_writer_json=${JSON.stringify(published.stateWriter)}`]
+        : []),
       "",
     ].join("\n"),
     "utf8",
   );
+}
+
+function writeStateWriterOutput(recorder: StateWriterTelemetryRecorder): void {
+  const terminal = recorder.toTerminalObject();
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!terminal || !outputPath) return;
+  fs.appendFileSync(outputPath, `state_writer_json=${JSON.stringify(terminal)}\n`, "utf8");
+}
+
+function stateWriterObserver(): StateWriterTelemetryObserver | undefined {
+  const integer = (value: string | undefined) => {
+    const number = Number(value);
+    return Number.isInteger(number) && number > 0 ? number : null;
+  };
+  return stateWriterProgressReporter({
+    queueUrl: String(process.env.EXACT_REVIEW_QUEUE_URL || ""),
+    leaseId: String(process.env.EXACT_REVIEW_LEASE_ID || ""),
+    itemKey: String(process.env.EXACT_REVIEW_ITEM_KEY || ""),
+    leaseRevision: integer(process.env.EXACT_REVIEW_LEASE_REVISION) ?? 0,
+    claimGeneration: integer(process.env.EXACT_REVIEW_CLAIM_GENERATION) ?? 0,
+    runId: String(process.env.GITHUB_RUN_ID || ""),
+    runAttempt: integer(process.env.GITHUB_RUN_ATTEMPT) ?? 0,
+  });
 }
 
 function writeLegacyRefreshRequiredOutputs(): void {

--- a/src/repair/state-writer-progress-reporter.ts
+++ b/src/repair/state-writer-progress-reporter.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import type { StateWriterTelemetryObserver } from "./state-writer-telemetry-recorder.js";
+
+export type StateWriterProgressClaim = {
+  queueUrl: string;
+  leaseId: string;
+  itemKey: string;
+  leaseRevision: number;
+  claimGeneration: number;
+  runId: string;
+  runAttempt: number;
+};
+
+export function stateWriterProgressReporter(
+  claim: StateWriterProgressClaim | null,
+): StateWriterTelemetryObserver | undefined {
+  if (!claim || !validClaim(claim)) return undefined;
+  return {
+    progress(progress) {
+      try {
+        const child = spawn(
+          process.execPath,
+          [
+            "--input-type=module",
+            "-e",
+            `const [url, payload] = process.argv.slice(1);
+             const controller = new AbortController();
+             setTimeout(() => controller.abort(), 4000).unref();
+             fetch(url, { method: "POST", headers: {"content-type": "application/json"},
+               body: payload, signal: controller.signal }).catch(() => {});`,
+            `${claim.queueUrl.replace(/\/$/, "")}/internal/exact-review/state-writer-progress`,
+            JSON.stringify({
+              ...progress,
+              lease_id: claim.leaseId,
+              item_key: claim.itemKey,
+              lease_revision: claim.leaseRevision,
+              claim_generation: claim.claimGeneration,
+              run_id: claim.runId,
+              run_attempt: claim.runAttempt,
+            }),
+          ],
+          { detached: true, stdio: "ignore", windowsHide: true },
+        );
+        child.on("error", () => {});
+        child.unref();
+      } catch {
+        // Progress is intentionally fire-and-forget.
+      }
+    },
+  };
+}
+
+function validClaim(claim: StateWriterProgressClaim): boolean {
+  return (
+    claim.queueUrl.startsWith("https://") &&
+    Boolean(claim.leaseId) &&
+    Boolean(claim.itemKey) &&
+    /^\d+$/.test(claim.runId) &&
+    Number.isInteger(claim.leaseRevision) &&
+    claim.leaseRevision > 0 &&
+    Number.isInteger(claim.claimGeneration) &&
+    claim.claimGeneration > 0 &&
+    Number.isInteger(claim.runAttempt) &&
+    claim.runAttempt > 0
+  );
+}

--- a/src/repair/state-writer-telemetry-recorder.ts
+++ b/src/repair/state-writer-telemetry-recorder.ts
@@ -1,0 +1,172 @@
+import {
+  normalizeStateWriterOperation,
+  type StateWriterOperation,
+  type StateWriterOutcome,
+  type StateWriterPhase,
+  type StateWriterProgress,
+  STATE_WRITER_SCHEMA_VERSION,
+} from "../state-writer-telemetry.js";
+
+export type StateWriterTelemetryObserver = {
+  progress?: (progress: StateWriterProgress) => void;
+};
+
+export type StateWriterTelemetryRecorderOptions = {
+  mode?: "single_item" | "batch";
+  operationId?: string;
+  runId?: string;
+  runAttempt?: string | number;
+  configuredBatchSize?: number;
+  actualBatchSize?: number;
+  batchWaitMs?: number | null;
+  observer?: StateWriterTelemetryObserver;
+  now?: () => number;
+};
+
+export class StateWriterTelemetryRecorder {
+  private readonly now;
+  private readonly startedAtMs;
+  private readonly operationId;
+  private readonly mode;
+  private readonly configuredBatchSize;
+  private actualBatchSize;
+  private readonly batchWaitMs;
+  private waitStartedAtMs: number | null = null;
+  private holdStartedAtMs: number | null = null;
+  private acquired = false;
+  private acquireAttempts = 0;
+  private waitMs = 0;
+  private holdMs: number | null = null;
+  private renewals = 0;
+  private released: boolean | null = null;
+  private gitProcesses = 0;
+  private commitCount: 0 | 1 = 0;
+  private materializedItems = 0;
+  private outcome: StateWriterOutcome | null = null;
+  private sequence = 0;
+  private terminal: StateWriterOperation | null = null;
+
+  constructor(private readonly options: StateWriterTelemetryRecorderOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.startedAtMs = this.now();
+    this.mode = options.mode ?? "single_item";
+    this.configuredBatchSize = options.configuredBatchSize ?? 1;
+    this.actualBatchSize = options.actualBatchSize ?? (this.mode === "single_item" ? 1 : 0);
+    this.batchWaitMs = options.batchWaitMs ?? (this.mode === "single_item" ? null : 0);
+    this.operationId =
+      options.operationId ??
+      (options.runId && options.runAttempt
+        ? `single:${options.runId}:${options.runAttempt}`
+        : `single:local:${this.startedAtMs}`);
+  }
+
+  enteredWaiting() {
+    if (this.waitStartedAtMs !== null || this.terminal) return;
+    this.waitStartedAtMs = this.now();
+    this.emit("waiting");
+  }
+
+  recordAcquireAttempt() {
+    if (!this.terminal) this.acquireAttempts += 1;
+  }
+
+  acquiredLease() {
+    if (this.acquired || this.terminal) return;
+    const now = this.now();
+    this.acquired = true;
+    this.waitMs = Math.max(0, now - (this.waitStartedAtMs ?? now));
+    this.holdStartedAtMs = now;
+    this.emit("holding");
+  }
+
+  recordRenewal() {
+    if (this.acquired && !this.terminal) this.renewals += 1;
+  }
+
+  recordGitProcess() {
+    if (!this.terminal) this.gitProcesses += 1;
+  }
+
+  recordMaterializedCommit(itemCount: number) {
+    if (!this.acquired || this.terminal || !Number.isSafeInteger(itemCount) || itemCount < 1)
+      return;
+    this.commitCount = 1;
+    this.materializedItems = itemCount;
+    if (this.mode === "single_item") this.actualBatchSize = 1;
+  }
+
+  enteredReleasing() {
+    if (this.acquired && !this.terminal) this.emit("releasing");
+  }
+
+  finished() {
+    if (!this.terminal) this.emit("finished");
+  }
+
+  releasedLease(released: boolean) {
+    if (!this.acquired || this.terminal) return;
+    this.released = released;
+    this.holdMs = Math.max(0, this.now() - (this.holdStartedAtMs ?? this.now()));
+  }
+
+  finalize(outcome: StateWriterOutcome): StateWriterOperation {
+    if (this.terminal) return this.terminal;
+    const finishedAtMs = this.now();
+    if (this.waitStartedAtMs !== null && !this.acquired) {
+      this.waitMs = Math.max(0, finishedAtMs - this.waitStartedAtMs);
+    }
+    if (this.acquired && this.holdMs === null) {
+      this.holdMs = Math.max(0, finishedAtMs - (this.holdStartedAtMs ?? finishedAtMs));
+    }
+    this.outcome = outcome;
+    this.emit("finished");
+    const candidate = {
+      schema_version: STATE_WRITER_SCHEMA_VERSION,
+      operation_id: this.operationId,
+      mode: this.mode,
+      started_at: new Date(this.startedAtMs).toISOString(),
+      finished_at: new Date(finishedAtMs).toISOString(),
+      wait_ms: this.waitMs,
+      acquire_attempts: this.acquireAttempts,
+      acquired: this.acquired,
+      hold_ms: this.acquired ? this.holdMs : null,
+      renewals: this.acquired ? this.renewals : 0,
+      released: this.acquired ? this.released : null,
+      git_duration_ms: Math.max(0, finishedAtMs - this.startedAtMs),
+      git_processes: this.gitProcesses,
+      commit_count: this.commitCount,
+      materialized_items: this.materializedItems,
+      configured_batch_size: this.configuredBatchSize,
+      actual_batch_size: this.actualBatchSize,
+      batch_wait_ms: this.batchWaitMs,
+      outcome: this.outcome,
+    };
+    this.terminal = normalizeStateWriterOperation(candidate) ?? {
+      ...candidate,
+      actual_batch_size: this.mode === "single_item" ? 1 : Math.max(1, this.actualBatchSize),
+      materialized_items: this.commitCount ? Math.max(1, this.materializedItems) : 0,
+    };
+    return this.terminal;
+  }
+
+  toTerminalObject(): StateWriterOperation | null {
+    return this.terminal;
+  }
+
+  private emit(phase: StateWriterPhase) {
+    try {
+      this.options.observer?.progress?.({
+        schema_version: STATE_WRITER_SCHEMA_VERSION,
+        operation_id: this.operationId,
+        mode: this.mode,
+        phase,
+        sequence: ++this.sequence,
+        observed_at: new Date(this.now()).toISOString(),
+        configured_batch_size: this.configuredBatchSize,
+        actual_batch_size: this.mode === "single_item" ? 1 : Math.max(1, this.actualBatchSize),
+      });
+    } catch {
+      // Telemetry observers are always best effort.
+    }
+  }
+}

--- a/src/repair/state-writer-telemetry-recorder.ts
+++ b/src/repair/state-writer-telemetry-recorder.ts
@@ -4,6 +4,8 @@ import {
   type StateWriterOutcome,
   type StateWriterPhase,
   type StateWriterProgress,
+  STATE_WRITER_MAX_COUNT,
+  STATE_WRITER_MAX_DURATION_MS,
   STATE_WRITER_SCHEMA_VERSION,
 } from "../state-writer-telemetry.js";
 
@@ -22,6 +24,8 @@ export type StateWriterTelemetryRecorderOptions = {
   observer?: StateWriterTelemetryObserver;
   now?: () => number;
 };
+
+const PROGRESS_REFRESH_MS = 30_000;
 
 export class StateWriterTelemetryRecorder {
   private readonly options: StateWriterTelemetryRecorderOptions;
@@ -45,6 +49,8 @@ export class StateWriterTelemetryRecorder {
   private materializedItems = 0;
   private outcome: StateWriterOutcome | null = null;
   private sequence = 0;
+  private lastProgressPhase: StateWriterPhase | null = null;
+  private lastProgressAtMs = 0;
   private terminal: StateWriterOperation | null = null;
 
   constructor(options: StateWriterTelemetryRecorderOptions = {}) {
@@ -69,7 +75,9 @@ export class StateWriterTelemetryRecorder {
   }
 
   recordAcquireAttempt() {
-    if (!this.terminal) this.acquireAttempts += 1;
+    if (this.terminal) return;
+    this.acquireAttempts += 1;
+    if (!this.acquired) this.refreshProgress("waiting");
   }
 
   acquiredLease() {
@@ -82,11 +90,16 @@ export class StateWriterTelemetryRecorder {
   }
 
   recordRenewal() {
-    if (this.acquired && !this.terminal) this.renewals += 1;
+    if (this.acquired && !this.terminal) {
+      this.renewals += 1;
+      this.refreshProgress("holding");
+    }
   }
 
   recordGitProcess() {
-    if (!this.terminal) this.gitProcesses += 1;
+    if (this.terminal) return;
+    this.gitProcesses += 1;
+    if (this.acquired) this.refreshProgress("holding");
   }
 
   recordMaterializedCommit(itemCount: number) {
@@ -111,7 +124,7 @@ export class StateWriterTelemetryRecorder {
     this.holdMs = Math.max(0, this.now() - (this.holdStartedAtMs ?? this.now()));
   }
 
-  finalize(outcome: StateWriterOutcome): StateWriterOperation {
+  finalize(outcome: StateWriterOutcome): StateWriterOperation | null {
     if (this.terminal) return this.terminal;
     const finishedAtMs = this.now();
     if (this.waitStartedAtMs !== null && !this.acquired) {
@@ -132,22 +145,22 @@ export class StateWriterTelemetryRecorder {
       mode: this.mode,
       started_at: new Date(this.startedAtMs).toISOString(),
       finished_at: new Date(finishedAtMs).toISOString(),
-      wait_ms: this.waitMs,
-      acquire_attempts: this.acquireAttempts,
+      wait_ms: clampDuration(this.waitMs),
+      acquire_attempts: clampCount(this.acquireAttempts),
       acquired: this.acquired,
-      hold_ms: this.acquired ? (this.holdMs ?? 0) : null,
-      renewals: this.acquired ? this.renewals : 0,
+      hold_ms: this.acquired ? clampDuration(this.holdMs ?? 0) : null,
+      renewals: this.acquired ? clampCount(this.renewals) : 0,
       released: this.acquired ? (this.released ?? false) : null,
-      git_duration_ms: Math.max(0, finishedAtMs - this.startedAtMs),
-      git_processes: this.gitProcesses,
+      git_duration_ms: clampDuration(Math.max(0, finishedAtMs - this.startedAtMs)),
+      git_processes: clampCount(this.gitProcesses),
       commit_count: this.commitCount,
-      materialized_items: this.materializedItems,
+      materialized_items: clampCount(this.materializedItems),
       configured_batch_size: this.configuredBatchSize,
       actual_batch_size:
         this.mode === "single_item"
           ? 1
           : Math.max(1, this.actualBatchSize || this.configuredBatchSize),
-      batch_wait_ms: this.mode === "single_item" ? null : (this.batchWaitMs ?? 0),
+      batch_wait_ms: this.mode === "single_item" ? null : clampDuration(this.batchWaitMs ?? 0),
       outcome: safeOutcome,
     };
     const normalized = normalizeStateWriterOperation(candidate);
@@ -155,26 +168,29 @@ export class StateWriterTelemetryRecorder {
       this.terminal = normalized;
       return this.terminal;
     }
-    // Keep publication authoritative: emit a minimal valid failed sample rather
-    // than an invariant-breaking payload that the queue would reject.
-    const fallback = normalizeStateWriterOperation({
-      ...candidate,
+    // Keep publication authoritative: omit malformed optional telemetry rather
+    // than throwing into the lease/publication path.
+    this.terminal = normalizeStateWriterOperation({
+      schema_version: STATE_WRITER_SCHEMA_VERSION,
+      operation_id: this.operationId.slice(0, 200) || `single:local:${this.startedAtMs}`,
+      mode: "single_item",
+      started_at: new Date(this.startedAtMs).toISOString(),
+      finished_at: new Date(finishedAtMs).toISOString(),
+      wait_ms: 0,
+      acquire_attempts: 0,
       acquired: false,
       hold_ms: null,
       renewals: 0,
       released: null,
+      git_duration_ms: 0,
+      git_processes: 0,
       commit_count: 0,
       materialized_items: 0,
       configured_batch_size: 1,
       actual_batch_size: 1,
       batch_wait_ms: null,
-      mode: "single_item",
       outcome: "failed",
     });
-    if (!fallback) {
-      throw new Error("state writer telemetry fallback normalization failed");
-    }
-    this.terminal = fallback;
     return this.terminal;
   }
 
@@ -182,8 +198,20 @@ export class StateWriterTelemetryRecorder {
     return this.terminal;
   }
 
+  private refreshProgress(phase: StateWriterPhase) {
+    if (this.terminal) return;
+    if (this.lastProgressPhase !== phase) {
+      this.emit(phase);
+      return;
+    }
+    if (this.now() - this.lastProgressAtMs < PROGRESS_REFRESH_MS) return;
+    this.emit(phase);
+  }
+
   private emit(phase: StateWriterPhase) {
     try {
+      this.lastProgressPhase = phase;
+      this.lastProgressAtMs = this.now();
       this.options.observer?.progress?.({
         schema_version: STATE_WRITER_SCHEMA_VERSION,
         operation_id: this.operationId,
@@ -198,4 +226,12 @@ export class StateWriterTelemetryRecorder {
       // Telemetry observers are always best effort.
     }
   }
+}
+
+function clampDuration(value: number): number {
+  return Math.min(STATE_WRITER_MAX_DURATION_MS, Math.max(0, value));
+}
+
+function clampCount(value: number): number {
+  return Math.min(STATE_WRITER_MAX_COUNT, Math.max(0, value));
 }

--- a/src/repair/state-writer-telemetry-recorder.ts
+++ b/src/repair/state-writer-telemetry-recorder.ts
@@ -24,13 +24,14 @@ export type StateWriterTelemetryRecorderOptions = {
 };
 
 export class StateWriterTelemetryRecorder {
-  private readonly now;
-  private readonly startedAtMs;
-  private readonly operationId;
-  private readonly mode;
-  private readonly configuredBatchSize;
-  private actualBatchSize;
-  private readonly batchWaitMs;
+  private readonly options: StateWriterTelemetryRecorderOptions;
+  private readonly now: () => number;
+  private readonly startedAtMs: number;
+  private readonly operationId: string;
+  private readonly mode: "single_item" | "batch";
+  private readonly configuredBatchSize: number;
+  private actualBatchSize: number;
+  private readonly batchWaitMs: number | null;
   private waitStartedAtMs: number | null = null;
   private holdStartedAtMs: number | null = null;
   private acquired = false;
@@ -46,7 +47,8 @@ export class StateWriterTelemetryRecorder {
   private sequence = 0;
   private terminal: StateWriterOperation | null = null;
 
-  constructor(private readonly options: StateWriterTelemetryRecorderOptions = {}) {
+  constructor(options: StateWriterTelemetryRecorderOptions = {}) {
+    this.options = options;
     this.now = options.now ?? Date.now;
     this.startedAtMs = this.now();
     this.mode = options.mode ?? "single_item";
@@ -120,6 +122,10 @@ export class StateWriterTelemetryRecorder {
     }
     this.outcome = outcome;
     this.emit("finished");
+    const safeOutcome =
+      !this.acquired && outcome !== "contention_timeout" && outcome !== "failed"
+        ? "failed"
+        : outcome;
     const candidate = {
       schema_version: STATE_WRITER_SCHEMA_VERSION,
       operation_id: this.operationId,
@@ -129,23 +135,46 @@ export class StateWriterTelemetryRecorder {
       wait_ms: this.waitMs,
       acquire_attempts: this.acquireAttempts,
       acquired: this.acquired,
-      hold_ms: this.acquired ? this.holdMs : null,
+      hold_ms: this.acquired ? (this.holdMs ?? 0) : null,
       renewals: this.acquired ? this.renewals : 0,
-      released: this.acquired ? this.released : null,
+      released: this.acquired ? (this.released ?? false) : null,
       git_duration_ms: Math.max(0, finishedAtMs - this.startedAtMs),
       git_processes: this.gitProcesses,
       commit_count: this.commitCount,
       materialized_items: this.materializedItems,
       configured_batch_size: this.configuredBatchSize,
-      actual_batch_size: this.actualBatchSize,
-      batch_wait_ms: this.batchWaitMs,
-      outcome: this.outcome,
+      actual_batch_size:
+        this.mode === "single_item"
+          ? 1
+          : Math.max(1, this.actualBatchSize || this.configuredBatchSize),
+      batch_wait_ms: this.mode === "single_item" ? null : (this.batchWaitMs ?? 0),
+      outcome: safeOutcome,
     };
-    this.terminal = normalizeStateWriterOperation(candidate) ?? {
+    const normalized = normalizeStateWriterOperation(candidate);
+    if (normalized) {
+      this.terminal = normalized;
+      return this.terminal;
+    }
+    // Keep publication authoritative: emit a minimal valid failed sample rather
+    // than an invariant-breaking payload that the queue would reject.
+    const fallback = normalizeStateWriterOperation({
       ...candidate,
-      actual_batch_size: this.mode === "single_item" ? 1 : Math.max(1, this.actualBatchSize),
-      materialized_items: this.commitCount ? Math.max(1, this.materializedItems) : 0,
-    };
+      acquired: false,
+      hold_ms: null,
+      renewals: 0,
+      released: null,
+      commit_count: 0,
+      materialized_items: 0,
+      configured_batch_size: 1,
+      actual_batch_size: 1,
+      batch_wait_ms: null,
+      mode: "single_item",
+      outcome: "failed",
+    });
+    if (!fallback) {
+      throw new Error("state writer telemetry fallback normalization failed");
+    }
+    this.terminal = fallback;
     return this.terminal;
   }
 

--- a/src/state-writer-telemetry.ts
+++ b/src/state-writer-telemetry.ts
@@ -101,6 +101,8 @@ export function normalizeStateWriterOperation(value: unknown): StateWriterOperat
         commitCount !== 0 ||
         materializedItems !== 0)) ||
     (commitCount === 1 && (!acquired || materializedItems < 1)) ||
+    (outcome === "materialized" && (commitCount !== 1 || materializedItems < 1)) ||
+    (outcome !== "materialized" && (commitCount !== 0 || materializedItems !== 0)) ||
     (mode === "single_item" &&
       (configuredBatchSize !== 1 || actualBatchSize !== 1 || batchWaitMs !== null)) ||
     (mode === "batch" && batchWaitMs === null) ||

--- a/src/state-writer-telemetry.ts
+++ b/src/state-writer-telemetry.ts
@@ -1,0 +1,241 @@
+export const STATE_WRITER_SCHEMA_VERSION = 1 as const;
+export const STATE_WRITER_MAX_DURATION_MS = 60 * 60 * 1000;
+export const STATE_WRITER_MAX_COUNT = 10_000;
+export const STATE_WRITER_MAX_OPERATION_ID_LENGTH = 200;
+
+export type StateWriterMode = "single_item" | "batch";
+export type StateWriterOutcome =
+  | "materialized"
+  | "unchanged"
+  | "superseded"
+  | "contention_timeout"
+  | "failed";
+export type StateWriterPhase = "waiting" | "holding" | "releasing" | "finished";
+
+export type StateWriterOperation = {
+  schema_version: typeof STATE_WRITER_SCHEMA_VERSION;
+  operation_id: string;
+  mode: StateWriterMode;
+  started_at: string;
+  finished_at: string;
+  wait_ms: number;
+  acquire_attempts: number;
+  acquired: boolean;
+  hold_ms: number | null;
+  renewals: number;
+  released: boolean | null;
+  git_duration_ms: number;
+  git_processes: number;
+  commit_count: 0 | 1;
+  materialized_items: number;
+  configured_batch_size: number;
+  actual_batch_size: number;
+  batch_wait_ms: number | null;
+  outcome: StateWriterOutcome;
+};
+
+export type StateWriterProgress = {
+  schema_version: typeof STATE_WRITER_SCHEMA_VERSION;
+  operation_id: string;
+  mode: StateWriterMode;
+  phase: StateWriterPhase;
+  sequence: number;
+  observed_at: string;
+  configured_batch_size: number;
+  actual_batch_size: number;
+};
+
+export function normalizeStateWriterOperation(value: unknown): StateWriterOperation | null {
+  const input = objectValue(value);
+  if (!input || input.schema_version !== STATE_WRITER_SCHEMA_VERSION) return null;
+  const operationId = boundedString(input.operation_id, STATE_WRITER_MAX_OPERATION_ID_LENGTH);
+  const mode = stateWriterMode(input.mode);
+  const outcome = stateWriterOutcome(input.outcome);
+  const startedAt = timestamp(input.started_at);
+  const finishedAt = timestamp(input.finished_at);
+  const waitMs = duration(input.wait_ms);
+  const acquireAttempts = count(input.acquire_attempts);
+  const acquired = input.acquired;
+  const holdMs = nullableDuration(input.hold_ms);
+  const renewals = count(input.renewals);
+  const released = nullableBoolean(input.released);
+  const gitDurationMs = duration(input.git_duration_ms);
+  const gitProcesses = count(input.git_processes);
+  const commitCount = input.commit_count;
+  const materializedItems = count(input.materialized_items);
+  const configuredBatchSize = count(input.configured_batch_size);
+  const actualBatchSize = count(input.actual_batch_size);
+  const batchWaitMs = nullableDuration(input.batch_wait_ms);
+  if (
+    !operationId ||
+    !mode ||
+    !outcome ||
+    !startedAt ||
+    !finishedAt ||
+    waitMs === null ||
+    acquireAttempts === null ||
+    typeof acquired !== "boolean" ||
+    holdMs === undefined ||
+    renewals === null ||
+    released === undefined ||
+    gitDurationMs === null ||
+    gitProcesses === null ||
+    (commitCount !== 0 && commitCount !== 1) ||
+    materializedItems === null ||
+    configuredBatchSize === null ||
+    actualBatchSize === null ||
+    batchWaitMs === undefined
+  ) {
+    return null;
+  }
+  if (
+    Date.parse(finishedAt) < Date.parse(startedAt) ||
+    configuredBatchSize < 1 ||
+    actualBatchSize < 1 ||
+    actualBatchSize > configuredBatchSize ||
+    materializedItems > actualBatchSize ||
+    (!acquired &&
+      (holdMs !== null ||
+        released !== null ||
+        renewals !== 0 ||
+        commitCount !== 0 ||
+        materializedItems !== 0)) ||
+    (commitCount === 1 && (!acquired || materializedItems < 1)) ||
+    (mode === "single_item" &&
+      (configuredBatchSize !== 1 || actualBatchSize !== 1 || batchWaitMs !== null)) ||
+    (mode === "batch" && batchWaitMs === null) ||
+    (outcome === "contention_timeout" && acquired)
+  ) {
+    return null;
+  }
+  return {
+    schema_version: STATE_WRITER_SCHEMA_VERSION,
+    operation_id: operationId,
+    mode,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    wait_ms: waitMs,
+    acquire_attempts: acquireAttempts,
+    acquired,
+    hold_ms: holdMs,
+    renewals,
+    released,
+    git_duration_ms: gitDurationMs,
+    git_processes: gitProcesses,
+    commit_count: commitCount,
+    materialized_items: materializedItems,
+    configured_batch_size: configuredBatchSize,
+    actual_batch_size: actualBatchSize,
+    batch_wait_ms: batchWaitMs,
+    outcome,
+  };
+}
+
+export function normalizeStateWriterProgress(value: unknown): StateWriterProgress | null {
+  const input = objectValue(value);
+  if (!input || input.schema_version !== STATE_WRITER_SCHEMA_VERSION) return null;
+  const operationId = boundedString(input.operation_id, STATE_WRITER_MAX_OPERATION_ID_LENGTH);
+  const mode = stateWriterMode(input.mode);
+  const phase = stateWriterPhase(input.phase);
+  const sequence = count(input.sequence);
+  const observedAt = timestamp(input.observed_at);
+  const configuredBatchSize = count(input.configured_batch_size);
+  const actualBatchSize = count(input.actual_batch_size);
+  if (
+    !operationId ||
+    !mode ||
+    !phase ||
+    sequence === null ||
+    sequence < 1 ||
+    !observedAt ||
+    configuredBatchSize === null ||
+    configuredBatchSize < 1 ||
+    actualBatchSize === null ||
+    actualBatchSize < 1 ||
+    actualBatchSize > configuredBatchSize ||
+    (mode === "single_item" && (configuredBatchSize !== 1 || actualBatchSize !== 1))
+  ) {
+    return null;
+  }
+  return {
+    schema_version: STATE_WRITER_SCHEMA_VERSION,
+    operation_id: operationId,
+    mode,
+    phase,
+    sequence,
+    observed_at: observedAt,
+    configured_batch_size: configuredBatchSize,
+    actual_batch_size: actualBatchSize,
+  };
+}
+
+export function payloadHash(normalized: StateWriterOperation): string {
+  return stableHash(JSON.stringify(normalized));
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function boundedString(value: unknown, maximum: number): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text && text.length <= maximum ? text : null;
+}
+
+function timestamp(value: unknown): string | null {
+  const text = typeof value === "string" ? value : "";
+  return Number.isFinite(Date.parse(text)) ? new Date(text).toISOString() : null;
+}
+
+function count(value: unknown): number | null {
+  return integer(value, STATE_WRITER_MAX_COUNT);
+}
+
+function duration(value: unknown): number | null {
+  return integer(value, STATE_WRITER_MAX_DURATION_MS);
+}
+
+function nullableDuration(value: unknown): number | null | undefined {
+  return value === null ? null : (duration(value) ?? undefined);
+}
+
+function nullableBoolean(value: unknown): boolean | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "boolean") return value;
+  return undefined;
+}
+
+function integer(value: unknown, maximum: number): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= maximum
+    ? value
+    : null;
+}
+
+function stateWriterMode(value: unknown): StateWriterMode | null {
+  return value === "single_item" || value === "batch" ? value : null;
+}
+
+function stateWriterOutcome(value: unknown): StateWriterOutcome | null {
+  return ["materialized", "unchanged", "superseded", "contention_timeout", "failed"].includes(
+    String(value),
+  )
+    ? (value as StateWriterOutcome)
+    : null;
+}
+
+function stateWriterPhase(value: unknown): StateWriterPhase | null {
+  return ["waiting", "holding", "releasing", "finished"].includes(String(value))
+    ? (value as StateWriterPhase)
+    : null;
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -166,6 +166,36 @@ test("health history preserves legacy samples and normalizes exact-review backlo
   );
 });
 
+test("health history keeps legacy samples when optional state_writer is absent or invalid", () => {
+  const legacy = legacyHistorySample();
+  assert.equal(normalizeHealthHistorySample(legacy)?.state_writer, undefined);
+  assert.deepEqual(
+    normalizeHealthHistorySample({
+      ...legacy,
+      state_writer: {
+        collection_ok: true,
+        mode: "single_item",
+        tracked_holding: 1,
+        tracked_waiting: 2,
+        tracked_releasing: 0,
+        accepted_operations_total: 3,
+        state_commits_total: 3,
+        materialized_items_total: 3,
+        contention_timeouts_total: 0,
+        wait_ms: { p50: 10, p95: 20, samples: 3 },
+        hold_ms: { p50: 30, p95: 40, samples: 3 },
+        last_successful_materialization_at: CHECKED_AT,
+      },
+    })?.state_writer?.mode,
+    "single_item",
+  );
+  const withInvalidWriter = normalizeHealthHistorySample({
+    ...legacy,
+    state_writer: { collection_ok: true, mode: "not-a-mode" },
+  });
+  assert.deepEqual(withInvalidWriter, legacy);
+});
+
 test("health history rejects non-finite or incomplete samples", () => {
   const sample = legacyHistorySample();
   assert.equal(normalizeHealthHistorySample({ ...sample, queued: "Infinity" }), null);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -11491,6 +11491,65 @@ function leasedExactReviewPublicationItem(itemNumber: number, runId: string) {
   };
 }
 
+test("state writer telemetry is optional, idempotent, and summary-safe", async () => {
+  const storage = new MemoryDurableStorage();
+  const items = Object.fromEntries(
+    Array.from({ length: 2 }, (_, index) => {
+      const item = leasedExactReviewQueueItem(96_000 + index, `9600${index}`);
+      return [item.key, item];
+    }),
+  );
+  await storage.put("exact-review-queue", { deliveries: {}, items });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const now = new Date().toISOString();
+  const telemetry = {
+    schema_version: 1,
+    operation_id: "batch:telemetry-test",
+    mode: "batch",
+    started_at: now,
+    finished_at: now,
+    wait_ms: 1,
+    acquire_attempts: 1,
+    acquired: true,
+    hold_ms: 2,
+    renewals: 0,
+    released: true,
+    git_duration_ms: 3,
+    git_processes: 4,
+    commit_count: 1,
+    materialized_items: 2,
+    configured_batch_size: 2,
+    actual_batch_size: 2,
+    batch_wait_ms: 1,
+    outcome: "materialized",
+  };
+  for (const item of Object.values(items)) {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: item.leaseId,
+          item_key: item.key,
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: item.claimedRunId,
+          run_attempt: 1,
+          outcome: "success",
+          state_writer: telemetry,
+        }),
+      }),
+    );
+    assert.equal(response.status, 200);
+  }
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.state_writer.last_15_minutes.operations, 1);
+  assert.equal(stats.state_writer.last_15_minutes.state_commits, 1);
+  assert.equal(stats.state_writer.last_15_minutes.materialized_items, 2);
+  assert.equal(stats.state_writer.last_15_minutes.items_per_commit, 2);
+});
+
 function unclaimedExactReviewQueueItem(itemNumber: number) {
   return {
     ...leasedExactReviewQueueItem(itemNumber, "unclaimed"),

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -11495,7 +11495,7 @@ test("state writer telemetry is optional, idempotent, and summary-safe", async (
   const storage = new MemoryDurableStorage();
   const items = Object.fromEntries(
     Array.from({ length: 2 }, (_, index) => {
-      const item = leasedExactReviewQueueItem(96_000 + index, `9600${index}`);
+      const item = leasedExactReviewPublicationItem(96_000 + index, `9600${index}`);
       return [item.key, item];
     }),
   );
@@ -11535,6 +11535,8 @@ test("state writer telemetry is optional, idempotent, and summary-safe", async (
           run_id: item.claimedRunId,
           run_attempt: 1,
           outcome: "success",
+          completion_kind: "published",
+          reason_code: "publication_applied",
           state_writer: telemetry,
         }),
       }),
@@ -11553,7 +11555,7 @@ test("state writer telemetry is optional, idempotent, and summary-safe", async (
   assert.equal(stats.state_writer.diagnostics.state_commits_total, 1);
   assert.equal(stats.state_writer.diagnostics.materialized_items_total, 2);
 
-  const malformed = leasedExactReviewQueueItem(97_001, "97001");
+  const malformed = leasedExactReviewPublicationItem(97_001, "97001");
   await storage.put("exact-review-queue", {
     deliveries: {},
     items: { [malformed.key]: malformed },
@@ -11569,6 +11571,8 @@ test("state writer telemetry is optional, idempotent, and summary-safe", async (
         run_id: malformed.claimedRunId,
         run_attempt: 1,
         outcome: "success",
+        completion_kind: "published",
+        reason_code: "publication_applied",
         state_writer: { schema_version: 1, operation_id: "bad" },
       }),
     }),
@@ -11578,6 +11582,33 @@ test("state writer telemetry is optional, idempotent, and summary-safe", async (
     await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
   assert.equal(afterReject.state_writer.diagnostics.rejected_terminal_total, 1);
+
+  const reviewOnly = leasedExactReviewQueueItem(97_002, "97002");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [reviewOnly.key]: reviewOnly },
+  });
+  const ignored = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: reviewOnly.leaseId,
+        item_key: reviewOnly.key,
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: reviewOnly.claimedRunId,
+        run_attempt: 1,
+        outcome: "success",
+        state_writer: telemetry,
+      }),
+    }),
+  );
+  assert.equal(ignored.status, 200);
+  const afterIgnore = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(afterIgnore.state_writer.last_15_minutes.operations, 1);
+  assert.equal(afterIgnore.state_writer.diagnostics.rejected_terminal_total, 2);
 });
 
 function unclaimedExactReviewQueueItem(itemNumber: number) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -11548,6 +11548,36 @@ test("state writer telemetry is optional, idempotent, and summary-safe", async (
   assert.equal(stats.state_writer.last_15_minutes.state_commits, 1);
   assert.equal(stats.state_writer.last_15_minutes.materialized_items, 2);
   assert.equal(stats.state_writer.last_15_minutes.items_per_commit, 2);
+  assert.equal(stats.state_writer.diagnostics.accepted_terminal_total, 1);
+  assert.equal(stats.state_writer.diagnostics.duplicate_terminal_total, 1);
+  assert.equal(stats.state_writer.diagnostics.state_commits_total, 1);
+  assert.equal(stats.state_writer.diagnostics.materialized_items_total, 2);
+
+  const malformed = leasedExactReviewQueueItem(97_001, "97001");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [malformed.key]: malformed },
+  });
+  const rejected = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: malformed.leaseId,
+        item_key: malformed.key,
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: malformed.claimedRunId,
+        run_attempt: 1,
+        outcome: "success",
+        state_writer: { schema_version: 1, operation_id: "bad" },
+      }),
+    }),
+  );
+  assert.equal(rejected.status, 200);
+  const afterReject = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(afterReject.state_writer.diagnostics.rejected_terminal_total, 1);
 });
 
 function unclaimedExactReviewQueueItem(itemNumber: number) {

--- a/test/repair/state-writer-telemetry-recorder.test.ts
+++ b/test/repair/state-writer-telemetry-recorder.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { StateWriterTelemetryRecorder } from "../../dist/repair/state-writer-telemetry-recorder.js";
+
+test("state writer recorder measures wait, hold, and verified materialization", () => {
+  let now = 1_000;
+  const phases: string[] = [];
+  const recorder = new StateWriterTelemetryRecorder({
+    runId: "42",
+    runAttempt: 1,
+    now: () => now,
+    observer: {
+      progress(progress) {
+        phases.push(progress.phase);
+      },
+    },
+  });
+
+  recorder.enteredWaiting();
+  now = 1_500;
+  recorder.recordAcquireAttempt();
+  recorder.recordAcquireAttempt();
+  recorder.acquiredLease();
+  now = 2_000;
+  recorder.recordGitProcess();
+  recorder.recordMaterializedCommit(1);
+  recorder.enteredReleasing();
+  recorder.releasedLease(true);
+  const terminal = recorder.finalize("materialized");
+
+  assert.equal(terminal.operation_id, "single:42:1");
+  assert.equal(terminal.wait_ms, 500);
+  assert.equal(terminal.acquire_attempts, 2);
+  assert.equal(terminal.hold_ms, 500);
+  assert.equal(terminal.commit_count, 1);
+  assert.equal(terminal.materialized_items, 1);
+  assert.equal(terminal.git_processes, 1);
+  assert.deepEqual(phases, ["waiting", "holding", "releasing", "finished"]);
+});
+
+test("state writer recorder isolates progress observer failures", () => {
+  const recorder = new StateWriterTelemetryRecorder({
+    runId: "7",
+    runAttempt: 2,
+    observer: {
+      progress() {
+        throw new Error("progress sink failed");
+      },
+    },
+  });
+  assert.doesNotThrow(() => {
+    recorder.enteredWaiting();
+    recorder.finalize("contention_timeout");
+  });
+  assert.equal(recorder.toTerminalObject()?.outcome, "contention_timeout");
+  assert.equal(recorder.toTerminalObject()?.acquired, false);
+});

--- a/test/repair/state-writer-telemetry-recorder.test.ts
+++ b/test/repair/state-writer-telemetry-recorder.test.ts
@@ -56,3 +56,28 @@ test("state writer recorder isolates progress observer failures", () => {
   assert.equal(recorder.toTerminalObject()?.outcome, "contention_timeout");
   assert.equal(recorder.toTerminalObject()?.acquired, false);
 });
+
+test("state writer recorder refreshes waiting progress during long acquisition", () => {
+  let now = 1_000;
+  const phases: Array<{ phase: string; at: number }> = [];
+  const recorder = new StateWriterTelemetryRecorder({
+    runId: "9",
+    runAttempt: 1,
+    now: () => now,
+    observer: {
+      progress(progress) {
+        phases.push({ phase: progress.phase, at: now });
+      },
+    },
+  });
+  recorder.enteredWaiting();
+  now = 20_000;
+  recorder.recordAcquireAttempt();
+  now = 40_000;
+  recorder.recordAcquireAttempt();
+  assert.deepEqual(
+    phases.map((entry) => entry.phase),
+    ["waiting", "waiting"],
+  );
+  assert.equal(phases[1]?.at, 40_000);
+});

--- a/test/state-writer-telemetry.test.ts
+++ b/test/state-writer-telemetry.test.ts
@@ -61,6 +61,24 @@ test("state writer telemetry enforces lease and batch invariants", () => {
     normalizeStateWriterOperation(operation({ outcome: "contention_timeout", acquired: true })),
     null,
   );
+  assert.equal(
+    normalizeStateWriterOperation(
+      operation({ outcome: "materialized", commit_count: 0, materialized_items: 0 }),
+    ),
+    null,
+  );
+  assert.equal(
+    normalizeStateWriterOperation(
+      operation({
+        outcome: "unchanged",
+        commit_count: 0,
+        materialized_items: 0,
+        hold_ms: 20,
+        released: true,
+      }),
+    )?.outcome,
+    "unchanged",
+  );
 });
 
 test("state writer progress accepts only monotonic-shaped valid payloads", () => {

--- a/test/state-writer-telemetry.test.ts
+++ b/test/state-writer-telemetry.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeStateWriterOperation,
+  normalizeStateWriterProgress,
+  payloadHash,
+} from "../src/state-writer-telemetry.ts";
+
+function operation(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: 1,
+    operation_id: "single:123:1",
+    mode: "single_item",
+    started_at: "2026-07-21T01:00:00.000Z",
+    finished_at: "2026-07-21T01:00:30.000Z",
+    wait_ms: 10,
+    acquire_attempts: 1,
+    acquired: true,
+    hold_ms: 20,
+    renewals: 0,
+    released: true,
+    git_duration_ms: 30,
+    git_processes: 4,
+    commit_count: 1,
+    materialized_items: 1,
+    configured_batch_size: 1,
+    actual_batch_size: 1,
+    batch_wait_ms: null,
+    outcome: "materialized",
+    ...overrides,
+  };
+}
+
+test("state writer telemetry normalizes valid terminal operations canonically", () => {
+  const normalized = normalizeStateWriterOperation(operation());
+  assert.ok(normalized);
+  assert.equal(payloadHash(normalized), payloadHash(normalized));
+  assert.deepEqual(normalizeStateWriterOperation({ ...operation(), schema_version: 2 }), null);
+});
+
+test("state writer telemetry enforces lease and batch invariants", () => {
+  assert.equal(
+    normalizeStateWriterOperation(
+      operation({ acquired: false, hold_ms: 1, commit_count: 0, materialized_items: 0 }),
+    ),
+    null,
+  );
+  assert.equal(
+    normalizeStateWriterOperation(
+      operation({
+        mode: "batch",
+        configured_batch_size: 2,
+        actual_batch_size: 2,
+        batch_wait_ms: null,
+      }),
+    ),
+    null,
+  );
+  assert.equal(
+    normalizeStateWriterOperation(operation({ outcome: "contention_timeout", acquired: true })),
+    null,
+  );
+});
+
+test("state writer progress accepts only monotonic-shaped valid payloads", () => {
+  assert.deepEqual(
+    normalizeStateWriterProgress({
+      schema_version: 1,
+      operation_id: "single:123:1",
+      mode: "single_item",
+      phase: "waiting",
+      sequence: 1,
+      observed_at: "2026-07-21T01:00:00.000Z",
+      configured_batch_size: 1,
+      actual_batch_size: 1,
+    })?.phase,
+    "waiting",
+  );
+  assert.equal(
+    normalizeStateWriterProgress({
+      schema_version: 1,
+      operation_id: "single:123:1",
+      mode: "single_item",
+      phase: "waiting",
+      sequence: 0,
+      observed_at: "2026-07-21T01:00:00.000Z",
+      configured_batch_size: 1,
+      actual_batch_size: 1,
+    }),
+    null,
+  );
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -22,6 +22,17 @@ test("sweep keeps optional media tooling out of review startup", () => {
   assert.doesNotMatch(workflow, /setup-media-proof-tools/);
 });
 
+test("exact publication forwards state writer telemetry through the Node payload builder", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  assert.match(
+    workflow,
+    /STATE_WRITER_JSON: \$\{\{ steps\.exact-review-publication-result\.outputs\.state_writer_json \}\}/,
+  );
+  assert.match(workflow, /const parsed = JSON\.parse\(process\.env\.STATE_WRITER_JSON \|\| ""\)/);
+  assert.match(workflow, /\.\.\.\(stateWriter \? \{ state_writer: stateWriter \} : \{\}\)/);
+  assert.doesNotMatch(workflow, /--data .*STATE_WRITER_JSON/);
+});
+
 test("ledger-producing jobs initialize immutable workflow context", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   for (const jobName of [

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -636,8 +636,10 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.match(publisherSource, /StatePublishContentionError\s*\? "state_contention"/);
   assert.match(
     publisherSource,
-    /const mutation = withStatePublishLease\(\(\) => \{\s*hardResetToRemoteMain\(\)/,
+    /const mutation = withStatePublishLease\(\s*\(\) => \{\s*hardResetToRemoteMain\(\)/,
   );
+  assert.match(publisherSource, /observer:\s*recorder/);
+  assert.match(publisherSource, /state_writer_json=/);
   assert.match(publisherSource, /retryable_failure/);
   assert.match(publisherSource, /error instanceof GitCommandTimeoutError/);
   assert.match(


### PR DESCRIPTION
## Summary
- Add additive State writer telemetry across the exact-result publisher, queue Durable Object, workflow completion payload, health history, and live dashboard.
- Surface a separate dashboard panel for the single serialized state-ref writer so `50 active` publication workflows are no longer mistaken for Git write concurrency.
- Keep the same v1 contract ready for later publication batching (`single_item` / `mixed` / `batch`) without enabling batching in this PR.

## Test plan
- [x] `pnpm run build:repair && pnpm run build:dashboard`
- [x] `pnpm run lint` / `pnpm run format:check`
- [x] Focused tests: `test/state-writer-telemetry.test.ts`, `test/repair/state-writer-telemetry-recorder.test.ts`, state-writer cases in `test/dashboard-worker.test.ts` / `test/dashboard-operational-health.test.ts`, `test/sweep-workflow.test.ts`
- [x] Autoreview clean vs `origin/main`
- [ ] After deploy: confirm old completions without `state_writer` still succeed, then verify `/stats.state_writer` and the new panel populate from single-item publishers


Made with [Cursor](https://cursor.com)