### PR TITLE
feat(queue): state-append window endpoints for single-writer materialization (#738 WP-1)

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -224,6 +224,23 @@ type ExactReviewQueueMetricDelta = {
   publicationDeadLettered?: number;
   publicationRefreshed?: number;
 };
+type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof";
+type StateAppendRecord = {
+  kind: StateAppendKind;
+  key: string;
+  payloadJson: string;
+  payloadBytes: number;
+  producedAt: string;
+};
+type StateAppendWindowRow = {
+  seq: number;
+  kind: StateAppendKind;
+  record_key: string;
+  payload_json: string;
+  payload_bytes: number;
+  produced_at: string;
+  delivery_id: string;
+};
 export type DurableObjectStub = { fetch: (request: Request) => Promise<Response> };
 export type DurableObjectNamespace = {
   idFromName: (name: string) => unknown;
@@ -291,6 +308,19 @@ const EXACT_REVIEW_QUEUE_DELIVERY_TABLE = "exact_review_queue_deliveries";
 const EXACT_REVIEW_QUEUE_METRICS_TABLE = "exact_review_queue_metrics";
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE = "exact_review_queue_metric_buckets";
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
+const STATE_APPEND_WINDOW_TABLE = "state_append_window";
+const STATE_APPEND_RECEIPT_TABLE = "state_append_receipts";
+const STATE_APPEND_DRAIN_TABLE = "state_append_drains";
+const STATE_APPEND_META_TABLE = "state_append_meta";
+const STATE_APPEND_KINDS = new Set<StateAppendKind>([
+  "sweep_status",
+  "comment_router",
+  "apply_proof",
+]);
+const DEFAULT_STATE_APPEND_MAX_PENDING_ROWS = 50_000;
+const DEFAULT_STATE_APPEND_MAX_PENDING_BYTES = 100 * 1024 * 1024;
+const DEFAULT_STATE_APPEND_MAX_RECORD_BYTES = 256 * 1024;
+const DEFAULT_STATE_APPEND_DRAIN_LEASE_MS = 10 * 60 * 1000;
 const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
 const EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE = "exact_review_state_writer_operations";
@@ -337,6 +367,151 @@ export class ExactReviewQueue {
     await this.ready;
     this.cleanupLegacyCompatibilitySync();
     const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/state/append") {
+      const body = objectValue(await request.json().catch(() => null));
+      const deliveryId = String(body.delivery_id || "").trim();
+      if (!deliveryId) return json({ error: "missing_delivery_id" }, 400);
+      const normalized = stateAppendRecords(body.records, stateAppendMaxRecordBytes(this.env));
+      if (!normalized.ok) return json({ error: normalized.error }, 400);
+
+      const now = Date.now();
+      const appended = this.storage.transactionSync(() => {
+        this.pruneStateAppendReceiptsSync(now);
+        this.storage.sql.exec(
+          `DELETE FROM ${STATE_APPEND_RECEIPT_TABLE}
+            WHERE delivery_id = ? AND received_at <= ?`,
+          deliveryId,
+          now - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS,
+        );
+        const existingReceipt = Array.from(
+          this.storage.sql.exec(
+            `SELECT delivery_id FROM ${STATE_APPEND_RECEIPT_TABLE} WHERE delivery_id = ?`,
+            deliveryId,
+          ),
+        ).length;
+        if (existingReceipt) return { kind: "deduped" as const };
+
+        const window = this.stateAppendWindowTotalsSync();
+        const appendedBytes = normalized.records.reduce(
+          (sum, record) => sum + record.payloadBytes,
+          0,
+        );
+        if (
+          window.pendingRows + normalized.records.length > stateAppendMaxPendingRows(this.env) ||
+          window.pendingBytes + appendedBytes > stateAppendMaxPendingBytes(this.env)
+        ) {
+          this.storage.sql.exec(
+            `UPDATE ${STATE_APPEND_META_TABLE}
+                SET shed_since_reset = shed_since_reset + 1
+              WHERE singleton_id = 1`,
+          );
+          return { kind: "shed" as const };
+        }
+
+        this.storage.sql.exec(
+          `INSERT INTO ${STATE_APPEND_RECEIPT_TABLE} (delivery_id, received_at) VALUES (?, ?)`,
+          deliveryId,
+          now,
+        );
+        let firstSeq: number | null = null;
+        let lastSeq: number | null = null;
+        for (const record of normalized.records) {
+          const inserted = Array.from(
+            this.storage.sql.exec(
+              `INSERT INTO ${STATE_APPEND_WINDOW_TABLE}
+                 (kind, record_key, payload_json, payload_bytes, produced_at, delivery_id)
+               VALUES (?, ?, ?, ?, ?, ?)
+               RETURNING seq`,
+              record.kind,
+              record.key,
+              record.payloadJson,
+              record.payloadBytes,
+              record.producedAt,
+              deliveryId,
+            ) as Iterable<{ seq: number }>,
+          )[0];
+          const seq = Number(inserted?.seq);
+          if (!Number.isSafeInteger(seq) || seq < 1) {
+            throw new Error("state append failed to allocate a sequence");
+          }
+          if (firstSeq === null) firstSeq = seq;
+          lastSeq = seq;
+        }
+        return {
+          kind: "appended" as const,
+          appended: normalized.records.length,
+          firstSeq,
+          lastSeq,
+        };
+      });
+      if (appended.kind === "deduped") return json({ ok: true, deduped: true }, 202);
+      if (appended.kind === "shed") {
+        return json({ ok: false, shed: true, reason: "capacity" }, 429);
+      }
+      return json(
+        {
+          ok: true,
+          appended: appended.appended,
+          first_seq: appended.firstSeq,
+          last_seq: appended.lastSeq,
+        },
+        202,
+      );
+    }
+
+    if (request.method === "POST" && url.pathname === "/state/drain") {
+      const body = objectValue(await request.json().catch(() => null));
+      const maxRows = stateAppendDrainLimit(body.max_rows);
+      const maxBytes = stateAppendDrainLimit(body.max_bytes);
+      if (maxRows === null || maxBytes === null) {
+        return json({ error: "invalid_drain_limits" }, 400);
+      }
+      const drain = this.storage.transactionSync(() =>
+        this.drainStateAppendWindowSync(
+          Math.min(maxRows, stateAppendMaxPendingRows(this.env)),
+          Math.min(maxBytes, stateAppendMaxPendingBytes(this.env)),
+          Date.now(),
+        ),
+      );
+      return json({
+        ok: true,
+        drain_token: drain.token,
+        lease_expires_at: drain.expiresAt === null ? null : new Date(drain.expiresAt).toISOString(),
+        records: drain.rows.map(stateAppendWindowRowJson),
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === "/state/ack") {
+      const body = objectValue(await request.json().catch(() => null));
+      const drainToken = String(body.drain_token || "").trim();
+      if (!drainToken) return json({ error: "missing_drain_token" }, 400);
+      const acked = this.storage.transactionSync(() => {
+        const now = Date.now();
+        this.reclaimExpiredStateAppendDrainsSync(now);
+        const active = Array.from(
+          this.storage.sql.exec(
+            `SELECT drain_token FROM ${STATE_APPEND_DRAIN_TABLE} WHERE drain_token = ?`,
+            drainToken,
+          ),
+        ).length;
+        if (!active) return 0;
+        const deleted = Array.from(
+          this.storage.sql.exec(
+            `DELETE FROM ${STATE_APPEND_WINDOW_TABLE}
+              WHERE drain_token = ?
+            RETURNING seq`,
+            drainToken,
+          ),
+        ).length;
+        this.storage.sql.exec(
+          `DELETE FROM ${STATE_APPEND_DRAIN_TABLE} WHERE drain_token = ?`,
+          drainToken,
+        );
+        return deleted;
+      });
+      return json({ ok: true, acked });
+    }
+
     if (request.method === "POST" && url.pathname === "/enqueue") {
       const body = objectValue(await request.json().catch(() => null));
       const deliveryId = String(body.delivery_id || "").trim();
@@ -1075,6 +1250,8 @@ export class ExactReviewQueue {
       const now = Date.now();
       const snapshot = this.storage.transactionSync(() => {
         this.pruneDeliveryReceiptsSync(now);
+        this.pruneStateAppendReceiptsSync(now);
+        this.reclaimExpiredStateAppendDrainsSync(now);
         this.pruneQueueTelemetrySync(now);
         this.pruneReviewTelemetrySync(now);
         this.reconcileStoredReviewRunsSync(now);
@@ -1102,6 +1279,7 @@ export class ExactReviewQueue {
             now,
           }),
           stateWriter: this.stateWriterSummarySync(now),
+          stateAppend: this.stateAppendStatsSync(),
         };
       });
       const {
@@ -1113,6 +1291,7 @@ export class ExactReviewQueue {
         reviewTelemetryHealth,
         reviewExecutionHealth,
         stateWriter,
+        stateAppend,
       } = snapshot;
       const publicationBatches = this.batchStore.stats(now);
       const batchOwnedItemKeys = new Set<string>(publicationBatches.activeItemKeys);
@@ -1192,6 +1371,11 @@ export class ExactReviewQueue {
         review_telemetry_health: reviewTelemetryHealth,
         review_execution_health: reviewExecutionHealth,
         state_writer: stateWriter,
+        state_append: {
+          ...stateAppend,
+          max_pending_rows: stateAppendMaxPendingRows(this.env),
+          max_pending_bytes: stateAppendMaxPendingBytes(this.env),
+        },
         storage_schema_version: EXACT_REVIEW_QUEUE_STORAGE_SCHEMA_VERSION,
         legacy_rollback_available:
           !this.legacyMirrorDisabled &&
@@ -1209,6 +1393,8 @@ export class ExactReviewQueue {
     await this.storage.deleteAlarm();
     this.storage.transactionSync(() => {
       this.pruneDeliveryReceiptsSync(startedAt);
+      this.pruneStateAppendReceiptsSync(startedAt);
+      this.reclaimExpiredStateAppendDrainsSync(startedAt);
       this.reconcileStoredReviewRunsSync(startedAt);
       this.syncLegacyCompatibilitySync(this.readStateSync());
     });
@@ -2465,6 +2651,52 @@ export class ExactReviewQueue {
          delivery_id TEXT PRIMARY KEY,
          received_at INTEGER NOT NULL
        ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_WINDOW_TABLE} (
+         seq INTEGER PRIMARY KEY AUTOINCREMENT,
+         kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof')),
+         record_key TEXT NOT NULL,
+         payload_json TEXT NOT NULL,
+         payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
+         produced_at TEXT NOT NULL,
+         delivery_id TEXT NOT NULL,
+         drain_token TEXT
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS state_append_window_drain_seq
+         ON ${STATE_APPEND_WINDOW_TABLE} (drain_token, seq)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_RECEIPT_TABLE} (
+         delivery_id TEXT PRIMARY KEY,
+         received_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS state_append_receipts_received_at
+         ON ${STATE_APPEND_RECEIPT_TABLE} (received_at, delivery_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_DRAIN_TABLE} (
+         drain_token TEXT PRIMARY KEY,
+         leased_at INTEGER NOT NULL,
+         expires_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS state_append_drains_expiry
+         ON ${STATE_APPEND_DRAIN_TABLE} (expires_at, drain_token)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_META_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         shed_since_reset INTEGER NOT NULL DEFAULT 0 CHECK (shed_since_reset >= 0)
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `INSERT OR IGNORE INTO ${STATE_APPEND_META_TABLE} (singleton_id) VALUES (1)`,
     );
     // Flow telemetry is independent of queue rollback compatibility. A
     // separate singleton keeps cumulative lane counters monotonic without
@@ -3733,6 +3965,150 @@ export class ExactReviewQueue {
       items,
       dispatcherJson: this.readStorageMetaSync()?.dispatcher_json ?? null,
     };
+  }
+
+  private stateAppendWindowTotalsSync() {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT COUNT(*) AS pending_rows,
+                COALESCE(SUM(payload_bytes), 0) AS pending_bytes
+           FROM ${STATE_APPEND_WINDOW_TABLE}`,
+      ),
+    )[0] as { pending_rows?: number; pending_bytes?: number } | undefined;
+    return {
+      pendingRows: Number(row?.pending_rows || 0),
+      pendingBytes: Number(row?.pending_bytes || 0),
+    };
+  }
+
+  private stateAppendStatsSync() {
+    const totals = this.stateAppendWindowTotalsSync();
+    const oldest = Array.from(
+      this.storage.sql.exec(
+        `SELECT produced_at
+           FROM ${STATE_APPEND_WINDOW_TABLE}
+          ORDER BY seq
+          LIMIT 1`,
+      ),
+    )[0] as { produced_at?: string } | undefined;
+    const meta = Array.from(
+      this.storage.sql.exec(
+        `SELECT shed_since_reset FROM ${STATE_APPEND_META_TABLE} WHERE singleton_id = 1`,
+      ),
+    )[0] as { shed_since_reset?: number } | undefined;
+    const receipts = Array.from(
+      this.storage.sql.exec(`SELECT COUNT(*) AS receipt_count FROM ${STATE_APPEND_RECEIPT_TABLE}`),
+    )[0] as { receipt_count?: number } | undefined;
+    return {
+      pending_rows: totals.pendingRows,
+      pending_bytes: totals.pendingBytes,
+      oldest_produced_at: oldest?.produced_at || null,
+      sheds_since_reset: Number(meta?.shed_since_reset || 0),
+      delivery_receipts: Number(receipts?.receipt_count || 0),
+    };
+  }
+
+  private reclaimExpiredStateAppendDrainsSync(now: number) {
+    this.storage.sql.exec(
+      `UPDATE ${STATE_APPEND_WINDOW_TABLE}
+          SET drain_token = NULL
+        WHERE drain_token IN (
+          SELECT drain_token
+            FROM ${STATE_APPEND_DRAIN_TABLE}
+           WHERE expires_at <= ?
+        )`,
+      now,
+    );
+    this.storage.sql.exec(`DELETE FROM ${STATE_APPEND_DRAIN_TABLE} WHERE expires_at <= ?`, now);
+  }
+
+  private drainStateAppendWindowSync(maxRows: number, maxBytes: number, now: number) {
+    this.reclaimExpiredStateAppendDrainsSync(now);
+    const active = Array.from(
+      this.storage.sql.exec(
+        `SELECT drain_token, expires_at
+           FROM ${STATE_APPEND_DRAIN_TABLE}
+          ORDER BY leased_at, drain_token
+          LIMIT 1`,
+      ),
+    )[0] as { drain_token?: string; expires_at?: number } | undefined;
+    if (active?.drain_token) {
+      return {
+        token: active.drain_token,
+        expiresAt: Number(active.expires_at),
+        rows: this.stateAppendRowsForDrainSync(active.drain_token),
+      };
+    }
+
+    const candidates = Array.from(
+      this.storage.sql.exec(
+        `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id
+           FROM ${STATE_APPEND_WINDOW_TABLE}
+          WHERE drain_token IS NULL
+          ORDER BY seq
+          LIMIT ?`,
+        maxRows,
+      ) as Iterable<StateAppendWindowRow>,
+    );
+    const rows: StateAppendWindowRow[] = [];
+    let bytes = 0;
+    for (const row of candidates) {
+      if (bytes + Number(row.payload_bytes) > maxBytes) break;
+      rows.push(row);
+      bytes += Number(row.payload_bytes);
+    }
+    if (!rows.length) return { token: null, expiresAt: null, rows };
+
+    const token = crypto.randomUUID();
+    const expiresAt = now + stateAppendDrainLeaseMs(this.env);
+    this.storage.sql.exec(
+      `INSERT INTO ${STATE_APPEND_DRAIN_TABLE}
+         (drain_token, leased_at, expires_at) VALUES (?, ?, ?)`,
+      token,
+      now,
+      expiresAt,
+    );
+    this.storage.sql.exec(
+      `UPDATE ${STATE_APPEND_WINDOW_TABLE}
+          SET drain_token = ?
+        WHERE drain_token IS NULL AND seq <= ?`,
+      token,
+      rows.at(-1)?.seq,
+    );
+    return { token, expiresAt, rows };
+  }
+
+  private stateAppendRowsForDrainSync(drainToken: string) {
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id
+           FROM ${STATE_APPEND_WINDOW_TABLE}
+          WHERE drain_token = ?
+          ORDER BY seq`,
+        drainToken,
+      ) as Iterable<StateAppendWindowRow>,
+    );
+  }
+
+  private pruneStateAppendReceiptsSync(now: number) {
+    const cutoff = now - EXACT_REVIEW_QUEUE_DELIVERY_TTL_MS;
+    for (let batch = 0; batch < EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_MAX_BATCHES; batch += 1) {
+      const deleted = Array.from(
+        this.storage.sql.exec(
+          `DELETE FROM ${STATE_APPEND_RECEIPT_TABLE}
+            WHERE delivery_id IN (
+              SELECT delivery_id
+                FROM ${STATE_APPEND_RECEIPT_TABLE}
+               WHERE received_at <= ?
+               ORDER BY received_at, delivery_id
+               LIMIT ${EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_BATCH}
+            )
+          RETURNING delivery_id`,
+          cutoff,
+        ),
+      );
+      if (deleted.length < EXACT_REVIEW_QUEUE_DELIVERY_PRUNE_BATCH) break;
+    }
   }
 
   private pruneDeliveryReceiptsSync(now: number) {
@@ -5862,6 +6238,108 @@ function exactReviewPendingSoftLimit(env) {
       numberFrom(env.EXACT_REVIEW_PENDING_SOFT_LIMIT, DEFAULT_EXACT_REVIEW_PENDING_SOFT_LIMIT),
     ),
   );
+}
+
+function stateAppendMaxPendingRows(env) {
+  return Math.max(
+    1,
+    Math.min(
+      1_000_000,
+      Math.floor(
+        numberFrom(env.STATE_APPEND_MAX_PENDING_ROWS, DEFAULT_STATE_APPEND_MAX_PENDING_ROWS),
+      ),
+    ),
+  );
+}
+
+function stateAppendMaxPendingBytes(env) {
+  return Math.max(
+    1,
+    Math.min(
+      512 * 1024 * 1024,
+      Math.floor(
+        numberFrom(env.STATE_APPEND_MAX_PENDING_BYTES, DEFAULT_STATE_APPEND_MAX_PENDING_BYTES),
+      ),
+    ),
+  );
+}
+
+function stateAppendMaxRecordBytes(env) {
+  return Math.max(
+    1,
+    Math.min(
+      10 * 1024 * 1024,
+      Math.floor(
+        numberFrom(env.STATE_APPEND_MAX_RECORD_BYTES, DEFAULT_STATE_APPEND_MAX_RECORD_BYTES),
+      ),
+    ),
+  );
+}
+
+function stateAppendDrainLeaseMs(env) {
+  return Math.max(
+    1_000,
+    Math.min(
+      24 * 60 * 60 * 1000,
+      Math.floor(numberFrom(env.STATE_APPEND_DRAIN_LEASE_MS, DEFAULT_STATE_APPEND_DRAIN_LEASE_MS)),
+    ),
+  );
+}
+
+function stateAppendDrainLimit(value: unknown) {
+  const limit = Number(value);
+  return Number.isSafeInteger(limit) && limit > 0 ? limit : null;
+}
+
+function stateAppendRecords(value: unknown, maxRecordBytes: number) {
+  if (!Array.isArray(value) || value.length === 0) {
+    return { ok: false as const, error: "invalid_state_append_records" };
+  }
+  const records: StateAppendRecord[] = [];
+  for (const valueRecord of value) {
+    const record = objectValue(valueRecord);
+    const kind = String(record.kind || "").trim() as StateAppendKind;
+    if (!STATE_APPEND_KINDS.has(kind)) {
+      return { ok: false as const, error: "invalid_state_append_kind" };
+    }
+    const key = String(record.key || "").trim();
+    if (!key || key.length > 2_048) {
+      return { ok: false as const, error: "invalid_state_append_key" };
+    }
+    const producedAt = String(record.produced_at || "").trim();
+    if (!producedAt || !Number.isFinite(Date.parse(producedAt))) {
+      return { ok: false as const, error: "invalid_state_append_produced_at" };
+    }
+    if (!Object.hasOwn(record, "payload")) {
+      return { ok: false as const, error: "missing_state_append_payload" };
+    }
+    let payloadJson: string;
+    try {
+      payloadJson = JSON.stringify(record.payload);
+    } catch {
+      return { ok: false as const, error: "invalid_state_append_payload" };
+    }
+    if (payloadJson === undefined) {
+      return { ok: false as const, error: "invalid_state_append_payload" };
+    }
+    const payloadBytes = new TextEncoder().encode(payloadJson).byteLength;
+    if (payloadBytes > maxRecordBytes) {
+      return { ok: false as const, error: "state_append_payload_too_large" };
+    }
+    records.push({ kind, key, payloadJson, payloadBytes, producedAt });
+  }
+  return { ok: true as const, records };
+}
+
+function stateAppendWindowRowJson(row: StateAppendWindowRow) {
+  return {
+    seq: Number(row.seq),
+    kind: row.kind,
+    key: row.record_key,
+    payload: JSON.parse(row.payload_json),
+    produced_at: row.produced_at,
+    delivery_id: row.delivery_id,
+  };
 }
 
 async function exactReviewDispatchToken(env) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -503,6 +503,12 @@ export default {
       return githubWebhook(request, env, ctx);
     if (url.pathname === "/internal/exact-review/enqueue" && request.method === "POST")
       return authenticatedExactReviewEnqueue(request, env);
+    if (url.pathname === "/internal/state/append" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/state/append");
+    if (url.pathname === "/internal/state/drain" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/state/drain");
+    if (url.pathname === "/internal/state/ack" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/state/ack");
     if (url.pathname === "/internal/exact-review/claim" && request.method === "POST")
       return exactReviewQueueRequest(env, "/claim", request);
     // Heartbeat authenticates by full lease tuple, matching /claim and /complete: the

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4402,6 +4402,210 @@ test("exact-review queue defers retained backlog until a paused dispatcher retry
   }
 });
 
+test("state append is idempotent by delivery and reports bounded-window stats", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const payload = {
+    delivery_id: "state-delivery-1",
+    records: [
+      {
+        kind: "sweep_status",
+        key: "openclaw/openclaw:sweep",
+        payload: { run_id: "123", status: "completed" },
+        produced_at: "2026-07-20T12:00:00.000Z",
+      },
+      {
+        kind: "comment_router",
+        key: "openclaw/openclaw#738",
+        payload: { comment_id: 456 },
+        produced_at: "2026-07-20T12:01:00.000Z",
+      },
+    ],
+  };
+
+  const first = await queue.fetch(stateAppendQueueRequest("/state/append", payload));
+  assert.equal(first.status, 202);
+  assert.deepEqual(await first.json(), {
+    ok: true,
+    appended: 2,
+    first_seq: 1,
+    last_seq: 2,
+  });
+  const duplicate = await queue.fetch(stateAppendQueueRequest("/state/append", payload));
+  assert.equal(duplicate.status, 202);
+  assert.deepEqual(await duplicate.json(), { ok: true, deduped: true });
+
+  const invalid = await queue.fetch(
+    stateAppendQueueRequest("/state/append", {
+      delivery_id: "state-delivery-invalid",
+      records: [{ ...payload.records[0], kind: "unknown" }],
+    }),
+  );
+  assert.equal(invalid.status, 400);
+  assert.deepEqual(await invalid.json(), { error: "invalid_state_append_kind" });
+
+  const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.deepEqual(stats.state_append, {
+    pending_rows: 2,
+    pending_bytes:
+      Buffer.byteLength(JSON.stringify(payload.records[0].payload)) +
+      Buffer.byteLength(JSON.stringify(payload.records[1].payload)),
+    oldest_produced_at: "2026-07-20T12:00:00.000Z",
+    sheds_since_reset: 0,
+    delivery_receipts: 1,
+    max_pending_rows: 50_000,
+    max_pending_bytes: 100 * 1024 * 1024,
+  });
+});
+
+test("state append sheds atomically at the configured cap without consuming its receipt", async () => {
+  const queue = new ExactReviewQueue(
+    { storage: new MemoryDurableStorage() },
+    { STATE_APPEND_MAX_PENDING_ROWS: "1" },
+  );
+  const firstPayload = stateAppendPayload("state-cap-first", "sweep_status", "first");
+  const shedPayload = stateAppendPayload("state-cap-retry", "apply_proof", "second");
+  assert.equal(
+    (await queue.fetch(stateAppendQueueRequest("/state/append", firstPayload))).status,
+    202,
+  );
+
+  const shed = await queue.fetch(stateAppendQueueRequest("/state/append", shedPayload));
+  assert.equal(shed.status, 429);
+  assert.deepEqual(await shed.json(), { ok: false, shed: true, reason: "capacity" });
+  let stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.state_append.pending_rows, 1);
+  assert.equal(stats.state_append.sheds_since_reset, 1);
+  assert.equal(stats.state_append.delivery_receipts, 1);
+
+  const drained = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 1, max_bytes: 1024 }))
+  ).json();
+  const acked = await queue.fetch(
+    stateAppendQueueRequest("/state/ack", { drain_token: drained.drain_token }),
+  );
+  assert.deepEqual(await acked.json(), { ok: true, acked: 1 });
+
+  const retried = await queue.fetch(stateAppendQueueRequest("/state/append", shedPayload));
+  assert.equal(retried.status, 202);
+  assert.equal((await retried.json()).appended, 1);
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.state_append.pending_rows, 1);
+  assert.equal(stats.state_append.delivery_receipts, 2);
+});
+
+test("state drain replays its active batch and deletes rows only after ack", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const payload = {
+    delivery_id: "state-drain",
+    records: [
+      stateAppendRecord("sweep_status", "one", { n: 1 }),
+      stateAppendRecord("comment_router", "two", { n: 2 }),
+      stateAppendRecord("apply_proof", "three", { n: 3 }),
+    ],
+  };
+  await queue.fetch(stateAppendQueueRequest("/state/append", payload));
+
+  const first = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 2, max_bytes: 1024 }))
+  ).json();
+  assert.equal(typeof first.drain_token, "string");
+  assert.deepEqual(
+    first.records.map((record) => [record.seq, record.kind, record.key, record.payload]),
+    [
+      [1, "sweep_status", "one", { n: 1 }],
+      [2, "comment_router", "two", { n: 2 }],
+    ],
+  );
+
+  const replay = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 1, max_bytes: 1 }))
+  ).json();
+  assert.equal(replay.drain_token, first.drain_token);
+  assert.deepEqual(replay.records, first.records);
+  let stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.state_append.pending_rows, 3);
+
+  const ack = await queue.fetch(
+    stateAppendQueueRequest("/state/ack", { drain_token: first.drain_token }),
+  );
+  assert.deepEqual(await ack.json(), { ok: true, acked: 2 });
+  const repeatedAck = await queue.fetch(
+    stateAppendQueueRequest("/state/ack", { drain_token: first.drain_token }),
+  );
+  assert.deepEqual(await repeatedAck.json(), { ok: true, acked: 0 });
+
+  const next = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 10, max_bytes: 1024 }))
+  ).json();
+  assert.notEqual(next.drain_token, first.drain_token);
+  assert.deepEqual(
+    next.records.map((record) => record.seq),
+    [3],
+  );
+  stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+  assert.equal(stats.state_append.pending_rows, 1);
+});
+
+test("expired state drain leases make the same rows available under a new token", async () => {
+  const originalNow = Date.now;
+  let now = Date.parse("2026-07-20T12:00:00.000Z");
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new MemoryDurableStorage() },
+      { STATE_APPEND_DRAIN_LEASE_MS: "1000" },
+    );
+    await queue.fetch(
+      stateAppendQueueRequest(
+        "/state/append",
+        stateAppendPayload("state-expiry", "apply_proof", "proof"),
+      ),
+    );
+    const first = await (
+      await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 1, max_bytes: 1024 }))
+    ).json();
+    now += 1_001;
+    const redrained = await (
+      await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 1, max_bytes: 1024 }))
+    ).json();
+    assert.notEqual(redrained.drain_token, first.drain_token);
+    assert.deepEqual(redrained.records, first.records);
+
+    const staleAck = await queue.fetch(
+      stateAppendQueueRequest("/state/ack", { drain_token: first.drain_token }),
+    );
+    assert.deepEqual(await staleAck.json(), { ok: true, acked: 0 });
+    const activeAck = await queue.fetch(
+      stateAppendQueueRequest("/state/ack", { drain_token: redrained.drain_token }),
+    );
+    assert.deepEqual(await activeAck.json(), { ok: true, acked: 1 });
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("internal state endpoints reject invalid HMAC signatures", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const payload = stateAppendPayload("state-auth", "sweep_status", "auth");
+  const unsigned = await worker.fetch(
+    stateAppendQueueRequest("/internal/state/append", payload, "https://clawsweeper.openclaw.ai"),
+    env,
+  );
+  assert.equal(unsigned.status, 401);
+  assert.deepEqual(await unsigned.json(), { error: "invalid_signature" });
+
+  const signed = await worker.fetch(
+    signedStateAppendRequest("/internal/state/append", payload, "test-secret"),
+    env,
+  );
+  assert.equal(signed.status, 202);
+  assert.equal((await signed.json()).appended, 1);
+});
+
 test("authenticated legacy exact-review intake enters the durable queue", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
@@ -11399,6 +11603,43 @@ function signedGithubWebhookBodyRequest({
       "x-github-event": event,
       "x-github-delivery": "test-delivery",
       "x-hub-signature-256": signature,
+    },
+    body,
+  });
+}
+
+function stateAppendRecord(kind: string, key: string, payload: unknown) {
+  return {
+    kind,
+    key,
+    payload,
+    produced_at: "2026-07-20T12:00:00.000Z",
+  };
+}
+
+function stateAppendPayload(deliveryId: string, kind: string, key: string) {
+  return {
+    delivery_id: deliveryId,
+    records: [stateAppendRecord(kind, key, { delivery_id: deliveryId })],
+  };
+}
+
+function stateAppendQueueRequest(path: string, payload: unknown, origin = "https://queue") {
+  return new Request(`${origin}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+function signedStateAppendRequest(path: string, payload: unknown, secret: string) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  return new Request(`https://clawsweeper.openclaw.ai${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
     },
     body,
   });


### PR DESCRIPTION
WP-1 of #738 (single-writer state materialization). Pure addition: HMAC-signed /internal/state/append (idempotent by delivery_id, per-record 256KB cap, window caps 50k rows / 100MB with 429 {shed:true}), two-phase /internal/state/drain + /internal/state/ack with 10-min drain leases, stats under state_append. No changes to existing endpoints or the git-publish machinery.

Validation: DO tests 175/175; build/lint/format green; pnpm check clean apart from one documented host-load timing flake (isolated rerun 8/8); commit-mode autoreview clean.
