### PR TITLE
feat: batch state publication

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -56,13 +56,20 @@ export type RebaseStrategy = "normal" | "theirs" | "apply-records" | "reconcile-
 export type GitRunOptions = {
   allowFailure?: boolean;
   displayArgs?: readonly string[];
-  input?: string;
+  env?: NodeJS.ProcessEnv;
+  input?: string | Uint8Array;
   maxBuffer?: number;
   quiet?: boolean;
   timeout?: number;
 };
 
 export type PublishResult = "committed" | "unchanged";
+
+export type GitProcessMeasurement = {
+  durationMs: number;
+  processes: number;
+  actions: Readonly<Record<string, number>>;
+};
 
 const GENERATED_PUBLISH_PATHS = [
   "apply-report.json",
@@ -200,11 +207,11 @@ export function runGit(args: readonly string[], options: GitRunOptions = {}): st
 }
 
 export function spawnGit(args: readonly string[], options: GitRunOptions = {}): GitRunResult {
-  recordGitProcess(args[0]);
+  recordGitProcess(gitSubcommand(args));
   console.log(`$ ${formatGitDisplayCommand(options.displayArgs ?? args)}`);
   const child = spawnSync("git", [...args], {
     cwd: publishRoot(),
-    env: process.env,
+    env: options.env ?? process.env,
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer ?? 16 * 1024 * 1024,
@@ -218,6 +225,35 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     stderr: child.stderr ?? "",
     timedOut: (child.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT",
   };
+}
+
+export function measureGitProcesses<T>(operation: () => T): {
+  result: T;
+  measurement: GitProcessMeasurement;
+} {
+  if (activeGitPublishMetrics) {
+    throw new Error("Nested Git process measurements are not supported");
+  }
+  const metrics: GitPublishMetrics = {
+    startedAtMs: Date.now(),
+    processes: 0,
+    actions: new Map(),
+    phase: "measured-operation",
+  };
+  activeGitPublishMetrics = metrics;
+  try {
+    const result = operation();
+    return {
+      result,
+      measurement: {
+        durationMs: Date.now() - metrics.startedAtMs,
+        processes: metrics.processes,
+        actions: Object.fromEntries([...metrics.actions].sort(([a], [b]) => a.localeCompare(b))),
+      },
+    };
+  } finally {
+    activeGitPublishMetrics = null;
+  }
 }
 
 export class GitCommandTimeoutError extends Error {
@@ -243,7 +279,19 @@ function recordGitProcess(action: string | undefined): void {
 }
 
 function formatGitDisplayCommand(args: readonly string[]): string {
-  return `git ${safeGitDisplayAction(args[0])} <redacted-args>`;
+  return `git ${safeGitDisplayAction(gitSubcommand(args))} <redacted-args>`;
+}
+
+function gitSubcommand(args: readonly string[]): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "-c") {
+      index += 1;
+      continue;
+    }
+    if (!argument?.startsWith("-")) return argument;
+  }
+  return undefined;
 }
 
 function safeGitDisplayAction(action: string | undefined): string {
@@ -255,8 +303,10 @@ function safeGitDisplayAction(action: string | undefined): string {
     case "fetch":
     case "checkout":
     case "cat-file":
+    case "check-ref-format":
     case "clean":
     case "log":
+    case "ls-remote":
     case "ls-files":
     case "ls-tree":
     case "merge-base":
@@ -271,6 +321,8 @@ function safeGitDisplayAction(action: string | undefined): string {
     case "rm":
     case "status":
     case "update-ref":
+    case "update-index":
+    case "hash-object":
     case "write-tree":
     case "commit-tree":
       return action;
@@ -2023,11 +2075,16 @@ function pushPublishedBranch(remote: string, branch: string): GitRunResult {
   return pushPublishedCommit("HEAD", remote, branch);
 }
 
-function pushPublishedCommit(source: string, remote: string, branch: string): GitRunResult {
+function pushPublishedCommit(
+  source: string,
+  remote: string,
+  branch: string,
+  receiptRef?: string,
+): GitRunResult {
   const lease = activeStatePublishLease;
   if (!lease && publishRoot()) {
     return withStatePublishMutationLease(remote, branch, () =>
-      pushPublishedCommit(source, remote, branch),
+      pushPublishedCommit(source, remote, branch, receiptRef),
     );
   }
   if (!lease) return spawnGit(["push", remote, `${source}:${branch}`]);
@@ -2052,9 +2109,11 @@ function pushPublishedCommit(source: string, remote: string, branch: string): Gi
       "push",
       "--atomic",
       `--force-with-lease=${lease.ref}:${lease.oid}`,
+      ...(receiptRef ? [`--force-with-lease=${receiptRef}:`] : []),
       lease.remote,
       `${source}:${branch}`,
       `${renewedOid}:${lease.ref}`,
+      ...(receiptRef ? [`${source}:${receiptRef}`] : []),
     ],
     { allowFailure: true },
   );
@@ -2062,7 +2121,10 @@ function pushPublishedCommit(source: string, remote: string, branch: string): Gi
     const currentLeaseOid = remoteRefOid(remote, lease.ref);
     if (currentLeaseOid === renewedOid) {
       const sourceCommit = runGit(["rev-parse", source], { quiet: true }).trim();
-      if (remoteRefOid(remote, `refs/heads/${branch}`) === sourceCommit) {
+      if (
+        remoteRefOid(remote, `refs/heads/${branch}`) === sourceCommit &&
+        (!receiptRef || remoteRefOid(remote, receiptRef) === sourceCommit)
+      ) {
         lease.oid = renewedOid;
         lease.expiresAtMs = Date.now() + lease.ttlMs;
         return { ...pushed, status: 0 };
@@ -2086,6 +2148,20 @@ function pushPublishedCommit(source: string, remote: string, branch: string): Gi
   lease.expiresAtMs = Date.now() + lease.ttlMs;
   console.log(`Renewed state publish lease owner=${lease.owner} with atomic branch update`);
   return pushed;
+}
+
+export function pushStateCommitUnderLease(
+  commit: string,
+  remote: string,
+  branch: string,
+  receiptRef?: string,
+): void {
+  const pushed = pushPublishedCommit(commit, remote, branch, receiptRef);
+  if (pushed.status !== 0) {
+    throw new StatePublishContentionError(
+      pushed.stderr.trim() || `Failed to publish the prepared state commit to ${remote}/${branch}`,
+    );
+  }
 }
 
 export function pushCommit(options: {

--- a/src/repair/state-publication-batch.ts
+++ b/src/repair/state-publication-batch.ts
@@ -1,0 +1,413 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  measureGitProcesses,
+  publishRoot,
+  pushStateCommitUnderLease,
+  runGit,
+  spawnGit,
+  withStatePublishLease,
+  type GitProcessMeasurement,
+  type StatePublishLeaseOptions,
+} from "./git-publish.js";
+import {
+  validatePreparedStateMutationPlans,
+  type PreparedStateMutationOperation,
+  type PreparedStateMutationPlan,
+} from "./state-publication-mutation.js";
+
+export const STATE_PUBLICATION_BATCH_MAX_ITEMS = 8;
+// Until the PR 2 proof supplies tighter operational limits, reuse the already
+// validated exact-review artifact envelope per item. This keeps the primitive
+// bounded without inventing a second payload contract before integration.
+export const STATE_PUBLICATION_BATCH_MAX_PATHS = 8 * 512;
+export const STATE_PUBLICATION_BATCH_MAX_BYTES = 8 * 16 * 1024 * 1024;
+export const STATE_PUBLICATION_BATCH_MAX_PATH_BYTES = 128 * 1024;
+
+const STATE_FETCH_TIMEOUT_MS = 60_000;
+const BATCH_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const GIT_OID_PATTERN = /^[a-f0-9]{40,64}$/;
+
+export class StateMutationConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StateMutationConflictError";
+  }
+}
+
+export type StateBatchCommitResult = {
+  outcome: "committed" | "already_committed";
+  commitSha: string;
+  batchId: string;
+  fingerprint: string;
+  itemCount: number;
+  pathCount: number;
+  totalBytes: number;
+  leaseHoldMs: number;
+  git: GitProcessMeasurement;
+};
+
+export type StateBatchCommitHooks = {
+  beforePush?: (commitSha: string) => void;
+  afterPush?: (commitSha: string) => void;
+};
+
+export function commitPreparedStateBatch(options: {
+  batchId: string;
+  plans: readonly PreparedStateMutationPlan[];
+  remote?: string;
+  branch?: string;
+  message?: string;
+  lease?: Omit<StatePublishLeaseOptions, "remote" | "branch">;
+  hooks?: StateBatchCommitHooks;
+}): StateBatchCommitResult {
+  if (!publishRoot()) {
+    throw new Error("State publication batches require an isolated state publish root");
+  }
+  validateBatchId(options.batchId);
+  const message = validateCommitSubject(options.message);
+  const validated = validatePreparedStateMutationPlans(options.plans);
+  const operations = validateAndCombinePlans(validated.plans, validated.totalBytes);
+  const fingerprint = batchFingerprint(validated.plans);
+  const remote = options.remote ?? "origin";
+  const branch = options.branch ?? process.env.CLAWSWEEPER_PUBLISH_BRANCH ?? "state";
+  const measured = measureGitProcesses(() => {
+    let leaseHoldMs = 0;
+    const publication = withStatePublishLease(
+      () => {
+        const leaseStartedAt = Date.now();
+        try {
+          return commitUnderLease({
+            ...options,
+            plans: validated.plans,
+            message,
+            remote,
+            branch,
+            operations,
+            fingerprint,
+          });
+        } finally {
+          leaseHoldMs = Date.now() - leaseStartedAt;
+        }
+      },
+      { ...options.lease, remote, branch },
+    );
+    return { publication, leaseHoldMs };
+  });
+
+  return {
+    ...measured.result.publication,
+    batchId: options.batchId,
+    fingerprint,
+    itemCount: validated.plans.length,
+    pathCount: operations.length,
+    totalBytes: validated.totalBytes,
+    leaseHoldMs: measured.result.leaseHoldMs,
+    git: measured.measurement,
+  };
+}
+
+function commitUnderLease(options: {
+  batchId: string;
+  plans: readonly PreparedStateMutationPlan[];
+  operations: readonly PreparedStateMutationOperation[];
+  fingerprint: string;
+  remote: string;
+  branch: string;
+  message: string;
+  hooks?: StateBatchCommitHooks;
+}): Pick<StateBatchCommitResult, "outcome" | "commitSha"> {
+  const receiptRef = batchReceiptRef(options.batchId);
+  const recovered = findBatchReceipt(options.remote, receiptRef, options.batchId);
+  if (recovered) {
+    if (recovered.fingerprint !== options.fingerprint) {
+      throw new StateMutationConflictError(
+        `Batch id ${options.batchId} is already bound to a different mutation fingerprint`,
+      );
+    }
+    return { outcome: "already_committed", commitSha: recovered.commit };
+  }
+
+  const remoteRef = fetchLatestState(options.remote, options.branch);
+  const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
+
+  const remoteEntries = readRemoteEntries(
+    remoteCommit,
+    options.operations.map(({ path }) => path),
+  );
+  const pending = options.operations.filter((operation) => {
+    const remoteEntry = remoteEntries.get(operation.path) ?? null;
+    const remoteOid = remoteEntry?.oid ?? null;
+    if (
+      remoteOid === operation.targetOid &&
+      (operation.targetOid === null || remoteEntry?.mode === operation.mode)
+    ) {
+      return false;
+    }
+    if (remoteOid !== operation.expectedOid) {
+      throw new StateMutationConflictError(
+        `Remote state path ${operation.path} changed after mutation preparation`,
+      );
+    }
+    return true;
+  });
+  const remoteTree = runGit(["rev-parse", `${remoteCommit}^{tree}`], { quiet: true }).trim();
+  // Even a content no-op needs a durable batch-id/fingerprint binding. A same-tree
+  // marker commit lets a later ambiguous retry prove which payload this id owns.
+  const tree = pending.length === 0 ? remoteTree : applyOperationsToTree(remoteTree, pending);
+  const commitSha = runGit(["commit-tree", tree, "-p", remoteCommit], {
+    input: batchCommitMessage(options),
+    quiet: true,
+  }).trim();
+  options.hooks?.beforePush?.(commitSha);
+  pushStateCommitUnderLease(commitSha, options.remote, options.branch, receiptRef);
+  verifyRemoteCommit(options.remote, options.branch, receiptRef, commitSha);
+  options.hooks?.afterPush?.(commitSha);
+  return { outcome: "committed", commitSha };
+}
+
+function validateAndCombinePlans(
+  plans: readonly PreparedStateMutationPlan[],
+  totalBytes: number,
+): PreparedStateMutationOperation[] {
+  if (plans.length === 0) throw new Error("A state publication batch must contain an item");
+  if (plans.length > STATE_PUBLICATION_BATCH_MAX_ITEMS) {
+    throw new Error(`A state publication batch exceeds ${STATE_PUBLICATION_BATCH_MAX_ITEMS} items`);
+  }
+  const itemKeys = new Set<string>();
+  const byPath = new Map<string, PreparedStateMutationOperation>();
+  let totalPathBytes = 0;
+  for (const plan of plans) {
+    if (itemKeys.has(plan.identity.itemKey)) {
+      throw new StateMutationConflictError(`Batch repeats item ${plan.identity.itemKey}`);
+    }
+    itemKeys.add(plan.identity.itemKey);
+    for (const operation of plan.operations) {
+      totalPathBytes += Buffer.byteLength(operation.path) + 1;
+      const existing = byPath.get(operation.path);
+      if (existing) {
+        const identical =
+          existing.expectedOid === operation.expectedOid &&
+          existing.targetOid === operation.targetOid &&
+          existing.mode === operation.mode;
+        if (!identical) {
+          throw new StateMutationConflictError(
+            `Batch contains incompatible mutations for ${operation.path}`,
+          );
+        }
+        continue;
+      }
+      byPath.set(operation.path, operation);
+    }
+  }
+  if (byPath.size > STATE_PUBLICATION_BATCH_MAX_PATHS) {
+    throw new Error(`A state publication batch exceeds ${STATE_PUBLICATION_BATCH_MAX_PATHS} paths`);
+  }
+  if (totalBytes > STATE_PUBLICATION_BATCH_MAX_BYTES) {
+    throw new Error(`A state publication batch exceeds ${STATE_PUBLICATION_BATCH_MAX_BYTES} bytes`);
+  }
+  if (totalPathBytes > STATE_PUBLICATION_BATCH_MAX_PATH_BYTES) {
+    throw new Error(
+      `A state publication batch exceeds ${STATE_PUBLICATION_BATCH_MAX_PATH_BYTES} path bytes`,
+    );
+  }
+  return [...byPath.values()].sort((left, right) => compareCanonicalText(left.path, right.path));
+}
+
+function fetchLatestState(remote: string, branch: string): string {
+  runGit(["check-ref-format", `refs/heads/${branch}`], { quiet: true });
+  const shallow = runGit(["rev-parse", "--is-shallow-repository"], { quiet: true }).trim();
+  runGit(
+    [
+      "fetch",
+      "--no-tags",
+      ...(shallow === "true" ? ["--depth=1"] : []),
+      remote,
+      `refs/heads/${branch}`,
+    ],
+    { quiet: true, timeout: STATE_FETCH_TIMEOUT_MS },
+  );
+  return "FETCH_HEAD";
+}
+
+function findBatchReceipt(
+  remote: string,
+  receiptRef: string,
+  batchId: string,
+): { commit: string; fingerprint: string } | null {
+  const advertised = spawnGit(["ls-remote", "--refs", remote, receiptRef], {
+    quiet: true,
+    timeout: STATE_FETCH_TIMEOUT_MS,
+  });
+  if (advertised.timedOut || advertised.status !== 0) {
+    throw new Error(`Failed to inspect state batch receipt ${receiptRef}`);
+  }
+  const advertisedLine = advertised.stdout.trim();
+  if (!advertisedLine) return null;
+  const receiptCommit = advertisedLine.split(/\s+/, 1)[0];
+  if (!receiptCommit || !GIT_OID_PATTERN.test(receiptCommit)) {
+    throw new StateMutationConflictError(`State batch receipt ${receiptRef} is malformed`);
+  }
+  if (spawnGit(["cat-file", "-e", `${receiptCommit}^{commit}`], { quiet: true }).status !== 0) {
+    runGit(["fetch", "--no-tags", "--depth=1", remote, receiptRef], {
+      quiet: true,
+      timeout: STATE_FETCH_TIMEOUT_MS,
+    });
+  }
+  const output = runGit(
+    [
+      "show",
+      "-s",
+      "--format=%H%x00%(trailers:key=ClawSweeper-Batch-ID,valueonly)%x00%(trailers:key=ClawSweeper-Batch-Fingerprint,valueonly)%x00",
+      receiptCommit,
+    ],
+    { quiet: true },
+  );
+  const [commit, receiptBatchId, fingerprint] = output.split("\0").map((field) => field.trim());
+  if (
+    !commit ||
+    !GIT_OID_PATTERN.test(commit) ||
+    receiptBatchId !== batchId ||
+    !fingerprint ||
+    !/^[a-f0-9]{64}$/.test(fingerprint)
+  ) {
+    throw new StateMutationConflictError(`State batch receipt ${receiptRef} is malformed`);
+  }
+  return { commit, fingerprint };
+}
+
+function readRemoteEntries(
+  commit: string,
+  paths: readonly string[],
+): Map<string, { mode: "100644" | "100755"; oid: string }> {
+  const output = runGit(
+    ["--literal-pathspecs", "ls-tree", "-z", "--full-tree", commit, "--", ...paths],
+    { quiet: true },
+  );
+  const result = new Map<string, { mode: "100644" | "100755"; oid: string }>();
+  for (const record of output.split("\0")) {
+    if (!record) continue;
+    const match = /^(100644|100755) blob ([a-f0-9]{40,64})\t(.+)$/.exec(record);
+    if (!match) throw new Error("State mutation path did not resolve to a regular Git blob");
+    result.set(match[3]!, { mode: match[1] as "100644" | "100755", oid: match[2]! });
+  }
+  return result;
+}
+
+function applyOperationsToTree(
+  remoteTree: string,
+  operations: readonly PreparedStateMutationOperation[],
+): string {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), "clawsweeper-state-batch-index-"));
+  const indexPath = join(temporaryRoot, "index");
+  const env = { ...process.env, GIT_INDEX_FILE: indexPath };
+  try {
+    runGit(["read-tree", remoteTree], { env, quiet: true });
+    const objectFormat = runGit(["rev-parse", "--show-object-format"], { env, quiet: true }).trim();
+    const zeroOid = objectFormat === "sha256" ? "0".repeat(64) : "0".repeat(40);
+    const indexInfo = operations
+      .map((operation) =>
+        operation.targetOid
+          ? `${operation.mode} ${operation.targetOid}\t${operation.path}\0`
+          : `0 ${zeroOid}\t${operation.path}\0`,
+      )
+      .join("");
+    runGit(["update-index", "-z", "--index-info"], { env, input: indexInfo, quiet: true });
+    return runGit(["write-tree"], { env, quiet: true }).trim();
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+function batchCommitMessage(options: {
+  batchId: string;
+  fingerprint: string;
+  plans: readonly PreparedStateMutationPlan[];
+  message: string;
+}): string {
+  return [
+    options.message,
+    "",
+    `ClawSweeper-Batch-ID: ${options.batchId}`,
+    `ClawSweeper-Batch-Fingerprint: ${options.fingerprint}`,
+    `ClawSweeper-Batch-Items: ${options.plans.length}`,
+    "",
+  ].join("\n");
+}
+
+function batchFingerprint(plans: readonly PreparedStateMutationPlan[]): string {
+  const canonical = [...plans]
+    .sort((left, right) => compareCanonicalText(left.identity.itemKey, right.identity.itemKey))
+    .map((plan) => ({
+      identity: {
+        itemKey: plan.identity.itemKey,
+        revision: plan.identity.revision,
+        claimGeneration: plan.identity.claimGeneration,
+      },
+      operations: [...plan.operations]
+        .sort((left, right) => compareCanonicalText(left.path, right.path))
+        .map(({ path, expectedOid, targetOid, mode, bytes }) => ({
+          path,
+          expectedOid,
+          targetOid,
+          mode,
+          bytes,
+        })),
+    }));
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+function compareCanonicalText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function verifyRemoteCommit(
+  remote: string,
+  branch: string,
+  receiptRef: string,
+  expected: string,
+): void {
+  const observed = spawnGit(["ls-remote", "--refs", remote, `refs/heads/${branch}`, receiptRef], {
+    quiet: true,
+    timeout: STATE_FETCH_TIMEOUT_MS,
+  });
+  if (observed.timedOut || observed.status !== 0) {
+    throw new Error(`State batch push succeeded but ${remote}/${branch} could not be verified`);
+  }
+  const oids = observed.stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/, 1)[0]);
+  if (oids.length !== 2 || oids.some((oid) => oid !== expected)) {
+    throw new StateMutationConflictError(
+      `State batch push was not the visible head of ${remote}/${branch}`,
+    );
+  }
+}
+
+function batchReceiptRef(batchId: string): string {
+  const digest = createHash("sha256").update(batchId).digest("hex");
+  // The state history can advance hundreds of commits before an ambiguous retry.
+  // A per-batch ref keeps recovery bounded; PR 3 owns deleting it only after the
+  // durable queue has acknowledged the matching commit and fingerprint.
+  return `refs/heads/clawsweeper-state-batches/${digest}`;
+}
+
+function validateCommitSubject(message: string | undefined): string {
+  const subject = message?.trim() || "chore: publish exact-review state batch";
+  if (subject.includes("\0") || subject.includes("\r") || subject.includes("\n")) {
+    throw new Error("State publication batch commit subjects must be single-line values");
+  }
+  return subject;
+}
+
+function validateBatchId(batchId: string): void {
+  if (!BATCH_ID_PATTERN.test(batchId)) {
+    throw new Error("State publication batch ids must be stable printable identifiers");
+  }
+}

--- a/src/repair/state-publication-mutation.ts
+++ b/src/repair/state-publication-mutation.ts
@@ -1,0 +1,244 @@
+import { Buffer } from "node:buffer";
+
+import {
+  EXACT_REVIEW_BUNDLE_MAX_FILES,
+  EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES,
+  EXACT_REVIEW_BUNDLE_MAX_TOTAL_BYTES,
+} from "./exact-review-bundle.js";
+import { runGit } from "./git-publish.js";
+
+export type StateMutationIdentity = {
+  itemKey: string;
+  revision: number;
+  claimGeneration: number;
+};
+
+export type StateMutationSourceOperation =
+  | { path: string; expectedOid: string | null; content: string | Uint8Array; mode?: "100644" }
+  | { path: string; expectedOid: string | null; delete: true };
+
+export type PreparedStateMutationOperation = {
+  path: string;
+  expectedOid: string | null;
+  targetOid: string | null;
+  mode: "100644";
+  bytes: number;
+};
+
+export type PreparedStateMutationPlan = {
+  identity: StateMutationIdentity;
+  operations: readonly PreparedStateMutationOperation[];
+  totalBytes: number;
+};
+
+export type ValidatedStateMutationPlans = {
+  plans: PreparedStateMutationPlan[];
+  totalBytes: number;
+};
+
+const GIT_OID_PATTERN = /^[a-f0-9]{40,64}$/;
+export const STATE_MUTATION_MAX_PATH_BYTES = 1024;
+
+export function prepareStateMutationPlan(options: {
+  identity: StateMutationIdentity;
+  operations: readonly StateMutationSourceOperation[];
+}): PreparedStateMutationPlan {
+  validateIdentity(options.identity);
+  if (options.operations.length === 0) throw new Error("A state mutation plan must change a path");
+  if (options.operations.length > EXACT_REVIEW_BUNDLE_MAX_FILES) {
+    throw new Error("A state mutation plan exceeds the exact-review file limit");
+  }
+
+  const paths = new Set<string>();
+  let totalBytes = 0;
+  const operations = options.operations.map((operation): PreparedStateMutationOperation => {
+    const path = validateMutationPath(operation.path);
+    if (paths.has(path)) throw new Error(`A state mutation plan repeats path ${path}`);
+    paths.add(path);
+    validateExpectedOid(operation.expectedOid, path);
+    if ("delete" in operation) {
+      return {
+        path,
+        expectedOid: operation.expectedOid,
+        targetOid: null,
+        mode: "100644",
+        bytes: 0,
+      };
+    }
+
+    const content = Buffer.from(operation.content);
+    if (content.byteLength > EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES) {
+      throw new Error(`State mutation content exceeds the per-file limit: ${path}`);
+    }
+    totalBytes += content.byteLength;
+    if (totalBytes > EXACT_REVIEW_BUNDLE_MAX_TOTAL_BYTES) {
+      throw new Error("A state mutation plan exceeds the exact-review total byte limit");
+    }
+    const targetOid = runGit(["hash-object", "-w", "--stdin"], {
+      input: content,
+      quiet: true,
+    }).trim();
+    if (!GIT_OID_PATTERN.test(targetOid)) {
+      throw new Error(`Git did not return a valid object id for ${path}`);
+    }
+    return {
+      path,
+      expectedOid: operation.expectedOid,
+      targetOid,
+      mode: operation.mode ?? "100644",
+      bytes: content.byteLength,
+    };
+  });
+
+  return { identity: { ...options.identity }, operations, totalBytes };
+}
+
+export function validatePreparedStateMutationPlans(
+  plans: readonly PreparedStateMutationPlan[],
+): ValidatedStateMutationPlans {
+  const normalized = plans.map((plan) => {
+    validateIdentity(plan.identity);
+    if (!Array.isArray(plan.operations) || plan.operations.length === 0) {
+      throw new Error("A prepared state mutation plan must change a path");
+    }
+    if (plan.operations.length > EXACT_REVIEW_BUNDLE_MAX_FILES) {
+      throw new Error("A prepared state mutation plan exceeds the exact-review file limit");
+    }
+
+    const paths = new Set<string>();
+    const operations = plan.operations.map((operation): PreparedStateMutationOperation => {
+      const path = validateMutationPath(operation.path);
+      if (path !== operation.path) {
+        throw new Error(`Prepared state mutation paths must be canonical: ${operation.path}`);
+      }
+      if (paths.has(path)) throw new Error(`A prepared state mutation plan repeats path ${path}`);
+      paths.add(path);
+      validateExpectedOid(operation.expectedOid, path);
+      if (operation.targetOid !== null) validateExpectedOid(operation.targetOid, path);
+      if (operation.mode !== "100644") {
+        throw new Error(`Invalid prepared state mutation mode for ${path}`);
+      }
+      if (!Number.isSafeInteger(operation.bytes) || operation.bytes < 0) {
+        throw new Error(`Invalid prepared state mutation byte count for ${path}`);
+      }
+      if (operation.targetOid === null && operation.bytes !== 0) {
+        throw new Error(`Deleted state mutation paths must have zero bytes: ${path}`);
+      }
+      return { ...operation, path };
+    });
+    if (!Number.isSafeInteger(plan.totalBytes) || plan.totalBytes < 0) {
+      throw new Error(`Invalid prepared state mutation total for ${plan.identity.itemKey}`);
+    }
+    return { identity: { ...plan.identity }, operations, totalBytes: plan.totalBytes };
+  });
+
+  const targetOids = [
+    ...new Set(
+      normalized.flatMap((plan) =>
+        plan.operations.flatMap((operation) =>
+          operation.targetOid === null ? [] : [operation.targetOid],
+        ),
+      ),
+    ),
+  ];
+  const sizeByOid = inspectBlobSizes(targetOids);
+  let batchBytes = 0;
+  const validatedPlans = normalized.map((plan): PreparedStateMutationPlan => {
+    let planBytes = 0;
+    const operations = plan.operations.map((operation): PreparedStateMutationOperation => {
+      if (operation.targetOid === null) return operation;
+      const bytes = sizeByOid.get(operation.targetOid);
+      if (bytes === undefined) {
+        throw new Error(`Prepared state mutation target is not a Git blob: ${operation.path}`);
+      }
+      if (bytes > EXACT_REVIEW_BUNDLE_MAX_FILE_BYTES) {
+        throw new Error(
+          `Prepared state mutation content exceeds the per-file limit: ${operation.path}`,
+        );
+      }
+      if (operation.bytes !== bytes) {
+        throw new Error(
+          `Prepared state mutation byte count does not match its Git blob: ${operation.path}`,
+        );
+      }
+      planBytes += bytes;
+      return { ...operation, bytes };
+    });
+    if (planBytes > EXACT_REVIEW_BUNDLE_MAX_TOTAL_BYTES) {
+      throw new Error("A prepared state mutation plan exceeds the exact-review total byte limit");
+    }
+    if (plan.totalBytes !== planBytes) {
+      throw new Error(
+        `Prepared state mutation total does not match its Git blobs: ${plan.identity.itemKey}`,
+      );
+    }
+    batchBytes += planBytes;
+    return { identity: plan.identity, operations, totalBytes: planBytes };
+  });
+
+  return { plans: validatedPlans, totalBytes: batchBytes };
+}
+
+function inspectBlobSizes(oids: readonly string[]): Map<string, number> {
+  if (oids.length === 0) return new Map();
+  const output = runGit(["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"], {
+    input: `${oids.join("\n")}\n`,
+    quiet: true,
+  });
+  const lines = output.trim().split("\n");
+  if (lines.length !== oids.length) {
+    throw new Error("Git returned incomplete prepared state mutation metadata");
+  }
+  const result = new Map<string, number>();
+  for (let index = 0; index < oids.length; index += 1) {
+    const match = /^([a-f0-9]{40,64}) blob ([0-9]+)$/.exec(lines[index]!);
+    const bytes = match ? Number(match[2]) : Number.NaN;
+    if (match?.[1] !== oids[index] || !Number.isSafeInteger(bytes)) {
+      throw new Error(`Prepared state mutation target is not a Git blob: ${oids[index]}`);
+    }
+    result.set(oids[index]!, bytes);
+  }
+  return result;
+}
+
+function validateIdentity(identity: StateMutationIdentity): void {
+  if (
+    !identity.itemKey.trim() ||
+    identity.itemKey.includes("\0") ||
+    identity.itemKey.includes("\r") ||
+    identity.itemKey.includes("\n")
+  ) {
+    throw new Error("State mutation item keys must be non-empty single-line values");
+  }
+  if (!Number.isSafeInteger(identity.revision) || identity.revision < 1) {
+    throw new Error("State mutation revisions must be positive safe integers");
+  }
+  if (!Number.isSafeInteger(identity.claimGeneration) || identity.claimGeneration < 1) {
+    throw new Error("State mutation claim generations must be positive safe integers");
+  }
+}
+
+function validateMutationPath(value: string): string {
+  const path = value.replaceAll("\\", "/").replace(/^\.\//, "");
+  if (
+    !path ||
+    path.startsWith("/") ||
+    path.endsWith("/") ||
+    path.includes("\0") ||
+    path.includes("\r") ||
+    path.includes("\n") ||
+    path.split("/").some((part) => !part || part === "." || part === ".." || part === ".git")
+  ) {
+    throw new Error(`Invalid bounded state mutation path: ${value}`);
+  }
+  if (Buffer.byteLength(path) > STATE_MUTATION_MAX_PATH_BYTES) {
+    throw new Error(`State mutation path exceeds ${STATE_MUTATION_MAX_PATH_BYTES} bytes`);
+  }
+  return path;
+}
+
+function validateExpectedOid(oid: string | null, path: string): void {
+  if (oid !== null && !GIT_OID_PATTERN.test(oid)) {
+    throw new Error(`Invalid expected object id for ${path}`);
+  }
+}

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -1,0 +1,606 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  commitPreparedStateBatch,
+  StateMutationConflictError,
+} from "../../dist/repair/state-publication-batch.js";
+import { prepareStateMutationPlan } from "../../dist/repair/state-publication-mutation.js";
+import type { PreparedStateMutationPlan } from "../../dist/repair/state-publication-mutation.js";
+
+type RepositoryFixture = {
+  root: string;
+  origin: string;
+  work: string;
+};
+
+test("bounded batches publish 1, 2, 4, and 8 item tuples in one state commit", () => {
+  const proof: Array<Record<string, unknown>> = [];
+  for (const size of [1, 2, 4, 8]) {
+    const fixture = createRepositoryFixture();
+    const beforeCount = Number(git(fixture.origin, "rev-list", "--count", "state").trim());
+    const plans = Array.from({ length: size }, (_, index) => {
+      const item = index + 1;
+      const itemPath = `records/openclaw-openclaw/items/${item}.md`;
+      return withStateEnvironment(fixture.work, () =>
+        prepareStateMutationPlan({
+          identity: { itemKey: `openclaw/openclaw#${item}`, revision: 1, claimGeneration: 1 },
+          operations: [{ path: itemPath, expectedOid: null, content: `item ${item}\n` }],
+        }),
+      );
+    });
+
+    const result = withStateEnvironment(fixture.work, () =>
+      commitPreparedStateBatch({ batchId: `proof-${size}`, plans }),
+    );
+
+    assert.equal(result.outcome, "committed");
+    assert.equal(
+      Number(git(fixture.origin, "rev-list", "--count", "state").trim()),
+      beforeCount + 1,
+    );
+    assert.equal(result.itemCount, size);
+    assert.equal(result.pathCount, size);
+    assert.ok(result.git.processes > 0);
+    assert.ok(result.leaseHoldMs >= 0);
+    for (let item = 1; item <= size; item += 1) {
+      assert.equal(
+        git(fixture.origin, "show", `state:records/openclaw-openclaw/items/${item}.md`),
+        `item ${item}\n`,
+      );
+    }
+    assert.match(
+      git(fixture.origin, "log", "-1", "--format=%B", "state"),
+      new RegExp(`ClawSweeper-Batch-ID: proof-${size}`),
+    );
+    proof.push({
+      size,
+      outcome: result.outcome,
+      commitSha: result.commitSha,
+      durationMs: result.git.durationMs,
+      leaseHoldMs: result.leaseHoldMs,
+      gitProcesses: result.git.processes,
+      gitActions: result.git.actions,
+    });
+  }
+  console.log(`STATE_BATCH_PROOF ${JSON.stringify(proof)}`);
+});
+
+test("latest remote sibling changes survive preparation and batch publication", () => {
+  const fixture = createRepositoryFixture();
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#42", revision: 1, claimGeneration: 1 },
+      operations: [
+        { path: "records/openclaw-openclaw/items/42.md", expectedOid: null, content: "item 42\n" },
+      ],
+    }),
+  );
+  publishSibling(fixture, "results/unrelated.json", '{"writer":"ordinary"}\n');
+
+  withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "sibling-preservation", plans: [plan] }),
+  );
+
+  assert.equal(
+    git(fixture.origin, "show", "state:results/unrelated.json"),
+    '{"writer":"ordinary"}\n',
+  );
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/42.md"),
+    "item 42\n",
+  );
+});
+
+test("filesystem-path remotes publish without constructing an invalid tracking ref", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 22);
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId: "filesystem-remote",
+      plans: [plan],
+      remote: fixture.origin,
+    }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/22.md"),
+    "item 22\n",
+  );
+});
+
+test("mutation plans reject oversized individual and aggregate path metadata", () => {
+  const fixture = createRepositoryFixture();
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        prepareStateMutationPlan({
+          identity: { itemKey: "openclaw/openclaw#23", revision: 1, claimGeneration: 1 },
+          operations: [{ path: `records/${"x".repeat(1024)}`, expectedOid: null, content: "x" }],
+        }),
+      ),
+    /path exceeds 1024 bytes/,
+  );
+
+  const existingOid = git(fixture.work, "rev-parse", "state:records/existing.md").trim();
+  const plans: PreparedStateMutationPlan[] = Array.from({ length: 8 }, (_, planIndex) => ({
+    identity: {
+      itemKey: `openclaw/openclaw#path-budget-${planIndex}`,
+      revision: 1,
+      claimGeneration: 1,
+    },
+    totalBytes: 512 * Buffer.byteLength("initial\n"),
+    operations: Array.from({ length: 512 }, (_, operationIndex) => ({
+      path: `records/${planIndex}/${operationIndex}-${"p".repeat(32)}.md`,
+      expectedOid: null,
+      targetOid: existingOid,
+      mode: "100644" as const,
+      bytes: Buffer.byteLength("initial\n"),
+    })),
+  }));
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({ batchId: "aggregate-path-budget", plans }),
+      ),
+    /exceeds 131072 path bytes/,
+  );
+});
+
+test("batch validation derives payload bytes from the referenced Git blobs", () => {
+  const fixture = createRepositoryFixture();
+  const prepared = newItemPlan(fixture, 24);
+  const forged: PreparedStateMutationPlan = {
+    ...prepared,
+    totalBytes: 0,
+    operations: prepared.operations.map((operation) => ({ ...operation, bytes: 0 })),
+  };
+  const before = git(fixture.origin, "rev-parse", "state").trim();
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({ batchId: "forged-byte-accounting", plans: [forged] }),
+      ),
+    /byte count does not match its Git blob/,
+  );
+  assert.equal(git(fixture.origin, "rev-parse", "state").trim(), before);
+  assert.equal(
+    git(fixture.origin, "show-ref", "refs/heads/clawsweeper-publish-lease/state", true),
+    "",
+  );
+});
+
+test("incompatible same-path plans fail before acquiring a lease or pushing", () => {
+  const fixture = createRepositoryFixture();
+  const plans = withStateEnvironment(fixture.work, () => [
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#7", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/shared.md", expectedOid: null, content: "first\n" }],
+    }),
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#8", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/shared.md", expectedOid: null, content: "second\n" }],
+    }),
+  ]);
+  const before = git(fixture.origin, "rev-parse", "state").trim();
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({ batchId: "overlap", plans }),
+      ),
+    StateMutationConflictError,
+  );
+  assert.equal(git(fixture.origin, "rev-parse", "state").trim(), before);
+  assert.equal(
+    git(fixture.origin, "show-ref", "refs/heads/clawsweeper-publish-lease/state", true),
+    "",
+  );
+});
+
+test("remote same-path drift is fenced before push", () => {
+  const fixture = createRepositoryFixture();
+  const expectedOid = git(fixture.work, "rev-parse", "state:records/existing.md").trim();
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#9", revision: 2, claimGeneration: 1 },
+      operations: [{ path: "records/existing.md", expectedOid, content: "candidate\n" }],
+    }),
+  );
+  publishSibling(fixture, "records/existing.md", "newer remote\n");
+  const before = git(fixture.origin, "rev-parse", "state").trim();
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({ batchId: "same-path-drift", plans: [plan] }),
+      ),
+    /changed after mutation preparation/,
+  );
+  assert.equal(git(fixture.origin, "rev-parse", "state").trim(), before);
+  assert.equal(git(fixture.origin, "show", "state:records/existing.md"), "newer remote\n");
+});
+
+test("a crash before push leaves the remote state unchanged", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 11);
+  const before = git(fixture.origin, "rev-parse", "state").trim();
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "crash-before-push",
+          plans: [plan],
+          hooks: {
+            beforePush: () => {
+              throw new Error("simulated process crash");
+            },
+          },
+        }),
+      ),
+    /simulated process crash/,
+  );
+  assert.equal(git(fixture.origin, "rev-parse", "state").trim(), before);
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/11.md", true),
+    "",
+  );
+});
+
+test("a retry recovers push success after local acknowledgement failure by batch identity", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 12);
+  let pushedCommit = "";
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "ambiguous-ack",
+          plans: [plan],
+          hooks: {
+            afterPush: (commit) => {
+              pushedCommit = commit;
+              throw new Error("ack lost");
+            },
+          },
+        }),
+      ),
+    /ack lost/,
+  );
+  const countAfterPush = git(fixture.origin, "rev-list", "--count", "state").trim();
+
+  const recovered = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "ambiguous-ack", plans: [plan] }),
+  );
+
+  assert.equal(recovered.outcome, "already_committed");
+  assert.equal(recovered.commitSha, pushedCommit);
+  assert.equal(git(fixture.origin, "rev-list", "--count", "state").trim(), countAfterPush);
+});
+
+test("a reused batch id cannot acknowledge a different mutation payload", () => {
+  const fixture = createRepositoryFixture();
+  const first = newItemPlan(fixture, 13);
+  withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "payload-binding", plans: [first] }),
+  );
+  const second = newItemPlan(fixture, 14);
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({ batchId: "payload-binding", plans: [second] }),
+      ),
+    /already bound to a different mutation fingerprint/,
+  );
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/14.md", true),
+    "",
+  );
+});
+
+test("batch receipt recovery remains durable beyond 256 newer state commits", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 20);
+  const committed = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "durable-receipt", plans: [plan] }),
+  );
+  const sibling = path.join(fixture.root, "receipt-history-writer");
+  git(fixture.root, "clone", "--branch", "state", fixture.origin, sibling);
+  configureUser(sibling);
+  fs.mkdirSync(path.join(sibling, "results"), { recursive: true });
+  for (let index = 0; index < 300; index += 1) {
+    fs.writeFileSync(path.join(sibling, "results", "history.txt"), `${index}\n`);
+    git(sibling, "add", "results/history.txt");
+    git(sibling, "commit", "-m", `ordinary state commit ${index}`);
+  }
+  git(sibling, "push", "origin", "HEAD:state");
+
+  const recovered = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "durable-receipt", plans: [plan] }),
+  );
+
+  assert.equal(recovered.outcome, "already_committed");
+  assert.equal(recovered.commitSha, committed.commitSha);
+});
+
+test("custom batch commit messages cannot inject recovery trailers", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 21);
+  const before = git(fixture.origin, "rev-parse", "state").trim();
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "message-injection",
+          plans: [plan],
+          message: "subject\n\nClawSweeper-Batch-ID: forged",
+        }),
+      ),
+    /commit subjects must be single-line/,
+  );
+  assert.equal(git(fixture.origin, "rev-parse", "state").trim(), before);
+});
+
+test("literal Git path names cannot bypass the remote compare-and-swap fence", () => {
+  const fixture = createRepositoryFixture();
+  const literalPath = "records/[ab].md";
+  fs.writeFileSync(path.join(fixture.work, literalPath), "remote literal\n");
+  git(fixture.work, "add", literalPath);
+  git(fixture.work, "commit", "-m", "add literal pathspec-shaped record");
+  git(fixture.work, "push", "origin", "HEAD:state");
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#17", revision: 1, claimGeneration: 1 },
+      operations: [{ path: literalPath, expectedOid: null, content: "candidate\n" }],
+    }),
+  );
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({ batchId: "literal-path-fence", plans: [plan] }),
+      ),
+    /changed after mutation preparation/,
+  );
+  assert.equal(git(fixture.origin, "show", `state:${literalPath}`), "remote literal\n");
+});
+
+test("semantically identical identity property order produces the same recovery fingerprint", () => {
+  const fixture = createRepositoryFixture();
+  const first = newItemPlan(fixture, 18);
+  const committed = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "canonical-identity", plans: [first] }),
+  );
+  const reordered = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { claimGeneration: 1, revision: 1, itemKey: "openclaw/openclaw#18" },
+      operations: [
+        {
+          path: "records/openclaw-openclaw/items/18.md",
+          expectedOid: null,
+          content: "item 18\n",
+        },
+      ],
+    }),
+  );
+
+  const recovered = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "canonical-identity", plans: [reordered] }),
+  );
+
+  assert.equal(recovered.outcome, "already_committed");
+  assert.equal(recovered.fingerprint, committed.fingerprint);
+});
+
+test("batch fingerprints do not depend on locale-aware string ordering", () => {
+  const fixture = createRepositoryFixture();
+  const plans = withStateEnvironment(fixture.work, () => [
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#ä", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/ä.md", expectedOid: null, content: "umlaut\n" }],
+    }),
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#z", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/z.md", expectedOid: null, content: "zed\n" }],
+    }),
+  ]);
+  const canonical = [...plans]
+    .sort((left, right) => (left.identity.itemKey < right.identity.itemKey ? -1 : 1))
+    .map((plan) => ({
+      identity: {
+        itemKey: plan.identity.itemKey,
+        revision: plan.identity.revision,
+        claimGeneration: plan.identity.claimGeneration,
+      },
+      operations: plan.operations.map(
+        ({ path: operationPath, expectedOid, targetOid, mode, bytes }) => ({
+          path: operationPath,
+          expectedOid,
+          targetOid,
+          mode,
+          bytes,
+        }),
+      ),
+    }));
+  const expected = createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "locale-independent-fingerprint", plans }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(result.fingerprint, expected);
+});
+
+test("materialization compares and corrects the executable bit as well as blob content", () => {
+  const fixture = createRepositoryFixture();
+  git(fixture.work, "update-index", "--chmod=+x", "records/existing.md");
+  git(fixture.work, "commit", "-m", "make existing record executable");
+  git(fixture.work, "push", "origin", "HEAD:state");
+  const expectedOid = git(fixture.work, "rev-parse", "HEAD:records/existing.md").trim();
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#15", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/existing.md", expectedOid, content: "initial\n" }],
+    }),
+  );
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "mode-correction", plans: [plan] }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.match(git(fixture.origin, "ls-tree", "state", "records/existing.md"), /^100644 blob /);
+});
+
+test("deletion index records use the SHA-256 repository object width", () => {
+  const fixture = createRepositoryFixture("sha256");
+  const expectedOid = git(fixture.work, "rev-parse", "state:records/existing.md").trim();
+  assert.equal(expectedOid.length, 64);
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#16", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/existing.md", expectedOid, delete: true }],
+    }),
+  );
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "sha256-deletion", plans: [plan] }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(git(fixture.origin, "show", "state:records/existing.md", true), "");
+});
+
+test("an absent deletion target writes one durable binding marker and then recovers", () => {
+  const fixture = createRepositoryFixture();
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#19", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/already-absent.md", expectedOid: null, delete: true }],
+    }),
+  );
+  const beforeCommit = git(fixture.origin, "rev-parse", "state").trim();
+  const beforeTree = git(fixture.origin, "rev-parse", "state^{tree}").trim();
+
+  const committed = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "absent-deletion", plans: [plan] }),
+  );
+  const recovered = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "absent-deletion", plans: [plan] }),
+  );
+
+  assert.equal(committed.outcome, "committed");
+  assert.notEqual(committed.commitSha, beforeCommit);
+  assert.equal(git(fixture.origin, "rev-parse", "state^{tree}").trim(), beforeTree);
+  assert.equal(recovered.outcome, "already_committed");
+  assert.equal(recovered.commitSha, committed.commitSha);
+});
+
+test("batch size one durably binds already-materialized content with one marker commit", () => {
+  const fixture = createRepositoryFixture();
+  const existingOid = git(fixture.work, "rev-parse", "state:records/existing.md").trim();
+  const plan = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#1", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/existing.md", expectedOid: null, content: "initial\n" }],
+    }),
+  );
+  assert.equal(plan.operations[0]?.targetOid, existingOid);
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "single-idempotent", plans: [plan] }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(result.commitSha, git(fixture.origin, "rev-parse", "state").trim());
+});
+
+function newItemPlan(fixture: RepositoryFixture, item: number) {
+  return withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: `openclaw/openclaw#${item}`, revision: 1, claimGeneration: 1 },
+      operations: [
+        {
+          path: `records/openclaw-openclaw/items/${item}.md`,
+          expectedOid: null,
+          content: `item ${item}\n`,
+        },
+      ],
+    }),
+  );
+}
+
+function createRepositoryFixture(objectFormat: "sha1" | "sha256" = "sha1"): RepositoryFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-batch-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  git(root, "init", "--bare", `--object-format=${objectFormat}`, origin);
+  git(root, "clone", origin, work);
+  configureUser(work);
+  fs.mkdirSync(path.join(work, "records"), { recursive: true });
+  fs.writeFileSync(path.join(work, "records", "existing.md"), "initial\n");
+  git(work, "add", ".");
+  git(work, "commit", "-m", "initial state");
+  git(work, "push", "origin", "HEAD:state");
+  git(work, "fetch", "origin", "state:state");
+  return { root, origin, work };
+}
+
+function publishSibling(fixture: RepositoryFixture, file: string, content: string): void {
+  const sibling = path.join(fixture.root, `sibling-${Math.random().toString(16).slice(2)}`);
+  git(fixture.root, "clone", "--branch", "state", fixture.origin, sibling);
+  configureUser(sibling);
+  fs.mkdirSync(path.dirname(path.join(sibling, file)), { recursive: true });
+  fs.writeFileSync(path.join(sibling, file), content);
+  git(sibling, "add", ".");
+  git(sibling, "commit", "-m", "ordinary sibling update");
+  git(sibling, "push", "origin", "HEAD:state");
+}
+
+function configureUser(root: string): void {
+  git(root, "config", "user.name", "ClawSweeper Test");
+  git(root, "config", "user.email", "clawsweeper@example.com");
+}
+
+function withStateEnvironment<T>(work: string, operation: () => T): T {
+  const previousDir = process.env.CLAWSWEEPER_STATE_DIR;
+  const previousBranch = process.env.CLAWSWEEPER_PUBLISH_BRANCH;
+  process.env.CLAWSWEEPER_STATE_DIR = work;
+  process.env.CLAWSWEEPER_PUBLISH_BRANCH = "state";
+  try {
+    return operation();
+  } finally {
+    if (previousDir === undefined) delete process.env.CLAWSWEEPER_STATE_DIR;
+    else process.env.CLAWSWEEPER_STATE_DIR = previousDir;
+    if (previousBranch === undefined) delete process.env.CLAWSWEEPER_PUBLISH_BRANCH;
+    else process.env.CLAWSWEEPER_PUBLISH_BRANCH = previousBranch;
+  }
+}
+
+function git(root: string, ...args: Array<string | boolean>): string {
+  const allowFailure = args.at(-1) === true;
+  if (allowFailure) args.pop();
+  try {
+    return execFileSync("git", args as string[], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    if (allowFailure) return "";
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- prepare and validate bounded per-item state mutation plans outside the publication lease
- publish up to eight plans with one lease, one tree commit, one atomic state/lease/receipt push, and durable ambiguous-push recovery
- preserve literal-path CAS fencing, SHA-1/SHA-256 support, no-op marker bindings, and bounded path/payload metadata

## Why

PR2 of the state-publication batching plan needs a safe commit primitive before dispatcher integration. This keeps the review lane proposal-only while reducing publication lock amplification without weakening conflict detection.

## Validation

- `pnpm run check`
- `pnpm run build:repair && pnpm run lint:repair && node --test test/repair/state-publication-batch.test.ts` (19/19)
- final autoreview: clean, no accepted/actionable findings

Remote Crabbox execution was attempted but blocked before test execution by provider hydration/auth/workflow availability; local Node 24 validation completed successfully.