### PR TITLE
test: stabilize state receipt history

### DIFF
--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -318,13 +318,22 @@ test("batch receipt recovery remains durable beyond 256 newer state commits", ()
   const sibling = path.join(fixture.root, "receipt-history-writer");
   git(fixture.root, "clone", "--branch", "state", fixture.origin, sibling);
   configureUser(sibling);
-  fs.mkdirSync(path.join(sibling, "results"), { recursive: true });
+  const tree = git(sibling, "rev-parse", "HEAD^{tree}").trim();
+  let parent = git(sibling, "rev-parse", "HEAD").trim();
+  // Only ancestry depth matters here. Plumbing commits avoid Git auto-maintenance
+  // racing hundreds of disposable worktree/index updates on shared CI runners.
   for (let index = 0; index < 300; index += 1) {
-    fs.writeFileSync(path.join(sibling, "results", "history.txt"), `${index}\n`);
-    git(sibling, "add", "results/history.txt");
-    git(sibling, "commit", "-m", `ordinary state commit ${index}`);
+    parent = git(
+      sibling,
+      "commit-tree",
+      tree,
+      "-p",
+      parent,
+      "-m",
+      `ordinary state commit ${index}`,
+    ).trim();
   }
-  git(sibling, "push", "origin", "HEAD:state");
+  git(sibling, "push", "origin", `${parent}:state`);
 
   const recovered = withStateEnvironment(fixture.work, () =>
     commitPreparedStateBatch({ batchId: "durable-receipt", plans: [plan] }),


### PR DESCRIPTION
## Summary

- construct the 300-commit receipt-recovery history with `git commit-tree`
- preserve the exact ancestry-depth proof while avoiding worktree/index auto-maintenance races

## Root cause

The PR2 CI run failed at ordinary commit 238 with `bad tree object HEAD` on Git 2.54. The test only needs more than 256 descendant commits; repeatedly mutating a disposable worktree unnecessarily allowed Git object maintenance to race the fixture.

## Validation

- `pnpm run build:repair`
- `pnpm run lint:repair`
- `node --test test/repair/state-publication-batch.test.ts` (19/19)
- final autoreview: clean