### PR TITLE
feat(repair): single-writer state materializer (#738 WP-2)

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -1,0 +1,55 @@
+name: Materialize queued state
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: clawsweeper-state-materializer
+  cancel-in-progress: false
+  queue: max
+
+permissions:
+  contents: read
+
+env:
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+
+jobs:
+  materialize:
+    name: Drain queued state into one commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
+      CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Materialize queued state
+        env:
+          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+        run: node dist/repair/state-materializer.js

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+import { createHmac } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  actionLedgerJson,
+  parseActionEventShardContent,
+  validateActionEvent,
+} from "../action-ledger.js";
+import { isActionEventPublishPath } from "../action-ledger-paths.js";
+import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
+import { publishMainCommit } from "./git-publish.js";
+import { mergeSweepStatusJson } from "./sweep-status-merge.js";
+
+export const DEFAULT_STATE_MATERIALIZER_MAX_ROWS = 2_000;
+export const DEFAULT_STATE_MATERIALIZER_MAX_BYTES = 20 * 1024 * 1024;
+export const DEFAULT_STATE_MATERIALIZER_MAX_RUNTIME_MS = 10 * 60 * 1_000;
+
+const COMMENT_ROUTER_LEDGER_PATH = "results/comment-router.json";
+const EMPTY_COMMENT_ROUTER_LEDGER = '{"updated_at":null,"commands":[]}';
+const STATE_MATERIALIZER_COMMIT_MESSAGE = "chore: materialize queued state\n\n[skip ci]";
+const STATE_APPEND_KINDS = new Set<StateAppendKind>([
+  "sweep_status",
+  "comment_router",
+  "apply_proof",
+]);
+
+export type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof";
+
+export type StateAppendRecord = {
+  seq: number;
+  kind: StateAppendKind;
+  key: string;
+  payload: unknown;
+  produced_at: string;
+  delivery_id: string;
+};
+
+export type StateMaterializerSummary = {
+  drained: number;
+  committed: number;
+  acked: number;
+  skipped: number;
+  errors: number;
+};
+
+export type StateMaterializationPlan = {
+  publishPaths: string[];
+  writes: Array<{ path: string; content: string }>;
+  selected: number;
+  skipped: number;
+};
+
+export type StateMaterializerRunOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+};
+
+type StateDrainResponse = {
+  token: string | null;
+  records: StateAppendRecord[];
+};
+
+export function selectLatestStateRecords(records: readonly StateAppendRecord[]): {
+  records: StateAppendRecord[];
+  skipped: number;
+} {
+  const ordered = [...records].sort((left, right) => left.seq - right.seq);
+  for (let index = 0; index < ordered.length; index += 1) {
+    const record = ordered[index]!;
+    assertStateAppendRecord(record);
+    if (index > 0 && ordered[index - 1]!.seq === record.seq) {
+      throw new Error(`state drain contains duplicate sequence ${record.seq}`);
+    }
+  }
+
+  const latest = new Map<string, StateAppendRecord>();
+  for (const record of ordered) latest.set(`${record.kind}\0${record.key}`, record);
+  const selected = [...latest.values()].sort((left, right) => left.seq - right.seq);
+  return { records: selected, skipped: records.length - selected.length };
+}
+
+export function sweepStatusPathForStateKey(key: string): string {
+  const slugMatch = /^([A-Za-z0-9][A-Za-z0-9_.-]*)$/.exec(key);
+  if (slugMatch) return `results/sweep-status/${slugMatch[1]}.json`;
+  const pathMatch = /^results\/sweep-status\/([A-Za-z0-9][A-Za-z0-9_.-]*)\.json$/.exec(key);
+  if (pathMatch) return key;
+  throw new Error(`invalid sweep status key: ${key}`);
+}
+
+export function serializeApplyProof(path: string, payload: unknown): string {
+  if (!isActionEventPublishPath(path)) {
+    throw new Error(`invalid apply proof ledger path: ${path}`);
+  }
+  if (path.endsWith(".jsonl")) {
+    const content =
+      typeof payload === "string"
+        ? payload
+        : Array.isArray(payload)
+          ? `${payload
+              .map((event, index) =>
+                actionLedgerJson(validateActionEvent(event, `${path}:${index + 1}`)),
+              )
+              .join("\n")}\n`
+          : (() => {
+              throw new Error(`apply proof event payload must be an array or string: ${path}`);
+            })();
+    parseActionEventShardContent(content, path);
+    return content;
+  }
+
+  if (typeof payload !== "string") return `${actionLedgerJson(payload)}\n`;
+  if (!payload.endsWith("\n") || payload.slice(0, -1).includes("\n")) {
+    throw new Error(`apply proof binding must be one newline-terminated JSON value: ${path}`);
+  }
+  const parsed = JSON.parse(payload.slice(0, -1)) as unknown;
+  const canonical = `${actionLedgerJson(parsed)}\n`;
+  if (payload !== canonical) throw new Error(`apply proof binding is not canonical: ${path}`);
+  return payload;
+}
+
+export function planStateMaterialization(
+  records: readonly StateAppendRecord[],
+  currentFiles: ReadonlyMap<string, string> = new Map(),
+): StateMaterializationPlan {
+  const selected = selectLatestStateRecords(records);
+  const contentByPath = new Map<string, string>();
+  const publishPaths: string[] = [];
+  const addPublishPath = (path: string): void => {
+    if (!publishPaths.includes(path)) publishPaths.push(path);
+  };
+
+  for (const record of selected.records) {
+    if (record.kind === "sweep_status") {
+      const path = sweepStatusPathForStateKey(record.key);
+      const slug = path.slice("results/sweep-status/".length, -".json".length);
+      if (!isRecord(record.payload) || record.payload.slug !== slug) {
+        throw new Error(`sweep status payload slug does not match ${path}`);
+      }
+      const payloadText = JSON.stringify(record.payload);
+      const content = mergeSweepStatusJson({
+        path,
+        baseText: null,
+        localText: null,
+        remoteText: payloadText,
+      });
+      contentByPath.set(path, content);
+      addPublishPath(path);
+      continue;
+    }
+
+    if (record.kind === "comment_router") {
+      const payloadText = JSON.stringify(record.payload);
+      const current =
+        contentByPath.get(COMMENT_ROUTER_LEDGER_PATH) ??
+        currentFiles.get(COMMENT_ROUTER_LEDGER_PATH) ??
+        EMPTY_COMMENT_ROUTER_LEDGER;
+      contentByPath.set(
+        COMMENT_ROUTER_LEDGER_PATH,
+        mergeCommentRouterLedgers(payloadText, current),
+      );
+      addPublishPath(COMMENT_ROUTER_LEDGER_PATH);
+      continue;
+    }
+
+    const path = record.key;
+    const content = serializeApplyProof(path, record.payload);
+    const current = currentFiles.get(path);
+    if (current !== undefined && current !== content) {
+      throw new Error(`immutable apply proof already has different content: ${path}`);
+    }
+    contentByPath.set(path, content);
+    addPublishPath(path);
+  }
+
+  return {
+    publishPaths,
+    writes: [...contentByPath]
+      .filter(([path, content]) => currentFiles.get(path) !== content)
+      .map(([path, content]) => ({ path, content })),
+    selected: selected.records.length,
+    skipped: selected.skipped,
+  };
+}
+
+export async function runStateMaterializer(
+  options: StateMaterializerRunOptions = {},
+): Promise<StateMaterializerSummary> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const queueUrl = (env.QUEUE_URL ?? "").replace(/\/$/, "");
+  const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  const maximumRows = boundedPositiveInteger(
+    env.CLAWSWEEPER_STATE_MATERIALIZER_MAX_ROWS ?? env.STATE_MATERIALIZER_MAX_ROWS,
+    DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
+    100_000,
+  );
+  const maximumBytes = boundedPositiveInteger(
+    env.CLAWSWEEPER_STATE_MATERIALIZER_MAX_BYTES ?? env.STATE_MATERIALIZER_MAX_BYTES,
+    DEFAULT_STATE_MATERIALIZER_MAX_BYTES,
+    100 * 1024 * 1024,
+  );
+  const maximumRuntimeMs = boundedPositiveInteger(
+    env.CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS ?? env.STATE_MATERIALIZER_MAX_RUNTIME_MS,
+    DEFAULT_STATE_MATERIALIZER_MAX_RUNTIME_MS,
+    60 * 60 * 1_000,
+  );
+  const publishMaxAttempts = boundedPositiveInteger(
+    env.CLAWSWEEPER_STATE_MATERIALIZER_PUBLISH_MAX_ATTEMPTS,
+    8,
+    64,
+  );
+  const publishPushAttempts = boundedPositiveInteger(
+    env.CLAWSWEEPER_STATE_MATERIALIZER_PUSH_ATTEMPTS,
+    3,
+    16,
+  );
+  const branch = env.CLAWSWEEPER_PUBLISH_BRANCH?.trim() || "state";
+  const startedAt = now().getTime();
+  const summary: StateMaterializerSummary = {
+    drained: 0,
+    committed: 0,
+    acked: 0,
+    skipped: 0,
+    errors: 0,
+  };
+  const finish = (): StateMaterializerSummary => {
+    console.log(
+      `state-materializer: drained=${summary.drained} committed=${summary.committed} acked=${summary.acked} skipped=${summary.skipped} errors=${summary.errors}`,
+    );
+    return summary;
+  };
+
+  if (!queueUrl || !webhookSecret) {
+    summary.errors += 1;
+    console.warn("state-materializer skipped: missing queue URL or webhook secret");
+    return finish();
+  }
+
+  while (now().getTime() - startedAt < maximumRuntimeMs) {
+    let drain: StateDrainResponse;
+    try {
+      drain = await drainStateWindow({
+        queueUrl,
+        webhookSecret,
+        maximumRows,
+        maximumBytes,
+        fetchImpl,
+      });
+    } catch (error) {
+      summary.errors += 1;
+      console.warn(`state-materializer drain failed: ${errorMessage(error)}`);
+      break;
+    }
+    if (drain.records.length === 0) break;
+    summary.drained += drain.records.length;
+
+    try {
+      if (!drain.token) throw new Error("non-empty state drain omitted its token");
+      const selected = selectLatestStateRecords(drain.records);
+      const currentFiles = readCurrentFiles(materializationPaths(selected.records), process.cwd());
+      const plan = planStateMaterialization(drain.records, currentFiles);
+      applyStateMaterializationPlan(plan, process.cwd());
+      publishMainCommit({
+        message: STATE_MATERIALIZER_COMMIT_MESSAGE,
+        paths: plan.publishPaths,
+        branch,
+        maxAttempts: publishMaxAttempts,
+        pushAttempts: publishPushAttempts,
+      });
+      summary.committed += plan.selected;
+      summary.skipped += plan.skipped;
+
+      const acked = await ackStateWindow({
+        queueUrl,
+        webhookSecret,
+        drainToken: drain.token,
+        fetchImpl,
+      });
+      if (acked !== drain.records.length) {
+        throw new Error(
+          `state ack count ${acked} did not match drained count ${drain.records.length}`,
+        );
+      }
+      summary.acked += acked;
+    } catch (error) {
+      summary.errors += 1;
+      console.warn(`state-materializer cycle failed: ${errorMessage(error)}`);
+      break;
+    }
+  }
+  return finish();
+}
+
+export function applyStateMaterializationPlan(plan: StateMaterializationPlan, root: string): void {
+  const resolvedRoot = resolve(root);
+  for (const write of plan.writes) {
+    const target = resolve(resolvedRoot, write.path);
+    if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${sep}`)) {
+      throw new Error(`refusing state materialization outside checkout: ${write.path}`);
+    }
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, write.content, "utf8");
+  }
+}
+
+function materializationPaths(records: readonly StateAppendRecord[]): string[] {
+  const paths: string[] = [];
+  for (const record of records) {
+    const path =
+      record.kind === "sweep_status"
+        ? sweepStatusPathForStateKey(record.key)
+        : record.kind === "comment_router"
+          ? COMMENT_ROUTER_LEDGER_PATH
+          : record.key;
+    if (record.kind === "apply_proof" && !isActionEventPublishPath(path)) {
+      throw new Error(`invalid apply proof ledger path: ${path}`);
+    }
+    if (!paths.includes(path)) paths.push(path);
+  }
+  return paths;
+}
+
+function readCurrentFiles(paths: readonly string[], root: string): Map<string, string> {
+  const resolvedRoot = resolve(root);
+  const files = new Map<string, string>();
+  for (const path of paths) {
+    const target = resolve(resolvedRoot, path);
+    if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${sep}`)) {
+      throw new Error(`refusing state read outside checkout: ${path}`);
+    }
+    if (existsSync(target)) files.set(path, readFileSync(target, "utf8"));
+  }
+  return files;
+}
+
+async function drainStateWindow(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  maximumRows: number;
+  maximumBytes: number;
+  fetchImpl: typeof fetch;
+}): Promise<StateDrainResponse> {
+  const body = await postSignedStateRequest({
+    ...options,
+    path: "/internal/state/drain",
+    payload: { max_rows: options.maximumRows, max_bytes: options.maximumBytes },
+  });
+  if (body.ok !== true || !Array.isArray(body.records)) {
+    throw new Error("POST /internal/state/drain returned an invalid response");
+  }
+  const token = body.drain_token === null ? null : String(body.drain_token || "").trim();
+  if (body.records.length > 0 && !token) {
+    throw new Error("POST /internal/state/drain returned records without a token");
+  }
+  const records = body.records.map(stateAppendRecordFrom);
+  selectLatestStateRecords(records);
+  return { token, records };
+}
+
+async function ackStateWindow(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  drainToken: string;
+  fetchImpl: typeof fetch;
+}): Promise<number> {
+  const body = await postSignedStateRequest({
+    ...options,
+    path: "/internal/state/ack",
+    payload: { drain_token: options.drainToken },
+  });
+  const acked = Number(body.acked);
+  if (body.ok !== true || !Number.isSafeInteger(acked) || acked < 0) {
+    throw new Error("POST /internal/state/ack returned an invalid response");
+  }
+  return acked;
+}
+
+async function postSignedStateRequest(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  path: string;
+  payload: unknown;
+  fetchImpl: typeof fetch;
+}): Promise<Record<string, unknown>> {
+  const body = JSON.stringify(options.payload);
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret)
+    .update(body)
+    .digest("hex")}`;
+  const response = await options.fetchImpl(`${options.queueUrl}${options.path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+  if (!response.ok) throw new Error(`POST ${options.path} returned ${response.status}`);
+  const value = (await response.json().catch(() => null)) as unknown;
+  if (!isRecord(value)) throw new Error(`POST ${options.path} returned invalid JSON`);
+  return value;
+}
+
+function stateAppendRecordFrom(value: unknown): StateAppendRecord {
+  if (!isRecord(value)) throw new Error("state drain record must be an object");
+  if (!Object.hasOwn(value, "payload")) throw new Error("state drain record has no payload");
+  const record = {
+    seq: Number(value.seq),
+    kind: String(value.kind || "") as StateAppendKind,
+    key: String(value.key || "").trim(),
+    payload: value.payload,
+    produced_at: String(value.produced_at || "").trim(),
+    delivery_id: String(value.delivery_id || "").trim(),
+  };
+  assertStateAppendRecord(record);
+  return record;
+}
+
+function assertStateAppendRecord(record: StateAppendRecord): void {
+  if (!Number.isSafeInteger(record.seq) || record.seq < 1) {
+    throw new Error("state drain record has an invalid sequence");
+  }
+  if (!STATE_APPEND_KINDS.has(record.kind)) {
+    throw new Error(`state drain record has an invalid kind: ${record.kind}`);
+  }
+  if (!record.key || record.key.length > 2_048) {
+    throw new Error("state drain record has an invalid key");
+  }
+  if (record.payload === undefined) throw new Error("state drain record has no payload");
+  if (!record.produced_at || !Number.isFinite(Date.parse(record.produced_at))) {
+    throw new Error("state drain record has an invalid produced_at");
+  }
+  if (!record.delivery_id) throw new Error("state drain record has no delivery_id");
+}
+
+function boundedPositiveInteger(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    const summary = await runStateMaterializer();
+    if (summary.errors > 0) process.exitCode = 1;
+  } catch (error) {
+    console.warn(`state-materializer failed: ${errorMessage(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -194,6 +194,7 @@ export async function runStateMaterializer(
   const now = options.now ?? (() => new Date());
   const queueUrl = (env.QUEUE_URL ?? "").replace(/\/$/, "");
   const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  registerStateSecretForRedaction(webhookSecret);
   const maximumRows = boundedPositiveInteger(
     env.CLAWSWEEPER_STATE_MATERIALIZER_MAX_ROWS ?? env.STATE_MATERIALIZER_MAX_ROWS,
     DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
@@ -451,7 +452,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return redactStateSecrets(message);
+}
+
+let stateSecretsToRedact: string[] = [];
+
+function registerStateSecretForRedaction(secret: string): void {
+  if (secret && !stateSecretsToRedact.includes(secret)) stateSecretsToRedact.push(secret);
+}
+
+// Error text can transit request internals; never let a registered secret
+// value reach the log stream in clear text.
+function redactStateSecrets(message: string): string {
+  let redacted = message;
+  for (const secret of stateSecretsToRedact) {
+    redacted = redacted.split(secret).join("<redacted>");
+  }
+  return redacted;
 }
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { actionLedgerJson } from "../../dist/action-ledger.js";
+import {
+  DEFAULT_STATE_MATERIALIZER_MAX_BYTES,
+  DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
+  runStateMaterializer,
+  type StateAppendRecord,
+} from "../../dist/repair/state-materializer.js";
+
+const webhookSecret = "state-materializer-test-secret";
+const producedAt = "2026-07-20T12:00:00.000Z";
+const proofPath = `ledger/v1/import-bindings/events/${"a".repeat(64)}.json`;
+
+test("materializer applies every record kind in sequence and keeps the last value per key", async () => {
+  const fixture = createStateFixture();
+  const records = [
+    record(1, "sweep_status", "openclaw-openclaw", sweepStatus("old", "12:00:00.000")),
+    record(2, "comment_router", "router-a", routerLedger("router-a", "12:00:01.000")),
+    record(3, "apply_proof", proofPath, {
+      event_id: "proof-event",
+      schema: "clawsweeper.action-ledger-import-event-binding",
+      schema_version: 1,
+    }),
+    record(4, "sweep_status", "openclaw-openclaw", sweepStatus("new", "12:00:04.000")),
+    record(5, "comment_router", "router-b", routerLedger("router-b", "12:00:05.000")),
+  ];
+  const requests: Array<{ path: string; body: Record<string, unknown> }> = [];
+  let drainCalls = 0;
+  let ackCalls = 0;
+  const fetchImpl = signedQueueFetch(async (url, body) => {
+    requests.push({ path: url.pathname, body });
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "drain-1", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/ack");
+    ackCalls += 1;
+    assert.deepEqual(body, { drain_token: "drain-1" });
+    return Response.json({ ok: true, acked: records.length });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 5, committed: 4, acked: 5, skipped: 1, errors: 0 });
+  assert.equal(ackCalls, 1);
+  assert.deepEqual(requests[0]?.body, {
+    max_rows: DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
+    max_bytes: DEFAULT_STATE_MATERIALIZER_MAX_BYTES,
+  });
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "rev-list", "--count", "state"], fixture.root),
+    "2\n",
+  );
+
+  const status = JSON.parse(showState(fixture, "results/sweep-status/openclaw-openclaw.json"));
+  assert.equal(status.detail, "new");
+  assert.equal(status.updated_at, "2026-07-20T12:00:04.000Z");
+
+  const router = JSON.parse(showState(fixture, "results/comment-router.json"));
+  assert.deepEqual(
+    router.commands.map((command: { comment_version_key: string }) => command.comment_version_key),
+    ["base", "router-a", "router-b"],
+  );
+  assert.equal(
+    showState(fixture, proofPath),
+    `${actionLedgerJson({
+      event_id: "proof-event",
+      schema: "clawsweeper.action-ledger-import-event-binding",
+      schema_version: 1,
+    })}\n`,
+  );
+  assert.match(
+    run("git", ["--git-dir", fixture.origin, "log", "-1", "--format=%B", "state"], fixture.root),
+    /chore: materialize queued state[\s\S]*\[skip ci\]/,
+  );
+});
+
+test("materializer does not ack a drain when the state push fails", async () => {
+  const fixture = createStateFixture();
+  run(
+    "git",
+    ["remote", "set-url", "origin", path.join(fixture.root, "unreachable-state.git")],
+    fixture.state,
+  );
+  let ackCalls = 0;
+  let drainCalls = 0;
+  const records = [
+    record(1, "sweep_status", "openclaw-openclaw", sweepStatus("blocked", "12:00:01.000")),
+  ];
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      assert.equal(drainCalls, 1);
+      return Response.json({ ok: true, drain_token: "drain-failed", records });
+    }
+    ackCalls += 1;
+    return Response.json({ ok: true, acked: records.length });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({
+      env: materializerEnv({
+        CLAWSWEEPER_STATE_MATERIALIZER_PUBLISH_MAX_ATTEMPTS: "1",
+        CLAWSWEEPER_STATE_MATERIALIZER_PUSH_ATTEMPTS: "1",
+      }),
+      fetchImpl,
+    }),
+  );
+
+  assert.deepEqual(summary, { drained: 1, committed: 0, acked: 0, skipped: 0, errors: 1 });
+  assert.equal(ackCalls, 0);
+  assert.equal(
+    JSON.parse(showState(fixture, "results/sweep-status/openclaw-openclaw.json")).detail,
+    "initial",
+  );
+});
+
+test("materializer no-ops when the drain is empty", async () => {
+  let calls = 0;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    calls += 1;
+    assert.equal(url.pathname, "/internal/state/drain");
+    return Response.json({ ok: true, drain_token: null, records: [] });
+  });
+
+  const summary = await runStateMaterializer({ env: materializerEnv(), fetchImpl });
+
+  assert.deepEqual(summary, { drained: 0, committed: 0, acked: 0, skipped: 0, errors: 0 });
+  assert.equal(calls, 1);
+});
+
+test("materializer stops before another drain when its runtime budget is exhausted", async () => {
+  const fixture = createStateFixture();
+  const records = [
+    record(1, "sweep_status", "openclaw-openclaw", sweepStatus("budget", "12:00:01.000")),
+  ];
+  let drainCalls = 0;
+  let ackCalls = 0;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return Response.json({ ok: true, drain_token: "drain-budget", records });
+    }
+    ackCalls += 1;
+    return Response.json({ ok: true, acked: 1 });
+  });
+  const instants = [0, 0, 1_001];
+  const now = () => new Date(instants.shift() ?? 1_001);
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({
+      env: materializerEnv({ CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS: "1000" }),
+      fetchImpl,
+      now,
+    }),
+  );
+
+  assert.deepEqual(summary, { drained: 1, committed: 1, acked: 1, skipped: 0, errors: 0 });
+  assert.equal(drainCalls, 1);
+  assert.equal(ackCalls, 1);
+});
+
+function record(
+  seq: number,
+  kind: StateAppendRecord["kind"],
+  key: string,
+  payload: unknown,
+): StateAppendRecord {
+  return {
+    seq,
+    kind,
+    key,
+    payload,
+    produced_at: producedAt,
+    delivery_id: `delivery-${seq}`,
+  };
+}
+
+function sweepStatus(detail: string, time: string): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    slug: "openclaw-openclaw",
+    display_name: "OpenClaw",
+    target_repo: "openclaw/openclaw",
+    state: "running",
+    detail,
+    updated_at: `2026-07-20T${time}Z`,
+  };
+}
+
+function routerLedger(key: string, time: string): Record<string, unknown> {
+  const timestamp = `2026-07-20T${time}Z`;
+  return {
+    updated_at: timestamp,
+    commands: [
+      {
+        comment_version_key: key,
+        comment_id: key,
+        comment_updated_at: timestamp,
+        status: "executed",
+        processed_at: timestamp,
+      },
+    ],
+  };
+}
+
+function signedQueueFetch(
+  handler: (url: URL, body: Record<string, unknown>) => Promise<Response>,
+): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const bodyText = String(init?.body ?? "");
+    const expected = `sha256=${createHmac("sha256", webhookSecret).update(bodyText).digest("hex")}`;
+    assert.equal(init?.method, "POST");
+    assert.equal(new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"), expected);
+    return handler(url, JSON.parse(bodyText) as Record<string, unknown>);
+  }) as typeof fetch;
+}
+
+function materializerEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    QUEUE_URL: "https://queue.test/",
+    CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
+    CLAWSWEEPER_PUBLISH_BRANCH: "state",
+    ...overrides,
+  };
+}
+
+function createStateFixture(): {
+  root: string;
+  origin: string;
+  source: string;
+  state: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-materializer-"));
+  const origin = path.join(root, "origin.git");
+  const source = path.join(root, "source");
+  const state = path.join(root, "state");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, state], root);
+  configureUser(state);
+  writeJson(
+    path.join(state, "results/sweep-status/openclaw-openclaw.json"),
+    sweepStatus("initial", "11:59:00.000"),
+  );
+  writeJson(path.join(state, "results/comment-router.json"), {
+    updated_at: "2026-07-20T11:59:00.000Z",
+    commands: [
+      {
+        comment_version_key: "base",
+        comment_id: "base",
+        comment_updated_at: "2026-07-20T11:59:00.000Z",
+        status: "executed",
+        processed_at: "2026-07-20T11:59:00.000Z",
+      },
+    ],
+  });
+  run("git", ["add", "."], state);
+  run("git", ["commit", "-m", "initial state"], state);
+  run("git", ["push", "origin", "HEAD:state"], state);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["checkout", "-B", "state", "origin/state"], state);
+  fs.cpSync(path.join(state, "results"), path.join(source, "results"), { recursive: true });
+  return { root, origin, source, state };
+}
+
+async function withMaterializerFixture<T>(
+  fixture: ReturnType<typeof createStateFixture>,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previousCwd = process.cwd();
+  const previousStateDir = process.env.CLAWSWEEPER_STATE_DIR;
+  const previousPriority = process.env.CLAWSWEEPER_STATE_LEASE_PRIORITY;
+  process.chdir(fixture.source);
+  process.env.CLAWSWEEPER_STATE_DIR = fixture.state;
+  process.env.CLAWSWEEPER_STATE_LEASE_PRIORITY = "1";
+  try {
+    return await operation();
+  } finally {
+    process.chdir(previousCwd);
+    if (previousStateDir === undefined) delete process.env.CLAWSWEEPER_STATE_DIR;
+    else process.env.CLAWSWEEPER_STATE_DIR = previousStateDir;
+    if (previousPriority === undefined) delete process.env.CLAWSWEEPER_STATE_LEASE_PRIORITY;
+    else process.env.CLAWSWEEPER_STATE_LEASE_PRIORITY = previousPriority;
+  }
+}
+
+function showState(fixture: ReturnType<typeof createStateFixture>, file: string): string {
+  return run("git", ["--git-dir", fixture.origin, "show", `state:${file}`], fixture.root);
+}
+
+function configureUser(cwd: string): void {
+  run("git", ["config", "user.name", "Tester"], cwd);
+  run("git", ["config", "user.email", "tester@example.com"], cwd);
+}
+
+function writeJson(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(command: string, args: readonly string[], cwd: string): string {
+  return execFileSync(command, [...args], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}


### PR DESCRIPTION
WP-2 of #738. Single-writer materializer: drains the DO state-append window in signed batches, reduces by seq/last-writer-wins, applies records through the existing serialization helpers (results/sweep-status/<slug>.json, mergeCommentRouterLedgers, canonical ledger/v1 paths), publishes ONE commit per cycle via the existing publish machinery (race-tolerant during transition), and acks only after a successful push — a crashed cycle re-drains via lease expiry.

Workflow: 5-min schedule + dispatch, serialized concurrency group, priority-lease env for the transition, 20-min timeout. Empty window no-ops.

Validation: materializer tests 4/4; git-publish 59/59 locally runnable; build/lint/format/actionlint green; commit-mode autoreview clean. Writers cut over in WP-3.
