### PR TITLE
feat(repair): cut sweep-status lane over to DO state append (#738 WP-3a)

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2306,6 +2306,10 @@ jobs:
         if: ${{ !((github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '6,21,36,51 * * * *'))) && !((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true' && github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) }}
         continue-on-error: true
         working-directory: clawsweeper
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           target_slug="${{ steps.target.outputs.target_repo }}"
           target_slug="${target_slug//\//-}"
@@ -2619,7 +2623,10 @@ jobs:
         continue-on-error: true
         working-directory: clawsweeper
         env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ github.token }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           target_slug="$TARGET_REPO"
@@ -3185,9 +3192,12 @@ jobs:
         id: commit-review-records
         if: ${{ always() && !cancelled() && steps.apply-review-artifacts.outputs.artifacts_applied == 'true' }}
         env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
           GH_TOKEN: ${{ github.token }}
           HOT_INTAKE: ${{ needs.plan.outputs.hot_intake }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
           target_slug="$TARGET_REPO"
@@ -3397,7 +3407,10 @@ jobs:
         if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
         timeout-minutes: 15
         env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
           set -euo pipefail
@@ -3950,6 +3963,9 @@ jobs:
 
       - name: Commit Audit Health
         env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           target_slug="$TARGET_REPO"
@@ -4393,12 +4409,15 @@ jobs:
         id: apply-existing-run
         timeout-minutes: 350
         env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           CLAWSWEEPER_PUBLISH_THROTTLE_STATUS: "true"
           CLAWSWEEPER_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CLAWSWEEPER_THROTTLE_STATUS_MIN_WAIT_MS: "60000"
           CLAWSWEEPER_THROTTLE_STATUS_MIN_INTERVAL_MS: "120000"
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -4788,6 +4807,10 @@ jobs:
 
       - name: Retry final apply status publication
         if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           if [ "${APPLY_NOOP:-false}" = "true" ]; then
             echo "No proposed closes were ready; no final apply status to retry."

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -1,5 +1,20 @@
 #!/usr/bin/env node
-import { publishMainCommit, type RebaseStrategy } from "./git-publish.js";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  publishMainCommit,
+  type GitPublishOptions,
+  type PublishResult,
+  type RebaseStrategy,
+} from "./git-publish.js";
+import {
+  postStateAppend,
+  type StateAppendInputRecord,
+  type StateAppendResult,
+} from "./state-append-client.js";
 
 type Args = {
   message: string;
@@ -10,15 +25,131 @@ type Args = {
   rebaseStrategy?: RebaseStrategy;
 };
 
-const args = parseArgs(process.argv.slice(2));
-publishMainCommit({
-  message: args.message,
-  paths: args.paths,
-  restorePaths: args.restorePaths,
-  maxAttempts: args.maxAttempts,
-  pushAttempts: args.pushAttempts,
-  rebaseStrategy: args.rebaseStrategy,
-});
+type PublishMainRuntime = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  publishGit?: (options: GitPublishOptions) => PublishResult;
+  root?: string;
+};
+
+type StateAppendPlan = {
+  consumedPaths: Set<string>;
+  records: StateAppendInputRecord[];
+};
+
+const SWEEP_STATUS_DIRECTORY = "results/sweep-status";
+const SWEEP_STATUS_FILE_PATTERN = /^results\/sweep-status\/([A-Za-z0-9][A-Za-z0-9_.-]*)\.json$/;
+
+export async function publishMainWithStateAppend(
+  options: GitPublishOptions,
+  runtime: PublishMainRuntime = {},
+): Promise<PublishResult | "appended"> {
+  const env = runtime.env ?? process.env;
+  const publishGit = runtime.publishGit ?? publishMainCommit;
+  const queueUrl = env.QUEUE_URL ?? "";
+  const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  if (env.CLAWSWEEPER_STATE_APPEND_ENABLED !== "1" || !queueUrl || !webhookSecret) {
+    return publishGit(options);
+  }
+
+  let plan: StateAppendPlan;
+  try {
+    plan = planSweepStatusAppend(options.paths, runtime.root ?? process.cwd(), runtime.now);
+  } catch {
+    console.warn("state-append shed/failed; falling back to git publish");
+    return publishGit(options);
+  }
+  if (plan.records.length === 0) return publishGit(options);
+
+  const contentHash = createHash("sha256").update(JSON.stringify(plan.records)).digest("hex");
+  const deliveryId = `router:sweep-status-${deliveryPart(env.GITHUB_RUN_ID, "local")}-${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}-${contentHash}`;
+
+  let appendResult: StateAppendResult;
+  try {
+    appendResult = await postStateAppend({
+      queueUrl,
+      webhookSecret,
+      deliveryId,
+      records: plan.records,
+      ...(runtime.fetchImpl ? { fetchImpl: runtime.fetchImpl } : {}),
+    });
+  } catch {
+    console.warn("state-append shed/failed; falling back to git publish");
+    return publishGit(options);
+  }
+  if (!appendResult.ok || appendResult.shed) {
+    console.warn("state-append shed/failed; falling back to git publish");
+    return publishGit(options);
+  }
+
+  const remainingPaths = options.paths.filter((path) => !plan.consumedPaths.has(path));
+  if (remainingPaths.length > 0) return publishGit({ ...options, paths: remainingPaths });
+  console.log(`Appended ${plan.records.length} sweep status record(s) to durable state`);
+  return "appended";
+}
+
+function planSweepStatusAppend(
+  paths: readonly string[],
+  root: string,
+  now: (() => Date) | undefined,
+): StateAppendPlan {
+  const consumedPaths = new Set<string>();
+  const files = new Set<string>();
+  for (const originalPath of paths) {
+    const path = normalizedPath(originalPath);
+    if (SWEEP_STATUS_FILE_PATTERN.test(path)) {
+      const absolute = resolve(root, path);
+      if (existsSync(absolute) && statSync(absolute).isFile()) {
+        consumedPaths.add(originalPath);
+        files.add(path);
+      }
+      continue;
+    }
+    if (path !== SWEEP_STATUS_DIRECTORY) continue;
+    const absolute = resolve(root, path);
+    if (!existsSync(absolute) || !statSync(absolute).isDirectory()) continue;
+    const directoryFiles = readdirSync(absolute)
+      .filter((name) => /^[A-Za-z0-9][A-Za-z0-9_.-]*\.json$/.test(name))
+      .map((name) => `${SWEEP_STATUS_DIRECTORY}/${name}`);
+    if (directoryFiles.length === 0) continue;
+    consumedPaths.add(originalPath);
+    for (const file of directoryFiles) files.add(file);
+  }
+
+  const fallbackProducedAt = (now ?? (() => new Date()))().toISOString();
+  const records = [...files].sort().map((path): StateAppendInputRecord => {
+    const match = SWEEP_STATUS_FILE_PATTERN.exec(path);
+    if (!match) throw new Error(`invalid sweep status path: ${path}`);
+    const payload = JSON.parse(readFileSync(resolve(root, path), "utf8")) as unknown;
+    if (!isRecord(payload) || payload.slug !== match[1]) {
+      throw new Error(`sweep status payload slug does not match ${path}`);
+    }
+    const updatedAt = typeof payload.updated_at === "string" ? payload.updated_at : "";
+    return {
+      kind: "sweep_status",
+      key: path,
+      payload,
+      produced_at: Number.isFinite(Date.parse(updatedAt)) ? updatedAt : fallbackProducedAt,
+    };
+  });
+  return { consumedPaths, records };
+}
+
+function normalizedPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
+}
+
+function deliveryPart(value: string | undefined, fallback: string): string {
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9_.-]/g, "-");
+  return normalized || fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
 
 function parseArgs(argv: readonly string[]): Args {
   const parsed: Args = { message: "", paths: [], restorePaths: [] };
@@ -63,4 +194,17 @@ function parseRebaseStrategy(value: string): RebaseStrategy {
   )
     return value;
   throw new Error("--rebase-strategy must be normal, theirs, apply-records, or reconcile-records");
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  await publishMainWithStateAppend({
+    message: args.message,
+    paths: args.paths,
+    restorePaths: args.restorePaths,
+    maxAttempts: args.maxAttempts,
+    pushAttempts: args.pushAttempts,
+    rebaseStrategy: args.rebaseStrategy,
+  });
 }

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -55,7 +55,12 @@ export async function publishMainWithStateAppend(
 
   let plan: StateAppendPlan;
   try {
-    plan = planSweepStatusAppend(options.paths, runtime.root ?? process.cwd(), runtime.now);
+    plan = planSweepStatusAppend(
+      options.paths,
+      runtime.root ?? process.cwd(),
+      env.CLAWSWEEPER_STATE_DIR,
+      runtime.now,
+    );
   } catch {
     console.warn("state-append shed/failed; falling back to git publish");
     return publishGit(options);
@@ -92,6 +97,7 @@ export async function publishMainWithStateAppend(
 function planSweepStatusAppend(
   paths: readonly string[],
   root: string,
+  stateRoot: string | undefined,
   now: (() => Date) | undefined,
 ): StateAppendPlan {
   const consumedPaths = new Set<string>();
@@ -109,9 +115,17 @@ function planSweepStatusAppend(
     if (path !== SWEEP_STATUS_DIRECTORY) continue;
     const absolute = resolve(root, path);
     if (!existsSync(absolute) || !statSync(absolute).isDirectory()) continue;
-    const directoryFiles = readdirSync(absolute)
-      .filter((name) => /^[A-Za-z0-9][A-Za-z0-9_.-]*\.json$/.test(name))
-      .map((name) => `${SWEEP_STATUS_DIRECTORY}/${name}`);
+    if (!stateRoot) throw new Error("cannot prove sweep status directory append is lossless");
+    const stateDirectory = resolve(stateRoot, path);
+    if (!existsSync(stateDirectory) || !statSync(stateDirectory).isDirectory()) {
+      throw new Error("cannot compare sweep status directory with state checkout");
+    }
+    const sourceNames = sweepStatusDirectoryNames(absolute);
+    const stateNames = sweepStatusDirectoryNames(stateDirectory);
+    if (stateNames.some((name) => !sourceNames.includes(name))) {
+      throw new Error("sweep status directory contains a deletion that requires git publish");
+    }
+    const directoryFiles = sourceNames.map((name) => `${SWEEP_STATUS_DIRECTORY}/${name}`);
     if (directoryFiles.length === 0) continue;
     consumedPaths.add(originalPath);
     for (const file of directoryFiles) files.add(file);
@@ -134,6 +148,18 @@ function planSweepStatusAppend(
     };
   });
   return { consumedPaths, records };
+}
+
+function sweepStatusDirectoryNames(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  if (
+    entries.some(
+      (entry) => !entry.isFile() || !/^[A-Za-z0-9][A-Za-z0-9_.-]*\.json$/.test(entry.name),
+    )
+  ) {
+    throw new Error("sweep status directory contains an unrepresentable entry");
+  }
+  return entries.map((entry) => entry.name).sort();
 }
 
 function normalizedPath(path: string): string {

--- a/src/repair/state-append-client.ts
+++ b/src/repair/state-append-client.ts
@@ -1,0 +1,83 @@
+import { createHmac } from "node:crypto";
+
+export type StateAppendInputRecord = {
+  kind: "sweep_status" | "comment_router" | "apply_proof";
+  key: string;
+  payload: unknown;
+  produced_at: string;
+};
+
+export type StateAppendResult = {
+  ok: boolean;
+  shed: boolean;
+};
+
+export async function postStateAppend(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  deliveryId: string;
+  records: readonly StateAppendInputRecord[];
+  fetchImpl?: typeof fetch;
+}): Promise<StateAppendResult> {
+  registerStateAppendSecretForRedaction(options.webhookSecret);
+  try {
+    const queueUrl = options.queueUrl.replace(/\/+$/, "");
+    if (!queueUrl) throw new Error("state append queue URL is required");
+    if (!options.webhookSecret) throw new Error("state append webhook secret is required");
+    if (!options.deliveryId) throw new Error("state append delivery ID is required");
+    if (options.records.length === 0) throw new Error("state append records are required");
+
+    const body = JSON.stringify({
+      delivery_id: options.deliveryId,
+      records: options.records,
+    });
+    const signature = `sha256=${createHmac("sha256", options.webhookSecret)
+      .update(body)
+      .digest("hex")}`;
+    const response = await (options.fetchImpl ?? fetch)(`${queueUrl}/internal/state/append`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-clawsweeper-exact-review-signature": signature,
+      },
+      body,
+    });
+    const value = (await response.json().catch(() => null)) as unknown;
+    if (isRecord(value) && value.shed === true) return { ok: false, shed: true };
+    if (!response.ok) {
+      throw new Error(`POST /internal/state/append returned ${response.status}`);
+    }
+    if (!isRecord(value) || typeof value.ok !== "boolean") {
+      throw new Error("POST /internal/state/append returned an invalid response");
+    }
+    return { ok: value.ok, shed: false };
+  } catch (error) {
+    throw new Error(redactStateAppendSecrets(errorMessage(error)));
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+let stateAppendSecretsToRedact: string[] = [];
+
+function registerStateAppendSecretForRedaction(secret: string): void {
+  if (secret && !stateAppendSecretsToRedact.includes(secret)) {
+    stateAppendSecretsToRedact.push(secret);
+  }
+}
+
+// Error text can transit request internals; never let a registered secret
+// value reach the log stream in clear text.
+function redactStateAppendSecrets(message: string): string {
+  let redacted = message;
+  for (const secret of stateAppendSecretsToRedact) {
+    redacted = redacted.split(secret).join("<redacted>");
+  }
+  return redacted;
+}

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { publishMainWithStateAppend } from "../../dist/repair/publish-main.js";
+import type { GitPublishOptions, PublishResult } from "../../dist/repair/git-publish.js";
+
+const statusPath = "results/sweep-status/openclaw-openclaw.json";
+
+test("publish-main appends sweep status instead of invoking the git publisher", async () => {
+  const root = statusFixture();
+  const gitPublishes: GitPublishOptions[] = [];
+  let posted: Record<string, unknown> | undefined;
+  const fetchImpl = (async (_input: string | URL | Request, init?: RequestInit) => {
+    posted = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+    return Response.json({ ok: true, appended: 1 }, { status: 202 });
+  }) as typeof fetch;
+
+  const result = await publishMainWithStateAppend(
+    { message: "chore: update sweep status", paths: [statusPath] },
+    {
+      root,
+      env: appendEnv(),
+      fetchImpl,
+      publishGit: (options) => {
+        gitPublishes.push(options);
+        return "committed";
+      },
+    },
+  );
+
+  assert.equal(result, "appended");
+  assert.equal(gitPublishes.length, 0);
+  assert.match(String(posted?.delivery_id), /^router:sweep-status-1234-2-[a-f0-9]{64}$/);
+  assert.deepEqual(posted?.records, [
+    {
+      kind: "sweep_status",
+      key: statusPath,
+      payload: sweepStatus(),
+      produced_at: "2026-07-21T12:00:00.000Z",
+    },
+  ]);
+});
+
+test("publish-main keeps mixed non-status paths on the git publisher", async () => {
+  const root = statusFixture();
+  const gitPublishes: GitPublishOptions[] = [];
+  const fetchImpl = (async () =>
+    Response.json({ ok: true, appended: 1 }, { status: 202 })) as typeof fetch;
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      {
+        message: "chore: publish sweep audit status",
+        paths: ["README.md", statusPath],
+        rebaseStrategy: "theirs",
+      },
+      {
+        root,
+        env: appendEnv(),
+        fetchImpl,
+        publishGit: capturePublishes(gitPublishes),
+      },
+    ),
+    "committed",
+  );
+  assert.deepEqual(gitPublishes[0]?.paths, ["README.md"]);
+  assert.equal(gitPublishes[0]?.rebaseStrategy, "theirs");
+});
+
+test("publish-main falls back to the original git publish on shed", async (t) => {
+  const root = statusFixture();
+  const gitPublishes: GitPublishOptions[] = [];
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+  const original = {
+    message: "chore: update sweep status",
+    paths: ["results/sweep-status"],
+    rebaseStrategy: "apply-records" as const,
+  };
+
+  assert.equal(
+    await publishMainWithStateAppend(original, {
+      root,
+      env: appendEnv(),
+      fetchImpl: (async () =>
+        Response.json({ ok: false, shed: true }, { status: 429 })) as typeof fetch,
+      publishGit: capturePublishes(gitPublishes),
+    }),
+    "committed",
+  );
+  assert.deepEqual(gitPublishes, [original]);
+  assert.deepEqual(warnings, ["state-append shed/failed; falling back to git publish"]);
+});
+
+function statusFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-main-"));
+  const target = path.join(root, statusPath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, `${JSON.stringify(sweepStatus())}\n`);
+  return root;
+}
+
+function sweepStatus(): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    slug: "openclaw-openclaw",
+    state: "Review in progress",
+    updated_at: "2026-07-21T12:00:00.000Z",
+  };
+}
+
+function appendEnv(): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_STATE_APPEND_ENABLED: "1",
+    QUEUE_URL: "https://queue.test",
+    CLAWSWEEPER_WEBHOOK_SECRET: "publish-main-test-secret",
+    GITHUB_RUN_ID: "1234",
+    GITHUB_RUN_ATTEMPT: "2",
+  };
+}
+
+function capturePublishes(
+  publishes: GitPublishOptions[],
+): (options: GitPublishOptions) => PublishResult {
+  return (options) => {
+    publishes.push(options);
+    return "committed";
+  };
+}

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -72,6 +72,7 @@ test("publish-main keeps mixed non-status paths on the git publisher", async () 
 
 test("publish-main falls back to the original git publish on shed", async (t) => {
   const root = statusFixture();
+  const stateRoot = statusFixture();
   const gitPublishes: GitPublishOptions[] = [];
   const warnings: string[] = [];
   t.mock.method(console, "warn", (message: string) => warnings.push(message));
@@ -84,7 +85,7 @@ test("publish-main falls back to the original git publish on shed", async (t) =>
   assert.equal(
     await publishMainWithStateAppend(original, {
       root,
-      env: appendEnv(),
+      env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
       fetchImpl: (async () =>
         Response.json({ ok: false, shed: true }, { status: 429 })) as typeof fetch,
       publishGit: capturePublishes(gitPublishes),
@@ -95,30 +96,66 @@ test("publish-main falls back to the original git publish on shed", async (t) =>
   assert.deepEqual(warnings, ["state-append shed/failed; falling back to git publish"]);
 });
 
+test("publish-main keeps directory deletions on the git fallback path", async (t) => {
+  const root = statusFixture();
+  const stateRoot = statusFixture();
+  writeStatus(stateRoot, "openclaw-clawhub");
+  const gitPublishes: GitPublishOptions[] = [];
+  const warnings: string[] = [];
+  let fetchCalls = 0;
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+  const original = {
+    message: "chore: delete stale sweep status",
+    paths: ["results/sweep-status"],
+    rebaseStrategy: "apply-records" as const,
+  };
+
+  assert.equal(
+    await publishMainWithStateAppend(original, {
+      root,
+      env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+      fetchImpl: (async () => {
+        fetchCalls += 1;
+        return Response.json({ ok: true }, { status: 202 });
+      }) as typeof fetch,
+      publishGit: capturePublishes(gitPublishes),
+    }),
+    "committed",
+  );
+  assert.equal(fetchCalls, 0);
+  assert.deepEqual(gitPublishes, [original]);
+  assert.deepEqual(warnings, ["state-append shed/failed; falling back to git publish"]);
+});
+
 function statusFixture(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-main-"));
-  const target = path.join(root, statusPath);
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-  fs.writeFileSync(target, `${JSON.stringify(sweepStatus())}\n`);
+  writeStatus(root, "openclaw-openclaw");
   return root;
 }
 
-function sweepStatus(): Record<string, unknown> {
+function writeStatus(root: string, slug: string): void {
+  const target = path.join(root, `results/sweep-status/${slug}.json`);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, `${JSON.stringify(sweepStatus(slug))}\n`);
+}
+
+function sweepStatus(slug = "openclaw-openclaw"): Record<string, unknown> {
   return {
     schema_version: 1,
-    slug: "openclaw-openclaw",
+    slug,
     state: "Review in progress",
     updated_at: "2026-07-21T12:00:00.000Z",
   };
 }
 
-function appendEnv(): NodeJS.ProcessEnv {
+function appendEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     CLAWSWEEPER_STATE_APPEND_ENABLED: "1",
     QUEUE_URL: "https://queue.test",
     CLAWSWEEPER_WEBHOOK_SECRET: "publish-main-test-secret",
     GITHUB_RUN_ID: "1234",
     GITHUB_RUN_ATTEMPT: "2",
+    ...overrides,
   };
 }
 

--- a/test/repair/state-append-client.test.ts
+++ b/test/repair/state-append-client.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+
+import { postStateAppend } from "../../dist/repair/state-append-client.js";
+
+const webhookSecret = "state-append-test-secret";
+const records = [
+  {
+    kind: "sweep_status" as const,
+    key: "results/sweep-status/openclaw-openclaw.json",
+    payload: { slug: "openclaw-openclaw", updated_at: "2026-07-21T12:00:00.000Z" },
+    produced_at: "2026-07-21T12:00:00.000Z",
+  },
+];
+
+test("postStateAppend signs and posts the exact append body", async () => {
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    assert.equal(input.toString(), "https://queue.test/internal/state/append");
+    assert.equal(init?.method, "POST");
+    const body = String(init?.body ?? "");
+    assert.deepEqual(JSON.parse(body), { delivery_id: "delivery-1", records });
+    assert.equal(
+      new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"),
+      `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`,
+    );
+    return Response.json({ ok: true, appended: 1 }, { status: 202 });
+  }) as typeof fetch;
+
+  assert.deepEqual(
+    await postStateAppend({
+      queueUrl: "https://queue.test/",
+      webhookSecret,
+      deliveryId: "delivery-1",
+      records,
+      fetchImpl,
+    }),
+    { ok: true, shed: false },
+  );
+});
+
+test("postStateAppend reports a shed response without throwing", async () => {
+  const fetchImpl = (async () =>
+    Response.json({ ok: false, shed: true, reason: "capacity" }, { status: 429 })) as typeof fetch;
+
+  assert.deepEqual(
+    await postStateAppend({
+      queueUrl: "https://queue.test",
+      webhookSecret,
+      deliveryId: "delivery-shed",
+      records,
+      fetchImpl,
+    }),
+    { ok: false, shed: true },
+  );
+});
+
+test("postStateAppend preserves an explicit unsuccessful response as a fallback signal", async () => {
+  const fetchImpl = (async () => Response.json({ ok: false }, { status: 202 })) as typeof fetch;
+
+  assert.deepEqual(
+    await postStateAppend({
+      queueUrl: "https://queue.test",
+      webhookSecret,
+      deliveryId: "delivery-failed",
+      records,
+      fetchImpl,
+    }),
+    { ok: false, shed: false },
+  );
+});
+
+test("postStateAppend redacts the webhook secret from client errors", async () => {
+  const fetchImpl = (async () => {
+    throw new Error(`request leaked ${webhookSecret}`);
+  }) as typeof fetch;
+
+  await assert.rejects(
+    postStateAppend({
+      queueUrl: "https://queue.test",
+      webhookSecret,
+      deliveryId: "delivery-error",
+      records,
+      fetchImpl,
+    }),
+    (error: Error) => {
+      assert.match(error.message, /request leaked <redacted>/);
+      assert.doesNotMatch(error.message, new RegExp(webhookSecret));
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
WP-3a of #738. Sweep-status lane cut over from git pushes to DO state append, env-gated (CLAWSWEEPER_STATE_APPEND_ENABLED=1 on the seven sweep-status publishing steps only). Fail-open: shed/HTTP/client errors and unrepresentable entries (directory deletions) fall back to the unchanged git publisher with one log line. Delivery ids = run+attempt+content hash (idempotent). Comment-router and apply-proof lanes untouched.

Validation: 8/8 new tests; git-publish 59/59 locally runnable; build/lint/format green; autoreview caught the directory-deletion edge (fixed, follow-up commit), final commit-mode rerun clean.
