### PR TITLE
feat(repair): state-repo guardrails — janitor, size alarm, compaction cron (#738 SM-4)

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -10,6 +10,9 @@ on:
 
 permissions: {}
 
+env:
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+
 concurrency:
   # Exact-review completions share one pending slot. Each surviving run scans all
   # live claims, so GitHub may safely coalesce a burst without losing a terminal run.
@@ -158,9 +161,17 @@ jobs:
 
       - uses: actions/checkout@v7
 
+      - name: Create state token
+        id: state-token
+        continue-on-error: true
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
       - uses: ./.github/actions/setup-pnpm
         with:
-          build-script: build
+          build-script: build:all
 
       - name: Recover orphaned review placeholders
         env:
@@ -173,3 +184,17 @@ jobs:
           TARGET_BRANCH: main
           TARGET_REPO: openclaw/openclaw
         run: node dist/review-placeholder-recovery.js
+
+      - name: Clean scratch state branches and report repository size
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
+          STATE_BRANCH_MAX_AGE_HOURS: ${{ vars.STATE_BRANCH_MAX_AGE_HOURS || '24' }}
+          STATE_BRANCH_MAX_DELETIONS: ${{ vars.STATE_BRANCH_MAX_DELETIONS || '50' }}
+          STATE_BRANCH_RUN_REPOSITORY: openclaw/clawsweeper
+          STATE_REPOSITORY: openclaw/clawsweeper-state
+          STATE_REPO_SIZE_WARN_GB: ${{ vars.STATE_REPO_SIZE_WARN_GB || '5' }}
+        run: |
+          node dist/repair/state-branch-janitor.js
+          node dist/repair/state-repo-size.js

--- a/.github/workflows/state-compaction.yml
+++ b/.github/workflows/state-compaction.yml
@@ -71,7 +71,6 @@ jobs:
         if: ${{ steps.preflight.outputs.compact == 'true' }}
         env:
           BACKUP_REF: ${{ steps.backup.outputs.backup_ref }}
-          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
           EXPECTED_HEAD: ${{ steps.backup.outputs.expected_head }}
         run: |
           set -euo pipefail
@@ -90,8 +89,14 @@ jobs:
             origin "$new_head:refs/heads/main"
           remote_head="$(git -C "$state_dir" ls-remote --refs origin refs/heads/main | awk '{print $1}')"
           test "$remote_head" = "$new_head"
-          STATE_COMPACTION_BACKUP_REF="$BACKUP_REF" \
-            STATE_COMPACTION_EXPECTED_HEAD="$EXPECTED_HEAD" \
-            STATE_COMPACTION_NEW_HEAD="$new_head" \
-            node dist/repair/state-compaction.js cleanup-backup
+          git -C "$state_dir" push --atomic \
+            --force-with-lease="refs/heads/main:$new_head" \
+            --force-with-lease="refs/heads/$BACKUP_REF:$EXPECTED_HEAD" \
+            origin \
+            "$new_head:refs/heads/main" \
+            ":refs/heads/$BACKUP_REF"
+          verified_refs="$(git -C "$state_dir" ls-remote --refs \
+            origin refs/heads/main "refs/heads/$BACKUP_REF")"
+          test "$(printf '%s\n' "$verified_refs" | awk '$2 == "refs/heads/main" {print $1}')" = "$new_head"
+          test -z "$(printf '%s\n' "$verified_refs" | awk -v ref="refs/heads/$BACKUP_REF" '$2 == ref {print $1}')"
           echo "state compaction: replaced $EXPECTED_HEAD with orphan $new_head; transactional backup removed"

--- a/.github/workflows/state-compaction.yml
+++ b/.github/workflows/state-compaction.yml
@@ -71,6 +71,7 @@ jobs:
         if: ${{ steps.preflight.outputs.compact == 'true' }}
         env:
           BACKUP_REF: ${{ steps.backup.outputs.backup_ref }}
+          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
           EXPECTED_HEAD: ${{ steps.backup.outputs.expected_head }}
         run: |
           set -euo pipefail
@@ -89,4 +90,8 @@ jobs:
             origin "$new_head:refs/heads/main"
           remote_head="$(git -C "$state_dir" ls-remote --refs origin refs/heads/main | awk '{print $1}')"
           test "$remote_head" = "$new_head"
-          echo "state compaction: replaced $EXPECTED_HEAD with orphan $new_head; backup=$BACKUP_REF"
+          STATE_COMPACTION_BACKUP_REF="$BACKUP_REF" \
+            STATE_COMPACTION_EXPECTED_HEAD="$EXPECTED_HEAD" \
+            STATE_COMPACTION_NEW_HEAD="$new_head" \
+            node dist/repair/state-compaction.js cleanup-backup
+          echo "state compaction: replaced $EXPECTED_HEAD with orphan $new_head; transactional backup removed"

--- a/.github/workflows/state-compaction.yml
+++ b/.github/workflows/state-compaction.yml
@@ -84,13 +84,8 @@ jobs:
           message="chore: compact state history (backup: $BACKUP_REF)"
           new_head="$(printf '%s\n' "$message" | git -C "$state_dir" commit-tree "$tree")"
           test "$(git -C "$state_dir" rev-list --parents -n 1 "$new_head" | wc -w | tr -d ' ')" = "1"
-          git -C "$state_dir" push \
-            --force-with-lease="refs/heads/main:$EXPECTED_HEAD" \
-            origin "$new_head:refs/heads/main"
-          remote_head="$(git -C "$state_dir" ls-remote --refs origin refs/heads/main | awk '{print $1}')"
-          test "$remote_head" = "$new_head"
           git -C "$state_dir" push --atomic \
-            --force-with-lease="refs/heads/main:$new_head" \
+            --force-with-lease="refs/heads/main:$EXPECTED_HEAD" \
             --force-with-lease="refs/heads/$BACKUP_REF:$EXPECTED_HEAD" \
             origin \
             "$new_head:refs/heads/main" \

--- a/.github/workflows/state-compaction.yml
+++ b/.github/workflows/state-compaction.yml
@@ -1,0 +1,92 @@
+name: Compact state repository history
+
+on:
+  schedule:
+    - cron: "17 9 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+  STATE_REPOSITORY: openclaw/clawsweeper-state
+  STATE_REPO_SIZE_WARN_GB: ${{ vars.STATE_REPO_SIZE_WARN_GB || '5' }}
+
+concurrency:
+  group: clawsweeper-state-compaction
+  cancel-in-progress: false
+
+jobs:
+  compact:
+    name: Replace state main with a single-root commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Check whether compaction is needed
+        id: preflight
+        env:
+          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
+        run: node dist/repair/state-compaction.js preflight
+
+      - name: Shallow-clone state main
+        if: ${{ steps.preflight.outputs.compact == 'true' }}
+        uses: actions/checkout@v7
+        with:
+          repository: openclaw/clawsweeper-state
+          ref: main
+          path: clawsweeper-state
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+          sparse-checkout: .github
+
+      - name: Create and verify backup ref
+        if: ${{ steps.preflight.outputs.compact == 'true' }}
+        id: backup
+        env:
+          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
+        run: |
+          expected_head="$(git -C clawsweeper-state rev-parse HEAD)"
+          STATE_COMPACTION_EXPECTED_HEAD="$expected_head" \
+            node dist/repair/state-compaction.js prepare-backup
+
+      - name: Replace state main history
+        if: ${{ steps.preflight.outputs.compact == 'true' }}
+        env:
+          BACKUP_REF: ${{ steps.backup.outputs.backup_ref }}
+          EXPECTED_HEAD: ${{ steps.backup.outputs.expected_head }}
+        run: |
+          set -euo pipefail
+          state_dir="clawsweeper-state"
+          test -n "$BACKUP_REF"
+          test -n "$EXPECTED_HEAD"
+          test "$(git -C "$state_dir" rev-parse HEAD)" = "$EXPECTED_HEAD"
+          tree="$(git -C "$state_dir" rev-parse "$EXPECTED_HEAD^{tree}")"
+          git -C "$state_dir" config user.name "ClawSweeper"
+          git -C "$state_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          message="chore: compact state history (backup: $BACKUP_REF)"
+          new_head="$(printf '%s\n' "$message" | git -C "$state_dir" commit-tree "$tree")"
+          test "$(git -C "$state_dir" rev-list --parents -n 1 "$new_head" | wc -w | tr -d ' ')" = "1"
+          git -C "$state_dir" push \
+            --force-with-lease="refs/heads/main:$EXPECTED_HEAD" \
+            origin "$new_head:refs/heads/main"
+          remote_head="$(git -C "$state_dir" ls-remote --refs origin refs/heads/main | awk '{print $1}')"
+          test "$remote_head" = "$new_head"
+          echo "state compaction: replaced $EXPECTED_HEAD with orphan $new_head; backup=$BACKUP_REF"

--- a/src/repair/state-branch-janitor.ts
+++ b/src/repair/state-branch-janitor.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DEFAULT_STATE_REPOSITORY } from "./state-repo-size.js";
+
+export const STATE_BRANCH_PREFIX = "clawsweeper/immutable-ledger/";
+export const DEFAULT_STATE_BRANCH_MAX_AGE_HOURS = 24;
+export const DEFAULT_STATE_BRANCH_MAX_DELETIONS = 50;
+
+type GitReference = {
+  ref?: unknown;
+  object?: { sha?: unknown } | null;
+};
+
+export type StateBranchIdentity = {
+  branch: string;
+  runId: string;
+  runAttempt: number;
+};
+
+export type StateBranchJanitorSummary = {
+  scanned: number;
+  deleted: number;
+  kept: number;
+  errors: number;
+};
+
+export type StateBranchJanitorOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: Date;
+};
+
+function boundedPositiveInteger(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+}
+
+function boundedPositiveNumber(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+}
+
+function validRepository(value: string): boolean {
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value);
+}
+
+export function parseStateBranchIdentity(ref: string): StateBranchIdentity | null {
+  const match = new RegExp(
+    `^refs/heads/${STATE_BRANCH_PREFIX.replaceAll("/", "\\/")}(\\d+)-(\\d+)-(\\d+)-([0-9a-fA-F]{7,64})$`,
+  ).exec(ref);
+  if (!match) return null;
+  const runAttempt = Number(match[2]);
+  if (!Number.isSafeInteger(runAttempt) || runAttempt < 1) return null;
+  return {
+    branch: ref.slice("refs/heads/".length),
+    runId: match[1]!,
+    runAttempt,
+  };
+}
+
+function timestamp(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export async function runStateBranchJanitor(
+  options: StateBranchJanitorOptions = {},
+): Promise<StateBranchJanitorSummary> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? new Date();
+  const stateRepository = env.STATE_REPOSITORY ?? DEFAULT_STATE_REPOSITORY;
+  const sourceRepository = env.STATE_BRANCH_RUN_REPOSITORY ?? env.GITHUB_REPOSITORY ?? "";
+  const stateToken = env.CLAWSWEEPER_STATE_REPO_TOKEN ?? "";
+  const sourceToken = env.GH_TOKEN ?? env.GITHUB_TOKEN ?? "";
+  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  const maximumAgeHours = boundedPositiveNumber(
+    env.STATE_BRANCH_MAX_AGE_HOURS,
+    DEFAULT_STATE_BRANCH_MAX_AGE_HOURS,
+    24 * 365,
+  );
+  const maximumDeletions = boundedPositiveInteger(
+    env.STATE_BRANCH_MAX_DELETIONS,
+    DEFAULT_STATE_BRANCH_MAX_DELETIONS,
+    500,
+  );
+  let scanned = 0;
+  let deleted = 0;
+  let kept = 0;
+  let errors = 0;
+
+  const summary = (): StateBranchJanitorSummary => {
+    console.log(
+      `state-branch janitor: scanned=${scanned} deleted=${deleted} kept=${kept} errors=${errors}`,
+    );
+    return { scanned, deleted, kept, errors };
+  };
+
+  if (
+    !stateToken ||
+    !sourceToken ||
+    !validRepository(stateRepository) ||
+    !validRepository(sourceRepository)
+  ) {
+    errors += 1;
+    console.warn("state-branch janitor skipped: missing or invalid configuration");
+    return summary();
+  }
+
+  const request = async (path: string, token: string, init: RequestInit = {}): Promise<Response> =>
+    fetchImpl(`${apiUrl}${path}`, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+        ...init.headers,
+      },
+    });
+
+  const references: GitReference[] = [];
+  try {
+    const prefix = STATE_BRANCH_PREFIX.slice(0, -1);
+    const response = await request(
+      `/repos/${stateRepository}/git/matching-refs/heads/${prefix}`,
+      stateToken,
+    );
+    if (!response.ok) throw new Error(`GET matching refs returned ${response.status}`);
+    const matchingReferences = (await response.json()) as unknown;
+    if (!Array.isArray(matchingReferences)) {
+      throw new Error("matching refs response is not an array");
+    }
+    references.push(...(matchingReferences as GitReference[]));
+  } catch (error) {
+    errors += 1;
+    console.warn(
+      `state-branch janitor discovery skipped: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return summary();
+  }
+
+  scanned = references.length;
+  const maximumAgeMs = maximumAgeHours * 60 * 60 * 1_000;
+
+  for (const reference of references) {
+    if (deleted >= maximumDeletions) {
+      kept += 1;
+      continue;
+    }
+    const ref = typeof reference.ref === "string" ? reference.ref : "";
+    const identity = parseStateBranchIdentity(ref);
+    const commitSha = typeof reference.object?.sha === "string" ? reference.object.sha : "";
+    if (!identity || !/^[0-9a-fA-F]{40}$/.test(commitSha)) {
+      kept += 1;
+      continue;
+    }
+
+    let shouldDelete = false;
+    let runCreatedAt: number | null = null;
+    try {
+      const response = await request(
+        `/repos/${sourceRepository}/actions/runs/${identity.runId}`,
+        sourceToken,
+      );
+      if (response.ok) {
+        const run = (await response.json()) as {
+          id?: unknown;
+          status?: unknown;
+          created_at?: unknown;
+        };
+        if (String(run.id ?? "") !== identity.runId) throw new Error("workflow run id mismatch");
+        shouldDelete = run.status === "completed";
+        runCreatedAt = timestamp(run.created_at);
+      } else if (response.status !== 404) {
+        throw new Error(`GET workflow run returned ${response.status}`);
+      }
+    } catch (error) {
+      errors += 1;
+      console.warn(
+        `${identity.branch} workflow lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (!shouldDelete && runCreatedAt !== null) {
+      shouldDelete = now.getTime() - runCreatedAt >= maximumAgeMs;
+    }
+    if (!shouldDelete && runCreatedAt === null) {
+      try {
+        const response = await request(
+          `/repos/${stateRepository}/git/commits/${commitSha}`,
+          stateToken,
+        );
+        if (!response.ok) throw new Error(`GET branch commit returned ${response.status}`);
+        const commit = (await response.json()) as {
+          committer?: { date?: unknown } | null;
+          author?: { date?: unknown } | null;
+        };
+        const committedAt = timestamp(commit.committer?.date) ?? timestamp(commit.author?.date);
+        if (committedAt === null) throw new Error("branch commit has no valid timestamp");
+        shouldDelete = now.getTime() - committedAt >= maximumAgeMs;
+      } catch (error) {
+        errors += 1;
+        console.warn(
+          `${identity.branch} age lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    if (!shouldDelete) {
+      kept += 1;
+      continue;
+    }
+    try {
+      const response = await request(
+        `/repos/${stateRepository}/git/refs/heads/${identity.branch}`,
+        stateToken,
+        { method: "DELETE" },
+      );
+      if (!response.ok) throw new Error(`DELETE branch returned ${response.status}`);
+      deleted += 1;
+      console.log(`state-branch janitor: deleted ${identity.branch}`);
+    } catch (error) {
+      errors += 1;
+      kept += 1;
+      console.warn(
+        `${identity.branch} deletion failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+  return summary();
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  await runStateBranchJanitor().catch((error) => {
+    console.warn(
+      `state-branch janitor skipped after unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.log("state-branch janitor: scanned=0 deleted=0 kept=0 errors=1");
+  });
+}

--- a/src/repair/state-compaction.ts
+++ b/src/repair/state-compaction.ts
@@ -22,10 +22,6 @@ export type StateCompactionBackup = {
   expectedHead: string;
 };
 
-export type StateCompactionCleanup = StateCompactionBackup & {
-  newHead: string;
-};
-
 function writeOutput(env: NodeJS.ProcessEnv, values: Record<string, string>): void {
   if (!env.GITHUB_OUTPUT) return;
   appendFileSync(
@@ -138,69 +134,12 @@ export async function createStateCompactionBackup(
   return { backupRef, expectedHead };
 }
 
-export async function cleanupStateCompactionBackup(
-  options: StateCompactionOptions = {},
-): Promise<StateCompactionCleanup> {
-  const env = options.env ?? process.env;
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const repository = env.STATE_REPOSITORY ?? "openclaw/clawsweeper-state";
-  const branch = env.STATE_COMPACTION_BRANCH ?? "main";
-  const backupRef = env.STATE_COMPACTION_BACKUP_REF ?? "";
-  const expectedHead = env.STATE_COMPACTION_EXPECTED_HEAD ?? "";
-  const newHead = env.STATE_COMPACTION_NEW_HEAD ?? "";
-  const token = env.CLAWSWEEPER_STATE_REPO_TOKEN ?? "";
-  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
-  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
-    throw new Error("state repository is invalid");
-  }
-  if (!/^[A-Za-z0-9_./-]+$/.test(branch)) throw new Error("compaction branch is invalid");
-  if (!/^backup\/pre-compact-\d{4}-\d{2}-\d{2}$/.test(backupRef)) {
-    throw new Error("backup ref is invalid");
-  }
-  if (!/^[0-9a-fA-F]{40}$/.test(expectedHead)) throw new Error("expected head is invalid");
-  if (!/^[0-9a-fA-F]{40}$/.test(newHead)) throw new Error("new head is invalid");
-  if (!token) throw new Error("state repository token is missing");
-
-  const request = async (path: string, init: RequestInit = {}): Promise<Response> =>
-    fetchImpl(`${apiUrl}${path}`, {
-      ...init,
-      headers: {
-        accept: "application/vnd.github+json",
-        authorization: `Bearer ${token}`,
-        "x-github-api-version": "2022-11-28",
-        ...init.headers,
-      },
-    });
-
-  const mainResponse = await request(`/repos/${repository}/git/ref/heads/${branch}`);
-  if (!mainResponse.ok) throw new Error(`GET compacted head returned ${mainResponse.status}`);
-  const main = (await mainResponse.json()) as { object?: { sha?: unknown } | null };
-  if (main.object?.sha !== newHead) {
-    throw new Error("compacted head verification failed before backup cleanup");
-  }
-
-  const backupResponse = await request(`/repos/${repository}/git/ref/heads/${backupRef}`);
-  if (!backupResponse.ok) throw new Error(`GET backup ref returned ${backupResponse.status}`);
-  const backup = (await backupResponse.json()) as { object?: { sha?: unknown } | null };
-  if (backup.object?.sha !== expectedHead) {
-    throw new Error("backup ref moved before cleanup");
-  }
-
-  const deleteResponse = await request(`/repos/${repository}/git/refs/heads/${backupRef}`, {
-    method: "DELETE",
-  });
-  if (!deleteResponse.ok) throw new Error(`DELETE backup ref returned ${deleteResponse.status}`);
-  console.log(`state compaction: removed transactional backup ${backupRef}`);
-  return { backupRef, expectedHead, newHead };
-}
-
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
   const command = process.argv[2] ?? "preflight";
   try {
     if (command === "preflight") await runStateCompactionPreflight();
     else if (command === "prepare-backup") await createStateCompactionBackup();
-    else if (command === "cleanup-backup") await cleanupStateCompactionBackup();
     else throw new Error(`unknown state-compaction command: ${command}`);
   } catch (error) {
     console.error(

--- a/src/repair/state-compaction.ts
+++ b/src/repair/state-compaction.ts
@@ -22,6 +22,10 @@ export type StateCompactionBackup = {
   expectedHead: string;
 };
 
+export type StateCompactionCleanup = StateCompactionBackup & {
+  newHead: string;
+};
+
 function writeOutput(env: NodeJS.ProcessEnv, values: Record<string, string>): void {
   if (!env.GITHUB_OUTPUT) return;
   appendFileSync(
@@ -98,8 +102,23 @@ export async function createStateCompactionBackup(
     throw new Error(`state head moved before backup creation: expected ${expectedHead}`);
   }
 
-  const date = now.toISOString().slice(0, 10);
-  const backupRef = `backup/pre-compact-${date}`;
+  const backupRef = `backup/pre-compact-${now.toISOString().slice(0, 10)}`;
+  const existingResponse = await request(`/repos/${repository}/git/ref/heads/${backupRef}`);
+  if (existingResponse.ok) {
+    const existing = (await existingResponse.json()) as {
+      ref?: unknown;
+      object?: { sha?: unknown } | null;
+    };
+    if (existing.ref !== `refs/heads/${backupRef}` || existing.object?.sha !== expectedHead) {
+      throw new Error("existing backup ref does not match the expected head");
+    }
+    console.log(`state compaction: reusing ${backupRef} at ${expectedHead}`);
+    writeOutput(env, { backup_ref: backupRef, expected_head: expectedHead });
+    return { backupRef, expectedHead };
+  }
+  if (existingResponse.status !== 404) {
+    throw new Error(`GET backup ref returned ${existingResponse.status}`);
+  }
   const backupResponse = await request(`/repos/${repository}/git/refs`, {
     method: "POST",
     body: JSON.stringify({ ref: `refs/heads/${backupRef}`, sha: expectedHead }),
@@ -119,12 +138,69 @@ export async function createStateCompactionBackup(
   return { backupRef, expectedHead };
 }
 
+export async function cleanupStateCompactionBackup(
+  options: StateCompactionOptions = {},
+): Promise<StateCompactionCleanup> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const repository = env.STATE_REPOSITORY ?? "openclaw/clawsweeper-state";
+  const branch = env.STATE_COMPACTION_BRANCH ?? "main";
+  const backupRef = env.STATE_COMPACTION_BACKUP_REF ?? "";
+  const expectedHead = env.STATE_COMPACTION_EXPECTED_HEAD ?? "";
+  const newHead = env.STATE_COMPACTION_NEW_HEAD ?? "";
+  const token = env.CLAWSWEEPER_STATE_REPO_TOKEN ?? "";
+  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("state repository is invalid");
+  }
+  if (!/^[A-Za-z0-9_./-]+$/.test(branch)) throw new Error("compaction branch is invalid");
+  if (!/^backup\/pre-compact-\d{4}-\d{2}-\d{2}$/.test(backupRef)) {
+    throw new Error("backup ref is invalid");
+  }
+  if (!/^[0-9a-fA-F]{40}$/.test(expectedHead)) throw new Error("expected head is invalid");
+  if (!/^[0-9a-fA-F]{40}$/.test(newHead)) throw new Error("new head is invalid");
+  if (!token) throw new Error("state repository token is missing");
+
+  const request = async (path: string, init: RequestInit = {}): Promise<Response> =>
+    fetchImpl(`${apiUrl}${path}`, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+        ...init.headers,
+      },
+    });
+
+  const mainResponse = await request(`/repos/${repository}/git/ref/heads/${branch}`);
+  if (!mainResponse.ok) throw new Error(`GET compacted head returned ${mainResponse.status}`);
+  const main = (await mainResponse.json()) as { object?: { sha?: unknown } | null };
+  if (main.object?.sha !== newHead) {
+    throw new Error("compacted head verification failed before backup cleanup");
+  }
+
+  const backupResponse = await request(`/repos/${repository}/git/ref/heads/${backupRef}`);
+  if (!backupResponse.ok) throw new Error(`GET backup ref returned ${backupResponse.status}`);
+  const backup = (await backupResponse.json()) as { object?: { sha?: unknown } | null };
+  if (backup.object?.sha !== expectedHead) {
+    throw new Error("backup ref moved before cleanup");
+  }
+
+  const deleteResponse = await request(`/repos/${repository}/git/refs/heads/${backupRef}`, {
+    method: "DELETE",
+  });
+  if (!deleteResponse.ok) throw new Error(`DELETE backup ref returned ${deleteResponse.status}`);
+  console.log(`state compaction: removed transactional backup ${backupRef}`);
+  return { backupRef, expectedHead, newHead };
+}
+
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
   const command = process.argv[2] ?? "preflight";
   try {
     if (command === "preflight") await runStateCompactionPreflight();
     else if (command === "prepare-backup") await createStateCompactionBackup();
+    else if (command === "cleanup-backup") await cleanupStateCompactionBackup();
     else throw new Error(`unknown state-compaction command: ${command}`);
   } catch (error) {
     console.error(

--- a/src/repair/state-compaction.ts
+++ b/src/repair/state-compaction.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { formatStateRepoSizeGb, inspectStateRepoSize } from "./state-repo-size.js";
+
+export type StateCompactionOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: Date;
+};
+
+export type StateCompactionPreflight = {
+  compact: boolean;
+  sizeGb: number;
+  thresholdGb: number;
+};
+
+export type StateCompactionBackup = {
+  backupRef: string;
+  expectedHead: string;
+};
+
+function writeOutput(env: NodeJS.ProcessEnv, values: Record<string, string>): void {
+  if (!env.GITHUB_OUTPUT) return;
+  appendFileSync(
+    env.GITHUB_OUTPUT,
+    Object.entries(values)
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join(""),
+  );
+}
+
+export async function runStateCompactionPreflight(
+  options: StateCompactionOptions = {},
+): Promise<StateCompactionPreflight> {
+  const env = options.env ?? process.env;
+  const size = await inspectStateRepoSize({
+    env,
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+  });
+  const compact = size.aboveThreshold;
+  const formattedSize = formatStateRepoSizeGb(size.sizeGb);
+  console.log(`state-repo size: ${formattedSize}GB`);
+  if (compact) {
+    console.log(
+      `state compaction: eligible above ${size.thresholdGb}GB threshold (${formattedSize}GB)`,
+    );
+  } else {
+    console.log(
+      `state compaction: skipped at ${formattedSize}GB (threshold ${size.thresholdGb}GB)`,
+    );
+  }
+  writeOutput(env, {
+    compact: String(compact),
+    size_gb: formattedSize,
+    threshold_gb: String(size.thresholdGb),
+  });
+  return { compact, sizeGb: size.sizeGb, thresholdGb: size.thresholdGb };
+}
+
+export async function createStateCompactionBackup(
+  options: StateCompactionOptions = {},
+): Promise<StateCompactionBackup> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? new Date();
+  const repository = env.STATE_REPOSITORY ?? "openclaw/clawsweeper-state";
+  const branch = env.STATE_COMPACTION_BRANCH ?? "main";
+  const expectedHead = env.STATE_COMPACTION_EXPECTED_HEAD ?? "";
+  const token = env.CLAWSWEEPER_STATE_REPO_TOKEN ?? "";
+  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("state repository is invalid");
+  }
+  if (!/^[A-Za-z0-9_./-]+$/.test(branch)) throw new Error("compaction branch is invalid");
+  if (!/^[0-9a-fA-F]{40}$/.test(expectedHead)) throw new Error("expected head is invalid");
+  if (!token) throw new Error("state repository token is missing");
+
+  const request = async (path: string, init: RequestInit = {}): Promise<Response> =>
+    fetchImpl(`${apiUrl}${path}`, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-github-api-version": "2022-11-28",
+        ...init.headers,
+      },
+    });
+
+  const headResponse = await request(`/repos/${repository}/git/ref/heads/${branch}`);
+  if (!headResponse.ok) throw new Error(`GET compaction head returned ${headResponse.status}`);
+  const head = (await headResponse.json()) as { object?: { sha?: unknown } | null };
+  const currentHead = typeof head.object?.sha === "string" ? head.object.sha : "";
+  if (currentHead !== expectedHead) {
+    throw new Error(`state head moved before backup creation: expected ${expectedHead}`);
+  }
+
+  const date = now.toISOString().slice(0, 10);
+  const backupRef = `backup/pre-compact-${date}`;
+  const backupResponse = await request(`/repos/${repository}/git/refs`, {
+    method: "POST",
+    body: JSON.stringify({ ref: `refs/heads/${backupRef}`, sha: expectedHead }),
+  });
+  if (!backupResponse.ok) {
+    throw new Error(`POST backup ref returned ${backupResponse.status}`);
+  }
+  const backup = (await backupResponse.json()) as {
+    ref?: unknown;
+    object?: { sha?: unknown } | null;
+  };
+  if (backup.ref !== `refs/heads/${backupRef}` || backup.object?.sha !== expectedHead) {
+    throw new Error("backup ref response did not confirm the expected head");
+  }
+  console.log(`state compaction: created ${backupRef} at ${expectedHead}`);
+  writeOutput(env, { backup_ref: backupRef, expected_head: expectedHead });
+  return { backupRef, expectedHead };
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  const command = process.argv[2] ?? "preflight";
+  try {
+    if (command === "preflight") await runStateCompactionPreflight();
+    else if (command === "prepare-backup") await createStateCompactionBackup();
+    else throw new Error(`unknown state-compaction command: ${command}`);
+  } catch (error) {
+    console.error(
+      `state compaction failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/src/repair/state-repo-size.ts
+++ b/src/repair/state-repo-size.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_STATE_REPOSITORY = "openclaw/clawsweeper-state";
+export const DEFAULT_STATE_REPO_SIZE_WARN_GB = 5;
+
+export type StateRepoSize = {
+  repository: string;
+  sizeKb: number;
+  sizeGb: number;
+  thresholdGb: number;
+  aboveThreshold: boolean;
+};
+
+export type StateRepoSizeOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+};
+
+function positiveNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= 1_024 ? parsed : fallback;
+}
+
+function stateRepository(env: NodeJS.ProcessEnv): string {
+  const repository = env.STATE_REPOSITORY ?? DEFAULT_STATE_REPOSITORY;
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("state repository is invalid");
+  }
+  return repository;
+}
+
+function stateToken(env: NodeJS.ProcessEnv): string {
+  const token = env.CLAWSWEEPER_STATE_REPO_TOKEN ?? "";
+  if (!token) throw new Error("state repository token is missing");
+  return token;
+}
+
+export function formatStateRepoSizeGb(sizeGb: number): string {
+  return sizeGb.toFixed(2);
+}
+
+export async function inspectStateRepoSize(
+  options: StateRepoSizeOptions = {},
+): Promise<StateRepoSize> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const repository = stateRepository(env);
+  const token = stateToken(env);
+  const thresholdGb = positiveNumber(env.STATE_REPO_SIZE_WARN_GB, DEFAULT_STATE_REPO_SIZE_WARN_GB);
+  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  const response = await fetchImpl(`${apiUrl}/repos/${repository}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (!response.ok) throw new Error(`GET repository returned ${response.status}`);
+  const payload = (await response.json()) as { size?: unknown };
+  const sizeKb = payload.size;
+  if (typeof sizeKb !== "number" || !Number.isFinite(sizeKb) || sizeKb < 0) {
+    throw new Error("repository response has an invalid size");
+  }
+  const sizeGb = sizeKb / 1024 / 1024;
+  return {
+    repository,
+    sizeKb,
+    sizeGb,
+    thresholdGb,
+    aboveThreshold: sizeGb > thresholdGb,
+  };
+}
+
+export async function runStateRepoSizeCheck(options: StateRepoSizeOptions = {}): Promise<{
+  size: StateRepoSize | null;
+  errors: number;
+}> {
+  try {
+    const size = await inspectStateRepoSize(options);
+    const formatted = formatStateRepoSizeGb(size.sizeGb);
+    console.log(`state-repo size: ${formatted}GB`);
+    if (size.aboveThreshold) {
+      console.warn(
+        `::warning::state-repo size: ${formatted}GB exceeds ${size.thresholdGb}GB threshold`,
+      );
+    }
+    return { size, errors: 0 };
+  } catch (error) {
+    console.log("state-repo size: unavailable");
+    console.warn(
+      `state-repo size check skipped: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { size: null, errors: 1 };
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  await runStateRepoSizeCheck();
+}

--- a/test/repair/state-compaction.test.ts
+++ b/test/repair/state-compaction.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  createStateCompactionBackup,
+  runStateCompactionPreflight,
+} from "../../dist/repair/state-compaction.js";
+
+const token = "test-token-state";
+const expectedHead = "a".repeat(40);
+
+function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_STATE_REPO_TOKEN: token,
+    GITHUB_API_URL: "https://api.github.test",
+    STATE_REPOSITORY: "openclaw/clawsweeper-state",
+    STATE_REPO_SIZE_WARN_GB: "5",
+    ...overrides,
+  };
+}
+
+test("compaction preflight skips below the repository warning threshold", async (t) => {
+  const logged: string[] = [];
+  t.mock.method(console, "log", (...parts: unknown[]) => logged.push(parts.join(" ")));
+  const result = await runStateCompactionPreflight({
+    env: env(),
+    fetchImpl: (async () => Response.json({ size: 4 * 1024 * 1024 })) as typeof fetch,
+  });
+  assert.deepEqual(result, { compact: false, sizeGb: 4, thresholdGb: 5 });
+  assert.ok(logged.includes("state compaction: skipped at 4.00GB (threshold 5GB)"));
+});
+
+test("compaction preflight proceeds only above the repository warning threshold", async () => {
+  const result = await runStateCompactionPreflight({
+    env: env(),
+    fetchImpl: (async () => Response.json({ size: 5.25 * 1024 * 1024 })) as typeof fetch,
+  });
+  assert.deepEqual(result, { compact: true, sizeGb: 5.25, thresholdGb: 5 });
+});
+
+test("backup creation verifies live main and creates a dated ref at the exact head", async () => {
+  const requests: Array<{ method: string; path: string; body: unknown }> = [];
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    requests.push({ method, path: url.pathname, body });
+    if (method === "GET") return Response.json({ object: { sha: expectedHead } });
+    return Response.json({
+      ref: "refs/heads/backup/pre-compact-2026-07-21",
+      object: { sha: expectedHead },
+    });
+  };
+
+  const result = await createStateCompactionBackup({
+    env: env({ STATE_COMPACTION_EXPECTED_HEAD: expectedHead }),
+    fetchImpl: mockFetch as typeof fetch,
+    now: new Date("2026-07-21T12:00:00.000Z"),
+  });
+
+  assert.deepEqual(result, {
+    backupRef: "backup/pre-compact-2026-07-21",
+    expectedHead,
+  });
+  assert.deepEqual(requests, [
+    {
+      method: "GET",
+      path: "/repos/openclaw/clawsweeper-state/git/ref/heads/main",
+      body: null,
+    },
+    {
+      method: "POST",
+      path: "/repos/openclaw/clawsweeper-state/git/refs",
+      body: { ref: "refs/heads/backup/pre-compact-2026-07-21", sha: expectedHead },
+    },
+  ]);
+});
+
+test("backup creation refuses a moved main before creating a ref", async () => {
+  let requests = 0;
+  await assert.rejects(
+    createStateCompactionBackup({
+      env: env({ STATE_COMPACTION_EXPECTED_HEAD: expectedHead }),
+      fetchImpl: (async () => {
+        requests += 1;
+        return Response.json({ object: { sha: "b".repeat(40) } });
+      }) as typeof fetch,
+    }),
+    /state head moved before backup creation/,
+  );
+  assert.equal(requests, 1);
+});
+
+test("backup creation refuses to continue when GitHub rejects the backup ref", async () => {
+  let requests = 0;
+  await assert.rejects(
+    createStateCompactionBackup({
+      env: env({ STATE_COMPACTION_EXPECTED_HEAD: expectedHead }),
+      fetchImpl: (async () => {
+        requests += 1;
+        if (requests === 1) return Response.json({ object: { sha: expectedHead } });
+        return Response.json({ message: "already exists" }, { status: 422 });
+      }) as typeof fetch,
+    }),
+    /POST backup ref returned 422/,
+  );
+  assert.equal(requests, 2);
+});
+
+test("compaction workflow preserves backup and lease safety", () => {
+  const workflow = readFileSync(".github/workflows/state-compaction.yml", "utf8");
+  assert.match(workflow, /cron: "17 9 1 \* \*"/);
+  assert.match(workflow, /node dist\/repair\/state-compaction\.js preflight/);
+  assert.match(workflow, /node dist\/repair\/state-compaction\.js prepare-backup/);
+  assert.match(workflow, /git -C "\$state_dir" commit-tree "\$tree"/);
+  assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$EXPECTED_HEAD"/);
+  assert.match(workflow, /test "\$remote_head" = "\$new_head"/);
+});

--- a/test/repair/state-compaction.test.ts
+++ b/test/repair/state-compaction.test.ts
@@ -3,7 +3,6 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
-  cleanupStateCompactionBackup,
   createStateCompactionBackup,
   runStateCompactionPreflight,
 } from "../../dist/repair/state-compaction.js";
@@ -140,50 +139,16 @@ test("backup creation refuses to continue when GitHub rejects the backup ref", a
   assert.equal(requests, 3);
 });
 
-test("transactional backup cleanup verifies both refs before deleting history", async () => {
-  const newHead = "b".repeat(40);
-  const requests: Array<{ method: string; path: string }> = [];
-  const result = await cleanupStateCompactionBackup({
-    env: env({
-      STATE_COMPACTION_BACKUP_REF: "backup/pre-compact-2026-07-21",
-      STATE_COMPACTION_EXPECTED_HEAD: expectedHead,
-      STATE_COMPACTION_NEW_HEAD: newHead,
-    }),
-    fetchImpl: (async (input, init) => {
-      const url = new URL(input instanceof Request ? input.url : input.toString());
-      requests.push({ method: init?.method ?? "GET", path: url.pathname });
-      if (init?.method === "DELETE") return new Response(null, { status: 204 });
-      if (url.pathname.endsWith("/git/ref/heads/main")) {
-        return Response.json({ object: { sha: newHead } });
-      }
-      return Response.json({ object: { sha: expectedHead } });
-    }) as typeof fetch,
-  });
-  assert.deepEqual(result, {
-    backupRef: "backup/pre-compact-2026-07-21",
-    expectedHead,
-    newHead,
-  });
-  assert.deepEqual(requests, [
-    { method: "GET", path: "/repos/openclaw/clawsweeper-state/git/ref/heads/main" },
-    {
-      method: "GET",
-      path: "/repos/openclaw/clawsweeper-state/git/ref/heads/backup/pre-compact-2026-07-21",
-    },
-    {
-      method: "DELETE",
-      path: "/repos/openclaw/clawsweeper-state/git/refs/heads/backup/pre-compact-2026-07-21",
-    },
-  ]);
-});
-
 test("compaction workflow preserves backup and lease safety", () => {
   const workflow = readFileSync(".github/workflows/state-compaction.yml", "utf8");
   assert.match(workflow, /cron: "17 9 1 \* \*"/);
   assert.match(workflow, /node dist\/repair\/state-compaction\.js preflight/);
   assert.match(workflow, /node dist\/repair\/state-compaction\.js prepare-backup/);
-  assert.match(workflow, /node dist\/repair\/state-compaction\.js cleanup-backup/);
   assert.match(workflow, /git -C "\$state_dir" commit-tree "\$tree"/);
   assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$EXPECTED_HEAD"/);
+  assert.match(workflow, /git -C "\$state_dir" push --atomic/);
+  assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$new_head"/);
+  assert.match(workflow, /--force-with-lease="refs\/heads\/\$BACKUP_REF:\$EXPECTED_HEAD"/);
+  assert.match(workflow, /":refs\/heads\/\$BACKUP_REF"/);
   assert.match(workflow, /test "\$remote_head" = "\$new_head"/);
 });

--- a/test/repair/state-compaction.test.ts
+++ b/test/repair/state-compaction.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  cleanupStateCompactionBackup,
   createStateCompactionBackup,
   runStateCompactionPreflight,
 } from "../../dist/repair/state-compaction.js";
@@ -49,7 +50,10 @@ test("backup creation verifies live main and creates a dated ref at the exact he
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : null;
     requests.push({ method, path: url.pathname, body });
-    if (method === "GET") return Response.json({ object: { sha: expectedHead } });
+    if (url.pathname.endsWith("/git/ref/heads/main")) {
+      return Response.json({ object: { sha: expectedHead } });
+    }
+    if (method === "GET") return new Response(null, { status: 404 });
     return Response.json({
       ref: "refs/heads/backup/pre-compact-2026-07-21",
       object: { sha: expectedHead },
@@ -70,6 +74,11 @@ test("backup creation verifies live main and creates a dated ref at the exact he
     {
       method: "GET",
       path: "/repos/openclaw/clawsweeper-state/git/ref/heads/main",
+      body: null,
+    },
+    {
+      method: "GET",
+      path: "/repos/openclaw/clawsweeper-state/git/ref/heads/backup/pre-compact-2026-07-21",
       body: null,
     },
     {
@@ -95,6 +104,25 @@ test("backup creation refuses a moved main before creating a ref", async () => {
   assert.equal(requests, 1);
 });
 
+test("backup creation reuses an exact same-day ref", async () => {
+  let requests = 0;
+  const result = await createStateCompactionBackup({
+    env: env({ STATE_COMPACTION_EXPECTED_HEAD: expectedHead }),
+    fetchImpl: (async (_input, init) => {
+      requests += 1;
+      assert.equal(init?.method, undefined);
+      if (requests === 1) return Response.json({ object: { sha: expectedHead } });
+      return Response.json({
+        ref: "refs/heads/backup/pre-compact-2026-07-21",
+        object: { sha: expectedHead },
+      });
+    }) as typeof fetch,
+    now: new Date("2026-07-21T12:00:00.000Z"),
+  });
+  assert.equal(result.backupRef, "backup/pre-compact-2026-07-21");
+  assert.equal(requests, 2);
+});
+
 test("backup creation refuses to continue when GitHub rejects the backup ref", async () => {
   let requests = 0;
   await assert.rejects(
@@ -103,12 +131,50 @@ test("backup creation refuses to continue when GitHub rejects the backup ref", a
       fetchImpl: (async () => {
         requests += 1;
         if (requests === 1) return Response.json({ object: { sha: expectedHead } });
-        return Response.json({ message: "already exists" }, { status: 422 });
+        if (requests === 2) return new Response(null, { status: 404 });
+        return Response.json({ message: "rejected" }, { status: 422 });
       }) as typeof fetch,
     }),
     /POST backup ref returned 422/,
   );
-  assert.equal(requests, 2);
+  assert.equal(requests, 3);
+});
+
+test("transactional backup cleanup verifies both refs before deleting history", async () => {
+  const newHead = "b".repeat(40);
+  const requests: Array<{ method: string; path: string }> = [];
+  const result = await cleanupStateCompactionBackup({
+    env: env({
+      STATE_COMPACTION_BACKUP_REF: "backup/pre-compact-2026-07-21",
+      STATE_COMPACTION_EXPECTED_HEAD: expectedHead,
+      STATE_COMPACTION_NEW_HEAD: newHead,
+    }),
+    fetchImpl: (async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      requests.push({ method: init?.method ?? "GET", path: url.pathname });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      if (url.pathname.endsWith("/git/ref/heads/main")) {
+        return Response.json({ object: { sha: newHead } });
+      }
+      return Response.json({ object: { sha: expectedHead } });
+    }) as typeof fetch,
+  });
+  assert.deepEqual(result, {
+    backupRef: "backup/pre-compact-2026-07-21",
+    expectedHead,
+    newHead,
+  });
+  assert.deepEqual(requests, [
+    { method: "GET", path: "/repos/openclaw/clawsweeper-state/git/ref/heads/main" },
+    {
+      method: "GET",
+      path: "/repos/openclaw/clawsweeper-state/git/ref/heads/backup/pre-compact-2026-07-21",
+    },
+    {
+      method: "DELETE",
+      path: "/repos/openclaw/clawsweeper-state/git/refs/heads/backup/pre-compact-2026-07-21",
+    },
+  ]);
 });
 
 test("compaction workflow preserves backup and lease safety", () => {
@@ -116,6 +182,7 @@ test("compaction workflow preserves backup and lease safety", () => {
   assert.match(workflow, /cron: "17 9 1 \* \*"/);
   assert.match(workflow, /node dist\/repair\/state-compaction\.js preflight/);
   assert.match(workflow, /node dist\/repair\/state-compaction\.js prepare-backup/);
+  assert.match(workflow, /node dist\/repair\/state-compaction\.js cleanup-backup/);
   assert.match(workflow, /git -C "\$state_dir" commit-tree "\$tree"/);
   assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$EXPECTED_HEAD"/);
   assert.match(workflow, /test "\$remote_head" = "\$new_head"/);

--- a/test/repair/state-compaction.test.ts
+++ b/test/repair/state-compaction.test.ts
@@ -150,5 +150,9 @@ test("compaction workflow preserves backup and lease safety", () => {
   assert.match(workflow, /--force-with-lease="refs\/heads\/\$BACKUP_REF:\$EXPECTED_HEAD"/);
   assert.match(workflow, /":refs\/heads\/\$BACKUP_REF"/);
   assert.equal(workflow.match(/git -C "\$state_dir" push/g)?.length, 1);
-  assert.match(workflow, /refs\/heads\/main" \{print \$1\}.*= "\$new_head"/);
+  assert.ok(
+    workflow.includes(
+      `test "$(printf '%s\\n' "$verified_refs" | awk '$2 == "refs/heads/main" {print $1}')" = "$new_head"`,
+    ),
+  );
 });

--- a/test/repair/state-compaction.test.ts
+++ b/test/repair/state-compaction.test.ts
@@ -145,10 +145,10 @@ test("compaction workflow preserves backup and lease safety", () => {
   assert.match(workflow, /node dist\/repair\/state-compaction\.js preflight/);
   assert.match(workflow, /node dist\/repair\/state-compaction\.js prepare-backup/);
   assert.match(workflow, /git -C "\$state_dir" commit-tree "\$tree"/);
-  assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$EXPECTED_HEAD"/);
   assert.match(workflow, /git -C "\$state_dir" push --atomic/);
-  assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$new_head"/);
+  assert.match(workflow, /--force-with-lease="refs\/heads\/main:\$EXPECTED_HEAD"/);
   assert.match(workflow, /--force-with-lease="refs\/heads\/\$BACKUP_REF:\$EXPECTED_HEAD"/);
   assert.match(workflow, /":refs\/heads\/\$BACKUP_REF"/);
-  assert.match(workflow, /test "\$remote_head" = "\$new_head"/);
+  assert.equal(workflow.match(/git -C "\$state_dir" push/g)?.length, 1);
+  assert.match(workflow, /refs\/heads\/main" \{print \$1\}.*= "\$new_head"/);
 });

--- a/test/repair/state-repo-guardrails.test.ts
+++ b/test/repair/state-repo-guardrails.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseStateBranchIdentity,
+  runStateBranchJanitor,
+} from "../../dist/repair/state-branch-janitor.js";
+import { runStateRepoSizeCheck } from "../../dist/repair/state-repo-size.js";
+
+const now = new Date("2026-07-21T12:00:00.000Z");
+const stateToken = "test-token-state";
+const sourceToken = "test-token-source";
+
+function branch(runId: string, attempt = 1, suffix = "abcdef123456") {
+  return {
+    ref: `refs/heads/clawsweeper/immutable-ledger/${runId}-${attempt}-42-${suffix}`,
+    object: { sha: runId.padStart(40, "a") },
+  };
+}
+
+function janitorEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_STATE_REPO_TOKEN: stateToken,
+    GH_TOKEN: sourceToken,
+    GITHUB_API_URL: "https://api.github.test",
+    STATE_BRANCH_RUN_REPOSITORY: "openclaw/clawsweeper",
+    STATE_REPOSITORY: "openclaw/clawsweeper-state",
+    ...overrides,
+  };
+}
+
+test("scratch branch identity accepts only the immutable-ledger run tuple", () => {
+  assert.deepEqual(
+    parseStateBranchIdentity("refs/heads/clawsweeper/immutable-ledger/12345-2-99-abcdef123456"),
+    {
+      branch: "clawsweeper/immutable-ledger/12345-2-99-abcdef123456",
+      runId: "12345",
+      runAttempt: 2,
+    },
+  );
+  assert.equal(parseStateBranchIdentity("refs/heads/clawsweeper/immutable-ledger/not-a-run"), null);
+  assert.equal(parseStateBranchIdentity("refs/heads/main"), null);
+});
+
+test("janitor deletes completed or old runs, respects its cap, and keeps recent runs", async (t) => {
+  const deleted: string[] = [];
+  const logged: string[] = [];
+  t.mock.method(console, "log", (...parts: unknown[]) => logged.push(parts.join(" ")));
+  const references = [
+    branch("100"),
+    branch("200"),
+    branch("300"),
+    branch("400"),
+    { ref: "refs/heads/clawsweeper/immutable-ledger/unparseable", object: { sha: "f".repeat(40) } },
+  ];
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const authorization = new Headers(init?.headers).get("authorization");
+    if (url.pathname.includes("/git/matching-refs/")) {
+      assert.equal(authorization, `Bearer ${stateToken}`);
+      assert.equal(
+        url.pathname,
+        "/repos/openclaw/clawsweeper-state/git/matching-refs/heads/clawsweeper/immutable-ledger",
+      );
+      return Response.json(references);
+    }
+    const runMatch = url.pathname.match(/\/actions\/runs\/(\d+)$/);
+    if (runMatch) {
+      assert.equal(authorization, `Bearer ${sourceToken}`);
+      const runId = runMatch[1]!;
+      const created_at = runId === "200" ? "2026-07-21T11:00:00.000Z" : "2026-07-19T11:00:00.000Z";
+      return Response.json({
+        id: Number(runId),
+        status: runId === "100" || runId === "400" ? "completed" : "in_progress",
+        created_at,
+      });
+    }
+    if (init?.method === "DELETE") {
+      assert.equal(authorization, `Bearer ${stateToken}`);
+      deleted.push(url.pathname);
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const summary = await runStateBranchJanitor({
+    env: janitorEnv({
+      STATE_BRANCH_MAX_AGE_HOURS: "24",
+      STATE_BRANCH_MAX_DELETIONS: "2",
+    }),
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, { scanned: 5, deleted: 2, kept: 3, errors: 0 });
+  assert.deepEqual(deleted, [
+    "/repos/openclaw/clawsweeper-state/git/refs/heads/clawsweeper/immutable-ledger/100-1-42-abcdef123456",
+    "/repos/openclaw/clawsweeper-state/git/refs/heads/clawsweeper/immutable-ledger/300-1-42-abcdef123456",
+  ]);
+  assert.ok(logged.includes("state-branch janitor: scanned=5 deleted=2 kept=3 errors=0"));
+});
+
+test("janitor falls back to branch commit age when the run no longer exists", async () => {
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname.includes("/git/matching-refs/")) return Response.json([branch("500")]);
+    if (url.pathname.endsWith("/actions/runs/500")) return new Response(null, { status: 404 });
+    if (url.pathname.includes("/git/commits/")) {
+      return Response.json({ committer: { date: "2026-07-19T11:00:00.000Z" } });
+    }
+    if (init?.method === "DELETE") return new Response(null, { status: 204 });
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runStateBranchJanitor({
+    env: janitorEnv(),
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+  assert.deepEqual(summary, { scanned: 1, deleted: 1, kept: 0, errors: 0 });
+});
+
+test("repository size check logs GB and warns only above the configured threshold", async (t) => {
+  const logged: string[] = [];
+  const warned: string[] = [];
+  t.mock.method(console, "log", (...parts: unknown[]) => logged.push(parts.join(" ")));
+  t.mock.method(console, "warn", (...parts: unknown[]) => warned.push(parts.join(" ")));
+  const mockFetch = async (): Promise<Response> => Response.json({ size: 6 * 1024 * 1024 });
+
+  const result = await runStateRepoSizeCheck({
+    env: {
+      CLAWSWEEPER_STATE_REPO_TOKEN: stateToken,
+      GITHUB_API_URL: "https://api.github.test",
+      STATE_REPO_SIZE_WARN_GB: "5",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+  });
+
+  assert.equal(result.errors, 0);
+  assert.equal(result.size?.aboveThreshold, true);
+  assert.ok(logged.includes("state-repo size: 6.00GB"));
+  assert.ok(warned.includes("::warning::state-repo size: 6.00GB exceeds 5GB threshold"));
+});
+
+test("janitor and size check fail open when credentials are unavailable", async (t) => {
+  const logged: string[] = [];
+  t.mock.method(console, "log", (...parts: unknown[]) => logged.push(parts.join(" ")));
+  t.mock.method(console, "warn", () => {});
+  const janitor = await runStateBranchJanitor({ env: {} });
+  const size = await runStateRepoSizeCheck({ env: {} });
+  assert.deepEqual(janitor, { scanned: 0, deleted: 0, kept: 0, errors: 1 });
+  assert.equal(size.errors, 1);
+  assert.ok(logged.includes("state-branch janitor: scanned=0 deleted=0 kept=0 errors=1"));
+  assert.ok(logged.includes("state-repo size: unavailable"));
+});
+
+test("janitor fails open when state reference discovery is unavailable", async () => {
+  const summary = await runStateBranchJanitor({
+    env: janitorEnv(),
+    fetchImpl: (async () => new Response(null, { status: 503 })) as typeof fetch,
+    now,
+  });
+  assert.deepEqual(summary, { scanned: 0, deleted: 0, kept: 0, errors: 1 });
+});


### PR DESCRIPTION
SM-4 of #738. Three guardrails so the state repo can never silently regrow into last weekend: (1) scratch-branch janitor in the reconcile sweep (completed-run or >24h immutable-ledger branches, max 50/sweep, fail-open, summary line); (2) repo-size log line with ::warning:: above 5GB (live read today: ~32.2GB pending GitHub GC after compaction); (3) monthly compaction cron codifying the manual 2026-07-20 procedure — threshold skip, dated backup ref, orphan commit of the head tree, force-with-lease, remote verification.

Validation: 13 new tests green; build/lint/format/actionlint green; autoreview clean (0.99) after four review-driven safety fixes.
