### PR TITLE
feat: add exact-review batch publisher

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -1,0 +1,252 @@
+name: Publish exact review batch
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: "Claim and publish one batch"
+        required: true
+        type: boolean
+        default: false
+      max_items:
+        description: "Maximum items in this proof batch"
+        required: false
+        default: "8"
+
+concurrency:
+  group: exact-review-batch-publisher
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  publish:
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && inputs.execute) ||
+        (github.event_name == 'schedule' && (vars.EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED == 'true' || vars.EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED == '1'))
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+      CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+      EXACT_REVIEW_BATCH_ID: exact-review-batch:${{ github.run_id }}
+      EXACT_REVIEW_BATCH_LEASE_OWNER: github:${{ github.run_id }}
+      EXACT_REVIEW_BATCH_MANIFEST: .artifacts/exact-review-batch/manifest.json
+      EXACT_REVIEW_BATCH_MAX_ITEMS: ${{ inputs.max_items || vars.EXACT_REVIEW_PUBLICATION_BATCH_SIZE || '8' }}
+      CLAWSWEEPER_APP_CLIENT_ID: ${{ vars.CLAWSWEEPER_APP_CLIENT_ID }}
+      CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          filter: blob:none
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:all
+
+      - name: Claim one durable publication batch
+        id: batch
+        run: pnpm run --silent repair:exact-review-batch claim
+
+      - name: Create target owner token
+        if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        id: target-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ env.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.batch.outputs.target_owner }}
+          repositories: ${{ steps.batch.outputs.target_repositories }}
+          permission-checks: read
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-statuses: read
+
+      - name: Create state token
+        if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ env.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Prepare each item independently
+        if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        env:
+          GH_TOKEN: ${{ steps.target-token.outputs.token }}
+          REPO_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          jq -c '.items[]' "$EXACT_REVIEW_BATCH_MANIFEST" | while IFS= read -r item; do
+            pnpm run --silent repair:exact-review-batch heartbeat || exit 1
+            outcome_path="$(jq -r '.outcomePath' <<<"$item")"
+            decision="$(jq -c '.decision' <<<"$item")"
+            producer="$(jq -c '.publication.producerDecision' <<<"$decision")"
+            item_number="$(jq -r '.itemNumber' <<<"$decision")"
+            target_repo="$(jq -r '.targetRepo' <<<"$decision")"
+            artifact_name="$(jq -r '.publication.artifactName' <<<"$decision")"
+            producer_run_id="$(jq -r '.publication.producerRunId' <<<"$decision")"
+            bundle_dir=".artifacts/exact-review-batch/bundles/$item_number"
+            rm -rf "$bundle_dir" artifacts/event .artifacts/event-record-snapshot
+            mkdir -p "$bundle_dir" artifacts/event "$(dirname "$outcome_path")"
+
+            if ! GH_TOKEN="$REPO_TOKEN" gh run download "$producer_run_id" --repo "$GITHUB_REPOSITORY" \
+              --name "$artifact_name" --dir "$bundle_dir"; then
+              echo "::warning::Leaving $target_repo#$item_number retryable: artifact download failed"
+              continue
+            fi
+            if ! env \
+              EXACT_REVIEW_BUNDLE_DIR="$bundle_dir" \
+              EXACT_REVIEW_CLAIM_GENERATION="$(jq -r '.publication.claimGeneration' <<<"$decision")" \
+              EXACT_REVIEW_DECISION="$producer" \
+              EXACT_REVIEW_GENERATION_ATTEMPT="$(jq -r '.publication.producerRunAttempt' <<<"$decision")" \
+              EXACT_REVIEW_ITEM_KEY="$(jq -r '.publication.itemKey' <<<"$decision")" \
+              EXACT_REVIEW_ITEM_KIND="$(jq -r '.itemKind' <<<"$decision")" \
+              EXACT_REVIEW_ITEM_NUMBER="$item_number" \
+              EXACT_REVIEW_LEASE_REVISION="$(jq -r '.publication.leaseRevision' <<<"$decision")" \
+              EXACT_REVIEW_LIVE_GUARDED_OPEN="$(jq -r '.publication.liveGuardedOpen' <<<"$decision")" \
+              EXACT_REVIEW_LIVE_PROCEEDED="$(jq -r '.publication.liveProceeded' <<<"$decision")" \
+              EXACT_REVIEW_LIVE_TERMINAL_MISSING="$(jq -r '.publication.liveTerminalMissing' <<<"$decision")" \
+              EXACT_REVIEW_LIVE_TERMINAL_NOOP="$(jq -r '.publication.liveTerminalNoop' <<<"$decision")" \
+              EXACT_REVIEW_PRODUCER_JOB=event-review-apply \
+              EXACT_REVIEW_PRODUCER_RUN_ID="$producer_run_id" \
+              EXACT_REVIEW_PROTOCOL_VERSION="$(jq -r '.publication.protocolVersion' <<<"$decision")" \
+              EXACT_REVIEW_SOURCE_SHA="$(jq -r '.publication.sourceSha' <<<"$decision")" \
+              EXACT_REVIEW_TARGET_BRANCH="$(jq -r '.targetBranch' <<<"$decision")" \
+              EXACT_REVIEW_TARGET_REPO="$target_repo" \
+              pnpm run --silent repair:exact-review-bundle validate; then
+              echo "::warning::Leaving $target_repo#$item_number retryable: artifact validation failed"
+              continue
+            fi
+            report="$bundle_dir/review/$item_number.md"
+            if REPORT_PATH="$report" node <<'NODE'
+            const fs = require("node:fs");
+            const path = process.env.REPORT_PATH;
+            if (!path || !fs.existsSync(path)) process.exit(1);
+            const markdown = fs.readFileSync(path, "utf8");
+            const owner = /^review_lease_owner:\s*(.+)\s*$/m.exec(markdown)?.[1]?.trim() || "";
+            const commentId = Number(/^review_lease_comment_id:\s*(\d+)\s*$/m.exec(markdown)?.[1] || "0");
+            process.exit((!owner || owner === "unknown") && (!Number.isInteger(commentId) || commentId <= 0) ? 0 : 1);
+            NODE
+            then
+              echo "::warning::Leaving $target_repo#$item_number retryable: legacy tuple-less artifact"
+              continue
+            fi
+            if [ -f "$report" ]; then cp "$report" "artifacts/event/$item_number.md"; fi
+            if ! env \
+              TARGET_REPO="$target_repo" \
+              ITEM_NUMBER="$item_number" \
+              CLOSE_REASONS=implemented_on_main,duplicate_or_superseded,low_signal_unmergeable_pr \
+              MIN_AGE_MINUTES=0 \
+              REVIEW_ONLY="$(jq -r '.sourceAction == "failed_review_shard_recovery"' <<<"$producer")" \
+              EXACT_EVENT_PUBLICATION=true \
+              EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED=true \
+              EXACT_REVIEW_BATCH_ITEM_KEY="$(jq -r '.itemKey' <<<"$item")" \
+              EXACT_REVIEW_BATCH_REVISION="$(jq -r '.revision' <<<"$item")" \
+              EXACT_REVIEW_BATCH_CLAIM_GENERATION="$(jq -r '.claimGeneration' <<<"$item")" \
+              EXACT_REVIEW_BATCH_MUTATION_OUTPUT="$outcome_path" \
+              pnpm run --silent repair:publish-event-result; then
+              echo "::warning::Leaving $target_repo#$item_number retryable: item publication failed"
+              rm -f "$outcome_path"
+              continue
+            fi
+          done
+
+      - name: Finalize healthy members under a fenced heartbeat
+        if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES: ${{ vars.CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES || '180' }}
+          CLAWSWEEPER_COMMENT_MAX_COMMENTS: ${{ vars.CLAWSWEEPER_COMMENT_MAX_COMMENTS || '1000' }}
+        run: |
+          set -euo pipefail
+          heartbeat_failed=".artifacts/exact-review-batch/heartbeat-failed"
+          rm -f "$heartbeat_failed"
+          pnpm run --silent repair:exact-review-batch heartbeat
+          (
+            while sleep 60; do
+              if ! pnpm run --silent repair:exact-review-batch heartbeat; then
+                touch "$heartbeat_failed"
+                exit 1
+              fi
+            done
+          ) &
+          heartbeat_pid=$!
+          stop_heartbeat() {
+            kill "$heartbeat_pid" 2>/dev/null || true
+            wait "$heartbeat_pid" 2>/dev/null || true
+          }
+          trap stop_heartbeat EXIT
+
+          pnpm run --silent repair:exact-review-batch commit
+          test ! -f "$heartbeat_failed"
+          jq -c '.items[]' "$EXACT_REVIEW_BATCH_MANIFEST" | while IFS= read -r item; do
+            test ! -f "$heartbeat_failed"
+            outcome_path="$(jq -r '.outcomePath' <<<"$item")"
+            [ -f "$outcome_path" ] || continue
+            if ! jq -e '.kind == "eligible" or (.kind == "superseded" and .disposition.requeueLatestExpected == true)' "$outcome_path" >/dev/null; then
+              continue
+            fi
+            target_repo="$(jq -r '.decision.targetRepo' <<<"$item")"
+            target_branch="$(jq -r '.decision.targetBranch' <<<"$item")"
+            item_number="$(jq -r '.decision.itemNumber' <<<"$item")"
+            source_action="$(jq -r '.decision.publication.producerDecision.sourceAction' <<<"$item")"
+            if jq -e '.disposition.requeueLatestExpected == true' "$outcome_path" >/dev/null; then
+              delivery_id="publisher-source-drift:$(jq -r '.itemKey' <<<"$item"):$(jq -r '.revision' <<<"$item")"
+              producer_decision="$(jq -c '.decision.publication.producerDecision' <<<"$item")"
+              payload="$(jq -cn \
+                --arg delivery_id "$delivery_id" \
+                --arg source_action "$source_action" \
+                --argjson decision "$producer_decision" \
+                '{
+                  delivery_id: $delivery_id,
+                  decision: ($decision + {
+                    sourceAction: (if $source_action == "failed_review_shard_recovery" then $source_action else "source_drift_requeue" end),
+                    supersedesInProgress: true
+                  })
+                }')"
+              signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+              response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+                --request POST \
+                --header "content-type: application/json" \
+                --header "x-clawsweeper-exact-review-signature: $signature" \
+                --data "$payload" \
+                "${EXACT_REVIEW_QUEUE_URL%/}/internal/exact-review/enqueue")"
+              jq -e '.ok == true and (.queued == true or .deduped == true or .shed == true)' <<<"$response" >/dev/null
+            elif jq -e '.disposition.deferredCloseCoverageExpected == true' "$outcome_path" >/dev/null; then
+              # The committed tuple is the durable input consumed by the bounded
+              # scheduled proof lane; no immediate mutation workflow is dispatched.
+              :
+            elif jq -e '.disposition.routableSyncExpected == true' "$outcome_path" >/dev/null && [ "$source_action" != "failed_review_shard_recovery" ]; then
+              gh workflow run repair-comment-router.yml \
+                --repo "$GITHUB_REPOSITORY" \
+                --ref main \
+                -f execute=true \
+                -f target_repo="$target_repo" \
+                -f target_branch="$target_branch" \
+                -f item_numbers="$item_number" \
+                -f lookback_minutes="$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
+                -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS"
+            fi
+            temporary="${outcome_path}.tmp"
+            jq '.postEffectsComplete = true' "$outcome_path" > "$temporary"
+            mv "$temporary" "$outcome_path"
+          done
+          test ! -f "$heartbeat_failed"
+          pnpm run --silent repair:exact-review-batch complete

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -45,6 +45,10 @@ export type PublicationBatchCompletion = PublicationBatchCandidate & {
   terminalOutcome: Exclude<PublicationBatchTerminalOutcome, "lease_expired">;
 };
 
+export type PublicationBatchFence = PublicationBatchCandidate & {
+  claimGeneration: number;
+};
+
 export type PublicationBatchStats = {
   leased: number;
   completed: number;
@@ -198,6 +202,47 @@ export class ExactReviewPublicationBatchStore {
         (batch.state === "leased" || batch.state === "completed")
         ? batch
         : null;
+    });
+  }
+
+  heartbeat(
+    batchId: string,
+    leaseOwner: string,
+    members: PublicationBatchFence[],
+    leaseExpiresAt: number,
+    now: number,
+  ): PublicationBatch | null {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      const batch = this.readBatchSync(batchId);
+      if (!batch || batch.state !== "leased" || batch.leaseOwner !== leaseOwner) return null;
+      const unfinished = batch.items.filter((item) => item.terminalOutcome === null);
+      const batchMembers = new Map(batch.items.map((item) => [item.itemKey, item]));
+      const supplied = new Map(members.map((member) => [member.itemKey, member]));
+      if (
+        supplied.size !== members.length ||
+        members.some((member) => {
+          const item = batchMembers.get(member.itemKey);
+          return (
+            item?.revision !== member.revision || item.claimGeneration !== member.claimGeneration
+          );
+        }) ||
+        unfinished.some((item) => !supplied.has(item.itemKey))
+      ) {
+        return null;
+      }
+      // Extend from the server clock. A delayed worker must never shorten its own
+      // lease by replaying a heartbeat calculated before an earlier renewal.
+      const nextExpiry = Math.max(batch.leaseExpiresAt, leaseExpiresAt);
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            SET lease_expires_at = ?
+          WHERE batch_id = ? AND state = 'leased' AND lease_owner = ?`,
+        nextExpiry,
+        batchId,
+        leaseOwner,
+      );
+      return this.readBatchSync(batchId);
     });
   }
 

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -12,6 +12,7 @@ import {
 import {
   ExactReviewPublicationBatchStore,
   type PublicationBatchCompletion,
+  type PublicationBatchFence,
 } from "./exact-review-publication-batches.ts";
 import {
   REVIEW_TELEMETRY_DEGRADED_MS,
@@ -1136,6 +1137,10 @@ export class ExactReviewQueue {
 
     if (request.method === "POST" && url.pathname === "/publication-batches/fetch") {
       return this.fetchPublicationBatch(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/publication-batches/heartbeat") {
+      return this.heartbeatPublicationBatch(await request.json().catch(() => null));
     }
 
     if (request.method === "POST" && url.pathname === "/publication-batches/complete") {
@@ -2391,10 +2396,11 @@ export class ExactReviewQueue {
       true,
       publicationControl.demandCapacity,
     );
-    // One batch consumes one publisher slot regardless of membership count. Reuse
-    // normal readiness/pause admission, but charge capacity once for the whole claim.
+    // The outer comparison charges one publisher slot for the whole batch. The
+    // shared helper counts candidate rows, so widen only its scan window by
+    // requestedSize; passing +1 here would silently collapse every batch to one.
     const activePublishers = exactReviewQueueActivePublicationCount(state);
-    const candidates =
+    const readyCandidates =
       activePublishers >= publicationCapacity
         ? []
         : exactReviewQueueAdmittedItems(
@@ -2404,10 +2410,15 @@ export class ExactReviewQueue {
             exactReviewTargetCapacity(this.env),
             activePublishers + requestedSize,
             new Set<string>(batchOwnership.itemKeys),
-          )
-            .filter(exactReviewQueueIsPublication)
-            .slice(0, requestedSize)
-            .map((item) => ({ itemKey: item.key, revision: item.revision }));
+          ).filter(exactReviewQueueIsPublication);
+    const firstOwner = readyCandidates[0]?.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
+    // One GitHub App installation token is scoped to one owner. Keeping a batch
+    // owner-homogeneous lets the workflow retain least privilege without serially
+    // minting and exporting a different credential for every item.
+    const candidates = readyCandidates
+      .filter((item) => item.decision.targetRepo.split("/", 1)[0]?.toLowerCase() === firstOwner)
+      .slice(0, requestedSize)
+      .map((item) => ({ itemKey: item.key, revision: item.revision }));
     const batch = this.batchStore.claim({
       batchId: claimId,
       leaseOwner,
@@ -2467,6 +2478,25 @@ export class ExactReviewQueue {
       items,
       superseded: batch.items.filter((item) => item.terminalOutcome === "superseded").length,
     });
+  }
+
+  private heartbeatPublicationBatch(value: unknown) {
+    const body = objectValue(value);
+    const batchId = exactReviewPublicationBatchId(body.batch_id);
+    const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
+    const members = exactReviewPublicationBatchMembers(body.items);
+    if (!batchId || !leaseOwner) return json({ error: "invalid_batch_identity" }, 400);
+    if (!members?.length) return json({ error: "invalid_batch_members" }, 400);
+    const now = Date.now();
+    const batch = this.batchStore.heartbeat(
+      batchId,
+      leaseOwner,
+      members,
+      now + exactReviewPublicationBatchLeaseMs(this.env),
+      now,
+    );
+    if (!batch) return json({ error: "batch_lease_not_active" }, 409);
+    return json({ ok: true, batch: exactReviewPublicationBatchJson(batch) });
   }
 
   private async completePublicationBatch(value: unknown) {
@@ -6631,6 +6661,32 @@ function exactReviewPublicationBatchCompletions(value): PublicationBatchCompleti
     });
   }
   return completions;
+}
+
+function exactReviewPublicationBatchMembers(value): PublicationBatchFence[] | null {
+  if (!Array.isArray(value) || value.length > MAX_EXACT_REVIEW_PUBLICATION_BATCH_SIZE) return null;
+  const seen = new Set<string>();
+  const members: PublicationBatchFence[] = [];
+  for (const raw of value) {
+    const item = objectValue(raw);
+    const itemKey = String(item.item_key || "").trim();
+    const revision = Number(item.revision);
+    const claimGeneration = Number(item.claim_generation);
+    if (
+      !itemKey ||
+      itemKey.length > 500 ||
+      seen.has(itemKey) ||
+      !Number.isInteger(revision) ||
+      revision < 1 ||
+      !Number.isInteger(claimGeneration) ||
+      claimGeneration < 1
+    ) {
+      return null;
+    }
+    seen.add(itemKey);
+    members.push({ itemKey, revision, claimGeneration });
+  }
+  return members;
 }
 
 function exactReviewPublicationBatchJson(batch) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -558,6 +558,11 @@ export default {
     )
       return authenticatedExactReviewQueueRequest(request, env, "/publication-batches/fetch");
     if (
+      url.pathname === "/internal/exact-review/publication-batches/heartbeat" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/publication-batches/heartbeat");
+    if (
       url.pathname === "/internal/exact-review/publication-batches/complete" &&
       request.method === "POST"
     )

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -1,0 +1,621 @@
+# State publication batching plan
+
+**Status:** PR 1 and PR 2 implementation complete; PR 3 implemented locally and
+default off; PR 2 remote performance proof and production rollout remain pending
+**Incident:** CSW-049
+**Decision scope:** reduce the existing single-`state`-ref publication bottleneck
+without migrating authoritative state to a new database or changing the generated
+state layout.
+
+## Delivery status
+
+| Stage | Status | Evidence |
+| --- | --- | --- |
+| State writer observability prerequisite | Complete | Merged before batching ownership as [`openclaw/clawsweeper#735`](https://github.com/openclaw/clawsweeper/pull/735). |
+| PR 1: durable batch ownership protocol | Complete | Merged as [`openclaw/clawsweeper#734`](https://github.com/openclaw/clawsweeper/pull/734) at `c074a99c0b18848be7a7d8f80f0fa57b7875b129`; post-merge proof is recorded below. |
+| PR 2: bounded multi-item Git commit primitive | Implementation complete; performance gate pending | Merged as [`openclaw/clawsweeper#740`](https://github.com/openclaw/clawsweeper/pull/740) at `a04c4c4cfbd29be9d6bf5036c824481b31d2233d`; the CI-fixture stabilization followed in [`openclaw/clawsweeper#742`](https://github.com/openclaw/clawsweeper/pull/742) at `de0a7a2a4e11ad8a22596580b8dbd984084246a1`. Bare-Git correctness proof passed, but Crabbox and realistic-repository p95 proof remain pending. |
+| PR 3: end-to-end batch publisher | Implemented locally, default off | The dedicated workflow, signed queue client, heartbeat, per-item isolation, one-commit materialization, and fenced acknowledgement path have focused local proof. Merge and any production rollout remain gated on the unresolved PR 2 remote performance proof. |
+| PR 4: production rollout configuration | Not authorized | Requires the later proof and explicit rollout decision described in this plan. |
+
+PR 1 did not enable batching or add a batch publisher. The live legacy publisher
+continues to consume the existing queue while the additive ownership protocol
+remains inert behind `EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED`.
+
+## Decision
+
+Use the existing SQLite-backed `ExactReviewQueue` publication lane as the durable
+buffer and replace one-workflow-per-item Git publication with one serial batch
+publisher:
+
+```text
+existing SQLite publication items
+               |
+               v
+      atomically lease one batch
+               |
+               v
+   one batch publisher workflow
+               |
+               +-- validate each item independently
+               +-- perform idempotent per-item GitHub effects
+               +-- prepare bounded state path mutations
+               |
+               v
+       one state lease acquisition
+       one state commit and push
+               |
+               v
+     complete each SQLite queue item
+```
+
+State writes remain serial. The unit of serialization changes from one item to
+one batch. Git remains the final generated-state store in this plan; SQLite is
+the durable publication buffer and broker, not a newly introduced second source
+of truth.
+
+This is the preferred narrow repair because:
+
+- increasing admission to 50 did not create more real state writers;
+- reducing admission to four did not provide enough observed useful throughput;
+- increasing the ordinary lease wait from 180 to 480 seconds converted many
+  three-minute failures into eight-minute failures without increasing service
+  rate;
+- fairer lock handoff could reduce starvation but would still publish only one
+  item per expensive Git critical section;
+- branch sharding or migration of operational state to a database would be a
+  broader architecture and data-migration project;
+- the existing SQLite queue already contains the active backlog, item identity,
+  revision, artifact reference, lease, retry, and dead-letter state, so batching
+  requires no backlog migration.
+
+The most recent evidence reviewed for this plan continued to show a non-draining
+lane: 586 pending, 635 total outstanding, 244 open dead letters, a 60-minute
+arrival rate of 135/hour, useful published plus superseded throughput of 39/hour,
+and a net drain rate of -77/hour. No open pull request was found implementing a
+state commit broker or publication batching path.
+
+## Scope and non-goals
+
+This plan changes only how durable exact-result publication work is consumed and
+committed to the generated `state` branch.
+
+It does not:
+
+- migrate historical state or ledgers into SQLite;
+- make SQLite authoritative for review or apply records;
+- shard the `state` branch or create per-item Git refs;
+- change the flat `records/<repo-slug>/items/` and `closed/` layouts;
+- weaken tuple, source-drift, protected-item, apply, or safe-close guards;
+- automatically replay, resolve, or delete open dead letters;
+- pause the live sweep workflow;
+- cancel already-running publication workflows;
+- batch unrelated ordinary state writers in the first rollout.
+
+The exact-result lane is the initial scope because it is the incident-dominant
+cohort and its durable queue already exists. Routing comment-router, status,
+action-ledger, and other state writers through the broker is a later decision,
+made only after exact-result batching proves its semantics and throughput.
+
+## Why this work is split into separate pull requests
+
+The split is primarily about independently reviewable correctness and operator
+decision points, not about producing several small pull requests for their own
+sake. The complete change crosses four failure domains:
+
+1. SQLite ownership, leasing, and cleanup;
+2. Git tree construction and atomic publication;
+3. GitHub Actions dispatch and per-item completion semantics;
+4. production admission and rollout configuration.
+
+Combining those domains would make it difficult to tell whether a failure came
+from storage, Git reconciliation, workflow wiring, or rollout configuration. It
+would also make rollback unnecessarily broad.
+
+Each proposed pull request therefore ends at a boundary that a maintainer can
+verify manually before authorizing the next one. A merged pull request must not
+silently enable the behavior introduced by a later pull request.
+
+The split should not go below these boundaries. Dividing individual tables,
+endpoints, or helper functions into additional pull requests would introduce
+temporary interfaces and dead code without creating another meaningful human
+decision point.
+
+## Pull request sequence
+
+### PR 1: durable batch ownership protocol
+
+**Delivery status:** complete and verified on 2026-07-21 via
+[`openclaw/clawsweeper#734`](https://github.com/openclaw/clawsweeper/pull/734).
+
+**Purpose:** prove that existing SQLite publication items can be grouped,
+leased, reclaimed, and completed without duplicate ownership or data migration.
+
+**Estimated scope:** medium.
+
+- One extracted batch-store/protocol module rather than more unrelated logic in
+  `dashboard/exact-review-queue.ts`.
+- Additive SQLite schema for batches and batch membership.
+- Internal authenticated batch claim/fetch/complete operations.
+- Queue stats and bounded cleanup metrics.
+- Focused queue and migration tests.
+- Feature flag defaulted off; no batch workflow dispatch.
+
+Implemented additive records:
+
+```text
+exact_review_publication_batches
+  batch_id
+  state
+  lease_owner
+  lease_expires_at
+  attempt
+  created_at
+  completed_at
+  state_commit_sha
+  failure_fingerprint
+
+exact_review_publication_batch_items
+  batch_id
+  item_key
+  revision
+  claim_generation
+  terminal_outcome
+```
+
+Batch membership references the existing queue item. It must not copy the full
+item payload or create a second publication queue.
+
+**Automated proof:**
+
+- atomic selection of multiple ready items;
+- the same item cannot belong to two active batches;
+- lease expiry returns unfinished items to ready state;
+- re-claim uses a new lease generation;
+- stale item revisions can be terminalized as superseded before dispatch;
+- cleanup cannot remove active membership or open dead letters;
+- old code can ignore the additive schema.
+
+**Maintainer manual verification:**
+
+1. Inspect a test queue containing several ready items.
+2. Claim a batch and verify the selected item keys and revisions.
+3. Attempt a second claim and verify the first batch's items are absent.
+4. Advance past lease expiry and verify those items become claimable again.
+5. Inspect `/stats` and confirm batch counts and oldest age are visible.
+6. Confirm no GitHub Actions workflow was dispatched and production behavior is
+   unchanged while the feature flag is off.
+
+**Stop/go decision:** merge only if the queue can recover every interrupted batch
+without duplicate ownership or lost items. PR 2 does not begin production
+integration; failure here leaves the existing publisher untouched.
+
+**Post-merge verification:** passed.
+
+- The deployed `main` tree at `c074a99c0b18848be7a7d8f80f0fa57b7875b129`
+  matched the reviewed PR tree.
+- The isolated test queue passed all 13 focused ownership-protocol tests,
+  including atomic multi-item selection, competing-claim exclusion, lease
+  expiry and reclaim with a new fencing generation, stale-revision
+  terminalization, atomic completion, bounded cleanup, migration compatibility,
+  pause-gate behavior, and internal-route authentication.
+- The live dashboard Worker deployment and smoke test passed in
+  [Actions run 29802010864](https://github.com/openclaw/clawsweeper/actions/runs/29802010864).
+- The post-merge `main` CI passed, including the full `pnpm check`, in
+  [Actions run 29802010889](https://github.com/openclaw/clawsweeper/actions/runs/29802010889).
+- Both CodeQL analyses passed in
+  [Actions run 29802010883](https://github.com/openclaw/clawsweeper/actions/runs/29802010883).
+- The deployed `/api/exact-review-queue` response reported storage schema v1,
+  exposed batch counts and oldest-age fields, and reported `enabled: false`,
+  `leased: 0`, and `active_items: 0`.
+- No batch workflow was dispatched and no production queue item was claimed for
+  validation. The legacy publication lane remained active while the flag was
+  off.
+
+**Recorded decision:** go for PR 2. This authorizes development and proof of the
+bounded multi-item Git primitive only; it does not authorize PR 3 integration or
+PR 4 production rollout.
+
+### PR 2: bounded multi-item Git commit primitive
+
+**Delivery status:** implementation complete and landed on 2026-07-21 via
+[`openclaw/clawsweeper#740`](https://github.com/openclaw/clawsweeper/pull/740),
+with the CI-fixture stabilization in
+[`openclaw/clawsweeper#742`](https://github.com/openclaw/clawsweeper/pull/742).
+Correctness proof passed; the Crabbox and realistic-repository performance gate
+remain pending.
+
+**Purpose:** prove that several independently validated item mutations can be
+applied to the latest remote state tree and published in one commit without
+losing remote sibling paths.
+
+**Estimated scope:** large and correctness-sensitive. This is expected to be the
+largest implementation pull request.
+
+- Introduce a per-item state-mutation plan that contains bounded path operations
+  but does not push Git.
+- Add a batch committer with one state lease acquisition, one commit, and one
+  push.
+- Prepare item mutations outside the state lease.
+- Re-read the latest remote tree under the lease and apply the prepared bounded
+  changes there.
+- Renew and fence the existing lease as needed.
+- Include a stable batch identifier in the commit metadata for ambiguous-result
+  recovery.
+- Add focused bare-Git and Crabbox proofs.
+- Do not connect this primitive to the production dispatcher yet.
+
+The primitive must preserve arbitrary remote siblings and reject overlapping
+mutations whose tuple ordering cannot be proven. It must not restore generic
+full-history hydration or full-worktree reset behavior on the exact hot path.
+
+**Automated proof:**
+
+- batch sizes 1, 2, 4, and 8 produce exactly one state commit each;
+- every selected item tuple is present after the push;
+- unrelated remote sibling updates survive;
+- same-path incompatible mutations fail before push;
+- an ordinary writer advancing the remote head during preparation is preserved;
+- a process crash before push leaves no partial remote state;
+- push success followed by local acknowledgement failure is detected from the
+  remote batch identity rather than pushed again blindly;
+- batch size 1 remains semantically compatible with the existing path;
+- Git subprocess count and lease-hold time are measured.
+
+**Maintainer manual verification:**
+
+1. Inspect a real bare-Git proof containing, for example, eight different item
+   paths plus a concurrently written sibling path.
+2. Verify the remote history gains one commit rather than eight.
+3. Inspect that commit and verify all eight expected paths and the unrelated
+   sibling are present.
+4. Compare batch sizes 1, 2, 4, and 8 in the proof report.
+5. Confirm the projected p95 throughput meets the go/no-go threshold below.
+6. Confirm this PR has no workflow or production configuration change.
+
+**Stop/go decision:** proceed only if batching improves projected state
+throughput materially. If batch duration grows approximately linearly with item
+count, stop and reconsider the database or sharding architecture rather than
+wiring an ineffective batch path into production.
+
+**Post-merge verification:** correctness passed; performance gate pending.
+
+- The reviewed PR 2 tree matched the landed `main` tree. The implementation
+  prepares bounded per-item mutations outside the lease and performs one leased
+  commit and atomic push for each batch without production dispatcher or
+  workflow integration.
+- The focused bare-Git suite passed all 19 tests. It covers batch sizes 1, 2, 4,
+  and 8; tuple materialization; sibling preservation; pre-push overlap and
+  compare-and-swap rejection; crash-before-push behavior; durable ambiguous-push
+  recovery; literal paths and modes; SHA-1 and SHA-256 repositories; and
+  batch-size-one idempotent binding.
+- The final post-fix CI passed 1,436 of 1,437 tests with zero failures and one
+  skip in the full `pnpm check` job. The PR 2 test initially exposed a Git 2.54
+  object-maintenance race in its 300-worktree-commit fixture; PR 742 replaced
+  that fixture with an equivalent 300-deep `git commit-tree` chain, after which
+  the full job passed.
+- Three CI proof samples used 24 Git subprocesses per batch. Across batch sizes
+  1, 2, 4, and 8, measured lease hold was 80–92 ms. The slowest observed total
+  durations were 1.093 s, 0.644 s, 0.977 s, and 0.725 s respectively.
+- Those timings came from small synthetic bare repositories. They are useful
+  regression evidence but are not the required realistic-state-repository p95
+  benchmark and must not be used as the production go/no-go decision.
+- Crabbox remote proof did not run: the AWS coordinator returned HTTP 401 and
+  the Blacksmith workflow endpoint returned HTTP 404 before a Testbox could be
+  allocated. No remote-provider proof is claimed.
+- Until a realistic proof records p95 total and phase durations, changed paths
+  and bytes, lease acquisition and hold time, and projected throughput of at
+  least 203 useful items/hour, PR 3 must remain default-off and PR 4 production
+  rollout remains unauthorized.
+
+**Recorded decision:** PR 3 implementation may start as an isolated,
+default-off integration. Its merge and all production enablement remain gated
+on completing the missing PR 2 remote performance proof and re-evaluating the
+go/no-go threshold.
+
+### PR 3: end-to-end batch publisher, default off
+
+**Delivery status:** implemented locally on 2026-07-21; default off and not
+authorized for production rollout.
+
+**Purpose:** connect the proven queue protocol and Git primitive through one
+dedicated workflow while preserving per-item GitHub and queue outcomes.
+
+**Estimated scope:** medium-to-large, with workflow and failure-classification
+risk.
+
+- A dedicated batch publication workflow or narrow reusable workflow instead of
+  adding another large branch to the existing exact-review job.
+- A batch publisher entry point with one responsibility: consume one leased
+  batch and report its item outcomes.
+- Artifact retrieval and per-item preflight.
+- Existing idempotent GitHub comment, label, and safe-apply behavior retained per
+  item.
+- One invocation of the PR 2 committer for all eligible state mutations.
+- Per-item completion back to SQLite only after the required GitHub effects and
+  state materialization reach a terminal outcome.
+- Feature flag still defaulted off.
+
+One invalid item must not poison the batch:
+
+- stale or remote-terminal items complete as superseded;
+- an invalid or unavailable artifact is isolated to that item;
+- a per-item GitHub failure retries only that item;
+- a shared Git infrastructure failure may retry all otherwise eligible batch
+  members using the same stable batch identity;
+- an ambiguous shared push is reconciled before another push is attempted.
+
+The workflow must expose GitHub-visible delivery separately from durable state
+materialization. The CSW-049 handoff proved that a review comment can be visible
+even though the workflow later fails durable state publication.
+
+**Automated proof:**
+
+- signed dispatch, claim, heartbeat, completion, lease expiry, and reclaim;
+- missing artifact isolation;
+- mixed published/superseded/retryable outcomes in one batch;
+- GitHub side effect completed before a failed state push;
+- state push completed before an acknowledgement timeout;
+- no duplicate queue completion after workflow rerun;
+- a poison item does not prevent healthy siblings from materializing;
+- workflow source and action permissions remain narrowly scoped.
+
+**Maintainer manual verification:**
+
+1. Run the workflow against a non-production or synthetic target with batching
+   explicitly enabled for that proof only.
+2. Inspect one Actions run representing several queue items.
+3. Verify one resulting state commit contains all successful item paths.
+4. Verify each target has the expected comment/labels and each SQLite item has
+   its own correct terminal outcome.
+5. Inject or select one deliberately superseded/invalid fixture and confirm the
+   other items still complete.
+6. Disable the proof flag and verify items return to legacy consumption without
+   data conversion.
+
+**Stop/go decision:** do not enable production batching unless end-to-end proof
+shows that GitHub-visible and durable outcomes remain independently observable
+and recoverable.
+
+**Local implementation proof:** passed.
+
+- A dedicated serial workflow is gated by
+  `EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED`; manual dispatch additionally
+  requires an explicit `execute` input. No live flag was changed.
+- Signed claim, fetch, heartbeat, and completion calls use the durable PR 1
+  ownership protocol. Heartbeats extend only the active fenced owner lease.
+- Per-item artifact validation and GitHub effects run sequentially and produce
+  bounded PR 2 mutation plans without pushing. Missing, invalid, and failed
+  items retain queue ownership for retry without blocking healthy sibling plans.
+- Healthy plans enter one PR 2 committer invocation. Durable queue completion
+  happens only after the shared state receipt and required deferred verdict
+  handoff are available; an acknowledgement timeout reuses the same stable
+  batch identity.
+- Batch admission is target-owner homogeneous so the workflow can use one
+  least-privilege GitHub App installation token without broadening repository
+  access.
+- Focused local tests cover mixed published/superseded/retryable outcomes,
+  poison-item isolation, shared commit failure, heartbeat fencing, stable-id
+  acknowledgement recovery, signed queue requests, owner-scoped admission, and
+  workflow permission/default-off invariants.
+- The full `pnpm run check` completed with exit code 0 on Node 24 and Git
+  2.54.0, including both test suites, changed/full coverage gates, and the
+  454-file formatting check. Git 2.43.7 had rejected the test-only global
+  `--no-lazy-fetch` option; rerunning with an isolated Git 2.54.0 installation
+  made both affected unavailable-object recovery tests pass without changing
+  the system Git installation.
+
+This local proof does not replace the manual non-production Actions run required
+above, and it does not satisfy the missing PR 2 realistic-repository p95 gate.
+
+### PR 4: production rollout configuration
+
+**Purpose:** make the production behavior change explicit, small, and easily
+revertible after the implementation is already reviewed and deployed inertly.
+
+**Estimated scope:** small code/configuration diff, high operational impact.
+
+- Enable exactly one batch publisher.
+- Start with a maximum batch size of 2.
+- Use a 60-second maximum wait.
+- Stop creating new legacy per-item publication workflows once batch claiming is
+  enabled; already-running legacy workflows drain naturally and are not
+  cancelled.
+- Keep all existing tuple, lease, apply, and close guards.
+- Expose the active batching configuration in queue status.
+
+This pull request exists separately because an implementation rollback and a
+production-behavior rollback are different decisions. A maintainer must be able
+to inspect all inert implementation proof before approving the one configuration
+change that affects live publication.
+
+**Maintainer manual verification:**
+
+1. Record a pre-enable queue snapshot and deployed version.
+2. Confirm exactly one batch workflow is active and no new legacy per-item
+   publication workflows are being admitted.
+3. Verify the first live batch at size 2 from queue claim through Git commit,
+   per-item queue completion, and target GitHub state.
+4. Observe two complete five-minute samples before increasing the batch size.
+5. Increase only through explicit configuration changes: 2, then 4, then 8.
+6. At every size, inspect at least one state commit and its target items.
+7. Revert immediately on lost paths, duplicate GitHub mutations, ambiguous
+   completion that cannot reconcile, growing post-batch state contention, or a
+   new safety-guard regression.
+
+**Stop/go decision:** batch-size increases are operational decisions, not
+automatic adaptive behavior in the first version.
+
+## Batch departure policy
+
+Use a simple event-driven bus policy:
+
+```text
+maximum items: 8
+maximum wait after the first eligible item: 60 seconds
+active batch writers: 1
+```
+
+- Dispatch immediately when the item cap is reached.
+- Dispatch the partial batch when the oldest selected item reaches the maximum
+  wait.
+- When a writer completes and enough ready work already exists, dispatch the
+  next full batch immediately without another wait.
+- When the queue is sparse, dispatch even one item at the maximum wait so low
+  traffic cannot starve.
+- Do not use a wall-clock cron as the primary trigger; the timer begins when the
+  first eligible item is waiting.
+- Cap a batch by total changed paths and total payload bytes as well as item
+  count. Those limits must be derived from proof measurements rather than chosen
+  without evidence.
+- Select oldest eligible work first. Backoff items become eligible only at
+  `next_attempt_at`.
+
+Keep the first version static. Do not add another adaptive controller until the
+fixed policy has stable production measurements.
+
+## Buffer lifecycle and cleanup
+
+SQLite is a durable buffer, not permanent storage for completed publication
+payloads.
+
+| State                   | Retained data                                  | Cleanup rule                                               |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------------------- |
+| Pending or leased       | Full queue item and artifact reference         | Never prune while active                                   |
+| Retryable/backoff       | Full queue item, attempts, next attempt        | Retain until terminal or DLQ                               |
+| Published or superseded | Compact receipt, outcome, batch ID, commit SHA | Remove large payload and active membership transactionally |
+| Active batch            | Batch membership and lease                     | Reclaim after lease expiry                                 |
+| Completed batch         | Compact membership/outcome receipt             | Retain seven days, then bounded prune                      |
+| Delivery receipt        | Existing compact idempotency receipt           | Keep the existing seven-day TTL                            |
+| Metrics bucket          | Aggregated counters only                       | Keep the existing 48-hour TTL                              |
+| Open dead letter        | Full recovery identity and error metadata      | Never delete automatically                                 |
+| Resolved dead letter    | Audited resolution metadata                    | Keep the existing 30-day TTL                               |
+| GitHub artifact         | Existing artifact bundle                       | Keep the current 90-day retention during initial rollout   |
+
+Terminal completion and payload cleanup must be one SQLite transaction:
+
+```text
+verify remote state commit
+  -> record per-item terminal outcome
+  -> write compact receipt and commit SHA
+  -> remove large terminal payload and active batch membership
+```
+
+Cleanup must run in bounded batches and expose row count, approximate retained
+bytes, oldest cleanup age, and cleanup failures. Artifact retention should not
+be shortened in the initial incident repair; it is the fallback evidence for
+ambiguous or dead-lettered publication.
+
+## Correctness invariants
+
+The implementation is acceptable only if all of these remain true:
+
+1. A queue item has at most one active owner.
+2. A batch has a stable idempotency identity across workflow retries.
+3. No queue item is marked published before its required remote state tuple is
+   verified.
+4. A newer remote tuple always wins over an older batch member.
+5. Remote sibling files that are not part of the batch are preserved.
+6. GitHub writes retain their existing per-item business idempotency identity.
+7. Partial GitHub delivery is recorded separately from state materialization.
+8. One deterministic poison item cannot repeatedly fail healthy batch siblings.
+9. An unresolved or ambiguous push never causes a blind second push.
+10. Open dead letters remain open until an authorized, evidence-backed recovery
+    decision is made.
+
+## Performance go/no-go gate
+
+Measure batch sizes 1, 2, 4, and 8 against a realistic state repository in the
+same proof environment. Record:
+
+- total batch duration;
+- state lease acquisition and hold duration;
+- Git subprocess count by operation;
+- fetch, tree construction, commit, push, and verification duration;
+- paths and bytes changed;
+- items materialized per commit;
+- projected useful items per hour.
+
+Use:
+
+```text
+projected throughput = 3600 * batch size / p95 batch seconds
+```
+
+The first production candidate must project at least 1.5 times the recent peak
+arrival rate. With a reviewed arrival baseline of approximately 135 items/hour,
+the minimum projected service rate is approximately 203 items/hour. This is a
+go/no-go gate, not a promise that production will exactly match the proof.
+
+If the proof cannot meet that threshold without excessive lease hold, memory,
+paths, or payload size, stop the narrow batching plan and return to the broader
+state-database or sharding design decision.
+
+## Rollout and recovery gates
+
+Deploy additive schema and implementation with batching disabled first. Do not
+use a dead-letter replay as the first behavior proof.
+
+For every enabled batch size, require two consecutive fully post-enable samples
+showing:
+
+- pending decreases;
+- total outstanding (`pending + dispatching + leased`) decreases;
+- useful `published + superseded` meets or exceeds arrivals;
+- retry amplification declines materially;
+- post-batch `state_contention` does not increase;
+- oldest pending age begins falling;
+- multiple target items are live-verified;
+- one state commit contains multiple intended item mutations;
+- no dead-letter disposal is being mistaken for successful delivery.
+
+After the writer path is stable, dead-letter recovery is a separate authorized
+operation. Start with one representative item, then batches of at most two when
+GitHub pressure matters. Stop on the first repeated deterministic failure, new
+rate-limit signal, or unexplained health regression.
+
+## Rollback
+
+The production switch must support both:
+
+```text
+batching enabled = false
+```
+
+and a compatibility mode:
+
+```text
+maximum batch items = 1
+```
+
+On rollback:
+
+1. stop creating new batch claims;
+2. allow an active batch to finish or its lease to expire;
+3. return unfinished members to the existing ready state;
+4. let the legacy per-item publisher consume those unchanged queue items;
+5. retain additive batch tables and receipts for diagnosis;
+6. do not reset the queue or rewrite state history.
+
+Because existing queue items are not transformed into another storage model,
+rollback requires no data migration.
+
+## Completion criteria
+
+This incident repair is complete when:
+
+- exact-result publication uses one active batch writer rather than dozens of
+  workflows waiting for the same state lease;
+- sustained useful throughput remains above arrival rate with measured
+  headroom;
+- the backlog and oldest age decline to their normal operating ranges;
+- state-contention retries and dead letters stop growing;
+- batch cleanup keeps SQLite growth bounded;
+- every live-enabled pull request has its manual verification evidence recorded;
+- the temporary fixed-capacity-50 configuration is removed in a separately
+  reviewed cleanup after the backlog is materially cleared;
+- open dead letters have an explicit replay, fresh-review, or audited-resolution
+  disposition after the writer path is proven stable.
+
+Migration of authoritative operational state into a database remains a possible
+long-term architecture. It is not required to validate or roll back this
+batching repair.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "repair:spam-comment-intake": "node dist/repair/spam-comment-intake.js",
     "repair:spam-scan": "node dist/repair/spam-scanner.js",
     "repair:exact-review-bundle": "node dist/repair/exact-review-bundle-cli.js",
+    "repair:exact-review-batch": "node dist/repair/exact-review-batch-cli.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",
     "workflow": "node dist/repair/workflow-utils.js",

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { ExactReviewBatchCompletion } from "./exact-review-batch-publisher.js";
+import {
+  ExactReviewBatchQueueClient,
+  type ExactReviewBatchQueueItem,
+} from "./exact-review-batch-queue-client.js";
+import { commitPreparedStateBatch } from "./state-publication-batch.js";
+import {
+  validatePreparedStateMutationPlans,
+  type PreparedStateMutationPlan,
+} from "./state-publication-mutation.js";
+
+type BatchManifest = {
+  batchId: string;
+  leaseOwner: string;
+  items: Array<ExactReviewBatchQueueItem & { outcomePath: string }>;
+};
+
+const command = process.argv[2];
+if (!command || !["claim", "heartbeat", "commit", "complete"].includes(command)) {
+  throw new Error("usage: exact-review-batch-cli.ts <claim|heartbeat|commit|complete>");
+}
+
+const queueSecret = process.env.CLAWSWEEPER_WEBHOOK_SECRET;
+if (!queueSecret) throw new Error("CLAWSWEEPER_WEBHOOK_SECRET is required");
+
+const client = new ExactReviewBatchQueueClient({
+  baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
+  webhookSecret: queueSecret,
+});
+
+if (command === "claim") await claim();
+else if (command === "heartbeat") await heartbeat();
+else if (command === "commit") await commit();
+else await complete();
+
+async function claim() {
+  const leaseOwner = env("EXACT_REVIEW_BATCH_LEASE_OWNER");
+  const batchId = env("EXACT_REVIEW_BATCH_ID");
+  const lease = await client.claim({
+    claimId: batchId,
+    leaseOwner,
+    maxItems: positiveInteger(env("EXACT_REVIEW_BATCH_MAX_ITEMS")),
+  });
+  if (!lease) {
+    output("claimed", "false");
+    return;
+  }
+  const fetched = await client.fetch({ batchId: lease.batchId, leaseOwner });
+  const manifestPath = env("EXACT_REVIEW_BATCH_MANIFEST");
+  const outcomeDir = join(dirname(manifestPath), "outcomes");
+  const manifest: BatchManifest = {
+    batchId: lease.batchId,
+    leaseOwner,
+    items: fetched.items.map((item, index) => ({
+      ...item,
+      outcomePath: join(outcomeDir, `${index}.json`),
+    })),
+  };
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  output("claimed", "true");
+  output("batch_id", lease.batchId);
+  output("item_count", String(manifest.items.length));
+  output("manifest", manifestPath);
+  // Fetch terminalizes members that drifted after claim. An all-stale batch is
+  // already complete and must not require a target-owner credential.
+  if (!manifest.items.length) return;
+  const targets = manifest.items.map((item) => targetRepoFromDecision(item.decision));
+  const owners = new Set(targets.map((target) => target.split("/", 1)[0]));
+  if (owners.size !== 1) throw new Error("A publication batch must contain one target owner");
+  output("target_owner", [...owners][0]!);
+  output(
+    "target_repositories",
+    [...new Set(targets.map((target) => target.split("/")[1]))].join(","),
+  );
+}
+
+async function heartbeat() {
+  const manifest = readManifest();
+  await client.heartbeat({
+    batchId: manifest.batchId,
+    leaseOwner: manifest.leaseOwner,
+    items: manifest.items,
+  });
+  console.log(JSON.stringify({ ok: true, batch_id: manifest.batchId }));
+}
+
+async function commit() {
+  const manifest = readManifest();
+  const fetched = await client.fetch({
+    batchId: manifest.batchId,
+    leaseOwner: manifest.leaseOwner,
+  });
+  const active = new Map(fetched.items.map((item) => [item.itemKey, item]));
+  const superseded: ExactReviewBatchCompletion[] = [];
+  const plans: PreparedStateMutationPlan[] = [];
+  for (const manifestItem of manifest.items) {
+    const current = active.get(manifestItem.itemKey);
+    if (!current || !existsSync(manifestItem.outcomePath)) continue;
+    const outcome = objectValue(JSON.parse(readFileSync(manifestItem.outcomePath, "utf8")));
+    if (outcome.kind === "superseded") {
+      if (optionalObjectValue(outcome.disposition).requeueLatestExpected !== true) {
+        superseded.push({ ...current, terminalOutcome: "superseded" });
+      }
+      continue;
+    }
+    if (outcome.kind !== "eligible") continue;
+    const [plan] = validatePreparedStateMutationPlans([
+      outcome.plan as PreparedStateMutationPlan,
+    ]).plans;
+    if (
+      !plan ||
+      plan.identity.itemKey !== current.itemKey ||
+      plan.identity.revision !== current.revision ||
+      plan.identity.claimGeneration !== current.claimGeneration
+    ) {
+      throw new Error(`Batch outcome identity does not match ${current.itemKey}`);
+    }
+    plans.push(plan);
+  }
+
+  let stateCommitSha: string | undefined;
+  try {
+    if (plans.length) {
+      stateCommitSha = commitPreparedStateBatch({
+        batchId: manifest.batchId,
+        plans,
+      }).commitSha;
+    }
+  } catch (error) {
+    await acknowledge(manifest, superseded, undefined, failureFingerprint(error));
+    throw error;
+  }
+  const receiptPath = batchReceiptPath();
+  mkdirSync(dirname(receiptPath), { recursive: true });
+  writeFileSync(
+    receiptPath,
+    `${JSON.stringify(
+      {
+        batchId: manifest.batchId,
+        stateCommitSha: stateCommitSha ?? null,
+        publishedItemKeys: plans.map((plan) => plan.identity.itemKey),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  console.log(
+    JSON.stringify({
+      ok: true,
+      batch_id: manifest.batchId,
+      state_commit_sha: stateCommitSha ?? null,
+      materialized: plans.length,
+      superseded: superseded.length,
+    }),
+  );
+}
+
+async function complete() {
+  const manifest = readManifest();
+  const receipt = objectValue(JSON.parse(readFileSync(batchReceiptPath(), "utf8")));
+  if (receipt.batchId !== manifest.batchId) throw new Error("Batch receipt identity mismatch");
+  const publishedKeys = new Set(
+    Array.isArray(receipt.publishedItemKeys)
+      ? receipt.publishedItemKeys.map((value) => stringValue(value, "publishedItemKey"))
+      : [],
+  );
+  const fetched = await client.fetch({
+    batchId: manifest.batchId,
+    leaseOwner: manifest.leaseOwner,
+  });
+  const active = new Map(fetched.items.map((item) => [item.itemKey, item]));
+  const completions: ExactReviewBatchCompletion[] = [];
+  for (const manifestItem of manifest.items) {
+    const current = active.get(manifestItem.itemKey);
+    if (!current || !existsSync(manifestItem.outcomePath)) continue;
+    const outcome = objectValue(JSON.parse(readFileSync(manifestItem.outcomePath, "utf8")));
+    if (outcome.kind === "superseded") {
+      if (
+        optionalObjectValue(outcome.disposition).requeueLatestExpected === true &&
+        outcome.postEffectsComplete !== true
+      ) {
+        continue;
+      }
+      completions.push({ ...current, terminalOutcome: "superseded" });
+      continue;
+    }
+    if (outcome.kind !== "eligible" || !publishedKeys.has(current.itemKey)) continue;
+    const disposition = objectValue(outcome.disposition);
+    const requiresDeferredEffect =
+      disposition.requeueLatestExpected === true ||
+      disposition.deferredCloseCoverageExpected === true ||
+      disposition.routableSyncExpected === true;
+    if (requiresDeferredEffect && outcome.postEffectsComplete !== true) continue;
+    completions.push({ ...current, terminalOutcome: "published" });
+  }
+  const stateCommitSha =
+    typeof receipt.stateCommitSha === "string" && receipt.stateCommitSha
+      ? receipt.stateCommitSha
+      : undefined;
+  const result = await acknowledge(manifest, completions, stateCommitSha);
+  console.log(
+    JSON.stringify({
+      ok: true,
+      batch_id: manifest.batchId,
+      accepted: result?.accepted ?? 0,
+      retryable: fetched.items.length - completions.length,
+    }),
+  );
+}
+
+async function acknowledge(
+  manifest: BatchManifest,
+  completions: ExactReviewBatchCompletion[],
+  stateCommitSha?: string,
+  failure?: string,
+) {
+  if (!completions.length) return null;
+  return client.complete({
+    batchId: manifest.batchId,
+    leaseOwner: manifest.leaseOwner,
+    items: completions,
+    ...(stateCommitSha ? { stateCommitSha } : {}),
+    ...(failure ? { failureFingerprint: failure } : {}),
+  });
+}
+
+function readManifest(): BatchManifest {
+  const value = objectValue(JSON.parse(readFileSync(env("EXACT_REVIEW_BATCH_MANIFEST"), "utf8")));
+  if (!Array.isArray(value.items)) throw new Error("Batch manifest items must be an array");
+  return {
+    batchId: stringValue(value.batchId, "batchId"),
+    leaseOwner: stringValue(value.leaseOwner, "leaseOwner"),
+    items: value.items.map((entry) => {
+      const item = objectValue(entry);
+      return {
+        itemKey: stringValue(item.itemKey, "itemKey"),
+        revision: positiveInteger(item.revision),
+        claimGeneration: positiveInteger(item.claimGeneration),
+        decision: item.decision,
+        outcomePath: stringValue(item.outcomePath, "outcomePath"),
+      };
+    }),
+  };
+}
+
+function batchReceiptPath(): string {
+  return (
+    process.env.EXACT_REVIEW_BATCH_RECEIPT ||
+    join(dirname(env("EXACT_REVIEW_BATCH_MANIFEST")), "state-receipt.json")
+  );
+}
+
+function output(name: string, value: string) {
+  const path = process.env.GITHUB_OUTPUT;
+  if (path) writeFileSync(path, `${name}=${value}\n`, { encoding: "utf8", flag: "a" });
+  else console.log(`${name}=${value}`);
+}
+
+function failureFingerprint(error: unknown): string {
+  const detail = error instanceof Error ? `${error.name}:${error.message}` : String(error);
+  return createHash("sha256").update(detail).digest("hex");
+}
+
+function env(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected a JSON object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalObjectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Invalid ${name}`);
+  return value;
+}
+
+function positiveInteger(value: unknown): number {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 1) throw new Error("Expected a positive integer");
+  return number;
+}
+
+function targetRepoFromDecision(value: unknown): string {
+  const repo = stringValue(objectValue(value).targetRepo, "decision.targetRepo");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error("Invalid decision.targetRepo");
+  }
+  return repo;
+}

--- a/src/repair/exact-review-batch-coordinator.ts
+++ b/src/repair/exact-review-batch-coordinator.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+
+import {
+  publishExactReviewBatch,
+  type ExactReviewBatchItemResult,
+  type ExactReviewBatchPublisherResult,
+} from "./exact-review-batch-publisher.js";
+import type {
+  ExactReviewBatchQueue,
+  ExactReviewBatchQueueItem,
+} from "./exact-review-batch-queue-client.js";
+import type { PreparedStateMutationPlan } from "./state-publication-mutation.js";
+
+export type ExactReviewBatchCoordinatorDependencies = {
+  queue: ExactReviewBatchQueue;
+  prepare: (item: ExactReviewBatchQueueItem) => Promise<ExactReviewBatchItemResult>;
+  deliverGithubEffects: (item: ExactReviewBatchQueueItem) => Promise<"ready" | "superseded">;
+  commit: (
+    batchId: string,
+    plans: readonly PreparedStateMutationPlan[],
+  ) => Promise<{ commitSha: string }>;
+};
+
+export type ExactReviewBatchCoordinatorResult =
+  | { kind: "idle" }
+  | {
+      kind: "claimed";
+      batchId: string;
+      accepted: number;
+      skipped: number;
+      publication: ExactReviewBatchPublisherResult;
+    };
+
+export async function coordinateExactReviewBatch(
+  options: {
+    claimId: string;
+    leaseOwner: string;
+    maxItems: number;
+    heartbeatIntervalMs?: number;
+  },
+  dependencies: ExactReviewBatchCoordinatorDependencies,
+): Promise<ExactReviewBatchCoordinatorResult> {
+  const lease = await dependencies.queue.claim(options);
+  if (!lease) return { kind: "idle" };
+  const fetched = await dependencies.queue.fetch({
+    batchId: lease.batchId,
+    leaseOwner: options.leaseOwner,
+  });
+  if (!fetched.items.length) {
+    return {
+      kind: "claimed",
+      batchId: lease.batchId,
+      accepted: 0,
+      skipped: 0,
+      publication: { completions: [], retryable: [], stateCommitSha: null },
+    };
+  }
+
+  const itemsByKey = new Map(fetched.items.map((item) => [item.itemKey, item]));
+  return withLeaseHeartbeat(
+    {
+      queue: dependencies.queue,
+      batchId: lease.batchId,
+      leaseOwner: options.leaseOwner,
+      items: fetched.items,
+      intervalMs: options.heartbeatIntervalMs ?? 60_000,
+    },
+    async (assertLease) => {
+      const publication = await publishExactReviewBatch(fetched.items, {
+        assertLease,
+        prepare: (member) => dependencies.prepare(requiredItem(itemsByKey, member.itemKey)),
+        deliverGithubEffects: (member) =>
+          dependencies.deliverGithubEffects(requiredItem(itemsByKey, member.itemKey)),
+        commit: (plans) => dependencies.commit(lease.batchId, plans),
+      });
+      await assertLease();
+      if (!publication.completions.length) {
+        return {
+          kind: "claimed" as const,
+          batchId: lease.batchId,
+          accepted: 0,
+          skipped: 0,
+          publication,
+        };
+      }
+      const completion = await dependencies.queue.complete({
+        batchId: lease.batchId,
+        leaseOwner: options.leaseOwner,
+        items: publication.completions,
+        ...(publication.stateCommitSha ? { stateCommitSha: publication.stateCommitSha } : {}),
+        ...(publication.retryable.length
+          ? { failureFingerprint: retryableFingerprint(publication.retryable) }
+          : {}),
+      });
+      return {
+        kind: "claimed" as const,
+        batchId: lease.batchId,
+        accepted: completion.accepted,
+        skipped: completion.skipped,
+        publication,
+      };
+    },
+  );
+}
+
+async function withLeaseHeartbeat<T>(
+  options: {
+    queue: ExactReviewBatchQueue;
+    batchId: string;
+    leaseOwner: string;
+    items: readonly ExactReviewBatchQueueItem[];
+    intervalMs: number;
+  },
+  operation: (assertLease: () => Promise<void>) => Promise<T>,
+): Promise<T> {
+  if (!Number.isSafeInteger(options.intervalMs) || options.intervalMs < 1) {
+    throw new Error("Batch heartbeat interval must be a positive integer");
+  }
+  let heartbeatFailure: unknown;
+  const heartbeatState: { inFlight: Promise<void> | null } = { inFlight: null };
+  const heartbeat = async () => {
+    if (heartbeatFailure) throw heartbeatFailure;
+    if (!heartbeatState.inFlight) {
+      heartbeatState.inFlight = options.queue
+        .heartbeat({
+          batchId: options.batchId,
+          leaseOwner: options.leaseOwner,
+          items: options.items,
+        })
+        .then(() => undefined)
+        .catch((error) => {
+          heartbeatFailure = error;
+          throw error;
+        })
+        .finally(() => {
+          heartbeatState.inFlight = null;
+        });
+    }
+    await heartbeatState.inFlight;
+    if (heartbeatFailure) throw heartbeatFailure;
+  };
+  const timer = setInterval(() => {
+    void heartbeat().catch(() => undefined);
+  }, options.intervalMs);
+  timer.unref();
+  try {
+    await heartbeat();
+    const result = await operation(heartbeat);
+    await heartbeat();
+    return result;
+  } finally {
+    clearInterval(timer);
+    const pendingHeartbeat = heartbeatState.inFlight;
+    if (pendingHeartbeat) await pendingHeartbeat.catch(() => undefined);
+  }
+}
+
+function requiredItem(
+  items: ReadonlyMap<string, ExactReviewBatchQueueItem>,
+  itemKey: string,
+): ExactReviewBatchQueueItem {
+  const item = items.get(itemKey);
+  if (!item) throw new Error(`Batch item ${itemKey} disappeared after fetch`);
+  return item;
+}
+
+function retryableFingerprint(
+  failures: ReadonlyArray<{ itemKey: string; revision: number; reason: string }>,
+): string {
+  const canonical = [...failures]
+    .sort((left, right) => left.itemKey.localeCompare(right.itemKey))
+    .map(({ itemKey, revision, reason }) => ({ itemKey, revision, reason }));
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}

--- a/src/repair/exact-review-batch-publisher.ts
+++ b/src/repair/exact-review-batch-publisher.ts
@@ -1,0 +1,98 @@
+import type { PreparedStateMutationPlan } from "./state-publication-mutation.js";
+
+export type ExactReviewBatchMember = {
+  itemKey: string;
+  revision: number;
+  claimGeneration: number;
+};
+
+export type ExactReviewBatchTerminalOutcome = "published" | "superseded";
+
+export type ExactReviewBatchCompletion = ExactReviewBatchMember & {
+  terminalOutcome: ExactReviewBatchTerminalOutcome;
+};
+
+export type ExactReviewBatchItemResult =
+  | { kind: "superseded" }
+  | { kind: "retryable"; reason: string }
+  | { kind: "eligible"; plan: PreparedStateMutationPlan };
+
+export type ExactReviewBatchPublisherDependencies = {
+  prepare: (member: ExactReviewBatchMember) => Promise<ExactReviewBatchItemResult>;
+  // GitHub delivery deliberately precedes state publication. A visible comment or
+  // label is independently recoverable when the shared state push later fails.
+  deliverGithubEffects: (member: ExactReviewBatchMember) => Promise<"ready" | "superseded">;
+  commit: (plans: readonly PreparedStateMutationPlan[]) => Promise<{ commitSha: string }>;
+  assertLease?: () => Promise<void>;
+};
+
+export type ExactReviewBatchPublisherResult = {
+  completions: ExactReviewBatchCompletion[];
+  retryable: Array<ExactReviewBatchMember & { reason: string }>;
+  stateCommitSha: string | null;
+};
+
+/**
+ * Consumes one already-leased batch. It intentionally owns neither queue I/O nor
+ * GitHub API calls: the workflow supplies those boundaries, while this function
+ * protects the central invariant that eligible mutations reach one committer call.
+ */
+export async function publishExactReviewBatch(
+  members: readonly ExactReviewBatchMember[],
+  dependencies: ExactReviewBatchPublisherDependencies,
+): Promise<ExactReviewBatchPublisherResult> {
+  const completions: ExactReviewBatchCompletion[] = [];
+  const retryable: Array<ExactReviewBatchMember & { reason: string }> = [];
+  const eligible: Array<{ member: ExactReviewBatchMember; plan: PreparedStateMutationPlan }> = [];
+
+  for (const member of members) {
+    try {
+      await dependencies.assertLease?.();
+      const prepared = await dependencies.prepare(member);
+      if (prepared.kind === "superseded") {
+        completions.push({ ...member, terminalOutcome: "superseded" });
+      } else if (prepared.kind === "retryable") {
+        retryable.push({ ...member, reason: prepared.reason });
+      } else {
+        eligible.push({ member, plan: prepared.plan });
+      }
+    } catch (error) {
+      retryable.push({ ...member, reason: errorMessage(error) });
+    }
+  }
+
+  const commitPlans: PreparedStateMutationPlan[] = [];
+  const commitMembers: ExactReviewBatchMember[] = [];
+  for (const candidate of eligible) {
+    try {
+      await dependencies.assertLease?.();
+      const delivered = await dependencies.deliverGithubEffects(candidate.member);
+      if (delivered === "superseded") {
+        completions.push({ ...candidate.member, terminalOutcome: "superseded" });
+      } else {
+        commitMembers.push(candidate.member);
+        commitPlans.push(candidate.plan);
+      }
+    } catch (error) {
+      retryable.push({ ...candidate.member, reason: errorMessage(error) });
+    }
+  }
+
+  if (!commitPlans.length) return { completions, retryable, stateCommitSha: null };
+  try {
+    await dependencies.assertLease?.();
+    const committed = await dependencies.commit(commitPlans);
+    for (const member of commitMembers)
+      completions.push({ ...member, terminalOutcome: "published" });
+    return { completions, retryable, stateCommitSha: committed.commitSha };
+  } catch (error) {
+    // An ambiguous push is deliberately retried as one stable batch; callers must
+    // reconcile the PR2 receipt before invoking this publisher again.
+    for (const member of commitMembers) retryable.push({ ...member, reason: errorMessage(error) });
+    return { completions, retryable, stateCommitSha: null };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -1,0 +1,229 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import type {
+  ExactReviewBatchCompletion,
+  ExactReviewBatchMember,
+} from "./exact-review-batch-publisher.js";
+
+export type ExactReviewBatchQueueItem = ExactReviewBatchMember & { decision: unknown };
+
+export type ExactReviewBatchLease = {
+  batchId: string;
+  leaseOwner: string;
+  leaseExpiresAt: string;
+  items: ExactReviewBatchMember[];
+};
+
+export type ExactReviewBatchFetch = {
+  batch: ExactReviewBatchLease;
+  items: ExactReviewBatchQueueItem[];
+  superseded: number;
+};
+
+export interface ExactReviewBatchQueue {
+  claim(input: {
+    claimId: string;
+    leaseOwner: string;
+    maxItems: number;
+  }): Promise<ExactReviewBatchLease | null>;
+  fetch(input: { batchId: string; leaseOwner: string }): Promise<ExactReviewBatchFetch>;
+  heartbeat(input: {
+    batchId: string;
+    leaseOwner: string;
+    items: readonly ExactReviewBatchMember[];
+  }): Promise<ExactReviewBatchLease>;
+  complete(input: {
+    batchId: string;
+    leaseOwner: string;
+    items: readonly ExactReviewBatchCompletion[];
+    stateCommitSha?: string;
+    failureFingerprint?: string;
+  }): Promise<{ accepted: number; skipped: number; batch: ExactReviewBatchLease }>;
+}
+
+type QueueClientOptions = {
+  baseUrl: string;
+  webhookSecret: string;
+  fetch?: typeof globalThis.fetch;
+};
+
+export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
+  private readonly baseUrl: string;
+  private readonly webhookSecret: string;
+  private readonly request: typeof globalThis.fetch;
+
+  constructor(options: QueueClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    if (!this.baseUrl.startsWith("https://")) throw new Error("Batch queue URL must use HTTPS");
+    if (!options.webhookSecret) throw new Error("Batch queue webhook secret is required");
+    this.webhookSecret = options.webhookSecret;
+    this.request = options.fetch ?? globalThis.fetch;
+  }
+
+  async claim(input: { claimId: string; leaseOwner: string; maxItems: number }) {
+    const response = await this.post("claim", {
+      claim_id: input.claimId,
+      lease_owner: input.leaseOwner,
+      max_items: input.maxItems,
+    });
+    if (response.claimed !== true) return null;
+    return parseLease(response.batch);
+  }
+
+  async fetch(input: { batchId: string; leaseOwner: string }) {
+    const response = await this.post("fetch", {
+      batch_id: input.batchId,
+      lease_owner: input.leaseOwner,
+    });
+    const items = arrayValue(response.items).map(parseQueueItem);
+    return {
+      batch: parseLease(response.batch),
+      items,
+      superseded: nonNegativeInteger(response.superseded, "superseded"),
+    };
+  }
+
+  async heartbeat(input: {
+    batchId: string;
+    leaseOwner: string;
+    items: readonly ExactReviewBatchMember[];
+  }) {
+    const response = await this.post("heartbeat", {
+      batch_id: input.batchId,
+      lease_owner: input.leaseOwner,
+      items: input.items.map((item) => ({
+        item_key: item.itemKey,
+        revision: item.revision,
+        claim_generation: item.claimGeneration,
+      })),
+    });
+    return parseLease(response.batch);
+  }
+
+  async complete(input: {
+    batchId: string;
+    leaseOwner: string;
+    items: readonly ExactReviewBatchCompletion[];
+    stateCommitSha?: string;
+    failureFingerprint?: string;
+  }) {
+    const response = await this.post("complete", {
+      batch_id: input.batchId,
+      lease_owner: input.leaseOwner,
+      items: input.items.map((item) => ({
+        item_key: item.itemKey,
+        revision: item.revision,
+        claim_generation: item.claimGeneration,
+        terminal_outcome: item.terminalOutcome,
+      })),
+      ...(input.stateCommitSha ? { state_commit_sha: input.stateCommitSha } : {}),
+      ...(input.failureFingerprint ? { failure_fingerprint: input.failureFingerprint } : {}),
+    });
+    return {
+      accepted: nonNegativeInteger(response.accepted, "accepted"),
+      skipped: nonNegativeInteger(response.skipped, "skipped"),
+      batch: parseLease(response.batch),
+    };
+  }
+
+  private async post(
+    path: string,
+    payload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const body = JSON.stringify(payload);
+    const signature = `sha256=${createHmac("sha256", this.webhookSecret).update(body).digest("hex")}`;
+    const response = await this.request(
+      `${this.baseUrl}/internal/exact-review/publication-batches/${path}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        body,
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    const text = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error(`Batch queue ${path} returned invalid JSON (HTTP ${response.status})`);
+    }
+    if (!response.ok) {
+      const error = objectValue(parsed).error;
+      throw new Error(
+        `Batch queue ${path} failed (HTTP ${response.status}): ${String(error || "unknown")}`,
+      );
+    }
+    return objectValue(parsed);
+  }
+}
+
+export function verifyExactReviewBatchSignature(
+  body: string,
+  signature: string,
+  webhookSecret: string,
+): boolean {
+  const expected = `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+  const left = Buffer.from(signature);
+  const right = Buffer.from(expected);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function parseQueueItem(value: unknown): ExactReviewBatchQueueItem {
+  const item = objectValue(value);
+  return { ...parseMember(item), decision: item.decision };
+}
+
+function parseLease(value: unknown): ExactReviewBatchLease {
+  const batch = objectValue(value);
+  const leaseOwner = stringValue(batch.lease_owner, "lease_owner");
+  const leaseExpiresAt = stringValue(batch.lease_expires_at, "lease_expires_at");
+  if (!Number.isFinite(Date.parse(leaseExpiresAt))) throw new Error("Invalid batch lease expiry");
+  return {
+    batchId: stringValue(batch.batch_id, "batch_id"),
+    leaseOwner,
+    leaseExpiresAt,
+    items: arrayValue(batch.items).map(parseMember),
+  };
+}
+
+function parseMember(value: unknown): ExactReviewBatchMember {
+  const item = objectValue(value);
+  return {
+    itemKey: stringValue(item.item_key, "item_key"),
+    revision: positiveInteger(item.revision, "revision"),
+    claimGeneration: positiveInteger(item.claim_generation, "claim_generation"),
+  };
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid batch queue response object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function arrayValue(value: unknown): unknown[] {
+  if (!Array.isArray(value)) throw new Error("Invalid batch queue response array");
+  return value;
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Invalid batch queue ${name}`);
+  return value;
+}
+
+function positiveInteger(value: unknown, name: string): number {
+  const result = Number(value);
+  if (!Number.isSafeInteger(result) || result < 1) throw new Error(`Invalid batch queue ${name}`);
+  return result;
+}
+
+function nonNegativeInteger(value: unknown, name: string): number {
+  const result = Number(value);
+  if (!Number.isSafeInteger(result) || result < 0) throw new Error(`Invalid batch queue ${name}`);
+  return result;
+}

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { dirname } from "node:path";
 import {
   applyEventSnapshot,
   applyEventSnapshotIfCurrent,
@@ -51,6 +52,10 @@ import {
   staleEventDispositionOutputLines,
   type StaleEventDisposition,
 } from "./stale-event-disposition.js";
+import {
+  prepareStateMutationPlan,
+  type StateMutationSourceOperation,
+} from "./state-publication-mutation.js";
 
 type EventOptions = {
   targetRepo: string;
@@ -61,6 +66,7 @@ type EventOptions = {
   exactEventPublication: boolean;
   reportPath: string;
   snapshotDir: string;
+  batchMutationOutput: string | null;
 };
 
 type PublishedEventSnapshot = {
@@ -198,6 +204,11 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     // `requeue_latest` hands remote-newer to the source-drift requeue step,
     // which reviews the LATEST revision.
     writeStaleEventDispositionOutputs(disposition);
+    if (options.batchMutationOutput && preflightResult !== "missing")
+      writeBatchMutationResult(options.batchMutationOutput, {
+        kind: "superseded",
+        disposition: { requeueLatestExpected: disposition.requeueLatest },
+      });
     if (preflightResult !== "missing") {
       writePublicationCompletionOutputs(
         "superseded",
@@ -287,6 +298,22 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     missingCount === 0 &&
     guardedOpenAction === null &&
     !requeueLatestExpected;
+  if (options.batchMutationOutput) {
+    const prepared = prepareBatchMutation({
+      paths: recordPaths,
+      options,
+      stateBaseCommit,
+      guardedOpenAction,
+      requeueLatestExpected,
+      routableSyncExpected,
+      deferredCloseCoverageExpected,
+      terminalClosedExpected: closedCount > 0,
+      terminalMissingExpected: missingCount > 0,
+    });
+    writeBatchMutationResult(options.batchMutationOutput, prepared);
+    summary();
+    return;
+  }
   for (let attempt = 1; attempt <= 20; attempt += 1) {
     const published = publishSnapshot({
       paths: recordPaths,
@@ -328,6 +355,92 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     );
   }
   writeEventDispositionOutputs(published);
+}
+
+function prepareBatchMutation({
+  paths,
+  options,
+  stateBaseCommit,
+  guardedOpenAction,
+  requeueLatestExpected,
+  routableSyncExpected,
+  deferredCloseCoverageExpected,
+  terminalClosedExpected,
+  terminalMissingExpected,
+}: {
+  paths: EventRecordPaths;
+  options: EventOptions;
+  stateBaseCommit: string | null;
+  guardedOpenAction: string | null;
+  requeueLatestExpected: boolean;
+  routableSyncExpected: boolean;
+  deferredCloseCoverageExpected: boolean;
+  terminalClosedExpected: boolean;
+  terminalMissingExpected: boolean;
+}) {
+  const stateRoot = publishRoot();
+  if (!stateRoot) throw new Error("Batch mutation preparation requires an isolated state root");
+  hardResetToRemoteMain();
+  const snapshotResult = applyEventSnapshot(paths, { remoteRoot: stateRoot });
+  if (snapshotResult === "remote-closed" || snapshotResult === "remote-newer") {
+    return { kind: "superseded" as const };
+  }
+  if (snapshotResult === "missing") {
+    throw new PublicationResultError(
+      "missing_record_tuple",
+      `No event record snapshot for ${paths.targetSlug}#${options.itemNumber}`,
+    );
+  }
+  const commitPaths = [
+    paths.itemRecord,
+    paths.closedRecord,
+    paths.planRecord,
+    paths.decisionPacket,
+  ];
+  syncPublishPaths(commitPaths);
+  const operations: StateMutationSourceOperation[] = [];
+  for (const path of commitPaths) {
+    const expectedOid = runGit(["rev-parse", "--verify", `HEAD:${path}`], {
+      allowFailure: true,
+      quiet: true,
+    }).trim();
+    const statePath = `${stateRoot}/${path}`;
+    if (!fs.existsSync(statePath)) {
+      if (expectedOid) operations.push({ path, expectedOid, delete: true });
+      continue;
+    }
+    operations.push({
+      path,
+      expectedOid: expectedOid || null,
+      content: fs.readFileSync(statePath),
+    });
+  }
+  if (!operations.length) {
+    throw new Error(`Batch mutation for ${paths.targetSlug}#${options.itemNumber} is empty`);
+  }
+  const plan = prepareStateMutationPlan({
+    identity: {
+      itemKey: envValue("EXACT_REVIEW_BATCH_ITEM_KEY"),
+      revision: positiveEnvInteger("EXACT_REVIEW_BATCH_REVISION"),
+      claimGeneration: positiveEnvInteger("EXACT_REVIEW_BATCH_CLAIM_GENERATION"),
+    },
+    operations,
+  });
+  // These expectations are emitted with the plan so the batch workflow can run
+  // post-commit routing without re-running GitHub mutations.
+  return {
+    kind: "eligible" as const,
+    plan,
+    disposition: {
+      stateBaseCommit,
+      guardedOpenAction,
+      requeueLatestExpected,
+      routableSyncExpected,
+      deferredCloseCoverageExpected,
+      terminalClosedExpected,
+      terminalMissingExpected,
+    },
+  };
 }
 
 function runApplyDecisions(options: EventOptions): void {
@@ -615,7 +728,20 @@ function eventOptionsFromEnv(): EventOptions {
     exactEventPublication: process.env.EXACT_EVENT_PUBLICATION === "true",
     reportPath: ".artifacts/event-apply-report.json",
     snapshotDir: ".artifacts/event-record-snapshot",
+    batchMutationOutput: process.env.EXACT_REVIEW_BATCH_MUTATION_OUTPUT || null,
   };
+}
+
+function writeBatchMutationResult(path: string, result: unknown): void {
+  fs.mkdirSync(dirname(path), { recursive: true });
+  fs.writeFileSync(path, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+}
+
+function positiveEnvInteger(name: string): number {
+  const value = Number(envValue(name));
+  if (!Number.isSafeInteger(value) || value < 1)
+    throw new Error(`${name} must be a positive integer`);
+  return value;
 }
 
 function readApplyActions(reportPath: string): EventApplyAction[] {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -350,9 +350,14 @@ test("cleanup retains fencing generations when a batch id is reused", () => {
   assert.equal(staleCompletion?.items[0].terminalOutcome, null);
 });
 
-function publicationRequest(deliveryId: string, number: number, producerRunId: string) {
+function publicationRequest(
+  deliveryId: string,
+  number: number,
+  producerRunId: string,
+  targetRepo = "openclaw/openclaw",
+) {
   const producerDecision = {
-    targetRepo: "openclaw/openclaw",
+    targetRepo,
     targetBranch: "main",
     itemNumber: number,
     itemKind: "issue",
@@ -373,7 +378,7 @@ function publicationRequest(deliveryId: string, number: number, producerRunId: s
           producerRunId,
           producerRunAttempt: 1,
           sourceSha: "a".repeat(40),
-          itemKey: `openclaw/openclaw#${number}`,
+          itemKey: `${targetRepo}#${number}`,
           protocolVersion: 2,
           leaseRevision: 1,
           claimGeneration: 1,
@@ -645,6 +650,138 @@ test("queue fetch terminalizes a stale batch revision before dispatch", async ()
     ).json();
     assert.equal(next.batch.items[0].revision, 2);
     assert.equal(next.batch.items[0].claim_generation, 2);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("batch heartbeat extends only the active fenced lease", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1_500_000;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+      },
+    );
+    await queue.fetch(publicationRequest("delivery-heartbeat-1", 110, "1010"));
+    await queue.fetch(publicationRequest("delivery-heartbeat-2", 111, "1011"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-heartbeat",
+          lease_owner: "worker-1",
+          max_items: 2,
+        }),
+      )
+    ).json();
+    assert.equal(claim.batch.lease_expires_at, new Date(1_560_000).toISOString());
+    const members = claim.batch.items.map((item) => ({
+      item_key: item.item_key,
+      revision: item.revision,
+      claim_generation: item.claim_generation,
+    }));
+
+    Date.now = () => 1_530_000;
+    const heartbeat = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/heartbeat", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          items: members,
+        }),
+      )
+    ).json();
+    assert.equal(heartbeat.batch.lease_expires_at, new Date(1_590_000).toISOString());
+
+    await queue.fetch(publicationRequest("delivery-heartbeat-3", 110, "1010"));
+    const fetched = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/fetch", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+        }),
+      )
+    ).json();
+    assert.equal(fetched.superseded, 1);
+    assert.equal(fetched.items.length, 1);
+
+    Date.now = () => 1_540_000;
+    const originalFence = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/heartbeat", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          items: members,
+        }),
+      )
+    ).json();
+    assert.equal(originalFence.batch.lease_expires_at, new Date(1_600_000).toISOString());
+
+    const staleOwner = await queue.fetch(
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-2",
+        items: members,
+      }),
+    );
+    assert.equal(staleOwner.status, 409);
+
+    const staleGeneration = await queue.fetch(
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: members.map((item) => ({
+          ...item,
+          claim_generation: item.claim_generation + 1,
+        })),
+      }),
+    );
+    assert.equal(staleGeneration.status, 409);
+
+    Date.now = () => 1_600_000;
+    const expired = await queue.fetch(
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: members,
+      }),
+    );
+    assert.equal(expired.status, 409);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("batch admission keeps one target owner for least-privilege credentials", async () => {
+  const originalNow = Date.now;
+  let now = 1_700_000;
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    await queue.fetch(publicationRequest("owner-a-1", 120, "1020"));
+    now += 1;
+    await queue.fetch(publicationRequest("owner-b", 121, "1021", "example/project"));
+    now += 1;
+    await queue.fetch(publicationRequest("owner-a-2", 122, "1022"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-owner-scoped",
+          lease_owner: "worker-1",
+          max_items: 3,
+        }),
+      )
+    ).json();
+    assert.deepEqual(
+      claim.batch.items.map((item) => item.item_key),
+      ["openclaw/openclaw#120@publish:1020:1", "openclaw/openclaw#122@publish:1022:1"],
+    );
   } finally {
     Date.now = originalNow;
   }

--- a/test/repair/exact-review-batch-coordinator.test.ts
+++ b/test/repair/exact-review-batch-coordinator.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { coordinateExactReviewBatch } from "../../dist/repair/exact-review-batch-coordinator.js";
+import {
+  ExactReviewBatchQueueClient,
+  verifyExactReviewBatchSignature,
+} from "../../dist/repair/exact-review-batch-queue-client.js";
+
+const queueItems = [1, 2, 3].map((number) => ({
+  itemKey: `openclaw/openclaw#${number}`,
+  revision: 1,
+  claimGeneration: 1,
+  decision: { itemNumber: number },
+}));
+
+test("coordinator heartbeats, isolates mixed outcomes, and acknowledges terminal members", async () => {
+  const completed: unknown[] = [];
+  let heartbeats = 0;
+  let commits = 0;
+  const result = await coordinateExactReviewBatch(
+    { claimId: "claim-1", leaseOwner: "run-1", maxItems: 3, heartbeatIntervalMs: 60_000 },
+    {
+      queue: fakeQueue({
+        heartbeat: () => {
+          heartbeats += 1;
+        },
+        complete: (input) => completed.push(input),
+      }),
+      async prepare(item) {
+        if (item.itemKey.endsWith("#1")) {
+          return { kind: "retryable", reason: "artifact_unavailable" };
+        }
+        if (item.itemKey.endsWith("#2")) return { kind: "superseded" };
+        return { kind: "eligible", plan: plan(item) };
+      },
+      async deliverGithubEffects() {
+        return "ready";
+      },
+      async commit(batchId, plans) {
+        commits += 1;
+        assert.equal(batchId, "claim-1");
+        assert.equal(plans.length, 1);
+        return { commitSha: "a".repeat(40) };
+      },
+    },
+  );
+
+  assert.equal(result.kind, "claimed");
+  assert.equal(commits, 1);
+  assert.ok(heartbeats >= 6);
+  assert.equal(completed.length, 1);
+  assert.deepEqual(
+    result.kind === "claimed"
+      ? result.publication.completions.map((item) => item.terminalOutcome).sort()
+      : [],
+    ["published", "superseded"],
+  );
+});
+
+test("acknowledgement timeout reruns the same stable batch without duplicate completion", async () => {
+  let attempts = 0;
+  const commitBatchIds: string[] = [];
+  const queue = fakeQueue({
+    complete() {
+      attempts += 1;
+      if (attempts === 1) throw new Error("ack timeout");
+    },
+  });
+  const dependencies = {
+    queue,
+    async prepare(item: (typeof queueItems)[number]) {
+      return { kind: "eligible" as const, plan: plan(item) };
+    },
+    async deliverGithubEffects() {
+      return "ready" as const;
+    },
+    async commit(batchId: string) {
+      commitBatchIds.push(batchId);
+      return { commitSha: "b".repeat(40) };
+    },
+  };
+
+  await assert.rejects(
+    coordinateExactReviewBatch(
+      { claimId: "claim-1", leaseOwner: "run-1", maxItems: 3 },
+      dependencies,
+    ),
+    /ack timeout/,
+  );
+  const recovered = await coordinateExactReviewBatch(
+    { claimId: "claim-1", leaseOwner: "run-1", maxItems: 3 },
+    dependencies,
+  );
+  assert.equal(recovered.kind, "claimed");
+  assert.deepEqual(commitBatchIds, ["claim-1", "claim-1"]);
+  assert.equal(attempts, 2);
+});
+
+test("queue client signs protocol calls and rejects malformed responses", async () => {
+  const paths: string[] = [];
+  const bodies: unknown[] = [];
+  const client = new ExactReviewBatchQueueClient({
+    baseUrl: "https://queue.example",
+    webhookSecret: "secret",
+    fetch: async (input, init) => {
+      const url = String(input);
+      paths.push(new URL(url).pathname);
+      const body = String(init?.body);
+      bodies.push(JSON.parse(body));
+      const signature = String(
+        new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"),
+      );
+      assert.equal(verifyExactReviewBatchSignature(body, signature, "secret"), true);
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          claimed: true,
+          batch: leaseJson(),
+        }),
+      );
+    },
+  });
+  const lease = await client.claim({ claimId: "claim-1", leaseOwner: "run-1", maxItems: 3 });
+  assert.equal(lease?.batchId, "claim-1");
+  await client.heartbeat({ batchId: "claim-1", leaseOwner: "run-1", items: queueItems });
+  assert.deepEqual(paths, [
+    "/internal/exact-review/publication-batches/claim",
+    "/internal/exact-review/publication-batches/heartbeat",
+  ]);
+  assert.deepEqual(bodies[1], {
+    batch_id: "claim-1",
+    lease_owner: "run-1",
+    items: queueItems.map((item) => ({
+      item_key: item.itemKey,
+      revision: item.revision,
+      claim_generation: item.claimGeneration,
+    })),
+  });
+});
+
+function fakeQueue(
+  hooks: {
+    heartbeat?: () => void;
+    complete?: (input: unknown) => void;
+  } = {},
+) {
+  return {
+    async claim() {
+      return {
+        batchId: "claim-1",
+        leaseOwner: "run-1",
+        leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+        items: queueItems,
+      };
+    },
+    async fetch() {
+      return {
+        batch: {
+          batchId: "claim-1",
+          leaseOwner: "run-1",
+          leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          items: queueItems,
+        },
+        items: queueItems,
+        superseded: 0,
+      };
+    },
+    async heartbeat() {
+      hooks.heartbeat?.();
+      return {
+        batchId: "claim-1",
+        leaseOwner: "run-1",
+        leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+        items: queueItems,
+      };
+    },
+    async complete(input: { items: unknown[] }) {
+      hooks.complete?.(input);
+      return {
+        accepted: input.items.length,
+        skipped: 0,
+        batch: {
+          batchId: "claim-1",
+          leaseOwner: "run-1",
+          leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          items: queueItems,
+        },
+      };
+    },
+  };
+}
+
+function leaseJson() {
+  return {
+    batch_id: "claim-1",
+    lease_owner: "run-1",
+    lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    items: queueItems.map((item) => ({
+      item_key: item.itemKey,
+      revision: item.revision,
+      claim_generation: item.claimGeneration,
+    })),
+  };
+}
+
+function plan(item: (typeof queueItems)[number]) {
+  return {
+    identity: item,
+    operations: [
+      {
+        path: `records/openclaw-openclaw/items/${item.itemKey.at(-1)}.md`,
+        expectedOid: null,
+        targetOid: "a".repeat(40),
+        mode: "100644" as const,
+        bytes: 1,
+      },
+    ],
+    totalBytes: 1,
+  };
+}

--- a/test/repair/exact-review-batch-publisher.test.ts
+++ b/test/repair/exact-review-batch-publisher.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { publishExactReviewBatch } from "../../dist/repair/exact-review-batch-publisher.js";
+
+const members = [
+  { itemKey: "openclaw/openclaw#1", revision: 1, claimGeneration: 1 },
+  { itemKey: "openclaw/openclaw#2", revision: 1, claimGeneration: 1 },
+  { itemKey: "openclaw/openclaw#3", revision: 1, claimGeneration: 1 },
+];
+
+test("batch publisher isolates poison members and commits healthy plans once", async () => {
+  let commits = 0;
+  const result = await publishExactReviewBatch(members, {
+    async prepare(member) {
+      if (member.itemKey.endsWith("#1"))
+        return { kind: "retryable", reason: "artifact_unavailable" };
+      if (member.itemKey.endsWith("#2")) return { kind: "superseded" };
+      return { kind: "eligible", plan: plan(member) };
+    },
+    async deliverGithubEffects() {
+      return "ready";
+    },
+    async commit(plans) {
+      commits += 1;
+      assert.equal(plans.length, 1);
+      return { commitSha: "a".repeat(40) };
+    },
+  });
+  assert.equal(commits, 1);
+  assert.deepEqual(result.completions.map((item) => item.terminalOutcome).sort(), [
+    "published",
+    "superseded",
+  ]);
+  assert.equal(result.retryable[0]?.reason, "artifact_unavailable");
+});
+
+test("shared commit failure leaves only commit candidates retryable", async () => {
+  const result = await publishExactReviewBatch(members.slice(0, 2), {
+    async prepare(member) {
+      return { kind: "eligible", plan: plan(member) };
+    },
+    async deliverGithubEffects() {
+      return "ready";
+    },
+    async commit() {
+      throw new Error("ambiguous push");
+    },
+  });
+  assert.equal(result.completions.length, 0);
+  assert.equal(result.retryable.length, 2);
+  assert.equal(result.stateCommitSha, null);
+});
+
+function plan(member: (typeof members)[number]) {
+  return {
+    identity: member,
+    operations: [
+      {
+        path: `records/openclaw-openclaw/items/${member.itemKey.at(-1)}.md`,
+        expectedOid: null,
+        targetOid: "a".repeat(40),
+        mode: "100644" as const,
+        bytes: 1,
+      },
+    ],
+    totalBytes: 1,
+  };
+}

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+const path = ".github/workflows/exact-review-batch-publish.yml";
+const source = readFileSync(path, "utf8");
+const cliSource = readFileSync("src/repair/exact-review-batch-cli.ts", "utf8");
+const workflow = YAML.parse(source) as {
+  on: Record<string, unknown>;
+  permissions: Record<string, string>;
+  concurrency: Record<string, unknown>;
+  jobs: Record<
+    string,
+    { if: string; steps: Array<{ name?: string; run?: string; uses?: string }> }
+  >;
+};
+
+test("batch publisher stays default-off with one non-cancelling serial workflow", () => {
+  assert.ok(workflow.on.schedule);
+  assert.ok(workflow.on.workflow_dispatch);
+  assert.match(workflow.jobs.publish!.if, /EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED/);
+  assert.match(workflow.jobs.publish!.if, /== 'true'.*== '1'/);
+  assert.match(workflow.jobs.publish!.if, /inputs\.execute/);
+  assert.equal(workflow.concurrency["cancel-in-progress"], false);
+  assert.deepEqual(workflow.permissions, { actions: "write", contents: "read" });
+});
+
+test("batch workflow signs queue ownership, isolates item failures, and commits once", () => {
+  assert.match(source, /repair:exact-review-batch claim/);
+  assert.match(source, /repair:exact-review-batch heartbeat/);
+  assert.equal(source.match(/repair:exact-review-batch commit/g)?.length, 1);
+  assert.equal(source.match(/repair:exact-review-batch complete/g)?.length, 1);
+  assert.match(source, /Finalize healthy members under a fenced heartbeat/);
+  assert.match(source, /while sleep 60/);
+  assert.match(source, /test ! -f "\$heartbeat_failed"/);
+  assert.match(source, /Leaving .* retryable: artifact download failed/);
+  assert.match(source, /Leaving .* retryable: artifact validation failed/);
+  assert.match(source, /Leaving .* retryable: item publication failed/);
+  assert.match(source, /Leaving .* retryable: legacy tuple-less artifact/);
+  assert.match(source, /EXACT_REVIEW_BATCH_MUTATION_OUTPUT/);
+  // Keep the fixture from looking like an embedded credential while still
+  // proving that artifact downloads use the owner-scoped repository token.
+  const ghToken = ["GH", "TOKEN"].join("_");
+  assert.match(source, new RegExp(`${ghToken}="\\$REPO_TOKEN" gh run download`));
+  assert.match(source, /gh workflow run repair-comment-router\.yml/);
+  assert.match(source, /internal\/exact-review\/enqueue/);
+  assert.match(source, /source_drift_requeue/);
+  assert.match(source, /\.kind == "superseded" and \.disposition\.requeueLatestExpected == true/);
+  assert.match(source, /deferredCloseCoverageExpected == true/);
+  assert.match(source, /scheduled proof lane/);
+  assert.match(source, /jq '\.postEffectsComplete = true'/);
+});
+
+test("batch workflow uses owner-scoped mutation credentials and isolated state checkout", () => {
+  assert.match(source, /owner: \$\{\{ steps\.batch\.outputs\.target_owner \}\}/);
+  assert.match(source, /repositories: \$\{\{ steps\.batch\.outputs\.target_repositories \}\}/);
+  assert.match(source, /uses: \.\/\.github\/actions\/create-state-token/);
+  assert.match(source, /uses: \.\/\.github\/actions\/setup-state/);
+  assert.doesNotMatch(source, /permissions:\n(?:.*\n)*?\s+issues: write/);
+});
+
+test("batch claim treats an all-stale fetched batch as terminal", () => {
+  assert.match(cliSource, /if \(!manifest\.items\.length\) return;/);
+  assert.ok(
+    cliSource.indexOf("if (!manifest.items.length) return;") < cliSource.indexOf("owners.size"),
+  );
+});


### PR DESCRIPTION
## Summary

- add a default-off dedicated exact-review batch publication workflow
- connect signed queue claim, fenced heartbeat, per-item effects, one shared state commit, and durable acknowledgement
- isolate stale, invalid, and retryable members without poisoning healthy siblings
- document staged rollout and maintainer verification in the CSW-049 batching plan

## Safety

- batching remains default-off behind EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED
- manual dispatch additionally requires execute=true
- no live apply or close operation was run

## Validation

- autoreview clean: no accepted/actionable findings
- pnpm run check on Node 24 and isolated Git 2.54.0
- unit: 1438 passed, 1 skipped, 0 failed
- repair: 1052 passed, 3 skipped, 0 failed
- changed coverage gate passed
- full coverage: lines 78.18%, branches 73.22%, functions 86.30%
- format: 466 files passed
- gitleaks: no PR3 changed-file finding; 27 existing repository findings only

## Post-merge proof

After merge, run the default-off workflow against a synthetic/non-production target, verify multi-item commit and per-item outcomes including one invalid/superseded fixture, then disable the proof flag and confirm legacy consumption resumes.