### PR TITLE
fix(repair): tolerate partial state acks; 30-min drain lease default

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -321,7 +321,9 @@ const STATE_APPEND_KINDS = new Set<StateAppendKind>([
 const DEFAULT_STATE_APPEND_MAX_PENDING_ROWS = 50_000;
 const DEFAULT_STATE_APPEND_MAX_PENDING_BYTES = 100 * 1024 * 1024;
 const DEFAULT_STATE_APPEND_MAX_RECORD_BYTES = 256 * 1024;
-const DEFAULT_STATE_APPEND_DRAIN_LEASE_MS = 10 * 60 * 1000;
+// Must outlast a worst-case materializer publish (observed 17 min under
+// residual lease contention during the #738 transition).
+const DEFAULT_STATE_APPEND_DRAIN_LEASE_MS = 30 * 60 * 1000;
 const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
 const EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE = "exact_review_state_writer_operations";

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -283,9 +283,7 @@ export async function runStateMaterializer(
         fetchImpl,
       });
       if (acked > drain.records.length) {
-        throw new Error(
-          `state ack count ${acked} exceeded drained count ${drain.records.length}`,
-        );
+        throw new Error(`state ack count ${acked} exceeded drained count ${drain.records.length}`);
       }
       if (acked < drain.records.length) {
         // An expired drain lease re-exposes the rows for the next cycle and a

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -283,8 +283,11 @@ export async function runStateMaterializer(
         fetchImpl,
       });
       if (acked !== drain.records.length) {
-        throw new Error(
-          `state ack count ${acked} did not match drained count ${drain.records.length}`,
+        // An expired drain lease re-exposes the rows for the next cycle and a
+        // re-materialization of already-applied records commits nothing, so a
+        // partial ack is re-delivery by design, not a failure.
+        console.warn(
+          `state ack count ${acked} did not match drained count ${drain.records.length}; rows re-drain next cycle`,
         );
       }
       summary.acked += acked;

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -282,12 +282,17 @@ export async function runStateMaterializer(
         drainToken: drain.token,
         fetchImpl,
       });
-      if (acked !== drain.records.length) {
+      if (acked > drain.records.length) {
+        throw new Error(
+          `state ack count ${acked} exceeded drained count ${drain.records.length}`,
+        );
+      }
+      if (acked < drain.records.length) {
         // An expired drain lease re-exposes the rows for the next cycle and a
         // re-materialization of already-applied records commits nothing, so a
         // partial ack is re-delivery by design, not a failure.
         console.warn(
-          `state ack count ${acked} did not match drained count ${drain.records.length}; rows re-drain next cycle`,
+          `state ack count ${acked} was below drained count ${drain.records.length}; rows re-drain next cycle`,
         );
       }
       summary.acked += acked;


### PR DESCRIPTION
First live materialization cycle (run drained=12 committed=6) proved the pipeline but ended errors=1: the publish took 17 min under residual lease contention, the 10-min drain lease expired, and the ack matched 0 rows.

Changes: partial acks (acked < drained) are now a warning — expired-lease re-delivery is by design and re-materialization no-ops; over-acks (acked > drained) stay fatal (protocol corruption). DO drain-lease default raised 10 → 30 min to outlast worst-case publishes during the transition.

Validation: materializer + DO tests green; build/lint/format green; autoreview clean (0.98) after keeping over-ack fatal per review.
