### PR TITLE
docs(crabbox): resolve provider before selecting lane

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -5,20 +5,37 @@ description: Use the Crabbox wrapper for validation across Linux, macOS, Windows
 
 # Crabbox
 
-Use the Crabbox wrapper when OpenClaw needs remote Linux proof for broad tests,
-CI-parity checks, secrets, hosted services, Docker/E2E/package lanes, warmed
-reusable boxes, sync timing, logs/results, cache inspection, or lease cleanup.
+## Provider Selection Contract
+
+Resolve the provider before deciding whether validation is local or remote. Run
+`crabbox config show` from the exact worktree being tested; a session may have
+started in another checkout whose repository config or skill text is stale. A
+request to "use Crabbox" does not authorize a provider override. When the user
+does not name a backend, omit `--provider` and preserve the resolved provider,
+including `local-container` from user config or `CRABBOX_PROVIDER`.
+
+`local-container` is an isolated Crabbox backend, not a broad test running
+directly on the laptop. Broad gates may run there when it is the resolved
+provider. Override it only when the user or an indispensable proof requirement
+explicitly names a different backend; explain that requirement before starting
+the override.
+
+Use the Crabbox wrapper when OpenClaw needs isolated Linux proof for broad
+tests, CI-parity checks, secrets, hosted services, Docker/E2E/package lanes,
+warmed reusable boxes, sync timing, logs/results, cache inspection, or lease
+cleanup.
 
 Crabbox is the transport/orchestration surface. The actual backend can be:
 
+- local Docker isolation: `provider=local-container`, lease ids like `cbx_...`
 - brokered AWS Crabbox: direct provider, `provider=aws`, lease ids like
   `cbx_...`, `syncDelegated=false`
 - Blacksmith Testbox through Crabbox: delegated provider,
   `provider=blacksmith-testbox`, ids like `tbx_...`, `syncDelegated=true`
 
 For OpenClaw maintainer broad `pnpm` gates, Blacksmith Testbox through the
-Crabbox wrapper is acceptable and often preferred when the standing Testbox
-rules apply. Do not describe those runs as "AWS Crabbox"; report them as
+Crabbox wrapper is acceptable when the resolved provider or requested proof
+lane selects it. Do not describe those runs as "AWS Crabbox"; report them as
 Testbox-through-Crabbox with the `tbx_...` id and Actions run.
 
 Use the repo `.crabbox.yaml` brokered AWS path when the task specifically needs
@@ -62,12 +79,13 @@ command -v crabbox
   config pins hot `eu-west-1a/b/c` placement so Fast Snapshot Restore can apply.
   If warmup drifts well past the minute-scale path, verify image promotion,
   region/AZ placement, and FSR state before blaming OpenClaw.
-- For broad OpenClaw maintainer `pnpm` gates, prefer the repo wrapper with
-  `--provider blacksmith-testbox` or the repo Testbox helpers when the standing
-  Testbox policy applies.
-- Always report the actual provider and id. `cbx_...` means AWS Crabbox;
-  `tbx_...` means Blacksmith Testbox through Crabbox. If the output only says
-  `blacksmith testbox list`, use `blacksmith testbox list --all` before
+- For broad OpenClaw maintainer `pnpm` gates, use the resolved provider. Select
+  `--provider blacksmith-testbox` or the repo Testbox helpers only when the user
+  or an indispensable proof requirement specifically calls for Testbox.
+- Always report the provider field and id. Both local-container and direct
+  providers can use `cbx_...`, so the id prefix alone does not prove AWS;
+  `tbx_...` identifies Blacksmith Testbox through Crabbox. If the output only
+  says `blacksmith testbox list`, use `blacksmith testbox list --all` before
   concluding no box exists.
 - If a warm direct-provider lease smells stale, retry with `--full-resync`
   (alias `--fresh-sync`) before replacing the lease. This resets the remote
@@ -79,7 +97,8 @@ command -v crabbox
   not leave it in remote shell history or logs. If no secret-safe injection path
   is available, say true live provider auth is blocked instead of silently using
   a fake key.
-- Prefer local targeted tests for tight edit loops. Broad gates belong remote.
+- Prefer local targeted tests for tight edit loops. Keep broad gates inside the
+  resolved Crabbox backend; `local-container` satisfies this isolation boundary.
 - Do not treat unrelated inherited shell controls as operator intent. In
   particular, `OPENCLAW_LOCAL_CHECK_MODE=throttled` from the local shell is not
   permission to move broad `pnpm check:changed`, `pnpm test:changed`, full

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -32,7 +32,9 @@ Crabbox is the transport/orchestration surface. The actual backend can be:
 
 The provider-specific sections below document capabilities and commands after
 configuration or an explicit user request has selected a backend. They are not
-provider-selection policy.
+provider-selection policy. Their validation commands intentionally omit
+`--provider`; add it only to carry out an explicit user override of the resolved
+configuration.
 
 When the resolved configuration selects Blacksmith Testbox, or the user
 explicitly requests it, do not describe the run as "AWS Crabbox". Report it as
@@ -77,7 +79,7 @@ command -v crabbox
   If warmup drifts well past the minute-scale path, verify image promotion,
   region/AZ placement, and FSR state before blaming OpenClaw.
 - Targeted and broad `pnpm` gates both use the resolved provider. Test size does
-  not authorize `--provider blacksmith-testbox` or another override.
+  not authorize a provider override.
 - Always report the provider field and id. Both local-container and direct
   providers can use `cbx_...`, so the id prefix alone does not prove AWS;
   `tbx_...` identifies Blacksmith Testbox through Crabbox. If the output only
@@ -111,18 +113,14 @@ Use these only when the task needs an existing non-Linux host. OpenClaw Linux
 validation uses the resolved Crabbox configuration unless the user explicitly
 requests another provider or target.
 
-Native brokered Windows is available for Windows-specific proof. The AWS
-developer image in `us-west-2` has the expected OpenClaw developer toolchain and
-Docker image cache. Select these Windows-specific flags only when the resolved
-configuration or an explicit user request selects that backend and target:
+Native brokered Windows is available for Windows-specific proof when the
+resolved provider supports that target. Keep provider, region, market, and image
+selection in configuration unless the user explicitly overrides them:
 
 ```sh
 ../crabbox/bin/crabbox warmup \
-  --provider aws \
   --target windows \
   --windows-mode normal \
-  --region us-west-2 \
-  --market on-demand \
   --timing-json
 ```
 
@@ -136,6 +134,10 @@ lifecycle/image routes and the operator has AWS EC2 Mac Dedicated Host quota
 and IAM. Prefer `CRABBOX_HOST_ID` for a known Crabbox-managed Dedicated Host,
 or run the no-spend preflight first:
 
+These administration commands specify AWS because they inspect or allocate an
+AWS EC2 Dedicated Host. The explicit provider is a billing and resource-scope
+safety boundary, not a validation default.
+
 ```sh
 crabbox admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2.metal --json
 crabbox admin hosts allocate --provider aws --target macos --region eu-west-1 --type mac2.metal --dry-run --json
@@ -147,6 +149,9 @@ paid-host blockers as quota, IAM, coordinator deployment, or host availability
 instead of falling back to local macOS.
 
 Crabbox supports static SSH targets:
+
+These commands specify `ssh` because the user-supplied static host selects that
+transport explicitly; they do not establish an SSH preference for other runs.
 
 ```sh
 ../crabbox/bin/crabbox run --provider ssh --target macos --static-host mac-studio.local -- xcodebuild test
@@ -173,7 +178,7 @@ request selects direct AWS Crabbox.
 Changed gate:
 
 ```sh
-pnpm crabbox:run -- --provider aws \
+../crabbox/bin/crabbox run \
   --idle-timeout 90m \
   --ttl 240m \
   --timing-json \
@@ -184,7 +189,7 @@ pnpm crabbox:run -- --provider aws \
 Full suite:
 
 ```sh
-pnpm crabbox:run -- --provider aws \
+../crabbox/bin/crabbox run \
   --idle-timeout 90m \
   --ttl 240m \
   --timing-json \
@@ -195,7 +200,7 @@ pnpm crabbox:run -- --provider aws \
 Focused rerun:
 
 ```sh
-pnpm crabbox:run -- --provider aws \
+../crabbox/bin/crabbox run \
   --idle-timeout 90m \
   --ttl 240m \
   --timing-json \
@@ -216,7 +221,7 @@ Crabbox should stop one-shot AWS leases automatically after the run. Verify
 cleanup when a run fails, is interrupted, or the command output is unclear:
 
 ```sh
-../crabbox/bin/crabbox list --provider aws
+../crabbox/bin/crabbox list
 ```
 
 ## Blacksmith Testbox Through Crabbox
@@ -225,12 +230,7 @@ This section applies only after the resolved configuration or an explicit user
 request selects Blacksmith Testbox:
 
 ```sh
-node scripts/crabbox-wrapper.mjs run \
-  --provider blacksmith-testbox \
-  --blacksmith-org openclaw \
-  --blacksmith-workflow .github/workflows/ci-check-testbox.yml \
-  --blacksmith-job check \
-  --blacksmith-ref main \
+../crabbox/bin/crabbox run \
   --idle-timeout 90m \
   --ttl 240m \
   --timing-json \
@@ -312,11 +312,11 @@ Use these on debugging runs before inventing ad hoc logging:
   commands; direct providers and Blacksmith Testbox both report them as
   `commandPhases`.
 
-Live-provider debug template for direct AWS/Hetzner leases:
+Live-provider debug template for the resolved direct-provider lease:
 
 ```sh
 mkdir -p .crabbox/logs
-pnpm crabbox:run -- --provider aws \
+../crabbox/bin/crabbox run \
   --preflight \
   --allow-env OPENAI_API_KEY,OPENAI_BASE_URL \
   --timing-json \
@@ -456,13 +456,13 @@ multiple manual commands on the same hydrated box.
 If Crabbox returns a reusable id or you intentionally keep a lease:
 
 ```sh
-pnpm crabbox:run -- --id <cbx_id-or-slug> --no-sync --timing-json --shell -- "pnpm test <path>"
+../crabbox/bin/crabbox run --id <cbx_id-or-slug> --no-sync --timing-json --shell -- "pnpm test <path>"
 ```
 
 Stop boxes you created before handoff:
 
 ```sh
-pnpm crabbox:stop -- <id-or-slug>
+../crabbox/bin/crabbox stop <id-or-slug>
 blacksmith testbox stop --id <tbx_id>
 ```
 
@@ -476,23 +476,23 @@ broken, or the user explicitly wants a local VNC client.
 Common desktop flow:
 
 ```sh
-../crabbox/bin/crabbox warmup --provider hetzner --desktop --browser --class standard --idle-timeout 60m --ttl 240m
-../crabbox/bin/crabbox desktop launch --provider hetzner --id <cbx_id-or-slug> --browser --url https://example.com --webvnc --open --take-control
+../crabbox/bin/crabbox warmup --desktop --browser --idle-timeout 60m --ttl 240m
+../crabbox/bin/crabbox desktop launch --id <cbx_id-or-slug> --browser --url https://example.com --webvnc --open --take-control
 ```
 
 Useful WebVNC commands:
 
 ```sh
-../crabbox/bin/crabbox webvnc --provider hetzner --id <cbx_id-or-slug> --open --take-control
-../crabbox/bin/crabbox webvnc daemon start --provider hetzner --id <cbx_id-or-slug> --open --take-control
-../crabbox/bin/crabbox webvnc daemon status --provider hetzner --id <cbx_id-or-slug>
-../crabbox/bin/crabbox webvnc daemon stop --provider hetzner --id <cbx_id-or-slug>
-../crabbox/bin/crabbox webvnc status --provider hetzner --id <cbx_id-or-slug>
-../crabbox/bin/crabbox webvnc reset --provider hetzner --id <cbx_id-or-slug> --open --take-control
-../crabbox/bin/crabbox desktop doctor --provider hetzner --id <cbx_id-or-slug>
-../crabbox/bin/crabbox desktop click --provider hetzner --id <cbx_id-or-slug> --x 640 --y 420
-../crabbox/bin/crabbox desktop paste --provider hetzner --id <cbx_id-or-slug> --text "user@example.com"
-../crabbox/bin/crabbox desktop key --provider hetzner --id <cbx_id-or-slug> ctrl+l
+../crabbox/bin/crabbox webvnc --id <cbx_id-or-slug> --open --take-control
+../crabbox/bin/crabbox webvnc daemon start --id <cbx_id-or-slug> --open --take-control
+../crabbox/bin/crabbox webvnc daemon status --id <cbx_id-or-slug>
+../crabbox/bin/crabbox webvnc daemon stop --id <cbx_id-or-slug>
+../crabbox/bin/crabbox webvnc status --id <cbx_id-or-slug>
+../crabbox/bin/crabbox webvnc reset --id <cbx_id-or-slug> --open --take-control
+../crabbox/bin/crabbox desktop doctor --id <cbx_id-or-slug>
+../crabbox/bin/crabbox desktop click --id <cbx_id-or-slug> --x 640 --y 420
+../crabbox/bin/crabbox desktop paste --id <cbx_id-or-slug> --text "user@example.com"
+../crabbox/bin/crabbox desktop key --id <cbx_id-or-slug> ctrl+l
 ../crabbox/bin/crabbox artifacts collect --id <cbx_id-or-slug> --all --output artifacts/<slug>
 ../crabbox/bin/crabbox artifacts publish --dir artifacts/<slug> --pr <number>
 ```
@@ -572,24 +572,24 @@ Common Crabbox-only failures:
   those before reaching for `--force-sync-large`. Quiet rsync watchdogs and SSH
   timeouts now print `next_action=` hints; follow them, usually `--full-resync`
   first and a fresh lease second.
-- Cleanup uncertainty: run `crabbox list --provider aws`; for explicit
-  Blacksmith runs, use `blacksmith testbox list` and stop only boxes you
-  created.
+- Cleanup uncertainty: run `crabbox list` with the resolved configuration; for
+  explicitly selected Blacksmith runs, use `blacksmith testbox list` and stop
+  only boxes you created.
 - Testbox queued/capacity pressure: do not retry repeatedly or switch providers.
   Report the blocker and preserve the resolved provider.
 
-If brokered AWS cannot dispatch, sync, attach, or stop, retry once with
-`--debug` and `--timing-json`:
+If the resolved direct provider cannot dispatch, sync, attach, or stop, retry
+once with `--debug` and `--timing-json` without changing providers:
 
 ```sh
-pnpm crabbox:run -- --provider aws --debug --timing-json -- \
+../crabbox/bin/crabbox run --debug --timing-json -- \
   CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test:changed
 ```
 
 Full suite:
 
 ```sh
-pnpm crabbox:run -- --provider aws --debug --timing-json -- \
+../crabbox/bin/crabbox run --debug --timing-json -- \
   CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test
 ```
 
@@ -627,7 +627,7 @@ execution, timing, logs/results, and cleanup.
 Minimal Blacksmith-backed Crabbox run, from repo root:
 
 ```sh
-pnpm crabbox:run -- --provider blacksmith-testbox --timing-json -- \
+../crabbox/bin/crabbox run --timing-json -- \
   CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:changed
 ```
 
@@ -651,13 +651,16 @@ This section applies only after the resolved configuration or an explicit user
 request selects AWS. Do not infer AWS from an omitted `--provider`.
 
 ```sh
-pnpm crabbox:warmup -- --provider aws --class beast --market on-demand --idle-timeout 90m
-pnpm crabbox:hydrate -- --provider aws --id <cbx_id-or-slug>
-pnpm crabbox:run -- --provider aws --id <cbx_id-or-slug> --timing-json --shell -- "env NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test:changed"
-pnpm crabbox:stop -- --provider aws <cbx_id-or-slug>
+../crabbox/bin/crabbox warmup --idle-timeout 90m
+../crabbox/bin/crabbox actions hydrate --id <cbx_id-or-slug>
+../crabbox/bin/crabbox run --id <cbx_id-or-slug> --timing-json --shell -- "env NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm test:changed"
+../crabbox/bin/crabbox stop <cbx_id-or-slug>
 ```
 
 Install/auth for owned Crabbox if needed:
+
+The login commands specify AWS so credentials are scoped to the brokered AWS
+authentication path. This does not change the provider for validation commands.
 
 ```sh
 brew install openclaw/tap/crabbox
@@ -735,9 +738,9 @@ Use `--market spot|on-demand` only on AWS warmup/one-shot runs.
   checkout is dirty.
 - Command failed: rerun only the failing shard/file first. Do not rerun a full
   suite until the focused failure is understood.
-- Cleanup uncertain: `crabbox list --provider aws`; for explicit Blacksmith
-  runs, use `blacksmith testbox list` and stop owned `tbx_...` leases you
-  created.
+- Cleanup uncertain: `crabbox list` with the resolved configuration; for
+  explicitly selected Blacksmith runs, use `blacksmith testbox list` and stop
+  owned `tbx_...` leases you created.
 - Selected provider broken: report the provider-specific blocker; do not switch
   providers unless the user explicitly requests the fallback.
 

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -113,9 +113,9 @@ Use these only when the task needs an existing non-Linux host. OpenClaw Linux
 validation uses the resolved Crabbox configuration unless the user explicitly
 requests another provider or target.
 
-Native brokered Windows is available for Windows-specific proof when the
-resolved provider supports that target. Keep provider, region, market, and image
-selection in configuration unless the user explicitly overrides them:
+Native Windows is available when the resolved provider supports that target.
+For providers other than AWS, keep placement and capacity in their resolved
+configuration:
 
 ```sh
 ../crabbox/bin/crabbox warmup \
@@ -123,6 +123,28 @@ selection in configuration unless the user explicitly overrides them:
   --windows-mode normal \
   --timing-json
 ```
+
+AWS has a provider-specific placement requirement: the OpenClaw Windows
+developer image and Docker cache are available in `us-west-2`, and native
+Windows leases must use on-demand capacity. After `crabbox config show` confirms
+`provider=aws` (or the user explicitly selects AWS), use:
+
+```sh
+CRABBOX_AWS_REGION=us-west-2 \
+CRABBOX_CAPACITY_REGIONS=us-west-2 \
+../crabbox/bin/crabbox warmup \
+  --target windows \
+  --windows-mode normal \
+  --market on-demand \
+  --timing-json
+```
+
+The region variables pin both the AWS image lookup and the capacity candidate
+set because `warmup` does not expose a generic `--region` flag. These placement
+and market settings are AWS availability constraints applied after provider
+selection; they are not a reason to select AWS for other runs. If the user
+explicitly requests AWS while `crabbox config show` resolves another provider,
+add `--provider aws` to this command to carry out that explicit override.
 
 The hydrate workflow assumes Docker should already be baked into Linux images
 and only installs it as a fallback. Do not add per-run Docker installs to proof
@@ -221,13 +243,49 @@ Crabbox should stop one-shot AWS leases automatically after the run. Verify
 cleanup when a run fails, is interrupted, or the command output is unclear:
 
 ```sh
-../crabbox/bin/crabbox list
+../crabbox/bin/crabbox list --provider aws
 ```
+
+The explicit provider keeps cleanup attached to the AWS lease recorded by the
+run, including when AWS was a user-requested override of another configured
+default.
 
 ## Blacksmith Testbox Through Crabbox
 
 This section applies only after the resolved configuration or an explicit user
 request selects Blacksmith Testbox:
+
+A fresh Testbox requires a repository-specific workflow. Crabbox resolves it
+from `blacksmith.workflow`, falling back to `actions.workflow`; job and ref use
+the equivalent Blacksmith values with Actions fallbacks. The workflow must
+contain a `useblacksmith/testbox`, `useblacksmith/begin-testbox`, or
+`useblacksmith/run-testbox` step. Confirm both the effective config and the
+actual workflow before using the provider-neutral command below; nonempty
+fields alone do not prove that an ordinary Actions workflow is Testbox-capable.
+
+For a local workflow path, validate it with:
+
+```sh
+rg -n 'useblacksmith/(testbox|begin-testbox|run-testbox)' <workflow-path>
+```
+
+For a workflow name or id, inspect its YAML through GitHub before dispatch. Do
+not guess a Testbox workflow from another repository.
+
+If the user explicitly supplies a Blacksmith override, carry those exact values
+on the command instead:
+
+```sh
+../crabbox/bin/crabbox run \
+  --provider blacksmith-testbox \
+  --blacksmith-workflow <repository-workflow> \
+  --timing-json -- <test-command>
+```
+
+Add `--blacksmith-org`, `--blacksmith-job`, and `--blacksmith-ref` only when the
+user supplies those overrides. The explicit provider and workflow flags in this
+form implement the user's repository-specific selection; they are not defaults
+for other runs.
 
 ```sh
 ../crabbox/bin/crabbox run \
@@ -615,16 +673,20 @@ it or switch providers. Report the delegated-provider outage.
 
 Crabbox Blacksmith backend delegates setup to:
 
-- org: `openclaw`
-- workflow: `.github/workflows/ci-check-testbox.yml`
-- job: `check`
-- ref: `main` unless testing a branch/tag intentionally
+- the organization reported by `crabbox config show`
+- a Testbox-capable `blacksmith.workflow` or `actions.workflow` in the target
+  repository
+- `blacksmith.job` / `blacksmith.ref`, with `actions.job` / `actions.ref`
+  fallbacks
 
 The hydration workflow owns checkout, Node/pnpm setup, dependency install,
 secrets, ready marker, and keepalive. Crabbox owns dispatch, sync, SSH command
 execution, timing, logs/results, and cleanup.
 
-Minimal Blacksmith-backed Crabbox run, from repo root:
+Minimal configured Blacksmith-backed Crabbox run, from repo root. Do not use
+this fresh-run form until the effective workflow is present and verified as
+Testbox-capable; supply the explicit user-provided workflow above or reuse an
+existing Testbox id instead.
 
 ```sh
 ../crabbox/bin/crabbox run --timing-json -- \
@@ -650,6 +712,22 @@ blacksmith auth login --non-interactive --organization openclaw
 This section applies only after the resolved configuration or an explicit user
 request selects AWS. Do not infer AWS from an omitted `--provider`.
 
+Confirm the selection first:
+
+```sh
+crabbox config show
+crabbox doctor
+```
+
+For Linux, the repository configuration supplies the broker URL, developer
+image, `eu-west-1` default region, capacity-region candidates, and
+spot-to-on-demand capacity policy. Do not repeat those values on every command;
+the resolved configuration remains the source of truth. For native Windows,
+use the `us-west-2` on-demand command in "macOS And Windows Targets" above. For
+brokered macOS, complete the quota/IAM and no-spend Dedicated Host preflight in
+that section before allocation. If the user explicitly selects AWS over a
+different resolved provider, add `--provider aws` to the AWS commands below.
+
 ```sh
 ../crabbox/bin/crabbox warmup --idle-timeout 90m
 ../crabbox/bin/crabbox actions hydrate --id <cbx_id-or-slug>
@@ -657,15 +735,21 @@ request selects AWS. Do not infer AWS from an omitted `--provider`.
 ../crabbox/bin/crabbox stop <cbx_id-or-slug>
 ```
 
-Install/auth for owned Crabbox if needed:
-
-The login commands specify AWS so credentials are scoped to the brokered AWS
-authentication path. This does not change the provider for validation commands.
+Install/auth for owned Crabbox if needed. When configuration already resolves
+AWS and only broker auth is missing, omit `--provider` so login writes the token
+without changing provider selection:
 
 ```sh
 brew install openclaw/tap/crabbox
-crabbox login --url https://crabbox.openclaw.ai --provider aws
+crabbox login --url https://crabbox.openclaw.ai
 ```
+
+If the user explicitly wants AWS as their persisted user-config default, use
+`crabbox login --url https://crabbox.openclaw.ai --provider aws`. The provider
+flag writes both broker auth and `provider=aws`; it is a configuration change,
+not merely credential scoping. Repository config or `CRABBOX_PROVIDER` may
+still take higher precedence, so confirm the effective result with
+`crabbox config show` in the target worktree.
 
 New users should self-resolve broker auth before anyone asks for AWS keys:
 
@@ -675,14 +759,16 @@ crabbox doctor
 crabbox whoami
 ```
 
-- If broker auth is missing, run `crabbox login --url https://crabbox.openclaw.ai --provider aws`.
+- If broker auth is missing, run `crabbox login --url https://crabbox.openclaw.ai`.
+  Add `--provider aws` only when the user also wants to persist AWS as their
+  user-config default.
 - If the CLI asks for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or AWS
   profile setup during normal OpenClaw validation, assume the agent selected
   the wrong path. Use brokered `crabbox login` or an existing brokered lease
   before asking the user for cloud credentials.
 - Ask for AWS keys only for explicit direct-provider/account administration,
   not for normal brokered OpenClaw proof.
-- Trusted automation may still use
+- Trusted automation that intentionally persists AWS as its default may use
   `printf '%s' "$CRABBOX_COORDINATOR_TOKEN" | crabbox login --url https://crabbox.openclaw.ai --provider aws --token-stdin`.
 
 macOS config lives at:

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -7,23 +7,20 @@ description: Use the Crabbox wrapper for validation across Linux, macOS, Windows
 
 ## Provider Selection Contract
 
-Resolve the provider before deciding whether validation is local or remote. Run
+Provider selection is configuration resolution, not testing policy. Run
 `crabbox config show` from the exact worktree being tested; a session may have
 started in another checkout whose repository config or skill text is stale. A
 request to "use Crabbox" does not authorize a provider override. When the user
 does not name a backend, omit `--provider` and preserve the resolved provider,
-including `local-container` from user config or `CRABBOX_PROVIDER`.
+including values supplied by user config or `CRABBOX_PROVIDER`.
 
-`local-container` is an isolated Crabbox backend, not a broad test running
-directly on the laptop. Broad gates may run there when it is the resolved
-provider. Override it only when the user or an indispensable proof requirement
-explicitly names a different backend; explain that requirement before starting
-the override.
+Test scope, expected duration, and hydration failures do not select a provider.
+Override the resolved provider only when the user explicitly names a different
+backend. If that provider cannot perform the requested test, report the blocker
+instead of silently selecting another backend.
 
-Use the Crabbox wrapper when OpenClaw needs isolated Linux proof for broad
-tests, CI-parity checks, secrets, hosted services, Docker/E2E/package lanes,
-warmed reusable boxes, sync timing, logs/results, cache inspection, or lease
-cleanup.
+Use the Crabbox wrapper for validation execution, environment lifecycle, sync,
+logs/results, cache inspection, and lease cleanup.
 
 Crabbox is the transport/orchestration surface. The actual backend can be:
 
@@ -33,22 +30,23 @@ Crabbox is the transport/orchestration surface. The actual backend can be:
 - Blacksmith Testbox through Crabbox: delegated provider,
   `provider=blacksmith-testbox`, ids like `tbx_...`, `syncDelegated=true`
 
-For OpenClaw maintainer broad `pnpm` gates, Blacksmith Testbox through the
-Crabbox wrapper is acceptable when the resolved provider or requested proof
-lane selects it. Do not describe those runs as "AWS Crabbox"; report them as
+The provider-specific sections below document capabilities and commands after
+configuration or an explicit user request has selected a backend. They are not
+provider-selection policy.
+
+When the resolved configuration selects Blacksmith Testbox, or the user
+explicitly requests it, do not describe the run as "AWS Crabbox". Report it as
 Testbox-through-Crabbox with the `tbx_...` id and Actions run.
 
-Use the repo `.crabbox.yaml` brokered AWS path when the task specifically needs
-direct AWS Crabbox behavior, persistent direct-provider leases, `--fresh-pr`,
-`--full-resync`, environment forwarding, capture/download support, or provider
-comparison. Use `--provider blacksmith-testbox` when the task needs OpenClaw
-maintainer Testbox proof, prepared CI environment, broad/heavy pnpm gates, or
-the user asks for Testbox/Blacksmith.
+Direct AWS supports persistent leases, `--fresh-pr`, `--full-resync`,
+environment forwarding, capture/download, and provider-comparison workflows.
+Blacksmith Testbox provides a prepared CI environment and delegated broad/heavy
+`pnpm` gates. These capabilities do not override the resolved configuration.
 
 ## First Checks
 
 - Run from the repo root. Crabbox sync mirrors the current checkout.
-- Check the wrapper and providers before remote work:
+- Check the wrapper and providers before Crabbox work:
 
 ```sh
 command -v crabbox
@@ -64,13 +62,12 @@ command -v crabbox
   before selecting a provider. The resolved provider can come from the user's
   Crabbox config or environment as well as the repository file.
 - Omitting `--provider` means "use the resolved configuration". Pass it only
-  when the task specifically requires a different backend, and report the
+  when the user explicitly requests a different backend, and report the
   provider from Crabbox output rather than inferring it from bootstrap wording.
-- Treat `CRABBOX_PROVIDER` as part of that resolved provider configuration. If
-  `crabbox config show` reports `provider=local-container`, keep that provider;
-  a hydration or test failure is not permission to retry on AWS or Testbox.
-  Override the resolved provider only when the user or the required proof lane
-  explicitly names another backend.
+- Treat `CRABBOX_PROVIDER` as part of that resolved provider configuration. The
+  provider reported by `crabbox config show` is authoritative; a hydration or
+  test failure is not permission to switch backends. Override it only when the
+  user explicitly names another provider.
 - Some package-manager wrappers insert a command delimiter before Crabbox
   options. If the printed command looks like `crabbox run -- --provider ...`
   or `crabbox run -- --no-hydrate ...`, call the trusted Crabbox binary
@@ -79,9 +76,8 @@ command -v crabbox
   config pins hot `eu-west-1a/b/c` placement so Fast Snapshot Restore can apply.
   If warmup drifts well past the minute-scale path, verify image promotion,
   region/AZ placement, and FSR state before blaming OpenClaw.
-- For broad OpenClaw maintainer `pnpm` gates, use the resolved provider. Select
-  `--provider blacksmith-testbox` or the repo Testbox helpers only when the user
-  or an indispensable proof requirement specifically calls for Testbox.
+- Targeted and broad `pnpm` gates both use the resolved provider. Test size does
+  not authorize `--provider blacksmith-testbox` or another override.
 - Always report the provider field and id. Both local-container and direct
   providers can use `cbx_...`, so the id prefix alone does not prove AWS;
   `tbx_...` identifies Blacksmith Testbox through Crabbox. If the output only
@@ -97,29 +93,28 @@ command -v crabbox
   not leave it in remote shell history or logs. If no secret-safe injection path
   is available, say true live provider auth is blocked instead of silently using
   a fake key.
-- Prefer local targeted tests for tight edit loops. Keep broad gates inside the
-  resolved Crabbox backend; `local-container` satisfies this isolation boundary.
+- Targeted versus broad describes test scope only; it does not imply local,
+  remote, host, or container execution.
 - Do not treat unrelated inherited shell controls as operator intent. In
   particular, `OPENCLAW_LOCAL_CHECK_MODE=throttled` from the local shell is not
   permission to move broad `pnpm check:changed`, `pnpm test:changed`, full
   `pnpm test`, or lint/typecheck fan-out onto the laptop. This does not negate
   provider-selection variables such as `CRABBOX_PROVIDER`, which are resolved
   and reported by `crabbox config show`.
-- Only use `OPENCLAW_LOCAL_CHECK_MODE=throttled|full` when the user explicitly
-  asks for local proof in the current task. If Testbox is queued or capacity is
-  constrained, report the blocker and keep only targeted local edit-loop checks
-  running.
+- `OPENCLAW_LOCAL_CHECK_MODE=throttled|full` controls direct host execution; it
+  is separate from Crabbox provider selection and must not override the provider
+  reported by `crabbox config show`.
 
 ## macOS And Windows Targets
 
-Use these only when the task needs an existing non-Linux host. OpenClaw broad
-Linux validation uses the repo Crabbox config unless a provider is explicitly
-requested.
+Use these only when the task needs an existing non-Linux host. OpenClaw Linux
+validation uses the resolved Crabbox configuration unless the user explicitly
+requests another provider or target.
 
-Native brokered Windows is available for Windows-specific proof. Use the AWS
-developer image in `us-west-2` on demand; it has the expected OpenClaw developer
-toolchain and Docker image cache. Keep broad Linux gates on Linux/Testbox unless
-the bug is Windows-specific:
+Native brokered Windows is available for Windows-specific proof. The AWS
+developer image in `us-west-2` has the expected OpenClaw developer toolchain and
+Docker image cache. Select these Windows-specific flags only when the resolved
+configuration or an explicit user request selects that backend and target:
 
 ```sh
 ../crabbox/bin/crabbox warmup \
@@ -172,8 +167,8 @@ Crabbox supports static SSH targets:
 
 ## Direct Brokered AWS Backend
 
-Use this when the task needs direct AWS Crabbox semantics rather than the
-prepared Blacksmith Testbox CI environment.
+This section applies only after the resolved configuration or an explicit user
+request selects direct AWS Crabbox.
 
 Changed gate:
 
@@ -226,8 +221,8 @@ cleanup when a run fails, is interrupted, or the command output is unclear:
 
 ## Blacksmith Testbox Through Crabbox
 
-Use this for OpenClaw maintainer broad/heavy `pnpm` gates when the prepared CI
-environment is the right proof surface:
+This section applies only after the resolved configuration or an explicit user
+request selects Blacksmith Testbox:
 
 ```sh
 node scripts/crabbox-wrapper.mjs run \
@@ -567,8 +562,8 @@ Common Crabbox-only failures:
   This is a hydration transport workaround, not permission to run the broad
   check on the host or silently select a remote provider.
 - Bad local config: inspect `.crabbox.yaml`, `crabbox config show`, and
-  `crabbox whoami`; preserve the resolved provider unless the requested proof
-  specifically requires another backend.
+  `crabbox whoami`; preserve the resolved provider unless the user explicitly
+  requests another backend.
 - Slug/claim confusion: use the raw `cbx_...` / `tbx_...` id, or run one-shot
   without `--id`.
 - Sync/timing bug: add `--debug --timing-json`; capture the final JSON and the
@@ -580,10 +575,8 @@ Common Crabbox-only failures:
 - Cleanup uncertainty: run `crabbox list --provider aws`; for explicit
   Blacksmith runs, use `blacksmith testbox list` and stop only boxes you
   created.
-- Testbox queued/capacity pressure: do not retry Blacksmith repeatedly. Rerun
-  once without `--provider` to use the resolved configuration, or report the
-  Blacksmith blocker if Testbox itself is the requested proof. Do not assume
-  the resolved fallback is AWS.
+- Testbox queued/capacity pressure: do not retry repeatedly or switch providers.
+  Report the blocker and preserve the resolved provider.
 
 If brokered AWS cannot dispatch, sync, attach, or stop, retry once with
 `--debug` and `--timing-json`:
@@ -615,10 +608,8 @@ Raw Blacksmith footguns:
 - Treat `blacksmith testbox list` as cleanup diagnostics, not a shared reusable
   queue.
 
-Use Blacksmith only when the task is specifically about Testbox, brokered AWS
-is unavailable, or an explicit comparison is needed. If Blacksmith is down or
-quota-limited, do not keep probing it; stay on brokered AWS and note the
-delegated-provider outage.
+If the selected Blacksmith backend is down or quota-limited, do not keep probing
+it or switch providers. Report the delegated-provider outage.
 
 ## Blacksmith Backend Notes
 
@@ -656,9 +647,8 @@ blacksmith auth login --non-interactive --organization openclaw
 
 ## Brokered AWS
 
-Use AWS when the task specifically requires remote direct-provider proof. If
-`crabbox config show` resolves another provider, select AWS explicitly for this
-lane instead of claiming that an omitted provider implies AWS.
+This section applies only after the resolved configuration or an explicit user
+request selects AWS. Do not infer AWS from an omitted `--provider`.
 
 ```sh
 pnpm crabbox:warmup -- --provider aws --class beast --market on-demand --idle-timeout 90m
@@ -699,8 +689,8 @@ macOS config lives at:
 ```
 
 It should include `broker.url` and `broker.token` for AWS lanes. Let the resolved
-config drive normal validation and override it only for a provider-specific
-proof lane.
+config select the backend; override it only when the user explicitly requests a
+different provider.
 
 ### Interactive Desktop / WebVNC
 
@@ -748,8 +738,8 @@ Use `--market spot|on-demand` only on AWS warmup/one-shot runs.
 - Cleanup uncertain: `crabbox list --provider aws`; for explicit Blacksmith
   runs, use `blacksmith testbox list` and stop owned `tbx_...` leases you
   created.
-- Crabbox broken but Blacksmith works: use the direct Blacksmith fallback above,
-  then file/fix the Crabbox issue.
+- Selected provider broken: report the provider-specific blocker; do not switch
+  providers unless the user explicitly requests the fallback.
 
 ## Boundary
 

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -36,6 +36,15 @@ provider-selection policy. Their validation commands intentionally omit
 `--provider`; add it only to carry out an explicit user override of the resolved
 configuration.
 
+Provider identity must remain attached to a lease after creation. A lease
+created through the resolved configuration can keep using provider-neutral
+commands while that configuration is unchanged. If the user explicitly
+overrode the provider, or the resolved configuration has changed since the
+lease was created, pass the provider reported by Crabbox to every later command
+that targets that lease, including hydrate, rerun, desktop/WebVNC, status,
+inspect, SSH, and stop. This preserves resource identity; it does not select a
+provider for unrelated work.
+
 When the resolved configuration selects Blacksmith Testbox, or the user
 explicitly requests it, do not describe the run as "AWS Crabbox". Report it as
 Testbox-through-Crabbox with the `tbx_...` id and Actions run.
@@ -511,6 +520,11 @@ Interactive CLI/onboarding:
 For most Crabbox calls, one-shot is enough. Use reuse only when you need
 multiple manual commands on the same hydrated box.
 
+The examples below assume the lease came from the still-current resolved
+configuration. For a lease created through an explicit provider override, add
+`--provider <reported-provider>` to every reuse, inspection, and cleanup command
+instead of relying on the id to recover its backend.
+
 If Crabbox returns a reusable id or you intentionally keep a lease:
 
 ```sh
@@ -526,10 +540,18 @@ blacksmith testbox stop --id <tbx_id>
 
 ## Interactive Desktop And WebVNC
 
-Prefer WebVNC for human inspection because the browser portal can preload the
-lease VNC password and avoids a native VNC client's copy/paste/password dance.
-Use native `crabbox vnc` only when WebVNC is unavailable, the browser portal is
-broken, or the user explicitly wants a local VNC client.
+Before using WebVNC, confirm the resolved provider supports both desktop and a
+coordinator-backed WebVNC lease, and that broker login is configured. Crabbox
+0.39 WebVNC supports coordinator-backed Hetzner, AWS, and Azure desktop leases;
+this capability list does not establish a provider preference. If the resolved
+provider lacks WebVNC, do not switch providers: use native `crabbox vnc` on the
+same provider when it supports that path, or report the capability blocker.
+
+When those preconditions hold, prefer WebVNC for human inspection because the
+browser portal can preload the lease VNC password and avoids a native VNC
+client's copy/paste/password dance. Use native `crabbox vnc` when the browser
+portal is unavailable or broken, or the user explicitly wants a local VNC
+client.
 
 Common desktop flow:
 


### PR DESCRIPTION
## Root cause

The affected agent session started in an older checkout (`a53830f`) even though
the requested work happened in a newer worktree. It therefore loaded pre-#741
Crabbox guidance, classified broad proof as remote, and tried AWS before
resolving the user's configured provider. The current skill also retained
local/remote and targeted/broad preferences plus provider-pinning examples that
could override the provider-resolution contract.

## Changes

- Resolve provider configuration first with `crabbox config show` in the exact
  target worktree, including user config and `CRABBOX_PROVIDER`.
- Make test scope, expected duration, and hydration failures provider-neutral;
  they cannot select or switch the backend.
- Remove provider, region, market, class, and repository-specific Blacksmith
  overrides from generic run, retry, reuse, cleanup, and desktop examples.
- Keep explicit provider flags only for an explicit user override or a concrete
  security, billing, resource, transport, or recorded-lease lifecycle boundary.
- Keep the actual provider attached to a lease created through an explicit
  override across later hydrate, rerun, desktop, observability, and cleanup
  commands; an id alone does not recover its backend.
- Gate authenticated portal WebVNC on the resolved provider's desktop/WebVNC
  capability and configured coordinator login, without selecting a fallback
  provider.
- Preserve provider-specific operating knowledge after selection:
  - AWS Linux uses resolved repository region/capacity/image configuration.
  - AWS native Windows uses the developer image and Docker cache in `us-west-2`
    with on-demand capacity; environment overrides pin both image lookup and
    capacity candidates because Crabbox 0.39 `warmup` has no generic `--region`.
  - AWS macOS retains Dedicated Host quota/IAM and no-spend preflight guidance.
  - AWS login without `--provider` adds broker auth without changing selection;
    `--provider aws` is documented as intentionally persisting AWS as the user
    default, followed by an effective-config check.
  - Blacksmith fresh runs require an effective repository workflow containing a
    Testbox action; existing `tbx_...` reuse does not require workflow config.
- Use the trusted Crabbox binary directly where package wrappers could place
  lifecycle flags after an extra command delimiter.
- Report the actual provider and id; `cbx_...` alone does not prove AWS because
  local-container uses the same prefix.

## Validation

- No-hint Claude/acpx prompt asked only to use Crabbox for a probe; it did not
  mention local-container, local, remote, AWS, or Testbox.
- Behavior proofs preserved resolved `provider=local-container`:
  - `cbx_53b4357174c8`
  - `cbx_7f192095d218`
  - `cbx_84d62a8bcd97`
  - `cbx_00851525a664` (unsupported hydration retried with `--no-hydrate` on
    the same provider)
  - `cbx_10cd9dcc36df` (fresh ACPx/Claude-adapter run after review; the same
    provider was preserved across hydration failure and `--no-hydrate`, exit 0,
    lease auto-stopped)
  - `cbx_1ddd16c5c156` (final ACPx 0.12.0 validation on PR head
    `6a27079914fe42a5cc310be68b386aa3eedd7fc6`; no provider hint or override,
    resolved `local-container`, printed `ACPX_CRABBOX_LAND_OK`, exit 0, lease
    auto-stopped, and no files modified)
- Verified against Crabbox 0.39 source and docs that Blacksmith falls back from
  `blacksmith.workflow` to `actions.workflow` without excluding generic names;
  workflow content, rather than its name, establishes Testbox capability.
- `git diff --check`.
- Full branch autoreview used the same provider-selection contract prompt. Two
  lifecycle/WebVNC regressions from independent review were fixed. The final
  run's only finding claimed a coordinator-free local-container noVNC path; it
  was rejected against Crabbox 0.39 `webvnc` and `desktop launch --webvnc`
  source, which require a configured coordinator client/token for the
  authenticated portal path.

This is a guidance-only follow-up to #741. It does not change live workflow or
apply behavior.
