### PR TITLE
feat(repair): cut router-ledger and apply-proof lanes over to DO state append (#738 WP-3b/3c)

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -801,6 +801,10 @@ jobs:
 
       - name: Publish immutable repair requeue action ledger
         if: ${{ always() && steps.execute-setup-pnpm.outcome == 'success' && steps.repair-requeue-ledger.outcome == 'success' && steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -281,6 +281,10 @@ jobs:
 
       - name: Commit comment router ledger
         if: always()
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           if jq -e '.short_circuited == true' results/comment-router-latest.json >/dev/null 2>&1; then
             echo "Exact terminal comment version already recorded; skipping state publication."
@@ -413,6 +417,10 @@ jobs:
 
       - name: Commit comment router retry ledger
         if: ${{ always() && steps.waiting-repair-dispatches.outputs.count != '' && steps.waiting-repair-dispatches.outputs.count != '0' }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           pnpm run repair:publish-main -- \
             --message "chore: record ClawSweeper repair dispatch retry" \
@@ -447,6 +455,10 @@ jobs:
 
       - name: Publish immutable command action ledger
         if: ${{ always() && steps.setup-pnpm.outcome == 'success' && steps.finalize-command-action-ledger.outputs.publish == 'true' }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3096,6 +3096,10 @@ jobs:
       - name: Publish immutable review action ledger
         if: ${{ always() && steps.import-review-action-ledger.outcome == 'success' }}
         continue-on-error: true
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           if [ ! -s .artifacts/action-ledger-paths.txt ]; then
             echo "No immutable review action events to publish."
@@ -3158,6 +3162,10 @@ jobs:
 
       - name: Publish review artifact action ledger
         if: ${{ always() && steps.apply-review-artifacts.outputs.artifacts_applied == 'true' }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -3484,6 +3492,10 @@ jobs:
 
       - name: Publish selected review comment action ledger
         if: ${{ always() && steps.sync-selected-review-comments.outcome != 'skipped' && steps.finalize-selected-review-comment-action-ledger.outcome == 'success' }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -3814,6 +3826,10 @@ jobs:
 
       - name: Publish failed-review retry action ledger
         if: ${{ always() }}
+        env:
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -4000,6 +4016,7 @@ jobs:
       issues: read
       pull-requests: read
     env:
+      CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
       CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
@@ -4218,6 +4235,7 @@ jobs:
   publish-apply-proof-action-ledger:
     name: Publish immutable apply proof action ledger
     env:
+      CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
     needs: apply-proof
@@ -4259,6 +4277,9 @@ jobs:
 
       - name: Publish apply proof action events
         if: ${{ needs.apply-proof.outputs.action_ledger_artifact_name != '' }}
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"
@@ -4300,6 +4321,7 @@ jobs:
       cancel-in-progress: false
       queue: max
     env:
+      CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
       CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED: ${{ vars.CLAWSWEEPER_UNCONFIRMED_PRODUCT_DIRECTION_CLOSE_ENABLED || 'false' }}
@@ -4409,7 +4431,6 @@ jobs:
         id: apply-existing-run
         timeout-minutes: 350
         env:
-          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           CLAWSWEEPER_PUBLISH_THROTTLE_STATUS: "true"
@@ -4808,7 +4829,6 @@ jobs:
       - name: Retry final apply status publication
         if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' }}
         env:
-          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
@@ -4825,6 +4845,9 @@ jobs:
 
       - name: Publish apply action events
         if: ${{ always() }}
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           test -n "${CLAWSWEEPER_STATE_DIR:-}"

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -216,7 +216,7 @@ import {
   workflowActionProducer,
 } from "./action-ledger-runtime.js";
 import { isActionEventPublishPath } from "./action-ledger-paths.js";
-import { publishMainCommit } from "./repair/git-publish.js";
+import { publishMainWithStateAppend } from "./repair/publish-main.js";
 
 export {
   codexEnv,
@@ -32223,7 +32223,7 @@ export function actionEventPublishPathsForTest(content: string): string[] {
   return paths;
 }
 
-function publishActionEventPathsCommand(args: Args): void {
+async function publishActionEventPathsCommand(args: Args): Promise<void> {
   const pathsFile = resolve(stringArg(args.paths_file, ""));
   const message = stringArg(args.message, "");
   if (!pathsFile || pathsFile === ROOT) {
@@ -32250,7 +32250,7 @@ function publishActionEventPathsCommand(args: Args): void {
       throw new Error(`action event publish path is not a regular file: ${path}`);
     }
   }
-  const result = publishMainCommit({
+  const result = await publishMainWithStateAppend({
     message,
     paths,
     rebaseStrategy: "normal",
@@ -32291,7 +32291,7 @@ export async function main(
     else if (command === "apply-artifacts") applyArtifactsCommand(args);
     else if (command === "apply-decisions") applyDecisionsCommand(args);
     else if (command === "publish-action-events") publishActionEventsCommand(args);
-    else if (command === "publish-action-event-paths") publishActionEventPathsCommand(args);
+    else if (command === "publish-action-event-paths") await publishActionEventPathsCommand(args);
     else if (command === "proof-nudges") proofNudgesCommand(args);
     else if (command === "bot-proof") botProofCommand(args);
     else if (command === "audit") auditCommand(args);

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { isActionEventPublishPath } from "../action-ledger-paths.js";
 import {
   publishMainCommit,
   type GitPublishOptions,
@@ -40,6 +41,8 @@ type StateAppendPlan = {
 
 const SWEEP_STATUS_DIRECTORY = "results/sweep-status";
 const SWEEP_STATUS_FILE_PATTERN = /^results\/sweep-status\/([A-Za-z0-9][A-Za-z0-9_.-]*)\.json$/;
+const COMMENT_ROUTER_LEDGER_PATH = "results/comment-router.json";
+const STATE_APPEND_MAX_RECORD_BYTES = 256 * 1024;
 
 export async function publishMainWithStateAppend(
   options: GitPublishOptions,
@@ -55,7 +58,7 @@ export async function publishMainWithStateAppend(
 
   let plan: StateAppendPlan;
   try {
-    plan = planSweepStatusAppend(
+    plan = planStateAppend(
       options.paths,
       runtime.root ?? process.cwd(),
       env.CLAWSWEEPER_STATE_DIR,
@@ -67,8 +70,17 @@ export async function publishMainWithStateAppend(
   }
   if (plan.records.length === 0) return publishGit(options);
 
-  const contentHash = createHash("sha256").update(JSON.stringify(plan.records)).digest("hex");
-  const deliveryId = `router:sweep-status-${deliveryPart(env.GITHUB_RUN_ID, "local")}-${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}-${contentHash}`;
+  const remainingPaths = options.paths.filter((path) => !plan.consumedPaths.has(path));
+  // Router replay is crash-recoverable through deterministic job paths, stable
+  // dispatch keys, and live-run/status reconciliation. Publish those outputs
+  // first so an interrupted append is retried instead of suppressing missing work.
+  const publishRemainingFirst =
+    remainingPaths.length > 0 && plan.records.some((record) => record.kind === "comment_router");
+  const remainingResult = publishRemainingFirst
+    ? publishGit({ ...options, paths: remainingPaths })
+    : undefined;
+  const contentHash = stateAppendContentHash(plan.records);
+  const deliveryId = `router:${stateAppendLane(plan.records)}-${deliveryPart(env.GITHUB_RUN_ID, "local")}-${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}-${contentHash}`;
 
   let appendResult: StateAppendResult;
   try {
@@ -88,17 +100,35 @@ export async function publishMainWithStateAppend(
     return publishGit(options);
   }
 
-  const remainingPaths = options.paths.filter((path) => !plan.consumedPaths.has(path));
+  if (remainingResult) return remainingResult;
   if (remainingPaths.length > 0) return publishGit({ ...options, paths: remainingPaths });
-  console.log(`Appended ${plan.records.length} sweep status record(s) to durable state`);
+  console.log(`Appended ${plan.records.length} state record(s) to durable state`);
   return "appended";
+}
+
+function planStateAppend(
+  paths: readonly string[],
+  root: string,
+  stateRoot: string | undefined,
+  now: (() => Date) | undefined,
+): StateAppendPlan {
+  const fallbackProducedAt = (now ?? (() => new Date()))().toISOString();
+  const plans = [
+    planSweepStatusAppend(paths, root, stateRoot, fallbackProducedAt),
+    planCommentRouterAppend(paths, root, fallbackProducedAt),
+    planApplyProofAppend(paths, root, fallbackProducedAt),
+  ];
+  return {
+    consumedPaths: new Set(plans.flatMap((plan) => [...plan.consumedPaths])),
+    records: plans.flatMap((plan) => plan.records),
+  };
 }
 
 function planSweepStatusAppend(
   paths: readonly string[],
   root: string,
   stateRoot: string | undefined,
-  now: (() => Date) | undefined,
+  fallbackProducedAt: string,
 ): StateAppendPlan {
   const consumedPaths = new Set<string>();
   const files = new Set<string>();
@@ -131,11 +161,10 @@ function planSweepStatusAppend(
     for (const file of directoryFiles) files.add(file);
   }
 
-  const fallbackProducedAt = (now ?? (() => new Date()))().toISOString();
   const records = [...files].sort().map((path): StateAppendInputRecord => {
     const match = SWEEP_STATUS_FILE_PATTERN.exec(path);
     if (!match) throw new Error(`invalid sweep status path: ${path}`);
-    const payload = JSON.parse(readFileSync(resolve(root, path), "utf8")) as unknown;
+    const payload = JSON.parse(readContainedRegularFile(root, path)) as unknown;
     if (!isRecord(payload) || payload.slug !== match[1]) {
       throw new Error(`sweep status payload slug does not match ${path}`);
     }
@@ -147,6 +176,58 @@ function planSweepStatusAppend(
       produced_at: Number.isFinite(Date.parse(updatedAt)) ? updatedAt : fallbackProducedAt,
     };
   });
+  return { consumedPaths, records };
+}
+
+function planCommentRouterAppend(
+  paths: readonly string[],
+  root: string,
+  fallbackProducedAt: string,
+): StateAppendPlan {
+  const consumedPaths = new Set<string>();
+  const records: StateAppendInputRecord[] = [];
+  for (const originalPath of paths) {
+    const path = normalizedPath(originalPath);
+    if (path !== COMMENT_ROUTER_LEDGER_PATH) continue;
+    const absolute = resolve(root, path);
+    if (!existsSync(absolute) || !statSync(absolute).isFile()) continue;
+    const payload = JSON.parse(readContainedRegularFile(root, path)) as unknown;
+    if (!isRecord(payload)) throw new Error("comment router ledger must be a JSON object");
+    const payloadText = JSON.stringify(payload);
+    const updatedAt = typeof payload.updated_at === "string" ? payload.updated_at : "";
+    consumedPaths.add(originalPath);
+    records.push({
+      kind: "comment_router",
+      key: createHash("sha256").update(payloadText).digest("hex"),
+      payload,
+      produced_at: Number.isFinite(Date.parse(updatedAt)) ? updatedAt : fallbackProducedAt,
+    });
+  }
+  return { consumedPaths, records };
+}
+
+function planApplyProofAppend(
+  paths: readonly string[],
+  root: string,
+  producedAt: string,
+): StateAppendPlan {
+  const consumedPaths = new Set<string>();
+  const records: StateAppendInputRecord[] = [];
+  for (const originalPath of paths) {
+    const path = normalizedPath(originalPath);
+    if (!isActionEventPublishPath(path)) continue;
+    const absolute = resolve(root, path);
+    if (!existsSync(absolute) || !statSync(absolute).isFile()) continue;
+    const payload = readContainedRegularFile(root, path);
+    if (Buffer.byteLength(JSON.stringify(payload)) > STATE_APPEND_MAX_RECORD_BYTES) {
+      console.warn(
+        `State append apply-proof record ${path} exceeds ${STATE_APPEND_MAX_RECORD_BYTES} bytes; using git fallback`,
+      );
+      continue;
+    }
+    consumedPaths.add(originalPath);
+    records.push({ kind: "apply_proof", key: path, payload, produced_at: producedAt });
+  }
   return { consumedPaths, records };
 }
 
@@ -162,6 +243,23 @@ function sweepStatusDirectoryNames(directory: string): string[] {
   return entries.map((entry) => entry.name).sort();
 }
 
+function readContainedRegularFile(root: string, path: string): string {
+  const realRoot = realpathSync(root);
+  const candidate = resolve(realRoot, path);
+  if (lstatSync(candidate).isSymbolicLink()) {
+    throw new Error(`state append source must not be a symbolic link: ${path}`);
+  }
+  const realFile = realpathSync(candidate);
+  const relativePath = relative(realRoot, realFile);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(`state append source resolves outside the workspace: ${path}`);
+  }
+  if (!statSync(realFile).isFile()) {
+    throw new Error(`state append source is not a regular file: ${path}`);
+  }
+  return readFileSync(realFile, "utf8");
+}
+
 function normalizedPath(path: string): string {
   return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
 }
@@ -171,6 +269,17 @@ function deliveryPart(value: string | undefined, fallback: string): string {
     .trim()
     .replace(/[^A-Za-z0-9_.-]/g, "-");
   return normalized || fallback;
+}
+
+function stateAppendContentHash(records: readonly StateAppendInputRecord[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify(records.map(({ kind, key, payload }) => ({ kind, key, payload }))))
+    .digest("hex");
+}
+
+function stateAppendLane(records: readonly StateAppendInputRecord[]): string {
+  const kinds = [...new Set(records.map((record) => record.kind))];
+  return kinds.length === 1 ? kinds[0]!.replaceAll("_", "-") : "mixed";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -810,6 +810,20 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.match(workflow, /--state-root "\$CLAWSWEEPER_STATE_DIR"/);
   assert.match(workflow, /durable_event_path="\$CLAWSWEEPER_STATE_DIR\/\$event_path"/);
   assert.equal((workflow.match(/publish-action-event-paths/g) ?? []).length, 6);
+  for (const name of [
+    "Publish immutable review action ledger",
+    "Publish review artifact action ledger",
+    "Publish selected review comment action ledger",
+    "Publish failed-review retry action ledger",
+  ]) {
+    assertStateAppendPublisherWiring(namedWorkflowStep(workflow, name), true);
+  }
+  for (const name of ["Publish apply proof action events", "Publish apply action events"]) {
+    assertStateAppendPublisherWiring(namedWorkflowStep(workflow, name), false);
+  }
+  for (const job of ["apply-proof", "publish-apply-proof-action-ledger", "apply-existing"]) {
+    assert.match(namedWorkflowJob(workflow, job), /CLAWSWEEPER_STATE_APPEND_ENABLED: "1"/);
+  }
   assert.doesNotMatch(
     workflow,
     /--message "chore: append (?:review|apply).*action ledger"[\s\S]{0,180}--path "ledger\/v1\/events"/,
@@ -819,6 +833,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
 test("comment router publishes immutable command receipts for initial and retry invocations", () => {
   const setupAction = readText(".github/actions/setup-action-ledger/action.yml");
   const workflow = readText(".github/workflows/repair-comment-router.yml");
+  const repairWorkerWorkflow = readText(".github/workflows/repair-cluster-worker.yml");
   const finalizeStart = workflow.indexOf("- name: Finalize command action ledger");
   const publishStart = workflow.indexOf("- name: Publish immutable command action ledger");
   const finalizeStep = workflow.slice(finalizeStart, publishStart);
@@ -842,6 +857,17 @@ test("comment router publishes immutable command receipts for initial and retry 
   assert.match(publishStep, /repair:action-ledger -- publish/);
   assert.match(publishStep, /--message "chore: append command action ledger"/);
   assert.match(publishStep, /action_ledger_args\+=\(--path "\$event_path"\)/);
+  for (const name of [
+    "Commit comment router ledger",
+    "Commit comment router retry ledger",
+    "Publish immutable command action ledger",
+  ]) {
+    assertStateAppendPublisherWiring(namedWorkflowStep(workflow, name), true);
+  }
+  assertStateAppendPublisherWiring(
+    namedWorkflowStep(repairWorkerWorkflow, "Publish immutable repair requeue action ledger"),
+    true,
+  );
   assert.doesNotMatch(
     publishStep,
     /--message "chore: append command action ledger"[\s\S]{0,180}--path "ledger\/v1\/events"/,
@@ -876,4 +902,27 @@ function assertCommandPublisherUsesCanonicalRoot(step: string): void {
   assert.match(step, /if \[ ! -s "\$event_paths_file" \]; then[\s\S]*?exit 1[\s\S]*?fi/);
   assert.doesNotMatch(step, /command_shard_found/);
   assert.doesNotMatch(step, /\.created > 0/);
+}
+
+function assertStateAppendPublisherWiring(step: string, expectEnabled: boolean): void {
+  if (expectEnabled) assert.match(step, /CLAWSWEEPER_STATE_APPEND_ENABLED: "1"/);
+  assert.match(step, /CLAWSWEEPER_WEBHOOK_SECRET:/);
+  assert.match(step, /QUEUE_URL:/);
+}
+
+function namedWorkflowStep(workflow: string, name: string): string {
+  const start = workflow.indexOf(`- name: ${name}`);
+  assert.ok(start >= 0, `missing workflow step ${name}`);
+  const end = workflow.indexOf("\n      - ", start + 1);
+  return workflow.slice(start, end < 0 ? workflow.length : end);
+}
+
+function namedWorkflowJob(workflow: string, name: string): string {
+  const start = workflow.indexOf(`\n  ${name}:`);
+  assert.ok(start >= 0, `missing workflow job ${name}`);
+  const remainder = workflow.slice(start + 1);
+  const next = /^  [a-zA-Z0-9_-]+:\s*$/gm;
+  next.lastIndex = name.length + 4;
+  const match = next.exec(remainder);
+  return remainder.slice(0, match?.index ?? remainder.length);
 }

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,9 @@ import { publishMainWithStateAppend } from "../../dist/repair/publish-main.js";
 import type { GitPublishOptions, PublishResult } from "../../dist/repair/git-publish.js";
 
 const statusPath = "results/sweep-status/openclaw-openclaw.json";
+const routerPath = "results/comment-router.json";
+const proofPath = `ledger/v1/import-bindings/events/${"a".repeat(64)}.json`;
+const oversizedProofPath = `ledger/v1/import-bindings/events/${"b".repeat(64)}.json`;
 
 test("publish-main appends sweep status instead of invoking the git publisher", async () => {
   const root = statusFixture();
@@ -68,6 +72,175 @@ test("publish-main keeps mixed non-status paths on the git publisher", async () 
   );
   assert.deepEqual(gitPublishes[0]?.paths, ["README.md"]);
   assert.equal(gitPublishes[0]?.rebaseStrategy, "theirs");
+});
+
+test("publish-main publishes dependent router outputs before appending a content-addressed ledger", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-router-"));
+  writeJson(root, routerPath, routerLedger());
+  const gitPublishes: GitPublishOptions[] = [];
+  const deliveries: string[] = [];
+  const routerPayload = routerLedger();
+  const routerKey = createHash("sha256").update(JSON.stringify(routerPayload)).digest("hex");
+  const fetchImpl = (async (_input: string | URL | Request, init?: RequestInit) => {
+    assert.equal(gitPublishes.length, deliveries.length + 1);
+    const body = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+    deliveries.push(String(body.delivery_id));
+    assert.deepEqual(body.records, [
+      {
+        kind: "comment_router",
+        key: routerKey,
+        payload: routerPayload,
+        produced_at: "2026-07-21T12:10:00.000Z",
+      },
+    ]);
+    return Response.json({ ok: true, appended: 1 }, { status: 202 });
+  }) as typeof fetch;
+  const options = {
+    message: "chore: record ClawSweeper comment routing",
+    paths: [routerPath, "results/comment-router-latest.json", "jobs"],
+    rebaseStrategy: "theirs" as const,
+  };
+
+  for (const instant of ["2026-07-21T12:11:00.000Z", "2026-07-21T12:12:00.000Z"]) {
+    assert.equal(
+      await publishMainWithStateAppend(options, {
+        root,
+        env: appendEnv(),
+        fetchImpl,
+        now: () => new Date(instant),
+        publishGit: capturePublishes(gitPublishes),
+      }),
+      "committed",
+    );
+  }
+
+  assert.deepEqual(
+    gitPublishes.map((publish) => publish.paths),
+    [
+      ["results/comment-router-latest.json", "jobs"],
+      ["results/comment-router-latest.json", "jobs"],
+    ],
+  );
+  assert.match(deliveries[0] ?? "", /^router:comment-router-1234-2-[a-f0-9]{64}$/);
+  assert.equal(deliveries[1], deliveries[0]);
+});
+
+test("publish-main falls back to the full comment-router git publish on shed", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-router-"));
+  writeJson(root, routerPath, routerLedger());
+  const gitPublishes: GitPublishOptions[] = [];
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+  const original = {
+    message: "chore: record ClawSweeper comment routing",
+    paths: [routerPath, "jobs"],
+    rebaseStrategy: "theirs" as const,
+  };
+
+  assert.equal(
+    await publishMainWithStateAppend(original, {
+      root,
+      env: appendEnv(),
+      fetchImpl: (async () =>
+        Response.json({ ok: false, shed: true }, { status: 429 })) as typeof fetch,
+      publishGit: capturePublishes(gitPublishes),
+    }),
+    "committed",
+  );
+  assert.deepEqual(
+    gitPublishes.map((publish) => publish.paths),
+    [["jobs"], [routerPath, "jobs"]],
+  );
+  assert.deepEqual(warnings, ["state-append shed/failed; falling back to git publish"]);
+});
+
+test("publish-main appends canonical apply-proof content and git-publishes an oversized sibling", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-proof-"));
+  const canonical =
+    '{"event_id":"proof-event","schema":"clawsweeper.action-ledger-import-event-binding","schema_version":1}\n';
+  writeText(root, proofPath, canonical);
+  writeText(root, oversizedProofPath, "x".repeat(256 * 1024));
+  const gitPublishes: GitPublishOptions[] = [];
+  const warnings: string[] = [];
+  let posted: Record<string, unknown> | undefined;
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      {
+        message: "chore: append apply proof action ledger",
+        paths: [proofPath, oversizedProofPath],
+        rebaseStrategy: "normal",
+      },
+      {
+        root,
+        env: appendEnv(),
+        fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+          posted = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+          return Response.json({ ok: true, appended: 1 }, { status: 202 });
+        }) as typeof fetch,
+        now: () => new Date("2026-07-21T12:20:00.000Z"),
+        publishGit: capturePublishes(gitPublishes),
+      },
+    ),
+    "committed",
+  );
+
+  assert.match(String(posted?.delivery_id), /^router:apply-proof-1234-2-[a-f0-9]{64}$/);
+  assert.deepEqual(posted?.records, [
+    {
+      kind: "apply_proof",
+      key: proofPath,
+      payload: canonical,
+      produced_at: "2026-07-21T12:20:00.000Z",
+    },
+  ]);
+  assert.deepEqual(gitPublishes[0]?.paths, [oversizedProofPath]);
+  assert.deepEqual(warnings, [
+    `State append apply-proof record ${oversizedProofPath} exceeds 262144 bytes; using git fallback`,
+  ]);
+});
+
+test("publish-main rejects an apply-proof symlink outside the workspace and uses git fallback", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-proof-"));
+  const outside = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-proof-outside-")),
+    "secret.json",
+  );
+  fs.writeFileSync(outside, '{"sensitive":"must-not-post"}\n');
+  const target = path.join(root, proofPath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  try {
+    fs.symlinkSync(outside, target, "file");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM") {
+      t.skip("file symlinks require an elevated Windows test environment");
+      return;
+    }
+    throw error;
+  }
+  const gitPublishes: GitPublishOptions[] = [];
+  const warnings: string[] = [];
+  let fetchCalls = 0;
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+  const original = { message: "chore: append apply proof action ledger", paths: [proofPath] };
+
+  assert.equal(
+    await publishMainWithStateAppend(original, {
+      root,
+      env: appendEnv(),
+      fetchImpl: (async () => {
+        fetchCalls += 1;
+        return Response.json({ ok: true, appended: 1 }, { status: 202 });
+      }) as typeof fetch,
+      publishGit: capturePublishes(gitPublishes),
+    }),
+    "committed",
+  );
+
+  assert.equal(fetchCalls, 0);
+  assert.deepEqual(gitPublishes, [original]);
+  assert.deepEqual(warnings, ["state-append shed/failed; falling back to git publish"]);
 });
 
 test("publish-main falls back to the original git publish on shed", async (t) => {
@@ -139,12 +312,37 @@ function writeStatus(root: string, slug: string): void {
   fs.writeFileSync(target, `${JSON.stringify(sweepStatus(slug))}\n`);
 }
 
+function writeJson(root: string, file: string, value: unknown): void {
+  writeText(root, file, `${JSON.stringify(value)}\n`);
+}
+
+function writeText(root: string, file: string, content: string): void {
+  const target = path.join(root, file);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+}
+
 function sweepStatus(slug = "openclaw-openclaw"): Record<string, unknown> {
   return {
     schema_version: 1,
     slug,
     state: "Review in progress",
     updated_at: "2026-07-21T12:00:00.000Z",
+  };
+}
+
+function routerLedger(): Record<string, unknown> {
+  return {
+    updated_at: "2026-07-21T12:10:00.000Z",
+    commands: [
+      {
+        comment_version_key: "router-a",
+        comment_id: "123",
+        comment_updated_at: "2026-07-21T12:09:00.000Z",
+        status: "executed",
+        processed_at: "2026-07-21T12:10:00.000Z",
+      },
+    ],
   };
 }
 

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -10,6 +10,7 @@ import { actionLedgerJson } from "../../dist/action-ledger.js";
 import {
   DEFAULT_STATE_MATERIALIZER_MAX_BYTES,
   DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
+  planStateMaterialization,
   runStateMaterializer,
   type StateAppendRecord,
 } from "../../dist/repair/state-materializer.js";
@@ -17,6 +18,23 @@ import {
 const webhookSecret = "state-materializer-test-secret";
 const producedAt = "2026-07-20T12:00:00.000Z";
 const proofPath = `ledger/v1/import-bindings/events/${"a".repeat(64)}.json`;
+
+test("materializer preserves canonical apply-proof content supplied as a string", () => {
+  const content = `${actionLedgerJson({
+    event_id: "proof-event-string",
+    schema: "clawsweeper.action-ledger-import-event-binding",
+    schema_version: 1,
+  })}\n`;
+
+  const plan = planStateMaterialization([record(1, "apply_proof", proofPath, content)]);
+
+  assert.deepEqual(plan, {
+    publishPaths: [proofPath],
+    writes: [{ path: proofPath, content }],
+    selected: 1,
+    skipped: 0,
+  });
+});
 
 test("materializer applies every record kind in sequence and keeps the last value per key", async () => {
   const fixture = createStateFixture();


### PR DESCRIPTION
WP-3b/3c of #738 — the last two writer lanes leave git. comment_router ledger updates and immutable apply-proof/action-ledger paths POST to /internal/state/append when CLAWSWEEPER_STATE_APPEND_ENABLED=1 (router, repair, review, retry, apply publishers wired). Fail-open git fallback on shed/error/oversize (>256KB records). Delivery ids: lane+run+attempt+content hash. Lease machinery intentionally untouched — deleted in the final PR once git-writer traffic is observed at zero.

Validation: 33/33 focused tests; 91/92 required suite (CI-only fixture exempt); build/lint/format/actionlint green; commit-mode autoreview clean.
