### PR TITLE
fix: configure batch publisher app client id

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -32,7 +32,7 @@ jobs:
       EXACT_REVIEW_BATCH_LEASE_OWNER: github:${{ github.run_id }}
       EXACT_REVIEW_BATCH_MANIFEST: .artifacts/exact-review-batch/manifest.json
       EXACT_REVIEW_BATCH_MAX_ITEMS: "2"
-      CLAWSWEEPER_APP_CLIENT_ID: ${{ vars.CLAWSWEEPER_APP_CLIENT_ID }}
+      CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
       CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -129,14 +129,14 @@ jobs:
             fi
             report="$bundle_dir/review/$item_number.md"
             if REPORT_PATH="$report" node <<'NODE'
-            const fs = require("node:fs");
-            const path = process.env.REPORT_PATH;
-            if (!path || !fs.existsSync(path)) process.exit(1);
-            const markdown = fs.readFileSync(path, "utf8");
-            const owner = /^review_lease_owner:\s*(.+)\s*$/m.exec(markdown)?.[1]?.trim() || "";
-            const commentId = Number(/^review_lease_comment_id:\s*(\d+)\s*$/m.exec(markdown)?.[1] || "0");
-            process.exit((!owner || owner === "unknown") && (!Number.isInteger(commentId) || commentId <= 0) ? 0 : 1);
-            NODE
+          const fs = require("node:fs");
+          const path = process.env.REPORT_PATH;
+          if (!path || !fs.existsSync(path)) process.exit(1);
+          const markdown = fs.readFileSync(path, "utf8");
+          const owner = /^review_lease_owner:\s*(.+)\s*$/m.exec(markdown)?.[1]?.trim() || "";
+          const commentId = Number(/^review_lease_comment_id:\s*(\d+)\s*$/m.exec(markdown)?.[1] || "0");
+          process.exit((!owner || owner === "unknown") && (!Number.isInteger(commentId) || commentId <= 0) ? 0 : 1);
+          NODE
             then
               echo "::warning::Leaving $target_repo#$item_number retryable: legacy tuple-less artifact"
               continue

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -29,6 +29,7 @@ test("batch publisher is event-driven with one non-cancelling serial workflow", 
   assert.match(workflow.jobs.publish!.if, /inputs\.execute/);
   assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute"]);
   assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_MAX_ITEMS, "2");
+  assert.equal(workflow.jobs.publish!.env.CLAWSWEEPER_APP_CLIENT_ID, "Iv23liOECG0slfuhz093");
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
   assert.deepEqual(workflow.permissions, { actions: "write", contents: "read" });
 });

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import YAML from "yaml";
@@ -66,6 +67,14 @@ test("batch workflow uses owner-scoped mutation credentials and isolated state c
   assert.match(source, /uses: \.\/\.github\/actions\/create-state-token/);
   assert.match(source, /uses: \.\/\.github\/actions\/setup-state/);
   assert.doesNotMatch(source, /permissions:\n(?:.*\n)*?\s+issues: write/);
+});
+
+test("batch workflow shell steps are valid Bash", () => {
+  for (const step of workflow.jobs.publish!.steps) {
+    if (!step.run) continue;
+    const syntax = spawnSync("bash", ["-n"], { input: step.run, encoding: "utf8" });
+    assert.equal(syntax.status, 0, `${step.name ?? "unnamed step"}: ${syntax.stderr}`);
+  }
 });
 
 test("batch claim treats an all-stale fetched batch as terminal", () => {


### PR DESCRIPTION
## Summary

- use the repository's established public ClawSweeper GitHub App client ID in the exact-review batch publisher
- keep the App private key secret-scoped
- assert the production client-ID wiring in the workflow test

## Root cause

The first live batch after #752 claimed two publication items, then failed before state setup because `vars.CLAWSWEEPER_APP_CLIENT_ID` was unset. Existing production workflows use the same public client ID as a checked-in environment constant.

Failed rollout evidence: https://github.com/openclaw/clawsweeper/actions/runs/29828501841

## Validation

- local Node 24 Alpine container only; no remote Crabbox/Testbox
- focused workflow test: 4 passed
- build/lint/unit: 1439 passed, 2 skipped, 0 failed
- repair/coverage/format gates passed after installing the CI toolchain in the container
- full coverage run: 2496 passed, 8 skipped, 0 failed
- autoreview: no accepted/actionable findings; patch correct (0.98)
