### PR TITLE
perf(dashboard): remove review reliability polling

### DIFF
--- a/dashboard/dashboard-health.ts
+++ b/dashboard/dashboard-health.ts
@@ -45,19 +45,6 @@ export function summarizeDashboardHealth(snapshot: Record<string, unknown>): Das
     else if (reviewTelemetryStatus !== "healthy") {
       raise("amber", "review_telemetry_unavailable");
     }
-
-    if (queue.review_execution_health != null) {
-      const reviewExecution = objectValue(queue.review_execution_health);
-      const reviewExecutionStatus = String(reviewExecution.health || "");
-      // Passive mode is a deliberate pre-producer rollout state and must not page operators
-      // before PR 674 turns enforcement on.
-      if (reviewExecutionStatus === "critical") raise("red", "review_execution_critical");
-      else if (reviewExecutionStatus === "degraded") {
-        raise("amber", "review_execution_degraded");
-      } else if (!["healthy", "passive"].includes(reviewExecutionStatus)) {
-        raise("amber", "review_execution_degraded");
-      }
-    }
   }
 
   const operationalStatus = String(objectValue(snapshot.operational_health).status || "");

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1286,11 +1286,8 @@ export class ExactReviewQueue {
           publicationFlow: this.publicationFlowSummarySync(now),
           deadLetters: this.deadLetterStatsSync(),
           reviewTelemetryHealth: this.reviewTelemetryHealthSync(now),
-          reviewExecutionHealth: this.reviewObservabilitySync({
-            range: "24h",
-            repo: null,
-            now,
-          }),
+          // Full review observability scans up to 10k durable records. Keep it on
+          // the diagnostic endpoint so the frequently-polled status path stays bounded.
           stateWriter: this.stateWriterSummarySync(now),
           stateAppend: this.stateAppendStatsSync(),
         };
@@ -1302,7 +1299,6 @@ export class ExactReviewQueue {
         publicationFlow,
         deadLetters,
         reviewTelemetryHealth,
-        reviewExecutionHealth,
         stateWriter,
         stateAppend,
       } = snapshot;
@@ -1399,7 +1395,6 @@ export class ExactReviewQueue {
         },
         delivery_receipts: this.deliveryReceiptCountSync(),
         review_telemetry_health: reviewTelemetryHealth,
-        review_execution_health: reviewExecutionHealth,
         state_writer: stateWriter,
         state_append: {
           ...stateAppend,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -7357,28 +7357,6 @@ h2::before { content: ""; flex: 0 0 auto; width: 14px; height: 2px; border-radiu
 .execution-alert-title strong { font-size: 13px; }
 .execution-alert-title span, .execution-alert-toggle, .execution-alert-body { color: var(--muted); font-size: 11px; }
 .execution-alert-body { padding: 0 15px 13px; }
-.review-reliability { margin-top: 22px; padding: 16px; border: 1px solid var(--line); border-radius: 12px; background: color-mix(in srgb, var(--panel) 94%, var(--claw)); }
-.review-reliability-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
-.review-reliability-title { display: grid; gap: 5px; }
-.review-reliability-title h3 { margin: 0; font-size: 14px; }
-.review-reliability-title span { color: var(--muted); font-size: 11px; }
-.review-reliability-controls { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
-.review-reliability-controls select { max-width: 220px; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--text); font: inherit; font-size: 11px; }
-.review-reliability-kpis, .review-reliability-sources { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; margin-top: 14px; background: var(--line-soft); border: 1px solid var(--line-soft); }
-.review-reliability-kpi, .review-reliability-source { padding: 11px 12px; background: var(--panel); min-width: 0; }
-.review-reliability-kpi span, .review-reliability-source span { display: block; color: var(--muted); font-size: 10px; }
-.review-reliability-kpi strong, .review-reliability-source strong { display: block; margin-top: 5px; font-size: 18px; }
-.review-reliability-source strong { font-size: 12px; }
-.review-reliability-source small { display: block; margin-top: 5px; color: var(--muted); font-size: 10px; }
-.review-status { display: inline-flex; align-items: center; gap: 6px; font-weight: 650; }
-.review-status::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--muted); }
-.review-status.healthy::before { background: var(--green); }
-.review-status.degraded::before { background: var(--amber); }
-.review-status.critical::before { background: var(--red); }
-.review-anomalies { margin-top: 12px; font-size: 11px; }
-.review-anomalies summary { cursor: pointer; color: var(--muted); }
-.review-anomaly-list { display: grid; gap: 7px; margin-top: 9px; }
-.review-anomaly { display: flex; justify-content: space-between; gap: 12px; padding-top: 7px; border-top: 1px solid var(--line-soft); }
 .exact-trend { margin: 14px 0 16px; }
 .exact-trend-status { font-size: 12px; font-weight: 650; }
 .exact-trend-status.growing { color: var(--amber); }
@@ -8205,7 +8183,6 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
 }
 @media (max-width: 760px) {
   .automerge-kpis { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .review-reliability-kpis, .review-reliability-sources { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .automerge-kpi:nth-child(3) { border-left: 0; border-top: 1px solid var(--line-soft); }
   .automerge-kpi:nth-child(4) { border-top: 1px solid var(--line-soft); }
   .automerge-details { grid-template-columns: 1fr; }
@@ -8224,9 +8201,6 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   .hero-headline { font-size: 23px; gap: 10px; }
   .hero-dot { width: 10px; height: 10px; }
   .exact-review-head { align-items: flex-start; flex-direction: column; }
-  .review-reliability-head { flex-direction: column; }
-  .review-reliability-controls { justify-content: flex-start; }
-  .review-reliability-kpis, .review-reliability-sources { grid-template-columns: 1fr; }
   .grid, .drawer-grid { grid-template-columns: 1fr; }
   .metric, .metric:nth-child(3n + 1) { border-left: 0; border-top: 1px solid var(--line-soft); padding-left: 0; }
   .metric:first-child { border-top: 0; }
@@ -8269,23 +8243,6 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     <h3 class="overview-section-title">Codex Capacity</h3>
     <div class="capacity-rail" id="capacity-rail"></div>
     <div id="execution-alert" aria-live="polite"></div>
-    <section class="review-reliability" aria-labelledby="review-reliability-title">
-      <div class="review-reliability-head">
-        <div class="review-reliability-title">
-          <h3 id="review-reliability-title">Review reliability</h3>
-          <span id="review-reliability-summary">Loading durable review telemetry…</span>
-        </div>
-        <div class="review-reliability-controls">
-          <select id="review-reliability-repo" aria-label="Review reliability repository"><option value="all">All repositories</option></select>
-          <div class="trend-ranges" id="review-reliability-ranges" aria-label="Review reliability range">
-            <button class="trend-range" type="button" data-review-range="6h">6h</button>
-            <button class="trend-range active" type="button" data-review-range="24h">24h</button>
-            <button class="trend-range" type="button" data-review-range="7d">7d</button>
-          </div>
-        </div>
-      </div>
-      <div id="review-reliability-body" aria-live="polite"><div class="empty">Loading review reliability…</div></div>
-    </section>
     <div class="exact-review-head">
       <h3 class="overview-section-title">Exact Review</h3>
       <div class="trend-ranges" id="trend-ranges" aria-label="Exact Review backlog history range">
@@ -8445,8 +8402,6 @@ let automaticIndex = new Map();
 let activeHealthRange = "6h";
 let healthHistoryLoadedAt = 0;
 let healthHistorySamples = [];
-let activeReviewRange = "24h";
-let reviewObservabilityRequestGeneration = 0;
 
 function exactReviewHistory(lane) {
   return healthHistorySamples.flatMap(sample => {
@@ -8727,56 +8682,6 @@ function renderExecutionAlert(current) {
   if (incomplete) parts.push("work execution telemetry is incomplete");
   const details = "Total GitHub queued " + fmt.format(Number(current?.queued_runs) || 0) + " · oldest queued " + formatAgeMinutes(current?.oldest_queued_minutes) + " · oldest running " + formatAgeMinutes(current?.oldest_running_minutes);
   target.innerHTML = '<details class="execution-alert"><summary><span class="execution-alert-title"><strong>⚠ Work execution needs attention</strong><span>' + esc(parts.join(" · ")) + '</span></span><span class="execution-alert-toggle">Details ▾</span></summary><div class="execution-alert-body">' + esc(details) + '</div></details>';
-}
-
-function reviewMetric(label, value, detail) {
-  return '<div class="review-reliability-kpi"><span>' + esc(label) + '</span><strong>' + esc(value) + '</strong>' + (detail ? '<small class="muted">' + esc(detail) + '</small>' : '') + '</div>';
-}
-
-function renderReviewReliability(payload) {
-  const summary = document.getElementById("review-reliability-summary");
-  const target = document.getElementById("review-reliability-body");
-  if (!summary || !target) return;
-  const passive = payload.mode === "passive";
-  const status = passive ? "Awaiting v2 producers" : payload.mode === "warmup" ? "Producer warm-up" : payload.health === "healthy" ? "Healthy" : payload.health === "critical" ? "Critical" : "Needs attention";
-  summary.innerHTML = '<span class="review-status ' + esc(payload.health) + '">' + esc(status) + '</span>' + (passive ? ' · PR 674 will enable enforcement' : ' · ' + esc(payload.range) + ' window');
-  const coverage = payload.terminal_coverage == null ? "n/a" : payload.terminal_coverage + "%";
-  const p95 = payload.phases?.total?.p95_ms;
-  const outcomes = payload.outcomes || {};
-  const kpis = [
-    reviewMetric("Terminal coverage", coverage, fmt.format(payload.terminal_attempts || 0) + " / " + fmt.format(payload.expected_attempts || 0)),
-    reviewMetric("Succeeded / failed / interrupted", fmt.format(outcomes.succeeded || 0) + " / " + fmt.format(outcomes.failed || 0) + " / " + fmt.format(outcomes.interrupted || 0), fmt.format(payload.unresolved_failures || 0) + " unresolved · success " + (payload.success_rate_percent == null ? "n/a" : payload.success_rate_percent + "%")),
-    reviewMetric("Superseded / cancelled", fmt.format(payload.expected_superseded || 0) + " / " + fmt.format(payload.unexpected_cancelled || 0), "expected / unexpected"),
-    reviewMetric("p95 total", p95 == null ? "n/a" : elapsed(p95), "refreshing " + fmt.format(payload.refreshing || 0) + " · slow " + fmt.format(payload.slow || 0) + " · orphan " + fmt.format(payload.orphan || 0))
-  ].join("");
-  const sources = (payload.sources || []).map(source => '<div class="review-reliability-source"><span>' + esc(source.label) + '</span><strong class="review-status ' + esc(source.status) + '">' + esc(source.status) + '</strong><small>last run ' + esc(source.last_run_at ? since(source.last_run_at) : "none") + ' · success ' + esc(source.last_success_at ? since(source.last_success_at) : "none") + ' · ' + fmt.format(source.item_count || 0) + ' items</small></div>').join("");
-  const anomalies = (payload.anomalies || []).map(row => '<div class="review-anomaly"><span><strong>' + esc(row.kind) + '</strong> ' + (row.item_url ? link(row.item_url, row.repo + "#" + row.item_number) : esc(row.repo || "workflow")) + (row.reason ? ' · ' + esc(row.reason) : '') + '</span>' + link(row.run_url, "Actions run") + '</div>').join("");
-  target.innerHTML = '<div class="review-reliability-kpis">' + kpis + '</div><div class="review-reliability-sources">' + sources + '</div>' + (anomalies ? '<details class="review-anomalies"><summary>' + fmt.format(payload.anomalies.length) + ' anomalies</summary><div class="review-anomaly-list">' + anomalies + '</div></details>' : '<div class="empty">No review anomalies in this window.</div>');
-}
-
-function populateReviewRepoFilter(repositories) {
-  const select = document.getElementById("review-reliability-repo");
-  if (!select) return;
-  const selected = select.value || "all";
-  const values = [...new Set((repositories || []).filter(Boolean))].sort();
-  select.innerHTML = '<option value="all">All repositories</option>' + values.map(repo => '<option value="' + esc(repo) + '">' + esc(repo) + '</option>').join("");
-  select.value = values.includes(selected) ? selected : "all";
-}
-
-async function loadReviewReliability() {
-  const generation = ++reviewObservabilityRequestGeneration;
-  const repo = document.getElementById("review-reliability-repo")?.value || "all";
-  try {
-    const response = await fetch("/api/review-observability?range=" + encodeURIComponent(activeReviewRange) + "&repo=" + encodeURIComponent(repo), { cache: "no-store" });
-    if (!response.ok) throw new Error("review observability returned " + response.status);
-    const payload = await response.json();
-    if (generation !== reviewObservabilityRequestGeneration) return;
-    renderReviewReliability(payload);
-  } catch {
-    if (generation !== reviewObservabilityRequestGeneration) return;
-    document.getElementById("review-reliability-summary").innerHTML = '<span class="review-status degraded">Telemetry unavailable</span>';
-    document.getElementById("review-reliability-body").innerHTML = '<div class="empty">Durable review telemetry could not be loaded.</div>';
-  }
 }
 
 function formatAgeMinutes(value) {
@@ -9277,7 +9182,6 @@ async function load() {
         : "",
   );
   loadHealthHistory(activeHealthRange, false).catch(() => undefined);
-  loadReviewReliability().catch(() => undefined);
   loadAutomergeMetrics().catch(() => undefined);
   } catch (error) {
     if (lastData) {
@@ -9326,7 +9230,6 @@ function renderDashboard(data, note) {
     metric("Codex Capacity", fleet.budget_used_percent + "%", "Codex slot utilization", fleet.budget_used_percent, "var(--green)")
   ].join("");
   renderExecutionAlert(data.operational_health);
-  populateReviewRepoFilter(data.source?.target_repositories || []);
   renderSystemMap(data);
   renderExactReviewLanes(data.exact_review_queue);
   renderStateWriter(data.exact_review_queue?.state_writer);
@@ -9829,14 +9732,6 @@ document.getElementById("trend-ranges").addEventListener("click", event => {
   document.querySelectorAll("button[data-trend-range]").forEach(item => item.classList.toggle("active", item === button));
   loadHealthHistory(button.dataset.trendRange || "6h", true).catch(() => undefined);
 });
-document.getElementById("review-reliability-ranges").addEventListener("click", event => {
-  const button = event.target.closest("button[data-review-range]");
-  if (!button) return;
-  activeReviewRange = button.dataset.reviewRange || "24h";
-  document.querySelectorAll("button[data-review-range]").forEach(item => item.classList.toggle("active", item === button));
-  loadReviewReliability().catch(() => undefined);
-});
-document.getElementById("review-reliability-repo").addEventListener("change", () => loadReviewReliability().catch(() => undefined));
 document.getElementById("automerge-ranges").addEventListener("click", event => {
   const button = event.target.closest("button[data-automerge-range]");
   if (!button) return;

--- a/docs/pr-674-observation-runbook.md
+++ b/docs/pr-674-observation-runbook.md
@@ -53,9 +53,9 @@ The watchdog is deliberately read-only. An aged refreshing row without an active
 changes the outcome to `interrupted`. A producer may record `interrupted` only after it proves the
 GitHub run is terminal and no current lease owns the attempt.
 
-## Review reliability API and card
+## Review reliability API
 
-The main dashboard loads:
+Operators can query:
 
 ```text
 GET /api/review-observability?range=24h&repo=all
@@ -64,17 +64,18 @@ GET /api/review-observability?range=24h&repo=all
 Accepted ranges are `6h`, `24h`, and `7d`; repository values are `all` or one `owner/repo` slug.
 The bounded response includes terminal coverage, outcome totals, expected supersession,
 unexpected cancellation, recovered/unresolved failures, phase p50/p95, four lane freshness rows,
-and at most 20 anomalies with complete item and Actions URLs. The card sits after Work execution
-and before Exact Review. `normal_backfill` has its own row so exact-event or hot-intake success
-cannot conceal global review failure.
+and at most 20 anomalies with complete item and Actions URLs. `normal_backfill` has its own row so
+exact-event or hot-intake success cannot conceal global review failure. The main dashboard does not
+load this expensive diagnostic on its polling path; query it only when investigating review
+reliability.
 
 Coverage uses the observer's paginated GitHub job count as an independent denominator, so an
 entirely missing item-producer record lowers coverage instead of disappearing from both sides of
 the ratio. Observer reconciliation is bound to the exact run attempt, and operation recovery is
 scoped by repository plus operation ID.
 
-The prerequisite deployment sets `REVIEW_OBSERVABILITY_REQUIRED=0`, and the card displays
-`Awaiting v2 producers` instead of green. PR 674 sets the flag to `1` and records
+The prerequisite deployment sets `REVIEW_OBSERVABILITY_REQUIRED=0`, so the API reports passive
+mode instead of green. PR 674 sets the flag to `1` and records
 `REVIEW_OBSERVABILITY_REQUIRED_SINCE` at rollout; the first 30 minutes are warm-up. After warm-up:
 
 - Green requires terminal coverage at least 98%, no slow/orphan/unexpected cancellation or

--- a/test/dashboard-health.test.ts
+++ b/test/dashboard-health.test.ts
@@ -68,34 +68,6 @@ test("dashboard health maps critical and stalled signals to red", () => {
   });
 });
 
-test("dashboard health rolls required review execution up while passive rollout stays neutral", () => {
-  const passive = healthySnapshot();
-  (passive.exact_review_queue as Record<string, any>).review_execution_health = {
-    health: "passive",
-  };
-  assert.equal(summarizeDashboardHealth(passive).severity, "green");
-
-  const degraded = healthySnapshot();
-  (degraded.exact_review_queue as Record<string, any>).review_execution_health = {
-    health: "degraded",
-  };
-  assert.deepEqual(summarizeDashboardHealth(degraded), {
-    conclusion: "needs_attention",
-    severity: "amber",
-    reasons: ["review_execution_degraded"],
-  });
-
-  const critical = healthySnapshot();
-  (critical.exact_review_queue as Record<string, any>).review_execution_health = {
-    health: "critical",
-  };
-  assert.deepEqual(summarizeDashboardHealth(critical), {
-    conclusion: "needs_attention",
-    severity: "red",
-    reasons: ["review_execution_critical"],
-  });
-});
-
 test("dashboard health fails amber when a required signal is absent", () => {
   const snapshot = healthySnapshot();
   const queue = snapshot.exact_review_queue as Record<string, any>;

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -811,6 +811,7 @@ test("dashboard status reads the exact-review handoff model from the durable que
   assert.equal(status.lanes.review.completed_total, 0);
   assert.equal(status.lanes.publication.enqueued_total, 1);
   assert.equal(status.lanes.publication.completed_total, 0);
+  assert.equal(status.review_execution_health, undefined);
   assert.deepEqual(
     {
       pending: status.lanes.review.pending,
@@ -7054,9 +7055,8 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.doesNotMatch(html, /id="health-trend-grid"/);
   assert.match(html, /\/api\/health-history\?range=/);
   assert.match(html, /Work execution needs attention/);
-  assert.match(html, /Review reliability/);
-  assert.match(html, /Awaiting v2 producers/);
-  assert.match(html, /\/api\/review-observability\?range=/);
+  assert.doesNotMatch(html, /Review reliability/);
+  assert.doesNotMatch(html, /\/api\/review-observability\?range=/);
   assert.match(html, /data-trend-range="6h"/);
   assert.match(html, /<details class="execution-alert">/);
   assert.match(html, /Error Rate/);
@@ -7078,7 +7078,6 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
     /<div class="exact-lanes">\s*<div class="exact-review-lanes" id="exact-review-lanes"[\s\S]*?<section class="exact-lane" id="state-writer-health"/,
   );
   assert.ok(html.indexOf("Codex Capacity") < html.indexOf('id="exact-review-lanes"'));
-  assert.ok(html.indexOf("Review reliability") < html.indexOf('id="exact-review-lanes"'));
   assert.ok(html.indexOf('id="exact-review-lanes"') < html.indexOf("Handoff Health"));
   assert.match(html, /Live terminals/);
   assert.match(html, /href="https:\/\/fleet\.example\.test\/terminal\?view=live&amp;mode=all"/);
@@ -7519,58 +7518,6 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(elementFor("execution-alert").innerHTML, /1 execution over 150m/);
   context.renderExecutionAlert({ ...healthyOperational, telemetry_complete: false });
   assert.match(elementFor("execution-alert").innerHTML, /telemetry is incomplete/);
-
-  const reviewReliability = {
-    mode: "passive",
-    health: "passive",
-    range: "24h",
-    terminal_coverage: null,
-    terminal_attempts: 0,
-    expected_attempts: 0,
-    success_rate_percent: null,
-    outcomes: {},
-    unresolved_failures: 0,
-    expected_superseded: 0,
-    unexpected_cancelled: 0,
-    refreshing: 0,
-    slow: 0,
-    orphan: 0,
-    phases: { total: { p95_ms: null } },
-    sources: [],
-    anomalies: [],
-  };
-  context.renderReviewReliability(reviewReliability);
-  assert.match(elementFor("review-reliability-summary").innerHTML, /Awaiting v2 producers/);
-  context.renderReviewReliability({
-    ...reviewReliability,
-    mode: "required",
-    health: "healthy",
-    terminal_coverage: 100,
-  });
-  assert.match(elementFor("review-reliability-summary").innerHTML, /review-status healthy/);
-  context.renderReviewReliability({
-    ...reviewReliability,
-    mode: "required",
-    health: "degraded",
-    anomalies: [
-      {
-        kind: "cancelled",
-        repo: "openclaw/openclaw",
-        item_number: 674,
-        item_url: "https://github.com/openclaw/openclaw/pull/674",
-        run_url: "https://github.com/openclaw/clawsweeper/actions/runs/123",
-        reason: "workflow_cancelled",
-      },
-    ],
-  });
-  assert.match(elementFor("review-reliability-summary").innerHTML, /review-status degraded/);
-  assert.match(elementFor("review-reliability-body").innerHTML, /actions\/runs\/123/);
-  context.renderReviewReliability({
-    ...reviewReliability,
-    mode: "required",
-    health: "critical",
-  });
-  assert.match(elementFor("review-reliability-summary").innerHTML, /review-status critical/);
 
   status.diagnostics.exact_review_queue_error = null;
   status.exact_review_queue = { handoff_health: { status: "healthy", phases: {} } };


### PR DESCRIPTION
## Summary

- remove the unused Review reliability panel and its 15-second browser polling
- keep full review observability on the explicit diagnostic endpoint instead of computing it during every queue stats/status request
- stop rolling the removed execution aggregate into dashboard health while preserving the lightweight review telemetry watchdog

## Why

`/api/status` always attaches exact-review queue stats, even when the fleet snapshot is cached. Queue stats had begun scanning up to 10,000 review records and 10,000 workflow-run records to build the Review reliability aggregate. The dashboard then fetched the same diagnostic independently after every status refresh. This made the frequently-polled status path unnecessarily expensive and contributed to multi-second and long-tail responses.

## Storage scope

This change does **not** remove storage-side review reliability telemetry. Producers, Durable Object tables, retention/pruning logic, the observer workflow, and `GET /api/review-observability` remain available for targeted diagnosis. Removing that stored telemetry can be evaluated separately later, after its operational value and migration/rollback requirements are understood.

## Validation

- `pnpm run build:dashboard`
- `node --test test/dashboard-health.test.ts test/dashboard-worker.test.ts` (166 passed)
- dashboard lint and format checks
- autoreview: clean, no accepted/actionable findings
- full `pnpm run check`: 1,059 passed, 3 skipped, 2 unrelated environment failures because the installed Git does not support the tests' required `--no-lazy-fetch`
