### PR TITLE
perf(dashboard): cache composed status responses

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -602,17 +602,17 @@ export default {
 async function statusJson(request, env, ctx) {
   const cache = caches.default;
   const cached = await cache.match(statusCacheRequest(request, "fresh"));
-  if (cached) return cachedStatusResponse(cached, "fresh", env);
+  if (cached) return cachedStatusResponse(cached, "fresh");
 
   const stale = await cache.match(statusCacheRequest(request, "stale"));
   if (stale && ctx?.waitUntil) {
     ctx.waitUntil(refreshStatus(request, env).catch(() => undefined));
-    return cachedStatusResponse(stale, "stale", env);
+    return cachedStatusResponse(stale, "stale");
   }
 
   const refreshed = await refreshStatus(request, env);
-  if (refreshed.looksEmpty && stale) return cachedStatusResponse(stale, "stale", env);
-  return statusSnapshotResponse(refreshed.snapshot, "miss", env);
+  if (refreshed.looksEmpty && stale) return cachedStatusResponse(stale, "stale");
+  return statusSnapshotResponse(refreshed.snapshot, "miss");
 }
 
 async function healthHistoryJson(request: Request, env: DashboardEnv) {
@@ -713,19 +713,22 @@ async function appendHealthHistorySample(env, sample) {
   );
 }
 
-async function cachedStatusResponse(cached, cacheState, env) {
-  const snapshot = await cached.json();
+function cachedStatusResponse(cached, cacheState) {
   const headers = new Headers(cached.headers);
-  return statusSnapshotResponse(snapshot, cacheState, env, cached.status, headers);
+  headers.set("content-type", "application/json; charset=utf-8");
+  headers.set("cache-control", "no-store");
+  headers.set("x-clawsweeper-cache", cacheState);
+  return cors(new Response(cached.body, { status: cached.status, headers }));
 }
 
-async function statusSnapshotResponse(snapshot, cacheState, env, status = 200, headers?) {
-  const current = await attachExactReviewQueueStatus(snapshot, env);
+function statusSnapshotResponse(snapshot, cacheState, status = 200, headers?) {
   const responseHeaders = new Headers(headers);
   responseHeaders.set("content-type", "application/json; charset=utf-8");
   responseHeaders.set("cache-control", "no-store");
   responseHeaders.set("x-clawsweeper-cache", cacheState);
-  return cors(new Response(JSON.stringify(current, null, 2), { status, headers: responseHeaders }));
+  return cors(
+    new Response(JSON.stringify(snapshot, null, 2), { status, headers: responseHeaders }),
+  );
 }
 
 function refreshStatus(request, env) {
@@ -755,7 +758,11 @@ function refreshStatus(request, env) {
 async function refreshStatusCaches(request, env) {
   const ttl = numberFrom(env.CACHE_TTL_SECONDS, 20);
   const staleTtl = numberFrom(env.STALE_CACHE_TTL_SECONDS, STALE_CACHE_TTL_SECONDS);
-  const snapshot = await statusSnapshot(env);
+  const baseSnapshot = await statusSnapshot(env);
+  // Queue stats and the GitHub-backed global lease are operational observations, not
+  // request-specific data. Cache the composed document so a cache hit never waits on
+  // those remote probes; the existing stale-while-revalidate path refreshes them safely.
+  const snapshot = await attachExactReviewQueueStatus(baseSnapshot, env);
   const body = JSON.stringify(snapshot, null, 2);
   const hasErrors = Boolean(snapshot.diagnostics?.errors?.length);
   const looksEmpty =
@@ -788,7 +795,7 @@ async function refreshStatusCaches(request, env) {
 }
 
 function statusCacheRequest(request, bucket) {
-  return new Request(new URL(`/api/status-cache/v2/${bucket}`, request.url).toString(), {
+  return new Request(new URL(`/api/status-cache/v3/${bucket}`, request.url).toString(), {
     method: "GET",
   });
 }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2694,12 +2694,15 @@ test("optional exact-review telemetry failures do not freeze an idle status snap
   globalThis.fetch = async () => {
     throw new Error("shared snapshot should avoid GitHub requests");
   };
+  let queueReads = 0;
   const failingQueue = {
-    fetch: async () =>
-      new Response(JSON.stringify({ error: "queue_read_failed" }), {
+    fetch: async () => {
+      queueReads += 1;
+      return new Response(JSON.stringify({ error: "queue_read_failed" }), {
         status: 503,
         headers: { "content-type": "application/json" },
-      }),
+      });
+    },
   };
   const env = {
     CACHE_TTL_SECONDS: "60",
@@ -2725,6 +2728,7 @@ test("optional exact-review telemetry failures do not freeze an idle status snap
     );
     assert.equal(cached.headers.get("x-clawsweeper-cache"), "fresh");
     assert.equal((await cached.json()).diagnostics.exact_review_queue_error, "queue_read_failed");
+    assert.equal(queueReads, 1);
   } finally {
     globalThis.fetch = originalFetch;
     Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });
@@ -8931,7 +8935,7 @@ test("dashboard serves stale status while coalescing one background refresh", as
     value: { default: cache },
   });
   await cache.put(
-    new Request("https://clawsweeper.openclaw.ai/api/status-cache/v2/stale"),
+    new Request("https://clawsweeper.openclaw.ai/api/status-cache/v3/stale"),
     jsonResponse({
       schema_version: 1,
       generated_at: "2026-06-13T18:00:00Z",
@@ -8967,8 +8971,12 @@ test("dashboard serves stale status while coalescing one background refresh", as
       },
     },
   };
+  let queueReads = 0;
   const exactReviewQueue = new MemoryDurableNamespace({
-    fetch: async () => jsonResponse(currentQueue),
+    fetch: async () => {
+      queueReads += 1;
+      return jsonResponse(currentQueue);
+    },
   });
 
   let releaseFetch!: () => void;
@@ -9014,18 +9022,24 @@ test("dashboard serves stale status while coalescing one background refresh", as
     const firstStatus = await first.json();
     const secondStatus = await second.json();
     assert.equal(firstStatus.pipeline[0].id, "stale-row");
-    assert.equal(firstStatus.exact_review_queue.pending, 7);
-    assert.equal(firstStatus.exact_review_queue.handoff_health.status, "healthy");
-    assert.equal(secondStatus.exact_review_queue.handoff_health.status, "healthy");
+    assert.equal(firstStatus.exact_review_queue.pending, 1);
+    assert.equal(firstStatus.exact_review_queue.handoff_health.status, "stalled");
+    assert.equal(secondStatus.exact_review_queue.handoff_health.status, "stalled");
+    assert.equal(queueReads, 0);
     assert.equal(waitUntilPromises.length, 2);
 
     releaseFetch();
     await Promise.all(waitUntilPromises);
     assert.equal(unfilteredRunRequests, 1);
+    assert.equal(queueReads, 1);
 
     const refreshed = await worker.fetch(request, env);
     assert.equal(refreshed.headers.get("x-clawsweeper-cache"), "fresh");
-    assert.deepEqual((await refreshed.json()).pipeline, []);
+    const refreshedStatus = await refreshed.json();
+    assert.deepEqual(refreshedStatus.pipeline, []);
+    assert.equal(refreshedStatus.exact_review_queue.pending, 7);
+    assert.equal(refreshedStatus.exact_review_queue.handoff_health.status, "healthy");
+    assert.equal(queueReads, 1);
   } finally {
     globalThis.fetch = originalFetch;
     Object.defineProperty(globalThis, "caches", { configurable: true, value: originalCaches });


### PR DESCRIPTION
## Summary

- cache the fully composed status document, including exact-review queue telemetry, global state-writer lease, and dashboard health
- serve fresh and stale cache hits as response streams without reparsing or recomputing the document
- move queue and GitHub lease probes onto the existing stale-while-revalidate refresh path
- bump the internal cache key version so old base-only cache entries cannot mix with the new contract

## Root cause and candidate slow points

A fresh base snapshot cache hit still synchronously attached queue status and the global state-writer lease before every response. Live measurements showed fresh cache hits taking 0.8-5.0 seconds. The queue endpoint alone took about 0.8-1.8 seconds, while the normal free-lease path performed two serial GitHub requests measured locally at about 0.8 and 1.5 seconds.

Other follow-up candidates are the queue stats read path, which also performs pruning/reconciliation/scheduling and several SQL summaries, the roughly 98 KB status payload polled every 15 seconds, and cold base snapshots with broad GitHub fan-out. This PR selects the cache-hit critical path because it removes remote blocking from the common request without deleting observability or changing its ownership.

## Impact

Fresh cache hits no longer contact the Durable Object or GitHub. Stale hits return the previous complete observation immediately and refresh once in the background. Queue and lease telemetry remain available with the same short bounded staleness as the rest of the status document.

## Validation

- pnpm run build:dashboard
- pnpm run lint:dashboard
- node --test test/dashboard-health.test.ts test/dashboard-worker.test.ts (166 passed)
- pnpm run check: 1,059 passed, 3 skipped; 2 unrelated repair tests fail because the local Git lacks required --no-lazy-fetch support
- autoreview local: clean, patch is correct, confidence 0.89