### PR TITLE
Fix State writer dashboard after serialization cutover

### DIFF
--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -54,6 +54,7 @@ export type ExactReviewLaneHistorySample = {
 
 export type StateWriterHistorySample = {
   collection_ok: boolean;
+  terminal_collection_ok?: boolean;
   mode?: "single_item" | "batch" | "mixed" | "unknown";
   tracked_holding?: number;
   tracked_waiting?: number;
@@ -166,17 +167,30 @@ export function stateWriterHistorySample(value: unknown): StateWriterHistorySamp
   const writer = objectValue(value);
   const collection = objectValue(writer.collection);
   const live = objectValue(writer.live);
+  const coordinator = objectValue(writer.coordinator);
   const window = objectValue(writer.last_15_minutes);
   const diagnostics = objectValue(writer.diagnostics);
   const mode = ["single_item", "batch", "mixed", "unknown"].includes(String(writer.mode))
     ? (writer.mode as StateWriterHistorySample["mode"])
     : "unknown";
-  const collectionOk = collection.status === "fresh";
+  const coordinatorQueued = nonNegativeInteger(coordinator.queued);
+  const coordinatorLeased = nonNegativeInteger(coordinator.leased);
+  const coordinatorOk = coordinatorQueued !== null && coordinatorLeased !== null;
+  // Progress events legitimately go stale while the serialized writer is idle.
+  // The coordinator snapshot is the authoritative liveness source after the
+  // repo-wide serialization cutover, so an idle writer must remain a valid
+  // history sample instead of disappearing from the panel.
+  const collectionOk = collection.status === "fresh" || coordinatorOk;
   return {
     collection_ok: collectionOk,
+    terminal_collection_ok: collection.status === "fresh",
     mode,
-    tracked_holding: nonNegativeInteger(live.tracked_holding) ?? 0,
-    tracked_waiting: nonNegativeInteger(live.tracked_waiting) ?? 0,
+    tracked_holding: coordinatorOk
+      ? coordinatorLeased
+      : (nonNegativeInteger(live.tracked_holding) ?? 0),
+    tracked_waiting: coordinatorOk
+      ? coordinatorQueued
+      : (nonNegativeInteger(live.tracked_waiting) ?? 0),
     tracked_releasing: nonNegativeInteger(live.tracked_releasing) ?? 0,
     accepted_operations_total: nonNegativeInteger(diagnostics.accepted_terminal_total) ?? 0,
     state_commits_total: nonNegativeInteger(diagnostics.state_commits_total) ?? 0,
@@ -251,6 +265,8 @@ function normalizeStateWriterHistorySample(value: unknown): StateWriterHistorySa
       : null;
   return {
     collection_ok: true,
+    terminal_collection_ok:
+      typeof sample.terminal_collection_ok === "boolean" ? sample.terminal_collection_ok : true,
     mode,
     ...values,
     wait_ms: wait,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8709,7 +8709,7 @@ function formatAgeMinutes(value) {
 async function loadHealthHistory(range, force) {
   if (!force && range === activeHealthRange && Date.now() - healthHistoryLoadedAt < 60000) {
     renderExactReviewLanes(lastData?.exact_review_queue);
-    renderStateWriter(lastData?.exact_review_queue?.state_writer);
+    renderStateWriter(lastData?.exact_review_queue);
     return;
   }
   activeHealthRange = range;
@@ -8726,7 +8726,7 @@ async function loadHealthHistory(range, force) {
     healthHistorySamples = [];
   }
   renderExactReviewLanes(lastData?.exact_review_queue);
-  renderStateWriter(lastData?.exact_review_queue?.state_writer);
+  renderStateWriter(lastData?.exact_review_queue);
 }
 
 function workerGroup(worker) {
@@ -8831,7 +8831,10 @@ function renderSystemMap(data) {
 function stateWriterHistorySamples() {
   return healthHistorySamples.flatMap((sample) => {
     const writer = sample?.state_writer;
-    if (!writer || writer.collection_ok !== true) return [];
+    // Legacy samples predate the split and used collection_ok exclusively for
+    // terminal telemetry. New coordinator-only samples stay useful for queue
+    // history but must not contribute stale throughput counters.
+    if (!writer || writer.collection_ok !== true || writer.terminal_collection_ok === false) return [];
     return [{
       at: sample.at,
       accepted: Number(writer.accepted_operations_total || 0),
@@ -8863,10 +8866,20 @@ function stateWriterRateFromHistory(samples, field) {
   return Math.round(((end[field] - start[field]) / elapsedHours) * 10) / 10;
 }
 
-function renderStateWriter(writer) {
+function renderStateWriter(queue) {
   const target = document.getElementById("state-writer-health");
   if (!target) return;
-  if (!writer || !writer.collection) {
+  const writer = queue?.state_writer;
+  const coordinator = writer?.coordinator || {};
+  const batches = queue?.lanes?.publication?.batches || {};
+  const coordinatorLive = ["queued", "leased", "admitted", "completed"].every(
+    field =>
+      coordinator[field] !== null &&
+      coordinator[field] !== undefined &&
+      Number.isFinite(Number(coordinator[field])) &&
+      Number(coordinator[field]) >= 0
+  );
+  if (!writer || (!writer.collection && !coordinatorLive)) {
     target.innerHTML = '<div class="exact-lane-head"><strong>State writer</strong><span>Unavailable</span></div><p class="state-writer-note">Writer telemetry has not been collected.</p>';
     return;
   }
@@ -8876,9 +8889,13 @@ function renderStateWriter(writer) {
   const hour = writer.last_60_minutes || {};
   const history = stateWriterHistorySamples();
   const latestHistory = history.at(-1);
-  const itemsPerHour = stateWriterRateFromHistory(history, "items");
-  const commitsPerHour = stateWriterRateFromHistory(history, "commits");
-  const commitSegment = stateWriterHistorySegment(history, "commits");
+  const historyFresh = Boolean(
+    latestHistory && Date.now() - Date.parse(latestHistory.at) <= 12 * 60 * 1000
+  );
+  const itemsPerHour = historyFresh ? stateWriterRateFromHistory(history, "items") : null;
+  const commitsPerHour = historyFresh ? stateWriterRateFromHistory(history, "commits") : null;
+  const commitSegment = historyFresh ? stateWriterHistorySegment(history, "commits") : null;
+  const terminalFresh = collection.status === "fresh";
   const itemsPerCommit =
     commitSegment &&
     commitSegment.length >= 2 &&
@@ -8888,18 +8905,24 @@ function renderStateWriter(writer) {
             (commitSegment[commitSegment.length - 1].commits - commitSegment[0].commits)) *
             100,
         ) / 100
-      : hour.items_per_commit;
-  const wait = latestHistory?.wait || hour.wait_ms;
-  const hold = latestHistory?.hold || hour.hold_ms;
+      : terminalFresh
+        ? hour.items_per_commit
+        : null;
+  const wait = historyFresh ? latestHistory?.wait : terminalFresh ? hour.wait_ms : null;
+  const hold = historyFresh ? latestHistory?.hold : terminalFresh ? hour.hold_ms : null;
   const rangeLabel = activeHealthRange === "7d" ? "7d" : activeHealthRange;
   const liveFresh =
     collection.status === "fresh" &&
     (live.freshness_seconds == null || Number(live.freshness_seconds) <= 90);
+  const configuredBatchSize = Number.isInteger(Number(batches.max_items)) && Number(batches.max_items) > 0
+    ? Number(batches.max_items)
+    : null;
+  const batchingConfigured = batches.enabled === true;
   const mode =
     writer.mode === "mixed"
       ? "Mixed · legacy draining + batch active"
-      : writer.mode === "batch"
-        ? "Batch"
+      : batchingConfigured || writer.mode === "batch"
+        ? "Batch" + (configuredBatchSize ? " · configured " + configuredBatchSize : "")
         : writer.mode === "single_item"
           ? "Single-item"
           : "Unknown";
@@ -8907,25 +8930,44 @@ function renderStateWriter(writer) {
   const percentile = (value) =>
     value?.samples ? "p50 " + metric(value.p50) + "ms · p95 " + metric(value.p95) + "ms · n=" + value.samples : "unknown";
   const itemTrend = history.map((sample) => ({ at: sample.at, pending: sample.items }));
+  const coordinatorTurns = coordinatorLive
+    ? metric(coordinator.completed) + " completed · " + metric(coordinator.admitted) + " admitted" +
+      (Number(coordinator.recovered) || Number(coordinator.expired)
+        ? " · " + metric(coordinator.recovered, 0) + " recovered · " + metric(coordinator.expired, 0) + " expired"
+        : "")
+    : "unknown";
+  const coordinatorWait = coordinatorLive
+    ? "last " + elapsed(Number(coordinator.last_wait_ms)) + " · max " + elapsed(Number(coordinator.max_wait_ms))
+    : "unknown";
+  const terminalStatus = terminalFresh
+    ? "terminal telemetry fresh"
+    : collection.last_observed_at
+      ? "terminal telemetry stale · last observed " + since(collection.last_observed_at)
+      : "terminal telemetry unavailable";
   target.innerHTML =
-    '<div class="exact-lane-head"><strong>State writer</strong><span>' + esc(mode) + " · " + esc(metric(collection.status)) + " · " + esc(rangeLabel) + "</span></div>" +
+    '<div class="exact-lane-head"><strong>State writer</strong><span>' + esc(mode) + " · " + esc(coordinatorLive ? "coordinator live" : metric(collection.status)) + " · " + esc(rangeLabel) + "</span></div>" +
     '<div class="lane-counts">' +
-    '<div class="lane-count"><span>Global state lease</span><strong>' + esc(metric(lease.status)) + ' · 1 writer max</strong></div>' +
-    '<div class="lane-count"><span>Tracked publishers</span><strong>' +
-    (liveFresh
-      ? metric(live.tracked_holding, "unknown") + " holding · " + metric(live.tracked_waiting, "unknown") + " waiting"
-      : "unknown holding · unknown waiting") +
+    '<div class="lane-count"><span>Serialization queue</span><strong>' +
+    (coordinatorLive
+      ? metric(coordinator.leased) + " active · " + metric(coordinator.queued) + " queued · 1 writer max"
+      : liveFresh
+        ? metric(live.tracked_holding, "unknown") + " active · " + metric(live.tracked_waiting, "unknown") + " queued · 1 writer max"
+        : "unknown active · unknown queued · 1 writer max") +
+    '</strong></div>' +
+    '<div class="lane-count"><span>Git crash fence</span><strong>' + esc(metric(lease.status)) +
     "</strong></div></div>" +
     exactReviewTrend(itemTrend, "Materialized items") +
     '<dl class="lane-metrics">' +
-    "<div><dt>Materialized</dt><dd>" + esc(metric(itemsPerHour ?? hour.materialized_items)) + " items/hour</dd></div>" +
-    "<div><dt>State commits</dt><dd>" + esc(metric(commitsPerHour ?? hour.state_commits)) + "/hour</dd></div>" +
+    "<div><dt>Coordinator turns</dt><dd>" + esc(coordinatorTurns) + "</dd></div>" +
+    "<div><dt>Coordinator wait</dt><dd>" + esc(coordinatorWait) + "</dd></div>" +
+    "<div><dt>Exact-review materialized</dt><dd>" + esc(metric(itemsPerHour ?? (terminalFresh ? hour.materialized_items : null))) + " items/hour</dd></div>" +
+    "<div><dt>Exact-review commits</dt><dd>" + esc(metric(commitsPerHour ?? (terminalFresh ? hour.state_commits : null))) + "/hour</dd></div>" +
     "<div><dt>Items / commit</dt><dd>" + esc(metric(itemsPerCommit)) + "</dd></div>" +
-    "<div><dt>Lease wait</dt><dd>" + esc(percentile(wait)) + "</dd></div>" +
-    "<div><dt>Lease hold</dt><dd>" + esc(percentile(hold)) + "</dd></div>" +
+    "<div><dt>Git fence wait</dt><dd>" + esc(percentile(wait)) + "</dd></div>" +
+    "<div><dt>Git fence hold</dt><dd>" + esc(percentile(hold)) + "</dd></div>" +
     "</dl>" +
-    '<p class="state-writer-note">Live holding/waiting require fresh progress. Throughput uses the selected ' + esc(rangeLabel) + " history when available; otherwise the rolling hour.</p>" +
-    '<p class="state-writer-note">Publication workflows can run concurrently, but they feed one serialized state-ref writer.</p>';
+    '<p class="state-writer-note">' + esc(terminalStatus) + ". Exact-review throughput uses recent " + esc(rangeLabel) + " history when available; stale terminal samples are never rendered as current zeroes.</p>" +
+    '<p class="state-writer-note">The durable coordinator is authoritative for active and queued writers. The Git ref remains only a crash-recovery fence.</p>';
 }
 
 function renderExactReviewLanes(queue) {
@@ -9245,7 +9287,7 @@ function renderDashboard(data, note) {
   renderExecutionAlert(data.operational_health);
   renderSystemMap(data);
   renderExactReviewLanes(data.exact_review_queue);
-  renderStateWriter(data.exact_review_queue?.state_writer);
+  renderStateWriter(data.exact_review_queue);
   renderExactReviewHandoff(data.exact_review_queue);
   renderApplyHealth(data);
   renderAutomaticWork(data.automatic_work || []);

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -327,6 +327,18 @@ recovery progress, and last classified GitHub pressure failure. `/api/status` re
 `control_plane` compatibility field, but the dashboard no longer renders that
 low-actionability section.
 
+The standalone **State writer** panel separates the repo-wide serialization
+boundary from exact-review materialization telemetry. After the coordinator
+cutover, `state_writer.coordinator` is authoritative for the active writer,
+FIFO queue depth, completed turns, recovery counters, and coordinator wait.
+The Git lease ref is displayed only as a crash-recovery fence. Exact-review
+terminal telemetry still owns item/commit throughput and Git fence timing; an
+idle or failed publisher can make that telemetry stale without making the
+coordinator unavailable. The panel therefore shows the configured publication
+batch size independently, labels stale terminal data, and never renders stale
+zeroes as current throughput. Five-minute history samples use coordinator
+liveness and queue depth when progress events are idle.
+
 Executors report the GitHub job outcome from their finalizer. Failure or
 cancellation clears the lease and requeues the item. Finalizer success remains
 provisional because GitHub can still cancel the run or fail a post-action; only

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -5,6 +5,7 @@ import {
   exactReviewHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
+  stateWriterHistorySample,
   summarizeOperationalHealth,
 } from "../dashboard/operational-health.ts";
 
@@ -194,6 +195,39 @@ test("health history keeps legacy samples when optional state_writer is absent o
     state_writer: { collection_ok: true, mode: "not-a-mode" },
   });
   assert.deepEqual(withInvalidWriter, legacy);
+});
+
+test("state writer history uses the coordinator while terminal progress is idle", () => {
+  assert.deepEqual(
+    stateWriterHistorySample({
+      collection: { status: "stale" },
+      coordinator: { queued: 3, leased: 1 },
+      diagnostics: {
+        accepted_terminal_total: 12,
+        state_commits_total: 6,
+        materialized_items_total: 11,
+        contention_timeouts_total: 2,
+      },
+      last_15_minutes: {},
+      live: { tracked_holding: 0, tracked_waiting: 0, tracked_releasing: 0 },
+      mode: "batch",
+    }),
+    {
+      collection_ok: true,
+      terminal_collection_ok: false,
+      mode: "batch",
+      tracked_holding: 1,
+      tracked_waiting: 3,
+      tracked_releasing: 0,
+      accepted_operations_total: 12,
+      state_commits_total: 6,
+      materialized_items_total: 11,
+      contention_timeouts_total: 2,
+      wait_ms: { p50: null, p95: null, samples: 0 },
+      hold_ms: { p50: null, p95: null, samples: 0 },
+      last_successful_materialization_at: null,
+    },
+  );
 });
 
 test("health history rejects non-finite or incomplete samples", () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7495,23 +7495,75 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     /<div class="exact-lane-head"><strong>State writer<\/strong><span>Unavailable<\/span><\/div>/,
   );
   context.renderStateWriter({
-    collection: { status: "fresh" },
-    global_lease: { status: "held" },
-    last_60_minutes: {
-      materialized_items: 2,
-      state_commits: 1,
-      items_per_commit: 2,
-      wait_ms: { p50: 10, p95: 20, samples: 2 },
-      hold_ms: { p50: 30, p95: 40, samples: 2 },
+    lanes: { publication: { batches: { enabled: true, max_items: 2 } } },
+    state_writer: {
+      collection: { status: "stale", last_observed_at: "2026-07-21T12:12:42.397Z" },
+      coordinator: {
+        queued: 0,
+        leased: 0,
+        admitted: 16,
+        completed: 16,
+        expired: 0,
+        recovered: 0,
+        last_wait_ms: 0,
+        max_wait_ms: 300_309,
+      },
+      global_lease: { status: "free" },
+      last_60_minutes: {
+        materialized_items: 0,
+        state_commits: 0,
+        items_per_commit: null,
+        wait_ms: { p50: null, p95: null, samples: 0 },
+        hold_ms: { p50: null, p95: null, samples: 0 },
+      },
+      live: { freshness_seconds: null, tracked_holding: 0, tracked_waiting: 0 },
+      mode: "unknown",
     },
-    live: { freshness_seconds: 10, tracked_holding: 1, tracked_waiting: 3 },
-    mode: "single_item",
   });
   const stateWriterHtml = elementFor("state-writer-health").innerHTML;
   assert.match(stateWriterHtml, /class="exact-lane-head"/);
-  assert.match(stateWriterHtml, /Single-item · fresh · 6h/);
-  assert.match(stateWriterHtml, /Global state lease<\/span><strong>held · 1 writer max/);
-  assert.match(stateWriterHtml, /Tracked publishers<\/span><strong>1 holding · 3 waiting/);
+  assert.match(stateWriterHtml, /Batch · configured 2 · coordinator live · 6h/);
+  assert.match(
+    stateWriterHtml,
+    /Serialization queue<\/span><strong>0 active · 0 queued · 1 writer max/,
+  );
+  assert.match(stateWriterHtml, /Git crash fence<\/span><strong>free/);
+  assert.match(stateWriterHtml, /Coordinator turns<\/dt><dd>16 completed · 16 admitted/);
+  assert.match(stateWriterHtml, /Coordinator wait<\/dt><dd>last 0s · max 5m/);
+  assert.match(stateWriterHtml, /Exact-review materialized<\/dt><dd>unknown items\/hour/);
+  assert.match(stateWriterHtml, /terminal telemetry stale/);
+  assert.doesNotMatch(stateWriterHtml, /Exact-review materialized<\/dt><dd>0 items\/hour/);
+
+  context.healthHistorySamples = [
+    {
+      at: new Date().toISOString(),
+      state_writer: {
+        collection_ok: true,
+        terminal_collection_ok: false,
+        accepted_operations_total: 16,
+        state_commits_total: 8,
+        materialized_items_total: 16,
+      },
+    },
+  ];
+  context.renderStateWriter({
+    lanes: { publication: { batches: { enabled: true, max_items: 2 } } },
+    state_writer: {
+      collection: { status: "stale" },
+      coordinator: { queued: 0, leased: 0, admitted: 16, completed: 16 },
+      global_lease: { status: "free" },
+      last_60_minutes: { materialized_items: 0, state_commits: 0 },
+      mode: "batch",
+    },
+  });
+  assert.match(
+    elementFor("state-writer-health").innerHTML,
+    /Exact-review materialized<\/dt><dd>unknown items\/hour/,
+  );
+  assert.doesNotMatch(
+    elementFor("state-writer-health").innerHTML,
+    /Exact-review materialized<\/dt><dd>0 items\/hour/,
+  );
   assert.match(stateWriterHtml, /class="lane-metrics"/);
   assert.doesNotMatch(stateWriterHtml, /<section class="exact-lane">/);
   const initialLaneHtml = elementFor("exact-review-lanes").innerHTML;


### PR DESCRIPTION
## What changed

- make the State writer panel use the durable coordinator for active/queued writer liveness
- show the configured exact-review batch size, coordinator turns/wait, and Git ref as a crash-recovery fence
- keep stale exact-review terminal telemetry from appearing as current zero throughput
- preserve legacy history while recording coordinator-only samples separately from terminal freshness
- document the coordinator/terminal telemetry ownership boundary

## Root cause

The panel still treated exact-review progress events as the liveness source for the whole state writer. After the repo-wide FIFO coordinator cutover, those events can legitimately become stale while the coordinator is healthy and idle. The panel therefore reported the writer as unavailable and rendered old single-item or zero-throughput data instead of the active batch/coordinator state.

## Validation

- `node --test test/dashboard-operational-health.test.ts test/dashboard-worker.test.ts` (172/172 passed after the autoreview fix)
- `pnpm run check` in local constrained Node 24 container (2525 tests, 2517 passed, 8 expected skipped, 0 failed; formatting clean)
- autoreview clean with no accepted/actionable findings

Batch size remains fixed at 2.
