### PR TITLE
fix(repair): configure git identity in publishMainCommit

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -387,6 +387,10 @@ export function hasWorktreePath(path: string): boolean {
 export function publishMainCommit(options: GitPublishOptions): PublishResult {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
+  // Every commit-creating path (lease commits included) flows through here;
+  // callers reached via publish-main entrypoints may run in checkouts without
+  // a configured git identity (observed: reconcile-before-apply, run 29852061381).
+  configureGitUser();
   if (publishRoot() && stateWriterCoordinatorEnabled() && !activeStatePublishLease) {
     // Coordinator mode admits the complete read-modify-write operation. Taking
     // a fresh ticket for each failed push would preserve CAS safety but defeat


### PR DESCRIPTION
Apply runs still failed after the #738 cutovers: "Reconcile before apply preselect" dies with `fatal: empty ident name` in createStatePublishLeaseCommit (run 29852061381) — the step never configures a git identity and the publish-main call chain assumed callers had. Fix: call configureGitUser() at the top of publishMainCommit, the shared entry every commit-producing path (lease commits included) flows through. Idempotent repo-local config.

Validation: git-publish suite green locally (CI-only fixture exempt); build/lint/format green; autoreview clean (0.91).
