### PR TITLE
fix: supply Git identity inline for state publish fence commits

### DIFF
--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -1,12 +1,13 @@
 # State publication batching plan
 
-**Status:** PR 1 through PR 4 and the rollout hotfix are merged. Production is
-still fixed at batch size 2 and a 60-second maximum wait. Two real size-2
-publishers have failed after waiting the full 480 seconds at the repository-wide
-state publish lease, so every size increase is frozen while the durable FIFO
-state-writer coordinator is delivered. The implementation and bounded local
-Node 24 proof plus the final full check are complete; autoreview, pull-request
-checks, landing, and live size-2 verification remain pending.
+**Status:** PR 1 through PR 4, the rollout hotfix, and the repository-wide FIFO
+state-writer coordinator are merged. Production remains fixed at batch size 2
+and a 60-second maximum wait. Coordinator admission is effective and the
+pre-cutover writer cohort has drained, but live size-2 proof is blocked by a
+narrow Git fence integration defect: a post-cutover ordinary writer acquired
+FIFO ticket 19 immediately, then `git commit-tree` rejected the fence commit
+because no author identity had been configured yet. Every size increase remains
+frozen until that defect is fixed and the size-2 live gates pass.
 **Incident:** CSW-049
 **Decision scope:** replace normal contention on the single generated-`state`
 publication lease with one recoverable, repository-wide serialization boundary,
@@ -23,7 +24,7 @@ generated state layout.
 | PR 3: end-to-end batch publisher              | Complete; merged default off         | Merged as [`openclaw/clawsweeper#746`](https://github.com/openclaw/clawsweeper/pull/746) at `8b5bbf8678b88f172340f1108d1bccdeed366618`. The equivalent synthetic maintainer proof verified one commit for two healthy items, isolated retryable and superseded items, per-item GitHub effects, and disabled fallback.                                                        |
 | PR 4: production rollout configuration        | Complete; landed                     | Landed as [`openclaw/clawsweeper#752`](https://github.com/openclaw/clawsweeper/pull/752). It enabled one event-driven batch publisher at size 2 and a 60-second maximum wait, blocked new legacy admission while enabled, preserved in-flight legacy work, and exposed active configuration plus last dispatch outcome.                                                      |
 | Rollout hotfix                                | Complete; landed                     | Landed as [`openclaw/clawsweeper#753`](https://github.com/openclaw/clawsweeper/pull/753). The deployed dashboard config remains `EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED=1`, `EXACT_REVIEW_PUBLICATION_BATCH_SIZE=2`, and `EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS=60000`; the workflow independently caps `EXACT_REVIEW_BATCH_MAX_ITEMS=2`.                                |
-| Repository-wide state-writer serialization    | Implemented locally; rollout blocked | Durable FIFO implementation, writer wiring, focused tests, a bounded direct-Docker Node 24 proof, and the full post-fix check are complete. Autoreview, pull request, merged-main/deployment verification, coordinator enablement, and a new production size-2 proof remain pending. The repository variable that enables coordinator mode is not present in production yet. |
+| Repository-wide state-writer serialization    | Landed; live proof blocked            | Landed as [`openclaw/clawsweeper#756`](https://github.com/openclaw/clawsweeper/pull/756) at `f422cbdd10b1ea42c9bd79d25c229e4d9fb07d79`; the dashboard deployment and smoke passed, coordinator mode is effective, and pre-cutover publishers have drained. [Run 29853679287](https://github.com/openclaw/clawsweeper/actions/runs/29853679287) acquired FIFO ticket 19 before failing to create the Git fence commit because author identity was not configured. A narrow identity hotfix and new size-2 proof remain pending. |
 
 ## Production incident and root cause
 
@@ -953,6 +954,47 @@ Only after the live size-2 proof and both samples pass may maintainers discuss a
 separate explicit change to size 4. Size 8 remains blocked until size 4 passes
 the same end-to-end and two-sample gate. No automatic `2 -> 4 -> 8` progression
 is permitted.
+
+### Follow-up task: fence identity hotfix and controlled 2 -> 4 -> 8 rollout
+
+Treat this as one ordered rollout task. A later phase must not begin merely
+because the earlier configuration has been deployed; it begins only after the
+earlier behavior and observation gates are recorded as passing.
+
+- [ ] Fix Git fence identity at the fence-commit boundary. Lease acquire,
+      renewal, stale-owner recovery, and cleanup must not depend on a caller
+      having configured repository or global `user.name` and `user.email`.
+- [ ] Add the narrow regression proof: an ordinary coordinator writer and a
+      batch coordinator writer must create and renew their fence from a checkout
+      with no preconfigured Git identity. Preserve existing commit authorship
+      for generated-state data commits.
+- [ ] Run focused tests and `pnpm run check` on local Node 24, run autoreview to
+      a clean result, land the hotfix through a green pull request, and verify
+      the merged `main` workflow. Do not use remote Crabbox or Testbox.
+- [ ] Keep production at `max_items=2` and `max_wait_seconds=60`. Let failed
+      batch ownership recover through the durable protocol; do not cancel live
+      workflows, replay or clean the DLQ, or run live apply/close as rollout
+      shortcuts.
+- [ ] Complete the first valid size-2 proof: one generated-state commit for two
+      claimed members, two correct independent outcomes and acknowledgements,
+      unrelated-sibling preservation, successful remote-HEAD CAS and fence
+      verification, attributable coordinator metrics, and no new normal
+      480-second lease wait.
+- [ ] Record two complete, consecutive five-minute size-2 samples satisfying
+      every gate above. Any contention increase, lost sibling, same-path safety
+      regression, ambiguous completion, or guard regression stops rollout and
+      returns configuration to the last proven size.
+- [ ] Increase to size 4 only through an explicit reviewed configuration change.
+      Inspect at least one four-member single commit and all four independent
+      outcomes, then record two new complete, consecutive five-minute samples.
+      Roll back to size 2 on any failed gate.
+- [ ] Increase to size 8 only through a second explicit reviewed configuration
+      change after size 4 passes. Inspect at least one eight-member single commit
+      and all eight independent outcomes, then record two new complete,
+      consecutive five-minute samples. Roll back to size 4 on any failed gate.
+- [ ] Update this document with pull requests, merged commits, production run
+      URLs, state commit identities, queue outcomes, coordinator/lease metrics,
+      sample windows, and the final keep-or-rollback decision at each size.
 
 After the writer path is stable, dead-letter recovery is a separate authorized
 operation. Start with one representative item, then batches of at most two when

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -14,7 +14,11 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
-import { clawsweeperGitUserEmail, clawsweeperGitUserName } from "./process-env.js";
+import {
+  clawsweeperGitIdentityEnv,
+  clawsweeperGitUserEmail,
+  clawsweeperGitUserName,
+} from "./process-env.js";
 import {
   chooseRecordTupleWinner,
   RecordTupleError,
@@ -1947,7 +1951,11 @@ function createStatePublishLeaseCommit(options: {
 }): string {
   const tree = runGit(["mktree"], { input: "", quiet: true }).trim();
   if (!tree) throw new Error("Failed to create the state publish lease tree");
+  // Fence commits run before the data-publish path configures user.identity.
+  // Supply the ClawSweeper identity inline so acquire, renewal, and
+  // stale-owner recovery never depend on repo/global Git identity.
   return runGit(["commit-tree", tree], {
+    env: { ...process.env, ...clawsweeperGitIdentityEnv() },
     input: [
       options.subject ?? "ClawSweeper state publish lease",
       "",

--- a/test/repair/state-writer-coordinator-git.test.ts
+++ b/test/repair/state-writer-coordinator-git.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
 import { createHmac } from "node:crypto";
 import fs from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
@@ -215,6 +215,127 @@ test(
   },
 );
 
+test("fence commits do not require a preconfigured Git identity", { timeout: 60_000 }, async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-fence-identity-"));
+  const repository = createStateRepositoryWithoutIdentity(root);
+  const batchSource = path.join(root, "batch-source");
+  const ordinarySource = path.join(root, "ordinary-source");
+  const batchReady = path.join(root, "batch-ready");
+  const releaseBatch = path.join(root, "release-batch");
+  fs.mkdirSync(batchSource);
+  fs.mkdirSync(ordinarySource);
+  assertNoGitIdentity(repository.batchWork);
+  assertNoGitIdentity(repository.ordinaryWork);
+  const coordinatorServer = await startCoordinatorServer();
+  const commonEnv: Record<string, string> = {
+    CLAWSWEEPER_PUBLISH_BRANCH: "state",
+    CLAWSWEEPER_STATE_COORDINATOR_ENABLED: "1",
+    CLAWSWEEPER_STATE_COORDINATOR_URL: coordinatorServer.url,
+    ["CLAWSWEEPER_STATE_COORDINATOR_SECRET"]: COORDINATOR_HMAC_FIXTURE,
+    CLAWSWEEPER_STATE_LEASE_PRIORITY: "0",
+    GITHUB_REPOSITORY: "openclaw/clawsweeper",
+    GITHUB_RUN_ATTEMPT: "1",
+    CLAWSWEEPER_GIT_USER_NAME: "",
+    CLAWSWEEPER_GIT_USER_EMAIL: "",
+  };
+  let batchRun: AsyncProcess | undefined;
+  let ordinaryRun: AsyncProcess | undefined;
+
+  try {
+    batchRun = startAsync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        logicalSizeTwoBatchWriter,
+        batchSource,
+        batchReady,
+        releaseBatch,
+      ],
+      process.cwd(),
+      {
+        ...commonEnv,
+        CLAWSWEEPER_STATE_DIR: repository.batchWork,
+        GITHUB_WORKFLOW: "Exact review batch publish",
+        GITHUB_JOB: "publish",
+        GITHUB_RUN_ID: "92001",
+      },
+    );
+    await waitForFile(batchReady, 15_000, "batch writer did not acquire its ticket");
+    assert.match(batchRun.output(), /Acquired state publish lease/);
+    const fenceAuthor = gitBare(
+      repository.origin,
+      "show",
+      "-s",
+      "--format=%an <%ae>",
+      "refs/heads/clawsweeper-publish-lease/state",
+    ).trim();
+    assert.equal(fenceAuthor, "clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>");
+    const fenceMessage = gitBare(
+      repository.origin,
+      "show",
+      "-s",
+      "--format=%B",
+      "refs/heads/clawsweeper-publish-lease/state",
+    );
+    assert.match(fenceMessage, /^ticket_id: state-writer:[0-9a-f-]+$/m);
+
+    fs.writeFileSync(releaseBatch, "release\n");
+    const batchOutput = await batchRun.result;
+    assert.match(batchOutput, /Released durable state writer ticket/);
+    assert.deepEqual(changedPaths(repository.origin, "state"), [...BATCH_PATHS]);
+
+    ordinaryRun = startAsync(
+      process.execPath,
+      ["--input-type=module", "-e", ordinaryWriter, ordinarySource],
+      process.cwd(),
+      {
+        ...commonEnv,
+        CLAWSWEEPER_STATE_DIR: repository.ordinaryWork,
+        GITHUB_WORKFLOW: "Sweep ordinary state writer",
+        GITHUB_JOB: "status",
+        GITHUB_RUN_ID: "92002",
+      },
+    );
+    const ordinaryOutput = await ordinaryRun.result;
+    assert.match(ordinaryOutput, /Acquired state publish lease/);
+    assert.deepEqual(changedPaths(repository.origin, "state"), [ORDINARY_PATH]);
+
+    assert.equal(gitBare(repository.origin, "rev-list", "--count", "state").trim(), "3");
+    assert.equal(
+      gitBare(repository.origin, "show", `state:${BATCH_PATHS[0]}`),
+      "logical batch item 1\n",
+    );
+    assert.equal(
+      gitBare(repository.origin, "show", `state:${BATCH_PATHS[1]}`),
+      "logical batch item 2\n",
+    );
+    assert.equal(
+      gitBare(repository.origin, "show", `state:${ORDINARY_PATH}`),
+      '{"writer":"ordinary"}\n',
+    );
+    const stateAuthors = gitBare(repository.origin, "log", "-2", "--format=%an", "state").trim();
+    assert.ok(
+      stateAuthors.split("\n").every((author) => author === "clawsweeper"),
+      "data commits retain the clawsweeper author identity",
+    );
+    assert.equal(
+      gitBare(
+        repository.origin,
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads/clawsweeper-publish-lease",
+      ).trim(),
+      "",
+    );
+  } finally {
+    if (batchRun && !batchRun.settled()) batchRun.child.kill("SIGKILL");
+    if (ordinaryRun && !ordinaryRun.settled()) ordinaryRun.child.kill("SIGKILL");
+    await coordinatorServer.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 const logicalSizeTwoBatchWriter = String.raw`
   import fs from "node:fs";
   import path from "node:path";
@@ -405,6 +526,35 @@ function createStateRepository(root: string) {
   configureUser(batchWork);
   configureUser(ordinaryWork);
   return { origin, batchWork, ordinaryWork };
+}
+
+function createStateRepositoryWithoutIdentity(root: string) {
+  const repository = createStateRepository(root);
+  unsetGitIdentity(repository.batchWork);
+  unsetGitIdentity(repository.ordinaryWork);
+  return repository;
+}
+
+function unsetGitIdentity(work: string): void {
+  git(work, "config", "--unset", "user.name");
+  git(work, "config", "--unset", "user.email");
+}
+
+function localGitConfig(work: string, key: string): string {
+  const result = spawnSync("git", ["config", "--local", "--get", key], {
+    cwd: work,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  // git config --get exits 1 when the key is unset; treat that as empty.
+  if (result.status === 0) return result.stdout.trim();
+  if (result.status === 1) return "";
+  throw new Error(`git config --get ${key} failed: ${result.stderr.trim()}`);
+}
+
+function assertNoGitIdentity(work: string): void {
+  assert.equal(localGitConfig(work, "user.name"), "", `${work} must not preconfigure user.name`);
+  assert.equal(localGitConfig(work, "user.email"), "", `${work} must not preconfigure user.email`);
 }
 
 function configureUser(root: string): void {


### PR DESCRIPTION
## Summary

- `createStatePublishLeaseCommit` runs `git commit-tree` before the data-publish path calls `configureGitUser`, so a post-cutover coordinator writer with no preconfigured repo/global `user.identity` fails at the fence boundary with `Author identity unknown` (run 29853679287, FIFO ticket 19).
- Pass `clawsweeperGitIdentityEnv()` inline to the `commit-tree` spawn so fence acquire, renewal, stale-owner recovery, and cleanup do not depend on caller identity configuration.
- Data commits retain their existing authorship via `configureGitUser`; only the fence commit boundary changes.
- Add a regression test proving an ordinary coordinator writer and a batch coordinator writer create and renew their fence from a checkout with no preconfigured Git identity, while data commits retain the clawsweeper author identity.

## Evidence

- Full `pnpm run check` passed in local Docker container `docker.io/masonxhuang/codex-node24-ci:20260721` (Node v24.18.0, Git 2.47.3, pnpm 11.10.0) with 8 GiB memory/swap, 1024 PIDs, 4 CPUs, and init. Build, lint, unit, repair, changed/full coverage, and formatting gates all exited clean.
- New test `fence commits do not require a preconfigured Git identity` passes alongside the existing durable FIFO test.
- Code-review skill run clean after unifying `createStateRepositoryWithoutIdentity` to reuse `createStateRepository`.

## Test plan

- [x] Focused state-writer coordinator git tests pass locally
- [x] Full `pnpm run check` passes in local Node 24 container
- [ ] CI checks pass
- [ ] Merged main verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)