### PR TITLE
fix(publication): release failed batches immediately

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -90,6 +90,15 @@ jobs:
           REPO_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
+          write_failure() {
+            local path="$1"
+            local kind="$2"
+            local reason_code="$3"
+            jq -n \
+              --arg kind "$kind" \
+              --arg reasonCode "$reason_code" \
+              '{ kind: $kind, reasonCode: $reasonCode }' > "$path"
+          }
           jq -c '.items[]' "$EXACT_REVIEW_BATCH_MANIFEST" | while IFS= read -r item; do
             pnpm run --silent repair:exact-review-batch heartbeat || exit 1
             outcome_path="$(jq -r '.outcomePath' <<<"$item")"
@@ -106,6 +115,7 @@ jobs:
             if ! GH_TOKEN="$REPO_TOKEN" gh run download "$producer_run_id" --repo "$GITHUB_REPOSITORY" \
               --name "$artifact_name" --dir "$bundle_dir"; then
               echo "::warning::Leaving $target_repo#$item_number retryable: artifact download failed"
+              write_failure "$outcome_path" retryable_failure artifact_unavailable
               continue
             fi
             if ! env \
@@ -129,6 +139,7 @@ jobs:
               EXACT_REVIEW_TARGET_REPO="$target_repo" \
               pnpm run --silent repair:exact-review-bundle validate; then
               echo "::warning::Leaving $target_repo#$item_number retryable: artifact validation failed"
+              write_failure "$outcome_path" retryable_failure unknown_failure
               continue
             fi
             report="$bundle_dir/review/$item_number.md"
@@ -143,6 +154,7 @@ jobs:
           NODE
             then
               echo "::warning::Leaving $target_repo#$item_number retryable: legacy tuple-less artifact"
+              write_failure "$outcome_path" permanent_failure tuple_protocol_invalid
               continue
             fi
             if [ -f "$report" ]; then cp "$report" "artifacts/event/$item_number.md"; fi
@@ -160,7 +172,7 @@ jobs:
               EXACT_REVIEW_BATCH_MUTATION_OUTPUT="$outcome_path" \
               pnpm run --silent repair:publish-event-result; then
               echo "::warning::Leaving $target_repo#$item_number retryable: item publication failed"
-              rm -f "$outcome_path"
+              write_failure "$outcome_path" retryable_failure unknown_failure
               continue
             fi
           done
@@ -248,3 +260,10 @@ jobs:
           done
           test ! -f "$heartbeat_failed"
           pnpm run --silent repair:exact-review-batch complete
+
+      - name: Release unfinished batch members
+        if: ${{ always() && steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run --silent repair:exact-review-batch release

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -42,7 +42,7 @@ export type PublicationBatch = {
 
 export type PublicationBatchCompletion = PublicationBatchCandidate & {
   claimGeneration: number;
-  terminalOutcome: Exclude<PublicationBatchTerminalOutcome, "lease_expired">;
+  terminalOutcome: PublicationBatchTerminalOutcome;
 };
 
 export type PublicationBatchFence = PublicationBatchCandidate & {
@@ -265,19 +265,20 @@ export class ExactReviewPublicationBatchStore {
       this.reclaimExpiredSync(now);
       const batch = this.readBatchSync(batchId);
       if (!batch || batch.leaseOwner !== leaseOwner) return null;
-      if (batch.state === "completed") {
+      if (batch.state !== "leased") {
         const membersByKey = new Map(batch.items.map((item) => [item.itemKey, item]));
-        const matchesReceipt = completions.every((completion) => {
+        const matchesFence = completions.every((completion) => {
           const member = membersByKey.get(completion.itemKey);
           return (
             member?.revision === completion.revision &&
-            member.claimGeneration === completion.claimGeneration &&
-            member.terminalOutcome === completion.terminalOutcome
+            member.claimGeneration === completion.claimGeneration
           );
         });
-        return matchesReceipt ? batch : null;
+        // A delayed always() cleanup may race a successful acknowledgement or
+        // lease expiry. Matching immutable fences make either retry an
+        // idempotent no-op; stale generations and wrong owners still fail.
+        return matchesFence ? batch : null;
       }
-      if (batch.state !== "leased") return null;
       const unfinishedByKey = new Map(
         batch.items
           .filter((item) => item.terminalOutcome === null)

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -137,6 +137,9 @@ type ExactReviewPublicationCompletion = {
   reasonCode: ExactReviewPublicationReasonCode;
   errorFingerprint?: string;
 };
+type ExactReviewPublicationBatchCompletion = PublicationBatchCompletion & {
+  publicationCompletion?: ExactReviewPublicationCompletion;
+};
 type ExactReviewPublicationFeedback = {
   at: number;
   capacity: number;
@@ -2680,11 +2683,26 @@ export class ExactReviewQueue {
       return json({ error: "invalid_failure_fingerprint" }, 400);
     }
     let acceptedCount = 0;
+    const requestedByFence = new Map(
+      completions.map(
+        (completion) =>
+          [
+            `${completion.itemKey}:${completion.revision}:${completion.claimGeneration}`,
+            completion,
+          ] as const,
+      ),
+    );
+    const now = Date.now();
     const batch = this.batchStore.complete(
       batchId,
       leaseOwner,
-      completions,
-      Date.now(),
+      completions.map(({ itemKey, revision, claimGeneration, terminalOutcome }) => ({
+        itemKey,
+        revision,
+        claimGeneration,
+        terminalOutcome,
+      })),
+      now,
       {
         ...(stateCommitSha ? { stateCommitSha } : {}),
         ...(failureFingerprint ? { failureFingerprint } : {}),
@@ -2695,13 +2713,15 @@ export class ExactReviewQueue {
         const state = this.readStateSync();
         let published = 0;
         let superseded = 0;
+        let completed = 0;
+        let retried = 0;
+        let deadLettered = 0;
+        let refreshed = 0;
         for (const completion of accepted) {
-          if (
-            completion.terminalOutcome !== "published" &&
-            completion.terminalOutcome !== "superseded"
-          ) {
-            continue;
-          }
+          const requested = requestedByFence.get(
+            `${completion.itemKey}:${completion.revision}:${completion.claimGeneration}`,
+          );
+          if (!requested) continue;
           const item = state.items[completion.itemKey];
           if (
             !item ||
@@ -2710,21 +2730,45 @@ export class ExactReviewQueue {
           ) {
             continue;
           }
+          if (requested.publicationCompletion) {
+            const result = finishExactReviewPublicationQueueItem({
+              state,
+              item,
+              now,
+              completion: requested.publicationCompletion,
+              ownedRevision: completion.revision,
+              deadLetterCapacityAvailable: this.deadLetterCapacityAvailableSync(
+                exactReviewDeadLetterId(item, completion.revision),
+              ),
+              env: this.env,
+            });
+            if (result.deadLetter) {
+              this.insertDeadLetterSync(result.deadLetter);
+              deadLettered += 1;
+            }
+            if (!result.requeued && !result.parked) completed += 1;
+            if (result.retried) retried += 1;
+            if (result.refreshed) refreshed += 1;
+            continue;
+          }
           delete state.items[completion.itemKey];
+          completed += 1;
           if (completion.terminalOutcome === "published") published += 1;
-          else superseded += 1;
+          else if (completion.terminalOutcome === "superseded") superseded += 1;
         }
-        if (!published && !superseded) return;
         this.writeStateSync(state);
         this.incrementQueueMetricsSync({
-          publicationCompleted: published + superseded,
+          publicationCompleted: completed,
           publicationPublished: published,
           publicationSuperseded: superseded,
+          publicationRetried: retried,
+          publicationDeadLettered: deadLettered,
+          publicationRefreshed: refreshed,
         });
       },
     );
     if (!batch) return json({ error: "batch_lease_not_active" }, 409);
-    if (acceptedCount) await this.scheduleNext(this.readStateSync(), Date.now());
+    if (acceptedCount) await this.scheduleNext(this.readStateSync(), now);
     return json({
       ok: true,
       accepted: acceptedCount,
@@ -4944,6 +4988,7 @@ function finishExactReviewPublicationQueueItem({
   item,
   now,
   completion,
+  ownedRevision,
   requestedRetryAt = 0,
   requeueLatest = false,
   deadLetterCapacityAvailable,
@@ -4953,6 +4998,7 @@ function finishExactReviewPublicationQueueItem({
   item: ExactReviewQueueItem;
   now: number;
   completion: ExactReviewPublicationCompletion;
+  ownedRevision?: number;
   requestedRetryAt?: number;
   requeueLatest?: boolean;
   deadLetterCapacityAvailable: boolean;
@@ -4964,7 +5010,8 @@ function finishExactReviewPublicationQueueItem({
   parked: boolean;
   deadLetter?: ExactReviewDeadLetterInsert;
 } {
-  const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
+  const completionRevision = ownedRevision ?? Number(item.leaseRevision || 0);
+  const hasNewerRevision = item.revision > completionRevision;
   if (hasNewerRevision || requeueLatest) {
     const requeued = finishExactReviewQueueItem(
       state,
@@ -5028,6 +5075,7 @@ function finishExactReviewPublicationQueueItem({
       firstFailureAt,
       now,
       completion.errorFingerprint,
+      completionRevision,
     );
     if (deadLetterCapacityAvailable) {
       delete state.items[item.key];
@@ -5115,8 +5163,8 @@ function exactReviewPublicationRetryDelayMs(
   return delay + Math.floor(delay * ((hash % 21) / 100));
 }
 
-function exactReviewDeadLetterId(item: ExactReviewQueueItem) {
-  return `${item.key}@revision:${item.leaseRevision || item.revision}`;
+function exactReviewDeadLetterId(item: ExactReviewQueueItem, ownedRevision?: number) {
+  return `${item.key}@revision:${ownedRevision || item.leaseRevision || item.revision}`;
 }
 
 function exactReviewDeadLetterInsert(
@@ -5126,13 +5174,14 @@ function exactReviewDeadLetterInsert(
   firstFailedAt: number,
   lastFailedAt: number,
   errorFingerprint?: string,
+  ownedRevision?: number,
 ): ExactReviewDeadLetterInsert {
   const publication = item.decision.publication;
   if (!publication) throw new Error(`publication metadata missing for ${item.key}`);
   return {
-    id: exactReviewDeadLetterId(item),
+    id: exactReviewDeadLetterId(item, ownedRevision),
     itemKey: item.key,
-    revision: Number(item.leaseRevision || item.revision),
+    revision: Number(ownedRevision || item.leaseRevision || item.revision),
     targetRepo: item.decision.targetRepo,
     itemNumber: item.decision.itemNumber,
     producerRunId: publication.producerRunId,
@@ -7031,20 +7080,26 @@ function exactReviewPublicationBatchOwner(value) {
   return /^[A-Za-z0-9._:@/-]{1,200}$/.test(text) ? text : "";
 }
 
-function exactReviewPublicationBatchCompletions(value): PublicationBatchCompletion[] | null {
+function exactReviewPublicationBatchCompletions(
+  value,
+): ExactReviewPublicationBatchCompletion[] | null {
   if (!Array.isArray(value) || value.length > MAX_EXACT_REVIEW_PUBLICATION_BATCH_SIZE) return null;
-  // PR1 only exposes outcomes whose existing queue terminal semantics are complete.
-  // Retry and dead-letter classifications stay on the legacy path until PR3 wires
-  // per-item batch failures through finishExactReviewPublicationQueueItem.
-  const outcomes = new Set(["published", "superseded"]);
   const seen = new Set<string>();
-  const completions: PublicationBatchCompletion[] = [];
+  const completions: ExactReviewPublicationBatchCompletion[] = [];
   for (const raw of value) {
     const item = objectValue(raw);
     const itemKey = String(item.item_key || "").trim();
     const revision = Number(item.revision);
     const claimGeneration = Number(item.claim_generation);
     const terminalOutcome = String(item.terminal_outcome || "").trim();
+    const publicationCompletion =
+      terminalOutcome === "published" || terminalOutcome === "superseded"
+        ? null
+        : exactReviewPublicationCompletion(
+            terminalOutcome,
+            item.reason_code,
+            item.error_fingerprint,
+          );
     if (
       !itemKey ||
       itemKey.length > 500 ||
@@ -7053,7 +7108,12 @@ function exactReviewPublicationBatchCompletions(value): PublicationBatchCompleti
       revision < 1 ||
       !Number.isInteger(claimGeneration) ||
       claimGeneration < 1 ||
-      !outcomes.has(terminalOutcome)
+      (terminalOutcome !== "published" &&
+        terminalOutcome !== "superseded" &&
+        !publicationCompletion) ||
+      publicationCompletion?.kind === "published" ||
+      publicationCompletion?.kind === "superseded" ||
+      publicationCompletion?.kind === "deferred"
     ) {
       return null;
     }
@@ -7062,7 +7122,11 @@ function exactReviewPublicationBatchCompletions(value): PublicationBatchCompleti
       itemKey,
       revision,
       claimGeneration,
-      terminalOutcome: terminalOutcome as PublicationBatchCompletion["terminalOutcome"],
+      terminalOutcome:
+        terminalOutcome === "published" || terminalOutcome === "superseded"
+          ? terminalOutcome
+          : "lease_expired",
+      ...(publicationCompletion ? { publicationCompletion } : {}),
     });
   }
   return completions;

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -90,6 +90,54 @@ minutes, and `state_writer.mode=unknown`. A matching-ref query at `13:43:23Z`
 returned no lease refs, and the lease ref is also empty after the later failure;
 absence of a stale ref does not repair unfair handoff among live writers.
 
+### Batch failure terminalization
+
+Repository-wide writer serialization addresses fair access to the generated
+state branch, but a batch must also relinquish its own queue ownership whenever
+publication cannot finish. A failed or partially successful workflow must not
+leave unfinished members behind until the 30-minute lease expiry, because one
+active batch blocks every later batch departure.
+
+Every claimed member therefore reaches one fenced acknowledgement before the
+workflow exits:
+
+- `published` or `superseded` removes the matching queue revision; or
+- `retryable_failure`, `refresh_required`, or `permanent_failure` terminalizes
+  only the matching batch membership and routes the underlying publication item
+  through the existing backoff, refresh, and dead-letter policy.
+
+Explicit failure release uses the existing `lease_expired` membership value so
+the additive SQLite schema remains migration-free. Revision and
+claim-generation fencing still prevent an old worker from releasing newer
+ownership. An `always()` workflow cleanup acknowledges any member left
+unfinished by cancellation or an unexpected step failure, while lease expiry
+remains the final crash fallback rather than the normal recovery path.
+
+The first post-coordinator production batch exposed a second availability
+dependency. [Run 29854892938](https://github.com/openclaw/clawsweeper/actions/runs/29854892938)
+claimed and prepared two members, then failed almost immediately when the batch
+commit command's queue `fetch` returned invalid JSON with HTTP 500. At
+`2026-07-21T18:11:00Z`, publication still had 1,729 pending and ready items,
+zero resolutions in the prior 60 minutes, one leased batch with two active
+members, and 8,020 pending state-append rows. The prior cleanup repeated the
+same `fetch`, so it could not release the members during that queue read
+failure.
+
+Failure cleanup now sends the revision and claim-generation fences persisted in
+the claimed manifest directly to the batch `complete` route. It does not depend
+on a fresh queue read. The route applies accepted retryable outcomes through
+`finishExactReviewPublicationQueueItem`, while a delayed cleanup that races an
+already completed or expired same-fence batch is an idempotent no-op. Wrong
+owners and stale generations remain rejected. The `always()` cleanup is also
+non-fatal after a successful primary publication, so a transient cleanup
+transport error cannot convert a completed publisher into a failed workflow;
+an earlier publication failure remains visible as the job's primary failure.
+
+This contract is independent of the coordinator rollout: the coordinator from
+#738/#756 makes state-writer admission durable and fair, while batch failure
+terminalization keeps the exact-review publication queue live when the admitted
+writer, artifact processing, or GitHub effects fail.
+
 ### Writer audit
 
 The production evidence and call-site/workflow audit identify these generated

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -8,6 +8,7 @@ import {
   ExactReviewBatchQueueClient,
   type ExactReviewBatchQueueItem,
 } from "./exact-review-batch-queue-client.js";
+import { StatePublishContentionError } from "./git-publish.js";
 import { commitPreparedStateBatch } from "./state-publication-batch.js";
 import {
   validatePreparedStateMutationPlans,
@@ -21,8 +22,8 @@ type BatchManifest = {
 };
 
 const command = process.argv[2];
-if (!command || !["claim", "heartbeat", "commit", "complete"].includes(command)) {
-  throw new Error("usage: exact-review-batch-cli.ts <claim|heartbeat|commit|complete>");
+if (!command || !["claim", "heartbeat", "commit", "complete", "release"].includes(command)) {
+  throw new Error("usage: exact-review-batch-cli.ts <claim|heartbeat|commit|complete|release>");
 }
 
 const queueSecret = process.env.CLAWSWEEPER_WEBHOOK_SECRET;
@@ -36,7 +37,8 @@ const client = new ExactReviewBatchQueueClient({
 if (command === "claim") await claim();
 else if (command === "heartbeat") await heartbeat();
 else if (command === "commit") await commit();
-else await complete();
+else if (command === "complete") await complete();
+else await release();
 
 async function claim() {
   const leaseOwner = env("EXACT_REVIEW_BATCH_LEASE_OWNER");
@@ -98,6 +100,7 @@ async function commit() {
   });
   const active = new Map(fetched.items.map((item) => [item.itemKey, item]));
   const superseded: ExactReviewBatchCompletion[] = [];
+  const commitMembers: ExactReviewBatchQueueItem[] = [];
   const plans: PreparedStateMutationPlan[] = [];
   for (const manifestItem of manifest.items) {
     const current = active.get(manifestItem.itemKey);
@@ -121,6 +124,7 @@ async function commit() {
     ) {
       throw new Error(`Batch outcome identity does not match ${current.itemKey}`);
     }
+    commitMembers.push(current);
     plans.push(plan);
   }
 
@@ -133,7 +137,22 @@ async function commit() {
       }).commitSha;
     }
   } catch (error) {
-    await acknowledge(manifest, superseded, undefined, failureFingerprint(error));
+    const fingerprint = failureFingerprint(error);
+    const reasonCode =
+      error instanceof StatePublishContentionError ? "state_contention" : "unknown_failure";
+    const retryable = commitMembers.map((member) => ({
+      ...member,
+      terminalOutcome: "retryable_failure" as const,
+      reasonCode,
+      errorFingerprint: fingerprint,
+    }));
+    try {
+      await acknowledge(manifest, [...superseded, ...retryable], undefined, fingerprint);
+    } catch (releaseError) {
+      console.error(
+        `Failed to release batch after commit error: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
+      );
+    }
     throw error;
   }
   const receiptPath = batchReceiptPath();
@@ -179,7 +198,11 @@ async function complete() {
   const completions: ExactReviewBatchCompletion[] = [];
   for (const manifestItem of manifest.items) {
     const current = active.get(manifestItem.itemKey);
-    if (!current || !existsSync(manifestItem.outcomePath)) continue;
+    if (!current) continue;
+    if (!existsSync(manifestItem.outcomePath)) {
+      completions.push(retryableCompletion(current, "unknown_failure"));
+      continue;
+    }
     const outcome = objectValue(JSON.parse(readFileSync(manifestItem.outcomePath, "utf8")));
     if (outcome.kind === "superseded") {
       if (
@@ -191,7 +214,15 @@ async function complete() {
       completions.push({ ...current, terminalOutcome: "superseded" });
       continue;
     }
-    if (outcome.kind !== "eligible" || !publishedKeys.has(current.itemKey)) continue;
+    const failure = failureCompletion(current, outcome);
+    if (failure) {
+      completions.push(failure);
+      continue;
+    }
+    if (outcome.kind !== "eligible" || !publishedKeys.has(current.itemKey)) {
+      completions.push(retryableCompletion(current, "unknown_failure"));
+      continue;
+    }
     const disposition = objectValue(outcome.disposition);
     const requiresDeferredEffect =
       disposition.requeueLatestExpected === true ||
@@ -205,12 +236,46 @@ async function complete() {
       ? receipt.stateCommitSha
       : undefined;
   const result = await acknowledge(manifest, completions, stateCommitSha);
+  const retryable = completions.filter(
+    (completion) =>
+      completion.terminalOutcome !== "published" && completion.terminalOutcome !== "superseded",
+  ).length;
   console.log(
     JSON.stringify({
       ok: true,
       batch_id: manifest.batchId,
       accepted: result?.accepted ?? 0,
-      retryable: fetched.items.length - completions.length,
+      retryable,
+    }),
+  );
+}
+
+async function release() {
+  const manifest = readManifest();
+  // Cleanup must remain available when the queue fetch path is degraded. The
+  // claimed manifest already contains the exact revision and generation fences
+  // accepted by the complete route, so a fresh read adds availability risk but
+  // cannot strengthen ownership.
+  const completions: ExactReviewBatchCompletion[] = manifest.items.map((member) => {
+    if (existsSync(member.outcomePath)) {
+      const outcome = objectValue(JSON.parse(readFileSync(member.outcomePath, "utf8")));
+      if (
+        outcome.kind === "superseded" &&
+        optionalObjectValue(outcome.disposition).requeueLatestExpected !== true
+      ) {
+        return { ...member, terminalOutcome: "superseded" };
+      }
+      const failure = failureCompletion(member, outcome);
+      if (failure) return failure;
+    }
+    return retryableCompletion(member, "workflow_cancelled");
+  });
+  const result = await acknowledge(manifest, completions);
+  console.log(
+    JSON.stringify({
+      ok: true,
+      batch_id: manifest.batchId,
+      released: result?.accepted ?? 0,
     }),
   );
 }
@@ -229,6 +294,44 @@ async function acknowledge(
     ...(stateCommitSha ? { stateCommitSha } : {}),
     ...(failure ? { failureFingerprint: failure } : {}),
   });
+}
+
+function failureCompletion(
+  member: ExactReviewBatchQueueItem,
+  outcome: Record<string, unknown>,
+): ExactReviewBatchCompletion | null {
+  const terminalOutcome = String(outcome.kind || "");
+  if (
+    terminalOutcome !== "retryable_failure" &&
+    terminalOutcome !== "refresh_required" &&
+    terminalOutcome !== "permanent_failure"
+  ) {
+    return null;
+  }
+  const reasonCode = stringValue(outcome.reasonCode, "outcome.reasonCode");
+  const errorFingerprint =
+    typeof outcome.errorFingerprint === "string" && outcome.errorFingerprint
+      ? outcome.errorFingerprint
+      : undefined;
+  return {
+    ...member,
+    terminalOutcome,
+    reasonCode,
+    ...(errorFingerprint ? { errorFingerprint } : {}),
+  };
+}
+
+function retryableCompletion(
+  member: ExactReviewBatchQueueItem,
+  reasonCode: string,
+  errorFingerprint?: string,
+): ExactReviewBatchCompletion {
+  return {
+    ...member,
+    terminalOutcome: "retryable_failure",
+    reasonCode,
+    ...(errorFingerprint ? { errorFingerprint } : {}),
+  };
 }
 
 function readManifest(): BatchManifest {

--- a/src/repair/exact-review-batch-coordinator.ts
+++ b/src/repair/exact-review-batch-coordinator.ts
@@ -74,7 +74,19 @@ export async function coordinateExactReviewBatch(
         commit: (plans) => dependencies.commit(lease.batchId, plans),
       });
       await assertLease();
-      if (!publication.completions.length) {
+      const failureFingerprint = publication.retryable.length
+        ? retryableFingerprint(publication.retryable)
+        : undefined;
+      const completions = [
+        ...publication.completions,
+        ...publication.retryable.map(({ reason, ...member }) => ({
+          ...member,
+          terminalOutcome: "retryable_failure" as const,
+          reasonCode: retryableReasonCode(reason),
+          ...(failureFingerprint ? { errorFingerprint: failureFingerprint } : {}),
+        })),
+      ];
+      if (!completions.length) {
         return {
           kind: "claimed" as const,
           batchId: lease.batchId,
@@ -86,11 +98,9 @@ export async function coordinateExactReviewBatch(
       const completion = await dependencies.queue.complete({
         batchId: lease.batchId,
         leaseOwner: options.leaseOwner,
-        items: publication.completions,
+        items: completions,
         ...(publication.stateCommitSha ? { stateCommitSha: publication.stateCommitSha } : {}),
-        ...(publication.retryable.length
-          ? { failureFingerprint: retryableFingerprint(publication.retryable) }
-          : {}),
+        ...(failureFingerprint ? { failureFingerprint } : {}),
       });
       return {
         kind: "claimed" as const,
@@ -171,4 +181,16 @@ function retryableFingerprint(
     .sort((left, right) => left.itemKey.localeCompare(right.itemKey))
     .map(({ itemKey, revision, reason }) => ({ itemKey, revision, reason }));
   return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+function retryableReasonCode(reason: string): string {
+  const normalized = reason.toLowerCase();
+  if (normalized.includes("artifact")) return "artifact_unavailable";
+  if (normalized.includes("rate limit") || normalized.includes("rate_limit")) {
+    return "github_rate_limit";
+  }
+  if (normalized.includes("contention") || normalized.includes("statepublishcontentionerror")) {
+    return "state_contention";
+  }
+  return "unknown_failure";
 }

--- a/src/repair/exact-review-batch-publisher.ts
+++ b/src/repair/exact-review-batch-publisher.ts
@@ -6,10 +6,17 @@ export type ExactReviewBatchMember = {
   claimGeneration: number;
 };
 
-export type ExactReviewBatchTerminalOutcome = "published" | "superseded";
+export type ExactReviewBatchTerminalOutcome =
+  | "published"
+  | "superseded"
+  | "retryable_failure"
+  | "refresh_required"
+  | "permanent_failure";
 
 export type ExactReviewBatchCompletion = ExactReviewBatchMember & {
   terminalOutcome: ExactReviewBatchTerminalOutcome;
+  reasonCode?: string;
+  errorFingerprint?: string;
 };
 
 export type ExactReviewBatchItemResult =

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -115,6 +115,8 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
         revision: item.revision,
         claim_generation: item.claimGeneration,
         terminal_outcome: item.terminalOutcome,
+        ...(item.reasonCode ? { reason_code: item.reasonCode } : {}),
+        ...(item.errorFingerprint ? { error_fingerprint: item.errorFingerprint } : {}),
       })),
       ...(input.stateCommitSha ? { state_commit_sha: input.stateCommitSha } : {}),
       ...(input.failureFingerprint ? { failure_fingerprint: input.failureFingerprint } : {}),

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -228,7 +228,7 @@ test("batch completion is fenced per item and retains publication metadata", () 
       itemKey: item.itemKey,
       revision: item.revision,
       claimGeneration: item.claimGeneration,
-      terminalOutcome: index === 0 ? "published" : "superseded",
+      terminalOutcome: index === 0 ? "lease_expired" : "published",
     })),
     2_100,
   );
@@ -237,7 +237,13 @@ test("batch completion is fenced per item and retains publication metadata", () 
     batches.complete(
       batch.batchId,
       batch.leaseOwner,
-      [{ ...batch.items[0], terminalOutcome: "superseded" }],
+      [
+        {
+          ...batch.items[0],
+          claimGeneration: batch.items[0].claimGeneration + 1,
+          terminalOutcome: "superseded",
+        },
+      ],
       2_100,
     ),
     null,
@@ -1026,21 +1032,6 @@ test("queue completion atomically removes only the owned publication revision", 
     ).json();
     assert.equal(claim.claimed, true, JSON.stringify(claim));
     const member = claim.batch.items[0];
-    const unsupportedFailure = await queue.fetch(
-      batchRequest("/publication-batches/complete", {
-        batch_id: claim.batch.batch_id,
-        lease_owner: "worker-1",
-        items: [
-          {
-            item_key: member.item_key,
-            revision: member.revision,
-            claim_generation: member.claim_generation,
-            terminal_outcome: "retryable_failure",
-          },
-        ],
-      }),
-    );
-    assert.equal(unsupportedFailure.status, 400);
     const completion = await (
       await queue.fetch(
         batchRequest("/publication-batches/complete", {
@@ -1072,7 +1063,8 @@ test("queue completion atomically removes only the owned publication revision", 
               item_key: member.item_key,
               revision: member.revision,
               claim_generation: member.claim_generation,
-              terminal_outcome: "published",
+              terminal_outcome: "retryable_failure",
+              reason_code: "workflow_cancelled",
             },
           ],
         }),
@@ -1085,6 +1077,231 @@ test("queue completion atomically removes only the owned publication revision", 
     assert.equal(stats.lanes.publication.pending, 0);
     assert.equal(stats.lanes.publication.published_total, 1);
     assert.equal(stats.lanes.publication.batches.completed, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("direct fenced cleanup treats an expired batch as an idempotent no-op", async () => {
+  const originalNow = Date.now;
+  let now = 2_500_000;
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+      },
+    );
+    await queue.fetch(publicationRequest("delivery-expired-cleanup", 126, "1026"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-expired-cleanup",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    const member = claim.batch.items[0];
+
+    now += 60_001;
+    const cleanup = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "workflow_cancelled",
+          },
+        ],
+      }),
+    );
+    assert.equal(cleanup.status, 200);
+    assert.deepEqual(await cleanup.json(), {
+      ok: true,
+      accepted: 0,
+      skipped: 1,
+      batch: {
+        ...claim.batch,
+        state: "expired",
+        completed_at: new Date(now).toISOString(),
+        items: [{ ...member, terminal_outcome: "lease_expired" }],
+      },
+    });
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("retryable batch completion releases ownership and preserves queue retry policy", async () => {
+  const originalNow = Date.now;
+  let now = 2_000_000;
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    await queue.fetch(publicationRequest("delivery-retryable", 123, "1023"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-retryable",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    const member = claim.batch.items[0];
+    const invalidCompletion = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-1",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "publication_applied",
+          },
+        ],
+      }),
+    );
+    assert.equal(invalidCompletion.status, 400);
+    const completion = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          failure_fingerprint: "state-contention-proof",
+          items: [
+            {
+              item_key: member.item_key,
+              revision: member.revision,
+              claim_generation: member.claim_generation,
+              terminal_outcome: "retryable_failure",
+              reason_code: "state_contention",
+              error_fingerprint: "state-contention-proof",
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(completion.accepted, 1, JSON.stringify(completion));
+    assert.equal(completion.batch.state, "completed");
+    assert.equal(completion.batch.items[0].terminal_outcome, "lease_expired");
+
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 1);
+    assert.equal(stats.lanes.publication.completed_total, 0);
+    assert.equal(stats.lanes.publication.retried_total, 1);
+    assert.equal(stats.lanes.publication.batches.leased, 0);
+
+    now += 10 * 60_000;
+    const replacement = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-after-retryable",
+          lease_owner: "worker-2",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(replacement.claimed, true, JSON.stringify(replacement));
+    assert.equal(replacement.batch.items[0].item_key, member.item_key);
+    assert.notEqual(replacement.batch.items[0].claim_generation, member.claim_generation);
+
+    const stale = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          items: [
+            {
+              item_key: member.item_key,
+              revision: member.revision,
+              claim_generation: member.claim_generation,
+              terminal_outcome: "retryable_failure",
+              reason_code: "state_contention",
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(stale.accepted, 0);
+    const fetchedReplacement = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/fetch", {
+          batch_id: replacement.batch.batch_id,
+          lease_owner: "worker-2",
+        }),
+      )
+    ).json();
+    assert.equal(fetchedReplacement.items.length, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("partial batch completion publishes healthy members and releases retryable members", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 3_000_000;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    await queue.fetch(publicationRequest("delivery-partial-published", 124, "1024"));
+    await queue.fetch(publicationRequest("delivery-partial-retryable", 125, "1025"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-partial",
+          lease_owner: "worker-1",
+          max_items: 2,
+        }),
+      )
+    ).json();
+    const [published, retryable] = claim.batch.items;
+    const completion = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+          state_commit_sha: "c".repeat(40),
+          items: [
+            {
+              item_key: published.item_key,
+              revision: published.revision,
+              claim_generation: published.claim_generation,
+              terminal_outcome: "published",
+            },
+            {
+              item_key: retryable.item_key,
+              revision: retryable.revision,
+              claim_generation: retryable.claim_generation,
+              terminal_outcome: "retryable_failure",
+              reason_code: "artifact_unavailable",
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(completion.accepted, 2, JSON.stringify(completion));
+    assert.equal(completion.batch.state, "completed");
+
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 1);
+    assert.equal(stats.lanes.publication.published_total, 1);
+    assert.equal(stats.lanes.publication.retried_total, 1);
+    assert.equal(stats.lanes.publication.batches.leased, 0);
   } finally {
     Date.now = originalNow;
   }

--- a/test/repair/exact-review-batch-coordinator.test.ts
+++ b/test/repair/exact-review-batch-coordinator.test.ts
@@ -51,10 +51,49 @@ test("coordinator heartbeats, isolates mixed outcomes, and acknowledges terminal
   assert.ok(heartbeats >= 6);
   assert.equal(completed.length, 1);
   assert.deepEqual(
+    (completed[0] as { items: Array<{ terminalOutcome: string; reasonCode?: string }> }).items
+      .map((item) => [item.terminalOutcome, item.reasonCode ?? null])
+      .sort(),
+    [
+      ["published", null],
+      ["retryable_failure", "artifact_unavailable"],
+      ["superseded", null],
+    ],
+  );
+  assert.deepEqual(
     result.kind === "claimed"
       ? result.publication.completions.map((item) => item.terminalOutcome).sort()
       : [],
     ["published", "superseded"],
+  );
+});
+
+test("shared commit contention releases every eligible batch member", async () => {
+  const completed: Array<{ items: Array<{ terminalOutcome: string; reasonCode?: string }> }> = [];
+  const result = await coordinateExactReviewBatch(
+    { claimId: "claim-1", leaseOwner: "run-1", maxItems: 3 },
+    {
+      queue: fakeQueue({
+        complete: (input) => completed.push(input as (typeof completed)[number]),
+      }),
+      async prepare(item) {
+        return { kind: "eligible", plan: plan(item) };
+      },
+      async deliverGithubEffects() {
+        return "ready";
+      },
+      async commit() {
+        throw new Error("StatePublishContentionError: lease wait exhausted");
+      },
+    },
+  );
+
+  assert.equal(result.kind, "claimed");
+  assert.equal(completed.length, 1);
+  assert.equal(completed[0]!.items.length, 3);
+  assert.deepEqual(
+    completed[0]!.items.map((item) => [item.terminalOutcome, item.reasonCode]),
+    Array.from({ length: 3 }, () => ["retryable_failure", "state_contention"]),
   );
 });
 
@@ -116,6 +155,8 @@ test("queue client signs protocol calls and rejects malformed responses", async 
         JSON.stringify({
           ok: true,
           claimed: true,
+          accepted: 1,
+          skipped: 0,
           batch: leaseJson(),
         }),
       );
@@ -124,9 +165,22 @@ test("queue client signs protocol calls and rejects malformed responses", async 
   const lease = await client.claim({ claimId: "claim-1", leaseOwner: "run-1", maxItems: 3 });
   assert.equal(lease?.batchId, "claim-1");
   await client.heartbeat({ batchId: "claim-1", leaseOwner: "run-1", items: queueItems });
+  await client.complete({
+    batchId: "claim-1",
+    leaseOwner: "run-1",
+    items: [
+      {
+        ...queueItems[0]!,
+        terminalOutcome: "retryable_failure",
+        reasonCode: "state_contention",
+        errorFingerprint: "state-contention-proof",
+      },
+    ],
+  });
   assert.deepEqual(paths, [
     "/internal/exact-review/publication-batches/claim",
     "/internal/exact-review/publication-batches/heartbeat",
+    "/internal/exact-review/publication-batches/complete",
   ]);
   assert.deepEqual(bodies[1], {
     batch_id: "claim-1",
@@ -136,6 +190,20 @@ test("queue client signs protocol calls and rejects malformed responses", async 
       revision: item.revision,
       claim_generation: item.claimGeneration,
     })),
+  });
+  assert.deepEqual(bodies[2], {
+    batch_id: "claim-1",
+    lease_owner: "run-1",
+    items: [
+      {
+        item_key: queueItems[0]!.itemKey,
+        revision: queueItems[0]!.revision,
+        claim_generation: queueItems[0]!.claimGeneration,
+        terminal_outcome: "retryable_failure",
+        reason_code: "state_contention",
+        error_fingerprint: "state-contention-proof",
+      },
+    ],
   });
 });
 

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -40,13 +40,19 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
   assert.match(source, /repair:exact-review-batch heartbeat/);
   assert.equal(source.match(/repair:exact-review-batch commit/g)?.length, 1);
   assert.equal(source.match(/repair:exact-review-batch complete/g)?.length, 1);
+  assert.equal(source.match(/repair:exact-review-batch release/g)?.length, 1);
   assert.match(source, /Finalize healthy members under a fenced heartbeat/);
+  assert.match(source, /Release unfinished batch members/);
+  assert.match(source, /always\(\).*steps\.batch\.outputs\.claimed/);
+  assert.match(source, /name: Release unfinished batch members[\s\S]*?continue-on-error: true/);
   assert.match(source, /while sleep 60/);
   assert.match(source, /test ! -f "\$heartbeat_failed"/);
   assert.match(source, /Leaving .* retryable: artifact download failed/);
   assert.match(source, /Leaving .* retryable: artifact validation failed/);
   assert.match(source, /Leaving .* retryable: item publication failed/);
   assert.match(source, /Leaving .* retryable: legacy tuple-less artifact/);
+  assert.match(source, /write_failure .*retryable_failure artifact_unavailable/);
+  assert.match(source, /write_failure .*permanent_failure tuple_protocol_invalid/);
   assert.match(source, /EXACT_REVIEW_BATCH_MUTATION_OUTPUT/);
   // Keep the fixture from looking like an embedded credential while still
   // proving that artifact downloads use the owner-scoped repository token.
@@ -82,4 +88,11 @@ test("batch claim treats an all-stale fetched batch as terminal", () => {
   assert.ok(
     cliSource.indexOf("if (!manifest.items.length) return;") < cliSource.indexOf("owners.size"),
   );
+});
+
+test("batch failure cleanup completes manifest fences without a queue fetch", () => {
+  const releaseSource = /async function release\(\) \{([\s\S]*?)\n\}/.exec(cliSource)?.[1] ?? "";
+  assert.match(releaseSource, /manifest\.items\.map/);
+  assert.match(releaseSource, /acknowledge\(manifest, completions\)/);
+  assert.doesNotMatch(releaseSource, /client\.fetch/);
 });


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submitted: July 21, 2026, 2:59 PM (US Eastern Time) / 18:59 UTC.
Last body edit: July 21, 2026, 3:01 PM (US Eastern Time) / 19:01 UTC.
Latest head commit: July 21, 2026, 2:29 PM (US Eastern Time) / 18:29 UTC.
<!-- submission-timestamps:end -->

## Summary

This PR adds failure containment to exact-review publication batches. A claimed batch member is now acknowledged with a fenced retryable, refresh-required, or permanent outcome when publication cannot finish, and an unconditional workflow cleanup releases any member left unfinished by cancellation or an unexpected step failure.

This is the liveness and failure-containment companion to the durable FIFO coordinator in #756. It does not replace that coordinator and does not claim to solve all throughput or production rollout concerns.

## Breaking changes

None. The existing publication queue protocol remains compatible and no migration is required. The new failure outcomes reuse the existing retry, refresh, and dead-letter policy, while the batch membership record continues to use the existing `lease_expired` terminal membership value for explicit fenced release.

## Why / user impact

The first production batch after the coordinator rollout claimed and prepared two members, then failed when the commit command's queue fetch returned invalid JSON with HTTP 500. The workflow had no unconditional cleanup step, so the claimed members remained in the batch until the lease expired. One active batch could consequently delay every later publication batch even though the failed workflow had already stopped making progress.

The intended behavior is that a failed or cancelled batch relinquishes only its own fenced memberships promptly. Healthy members may still be published, retryable members follow the existing bounded backoff policy, refresh-required members are requeued for a fresh source, and permanent failures use the existing dead-letter capacity checks. A stale worker cannot release a newer revision or claim generation.

## Implementation

- `.github/workflows/exact-review-batch-publish.yml`
  - writes a small structured failure outcome for artifact, validation, tuple, and publication failures;
  - acknowledges unfinished members from an `always()` cleanup step;
  - makes cleanup `continue-on-error` so a cleanup transport failure cannot mask the primary publication failure.
- `src/repair/exact-review-batch-cli.ts`
  - adds the `release` command;
  - releases directly from the claimed manifest's revision and claim-generation fences without fetching the queue again;
  - maps recorded outcomes to the existing completion policy and falls back to `workflow_cancelled` retryable outcomes when a member has no outcome file;
  - releases members after commit contention and preserves the original error as the primary workflow failure.
- `src/repair/exact-review-batch-coordinator.ts`
  - sends retryable members through the same completion request as published and superseded members;
  - assigns stable reason codes such as `artifact_unavailable`, `state_contention`, `github_rate_limit`, and `unknown_failure`.
- `src/repair/exact-review-batch-publisher.ts` and `src/repair/exact-review-batch-queue-client.ts`
  - extend the completion contract with failure classifications and optional error fingerprints;
  - serialize the optional fields without changing existing successful completion semantics.
- `dashboard/exact-review-publication-batches.ts` and `dashboard/exact-review-queue.ts`
  - accept fenced retryable outcomes;
  - route them through `finishExactReviewPublicationQueueItem` and the existing retry, refresh, and dead-letter policy;
  - make same-fence completion and delayed cleanup idempotent after normal completion or lease expiry;
  - preserve owner, revision, and claim-generation rejection for stale requests.
- `docs/state-publication-batching-plan.md`
  - documents explicit failure terminalization, direct manifest release, idempotent cleanup, and the separation from coordinator rollout.

## Code-path analysis

- Runtime entry: `.github/workflows/exact-review-batch-publish.yml` claims a publication batch, prepares artifacts, commits generated state, completes successful members, and now always invokes the release path for unfinished members.
- Queue owner: `ExactReviewQueue` in `dashboard/exact-review-queue.ts` owns publication item revision, retry, refresh, dead-letter, batch lease, and completion fencing.
- Batch owner: `ExactReviewPublicationBatchStore` in `dashboard/exact-review-publication-batches.ts` owns batch membership, lease state, claim generation, expiry, and idempotent completion.
- Callers: `src/repair/exact-review-batch-cli.ts` and `src/repair/exact-review-batch-coordinator.ts` submit completion requests through `ExactReviewBatchQueueClient`.
- Callees: `finishExactReviewPublicationQueueItem` applies the existing retry/refresh/dead-letter policy; `StatePublishContentionError` identifies a retryable state-writer contention failure; the workflow cleanup uses the already claimed manifest rather than a second queue read.
- Sibling behavior: published and superseded outcomes retain their existing publication and source-drift behavior; lease expiry remains the crash fallback for workers that cannot send any acknowledgement.
- Contract boundary: every completion is checked against batch id, lease owner, item key, revision, and claim generation. A delayed cleanup that matches the same immutable fences is an idempotent no-op; a wrong owner or stale generation is rejected.
- Adjacent tests: `test/exact-review-publication-batches.test.ts`, `test/repair/exact-review-batch-coordinator.test.ts`, and `test/repair/exact-review-batch-workflow.test.ts` cover retry release, partial completion, expiry races, stale generations, reason-code mapping, manifest-only cleanup, and workflow structure.

## Mainline comparison

The official upstream default branch is `main` at `36d600302da14396cefa3ade3fa7aee2a6d155ce` (committed July 21, 2026 at 17:56:50 UTC). This is the latest confirmed upstream base at the final pre-submission refresh.

PR #756 introduced the durable FIFO coordinator and its production rollout exposed the remaining failure-containment gap described above. PR #757 is included in the confirmed base commit. This PR is intentionally narrower: the coordinator controls durable writer admission and fairness, while this change ensures that a batch which has already been admitted cannot strand its own queue membership after artifact, publication, cancellation, or cleanup-path failure.

No current-main code path was treated as proof that failure cleanup was complete. The changed behavior is validated independently on the exact current head.

## Branch / base provenance

- Base repository/ref: `openclaw/clawsweeper:main@36d600302da14396cefa3ade3fa7aee2a6d155ce`.
- Head repository/ref: `snowzlmbot/clawsweeper:fix/release-failed-publication-batches@94d3ef355f07d648bf67df175d3260e89fa5008b`.
- The code head is the recorded upstream base plus the focused implementation and regression-test commit.
- Dedicated evidence branch: [`snowzlmbot/clawsweeper:evidence/issue-738-publication-batch-release`](https://github.com/snowzlmbot/clawsweeper/tree/evidence/issue-738-publication-batch-release). Its current head is `24e3cf86ff24c8d9454a2622ca09e8e9eff0e41a`, and its only difference from the code head is the proof-only workflow under `.github/workflows/evidence-release-failed-publication-batches.yml`.
- The fork default branch is used only as the mirror and was not used for implementation or evidence commits. No feature branch was pushed to upstream.

## Dependency / contract verification

- No package dependency, lockfile, queue schema migration, or public configuration name changes.
- Existing HMAC queue authentication and owner-scoped batch routes remain in use.
- Existing retry delay, refresh, and dead-letter policy remains the owner of item-level failure handling.
- Existing lease expiry remains the final crash fallback; explicit cleanup only succeeds for the immutable fences persisted in the claimed manifest.
- Cleanup is best-effort after a primary failure, but accepted fenced completions remain durable and idempotent.

## Labels considered

`bug`, `impact:automation`, `merge-risk: automation`, and `P1`/`P2` may be relevant for maintainer triage. No upstream labels are requested or claimed as applied by this contributor.

## Validation

The final upstream refresh confirmed the base remained unchanged, so no rebase was required. The code branch was checked for a clean worktree, correct ancestry, and exact remote head. Lightweight local checks were limited to diff whitespace and repository topology; no local build or non-small test was used as proof.

- Full fork CI: [run 29858440599](https://github.com/snowzlmbot/clawsweeper/actions/runs/29858440599) ran the repository CI workflow against code head `94d3ef355f07d648bf67df175d3260e89fa5008b`. The build-related jobs passed, but the aggregate `pnpm check` job did not reach a clean conclusion because an unrelated `failed-review-retry` simulation produced a mismatched generated timeout fixture. This failure is outside the changed publication-batch paths.
- Focused current-head proof: [run 29859206650](https://github.com/snowzlmbot/clawsweeper/actions/runs/29859206650) completed successfully against evidence head `24e3cf86ff24c8d9454a2622ca09e8e9eff0e41a`, with the code head pinned to `94d3ef355f07d648bf67df175d3260e89fa5008b`.
- The focused proof ran `pnpm run build:all`, all three changed-path regression suites, focused `oxlint` correctness checks for changed TypeScript/test paths, and `oxfmt --check` for changed source, documentation, test, and workflow files.
- The proof workflow also verified that the evidence branch is an ancestor-preserving extension of the code head and differs from it only by the proof workflow.

## Evidence source map

- Existing design and failure-containment context: [#738](https://github.com/openclaw/clawsweeper/issues/738) and [#725](https://github.com/openclaw/clawsweeper/issues/725).
- Durable coordinator context: [#756](https://github.com/openclaw/clawsweeper/pull/756).
- Latest confirmed mainline context: [#757](https://github.com/openclaw/clawsweeper/pull/757) and base commit [`36d6003`](https://github.com/openclaw/clawsweeper/commit/36d600302da14396cefa3ade3fa7aee2a6d155ce).
- Production failure: [failed publication batch run 29854892938](https://github.com/openclaw/clawsweeper/actions/runs/29854892938). The run claimed and prepared two members, then the queue fetch returned invalid JSON with HTTP 500; no unconditional cleanup was present, so membership remained leased.
- Current-head focused proof: [successful evidence run 29859206650](https://github.com/snowzlmbot/clawsweeper/actions/runs/29859206650). It covers build, changed-path tests, lint, formatting, and evidence-branch topology.

## Sanitized logs

```text
production failure: batch claimed=2; queue fetch returned invalid JSON; HTTP 500; no unconditional cleanup
production snapshot: publication backlog ready=1729; resolved in prior 60m=0; active=0; leased batches=1; active members=2; expired batches=9; state_append pending_rows=8020
focused proof: build:all=passed; changed suites=passed; focused lint=passed; changed-path format=passed; topology guard=passed
code base: 36d600302da14396cefa3ade3fa7aee2a6d155ce
code head: 94d3ef355f07d648bf67df175d3260e89fa5008b
evidence head: 24e3cf86ff24c8d9454a2622ca09e8e9eff0e41a
```

The log excerpts contain no credentials, cookies, hostnames, IP addresses, local paths, or private runtime identifiers.

## Media evidence

This change covers a queue and workflow lifecycle rather than a UI interaction. A screenshot cannot establish the required claim, failure, cleanup, retry, and stale-fence sequence. The public production failure run and the reproducible focused Actions run are the appropriate evidence for this behavior; no screenshot or video is claimed.

## Risk

- A cleanup request can race normal completion or lease expiry. Immutable revision and claim-generation fences make same-fence repeats idempotent and reject stale ownership.
- A queue or network outage can prevent explicit cleanup. Lease expiry remains the final fallback, and the workflow preserves the primary failure result.
- Retryable release increases queue work according to the existing bounded retry policy. Dead-letter capacity and permanent-failure handling remain unchanged.
- The workflow cleanup is intentionally non-fatal after the primary publication step, so a cleanup transport error cannot turn an already successful publication into a failed workflow.
- No new credentials, permissions, external service, or persistent schema migration is introduced by the queue contract changes.

## Rollback

Revert the single code commit `94d3ef355f07d648bf67df175d3260e89fa5008b`. This requires no data migration or configuration rollback. Existing leased batches remain compatible; any currently running workflow can finish under the old lease-expiry fallback.

## Docs updated

- `docs/state-publication-batching-plan.md`

## Related issue / PR

- Related to [#725](https://github.com/openclaw/clawsweeper/issues/725), which documents state-publication lease starvation.
- Related to [#738](https://github.com/openclaw/clawsweeper/issues/738), the single-writer materialization RFC.
- Companion to [#756](https://github.com/openclaw/clawsweeper/pull/756), the durable FIFO coordinator.
- Based on the latest upstream mainline represented by [#757](https://github.com/openclaw/clawsweeper/pull/757).

## Limitations

- This PR does not claim to fix all publication throughput, state-repository contention, or coordinator rollout issues.
- No production deployment or live cancellation was performed from this contributor branch.
- The full aggregate fork check remains limited by the unrelated `failed-review-retry` simulation noted above; the focused current-head proof passed every changed path.
- Upstream pull-request CI and maintainer review remain authoritative for merge readiness.
