### PR TITLE
Fix State writer coordinator history chart

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8581,7 +8581,7 @@ function oneHourTrend(samples) {
   return { className: "stable", label: "Stable · no change in the last hour" };
 }
 
-function exactReviewTrend(samples, label) {
+function exactReviewTrend(samples, label, ariaMetric = "pending backlog") {
   if (!samples.length) {
     return '<div class="exact-trend"><div class="exact-trend-status collecting">Collecting 1h trend</div><div class="trend-empty">No backlog history in this range.</div></div>';
   }
@@ -8603,7 +8603,7 @@ function exactReviewTrend(samples, label) {
   const direction = oneHourTrend(visible);
   const rangeLabel = activeHealthRange === "7d" ? "7d ago" : activeHealthRange + " ago";
   const axis = '<text class="trend-axis-label" x="' + plot.left + '" y="' + (height - 7) + '">' + rangeLabel + '</text><text class="trend-axis-label" x="' + (plot.left + plot.width) + '" y="' + (height - 7) + '" text-anchor="end">now</text>';
-  return '<div class="exact-trend"><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(label + " pending backlog over " + activeHealthRange) + '">' + grid + '<path class="exact-trend-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
+  return '<div class="exact-trend"><div class="exact-trend-status ' + direction.className + '">' + esc(direction.label) + '</div><svg class="exact-trend-svg" viewBox="0 0 ' + width + " " + height + '" role="img" aria-label="' + esc(label + " " + ariaMetric + " over " + activeHealthRange) + '">' + grid + '<path class="exact-trend-line" d="' + trendPath(geometry) + '"></path>' + points + axis + '</svg></div>';
 }
 
 function laneSpeedStatus(sample) {
@@ -8846,6 +8846,25 @@ function stateWriterHistorySamples() {
   });
 }
 
+function stateWriterCoordinatorHistorySamples() {
+  return healthHistorySamples.flatMap((sample) => {
+    const writer = sample?.state_writer;
+    const active = writer?.tracked_holding;
+    const queued = writer?.tracked_waiting;
+    if (
+      !writer ||
+      writer.collection_ok !== true ||
+      typeof active !== "number" ||
+      !Number.isInteger(active) ||
+      active < 0 ||
+      typeof queued !== "number" ||
+      !Number.isInteger(queued) ||
+      queued < 0
+    ) return [];
+    return [{ at: sample.at, active, queued }];
+  });
+}
+
 function stateWriterHistorySegment(samples, field) {
   if (samples.length < 2) return null;
   let startIndex = 0;
@@ -8888,6 +8907,8 @@ function renderStateWriter(queue) {
   const lease = writer.global_lease || {};
   const hour = writer.last_60_minutes || {};
   const history = stateWriterHistorySamples();
+  const coordinatorHistory = stateWriterCoordinatorHistorySamples();
+  const latestCoordinatorHistory = coordinatorHistory.at(-1);
   const latestHistory = history.at(-1);
   const historyFresh = Boolean(
     latestHistory && Date.now() - Date.parse(latestHistory.at) <= 12 * 60 * 1000
@@ -8929,7 +8950,14 @@ function renderStateWriter(queue) {
   const metric = (value, fallback = "unknown") => value === null || value === undefined ? fallback : value;
   const percentile = (value) =>
     value?.samples ? "p50 " + metric(value.p50) + "ms · p95 " + metric(value.p95) + "ms · n=" + value.samples : "unknown";
-  const itemTrend = history.map((sample) => ({ at: sample.at, pending: sample.items }));
+  const queueTrend = coordinatorHistory.map((sample) => ({ at: sample.at, pending: sample.queued }));
+  const queuedHistory = coordinatorHistory.map((sample) => sample.queued);
+  const coordinatorHistorySummary = coordinatorHistory.length
+    ? metric(coordinatorHistory.length) + " samples · " + metric(Math.min(...queuedHistory)) + "–" + metric(Math.max(...queuedHistory)) + " queued"
+    : "collecting samples";
+  const latestCoordinatorSummary = latestCoordinatorHistory
+    ? metric(latestCoordinatorHistory.active) + " active · " + metric(latestCoordinatorHistory.queued) + " queued · " + since(latestCoordinatorHistory.at)
+    : "collecting samples";
   const coordinatorTurns = coordinatorLive
     ? metric(coordinator.completed) + " completed · " + metric(coordinator.admitted) + " admitted" +
       (Number(coordinator.recovered) || Number(coordinator.expired)
@@ -8944,6 +8972,14 @@ function renderStateWriter(queue) {
     : collection.last_observed_at
       ? "terminal telemetry stale · last observed " + since(collection.last_observed_at)
       : "terminal telemetry unavailable";
+  const terminalMetrics = terminalFresh
+    ? "<div><dt>Exact-review materialized</dt><dd>" + esc(metric(itemsPerHour ?? hour.materialized_items)) + " items/hour</dd></div>" +
+      "<div><dt>Exact-review commits</dt><dd>" + esc(metric(commitsPerHour ?? hour.state_commits)) + "/hour</dd></div>" +
+      "<div><dt>Items / commit</dt><dd>" + esc(metric(itemsPerCommit)) + "</dd></div>" +
+      "<div><dt>Git fence wait</dt><dd>" + esc(percentile(wait)) + "</dd></div>" +
+      "<div><dt>Git fence hold</dt><dd>" + esc(percentile(hold)) + "</dd></div>"
+    : "<div><dt>Last exact-review materialization</dt><dd>" + esc(writer.last_successful_materialization_at ? since(writer.last_successful_materialization_at) : "not observed") + "</dd></div>" +
+      "<div><dt>Terminal telemetry</dt><dd>" + esc(terminalStatus) + "</dd></div>";
   target.innerHTML =
     '<div class="exact-lane-head"><strong>State writer</strong><span>' + esc(mode) + " · " + esc(coordinatorLive ? "coordinator live" : metric(collection.status)) + " · " + esc(rangeLabel) + "</span></div>" +
     '<div class="lane-counts">' +
@@ -8956,17 +8992,15 @@ function renderStateWriter(queue) {
     '</strong></div>' +
     '<div class="lane-count"><span>Git crash fence</span><strong>' + esc(metric(lease.status)) +
     "</strong></div></div>" +
-    exactReviewTrend(itemTrend, "Materialized items") +
+    exactReviewTrend(queueTrend, "Serialized writer queue", "depth") +
     '<dl class="lane-metrics">' +
     "<div><dt>Coordinator turns</dt><dd>" + esc(coordinatorTurns) + "</dd></div>" +
     "<div><dt>Coordinator wait</dt><dd>" + esc(coordinatorWait) + "</dd></div>" +
-    "<div><dt>Exact-review materialized</dt><dd>" + esc(metric(itemsPerHour ?? (terminalFresh ? hour.materialized_items : null))) + " items/hour</dd></div>" +
-    "<div><dt>Exact-review commits</dt><dd>" + esc(metric(commitsPerHour ?? (terminalFresh ? hour.state_commits : null))) + "/hour</dd></div>" +
-    "<div><dt>Items / commit</dt><dd>" + esc(metric(itemsPerCommit)) + "</dd></div>" +
-    "<div><dt>Git fence wait</dt><dd>" + esc(percentile(wait)) + "</dd></div>" +
-    "<div><dt>Git fence hold</dt><dd>" + esc(percentile(hold)) + "</dd></div>" +
+    "<div><dt>Queue history</dt><dd>" + esc(coordinatorHistorySummary) + "</dd></div>" +
+    "<div><dt>Latest queue sample</dt><dd>" + esc(latestCoordinatorSummary) + "</dd></div>" +
+    terminalMetrics +
     "</dl>" +
-    '<p class="state-writer-note">' + esc(terminalStatus) + ". Exact-review throughput uses recent " + esc(rangeLabel) + " history when available; stale terminal samples are never rendered as current zeroes.</p>" +
+    '<p class="state-writer-note">The chart uses five-minute coordinator queue samples from the selected ' + esc(rangeLabel) + " range. Exact-review throughput appears only while its separate terminal telemetry is fresh.</p>" +
     '<p class="state-writer-note">The durable coordinator is authoritative for active and queued writers. The Git ref remains only a crash-recovery fence.</p>';
 }
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -335,9 +335,10 @@ The Git lease ref is displayed only as a crash-recovery fence. Exact-review
 terminal telemetry still owns item/commit throughput and Git fence timing; an
 idle or failed publisher can make that telemetry stale without making the
 coordinator unavailable. The panel therefore shows the configured publication
-batch size independently, labels stale terminal data, and never renders stale
-zeroes as current throughput. Five-minute history samples use coordinator
-liveness and queue depth when progress events are idle.
+batch size independently, uses five-minute coordinator queue depth for its
+primary chart and recent sample summary, and never renders stale terminal
+zeroes as current throughput. Exact-review item, commit, and Git-fence timing
+metrics appear only while that separate terminal telemetry is fresh.
 
 Executors report the GitHub job outcome from their finalizer. Failure or
 cancellation clears the lease and requeues the item. Finalizer success remains

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7530,22 +7530,57 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(stateWriterHtml, /Git crash fence<\/span><strong>free/);
   assert.match(stateWriterHtml, /Coordinator turns<\/dt><dd>16 completed · 16 admitted/);
   assert.match(stateWriterHtml, /Coordinator wait<\/dt><dd>last 0s · max 5m/);
-  assert.match(stateWriterHtml, /Exact-review materialized<\/dt><dd>unknown items\/hour/);
+  assert.match(stateWriterHtml, /Queue history<\/dt><dd>collecting samples/);
+  assert.match(stateWriterHtml, /Terminal telemetry<\/dt><dd>terminal telemetry stale/);
   assert.match(stateWriterHtml, /terminal telemetry stale/);
-  assert.doesNotMatch(stateWriterHtml, /Exact-review materialized<\/dt><dd>0 items\/hour/);
+  assert.doesNotMatch(stateWriterHtml, /Exact-review materialized/);
 
-  context.healthHistorySamples = [
+  const coordinatorSamples = [
     {
-      at: new Date().toISOString(),
+      at: new Date(Date.now() - 15 * 60_000).toISOString(),
       state_writer: {
         collection_ok: true,
         terminal_collection_ok: false,
+        tracked_holding: null,
+        tracked_waiting: "",
+      },
+    },
+    {
+      at: new Date(Date.now() - 10 * 60_000).toISOString(),
+      state_writer: {
+        collection_ok: true,
+        terminal_collection_ok: false,
+        tracked_holding: 1,
+        tracked_waiting: 5,
         accepted_operations_total: 16,
         state_commits_total: 8,
         materialized_items_total: 16,
       },
     },
+    {
+      at: new Date(Date.now() - 5 * 60_000).toISOString(),
+      state_writer: {
+        collection_ok: true,
+        terminal_collection_ok: false,
+        tracked_holding: 1,
+        tracked_waiting: 2,
+      },
+    },
+    {
+      at: new Date().toISOString(),
+      state_writer: {
+        collection_ok: true,
+        terminal_collection_ok: false,
+        tracked_holding: 1,
+        tracked_waiting: 4,
+      },
+    },
   ];
+  context.fetch = async () => ({
+    ok: true,
+    json: async () => ({ samples: coordinatorSamples }),
+  });
+  await context.loadHealthHistory("6h", true);
   context.renderStateWriter({
     lanes: { publication: { batches: { enabled: true, max_items: 2 } } },
     state_writer: {
@@ -7558,12 +7593,17 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   });
   assert.match(
     elementFor("state-writer-health").innerHTML,
-    /Exact-review materialized<\/dt><dd>unknown items\/hour/,
+    /Queue history<\/dt><dd>3 samples · 2–5 queued/,
   );
-  assert.doesNotMatch(
+  assert.match(
     elementFor("state-writer-health").innerHTML,
-    /Exact-review materialized<\/dt><dd>0 items\/hour/,
+    /Latest queue sample<\/dt><dd>1 active · 4 queued ·/,
   );
+  assert.match(
+    elementFor("state-writer-health").innerHTML,
+    /Serialized writer queue depth over 6h/,
+  );
+  assert.doesNotMatch(elementFor("state-writer-health").innerHTML, /Exact-review materialized/);
   assert.match(stateWriterHtml, /class="lane-metrics"/);
   assert.doesNotMatch(stateWriterHtml, /<section class="exact-lane">/);
   const initialLaneHtml = elementFor("exact-review-lanes").innerHTML;


### PR DESCRIPTION
## What changed

- render the State writer chart from five-minute coordinator queue-depth samples
- show the selected range's sample count and queued min/max plus the latest active/queued sample
- hide exact-review throughput rows while their separate terminal telemetry is stale
- reject null, empty, boolean, fractional, and negative queue counters instead of coercing them to zero

## Root cause

The previous dashboard fix admitted coordinator-only samples into health history but the chart selector still filtered them out and plotted only terminal-fresh materialization counters. Once terminal telemetry went stale, the chart stopped halfway through the selected range and the remaining rows rendered as `unknown`, even though recent coordinator samples were available.

Production currently has 173 usable coordinator samples in the 24-hour history, including current five-minute queue-depth points, so this change populates the chart immediately after deployment without changing the state writer itself.

## Validation

- `node --test test/dashboard-worker.test.ts` — 163/163 passed
- dashboard build, lint, and unit suites passed under host `pnpm run check`
- the two repair-only failures are the known host Git 2.43.7 lack of `--no-lazy-fetch`; the PR runner provides the supported Git version
- autoreview clean after addressing both accepted findings

This PR changes only Dashboard rendering, tests, and documentation. Batch size remains 2.
