### PR TITLE
fix(publication): raise batch publisher ask to 32 items

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -30,7 +30,7 @@ jobs:
       EXACT_REVIEW_BATCH_ID: exact-review-batch:${{ github.run_id }}
       EXACT_REVIEW_BATCH_LEASE_OWNER: github:${{ github.run_id }}
       EXACT_REVIEW_BATCH_MANIFEST: .artifacts/exact-review-batch/manifest.json
-      EXACT_REVIEW_BATCH_MAX_ITEMS: "4"
+      EXACT_REVIEW_BATCH_MAX_ITEMS: "32"
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
       CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
     steps:

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -29,7 +29,7 @@ test("batch publisher is event-driven with one non-cancelling serial workflow", 
   assert.ok(workflow.on.workflow_dispatch);
   assert.match(workflow.jobs.publish!.if, /inputs\.execute/);
   assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute"]);
-  assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_MAX_ITEMS, "4");
+  assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_MAX_ITEMS, "32");
   assert.equal(workflow.jobs.publish!.env.CLAWSWEEPER_APP_CLIENT_ID, "Iv23liOECG0slfuhz093");
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
   assert.deepEqual(workflow.permissions, { actions: "write", contents: "read" });

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -125,7 +125,7 @@ test("state compaction remains an explicitly separate main-branch writer", () =>
 test("the rollout returns to the last safe batch size during item deduplication", () => {
   const workflow = readFileSync(join(workflowDirectory, "exact-review-batch-publish.yml"), "utf8");
   const worker = readFileSync("dashboard/wrangler.toml", "utf8");
-  assert.match(workflow, /EXACT_REVIEW_BATCH_MAX_ITEMS: "4"/);
+  assert.match(workflow, /EXACT_REVIEW_BATCH_MAX_ITEMS: "32"/);
   assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "4"/);
   assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"/);
 });


### PR DESCRIPTION
Publication backlog is at ~2,481 pending with the single serialized batch publisher asking only 4 items per ~7-min cycle (~35-70/h) — placeholders sit for hours (e.g. openclaw/openclaw#112379, #112489; watchdog re-enqueues amplify load). This raises the workflow ask to 32, aligned with the batch-32 rollout plan branch; the DO-side grant still bounds the actual batch, so this is a ceiling lift, not a forced jump. Composes with #767/#771/#772.

Coordination note on #738: publication throughput during backlog drain needs to exceed review inflow; happy to revert in favor of the rollout-plan PR if one is imminent.
