### PR TITLE
fix(apply): stop cleanly at token budget and resume next run

### DIFF
--- a/.github/actions/create-target-write-token/action.yml
+++ b/.github/actions/create-target-write-token/action.yml
@@ -31,6 +31,7 @@ runs:
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repository }}
+        permission-actions: read
         permission-checks: read
         permission-contents: write
         permission-issues: write

--- a/.github/actions/create-target-write-token/action.yml
+++ b/.github/actions/create-target-write-token/action.yml
@@ -31,10 +31,11 @@ runs:
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repository }}
-        permission-actions: read
+        permission-checks: read
         permission-contents: write
         permission-issues: write
         permission-pull-requests: write
+        permission-statuses: read
 
     - name: Record token mint time
       id: minted-at

--- a/.github/actions/create-target-write-token/action.yml
+++ b/.github/actions/create-target-write-token/action.yml
@@ -1,0 +1,42 @@
+name: Create ClawSweeper target write token
+description: Mint a GitHub App token for an apply target and record when its lifetime began.
+inputs:
+  client-id:
+    description: GitHub App client ID.
+    required: true
+  private-key:
+    description: GitHub App private key.
+    required: true
+  owner:
+    description: Target repository owner.
+    required: true
+  repository:
+    description: Target repository name.
+    required: true
+outputs:
+  token:
+    description: GitHub App installation token for the target repository.
+    value: ${{ steps.target-token.outputs.token }}
+  minted-at-ms:
+    description: Unix timestamp in milliseconds captured immediately after the token was minted.
+    value: ${{ steps.minted-at.outputs.milliseconds }}
+runs:
+  using: composite
+  steps:
+    - name: Create target repository token
+      id: target-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ inputs.client-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repository }}
+        permission-actions: read
+        permission-contents: write
+        permission-issues: write
+        permission-pull-requests: write
+
+    - name: Record token mint time
+      id: minted-at
+      shell: bash
+      run: echo "milliseconds=$(node -e 'process.stdout.write(String(Date.now()))')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4392,16 +4392,12 @@ jobs:
       - name: Create target write token
         id: target-write-token
         continue-on-error: true
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: ./.github/actions/create-target-write-token
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.target_repo_owner }}
-          repositories: ${{ steps.target.outputs.target_repo_name }}
-          permission-contents: write
-          permission-actions: read
-          permission-issues: write
-          permission-pull-requests: write
+          repository: ${{ steps.target.outputs.target_repo_name }}
 
       - name: Create state token
         id: state-token
@@ -4453,10 +4449,11 @@ jobs:
 
       - name: Apply unchanged proposed decisions with checkpoints
         id: apply-existing-run
-        timeout-minutes: 350
+        timeout-minutes: 70
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS: ${{ steps.target-write-token.outputs.minted-at-ms }}
           CLAWSWEEPER_PUBLISH_THROTTLE_STATUS: "true"
           CLAWSWEEPER_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CLAWSWEEPER_THROTTLE_STATUS_MIN_WAIT_MS: "60000"
@@ -4467,6 +4464,7 @@ jobs:
           set -euo pipefail
           test -n "$GH_TOKEN"
           source scripts/apply-workflow-helpers.sh
+          initialize_apply_token_budget
           limit="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '20' }}"
           min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_days || '0' }}"
           min_age_minutes="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_min_age_minutes || '' }}"
@@ -4668,6 +4666,7 @@ jobs:
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
               --apply-health-file ".artifacts/apply-health-$checkpoint.json"
             publish_status "chore: update sweep comment sync status"
+            report_apply_token_budget_stop ".artifacts/apply-reports/apply-report-$checkpoint.json" "$result_count" "unknown"
             echo "::endgroup::"
           fi
           while [ "$closed_total" -lt "$limit" ]; do
@@ -4745,7 +4744,7 @@ jobs:
             publish_status "chore: update sweep apply checkpoint $checkpoint status"
             echo "::endgroup::"
             drop_bounded_coverage_proof_tail "$cursor_trace_path"
-            if automatic_apply_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json"; then break; fi
+            if apply_checkpoint_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json" "$result_count" "$((limit - closed_total))"; then break; fi
             if [ "$result_count" -ge "$close_processed_limit" ]; then
               if [ "$closed_in_chunk" -gt 0 ]; then
                 echo "Close scan reached its $close_processed_limit-record budget; queueing a fresh-token continuation."

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -6,6 +6,43 @@
 
 max_close_processed_limit=900
 coverage_proof_limit=2
+apply_token_budget_ms=3300000
+
+initialize_apply_token_budget() {
+  local minted_at_ms="${CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS:-}"
+  if ! [[ "$minted_at_ms" =~ ^[0-9]+$ ]]; then
+    echo "Target write token mint time is missing or invalid." >&2
+    return 1
+  fi
+  CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS=$((minted_at_ms + apply_token_budget_ms))
+  export CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS
+  echo "Apply token deadline is ${CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS}ms since epoch (55 minutes after mint)."
+}
+
+apply_token_budget_reached() {
+  local report_path="$1"
+  jq -e '
+    any(.[];
+      .action == "skipped_runtime_budget" and
+      ((.reason // "") | startswith("apply token budget reached"))
+    )
+  ' "$report_path" >/dev/null
+}
+
+apply_token_budget_stop_summary() {
+  local processed="$1"
+  local remaining="$2"
+  echo "apply stopped at token budget: processed=$processed remaining=~$remaining; next run continues"
+}
+
+report_apply_token_budget_stop() {
+  local report_path="$1"
+  local processed="$2"
+  local remaining="$3"
+  if apply_token_budget_reached "$report_path"; then
+    apply_token_budget_stop_summary "$processed" "$remaining"
+  fi
+}
 
 validate_coverage_proof_tree() {
   local proof_dir="$1"
@@ -209,11 +246,25 @@ automatic_apply_runtime_reached() {
   fi
   if [ "$runtime_auto_selected_apply_batch" = "true" ] &&
     { [ -z "$runtime_cursor_advance_count" ] || [ "$runtime_cursor_advance_count" -eq 0 ]; }; then
-    echo "Automatic close checkpoint reached its 600000ms runtime budget before cursor progress; cursor is unchanged and scheduled apply will retry without queueing an immediate continuation."
+    echo "Apply checkpoint reached its runtime budget before cursor progress; cursor is unchanged and scheduled apply will retry without queueing an immediate continuation."
     return 0
   fi
-  echo "Automatic close checkpoint reached its 600000ms runtime budget; cursor is persisted and a fresh-token continuation will resume the lane."
+  echo "Apply checkpoint reached its runtime budget; cursor is persisted and a fresh-token continuation will resume the lane."
   continue_apply=true
+  return 0
+}
+
+apply_checkpoint_runtime_reached() {
+  local report_path="$1"
+  local processed="$2"
+  local remaining="$3"
+  if ! automatic_apply_runtime_reached "$report_path"; then
+    return 1
+  fi
+  if [ "${auto_selected_apply_batch:-false}" = "true" ] && [ -n "${apply_ready_count:-}" ]; then
+    remaining="$apply_ready_count"
+  fi
+  report_apply_token_budget_stop "$report_path" "$processed" "$remaining"
   return 0
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -2515,6 +2515,7 @@ const GITHUB_RUNTIME_REPORT_FLUSH_RESERVE_MS = 1_000;
 interface GitHubRuntimeBudget {
   startedAtMs: number;
   maxRuntimeMs: number;
+  limitReason?: string;
   onYield?: (reason: string, resumeCurrent?: boolean) => void;
   onFailure?: (error: unknown) => void;
   yieldReason?: string;
@@ -2550,7 +2551,9 @@ function githubRuntimeRemainingMs(nowMs = Date.now()): number | null {
 function githubRuntimeBudgetError(phase: string): GitHubRuntimeBudgetError {
   const budget = activeGitHubRuntimeBudget;
   const reason =
-    budget?.yieldReason ?? `max runtime ${budget?.maxRuntimeMs ?? 0}ms reached ${phase}`;
+    budget?.yieldReason ??
+    budget?.limitReason ??
+    `max runtime ${budget?.maxRuntimeMs ?? 0}ms reached ${phase}`;
   if (budget) budget.yieldReason = reason;
   return new GitHubRuntimeBudgetError(reason);
 }
@@ -26333,11 +26336,56 @@ function recordApplyActionEvents(options: {
   options.ledger.terminal = true;
 }
 
-function applyDecisionsCommand(args: Args): void {
-  const runtimeBudget: GitHubRuntimeBudget = {
-    startedAtMs: Date.now(),
-    maxRuntimeMs: numberArg(args.max_runtime_ms, 0),
+function applyRuntimeBudget(
+  configuredMaxRuntimeMs: number,
+  tokenDeadlineText: string | undefined,
+  nowMs = Date.now(),
+): GitHubRuntimeBudget {
+  if (!tokenDeadlineText) {
+    return { startedAtMs: nowMs, maxRuntimeMs: configuredMaxRuntimeMs };
+  }
+  if (!/^\d+$/.test(tokenDeadlineText)) {
+    throw new Error("CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS must be a Unix timestamp in milliseconds");
+  }
+  const tokenDeadlineMs = Number(tokenDeadlineText);
+  if (!Number.isSafeInteger(tokenDeadlineMs)) {
+    throw new Error("CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS is outside the safe integer range");
+  }
+  const remainingMs = tokenDeadlineMs - nowMs;
+  if (remainingMs <= 0) {
+    return {
+      startedAtMs: nowMs - 1,
+      maxRuntimeMs: 1,
+      limitReason: `apply token budget reached at ${tokenDeadlineMs}ms since epoch`,
+    };
+  }
+  if (configuredMaxRuntimeMs > 0 && configuredMaxRuntimeMs <= remainingMs) {
+    return { startedAtMs: nowMs, maxRuntimeMs: configuredMaxRuntimeMs };
+  }
+  return {
+    startedAtMs: nowMs,
+    maxRuntimeMs: remainingMs,
+    limitReason: `apply token budget reached at ${tokenDeadlineMs}ms since epoch`,
   };
+}
+
+export function applyRuntimeBudgetForTest(options: {
+  configuredMaxRuntimeMs: number;
+  tokenDeadlineMs?: number;
+  nowMs: number;
+}): Pick<GitHubRuntimeBudget, "startedAtMs" | "maxRuntimeMs" | "limitReason"> {
+  return applyRuntimeBudget(
+    options.configuredMaxRuntimeMs,
+    options.tokenDeadlineMs === undefined ? undefined : String(options.tokenDeadlineMs),
+    options.nowMs,
+  );
+}
+
+function applyDecisionsCommand(args: Args): void {
+  const runtimeBudget = applyRuntimeBudget(
+    numberArg(args.max_runtime_ms, 0),
+    process.env.CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS,
+  );
   withGitHubRuntimeBudget(runtimeBudget, () => {
     try {
       applyDecisionsCommandInner(args, runtimeBudget);
@@ -26379,7 +26427,6 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const emitEventApplyProof = boolArg(args.event_apply_proof);
   const exactEventPublication = boolArg(args.exact_event_publication);
   const commentSyncMinAgeDays = numberArg(args.comment_sync_min_age_days, 0);
-  const maxRuntimeMs = numberArg(args.max_runtime_ms, 0);
   const reportPath = resolve(stringArg(args.report_path, join(ROOT, "apply-report.json")));
   const artifactDir = resolve(stringArg(args.artifact_dir, join(ROOT, "artifacts", "apply")));
   const cursorTraceArg = stringArg(args.cursor_trace, "").trim();
@@ -26399,6 +26446,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       : {}),
   };
   const startedAtMs = Date.now();
+  const { maxRuntimeMs } = runtimeBudget;
   const bulkFilerRepositoryPermissionCache: BulkFilerRepositoryPermissionCache = new Map();
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
@@ -26630,12 +26678,14 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     const file = entry.name;
     const path = entry.path;
     if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
+      const reason =
+        runtimeBudget.limitReason ?? `max runtime ${maxRuntimeMs}ms reached`;
       results.push({
         number: 0,
         action: "skipped_runtime_budget",
-        reason: `max runtime ${maxRuntimeMs}ms reached`,
+        reason,
       });
-      logProgress(`stopping apply: max runtime ${maxRuntimeMs}ms reached`);
+      logProgress(`stopping apply: ${reason}`);
       break;
     }
     let markdown = entry.markdown;

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -419,7 +419,7 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
   );
   writeFileSync(join(fixture.itemsDir, "725.md"), synced.report, "utf8");
   writeFileSync(clockHookPath, `Date.now = () => ${Date.now()};\n`, "utf8");
-  process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${clockHookPath}`]
+  process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${JSON.stringify(clockHookPath)}`]
     .filter(Boolean)
     .join(" ");
   try {
@@ -522,7 +522,7 @@ Date.now = () => existsSync(${JSON.stringify(closeCommandLogPath)})
 `,
     "utf8",
   );
-  process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${clockHookPath}`]
+  process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${JSON.stringify(clockHookPath)}`]
     .filter(Boolean)
     .join(" ");
   try {

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -400,6 +400,8 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
   const fixture = runtimeBudgetFixture(725);
   const maxRuntimeMs = 15_000;
   const proofLogPath = join(fixture.root, "proof.log");
+  const clockHookPath = join(fixture.root, "runtime-clock.cjs");
+  const originalNodeOptions = process.env.NODE_OPTIONS;
   const synced = reportWithSyncedReviewComment(
     lowSignalCloseReport({
       number: 725,
@@ -416,6 +418,10 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
     "duplicate_or_superseded",
   );
   writeFileSync(join(fixture.itemsDir, "725.md"), synced.report, "utf8");
+  writeFileSync(clockHookPath, `Date.now = () => ${Date.now()};\n`, "utf8");
+  process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${clockHookPath}`]
+    .filter(Boolean)
+    .join(" ");
   try {
     const startedAt = Date.now();
     withMockGh(
@@ -476,6 +482,8 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
     const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
     assert.match(report[0]?.reason ?? "", /before close$/);
   } finally {
+    if (originalNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = originalNodeOptions;
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
@@ -483,7 +491,12 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
 test("apply-decisions records a successful close before yielding after it", () => {
   const fixture = runtimeBudgetFixture(727);
   const maxRuntimeMs = 25_000;
+  const closeDelayMs = 8_000;
   const proofLogPath = join(fixture.root, "proof.log");
+  const closeCommandLogPath = join(fixture.root, "close-command.log");
+  const clockHookPath = join(fixture.root, "runtime-clock.cjs");
+  const startedAtMs = Date.now();
+  const originalNodeOptions = process.env.NODE_OPTIONS;
   const synced = reportWithSyncedReviewComment(
     lowSignalCloseReport({
       number: 727,
@@ -500,6 +513,18 @@ test("apply-decisions records a successful close before yielding after it", () =
     "duplicate_or_superseded",
   );
   writeFileSync(join(fixture.itemsDir, "727.md"), synced.report, "utf8");
+  writeFileSync(
+    clockHookPath,
+    `const { existsSync } = require("node:fs");
+Date.now = () => existsSync(${JSON.stringify(closeCommandLogPath)})
+  ? ${startedAtMs + maxRuntimeMs - closeDelayMs}
+  : ${startedAtMs};
+`,
+    "utf8",
+  );
+  process.env.NODE_OPTIONS = [originalNodeOptions, `--require=${clockHookPath}`]
+    .filter(Boolean)
+    .join(" ");
   try {
     withMockGh(
       fixture.root,
@@ -507,7 +532,7 @@ test("apply-decisions records a successful close before yielding after it", () =
         number: 727,
         title: "Provider route fallback",
         comment: synced.comment,
-        closeCommandDelayMs: 8_000,
+        closeCommandLogPath,
         itemUpdatedAtAfterProofLogPath: proofLogPath,
         linkedPulls: {
           400: {
@@ -542,7 +567,7 @@ test("apply-decisions records a successful close before yielding after it", () =
                 "--max-runtime-ms",
                 String(maxRuntimeMs),
                 "--close-delay-ms",
-                "8000",
+                String(closeDelayMs),
                 "--cursor-trace",
                 fixture.cursorTracePath,
               ],
@@ -552,6 +577,7 @@ test("apply-decisions records a successful close before yielding after it", () =
       },
     );
 
+    assert.match(readFileSync(closeCommandLogPath, "utf8"), /pr close 727/);
     const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
     const cursorTrace = JSON.parse(readFileSync(fixture.cursorTracePath, "utf8"));
     assert.deepEqual(
@@ -564,6 +590,8 @@ test("apply-decisions records a successful close before yielding after it", () =
     assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [727] });
     assert.equal(existsSync(join(fixture.closedDir, "727.md")), true);
   } finally {
+    if (originalNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = originalNodeOptions;
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -3,7 +3,11 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "node:path";
 import test from "node:test";
 
-import { main, referencingMergedPullRequestsForIssueForTest } from "../dist/clawsweeper.js";
+import {
+  applyRuntimeBudgetForTest,
+  main,
+  referencingMergedPullRequestsForIssueForTest,
+} from "../dist/clawsweeper.js";
 import {
   implementedCloseReport,
   lowSignalCloseReport,
@@ -44,6 +48,93 @@ function assertRuntimeYield(
   assert.match(report[0]?.reason ?? "", new RegExp(`max runtime ${maxRuntimeMs}ms reached`));
   assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [] });
 }
+
+test("apply runtime budget uses the token deadline as an absolute wall clock", () => {
+  const nowMs = 1_000_000;
+  assert.deepEqual(
+    applyRuntimeBudgetForTest({
+      configuredMaxRuntimeMs: 0,
+      tokenDeadlineMs: nowMs + 55_000,
+      nowMs,
+    }),
+    {
+      startedAtMs: nowMs,
+      maxRuntimeMs: 55_000,
+      limitReason: `apply token budget reached at ${nowMs + 55_000}ms since epoch`,
+    },
+  );
+  assert.deepEqual(
+    applyRuntimeBudgetForTest({
+      configuredMaxRuntimeMs: 10_000,
+      tokenDeadlineMs: nowMs + 55_000,
+      nowMs,
+    }),
+    { startedAtMs: nowMs, maxRuntimeMs: 10_000 },
+  );
+  assert.deepEqual(
+    applyRuntimeBudgetForTest({
+      configuredMaxRuntimeMs: 10_000,
+      tokenDeadlineMs: nowMs - 1,
+      nowMs,
+    }),
+    {
+      startedAtMs: nowMs - 1,
+      maxRuntimeMs: 1,
+      limitReason: `apply token budget reached at ${nowMs - 1}ms since epoch`,
+    },
+  );
+});
+
+test("apply-decisions exits cleanly at an expired token deadline and retries the same item", () => {
+  const fixture = runtimeBudgetFixture(728);
+  const invocationLog = join(fixture.root, "gh-invocations.log");
+  const originalDeadline = process.env.CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS;
+  try {
+    withMockGh(
+      fixture.root,
+      `
+const { appendFileSync } = require("node:fs");
+appendFileSync(${JSON.stringify(invocationLog)}, "attempted\\n");
+setTimeout(() => {}, 10_000);
+`,
+      () => {
+        process.env.CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS = String(Date.now() - 1);
+        runApplyDecisionsForTest({
+          ...fixture,
+          extraArgs: ["--cursor-trace", fixture.cursorTracePath],
+        });
+        const stoppedReport = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
+        assert.deepEqual(
+          stoppedReport.map((entry: { number: number; action: string }) => [
+            entry.number,
+            entry.action,
+          ]),
+          [[0, "skipped_runtime_budget"]],
+        );
+        assert.match(stoppedReport[0]?.reason ?? "", /^apply token budget reached/);
+        assert.deepEqual(JSON.parse(readFileSync(fixture.cursorTracePath, "utf8")), {
+          schema_version: 1,
+          examined_item_numbers: [],
+        });
+        assert.equal(existsSync(invocationLog), false, "expired token attempted a GitHub call");
+        assert.equal(existsSync(join(fixture.itemsDir, "728.md")), true);
+
+        process.env.CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS = String(Date.now() + 30_000);
+        runApplyDecisionsForTest({
+          ...fixture,
+          extraArgs: ["--max-runtime-ms", "2200", "--cursor-trace", fixture.cursorTracePath],
+        });
+        assert.match(readFileSync(invocationLog, "utf8"), /attempted/);
+        assertRuntimeYield(fixture, 2_200);
+        assert.equal(existsSync(join(fixture.itemsDir, "728.md")), true);
+      },
+    );
+  } finally {
+    if (originalDeadline === undefined) delete process.env.CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS;
+    else process.env.CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS = originalDeadline;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test("apply-decisions bounds a hung GitHub command and writes a resumable runtime yield", () => {
   const fixture = runtimeBudgetFixture(721);
@@ -136,7 +227,10 @@ test("apply-decisions yields instead of starting a GitHub retry that cannot fit"
       });
     });
 
-    assert.ok(Date.now() - startedAt < 2_000, "GitHub retry sleep ignored the remaining runtime");
+    assert.ok(
+      Date.now() - startedAt < maxRuntimeMs + 500,
+      "GitHub retry sleep ignored the remaining runtime",
+    );
     assertRuntimeYield(fixture, maxRuntimeMs);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
@@ -160,7 +254,10 @@ test("apply-decisions yields instead of retrying malformed GitHub JSON past the 
       });
     });
 
-    assert.ok(Date.now() - startedAt < 2_000, "malformed JSON retry ignored the runtime bound");
+    assert.ok(
+      Date.now() - startedAt < maxRuntimeMs + 500,
+      "malformed JSON retry ignored the runtime bound",
+    );
     assertRuntimeYield(fixture, maxRuntimeMs);
   } finally {
     rmSync(fixture.root, { recursive: true, force: true });
@@ -385,7 +482,7 @@ test("apply-decisions yields instead of starting a post-close delay that cannot 
 
 test("apply-decisions records a successful close before yielding after it", () => {
   const fixture = runtimeBudgetFixture(727);
-  const maxRuntimeMs = 17_000;
+  const maxRuntimeMs = 25_000;
   const proofLogPath = join(fixture.root, "proof.log");
   const synced = reportWithSyncedReviewComment(
     lowSignalCloseReport({

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -772,7 +772,7 @@ test("sweep publishes complete immutable shards for every review and apply produ
   assert.ok(applyPublish > applyFinalizer);
   assert.match(
     workflow.slice(applyStep, applyFinalizer),
-    /id: apply-existing-run[\s\S]*timeout-minutes: 350/,
+    /id: apply-existing-run[\s\S]*timeout-minutes: 70/,
   );
   assert.match(
     workflow.slice(applyFinalizer, applyPublish),

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2532,7 +2532,11 @@ test("sweep target write tokens can merge pull requests", () => {
     .map((block) => block.split("\n      - ")[0]);
 
   assert.equal(targetWriteTokenBlocks.length, 4);
+  const compositeAction = readText(".github/actions/create-target-write-token/action.yml");
+  assert.match(compositeAction, /permission-contents: write/);
+  assert.match(compositeAction, /permission-pull-requests: write/);
   for (const block of targetWriteTokenBlocks) {
+    if (block.includes("uses: ./.github/actions/create-target-write-token")) continue;
     assert.match(block, /permission-contents: write/);
     assert.match(block, /permission-pull-requests: write/);
   }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -456,6 +456,7 @@ export function promotionGhMock(options: {
   commentWriteLogPath?: string;
   commentWriteError?: string;
   closeAppliedBodyLogPath?: string;
+  closeCommandLogPath?: string;
   closeCommandDelayMs?: number;
   comments?: unknown[];
   commentsAfterFirstRead?: unknown[];
@@ -545,6 +546,7 @@ export function promotionGhMock(options: {
 	const commentWriteLogPath = ${JSON.stringify(options.commentWriteLogPath ?? "")};
 	const commentWriteError = ${JSON.stringify(options.commentWriteError ?? "")};
 	const closeAppliedBodyLogPath = ${JSON.stringify(options.closeAppliedBodyLogPath ?? "")};
+	const closeCommandLogPath = ${JSON.stringify(options.closeCommandLogPath ?? "")};
 	const closeCommandDelayMs = ${JSON.stringify(options.closeCommandDelayMs ?? 0)};
 	const number = ${options.number};
 	const commentStatePath = join(__dirname, "..", "comment-state-" + number + ".json");
@@ -848,6 +850,7 @@ export function promotionGhMock(options: {
 } else if (args[0] === "api" && new RegExp("/pulls/" + number + "/(files|commits)(?:\\\\?|$)").test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "pr" && args[1] === "close" && args[2] === String(number)) {
+  if (closeCommandLogPath) appendFileSync(closeCommandLogPath, args.join(" ") + "\\n");
   if (closeCommandDelayMs > 0) setTimeout(() => console.log(""), closeCommandDelayMs);
   else console.log("");
 	} else if (args[0] === "issue" && args[1] === "edit") {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1317,13 +1317,19 @@ test("apply workflow rejects malformed or oversized coverage proof artifact tree
 
 test("apply workflow target token can inspect source workflow runs", () => {
   const workflow = readText(".github/workflows/sweep.yml");
+  const action = readText(".github/actions/create-target-write-token/action.yml");
   const applyJob = workflow.slice(workflow.indexOf("\n  apply-existing:"));
   const tokenStart = applyJob.indexOf("- name: Create target write token");
   const stateTokenStart = applyJob.indexOf("- name: Create state token", tokenStart);
 
   assert.ok(tokenStart !== -1);
   assert.ok(stateTokenStart > tokenStart);
-  assert.match(applyJob.slice(tokenStart, stateTokenStart), /permission-actions: read/);
+  assert.match(
+    applyJob.slice(tokenStart, stateTokenStart),
+    /uses: \.\/\.github\/actions\/create-target-write-token/,
+  );
+  assert.match(action, /permission-actions: read/);
+  assert.match(action, /minted-at-ms:[\s\S]*steps\.minted-at\.outputs\.milliseconds/);
 });
 
 test("targeted apply dispatches keep apply names ahead of exact-review names", () => {
@@ -1388,10 +1394,17 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /Capping apply checkpoint size at 20/);
   assert.match(applyStep, /base_close_processed_limit=300/);
   assert.match(applyHelper, /coverage_proof_limit=2/);
+  assert.match(applyHelper, /apply_token_budget_ms=3300000/);
   assert.match(applyHelper, /max_runtime_arg=\(--max-runtime-ms 600000\)/);
   assert.match(applyHelper, /max_close_processed_limit=900/);
   assert.match(applyStep, /close_processed_limit="\$base_close_processed_limit"/);
   assert.match(applyStep, /source scripts\/apply-workflow-helpers\.sh/);
+  assert.match(applyStep, /timeout-minutes: 70/);
+  assert.match(
+    applyStep,
+    /CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS: \$\{\{ steps\.target-write-token\.outputs\.minted-at-ms \}\}/,
+  );
+  assert.match(applyStep, /initialize_apply_token_budget/);
   assert.match(applyStep, /select_adaptive_apply_batch/);
   assert.match(applyHelper, /adaptive-apply-batch-size/);
   assert.match(applyHelper, /--status-path "results\/sweep-status\/\$\{target_slug\}\.json"/);
@@ -1505,7 +1518,9 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
   assert.match(applyStep, /true\|1\|yes\|on\) product_direction_enabled=true/);
   assert.match(applyStep, /if \[ "\$result_count" -ge "\$close_processed_limit" \]; then/);
   assert.match(applyHelper, /--action skipped_runtime_budget/);
-  assert.match(applyStep, /if automatic_apply_runtime_reached/);
+  assert.match(applyStep, /if apply_checkpoint_runtime_reached/);
+  assert.match(applyStep, /report_apply_token_budget_stop .*"\$result_count"/);
+  assert.match(applyStep, /apply_checkpoint_runtime_reached .*"\$result_count"/);
   assert.match(applyHelper, /runtime budget before cursor progress/);
   assert.match(applyHelper, /fresh-token continuation will resume the lane/);
   assert.doesNotMatch(
@@ -1576,7 +1591,7 @@ test("apply workflow finalization retries only target status after checkpointed 
   assert.ok(cursorPath > closePaths);
   assert.ok(closeCheckpoint > cursorPath);
   for (const laterBranch of [
-    'if automatic_apply_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json"',
+    'if apply_checkpoint_runtime_reached ".artifacts/apply-reports/apply-report-$checkpoint.json"',
     'if [ "$result_count" -ge "$close_processed_limit" ]; then',
     'if [ "$result_count" -eq 0 ]; then',
     'if [ "$closed_in_chunk" -eq 0 ]; then',
@@ -1650,6 +1665,53 @@ test("apply workflow does not queue runtime-yield continuation without cursor pr
         .filter((line) => line.includes("|")),
       ["yielded|false", "yielded|true"],
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply checkpoint publishes a clean token-budget stop and a later run resumes", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const stoppedReport = join(root, "stopped.json");
+  const resumedReport = join(root, "resumed.json");
+  writeFileSync(
+    stoppedReport,
+    JSON.stringify([
+      {
+        number: 0,
+        action: "skipped_runtime_budget",
+        reason: "apply token budget reached at 4300000ms since epoch",
+      },
+    ]),
+  );
+  writeFileSync(resumedReport, JSON.stringify([{ number: 42, action: "closed" }]));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "source scripts/apply-workflow-helpers.sh",
+          "CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS=1000000",
+          "initialize_apply_token_budget",
+          'printf "deadline=%s\\n" "$CLAWSWEEPER_APPLY_TOKEN_DEADLINE_MS"',
+          'if apply_token_budget_reached "$STOPPED_REPORT"; then apply_token_budget_stop_summary 7 12; fi',
+          'if apply_token_budget_reached "$RESUMED_REPORT"; then echo stopped-again; else echo resumed; fi',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, STOPPED_REPORT: stoppedReport, RESUMED_REPORT: resumedReport },
+      },
+    );
+    assert.match(output, /deadline=4300000/);
+    assert.match(
+      output,
+      /apply stopped at token budget: processed=7 remaining=~12; next run continues/,
+    );
+    assert.match(output, /resumed/);
+    assert.doesNotMatch(output, /stopped-again/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Run 29881371231 closed 61+ items over an hour of backlog drain, then died on GitHub App token expiry (1h lifetime) mid-step — the checkpoint apply allows 360 min. Fix: the target-write token mint exports its mint time; every apply path honors an absolute 55-minute deadline from mint, finishes the current chunk, publishes its checkpoint, and exits 0 with a stop summary ("apply stopped at token budget ... next run continues") — the scheduled cadence resumes the drain. Workflow step backstop reduced to 70 min.

Validation: 69 workflow tests + 10 runtime tests green; build/lint/format/actionlint green; commit-mode autoreview clean (0.90).
