### PR TITLE
feat(publication): advance batch grant to 32 (#738)

### DIFF
--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -56,10 +56,11 @@ EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = "60000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = "45000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "300"
-# The first size-8 batch selected two events for one durable item and failed its
-# single-commit gate. Hold at the last safe size while claim deduplication deploys.
+# Size-8 initially failed when one durable item claimed two events in a batch;
+# #772's in-batch serialization fixed that class, so the grant advances to the
+# batch-32 rollout target (workflow ask raised in #773).
 EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED = "1"
-EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "4"
+EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "32"
 EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"
 EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS = "30000"
 EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS = "600000"

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -126,7 +126,7 @@ test("the rollout returns to the last safe batch size during item deduplication"
   const workflow = readFileSync(join(workflowDirectory, "exact-review-batch-publish.yml"), "utf8");
   const worker = readFileSync("dashboard/wrangler.toml", "utf8");
   assert.match(workflow, /EXACT_REVIEW_BATCH_MAX_ITEMS: "4"/);
-  assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "4"/);
+  assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "32"/);
   assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"/);
 });
 


### PR DESCRIPTION
Completes the batch throughput pair with #773 (workflow ask 32): the DO-side grant advances 4 -> 32. The hold comment's condition — "while claim deduplication deploys" — is satisfied: #772's in-batch serialization of duplicate publication items is on main and deployed. Publication pending was ~2.5k during the transition; at 32/batch the drain rate rises ~8x.

Validation: batch/state-writer suites green (pin updated); build/lint/format green; autoreview clean (0.91). Coordination context: #738 comments.
