### PR TITLE
Bound state publication batches at eight

### DIFF
--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -56,11 +56,11 @@ EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = "60000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = "45000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "300"
-# Size-8 initially failed when one durable item claimed two events in a batch;
-# #772's in-batch serialization fixed that class, so the grant advances to the
-# batch-32 rollout target (workflow ask raised in #773).
+# Keep 32 as the owner-homogeneous candidate scan width. Sequential preparation
+# made the first production size-32 ask claim 30 members, so the hard mutation
+# lease remains at the proven size-8 checkpoint.
 EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED = "1"
-EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "32"
+EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"
 EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"
 EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS = "30000"
 EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS = "600000"

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -122,11 +122,11 @@ test("state compaction remains an explicitly separate main-branch writer", () =>
   assert.doesNotMatch(source, /\.github\/actions\/setup-state/);
 });
 
-test("the rollout asks for and grants batches of 32 after item deduplication", () => {
+test("the rollout scans 32 candidates while bounding mutation leases at eight", () => {
   const workflow = readFileSync(join(workflowDirectory, "exact-review-batch-publish.yml"), "utf8");
   const worker = readFileSync("dashboard/wrangler.toml", "utf8");
   assert.match(workflow, /EXACT_REVIEW_BATCH_MAX_ITEMS: "32"/);
-  assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "32"/);
+  assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"/);
   assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"/);
 });
 


### PR DESCRIPTION
## Summary

- retain the 32-item owner-homogeneous candidate scan
- roll the hard mutation/lease cap back to 8 after the first production 32 ask claimed only 30 members under sequential preparation
- preserve the active larger lease through the durable configured-cap protocol from #779; no running workflow is cancelled

## Focused validation

- `node --test test/state-writer-workflow.test.ts test/exact-review-publication-batches.test.ts` (34 passed)
- autoreview: clean, no accepted/actionable findings
