### PR TITLE
Roll state publication lease cap back to eight

### DIFF
--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -56,10 +56,10 @@ EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = "60000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = "45000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "300"
-# Bounded four-worker preparation keeps the size-32 lease inside the operational
-# runtime target while preserving one deterministic final state commit.
+# Keep bounded four-worker preparation, but return the live mutation lease to 8:
+# the first size-32 run exceeded the 15-minute operational target during prepare.
 EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED = "1"
-EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "32"
+EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"
 EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"
 EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS = "30000"
 EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS = "600000"

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -123,11 +123,11 @@ test("state compaction remains an explicitly separate main-branch writer", () =>
   assert.doesNotMatch(source, /\.github\/actions\/setup-state/);
 });
 
-test("the rollout scans 50 and grants 32 with bounded parallel preparation", () => {
+test("the rollback scans 50 and grants 8 with bounded parallel preparation", () => {
   const workflow = readFileSync(join(workflowDirectory, "exact-review-batch-publish.yml"), "utf8");
   const worker = readFileSync("dashboard/wrangler.toml", "utf8");
   assert.match(workflow, /EXACT_REVIEW_BATCH_MAX_ITEMS: "50"/);
-  assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "32"/);
+  assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"/);
   assert.match(worker, /EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"/);
 });
 


### PR DESCRIPTION
## Reason

The first production run at cap 32, [29903573048](https://github.com/openclaw/clawsweeper/actions/runs/29903573048), exceeded the documented 15-minute operational target while still in parallel preparation. Per the rollout gate, return the effective lease cap to the proven size 8 without cancelling the active fenced batch.

## Scope

- set only the live dashboard lease cap back to 8
- retain four-worker parallel preparation, the 50-candidate scan, and the bounded 32-item primitive
- no workflow pause, DLQ action, or live apply/close

## Focused validation

- `node --test test/state-writer-workflow.test.ts`
- focused `oxlint --deny-warnings`
