### PR TITLE
fix(materializer): break timeout deadlock — 60m window, 5m lease budget

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -20,10 +20,14 @@ jobs:
   materialize:
     name: Drain queued state into one commit
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     env:
-      CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
+      # Priority intent wins a slot quickly; a long acquire budget just lets one
+      # contended wait eat the whole run (observed: six consecutive 20-min
+      # timeout-cancels while the append window grew to ~25k rows).
+      CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "300000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
+      CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS: "2400000"
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Six consecutive materializer runs were cancelled at exactly the 20-min job timeout while the state-append window grew to ~25k rows: the 900s lease-acquire budget let one contended wait consume the window, the run died mid-publish, nothing acked, rows re-exposed — a timeout deadlock on the single writer. Changes: job timeout 20→60m, lease acquire budget 900s→300s (priority intent wins slots quickly since #737), internal runtime budget 40m. Validation: workflow tests 6/6, yaml/format green, autoreview clean (0.91). Context: #738.