### PR TITLE
test(worker): expect superseded_publications in enqueue responses

### DIFF
--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4760,6 +4760,7 @@ test("authenticated legacy exact-review intake enters the durable queue", async 
     ok: true,
     queued: true,
     item_key: "openclaw/gogcli#597",
+    superseded_publications: 0,
   });
   const stored = (await storage.get("exact-review-queue")) as {
     items: Record<string, { decision: Record<string, unknown> }>;
@@ -11024,6 +11025,7 @@ test("hosted webhook enqueues item events with the repository default branch", a
     ok: true,
     queued: true,
     item_key: "openclaw/gogcli#597",
+    superseded_publications: 0,
   });
 });
 
@@ -11080,6 +11082,7 @@ test("hosted webhook requeues unlocked and close-guard removal events", async ()
       ok: true,
       queued: true,
       item_key: `openclaw/gogcli#${number}`,
+      superseded_publications: 0,
     });
     const stored = (await storage.get("exact-review-queue")) as {
       items: Record<string, { decision: { sourceAction: string; supersedesInProgress: boolean } }>;


### PR DESCRIPTION
Main went red at 10:12Z: fb04ccdd01 (publication coalescing, pushed directly to main and already deployed) added superseded_publications to enqueue responses and updated the batch tests but missed three strict deepEquals in test/dashboard-worker.test.ts. Fix-forward aligning the three expectations; full file 163/163 locally. Unblocks CI for all open PRs (incl. #785 materializer deadlock fix).