### PR TITLE
fix(publication): recover durable review batches

### DIFF
--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -55,9 +55,33 @@ export async function createIsolatedStateClone({ stateRoot, destination, baselin
   await runChecked("git", ["-C", destination, "remote", "set-url", "origin", remoteUrl], {
     timeoutMs,
   });
+  const config = await capture("git", ["-C", stateRoot, "config", "--local", "--null", "--list"]);
+  for (const entry of workerGitConfigEntries(config)) {
+    await runChecked(
+      "git",
+      ["-C", destination, "config", "--local", "--add", entry.key, entry.value],
+      {
+        timeoutMs,
+      },
+    );
+  }
   await runChecked("git", ["-C", destination, "checkout", "--detach", baselineSha], {
     timeoutMs,
   });
+}
+
+function workerGitConfigEntries(config) {
+  const allowed =
+    /^(?:http\..*\.extraheader|credential\..*|core\.sshcommand|user\.(?:name|email))$/i;
+  return config
+    .split("\0")
+    .filter(Boolean)
+    .flatMap((entry) => {
+      const separator = entry.indexOf("\n");
+      if (separator < 1) return [];
+      const key = entry.slice(0, separator);
+      return allowed.test(key) ? [{ key, value: entry.slice(separator + 1) }] : [];
+    });
 }
 
 async function controller() {
@@ -179,7 +203,7 @@ async function controller() {
   if (telemetry.heartbeatFailed || cleanupFailures > 0) process.exitCode = 1;
 }
 
-async function worker(itemPath, root, stateWorktree, workspace) {
+async function worker(itemPath, root, stateClone, workspace) {
   const item = JSON.parse(readFileSync(itemPath, "utf8"));
   const decision = item.decision;
   const publication = decision.publication;
@@ -258,7 +282,7 @@ async function worker(itemPath, root, stateWorktree, workspace) {
     cwd: workspace,
     env: {
       ...process.env,
-      CLAWSWEEPER_STATE_DIR: stateWorktree,
+      CLAWSWEEPER_STATE_DIR: stateClone,
       EXACT_REVIEW_WORK_ROOT: root,
       TARGET_REPO: targetRepo,
       ITEM_NUMBER: itemNumber,

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -46,6 +46,20 @@ export async function runBoundedPool(items, concurrency, worker) {
   return { results, peak };
 }
 
+export async function createIsolatedStateClone({ stateRoot, destination, baselineSha, timeoutMs }) {
+  const remoteUrl = (await capture("git", ["-C", stateRoot, "remote", "get-url", "origin"])).trim();
+  if (!remoteUrl) throw new Error("state origin URL is required");
+  await runChecked("git", ["clone", "--shared", "--no-checkout", stateRoot, destination], {
+    timeoutMs,
+  });
+  await runChecked("git", ["-C", destination, "remote", "set-url", "origin", remoteUrl], {
+    timeoutMs,
+  });
+  await runChecked("git", ["-C", destination, "checkout", "--detach", baselineSha], {
+    timeoutMs,
+  });
+}
+
 async function controller() {
   const startedAt = Date.now();
   const workspace = resolve(process.env.GITHUB_WORKSPACE || process.cwd());
@@ -76,21 +90,11 @@ async function controller() {
       ".artifacts/exact-review-batch/heartbeat-failed",
   );
   rmSync(workersRoot, { recursive: true, force: true });
-  await runChecked("git", ["-C", stateRoot, "worktree", "prune"], {
-    timeoutMs: remainingTimeout(deadline),
-  });
   mkdirSync(workersRoot, { recursive: true });
-  let gitQueue = Promise.resolve();
   let cleanupFailures = 0;
   const durations = [];
   let timeouts = 0;
   let admitted = 0;
-
-  const withGitQueue = (operation) => {
-    const pending = gitQueue.then(operation, operation);
-    gitQueue = pending.catch(() => undefined);
-    return pending;
-  };
 
   const { peak } = await runBoundedPool(items, concurrency, async (item, index) => {
     const outcomePath = checkedOutcomePath(workspace, item.outcomePath);
@@ -104,25 +108,22 @@ async function controller() {
       .digest("hex")
       .slice(0, 16);
     const root = join(workersRoot, `${String(index).padStart(2, "0")}-${identity}`);
-    const stateWorktree = join(root, "state");
+    const stateClone = join(root, "state");
     const itemPath = join(root, "item.json");
     mkdirSync(root, { recursive: true });
     writeFileSync(itemPath, `${JSON.stringify(item)}\n`, "utf8");
     const workerStartedAt = Date.now();
     let timedOut = false;
-    let worktreeAdded = false;
     try {
-      await withGitQueue(() =>
-        runChecked(
-          "git",
-          ["-C", stateRoot, "worktree", "add", "--detach", stateWorktree, baselineSha],
-          { timeoutMs: remainingTimeout(deadline) },
-        ),
-      );
-      worktreeAdded = true;
+      await createIsolatedStateClone({
+        stateRoot,
+        destination: stateClone,
+        baselineSha,
+        timeoutMs: remainingTimeout(deadline),
+      });
       const status = await run(
         process.execPath,
-        [process.argv[1], "worker", itemPath, root, stateWorktree, workspace],
+        [process.argv[1], "worker", itemPath, root, stateClone, workspace],
         { timeoutMs: Math.min(itemTimeoutMs, remainingTimeout(deadline)) },
       );
       timedOut = status.timedOut;
@@ -136,18 +137,11 @@ async function controller() {
       }
     } finally {
       durations.push(Date.now() - workerStartedAt);
-      if (worktreeAdded) {
-        try {
-          await withGitQueue(() =>
-            runChecked("git", ["-C", stateRoot, "worktree", "remove", "--force", stateWorktree], {
-              timeoutMs: remainingTimeout(deadline),
-            }),
-          );
-        } catch {
-          cleanupFailures += 1;
-        }
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        cleanupFailures += 1;
       }
-      rmSync(root, { recursive: true, force: true });
     }
     return { kind: timedOut ? "timeout" : "complete", durationMs: Date.now() - workerStartedAt };
   });

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -2199,12 +2199,19 @@ function pushPublishedCommit(
       console.log(
         "State publish renewed its owner lease without the branch; recovering the lost state race",
       );
+      if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
+        return pushStateAndReceiptAfterCommitRefsFailure(source, remote, branch, receiptRef, lease);
+      }
       return pushed;
     }
     if (currentLeaseOid !== lease.oid) {
       throw new StatePublishContentionError(
         "State publish lease ownership changed before branch publication",
       );
+    }
+    if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
+      renewStatePublishLease(lease, "before commit_refs recovery");
+      return pushStateAndReceiptAfterCommitRefsFailure(source, remote, branch, receiptRef, lease);
     }
     return pushed;
   }
@@ -2213,6 +2220,54 @@ function pushPublishedCommit(
   lease.expiresAtMs = Date.now() + lease.ttlMs;
   console.log(`Renewed state publish lease owner=${lease.owner} with atomic branch update`);
   return pushed;
+}
+
+function isCommitRefsTransactionFailure(result: GitRunResult): boolean {
+  return /fatal error in commit_refs/i.test(`${result.stderr}\n${result.stdout}`);
+}
+
+function pushStateAndReceiptAfterCommitRefsFailure(
+  source: string,
+  remote: string,
+  branch: string,
+  receiptRef: string,
+  lease: StatePublishLease,
+): GitRunResult {
+  lease.coordinator?.assertActive();
+  const sourceCommit = runGit(["rev-parse", source], { quiet: true }).trim();
+  const remoteBranchOid = remoteRefOid(remote, `refs/heads/${branch}`);
+  const remoteReceiptOid = remoteRefOid(remote, receiptRef);
+  if (remoteReceiptOid && remoteReceiptOid !== sourceCommit) {
+    throw new StatePublishContentionError(
+      `State batch receipt ${receiptRef} changed before commit_refs recovery`,
+    );
+  }
+  if (remoteBranchOid === sourceCommit && remoteReceiptOid === sourceCommit) {
+    return { status: 0, stdout: "", stderr: "", timedOut: false };
+  }
+  if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
+    renewStatePublishLease(lease, "before commit_refs recovery push");
+  }
+  lease.coordinator?.assertActive();
+
+  console.log(
+    "State publish retrying GitHub commit_refs failure with the lease held and an atomic state/receipt update",
+  );
+  const recovered = spawnGit(
+    [
+      "push",
+      "--atomic",
+      `--force-with-lease=${receiptRef}:${remoteReceiptOid ?? ""}`,
+      remote,
+      `${source}:${branch}`,
+      `${source}:${receiptRef}`,
+    ],
+    { allowFailure: true },
+  );
+  if (recovered.status === 0) {
+    console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+  }
+  return recovered;
 }
 
 export function pushStateCommitUnderLease(

--- a/src/repair/state-writer-telemetry-recorder.ts
+++ b/src/repair/state-writer-telemetry-recorder.ts
@@ -133,13 +133,13 @@ export class StateWriterTelemetryRecorder {
     if (this.acquired && this.holdMs === null) {
       this.holdMs = Math.max(0, finishedAtMs - (this.holdStartedAtMs ?? finishedAtMs));
     }
-    this.outcome = outcome;
-    this.emit("finished");
     const safeOutcome =
       (!this.acquired && outcome !== "contention_timeout" && outcome !== "failed") ||
       (this.acquired && outcome === "contention_timeout")
         ? "failed"
         : outcome;
+    this.outcome = safeOutcome;
+    this.emit("finished");
     const candidate = {
       schema_version: STATE_WRITER_SCHEMA_VERSION,
       operation_id: this.operationId,

--- a/src/repair/state-writer-telemetry-recorder.ts
+++ b/src/repair/state-writer-telemetry-recorder.ts
@@ -136,7 +136,8 @@ export class StateWriterTelemetryRecorder {
     this.outcome = outcome;
     this.emit("finished");
     const safeOutcome =
-      !this.acquired && outcome !== "contention_timeout" && outcome !== "failed"
+      (!this.acquired && outcome !== "contention_timeout" && outcome !== "failed") ||
+      (this.acquired && outcome === "contention_timeout")
         ? "failed"
         : outcome;
     const candidate = {

--- a/test/repair/exact-review-batch-prepare.test.mjs
+++ b/test/repair/exact-review-batch-prepare.test.mjs
@@ -72,6 +72,15 @@ test("parallel preparers use independent shallow state repositories", async (t) 
   git(source, "push", "origin", "state");
   const remoteUrl = `file://${origin}`;
   git(root, "clone", "--depth", "1", "--branch", "state", remoteUrl, stateRoot);
+  git(stateRoot, "config", "--local", "user.name", "State Publisher");
+  git(stateRoot, "config", "--local", "user.email", "state-publisher@example.com");
+  git(
+    stateRoot,
+    "config",
+    "--local",
+    "http.https://github.invalid/.extraheader",
+    "AUTHORIZATION: basic fixture",
+  );
   const baselineSha = git(stateRoot, "rev-parse", "HEAD");
   const left = join(root, "left");
   const right = join(root, "right");
@@ -93,6 +102,12 @@ test("parallel preparers use independent shallow state repositories", async (t) 
 
   assert.equal(git(left, "remote", "get-url", "origin"), remoteUrl);
   assert.equal(git(right, "remote", "get-url", "origin"), remoteUrl);
+  assert.equal(git(left, "config", "--local", "user.name"), "State Publisher");
+  assert.equal(git(right, "config", "--local", "user.email"), "state-publisher@example.com");
+  assert.equal(
+    git(left, "config", "--local", "http.https://github.invalid/.extraheader"),
+    "AUTHORIZATION: basic fixture",
+  );
   assert.equal(git(left, "rev-parse", "HEAD"), baselineSha);
   assert.equal(git(right, "rev-parse", "HEAD"), baselineSha);
   assert.equal(git(left, "rev-parse", "--is-shallow-repository"), "true");

--- a/test/repair/exact-review-batch-prepare.test.mjs
+++ b/test/repair/exact-review-batch-prepare.test.mjs
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
-import { run, runBoundedPool } from "../../scripts/prepare-exact-review-batch.mjs";
+import {
+  createIsolatedStateClone,
+  run,
+  runBoundedPool,
+} from "../../scripts/prepare-exact-review-batch.mjs";
 
 test("bounded preparation never exceeds four workers and preserves manifest order", async () => {
   const completionOrder = [];
@@ -46,3 +54,75 @@ test("a process timeout terminates the full worker process group", async () => {
   assert.equal(result.timedOut, true);
   assert.ok(Date.now() - startedAt < 1_000);
 });
+
+test("parallel preparers use independent shallow state repositories", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-exact-review-state-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const origin = join(root, "origin.git");
+  const source = join(root, "source");
+  const stateRoot = join(root, "state");
+  git(root, "init", "--bare", origin);
+  git(root, "clone", origin, source);
+  git(source, "config", "user.name", "ClawSweeper Test");
+  git(source, "config", "user.email", "clawsweeper@example.com");
+  writeFileSync(join(source, "record.md"), "record\n");
+  git(source, "add", "record.md");
+  git(source, "commit", "-m", "seed state");
+  git(source, "branch", "-M", "state");
+  git(source, "push", "origin", "state");
+  const remoteUrl = `file://${origin}`;
+  git(root, "clone", "--depth", "1", "--branch", "state", remoteUrl, stateRoot);
+  const baselineSha = git(stateRoot, "rev-parse", "HEAD");
+  const left = join(root, "left");
+  const right = join(root, "right");
+
+  await Promise.all([
+    createIsolatedStateClone({
+      stateRoot,
+      destination: left,
+      baselineSha,
+      timeoutMs: 5_000,
+    }),
+    createIsolatedStateClone({
+      stateRoot,
+      destination: right,
+      baselineSha,
+      timeoutMs: 5_000,
+    }),
+  ]);
+
+  assert.equal(git(left, "remote", "get-url", "origin"), remoteUrl);
+  assert.equal(git(right, "remote", "get-url", "origin"), remoteUrl);
+  assert.equal(git(left, "rev-parse", "HEAD"), baselineSha);
+  assert.equal(git(right, "rev-parse", "HEAD"), baselineSha);
+  assert.equal(git(left, "rev-parse", "--is-shallow-repository"), "true");
+  assert.equal(git(right, "rev-parse", "--is-shallow-repository"), "true");
+  const leftGitDir = git(left, "rev-parse", "--absolute-git-dir");
+  const rightGitDir = git(right, "rev-parse", "--absolute-git-dir");
+  assert.notEqual(leftGitDir, rightGitDir);
+  assert.notEqual(join(leftGitDir, "shallow"), join(rightGitDir, "shallow"));
+
+  writeFileSync(join(source, "record.md"), "updated\n");
+  git(source, "commit", "-am", "update state");
+  git(source, "push", "origin", "state");
+  const updatedSha = git(source, "rev-parse", "HEAD");
+  const fetches = await Promise.all([
+    run("git", ["-C", left, "fetch", "--depth=1", "origin", "state"]),
+    run("git", ["-C", right, "fetch", "--depth=1", "origin", "state"]),
+  ]);
+  assert.deepEqual(
+    fetches.map(({ code }) => code),
+    [0, 0],
+  );
+  git(left, "reset", "--hard", "FETCH_HEAD");
+  git(right, "reset", "--hard", "FETCH_HEAD");
+  assert.equal(git(left, "rev-parse", "HEAD"), updatedSha);
+  assert.equal(git(right, "rev-parse", "HEAD"), updatedSha);
+});
+
+function git(cwd, ...args) {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -72,8 +72,9 @@ test("batch workflow uses owner-scoped mutation credentials and isolated state c
   assert.match(source, /uses: \.\/\.github\/actions\/create-state-token/);
   assert.match(source, /uses: \.\/\.github\/actions\/setup-state/);
   assert.doesNotMatch(source, /permissions:\n(?:.*\n)*?\s+issues: write/);
-  assert.match(prepareSource, /"worktree",[\s\S]*?"add",[\s\S]*?"--detach"/);
-  assert.match(prepareSource, /CLAWSWEEPER_STATE_DIR: stateWorktree/);
+  assert.match(prepareSource, /"clone",[\s\S]*?"--shared",[\s\S]*?"--no-checkout"/);
+  assert.match(prepareSource, /http\\\.\.\*\\\.extraheader/);
+  assert.match(prepareSource, /CLAWSWEEPER_STATE_DIR: stateClone/);
   assert.match(prepareSource, /EXACT_REVIEW_WORK_ROOT: root/);
 });
 

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -117,6 +117,32 @@ test("filesystem-path remotes publish without constructing an invalid tracking r
   );
 });
 
+test("GitHub three-ref commit_refs rejection falls back to an atomic state and receipt push", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 25);
+  installThreeRefCommitRefsFailure(fixture.origin);
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId: "github-commit-refs-fallback",
+      plans: [plan],
+    }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/25.md"),
+    "item 25\n",
+  );
+  const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
+    .update("github-commit-refs-fallback")
+    .digest("hex")}`;
+  assert.equal(
+    git(fixture.origin, "rev-parse", "state").trim(),
+    git(fixture.origin, "rev-parse", receiptRef).trim(),
+  );
+});
+
 test("mutation plans reject oversized individual and aggregate path metadata", () => {
   const fixture = createRepositoryFixture();
   assert.throws(
@@ -577,6 +603,27 @@ function publishSibling(fixture: RepositoryFixture, file: string, content: strin
   git(sibling, "add", ".");
   git(sibling, "commit", "-m", "ordinary sibling update");
   git(sibling, "push", "origin", "HEAD:state");
+}
+
+function installThreeRefCommitRefsFailure(origin: string): void {
+  const hook = path.join(origin, "hooks", "pre-receive");
+  fs.writeFileSync(
+    hook,
+    [
+      "#!/bin/sh",
+      "count=0",
+      "while read -r old_oid new_oid ref_name; do",
+      "  count=$((count + 1))",
+      "done",
+      'if [ "$count" -ge 3 ]; then',
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(hook, 0o755);
 }
 
 function configureUser(root: string): void {

--- a/test/repair/state-writer-telemetry-recorder.test.ts
+++ b/test/repair/state-writer-telemetry-recorder.test.ts
@@ -57,6 +57,28 @@ test("state writer recorder isolates progress observer failures", () => {
   assert.equal(recorder.toTerminalObject()?.acquired, false);
 });
 
+test("an acquired batch writer reports a push failure without losing its batch identity", () => {
+  const recorder = new StateWriterTelemetryRecorder({
+    mode: "batch",
+    operationId: "batch:exact-review-batch:123",
+    configuredBatchSize: 8,
+    actualBatchSize: 8,
+    batchWaitMs: 500,
+  });
+
+  recorder.enteredWaiting();
+  recorder.recordAcquireAttempt();
+  recorder.acquiredLease();
+  recorder.enteredReleasing();
+  recorder.releasedLease(true);
+  const terminal = recorder.finalize("contention_timeout");
+
+  assert.equal(terminal.mode, "batch");
+  assert.equal(terminal.operation_id, "batch:exact-review-batch:123");
+  assert.equal(terminal.outcome, "failed");
+  assert.equal(terminal.acquired, true);
+});
+
 test("state writer recorder refreshes waiting progress during long acquisition", () => {
   let now = 1_000;
   const phases: Array<{ phase: string; at: number }> = [];


### PR DESCRIPTION
## Summary

- recover GitHub's exact `fatal error in commit_refs` rejection by renewing the fenced state lease and atomically publishing the state branch plus durable batch receipt
- preserve acquired batch-writer identity when a push fails so cleanup reports the real batch outcome
- isolate parallel exact-review preparation in lightweight state clones so shallow Git locks are not shared across workers
- retain the state checkout's authentication and author configuration in each isolated worker clone

This unblocks durable review publication for [openclaw/openclaw#112547](https://github.com/openclaw/openclaw/pull/112547) without changing that PR's head.

## Safety

- fallback is limited to GitHub's exact `commit_refs` failure
- lease ownership and freshness are rechecked immediately before the recovery push
- ordinary push races and ownership changes remain fail-closed
- parallel workers share immutable objects only; refs, `FETCH_HEAD`, and shallow metadata are independent

## Validation

- `pnpm run build:repair`
- focused publication, telemetry, workflow, and shallow-clone tests passed
- deterministic red-before/green-after coverage for the three-ref rejection, batch telemetry identity, and concurrent shallow fetch isolation
- structured autoreview clean after resolving both actionable findings
- exact-head hosted Linux `pnpm check` passed on `0b47a0ee37c061f896d5feb9cab39538b014fab6`
- exact-head CodeQL, sparse build, Windows launcher, crawl-remote integration, and production automerge flow passed

Local macOS `pnpm check` retains platform/baseline-only failures in Linux containment and unrelated filesystem-sensitive tests; the repository's hosted Linux check is green and authoritative for the full gate.
