### PR TITLE
fix(queue): drain lease must outlive a full publish (90m)

### DIFF
--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -58,6 +58,9 @@ EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "300"
 # Keep bounded four-worker preparation, but return the live mutation lease to 8:
 # the first size-32 run exceeded the 15-minute operational target during prepare.
+# A full-window publish moves ~2k paths and observed ~40 min; the drain lease
+# must outlive it or the ack lands after expiry and the cycle makes no progress.
+STATE_APPEND_DRAIN_LEASE_MS = "5400000"
 EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED = "1"
 EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"
 EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS = "60000"


### PR DESCRIPTION
Materializer run 29913644079 succeeded but made ZERO progress: it drained 2000 rows, published 1974 paths over ~40 minutes, then acked past the 30-minute drain lease — `state ack count 0 was below drained count 2000` — so every row re-drains next cycle. Six earlier cancelled runs hold un-acked leases too, which is why only 2000 of ~25k rows were even available.

Raises STATE_APPEND_DRAIN_LEASE_MS to 90 min so a full-window publish finishes inside its lease and acks land. Follow-up (separate): publish of ~2k paths taking 40 min is the deeper throughput ceiling.