### PR TITLE
fix(publication): set batch commit identity

### DIFF
--- a/src/repair/state-publication-batch.ts
+++ b/src/repair/state-publication-batch.ts
@@ -19,6 +19,7 @@ import {
   type PreparedStateMutationOperation,
   type PreparedStateMutationPlan,
 } from "./state-publication-mutation.js";
+import { clawsweeperGitIdentityEnv } from "./process-env.js";
 
 export const STATE_PUBLICATION_BATCH_MAX_ITEMS = 32;
 // Reuse the validated exact-review envelope per item while keeping aggregate
@@ -159,6 +160,7 @@ function commitUnderLease(options: {
   // marker commit lets a later ambiguous retry prove which payload this id owns.
   const tree = pending.length === 0 ? remoteTree : applyOperationsToTree(remoteTree, pending);
   const commitSha = runGit(["commit-tree", tree, "-p", remoteCommit], {
+    env: { ...process.env, ...clawsweeperGitIdentityEnv() },
     input: batchCommitMessage(options),
     quiet: true,
   }).trim();

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -117,6 +117,44 @@ test("filesystem-path remotes publish without constructing an invalid tracking r
   );
 });
 
+test("batch commits use the ClawSweeper identity without repository or global Git config", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 24);
+  git(fixture.work, "config", "--unset-all", "user.name");
+  git(fixture.work, "config", "--unset-all", "user.email");
+
+  const result = withProcessEnv(
+    {
+      CLAWSWEEPER_GIT_USER_NAME: "",
+      CLAWSWEEPER_GIT_USER_EMAIL: "",
+      GIT_AUTHOR_NAME: "",
+      GIT_AUTHOR_EMAIL: "",
+      GIT_COMMITTER_NAME: "",
+      GIT_COMMITTER_EMAIL: "",
+      GIT_CONFIG_GLOBAL: os.devNull,
+      GIT_CONFIG_SYSTEM: os.devNull,
+    },
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "explicit-git-identity",
+          plans: [plan],
+        }),
+      ),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(
+    git(fixture.origin, "log", "-1", "--format=%an%n%ae%n%cn%n%ce", "state").trim(),
+    [
+      "clawsweeper",
+      "274271284+clawsweeper[bot]@users.noreply.github.com",
+      "clawsweeper",
+      "274271284+clawsweeper[bot]@users.noreply.github.com",
+    ].join("\n"),
+  );
+});
+
 test("GitHub three-ref commit_refs rejection falls back to an atomic state and receipt push", () => {
   const fixture = createRepositoryFixture();
   const plan = newItemPlan(fixture, 25);
@@ -643,6 +681,23 @@ function withStateEnvironment<T>(work: string, operation: () => T): T {
     else process.env.CLAWSWEEPER_STATE_DIR = previousDir;
     if (previousBranch === undefined) delete process.env.CLAWSWEEPER_PUBLISH_BRANCH;
     else process.env.CLAWSWEEPER_PUBLISH_BRANCH = previousBranch;
+  }
+}
+
+function withProcessEnv<T>(values: Record<string, string | undefined>, operation: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return operation();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- supply ClawSweeper's explicit bot author/committer environment to batch `git commit-tree`
- add a regression that removes repository, global, system, and ambient Git identity
- verify the resulting state commit records the expected ClawSweeper bot identity

This fixes the exact finalization failure from publisher run https://github.com/openclaw/clawsweeper/actions/runs/29918706122 (`Author identity unknown`, `fatal: empty ident name`).

## Validation

- `node --test test/repair/state-publication-batch.test.ts` (21 passed)
- `./node_modules/.bin/tsc -p tsconfig.repair.json`
- targeted formatting and lint checks passed
- autoreview clean
- full `pnpm run check`: touched tests and all static/build/lint gates passed; current-main macOS/platform and unrelated fixture failures reproduced in unchanged files (`capset`, `/private/var` canonicalization, symlink identity, and sustained ledger-race fixture)

OpenClaw PR https://github.com/openclaw/openclaw/pull/112547 remains frozen until this lands and a fresh durable publisher run proves exact-head comment/label publication.
