### PR TITLE
feat(repair): model-guided git recovery with allowlisted actions

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
+      CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"
       # Priority intent wins a slot quickly; a long acquire budget just lets one
       # contended wait eat the whole run (observed: six consecutive 20-min
       # timeout-cancels while the append window grew to ~25k rows).
@@ -36,6 +37,9 @@ jobs:
           filter: blob:none
           fetch-depth: 1
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-action-ledger
+        continue-on-error: true
 
       - name: Create state token
         id: state-token
@@ -53,11 +57,64 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         with:
-          build-script: build:repair
+          build-script: build:all
+
+      - uses: ./.github/actions/setup-codex
+        continue-on-error: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+        with:
+          auth-mode: login
 
       - name: Materialize queued state
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: node dist/repair/state-materializer.js
+
+      - name: Finalize materializer recovery action ledger
+        if: ${{ always() }}
+        run: pnpm run --silent finalize-action-events
+
+      - name: Publish materializer recovery action events
+        if: ${{ always() }}
+        env:
+          CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "0"
+          CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT:-}" ]; then
+            echo "Materializer recovery action ledger is disabled."
+            exit 0
+          fi
+          source_root="$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT"
+          if [ ! -d "$source_root/ledger" ]; then
+            echo "No materializer recovery action events were finalized."
+            exit 0
+          fi
+          event_paths_file=".artifacts/materializer-recovery-action-ledger-paths.txt"
+          mkdir -p .artifacts
+          pnpm run --silent publish-action-events -- \
+            --source-root "$source_root" \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --expected-producer-job "$GITHUB_JOB" |
+            jq -r '.paths[]?' |
+            sort -u > "$event_paths_file"
+          if [ ! -s "$event_paths_file" ]; then
+            echo "Materializer recovery events existed but no paths were imported." >&2
+            exit 1
+          fi
+          while IFS= read -r event_path; do
+            durable_event_path="$CLAWSWEEPER_STATE_DIR/$event_path"
+            test -f "$durable_event_path"
+            mkdir -p "$(dirname "$event_path")"
+            cp "$durable_event_path" "$event_path"
+          done < "$event_paths_file"
+          node dist/clawsweeper.js publish-action-event-paths \
+            --paths-file "$event_paths_file" \
+            --message "chore: append materializer recovery action ledger"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4033,6 +4033,7 @@ jobs:
       issues: read
       pull-requests: read
     env:
+      CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"
       CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
@@ -4175,6 +4176,7 @@ jobs:
         if: ${{ steps.proof-select.outputs.item_numbers != '' }}
         timeout-minutes: 50
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_TOKEN: ${{ github.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -4254,6 +4256,7 @@ jobs:
   publish-apply-proof-action-ledger:
     name: Publish immutable apply proof action ledger
     env:
+      CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "0"
       CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
@@ -4342,6 +4345,7 @@ jobs:
       cancel-in-progress: false
       queue: max
     env:
+      CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"
       CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "900000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
@@ -4416,6 +4420,14 @@ jobs:
         with:
           build-script: build:all
 
+      - uses: ./.github/actions/setup-codex
+        continue-on-error: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CLAWSWEEPER_INTERNAL_MODEL: ${{ secrets.CLAWSWEEPER_MODEL }}
+        with:
+          auth-mode: login
+
       - uses: actions/download-artifact@v8
         continue-on-error: true
         with:
@@ -4431,6 +4443,7 @@ jobs:
 
       - name: Reconcile before apply preselect
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -4451,6 +4464,7 @@ jobs:
         id: apply-existing-run
         timeout-minutes: 70
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS: ${{ steps.target-write-token.outputs.minted-at-ms }}
@@ -4852,6 +4866,7 @@ jobs:
       - name: Retry final apply status publication
         if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' }}
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
@@ -4869,6 +4884,7 @@ jobs:
       - name: Publish apply action events
         if: ${{ always() }}
         env:
+          CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "0"
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |

--- a/schema/repair/recovery-advisor.schema.json
+++ b/schema/repair/recovery-advisor.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["diagnosis", "actions", "confidence"],
+  "properties": {
+    "diagnosis": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "string",
+        "pattern": "^(?:fetch_object [a-fA-F0-9]{40,64}|refetch_depth1|deepen [0-9]+|unshallow|rebuild_on_remote_head|reset_to_remote|retry_push|defer_to_next_run|give_up)$"
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    }
+  }
+}

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -42,6 +42,18 @@ import {
   stateWriterCoordinatorEnabled,
   type StateWriterCoordinatorGuard,
 } from "./state-writer-coordinator.js";
+import {
+  buildRecoveryFailureContext,
+  executeRecoveryActions,
+  modelRecoveryConfigured,
+  recordRecoveryOutcome,
+  requestRecoveryAdvice,
+  publicDiagnosisSummary,
+  type RecoveryActionHandlers,
+  type RecoveryActionName,
+  type RecoveryAdvice,
+  type RecoveryExecution,
+} from "./recovery-advisor.js";
 
 export type GitRunResult = {
   status: number;
@@ -597,6 +609,8 @@ function pushImmutableActionLedgerCommit(options: {
   const protectedWorktreePaths = captureDirtyWorktreePaths();
   let candidateCommit = options.sourceCommit;
   let unavailableObjectRecoveryUsed = false;
+  let modelPushRecoveryConsulted = false;
+  const modelPushAttemptHistory: string[] = [];
   const verifiedSourceObjectIds = new Set<string>();
   for (let attempt = 1; attempt <= pushBudget; attempt += 1) {
     const pushArgs = ["push", options.remote, `${candidateCommit}:${options.branch}`];
@@ -640,8 +654,43 @@ function pushImmutableActionLedgerCommit(options: {
       });
       return "committed";
     }
+    modelPushAttemptHistory.push(gitFailureSummary(pushResult));
+    let modelRequestedRebuild = false;
+    let modelRequestedRebuildAdvice: RecoveryAdvice | null = null;
+    if (!modelPushRecoveryConsulted) {
+      modelPushRecoveryConsulted = true;
+      const recovery = modelGuidedPushRecovery({
+        phase: "push_immutable_action_ledger",
+        failure: pushResult,
+        remote: options.remote,
+        branch: options.branch,
+        recentAttempts: modelPushAttemptHistory,
+        allowRebuildOnRemoteHead: true,
+      });
+      if (recovery?.directive === "retry_push") {
+        if (activeStatePublishLease) {
+          renewStatePublishLease(activeStatePublishLease, "before model-guided retry");
+        }
+        pushResult = pushPublishedCommit(candidateCommit, options.remote, options.branch);
+        if (pushResult.status === 0) {
+          recordRecoveryOutcome(recovery.advice, "retry_push_succeeded");
+          finalizeImmutableActionLedgerCheckout({
+            previousCommit,
+            publishedCommit: candidateCommit,
+            paths: options.paths,
+            protectedWorktreePaths,
+          });
+          return "committed";
+        }
+        recordRecoveryOutcome(recovery.advice, "retry_push_failed");
+      }
+      if (recovery?.directive === "rebuild_on_remote_head") {
+        modelRequestedRebuild = true;
+        modelRequestedRebuildAdvice = recovery.advice;
+      }
+    }
     const stateRepository = immutableLedgerStateRepository();
-    if (attempt === 1 && stateRepository) {
+    if (!modelRequestedRebuild && attempt === 1 && stateRepository) {
       const publishedCommit = mergeImmutableActionLedgerOnGitHub({
         remote: options.remote,
         branch: options.branch,
@@ -676,17 +725,36 @@ function pushImmutableActionLedgerCommit(options: {
         verifiedSourceObjectIds,
       });
     } catch (error) {
-      if (unavailableObjectRecoveryUsed || unavailableGitObjectIds(error).length === 0) throw error;
+      if (unavailableObjectRecoveryUsed || unavailableGitObjectIds(error).length === 0) {
+        if (modelRequestedRebuildAdvice) {
+          recordRecoveryOutcome(modelRequestedRebuildAdvice, "rebuild_on_remote_head_failed", {
+            error,
+          });
+        }
+        throw error;
+      }
       recoverUnavailableGitObjects(options.remote, options.branch, error);
       unavailableObjectRecoveryUsed = true;
-      rebuilt = rebuildImmutableActionLedgerCommit({
-        remote: options.remote,
-        branch: options.branch,
-        message: options.message,
-        paths: options.paths,
-        sourceCommit: options.sourceCommit,
-        verifiedSourceObjectIds,
-      });
+      try {
+        rebuilt = rebuildImmutableActionLedgerCommit({
+          remote: options.remote,
+          branch: options.branch,
+          message: options.message,
+          paths: options.paths,
+          sourceCommit: options.sourceCommit,
+          verifiedSourceObjectIds,
+        });
+      } catch (recoveryError) {
+        if (modelRequestedRebuildAdvice) {
+          recordRecoveryOutcome(modelRequestedRebuildAdvice, "rebuild_on_remote_head_failed", {
+            error: recoveryError,
+          });
+        }
+        throw recoveryError;
+      }
+    }
+    if (modelRequestedRebuildAdvice) {
+      recordRecoveryOutcome(modelRequestedRebuildAdvice, "rebuild_on_remote_head_succeeded");
     }
     candidateCommit = rebuilt.commit;
     if (rebuilt.result === "unchanged") {
@@ -725,6 +793,40 @@ function recoverUnavailableGitObjects(remote: string, branch: string, failure: u
   }
   requireNoLazyFetchSupport();
   console.log(`Recovering ${objectIds.length} unavailable Git object(s) from ${remote}`);
+  if (modelRecoveryConfigured()) {
+    const shallow = isShallowRepository();
+    const attempt = executeModelRecovery({
+      phase: "recover_unavailable_git_objects",
+      failure,
+      shallow,
+      remote,
+      branch,
+      recentAttempts: objectIds.map((objectId) => `unavailable_object:${objectId}`),
+      availableActions: [
+        "fetch_object",
+        "refetch_depth1",
+        "deepen",
+        "unshallow",
+        "defer_to_next_run",
+        "give_up",
+      ],
+      handlers: gitFetchRecoveryHandlers(remote, branch, {
+        deferToNextRun: () => {},
+        giveUp: () => {},
+      }),
+    });
+    if (attempt) {
+      throwForModelRecoveryDirective(attempt.advice, attempt.execution);
+      if (gitObjectIdsAvailable(objectIds)) {
+        recordRecoveryOutcome(attempt.advice, "objects_recovered");
+        return;
+      }
+      recordRecoveryOutcome(attempt.advice, "verification_failed");
+      console.warn(
+        "Model-guided Git object recovery did not restore every object; using deterministic fallback",
+      );
+    }
+  }
   for (const objectId of objectIds) {
     spawnBoundedFetch(["fetch", remote, objectId], PUBLISH_FETCH_TIMEOUT_MS);
   }
@@ -1047,6 +1149,56 @@ function mergeBaseWithShallowRecovery(
   if (result.status !== 1) throw gitRunError(result, args);
   if (!isShallowRepository()) {
     return { base: null, recoveredShallowMiss: false };
+  }
+
+  if (modelRecoveryConfigured()) {
+    const attempt = executeModelRecovery({
+      phase: "merge_base_shallow_recovery",
+      failure: gitRunError(result, args),
+      shallow: true,
+      remote,
+      branch,
+      recentAttempts: [`merge_base:${left}:${right}:status=${result.status}`],
+      availableActions: [
+        "refetch_depth1",
+        "deepen",
+        "unshallow",
+        "rebuild_on_remote_head",
+        "defer_to_next_run",
+        "give_up",
+      ],
+      handlers: gitFetchRecoveryHandlers(remote, branch, {
+        rebuildOnRemoteHead: () => {},
+        deferToNextRun: () => {},
+        giveUp: () => {},
+      }),
+    });
+    if (attempt) {
+      throwForModelRecoveryDirective(attempt.advice, attempt.execution);
+      if (attempt.execution.directive === "rebuild_on_remote_head") {
+        recordRecoveryOutcome(attempt.advice, "rebuild_on_remote_head_selected");
+        return { base: null, recoveredShallowMiss: true };
+      }
+      result = spawnGit(args, { quiet: true });
+      if (result.status === 0) {
+        recordRecoveryOutcome(attempt.advice, "merge_base_recovered");
+        return { base: result.stdout.trim(), recoveredShallowMiss: true };
+      }
+      if (result.status !== 1) {
+        recordRecoveryOutcome(attempt.advice, "verification_failed", {
+          error: gitRunError(result, args),
+        });
+        throw gitRunError(result, args);
+      }
+      if (!isShallowRepository()) {
+        recordRecoveryOutcome(attempt.advice, "history_hydrated_no_merge_base");
+        return { base: null, recoveredShallowMiss: true };
+      }
+      recordRecoveryOutcome(attempt.advice, "verification_failed");
+      console.warn(
+        "Model-guided shallow recovery did not find a merge base; using deterministic fallback",
+      );
+    }
   }
 
   const deepenArgs = ["fetch", "--deepen=32", remote, branch];
@@ -2297,9 +2449,62 @@ export function pushCommit(options: {
   const branch = options.branch ?? publishDefaultBranch();
   const pushAttempts = positiveInt(options.pushAttempts, 3);
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
+  let modelPushRecoveryConsulted = false;
+  const modelPushAttemptHistory: string[] = [];
 
   for (let pushAttempt = 1; pushAttempt <= pushAttempts; pushAttempt += 1) {
-    if (pushPublishedBranch(remote, branch).status === 0) return true;
+    let pushResult = pushPublishedBranch(remote, branch);
+    if (pushResult.status === 0) return true;
+    modelPushAttemptHistory.push(gitFailureSummary(pushResult));
+    if (!modelPushRecoveryConsulted) {
+      modelPushRecoveryConsulted = true;
+      const recovery = modelGuidedPushRecovery({
+        phase: "push_commit",
+        failure: pushResult,
+        remote,
+        branch,
+        recentAttempts: modelPushAttemptHistory,
+        allowRebuildOnRemoteHead: rebaseStrategy === "reconcile-records",
+      });
+      if (recovery?.directive === "retry_push") {
+        if (activeStatePublishLease) {
+          renewStatePublishLease(activeStatePublishLease, "before model-guided retry");
+        }
+        pushResult = pushPublishedBranch(remote, branch);
+        if (pushResult.status === 0) {
+          recordRecoveryOutcome(recovery.advice, "retry_push_succeeded");
+          return true;
+        }
+        recordRecoveryOutcome(recovery.advice, "retry_push_failed");
+        modelPushAttemptHistory.push(gitFailureSummary(pushResult));
+      }
+      if (recovery?.directive === "rebuild_on_remote_head") {
+        if (activeStatePublishLease && options.boundedRemoteHeadRebuild) {
+          renewStatePublishLease(activeStatePublishLease, "before model-guided state rebuild");
+        }
+        if (rebaseStrategy !== "reconcile-records") return false;
+        fetchPublishRemote(remote, branch, { allowFailure: true });
+        let rebuilt = false;
+        try {
+          rebuilt = rebuildReconciliationCommit(
+            remote,
+            branch,
+            options.reconciliationSourceCommit,
+            options.reconciliationTupleKeys,
+            options.boundedRemoteHeadRebuild,
+          );
+        } catch (error) {
+          recordRecoveryOutcome(recovery.advice, "rebuild_on_remote_head_failed", { error });
+          throw error;
+        }
+        if (!rebuilt) {
+          recordRecoveryOutcome(recovery.advice, "rebuild_on_remote_head_failed");
+          return false;
+        }
+        recordRecoveryOutcome(recovery.advice, "rebuild_on_remote_head_succeeded");
+        continue;
+      }
+    }
     if (activeStatePublishLease && options.boundedRemoteHeadRebuild) {
       renewStatePublishLease(activeStatePublishLease, "before state race recovery");
     }
@@ -2373,6 +2578,123 @@ export function pushCommit(options: {
     }
   }
   return pushPublishedBranch(remote, branch).status === 0;
+}
+
+function executeModelRecovery(options: {
+  phase: string;
+  failure: unknown;
+  shallow: boolean;
+  remote: string;
+  branch: string;
+  recentAttempts: readonly string[];
+  availableActions: readonly RecoveryActionName[];
+  handlers: RecoveryActionHandlers;
+}): { advice: RecoveryAdvice; execution: RecoveryExecution } | null {
+  const context = buildRecoveryFailureContext({
+    phase: options.phase,
+    gitError: options.failure,
+    shallow: options.shallow,
+    remote: options.remote,
+    branch: options.branch,
+    recentAttempts: options.recentAttempts,
+    availableActions: options.availableActions,
+  });
+  const advice = requestRecoveryAdvice(context);
+  if (!advice) return null;
+  try {
+    return { advice, execution: executeRecoveryActions(advice.plan.actions, options.handlers) };
+  } catch (error) {
+    recordRecoveryOutcome(advice, "execution_failed", { error });
+    console.warn(
+      `Model-guided Git recovery action failed; using deterministic fallback: ${errorMessage(error)}`,
+    );
+    return null;
+  }
+}
+
+function modelGuidedPushRecovery(options: {
+  phase: string;
+  failure: unknown;
+  remote: string;
+  branch: string;
+  recentAttempts: readonly string[];
+  allowRebuildOnRemoteHead: boolean;
+}): { advice: RecoveryAdvice; directive: "retry_push" | "rebuild_on_remote_head" } | null {
+  if (!modelRecoveryConfigured()) return null;
+  const shallow = isShallowRepository();
+  const availableActions: RecoveryActionName[] = [
+    "fetch_object",
+    "retry_push",
+    "defer_to_next_run",
+    "give_up",
+  ];
+  if (options.allowRebuildOnRemoteHead) availableActions.splice(1, 0, "rebuild_on_remote_head");
+  if (shallow) availableActions.splice(1, 0, "refetch_depth1", "deepen", "unshallow");
+  const attempt = executeModelRecovery({
+    ...options,
+    shallow,
+    availableActions,
+    handlers: gitFetchRecoveryHandlers(options.remote, options.branch, {
+      rebuildOnRemoteHead: () => {},
+      retryPush: () => {},
+      deferToNextRun: () => {},
+      giveUp: () => {},
+    }),
+  });
+  if (!attempt) return null;
+  throwForModelRecoveryDirective(attempt.advice, attempt.execution);
+  const directive =
+    attempt.execution.directive === "rebuild_on_remote_head"
+      ? "rebuild_on_remote_head"
+      : "retry_push";
+  return { advice: attempt.advice, directive };
+}
+
+function gitFetchRecoveryHandlers(
+  remote: string,
+  branch: string,
+  directives: RecoveryActionHandlers,
+): RecoveryActionHandlers {
+  return {
+    fetchObject: (sha) => {
+      spawnBoundedFetch(["fetch", remote, sha], PUBLISH_FETCH_TIMEOUT_MS);
+    },
+    refetchDepth1: () => {
+      spawnBoundedFetch(
+        ["fetch", "--refetch", "--depth=1", remote, branch],
+        RECOVERY_FETCH_TIMEOUT_MS,
+      );
+    },
+    deepen: (depth) => {
+      spawnBoundedFetch(["fetch", `--deepen=${depth}`, remote, branch], RECOVERY_FETCH_TIMEOUT_MS);
+    },
+    unshallow: () => {
+      spawnBoundedFetch(["fetch", "--unshallow", remote, branch], RECOVERY_FETCH_TIMEOUT_MS);
+    },
+    ...directives,
+  };
+}
+
+function throwForModelRecoveryDirective(
+  advice: RecoveryAdvice,
+  execution: RecoveryExecution,
+): void {
+  if (execution.directive === "defer_to_next_run") {
+    recordRecoveryOutcome(advice, execution.directive);
+    throw new Error(
+      `Model-guided Git recovery deferred to the next run: ${publicDiagnosisSummary(advice.plan.diagnosis)}`,
+    );
+  }
+  if (execution.directive === "give_up") {
+    recordRecoveryOutcome(advice, execution.directive);
+    throw new Error(
+      `Model-guided Git recovery gave up: ${publicDiagnosisSummary(advice.plan.diagnosis)}`,
+    );
+  }
+}
+
+function gitFailureSummary(value: GitRunResult): string {
+  return `${value.timedOut ? "timeout" : `status=${value.status}`}: ${value.stderr || value.stdout}`;
 }
 
 export function pushSingleRecordTupleCommit(options: {

--- a/src/repair/recovery-advisor.ts
+++ b/src/repair/recovery-advisor.ts
@@ -1,0 +1,608 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ACTION_EVENT_REASON_CODES,
+  ACTION_EVENT_STATUSES,
+  ACTION_EVENT_TYPES,
+} from "../action-ledger.js";
+import { recordWorkflowActionEvent } from "../action-ledger-runtime.js";
+import { codexEnv, codexModelArgs } from "../codex-env.js";
+import { runCodexProcess } from "../codex-process.js";
+import { repoRoot } from "./paths.js";
+
+const RECOVERY_MODEL_TIMEOUT_MS = 30_000;
+const RECOVERY_OUTPUT_MAX_BYTES = 64 * 1024;
+const RECOVERY_TEXT_MAX_CHARS = 8_000;
+const RECOVERY_ATTEMPT_HISTORY_LIMIT = 8;
+const RECOVERY_ACTION_LIMIT = 8;
+const PUBLIC_DIAGNOSIS_TERMS = new Set([
+  "authentication",
+  "authorization",
+  "branch",
+  "conflict",
+  "deepen",
+  "depth",
+  "fetch",
+  "history",
+  "merge",
+  "missing",
+  "nonfastforward",
+  "object",
+  "push",
+  "race",
+  "rebuild",
+  "refetch",
+  "remote",
+  "retry",
+  "shallow",
+  "timeout",
+  "unavailable",
+  "unshallow",
+]);
+
+export const RECOVERY_ACTION_NAMES = [
+  "fetch_object",
+  "refetch_depth1",
+  "deepen",
+  "unshallow",
+  "rebuild_on_remote_head",
+  "reset_to_remote",
+  "retry_push",
+  "defer_to_next_run",
+  "give_up",
+] as const;
+
+export type RecoveryActionName = (typeof RECOVERY_ACTION_NAMES)[number];
+
+export type RecoveryAction =
+  | { name: "fetch_object"; sha: string }
+  | { name: "deepen"; depth: number }
+  | {
+      name:
+        | "refetch_depth1"
+        | "unshallow"
+        | "rebuild_on_remote_head"
+        | "reset_to_remote"
+        | "retry_push"
+        | "defer_to_next_run"
+        | "give_up";
+    };
+
+export type RecoveryFailureContext = {
+  phase: string;
+  git_error: string;
+  shallow: boolean;
+  remote: string;
+  branch: string;
+  recent_attempts: string[];
+  available_actions: string[];
+};
+
+export type RecoveryPlan = {
+  diagnosis: string;
+  actions: RecoveryAction[];
+  confidence: number;
+};
+
+export type RecoveryAdvice = {
+  context: RecoveryFailureContext;
+  contextHash: string;
+  plan: RecoveryPlan;
+};
+
+export type RecoveryExecution = {
+  actions: string[];
+  directive:
+    | "continue"
+    | "rebuild_on_remote_head"
+    | "reset_to_remote"
+    | "retry_push"
+    | "defer_to_next_run"
+    | "give_up";
+};
+
+export type RecoveryActionHandlers = Partial<{
+  fetchObject: (sha: string) => void;
+  refetchDepth1: () => void;
+  deepen: (depth: number) => void;
+  unshallow: () => void;
+  rebuildOnRemoteHead: () => void;
+  resetToRemote: () => void;
+  retryPush: () => void;
+  deferToNextRun: () => void;
+  giveUp: () => void;
+}>;
+
+export type RecoveryModelRunner = (input: {
+  context: RecoveryFailureContext;
+  contextHash: string;
+  prompt: string;
+  timeoutMs: number;
+}) => string;
+
+export function modelRecoveryConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (
+    env.CLAWSWEEPER_MODEL_RECOVERY_ENABLED === "1" &&
+    Boolean(env.OPENAI_API_KEY?.trim() || env.CODEX_API_KEY?.trim())
+  );
+}
+
+export function buildRecoveryFailureContext(input: {
+  phase: string;
+  gitError: unknown;
+  shallow: boolean;
+  remote: string;
+  branch: string;
+  recentAttempts?: readonly string[];
+  availableActions?: readonly RecoveryActionName[];
+  env?: NodeJS.ProcessEnv;
+}): RecoveryFailureContext {
+  const env = input.env ?? process.env;
+  return {
+    phase: machineToken(input.phase, "recovery phase"),
+    git_error: redactRecoverySecrets(errorText(input.gitError), env).slice(
+      0,
+      RECOVERY_TEXT_MAX_CHARS,
+    ),
+    shallow: input.shallow,
+    remote: redactRecoverySecrets(input.remote, env).slice(0, 256),
+    branch: redactRecoverySecrets(input.branch, env).slice(0, 256),
+    recent_attempts: (input.recentAttempts ?? [])
+      .slice(-RECOVERY_ATTEMPT_HISTORY_LIMIT)
+      .map((attempt) =>
+        redactRecoverySecrets(String(attempt), env).slice(0, RECOVERY_TEXT_MAX_CHARS),
+      ),
+    available_actions: (input.availableActions ?? RECOVERY_ACTION_NAMES).map(String),
+  };
+}
+
+export function recoveryContextHash(context: RecoveryFailureContext): string {
+  return createHash("sha256").update(JSON.stringify(context)).digest("hex");
+}
+
+export function requestRecoveryAdvice(
+  context: RecoveryFailureContext,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    modelRunner?: RecoveryModelRunner;
+    timeoutMs?: number;
+  } = {},
+): RecoveryAdvice | null {
+  const env = options.env ?? process.env;
+  if (!modelRecoveryConfigured(env)) return null;
+  const contextHash = recoveryContextHash(context);
+  const timeoutMs = boundedTimeout(options.timeoutMs);
+  try {
+    const prompt = recoveryPrompt(context, contextHash);
+    const raw = (options.modelRunner ?? defaultRecoveryModelRunner)({
+      context,
+      contextHash,
+      prompt,
+      timeoutMs,
+    });
+    const plan = parseRecoveryPlan(raw, context);
+    plan.diagnosis = redactRecoverySecrets(plan.diagnosis, env);
+    return { context, contextHash, plan };
+  } catch (error) {
+    console.warn(
+      `Model-guided Git recovery unavailable; using deterministic fallback: ${safeReason(error)}`,
+    );
+    return null;
+  }
+}
+
+export function parseRecoveryPlan(raw: string, context: RecoveryFailureContext): RecoveryPlan {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error("recovery plan is not valid JSON");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("recovery plan must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    JSON.stringify(Object.keys(record).sort()) !==
+    JSON.stringify(["actions", "confidence", "diagnosis"])
+  ) {
+    throw new Error("recovery plan keys are invalid");
+  }
+  if (
+    typeof record.diagnosis !== "string" ||
+    !record.diagnosis.trim() ||
+    record.diagnosis.length > 2_000
+  ) {
+    throw new Error("recovery diagnosis is invalid");
+  }
+  if (
+    typeof record.confidence !== "number" ||
+    !Number.isFinite(record.confidence) ||
+    record.confidence < 0 ||
+    record.confidence > 1
+  ) {
+    throw new Error("recovery confidence must be between 0 and 1");
+  }
+  if (
+    !Array.isArray(record.actions) ||
+    record.actions.length === 0 ||
+    record.actions.length > RECOVERY_ACTION_LIMIT ||
+    !record.actions.every((action) => typeof action === "string")
+  ) {
+    throw new Error("recovery actions are invalid");
+  }
+  const actions = record.actions.map((action) => parseRecoveryAction(action as string, context));
+  const formatted = actions.map(formatRecoveryAction);
+  if (new Set(formatted).size !== formatted.length) {
+    throw new Error("recovery plan contains duplicate actions");
+  }
+  const terminalIndex = actions.findIndex((action) => terminalRecoveryAction(action.name));
+  if (terminalIndex >= 0 && terminalIndex !== actions.length - 1) {
+    throw new Error("terminal recovery action must be last");
+  }
+  const unshallowIndex = actions.findIndex((action) => action.name === "unshallow");
+  if (
+    unshallowIndex >= 0 &&
+    actions.slice(unshallowIndex + 1).some((action) => !terminalRecoveryAction(action.name))
+  ) {
+    throw new Error("unshallow must be the last history-changing recovery action");
+  }
+  return { diagnosis: record.diagnosis.trim(), actions, confidence: record.confidence };
+}
+
+export function executeRecoveryActions(
+  actions: readonly RecoveryAction[],
+  handlers: RecoveryActionHandlers,
+): RecoveryExecution {
+  let directive: RecoveryExecution["directive"] = "continue";
+  const executed: string[] = [];
+  for (const action of actions) {
+    const formatted = formatRecoveryAction(action);
+    switch (action.name) {
+      case "fetch_object":
+        requiredHandler(handlers.fetchObject, action.name)(action.sha);
+        break;
+      case "refetch_depth1":
+        requiredHandler(handlers.refetchDepth1, action.name)();
+        break;
+      case "deepen":
+        requiredHandler(handlers.deepen, action.name)(action.depth);
+        break;
+      case "unshallow":
+        requiredHandler(handlers.unshallow, action.name)();
+        break;
+      case "rebuild_on_remote_head":
+        requiredHandler(handlers.rebuildOnRemoteHead, action.name)();
+        directive = action.name;
+        break;
+      case "reset_to_remote":
+        requiredHandler(handlers.resetToRemote, action.name)();
+        directive = action.name;
+        break;
+      case "retry_push":
+        requiredHandler(handlers.retryPush, action.name)();
+        directive = action.name;
+        break;
+      case "defer_to_next_run":
+        requiredHandler(handlers.deferToNextRun, action.name)();
+        directive = action.name;
+        break;
+      case "give_up":
+        requiredHandler(handlers.giveUp, action.name)();
+        directive = action.name;
+        break;
+    }
+    executed.push(formatted);
+  }
+  return { actions: executed, directive };
+}
+
+export function recordRecoveryOutcome(
+  advice: RecoveryAdvice,
+  outcome: string,
+  options: { env?: NodeJS.ProcessEnv; root?: string; error?: unknown } = {},
+): void {
+  const env = options.env ?? process.env;
+  const normalizedOutcome = machineToken(outcome, "recovery outcome");
+  const failed = normalizedOutcome.includes("failed") || normalizedOutcome === "give_up";
+  const gaveUp = normalizedOutcome === "give_up";
+  const deferred = normalizedOutcome === "defer_to_next_run";
+  const selected = normalizedOutcome.endsWith("_selected");
+  const plan = advice.plan.actions.map(formatRecoveryAction).join("+");
+  const diagnosis = publicDiagnosisSummary(advice.plan.diagnosis);
+  try {
+    recordWorkflowActionEvent(
+      options.root ?? env.CLAWSWEEPER_ACTION_LEDGER_ROOT?.trim() ?? repoRoot(),
+      {
+        scope: "publication.git_recovery",
+        identity: {
+          context_sha256: advice.contextHash,
+          diagnosis,
+          plan,
+          outcome: normalizedOutcome,
+        },
+        operation: "git_recovery",
+        operationIdentity: { context_sha256: advice.contextHash },
+        attemptIdentity: { context_sha256: advice.contextHash, plan },
+        type: ACTION_EVENT_TYPES.publicationLifecycle,
+        component: "git_recovery",
+        subject: {
+          repository: env.GITHUB_REPOSITORY ?? "openclaw/clawsweeper",
+          kind: "publication",
+          subjectId: machineToken(
+            `${advice.context.remote}.${advice.context.branch}`,
+            "publication",
+          ),
+          sourceRevision: advice.contextHash,
+        },
+        action: {
+          name: "git.recovery",
+          status: failed
+            ? ACTION_EVENT_STATUSES.failed
+            : deferred
+              ? ACTION_EVENT_STATUSES.yielded
+              : selected
+                ? ACTION_EVENT_STATUSES.planned
+                : ACTION_EVENT_STATUSES.recovered,
+          reasonCode: failed
+            ? ACTION_EVENT_REASON_CODES.exception
+            : deferred
+              ? ACTION_EVENT_REASON_CODES.retryScheduled
+              : selected
+                ? ACTION_EVENT_REASON_CODES.selected
+                : ACTION_EVENT_REASON_CODES.completed,
+          retryable: deferred || selected || (failed && !gaveUp),
+          mutation: false,
+        },
+        learning: {
+          category: "model_guided_git_recovery",
+          signal: diagnosis,
+          ruleId: ledgerText(plan),
+          confidence: advice.plan.confidence,
+        },
+        attributes: {
+          action_count: advice.plan.actions.length,
+          phase: advice.context.phase,
+          state: normalizedOutcome,
+          validation_kind: "allowlisted_plan",
+        },
+        privacy: {
+          classification: "public",
+          redactionVersion: "git_recovery_v1",
+          fieldsDropped: ["git_error", ...(options.error === undefined ? [] : ["execution_error"])],
+        },
+      },
+      { env },
+    );
+  } catch (error) {
+    console.warn(`Failed to record model-guided Git recovery outcome: ${safeReason(error)}`);
+  }
+}
+
+export function redactRecoverySecrets(value: string, env: NodeJS.ProcessEnv = process.env): string {
+  let redacted = value;
+  for (const key of [
+    "OPENAI_API_KEY",
+    "CODEX_API_KEY",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "CLAWSWEEPER_STATE_REPO_TOKEN",
+    "CLAWSWEEPER_WEBHOOK_SECRET",
+    "CLAWSWEEPER_APP_PRIVATE_KEY",
+  ]) {
+    const secret = env[key]?.trim();
+    if (secret && secret.length >= 8) redacted = redacted.replaceAll(secret, "[REDACTED]");
+  }
+  return redacted
+    .replace(/\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/\bgithub_pat_[A-Za-z0-9_]{16,}\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(
+      /\b(OPENAI_API_KEY|CODEX_API_KEY|GH_TOKEN|GITHUB_TOKEN|CLAWSWEEPER_STATE_REPO_TOKEN)=([^\s"']+)/g,
+      "$1=[REDACTED]",
+    )
+    .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 [REDACTED]")
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1[REDACTED]@");
+}
+
+export function formatRecoveryAction(action: RecoveryAction): string {
+  if (action.name === "fetch_object") return `${action.name} ${action.sha}`;
+  if (action.name === "deepen") return `${action.name} ${action.depth}`;
+  return action.name;
+}
+
+function parseRecoveryAction(value: string, context: RecoveryFailureContext): RecoveryAction {
+  const normalized = value.trim();
+  const fetchMatch = /^fetch_object ([a-fA-F0-9]{40,64})$/.exec(normalized);
+  if (fetchMatch?.[1]) {
+    if (!context.available_actions.includes("fetch_object")) {
+      throw new Error(`fetch_object is not available during ${context.phase}`);
+    }
+    const sha = fetchMatch[1].toLowerCase();
+    const knownObjects = new Set(
+      [
+        ...`${context.git_error}\n${context.recent_attempts.join("\n")}`.matchAll(
+          /\b[a-f0-9]{40,64}\b/gi,
+        ),
+      ].map((match) => match[0].toLowerCase()),
+    );
+    if (!knownObjects.has(sha))
+      throw new Error("fetch_object must target an object from the failure context");
+    return { name: "fetch_object", sha };
+  }
+  const deepenMatch = /^deepen ([0-9]+)$/.exec(normalized);
+  if (deepenMatch?.[1]) {
+    if (!context.available_actions.includes("deepen")) {
+      throw new Error(`deepen is not available during ${context.phase}`);
+    }
+    const depth = Number(deepenMatch[1]);
+    if (!Number.isInteger(depth) || depth < 1 || depth > 64) {
+      throw new Error("deepen must be between 1 and 64");
+    }
+    if (!context.shallow) throw new Error("deepen requires a shallow repository");
+    return { name: "deepen", depth };
+  }
+  if (normalized === "fetch_object" || normalized === "deepen") {
+    throw new Error(`${normalized} requires an argument`);
+  }
+  if (!RECOVERY_ACTION_NAMES.includes(normalized as RecoveryActionName)) {
+    throw new Error(`unknown recovery action: ${normalized || "<empty>"}`);
+  }
+  const name = normalized as Exclude<RecoveryActionName, "fetch_object" | "deepen">;
+  if ((name === "refetch_depth1" || name === "unshallow") && !context.shallow) {
+    throw new Error(`${name} requires a shallow repository`);
+  }
+  if (!context.available_actions.includes(name)) {
+    throw new Error(`${name} is not available during ${context.phase}`);
+  }
+  return { name };
+}
+
+function defaultRecoveryModelRunner(input: { prompt: string; timeoutMs: number }): string {
+  const workDir = mkdtempSync(join(tmpdir(), "clawsweeper-recovery-advisor-"));
+  const outputPath = join(workDir, "recovery-plan.json");
+  try {
+    const result = runCodexProcess({
+      args: [
+        "exec",
+        ...codexModelArgs(process.env.CLAWSWEEPER_MODEL_RECOVERY_MODEL ?? "internal"),
+        "-c",
+        'model_reasoning_effort="low"',
+        "-c",
+        'approval_policy="never"',
+        "-c",
+        'shell_environment_policy.inherit="none"',
+        "-c",
+        'web_search="disabled"',
+        "--sandbox",
+        "read-only",
+        "--disable",
+        "shell_tool",
+        "--disable",
+        "apps",
+        "--disable",
+        "browser_use",
+        "--disable",
+        "computer_use",
+        "--ephemeral",
+        "--ignore-rules",
+        "--skip-git-repo-check",
+        "--output-schema",
+        join(repoRoot(), "schema", "repair", "recovery-advisor.schema.json"),
+        "--output-last-message",
+        outputPath,
+        "-",
+      ],
+      cwd: workDir,
+      env: recoveryCodexEnv(),
+      input: input.prompt,
+      timeoutMs: input.timeoutMs,
+      tailBytes: 8 * 1024,
+      outputFileBytes: RECOVERY_OUTPUT_MAX_BYTES,
+    });
+    if (result.error || result.status !== 0 || !existsSync(outputPath)) {
+      throw new Error(
+        result.error?.message || `Codex recovery advisor exited ${result.status ?? "unknown"}`,
+      );
+    }
+    if (statSync(outputPath).size > RECOVERY_OUTPUT_MAX_BYTES) {
+      throw new Error("Codex recovery plan exceeded the output limit");
+    }
+    return readFileSync(outputPath, "utf8");
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+function recoveryCodexEnv(): NodeJS.ProcessEnv {
+  const env = codexEnv({ preserveCodexAuth: true });
+  const allowedSecrets = new Set(["OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"]);
+  for (const key of Object.keys(env)) {
+    if (
+      !allowedSecrets.has(key) &&
+      /(?:TOKEN|SECRET|PASSWORD|CREDENTIAL|PRIVATE_KEY|API_KEY)$/i.test(key)
+    ) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+function recoveryPrompt(context: RecoveryFailureContext, contextHash: string): string {
+  return [
+    "Diagnose this Git publication failure and choose the smallest safe recovery plan.",
+    "Return only JSON matching the supplied schema.",
+    "Use only actions listed in available_actions, with these exact forms:",
+    "fetch_object <sha>, refetch_depth1, deepen <n>, unshallow, rebuild_on_remote_head, reset_to_remote, retry_push, defer_to_next_run, give_up.",
+    "Never propose shell commands. deepen must be an integer from 1 through 64. fetch_object must use a SHA present in the context.",
+    "Prefer defer_to_next_run or give_up when the safe recovery is unclear.",
+    `Failure context hash: ${contextHash}`,
+    JSON.stringify(context, null, 2),
+  ].join("\n\n");
+}
+
+function terminalRecoveryAction(name: RecoveryActionName): boolean {
+  return [
+    "rebuild_on_remote_head",
+    "reset_to_remote",
+    "retry_push",
+    "defer_to_next_run",
+    "give_up",
+  ].includes(name);
+}
+
+function requiredHandler<T extends (...args: never[]) => void>(
+  handler: T | undefined,
+  action: RecoveryActionName,
+): T {
+  if (!handler) throw new Error(`recovery action is not executable in this phase: ${action}`);
+  return handler;
+}
+
+function errorText(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const combined = [record.stderr, record.stdout]
+      .filter((part) => typeof part === "string")
+      .join("\n");
+    if (combined) return combined;
+  }
+  return String(value);
+}
+
+function boundedTimeout(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return RECOVERY_MODEL_TIMEOUT_MS;
+  return Math.max(1_000, Math.min(Math.floor(value), RECOVERY_MODEL_TIMEOUT_MS));
+}
+
+function machineToken(value: string, label: string): string {
+  const token = value
+    .trim()
+    .replace(/[^A-Za-z0-9_.:/@+-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!token) throw new Error(`${label} is empty`);
+  return token.slice(0, 240);
+}
+
+function ledgerText(value: string): string {
+  return machineToken(value, "recovery ledger text");
+}
+
+export function publicDiagnosisSummary(value: string): string {
+  const terms = value
+    .toLowerCase()
+    .replace(/non[- ]fast[- ]forward/g, "nonfastforward")
+    .match(/[a-z]+/g)
+    ?.filter((term) => PUBLIC_DIAGNOSIS_TERMS.has(term));
+  return [...new Set(terms?.slice(0, 12) ?? [])].join("_") || "unclassified_git_failure";
+}
+
+function safeReason(error: unknown): string {
+  return redactRecoverySecrets(errorText(error))
+    .replace(/[\r\n]+/g, " ")
+    .slice(0, 500);
+}

--- a/src/repair/recovery-advisor.ts
+++ b/src/repair/recovery-advisor.ts
@@ -332,10 +332,7 @@ export function recordRecoveryOutcome(
         subject: {
           repository: env.GITHUB_REPOSITORY ?? "openclaw/clawsweeper",
           kind: "publication",
-          subjectId: machineToken(
-            `${advice.context.remote}.${advice.context.branch}`,
-            "publication",
-          ),
+          subjectId: "git_recovery",
           sourceRevision: advice.contextHash,
         },
         action: {
@@ -405,7 +402,8 @@ export function redactRecoverySecrets(value: string, env: NodeJS.ProcessEnv = pr
       "$1=[REDACTED]",
     )
     .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 [REDACTED]")
-    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1[REDACTED]@");
+    .replace(/\b[a-z][a-z0-9+.-]*:\/\/\S*/gi, "[REDACTED_URL]")
+    .replace(/\b[^\s/@:]+@[^\s]+:[^\s]+/g, "[REDACTED_GIT_REMOTE]");
 }
 
 export function formatRecoveryAction(action: RecoveryAction): string {

--- a/test/repair/recovery-advisor.test.ts
+++ b/test/repair/recovery-advisor.test.ts
@@ -205,6 +205,12 @@ test("recovery context redacts credentials before hashing or model invocation", 
     `fatal: OPENAI_API_KEY=${openAiKey}`,
     `Authorization: Bearer ${githubToken}`,
     `https://x-access-token:${githubToken}@github.com/openclaw/clawsweeper-state.git`,
+    "https://opaque-access-token@git.example/private.git?access_token=another-secret&depth=1",
+    "(https://punctuation-token@git.example/private.git).",
+    "https://account.blob.core.windows.net/container/blob?sv=1&sig=azure-secret",
+    "https://proxy.test/?target=https%3A%2F%2Fapi.test%2F%3Faccess_token%3Dnested-secret",
+    "https://safe.example,https://adjacent-token@git.example/private.git",
+    "https://user:abc'def@git.example/repo.git",
   ].join("\n");
   const redacted = redactRecoverySecrets(value, {
     OPENAI_API_KEY: openAiKey,
@@ -214,7 +220,28 @@ test("recovery context redacts credentials before hashing or model invocation", 
   assert.doesNotMatch(redacted, /super-secret|supersecret/);
   assert.match(redacted, /OPENAI_API_KEY=\[REDACTED\]/);
   assert.match(redacted, /Bearer \[REDACTED\]/);
-  assert.match(redacted, /https:\/\/\[REDACTED\]@github\.com/);
+  assert.match(redacted, /\[REDACTED_URL\]/);
+  assert.doesNotMatch(
+    redacted,
+    /opaque-access-token|another-secret|access_token|punctuation-token|azure-secret|nested-secret|adjacent-token|abc'def/,
+  );
+  assert.doesNotMatch(redacted, /depth=1|sig=|sv=1/);
+  assert.equal(
+    redactRecoverySecrets("https://git.example?email=owner@example.org"),
+    "[REDACTED_URL]",
+  );
+  assert.equal(
+    redactRecoverySecrets("opaque-token@git.example:private/repo.git"),
+    "[REDACTED_GIT_REMOTE]",
+  );
+  assert.equal(
+    redactRecoverySecrets("opaque-token@git_internal:private/repo.git"),
+    "[REDACTED_GIT_REMOTE]",
+  );
+  assert.equal(
+    redactRecoverySecrets("opaque-token@[2001:db8::1]:private/repo.git"),
+    "[REDACTED_GIT_REMOTE]",
+  );
 
   const failureContext = buildRecoveryFailureContext({
     phase: "push_commit",

--- a/test/repair/recovery-advisor.test.ts
+++ b/test/repair/recovery-advisor.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { readAllSpooledActionEvents } from "../../dist/action-ledger.js";
+import {
+  buildRecoveryFailureContext,
+  executeRecoveryActions,
+  parseRecoveryPlan,
+  publicDiagnosisSummary,
+  recordRecoveryOutcome,
+  redactRecoverySecrets,
+  requestRecoveryAdvice,
+  type RecoveryActionHandlers,
+} from "../../dist/repair/recovery-advisor.js";
+
+const objectId = "a".repeat(40);
+
+function context() {
+  return buildRecoveryFailureContext({
+    phase: "push_commit",
+    gitError: `remote rejected object ${objectId} is unavailable`,
+    shallow: true,
+    remote: "origin",
+    branch: "state",
+    recentAttempts: ["push status=1"],
+    availableActions: [
+      "fetch_object",
+      "refetch_depth1",
+      "deepen",
+      "unshallow",
+      "rebuild_on_remote_head",
+      "retry_push",
+      "defer_to_next_run",
+      "give_up",
+    ],
+  });
+}
+
+test("recovery advisor rejects unknown actions instead of partially accepting a plan", () => {
+  assert.throws(
+    () =>
+      parseRecoveryPlan(
+        JSON.stringify({
+          diagnosis: "The shallow checkout is missing an object.",
+          actions: [`fetch_object ${objectId}`, "run_shell git fetch --all"],
+          confidence: 0.9,
+        }),
+        context(),
+      ),
+    /unknown recovery action/,
+  );
+  assert.throws(
+    () =>
+      parseRecoveryPlan(
+        JSON.stringify({
+          diagnosis: "The shallow checkout needs too much history.",
+          actions: ["deepen 65"],
+          confidence: 0.5,
+        }),
+        context(),
+      ),
+    /between 1 and 64/,
+  );
+  for (const action of ["fetch_object", "deepen"]) {
+    assert.throws(
+      () =>
+        parseRecoveryPlan(
+          JSON.stringify({
+            diagnosis: "The parameterized action is incomplete.",
+            actions: [action],
+            confidence: 0.5,
+          }),
+          context(),
+        ),
+      /requires an argument/,
+    );
+  }
+  assert.throws(
+    () =>
+      parseRecoveryPlan(
+        JSON.stringify({
+          diagnosis: "The plan contradicts its own shallow-state transition.",
+          actions: ["unshallow", "deepen 1", "retry_push"],
+          confidence: 0.5,
+        }),
+        context(),
+      ),
+    /unshallow must be the last history-changing recovery action/,
+  );
+});
+
+test("terminal recovery actions map to explicit trust-boundary handlers", () => {
+  const calls: string[] = [];
+  const handlers: RecoveryActionHandlers = {
+    rebuildOnRemoteHead: () => calls.push("rebuild"),
+    resetToRemote: () => calls.push("reset"),
+    retryPush: () => calls.push("retry"),
+    deferToNextRun: () => calls.push("defer"),
+    giveUp: () => calls.push("give_up"),
+  };
+  const cases = [
+    ["rebuild_on_remote_head", "rebuild"],
+    ["reset_to_remote", "reset"],
+    ["retry_push", "retry"],
+    ["defer_to_next_run", "defer"],
+    ["give_up", "give_up"],
+  ] as const;
+  for (const [name, expectedCall] of cases) {
+    calls.length = 0;
+    const execution = executeRecoveryActions([{ name }], handlers);
+    assert.deepEqual(calls, [expectedCall]);
+    assert.equal(execution.directive, name);
+  }
+});
+
+test("malformed model JSON is discarded for deterministic fallback", () => {
+  let calls = 0;
+  const advice = requestRecoveryAdvice(context(), {
+    env: {
+      CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1",
+      OPENAI_API_KEY: "sk-test-placeholder-value",
+    },
+    modelRunner: () => {
+      calls += 1;
+      return "not json";
+    },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(advice, null);
+});
+
+test("disabled model recovery never invokes the model runner", () => {
+  let calls = 0;
+  const advice = requestRecoveryAdvice(context(), {
+    env: { OPENAI_API_KEY: "sk-test-placeholder-value" },
+    modelRunner: () => {
+      calls += 1;
+      return "{}";
+    },
+  });
+
+  assert.equal(advice, null);
+  assert.equal(calls, 0);
+});
+
+test("missing model credentials use deterministic fallback without invoking the model", () => {
+  let calls = 0;
+  const advice = requestRecoveryAdvice(context(), {
+    env: { CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1" },
+    modelRunner: () => {
+      calls += 1;
+      return "{}";
+    },
+  });
+
+  assert.equal(advice, null);
+  assert.equal(calls, 0);
+});
+
+test("allowlisted recovery actions map only to typed execution handlers", () => {
+  const calls: string[] = [];
+  const handlers: RecoveryActionHandlers = {
+    fetchObject: (sha) => calls.push(`fetch:${sha}`),
+    refetchDepth1: () => calls.push("refetch"),
+    deepen: (depth) => calls.push(`deepen:${depth}`),
+    unshallow: () => calls.push("unshallow"),
+    retryPush: () => calls.push("retry"),
+  };
+  const plan = parseRecoveryPlan(
+    JSON.stringify({
+      diagnosis: "Hydrate the missing history and retry.",
+      actions: [
+        `fetch_object ${objectId}`,
+        "refetch_depth1",
+        "deepen 32",
+        "unshallow",
+        "retry_push",
+      ],
+      confidence: 0.8,
+    }),
+    context(),
+  );
+
+  const execution = executeRecoveryActions(plan.actions, handlers);
+
+  assert.deepEqual(calls, [`fetch:${objectId}`, "refetch", "deepen:32", "unshallow", "retry"]);
+  assert.equal(execution.directive, "retry_push");
+  assert.deepEqual(execution.actions, [
+    `fetch_object ${objectId}`,
+    "refetch_depth1",
+    "deepen 32",
+    "unshallow",
+    "retry_push",
+  ]);
+});
+
+test("recovery context redacts credentials before hashing or model invocation", () => {
+  const openAiKey = "sk-proj-super-secret-recovery-key";
+  const githubToken = "ghp_supersecretrecoverytoken123456";
+  const value = [
+    `fatal: OPENAI_API_KEY=${openAiKey}`,
+    `Authorization: Bearer ${githubToken}`,
+    `https://x-access-token:${githubToken}@github.com/openclaw/clawsweeper-state.git`,
+  ].join("\n");
+  const redacted = redactRecoverySecrets(value, {
+    OPENAI_API_KEY: openAiKey,
+    GITHUB_TOKEN: githubToken,
+  });
+
+  assert.doesNotMatch(redacted, /super-secret|supersecret/);
+  assert.match(redacted, /OPENAI_API_KEY=\[REDACTED\]/);
+  assert.match(redacted, /Bearer \[REDACTED\]/);
+  assert.match(redacted, /https:\/\/\[REDACTED\]@github\.com/);
+
+  const failureContext = buildRecoveryFailureContext({
+    phase: "push_commit",
+    gitError: value,
+    shallow: false,
+    remote: `https://x-access-token:${githubToken}@github.com/openclaw/state.git`,
+    branch: "state",
+    env: { OPENAI_API_KEY: openAiKey, GITHUB_TOKEN: githubToken },
+  });
+  assert.doesNotMatch(JSON.stringify(failureContext), /super-secret|supersecret/);
+  assert.equal(
+    publicDiagnosisSummary("Customer Acme path /private/repo has a shallow missing object"),
+    "shallow_missing_object",
+  );
+});
+
+test("validated recovery advice records its context hash, diagnosis, plan, and outcome", () => {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-recovery-ledger-")),
+  );
+  const advice = requestRecoveryAdvice(context(), {
+    env: {
+      CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1",
+      OPENAI_API_KEY: "sk-test-placeholder-value",
+    },
+    modelRunner: () =>
+      JSON.stringify({
+        diagnosis: "The shallow checkout needs one bounded deepen before retry.",
+        actions: ["deepen 16", "retry_push"],
+        confidence: 0.75,
+      }),
+  });
+  assert.ok(advice);
+  recordRecoveryOutcome(advice, "retry_push_selected", {
+    root,
+    env: {
+      CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+      CLAWSWEEPER_ACTION_LEDGER_INVOCATION: "recovery-0",
+      CLAWSWEEPER_ACTION_LEDGER_PARTITION_DATE: "2026-07-22",
+      GITHUB_ACTION: "materialize",
+      GITHUB_JOB: "materialize",
+      GITHUB_REPOSITORY: "openclaw/clawsweeper",
+      GITHUB_RUN_ATTEMPT: "1",
+      GITHUB_RUN_ID: "123",
+      GITHUB_SHA: "abc123",
+      GITHUB_WORKFLOW: "State materializer",
+    },
+  });
+
+  const events = readAllSpooledActionEvents(root);
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.subject.source_revision, advice.contextHash);
+  assert.equal(events[0]?.learning?.signal, "shallow_deepen_retry");
+  assert.equal(events[0]?.learning?.rule_id, "deepen_16+retry_push");
+  assert.equal(events[0]?.attributes?.state, "retry_push_selected");
+  assert.equal(events[0]?.action.status, "planned");
+});

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -10,6 +10,7 @@ type WorkflowStep = {
   run?: string;
   env?: Record<string, unknown>;
   with?: Record<string, unknown>;
+  "continue-on-error"?: boolean;
 };
 
 type WorkflowJob = {
@@ -69,6 +70,65 @@ test("the setup action exports no long-lived coordinator credential", () => {
   assert.match(source, /CLAWSWEEPER_STATE_COORDINATOR_CLASS=\$\{\{ inputs\.coordinator-class \}\}/);
 });
 
+test("state materializer and apply publishers enable model-guided recovery with the existing Codex key", () => {
+  const expectedKey = "${{ secrets.OPENAI_API_KEY }}";
+  const expectedModel = "${{ secrets.CLAWSWEEPER_MODEL }}";
+  const expectedJobs = [
+    [".github/workflows/state-materializer.yml", "materialize", ["Materialize queued state"]],
+    [".github/workflows/sweep.yml", "apply-proof", ["Generate bound close coverage proofs"]],
+    [
+      ".github/workflows/sweep.yml",
+      "apply-existing",
+      [
+        "Reconcile before apply preselect",
+        "Apply unchanged proposed decisions with checkpoints",
+        "Retry final apply status publication",
+      ],
+    ],
+  ] as const;
+  const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
+
+  for (const [file, jobName, recoverySteps] of expectedJobs) {
+    const job = byFile.get(file)?.jobs?.[jobName];
+    assert.ok(job, `${file}:${jobName}`);
+    assert.equal(job.env?.CLAWSWEEPER_MODEL_RECOVERY_ENABLED, "1", `${file}:${jobName}`);
+    assert.equal(job.env?.OPENAI_API_KEY, undefined, `${file}:${jobName}: key must be step-scoped`);
+    const setupCodex = job.steps?.find((step) =>
+      step.uses?.endsWith("/.github/actions/setup-codex"),
+    );
+    assert.ok(setupCodex, `${file}:${jobName}: setup-codex`);
+    assert.equal(setupCodex.env?.OPENAI_API_KEY, expectedKey, `${file}:${jobName}`);
+    assert.equal(setupCodex.env?.CLAWSWEEPER_INTERNAL_MODEL, expectedModel, `${file}:${jobName}`);
+    if (jobName !== "apply-proof") {
+      assert.equal(setupCodex["continue-on-error"], true, `${file}:${jobName}: optional setup`);
+    }
+    for (const stepName of recoverySteps) {
+      const step = job.steps?.find((candidate) => candidate.name === stepName);
+      assert.ok(step, `${file}:${jobName}:${stepName}`);
+      assert.equal(step.env?.OPENAI_API_KEY, expectedKey, `${file}:${jobName}:${stepName}`);
+    }
+  }
+  const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
+  const recoveryPublisher = materializer?.steps?.find(
+    (step) => step.name === "Publish materializer recovery action events",
+  );
+  assert.equal(
+    recoveryPublisher?.env?.CLAWSWEEPER_STATE_REPO_TOKEN,
+    "${{ steps.state-token.outputs.token }}",
+  );
+  assert.equal(recoveryPublisher?.env?.CLAWSWEEPER_MODEL_RECOVERY_ENABLED, "0");
+  assert.equal(recoveryPublisher?.env?.OPENAI_API_KEY, undefined);
+
+  const sweep = byFile.get(".github/workflows/sweep.yml");
+  const proofPublisher = sweep?.jobs?.["publish-apply-proof-action-ledger"];
+  assert.equal(proofPublisher?.env?.CLAWSWEEPER_MODEL_RECOVERY_ENABLED, "0");
+  const applyEventPublisher = sweep?.jobs?.["apply-existing"]?.steps?.find(
+    (step) => step.name === "Publish apply action events",
+  );
+  assert.equal(applyEventPublisher?.env?.CLAWSWEEPER_MODEL_RECOVERY_ENABLED, "0");
+  assert.equal(applyEventPublisher?.env?.OPENAI_API_KEY, undefined);
+});
+
 test("only the exact-review batch publisher requests priority admission", () => {
   const prioritySetups: string[] = [];
   for (const { file, workflow } of workflows()) {
@@ -111,7 +171,7 @@ test("trusted generated-state mutation steps receive a step-scoped coordinator c
   }
   assert.equal(
     publishers,
-    35,
+    36,
     "new or removed generated-state publication surfaces require an explicit credential audit",
   );
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1057,7 +1057,7 @@ test("broad record publishers isolate tuple reconciliation from status and auxil
   }
 });
 
-test("apply workflow isolates Codex proof from the credentialed mutation runner", () => {
+test("apply workflow isolates proof Codex and limits mutation Codex to model-guided recovery", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const workflowConcurrency = workflow.slice(
     workflow.indexOf("\nconcurrency:"),
@@ -1149,7 +1149,11 @@ test("apply workflow isolates Codex proof from the credentialed mutation runner"
   );
   assert.doesNotMatch(applyCondition, /needs\.apply-proof\.result/);
   assert.doesNotMatch(applyCondition, /needs\.publish-apply-proof-action-ledger/);
-  assert.doesNotMatch(applyJob, /setup-codex|OPENAI_API_KEY|CLAWSWEEPER_INTERNAL_MODEL/);
+  assert.match(applyJob, /CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"/);
+  assert.match(applyJob, /OPENAI_API_KEY: \$\{\{ secrets\.OPENAI_API_KEY \}\}/);
+  assert.match(applyJob, /uses: \.\/\.github\/actions\/setup-codex/);
+  assert.match(applyJob, /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ secrets\.CLAWSWEEPER_MODEL \}\}/);
+  assert.doesNotMatch(applyJob, /--codex-model|--codex-reasoning-effort/);
   assert.match(applyJob, /Create target write token/);
   assert.match(applyJob, /Create state token/);
   assert.match(applyJob, /actions\/download-artifact@v8/);


### PR DESCRIPTION
First conversion under VISION.md's 'abundant intelligence, scarce trust' stance. Git-failure recovery was hardcoded ladders (deepen → unshallow → rebuild) — guesses tuned to last week's failures. Now Codex diagnoses the failure and returns a plan drawn ONLY from an allowlisted vocabulary (fetch_object, refetch_depth1, deepen ≤64, unshallow, rebuild_on_remote_head, reset_to_remote, retry_push, defer_to_next_run, give_up), validated hard before execution — no model output reaches a shell. Diagnosis, plan, and outcome land in the action ledger so maintainers can read why recovery did what it did.

Trust boundary stays code: strict schema validation, secret redaction, step-scoped model keys, and the existing deterministic ladders remain as the fallback whenever the model path is disabled, unauthenticated, slow, or returns anything invalid.

Validation: 8/8 advisor tests, 84 focused tests, git-publish 59/59 applicable, build/lint/format green, autoreview clean, TruffleHog clean.