### PR TITLE
fix: recover state publication after commit_refs failures

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -2313,6 +2313,13 @@ function pushPublishedCommit(
     renewStatePublishLease(lease, "before branch publication");
   }
   lease.coordinator?.assertActive();
+  const sourceCommit = receiptRef ? runGit(["rev-parse", source], { quiet: true }).trim() : null;
+  const expectedReceiptOid = receiptRef ? remoteRefOid(remote, receiptRef) : null;
+  if (receiptRef && expectedReceiptOid && expectedReceiptOid !== sourceCommit) {
+    throw new StatePublishContentionError(
+      `State batch receipt ${receiptRef} changed before branch publication`,
+    );
+  }
 
   const renewedOid = createStatePublishLeaseCommit({
     branch: lease.branch,
@@ -2326,7 +2333,7 @@ function pushPublishedCommit(
       "push",
       "--atomic",
       `--force-with-lease=${lease.ref}:${lease.oid}`,
-      ...(receiptRef ? [`--force-with-lease=${receiptRef}:`] : []),
+      ...(receiptRef ? [`--force-with-lease=${receiptRef}:${expectedReceiptOid ?? ""}`] : []),
       lease.remote,
       `${source}:${branch}`,
       `${renewedOid}:${lease.ref}`,
@@ -2337,10 +2344,10 @@ function pushPublishedCommit(
   if (pushed.status !== 0) {
     const currentLeaseOid = remoteRefOid(remote, lease.ref);
     if (currentLeaseOid === renewedOid) {
-      const sourceCommit = runGit(["rev-parse", source], { quiet: true }).trim();
+      const publishedCommit = sourceCommit ?? runGit(["rev-parse", source], { quiet: true }).trim();
       if (
-        remoteRefOid(remote, `refs/heads/${branch}`) === sourceCommit &&
-        (!receiptRef || remoteRefOid(remote, receiptRef) === sourceCommit)
+        remoteRefOid(remote, `refs/heads/${branch}`) === publishedCommit &&
+        (!receiptRef || remoteRefOid(remote, receiptRef) === publishedCommit)
       ) {
         lease.oid = renewedOid;
         lease.expiresAtMs = Date.now() + lease.ttlMs;
@@ -2352,7 +2359,14 @@ function pushPublishedCommit(
         "State publish renewed its owner lease without the branch; recovering the lost state race",
       );
       if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
-        return pushStateAndReceiptAfterCommitRefsFailure(source, remote, branch, receiptRef, lease);
+        return pushStateAndReceiptAfterCommitRefsFailure(
+          source,
+          remote,
+          branch,
+          receiptRef,
+          expectedReceiptOid,
+          lease,
+        );
       }
       return pushed;
     }
@@ -2363,7 +2377,14 @@ function pushPublishedCommit(
     }
     if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
       renewStatePublishLease(lease, "before commit_refs recovery");
-      return pushStateAndReceiptAfterCommitRefsFailure(source, remote, branch, receiptRef, lease);
+      return pushStateAndReceiptAfterCommitRefsFailure(
+        source,
+        remote,
+        branch,
+        receiptRef,
+        expectedReceiptOid,
+        lease,
+      );
     }
     return pushed;
   }
@@ -2383,13 +2404,16 @@ function pushStateAndReceiptAfterCommitRefsFailure(
   remote: string,
   branch: string,
   receiptRef: string,
+  expectedReceiptOid: string | null,
   lease: StatePublishLease,
 ): GitRunResult {
   lease.coordinator?.assertActive();
   const sourceCommit = runGit(["rev-parse", source], { quiet: true }).trim();
-  const remoteBranchOid = remoteRefOid(remote, `refs/heads/${branch}`);
-  const remoteReceiptOid = remoteRefOid(remote, receiptRef);
-  if (remoteReceiptOid && remoteReceiptOid !== sourceCommit) {
+  const sourceParent = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
+  const branchRef = `refs/heads/${branch}`;
+  let remoteBranchOid = remoteRefOid(remote, branchRef);
+  let remoteReceiptOid = remoteRefOid(remote, receiptRef);
+  if (remoteReceiptOid !== expectedReceiptOid && remoteReceiptOid !== sourceCommit) {
     throw new StatePublishContentionError(
       `State batch receipt ${receiptRef} changed before commit_refs recovery`,
     );
@@ -2397,29 +2421,59 @@ function pushStateAndReceiptAfterCommitRefsFailure(
   if (remoteBranchOid === sourceCommit && remoteReceiptOid === sourceCommit) {
     return { status: 0, stdout: "", stderr: "", timedOut: false };
   }
+  if (remoteBranchOid !== sourceCommit && remoteBranchOid !== sourceParent) {
+    throw new StatePublishContentionError(
+      `State branch ${branchRef} changed before commit_refs recovery`,
+    );
+  }
   if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
-    renewStatePublishLease(lease, "before commit_refs recovery push");
+    renewStatePublishLease(lease, "before commit_refs receipt recovery");
   }
   lease.coordinator?.assertActive();
 
   console.log(
-    "State publish retrying GitHub commit_refs failure with the lease held and an atomic state/receipt update",
+    "State publish retrying GitHub commit_refs failure with fenced single-ref receipt and state updates",
   );
-  const recovered = spawnGit(
-    [
-      "push",
-      "--atomic",
-      `--force-with-lease=${receiptRef}:${remoteReceiptOid ?? ""}`,
-      remote,
-      `${source}:${branch}`,
-      `${source}:${receiptRef}`,
-    ],
+  if (remoteReceiptOid !== sourceCommit) {
+    const receiptPush = spawnGit(
+      [
+        "push",
+        `--force-with-lease=${receiptRef}:${remoteReceiptOid ?? ""}`,
+        remote,
+        `${source}:${receiptRef}`,
+      ],
+      { allowFailure: true },
+    );
+    if (receiptPush.status !== 0 && remoteRefOid(remote, receiptRef) !== sourceCommit) {
+      return receiptPush;
+    }
+    remoteReceiptOid = sourceCommit;
+  }
+
+  if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
+    renewStatePublishLease(lease, "before commit_refs state recovery");
+  }
+  lease.coordinator?.assertActive();
+  remoteBranchOid = remoteRefOid(remote, branchRef);
+  if (remoteBranchOid === sourceCommit) {
+    console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+    return { status: 0, stdout: "", stderr: "", timedOut: false };
+  }
+  if (remoteBranchOid !== sourceParent) {
+    throw new StatePublishContentionError(
+      `State branch ${branchRef} changed during commit_refs recovery`,
+    );
+  }
+
+  const statePush = spawnGit(
+    ["push", `--force-with-lease=${branchRef}:${sourceParent}`, remote, `${source}:${branchRef}`],
     { allowFailure: true },
   );
-  if (recovered.status === 0) {
-    console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+  if (statePush.status !== 0 && remoteRefOid(remote, branchRef) !== sourceCommit) {
+    return statePush;
   }
-  return recovered;
+  console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+  return { ...statePush, status: 0 };
 }
 
 export function pushStateCommitUnderLease(

--- a/src/repair/state-publication-batch.ts
+++ b/src/repair/state-publication-batch.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import {
   measureGitProcesses,
@@ -29,6 +29,7 @@ export const STATE_PUBLICATION_BATCH_MAX_BYTES = 32 * 16 * 1024 * 1024;
 export const STATE_PUBLICATION_BATCH_MAX_PATH_BYTES = 128 * 1024;
 
 const STATE_FETCH_TIMEOUT_MS = 60_000;
+const STATE_RECEIPT_RECOVERY_DEEPEN = 512;
 const BATCH_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const GIT_OID_PATTERN = /^[a-f0-9]{40,64}$/;
 
@@ -122,6 +123,8 @@ function commitUnderLease(options: {
   hooks?: StateBatchCommitHooks;
 }): Pick<StateBatchCommitResult, "outcome" | "commitSha"> {
   const receiptRef = batchReceiptRef(options.batchId);
+  const remoteRef = fetchLatestState(options.remote, options.branch);
+  const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
   const recovered = findBatchReceipt(options.remote, receiptRef, options.batchId);
   if (recovered) {
     if (recovered.fingerprint !== options.fingerprint) {
@@ -129,11 +132,27 @@ function commitUnderLease(options: {
         `Batch id ${options.batchId} is already bound to a different mutation fingerprint`,
       );
     }
-    return { outcome: "already_committed", commitSha: recovered.commit };
+    const recoveredParent = runGit(["rev-parse", `${recovered.commit}^`], {
+      quiet: true,
+    }).trim();
+    if (
+      remoteCommit === recovered.commit ||
+      (remoteCommit !== recoveredParent &&
+        stateContainsCommit(options.remote, options.branch, remoteCommit, recovered.commit))
+    ) {
+      return { outcome: "already_committed", commitSha: recovered.commit };
+    }
+    if (remoteCommit === recoveredParent) {
+      options.hooks?.beforePush?.(recovered.commit);
+      pushStateCommitUnderLease(recovered.commit, options.remote, options.branch, receiptRef);
+      verifyRemoteCommit(options.remote, options.branch, receiptRef, recovered.commit);
+      options.hooks?.afterPush?.(recovered.commit);
+      return { outcome: "committed", commitSha: recovered.commit };
+    }
+    throw new StateMutationConflictError(
+      `Batch id ${options.batchId} has a prepared receipt but state advanced before retry`,
+    );
   }
-
-  const remoteRef = fetchLatestState(options.remote, options.branch);
-  const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
 
   const remoteEntries = readRemoteEntries(
     remoteCommit,
@@ -253,8 +272,8 @@ function findBatchReceipt(
   if (!receiptCommit || !GIT_OID_PATTERN.test(receiptCommit)) {
     throw new StateMutationConflictError(`State batch receipt ${receiptRef} is malformed`);
   }
-  if (spawnGit(["cat-file", "-e", `${receiptCommit}^{commit}`], { quiet: true }).status !== 0) {
-    runGit(["fetch", "--no-tags", "--depth=1", remote, receiptRef], {
+  if (spawnGit(["cat-file", "-e", `${receiptCommit}^1^{commit}`], { quiet: true }).status !== 0) {
+    runGit(["fetch", "--no-tags", "--depth=2", remote, receiptRef], {
       quiet: true,
       timeout: STATE_FETCH_TIMEOUT_MS,
     });
@@ -279,6 +298,78 @@ function findBatchReceipt(
     throw new StateMutationConflictError(`State batch receipt ${receiptRef} is malformed`);
   }
   return { commit, fingerprint };
+}
+
+function stateContainsCommit(
+  remote: string,
+  branch: string,
+  stateCommit: string,
+  candidateCommit: string,
+): boolean {
+  if (isAncestor(candidateCommit, stateCommit)) return true;
+  const recoveryRef = `refs/clawsweeper-recovery/state-receipts/${createHash("sha256")
+    .update(`${remote}\0${branch}\0${candidateCommit}`)
+    .digest("hex")}`;
+  const recoveryRefspec = `+refs/heads/${branch}:${recoveryRef}`;
+  try {
+    runGit(
+      ["fetch", "--no-tags", `--depth=${STATE_RECEIPT_RECOVERY_DEEPEN}`, remote, recoveryRefspec],
+      { quiet: true, timeout: STATE_FETCH_TIMEOUT_MS },
+    );
+    const inspectedStateCommit = runGit(["rev-parse", recoveryRef], { quiet: true }).trim();
+    if (isAncestor(candidateCommit, inspectedStateCommit)) return true;
+    let shallowBoundaries = reachableShallowBoundaries(inspectedStateCommit);
+    while (shallowBoundaries.length > 0) {
+      runGit(
+        [
+          "fetch",
+          "--no-tags",
+          `--deepen=${STATE_RECEIPT_RECOVERY_DEEPEN}`,
+          remote,
+          recoveryRefspec,
+        ],
+        { quiet: true, timeout: STATE_FETCH_TIMEOUT_MS },
+      );
+      if (isAncestor(candidateCommit, inspectedStateCommit)) return true;
+      const nextBoundaries = reachableShallowBoundaries(inspectedStateCommit);
+      if (
+        nextBoundaries.length > 0 &&
+        nextBoundaries.length === shallowBoundaries.length &&
+        nextBoundaries.every((boundary, index) => boundary === shallowBoundaries[index])
+      ) {
+        throw new Error("State batch receipt recovery could not deepen shallow state history");
+      }
+      shallowBoundaries = nextBoundaries;
+    }
+    return false;
+  } finally {
+    spawnGit(["update-ref", "-d", recoveryRef], { allowFailure: true, quiet: true });
+  }
+}
+
+function reachableShallowBoundaries(stateCommit: string): string[] {
+  const gitPath = runGit(["rev-parse", "--git-path", "shallow"], { quiet: true }).trim();
+  const shallowPath = resolve(publishRoot() ?? process.cwd(), gitPath);
+  if (!existsSync(shallowPath)) return [];
+  return readFileSync(shallowPath, "utf8")
+    .split("\n")
+    .map((boundary) => boundary.trim())
+    .filter(
+      (boundary) =>
+        GIT_OID_PATTERN.test(boundary) &&
+        (boundary === stateCommit || isAncestor(boundary, stateCommit)),
+    )
+    .sort(compareCanonicalText);
+}
+
+function isAncestor(candidateCommit: string, stateCommit: string): boolean {
+  const result = spawnGit(["merge-base", "--is-ancestor", candidateCommit, stateCommit], {
+    allowFailure: true,
+    quiet: true,
+  });
+  if (result.status === 0) return true;
+  if (result.status === 1) return false;
+  throw new Error(result.stderr.trim() || "Failed to inspect state batch ancestry");
 }
 
 function readRemoteEntries(

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -155,10 +155,10 @@ test("batch commits use the ClawSweeper identity without repository or global Gi
   );
 });
 
-test("GitHub three-ref commit_refs rejection falls back to an atomic state and receipt push", () => {
+test("GitHub multi-ref commit_refs rejection falls back to fenced single-ref pushes", () => {
   const fixture = createRepositoryFixture();
   const plan = newItemPlan(fixture, 25);
-  installThreeRefCommitRefsFailure(fixture.origin);
+  installMultiRefCommitRefsFailure(fixture.origin);
 
   const result = withStateEnvironment(fixture.work, () =>
     commitPreparedStateBatch({
@@ -178,6 +178,177 @@ test("GitHub three-ref commit_refs rejection falls back to an atomic state and r
   assert.equal(
     git(fixture.origin, "rev-parse", "state").trim(),
     git(fixture.origin, "rev-parse", receiptRef).trim(),
+  );
+});
+
+test("a receipt created after lookup cannot be overwritten", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 29);
+  const batchId = "concurrent-receipt";
+  const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
+    .update(batchId)
+    .digest("hex")}`;
+  const stateBefore = git(fixture.origin, "rev-parse", "state").trim();
+  const tree = git(fixture.origin, "rev-parse", "state^{tree}").trim();
+  const foreignReceipt = git(
+    fixture.work,
+    "commit-tree",
+    tree,
+    "-p",
+    stateBefore,
+    "-m",
+    "foreign receipt",
+  ).trim();
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId,
+          plans: [plan],
+          hooks: {
+            beforePush: () => {
+              git(fixture.work, "push", "origin", `${foreignReceipt}:${receiptRef}`);
+            },
+          },
+        }),
+      ),
+    /receipt .* changed before branch publication/,
+  );
+
+  assert.equal(git(fixture.origin, "rev-parse", receiptRef).trim(), foreignReceipt);
+  assert.equal(git(fixture.origin, "rev-parse", "state").trim(), stateBefore);
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/29.md", true),
+    "",
+  );
+});
+
+test("a prepared receipt resumes the same batch without a blind second state commit", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 26);
+  const before = git(fixture.origin, "rev-list", "--count", "state").trim();
+  installMultiRefAndFirstStateFailure(fixture.origin);
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "github-single-ref-resume",
+          plans: [plan],
+        }),
+      ),
+    /simulated state push failure/,
+  );
+
+  const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
+    .update("github-single-ref-resume")
+    .digest("hex")}`;
+  assert.notEqual(git(fixture.origin, "rev-parse", receiptRef, true), "");
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/26.md", true),
+    "",
+  );
+
+  const recovered = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId: "github-single-ref-resume",
+      plans: [plan],
+    }),
+  );
+
+  assert.equal(recovered.outcome, "committed");
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/26.md"),
+    "item 26\n",
+  );
+  assert.equal(
+    git(fixture.origin, "rev-list", "--count", "state").trim(),
+    String(Number(before) + 1),
+  );
+  assert.equal(
+    git(fixture.origin, "rev-parse", "state").trim(),
+    git(fixture.origin, "rev-parse", receiptRef).trim(),
+  );
+});
+
+test("a prepared receipt resumes from a fresh shallow state checkout", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 28);
+  installMultiRefAndFirstStateFailure(fixture.origin);
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "github-single-ref-shallow-resume",
+          plans: [plan],
+        }),
+      ),
+    /simulated state push failure/,
+  );
+
+  const shallow = path.join(fixture.root, "shallow-retry");
+  git(fixture.root, "clone", "--depth=1", "--branch", "state", `file://${fixture.origin}`, shallow);
+  configureUser(shallow);
+  const transferredBlob = path.join(fixture.root, "transferred-item-28.md");
+  fs.writeFileSync(transferredBlob, "item 28\n");
+  assert.equal(
+    git(shallow, "hash-object", "-w", transferredBlob).trim(),
+    plan.operations[0]?.targetOid,
+  );
+
+  const recovered = withStateEnvironment(shallow, () =>
+    commitPreparedStateBatch({
+      batchId: "github-single-ref-shallow-resume",
+      plans: [plan],
+    }),
+  );
+
+  assert.equal(recovered.outcome, "committed");
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/28.md"),
+    "item 28\n",
+  );
+});
+
+test("a prepared receipt fails closed when state advances before retry", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 27);
+  installMultiRefAndFirstStateFailure(fixture.origin);
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "github-single-ref-drift",
+          plans: [plan],
+        }),
+      ),
+    /simulated state push failure/,
+  );
+
+  publishSibling(fixture, "results/intervening.json", '{"writer":"ordinary"}\n');
+
+  assert.throws(
+    () =>
+      withStateEnvironment(fixture.work, () =>
+        commitPreparedStateBatch({
+          batchId: "github-single-ref-drift",
+          plans: [plan],
+        }),
+      ),
+    (error: unknown) =>
+      error instanceof StateMutationConflictError &&
+      /prepared receipt.*state advanced/i.test(error.message),
+  );
+  assert.equal(
+    git(fixture.origin, "show", "state:results/intervening.json"),
+    '{"writer":"ordinary"}\n',
+  );
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/27.md", true),
+    "",
   );
 });
 
@@ -373,7 +544,7 @@ test("a reused batch id cannot acknowledge a different mutation payload", () => 
   );
 });
 
-test("batch receipt recovery remains durable beyond 256 newer state commits", () => {
+test("batch receipt recovery deepens past 512 newer commits in a fresh shallow checkout", () => {
   const fixture = createRepositoryFixture();
   const plan = newItemPlan(fixture, 20);
   const committed = withStateEnvironment(fixture.work, () =>
@@ -386,7 +557,7 @@ test("batch receipt recovery remains durable beyond 256 newer state commits", ()
   let parent = git(sibling, "rev-parse", "HEAD").trim();
   // Only ancestry depth matters here. Plumbing commits avoid Git auto-maintenance
   // racing hundreds of disposable worktree/index updates on shared CI runners.
-  for (let index = 0; index < 300; index += 1) {
+  for (let index = 0; index < 700; index += 1) {
     parent = git(
       sibling,
       "commit-tree",
@@ -399,7 +570,10 @@ test("batch receipt recovery remains durable beyond 256 newer state commits", ()
   }
   git(sibling, "push", "origin", `${parent}:state`);
 
-  const recovered = withStateEnvironment(fixture.work, () =>
+  const shallow = path.join(fixture.root, "receipt-history-shallow");
+  git(fixture.root, "clone", "--depth=1", "--branch", "state", `file://${fixture.origin}`, shallow);
+  configureUser(shallow);
+  const recovered = withStateEnvironment(shallow, () =>
     commitPreparedStateBatch({ batchId: "durable-receipt", plans: [plan] }),
   );
 
@@ -643,7 +817,7 @@ function publishSibling(fixture: RepositoryFixture, file: string, content: strin
   git(sibling, "push", "origin", "HEAD:state");
 }
 
-function installThreeRefCommitRefsFailure(origin: string): void {
+function installMultiRefCommitRefsFailure(origin: string): void {
   const hook = path.join(origin, "hooks", "pre-receive");
   fs.writeFileSync(
     hook,
@@ -653,8 +827,37 @@ function installThreeRefCommitRefsFailure(origin: string): void {
       "while read -r old_oid new_oid ref_name; do",
       "  count=$((count + 1))",
       "done",
-      'if [ "$count" -ge 3 ]; then',
+      'if [ "$count" -ge 2 ]; then',
       '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(hook, 0o755);
+}
+
+function installMultiRefAndFirstStateFailure(origin: string): void {
+  const hook = path.join(origin, "hooks", "pre-receive");
+  const rejectedStateMarker = path.join(origin, "hooks", "rejected-state-once");
+  fs.writeFileSync(
+    hook,
+    [
+      "#!/bin/sh",
+      "count=0",
+      'only_ref=""',
+      "while read -r old_oid new_oid ref_name; do",
+      "  count=$((count + 1))",
+      '  only_ref="$ref_name"',
+      "done",
+      'if [ "$count" -ge 2 ]; then',
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      `if [ "$only_ref" = "refs/heads/state" ] && [ ! -f '${rejectedStateMarker}' ]; then`,
+      `  touch '${rejectedStateMarker}'`,
+      '  echo "simulated state push failure" >&2',
       "  exit 1",
       "fi",
       "exit 0",


### PR DESCRIPTION
## Summary

- recover GitHub `commit_refs` transaction failures with fenced single-ref receipt and state pushes while retaining the state writer lease
- resume interrupted prepared receipts without creating a second state commit, and fail closed on receipt or state drift
- hydrate shallow state history to distinguish already-committed receipts from conflicting prepared receipts
- prevent a receipt that appears after lookup from being overwritten by a different publication

This unblocks durable review publication for [openclaw/openclaw#112547](https://github.com/openclaw/openclaw/pull/112547).

## Validation

- `node --test test/repair/state-publication-batch.test.ts` (25 passed)
- `pnpm run check:static`
- `pnpm run build:all`
- `pnpm run lint`
- `git diff --check`
- autoreview clean after resolving its receipt-race finding
- `pnpm run check` attempted locally; it reached 8 known macOS baseline failures also reproduced on untouched `origin/main` (server-merge fixture Git config, five Linux containment imports, `/var` vs `/private/var`, and symlink runtime identity). Hosted Linux CI remains the authoritative full-suite gate.
