### PR TITLE
fix(publication): retry commit_refs recovery pushes

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -138,6 +138,7 @@ const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = (() => {
 })();
 const STATE_PUBLISH_LEASE_WAIT_MS = 1_000;
 const STATE_PUBLISH_LEASE_MAX_WAIT_MS = 5_000;
+const STATE_PUBLISH_COMMIT_REFS_RENEW_ATTEMPTS = 3;
 const STATE_PUBLISH_PRIORITY_INTENT_ATTEMPT = 2;
 const STATE_PUBLISH_PRIORITY_INTENT_MAX_TTL_MS = 5 * 60_000;
 const STATE_PUBLISH_OWNER_PATTERN =
@@ -2241,42 +2242,57 @@ function releaseStatePublishLease(lease: StatePublishLease): boolean {
   }
 }
 
-function renewStatePublishLease(lease: StatePublishLease, reason: string): void {
-  lease.coordinator?.assertActive();
-  const renewedOid = createStatePublishLeaseCommit({
-    branch: lease.branch,
-    owner: lease.owner,
-    ttlMs: lease.ttlMs,
-    coordinator: lease.coordinator,
-  });
-  lease.cleanup?.track(renewedOid);
-  const renewed = spawnGit(
-    [
-      "push",
-      `--force-with-lease=${lease.ref}:${lease.oid}`,
-      lease.remote,
-      `${renewedOid}:${lease.ref}`,
-    ],
-    { allowFailure: true, quiet: true, timeout: PUBLISH_FETCH_TIMEOUT_MS },
-  );
-  if (renewed.timedOut) {
-    throw new GitCommandTimeoutError(["push"], PUBLISH_FETCH_TIMEOUT_MS);
-  }
-  if (renewed.status !== 0) {
-    const currentLeaseOid = remoteRefOid(lease.remote, lease.ref);
-    if (currentLeaseOid !== renewedOid) {
-      if (currentLeaseOid !== lease.oid) {
-        throw new StatePublishContentionError(
-          `State publish lease ownership changed while renewing ${reason}`,
-        );
-      }
-      throw new StatePublishContentionError(`Failed to renew state publish lease ${reason}`);
+function renewStatePublishLease(
+  lease: StatePublishLease,
+  reason: string,
+  options: { commitRefsAttempts?: number } = {},
+): void {
+  const attempts = Math.max(1, options.commitRefsAttempts ?? 1);
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    lease.coordinator?.assertActive();
+    const renewedOid = createStatePublishLeaseCommit({
+      branch: lease.branch,
+      owner: lease.owner,
+      ttlMs: lease.ttlMs,
+      coordinator: lease.coordinator,
+    });
+    lease.cleanup?.track(renewedOid);
+    const renewed = spawnGit(
+      [
+        "push",
+        `--force-with-lease=${lease.ref}:${lease.oid}`,
+        lease.remote,
+        `${renewedOid}:${lease.ref}`,
+      ],
+      { allowFailure: true, quiet: true, timeout: PUBLISH_FETCH_TIMEOUT_MS },
+    );
+    if (renewed.timedOut) {
+      throw new GitCommandTimeoutError(["push"], PUBLISH_FETCH_TIMEOUT_MS);
     }
+    if (renewed.status !== 0) {
+      const currentLeaseOid = remoteRefOid(lease.remote, lease.ref);
+      if (currentLeaseOid !== renewedOid) {
+        if (currentLeaseOid !== lease.oid) {
+          throw new StatePublishContentionError(
+            `State publish lease ownership changed while renewing ${reason}`,
+          );
+        }
+        if (attempt < attempts && isCommitRefsTransactionFailure(renewed)) {
+          console.log(
+            `State publish lease renewal hit GitHub commit_refs ${reason}; retrying attempt=${attempt + 1}/${attempts}`,
+          );
+          sleep(Math.min(STATE_PUBLISH_LEASE_WAIT_MS * attempt, STATE_PUBLISH_LEASE_MAX_WAIT_MS));
+          continue;
+        }
+        throw new StatePublishContentionError(`Failed to renew state publish lease ${reason}`);
+      }
+    }
+    lease.oid = renewedOid;
+    lease.expiresAtMs = Date.now() + lease.ttlMs;
+    activeStateWriterTelemetry?.recordRenewal();
+    console.log(`Renewed state publish lease owner=${lease.owner} ${reason}`);
+    return;
   }
-  lease.oid = renewedOid;
-  lease.expiresAtMs = Date.now() + lease.ttlMs;
-  activeStateWriterTelemetry?.recordRenewal();
-  console.log(`Renewed state publish lease owner=${lease.owner} ${reason}`);
 }
 
 function remoteRefOid(remote: string, ref: string): string | null {
@@ -2386,7 +2402,6 @@ function pushPublishedCommit(
       );
     }
     if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
-      renewStatePublishLease(lease, "before commit_refs recovery");
       return pushStateAndReceiptAfterCommitRefsFailure(
         source,
         remote,
@@ -2436,15 +2451,15 @@ function pushStateAndReceiptAfterCommitRefsFailure(
       `State branch ${branchRef} changed before commit_refs recovery`,
     );
   }
-  if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
-    renewStatePublishLease(lease, "before commit_refs receipt recovery");
-  }
   lease.coordinator?.assertActive();
 
   console.log(
     "State publish retrying GitHub commit_refs failure with fenced single-ref receipt and state updates",
   );
   if (remoteReceiptOid !== sourceCommit) {
+    // A batch-specific receipt may safely outlive this lease. A later retry
+    // resumes only while state still equals sourceParent and otherwise fails
+    // closed, so persist that progress before renewing the shared-state fence.
     const receiptPush = spawnGit(
       [
         "push",
@@ -2460,9 +2475,21 @@ function pushStateAndReceiptAfterCommitRefsFailure(
     remoteReceiptOid = sourceCommit;
   }
 
-  if (lease.expiresAtMs - Date.now() <= STATE_PUBLISH_LEASE_RENEW_THRESHOLD_MS) {
-    renewStatePublishLease(lease, "before commit_refs state recovery");
+  lease.coordinator?.assertActive();
+  remoteBranchOid = remoteRefOid(remote, branchRef);
+  if (remoteBranchOid === sourceCommit) {
+    console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+    return { status: 0, stdout: "", stderr: "", timedOut: false };
   }
+  if (remoteBranchOid !== sourceParent) {
+    throw new StatePublishContentionError(
+      `State branch ${branchRef} changed during commit_refs recovery`,
+    );
+  }
+
+  renewStatePublishLease(lease, "before commit_refs state recovery", {
+    commitRefsAttempts: STATE_PUBLISH_COMMIT_REFS_RENEW_ATTEMPTS,
+  });
   lease.coordinator?.assertActive();
   remoteBranchOid = remoteRefOid(remote, branchRef);
   if (remoteBranchOid === sourceCommit) {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -138,7 +138,7 @@ const STATE_PUBLISH_LEASE_ACQUIRE_TIMEOUT_MS = (() => {
 })();
 const STATE_PUBLISH_LEASE_WAIT_MS = 1_000;
 const STATE_PUBLISH_LEASE_MAX_WAIT_MS = 5_000;
-const STATE_PUBLISH_COMMIT_REFS_RENEW_ATTEMPTS = 3;
+const STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS = 3;
 const STATE_PUBLISH_PRIORITY_INTENT_ATTEMPT = 2;
 const STATE_PUBLISH_PRIORITY_INTENT_MAX_TTL_MS = 5 * 60_000;
 const STATE_PUBLISH_OWNER_PATTERN =
@@ -2460,19 +2460,43 @@ function pushStateAndReceiptAfterCommitRefsFailure(
     // A batch-specific receipt may safely outlive this lease. A later retry
     // resumes only while state still equals sourceParent and otherwise fails
     // closed, so persist that progress before renewing the shared-state fence.
-    const receiptPush = spawnGit(
-      [
-        "push",
-        `--force-with-lease=${receiptRef}:${remoteReceiptOid ?? ""}`,
-        remote,
-        `${source}:${receiptRef}`,
-      ],
-      { allowFailure: true },
-    );
-    if (receiptPush.status !== 0 && remoteRefOid(remote, receiptRef) !== sourceCommit) {
+    for (let attempt = 1; attempt <= STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS; attempt += 1) {
+      lease.coordinator?.assertActive();
+      const receiptPush = spawnGit(
+        [
+          "push",
+          `--force-with-lease=${receiptRef}:${remoteReceiptOid ?? ""}`,
+          remote,
+          `${source}:${receiptRef}`,
+        ],
+        { allowFailure: true },
+      );
+      if (receiptPush.status === 0) {
+        remoteReceiptOid = sourceCommit;
+        break;
+      }
+      const currentReceiptOid = remoteRefOid(remote, receiptRef);
+      if (currentReceiptOid === sourceCommit) {
+        remoteReceiptOid = sourceCommit;
+        break;
+      }
+      if (currentReceiptOid !== remoteReceiptOid) {
+        throw new StatePublishContentionError(
+          `State batch receipt ${receiptRef} changed during commit_refs recovery`,
+        );
+      }
+      if (
+        attempt < STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS &&
+        isCommitRefsTransactionFailure(receiptPush)
+      ) {
+        console.log(
+          `State batch receipt push hit GitHub commit_refs; retrying attempt=${attempt + 1}/${STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS}`,
+        );
+        sleep(Math.min(STATE_PUBLISH_LEASE_WAIT_MS * attempt, STATE_PUBLISH_LEASE_MAX_WAIT_MS));
+        continue;
+      }
       return receiptPush;
     }
-    remoteReceiptOid = sourceCommit;
   }
 
   lease.coordinator?.assertActive();
@@ -2488,7 +2512,7 @@ function pushStateAndReceiptAfterCommitRefsFailure(
   }
 
   renewStatePublishLease(lease, "before commit_refs state recovery", {
-    commitRefsAttempts: STATE_PUBLISH_COMMIT_REFS_RENEW_ATTEMPTS,
+    commitRefsAttempts: STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS,
   });
   lease.coordinator?.assertActive();
   remoteBranchOid = remoteRefOid(remote, branchRef);

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -181,6 +181,37 @@ test("GitHub multi-ref commit_refs rejection falls back to fenced single-ref pus
   );
 });
 
+test("commit_refs recovery survives one transient lease renewal rejection", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 30);
+  const batchId = "github-lease-renewal-retry";
+  const rejectedRenewalMarker = installMultiRefAndFirstLeaseRenewalCommitRefsFailure(
+    fixture.origin,
+    batchId,
+  );
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId,
+      plans: [plan],
+    }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(fs.existsSync(rejectedRenewalMarker), true);
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/30.md"),
+    "item 30\n",
+  );
+  const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
+    .update(batchId)
+    .digest("hex")}`;
+  assert.equal(
+    git(fixture.origin, "rev-parse", "state").trim(),
+    git(fixture.origin, "rev-parse", receiptRef).trim(),
+  );
+});
+
 test("a receipt created after lookup cannot be overwritten", () => {
   const fixture = createRepositoryFixture();
   const plan = newItemPlan(fixture, 29);
@@ -836,6 +867,61 @@ function installMultiRefCommitRefsFailure(origin: string): void {
     ].join("\n"),
   );
   fs.chmodSync(hook, 0o755);
+}
+
+function installMultiRefAndFirstLeaseRenewalCommitRefsFailure(
+  origin: string,
+  batchId: string,
+): string {
+  const hook = path.join(origin, "hooks", "pre-receive");
+  const rejectedRenewalMarker = path.join(origin, "hooks", "rejected-lease-renewal-once");
+  const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
+    .update(batchId)
+    .digest("hex")}`;
+  fs.writeFileSync(
+    hook,
+    [
+      "#!/bin/sh",
+      "count=0",
+      'only_old_oid=""',
+      'only_new_oid=""',
+      'only_ref=""',
+      "while read -r old_oid new_oid ref_name; do",
+      "  count=$((count + 1))",
+      '  only_old_oid="$old_oid"',
+      '  only_new_oid="$new_oid"',
+      '  only_ref="$ref_name"',
+      "done",
+      'if [ "$count" -ge 2 ]; then',
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      'case "$only_old_oid" in',
+      "  *[!0]*) old_oid_is_zero=0 ;;",
+      "  *) old_oid_is_zero=1 ;;",
+      "esac",
+      'case "$only_new_oid" in',
+      "  *[!0]*) new_oid_is_zero=0 ;;",
+      "  *) new_oid_is_zero=1 ;;",
+      "esac",
+      'if [ "$only_ref" = "refs/heads/clawsweeper-publish-lease/state" ] &&',
+      '   [ "$old_oid_is_zero" -eq 0 ] && [ "$new_oid_is_zero" -eq 0 ]; then',
+      `  if ! git --git-dir='${origin}' show-ref --verify --quiet '${receiptRef}'; then`,
+      '    echo "lease renewal occurred before receipt publication" >&2',
+      "    exit 1",
+      "  fi",
+      `  if [ ! -f '${rejectedRenewalMarker}' ]; then`,
+      `    touch '${rejectedRenewalMarker}'`,
+      '    echo "fatal error in commit_refs" >&2',
+      "    exit 1",
+      "  fi",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(hook, 0o755);
+  return rejectedRenewalMarker;
 }
 
 function installMultiRefAndFirstStateFailure(origin: string): void {

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -181,11 +181,11 @@ test("GitHub multi-ref commit_refs rejection falls back to fenced single-ref pus
   );
 });
 
-test("commit_refs recovery survives one transient lease renewal rejection", () => {
+test("commit_refs recovery retries transient receipt and lease renewal rejections", () => {
   const fixture = createRepositoryFixture();
   const plan = newItemPlan(fixture, 30);
-  const batchId = "github-lease-renewal-retry";
-  const rejectedRenewalMarker = installMultiRefAndFirstLeaseRenewalCommitRefsFailure(
+  const batchId = "github-single-ref-retries";
+  const rejectedMarkers = installMultiRefAndFirstSingleRefCommitRefsFailures(
     fixture.origin,
     batchId,
   );
@@ -198,7 +198,8 @@ test("commit_refs recovery survives one transient lease renewal rejection", () =
   );
 
   assert.equal(result.outcome, "committed");
-  assert.equal(fs.existsSync(rejectedRenewalMarker), true);
+  assert.equal(fs.existsSync(rejectedMarkers.receipt), true);
+  assert.equal(fs.existsSync(rejectedMarkers.renewal), true);
   assert.equal(
     git(fixture.origin, "show", "state:records/openclaw-openclaw/items/30.md"),
     "item 30\n",
@@ -869,11 +870,12 @@ function installMultiRefCommitRefsFailure(origin: string): void {
   fs.chmodSync(hook, 0o755);
 }
 
-function installMultiRefAndFirstLeaseRenewalCommitRefsFailure(
+function installMultiRefAndFirstSingleRefCommitRefsFailures(
   origin: string,
   batchId: string,
-): string {
+): { receipt: string; renewal: string } {
   const hook = path.join(origin, "hooks", "pre-receive");
+  const rejectedReceiptMarker = path.join(origin, "hooks", "rejected-receipt-once");
   const rejectedRenewalMarker = path.join(origin, "hooks", "rejected-lease-renewal-once");
   const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
     .update(batchId)
@@ -893,6 +895,11 @@ function installMultiRefAndFirstLeaseRenewalCommitRefsFailure(
       '  only_ref="$ref_name"',
       "done",
       'if [ "$count" -ge 2 ]; then',
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      `if [ "$only_ref" = "${receiptRef}" ] && [ ! -f '${rejectedReceiptMarker}' ]; then`,
+      `  touch '${rejectedReceiptMarker}'`,
       '  echo "fatal error in commit_refs" >&2',
       "  exit 1",
       "fi",
@@ -921,7 +928,7 @@ function installMultiRefAndFirstLeaseRenewalCommitRefsFailure(
     ].join("\n"),
   );
   fs.chmodSync(hook, 0o755);
-  return rejectedRenewalMarker;
+  return { receipt: rejectedReceiptMarker, renewal: rejectedRenewalMarker };
 }
 
 function installMultiRefAndFirstStateFailure(origin: string): void {


### PR DESCRIPTION
## Summary
- persist the batch-specific receipt before renewing the shared-state lease during `commit_refs` recovery
- retry both the batch receipt push and lease renewal up to three times only for GitHub `commit_refs` failures
- re-read remote refs after ambiguous failures, accept an already-landed intended commit, and fail closed on competing changes
- recheck the state parent after renewal and preserve the durable writer coordinator fence
- add a regression for the live sequence: atomic rejection, receipt rejection, lease-renewal rejection, then successful state publication

## Live evidence
- merged-main publisher run https://github.com/openclaw/clawsweeper/actions/runs/29928105752 recovered the initial atomic failure and renewed the lease, then GitHub rejected the single-ref batch receipt push with `remote: fatal error in commit_refs`
- cleanup released the lease, writer ticket, and unfinished members; OpenClaw PR #112547 remained unchanged and frozen

## Validation
- `pnpm run build:repair && node --test --test-concurrency=1 test/repair/state-publication-batch.test.ts` (26 passed)
- `pnpm exec oxfmt --check src/repair/git-publish.ts test/repair/state-publication-batch.test.ts`
- `pnpm exec oxlint src/repair/git-publish.ts test/repair/state-publication-batch.test.ts --tsconfig tsconfig.repair.json --deny-warnings --report-unused-disable-directives -D correctness`
- structured autoreview: clean

`pnpm run check` was also exercised locally. Its changed publication coverage passed; the remaining macOS failures are existing platform, timing, and path-alias baselines, including the adjacent immutable-ledger server-merge failure reproduced unchanged at `origin/main`. Exact-head hosted CI is the Linux full-gate proof.
