### PR TITLE
fix(materializer): fire at a cadence a cycle can finish

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -2,7 +2,10 @@ name: Materialize queued state
 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    # A cycle now drains up to 10k rows and can run for tens of minutes; a
+    # 5-minute schedule queued runs faster than they could execute (observed
+    # 2h14m wait for a slot). Fire at the cadence a cycle can actually finish.
+    - cron: "*/20 * * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The 5-minute schedule predates the larger cycles: with #785 (60m window) and #787 (10k rows) a cycle can run for tens of minutes, so scheduled runs queued faster than they executed — four stacked pending and the active run waited 2h14m for its slot, delaying every drain behind it. Schedule moves to every 20 minutes, matching what a cycle can actually finish; the serialized concurrency group is unchanged. Workflow tests green.