### PR TITLE
fix(materializer): checkout depth 50 so rebuild can reconcile

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -60,7 +60,12 @@ jobs:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           token: ${{ steps.state-token.outputs.token }}
-          fetch-depth: 1
+          # depth-1 cannot fast-forward or rebuild against a branch other
+          # writers keep advancing (non-fast-forward shallow push rejections,
+          # runs 29938808338 / 29957012043); a full clone of `state`'s own
+          # (large) history times out. 50 commits give the rebuild-on-remote-head
+          # path a real merge-base against recent advances while staying bounded.
+          fetch-depth: 50
 
       - uses: ./.github/actions/setup-pnpm
         with:


### PR DESCRIPTION
Root cause of the persistent materializer failure, finally isolated: not batch size (2.5k failed the same way as 10k) but the shallow checkout. depth-1 cannot fast-forward or rebuild against `state` while other writers advance it — every push dies `remote_branch_push_nonfastforward_shallow` and the model advisor correctly defers. A full clone of state's own (now-large) history times out; depth 50 gives the existing rebuild-on-remote-head path (#716) a real merge-base against recent advances while staying bounded. Workflow tests green.