### PR TITLE
fix(publication): coalesce duplicate result lineages

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -214,6 +214,7 @@ type ExactReviewQueueMetricTotals = {
     completed: number;
     published: number;
     superseded: number;
+    semanticDeduped: number;
     retried: number;
     deadLettered: number;
     refreshed: number;
@@ -228,6 +229,7 @@ type ExactReviewQueueMetricDelta = {
   publicationCompleted?: number;
   publicationPublished?: number;
   publicationSuperseded?: number;
+  publicationSemanticDeduped?: number;
   publicationRetried?: number;
   publicationDeadLettered?: number;
   publicationRefreshed?: number;
@@ -645,14 +647,20 @@ export class ExactReviewQueue {
         );
         let supersededPublications = 0;
         if (incomingPublicationRevision) {
+          const incomingLineage = exactReviewPublicationLineage(decision);
           const matching = Object.values(state.items)
-            .map((item) => ({ item, revision: exactReviewPublicationRevision(item.decision) }))
+            .map((item) => ({
+              item,
+              revision: exactReviewPublicationRevision(item.decision),
+              lineage: exactReviewPublicationLineage(item.decision),
+            }))
             .filter(
               (
                 entry,
               ): entry is {
                 item: ExactReviewQueueItem;
                 revision: { targetKey: string; sourceRevision: number };
+                lineage: ReturnType<typeof exactReviewPublicationLineage>;
               } => entry.revision?.targetKey === incomingPublicationRevision.targetKey,
             );
           const newestSourceRevision = matching.reduce(
@@ -676,6 +684,69 @@ export class ExactReviewQueue {
               supersededByRevision: newestSourceRevision,
               state,
             };
+          }
+
+          if (incomingLineage) {
+            const sameLineage = matching.filter(
+              (entry) =>
+                entry.lineage?.sourceRevision === incomingLineage.sourceRevision &&
+                entry.lineage.claimGeneration === incomingLineage.claimGeneration,
+            );
+            const activeLineage = sameLineage
+              .filter(
+                ({ item }) =>
+                  activeBatchItemKeys.has(item.key) ||
+                  item.state === "dispatching" ||
+                  item.state === "leased",
+              )
+              .sort((left, right) => left.item.key.localeCompare(right.item.key));
+            const retained =
+              activeLineage[0] ||
+              sameLineage
+                .filter(({ item }) => item.state === "pending" || item.state === "parked")
+                .sort(
+                  (left, right) =>
+                    left.item.createdAt - right.item.createdAt ||
+                    left.item.key.localeCompare(right.item.key),
+                )[0];
+            const retainedPublication = retained?.item.decision.publication;
+            const producerChanged =
+              retainedPublication?.producerRunId !== decision.publication?.producerRunId ||
+              retainedPublication?.producerRunAttempt !== decision.publication?.producerRunAttempt;
+            if (retained && producerChanged) {
+              let semanticDuplicatesRemoved = 0;
+              for (const entry of sameLineage) {
+                if (
+                  entry.item.key === retained.item.key ||
+                  activeBatchItemKeys.has(entry.item.key) ||
+                  (entry.item.state !== "pending" && entry.item.state !== "parked")
+                ) {
+                  continue;
+                }
+                delete state.items[entry.item.key];
+                semanticDuplicatesRemoved += 1;
+              }
+              if (!activeLineage.length) {
+                // Keep the queue slot and its retry history, but refresh the
+                // producer provenance so a duplicate retry can replace an
+                // artifact that is no longer available.
+                retained.item.decision = decision;
+                retained.item.updatedAt = now;
+              }
+              this.writeStateSync(state);
+              this.incrementQueueMetricsSync({
+                publicationCompleted: semanticDuplicatesRemoved,
+                publicationSuperseded: semanticDuplicatesRemoved,
+                publicationSemanticDeduped: semanticDuplicatesRemoved + 1,
+              });
+              return {
+                deduped: true as const,
+                semantic: true as const,
+                key: retained.item.key,
+                semanticDuplicatesRemoved,
+                state,
+              };
+            }
           }
           for (const entry of matching
             .filter(
@@ -765,7 +836,16 @@ export class ExactReviewQueue {
           {
             ok: true,
             deduped: true,
-            item_key: exactReviewItemKey(decision),
+            item_key:
+              "semantic" in accepted && accepted.semantic
+                ? accepted.key
+                : exactReviewItemKey(decision),
+            ...("semantic" in accepted && accepted.semantic
+              ? {
+                  semantic_deduped: true,
+                  semantic_duplicates_removed: accepted.semanticDuplicatesRemoved,
+                }
+              : {}),
             ...(accepted.superseded
               ? {
                   superseded: true,
@@ -1514,6 +1594,7 @@ export class ExactReviewQueue {
             completed_total: metrics.publication.completed,
             published_total: metrics.publication.published,
             superseded_total: metrics.publication.superseded,
+            semantic_deduped_total: metrics.publication.semanticDeduped,
             retried_total: metrics.publication.retried,
             dead_lettered_total: metrics.publication.deadLettered,
             refreshed_total: metrics.publication.refreshed,
@@ -3279,6 +3360,7 @@ export class ExactReviewQueue {
       "publication_enqueued_total",
       "publication_published_total",
       "publication_superseded_total",
+      "publication_semantic_deduped_total",
       "publication_retried_total",
       "publication_dead_lettered_total",
       "publication_refreshed_total",
@@ -3317,12 +3399,20 @@ export class ExactReviewQueue {
          publication_resolved INTEGER NOT NULL DEFAULT 0 CHECK (publication_resolved >= 0),
          publication_published INTEGER NOT NULL DEFAULT 0 CHECK (publication_published >= 0),
          publication_superseded INTEGER NOT NULL DEFAULT 0 CHECK (publication_superseded >= 0),
+         publication_semantic_deduped INTEGER NOT NULL DEFAULT 0
+           CHECK (publication_semantic_deduped >= 0),
          publication_retried INTEGER NOT NULL DEFAULT 0 CHECK (publication_retried >= 0),
          publication_dead_lettered INTEGER NOT NULL DEFAULT 0
            CHECK (publication_dead_lettered >= 0)
        ) STRICT`,
     );
-    for (const column of ["review_enqueued", "review_completed", "review_retried", "review_shed"]) {
+    for (const column of [
+      "review_enqueued",
+      "review_completed",
+      "review_retried",
+      "review_shed",
+      "publication_semantic_deduped",
+    ]) {
       const present = Array.from(
         this.storage.sql.exec(
           `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}')
@@ -3821,6 +3911,7 @@ export class ExactReviewQueue {
         `SELECT review_enqueued_total, review_completed_total,
                 publication_enqueued_total, publication_completed_total,
                 publication_published_total, publication_superseded_total,
+                publication_semantic_deduped_total,
                 publication_retried_total, publication_dead_lettered_total,
                 publication_refreshed_total
            FROM ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
@@ -3834,6 +3925,7 @@ export class ExactReviewQueue {
           publication_completed_total?: number;
           publication_published_total?: number;
           publication_superseded_total?: number;
+          publication_semantic_deduped_total?: number;
           publication_retried_total?: number;
           publication_dead_lettered_total?: number;
           publication_refreshed_total?: number;
@@ -3849,6 +3941,7 @@ export class ExactReviewQueue {
         completed: exactReviewMetricTotal(row?.publication_completed_total),
         published: exactReviewMetricTotal(row?.publication_published_total),
         superseded: exactReviewMetricTotal(row?.publication_superseded_total),
+        semanticDeduped: exactReviewMetricTotal(row?.publication_semantic_deduped_total),
         retried: exactReviewMetricTotal(row?.publication_retried_total),
         deadLettered: exactReviewMetricTotal(row?.publication_dead_lettered_total),
         refreshed: exactReviewMetricTotal(row?.publication_refreshed_total),
@@ -3865,6 +3958,7 @@ export class ExactReviewQueue {
     const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
     const publicationPublished = exactReviewMetricDelta(delta.publicationPublished);
     const publicationSuperseded = exactReviewMetricDelta(delta.publicationSuperseded);
+    const publicationSemanticDeduped = exactReviewMetricDelta(delta.publicationSemanticDeduped);
     const publicationRetried = exactReviewMetricDelta(delta.publicationRetried);
     const publicationDeadLettered = exactReviewMetricDelta(delta.publicationDeadLettered);
     const publicationRefreshed = exactReviewMetricDelta(delta.publicationRefreshed);
@@ -3877,6 +3971,7 @@ export class ExactReviewQueue {
       !publicationCompleted &&
       !publicationPublished &&
       !publicationSuperseded &&
+      !publicationSemanticDeduped &&
       !publicationRetried &&
       !publicationDeadLettered &&
       !publicationRefreshed
@@ -3891,6 +3986,7 @@ export class ExactReviewQueue {
               publication_completed_total = publication_completed_total + ?,
               publication_published_total = publication_published_total + ?,
               publication_superseded_total = publication_superseded_total + ?,
+              publication_semantic_deduped_total = publication_semantic_deduped_total + ?,
               publication_retried_total = publication_retried_total + ?,
               publication_dead_lettered_total = publication_dead_lettered_total + ?,
               publication_refreshed_total = publication_refreshed_total + ?
@@ -3901,6 +3997,7 @@ export class ExactReviewQueue {
       publicationCompleted,
       publicationPublished,
       publicationSuperseded,
+      publicationSemanticDeduped,
       publicationRetried,
       publicationDeadLettered,
       publicationRefreshed,
@@ -3914,6 +4011,7 @@ export class ExactReviewQueue {
       publicationCompleted,
       publicationPublished,
       publicationSuperseded,
+      publicationSemanticDeduped,
       publicationRetried,
       publicationDeadLettered,
     });
@@ -3928,6 +4026,7 @@ export class ExactReviewQueue {
     publicationCompleted,
     publicationPublished,
     publicationSuperseded,
+    publicationSemanticDeduped,
     publicationRetried,
     publicationDeadLettered,
   }: {
@@ -3939,6 +4038,7 @@ export class ExactReviewQueue {
     publicationCompleted: number;
     publicationPublished: number;
     publicationSuperseded: number;
+    publicationSemanticDeduped: number;
     publicationRetried: number;
     publicationDeadLettered: number;
   }) {
@@ -3951,6 +4051,7 @@ export class ExactReviewQueue {
       !publicationCompleted &&
       !publicationPublished &&
       !publicationSuperseded &&
+      !publicationSemanticDeduped &&
       !publicationRetried &&
       !publicationDeadLettered
     ) {
@@ -3963,8 +4064,9 @@ export class ExactReviewQueue {
       `INSERT INTO ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
          (bucket_start, review_enqueued, review_completed, review_retried, review_shed,
           publication_enqueued, publication_resolved, publication_published,
-          publication_superseded, publication_retried, publication_dead_lettered)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          publication_superseded, publication_semantic_deduped,
+          publication_retried, publication_dead_lettered)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(bucket_start) DO UPDATE SET
          review_enqueued = review_enqueued + excluded.review_enqueued,
          review_completed = review_completed + excluded.review_completed,
@@ -3974,6 +4076,8 @@ export class ExactReviewQueue {
          publication_resolved = publication_resolved + excluded.publication_resolved,
          publication_published = publication_published + excluded.publication_published,
          publication_superseded = publication_superseded + excluded.publication_superseded,
+         publication_semantic_deduped =
+           publication_semantic_deduped + excluded.publication_semantic_deduped,
          publication_retried = publication_retried + excluded.publication_retried,
          publication_dead_lettered =
            publication_dead_lettered + excluded.publication_dead_lettered`,
@@ -3986,6 +4090,7 @@ export class ExactReviewQueue {
       publicationCompleted,
       publicationPublished,
       publicationSuperseded,
+      publicationSemanticDeduped,
       publicationRetried,
       publicationDeadLettered,
     );
@@ -4403,6 +4508,7 @@ export class ExactReviewQueue {
                   COALESCE(SUM(publication_resolved), 0) AS resolved,
                   COALESCE(SUM(publication_published), 0) AS published,
                   COALESCE(SUM(publication_superseded), 0) AS superseded,
+                  COALESCE(SUM(publication_semantic_deduped), 0) AS semantic_deduped,
                   COALESCE(SUM(publication_retried), 0) AS retried,
                   COALESCE(SUM(publication_dead_lettered), 0) AS dead_lettered
              FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
@@ -4416,6 +4522,7 @@ export class ExactReviewQueue {
       const retried = Number(row?.retried || 0);
       const published = Number(row?.published || 0);
       const superseded = Number(row?.superseded || 0);
+      const semanticDeduped = Number(row?.semantic_deduped || 0);
       const deadLettered = Number(row?.dead_lettered || 0);
       return {
         window_minutes: windowMs / 60_000,
@@ -4423,12 +4530,14 @@ export class ExactReviewQueue {
         resolved,
         published,
         superseded,
+        semantic_deduped: semanticDeduped,
         retried,
         dead_lettered: deadLettered,
         arrival_rate_per_hour: Math.round(enqueued * multiplier * 10) / 10,
         resolved_rate_per_hour: Math.round(resolved * multiplier * 10) / 10,
         published_rate_per_hour: Math.round(published * multiplier * 10) / 10,
         superseded_rate_per_hour: Math.round(superseded * multiplier * 10) / 10,
+        semantic_deduped_rate_per_hour: Math.round(semanticDeduped * multiplier * 10) / 10,
         retried_rate_per_hour: Math.round(retried * multiplier * 10) / 10,
         dead_lettered_rate_per_hour: Math.round(deadLettered * multiplier * 10) / 10,
         net_drain_rate_per_hour: Math.round((resolved - enqueued) * multiplier * 10) / 10,
@@ -4958,6 +5067,23 @@ function exactReviewPublicationRevision(decision: ExactReviewDecision): {
   return {
     targetKey: publication.itemKey.toLowerCase(),
     sourceRevision: publication.leaseRevision,
+  };
+}
+
+function exactReviewPublicationLineage(decision: ExactReviewDecision): {
+  targetKey: string;
+  sourceRevision: number;
+  claimGeneration: number;
+} | null {
+  const publication = decision.publication;
+  if (!publication || publication.protocolVersion !== 2 || publication.leaseRevision === null) {
+    return null;
+  }
+  if (publication.claimGeneration === null) return null;
+  return {
+    targetKey: publication.itemKey.toLowerCase(),
+    sourceRevision: publication.leaseRevision,
+    claimGeneration: publication.claimGeneration,
   };
 }
 

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -182,6 +182,19 @@ cleaned up, no workflow was paused, and no live apply or close was executed.
 | Parallel prepare and size-32 readiness        | Planned; separate implementation boundary      | Keep actual ownership bounded while preparation becomes concurrent, initially with four isolated workers. Preserve deterministic aggregation, batch heartbeat, fencing, per-item outcomes, GitHub-effect idempotency, resource bounds, and one final state commit. Prove this at size 8 before treating size 32 as safe.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | Size-32 capacity proof                        | Not complete                                   | A dashboard value of 32 is configuration evidence, not behavior proof. Completion requires one 32-distinct-item state commit with 32 independent accepted outcomes, bounded runtime and lease margin, unchanged contention/DLQ safety, two consecutive positive five-minute windows, and a following positive 60-minute window.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
+### Publication lineage deduplication
+
+Queue admission treats one protocol-v2 result tuple as one publication lineage:
+`targetRepo#itemNumber + leaseRevision + claimGeneration`. Producer run ids and
+attempts remain provenance, but retries for the same tuple do not create another
+effective publication chain. A pending lineage keeps its queue slot and retry
+history while adopting the newest producer artifact. A lineage already owned by
+a dispatch or durable batch lease is immutable; later equivalent deliveries are
+acknowledged as semantic duplicates without stealing ownership. New review
+revisions, comment routing, and apply work remain separate lanes. The queue
+reports `semantic_deduped_total` independently from stale-revision supersession
+so backlog reduction is not mistaken for completed review output. See #800.
+
 ## Production incident and root cause
 
 The first real size-2 batch was

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -266,6 +266,106 @@ test("exact-review queue bypasses debounce for commands and publications", async
   }
 });
 
+test("exact-review queue coalesces one pending publication lineage across producer runs", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const first = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "lineage-first",
+      753,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(753, "7530"),
+    ),
+  );
+  assert.equal((await first.json()).queued, true);
+
+  const duplicate = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "lineage-duplicate",
+      753,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(753, "7531"),
+    ),
+  );
+  assert.deepEqual(await duplicate.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#753@publish:7530:1",
+    semantic_deduped: true,
+    semantic_duplicates_removed: 0,
+  });
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { publication: { producerRunId: string } } }>;
+  };
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#753@publish:7530:1"]);
+  assert.equal(
+    state.items["openclaw/gogcli#753@publish:7530:1"].decision.publication.producerRunId,
+    "7531",
+  );
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.enqueued_total, 1);
+  assert.equal(stats.lanes.publication.semantic_deduped_total, 1);
+});
+
+test("exact-review queue protects an active batch lineage from a later duplicate", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "1",
+    },
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "active-lineage-first",
+      754,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(754, "7540"),
+    ),
+  );
+  const claim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        claim_id: "lineage-batch",
+        lease_owner: "lineage-owner",
+        max_items: 1,
+      }),
+    }),
+  );
+  assert.equal((await claim.json()).claimed, true);
+
+  const duplicate = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "active-lineage-duplicate",
+      754,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(754, "7541"),
+    ),
+  );
+  assert.equal((await duplicate.json()).semantic_deduped, true);
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { publication: { producerRunId: string } } }>;
+  };
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#754@publish:7540:1"]);
+  assert.equal(
+    state.items["openclaw/gogcli#754@publish:7540:1"].decision.publication.producerRunId,
+    "7540",
+  );
+});
+
 test("exact-review queue sheds only new recovery work above the pending soft limit", async () => {
   const storage = new MemoryDurableStorage();
   const env = {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -702,7 +702,7 @@ test("newer publication revisions supersede unowned pending rows at enqueue", as
   }
 });
 
-test("bounded enqueue cleanup cannot leave obsolete rows eligible for a batch", async () => {
+test("semantic lineage dedupe cannot leave obsolete rows eligible for a batch", async () => {
   const originalNow = Date.now;
   Date.now = () => 6_250_000;
   try {
@@ -729,7 +729,8 @@ test("bounded enqueue cleanup cannot leave obsolete rows eligible for a batch", 
     );
 
     const before = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(before.lanes.publication.pending, 2);
+    assert.equal(before.lanes.publication.pending, 1);
+    assert.equal(before.lanes.publication.semantic_deduped_total, 100);
     const claim = await (
       await queue.fetch(
         batchRequest("/publication-batches/claim", {


### PR DESCRIPTION
## Summary

- enforce one effective queued publication lineage for a protocol-v2 exact review tuple: `targetRepo#itemNumber + leaseRevision + claimGeneration`;
- preserve producer run id/attempt as artifact provenance, while preventing a retry or duplicated artifact from a different producer for the same reviewed tuple from creating another queue chain;
- preserve the established same-producer redelivery behavior, including a newer queue revision owned by the same batch lease;
- protect dispatching, leased, and durable-batch-owned items from replacement or cancellation;
- retain pending/parked queue retry state while refreshing it with a newer equivalent producer artifact;
- expose `semantic_deduped_total` and time-window flow telemetry separately from stale-revision supersession;
- document the lane boundary, ownership rule, and reporting contract.

Fixes #800.

## Problem

The queue key for result publication includes `producerRunId` and `producerRunAttempt`. Two artifact deliveries from different producer attempts for the same already-reviewed lease can therefore occupy distinct queue records. Existing controls dedupe identical delivery ids, supersede an older review revision, and avoid duplicate target items inside one batch, but they do not collapse equal review tuples across the full pending queue.

During a publication backlog, this creates avoidable preparation, state-writer, and GitHub mutation pressure without adding a new review decision. It also lets the queue count grow from repeated producer attempts even though there should be one visible final review result.

## Behavior

The new semantic identity applies only to publication results for protocol-v2 tuples.

- An equivalent item from another producer already owned by a batch, dispatch, or lease remains authoritative. The later delivery is acknowledged as deduplicated and cannot alter the owner.
- For an equivalent pending or parked item from another producer, the queue slot and retry/failure history remain intact while producer provenance is refreshed to the later artifact. This prefers an available artifact without resetting failure budgets.
- Other pending/parked equivalent legacy records are removed and recorded as superseded queue work.
- Redelivery from the same producer run and attempt keeps the pre-existing queue-revision behavior; the active batch can preserve and requeue that newer revision after its owned completion.
- A different review revision remains a separate tuple and follows existing stale-revision fencing.
- Review, comment-routing, apply, and command lanes do not share this identity and are never cancelled merely because their issue/PR number matches.

## Safety and scope

This does not change Codex prompts, review criteria, close/merge policy, batch ownership, state-writer coordination, GitHub write authorization, or per-item tuple fences. It does not raise batch size or concurrency.

An active publisher is deliberately immutable for a different producer: its batch membership and callbacks keep the original key and immutable ownership tuple. The change only absorbs later equivalent ingress. Same-producer redelivery retains the existing newer-revision path required by batch completion fencing.

## Code paths

- `dashboard/exact-review-queue.ts`
  - derives the immutable publication lineage;
  - coalesces different-producer equivalents at enqueue;
  - protects active ownership and keeps retry state;
  - records cumulative and time-window semantic-dedupe telemetry.
- `test/dashboard-worker.test.ts`
  - proves pending-lineage coalescing and active-batch protection.
- `test/exact-review-publication-batches.test.ts`
  - aligns the 101-delivery cleanup regression with the new single-lineage invariant while retaining newer-revision batch coverage.
- `docs/state-publication-batching-plan.md`
  - documents lineage identity, lane isolation, ownership, and telemetry.

## Validation

Local work was limited to lightweight static preflight:

- `git diff --check`: passed;
- `oxfmt --check dashboard/exact-review-queue.ts test/dashboard-worker.test.ts test/exact-review-publication-batches.test.ts`: passed;
- focused `oxlint` on the same files with `--deny-warnings`: 0 warnings, 0 errors.

Current-head cloud validation for `ba6853923507fa3f2b8f1b3ffeb2be69d6a1d5c7`:

- [CI run 29979983902](https://github.com/openclaw/clawsweeper/actions/runs/29979983902): full `pnpm check`, Windows launcher, sparse repair build smoke, and crawl-remote integration passed;
- [CodeQL run 29979983911](https://github.com/openclaw/clawsweeper/actions/runs/29979983911): Actions and JavaScript/TypeScript analyses passed;
- all current-head PR checks are terminal and successful, apart from the intentionally skipped notification job.

Failure-to-pass evidence:

- [run 29978745022](https://github.com/openclaw/clawsweeper/actions/runs/29978745022) exposed the established same-producer/newer-revision contract; the implementation was narrowed to different producers;
- [run 29979518925](https://github.com/openclaw/clawsweeper/actions/runs/29979518925) exposed the old 101-duplicate test expectation; the regression now verifies 100 semantic dedupes and one latest batch candidate;
- [run 29979983902](https://github.com/openclaw/clawsweeper/actions/runs/29979983902) then passed the full current-head check.

## Risk

- Refreshing provenance for a pending/parked equivalent item could select a newer artifact that later becomes unavailable. Retry history is deliberately retained, and the existing artifact-refresh recovery remains the fallback.
- Treating equal tuples as one chain is only enabled for protocol-v2 publications with both immutable tuple fields present. Legacy items retain their original keys and behavior.
- Active batch, dispatching, and leased items from another producer are never mutated, so an in-flight publisher retains its original fenced callback contract.
- Same-producer deliveries are intentionally excluded from semantic coalescing because current batch completion relies on their queue-revision relationship.

## Rollback

Revert commit `ba6853923507fa3f2b8f1b3ffeb2be69d6a1d5c7`. The change is additive: no queue schema-version bump, no external migration, and no configuration change. Existing queue records and active callbacks remain readable through their original keys.

## Docs updated

- `docs/state-publication-batching-plan.md`

## Related work

- #800 — queue-wide publication lineage deduplication
- #749 — supersede stale active exact-review runs before publication
- #772 — batch-local duplicate target protection
- #738 — durable state writer/materializer convergence

## Not tested / limitations

- No production deployment or live queue mutation was performed from this branch.
- Backlog reduction depends on merge and deployment; this PR prevents new semantic duplicate pressure but does not claim to erase all historical non-duplicate publication work by itself.
- Maintainer review and deployment observation remain authoritative for rollout readiness.
