### PR TITLE
fix(publish): consult the recovery advisor only after retries exhaust

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -668,7 +668,9 @@ function pushImmutableActionLedgerCommit(options: {
     modelPushAttemptHistory.push(gitFailureSummary(pushResult));
     let modelRequestedRebuild = false;
     let modelRequestedRebuildAdvice: RecoveryAdvice | null = null;
-    if (!modelPushRecoveryConsulted) {
+    // Same contract as the branch loop: deterministic rebuild attempts first,
+    // the advisor only for what remains after they are spent.
+    if (!modelPushRecoveryConsulted && attempt === pushBudget) {
       modelPushRecoveryConsulted = true;
       const recovery = modelGuidedPushRecovery({
         phase: "push_immutable_action_ledger",
@@ -2571,7 +2573,11 @@ export function pushCommit(options: {
     let pushResult = pushPublishedBranch(remote, branch);
     if (pushResult.status === 0) return true;
     modelPushAttemptHistory.push(gitFailureSummary(pushResult));
-    if (!modelPushRecoveryConsulted) {
+    // The advisor rules on failures the deterministic loop cannot handle; an
+    // ordinary push race resolves through the remaining rebuild attempts, so
+    // consult only once those are exhausted (a defer on attempt 1 previously
+    // threw away the whole retry budget — materializer runs 29966193607 etc.).
+    if (!modelPushRecoveryConsulted && pushAttempt === pushAttempts) {
       modelPushRecoveryConsulted = true;
       const recovery = modelGuidedPushRecovery({
         phase: "push_commit",


### PR DESCRIPTION
The materializer's push kept failing at any batch size and any checkout depth because the model advisor (#793) is consulted on the FIRST non-fast-forward and its defer_to_next_run THROWS out of the retry loop — the deterministic rebuild budget (3-8 attempts) never runs, so a writer racing every 1-3 minutes always wins. Runs 29938808338/29957012043/29966193607 all died this way on attempt 1.

Gate: the advisor is consulted only on the final attempt, ruling on what remains after deterministic retries are spent — the correct division of labor per VISION.md (machinery for the expected race, judgment for the unexpected).

Validation: git-publish + advisor suites green (CI-only fixture exempt); build/lint/format green; autoreview clean (0.91).