### PR TITLE
feat(materializer): dedicated clawsweeper-heavy runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,5 +5,6 @@ self-hosted-runner:
     - crabbox
     - openclaw
     - clawsweeper
+    - clawsweeper-heavy
 
 config-variables: null

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -22,7 +22,11 @@ env:
 jobs:
   materialize:
     name: Drain queued state into one commit
-    runs-on: ubuntu-latest
+    # Dedicated larger runner (own concurrency pool): the shared ubuntu-latest
+    # queue is saturated by review traffic and starved the single state writer
+    # for hours (2026-07-22/23). Revisit: if shared-pool queue-wait stays <5 min
+    # for a week after the migration completes, drop this back to ubuntu-latest.
+    runs-on: clawsweeper-heavy
     timeout-minutes: 60
     env:
       CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"


### PR DESCRIPTION
The shared ubuntu-latest pool is saturated by review traffic; the single state writer queued 4h for slots (multiple lease pile-ups downstream). New org larger runner clawsweeper-heavy (Linux ARM64, Ubuntu 24.04, 2-core, max concurrency 2 — bought for its private queue, not its cores) created by Peter+me via the org UI. Exit criterion in-file: revert to ubuntu-latest if shared-pool queue-wait stays <5 min for a week post-migration. Workflow tests green.