### PR TITLE
fix(ci): restore hosted materializer runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,5 @@ self-hosted-runner:
     - crabbox
     - openclaw
     - clawsweeper
-    - clawsweeper-heavy
 
 config-variables: null

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -22,11 +22,7 @@ env:
 jobs:
   materialize:
     name: Drain queued state into one commit
-    # Dedicated larger runner (own concurrency pool): the shared ubuntu-latest
-    # queue is saturated by review traffic and starved the single state writer
-    # for hours (2026-07-22/23). Revisit: if shared-pool queue-wait stays <5 min
-    # for a week after the migration completes, drop this back to ubuntu-latest.
-    runs-on: clawsweeper-heavy
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Restored the state materializer to GitHub-hosted runners after the dedicated
+  runner label left the sole publication drain queued without an eligible
+  runner.
 - Split exact-item review from Git-backed publication: read-only reviewers now upload hash-bound, 90-day artifacts and enqueue separate durable publication leases before one globally serialized publisher validates, comments, routes, and commits state without rerunning Codex after ordinary publisher failure; handoffs still blocked after 80 days safely fall back to one fresh exact review.
 - Reverted the action-lifecycle expansion from PR #521, restoring the pre-merge ClawSweeper paths while retaining later exact-review throughput fixes and retrying coalesced reconciliations after any partial lookup failure.
 - Raised exact-review capacity from 48/44 global/per-target workers to 64/60, shortened unclaimed dispatch recovery from ten to six minutes, and coalesced terminal-run reconciliation bursts into one bounded aggregate claim scan.

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -15,6 +15,7 @@ type WorkflowStep = {
 
 type WorkflowJob = {
   env?: Record<string, unknown>;
+  "runs-on"?: unknown;
   steps?: WorkflowStep[];
 };
 
@@ -127,6 +128,12 @@ test("state materializer and apply publishers enable model-guided recovery with 
   );
   assert.equal(applyEventPublisher?.env?.CLAWSWEEPER_MODEL_RECOVERY_ENABLED, "0");
   assert.equal(applyEventPublisher?.env?.OPENAI_API_KEY, undefined);
+});
+
+test("state materializer uses an available GitHub-hosted runner", () => {
+  const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
+  const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
+  assert.equal(materializer?.["runs-on"], "ubuntu-latest");
 });
 
 test("only the exact-review batch publisher requests priority admission", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the sole state materializer stayed queued for hours because its dedicated runner label had no eligible runner, stopping publication while exact-review results accumulated.

## Why This Change Was Made

Moves the materializer back to `ubuntu-latest`, removes the obsolete actionlint label, and adds a workflow contract test so the publication drain cannot silently return to the unavailable label.

## User Impact

Operators can expect queued state and exact-review publications to resume draining on an available GitHub-hosted runner.

## Evidence

- Live run `29988689006` remained queued on `clawsweeper-heavy` from July 23, 2026 without an eligible runner.
- `node --test test/state-writer-workflow.test.ts`: 8/8 passed.
- `oxfmt --check` on touched files: passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, correctness 0.98.
- `CI=true pnpm run check`: formatting, builds, lint, focused coverage, and queue guards passed; broad suite only hit unrelated existing macOS/environment failures in repair git publishing, Linux process containment, temp-path normalization, and shared symlink handling.
- Blacksmith Testbox was unavailable with repeated control-plane timeouts, so trusted-source validation used the local full checkout.