### PR TITLE
fix(publish): rebase state publishes onto the live remote head and bound silent waits

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -30,6 +30,11 @@ jobs:
       # contended wait eat the whole run (observed: six consecutive 20-min
       # timeout-cancels while the append window grew to ~25k rows).
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "300000"
+      # The durable-ticket queue can legitimately run tens of minutes deep
+      # behind the long-tail writers (run 29996334590 waited 31 minutes for
+      # seq 2284); budget most of the job window but keep a clean failure
+      # ahead of the 60-minute job kill.
+      CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "2700000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
       CLAWSWEEPER_STATE_LEASE_TTL_MS: "1200000"
       CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS: "2400000"

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -32,9 +32,10 @@ jobs:
       CLAWSWEEPER_STATE_LEASE_ACQUIRE_TIMEOUT_MS: "300000"
       # The durable-ticket queue can legitimately run tens of minutes deep
       # behind the long-tail writers (run 29996334590 waited 31 minutes for
-      # seq 2284); budget most of the job window but keep a clean failure
-      # ahead of the 60-minute job kill.
-      CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "2700000"
+      # seq 2284). 35 minutes of waiting still leaves a late grant enough of
+      # the 60-minute job for one publish and the finalize steps; a clean
+      # timeout beats a job kill either way.
+      CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "2100000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
       CLAWSWEEPER_STATE_LEASE_TTL_MS: "1200000"
       CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS: "2400000"

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -112,6 +112,10 @@ const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
 // one-time repairs but move far more data than an ordinary publish fetch; a
 // 60s budget times out on the grown state repo (prod run 29745570319).
 const RECOVERY_FETCH_TIMEOUT_MS = 300_000;
+// Branch pushes move materializer-sized batches and must outlast them, but a
+// push with no timeout turns a stalled transport into a silent hang that only
+// the job timeout can end.
+const PUBLISH_PUSH_TIMEOUT_MS = 300_000;
 const STATE_PUBLISH_LEASE_REF_ROOT = "refs/heads/clawsweeper-publish-lease";
 // A small publish renews well inside two minutes, but a materializer batch of
 // thousands of paths stages and pushes for longer than that and loses the lease
@@ -466,7 +470,11 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
     `paths=${uniqueNonEmpty(options.paths).length} strategy=${rebaseStrategy}`,
   );
   prepareReconciliationStateRoot(remote, branch, rebaseStrategy);
+  // Baseline before the head sync: the source-refresh diff below must span the
+  // remote commits this checkout had not seen yet, and the sync collapses them
+  // into the new HEAD.
   const stateBaseCommit = captureStatePublishBaseline();
+  syncStatePublishBaseToRemoteHead(remote, branch, rebaseStrategy);
 
   syncPublishPaths(options.paths, { rebaseStrategy });
   configureGitUser();
@@ -951,6 +959,7 @@ function mergeImmutableActionLedgerOnGitHub(options: {
       if (
         spawnGit(["push", options.remote, `${options.sourceCommit}:${temporaryRef}`], {
           displayArgs: ["push", options.remote, `<commit>:${temporaryRef}`],
+          timeout: PUBLISH_PUSH_TIMEOUT_MS,
         }).status === 0
       ) {
         pushed = true;
@@ -1278,6 +1287,37 @@ function prepareReconciliationStateRoot(
   }
   console.log("Discarding an unpublished reconciliation checkpoint before retry");
   runGit(["reset", "--hard", semanticBase.base ?? remoteRef]);
+}
+
+function syncStatePublishBaseToRemoteHead(
+  remote: string,
+  branch: string,
+  rebaseStrategy: RebaseStrategy,
+): void {
+  const stateRoot = publishRoot();
+  if (
+    rebaseStrategy === "reconcile-records" ||
+    !stateRoot ||
+    resolve(stateRoot) === resolve(process.cwd())
+  ) {
+    return;
+  }
+  // A publish can wait tens of minutes for its writer ticket while other
+  // writers advance the remote branch — or the compaction cron force-rewrites
+  // it, leaving no common ancestor at all (observed: run 29996334590 built a
+  // commit on a 34-minute-stale base and died on "fetch first"). The pending
+  // content lives in the source checkout and is copied (or merged) into the
+  // state root afterwards, so the checkout itself carries nothing worth
+  // keeping: reset it to the live head so both the commit base and the merge
+  // inputs are current, without needing any common ancestor.
+  fetchPublishRemote(remote, branch);
+  const remoteRef = `${remote}/${branch}`;
+  const remoteCommit = spawnGit(["rev-parse", remoteRef], { quiet: true });
+  if (remoteCommit.status !== 0) return;
+  const localCommit = runGit(["rev-parse", "HEAD"], { quiet: true }).trim();
+  if (remoteCommit.stdout.trim() === localCommit) return;
+  console.log(`Rebasing the state publish base onto the live ${remoteRef} head`);
+  runGit(["reset", "--hard", remoteRef]);
 }
 
 function reconciliationTupleKeysForCommit(sourceCommit: string): string[] {
@@ -2367,7 +2407,7 @@ function pushPublishedCommit(
       `${renewedOid}:${lease.ref}`,
       ...(receiptRef ? [`${source}:${receiptRef}`] : []),
     ],
-    { allowFailure: true },
+    { allowFailure: true, timeout: PUBLISH_PUSH_TIMEOUT_MS },
   );
   if (pushed.status !== 0) {
     const currentLeaseOid = remoteRefOid(remote, lease.ref);

--- a/src/repair/state-writer-coordinator.ts
+++ b/src/repair/state-writer-coordinator.ts
@@ -7,6 +7,18 @@ const COORDINATOR_POLL_MS = 1_000;
 const COORDINATOR_HEARTBEAT_MS = 30_000;
 const COORDINATOR_REQUEST_TIMEOUT_MS = 10_000;
 const COORDINATOR_AMBIGUOUS_REQUEST_LIMIT = 3;
+const COORDINATOR_QUEUE_LOG_MS = 60_000;
+// The queue behind a deep writer backlog is a legitimate multi-minute wait,
+// but an uncapped poll turns any stuck leader into a silent hang that only the
+// job timeout can end (observed: 26 minutes of blocked Atomics.wait in run
+// 29996334590). Fail with a diagnosable error instead.
+const COORDINATOR_ACQUIRE_TIMEOUT_FALLBACK_MS = 30 * 60_000;
+
+function coordinatorAcquireTimeoutMs(env: NodeJS.ProcessEnv): number {
+  const configured = Number(env.CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS);
+  if (Number.isInteger(configured) && configured > 0) return configured;
+  return COORDINATOR_ACQUIRE_TIMEOUT_FALLBACK_MS;
+}
 
 export type StateWriterCoordinatorTicket = {
   ticketId: string;
@@ -65,10 +77,22 @@ export function acquireStateWriterCoordinator(
   const ticketId = `state-writer:${randomUUID()}`;
   const request = runtime.request ?? signedCoordinatorRequest(config);
   const sleep = runtime.sleep ?? sleepSync;
+  const acquireDeadlineAt = Date.now() + coordinatorAcquireTimeoutMs(env);
   let lastPosition: number | null = null;
+  let lastQueueLogAt = Date.now();
   let ambiguousRequestFailures = 0;
 
   while (true) {
+    if (Date.now() >= acquireDeadlineAt) {
+      try {
+        request("/internal/state-writer/release", { ticket_id: ticketId, owner, branch });
+      } catch {
+        // Best effort: a queued ticket left behind is reclaimed as stale.
+      }
+      throw new Error(
+        `state writer coordinator acquire timed out after ${coordinatorAcquireTimeoutMs(env)}ms at queue position ${lastPosition ?? "unknown"}`,
+      );
+    }
     let response: CoordinatorResponse;
     try {
       runtime.onAcquireAttempt?.();
@@ -164,9 +188,12 @@ export function acquireStateWriterCoordinator(
       throw new Error(`state writer coordinator returned terminal ticket state ${ticket.state}`);
     }
     const position = Number(ticket.position || 0);
-    if (position !== lastPosition) {
-      console.log(`Queued durable state writer ticket position=${position} seq=${ticket.seq}`);
+    if (position !== lastPosition || Date.now() - lastQueueLogAt >= COORDINATOR_QUEUE_LOG_MS) {
+      console.log(
+        `Queued durable state writer ticket position=${position} seq=${ticket.seq} deadline_in_ms=${Math.max(0, acquireDeadlineAt - Date.now())}`,
+      );
       lastPosition = position;
+      lastQueueLogAt = Date.now();
     }
     sleep(COORDINATOR_POLL_MS);
   }

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -490,6 +490,76 @@ test("publishMainCommit survives a shallow-checkout push race without a common G
   );
 });
 
+test("publishMainCommit rebases a stale state base onto a force-updated remote head", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const state = path.join(root, "state");
+  const work = path.join(root, "work");
+  const other = path.join(root, "other");
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, seed], root);
+  configureUser(seed);
+  write(path.join(seed, "results/other.txt"), "remote\n");
+  run("git", ["add", "."], seed);
+  run("git", ["commit", "-m", "initial"], seed);
+  run("git", ["push", "origin", "HEAD:state"], seed);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/state"], root);
+  run("git", ["clone", origin, work], root);
+  run("git", ["clone", "--depth", "1", `file://${origin}`, state], root);
+  configureUser(state);
+
+  // The compaction cron rewrites the state branch: a force-pushed orphan head
+  // shares no ancestry with the stale checkout and carries newer content.
+  run("git", ["clone", origin, other], root);
+  configureUser(other);
+  run("git", ["checkout", "--orphan", "compacted"], other);
+  write(path.join(other, "results/other.txt"), "compacted\n");
+  run("git", ["add", "."], other);
+  run("git", ["commit", "-m", "compacted"], other);
+  run("git", ["push", "--force", "origin", "HEAD:state"], other);
+  const compactedHead = run("git", ["rev-parse", "HEAD"], other).trim();
+
+  write(path.join(work, "results/spam-scanner.json"), '{"scans":9}\n');
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: record ClawSweeper spam scan",
+          paths: ["results/spam-scanner.json"],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "theirs",
+        }),
+      ),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  assert.equal(
+    lines.some((line) =>
+      line.includes("Rebasing the state publish base onto the live origin/state head"),
+    ),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:results/spam-scanner.json"], root),
+    '{"scans":9}\n',
+  );
+  // The stale checkout-era copy outside the publish paths must not shadow the
+  // newer remote content, and the publish lands directly on the rewritten head.
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:results/other.txt"], root),
+    "compacted\n",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "rev-parse", "state^"], root).trim(),
+    compactedHead,
+  );
+});
+
 test("publishMainCommit fails closed when a racing sweep status is malformed", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");

--- a/test/repair/state-writer-coordinator.test.ts
+++ b/test/repair/state-writer-coordinator.test.ts
@@ -139,28 +139,37 @@ test("queued polling preserves one durable identity through heartbeat and releas
 
 test("queued polling times out at the coordinator acquire deadline", () => {
   const paths: string[] = [];
-  assert.throws(
-    () =>
-      acquireStateWriterCoordinator(
-        "state",
-        {
-          request(path, rawPayload) {
-            paths.push(path);
-            if (path === "/internal/state-writer/acquire") {
-              return queued(requestPayload(rawPayload), 7);
-            }
-            assert.equal(path, "/internal/state-writer/release");
-            return { ok: true, released: true };
+  const originalNow = Date.now;
+  let fakeNow = 0;
+  Date.now = () => fakeNow;
+  try {
+    assert.throws(
+      () =>
+        acquireStateWriterCoordinator(
+          "state",
+          {
+            request(path, rawPayload) {
+              paths.push(path);
+              if (path === "/internal/state-writer/acquire") {
+                return queued(requestPayload(rawPayload), 7);
+              }
+              assert.equal(path, "/internal/state-writer/release");
+              return { ok: true, released: true };
+            },
+            sleep(milliseconds) {
+              fakeNow += milliseconds;
+            },
+            startWatchdog() {
+              return { close() {} };
+            },
           },
-          sleep() {},
-          startWatchdog() {
-            return { close() {} };
-          },
-        },
-        { ...enabledEnv, CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "1" },
-      ),
-    /state writer coordinator acquire timed out after 1ms at queue position 7/,
-  );
+          { ...enabledEnv, CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "500" },
+        ),
+      /state writer coordinator acquire timed out after 500ms at queue position 7/,
+    );
+  } finally {
+    Date.now = originalNow;
+  }
   assert.equal(paths.at(-1), "/internal/state-writer/release");
 });
 

--- a/test/repair/state-writer-coordinator.test.ts
+++ b/test/repair/state-writer-coordinator.test.ts
@@ -137,6 +137,33 @@ test("queued polling preserves one durable identity through heartbeat and releas
   assert.deepEqual(watchdogCloses, [true]);
 });
 
+test("queued polling times out at the coordinator acquire deadline", () => {
+  const paths: string[] = [];
+  assert.throws(
+    () =>
+      acquireStateWriterCoordinator(
+        "state",
+        {
+          request(path, rawPayload) {
+            paths.push(path);
+            if (path === "/internal/state-writer/acquire") {
+              return queued(requestPayload(rawPayload), 7);
+            }
+            assert.equal(path, "/internal/state-writer/release");
+            return { ok: true, released: true };
+          },
+          sleep() {},
+          startWatchdog() {
+            return { close() {} };
+          },
+        },
+        { ...enabledEnv, CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "1" },
+      ),
+    /state writer coordinator acquire timed out after 1ms at queue position 7/,
+  );
+  assert.equal(paths.at(-1), "/internal/state-writer/release");
+});
+
 test("an ambiguous acquire response rereads the same durable ticket identity", () => {
   const payloads: RequestPayload[] = [];
   const sleeps: number[] = [];

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -140,8 +140,10 @@ test("state materializer bounds its coordinator acquire below the job timeout", 
   const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
   const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
   const budgetMs = Number(materializer?.env?.CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS);
-  assert.equal(budgetMs, 2_700_000);
-  assert.equal(budgetMs < Number(materializer?.["timeout-minutes"]) * 60_000, true);
+  assert.equal(budgetMs, 2_100_000);
+  // A late grant still needs room inside the job window to publish one batch
+  // and run the finalize steps.
+  assert.equal(budgetMs + 15 * 60_000 <= Number(materializer?.["timeout-minutes"]) * 60_000, true);
 });
 
 test("only the exact-review batch publisher requests priority admission", () => {

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -136,6 +136,14 @@ test("state materializer uses an available GitHub-hosted runner", () => {
   assert.equal(materializer?.["runs-on"], "ubuntu-latest");
 });
 
+test("state materializer bounds its coordinator acquire below the job timeout", () => {
+  const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
+  const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
+  const budgetMs = Number(materializer?.env?.CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS);
+  assert.equal(budgetMs, 2_700_000);
+  assert.equal(budgetMs < Number(materializer?.["timeout-minutes"]) * 60_000, true);
+});
+
 test("only the exact-review batch publisher requests priority admission", () => {
   const prioritySetups: string[] = [];
   for (const { file, workflow } of workflows()) {


### PR DESCRIPTION
## What Problem This Solves

The state materializer has never landed a full cycle. Run 29996334590 exposed the two remaining causes: it waited 31 minutes for its durable writer ticket, built its commit on the by-then-stale checkout base (which the compaction cron had force-rewritten away entirely), died on `fetch first`, and then hung silently for 26 minutes in the coordinator's unbounded re-acquire poll until the 60-minute job kill.

## Why This Change Was Made

- **Fresh base under the lease**: `publishMainCommit` now fetches and hard-resets the state checkout onto the live remote head after admission, before staging. Pending content lives in the source checkout and is copied/merged in afterwards, so the checkout carries nothing worth keeping; the reset needs no common ancestor and is therefore immune to compaction force-pushes. The pre-sync baseline is preserved for the downstream source-refresh diff.
- **Bounded coordinator acquire**: the durable-ticket poll was `while (true)` with 1-second synchronous sleeps and logged only on queue-position changes — a stable position produced infinite silence. It now has a deadline (`CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS`, default 30m; the materializer sets 35m against its 60-minute job) plus a once-a-minute still-queued heartbeat, and releases its queued ticket before failing.
- **Bounded pushes**: the lease-coordinated atomic push and the immutable-ledger temp-ref push had no timeout; both now carry a 5-minute budget.

## User Impact

Materializer cycles land instead of dying on stale bases or hanging until the job kill; the queued append backlog can finally drain.

## Evidence

- Forensics: run 29996334590 (`fetch first` rejection at 10:16:37, forced-update fetch, then 26 minutes of silence to the job kill).
- New tests: force-updated-orphan-head publish lands with remote content preserved; coordinator acquire deadline (deterministic fake clock); workflow pin proving acquire budget + publish room fit the job window.
- `node --test` on git-publish, state-writer-coordinator, state-materializer, state-writer-workflow suites: all pass except the pre-existing CI-only server-merge fixture.
- Codex autoreview: clean (correct 0.84) after addressing both findings from the first pass.
