### PR TITLE
fix(materializer): admit the materializer through the publication-batch lane

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          # The materializer is the designated bulk writer of the single-writer
+          # plan (RFC #738). In the ordinary lane it starves behind batch-class
+          # turns (run 30003798477 timed out after 35 minutes at queue
+          # position 3); the batch lane's two-turn cap still guarantees
+          # ordinary writers a slot.
+          coordinator-class: publication_batch
           token: ${{ steps.state-token.outputs.token }}
           # depth-1 cannot fast-forward or rebuild against a branch other
           # writers keep advancing (non-fast-forward shallow push rejections,

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -146,7 +146,7 @@ test("state materializer bounds its coordinator acquire below the job timeout", 
   assert.equal(budgetMs + 15 * 60_000 <= Number(materializer?.["timeout-minutes"]) * 60_000, true);
 });
 
-test("only the exact-review batch publisher requests priority admission", () => {
+test("only the batch publisher and the state materializer request priority admission", () => {
   const prioritySetups: string[] = [];
   for (const { file, workflow } of workflows()) {
     for (const [job, definition] of Object.entries(workflow.jobs ?? {})) {
@@ -157,7 +157,10 @@ test("only the exact-review batch publisher requests priority admission", () => 
       }
     }
   }
-  assert.deepEqual(prioritySetups, [".github/workflows/exact-review-batch-publish.yml:publish"]);
+  assert.deepEqual(prioritySetups, [
+    ".github/workflows/exact-review-batch-publish.yml:publish",
+    ".github/workflows/state-materializer.yml:materialize",
+  ]);
 });
 
 test("trusted generated-state mutation steps receive a step-scoped coordinator credential", () => {


### PR DESCRIPTION
## What Problem This Solves

With the silent coordinator hang fixed (#805), run 30003798477 failed cleanly with the real diagnosis: `state writer coordinator acquire timed out after 2100000ms at queue position 3`. The materializer sat 35 minutes in the ordinary lane while publication-batch tickets — each holding the global writer lease for ~10 minutes at batch size 50 — took two of every three turns ahead of it.

## Why This Change Was Made

The materializer is the designated bulk writer of the single-writer plan (RFC #738); admitting it as `publication_batch` puts it in the lane sized for exactly this work. The DO's two-consecutive-batch-turns cap still guarantees ordinary writers (status, repair, dashboard) a slot, so this shifts starvation off the one writer that drains the append backlog without recreating it elsewhere.

## User Impact

Materializer cycles acquire the writer lease in minutes instead of timing out; the queued state backlog can drain.

## Evidence

- Run 30003798477: clean acquire timeout at position 3 after the full 35-minute budget on the ordinary lane.
- `node --test test/state-writer-workflow.test.ts`: 9/9 pass with the priority-admission pin updated to exactly these two jobs.
- Codex autoreview: clean (correct 0.97).
