### PR TITLE
fix(publication): coalesce result lineages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Coalesced retried exact-review publication deliveries after provenance refresh without breaking same-producer revision handoff. Reported by @snowzlmbot automation.
 - Synchronized review-derived labels on high-activity pull requests when complete hydration proves omitted activity is automation-only, while continuing to fail closed on hidden human activity or incomplete hydration. Thanks @veteranbv.
 - Stopped stale "review started" placeholder comments from accumulating on reviewed items: publishing the durable review comment now sweeps superseded placeholders.
 - Stopped narrow OpenClaw automerge repairs from chasing unrelated full-repository lint and typecheck failures.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -214,6 +214,7 @@ type ExactReviewQueueMetricTotals = {
     completed: number;
     published: number;
     superseded: number;
+    semanticDeduped: number;
     retried: number;
     deadLettered: number;
     refreshed: number;
@@ -228,6 +229,7 @@ type ExactReviewQueueMetricDelta = {
   publicationCompleted?: number;
   publicationPublished?: number;
   publicationSuperseded?: number;
+  publicationSemanticDeduped?: number;
   publicationRetried?: number;
   publicationDeadLettered?: number;
   publicationRefreshed?: number;
@@ -645,14 +647,20 @@ export class ExactReviewQueue {
         );
         let supersededPublications = 0;
         if (incomingPublicationRevision) {
+          const incomingLineage = exactReviewPublicationLineage(decision);
           const matching = Object.values(state.items)
-            .map((item) => ({ item, revision: exactReviewPublicationRevision(item.decision) }))
+            .map((item) => ({
+              item,
+              revision: exactReviewPublicationRevision(item.decision),
+              lineage: exactReviewPublicationLineage(item.decision),
+            }))
             .filter(
               (
                 entry,
               ): entry is {
                 item: ExactReviewQueueItem;
                 revision: { targetKey: string; sourceRevision: number };
+                lineage: ReturnType<typeof exactReviewPublicationLineage>;
               } => entry.revision?.targetKey === incomingPublicationRevision.targetKey,
             );
           const newestSourceRevision = matching.reduce(
@@ -676,6 +684,122 @@ export class ExactReviewQueue {
               supersededByRevision: newestSourceRevision,
               state,
             };
+          }
+
+          if (incomingLineage) {
+            const sameLineage = matching.filter(
+              (entry) =>
+                entry.lineage?.sourceRevision === incomingLineage.sourceRevision &&
+                entry.lineage.claimGeneration === incomingLineage.claimGeneration,
+            );
+            const activeLineage = sameLineage
+              .filter(
+                ({ item }) =>
+                  activeBatchItemKeys.has(item.key) ||
+                  item.state === "dispatching" ||
+                  item.state === "leased",
+              )
+              .sort((left, right) => left.item.key.localeCompare(right.item.key));
+            const retained =
+              activeLineage[0] ||
+              sameLineage
+                .filter(({ item }) => item.state === "pending" || item.state === "parked")
+                .sort(
+                  (left, right) =>
+                    left.item.createdAt - right.item.createdAt ||
+                    left.item.key.localeCompare(right.item.key),
+                )[0];
+            const retainedPublication = retained?.item.decision.publication;
+            const producerChanged =
+              retainedPublication?.producerRunId !== decision.publication?.producerRunId ||
+              retainedPublication?.producerRunAttempt !== decision.publication?.producerRunAttempt;
+            const retainedUsesIncomingKey = retained?.item.key === exactReviewItemKey(decision);
+            const newestPendingDecision = activeLineage.length
+              ? null
+              : sameLineage
+                  .filter(({ item }) => item.state === "pending" || item.state === "parked")
+                  .map(({ item }) => item.decision)
+                  .concat(decision)
+                  .reduce<ExactReviewDecision | null>((newest, candidate) => {
+                    if (!newest?.publication) return candidate;
+                    return exactReviewPublicationProducerIsNewer(
+                      candidate.publication!,
+                      newest.publication,
+                    )
+                      ? candidate
+                      : newest;
+                  }, null);
+            const incomingIsOlderThanPendingLineage = Boolean(
+              newestPendingDecision?.publication &&
+              decision.publication &&
+              exactReviewPublicationProducerIsNewer(
+                newestPendingDecision.publication,
+                decision.publication,
+              ),
+            );
+            const semanticIngress =
+              producerChanged || !retainedUsesIncomingKey || incomingIsOlderThanPendingLineage;
+            const hasRemovableDuplicate =
+              Boolean(retained) &&
+              sameLineage.some(
+                ({ item }) =>
+                  item.key !== retained?.item.key &&
+                  !activeBatchItemKeys.has(item.key) &&
+                  (item.state === "pending" || item.state === "parked"),
+              );
+            // Refreshing provenance deliberately preserves the existing queue
+            // key, so a redelivery from that refreshed producer must still
+            // collapse into it. Same-key redeliveries retain revision handoff.
+            if (retained && (semanticIngress || hasRemovableDuplicate)) {
+              let semanticDuplicatesRemoved = 0;
+              for (const entry of sameLineage) {
+                if (
+                  entry.item.key === retained.item.key ||
+                  activeBatchItemKeys.has(entry.item.key) ||
+                  (entry.item.state !== "pending" && entry.item.state !== "parked")
+                ) {
+                  continue;
+                }
+                delete state.items[entry.item.key];
+                semanticDuplicatesRemoved += 1;
+              }
+              if (
+                !activeLineage.length &&
+                retainedPublication &&
+                newestPendingDecision?.publication &&
+                exactReviewPublicationProducerIsNewer(
+                  newestPendingDecision.publication,
+                  retainedPublication,
+                )
+              ) {
+                // Keep the queue slot and its retry history, but refresh the
+                // producer provenance from the freshest known artifact.
+                retained.item.decision = newestPendingDecision;
+                retained.item.updatedAt = now;
+              }
+              if (semanticIngress) {
+                this.writeStateSync(state);
+                this.incrementQueueMetricsSync({
+                  publicationCompleted: semanticDuplicatesRemoved,
+                  publicationSuperseded: semanticDuplicatesRemoved,
+                  publicationSemanticDeduped: semanticDuplicatesRemoved + 1,
+                });
+                return {
+                  deduped: true as const,
+                  semantic: true as const,
+                  key: retained.item.key,
+                  semanticDuplicatesRemoved,
+                  state,
+                };
+              }
+              if (semanticDuplicatesRemoved) {
+                this.incrementQueueMetricsSync({
+                  publicationCompleted: semanticDuplicatesRemoved,
+                  publicationSuperseded: semanticDuplicatesRemoved,
+                  publicationSemanticDeduped: semanticDuplicatesRemoved,
+                });
+              }
+            }
           }
           for (const entry of matching
             .filter(
@@ -765,7 +889,16 @@ export class ExactReviewQueue {
           {
             ok: true,
             deduped: true,
-            item_key: exactReviewItemKey(decision),
+            item_key:
+              "semantic" in accepted && accepted.semantic
+                ? accepted.key
+                : exactReviewItemKey(decision),
+            ...("semantic" in accepted && accepted.semantic
+              ? {
+                  semantic_deduped: true,
+                  semantic_duplicates_removed: accepted.semanticDuplicatesRemoved,
+                }
+              : {}),
             ...(accepted.superseded
               ? {
                   superseded: true,
@@ -1514,6 +1647,7 @@ export class ExactReviewQueue {
             completed_total: metrics.publication.completed,
             published_total: metrics.publication.published,
             superseded_total: metrics.publication.superseded,
+            semantic_deduped_total: metrics.publication.semanticDeduped,
             retried_total: metrics.publication.retried,
             dead_lettered_total: metrics.publication.deadLettered,
             refreshed_total: metrics.publication.refreshed,
@@ -3279,6 +3413,7 @@ export class ExactReviewQueue {
       "publication_enqueued_total",
       "publication_published_total",
       "publication_superseded_total",
+      "publication_semantic_deduped_total",
       "publication_retried_total",
       "publication_dead_lettered_total",
       "publication_refreshed_total",
@@ -3317,12 +3452,20 @@ export class ExactReviewQueue {
          publication_resolved INTEGER NOT NULL DEFAULT 0 CHECK (publication_resolved >= 0),
          publication_published INTEGER NOT NULL DEFAULT 0 CHECK (publication_published >= 0),
          publication_superseded INTEGER NOT NULL DEFAULT 0 CHECK (publication_superseded >= 0),
+         publication_semantic_deduped INTEGER NOT NULL DEFAULT 0
+           CHECK (publication_semantic_deduped >= 0),
          publication_retried INTEGER NOT NULL DEFAULT 0 CHECK (publication_retried >= 0),
          publication_dead_lettered INTEGER NOT NULL DEFAULT 0
            CHECK (publication_dead_lettered >= 0)
        ) STRICT`,
     );
-    for (const column of ["review_enqueued", "review_completed", "review_retried", "review_shed"]) {
+    for (const column of [
+      "review_enqueued",
+      "review_completed",
+      "review_retried",
+      "review_shed",
+      "publication_semantic_deduped",
+    ]) {
       const present = Array.from(
         this.storage.sql.exec(
           `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}')
@@ -3821,6 +3964,7 @@ export class ExactReviewQueue {
         `SELECT review_enqueued_total, review_completed_total,
                 publication_enqueued_total, publication_completed_total,
                 publication_published_total, publication_superseded_total,
+                publication_semantic_deduped_total,
                 publication_retried_total, publication_dead_lettered_total,
                 publication_refreshed_total
            FROM ${EXACT_REVIEW_QUEUE_METRICS_TABLE}
@@ -3834,6 +3978,7 @@ export class ExactReviewQueue {
           publication_completed_total?: number;
           publication_published_total?: number;
           publication_superseded_total?: number;
+          publication_semantic_deduped_total?: number;
           publication_retried_total?: number;
           publication_dead_lettered_total?: number;
           publication_refreshed_total?: number;
@@ -3849,6 +3994,7 @@ export class ExactReviewQueue {
         completed: exactReviewMetricTotal(row?.publication_completed_total),
         published: exactReviewMetricTotal(row?.publication_published_total),
         superseded: exactReviewMetricTotal(row?.publication_superseded_total),
+        semanticDeduped: exactReviewMetricTotal(row?.publication_semantic_deduped_total),
         retried: exactReviewMetricTotal(row?.publication_retried_total),
         deadLettered: exactReviewMetricTotal(row?.publication_dead_lettered_total),
         refreshed: exactReviewMetricTotal(row?.publication_refreshed_total),
@@ -3865,6 +4011,7 @@ export class ExactReviewQueue {
     const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
     const publicationPublished = exactReviewMetricDelta(delta.publicationPublished);
     const publicationSuperseded = exactReviewMetricDelta(delta.publicationSuperseded);
+    const publicationSemanticDeduped = exactReviewMetricDelta(delta.publicationSemanticDeduped);
     const publicationRetried = exactReviewMetricDelta(delta.publicationRetried);
     const publicationDeadLettered = exactReviewMetricDelta(delta.publicationDeadLettered);
     const publicationRefreshed = exactReviewMetricDelta(delta.publicationRefreshed);
@@ -3877,6 +4024,7 @@ export class ExactReviewQueue {
       !publicationCompleted &&
       !publicationPublished &&
       !publicationSuperseded &&
+      !publicationSemanticDeduped &&
       !publicationRetried &&
       !publicationDeadLettered &&
       !publicationRefreshed
@@ -3891,6 +4039,7 @@ export class ExactReviewQueue {
               publication_completed_total = publication_completed_total + ?,
               publication_published_total = publication_published_total + ?,
               publication_superseded_total = publication_superseded_total + ?,
+              publication_semantic_deduped_total = publication_semantic_deduped_total + ?,
               publication_retried_total = publication_retried_total + ?,
               publication_dead_lettered_total = publication_dead_lettered_total + ?,
               publication_refreshed_total = publication_refreshed_total + ?
@@ -3901,6 +4050,7 @@ export class ExactReviewQueue {
       publicationCompleted,
       publicationPublished,
       publicationSuperseded,
+      publicationSemanticDeduped,
       publicationRetried,
       publicationDeadLettered,
       publicationRefreshed,
@@ -3914,6 +4064,7 @@ export class ExactReviewQueue {
       publicationCompleted,
       publicationPublished,
       publicationSuperseded,
+      publicationSemanticDeduped,
       publicationRetried,
       publicationDeadLettered,
     });
@@ -3928,6 +4079,7 @@ export class ExactReviewQueue {
     publicationCompleted,
     publicationPublished,
     publicationSuperseded,
+    publicationSemanticDeduped,
     publicationRetried,
     publicationDeadLettered,
   }: {
@@ -3939,6 +4091,7 @@ export class ExactReviewQueue {
     publicationCompleted: number;
     publicationPublished: number;
     publicationSuperseded: number;
+    publicationSemanticDeduped: number;
     publicationRetried: number;
     publicationDeadLettered: number;
   }) {
@@ -3951,6 +4104,7 @@ export class ExactReviewQueue {
       !publicationCompleted &&
       !publicationPublished &&
       !publicationSuperseded &&
+      !publicationSemanticDeduped &&
       !publicationRetried &&
       !publicationDeadLettered
     ) {
@@ -3963,8 +4117,9 @@ export class ExactReviewQueue {
       `INSERT INTO ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
          (bucket_start, review_enqueued, review_completed, review_retried, review_shed,
           publication_enqueued, publication_resolved, publication_published,
-          publication_superseded, publication_retried, publication_dead_lettered)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          publication_superseded, publication_semantic_deduped,
+          publication_retried, publication_dead_lettered)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(bucket_start) DO UPDATE SET
          review_enqueued = review_enqueued + excluded.review_enqueued,
          review_completed = review_completed + excluded.review_completed,
@@ -3974,6 +4129,8 @@ export class ExactReviewQueue {
          publication_resolved = publication_resolved + excluded.publication_resolved,
          publication_published = publication_published + excluded.publication_published,
          publication_superseded = publication_superseded + excluded.publication_superseded,
+         publication_semantic_deduped =
+           publication_semantic_deduped + excluded.publication_semantic_deduped,
          publication_retried = publication_retried + excluded.publication_retried,
          publication_dead_lettered =
            publication_dead_lettered + excluded.publication_dead_lettered`,
@@ -3986,6 +4143,7 @@ export class ExactReviewQueue {
       publicationCompleted,
       publicationPublished,
       publicationSuperseded,
+      publicationSemanticDeduped,
       publicationRetried,
       publicationDeadLettered,
     );
@@ -4403,6 +4561,7 @@ export class ExactReviewQueue {
                   COALESCE(SUM(publication_resolved), 0) AS resolved,
                   COALESCE(SUM(publication_published), 0) AS published,
                   COALESCE(SUM(publication_superseded), 0) AS superseded,
+                  COALESCE(SUM(publication_semantic_deduped), 0) AS semantic_deduped,
                   COALESCE(SUM(publication_retried), 0) AS retried,
                   COALESCE(SUM(publication_dead_lettered), 0) AS dead_lettered
              FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
@@ -4416,6 +4575,7 @@ export class ExactReviewQueue {
       const retried = Number(row?.retried || 0);
       const published = Number(row?.published || 0);
       const superseded = Number(row?.superseded || 0);
+      const semanticDeduped = Number(row?.semantic_deduped || 0);
       const deadLettered = Number(row?.dead_lettered || 0);
       return {
         window_minutes: windowMs / 60_000,
@@ -4423,12 +4583,14 @@ export class ExactReviewQueue {
         resolved,
         published,
         superseded,
+        semantic_deduped: semanticDeduped,
         retried,
         dead_lettered: deadLettered,
         arrival_rate_per_hour: Math.round(enqueued * multiplier * 10) / 10,
         resolved_rate_per_hour: Math.round(resolved * multiplier * 10) / 10,
         published_rate_per_hour: Math.round(published * multiplier * 10) / 10,
         superseded_rate_per_hour: Math.round(superseded * multiplier * 10) / 10,
+        semantic_deduped_rate_per_hour: Math.round(semanticDeduped * multiplier * 10) / 10,
         retried_rate_per_hour: Math.round(retried * multiplier * 10) / 10,
         dead_lettered_rate_per_hour: Math.round(deadLettered * multiplier * 10) / 10,
         net_drain_rate_per_hour: Math.round((resolved - enqueued) * multiplier * 10) / 10,
@@ -4959,6 +5121,43 @@ function exactReviewPublicationRevision(decision: ExactReviewDecision): {
     targetKey: publication.itemKey.toLowerCase(),
     sourceRevision: publication.leaseRevision,
   };
+}
+
+function exactReviewPublicationLineage(decision: ExactReviewDecision): {
+  targetKey: string;
+  sourceRevision: number;
+  claimGeneration: number;
+} | null {
+  const publication = decision.publication;
+  if (!publication || publication.protocolVersion !== 2 || publication.leaseRevision === null) {
+    return null;
+  }
+  if (publication.claimGeneration === null) return null;
+  return {
+    targetKey: publication.itemKey.toLowerCase(),
+    sourceRevision: publication.leaseRevision,
+    claimGeneration: publication.claimGeneration,
+  };
+}
+
+function exactReviewPublicationProducerIsNewer(
+  incoming: ExactReviewPublication,
+  retained: ExactReviewPublication,
+) {
+  const runComparison = compareDecimalIdentifiers(incoming.producerRunId, retained.producerRunId);
+  return (
+    runComparison > 0 ||
+    (runComparison === 0 && incoming.producerRunAttempt > retained.producerRunAttempt)
+  );
+}
+
+function compareDecimalIdentifiers(left: string, right: string) {
+  const normalizedLeft = left.replace(/^0+/, "") || "0";
+  const normalizedRight = right.replace(/^0+/, "") || "0";
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return normalizedLeft.length - normalizedRight.length;
+  }
+  return normalizedLeft.localeCompare(normalizedRight);
 }
 
 function exactReviewPublicationFrom(value): ExactReviewPublication | null {

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -182,6 +182,19 @@ cleaned up, no workflow was paused, and no live apply or close was executed.
 | Parallel prepare and size-32 readiness        | Planned; separate implementation boundary      | Keep actual ownership bounded while preparation becomes concurrent, initially with four isolated workers. Preserve deterministic aggregation, batch heartbeat, fencing, per-item outcomes, GitHub-effect idempotency, resource bounds, and one final state commit. Prove this at size 8 before treating size 32 as safe.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | Size-32 capacity proof                        | Not complete                                   | A dashboard value of 32 is configuration evidence, not behavior proof. Completion requires one 32-distinct-item state commit with 32 independent accepted outcomes, bounded runtime and lease margin, unchanged contention/DLQ safety, two consecutive positive five-minute windows, and a following positive 60-minute window.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
+### Publication lineage deduplication
+
+Queue admission treats one protocol-v2 result tuple as one publication lineage:
+`targetRepo#itemNumber + leaseRevision + claimGeneration`. Producer run ids and
+attempts remain provenance, but retries for the same tuple do not create another
+effective publication chain. A pending lineage keeps its queue slot and retry
+history while adopting the newest producer artifact. A lineage already owned by
+a dispatch or durable batch lease is immutable; later equivalent deliveries are
+acknowledged as semantic duplicates without stealing ownership. New review
+revisions, comment routing, and apply work remain separate lanes. The queue
+reports `semantic_deduped_total` independently from stale-revision supersession
+so backlog reduction is not mistaken for completed review output. See #800.
+
 ## Production incident and root cause
 
 The first real size-2 batch was

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -266,6 +266,288 @@ test("exact-review queue bypasses debounce for commands and publications", async
   }
 });
 
+test("exact-review queue coalesces one pending publication lineage across producer runs", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const first = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "lineage-first",
+      753,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(753, "7530"),
+    ),
+  );
+  assert.equal((await first.json()).queued, true);
+
+  const duplicate = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "lineage-duplicate",
+      753,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(753, "7531"),
+    ),
+  );
+  assert.deepEqual(await duplicate.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#753@publish:7530:1",
+    semantic_deduped: true,
+    semantic_duplicates_removed: 0,
+  });
+
+  const duplicateRetry = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "lineage-duplicate-retry",
+      753,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(753, "7531"),
+    ),
+  );
+  assert.deepEqual(await duplicateRetry.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#753@publish:7530:1",
+    semantic_deduped: true,
+    semantic_duplicates_removed: 0,
+  });
+
+  const delayedFirstProducer = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "lineage-first-producer-delayed",
+      753,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(753, "7530"),
+    ),
+  );
+  assert.equal((await delayedFirstProducer.json()).deduped, true);
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { publication: { producerRunId: string } } }>;
+  };
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#753@publish:7530:1"]);
+  assert.equal(
+    state.items["openclaw/gogcli#753@publish:7530:1"].decision.publication.producerRunId,
+    "7531",
+  );
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.publication.enqueued_total, 1);
+  assert.equal(stats.lanes.publication.semantic_deduped_total, 3);
+});
+
+test("exact-review queue cleans legacy sibling lineages without replacing newer provenance", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "legacy-lineage-first",
+      755,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(755, "7550"),
+    ),
+  );
+  const firstState = structuredClone(
+    (await storage.get("exact-review-queue")) as {
+      items: Record<string, { key: string; createdAt: number; decision: unknown }>;
+    },
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "legacy-lineage-second",
+      755,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(755, "7551"),
+    ),
+  );
+  const refreshedState = structuredClone(
+    (await storage.get("exact-review-queue")) as typeof firstState,
+  );
+  const firstKey = "openclaw/gogcli#755@publish:7550:1";
+  const siblingKey = "openclaw/gogcli#755@publish:7551:1";
+  const firstItem = firstState.items[firstKey];
+  const refreshedItem = refreshedState.items[firstKey];
+  await storage.put("exact-review-queue", {
+    ...refreshedState,
+    items: {
+      [firstKey]: firstItem,
+      [siblingKey]: {
+        ...refreshedItem,
+        key: siblingKey,
+        createdAt: firstItem.createdAt + 1,
+      },
+    },
+  });
+
+  const retry = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "legacy-lineage-first-retry",
+      755,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(755, "7550"),
+    ),
+  );
+  assert.deepEqual(await retry.json(), {
+    ok: true,
+    deduped: true,
+    item_key: firstKey,
+    semantic_deduped: true,
+    semantic_duplicates_removed: 1,
+  });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { revision: number; decision: { publication: { producerRunId: string } } }
+    >;
+  };
+  assert.deepEqual(Object.keys(state.items), [firstKey]);
+  assert.equal(state.items[firstKey].revision, 1);
+  assert.equal(state.items[firstKey].decision.publication.producerRunId, "7551");
+});
+
+test("exact-review queue persists legacy sibling cleanup during same-key redelivery", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "legacy-sibling-first",
+      756,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(756, "7560"),
+    ),
+  );
+  const firstState = structuredClone(
+    (await storage.get("exact-review-queue")) as {
+      items: Record<string, { key: string; createdAt: number; decision: unknown }>;
+    },
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "legacy-sibling-second",
+      756,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(756, "7561"),
+    ),
+  );
+  const refreshedState = structuredClone(
+    (await storage.get("exact-review-queue")) as typeof firstState,
+  );
+  const olderKey = "openclaw/gogcli#756@publish:7560:1";
+  const retainedKey = "openclaw/gogcli#756@publish:7561:1";
+  const olderItem = firstState.items[olderKey];
+  const refreshedItem = refreshedState.items[olderKey];
+  await storage.put("exact-review-queue", {
+    ...refreshedState,
+    items: {
+      [retainedKey]: {
+        ...refreshedItem,
+        key: retainedKey,
+        createdAt: 1,
+      },
+      [olderKey]: {
+        ...olderItem,
+        createdAt: 2,
+      },
+    },
+  });
+
+  const retry = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "legacy-sibling-retained-retry",
+      756,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(756, "7561"),
+    ),
+  );
+  assert.deepEqual(await retry.json(), {
+    ok: true,
+    queued: true,
+    item_key: retainedKey,
+    superseded_publications: 0,
+  });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { revision: number; decision: { publication: { producerRunId: string } } }
+    >;
+  };
+  assert.deepEqual(Object.keys(state.items), [retainedKey]);
+  assert.equal(state.items[retainedKey].revision, 2);
+  assert.equal(state.items[retainedKey].decision.publication.producerRunId, "7561");
+});
+
+test("exact-review queue protects an active batch lineage from a later duplicate", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+      EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "1",
+    },
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "active-lineage-first",
+      754,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(754, "7540"),
+    ),
+  );
+  const claim = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        claim_id: "lineage-batch",
+        lease_owner: "lineage-owner",
+        max_items: 1,
+      }),
+    }),
+  );
+  assert.equal((await claim.json()).claimed, true);
+
+  const duplicate = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "active-lineage-duplicate",
+      754,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(754, "7541"),
+    ),
+  );
+  assert.equal((await duplicate.json()).semantic_deduped, true);
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: { publication: { producerRunId: string } } }>;
+  };
+  assert.deepEqual(Object.keys(state.items), ["openclaw/gogcli#754@publish:7540:1"]);
+  assert.equal(
+    state.items["openclaw/gogcli#754@publish:7540:1"].decision.publication.producerRunId,
+    "7540",
+  );
+});
+
 test("exact-review queue sheds only new recovery work above the pending soft limit", async () => {
   const storage = new MemoryDurableStorage();
   const env = {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -702,7 +702,7 @@ test("newer publication revisions supersede unowned pending rows at enqueue", as
   }
 });
 
-test("bounded enqueue cleanup cannot leave obsolete rows eligible for a batch", async () => {
+test("semantic lineage dedupe cannot leave obsolete rows eligible for a batch", async () => {
   const originalNow = Date.now;
   Date.now = () => 6_250_000;
   try {
@@ -729,7 +729,8 @@ test("bounded enqueue cleanup cannot leave obsolete rows eligible for a batch", 
     );
 
     const before = await (await queue.fetch(new Request("https://queue/stats"))).json();
-    assert.equal(before.lanes.publication.pending, 2);
+    assert.equal(before.lanes.publication.pending, 1);
+    assert.equal(before.lanes.publication.semantic_deduped_total, 100);
     const claim = await (
       await queue.fetch(
         batchRequest("/publication-batches/claim", {


### PR DESCRIPTION
## Summary

- Coalesce protocol-v2 exact-review publication deliveries by immutable lineage before batch claim.
- Keep the oldest pending slot's retry history while retaining the freshest known producer artifact.
- Preserve active-batch ownership and same-producer revision handoff.
- Add regressions for refreshed-producer retries, delayed older producers, and both legacy sibling orderings.

Reported by @snowzlmbot automation in #801. This maintainer-owned replacement supersedes that broken PR.

Fixes #800.

## Proof

- `pnpm run build:all`
- Focused lineage and same-producer handoff tests passed.
- Autoreview completed clean with no findings.
- Local `pnpm run check` reached the complete suite but has unrelated host failures: missing GNU `timeout`, Linux-only `capset` assumptions, and macOS `/private` path normalization. Hosted CI is the full-suite gate for this exact head.
