### PR TITLE
fix(router): strip every trailing bot suffix in normalizeGitHubActor

### DIFF
--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -419,10 +419,12 @@ export function isAllowedMutationActor(login: JsonValue, trustedBots: Iterable<s
 }
 
 export function normalizeGitHubActor(login: JsonValue) {
+  // Strip every trailing [bot] suffix: "evil[bot][bot]" must not normalize to
+  // "evil[bot]" and collide with a real bot's normalized identity (#574).
   return String(login ?? "")
     .trim()
     .toLowerCase()
-    .replace(/\[bot\]$/i, "");
+    .replace(/(\[bot\])+$/i, "");
 }
 
 export function isGitHubAppIntegrationAuthError(message: JsonValue) {

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -1433,6 +1433,12 @@ test("mutation actor guard accepts only trusted bot identities", () => {
   const trustedBots = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
 
   assert.equal(normalizeGitHubActor("ClawSweeper[bot]"), "clawsweeper");
+  // Idempotent suffix strip: a doubled suffix must not survive one pass and
+  // collide with a real bot's normalized identity (#574).
+  assert.equal(normalizeGitHubActor("ClawSweeper[bot][bot]"), "clawsweeper");
+  assert.equal(normalizeGitHubActor("evil[BOT][bot][Bot]"), "evil");
+  assert.equal(normalizeGitHubActor(normalizeGitHubActor("evil[bot][bot]")), "evil");
+  assert.equal(normalizeGitHubActor("keeps[bot]inside"), "keeps[bot]inside");
   assert.equal(isAllowedMutationActor("ClawSweeper[bot]", trustedBots), true);
   assert.equal(isAllowedMutationActor("clawsweeper[bot]", trustedBots), true);
   assert.equal(isAllowedMutationActor("clawsweeper", trustedBots), false);


### PR DESCRIPTION
## What Problem This Solves

Fixes #574. `normalizeGitHubActor` stripped only one trailing `[bot]` suffix, so `evil[bot][bot]` normalized to `evil[bot]` — one strip away from colliding with a real bot's normalized identity in the re-review requester dedupe key, the one comparison built on this normalization.

## Why This Change Was Made

The strip is now anchored and greedy (`/(\[bot\])+$/i`), removing every contiguous trailing suffix in one pass and making the function idempotent. Embedded markers (`keeps[bot]inside`) are untouched. Call-site audit: the only production consumer is the requester key in `supersededReReviewVersions`; `isAllowedMutationActor` compares raw lowercase logins against the trusted list and was never affected.

## User Impact

Actor normalization can no longer be spoofed by suffix stacking.

## Evidence

- `node --test test/repair/comment-router-utils.test.ts`: 48/48 pass, including the doubled-suffix, mixed-case, idempotency, and embedded-marker regressions.
- Codex autoreview: clean (correct 0.98).
