### PR TITLE
feat(repair): one authoritative multi-owner repair policy enforced at intake

### DIFF
--- a/src/repair/commit-finding-intake.ts
+++ b/src/repair/commit-finding-intake.ts
@@ -3,7 +3,9 @@ import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
 import path from "node:path";
 import {
+  allowedRepairOwners,
   hasSecuritySignalText,
+  isAllowedRepairOwner,
   makeRunDir,
   parseArgs,
   parseJob,
@@ -60,7 +62,7 @@ function prepare() {
   const branch = `clawsweeper/${clusterId}`;
   const latestMain = fetchLatestMain(targetRepo);
   const decision = reportRead.ok
-    ? intakeDecision({ enabled, report, reportMarkdown })
+    ? intakeDecision({ enabled, targetRepo, report, reportMarkdown })
     : { status: "report_missing", shouldRepair: false, reason: reportRead.reason };
   const preparedAt = new Date().toISOString();
   const runDir = decision.shouldRepair
@@ -142,9 +144,21 @@ function finalize() {
   console.log(JSON.stringify({ status, audit_path: relative(auditPath), pr_url: prUrl }, null, 2));
 }
 
-function intakeDecision({ enabled, report, reportMarkdown }: LooseRecord) {
+function intakeDecision({ enabled, targetRepo, report, reportMarkdown }: LooseRecord) {
   if (!truthy(enabled)) {
     return { status: "disabled", shouldRepair: false, reason: "commit finding intake disabled" };
+  }
+  // Same authoritative owner policy as issue intake and the execution gates:
+  // never commit a durable repair job that assertAllowedOwner or CrabFleet
+  // registration would reject (#604).
+  const repo = String(targetRepo ?? "");
+  const allowedOwner = process.env.CLAWSWEEPER_ALLOWED_OWNER;
+  if (!isAllowedRepairOwner(repo, allowedOwner)) {
+    return {
+      status: "owner_policy_blocked",
+      shouldRepair: false,
+      reason: `unsupported target repo owner ${repo.split("/")[0]}; repair owner policy allows ${allowedRepairOwners(allowedOwner).join(", ")}`,
+    };
   }
   if (report.result !== "findings") {
     return {

--- a/src/repair/issue-implementation-intake.ts
+++ b/src/repair/issue-implementation-intake.ts
@@ -4,7 +4,14 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { parseArgs, parseJob, repoRoot, validateJob } from "./lib.js";
+import {
+  allowedRepairOwners,
+  isAllowedRepairOwner,
+  parseArgs,
+  parseJob,
+  repoRoot,
+  validateJob,
+} from "./lib.js";
 import { ghErrorText, ghJsonWithRetry } from "./github-cli.js";
 import {
   issueImplementationJobBranch,
@@ -266,6 +273,7 @@ export function reportOnlyDecision({
   operatorOverride = false,
   itemNumber = Number(report.frontmatter.number),
   live = null,
+  allowedOwner,
 }: {
   targetRepo: string;
   report: ReviewReport;
@@ -274,6 +282,7 @@ export function reportOnlyDecision({
   operatorOverride?: boolean;
   itemNumber?: number;
   live?: LooseRecord | null;
+  allowedOwner?: string;
 }): IntakeDecision {
   return eligibilityDecision({
     targetRepo,
@@ -284,6 +293,7 @@ export function reportOnlyDecision({
     candidateKind,
     operatorOverride,
     itemNumber,
+    ...(allowedOwner === undefined ? {} : { allowedOwner }),
   });
 }
 
@@ -327,6 +337,7 @@ function eligibilityDecision({
   reportMarkdown,
   live,
   operatorOverride = false,
+  allowedOwner = process.env.CLAWSWEEPER_ALLOWED_OWNER,
 }: {
   enabled: string;
   targetRepo: string;
@@ -336,9 +347,20 @@ function eligibilityDecision({
   reportMarkdown: string;
   live: LooseRecord | null;
   operatorOverride?: boolean;
+  allowedOwner?: string;
 }): IntakeDecision {
   if (!truthy(enabled)) {
     return decision("disabled", false, "issue implementation intake disabled");
+  }
+  // The execution gates (assertAllowedOwner, CrabFleet registration) enforce
+  // the same owner policy; rejecting here keeps durable state free of repair
+  // jobs that could never pass their first gate (#604).
+  if (!isAllowedRepairOwner(targetRepo, allowedOwner)) {
+    return decision(
+      "owner_policy_blocked",
+      false,
+      `unsupported target repo owner ${targetRepo.split("/")[0]}; repair owner policy allows ${allowedRepairOwners(allowedOwner).join(", ")}`,
+    );
   }
   const normalizedTargetRepo = targetRepo.trim().toLowerCase();
   if (

--- a/src/repair/lib.ts
+++ b/src/repair/lib.ts
@@ -460,10 +460,26 @@ export function parseArgs(argv: string[]): CliArgs {
   return args;
 }
 
+// CLAWSWEEPER_ALLOWED_OWNER is the one authoritative repair owner policy
+// (issue #604): a comma- or whitespace-separated owner list shared by intake
+// and every execution gate, so eligibility cannot diverge between them.
+export function allowedRepairOwners(allowedOwner?: string): string[] {
+  return String(allowedOwner ?? "")
+    .split(/[\s,]+/)
+    .map((owner) => owner.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isAllowedRepairOwner(repo: string, allowedOwner?: string): boolean {
+  const owners = allowedRepairOwners(allowedOwner);
+  if (owners.length === 0) return true;
+  return owners.includes(String(repo.split("/")[0] ?? "").toLowerCase());
+}
+
 export function assertAllowedOwner(repo: string, allowedOwner?: string) {
   if (!allowedOwner) return;
-  const owner = repo.split("/")[0];
-  if (owner !== allowedOwner) {
+  if (!isAllowedRepairOwner(repo, allowedOwner)) {
+    const owner = repo.split("/")[0];
     throw new Error(`repo owner ${owner} does not match CLAWSWEEPER_ALLOWED_OWNER=${allowedOwner}`);
   }
 }

--- a/test/repair/issue-implementation-intake.test.ts
+++ b/test/repair/issue-implementation-intake.test.ts
@@ -64,6 +64,48 @@ test("strict reproducible bug reports are eligible for implementation intake", (
   assert.equal(decision.status, "queued_for_repair");
 });
 
+test("owner policy admits allowed owners and rejects the rest before durable intake", () => {
+  const markdown = report({ repository: "steipete/oracle" });
+  const parsed = parseReviewReport(markdown);
+  const base = {
+    targetRepo: "steipete/oracle",
+    report: parsed,
+    reportMarkdown: markdown,
+  };
+
+  // Review-only external owner: policy does not include it, so nothing is queued.
+  const reviewOnly = reportOnlyDecision({ ...base, allowedOwner: "openclaw" });
+  assert.equal(reviewOnly.shouldRepair, false);
+  assert.equal(reviewOnly.status, "owner_policy_blocked");
+  assert.match(reviewOnly.reason, /unsupported target repo owner steipete/);
+  assert.match(reviewOnly.reason, /repair owner policy allows openclaw/);
+
+  // Explicitly approved external repair owner: the same report queues.
+  const approved = reportOnlyDecision({ ...base, allowedOwner: "openclaw, steipete" });
+  assert.equal(approved.shouldRepair, true);
+  assert.equal(approved.status, "queued_for_repair");
+
+  // Allowed primary owner keeps working under the widened policy.
+  const internalMarkdown = report();
+  const internal = reportOnlyDecision({
+    targetRepo: "openclaw/openclaw",
+    report: parseReviewReport(internalMarkdown),
+    reportMarkdown: internalMarkdown,
+    allowedOwner: "openclaw,steipete",
+  });
+  assert.equal(internal.shouldRepair, true);
+  assert.equal(internal.status, "queued_for_repair");
+
+  // An operator override cannot bypass the owner policy.
+  const overridden = reportOnlyDecision({
+    ...base,
+    allowedOwner: "openclaw",
+    operatorOverride: true,
+  });
+  assert.equal(overridden.shouldRepair, false);
+  assert.equal(overridden.status, "owner_policy_blocked");
+});
+
 test("implementation intake rejects feature and config-option work", () => {
   for (const overrides of [
     { item_category: "feature" },

--- a/test/repair/lib.test.ts
+++ b/test/repair/lib.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  allowedRepairOwners,
+  assertAllowedOwner,
   hasDeterministicSecuritySignal,
   hasSecuritySignalText,
+  isAllowedRepairOwner,
   parseArgs,
   parseSimpleYaml,
   renderPrompt,
@@ -84,5 +87,24 @@ test("deterministic security signals accept labels and structured ClawSweeper ma
       comments: ["<!-- clawsweeper-security:security-sensitive item=123 sha=abc -->"],
     }),
     true,
+  );
+});
+
+test("repair owner policy accepts a comma or whitespace separated owner list", () => {
+  assert.deepEqual(allowedRepairOwners("openclaw, steipete"), ["openclaw", "steipete"]);
+  assert.deepEqual(allowedRepairOwners("  OpenClaw   steipete\n"), ["openclaw", "steipete"]);
+  assert.deepEqual(allowedRepairOwners(undefined), []);
+
+  assert.equal(isAllowedRepairOwner("openclaw/openclaw", "openclaw,steipete"), true);
+  assert.equal(isAllowedRepairOwner("steipete/oracle", "openclaw,steipete"), true);
+  assert.equal(isAllowedRepairOwner("Steipete/oracle", "openclaw,steipete"), true);
+  assert.equal(isAllowedRepairOwner("evil/oracle", "openclaw,steipete"), false);
+  // An empty policy keeps the historical fail-open behavior of assertAllowedOwner.
+  assert.equal(isAllowedRepairOwner("anyone/repo", undefined), true);
+
+  assertAllowedOwner("steipete/oracle", "openclaw,steipete");
+  assert.throws(
+    () => assertAllowedOwner("evil/oracle", "openclaw,steipete"),
+    /repo owner evil does not match CLAWSWEEPER_ALLOWED_OWNER=openclaw,steipete/,
   );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes #604 per maintainer decision: widen the repair scope to cover steipete-owned repositories, with one authoritative policy instead of the current intake/execution mismatch (intake queued `steipete/oracle` work that `CLAWSWEEPER_ALLOWED_OWNER=openclaw` and CrabFleet then rejected, leaving impossible jobs in durable state).

## Why This Change Was Made

- `CLAWSWEEPER_ALLOWED_OWNER` is now the single policy: a comma- or whitespace-separated, case-insensitive owner list parsed by shared helpers (`allowedRepairOwners` / `isAllowedRepairOwner`) in `lib.ts`. `assertAllowedOwner` (every execution gate) and both intakes read the same value, so eligibility cannot diverge.
- Issue-implementation intake and commit-finding intake reject disallowed owners **before** committing a durable job, recording `owner_policy_blocked` with an explicit reason. Operator override cannot bypass the owner policy.
- An empty/unset policy keeps the historical fail-open behavior; existing single-owner values keep working unchanged.

## Rollout (order matters)

1. Merge this PR (parsing must be deployed first — the old exact-string compare would reject everything if the variable were widened early).
2. Set Actions variable `CLAWSWEEPER_ALLOWED_OWNER` to `openclaw,steipete`.
3. Allowlist the steipete repos in CrabFleet (runtime admin action, owner role, on the CrabFleet admin surface — its allowlist is DB-managed, not config).
4. Reconciliation of existing stuck jobs (e.g. `jobs/steipete/inbox/issue-steipete-oracle-326.md`): once steps 2–3 land, the existing jobs pass the gates on their next repair run — no state surgery needed. Jobs for owners that remain outside the policy will be rejected at intake going forward and can be pruned by the janitor.

## User Impact

Hot-target review findings on approved external repos (e.g. `steipete/oracle#326`) can proceed to autonomous repair instead of dying at CrabFleet registration; disallowed owners are now refused up front with an auditable status.

## Evidence

- `node --test` lib + both intake suites: 34/34 pass, covering allowed owner, review-only external owner, explicitly approved external owner, override-cannot-bypass, delimiters, casing, and fail-open.
- Codex autoreview: clean (correct 0.91).
