### PR TITLE
fix(materializer): append recovery action events

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -107,6 +107,7 @@ jobs:
         if: ${{ always() }}
         env:
           CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "0"
+          CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
           CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -118,6 +118,7 @@ test("state materializer and apply publishers enable model-guided recovery with 
     "${{ steps.state-token.outputs.token }}",
   );
   assert.equal(recoveryPublisher?.env?.CLAWSWEEPER_MODEL_RECOVERY_ENABLED, "0");
+  assert.equal(recoveryPublisher?.env?.CLAWSWEEPER_STATE_APPEND_ENABLED, "1");
   assert.equal(recoveryPublisher?.env?.OPENAI_API_KEY, undefined);
 
   const sweep = byFile.get(".github/workflows/sweep.yml");
@@ -194,6 +195,24 @@ test("trusted generated-state mutation steps receive a step-scoped coordinator c
     36,
     "new or removed generated-state publication surfaces require an explicit credential audit",
   );
+});
+
+test("every immutable action-event publisher uses the state append window", () => {
+  const publishers: string[] = [];
+  for (const { file, workflow } of workflows()) {
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        if (!String(step.run || "").includes("publish-action-event-paths")) continue;
+        publishers.push(`${file}:${jobName}:${step.name}`);
+        assert.equal(
+          step.env?.CLAWSWEEPER_STATE_APPEND_ENABLED ?? job.env?.CLAWSWEEPER_STATE_APPEND_ENABLED,
+          "1",
+          `${file}:${jobName}:${step.name}`,
+        );
+      }
+    }
+  }
+  assert.equal(publishers.length, 7);
 });
 
 test("state compaction remains an explicitly separate main-branch writer", () => {


### PR DESCRIPTION
Related: #738

## What Problem This Solves

Resolves a problem where each state materializer cycle could finish its bulk append drain and then immediately perform another direct Git commit for its recovery action-event ledger, adding avoidable contention to the state repository.

## Why This Change Was Made

The recovery action-event publisher now uses the existing immutable `apply_proof` append path. The normal queue failure fallback remains available, and the change introduces no new append kind, SQLite schema, or protocol surface.

## User Impact

Successful materializer cycles no longer follow the main drain with a second routine state-repository writer, reducing contention while preserving recovery evidence.

## Evidence

- State-writer workflow tests: 10/10 passed.
- Immutable ledger focused tests: 2/2 passed.
- Added a repository-wide invariant proving all seven `publish-action-event-paths` workflow surfaces enable state append.
- Formatting, lint, `git diff --check`, and structured autoreview passed with no actionable findings.