### PR TITLE
fix(queue): backpressure reviews on publication health

### DIFF
--- a/dashboard/exact-review-health.ts
+++ b/dashboard/exact-review-health.ts
@@ -53,12 +53,18 @@ export type ExactReviewPressureSummary = {
     | "no_admissible_backlog"
     | "dispatcher_inactive"
     | "handoff_unknown"
-    | "capacity_full_with_backlog";
+    | "capacity_full_with_backlog"
+    | "publication_degraded"
+    | "publication_critical";
   capacity: number;
   active: number;
   pending: number;
   ready_pending: number;
   admissible_pending: number;
+};
+
+export type ExactReviewPublicationHealth = {
+  status?: "idle" | "healthy" | "degraded" | "critical";
 };
 
 const PHASES: ExactReviewPhase[] = ["pending", "dispatching", "leased"];
@@ -244,6 +250,19 @@ export function summarizeExactReviewPressure({
     reason: "capacity_full_with_backlog",
     ...common,
   };
+}
+
+export function elevateExactReviewPressureForPublication(
+  pressure: ExactReviewPressureSummary,
+  publication: ExactReviewPublicationHealth,
+): ExactReviewPressureSummary {
+  if (publication.status === "critical" && pressure.status !== "saturated") {
+    return { ...pressure, status: "saturated", reason: "publication_critical" };
+  }
+  if (publication.status === "degraded" && pressure.status === "idle") {
+    return { ...pressure, status: "congested", reason: "publication_degraded" };
+  }
+  return pressure;
 }
 
 function exactReviewPhaseStartedAt(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -6,8 +6,10 @@ import {
   type StateWriterOperation,
 } from "../src/state-writer-telemetry.ts";
 import {
+  elevateExactReviewPressureForPublication,
   summarizeExactReviewHandoff,
   summarizeExactReviewPressure,
+  type ExactReviewPublicationHealth,
 } from "./exact-review-health.ts";
 import {
   ExactReviewPublicationBatchStore,
@@ -1631,8 +1633,14 @@ export class ExactReviewQueue {
         legacyExcludedItemKeys,
         publicationBatches.nextLeaseExpiresAt,
       );
+      const publicationHealth = exactReviewPublicationHealth(
+        stats.lanes.publication,
+        publicationFlow,
+        deadLetters,
+      );
       return json({
         ...stats,
+        pressure: elevateExactReviewPressureForPublication(stats.pressure, publicationHealth),
         bay_projection: exactReviewQueueBayProjection(Object.values(state.items), bayPriorityKeys),
         lanes: {
           review: {
@@ -1653,11 +1661,7 @@ export class ExactReviewQueue {
             refreshed_total: metrics.publication.refreshed,
             flow: publicationFlow,
             dead_letters: deadLetters,
-            health: exactReviewPublicationHealth(
-              stats.lanes.publication,
-              publicationFlow,
-              deadLetters,
-            ),
+            health: publicationHealth,
             capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
             batches: {
               enabled: exactReviewPublicationBatchingEnabled(this.env),
@@ -6474,7 +6478,7 @@ function exactReviewPublicationHealth(
   lane: ReturnType<typeof exactReviewQueueLaneStats>,
   flow: { last_15_minutes: { net_drain_rate_per_hour: number } },
   deadLetters: { open: number },
-) {
+): ExactReviewPublicationHealth & { reason: string | null } {
   const oldestAge = Number(lane.oldest_pending_age_seconds || 0);
   if (lane.parked > 0 || oldestAge >= 6 * 60 * 60) {
     return {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9082,6 +9082,11 @@ function renderExactReviewHandoff(queue) {
   const pressureStatus = ["idle", "congested", "saturated", "unknown"].includes(pressure?.status)
     ? pressure.status
     : "unknown";
+  const pressureLabel = pressure?.reason === "publication_critical"
+    ? "publication critical"
+    : pressure?.reason === "publication_degraded"
+      ? "publication degraded"
+      : "pressure " + pressureStatus;
   const labels = {
     pending: ["Pending", "waiting for admission"],
     dispatching: ["Dispatching", "waiting for run claim"],
@@ -9097,7 +9102,7 @@ function renderExactReviewHandoff(queue) {
   const slots = fmt.format(health.available_slots || 0) + " of " + fmt.format(health.capacity || 0) + " exact-review slots open";
   const backlog = fmt.format(queue?.pending || 0) + " total · " + fmt.format(queue?.ready_pending || 0) + " ready · " + fmt.format(queue?.admissible_pending || 0) + " admissible";
   const threshold = "stalled after " + elapsed((health.stalled_after_seconds || 0) * 1000);
-  target.innerHTML = '<div class="exact-handoff"><div class="exact-handoff-head"><div class="exact-handoff-title"><strong>Queue handoff health</strong><span>' + esc(health.message || "Queue phase telemetry") + '</span></div><div class="exact-handoff-badges"><span class="health-badge ' + esc(status) + '">' + esc(status) + '</span><span class="health-badge ' + esc(pressureStatus) + '">pressure ' + esc(pressureStatus) + '</span></div></div><div class="handoff-phases">' + phases + '</div><div class="handoff-foot"><span>' + esc(slots) + '</span><span>' + esc(backlog) + '</span><span>' + esc(threshold) + '</span></div></div>';
+  target.innerHTML = '<div class="exact-handoff"><div class="exact-handoff-head"><div class="exact-handoff-title"><strong>Queue handoff health</strong><span>' + esc(health.message || "Queue phase telemetry") + '</span></div><div class="exact-handoff-badges"><span class="health-badge ' + esc(status) + '">' + esc(status) + '</span><span class="health-badge ' + esc(pressureStatus) + '">' + esc(pressureLabel) + '</span></div></div><div class="handoff-phases">' + phases + '</div><div class="handoff-foot"><span>' + esc(slots) + '</span><span>' + esc(backlog) + '</span><span>' + esc(threshold) + '</span></div></div>';
 }
 function renderWorkers(rows) {
   workerIndex = new Map(rows.map(worker => [String(worker.id), worker]));

--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -11,6 +11,7 @@ export type ExactReviewQueuePressure =
       ok: true;
       pendingCount: number;
       oldestPendingAgeMs: number;
+      publicationStatus?: "degraded" | "critical";
     }
   | {
       ok: false;
@@ -39,12 +40,19 @@ export async function fetchExactReviewQueuePressure({
 
     const body: unknown = await response.json();
     if (!isRecord(body)) return malformedPressure();
-    // Pressure exists to protect Codex review capacity. Publication items
-    // consume no Codex, so prefer the review lane's numbers when the stats
-    // expose them; totals (which include publications) remain the fallback
-    // for older queue deployments.
+    // Review backlog controls the normal capacity thresholds. Publication
+    // health can still elevate pressure because producing decisions faster
+    // than they can be published compounds durable queue debt.
     const reviewLane =
       isRecord(body.lanes) && isRecord(body.lanes.review) ? body.lanes.review : null;
+    const publicationLane =
+      isRecord(body.lanes) && isRecord(body.lanes.publication) ? body.lanes.publication : null;
+    const publicationHealth =
+      publicationLane && isRecord(publicationLane.health) ? publicationLane.health : null;
+    const publicationStatus =
+      publicationHealth?.status === "critical" || publicationHealth?.status === "degraded"
+        ? publicationHealth.status
+        : undefined;
     const pendingCount =
       reviewLane && isNonNegativeInteger(reviewLane.pending) ? reviewLane.pending : body.pending;
     const oldestPendingAgeSeconds =
@@ -53,7 +61,12 @@ export async function fetchExactReviewQueuePressure({
         : body.oldest_pending_age_seconds;
     if (!isNonNegativeInteger(pendingCount)) return malformedPressure();
     if (pendingCount === 0) {
-      return { ok: true, pendingCount, oldestPendingAgeMs: 0 };
+      return {
+        ok: true,
+        pendingCount,
+        oldestPendingAgeMs: 0,
+        ...(publicationStatus ? { publicationStatus } : {}),
+      };
     }
     // A null age with a positive backlog is inconsistent data — fail open
     // rather than fabricating a zero-age backlog.
@@ -65,6 +78,7 @@ export async function fetchExactReviewQueuePressure({
       ok: true,
       pendingCount,
       oldestPendingAgeMs,
+      ...(publicationStatus ? { publicationStatus } : {}),
     };
   } catch (error) {
     return {
@@ -78,6 +92,7 @@ export async function fetchExactReviewQueuePressure({
 
 export function queuePressureLevel(pressure: ExactReviewQueuePressure): QueuePressureLevel {
   if (!pressure.ok) return "none";
+  if (pressure.publicationStatus === "critical") return "hard";
   const hardPending = envThreshold(
     "CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING",
     QUEUE_PRESSURE_HARD_PENDING,
@@ -89,6 +104,7 @@ export function queuePressureLevel(pressure: ExactReviewQueuePressure): QueuePre
   if (pressure.pendingCount >= hardPending || pressure.oldestPendingAgeMs >= hardAgeMs) {
     return "hard";
   }
+  if (pressure.publicationStatus === "degraded") return "soft";
 
   const softPending = envThreshold(
     "CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING",

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7963,6 +7963,7 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   status.recent.apply_health.items = [];
   status.exact_review_queue.handoff_health.status = "stalled";
   status.exact_review_queue.pressure.status = "saturated";
+  status.exact_review_queue.pressure.reason = "publication_critical";
   status.exact_review_queue.handoff_health.message =
     "A dispatched review has not been claimed within the expected handoff window.";
   context.renderDashboard(status, "");
@@ -7970,7 +7971,7 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(elementFor("hero-dot").className, "hero-dot red");
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /health-badge stalled/);
-  assert.match(elementFor("exact-review-handoff").innerHTML, /pressure saturated/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /publication critical/);
 
   Object.assign(status, { exact_review_queue: null });
   status.diagnostics.exact_review_queue_error = "exact-review queue timed out";

--- a/test/exact-review-health.test.ts
+++ b/test/exact-review-health.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  elevateExactReviewPressureForPublication,
   summarizeExactReviewHandoff,
   summarizeExactReviewPressure,
 } from "../dashboard/exact-review-health.ts";
@@ -268,5 +269,40 @@ test("exact-review pressure preserves non-dispatchable and unknown states", () =
       ready_pending: 2,
       admissible_pending: 2,
     },
+  );
+});
+
+test("publication health elevates an otherwise idle review pressure signal", () => {
+  const idle = summarizeExactReviewPressure({
+    pending: 1,
+    readyPending: 1,
+    admissiblePending: 1,
+    dispatching: 0,
+    leased: 1,
+    capacity: 64,
+    dispatcherState: "active",
+    handoffStatus: "healthy",
+  });
+
+  assert.deepEqual(elevateExactReviewPressureForPublication(idle, { status: "degraded" }), {
+    ...idle,
+    status: "congested",
+    reason: "publication_degraded",
+  });
+  assert.deepEqual(elevateExactReviewPressureForPublication(idle, { status: "critical" }), {
+    ...idle,
+    status: "saturated",
+    reason: "publication_critical",
+  });
+  assert.deepEqual(elevateExactReviewPressureForPublication(idle, { status: "healthy" }), idle);
+
+  const saturated = {
+    ...idle,
+    status: "saturated" as const,
+    reason: "capacity_full_with_backlog" as const,
+  };
+  assert.deepEqual(
+    elevateExactReviewPressureForPublication(saturated, { status: "critical" }),
+    saturated,
   );
 });

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -504,6 +504,27 @@ test("queue batch claim defaults off and additive schema keeps the legacy versio
   assert.equal(stats.lanes.publication.batches.leased, 0);
 });
 
+test("queue pressure cannot stay idle while publication health is critical", async () => {
+  const originalNow = Date.now;
+  let now = 1_000_000;
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue({ storage: new TestStorage() }, {});
+    await queue.fetch(publicationRequest("delivery-critical", 102, "1002"));
+    now += 6 * 60 * 60 * 1_000;
+
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.deepEqual(stats.lanes.publication.health, {
+      status: "critical",
+      reason: "oldest_pending_over_6h",
+    });
+    assert.equal(stats.pressure.status, "saturated");
+    assert.equal(stats.pressure.reason, "publication_critical");
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("legacy queue migration preserves receipts while adding empty batch tables", async () => {
   const originalNow = Date.now;
   Date.now = () => 3_000_000;

--- a/test/queue-pressure.test.ts
+++ b/test/queue-pressure.test.ts
@@ -69,10 +69,8 @@ test("queue pressure fetch reads public aggregate stats", async () => {
   assert.deepEqual(empty, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
 });
 
-test("queue pressure prefers the review lane over totals that include publications", async () => {
-  // 812 total pending, but only 36 are Codex-consuming review items — pressure
-  // must not throttle review shards because of a publication backlog.
-  const result = await fetchExactReviewQueuePressure({
+test("queue pressure uses review thresholds and elevates unhealthy publication", async () => {
+  const healthyPublication = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",
     fetchImpl: async () =>
       Response.json({
@@ -80,11 +78,51 @@ test("queue pressure prefers the review lane over totals that include publicatio
         oldest_pending_age_seconds: 80_000,
         lanes: {
           review: { pending: 36, oldest_pending_age_seconds: 120 },
-          publication: { pending: 776, oldest_pending_age_seconds: 80_000 },
+          publication: {
+            pending: 776,
+            oldest_pending_age_seconds: 80_000,
+            health: { status: "healthy" },
+          },
         },
       }),
   });
-  assert.deepEqual(result, { ok: true, pendingCount: 36, oldestPendingAgeMs: 120_000 });
+  assert.deepEqual(healthyPublication, {
+    ok: true,
+    pendingCount: 36,
+    oldestPendingAgeMs: 120_000,
+  });
+  assert.equal(queuePressureLevel(healthyPublication), "none");
+
+  const criticalPublication = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () =>
+      Response.json({
+        lanes: {
+          review: { pending: 0, oldest_pending_age_seconds: null },
+          publication: {
+            pending: 776,
+            oldest_pending_age_seconds: 80_000,
+            health: { status: "critical" },
+          },
+        },
+      }),
+  });
+  assert.deepEqual(criticalPublication, {
+    ok: true,
+    pendingCount: 0,
+    oldestPendingAgeMs: 0,
+    publicationStatus: "critical",
+  });
+  assert.equal(queuePressureLevel(criticalPublication), "hard");
+  assert.equal(
+    queuePressureLevel({
+      ok: true,
+      pendingCount: QUEUE_PRESSURE_HARD_PENDING,
+      oldestPendingAgeMs: 0,
+      publicationStatus: "degraded",
+    }),
+    "hard",
+  );
 
   const emptyReviewLane = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",


### PR DESCRIPTION
Related: #738

## What Problem This Solves

Fixes an issue where the exact-review queue reported `idle` and continued admitting background reviews while durable publication was critically backlogged. This let review production compound result-delivery debt.

## Why This Change Was Made

Publication health now elevates the public pressure signal: degraded publication produces soft pressure and critical publication produces hard pressure. Existing review-pressure severity still wins, and priority review lanes plus lease semantics are unchanged.

## User Impact

Background review admission yields while durable results are falling behind, allowing publication to recover without disabling interactive or priority review work. Operators also see the publication cause instead of a misleading idle badge.

## Evidence

- Main, repair, and dashboard TypeScript builds passed.
- 19 focused tests passed.
- Touched-file lint and `git diff --check` passed.
- Structured autoreview passed with no actionable findings after one severity-ordering fix.
- The unrelated dashboard type-aware lint baseline still has the same 32 failures on `origin/main`.