### PR TITLE
fix(repair): remove router Git writer pressure

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -292,12 +292,17 @@ jobs:
             echo "Exact terminal comment version already recorded; skipping state publication."
             exit 0
           fi
-          pnpm run repair:publish-main -- \
+          publish_args=(
             --message "chore: record ClawSweeper comment routing" \
             --path results/comment-router.json \
-            --path results/comment-router-latest.json \
-            --path jobs \
             --rebase-strategy theirs
+          )
+          # The latest scan report is run-local. Only commands that actually
+          # changed repair jobs need the serialized Git state writer.
+          if [ -n "$(git status --porcelain=v1 --untracked-files=all -- jobs)" ]; then
+            publish_args+=(--path jobs)
+          fi
+          pnpm run repair:publish-main -- "${publish_args[@]}"
 
       - name: Detect waiting repair dispatches
         id: waiting-repair-dispatches
@@ -424,12 +429,16 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
-          pnpm run repair:publish-main -- \
+          publish_args=(
             --message "chore: record ClawSweeper repair dispatch retry" \
             --path results/comment-router.json \
-            --path results/comment-router-latest.json \
-            --path jobs \
             --rebase-strategy theirs
+          )
+          # Retry receipts are append-only unless the retry changed a repair job.
+          if [ -n "$(git status --porcelain=v1 --untracked-files=all -- jobs)" ]; then
+            publish_args+=(--path jobs)
+          fi
+          pnpm run repair:publish-main -- "${publish_args[@]}"
 
       - name: Finalize command action ledger
         id: finalize-command-action-ledger

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -419,7 +419,14 @@ Scripts:
 Durable state:
 
 - `results/comment-router.json`
+
+Run-local diagnostics:
+
 - `results/comment-router-latest.json`
+
+The router ledger uses the state append/materializer lane. The workflow
+publishes `jobs/` through the serialized Git writer only when a command changed
+durable repair work.
 
 Important knobs:
 

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -532,7 +532,13 @@ Branch mutation still requires the downstream `CLAWSWEEPER_ALLOW_EXECUTE=1` and
 Ledgers:
 
 - `results/comment-router.json`: processed command ledger
-- `results/comment-router-latest.json`: latest scan report
+- `results/comment-router-latest.json`: run-local latest scan report; workflows
+  consume it before exit but do not publish it as durable state
+
+The processed command ledger publishes through the state append/materializer
+lane. `jobs/` enters the serialized Git state writer only when a command creates
+or updates durable repair work, so independent re-review and status commands do
+not contend on Git publication.
 
 Command replies are marker-backed and edited in place per item, intent, and
 head SHA. Repeated maintainer nudges update the same small status comment

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHmac } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,6 +19,7 @@ export const DEFAULT_STATE_MATERIALIZER_MAX_BYTES = 20 * 1024 * 1024;
 export const DEFAULT_STATE_MATERIALIZER_MAX_RUNTIME_MS = 10 * 60 * 1_000;
 
 const COMMENT_ROUTER_LEDGER_PATH = "results/comment-router.json";
+const COMMENT_ROUTER_LATEST_REPORT_PATH = "results/comment-router-latest.json";
 const EMPTY_COMMENT_ROUTER_LEDGER = '{"updated_at":null,"commands":[]}';
 const STATE_MATERIALIZER_COMMIT_MESSAGE = "chore: materialize queued state\n\n[skip ci]";
 const STATE_APPEND_KINDS = new Set<StateAppendKind>([
@@ -47,6 +48,7 @@ export type StateMaterializerSummary = {
 };
 
 export type StateMaterializationPlan = {
+  deletes: string[];
   publishPaths: string[];
   writes: Array<{ path: string; content: string }>;
   selected: number;
@@ -128,6 +130,7 @@ export function planStateMaterialization(
 ): StateMaterializationPlan {
   const selected = selectLatestStateRecords(records);
   const contentByPath = new Map<string, string>();
+  const deletes = new Set<string>();
   const publishPaths: string[] = [];
   const addPublishPath = (path: string): void => {
     if (!publishPaths.includes(path)) publishPaths.push(path);
@@ -163,6 +166,12 @@ export function planStateMaterialization(
         mergeCommentRouterLedgers(payloadText, current),
       );
       addPublishPath(COMMENT_ROUTER_LEDGER_PATH);
+      // This report describes one invocation, not durable command state. Retire
+      // the old tracked copy in the same single-writer commit as the next ledger.
+      if (currentFiles.has(COMMENT_ROUTER_LATEST_REPORT_PATH)) {
+        deletes.add(COMMENT_ROUTER_LATEST_REPORT_PATH);
+        addPublishPath(COMMENT_ROUTER_LATEST_REPORT_PATH);
+      }
       continue;
     }
 
@@ -177,6 +186,7 @@ export function planStateMaterialization(
   }
 
   return {
+    deletes: [...deletes].sort(),
     publishPaths,
     writes: [...contentByPath]
       .filter(([path, content]) => currentFiles.get(path) !== content)
@@ -305,6 +315,13 @@ export async function runStateMaterializer(
 
 export function applyStateMaterializationPlan(plan: StateMaterializationPlan, root: string): void {
   const resolvedRoot = resolve(root);
+  for (const path of plan.deletes) {
+    const target = resolve(resolvedRoot, path);
+    if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${sep}`)) {
+      throw new Error(`refusing state deletion outside checkout: ${path}`);
+    }
+    rmSync(target, { force: true });
+  }
   for (const write of plan.writes) {
     const target = resolve(resolvedRoot, write.path);
     if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${sep}`)) {
@@ -322,12 +339,15 @@ function materializationPaths(records: readonly StateAppendRecord[]): string[] {
       record.kind === "sweep_status"
         ? sweepStatusPathForStateKey(record.key)
         : record.kind === "comment_router"
-          ? COMMENT_ROUTER_LEDGER_PATH
+          ? [COMMENT_ROUTER_LEDGER_PATH, COMMENT_ROUTER_LATEST_REPORT_PATH]
           : record.key;
-    if (record.kind === "apply_proof" && !isActionEventPublishPath(path)) {
-      throw new Error(`invalid apply proof ledger path: ${path}`);
+    const recordPaths = Array.isArray(path) ? path : [path];
+    if (record.kind === "apply_proof" && !isActionEventPublishPath(recordPaths[0]!)) {
+      throw new Error(`invalid apply proof ledger path: ${recordPaths[0]}`);
     }
-    if (!paths.includes(path)) paths.push(path);
+    for (const recordPath of recordPaths) {
+      if (!paths.includes(recordPath)) paths.push(recordPath);
+    }
   }
   return paths;
 }

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -29,6 +29,7 @@ test("materializer preserves canonical apply-proof content supplied as a string"
   const plan = planStateMaterialization([record(1, "apply_proof", proofPath, content)]);
 
   assert.deepEqual(plan, {
+    deletes: [],
     publishPaths: [proofPath],
     writes: [{ path: proofPath, content }],
     selected: 1,
@@ -98,6 +99,7 @@ test("materializer applies every record kind in sequence and keeps the last valu
       schema_version: 1,
     })}\n`,
   );
+  assert.equal(statePathExists(fixture, "results/comment-router-latest.json"), false);
   assert.match(
     run("git", ["--git-dir", fixture.origin, "log", "-1", "--format=%B", "state"], fixture.root),
     /chore: materialize queued state[\s\S]*\[skip ci\]/,
@@ -284,6 +286,10 @@ function createStateFixture(): {
       },
     ],
   });
+  writeJson(path.join(state, "results/comment-router-latest.json"), {
+    generated_at: "2026-07-20T11:59:00.000Z",
+    commands_seen: 1,
+  });
   run("git", ["add", "."], state);
   run("git", ["commit", "-m", "initial state"], state);
   run("git", ["push", "origin", "HEAD:state"], state);
@@ -316,6 +322,15 @@ async function withMaterializerFixture<T>(
 
 function showState(fixture: ReturnType<typeof createStateFixture>, file: string): string {
   return run("git", ["--git-dir", fixture.origin, "show", `state:${file}`], fixture.root);
+}
+
+function statePathExists(fixture: ReturnType<typeof createStateFixture>, file: string): boolean {
+  try {
+    run("git", ["--git-dir", fixture.origin, "cat-file", "-e", `state:${file}`], fixture.root);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function configureUser(cwd: string): void {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2034,6 +2034,26 @@ test("trusted comment router owns command ledger capacity retries", () => {
   assert.match(routerWorkflow, /--wait-for-capacity/);
 });
 
+test("comment router keeps scan reports out of durable state and Git-publishes only changed jobs", () => {
+  const workflow = readText(".github/workflows/repair-comment-router.yml");
+  const initialStart = workflow.indexOf("- name: Commit comment router ledger");
+  const initialEnd = workflow.indexOf("- name: Detect waiting repair dispatches", initialStart);
+  const retryStart = workflow.indexOf("- name: Commit comment router retry ledger");
+  const retryEnd = workflow.indexOf("- name: Finalize command action ledger", retryStart);
+  const publishSteps = [
+    workflow.slice(initialStart, initialEnd),
+    workflow.slice(retryStart, retryEnd),
+  ];
+
+  for (const step of publishSteps) {
+    assert.match(step, /--path results\/comment-router\.json/);
+    assert.doesNotMatch(step, /--path results\/comment-router-latest\.json/);
+    assert.match(step, /git status --porcelain=v1 --untracked-files=all -- jobs/);
+    assert.match(step, /publish_args\+=\(--path jobs\)/);
+    assert.doesNotMatch(step, /--path jobs \\/);
+  }
+});
+
 test("deferred exact verdict routers cannot replace each other's pending runs", () => {
   const workflow = readText(".github/workflows/repair-comment-router.yml");
   const concurrency = workflow.slice(workflow.indexOf("concurrency:"), workflow.indexOf("\njobs:"));


### PR DESCRIPTION
Related: #738

## What Problem This Solves

Fixes an issue where every distinct `@clawsweeper` command entered the serialized state-repository writer even when routing completed in seconds and no repair job changed. During the incident, one router finished command processing in about 20 seconds, then waited over 22 minutes at writer queue position 33 before cancellation.

## Why This Change Was Made

Distinct maintainer commands remain independent and lossless. The durable processed-command ledger continues through the append/materializer path; the invocation-only latest scan report is no longer Git-published; and `jobs/` enters the Git writer only when a command actually changed durable repair work. The materializer retires the old tracked latest report on its next router batch.

## User Impact

Routine status and re-review commands no longer contend for the state Git writer after routing, while commands that genuinely create or update repair jobs retain durable publication.

## Evidence

- Live failure evidence: run 30010373110 routed successfully, then stalled in the state writer until cancellation.
- 75 focused tests passed.
- Main and repair TypeScript builds passed.
- Targeted formatting, lint, `git diff --check`, and structured autoreview passed with no actionable findings.
- No SQLite schema or append protocol change.