### PR TITLE
fix(repair): skip unchanged router state publishes

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -292,6 +292,15 @@ jobs:
             echo "Exact terminal comment version already recorded; skipping state publication."
             exit 0
           fi
+          jobs_changed=0
+          if ! git diff --no-index --quiet -- "$CLAWSWEEPER_STATE_DIR/jobs" jobs; then
+            jobs_changed=1
+          fi
+          if [ "$jobs_changed" = "0" ] &&
+             jq -e '((.ledger_claimed // 0) + (.ledger_changed // 0)) == 0' results/comment-router-latest.json >/dev/null 2>&1; then
+            echo "No durable router state changed; skipping state publication."
+            exit 0
+          fi
           publish_args=(
             --message "chore: record ClawSweeper comment routing" \
             --path results/comment-router.json \
@@ -299,7 +308,7 @@ jobs:
           )
           # The latest scan report is run-local. Only commands that actually
           # changed repair jobs need the serialized Git state writer.
-          if [ -n "$(git status --porcelain=v1 --untracked-files=all -- jobs)" ]; then
+          if [ "$jobs_changed" = "1" ]; then
             publish_args+=(--path jobs)
           fi
           pnpm run repair:publish-main -- "${publish_args[@]}"
@@ -429,13 +438,24 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
+          # The initial publish copies every published path back into the state
+          # checkout, making it the baseline for retry-only job mutations.
+          jobs_changed=0
+          if ! git diff --no-index --quiet -- "$CLAWSWEEPER_STATE_DIR/jobs" jobs; then
+            jobs_changed=1
+          fi
+          if [ "$jobs_changed" = "0" ] &&
+             jq -e '((.ledger_claimed // 0) + (.ledger_changed // 0)) == 0' results/comment-router-latest.json >/dev/null 2>&1; then
+            echo "No durable router retry state changed; skipping state publication."
+            exit 0
+          fi
           publish_args=(
             --message "chore: record ClawSweeper repair dispatch retry" \
             --path results/comment-router.json \
             --rebase-strategy theirs
           )
           # Retry receipts are append-only unless the retry changed a repair job.
-          if [ -n "$(git status --porcelain=v1 --untracked-files=all -- jobs)" ]; then
+          if [ "$jobs_changed" = "1" ]; then
             publish_args+=(--path jobs)
           fi
           pnpm run repair:publish-main -- "${publish_args[@]}"

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2034,7 +2034,7 @@ test("trusted comment router owns command ledger capacity retries", () => {
   assert.match(routerWorkflow, /--wait-for-capacity/);
 });
 
-test("comment router keeps scan reports out of durable state and Git-publishes only changed jobs", () => {
+test("comment router publishes only durable ledger mutations and changed jobs", () => {
   const workflow = readText(".github/workflows/repair-comment-router.yml");
   const initialStart = workflow.indexOf("- name: Commit comment router ledger");
   const initialEnd = workflow.indexOf("- name: Detect waiting repair dispatches", initialStart);
@@ -2046,9 +2046,13 @@ test("comment router keeps scan reports out of durable state and Git-publishes o
   ];
 
   for (const step of publishSteps) {
+    assert.match(step, /git diff --no-index --quiet -- "\$CLAWSWEEPER_STATE_DIR\/jobs" jobs/);
+    assert.match(step, /\[ "\$jobs_changed" = "0" \] &&/);
+    assert.match(step, /\(\(\.ledger_claimed \/\/ 0\) \+ \(\.ledger_changed \/\/ 0\)\) == 0/);
+    assert.match(step, /No durable router(?: retry)? state changed; skipping state publication\./);
     assert.match(step, /--path results\/comment-router\.json/);
     assert.doesNotMatch(step, /--path results\/comment-router-latest\.json/);
-    assert.match(step, /git status --porcelain=v1 --untracked-files=all -- jobs/);
+    assert.match(step, /\[ "\$jobs_changed" = "1" \]/);
     assert.match(step, /publish_args\+=\(--path jobs\)/);
     assert.doesNotMatch(step, /--path jobs \\/);
   }


### PR DESCRIPTION
Related: #738

## What Problem This Solves

Fixes an issue where no-op comment-router runs would enter the serialized Git state writer even when they changed neither the command ledger nor repair jobs. The router ledger is currently about 1.48 MB, above the 256 KiB state-append record limit, so those unnecessary publishes fell back to Git and waited behind the incident backlog.

## Why This Change Was Made

Both initial and retry publication steps now compare repair jobs against the hydrated state checkout and publish only when the ledger or jobs changed. The retry comparison relies on `publish-main` refreshing published paths in the state checkout, so it measures retry-only mutations. Actual command/job mutations keep the existing Git path until the planned Cloudflare state-store migration.

## User Impact

No-op comment routing no longer consumes a state-writer ticket. Real routing mutations remain durable and unchanged in behavior.

## Evidence

- Before: workflow run https://github.com/openclaw/clawsweeper/actions/runs/30018859623 had zero routed work but remained in `Commit comment router ledger` behind the Git writer.
- Live state file: `results/comment-router.json` is 1,475,054 bytes; state append accepts 262,144-byte records.
- `node --test test/sweep-workflow.test.ts`: 70/70 pass.
- Targeted oxfmt/oxlint and `git diff --check`: pass.
- Fresh autoreview: clean, no accepted/actionable findings.