### PR TITLE
fix(repair): stop the review pipeline from stranding delivered verdicts

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -90,7 +90,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: read
+      issues: write
       pull-requests: read
     steps:
       - name: Reconcile claimed terminal runs

--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -90,7 +90,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
+      issues: read
       pull-requests: read
     steps:
       - name: Reconcile claimed terminal runs
@@ -192,10 +192,24 @@ jobs:
         with:
           build-script: build:all
 
+      # The workflow-scoped GITHUB_TOKEN cannot mutate the target repo; stuck
+      # escalation labels need an app installation token for the target owner.
+      - name: Create target write token
+        id: target-write-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: openclaw
+          permission-issues: write
+
       - name: Recover orphaned review placeholders
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ github.token }}
+          TARGET_WRITE_TOKEN: ${{ steps.target-write-token.outputs.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           REVIEW_PLACEHOLDER_MAX_CHECKS: ${{ vars.REVIEW_PLACEHOLDER_MAX_CHECKS || '20' }}
           REVIEW_PLACEHOLDER_MAX_RECOVERIES: ${{ vars.REVIEW_PLACEHOLDER_MAX_RECOVERIES || '5' }}

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -28750,6 +28750,15 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     }
     const earlyLeaseState = refreshReviewStartLeaseState();
     existingReviewComment = earlyLeaseState.comment;
+    if (!dryRun && existingReviewComment) {
+      const durableCommentId = commentId(existingReviewComment);
+      cleanupSupersededReviewPlaceholderComments({
+        number,
+        comments: earlyLeaseState.comments,
+        keepCommentIds:
+          durableCommentId === null ? new Set<number>() : new Set([durableCommentId]),
+      });
+    }
     if (state === "open" && earlyLeaseState.blockReason) {
       if (recordReviewLeaseSkip(earlyLeaseState.blockReason)) break;
       continue;

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -176,7 +176,8 @@ async function commit() {
         plans,
       });
       stateCommitSha = committed.commitSha ?? undefined;
-      if (committed.outcome === "committed") recorder?.recordMaterializedCommit(committed.itemCount);
+      if (committed.outcome === "committed")
+        recorder?.recordMaterializedCommit(committed.itemCount);
       recorder?.finalize(committed.outcome === "committed" ? "materialized" : "unchanged");
       stateWriter = recorder?.toTerminalObject() ?? undefined;
       quarantined = committed.quarantinedItems;

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -11,7 +11,10 @@ import {
 import { StatePublishContentionError } from "./git-publish.js";
 import { setStatePublishTelemetryObserver } from "./git-publish.js";
 import { exactReviewBatchStateWriterProgressReporter } from "./exact-review-batch-state-writer-progress.js";
-import { commitPreparedStateBatch } from "./state-publication-batch.js";
+import {
+  commitPreparedStateBatch,
+  type StateBatchQuarantinedItem,
+} from "./state-publication-batch.js";
 import { StateWriterTelemetryRecorder } from "./state-writer-telemetry-recorder.js";
 import type { StateWriterOperation } from "../state-writer-telemetry.js";
 import {
@@ -145,6 +148,7 @@ async function commit() {
 
   let stateCommitSha: string | undefined;
   let stateWriter: StateWriterOperation | undefined;
+  let quarantined: readonly StateBatchQuarantinedItem[] = [];
   const progressObserver = exactReviewBatchStateWriterProgressReporter({
     queueUrl: env("EXACT_REVIEW_QUEUE_URL"),
     webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
@@ -170,9 +174,10 @@ async function commit() {
         plans,
       });
       stateCommitSha = committed.commitSha;
-      if (committed.outcome === "committed") recorder?.recordMaterializedCommit(plans.length);
+      if (committed.outcome === "committed") recorder?.recordMaterializedCommit(committed.itemCount);
       recorder?.finalize(committed.outcome === "committed" ? "materialized" : "unchanged");
       stateWriter = recorder?.toTerminalObject() ?? undefined;
+      quarantined = committed.quarantinedItems;
     }
   } catch (error) {
     recorder?.finalize(
@@ -205,6 +210,26 @@ async function commit() {
   } finally {
     resetTelemetry();
   }
+  if (quarantined.length) {
+    const quarantineReasons = new Map(quarantined.map((item) => [item.itemKey, item.reason]));
+    const quarantinedCompletions = commitMembers
+      .filter((member) => quarantineReasons.has(member.itemKey))
+      .map((member) =>
+        retryableCompletion(
+          member,
+          "state_conflict_quarantined",
+          failureFingerprint(new Error(quarantineReasons.get(member.itemKey))),
+        ),
+      );
+    try {
+      await acknowledge(manifest, quarantinedCompletions);
+    } catch (releaseError) {
+      console.error(
+        `Failed to acknowledge quarantined batch items: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
+      );
+    }
+  }
+  const quarantinedItemKeys = new Set(quarantined.map((item) => item.itemKey));
   const receiptPath = batchReceiptPath();
   mkdirSync(dirname(receiptPath), { recursive: true });
   writeFileSync(
@@ -213,7 +238,9 @@ async function commit() {
       {
         batchId: manifest.batchId,
         stateCommitSha: stateCommitSha ?? null,
-        publishedItemKeys: plans.map((plan) => plan.identity.itemKey),
+        publishedItemKeys: plans
+          .map((plan) => plan.identity.itemKey)
+          .filter((itemKey) => !quarantinedItemKeys.has(itemKey)),
         stateWriter: stateWriter ?? null,
       },
       null,
@@ -226,7 +253,8 @@ async function commit() {
       ok: true,
       batch_id: manifest.batchId,
       state_commit_sha: stateCommitSha ?? null,
-      materialized: plans.length,
+      materialized: plans.length - quarantined.length,
+      quarantined: quarantined.length,
       superseded: superseded.length,
     }),
   );

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -120,6 +120,7 @@ async function commit() {
   const superseded: ExactReviewBatchCompletion[] = [];
   const commitMembers: ExactReviewBatchQueueItem[] = [];
   const plans: PreparedStateMutationPlan[] = [];
+  const outcomePathByItemKey = new Map<string, string>();
   for (const manifestItem of manifest.items) {
     const current = active.get(manifestItem.itemKey);
     if (!current || !existsSync(manifestItem.outcomePath)) continue;
@@ -144,6 +145,7 @@ async function commit() {
     }
     commitMembers.push(current);
     plans.push(plan);
+    outcomePathByItemKey.set(current.itemKey, manifestItem.outcomePath);
   }
 
   let stateCommitSha: string | undefined;
@@ -173,7 +175,7 @@ async function commit() {
         batchId: manifest.batchId,
         plans,
       });
-      stateCommitSha = committed.commitSha;
+      stateCommitSha = committed.commitSha ?? undefined;
       if (committed.outcome === "committed") recorder?.recordMaterializedCommit(committed.itemCount);
       recorder?.finalize(committed.outcome === "committed" ? "materialized" : "unchanged");
       stateWriter = recorder?.toTerminalObject() ?? undefined;
@@ -230,6 +232,25 @@ async function commit() {
     }
   }
   const quarantinedItemKeys = new Set(quarantined.map((item) => item.itemKey));
+  for (const itemKey of quarantinedItemKeys) {
+    const outcomePath = outcomePathByItemKey.get(itemKey);
+    if (!outcomePath || !existsSync(outcomePath)) continue;
+    const outcome = objectValue(JSON.parse(readFileSync(outcomePath, "utf8")));
+    // A quarantined item's local outcome file still says kind: "eligible"; the
+    // workflow's post-commit loop reads that file directly (not this receipt) to
+    // decide whether to dispatch comment-router or requeue effects, so it must be
+    // corrected here or the loop will run post-effects for state that was never
+    // committed.
+    writeFileSync(
+      outcomePath,
+      `${JSON.stringify(
+        { ...outcome, kind: "retryable_failure", reasonCode: "state_conflict_quarantined" },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  }
   const receiptPath = batchReceiptPath();
   mkdirSync(dirname(receiptPath), { recursive: true });
   writeFileSync(

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -2467,7 +2467,10 @@ function isCommitRefsTransactionFailure(result: GitRunResult): boolean {
 }
 
 function commitRefsRetryDelayMs(attempt: number): number {
-  return Math.min(STATE_PUBLISH_LEASE_WAIT_MS * 2 ** (attempt - 1), STATE_PUBLISH_LEASE_MAX_WAIT_MS);
+  return Math.min(
+    STATE_PUBLISH_LEASE_WAIT_MS * 2 ** (attempt - 1),
+    STATE_PUBLISH_LEASE_MAX_WAIT_MS,
+  );
 }
 
 function pushStateAndReceiptAfterCommitRefsFailure(

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -2323,7 +2323,7 @@ function renewStatePublishLease(
           console.log(
             `State publish lease renewal hit GitHub commit_refs ${reason}; retrying attempt=${attempt + 1}/${attempts}`,
           );
-          sleep(Math.min(STATE_PUBLISH_LEASE_WAIT_MS * attempt, STATE_PUBLISH_LEASE_MAX_WAIT_MS));
+          sleep(commitRefsRetryDelayMs(attempt));
           continue;
         }
         throw new StatePublishContentionError(`Failed to renew state publish lease ${reason}`);
@@ -2466,6 +2466,10 @@ function isCommitRefsTransactionFailure(result: GitRunResult): boolean {
   return /fatal error in commit_refs/i.test(`${result.stderr}\n${result.stdout}`);
 }
 
+function commitRefsRetryDelayMs(attempt: number): number {
+  return Math.min(STATE_PUBLISH_LEASE_WAIT_MS * 2 ** (attempt - 1), STATE_PUBLISH_LEASE_MAX_WAIT_MS);
+}
+
 function pushStateAndReceiptAfterCommitRefsFailure(
   source: string,
   remote: string,
@@ -2534,7 +2538,7 @@ function pushStateAndReceiptAfterCommitRefsFailure(
         console.log(
           `State batch receipt push hit GitHub commit_refs; retrying attempt=${attempt + 1}/${STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS}`,
         );
-        sleep(Math.min(STATE_PUBLISH_LEASE_WAIT_MS * attempt, STATE_PUBLISH_LEASE_MAX_WAIT_MS));
+        sleep(commitRefsRetryDelayMs(attempt));
         continue;
       }
       return receiptPush;
@@ -2568,15 +2572,41 @@ function pushStateAndReceiptAfterCommitRefsFailure(
     );
   }
 
-  const statePush = spawnGit(
-    ["push", `--force-with-lease=${branchRef}:${sourceParent}`, remote, `${source}:${branchRef}`],
-    { allowFailure: true },
-  );
-  if (statePush.status !== 0 && remoteRefOid(remote, branchRef) !== sourceCommit) {
+  for (let attempt = 1; attempt <= STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS; attempt += 1) {
+    lease.coordinator?.assertActive();
+    const statePush = spawnGit(
+      ["push", `--force-with-lease=${branchRef}:${sourceParent}`, remote, `${source}:${branchRef}`],
+      { allowFailure: true },
+    );
+    if (statePush.status === 0) {
+      console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+      return { ...statePush, status: 0 };
+    }
+    const currentBranchOid = remoteRefOid(remote, branchRef);
+    if (currentBranchOid === sourceCommit) {
+      console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
+      return { ...statePush, status: 0 };
+    }
+    if (currentBranchOid !== sourceParent) {
+      throw new StatePublishContentionError(
+        `State branch ${branchRef} changed during commit_refs recovery`,
+      );
+    }
+    if (
+      attempt < STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS &&
+      isCommitRefsTransactionFailure(statePush)
+    ) {
+      console.log(
+        `State branch push hit GitHub commit_refs; retrying attempt=${attempt + 1}/${STATE_PUBLISH_COMMIT_REFS_SINGLE_REF_ATTEMPTS}`,
+      );
+      sleep(commitRefsRetryDelayMs(attempt));
+      continue;
+    }
     return statePush;
   }
-  console.log(`Recovered GitHub commit_refs failure for ${remote}/${branch}`);
-  return { ...statePush, status: 0 };
+  throw new StatePublishContentionError(
+    `Failed to publish state branch ${branchRef} after commit_refs recovery`,
+  );
 }
 
 export function pushStateCommitUnderLease(

--- a/src/repair/state-publication-batch.ts
+++ b/src/repair/state-publication-batch.ts
@@ -46,8 +46,8 @@ export type StateBatchQuarantinedItem = {
 };
 
 export type StateBatchCommitResult = {
-  outcome: "committed" | "already_committed";
-  commitSha: string;
+  outcome: "committed" | "already_committed" | "quarantined";
+  commitSha: string | null;
   batchId: string;
   fingerprint: string;
   itemCount: number;
@@ -162,7 +162,15 @@ function commitUnderLease(options: {
     return true;
   });
   if (survivingPlans.length === 0) {
-    throw new StateMutationConflictError(quarantinedItems.map((item) => item.reason).join("; "));
+    return {
+      outcome: "quarantined",
+      commitSha: null,
+      fingerprint: "",
+      itemCount: 0,
+      pathCount: 0,
+      totalBytes: 0,
+      quarantinedItems,
+    };
   }
 
   const operations =

--- a/src/repair/state-publication-batch.ts
+++ b/src/repair/state-publication-batch.ts
@@ -40,6 +40,11 @@ export class StateMutationConflictError extends Error {
   }
 }
 
+export type StateBatchQuarantinedItem = {
+  itemKey: string;
+  reason: string;
+};
+
 export type StateBatchCommitResult = {
   outcome: "committed" | "already_committed";
   commitSha: string;
@@ -50,6 +55,7 @@ export type StateBatchCommitResult = {
   totalBytes: number;
   leaseHoldMs: number;
   git: GitProcessMeasurement;
+  quarantinedItems: readonly StateBatchQuarantinedItem[];
 };
 
 export type StateBatchCommitHooks = {
@@ -73,7 +79,6 @@ export function commitPreparedStateBatch(options: {
   const message = validateCommitSubject(options.message);
   const validated = validatePreparedStateMutationPlans(options.plans);
   const operations = validateAndCombinePlans(validated.plans, validated.totalBytes);
-  const fingerprint = batchFingerprint(validated.plans);
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? process.env.CLAWSWEEPER_PUBLISH_BRANCH ?? "state";
   const measured = measureGitProcesses(() => {
@@ -83,13 +88,13 @@ export function commitPreparedStateBatch(options: {
         const leaseStartedAt = Date.now();
         try {
           return commitUnderLease({
-            ...options,
+            batchId: options.batchId,
             plans: validated.plans,
+            operations,
             message,
             remote,
             branch,
-            operations,
-            fingerprint,
+            ...(options.hooks ? { hooks: options.hooks } : {}),
           });
         } finally {
           leaseHoldMs = Date.now() - leaseStartedAt;
@@ -103,10 +108,6 @@ export function commitPreparedStateBatch(options: {
   return {
     ...measured.result.publication,
     batchId: options.batchId,
-    fingerprint,
-    itemCount: validated.plans.length,
-    pathCount: operations.length,
-    totalBytes: validated.totalBytes,
     leaseHoldMs: measured.result.leaseHoldMs,
     git: measured.measurement,
   };
@@ -116,18 +117,74 @@ function commitUnderLease(options: {
   batchId: string;
   plans: readonly PreparedStateMutationPlan[];
   operations: readonly PreparedStateMutationOperation[];
-  fingerprint: string;
   remote: string;
   branch: string;
   message: string;
   hooks?: StateBatchCommitHooks;
-}): Pick<StateBatchCommitResult, "outcome" | "commitSha"> {
-  const receiptRef = batchReceiptRef(options.batchId);
+}): Pick<
+  StateBatchCommitResult,
+  | "outcome"
+  | "commitSha"
+  | "fingerprint"
+  | "itemCount"
+  | "pathCount"
+  | "totalBytes"
+  | "quarantinedItems"
+> {
   const remoteRef = fetchLatestState(options.remote, options.branch);
   const remoteCommit = runGit(["rev-parse", remoteRef], { quiet: true }).trim();
+  const remoteEntries = readRemoteEntries(
+    remoteCommit,
+    options.operations.map(({ path }) => path),
+  );
+
+  // A single item whose remote path drifted (or a missing/poisoned record) is
+  // fenced out of the batch here instead of throwing and aborting every other
+  // item's already-delivered work. Fencing runs before the receipt lookup so a
+  // batch id stays bound to exactly one payload across retries.
+  const quarantinedItems: StateBatchQuarantinedItem[] = [];
+  const survivingPlans = options.plans.filter((plan) => {
+    for (const operation of plan.operations) {
+      const remoteEntry = remoteEntries.get(operation.path) ?? null;
+      const remoteOid = remoteEntry?.oid ?? null;
+      const alreadyApplied =
+        remoteOid === operation.targetOid &&
+        (operation.targetOid === null || remoteEntry?.mode === operation.mode);
+      if (alreadyApplied) continue;
+      if (remoteOid !== operation.expectedOid) {
+        quarantinedItems.push({
+          itemKey: plan.identity.itemKey,
+          reason: `Remote state path ${operation.path} changed after mutation preparation`,
+        });
+        return false;
+      }
+    }
+    return true;
+  });
+  if (survivingPlans.length === 0) {
+    throw new StateMutationConflictError(quarantinedItems.map((item) => item.reason).join("; "));
+  }
+
+  const operations =
+    survivingPlans.length === options.plans.length
+      ? options.operations
+      : validateAndCombinePlans(
+          survivingPlans,
+          survivingPlans.reduce((total, plan) => total + plan.totalBytes, 0),
+        );
+  const fingerprint = batchFingerprint(survivingPlans);
+  const receiptRef = batchReceiptRef(options.batchId);
+  const outcomeMeta = () => ({
+    fingerprint,
+    itemCount: survivingPlans.length,
+    pathCount: operations.length,
+    totalBytes: survivingPlans.reduce((total, plan) => total + plan.totalBytes, 0),
+    quarantinedItems,
+  });
+
   const recovered = findBatchReceipt(options.remote, receiptRef, options.batchId);
   if (recovered) {
-    if (recovered.fingerprint !== options.fingerprint) {
+    if (recovered.fingerprint !== fingerprint) {
       throw new StateMutationConflictError(
         `Batch id ${options.batchId} is already bound to a different mutation fingerprint`,
       );
@@ -140,39 +197,27 @@ function commitUnderLease(options: {
       (remoteCommit !== recoveredParent &&
         stateContainsCommit(options.remote, options.branch, remoteCommit, recovered.commit))
     ) {
-      return { outcome: "already_committed", commitSha: recovered.commit };
+      return { outcome: "already_committed", commitSha: recovered.commit, ...outcomeMeta() };
     }
     if (remoteCommit === recoveredParent) {
       options.hooks?.beforePush?.(recovered.commit);
       pushStateCommitUnderLease(recovered.commit, options.remote, options.branch, receiptRef);
       verifyRemoteCommit(options.remote, options.branch, receiptRef, recovered.commit);
       options.hooks?.afterPush?.(recovered.commit);
-      return { outcome: "committed", commitSha: recovered.commit };
+      return { outcome: "committed", commitSha: recovered.commit, ...outcomeMeta() };
     }
     throw new StateMutationConflictError(
       `Batch id ${options.batchId} has a prepared receipt but state advanced before retry`,
     );
   }
 
-  const remoteEntries = readRemoteEntries(
-    remoteCommit,
-    options.operations.map(({ path }) => path),
-  );
-  const pending = options.operations.filter((operation) => {
+  const pending = operations.filter((operation) => {
     const remoteEntry = remoteEntries.get(operation.path) ?? null;
     const remoteOid = remoteEntry?.oid ?? null;
-    if (
+    return !(
       remoteOid === operation.targetOid &&
       (operation.targetOid === null || remoteEntry?.mode === operation.mode)
-    ) {
-      return false;
-    }
-    if (remoteOid !== operation.expectedOid) {
-      throw new StateMutationConflictError(
-        `Remote state path ${operation.path} changed after mutation preparation`,
-      );
-    }
-    return true;
+    );
   });
   const remoteTree = runGit(["rev-parse", `${remoteCommit}^{tree}`], { quiet: true }).trim();
   // Even a content no-op needs a durable batch-id/fingerprint binding. A same-tree
@@ -180,14 +225,19 @@ function commitUnderLease(options: {
   const tree = pending.length === 0 ? remoteTree : applyOperationsToTree(remoteTree, pending);
   const commitSha = runGit(["commit-tree", tree, "-p", remoteCommit], {
     env: { ...process.env, ...clawsweeperGitIdentityEnv() },
-    input: batchCommitMessage(options),
+    input: batchCommitMessage({
+      batchId: options.batchId,
+      fingerprint,
+      plans: survivingPlans,
+      message: options.message,
+    }),
     quiet: true,
   }).trim();
   options.hooks?.beforePush?.(commitSha);
   pushStateCommitUnderLease(commitSha, options.remote, options.branch, receiptRef);
   verifyRemoteCommit(options.remote, options.branch, receiptRef, commitSha);
   options.hooks?.afterPush?.(commitSha);
-  return { outcome: "committed", commitSha };
+  return { outcome: "committed", commitSha, ...outcomeMeta() };
 }
 
 function validateAndCombinePlans(

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -35,9 +35,24 @@ export type ReviewPlaceholderRecoverySummary = {
   checked: number;
   orphaned: number;
   enqueued: number;
+  cleaned: number;
   escalated: number;
   errors: number;
 };
+
+// The scheduled sweep should go red only when placeholders needed resolution
+// and the run resolved none of them; routine transient noise with nothing to
+// do must stay green or the 15-minute cadence turns into a standing alarm.
+// Escalation labels are visibility, not resolution, so they never count.
+export function reviewPlaceholderRecoveryFailureReason(
+  summary: ReviewPlaceholderRecoverySummary,
+): string | null {
+  const resolved = summary.enqueued + summary.cleaned;
+  if (summary.orphaned > 0 && summary.errors > 0 && resolved === 0) {
+    return "orphaned placeholders remain and every recovery action failed";
+  }
+  return null;
+}
 
 type ReviewPlaceholderRecoveryRunOptions = {
   env?: NodeJS.ProcessEnv;
@@ -166,14 +181,15 @@ export async function runReviewPlaceholderRecovery(
   let checked = 0;
   let orphaned = 0;
   let enqueued = 0;
+  let cleaned = 0;
   let escalated = 0;
   let errors = 0;
 
   const summary = (): ReviewPlaceholderRecoverySummary => {
     console.log(
-      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} escalated=${escalated} errors=${errors}`,
+      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} cleaned=${cleaned} escalated=${escalated} errors=${errors}`,
     );
-    return { checked, orphaned, enqueued, escalated, errors };
+    return { checked, orphaned, enqueued, cleaned, escalated, errors };
   };
   if (
     !token ||
@@ -182,8 +198,12 @@ export async function runReviewPlaceholderRecovery(
     !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) ||
     !/^[A-Za-z0-9_./-]+$/.test(targetBranch)
   ) {
-    console.warn("review-placeholder recovery skipped: missing or invalid configuration");
-    return summary();
+    // Silent no-op here means orphaned placeholders stay invisible forever;
+    // in production every value comes from repo secrets/vars, so loss of one
+    // is an operator problem the run must surface.
+    throw new Error(
+      "review-placeholder recovery is misconfigured: missing token, secret, or target",
+    );
   }
 
   const github = async <T>(path: string): Promise<T> => {
@@ -251,6 +271,52 @@ export async function runReviewPlaceholderRecovery(
       throw new Error(`POST /repos/${repo}/issues/${number}/labels returned ${response.status}`);
     }
   };
+  const deletePlaceholderComment = async (
+    number: number,
+    commentId: number,
+  ): Promise<"deleted" | "skipped"> => {
+    if (!targetWriteToken) {
+      throw new Error("TARGET_WRITE_TOKEN is missing; cannot delete placeholder comments");
+    }
+    // The closed state and placeholder body come from earlier snapshots; reread
+    // both right before the destructive call so a reopened item or an in-flight
+    // publish that edited the placeholder into a real review is not deleted.
+    // The gate requires the machine status marker with this item's number, not
+    // the human sentence, because a published review can quote the sentence.
+    // GitHub has no conditional delete, so the one-RTT window between this
+    // reread and the DELETE is an accepted residual race on a >=2h-orphaned
+    // closed item; the durable review tuple in the state repo survives either
+    // way and the 15-minute sweep converges.
+    const item = await github<{ state?: unknown }>(`/repos/${repo}/issues/${number}`);
+    if (item.state !== "closed") return "skipped";
+    const current = await github<ReviewPlaceholderComment>(
+      `/repos/${repo}/issues/comments/${commentId}`,
+    );
+    if (
+      !isClawSweeperBotComment(current) ||
+      typeof current.body !== "string" ||
+      !current.body.includes(`<!-- clawsweeper-review-status:started item=${number} `) ||
+      // A refresh bumps updated_at, so a placeholder re-claimed by an active
+      // run drops back under the orphan age and must not be deleted.
+      !isOrphanedReviewPlaceholder(current, now, minimumAgeHours)
+    ) {
+      return "skipped";
+    }
+    const response = await fetchImpl(`${apiUrl}/repos/${repo}/issues/comments/${commentId}`, {
+      method: "DELETE",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${targetWriteToken}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `DELETE /repos/${repo}/issues/comments/${commentId} returned ${response.status}`,
+      );
+    }
+    return "deleted";
+  };
   const fetchLatestBotComment = async (
     number: number,
   ): Promise<ReviewPlaceholderComment | null> => {
@@ -265,13 +331,16 @@ export async function runReviewPlaceholderRecovery(
     return latestClawSweeperBotComment(comments);
   };
 
-  const candidates = new Map<number, ReviewPlaceholderCandidate>();
+  const candidates = new Map<number, { candidate: ReviewPlaceholderCandidate; closed: boolean }>();
   const updatedSince = new Date(
     now.getTime() - REVIEW_PLACEHOLDER_LOOKBACK_HOURS * 60 * 60 * 1_000,
   ).toISOString();
-  const query = `repo:${repo} "${REVIEW_PLACEHOLDER_MARKER}" in:comments updated:>=${updatedSince} is:open`;
-  for (let page = 1; page <= SEARCH_MAX_PAGES && candidates.size < maximumChecks; page += 1) {
-    try {
+  // Each state class gets its own check budget; sharing one would let a
+  // backlog of open placeholders permanently starve closed-item cleanup.
+  const searchCandidates = async (stateQualifier: "is:open" | "is:closed"): Promise<void> => {
+    const query = `repo:${repo} "${REVIEW_PLACEHOLDER_MARKER}" in:comments updated:>=${updatedSince} ${stateQualifier}`;
+    let added = 0;
+    for (let page = 1; page <= SEARCH_MAX_PAGES && added < maximumChecks; page += 1) {
       const result = await github<{ items?: unknown }>(
         `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=desc&per_page=${SEARCH_PAGE_SIZE}&page=${page}`,
       );
@@ -281,16 +350,21 @@ export async function runReviewPlaceholderRecovery(
         const candidate = value as ReviewPlaceholderCandidate;
         const number = Number(candidate.number);
         if (!Number.isInteger(number) || number <= 0 || candidates.has(number)) continue;
-        candidates.set(number, candidate);
-        if (candidates.size >= maximumChecks) break;
+        candidates.set(number, { candidate, closed: stateQualifier === "is:closed" });
+        added += 1;
+        if (added >= maximumChecks) break;
       }
       if (items.length < SEARCH_PAGE_SIZE) break;
+    }
+  };
+  for (const stateQualifier of ["is:open", "is:closed"] as const) {
+    try {
+      await searchCandidates(stateQualifier);
     } catch (error) {
       errors += 1;
       console.warn(
-        `review-placeholder discovery page ${page} skipped: ${error instanceof Error ? error.message : String(error)}`,
+        `review-placeholder discovery (${stateQualifier}) skipped: ${error instanceof Error ? error.message : String(error)}`,
       );
-      break;
     }
   }
 
@@ -299,14 +373,38 @@ export async function runReviewPlaceholderRecovery(
     itemKind: "issue" | "pull_request";
     createdAtMs: number;
   }[] = [];
-  for (const [number, candidate] of candidates) {
+  for (const [number, { candidate, closed }] of candidates) {
     checked += 1;
     try {
       const comment = await fetchLatestBotComment(number);
-      if (!isOrphanedReviewPlaceholder(comment, now, minimumAgeHours)) continue;
+      if (!comment || !isOrphanedReviewPlaceholder(comment, now, minimumAgeHours)) continue;
       orphaned += 1;
+      if (closed) {
+        // A closed item can never be recovered by re-enqueueing a review; the
+        // only useful terminal action is removing the stale placeholder so the
+        // thread stops claiming a review is in flight.
+        const placeholderCommentId = Number(comment.id);
+        try {
+          if (!Number.isInteger(placeholderCommentId) || placeholderCommentId <= 0) {
+            throw new Error("placeholder comment id is unavailable");
+          }
+          const outcome = await deletePlaceholderComment(number, placeholderCommentId);
+          if (outcome === "deleted") {
+            cleaned += 1;
+            console.log(`review-placeholder recovery: cleaned closed #${number}`);
+          } else {
+            console.log(`review-placeholder recovery: skipped changed closed #${number}`);
+          }
+        } catch (cleanupError) {
+          errors += 1;
+          console.warn(
+            `#${number} closed-item placeholder cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+          );
+        }
+        continue;
+      }
       const itemKind = candidate.pull_request ? "pull_request" : "issue";
-      const createdAtMs = (comment && commentCreatedAtMs(comment)) ?? now.getTime();
+      const createdAtMs = commentCreatedAtMs(comment) ?? now.getTime();
       orphanedCandidates.push({ number, itemKind, createdAtMs });
       if (
         now.getTime() - createdAtMs >= stuckAgeMs &&
@@ -354,9 +452,17 @@ export async function runReviewPlaceholderRecovery(
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
-  await runReviewPlaceholderRecovery().catch((error) => {
-    console.warn(
-      `review-placeholder recovery skipped after unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+  try {
+    const summary = await runReviewPlaceholderRecovery();
+    const failureReason = reviewPlaceholderRecoveryFailureReason(summary);
+    if (failureReason) {
+      console.error(`review-placeholder recovery failed: ${failureReason}`);
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(
+      `review-placeholder recovery failed: ${error instanceof Error ? error.message : String(error)}`,
     );
-  });
+    process.exitCode = 1;
+  }
 }

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -7,6 +7,8 @@ export const REVIEW_PLACEHOLDER_MARKER = "ClawSweeper status: review started.";
 export const DEFAULT_REVIEW_PLACEHOLDER_MAX_CHECKS = 20;
 export const DEFAULT_REVIEW_PLACEHOLDER_MIN_AGE_HOURS = 2;
 export const DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES = 5;
+export const DEFAULT_REVIEW_PLACEHOLDER_STUCK_HOURS = 12;
+export const REVIEW_PLACEHOLDER_STUCK_LABEL = "clawsweeper-recovery-stuck";
 export const REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
 
 const SEARCH_PAGE_SIZE = 100;
@@ -26,12 +28,14 @@ export type ReviewPlaceholderComment = {
 export type ReviewPlaceholderCandidate = {
   number?: unknown;
   pull_request?: unknown;
+  labels?: unknown;
 };
 
 export type ReviewPlaceholderRecoverySummary = {
   checked: number;
   orphaned: number;
   enqueued: number;
+  escalated: number;
   errors: number;
 };
 
@@ -85,6 +89,22 @@ export function latestClawSweeperBotComment(
   return latest?.comment ?? null;
 }
 
+function candidateLabelNames(candidate: ReviewPlaceholderCandidate): string[] {
+  if (!Array.isArray(candidate.labels)) return [];
+  const names: string[] = [];
+  for (const label of candidate.labels) {
+    if (typeof label === "string") names.push(label);
+    else if (
+      label &&
+      typeof label === "object" &&
+      typeof (label as { name?: unknown }).name === "string"
+    ) {
+      names.push((label as { name: string }).name);
+    }
+  }
+  return names;
+}
+
 export function isOrphanedReviewPlaceholder(
   comment: ReviewPlaceholderComment | null,
   now: Date = new Date(),
@@ -131,16 +151,26 @@ export async function runReviewPlaceholderRecovery(
     DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES,
     100,
   );
+  const stuckAgeMs =
+    boundedPositiveInteger(
+      env.REVIEW_PLACEHOLDER_STUCK_HOURS,
+      DEFAULT_REVIEW_PLACEHOLDER_STUCK_HOURS,
+      24 * 30,
+    ) *
+    60 *
+    60 *
+    1_000;
   let checked = 0;
   let orphaned = 0;
   let enqueued = 0;
+  let escalated = 0;
   let errors = 0;
 
   const summary = (): ReviewPlaceholderRecoverySummary => {
     console.log(
-      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} errors=${errors}`,
+      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} escalated=${escalated} errors=${errors}`,
     );
-    return { checked, orphaned, enqueued, errors };
+    return { checked, orphaned, enqueued, escalated, errors };
   };
   if (
     !token ||
@@ -200,6 +230,21 @@ export async function runReviewPlaceholderRecovery(
       throw new Error("POST /internal/exact-review/enqueue was not admitted");
     }
   };
+  const addLabel = async (number: number, label: string): Promise<void> => {
+    const response = await fetchImpl(`${apiUrl}/repos/${repo}/issues/${number}/labels`, {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+        "x-github-api-version": "2022-11-28",
+      },
+      body: JSON.stringify({ labels: [label] }),
+    });
+    if (!response.ok) {
+      throw new Error(`POST /repos/${repo}/issues/${number}/labels returned ${response.status}`);
+    }
+  };
   const fetchLatestBotComment = async (
     number: number,
   ): Promise<ReviewPlaceholderComment | null> => {
@@ -243,21 +288,58 @@ export async function runReviewPlaceholderRecovery(
     }
   }
 
+  const orphanedCandidates: {
+    number: number;
+    itemKind: "issue" | "pull_request";
+    createdAtMs: number;
+  }[] = [];
   for (const [number, candidate] of candidates) {
-    if (enqueued >= maximumRecoveries) break;
     checked += 1;
     try {
       const comment = await fetchLatestBotComment(number);
       if (!isOrphanedReviewPlaceholder(comment, now, minimumAgeHours)) continue;
       orphaned += 1;
       const itemKind = candidate.pull_request ? "pull_request" : "issue";
-      await enqueue(number, itemKind);
-      enqueued += 1;
-      console.log(`review-placeholder recovery: enqueued #${number} (${itemKind})`);
+      const createdAtMs = (comment && commentCreatedAtMs(comment)) ?? now.getTime();
+      orphanedCandidates.push({ number, itemKind, createdAtMs });
+      if (
+        now.getTime() - createdAtMs >= stuckAgeMs &&
+        !candidateLabelNames(candidate).includes(REVIEW_PLACEHOLDER_STUCK_LABEL)
+      ) {
+        try {
+          await addLabel(number, REVIEW_PLACEHOLDER_STUCK_LABEL);
+          escalated += 1;
+          console.error(
+            `review-placeholder recovery: escalated #${number} as stuck after repeated orphan cycles`,
+          );
+        } catch (labelError) {
+          errors += 1;
+          console.warn(
+            `#${number} review-placeholder stuck-label escalation failed: ${labelError instanceof Error ? labelError.message : String(labelError)}`,
+          );
+        }
+      }
     } catch (error) {
       errors += 1;
       console.warn(
         `#${number} review-placeholder recovery skipped: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  orphanedCandidates.sort((a, b) => a.createdAtMs - b.createdAtMs);
+  for (const candidate of orphanedCandidates) {
+    if (enqueued >= maximumRecoveries) break;
+    try {
+      await enqueue(candidate.number, candidate.itemKind);
+      enqueued += 1;
+      console.log(
+        `review-placeholder recovery: enqueued #${candidate.number} (${candidate.itemKind})`,
+      );
+    } catch (error) {
+      errors += 1;
+      console.warn(
+        `#${candidate.number} review-placeholder recovery skipped: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -131,6 +131,9 @@ export async function runReviewPlaceholderRecovery(
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? new Date();
   const token = env.GH_TOKEN ?? env.GITHUB_TOKEN ?? "";
+  // Label mutations target the review repository, which the workflow-scoped
+  // GITHUB_TOKEN cannot write to; escalation needs the app installation token.
+  const targetWriteToken = env.TARGET_WRITE_TOKEN ?? "";
   const { CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret = "" } = env;
   const repo = env.TARGET_REPO ?? "openclaw/openclaw";
   const targetBranch = env.TARGET_BRANCH ?? "main";
@@ -231,11 +234,14 @@ export async function runReviewPlaceholderRecovery(
     }
   };
   const addLabel = async (number: number, label: string): Promise<void> => {
+    if (!targetWriteToken) {
+      throw new Error("TARGET_WRITE_TOKEN is missing; cannot write labels on the target repo");
+    }
     const response = await fetchImpl(`${apiUrl}/repos/${repo}/issues/${number}/labels`, {
       method: "POST",
       headers: {
         accept: "application/vnd.github+json",
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${targetWriteToken}`,
         "content-type": "application/json",
         "x-github-api-version": "2022-11-28",
       },

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -146,3 +146,14 @@ test("batch failure cleanup completes manifest fences without a queue fetch", ()
   assert.match(releaseSource, /receipt\?\.stateWriter/);
   assert.doesNotMatch(releaseSource, /client\.fetch/);
 });
+
+test("batch commit rewrites quarantined outcome files before the receipt is written", () => {
+  const commitSource = /async function commit\(\) \{([\s\S]*?)\n\}/.exec(cliSource)?.[1] ?? "";
+  assert.match(commitSource, /outcomePathByItemKey\.set\(current\.itemKey, manifestItem\.outcomePath\)/);
+  const quarantineRewrite = commitSource.indexOf("for (const itemKey of quarantinedItemKeys)");
+  const receiptWrite = commitSource.indexOf("const receiptPath = batchReceiptPath();");
+  assert.ok(quarantineRewrite >= 0 && receiptWrite >= 0 && quarantineRewrite < receiptWrite);
+  const rewriteWindow = commitSource.slice(quarantineRewrite, receiptWrite);
+  assert.match(rewriteWindow, /kind: "retryable_failure"/);
+  assert.match(rewriteWindow, /reasonCode: "state_conflict_quarantined"/);
+});

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -149,7 +149,10 @@ test("batch failure cleanup completes manifest fences without a queue fetch", ()
 
 test("batch commit rewrites quarantined outcome files before the receipt is written", () => {
   const commitSource = /async function commit\(\) \{([\s\S]*?)\n\}/.exec(cliSource)?.[1] ?? "";
-  assert.match(commitSource, /outcomePathByItemKey\.set\(current\.itemKey, manifestItem\.outcomePath\)/);
+  assert.match(
+    commitSource,
+    /outcomePathByItemKey\.set\(current\.itemKey, manifestItem\.outcomePath\)/,
+  );
   const quarantineRewrite = commitSource.indexOf("for (const itemKey of quarantinedItemKeys)");
   const receiptWrite = commitSource.indexOf("const receiptPath = batchReceiptPath();");
   assert.ok(quarantineRewrite >= 0 && receiptWrite >= 0 && quarantineRewrite < receiptWrite);

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -589,13 +589,13 @@ test("remote same-path drift is fenced before push", () => {
   publishSibling(fixture, "records/existing.md", "newer remote\n");
   const before = git(fixture.origin, "rev-parse", "state").trim();
 
-  assert.throws(
-    () =>
-      withStateEnvironment(fixture.work, () =>
-        commitPreparedStateBatch({ batchId: "same-path-drift", plans: [plan] }),
-      ),
-    /changed after mutation preparation/,
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "same-path-drift", plans: [plan] }),
   );
+  assert.equal(result.outcome, "quarantined");
+  assert.equal(result.commitSha, null);
+  assert.equal(result.quarantinedItems.length, 1);
+  assert.match(result.quarantinedItems[0].reason, /changed after mutation preparation/);
   assert.equal(git(fixture.origin, "rev-parse", "state").trim(), before);
   assert.equal(git(fixture.origin, "show", "state:records/existing.md"), "newer remote\n");
 });
@@ -749,13 +749,12 @@ test("literal Git path names cannot bypass the remote compare-and-swap fence", (
     }),
   );
 
-  assert.throws(
-    () =>
-      withStateEnvironment(fixture.work, () =>
-        commitPreparedStateBatch({ batchId: "literal-path-fence", plans: [plan] }),
-      ),
-    /changed after mutation preparation/,
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({ batchId: "literal-path-fence", plans: [plan] }),
   );
+  assert.equal(result.outcome, "quarantined");
+  assert.equal(result.quarantinedItems.length, 1);
+  assert.match(result.quarantinedItems[0].reason, /changed after mutation preparation/);
   assert.equal(git(fixture.origin, "show", `state:${literalPath}`), "remote literal\n");
 });
 

--- a/test/repair/state-publication-batch.test.ts
+++ b/test/repair/state-publication-batch.test.ts
@@ -213,6 +213,34 @@ test("commit_refs recovery retries transient receipt and lease renewal rejection
   );
 });
 
+test("commit_refs recovery retries a transient state branch push rejection", () => {
+  const fixture = createRepositoryFixture();
+  const plan = newItemPlan(fixture, 31);
+  const batchId = "github-state-branch-single-ref-retry";
+  const rejected = installMultiRefAndStateBranchCommitRefsFailure(fixture.origin);
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId,
+      plans: [plan],
+    }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(fs.existsSync(rejected.statePush), true);
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/31.md"),
+    "item 31\n",
+  );
+  const receiptRef = `refs/heads/clawsweeper-state-batches/${createHash("sha256")
+    .update(batchId)
+    .digest("hex")}`;
+  assert.equal(
+    git(fixture.origin, "rev-parse", "state").trim(),
+    git(fixture.origin, "rev-parse", receiptRef).trim(),
+  );
+});
+
 test("a receipt created after lookup cannot be overwritten", () => {
   const fixture = createRepositoryFixture();
   const plan = newItemPlan(fixture, 29);
@@ -471,6 +499,81 @@ test("incompatible same-path plans fail before acquiring a lease or pushing", ()
   assert.equal(
     git(fixture.origin, "show-ref", "refs/heads/clawsweeper-publish-lease/state", true),
     "",
+  );
+});
+
+test("a single poisoned item is quarantined without stranding the rest of the batch", () => {
+  const fixture = createRepositoryFixture();
+  const healthyBefore = newItemPlan(fixture, 50);
+  const expectedOid = git(fixture.work, "rev-parse", "state:records/existing.md").trim();
+  const poisoned = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#51", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/existing.md", expectedOid, content: "candidate\n" }],
+    }),
+  );
+  const healthyAfter = newItemPlan(fixture, 52);
+  publishSibling(fixture, "records/existing.md", "raced by another writer\n");
+
+  const result = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId: "quarantine-single-item",
+      plans: [healthyBefore, poisoned, healthyAfter],
+    }),
+  );
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(result.itemCount, 2);
+  assert.deepEqual(
+    result.quarantinedItems.map((item) => item.itemKey),
+    ["openclaw/openclaw#51"],
+  );
+  assert.match(result.quarantinedItems[0]?.reason ?? "", /changed after mutation preparation/);
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/50.md"),
+    "item 50\n",
+  );
+  assert.equal(
+    git(fixture.origin, "show", "state:records/openclaw-openclaw/items/52.md"),
+    "item 52\n",
+  );
+  assert.equal(
+    git(fixture.origin, "show", "state:records/existing.md"),
+    "raced by another writer\n",
+  );
+});
+
+test("a batch that quarantines an item down to one survivor is retry-idempotent", () => {
+  const fixture = createRepositoryFixture();
+  const healthy = newItemPlan(fixture, 60);
+  const expectedOid = git(fixture.work, "rev-parse", "state:records/existing.md").trim();
+  const poisoned = withStateEnvironment(fixture.work, () =>
+    prepareStateMutationPlan({
+      identity: { itemKey: "openclaw/openclaw#61", revision: 1, claimGeneration: 1 },
+      operations: [{ path: "records/existing.md", expectedOid, content: "candidate\n" }],
+    }),
+  );
+  publishSibling(fixture, "records/existing.md", "raced by another writer\n");
+
+  const first = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId: "quarantine-retry",
+      plans: [healthy, poisoned],
+    }),
+  );
+  const retried = withStateEnvironment(fixture.work, () =>
+    commitPreparedStateBatch({
+      batchId: "quarantine-retry",
+      plans: [healthy, poisoned],
+    }),
+  );
+
+  assert.equal(first.outcome, "committed");
+  assert.equal(retried.outcome, "already_committed");
+  assert.equal(retried.commitSha, first.commitSha);
+  assert.deepEqual(
+    retried.quarantinedItems.map((item) => item.itemKey),
+    ["openclaw/openclaw#61"],
   );
 });
 
@@ -958,6 +1061,36 @@ function installMultiRefAndFirstStateFailure(origin: string): void {
     ].join("\n"),
   );
   fs.chmodSync(hook, 0o755);
+}
+
+function installMultiRefAndStateBranchCommitRefsFailure(origin: string): { statePush: string } {
+  const hook = path.join(origin, "hooks", "pre-receive");
+  const rejectedStateMarker = path.join(origin, "hooks", "rejected-state-branch-commit-refs-once");
+  fs.writeFileSync(
+    hook,
+    [
+      "#!/bin/sh",
+      "count=0",
+      'only_ref=""',
+      "while read -r old_oid new_oid ref_name; do",
+      "  count=$((count + 1))",
+      '  only_ref="$ref_name"',
+      "done",
+      'if [ "$count" -ge 2 ]; then',
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      `if [ "$only_ref" = "refs/heads/state" ] && [ ! -f '${rejectedStateMarker}' ]; then`,
+      `  touch '${rejectedStateMarker}'`,
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(hook, 0o755);
+  return { statePush: rejectedStateMarker };
 }
 
 function configureUser(root: string): void {

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -1342,3 +1342,19 @@ test("publishing the durable review comment sweeps superseded placeholders", () 
   const applyWindow = source.slice(applyStart, applyStart + 1200);
   assert.match(applyWindow, /cleanupSupersededReviewPlaceholderComments\(\{/);
 });
+
+test("placeholder sweep retries on every apply pass independent of comment body sync", () => {
+  const source = readFileSync("src/clawsweeper.ts", "utf8");
+  const earlyLeaseStart = source.indexOf(
+    "const earlyLeaseState = refreshReviewStartLeaseState();",
+  );
+  assert.ok(earlyLeaseStart >= 0);
+  const needsReviewCommentSyncStart = source.indexOf(
+    "let needsReviewCommentSync = shouldSyncReviewComment({",
+    earlyLeaseStart,
+  );
+  assert.ok(needsReviewCommentSyncStart > earlyLeaseStart);
+  const earlyWindow = source.slice(earlyLeaseStart, needsReviewCommentSyncStart);
+  assert.match(earlyWindow, /cleanupSupersededReviewPlaceholderComments\(\{/);
+  assert.match(earlyWindow, /comments:\s*earlyLeaseState\.comments/);
+});

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -1345,9 +1345,7 @@ test("publishing the durable review comment sweeps superseded placeholders", () 
 
 test("placeholder sweep retries on every apply pass independent of comment body sync", () => {
   const source = readFileSync("src/clawsweeper.ts", "utf8");
-  const earlyLeaseStart = source.indexOf(
-    "const earlyLeaseState = refreshReviewStartLeaseState();",
-  );
+  const earlyLeaseStart = source.indexOf("const earlyLeaseState = refreshReviewStartLeaseState();");
   assert.ok(earlyLeaseStart >= 0);
   const needsReviewCommentSyncStart = source.indexOf(
     "let needsReviewCommentSync = shouldSyncReviewComment({",

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -158,7 +158,7 @@ test("review placeholder runner fails open and sends a signed exact-review decis
     now,
   });
 
-  assert.deepEqual(summary, { checked: 3, orphaned: 1, enqueued: 1, errors: 1 });
+  assert.deepEqual(summary, { checked: 3, orphaned: 1, enqueued: 1, escalated: 0, errors: 1 });
   assert.ok(logged.includes("review-placeholder recovery: enqueued #103 (pull_request)"));
   assert.deepEqual(commentChecks, [101, 102, 103]);
   assert.equal(enqueueBodies.length, 1);
@@ -176,27 +176,36 @@ test("review placeholder runner fails open and sends a signed exact-review decis
   });
 });
 
-test("review placeholder runner stops at the recovery cap", async () => {
+test("review placeholder runner fills the recovery cap with the oldest orphans first", async () => {
   const commentChecks: number[] = [];
-  let enqueueCalls = 0;
-  const mockFetch = async (input: string | URL | Request): Promise<Response> => {
+  const enqueuedNumbers: number[] = [];
+  const createdAtByNumber: Record<number, string> = {
+    201: "2026-07-17T09:00:00.000Z",
+    202: "2026-07-17T04:00:00.000Z",
+  };
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const url = new URL(input instanceof Request ? input.url : input.toString());
     if (url.pathname === "/search/issues") {
       return Response.json({ items: [{ number: 201 }, { number: 202 }] });
     }
     const commentMatch = url.pathname.match(/\/issues\/(\d+)\/comments$/);
     if (commentMatch) {
-      commentChecks.push(Number(commentMatch[1]));
+      const number = Number(commentMatch[1]);
+      commentChecks.push(number);
       return Response.json([
         {
           body: REVIEW_PLACEHOLDER_MARKER,
-          created_at: "2026-07-17T08:00:00.000Z",
+          created_at: createdAtByNumber[number],
           user: bot,
         },
       ]);
     }
     if (url.pathname === "/internal/exact-review/enqueue") {
-      enqueueCalls += 1;
+      const body = JSON.parse(String(init?.body ?? "{}")) as { decision: { itemNumber: number } };
+      enqueuedNumbers.push(body.decision.itemNumber);
       return Response.json({ ok: true, queued: true }, { status: 202 });
     }
     throw new Error(`unexpected request: ${url.pathname}`);
@@ -214,9 +223,70 @@ test("review placeholder runner stops at the recovery cap", async () => {
     now,
   });
 
-  assert.deepEqual(summary, { checked: 1, orphaned: 1, enqueued: 1, errors: 0 });
-  assert.deepEqual(commentChecks, [201]);
-  assert.equal(enqueueCalls, 1);
+  assert.deepEqual(summary, { checked: 2, orphaned: 2, enqueued: 1, escalated: 0, errors: 0 });
+  assert.deepEqual(commentChecks, [201, 202]);
+  assert.deepEqual(enqueuedNumbers, [202]);
+});
+
+test("review placeholder runner escalates orphans stuck well beyond the minimum age", async () => {
+  const escalatedLabels: { number: number; body: unknown }[] = [];
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      return Response.json({
+        items: [{ number: 301 }, { number: 302, labels: [{ name: "clawsweeper-recovery-stuck" }] }],
+      });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/301/comments") {
+      return Response.json([
+        {
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-16T00:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/302/comments") {
+      return Response.json([
+        {
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-16T00:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/301/labels") {
+      assert.equal(init?.method, "POST");
+      escalatedLabels.push({ number: 301, body: JSON.parse(String(init?.body ?? "{}")) });
+      return Response.json([], { status: 200 });
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+      REVIEW_PLACEHOLDER_STUCK_HOURS: "12",
+      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "2",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, { checked: 2, orphaned: 2, enqueued: 2, escalated: 1, errors: 0 });
+  assert.deepEqual(escalatedLabels, [
+    { number: 301, body: { labels: ["clawsweeper-recovery-stuck"] } },
+  ]);
 });
 
 test("placeholder refreshed recently by an active recovery is not orphaned", () => {

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   isOrphanedReviewPlaceholder,
   latestClawSweeperBotComment,
   REVIEW_PLACEHOLDER_MARKER,
+  reviewPlaceholderRecoveryFailureReason,
   runReviewPlaceholderRecovery,
 } from "../dist/review-placeholder-recovery.js";
 
@@ -92,7 +93,8 @@ test("review placeholder runner fails open and sends a signed exact-review decis
       assert.match(query, /repo:openclaw\/openclaw/);
       assert.match(query, /ClawSweeper status: review started\./);
       assert.match(query, /updated:>=2026-07-15T12:00:00\.000Z/);
-      assert.match(query, /is:open/);
+      assert.match(query, /is:(open|closed)/);
+      if (query.includes("is:closed")) return Response.json({ items: [] });
       return Response.json({
         items: [
           { number: 101 },
@@ -158,7 +160,14 @@ test("review placeholder runner fails open and sends a signed exact-review decis
     now,
   });
 
-  assert.deepEqual(summary, { checked: 3, orphaned: 1, enqueued: 1, escalated: 0, errors: 1 });
+  assert.deepEqual(summary, {
+    checked: 3,
+    orphaned: 1,
+    enqueued: 1,
+    cleaned: 0,
+    escalated: 0,
+    errors: 1,
+  });
   assert.ok(logged.includes("review-placeholder recovery: enqueued #103 (pull_request)"));
   assert.deepEqual(commentChecks, [101, 102, 103]);
   assert.equal(enqueueBodies.length, 1);
@@ -223,7 +232,14 @@ test("review placeholder runner fills the recovery cap with the oldest orphans f
     now,
   });
 
-  assert.deepEqual(summary, { checked: 2, orphaned: 2, enqueued: 1, escalated: 0, errors: 0 });
+  assert.deepEqual(summary, {
+    checked: 2,
+    orphaned: 2,
+    enqueued: 1,
+    cleaned: 0,
+    escalated: 0,
+    errors: 0,
+  });
   assert.deepEqual(commentChecks, [201, 202]);
   assert.deepEqual(enqueuedNumbers, [202]);
 });
@@ -286,7 +302,14 @@ test("review placeholder runner escalates orphans stuck well beyond the minimum 
     now,
   });
 
-  assert.deepEqual(summary, { checked: 2, orphaned: 2, enqueued: 2, escalated: 1, errors: 0 });
+  assert.deepEqual(summary, {
+    checked: 2,
+    orphaned: 2,
+    enqueued: 2,
+    cleaned: 0,
+    escalated: 1,
+    errors: 0,
+  });
   assert.deepEqual(escalatedLabels, [
     { number: 301, body: { labels: ["clawsweeper-recovery-stuck"] } },
   ]);
@@ -331,8 +354,321 @@ test("stuck escalation without a target write token is a visible error, not a wr
     now,
   });
 
-  assert.deepEqual(summary, { checked: 1, orphaned: 1, enqueued: 1, escalated: 0, errors: 1 });
+  assert.deepEqual(summary, {
+    checked: 1,
+    orphaned: 1,
+    enqueued: 1,
+    cleaned: 0,
+    escalated: 0,
+    errors: 1,
+  });
   assert.equal(labelRequests, 0);
+});
+
+test("orphaned placeholders on closed items are deleted instead of re-enqueued", async () => {
+  const deletedComments: string[] = [];
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) {
+        return Response.json({
+          items: [{ number: 401, pull_request: { url: "https://api.github.test/pulls/401" } }],
+        });
+      }
+      return Response.json({ items: [] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/401/comments") {
+      return Response.json([
+        {
+          id: 9001,
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/401") {
+      return Response.json({ state: "closed" });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/comments/9001") {
+      if ((init?.method ?? "GET") === "GET") {
+        return Response.json({
+          id: 9001,
+          body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=401 sha=abc lease_expires_at=2026-07-17T09:00:00.000Z owner=github-run-1-1 v=1 -->`,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        });
+      }
+      assert.equal(init?.method, "DELETE");
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("authorization"), "Bearer test-target-write-token");
+      deletedComments.push(url.pathname);
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      TARGET_WRITE_TOKEN: "test-target-write-token",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 1,
+    orphaned: 1,
+    enqueued: 0,
+    cleaned: 1,
+    escalated: 0,
+    errors: 0,
+  });
+  assert.deepEqual(deletedComments, ["/repos/openclaw/openclaw/issues/comments/9001"]);
+});
+
+test("closed-item cleanup without a target write token is a visible error", async () => {
+  let deleteRequests = 0;
+  const mockFetch = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ items: [{ number: 402 }] });
+      return Response.json({ items: [] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/402/comments") {
+      return Response.json([
+        {
+          id: 9002,
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname.startsWith("/repos/openclaw/openclaw/issues/comments/")) {
+      deleteRequests += 1;
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 1,
+    orphaned: 1,
+    enqueued: 0,
+    cleaned: 0,
+    escalated: 0,
+    errors: 1,
+  });
+  assert.equal(deleteRequests, 0);
+});
+
+test("closed-item cleanup revalidates and skips a placeholder that became a real review", async () => {
+  let deleteRequests = 0;
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ items: [{ number: 403 }] });
+      return Response.json({ items: [] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/403/comments") {
+      return Response.json([
+        {
+          id: 9003,
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/403") {
+      return Response.json({ state: "closed" });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/comments/9003") {
+      if ((init?.method ?? "GET") === "GET") {
+        // An in-flight publish replaced the placeholder body with the review.
+        return Response.json({
+          id: 9003,
+          body: "ClawSweeper review: keep open.",
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        });
+      }
+      deleteRequests += 1;
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      TARGET_WRITE_TOKEN: "test-target-write-token",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 1,
+    orphaned: 1,
+    enqueued: 0,
+    cleaned: 0,
+    escalated: 0,
+    errors: 0,
+  });
+  assert.equal(deleteRequests, 0);
+});
+
+test("closed cleanup keeps its own check budget when open placeholders fill the cap", async () => {
+  const deletedComments: string[] = [];
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ items: [{ number: 502 }] });
+      return Response.json({ items: [{ number: 501 }] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/501/comments") {
+      return Response.json([
+        {
+          body: "ClawSweeper review: keep open.",
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/502/comments") {
+      return Response.json([
+        {
+          id: 9502,
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/502") {
+      return Response.json({ state: "closed" });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/comments/9502") {
+      if ((init?.method ?? "GET") === "GET") {
+        return Response.json({
+          id: 9502,
+          body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=502 sha=abc v=1 -->`,
+          created_at: "2026-07-17T08:00:00.000Z",
+          user: bot,
+        });
+      }
+      deletedComments.push(url.pathname);
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      TARGET_WRITE_TOKEN: "test-target-write-token",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+      REVIEW_PLACEHOLDER_MAX_CHECKS: "1",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 2,
+    orphaned: 1,
+    enqueued: 0,
+    cleaned: 1,
+    escalated: 0,
+    errors: 0,
+  });
+  assert.deepEqual(deletedComments, ["/repos/openclaw/openclaw/issues/comments/9502"]);
+});
+
+test("recovery failure reason fires only on total action failure", () => {
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason({
+      checked: 5,
+      orphaned: 2,
+      enqueued: 0,
+      cleaned: 0,
+      escalated: 0,
+      errors: 2,
+    }),
+    "orphaned placeholders remain and every recovery action failed",
+  );
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason({
+      checked: 5,
+      orphaned: 2,
+      enqueued: 1,
+      cleaned: 0,
+      escalated: 0,
+      errors: 1,
+    }),
+    null,
+  );
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason({
+      checked: 5,
+      orphaned: 0,
+      enqueued: 0,
+      cleaned: 0,
+      escalated: 0,
+      errors: 1,
+    }),
+    null,
+  );
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason({
+      checked: 5,
+      orphaned: 2,
+      enqueued: 0,
+      cleaned: 0,
+      escalated: 1,
+      errors: 2,
+    }),
+    "orphaned placeholders remain and every recovery action failed",
+  );
 });
 
 test("placeholder refreshed recently by an active recovery is not orphaned", () => {

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -260,7 +260,56 @@ test("review placeholder runner escalates orphans stuck well beyond the minimum 
     }
     if (url.pathname === "/repos/openclaw/openclaw/issues/301/labels") {
       assert.equal(init?.method, "POST");
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("authorization"), "Bearer test-target-write-token");
       escalatedLabels.push({ number: 301, body: JSON.parse(String(init?.body ?? "{}")) });
+      return Response.json([], { status: 200 });
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      TARGET_WRITE_TOKEN: "test-target-write-token",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+      REVIEW_PLACEHOLDER_STUCK_HOURS: "12",
+      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "2",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, { checked: 2, orphaned: 2, enqueued: 2, escalated: 1, errors: 0 });
+  assert.deepEqual(escalatedLabels, [
+    { number: 301, body: { labels: ["clawsweeper-recovery-stuck"] } },
+  ]);
+});
+
+test("stuck escalation without a target write token is a visible error, not a wrong-identity write", async () => {
+  let labelRequests = 0;
+  const mockFetch = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      return Response.json({ items: [{ number: 311 }] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/311/comments") {
+      return Response.json([
+        {
+          body: REVIEW_PLACEHOLDER_MARKER,
+          created_at: "2026-07-16T00:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname.endsWith("/labels")) {
+      labelRequests += 1;
       return Response.json([], { status: 200 });
     }
     if (url.pathname === "/internal/exact-review/enqueue") {
@@ -277,16 +326,13 @@ test("review placeholder runner escalates orphans stuck well beyond the minimum 
       QUEUE_URL: "https://queue.test",
       TARGET_REPO: "openclaw/openclaw",
       REVIEW_PLACEHOLDER_STUCK_HOURS: "12",
-      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "2",
     },
     fetchImpl: mockFetch as typeof fetch,
     now,
   });
 
-  assert.deepEqual(summary, { checked: 2, orphaned: 2, enqueued: 2, escalated: 1, errors: 0 });
-  assert.deepEqual(escalatedLabels, [
-    { number: 301, body: { labels: ["clawsweeper-recovery-stuck"] } },
-  ]);
+  assert.deepEqual(summary, { checked: 1, orphaned: 1, enqueued: 1, escalated: 0, errors: 1 });
+  assert.equal(labelRequests, 0);
 });
 
 test("placeholder refreshed recently by an active recovery is not orphaned", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -929,7 +929,7 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.match(sweepJob, /timeout-minutes: 10/);
   assert.match(
     sweepJob,
-    /permissions:\s+actions: read\s+contents: read\s+issues: write\s+pull-requests: read/,
+    /permissions:\s+actions: read\s+contents: read\s+issues: read\s+pull-requests: read/,
   );
   assert.match(sweepJob, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(sweepJob, /\/internal\/exact-review\/claimed-runs/);
@@ -940,8 +940,14 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.match(sweepJob, /x-clawsweeper-exact-review-signature/);
   assert.match(sweepJob, /actions\/checkout@v7/);
   assert.match(sweepJob, /build-script: build/);
+  assert.match(sweepJob, /name: Create target write token/);
+  assert.match(sweepJob, /owner: openclaw\s+repositories: openclaw\s+permission-issues: write/);
   assert.match(sweepJob, /name: Recover orphaned review placeholders/);
   assert.match(sweepJob, /run: node dist\/review-placeholder-recovery\.js/);
+  assert.match(
+    sweepJob,
+    /TARGET_WRITE_TOKEN: \$\{\{ steps\.target-write-token\.outputs\.token \}\}/,
+  );
   assert.match(
     sweepJob,
     /REVIEW_PLACEHOLDER_MAX_CHECKS: \$\{\{ vars\.REVIEW_PLACEHOLDER_MAX_CHECKS \|\| '20' \}\}/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -929,7 +929,7 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.match(sweepJob, /timeout-minutes: 10/);
   assert.match(
     sweepJob,
-    /permissions:\s+actions: read\s+contents: read\s+issues: read\s+pull-requests: read/,
+    /permissions:\s+actions: read\s+contents: read\s+issues: write\s+pull-requests: read/,
   );
   assert.match(sweepJob, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(sweepJob, /\/internal\/exact-review\/claimed-runs/);


### PR DESCRIPTION
## Summary

Closes the still-open gap behind #725. #805 and #806 fixed real bugs in the git state-materializer layer, but that layer is not the code path that posts or edits the review verdict comment on openclaw/openclaw issues and PRs. This PR fixes four separate, confirmed bugs in the actual production path (`exact-review-batch-cli.ts`, `prepare-exact-review-batch.mjs`, `publish-event-result.ts`, `state-publication-batch.ts`, `git-publish.ts`), none of which #805/#806 touch.

Note along the way: `exact-review-batch-publisher.ts` / `exact-review-batch-coordinator.ts`, the module whose comments describe GitHub delivery as "deliberately preceding state publication," has no production callers. It is exercised only by its own unit tests and `scripts/state-publication-batching-proof.mjs`. The real pipeline reimplements similar ordering through a different, unabstracted path, which is what this PR patches.

1. `state-publication-batch.ts`: `commitUnderLease` threw for the whole batch when a single item's remote state had drifted from its expected oid, stranding every other item in that batch as `retryable_failure` even though their GitHub verdict comments had already been delivered. It now quarantines only the conflicting item(s) and commits the remaining healthy plans; quarantined items come back as `state_conflict_quarantined` for a fresh retry instead of blocking the batch.

2. `git-publish.ts`: `pushStateAndReceiptAfterCommitRefsFailure` already retried the receipt-ref push and the lease-renewal push on a `commit_refs` rejection, but never retried its own final state-branch push. One rejection there killed the batch outright (reproduced in Actions run 30010201171: three `commit_refs` hits, run still ends cancelled). The state-branch push now gets the same bounded, remote-fenced retry loop as its siblings, and all three backoff sites now use real exponential backoff instead of a barely-growing linear formula.

3. `clawsweeper.ts`: `cleanupSupersededReviewPlaceholderComments` only runs inside the same pass that just posted the durable verdict comment. Its own inline comment claims a failed sweep is retried on the next apply, but that is not true: once the verdict comment is considered synced, the branch that calls the sweep is never reached again. A single transient delete failure (rate limit, momentary API error) permanently strands the placeholder. The sweep now also runs whenever a durable comment already exists, before the body-sync gate, reusing the comment list already fetched for the lease check, so it costs nothing in the common no-op case and actually retries on subsequent passes.

4. `review-placeholder-recovery.ts`: the 15-minute recovery cron spends its per-run budget (default 5) on GitHub search results sorted newest-orphan-first, so under sustained backlog the oldest, most-stuck placeholders are structurally last in line for a recovery slot every run, and exhausting the budget was silent. Admission is now sorted oldest-first within the same cap, and placeholders that stay orphaned past a longer threshold get a distinct label so they are visible instead of invisible.

None of these fix the documented capacity gap in `docs/state-publication-batching-plan.md` (arrivals outpacing completions at every tested batch size). That is a separate admission/throughput question. These four fixes should reduce how often already-delivered verdicts get needlessly stranded and re-processed, which helps, but this PR does not claim to single-handedly drain the backlog.

## Test plan

- `tsc -p tsconfig.json` and `tsc -p tsconfig.repair.json`: clean.
- `oxlint src --ignore-pattern "src/repair/**" --tsconfig tsconfig.json --type-aware --deny-warnings -D correctness` and `oxlint src/repair --tsconfig tsconfig.repair.json --deny-warnings -D correctness`: clean.
- Each fix has a new regression test verified to fail on unpatched `main` and pass on this branch.
- `test/repair/state-publication-batch.test.ts` (29 tests, combines the quarantine and commit_refs-retry fixes in one file): all pass.
- Full targeted run across affected areas (`placeholder|superseded|commit_refs|poisoned|quarantine|stuck`, 115 tests) and the full `repair` suite: pass, aside from two pre-existing failures in `test/repair/target-validation.test.ts` (tight ~8ms timing budgets) that reproduce identically on unpatched `main` and are unrelated to any file this PR touches.

## Maintainer additions (steipete)

Taken over for landing during the publication-backlog incident (CSW-049). Rebased onto current `main` (clean; the overnight batching fixes #817-#823 touch disjoint files), fixed the `oxfmt` failures that broke CI, and added two commits:

1. **Target write token for escalation.** The reconcile sweep runs with the clawsweeper-scoped `GITHUB_TOKEN`, which can never write labels on `openclaw/openclaw`, so the stuck-placeholder escalation in this PR would have 403'd in production (and the job-level `issues: write` bump granted nothing useful — reverted). The workflow now mints an app installation token scoped to the target repo (`permission-issues: write`) and the recovery script uses it for mutations; a missing token is a counted, visible error rather than a wrong-identity write.

2. **Closed-item placeholder cleanup + loud total failure.** Recovery only searched open items, so a placeholder whose item closed while its publication starved in the queue was stranded forever — observed live on openclaw/openclaw#113156 (review generated 2026-07-23 22:05Z, publication still `pending attempts=0` behind ~1300 stale items, PR closed 00:40Z, placeholder with expired lease still up). Closed items now get their own bounded search/check budget and their stale placeholders are deleted after a fresh reread proves the item is still closed and the comment still carries this item's `clawsweeper-review-status:started` machine marker at orphan age. Missing configuration now fails the run instead of silently no-opping, and the CLI exits nonzero when orphans exist and every resolving action failed. Named tradeoff: GitHub has no conditional comment delete, so a one-RTT race against a concurrent publish remains, documented at the code site.

Validation: `pnpm run build:all`, full `pnpm run test:no-build` (green), focused reruns of `review-placeholder-recovery` (10 tests), `sweep-workflow`, `review-comment-rendering`, `exact-review-batch-workflow`, and `state-publication-batch` (29 tests incl. the new quarantine/commit_refs coverage), plus lint and the CI static gates. Four Codex autoreview rounds; the two accepted rounds of findings (wrong-token escalation counted as accomplishment, stale-snapshot deletion, substring marker gate, refreshed-placeholder deletion, open-search starving closed cleanup) are fixed; the residual TOCTOU finding is consciously rejected with the rationale inline.
