### PR TITLE
fix(validation): classify identity-capture starvation under the runtime budget

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1145,13 +1145,24 @@ export function runAllowedValidationCommandsWithBinding(
       options.validationTimeoutMs ?? DEFAULT_TARGET_VALIDATION_TIMEOUT_MS,
       options.validationTimeoutMs,
     );
-    const identityCaptureDeadlineAt =
-      Date.now() + Math.max(validationTimeoutMs, MIN_VALIDATION_IDENTITY_WINDOW_MS);
+    // Match the pre-change shape: each capture stage gets its own fresh window
+    // so ignored-path enumeration cannot starve the checkout identity capture.
+    const identityCaptureWindowMs = Math.max(
+      validationTimeoutMs,
+      MIN_VALIDATION_IDENTITY_WINDOW_MS,
+    );
     let ignoredValidationInputs: string[];
     let checkoutIdentity: ValidationCheckoutIdentity;
     try {
-      ignoredValidationInputs = ignoredValidationRuntimePaths(cwd, identityCaptureDeadlineAt);
-      checkoutIdentity = validationCheckoutIdentity(cwd, baseRef, identityCaptureDeadlineAt);
+      ignoredValidationInputs = ignoredValidationRuntimePaths(
+        cwd,
+        Date.now() + identityCaptureWindowMs,
+      );
+      checkoutIdentity = validationCheckoutIdentity(
+        cwd,
+        baseRef,
+        Date.now() + identityCaptureWindowMs,
+      );
     } catch (error) {
       if (isValidationIdentityTimeoutError(error)) {
         throw new Error(

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1221,12 +1221,11 @@ export function runAllowedValidationCommandsWithBinding(
           } catch (error) {
             executionError = error as Error;
           }
-          const identityProofDeadlineAt = validationIdentityProofDeadlineAt(deadlineAt);
           try {
             clearNewIgnoredValidationRuntimePaths(
               cwd,
               ignoredValidationInputs,
-              identityProofDeadlineAt,
+              validationIdentityProofDeadlineAt(deadlineAt),
             );
           } catch (error) {
             executionError ??= error as Error;
@@ -1235,7 +1234,7 @@ export function runAllowedValidationCommandsWithBinding(
             cwd,
             baseRef,
             checkoutIdentity,
-            identityProofDeadlineAt,
+            validationIdentityProofDeadlineAt(deadlineAt),
             rendered,
             executionError,
           );
@@ -1273,12 +1272,11 @@ export function runAllowedValidationCommandsWithBinding(
               } catch (error) {
                 fallbackError = error as Error;
               }
-              const fallbackProofDeadlineAt = validationIdentityProofDeadlineAt(deadlineAt);
               try {
                 clearNewIgnoredValidationRuntimePaths(
                   cwd,
                   ignoredValidationInputs,
-                  fallbackProofDeadlineAt,
+                  validationIdentityProofDeadlineAt(deadlineAt),
                 );
               } catch (error) {
                 fallbackError ??= error as Error;
@@ -1287,7 +1285,7 @@ export function runAllowedValidationCommandsWithBinding(
                 cwd,
                 baseRef,
                 checkoutIdentity,
-                fallbackProofDeadlineAt,
+                validationIdentityProofDeadlineAt(deadlineAt),
                 rendered,
                 fallbackError ?? executionError,
               );

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -46,6 +46,14 @@ const MAX_TARGET_INSTALL_GIT_PATHS = 250_000;
 const MAX_VALIDATION_IGNORED_PATH_BYTES = 16 * 1024 * 1024;
 const MAX_VALIDATION_IGNORED_PATHS = 250_000;
 const MIN_VALIDATION_RETRY_BUDGET_MS = 1_000;
+// Checkout-identity capture and post-command mutation proof run trusted git
+// subprocesses only. On a loaded machine they can starve tiny per-command
+// budgets, so they get at least this much room instead of surfacing raw
+// near-zero subprocess timeouts. Healthy (default) budgets already exceed it.
+const MIN_VALIDATION_IDENTITY_WINDOW_MS = 10_000;
+// Never spawn a validation command with a near-zero timeout; classify the
+// starved budget instead so callers see the runtime-budget error family.
+const MIN_VALIDATION_COMMAND_BUDGET_MS = 25;
 const verifiedRustupToolchainBins = new Map<string, VerifiedRustupToolchain>();
 const preparedTargetPnpmRuntimes = new Map<string, PreparedTargetPnpmRuntime>();
 let preparedTargetPnpmRuntimeCleanupRegistered = false;
@@ -1137,15 +1145,22 @@ export function runAllowedValidationCommandsWithBinding(
       options.validationTimeoutMs ?? DEFAULT_TARGET_VALIDATION_TIMEOUT_MS,
       options.validationTimeoutMs,
     );
-    const ignoredValidationInputs = ignoredValidationRuntimePaths(
-      cwd,
-      Date.now() + validationTimeoutMs,
-    );
-    const checkoutIdentity = validationCheckoutIdentity(
-      cwd,
-      baseRef,
-      Date.now() + validationTimeoutMs,
-    );
+    const identityCaptureDeadlineAt =
+      Date.now() + Math.max(validationTimeoutMs, MIN_VALIDATION_IDENTITY_WINDOW_MS);
+    let ignoredValidationInputs: string[];
+    let checkoutIdentity: ValidationCheckoutIdentity;
+    try {
+      ignoredValidationInputs = ignoredValidationRuntimePaths(cwd, identityCaptureDeadlineAt);
+      checkoutIdentity = validationCheckoutIdentity(cwd, baseRef, identityCaptureDeadlineAt);
+    } catch (error) {
+      if (isValidationIdentityTimeoutError(error)) {
+        throw new Error(
+          "unsafe validation command checkout identity could not be verified (checkout identity capture)",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
     const currentSourceIdentity = sourceIdentityFromCheckout(checkoutIdentity);
     if (
       preparedPnpmRuntime &&
@@ -1183,7 +1198,9 @@ export function runAllowedValidationCommandsWithBinding(
             }
             const executionParts = validationCommandForExecution(parts);
             const executionBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
-            if (executionBudgetMs <= 0) throw validationCommandBudgetError(rendered);
+            if (executionBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
+              throw validationCommandBudgetError(rendered);
+            }
             runContainedCommand(executionParts[0]!, executionParts.slice(1), {
               cwd,
               env: validationEnv,
@@ -1193,8 +1210,13 @@ export function runAllowedValidationCommandsWithBinding(
           } catch (error) {
             executionError = error as Error;
           }
+          const identityProofDeadlineAt = validationIdentityProofDeadlineAt(deadlineAt);
           try {
-            clearNewIgnoredValidationRuntimePaths(cwd, ignoredValidationInputs, deadlineAt);
+            clearNewIgnoredValidationRuntimePaths(
+              cwd,
+              ignoredValidationInputs,
+              identityProofDeadlineAt,
+            );
           } catch (error) {
             executionError ??= error as Error;
           }
@@ -1202,7 +1224,7 @@ export function runAllowedValidationCommandsWithBinding(
             cwd,
             baseRef,
             checkoutIdentity,
-            deadlineAt,
+            identityProofDeadlineAt,
             rendered,
             executionError,
           );
@@ -1227,7 +1249,7 @@ export function runAllowedValidationCommandsWithBinding(
               try {
                 resetValidationEnvironment(deadlineAt - identityReserveMs);
                 const fallbackBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
-                if (fallbackBudgetMs <= 0) {
+                if (fallbackBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
                   throw validationCommandBudgetError(rendered, executionError);
                 }
                 const executionParts = validationCommandForExecution(fallbackParts);
@@ -1240,8 +1262,13 @@ export function runAllowedValidationCommandsWithBinding(
               } catch (error) {
                 fallbackError = error as Error;
               }
+              const fallbackProofDeadlineAt = validationIdentityProofDeadlineAt(deadlineAt);
               try {
-                clearNewIgnoredValidationRuntimePaths(cwd, ignoredValidationInputs, deadlineAt);
+                clearNewIgnoredValidationRuntimePaths(
+                  cwd,
+                  ignoredValidationInputs,
+                  fallbackProofDeadlineAt,
+                );
               } catch (error) {
                 fallbackError ??= error as Error;
               }
@@ -1249,7 +1276,7 @@ export function runAllowedValidationCommandsWithBinding(
                 cwd,
                 baseRef,
                 checkoutIdentity,
-                deadlineAt,
+                fallbackProofDeadlineAt,
                 rendered,
                 fallbackError ?? executionError,
               );
@@ -1265,7 +1292,9 @@ export function runAllowedValidationCommandsWithBinding(
           ) {
             continue;
           }
-          if (retryBudgetMs <= 0) throw validationCommandBudgetError(rendered, executionError);
+          if (retryBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
+            throw validationCommandBudgetError(rendered, executionError);
+          }
           throw new Error(
             `validation command failed (${rendered}): ${compactText(executionError.message, 12000)}`,
             { cause: executionError },
@@ -3520,6 +3549,22 @@ function targetToolchainCommandTimeout(
 
 function validationIdentityReserveMs(timeoutMs: number) {
   return Math.max(1, Math.min(30_000, Math.floor(timeoutMs / 2)));
+}
+
+// The post-command identity proof runs after the command has been reaped, so
+// extending a starved reserve here never grants untrusted code extra runtime.
+// It keeps mutation detection deterministic instead of collapsing into raw
+// near-zero git subprocess timeouts under tiny budgets or machine load.
+function validationIdentityProofDeadlineAt(deadlineAt: number) {
+  return Math.max(deadlineAt, Date.now() + MIN_VALIDATION_IDENTITY_WINDOW_MS);
+}
+
+function isValidationIdentityTimeoutError(error: unknown) {
+  const message = String((error as Error | null)?.message ?? "");
+  return (
+    /command timed out after \d+ms/.test(message) ||
+    message.includes("validation identity deadline exhausted during")
+  );
 }
 
 function remainingCommandBudget(deadlineAt: number, identityReserveMs: number) {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3798,10 +3798,15 @@ test(
     git(cwd, "add", ".");
     git(cwd, "commit", "-m", "initial");
 
+    // The identity walk resolves the checkout root through realpath, so on
+    // macOS the opened path lives under /private/var while the fixture path
+    // references the /var tmpdir symlink; compare against the resolved path.
+    const resolvedRuntimeInput = fs.realpathSync(runtimeInput);
     const originalOpenSync = fs.openSync;
     let runtimeInputOpenCount = 0;
     fs.openSync = ((filePath, flags, mode) => {
-      if (path.resolve(String(filePath)) === runtimeInput && flags === "r") {
+      const openedPath = path.resolve(String(filePath));
+      if ((openedPath === runtimeInput || openedPath === resolvedRuntimeInput) && flags === "r") {
         runtimeInputOpenCount += 1;
       }
       return originalOpenSync(filePath, flags, mode);


### PR DESCRIPTION
## What

Classifies checkout-identity starvation into the existing validation error families instead of letting raw near-zero subprocess timeouts escape, and fixes a macOS-only path comparison in the runtime-identity dedup test.

- `src/repair/target-validation.ts`:
  - Pre-command identity capture (`ignoredValidationRuntimePaths` + `validationCheckoutIdentity`) now gets a floored window per stage (`max(validationTimeoutMs, 10s)`), and any timeout during capture is classified as `unsafe validation command checkout identity could not be verified (checkout identity capture)` instead of a raw `command timed out after Nms: git ...` error.
  - Validation commands (main, fallback, retry paths) are never spawned with a near-zero timeout: budgets below a 25ms floor throw the classified `validation command runtime budget exhausted` error.
  - The post-command identity proof (ignored-path cleanup and checkout mutation check) gets a fresh floored window per stage via `validationIdentityProofDeadlineAt`. The command has already been reaped at that point, so this never grants untrusted code extra runtime; it just makes mutation detection deterministic under load.
- `test/repair/target-validation.test.ts`: the symlink dedup test now compares opened paths against the realpath of the runtime input, since macOS `os.tmpdir()` lives under the `/var -> /private/var` symlink while the identity walk resolves the checkout root through realpath.

## Why

Three tests in `test/repair/target-validation.test.ts` failed deterministically (one intermittently) on a local macOS machine:

- "changed validation shares one timeout with checkout identity proof" (250ms budget): the pre-command identity capture spawns dozens of git subprocesses and consumed nearly the whole 250ms, so a later capture subprocess got a ~9ms timeout and a raw timeout error escaped instead of the classified budget/identity errors the test expects.
- "validation reserves deadline to prove checkout mutation after command timeout" (800ms budget, intermittent): the post-command mutation proof shared the leftover reserve and could time out under load, hiding the expected "mutated checkout identity" classification.
- "runtime identity deduplicates shared symlink targets across ignored roots": pure macOS path-resolution mismatch (`/var` vs `/private/var`) in the test spy, counting 0 opens instead of 1.

CI behavior with healthy (default 12-minute) budgets is unchanged: the floors only lift windows that are already far below any realistic production configuration.

## Evidence

- `pnpm run build && pnpm run build:repair` clean.
- Each of the three affected tests run 5 times in a loop (also all three together 5x after each review iteration): 15/15 pass, 0 fail.
- Full suite `node --test test/repair/target-validation.test.ts`: 160 tests, 157 pass, 3 skipped (platform skips), 0 fail.
- `pnpm exec oxfmt` clean on touched files.
- Autoreview (branch vs origin/main): two P2 findings on intermediate revisions (shared capture window; shared post-command proof window) addressed in follow-up commits; final run clean, verdict "patch is correct".
