### PR TITLE
fix(publication): bound historical lineage backfill

### DIFF
--- a/.github/workflows/exact-review-queue-maintenance.yml
+++ b/.github/workflows/exact-review-queue-maintenance.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: boolean
         default: false
+      passes:
+        description: "Deprecated compatibility input; accepted but clamped to one pass"
+        required: true
+        type: string
+        default: "1"
 
 concurrency:
   group: exact-review-queue-maintenance
@@ -38,9 +43,11 @@ jobs:
       - name: Preview or reconcile historical publication lineages
         env:
           EXECUTE: ${{ inputs.execute }}
+          PASSES: ${{ inputs.passes }}
         run: |
           args=(--max-items 100)
           if [[ "$EXECUTE" == "true" ]]; then
             args+=(--apply)
           fi
+          args+=(--passes "$PASSES")
           pnpm run --silent repair:exact-review-queue-maintenance -- "${args[@]}"

--- a/.github/workflows/exact-review-queue-maintenance.yml
+++ b/.github/workflows/exact-review-queue-maintenance.yml
@@ -4,15 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       execute:
-        description: "Apply bounded publication supersession"
+        description: "Apply one bounded pass (false runs a dry-run)"
         required: true
         type: boolean
         default: false
-      passes:
-        description: "Maximum 100-item passes"
-        required: true
-        type: string
-        default: "1"
 
 concurrency:
   group: exact-review-queue-maintenance
@@ -23,7 +18,6 @@ permissions:
 
 jobs:
   reconcile:
-    if: ${{ inputs.execute }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -41,11 +35,12 @@ jobs:
         with:
           build-script: build:repair
 
-      - name: Reconcile superseded publication items
+      - name: Preview or reconcile historical publication lineages
         env:
-          PASSES: ${{ inputs.passes }}
-        run: >-
-          pnpm run --silent repair:exact-review-queue-maintenance --
-          --apply
-          --max-items 100
-          --passes "$PASSES"
+          EXECUTE: ${{ inputs.execute }}
+        run: |
+          args=(--max-items 100)
+          if [[ "$EXECUTE" == "true" ]]; then
+            args+=(--apply)
+          fi
+          pnpm run --silent repair:exact-review-queue-maintenance -- "${args[@]}"

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -3077,11 +3077,16 @@ export class ExactReviewQueue {
             left.item.createdAt - right.item.createdAt ||
             left.item.key.localeCompare(right.item.key),
         );
-      protectedLineageItems += active.length;
-      const retained = active[0] ?? pending[0];
+      if (active.length) {
+        // An active owner may still publish its captured decision. Preserve the
+        // whole lineage until ownership expires so newer provenance is not lost.
+        protectedLineageItems += entries.length;
+        continue;
+      }
+      const retained = pending[0];
       if (!retained) continue;
 
-      if (!active.length && pending.length > 1) {
+      if (pending.length > 1) {
         const freshest = pending.reduce((latest, candidate) => {
           const latestPublication = latest.item.decision.publication;
           const candidatePublication = candidate.item.decision.publication;

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -3006,7 +3006,7 @@ export class ExactReviewQueue {
         revision.targetKey,
         Math.max(newestByTarget.get(revision.targetKey) ?? 0, revision.sourceRevision),
       );
-      return [{ item, revision }];
+      return [{ item, revision, lineage: exactReviewPublicationLineage(item.decision) }];
     });
     for (const [targetKey, sourceRevision] of newestByTarget) {
       newestByTarget.set(
@@ -3014,23 +3014,114 @@ export class ExactReviewQueue {
         Math.max(sourceRevision, this.publicationHeadRevisionSync(targetKey)),
       );
     }
-    const candidates = versioned
-      .filter(
-        ({ item, revision }) =>
-          revision.sourceRevision < (newestByTarget.get(revision.targetKey) ?? 0) &&
-          (item.state === "pending" || item.state === "parked") &&
-          !activeBatchItemKeys.has(item.key),
-      )
-      .sort(
-        (left, right) =>
-          left.revision.targetKey.localeCompare(right.revision.targetKey) ||
-          left.revision.sourceRevision - right.revision.sourceRevision ||
-          left.item.key.localeCompare(right.item.key),
-      );
+
+    type ReconcileCandidate = {
+      item: ExactReviewQueueItem;
+      revision: { targetKey: string; sourceRevision: number };
+      reason: "stale_revision" | "duplicate_lineage";
+      lineage: ExactReviewPublicationLineage | null;
+      lineageKey?: string;
+      retainedKey?: string;
+    };
+    const candidatesByKey = new Map<string, ReconcileCandidate>();
+    for (const entry of versioned) {
+      if (
+        entry.revision.sourceRevision < (newestByTarget.get(entry.revision.targetKey) ?? 0) &&
+        (entry.item.state === "pending" || entry.item.state === "parked") &&
+        !activeBatchItemKeys.has(entry.item.key)
+      ) {
+        candidatesByKey.set(entry.item.key, {
+          ...entry,
+          reason: "stale_revision",
+        });
+      }
+    }
+
+    const lineageGroups = new Map<string, typeof versioned>();
+    for (const entry of versioned) {
+      if (
+        !entry.lineage ||
+        entry.revision.sourceRevision < (newestByTarget.get(entry.revision.targetKey) ?? 0)
+      ) {
+        continue;
+      }
+      const lineageKey = exactReviewPublicationLineageKey(entry.lineage);
+      const group = lineageGroups.get(lineageKey) ?? [];
+      group.push(entry);
+      lineageGroups.set(lineageKey, group);
+    }
+
+    const lineageRefreshes = new Map<
+      string,
+      { retainedKey: string; decision: ExactReviewDecision }
+    >();
+    let protectedLineageItems = 0;
+    for (const [lineageKey, entries] of lineageGroups) {
+      if (entries.length < 2) continue;
+      const active = entries
+        .filter(
+          ({ item }) =>
+            activeBatchItemKeys.has(item.key) ||
+            item.state === "dispatching" ||
+            item.state === "leased",
+        )
+        .sort((left, right) => left.item.key.localeCompare(right.item.key));
+      const pending = entries
+        .filter(
+          ({ item }) =>
+            !activeBatchItemKeys.has(item.key) &&
+            (item.state === "pending" || item.state === "parked"),
+        )
+        .sort(
+          (left, right) =>
+            left.item.createdAt - right.item.createdAt ||
+            left.item.key.localeCompare(right.item.key),
+        );
+      protectedLineageItems += active.length;
+      const retained = active[0] ?? pending[0];
+      if (!retained) continue;
+
+      if (!active.length && pending.length > 1) {
+        const freshest = pending.reduce((latest, candidate) => {
+          const latestPublication = latest.item.decision.publication;
+          const candidatePublication = candidate.item.decision.publication;
+          return latestPublication &&
+            candidatePublication &&
+            exactReviewPublicationProducerIsNewer(candidatePublication, latestPublication)
+            ? candidate
+            : latest;
+        });
+        lineageRefreshes.set(lineageKey, {
+          retainedKey: retained.item.key,
+          decision: freshest.item.decision,
+        });
+      }
+
+      for (const entry of pending) {
+        if (entry.item.key === retained.item.key || candidatesByKey.has(entry.item.key)) continue;
+        candidatesByKey.set(entry.item.key, {
+          ...entry,
+          reason: "duplicate_lineage",
+          lineageKey,
+          retainedKey: retained.item.key,
+        });
+      }
+    }
+
+    const candidates = [...candidatesByKey.values()].sort(
+      (left, right) =>
+        left.item.createdAt - right.item.createdAt || left.item.key.localeCompare(right.item.key),
+    );
     const selected = candidates.slice(0, limit);
+    const changedKeys = new Set<string>();
+    const changedLineages = new Set<string>();
+    let staleRevisionChanged = 0;
+    let lineageDuplicateChanged = 0;
+    let lineageRefreshed = 0;
     if (apply && selected.length) {
       this.storage.transactionSync(() => {
-        for (const { item, revision } of selected) {
+        for (const candidate of selected) {
+          const { item, revision } = candidate;
           const current = state.items[item.key];
           const currentRevision = current ? exactReviewPublicationRevision(current.decision) : null;
           if (
@@ -3043,30 +3134,113 @@ export class ExactReviewQueue {
           ) {
             continue;
           }
+          if (
+            candidate.reason === "stale_revision" &&
+            currentRevision.sourceRevision >=
+              (newestByTarget.get(currentRevision.targetKey) ?? currentRevision.sourceRevision)
+          ) {
+            continue;
+          }
+          if (candidate.reason === "duplicate_lineage") {
+            const currentLineage = exactReviewPublicationLineage(current.decision);
+            const retained = candidate.retainedKey ? state.items[candidate.retainedKey] : null;
+            const retainedLineage = retained
+              ? exactReviewPublicationLineage(retained.decision)
+              : null;
+            if (
+              !currentLineage ||
+              !retainedLineage ||
+              !candidate.lineageKey ||
+              exactReviewPublicationLineageKey(currentLineage) !== candidate.lineageKey ||
+              exactReviewPublicationLineageKey(retainedLineage) !== candidate.lineageKey
+            ) {
+              continue;
+            }
+          }
           delete state.items[current.key];
+          changedKeys.add(current.key);
+          if (candidate.reason === "stale_revision") staleRevisionChanged += 1;
+          else {
+            lineageDuplicateChanged += 1;
+            if (candidate.lineageKey) changedLineages.add(candidate.lineageKey);
+          }
         }
-        this.writeStateSync(state);
-        this.incrementQueueMetricsSync({
-          publicationCompleted: selected.length,
-          publicationSuperseded: selected.length,
-        });
+
+        for (const lineageKey of changedLineages) {
+          const refresh = lineageRefreshes.get(lineageKey);
+          if (!refresh) continue;
+          const retained = state.items[refresh.retainedKey];
+          const retainedLineage = retained
+            ? exactReviewPublicationLineage(retained.decision)
+            : null;
+          const retainedPublication = retained?.decision.publication;
+          const freshestPublication = refresh.decision.publication;
+          if (
+            !retained ||
+            !retainedLineage ||
+            exactReviewPublicationLineageKey(retainedLineage) !== lineageKey ||
+            (retained.state !== "pending" && retained.state !== "parked") ||
+            activeBatchItemKeys.has(retained.key) ||
+            !retainedPublication ||
+            !freshestPublication ||
+            !exactReviewPublicationProducerIsNewer(freshestPublication, retainedPublication)
+          ) {
+            continue;
+          }
+          retained.decision = refresh.decision;
+          retained.updatedAt = now;
+          lineageRefreshed += 1;
+        }
+        if (changedKeys.size) {
+          this.writeStateSync(state);
+          this.incrementQueueMetricsSync({
+            publicationCompleted: changedKeys.size,
+            publicationSuperseded: changedKeys.size,
+            publicationSemanticDeduped: lineageDuplicateChanged,
+          });
+        }
       });
-      await this.scheduleNext(state, now);
+      if (changedKeys.size) await this.scheduleNext(state, now);
     }
+
+    const remaining = apply
+      ? candidates.filter(({ item }) => !changedKeys.has(item.key))
+      : candidates;
+    const oldestAgeSeconds = (entries: ReconcileCandidate[]) =>
+      entries.length
+        ? Math.floor(
+            Math.max(0, now - Math.min(...entries.map(({ item }) => item.createdAt))) / 1000,
+          )
+        : null;
+    const staleRevisionEligible = candidates.filter(
+      ({ reason }) => reason === "stale_revision",
+    ).length;
+    const lineageDuplicateEligible = candidates.length - staleRevisionEligible;
     return json({
       ok: true,
       apply,
       scanned: versioned.length,
       eligible: candidates.length,
-      changed: apply ? selected.length : 0,
-      eligible_remaining: Math.max(0, candidates.length - (apply ? selected.length : 0)),
+      changed: changedKeys.size,
+      eligible_remaining: remaining.length,
+      stale_revision_eligible: staleRevisionEligible,
+      stale_revision_changed: staleRevisionChanged,
+      lineage_duplicate_eligible: lineageDuplicateEligible,
+      lineage_duplicate_changed: lineageDuplicateChanged,
+      lineage_refreshed: lineageRefreshed,
       protected_batch_items: activeBatchItemKeys.size,
-      sample: selected.slice(0, 20).map(({ item, revision }) => ({
+      protected_lineage_items: protectedLineageItems,
+      oldest_eligible_age_seconds: oldestAgeSeconds(candidates),
+      oldest_remaining_age_seconds: oldestAgeSeconds(remaining),
+      sample: selected.slice(0, 20).map(({ item, revision, reason, lineage, retainedKey }) => ({
         item_key: item.key,
         queue_revision: item.revision,
+        reason,
         target_key: revision.targetKey,
         publication_revision: revision.sourceRevision,
         superseded_by_revision: newestByTarget.get(revision.targetKey),
+        lineage_claim_generation: lineage?.claimGeneration ?? null,
+        retained_item_key: retainedKey ?? null,
       })),
     });
   }
@@ -5593,11 +5767,15 @@ function exactReviewPublicationRevision(decision: ExactReviewDecision): {
   };
 }
 
-function exactReviewPublicationLineage(decision: ExactReviewDecision): {
+type ExactReviewPublicationLineage = {
   targetKey: string;
   sourceRevision: number;
   claimGeneration: number;
-} | null {
+};
+
+function exactReviewPublicationLineage(
+  decision: ExactReviewDecision,
+): ExactReviewPublicationLineage | null {
   const publication = decision.publication;
   if (!publication || publication.protocolVersion !== 2 || publication.leaseRevision === null) {
     return null;
@@ -5608,6 +5786,10 @@ function exactReviewPublicationLineage(decision: ExactReviewDecision): {
     sourceRevision: publication.leaseRevision,
     claimGeneration: publication.claimGeneration,
   };
+}
+
+function exactReviewPublicationLineageKey(lineage: ExactReviewPublicationLineage) {
+  return `${lineage.targetKey}\u0000${lineage.sourceRevision}\u0000${lineage.claimGeneration}`;
 }
 
 function exactReviewPublicationProducerIsNewer(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -3193,6 +3193,7 @@ export class ExactReviewQueue {
             continue;
           }
           retained.decision = refresh.decision;
+          retained.revision += 1;
           retained.updatedAt = now;
           lineageRefreshed += 1;
         }

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -199,8 +199,10 @@ The same invariant is available as an explicit historical backfill through
 `/internal/exact-review/publications/reconcile` and
 `.github/workflows/exact-review-queue-maintenance.yml`. The workflow runs a
 dry-run by default and can apply exactly one pass of at most 100 removals per
-manual dispatch. It is not scheduled and cannot loop through multiple passes in
-one run. A pass considers only `pending` and `parked` protocol-v2 publications.
+manual dispatch. The deprecated `passes` input remains accepted for existing
+dispatch callers, but values above one are explicitly logged and clamped to one
+observed pass. The workflow is not scheduled and cannot loop through multiple
+passes in one run. A pass considers only `pending` and `parked` protocol-v2 publications.
 It never removes `dispatching`, `leased`, or active-batch-owned rows. For a
 current lineage without an active owner, it preserves the oldest queue slot and
 its retry/failure budget, refreshes that slot to the newest known producer

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -195,6 +195,27 @@ revisions, comment routing, and apply work remain separate lanes. The queue
 reports `semantic_deduped_total` independently from stale-revision supersession
 so backlog reduction is not mistaken for completed review output. See #800.
 
+The same invariant is available as an explicit historical backfill through
+`/internal/exact-review/publications/reconcile` and
+`.github/workflows/exact-review-queue-maintenance.yml`. The workflow runs a
+dry-run by default and can apply exactly one pass of at most 100 removals per
+manual dispatch. It is not scheduled and cannot loop through multiple passes in
+one run. A pass considers only `pending` and `parked` protocol-v2 publications.
+It never removes `dispatching`, `leased`, or active-batch-owned rows. For a
+current lineage without an active owner, it preserves the oldest queue slot and
+its retry/failure budget, refreshes that slot to the newest known producer
+artifact, and removes only the redundant siblings. Older review revisions keep
+the existing supersession behavior.
+
+Each dry-run or apply result records the total scanned and eligible rows, rows
+changed and remaining, stale-revision versus duplicate-lineage counts, refreshed
+retained lineages, protected ownership, and the oldest eligible and remaining
+ages. Operators should inspect a dry-run first, apply one bounded pass, then
+observe the public 15-minute and 60-minute publication flow. Another pass should
+wait for stable positive net drain and unchanged contention/dead-letter safety;
+historical cleanup is not a reason to raise publication concurrency or bypass
+the state-writer rollout gates.
+
 ## Production incident and root cause
 
 The first real size-2 batch was

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -32,7 +32,15 @@ export type ExactReviewPublicationReconcileResult = {
   eligible: number;
   changed: number;
   eligibleRemaining: number;
+  staleRevisionEligible: number;
+  staleRevisionChanged: number;
+  lineageDuplicateEligible: number;
+  lineageDuplicateChanged: number;
+  lineageRefreshed: number;
   protectedBatchItems: number;
+  protectedLineageItems: number;
+  oldestEligibleAgeSeconds: number | null;
+  oldestRemainingAgeSeconds: number | null;
 };
 
 export interface ExactReviewBatchQueue {
@@ -145,9 +153,38 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
       eligible: nonNegativeInteger(response.eligible, "eligible"),
       changed: nonNegativeInteger(response.changed, "changed"),
       eligibleRemaining: nonNegativeInteger(response.eligible_remaining, "eligible_remaining"),
+      staleRevisionEligible: nonNegativeInteger(
+        response.stale_revision_eligible ?? response.eligible,
+        "stale_revision_eligible",
+      ),
+      staleRevisionChanged: nonNegativeInteger(
+        response.stale_revision_changed ?? response.changed,
+        "stale_revision_changed",
+      ),
+      lineageDuplicateEligible: nonNegativeInteger(
+        response.lineage_duplicate_eligible ?? 0,
+        "lineage_duplicate_eligible",
+      ),
+      lineageDuplicateChanged: nonNegativeInteger(
+        response.lineage_duplicate_changed ?? 0,
+        "lineage_duplicate_changed",
+      ),
+      lineageRefreshed: nonNegativeInteger(response.lineage_refreshed ?? 0, "lineage_refreshed"),
       protectedBatchItems: nonNegativeInteger(
         response.protected_batch_items,
         "protected_batch_items",
+      ),
+      protectedLineageItems: nonNegativeInteger(
+        response.protected_lineage_items ?? 0,
+        "protected_lineage_items",
+      ),
+      oldestEligibleAgeSeconds: nullableNonNegativeInteger(
+        response.oldest_eligible_age_seconds,
+        "oldest_eligible_age_seconds",
+      ),
+      oldestRemainingAgeSeconds: nullableNonNegativeInteger(
+        response.oldest_remaining_age_seconds,
+        "oldest_remaining_age_seconds",
       ),
     } satisfies ExactReviewPublicationReconcileResult;
   }
@@ -286,4 +323,8 @@ function nonNegativeInteger(value: unknown, name: string): number {
   const result = Number(value);
   if (!Number.isSafeInteger(result) || result < 0) throw new Error(`Invalid batch queue ${name}`);
   return result;
+}
+
+function nullableNonNegativeInteger(value: unknown, name: string): number | null {
+  return value === null || value === undefined ? null : nonNegativeInteger(value, name);
 }

--- a/src/repair/exact-review-queue-maintenance.ts
+++ b/src/repair/exact-review-queue-maintenance.ts
@@ -3,17 +3,13 @@ import { ExactReviewBatchQueueClient } from "./exact-review-batch-queue-client.j
 
 const apply = process.argv.includes("--apply");
 const maxItems = integerArg("--max-items", 100, 1, 100);
-const passes = integerArg("--passes", apply ? 1 : 1, 1, 100);
 const client = new ExactReviewBatchQueueClient({
   baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
   webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
 });
 
-for (let pass = 1; pass <= passes; pass += 1) {
-  const result = await client.reconcilePublications({ apply, maxItems });
-  console.log(JSON.stringify({ ok: true, pass, ...result }));
-  if (!apply || result.changed === 0 || result.eligibleRemaining === 0) break;
-}
+const result = await client.reconcilePublications({ apply, maxItems });
+console.log(JSON.stringify({ ok: true, ...result }));
 
 function integerArg(name: string, fallback: number, minimum: number, maximum: number): number {
   const index = process.argv.indexOf(name);

--- a/src/repair/exact-review-queue-maintenance.ts
+++ b/src/repair/exact-review-queue-maintenance.ts
@@ -3,13 +3,19 @@ import { ExactReviewBatchQueueClient } from "./exact-review-batch-queue-client.j
 
 const apply = process.argv.includes("--apply");
 const maxItems = integerArg("--max-items", 100, 1, 100);
+const requestedPasses = integerArg("--passes", 1, 1, 100);
 const client = new ExactReviewBatchQueueClient({
   baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
   webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
 });
 
+if (requestedPasses > 1) {
+  console.error(
+    `--passes=${requestedPasses} is deprecated and clamped to one observed pass per invocation`,
+  );
+}
 const result = await client.reconcilePublications({ apply, maxItems });
-console.log(JSON.stringify({ ok: true, ...result }));
+console.log(JSON.stringify({ ok: true, requestedPasses, effectivePasses: 1, ...result }));
 
 function integerArg(name: string, fallback: number, minimum: number, maximum: number): number {
   const index = process.argv.indexOf(name);

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -969,9 +969,9 @@ test("publication reconcile backfills historical duplicate lineages in bounded p
   }
 });
 
-test("publication lineage reconcile preserves active batch ownership", async () => {
+test("publication lineage reconcile defers the whole lineage while a batch owns it", async () => {
   const originalNow = Date.now;
-  const now = 6_475_000;
+  let now = 6_475_000;
   Date.now = () => now;
   try {
     const storage = new TestStorage();
@@ -1028,10 +1028,11 @@ test("publication lineage reconcile preserves active batch ownership", async () 
     const applied = await (
       await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
     ).json();
-    assert.equal(applied.changed, 1);
-    assert.equal(applied.lineage_duplicate_changed, 1);
+    assert.equal(applied.changed, 0);
+    assert.equal(applied.eligible, 0);
+    assert.equal(applied.lineage_duplicate_changed, 0);
     assert.equal(applied.protected_batch_items, 1);
-    assert.equal(applied.protected_lineage_items, 1);
+    assert.equal(applied.protected_lineage_items, 2);
 
     const fetched = await (
       await queue.fetch(
@@ -1043,6 +1044,21 @@ test("publication lineage reconcile preserves active batch ownership", async () 
     ).json();
     assert.equal(fetched.batch.items[0].item_key, keys[0]);
     assert.equal(fetched.items[0].item_key, keys[0]);
+
+    now += 60_001;
+    const reconciled = await (
+      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+    ).json();
+    assert.equal(reconciled.changed, 1);
+    assert.equal(reconciled.lineage_duplicate_changed, 1);
+    assert.equal(reconciled.lineage_refreshed, 1);
+
+    const publications = await (
+      await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
+    ).json();
+    assert.equal(publications.publications.length, 1);
+    assert.equal(publications.publications[0].item_key, keys[0]);
+    assert.equal(publications.publications[0].decision.publication.producerRunId, "2502");
   } finally {
     Date.now = originalNow;
   }

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -876,6 +876,178 @@ test("publication reconcile preserves active batches and removes older revisions
   }
 });
 
+test("publication reconcile backfills historical duplicate lineages in bounded passes", async () => {
+  const originalNow = Date.now;
+  const now = 6_450_000;
+  Date.now = () => now;
+  try {
+    const storage = new TestStorage();
+    const decisions = await Promise.all(
+      ["2401", "2402", "2403"].map(async (producerRunId) => {
+        const payload = (await publicationRequest(
+          `legacy-lineage-${producerRunId}`,
+          108703,
+          producerRunId,
+        ).json()) as { decision: Record<string, unknown> };
+        return payload.decision;
+      }),
+    );
+    const keys = ["2401", "2402", "2403"].map(
+      (producerRunId) => `openclaw/openclaw#108703@publish:${producerRunId}:1`,
+    );
+    await storage.put("exact-review-queue", {
+      items: Object.fromEntries(
+        keys.map((key, index) => [
+          key,
+          {
+            decision: decisions[index],
+            state: "pending",
+            revision: 1,
+            createdAt: now - (3 - index) * 100_000,
+            updatedAt: now - (3 - index) * 100_000,
+            nextAttemptAt: now - (3 - index) * 100_000,
+            attempts: index === 0 ? 7 : 0,
+            ...(index === 0
+              ? {
+                  publicationFailureAttempts: 2,
+                  firstFailureAt: now - 300_000,
+                  lastFailureReason: "state_contention",
+                }
+              : {}),
+          },
+        ]),
+      ),
+      deliveries: {},
+    });
+    const queue = new ExactReviewQueue({ storage }, {});
+
+    const dryRun = await (
+      await queue.fetch(batchRequest("/publications/reconcile", { max_items: 1 }))
+    ).json();
+    assert.equal(dryRun.apply, false);
+    assert.equal(dryRun.eligible, 2);
+    assert.equal(dryRun.changed, 0);
+    assert.equal(dryRun.lineage_duplicate_eligible, 2);
+    assert.equal(dryRun.oldest_eligible_age_seconds, 200);
+    assert.equal(dryRun.oldest_remaining_age_seconds, 200);
+    assert.equal(dryRun.sample[0].reason, "duplicate_lineage");
+    assert.equal(dryRun.sample[0].retained_item_key, keys[0]);
+
+    const firstPass = await (
+      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 1 }))
+    ).json();
+    assert.equal(firstPass.changed, 1);
+    assert.equal(firstPass.eligible_remaining, 1);
+    assert.equal(firstPass.lineage_duplicate_changed, 1);
+    assert.equal(firstPass.lineage_refreshed, 1);
+    assert.equal(firstPass.oldest_remaining_age_seconds, 100);
+
+    const afterFirstPass = await (
+      await queue.fetch(batchRequest("/publications/list", { limit: 100 }))
+    ).json();
+    const retained = afterFirstPass.publications.find(
+      (item: { item_key: string }) => item.item_key === keys[0],
+    );
+    assert.equal(retained.attempts, 7);
+    assert.equal(retained.decision.publication.producerRunId, "2403");
+
+    const secondPass = await (
+      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+    ).json();
+    assert.equal(secondPass.changed, 1);
+    assert.equal(secondPass.eligible_remaining, 0);
+    assert.equal(secondPass.lineage_duplicate_changed, 1);
+    assert.equal(secondPass.lineage_refreshed, 0);
+    assert.equal(secondPass.oldest_remaining_age_seconds, null);
+
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 1);
+    assert.equal(stats.lanes.publication.superseded_total, 2);
+    assert.equal(stats.lanes.publication.semantic_deduped_total, 2);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("publication lineage reconcile preserves active batch ownership", async () => {
+  const originalNow = Date.now;
+  const now = 6_475_000;
+  Date.now = () => now;
+  try {
+    const storage = new TestStorage();
+    const producerRunIds = ["2501", "2502"];
+    const decisions = await Promise.all(
+      producerRunIds.map(async (producerRunId) => {
+        const payload = (await publicationRequest(
+          `legacy-owned-lineage-${producerRunId}`,
+          108704,
+          producerRunId,
+        ).json()) as { decision: Record<string, unknown> };
+        return payload.decision;
+      }),
+    );
+    const keys = producerRunIds.map(
+      (producerRunId) => `openclaw/openclaw#108704@publish:${producerRunId}:1`,
+    );
+    await storage.put("exact-review-queue", {
+      items: Object.fromEntries(
+        keys.map((key, index) => [
+          key,
+          {
+            decision: decisions[index],
+            state: "pending",
+            revision: 1,
+            createdAt: now - (2 - index) * 100_000,
+            updatedAt: now - (2 - index) * 100_000,
+            nextAttemptAt: now - (2 - index) * 100_000,
+            attempts: 0,
+          },
+        ]),
+      ),
+      deliveries: {},
+    });
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+      },
+    );
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-lineage-reconcile-protection",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true);
+    assert.equal(claim.batch.items[0].item_key, keys[0]);
+
+    const applied = await (
+      await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))
+    ).json();
+    assert.equal(applied.changed, 1);
+    assert.equal(applied.lineage_duplicate_changed, 1);
+    assert.equal(applied.protected_batch_items, 1);
+    assert.equal(applied.protected_lineage_items, 1);
+
+    const fetched = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/fetch", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-1",
+        }),
+      )
+    ).json();
+    assert.equal(fetched.batch.items[0].item_key, keys[0]);
+    assert.equal(fetched.items[0].item_key, keys[0]);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("batch claim scans beyond but cannot exceed the configured rollout size", async () => {
   const originalNow = Date.now;
   Date.now = () => 6_500_000;

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1312,37 +1312,103 @@ test("batch protocol routes require the shared internal signature", async () => 
   assert.equal(forwardedPath, "/publication-batches/claim");
 });
 
-test("publication reconciliation route requires the shared internal signature", async () => {
-  const secret = "test-secret";
-  const body = JSON.stringify({ apply: false, max_items: 1 });
-  let forwardedPath = "";
-  const env = {
-    CLAWSWEEPER_WEBHOOK_SECRET: secret,
-    EXACT_REVIEW_QUEUE: {
-      idFromName: () => "global",
-      get: () => ({
-        fetch: async (request: Request) => {
-          forwardedPath = new URL(request.url).pathname;
-          return new Response(JSON.stringify({ ok: true }));
-        },
+test("authenticated publication reconciliation dry-run reports without mutation", async () => {
+  const originalNow = Date.now;
+  const now = 13_000_000;
+  Date.now = () => now;
+  try {
+    const secret = "test-secret";
+    const producerRunIds = ["2601", "2602"];
+    const decisions = await Promise.all(
+      producerRunIds.map(async (producerRunId) => {
+        const payload = (await publicationRequest(
+          `authenticated-dry-run-${producerRunId}`,
+          108705,
+          producerRunId,
+        ).json()) as { decision: Record<string, unknown> };
+        return payload.decision;
       }),
-    },
-  };
-  const url = "https://clawsweeper.openclaw.ai/internal/exact-review/publications/reconcile";
-  const unauthorized = await worker.fetch(new Request(url, { method: "POST", body }), env);
-  assert.equal(unauthorized.status, 401);
+    );
+    const storage = new TestStorage();
+    await storage.put("exact-review-queue", {
+      items: Object.fromEntries(
+        producerRunIds.map((producerRunId, index) => [
+          `openclaw/openclaw#108705@publish:${producerRunId}:1`,
+          {
+            decision: decisions[index],
+            state: "pending",
+            revision: 1,
+            createdAt: now - (2 - index) * 60_000,
+            updatedAt: now - (2 - index) * 60_000,
+            nextAttemptAt: now - (2 - index) * 60_000,
+            attempts: 0,
+          },
+        ]),
+      ),
+      deliveries: {},
+    });
+    const queue = new ExactReviewQueue({ storage }, {});
+    let forwardedPath = "";
+    const env = {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      EXACT_REVIEW_QUEUE: {
+        idFromName: () => "global",
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedPath = new URL(request.url).pathname;
+            return queue.fetch(request);
+          },
+        }),
+      },
+    };
+    const body = JSON.stringify({ apply: false, max_items: 1 });
+    const url = "https://clawsweeper.openclaw.ai/internal/exact-review/publications/reconcile";
+    const unauthorized = await worker.fetch(new Request(url, { method: "POST", body }), env);
+    assert.equal(unauthorized.status, 401);
 
-  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
-  const authorized = await worker.fetch(
-    new Request(url, {
-      method: "POST",
-      headers: { "x-clawsweeper-exact-review-signature": signature },
-      body,
-    }),
-    env,
-  );
-  assert.equal(authorized.status, 200);
-  assert.equal(forwardedPath, "/publications/reconcile");
+    const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+    const authorized = await worker.fetch(
+      new Request(url, {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": signature },
+        body,
+      }),
+      env,
+    );
+    assert.equal(authorized.status, 200);
+    assert.equal(forwardedPath, "/publications/reconcile");
+    const result = await authorized.json();
+    assert.equal(result.apply, false);
+    assert.equal(result.eligible, 1);
+    assert.equal(result.changed, 0);
+    assert.equal(result.eligible_remaining, 1);
+    assert.equal(result.lineage_duplicate_eligible, 1);
+    assert.equal(result.protected_lineage_items, 0);
+    assert.equal(result.oldest_eligible_age_seconds, 60);
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.pending, 2);
+
+    if (process.env.CLAWSWEEPER_EVIDENCE_TRANSCRIPT === "1") {
+      console.log(
+        `AUTHENTICATED_PUBLICATION_RECONCILE_DRY_RUN=${JSON.stringify({
+          http_status: authorized.status,
+          apply: result.apply,
+          scanned: result.scanned,
+          eligible: result.eligible,
+          changed: result.changed,
+          eligible_remaining: result.eligible_remaining,
+          lineage_duplicate_eligible: result.lineage_duplicate_eligible,
+          protected_batch_items: result.protected_batch_items,
+          protected_lineage_items: result.protected_lineage_items,
+          oldest_eligible_age_seconds: result.oldest_eligible_age_seconds,
+          pending_before: 2,
+          pending_after: stats.lanes.publication.pending,
+        })}`,
+      );
+    }
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("queue fetch terminalizes a stale batch revision before dispatch", async () => {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -949,7 +949,17 @@ test("publication reconcile backfills historical duplicate lineages in bounded p
       (item: { item_key: string }) => item.item_key === keys[0],
     );
     assert.equal(retained.attempts, 7);
+    assert.equal(retained.revision, 2);
     assert.equal(retained.decision.publication.producerRunId, "2403");
+
+    const staleSupersede = await (
+      await queue.fetch(
+        batchRequest("/publications/supersede", {
+          items: [{ item_key: keys[0], revision: 1 }],
+        }),
+      )
+    ).json();
+    assert.equal(staleSupersede.superseded, 0);
 
     const secondPass = await (
       await queue.fetch(batchRequest("/publications/reconcile", { apply: true, max_items: 100 }))

--- a/test/repair/exact-review-queue-maintenance-workflow.test.ts
+++ b/test/repair/exact-review-queue-maintenance-workflow.test.ts
@@ -12,7 +12,6 @@ const workflow = YAML.parse(source) as {
   jobs: Record<
     string,
     {
-      if: string;
       env: Record<string, string>;
       steps: Array<{ name?: string; env?: Record<string, string>; run?: string }>;
     }
@@ -21,18 +20,17 @@ const workflow = YAML.parse(source) as {
 
 test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   assert.equal(workflow.on.schedule, undefined);
-  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute", "passes"]);
+  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute"]);
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
   assert.deepEqual(workflow.permissions, { contents: "read" });
-  assert.match(workflow.jobs.reconcile!.if, /inputs\.execute/);
   const maintenance = workflow.jobs.reconcile!.steps.find(
-    (step) => step.name === "Reconcile superseded publication items",
+    (step) => step.name === "Preview or reconcile historical publication lineages",
   );
-  assert.equal(maintenance?.env?.PASSES, "${{ inputs.passes }}");
+  assert.equal(maintenance?.env?.EXECUTE, "${{ inputs.execute }}");
   const run = maintenance?.run || "";
   assert.match(run, /repair:exact-review-queue-maintenance/);
   assert.match(run, /--max-items 100/);
-  assert.match(run, /--passes "\$PASSES"/);
-  assert.doesNotMatch(run, /inputs\.passes/);
+  assert.match(run, /args\+=\(--apply\)/);
+  assert.doesNotMatch(run, /--passes/);
   assert.doesNotMatch(source, /schedule:/);
 });

--- a/test/repair/exact-review-queue-maintenance-workflow.test.ts
+++ b/test/repair/exact-review-queue-maintenance-workflow.test.ts
@@ -5,6 +5,7 @@ import YAML from "yaml";
 
 const path = ".github/workflows/exact-review-queue-maintenance.yml";
 const source = readFileSync(path, "utf8");
+const cliSource = readFileSync("src/repair/exact-review-queue-maintenance.ts", "utf8");
 const workflow = YAML.parse(source) as {
   on: { schedule?: unknown; workflow_dispatch: { inputs: Record<string, unknown> } };
   concurrency: Record<string, unknown>;
@@ -20,17 +21,21 @@ const workflow = YAML.parse(source) as {
 
 test("queue maintenance is explicit, bounded, and non-cancelling", () => {
   assert.equal(workflow.on.schedule, undefined);
-  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute"]);
+  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute", "passes"]);
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
   assert.deepEqual(workflow.permissions, { contents: "read" });
   const maintenance = workflow.jobs.reconcile!.steps.find(
     (step) => step.name === "Preview or reconcile historical publication lineages",
   );
   assert.equal(maintenance?.env?.EXECUTE, "${{ inputs.execute }}");
+  assert.equal(maintenance?.env?.PASSES, "${{ inputs.passes }}");
   const run = maintenance?.run || "";
   assert.match(run, /repair:exact-review-queue-maintenance/);
   assert.match(run, /--max-items 100/);
   assert.match(run, /args\+=\(--apply\)/);
-  assert.doesNotMatch(run, /--passes/);
+  assert.match(run, /--passes "\$PASSES"/);
+  assert.match(cliSource, /requestedPasses = integerArg\("--passes", 1, 1, 100\)/);
+  assert.match(cliSource, /effectivePasses: 1/);
+  assert.doesNotMatch(cliSource, /for \(let pass/);
   assert.doesNotMatch(source, /schedule:/);
 });


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submitted: July 23, 2026, 1:05 PM (US Eastern Time) / 17:05 UTC.
Last body edit: July 23, 2026, 1:34 PM (US Eastern Time) / 17:34 UTC.
Latest head commit: July 23, 2026, 1:20 PM (US Eastern Time) / 17:20 UTC.
<!-- submission-timestamps:end -->

Related: #800
Follow-up to #807

## What Problem This Solves

Resolves a publication-queue problem where duplicate protocol-v2 result lineages that predate #807 can remain pending indefinitely unless another equivalent artifact happens to arrive. Those rows add preparation and state-writer pressure without representing a new review decision.

The public snapshot at `2026-07-23T17:00:40Z` showed 2,072 pending result publications, zero active publishers despite 50 available publication slots, an oldest pending age of 202,680 seconds, and a 60-minute net drain rate of `-29/hour` (41 arrivals, 12 resolutions). This does not imply that every pending row is a duplicate; it shows why historical duplicates need a deterministic dry-run and bounded cleanup path instead of relying only on future ingress.

## Why This Change Was Made

#807 now enforces one effective lineage for new protocol-v2 deliveries. This follow-up extends the existing publication reconcile owner path so it can proactively identify and remove only proven historical siblings while preserving every active ownership fence and retry budget.

The maintenance workflow is intentionally one pass per manual dispatch. It runs a dry-run by default and can apply at most 100 removals, so operators can observe 15-minute and 60-minute flow, contention, and dead-letter safety before another pass.

## User Impact

Operators can preview the historical cleanup set, apply one bounded pass, and see exactly how many stale revisions and duplicate lineages were removed, how many remain, how many active owners were protected, and the oldest eligible/remaining age. Review decisions, comments, apply work, batch size, and publication concurrency are unchanged.

## Breaking Changes

No runtime API, queue schema, storage format, dependency, configuration, or workflow-dispatch input is removed.

The deprecated `passes` input remains accepted for compatibility. Values above one are explicitly logged and clamped to one observed pass per invocation. This intentionally narrows prior multi-pass behavior while keeping existing dispatch payloads valid; maintainer acceptance of that operational policy remains the merge gate.

## Implementation

- Extend `/internal/exact-review/publications/reconcile` to classify both stale review revisions and same-lineage historical duplicates.
- Define a lineage with the same immutable tuple used by #807: target item, lease revision, and claim generation.
- Consider only `pending` and `parked` rows for removal.
- Preserve `dispatching`, `leased`, and active-batch-owned rows. If one owns a lineage, it remains authoritative and only unowned pending siblings are eligible.
- Without an active owner, keep the oldest queue slot and its attempts/failure budget, refresh that slot to the newest known producer artifact, and remove redundant siblings.
- Select the oldest eligible rows first and cap every request at 100 mutations.
- Return stale/lineage counts, retained-lineage refreshes, protected ownership, and oldest eligible/remaining ages.
- Keep the repair client compatible with a rolling deployment where the older dashboard response does not yet expose the new fields.
- Keep the deprecated `passes` input valid during migration, log values above one, and clamp every invocation to one observed pass.

## Code-Path Analysis

- Entry: `.github/workflows/exact-review-queue-maintenance.yml`
- CLI: `src/repair/exact-review-queue-maintenance.ts`
- Authenticated client: `src/repair/exact-review-batch-queue-client.ts`
- Dashboard proxy: `dashboard/worker.ts`
- Queue owner and mutation boundary: `ExactReviewQueue.reconcilePublicationCandidates()` in `dashboard/exact-review-queue.ts`
- Active batch ownership: `dashboard/exact-review-publication-batches.ts`
- Sibling invariant: #807's enqueue-time lineage coalescing in `dashboard/exact-review-queue.ts`
- Focused tests: `test/exact-review-publication-batches.test.ts` and `test/repair/exact-review-queue-maintenance-workflow.test.ts`

## Mainline Comparison

- Official default branch: `openclaw/clawsweeper:main`
- Current base: `8cdbe5755e22c2f869930f31b2e5d439e5149e49`
- The base includes #807 (`205b92b9b6dc1cea735ef610fd6a39e98d18a5d1`), #749, and #817.
- #807 handles new ingress and same-lineage redelivery; it does not make a standalone bounded pass over historical rows.
- No open PR with a publication-lineage reconcile/backfill title or scope was found before submission.

## Branch and Base Provenance

- Base: `openclaw/clawsweeper:main@8cdbe5755e22c2f869930f31b2e5d439e5149e49`
- Head: `snowzlmbot/clawsweeper:fix/publication-lineage-reconcile@bd2b85d5fafab888c9b64f8f31e2b61e6ac80c86`
- Evidence branch: `snowzlmbot/clawsweeper:evidence/pr-publication-lineage-reconcile@3708ce99ce51f64f0b6185a39d80abfaf6aba2f2`
- The fork default branch remains a mirror-only branch and contains none of this contribution's implementation commits.

## Dependency and Contract Verification

No dependency or lockfile changes. The existing signed internal queue endpoint, protocol-v2 lineage fields, durable batch ownership store, queue metrics, and state schema remain the authoritative contracts. Older dashboard responses remain accepted by the updated repair client during rollout.

## Evidence

Current-head focused proof:

- [Bounded historical lineage reconcile proof](https://github.com/snowzlmbot/clawsweeper/actions/runs/30029247413) — successful on evidence head `3708ce99ce51f64f0b6185a39d80abfaf6aba2f2`, which contains code head `bd2b85d5fafab888c9b64f8f31e2b61e6ac80c86` unchanged plus evidence-only files.
- The run passed `build:all`, the historical three-sibling dry-run/two-pass convergence regression, active batch ownership fencing, compatibility-preserving one-pass workflow checks, an authenticated worker-route dry-run, formatting, and focused lint.
- [Upstream CI run](https://github.com/openclaw/clawsweeper/actions/runs/30029016057) — successful on code head `bd2b85d5fafab888c9b64f8f31e2b61e6ac80c86`; `pnpm check`, workflow semantics, sparse repair build smoke, the Windows launcher, and crawl-remote integration all passed.
- [Upstream CodeQL run](https://github.com/openclaw/clawsweeper/actions/runs/30029016046) — both Actions and JavaScript/TypeScript analysis passed on the same PR head.
- [Public dashboard snapshot](https://raw.githubusercontent.com/snowzlmbot/clawsweeper/3708ce99ce51f64f0b6185a39d80abfaf6aba2f2/evidence/clawsweeper-publication-backlog-2026-07-23.png) — captured from the public status surface; it shows the publication backlog and idle publication capacity without exposing private data.
- [Live dashboard](https://clawsweeper.openclaw.ai/) and [JSON status](https://clawsweeper.openclaw.ai/api/status) remain the post-deploy observation sources.

Local preflight was limited to non-building static checks:

- `git diff --check`: passed.
- Changed-file `oxfmt --check`: passed.
- Changed-TypeScript `oxlint --deny-warnings`: 0 warnings, 0 errors.

## Sanitized Proof Summary

The focused historical fixture begins with three pending rows for one immutable lineage. Dry-run reports two eligible duplicates and changes nothing. A one-item apply removes one sibling, preserves the oldest slot's seven attempts and failure history, refreshes it to the newest producer artifact, reports one remaining duplicate, and records the remaining age. A second bounded pass removes the last sibling. A separate fixture leases the retained row to an active batch and proves reconcile removes only the unowned sibling while fetch/completion ownership remains valid.

The evidence workflow also sends an HMAC-signed `apply=false` request through the real dashboard worker route into the real queue owner. Its redacted transcript is:

```json
{"http_status":200,"apply":false,"scanned":2,"eligible":1,"changed":0,"eligible_remaining":1,"lineage_duplicate_eligible":1,"protected_batch_items":0,"protected_lineage_items":0,"oldest_eligible_age_seconds":60,"pending_before":2,"pending_after":2}
```

This proves authorization, response telemetry, and no mutation on the production code path without exposing credentials or queue identities.

## Media Evidence

The linked screenshot is sufficient for the public backlog state. No video is needed: this change has no interactive UI or timing-dependent user flow, and the mutation behavior is deterministically covered by the linked current-head Actions run.

## Review Context Addressed

- The first exact-head review identified removal of the `passes` input as a compatibility blocker. The input is now retained; larger values are accepted, logged as deprecated, and clamped to one pass. Existing dispatch payloads remain valid.
- The proof guidance requested an authenticated dry-run transcript. Evidence run `30029247413` now exercises the HMAC-protected worker route and real queue owner with `apply=false`, records eligible/protected/remaining fields, and proves pending state is unchanged.
- No production apply or queue mutation was performed. A maintainer-authorized live dry-run remains the final operational rollout gate before any apply dispatch.

## Risk

- Incorrect equivalence could remove distinct work. The cleanup is restricted to complete protocol-v2 lineage tuples and does not cross review revisions or lanes.
- A cleanup could interfere with a publisher. Active batch membership, `dispatching`, and `leased` states are excluded and revalidated at mutation time.
- Selecting a fresher artifact could reset retry safety. The retained queue slot, attempts, first-failure time, and failure budget are preserved; only producer provenance is refreshed using #807's established ordering.
- Large historical state could create a long mutation. The endpoint scans the existing bounded Durable Object state but mutates at most 100 oldest eligible rows per request, and the workflow allows only one pass per manual dispatch.
- Operators could run another pass before observing health. Documentation explicitly requires a dry-run and stable positive net drain with unchanged contention/dead-letter safety before the next pass.

## Rollback

Revert `bd2b85d5fafab888c9b64f8f31e2b61e6ac80c86` and `cf3f406d4ba9881e8f10e94df2170100069ecca8`. No schema, dependency, or configuration migration is required. The previous stale-revision reconcile response remains compatible with the repair client. Already applied cleanup cannot recreate removed queue keys automatically, but removal is limited to redundant pending/parked siblings; no active owner or review decision is deleted.

## Docs Updated

- `docs/state-publication-batching-plan.md` documents dry-run, the one-pass/100-item boundary, ownership protections, retained-slot behavior, telemetry, and the positive-drain gate.

## Labels Considered

`bug` and `performance` are relevant. No upstream labels were applied by the contributor.

## Related Work

- #800 — publication lineage invariant and bounded historical reconciliation requirement
- #807 — maintainer-owned clean implementation for new-ingress lineage coalescing
- #749 — stale active exact-review supersession
- #772 — one durable target item per publication batch

## Not Tested / Limitations

- No production queue apply, dead-letter replay, concurrency increase, workflow pause, or live state mutation was performed from this branch.
- The authenticated dry-run proof uses the exact worker/auth/queue production code path with a bounded fixture; a live production dry-run remains a maintainer-authorized pre-apply gate.
- The 2,072-row public backlog is not assumed to consist entirely of duplicates; the live dry-run result after deployment is the authoritative eligible count.
- Full repository CI and CodeQL passed on the submitted head; the linked focused evidence run is the deterministic backfill/ownership/authentication proof.
- Post-deploy operation remains manual: live dry-run first, one bounded apply, then health observation before any later pass.
