### PR TITLE
fix(publication): stop batch workers corrupting shared state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Isolated each exact-review batch member's records, action ledger, snapshots,
+  and apply reports under its private work root while serializing imports into
+  the shared Git object database, preventing parallel publishers from moving
+  each other's records or losing prepared mutation blobs.
 - Restored the state materializer to GitHub-hosted runners after the dedicated
   runner label left the sole publication drain queued without an eligible
   runner.

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -51,6 +51,15 @@ export async function runBoundedPool(items, concurrency, worker) {
   return { results, peak };
 }
 
+export function createSerialTaskQueue() {
+  let tail = Promise.resolve();
+  return (task) => {
+    const current = tail.then(task);
+    tail = current.catch(() => {});
+    return current;
+  };
+}
+
 export async function createIsolatedStateClone({ stateRoot, destination, baselineSha, timeoutMs }) {
   const remoteUrl = (await capture("git", ["-C", stateRoot, "remote", "get-url", "origin"])).trim();
   if (!remoteUrl) throw new Error("state origin URL is required");
@@ -196,6 +205,9 @@ async function controller() {
   const durations = [];
   let timeouts = 0;
   let admitted = 0;
+  // Worker preparation is parallel, but every imported object lands in the
+  // same state repository. Keep that shared Git mutation boundary serial.
+  const importObjects = createSerialTaskQueue();
 
   const { peak } = await runBoundedPool(items, concurrency, async (item, index) => {
     const outcomePath = checkedOutcomePath(workspace, item.outcomePath);
@@ -232,12 +244,14 @@ async function controller() {
       if (timedOut) timeouts += 1;
       if (existsSync(outcomePath)) {
         try {
-          await importPreparedMutationObjects({
-            stateRoot,
-            stateClone,
-            outcomePath,
-            timeoutMs: importTimeout(itemDeadline),
-          });
+          await importObjects(() =>
+            importPreparedMutationObjects({
+              stateRoot,
+              stateClone,
+              outcomePath,
+              timeoutMs: importTimeout(itemDeadline),
+            }),
+          );
         } catch (error) {
           writeFailure(outcomePath, "retryable_failure", "unknown_failure");
           console.error(
@@ -372,9 +386,10 @@ async function worker(itemPath, root, stateClone, workspace) {
   if (existsSync(report)) cpSync(report, join(eventArtifacts, `${itemNumber}.md`));
 
   result = await run(process.execPath, [join(workspace, "dist/repair/publish-event-result.js")], {
-    cwd: workspace,
+    cwd: root,
     env: {
       ...process.env,
+      CLAWSWEEPER_CODE_ROOT: workspace,
       CLAWSWEEPER_STATE_DIR: stateClone,
       EXACT_REVIEW_WORK_ROOT: root,
       TARGET_REPO: targetRepo,

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -58,6 +58,8 @@ import {
 } from "./state-publication-mutation.js";
 
 type EventOptions = {
+  codeRoot: string;
+  workRoot: string;
   targetRepo: string;
   itemNumber: string;
   closeReasons: string;
@@ -148,10 +150,8 @@ async function publishEventResult(options: EventOptions): Promise<void> {
   captureEventBaseSnapshot(recordStore);
   fs.rmSync(options.reportPath, { force: true });
 
-  runStreaming("pnpm", [
-    "run",
+  runClawsweeper(options, [
     "apply-artifacts",
-    "--",
     "--target-repo",
     options.targetRepo,
     "--artifact-dir",
@@ -446,9 +446,7 @@ function prepareBatchMutation({
 
 function runApplyDecisions(options: EventOptions): void {
   const args = [
-    "run",
     "apply-decisions",
-    "--",
     "--target-repo",
     options.targetRepo,
     "--item-numbers",
@@ -478,7 +476,7 @@ function runApplyDecisions(options: EventOptions): void {
     "--report-path",
     options.reportPath,
   ];
-  runStreaming("pnpm", args);
+  runClawsweeper(options, args);
 }
 
 function publishSnapshot({
@@ -720,6 +718,8 @@ function candidateEventTupleState(paths: EventRecordPaths): "closed" | "open" | 
 function eventOptionsFromEnv(): EventOptions {
   const workRoot = resolve(process.env.EXACT_REVIEW_WORK_ROOT || ".");
   return {
+    codeRoot: resolve(process.env.CLAWSWEEPER_CODE_ROOT || process.env.GITHUB_WORKSPACE || "."),
+    workRoot,
     targetRepo: envValue("TARGET_REPO"),
     itemNumber: envValue("ITEM_NUMBER"),
     closeReasons:
@@ -918,9 +918,16 @@ function envValue(name: string): string {
   return value;
 }
 
-function runStreaming(command: string, args: readonly string[]): void {
-  const child = spawnSync(command, [...args], { stdio: "inherit", env: process.env });
-  if (child.status !== 0) throw new Error(`${command} ${args.join(" ")} exited ${child.status}`);
+function runClawsweeper(options: EventOptions, args: readonly string[]): void {
+  const cli = join(options.codeRoot, "dist/clawsweeper.js");
+  const child = spawnSync(process.execPath, [cli, ...args], {
+    cwd: options.workRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (child.status !== 0) {
+    throw new Error(`${process.execPath} ${cli} ${args.join(" ")} exited ${child.status}`);
+  }
 }
 
 function sleep(milliseconds: number): Promise<void> {

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -161,6 +161,7 @@ const leasePath = ${JSON.stringify(leasePath)};
 const deleteLogPath = ${JSON.stringify(deleteLogPath)};
 const headSha = ${JSON.stringify(headSha)};
 const oldHeadSha = ${JSON.stringify(oldHeadSha)};
+const leaseExpiresAt = new Date(Date.now() + 10 * 60_000).toISOString();
 const args = process.argv.slice(2);
 const path = args[1] || "";
 const oldLease = {
@@ -171,7 +172,7 @@ const oldLease = {
   user: { login: "clawsweeper[bot]" },
   body: [
     "ClawSweeper status: review started.",
-    \`<!-- clawsweeper-review-status:started item=357 sha=\${oldHeadSha} started_at=2026-07-15T00:00:00.000Z lease_expires_at=2026-07-24T00:00:00.000Z owner=github-run-998-1 v=1 -->\`,
+    \`<!-- clawsweeper-review-status:started item=357 sha=\${oldHeadSha} started_at=2026-07-15T00:00:00.000Z lease_expires_at=\${leaseExpiresAt} owner=github-run-998-1 v=1 -->\`,
     "<!-- clawsweeper-review-lease item=357 -->",
   ].join("\\n"),
 };
@@ -297,6 +298,7 @@ const pullCountPath = ${JSON.stringify(pullCountPath)};
 const deleteLogPath = ${JSON.stringify(deleteLogPath)};
 const staleHead = ${JSON.stringify(staleHead)};
 const newerHead = ${JSON.stringify(newerHead)};
+const leaseExpiresAt = new Date(Date.now() + 10 * 60_000).toISOString();
 const args = process.argv.slice(2);
 const path = args[1] || "";
 const newerLease = {
@@ -307,7 +309,7 @@ const newerLease = {
   user: { login: "clawsweeper[bot]" },
   body: [
     "ClawSweeper status: review started.",
-    \`<!-- clawsweeper-review-status:started item=357 sha=\${newerHead} started_at=2026-07-23T13:00:02.000Z lease_expires_at=2026-07-24T14:00:02.000Z owner=github-run-222-1 v=1 -->\`,
+    \`<!-- clawsweeper-review-status:started item=357 sha=\${newerHead} started_at=2026-07-23T13:00:02.000Z lease_expires_at=\${leaseExpiresAt} owner=github-run-222-1 v=1 -->\`,
     "<!-- clawsweeper-review-lease item=357 -->",
   ].join("\\n"),
 };

--- a/test/repair/exact-review-batch-prepare.test.mjs
+++ b/test/repair/exact-review-batch-prepare.test.mjs
@@ -6,11 +6,48 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  createSerialTaskQueue,
   createIsolatedStateClone,
   importPreparedMutationObjects,
   run,
   runBoundedPool,
 } from "../../scripts/prepare-exact-review-batch.mjs";
+
+test("shared Git object mutations run serially and recover after a failed task", async () => {
+  const runSerial = createSerialTaskQueue();
+  let active = 0;
+  let peak = 0;
+  const order = [];
+  const tasks = [0, 1, 2, 3].map((index) =>
+    runSerial(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      order.push(`start-${index}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      order.push(`end-${index}`);
+      if (index === 1) throw new Error("expected failure");
+      return index;
+    }),
+  );
+  const results = await Promise.allSettled(tasks);
+
+  assert.equal(peak, 1);
+  assert.deepEqual(order, [
+    "start-0",
+    "end-0",
+    "start-1",
+    "end-1",
+    "start-2",
+    "end-2",
+    "start-3",
+    "end-3",
+  ]);
+  assert.deepEqual(
+    results.map(({ status }) => status),
+    ["fulfilled", "rejected", "fulfilled", "fulfilled"],
+  );
+});
 
 test("bounded preparation never exceeds four workers and preserves manifest order", async () => {
   const completionOrder = [];

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -8,6 +8,7 @@ const path = ".github/workflows/exact-review-batch-publish.yml";
 const source = readFileSync(path, "utf8");
 const cliSource = readFileSync("src/repair/exact-review-batch-cli.ts", "utf8");
 const prepareSource = readFileSync("scripts/prepare-exact-review-batch.mjs", "utf8");
+const publisherSource = readFileSync("src/repair/publish-event-result.ts", "utf8");
 const workflow = YAML.parse(source) as {
   on: {
     schedule?: unknown;
@@ -75,11 +76,20 @@ test("batch workflow uses owner-scoped mutation credentials and isolated state c
   assert.match(prepareSource, /"clone",[\s\S]*?"--shared",[\s\S]*?"--no-checkout"/);
   assert.match(prepareSource, /http\\\.\.\*\\\.extraheader/);
   assert.match(prepareSource, /CLAWSWEEPER_STATE_DIR: stateClone/);
+  assert.match(prepareSource, /CLAWSWEEPER_CODE_ROOT: workspace/);
   assert.match(prepareSource, /EXACT_REVIEW_WORK_ROOT: root/);
+  assert.match(prepareSource, /publish-event-result\.js"\)\], \{\s*cwd: root,\s*env:/);
   assert.match(
     prepareSource,
-    /await importPreparedMutationObjects\(\{[\s\S]*?stateRoot,[\s\S]*?stateClone,[\s\S]*?outcomePath,/,
+    /await importObjects\(\(\) =>\s*importPreparedMutationObjects\(\{[\s\S]*?stateRoot,[\s\S]*?stateClone,[\s\S]*?outcomePath,/,
   );
+  assert.match(publisherSource, /codeRoot: resolve\(process\.env\.CLAWSWEEPER_CODE_ROOT/);
+  assert.match(publisherSource, /const cli = join\(options\.codeRoot, "dist\/clawsweeper\.js"\)/);
+  assert.match(
+    publisherSource,
+    /spawnSync\(process\.execPath, \[cli, \.\.\.args\], \{\s*cwd: options\.workRoot,/,
+  );
+  assert.doesNotMatch(publisherSource, /runStreaming\("pnpm"/);
 });
 
 test("batch preparation is bounded, heartbeat-fenced, and deterministically aggregated", () => {
@@ -92,6 +102,8 @@ test("batch preparation is bounded, heartbeat-fenced, and deterministically aggr
   assert.match(prepareSource, /const MAX_OUTCOME_BYTES = 2 \* 1024 \* 1024/);
   assert.match(prepareSource, /Math\.min\(itemTimeoutMs, remainingTimeout\(deadline\)\)/);
   assert.match(prepareSource, /timeoutMs: importTimeout\(deadline\)/);
+  assert.match(prepareSource, /const importObjects = createSerialTaskQueue\(\)/);
+  assert.match(prepareSource, /await importObjects\(\(\) =>\s*importPreparedMutationObjects\(/);
   assert.match(prepareSource, /"pack-objects", "--stdout", "--revs", "--no-reuse-object"/);
   assert.match(
     prepareSource,


### PR DESCRIPTION
Related: #738

## What Problem This Solves

Resolves a problem where exact-review publication batches would accept eight items but only complete three to seven when concurrent workers archived or enumerated the same shared records and action-ledger state. The same runs could also fail while concurrently importing prepared objects into the shared destination Git object database.

## Why This Change Was Made

Each worker now runs the trusted compiled ClawSweeper CLI from the repository code root while using its own work root for records, ledgers, reports, and snapshots. Preparation remains concurrent, but the short destination Git-object import and validation section is serialized because all workers mutate one object database.

This PR also repairs an unrelated baseline CI time bomb exposed on July 24, 2026: two active-lease tests used fixed expiration timestamps that had passed. Their leases are now relative to test execution.

## User Impact

Operators can expect accepted publication items to reach terminal outcomes without cross-worker `ENOENT` failures or destination-object visibility races. Batch size and worker preparation concurrency remain unchanged.

## Evidence

- Production failure evidence: https://github.com/openclaw/clawsweeper/actions/runs/30056180409
- `node --test test/repair/exact-review-batch-prepare.test.mjs` (6 passed)
- `node --test test/repair/exact-review-batch-workflow.test.ts` (8 passed)
- `node --test test/repair/stale-event-disposition.test.ts` (3 passed)
- `node --test test/command.test.ts` (12 passed after replacing expired fixed-date leases)
- `tsc -p tsconfig.json`, `tsconfig.repair.json`, and `tsconfig.dashboard.json`
- targeted `oxlint --deny-warnings`, `oxfmt --check`, and `git diff --check`
- fresh autoreview after each change: no accepted/actionable findings

Full hosted CI is authoritative because the shared local dependency install is intentionally not reconciled from this worktree.