### PR TITLE
fix(publication): stale tupleless batch items stop retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Completed tuple-missing stale publication artifacts as superseded in batch
+  mode instead of retrying them forever without a mutation outcome.
 - Isolated each exact-review batch member's records, action ledger, snapshots,
   and apply reports under its private work root while serializing imports into
   the shared Git object database, preventing parallel publishers from moving

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -205,7 +205,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     // `requeue_latest` hands remote-newer to the source-drift requeue step,
     // which reviews the LATEST revision.
     writeStaleEventDispositionOutputs(disposition);
-    if (options.batchMutationOutput && preflightResult !== "missing")
+    if (options.batchMutationOutput)
       writeBatchMutationResult(options.batchMutationOutput, {
         kind: "superseded",
         disposition: { requeueLatestExpected: disposition.requeueLatest },

--- a/test/repair/stale-event-disposition.test.ts
+++ b/test/repair/stale-event-disposition.test.ts
@@ -49,5 +49,10 @@ test("publish-event-result exits terminally on a stale preflight instead of thro
     source.indexOf("const actions = readApplyActions"),
   );
   assert.ok(preflightBlock.includes("writeStaleEventDispositionOutputs"));
+  assert.match(preflightBlock, /if \(options\.batchMutationOutput\)\s+writeBatchMutationResult/);
+  assert.doesNotMatch(
+    preflightBlock,
+    /options\.batchMutationOutput && preflightResult !== "missing"/,
+  );
   assert.ok(!preflightBlock.includes("throw new Error"));
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stale exact-review publication items whose artifact no longer produces a record tuple would be retried forever by the batch publisher.

## Why This Change Was Made

Batch preparation now emits the same terminal superseded outcome for tuple-missing stale artifacts that the standalone publisher already exposes as `terminal_missing`. This preserves the existing stale-event contract while allowing the batch completer to acknowledge the item instead of defaulting it to `workflow_cancelled`.

## User Impact

Operators can drain historical publication backlog without tuple-missing singleton items repeatedly consuming batch capacity and eventually entering the dead-letter queue.

## Evidence

- Live batch https://github.com/openclaw/clawsweeper/actions/runs/30059202842 applied all eight artifacts, then classified all eight as retryable because four tuple-missing members produced no batch outcome; the other four showed the same terminal behavior in prior batches.
- Historical duplicate reconciliation removed 478 duplicate lineage items, exposing this independent singleton retry class.
- `./node_modules/.bin/tsc -p tsconfig.repair.json`
- `node --test test/repair/stale-event-disposition.test.ts test/repair/exact-review-batch-publisher.test.ts` (5 passed)
- targeted `oxfmt --check`
- `git diff --check`
- autoreview clean (0.91)