### PR TITLE
fix(publication): stabilize batch clone bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Snapshot exact-review batch clone credentials once before worker fanout so
+  parallel preparation no longer drops members during repeated shared-repo
+  bootstrap reads, and report any remaining member-specific setup failure.
 - Completed tuple-missing stale publication artifacts as superseded in batch
   mode instead of retrying them forever without a mutation outcome.
 - Isolated each exact-review batch member's records, action ledger, snapshots,

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -60,17 +60,27 @@ export function createSerialTaskQueue() {
   };
 }
 
-export async function createIsolatedStateClone({ stateRoot, destination, baselineSha, timeoutMs }) {
+export async function captureIsolatedStateCloneSource(stateRoot) {
   const remoteUrl = (await capture("git", ["-C", stateRoot, "remote", "get-url", "origin"])).trim();
   if (!remoteUrl) throw new Error("state origin URL is required");
+  const config = await capture("git", ["-C", stateRoot, "config", "--local", "--null", "--list"]);
+  return { remoteUrl, configEntries: workerGitConfigEntries(config) };
+}
+
+export async function createIsolatedStateClone({
+  stateRoot,
+  destination,
+  baselineSha,
+  timeoutMs,
+  source,
+}) {
   await runChecked("git", ["clone", "--shared", "--no-checkout", stateRoot, destination], {
     timeoutMs,
   });
-  await runChecked("git", ["-C", destination, "remote", "set-url", "origin", remoteUrl], {
+  await runChecked("git", ["-C", destination, "remote", "set-url", "origin", source.remoteUrl], {
     timeoutMs,
   });
-  const config = await capture("git", ["-C", stateRoot, "config", "--local", "--null", "--list"]);
-  for (const entry of workerGitConfigEntries(config)) {
+  for (const entry of source.configEntries) {
     await runChecked(
       "git",
       ["-C", destination, "config", "--local", "--add", entry.key, entry.value],
@@ -193,6 +203,9 @@ async function controller() {
   const deadline = startedAt + totalTimeoutMs;
   const stateRoot = resolve(env("CLAWSWEEPER_STATE_DIR"));
   const baselineSha = (await capture("git", ["-C", stateRoot, "rev-parse", "HEAD"])).trim();
+  // The source remote and auth config are process-stable for the batch. Capture
+  // them once so worker fanout never races repeated reads of the shared clone.
+  const cloneSource = await captureIsolatedStateCloneSource(stateRoot);
   const workersRoot = resolve(workspace, ".artifacts/exact-review-batch/workers");
   const heartbeatFailurePath = resolve(
     workspace,
@@ -228,13 +241,16 @@ async function controller() {
     const workerStartedAt = Date.now();
     const itemDeadline = Math.min(deadline, workerStartedAt + itemTimeoutMs);
     let timedOut = false;
+    let failureStage = "isolated state clone";
     try {
       await createIsolatedStateClone({
         stateRoot,
         destination: stateClone,
         baselineSha,
         timeoutMs: remainingTimeout(deadline),
+        source: cloneSource,
       });
+      failureStage = "worker execution";
       const status = await run(
         process.execPath,
         [process.argv[1], "worker", itemPath, root, stateClone, workspace],
@@ -243,6 +259,7 @@ async function controller() {
       timedOut = status.timedOut;
       if (timedOut) timeouts += 1;
       if (existsSync(outcomePath)) {
+        failureStage = "prepared object import";
         try {
           await importObjects(() =>
             importPreparedMutationObjects({
@@ -266,6 +283,7 @@ async function controller() {
       if (!existsSync(outcomePath)) {
         writeFailure(outcomePath, "retryable_failure", "unknown_failure");
       }
+      console.error(`Failed to prepare batch member ${item.itemKey} during ${failureStage}`);
     } finally {
       durations.push(Date.now() - workerStartedAt);
       try {

--- a/test/repair/exact-review-batch-prepare.test.mjs
+++ b/test/repair/exact-review-batch-prepare.test.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  captureIsolatedStateCloneSource,
   createSerialTaskQueue,
   createIsolatedStateClone,
   importPreparedMutationObjects,
@@ -120,6 +121,11 @@ test("parallel preparers use independent shallow state repositories", async (t) 
     "AUTHORIZATION: basic fixture",
   );
   const baselineSha = git(stateRoot, "rev-parse", "HEAD");
+  const cloneSource = await captureIsolatedStateCloneSource(stateRoot);
+  git(stateRoot, "remote", "remove", "origin");
+  git(stateRoot, "config", "--local", "--unset-all", "user.name");
+  git(stateRoot, "config", "--local", "--unset-all", "user.email");
+  git(stateRoot, "config", "--local", "--unset-all", "http.https://github.invalid/.extraheader");
   const left = join(root, "left");
   const right = join(root, "right");
 
@@ -129,12 +135,14 @@ test("parallel preparers use independent shallow state repositories", async (t) 
       destination: left,
       baselineSha,
       timeoutMs: 5_000,
+      source: cloneSource,
     }),
     createIsolatedStateClone({
       stateRoot,
       destination: right,
       baselineSha,
       timeoutMs: 5_000,
+      source: cloneSource,
     }),
   ]);
 
@@ -192,11 +200,13 @@ test("prepared mutation blobs survive isolated worker cleanup", async (t) => {
   git(source, "push", "origin", "state");
   git(root, "clone", "--depth", "1", "--branch", "state", `file://${origin}`, stateRoot);
   const baselineSha = git(stateRoot, "rev-parse", "HEAD");
+  const cloneSource = await captureIsolatedStateCloneSource(stateRoot);
   await createIsolatedStateClone({
     stateRoot,
     destination: worker,
     baselineSha,
     timeoutMs: 5_000,
+    source: cloneSource,
   });
 
   const content = "prepared in an isolated worker\n";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact-review publication batches could retry half of an eight-item lease when parallel workers repeatedly read bootstrap metadata from the shared state clone.

## Why This Change Was Made

Capture the state origin and allowed local Git configuration once before worker fanout, then pass that immutable snapshot into every isolated clone. Member-specific setup failures now report only a controlled stage so credential-bearing Git arguments cannot reach logs.

## User Impact

Operators can drain the historical publication backlog without unexplained pre-clone retries consuming attempts or moving items into the dead-letter queue.

## Evidence

- Before: https://github.com/openclaw/clawsweeper/actions/runs/30061023049 completed four tuple-missing members but returned `accepted: 8, retryable: 4`; only four worker clones started.
- `node --test test/repair/exact-review-batch-prepare.test.mjs test/repair/exact-review-batch-workflow.test.ts` (14 passed)
- focused formatting and `git diff --check` pass
- autoreview clean, patch correct, confidence 0.93
