### PR TITLE
feat(queue): add bounded dead-letter operator

### DIFF
--- a/.github/workflows/exact-review-dead-letter-operator.yml
+++ b/.github/workflows/exact-review-dead-letter-operator.yml
@@ -1,0 +1,99 @@
+name: Operate exact review dead letters
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Inventory, recover a fresh review, or resolve audited rows"
+        required: true
+        type: choice
+        options:
+          - inventory
+          - recover-fresh
+          - resolve
+        default: inventory
+      execute:
+        description: "Apply the selected mutation; false is read-only"
+        required: true
+        type: boolean
+        default: false
+      ids:
+        description: "One or two comma-separated dead-letter ids"
+        required: false
+        type: string
+      idempotency_key:
+        description: "Optional recovery key; defaults to this workflow run"
+        required: false
+        type: string
+      note:
+        description: "Resolution note required for resolve"
+        required: false
+        type: string
+
+concurrency:
+  group: exact-review-dead-letter-operator
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  operate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: exact-review-operator
+    env:
+      EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: main
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
+      - name: Inventory or operate dead letters
+        env:
+          ACTION: ${{ inputs.action }}
+          EXECUTE: ${{ inputs.execute }}
+          IDS: ${{ inputs.ids }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+          NOTE: ${{ inputs.note }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}
+        run: |
+          set -euo pipefail
+          args=(
+            --action "$ACTION"
+            --output ".artifacts/exact-review-dlq/inventory.json"
+          )
+          if [[ "$ACTION" != "inventory" ]]; then
+            args+=(--ids "$IDS")
+          fi
+          if [[ "$ACTION" == "recover-fresh" ]]; then
+            recovery_key="$IDEMPOTENCY_KEY"
+            if [[ -z "$recovery_key" ]]; then
+              recovery_key="operator:${GITHUB_RUN_ID}"
+            fi
+            args+=(--idempotency-key "$recovery_key")
+          fi
+          if [[ "$ACTION" == "resolve" ]]; then
+            args+=(--note "$NOTE")
+          fi
+          if [[ "$EXECUTE" == "true" ]]; then
+            args+=(--execute)
+          fi
+          node scripts/exact-review-dead-letter-operator.mjs "${args[@]}"
+
+      - name: Upload sanitized inventory
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: exact-review-dlq-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/exact-review-dlq/inventory.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -532,16 +532,16 @@ export default {
     if (url.pathname === "/internal/exact-review/claimed-runs" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/claimed-runs");
     if (url.pathname === "/internal/exact-review/dead-letters/list" && request.method === "POST")
-      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/list");
+      return authenticatedExactReviewOperatorRequest(request, env, "/dead-letters/list");
     if (url.pathname === "/internal/exact-review/dead-letters/replay" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/replay");
     if (
       url.pathname === "/internal/exact-review/dead-letters/recover-fresh" &&
       request.method === "POST"
     )
-      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/recover-fresh");
+      return authenticatedExactReviewOperatorRequest(request, env, "/dead-letters/recover-fresh");
     if (url.pathname === "/internal/exact-review/dead-letters/resolve" && request.method === "POST")
-      return authenticatedExactReviewQueueRequest(request, env, "/dead-letters/resolve");
+      return authenticatedExactReviewOperatorRequest(request, env, "/dead-letters/resolve");
     if (url.pathname === "/internal/exact-review/publications/list" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/publications/list");
     if (
@@ -1572,6 +1572,25 @@ async function authenticatedExactReviewEnqueue(request, env) {
 async function authenticatedExactReviewQueueRequest(request, env, path: string) {
   const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
   if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const body = await request.text();
+  const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
+  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+  return exactReviewQueueRequest(
+    env,
+    path,
+    new Request(`https://clawsweeper-exact-review-queue${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    }),
+  );
+}
+
+async function authenticatedExactReviewOperatorRequest(request, env, path: string) {
+  const secret = stringEnv(env.EXACT_REVIEW_OPERATOR_SECRET);
+  if (!secret) return json({ error: "operator_not_configured" }, 503);
   const body = await request.text();
   const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
   if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "repair:spam-scan": "node dist/repair/spam-scanner.js",
     "repair:exact-review-bundle": "node dist/repair/exact-review-bundle-cli.js",
     "repair:exact-review-queue-maintenance": "node dist/repair/exact-review-queue-maintenance.js",
+    "repair:exact-review-dead-letters": "node scripts/exact-review-dead-letter-operator.mjs",
     "repair:exact-review-batch": "node dist/repair/exact-review-batch-cli.js",
     "proof:state-publication-batching": "node scripts/state-publication-batching-proof.mjs",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",

--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+import { createHmac } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+
+const DEFAULT_OUTPUT = ".artifacts/exact-review-dlq/inventory.json";
+const MAX_SELECTED_IDS = 2;
+const MAX_INVENTORY_ROWS = 10_000;
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9:._-]{1,200}$/;
+
+const HELP = `Usage:
+  node scripts/exact-review-dead-letter-operator.mjs --action <inventory|recover-fresh|resolve> [options]
+
+Options:
+  --action <action>             Required operator action
+  --ids <id,id>                 One or two dead-letter ids for mutation actions
+  --idempotency-key <key>       Required for recover-fresh
+  --note <text>                 Required for resolve
+  --execute                     Apply the selected mutation; otherwise preview only
+  --output <path>               Inventory artifact path
+  -h, --help                    Show this help
+
+The operator always inventories open dead letters first. It never exposes raw replay.
+`;
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const queueUrl = String(process.env.EXACT_REVIEW_QUEUE_URL || "").replace(/\/$/, "");
+  const secret = String(process.env.CLAWSWEEPER_WEBHOOK_SECRET || "");
+  if (!queueUrl || !secret) {
+    throw new Error("EXACT_REVIEW_QUEUE_URL and CLAWSWEEPER_WEBHOOK_SECRET are required");
+  }
+
+  const inventory = await loadInventory({ queueUrl, secret });
+  await mkdir(dirname(resolve(args.output)), { recursive: true });
+  await writeFile(args.output, `${JSON.stringify(inventory, null, 2)}\n`, "utf8");
+
+  if (args.action === "inventory") {
+    printResult({ action: args.action, output: args.output, summary: inventory.summary });
+    return;
+  }
+
+  const selected = selectRows(inventory.dead_letters, args.ids);
+  if (args.action === "recover-fresh") {
+    if (!IDEMPOTENCY_KEY.test(args.idempotencyKey)) {
+      throw new Error("--idempotency-key must match [A-Za-z0-9:._-]{1,200}");
+    }
+    const ineligible = selected.filter((row) => !row.fresh_recovery.eligible);
+    if (ineligible.length) {
+      throw new Error(
+        `selected dead letters are not eligible for fresh recovery: ${ineligible
+          .map((row) => row.dead_letter_id)
+          .join(",")}`,
+      );
+    }
+    if (!args.execute) {
+      printResult({ action: args.action, dry_run: true, selected });
+      return;
+    }
+    const result = await signedPost({
+      queueUrl,
+      secret,
+      path: "/internal/exact-review/dead-letters/recover-fresh",
+      payload: { ids: args.ids, idempotency_key: args.idempotencyKey },
+    });
+    printResult({
+      action: args.action,
+      dry_run: false,
+      selected,
+      result: mutationSummary(args.action, result),
+    });
+    return;
+  }
+
+  if (!args.note || args.note.length > 500) {
+    throw new Error("--note is required for resolve and must be at most 500 characters");
+  }
+  if (!args.execute) {
+    printResult({ action: args.action, dry_run: true, selected });
+    return;
+  }
+  const result = await signedPost({
+    queueUrl,
+    secret,
+    path: "/internal/exact-review/dead-letters/resolve",
+    payload: { ids: args.ids, note: args.note },
+  });
+  printResult({
+    action: args.action,
+    dry_run: false,
+    selected,
+    result: mutationSummary(args.action, result),
+  });
+}
+
+function parseArgs(argv) {
+  const args = {
+    action: "",
+    ids: [],
+    idempotencyKey: "",
+    note: "",
+    execute: false,
+    output: DEFAULT_OUTPUT,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "-h" || value === "--help") args.help = true;
+    else if (value === "--execute") args.execute = true;
+    else if (value === "--action") args.action = String(argv[++index] || "");
+    else if (value === "--ids") {
+      args.ids = String(argv[++index] || "")
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean);
+    } else if (value === "--idempotency-key") {
+      args.idempotencyKey = String(argv[++index] || "").trim();
+    } else if (value === "--note") args.note = String(argv[++index] || "").trim();
+    else if (value === "--output") args.output = String(argv[++index] || "").trim();
+    else throw new Error(`unknown option ${value}; use --help`);
+  }
+  if (args.help) return args;
+  if (!["inventory", "recover-fresh", "resolve"].includes(args.action)) {
+    throw new Error("--action must be inventory, recover-fresh, or resolve");
+  }
+  if (!args.output) throw new Error("--output is required");
+  if (args.action !== "inventory") {
+    if (args.ids.length < 1 || args.ids.length > MAX_SELECTED_IDS) {
+      throw new Error(`mutation actions require between 1 and ${MAX_SELECTED_IDS} --ids`);
+    }
+    if (new Set(args.ids).size !== args.ids.length) {
+      throw new Error("--ids must not contain duplicates");
+    }
+  }
+  return args;
+}
+
+async function loadInventory(options) {
+  const rows = [];
+  let cursor = "";
+  for (;;) {
+    const page = await signedPost({
+      ...options,
+      path: "/internal/exact-review/dead-letters/list",
+      payload: { status: "open", limit: 20, ...(cursor ? { cursor } : {}) },
+    });
+    const pageRows = Array.isArray(page.dead_letters) ? page.dead_letters : [];
+    rows.push(...pageRows.map(sanitizeRow));
+    if (rows.length > MAX_INVENTORY_ROWS) {
+      throw new Error(`open dead-letter inventory exceeds ${MAX_INVENTORY_ROWS} rows`);
+    }
+    cursor = String(page.next_cursor || "");
+    if (!cursor) break;
+  }
+
+  const uniqueItemKeys = new Set(rows.map((row) => row.item_key));
+  const byReason = countBy(rows, (row) => row.reason_code);
+  const recoveryReasons = countBy(rows, (row) => row.fresh_recovery.reason);
+  return {
+    generated_at: new Date().toISOString(),
+    summary: {
+      rows: rows.length,
+      unique_item_keys: uniqueItemKeys.size,
+      duplicate_revision_rows: rows.length - uniqueItemKeys.size,
+      eligible_fresh_recovery: rows.filter((row) => row.fresh_recovery.eligible).length,
+      by_reason: byReason,
+      recovery_reasons: recoveryReasons,
+    },
+    dead_letters: rows,
+  };
+}
+
+function sanitizeRow(row) {
+  const value = row && typeof row === "object" ? row : {};
+  const recovery =
+    value.fresh_recovery && typeof value.fresh_recovery === "object" ? value.fresh_recovery : {};
+  const diagnostic =
+    value.diagnostic && typeof value.diagnostic === "object" ? value.diagnostic : {};
+  return {
+    dead_letter_id: String(value.dead_letter_id || ""),
+    item_key: String(value.item_key || ""),
+    revision: Number(value.revision || 0),
+    reason_code: String(value.reason_code || diagnostic.reason_code || "unknown_failure"),
+    attempts: Number(value.attempts || diagnostic.attempts || 0),
+    first_failed_at: diagnostic.first_failed_at || null,
+    last_failed_at: diagnostic.last_failed_at || null,
+    error_fingerprint:
+      String(value.error_fingerprint || diagnostic.error_fingerprint || "") || null,
+    status: String(value.status || "open"),
+    fresh_recovery: {
+      eligible: recovery.eligible === true,
+      reason: String(recovery.reason || "unknown"),
+      item_key: recovery.item_key ? String(recovery.item_key) : null,
+    },
+  };
+}
+
+function selectRows(rows, ids) {
+  const byId = new Map(rows.map((row) => [row.dead_letter_id, row]));
+  const missing = ids.filter((id) => !byId.has(id));
+  if (missing.length)
+    throw new Error(`dead letters are not open or were not found: ${missing.join(",")}`);
+  return ids.map((id) => byId.get(id));
+}
+
+function countBy(rows, keyFor) {
+  return Object.fromEntries(
+    [
+      ...rows.reduce((counts, row) => {
+        const key = keyFor(row);
+        counts.set(key, (counts.get(key) || 0) + 1);
+        return counts;
+      }, new Map()),
+    ].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+async function signedPost({ queueUrl, secret, path, payload }) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  const response = await fetch(`${queueUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+    signal: AbortSignal.timeout(20_000),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+  let result;
+  try {
+    result = JSON.parse(text);
+  } catch {
+    throw new Error(`${path} returned invalid JSON`);
+  }
+  if (!result?.ok) throw new Error(`${path} returned an invalid response`);
+  return result;
+}
+
+function mutationSummary(action, result) {
+  const keys =
+    action === "recover-fresh"
+      ? ["recovered", "deduped", "skipped", "unparked"]
+      : ["resolved", "skipped", "unparked"];
+  return Object.fromEntries(keys.map((key) => [key, requiredCount(result, key)]));
+}
+
+function requiredCount(result, key) {
+  const count = result[key];
+  if (typeof count !== "number" || !Number.isInteger(count) || count < 0) {
+    throw new Error(`mutation response has invalid ${key} count`);
+  }
+  return count;
+}
+
+function printResult(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+main(process.argv.slice(2)).catch((error) => {
+  process.stderr.write(
+    `exact-review-dead-letter-operator: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.stderr.write("[exact-review-dead-letter-operator] FAILED (exit 1)\n");
+  process.exitCode = 1;
+});

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1659,6 +1659,7 @@ test("fresh dead-letter recovery is available only through the signed internal r
   const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
   const env = {
     CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+    EXACT_REVIEW_OPERATOR_SECRET: "operator-token-placeholder",
     EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
   };
   const body = JSON.stringify({ ids: ["missing-dead-letter"], idempotency_key: "operator:test" });
@@ -1674,7 +1675,21 @@ test("fresh dead-letter recovery is available only through the signed internal r
   );
   assert.equal(unsigned.status, 401);
 
-  const signature = `sha256=${createHmac("sha256", "test-token-placeholder").update(body).digest("hex")}`;
+  const sharedSignature = `sha256=${createHmac("sha256", "test-token-placeholder").update(body).digest("hex")}`;
+  const sharedSigned = await worker.fetch(
+    new Request(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/dead-letters/recover-fresh",
+      {
+        method: "POST",
+        headers: { "x-clawsweeper-exact-review-signature": sharedSignature },
+        body,
+      },
+    ),
+    env,
+  );
+  assert.equal(sharedSigned.status, 401);
+
+  const signature = `sha256=${createHmac("sha256", "operator-token-placeholder").update(body).digest("hex")}`;
   const signed = await worker.fetch(
     new Request(
       "https://clawsweeper.openclaw.ai/internal/exact-review/dead-letters/recover-fresh",

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import YAML from "yaml";
+import { readFileSync } from "node:fs";
+
+const workflowPath = ".github/workflows/exact-review-dead-letter-operator.yml";
+const workflowSource = readFileSync(workflowPath, "utf8");
+const workflow = YAML.parse(workflowSource);
+
+test("dead-letter workflow is manual, serialized, and bounded to safe actions", () => {
+  assert.equal(workflow.on.schedule, undefined);
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs.action.options, [
+    "inventory",
+    "recover-fresh",
+    "resolve",
+  ]);
+  assert.equal(workflow.concurrency["cancel-in-progress"], false);
+  assert.deepEqual(workflow.permissions, { contents: "read" });
+  assert.equal(workflow.jobs.operate.environment, "exact-review-operator");
+  assert.doesNotMatch(workflowSource, /dead-letters\/replay/);
+  assert.match(workflowSource, /actions\/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/);
+  assert.match(workflowSource, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
+  assert.match(workflowSource, /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/);
+  const uploadStep = workflow.jobs.operate.steps.find(
+    (step) => step.name === "Upload sanitized inventory",
+  );
+  assert.equal(uploadStep.with["include-hidden-files"], true);
+  assert.equal(workflow.jobs.operate.env.CLAWSWEEPER_WEBHOOK_SECRET, undefined);
+  const operatorStep = workflow.jobs.operate.steps.find(
+    (step) => step.name === "Inventory or operate dead letters",
+  );
+  assert.equal(
+    operatorStep.env.CLAWSWEEPER_WEBHOOK_SECRET,
+    "${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}",
+  );
+  assert.match(operatorStep.run, /operator:\$\{GITHUB_RUN_ID\}/);
+  assert.doesNotMatch(operatorStep.run, /GITHUB_RUN_ATTEMPT/);
+});
+
+test("operator inventories every page, signs requests, and reports unique targets", async () => {
+  const secret = "test-dead-letter-secret";
+  const requests = [];
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString("utf8");
+    const expected = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+    assert.equal(request.headers["x-clawsweeper-exact-review-signature"], expected);
+    const payload = JSON.parse(body);
+    requests.push({ url: request.url, payload });
+    const secondPage = payload.cursor === "dlq-2";
+    const deadLetters = secondPage
+      ? [row("dlq-3", "item:2", 1, "retry_exhausted", false, "target_not_enabled")]
+      : [
+          row("dlq-1", "item:1", 1, "state_contention", true, "eligible"),
+          row("dlq-2", "item:1", 2, "state_contention", false, "publication_item_active"),
+        ];
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        ok: true,
+        dead_letters: deadLetters,
+        next_cursor: secondPage ? null : "dlq-2",
+      }),
+    );
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const directory = await mkdtemp(join(tmpdir(), "clawsweeper-dlq-"));
+  const output = join(directory, "inventory.json");
+  try {
+    const result = await runOperator(
+      ["--action", "inventory", "--output", output],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(requests.length, 2);
+    assert.deepEqual(
+      requests.map((entry) => entry.url),
+      ["/internal/exact-review/dead-letters/list", "/internal/exact-review/dead-letters/list"],
+    );
+    const inventory = JSON.parse(await readFile(output, "utf8"));
+    assert.deepEqual(inventory.summary, {
+      rows: 3,
+      unique_item_keys: 2,
+      duplicate_revision_rows: 1,
+      eligible_fresh_recovery: 1,
+      by_reason: { retry_exhausted: 1, state_contention: 2 },
+      recovery_reasons: {
+        eligible: 1,
+        publication_item_active: 1,
+        target_not_enabled: 1,
+      },
+    });
+    assert.equal(inventory.dead_letters[0].item, undefined);
+  } finally {
+    server.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("operator previews by default and caps mutations at two audited ids", async () => {
+  const secret = "test-dead-letter-secret";
+  let mutations = 0;
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    if (request.url?.endsWith("/recover-fresh")) {
+      mutations += 1;
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          recovered: payload.idempotency_key === "operator:bad" ? "1" : 1,
+          deduped: 0,
+          skipped: 0,
+          unparked: 0,
+          item: { secret: "must not reach stdout" },
+        }),
+      );
+      return;
+    }
+    if (request.url?.endsWith("/resolve")) {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "internal", secret: "must not reach stderr" }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        ok: true,
+        dead_letters: [row("dlq-1", "item:1", 1, "state_contention", true, "eligible")],
+        next_cursor: null,
+      }),
+    );
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const directory = await mkdtemp(join(tmpdir(), "clawsweeper-dlq-"));
+  try {
+    const result = await runOperator(
+      [
+        "--action",
+        "recover-fresh",
+        "--ids",
+        "dlq-1",
+        "--idempotency-key",
+        "operator:test:1",
+        "--output",
+        join(directory, "inventory.json"),
+      ],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(mutations, 0);
+    assert.equal(JSON.parse(result.stdout).dry_run, true);
+
+    const executed = await runOperator(
+      [
+        "--action",
+        "recover-fresh",
+        "--ids",
+        "dlq-1",
+        "--idempotency-key",
+        "operator:test:1",
+        "--execute",
+        "--output",
+        join(directory, "inventory.json"),
+      ],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(executed.code, 0, executed.stderr);
+    assert.equal(mutations, 1);
+    assert.deepEqual(JSON.parse(executed.stdout).result, {
+      recovered: 1,
+      deduped: 0,
+      skipped: 0,
+      unparked: 0,
+    });
+    assert.doesNotMatch(executed.stdout, /must not reach stdout/);
+
+    const malformedResponse = await runOperator(
+      [
+        "--action",
+        "recover-fresh",
+        "--ids",
+        "dlq-1",
+        "--idempotency-key",
+        "operator:bad",
+        "--execute",
+      ],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(malformedResponse.code, 1);
+    assert.match(malformedResponse.stderr, /mutation response has invalid recovered count/);
+
+    const invalidPreview = await runOperator(
+      ["--action", "recover-fresh", "--ids", "dlq-1", "--idempotency-key", "invalid key"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(invalidPreview.code, 1);
+    assert.match(invalidPreview.stderr, /--idempotency-key must match/);
+    assert.equal(mutations, 2);
+
+    const missingNotePreview = await runOperator(
+      ["--action", "resolve", "--ids", "dlq-1"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(missingNotePreview.code, 1);
+    assert.match(missingNotePreview.stderr, /--note is required for resolve/);
+
+    const failedResolve = await runOperator(
+      ["--action", "resolve", "--ids", "dlq-1", "--note", "audited", "--execute"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(failedResolve.code, 1);
+    assert.match(failedResolve.stderr, /dead-letters\/resolve returned 500/);
+    assert.doesNotMatch(failedResolve.stderr, /must not reach stderr/);
+
+    const rejected = await runOperator(
+      ["--action", "resolve", "--ids", "1,2,3", "--note", "audited"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(rejected.code, 1);
+    assert.match(rejected.stderr, /between 1 and 2 --ids/);
+    assert.match(rejected.stderr, /\[exact-review-dead-letter-operator\] FAILED \(exit 1\)$/m);
+  } finally {
+    server.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function row(id, key, revision, reason, eligible, recoveryReason) {
+  return {
+    dead_letter_id: id,
+    item_key: key,
+    revision,
+    reason_code: reason,
+    attempts: 3,
+    status: "open",
+    item: { secret: "must not be copied" },
+    diagnostic: {
+      first_failed_at: "2026-07-23T00:00:00.000Z",
+      last_failed_at: "2026-07-24T00:00:00.000Z",
+      error_fingerprint: "abc",
+    },
+    fresh_recovery: {
+      eligible,
+      reason: recoveryReason,
+      item_key: eligible ? `${key}:fresh` : null,
+    },
+  };
+}
+
+function runOperator(args, queueUrl, secret) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["scripts/exact-review-dead-letter-operator.mjs", ...args],
+      {
+        env: {
+          ...process.env,
+          EXACT_REVIEW_QUEUE_URL: queueUrl,
+          CLAWSWEEPER_WEBHOOK_SECRET: secret,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
+    child.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational gap where maintainers could inspect aggregate dead-letter counts but had no audited, bounded workflow for inventorying individual revision rows or recovering safe cohorts.

## Why This Change Was Made

Adds a manual signed operator that always inventories sanitized open rows first, exposes only fresh-review recovery or audited resolution, defaults to dry-run, caps selections at two rows, and never exposes raw artifact replay. Mutation credentials are scoped only to the operator step and recovery idempotency remains stable across workflow retries.

## User Impact

Maintainers can measure unique affected items behind the current 614 revision rows and recover only endpoint-confirmed fresh-review candidates without replaying failed immutable publication artifacts.

## Evidence

- `node --test test/exact-review-dead-letter-operator.test.ts` (3/3)
- focused `oxfmt` and `oxlint` checks pass
- workflow Bash syntax passes
- `git diff --check` passes
- autoreview clean after fixing secret scope, stable retry idempotency, and hidden artifact upload
