### PR TITLE
fix(queue): report dead-letter targets accurately

### DIFF
--- a/.github/workflows/exact-review-dead-letter-operator.yml
+++ b/.github/workflows/exact-review-dead-letter-operator.yml
@@ -36,6 +36,8 @@ concurrency:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   operate:
@@ -64,6 +66,7 @@ jobs:
           IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
           NOTE: ${{ inputs.note }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           args=(

--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -49,6 +49,7 @@ async function main(argv) {
 
   const selected = selectRows(inventory.dead_letters, args.ids);
   if (args.action === "recover-fresh") {
+    // Resolve must remain available for closed or unmapped rows; only recovery needs a live target.
     if (!IDEMPOTENCY_KEY.test(args.idempotencyKey)) {
       throw new Error("--idempotency-key must match [A-Za-z0-9:._-]{1,200}");
     }
@@ -59,6 +60,17 @@ async function main(argv) {
           .map((row) => row.dead_letter_id)
           .join(",")}`,
       );
+    }
+    const recoveryTargets = selected.map((row) => row.fresh_recovery.item_key);
+    if (recoveryTargets.some((target) => !target)) {
+      throw new Error("selected dead letters are missing fresh recovery targets");
+    }
+    if (new Set(recoveryTargets).size !== recoveryTargets.length) {
+      throw new Error("selected dead letters must map to distinct fresh recovery targets");
+    }
+    const canonicalTargetIds = await assertOpenRecoveryTargets(recoveryTargets);
+    if (new Set(canonicalTargetIds).size !== canonicalTargetIds.length) {
+      throw new Error("selected dead letters must resolve to distinct GitHub items");
     }
     if (!args.execute) {
       printResult({ action: args.action, dry_run: true, selected });
@@ -160,21 +172,42 @@ async function loadInventory(options) {
     if (!cursor) break;
   }
 
-  const uniqueItemKeys = new Set(rows.map((row) => row.item_key));
+  const uniquePublicationKeys = new Set(rows.map((row) => row.item_key));
+  const targetKeys = rows
+    .map((row) => row.fresh_recovery.item_key)
+    .filter(Boolean)
+    .map(normalizeRecoveryTargetKey);
+  const eligibleRows = rows.filter((row) => row.fresh_recovery.eligible);
+  const eligibleTargetKeys = eligibleRows
+    .map((row) => row.fresh_recovery.item_key)
+    .filter(Boolean)
+    .map(normalizeRecoveryTargetKey);
+  const uniqueTargetKeys = new Set(targetKeys);
+  const uniqueEligibleTargetKeys = new Set(eligibleTargetKeys);
   const byReason = countBy(rows, (row) => row.reason_code);
   const recoveryReasons = countBy(rows, (row) => row.fresh_recovery.reason);
   return {
     generated_at: new Date().toISOString(),
     summary: {
       rows: rows.length,
-      unique_item_keys: uniqueItemKeys.size,
-      duplicate_revision_rows: rows.length - uniqueItemKeys.size,
-      eligible_fresh_recovery: rows.filter((row) => row.fresh_recovery.eligible).length,
+      unique_publication_keys: uniquePublicationKeys.size,
+      duplicate_publication_rows: rows.length - uniquePublicationKeys.size,
+      unique_target_keys: uniqueTargetKeys.size,
+      duplicate_target_key_rows: targetKeys.length - uniqueTargetKeys.size,
+      unmapped_target_rows: rows.length - targetKeys.length,
+      eligible_fresh_recovery_rows: eligibleRows.length,
+      eligible_fresh_recovery_target_keys: uniqueEligibleTargetKeys.size,
       by_reason: byReason,
       recovery_reasons: recoveryReasons,
     },
     dead_letters: rows,
   };
+}
+
+function normalizeRecoveryTargetKey(target) {
+  const match = /^([^/]+)\/([^#]+)#([1-9]\d*)$/.exec(target);
+  if (!match) return target;
+  return `${match[1].toLowerCase()}/${match[2].toLowerCase()}#${match[3]}`;
 }
 
 function sanitizeRow(row) {
@@ -244,6 +277,45 @@ async function signedPost({ queueUrl, secret, path, payload }) {
   }
   if (!result?.ok) throw new Error(`${path} returned an invalid response`);
   return result;
+}
+
+async function assertOpenRecoveryTargets(targets) {
+  const apiUrl = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
+  const token = String(process.env.GITHUB_TOKEN || "");
+  const canonicalTargetIds = [];
+  for (const target of targets) {
+    const match = /^([^/]+)\/([^#]+)#([1-9]\d*)$/.exec(target);
+    if (!match) throw new Error(`invalid fresh recovery target: ${target}`);
+    const [, owner, repo, number] = match;
+    const response = await fetch(
+      `${apiUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${number}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          "user-agent": "clawsweeper-dead-letter-operator",
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`live target check failed for ${target} (${response.status})`);
+    }
+    let item;
+    try {
+      item = await response.json();
+    } catch {
+      throw new Error(`live target check returned invalid JSON for ${target}`);
+    }
+    if (item?.state !== "open") {
+      throw new Error(`fresh recovery target is not open: ${target}`);
+    }
+    if (typeof item.node_id !== "string" || !item.node_id) {
+      throw new Error(`live target check returned an invalid canonical identity for ${target}`);
+    }
+    canonicalTargetIds.push(item.node_id);
+  }
+  return canonicalTargetIds;
 }
 
 function mutationSummary(action, result) {

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -21,7 +21,11 @@ test("dead-letter workflow is manual, serialized, and bounded to safe actions", 
     "resolve",
   ]);
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
-  assert.deepEqual(workflow.permissions, { contents: "read" });
+  assert.deepEqual(workflow.permissions, {
+    contents: "read",
+    issues: "read",
+    "pull-requests": "read",
+  });
   assert.equal(workflow.jobs.operate.environment, "exact-review-operator");
   assert.doesNotMatch(workflowSource, /dead-letters\/replay/);
   assert.match(workflowSource, /actions\/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/);
@@ -39,6 +43,7 @@ test("dead-letter workflow is manual, serialized, and bounded to safe actions", 
     operatorStep.env.CLAWSWEEPER_WEBHOOK_SECRET,
     "${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}",
   );
+  assert.equal(operatorStep.env.GITHUB_TOKEN, "${{ github.token }}");
   assert.match(operatorStep.run, /operator:\$\{GITHUB_RUN_ID\}/);
   assert.doesNotMatch(operatorStep.run, /GITHUB_RUN_ATTEMPT/);
 });
@@ -56,10 +61,28 @@ test("operator inventories every page, signs requests, and reports unique target
     requests.push({ url: request.url, payload });
     const secondPage = payload.cursor === "dlq-2";
     const deadLetters = secondPage
-      ? [row("dlq-3", "item:2", 1, "retry_exhausted", false, "target_not_enabled")]
+      ? [
+          row(
+            "dlq-3",
+            "publication:3",
+            1,
+            "retry_exhausted",
+            false,
+            "target_not_enabled",
+            "openclaw/repo#2",
+          ),
+        ]
       : [
-          row("dlq-1", "item:1", 1, "state_contention", true, "eligible"),
-          row("dlq-2", "item:1", 2, "state_contention", false, "publication_item_active"),
+          row("dlq-1", "publication:1", 1, "state_contention", true, "eligible", "openclaw/repo#1"),
+          row(
+            "dlq-2",
+            "publication:2",
+            2,
+            "state_contention",
+            false,
+            "publication_item_active",
+            "OpenClaw/Repo#1",
+          ),
         ];
     response.writeHead(200, { "content-type": "application/json" });
     response.end(
@@ -90,9 +113,13 @@ test("operator inventories every page, signs requests, and reports unique target
     const inventory = JSON.parse(await readFile(output, "utf8"));
     assert.deepEqual(inventory.summary, {
       rows: 3,
-      unique_item_keys: 2,
-      duplicate_revision_rows: 1,
-      eligible_fresh_recovery: 1,
+      unique_publication_keys: 3,
+      duplicate_publication_rows: 0,
+      unique_target_keys: 2,
+      duplicate_target_key_rows: 1,
+      unmapped_target_rows: 0,
+      eligible_fresh_recovery_rows: 1,
+      eligible_fresh_recovery_target_keys: 1,
       by_reason: { retry_exhausted: 1, state_contention: 2 },
       recovery_reasons: {
         eligible: 1,
@@ -113,6 +140,18 @@ test("operator previews by default and caps mutations at two audited ids", async
   const server = createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
+    if (request.url?.toLowerCase().startsWith("/repos/openclaw/repo/issues/")) {
+      const number = Number(request.url.split("/").at(-1));
+      assert.equal(request.headers.authorization, "Bearer test-github-token");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          node_id: `ISSUE_${number}`,
+          state: number === 2 ? "closed" : "open",
+        }),
+      );
+      return;
+    }
     if (request.url?.endsWith("/recover-fresh")) {
       mutations += 1;
       const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
@@ -138,7 +177,21 @@ test("operator previews by default and caps mutations at two audited ids", async
     response.end(
       JSON.stringify({
         ok: true,
-        dead_letters: [row("dlq-1", "item:1", 1, "state_contention", true, "eligible")],
+        dead_letters: [
+          row("dlq-1", "publication:1", 1, "state_contention", true, "eligible", "openclaw/repo#1"),
+          row("dlq-2", "publication:2", 1, "state_contention", true, "eligible", "openclaw/repo#1"),
+          row("dlq-3", "publication:3", 1, "state_contention", true, "eligible", "openclaw/repo#2"),
+          row("dlq-5", "publication:5", 1, "state_contention", true, "eligible", "OpenClaw/Repo#1"),
+          row(
+            "dlq-4",
+            "publication:4",
+            1,
+            "tuple_protocol_invalid",
+            false,
+            "invalid_dead_letter_item",
+            null,
+          ),
+        ],
         next_cursor: null,
       }),
     );
@@ -216,6 +269,55 @@ test("operator previews by default and caps mutations at two audited ids", async
     assert.match(invalidPreview.stderr, /--idempotency-key must match/);
     assert.equal(mutations, 2);
 
+    const duplicateTargetPreview = await runOperator(
+      [
+        "--action",
+        "recover-fresh",
+        "--ids",
+        "dlq-1,dlq-2",
+        "--idempotency-key",
+        "operator:test:duplicate",
+      ],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(duplicateTargetPreview.code, 1);
+    assert.match(duplicateTargetPreview.stderr, /must map to distinct fresh recovery targets/);
+    assert.equal(mutations, 2);
+
+    const canonicalDuplicatePreview = await runOperator(
+      [
+        "--action",
+        "recover-fresh",
+        "--ids",
+        "dlq-1,dlq-5",
+        "--idempotency-key",
+        "operator:test:canonical-duplicate",
+      ],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(canonicalDuplicatePreview.code, 1);
+    assert.match(canonicalDuplicatePreview.stderr, /must resolve to distinct GitHub items/);
+    assert.equal(mutations, 2);
+
+    const closedTargetPreview = await runOperator(
+      ["--action", "recover-fresh", "--ids", "dlq-3", "--idempotency-key", "operator:test:closed"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(closedTargetPreview.code, 1);
+    assert.match(closedTargetPreview.stderr, /fresh recovery target is not open: openclaw\/repo#2/);
+    assert.equal(mutations, 2);
+
+    const unmappedResolvePreview = await runOperator(
+      ["--action", "resolve", "--ids", "dlq-4", "--note", "unrecoverable legacy row"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(unmappedResolvePreview.code, 0, unmappedResolvePreview.stderr);
+    assert.equal(JSON.parse(unmappedResolvePreview.stdout).dry_run, true);
+
     const missingNotePreview = await runOperator(
       ["--action", "resolve", "--ids", "dlq-1"],
       `http://127.0.0.1:${address.port}`,
@@ -247,7 +349,15 @@ test("operator previews by default and caps mutations at two audited ids", async
   }
 });
 
-function row(id, key, revision, reason, eligible, recoveryReason) {
+function row(
+  id,
+  key,
+  revision,
+  reason,
+  eligible,
+  recoveryReason,
+  recoveryItemKey = `${key}:fresh`,
+) {
   return {
     dead_letter_id: id,
     item_key: key,
@@ -264,7 +374,7 @@ function row(id, key, revision, reason, eligible, recoveryReason) {
     fresh_recovery: {
       eligible,
       reason: recoveryReason,
-      item_key: eligible ? `${key}:fresh` : null,
+      item_key: recoveryItemKey,
     },
   };
 }
@@ -279,6 +389,8 @@ function runOperator(args, queueUrl, secret) {
           ...process.env,
           EXACT_REVIEW_QUEUE_URL: queueUrl,
           CLAWSWEEPER_WEBHOOK_SECRET: secret,
+          GITHUB_API_URL: queueUrl,
+          GITHUB_TOKEN: "test-github-token",
         },
         stdio: ["ignore", "pipe", "pipe"],
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the dead-letter inventory labeled publication-run keys as unique items, overstating the number of distinct GitHub targets and allowing two selected rows to point at the same fresh-review target.

## Why This Change Was Made

Reports publication-key and target-item cardinality separately, includes eligible target counts, and rejects recovery selections that map multiple dead-letter rows to the same target. Resolution remains row-oriented and unchanged.

## User Impact

Maintainers get an accurate recovery workload count and cannot waste a bounded two-row recovery run on duplicate rows for one issue or pull request.

## Evidence

- Live inventory run https://github.com/openclaw/clawsweeper/actions/runs/30065667159 showed 614 rows but only 420 distinct target items.
- 194 rows duplicate an already represented target; 594 eligible rows cover 411 targets.
- `node --test test/exact-review-dead-letter-operator.test.ts` (3/3)
- focused oxfmt, oxlint, and `git diff --check` pass
- autoreview clean, no accepted/actionable findings