### PR TITLE
fix(dashboard): distinguish idle writer telemetry

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9103,6 +9103,7 @@ function renderStateWriter(queue) {
   const live = writer.live || {};
   const lease = writer.global_lease || {};
   const hour = writer.last_60_minutes || {};
+  const publicationFlow = queue?.lanes?.publication?.flow?.last_15_minutes || {};
   const history = stateWriterHistorySamples();
   const coordinatorHistory = stateWriterCoordinatorHistorySamples();
   const latestCoordinatorHistory = coordinatorHistory.at(-1);
@@ -9114,6 +9115,29 @@ function renderStateWriter(queue) {
   const commitsPerHour = historyFresh ? stateWriterRateFromHistory(history, "commits") : null;
   const commitSegment = historyFresh ? stateWriterHistorySegment(history, "commits") : null;
   const terminalFresh = collection.status === "fresh";
+  const recentPublicationCounts = ["resolved", "published", "superseded", "retried", "dead_lettered"]
+    .map(field => Number(publicationFlow[field]));
+  const recentPublicationNeedsTelemetry =
+    recentPublicationCounts.some(count => !Number.isInteger(count) || count < 0) ||
+    Number(publicationFlow.published) > 0 ||
+    Number(publicationFlow.retried) > 0 ||
+    Number(publicationFlow.dead_lettered) > 0 ||
+    Number(publicationFlow.superseded) !== Number(publicationFlow.resolved);
+  // The coordinator also serializes unrelated state writers. Exact publication
+  // ownership is the signal that this panel still expects a terminal sample.
+  const exactPublicationActive =
+    [batches.leased, queue?.lanes?.publication?.active, queue?.lanes?.publication?.leased, queue?.lanes?.publication?.dispatching]
+      .some(count => Number.isInteger(Number(count)) && Number(count) > 0);
+  const terminalPending =
+    !terminalFresh &&
+    coordinatorLive &&
+    !recentPublicationNeedsTelemetry &&
+    exactPublicationActive;
+  const terminalIdle =
+    !terminalFresh &&
+    coordinatorLive &&
+    !recentPublicationNeedsTelemetry &&
+    !exactPublicationActive;
   const itemsPerCommit =
     commitSegment &&
     commitSegment.length >= 2 &&
@@ -9166,6 +9190,10 @@ function renderStateWriter(queue) {
     : "unknown";
   const terminalStatus = terminalFresh
     ? "terminal telemetry fresh"
+    : terminalPending
+      ? "awaiting exact-review writer result"
+    : terminalIdle
+      ? "idle · no exact-review materialization required in the last 15m"
     : collection.last_observed_at
       ? "terminal telemetry stale · last observed " + since(collection.last_observed_at)
       : "terminal telemetry unavailable";
@@ -9197,7 +9225,7 @@ function renderStateWriter(queue) {
     "<div><dt>Latest queue sample</dt><dd>" + esc(latestCoordinatorSummary) + "</dd></div>" +
     terminalMetrics +
     "</dl>" +
-    '<p class="state-writer-note">The chart uses five-minute coordinator queue samples from the selected ' + esc(rangeLabel) + " range. Exact-review throughput appears only while its separate terminal telemetry is fresh.</p>" +
+    '<p class="state-writer-note">The chart uses five-minute coordinator queue samples from the selected ' + esc(rangeLabel) + " range. Exact-review throughput appears only while its separate terminal telemetry is fresh; all-superseded and no-work windows are idle.</p>" +
     '<p class="state-writer-note">The durable coordinator is authoritative for active and queued writers. The Git ref remains only a crash-recovery fence.</p>';
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -8611,7 +8611,23 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
     /<div class="exact-lane-head"><strong>State writer<\/strong><span>Unavailable<\/span><\/div>/,
   );
   context.renderStateWriter({
-    lanes: { publication: { batches: { enabled: true, max_items: 2 } } },
+    lanes: {
+      publication: {
+        batches: { enabled: true, max_items: 2 },
+        active: 0,
+        leased: 0,
+        dispatching: 0,
+        flow: {
+          last_15_minutes: {
+            resolved: 16,
+            published: 0,
+            superseded: 16,
+            retried: 0,
+            dead_lettered: 0,
+          },
+        },
+      },
+    },
     state_writer: {
       collection: { status: "stale", last_observed_at: "2026-07-21T12:12:42.397Z" },
       coordinator: {
@@ -8647,9 +8663,90 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.match(stateWriterHtml, /Coordinator turns<\/dt><dd>16 completed · 16 admitted/);
   assert.match(stateWriterHtml, /Coordinator wait<\/dt><dd>last 0s · max 5m/);
   assert.match(stateWriterHtml, /Queue history<\/dt><dd>collecting samples/);
-  assert.match(stateWriterHtml, /Terminal telemetry<\/dt><dd>terminal telemetry stale/);
-  assert.match(stateWriterHtml, /terminal telemetry stale/);
+  assert.match(
+    stateWriterHtml,
+    /Terminal telemetry<\/dt><dd>idle · no exact-review materialization required in the last 15m/,
+  );
+  assert.doesNotMatch(stateWriterHtml, /terminal telemetry stale/);
   assert.doesNotMatch(stateWriterHtml, /Exact-review materialized/);
+
+  context.renderStateWriter({
+    lanes: {
+      publication: {
+        batches: { enabled: true, max_items: 2, leased: 1 },
+        active: 0,
+        leased: 0,
+        dispatching: 0,
+        flow: {
+          last_15_minutes: {
+            resolved: 16,
+            published: 0,
+            superseded: 16,
+            retried: 0,
+            dead_lettered: 0,
+          },
+        },
+      },
+    },
+    state_writer: {
+      collection: { status: "stale", last_observed_at: "2026-07-21T12:12:42.397Z" },
+      coordinator: {
+        queued: 2,
+        leased: 1,
+        admitted: 16,
+        completed: 16,
+        expired: 0,
+        recovered: 0,
+        last_wait_ms: 0,
+        max_wait_ms: 300_309,
+      },
+      global_lease: { status: "free" },
+      last_60_minutes: { materialized_items: 0, state_commits: 0 },
+      mode: "batch",
+    },
+  });
+  assert.match(
+    elementFor("state-writer-health").innerHTML,
+    /Terminal telemetry<\/dt><dd>awaiting exact-review writer result/,
+  );
+  assert.doesNotMatch(elementFor("state-writer-health").innerHTML, /terminal telemetry stale/);
+
+  context.renderStateWriter({
+    lanes: {
+      publication: {
+        batches: { enabled: true, max_items: 2 },
+        flow: {
+          last_15_minutes: {
+            resolved: 1,
+            published: 1,
+            superseded: 0,
+            retried: 0,
+            dead_lettered: 0,
+          },
+        },
+      },
+    },
+    state_writer: {
+      collection: { status: "stale", last_observed_at: "2026-07-21T12:12:42.397Z" },
+      coordinator: {
+        queued: 0,
+        leased: 0,
+        admitted: 16,
+        completed: 16,
+        expired: 0,
+        recovered: 0,
+        last_wait_ms: 0,
+        max_wait_ms: 300_309,
+      },
+      global_lease: { status: "free" },
+      last_60_minutes: { materialized_items: 0, state_commits: 0 },
+      mode: "batch",
+    },
+  });
+  assert.match(
+    elementFor("state-writer-health").innerHTML,
+    /Terminal telemetry<\/dt><dd>terminal telemetry stale/,
+  );
 
   const coordinatorSamples = [
     {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators checking the State writer panel would see stale terminal telemetry during all-superseded or no-work exact-review windows, even though the durable coordinator was healthy and no materialization was expected.

## Why This Change Was Made

The panel now combines terminal freshness with exact-review publication outcomes and active publication ownership. It reports idle when no materialization is required, awaiting writer result while an exact publication owner is active, and preserves stale when published/retried/dead-lettered outcomes indicate terminal telemetry should have arrived.

## User Impact

Operators can distinguish a healthy idle writer from a genuinely missing terminal telemetry signal without masking active exact-review publication work.

## Evidence

- Live production snapshot on July 24, 2026: 62 publication resolutions in the prior hour, all 62 superseded, with zero published, retried, or dead-lettered outcomes; coordinator remained live.
- `node_modules/.bin/tsc -p tsconfig.dashboard.json`
- `node --test test/dashboard-worker.test.ts` (182 passed)
- Autoreview clean after adding the active-publication guard.