### PR TITLE
fix(publication): restore isolated review tuples

### DIFF
--- a/src/repair/event-record-store.ts
+++ b/src/repair/event-record-store.ts
@@ -32,6 +32,13 @@ export type EventRecordPaths = {
   snapshotDecisionPacket: string;
 };
 
+export type EventRecordDirectories = {
+  items: string;
+  closed: string;
+  plans: string;
+  decisionPackets: string;
+};
+
 export type EventSnapshotApplyResult =
   | "closed"
   | "open"
@@ -69,6 +76,18 @@ export function eventRecordPaths(store: EventRecordStore): EventRecordPaths {
       "decision-packets",
       `${store.itemNumber}.json`,
     ),
+  };
+}
+
+export function eventRecordDirectories(
+  paths: EventRecordPaths,
+  root: string,
+): EventRecordDirectories {
+  return {
+    items: path.resolve(root, path.dirname(paths.itemRecord)),
+    closed: path.resolve(root, path.dirname(paths.closedRecord)),
+    plans: path.resolve(root, path.dirname(paths.planRecord)),
+    decisionPackets: path.resolve(root, path.dirname(paths.decisionPacket)),
   };
 }
 

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -8,6 +8,7 @@ import {
   applyEventSnapshotIfCurrent,
   captureEventBaseSnapshot,
   captureEventSnapshot,
+  eventRecordDirectories,
   eventSnapshotMatchesCurrent,
   type EventRecordPaths,
   resetEventSnapshot,
@@ -147,7 +148,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
   };
 
   resetEventSnapshot(recordStore);
-  captureEventBaseSnapshot(recordStore);
+  const recordPaths = captureEventBaseSnapshot(recordStore);
   fs.rmSync(options.reportPath, { force: true });
 
   runClawsweeper(options, [
@@ -159,19 +160,20 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     "--skip-reconcile",
     "--skip-dashboard",
     "--replay-closed-artifacts",
+    ...eventRecordDirectoryArgs(options, recordPaths),
   ]);
 
   // Preserve the exact artifact candidate before refreshing the state checkout.
   // A stale event must be rejected before apply-decisions can comment, label,
   // or close anything on GitHub.
-  const recordPaths = captureEventSnapshot(recordStore);
+  captureEventSnapshot(recordStore);
   hardResetToRemoteMain();
   const stateBaseCommit = captureStatePublishBaseline();
   const stateRoot = publishRoot();
   const preflightResult = applyEventSnapshotIfCurrent(
     recordPaths,
     stateRoot ? { remoteRoot: stateRoot } : {},
-    () => runApplyDecisions(options),
+    () => runApplyDecisions(options, recordPaths),
   );
   if (
     preflightResult === "remote-closed" ||
@@ -444,7 +446,7 @@ function prepareBatchMutation({
   };
 }
 
-function runApplyDecisions(options: EventOptions): void {
+function runApplyDecisions(options: EventOptions, paths: EventRecordPaths): void {
   const args = [
     "apply-decisions",
     "--target-repo",
@@ -475,8 +477,23 @@ function runApplyDecisions(options: EventOptions): void {
     "--skip-dashboard",
     "--report-path",
     options.reportPath,
+    ...eventRecordDirectoryArgs(options, paths),
   ];
   runClawsweeper(options, args);
+}
+
+function eventRecordDirectoryArgs(options: EventOptions, paths: EventRecordPaths): string[] {
+  const directories = eventRecordDirectories(paths, options.workRoot);
+  return [
+    "--items-dir",
+    directories.items,
+    "--closed-dir",
+    directories.closed,
+    "--plans-dir",
+    directories.plans,
+    "--decision-packets-dir",
+    directories.decisionPackets,
+  ];
 }
 
 function publishSnapshot({

--- a/test/repair/event-record-store.test.ts
+++ b/test/repair/event-record-store.test.ts
@@ -10,11 +10,28 @@ import {
   applyEventSnapshotIfCurrent,
   captureEventBaseSnapshot,
   captureEventSnapshot,
+  eventRecordDirectories,
   eventRecordPaths,
   eventSnapshotMatchesCurrent,
   resetEventSnapshot,
 } from "../../dist/repair/event-record-store.js";
 import { refreshSourceAfterStatePublish } from "../../dist/repair/git-publish.js";
+
+test("event record directories stay inside the isolated worker root", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-record-dirs-"));
+  const paths = eventRecordPaths({
+    targetRepo: "openclaw/clawsweeper",
+    itemNumber: "828",
+    snapshotDir: path.join(root, "snapshot"),
+  });
+
+  assert.deepEqual(eventRecordDirectories(paths, root), {
+    items: path.join(root, "records", "openclaw-clawsweeper", "items"),
+    closed: path.join(root, "records", "openclaw-clawsweeper", "closed"),
+    plans: path.join(root, "records", "openclaw-clawsweeper", "plans"),
+    decisionPackets: path.join(root, "records", "openclaw-clawsweeper", "decision-packets"),
+  });
+});
 
 test("event snapshot match follows the final tuple winner, not only its action", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -89,6 +89,14 @@ test("batch workflow uses owner-scoped mutation credentials and isolated state c
     publisherSource,
     /spawnSync\(process\.execPath, \[cli, \.\.\.args\], \{\s*cwd: options\.workRoot,/,
   );
+  assert.equal(
+    publisherSource.match(/\.\.\.eventRecordDirectoryArgs\(options, (?:recordPaths|paths)\)/g)
+      ?.length,
+    2,
+  );
+  for (const flag of ["items", "closed", "plans", "decision-packets"]) {
+    assert.match(publisherSource, new RegExp(`"--${flag}-dir"`));
+  }
   assert.doesNotMatch(publisherSource, /runStreaming\("pnpm"/);
 });
 


### PR DESCRIPTION
Related: #819

## What Problem This Solves

Fixes an issue where exact-review batch workers would supersede every generated publication as tuple-missing after worker isolation moved execution out of the shared checkout. Reviews completed, but durable GitHub verdict comments stayed as placeholders.

## Why This Change Was Made

The compiled ClawSweeper CLI still derives default record directories from its code checkout, not the worker cwd. The publisher now passes the isolated worker items, closed, plans, and decision-packet directories explicitly to both artifact apply and decision apply. State comparison and batch mutation preparation remain unchanged.

## User Impact

Completed exact reviews can publish their durable GitHub verdict comments again instead of being terminally superseded and requeued.

## Evidence

- Production batch https://github.com/openclaw/clawsweeper/actions/runs/30084385874 applied PR #828's artifact, then logged `the event produced no record tuple` and completed it as superseded.
- Live publication flow on July 24, 2026 showed 18 resolutions in 60 minutes, all 18 superseded, with zero published.
- `node_modules/.bin/tsc -p tsconfig.repair.json`
- `node --test test/repair/event-record-store.test.ts test/repair/exact-review-batch-workflow.test.ts` (28 passed)
- Autoreview clean, correctness 0.90.