### PR TITLE
fix(publication): canonicalize isolated packet paths

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -27336,6 +27336,7 @@ function applyDecisionsCommand(args: Args): void {
 
 function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudget): void {
   repoFromArgs(args);
+  const recordRoot = resolve(stringArg(args.record_root, ROOT));
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
   const plansDir = resolve(stringArg(args.plans_dir, defaultPlansDir()));
@@ -27444,7 +27445,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       markdown: nextMarkdown,
       reportPath,
       packetsDir: decisionPacketsDir,
-      repoRoot: ROOT,
+      repoRoot: recordRoot,
       subjectState,
     }).markdown;
   const writeReportMarkdown = (
@@ -31128,6 +31129,7 @@ function botProofCommand(args: Args): void {
 function applyArtifactsCommand(args: Args): void {
   repoFromArgs(args);
   const artifactDir = resolve(stringArg(args.artifact_dir, "artifacts"));
+  const recordRoot = resolve(stringArg(args.record_root, ROOT));
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
   const plansDir = resolve(stringArg(args.plans_dir, defaultPlansDir()));
@@ -31342,7 +31344,7 @@ function applyArtifactsCommand(args: Args): void {
           markdown,
           reportPath,
           packetsDir: decisionPacketsDir,
-          repoRoot: ROOT,
+          repoRoot: recordRoot,
           subjectState: destination === "closed" ? "closed" : "open",
         }).markdown;
         activePublication.markdown = syncedMarkdown;

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -485,6 +485,8 @@ function runApplyDecisions(options: EventOptions, paths: EventRecordPaths): void
 function eventRecordDirectoryArgs(options: EventOptions, paths: EventRecordPaths): string[] {
   const directories = eventRecordDirectories(paths, options.workRoot);
   return [
+    "--record-root",
+    options.workRoot,
     "--items-dir",
     directories.items,
     "--closed-dir",

--- a/test/decision-packets.test.ts
+++ b/test/decision-packets.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -177,6 +178,54 @@ test("decision packet sync writes pointers and removes stale generated state", (
     assert.equal(existsSync(first.packetPath), false);
     assert.match(second.markdown, /^decision_packet_path: none$/m);
     assert.match(second.markdown, /^decision_packet_sha256: none$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-artifacts anchors packet pointers to an explicit record root", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const artifactDir = join(root, "artifacts");
+    const recordRoot = join(root, "worker");
+    const recordDir = join(recordRoot, "records", "openclaw-clawsweeper");
+    const itemsDir = join(recordDir, "items");
+    const closedDir = join(recordDir, "closed");
+    const plansDir = join(recordDir, "plans");
+    const packetsDir = join(recordDir, "decision-packets");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "321.md"),
+      decisionReport({ maintainer_decision: JSON.stringify(productDecision) }),
+      "utf8",
+    );
+
+    execFileSync(process.execPath, [
+      "dist/clawsweeper.js",
+      "apply-artifacts",
+      "--target-repo",
+      "openclaw/clawsweeper",
+      "--artifact-dir",
+      artifactDir,
+      "--record-root",
+      recordRoot,
+      "--items-dir",
+      itemsDir,
+      "--closed-dir",
+      closedDir,
+      "--plans-dir",
+      plansDir,
+      "--decision-packets-dir",
+      packetsDir,
+      "--replay-closed-artifacts",
+      "--skip-reconcile",
+    ]);
+
+    assert.match(
+      readFileSync(join(itemsDir, "321.md"), "utf8"),
+      /^decision_packet_path: records\/openclaw-clawsweeper\/decision-packets\/321\.json$/m,
+    );
+    assert.ok(existsSync(join(packetsDir, "321.json")));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -97,6 +97,7 @@ test("batch workflow uses owner-scoped mutation credentials and isolated state c
   for (const flag of ["items", "closed", "plans", "decision-packets"]) {
     assert.match(publisherSource, new RegExp(`"--${flag}-dir"`));
   }
+  assert.match(publisherSource, /"--record-root",\s*options\.workRoot/);
   assert.doesNotMatch(publisherSource, /runStreaming\("pnpm"/);
 });
 


### PR DESCRIPTION
Related: #829

## What Problem This Solves

Fixes an issue where exact-review batch publication would retry a generated review after artifact application because its decision-packet pointer included the isolated worker filesystem prefix instead of the canonical `records/...` path.

## Why This Change Was Made

The shared CLI checkout and isolated record workspace now have an explicit internal `--record-root` boundary. Both artifact and decision application use that root when serializing decision-packet references, while normal commands retain the repository root default.

## User Impact

Completed exact reviews with maintainer decision packets can pass tuple validation and continue to durable GitHub publication instead of being returned to the queue.

## Evidence

- Production repro: https://github.com/openclaw/clawsweeper/actions/runs/30085956306 logged `Invalid record tuple openclaw-openclaw/113302: local points to unexpected packet path .artifacts/exact-review-batch/workers/.../records/openclaw-openclaw/decision-packets/113302.json`.
- `node_modules/.bin/tsc -p tsconfig.json`
- `node_modules/.bin/tsc -p tsconfig.repair.json`
- `node --test test/decision-packets.test.ts test/repair/exact-review-batch-workflow.test.ts` (16 passed)
- targeted `oxfmt --check` and `git diff --check`
- autoreview clean, no accepted/actionable findings

No changelog entry: `CHANGELOG.md` is release-owned.