### PR TITLE
fix(publication): ratchet new review revisions above the publication head

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1146,8 +1146,12 @@ jobs:
               --header "x-clawsweeper-exact-review-signature: $signature" \
               --data "$payload" \
               "$queue_url/internal/exact-review/enqueue")" &&
-              jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
+              jq -e '.ok == true and (.queued == true or (.deduped == true and .superseded != true))' <<< "$response" >/dev/null; then
               exit 0
+            fi
+            if jq -e '.superseded == true' <<< "${response:-}" >/dev/null 2>&1; then
+              echo "::error::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was rejected as superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the verdict was not delivered."
+              exit 1
             fi
             if [ "$attempt" -lt 3 ]; then
               sleep "$((attempt * 5))"

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1055,7 +1055,7 @@ export class ExactReviewQueue {
             key,
             decision,
             state: "pending",
-            revision: 1,
+            revision: this.nextExactReviewItemRevisionSync(key),
             createdAt: now,
             updatedAt: now,
             nextAttemptAt: exactReviewQueueDebouncedAttemptAt(state, decision, now, now, this.env),
@@ -2403,7 +2403,7 @@ export class ExactReviewQueue {
           key: recovery.key,
           decision: recovery.decision,
           state: "pending",
-          revision: 1,
+          revision: this.nextExactReviewItemRevisionSync(recovery.key),
           createdAt: now,
           updatedAt: now,
           nextAttemptAt: exactReviewQueueDebouncedAttemptAt(
@@ -3606,6 +3606,10 @@ export class ExactReviewQueue {
       ),
     )[0] as { source_revision?: number } | undefined;
     return Number(row?.source_revision || 0);
+  }
+
+  private nextExactReviewItemRevisionSync(itemKey: string): number {
+    return this.publicationHeadRevisionSync(itemKey.toLowerCase()) + 1;
   }
 
   private recordPublicationHeadSync(targetKey: string, sourceRevision: number, now: number) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -6651,6 +6651,154 @@ test("exact-review dead letters expose diagnostics and recover fresh reviews in 
   assert.equal(resolved.dead_letters[0].fresh_recovery.reason, "fresh_review_already_active");
 });
 
+test("a later exact-review cycle still publishes after an earlier cycle raised the publication head", async () => {
+  const storage = new MemoryDurableStorage();
+  const published = leasedExactReviewPublicationItem(864, "8640");
+  published.decision.publication.leaseRevision = 2;
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [published.key]: published },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const completed = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: published.leaseId,
+        item_key: published.key,
+        lease_revision: published.leaseRevision,
+        claim_generation: published.claimGeneration,
+        run_id: published.claimedRunId,
+        run_attempt: published.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "published",
+        reason_code: "publication_applied",
+      }),
+    }),
+  );
+  assert.deepEqual(await completed.json(), { ok: true, requeued: false });
+  const drained = (await storage.get("exact-review-queue")) as {
+    items: Record<string, unknown>;
+  };
+  assert.deepEqual(Object.keys(drained.items), []);
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest("cycle-b-review", 864, "opened", "issue", "openclaw/openclaw"),
+      )
+    ).status,
+    202,
+  );
+  const reopened = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { revision: number }>;
+  };
+
+  const republished = await (
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "cycle-b-publish",
+        864,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/openclaw",
+        exactReviewPublicationOverrides(
+          864,
+          "8641",
+          "opened",
+          reopened.items["openclaw/openclaw#864"].revision,
+          "openclaw/openclaw",
+        ),
+      ),
+    )
+  ).json();
+  assert.equal(republished.queued, true);
+  assert.equal(republished.deduped, undefined);
+  assert.equal(republished.superseded, undefined);
+  assert.equal(republished.item_key, "openclaw/openclaw#864@publish:8641:1");
+  assert.equal(reopened.items["openclaw/openclaw#864"].revision, 3);
+});
+
+test("dead-letter fresh recovery seeds a review revision that can still publish", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(866, "8660");
+  item.decision.publication.leaseRevision = 2;
+  item.attempts = 2;
+  Object.assign(item, { publicationFailureAttempts: 2 });
+  item.firstFailureAt = Date.now() - 6 * 60_000;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const completed = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        completion_kind: "permanent_failure",
+        reason_code: "invalid_artifact",
+        error_fingerprint: "sha256:recovery-ratchet",
+      }),
+    }),
+  );
+  assert.deepEqual(await completed.json(), { ok: true, requeued: false });
+
+  const listed = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/dead-letters/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 10 }),
+      }),
+    )
+  ).json();
+  assert.deepEqual(
+    await (
+      await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/dead-letters/recover-fresh", {
+          method: "POST",
+          body: JSON.stringify({
+            ids: [listed.dead_letters[0].dead_letter_id],
+            idempotency_key: "operator:866:v1",
+          }),
+        }),
+      )
+    ).json(),
+    { ok: true, recovered: 1, deduped: 0, skipped: 0, unparked: 0 },
+  );
+
+  const recovered = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { revision: number }>;
+  };
+  assert.equal(recovered.items["openclaw/openclaw#866"].revision, 3);
+
+  const republished = await (
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "recovery-publish",
+        866,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/openclaw",
+        exactReviewPublicationOverrides(
+          866,
+          "8661",
+          "artifact_retention_recovery",
+          recovered.items["openclaw/openclaw#866"].revision,
+          "openclaw/openclaw",
+        ),
+      ),
+    )
+  ).json();
+  assert.equal(republished.queued, true);
+  assert.equal(republished.superseded, undefined);
+});
+
 test("exact-review fresh recovery preserves failed-shard review-only behavior", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(794, "7940");
@@ -13357,9 +13505,11 @@ function exactReviewPublicationOverrides(
   itemNumber: number,
   producerRunId: string,
   producerSourceAction = "opened",
+  leaseRevision = 1,
+  targetRepo = "openclaw/gogcli",
 ) {
   const producerDecision = {
-    targetRepo: "openclaw/gogcli",
+    targetRepo,
     targetBranch: "main",
     itemNumber,
     itemKind: "issue",
@@ -13373,9 +13523,9 @@ function exactReviewPublicationOverrides(
       producerRunId,
       producerRunAttempt: 1,
       sourceSha: "a".repeat(40),
-      itemKey: `openclaw/gogcli#${itemNumber}`,
+      itemKey: `${targetRepo}#${itemNumber}`,
       protocolVersion: 2,
-      leaseRevision: 1,
+      leaseRevision,
       claimGeneration: 1,
       liveProceeded: true,
       liveTerminalNoop: false,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -450,7 +450,10 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.equal(upload.uses, "actions/upload-artifact@v7");
   assert.equal(upload.with?.["retention-days"], 90);
   assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
-  assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
+  assert.match(
+    queuePublication.run ?? "",
+    /\.queued == true or \(\.deduped == true and \.superseded != true\)/,
+  );
   assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
   assert.match(deferHeldReview.run ?? "", /retry deferred/);
@@ -2758,4 +2761,24 @@ test("github activity workflow scopes cancellation to matching item activity", (
     /group: github-activity-\$\{\{ github\.event_name \}\}-\$\{\{ github\.run_id \}\}/,
   );
   assert.doesNotMatch(concurrencyBlock, /workflow-run' \|\| 'activity'/);
+});
+
+test("exact review publication enqueue rejects a superseded acknowledgement", () => {
+  type WorkflowStep = { name?: string; id?: string; run?: string };
+  type WorkflowJob = { steps: WorkflowStep[] };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, WorkflowJob>;
+  };
+  const publicationEnqueue = workflow.jobs["event-review-apply"]?.steps.find(
+    (candidate) => candidate.id === "queue-exact-review-publication",
+  );
+  assert.ok(publicationEnqueue, "missing queue-exact-review-publication step");
+  const run = publicationEnqueue.run ?? "";
+  assert.match(
+    run,
+    /\.ok == true and \(\.queued == true or \(\.deduped == true and \.superseded != true\)\)/,
+  );
+  assert.doesNotMatch(run, /\.ok == true and \(\.queued == true or \.deduped == true\)/);
+  assert.match(run, /jq -e '\.superseded == true'/);
+  assert.match(run, /the verdict was not delivered/);
 });


### PR DESCRIPTION
## Summary

A review target that has already been reviewed once can permanently lose every later verdict. Once any earlier review cycle for `owner/repo#N` reached revision 2 or higher and published, the monotonic publication head for that target stays at that revision forever. Every later cycle creates a fresh review item that restarts at revision 1, so its publication is rejected at `/enqueue` as superseded, the publisher workflow still reports success, the queue item is deleted, and no verdict comment is ever posted. Nothing retries.

This change seeds new review items above the recorded publication head so a new cycle can never publish below the watermark left by a dead one, and stops the workflow from treating a superseded publication as a successful delivery.

## Root cause

`exact_review_publication_heads` stores a monotonic max `source_revision` per target key. `exactReviewPublicationRevision` derives that key from `publication.itemKey`, which is the review item key `owner/repo#N`, and derives the value from `publication.leaseRevision`, which dispatch sets to `item.leaseRevision = item.revision`.

The key is stable across the life of the target. The value is a per-cycle counter that resets:

- a successful review completion deletes the queue item;
- the next enqueue for that target recreates it at `revision: 1`;
- there is no delete, prune, TTL, or reset anywhere for `exact_review_publication_heads`. Its only writers are the enqueue path and `backfillPublicationHeadsSync`, both MAX-monotonic.

So the comparison in the `/enqueue` publication path

```ts
if (incomingPublicationRevision.sourceRevision < newestSourceRevision) {
  return { deduped: true, superseded: true, ... };
}
```

compares a fresh cycle's revision 1 against a watermark left by a previous cycle, and drops the verdict.

`.github/workflows/sweep.yml` then accepted `deduped == true` unconditionally, so the drop was invisible: green job, item deleted by `/complete`, no comment, no retry. It is sticky, because every later cycle also starts at revision 1.

Precondition, stated honestly: the defect needs some earlier cycle for that target to have reached revision 2 or higher. Revision is bumped by any additional source event while the item is queued or in flight, which includes a `synchronize` webhook, a `/review` command, and an in-progress supersession. A target reviewed exactly once, on the first try, with no follow-up event never trips it.

One caller triggers it deterministically: `recoverDeadLettersFresh`, the operator escape hatch for dead-lettered publications, explicitly recreates the recovery review item at `revision: 1`. Whenever the original cycle had exceeded revision 1, the recovered review is guaranteed to produce a dropped publication, which is exactly the situation where an operator is trying to get a lost verdict delivered.

## Fix

1. `dashboard/exact-review-queue.ts`: new review items are seeded from the recorded head instead of a hardcoded `1`, via `nextExactReviewItemRevisionSync(itemKey)` which returns `publicationHeadRevisionSync(itemKey.toLowerCase()) + 1`. Applied at the `/enqueue` creation path and at `recoverDeadLettersFresh`. No schema change: the head table is already keyed by exactly the review item key, and `CHECK (source_revision >= 1)` still holds because the seed is at least 1. Publication item keys carry an `@publish:` suffix, never have a head row, and therefore still start at 1.

2. `.github/workflows/sweep.yml`: the publication enqueue step no longer accepts a superseded acknowledgement as success. The predicate becomes `.ok == true and (.queued == true or (.deduped == true and .superseded != true))`, and a superseded response fails the step immediately with the revision numbers the queue already returns, rather than burning the remaining retries on a deterministic rejection. The response has always carried `superseded`, `publication_revision`, and `superseded_by_revision`; the workflow simply ignored them.

Both changes are needed. Change 1 makes the queue stop rejecting live verdicts, and it is the only one that fixes the existing behavior. Change 2 does not fix any case on its own, and by itself would only turn today's silent drop into a red job. It is included because an undelivered verdict must never be reported as a delivered one, whatever the future cause: a target with no head row still legitimately starts at revision 1, and the remaining supersession paths stay reachable.

## Why this is the right boundary

Seeding at creation is the smallest change that makes the watermark comparison mean the same thing in every cycle. The alternative shapes are worse:

- Deleting or resetting head rows on review completion would break the within-lifetime protection the table exists for, namely rejecting a late publication from a producer run whose review was already superseded.
- Making the comparison lifetime-aware would require new persisted identity per cycle and a schema migration for a bug that a seed value fixes.

Existing supersession behavior is deliberately untouched. `test/exact-review-publication-batches.test.ts` still asserts that a stale publication at revision 1 arriving after revision 2 is acknowledged with `deduped: true, superseded: true, publication_revision: 1, superseded_by_revision: 2`. That is the correct within-lifetime outcome and it still passes. Batch admission at `excludedItemKeys` and the `readyCandidates` filter compares the same watermark against the same publication revisions, so both sides move together and neither changes behavior.

Rollout note: an item that is already queued at revision 1 under a head of 2 at deploy time keeps its stored revision, so that single in-flight publication can still be rejected once. It now fails the publisher step visibly instead of reporting success, and the next enqueue for that target is seeded correctly.

Two other enqueue predicates in the workflow use looser expressions: the source-drift recovery enqueue and the dead-letter recovery enqueue. Both are left alone. They enqueue review decisions, not publications, and the queue only returns `superseded` on the publication revision path, so those responses can never carry the field. Widening them would grow the diff without changing any outcome.

One instance of the same seed is knowingly not changed: `refreshExactReviewPublicationItem`, the artifact-refresh recovery, also creates a review item at `revision: 1`. It is a module-level function with no handle on durable storage, and threading a watermark lookup through its three call sites would enlarge this diff well beyond the defect. With change 2 in place that path can no longer fail silently: a dropped publication now fails the publisher step visibly instead of reporting success. It is worth a separate follow-up.

## Verification

- `pnpm run build:dashboard`, `pnpm run lint:dashboard`, `pnpm run format`: clean.
- `pnpm run test:unit`: 1533 tests, 1530 pass, 1 skipped, 2 failures. Both failures are load-sensitive timing assertions unrelated to this change. `exact-review health includes the oldest refreshing row beyond operator page bounds` fails identically on unpatched `main` on this machine, and `apply-decisions yields instead of starting a post-close delay that cannot fit` passes in isolation on this branch, taking 7.4s alone against 22s inside the full concurrent run. Targeted reruns: `test/dashboard-worker.test.ts` 184 tests, `test/exact-review-publication-batches.test.ts` with the dead-letter and health operator suites 54 tests, `test/sweep-workflow.test.ts` 71 tests, all green.
- New regression coverage:
  - `a later exact-review cycle still publishes after an earlier cycle raised the publication head`: an earlier cycle publishes at revision 2 and completes, the item is deleted, a new cycle enqueues, and the new cycle's publication must be queued rather than superseded. Without the fix this fails with `republished.queued` undefined.
  - `dead-letter fresh recovery seeds a review revision that can still publish`: an operator recovery of a dead-lettered publication produces a review item whose publication is accepted. Without the fix this fails at revision 1 against a head of 2.
  - `exact review publication enqueue rejects a superseded acknowledgement` in `test/sweep-workflow.test.ts`, asserting the tightened predicate and the absence of the old one.

## Real behavior proof

Behavior addressed: a review target whose earlier cycle reached revision 2 silently loses the verdict of every later review cycle, because the fresh cycle restarts at revision 1 and its publication is rejected as superseded by a watermark the dead cycle left behind.

Real environment tested: the real `ExactReviewQueue` Durable Object, imported from `dashboard/exact-review-queue.ts` and driven over real `Request` objects against a `node:sqlite` in-memory SQL storage backend, with the GitHub App token and `repository_dispatch` endpoints served by a local stub so dispatch, claim, and completion all run their production code paths. Node 24.18.0. The unpatched tree is a separate pristine checkout of `main` at 6284161cdc; the patched tree is this branch. The same driver file runs against both.

Exact steps or command run after this patch: `node /tmp/pr2-proof-driver.mjs <tree>` replaying one full lifecycle per cycle for `openclaw/openclaw#108703`. Cycle A: enqueue the review, enqueue a second source event so the item reaches revision 2, dispatch it through the alarm, claim the lease, enqueue the publication artifact, complete the review, then dispatch, claim, and complete the publication so the verdict comment is delivered and both items leave the queue. Cycle B: enqueue the same target again as a new review, dispatch, claim, and enqueue that cycle's publication artifact. The driver prints the queue response payload at each step, the surviving queue items, and whether the publication enqueue satisfies the workflow acceptance predicate.

Evidence after fix:

BEFORE, pristine main 6284161cdc:

```
[cycle A publication head rows]
[
  {
    "target_key": "openclaw/openclaw#108703",
    "source_revision": 2
  }
]

[queue items after cycle A completes (verdict comment posted)]
[]

===== CYCLE B (new review cycle, days later) =====

[cycle B fresh review item seed revision]
{
  "item_key": "openclaw/openclaw#108703",
  "revision": 1
}

[cycle B dispatch claim tuple]
{
  "protocol_version": 2,
  "item_key": "openclaw/openclaw#108703",
  "lease_revision": 1
}

[cycle B publication enqueue response]
{
  "ok": true,
  "deduped": true,
  "item_key": "openclaw/openclaw#108703@publish:9002:1",
  "superseded": true,
  "publication_revision": 1,
  "superseded_by_revision": 2
}

[cycle B sweep.yml acceptance predicate]
{
  "currentPredicate": true,
  "tightenedPredicate": false
}

[cycle B verdict delivery outcome]
{
  "publication_item_queued": false,
  "queue_items": [
    "openclaw/openclaw#108703"
  ],
  "verdict_comment_will_be_posted": false
}
```

AFTER, this branch:

```
[cycle A publication head rows]
[
  {
    "target_key": "openclaw/openclaw#108703",
    "source_revision": 2
  }
]

[queue items after cycle A completes (verdict comment posted)]
[]

===== CYCLE B (new review cycle, days later) =====

[cycle B fresh review item seed revision]
{
  "item_key": "openclaw/openclaw#108703",
  "revision": 3
}

[cycle B dispatch claim tuple]
{
  "protocol_version": 2,
  "item_key": "openclaw/openclaw#108703",
  "lease_revision": 3
}

[cycle B publication enqueue response]
{
  "ok": true,
  "queued": true,
  "item_key": "openclaw/openclaw#108703@publish:9002:1",
  "superseded_publications": 0
}

[cycle B sweep.yml acceptance predicate]
{
  "currentPredicate": true,
  "tightenedPredicate": true
}

[cycle B verdict delivery outcome]
{
  "publication_item_queued": true,
  "queue_items": [
    "openclaw/openclaw#108703",
    "openclaw/openclaw#108703@publish:9002:1"
  ],
  "verdict_comment_will_be_posted": true
}
```

Observed result after fix: on unpatched main the second cycle's review item is recreated at revision 1, dispatches with `lease_revision: 1`, and its publication is answered `deduped: true, superseded: true, superseded_by_revision: 2`. No publication item enters the queue, so the verdict comment is never posted, and the old workflow predicate still evaluates true, which is why the job stayed green. On this branch the same second cycle is seeded at revision 3, dispatches with `lease_revision: 3`, and the publication is answered `queued: true` with the publication item `openclaw/openclaw#108703@publish:9002:1` present in the queue, so the verdict is delivered. Cycle A is byte-identical between the two runs, including the head row at revision 2, which confirms the change alters only the cross-cycle outcome.

What was not tested: no run against the deployed Cloudflare Durable Object or a live GitHub repository. The GitHub App token mint and `repository_dispatch` calls are served by a local stub, so real GitHub API behavior, real network retries, and the actual posted comment are out of scope. The tightened workflow predicate is asserted against the workflow YAML and exercised by evaluating the same expression against the real queue response in the driver, not by running the job on GitHub Actions. The narrow race where a producer is superseded after its review finishes but before its publication enqueue will now fail that step instead of passing silently; that path is not reproduced here.
