### PR TITLE
fix(review-placeholder): rank recovery discovery before the check budget

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -211,6 +211,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_WRITE_TOKEN: ${{ steps.target-write-token.outputs.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          REVIEW_PLACEHOLDER_BACKLOG_ALERT: ${{ vars.REVIEW_PLACEHOLDER_BACKLOG_ALERT || '480' }}
+          REVIEW_PLACEHOLDER_LOOKBACK_HOURS: ${{ vars.REVIEW_PLACEHOLDER_LOOKBACK_HOURS || '48' }}
           REVIEW_PLACEHOLDER_MAX_CHECKS: ${{ vars.REVIEW_PLACEHOLDER_MAX_CHECKS || '20' }}
           REVIEW_PLACEHOLDER_MAX_RECOVERIES: ${{ vars.REVIEW_PLACEHOLDER_MAX_RECOVERIES || '5' }}
           REVIEW_PLACEHOLDER_MIN_AGE_HOURS: ${{ vars.REVIEW_PLACEHOLDER_MIN_AGE_HOURS || '2' }}

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -9,12 +9,13 @@ export const DEFAULT_REVIEW_PLACEHOLDER_MIN_AGE_HOURS = 2;
 export const DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES = 5;
 export const DEFAULT_REVIEW_PLACEHOLDER_STUCK_HOURS = 12;
 export const REVIEW_PLACEHOLDER_STUCK_LABEL = "clawsweeper-recovery-stuck";
-export const REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
+export const DEFAULT_REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
+export const DEFAULT_REVIEW_PLACEHOLDER_BACKLOG_ALERT = 480;
 
 const SEARCH_PAGE_SIZE = 100;
 const SEARCH_MAX_PAGES = 2;
 const COMMENT_PAGE_SIZE = 100;
-const COMMENT_MAX_PAGES = 2;
+const COMMENT_MAX_PAGES = 5;
 const CLAWSWEEPER_BOT_LOGINS = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
 
 export type ReviewPlaceholderComment = {
@@ -29,6 +30,7 @@ export type ReviewPlaceholderCandidate = {
   number?: unknown;
   pull_request?: unknown;
   labels?: unknown;
+  updated_at?: unknown;
 };
 
 export type ReviewPlaceholderRecoverySummary = {
@@ -38,6 +40,8 @@ export type ReviewPlaceholderRecoverySummary = {
   cleaned: number;
   escalated: number;
   errors: number;
+  matched: number;
+  remaining: number;
 };
 
 // The scheduled sweep should go red only when placeholders needed resolution
@@ -46,10 +50,14 @@ export type ReviewPlaceholderRecoverySummary = {
 // Escalation labels are visibility, not resolution, so they never count.
 export function reviewPlaceholderRecoveryFailureReason(
   summary: ReviewPlaceholderRecoverySummary,
+  backlogAlert: number = DEFAULT_REVIEW_PLACEHOLDER_BACKLOG_ALERT,
 ): string | null {
   const resolved = summary.enqueued + summary.cleaned;
   if (summary.orphaned > 0 && summary.errors > 0 && resolved === 0) {
     return "orphaned placeholders remain and every recovery action failed";
+  }
+  if (backlogAlert > 0 && summary.remaining >= backlogAlert) {
+    return `${summary.remaining} matching placeholders were left unexamined (backlog alert threshold ${backlogAlert})`;
   }
   return null;
 }
@@ -91,17 +99,36 @@ export function isClawSweeperBotComment(comment: ReviewPlaceholderComment): bool
   return type === "bot" && CLAWSWEEPER_BOT_LOGINS.has(login);
 }
 
-export function latestClawSweeperBotComment(
+export function reviewStartStatusMarker(number: number): string {
+  return `<!-- clawsweeper-review-status:started item=${number} `;
+}
+
+export function selectReviewPlaceholderComment(
+  number: number,
   comments: readonly ReviewPlaceholderComment[],
 ): ReviewPlaceholderComment | null {
+  const marker = reviewStartStatusMarker(number);
+  const botComments = comments.filter(
+    (comment) => isClawSweeperBotComment(comment) && typeof comment.body === "string",
+  );
+  const markerMatches = botComments.filter((comment) => String(comment.body).includes(marker));
+  const pool =
+    markerMatches.length > 0
+      ? markerMatches
+      : botComments.filter((comment) => String(comment.body).includes(REVIEW_PLACEHOLDER_MARKER));
   let latest: { comment: ReviewPlaceholderComment; createdAtMs: number } | null = null;
-  for (const comment of comments) {
-    if (!isClawSweeperBotComment(comment)) continue;
+  for (const comment of pool) {
     const createdAtMs = commentCreatedAtMs(comment);
     if (createdAtMs === null) continue;
     if (!latest || createdAtMs > latest.createdAtMs) latest = { comment, createdAtMs };
   }
   return latest?.comment ?? null;
+}
+
+function candidateUpdatedAtMs(candidate: ReviewPlaceholderCandidate): number {
+  const parsed =
+    typeof candidate.updated_at === "string" ? Date.parse(candidate.updated_at) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 
 function candidateLabelNames(candidate: ReviewPlaceholderCandidate): string[] {
@@ -178,18 +205,25 @@ export async function runReviewPlaceholderRecovery(
     60 *
     60 *
     1_000;
+  const lookbackHours = boundedPositiveInteger(
+    env.REVIEW_PLACEHOLDER_LOOKBACK_HOURS,
+    DEFAULT_REVIEW_PLACEHOLDER_LOOKBACK_HOURS,
+    24 * 365,
+  );
   let checked = 0;
   let orphaned = 0;
   let enqueued = 0;
   let cleaned = 0;
   let escalated = 0;
   let errors = 0;
+  let matched = 0;
 
   const summary = (): ReviewPlaceholderRecoverySummary => {
+    const remaining = Math.max(0, matched - checked);
     console.log(
-      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} cleaned=${cleaned} escalated=${escalated} errors=${errors}`,
+      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} cleaned=${cleaned} escalated=${escalated} errors=${errors} matched=${matched} remaining=${remaining}`,
     );
-    return { checked, orphaned, enqueued, cleaned, escalated, errors };
+    return { checked, orphaned, enqueued, cleaned, escalated, errors, matched, remaining };
   };
   if (
     !token ||
@@ -297,7 +331,7 @@ export async function runReviewPlaceholderRecovery(
     if (
       !isClawSweeperBotComment(current) ||
       typeof current.body !== "string" ||
-      !current.body.includes(`<!-- clawsweeper-review-status:started item=${number} `) ||
+      !current.body.includes(reviewStartStatusMarker(number)) ||
       // A refresh bumps updated_at, so a placeholder re-claimed by an active
       // run drops back under the orphan age and must not be deleted.
       !isOrphanedReviewPlaceholder(current, now, minimumAgeHours)
@@ -324,9 +358,10 @@ export async function runReviewPlaceholderRecovery(
     }
     return "deleted";
   };
-  const fetchLatestBotComment = async (
+  const fetchPlaceholderComment = async (
     number: number,
   ): Promise<ReviewPlaceholderComment | null> => {
+    const marker = reviewStartStatusMarker(number);
     const comments: ReviewPlaceholderComment[] = [];
     for (let page = 1; page <= COMMENT_MAX_PAGES; page += 1) {
       const pageComments = await github<ReviewPlaceholderComment[]>(
@@ -334,34 +369,60 @@ export async function runReviewPlaceholderRecovery(
       );
       comments.push(...pageComments);
       if (pageComments.length < COMMENT_PAGE_SIZE) break;
+      if (
+        pageComments.some(
+          (comment) => typeof comment.body === "string" && comment.body.includes(marker),
+        )
+      ) {
+        break;
+      }
     }
-    return latestClawSweeperBotComment(comments);
+    return selectReviewPlaceholderComment(number, comments);
   };
 
   const candidates = new Map<number, { candidate: ReviewPlaceholderCandidate; closed: boolean }>();
-  const updatedSince = new Date(
-    now.getTime() - REVIEW_PLACEHOLDER_LOOKBACK_HOURS * 60 * 60 * 1_000,
-  ).toISOString();
+  const updatedSince = new Date(now.getTime() - lookbackHours * 60 * 60 * 1_000).toISOString();
   // Each state class gets its own check budget; sharing one would let a
   // backlog of open placeholders permanently starve closed-item cleanup.
   const searchCandidates = async (stateQualifier: "is:open" | "is:closed"): Promise<void> => {
     const query = `repo:${repo} "${REVIEW_PLACEHOLDER_MARKER}" in:comments updated:>=${updatedSince} ${stateQualifier}`;
-    let added = 0;
-    for (let page = 1; page <= SEARCH_MAX_PAGES && added < maximumChecks; page += 1) {
-      const result = await github<{ items?: unknown }>(
-        `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=desc&per_page=${SEARCH_PAGE_SIZE}&page=${page}`,
+    const found: ReviewPlaceholderCandidate[] = [];
+    let total = 0;
+    for (let page = 1; page <= SEARCH_MAX_PAGES && found.length < maximumChecks; page += 1) {
+      const result = await github<{ items?: unknown; total_count?: unknown }>(
+        `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=${SEARCH_PAGE_SIZE}&page=${page}`,
       );
       const items = Array.isArray(result.items) ? result.items : [];
+      if (page === 1 && typeof result.total_count === "number") {
+        total = Number.isFinite(result.total_count)
+          ? Math.max(0, Math.trunc(result.total_count))
+          : 0;
+      }
       for (const value of items) {
         if (!value || typeof value !== "object" || Array.isArray(value)) continue;
-        const candidate = value as ReviewPlaceholderCandidate;
-        const number = Number(candidate.number);
-        if (!Number.isInteger(number) || number <= 0 || candidates.has(number)) continue;
-        candidates.set(number, { candidate, closed: stateQualifier === "is:closed" });
-        added += 1;
-        if (added >= maximumChecks) break;
+        found.push(value as ReviewPlaceholderCandidate);
       }
       if (items.length < SEARCH_PAGE_SIZE) break;
+    }
+    matched += Math.max(total, found.length);
+    const ranked = found.map((candidate, index) => ({
+      candidate,
+      index,
+      updatedAtMs: candidateUpdatedAtMs(candidate),
+    }));
+    ranked.sort((a, b) =>
+      a.updatedAtMs === b.updatedAtMs ? a.index - b.index : a.updatedAtMs - b.updatedAtMs,
+    );
+    let added = 0;
+    for (const entry of ranked) {
+      if (added >= maximumChecks) break;
+      const number = Number(entry.candidate.number);
+      if (!Number.isInteger(number) || number <= 0 || candidates.has(number)) continue;
+      candidates.set(number, {
+        candidate: entry.candidate,
+        closed: stateQualifier === "is:closed",
+      });
+      added += 1;
     }
   };
   for (const stateQualifier of ["is:open", "is:closed"] as const) {
@@ -383,7 +444,7 @@ export async function runReviewPlaceholderRecovery(
   for (const [number, { candidate, closed }] of candidates) {
     checked += 1;
     try {
-      const comment = await fetchLatestBotComment(number);
+      const comment = await fetchPlaceholderComment(number);
       if (!comment || !isOrphanedReviewPlaceholder(comment, now, minimumAgeHours)) continue;
       orphaned += 1;
       if (closed) {
@@ -461,7 +522,14 @@ const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
   try {
     const summary = await runReviewPlaceholderRecovery();
-    const failureReason = reviewPlaceholderRecoveryFailureReason(summary);
+    const failureReason = reviewPlaceholderRecoveryFailureReason(
+      summary,
+      boundedPositiveInteger(
+        process.env.REVIEW_PLACEHOLDER_BACKLOG_ALERT,
+        DEFAULT_REVIEW_PLACEHOLDER_BACKLOG_ALERT,
+        1_000_000,
+      ),
+    );
     if (failureReason) {
       console.error(`review-placeholder recovery failed: ${failureReason}`);
       process.exitCode = 1;

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -4,10 +4,10 @@ import test from "node:test";
 
 import {
   isOrphanedReviewPlaceholder,
-  latestClawSweeperBotComment,
   REVIEW_PLACEHOLDER_MARKER,
   reviewPlaceholderRecoveryFailureReason,
   runReviewPlaceholderRecovery,
+  selectReviewPlaceholderComment,
 } from "../dist/review-placeholder-recovery.js";
 
 const now = new Date("2026-07-17T12:00:00.000Z");
@@ -53,26 +53,38 @@ test("review placeholder orphan detection requires the bot marker and minimum ag
   );
 });
 
-test("review placeholder detection considers only the latest ClawSweeper bot comment", () => {
-  const latest = latestClawSweeperBotComment([
-    {
-      body: REVIEW_PLACEHOLDER_MARKER,
-      created_at: "2026-07-17T08:00:00.000Z",
-      user: bot,
-    },
-    {
-      body: "ClawSweeper review: keep open.",
-      created_at: "2026-07-17T09:00:00.000Z",
-      user: bot,
-    },
-    {
-      body: REVIEW_PLACEHOLDER_MARKER,
-      created_at: "2026-07-17T11:00:00.000Z",
-      user: { login: "someone-else", type: "User" },
-    },
-  ]);
-  assert.equal(latest?.body, "ClawSweeper review: keep open.");
-  assert.equal(isOrphanedReviewPlaceholder(latest, now, 2), false);
+test("review placeholder selection matches the status marker, not the newest bot comment", () => {
+  const placeholder = {
+    id: 11,
+    body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=42 sha=abc v=1 -->`,
+    created_at: "2026-07-17T06:00:00.000Z",
+    updated_at: "2026-07-17T06:00:00.000Z",
+    user: bot,
+  };
+  const editedVerdict = {
+    id: 12,
+    body: "ClawSweeper review: keep open.\n\n<!-- clawsweeper-review item=42 v=1 -->",
+    created_at: "2026-07-16T16:00:00.000Z",
+    updated_at: "2026-07-17T11:50:00.000Z",
+    user: bot,
+  };
+  const selected = selectReviewPlaceholderComment(42, [editedVerdict, placeholder]);
+  assert.equal(selected?.id, 11);
+  assert.equal(isOrphanedReviewPlaceholder(selected, now, 2), true);
+  assert.equal(
+    selectReviewPlaceholderComment(42, [
+      editedVerdict,
+      { ...placeholder, id: 13, body: REVIEW_PLACEHOLDER_MARKER },
+    ])?.id,
+    13,
+  );
+  assert.equal(selectReviewPlaceholderComment(42, [editedVerdict]), null);
+  assert.equal(
+    selectReviewPlaceholderComment(42, [
+      { ...placeholder, id: 14, user: { login: "someone-else", type: "User" } },
+    ]),
+    null,
+  );
 });
 
 test("review placeholder runner fails open and sends a signed exact-review decision", async (t) => {
@@ -167,6 +179,8 @@ test("review placeholder runner fails open and sends a signed exact-review decis
     cleaned: 0,
     escalated: 0,
     errors: 1,
+    matched: 4,
+    remaining: 1,
   });
   assert.ok(logged.includes("review-placeholder recovery: enqueued #103 (pull_request)"));
   assert.deepEqual(commentChecks, [101, 102, 103]);
@@ -239,6 +253,8 @@ test("review placeholder runner fills the recovery cap with the oldest orphans f
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    matched: 4,
+    remaining: 2,
   });
   assert.deepEqual(commentChecks, [201, 202]);
   assert.deepEqual(enqueuedNumbers, [202]);
@@ -309,6 +325,8 @@ test("review placeholder runner escalates orphans stuck well beyond the minimum 
     cleaned: 0,
     escalated: 1,
     errors: 0,
+    matched: 4,
+    remaining: 2,
   });
   assert.deepEqual(escalatedLabels, [
     { number: 301, body: { labels: ["clawsweeper-recovery-stuck"] } },
@@ -361,6 +379,8 @@ test("stuck escalation without a target write token is a visible error, not a wr
     cleaned: 0,
     escalated: 0,
     errors: 1,
+    matched: 2,
+    remaining: 1,
   });
   assert.equal(labelRequests, 0);
 });
@@ -432,6 +452,8 @@ test("orphaned placeholders on closed items are deleted instead of re-enqueued",
     cleaned: 1,
     escalated: 0,
     errors: 0,
+    matched: 1,
+    remaining: 0,
   });
   assert.deepEqual(deletedComments, ["/repos/openclaw/openclaw/issues/comments/9001"]);
 });
@@ -481,6 +503,8 @@ test("closed-item cleanup without a target write token is a visible error", asyn
     cleaned: 0,
     escalated: 0,
     errors: 1,
+    matched: 1,
+    remaining: 0,
   });
   assert.equal(deleteRequests, 0);
 });
@@ -546,6 +570,8 @@ test("closed-item cleanup revalidates and skips a placeholder that became a real
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    matched: 1,
+    remaining: 0,
   });
   assert.equal(deleteRequests, 0);
 });
@@ -610,6 +636,8 @@ test("locked closed items are terminal skips, not retrying cleanup errors", asyn
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    matched: 1,
+    remaining: 0,
   });
   assert.equal(deleteRequests, 1);
 });
@@ -684,11 +712,13 @@ test("closed cleanup keeps its own check budget when open placeholders fill the 
     cleaned: 1,
     escalated: 0,
     errors: 0,
+    matched: 2,
+    remaining: 0,
   });
   assert.deepEqual(deletedComments, ["/repos/openclaw/openclaw/issues/comments/9502"]);
 });
 
-test("recovery failure reason fires only on total action failure", () => {
+test("recovery failure reason fires on total action failure and on an undrainable backlog", () => {
   assert.equal(
     reviewPlaceholderRecoveryFailureReason({
       checked: 5,
@@ -697,6 +727,8 @@ test("recovery failure reason fires only on total action failure", () => {
       cleaned: 0,
       escalated: 0,
       errors: 2,
+      matched: 5,
+      remaining: 0,
     }),
     "orphaned placeholders remain and every recovery action failed",
   );
@@ -708,6 +740,8 @@ test("recovery failure reason fires only on total action failure", () => {
       cleaned: 0,
       escalated: 0,
       errors: 1,
+      matched: 5,
+      remaining: 0,
     }),
     null,
   );
@@ -719,6 +753,8 @@ test("recovery failure reason fires only on total action failure", () => {
       cleaned: 0,
       escalated: 0,
       errors: 1,
+      matched: 5,
+      remaining: 0,
     }),
     null,
   );
@@ -730,8 +766,245 @@ test("recovery failure reason fires only on total action failure", () => {
       cleaned: 0,
       escalated: 1,
       errors: 2,
+      matched: 5,
+      remaining: 0,
     }),
     "orphaned placeholders remain and every recovery action failed",
+  );
+  const backlogged = {
+    checked: 40,
+    orphaned: 1,
+    enqueued: 1,
+    cleaned: 0,
+    escalated: 0,
+    errors: 0,
+    matched: 1_240,
+    remaining: 1_200,
+  };
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason(backlogged),
+    "1200 matching placeholders were left unexamined (backlog alert threshold 480)",
+  );
+  assert.equal(reviewPlaceholderRecoveryFailureReason(backlogged, 1_201), null);
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason({ ...backlogged, matched: 60, remaining: 20 }),
+    null,
+  );
+});
+
+test("discovery ranks the whole search page before it applies the check budget", async () => {
+  const commentChecks: number[] = [];
+  const searchOrders: string[] = [];
+  const enqueuedNumbers: number[] = [];
+  const createdAtByNumber: Record<number, string> = {
+    603: "2026-07-16T02:00:00.000Z",
+    604: "2026-07-15T22:00:00.000Z",
+  };
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      searchOrders.push(url.searchParams.get("order") ?? "");
+      assert.match(query, /updated:>=2026-07-14T12:00:00\.000Z/);
+      if (query.includes("is:closed")) return Response.json({ total_count: 0, items: [] });
+      return Response.json({
+        total_count: 4,
+        items: [
+          { number: 601, updated_at: "2026-07-17T11:40:00.000Z" },
+          { number: 602, updated_at: "2026-07-17T11:20:00.000Z" },
+          { number: 603, updated_at: "2026-07-16T02:00:00.000Z" },
+          { number: 604, updated_at: "2026-07-15T22:00:00.000Z" },
+        ],
+      });
+    }
+    const commentMatch = url.pathname.match(/\/issues\/(\d+)\/comments$/);
+    if (commentMatch) {
+      const number = Number(commentMatch[1]);
+      commentChecks.push(number);
+      const createdAt = createdAtByNumber[number];
+      assert.ok(createdAt, `unexpected comment fetch for #${number}`);
+      return Response.json([
+        {
+          id: 7000 + number,
+          body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=${number} sha=abc v=1 -->`,
+          created_at: createdAt,
+          updated_at: createdAt,
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { decision: { itemNumber: number } };
+      enqueuedNumbers.push(body.decision.itemNumber);
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+      REVIEW_PLACEHOLDER_MAX_CHECKS: "2",
+      REVIEW_PLACEHOLDER_LOOKBACK_HOURS: "72",
+      REVIEW_PLACEHOLDER_STUCK_HOURS: "720",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 2,
+    orphaned: 2,
+    enqueued: 2,
+    cleaned: 0,
+    escalated: 0,
+    errors: 0,
+    matched: 4,
+    remaining: 2,
+  });
+  assert.deepEqual(searchOrders, ["asc", "asc"]);
+  assert.deepEqual(commentChecks, [604, 603]);
+  assert.deepEqual(enqueuedNumbers, [604, 603]);
+});
+
+test("an edited durable verdict no longer masks the marker-tagged placeholder", async () => {
+  const enqueuedNumbers: number[] = [];
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ total_count: 0, items: [] });
+      return Response.json({
+        total_count: 1,
+        items: [{ number: 611, updated_at: "2026-07-17T11:50:00.000Z" }],
+      });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/611/comments") {
+      return Response.json([
+        {
+          id: 6111,
+          body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=611 sha=abc v=1 -->`,
+          created_at: "2026-07-17T06:00:00.000Z",
+          updated_at: "2026-07-17T06:00:00.000Z",
+          user: bot,
+        },
+        {
+          id: 6112,
+          body: "ClawSweeper review: keep open.\n\n<!-- clawsweeper-review item=611 v=1 -->",
+          created_at: "2026-07-16T16:00:00.000Z",
+          updated_at: "2026-07-17T11:50:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { decision: { itemNumber: number } };
+      enqueuedNumbers.push(body.decision.itemNumber);
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 1,
+    orphaned: 1,
+    enqueued: 1,
+    cleaned: 0,
+    escalated: 0,
+    errors: 0,
+    matched: 1,
+    remaining: 0,
+  });
+  assert.deepEqual(enqueuedNumbers, [611]);
+});
+
+test("a backlog the sweep cannot examine is reported and fails the run", async (t) => {
+  const logged: string[] = [];
+  t.mock.method(console, "log", (...parts: unknown[]) => {
+    logged.push(parts.join(" "));
+  });
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ total_count: 0, items: [] });
+      return Response.json({
+        total_count: 900,
+        items: [{ number: 621, updated_at: "2026-07-17T05:00:00.000Z" }],
+      });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/621/comments") {
+      return Response.json([
+        {
+          id: 6211,
+          body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=621 sha=abc v=1 -->`,
+          created_at: "2026-07-17T05:00:00.000Z",
+          updated_at: "2026-07-17T05:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const summary = await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "test-token-placeholder",
+      CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+      REVIEW_PLACEHOLDER_MAX_CHECKS: "1",
+    },
+    fetchImpl: mockFetch as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(summary, {
+    checked: 1,
+    orphaned: 1,
+    enqueued: 1,
+    cleaned: 0,
+    escalated: 0,
+    errors: 0,
+    matched: 900,
+    remaining: 899,
+  });
+  assert.ok(
+    logged.some((line) => line.includes("matched=900 remaining=899")),
+    "summary line reports the discovery backlog",
+  );
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason(summary),
+    "899 matching placeholders were left unexamined (backlog alert threshold 480)",
   );
 });
 


### PR DESCRIPTION
## Summary

The review-placeholder recovery sweep is the only backstop for the "ClawSweeper status: review started." comments that ClawSweeper posts on every lease acquisition and never edits. Right now that backstop cannot see most of what it is supposed to clean up: openclaw/openclaw currently carries roughly 1,200 stranded placeholders across 586 open pull requests, 616 open issues, and 3,288 closed items, and a sample of 60 recently reviewed pull requests turned up exactly one leftover placeholder on every single one.

This PR fixes three independent defects in `src/review-placeholder-recovery.ts`:

- discovery applied the check budget before any ranking, so only the newest 20 matches were ever reachable;
- placeholder detection looked at a single comment per item, so an edited durable verdict hid the placeholder permanently;
- the job failure predicate could not fire on the shape the sweep actually produces, so a standing backlog reported success every 15 minutes.

## Root cause

**Discovery truncated before it ranked.** `searchCandidates` queried `/search/issues` with `sort=updated&order=desc` and broke out of the item loop at `added >= maximumChecks` (default 20). The oldest-first ordering landed by #816 (`orphanedCandidates.sort((a, b) => a.createdAtMs - b.createdAtMs)`) runs later and only over the survivors of that truncation. #816 moved the `enqueued >= maximumRecoveries` break out of the inspection loop and fixed the recoveries budget of 5; it did not touch discovery. Because the break happened in the middle of page 1, `SEARCH_MAX_PAGES = 2` was dead at default settings and the oldest stranded placeholders were structurally unreachable.

**Only one comment per item was inspected.** `fetchLatestBotComment` returned `latestClawSweeperBotComment(comments)`, which picks the single newest ClawSweeper comment ranked by `commentCreatedAtMs`, that is `max(created_at, updated_at)`. `upsertReviewComment` PATCHes the durable verdict comment in place, so a verdict written before the placeholder and edited after it outranks the placeholder forever. The item still consumed a check slot (`checked += 1` runs before inspection) and was then dropped.

**The failure predicate never fired.** `reviewPlaceholderRecoveryFailureReason` required `orphaned > 0 && errors > 0 && enqueued + cleaned === 0`, a three-way AND. The dominant real shape is orphaned small, errors zero, at least one enqueue, which returns null. The summary also had no input describing truncation or backlog: `checked` was never consulted, and the `total_count` that every `/search/issues` response already returns was discarded.

## Fix

- `searchCandidates` now queries `order=asc`, accumulates whole pages in the `ghPagedLimit` loop shape (`page <= SEARCH_MAX_PAGES && found.length < maximumChecks`, no mid-page break), ranks the accumulated candidates by item `updated_at` ascending with a stable index tiebreak, and only then fills the per-state check budget. Each state class keeps its own budget as before.
- `selectReviewPlaceholderComment(number, comments)` replaces `latestClawSweeperBotComment`. It matches bot comments on the machine marker `<!-- clawsweeper-review-status:started item=N ` (the same string `deletePlaceholderComment` already gates on, now shared through `reviewStartStatusMarker`), mirroring `selectDedicatedReviewStartLeaseComments`. Marker matches win; the placeholder sentence remains a fallback for comments written before the marker existed. This also removes the `max(created_at, updated_at)` promotion hazard, because the pool no longer contains the durable verdict.
- Comment paging goes from 2 to 5 pages with an early exit as soon as a page contains the marker, so a long thread no longer puts the placeholder out of reach while normal threads still cost one request.
- `ReviewPlaceholderRecoverySummary` gains `matched` (the `total_count` the search already returned) and `remaining` (`max(0, matched - checked)`), both printed on the existing summary line. `reviewPlaceholderRecoveryFailureReason` takes an optional threshold and fails the run when `remaining` reaches it. The default of 480 is one full day of best-case drain: 96 sweeps per day at `DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES` of 5. A remainder above that cannot be worked off by the cadence at all.
- `REVIEW_PLACEHOLDER_LOOKBACK_HOURS` now goes through the existing `boundedPositiveInteger` helper (default unchanged at 48 hours, ceiling one year) and is exposed in `.github/workflows/exact-review-reconcile.yml` together with `REVIEW_PLACEHOLDER_BACKLOG_ALERT`, so both can be widened by repository variable without a code change.

`matched` counts search matches rather than confirmed orphans, so it is an upper bound: an item whose placeholder was already removed can linger in the search index. That is the correct direction for an alert threshold, and `orphaned` remains the precise number.

## Why this is the right boundary

The placeholder design itself is untouched. A fresh comment per lease acquisition is deliberate (`src/clawsweeper.ts:21501`), and the durable verdict is a separate comment maintained by `upsertReviewComment`. Making the placeholder promise literally true would mean changing how leases publish, which is a much larger change with review-delivery risk. This PR repairs only the backstop that is supposed to converge the difference, and it does so without new state: no cursor, no schema, no extra API surface beyond a response field that was already being fetched and thrown away.

The request budget barely moves. Discovery still issues one search request per state class at default settings, and inspection still visits at most `maximumChecks` items per class. Comment paging only reaches past its first page on threads longer than 100 comments where the marker has not been seen yet, which is the exact case the old two-page ceiling could not resolve.

## Out of scope

- Editing the placeholder in place, or removing the public promise in its body. That is a lease-publication decision, not a recovery bug.
- Draining the pre-2026-07-22 backlog. About 524 open items carrying the marker sit outside the 48 hour lookback and stay invisible even after this PR. Reaching them properly needs date-window partitioning around the 1000-result pagination ceiling on `/search/issues`, which in turn needs resumable sweep state so consecutive runs advance through the windows instead of restarting at the same one. This repository has no such cursor to reuse: `src/review-activity-cursor.ts` is specific to GraphQL connection cursors for a single item's activity and does not generalize to a repository-wide date-partitioned scan. Building that belongs in its own change with its own proof, so this PR only makes the window operator-tunable and makes the resulting backlog visible instead of silent.
- The `cleanupSupersededReviewPlaceholderComments` call sites in `src/clawsweeper.ts`. They are unchanged.

## Verification

- `pnpm run build`
- `pnpm run test:unit`
- `pnpm run format`
- `pnpm run lint:src`

`test/review-placeholder-recovery.test.ts` goes from 12 to 16 cases. Nine summary assertions were extended with the two new fields. Two cases were rewritten because they encoded the defects being fixed: the one asserting that detection considers only the latest bot comment now asserts marker-based selection in the presence of an edited newer verdict, and the failure-reason case now covers the backlog branch as well as the total-action-failure branch. Three cases were added: rank-before-truncate (an item outside the newest-20 window is discovered and inspected first), an edited durable verdict no longer masking a marker-tagged placeholder, and the backlog signal reaching both the summary line and the failure reason. The oldest-orphans-first case from #816 and the closed-cleanup budget case are preserved unchanged apart from the new summary fields.

One pre-existing failure in `test/sweep-workflow.test.ts` ("apply workflow drops a coverage-proof tail only after exact trace examination") reproduces identically on unmodified `origin/main` at 6284161cdc and is unrelated to this change.

## Real behavior proof

Behavior addressed: the 15-minute recovery sweep could not discover stranded review placeholders outside the newest 20 search results, silently skipped any placeholder whose durable verdict comment had been edited more recently, and reported success while a large backlog of placeholders went untouched.

Real environment tested: the compiled recovery module `dist/review-placeholder-recovery.js` executed on Node 24 on Linux, at pristine `origin/main` 6284161cdc and at this branch head c890f8fa39, driven end to end through its exported `runReviewPlaceholderRecovery` entry point against GitHub REST responses reproducing the current openclaw/openclaw placeholder shape: 24 open items inside the 48 hour window (17 of the 20 newest-updated carrying a placeholder, only #906 both past the 2 hour orphan threshold and unmasked, #913 past the threshold but carrying a durable verdict edited 10 minutes ago, #922 stranded for 30 hours and sitting outside the newest-20 window) and 3,288 closed items carrying the marker.

Exact steps or command run after this patch:

```
RPR_DIST=/root/clawsweeper-audit-jul24/dist/review-placeholder-recovery.js node /tmp/pr3-proof-driver.mjs
RPR_DIST=/root/cs-pr3-placeholders/dist/review-placeholder-recovery.js node /tmp/pr3-proof-driver.mjs
```

Evidence after fix:

BEFORE (origin/main 6284161cdc):

```
review-placeholder recovery: enqueued #906 (issue)
review-placeholder recovery: checked=40 orphaned=1 enqueued=1 cleaned=0 escalated=0 errors=0
SEARCH REQUESTS: is:open order=desc page=1 | is:closed order=desc page=1
ITEMS INSPECTED (open): 901,902,903,904,905,906,907,908,909,910,911,912,913,914,915,916,917,918,919,920
ENQUEUED: 906
ESCALATED: (none)
SUMMARY OBJECT: {"checked":40,"orphaned":1,"enqueued":1,"cleaned":0,"escalated":0,"errors":0}
FAILURE REASON: (none, run reported success)
```

AFTER (this branch, head c890f8fa39):

```
review-placeholder recovery: escalated #922 as stuck after repeated orphan cycles
review-placeholder recovery: enqueued #922 (issue)
review-placeholder recovery: enqueued #913 (issue)
review-placeholder recovery: enqueued #906 (issue)
review-placeholder recovery: checked=40 orphaned=3 enqueued=3 cleaned=0 escalated=1 errors=0 matched=3312 remaining=3272
SEARCH REQUESTS: is:open order=asc page=1 | is:closed order=asc page=1
ITEMS INSPECTED (open): 924,923,922,921,920,919,918,917,916,915,914,913,912,911,910,909,908,907,906,905
ENQUEUED: 922,913,906
ESCALATED: 922
SUMMARY OBJECT: {"checked":40,"orphaned":3,"enqueued":3,"cleaned":0,"escalated":1,"errors":0,"matched":3312,"remaining":3272}
FAILURE REASON: 3272 matching placeholders were left unexamined (backlog alert threshold 480)
```

Observed result after fix: with an identical GitHub-side shape and an identical inspection budget of 20 items per state class, the run recovers 3 stranded placeholders instead of 1. #922, stranded for 30 hours and outside the newest-20 window, is discovered for the first time, recovered first because it is the oldest, and labelled `clawsweeper-recovery-stuck`. #913, whose durable verdict had been edited 10 minutes earlier, is no longer hidden behind that edit and is recovered. #906 is still recovered. The run now reports `matched=3312 remaining=3272` and returns a failure reason, so the scheduled job exits non-zero instead of reporting success while 3,272 matching placeholders sit untouched.

What was not tested: no request was issued against api.github.com, so live GitHub rate limiting, `/search/issues` secondary limits, and the real 1000-result pagination ceiling are not exercised here. The API responses were assembled to match the counts and comment layout observed on openclaw/openclaw rather than captured verbatim from a live sweep run. The workflow step exit code was observed in process through the same predicate the CLI guard uses, not by dispatching `.github/workflows/exact-review-reconcile.yml`. Draining the pre-2026-07-22 backlog outside the 48 hour lookback is deliberately not addressed, and the widened lookback was exercised only through the configuration path, not against a real multi-day window.
