### PR TITLE
fix(exact-review): bound review retries with an attempt ceiling

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -104,7 +104,7 @@ export type ExactReviewQueueItem = {
   claimProtocolVersion?: 1 | 2;
   dispatchedAt?: number;
   claimedAt?: number;
-  parkedReason?: "dead_letter_capacity" | "dispatch_rejected";
+  parkedReason?: "dead_letter_capacity" | "dispatch_rejected" | "review_retry_exhausted";
   dispatchFailureStatus?: number;
   dispatchFailureClass?: ExactReviewDispatchFailureClass;
   dispatchFailureAt?: number;
@@ -112,6 +112,7 @@ export type ExactReviewQueueItem = {
   lastFailureReason?: ExactReviewPublicationReasonCode;
   firstFailureAt?: number;
   publicationFailureAttempts?: number;
+  reviewFailureAttempts?: number;
 };
 export type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
@@ -340,6 +341,7 @@ const EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_LIMIT = 12;
 const EXACT_REVIEW_PUBLICATION_PERMANENT_RETRY_LIMIT = 3;
 const EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_LIMIT = 5;
 const EXACT_REVIEW_PUBLICATION_ARTIFACT_RETRY_LIMIT = 3;
+const EXACT_REVIEW_RETRY_LIMIT = 8;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 128;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 export const EXACT_REVIEW_RECONCILE_CONCURRENCY = 8;
@@ -1060,6 +1062,7 @@ export class ExactReviewQueue {
               clearExactReviewDispatchFailure(current);
               current.attempts = 0;
               current.publicationFailureAttempts = 0;
+              current.reviewFailureAttempts = 0;
               current.firstFailureAt = undefined;
               current.lastFailureReason = undefined;
             }
@@ -1496,7 +1499,7 @@ export class ExactReviewQueue {
               env: this.env,
             })
           : {
-              requeued: finishExactReviewQueueItem(
+              ...finishExactReviewQueueItem(
                 state,
                 item,
                 now,
@@ -1506,7 +1509,6 @@ export class ExactReviewQueue {
               ),
               retried: outcome !== "success",
               refreshed: false,
-              parked: false,
               deadLetter: undefined,
             };
       const { requeued } = completionResult;
@@ -1710,9 +1712,9 @@ export class ExactReviewQueue {
       const items = matches.map((item) => ({
         lane: exactReviewQueueLane(item),
         state: item.state,
+        parked_reason: item.parkedReason ?? null,
         revision: item.revision,
         attempts: item.attempts,
-        parked_reason: item.parkedReason || null,
         dispatch_failure_status: item.dispatchFailureStatus ?? null,
         dispatch_failure_class: item.dispatchFailureClass || null,
         dispatch_failure_at: item.dispatchFailureAt
@@ -1774,8 +1776,14 @@ export class ExactReviewQueue {
         );
         if (matches.length !== 1) continue;
         const item = matches[0];
-        const didRequeue = finishExactReviewQueueItem(state, item, now, run.outcome);
+        const { requeued: didRequeue, parked } = finishExactReviewQueueItem(
+          state,
+          item,
+          now,
+          run.outcome,
+        );
         reconciled += 1;
+        if (parked) continue;
         if (didRequeue) {
           requeued += 1;
           if (!exactReviewQueueIsPublication(item) && run.outcome !== "success") {
@@ -6544,25 +6552,37 @@ function finishExactReviewQueueItem(
   const oneShotRecovery =
     item.leaseDecision?.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION;
   const requeued = (!oneShotRecovery && retryingFailure) || hasNewerRevision || requeueLatest;
-  if (requeued) {
-    clearExactReviewLease(item);
-    item.state = "pending";
-    if (retryingFailure && !hasNewerRevision && !requeueLatest) {
-      item.attempts += 1;
-      item.nextAttemptAt = Math.max(
-        exactReviewQueueEnqueueAttemptAt(state, now),
-        now + exactReviewRetryDelayMs(item.attempts),
-        hasNewerRevision ? 0 : requestedRetryAt,
-      );
-    } else {
-      item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
-      item.attempts = 0;
-    }
-    item.updatedAt = now;
-  } else {
+  if (!requeued) {
     delete state.items[item.key];
+    return { requeued: false, parked: false };
   }
-  return requeued;
+  clearExactReviewLease(item);
+  item.state = "pending";
+  if (retryingFailure && !hasNewerRevision && !requeueLatest) {
+    item.attempts += 1;
+    if (!exactReviewQueueIsPublication(item)) {
+      const failureAttempts = Number(item.reviewFailureAttempts || 0) + 1;
+      item.reviewFailureAttempts = failureAttempts;
+      if (failureAttempts >= EXACT_REVIEW_RETRY_LIMIT) {
+        item.state = "parked";
+        item.parkedReason = "review_retry_exhausted";
+        item.updatedAt = now;
+        return { requeued: false, parked: true };
+      }
+    }
+    item.nextAttemptAt = Math.max(
+      exactReviewQueueEnqueueAttemptAt(state, now),
+      now + exactReviewRetryDelayMs(item.attempts),
+      hasNewerRevision ? 0 : requestedRetryAt,
+    );
+  } else {
+    item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+    item.attempts = 0;
+    item.reviewFailureAttempts = 0;
+    item.parkedReason = undefined;
+  }
+  item.updatedAt = now;
+  return { requeued: true, parked: false };
 }
 
 function exactReviewCompletionRetryAt(value, now: number): number | null {
@@ -6680,6 +6700,7 @@ function reclaimExpiredExactReviewLease(
   if (hasNewerRevision) {
     item.attempts = 0;
     item.publicationFailureAttempts = 0;
+    item.reviewFailureAttempts = 0;
     item.firstFailureAt = undefined;
     item.lastFailureReason = undefined;
   }
@@ -6742,6 +6763,7 @@ function refreshExactReviewPublicationItem(
     );
     current.attempts = 0;
     current.publicationFailureAttempts = 0;
+    current.reviewFailureAttempts = 0;
     current.firstFailureAt = undefined;
     current.lastFailureReason = undefined;
     return;

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5049,6 +5049,246 @@ test("exact-review queue admits at most one active item per target repository", 
   }
 });
 
+test("exact-review review retries stop at the attempt ceiling and park the item", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = new MemoryDurableStorage();
+  const dispatched: Record<string, unknown>[] = [];
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
+      return jsonResponse({ state: "active" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation")
+      return jsonResponse({ id: 999 });
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return jsonResponse({ token: "dispatch-token" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      dispatched.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  const itemKey = "openclaw/openclaw#113341";
+  try {
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
+      },
+    );
+    assert.equal(
+      (
+        await queue.fetch(
+          buildExactReviewQueueRequest(
+            "ceiling-1",
+            113_341,
+            "synchronize",
+            "pull_request",
+            "openclaw/openclaw",
+            {
+              sourceHeadSha: `956eaead7f${"0".repeat(30)}`,
+              sourceHeadVerified: true,
+              sourceAuthoritySeq: 1,
+              sourceUpdatedAt: new Date().toISOString(),
+            },
+          ),
+        )
+      ).status,
+      202,
+    );
+
+    const failOnce = async (cycle: number) => {
+      const ready = (await storage.get("exact-review-queue")) as {
+        items: Record<string, { state: string; nextAttemptAt: number }>;
+      };
+      if (ready.items[itemKey]?.state === "pending") {
+        ready.items[itemKey].nextAttemptAt = Date.now() - 1;
+        await storage.put("exact-review-queue", ready);
+      }
+      const before = dispatched.length;
+      await queue.alarm();
+      if (dispatched.length === before) return false;
+      const payload = dispatched.at(-1)?.client_payload as {
+        queue_lease_id: string;
+        queue_claim: { item_key: string; lease_revision: number };
+      };
+      const claim = await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/claim", {
+          method: "POST",
+          body: JSON.stringify({
+            lease_id: payload.queue_lease_id,
+            item_key: payload.queue_claim.item_key,
+            lease_revision: payload.queue_claim.lease_revision,
+            run_id: `90000${cycle}`,
+            run_attempt: 1,
+          }),
+        }),
+      );
+      assert.equal(claim.status, 200);
+      const claimed = (await claim.json()) as { claim_generation: number };
+      const completed = await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/complete", {
+          method: "POST",
+          body: JSON.stringify({
+            lease_id: payload.queue_lease_id,
+            item_key: payload.queue_claim.item_key,
+            lease_revision: payload.queue_claim.lease_revision,
+            claim_generation: claimed.claim_generation,
+            run_id: `90000${cycle}`,
+            run_attempt: 1,
+            outcome: "failure",
+          }),
+        }),
+      );
+      assert.equal(completed.status, 200);
+      return true;
+    };
+
+    const readItem = async () => {
+      const state = (await storage.get("exact-review-queue")) as {
+        items: Record<
+          string,
+          { state: string; attempts: number; nextAttemptAt: number; parkedReason?: string }
+        >;
+      };
+      return state.items[itemKey];
+    };
+
+    for (let cycle = 1; cycle <= 7; cycle += 1) {
+      assert.equal(await failOnce(cycle), true);
+      const item = await readItem();
+      assert.equal(item.state, "pending");
+      assert.equal(item.attempts, cycle);
+      assert.equal(item.parkedReason, undefined);
+      assert.ok(item.nextAttemptAt > Date.now());
+    }
+
+    assert.equal(await failOnce(8), true);
+    const parked = await readItem();
+    assert.equal(parked.state, "parked");
+    assert.equal(parked.attempts, 8);
+    assert.equal(parked.parkedReason, "review_retry_exhausted");
+    assert.equal(dispatched.length, 8);
+
+    for (let cycle = 9; cycle <= 11; cycle += 1) {
+      assert.equal(await failOnce(cycle), false);
+    }
+    assert.equal(dispatched.length, 8);
+    assert.equal((await readItem()).state, "parked");
+
+    const stats = (await (
+      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json()) as { lanes: { review: { parked: number; pending: number } } };
+    assert.equal(stats.lanes.review.parked, 1);
+    assert.equal(stats.lanes.review.pending, 0);
+
+    const status = (await (
+      await queue.fetch(
+        new Request(
+          "https://clawsweeper-exact-review-queue/item-status?target_repo=openclaw%2Fopenclaw&item_number=113341",
+        ),
+      )
+    ).json()) as { items: Array<{ state: string; parked_reason: string | null }> };
+    assert.deepEqual(
+      status.items.map((entry) => [entry.state, entry.parked_reason]),
+      [["parked", "review_retry_exhausted"]],
+    );
+
+    assert.equal(
+      (
+        await queue.fetch(
+          buildExactReviewQueueRequest(
+            "ceiling-rescue",
+            113_341,
+            "synchronize",
+            "pull_request",
+            "openclaw/openclaw",
+            {
+              sourceHeadSha: `1234abcd56${"0".repeat(30)}`,
+              sourceHeadVerified: true,
+              sourceAuthoritySeq: 2,
+              sourceUpdatedAt: new Date(Date.now() + 60_000).toISOString(),
+            },
+          ),
+        )
+      ).status,
+      202,
+    );
+    const rescued = await readItem();
+    assert.equal(rescued.state, "pending");
+    assert.equal(rescued.attempts, 0);
+    assert.equal(rescued.parkedReason, undefined);
+    assert.equal(await failOnce(12), true);
+    assert.equal(dispatched.length, 9);
+    const afterRescue = await readItem();
+    assert.equal(afterRescue.state, "pending");
+    assert.equal(afterRescue.attempts, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review requeue_latest and publication completions ignore the review ceiling", async () => {
+  const storage = new MemoryDurableStorage();
+  const review = leasedExactReviewQueueItem(113_342, "9130");
+  const publication = leasedExactReviewPublicationItem(113_343, "9131");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      [review.key]: { ...review, attempts: 7, reviewFailureAttempts: 7 },
+      [publication.key]: { ...publication, attempts: 40, reviewFailureAttempts: 40 },
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const completion = (item: { key: string }, runId: string, extra: Record<string, unknown>) =>
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: `lease-${item.key.split("#")[1].split("@")[0]}`,
+        item_key: item.key,
+        lease_revision: 1,
+        claim_generation: 1,
+        run_id: runId,
+        run_attempt: 1,
+        ...extra,
+      }),
+    });
+
+  assert.equal(
+    (await queue.fetch(completion(review, "9130", { outcome: "success", requeue_latest: true })))
+      .status,
+    200,
+  );
+  assert.equal(
+    (await queue.fetch(completion(publication, "9131", { outcome: "failure" }))).status,
+    200,
+  );
+
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { state: string; attempts: number; reviewFailureAttempts?: number; parkedReason?: string }
+    >;
+  };
+  assert.equal(state.items[review.key].state, "pending");
+  assert.equal(state.items[review.key].attempts, 0);
+  assert.equal(state.items[review.key].reviewFailureAttempts, 0);
+  assert.equal(state.items[review.key].parkedReason, undefined);
+  assert.equal(state.items[publication.key].state, "pending");
+  assert.equal(state.items[publication.key].attempts, 41);
+  assert.equal(state.items[publication.key].parkedReason, undefined);
+});
+
 test("exact-review queue can use the global capacity for one target", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();


### PR DESCRIPTION
## Summary

A review item in the exact-review queue has no attempt ceiling. When the same head keeps failing its review run, `finishExactReviewQueueItem` requeues it forever, so it burns one GitHub Actions run every 5 minutes with no terminal state and no operator-visible signal.

The trigger is a lost superseding delivery, not force-push in general. The normal force-push path does rescue the item: `bindLivePullRequestHeadAuthority` compares the webhook head against the live head, so the force-push's own `synchronize` delivery arrives with `sourceHeadVerified: true`, clears `exactReviewDecisionCanSupersedeReview`, bumps the revision and resets `attempts` to 0. `processSourceAuthorityReservations` re-fetches the live head for the async case. This PR is about the cases where no superseding delivery ever lands: the webhook delivery is lost, it was consumed as a mismatched "stale pull request head" 202 that never touches the queue item, or the source-authority reservation exhausts `EXACT_REVIEW_SOURCE_AUTHORITY_RETRY_LIMIT`. In those cases nothing else in the file will ever stop the item.

Observed impact on the live queue: 52 of 132 failures in a 1200-run window came from two such items. openclaw/openclaw#113341 latched a SHA that is no longer in the PR and produced 27 red dispatches in 3 hours while still sitting at revision 1.

## Root cause

`finishExactReviewQueueItem` (dashboard/exact-review-queue.ts) increments `item.attempts` on every failed completion and immediately recomputes `nextAttemptAt`. `attempts` was never compared against any limit anywhere in the file. The only `*_RETRY_LIMIT` constants are the `EXACT_REVIEW_PUBLICATION_*` set, and they are read exclusively by `exactReviewPublicationRetryExhausted`, which is reachable only from `finishExactReviewPublicationItem`.

The two compounding gaps:

- `exactReviewRetryDelayMs` caps the backoff at 5 minutes, so an item that can never succeed re-dispatches at a fixed 5 minute cadence indefinitely.
- There is no dead-letter path for review items. `exactReviewDeadLetterInsert` throws when `item.decision.publication` is absent, both of its call sites are publication-only, and the dead-letter table is publication-shaped (`producer_run_id`, `producer_run_attempt`, `artifact_name` are all NOT NULL). A review item has none of those columns to fill.

## Fix

Give the review lane the same shape the publication lane already has, with no schema change.

- `EXACT_REVIEW_RETRY_LIMIT = 8`, declared alongside the existing `EXACT_REVIEW_PUBLICATION_*` limits.
- `reviewFailureAttempts` counts only failed review completions. `item.attempts` keeps its existing meaning (it also absorbs dispatch handoff failures and drives the backoff schedule), so a repository_dispatch outage cannot park healthy work. This mirrors the publication lane's existing split between `attempts` and `publicationFailureAttempts`.
- On the eighth consecutive review failure the item is parked instead of requeued: `state: "parked"` and `parkedReason: "review_retry_exhausted"`. Both already exist; `parkedReason` was a closed union of one value and is now two. Queue items are stored as JSON blobs in `exact_review_queue_items (item_key, item_json) STRICT`, so the added optional field needs no migration.
- `finishExactReviewQueueItem` now returns `{ requeued, parked }` so `/complete` does not book a parked item as a completed review, and `/reconcile` does not book it as requeued.
- Every place that already resets `attempts` and `publicationFailureAttempts` now also resets `reviewFailureAttempts`: the enqueue merge path, expired-lease reclaim with a newer revision, and publication artifact refresh.
- `/item-status` now returns `parked_reason` so an operator inspecting a specific PR can tell a parked item apart from a backing-off one.

Why 8: the review lane has no reason-code taxonomy, so one budget has to cover every failure class. Eight failures spans the entire backoff ramp (30s, 60s, 120s, 240s, then the 5 minute cap), which is about 22 minutes of wall clock. Every transient runner or GitHub-side fault that recovers inside that window still recovers untouched. It sits between the publication lane's known-permanent limit of 3 and its known-transient limit of 12, which is the right place for a failure that is not classified either way. Against the live data, it turns openclaw/openclaw#113341 from 27 red runs in 3 hours and climbing into 8 runs total.

The 5 minute delay cap is deliberately left alone. The cost being controlled is Actions runs, and the attempt ceiling now bounds that directly. Growing the cap would only stretch the wall clock before a poison item becomes visible, while adding latency to the ordinary transient failures that recover in the first two or three attempts.

## Why this is the right boundary

The obvious alternative is to have the Durable Object re-verify the live head before dispatch. That is not reachable from here: `exactReviewDecisionFrom` is an allowlist that drops `installationId`, so a stored queue item cannot mint a target-repo token. Adding that is a larger change with its own token-scope questions and does not belong in a retry-bounding fix.

Routing review items to the dead-letter queue is also the wrong move. The DLQ table is publication-shaped with three NOT NULL columns a review item cannot fill, and `exactReviewDeadLetterInsert` throws without publication metadata. Reshaping it would mean a real migration and would change publication-lane replay semantics for no gain here. Parking reuses machinery that already exists, is already surfaced in `/stats`, and is already excluded from dispatch selection and from handoff-phase health.

Publication-lane behavior is untouched. The ceiling is gated on `!exactReviewQueueIsPublication(item)`, which matters because `/complete` falls back to `finishExactReviewQueueItem` for a publication item that arrives without a structured `publication_completion`, and `/reconcile` runs both lanes through the same function.

## Operator recovery

No new endpoint. A parked review item is unparked by the paths that already unpark one:

- Any later head-changing webhook for the PR. The enqueue merge path treats `parked` as mergeable, clears `parkedReason`, resets `attempts` and `reviewFailureAttempts` to 0, and returns the item to `pending`. This is the same supersede path that already rescues the ordinary force-push case, and the regression test asserts the ceiling does not break it.
- An explicit `@clawsweeper review` command. It binds to the current authority rather than attempting supersession, so it reaches the same merge branch and unparks the item without needing a new head.

Both are correct as the recovery: the item parked because the head it holds keeps failing review, so what it needs is a new head or an explicit human re-request, not a blind replay. Visibility is already there: `/stats` reports `lanes.review.parked`, and `/item-status` now reports `parked_reason` for a specific PR.

## Verification

- `pnpm run build:dashboard`, `pnpm run test:unit`, `pnpm run format`, `pnpm run lint:dashboard` all pass.
- New regression coverage in test/dashboard-worker.test.ts drives the real `ExactReviewQueue` Durable Object over real Requests: it dispatches through `alarm()` with the GitHub HTTP boundary stubbed, claims the lease, and completes with `outcome: "failure"`, asserting that attempts 1 through 7 requeue with growing backoff exactly as before, that the eighth parks with `review_retry_exhausted`, that no further dispatch happens, that `/stats` and `/item-status` report it, that a newer verified head unparks it and it dispatches again, and that `requeue_latest` and publication-lane completions are unaffected. Both tests fail on the base commit and pass with the patch.

## Real behavior proof

Behavior addressed: a review queue item whose review run keeps failing is dispatched forever at the 5 minute backoff cap, with no attempt ceiling, no terminal state, and no operator-visible parked reason.

Real environment tested: the real `ExactReviewQueue` Durable Object class from dashboard/worker.ts, constructed against the in-memory SQL-backed durable storage harness (node:sqlite `DatabaseSync(":memory:")`) and driven only through real `Request` objects to `/enqueue`, `/claim`, `/complete`, `/stats` and the real `alarm()` dispatch loop. GitHub is stubbed at the HTTP boundary only, so the real dispatch, lease, claim and completion code paths execute. No hand-built queue-item literals.

Exact steps or command run after this patch: enqueue one `pull_request` `synchronize` decision for openclaw/openclaw#113341 pinned to head `956eaead7f...`, then repeat 12 cycles of: force `nextAttemptAt` into the past, run `alarm()` so the queue dispatches, `POST /claim` with the dispatched lease tuple, `POST /complete` with `outcome: "failure"`, and print `state`, `attempts`, `nextAttemptAt` and `parkedReason`. The identical driver was run against pristine main at 6284161cdc and against this branch.

Evidence after fix:

BEFORE (pristine main 6284161cdc):

```
enqueue: HTTP 202
cycle  1 dispatched=1 state=pending attempts=1 nextAttemptAt=+30s parkedReason=none
cycle  2 dispatched=1 state=pending attempts=2 nextAttemptAt=+60s parkedReason=none
cycle  3 dispatched=1 state=pending attempts=3 nextAttemptAt=+120s parkedReason=none
cycle  4 dispatched=1 state=pending attempts=4 nextAttemptAt=+240s parkedReason=none
cycle  5 dispatched=1 state=pending attempts=5 nextAttemptAt=+300s parkedReason=none
cycle  6 dispatched=1 state=pending attempts=6 nextAttemptAt=+300s parkedReason=none
cycle  7 dispatched=1 state=pending attempts=7 nextAttemptAt=+300s parkedReason=none
cycle  8 dispatched=1 state=pending attempts=8 nextAttemptAt=+300s parkedReason=none
cycle  9 dispatched=1 state=pending attempts=9 nextAttemptAt=+300s parkedReason=none
cycle 10 dispatched=1 state=pending attempts=10 nextAttemptAt=+300s parkedReason=none
cycle 11 dispatched=1 state=pending attempts=11 nextAttemptAt=+300s parkedReason=none
cycle 12 dispatched=1 state=pending attempts=12 nextAttemptAt=+300s parkedReason=none
total dispatches: 12
final: state=pending attempts=12 parkedReason=none
```

AFTER (this branch):

```
enqueue: HTTP 202
cycle  1 dispatched=1 state=pending attempts=1 nextAttemptAt=+30s parkedReason=none
cycle  2 dispatched=1 state=pending attempts=2 nextAttemptAt=+60s parkedReason=none
cycle  3 dispatched=1 state=pending attempts=3 nextAttemptAt=+120s parkedReason=none
cycle  4 dispatched=1 state=pending attempts=4 nextAttemptAt=+240s parkedReason=none
cycle  5 dispatched=1 state=pending attempts=5 nextAttemptAt=+300s parkedReason=none
cycle  6 dispatched=1 state=pending attempts=6 nextAttemptAt=+300s parkedReason=none
cycle  7 dispatched=1 state=pending attempts=7 nextAttemptAt=+300s parkedReason=none
cycle  8 dispatched=1 state=parked attempts=8 nextAttemptAt=+0s parkedReason=review_retry_exhausted
cycle  9 dispatched=0 state=parked attempts=8 nextAttemptAt=+0s parkedReason=review_retry_exhausted
cycle 10 dispatched=0 state=parked attempts=8 nextAttemptAt=+0s parkedReason=review_retry_exhausted
cycle 11 dispatched=0 state=parked attempts=8 nextAttemptAt=+0s parkedReason=review_retry_exhausted
cycle 12 dispatched=0 state=parked attempts=8 nextAttemptAt=+0s parkedReason=review_retry_exhausted
total dispatches: 8
final: state=parked attempts=8 parkedReason=review_retry_exhausted
```

Observed result after fix: attempts 1 through 7 are byte-for-byte identical to main, including the 30s, 60s, 120s, 240s, 300s backoff ramp, so nothing below the ceiling changed. On the eighth failure the item flips to `parked` with `parkedReason: review_retry_exhausted`, and cycles 9 through 12 dispatch nothing at all. Twelve cycles that produced twelve dispatches on main now produce eight. Enqueuing a later verified head after the item is parked returns it to `pending` with `attempts` back to 0 and dispatches it again, so the supersede rescue still works on a parked item.

What was not tested: no deployment to a live Cloudflare Durable Object and no real GitHub Actions run. The GitHub App token, workflow-status and `repository_dispatch` calls are stubbed at the `fetch` boundary, so no real repository_dispatch was sent and the runner-side `reserveReviewLeaseCommand` head comparison in src/clawsweeper.ts was not exercised end to end. The live openclaw/openclaw#113341 item was not replayed against production, and the 8-attempt value has not been validated against a full production window.
