### PR TITLE
revert: stale PR-head supersession (#842)

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -296,13 +296,11 @@ type StateAppendWindowRow = {
   delivery_id: string;
 };
 type ExactReviewSupersessionAudit = {
-  auditId: string;
   itemKey: string;
   priorRevision: number;
   nextRevision: number;
   supersededRunId: string | null;
   sourceAction: string;
-  reasonCode: "newer_source_event" | "live_head_advanced";
   supersededAt: number;
 };
 export type DurableObjectStub = { fetch: (request: Request) => Promise<Response> };
@@ -1036,13 +1034,11 @@ export class ExactReviewQueue {
               const priorRevision = current.revision;
               supersededRunId = current.claimedRunId || null;
               supersessionAudit = {
-                auditId: crypto.randomUUID(),
                 itemKey: key,
                 priorRevision,
                 nextRevision: priorRevision + 1,
                 supersededRunId,
                 sourceAction: decision.sourceAction,
-                reasonCode: "newer_source_event",
                 supersededAt: now,
               };
               clearExactReviewLease(current);
@@ -2247,7 +2243,7 @@ export class ExactReviewQueue {
             `exact-review admission target check failed for ${candidate.key}`,
             error instanceof Error ? error.message : String(error),
           );
-          return { ...candidate, state: { state: "unavailable" as const }, failure };
+          return { ...candidate, state: "unavailable" as const, failure };
         }
       },
     );
@@ -2261,18 +2257,11 @@ export class ExactReviewQueue {
     );
     let globalAdmissionFailure: ExactReviewDispatchFailure | null = null;
     for (const candidate of liveStates) {
-      if (
-        candidate.state.state !== "unavailable" ||
-        !("failure" in candidate) ||
-        candidate.failure.scope !== "global"
-      ) {
-        continue;
-      }
+      if (candidate.state !== "unavailable" || candidate.failure.scope !== "global") continue;
       globalAdmissionFailure = candidate.failure;
       break;
     }
     let terminalCompleted = 0;
-    const supersessionAudits: ExactReviewSupersessionAudit[] = [];
     for (const candidate of liveStates) {
       const item = checkedState.items[candidate.key];
       if (
@@ -2283,45 +2272,12 @@ export class ExactReviewQueue {
       ) {
         continue;
       }
-      if (candidate.state.state === "terminal" && !exactReviewQueueHasCommandContext(item)) {
+      if (candidate.state === "terminal" && !exactReviewQueueHasCommandContext(item)) {
         delete checkedState.items[item.key];
         terminalCompleted += 1;
         continue;
       }
-      if (exactReviewQueueHasStaleLiveHead(item, candidate.state)) {
-        const audit: ExactReviewSupersessionAudit = {
-          auditId: crypto.randomUUID(),
-          itemKey: item.key,
-          priorRevision: item.revision,
-          nextRevision: item.revision + 1,
-          supersededRunId: null,
-          sourceAction: item.decision.sourceAction,
-          reasonCode: "live_head_advanced",
-          supersededAt: checkedAt,
-        };
-        if (exactReviewQueueHasCommandContext(item)) {
-          // A command/status receipt is independently meaningful. Advance it to
-          // the authoritative current head rather than dispatching its stale
-          // source tuple or dropping the acknowledgement lifecycle.
-          item.decision = exactReviewDecisionAtLiveHead(item.decision, candidate.state.headSha);
-          item.revision += 1;
-          item.updatedAt = checkedAt;
-          item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(checkedState, checkedAt);
-          item.parkedReason = undefined;
-          item.attempts = 0;
-          item.publicationFailureAttempts = 0;
-          item.reviewFailureAttempts = 0;
-          item.firstFailureAt = undefined;
-          item.lastFailureReason = undefined;
-          clearExactReviewDispatchFailure(item);
-        } else {
-          delete checkedState.items[item.key];
-          terminalCompleted += 1;
-        }
-        supersessionAudits.push(audit);
-        continue;
-      }
-      if (candidate.state.state === "unavailable") {
+      if (candidate.state === "unavailable") {
         // A shared GitHub or credential failure must not consume each item's
         // retry budget. The dispatcher backoff below holds the whole admission
         // pass until that dependency recovers.
@@ -2362,12 +2318,7 @@ export class ExactReviewQueue {
       };
       await this.writeState(
         checkedState,
-        terminalCompleted || supersessionAudits.length
-          ? { reviewCompleted: terminalCompleted, reviewSuperseded: supersessionAudits.length }
-          : undefined,
-        undefined,
-        undefined,
-        supersessionAudits,
+        terminalCompleted ? { reviewCompleted: terminalCompleted } : undefined,
       );
       await this.scheduleNext(checkedState, checkedAt);
       return;
@@ -2380,8 +2331,8 @@ export class ExactReviewQueue {
       // A command acknowledgement needs the workflow's terminal completion
       // path even when the target is already closed. Unprobed reviews wait for
       // a later bounded admission pass instead of bypassing the live check.
-      return live?.state.state === "open" ||
-        (live?.state.state === "terminal" && exactReviewQueueHasCommandContext(item))
+      return live?.state === "open" ||
+        (live?.state === "terminal" && exactReviewQueueHasCommandContext(item))
         ? [item]
         : [];
     });
@@ -2426,12 +2377,7 @@ export class ExactReviewQueue {
     }
     await this.writeState(
       checkedState,
-      terminalCompleted || supersessionAudits.length
-        ? { reviewCompleted: terminalCompleted, reviewSuperseded: supersessionAudits.length }
-        : undefined,
-      undefined,
-      undefined,
-      supersessionAudits,
+      terminalCompleted ? { reviewCompleted: terminalCompleted } : undefined,
     );
     if (!dispatchable.length) {
       await this.scheduleNext(checkedState, checkedAt);
@@ -4269,64 +4215,15 @@ export class ExactReviewQueue {
     );
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE} (
-         audit_id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
          item_key TEXT NOT NULL,
          prior_revision INTEGER NOT NULL CHECK (prior_revision >= 1),
          next_revision INTEGER NOT NULL CHECK (next_revision > prior_revision),
          superseded_run_id TEXT,
          source_action TEXT NOT NULL,
-         reason_code TEXT NOT NULL DEFAULT 'newer_source_event',
-         superseded_at INTEGER NOT NULL
-        ) STRICT`,
+         superseded_at INTEGER NOT NULL,
+         PRIMARY KEY (item_key, prior_revision, next_revision)
+       ) STRICT`,
     );
-    const hasSupersessionAuditId = Array.from(
-      this.storage.sql.exec(
-        `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}')
-          WHERE name = 'audit_id'`,
-      ),
-    ).length;
-    const hasSupersessionReason = Array.from(
-      this.storage.sql.exec(
-        `SELECT name FROM pragma_table_info('${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}')
-          WHERE name = 'reason_code'`,
-      ),
-    ).length;
-    if (!hasSupersessionReason) {
-      this.storage.sql.exec(
-        `ALTER TABLE ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}
-           ADD COLUMN reason_code TEXT NOT NULL DEFAULT 'newer_source_event'`,
-      );
-    }
-    if (!hasSupersessionAuditId) {
-      const replacement = `${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}_replacement`;
-      this.storage.transactionSync(() => {
-        this.storage.sql.exec(
-          `CREATE TABLE ${replacement} (
-             audit_id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
-             item_key TEXT NOT NULL,
-             prior_revision INTEGER NOT NULL CHECK (prior_revision >= 1),
-             next_revision INTEGER NOT NULL CHECK (next_revision > prior_revision),
-             superseded_run_id TEXT,
-             source_action TEXT NOT NULL,
-             reason_code TEXT NOT NULL DEFAULT 'newer_source_event',
-             superseded_at INTEGER NOT NULL
-           ) STRICT`,
-        );
-        this.storage.sql.exec(
-          `INSERT INTO ${replacement}
-             (audit_id, item_key, prior_revision, next_revision, superseded_run_id,
-              source_action, reason_code, superseded_at)
-           SELECT printf('legacy:%s:%d:%d', item_key, prior_revision, next_revision),
-                  item_key, prior_revision, next_revision, superseded_run_id,
-                  source_action, reason_code, superseded_at
-             FROM ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}`,
-        );
-        this.storage.sql.exec(`DROP TABLE ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}`);
-        this.storage.sql.exec(
-          `ALTER TABLE ${replacement} RENAME TO ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}`,
-        );
-      });
-    }
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS exact_review_queue_supersessions_at
          ON ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE} (superseded_at, item_key)`,
@@ -4807,14 +4704,12 @@ export class ExactReviewQueue {
     metricDelta: ExactReviewQueueMetricDelta = {},
     publicationFeedback?: ExactReviewPublicationFeedback,
     deadLetter?: ExactReviewDeadLetterInsert,
-    supersessionAudits: ExactReviewSupersessionAudit[] = [],
   ) {
     this.storage.transactionSync(() => {
       this.writeStateSync(state);
       this.incrementQueueMetricsSync(metricDelta);
       if (publicationFeedback) this.applyPublicationFeedbackSync(publicationFeedback);
       if (deadLetter) this.insertDeadLetterSync(deadLetter);
-      for (const audit of supersessionAudits) this.insertSupersessionAuditSync(audit);
     });
   }
 
@@ -5109,16 +5004,14 @@ export class ExactReviewQueue {
   private insertSupersessionAuditSync(audit: ExactReviewSupersessionAudit) {
     this.storage.sql.exec(
       `INSERT OR IGNORE INTO ${EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE}
-          (audit_id, item_key, prior_revision, next_revision, superseded_run_id,
-           source_action, reason_code, superseded_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      audit.auditId,
+         (item_key, prior_revision, next_revision, superseded_run_id,
+          source_action, superseded_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
       audit.itemKey,
       audit.priorRevision,
       audit.nextRevision,
       audit.supersededRunId,
       audit.sourceAction,
-      audit.reasonCode,
       audit.supersededAt,
     );
   }
@@ -6358,28 +6251,6 @@ function mergePendingExactReviewDecision(
     delete merged.statusCommentId;
   }
   return merged;
-}
-
-function exactReviewDecisionAtLiveHead(decision: ExactReviewDecision, headSha: string) {
-  const refreshed = {
-    ...decision,
-    sourceHeadSha: headSha,
-    sourceHeadVerified: true,
-  };
-  // The live read is authoritative for the head, but it has no webhook
-  // sequence or event timestamp to truthfully carry forward.
-  delete refreshed.sourceAuthoritySeq;
-  delete refreshed.sourceUpdatedAt;
-  return refreshed;
-}
-
-function exactReviewQueueHasStaleLiveHead(
-  item: Pick<ExactReviewQueueItem, "decision">,
-  live: ExactReviewTargetItemState,
-): live is { state: "open"; headSha: string } {
-  if (item.decision.itemKind !== "pull_request" || live.state !== "open") return false;
-  const queuedHead = String(item.decision.sourceHeadSha || "").toLowerCase();
-  return /^[0-9a-f]{40}$/.test(queuedHead) && queuedHead !== live.headSha;
 }
 
 function exactReviewDecisionCanSupersedeReview(
@@ -8733,41 +8604,21 @@ async function exactReviewTargetReadToken(env, targetRepo: string) {
   });
 }
 
-type ExactReviewTargetItemState =
-  | { state: "open"; headSha?: string }
-  | { state: "terminal" }
-  | { state: "unavailable" };
-
-async function exactReviewTargetItemState(
-  token: string,
-  decision: ExactReviewDecision,
-): Promise<Exclude<ExactReviewTargetItemState, { state: "unavailable" }>> {
+async function exactReviewTargetItemState(token: string, decision: ExactReviewDecision) {
   try {
-    const isPullRequest = decision.itemKind === "pull_request";
-    const queuedHeadSha = String(decision.sourceHeadSha || "").toLowerCase();
-    const readPullHead = isPullRequest && /^[0-9a-f]{40}$/.test(queuedHeadSha);
     const item = await githubTokenJson({
       token,
-      path: `/repos/${decision.targetRepo}/${readPullHead ? "pulls" : "issues"}/${decision.itemNumber}`,
+      path: `/repos/${decision.targetRepo}/issues/${decision.itemNumber}`,
       method: "GET",
       body: undefined,
       errorLabel: "live review item state",
     });
     const state = String(item.state || "").trim();
-    if (state === "open") {
-      if (!readPullHead) return { state: "open" };
-      const headSha = String(objectValue(objectValue(item).head).sha || "")
-        .trim()
-        .toLowerCase();
-      if (!/^[0-9a-f]{40}$/.test(headSha)) {
-        throw new Error("live pull request response missing head SHA");
-      }
-      return { state: "open", headSha };
-    }
-    if (state === "closed") return { state: "terminal" };
+    if (state === "open") return "open" as const;
+    if (state === "closed") return "terminal" as const;
     throw new Error("live review item state response missing state");
   } catch (error) {
-    if (error instanceof GitHubRequestError && error.status === 410) return { state: "terminal" };
+    if (error instanceof GitHubRequestError && error.status === 410) return "terminal" as const;
     if (error instanceof GitHubRequestError && error.status === 404) {
       // GitHub masks inaccessible private repositories as 404. Treat the item
       // as missing only when this token can still read its repository.
@@ -8778,7 +8629,7 @@ async function exactReviewTargetItemState(
         body: undefined,
         errorLabel: "live review target repository",
       });
-      return { state: "terminal" };
+      return "terminal" as const;
     }
     throw error;
   }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -84,74 +84,6 @@ test("exact-review source authority sequence survives queue restarts", async () 
   });
 });
 
-test("exact-review supersession audit migration preserves legacy records", () => {
-  const storage = new MemoryDurableStorage();
-  storage.sql.exec(`CREATE TABLE exact_review_queue_supersessions (
-    item_key TEXT NOT NULL,
-    prior_revision INTEGER NOT NULL,
-    next_revision INTEGER NOT NULL,
-    superseded_run_id TEXT,
-    source_action TEXT NOT NULL,
-    superseded_at INTEGER NOT NULL,
-    PRIMARY KEY (item_key, prior_revision, next_revision)
-  ) STRICT`);
-  storage.sql.exec(
-    `INSERT INTO exact_review_queue_supersessions
-       (item_key, prior_revision, next_revision, superseded_run_id, source_action, superseded_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    "openclaw/openclaw#113453",
-    3,
-    4,
-    "30138593399",
-    "synchronize",
-    1_785_000_000_000,
-  );
-
-  new ExactReviewQueue({ storage }, {});
-
-  const rows = Array.from(
-    storage.sql.exec(
-      `SELECT audit_id, item_key, prior_revision, next_revision, superseded_run_id,
-              source_action, reason_code, superseded_at
-         FROM exact_review_queue_supersessions`,
-    ),
-  ).map((row) => ({ ...row }));
-  assert.deepEqual(rows, [
-    {
-      audit_id: "legacy:openclaw/openclaw#113453:3:4",
-      item_key: "openclaw/openclaw#113453",
-      prior_revision: 3,
-      next_revision: 4,
-      superseded_run_id: "30138593399",
-      source_action: "synchronize",
-      reason_code: "newer_source_event",
-      superseded_at: 1_785_000_000_000,
-    },
-  ]);
-
-  storage.sql.exec(
-    `INSERT OR IGNORE INTO exact_review_queue_supersessions
-       (item_key, prior_revision, next_revision, superseded_run_id, source_action, superseded_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    "openclaw/openclaw#113453",
-    4,
-    5,
-    "30138593400",
-    "synchronize",
-    1_785_000_000_001,
-  );
-  const rollbackAudit = Array.from(
-    storage.sql.exec(
-      `SELECT audit_id, reason_code
-         FROM exact_review_queue_supersessions
-        WHERE prior_revision = 4`,
-    ),
-  ).map((row) => ({ ...row }));
-  assert.equal(rollbackAudit.length, 1);
-  assert.match(String(rollbackAudit[0]?.audit_id), /^[0-9a-f]{32}$/);
-  assert.equal(rollbackAudit[0]?.reason_code, "newer_source_event");
-});
-
 test("automerge reliability summarizes failures, recovery, duration, and stalled runs", () => {
   const run = (
     id: number,
@@ -4209,28 +4141,6 @@ test("exact-review queue dispatches a closed command item to complete its acknow
       ).status,
       202,
     );
-    const seeded = (await harness.storage.get("exact-review-queue")) as {
-      items: Record<
-        string,
-        {
-          attempts: number;
-          reviewFailureAttempts?: number;
-          dispatchFailureStatus?: number;
-          dispatchFailureClass?: string;
-          dispatchFailureAt?: number;
-          dispatchFailureFingerprint?: string;
-        }
-      >;
-    };
-    Object.assign(seeded.items["openclaw/gogcli#597"]!, {
-      attempts: 1,
-      reviewFailureAttempts: 1,
-      dispatchFailureStatus: 503,
-      dispatchFailureClass: "github_outage",
-      dispatchFailureAt: 1_785_000_000_000,
-      dispatchFailureFingerprint: "github_outage:503:upstream",
-    });
-    await harness.storage.put("exact-review-queue", seeded);
 
     await harness.queue.alarm();
 
@@ -4433,176 +4343,6 @@ test("exact-review queue dispatches an item that remains open", async () => {
       await harness.queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
     ).json();
     assert.equal(stats.dispatching, 1);
-  } finally {
-    harness.restore();
-  }
-});
-
-test("exact-review queue supersedes a stale open pull-request head before dispatch", async () => {
-  const staleHeadSha = "a".repeat(40);
-  const currentHeadSha = "b".repeat(40);
-  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
-    targetPull: () => jsonResponse({ state: "open", head: { sha: currentHeadSha } }),
-  });
-  try {
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "stale-pr-head",
-            597,
-            "synchronize",
-            "pull_request",
-            undefined,
-            {
-              sourceHeadSha: staleHeadSha,
-            },
-          ),
-        )
-      ).status,
-      202,
-    );
-
-    await harness.queue.alarm();
-
-    assert.equal(harness.dispatched.length, 0);
-    const state = (await harness.storage.get("exact-review-queue")) as {
-      items: Record<string, unknown>;
-    };
-    assert.equal(state.items["openclaw/gogcli#597"], undefined);
-    const audit = Array.from(
-      harness.storage.sql.exec(
-        `SELECT audit_id, item_key, prior_revision, next_revision, source_action, reason_code
-           FROM exact_review_queue_supersessions`,
-      ),
-    ).map((row) => ({ ...row }));
-    assert.equal(audit.length, 1);
-    assert.match(String(audit[0]?.audit_id), /^[0-9a-f-]{36}$/);
-    assert.deepEqual(
-      { ...audit[0], audit_id: undefined },
-      {
-        audit_id: undefined,
-        item_key: "openclaw/gogcli#597",
-        prior_revision: 1,
-        next_revision: 2,
-        source_action: "synchronize",
-        reason_code: "live_head_advanced",
-      },
-    );
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "stale-pr-head-again",
-            597,
-            "synchronize",
-            "pull_request",
-            undefined,
-            { sourceHeadSha: "c".repeat(40) },
-          ),
-        )
-      ).status,
-      202,
-    );
-    await harness.queue.alarm();
-    const repeatedAudit = Array.from(
-      harness.storage.sql.exec(
-        `SELECT audit_id FROM exact_review_queue_supersessions ORDER BY superseded_at, audit_id`,
-      ),
-    ).map((row) => String(row.audit_id));
-    assert.equal(harness.dispatched.length, 0);
-    assert.equal(repeatedAudit.length, 2);
-    assert.equal(new Set(repeatedAudit).size, 2);
-    const stats = await (
-      await harness.queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
-    ).json();
-    assert.equal(stats.lanes.review.completed_total, 2);
-    assert.equal(stats.lanes.review.superseded_total, 2);
-  } finally {
-    harness.restore();
-  }
-});
-
-test("exact-review queue refreshes a stale pull-request command to the current head", async () => {
-  const staleHeadSha = "a".repeat(40);
-  const currentHeadSha = "b".repeat(40);
-  const commandStatusMarker =
-    "<!-- clawsweeper-command-status:597:re_review:0123456789abcdef0123456789abcdef01234567 -->";
-  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
-    targetPull: () => jsonResponse({ state: "open", head: { sha: currentHeadSha } }),
-  });
-  try {
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "stale-pr-command",
-            597,
-            "synchronize",
-            "pull_request",
-            undefined,
-            {
-              sourceHeadSha: staleHeadSha,
-              commandStatusMarker,
-              statusCommentId: 9001,
-            },
-          ),
-        )
-      ).status,
-      202,
-    );
-
-    await harness.queue.alarm();
-
-    assert.equal(harness.dispatched.length, 0);
-    let state = (await harness.storage.get("exact-review-queue")) as {
-      items: Record<
-        string,
-        {
-          state: string;
-          revision: number;
-          attempts: number;
-          dispatchFailureStatus?: number;
-          dispatchFailureClass?: string;
-          dispatchFailureAt?: number;
-          dispatchFailureFingerprint?: string;
-          decision: {
-            sourceHeadSha?: string;
-            sourceHeadVerified?: boolean;
-            sourceAuthoritySeq?: number;
-            commandStatusMarker?: string;
-            statusCommentId?: number;
-          };
-          leaseDecision?: {
-            sourceHeadSha?: string;
-            commandStatusMarker?: string;
-          };
-        }
-      >;
-    };
-    const refreshed = state.items["openclaw/gogcli#597"];
-    assert.equal(refreshed?.state, "pending");
-    assert.equal(refreshed?.revision, 2);
-    assert.equal(refreshed?.attempts, 0);
-    assert.equal(refreshed?.decision.sourceHeadSha, currentHeadSha);
-    assert.equal(refreshed?.decision.sourceHeadVerified, true);
-    assert.equal(refreshed?.decision.sourceAuthoritySeq, undefined);
-    assert.equal(refreshed?.decision.commandStatusMarker, commandStatusMarker);
-    assert.equal(refreshed?.decision.statusCommentId, 9001);
-    assert.equal(refreshed?.dispatchFailureStatus, undefined);
-    assert.equal(refreshed?.dispatchFailureClass, undefined);
-    assert.equal(refreshed?.dispatchFailureAt, undefined);
-    assert.equal(refreshed?.dispatchFailureFingerprint, undefined);
-
-    await harness.queue.alarm();
-
-    assert.equal(harness.dispatched.length, 1);
-    state = (await harness.storage.get("exact-review-queue")) as typeof state;
-    const dispatched = state.items["openclaw/gogcli#597"];
-    assert.equal(dispatched?.state, "dispatching");
-    assert.equal(dispatched?.attempts, 0);
-    assert.equal(dispatched?.leaseDecision?.sourceHeadSha, currentHeadSha);
-    assert.equal(dispatched?.leaseDecision?.commandStatusMarker, commandStatusMarker);
   } finally {
     harness.restore();
   }
@@ -5938,7 +5678,6 @@ test("exact-review review retries stop at the attempt ceiling and park the item"
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const dispatched: Record<string, unknown>[] = [];
-  let liveHeadSha = `956eaead7f${"0".repeat(30)}`;
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -5953,9 +5692,6 @@ test("exact-review review retries stop at the attempt ceiling and park the item"
       return jsonResponse({ id: 999 });
     if (/^\/repos\/openclaw\/(?:clawsweeper|gogcli|openclaw)\/issues\/\d+$/.test(url.pathname))
       return jsonResponse({ state: "open" });
-    if (/^\/repos\/openclaw\/openclaw\/pulls\/\d+$/.test(url.pathname)) {
-      return jsonResponse({ state: "open", head: { sha: liveHeadSha } });
-    }
     if (url.pathname === "/app/installations/999/access_tokens") {
       return jsonResponse({ token: "dispatch-token" });
     }
@@ -6094,7 +5830,6 @@ test("exact-review review retries stop at the attempt ceiling and park the item"
       [["parked", "review_retry_exhausted"]],
     );
 
-    liveHeadSha = `1234abcd56${"0".repeat(30)}`;
     assert.equal(
       (
         await queue.fetch(
@@ -14972,7 +14707,6 @@ function createExactReviewAdmissionHarness(
     targetInstallation?: (targetRepo: string) => Response | Promise<Response>;
     targetRepository?: (targetRepo: string) => Response | Promise<Response>;
     targetItem?: (targetRepo: string) => Response | Promise<Response>;
-    targetPull?: (targetRepo: string) => Response | Promise<Response>;
     dispatch?: () => Response | Promise<Response>;
   } = {},
 ) {
@@ -15007,12 +14741,6 @@ function createExactReviewAdmissionHarness(
     );
     if (targetItem) {
       return options.targetItem?.(targetItem[1]) ?? liveItem();
-    }
-    const targetPull = url.pathname.match(/^\/repos\/(openclaw\/(?:gogcli|openclaw))\/pulls\/\d+$/);
-    if (targetPull) {
-      return (
-        options.targetPull?.(targetPull[1]) ?? options.targetItem?.(targetPull[1]) ?? liveItem()
-      );
     }
     if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
       dispatched.push(JSON.parse(String(init?.body)));


### PR DESCRIPTION
## Draft contingency — do not merge

This is a prepared, exact rollback of [#842](https://github.com/openclaw/clawsweeper/pull/842), retained only in case maintainers determine its live-head admission behavior is unsafe in production.

It is based on current `main` after [#843](https://github.com/openclaw/clawsweeper/pull/843), so it preserves the later dispatch-422 classification fix. It must not be merged merely because it exists.

## What it reverts

- The pre-dispatch live `/pulls` head comparison for source-head-bound exact-review work.
- Local stale-head supersession/command refresh, audit identity/reason, and the related durable-schema migration and tests.

## Known consequence

Reverting #842 deliberately restores the prior behavior in which an open PR with an obsolete queued head can dispatch and later fail its lease check. Codex branch review reported this as P2; it is intentionally rejected only because this PR is a rollback artifact. A maintainer must reassess that trade-off against concrete production evidence before merging.

## Validation

- `node --test test/dashboard-worker.test.ts` — 205 passing on the rebased draft.
- `pnpm run build:dashboard` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `codex review --uncommitted` — clean: exact inverse of #842.
- `codex review --base origin/main` — reviewed the current rebased branch; its sole P2 is the intentionally restored stale-head behavior described above.

No queue, target, comment, workflow, Actions, or gate mutation was used to prepare this draft. No changelog or workflow change is included.
