### PR TITLE
draft: revert #843 dispatch 422 classification

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -17,7 +17,7 @@ run-name: >-
       github.event.action == 'clawsweeper_target_sweep') &&
       format('Review target repo {0}', github.event.client_payload.target_repo || 'openclaw/openclaw') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '') &&
-      format('Review exact item {0} rev {1} head {2}', github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || '?', github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision || '?', github.event.client_payload.queue_claim.source_head_sha || github.event.client_payload.source_head_sha || 'na') ||
+      format('Review exact item {0} rev {1} head {2}', github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || '?', github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision || '?', github.event.client_payload.source_head_sha || 'na') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.dispatch_key != '') &&
       format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
     github.event_name == 'repository_dispatch' &&
@@ -278,8 +278,8 @@ jobs:
                 sourceEvent,
                 sourceAction: payload.source_action || "legacy_dispatch",
                 supersedesInProgress: payload.supersedes_in_progress === true,
-                ...(/^[0-9a-f]{40}$/.test(String(payload.queue_claim?.source_head_sha || payload.source_head_sha || "").trim().toLowerCase())
-                  ? { sourceHeadSha: String(payload.queue_claim?.source_head_sha || payload.source_head_sha).trim().toLowerCase() }
+                ...(/^[0-9a-f]{40}$/.test(String(payload.source_head_sha || "").trim().toLowerCase())
+                  ? { sourceHeadSha: String(payload.source_head_sha).trim().toLowerCase() }
                   : {}),
                 ...(Number.isFinite(Number(payload.codex_timeout_ms))
                   ? { codexTimeoutMs: Number(payload.codex_timeout_ms) }
@@ -416,8 +416,8 @@ jobs:
                   sourceEvent: String(dispatch.source_event || ""),
                   sourceAction: String(dispatch.source_action || "legacy_dispatch"),
                   supersedesInProgress: dispatch.supersedes_in_progress === true,
-                  ...(/^[0-9a-f]{40}$/.test(String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha || "").trim().toLowerCase())
-                    ? { sourceHeadSha: String(dispatch.queue_claim?.source_head_sha || dispatch.source_head_sha).trim().toLowerCase() }
+                  ...(/^[0-9a-f]{40}$/.test(String(dispatch.source_head_sha || "").trim().toLowerCase())
+                    ? { sourceHeadSha: String(dispatch.source_head_sha).trim().toLowerCase() }
                     : {}),
                   ...(Number.isFinite(Number(reviewOptions.codex_timeout_ms))
                     ? { codexTimeoutMs: Number(reviewOptions.codex_timeout_ms) }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -109,7 +109,6 @@ export type ExactReviewQueueItem = {
   dispatchFailureClass?: ExactReviewDispatchFailureClass;
   dispatchFailureAt?: number;
   dispatchFailureFingerprint?: string;
-  dispatchFailureDetail?: ExactReviewDispatchFailureDetail;
   lastFailureReason?: ExactReviewPublicationReasonCode;
   firstFailureAt?: number;
   publicationFailureAttempts?: number;
@@ -119,7 +118,6 @@ export type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 type ExactReviewDispatchFailureClass =
   | "permanent_rejection"
-  | "validation_unknown"
   | "authentication"
   | "rate_limit"
   | "github_outage"
@@ -195,7 +193,6 @@ export type ExactReviewQueueState = {
       | "dispatch_rate_limit"
       | "dispatch_github_outage"
       | "dispatch_timeout"
-      | "dispatch_validation"
       | "dispatch_network";
     workflowState?: string;
     checkedAt: number;
@@ -204,7 +201,6 @@ export type ExactReviewQueueState = {
     dispatchFailureClass?: ExactReviewDispatchFailureClass;
     dispatchFailureAt?: number;
     dispatchFailureFingerprint?: string;
-    dispatchFailureDetail?: ExactReviewDispatchFailureDetail;
     dispatchConsecutiveFailures?: number;
     reviewAdmissionNextAt?: number;
     publicationBatchDispatchedAt?: number;
@@ -1735,7 +1731,6 @@ export class ExactReviewQueue {
           ? new Date(item.dispatchFailureAt).toISOString()
           : null,
         dispatch_failure_fingerprint: item.dispatchFailureFingerprint || null,
-        dispatch_failure_detail: exactReviewDispatchFailureDetailJson(item.dispatchFailureDetail),
         created_at: new Date(item.createdAt).toISOString(),
         next_attempt_at:
           item.state === "pending" ? new Date(item.nextAttemptAt).toISOString() : null,
@@ -2497,7 +2492,6 @@ export class ExactReviewQueue {
         item.dispatchFailureClass = failure.failure.failureClass;
         item.dispatchFailureAt = completedAt;
         item.dispatchFailureFingerprint = failure.failure.fingerprint;
-        item.dispatchFailureDetail = failure.failure.detail;
       }
       if (failure.attempted && failure.failure.scope === "item") {
         item.state = "parked";
@@ -2524,7 +2518,6 @@ export class ExactReviewQueue {
         dispatchFailureClass: globalFailure.failureClass,
         dispatchFailureAt: completedAt,
         dispatchFailureFingerprint: globalFailure.fingerprint,
-        dispatchFailureDetail: globalFailure.detail,
         dispatchConsecutiveFailures: consecutiveFailures,
         ...currentBatchDispatcherFields,
       };
@@ -7007,15 +7000,6 @@ function clearExactReviewDispatchFailure(item: ExactReviewQueueItem) {
   item.dispatchFailureClass = undefined;
   item.dispatchFailureAt = undefined;
   item.dispatchFailureFingerprint = undefined;
-  item.dispatchFailureDetail = undefined;
-}
-
-function exactReviewDispatchFailureDetailJson(detail?: ExactReviewDispatchFailureDetail) {
-  if (!detail) return null;
-  return {
-    validation_fields: detail.validationFields,
-    validation_codes: detail.validationCodes,
-  };
 }
 
 export function exactReviewEffectiveLeaseExpiresAt(
@@ -7673,9 +7657,6 @@ function exactReviewQueueStats(
         ? new Date(state.dispatcher.dispatchFailureAt).toISOString()
         : null,
       dispatch_failure_fingerprint: state.dispatcher?.dispatchFailureFingerprint || null,
-      dispatch_failure_detail: exactReviewDispatchFailureDetailJson(
-        state.dispatcher?.dispatchFailureDetail,
-      ),
       dispatch_consecutive_failures: state.dispatcher?.dispatchConsecutiveFailures || 0,
     },
     target_stats: targetStats,
@@ -8982,7 +8963,6 @@ async function dispatchClawsweeperItem({
           protocol_version: 2,
           item_key: itemKey,
           lease_revision: leaseRevision,
-          ...(decision.sourceHeadSha ? { source_head_sha: decision.sourceHeadSha } : {}),
         },
         target_repo: decision.targetRepo,
         target_branch: decision.targetBranch,
@@ -8991,6 +8971,7 @@ async function dispatchClawsweeperItem({
         source_event: decision.sourceEvent,
         source_action: decision.sourceAction,
         supersedes_in_progress: decision.supersedesInProgress,
+        ...(decision.sourceHeadSha ? { source_head_sha: decision.sourceHeadSha } : {}),
         ...(Object.keys(reviewOptions).length > 0 ? { review_options: reviewOptions } : {}),
       },
     },
@@ -9003,73 +8984,46 @@ type ExactReviewDispatchFailure = {
   failureClass: ExactReviewDispatchFailureClass;
   status?: number;
   fingerprint: string;
-  detail?: ExactReviewDispatchFailureDetail;
-};
-
-type ExactReviewDispatchFailureDetail = {
-  validationFields: string[];
-  validationCodes: string[];
 };
 
 class GitHubRequestError extends Error {
   readonly status?: number;
   readonly timedOut: boolean;
   readonly rateLimited: boolean;
-  readonly validationDetail?: ExactReviewDispatchFailureDetail;
 
-  constructor(
-    message: string,
-    status?: number,
-    timedOut = false,
-    rateLimited = false,
-    validationDetail?: ExactReviewDispatchFailureDetail,
-  ) {
+  constructor(message: string, status?: number, timedOut = false, rateLimited = false) {
     super(message);
     this.name = "GitHubRequestError";
     this.status = status;
     this.timedOut = timedOut;
     this.rateLimited = rateLimited;
-    this.validationDetail = validationDetail;
   }
 }
 
 function exactReviewDispatchFailure(error: unknown): ExactReviewDispatchFailure {
   const requestError = error instanceof GitHubRequestError ? error : null;
   const status = requestError?.status;
-  const detail = requestError?.validationDetail;
   const failureClass: ExactReviewDispatchFailureClass = requestError?.timedOut
     ? "timeout"
-    : requestError?.rateLimited || status === 429
-      ? "rate_limit"
-      : status === 422 && !exactReviewPermanentDispatchValidation(detail)
-        ? "validation_unknown"
-        : status === 400 || status === 404 || status === 422
-          ? "permanent_rejection"
-          : status === 401 || status === 403
-            ? "authentication"
-            : status !== undefined && status >= 500
-              ? "github_outage"
-              : "network";
+    : status === 400 || status === 404 || status === 422
+      ? "permanent_rejection"
+      : requestError?.rateLimited || status === 429
+        ? "rate_limit"
+        : status === 401 || status === 403
+          ? "authentication"
+          : status !== undefined && status >= 500
+            ? "github_outage"
+            : "network";
   return {
     scope: failureClass === "permanent_rejection" ? "item" : "global",
     failureClass,
     ...(status === undefined ? {} : { status }),
-    ...(detail ? { detail } : {}),
-    fingerprint: exactReviewDispatchFailureFingerprint(failureClass, status, detail),
+    fingerprint: exactReviewDispatchFailureFingerprint(failureClass, status),
   };
-}
-
-function exactReviewPermanentDispatchValidation(detail?: ExactReviewDispatchFailureDetail) {
-  return detail?.validationFields.length === 1 && detail.validationFields[0] === "client_payload";
 }
 
 function exactReviewAdmissionFailure(error: unknown): ExactReviewDispatchFailure {
   const failure = exactReviewDispatchFailure(error);
-  // Admission reads one target item. Its validation response cannot describe
-  // the shared repository_dispatch contract, so it must not hold other items.
-  if (error instanceof GitHubRequestError && error.status === 422) {
-    return { ...failure, scope: "item" };
-  }
   // This error arose while checking one specific target. A target installation
   // may lack issue-read access even though other target installations are
   // healthy, so a 403 must not hold the whole queue.
@@ -9082,9 +9036,8 @@ function exactReviewAdmissionFailure(error: unknown): ExactReviewDispatchFailure
 function exactReviewDispatchFailureFingerprint(
   failureClass: ExactReviewDispatchFailureClass,
   status?: number,
-  detail?: ExactReviewDispatchFailureDetail,
 ) {
-  const value = `${failureClass}:${status ?? "none"}:${detail?.validationFields.join(",") || "none"}:${detail?.validationCodes.join(",") || "none"}`;
+  const value = `${failureClass}:${status ?? "none"}`;
   let hash = 2166136261;
   for (let index = 0; index < value.length; index += 1) {
     hash ^= value.charCodeAt(index);
@@ -9100,7 +9053,6 @@ function exactReviewDispatchDispatcherReason(
   if (failureClass === "rate_limit") return "dispatch_rate_limit";
   if (failureClass === "github_outage") return "dispatch_github_outage";
   if (failureClass === "timeout") return "dispatch_timeout";
-  if (failureClass === "validation_unknown") return "dispatch_validation";
   return "dispatch_network";
 }
 
@@ -9157,11 +9109,10 @@ async function githubTokenJson({ token, path, method = "GET", body, errorLabel }
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     throw new GitHubRequestError(
-      `${errorLabel || "GitHub"} ${response.status}`,
+      `${errorLabel || "GitHub"} ${response.status}${text ? `: ${text.slice(0, 240)}` : ""}`,
       response.status,
       false,
       githubResponseRateLimited(response, text),
-      githubResponseValidationDetail(response.status, text),
     );
   }
   if (response.status === 204) return {};
@@ -9361,11 +9312,10 @@ async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}) {
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     throw new GitHubRequestError(
-      `${options.errorLabel || "GitHub App"} ${response.status}`,
+      `${options.errorLabel || "GitHub App"} ${response.status}${text ? `: ${text.slice(0, 240)}` : ""}`,
       response.status,
       false,
       githubResponseRateLimited(response, text),
-      githubResponseValidationDetail(response.status, text),
     );
   }
   return response.json();
@@ -9378,39 +9328,6 @@ function githubResponseRateLimited(response: Response, text: string) {
     response.headers.get("x-ratelimit-remaining") === "0" ||
     /(?:secondary )?rate limit|api rate limit|abuse detection/i.test(text)
   );
-}
-
-function githubResponseValidationDetail(status: number, text: string) {
-  if (status !== 422 || text.length > 16_384) return undefined;
-  let payload: unknown;
-  try {
-    payload = JSON.parse(text);
-  } catch {
-    return undefined;
-  }
-  const errors = Array.isArray(objectValue(payload).errors) ? objectValue(payload).errors : [];
-  const validationFields = new Set<string>();
-  const validationCodes = new Set<string>();
-  for (const error of errors.slice(0, 8)) {
-    const value = objectValue(error);
-    const field = githubValidationToken(value.field);
-    const code = githubValidationToken(value.code);
-    if (field) validationFields.add(field);
-    if (code) validationCodes.add(code);
-  }
-  if (!validationFields.size && !validationCodes.size) return undefined;
-  return {
-    validationFields: [...validationFields].sort().slice(0, 4),
-    validationCodes: [...validationCodes].sort().slice(0, 4),
-  };
-}
-
-function githubValidationToken(value: unknown) {
-  const token =
-    String(value || "")
-      .match(/^[A-Za-z_][A-Za-z0-9_]*/)?.[0]
-      ?.toLowerCase() || "";
-  return token.length <= 64 ? token : "";
 }
 
 async function signGithubAppJwt(issuer, privateKey) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7200,7 +7200,7 @@ test("exact-review queue retries dispatch failures and reclaims an unclaimed lea
   }
 });
 
-test("exact-review queue parks structured client-payload validation and explicit command recovers it", async () => {
+test("exact-review queue parks permanent dispatch rejection and explicit command recovers it", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const { privateKey } = generateKeyPairSync("rsa", {
@@ -7222,20 +7222,9 @@ test("exact-review queue parks structured client-payload validation and explicit
     if (url.pathname === "/repos/openclaw/clawsweeper/dispatches")
       return dispatchStatus === 204
         ? new Response(null, { status: 204 })
-        : new Response(
-            JSON.stringify({
-              message: "Validation Failed: must-not-persist",
-              errors: [
-                {
-                  resource: "Repository",
-                  field: "client_payload",
-                  code: "invalid",
-                  value: "https://private.example/secret?token=must-not-persist",
-                },
-              ],
-            }),
-            { status: dispatchStatus },
-          );
+        : new Response(JSON.stringify({ message: "unprocessable payload" }), {
+            status: dispatchStatus,
+          });
     throw new Error(`unexpected fetch ${url}`);
   };
 
@@ -7266,14 +7255,7 @@ test("exact-review queue parks structured client-payload validation and explicit
     assert.equal(status.items[0].attempts, 0);
     assert.equal(status.items[0].dispatch_failure_status, 422);
     assert.equal(status.items[0].dispatch_failure_class, "permanent_rejection");
-    assert.deepEqual(status.items[0].dispatch_failure_detail, {
-      validation_fields: ["client_payload"],
-      validation_codes: ["invalid"],
-    });
     assert.match(status.items[0].dispatch_failure_fingerprint, /^dispatch-[0-9a-f]{8}$/);
-
-    const persisted = JSON.stringify(await storage.get("exact-review-queue"));
-    assert.doesNotMatch(persisted, /must-not-persist|private\.example|token=/);
 
     dispatchStatus = 204;
     assert.equal(
@@ -7309,176 +7291,6 @@ test("exact-review queue parks structured client-payload validation and explicit
     assert.equal(recovered.items["openclaw/gogcli#600"].parkedReason, undefined);
     assert.equal(recovered.items["openclaw/gogcli#600"].dispatchFailureClass, undefined);
     assert.equal(recovered.items["openclaw/gogcli#600"].attempts, 0);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("exact-review queue retains a synchronize update after an unclassified 422", async () => {
-  const originalFetch = globalThis.fetch;
-  const storage = new MemoryDurableStorage();
-  const { privateKey } = generateKeyPairSync("rsa", {
-    modulusLength: 2048,
-    privateKeyEncoding: { type: "pkcs8", format: "pem" },
-    publicKeyEncoding: { type: "spki", format: "pem" },
-  });
-  let dispatchedPayload: Record<string, unknown> | undefined;
-  globalThis.fetch = async (input, init) => {
-    const url = new URL(String(input));
-    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml")
-      return jsonResponse({ state: "active" });
-    if (/^\/repos\/openclaw\/(?:clawsweeper|gogcli)\/installation$/.test(url.pathname))
-      return jsonResponse({ id: 999 });
-    if (/^\/repos\/openclaw\/(?:clawsweeper|gogcli)\/issues\/\d+$/.test(url.pathname))
-      return jsonResponse({ state: "open" });
-    if (url.pathname === "/app/installations/999/access_tokens")
-      return jsonResponse({ token: "dispatch-token" });
-    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
-      dispatchedPayload = JSON.parse(String(init?.body || "{}"));
-      return new Response(
-        JSON.stringify({
-          message: "Validation Failed: must-not-persist",
-          errors: [
-            {
-              resource: "Repository",
-              field: "event_type",
-              code: "invalid",
-              value: "https://private.example/secret?token=must-not-persist",
-            },
-          ],
-        }),
-        { status: 422 },
-      );
-    }
-    throw new Error(`unexpected fetch ${url}`);
-  };
-
-  try {
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
-        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
-        EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
-      },
-    );
-    await queue.fetch(
-      buildExactReviewQueueRequest(
-        "842-command",
-        842,
-        "legacy_dispatch",
-        "pull_request",
-        "openclaw/clawsweeper",
-        { commandStatusMarker: "<!-- clawsweeper-command-status:842:re_review:old -->" },
-      ),
-    );
-    await queue.fetch(
-      buildExactReviewQueueRequest(
-        "842-synchronize",
-        842,
-        "synchronize",
-        "pull_request",
-        "openclaw/clawsweeper",
-        {
-          sourceHeadSha: "81e4abc894e7d3ec1fddbd856378b6aadb4392f3",
-          sourceHeadVerified: true,
-          sourceAuthoritySeq: 1,
-        },
-      ),
-    );
-    await queue.alarm();
-
-    const clientPayload = (dispatchedPayload?.client_payload || {}) as Record<string, unknown>;
-    assert.equal(Object.keys(clientPayload).length, 10);
-    assert.equal(clientPayload.source_head_sha, undefined);
-    assert.equal(
-      (clientPayload.queue_claim as Record<string, unknown>).source_head_sha,
-      "81e4abc894e7d3ec1fddbd856378b6aadb4392f3",
-    );
-    assert.ok(clientPayload.review_options);
-
-    const status = await (
-      await queue.fetch(
-        new Request(
-          "https://clawsweeper-exact-review-queue/item-status?target_repo=openclaw%2Fclawsweeper&item_number=842",
-        ),
-      )
-    ).json();
-    assert.equal(status.items[0].state, "pending");
-    assert.equal(status.items[0].parked_reason, null);
-    assert.equal(status.items[0].dispatch_failure_status, 422);
-    assert.equal(status.items[0].dispatch_failure_class, "validation_unknown");
-    assert.deepEqual(status.items[0].dispatch_failure_detail, {
-      validation_fields: ["event_type"],
-      validation_codes: ["invalid"],
-    });
-
-    const queueStatus = await (
-      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
-    ).json();
-    assert.equal(queueStatus.dispatcher.state, "blocked");
-    assert.equal(queueStatus.dispatcher.reason, "dispatch_validation");
-    assert.ok(Date.parse(queueStatus.dispatcher.retry_at) > Date.now());
-    assert.deepEqual(queueStatus.dispatcher.dispatch_failure_detail, {
-      validation_fields: ["event_type"],
-      validation_codes: ["invalid"],
-    });
-    assert.doesNotMatch(
-      JSON.stringify(await storage.get("exact-review-queue")),
-      /must-not-persist|private\.example|token=/,
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("exact-review queue treats a secondary-limit 422 as a global retry", async () => {
-  const originalFetch = globalThis.fetch;
-  const storage = new MemoryDurableStorage();
-  const { privateKey } = generateKeyPairSync("rsa", {
-    modulusLength: 2048,
-    privateKeyEncoding: { type: "pkcs8", format: "pem" },
-    publicKeyEncoding: { type: "spki", format: "pem" },
-  });
-  globalThis.fetch = async (input) => {
-    const url = new URL(String(input));
-    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml")
-      return jsonResponse({ state: "active" });
-    if (/^\/repos\/openclaw\/(?:clawsweeper|gogcli)\/installation$/.test(url.pathname))
-      return jsonResponse({ id: 999 });
-    if (/^\/repos\/openclaw\/(?:clawsweeper|gogcli)\/issues\/\d+$/.test(url.pathname))
-      return jsonResponse({ state: "open" });
-    if (url.pathname === "/app/installations/999/access_tokens")
-      return jsonResponse({ token: "dispatch-token" });
-    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches")
-      return new Response(
-        JSON.stringify({ message: "You have exceeded a secondary rate limit." }),
-        {
-          status: 422,
-        },
-      );
-    throw new Error(`unexpected fetch ${url}`);
-  };
-
-  try {
-    const queue = new ExactReviewQueue(
-      { storage },
-      {
-        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
-        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
-        EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
-      },
-    );
-    await queue.fetch(buildExactReviewQueueRequest("secondary-limit", 843, "synchronize"));
-    await queue.alarm();
-    const status = await (
-      await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
-    ).json();
-    assert.equal(status.dispatcher.state, "blocked");
-    assert.equal(status.dispatcher.reason, "dispatch_rate_limit");
-    assert.equal(status.dispatcher.dispatch_failure_status, 422);
-    assert.equal(status.dispatcher.dispatch_failure_class, "rate_limit");
-    assert.equal(status.pending, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Draft rollback — do not merge pre-emptively

This draft exactly reverts squash commit `df5ec544d6d6220e84cc6886ee999dd0885b09ab` from #843. It exists only as a ready rollback if production evidence shows #843 is harmful. It must remain draft until Martin explicitly approves merging it after a demonstrated regression.

## What this restores

The revert restores the pre-#843 exact-review dispatch behavior, including:

- top-level `source_head_sha` dispatch compatibility;
- the previous HTTP 422 classification; and
- no persisted redacted validation detail.

## Intentionally rejected Codex-review findings

Both dirty and branch review correctly identify that this exact revert would reintroduce the #843 failure modes:

1. A synchronize event carrying both a source head and review options can exceed GitHub's 10-key `client_payload` limit and receive a 422.
2. Secondary-rate-limit, opaque, and shared-validation 422s can again be parked as permanent item failures instead of receiving bounded global backoff.

Those findings are intentionally not fixed because this is an exact emergency rollback of #843, requested in advance. They are the reason this PR must remain draft and must not be merged without an observed #843 regression and explicit maintainer approval.

## Validation

```text
pnpm run build:all
node --test --test-name-pattern='(bounds item-specific terminal-state check failures|parks an item after repeated item-specific target-state failures|parks permanent dispatch rejection|globally backs off GitHub outages)' test/dashboard-worker.test.ts
node --test --test-name-pattern='exact event item' test/sweep-workflow.test.ts
git diff --check
```

All commands passed. `actionlint` is unavailable on this host.

## Merge condition and rollout

Do not merge merely because this draft exists. First capture concrete evidence that #843 causes a production regression, identify why the safer forward fix cannot be used, and obtain Martin's explicit merge approval. No automerge, gates, or ClawSweeper command is requested for this draft.

## Links

- Reverts: #843
- Related incident: #842
