### PR TITLE
fix(exact-review): snapshot durable tuple before publication

### DIFF
--- a/src/repair/event-record-store.ts
+++ b/src/repair/event-record-store.ts
@@ -96,12 +96,16 @@ export function resetEventSnapshot(store: EventRecordStore): void {
   fs.mkdirSync(store.snapshotDir, { recursive: true });
 }
 
-export function captureEventBaseSnapshot(store: EventRecordStore): EventRecordPaths {
+export function captureEventBaseSnapshot(
+  store: EventRecordStore,
+  options: { sourceRoot?: string } = {},
+): EventRecordPaths {
   const paths = eventRecordPaths(store);
-  copyIfExists(paths.itemRecord, paths.snapshotBaseItem);
-  copyIfExists(paths.closedRecord, paths.snapshotBaseClosed);
-  copyIfExists(paths.planRecord, paths.snapshotBasePlan);
-  copyIfExists(paths.decisionPacket, paths.snapshotBaseDecisionPacket);
+  const sourceRoot = options.sourceRoot ?? ".";
+  copyIfExists(path.resolve(sourceRoot, paths.itemRecord), paths.snapshotBaseItem);
+  copyIfExists(path.resolve(sourceRoot, paths.closedRecord), paths.snapshotBaseClosed);
+  copyIfExists(path.resolve(sourceRoot, paths.planRecord), paths.snapshotBasePlan);
+  copyIfExists(path.resolve(sourceRoot, paths.decisionPacket), paths.snapshotBaseDecisionPacket);
   return paths;
 }
 

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -151,9 +151,13 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     itemNumber: options.itemNumber,
     snapshotDir: options.snapshotDir,
   };
+  const stateRoot = publishRoot();
 
   resetEventSnapshot(recordStore);
-  const recordPaths = captureEventBaseSnapshot(recordStore);
+  const recordPaths = captureEventBaseSnapshot(
+    recordStore,
+    stateRoot ? { sourceRoot: stateRoot } : {},
+  );
   fs.rmSync(options.reportPath, { force: true });
 
   runClawsweeper(options, [
@@ -174,7 +178,6 @@ async function publishEventResult(options: EventOptions): Promise<void> {
   captureEventSnapshot(recordStore);
   hardResetToRemoteMain();
   const stateBaseCommit = captureStatePublishBaseline();
-  const stateRoot = publishRoot();
   const preflightResult = applyEventSnapshotIfCurrent(
     recordPaths,
     stateRoot ? { remoteRoot: stateRoot } : {},

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7331,6 +7331,11 @@ test("exact-review queue retains a synchronize update after an unclassified 422"
       return jsonResponse({ id: 999 });
     if (/^\/repos\/openclaw\/(?:clawsweeper|gogcli)\/issues\/\d+$/.test(url.pathname))
       return jsonResponse({ state: "open" });
+    if (url.pathname === "/repos/openclaw/clawsweeper/pulls/842")
+      return jsonResponse({
+        state: "open",
+        head: { sha: "81e4abc894e7d3ec1fddbd856378b6aadb4392f3" },
+      });
     if (url.pathname === "/app/installations/999/access_tokens")
       return jsonResponse({ token: "dispatch-token" });
     if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {

--- a/test/repair/event-record-store.test.ts
+++ b/test/repair/event-record-store.test.ts
@@ -33,6 +33,53 @@ test("event record directories stay inside the isolated worker root", () => {
   });
 });
 
+test("event base snapshot uses durable state when the isolated worker starts empty", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
+  const workerRoot = path.join(root, "worker");
+  const stateRoot = path.join(root, "state");
+  const store = {
+    targetRepo: "openclaw/openclaw",
+    itemNumber: "93584",
+    snapshotDir: path.join(workerRoot, "snapshot"),
+  };
+  const paths = eventRecordPaths(store);
+  fs.mkdirSync(workerRoot, { recursive: true });
+  fs.mkdirSync(stateRoot, { recursive: true });
+
+  withCwd(stateRoot, () => {
+    writeEventTuple(paths, {
+      marker: "durable previous review",
+      reviewedAt: "2026-07-24T22:16:08.206Z",
+      itemUpdatedAt: "2026-07-24T22:14:34Z",
+    });
+  });
+
+  withCwd(workerRoot, () => {
+    resetEventSnapshot(store);
+    captureEventBaseSnapshot(store);
+    writeEventTuple(paths, {
+      marker: "fresh exact review",
+      reviewedAt: "2026-07-25T03:12:20.195Z",
+      itemUpdatedAt: "2026-07-25T03:10:15Z",
+    });
+    captureEventSnapshot(store);
+    assert.throws(
+      () => applyEventSnapshot(paths, { remoteRoot: stateRoot }),
+      /missing comparable state-mutation timestamp/,
+    );
+
+    resetEventSnapshot(store);
+    captureEventBaseSnapshot(store, { sourceRoot: stateRoot });
+    writeEventTuple(paths, {
+      marker: "fresh exact review",
+      reviewedAt: "2026-07-25T03:12:20.195Z",
+      itemUpdatedAt: "2026-07-25T03:10:15Z",
+    });
+    captureEventSnapshot(store);
+    assert.equal(applyEventSnapshot(paths, { remoteRoot: stateRoot }), "open");
+  });
+});
+
 test("event snapshot match follows the final tuple winner, not only its action", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
   const store = {


### PR DESCRIPTION
## Summary

Fix the exact-review batch publisher so its tuple base snapshot comes from the durable isolated state checkout, not the empty worker directory. Also repair the CI fixture exposed by the current `main` admission behavior.

## Problem

A re-review of [openclaw/openclaw#93584](https://github.com/openclaw/openclaw/pull/93584) completed its exact worker successfully, produced a valid review artifact, and created the review-started placeholder, but never updated the durable review comment/status.

The first terminal loss was in [batch run 30141831366](https://github.com/openclaw/clawsweeper/actions/runs/30141831366) at 2026-07-25 03:16:37Z:

```text
RecordTupleError: Invalid record tuple openclaw-openclaw/93584: missing comparable state-mutation timestamp
```

The batch workflow reported success even though it recorded that individual publication as permanent `tuple_protocol_invalid`; queue completion then removed the active item and placed it in the DLQ. This PR deliberately does not replay, requeue, or otherwise mutate that live item.

## Timeline and cause

- 03:06:21Z: `@clawsweeper re-review` on #93584.
- 03:09:01Z–03:12:37Z: [exact worker run 30141719145](https://github.com/openclaw/clawsweeper/actions/runs/30141719145) succeeded; its artifact contains valid `item_updated_at` (03:10:15Z) and `reviewed_at` (03:12:20.195Z).
- 03:10:14Z: review-started placeholder posted.
- 03:16:37Z: the publisher failed above because `publish-event-result` captured the base tuple from the empty worker root. It later compared both the fresh artifact and the durable tuple against that empty base.

Causal classification: #840 introduced the isolated artifact/root flow that exposed this missing durable-base capture. #829/#830/#832 are predecessor tuple-protocol work, not sufficient causes. #842/#843 concern dispatch validation and are unrelated to the production publication failure. The separate stale-publication revision conflict observed for #111368 is also unrelated.

## Implementation

- Let `captureEventBaseSnapshot` read a specified source root.
- In `publish-event-result`, snapshot from `publishRoot()` before applying artifacts to the isolated worker directory.
- Preserve existing behavior when no durable state root is configured.
- Restore #843's unclassified-422 fixture by mocking the verified `/pulls/842` admission read and its head SHA. This is test-only; no production dispatch behavior changed.

## Validation

- `pnpm run build:all`
- `node --test --test-name-pattern='event base snapshot uses durable state' test/repair/event-record-store.test.ts`
- `pnpm run lint:repair`
- `pnpm run build:dashboard`
- `node --test test/dashboard-worker.test.ts` — 208 passed, 0 failed
- `pnpm run lint:scripts`
- `pnpm exec oxfmt --check src/repair/event-record-store.ts src/repair/publish-event-result.ts test/repair/event-record-store.test.ts test/dashboard-worker.test.ts`
- `git diff --check`

The lifecycle regression constructs the #93584 topology: an empty worker, an existing durable tuple, and a fresh exact-review tuple. It proves the old base capture throws the production error and the durable-state capture resolves the fresh tuple as `open`.

The initial [CI failure](https://github.com/openclaw/clawsweeper/actions/runs/30144792869/job/89644415945) was deterministic but separate: #843 changed verified PR admission to read `/pulls/<number>`, while its test only mocked `/issues/<number>`. The dispatcher therefore never ran and the test observed an empty payload. The added fixture proves the real verified-head flow.

The full affected event-record test file has two pre-existing Windows fixture failures in unchanged cases: their remote tuple helpers write absolute `decision_packet_path` values, while tuple validation correctly requires `records/...` paths. They are outside this lifecycle patch.

## Risk and rollback

The lifecycle change only selects the correct source for the existing baseline snapshot; tuple ordering, stale-event handling, retry/DLQ accounting, and routing semantics are unchanged. The CI follow-up is test-only. Roll back commits `0ea41f918ab280e44b909be56a7ad4fe049eeddc` and `0b4839236a` to restore prior behavior.

## Review closeout

- Lifecycle dirty patch: `codex review --uncommitted` — clean; no accepted/actionable findings.
- Lifecycle branch against actual base: `codex review --base origin/main` — clean; no accepted/actionable findings.
- CI follow-up dirty patch: `codex review --uncommitted` — clean; no accepted/actionable findings.
- Final branch against actual base: `codex review --base origin/main` — clean; no accepted/actionable findings.

No live queue, state, review command, label, comment, or merge operation was performed by this PR preparation.