### PR TITLE
revert: draft contingency rollback for #846

### DIFF
--- a/src/repair/event-record-store.ts
+++ b/src/repair/event-record-store.ts
@@ -96,16 +96,12 @@ export function resetEventSnapshot(store: EventRecordStore): void {
   fs.mkdirSync(store.snapshotDir, { recursive: true });
 }
 
-export function captureEventBaseSnapshot(
-  store: EventRecordStore,
-  options: { sourceRoot?: string } = {},
-): EventRecordPaths {
+export function captureEventBaseSnapshot(store: EventRecordStore): EventRecordPaths {
   const paths = eventRecordPaths(store);
-  const sourceRoot = options.sourceRoot ?? ".";
-  copyIfExists(path.resolve(sourceRoot, paths.itemRecord), paths.snapshotBaseItem);
-  copyIfExists(path.resolve(sourceRoot, paths.closedRecord), paths.snapshotBaseClosed);
-  copyIfExists(path.resolve(sourceRoot, paths.planRecord), paths.snapshotBasePlan);
-  copyIfExists(path.resolve(sourceRoot, paths.decisionPacket), paths.snapshotBaseDecisionPacket);
+  copyIfExists(paths.itemRecord, paths.snapshotBaseItem);
+  copyIfExists(paths.closedRecord, paths.snapshotBaseClosed);
+  copyIfExists(paths.planRecord, paths.snapshotBasePlan);
+  copyIfExists(paths.decisionPacket, paths.snapshotBaseDecisionPacket);
   return paths;
 }
 

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -151,13 +151,9 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     itemNumber: options.itemNumber,
     snapshotDir: options.snapshotDir,
   };
-  const stateRoot = publishRoot();
 
   resetEventSnapshot(recordStore);
-  const recordPaths = captureEventBaseSnapshot(
-    recordStore,
-    stateRoot ? { sourceRoot: stateRoot } : {},
-  );
+  const recordPaths = captureEventBaseSnapshot(recordStore);
   fs.rmSync(options.reportPath, { force: true });
 
   runClawsweeper(options, [
@@ -178,6 +174,7 @@ async function publishEventResult(options: EventOptions): Promise<void> {
   captureEventSnapshot(recordStore);
   hardResetToRemoteMain();
   const stateBaseCommit = captureStatePublishBaseline();
+  const stateRoot = publishRoot();
   const preflightResult = applyEventSnapshotIfCurrent(
     recordPaths,
     stateRoot ? { remoteRoot: stateRoot } : {},

--- a/test/repair/event-record-store.test.ts
+++ b/test/repair/event-record-store.test.ts
@@ -33,53 +33,6 @@ test("event record directories stay inside the isolated worker root", () => {
   });
 });
 
-test("event base snapshot uses durable state when the isolated worker starts empty", () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
-  const workerRoot = path.join(root, "worker");
-  const stateRoot = path.join(root, "state");
-  const store = {
-    targetRepo: "openclaw/openclaw",
-    itemNumber: "93584",
-    snapshotDir: path.join(workerRoot, "snapshot"),
-  };
-  const paths = eventRecordPaths(store);
-  fs.mkdirSync(workerRoot, { recursive: true });
-  fs.mkdirSync(stateRoot, { recursive: true });
-
-  withCwd(stateRoot, () => {
-    writeEventTuple(paths, {
-      marker: "durable previous review",
-      reviewedAt: "2026-07-24T22:16:08.206Z",
-      itemUpdatedAt: "2026-07-24T22:14:34Z",
-    });
-  });
-
-  withCwd(workerRoot, () => {
-    resetEventSnapshot(store);
-    captureEventBaseSnapshot(store);
-    writeEventTuple(paths, {
-      marker: "fresh exact review",
-      reviewedAt: "2026-07-25T03:12:20.195Z",
-      itemUpdatedAt: "2026-07-25T03:10:15Z",
-    });
-    captureEventSnapshot(store);
-    assert.throws(
-      () => applyEventSnapshot(paths, { remoteRoot: stateRoot }),
-      /missing comparable state-mutation timestamp/,
-    );
-
-    resetEventSnapshot(store);
-    captureEventBaseSnapshot(store, { sourceRoot: stateRoot });
-    writeEventTuple(paths, {
-      marker: "fresh exact review",
-      reviewedAt: "2026-07-25T03:12:20.195Z",
-      itemUpdatedAt: "2026-07-25T03:10:15Z",
-    });
-    captureEventSnapshot(store);
-    assert.equal(applyEventSnapshot(paths, { remoteRoot: stateRoot }), "open");
-  });
-});
-
 test("event snapshot match follows the final tuple winner, not only its action", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-event-records-"));
   const store = {


### PR DESCRIPTION
## Draft contingency rollback — do not merge without explicit incident approval

This draft is a contingency rollback for [#846](https://github.com/openclaw/clawsweeper/pull/846), merged as `4707e591f3a7ab04b52d13768dba57b5059a0d99` on 2026-07-25.

It is deliberately a draft: #846 fixes the proven cause of the missing #93584 re-review completion. Do not merge this PR to address #93584; its existing DLQ item does not auto-replay. Use it only if a new, post-deploy incident proves that #846 itself must be rolled back, and obtain explicit maintainer approval first.

## Scope

This selectively restores the pre-#846 production behavior:

- captures event tuple bases from the publisher working directory;
- removes #846's durable-state topology regression test.

It intentionally retains the unrelated verified-pull fixture from #843's follow-up CI repair. A complete textual revert would reintroduce the known deterministic `pnpm check` failure because it removes the `/repos/openclaw/clawsweeper/pulls/842` mock. This draft therefore contains no change to that fixture and no other production behavior.

## Risk

Merging this draft reintroduces the #93584 root cause in the isolated exact-review batch path: when a durable tuple already exists, an empty worker-root base is compared with the durable-state candidate and can terminalise as `tuple_protocol_invalid` with `missing comparable state-mutation timestamp`. It does not replay, repair, or otherwise mutate #93584.

The separate stale-publication revision conflict observed for #111368 is unaffected.

## Validation

- `pnpm run build:all`
- `node --test test/dashboard-worker.test.ts` — 208 passed
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `pnpm exec oxfmt --check src/repair/event-record-store.ts src/repair/publish-event-result.ts test/repair/event-record-store.test.ts`
- `git diff --cached --check`

## Codex review closeout

- `codex review --uncommitted` reported the expected P1: the rollback restores the durable-tuple failure.
- `codex review --base origin/main` reported the same expected P1 at `src/repair/publish-event-result.ts:156`.

That finding is intentionally rejected only because this PR is an explicit, user-requested contingency rollback. It is not a clean safety fix and must remain a draft unless a separate incident decision authorizes this exact risk.
