### PR TITLE
Fix stale exact-review publication retry loop

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1156,18 +1156,20 @@ jobs:
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           for attempt in 1 2 3; do
-            if response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-              --request POST \
-              --header "content-type: application/json" \
-              --header "x-clawsweeper-exact-review-signature: $signature" \
-              --data "$payload" \
-              "$queue_url/internal/exact-review/enqueue")" &&
-              jq -e '.ok == true and (.queued == true or (.deduped == true and .superseded != true))' <<< "$response" >/dev/null; then
+            response="$(
+              curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+                --request POST \
+                --header "content-type: application/json" \
+                --header "x-clawsweeper-exact-review-signature: $signature" \
+                --data "$payload" \
+                "$queue_url/internal/exact-review/enqueue" || true
+            )"
+            if jq -e '.superseded == true' <<< "$response" >/dev/null 2>&1; then
+              echo "::notice::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the newer publisher owns final delivery."
               exit 0
             fi
-            if jq -e '.superseded == true' <<< "${response:-}" >/dev/null 2>&1; then
-              echo "::error::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was rejected as superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the verdict was not delivered."
-              exit 1
+            if jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
+              exit 0
             fi
             if [ "$attempt" -lt 3 ]; then
               sleep "$((attempt * 5))"

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -450,10 +450,7 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.equal(upload.uses, "actions/upload-artifact@v7");
   assert.equal(upload.with?.["retention-days"], 90);
   assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
-  assert.match(
-    queuePublication.run ?? "",
-    /\.queued == true or \(\.deduped == true and \.superseded != true\)/,
-  );
+  assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
   assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
   assert.match(deferHeldReview.run ?? "", /retry deferred/);
@@ -2770,7 +2767,7 @@ test("github activity workflow scopes cancellation to matching item activity", (
   assert.doesNotMatch(concurrencyBlock, /workflow-run' \|\| 'activity'/);
 });
 
-test("exact review publication enqueue rejects a superseded acknowledgement", () => {
+test("exact review publication enqueue accepts a superseded acknowledgement", () => {
   type WorkflowStep = { name?: string; id?: string; run?: string };
   type WorkflowJob = { steps: WorkflowStep[] };
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
@@ -2781,11 +2778,7 @@ test("exact review publication enqueue rejects a superseded acknowledgement", ()
   );
   assert.ok(publicationEnqueue, "missing queue-exact-review-publication step");
   const run = publicationEnqueue.run ?? "";
-  assert.match(
-    run,
-    /\.ok == true and \(\.queued == true or \(\.deduped == true and \.superseded != true\)\)/,
-  );
-  assert.doesNotMatch(run, /\.ok == true and \(\.queued == true or \.deduped == true\)/);
+  assert.match(run, /\.ok == true and \(\.queued == true or \.deduped == true\)/);
   assert.match(run, /jq -e '\.superseded == true'/);
-  assert.match(run, /the verdict was not delivered/);
+  assert.match(run, /the newer publisher owns final delivery/);
 });


### PR DESCRIPTION
## Summary

Treat an exact-review publication queue response marked `superseded: true` as a successful handoff rather than a failed workflow step.

## Problem

During the CSW-059 monitor, [openclaw/openclaw#111368](https://github.com/openclaw/openclaw/pull/111368) repeatedly completed review generation but its publication enqueue returned `ok: true`, `deduped: true`, and `superseded: true` (publication revision 9 superseded by revision 12). The workflow then exited non-zero, so the review queue retried the same stale handoff instead of allowing the queue's newer durable publication to own delivery.

## Implementation

- Accept the queue's documented superseded acknowledgement as terminal success and emit a notice with both revisions.
- Preserve retries for transport failures, malformed responses, and all non-superseded unsuccessful enqueue responses.
- Update the workflow contract test accordingly.

## Validation

- `pnpm run build:all`
- `pnpm exec node --test --test-name-pattern "exact event review hands immutable artifacts to the queue-bounded publisher lane|exact review publication enqueue accepts a superseded acknowledgement" test/sweep-workflow.test.ts`
- `pnpm exec oxfmt --check .github/workflows/sweep.yml test/sweep-workflow.test.ts`
- `git diff --check`

The broader workflow test file has pre-existing Windows-host failures because Bash-dependent tests invoke the `docker-desktop` WSL distribution, which has no `/bin/bash`; the focused affected tests pass.

## Review closeout

- Dirty patch: `codex review --uncommitted` found two workflow/test issues; both were fixed, then focused proof was rerun and the dirty review completed cleanly.
- Committed branch: `codex review --base origin/main` completed with no actionable findings.

## Risk and rollout

This only changes handling of an explicit stale-publication acknowledgement. It does not publish stale output or suppress actual enqueue failures. Delivery still depends on the newer durable publication referenced by the queue response.

Related: CSW-059 monitoring; distinct from the #846 durable-tuple repair and CSW-058 stale-head/422 monitoring.
