### PR TITLE
Draft: revert #849 stale publication handoff

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1156,20 +1156,18 @@ jobs:
           )"
           signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
           for attempt in 1 2 3; do
-            response="$(
-              curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
-                --request POST \
-                --header "content-type: application/json" \
-                --header "x-clawsweeper-exact-review-signature: $signature" \
-                --data "$payload" \
-                "$queue_url/internal/exact-review/enqueue" || true
-            )"
-            if jq -e '.superseded == true' <<< "$response" >/dev/null 2>&1; then
-              echo "::notice::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the newer publisher owns final delivery."
+            if response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+              --request POST \
+              --header "content-type: application/json" \
+              --header "x-clawsweeper-exact-review-signature: $signature" \
+              --data "$payload" \
+              "$queue_url/internal/exact-review/enqueue")" &&
+              jq -e '.ok == true and (.queued == true or (.deduped == true and .superseded != true))' <<< "$response" >/dev/null; then
               exit 0
             fi
-            if jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null; then
-              exit 0
+            if jq -e '.superseded == true' <<< "${response:-}" >/dev/null 2>&1; then
+              echo "::error::Exact-review publication revision $(jq -r '.publication_revision // "unknown"' <<< "$response") was rejected as superseded by revision $(jq -r '.superseded_by_revision // "unknown"' <<< "$response"); the verdict was not delivered."
+              exit 1
             fi
             if [ "$attempt" -lt 3 ]; then
               sleep "$((attempt * 5))"

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -450,7 +450,10 @@ test("exact event review hands immutable artifacts to the queue-bounded publishe
   assert.equal(upload.uses, "actions/upload-artifact@v7");
   assert.equal(upload.with?.["retention-days"], 90);
   assert.match(queuePublication.run ?? "", /for attempt in 1 2 3/);
-  assert.match(queuePublication.run ?? "", /\.queued == true or \.deduped == true/);
+  assert.match(
+    queuePublication.run ?? "",
+    /\.queued == true or \(\.deduped == true and \.superseded != true\)/,
+  );
   assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
   assert.match(deferHeldReview.run ?? "", /retry deferred/);
@@ -2767,7 +2770,7 @@ test("github activity workflow scopes cancellation to matching item activity", (
   assert.doesNotMatch(concurrencyBlock, /workflow-run' \|\| 'activity'/);
 });
 
-test("exact review publication enqueue accepts a superseded acknowledgement", () => {
+test("exact review publication enqueue rejects a superseded acknowledgement", () => {
   type WorkflowStep = { name?: string; id?: string; run?: string };
   type WorkflowJob = { steps: WorkflowStep[] };
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
@@ -2778,7 +2781,11 @@ test("exact review publication enqueue accepts a superseded acknowledgement", ()
   );
   assert.ok(publicationEnqueue, "missing queue-exact-review-publication step");
   const run = publicationEnqueue.run ?? "";
-  assert.match(run, /\.ok == true and \(\.queued == true or \.deduped == true\)/);
+  assert.match(
+    run,
+    /\.ok == true and \(\.queued == true or \(\.deduped == true and \.superseded != true\)\)/,
+  );
+  assert.doesNotMatch(run, /\.ok == true and \(\.queued == true or \.deduped == true\)/);
   assert.match(run, /jq -e '\.superseded == true'/);
-  assert.match(run, /the newer publisher owns final delivery/);
+  assert.match(run, /the verdict was not delivered/);
 });


### PR DESCRIPTION
## Draft rollback for #849

This is a draft-only rollback of [#849](https://github.com/openclaw/clawsweeper/pull/849), requested as a prepared fallback after #849 merged as `a0143ccfd96d` on 2026-07-25.

## What it reverts

Restores the #836 handling in which an `ok: true`, `deduped: true`, `superseded: true` exact-review publication acknowledgement is visible as a failed workflow outcome rather than a successful handoff.

## Current status — do not merge

Codex review found a P1 against this rollback: it can restore retry churn for a stale publication while the newer durable publication owns delivery. This branch is intentionally a draft fallback only; it requires maintainer review and evidence of a bad #849 production outcome before any merge decision.

## Validation

- `pnpm run build:all`
- `pnpm exec node --test --test-name-pattern "exact review publication enqueue rejects a superseded acknowledgement" test/sweep-workflow.test.ts`
- `git diff --check origin/main`

The reverted #836 formatting is not accepted by the current formatter check; this draft preserves the exact revert without unrelated reformatting.

## References

- Merged change: #849
- Original safeguard: #836
- Monitoring context: CSW-059 / openclaw/openclaw#111368
