### PR TITLE
Fix stale existing exact-review publication revisions

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -999,6 +999,10 @@ export class ExactReviewQueue {
           // Ordinary source events retain normal replacement behavior, including the
           // command-context merge for pending items.
           if (!ignoredRecovery) {
+            const nextRevision = Math.max(
+              current.revision + 1,
+              this.nextExactReviewItemRevisionSync(key),
+            );
             // Explicit commands arrive through repository_dispatch without a webhook authority
             // tuple. Bind them to the current verified decision via the merge below. An active
             // review keeps its lease and exposes the command as a follow-up revision on completion.
@@ -1039,7 +1043,7 @@ export class ExactReviewQueue {
                 auditId: crypto.randomUUID(),
                 itemKey: key,
                 priorRevision,
-                nextRevision: priorRevision + 1,
+                nextRevision,
                 supersededRunId,
                 sourceAction: decision.sourceAction,
                 reasonCode: "newer_source_event",
@@ -1056,7 +1060,7 @@ export class ExactReviewQueue {
               : mergeable || queuesCommandFollowUp
                 ? mergePendingExactReviewDecision(current.decision, decision)
                 : decision;
-            current.revision += 1;
+            current.revision = nextRevision;
             current.updatedAt = now;
             // Immediacy must come from the merged decision: a pending explicit command
             // keeps its command marker through the merge, and a later plain webhook

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -8215,6 +8215,80 @@ test("a later exact-review cycle still publishes after an earlier cycle raised t
   assert.equal(reopened.items["openclaw/openclaw#864"].revision, 3);
 });
 
+test("an existing exact-review item rebases above the publication head on a newer source event", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const reviewKey = "openclaw/openclaw#865";
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "existing-review",
+          865,
+          "opened",
+          "issue",
+          "openclaw/openclaw",
+        ),
+      )
+    ).status,
+    202,
+  );
+  const existing = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { revision: number }>;
+  };
+  existing.items[reviewKey].revision = 7;
+  await storage.put("exact-review-queue", existing);
+
+  const recorded = await (
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "record-publication-head",
+        865,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/openclaw",
+        exactReviewPublicationOverrides(865, "8650", "opened", 12, "openclaw/openclaw"),
+      ),
+    )
+  ).json();
+  assert.equal(recorded.queued, true);
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest("newer-source", 865, "edited", "issue", "openclaw/openclaw"),
+      )
+    ).status,
+    202,
+  );
+  const rebased = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { revision: number }>;
+  };
+  assert.equal(rebased.items[reviewKey].revision, 13);
+
+  const republished = await (
+    await queue.fetch(
+      buildExactReviewQueueRequest(
+        "rebased-publication",
+        865,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/openclaw",
+        exactReviewPublicationOverrides(
+          865,
+          "8651",
+          "edited",
+          rebased.items[reviewKey].revision,
+          "openclaw/openclaw",
+        ),
+      ),
+    )
+  ).json();
+  assert.equal(republished.queued, true);
+  assert.equal(republished.superseded, undefined);
+});
+
 test("dead-letter fresh recovery seeds a review revision that can still publish", async () => {
   const storage = new MemoryDurableStorage();
   const item = leasedExactReviewPublicationItem(866, "8660");


### PR DESCRIPTION
## Summary

Rebase an existing exact-review item above its target's durable publication head whenever a newer source event updates that item.

## Problem

An existing review item can retain a local revision below the permanent publication head for the same target. A normal re-review then incremented only the stale local value (for example, 7 to 8 to 9 while the durable head was 12), so its artifact was rejected as superseded before publisher, state writer, router, or final comment delivery.

## Implementation

- Compute the next existing-item revision as `max(current + 1, publication head + 1)`.
- Keep the supersession audit's recorded next revision aligned with the rebased value.
- Add a lifecycle regression test for persisted revision 7, publication head 12, and a newer source event producing revision 13 that queues normally.

## Validation

- `pnpm run build:dashboard`
- `pnpm exec node --test --test-name-pattern "a later exact-review cycle still publishes after an earlier cycle raised the publication head|an existing exact-review item rebases above the publication head on a newer source event" test/dashboard-worker.test.ts`
- `pnpm exec oxfmt --check dashboard/exact-review-queue.ts test/dashboard-worker.test.ts`
- `git diff --check`

## Review closeout

- `codex review --uncommitted`: clean after focused proof.
- `codex review --base origin/main`: clean; reviewer also ran all 209 `test/dashboard-worker.test.ts` tests successfully.

## Risk and rollout

This affects only an incoming newer source event updating an existing review item. It does not replay, mutate, or change already completed publications. It closes the pre-existing-item gap left after #836 seeded only new items above the durable head.

Related: #836, #849, and CSW-059 / openclaw/openclaw#111368.
