### PR TITLE
revert: terminalize targets before dispatch

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -210,10 +210,6 @@ export type ExactReviewQueueState = {
     publicationBatchDispatchedAt?: number;
     publicationBatchDispatchSucceeded?: boolean;
     publicationBatchDispatchPendingUntil?: number;
-    // A batch workflow may only claim the exact selection that the dispatcher
-    // terminal-probed immediately before its dispatch. The marker is cleared
-    // when that departure is consumed, fails, or expires.
-    publicationBatchTerminalProbe?: string;
   };
 };
 type LegacyExactReviewQueueState = ExactReviewQueueState & {
@@ -2028,8 +2024,8 @@ export class ExactReviewQueue {
       this.reconcileStoredReviewRunsSync(startedAt);
       this.syncLegacyCompatibilitySync(this.readStateSync());
     });
-    let snapshot = this.readStateSync();
-    let snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(startedAt);
+    const snapshot = this.readStateSync();
+    const snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(startedAt);
     const reclaimedSnapshot = reclaimExpiredExactReviewLeases(
       snapshot,
       startedAt,
@@ -2037,26 +2033,11 @@ export class ExactReviewQueue {
       exactReviewHeartbeatGraceMs(this.env),
     );
     const expiredSnapshot = expireExactReviewPublicationItems(snapshot, startedAt, this.env);
-    let snapshotChanged = reclaimedSnapshot || expiredSnapshot;
-    if (
-      snapshot.dispatcher?.publicationBatchTerminalProbe &&
-      Number(snapshot.dispatcher.publicationBatchDispatchPendingUntil || 0) <= startedAt
-    ) {
-      const dispatcher = { ...snapshot.dispatcher };
-      delete dispatcher.publicationBatchTerminalProbe;
-      snapshot.dispatcher = dispatcher;
-      snapshotChanged = true;
-    }
-    // Persist early housekeeping and an expired preflight fence before target
-    // reads release the input gate. A later workflow must never consume an old
-    // terminal probe as though it belonged to its new departure.
-    if (snapshotChanged) {
-      await this.writeState(snapshot);
-    }
+    const snapshotChanged = reclaimedSnapshot || expiredSnapshot;
     const capacity = exactReviewQueueCapacity(this.env);
     const targetCapacity = exactReviewTargetCapacity(this.env);
-    let snapshotPublicationControl = this.refreshPublicationControlSync(snapshot, startedAt);
-    let snapshotPublicationCapacity = exactReviewPublicationCapacityForState(
+    const snapshotPublicationControl = this.refreshPublicationControlSync(snapshot, startedAt);
+    const snapshotPublicationCapacity = exactReviewPublicationCapacityForState(
       this.env,
       snapshot,
       startedAt,
@@ -2064,7 +2045,7 @@ export class ExactReviewQueue {
       true,
       snapshotPublicationControl.demandCapacity,
     );
-    let snapshotAdmission = exactReviewQueueAdmittedItems(
+    const snapshotAdmission = exactReviewQueueAdmittedItems(
       snapshot,
       startedAt,
       capacity,
@@ -2073,7 +2054,7 @@ export class ExactReviewQueue {
       new Set<string>(snapshotBatchOwnership.itemKeys),
       exactReviewPublicationBatchingEnabled(this.env) || snapshotBatchOwnership.itemKeys.length > 0,
     );
-    let snapshotBatchDeparture = exactReviewPublicationBatchDeparture(
+    const snapshotBatchDeparture = exactReviewPublicationBatchDeparture(
       this.env,
       snapshot,
       startedAt,
@@ -2081,96 +2062,10 @@ export class ExactReviewQueue {
       snapshotBatchOwnership.activeBatches,
       this.freshPublicationItemKeysSync(snapshot, startedAt),
     );
-    let snapshotBatchCandidates = snapshotBatchDeparture?.due
-      ? this.publicationBatchCandidates(
-          snapshot,
-          startedAt,
-          snapshotBatchOwnership,
-          snapshotPublicationCapacity,
-          MAX_EXACT_REVIEW_PUBLICATION_BATCH_SCAN_SIZE,
-          Math.min(
-            MAX_EXACT_REVIEW_PUBLICATION_BATCH_SCAN_SIZE,
-            exactReviewPublicationBatchSize(this.env),
-          ),
-        )
-      : [];
-    let snapshotDispatcherBackoffActive =
-      (snapshot.dispatcher?.state === "paused" || snapshot.dispatcher?.state === "blocked") &&
-      Number(snapshot.dispatcher?.retryAt || 0) > startedAt;
-    let batchTerminalPreflightReady = false;
-    if (snapshotBatchDeparture?.due && !snapshotDispatcherBackoffActive) {
-      const batchTerminalProbe = exactReviewPublicationBatchCandidateProbe(snapshotBatchCandidates);
-      const terminalized = await this.terminalizePublicationCandidates(
-        snapshotBatchCandidates.map((item) => ({
-          key: item.key,
-          revision: item.revision,
-          decision: item.decision,
-        })),
-      );
-      if (terminalized) {
-        await this.scheduleNext(this.readStateSync(), Date.now());
-        return;
-      }
-
-      // Target reads release the Durable Object input gate. Recompute the
-      // departure and admit a workflow only when its exact eventual claim is
-      // the selection that was just checked. A concurrent fresh item or owner
-      // change gets a new departure and therefore a new probe.
-      const recheckedAt = Date.now();
-      snapshot = this.readStateSync();
-      snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(recheckedAt);
-      snapshotPublicationControl = this.refreshPublicationControlSync(snapshot, recheckedAt);
-      snapshotPublicationCapacity = exactReviewPublicationCapacityForState(
-        this.env,
-        snapshot,
-        recheckedAt,
-        snapshotPublicationControl.capacityCeiling,
-        true,
-        snapshotPublicationControl.demandCapacity,
-      );
-      snapshotAdmission = exactReviewQueueAdmittedItems(
-        snapshot,
-        recheckedAt,
-        capacity,
-        targetCapacity,
-        snapshotPublicationCapacity,
-        new Set<string>(snapshotBatchOwnership.itemKeys),
-        exactReviewPublicationBatchingEnabled(this.env) ||
-          snapshotBatchOwnership.itemKeys.length > 0,
-      );
-      snapshotBatchDeparture = exactReviewPublicationBatchDeparture(
-        this.env,
-        snapshot,
-        recheckedAt,
-        new Set(snapshotBatchOwnership.itemKeys),
-        snapshotBatchOwnership.activeBatches,
-        this.freshPublicationItemKeysSync(snapshot, recheckedAt),
-      );
-      snapshotBatchCandidates = snapshotBatchDeparture?.due
-        ? this.publicationBatchCandidates(
-            snapshot,
-            recheckedAt,
-            snapshotBatchOwnership,
-            snapshotPublicationCapacity,
-            MAX_EXACT_REVIEW_PUBLICATION_BATCH_SCAN_SIZE,
-            Math.min(
-              MAX_EXACT_REVIEW_PUBLICATION_BATCH_SCAN_SIZE,
-              exactReviewPublicationBatchSize(this.env),
-            ),
-          )
-        : [];
-      snapshotDispatcherBackoffActive =
-        (snapshot.dispatcher?.state === "paused" || snapshot.dispatcher?.state === "blocked") &&
-        Number(snapshot.dispatcher?.retryAt || 0) > recheckedAt;
-      batchTerminalPreflightReady =
-        snapshotBatchDeparture?.due === true &&
-        !snapshotDispatcherBackoffActive &&
-        exactReviewPublicationBatchCandidateProbe(snapshotBatchCandidates) === batchTerminalProbe;
-    }
     let batchDispatchAttempted = false;
     let batchDispatchSucceeded = false;
     let batchDispatchRecordedAt: number | undefined;
-    if (snapshotBatchDeparture?.due && batchTerminalPreflightReady) {
+    if (snapshotBatchDeparture?.due) {
       batchDispatchAttempted = true;
       batchDispatchRecordedAt = Date.now();
       const reserved = this.readStateSync();
@@ -2184,8 +2079,6 @@ export class ExactReviewQueue {
         publicationBatchDispatchSucceeded: undefined,
         publicationBatchDispatchPendingUntil:
           batchDispatchRecordedAt + exactReviewPublicationBatchDispatchReservationMs(this.env),
-        publicationBatchTerminalProbe:
-          exactReviewPublicationBatchCandidateProbe(snapshotBatchCandidates),
       };
       await this.writeState(reserved);
       try {
@@ -2204,10 +2097,7 @@ export class ExactReviewQueue {
       if (current.dispatcher?.publicationBatchDispatchedAt === batchDispatchRecordedAt) {
         const dispatcher = { ...current.dispatcher };
         dispatcher.publicationBatchDispatchSucceeded = batchDispatchSucceeded;
-        if (!batchDispatchSucceeded) {
-          delete dispatcher.publicationBatchDispatchPendingUntil;
-          delete dispatcher.publicationBatchTerminalProbe;
-        }
+        if (!batchDispatchSucceeded) delete dispatcher.publicationBatchDispatchPendingUntil;
         current.dispatcher = dispatcher;
         reclaimExpiredExactReviewLeases(
           current,
@@ -2221,6 +2111,7 @@ export class ExactReviewQueue {
     }
     if (!snapshotAdmission.length) {
       const current = batchDispatchAttempted ? this.readStateSync() : snapshot;
+      if (snapshotChanged && !batchDispatchAttempted) await this.writeState(snapshot);
       await this.scheduleNext(current, Date.now());
       return;
     }
@@ -2230,6 +2121,7 @@ export class ExactReviewQueue {
       snapshotAdmission.some((item) => !exactReviewQueueIsPublication(item)) &&
       !snapshotAdmission.some(exactReviewQueueIsPublication)
     ) {
+      if (snapshotChanged && !batchDispatchAttempted) await this.writeState(snapshot);
       await this.scheduleNext(batchDispatchAttempted ? this.readStateSync() : snapshot, startedAt);
       return;
     }
@@ -2370,45 +2262,10 @@ export class ExactReviewQueue {
         }
       },
     );
-    // The legacy lane can admit more ordinary publications than the bounded
-    // review probe. Check its entire dispatch set, not a prefix, so a closed
-    // item cannot slip past the probe simply because it was later in admission
-    // order. Command/status acknowledgements retain their normal completion
-    // route even when their target is terminal.
-    const publicationCandidates = admission
-      .filter(
-        (item) => exactReviewQueueIsPublication(item) && !exactReviewQueueHasCommandContext(item),
-      )
-      .map((item) => ({ key: item.key, revision: item.revision, decision: item.decision }));
-    const livePublicationStates = await mapWithConcurrency(
-      publicationCandidates,
-      EXACT_REVIEW_ADMISSION_LIVE_CHECK_CONCURRENCY,
-      async (candidate) => {
-        try {
-          const token = await targetTokenFor(candidate.decision.targetRepo);
-          return {
-            ...candidate,
-            state: await exactReviewTargetItemState(token, candidate.decision),
-          };
-        } catch (error) {
-          // Do not convert a target-read failure into a terminal result or a
-          // new retry class. Publication delivery retains its established path.
-          console.warn(
-            `exact-review publication terminal check failed for ${candidate.key}`,
-            error instanceof Error ? error.message : String(error),
-          );
-          return { ...candidate, state: { state: "unavailable" as const } };
-        }
-      },
-    );
 
     const checkedAt = Date.now();
     const liveStateByCandidate = new Map(liveStates.map((candidate) => [candidate.key, candidate]));
-    const livePublicationStateByCandidate = new Map(
-      livePublicationStates.map((candidate) => [candidate.key, candidate]),
-    );
     const checkedState = this.readStateSync();
-    const checkedBatchOwnership = this.batchStore.activeLeaseSnapshot(checkedAt);
     const checkedBatchDispatcherFields = batchDispatcherFieldsFor(checkedState.dispatcher);
     const priorDispatchConsecutiveFailures = Number(
       checkedState.dispatcher?.dispatchConsecutiveFailures || 0,
@@ -2496,23 +2353,6 @@ export class ExactReviewQueue {
         item.updatedAt = checkedAt;
       }
     }
-    let terminalPublications = 0;
-    for (const candidate of livePublicationStates) {
-      const item = checkedState.items[candidate.key];
-      if (
-        !item ||
-        item.revision !== candidate.revision ||
-        item.state !== "pending" ||
-        !exactReviewQueueIsPublication(item) ||
-        exactReviewQueueHasCommandContext(item) ||
-        checkedBatchOwnership.itemKeys.includes(item.key) ||
-        candidate.state.state !== "terminal"
-      ) {
-        continue;
-      }
-      delete checkedState.items[item.key];
-      terminalPublications += 1;
-    }
     if (globalAdmissionFailure) {
       const consecutiveFailures = priorDispatchConsecutiveFailures + 1;
       const retryAt =
@@ -2533,13 +2373,8 @@ export class ExactReviewQueue {
       };
       await this.writeState(
         checkedState,
-        terminalCompleted || terminalPublications || supersessionAudits.length
-          ? {
-              reviewCompleted: terminalCompleted,
-              reviewSuperseded: supersessionAudits.length,
-              publicationCompleted: terminalPublications,
-              publicationSuperseded: terminalPublications,
-            }
+        terminalCompleted || supersessionAudits.length
+          ? { reviewCompleted: terminalCompleted, reviewSuperseded: supersessionAudits.length }
           : undefined,
         undefined,
         undefined,
@@ -2551,11 +2386,7 @@ export class ExactReviewQueue {
     const dispatchable = admission.flatMap((candidate) => {
       const item = checkedState.items[candidate.key];
       if (!item || item.revision !== candidate.revision || item.state !== "pending") return [];
-      if (exactReviewQueueIsPublication(item)) {
-        if (checkedBatchOwnership.itemKeys.includes(item.key)) return [];
-        const livePublication = livePublicationStateByCandidate.get(candidate.key);
-        return !livePublication || livePublication.state.state !== "terminal" ? [item] : [];
-      }
+      if (exactReviewQueueIsPublication(item)) return [item];
       const live = liveStateByCandidate.get(candidate.key);
       // A command acknowledgement needs the workflow's terminal completion
       // path even when the target is already closed. Unprobed reviews wait for
@@ -2606,13 +2437,8 @@ export class ExactReviewQueue {
     }
     await this.writeState(
       checkedState,
-      terminalCompleted || terminalPublications || supersessionAudits.length
-        ? {
-            reviewCompleted: terminalCompleted,
-            reviewSuperseded: supersessionAudits.length,
-            publicationCompleted: terminalPublications,
-            publicationSuperseded: terminalPublications,
-          }
+      terminalCompleted || supersessionAudits.length
+        ? { reviewCompleted: terminalCompleted, reviewSuperseded: supersessionAudits.length }
         : undefined,
       undefined,
       undefined,
@@ -2717,75 +2543,6 @@ export class ExactReviewQueue {
     }
     if (currentChanged) await this.writeState(current);
     await this.scheduleNext(current, completedAt);
-  }
-
-  private async terminalizePublicationCandidates(
-    candidates: Array<Pick<ExactReviewQueueItem, "key" | "revision" | "decision">>,
-  ) {
-    const ordinaryCandidates = candidates.filter(
-      (item) => !exactReviewQueueHasCommandContext(item),
-    );
-    if (!ordinaryCandidates.length) return 0;
-
-    const targetTokens = new Map<string, Promise<string>>();
-    const targetTokenFor = (targetRepo: string) => {
-      let token = targetTokens.get(targetRepo);
-      if (!token) {
-        token = exactReviewTargetReadToken(this.env, targetRepo);
-        targetTokens.set(targetRepo, token);
-      }
-      return token;
-    };
-    const liveStates = await mapWithConcurrency(
-      ordinaryCandidates,
-      EXACT_REVIEW_ADMISSION_LIVE_CHECK_CONCURRENCY,
-      async (candidate) => {
-        try {
-          const token = await targetTokenFor(candidate.decision.targetRepo);
-          return {
-            ...candidate,
-            state: await exactReviewTargetItemState(token, candidate.decision),
-          };
-        } catch (error) {
-          // Keep the established publication behavior on a target-read failure:
-          // retain the item for its normal delivery/retry path rather than
-          // treating a temporary lookup problem as a terminal result.
-          console.warn(
-            `exact-review publication terminal check failed for ${candidate.key}`,
-            error instanceof Error ? error.message : String(error),
-          );
-          return { ...candidate, state: { state: "unavailable" as const } };
-        }
-      },
-    );
-
-    const checkedAt = Date.now();
-    const checkedState = this.readStateSync();
-    const batchOwnership = this.batchStore.activeLeaseSnapshot(checkedAt);
-    let completed = 0;
-    for (const candidate of liveStates) {
-      const item = checkedState.items[candidate.key];
-      if (
-        !item ||
-        item.revision !== candidate.revision ||
-        item.state !== "pending" ||
-        !exactReviewQueueIsPublication(item) ||
-        exactReviewQueueHasCommandContext(item) ||
-        batchOwnership.itemKeys.includes(item.key) ||
-        candidate.state.state !== "terminal"
-      ) {
-        continue;
-      }
-      delete checkedState.items[item.key];
-      completed += 1;
-    }
-    if (completed) {
-      await this.writeState(checkedState, {
-        publicationCompleted: completed,
-        publicationSuperseded: completed,
-      });
-    }
-    return completed;
   }
 
   private listDeadLetters(value: unknown) {
@@ -3851,14 +3608,42 @@ export class ExactReviewQueue {
     });
   }
 
-  private publicationBatchCandidates(
-    state: ExactReviewQueueState,
-    now: number,
-    batchOwnership: { itemKeys: string[] },
-    publicationCapacity: number,
-    requestedSize: number,
-    leaseSize: number,
-  ) {
+  private async claimPublicationBatch(value: unknown) {
+    // The rollout switch closes only new admission. Fetch and complete stay available so
+    // disabling the flag cannot strand ownership that was leased before the config change.
+    if (!exactReviewPublicationBatchingEnabled(this.env)) {
+      return json({ error: "publication_batching_disabled" }, 409);
+    }
+    const body = objectValue(value);
+    const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
+    const claimId = exactReviewPublicationBatchId(body.claim_id);
+    if (!leaseOwner) return json({ error: "invalid_lease_owner" }, 400);
+    if (!claimId) return json({ error: "invalid_claim_id" }, 400);
+    const configuredSize = exactReviewPublicationBatchSize(this.env);
+    const requestedSize = body.max_items === undefined ? configuredSize : Number(body.max_items);
+    if (
+      !Number.isInteger(requestedSize) ||
+      requestedSize < 1 ||
+      requestedSize > MAX_EXACT_REVIEW_PUBLICATION_BATCH_SCAN_SIZE
+    ) {
+      return json({ error: "invalid_max_items" }, 400);
+    }
+    // The workflow may ask to scan farther than the deployed lease size so an
+    // owner-homogeneous batch can be filled through interleaved repositories.
+    // Keep the configured size as the hard mutation/lease boundary.
+    const leaseSize = Math.min(requestedSize, configuredSize);
+    const now = Date.now();
+    const state = this.readStateSync();
+    const batchOwnership = this.batchStore.activeLeaseSnapshot(now);
+    const publicationControl = this.refreshPublicationControlSync(state, now);
+    const publicationCapacity = exactReviewPublicationCapacityForState(
+      this.env,
+      state,
+      now,
+      publicationControl.capacityCeiling,
+      true,
+      publicationControl.demandCapacity,
+    );
     // The outer comparison charges one publisher slot for the whole batch. The
     // shared helper counts candidate rows, so widen only its scan window by
     // requestedSize; passing +1 here would silently collapse every batch to one.
@@ -3900,108 +3685,10 @@ export class ExactReviewQueue {
     // One GitHub App installation token is scoped to one owner. Keeping a batch
     // owner-homogeneous lets the workflow retain least privilege without serially
     // minting and exporting a different credential for every item.
-    return readyCandidates
+    const candidates = readyCandidates
       .filter((item) => item.decision.targetRepo.split("/", 1)[0]?.toLowerCase() === firstOwner)
-      .slice(0, leaseSize);
-  }
-
-  private async claimPublicationBatch(value: unknown) {
-    // The rollout switch closes only new admission. Fetch and complete stay available so
-    // disabling the flag cannot strand ownership that was leased before the config change.
-    if (!exactReviewPublicationBatchingEnabled(this.env)) {
-      return json({ error: "publication_batching_disabled" }, 409);
-    }
-    const body = objectValue(value);
-    const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
-    const claimId = exactReviewPublicationBatchId(body.claim_id);
-    if (!leaseOwner) return json({ error: "invalid_lease_owner" }, 400);
-    if (!claimId) return json({ error: "invalid_claim_id" }, 400);
-    const configuredSize = exactReviewPublicationBatchSize(this.env);
-    const requestedSize = body.max_items === undefined ? configuredSize : Number(body.max_items);
-    if (
-      !Number.isInteger(requestedSize) ||
-      requestedSize < 1 ||
-      requestedSize > MAX_EXACT_REVIEW_PUBLICATION_BATCH_SCAN_SIZE
-    ) {
-      return json({ error: "invalid_max_items" }, 400);
-    }
-    // The workflow may ask to scan farther than the deployed lease size so an
-    // owner-homogeneous batch can be filled through interleaved repositories.
-    // Keep the configured size as the hard mutation/lease boundary.
-    const leaseSize = Math.min(requestedSize, configuredSize);
-    const now = Date.now();
-    const state = this.readStateSync();
-    // A workflow retry keeps its original claim id and owner. Its first claim
-    // consumed the departure reservation, so return that live lease before
-    // requiring a terminal probe for a newer departure.
-    const existingBatch = this.batchStore.fetch(claimId, leaseOwner, now);
-    if (existingBatch?.state === "leased") {
-      await this.scheduleNext(state, now);
-      const oldestCandidateAt = existingBatch.items.reduce(
-        (oldest, membership) =>
-          Math.min(oldest, state.items[membership.itemKey]?.createdAt ?? existingBatch.createdAt),
-        existingBatch.createdAt,
-      );
-      return json({
-        ok: true,
-        claimed: true,
-        batch: exactReviewPublicationBatchJson(existingBatch),
-        configured_batch_size: existingBatch.configuredBatchSize,
-        batch_wait_ms: Math.max(0, now - oldestCandidateAt),
-        requested_max_items: requestedSize,
-        effective_max_items: leaseSize,
-      });
-    }
-    const batchOwnership = this.batchStore.activeLeaseSnapshot(now);
-    const publicationControl = this.refreshPublicationControlSync(state, now);
-    const publicationCapacity = exactReviewPublicationCapacityForState(
-      this.env,
-      state,
-      now,
-      publicationControl.capacityCeiling,
-      true,
-      publicationControl.demandCapacity,
-    );
-    const candidates = this.publicationBatchCandidates(
-      state,
-      now,
-      batchOwnership,
-      publicationCapacity,
-      requestedSize,
-      leaseSize,
-    );
-    const candidateProbe = exactReviewPublicationBatchCandidateProbe(candidates);
-    const dispatchReservationActive =
-      Number(state.dispatcher?.publicationBatchDispatchPendingUntil || 0) > now;
-    // Before the dispatcher has ever launched a workflow, retain the existing
-    // direct-claim compatibility. Once it has, every subsequent workflow claim
-    // must carry a live terminal probe; an old delayed workflow cannot erase a
-    // newer departure's fence and fall back to an unprobed claim.
-    const terminalProbeRequired = state.dispatcher?.publicationBatchDispatchedAt !== undefined;
-    // A dispatch reservation written by the previous queue version predates
-    // the probe marker. Let that already-in-flight workflow finish during a
-    // rolling deployment; new departures always persist a probe.
-    const legacyDispatchReservation =
-      dispatchReservationActive && state.dispatcher?.publicationBatchTerminalProbe === undefined;
-    const probeMatches =
-      !terminalProbeRequired ||
-      legacyDispatchReservation ||
-      (dispatchReservationActive &&
-        state.dispatcher.publicationBatchTerminalProbe === candidateProbe);
-    if (!probeMatches) {
-      // Leave the current fence intact. This request may belong to a delayed
-      // workflow from an earlier departure; clearing here could let the current
-      // workflow claim an unprobed, newer selection.
-      await this.scheduleNext(state, now);
-      return json({
-        ok: true,
-        claimed: false,
-        batch: null,
-        requested_max_items: requestedSize,
-        effective_max_items: leaseSize,
-        preflight_required: true,
-      });
-    }
+      .slice(0, leaseSize)
+      .map((item) => ({ itemKey: item.key, revision: item.revision }));
     const batch = this.batchStore.claim({
       batchId: claimId,
       leaseOwner,
@@ -4009,20 +3696,15 @@ export class ExactReviewQueue {
       now,
       maxItems: leaseSize,
       maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
-      candidates: candidates.map((item) => ({ itemKey: item.key, revision: item.revision })),
+      candidates,
     });
-    if (
-      state.dispatcher?.publicationBatchDispatchPendingUntil ||
-      state.dispatcher?.publicationBatchTerminalProbe
-    ) {
+    if (state.dispatcher?.publicationBatchDispatchPendingUntil) {
       const dispatcher = { ...state.dispatcher };
       delete dispatcher.publicationBatchDispatchPendingUntil;
-      delete dispatcher.publicationBatchTerminalProbe;
       state.dispatcher = dispatcher;
       this.writeStateSync(state);
     }
     if (!batch) {
-      await this.scheduleNext(state, now);
       return json({
         ok: true,
         claimed: false,
@@ -8769,16 +8451,7 @@ function exactReviewBatchDispatcherFields(dispatcher: ExactReviewQueueState["dis
     ...(dispatcher?.publicationBatchDispatchPendingUntil
       ? { publicationBatchDispatchPendingUntil: dispatcher.publicationBatchDispatchPendingUntil }
       : {}),
-    ...(dispatcher?.publicationBatchTerminalProbe
-      ? { publicationBatchTerminalProbe: dispatcher.publicationBatchTerminalProbe }
-      : {}),
   };
-}
-
-function exactReviewPublicationBatchCandidateProbe(
-  candidates: ReadonlyArray<Pick<ExactReviewQueueItem, "key" | "revision">>,
-) {
-  return JSON.stringify(candidates.map((candidate) => [candidate.key, candidate.revision]));
 }
 
 function exactReviewPublicationBatchLeaseMs(env) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4746,384 +4746,6 @@ test("exact-review queue resolves missing target responses before dispatch", asy
   }
 });
 
-test("exact-review queue terminalizes every admitted ordinary publication before legacy dispatch", async () => {
-  let liveChecks = 0;
-  const harness = createExactReviewAdmissionHarness(
-    (_targetRepo, itemNumber) => {
-      liveChecks += 1;
-      return jsonResponse({ state: itemNumber === 9215 ? "closed" : "open" });
-    },
-    { maxConcurrent: "16" },
-  );
-  try {
-    for (let itemNumber = 9211; itemNumber <= 9215; itemNumber += 1) {
-      const itemKind = itemNumber === 9215 ? "pull_request" : "issue";
-      const publication = exactReviewPublicationOverrides(
-        itemNumber,
-        String(itemNumber * 10),
-        "opened",
-        1,
-        "openclaw/gogcli",
-      );
-      if (itemKind === "pull_request") {
-        publication.publication.producerDecision.itemKind = "pull_request";
-        publication.publication.producerDecision.sourceEvent = "pull_request";
-      }
-      assert.equal(
-        (
-          await harness.queue.fetch(
-            buildExactReviewQueueRequest(
-              `legacy-terminal-${itemNumber}`,
-              itemNumber,
-              "exact_review_artifact_publish",
-              itemKind,
-              "openclaw/gogcli",
-              publication,
-            ),
-          )
-        ).status,
-        202,
-      );
-    }
-
-    await harness.queue.alarm();
-
-    // The legacy admission can contain more rows than the four-review probe.
-    // Its fifth item is a merged pull request and must never be dispatched.
-    assert.equal(liveChecks, 5);
-    assert.equal(harness.dispatched.length, 4);
-    const stats = await (
-      await harness.queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
-    ).json();
-    assert.equal(stats.lanes.publication.completed_total, 1);
-    assert.equal(stats.lanes.publication.superseded_total, 1);
-    const terminal = await (
-      await harness.queue.fetch(
-        new Request(
-          "https://clawsweeper-exact-review-queue/item-status?target_repo=openclaw%2Fgogcli&item_number=9215",
-        ),
-      )
-    ).json();
-    assert.equal(terminal.items.length, 0);
-  } finally {
-    harness.restore();
-  }
-});
-
-test("exact-review batch preflight follows the publisher owner selection", async () => {
-  const checked: Array<[string, number]> = [];
-  const harness = createExactReviewAdmissionHarness(
-    (targetRepo, itemNumber) => {
-      checked.push([targetRepo, itemNumber]);
-      return jsonResponse({ state: targetRepo === "alpha/repo" ? "closed" : "open" });
-    },
-    {
-      publicationBatching: true,
-      publicationBatchSize: "2",
-      captureBatchDispatch: true,
-    },
-  );
-  try {
-    for (const [deliveryId, itemNumber, targetRepo] of [
-      ["owner-alpha", 9221, "alpha/repo"],
-      ["owner-beta-1", 9222, "beta/repo"],
-      ["owner-beta-2", 9223, "beta/repo"],
-    ] as const) {
-      assert.equal(
-        (
-          await harness.queue.fetch(
-            buildExactReviewQueueRequest(
-              deliveryId,
-              itemNumber,
-              "exact_review_artifact_publish",
-              "issue",
-              targetRepo,
-              exactReviewPublicationOverrides(
-                itemNumber,
-                String(itemNumber * 10),
-                "opened",
-                1,
-                targetRepo,
-              ),
-            ),
-          )
-        ).status,
-        202,
-      );
-    }
-
-    await harness.queue.alarm();
-
-    // Departure policy sees beta's full batch, while the publisher picks the
-    // oldest alpha owner. The preflight must inspect that publisher selection.
-    assert.deepEqual(checked, [["alpha/repo", 9221]]);
-    assert.equal(harness.batchDispatches, 0);
-    const terminal = await (
-      await harness.queue.fetch(
-        new Request(
-          "https://clawsweeper-exact-review-queue/item-status?target_repo=alpha%2Frepo&item_number=9221",
-        ),
-      )
-    ).json();
-    assert.equal(terminal.items.length, 0);
-  } finally {
-    harness.restore();
-  }
-});
-
-test("exact-review batch terminal probe resets for a later departure", async () => {
-  const originalNow = Date.now;
-  let now = Date.parse("2026-07-25T12:00:00.000Z");
-  Date.now = () => now;
-  let terminal = false;
-  let dispatchAttempts = 0;
-  const harness = createExactReviewAdmissionHarness(
-    () => jsonResponse({ state: terminal ? "closed" : "open" }),
-    {
-      publicationBatching: true,
-      captureBatchDispatch: true,
-      batchDispatch: () => {
-        dispatchAttempts += 1;
-        return new Response(null, { status: 500 });
-      },
-    },
-  );
-  try {
-    const itemNumber = 9231;
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "batch-probe-reset",
-            itemNumber,
-            "exact_review_artifact_publish",
-            "issue",
-            "openclaw/gogcli",
-            exactReviewPublicationOverrides(itemNumber, "92310"),
-          ),
-        )
-      ).status,
-      202,
-    );
-
-    await harness.queue.alarm();
-    assert.equal(harness.batchDispatches, 1);
-    assert.equal(dispatchAttempts, 1);
-
-    terminal = true;
-    now += 300_000;
-    await harness.queue.alarm();
-
-    // A failed dispatch begins a new departure; it must not reuse the first
-    // open probe to publish the now-closed item.
-    assert.equal(harness.batchDispatches, 1);
-    const item = await (
-      await harness.queue.fetch(
-        new Request(
-          "https://clawsweeper-exact-review-queue/item-status?target_repo=openclaw%2Fgogcli&item_number=9231",
-        ),
-      )
-    ).json();
-    assert.equal(item.items.length, 0);
-  } finally {
-    Date.now = originalNow;
-    harness.restore();
-  }
-});
-
-test("exact-review batch claims keep a newer departure fence when an older workflow arrives", async () => {
-  const originalNow = Date.now;
-  let now = Date.parse("2026-07-25T13:00:00.000Z");
-  Date.now = () => now;
-  let releaseBatchDispatch!: () => void;
-  let signalBatchDispatch!: () => void;
-  const batchDispatchStarted = new Promise<void>((resolve) => {
-    signalBatchDispatch = resolve;
-  });
-  const batchDispatchRelease = new Promise<void>((resolve) => {
-    releaseBatchDispatch = resolve;
-  });
-  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
-    publicationBatching: true,
-    publicationBatchSize: "2",
-    publicationFreshLane: true,
-    captureBatchDispatch: true,
-    batchDispatch: async () => {
-      signalBatchDispatch();
-      await batchDispatchRelease;
-      return new Response(null, { status: 204 });
-    },
-  });
-  try {
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "delayed-workflow-old",
-            9241,
-            "exact_review_artifact_publish",
-            "issue",
-            "openclaw/gogcli",
-            exactReviewPublicationOverrides(9241, "92410"),
-          ),
-        )
-      ).status,
-      202,
-    );
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "delayed-workflow-old-second",
-            9242,
-            "exact_review_artifact_publish",
-            "issue",
-            "openclaw/gogcli",
-            exactReviewPublicationOverrides(9242, "92420"),
-          ),
-        )
-      ).status,
-      202,
-    );
-    now += 16 * 60_000;
-    const alarm = harness.queue.alarm();
-    await batchDispatchStarted;
-
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "delayed-workflow-fresh",
-            9243,
-            "exact_review_artifact_publish",
-            "issue",
-            "openclaw/gogcli",
-            exactReviewPublicationOverrides(9243, "92430"),
-          ),
-        )
-      ).status,
-      202,
-    );
-
-    const firstDelayedClaim = await (
-      await harness.queue.fetch(
-        new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
-          method: "POST",
-          body: JSON.stringify({ claim_id: "delayed-claim-old", lease_owner: "worker-old" }),
-        }),
-      )
-    ).json();
-    const secondDelayedClaim = await (
-      await harness.queue.fetch(
-        new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
-          method: "POST",
-          body: JSON.stringify({ claim_id: "delayed-claim-new", lease_owner: "worker-new" }),
-        }),
-      )
-    ).json();
-    assert.equal(firstDelayedClaim.claimed, false);
-    assert.equal(firstDelayedClaim.preflight_required, true);
-    assert.equal(secondDelayedClaim.claimed, false);
-    assert.equal(secondDelayedClaim.preflight_required, true);
-
-    releaseBatchDispatch();
-    await alarm;
-  } finally {
-    Date.now = originalNow;
-    harness.restore();
-  }
-});
-
-test("exact-review batch claim retries resume their existing leased batch", async () => {
-  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
-    publicationBatching: true,
-    captureBatchDispatch: true,
-  });
-  try {
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "batch-claim-retry",
-            9244,
-            "exact_review_artifact_publish",
-            "issue",
-            "openclaw/gogcli",
-            exactReviewPublicationOverrides(9244, "92440"),
-          ),
-        )
-      ).status,
-      202,
-    );
-    await harness.queue.alarm();
-    assert.equal(harness.batchDispatches, 1);
-
-    const request = () =>
-      new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
-        method: "POST",
-        body: JSON.stringify({ claim_id: "retry-claim", lease_owner: "retry-worker" }),
-      });
-    const first = await (await harness.queue.fetch(request())).json();
-    const retry = await (await harness.queue.fetch(request())).json();
-
-    assert.equal(first.claimed, true, JSON.stringify(first));
-    assert.equal(retry.claimed, true, JSON.stringify(retry));
-    assert.equal(retry.batch.batch_id, first.batch.batch_id);
-    assert.deepEqual(retry.batch.items, first.batch.items);
-  } finally {
-    harness.restore();
-  }
-});
-
-test("exact-review batch accepts an in-flight pre-probe rolling-deploy departure", async () => {
-  const originalNow = Date.now;
-  const now = Date.parse("2026-07-25T14:00:00.000Z");
-  Date.now = () => now;
-  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
-    publicationBatching: true,
-  });
-  try {
-    assert.equal(
-      (
-        await harness.queue.fetch(
-          buildExactReviewQueueRequest(
-            "pre-probe-departure",
-            9245,
-            "exact_review_artifact_publish",
-            "issue",
-            "openclaw/gogcli",
-            exactReviewPublicationOverrides(9245, "92450"),
-          ),
-        )
-      ).status,
-      202,
-    );
-    const state = (await harness.storage.get("exact-review-queue")) as {
-      dispatcher?: Record<string, unknown>;
-    };
-    state.dispatcher = {
-      state: "active",
-      checkedAt: now,
-      publicationBatchDispatchedAt: now,
-      publicationBatchDispatchPendingUntil: now + 600_000,
-    };
-    await harness.storage.put("exact-review-queue", state);
-
-    const claim = await (
-      await harness.queue.fetch(
-        new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
-          method: "POST",
-          body: JSON.stringify({ claim_id: "pre-probe-claim", lease_owner: "pre-probe-worker" }),
-        }),
-      )
-    ).json();
-    assert.equal(claim.claimed, true, JSON.stringify(claim));
-  } finally {
-    Date.now = originalNow;
-    harness.restore();
-  }
-});
-
 test("exact-review queue retains a 404 item when the target repository is inaccessible", async () => {
   const harness = createExactReviewAdmissionHarness(() => new Response(null, { status: 404 }), {
     targetRepository: () => new Response(null, { status: 404 }),
@@ -15879,29 +15501,20 @@ function signedStateAppendRequest(path: string, payload: unknown, secret: string
 }
 
 function createExactReviewAdmissionHarness(
-  liveItem: (
-    targetRepo: string,
-    itemNumber: number,
-    itemKind: "issue" | "pull_request",
-  ) => Response | Promise<Response>,
+  liveItem: () => Response | Promise<Response>,
   options: {
     maxConcurrent?: string;
     publicationBatching?: boolean;
-    publicationBatchSize?: string;
-    publicationFreshLane?: boolean;
-    captureBatchDispatch?: boolean;
     targetInstallation?: (targetRepo: string) => Response | Promise<Response>;
     targetRepository?: (targetRepo: string) => Response | Promise<Response>;
     targetItem?: (targetRepo: string) => Response | Promise<Response>;
     targetPull?: (targetRepo: string) => Response | Promise<Response>;
     dispatch?: () => Response | Promise<Response>;
-    batchDispatch?: () => Response | Promise<Response>;
   } = {},
 ) {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const dispatched: Record<string, unknown>[] = [];
-  let batchDispatches = 0;
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -15912,11 +15525,11 @@ function createExactReviewAdmissionHarness(
     if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
       return jsonResponse({ state: "active" });
     }
-    const installation = url.pathname.match(/^\/repos\/([^/]+\/[^/]+)\/installation$/);
+    const installation = url.pathname.match(/^\/repos\/(openclaw\/[^/]+)\/installation$/);
     if (installation) {
       return options.targetInstallation?.(installation[1]) ?? jsonResponse({ id: 999 });
     }
-    const repository = url.pathname.match(/^\/repos\/([^/]+\/[^/]+)$/);
+    const repository = url.pathname.match(/^\/repos\/(openclaw\/[^/]+)$/);
     if (repository) {
       return (
         options.targetRepository?.(repository[1]) ?? jsonResponse({ full_name: repository[1] })
@@ -15925,28 +15538,17 @@ function createExactReviewAdmissionHarness(
     if (url.pathname === "/app/installations/999/access_tokens") {
       return jsonResponse({ token: "queue-token" });
     }
-    const targetItem = url.pathname.match(/^\/repos\/([^/]+\/[^/]+)\/issues\/(\d+)$/);
+    const targetItem = url.pathname.match(
+      /^\/repos\/(openclaw\/(?:gogcli|openclaw))\/issues\/\d+$/,
+    );
     if (targetItem) {
-      return (
-        options.targetItem?.(targetItem[1]) ??
-        liveItem(targetItem[1], Number(targetItem[2]), "issue")
-      );
+      return options.targetItem?.(targetItem[1]) ?? liveItem();
     }
-    const targetPull = url.pathname.match(/^\/repos\/([^/]+\/[^/]+)\/pulls\/(\d+)$/);
+    const targetPull = url.pathname.match(/^\/repos\/(openclaw\/(?:gogcli|openclaw))\/pulls\/\d+$/);
     if (targetPull) {
       return (
-        options.targetPull?.(targetPull[1]) ??
-        options.targetItem?.(targetPull[1]) ??
-        liveItem(targetPull[1], Number(targetPull[2]), "pull_request")
+        options.targetPull?.(targetPull[1]) ?? options.targetItem?.(targetPull[1]) ?? liveItem()
       );
-    }
-    if (
-      options.captureBatchDispatch &&
-      url.pathname ===
-        "/repos/openclaw/clawsweeper/actions/workflows/exact-review-batch-publish.yml/dispatches"
-    ) {
-      batchDispatches += 1;
-      return options.batchDispatch?.() ?? new Response(null, { status: 204 });
     }
     if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
       dispatched.push(JSON.parse(String(init?.body)));
@@ -15964,11 +15566,8 @@ function createExactReviewAdmissionHarness(
       ...(options.publicationBatching
         ? {
             EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
-            EXACT_REVIEW_PUBLICATION_BATCH_SIZE: options.publicationBatchSize ?? "1",
+            EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "1",
             EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "300000",
-            ...(options.publicationFreshLane
-              ? { EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1" }
-              : {}),
           }
         : {}),
     },
@@ -15977,9 +15576,6 @@ function createExactReviewAdmissionHarness(
     queue,
     storage,
     dispatched,
-    get batchDispatches() {
-      return batchDispatches;
-    },
     restore: () => {
       globalThis.fetch = originalFetch;
     },


### PR DESCRIPTION
## Purpose

This is a pre-created, **draft-only** rollback for [#853](https://github.com/openclaw/clawsweeper/pull/853). It exactly reverts squash commit `2b34ce402b5272397bf4e7b95e030091688c3cc2`; do not merge it unless the terminal-publication repair causes a concrete regression.

## Scope

- Restores the two files changed by #853 to their immediate pre-merge state.
- Contains no new behavior, state mutation, workflow change, or sandbox activity.

## Validation

```text
pnpm exec tsc --noEmit --pretty false
pnpm run build:all
pnpm run lint:dashboard
git diff --cached --check
node --test test/dashboard-worker.test.ts                 # 212 pass
node --test test/exact-review-publication-batches.test.ts # 44 pass
```

`pnpm exec oxfmt --check dashboard/exact-review-queue.ts test/dashboard-worker.test.ts` reports pre-existing formatter drift in the restored parent files. It is intentionally not reformatted, so this remains an exact rollback.

## Codex review closeout

- `codex review --uncommitted`: clean; confirmed an exact inverse with no partial rollback drift.
- `codex review --base origin/main`: clean; no additional correctness issues.

## Operational status

E2E-003 remains released unused. No sandbox fixture, Action, webhook, queue, Worker, state, gate, or production component was activated or changed for this rollback.
