### PR TITLE
fix(automation): restore apply and repair workflows

### DIFF
--- a/.github/workflows/repair-commit-finding-intake.yml
+++ b/.github/workflows/repair-commit-finding-intake.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          owner: ${{ github.repository_owner }}
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          owner: ${{ github.repository_owner }}
           permission-actions: write
           permission-contents: write
           permission-issues: write

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          owner: ${{ github.repository_owner }}
           permission-actions: write
           permission-contents: write
           permission-issues: read

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          owner: ${{ github.repository_owner }}
           permission-actions: read
           permission-contents: write
           permission-pull-requests: read

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          owner: ${{ github.repository_owner }}
           permission-actions: write
           permission-contents: write
 

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || github.repository_owner }}
+          owner: ${{ github.repository_owner }}
           permission-contents: write
           permission-issues: read
           permission-pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Kept root-level apply reports as digest-only action-ledger evidence so ledger-enabled apply runs can finish, publish their compatibility report, and advance their cursor. Thanks @yetval! (#833)
+- Restored repair and spam workflows by keeping the multi-owner repair policy out of the GitHub App token action's single-owner input. Thanks @yetval! (#834)
 - Stopped the review pipeline stranding delivered verdicts: a single drifted state item is quarantined instead of aborting its whole batch, the commit_refs recovery path retries its final state-branch push with exponential backoff like its receipt and lease siblings, the superseded-placeholder sweep runs on every apply pass instead of only right after posting the durable verdict comment, and placeholder recovery spends its per-run budget on the oldest orphans first and labels long-stuck ones. Thanks @yetval! (#816)
 - State publishes rebase onto the live remote head after lease admission, the coordinator ticket poll has a hard deadline with a still-queued heartbeat, and network pushes carry timeouts — ending the materializer's stale-base rejections and silent hangs. (#805)
 - The state materializer is admitted through the publication-batch coordinator lane so the bulk writer no longer starves behind batch lease turns; queued state now drains on schedule. (#806)

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -22903,6 +22903,17 @@ function actionLedgerFileEvidence(kind: string, filePath: string): ActionEventEv
   };
 }
 
+function actionLedgerFileDigestEvidence(
+  kind: string,
+  filePath: string,
+): ActionEventEvidence | null {
+  if (!existsSync(filePath)) return null;
+  return {
+    kind,
+    sha256: sha256(readFileSync(filePath, "utf8")),
+  };
+}
+
 function actionLedgerItemSubject(
   item: Item,
   options: { sourceRevision?: string; recordPath?: string } = {},
@@ -27232,7 +27243,9 @@ function recordApplyActionEvents(options: {
     },
     privacy: actionLedgerPrivacy(),
   });
-  const reportEvidence = actionLedgerFileEvidence("apply_report", options.reportPath);
+  // The apply report is a local workflow projection, so bind its contents
+  // without claiming that its root-level compatibility path is durable state.
+  const reportEvidence = actionLedgerFileDigestEvidence("apply_report", options.reportPath);
   const reportPublicationPhaseSeq = nextApplyPhaseSeq(options.ledger);
   recordWorkflowPhaseEvent(ROOT, {
     phase: ACTION_EVENT_TYPES.applyPublish,
@@ -27255,9 +27268,6 @@ function recordApplyActionEvents(options: {
     subject: {
       repository: targetRepo(),
       kind: "publication",
-      ...(repoRelativePath(options.reportPath).startsWith("../")
-        ? {}
-        : { recordPath: repoRelativePath(options.reportPath) }),
     },
     evidence: [...workflowRunEvidence(), ...(reportEvidence ? [reportEvidence] : [])],
     attributes: {

--- a/test/actions-runtime.test.ts
+++ b/test/actions-runtime.test.ts
@@ -31,6 +31,17 @@ test("GitHub App token creation uses the approved immutable action pin everywher
   );
 });
 
+test("GitHub App token owner inputs do not consume the multi-owner repair policy", () => {
+  const invalidOwnerInputs = referenceFiles(".github/workflows").flatMap((path) =>
+    readFileSync(path, "utf8")
+      .split("\n")
+      .filter((line) => /^\s*owner:.*CLAWSWEEPER_ALLOWED_OWNER/.test(line))
+      .map((line) => `${path}: ${line.trim()}`),
+  );
+
+  assert.deepEqual(invalidOwnerInputs, []);
+});
+
 test("cache actions use one runtime generation everywhere", () => {
   const references = referenceRoots.flatMap(referenceFiles).flatMap((path) =>
     readFileSync(path, "utf8")

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -701,6 +701,25 @@ test("apply failure finalization survives report publication errors", () => {
   );
 });
 
+test("apply report publication uses digest evidence without a durable record path", () => {
+  const source = readText("src/clawsweeper.ts");
+  const evidenceStart = source.indexOf(
+    'const reportEvidence = actionLedgerFileDigestEvidence("apply_report", options.reportPath)',
+  );
+  const publicationStart = source.indexOf('identity: { slot: "apply_report_publication" }');
+  const publicationEnd = source.indexOf("attributes:", publicationStart);
+  const evidence = source.slice(evidenceStart, publicationStart);
+  const publication = source.slice(publicationStart, publicationEnd);
+
+  assert.ok(evidenceStart >= 0);
+  assert.ok(publicationStart >= 0);
+  assert.ok(publicationEnd > publicationStart);
+  assert.doesNotMatch(evidence, /actionLedgerFileEvidence\("apply_report"/);
+  assert.match(publication, /kind: "publication"/);
+  assert.doesNotMatch(publication, /recordPath/);
+  assert.match(publication, /reportEvidence/);
+});
+
 test("retry and review publication lanes finalize unexpected failures", () => {
   const source = readText("src/clawsweeper.ts");
   const retryStart = source.indexOf("const retryLedger = startFailedReviewRetryLedger({");


### PR DESCRIPTION
## Summary

- keep the root apply report as digest-only action-ledger evidence so ledger-enabled apply runs can finalize without weakening namespaced durable-path validation
- pass the scalar repository owner to GitHub App token creation while preserving `CLAWSWEEPER_ALLOWED_OWNER` as the multi-owner repair authorization policy
- add regression coverage for both invariants and credit @yetval in the changelog

Closes #833.
Closes #834.

## Proof

- Before the patch, a forced-ledger dry run with the default report path exited 1 with `action event subject record path must be a namespaced repository-relative data path using portable segments`.
- After the patch, the identical dry run exited 0 and finalized two immutable workflow shards.
- `node --test test/clawsweeper-action-ledger.test.ts test/actions-runtime.test.ts` — 24 passed.
- `pnpm run build:all` — passed.
- `pnpm run check` passed formatting, all builds, lint, and changed coverage. Its aggregate macOS coverage stage reached unrelated existing host/flaky failures (GNU `timeout` unavailable, Linux Landlock symbols unavailable, `/var` canonicalization, one clock-second drift, and loaded-suite timing/mock races).
- Autoreview: clean, no accepted/actionable findings (0.98 confidence).

## Operational evidence

- Current-head self-heal, conflict-self-heal, and spam-scanner runs still fail before useful work with the list-valued owner input.
