### PR TITLE
fix(publication): persist terminal redelivery outcomes

### DIFF
--- a/dashboard/exact-review-publication-terminal-ledger.ts
+++ b/dashboard/exact-review-publication-terminal-ledger.ts
@@ -1,0 +1,189 @@
+const TERMINAL_LEDGER_TABLE = "exact_review_publication_terminals";
+const TERMINAL_LEDGER_HEAD_TABLE = "exact_review_publication_terminal_heads";
+
+export const EXACT_REVIEW_PUBLICATION_TERMINAL_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+export const EXACT_REVIEW_PUBLICATION_TERMINAL_COMPACTION_LIMIT = 100;
+
+type SqlStorage = {
+  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
+};
+
+type DurableStorage = {
+  sql: SqlStorage;
+};
+
+export type ExactReviewPublicationTerminalOutcome = "published" | "superseded" | "closed";
+
+export type ExactReviewPublicationTerminal = {
+  targetKey: string;
+  sourceRevision: number;
+  outcome: ExactReviewPublicationTerminalOutcome;
+  terminalAt: number;
+  runId?: string;
+  batchId?: string;
+  stateCommitSha?: string;
+};
+
+export type ExactReviewPublicationTerminalMatch = {
+  outcome: ExactReviewPublicationTerminalOutcome | "compacted";
+  compacted: boolean;
+};
+
+/**
+ * Stores the terminal result for a review publication revision. Detailed rows
+ * expire, but a one-row-per-target high-water mark survives compaction so an
+ * old redelivery remains a no-op while a newer source revision can proceed.
+ */
+export class ExactReviewPublicationTerminalLedger {
+  private readonly storage: DurableStorage;
+
+  constructor(storage: DurableStorage) {
+    this.storage = storage;
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${TERMINAL_LEDGER_TABLE} (
+         target_key TEXT NOT NULL,
+         source_revision INTEGER NOT NULL CHECK (source_revision >= 1),
+         terminal_outcome TEXT NOT NULL CHECK (
+           terminal_outcome IN ('published', 'superseded', 'closed')
+         ),
+         terminal_at INTEGER NOT NULL,
+         run_id TEXT,
+         batch_id TEXT,
+         state_commit_sha TEXT,
+         PRIMARY KEY (target_key, source_revision)
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${TERMINAL_LEDGER_HEAD_TABLE} (
+         target_key TEXT PRIMARY KEY,
+         completed_through_revision INTEGER NOT NULL CHECK (completed_through_revision >= 1),
+         updated_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_publication_terminals_compaction
+         ON ${TERMINAL_LEDGER_TABLE} (terminal_at, target_key, source_revision)`,
+    );
+    // A rolling upgrade can encounter detailed rows from an interrupted older
+    // deployment. Reconstruct the compacted fence before admitting redelivery.
+    this.storage.sql.exec(
+      `INSERT INTO ${TERMINAL_LEDGER_HEAD_TABLE}
+         (target_key, completed_through_revision, updated_at)
+       SELECT target_key, MAX(source_revision), MAX(terminal_at)
+         FROM ${TERMINAL_LEDGER_TABLE}
+        GROUP BY target_key
+       ON CONFLICT(target_key) DO UPDATE SET
+         completed_through_revision = MAX(
+           completed_through_revision,
+           excluded.completed_through_revision
+         ),
+         updated_at = MAX(updated_at, excluded.updated_at)`,
+    );
+  }
+
+  terminalFor(
+    targetKey: string,
+    sourceRevision: number,
+  ): ExactReviewPublicationTerminalMatch | null {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT terminal_outcome
+           FROM ${TERMINAL_LEDGER_TABLE}
+          WHERE target_key = ? AND source_revision = ?`,
+        targetKey,
+        sourceRevision,
+      ),
+    )[0];
+    if (row) {
+      return {
+        outcome: String(row.terminal_outcome) as ExactReviewPublicationTerminalOutcome,
+        compacted: false,
+      };
+    }
+    const head = Array.from(
+      this.storage.sql.exec(
+        `SELECT completed_through_revision
+           FROM ${TERMINAL_LEDGER_HEAD_TABLE}
+          WHERE target_key = ?`,
+        targetKey,
+      ),
+    )[0];
+    return Number(head?.completed_through_revision || 0) >= sourceRevision
+      ? { outcome: "compacted", compacted: true }
+      : null;
+  }
+
+  record(terminal: ExactReviewPublicationTerminal): "recorded" | "duplicate" | "conflict" {
+    const existing = this.terminalFor(terminal.targetKey, terminal.sourceRevision);
+    if (existing) {
+      return existing.outcome === terminal.outcome || existing.compacted ? "duplicate" : "conflict";
+    }
+    this.storage.sql.exec(
+      `INSERT INTO ${TERMINAL_LEDGER_TABLE}
+         (target_key, source_revision, terminal_outcome, terminal_at, run_id, batch_id, state_commit_sha)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      terminal.targetKey,
+      terminal.sourceRevision,
+      terminal.outcome,
+      terminal.terminalAt,
+      terminal.runId ?? null,
+      terminal.batchId ?? null,
+      terminal.stateCommitSha ?? null,
+    );
+    this.storage.sql.exec(
+      `INSERT INTO ${TERMINAL_LEDGER_HEAD_TABLE}
+         (target_key, completed_through_revision, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(target_key) DO UPDATE SET
+         completed_through_revision = MAX(
+           completed_through_revision,
+           excluded.completed_through_revision
+         ),
+         updated_at = MAX(updated_at, excluded.updated_at)`,
+      terminal.targetKey,
+      terminal.sourceRevision,
+      terminal.terminalAt,
+    );
+    return "recorded";
+  }
+
+  compact(
+    now: number,
+    options: { retentionMs?: number; limit?: number } = {},
+  ): { deleted: number; remaining: number } {
+    const retentionMs = options.retentionMs ?? EXACT_REVIEW_PUBLICATION_TERMINAL_RETENTION_MS;
+    const limit = options.limit ?? EXACT_REVIEW_PUBLICATION_TERMINAL_COMPACTION_LIMIT;
+    const cutoff = now - retentionMs;
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT target_key, source_revision
+           FROM ${TERMINAL_LEDGER_TABLE}
+          WHERE terminal_at <= ?
+          ORDER BY terminal_at, target_key, source_revision
+          LIMIT ?`,
+        cutoff,
+        limit,
+      ),
+    );
+    for (const row of rows) {
+      this.storage.sql.exec(
+        `DELETE FROM ${TERMINAL_LEDGER_TABLE}
+          WHERE target_key = ? AND source_revision = ?`,
+        String(row.target_key),
+        Number(row.source_revision),
+      );
+    }
+    const remaining = Number(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT COUNT(*) AS count FROM ${TERMINAL_LEDGER_TABLE} WHERE terminal_at <= ?`,
+          cutoff,
+        ),
+      )[0]?.count ?? 0,
+    );
+    return { deleted: rows.length, remaining };
+  }
+}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -17,6 +17,11 @@ import {
   type PublicationBatchFence,
 } from "./exact-review-publication-batches.ts";
 import {
+  ExactReviewPublicationTerminalLedger,
+  type ExactReviewPublicationTerminal,
+  type ExactReviewPublicationTerminalOutcome,
+} from "./exact-review-publication-terminal-ledger.ts";
+import {
   REVIEW_TELEMETRY_DEGRADED_MS,
   REVIEW_TELEMETRY_ORPHAN_MS,
   REVIEW_TELEMETRY_RETENTION_MS,
@@ -447,6 +452,7 @@ export class ExactReviewQueue {
   private legacyMirrorDisabled = false;
   private legacyMirrorWarningReported = false;
   private batchStore;
+  private publicationTerminalLedger;
   private stateWriterCoordinator;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
 
@@ -454,6 +460,7 @@ export class ExactReviewQueue {
     this.storage = state.storage;
     this.env = env;
     this.batchStore = new ExactReviewPublicationBatchStore(this.storage);
+    this.publicationTerminalLedger = new ExactReviewPublicationTerminalLedger(this.storage);
     this.stateWriterCoordinator = new StateWriterCoordinator(this.storage);
     const initialize = () => this.initializeStorage();
     this.ready =
@@ -824,6 +831,28 @@ export class ExactReviewQueue {
         );
         let supersededPublications = 0;
         if (incomingPublicationRevision) {
+          const terminal = this.publicationTerminalLedger.terminalFor(
+            incomingPublicationRevision.targetKey,
+            incomingPublicationRevision.sourceRevision,
+          );
+          if (terminal) {
+            this.syncLegacyCompatibilitySync(state);
+            return {
+              deduped: true as const,
+              terminal: true as const,
+              terminalOutcome: terminal.outcome,
+              ...(terminal.compacted
+                ? {
+                    superseded: true as const,
+                    publicationRevision: incomingPublicationRevision.sourceRevision,
+                    supersededByRevision: this.publicationHeadRevisionSync(
+                      incomingPublicationRevision.targetKey,
+                    ),
+                  }
+                : {}),
+              state,
+            };
+          }
           const incomingLineage = exactReviewPublicationLineage(decision);
           const matching = Object.values(state.items)
             .map((item) => ({
@@ -853,6 +882,24 @@ export class ExactReviewQueue {
             now,
           );
           if (incomingPublicationRevision.sourceRevision < newestSourceRevision) {
+            const activeSameRevision = matching.some(
+              ({ item, revision }) =>
+                revision.sourceRevision === incomingPublicationRevision.sourceRevision &&
+                (activeBatchItemKeys.has(item.key) ||
+                  item.state === "dispatching" ||
+                  item.state === "leased"),
+            );
+            // An active publisher still owns this revision's authoritative
+            // completion. Its duplicate ingress is stale, but must not replace
+            // that eventual published/closed outcome in the terminal ledger.
+            if (!activeSameRevision) {
+              this.publicationTerminalLedger.record({
+                targetKey: incomingPublicationRevision.targetKey,
+                sourceRevision: incomingPublicationRevision.sourceRevision,
+                outcome: "superseded",
+                terminalAt: now,
+              });
+            }
             this.writeStateSync(state);
             return {
               deduped: true as const,
@@ -987,6 +1034,8 @@ export class ExactReviewQueue {
             )
             .sort((left, right) => left.item.key.localeCompare(right.item.key))
             .slice(0, EXACT_REVIEW_PUBLICATION_ENQUEUE_SUPERSEDE_LIMIT)) {
+            const terminal = exactReviewPublicationTerminal(entry.item, "superseded", now);
+            if (terminal) this.publicationTerminalLedger.record(terminal);
             delete state.items[entry.item.key];
             supersededPublications += 1;
           }
@@ -1147,6 +1196,9 @@ export class ExactReviewQueue {
                 }
               : {}),
             ...("staleSource" in accepted && accepted.staleSource ? { stale_source: true } : {}),
+            ...("terminal" in accepted && accepted.terminal
+              ? { terminal: true, terminal_outcome: accepted.terminalOutcome }
+              : {}),
             ...(accepted.superseded
               ? {
                   superseded: true,
@@ -1540,6 +1592,24 @@ export class ExactReviewQueue {
       const completedLane =
         !requeued && !completionResult.parked ? exactReviewQueueLane(item) : null;
       const structuredTerminal = publicationCompletion && !requeued && !completionResult.parked;
+      // Older publishers and the signed run reconciler use the generic success
+      // completion path. They do not attest a publication-specific outcome, but
+      // successful removal is still terminal for that immutable source revision.
+      const terminalOutcome =
+        completionResult.terminalOutcome ??
+        (publicationItem &&
+        !publicationCompletion &&
+        outcome === "success" &&
+        !requeued &&
+        !completionResult.parked
+          ? "closed"
+          : undefined);
+      const publicationTerminals =
+        publicationItem && terminalOutcome
+          ? [exactReviewPublicationTerminal(item, terminalOutcome, now)].filter(
+              (terminal): terminal is ExactReviewPublicationTerminal => terminal !== null,
+            )
+          : [];
       await this.writeState(
         state,
         {
@@ -1574,6 +1644,8 @@ export class ExactReviewQueue {
             }
           : undefined,
         completionResult.deadLetter,
+        [],
+        publicationTerminals,
       );
       await this.scheduleNext(state, now);
       return json({ ok: true, requeued });
@@ -1789,6 +1861,7 @@ export class ExactReviewQueue {
       let completedReviews = 0;
       let retriedReviews = 0;
       let completedPublications = 0;
+      const publicationTerminals: ExactReviewPublicationTerminal[] = [];
       for (const run of runs) {
         const matches = Object.values(state.items).filter(
           (item) =>
@@ -1815,17 +1888,27 @@ export class ExactReviewQueue {
         } else {
           completed += 1;
           if (run.outcome === "success") {
-            if (exactReviewQueueIsPublication(item)) completedPublications += 1;
-            else completedReviews += 1;
+            if (exactReviewQueueIsPublication(item)) {
+              completedPublications += 1;
+              const terminal = exactReviewPublicationTerminal(item, "closed", now);
+              if (terminal) publicationTerminals.push(terminal);
+            } else completedReviews += 1;
           }
         }
       }
       if (reconciled) {
-        await this.writeState(state, {
-          reviewCompleted: completedReviews,
-          reviewRetried: retriedReviews,
-          publicationCompleted: completedPublications,
-        });
+        await this.writeState(
+          state,
+          {
+            reviewCompleted: completedReviews,
+            reviewRetried: retriedReviews,
+            publicationCompleted: completedPublications,
+          },
+          undefined,
+          undefined,
+          [],
+          publicationTerminals,
+        );
         await this.scheduleNext(state, now);
       }
       return json({ ok: true, reconciled, requeued, completed });
@@ -2497,6 +2580,7 @@ export class ExactReviewQueue {
       }
     }
     let terminalPublications = 0;
+    const publicationTerminals: ExactReviewPublicationTerminal[] = [];
     for (const candidate of livePublicationStates) {
       const item = checkedState.items[candidate.key];
       if (
@@ -2510,6 +2594,8 @@ export class ExactReviewQueue {
       ) {
         continue;
       }
+      const terminal = exactReviewPublicationTerminal(item, "closed", checkedAt);
+      if (terminal) publicationTerminals.push(terminal);
       delete checkedState.items[item.key];
       terminalPublications += 1;
     }
@@ -2544,6 +2630,7 @@ export class ExactReviewQueue {
         undefined,
         undefined,
         supersessionAudits,
+        publicationTerminals,
       );
       await this.scheduleNext(checkedState, checkedAt);
       return;
@@ -2617,6 +2704,7 @@ export class ExactReviewQueue {
       undefined,
       undefined,
       supersessionAudits,
+      publicationTerminals,
     );
     if (!dispatchable.length) {
       await this.scheduleNext(checkedState, checkedAt);
@@ -2763,6 +2851,7 @@ export class ExactReviewQueue {
     const checkedState = this.readStateSync();
     const batchOwnership = this.batchStore.activeLeaseSnapshot(checkedAt);
     let completed = 0;
+    const terminals: ExactReviewPublicationTerminal[] = [];
     for (const candidate of liveStates) {
       const item = checkedState.items[candidate.key];
       if (
@@ -2776,14 +2865,23 @@ export class ExactReviewQueue {
       ) {
         continue;
       }
+      const terminal = exactReviewPublicationTerminal(item, "closed", checkedAt);
+      if (terminal) terminals.push(terminal);
       delete checkedState.items[item.key];
       completed += 1;
     }
     if (completed) {
-      await this.writeState(checkedState, {
-        publicationCompleted: completed,
-        publicationSuperseded: completed,
-      });
+      await this.writeState(
+        checkedState,
+        {
+          publicationCompleted: completed,
+          publicationSuperseded: completed,
+        },
+        undefined,
+        undefined,
+        [],
+        terminals,
+      );
     }
     return completed;
   }
@@ -3551,6 +3649,7 @@ export class ExactReviewQueue {
     const activeBatchItemKeys = new Set(this.batchStore.activeLeaseSnapshot(Date.now()).itemKeys);
     const state = this.readStateSync();
     let superseded = 0;
+    const terminals: ExactReviewPublicationTerminal[] = [];
     for (const candidate of candidates) {
       const item = state.items[candidate.itemKey];
       if (
@@ -3562,14 +3661,23 @@ export class ExactReviewQueue {
       ) {
         continue;
       }
+      const terminal = exactReviewPublicationTerminal(item, "superseded", Date.now());
+      if (terminal) terminals.push(terminal);
       delete state.items[item.key];
       superseded += 1;
     }
     if (superseded) {
-      await this.writeState(state, {
-        publicationCompleted: superseded,
-        publicationSuperseded: superseded,
-      });
+      await this.writeState(
+        state,
+        {
+          publicationCompleted: superseded,
+          publicationSuperseded: superseded,
+        },
+        undefined,
+        undefined,
+        [],
+        terminals,
+      );
       await this.scheduleNext(state, Date.now());
     }
     return json({ ok: true, superseded, skipped: candidates.length - superseded });
@@ -3761,6 +3869,10 @@ export class ExactReviewQueue {
             ) {
               continue;
             }
+          }
+          if (candidate.reason === "stale_revision") {
+            const terminal = exactReviewPublicationTerminal(current, "superseded", now);
+            if (terminal) this.publicationTerminalLedger.record(terminal);
           }
           delete state.items[current.key];
           changedKeys.add(current.key);
@@ -4103,6 +4215,12 @@ export class ExactReviewQueue {
             deadLetterCapacityAvailable: true,
             env: this.env,
           });
+          if (result.terminalOutcome) {
+            const terminal = exactReviewPublicationTerminal(item, result.terminalOutcome, now, {
+              batchId,
+            });
+            if (terminal) this.publicationTerminalLedger.record(terminal);
+          }
           if (!result.requeued && !result.parked) superseded += 1;
         }
         if (!superseded) return;
@@ -4270,6 +4388,13 @@ export class ExactReviewQueue {
               this.insertDeadLetterSync(result.deadLetter);
               deadLettered += 1;
             }
+            if (result.terminalOutcome) {
+              const terminal = exactReviewPublicationTerminal(item, result.terminalOutcome, now, {
+                batchId,
+                ...(stateCommitSha ? { stateCommitSha } : {}),
+              });
+              if (terminal) this.publicationTerminalLedger.record(terminal);
+            }
             if (!result.requeued && !result.parked) completed += 1;
             if (result.retried) retried += 1;
             if (result.refreshed) refreshed += 1;
@@ -4287,6 +4412,13 @@ export class ExactReviewQueue {
             deadLetterCapacityAvailable: true,
             env: this.env,
           });
+          if (result.terminalOutcome) {
+            const terminal = exactReviewPublicationTerminal(item, result.terminalOutcome, now, {
+              batchId,
+              ...(stateCommitSha ? { stateCommitSha } : {}),
+            });
+            if (terminal) this.publicationTerminalLedger.record(terminal);
+          }
           if (!result.requeued) completed += 1;
           if (completion.terminalOutcome === "published") published += 1;
           else if (completion.terminalOutcome === "superseded") superseded += 1;
@@ -4378,6 +4510,7 @@ export class ExactReviewQueue {
   private async initializeStorage() {
     this.ensureStorageSchemaSync();
     this.batchStore.ensureSchemaSync();
+    this.publicationTerminalLedger.ensureSchemaSync();
     this.stateWriterCoordinator.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
@@ -5137,8 +5270,10 @@ export class ExactReviewQueue {
     publicationFeedback?: ExactReviewPublicationFeedback,
     deadLetter?: ExactReviewDeadLetterInsert,
     supersessionAudits: ExactReviewSupersessionAudit[] = [],
+    publicationTerminals: ExactReviewPublicationTerminal[] = [],
   ) {
     this.storage.transactionSync(() => {
+      for (const terminal of publicationTerminals) this.publicationTerminalLedger.record(terminal);
       this.writeStateSync(state);
       this.incrementQueueMetricsSync(metricDelta);
       if (publicationFeedback) this.applyPublicationFeedbackSync(publicationFeedback);
@@ -5520,6 +5655,7 @@ export class ExactReviewQueue {
   }
 
   private pruneQueueTelemetrySync(now: number) {
+    this.publicationTerminalLedger.compact(now);
     this.storage.sql.exec(
       `DELETE FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE} WHERE bucket_start < ?`,
       now - EXACT_REVIEW_QUEUE_METRIC_BUCKET_TTL_MS,
@@ -6577,6 +6713,25 @@ function exactReviewPublicationRevision(decision: ExactReviewDecision): {
   };
 }
 
+function exactReviewPublicationTerminal(
+  item: ExactReviewQueueItem,
+  outcome: ExactReviewPublicationTerminalOutcome,
+  terminalAt: number,
+  metadata: { batchId?: string; stateCommitSha?: string } = {},
+): ExactReviewPublicationTerminal | null {
+  const revision = exactReviewPublicationRevision(item.decision);
+  if (!revision) return null;
+  return {
+    targetKey: revision.targetKey,
+    sourceRevision: revision.sourceRevision,
+    outcome,
+    terminalAt,
+    ...(item.claimedRunId ? { runId: item.claimedRunId } : {}),
+    ...(metadata.batchId ? { batchId: metadata.batchId } : {}),
+    ...(metadata.stateCommitSha ? { stateCommitSha: metadata.stateCommitSha } : {}),
+  };
+}
+
 type ExactReviewPublicationLineage = {
   targetKey: string;
   sourceRevision: number;
@@ -7072,6 +7227,7 @@ function finishExactReviewPublicationQueueItem({
   retried: boolean;
   refreshed: boolean;
   parked: boolean;
+  terminalOutcome?: ExactReviewPublicationTerminalOutcome;
   deadLetter?: ExactReviewDeadLetterInsert;
 } {
   const completionRevision = ownedRevision ?? Number(item.leaseRevision || 0);
@@ -7108,6 +7264,12 @@ function finishExactReviewPublicationQueueItem({
       retried: false,
       refreshed: false,
       parked: false,
+      terminalOutcome:
+        completion.kind === "published"
+          ? "published"
+          : completion.kind === "superseded"
+            ? "superseded"
+            : "closed",
     };
   }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4805,6 +4805,33 @@ test("exact-review queue terminalizes every admitted ordinary publication before
       )
     ).json();
     assert.equal(terminal.items.length, 0);
+
+    const redeliveryPublication = exactReviewPublicationOverrides(
+      9215,
+      "92151",
+      "opened",
+      1,
+      "openclaw/gogcli",
+    );
+    redeliveryPublication.publication.producerDecision.itemKind = "pull_request";
+    redeliveryPublication.publication.producerDecision.sourceEvent = "pull_request";
+    const redelivery = await harness.queue.fetch(
+      buildExactReviewQueueRequest(
+        "legacy-terminal-redelivery",
+        9215,
+        "exact_review_artifact_publish",
+        "pull_request",
+        "openclaw/gogcli",
+        redeliveryPublication,
+      ),
+    );
+    assert.deepEqual(await redelivery.json(), {
+      ok: true,
+      deduped: true,
+      item_key: "openclaw/gogcli#9215@publish:92151:1",
+      terminal: true,
+      terminal_outcome: "closed",
+    });
   } finally {
     harness.restore();
   }
@@ -8696,6 +8723,251 @@ test("exact-review publication supersedes stale tuples without counting a publis
   assert.equal(stats.lanes.publication.flow.last_15_minutes.published_rate_per_hour, 0);
   assert.equal(stats.lanes.publication.flow.last_15_minutes.superseded_rate_per_hour, 4);
   assert.equal(stats.lanes.publication.dead_letters.open, 0);
+
+  const redelivery = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "superseded-terminal-redelivery",
+      781,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/openclaw",
+      exactReviewPublicationOverrides(781, "7811", "opened", 1, "openclaw/openclaw"),
+    ),
+  );
+  assert.deepEqual(await redelivery.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/openclaw#781@publish:7811:1",
+    terminal: true,
+    terminal_outcome: "superseded",
+  });
+});
+
+test("exact-review publication terminal recording rolls back with the queue and fences redelivery", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7811, "78110");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const complete = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: item.leaseId,
+          item_key: item.key,
+          lease_revision: item.leaseRevision,
+          claim_generation: item.claimGeneration,
+          run_id: item.claimedRunId,
+          run_attempt: item.claimedRunAttempt,
+          outcome: "success",
+          completion_kind: "published",
+          reason_code: "publication_applied",
+        }),
+      }),
+    );
+
+  storage.failNextSql(/INSERT INTO exact_review_publication_terminals/);
+  await assert.rejects(complete(), /injected SQL failure/);
+  const afterCrash = (await storage.get("exact-review-queue")) as {
+    items: Record<string, unknown>;
+  };
+  assert.ok(afterCrash.items[item.key]);
+  assert.equal(
+    Array.from(storage.sql.exec("SELECT * FROM exact_review_publication_terminals")).length,
+    0,
+  );
+
+  assert.deepEqual(await (await complete()).json(), { ok: true, requeued: false });
+  const terminal = Array.from(
+    storage.sql.exec(
+      `SELECT terminal_outcome, run_id
+         FROM exact_review_publication_terminals
+        WHERE target_key = ? AND source_revision = ?`,
+      "openclaw/openclaw#7811",
+      1,
+    ),
+  )[0];
+  assert.equal(terminal?.terminal_outcome, "published");
+  assert.equal(terminal?.run_id, "78110");
+
+  const redelivery = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "published-terminal-redelivery",
+      7811,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/openclaw",
+      exactReviewPublicationOverrides(7811, "78111", "opened", 1, "openclaw/openclaw"),
+    ),
+  );
+  assert.deepEqual(await redelivery.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/openclaw#7811@publish:78111:1",
+    terminal: true,
+    terminal_outcome: "published",
+  });
+
+  const laterRevision = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "published-terminal-next-revision",
+      7811,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/openclaw",
+      exactReviewPublicationOverrides(7811, "78112", "opened", 2, "openclaw/openclaw"),
+    ),
+  );
+  assert.equal(laterRevision.status, 202);
+  assert.equal((await laterRevision.json()).queued, true);
+});
+
+test("exact-review publication generic success records a closed terminal outcome", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7812, "78120");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const completed = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+      }),
+    }),
+  );
+  assert.deepEqual(await completed.json(), { ok: true, requeued: false });
+  const terminal = Array.from(
+    storage.sql.exec(
+      `SELECT terminal_outcome, run_id
+         FROM exact_review_publication_terminals
+        WHERE target_key = ? AND source_revision = ?`,
+      "openclaw/openclaw#7812",
+      1,
+    ),
+  )[0];
+  assert.equal(terminal?.terminal_outcome, "closed");
+  assert.equal(terminal?.run_id, "78120");
+
+  const redelivery = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "generic-success-terminal-redelivery",
+      7812,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/openclaw",
+      exactReviewPublicationOverrides(7812, "78121", "opened", 1, "openclaw/openclaw"),
+    ),
+  );
+  assert.deepEqual(await redelivery.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/openclaw#7812@publish:78121:1",
+    terminal: true,
+    terminal_outcome: "closed",
+  });
+});
+
+test("stale publication redelivery preserves an active revision's final terminal outcome", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(7813, "78130");
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  assert.equal(
+    (
+      await queue.fetch(
+        buildExactReviewQueueRequest(
+          "active-terminal-newer-revision",
+          7813,
+          "exact_review_artifact_publish",
+          "issue",
+          "openclaw/openclaw",
+          exactReviewPublicationOverrides(7813, "78131", "opened", 2, "openclaw/openclaw"),
+        ),
+      )
+    ).status,
+    202,
+  );
+  const staleRedelivery = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "active-terminal-stale-redelivery",
+      7813,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/openclaw",
+      exactReviewPublicationOverrides(7813, "78130", "opened", 1, "openclaw/openclaw"),
+    ),
+  );
+  const staleResult = await staleRedelivery.json();
+  assert.equal(staleResult.deduped, true);
+  assert.equal(staleResult.superseded, true);
+  assert.equal(staleResult.terminal, undefined);
+  assert.equal(
+    Array.from(
+      storage.sql.exec(
+        `SELECT *
+           FROM exact_review_publication_terminals
+          WHERE target_key = ? AND source_revision = ?`,
+        "openclaw/openclaw#7813",
+        1,
+      ),
+    ).length,
+    0,
+  );
+
+  const completed = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "success",
+        completion_kind: "published",
+        reason_code: "publication_applied",
+      }),
+    }),
+  );
+  assert.deepEqual(await completed.json(), { ok: true, requeued: false });
+  const terminal = Array.from(
+    storage.sql.exec(
+      `SELECT terminal_outcome, run_id
+         FROM exact_review_publication_terminals
+        WHERE target_key = ? AND source_revision = ?`,
+      "openclaw/openclaw#7813",
+      1,
+    ),
+  )[0];
+  assert.equal(terminal?.terminal_outcome, "published");
+  assert.equal(terminal?.run_id, "78130");
+
+  const terminalRedelivery = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "active-terminal-final-redelivery",
+      7813,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/openclaw",
+      exactReviewPublicationOverrides(7813, "78130", "opened", 1, "openclaw/openclaw"),
+    ),
+  );
+  assert.deepEqual(await terminalRedelivery.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/openclaw#7813@publish:78130:1",
+    terminal: true,
+    terminal_outcome: "published",
+  });
 });
 
 test("exact-review publication dead-letters exhausted permanent failures and replays idempotently", async () => {
@@ -10075,7 +10347,7 @@ test("signed exact-review reconciliation releases only immutable terminal runs",
       "openclaw/openclaw#711": leasedExactReviewQueueItem(711, "9001"),
       "openclaw/openclaw#712": leasedExactReviewQueueItem(712, "9002"),
       "openclaw/openclaw#720": leasedExactReviewQueueItem(720, "9004"),
-      "openclaw/openclaw#719": leasedExactReviewQueueItem(719, "9003"),
+      "openclaw/openclaw#719": leasedExactReviewPublicationItem(719, "9003"),
     },
   });
   const queue = new ExactReviewQueue({ storage }, {});
@@ -10200,6 +10472,17 @@ test("signed exact-review reconciliation releases only immutable terminal runs",
     assert.equal(state.items["openclaw/openclaw#712"].claimedRunId, "9002");
     assert.equal(state.items["openclaw/openclaw#720"].claimedRunId, "9004");
     assert.equal(state.items["openclaw/openclaw#719"], undefined);
+    const terminal = Array.from(
+      storage.sql.exec(
+        `SELECT terminal_outcome, run_id
+           FROM exact_review_publication_terminals
+          WHERE target_key = ? AND source_revision = ?`,
+        "openclaw/openclaw#719",
+        1,
+      ),
+    )[0];
+    assert.equal(terminal?.terminal_outcome, "closed");
+    assert.equal(terminal?.run_id, "9003");
     const staleAttemptBody = JSON.stringify({
       runs: [{ run_id: "9004", run_attempt: 2 }],
       include_all_claimed: true,

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -2220,8 +2220,9 @@ test("queue completion atomically removes only the owned publication revision", 
   const originalNow = Date.now;
   Date.now = () => 2_000_000;
   try {
+    const storage = new TestStorage();
     const queue = new ExactReviewQueue(
-      { storage: new TestStorage() },
+      { storage },
       { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
     );
     const enqueued = await queue.fetch(publicationRequest("delivery-complete", 103, "1003"));
@@ -2300,6 +2301,18 @@ test("queue completion atomically removes only the owned publication revision", 
     ).json();
     assert.equal(completion.accepted, 1);
     assert.equal(completion.batch.state, "completed");
+    const terminal = Array.from(
+      storage.sql.exec(
+        `SELECT terminal_outcome, batch_id, state_commit_sha
+           FROM exact_review_publication_terminals
+          WHERE target_key = ? AND source_revision = ?`,
+        "openclaw/openclaw#103",
+        1,
+      ),
+    )[0];
+    assert.equal(terminal?.terminal_outcome, "published");
+    assert.equal(terminal?.batch_id, "claim-complete");
+    assert.equal(terminal?.state_commit_sha, "b".repeat(40));
 
     const retriedCompletion = await (
       await queue.fetch(

--- a/test/exact-review-publication-terminal-ledger.test.ts
+++ b/test/exact-review-publication-terminal-ledger.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+
+import { ExactReviewPublicationTerminalLedger } from "../dashboard/exact-review-publication-terminal-ledger.ts";
+
+class TestStorage {
+  private readonly database = new DatabaseSync(":memory:");
+  readonly sql = {
+    exec: (query: string, ...bindings: unknown[]) => {
+      const statement = this.database.prepare(query);
+      return /\b(?:SELECT|RETURNING)\b/i.test(query)
+        ? statement.all(...bindings)
+        : (statement.run(...bindings), []);
+    },
+  };
+}
+
+test("terminal ledger compacts old revisions without admitting their redelivery", () => {
+  const ledger = new ExactReviewPublicationTerminalLedger(new TestStorage());
+  ledger.ensureSchemaSync();
+  assert.equal(
+    ledger.record({
+      targetKey: "openclaw/openclaw#42",
+      sourceRevision: 3,
+      outcome: "published",
+      terminalAt: 100,
+      runId: "301",
+    }),
+    "recorded",
+  );
+  assert.equal(
+    ledger.record({
+      targetKey: "openclaw/openclaw#42",
+      sourceRevision: 3,
+      outcome: "published",
+      terminalAt: 101,
+    }),
+    "duplicate",
+  );
+  assert.equal(ledger.compact(1_000, { retentionMs: 1, limit: 10 }).deleted, 1);
+  assert.deepEqual(ledger.terminalFor("openclaw/openclaw#42", 3), {
+    outcome: "compacted",
+    compacted: true,
+  });
+  assert.equal(ledger.terminalFor("openclaw/openclaw#42", 4), null);
+});


### PR DESCRIPTION
## Summary

Persist exact-review publication terminal outcomes by target and immutable source revision, so terminal redelivery is a deterministic no-op while a later source revision can still be queued.

## Problem

Publication completion removed the hot queue item but did not retain a durable terminal decision. A later delivery for the same source revision could therefore re-enter the publication lane and repost. The old collision branches `fix/immutable-ledger-hot-state-race` (#584) and `fix/spam-empty-ledger-finalization` (#548) are closed, stale, and outside this scoped replacement (including unrelated CHANGELOG/workflow edits), so this PR does not reuse them.

## Implementation

- Add a transactional terminal ledger keyed by `target_key` and `source_revision`, with optional run, batch, and state-commit metadata.
- Store `published`, `superseded`, and `closed` outcomes in the same durable transaction as queue removal, including direct completion, signed reconciliation, batch completion, live terminalization, and supersession paths.
- Consult the ledger before enqueueing publication redelivery. Detailed entries produce their recorded terminal outcome; a compacted per-target high-water mark makes only older revisions no-ops, leaving later revisions admissible.
- Backfill the high-water table from existing detailed rows and compact old detailed rows in bounded batches after 90 days.
- Preserve an active revision's final outcome: stale redelivery does not prematurely write `superseded` while that revision is leased or batch-owned.

## Validation

```text
node --test test/exact-review-publication-terminal-ledger.test.ts test/dashboard-worker.test.ts test/exact-review-publication-batches.test.ts
# 266 passed, 0 failed

pnpm run build:dashboard
pnpm run lint:dashboard
pnpm exec oxfmt --check dashboard/exact-review-queue.ts dashboard/exact-review-publication-terminal-ledger.ts test/dashboard-worker.test.ts test/exact-review-publication-batches.test.ts test/exact-review-publication-terminal-ledger.test.ts
git diff --check
```

`pnpm run format:check` remains baseline noise on current `main` (498 pre-existing, unrelated formatting reports); the targeted formatter check above passes for every changed file.

Codex review closeout:

- `codex review --uncommitted`: clean after accepting and testing two findings: generic successful completion/reconciliation must record `closed`, and stale ingress must not preempt an active revision's final outcome.
- `git fetch origin main && codex review --base origin/main`: clean; no actionable defects reported.

## Risks and rollout

The compacted target head intentionally retains a durable no-op fence after detailed metadata expires; only source revisions at or below that fence are suppressed. The focused tests cover atomic rollback, duplicate redelivery, published/superseded/closed outcomes, signed reconciliation, batch state-commit metadata, migration/backfill, bounded compaction, and a later source revision proceeding normally. No CHANGELOG, workflow, queue reset, or state-branch push logic is changed.

## Current compatibility reassessment (2026-07-26)

This branch was reviewed at `517547d155840e7065892925cbca6a92ac70326b` against `a0cbed1cf71b5efd66ae6e37804841788a8ed0b8`. Current `main` is `0974eeea2fc0fed84ac9ef6b9a5e8ed2887af10c` after #859, #866, and #867.

- #859 introduced normal direct publication through `ExactReviewDirectPublicationStore`.
- #866 made Cloudflare Durable Object canonical records and their digest/revision fences authoritative; the state repository is now a projection.
- #867 repaired canonical record-tuple projection and isolation.

`main` also already owns a controller publication-head fence. This PR's new controller-local `exact_review_publication_terminals` table conflicts in `dashboard/exact-review-queue.ts` and would create a parallel terminal authority beside the canonical direct-publication store. A non-mutating merge simulation against current `main` reports that content conflict, so this branch is not safe to rebase as-is.

The durable-redelivery requirement is not dismissed: a successor must define terminal `published`, `superseded`, and `closed` semantics for the bounded legacy fallback through the canonical state abstraction, while preserving its existing direct-path idempotency and migration behavior. That is a Cloudflare-canonical design decision, not a compatibility-only edit to this controller-ledger branch, so no migration was added here.

## Fresh ClawSweeper review (2026-07-26T08:19:11Z)

The durable [ClawSweeper review comment](https://github.com/openclaw/clawsweeper/pull/856#issuecomment-5080815357) is fresh for the current head and contains one actionable P1: routing terminal outcomes through canonical publication state. It reviewed `517547d155840e7065892925cbca6a92ac70326b` against current `main` `0974eeea2fc0fed84ac9ef6b9a5e8ed2887af10c`.

The finding confirms the compatibility assessment above: a controller-local terminal ledger would become a second terminal/revision authority after #859 and #866. Current direct canonical state has `published` and `superseded` receipts with seven-day retention; the legacy queue separately retains its publication head and has no canonical `closed` terminal outcome. Reworking that behavior requires a maintainer-owned retention, revision-fence, and fallback-ownership contract—not a conflict-only rebase.

ClawSweeper's recommended disposition is to close this PR as superseded by #859, or pause it pending that contract. No close, rebase, migration, test claim, or duplicate `@clawsweeper` command has been performed. The review also requires redacted production-shaped evidence that duplicate redelivery is a no-op and a later revision proceeds, but that proof cannot validate an architecture the fresh review marks P1-incompatible.
