### PR TITLE
feat(telemetry): trace exact publication handoffs

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -8,6 +8,14 @@ on:
         required: true
         type: boolean
         default: false
+      dispatch_id:
+        description: "Durable dispatcher reservation identifier"
+        required: false
+        type: string
+      dispatched_at:
+        description: "UTC timestamp for the dispatcher reservation"
+        required: false
+        type: string
 
 permissions:
   actions: write
@@ -25,6 +33,8 @@ jobs:
       EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
       EXACT_REVIEW_BATCH_ID: exact-review-batch:${{ github.run_id }}
       EXACT_REVIEW_BATCH_LEASE_OWNER: github:${{ github.run_id }}
+      EXACT_REVIEW_BATCH_DISPATCH_ID: ${{ inputs.dispatch_id }}
+      EXACT_REVIEW_BATCH_DISPATCHED_AT: ${{ inputs.dispatched_at }}
       EXACT_REVIEW_BATCH_MANIFEST: .artifacts/exact-review-batch/manifest.json
       # Scan the full queue window so owner filtering can still fill the 32-item lease cap.
       EXACT_REVIEW_BATCH_MAX_ITEMS: "50"
@@ -32,6 +42,9 @@ jobs:
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
       CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
     steps:
+      - name: Capture runner start timestamp
+        run: echo "EXACT_REVIEW_BATCH_RUNNER_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
         with:
           ref: main
@@ -63,6 +76,14 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
           permission-statuses: read
+
+      - name: Record batch preparation start
+        if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          EXACT_REVIEW_BATCH_OBSERVATION: preparation_started
+        run: pnpm run --silent repair:exact-review-batch observe
 
       - name: Create state token
         if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
@@ -109,6 +130,14 @@ jobs:
           EXACT_REVIEW_BATCH_HEARTBEAT_FAILURE_PATH="$heartbeat_failed" \
             node scripts/prepare-exact-review-batch.mjs
           test ! -f "$heartbeat_failed"
+
+      - name: Record batch preparation finish
+        if: ${{ always() && steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          EXACT_REVIEW_BATCH_OBSERVATION: preparation_finished
+        run: pnpm run --silent repair:exact-review-batch observe
 
       - name: Finalize healthy members under a fenced heartbeat
         if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}
@@ -177,7 +206,8 @@ jobs:
               # scheduled proof lane; no immediate mutation workflow is dispatched.
               :
             elif jq -e '.disposition.routableSyncExpected == true' "$outcome_path" >/dev/null && [ "$source_action" != "failed_review_shard_recovery" ]; then
-              gh workflow run repair-comment-router.yml \
+              github_apply_error="$(mktemp)"
+              if gh workflow run repair-comment-router.yml \
                 --repo "$GITHUB_REPOSITORY" \
                 --ref main \
                 -f execute=true \
@@ -185,13 +215,27 @@ jobs:
                 -f target_branch="$target_branch" \
                 -f item_numbers="$item_number" \
                 -f lookback_minutes="$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
-                -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS"
+                -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS" \
+                2>"$github_apply_error"; then
+                rm -f "$github_apply_error"
+              else
+                github_apply_status=$?
+                if grep -Eqi 'rate limit|HTTP 429' "$github_apply_error"; then
+                  EXACT_REVIEW_BATCH_OBSERVATION=github_throttle \
+                    pnpm run --silent repair:exact-review-batch observe || true
+                fi
+                cat "$github_apply_error" >&2
+                rm -f "$github_apply_error"
+                exit "$github_apply_status"
+              fi
             fi
             temporary="${outcome_path}.tmp"
             jq '.postEffectsComplete = true' "$outcome_path" > "$temporary"
             mv "$temporary" "$outcome_path"
           done
           test ! -f "$heartbeat_failed"
+          EXACT_REVIEW_BATCH_OBSERVATION=final_github_apply \
+            pnpm run --silent repair:exact-review-batch observe || true
           pnpm run --silent repair:exact-review-batch complete
 
       - name: Release unfinished batch members

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -18,6 +18,9 @@ type DurableStorage = {
 export type PublicationBatchCandidate = {
   itemKey: string;
   revision: number;
+  producerRunId?: string;
+  producerRunAttempt?: number;
+  enqueuedAt?: number;
 };
 
 export type PublicationBatchTerminalOutcome = "published" | "superseded" | "lease_expired";
@@ -26,6 +29,14 @@ export type PublicationBatchItem = PublicationBatchCandidate & {
   claimGeneration: number;
   terminalOutcome: PublicationBatchTerminalOutcome | null;
 };
+
+export type PublicationBatchObservationStage =
+  | "preparation_started"
+  | "preparation_finished"
+  | "state_writer_wait"
+  | "state_writer_committed"
+  | "final_github_apply"
+  | "github_throttle";
 
 export type PublicationBatch = {
   batchId: string;
@@ -38,6 +49,17 @@ export type PublicationBatch = {
   completedAt: number | null;
   stateCommitSha: string | null;
   failureFingerprint: string | null;
+  dispatchId: string | null;
+  dispatchedAt: number | null;
+  runnerRunId: string | null;
+  runnerRunAttempt: number | null;
+  runnerStartedAt: number | null;
+  preparationStartedAt: number | null;
+  preparationFinishedAt: number | null;
+  stateWriterWaitAt: number | null;
+  stateWriterCommittedAt: number | null;
+  finalGithubApplyAt: number | null;
+  githubThrottleAt: number | null;
   items: PublicationBatchItem[];
 };
 
@@ -68,6 +90,10 @@ export type PublicationBatchStats = {
     eligibleRemaining: number;
     limit: number;
   };
+};
+
+export type PublicationBatchObservability = {
+  batches: PublicationBatch[];
 };
 
 export class ExactReviewPublicationBatchStore {
@@ -106,6 +132,25 @@ export class ExactReviewPublicationBatchStore {
              CHECK (configured_batch_size >= 1)`,
       );
     }
+    const telemetryBatchColumns = [
+      ["dispatch_id", "TEXT"],
+      ["dispatched_at", "INTEGER"],
+      ["runner_run_id", "TEXT"],
+      ["runner_run_attempt", "INTEGER"],
+      ["runner_started_at", "INTEGER"],
+      ["preparation_started_at", "INTEGER"],
+      ["preparation_finished_at", "INTEGER"],
+      ["state_writer_wait_at", "INTEGER"],
+      ["state_writer_committed_at", "INTEGER"],
+      ["final_github_apply_at", "INTEGER"],
+      ["github_throttle_at", "INTEGER"],
+    ] as const;
+    for (const [name, definition] of telemetryBatchColumns) {
+      if (batchColumns.has(name)) continue;
+      this.storage.sql.exec(
+        `ALTER TABLE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} ADD COLUMN ${name} ${definition}`,
+      );
+    }
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} (
          batch_id TEXT NOT NULL,
@@ -122,6 +167,24 @@ export class ExactReviewPublicationBatchStore {
            ON DELETE CASCADE
        ) STRICT`,
     );
+    const batchItemColumns = new Set(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}')`,
+        ),
+      ).map((row) => String(row.name || "")),
+    );
+    const telemetryItemColumns = [
+      ["producer_run_id", "TEXT"],
+      ["producer_run_attempt", "INTEGER"],
+      ["enqueued_at", "INTEGER"],
+    ] as const;
+    for (const [name, definition] of telemetryItemColumns) {
+      if (batchItemColumns.has(name)) continue;
+      this.storage.sql.exec(
+        `ALTER TABLE ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} ADD COLUMN ${name} ${definition}`,
+      );
+    }
     // Only unfinished membership owns an item. Expiry terminalizes that membership,
     // preserving its fencing generation while allowing a later batch to reclaim the item.
     this.storage.sql.exec(
@@ -171,6 +234,8 @@ export class ExactReviewPublicationBatchStore {
     now: number;
     maxItems: number;
     maxConcurrentBatches?: number;
+    dispatch?: { id: string; at: number };
+    runner?: { runId: string; runAttempt: number; startedAt: number };
     candidates: PublicationBatchCandidate[];
   }): PublicationBatch | null {
     return this.storage.transactionSync(() => {
@@ -196,25 +261,35 @@ export class ExactReviewPublicationBatchStore {
       this.storage.sql.exec(
         `INSERT INTO ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
            (batch_id, state, lease_owner, lease_expires_at, configured_batch_size,
-            attempt, created_at)
-         VALUES (?, 'leased', ?, ?, ?, 1, ?)`,
+            attempt, created_at, dispatch_id, dispatched_at, runner_run_id,
+            runner_run_attempt, runner_started_at)
+         VALUES (?, 'leased', ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
         input.batchId,
         input.leaseOwner,
         input.leaseExpiresAt,
         input.maxItems,
         input.now,
+        input.dispatch?.id ?? null,
+        input.dispatch?.at ?? null,
+        input.runner?.runId ?? null,
+        input.runner?.runAttempt ?? null,
+        input.runner?.startedAt ?? null,
       );
       for (const candidate of input.candidates) {
         if (this.countUnfinishedItemsSync(input.batchId) >= input.maxItems) break;
         const generation = this.nextClaimGenerationSync(candidate.itemKey);
         this.storage.sql.exec(
           `INSERT OR IGNORE INTO ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
-             (batch_id, item_key, revision, claim_generation)
-           VALUES (?, ?, ?, ?)`,
+             (batch_id, item_key, revision, claim_generation, producer_run_id,
+              producer_run_attempt, enqueued_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
           input.batchId,
           candidate.itemKey,
           candidate.revision,
           generation,
+          candidate.producerRunId ?? null,
+          candidate.producerRunAttempt ?? null,
+          candidate.enqueuedAt ?? null,
         );
       }
       const batch = this.readBatchSync(input.batchId);
@@ -286,6 +361,84 @@ export class ExactReviewPublicationBatchStore {
     return this.storage.transactionSync(() => {
       this.reclaimExpiredSync(now);
       return this.activeLeaseSnapshotSync();
+    });
+  }
+
+  recordObservation(
+    batchId: string,
+    leaseOwner: string,
+    stage: PublicationBatchObservationStage,
+    observedAt: number,
+  ): PublicationBatch | null {
+    const column = {
+      preparation_started: "preparation_started_at",
+      preparation_finished: "preparation_finished_at",
+      state_writer_wait: "state_writer_wait_at",
+      state_writer_committed: "state_writer_committed_at",
+      final_github_apply: "final_github_apply_at",
+      github_throttle: "github_throttle_at",
+    }[stage];
+    return this.storage.transactionSync(() => {
+      const batch = this.readBatchSync(batchId);
+      if (!batch || batch.leaseOwner !== leaseOwner) return null;
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            SET ${column} = COALESCE(${column}, ?)
+          WHERE batch_id = ? AND lease_owner = ?`,
+        observedAt,
+        batchId,
+        leaseOwner,
+      );
+      return this.readBatchSync(batchId);
+    });
+  }
+
+  recordGithubThrottle(
+    batchId: string,
+    leaseOwner: string,
+    observedAt: number,
+  ): PublicationBatch | null {
+    return this.storage.transactionSync(() => {
+      const batch = this.readBatchSync(batchId);
+      if (!batch || batch.leaseOwner !== leaseOwner) return null;
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            SET github_throttle_at = COALESCE(github_throttle_at, ?)
+          WHERE batch_id = ? AND lease_owner = ?`,
+        observedAt,
+        batchId,
+        leaseOwner,
+      );
+      return this.readBatchSync(batchId);
+    });
+  }
+
+  observability(now: number, limit = 50): PublicationBatchObservability {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      // A bounded terminal history must never hide a currently leased batch:
+      // active leases drive capacity and stall alerts, whereas completed and
+      // expired rows are only diagnostic history.
+      const activeBatchIds = Array.from(
+        this.storage.sql.exec(
+          `SELECT batch_id FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            WHERE state = 'leased' ORDER BY created_at DESC, batch_id DESC`,
+        ),
+        (row) => String(row.batch_id),
+      );
+      const historicalBatchIds = Array.from(
+        this.storage.sql.exec(
+          `SELECT batch_id FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE}
+            WHERE state <> 'leased' ORDER BY completed_at DESC, batch_id DESC LIMIT ?`,
+          Math.max(1, Math.min(100, limit)),
+        ),
+        (row) => String(row.batch_id),
+      );
+      return {
+        batches: [...activeBatchIds, ...historicalBatchIds]
+          .map((batchId) => this.readBatchSync(batchId))
+          .filter((batch): batch is PublicationBatch => Boolean(batch)),
+      };
     });
   }
 
@@ -517,7 +670,10 @@ export class ExactReviewPublicationBatchStore {
     const row = Array.from(
       this.storage.sql.exec(
         `SELECT batch_id, state, lease_owner, lease_expires_at, attempt, created_at,
-                configured_batch_size, completed_at, state_commit_sha, failure_fingerprint
+                configured_batch_size, completed_at, state_commit_sha, failure_fingerprint,
+                dispatch_id, dispatched_at, runner_run_id, runner_run_attempt, runner_started_at,
+                preparation_started_at, preparation_finished_at, state_writer_wait_at,
+                state_writer_committed_at, final_github_apply_at, github_throttle_at
            FROM ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} WHERE batch_id = ?`,
         batchId,
       ),
@@ -525,7 +681,8 @@ export class ExactReviewPublicationBatchStore {
     if (!row) return null;
     const items = Array.from(
       this.storage.sql.exec(
-        `SELECT item_key, revision, claim_generation, terminal_outcome
+        `SELECT item_key, revision, claim_generation, terminal_outcome, producer_run_id,
+                producer_run_attempt, enqueued_at
            FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE}
           WHERE batch_id = ? ORDER BY item_key`,
         batchId,
@@ -538,6 +695,10 @@ export class ExactReviewPublicationBatchStore {
           item.terminal_outcome === null
             ? null
             : (String(item.terminal_outcome) as PublicationBatchTerminalOutcome),
+        producerRunId: item.producer_run_id === null ? undefined : String(item.producer_run_id),
+        producerRunAttempt:
+          item.producer_run_attempt === null ? undefined : Number(item.producer_run_attempt),
+        enqueuedAt: item.enqueued_at === null ? undefined : Number(item.enqueued_at),
       }),
     );
     return {
@@ -551,6 +712,22 @@ export class ExactReviewPublicationBatchStore {
       completedAt: row.completed_at === null ? null : Number(row.completed_at),
       stateCommitSha: row.state_commit_sha === null ? null : String(row.state_commit_sha),
       failureFingerprint: row.failure_fingerprint === null ? null : String(row.failure_fingerprint),
+      dispatchId: row.dispatch_id === null ? null : String(row.dispatch_id),
+      dispatchedAt: row.dispatched_at === null ? null : Number(row.dispatched_at),
+      runnerRunId: row.runner_run_id === null ? null : String(row.runner_run_id),
+      runnerRunAttempt: row.runner_run_attempt === null ? null : Number(row.runner_run_attempt),
+      runnerStartedAt: row.runner_started_at === null ? null : Number(row.runner_started_at),
+      preparationStartedAt:
+        row.preparation_started_at === null ? null : Number(row.preparation_started_at),
+      preparationFinishedAt:
+        row.preparation_finished_at === null ? null : Number(row.preparation_finished_at),
+      stateWriterWaitAt:
+        row.state_writer_wait_at === null ? null : Number(row.state_writer_wait_at),
+      stateWriterCommittedAt:
+        row.state_writer_committed_at === null ? null : Number(row.state_writer_committed_at),
+      finalGithubApplyAt:
+        row.final_github_apply_at === null ? null : Number(row.final_github_apply_at),
+      githubThrottleAt: row.github_throttle_at === null ? null : Number(row.github_throttle_at),
       items,
     };
   }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2277,6 +2277,8 @@ export class ExactReviewQueue {
         dispatcher: state.dispatcher,
         publication: stats.lanes.publication,
         batches: this.batchStore.observability(now).batches,
+        directPublicationEnabled: exactReviewDirectPublicationEnabled(this.env),
+        legacyStateRepoBatchEnabled: exactReviewPublicationBatchingEnabled(this.env),
         maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
       });
       return json({
@@ -4292,7 +4294,7 @@ export class ExactReviewQueue {
     if (!leaseOwner) return json({ error: "invalid_lease_owner" }, 400);
     if (!claimId) return json({ error: "invalid_claim_id" }, 400);
     const dispatch = exactReviewPublicationBatchDispatchMetadata(body);
-    if (body.dispatch_id !== undefined && !dispatch) {
+    if ((body.dispatch_id !== undefined || body.dispatched_at !== undefined) && !dispatch) {
       return json({ error: "invalid_batch_dispatch_metadata" }, 400);
     }
     const runner = exactReviewPublicationBatchRunnerMetadata(body);
@@ -10274,6 +10276,8 @@ function exactReviewReservationClaimObservability({
   dispatcher,
   publication,
   batches,
+  directPublicationEnabled,
+  legacyStateRepoBatchEnabled,
   maxConcurrentBatches,
 }) {
   const reservationToClaimDelays = batches.flatMap((batch) =>
@@ -10372,6 +10376,22 @@ function exactReviewReservationClaimObservability({
   return {
     schema_version: 1,
     generated_at: new Date(now).toISOString(),
+    // Direct publication never enters a publication batch unless it falls back.
+    // Keep its canonical Durable Object path distinct from the batch-only
+    // timestamps below so dashboards do not infer state-writer latency for a
+    // direct publication.
+    publication_paths: {
+      cloudflare_canonical_direct: {
+        enabled: directPublicationEnabled,
+        reservation_to_claim: "not_applicable",
+        state_writer_timing: "not_applicable",
+      },
+      legacy_state_repo_batch: {
+        enabled: legacyStateRepoBatchEnabled,
+        reservation_to_claim: "tracked",
+        state_writer_timing: "tracked",
+      },
+    },
     queue_slots: {
       pending,
       unassigned_pending: unassignedPending,
@@ -10384,6 +10404,7 @@ function exactReviewReservationClaimObservability({
     alerts,
     batches: batches.map((batch) => ({
       batch_id: batch.batchId,
+      publication_path: "legacy_state_repo_batch",
       state: batch.state,
       configured_batch_size: batch.configuredBatchSize,
       claimed_at: new Date(batch.createdAt).toISOString(),

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -15,6 +15,7 @@ import {
   ExactReviewPublicationBatchStore,
   type PublicationBatchCompletion,
   type PublicationBatchFence,
+  type PublicationBatchObservationStage,
 } from "./exact-review-publication-batches.ts";
 import {
   DirectPublicationProjectionCapacityError,
@@ -219,6 +220,7 @@ export type ExactReviewQueueState = {
     dispatchFailureFingerprint?: string;
     dispatchFailureDetail?: ExactReviewDispatchFailureDetail;
     dispatchConsecutiveFailures?: number;
+    publicationBatchDispatchId?: string;
     reviewAdmissionNextAt?: number;
     publicationBatchDispatchedAt?: number;
     publicationBatchDispatchSucceeded?: boolean;
@@ -2270,6 +2272,13 @@ export class ExactReviewQueue {
         publicationFlow,
         deadLetters,
       );
+      const reservationClaimObservability = exactReviewReservationClaimObservability({
+        now,
+        dispatcher: state.dispatcher,
+        publication: stats.lanes.publication,
+        batches: this.batchStore.observability(now).batches,
+        maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
+      });
       return json({
         ...stats,
         pressure: elevateExactReviewPressureForPublication(stats.pressure, publicationHealth),
@@ -2355,6 +2364,7 @@ export class ExactReviewQueue {
         },
         delivery_receipts: this.deliveryReceiptCountSync(),
         review_telemetry_health: reviewTelemetryHealth,
+        reservation_claim_observability: reservationClaimObservability,
         state_writer: { ...stateWriter, coordinator: stateWriterCoordinator },
         state_append: {
           ...stateAppend,
@@ -2527,9 +2537,11 @@ export class ExactReviewQueue {
     let batchDispatchAttempted = false;
     let batchDispatchSucceeded = false;
     let batchDispatchRecordedAt: number | undefined;
+    let batchDispatchId: string | undefined;
     if (snapshotBatchDeparture?.due && batchTerminalPreflightReady) {
       batchDispatchAttempted = true;
       batchDispatchRecordedAt = Date.now();
+      batchDispatchId = `publication-batch-dispatch:${crypto.randomUUID()}`;
       const reserved = this.readStateSync();
       const reservedDispatcher = reserved.dispatcher ?? {
         state: "unknown",
@@ -2537,6 +2549,7 @@ export class ExactReviewQueue {
       };
       reserved.dispatcher = {
         ...reservedDispatcher,
+        publicationBatchDispatchId: batchDispatchId,
         publicationBatchDispatchedAt: batchDispatchRecordedAt,
         publicationBatchDispatchSucceeded: undefined,
         publicationBatchDispatchPendingUntil:
@@ -2547,7 +2560,11 @@ export class ExactReviewQueue {
       await this.writeState(reserved);
       try {
         const token = await exactReviewDispatchToken(this.env);
-        await dispatchExactReviewBatchWorkflow({ token });
+        await dispatchExactReviewBatchWorkflow({
+          token,
+          dispatchId: batchDispatchId,
+          dispatchedAt: new Date(batchDispatchRecordedAt).toISOString(),
+        });
         batchDispatchSucceeded = true;
       } catch (error) {
         console.warn(
@@ -2615,6 +2632,7 @@ export class ExactReviewQueue {
         dispatcher?.publicationBatchDispatchedAt === batchDispatchRecordedAt
         ? {
             ...persisted,
+            publicationBatchDispatchId: batchDispatchId,
             publicationBatchDispatchedAt: batchDispatchRecordedAt,
             publicationBatchDispatchSucceeded: batchDispatchSucceeded,
           }
@@ -4273,6 +4291,19 @@ export class ExactReviewQueue {
     const claimId = exactReviewPublicationBatchId(body.claim_id);
     if (!leaseOwner) return json({ error: "invalid_lease_owner" }, 400);
     if (!claimId) return json({ error: "invalid_claim_id" }, 400);
+    const dispatch = exactReviewPublicationBatchDispatchMetadata(body);
+    if (body.dispatch_id !== undefined && !dispatch) {
+      return json({ error: "invalid_batch_dispatch_metadata" }, 400);
+    }
+    const runner = exactReviewPublicationBatchRunnerMetadata(body);
+    if (
+      (body.runner_run_id !== undefined ||
+        body.runner_run_attempt !== undefined ||
+        body.runner_started_at !== undefined) &&
+      !runner
+    ) {
+      return json({ error: "invalid_batch_runner_metadata" }, 400);
+    }
     const configuredSize = exactReviewPublicationBatchSize(this.env);
     const requestedSize = body.max_items === undefined ? configuredSize : Number(body.max_items);
     if (
@@ -4340,11 +4371,20 @@ export class ExactReviewQueue {
     // rolling deployment; new departures always persist a probe.
     const legacyDispatchReservation =
       dispatchReservationActive && state.dispatcher?.publicationBatchTerminalProbe === undefined;
+    // Older workflow definitions have no dispatch metadata and must remain
+    // claim-compatible. A telemetry-bearing workflow, however, must consume
+    // the reservation that issued its immutable dispatch id; otherwise a late
+    // workflow could erase a newer departure and corrupt its handoff trace.
+    const dispatchMatchesReservation =
+      !dispatch ||
+      !dispatchReservationActive ||
+      dispatch.id === state.dispatcher?.publicationBatchDispatchId;
     const probeMatches =
       !terminalProbeRequired ||
       legacyDispatchReservation ||
       (dispatchReservationActive &&
-        state.dispatcher.publicationBatchTerminalProbe === candidateProbe);
+        state.dispatcher.publicationBatchTerminalProbe === candidateProbe &&
+        dispatchMatchesReservation);
     if (!probeMatches) {
       // Leave the current fence intact. This request may belong to a delayed
       // workflow from an earlier departure; clearing here could let the current
@@ -4366,7 +4406,15 @@ export class ExactReviewQueue {
       now,
       maxItems: leaseSize,
       maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
-      candidates: candidates.map((item) => ({ itemKey: item.key, revision: item.revision })),
+      ...(dispatch ? { dispatch } : {}),
+      ...(runner ? { runner } : {}),
+      candidates: candidates.map((item) => ({
+        itemKey: item.key,
+        revision: item.revision,
+        producerRunId: item.decision.publication?.producerRunId,
+        producerRunAttempt: item.decision.publication?.producerRunAttempt,
+        enqueuedAt: item.createdAt,
+      })),
     });
     if (
       state.dispatcher?.publicationBatchDispatchPendingUntil ||
@@ -4503,8 +4551,12 @@ export class ExactReviewQueue {
       body.state_writer_progress === undefined
         ? undefined
         : normalizeStateWriterProgress(body.state_writer_progress);
+    const observation = exactReviewPublicationBatchObservation(body);
     if (!batchId || !leaseOwner) return json({ error: "invalid_batch_identity" }, 400);
     if (!members?.length) return json({ error: "invalid_batch_members" }, 400);
+    if ((body.timeline_stage !== undefined || body.observed_at !== undefined) && !observation) {
+      return json({ error: "invalid_batch_timeline_observation" }, 400);
+    }
     if (body.state_writer_progress !== undefined && !progress) {
       this.incrementStateWriterDiagnosticSafely("rejected_progress_total");
       return json({ error: "invalid_state_writer_progress" }, 400);
@@ -4525,6 +4577,22 @@ export class ExactReviewQueue {
         return json({ error: "invalid_batch_state_writer_progress" }, 400);
       }
       this.recordStateWriterProgressSafely(progress, now);
+      if (progress.phase === "waiting") {
+        this.batchStore.recordObservation(
+          batchId,
+          leaseOwner,
+          "state_writer_wait",
+          Date.parse(progress.observed_at),
+        );
+      }
+    }
+    if (observation) {
+      this.batchStore.recordObservation(
+        batchId,
+        leaseOwner,
+        observation.stage,
+        observation.observedAt,
+      );
     }
     return json({ ok: true, batch: exactReviewPublicationBatchJson(batch) });
   }
@@ -4570,7 +4638,7 @@ export class ExactReviewQueue {
       ),
     );
     const now = Date.now();
-    const batch = this.batchStore.complete(
+    let batch = this.batchStore.complete(
       batchId,
       leaseOwner,
       completions.map(({ itemKey, revision, claimGeneration, terminalOutcome }) => ({
@@ -4660,6 +4728,22 @@ export class ExactReviewQueue {
       },
     );
     if (!batch) return json({ error: "batch_lease_not_active" }, 409);
+    if (stateWriter?.commit_count === 1) {
+      batch =
+        this.batchStore.recordObservation(
+          batchId,
+          leaseOwner,
+          "state_writer_committed",
+          Date.parse(stateWriter.finished_at),
+        ) ?? batch;
+    }
+    if (
+      completions.some(
+        (completion) => completion.publicationCompletion?.reasonCode === "github_rate_limit",
+      )
+    ) {
+      batch = this.batchStore.recordGithubThrottle(batchId, leaseOwner, now) ?? batch;
+    }
     this.recordStateWriterOperationSafely(stateWriter, false, now);
     if (acceptedCount) await this.scheduleNext(this.readStateSync(), now);
     return json({
@@ -9255,6 +9339,9 @@ function exactReviewPublicationBatchDeparture(
 
 function exactReviewBatchDispatcherFields(dispatcher: ExactReviewQueueState["dispatcher"]) {
   return {
+    ...(dispatcher?.publicationBatchDispatchId
+      ? { publicationBatchDispatchId: dispatcher.publicationBatchDispatchId }
+      : {}),
     ...(dispatcher?.publicationBatchDispatchedAt
       ? { publicationBatchDispatchedAt: dispatcher.publicationBatchDispatchedAt }
       : {}),
@@ -10003,14 +10090,22 @@ function exactReviewDispatchGlobalRetryDelayMs(
   return Math.min(15 * 60_000, base * 2 ** Math.min(Math.max(0, consecutiveFailures - 1), 5));
 }
 
-async function dispatchExactReviewBatchWorkflow({ token }: { token: string }) {
+async function dispatchExactReviewBatchWorkflow({
+  token,
+  dispatchId,
+  dispatchedAt,
+}: {
+  token: string;
+  dispatchId: string;
+  dispatchedAt: string;
+}) {
   await githubTokenJson({
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/workflows/exact-review-batch-publish.yml/dispatches`,
     method: "POST",
     body: {
       ref: "main",
-      inputs: { execute: "true" },
+      inputs: { execute: "true", dispatch_id: dispatchId, dispatched_at: dispatchedAt },
     },
     errorLabel: "Exact-review batch workflow dispatch",
   });
@@ -10167,6 +10262,244 @@ function exactReviewPublicationBatchJson(batch) {
       terminal_outcome: item.terminalOutcome,
     })),
   };
+}
+
+const RESERVATION_TO_CLAIM_DELAY_BUCKET_MS = 10 * 60_000;
+const RUNNER_HANDOFF_ALERT_MS = 10 * 60_000;
+const STATE_WRITER_ALERT_MS = 20 * 60_000;
+const GITHUB_THROTTLE_ALERT_MS = 15 * 60_000;
+
+function exactReviewReservationClaimObservability({
+  now,
+  dispatcher,
+  publication,
+  batches,
+  maxConcurrentBatches,
+}) {
+  const reservationToClaimDelays = batches.flatMap((batch) =>
+    batch.dispatchedAt === null ? [] : [Math.max(0, batch.createdAt - batch.dispatchedAt)],
+  );
+  const alerts = [];
+  const activeBatches = batches.filter((batch) => batch.state === "leased");
+  const pending = Number(publication?.pending || 0);
+  const activeItems = activeBatches.reduce(
+    (total, batch) => total + batch.items.filter((item) => item.terminalOutcome === null).length,
+    0,
+  );
+  const unassignedPending = Math.max(0, pending - activeItems);
+  if (unassignedPending > 0 && activeBatches.length >= maxConcurrentBatches) {
+    alerts.push({
+      kind: "no_capacity",
+      status: "active",
+      detail:
+        "All configured publication batch slots are leased while durable publication work remains pending.",
+    });
+  }
+  const dispatchAt = Number(dispatcher?.publicationBatchDispatchedAt || 0);
+  const dispatchId = String(dispatcher?.publicationBatchDispatchId || "");
+  const dispatchPendingUntil = Number(dispatcher?.publicationBatchDispatchPendingUntil || 0);
+  // Alert halfway through the actual reservation window. This keeps the alert
+  // actionable for deployments configured below the ten-minute default.
+  const dispatchHandoffAlertMs = Math.max(
+    1_000,
+    Math.floor((dispatchPendingUntil - dispatchAt) / 2),
+  );
+  const dispatchedBatch = dispatchId
+    ? batches.find((batch) => batch.dispatchId === dispatchId)
+    : undefined;
+  if (
+    dispatchAt &&
+    dispatchPendingUntil > now &&
+    !dispatchedBatch &&
+    now - dispatchAt >= dispatchHandoffAlertMs &&
+    dispatcher?.publicationBatchDispatchSucceeded !== false
+  ) {
+    alerts.push({
+      kind: "dispatcher_handoff_stalled",
+      status: "active",
+      dispatch_id: dispatchId || null,
+      since: new Date(dispatchAt).toISOString(),
+      detail:
+        "A batch workflow dispatch has not produced a durable batch claim within the handoff threshold.",
+    });
+  }
+  for (const batch of activeBatches) {
+    if (
+      batch.dispatchedAt !== null &&
+      batch.runnerStartedAt === null &&
+      now - batch.dispatchedAt >= RUNNER_HANDOFF_ALERT_MS
+    ) {
+      alerts.push({
+        kind: "runner_stalled",
+        status: "active",
+        batch_id: batch.batchId,
+        dispatch_id: batch.dispatchId,
+        since: new Date(batch.dispatchedAt).toISOString(),
+        detail:
+          "The workflow was dispatched and the batch was claimed, but no runner-start timestamp was recorded.",
+      });
+    }
+    const stateWriterBlockedAt = batch.stateWriterWaitAt ?? batch.preparationFinishedAt;
+    if (
+      stateWriterBlockedAt !== null &&
+      batch.stateWriterCommittedAt === null &&
+      now - stateWriterBlockedAt >= STATE_WRITER_ALERT_MS
+    ) {
+      alerts.push({
+        kind: "state_writer_stalled",
+        status: "active",
+        batch_id: batch.batchId,
+        since: new Date(stateWriterBlockedAt).toISOString(),
+        detail:
+          "Preparation completed but the state-writer commit timestamp has not arrived within the threshold.",
+      });
+    }
+  }
+  for (const batch of batches) {
+    if (
+      batch.githubThrottleAt !== null &&
+      now - batch.githubThrottleAt < GITHUB_THROTTLE_ALERT_MS
+    ) {
+      alerts.push({
+        kind: "github_throttle",
+        status: "active",
+        batch_id: batch.batchId,
+        since: new Date(batch.githubThrottleAt).toISOString(),
+        detail: "A batch completion reported a GitHub rate-limit outcome.",
+      });
+    }
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date(now).toISOString(),
+    queue_slots: {
+      pending,
+      unassigned_pending: unassignedPending,
+      active_items: activeItems,
+      active_batches: activeBatches.length,
+      max_concurrent_batches: maxConcurrentBatches,
+      available_batches: Math.max(0, maxConcurrentBatches - activeBatches.length),
+    },
+    delay_buckets: exactReviewReservationClaimDelayBuckets(reservationToClaimDelays),
+    alerts,
+    batches: batches.map((batch) => ({
+      batch_id: batch.batchId,
+      state: batch.state,
+      configured_batch_size: batch.configuredBatchSize,
+      claimed_at: new Date(batch.createdAt).toISOString(),
+      batch_age_seconds: Math.max(0, Math.floor((now - batch.createdAt) / 1000)),
+      dispatch: {
+        id: batch.dispatchId,
+        at: exactReviewReservationClaimTimestamp(batch.dispatchedAt),
+      },
+      workflow: {
+        run_id: batch.runnerRunId,
+        run_attempt: batch.runnerRunAttempt,
+        runner_started_at: exactReviewReservationClaimTimestamp(batch.runnerStartedAt),
+      },
+      timeline: {
+        preparation_started_at: exactReviewReservationClaimTimestamp(batch.preparationStartedAt),
+        preparation_finished_at: exactReviewReservationClaimTimestamp(batch.preparationFinishedAt),
+        state_writer_wait_at: exactReviewReservationClaimTimestamp(batch.stateWriterWaitAt),
+        state_writer_committed_at: exactReviewReservationClaimTimestamp(
+          batch.stateWriterCommittedAt,
+        ),
+        final_github_apply_at: exactReviewReservationClaimTimestamp(batch.finalGithubApplyAt),
+        github_throttle_at: exactReviewReservationClaimTimestamp(batch.githubThrottleAt),
+      },
+      items: batch.items.map((item) => ({
+        item_key: item.itemKey,
+        revision: item.revision,
+        claim_generation: item.claimGeneration,
+        producer_run_id: item.producerRunId ?? null,
+        producer_run_attempt: item.producerRunAttempt ?? null,
+        enqueued_at:
+          item.enqueuedAt === undefined
+            ? null
+            : exactReviewReservationClaimTimestamp(item.enqueuedAt),
+        reservation_to_claim_ms:
+          batch.dispatchedAt === null ? null : Math.max(0, batch.createdAt - batch.dispatchedAt),
+        enqueue_to_claim_ms:
+          item.enqueuedAt === undefined ? null : Math.max(0, batch.createdAt - item.enqueuedAt),
+        terminal_outcome: item.terminalOutcome,
+      })),
+    })),
+  };
+}
+
+function exactReviewReservationClaimDelayBuckets(delays) {
+  const buckets = [
+    { id: "under_1m", max_ms: 60_000 },
+    { id: "1m_to_5m", max_ms: 5 * 60_000 },
+    { id: "5m_to_10m", max_ms: RESERVATION_TO_CLAIM_DELAY_BUCKET_MS },
+    { id: "over_10m", max_ms: Number.POSITIVE_INFINITY },
+  ].map((bucket) => ({
+    id: bucket.id,
+    count: delays.filter(
+      (delay) =>
+        delay <= bucket.max_ms &&
+        (bucket.id === "under_1m" || delay > previousReservationClaimBucketMax(bucket.id)),
+    ).length,
+  }));
+  return { metric: "reservation_to_claim_ms", buckets };
+}
+
+function previousReservationClaimBucketMax(id) {
+  if (id === "1m_to_5m") return 60_000;
+  if (id === "5m_to_10m") return 5 * 60_000;
+  return RESERVATION_TO_CLAIM_DELAY_BUCKET_MS;
+}
+
+function exactReviewReservationClaimTimestamp(value) {
+  return value === null || value === undefined ? null : new Date(value).toISOString();
+}
+
+function exactReviewPublicationBatchDispatchMetadata(value) {
+  const id = String(value.dispatch_id || "").trim();
+  const at = exactReviewPublicationBatchTimestamp(value.dispatched_at);
+  if (!id || !at || !/^[A-Za-z0-9:._-]{1,200}$/.test(id)) return null;
+  return { id, at };
+}
+
+function exactReviewPublicationBatchRunnerMetadata(value) {
+  const runId = String(value.runner_run_id || "").trim();
+  const runAttempt = Number(value.runner_run_attempt);
+  const startedAt = exactReviewPublicationBatchTimestamp(value.runner_started_at);
+  if (
+    !/^[0-9]{1,30}$/.test(runId) ||
+    !Number.isSafeInteger(runAttempt) ||
+    runAttempt < 1 ||
+    !startedAt
+  ) {
+    return null;
+  }
+  return { runId, runAttempt, startedAt };
+}
+
+function exactReviewPublicationBatchObservation(
+  value,
+): { stage: PublicationBatchObservationStage; observedAt: number } | null {
+  const stage = String(value.timeline_stage || "");
+  const observedAt = exactReviewPublicationBatchTimestamp(value.observed_at);
+  if (
+    ![
+      "preparation_started",
+      "preparation_finished",
+      "state_writer_wait",
+      "state_writer_committed",
+      "final_github_apply",
+      "github_throttle",
+    ].includes(stage) ||
+    !observedAt
+  ) {
+    return null;
+  }
+  return { stage: stage as PublicationBatchObservationStage, observedAt };
+}
+
+function exactReviewPublicationBatchTimestamp(value) {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function objectValue(value) {

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -38,8 +38,13 @@ type BatchReceipt = {
 };
 
 const command = process.argv[2];
-if (!command || !["claim", "heartbeat", "commit", "complete", "release"].includes(command)) {
-  throw new Error("usage: exact-review-batch-cli.ts <claim|heartbeat|commit|complete|release>");
+if (
+  !command ||
+  !["claim", "heartbeat", "observe", "commit", "complete", "release"].includes(command)
+) {
+  throw new Error(
+    "usage: exact-review-batch-cli.ts <claim|heartbeat|observe|commit|complete|release>",
+  );
 }
 
 const queueSecret = process.env.CLAWSWEEPER_WEBHOOK_SECRET;
@@ -52,6 +57,7 @@ const client = new ExactReviewBatchQueueClient({
 
 if (command === "claim") await claim();
 else if (command === "heartbeat") await heartbeat();
+else if (command === "observe") await observe();
 else if (command === "commit") await commit();
 else if (command === "complete") await complete();
 else await release();
@@ -59,10 +65,14 @@ else await release();
 async function claim() {
   const leaseOwner = env("EXACT_REVIEW_BATCH_LEASE_OWNER");
   const batchId = env("EXACT_REVIEW_BATCH_ID");
+  const dispatch = optionalDispatchTelemetry();
+  const runner = optionalRunnerTelemetry();
   const lease = await client.claim({
     claimId: batchId,
     leaseOwner,
     maxItems: positiveInteger(env("EXACT_REVIEW_BATCH_MAX_ITEMS")),
+    ...(dispatch ? { dispatch } : {}),
+    ...(runner ? { runner } : {}),
   });
   if (!lease) {
     output("claimed", "false");
@@ -108,6 +118,41 @@ async function heartbeat() {
     items: manifest.items,
   });
   console.log(JSON.stringify({ ok: true, batch_id: manifest.batchId }));
+}
+
+async function observe() {
+  const manifest = readManifest();
+  const stage = String(process.env.EXACT_REVIEW_BATCH_OBSERVATION || "").trim();
+  if (
+    !(
+      [
+        "preparation_started",
+        "preparation_finished",
+        "final_github_apply",
+        "github_throttle",
+      ] as string[]
+    ).includes(stage)
+  ) {
+    throw new Error("EXACT_REVIEW_BATCH_OBSERVATION is invalid");
+  }
+  const observedAt = process.env.EXACT_REVIEW_BATCH_OBSERVED_AT?.trim() || new Date().toISOString();
+  if (!Number.isFinite(Date.parse(observedAt))) {
+    throw new Error("EXACT_REVIEW_BATCH_OBSERVED_AT is invalid");
+  }
+  await client.heartbeat({
+    batchId: manifest.batchId,
+    leaseOwner: manifest.leaseOwner,
+    items: manifest.items,
+    observation: {
+      stage: stage as
+        | "preparation_started"
+        | "preparation_finished"
+        | "final_github_apply"
+        | "github_throttle",
+      observedAt,
+    },
+  });
+  console.log(JSON.stringify({ ok: true, batch_id: manifest.batchId, stage }));
 }
 
 async function commit() {
@@ -528,6 +573,35 @@ function env(name: string): string {
   const value = process.env[name]?.trim();
   if (!value) throw new Error(`${name} is required`);
   return value;
+}
+
+function optionalDispatchTelemetry() {
+  const id = process.env.EXACT_REVIEW_BATCH_DISPATCH_ID?.trim();
+  const at = process.env.EXACT_REVIEW_BATCH_DISPATCHED_AT?.trim();
+  if (!id && !at) return undefined;
+  if (!id || !at || !Number.isFinite(Date.parse(at))) {
+    throw new Error("Exact-review batch dispatch telemetry is incomplete");
+  }
+  return { id, at };
+}
+
+function optionalRunnerTelemetry() {
+  const runId = process.env.GITHUB_RUN_ID?.trim();
+  const runAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+  const startedAt = process.env.EXACT_REVIEW_BATCH_RUNNER_STARTED_AT?.trim();
+  // A job that began before the workflow gained this environment value checks
+  // out current main for the CLI. Keep that in-flight job claim-compatible and
+  // leave only its optional runner telemetry absent.
+  if (!startedAt) return undefined;
+  if (
+    !runId ||
+    !Number.isSafeInteger(runAttempt) ||
+    runAttempt < 1 ||
+    !Number.isFinite(Date.parse(startedAt))
+  ) {
+    throw new Error("Exact-review batch runner telemetry is incomplete");
+  }
+  return { runId, runAttempt, startedAt };
 }
 
 function objectValue(value: unknown): Record<string, unknown> {

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -20,6 +20,12 @@ export type ExactReviewBatchClaim = ExactReviewBatchLease & {
   batchWaitMs: number;
 };
 
+export type ExactReviewBatchObservationStage =
+  | "preparation_started"
+  | "preparation_finished"
+  | "final_github_apply"
+  | "github_throttle";
+
 export type ExactReviewBatchFetch = {
   batch: ExactReviewBatchLease;
   items: ExactReviewBatchQueueItem[];
@@ -48,6 +54,8 @@ export interface ExactReviewBatchQueue {
     claimId: string;
     leaseOwner: string;
     maxItems: number;
+    dispatch?: { id: string; at: string };
+    runner?: { runId: string; runAttempt: number; startedAt: string };
   }): Promise<ExactReviewBatchClaim | null>;
   fetch(input: { batchId: string; leaseOwner: string }): Promise<ExactReviewBatchFetch>;
   heartbeat(input: {
@@ -55,6 +63,7 @@ export interface ExactReviewBatchQueue {
     leaseOwner: string;
     items: readonly ExactReviewBatchMember[];
     stateWriterProgress?: StateWriterProgress;
+    observation?: { stage: ExactReviewBatchObservationStage; observedAt: string };
   }): Promise<ExactReviewBatchLease>;
   complete(input: {
     batchId: string;
@@ -85,11 +94,27 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     this.request = options.fetch ?? globalThis.fetch;
   }
 
-  async claim(input: { claimId: string; leaseOwner: string; maxItems: number }) {
+  async claim(input: {
+    claimId: string;
+    leaseOwner: string;
+    maxItems: number;
+    dispatch?: { id: string; at: string };
+    runner?: { runId: string; runAttempt: number; startedAt: string };
+  }) {
     const response = await this.post("claim", {
       claim_id: input.claimId,
       lease_owner: input.leaseOwner,
       max_items: input.maxItems,
+      ...(input.dispatch
+        ? { dispatch_id: input.dispatch.id, dispatched_at: input.dispatch.at }
+        : {}),
+      ...(input.runner
+        ? {
+            runner_run_id: input.runner.runId,
+            runner_run_attempt: input.runner.runAttempt,
+            runner_started_at: input.runner.startedAt,
+          }
+        : {}),
     });
     if (response.claimed !== true) return null;
     const batch = parseLease(response.batch);
@@ -128,6 +153,7 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     leaseOwner: string;
     items: readonly ExactReviewBatchMember[];
     stateWriterProgress?: StateWriterProgress;
+    observation?: { stage: ExactReviewBatchObservationStage; observedAt: string };
   }) {
     const response = await this.post("heartbeat", {
       batch_id: input.batchId,
@@ -138,6 +164,12 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
         claim_generation: item.claimGeneration,
       })),
       ...(input.stateWriterProgress ? { state_writer_progress: input.stateWriterProgress } : {}),
+      ...(input.observation
+        ? {
+            timeline_stage: input.observation.stage,
+            observed_at: input.observation.observedAt,
+          }
+        : {}),
     });
     return parseLease(response.batch);
   }

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1578,6 +1578,7 @@ test("rollout dispatches one full batch workflow without admitting legacy publis
         EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
         EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
         EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "60000",
+        EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS: "60000",
         EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
       },
     );
@@ -1588,12 +1589,42 @@ test("rollout dispatches one full batch workflow without admitting legacy publis
     const alarm = queue.alarm();
     await batchDispatchStarted;
 
-    assert.deepEqual(dispatches, [{ ref: "main", inputs: { execute: "true" } }]);
+    assert.equal(dispatches.length, 1);
+    const [dispatch] = dispatches as Array<{
+      ref: string;
+      inputs: Record<string, string>;
+    }>;
+    assert.equal(dispatch?.ref, "main");
+    assert.equal(dispatch?.inputs.execute, "true");
+    assert.match(String(dispatch?.inputs.dispatch_id), /^publication-batch-dispatch:/);
+    assert.equal(dispatch?.inputs.dispatched_at, "1970-01-01T01:56:40.000Z");
     const dispatchedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
     assert.equal(
       dispatchedStats.lanes.publication.batches.dispatch_pending_until,
-      "1970-01-01T02:06:40.000Z",
+      "1970-01-01T01:57:40.000Z",
     );
+    now += 30_000;
+    const stalledDispatchStats = await (
+      await queue.fetch(new Request("https://queue/stats"))
+    ).json();
+    assert.ok(
+      stalledDispatchStats.reservation_claim_observability.alerts.some(
+        (alert: { kind: string }) => alert.kind === "dispatcher_handoff_stalled",
+      ),
+    );
+    const delayedClaim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-delayed-dispatch",
+          lease_owner: "worker-delayed",
+          max_items: 2,
+          dispatch_id: "publication-batch-dispatch:delayed",
+          dispatched_at: new Date(now - 1_000).toISOString(),
+        }),
+      )
+    ).json();
+    assert.equal(delayedClaim.claimed, false);
+    assert.equal(delayedClaim.preflight_required, true);
     const claimed = await (
       await queue.fetch(
         batchRequest("/publication-batches/claim", {
@@ -1616,7 +1647,7 @@ test("rollout dispatches one full batch workflow without admitting legacy publis
     assert.equal(stats.lanes.publication.batches.last_dispatch_succeeded, true);
     assert.equal(stats.lanes.publication.batches.dispatch_pending_until, null);
     assert.equal(regularDispatches.length, 1);
-    assert.equal(storage.scheduledAlarm(), 7_001_000);
+    assert.equal(storage.scheduledAlarm(), 7_031_000);
 
     await queue.alarm();
     assert.equal(dispatches.length, 1);
@@ -1640,10 +1671,11 @@ test("rollout dispatches one full batch workflow without admitting legacy publis
 
     now = 8_060_000;
     await partialQueue.alarm();
-    assert.deepEqual(dispatches[1], {
-      ref: "main",
-      inputs: { execute: "true" },
-    });
+    const secondDispatch = dispatches[1] as { ref: string; inputs: Record<string, string> };
+    assert.equal(secondDispatch.ref, "main");
+    assert.equal(secondDispatch.inputs.execute, "true");
+    assert.match(secondDispatch.inputs.dispatch_id, /^publication-batch-dispatch:/);
+    assert.equal(secondDispatch.inputs.dispatched_at, "1970-01-01T02:14:20.000Z");
     assert.equal(partialStorage.scheduledAlarm(), 8_660_000);
 
     const multiOwnerStorage = new TestStorage();
@@ -1834,6 +1866,231 @@ test("batch protocol routes require the shared internal signature", async () => 
   );
   assert.equal(authorized.status, 200);
   assert.equal(forwardedPath, "/publication-batches/claim");
+});
+
+test("publication batch observability always retains active leases beside bounded history", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  const active = batches.claim({
+    batchId: "active-observability",
+    leaseOwner: "worker-active",
+    leaseExpiresAt: 10_000,
+    now: 1_000,
+    maxItems: 1,
+    maxConcurrentBatches: 2,
+    candidates: [candidates[0]!],
+  });
+  const historical = batches.claim({
+    batchId: "historical-observability",
+    leaseOwner: "worker-history",
+    leaseExpiresAt: 10_000,
+    now: 2_000,
+    maxItems: 1,
+    maxConcurrentBatches: 2,
+    candidates: [candidates[1]!],
+  });
+  assert.ok(active);
+  assert.ok(historical);
+  batches.complete(
+    historical.batchId,
+    historical.leaseOwner,
+    historical.items.map((item) => ({ ...item, terminalOutcome: "published" as const })),
+    3_000,
+  );
+
+  const sample = batches.observability(3_001, 1).batches;
+  assert.deepEqual(
+    sample.map((batch) => batch.batchId),
+    ["active-observability", "historical-observability"],
+  );
+});
+
+test("publication batch observability retains the most recently completed terminal history", () => {
+  const storage = new TestStorage();
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  const slow = batches.claim({
+    batchId: "slow-terminal-observability",
+    leaseOwner: "worker-slow",
+    leaseExpiresAt: 10_000,
+    now: 1_000,
+    maxItems: 1,
+    candidates: [candidates[0]!],
+  });
+  const newer = batches.claim({
+    batchId: "newer-terminal-observability",
+    leaseOwner: "worker-newer",
+    leaseExpiresAt: 10_000,
+    now: 2_000,
+    maxItems: 1,
+    maxConcurrentBatches: 2,
+    candidates: [candidates[1]!],
+  });
+  assert.ok(slow);
+  assert.ok(newer);
+  batches.complete(
+    newer.batchId,
+    newer.leaseOwner,
+    newer.items.map((item) => ({ ...item, terminalOutcome: "published" as const })),
+    2_500,
+  );
+  batches.complete(
+    slow.batchId,
+    slow.leaseOwner,
+    slow.items.map((item) => ({ ...item, terminalOutcome: "published" as const })),
+    3_000,
+  );
+
+  assert.deepEqual(
+    batches.observability(3_001, 1).batches.map((batch) => batch.batchId),
+    ["slow-terminal-observability"],
+  );
+});
+
+test("reservation-to-claim observability traces one batch without exposing lease credentials", async () => {
+  const originalNow = Date.now;
+  let now = 18_000_000;
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    await queue.fetch(publicationRequest("reservation-claim-trace", 729, "2729"));
+    now += 2_000;
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "trace-batch-729",
+          lease_owner: "worker-secret-not-public",
+          max_items: 1,
+          dispatch_id: "publication-batch-dispatch:trace-729",
+          dispatched_at: new Date(now - 1_000).toISOString(),
+          runner_run_id: "92729",
+          runner_run_attempt: 3,
+          runner_started_at: new Date(now - 500).toISOString(),
+        }),
+      )
+    ).json();
+    const member = claim.batch.items[0];
+    const claimedStats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(claimedStats.reservation_claim_observability.queue_slots.active_items, 1);
+    assert.equal(claimedStats.reservation_claim_observability.queue_slots.unassigned_pending, 0);
+    assert.ok(
+      !claimedStats.reservation_claim_observability.alerts.some(
+        (alert: { kind: string }) => alert.kind === "no_capacity",
+      ),
+    );
+    const heartbeat = (
+      timelineStage: string,
+      observedAt: number,
+      progress?: Record<string, unknown>,
+    ) =>
+      batchRequest("/publication-batches/heartbeat", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-secret-not-public",
+        items: [member],
+        ...(progress ? { state_writer_progress: progress } : {}),
+        ...(timelineStage
+          ? { timeline_stage: timelineStage, observed_at: new Date(observedAt).toISOString() }
+          : {}),
+      });
+    now += 500;
+    assert.equal((await queue.fetch(heartbeat("preparation_started", now))).status, 200);
+    now += 500;
+    assert.equal((await queue.fetch(heartbeat("preparation_finished", now))).status, 200);
+    now += 500;
+    assert.equal(
+      (
+        await queue.fetch(
+          heartbeat("", now, {
+            schema_version: 1,
+            operation_id: `batch:${claim.batch.batch_id}`,
+            mode: "batch",
+            phase: "waiting",
+            sequence: 1,
+            observed_at: new Date(now).toISOString(),
+            configured_batch_size: 1,
+            actual_batch_size: 1,
+          }),
+        )
+      ).status,
+      200,
+    );
+    now += 500;
+    assert.equal((await queue.fetch(heartbeat("final_github_apply", now))).status, 200);
+    now += 500;
+    assert.equal((await queue.fetch(heartbeat("github_throttle", now))).status, 200);
+    now += 500;
+    const completed = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-secret-not-public",
+          state_commit_sha: "a".repeat(40),
+          state_writer: {
+            schema_version: 1,
+            operation_id: `batch:${claim.batch.batch_id}`,
+            mode: "batch",
+            started_at: new Date(now - 1_000).toISOString(),
+            finished_at: new Date(now).toISOString(),
+            wait_ms: 500,
+            acquire_attempts: 1,
+            acquired: true,
+            hold_ms: 500,
+            renewals: 0,
+            released: true,
+            git_duration_ms: 1_000,
+            git_processes: 1,
+            commit_count: 1,
+            materialized_items: 1,
+            configured_batch_size: 1,
+            actual_batch_size: 1,
+            batch_wait_ms: 0,
+            outcome: "materialized",
+          },
+          items: [
+            {
+              item_key: member.item_key,
+              revision: member.revision,
+              claim_generation: member.claim_generation,
+              terminal_outcome: "published",
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(completed.accepted, 1, JSON.stringify(completed));
+
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    const observability = stats.reservation_claim_observability;
+    const batch = observability.batches.find(
+      (entry: { batch_id: string }) => entry.batch_id === claim.batch.batch_id,
+    );
+    assert.ok(batch, JSON.stringify(observability));
+    assert.equal(batch.dispatch.id, "publication-batch-dispatch:trace-729");
+    assert.equal(batch.workflow.run_id, "92729");
+    assert.equal(batch.workflow.run_attempt, 3);
+    assert.ok(batch.workflow.runner_started_at);
+    assert.ok(batch.timeline.preparation_started_at);
+    assert.ok(batch.timeline.preparation_finished_at);
+    assert.ok(batch.timeline.state_writer_wait_at);
+    assert.ok(batch.timeline.state_writer_committed_at);
+    assert.ok(batch.timeline.final_github_apply_at);
+    assert.ok(batch.timeline.github_throttle_at);
+    assert.equal(batch.items[0].producer_run_id, "2729");
+    assert.equal(batch.items[0].reservation_to_claim_ms, 1_000);
+    assert.equal(batch.items[0].enqueue_to_claim_ms, 2_000);
+    assert.equal(observability.delay_buckets.metric, "reservation_to_claim_ms");
+    assert.ok(
+      observability.alerts.some((alert: { kind: string }) => alert.kind === "github_throttle"),
+    );
+    assert.match(JSON.stringify(observability), /publication-batch-dispatch:trace-729/);
+    assert.doesNotMatch(JSON.stringify(observability), /worker-secret-not-public/);
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("authenticated publication reconciliation dry-run reports without mutation", async () => {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1868,6 +1868,29 @@ test("batch protocol routes require the shared internal signature", async () => 
   assert.equal(forwardedPath, "/publication-batches/claim");
 });
 
+test("batch claims reject partial dispatch metadata", async () => {
+  const queue = new ExactReviewQueue(
+    { storage: new TestStorage() },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+  );
+  for (const body of [
+    {
+      claim_id: "partial-dispatch-id",
+      lease_owner: "worker-partial",
+      dispatch_id: "publication-batch-dispatch:partial",
+    },
+    {
+      claim_id: "partial-dispatch-time",
+      lease_owner: "worker-partial",
+      dispatched_at: "2026-07-26T08:00:00.000Z",
+    },
+  ]) {
+    const response = await queue.fetch(batchRequest("/publication-batches/claim", body));
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).error, "invalid_batch_dispatch_metadata");
+  }
+});
+
 test("publication batch observability always retains active leases beside bounded history", () => {
   const storage = new TestStorage();
   const batches = new ExactReviewPublicationBatchStore(storage);
@@ -2029,6 +2052,7 @@ test("reservation-to-claim observability traces one batch without exposing lease
           batch_id: claim.batch.batch_id,
           lease_owner: "worker-secret-not-public",
           state_commit_sha: "a".repeat(40),
+          failure_fingerprint: "failure-body-secret-not-public",
           state_writer: {
             schema_version: 1,
             operation_id: `batch:${claim.batch.batch_id}`,
@@ -2065,10 +2089,23 @@ test("reservation-to-claim observability traces one batch without exposing lease
 
     const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
     const observability = stats.reservation_claim_observability;
+    assert.deepEqual(observability.publication_paths, {
+      cloudflare_canonical_direct: {
+        enabled: true,
+        reservation_to_claim: "not_applicable",
+        state_writer_timing: "not_applicable",
+      },
+      legacy_state_repo_batch: {
+        enabled: true,
+        reservation_to_claim: "tracked",
+        state_writer_timing: "tracked",
+      },
+    });
     const batch = observability.batches.find(
       (entry: { batch_id: string }) => entry.batch_id === claim.batch.batch_id,
     );
     assert.ok(batch, JSON.stringify(observability));
+    assert.equal(batch.publication_path, "legacy_state_repo_batch");
     assert.equal(batch.dispatch.id, "publication-batch-dispatch:trace-729");
     assert.equal(batch.workflow.run_id, "92729");
     assert.equal(batch.workflow.run_attempt, 3);
@@ -2088,6 +2125,7 @@ test("reservation-to-claim observability traces one batch without exposing lease
     );
     assert.match(JSON.stringify(observability), /publication-batch-dispatch:trace-729/);
     assert.doesNotMatch(JSON.stringify(observability), /worker-secret-not-public/);
+    assert.doesNotMatch(JSON.stringify(observability), /failure-body-secret-not-public/);
   } finally {
     Date.now = originalNow;
   }

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -31,7 +31,11 @@ test("batch publisher is event-driven and queue-bounded instead of workflow-seri
   assert.equal(workflow.on.schedule, undefined);
   assert.ok(workflow.on.workflow_dispatch);
   assert.match(workflow.jobs.publish!.if, /inputs\.execute/);
-  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["execute"]);
+  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), [
+    "execute",
+    "dispatch_id",
+    "dispatched_at",
+  ]);
   assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_MAX_ITEMS, "50");
   assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY, "4");
   assert.equal(workflow.jobs.publish!.env.CLAWSWEEPER_APP_CLIENT_ID, "Iv23liOECG0slfuhz093");
@@ -70,6 +74,17 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
   assert.match(source, /deferredCloseCoverageExpected == true/);
   assert.match(source, /scheduled proof lane/);
   assert.match(source, /jq '\.postEffectsComplete = true'/);
+  assert.match(source, /Capture runner start timestamp/);
+  assert.match(source, /EXACT_REVIEW_BATCH_DISPATCH_ID/);
+  assert.match(source, /Record batch preparation start/);
+  assert.match(source, /Record batch preparation finish/);
+  assert.match(source, /EXACT_REVIEW_BATCH_OBSERVATION=final_github_apply/);
+  assert.match(source, /EXACT_REVIEW_BATCH_OBSERVATION=github_throttle/);
+  assert.match(source, /rate limit\|HTTP 429/);
+  assert.match(cliSource, /"observe"/);
+  assert.match(cliSource, /optionalDispatchTelemetry/);
+  assert.match(cliSource, /optionalRunnerTelemetry/);
+  assert.match(cliSource, /if \(!startedAt\) return undefined;/);
 });
 
 test("exact-review producer uses direct publication with bounded legacy fallback", () => {


### PR DESCRIPTION
## Summary

Adds `reservation_claim_observability` to exact-review queue stats, tracing a legacy publication batch from durable dispatcher reservation through claim, preparation, state-writer work, and final GitHub apply. The response now explicitly distinguishes that legacy state-repository batch timing from the Cloudflare-canonical direct-publication path introduced by #859/#866/#867.

## Problem

Operators could not determine whether a legacy publication delay occurred before capacity, during dispatcher-to-runner handoff, on a runner, at the state writer, or at GitHub. The original surface also made it too easy to read those batch-only timings as applying to direct canonical publication.

## Implementation

- Adds additive SQLite telemetry for dispatcher reservation, batch claim, runner, preparation, state-writer, final GitHub apply, and GitHub-throttle timestamps and stable identifiers.
- Exposes scrubbed queue slots, batch age, reservation-to-claim delay buckets, and distinct no-capacity, dispatcher/handoff, runner, state-writer, and GitHub-throttle alerts.
- Labels every observed batch as `legacy_state_repo_batch`; `publication_paths.cloudflare_canonical_direct` is explicitly `not_applicable` for reservation-to-claim and state-writer timing, while a direct-publication fallback enters the legacy batch path.
- Rejects partially supplied dispatch metadata so a claim cannot bypass the reservation/dispatch-ID correlation fence.
- Never returns payloads, credentials, lease owners, or batch failure fingerprints from the observability response.

## Compatibility

The current direct Cloudflare-canonical producer completes before a legacy publication batch is created. This PR does not change that producer, its bounded fallback, capacity, admission, retries, state-writer behavior, or GitHub writes. It only makes the two paths unambiguous to operators:

| Path | Reservation-to-claim / state-writer timing |
| --- | --- |
| `cloudflare_canonical_direct` | `not_applicable`; canonical Durable Object publication bypasses the legacy batch. |
| `legacy_state_repo_batch` | `tracked`; this is the existing batch/fallback path. |

The extra response fields are additive. Existing metadata-free legacy workflow claims remain accepted; claims that opt into dispatch telemetry must supply both dispatch ID and UTC dispatch time.

## Validation

- `pnpm run build:all`
- `node --test test/exact-review-publication-batches.test.ts test/repair/exact-review-batch-coordinator.test.ts` — 61 passing
- `node --test test/repair/exact-review-batch-workflow.test.ts` with Git Bash on Windows — 10 passing, including workflow Bash syntax and the direct-publication/fallback source contract
- `git diff --check`
- `pnpm run lint:dashboard` and `pnpm run lint:repair`

The repository-wide formatter baseline still reports unrelated formatting differences; no formatter rewrite was made. `actionlint` is not installed on this runner.

## Runtime and migration proof

The focused `ExactReviewQueue` Durable Object runtime test creates and completes one redacted batch trace with a fixed UTC clock. It proves the public stats response contains:

- dispatch ID/time, workflow run ID/attempt/runner-start time;
- preparation start/end, state-writer wait/commit, final GitHub-apply, and GitHub-throttle UTC times;
- item/run/claim identifiers and both reservation-to-claim and enqueue-to-claim durations;
- `legacy_state_repo_batch` for the batch, plus the explicit direct-versus-legacy path contract above.

It also verifies that the public response excludes `worker-secret-not-public` and a persisted `failure-body-secret-not-public` fixture. The same suite covers migration of a pre-deployment direct-publication plan to the canonical store and preservation of legacy queue receipts while adding batch tables.

This is local Durable Object/SQLite runtime proof, not a production dispatch. No live exact-review run, Action dispatch, or E2E activity was initiated because this task prohibits those operations. A redacted deployed dispatcher-to-stats capture remains the only unfulfilled ClawSweeper rank-up artifact.

## Local Crabbox proof (not deployed)

On 2026-07-26, the PR head `e8e526a1336057c6bff8217135ce9773917edf47` passed an isolated Docker-backed Crabbox run (`provider=local-container`, lease `cbx_ae7f17d0f5c9`, Playwright v1.60.0-noble). Wrangler/Miniflare hosted the worker and its Durable Object locally; the harness then signed an enqueue, claimed the resulting legacy batch, recorded each handoff stage, completed it, and fetched the public stats endpoint.

The captured, public-safe trace was:

```text
publication paths:
  cloudflare_canonical_direct: reservation_to_claim=not_applicable, state_writer_timing=not_applicable
  legacy_state_repo_batch: reservation_to_claim=tracked, state_writer_timing=tracked
batch: csw-858-local-container-batch (legacy_state_repo_batch)
dispatch: publication-batch-dispatch:csw-858-local-container at 2026-07-26T11:46:43.790Z
workflow: run 92729, attempt 1, runner started 2026-07-26T11:46:44.790Z
enqueue: 2026-07-26T11:46:45.799Z; reservation-to-claim: 2026 ms; enqueue-to-claim: 17 ms
stages: preparation start/end 2026-07-26T11:46:45.826Z/2026-07-26T11:46:45.837Z;
        state-writer wait/commit 2026-07-26T11:46:45.846Z/2026-07-26T11:46:45.875Z;
        final-GitHub-apply/GitHub-throttle 2026-07-26T11:46:45.856Z/2026-07-26T11:46:45.864Z
public-redaction checks: lease owner absent; failure body absent
```

This verifies the local HTTP-to-worker-to-Durable-Object observability contract, including direct-versus-legacy classification and public redaction. The two final stage timestamps are local telemetry markers only: this run performed no Cloudflare deployment, GitHub Actions dispatch, or GitHub write. The latest ClawSweeper review accepts this as sufficient contributor runtime proof; a deployed dispatcher-to-stats capture is now a maintainer-controlled rollout decision and optional rank-up artifact, not a contributor-facing proof defect.

## Supersession assessment

### Current ClawSweeper disposition

The durable ClawSweeper review at `2026-07-26T12:28:51.002Z` supersedes the prior 12:18 revision. It marks `proof: sufficient` and `status: 👀 ready for maintainer look`, while retaining P3 / `gold shrimp`: no code or security finding was identified; the local Crabbox trace is accepted as sufficient contributor runtime evidence; and this PR should remain open for maintainer review because it instruments a distinct retained fallback path rather than duplicating #859.

The remaining decisions are maintainer-owned rollout decisions, not a contributor-facing proof failure: whether to retain the persisted/public legacy-fallback observability contract; whether to require or waive one controlled, redacted deployed dispatcher-to-stats capture before merge; and acceptance of the additive Durable Object migration/public queue-stat compatibility contract. Any deployed evidence must redact endpoints, IP addresses, credentials, lease owners, and failure bodies.

**#859 is a prerequisite, not a technical replacement for this PR.** It merged the Cloudflare-canonical direct-publication path and deliberately retained the bounded legacy state-repository batch fallback. This PR observes that remaining fallback without changing its behavior; the direct path is explicitly marked `not_applicable` for batch-only timing.

Current `origin/main` at `4f1d7d6caa42c7c559301b970116b02cb98aa8c4` still has none of this PR's `reservation_claim_observability`, durable dispatcher reservation correlation, workflow stage timestamps, public delay buckets, or stall alerts. The seven-file / 1,016-line PR diff therefore remains additive and unmerged rather than duplicated by #859.

**Maintainer decision required:**

1. Retain this legacy-fallback telemetry scope: approve the additive public-contract/schema risk and authorize one controlled, redacted deployed legacy-fallback dispatcher-to-stats capture; or explicitly waive that deployment-evidence requirement.
2. Decline the telemetry scope because legacy-fallback observability is no longer wanted. In that case the PR may be closed as intentionally not pursued, but not as technically superseded by #859.

Until that decision, preserve this PR open. No deployed capture, queue replay, workflow dispatch, or behavioral change has been made from this branch.

## Codex review

- Dirty review: `codex review --uncommitted` — final clean result: no accepted/actionable findings.
- Branch review: `codex review --base origin/main` — final clean result: no actionable correctness issues.
- Accepted branch-review finding: a claim with only `dispatch_id` or only `dispatched_at` could bypass the correlation fence. The queue now rejects either partial form, with two-sided focused coverage.
- Rejected findings: none. The prior ClawSweeper review raised proof/readiness requirements rather than a code defect; this body adds the available local runtime, migration, and redaction evidence without overstating it as live proof.

## Risks / rollout

- Additive Durable Object schema and public response fields only; no payloads, secrets, lease owners, or error bodies are exposed by the observability surface.
- This remains telemetry-only. It does not modify scheduling, capacity, publisher admission, retries, state-writer semantics, direct Cloudflare publication, or GitHub-write behavior.
- The changed batch workflow still requires the repository's existing GitHub OAuth/workflow permission. If that scope is unavailable, a maintainer-owned replacement branch may be needed.
- Remaining maintainer rollout decision: accept the additive public contract and choose whether to authorize or waive a redacted deployed handoff capture. No merge or automerge is requested.

## Related

- Rebased onto current `main` after merged #855, #859, #863, #866, and #867.
- Collision checked against CSW-053 / `agent/add-apply-observability-lag` and `agent/record-batching-rollout-status`; this PR stays on the disjoint exact-review queue observability surface.
