### PR TITLE
feat(runner): add built-in Cerebras provider and widen the provider-key allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- The OpenClaw runner ships a built-in Cerebras provider: `CLAWSWEEPER_OPENCLAW_MODEL=cerebras/zai-glm-4.7` needs only `CEREBRAS_API_KEY` (validated live at ~474 tok/s on Cerebras Code Max); provider-key allowlist extended for Cerebras, Z.AI, DeepSeek, and Mistral.
 - Redesigned PR review comments into a scan-first layout: outcome and merge readiness up top, ratings and verification as compact tables, before-merge work as native checklists, evidence folded into details — with hardened fence-aware section parsing and Mermaid sanitization. Thanks @Patrick-Erichsen! (#776)
 - Screenshot-only real-behavior proof (PNG/JPEG/WebP/GIF) is now hydrated through the bounded media path so sandboxed reviewers can assess it instead of marking it insufficient. Thanks @goutamadwant! (#595)
 - The repair owner policy (`CLAWSWEEPER_ALLOWED_OWNER`) accepts a multi-owner list enforced identically at intake and every execution gate; disallowed owners are rejected before a durable job is written. (#809)

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -250,7 +250,13 @@ otherwise ClawSweeper runs `openclaw` from `PATH`.
 Providers that are not bundled with OpenClaw can be supplied through
 `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`, a JSON object merged into
 `models.providers`; referenced provider API-key environment variables must also
-be present. ClawSweeper gives OpenClaw a fresh state directory, a coding tool
+be present. Two providers ship as built-in defaults and need only their API key
+in the environment: `kimi/…` (Kimi Code endpoint, `KIMI_API_KEY`; models
+`kimi-for-coding` and `k3`) and `cerebras/…` (Cerebras Code plans,
+`CEREBRAS_API_KEY`; model `zai-glm-4.7` until Cerebras retires it on
+2026-08-17). The subprocess environment is deny-by-default: only the base OS
+surface, `OPENCLAW_*` controls, proxy settings, and known provider API keys
+reach the agent. ClawSweeper gives OpenClaw a fresh state directory, a coding tool
 profile limited to the target workspace, and the lane's existing timeout and
 reasoning effort. OpenClaw can exit zero for terminal agent failures, so the
 wrapper inspects its JSON envelope for agent errors, aborts, timeouts, exhausted

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -300,6 +300,10 @@ const OPENCLAW_CHILD_ENV_ALLOWLIST = [
   "KIMI_API_KEY",
   "KIMICODE_API_KEY",
   "MOONSHOT_API_KEY",
+  "CEREBRAS_API_KEY",
+  "ZAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "MISTRAL_API_KEY",
 ] as const;
 
 function pickEnv(env: NodeJS.ProcessEnv, names: readonly string[]): NodeJS.ProcessEnv {
@@ -320,7 +324,7 @@ function pickEnv(env: NodeJS.ProcessEnv, names: readonly string[]): NodeJS.Proce
 // Verified 2026-07-25: kimi-for-coding needs maxTokens above the runtime
 // default or reasoning-heavy turns die on the output cap; k3 limits are from
 // the Kimi Code catalog (1M context, 131072 max output).
-const KIMI_BUILTIN_PROVIDER = {
+const BUILTIN_PROVIDERS = {
   kimi: {
     baseUrl: "https://api.kimi.com/coding/",
     apiKey: "${KIMI_API_KEY}",
@@ -330,12 +334,23 @@ const KIMI_BUILTIN_PROVIDER = {
       { id: "k3", name: "Kimi K3", contextWindow: 1048576, maxTokens: 131072 },
     ],
   },
+  // Cerebras Code plans serve the GLM coding model at ~1000 tok/s; validated
+  // live 2026-07-25 (474 tok/s wall including network, E2E tool run in 5s).
+  // zai-glm-4.7 deprecates 2026-08-17 — update the id when Cerebras swaps in
+  // its successor.
+  cerebras: {
+    baseUrl: "https://api.cerebras.ai/v1",
+    apiKey: "${CEREBRAS_API_KEY}",
+    api: "openai-completions",
+    models: [{ id: "zai-glm-4.7", name: "Z.ai GLM 4.7", contextWindow: 128000, maxTokens: 8192 }],
+  },
 } as const;
 
 function builtinProviderBlock(model: string): Record<string, unknown> | undefined {
-  const provider = model.split("/", 1)[0];
-  if (provider !== "kimi") return undefined;
-  return structuredClone(KIMI_BUILTIN_PROVIDER) as unknown as Record<string, unknown>;
+  const provider = model.split("/", 1)[0] as keyof typeof BUILTIN_PROVIDERS;
+  const block = BUILTIN_PROVIDERS[provider];
+  if (!block) return undefined;
+  return structuredClone({ [provider]: block }) as unknown as Record<string, unknown>;
 }
 
 function boundedStderrDetail(stderr: string): string {

--- a/test/openclaw-process.test.ts
+++ b/test/openclaw-process.test.ts
@@ -362,3 +362,41 @@ test("OpenClaw subprocess env strips workflow credentials and keeps provider key
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("OpenClaw cerebras models get built-in provider defaults", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-test-"));
+  const recordPath = join(root, "record.json");
+  const binary = fakeOpenclaw(root);
+  try {
+    const result = runOpenclawProcess({
+      label: "cerebras-defaults",
+      prompt: "hi",
+      model: "cerebras/zai-glm-4.7",
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAWSWEEPER_OPENCLAW_BIN: binary,
+        CLAWSWEEPER_OPENCLAW_MODEL: "cerebras/zai-glm-4.7",
+        OPENCLAW_TEST_RECORD: recordPath,
+      },
+      timeoutMs: 60_000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const record = JSON.parse(readFileSync(recordPath, "utf8"));
+    assert.deepEqual(record.config.models, {
+      mode: "merge",
+      providers: {
+        cerebras: {
+          baseUrl: "https://api.cerebras.ai/v1",
+          apiKey: "${CEREBRAS_API_KEY}",
+          api: "openai-completions",
+          models: [
+            { id: "zai-glm-4.7", name: "Z.ai GLM 4.7", contextWindow: 128000, maxTokens: 8192 },
+          ],
+        },
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add Cerebras as a built-in OpenClaw provider using Cerebras Code Max
- allow CEREBRAS_API_KEY through the runner provider-key allowlist
- document the provider path and cover built-in configuration in the focused runner tests

## Validation

- existing focused OpenClaw suite: 120/120 passing
- live Cerebras Code Max validation: 474 tok/s wall, 5s end to end

## Context

The provider-key allowlist previously stripped CEREBRAS_API_KEY, causing a 401. The configured zai-glm-4.7 model deprecates on 2026-08-17.

