### PR TITLE
feat(runner): add built-in Z.AI GLM-5.2 Coding Plan provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- The OpenClaw runner ships a built-in Z.AI provider: `CLAWSWEEPER_OPENCLAW_MODEL=zai/glm-5.2` runs GLM-5.2 on the GLM Coding Plan endpoint with only `ZAI_API_KEY` (validated live end to end).
 - The OpenClaw runner ships a built-in Cerebras provider: `CLAWSWEEPER_OPENCLAW_MODEL=cerebras/zai-glm-4.7` needs only `CEREBRAS_API_KEY` (validated live at ~474 tok/s on Cerebras Code Max); provider-key allowlist extended for Cerebras, Z.AI, DeepSeek, and Mistral.
 - Redesigned PR review comments into a scan-first layout: outcome and merge readiness up top, ratings and verification as compact tables, before-merge work as native checklists, evidence folded into details — with hardened fence-aware section parsing and Mermaid sanitization. Thanks @Patrick-Erichsen! (#776)
 - Screenshot-only real-behavior proof (PNG/JPEG/WebP/GIF) is now hydrated through the bounded media path so sandboxed reviewers can assess it instead of marking it insufficient. Thanks @goutamadwant! (#595)

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -250,11 +250,12 @@ otherwise ClawSweeper runs `openclaw` from `PATH`.
 Providers that are not bundled with OpenClaw can be supplied through
 `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`, a JSON object merged into
 `models.providers`; referenced provider API-key environment variables must also
-be present. Two providers ship as built-in defaults and need only their API key
+be present. Three providers ship as built-in defaults and need only their API key
 in the environment: `kimi/…` (Kimi Code endpoint, `KIMI_API_KEY`; models
-`kimi-for-coding` and `k3`) and `cerebras/…` (Cerebras Code plans,
+`kimi-for-coding` and `k3`), `cerebras/…` (Cerebras Code plans,
 `CEREBRAS_API_KEY`; model `zai-glm-4.7` until Cerebras retires it on
-2026-08-17). The subprocess environment is deny-by-default: only the base OS
+2026-08-17), and `zai/…` (Z.AI GLM Coding Plan endpoint, `ZAI_API_KEY`;
+model `glm-5.2` — plan keys only work on the coding endpoint). The subprocess environment is deny-by-default: only the base OS
 surface, `OPENCLAW_*` controls, proxy settings, and known provider API keys
 reach the agent. ClawSweeper gives OpenClaw a fresh state directory, a coding tool
 profile limited to the target workspace, and the lane's existing timeout and

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -344,6 +344,15 @@ const BUILTIN_PROVIDERS = {
     api: "openai-completions",
     models: [{ id: "zai-glm-4.7", name: "Z.ai GLM 4.7", contextWindow: 128000, maxTokens: 8192 }],
   },
+  // Z.AI GLM Coding Plan keys only authorize the coding endpoint — the general
+  // paas endpoint rejects them with error 1113. Validated live 2026-07-25
+  // (~51 tok/s, E2E tool run in 16s).
+  zai: {
+    baseUrl: "https://api.z.ai/api/coding/paas/v4",
+    apiKey: "${ZAI_API_KEY}",
+    api: "openai-completions",
+    models: [{ id: "glm-5.2", name: "GLM-5.2", contextWindow: 1000000, maxTokens: 131072 }],
+  },
 } as const;
 
 function builtinProviderBlock(model: string): Record<string, unknown> | undefined {

--- a/test/openclaw-process.test.ts
+++ b/test/openclaw-process.test.ts
@@ -400,3 +400,39 @@ test("OpenClaw cerebras models get built-in provider defaults", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("OpenClaw zai models get built-in Coding Plan endpoint defaults", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-test-"));
+  const recordPath = join(root, "record.json");
+  const binary = fakeOpenclaw(root);
+  try {
+    const result = runOpenclawProcess({
+      label: "zai-defaults",
+      prompt: "hi",
+      model: "zai/glm-5.2",
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAWSWEEPER_OPENCLAW_BIN: binary,
+        CLAWSWEEPER_OPENCLAW_MODEL: "zai/glm-5.2",
+        OPENCLAW_TEST_RECORD: recordPath,
+      },
+      timeoutMs: 60_000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const record = JSON.parse(readFileSync(recordPath, "utf8"));
+    assert.deepEqual(record.config.models, {
+      mode: "merge",
+      providers: {
+        zai: {
+          baseUrl: "https://api.z.ai/api/coding/paas/v4",
+          apiKey: "${ZAI_API_KEY}",
+          api: "openai-completions",
+          models: [{ id: "glm-5.2", name: "GLM-5.2", contextWindow: 1000000, maxTokens: 131072 }],
+        },
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add Z.AI GLM-5.2 Coding Plan as a built-in OpenClaw provider
- document the coding-endpoint requirement and provider configuration
- cover built-in provider selection in the OpenClaw process tests

## Validation

- OpenClaw suite: 121/121
- AutoReview: CLEAN (0.99); TruffleHog clean
- Live validation on 2026-07-25: approximately 51 tok/s; end-to-end tool run completed in 16 seconds

Coding Plan keys authorize only the coding endpoint. The general PaaS endpoint returns error 1113.
