### PR TITLE
chore(runner): drop the built-in Cerebras GLM-4.7 provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Added
 
 - The OpenClaw runner ships a built-in Z.AI provider: `CLAWSWEEPER_OPENCLAW_MODEL=zai/glm-5.2` runs GLM-5.2 on the GLM Coding Plan endpoint with only `ZAI_API_KEY` (validated live end to end).
-- The OpenClaw runner ships a built-in Cerebras provider: `CLAWSWEEPER_OPENCLAW_MODEL=cerebras/zai-glm-4.7` needs only `CEREBRAS_API_KEY` (validated live at ~474 tok/s on Cerebras Code Max); provider-key allowlist extended for Cerebras, Z.AI, DeepSeek, and Mistral.
+- The OpenClaw runner's subprocess provider-key allowlist covers Cerebras, Z.AI, DeepSeek, and Mistral keys for `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON` providers. (A briefly built-in Cerebras GLM-4.7 default was removed before release; use providers JSON for Cerebras.)
 - Redesigned PR review comments into a scan-first layout: outcome and merge readiness up top, ratings and verification as compact tables, before-merge work as native checklists, evidence folded into details — with hardened fence-aware section parsing and Mermaid sanitization. Thanks @Patrick-Erichsen! (#776)
 - Screenshot-only real-behavior proof (PNG/JPEG/WebP/GIF) is now hydrated through the bounded media path so sandboxed reviewers can assess it instead of marking it insufficient. Thanks @goutamadwant! (#595)
 - The repair owner policy (`CLAWSWEEPER_ALLOWED_OWNER`) accepts a multi-owner list enforced identically at intake and every execution gate; disallowed owners are rejected before a durable job is written. (#809)

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -250,12 +250,12 @@ otherwise ClawSweeper runs `openclaw` from `PATH`.
 Providers that are not bundled with OpenClaw can be supplied through
 `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`, a JSON object merged into
 `models.providers`; referenced provider API-key environment variables must also
-be present. Three providers ship as built-in defaults and need only their API key
+be present. Two providers ship as built-in defaults and need only their API key
 in the environment: `kimi/…` (Kimi Code endpoint, `KIMI_API_KEY`; models
-`kimi-for-coding` and `k3`), `cerebras/…` (Cerebras Code plans,
-`CEREBRAS_API_KEY`; model `zai-glm-4.7` until Cerebras retires it on
-2026-08-17), and `zai/…` (Z.AI GLM Coding Plan endpoint, `ZAI_API_KEY`;
-model `glm-5.2` — plan keys only work on the coding endpoint). The subprocess environment is deny-by-default: only the base OS
+`kimi-for-coding` and `k3`) and `zai/…` (Z.AI GLM Coding Plan endpoint,
+`ZAI_API_KEY`; model `glm-5.2` — plan keys only work on the coding
+endpoint). Other providers (for example Cerebras) go through
+`CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`. The subprocess environment is deny-by-default: only the base OS
 surface, `OPENCLAW_*` controls, proxy settings, and known provider API keys
 reach the agent. ClawSweeper gives OpenClaw a fresh state directory, a coding tool
 profile limited to the target workspace, and the lane's existing timeout and

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -334,16 +334,6 @@ const BUILTIN_PROVIDERS = {
       { id: "k3", name: "Kimi K3", contextWindow: 1048576, maxTokens: 131072 },
     ],
   },
-  // Cerebras Code plans serve the GLM coding model at ~1000 tok/s; validated
-  // live 2026-07-25 (474 tok/s wall including network, E2E tool run in 5s).
-  // zai-glm-4.7 deprecates 2026-08-17 — update the id when Cerebras swaps in
-  // its successor.
-  cerebras: {
-    baseUrl: "https://api.cerebras.ai/v1",
-    apiKey: "${CEREBRAS_API_KEY}",
-    api: "openai-completions",
-    models: [{ id: "zai-glm-4.7", name: "Z.ai GLM 4.7", contextWindow: 128000, maxTokens: 8192 }],
-  },
   // Z.AI GLM Coding Plan keys only authorize the coding endpoint — the general
   // paas endpoint rejects them with error 1113. Validated live 2026-07-25
   // (~51 tok/s, E2E tool run in 16s).

--- a/test/openclaw-process.test.ts
+++ b/test/openclaw-process.test.ts
@@ -363,44 +363,6 @@ test("OpenClaw subprocess env strips workflow credentials and keeps provider key
   }
 });
 
-test("OpenClaw cerebras models get built-in provider defaults", () => {
-  const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-test-"));
-  const recordPath = join(root, "record.json");
-  const binary = fakeOpenclaw(root);
-  try {
-    const result = runOpenclawProcess({
-      label: "cerebras-defaults",
-      prompt: "hi",
-      model: "cerebras/zai-glm-4.7",
-      cwd: root,
-      env: {
-        ...process.env,
-        CLAWSWEEPER_OPENCLAW_BIN: binary,
-        CLAWSWEEPER_OPENCLAW_MODEL: "cerebras/zai-glm-4.7",
-        OPENCLAW_TEST_RECORD: recordPath,
-      },
-      timeoutMs: 60_000,
-    });
-    assert.equal(result.status, 0, result.stderr);
-    const record = JSON.parse(readFileSync(recordPath, "utf8"));
-    assert.deepEqual(record.config.models, {
-      mode: "merge",
-      providers: {
-        cerebras: {
-          baseUrl: "https://api.cerebras.ai/v1",
-          apiKey: "${CEREBRAS_API_KEY}",
-          api: "openai-completions",
-          models: [
-            { id: "zai-glm-4.7", name: "Z.ai GLM 4.7", contextWindow: 128000, maxTokens: 8192 },
-          ],
-        },
-      },
-    });
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
 test("OpenClaw zai models get built-in Coding Plan endpoint defaults", () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-test-"));
   const recordPath = join(root, "record.json");


### PR DESCRIPTION
## Summary

- Remove Cerebras GLM-4.7 from ClawSweeper's built-in OpenClaw fallback providers because it is below the quality bar and Cerebras serves no GLM 5.x as of the 2026-07-25 live probe.
- Keep Cerebras available through `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON` and retain its API key in the subprocess allowlist.
- Update the repair operations documentation and changelog to match.

## Testing

- OpenClaw suite: 120/120 on the exact pre-commit diff.
- Autoreview: CLEAN (0.99) on the exact pre-commit diff.
