### PR TITLE
fix(router): preserve paused approvals until repair intent is durable

### DIFF
--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -2232,38 +2232,17 @@ function executeCommand(command: LooseRecord) {
         .filter((action: JsonValue) => action.action === "remove_label")
         .map((action: JsonValue) => String(action.label ?? ""))
         .filter(Boolean);
-      if (pauseLabels.length > 0) {
-        for (const pausedLabel of pauseLabels) {
-          runGitHubBestEffortMutation(
-            command,
-            "label_remove",
-            { repository: command.repo, number: command.issue_number, label: pausedLabel },
-            [
-              "issue",
-              "edit",
-              String(command.issue_number),
-              "--repo",
-              command.repo,
-              "--remove-label",
-              pausedLabel,
-            ],
-            githubNotFoundNoMutation,
-          );
-        }
-        command.target = {
-          ...command.target,
-          labels: (command.target?.labels ?? []).filter(
-            (label: JsonValue) => !pauseLabels.includes(String(label)),
-          ),
-        };
-      }
+      const deferPauseLabelRemoval = command.intent === "maintainer_approve_automerge";
+      if (pauseLabels.length > 0 && !deferPauseLabelRemoval) applyRemoveLabelActions(command);
       const merge = executeAutomerge(command);
       dispatched = { ...dispatched, merge };
       command.actions = command.actions.map((action: JsonValue) =>
         action.action === "label"
           ? { ...action, status: "executed", label: action.label }
           : action.action === "remove_label"
-            ? { ...action, status: "executed", label: action.label }
+            ? deferPauseLabelRemoval
+              ? action
+              : { ...action, status: "executed", label: action.label }
             : action.action === "update_description_note"
               ? { ...action, status: "executed" }
               : action.action === "merge"
@@ -2306,11 +2285,15 @@ function executeCommand(command: LooseRecord) {
             mode: command.target.mode,
             ...dispatchRepairActionStatus(repair),
           });
+          if (deferPauseLabelRemoval) applyRemoveLabelActions(command);
           if (repair.status === "claimed") {
             keepCommandClaimed(command);
             return;
           }
         }
+      }
+      if (deferPauseLabelRemoval && merge.status === "executed") {
+        applyRemoveLabelActions(command);
       }
     }
     if (
@@ -4160,7 +4143,9 @@ function validateAutomergeReadiness({ command, view, target }: LooseRecord) {
   if (!hasLabel(target, AUTOMERGE_LABEL)) {
     return "PR is not opted into ClawSweeper automerge";
   }
-  if (hasLabel(target, HUMAN_REVIEW_LABEL)) return "PR is paused for human review";
+  if (hasLabel(target, HUMAN_REVIEW_LABEL) && command.intent !== "maintainer_approve_automerge") {
+    return "PR is paused for human review";
+  }
   if (view.state && view.state !== "OPEN")
     return `pull request is ${String(view.state).toLowerCase()}`;
   if (view.isDraft) return "pull request is draft";

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -257,7 +257,6 @@ export function runAutomergeE2E({
     const repairedHead = currentRef(targetFixture.remote, targetFixture.headRef);
     assertFixturePostRepair(targetFixture, repairedHead);
     if (
-      scenario === "approve-intent-persistence" ||
       scenario === "completed-verdict-resume" ||
       scenario === "completed-verdict-source-drift" ||
       scenario === "resume-intent-persistence"
@@ -288,9 +287,36 @@ export function runAutomergeE2E({
       assert.match(String(behindMerge?.repair_reason ?? ""), /cloud rebase repair/);
       assert.equal(
         behindCommand?.actions.find((action) => action.action === "dispatch_repair")?.status,
+        "waiting",
+      );
+      let behindState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(
+        behindState.pr.labels.includes("clawsweeper:human-review"),
+        true,
+        "approval must preserve the pause label until the newly written repair job is durable",
+      );
+      assert.equal(
+        behindState.workflowDispatches.length,
+        0,
+        "a newly written repair job must not dispatch before its durable publication",
+      );
+      runCommentRouterExact(runtimeRoot, baseEnv, artifacts, "09-comment-router-approve-durable", {
+        commentId: approvalId,
+      });
+      const durableReport = readRouterReport(runtimeRoot);
+      const durableCommand = durableReport.commands.find(
+        (command) => command.intent === "maintainer_approve_automerge",
+      );
+      assert.equal(
+        durableCommand?.actions.find((action) => action.action === "dispatch_repair")?.status,
         "executed",
       );
-      const behindState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      behindState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      assert.equal(
+        behindState.pr.labels.includes("clawsweeper:human-review"),
+        false,
+        "the pause label may clear after the durable repair job dispatches",
+      );
       const repairDispatch = behindState.workflowDispatches.at(-1);
       assert.equal(
         repairDispatch?.inputs.job,
@@ -492,8 +518,8 @@ export function runAutomergeE2E({
     assert.equal(idempotentRouterReport.actionable, 0);
     assert.equal(
       state.calls.filter((call) => call.args[0] === "pr" && call.args[1] === "merge").length,
-      scenario === "approve-intent-persistence" ? 2 : 1,
-      "an idempotent router replay must not attempt a second merge",
+      scenario === "approve-intent-persistence" ? 3 : 1,
+      "only the durable approval replay and final exact-head verdict may retry merge",
     );
     assert.ok(state.calls.some((call) => call.token === "read"));
     assert.ok(state.calls.some((call) => call.token === "write"));


### PR DESCRIPTION
## Summary

- keep the human-review pause label in place while an approved automerge repair job is still only local
- let an explicit maintainer approval evaluate merge readiness without first mutating that pause label
- clear the pause only after the PR merges or a previously durable repair job is dispatched
- extend the automerge E2E proof through the interrupted approval handoff and replay

## Root cause

A maintainer approval removed the pause label before attempting merge. When GitHub rejected the merge because the branch was behind, the router wrote an adopted repair job and waited for the shared state writer before dispatch. If that state publication timed out, the job was lost but the label removal remained. A replay then rejected the same approval because no active pause label remained.

Live instance: https://github.com/openclaw/openclaw/pull/113663

The first exact approval run planned the repair and then failed in `Commit comment router ledger`: https://github.com/openclaw/clawsweeper/actions/runs/30166399701

A later replay found no actionable approval because the pause label had already been removed: https://github.com/openclaw/clawsweeper/actions/runs/30166403919

## Validation

- `pnpm run build:repair`
- `node --test test/repair/comment-router-core.test.ts` — 125 passed
- `node --test test/repair/comment-router-action-ledger.test.ts test/sweep-workflow.test.ts test/repair/automerge-e2e-workflow.test.ts` — 80 passed
- exact-head CI `pnpm check` passed: https://github.com/openclaw/clawsweeper/actions/runs/30187967254/job/89755940313
- exact-head CodeQL passed: https://github.com/openclaw/clawsweeper/actions/runs/30187967245

## Linux production behavior proof

The exact-head production automerge workflow passed on an Ubuntu 24.04 runner:
https://github.com/openclaw/clawsweeper/actions/runs/30187967236/job/89755940224

Its real containerized router/workflow run reported the `approve-intent-persistence` scenario as passed for both fixtures:

- `tiny/approve-intent-persistence`
- `openclaw-shaped/approve-intent-persistence`

The scenario proves the interrupted handoff and replay ordering:

1. the first maintainer approval writes the repair job and returns `waiting` while preserving the human-review pause label and issuing no repair dispatch;
2. after that job becomes durable, replay dispatches the repair;
3. only the successful durable replay clears the pause label.

The workflow also uploaded artifact `automerge-e2e-30187967236-1` (artifact ID `8627648385`) containing the run evidence.
