### PR TITLE
fix(reconcile): escalate stuck review placeholders on pull requests

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -194,6 +194,9 @@ jobs:
 
       # The workflow-scoped GITHUB_TOKEN cannot mutate the target repo; stuck
       # escalation labels need an app installation token for the target owner.
+      # The label endpoint is served under /issues but still requires
+      # pull-requests write when the item is a pull request; issues write alone
+      # escalates issues and 403s every pull-request escalation.
       - name: Create target write token
         id: target-write-token
         continue-on-error: true
@@ -204,6 +207,7 @@ jobs:
           owner: openclaw
           repositories: openclaw
           permission-issues: write
+          permission-pull-requests: write
 
       - name: Recover orphaned review placeholders
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Allowed stuck-placeholder recovery to label pull requests by granting its target token pull-request write permission alongside issue write. Thanks @masatohoshino! (#865)
 - Kept root-level apply reports as digest-only action-ledger evidence so ledger-enabled apply runs can finish, publish their compatibility report, and advance their cursor. Thanks @yetval! (#833)
 - Restored repair and spam workflows by keeping the multi-owner repair policy out of the GitHub App token action's single-owner input. Thanks @yetval! (#834)
 - Stopped the review pipeline stranding delivered verdicts: a single drifted state item is quarantined instead of aborting its whole batch, the commit_refs recovery path retries its final state-branch push with exponential backoff like its receipt and lease siblings, the superseded-placeholder sweep runs on every apply pass instead of only right after posting the durable verdict comment, and placeholder recovery spends its per-run budget on the oldest orphans first and labels long-stuck ones. Thanks @yetval! (#816)

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1006,7 +1006,13 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.match(sweepJob, /actions\/checkout@v7/);
   assert.match(sweepJob, /build-script: build/);
   assert.match(sweepJob, /name: Create target write token/);
-  assert.match(sweepJob, /owner: openclaw\s+repositories: openclaw\s+permission-issues: write/);
+  // GitHub's label endpoint lives under /issues but needs pull-requests write
+  // when the item is a pull request; issues write alone 403s every
+  // pull-request escalation.
+  assert.match(
+    sweepJob,
+    /owner: openclaw\s+repositories: openclaw\s+permission-issues: write\s+permission-pull-requests: write/,
+  );
   assert.match(sweepJob, /name: Recover orphaned review placeholders/);
   assert.match(sweepJob, /run: node dist\/review-placeholder-recovery\.js/);
   assert.match(


### PR DESCRIPTION
Closes https://github.com/openclaw/clawsweeper/issues/864

## What Problem This Solves

Fixes an issue where operators watching for stranded reviews would see the
`clawsweeper-recovery-stuck` label appear on issues but never on pull requests.

The placeholder recovery sweep labels items whose `ClawSweeper status: review
started.` placeholder was never replaced by a published review. Across the two
production runs cited below it attempted 47 escalations: all 41 on pull requests
failed with a 403, and all 6 on issues succeeded, so stranded pull requests
carried no signal.

## Why This Change Was Made

The `Create target write token` step requested `permission-issues: write` only.
GitHub serves the label endpoint under `/issues`, but adding a label to a pull
request additionally requires `Pull requests` write —
`POST /repos/{owner}/{repo}/issues/{issue_number}/labels` appears under both
categories in the
[fine-grained token permission reference](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens).

The installation already holds this grant, so requesting it here does not depend
on an installation change: other workflows in this repository request
`permission-pull-requests: write` from the same app, and `clawsweeper[bot]`
labels pull requests in the target repository with it — for example
https://github.com/openclaw/openclaw/pull/113395, a pull request labelled by
`clawsweeper[bot]` on 2026-07-24. `create-github-app-token` fails when it
requests a permission the installation lacks.

`test/sweep-workflow.test.ts` pinned the `permission-issues: write` form on its
own, so it now requires the pair — matching how the same file already asserts
both scopes for the sweep's target review token.

Scope is limited to this permission grant. The sweep's throughput and discovery
limits are separate problems, noted in
https://github.com/openclaw/clawsweeper/issues/864.

## User Impact

Stranded pull requests should get labelled `clawsweeper-recovery-stuck` the way
stranded issues already do, and the escalation attempts that are currently
rejected should start taking effect. Confirming that end to end needs one
in-org scheduled run after merge.


## Real behavior proof

Behavior addressed: the placeholder recovery sweep applies
`clawsweeper-recovery-stuck` to stranded issues but receives 403 on every
stranded pull request, so pull requests carry no recovery signal.

Real environment tested: two real environments, no mocks or synthetic data.
(1) Public logs of the production scheduled workflow `Reconcile exact-review
leases` in this repository, running against `openclaw/openclaw` with the token
produced by the `Create target write token` step before this change.
(2) A live permission probe against a fork I own,
`masatohoshino/clawsweeper` (its own PR #1 and issue #2), using two
fine-grained personal access tokens scoped to that fork and differing only in
the `Pull requests` grant. The label was pre-created on the fork so
label-creation rights are not a variable.

Exact steps or command run after this patch:

```bash
# (1) production: classify every item whose escalation returned 403
gh api repos/openclaw/clawsweeper/actions/jobs/89754699467/logs > job.log
grep -o "#[0-9]* review-placeholder stuck-label escalation failed" job.log \
  | grep -o '[0-9]*' | sort -u > f403.txt
xargs -I{} gh api repos/openclaw/openclaw/issues/{} \
  --jq '"#\(.number) \(if .pull_request then "PULL_REQUEST" else "ISSUE" end) state=\(.state) locked=\(.locked)"' \
  < f403.txt

# (2) permission probe, run once per token against the fork's PR and issue.
#     /tmp/pat-a holds a token with Issues:write only.
#     /tmp/pat-b holds a token with Issues:write + Pull requests:write.
curl -s -o /dev/null -w '%{http_code}\n' -X POST \
  -H "Authorization: Bearer $(cat /tmp/pat-a)" \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  -d '{"labels":["clawsweeper-recovery-stuck"]}' \
  https://api.github.com/repos/masatohoshino/clawsweeper/issues/1/labels

# The other three cells are the same call with /tmp/pat-b substituted for
# /tmp/pat-a (after evidence) and with issues/2 substituted for issues/1
# (the issue control). The label is deleted between attempts.
```

Before evidence:

```
production run 30187501666 (2026-07-26T04:15:45Z), token = Issues:write only

review-placeholder recovery: checked=120 orphaned=58 enqueued=5 cleaned=0 escalated=0 errors=41 matched=1132 remaining=1012
#112512 review-placeholder stuck-label escalation failed: POST /repos/openclaw/openclaw/issues/112512/labels returned 403
        ... 41 such lines

classification of all 41 items that returned 403:
#102128 PULL_REQUEST state=open locked=false
#102182 PULL_REQUEST state=open locked=false
#104569 PULL_REQUEST state=open locked=false
        ... 41 lines
tally: PULL_REQUEST 41 / ISSUE 0, state=open 41, locked=false 41

production run 30161728019 (2026-07-25T14:29:24Z), same token configuration
reported escalated=6; those 6 items (#11623 #9865 #7490 #9656 #9764 #113251)
are all issues.

fork probe, token with Issues:write only:
POST .../issues/1/labels   (pull request) -> HTTP 403  Resource not accessible by personal access token
POST .../issues/2/labels   (issue)        -> HTTP 200  label applied
```

Evidence after fix:

```
fork probe, token with Issues:write + Pull requests:write
(the permission set this PR moves the workflow token to):

POST .../issues/1/labels   (pull request) -> HTTP 200  label applied
POST .../issues/2/labels   (issue)        -> HTTP 200  label applied
```

Observed result after fix: adding the `Pull requests` grant is the single change
that turns the pull-request 403 into a successful label write; the issue path is
unaffected in both directions. The before rows reproduce the production
asymmetry exactly, and every production 403 came from an open, unlocked pull
request, which rules out locked conversations and closed items for those 41
failures.

What was not tested: the workflow's own after-fix run. That needs the
ClawSweeper app installation private key for the `openclaw` org, which is not
available outside the org. The probe uses fine-grained personal access tokens,
so it establishes GitHub's permission model for this endpoint rather than this
workflow's execution. The next scheduled run that reaches a stranded pull
request shows it end to end: the pull-request 403s should disappear from
`errors`, `escalated` should count pull requests, and those pull requests should
start carrying `clawsweeper-recovery-stuck`. The production runs also left 1,012
matched placeholders unexamined; those were not classified.

Proof limitations or environment constraints: captured against branch head
`6cbf326ca6f89d1a01bf4a0ce444ff06ad9c10df`, which is the diff under review; the
production logs predate this branch and do not depend on it. The production
evidence is read-only — nothing in `openclaw/*` was written to while gathering
it. The
probe does write, but only to a fork I own, and it removes the label again after
each attempt. The two probe tokens were created with identical repository scope
(that fork only) and identical permissions except the `Pull requests` grant.
Run logs are re-fetchable only within GitHub's retention window (collected
2026-07-26).

## Focused test

`test/sweep-workflow.test.ts` passes with the updated assertion;
`test/review-reliability-workflow.test.ts` passes (1/1); `pnpm run check:static`
passes. One unrelated failure in `test/sweep-workflow.test.ts` reproduces
identically on unpatched `upstream/main`, so it is pre-existing and untouched
here.
