### PR TITLE
feat(state): Cloudflare-canonical exact-review records (state-repo retirement, phase 1)

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1,14 +1,17 @@
 export const EXACT_REVIEW_DIRECT_PUBLICATION_TABLE = "exact_review_direct_publication_plans";
+export const EXACT_REVIEW_CANONICAL_RECORD_TABLE = "exact_review_canonical_records";
+export const EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE = "exact_review_canonical_record_chunks";
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES = 4 * 1024 * 1024;
-export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_COMMIT_BYTES = 20 * 1024 * 1024;
-export const EXACT_REVIEW_DIRECT_PUBLICATION_FILE_THRESHOLD = 64;
-export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES = 512;
+export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES = 4;
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES = 2 * 1024 * 1024;
-export const EXACT_REVIEW_DIRECT_PUBLICATION_CADENCE_MS = 15_000;
-export const EXACT_REVIEW_DIRECT_PUBLICATION_RETRY_LIMIT = 12;
+export const EXACT_REVIEW_CANONICAL_INLINE_BYTES = Math.floor(1.5 * 1024 * 1024);
+export const EXACT_REVIEW_CANONICAL_CHUNK_BYTES = 512 * 1024;
+export const EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
-const OID_PATTERN = /^[a-f0-9]{40,64}$/;
+const DIRECT_PUBLICATION_TERMINAL_PRUNE_LIMIT = 256;
 const MAX_PATH_BYTES = 1024;
+const STATE_APPEND_WINDOW_TABLE = "state_append_window";
+const RECORD_SECTIONS = new Set<RecordSection>(["items", "closed", "plans", "decision-packets"]);
 
 type SqlStorage = {
   exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
@@ -18,6 +21,8 @@ type DurableStorage = {
   sql: SqlStorage;
   transactionSync: <T>(callback: () => T) => T;
 };
+
+export type RecordSection = "items" | "closed" | "plans" | "decision-packets";
 
 export type DirectPublicationOperation = {
   path: string;
@@ -36,7 +41,27 @@ export type DirectPublicationPlan = {
   totalBytes: number;
 };
 
-export type DirectPublicationRow = DirectPublicationPlan & {
+export type CanonicalDirectPublicationOperation = DirectPublicationOperation & {
+  repoSlug: string;
+  section: RecordSection;
+  itemId: number;
+  content: string | null;
+  digest: string | null;
+};
+
+export type CanonicalDirectPublicationPlan = Omit<DirectPublicationPlan, "operations"> & {
+  operations: CanonicalDirectPublicationOperation[];
+};
+
+export type DirectPublicationStoredOperation = {
+  path: string;
+  bytes: number;
+  digest: string | null;
+  deleted: boolean;
+};
+
+export type DirectPublicationRow = Omit<DirectPublicationPlan, "operations"> & {
+  operations: DirectPublicationStoredOperation[] | DirectPublicationOperation[];
   state: "pending" | "committing" | "retryable" | "published" | "superseded" | "failed";
   attempts: number;
   createdAt: number;
@@ -52,21 +77,27 @@ export type DirectPublicationAcceptResult = {
   supersededRevisions: number[];
 };
 
-export type DirectPublicationCommitApi = {
-  readHead: () => Promise<{ commitSha: string; treeSha: string; paths: Map<string, string> }>;
-  createBlob: (contentBase64: string) => Promise<string>;
-  createTree: (
-    baseTreeSha: string,
-    entries: Array<{ path: string; mode: "100644"; type: "blob"; sha: string | null }>,
-  ) => Promise<string>;
-  createCommit: (message: string, treeSha: string, parentSha: string) => Promise<string>;
-  updateRef: (commitSha: string) => Promise<void>;
+export type DirectPublicationProjectionLimits = {
+  maxRecordBytes: number;
+  maxPendingRows: number;
+  maxPendingBytes: number;
 };
 
-export class DirectPublicationRefRaceError extends Error {
-  constructor() {
-    super("state ref changed while publishing direct exact-review results");
-    this.name = "DirectPublicationRefRaceError";
+export type CanonicalRecord = {
+  repoSlug: string;
+  section: RecordSection;
+  itemId: number;
+  content: string | null;
+  digest: string | null;
+  revision: number;
+  updatedAt: number;
+  deleted: boolean;
+};
+
+export class DirectPublicationProjectionCapacityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DirectPublicationProjectionCapacityError";
   }
 }
 
@@ -101,194 +132,217 @@ export class ExactReviewDirectPublicationStore {
        ) STRICT`,
     );
     this.storage.sql.exec(
-      `CREATE INDEX IF NOT EXISTS exact_review_direct_publication_ready
-         ON ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-         (state, next_attempt_at, created_at, item_key, revision)`,
+      `CREATE INDEX IF NOT EXISTS exact_review_direct_publication_terminal_retention
+         ON ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE} (state, updated_at, item_key, revision)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_CANONICAL_RECORD_TABLE} (
+         repo_slug TEXT NOT NULL,
+         section TEXT NOT NULL CHECK (section IN ('items', 'closed', 'plans', 'decision-packets')),
+         item_id INTEGER NOT NULL CHECK (item_id >= 1),
+         content TEXT,
+         digest TEXT CHECK (digest IS NULL OR length(digest) = 64),
+         byte_length INTEGER NOT NULL CHECK (byte_length >= 0),
+         chunk_count INTEGER NOT NULL DEFAULT 0 CHECK (chunk_count >= 0),
+         deleted INTEGER NOT NULL DEFAULT 0 CHECK (deleted IN (0, 1)),
+         revision INTEGER NOT NULL CHECK (revision >= 1),
+         item_key TEXT NOT NULL,
+         claim_generation INTEGER NOT NULL CHECK (claim_generation >= 1),
+         updated_at INTEGER NOT NULL,
+         PRIMARY KEY (repo_slug, section, item_id),
+         CHECK ((deleted = 1 AND content IS NULL AND digest IS NULL AND byte_length = 0 AND chunk_count = 0)
+             OR (deleted = 0 AND digest IS NOT NULL AND ((content IS NOT NULL AND chunk_count = 0)
+               OR (content IS NULL AND chunk_count > 0))))
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_canonical_records_listing
+         ON ${EXACT_REVIEW_CANONICAL_RECORD_TABLE} (repo_slug, section, item_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE} (
+         repo_slug TEXT NOT NULL,
+         section TEXT NOT NULL CHECK (section IN ('items', 'closed', 'plans', 'decision-packets')),
+         item_id INTEGER NOT NULL CHECK (item_id >= 1),
+         chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+         content_base64 TEXT NOT NULL,
+         PRIMARY KEY (repo_slug, section, item_id, chunk_index)
+       ) STRICT`,
     );
   }
 
-  accept(plan: DirectPublicationPlan, now: number): DirectPublicationAcceptResult {
-    const validated = validateDirectPublicationPlan(plan);
+  accept(
+    plan: CanonicalDirectPublicationPlan,
+    now: number,
+    limits: DirectPublicationProjectionLimits,
+  ): DirectPublicationAcceptResult {
+    const storedOperations = storedOperationsFrom(plan.operations);
     return this.storage.transactionSync(() => {
-      const existing = this.readSync(validated.itemKey, validated.revision);
+      this.pruneTerminalSync(now);
+      const existing = this.readSync(plan.itemKey, plan.revision);
       if (existing) {
-        if (canonicalPlan(existing) !== canonicalPlan(validated)) {
-          throw new Error("conflicting direct publication retry");
+        if (["pending", "committing", "retryable"].includes(existing.state)) {
+          if (!legacyPlanMatches(existing, plan)) {
+            throw new Error("conflicting legacy direct publication retry");
+          }
+          this.storage.sql.exec(
+            `DELETE FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+              WHERE item_key = ? AND revision = ?`,
+            plan.itemKey,
+            plan.revision,
+          );
+        } else {
+          if (canonicalStoredPlan(existing) !== canonicalIncomingPlan(plan, storedOperations)) {
+            throw new Error("conflicting direct publication retry");
+          }
+          return { outcome: "deduped" as const, row: existing, supersededRevisions: [] };
         }
-        return { outcome: "deduped" as const, row: existing, supersededRevisions: [] };
       }
+
       const newer = Array.from(
         this.storage.sql.exec(
           `SELECT revision FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
             WHERE item_key = ? AND revision > ?
             ORDER BY revision DESC LIMIT 1`,
-          validated.itemKey,
-          validated.revision,
+          plan.itemKey,
+          plan.revision,
         ),
       )[0];
       if (newer) {
-        const row: DirectPublicationRow = {
-          ...validated,
+        const row = directPublicationRowFromPlan({
+          plan,
+          operations: storedOperations,
           state: "superseded",
-          attempts: 0,
-          createdAt: now,
-          updatedAt: now,
-          nextAttemptAt: now,
+          now,
           commitSha: null,
-          failureReason: "newer_revision_already_staged",
-        };
+          failureReason: "newer_revision_already_published",
+        });
         this.insertSync(row);
         return { outcome: "superseded" as const, row, supersededRevisions: [] };
       }
-      const supersededRevisions = Array.from(
+
+      for (const operation of plan.operations) {
+        const current = this.readCanonicalMetadataSync(
+          operation.repoSlug,
+          operation.section,
+          operation.itemId,
+        );
+        if (current && current.revision > plan.revision) {
+          throw new Error(`canonical record revision advanced for ${operation.path}`);
+        }
+        if (
+          current &&
+          current.revision === plan.revision &&
+          (current.digest !== operation.digest || current.deleted !== (operation.content === null))
+        ) {
+          throw new Error(
+            `canonical record digest conflicts at revision ${plan.revision}: ${operation.path}`,
+          );
+        }
+      }
+
+      const projection = recordTupleProjection(plan, limits.maxRecordBytes);
+      const totals = stateAppendWindowTotalsSync(this.storage);
+      if (
+        totals.pendingRows + 1 > limits.maxPendingRows ||
+        totals.pendingBytes + projection.payloadBytes > limits.maxPendingBytes
+      ) {
+        throw new DirectPublicationProjectionCapacityError(
+          `record tuple projection capacity exceeded: rows=${totals.pendingRows}/${limits.maxPendingRows} bytes=${totals.pendingBytes}/${limits.maxPendingBytes} incoming=${projection.payloadBytes}`,
+        );
+      }
+
+      for (const operation of plan.operations)
+        this.writeCanonicalOperationSync(operation, plan, now);
+      const inserted = Array.from(
         this.storage.sql.exec(
-          `SELECT revision FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-            WHERE item_key = ? AND revision < ?
-              AND state IN ('pending', 'retryable', 'committing')
-            ORDER BY revision`,
-          validated.itemKey,
-          validated.revision,
-        ),
-        (row) => Number(row.revision),
-      );
-      this.storage.sql.exec(
-        `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-            SET state = 'superseded', updated_at = ?, failure_reason = 'newer_revision_staged'
-          WHERE item_key = ? AND revision < ?
-            AND state IN ('pending', 'retryable', 'committing')`,
+          `INSERT INTO ${STATE_APPEND_WINDOW_TABLE}
+             (kind, record_key, payload_json, payload_bytes, produced_at, delivery_id)
+           VALUES ('record_tuple', ?, ?, ?, ?, ?)
+           RETURNING seq`,
+          projection.key,
+          projection.payloadJson,
+          projection.payloadBytes,
+          new Date(now).toISOString(),
+          `record-tuple:${plan.itemKey}:${plan.revision}:${plan.identity.claimGeneration}`,
+        ) as Iterable<{ seq: number }>,
+      )[0];
+      const sequence = Number(inserted?.seq);
+      if (!Number.isSafeInteger(sequence) || sequence < 1) {
+        throw new Error("record tuple projection failed to allocate a sequence");
+      }
+      const receipt = `do-txn:${sequence}`;
+      const row = directPublicationRowFromPlan({
+        plan,
+        operations: storedOperations,
+        state: "published",
         now,
-        validated.itemKey,
-        validated.revision,
-      );
-      const row: DirectPublicationRow = {
-        ...validated,
-        state: "pending",
-        attempts: 0,
-        createdAt: now,
-        updatedAt: now,
-        nextAttemptAt: now,
-        commitSha: null,
+        commitSha: receipt,
         failureReason: null,
-      };
+      });
       this.insertSync(row);
-      return { outcome: "accepted" as const, row, supersededRevisions };
+      return { outcome: "accepted" as const, row, supersededRevisions: [] };
     });
   }
 
-  nextWakeAt(now: number): number | null {
-    const summary = Array.from(
+  readCanonical(repoSlug: string, section: RecordSection, itemId: number): CanonicalRecord | null {
+    const metadata = this.readCanonicalMetadataSync(repoSlug, section, itemId);
+    if (!metadata) return null;
+    if (metadata.deleted) return { ...metadata, content: null };
+    if (metadata.content !== null) return metadata;
+    const chunks = Array.from(
       this.storage.sql.exec(
-        `SELECT MIN(created_at) AS oldest_at, MIN(next_attempt_at) AS retry_at,
-                COALESCE(SUM(CASE WHEN next_attempt_at <= ? THEN file_count ELSE 0 END), 0)
-                  AS files
-           FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-          WHERE state IN ('pending', 'retryable')`,
-        now,
+        `SELECT chunk_index, content_base64
+           FROM ${EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE}
+          WHERE repo_slug = ? AND section = ? AND item_id = ?
+          ORDER BY chunk_index`,
+        repoSlug,
+        section,
+        itemId,
       ),
-    )[0];
-    if (summary?.oldest_at === null || summary?.oldest_at === undefined) return null;
-    const retryAt = Number(summary.retry_at);
-    const cadenceAt = Number(summary.oldest_at) + EXACT_REVIEW_DIRECT_PUBLICATION_CADENCE_MS;
-    return Number(summary.files) >= EXACT_REVIEW_DIRECT_PUBLICATION_FILE_THRESHOLD
-      ? Math.max(now, retryAt)
-      : Math.max(retryAt, cadenceAt);
+    );
+    if (chunks.length !== metadata.chunkCount) {
+      throw new Error(`canonical record chunk count mismatch: ${repoSlug}/${section}/${itemId}`);
+    }
+    const byteParts = chunks.map((row) => base64Bytes(String(row.content_base64)));
+    const combined = new Uint8Array(byteParts.reduce((sum, part) => sum + part.byteLength, 0));
+    let offset = 0;
+    for (const part of byteParts) {
+      combined.set(part, offset);
+      offset += part.byteLength;
+    }
+    const content = new TextDecoder("utf-8", { fatal: true }).decode(combined);
+    if (new TextEncoder().encode(content).byteLength !== metadata.byteLength) {
+      throw new Error(`canonical record byte count mismatch: ${repoSlug}/${section}/${itemId}`);
+    }
+    return { ...metadata, content };
   }
 
-  claimCycle(now: number): DirectPublicationRow[] {
-    return this.storage.transactionSync(() => {
+  listCanonical(options: {
+    repoSlug: string;
+    section: RecordSection;
+    cursor: number;
+    limit: number;
+  }) {
+    return Array.from(
       this.storage.sql.exec(
-        `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-            SET state = 'retryable', next_attempt_at = ?, updated_at = ?,
-                failure_reason = 'stale_inflight_recovery'
-          WHERE state = 'committing' AND updated_at <= ?`,
-        now,
-        now,
-        now - 30 * 60_000,
-      );
-      const rows = Array.from(
-        this.storage.sql.exec(
-          `SELECT * FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-            WHERE state IN ('pending', 'retryable') AND next_attempt_at <= ?
-            ORDER BY created_at, item_key, revision`,
-          now,
-        ),
-        directPublicationRow,
-      );
-      const selected: DirectPublicationRow[] = [];
-      let stagedBytes = 0;
-      for (const row of rows) {
-        if (stagedBytes + row.totalBytes > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_COMMIT_BYTES) break;
-        selected.push(row);
-        stagedBytes += row.totalBytes;
-      }
-      for (const row of selected) {
-        this.storage.sql.exec(
-          `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-              SET state = 'committing', updated_at = ?
-            WHERE item_key = ? AND revision = ? AND state IN ('pending', 'retryable')`,
-          now,
-          row.itemKey,
-          row.revision,
-        );
-        row.state = "committing";
-        row.updatedAt = now;
-      }
-      return selected;
-    });
-  }
-
-  complete(rows: readonly DirectPublicationRow[], commitSha: string, now: number) {
-    this.storage.transactionSync(() => {
-      for (const row of rows) {
-        this.storage.sql.exec(
-          `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-              SET state = 'published', commit_sha = ?, updated_at = ?, failure_reason = NULL
-            WHERE item_key = ? AND revision = ? AND state = 'committing'`,
-          commitSha,
-          now,
-          row.itemKey,
-          row.revision,
-        );
-      }
-    });
-  }
-
-  supersede(rows: readonly DirectPublicationRow[], now: number, reason = "newer_queue_revision") {
-    this.storage.transactionSync(() => {
-      for (const row of rows) {
-        this.storage.sql.exec(
-          `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-              SET state = 'superseded', updated_at = ?, failure_reason = ?
-            WHERE item_key = ? AND revision = ?
-              AND state IN ('pending', 'retryable', 'committing')`,
-          now,
-          reason,
-          row.itemKey,
-          row.revision,
-        );
-      }
-    });
-  }
-
-  retry(rows: readonly DirectPublicationRow[], reason: string, now: number) {
-    this.storage.transactionSync(() => {
-      for (const row of rows) {
-        const attempts = row.attempts + 1;
-        const exhausted = attempts >= EXACT_REVIEW_DIRECT_PUBLICATION_RETRY_LIMIT;
-        this.storage.sql.exec(
-          `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-              SET state = ?, attempts = ?, updated_at = ?, next_attempt_at = ?, failure_reason = ?
-            WHERE item_key = ? AND revision = ? AND state = 'committing'`,
-          exhausted ? "failed" : "retryable",
-          attempts,
-          now,
-          now + directPublicationRetryDelayMs(attempts),
-          reason.slice(0, 500),
-          row.itemKey,
-          row.revision,
-        );
-      }
-    });
+        `SELECT item_id, digest, revision, updated_at
+           FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+          WHERE repo_slug = ? AND section = ? AND item_id > ? AND deleted = 0
+          ORDER BY item_id
+          LIMIT ?`,
+        options.repoSlug,
+        options.section,
+        options.cursor,
+        options.limit,
+      ),
+      (row) => ({
+        id: Number(row.item_id),
+        digest: String(row.digest),
+        revision: Number(row.revision),
+        updatedAt: Number(row.updated_at),
+      }),
+    );
   }
 
   list(): DirectPublicationRow[] {
@@ -298,6 +352,49 @@ export class ExactReviewDirectPublicationStore {
       ),
       directPublicationRow,
     );
+  }
+
+  legacyPendingPlans(): DirectPublicationPlan[] {
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT item_key, revision, identity_item_key, identity_revision, claim_generation,
+                operations_json, total_bytes
+           FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+          WHERE state IN ('pending', 'committing', 'retryable')
+          ORDER BY created_at, item_key, revision`,
+      ),
+      (row) => ({
+        itemKey: String(row.item_key),
+        revision: Number(row.revision),
+        identity: {
+          itemKey: String(row.identity_item_key),
+          revision: Number(row.identity_revision),
+          claimGeneration: Number(row.claim_generation),
+        },
+        operations: JSON.parse(String(row.operations_json)) as DirectPublicationOperation[],
+        totalBytes: Number(row.total_bytes),
+      }),
+    );
+  }
+
+  get(itemKey: string, revision: number): DirectPublicationRow | null {
+    return this.readSync(itemKey, revision);
+  }
+
+  pruneTerminalSync(now: number) {
+    return Array.from(
+      this.storage.sql.exec(
+        `DELETE FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+          WHERE rowid IN (
+            SELECT rowid FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+             WHERE state IN ('published', 'superseded', 'failed') AND updated_at <= ?
+             ORDER BY updated_at, item_key, revision
+             LIMIT ${DIRECT_PUBLICATION_TERMINAL_PRUNE_LIMIT}
+          )
+          RETURNING item_key`,
+        now - EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS,
+      ),
+    ).length;
   }
 
   private readSync(itemKey: string, revision: number) {
@@ -310,6 +407,91 @@ export class ExactReviewDirectPublicationStore {
       ),
     )[0];
     return row ? directPublicationRow(row) : null;
+  }
+
+  private readCanonicalMetadataSync(repoSlug: string, section: RecordSection, itemId: number) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT content, digest, byte_length, chunk_count, deleted, revision, updated_at
+           FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+          WHERE repo_slug = ? AND section = ? AND item_id = ?`,
+        repoSlug,
+        section,
+        itemId,
+      ),
+    )[0];
+    if (!row) return null;
+    return {
+      repoSlug,
+      section,
+      itemId,
+      content: row.content === null ? null : String(row.content),
+      digest: row.digest === null ? null : String(row.digest),
+      byteLength: Number(row.byte_length),
+      chunkCount: Number(row.chunk_count),
+      revision: Number(row.revision),
+      updatedAt: Number(row.updated_at),
+      deleted: Number(row.deleted) === 1,
+    };
+  }
+
+  private writeCanonicalOperationSync(
+    operation: CanonicalDirectPublicationOperation,
+    plan: CanonicalDirectPublicationPlan,
+    now: number,
+  ) {
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE}
+        WHERE repo_slug = ? AND section = ? AND item_id = ?`,
+      operation.repoSlug,
+      operation.section,
+      operation.itemId,
+    );
+    const chunked =
+      operation.content !== null && operation.bytes > EXACT_REVIEW_CANONICAL_INLINE_BYTES;
+    const chunks = chunked
+      ? byteChunks(operation.content!, EXACT_REVIEW_CANONICAL_CHUNK_BYTES)
+      : [];
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+         (repo_slug, section, item_id, content, digest, byte_length, chunk_count, deleted,
+          revision, item_key, claim_generation, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(repo_slug, section, item_id) DO UPDATE SET
+         content = excluded.content,
+         digest = excluded.digest,
+         byte_length = excluded.byte_length,
+         chunk_count = excluded.chunk_count,
+         deleted = excluded.deleted,
+         revision = excluded.revision,
+         item_key = excluded.item_key,
+         claim_generation = excluded.claim_generation,
+         updated_at = excluded.updated_at`,
+      operation.repoSlug,
+      operation.section,
+      operation.itemId,
+      operation.content === null || chunked ? null : operation.content,
+      operation.digest,
+      operation.bytes,
+      chunks.length,
+      operation.content === null ? 1 : 0,
+      plan.revision,
+      plan.itemKey,
+      plan.identity.claimGeneration,
+      now,
+    );
+    for (let index = 0; index < chunks.length; index += 1) {
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE}
+           (repo_slug, section, item_id, chunk_index, content_base64)
+         VALUES (?, ?, ?, ?, ?)`,
+        operation.repoSlug,
+        operation.section,
+        operation.itemId,
+        index,
+        chunks[index],
+      );
+    }
   }
 
   private insertSync(row: DirectPublicationRow) {
@@ -338,145 +520,31 @@ export class ExactReviewDirectPublicationStore {
   }
 }
 
-export async function commitDirectPublicationCycle(options: {
-  store: ExactReviewDirectPublicationStore;
-  api: DirectPublicationCommitApi;
-  now: number;
-  message?: string;
-}): Promise<{
-  commitSha: string | null;
-  published: DirectPublicationRow[];
-  retryable: DirectPublicationRow[];
-}> {
-  const claimed = options.store.claimCycle(options.now);
-  if (!claimed.length) return { commitSha: null, published: [], retryable: [] };
-  let remaining = claimed;
-  const published: DirectPublicationRow[] = [];
-  try {
-    for (let refAttempt = 1; refAttempt <= 3; refAttempt += 1) {
-      let head = await options.api.readHead();
-      const alreadyApplied = remaining.filter((row) => targetOidsMatch(row, head.paths));
-      if (alreadyApplied.length) {
-        options.store.complete(alreadyApplied, head.commitSha, options.now);
-        published.push(...alreadyApplied);
-        const appliedKeys = new Set(alreadyApplied.map((row) => `${row.itemKey}\0${row.revision}`));
-        remaining = remaining.filter((row) => !appliedKeys.has(`${row.itemKey}\0${row.revision}`));
-      }
-      if (!remaining.length) {
-        return { commitSha: head.commitSha, published, retryable: [] };
-      }
-      let conflicts = remaining.filter((row) => !expectedOidsMatch(row, head.paths));
-      if (conflicts.length) {
-        // A materializer may have advanced the state ref between producer
-        // preparation and this alarm. Re-read once before spending a retry.
-        head = await options.api.readHead();
-        conflicts = remaining.filter((row) => !expectedOidsMatch(row, head.paths));
-      }
-      if (conflicts.length) {
-        options.store.retry(conflicts, "expected_oid_conflict", options.now);
-        const conflictKeys = new Set(conflicts.map((row) => `${row.itemKey}\0${row.revision}`));
-        remaining = remaining.filter((row) => !conflictKeys.has(`${row.itemKey}\0${row.revision}`));
-      }
-      if (!remaining.length)
-        return {
-          commitSha: published.length ? head.commitSha : null,
-          published,
-          retryable: claimed.filter((row) => !published.includes(row)),
-        };
-      const compatibility = compatibleDirectPublicationPlans(remaining);
-      if (compatibility.conflicts.length) {
-        options.store.retry(
-          compatibility.conflicts,
-          "incompatible_same_path_mutation",
-          options.now,
-        );
-        remaining = compatibility.plans;
-      }
-      if (!remaining.length)
-        return {
-          commitSha: published.length ? head.commitSha : null,
-          published,
-          retryable: claimed.filter((row) => !published.includes(row)),
-        };
-
-      const entries: Array<{ path: string; mode: "100644"; type: "blob"; sha: string | null }> = [];
-      for (const row of remaining) {
-        for (const operation of row.operations) {
-          if (operation.targetOid === null) {
-            entries.push({ path: operation.path, mode: operation.mode, type: "blob", sha: null });
-            continue;
-          }
-          const oid = await options.api.createBlob(operation.contentBase64!);
-          if (oid !== operation.targetOid) {
-            options.store.retry([row], "prepared_blob_oid_mismatch", options.now);
-            const rowKey = `${row.itemKey}\0${row.revision}`;
-            remaining = remaining.filter(
-              (candidate) => `${candidate.itemKey}\0${candidate.revision}` !== rowKey,
-            );
-            break;
-          }
-          entries.push({ path: operation.path, mode: operation.mode, type: "blob", sha: oid });
-        }
-      }
-      if (!remaining.length)
-        return {
-          commitSha: published.length ? head.commitSha : null,
-          published,
-          retryable: claimed.filter((row) => !published.includes(row)),
-        };
-      const remainingPaths = new Set(
-        remaining.flatMap((row) => row.operations.map((op) => op.path)),
-      );
-      const filteredEntries = [
-        ...new Map(
-          entries
-            .filter((entry) => remainingPaths.has(entry.path))
-            .map((entry) => [entry.path, entry] as const),
-        ).values(),
-      ];
-      const treeSha = await options.api.createTree(head.treeSha, filteredEntries);
-      const commitSha = await options.api.createCommit(
-        options.message ?? `chore(state): publish ${remaining.length} exact-review result(s)`,
-        treeSha,
-        head.commitSha,
-      );
-      try {
-        await options.api.updateRef(commitSha);
-        options.store.complete(remaining, commitSha, options.now);
-        published.push(...remaining);
-        return {
-          commitSha,
-          published,
-          retryable: claimed.filter((row) => !published.includes(row)),
-        };
-      } catch (error) {
-        if (!(error instanceof DirectPublicationRefRaceError) || refAttempt === 3) {
-          options.store.retry(remaining, errorMessage(error), options.now);
-          return { commitSha: null, published: [], retryable: claimed };
-        }
-      }
-    }
-  } catch (error) {
-    options.store.retry(remaining, errorMessage(error), options.now);
-    return { commitSha: null, published: [], retryable: claimed };
-  }
-  options.store.retry(remaining, "state_ref_race", options.now);
-  return { commitSha: null, published: [], retryable: claimed };
+export function validateRecordSection(value: unknown): RecordSection | null {
+  const section = String(value || "").trim() as RecordSection;
+  return RECORD_SECTIONS.has(section) ? section : null;
 }
 
-export function validateDirectPublicationPlan(value: DirectPublicationPlan): DirectPublicationPlan {
+export function validateRepoSlug(value: unknown): string | null {
+  const slug = String(value || "").trim();
+  return /^[A-Za-z0-9][A-Za-z0-9_.-]{0,199}$/.test(slug) ? slug : null;
+}
+
+export async function validateDirectPublicationPlan(
+  value: DirectPublicationPlan,
+): Promise<CanonicalDirectPublicationPlan> {
   const plan = value && typeof value === "object" ? value : ({} as DirectPublicationPlan);
   const itemKey = boundedItemKey(plan.itemKey);
-  if (!itemKey) throw new Error("invalid direct publication item key");
+  const itemIdentity = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#([1-9]\d*)$/.exec(itemKey);
+  if (!itemIdentity) throw new Error("invalid direct publication item key");
   if (!Number.isSafeInteger(plan.revision) || plan.revision < 1) {
     throw new Error("invalid direct publication revision");
   }
   const identity = plan.identity;
   if (
     !identity ||
-    !boundedItemKey(identity.itemKey) ||
-    !Number.isSafeInteger(identity.revision) ||
-    identity.revision < 1 ||
+    boundedItemKey(identity.itemKey) !== itemKey ||
+    identity.revision !== plan.revision ||
     !Number.isSafeInteger(identity.claimGeneration) ||
     identity.claimGeneration < 1
   ) {
@@ -486,22 +554,23 @@ export function validateDirectPublicationPlan(value: DirectPublicationPlan): Dir
     throw new Error("a direct publication plan must change a path");
   }
   if (plan.operations.length > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES) {
-    throw new Error("a direct publication plan exceeds the exact-review file limit");
+    throw new Error("a direct publication plan exceeds the exact-review tuple file limit");
   }
+  const repoSlug = `${itemIdentity[1]}-${itemIdentity[2]}`;
+  const itemId = Number(itemIdentity[3]);
   const paths = new Set<string>();
   let totalBytes = 0;
-  const operations = plan.operations.map((raw): DirectPublicationOperation => {
+  const operations: CanonicalDirectPublicationOperation[] = [];
+  for (const raw of plan.operations) {
     const operation = raw && typeof raw === "object" ? raw : ({} as DirectPublicationOperation);
     const path = canonicalPath(operation.path);
     if (path !== operation.path || paths.has(path)) {
       throw new Error(`invalid or repeated direct publication path: ${String(operation.path)}`);
     }
     paths.add(path);
-    if (operation.expectedOid !== null && !OID_PATTERN.test(String(operation.expectedOid))) {
-      throw new Error(`invalid expected object id for ${path}`);
-    }
-    if (operation.targetOid !== null && !OID_PATTERN.test(String(operation.targetOid))) {
-      throw new Error(`invalid target object id for ${path}`);
+    const tuple = canonicalTuplePath(path);
+    if (!tuple || tuple.repoSlug !== repoSlug || tuple.itemId !== itemId) {
+      throw new Error(`direct publication path is outside ${repoSlug}#${itemId}: ${path}`);
     }
     if (operation.mode !== "100644") throw new Error(`invalid mutation mode for ${path}`);
     if (
@@ -515,13 +584,8 @@ export function validateDirectPublicationPlan(value: DirectPublicationPlan): Dir
       if (operation.bytes !== 0 || operation.contentBase64 !== undefined) {
         throw new Error(`deleted mutation paths must not carry content: ${path}`);
       }
-      return {
-        path,
-        expectedOid: operation.expectedOid,
-        targetOid: null,
-        mode: "100644",
-        bytes: 0,
-      };
+      operations.push({ ...operation, path, ...tuple, content: null, digest: null, bytes: 0 });
+      continue;
     }
     const contentBase64 = operation.contentBase64;
     if (
@@ -530,20 +594,20 @@ export function validateDirectPublicationPlan(value: DirectPublicationPlan): Dir
     ) {
       throw new Error(`missing or invalid mutation content for ${path}`);
     }
-    const decodedBytes = base64DecodedBytes(contentBase64);
-    if (decodedBytes !== operation.bytes) {
+    const bytes = base64Bytes(contentBase64);
+    if (bytes.byteLength !== operation.bytes) {
       throw new Error(`mutation byte count does not match content for ${path}`);
     }
-    totalBytes += decodedBytes;
-    return {
-      path,
-      expectedOid: operation.expectedOid,
-      targetOid: operation.targetOid,
-      mode: "100644",
-      bytes: decodedBytes,
-      contentBase64,
-    };
-  });
+    let content: string;
+    try {
+      content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      throw new Error(`canonical record content is not UTF-8: ${path}`);
+    }
+    const digest = await sha256Hex(bytes);
+    totalBytes += bytes.byteLength;
+    operations.push({ ...operation, path, ...tuple, contentBase64, content, digest });
+  }
   if (!Number.isSafeInteger(plan.totalBytes) || plan.totalBytes !== totalBytes) {
     throw new Error("direct publication total does not match its operations");
   }
@@ -553,29 +617,93 @@ export function validateDirectPublicationPlan(value: DirectPublicationPlan): Dir
   return {
     itemKey,
     revision: plan.revision,
-    identity: { ...identity, itemKey: identity.itemKey.trim() },
+    identity: { itemKey, revision: plan.revision, claimGeneration: identity.claimGeneration },
     operations,
     totalBytes,
   };
 }
 
-export async function validateDirectPublicationBlobOids(value: DirectPublicationPlan) {
-  const plan = validateDirectPublicationPlan(value);
-  for (const operation of plan.operations) {
-    if (operation.targetOid === null) continue;
-    const content = base64Bytes(operation.contentBase64!);
-    const header = new TextEncoder().encode(`blob ${content.byteLength}\0`);
-    const input = new Uint8Array(header.byteLength + content.byteLength);
-    input.set(header);
-    input.set(content, header.byteLength);
-    const algorithm = operation.targetOid.length === 64 ? "SHA-256" : "SHA-1";
-    const digest = new Uint8Array(await crypto.subtle.digest(algorithm, input));
-    const oid = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-    if (oid !== operation.targetOid) {
-      throw new Error(`prepared mutation target does not match content for ${operation.path}`);
-    }
+// Kept as a compatibility export for callers deployed with the former validator name.
+// The direct path now derives SHA-256 content digests and deliberately ignores Git blob OIDs.
+export const validateDirectPublicationBlobOids = validateDirectPublicationPlan;
+
+function recordTupleProjection(plan: CanonicalDirectPublicationPlan, maxRecordBytes: number) {
+  const operationJson = (operation: CanonicalDirectPublicationOperation, inline: boolean) => ({
+    path: operation.path,
+    repoSlug: operation.repoSlug,
+    section: operation.section,
+    itemId: operation.itemId,
+    digest: operation.digest,
+    revision: plan.revision,
+    bytes: operation.bytes,
+    deleted: operation.content === null,
+    ...(operation.content === null
+      ? {}
+      : inline
+        ? { content: operation.content, oversize: false }
+        : { oversize: true }),
+  });
+  const base = {
+    itemKey: plan.itemKey,
+    revision: plan.revision,
+    claimGeneration: plan.identity.claimGeneration,
+    operations: plan.operations.map((operation) => operationJson(operation, true)),
+  };
+  let payloadJson = JSON.stringify(base);
+  let payloadBytes = new TextEncoder().encode(payloadJson).byteLength;
+  if (payloadBytes > maxRecordBytes) {
+    const oversize = {
+      ...base,
+      operations: plan.operations.map((operation) => operationJson(operation, false)),
+    };
+    payloadJson = JSON.stringify(oversize);
+    payloadBytes = new TextEncoder().encode(payloadJson).byteLength;
+    console.warn(
+      `record tuple projection uses canonical fetch: ${plan.itemKey}@${plan.revision} inline_bytes=${new TextEncoder().encode(JSON.stringify(base)).byteLength} limit=${maxRecordBytes}`,
+    );
   }
-  return plan;
+  if (payloadBytes > maxRecordBytes) {
+    throw new Error(
+      `record tuple projection metadata exceeds append limit: bytes=${payloadBytes} limit=${maxRecordBytes}`,
+    );
+  }
+  const first = plan.operations[0]!;
+  return { key: `${first.repoSlug}/${first.itemId}`, payloadJson, payloadBytes };
+}
+
+function storedOperationsFrom(
+  operations: readonly CanonicalDirectPublicationOperation[],
+): DirectPublicationStoredOperation[] {
+  return operations.map((operation) => ({
+    path: operation.path,
+    bytes: operation.bytes,
+    digest: operation.digest,
+    deleted: operation.content === null,
+  }));
+}
+
+function directPublicationRowFromPlan(options: {
+  plan: CanonicalDirectPublicationPlan;
+  operations: DirectPublicationStoredOperation[];
+  state: DirectPublicationRow["state"];
+  now: number;
+  commitSha: string | null;
+  failureReason: string | null;
+}): DirectPublicationRow {
+  return {
+    itemKey: options.plan.itemKey,
+    revision: options.plan.revision,
+    identity: options.plan.identity,
+    operations: options.operations,
+    totalBytes: options.plan.totalBytes,
+    state: options.state,
+    attempts: 0,
+    createdAt: options.now,
+    updatedAt: options.now,
+    nextAttemptAt: options.now,
+    commitSha: options.commitSha,
+    failureReason: options.failureReason,
+  };
 }
 
 function directPublicationRow(row: Record<string, unknown>): DirectPublicationRow {
@@ -587,7 +715,7 @@ function directPublicationRow(row: Record<string, unknown>): DirectPublicationRo
       revision: Number(row.identity_revision),
       claimGeneration: Number(row.claim_generation),
     },
-    operations: JSON.parse(String(row.operations_json)) as DirectPublicationOperation[],
+    operations: JSON.parse(String(row.operations_json)) as DirectPublicationStoredOperation[],
     totalBytes: Number(row.total_bytes),
     state: row.state as DirectPublicationRow["state"],
     attempts: Number(row.attempts),
@@ -599,7 +727,20 @@ function directPublicationRow(row: Record<string, unknown>): DirectPublicationRo
   };
 }
 
-function canonicalPlan(plan: DirectPublicationPlan) {
+function canonicalIncomingPlan(
+  plan: CanonicalDirectPublicationPlan,
+  operations: DirectPublicationStoredOperation[],
+) {
+  return JSON.stringify({
+    itemKey: plan.itemKey,
+    revision: plan.revision,
+    identity: plan.identity,
+    operations,
+    totalBytes: plan.totalBytes,
+  });
+}
+
+function canonicalStoredPlan(plan: DirectPublicationRow) {
   return JSON.stringify({
     itemKey: plan.itemKey,
     revision: plan.revision,
@@ -609,42 +750,41 @@ function canonicalPlan(plan: DirectPublicationPlan) {
   });
 }
 
-function expectedOidsMatch(row: DirectPublicationRow, paths: ReadonlyMap<string, string>) {
-  return row.operations.every(
-    (operation) => (paths.get(operation.path) ?? null) === operation.expectedOid,
+function legacyPlanMatches(
+  existing: DirectPublicationRow,
+  incoming: CanonicalDirectPublicationPlan,
+): boolean {
+  const operations = existing.operations as DirectPublicationOperation[];
+  return (
+    existing.itemKey === incoming.itemKey &&
+    existing.revision === incoming.revision &&
+    JSON.stringify(existing.identity) === JSON.stringify(incoming.identity) &&
+    existing.totalBytes === incoming.totalBytes &&
+    JSON.stringify(operations) ===
+      JSON.stringify(
+        incoming.operations.map(
+          ({
+            repoSlug: _repoSlug,
+            section: _section,
+            itemId: _itemId,
+            content: _content,
+            digest: _digest,
+            ...operation
+          }) => operation,
+        ),
+      )
   );
 }
 
-function targetOidsMatch(row: DirectPublicationRow, paths: ReadonlyMap<string, string>) {
-  return row.operations.every(
-    (operation) => (paths.get(operation.path) ?? null) === operation.targetOid,
-  );
-}
-
-function compatibleDirectPublicationPlans(rows: readonly DirectPublicationRow[]) {
-  const byPath = new Map<string, DirectPublicationOperation>();
-  const plans: DirectPublicationRow[] = [];
-  const conflicts: DirectPublicationRow[] = [];
-  for (const row of rows) {
-    const incompatible = row.operations.some((operation) => {
-      const existing = byPath.get(operation.path);
-      return Boolean(
-        existing &&
-        (existing.expectedOid !== operation.expectedOid ||
-          existing.targetOid !== operation.targetOid ||
-          existing.mode !== operation.mode ||
-          existing.bytes !== operation.bytes ||
-          existing.contentBase64 !== operation.contentBase64),
-      );
-    });
-    if (incompatible) {
-      conflicts.push(row);
-      continue;
-    }
-    plans.push(row);
-    for (const operation of row.operations) byPath.set(operation.path, operation);
-  }
-  return { plans, conflicts };
+function canonicalTuplePath(path: string) {
+  const match =
+    /^records\/([A-Za-z0-9][A-Za-z0-9_.-]{0,199})\/(items|closed|plans|decision-packets)\/([1-9]\d*)\.(md|json)$/.exec(
+      path,
+    );
+  if (!match) return null;
+  const section = match[2] as RecordSection;
+  if ((section === "decision-packets") !== (match[4] === "json")) return null;
+  return { repoSlug: match[1]!, section, itemId: Number(match[3]) };
 }
 
 function boundedItemKey(value: unknown) {
@@ -670,9 +810,17 @@ function canonicalPath(value: unknown) {
   return path;
 }
 
-function base64DecodedBytes(value: string) {
-  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
-  return (value.length / 4) * 3 - padding;
+function stateAppendWindowTotalsSync(storage: DurableStorage) {
+  const row = Array.from(
+    storage.sql.exec(
+      `SELECT COUNT(*) AS pending_rows, COALESCE(SUM(payload_bytes), 0) AS pending_bytes
+         FROM ${STATE_APPEND_WINDOW_TABLE}`,
+    ),
+  )[0];
+  return {
+    pendingRows: Number(row?.pending_rows || 0),
+    pendingBytes: Number(row?.pending_bytes || 0),
+  };
 }
 
 function base64Bytes(value: string) {
@@ -680,10 +828,21 @@ function base64Bytes(value: string) {
   return Uint8Array.from(binary, (character) => character.charCodeAt(0));
 }
 
-function directPublicationRetryDelayMs(attempt: number) {
-  return Math.min(30 * 60_000, 60_000 * 2 ** Math.min(Math.max(0, attempt - 1), 5));
+function byteChunks(content: string, maximumBytes: number) {
+  const bytes = new TextEncoder().encode(content);
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.byteLength; offset += maximumBytes) {
+    const chunk = bytes.slice(offset, Math.min(bytes.byteLength, offset + maximumBytes));
+    let binary = "";
+    for (const byte of chunk) binary += String.fromCharCode(byte);
+    chunks.push(btoa(binary));
+  }
+  return chunks;
 }
 
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
+async function sha256Hex(bytes: Uint8Array) {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", Uint8Array.from(bytes).buffer),
+  );
+  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -17,14 +17,13 @@ import {
   type PublicationBatchFence,
 } from "./exact-review-publication-batches.ts";
 import {
-  commitDirectPublicationCycle,
-  DirectPublicationRefRaceError,
+  DirectPublicationProjectionCapacityError,
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   ExactReviewDirectPublicationStore,
   validateDirectPublicationBlobOids,
-  type DirectPublicationCommitApi,
+  validateRecordSection,
+  validateRepoSlug,
   type DirectPublicationPlan,
-  type DirectPublicationRow,
 } from "./exact-review-direct-publication.ts";
 import {
   REVIEW_TELEMETRY_DEGRADED_MS,
@@ -296,7 +295,7 @@ type ExactReviewQueueMetricDelta = {
   publicationDeadLettered?: number;
   publicationRefreshed?: number;
 };
-type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof";
+type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof" | "record_tuple";
 type StateAppendRecord = {
   kind: StateAppendKind;
   key: string;
@@ -1700,6 +1699,82 @@ export class ExactReviewQueue {
       return this.reconcilePublicationCandidates(await request.json().catch(() => null));
     }
 
+    const canonicalRecordMatch =
+      request.method === "GET"
+        ? /^\/records\/([^/]+)\/(items|closed|plans|decision-packets)\/([1-9]\d*)$/.exec(
+            url.pathname,
+          )
+        : null;
+    if (canonicalRecordMatch) {
+      const repoSlug = validateRepoSlug(canonicalRecordMatch[1]);
+      const section = validateRecordSection(canonicalRecordMatch[2]);
+      const itemId = Number(canonicalRecordMatch[3]);
+      if (!repoSlug || !section || !Number.isSafeInteger(itemId)) {
+        return json({ error: "invalid_canonical_record_identity" }, 400);
+      }
+      const record = this.directPublicationStore.readCanonical(repoSlug, section, itemId);
+      if (!record || record.deleted) {
+        return json(
+          {
+            error: "record_not_found",
+            ...(record
+              ? {
+                  digest: null,
+                  revision: record.revision,
+                  updatedAt: new Date(record.updatedAt).toISOString(),
+                  deleted: true,
+                }
+              : {}),
+          },
+          404,
+        );
+      }
+      return json({
+        content: record.content,
+        digest: record.digest,
+        revision: record.revision,
+        updatedAt: new Date(record.updatedAt).toISOString(),
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === "/records/list") {
+      const body = objectValue(await request.json().catch(() => null));
+      const repoSlug = validateRepoSlug(body.repoSlug);
+      const section = validateRecordSection(body.section);
+      const cursor = body.cursor === undefined || body.cursor === null ? 0 : Number(body.cursor);
+      const limit = body.limit === undefined ? 100 : Number(body.limit);
+      if (
+        !repoSlug ||
+        !section ||
+        !Number.isSafeInteger(cursor) ||
+        cursor < 0 ||
+        !Number.isSafeInteger(limit) ||
+        limit < 1 ||
+        limit > 500
+      ) {
+        return json({ error: "invalid_canonical_record_listing" }, 400);
+      }
+      const records = this.directPublicationStore.listCanonical({
+        repoSlug,
+        section,
+        cursor,
+        limit,
+      });
+      return json({
+        repoSlug,
+        section,
+        cursor,
+        limit,
+        records: records.map((record) => ({
+          id: record.id,
+          digest: record.digest,
+          revision: record.revision,
+          updatedAt: new Date(record.updatedAt).toISOString(),
+        })),
+        nextCursor: records.length === limit ? (records.at(-1)?.id ?? null) : null,
+      });
+    }
+
     if (request.method === "POST" && url.pathname === "/publication-results") {
       if (!exactReviewDirectPublicationEnabled(this.env)) {
         return json({ error: "direct_publication_disabled", fallback_required: true }, 409);
@@ -1729,6 +1804,7 @@ export class ExactReviewQueue {
         const validated = await validateDirectPublicationBlobOids(plan);
         const state = this.readStateSync();
         const owned = state.items[validated.itemKey];
+        const existing = this.directPublicationStore.get(validated.itemKey, validated.revision);
         const validFence =
           owned &&
           owned.revision === validated.revision &&
@@ -1738,14 +1814,19 @@ export class ExactReviewQueue {
           validated.identity.revision === validated.revision &&
           (owned.state === "leased" ||
             (owned.state === "parked" && owned.parkedReason === "direct_publication"));
-        if (!validFence) {
+        if (!validFence && !existing) {
           return json(
             { error: "direct_publication_fence_not_owned", fallback_required: true },
             409,
           );
         }
-        const accepted = this.directPublicationStore.accept(validated, Date.now());
-        if (accepted.outcome === "accepted") {
+        const now = Date.now();
+        const accepted = this.directPublicationStore.accept(validated, now, {
+          maxRecordBytes: stateAppendMaxRecordBytes(this.env),
+          maxPendingRows: stateAppendMaxPendingRows(this.env),
+          maxPendingBytes: stateAppendMaxPendingBytes(this.env),
+        });
+        if (owned && validFence) {
           const producerDecision = owned.decision.publication
             ? owned.decision.publication.producerDecision
             : (owned.leaseDecision ?? owned.decision);
@@ -1781,17 +1862,30 @@ export class ExactReviewQueue {
           };
           owned.decision = publicationDecision;
           owned.leaseDecision = publicationDecision;
-          owned.state = "parked";
-          owned.parkedReason = "direct_publication";
-          owned.updatedAt = Date.now();
+          const completionKind =
+            accepted.outcome === "superseded" ? ("superseded" as const) : ("published" as const);
+          const terminal = finishExactReviewPublicationQueueItem({
+            state,
+            item: owned,
+            now,
+            completion: {
+              kind: completionKind,
+              reasonCode:
+                completionKind === "published" ? "publication_applied" : "remote_newer_tuple",
+            },
+            ownedRevision: validated.revision,
+            deadLetterCapacityAvailable: true,
+            env: this.env,
+          });
           await this.writeState(state, {
             reviewCompleted: 1,
             publicationEnqueued: 1,
-            ...(accepted.supersededRevisions.length
-              ? {
-                  publicationCompleted: accepted.supersededRevisions.length,
-                  publicationSuperseded: accepted.supersededRevisions.length,
-                }
+            ...(!terminal.requeued && !terminal.parked ? { publicationCompleted: 1 } : {}),
+            ...(completionKind === "published" && !terminal.requeued
+              ? { publicationPublished: 1 }
+              : {}),
+            ...(completionKind === "superseded" && !terminal.requeued
+              ? { publicationSuperseded: 1 }
               : {}),
           });
         }
@@ -1803,10 +1897,25 @@ export class ExactReviewQueue {
             deduped: accepted.outcome === "deduped",
             superseded: accepted.outcome === "superseded",
             superseded_revisions: accepted.supersededRevisions,
+            state_commit_sha: accepted.row.commitSha,
           },
           202,
         );
       } catch (error) {
+        if (error instanceof DirectPublicationProjectionCapacityError) {
+          console.warn(`direct publication projection rejected: ${error.message}`);
+          return json(
+            {
+              error: "direct_publication_projection_capacity",
+              detail: error.message,
+              fallback_required: true,
+            },
+            429,
+          );
+        }
+        console.warn(
+          `direct publication plan rejected: ${error instanceof Error ? error.message : String(error)}`,
+        );
         return json(
           {
             error: "invalid_direct_publication_plan",
@@ -2019,10 +2128,6 @@ export class ExactReviewQueue {
       );
       const publicationBatches = this.batchStore.stats(now);
       const directPublications = this.directPublicationStore.list();
-      const directPending = directPublications.filter(
-        (row) => row.state === "pending" || row.state === "retryable" || row.state === "committing",
-      );
-      const directPendingOutsideQueue = directPending.filter((row) => !state.items[row.itemKey]);
       const batchByItemKey = new Map<string, ExactReviewBayBatchOwner>(
         publicationBatches.activeItemBatches.map((batch) => [batch.itemKey, batch] as const),
       );
@@ -2070,7 +2175,6 @@ export class ExactReviewQueue {
           Object.values(state.items),
           bayPriorityKeys,
           batchByItemKey,
-          directPublications,
         ),
         lanes: {
           review: {
@@ -2082,7 +2186,7 @@ export class ExactReviewQueue {
           },
           publication: {
             ...stats.lanes.publication,
-            pending: stats.lanes.publication.pending + directPendingOutsideQueue.length,
+            pending: stats.lanes.publication.pending,
             enqueued_total: metrics.publication.enqueued,
             completed_total: metrics.publication.completed,
             published_total: metrics.publication.published,
@@ -2138,15 +2242,12 @@ export class ExactReviewQueue {
             },
             direct: {
               enabled: exactReviewDirectPublicationEnabled(this.env),
-              health: githubAppCredentials(this.env)
-                ? { status: "healthy" }
-                : { status: "blocked", reason: "github_app_not_configured" },
-              pending: directPending.length,
-              retryable: directPublications.filter((row) => row.state === "retryable").length,
-              failed: directPublications.filter((row) => row.state === "failed").length,
-              oldest_pending_at: directPending.length
-                ? new Date(Math.min(...directPending.map((row) => row.createdAt))).toISOString()
-                : null,
+              health: { status: "healthy", store: "durable_object_sqlite" },
+              pending: 0,
+              retryable: 0,
+              failed: 0,
+              retained_receipts: directPublications.length,
+              oldest_pending_at: null,
             },
           },
         },
@@ -2173,11 +2274,11 @@ export class ExactReviewQueue {
     this.cleanupLegacyCompatibilitySync();
     const startedAt = Date.now();
     await this.storage.deleteAlarm();
-    await this.publishDirectResultsIfDue(startedAt);
     await this.processSourceAuthorityReservations(startedAt);
     this.storage.transactionSync(() => {
       this.pruneDeliveryReceiptsSync(startedAt);
       this.pruneStateAppendReceiptsSync(startedAt);
+      this.directPublicationStore.pruneTerminalSync(startedAt);
       this.reclaimExpiredStateAppendDrainsSync(startedAt);
       this.reconcileStoredReviewRunsSync(startedAt);
       this.syncLegacyCompatibilitySync(this.readStateSync());
@@ -4611,6 +4712,58 @@ export class ExactReviewQueue {
     this.storage.transactionSync(() => {
       this.backfillPublicationHeadsSync(this.readStateSync(), Date.now());
     });
+    await this.migrateLegacyDirectPublications();
+  }
+
+  private async migrateLegacyDirectPublications() {
+    const plans = this.directPublicationStore.legacyPendingPlans();
+    if (!plans.length) return;
+    const now = Date.now();
+    const state = this.readStateSync();
+    let completed = 0;
+    let published = 0;
+    let superseded = 0;
+    for (const plan of plans) {
+      try {
+        const validated = await validateDirectPublicationBlobOids(plan);
+        const accepted = this.directPublicationStore.accept(validated, now, {
+          maxRecordBytes: stateAppendMaxRecordBytes(this.env),
+          maxPendingRows: stateAppendMaxPendingRows(this.env),
+          maxPendingBytes: stateAppendMaxPendingBytes(this.env),
+        });
+        const item = state.items[validated.itemKey];
+        if (!item || !exactReviewQueueIsPublication(item) || item.revision !== validated.revision) {
+          continue;
+        }
+        const completion =
+          accepted.outcome === "superseded"
+            ? ({ kind: "superseded", reasonCode: "remote_newer_tuple" } as const)
+            : ({ kind: "published", reasonCode: "publication_applied" } as const);
+        const terminal = finishExactReviewPublicationQueueItem({
+          state,
+          item,
+          now,
+          completion,
+          ownedRevision: validated.revision,
+          deadLetterCapacityAvailable: true,
+          env: this.env,
+        });
+        if (!terminal.requeued && !terminal.parked) completed += 1;
+        if (!terminal.requeued && completion.kind === "published") published += 1;
+        if (!terminal.requeued && completion.kind === "superseded") superseded += 1;
+      } catch (error) {
+        console.warn(
+          `legacy direct publication migration deferred for ${plan.itemKey}@${plan.revision}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    if (completed || published || superseded) {
+      await this.writeState(state, {
+        publicationCompleted: completed,
+        publicationPublished: published,
+        publicationSuperseded: superseded,
+      });
+    }
   }
 
   private ensureStorageSchemaSync() {
@@ -4658,7 +4811,7 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_WINDOW_TABLE} (
          seq INTEGER PRIMARY KEY AUTOINCREMENT,
-         kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof')),
+         kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple')),
          record_key TEXT NOT NULL,
          payload_json TEXT NOT NULL,
          payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
@@ -4667,6 +4820,39 @@ export class ExactReviewQueue {
          drain_token TEXT
        ) STRICT`,
     );
+    const stateAppendTableRow = Array.from(
+      this.storage.sql.exec(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`,
+        STATE_APPEND_WINDOW_TABLE,
+      ),
+    )[0] as { sql?: string } | undefined;
+    const stateAppendTableSql = String(stateAppendTableRow?.sql || "");
+    if (!stateAppendTableSql.includes("'record_tuple'")) {
+      this.storage.transactionSync(() => {
+        this.storage.sql.exec(
+          `CREATE TABLE state_append_window_v2 (
+             seq INTEGER PRIMARY KEY AUTOINCREMENT,
+             kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple')),
+             record_key TEXT NOT NULL,
+             payload_json TEXT NOT NULL,
+             payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
+             produced_at TEXT NOT NULL,
+             delivery_id TEXT NOT NULL,
+             drain_token TEXT
+           ) STRICT`,
+        );
+        this.storage.sql.exec(
+          `INSERT INTO state_append_window_v2
+             (seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token)
+           SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token
+             FROM ${STATE_APPEND_WINDOW_TABLE}`,
+        );
+        this.storage.sql.exec(`DROP TABLE ${STATE_APPEND_WINDOW_TABLE}`);
+        this.storage.sql.exec(
+          `ALTER TABLE state_append_window_v2 RENAME TO ${STATE_APPEND_WINDOW_TABLE}`,
+        );
+      });
+    }
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS state_append_window_drain_seq
          ON ${STATE_APPEND_WINDOW_TABLE} (drain_token, seq)`,
@@ -6528,14 +6714,12 @@ export class ExactReviewQueue {
       this.freshPublicationItemKeysSync(state, now),
     );
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
-    const directPublicationNext = this.directPublicationStore.nextWakeAt(now);
     const next = [
       queueNext,
       reviewNext,
       batchOwnership.nextLeaseExpiresAt,
       batchDeparture?.dueAt ?? null,
       sourceAuthorityNext,
-      directPublicationNext,
     ]
       .filter((candidate): candidate is number => candidate !== null)
       .reduce<number | null>(
@@ -6550,121 +6734,6 @@ export class ExactReviewQueue {
     if (scheduled === null || scheduled <= now || next < scheduled) {
       await this.storage.setAlarm(next);
     }
-  }
-
-  private async publishDirectResultsIfDue(now: number) {
-    const queueState = this.readStateSync();
-    const stale = this.directPublicationStore.list().filter((row) => {
-      if (row.state !== "pending" && row.state !== "retryable") return false;
-      const item = queueState.items[row.itemKey];
-      return (
-        !item ||
-        item.revision !== row.revision ||
-        !exactReviewQueueIsPublication(item) ||
-        item.parkedReason !== "direct_publication"
-      );
-    });
-    if (stale.length) {
-      this.directPublicationStore.supersede(stale, now);
-      this.incrementQueueMetricsSync({
-        publicationCompleted: stale.length,
-        publicationSuperseded: stale.length,
-      });
-    }
-    const next = this.directPublicationStore.nextWakeAt(now);
-    if (next === null || next > now) return;
-    try {
-      const result = await commitDirectPublicationCycle({
-        store: this.directPublicationStore,
-        api: await exactReviewDirectPublicationApi(this.env),
-        now,
-      });
-      if (result.published.length) {
-        const state = this.readStateSync();
-        let completed = 0;
-        let published = 0;
-        for (const row of result.published) {
-          const item = state.items[row.itemKey];
-          if (!item || !exactReviewQueueIsPublication(item)) continue;
-          const terminal = finishExactReviewPublicationQueueItem({
-            state,
-            item,
-            now,
-            completion: { kind: "published", reasonCode: "publication_applied" },
-            ownedRevision: row.revision,
-            deadLetterCapacityAvailable: true,
-            env: this.env,
-          });
-          if (!terminal.requeued && !terminal.parked) completed += 1;
-          if (!terminal.requeued) published += 1;
-        }
-        await this.writeState(state, {
-          publicationCompleted: completed,
-          publicationPublished: published,
-        });
-      }
-      if (result.retryable.length) {
-        await this.recordDirectPublicationRetries(result.retryable, now);
-      }
-    } catch (error) {
-      const deferred = this.directPublicationStore.claimCycle(now);
-      if (deferred.length) {
-        this.directPublicationStore.retry(
-          deferred,
-          error instanceof Error ? error.message : String(error),
-          now,
-        );
-        await this.recordDirectPublicationRetries(deferred, now);
-      }
-      console.error(
-        "direct exact-review publication unavailable",
-        error instanceof Error ? error.message : String(error),
-      );
-    }
-  }
-
-  private async recordDirectPublicationRetries(rows: readonly DirectPublicationRow[], now: number) {
-    const failed = new Set(
-      this.directPublicationStore
-        .list()
-        .filter((row) => row.state === "failed")
-        .map((row) => `${row.itemKey}\0${row.revision}`),
-    );
-    const exhausted = rows.filter((row) => failed.has(`${row.itemKey}\0${row.revision}`));
-    if (!exhausted.length) {
-      this.incrementQueueMetricsSync({ publicationRetried: rows.length });
-      return;
-    }
-    const state = this.readStateSync();
-    let completed = 0;
-    let deadLettered = 0;
-    for (const row of exhausted) {
-      const item = state.items[row.itemKey];
-      if (!item || !exactReviewQueueIsPublication(item) || item.revision !== row.revision) continue;
-      item.publicationFailureAttempts = EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_LIMIT - 1;
-      item.firstFailureAt ??= now;
-      const terminal = finishExactReviewPublicationQueueItem({
-        state,
-        item,
-        now,
-        completion: { kind: "retryable_failure", reasonCode: "state_contention" },
-        ownedRevision: row.revision,
-        deadLetterCapacityAvailable: this.deadLetterCapacityAvailableSync(
-          exactReviewDeadLetterId(item, row.revision),
-        ),
-        env: this.env,
-      });
-      if (terminal.deadLetter) {
-        this.insertDeadLetterSync(terminal.deadLetter);
-        deadLettered += 1;
-      }
-      if (!terminal.requeued && !terminal.parked) completed += 1;
-    }
-    await this.writeState(state, {
-      publicationRetried: rows.length - exhausted.length,
-      publicationCompleted: completed,
-      publicationDeadLettered: deadLettered,
-    });
   }
 }
 
@@ -7925,7 +7994,6 @@ function exactReviewQueueBayProjection(
   items: ExactReviewQueueItem[],
   priorityItemKeys: string[] = [],
   batchByItemKey: ReadonlyMap<string, ExactReviewBayBatchOwner> = new Map(),
-  directPublications: readonly DirectPublicationRow[] = [],
 ) {
   const projected = new Map<string, ExactReviewBayProjectionItem>();
   for (const item of items) {
@@ -7961,26 +8029,6 @@ function exactReviewQueueBayProjection(
         exactReviewQueueBayStagePriority(candidate.stage) >
           exactReviewQueueBayStagePriority(previous.stage))
     ) {
-      projected.set(candidate.item_key, candidate);
-    }
-  }
-  for (const row of directPublications) {
-    if (row.state === "published" || row.state === "superseded") continue;
-    const match = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([1-9]\d*)$/.exec(row.itemKey);
-    if (!match) continue;
-    const candidate: ExactReviewBayProjectionItem = {
-      item_key: row.itemKey,
-      repository: match[1],
-      item_number: Number(match[2]),
-      stage: row.state === "failed" ? "repairing" : "publishing",
-      queue_state:
-        row.state === "failed" ? "parked" : row.state === "committing" ? "leased" : "pending",
-      created_at: new Date(row.createdAt).toISOString(),
-      updated_at: new Date(row.updatedAt).toISOString(),
-      next_attempt_at: new Date(row.nextAttemptAt).toISOString(),
-    };
-    const previous = projected.get(candidate.item_key);
-    if (!previous || Date.parse(candidate.updated_at) >= Date.parse(previous.updated_at)) {
       projected.set(candidate.item_key, candidate);
     }
   }
@@ -9451,129 +9499,6 @@ async function exactReviewTargetItemState(
 
 export async function exactReviewActionsReadToken(env) {
   return exactReviewRepositoryToken(env, { actions: "read" });
-}
-
-async function exactReviewDirectPublicationApi(env): Promise<DirectPublicationCommitApi> {
-  const stateRepo = String(env.EXACT_REVIEW_STATE_REPO || "openclaw/clawsweeper-state").trim();
-  const stateRef = String(env.EXACT_REVIEW_STATE_REF || "state").trim();
-  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(stateRepo)) {
-    throw new Error("EXACT_REVIEW_STATE_REPO is invalid");
-  }
-  if (!/^[A-Za-z0-9_./-]+$/.test(stateRef)) {
-    throw new Error("EXACT_REVIEW_STATE_REF is invalid");
-  }
-  const credentials = githubAppCredentials(env);
-  if (!credentials) {
-    throw new Error("direct publication health: GitHub App private key is not configured");
-  }
-  const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
-  const installationId = await githubAppInstallationId(appJwt, stateRepo);
-  // This token is deliberately separate from dashboard reads: one repository,
-  // contents:write only, and no inherited issue, action, or pull-request scope.
-  const token = await createGithubAppTokenFor({
-    appJwt,
-    installationId,
-    label: stateRepo,
-    repositories: [repoName(stateRepo)],
-    permissions: { contents: "write" },
-  });
-  const api = (path: string, method = "GET", body?: unknown, errorLabel?: string) =>
-    githubTokenJson({ token, path: `/repos/${stateRepo}${path}`, method, body, errorLabel });
-  return {
-    async readHead() {
-      const ref = await api(
-        `/git/ref/heads/${stateRef}`,
-        "GET",
-        undefined,
-        "direct publication state ref",
-      );
-      const commitSha = String(objectValue(ref.object).sha || "").toLowerCase();
-      if (!/^[a-f0-9]{40,64}$/.test(commitSha)) {
-        throw new Error("direct publication state ref response missing commit SHA");
-      }
-      const commit = await api(
-        `/git/commits/${commitSha}`,
-        "GET",
-        undefined,
-        "direct publication state commit",
-      );
-      const treeSha = String(objectValue(commit.tree).sha || "").toLowerCase();
-      if (!/^[a-f0-9]{40,64}$/.test(treeSha)) {
-        throw new Error("direct publication state commit response missing tree SHA");
-      }
-      const tree = await api(
-        `/git/trees/${treeSha}?recursive=1`,
-        "GET",
-        undefined,
-        "direct publication state tree",
-      );
-      if (tree.truncated === true || !Array.isArray(tree.tree)) {
-        throw new Error("direct publication state tree is unavailable or truncated");
-      }
-      const paths = new Map<string, string>();
-      for (const raw of tree.tree) {
-        const entry = objectValue(raw);
-        const path = String(entry.path || "");
-        const sha = String(entry.sha || "").toLowerCase();
-        if (entry.type === "blob" && path && /^[a-f0-9]{40,64}$/.test(sha)) paths.set(path, sha);
-      }
-      return { commitSha, treeSha, paths };
-    },
-    async createBlob(contentBase64) {
-      const blob = await api(
-        "/git/blobs",
-        "POST",
-        { content: contentBase64, encoding: "base64" },
-        "direct publication blob",
-      );
-      const sha = String(blob.sha || "").toLowerCase();
-      if (!/^[a-f0-9]{40,64}$/.test(sha)) {
-        throw new Error("direct publication blob response missing SHA");
-      }
-      return sha;
-    },
-    async createTree(baseTreeSha, entries) {
-      const tree = await api(
-        "/git/trees",
-        "POST",
-        { base_tree: baseTreeSha, tree: entries },
-        "direct publication tree",
-      );
-      const sha = String(tree.sha || "").toLowerCase();
-      if (!/^[a-f0-9]{40,64}$/.test(sha)) {
-        throw new Error("direct publication tree response missing SHA");
-      }
-      return sha;
-    },
-    async createCommit(message, treeSha, parentSha) {
-      const commit = await api(
-        "/git/commits",
-        "POST",
-        { message, tree: treeSha, parents: [parentSha] },
-        "direct publication commit",
-      );
-      const sha = String(commit.sha || "").toLowerCase();
-      if (!/^[a-f0-9]{40,64}$/.test(sha)) {
-        throw new Error("direct publication commit response missing SHA");
-      }
-      return sha;
-    },
-    async updateRef(commitSha) {
-      try {
-        await api(
-          `/git/refs/heads/${stateRef}`,
-          "PATCH",
-          { sha: commitSha, force: false },
-          "direct publication state ref update",
-        );
-      } catch (error) {
-        if (error instanceof GitHubRequestError && error.status === 422) {
-          throw new DirectPublicationRefRaceError();
-        }
-        throw error;
-      }
-    },
-  };
 }
 
 async function exactReviewRepositoryToken(env, permissions) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -541,6 +541,20 @@ export default {
       return githubWebhook(request, env, ctx);
     if (url.pathname === "/internal/exact-review/enqueue" && request.method === "POST")
       return authenticatedExactReviewEnqueue(request, env);
+    const canonicalRecordPath =
+      request.method === "GET"
+        ? /^\/internal\/state\/records\/[^/]+\/(?:items|closed|plans|decision-packets)\/[1-9]\d*$/.exec(
+            url.pathname,
+          )
+        : null;
+    if (canonicalRecordPath)
+      return authenticatedExactReviewQueueRead(
+        request,
+        env,
+        url.pathname.slice("/internal/state".length),
+      );
+    if (url.pathname === "/internal/state/records/list" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/list");
     if (url.pathname === "/internal/state/append" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/state/append");
     if (url.pathname === "/internal/state/drain" && request.method === "POST")
@@ -1564,7 +1578,7 @@ async function exactReviewQueueRequest(env, path, request?: Request) {
     new Request(`https://clawsweeper-exact-review-queue${path}`, {
       method: request?.method || "GET",
       headers: body ? { "content-type": "application/json" } : undefined,
-      body,
+      ...(body ? { body } : {}),
     }),
   );
 }
@@ -1629,6 +1643,21 @@ async function authenticatedExactReviewQueueRequest(request, env, path: string) 
       headers: { "content-type": "application/json" },
       body,
     }),
+  );
+}
+
+async function authenticatedExactReviewQueueRead(request, env, path: string) {
+  const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
+  if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const body = await request.text();
+  const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
+  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+  return exactReviewQueueRequest(
+    env,
+    path,
+    new Request(`https://clawsweeper-exact-review-queue${path}`, { method: "GET" }),
   );
 }
 

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +12,7 @@ import {
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
 import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
 import { publishMainCommit } from "./git-publish.js";
+import { recordTuplePaths, validateRecordTuple, type RecordTupleContents } from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 
 export const DEFAULT_STATE_MATERIALIZER_MAX_ROWS = 2_000;
@@ -26,9 +27,30 @@ const STATE_APPEND_KINDS = new Set<StateAppendKind>([
   "sweep_status",
   "comment_router",
   "apply_proof",
+  "record_tuple",
 ]);
 
-export type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof";
+export type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof" | "record_tuple";
+
+type RecordTupleProjectionOperation = {
+  path: string;
+  repoSlug: string;
+  section: "items" | "closed" | "plans" | "decision-packets";
+  itemId: number;
+  digest: string | null;
+  revision: number;
+  bytes: number;
+  deleted: boolean;
+  content?: string;
+  oversize?: boolean;
+};
+
+type RecordTupleProjection = {
+  itemKey: string;
+  revision: number;
+  claimGeneration: number;
+  operations: RecordTupleProjectionOperation[];
+};
 
 export type StateAppendRecord = {
   seq: number;
@@ -175,6 +197,40 @@ export function planStateMaterialization(
       continue;
     }
 
+    if (record.kind === "record_tuple") {
+      const tuple = recordTupleProjection(record);
+      for (const operation of tuple.operations) {
+        addPublishPath(operation.path);
+        if (operation.deleted) {
+          contentByPath.delete(operation.path);
+          if (currentFiles.has(operation.path)) deletes.add(operation.path);
+        } else {
+          if (typeof operation.content !== "string" || operation.oversize) {
+            throw new Error(`record tuple content was not hydrated: ${operation.path}`);
+          }
+          contentByPath.set(operation.path, operation.content);
+          deletes.delete(operation.path);
+        }
+      }
+      const paths = recordTuplePaths({
+        repository: tuple.operations[0]!.repoSlug,
+        number: String(tuple.operations[0]!.itemId),
+      });
+      const target = (path: string): string | null => {
+        if (deletes.has(path)) return null;
+        return contentByPath.get(path) ?? currentFiles.get(path) ?? null;
+      };
+      const contents: RecordTupleContents = {
+        paths,
+        item: target(paths.item),
+        closed: target(paths.closed),
+        plan: target(paths.plan),
+        packet: target(paths.packet),
+      };
+      validateRecordTuple(contents, `record tuple projection ${record.key}`);
+      continue;
+    }
+
     const path = record.key;
     const content = serializeApplyProof(path, record.payload);
     const current = currentFiles.get(path);
@@ -273,18 +329,38 @@ export async function runStateMaterializer(
     try {
       if (!drain.token) throw new Error("non-empty state drain omitted its token");
       const selected = selectLatestStateRecords(drain.records);
-      const currentFiles = readCurrentFiles(materializationPaths(selected.records), process.cwd());
-      const plan = planStateMaterialization(drain.records, currentFiles);
-      applyStateMaterializationPlan(plan, process.cwd());
-      publishMainCommit({
-        message: STATE_MATERIALIZER_COMMIT_MESSAGE,
-        paths: plan.publishPaths,
-        branch,
-        maxAttempts: publishMaxAttempts,
-        pushAttempts: publishPushAttempts,
+      const hydrated = await hydrateRecordTupleRecords({
+        records: selected.records,
+        queueUrl,
+        webhookSecret,
+        fetchImpl,
       });
+      const currentFiles = readCurrentFiles(materializationPaths(hydrated.records), process.cwd());
+      const plan = planStateMaterialization(hydrated.records, currentFiles);
+      applyStateMaterializationPlan(plan, process.cwd());
+      const recordTuplePaths = plan.publishPaths.filter(isRecordTupleProjectionPath);
+      const regularPaths = plan.publishPaths.filter((path) => !isRecordTupleProjectionPath(path));
+      if (regularPaths.length > 0) {
+        publishMainCommit({
+          message: STATE_MATERIALIZER_COMMIT_MESSAGE,
+          paths: regularPaths,
+          branch,
+          maxAttempts: publishMaxAttempts,
+          pushAttempts: publishPushAttempts,
+        });
+      }
+      if (recordTuplePaths.length > 0) {
+        publishMainCommit({
+          message: STATE_MATERIALIZER_COMMIT_MESSAGE,
+          paths: recordTuplePaths,
+          branch,
+          maxAttempts: publishMaxAttempts,
+          pushAttempts: publishPushAttempts,
+          rebaseStrategy: "reconcile-records",
+        });
+      }
       summary.committed += plan.selected;
-      summary.skipped += plan.skipped;
+      summary.skipped += selected.skipped + hydrated.skipped + plan.skipped;
 
       const acked = await ackStateWindow({
         queueUrl,
@@ -335,6 +411,22 @@ export function applyStateMaterializationPlan(plan: StateMaterializationPlan, ro
 function materializationPaths(records: readonly StateAppendRecord[]): string[] {
   const paths: string[] = [];
   for (const record of records) {
+    if (record.kind === "record_tuple") {
+      const tuple = recordTupleProjection(record);
+      const tuplePaths = recordTuplePaths({
+        repository: tuple.operations[0]!.repoSlug,
+        number: String(tuple.operations[0]!.itemId),
+      });
+      for (const recordPath of [
+        tuplePaths.item,
+        tuplePaths.closed,
+        tuplePaths.plan,
+        tuplePaths.packet,
+      ]) {
+        if (!paths.includes(recordPath)) paths.push(recordPath);
+      }
+      continue;
+    }
     const path =
       record.kind === "sweep_status"
         ? sweepStatusPathForStateKey(record.key)
@@ -363,6 +455,187 @@ function readCurrentFiles(paths: readonly string[], root: string): Map<string, s
     if (existsSync(target)) files.set(path, readFileSync(target, "utf8"));
   }
   return files;
+}
+
+async function hydrateRecordTupleRecords(options: {
+  records: readonly StateAppendRecord[];
+  queueUrl: string;
+  webhookSecret: string;
+  fetchImpl: typeof fetch;
+}): Promise<{ records: StateAppendRecord[]; skipped: number }> {
+  const records: StateAppendRecord[] = [];
+  let skipped = 0;
+  for (const record of options.records) {
+    if (record.kind !== "record_tuple") {
+      records.push(record);
+      continue;
+    }
+    const tuple = recordTupleProjection(record);
+    const operations: RecordTupleProjectionOperation[] = [];
+    let superseded = false;
+    for (const operation of tuple.operations) {
+      if (!operation.oversize) {
+        operations.push(operation);
+        continue;
+      }
+      const fetched = await fetchCanonicalRecord({
+        queueUrl: options.queueUrl,
+        webhookSecret: options.webhookSecret,
+        operation,
+        fetchImpl: options.fetchImpl,
+      });
+      if (fetched.kind === "superseded") {
+        superseded = true;
+        break;
+      }
+      operations.push({ ...operation, content: fetched.content, oversize: false });
+    }
+    if (superseded) {
+      skipped += 1;
+      console.warn(`record tuple projection superseded before oversize fetch: ${record.key}`);
+      continue;
+    }
+    records.push({ ...record, payload: { ...tuple, operations } });
+  }
+  return { records, skipped };
+}
+
+async function fetchCanonicalRecord(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  operation: RecordTupleProjectionOperation;
+  fetchImpl: typeof fetch;
+}): Promise<{ kind: "fetched"; content: string } | { kind: "superseded" }> {
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update("").digest("hex")}`;
+  const path = `/internal/state/records/${encodeURIComponent(options.operation.repoSlug)}/${options.operation.section}/${options.operation.itemId}`;
+  const response = await options.fetchImpl(`${options.queueUrl}${path}`, {
+    method: "GET",
+    headers: { "x-clawsweeper-exact-review-signature": signature },
+  });
+  const body = (await response.json().catch(() => null)) as unknown;
+  if (!isRecord(body)) throw new Error(`GET ${path} returned invalid JSON`);
+  const revision = Number(body.revision);
+  if (Number.isSafeInteger(revision) && revision > options.operation.revision) {
+    return { kind: "superseded" };
+  }
+  if (!response.ok) throw new Error(`GET ${path} returned ${response.status}`);
+  const content = body.content;
+  const digest = String(body.digest || "");
+  if (
+    revision !== options.operation.revision ||
+    typeof content !== "string" ||
+    digest !== options.operation.digest
+  ) {
+    throw new Error(`canonical record fence mismatch for ${options.operation.path}`);
+  }
+  assertProjectedContent(options.operation, content);
+  return { kind: "fetched", content };
+}
+
+function recordTupleProjection(record: StateAppendRecord): RecordTupleProjection {
+  if (!isRecord(record.payload))
+    throw new Error(`record tuple payload must be an object: ${record.key}`);
+  const itemKey = String(record.payload.itemKey || "").trim();
+  const revision = Number(record.payload.revision);
+  const claimGeneration = Number(record.payload.claimGeneration);
+  const itemMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#([1-9]\d*)$/.exec(itemKey);
+  if (
+    !itemMatch ||
+    !Number.isSafeInteger(revision) ||
+    revision < 1 ||
+    !Number.isSafeInteger(claimGeneration) ||
+    claimGeneration < 1 ||
+    !Array.isArray(record.payload.operations) ||
+    record.payload.operations.length < 1 ||
+    record.payload.operations.length > 4
+  ) {
+    throw new Error(`invalid record tuple projection fence: ${record.key}`);
+  }
+  const repoSlug = `${itemMatch[1]}-${itemMatch[2]}`;
+  const itemId = Number(itemMatch[3]);
+  if (record.key !== `${repoSlug}/${itemId}`) {
+    throw new Error(`record tuple key does not match its item fence: ${record.key}`);
+  }
+  const seen = new Set<string>();
+  const operations = record.payload.operations.map((value): RecordTupleProjectionOperation => {
+    if (!isRecord(value))
+      throw new Error(`record tuple operation must be an object: ${record.key}`);
+    const hasContent = Object.hasOwn(value, "content");
+    if (hasContent && typeof value.content !== "string") {
+      throw new Error(`record tuple operation has invalid content: ${record.key}`);
+    }
+    const operation = {
+      path: String(value.path || ""),
+      repoSlug: String(value.repoSlug || ""),
+      section: String(value.section || "") as RecordTupleProjectionOperation["section"],
+      itemId: Number(value.itemId),
+      digest: value.digest === null ? null : String(value.digest || ""),
+      revision: Number(value.revision),
+      bytes: Number(value.bytes),
+      deleted: value.deleted === true,
+      ...(hasContent ? { content: value.content as string } : {}),
+      ...(Object.hasOwn(value, "oversize") ? { oversize: value.oversize === true } : {}),
+    };
+    const extension = operation.section === "decision-packets" ? "json" : "md";
+    const expectedPath = `records/${repoSlug}/${operation.section}/${itemId}.${extension}`;
+    if (
+      operation.repoSlug !== repoSlug ||
+      operation.itemId !== itemId ||
+      operation.revision !== revision ||
+      !["items", "closed", "plans", "decision-packets"].includes(operation.section) ||
+      operation.path !== expectedPath ||
+      seen.has(operation.path) ||
+      !Number.isSafeInteger(operation.bytes) ||
+      operation.bytes < 0 ||
+      operation.bytes > 2 * 1024 * 1024
+    ) {
+      throw new Error(`invalid record tuple operation: ${operation.path || record.key}`);
+    }
+    seen.add(operation.path);
+    if (operation.deleted) {
+      if (
+        operation.digest !== null ||
+        operation.bytes !== 0 ||
+        operation.content !== undefined ||
+        operation.oversize
+      ) {
+        throw new Error(`invalid deleted record tuple operation: ${operation.path}`);
+      }
+      return operation;
+    }
+    if (!/^[a-f0-9]{64}$/.test(operation.digest || "")) {
+      throw new Error(`invalid record tuple digest: ${operation.path}`);
+    }
+    if (operation.oversize) {
+      if (operation.content !== undefined) {
+        throw new Error(
+          `oversize record tuple operation carried inline content: ${operation.path}`,
+        );
+      }
+      return operation;
+    }
+    if (typeof operation.content !== "string") {
+      throw new Error(`record tuple operation omitted content: ${operation.path}`);
+    }
+    assertProjectedContent(operation, operation.content);
+    return operation;
+  });
+  return { itemKey, revision, claimGeneration, operations };
+}
+
+function assertProjectedContent(operation: RecordTupleProjectionOperation, content: string): void {
+  const bytes = Buffer.byteLength(content);
+  const digest = createHash("sha256").update(content).digest("hex");
+  if (bytes !== operation.bytes || digest !== operation.digest) {
+    throw new Error(`record tuple content does not match its digest: ${operation.path}`);
+  }
+}
+
+function isRecordTupleProjectionPath(path: string): boolean {
+  return (
+    /^records\/[^/]+\/(?:items|closed|plans)\/[^/]+\.md$/.test(path) ||
+    /^records\/[^/]+\/decision-packets\/\d+\.json$/.test(path)
+  );
 }
 
 async function drainStateWindow(options: {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1826,13 +1826,63 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
       env,
     );
     assert.equal(response.status, 202);
-    assert.deepEqual(await response.json(), {
+    const responseBody = await response.json();
+    assert.deepEqual(responseBody, {
       ok: true,
       ...expected,
       superseded: false,
       superseded_revisions: [],
+      state_commit_sha: "do-txn:1",
     });
   }
+
+  const recordUrl =
+    "https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/items/701";
+  const unsignedRecord = await worker.fetch(new Request(recordUrl), env);
+  assert.equal(unsignedRecord.status, 401);
+  const emptySignature = `sha256=${createHmac("sha256", "test-secret").update("").digest("hex")}`;
+  const recordResponse = await worker.fetch(
+    new Request(recordUrl, {
+      headers: { "x-clawsweeper-exact-review-signature": emptySignature },
+    }),
+    env,
+  );
+  assert.equal(recordResponse.status, 200);
+  const record = await recordResponse.json();
+  assert.deepEqual(record, {
+    content: "x",
+    digest: createHash("sha256").update("x").digest("hex"),
+    revision: 4,
+    updatedAt: record.updatedAt,
+  });
+  assert.equal(Number.isFinite(Date.parse(record.updatedAt)), true);
+
+  const listingBody = JSON.stringify({
+    repoSlug: "openclaw-openclaw",
+    section: "items",
+    cursor: 0,
+    limit: 500,
+  });
+  const listingSignature = `sha256=${createHmac("sha256", "test-secret").update(listingBody).digest("hex")}`;
+  const listingResponse = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/state/records/list", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": listingSignature },
+      body: listingBody,
+    }),
+    env,
+  );
+  assert.equal(listingResponse.status, 200);
+  const listing = await listingResponse.json();
+  assert.deepEqual(listing.records, [
+    {
+      id: 701,
+      digest: createHash("sha256").update("x").digest("hex"),
+      revision: 4,
+      updatedAt: listing.records[0].updatedAt,
+    },
+  ]);
+  assert.equal(listing.nextCursor, null);
 
   const oversizedBody = JSON.stringify({ ...payload, padding: "x".repeat(4 * 1024 * 1024) });
   const oversizedSignature = `sha256=${createHmac("sha256", "test-secret").update(oversizedBody).digest("hex")}`;

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -5,8 +5,8 @@ import test from "node:test";
 
 import { ExactReviewPublicationBatchStore } from "../dashboard/exact-review-publication-batches.ts";
 import {
-  commitDirectPublicationCycle,
-  DirectPublicationRefRaceError,
+  EXACT_REVIEW_CANONICAL_INLINE_BYTES,
+  EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS,
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   ExactReviewDirectPublicationStore,
   validateDirectPublicationPlan,
@@ -67,6 +67,10 @@ class TestStorage {
     this.database.exec(query);
   }
 
+  run(query: string, ...bindings: unknown[]) {
+    this.database.prepare(query).run(...bindings);
+  }
+
   async get(key: string) {
     return this.values.get(key);
   }
@@ -115,18 +119,33 @@ const candidates = [
 function directPlan(
   itemKey: string,
   revision: number,
-  options: { path?: string; expectedOid?: string | null; content?: Buffer; files?: number } = {},
+  options: {
+    path?: string;
+    expectedOid?: string | null;
+    targetOid?: string | null;
+    content?: Buffer;
+    files?: number;
+  } = {},
 ): DirectPublicationPlan {
   const content = options.content ?? Buffer.from(`result-${revision}`);
   const files = options.files ?? 1;
+  const match = /^([^/]+)\/([^#]+)#(\d+)$/.exec(itemKey)!;
+  const root = `records/${match[1]}-${match[2]}`;
+  const number = match[3];
+  const tuplePaths = [
+    `${root}/items/${number}.md`,
+    `${root}/plans/${number}.md`,
+    `${root}/decision-packets/${number}.json`,
+    `${root}/closed/${number}.md`,
+  ];
   return {
     itemKey,
     revision,
     identity: { itemKey, revision, claimGeneration: 1 },
     operations: Array.from({ length: files }, (_, index) => ({
-      path: options.path ?? `records/repo/items/${revision}-${index}.md`,
+      path: options.path ?? tuplePaths[index]!,
       expectedOid: options.expectedOid ?? null,
-      targetOid: "a".repeat(40),
+      targetOid: options.targetOid === undefined ? "a".repeat(40) : options.targetOid,
       mode: "100644" as const,
       bytes: content.byteLength,
       contentBase64: content.toString("base64"),
@@ -135,145 +154,167 @@ function directPlan(
   };
 }
 
-test("direct publication plans dedupe producer retries and ratchet newer revisions", () => {
+const projectionLimits = {
+  maxRecordBytes: 256 * 1024,
+  maxPendingRows: 50_000,
+  maxPendingBytes: 100 * 1024 * 1024,
+};
+
+function ensureProjectionSchema(storage: TestStorage) {
+  storage.exec(`CREATE TABLE state_append_window (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    record_key TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    payload_bytes INTEGER NOT NULL,
+    produced_at TEXT NOT NULL,
+    delivery_id TEXT NOT NULL,
+    drain_token TEXT
+  ) STRICT`);
+}
+
+test("direct publication canonically stores, projects, dedupes, and ratchets revisions", async () => {
   const storage = new TestStorage();
+  ensureProjectionSchema(storage);
   const store = new ExactReviewDirectPublicationStore(storage);
   store.ensureSchemaSync();
 
-  assert.equal(store.accept(directPlan("openclaw/openclaw#1", 1), 1_000).outcome, "accepted");
-  assert.equal(store.accept(directPlan("openclaw/openclaw#1", 1), 1_001).outcome, "deduped");
-  const newer = store.accept(directPlan("openclaw/openclaw#1", 2), 1_002);
+  const first = await validateDirectPublicationPlan(directPlan("openclaw/openclaw#1", 1));
+  const accepted = store.accept(first, 1_000, projectionLimits);
+  assert.equal(accepted.outcome, "accepted");
+  assert.match(accepted.row.commitSha || "", /^do-txn:\d+$/);
+  assert.equal(store.accept(first, 1_001, projectionLimits).outcome, "deduped");
+  const newer = store.accept(
+    await validateDirectPublicationPlan(directPlan("openclaw/openclaw#1", 2)),
+    1_002,
+    projectionLimits,
+  );
+  assert.equal(newer.outcome, "accepted");
 
-  assert.deepEqual(newer.supersededRevisions, [1]);
+  const record = store.readCanonical("openclaw-openclaw", "items", 1);
+  assert.equal(record?.content, "result-2");
+  assert.equal(record?.revision, 2);
+  assert.match(record?.digest || "", /^[a-f0-9]{64}$/);
+  assert.equal(storage.scalar("SELECT COUNT(*) AS value FROM state_append_window"), 2);
   assert.deepEqual(
     store.list().map((row) => [row.revision, row.state]),
     [
-      [1, "superseded"],
-      [2, "pending"],
+      [1, "published"],
+      [2, "published"],
     ],
   );
 });
 
-test("direct publication alarm cadence fires at 15 seconds or 64 staged files", () => {
+test("direct publication idempotency compares canonical digests instead of Git OIDs", async () => {
   const storage = new TestStorage();
+  ensureProjectionSchema(storage);
   const store = new ExactReviewDirectPublicationStore(storage);
   store.ensureSchemaSync();
-  store.accept(directPlan("openclaw/openclaw#2", 1, { files: 63 }), 1_000);
-  assert.equal(store.nextWakeAt(1_000), 16_000);
-  store.accept(directPlan("openclaw/openclaw#3", 1), 2_000);
-  assert.equal(store.nextWakeAt(2_000), 2_000);
+  const first = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#2", 1, {
+      expectedOid: "b".repeat(40),
+      targetOid: "c".repeat(40),
+    }),
+  );
+  store.accept(first, 1_000, projectionLimits);
+  const retry = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#2", 1, {
+      expectedOid: "d".repeat(40),
+      targetOid: "e".repeat(40),
+    }),
+  );
+  assert.equal(store.accept(retry, 1_001, projectionLimits).outcome, "deduped");
 });
 
-test("direct publication retries only the expectedOid conflict and commits other plans", async () => {
+test("direct publication marks tuple projections oversize and chunks canonical values", async () => {
   const storage = new TestStorage();
+  ensureProjectionSchema(storage);
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  const content = Buffer.alloc(EXACT_REVIEW_CANONICAL_INLINE_BYTES + 1, "x");
+  const plan = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#3", 1, { content }),
+  );
+  store.accept(plan, 1_000, { ...projectionLimits, maxRecordBytes: 1024 });
+  const row = store.readCanonical("openclaw-openclaw", "items", 3);
+  assert.equal(row?.content?.length, content.length);
+  assert.equal(row?.revision, 1);
+  assert.equal(
+    storage.scalar(
+      `SELECT COUNT(*) AS value FROM exact_review_canonical_record_chunks WHERE item_id = 3`,
+    ) > 1,
+    true,
+  );
+  assert.equal(
+    storage.scalar(
+      `SELECT COUNT(*) AS value FROM state_append_window WHERE payload_json LIKE '%"oversize":true%'`,
+    ),
+    1,
+  );
+});
+
+test("direct publication prunes terminal plan receipts after seven days but keeps records", async () => {
+  const storage = new TestStorage();
+  ensureProjectionSchema(storage);
   const store = new ExactReviewDirectPublicationStore(storage);
   store.ensureSchemaSync();
   store.accept(
-    directPlan("openclaw/openclaw#4", 1, { path: "records/a.md", expectedOid: "b".repeat(40) }),
+    await validateDirectPublicationPlan(directPlan("openclaw/openclaw#4", 1)),
     1_000,
+    projectionLimits,
   );
-  store.accept(directPlan("openclaw/openclaw#5", 1, { path: "records/b.md" }), 1_000);
-
-  const result = await commitDirectPublicationCycle({
-    store,
-    now: 20_000,
-    api: {
-      async readHead() {
-        return { commitSha: "1".repeat(40), treeSha: "2".repeat(40), paths: new Map() };
-      },
-      async createBlob() {
-        return "a".repeat(40);
-      },
-      async createTree() {
-        return "3".repeat(40);
-      },
-      async createCommit() {
-        return "4".repeat(40);
-      },
-      async updateRef() {},
-    },
-  });
-
-  assert.deepEqual(
-    result.published.map((row) => row.itemKey),
-    ["openclaw/openclaw#5"],
-  );
-  assert.deepEqual(
-    store.list().map((row) => [row.itemKey, row.state, row.attempts]),
-    [
-      ["openclaw/openclaw#4", "retryable", 1],
-      ["openclaw/openclaw#5", "published", 0],
-    ],
-  );
+  assert.equal(store.pruneTerminalSync(1_000 + EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS), 1);
+  assert.equal(store.list().length, 0);
+  assert.equal(store.readCanonical("openclaw-openclaw", "items", 4)?.content, "result-1");
 });
 
-test("direct publication ref update 422 refetches and succeeds on the third bounded attempt", async () => {
+test("direct publication migrates a pre-deployment pending plan into the canonical store", async () => {
   const storage = new TestStorage();
+  ensureProjectionSchema(storage);
   const store = new ExactReviewDirectPublicationStore(storage);
   store.ensureSchemaSync();
-  store.accept(directPlan("openclaw/openclaw#6", 1), 1_000);
-  let heads = 0;
-  let updates = 0;
-  const result = await commitDirectPublicationCycle({
-    store,
-    now: 20_000,
-    api: {
-      async readHead() {
-        heads += 1;
-        return { commitSha: String(heads).repeat(40), treeSha: "2".repeat(40), paths: new Map() };
-      },
-      async createBlob() {
-        return "a".repeat(40);
-      },
-      async createTree() {
-        return "3".repeat(40);
-      },
-      async createCommit() {
-        return "4".repeat(40);
-      },
-      async updateRef() {
-        updates += 1;
-        if (updates < 3) throw new DirectPublicationRefRaceError();
-      },
-    },
-  });
-  assert.equal(heads, 3);
-  assert.equal(updates, 3);
-  assert.equal(result.commitSha, "4".repeat(40));
-  assert.equal(store.list()[0]?.state, "published");
-});
-
-test("direct publication retryable conflicts stop at the bounded attempt ceiling", () => {
-  const storage = new TestStorage();
-  const store = new ExactReviewDirectPublicationStore(storage);
-  store.ensureSchemaSync();
-  store.accept(directPlan("openclaw/openclaw#9", 1), 1_000);
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    const now = 1_000 + attempt * 31 * 60_000;
-    const claimed = store.claimCycle(now);
-    assert.equal(claimed.length, 1);
-    store.retry(claimed, "expected_oid_conflict", now);
-  }
-  assert.deepEqual(
-    store.list().map((row) => [row.state, row.attempts]),
-    [["failed", 12]],
+  const legacy = directPlan("openclaw/openclaw#5", 1);
+  storage.run(
+    `INSERT INTO exact_review_direct_publication_plans
+       (item_key, revision, identity_item_key, identity_revision, claim_generation,
+        operations_json, total_bytes, file_count, state, attempts, created_at, updated_at,
+        next_attempt_at, commit_sha, failure_reason)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, 1000, 1000, 1000, NULL, NULL)`,
+    legacy.itemKey,
+    legacy.revision,
+    legacy.identity.itemKey,
+    legacy.identity.revision,
+    legacy.identity.claimGeneration,
+    JSON.stringify(legacy.operations),
+    legacy.totalBytes,
+    legacy.operations.length,
   );
+
+  const pending = store.legacyPendingPlans();
+  assert.equal(pending.length, 1);
+  const accepted = store.accept(
+    await validateDirectPublicationPlan(pending[0]!),
+    2_000,
+    projectionLimits,
+  );
+
+  assert.equal(accepted.outcome, "accepted");
+  assert.equal(store.readCanonical("openclaw-openclaw", "items", 5)?.content, "result-1");
+  assert.equal(store.legacyPendingPlans().length, 0);
 });
 
-test("direct publication validates per-file and per-POST size caps", () => {
+test("direct publication validates tuple and per-file size caps", async () => {
   const tooLargeFile = Buffer.alloc(2 * 1024 * 1024 + 1);
-  assert.throws(
-    () =>
-      validateDirectPublicationPlan(
-        directPlan("openclaw/openclaw#7", 1, { content: tooLargeFile }),
-      ),
+  await assert.rejects(
+    validateDirectPublicationPlan(directPlan("openclaw/openclaw#7", 1, { content: tooLargeFile })),
     /byte count/,
   );
 
-  const content = Buffer.alloc(2 * 1024 * 1024);
-  const plan = directPlan("openclaw/openclaw#8", 1, { content, files: 3 });
-  assert.ok(plan.totalBytes > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES);
-  assert.throws(() => validateDirectPublicationPlan(plan), /per-POST byte limit/);
+  const invalidPath = directPlan("openclaw/openclaw#8", 1, {
+    path: "records/other/items/8.md",
+  });
+  await assert.rejects(validateDirectPublicationPlan(invalidPath), /outside openclaw-openclaw#8/);
+  assert.equal(EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES, 4 * 1024 * 1024);
 });
 
 test("publication batches atomically select ready items without duplicate active ownership", () => {

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -106,6 +106,137 @@ test("materializer applies every record kind in sequence and keeps the last valu
   );
 });
 
+test("materializer commits one canonical record tuple atomically", async () => {
+  const fixture = createStateFixture();
+  const tuple = canonicalTuplePayload(42, "incoming", "2026-07-20T12:10:00.000Z");
+  const records = [record(1, "record_tuple", "openclaw-openclaw/42", tuple)];
+  let drainCalls = 0;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "tuple-inline", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/ack");
+    return Response.json({ ok: true, acked: 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 1, committed: 1, acked: 1, skipped: 0, errors: 0 });
+  assert.match(showState(fixture, "records/openclaw-openclaw/items/42.md"), /# incoming/);
+  assert.match(showState(fixture, "records/openclaw-openclaw/plans/42.md"), /Plan incoming/);
+  assert.match(
+    showState(fixture, "records/openclaw-openclaw/decision-packets/42.json"),
+    /"marker": "incoming"/,
+  );
+  const commitPaths = run(
+    "git",
+    ["--git-dir", fixture.origin, "diff-tree", "--no-commit-id", "--name-only", "-r", "state"],
+    fixture.root,
+  )
+    .trim()
+    .split("\n")
+    .filter((value) => value.startsWith("records/openclaw-openclaw/"));
+  assert.deepEqual(commitPaths.sort(), tuple.operations.map((operation) => operation.path).sort());
+});
+
+test("materializer fetches oversize canonical tuple content before projection", async () => {
+  const fixture = createStateFixture();
+  const tuple = canonicalTuplePayload(43, "oversize", "2026-07-20T12:11:00.000Z");
+  const primary = tuple.operations.find((operation) => operation.section === "items")!;
+  delete primary.content;
+  primary.oversize = true;
+  const records = [record(1, "record_tuple", "openclaw-openclaw/43", tuple)];
+  let drainCalls = 0;
+  let fetchCalls = 0;
+  const expectedContent = canonicalTuplePayload(
+    43,
+    "oversize",
+    "2026-07-20T12:11:00.000Z",
+  ).operations.find((operation) => operation.section === "items")!.content!;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "tuple-oversize", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    if (url.pathname === "/internal/state/records/openclaw-openclaw/items/43") {
+      fetchCalls += 1;
+      return Response.json({
+        content: expectedContent,
+        digest: primary.digest,
+        revision: 1,
+        updatedAt: producedAt,
+      });
+    }
+    assert.equal(url.pathname, "/internal/state/ack");
+    return Response.json({ ok: true, acked: 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 1, committed: 1, acked: 1, skipped: 0, errors: 0 });
+  assert.equal(fetchCalls, 1);
+  assert.equal(showState(fixture, primary.path), expectedContent);
+});
+
+test("materializer preserves a fresher concurrent git tuple through winner semantics", async () => {
+  const fixture = createStateFixture();
+  writeTupleFiles(fixture.state, canonicalTuplePayload(44, "base", "2026-07-20T12:00:00.000Z"));
+  run("git", ["add", "records/openclaw-openclaw"], fixture.state);
+  run("git", ["commit", "-m", "base tuple"], fixture.state);
+  run("git", ["push", "origin", "HEAD:state"], fixture.state);
+  fs.cpSync(path.join(fixture.state, "records"), path.join(fixture.source, "records"), {
+    recursive: true,
+  });
+
+  const other = path.join(fixture.root, "concurrent");
+  run("git", ["clone", fixture.origin, other], fixture.root);
+  configureUser(other);
+  run("git", ["checkout", "-B", "state", "origin/state"], other);
+  writeTupleFiles(other, canonicalTuplePayload(44, "remote-newer", "2026-07-20T12:20:00.000Z"));
+  run("git", ["add", "records/openclaw-openclaw"], other);
+  run("git", ["commit", "-m", "concurrent newer tuple"], other);
+  const hook = path.join(fixture.state, ".git/hooks/pre-push");
+  const marker = path.join(fixture.state, ".git/hooks/materializer-race-fired");
+  fs.writeFileSync(
+    hook,
+    `#!/bin/sh\nif [ ! -f '${marker}' ]; then\n  touch '${marker}'\n  git -C '${other}' push origin HEAD:state\nfi\n`,
+  );
+  fs.chmodSync(hook, 0o755);
+
+  const incoming = canonicalTuplePayload(44, "incoming-older", "2026-07-20T12:10:00.000Z");
+  const records = [record(1, "record_tuple", "openclaw-openclaw/44", incoming)];
+  let drainCalls = 0;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "tuple-race", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    return Response.json({ ok: true, acked: 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 1, committed: 1, acked: 1, skipped: 0, errors: 0 });
+  assert.match(showState(fixture, "records/openclaw-openclaw/items/44.md"), /# remote-newer/);
+  assert.doesNotMatch(
+    showState(fixture, "records/openclaw-openclaw/items/44.md"),
+    /incoming-older/,
+  );
+});
+
 test("materializer does not ack a drain when the state push fails", async () => {
   const fixture = createStateFixture();
   run(
@@ -207,6 +338,104 @@ function record(
   };
 }
 
+type TupleTestOperation = {
+  path: string;
+  repoSlug: string;
+  section: "items" | "plans" | "decision-packets";
+  itemId: number;
+  digest: string;
+  revision: number;
+  bytes: number;
+  deleted: false;
+  content?: string;
+  oversize?: boolean;
+};
+
+type TupleTestPayload = {
+  itemKey: string;
+  revision: number;
+  claimGeneration: number;
+  operations: TupleTestOperation[];
+};
+
+function canonicalTuplePayload(
+  number: number,
+  marker: string,
+  timestamp: string,
+): TupleTestPayload {
+  const packet = `${JSON.stringify(
+    {
+      version: 1,
+      generatedAt: timestamp,
+      updatedAt: timestamp,
+      subject: { repo: "openclaw/openclaw", number },
+      source: {
+        reportPath: `records/openclaw-openclaw/items/${number}.md`,
+        reviewedAt: timestamp,
+      },
+      marker,
+    },
+    null,
+    2,
+  )}\n`;
+  const packetDigest = createHash("sha256").update(packet).digest("hex");
+  const primary = [
+    "---",
+    `decision_packet_sha256: ${packetDigest}`,
+    `decision_packet_path: records/openclaw-openclaw/decision-packets/${number}.json`,
+    `number: ${number}`,
+    "repository: openclaw/openclaw",
+    `item_updated_at: ${timestamp}`,
+    `reviewed_at: ${timestamp}`,
+    "---",
+    "",
+    `# ${marker}`,
+    "",
+  ].join("\n");
+  const plan = [
+    "---",
+    `number: ${number}`,
+    "repository: openclaw/openclaw",
+    `reviewed_at: ${timestamp}`,
+    "---",
+    "",
+    `# Plan ${marker}`,
+    "",
+  ].join("\n");
+  const values = [
+    { section: "items" as const, extension: "md", content: primary },
+    { section: "plans" as const, extension: "md", content: plan },
+    { section: "decision-packets" as const, extension: "json", content: packet },
+  ];
+  return {
+    itemKey: `openclaw/openclaw#${number}`,
+    revision: 1,
+    claimGeneration: 1,
+    operations: values.map(({ section, extension, content }) => ({
+      path: `records/openclaw-openclaw/${section}/${number}.${extension}`,
+      repoSlug: "openclaw-openclaw",
+      section,
+      itemId: number,
+      digest: createHash("sha256").update(content).digest("hex"),
+      revision: 1,
+      bytes: Buffer.byteLength(content),
+      deleted: false,
+      content,
+      oversize: false,
+    })),
+  };
+}
+
+function writeTupleFiles(root: string, tuple: TupleTestPayload): void {
+  for (const operation of tuple.operations) {
+    if (operation.content === undefined)
+      throw new Error(`missing tuple content: ${operation.path}`);
+    const target = path.join(root, operation.path);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, operation.content);
+  }
+}
+
 function sweepStatus(detail: string, time: string): Record<string, unknown> {
   return {
     schema_version: 1,
@@ -242,9 +471,9 @@ function signedQueueFetch(
     const url = new URL(input instanceof Request ? input.url : input.toString());
     const bodyText = String(init?.body ?? "");
     const expected = `sha256=${createHmac("sha256", webhookSecret).update(bodyText).digest("hex")}`;
-    assert.equal(init?.method, "POST");
+    assert.equal(init?.method === "POST" || init?.method === "GET", true);
     assert.equal(new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"), expected);
-    return handler(url, JSON.parse(bodyText) as Record<string, unknown>);
+    return handler(url, bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {});
   }) as typeof fetch;
 }
 


### PR DESCRIPTION
## Summary

- Make Durable Object SQLite canonical for exact-review records, with digest and monotonic revision fences, chunking for payloads above 1.5 MiB, and tombstones.
- Atomically write canonical rows and a `record_tuple` append-window entry when POST acceptance succeeds, then terminalize immediately with a `do-txn` receipt.
- Delete the structurally broken 380-line Worker git writer. Recursive tree reads always truncate against the 39.5 GiB state repository, so that path never committed successfully.
- Make the materializer drain `record_tuple` appends into git as a projection, preserving tuple atomicity and `chooseRecordTupleWinner` semantics.
- Add authenticated record get/list endpoints, migrate pre-deploy pending plans, and prune receipts after seven days.

The git state repository is now a projection for these records rather than the authority. This is phase 1 of full GitHub-storage retirement.

## Proof

- Exact-review direct-publication suite: 50/50 passing
- State materializer suite: 8/8 passing
- Build, lint, and format: passing
- Autoreview: CLEAN on this exact tree (0.94); TruffleHog clean
- Repo-wide failures: only the known macOS-environment set
