### PR TITLE
fix(state): record-tuple section-move projection and cycle isolation

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -177,6 +177,7 @@ export class ExactReviewDirectPublicationStore {
     limits: DirectPublicationProjectionLimits,
   ): DirectPublicationAcceptResult {
     const storedOperations = storedOperationsFrom(plan.operations);
+    const canonicalOperations = canonicalTupleOperations(plan);
     return this.storage.transactionSync(() => {
       this.pruneTerminalSync(now);
       const existing = this.readSync(plan.itemKey, plan.revision);
@@ -221,7 +222,7 @@ export class ExactReviewDirectPublicationStore {
         return { outcome: "superseded" as const, row, supersededRevisions: [] };
       }
 
-      for (const operation of plan.operations) {
+      for (const operation of canonicalOperations) {
         const current = this.readCanonicalMetadataSync(
           operation.repoSlug,
           operation.section,
@@ -241,7 +242,10 @@ export class ExactReviewDirectPublicationStore {
         }
       }
 
-      const projection = recordTupleProjection(plan, limits.maxRecordBytes);
+      const projection = recordTupleProjection(
+        { ...plan, operations: canonicalOperations },
+        limits.maxRecordBytes,
+      );
       const totals = stateAppendWindowTotalsSync(this.storage);
       if (
         totals.pendingRows + 1 > limits.maxPendingRows ||
@@ -252,7 +256,7 @@ export class ExactReviewDirectPublicationStore {
         );
       }
 
-      for (const operation of plan.operations)
+      for (const operation of canonicalOperations)
         this.writeCanonicalOperationSync(operation, plan, now);
       const inserted = Array.from(
         this.storage.sql.exec(
@@ -518,6 +522,72 @@ export class ExactReviewDirectPublicationStore {
       row.failureReason,
     );
   }
+}
+
+function canonicalTupleOperations(
+  plan: CanonicalDirectPublicationPlan,
+): CanonicalDirectPublicationOperation[] {
+  const operations = [...plan.operations];
+  const primaryWrites = operations.filter(
+    (operation) =>
+      (operation.section === "items" || operation.section === "closed") &&
+      operation.content !== null,
+  );
+  if (primaryWrites.length > 1) {
+    throw new Error(`direct publication tuple writes both primary sections: ${plan.itemKey}`);
+  }
+  const primaryWrite = primaryWrites[0];
+  const first = operations[0]!;
+  const addDelete = (section: RecordSection): void => {
+    if (operations.some((operation) => operation.section === section)) return;
+    const extension = section === "decision-packets" ? "json" : "md";
+    operations.push({
+      path: `records/${first.repoSlug}/${section}/${first.itemId}.${extension}`,
+      expectedOid: null,
+      targetOid: null,
+      mode: "100644",
+      bytes: 0,
+      repoSlug: first.repoSlug,
+      section,
+      itemId: first.itemId,
+      content: null,
+      digest: null,
+    });
+  };
+
+  if (primaryWrite) {
+    addDelete(primaryWrite.section === "items" ? "closed" : "items");
+    if (primaryWrite.section === "closed") addDelete("plans");
+    if (!primaryReferencesDecisionPacket(primaryWrite.content!)) addDelete("decision-packets");
+  } else if (
+    operations.some(
+      (operation) =>
+        (operation.section === "items" || operation.section === "closed") &&
+        operation.content === null,
+    )
+  ) {
+    addDelete("plans");
+    addDelete("decision-packets");
+  }
+  if (operations.length > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES) {
+    throw new Error(`canonical record tuple exceeds its file limit: ${plan.itemKey}`);
+  }
+  return operations;
+}
+
+function primaryReferencesDecisionPacket(content: string): boolean {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) return false;
+  const end = normalized.indexOf("\n---", 4);
+  if (end === -1) return false;
+  const frontMatter = new Map<string, string>();
+  for (const line of normalized.slice(4, end).split("\n")) {
+    const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+    if (match?.[1]) frontMatter.set(match[1], match[2] ?? "");
+  }
+  const digest = frontMatter.get("decision_packet_sha256");
+  const pointer = frontMatter.get("decision_packet_path");
+  return Boolean(digest && pointer && digest !== "none" && pointer !== "none");
 }
 
 export function validateRecordSection(value: unknown): RecordSection | null {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -311,6 +311,8 @@ type StateAppendWindowRow = {
   payload_bytes: number;
   produced_at: string;
   delivery_id: string;
+  materialization_attempts: number;
+  materialization_first_failed_at: number | null;
 };
 type ExactReviewSupersessionAudit = {
   auditId: string;
@@ -407,6 +409,7 @@ const STATE_APPEND_WINDOW_TABLE = "state_append_window";
 const STATE_APPEND_RECEIPT_TABLE = "state_append_receipts";
 const STATE_APPEND_DRAIN_TABLE = "state_append_drains";
 const STATE_APPEND_META_TABLE = "state_append_meta";
+const STATE_APPEND_DEAD_LETTER_TABLE = "state_append_dead_letters";
 const STATE_APPEND_KINDS = new Set<StateAppendKind>([
   "sweep_status",
   "comment_router",
@@ -418,6 +421,7 @@ const DEFAULT_STATE_APPEND_MAX_RECORD_BYTES = 256 * 1024;
 // Must outlast a worst-case materializer publish (observed 17 min under
 // residual lease contention during the #738 transition).
 const DEFAULT_STATE_APPEND_DRAIN_LEASE_MS = 30 * 60 * 1000;
+const STATE_APPEND_MATERIALIZATION_RETRY_LIMIT = 3;
 const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
 const EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE = "exact_review_state_writer_operations";
@@ -729,6 +733,104 @@ export class ExactReviewQueue {
         return deleted;
       });
       return json({ ok: true, acked });
+    }
+
+    if (request.method === "POST" && url.pathname === "/state/dispose") {
+      const body = objectValue(await request.json().catch(() => null));
+      const drainToken = String(body.drain_token || "").trim();
+      const failures = stateAppendMaterializationFailures(body.failures);
+      if (!drainToken) return json({ error: "missing_drain_token" }, 400);
+      if (failures === null) return json({ error: "invalid_materialization_failures" }, 400);
+      const disposition = this.storage.transactionSync(() => {
+        const now = Date.now();
+        this.reclaimExpiredStateAppendDrainsSync(now);
+        const active = Array.from(
+          this.storage.sql.exec(
+            `SELECT drain_token FROM ${STATE_APPEND_DRAIN_TABLE} WHERE drain_token = ?`,
+            drainToken,
+          ),
+        ).length;
+        if (!active) return { acked: 0, retried: 0, deadLettered: 0 };
+
+        const rows = new Map(
+          this.stateAppendRowsForDrainSync(drainToken).map((row) => [Number(row.seq), row]),
+        );
+        if (failures.some((failure) => !rows.has(failure.seq))) {
+          throw new Error("state materialization failure is outside its drain");
+        }
+
+        let retried = 0;
+        let deadLettered = 0;
+        for (const failure of failures) {
+          const row = rows.get(failure.seq)!;
+          const attempts = Number(row.materialization_attempts || 0) + 1;
+          const firstFailedAt = Number(row.materialization_first_failed_at || now);
+          if (failure.retryable && attempts < STATE_APPEND_MATERIALIZATION_RETRY_LIMIT) {
+            this.storage.sql.exec(
+              `UPDATE ${STATE_APPEND_WINDOW_TABLE}
+                  SET drain_token = NULL,
+                      materialization_attempts = ?,
+                      materialization_first_failed_at = ?,
+                      materialization_last_error = ?
+                WHERE seq = ? AND drain_token = ?`,
+              attempts,
+              firstFailedAt,
+              failure.reason,
+              failure.seq,
+              drainToken,
+            );
+            retried += 1;
+            continue;
+          }
+          this.storage.sql.exec(
+            `INSERT INTO ${STATE_APPEND_DEAD_LETTER_TABLE}
+               (dead_letter_id, seq, kind, record_key, payload_json, produced_at, delivery_id,
+                reason, attempts, first_failed_at, last_failed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(dead_letter_id) DO UPDATE SET
+               reason = excluded.reason,
+               attempts = excluded.attempts,
+               last_failed_at = excluded.last_failed_at`,
+            `state-append:${row.delivery_id}:${row.seq}`,
+            row.seq,
+            row.kind,
+            row.record_key,
+            row.payload_json,
+            row.produced_at,
+            row.delivery_id,
+            failure.reason,
+            attempts,
+            firstFailedAt,
+            now,
+          );
+          this.storage.sql.exec(
+            `DELETE FROM ${STATE_APPEND_WINDOW_TABLE} WHERE seq = ? AND drain_token = ?`,
+            failure.seq,
+            drainToken,
+          );
+          deadLettered += 1;
+        }
+
+        const acknowledged = Array.from(
+          this.storage.sql.exec(
+            `DELETE FROM ${STATE_APPEND_WINDOW_TABLE}
+              WHERE drain_token = ?
+            RETURNING seq`,
+            drainToken,
+          ),
+        ).length;
+        this.storage.sql.exec(
+          `DELETE FROM ${STATE_APPEND_DRAIN_TABLE} WHERE drain_token = ?`,
+          drainToken,
+        );
+        return { acked: acknowledged + deadLettered, retried, deadLettered };
+      });
+      return json({
+        ok: true,
+        acked: disposition.acked,
+        retried: disposition.retried,
+        dead_lettered: disposition.deadLettered,
+      });
     }
 
     if (request.method === "POST" && url.pathname === "/state-writer/acquire") {
@@ -4817,7 +4919,10 @@ export class ExactReviewQueue {
          payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
          produced_at TEXT NOT NULL,
          delivery_id TEXT NOT NULL,
-         drain_token TEXT
+         drain_token TEXT,
+         materialization_attempts INTEGER NOT NULL DEFAULT 0 CHECK (materialization_attempts >= 0),
+         materialization_first_failed_at INTEGER,
+         materialization_last_error TEXT
        ) STRICT`,
     );
     const stateAppendTableRow = Array.from(
@@ -4838,7 +4943,10 @@ export class ExactReviewQueue {
              payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
              produced_at TEXT NOT NULL,
              delivery_id TEXT NOT NULL,
-             drain_token TEXT
+             drain_token TEXT,
+             materialization_attempts INTEGER NOT NULL DEFAULT 0 CHECK (materialization_attempts >= 0),
+             materialization_first_failed_at INTEGER,
+             materialization_last_error TEXT
            ) STRICT`,
         );
         this.storage.sql.exec(
@@ -4852,6 +4960,26 @@ export class ExactReviewQueue {
           `ALTER TABLE state_append_window_v2 RENAME TO ${STATE_APPEND_WINDOW_TABLE}`,
         );
       });
+    }
+    for (const [column, definition] of [
+      [
+        "materialization_attempts",
+        "INTEGER NOT NULL DEFAULT 0 CHECK (materialization_attempts >= 0)",
+      ],
+      ["materialization_first_failed_at", "INTEGER"],
+      ["materialization_last_error", "TEXT"],
+    ]) {
+      const present = Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${STATE_APPEND_WINDOW_TABLE}') WHERE name = ?`,
+          column,
+        ),
+      ).length;
+      if (!present) {
+        this.storage.sql.exec(
+          `ALTER TABLE ${STATE_APPEND_WINDOW_TABLE} ADD COLUMN ${column} ${definition}`,
+        );
+      }
     }
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS state_append_window_drain_seq
@@ -4886,6 +5014,26 @@ export class ExactReviewQueue {
     );
     this.storage.sql.exec(
       `INSERT OR IGNORE INTO ${STATE_APPEND_META_TABLE} (singleton_id) VALUES (1)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_DEAD_LETTER_TABLE} (
+         dead_letter_id TEXT PRIMARY KEY,
+         seq INTEGER NOT NULL CHECK (seq >= 1),
+         kind TEXT NOT NULL,
+         record_key TEXT NOT NULL,
+         payload_json TEXT NOT NULL,
+         produced_at TEXT NOT NULL,
+         delivery_id TEXT NOT NULL,
+         reason TEXT NOT NULL,
+         attempts INTEGER NOT NULL CHECK (attempts >= 1),
+         first_failed_at INTEGER NOT NULL,
+         last_failed_at INTEGER NOT NULL,
+         status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'resolved'))
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS state_append_dead_letters_status
+         ON ${STATE_APPEND_DEAD_LETTER_TABLE} (status, last_failed_at, dead_letter_id)`,
     );
     // Flow telemetry is independent of queue rollback compatibility. A
     // separate singleton keeps cumulative lane counters monotonic without
@@ -6364,7 +6512,8 @@ export class ExactReviewQueue {
 
     const candidates = Array.from(
       this.storage.sql.exec(
-        `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id
+        `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id,
+                materialization_attempts, materialization_first_failed_at
            FROM ${STATE_APPEND_WINDOW_TABLE}
           WHERE drain_token IS NULL
           ORDER BY seq
@@ -6403,7 +6552,8 @@ export class ExactReviewQueue {
   private stateAppendRowsForDrainSync(drainToken: string) {
     return Array.from(
       this.storage.sql.exec(
-        `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id
+        `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id,
+                materialization_attempts, materialization_first_failed_at
            FROM ${STATE_APPEND_WINDOW_TABLE}
           WHERE drain_token = ?
           ORDER BY seq`,
@@ -9399,7 +9549,35 @@ function stateAppendWindowRowJson(row: StateAppendWindowRow) {
     payload: JSON.parse(row.payload_json),
     produced_at: row.produced_at,
     delivery_id: row.delivery_id,
+    materialization_attempts: Number(row.materialization_attempts || 0),
   };
+}
+
+function stateAppendMaterializationFailures(value: unknown) {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 100_000) return null;
+  const seen = new Set<number>();
+  const failures: Array<{ seq: number; reason: string; retryable: boolean }> = [];
+  for (const entry of value) {
+    const record = objectValue(entry);
+    const seq = Number(record.seq);
+    const reason = String(record.reason || "").trim();
+    if (
+      !Number.isSafeInteger(seq) ||
+      seq < 1 ||
+      seen.has(seq) ||
+      !reason ||
+      reason.length > 2_000 ||
+      reason.includes("\u0000") ||
+      reason.includes("\r") ||
+      reason.includes("\n") ||
+      typeof record.retryable !== "boolean"
+    ) {
+      return null;
+    }
+    seen.add(seq);
+    failures.push({ seq, reason, retryable: record.retryable });
+  }
+  return failures;
 }
 
 async function exactReviewDispatchToken(env) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -561,6 +561,8 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/state/drain");
     if (url.pathname === "/internal/state/ack" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/state/ack");
+    if (url.pathname === "/internal/state/dispose" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/state/dispose");
     if (url.pathname === "/internal/state-writer/acquire" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/state-writer/acquire");
     if (url.pathname === "/internal/state-writer/heartbeat" && request.method === "POST")

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -59,6 +59,14 @@ export type StateAppendRecord = {
   payload: unknown;
   produced_at: string;
   delivery_id: string;
+  materialization_attempts?: number;
+};
+
+type StateMaterializationFailure = {
+  seq: number;
+  key: string;
+  reason: string;
+  retryable: boolean;
 };
 
 export type StateMaterializerSummary = {
@@ -102,7 +110,22 @@ export function selectLatestStateRecords(records: readonly StateAppendRecord[]):
   }
 
   const latest = new Map<string, StateAppendRecord>();
-  for (const record of ordered) latest.set(`${record.kind}\0${record.key}`, record);
+  for (const record of ordered) {
+    const key = `${record.kind}\0${record.key}`;
+    const current = latest.get(key);
+    const currentRevision = current?.kind === "record_tuple" ? recordTupleRevision(current) : null;
+    const incomingRevision = record.kind === "record_tuple" ? recordTupleRevision(record) : null;
+    if (
+      record.kind === "record_tuple" &&
+      current?.kind === "record_tuple" &&
+      currentRevision !== null &&
+      incomingRevision !== null &&
+      currentRevision > incomingRevision
+    ) {
+      continue;
+    }
+    latest.set(key, record);
+  }
   const selected = [...latest.values()].sort((left, right) => left.seq - right.seq);
   return { records: selected, skipped: records.length - selected.length };
 }
@@ -199,6 +222,13 @@ export function planStateMaterialization(
 
     if (record.kind === "record_tuple") {
       const tuple = recordTupleProjection(record);
+      const primaryWrites = tuple.operations.filter(
+        (operation) =>
+          (operation.section === "items" || operation.section === "closed") && !operation.deleted,
+      );
+      if (primaryWrites.length > 1) {
+        throw new Error(`record tuple projection ${record.key} writes both primary sections`);
+      }
       for (const operation of tuple.operations) {
         addPublishPath(operation.path);
         if (operation.deleted) {
@@ -216,6 +246,43 @@ export function planStateMaterialization(
         repository: tuple.operations[0]!.repoSlug,
         number: String(tuple.operations[0]!.itemId),
       });
+      const primaryWrite = primaryWrites[0];
+      if (primaryWrite) {
+        const displacedPrimary = primaryWrite.section === "items" ? paths.closed : paths.item;
+        contentByPath.delete(displacedPrimary);
+        if (currentFiles.has(displacedPrimary)) deletes.add(displacedPrimary);
+        addPublishPath(displacedPrimary);
+
+        if (
+          primaryWrite.section === "closed" &&
+          !tuple.operations.some((operation) => operation.path === paths.plan)
+        ) {
+          contentByPath.delete(paths.plan);
+          if (currentFiles.has(paths.plan)) deletes.add(paths.plan);
+          addPublishPath(paths.plan);
+        }
+        if (
+          typeof primaryWrite.content === "string" &&
+          !primaryReferencesDecisionPacket(primaryWrite.content) &&
+          !tuple.operations.some((operation) => operation.path === paths.packet)
+        ) {
+          contentByPath.delete(paths.packet);
+          if (currentFiles.has(paths.packet)) deletes.add(paths.packet);
+          addPublishPath(paths.packet);
+        }
+      } else if (
+        tuple.operations.some(
+          (operation) =>
+            (operation.section === "items" || operation.section === "closed") && operation.deleted,
+        )
+      ) {
+        for (const sidecar of [paths.plan, paths.packet]) {
+          if (tuple.operations.some((operation) => operation.path === sidecar)) continue;
+          contentByPath.delete(sidecar);
+          if (currentFiles.has(sidecar)) deletes.add(sidecar);
+          addPublishPath(sidecar);
+        }
+      }
       const target = (path: string): string | null => {
         if (deletes.has(path)) return null;
         return contentByPath.get(path) ?? currentFiles.get(path) ?? null;
@@ -336,7 +403,9 @@ export async function runStateMaterializer(
         fetchImpl,
       });
       const currentFiles = readCurrentFiles(materializationPaths(hydrated.records), process.cwd());
-      const plan = planStateMaterialization(hydrated.records, currentFiles);
+      const isolated = planStateMaterializationWithIsolation(hydrated.records, currentFiles);
+      const failures = [...hydrated.failures, ...isolated.failures];
+      const plan = isolated.plan;
       applyStateMaterializationPlan(plan, process.cwd());
       const recordTuplePaths = plan.publishPaths.filter(isRecordTupleProjectionPath);
       const regularPaths = plan.publishPaths.filter((path) => !isRecordTupleProjectionPath(path));
@@ -361,13 +430,33 @@ export async function runStateMaterializer(
       }
       summary.committed += plan.selected;
       summary.skipped += selected.skipped + hydrated.skipped + plan.skipped;
+      summary.errors += failures.length;
+      for (const failure of failures) {
+        console.warn(
+          `state-materializer isolated ${failure.retryable ? "retryable" : "terminal"} record ${failure.key} seq=${failure.seq}: ${failure.reason}`,
+        );
+      }
 
-      const acked = await ackStateWindow({
-        queueUrl,
-        webhookSecret,
-        drainToken: drain.token,
-        fetchImpl,
-      });
+      const disposition =
+        failures.length > 0
+          ? await disposeStateWindow({
+              queueUrl,
+              webhookSecret,
+              drainToken: drain.token,
+              failures,
+              fetchImpl,
+            })
+          : {
+              acked: await ackStateWindow({
+                queueUrl,
+                webhookSecret,
+                drainToken: drain.token,
+                fetchImpl,
+              }),
+              retried: 0,
+              deadLettered: 0,
+            };
+      const acked = disposition.acked;
       if (acked > drain.records.length) {
         throw new Error(`state ack count ${acked} exceeded drained count ${drain.records.length}`);
       }
@@ -380,6 +469,11 @@ export async function runStateMaterializer(
         );
       }
       summary.acked += acked;
+      if (disposition.retried > 0 || disposition.deadLettered > 0) {
+        console.warn(
+          `state-materializer disposition: retried=${disposition.retried} dead_lettered=${disposition.deadLettered}`,
+        );
+      }
     } catch (error) {
       summary.errors += 1;
       console.warn(`state-materializer cycle failed: ${errorMessage(error)}`);
@@ -387,6 +481,54 @@ export async function runStateMaterializer(
     }
   }
   return finish();
+}
+
+function planStateMaterializationWithIsolation(
+  records: readonly StateAppendRecord[],
+  currentFiles: ReadonlyMap<string, string>,
+): { plan: StateMaterializationPlan; failures: StateMaterializationFailure[] } {
+  const staged = new Map(currentFiles);
+  const publishPaths: string[] = [];
+  const failures: StateMaterializationFailure[] = [];
+  let selected = 0;
+  let skipped = 0;
+
+  for (const record of records) {
+    try {
+      const recordPlan = planStateMaterialization([record], staged);
+      for (const path of recordPlan.deletes) staged.delete(path);
+      for (const write of recordPlan.writes) staged.set(write.path, write.content);
+      for (const path of recordPlan.publishPaths) {
+        if (!publishPaths.includes(path)) publishPaths.push(path);
+      }
+      selected += recordPlan.selected;
+      skipped += recordPlan.skipped;
+    } catch (error) {
+      if (record.kind !== "record_tuple") throw error;
+      failures.push({
+        seq: record.seq,
+        key: record.key,
+        reason: materializationFailureReason(error),
+        retryable: false,
+      });
+    }
+  }
+
+  return {
+    plan: {
+      deletes: publishPaths.filter((path) => currentFiles.has(path) && !staged.has(path)).sort(),
+      publishPaths,
+      writes: publishPaths.flatMap((path) => {
+        const content = staged.get(path);
+        return content !== undefined && currentFiles.get(path) !== content
+          ? [{ path, content }]
+          : [];
+      }),
+      selected,
+      skipped,
+    },
+    failures,
+  };
 }
 
 export function applyStateMaterializationPlan(plan: StateMaterializationPlan, root: string): void {
@@ -462,43 +604,59 @@ async function hydrateRecordTupleRecords(options: {
   queueUrl: string;
   webhookSecret: string;
   fetchImpl: typeof fetch;
-}): Promise<{ records: StateAppendRecord[]; skipped: number }> {
+}): Promise<{
+  records: StateAppendRecord[];
+  skipped: number;
+  failures: StateMaterializationFailure[];
+}> {
   const records: StateAppendRecord[] = [];
+  const failures: StateMaterializationFailure[] = [];
   let skipped = 0;
   for (const record of options.records) {
     if (record.kind !== "record_tuple") {
       records.push(record);
       continue;
     }
-    const tuple = recordTupleProjection(record);
-    const operations: RecordTupleProjectionOperation[] = [];
-    let superseded = false;
-    for (const operation of tuple.operations) {
-      if (!operation.oversize) {
-        operations.push(operation);
+    try {
+      const tuple = recordTupleProjection(record);
+      const operations: RecordTupleProjectionOperation[] = [];
+      let superseded = false;
+      for (const operation of tuple.operations) {
+        if (!operation.oversize) {
+          operations.push(operation);
+          continue;
+        }
+        const fetched = await fetchCanonicalRecord({
+          queueUrl: options.queueUrl,
+          webhookSecret: options.webhookSecret,
+          operation,
+          fetchImpl: options.fetchImpl,
+        });
+        if (fetched.kind === "superseded") {
+          superseded = true;
+          break;
+        }
+        operations.push({ ...operation, content: fetched.content, oversize: false });
+      }
+      if (superseded) {
+        skipped += 1;
+        console.warn(`record tuple projection superseded before oversize fetch: ${record.key}`);
         continue;
       }
-      const fetched = await fetchCanonicalRecord({
-        queueUrl: options.queueUrl,
-        webhookSecret: options.webhookSecret,
-        operation,
-        fetchImpl: options.fetchImpl,
+      records.push({ ...record, payload: { ...tuple, operations } });
+    } catch (error) {
+      failures.push({
+        seq: record.seq,
+        key: record.key,
+        reason: materializationFailureReason(error),
+        retryable: error instanceof RetryableStateMaterializationError,
       });
-      if (fetched.kind === "superseded") {
-        superseded = true;
-        break;
-      }
-      operations.push({ ...operation, content: fetched.content, oversize: false });
     }
-    if (superseded) {
-      skipped += 1;
-      console.warn(`record tuple projection superseded before oversize fetch: ${record.key}`);
-      continue;
-    }
-    records.push({ ...record, payload: { ...tuple, operations } });
   }
-  return { records, skipped };
+  return { records, skipped, failures };
 }
+
+class RetryableStateMaterializationError extends Error {}
 
 async function fetchCanonicalRecord(options: {
   queueUrl: string;
@@ -508,17 +666,36 @@ async function fetchCanonicalRecord(options: {
 }): Promise<{ kind: "fetched"; content: string } | { kind: "superseded" }> {
   const signature = `sha256=${createHmac("sha256", options.webhookSecret).update("").digest("hex")}`;
   const path = `/internal/state/records/${encodeURIComponent(options.operation.repoSlug)}/${options.operation.section}/${options.operation.itemId}`;
-  const response = await options.fetchImpl(`${options.queueUrl}${path}`, {
-    method: "GET",
-    headers: { "x-clawsweeper-exact-review-signature": signature },
-  });
+  let response: Response;
+  try {
+    response = await options.fetchImpl(`${options.queueUrl}${path}`, {
+      method: "GET",
+      headers: { "x-clawsweeper-exact-review-signature": signature },
+    });
+  } catch (error) {
+    throw new RetryableStateMaterializationError(
+      `GET ${path} failed transiently: ${errorMessage(error)}`,
+    );
+  }
   const body = (await response.json().catch(() => null)) as unknown;
-  if (!isRecord(body)) throw new Error(`GET ${path} returned invalid JSON`);
+  if (!isRecord(body)) {
+    if (response.status === 429 || response.status >= 500) {
+      throw new RetryableStateMaterializationError(
+        `GET ${path} returned ${response.status} with invalid JSON`,
+      );
+    }
+    throw new Error(`GET ${path} returned invalid JSON`);
+  }
   const revision = Number(body.revision);
   if (Number.isSafeInteger(revision) && revision > options.operation.revision) {
     return { kind: "superseded" };
   }
-  if (!response.ok) throw new Error(`GET ${path} returned ${response.status}`);
+  if (!response.ok) {
+    if (response.status === 429 || response.status >= 500) {
+      throw new RetryableStateMaterializationError(`GET ${path} returned ${response.status}`);
+    }
+    throw new Error(`GET ${path} returned ${response.status}`);
+  }
   const content = body.content;
   const digest = String(body.digest || "");
   if (
@@ -623,6 +800,27 @@ function recordTupleProjection(record: StateAppendRecord): RecordTupleProjection
   return { itemKey, revision, claimGeneration, operations };
 }
 
+function recordTupleRevision(record: StateAppendRecord): number | null {
+  if (!isRecord(record.payload)) return null;
+  const revision = Number(record.payload.revision);
+  return Number.isSafeInteger(revision) && revision >= 1 ? revision : null;
+}
+
+function primaryReferencesDecisionPacket(content: string): boolean {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) return false;
+  const end = normalized.indexOf("\n---", 4);
+  if (end === -1) return false;
+  const frontMatter = new Map<string, string>();
+  for (const line of normalized.slice(4, end).split("\n")) {
+    const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+    if (match?.[1]) frontMatter.set(match[1], match[2] ?? "");
+  }
+  const digest = frontMatter.get("decision_packet_sha256");
+  const pointer = frontMatter.get("decision_packet_path");
+  return Boolean(digest && pointer && digest !== "none" && pointer !== "none");
+}
+
 function assertProjectedContent(operation: RecordTupleProjectionOperation, content: string): void {
   const bytes = Buffer.byteLength(content);
   const digest = createHash("sha256").update(content).digest("hex");
@@ -680,6 +878,42 @@ async function ackStateWindow(options: {
   return acked;
 }
 
+async function disposeStateWindow(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  drainToken: string;
+  failures: readonly StateMaterializationFailure[];
+  fetchImpl: typeof fetch;
+}): Promise<{ acked: number; retried: number; deadLettered: number }> {
+  const body = await postSignedStateRequest({
+    ...options,
+    path: "/internal/state/dispose",
+    payload: {
+      drain_token: options.drainToken,
+      failures: options.failures.map((failure) => ({
+        seq: failure.seq,
+        reason: failure.reason,
+        retryable: failure.retryable,
+      })),
+    },
+  });
+  const acked = Number(body.acked);
+  const retried = Number(body.retried);
+  const deadLettered = Number(body.dead_lettered);
+  if (
+    body.ok !== true ||
+    !Number.isSafeInteger(acked) ||
+    acked < 0 ||
+    !Number.isSafeInteger(retried) ||
+    retried < 0 ||
+    !Number.isSafeInteger(deadLettered) ||
+    deadLettered < 0
+  ) {
+    throw new Error("POST /internal/state/dispose returned an invalid response");
+  }
+  return { acked, retried, deadLettered };
+}
+
 async function postSignedStateRequest(options: {
   queueUrl: string;
   webhookSecret: string;
@@ -715,6 +949,9 @@ function stateAppendRecordFrom(value: unknown): StateAppendRecord {
     payload: value.payload,
     produced_at: String(value.produced_at || "").trim(),
     delivery_id: String(value.delivery_id || "").trim(),
+    ...(Object.hasOwn(value, "materialization_attempts")
+      ? { materialization_attempts: Number(value.materialization_attempts) }
+      : {}),
   };
   assertStateAppendRecord(record);
   return record;
@@ -735,6 +972,12 @@ function assertStateAppendRecord(record: StateAppendRecord): void {
     throw new Error("state drain record has an invalid produced_at");
   }
   if (!record.delivery_id) throw new Error("state drain record has no delivery_id");
+  if (
+    record.materialization_attempts !== undefined &&
+    (!Number.isSafeInteger(record.materialization_attempts) || record.materialization_attempts < 0)
+  ) {
+    throw new Error("state drain record has invalid materialization attempts");
+  }
 }
 
 function boundedPositiveInteger(
@@ -753,6 +996,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function errorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return redactStateSecrets(message);
+}
+
+function materializationFailureReason(error: unknown): string {
+  return errorMessage(error)
+    .replaceAll("\u0000", " ")
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .slice(0, 2_000);
 }
 
 let stateSecretsToRedact: string[] = [];

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7647,6 +7647,74 @@ test("state drain replays its active batch and deletes rows only after ack", asy
   assert.equal(stats.state_append.pending_rows, 1);
 });
 
+test("state disposition commits valid rows and dead-letters a poison row after bounded retries", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  await queue.fetch(
+    stateAppendQueueRequest("/state/append", {
+      delivery_id: "state-mixed-disposition",
+      records: [
+        stateAppendRecord("sweep_status", "valid", { n: 1 }),
+        stateAppendRecord("apply_proof", "poison", { n: 2 }),
+      ],
+    }),
+  );
+
+  const first = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 2, max_bytes: 1024 }))
+  ).json();
+  const poisonSeq = first.records.find((record) => record.key === "poison").seq;
+  const firstDisposition = await queue.fetch(
+    stateAppendQueueRequest("/state/dispose", {
+      drain_token: first.drain_token,
+      failures: [{ seq: poisonSeq, reason: "temporary canonical fetch failure", retryable: true }],
+    }),
+  );
+  assert.deepEqual(await firstDisposition.json(), {
+    ok: true,
+    acked: 1,
+    retried: 1,
+    dead_lettered: 0,
+  });
+
+  for (const expectedAttempts of [1, 2]) {
+    const drain = await (
+      await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 2, max_bytes: 1024 }))
+    ).json();
+    assert.equal(drain.records.length, 1);
+    assert.equal(drain.records[0].materialization_attempts, expectedAttempts);
+    const disposed = await queue.fetch(
+      stateAppendQueueRequest("/state/dispose", {
+        drain_token: drain.drain_token,
+        failures: [
+          { seq: poisonSeq, reason: "temporary canonical fetch failure", retryable: true },
+        ],
+      }),
+    );
+    assert.deepEqual(await disposed.json(), {
+      ok: true,
+      acked: expectedAttempts === 2 ? 1 : 0,
+      retried: expectedAttempts === 2 ? 0 : 1,
+      dead_lettered: expectedAttempts === 2 ? 1 : 0,
+    });
+  }
+
+  const deadLetters = Array.from(
+    storage.sql.exec("SELECT record_key, reason, attempts, status FROM state_append_dead_letters"),
+  );
+  assert.deepEqual(
+    deadLetters.map((row) => ({ ...row })),
+    [
+      {
+        record_key: "poison",
+        reason: "temporary canonical fetch failure",
+        attempts: 3,
+        status: "open",
+      },
+    ],
+  );
+});
+
 test("expired state drain leases make the same rows available under a new token", async () => {
   const originalNow = Date.now;
   let now = Date.parse("2026-07-20T12:00:00.000Z");

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -205,6 +205,49 @@ test("direct publication canonically stores, projects, dedupes, and ratchets rev
   );
 });
 
+test("direct publication makes section moves canonical with sibling and stale-sidecar tombstones", async () => {
+  const storage = new TestStorage();
+  ensureProjectionSchema(storage);
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  store.accept(
+    await validateDirectPublicationPlan(directPlan("openclaw/openclaw#11", 1)),
+    1_000,
+    projectionLimits,
+  );
+  store.accept(
+    await validateDirectPublicationPlan(
+      directPlan("openclaw/openclaw#11", 2, {
+        path: "records/openclaw-openclaw/closed/11.md",
+        content: Buffer.from("closed-result"),
+      }),
+    ),
+    1_001,
+    projectionLimits,
+  );
+
+  assert.equal(store.readCanonical("openclaw-openclaw", "closed", 11)?.content, "closed-result");
+  assert.equal(store.readCanonical("openclaw-openclaw", "items", 11)?.deleted, true);
+  assert.equal(store.readCanonical("openclaw-openclaw", "plans", 11)?.deleted, true);
+  assert.equal(store.readCanonical("openclaw-openclaw", "decision-packets", 11)?.deleted, true);
+  const projection = JSON.parse(
+    String(
+      Array.from(
+        storage.sql.exec("SELECT payload_json FROM state_append_window ORDER BY seq DESC LIMIT 1"),
+      )[0]?.payload_json,
+    ),
+  );
+  assert.deepEqual(
+    projection.operations.map((operation) => [operation.section, operation.deleted]),
+    [
+      ["closed", false],
+      ["items", true],
+      ["plans", true],
+      ["decision-packets", true],
+    ],
+  );
+});
+
 test("direct publication idempotency compares canonical digests instead of Git OIDs", async () => {
   const storage = new TestStorage();
   ensureProjectionSchema(storage);

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -144,6 +144,142 @@ test("materializer commits one canonical record tuple atomically", async () => {
   assert.deepEqual(commitPaths.sort(), tuple.operations.map((operation) => operation.path).sort());
 });
 
+test("materializer projects an items-to-closed move by deleting the displaced primary and stale plan", () => {
+  const open = canonicalTuplePayload(45, "open", "2026-07-20T12:00:00.000Z");
+  const closed = canonicalTuplePayload(45, "closed", "2026-07-20T12:10:00.000Z", {
+    section: "closed",
+    revision: 2,
+    includePlan: false,
+  });
+  const currentFiles = new Map(
+    open.operations.map((operation) => [operation.path, operation.content!]),
+  );
+
+  const plan = planStateMaterialization(
+    [record(1, "record_tuple", "openclaw-openclaw/45", closed)],
+    currentFiles,
+  );
+
+  assert.deepEqual(plan.deletes, [
+    "records/openclaw-openclaw/items/45.md",
+    "records/openclaw-openclaw/plans/45.md",
+  ]);
+  assert.equal(
+    plan.writes.some((write) => write.path === "records/openclaw-openclaw/closed/45.md"),
+    true,
+  );
+  assert.equal(plan.publishPaths.includes("records/openclaw-openclaw/items/45.md"), true);
+});
+
+test("materializer coalesces section-changing tuple records by highest revision", () => {
+  const closed = canonicalTuplePayload(46, "closed-newer", "2026-07-20T12:20:00.000Z", {
+    section: "closed",
+    revision: 2,
+    includePlan: false,
+  });
+  const open = canonicalTuplePayload(46, "open-older", "2026-07-20T12:10:00.000Z", {
+    revision: 1,
+  });
+
+  const plan = planStateMaterialization([
+    record(1, "record_tuple", "openclaw-openclaw/46", closed),
+    record(2, "record_tuple", "openclaw-openclaw/46", open),
+  ]);
+
+  assert.equal(plan.selected, 1);
+  assert.equal(plan.skipped, 1);
+  assert.equal(
+    plan.writes.some(
+      (write) =>
+        write.path === "records/openclaw-openclaw/closed/46.md" &&
+        write.content.includes("closed-newer"),
+    ),
+    true,
+  );
+  assert.equal(
+    plan.writes.some((write) => write.path === "records/openclaw-openclaw/items/46.md"),
+    false,
+  );
+});
+
+test("materializer isolates a corrupt tuple, commits ordinary state, and records its dead letter", async () => {
+  const fixture = createStateFixture();
+  const invalid = canonicalTuplePayload(47, "invalid-open", "2026-07-20T12:10:00.000Z");
+  const closed = canonicalTuplePayload(47, "invalid-closed", "2026-07-20T12:10:00.000Z", {
+    section: "closed",
+    includePlan: false,
+  });
+  invalid.operations.push(closed.operations.find((operation) => operation.section === "closed")!);
+  const records = [
+    record(1, "record_tuple", "openclaw-openclaw/47", invalid),
+    record(2, "sweep_status", "openclaw-openclaw", sweepStatus("continued", "12:10:01.000")),
+  ];
+  let drainCalls = 0;
+  let disposition: Record<string, unknown> | null = null;
+  const fetchImpl = signedQueueFetch(async (url, body) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "mixed-cycle", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/dispose");
+    disposition = body;
+    return Response.json({ ok: true, acked: 2, retried: 0, dead_lettered: 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 2, committed: 1, acked: 2, skipped: 0, errors: 1 });
+  assert.equal(
+    JSON.parse(showState(fixture, "results/sweep-status/openclaw-openclaw.json")).detail,
+    "continued",
+  );
+  assert.deepEqual(disposition, {
+    drain_token: "mixed-cycle",
+    failures: [
+      {
+        seq: 1,
+        reason: "record tuple projection openclaw-openclaw/47 writes both primary sections",
+        retryable: false,
+      },
+    ],
+  });
+});
+
+test("materializer re-drains an already-published backlog without duplicating its commit", async () => {
+  const fixture = createStateFixture();
+  const records = [
+    record(1, "sweep_status", "openclaw-openclaw", sweepStatus("backlog", "12:11:00.000")),
+  ];
+  let drainCalls = 0;
+  let ackCalls = 0;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      if (drainCalls <= 2) {
+        return Response.json({ ok: true, drain_token: "redrain", records });
+      }
+      return Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/ack");
+    ackCalls += 1;
+    return Response.json({ ok: true, acked: ackCalls === 1 ? 0 : 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 2, committed: 2, acked: 1, skipped: 0, errors: 0 });
+  assert.equal(
+    run("git", ["--git-dir", fixture.origin, "rev-list", "--count", "state"], fixture.root),
+    "2\n",
+  );
+});
+
 test("materializer fetches oversize canonical tuple content before projection", async () => {
   const fixture = createStateFixture();
   const tuple = canonicalTuplePayload(43, "oversize", "2026-07-20T12:11:00.000Z");
@@ -341,12 +477,12 @@ function record(
 type TupleTestOperation = {
   path: string;
   repoSlug: string;
-  section: "items" | "plans" | "decision-packets";
+  section: "items" | "closed" | "plans" | "decision-packets";
   itemId: number;
-  digest: string;
+  digest: string | null;
   revision: number;
   bytes: number;
-  deleted: false;
+  deleted: boolean;
   content?: string;
   oversize?: boolean;
 };
@@ -362,7 +498,11 @@ function canonicalTuplePayload(
   number: number,
   marker: string,
   timestamp: string,
+  options: { section?: "items" | "closed"; revision?: number; includePlan?: boolean } = {},
 ): TupleTestPayload {
+  const section = options.section ?? "items";
+  const revision = options.revision ?? 1;
+  const includePlan = options.includePlan ?? section === "items";
   const packet = `${JSON.stringify(
     {
       version: 1,
@@ -370,7 +510,7 @@ function canonicalTuplePayload(
       updatedAt: timestamp,
       subject: { repo: "openclaw/openclaw", number },
       source: {
-        reportPath: `records/openclaw-openclaw/items/${number}.md`,
+        reportPath: `records/openclaw-openclaw/${section}/${number}.md`,
         reviewedAt: timestamp,
       },
       marker,
@@ -403,13 +543,13 @@ function canonicalTuplePayload(
     "",
   ].join("\n");
   const values = [
-    { section: "items" as const, extension: "md", content: primary },
-    { section: "plans" as const, extension: "md", content: plan },
+    { section, extension: "md", content: primary },
+    ...(includePlan ? [{ section: "plans" as const, extension: "md", content: plan }] : []),
     { section: "decision-packets" as const, extension: "json", content: packet },
   ];
   return {
     itemKey: `openclaw/openclaw#${number}`,
-    revision: 1,
+    revision,
     claimGeneration: 1,
     operations: values.map(({ section, extension, content }) => ({
       path: `records/openclaw-openclaw/${section}/${number}.${extension}`,
@@ -417,7 +557,7 @@ function canonicalTuplePayload(
       section,
       itemId: number,
       digest: createHash("sha256").update(content).digest("hex"),
-      revision: 1,
+      revision,
       bytes: Buffer.byteLength(content),
       deleted: false,
       content,


### PR DESCRIPTION
## Summary

- project record-tuple section moves by tombstoning displaced primaries and stale sidecars before validation
- coalesce tuple updates by highest revision and normalize payloads already wedged by the prior projection path
- isolate invalid tuples into durable dead letters with bounded retries so valid rows can keep committing
- keep re-drains idempotent and emit canonical Durable Object tombstones for section moves

## Live failure

#866 overlaid tuple paths onto existing git state before validation. An `items` to `closed` section move therefore tripped the both-primaries invariant inside the whole-cycle transaction, aborting every projection cycle.

The production materializer has failed every 20 minutes since 07:04Z, blocking 813 rows. `openclaw-openclaw/113989` is the observed item that exposed the wedge.

## Proof

- Autoreview: CLEAN (0.98); TruffleHog clean
- Materializer tests: 12/12 passed
- Direct-publication tests: 102/102 passed
- Build: passed
- Lint: passed
