### PR TITLE
fix(state): bounded shallow-history deepening for the materializer

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -75,9 +75,10 @@ jobs:
           # depth-1 cannot fast-forward or rebuild against a branch other
           # writers keep advancing (non-fast-forward shallow push rejections,
           # runs 29938808338 / 29957012043); a full clone of `state`'s own
-          # (large) history times out. 50 commits give the rebuild-on-remote-head
-          # path a real merge-base against recent advances while staying bounded.
-          fetch-depth: 50
+          # (large) history times out. The state branch can advance by hundreds
+          # of commits between 20-minute cycles, so keep one recovery-sized
+          # window available without cloning the full history.
+          fetch-depth: 512
 
       - uses: ./.github/actions/setup-pnpm
         with:

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -108,6 +108,8 @@ const GIT_TREE_LIST_MAX_BUFFER = 64 * 1024 * 1024;
 const GIT_STATE_DIFF_MAX_BUFFER = 256 * 1024 * 1024;
 const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
 const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
+const SHALLOW_MERGE_DEEPEN_STEP = 512;
+const SHALLOW_MERGE_MAX_DEEPEN = 2_048;
 // Recovery fetches (deepen/unshallow/refetch of the state history) are rare
 // one-time repairs but move far more data than an ordinary publish fetch; a
 // 60s budget times out on the grown state repo (prod run 29745570319).
@@ -1157,7 +1159,7 @@ function gitRunError(
   return new Error(detail.trim());
 }
 
-function mergeBaseWithShallowRecovery(
+export function mergeBaseWithShallowRecovery(
   left: string,
   right: string,
   remote: string,
@@ -1173,6 +1175,23 @@ function mergeBaseWithShallowRecovery(
     return { base: null, recoveredShallowMiss: false };
   }
 
+  let deepenedBy = 0;
+  while (deepenedBy < SHALLOW_MERGE_MAX_DEEPEN && isShallowRepository()) {
+    const deepenBy = Math.min(SHALLOW_MERGE_DEEPEN_STEP, SHALLOW_MERGE_MAX_DEEPEN - deepenedBy);
+    const deepenArgs = ["fetch", `--deepen=${deepenBy}`, remote, branch];
+    const deepen = spawnBoundedFetch(deepenArgs, RECOVERY_FETCH_TIMEOUT_MS);
+    if (deepen.status !== 0) throw gitRunError(deepen, deepenArgs);
+    deepenedBy += deepenBy;
+    result = spawnGit(args, { quiet: true });
+    if (result.status === 0) {
+      return { base: result.stdout.trim(), recoveredShallowMiss: true };
+    }
+    if (result.status !== 1) throw gitRunError(result, args);
+  }
+  if (!isShallowRepository()) {
+    return { base: null, recoveredShallowMiss: true };
+  }
+
   if (modelRecoveryConfigured()) {
     const attempt = executeModelRecovery({
       phase: "merge_base_shallow_recovery",
@@ -1180,7 +1199,10 @@ function mergeBaseWithShallowRecovery(
       shallow: true,
       remote,
       branch,
-      recentAttempts: [`merge_base:${left}:${right}:status=${result.status}`],
+      recentAttempts: [
+        `merge_base:${left}:${right}:status=${result.status}`,
+        `bounded_deepen:${deepenedBy}:merge_base_status=${result.status}`,
+      ],
       availableActions: [
         "refetch_depth1",
         "deepen",
@@ -1222,19 +1244,6 @@ function mergeBaseWithShallowRecovery(
       );
     }
   }
-
-  const deepenArgs = ["fetch", "--deepen=32", remote, branch];
-  const deepen = spawnGit(deepenArgs, {
-    quiet: true,
-    timeout: RECOVERY_FETCH_TIMEOUT_MS,
-  });
-  if (deepen.timedOut) throw new GitCommandTimeoutError(deepenArgs, PUBLISH_FETCH_TIMEOUT_MS);
-  if (deepen.status !== 0) throw gitRunError(deepen, deepenArgs);
-  result = spawnGit(args, { quiet: true });
-  if (result.status === 0) {
-    return { base: result.stdout.trim(), recoveredShallowMiss: true };
-  }
-  if (result.status !== 1) throw gitRunError(result, args);
 
   if (isShallowRepository()) {
     const unshallowArgs = ["fetch", "--unshallow", remote, branch];

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -476,11 +476,24 @@ export async function runStateMaterializer(
       }
     } catch (error) {
       summary.errors += 1;
-      console.warn(`state-materializer cycle failed: ${errorMessage(error)}`);
+      const message = errorMessage(error);
+      console.warn(`state-materializer cycle failed: ${message}`);
+      if (message.includes("deferred to the next run")) {
+        finish();
+        throw new Error(stateMaterializerDeferralMessage(summary, message));
+      }
       break;
     }
   }
   return finish();
+}
+
+export function stateMaterializerDeferralMessage(
+  summary: StateMaterializerSummary,
+  reason: string,
+): string {
+  const outcome = summary.committed > 0 ? "progress with deferral" : "stalled cycle with deferral";
+  return `state-materializer ${outcome}: drained=${summary.drained} committed=${summary.committed} acked=${summary.acked} skipped=${summary.skipped} errors=${summary.errors}; ${reason}`;
 }
 
 function planStateMaterializationWithIsolation(

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -114,6 +114,112 @@ test("publisher fetches share the bounded fetch helper", () => {
   assert.equal(source.match(/runGit\(\["fetch"/g)?.length, 1);
 });
 
+test("shallow merge-base recovery deepens before retrying prepare", () => {
+  const script = String.raw`
+    import childProcess from "node:child_process";
+    import { syncBuiltinESMExports } from "node:module";
+
+    const calls = [];
+    let deepened = false;
+    childProcess.spawnSync = (command, args) => {
+      calls.push({ command, args });
+      if (command !== "git") throw new Error("unexpected command: " + command);
+      if (args[0] === "merge-base") {
+        return deepened
+          ? { status: 0, stdout: "base-commit\n", stderr: "" }
+          : { status: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
+        return { status: 0, stdout: "true\n", stderr: "" };
+      }
+      if (args[0] === "fetch" && args[1] === "--deepen=512") {
+        deepened = true;
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      throw new Error("unexpected git args: " + args.join(" "));
+    };
+    syncBuiltinESMExports();
+    console.log = () => {};
+
+    const { mergeBaseWithShallowRecovery } = await import("./dist/repair/git-publish.js");
+    const result = mergeBaseWithShallowRecovery("HEAD", "origin/state", "origin", "state");
+    process.stdout.write(JSON.stringify({ calls, result }));
+  `;
+
+  const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
+  assert.deepEqual(output.result, { base: "base-commit", recoveredShallowMiss: true });
+  assert.deepEqual(
+    output.calls.filter(({ args }) => args[0] === "fetch").map(({ args }) => args),
+    [["fetch", "--deepen=512", "origin", "state"]],
+  );
+});
+
+test("shallow merge-base recovery defers only after bounded deepening is exhausted", () => {
+  const script = String.raw`
+    import childProcess from "node:child_process";
+    import fs from "node:fs";
+    import { syncBuiltinESMExports } from "node:module";
+
+    process.env.CLAWSWEEPER_MODEL_RECOVERY_ENABLED = "1";
+    process.env.CLAWSWEEPER_ACTION_LEDGER_DISABLED = "1";
+    process.env.OPENAI_API_KEY = "test-recovery-key";
+    const calls = [];
+    childProcess.spawnSync = (command, args) => {
+      if (command === "git") {
+        calls.push(args);
+        if (args[0] === "merge-base") return { status: 1, stdout: "", stderr: "" };
+        if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
+          return { status: 0, stdout: "true\n", stderr: "" };
+        }
+        if (args[0] === "fetch" && args[1] === "--deepen=512") {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        throw new Error("unexpected git args: " + args.join(" "));
+      }
+      if (command === process.execPath && String(args[0]).endsWith("codex-process-worker.js")) {
+        const options = JSON.parse(fs.readFileSync(args[1], "utf8"));
+        const outputIndex = options.args.lastIndexOf("--output-last-message");
+        fs.writeFileSync(
+          options.args[outputIndex + 1],
+          JSON.stringify({
+            diagnosis: "shallow merge history depth",
+            actions: ["defer_to_next_run"],
+            confidence: 1,
+          }),
+        );
+        fs.writeFileSync(
+          options.resultPath,
+          JSON.stringify({ status: 0, signal: null, stdout: "", stderr: "" }),
+        );
+        return { status: 0, signal: null, stdout: "", stderr: "" };
+      }
+      throw new Error("unexpected command: " + command);
+    };
+    syncBuiltinESMExports();
+    console.log = () => {};
+    console.warn = () => {};
+
+    const { mergeBaseWithShallowRecovery } = await import("./dist/repair/git-publish.js");
+    let message = "";
+    try {
+      mergeBaseWithShallowRecovery("HEAD", "origin/state", "origin", "state");
+    } catch (error) {
+      message = error.message;
+    }
+    process.stdout.write(JSON.stringify({ calls, message }));
+  `;
+
+  const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
+  assert.match(
+    output.message,
+    /Model-guided Git recovery deferred to the next run: shallow_merge_history_depth/,
+  );
+  assert.deepEqual(
+    output.calls.filter((args) => args[0] === "fetch").map((args) => args[1]),
+    ["--deepen=512", "--deepen=512", "--deepen=512", "--deepen=512"],
+  );
+});
+
 test("commitMessageForPublishedPaths skips CI for generated-only publishes", () => {
   assert.equal(
     commitMessageForPublishedPaths("chore: update sweep records", [
@@ -4879,7 +4985,7 @@ function installDeepenFetchFailureShim(fakeBin) {
     git,
     `#!/bin/sh
 set -u
-if test "$1" = fetch && test "$2" = --deepen=32; then
+if test "$1" = fetch && test "$2" = --deepen=512; then
   printf '%s\n' 'fatal: synthetic deepen failure' >&2
   exit 2
 fi

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
   planStateMaterialization,
   runStateMaterializer,
+  stateMaterializerDeferralMessage,
   type StateAppendRecord,
 } from "../../dist/repair/state-materializer.js";
 
@@ -411,6 +412,20 @@ test("materializer does not ack a drain when the state push fails", async () => 
     JSON.parse(showState(fixture, "results/sweep-status/openclaw-openclaw.json")).detail,
     "initial",
   );
+});
+
+test("materializer deferral failure distinguishes progress from a stalled cycle", () => {
+  const progress = stateMaterializerDeferralMessage(
+    { drained: 1_400, committed: 720, acked: 720, skipped: 0, errors: 1 },
+    "Model-guided Git recovery deferred to the next run: merge_shallow_history",
+  );
+  const stalled = stateMaterializerDeferralMessage(
+    { drained: 1_400, committed: 0, acked: 0, skipped: 0, errors: 1 },
+    "Model-guided Git recovery deferred to the next run: merge_shallow_history",
+  );
+
+  assert.match(progress, /progress with deferral: drained=1400 committed=720/);
+  assert.match(stalled, /stalled cycle with deferral: drained=1400 committed=0/);
 });
 
 test("materializer no-ops when the drain is empty", async () => {

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -137,6 +137,13 @@ test("state materializer uses an available GitHub-hosted runner", () => {
   assert.equal(materializer?.["runs-on"], "ubuntu-latest");
 });
 
+test("state materializer checks out a recovery-sized state history window", () => {
+  const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
+  const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
+  const setupState = materializer?.steps?.find(isSetupState);
+  assert.equal(setupState?.with?.["fetch-depth"], 512);
+});
+
 test("state materializer bounds its coordinator acquire below the job timeout", () => {
   const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
   const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;


### PR DESCRIPTION
## What changed

- Deepen shallow history in bounded 512-commit steps, up to four times, when a merge-base lookup misses, then retry the merge once before deferring.
- Increase the state materializer fetch depth from 50 to 512 so deterministic recovery has useful history available.
- Include committed record counts in failure messages so progress-with-deferral is distinguishable from a stalled materializer.

## Live evidence

- [Run 30193864122](https://github.com/openclaw/clawsweeper/actions/runs/30193864122) committed hundreds of records before failing with `merge_shallow_history` / `shallow_merge_history_depth`.
- [Run 30195774647](https://github.com/openclaw/clawsweeper/actions/runs/30195774647) repeated the same pattern: 600-800 records were committed before model-guided deferral fired ahead of deterministic recovery.

## Proof

- Focused tests: 99 passed.
- Build and lint: green.
- Autoreview: CLEAN at 0.98 confidence.
- TruffleHog: clean.
