### PR TITLE
fix(state): commit-graph-only deepening for materializer merge recovery

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -108,6 +108,7 @@ const GIT_TREE_LIST_MAX_BUFFER = 64 * 1024 * 1024;
 const GIT_STATE_DIFF_MAX_BUFFER = 256 * 1024 * 1024;
 const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
 const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
+const COMMIT_GRAPH_FETCH_FILTER = "tree:0";
 const SHALLOW_MERGE_DEEPEN_STEP = 512;
 const SHALLOW_MERGE_MAX_DEEPEN = 2_048;
 // Recovery fetches (deepen/unshallow/refetch of the state history) are rare
@@ -1175,10 +1176,11 @@ export function mergeBaseWithShallowRecovery(
     return { base: null, recoveredShallowMiss: false };
   }
 
+  configureCommitGraphPromisor(remote);
   let deepenedBy = 0;
   while (deepenedBy < SHALLOW_MERGE_MAX_DEEPEN && isShallowRepository()) {
     const deepenBy = Math.min(SHALLOW_MERGE_DEEPEN_STEP, SHALLOW_MERGE_MAX_DEEPEN - deepenedBy);
-    const deepenArgs = ["fetch", `--deepen=${deepenBy}`, remote, branch];
+    const deepenArgs = commitGraphHistoryFetchArgs(`--deepen=${deepenBy}`, remote, branch);
     const deepen = spawnBoundedFetch(deepenArgs, RECOVERY_FETCH_TIMEOUT_MS);
     if (deepen.status !== 0) throw gitRunError(deepen, deepenArgs);
     deepenedBy += deepenBy;
@@ -1211,7 +1213,7 @@ export function mergeBaseWithShallowRecovery(
         "defer_to_next_run",
         "give_up",
       ],
-      handlers: gitFetchRecoveryHandlers(remote, branch, {
+      handlers: commitGraphRecoveryHandlers(remote, branch, {
         rebuildOnRemoteHead: () => {},
         deferToNextRun: () => {},
         giveUp: () => {},
@@ -1246,14 +1248,8 @@ export function mergeBaseWithShallowRecovery(
   }
 
   if (isShallowRepository()) {
-    const unshallowArgs = ["fetch", "--unshallow", remote, branch];
-    const unshallow = spawnGit(unshallowArgs, {
-      quiet: true,
-      timeout: RECOVERY_FETCH_TIMEOUT_MS,
-    });
-    if (unshallow.timedOut) {
-      throw new GitCommandTimeoutError(unshallowArgs, PUBLISH_FETCH_TIMEOUT_MS);
-    }
+    const unshallowArgs = commitGraphHistoryFetchArgs("--unshallow", remote, branch);
+    const unshallow = spawnBoundedFetch(unshallowArgs, RECOVERY_FETCH_TIMEOUT_MS);
     if (unshallow.status !== 0) throw gitRunError(unshallow, unshallowArgs);
     result = spawnGit(args, { quiet: true });
     if (result.status === 0) {
@@ -2875,6 +2871,45 @@ function gitFetchRecoveryHandlers(
       spawnBoundedFetch(["fetch", "--unshallow", remote, branch], RECOVERY_FETCH_TIMEOUT_MS);
     },
     ...directives,
+  };
+}
+
+function configureCommitGraphPromisor(remote: string): void {
+  // Merge-base needs commits only; keep omitted trees lazy-fetchable for the
+  // later diff/rebase work that touches a small subset of the state checkout.
+  runGit(["config", "--local", `remote.${remote}.promisor`, "true"], { quiet: true });
+  runGit(["config", "--local", `remote.${remote}.partialclonefilter`, COMMIT_GRAPH_FETCH_FILTER], {
+    quiet: true,
+  });
+}
+
+function commitGraphHistoryFetchArgs(
+  historyArgument: `--deepen=${number}` | "--unshallow",
+  remote: string,
+  branch: string,
+): string[] {
+  return ["fetch", `--filter=${COMMIT_GRAPH_FETCH_FILTER}`, historyArgument, remote, branch];
+}
+
+function commitGraphRecoveryHandlers(
+  remote: string,
+  branch: string,
+  directives: RecoveryActionHandlers,
+): RecoveryActionHandlers {
+  return {
+    ...gitFetchRecoveryHandlers(remote, branch, directives),
+    deepen: (depth) => {
+      spawnBoundedFetch(
+        commitGraphHistoryFetchArgs(`--deepen=${depth}`, remote, branch),
+        RECOVERY_FETCH_TIMEOUT_MS,
+      );
+    },
+    unshallow: () => {
+      spawnBoundedFetch(
+        commitGraphHistoryFetchArgs("--unshallow", remote, branch),
+        RECOVERY_FETCH_TIMEOUT_MS,
+      );
+    },
   };
 }
 

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -132,7 +132,10 @@ test("shallow merge-base recovery deepens before retrying prepare", () => {
       if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
         return { status: 0, stdout: "true\n", stderr: "" };
       }
-      if (args[0] === "fetch" && args[1] === "--deepen=512") {
+      if (args[0] === "config") {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "fetch" && args[1] === "--filter=tree:0" && args[2] === "--deepen=512") {
         deepened = true;
         return { status: 0, stdout: "", stderr: "" };
       }
@@ -149,8 +152,15 @@ test("shallow merge-base recovery deepens before retrying prepare", () => {
   const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
   assert.deepEqual(output.result, { base: "base-commit", recoveredShallowMiss: true });
   assert.deepEqual(
+    output.calls.filter(({ args }) => args[0] === "config").map(({ args }) => args),
+    [
+      ["config", "--local", "remote.origin.promisor", "true"],
+      ["config", "--local", "remote.origin.partialclonefilter", "tree:0"],
+    ],
+  );
+  assert.deepEqual(
     output.calls.filter(({ args }) => args[0] === "fetch").map(({ args }) => args),
-    [["fetch", "--deepen=512", "origin", "state"]],
+    [["fetch", "--filter=tree:0", "--deepen=512", "origin", "state"]],
   );
 });
 
@@ -171,7 +181,10 @@ test("shallow merge-base recovery defers only after bounded deepening is exhaust
         if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
           return { status: 0, stdout: "true\n", stderr: "" };
         }
-        if (args[0] === "fetch" && args[1] === "--deepen=512") {
+        if (args[0] === "config") {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        if (args[0] === "fetch" && args[1] === "--filter=tree:0" && args[2] === "--deepen=512") {
           return { status: 0, stdout: "", stderr: "" };
         }
         throw new Error("unexpected git args: " + args.join(" "));
@@ -215,8 +228,60 @@ test("shallow merge-base recovery defers only after bounded deepening is exhaust
     /Model-guided Git recovery deferred to the next run: shallow_merge_history_depth/,
   );
   assert.deepEqual(
-    output.calls.filter((args) => args[0] === "fetch").map((args) => args[1]),
-    ["--deepen=512", "--deepen=512", "--deepen=512", "--deepen=512"],
+    output.calls.filter((args) => args[0] === "fetch"),
+    Array.from({ length: 4 }, () => [
+      "fetch",
+      "--filter=tree:0",
+      "--deepen=512",
+      "origin",
+      "state",
+    ]),
+  );
+});
+
+test("shallow merge-base recovery filters its final unshallow fallback", () => {
+  const script = String.raw`
+    import childProcess from "node:child_process";
+    import { syncBuiltinESMExports } from "node:module";
+
+    const calls = [];
+    let shallow = true;
+    childProcess.spawnSync = (command, args) => {
+      calls.push({ command, args });
+      if (command !== "git") throw new Error("unexpected command: " + command);
+      if (args[0] === "merge-base") return { status: 1, stdout: "", stderr: "" };
+      if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
+        return { status: 0, stdout: String(shallow) + "\n", stderr: "" };
+      }
+      if (args[0] === "config") return { status: 0, stdout: "", stderr: "" };
+      if (args[0] === "fetch" && args[1] === "--filter=tree:0") {
+        if (args[2] === "--unshallow") shallow = false;
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      throw new Error("unexpected git args: " + args.join(" "));
+    };
+    syncBuiltinESMExports();
+    console.log = () => {};
+
+    const { mergeBaseWithShallowRecovery } = await import("./dist/repair/git-publish.js");
+    const result = mergeBaseWithShallowRecovery("HEAD", "origin/state", "origin", "state");
+    process.stdout.write(JSON.stringify({ calls, result }));
+  `;
+
+  const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
+  assert.deepEqual(output.result, { base: null, recoveredShallowMiss: true });
+  assert.deepEqual(
+    output.calls.filter(({ args }) => args[0] === "fetch").map(({ args }) => args),
+    [
+      ...Array.from({ length: 4 }, () => [
+        "fetch",
+        "--filter=tree:0",
+        "--deepen=512",
+        "origin",
+        "state",
+      ]),
+      ["fetch", "--filter=tree:0", "--unshallow", "origin", "state"],
+    ],
   );
 });
 
@@ -4985,7 +5050,7 @@ function installDeepenFetchFailureShim(fakeBin) {
     git,
     `#!/bin/sh
 set -u
-if test "$1" = fetch && test "$2" = --deepen=512; then
+if test "$1" = fetch && test "$2" = --filter=tree:0 && test "$3" = --deepen=512; then
   printf '%s\n' 'fatal: synthetic deepen failure' >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

- Restrict materializer deepen and unshallow fetches to the commit graph with `--filter=tree:0`.
- Configure the state remote as a promisor with `partialclonefilter=tree:0` before fetching, so an existing shallow non-promisor checkout converts safely and later merge object reads remain lazy.
- Preserve the bounded deepen steps, retry behavior, and deferral semantics introduced by https://github.com/openclaw/clawsweeper/pull/868.

## Evidence

https://github.com/openclaw/clawsweeper/actions/runs/30197444471 showed the materializer recovery path spending its 300-second git timeout deepening the 39.5 GiB state repository. Merge-base recovery only needs commits; fetching trees during each deepen step is unnecessary.

## Proof

- AutoReview: CLEAN (0.98)
- TruffleHog: clean
- Focused `git-publish` test suite: passed
- Full unit suite: 95 files passed
- `pnpm run check`: passed
- Local probe: safely converted an existing shallow non-promisor checkout and completed the filtered deepen path
