### PR TITLE
fix(state): sidecar convergence and complete per-tuple failure isolation

### DIFF
--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -21,6 +21,7 @@ import {
 } from "./process-env.js";
 import {
   chooseRecordTupleWinner,
+  convergeRecordTupleSidecars,
   RecordTupleError,
   recordTupleIdentityForPath,
   recordTupleMarkdownFileForPath,
@@ -71,7 +72,15 @@ export type GitPublishOptions = {
   remote?: string;
   branch?: string;
   rebaseStrategy?: RebaseStrategy | undefined;
+  onRecordTupleFailure?: ((failure: RecordTuplePublishFailure) => void) | undefined;
 };
+
+export type RecordTuplePublishFailure = {
+  key: string;
+  reason: string;
+};
+
+type RecordTupleFailureReporter = (failure: RecordTuplePublishFailure) => void;
 
 export type RebaseStrategy = "normal" | "theirs" | "apply-records" | "reconcile-records";
 
@@ -468,6 +477,14 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   const maxAttempts = positiveInt(options.maxAttempts, 8);
   const pushAttempts = positiveInt(options.pushAttempts, 3);
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
+  const reportedTupleFailures = new Set<string>();
+  const reportTupleFailure: RecordTupleFailureReporter | undefined = options.onRecordTupleFailure
+    ? (failure) => {
+        if (reportedTupleFailures.has(failure.key)) return;
+        reportedTupleFailures.add(failure.key);
+        options.onRecordTupleFailure!(failure);
+      }
+    : undefined;
   gitPublishPhase(
     "sync",
     `paths=${uniqueNonEmpty(options.paths).length} strategy=${rebaseStrategy}`,
@@ -504,8 +521,9 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   let reconciliationTupleKeys: ReadonlySet<string> | undefined;
   if (rebaseStrategy === "reconcile-records") {
     gitPublishPhase("normalize");
-    const normalized = normalizeReconciliationCommit(sourceCommit);
+    const normalized = normalizeReconciliationCommit(sourceCommit, reportTupleFailure);
     sourceCommit = normalized.commit;
+    reconciliationTupleKeys = new Set(normalized.tupleKeys);
     if (!normalized.changed) {
       restoreWorktree(options.restorePaths ?? []);
       if (
@@ -515,14 +533,15 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
           pushAttempts,
           maxAttempts,
           ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
+          ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
+          ...(reportTupleFailure ? { reportTupleFailure } : {}),
         })
       ) {
         throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
       }
       return completeStatePublish("unchanged", options.paths, stateBaseCommit);
     }
-    const tupleKeys = reconciliationTupleKeysForCommit(sourceCommit);
-    reconciliationTupleKeys = new Set(tupleKeys);
+    const tupleKeys = normalized.tupleKeys;
     if (tupleKeys.length > RECONCILIATION_TUPLE_CHUNK_SIZE) {
       restoreWorktree(options.restorePaths ?? []);
       const result = publishReconciliationChunks({
@@ -532,6 +551,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         maxAttempts,
         sourceCommit: reconciliationSourceCommit ?? sourceCommit,
         tupleKeys,
+        ...(reportTupleFailure ? { reportTupleFailure } : {}),
       });
       return completeStatePublish(result, options.paths, stateBaseCommit);
     }
@@ -548,6 +568,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         maxAttempts,
         ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
         ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
+        ...(reportTupleFailure ? { reportTupleFailure } : {}),
       })
     ) {
       throw new Error(
@@ -1089,6 +1110,7 @@ function pushReconciliationCommit(options: {
   maxAttempts: number;
   reconciliationSourceCommit?: string;
   reconciliationTupleKeys?: ReadonlySet<string>;
+  reportTupleFailure?: RecordTupleFailureReporter;
 }): boolean {
   for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
     if (
@@ -1103,6 +1125,7 @@ function pushReconciliationCommit(options: {
         ...(options.reconciliationTupleKeys
           ? { reconciliationTupleKeys: options.reconciliationTupleKeys }
           : {}),
+        ...(options.reportTupleFailure ? { reportTupleFailure: options.reportTupleFailure } : {}),
       })
     ) {
       return true;
@@ -1125,6 +1148,7 @@ function pushReconciliationCommit(options: {
     ...(options.reconciliationTupleKeys
       ? { reconciliationTupleKeys: options.reconciliationTupleKeys }
       : {}),
+    ...(options.reportTupleFailure ? { reportTupleFailure: options.reportTupleFailure } : {}),
   });
 }
 
@@ -1325,17 +1349,6 @@ function syncStatePublishBaseToRemoteHead(
   runGit(["reset", "--hard", remoteRef]);
 }
 
-function reconciliationTupleKeysForCommit(sourceCommit: string): string[] {
-  const baseCommit = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
-  const keys = new Set<string>();
-  for (const path of changedPathsBetween(baseCommit, sourceCommit)) {
-    const identity = recordTupleIdentityForPath(path);
-    if (!identity) throw new Error(`Unsupported reconciliation publish path: ${path}`);
-    keys.add(recordTupleIdentityKey(identity));
-  }
-  return [...keys];
-}
-
 function publishReconciliationChunks(options: {
   remote: string;
   branch: string;
@@ -1343,6 +1356,7 @@ function publishReconciliationChunks(options: {
   maxAttempts: number;
   sourceCommit: string;
   tupleKeys: readonly string[];
+  reportTupleFailure?: RecordTupleFailureReporter;
 }): PublishResult {
   const chunks = chunked(options.tupleKeys, RECONCILIATION_TUPLE_CHUNK_SIZE);
   console.log(
@@ -1361,6 +1375,8 @@ function publishReconciliationChunks(options: {
         options.branch,
         options.sourceCommit,
         allowedTupleKeys,
+        false,
+        options.reportTupleFailure,
       )
     ) {
       throw new Error(`Failed to build reconciliation checkpoint ${index + 1}/${chunks.length}`);
@@ -1379,6 +1395,7 @@ function publishReconciliationChunks(options: {
         maxAttempts: options.maxAttempts,
         reconciliationSourceCommit: options.sourceCommit,
         reconciliationTupleKeys: allowedTupleKeys,
+        ...(options.reportTupleFailure ? { reportTupleFailure: options.reportTupleFailure } : {}),
       })
     ) {
       throw new Error(`Failed to publish reconciliation checkpoint ${index + 1}/${chunks.length}`);
@@ -2639,6 +2656,7 @@ export function pushCommit(options: {
   reconciliationSourceCommit?: string;
   reconciliationTupleKeys?: ReadonlySet<string>;
   boundedRemoteHeadRebuild?: boolean;
+  reportTupleFailure?: RecordTupleFailureReporter;
 }): boolean {
   const remote = options.remote ?? "origin";
   const branch = options.branch ?? publishDefaultBranch();
@@ -2691,6 +2709,7 @@ export function pushCommit(options: {
             options.reconciliationSourceCommit,
             options.reconciliationTupleKeys,
             options.boundedRemoteHeadRebuild,
+            options.reportTupleFailure,
           );
         } catch (error) {
           recordRecoveryOutcome(recovery.advice, "rebuild_on_remote_head_failed", { error });
@@ -2732,6 +2751,7 @@ export function pushCommit(options: {
           options.reconciliationSourceCommit,
           options.reconciliationTupleKeys,
           options.boundedRemoteHeadRebuild,
+          options.reportTupleFailure,
         )
       ) {
         return false;
@@ -3002,6 +3022,7 @@ function rebuildReconciliationCommit(
   reconciliationSourceCommit?: string,
   allowedTupleKeys?: ReadonlySet<string>,
   boundedRemoteHeadRebuild = false,
+  reportTupleFailure?: RecordTupleFailureReporter,
 ): boolean {
   const remoteRef = `${remote}/${branch}`;
   const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
@@ -3054,13 +3075,20 @@ function rebuildReconciliationCommit(
     new Set([...localIdentities.values()].map((identity) => identity.repository)),
     new Set(localIdentities.keys()),
   );
-  const resolvedTuples = [...localIdentities].map(([key, identity]) => ({
-    key,
-    paths: resolveRecordTuplePaths({
-      identity,
-      changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
-    }),
-  }));
+  const resolvedTuples: Array<{ key: string; paths: RecordTuplePaths }> = [];
+  for (const [key, identity] of localIdentities) {
+    try {
+      resolvedTuples.push({
+        key,
+        paths: resolveRecordTuplePaths({
+          identity,
+          changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
+        }),
+      });
+    } catch (error) {
+      if (!isolateRecordTupleFailure(error, key, reportTupleFailure)) throw error;
+    }
+  }
   const snapshots = readRecordTupleSnapshots(
     resolvedTuples.flatMap(({ paths }) => [
       { commit: baseCommit, paths },
@@ -3068,17 +3096,22 @@ function rebuildReconciliationCommit(
       { commit: remoteRef, paths },
     ]),
   );
-  const selectedTuples: { paths: RecordTuplePaths; commit: string }[] = [];
+  const selectedTuples: RecordTupleSelection[] = [];
   const deferredTupleKeys = new Set<string>();
   for (const [index, { key, paths }] of resolvedTuples.entries()) {
     const offset = index * 3;
-    const winner = chooseReconciliationTupleWinner({
-      base: snapshots[offset]!,
-      local: snapshots[offset + 1]!,
-      remote: snapshots[offset + 2]!,
-    });
-    if (winner === "local") selectedTuples.push({ paths, commit: sourceCommit });
-    else if (winner === "base") selectedTuples.push({ paths, commit: baseCommit });
+    const converged = convergeRecordTupleSidecars(snapshots[offset + 1]!);
+    const winner = chooseReconciliationTupleWinner(
+      {
+        base: snapshots[offset]!,
+        local: converged.tuple,
+        remote: snapshots[offset + 2]!,
+      },
+      reportTupleFailure,
+    );
+    if (winner === "local") {
+      selectedTuples.push({ paths, commit: sourceCommit, deletedPaths: converged.deletedPaths });
+    } else if (winner === "base") selectedTuples.push({ paths, commit: baseCommit });
     else deferredTupleKeys.add(key);
   }
 
@@ -3159,9 +3192,13 @@ function mergeBaseWithoutHydration(
   return { base: null, recoveredShallowMiss: false };
 }
 
-function normalizeReconciliationCommit(sourceCommit: string): {
+function normalizeReconciliationCommit(
+  sourceCommit: string,
+  reportTupleFailure?: RecordTupleFailureReporter,
+): {
   commit: string;
   changed: boolean;
+  tupleKeys: string[];
 } {
   const baseCommit = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
   const localPaths = changedPathsBetween(baseCommit, sourceCommit);
@@ -3177,62 +3214,137 @@ function normalizeReconciliationCommit(sourceCommit: string): {
     new Set([...identities.values()].map((identity) => identity.repository)),
     new Set(identities.keys()),
   );
-  const resolvedTuples = [...identities].map(([key, identity]) => ({
-    key,
-    paths: resolveRecordTuplePaths({
-      identity,
-      changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
-    }),
-  }));
+  const resolvedTuples: Array<{ key: string; paths: RecordTuplePaths }> = [];
+  const isolatedTupleKeys = new Set<string>();
+  const normalizeFailureReporter: RecordTupleFailureReporter | undefined = reportTupleFailure
+    ? (failure) => {
+        isolatedTupleKeys.add(failure.key);
+        reportTupleFailure(failure);
+      }
+    : undefined;
+  for (const [key, identity] of identities) {
+    try {
+      resolvedTuples.push({
+        key,
+        paths: resolveRecordTuplePaths({
+          identity,
+          changedPaths: [...localPaths, ...(knownTuplePaths.get(key) ?? [])],
+        }),
+      });
+    } catch (error) {
+      if (!isolateRecordTupleFailure(error, key, normalizeFailureReporter)) throw error;
+    }
+  }
   const snapshots = readRecordTupleSnapshots(
     resolvedTuples.flatMap(({ paths }) => [
       { commit: baseCommit, paths },
       { commit: sourceCommit, paths },
     ]),
   );
-  const selectedTuples: RecordTuplePaths[] = [];
-  for (const [index, { paths }] of resolvedTuples.entries()) {
+  const selectedTuples: Array<{
+    key: string;
+    paths: RecordTuplePaths;
+    deletedPaths: string[];
+  }> = [];
+  for (const [index, { key, paths }] of resolvedTuples.entries()) {
     const base = snapshots[index * 2]!;
     const local = snapshots[index * 2 + 1]!;
-    const winner = chooseReconciliationTupleWinner({ base, local, remote: base });
-    if (winner === "local") selectedTuples.push(paths);
+    const converged = convergeRecordTupleSidecars(local);
+    const winner = chooseReconciliationTupleWinner(
+      { base, local: converged.tuple, remote: base },
+      normalizeFailureReporter,
+    );
+    if (winner === "local") {
+      selectedTuples.push({ key, paths, deletedPaths: converged.deletedPaths });
+    }
   }
+  const reconciliationTupleKeys = resolvedTuples
+    .map(({ key }) => key)
+    .filter((key) => !isolatedTupleKeys.has(key));
 
-  if (selectedTuples.length === identities.size) {
-    return { commit: sourceCommit, changed: true };
+  const convergedDeletionCount = selectedTuples.reduce(
+    (total, tuple) => total + tuple.deletedPaths.length,
+    0,
+  );
+  if (selectedTuples.length === identities.size && convergedDeletionCount === 0) {
+    return {
+      commit: sourceCommit,
+      changed: true,
+      tupleKeys: reconciliationTupleKeys,
+    };
   }
 
   const discarded = identities.size - selectedTuples.length;
-  console.log(`Discarding ${discarded} stale or ambiguous local record tuple(s) before push`);
+  if (discarded > 0) {
+    console.log(`Discarding ${discarded} stale or invalid local record tuple(s) before push`);
+  }
+  if (convergedDeletionCount > 0) {
+    console.log(`Deleting ${convergedDeletionCount} orphaned record tuple sidecar(s) before push`);
+  }
   runGit(["reset", "--hard", baseCommit]);
   const selectedPaths = applyRecordTupleSelections(
-    selectedTuples.map((paths) => ({ paths, commit: sourceCommit })),
+    selectedTuples.map(({ paths, deletedPaths }) => ({
+      paths,
+      commit: sourceCommit,
+      deletedPaths,
+    })),
   );
   if (selectedPaths.length > 0) stagePaths(selectedPaths);
-  if (!hasStagedChanges()) return { commit: baseCommit, changed: false };
+  if (!hasStagedChanges()) {
+    return { commit: baseCommit, changed: false, tupleKeys: reconciliationTupleKeys };
+  }
   runGit(["commit", "-C", sourceCommit]);
-  return { commit: runGit(["rev-parse", "HEAD"]).trim(), changed: true };
+  return {
+    commit: runGit(["rev-parse", "HEAD"]).trim(),
+    changed: true,
+    tupleKeys: reconciliationTupleKeys,
+  };
 }
 
-function chooseReconciliationTupleWinner(options: {
-  base: RecordTupleContents;
-  local: RecordTupleContents;
-  remote: RecordTupleContents;
-}): RecordTupleWinner | undefined {
+function chooseReconciliationTupleWinner(
+  options: {
+    base: RecordTupleContents;
+    local: RecordTupleContents;
+    remote: RecordTupleContents;
+  },
+  reportTupleFailure?: RecordTupleFailureReporter,
+): RecordTupleWinner | undefined {
   // A malformed local tuple must still fail the publish. Once the candidate is
   // structurally valid, however, an unorderable legacy/base conflict can be
   // quarantined to this tuple instead of blocking every independent repair in
   // a broad reconciliation batch.
-  validateRecordTuple(options.local, "local reconciliation");
+  try {
+    validateRecordTuple(options.local, "local reconciliation");
+  } catch (error) {
+    if (isolateRecordTupleFailure(error, options.local.paths.key, reportTupleFailure)) {
+      return undefined;
+    }
+    throw error;
+  }
   try {
     return chooseRecordTupleWinner(options);
   } catch (error) {
     if (!(error instanceof RecordTupleError)) throw error;
+    if (isolateRecordTupleFailure(error, options.local.paths.key, reportTupleFailure)) {
+      return undefined;
+    }
     console.log(
       `Deferring ambiguous reconciliation for ${options.local.paths.key}: ${error.message}`,
     );
     return undefined;
   }
+}
+
+function isolateRecordTupleFailure(
+  error: unknown,
+  key: string,
+  reportTupleFailure?: RecordTupleFailureReporter,
+): boolean {
+  if (!(error instanceof RecordTupleError) || !reportTupleFailure) return false;
+  const reason = errorMessage(error);
+  reportTupleFailure({ key, reason });
+  console.warn(`Isolating invalid record tuple ${key}: ${reason}`);
+  return true;
 }
 
 function changedPathsBetween(from: string, to: string): string[] {
@@ -3269,7 +3381,7 @@ function resolveRecordTuplePaths(options: {
   }
   for (const [section, files] of Object.entries(markdownFiles)) {
     if (files.size > 1) {
-      throw new Error(
+      throw new RecordTupleError(
         `Invalid record tuple ${recordTupleIdentityKey(options.identity)}: ambiguous ${section} filenames ${[
           ...files,
         ].join(", ")}`,
@@ -3433,9 +3545,7 @@ function gitObjectSpec(commit: string, path: string): string {
   return spec;
 }
 
-function applyRecordTupleSelections(
-  selections: readonly { paths: RecordTuplePaths; commit: string }[],
-): string[] {
+function applyRecordTupleSelections(selections: readonly RecordTupleSelection[]): string[] {
   const commitByPath = new Map<string, string>();
   for (const selection of selections) {
     for (const path of recordTuplePathList(selection.paths)) {
@@ -3466,6 +3576,15 @@ function applyRecordTupleSelections(
     for (const batch of chunked(checkoutPaths, GIT_PATHSPEC_BATCH_SIZE)) {
       runGit(["checkout", commit, "--", ...batch]);
     }
+  }
+  const deletedPaths = uniqueNonEmpty(
+    selections.flatMap((selection) => selection.deletedPaths ?? []),
+  );
+  for (const batch of chunked(deletedPaths, GIT_PATHSPEC_BATCH_SIZE)) {
+    runGit(["rm", "-r", "--ignore-unmatch", "--", ...batch], {
+      allowFailure: true,
+      quiet: true,
+    });
   }
   return selectedPaths;
 }
@@ -3568,9 +3687,15 @@ type GitTreePatch = {
   directories: Map<string, GitTreePatch>;
 };
 
+type RecordTupleSelection = {
+  paths: RecordTuplePaths;
+  commit: string;
+  deletedPaths?: readonly string[];
+};
+
 function rewriteRecordTupleSelectionsTree(
   remoteTree: string,
-  selections: readonly { paths: RecordTuplePaths; commit: string }[],
+  selections: readonly RecordTupleSelection[],
 ): string {
   const patch: GitTreePatch = { files: new Map(), directories: new Map() };
   for (const selection of selections) {
@@ -3585,7 +3710,11 @@ function rewriteRecordTupleSelectionsTree(
     ]);
     const sourceByPath = new Map(entries.map((entry) => [entry.name, entry]));
     for (const path of paths) {
-      addGitTreePatch(patch, path.split("/"), sourceByPath.get(path) ?? null);
+      addGitTreePatch(
+        patch,
+        path.split("/"),
+        selection.deletedPaths?.includes(path) ? null : (sourceByPath.get(path) ?? null),
+      );
     }
   }
   return writePatchedGitTree(remoteTree, patch, new Set(), { allowReplace: true });

--- a/src/repair/record-tuple.ts
+++ b/src/repair/record-tuple.ts
@@ -344,6 +344,47 @@ export function validateRecordTuple(tuple: RecordTupleContents, label = "tuple")
   inspectRecordTuple(tuple, label);
 }
 
+export function convergeRecordTupleSidecars(tuple: RecordTupleContents): {
+  tuple: RecordTupleContents;
+  deletedPaths: string[];
+} {
+  const deletedPaths: string[] = [];
+  let plan = tuple.plan;
+  let packet = tuple.packet;
+  const hasSinglePrimary = (tuple.item === null) !== (tuple.closed === null);
+
+  // Sidecars derive their authority from the primary record. A deleted primary
+  // cannot leave either sidecar behind, and closed records cannot carry a work
+  // plan. Dual primaries remain contradictory and are deliberately untouched
+  // so strict validation can quarantine them instead of choosing one.
+  if (tuple.item === null && tuple.closed === null) {
+    if (plan !== null) deletedPaths.push(tuple.paths.plan);
+    if (packet !== null) deletedPaths.push(tuple.paths.packet);
+    plan = null;
+    packet = null;
+  } else if (hasSinglePrimary) {
+    if (tuple.closed !== null && plan !== null) {
+      deletedPaths.push(tuple.paths.plan);
+      plan = null;
+    }
+    const primary = tuple.item ?? tuple.closed;
+    const frontMatter = parseFrontMatter(primary!);
+    const digest = frontMatter.get("decision_packet_sha256");
+    const pointer = frontMatter.get("decision_packet_path");
+    const packetWasCleared =
+      (digest === undefined && pointer === undefined) || (digest === "none" && pointer === "none");
+    if (packetWasCleared && packet !== null) {
+      deletedPaths.push(tuple.paths.packet);
+      packet = null;
+    }
+  }
+
+  return {
+    tuple: { ...tuple, plan, packet },
+    deletedPaths,
+  };
+}
+
 export function recordTupleContentsEqual(
   left: RecordTupleContents,
   right: RecordTupleContents,

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -12,7 +12,12 @@ import {
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
 import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
 import { publishMainCommit } from "./git-publish.js";
-import { recordTuplePaths, validateRecordTuple, type RecordTupleContents } from "./record-tuple.js";
+import {
+  convergeRecordTupleSidecars,
+  recordTuplePaths,
+  validateRecordTuple,
+  type RecordTupleContents,
+} from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
 
 export const DEFAULT_STATE_MATERIALIZER_MAX_ROWS = 2_000;
@@ -252,36 +257,6 @@ export function planStateMaterialization(
         contentByPath.delete(displacedPrimary);
         if (currentFiles.has(displacedPrimary)) deletes.add(displacedPrimary);
         addPublishPath(displacedPrimary);
-
-        if (
-          primaryWrite.section === "closed" &&
-          !tuple.operations.some((operation) => operation.path === paths.plan)
-        ) {
-          contentByPath.delete(paths.plan);
-          if (currentFiles.has(paths.plan)) deletes.add(paths.plan);
-          addPublishPath(paths.plan);
-        }
-        if (
-          typeof primaryWrite.content === "string" &&
-          !primaryReferencesDecisionPacket(primaryWrite.content) &&
-          !tuple.operations.some((operation) => operation.path === paths.packet)
-        ) {
-          contentByPath.delete(paths.packet);
-          if (currentFiles.has(paths.packet)) deletes.add(paths.packet);
-          addPublishPath(paths.packet);
-        }
-      } else if (
-        tuple.operations.some(
-          (operation) =>
-            (operation.section === "items" || operation.section === "closed") && operation.deleted,
-        )
-      ) {
-        for (const sidecar of [paths.plan, paths.packet]) {
-          if (tuple.operations.some((operation) => operation.path === sidecar)) continue;
-          contentByPath.delete(sidecar);
-          if (currentFiles.has(sidecar)) deletes.add(sidecar);
-          addPublishPath(sidecar);
-        }
       }
       const target = (path: string): string | null => {
         if (deletes.has(path)) return null;
@@ -294,7 +269,13 @@ export function planStateMaterialization(
         plan: target(paths.plan),
         packet: target(paths.packet),
       };
-      validateRecordTuple(contents, `record tuple projection ${record.key}`);
+      const converged = convergeRecordTupleSidecars(contents);
+      for (const path of converged.deletedPaths) {
+        contentByPath.delete(path);
+        if (currentFiles.has(path)) deletes.add(path);
+        addPublishPath(path);
+      }
+      validateRecordTuple(converged.tuple, `record tuple projection ${record.key}`);
       continue;
     }
 
@@ -405,6 +386,12 @@ export async function runStateMaterializer(
       const currentFiles = readCurrentFiles(materializationPaths(hydrated.records), process.cwd());
       const isolated = planStateMaterializationWithIsolation(hydrated.records, currentFiles);
       const failures = [...hydrated.failures, ...isolated.failures];
+      const publicationFailureSeqs = new Set<number>();
+      const tupleRecordsByKey = new Map(
+        hydrated.records
+          .filter((record) => record.kind === "record_tuple")
+          .map((record) => [record.key, record]),
+      );
       const plan = isolated.plan;
       applyStateMaterializationPlan(plan, process.cwd());
       const recordTuplePaths = plan.publishPaths.filter(isRecordTupleProjectionPath);
@@ -426,9 +413,23 @@ export async function runStateMaterializer(
           maxAttempts: publishMaxAttempts,
           pushAttempts: publishPushAttempts,
           rebaseStrategy: "reconcile-records",
+          onRecordTupleFailure: ({ key, reason }) => {
+            const record = tupleRecordsByKey.get(key);
+            if (!record) {
+              throw new Error(`git publisher isolated an unknown record tuple: ${key}`);
+            }
+            if (publicationFailureSeqs.has(record.seq)) return;
+            publicationFailureSeqs.add(record.seq);
+            failures.push({
+              seq: record.seq,
+              key,
+              reason: materializationFailureReason(reason),
+              retryable: false,
+            });
+          },
         });
       }
-      summary.committed += plan.selected;
+      summary.committed += plan.selected - publicationFailureSeqs.size;
       summary.skipped += selected.skipped + hydrated.skipped + plan.skipped;
       summary.errors += failures.length;
       for (const failure of failures) {
@@ -817,21 +818,6 @@ function recordTupleRevision(record: StateAppendRecord): number | null {
   if (!isRecord(record.payload)) return null;
   const revision = Number(record.payload.revision);
   return Number.isSafeInteger(revision) && revision >= 1 ? revision : null;
-}
-
-function primaryReferencesDecisionPacket(content: string): boolean {
-  const normalized = content.replace(/\r\n/g, "\n");
-  if (!normalized.startsWith("---\n")) return false;
-  const end = normalized.indexOf("\n---", 4);
-  if (end === -1) return false;
-  const frontMatter = new Map<string, string>();
-  for (const line of normalized.slice(4, end).split("\n")) {
-    const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
-    if (match?.[1]) frontMatter.set(match[1], match[2] ?? "");
-  }
-  const digest = frontMatter.get("decision_packet_sha256");
-  const pointer = frontMatter.get("decision_packet_path");
-  return Boolean(digest && pointer && digest !== "none" && pointer !== "none");
 }
 
 function assertProjectedContent(operation: RecordTupleProjectionOperation, content: string): void {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -1206,6 +1206,127 @@ test("reconcile-records quarantines an ambiguous valid tuple without blocking in
   );
 });
 
+test("reconcile-records deletes a packet orphaned by the authoritative primary", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  const base = writeRecordTuple(work, {
+    number: 43,
+    marker: "base packet",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  const cleared = writeRecordTuple(work, {
+    number: 43,
+    marker: "packet pointer cleared",
+    reviewedAt: "2026-07-09T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:01:00Z",
+    packet: false,
+  });
+  write(path.join(work, recordsRoot, "decision-packets/43.json"), base.packet);
+
+  assert.equal(
+    withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: clear packet pointer",
+        paths: [recordsRoot],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "reconcile-records",
+      }),
+    ),
+    "committed",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/43.md`], root),
+    cleared.primary,
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/decision-packets/43.json`], root),
+  );
+});
+
+test("reconcile-records isolates malformed local tuples and commits valid siblings", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
+  const origin = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  const recordsRoot = "records/openclaw-openclaw";
+  run("git", ["init", "--bare", origin], root);
+  run("git", ["clone", origin, work], root);
+  configureUser(work);
+  const baseInvalid = writeRecordTuple(work, {
+    number: 44,
+    marker: "base invalid candidate",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  writeRecordTuple(work, {
+    number: 45,
+    marker: "base valid sibling",
+    reviewedAt: "2026-07-09T23:00:00.000Z",
+    itemUpdatedAt: "2026-07-09T22:59:00Z",
+  });
+  run("git", ["add", "."], work);
+  run("git", ["commit", "-m", "initial"], work);
+  run("git", ["push", "origin", "HEAD:main"], work);
+  run("git", ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"], root);
+  run("git", ["checkout", "-B", "main", "origin/main"], work);
+
+  writeRecordTuple(work, {
+    number: 44,
+    marker: "malformed local candidate",
+    reviewedAt: "2026-07-09T23:02:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:01:00Z",
+  });
+  fs.appendFileSync(path.join(work, recordsRoot, "decision-packets/44.json"), " ");
+  const valid = writeRecordTuple(work, {
+    number: 45,
+    marker: "valid local sibling",
+    reviewedAt: "2026-07-09T23:03:00.000Z",
+    itemUpdatedAt: "2026-07-09T23:02:00Z",
+  });
+  const failures = [];
+
+  assert.equal(
+    withCwd(work, () =>
+      publishMainCommit({
+        message: "chore: isolate malformed tuple",
+        paths: [recordsRoot],
+        maxAttempts: 1,
+        pushAttempts: 1,
+        rebaseStrategy: "reconcile-records",
+        onRecordTupleFailure: (failure) => failures.push(failure),
+      }),
+    ),
+    "committed",
+  );
+  assert.deepEqual(failures, [
+    {
+      key: "openclaw-openclaw/44",
+      reason:
+        "Invalid record tuple openclaw-openclaw/44: local reconciliation decision packet digest mismatch",
+    },
+  ]);
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/44.md`], root),
+    baseInvalid.primary,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `main:${recordsRoot}/items/45.md`], root),
+    valid.primary,
+  );
+});
+
 test("reconcile-records retries after a full push batch loses continuous state races", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -145,12 +145,12 @@ test("materializer commits one canonical record tuple atomically", async () => {
   assert.deepEqual(commitPaths.sort(), tuple.operations.map((operation) => operation.path).sort());
 });
 
-test("materializer projects an items-to-closed move by deleting the displaced primary and stale plan", () => {
+test("materializer projects an items-to-closed move by deleting an explicitly retained plan", () => {
   const open = canonicalTuplePayload(45, "open", "2026-07-20T12:00:00.000Z");
   const closed = canonicalTuplePayload(45, "closed", "2026-07-20T12:10:00.000Z", {
     section: "closed",
     revision: 2,
-    includePlan: false,
+    includePlan: true,
   });
   const currentFiles = new Map(
     open.operations.map((operation) => [operation.path, operation.content!]),
@@ -170,6 +170,37 @@ test("materializer projects an items-to-closed move by deleting the displaced pr
     true,
   );
   assert.equal(plan.publishPaths.includes("records/openclaw-openclaw/items/45.md"), true);
+  assert.equal(
+    plan.writes.some((write) => write.path === "records/openclaw-openclaw/plans/45.md"),
+    false,
+  );
+});
+
+test("materializer deletes a retained packet when the authoritative primary clears its pointer", () => {
+  const base = canonicalTuplePayload(48, "packet-base", "2026-07-20T12:00:00.000Z");
+  const cleared = clearDecisionPacketReference(
+    canonicalTuplePayload(48, "packet-cleared", "2026-07-20T12:10:00.000Z", { revision: 2 }),
+  );
+  const currentFiles = new Map(
+    base.operations.map((operation) => [operation.path, operation.content!]),
+  );
+
+  const plan = planStateMaterialization(
+    [record(1, "record_tuple", "openclaw-openclaw/48", cleared)],
+    currentFiles,
+  );
+
+  assert.equal(
+    cleared.operations.some((operation) => operation.section === "decision-packets"),
+    true,
+  );
+  assert.equal(plan.deletes.includes("records/openclaw-openclaw/decision-packets/48.json"), true);
+  assert.equal(
+    plan.writes.some(
+      (write) => write.path === "records/openclaw-openclaw/decision-packets/48.json",
+    ),
+    false,
+  );
 });
 
 test("materializer coalesces section-changing tuple records by highest revision", () => {
@@ -372,6 +403,75 @@ test("materializer preserves a fresher concurrent git tuple through winner seman
     showState(fixture, "records/openclaw-openclaw/items/44.md"),
     /incoming-older/,
   );
+});
+
+test("materializer dead-letters a normalize-phase filename alias and commits ordinary state", async () => {
+  const fixture = createStateFixture();
+  const alias = canonicalTuplePayload(49, "legacy alias", "2026-07-20T12:00:00.000Z");
+  writeTupleFiles(fixture.state, alias);
+  const recordsRoot = path.join(fixture.state, "records/openclaw-openclaw");
+  fs.renameSync(
+    path.join(recordsRoot, "items/49.md"),
+    path.join(recordsRoot, "items/openclaw-openclaw-49.md"),
+  );
+  fs.rmSync(path.join(recordsRoot, "plans/49.md"));
+  run("git", ["add", "records/openclaw-openclaw"], fixture.state);
+  run("git", ["commit", "-m", "legacy alias tuple"], fixture.state);
+  run("git", ["push", "origin", "HEAD:state"], fixture.state);
+  fs.cpSync(path.join(fixture.state, "records"), path.join(fixture.source, "records"), {
+    recursive: true,
+  });
+
+  const records = [
+    record(
+      1,
+      "record_tuple",
+      "openclaw-openclaw/49",
+      canonicalTuplePayload(49, "canonical incoming", "2026-07-20T12:10:00.000Z", {
+        revision: 2,
+      }),
+    ),
+    record(2, "sweep_status", "openclaw-openclaw", sweepStatus("continued", "12:10:01.000")),
+  ];
+  let drainCalls = 0;
+  let disposition: Record<string, unknown> | null = null;
+  const fetchImpl = signedQueueFetch(async (url, body) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "normalize-alias", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/dispose");
+    disposition = body;
+    return Response.json({ ok: true, acked: 2, retried: 0, dead_lettered: 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({ env: materializerEnv(), fetchImpl }),
+  );
+
+  assert.deepEqual(summary, { drained: 2, committed: 1, acked: 2, skipped: 0, errors: 1 });
+  assert.equal(
+    JSON.parse(showState(fixture, "results/sweep-status/openclaw-openclaw.json")).detail,
+    "continued",
+  );
+  assert.deepEqual(disposition, {
+    drain_token: "normalize-alias",
+    failures: [
+      {
+        seq: 1,
+        reason:
+          "Invalid record tuple openclaw-openclaw/49: ambiguous items filenames 49.md, openclaw-openclaw-49.md",
+        retryable: false,
+      },
+    ],
+  });
+  assert.equal(
+    statePathExists(fixture, "records/openclaw-openclaw/items/openclaw-openclaw-49.md"),
+    true,
+  );
+  assert.equal(statePathExists(fixture, "records/openclaw-openclaw/items/49.md"), false);
 });
 
 test("materializer does not ack a drain when the state push fails", async () => {
@@ -579,6 +679,19 @@ function canonicalTuplePayload(
       oversize: false,
     })),
   };
+}
+
+function clearDecisionPacketReference(tuple: TupleTestPayload): TupleTestPayload {
+  const primary = tuple.operations.find(
+    (operation) => operation.section === "items" || operation.section === "closed",
+  );
+  if (!primary?.content) throw new Error("tuple primary is missing");
+  primary.content = primary.content
+    .replace(/^decision_packet_sha256: .*$/m, "decision_packet_sha256: none")
+    .replace(/^decision_packet_path: .*$/m, "decision_packet_path: none");
+  primary.digest = createHash("sha256").update(primary.content).digest("hex");
+  primary.bytes = Buffer.byteLength(primary.content);
+  return tuple;
 }
 
 function writeTupleFiles(root: string, tuple: TupleTestPayload): void {


### PR DESCRIPTION
## Summary

- Converge record-tuple sidecars from the authoritative primary: no primary drops plan and packet, a closed primary drops plan, and a cleared packet pointer drops packet.
- Route every per-tuple projection failure through the existing dead-letter disposition instead of aborting unrelated tuple publication.
- Preserve publish-fatal handling for transport and parse corruption, with fencing, digest, and revision semantics unchanged.

## Incident

[Run 30199610295](https://github.com/openclaw/clawsweeper/actions/runs/30199610295) aborted the whole cycle on `keeps a packet after clearing its pointer`. Normalize-phase tuple validation was still outside the isolation introduced by #867, so one invalid tuple prevented every independent repair from publishing.

The shared convergence helper now makes the primary record authoritative over its sidecars before validation and reconciliation. The publisher reports isolated tuple failures back to materialization, which records the normal dead-letter disposition without weakening repository-wide corruption handling.

## Throw-site audit

| Failure site | Scope | Disposition |
| --- | --- | --- |
| Tuple filename/key resolution | One record tuple | Dead-letter that tuple; continue independent tuples |
| Structural tuple validation during normalization | One record tuple | Dead-letter that tuple; continue independent tuples |
| Reconciliation winner arbitration | One record tuple | Dead-letter that tuple; continue independent tuples |
| Push-race rebuild resolution, validation, or arbitration | One record tuple | Dead-letter that tuple; continue independent tuples |
| Git transport failure or repository/batch parse corruption | Whole publish | Remain publish-fatal |

## Proof

- Autoreview: CLEAN at 0.96 confidence; TruffleHog clean.
- State materializer targeted suite: 15/15 passed.
- Git publisher targeted suite: 65/65 passed, with the known local credential-fixture caveat unchanged.
- Unit suite: 1,614 passed.
- `pnpm run check`: code-owned checks green; only known environment failures remained.

