### PR TITLE
fix(reconcile): add permission-pull-requests: write to target write t…

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -204,6 +204,7 @@ jobs:
           owner: openclaw
           repositories: openclaw
           permission-issues: write
+          permission-pull-requests: write
 
       - name: Recover orphaned review placeholders
         env:

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1007,6 +1007,7 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
   assert.match(sweepJob, /build-script: build/);
   assert.match(sweepJob, /name: Create target write token/);
   assert.match(sweepJob, /owner: openclaw\s+repositories: openclaw\s+permission-issues: write/);
+  assert.match(sweepJob, /permission-pull-requests: write/);
   assert.match(sweepJob, /name: Recover orphaned review placeholders/);
   assert.match(sweepJob, /run: node dist\/review-placeholder-recovery\.js/);
   assert.match(


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Closes #864

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Resolves a problem where the review-placeholder recovery workflow would silently
fail to label any pull request with `clawsweeper-recovery-stuck` during
stuck-placeholder escalation, returning a 403 on every PR while issues were
labelled successfully. This caused 50+ consecutive scheduled reconciliation runs
to fail and left stranded pull requests permanently invisible to the escalation
signal.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

GitHub's fine-grained token model requires both `permission-issues: write` and
`permission-pull-requests: write` to label a pull request, even when using the
shared `/issues/{number}/labels` endpoint. The "Create target write token" step
in `exact-review-reconcile.yml` was the only write-token step in the repository
that touched pull requests without requesting the pull-requests scope; adding it
is the complete fix. The regression test that was pinning the broken
issues-only assertion has also been updated to guard against recurrence.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Operators and maintainers will now see `clawsweeper-recovery-stuck` applied to
stranded pull requests (not only issues) during scheduled reconciliation runs.
The orphaned-placeholder backlog will drain as escalation resumes across both
item types, and the scheduled workflow will stop failing.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

**Before** — production run [`30187501666`](https://github.com/openclaw/clawsweeper/actions/runs/30187501666) (2026-07-26T04:15:45Z):
```
403 (escalation failed) : 41 PULL_REQUEST / 0 ISSUE
escalated=0  errors=41
```

**After** — targeted test run with the fix applied:
```
✔ terminal exact-review runs reconcile through a signed isolated backstop (3.1995ms)
ℹ pass 1  ℹ fail 0
```

The app installation already holds the `pull-requests: write` grant —
`clawsweeper[bot]` successfully labels PRs in `openclaw/openclaw`
(e.g. openclaw/openclaw#113395, labelled 2026-07-24) — so this change does not
require any installation update.
