### PR TITLE
fix(state): retire partial-clone mode; bounded deepen with rebuild escalation

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -313,6 +313,7 @@ type StateAppendWindowRow = {
   delivery_id: string;
   materialization_attempts: number;
   materialization_first_failed_at: number | null;
+  materialization_last_error: string | null;
 };
 type ExactReviewSupersessionAudit = {
   auditId: string;
@@ -6513,7 +6514,7 @@ export class ExactReviewQueue {
     const candidates = Array.from(
       this.storage.sql.exec(
         `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id,
-                materialization_attempts, materialization_first_failed_at
+                materialization_attempts, materialization_first_failed_at, materialization_last_error
            FROM ${STATE_APPEND_WINDOW_TABLE}
           WHERE drain_token IS NULL
           ORDER BY seq
@@ -6553,7 +6554,7 @@ export class ExactReviewQueue {
     return Array.from(
       this.storage.sql.exec(
         `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id,
-                materialization_attempts, materialization_first_failed_at
+                materialization_attempts, materialization_first_failed_at, materialization_last_error
            FROM ${STATE_APPEND_WINDOW_TABLE}
           WHERE drain_token = ?
           ORDER BY seq`,
@@ -9550,6 +9551,9 @@ function stateAppendWindowRowJson(row: StateAppendWindowRow) {
     produced_at: row.produced_at,
     delivery_id: row.delivery_id,
     materialization_attempts: Number(row.materialization_attempts || 0),
+    ...(row.materialization_last_error
+      ? { materialization_last_error: row.materialization_last_error }
+      : {}),
   };
 }
 

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -72,6 +72,7 @@ export type GitPublishOptions = {
   remote?: string;
   branch?: string;
   rebaseStrategy?: RebaseStrategy | undefined;
+  shallowHistoryExhaustionStrategy?: ShallowHistoryExhaustionStrategy | undefined;
   onRecordTupleFailure?: ((failure: RecordTuplePublishFailure) => void) | undefined;
 };
 
@@ -83,6 +84,18 @@ export type RecordTuplePublishFailure = {
 type RecordTupleFailureReporter = (failure: RecordTuplePublishFailure) => void;
 
 export type RebaseStrategy = "normal" | "theirs" | "apply-records" | "reconcile-records";
+
+export type ShallowHistoryExhaustionStrategy = "defer" | "rebuild-on-remote-head";
+
+export const SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION =
+  "git_publish:merge_base_shallow_recovery:bounded_deepen_exhausted";
+
+export class GitShallowHistoryExhaustionError extends Error {
+  constructor(readonly deepenedBy: number) {
+    super(`Shallow Git recovery deferred to the next run after deepening by ${deepenedBy} commits`);
+    this.name = "GitShallowHistoryExhaustionError";
+  }
+}
 
 export type GitRunOptions = {
   allowFailure?: boolean;
@@ -117,13 +130,16 @@ const GIT_TREE_LIST_MAX_BUFFER = 64 * 1024 * 1024;
 const GIT_STATE_DIFF_MAX_BUFFER = 256 * 1024 * 1024;
 const RECONCILIATION_TUPLE_CHUNK_SIZE = 128;
 const PUBLISH_FETCH_TIMEOUT_MS = 60_000;
-const COMMIT_GRAPH_FETCH_FILTER = "tree:0";
 const SHALLOW_MERGE_DEEPEN_STEP = 512;
-const SHALLOW_MERGE_MAX_DEEPEN = 2_048;
-// Recovery fetches (deepen/unshallow/refetch of the state history) are rare
-// one-time repairs but move far more data than an ordinary publish fetch; a
-// 60s budget times out on the grown state repo (prod run 29745570319).
+const SHALLOW_MERGE_MAX_DEEPEN = 1_024;
+// Recovery refetches are rare one-time repairs but move far more data than an
+// ordinary publish fetch; a 60s budget times out on the grown state repo
+// (prod run 29745570319).
 const RECOVERY_FETCH_TIMEOUT_MS = 300_000;
+// Plain shallow-history fetches transfer enough of the 39.5 GiB state repo to
+// exceed the general recovery budget. Two 512-commit deepens remain bounded by
+// the materializer runtime while this dedicated budget gives each one headroom.
+const SHALLOW_HISTORY_FETCH_TIMEOUT_MS = 900_000;
 // Branch pushes move materializer-sized batches and must outlast them, but a
 // push with no timeout turns a stalled transport into a silent hang that only
 // the job timeout can end.
@@ -477,6 +493,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
   const maxAttempts = positiveInt(options.maxAttempts, 8);
   const pushAttempts = positiveInt(options.pushAttempts, 3);
   const rebaseStrategy = options.rebaseStrategy ?? "normal";
+  const shallowHistoryExhaustionStrategy = options.shallowHistoryExhaustionStrategy ?? "defer";
   const reportedTupleFailures = new Set<string>();
   const reportTupleFailure: RecordTupleFailureReporter | undefined = options.onRecordTupleFailure
     ? (failure) => {
@@ -489,7 +506,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
     "sync",
     `paths=${uniqueNonEmpty(options.paths).length} strategy=${rebaseStrategy}`,
   );
-  prepareReconciliationStateRoot(remote, branch, rebaseStrategy);
+  prepareReconciliationStateRoot(remote, branch, rebaseStrategy, shallowHistoryExhaustionStrategy);
   // Baseline before the head sync: the source-refresh diff below must span the
   // remote commits this checkout had not seen yet, and the sync collapses them
   // into the new HEAD.
@@ -505,7 +522,13 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
     const synchronized =
       !stateBaseCommit ||
       (rebaseStrategy === "reconcile-records"
-        ? pushReconciliationCommit({ remote, branch, pushAttempts, maxAttempts })
+        ? pushReconciliationCommit({
+            remote,
+            branch,
+            pushAttempts,
+            maxAttempts,
+            shallowHistoryExhaustionStrategy,
+          })
         : pushCommit({ remote, branch, pushAttempts, rebaseStrategy }));
     if (!synchronized) {
       throw new Error(`Failed to synchronize unchanged publish with ${remote}/${branch}`);
@@ -532,6 +555,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
           branch,
           pushAttempts,
           maxAttempts,
+          shallowHistoryExhaustionStrategy,
           ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
           ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
           ...(reportTupleFailure ? { reportTupleFailure } : {}),
@@ -551,6 +575,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         maxAttempts,
         sourceCommit: reconciliationSourceCommit ?? sourceCommit,
         tupleKeys,
+        shallowHistoryExhaustionStrategy,
         ...(reportTupleFailure ? { reportTupleFailure } : {}),
       });
       return completeStatePublish(result, options.paths, stateBaseCommit);
@@ -566,6 +591,7 @@ function publishMainCommitInternal(options: GitPublishOptions): PublishResult {
         branch,
         pushAttempts,
         maxAttempts,
+        shallowHistoryExhaustionStrategy,
         ...(reconciliationSourceCommit ? { reconciliationSourceCommit } : {}),
         ...(reconciliationTupleKeys ? { reconciliationTupleKeys } : {}),
         ...(reportTupleFailure ? { reportTupleFailure } : {}),
@@ -890,7 +916,7 @@ function recoverUnavailableGitObjects(remote: string, branch: string, failure: u
   }
   const deepened = spawnBoundedFetch(
     ["fetch", "--deepen=1", remote, branch],
-    RECOVERY_FETCH_TIMEOUT_MS,
+    SHALLOW_HISTORY_FETCH_TIMEOUT_MS,
   );
   if (deepened.status === 0 && gitObjectIdsAvailable(objectIds)) return;
   if (!isShallowRepository()) {
@@ -899,7 +925,7 @@ function recoverUnavailableGitObjects(remote: string, branch: string, failure: u
   }
   const unshallowed = spawnBoundedFetch(
     ["fetch", "--unshallow", remote, branch],
-    RECOVERY_FETCH_TIMEOUT_MS,
+    SHALLOW_HISTORY_FETCH_TIMEOUT_MS,
   );
   if (unshallowed.status === 0 && gitObjectIdsAvailable(objectIds)) return;
   assertGitObjectsAvailable(objectIds);
@@ -1108,6 +1134,7 @@ function pushReconciliationCommit(options: {
   branch: string;
   pushAttempts: number;
   maxAttempts: number;
+  shallowHistoryExhaustionStrategy: ShallowHistoryExhaustionStrategy;
   reconciliationSourceCommit?: string;
   reconciliationTupleKeys?: ReadonlySet<string>;
   reportTupleFailure?: RecordTupleFailureReporter;
@@ -1119,6 +1146,7 @@ function pushReconciliationCommit(options: {
         branch: options.branch,
         pushAttempts: options.pushAttempts,
         rebaseStrategy: "reconcile-records",
+        shallowHistoryExhaustionStrategy: options.shallowHistoryExhaustionStrategy,
         ...(options.reconciliationSourceCommit
           ? { reconciliationSourceCommit: options.reconciliationSourceCommit }
           : {}),
@@ -1142,6 +1170,7 @@ function pushReconciliationCommit(options: {
     branch: options.branch,
     pushAttempts: options.pushAttempts,
     rebaseStrategy: "reconcile-records",
+    shallowHistoryExhaustionStrategy: options.shallowHistoryExhaustionStrategy,
     ...(options.reconciliationSourceCommit
       ? { reconciliationSourceCommit: options.reconciliationSourceCommit }
       : {}),
@@ -1189,6 +1218,7 @@ export function mergeBaseWithShallowRecovery(
   right: string,
   remote: string,
   branch: string,
+  exhaustionStrategy: ShallowHistoryExhaustionStrategy = "defer",
 ): { base: string | null; recoveredShallowMiss: boolean } {
   const args = ["merge-base", left, right];
   let result = spawnGit(args, { quiet: true });
@@ -1200,12 +1230,11 @@ export function mergeBaseWithShallowRecovery(
     return { base: null, recoveredShallowMiss: false };
   }
 
-  configureCommitGraphPromisor(remote);
   let deepenedBy = 0;
   while (deepenedBy < SHALLOW_MERGE_MAX_DEEPEN && isShallowRepository()) {
     const deepenBy = Math.min(SHALLOW_MERGE_DEEPEN_STEP, SHALLOW_MERGE_MAX_DEEPEN - deepenedBy);
-    const deepenArgs = commitGraphHistoryFetchArgs(`--deepen=${deepenBy}`, remote, branch);
-    const deepen = spawnBoundedFetch(deepenArgs, RECOVERY_FETCH_TIMEOUT_MS);
+    const deepenArgs = ["fetch", `--deepen=${deepenBy}`, remote, branch];
+    const deepen = spawnBoundedFetch(deepenArgs, SHALLOW_HISTORY_FETCH_TIMEOUT_MS);
     if (deepen.status !== 0) throw gitRunError(deepen, deepenArgs);
     deepenedBy += deepenBy;
     result = spawnGit(args, { quiet: true });
@@ -1218,70 +1247,16 @@ export function mergeBaseWithShallowRecovery(
     return { base: null, recoveredShallowMiss: true };
   }
 
-  if (modelRecoveryConfigured()) {
-    const attempt = executeModelRecovery({
-      phase: "merge_base_shallow_recovery",
-      failure: gitRunError(result, args),
-      shallow: true,
-      remote,
-      branch,
-      recentAttempts: [
-        `merge_base:${left}:${right}:status=${result.status}`,
-        `bounded_deepen:${deepenedBy}:merge_base_status=${result.status}`,
-      ],
-      availableActions: [
-        "refetch_depth1",
-        "deepen",
-        "unshallow",
-        "rebuild_on_remote_head",
-        "defer_to_next_run",
-        "give_up",
-      ],
-      handlers: commitGraphRecoveryHandlers(remote, branch, {
-        rebuildOnRemoteHead: () => {},
-        deferToNextRun: () => {},
-        giveUp: () => {},
-      }),
-    });
-    if (attempt) {
-      throwForModelRecoveryDirective(attempt.advice, attempt.execution);
-      if (attempt.execution.directive === "rebuild_on_remote_head") {
-        recordRecoveryOutcome(attempt.advice, "rebuild_on_remote_head_selected");
-        return { base: null, recoveredShallowMiss: true };
-      }
-      result = spawnGit(args, { quiet: true });
-      if (result.status === 0) {
-        recordRecoveryOutcome(attempt.advice, "merge_base_recovered");
-        return { base: result.stdout.trim(), recoveredShallowMiss: true };
-      }
-      if (result.status !== 1) {
-        recordRecoveryOutcome(attempt.advice, "verification_failed", {
-          error: gitRunError(result, args),
-        });
-        throw gitRunError(result, args);
-      }
-      if (!isShallowRepository()) {
-        recordRecoveryOutcome(attempt.advice, "history_hydrated_no_merge_base");
-        return { base: null, recoveredShallowMiss: true };
-      }
-      recordRecoveryOutcome(attempt.advice, "verification_failed");
-      console.warn(
-        "Model-guided shallow recovery did not find a merge base; using deterministic fallback",
-      );
-    }
-  }
-
-  if (isShallowRepository()) {
-    const unshallowArgs = commitGraphHistoryFetchArgs("--unshallow", remote, branch);
-    const unshallow = spawnBoundedFetch(unshallowArgs, RECOVERY_FETCH_TIMEOUT_MS);
-    if (unshallow.status !== 0) throw gitRunError(unshallow, unshallowArgs);
-    result = spawnGit(args, { quiet: true });
-    if (result.status === 0) {
-      return { base: result.stdout.trim(), recoveredShallowMiss: true };
-    }
-  }
   if (result.status !== 1) throw gitRunError(result, args);
-  if (isShallowRepository()) throw gitRunError(result, args);
+  if (isShallowRepository()) {
+    if (exhaustionStrategy === "rebuild-on-remote-head") {
+      console.log(
+        `Persistent shallow-history exhaustion after deepening by ${deepenedBy} commits; rebuilding from ${remote}/${branch}`,
+      );
+      return { base: null, recoveredShallowMiss: true };
+    }
+    throw new GitShallowHistoryExhaustionError(deepenedBy);
+  }
   return { base: null, recoveredShallowMiss: true };
 }
 
@@ -1289,6 +1264,7 @@ function prepareReconciliationStateRoot(
   remote: string,
   branch: string,
   rebaseStrategy: RebaseStrategy,
+  exhaustionStrategy: ShallowHistoryExhaustionStrategy,
 ): void {
   const stateRoot = publishRoot();
   if (
@@ -1304,7 +1280,13 @@ function prepareReconciliationStateRoot(
   if (spawnGit(["merge-base", "--is-ancestor", "HEAD", remoteRef], { quiet: true }).status === 0) {
     return;
   }
-  const semanticBase = mergeBaseWithShallowRecovery("HEAD", remoteRef, remote, branch);
+  const semanticBase = mergeBaseWithShallowRecovery(
+    "HEAD",
+    remoteRef,
+    remote,
+    branch,
+    exhaustionStrategy,
+  );
   if (!semanticBase.base) {
     console.log(
       `No common Git base with ${remoteRef}; resetting the unpublished reconciliation checkpoint to the remote head`,
@@ -1356,6 +1338,7 @@ function publishReconciliationChunks(options: {
   maxAttempts: number;
   sourceCommit: string;
   tupleKeys: readonly string[];
+  shallowHistoryExhaustionStrategy: ShallowHistoryExhaustionStrategy;
   reportTupleFailure?: RecordTupleFailureReporter;
 }): PublishResult {
   const chunks = chunked(options.tupleKeys, RECONCILIATION_TUPLE_CHUNK_SIZE);
@@ -1377,6 +1360,7 @@ function publishReconciliationChunks(options: {
         allowedTupleKeys,
         false,
         options.reportTupleFailure,
+        options.shallowHistoryExhaustionStrategy,
       )
     ) {
       throw new Error(`Failed to build reconciliation checkpoint ${index + 1}/${chunks.length}`);
@@ -1393,6 +1377,7 @@ function publishReconciliationChunks(options: {
         branch: options.branch,
         pushAttempts: options.pushAttempts,
         maxAttempts: options.maxAttempts,
+        shallowHistoryExhaustionStrategy: options.shallowHistoryExhaustionStrategy,
         reconciliationSourceCommit: options.sourceCommit,
         reconciliationTupleKeys: allowedTupleKeys,
         ...(options.reportTupleFailure ? { reportTupleFailure: options.reportTupleFailure } : {}),
@@ -2656,6 +2641,7 @@ export function pushCommit(options: {
   reconciliationSourceCommit?: string;
   reconciliationTupleKeys?: ReadonlySet<string>;
   boundedRemoteHeadRebuild?: boolean;
+  shallowHistoryExhaustionStrategy?: ShallowHistoryExhaustionStrategy;
   reportTupleFailure?: RecordTupleFailureReporter;
 }): boolean {
   const remote = options.remote ?? "origin";
@@ -2710,6 +2696,7 @@ export function pushCommit(options: {
             options.reconciliationTupleKeys,
             options.boundedRemoteHeadRebuild,
             options.reportTupleFailure,
+            options.shallowHistoryExhaustionStrategy,
           );
         } catch (error) {
           recordRecoveryOutcome(recovery.advice, "rebuild_on_remote_head_failed", { error });
@@ -2752,6 +2739,7 @@ export function pushCommit(options: {
           options.reconciliationTupleKeys,
           options.boundedRemoteHeadRebuild,
           options.reportTupleFailure,
+          options.shallowHistoryExhaustionStrategy,
         )
       ) {
         return false;
@@ -2885,51 +2873,15 @@ function gitFetchRecoveryHandlers(
       );
     },
     deepen: (depth) => {
-      spawnBoundedFetch(["fetch", `--deepen=${depth}`, remote, branch], RECOVERY_FETCH_TIMEOUT_MS);
+      spawnBoundedFetch(
+        ["fetch", `--deepen=${depth}`, remote, branch],
+        SHALLOW_HISTORY_FETCH_TIMEOUT_MS,
+      );
     },
     unshallow: () => {
-      spawnBoundedFetch(["fetch", "--unshallow", remote, branch], RECOVERY_FETCH_TIMEOUT_MS);
+      spawnBoundedFetch(["fetch", "--unshallow", remote, branch], SHALLOW_HISTORY_FETCH_TIMEOUT_MS);
     },
     ...directives,
-  };
-}
-
-function configureCommitGraphPromisor(remote: string): void {
-  // Merge-base needs commits only; keep omitted trees lazy-fetchable for the
-  // later diff/rebase work that touches a small subset of the state checkout.
-  runGit(["config", "--local", `remote.${remote}.promisor`, "true"], { quiet: true });
-  runGit(["config", "--local", `remote.${remote}.partialclonefilter`, COMMIT_GRAPH_FETCH_FILTER], {
-    quiet: true,
-  });
-}
-
-function commitGraphHistoryFetchArgs(
-  historyArgument: `--deepen=${number}` | "--unshallow",
-  remote: string,
-  branch: string,
-): string[] {
-  return ["fetch", `--filter=${COMMIT_GRAPH_FETCH_FILTER}`, historyArgument, remote, branch];
-}
-
-function commitGraphRecoveryHandlers(
-  remote: string,
-  branch: string,
-  directives: RecoveryActionHandlers,
-): RecoveryActionHandlers {
-  return {
-    ...gitFetchRecoveryHandlers(remote, branch, directives),
-    deepen: (depth) => {
-      spawnBoundedFetch(
-        commitGraphHistoryFetchArgs(`--deepen=${depth}`, remote, branch),
-        RECOVERY_FETCH_TIMEOUT_MS,
-      );
-    },
-    unshallow: () => {
-      spawnBoundedFetch(
-        commitGraphHistoryFetchArgs("--unshallow", remote, branch),
-        RECOVERY_FETCH_TIMEOUT_MS,
-      );
-    },
   };
 }
 
@@ -3023,12 +2975,19 @@ function rebuildReconciliationCommit(
   allowedTupleKeys?: ReadonlySet<string>,
   boundedRemoteHeadRebuild = false,
   reportTupleFailure?: RecordTupleFailureReporter,
+  shallowHistoryExhaustionStrategy: ShallowHistoryExhaustionStrategy = "defer",
 ): boolean {
   const remoteRef = `${remote}/${branch}`;
   const sourceCommit = reconciliationSourceCommit ?? runGit(["rev-parse", "HEAD"]).trim();
   const mergeBase = boundedRemoteHeadRebuild
     ? mergeBaseWithoutHydration(sourceCommit, remoteRef)
-    : mergeBaseWithShallowRecovery(sourceCommit, remoteRef, remote, branch);
+    : mergeBaseWithShallowRecovery(
+        sourceCommit,
+        remoteRef,
+        remote,
+        branch,
+        shallowHistoryExhaustionStrategy,
+      );
   let baseCommit: string;
   let localPaths: string[];
   if (!mergeBase.base) {

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -11,7 +11,12 @@ import {
 } from "../action-ledger.js";
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
 import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
-import { publishMainCommit } from "./git-publish.js";
+import {
+  GitShallowHistoryExhaustionError,
+  publishMainCommit,
+  SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
+  type ShallowHistoryExhaustionStrategy,
+} from "./git-publish.js";
 import {
   convergeRecordTupleSidecars,
   recordTuplePaths,
@@ -65,6 +70,7 @@ export type StateAppendRecord = {
   produced_at: string;
   delivery_id: string;
   materialization_attempts?: number;
+  materialization_last_error?: string;
 };
 
 type StateMaterializationFailure = {
@@ -94,6 +100,7 @@ export type StateMaterializerRunOptions = {
   env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
   now?: () => Date;
+  publishCommit?: typeof publishMainCommit;
 };
 
 type StateDrainResponse = {
@@ -306,6 +313,7 @@ export async function runStateMaterializer(
   const env = options.env ?? process.env;
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? (() => new Date());
+  const publishCommit = options.publishCommit ?? publishMainCommit;
   const queueUrl = (env.QUEUE_URL ?? "").replace(/\/$/, "");
   const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
   registerStateSecretForRedaction(webhookSecret);
@@ -397,7 +405,7 @@ export async function runStateMaterializer(
       const recordTuplePaths = plan.publishPaths.filter(isRecordTupleProjectionPath);
       const regularPaths = plan.publishPaths.filter((path) => !isRecordTupleProjectionPath(path));
       if (regularPaths.length > 0) {
-        publishMainCommit({
+        publishCommit({
           message: STATE_MATERIALIZER_COMMIT_MESSAGE,
           paths: regularPaths,
           branch,
@@ -406,13 +414,16 @@ export async function runStateMaterializer(
         });
       }
       if (recordTuplePaths.length > 0) {
-        publishMainCommit({
+        publishCommit({
           message: STATE_MATERIALIZER_COMMIT_MESSAGE,
           paths: recordTuplePaths,
           branch,
           maxAttempts: publishMaxAttempts,
           pushAttempts: publishPushAttempts,
           rebaseStrategy: "reconcile-records",
+          shallowHistoryExhaustionStrategy: shallowHistoryExhaustionStrategyForRecords(
+            drain.records,
+          ),
           onRecordTupleFailure: ({ key, reason }) => {
             const record = tupleRecordsByKey.get(key);
             if (!record) {
@@ -479,6 +490,27 @@ export async function runStateMaterializer(
       summary.errors += 1;
       const message = errorMessage(error);
       console.warn(`state-materializer cycle failed: ${message}`);
+      if (error instanceof GitShallowHistoryExhaustionError) {
+        if (!drain.token) throw new Error("shallow-history deferral has no drain token");
+        const disposition = await disposeStateWindow({
+          queueUrl,
+          webhookSecret,
+          drainToken: drain.token,
+          failures: drain.records.map((record) => ({
+            seq: record.seq,
+            key: record.key,
+            reason: SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
+            retryable: true,
+          })),
+          fetchImpl,
+        });
+        summary.acked += disposition.acked;
+        console.warn(
+          `state-materializer shallow-history deferral disposition: retried=${disposition.retried} dead_lettered=${disposition.deadLettered}`,
+        );
+        finish();
+        throw new Error(stateMaterializerDeferralMessage(summary, message));
+      }
       if (message.includes("deferred to the next run")) {
         finish();
         throw new Error(stateMaterializerDeferralMessage(summary, message));
@@ -487,6 +519,20 @@ export async function runStateMaterializer(
     }
   }
   return finish();
+}
+
+export function shallowHistoryExhaustionStrategyForRecords(
+  records: readonly StateAppendRecord[],
+): ShallowHistoryExhaustionStrategy {
+  // The queue persists both fields through /state/dispose. Requiring the same
+  // last error keeps an unrelated retry from escalating this recovery phase.
+  return records.some(
+    (record) =>
+      (record.materialization_attempts ?? 0) > 0 &&
+      record.materialization_last_error === SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
+  )
+    ? "rebuild-on-remote-head"
+    : "defer";
 }
 
 export function stateMaterializerDeferralMessage(
@@ -951,6 +997,9 @@ function stateAppendRecordFrom(value: unknown): StateAppendRecord {
     ...(Object.hasOwn(value, "materialization_attempts")
       ? { materialization_attempts: Number(value.materialization_attempts) }
       : {}),
+    ...(Object.hasOwn(value, "materialization_last_error")
+      ? { materialization_last_error: String(value.materialization_last_error || "").trim() }
+      : {}),
   };
   assertStateAppendRecord(record);
   return record;
@@ -976,6 +1025,16 @@ function assertStateAppendRecord(record: StateAppendRecord): void {
     (!Number.isSafeInteger(record.materialization_attempts) || record.materialization_attempts < 0)
   ) {
     throw new Error("state drain record has invalid materialization attempts");
+  }
+  if (
+    record.materialization_last_error !== undefined &&
+    (!record.materialization_last_error ||
+      record.materialization_last_error.length > 2_000 ||
+      record.materialization_last_error.includes("\r") ||
+      record.materialization_last_error.includes("\n") ||
+      record.materialization_last_error.includes(String.fromCharCode(0)))
+  ) {
+    throw new Error("state drain record has invalid materialization last error");
   }
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7683,6 +7683,7 @@ test("state disposition commits valid rows and dead-letters a poison row after b
     ).json();
     assert.equal(drain.records.length, 1);
     assert.equal(drain.records[0].materialization_attempts, expectedAttempts);
+    assert.equal(drain.records[0].materialization_last_error, "temporary canonical fetch failure");
     const disposed = await queue.fetch(
       stateAppendQueueRequest("/state/dispose", {
         drain_token: drain.drain_token,

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -107,6 +107,16 @@ test("publisher fetches share the bounded fetch helper", () => {
   const source = fs.readFileSync(path.resolve("src/repair/git-publish.ts"), "utf8");
 
   assert.match(source, /const PUBLISH_FETCH_TIMEOUT_MS = 60_000/);
+  assert.match(source, /const RECOVERY_FETCH_TIMEOUT_MS = 300_000/);
+  assert.match(source, /const SHALLOW_HISTORY_FETCH_TIMEOUT_MS = 900_000/);
+  assert.match(
+    source,
+    /\["fetch", `--deepen=\$\{depth\}`, remote, branch\],\s*SHALLOW_HISTORY_FETCH_TIMEOUT_MS/,
+  );
+  assert.match(
+    source,
+    /\["fetch", "--unshallow", remote, branch\],\s*SHALLOW_HISTORY_FETCH_TIMEOUT_MS/,
+  );
   assert.match(
     source,
     /function fetchPublishRemote\([\s\S]*const shallow = isShallowRepository\(\)[\s\S]*runGit\(\["fetch", \.\.\.depthArgs, remote, branch\], \{/,
@@ -121,8 +131,8 @@ test("shallow merge-base recovery deepens before retrying prepare", () => {
 
     const calls = [];
     let deepened = false;
-    childProcess.spawnSync = (command, args) => {
-      calls.push({ command, args });
+    childProcess.spawnSync = (command, args, options) => {
+      calls.push({ command, args, timeout: options.timeout ?? null });
       if (command !== "git") throw new Error("unexpected command: " + command);
       if (args[0] === "merge-base") {
         return deepened
@@ -132,10 +142,7 @@ test("shallow merge-base recovery deepens before retrying prepare", () => {
       if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
         return { status: 0, stdout: "true\n", stderr: "" };
       }
-      if (args[0] === "config") {
-        return { status: 0, stdout: "", stderr: "" };
-      }
-      if (args[0] === "fetch" && args[1] === "--filter=tree:0" && args[2] === "--deepen=512") {
+      if (args[0] === "fetch" && args[1] === "--deepen=512") {
         deepened = true;
         return { status: 0, stdout: "", stderr: "" };
       }
@@ -152,61 +159,34 @@ test("shallow merge-base recovery deepens before retrying prepare", () => {
   const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
   assert.deepEqual(output.result, { base: "base-commit", recoveredShallowMiss: true });
   assert.deepEqual(
-    output.calls.filter(({ args }) => args[0] === "config").map(({ args }) => args),
+    output.calls.filter(({ args }) => args[0] === "fetch"),
     [
-      ["config", "--local", "remote.origin.promisor", "true"],
-      ["config", "--local", "remote.origin.partialclonefilter", "tree:0"],
+      {
+        command: "git",
+        args: ["fetch", "--deepen=512", "origin", "state"],
+        timeout: 900_000,
+      },
     ],
-  );
-  assert.deepEqual(
-    output.calls.filter(({ args }) => args[0] === "fetch").map(({ args }) => args),
-    [["fetch", "--filter=tree:0", "--deepen=512", "origin", "state"]],
   );
 });
 
-test("shallow merge-base recovery defers only after bounded deepening is exhausted", () => {
+test("shallow merge-base recovery defers deterministically after bounded deepening", () => {
   const script = String.raw`
     import childProcess from "node:child_process";
-    import fs from "node:fs";
     import { syncBuiltinESMExports } from "node:module";
 
-    process.env.CLAWSWEEPER_MODEL_RECOVERY_ENABLED = "1";
-    process.env.CLAWSWEEPER_ACTION_LEDGER_DISABLED = "1";
-    process.env.OPENAI_API_KEY = "test-recovery-key";
     const calls = [];
-    childProcess.spawnSync = (command, args) => {
-      if (command === "git") {
-        calls.push(args);
-        if (args[0] === "merge-base") return { status: 1, stdout: "", stderr: "" };
-        if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
-          return { status: 0, stdout: "true\n", stderr: "" };
-        }
-        if (args[0] === "config") {
-          return { status: 0, stdout: "", stderr: "" };
-        }
-        if (args[0] === "fetch" && args[1] === "--filter=tree:0" && args[2] === "--deepen=512") {
-          return { status: 0, stdout: "", stderr: "" };
-        }
-        throw new Error("unexpected git args: " + args.join(" "));
+    childProcess.spawnSync = (command, args, options) => {
+      if (command !== "git") throw new Error("unexpected command: " + command);
+      calls.push({ args, timeout: options.timeout ?? null });
+      if (args[0] === "merge-base") return { status: 1, stdout: "", stderr: "" };
+      if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
+        return { status: 0, stdout: "true\n", stderr: "" };
       }
-      if (command === process.execPath && String(args[0]).endsWith("codex-process-worker.js")) {
-        const options = JSON.parse(fs.readFileSync(args[1], "utf8"));
-        const outputIndex = options.args.lastIndexOf("--output-last-message");
-        fs.writeFileSync(
-          options.args[outputIndex + 1],
-          JSON.stringify({
-            diagnosis: "shallow merge history depth",
-            actions: ["defer_to_next_run"],
-            confidence: 1,
-          }),
-        );
-        fs.writeFileSync(
-          options.resultPath,
-          JSON.stringify({ status: 0, signal: null, stdout: "", stderr: "" }),
-        );
-        return { status: 0, signal: null, stdout: "", stderr: "" };
+      if (args[0] === "fetch" && args[1] === "--deepen=512") {
+        return { status: 0, stdout: "", stderr: "" };
       }
-      throw new Error("unexpected command: " + command);
+      throw new Error("unexpected git args: " + args.join(" "));
     };
     syncBuiltinESMExports();
     console.log = () => {};
@@ -225,37 +205,31 @@ test("shallow merge-base recovery defers only after bounded deepening is exhaust
   const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
   assert.match(
     output.message,
-    /Model-guided Git recovery deferred to the next run: shallow_merge_history_depth/,
+    /Shallow Git recovery deferred to the next run after deepening by 1024 commits/,
   );
   assert.deepEqual(
-    output.calls.filter((args) => args[0] === "fetch"),
-    Array.from({ length: 4 }, () => [
-      "fetch",
-      "--filter=tree:0",
-      "--deepen=512",
-      "origin",
-      "state",
-    ]),
+    output.calls.filter(({ args }) => args[0] === "fetch"),
+    Array.from({ length: 2 }, () => ({
+      args: ["fetch", "--deepen=512", "origin", "state"],
+      timeout: 900_000,
+    })),
   );
 });
 
-test("shallow merge-base recovery filters its final unshallow fallback", () => {
+test("persistent shallow merge-base exhaustion escalates without unshallowing", () => {
   const script = String.raw`
     import childProcess from "node:child_process";
     import { syncBuiltinESMExports } from "node:module";
 
     const calls = [];
-    let shallow = true;
-    childProcess.spawnSync = (command, args) => {
-      calls.push({ command, args });
+    childProcess.spawnSync = (command, args, options) => {
+      calls.push({ command, args, timeout: options.timeout ?? null });
       if (command !== "git") throw new Error("unexpected command: " + command);
       if (args[0] === "merge-base") return { status: 1, stdout: "", stderr: "" };
       if (args[0] === "rev-parse" && args[1] === "--is-shallow-repository") {
-        return { status: 0, stdout: String(shallow) + "\n", stderr: "" };
+        return { status: 0, stdout: "true\n", stderr: "" };
       }
-      if (args[0] === "config") return { status: 0, stdout: "", stderr: "" };
-      if (args[0] === "fetch" && args[1] === "--filter=tree:0") {
-        if (args[2] === "--unshallow") shallow = false;
+      if (args[0] === "fetch" && args[1] === "--deepen=512") {
         return { status: 0, stdout: "", stderr: "" };
       }
       throw new Error("unexpected git args: " + args.join(" "));
@@ -264,24 +238,25 @@ test("shallow merge-base recovery filters its final unshallow fallback", () => {
     console.log = () => {};
 
     const { mergeBaseWithShallowRecovery } = await import("./dist/repair/git-publish.js");
-    const result = mergeBaseWithShallowRecovery("HEAD", "origin/state", "origin", "state");
+    const result = mergeBaseWithShallowRecovery(
+      "HEAD",
+      "origin/state",
+      "origin",
+      "state",
+      "rebuild-on-remote-head",
+    );
     process.stdout.write(JSON.stringify({ calls, result }));
   `;
 
   const output = JSON.parse(run("node", ["--input-type=module", "-e", script], process.cwd()));
   assert.deepEqual(output.result, { base: null, recoveredShallowMiss: true });
   assert.deepEqual(
-    output.calls.filter(({ args }) => args[0] === "fetch").map(({ args }) => args),
-    [
-      ...Array.from({ length: 4 }, () => [
-        "fetch",
-        "--filter=tree:0",
-        "--deepen=512",
-        "origin",
-        "state",
-      ]),
-      ["fetch", "--filter=tree:0", "--unshallow", "origin", "state"],
-    ],
+    output.calls.filter(({ args }) => args[0] === "fetch"),
+    Array.from({ length: 2 }, () => ({
+      command: "git",
+      args: ["fetch", "--deepen=512", "origin", "state"],
+      timeout: 900_000,
+    })),
   );
 });
 
@@ -1661,7 +1636,77 @@ test("reconcile-records preserves a newer remote tuple after resetting unrelated
   assert.throws(() => run("git", ["--git-dir", origin, "show", "state:unrelated.txt"], root));
 });
 
-test("reconcile-records resets shallow state to a truly unrelated remote head", () => {
+test("reconcile-records defers an unprovably unrelated shallow remote head", () => {
+  const { origin, recordsRoot, root, state, work } = createUnrelatedShallowReconciliationFixture();
+
+  assert.throws(
+    () =>
+      withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+        withCwd(work, () =>
+          publishMainCommit({
+            message: "chore: defer unrelated shallow state",
+            paths: [recordsRoot],
+            maxAttempts: 1,
+            pushAttempts: 1,
+            rebaseStrategy: "reconcile-records",
+          }),
+        ),
+      ),
+    /Shallow Git recovery deferred to the next run after deepening by 1024 commits/,
+  );
+
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:replacement.txt"], root),
+    "replacement history\n",
+  );
+  assert.throws(() =>
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
+  );
+  assert.equal(run("git", ["rev-parse", "--is-shallow-repository"], state).trim(), "true");
+});
+
+test("persistent shallow exhaustion rebuilds reconciliation from the remote head", () => {
+  const { candidateTuple, origin, recordsRoot, root, state, work } =
+    createUnrelatedShallowReconciliationFixture();
+
+  const lines = [];
+  let result;
+  captureConsoleLog(() => {
+    result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
+      withCwd(work, () =>
+        publishMainCommit({
+          message: "chore: rebuild persistent shallow state",
+          paths: [recordsRoot],
+          maxAttempts: 1,
+          pushAttempts: 1,
+          rebaseStrategy: "reconcile-records",
+          shallowHistoryExhaustionStrategy: "rebuild-on-remote-head",
+        }),
+      ),
+    );
+  }, lines);
+
+  assert.equal(result, "committed");
+  assert.equal(
+    lines.some((line) =>
+      line.includes(
+        "Persistent shallow-history exhaustion after deepening by 1024 commits; rebuilding from origin/state",
+      ),
+    ),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", "state:replacement.txt"], root),
+    "replacement history\n",
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
+    candidateTuple.primary,
+  );
+  assert.equal(run("git", ["rev-parse", "--is-shallow-repository"], state).trim(), "true");
+});
+
+function createUnrelatedShallowReconciliationFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-shallow-unrelated-"));
   const origin = path.join(root, "origin.git");
   const seed = path.join(root, "seed");
@@ -1700,42 +1745,8 @@ test("reconcile-records resets shallow state to a truly unrelated remote head", 
   run("git", ["add", "-A"], seed);
   run("git", ["commit", "-m", "replace state history"], seed);
   run("git", ["push", "--force", "origin", "HEAD:state"], seed);
-
-  const lines = [];
-  let result;
-  captureConsoleLog(() => {
-    result = withEnv({ CLAWSWEEPER_STATE_DIR: state }, () =>
-      withCwd(work, () =>
-        publishMainCommit({
-          message: "chore: publish from unrelated shallow state",
-          paths: [recordsRoot],
-          maxAttempts: 1,
-          pushAttempts: 1,
-          rebaseStrategy: "reconcile-records",
-        }),
-      ),
-    );
-  }, lines);
-
-  assert.equal(result, "committed");
-  assert.equal(
-    lines.some((line) =>
-      line.includes(
-        "No common Git base with origin/state; resetting the unpublished reconciliation checkpoint to the remote head",
-      ),
-    ),
-    true,
-  );
-  assert.equal(
-    run("git", ["--git-dir", origin, "show", "state:replacement.txt"], root),
-    "replacement history\n",
-  );
-  assert.equal(
-    run("git", ["--git-dir", origin, "show", `state:${recordsRoot}/items/42.md`], root),
-    candidateTuple.primary,
-  );
-  assert.equal(run("git", ["rev-parse", "--is-shallow-repository"], state).trim(), "false");
-});
+  return { candidateTuple, origin, recordsRoot, root, state, work };
+}
 
 test("reconcile-records prepares a shallow state checkout from the remote head", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-shallow-prepare-"));
@@ -5171,7 +5182,7 @@ function installDeepenFetchFailureShim(fakeBin) {
     git,
     `#!/bin/sh
 set -u
-if test "$1" = fetch && test "$2" = --filter=tree:0 && test "$3" = --deepen=512; then
+if test "$1" = fetch && test "$2" = --deepen=512; then
   printf '%s\n' 'fatal: synthetic deepen failure' >&2
   exit 2
 fi

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -8,6 +8,10 @@ import test from "node:test";
 
 import { actionLedgerJson } from "../../dist/action-ledger.js";
 import {
+  GitShallowHistoryExhaustionError,
+  SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
+} from "../../dist/repair/git-publish.js";
+import {
   DEFAULT_STATE_MATERIALIZER_MAX_BYTES,
   DEFAULT_STATE_MATERIALIZER_MAX_ROWS,
   planStateMaterialization,
@@ -526,6 +530,87 @@ test("materializer deferral failure distinguishes progress from a stalled cycle"
 
   assert.match(progress, /progress with deferral: drained=1400 committed=720/);
   assert.match(stalled, /stalled cycle with deferral: drained=1400 committed=0/);
+});
+
+test("materializer persists the first shallow-history exhaustion as a retryable disposition", async () => {
+  const fixture = createStateFixture();
+  const records = [
+    record(
+      1,
+      "record_tuple",
+      "openclaw-openclaw/50",
+      canonicalTuplePayload(50, "first shallow exhaustion", "2026-07-20T12:20:00.000Z"),
+    ),
+  ];
+  let disposition: Record<string, unknown> | null = null;
+  const fetchImpl = signedQueueFetch(async (url, body) => {
+    if (url.pathname === "/internal/state/drain") {
+      return Response.json({ ok: true, drain_token: "shallow-first", records });
+    }
+    assert.equal(url.pathname, "/internal/state/dispose");
+    disposition = body;
+    return Response.json({ ok: true, acked: 0, retried: 1, dead_lettered: 0 });
+  });
+
+  await assert.rejects(
+    withMaterializerFixture(fixture, () =>
+      runStateMaterializer({
+        env: materializerEnv(),
+        fetchImpl,
+        publishCommit: (options) => {
+          assert.equal(options.shallowHistoryExhaustionStrategy, "defer");
+          throw new GitShallowHistoryExhaustionError(1_024);
+        },
+      }),
+    ),
+    /state-materializer stalled cycle with deferral.*deepening by 1024 commits/,
+  );
+  assert.deepEqual(disposition, {
+    drain_token: "shallow-first",
+    failures: [
+      {
+        seq: 1,
+        reason: SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
+        retryable: true,
+      },
+    ],
+  });
+});
+
+test("materializer escalates a repeated shallow-history phase to remote-head rebuild", async () => {
+  const fixture = createStateFixture();
+  const retriedRecord = record(
+    1,
+    "record_tuple",
+    "openclaw-openclaw/51",
+    canonicalTuplePayload(51, "persistent shallow exhaustion", "2026-07-20T12:21:00.000Z"),
+  );
+  retriedRecord.materialization_attempts = 1;
+  retriedRecord.materialization_last_error = SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION;
+  let drainCalls = 0;
+  const fetchImpl = signedQueueFetch(async (url) => {
+    if (url.pathname === "/internal/state/drain") {
+      drainCalls += 1;
+      return drainCalls === 1
+        ? Response.json({ ok: true, drain_token: "shallow-retry", records: [retriedRecord] })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/ack");
+    return Response.json({ ok: true, acked: 1 });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({
+      env: materializerEnv(),
+      fetchImpl,
+      publishCommit: (options) => {
+        assert.equal(options.shallowHistoryExhaustionStrategy, "rebuild-on-remote-head");
+        return "committed";
+      },
+    }),
+  );
+
+  assert.deepEqual(summary, { drained: 1, committed: 1, acked: 1, skipped: 0, errors: 0 });
 });
 
 test("materializer no-ops when the drain is empty", async () => {


### PR DESCRIPTION
## Summary

- Retire partial-clone/promisor mode and return state publishing to plain bounded fetches: `--deepen=512` at most twice, with a 900-second timeout per attempt.
- Persist merge-base exhaustion as `materialization_attempts` plus `last_error`, then rebuild from the remote head when the same exhaustion repeats.
- Remove the unprovable `unrelated history` classification along with the unshallow path that supported it.

## Incident

[Run 30203200727](https://github.com/openclaw/clawsweeper/actions/runs/30203200727) exposed a Git 2.54 fetch-side BUG in the partial-clone mode introduced by #869: `index-pack` attempted to repack promisor links while deepening the state repository.

State publishing now uses ordinary deepen fetches only—no filter, promisor configuration, or unshallow fallback. Exhaustion is bounded within a run and durable across runs: the first matching failure defers with its attempt state recorded, while the matching repeat escalates to rebuilding from the authoritative remote head.

## Proof

- Autoreview: CLEAN at 0.97 confidence; TruffleHog clean.
- State materializer targeted suite: 17/17 passed.
- Git publisher targeted suite: 66/67 passed; the remaining failure is the known environment credential fixture.
- Unit suite: 1,614 passed.

