### PR TITLE
fix(repair): cut over durable cluster intake publication

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -87,18 +87,32 @@ jobs:
           repositories: gitcrawl-store
           permission-contents: read
 
-      - name: Resolve target owner
+      - name: Resolve target repository
         id: target
         env:
           TARGET_REPO: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+          ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
         run: |
           set -euo pipefail
-          owner="${TARGET_REPO%%/*}"
-          if ! printf '%s' "$owner" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
-            echo "Invalid target repository: $TARGET_REPO" >&2
-            exit 1
+          if ! printf '%s' "$ALLOWED_OWNER" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+            echo "Invalid allowed repository owner" >&2
+            exit 2
           fi
-          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid target repository" >&2
+            exit 2
+          fi
+          target_owner="${TARGET_REPO%%/*}"
+          target_name="${TARGET_REPO#*/}"
+          if [ "$target_owner" != "$ALLOWED_OWNER" ]; then
+            echo "Target repository must be owned by ${ALLOWED_OWNER}" >&2
+            exit 2
+          fi
+          {
+            printf 'owner=%s\n' "$target_owner"
+            printf 'name=%s\n' "$target_name"
+            printf 'full_name=%s/%s\n' "$target_owner" "$target_name"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create target read token
         id: target-token
@@ -107,7 +121,7 @@ jobs:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
-          permission-contents: read
+          repositories: ${{ steps.target.outputs.name }}
           permission-issues: read
           permission-pull-requests: read
 
@@ -154,7 +168,7 @@ jobs:
         env:
           ENABLED: ${{ github.event.inputs.enabled || '1' }}
           SCHEDULE_ENABLED: ${{ vars.CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED == '1' && '1' || '0' }}
-          TARGET_REPO: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+          TARGET_REPO: ${{ steps.target.outputs.full_name }}
           FORCE_STORE: ${{ github.event.inputs.force_store == 'true' && '1' || '0' }}
         run: |
           set -euo pipefail
@@ -277,19 +291,20 @@ jobs:
             fi
           } >> "$GITHUB_OUTPUT"
 
-      - name: Record intake ledger
+      - name: Build durable intake intent
         if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
-          LEDGER_PATH: ${{ steps.prepare.outputs.ledger_path }}
           TARGET_REPO: ${{ steps.prepare.outputs.target_repo }}
           STORE_SHA: ${{ steps.prepare.outputs.store_sha }}
           EXPORTED_AT: ${{ steps.prepare.outputs.exported_at }}
           MANIFEST_PATH: ${{ steps.prepare.outputs.manifest_path }}
-          GENERATED_COUNT: ${{ steps.select.outputs.count || '0' }}
+          WORKER_RUNNER: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+          MODEL: internal
         run: |
           set -euo pipefail
-          mkdir -p "$(dirname "$LEDGER_PATH")"
           node <<'NODE'
+          const crypto = require("crypto");
           const fs = require("fs");
           const generatedPath = ".artifacts/cluster-repair-intake/generated-paths.txt";
           const selectionPath = ".artifacts/cluster-repair-intake/selection-report.json";
@@ -300,48 +315,53 @@ jobs:
           const selection = fs.existsSync(selectionPath)
             ? JSON.parse(fs.readFileSync(selectionPath, "utf8"))
             : { evaluated: 0, rejected: 0, selected: 0, reason_counts: {}, decision: null, assessments: [] };
-          const ledger = {
-            schema: "clawsweeper-cluster-repair-intake-v1",
+          const repoSlug = process.env.TARGET_REPO.replace("/", "-");
+          const jobs = generated.map((jobPath) => {
+            const match = /\/gitcrawl-(\d+)-/.exec(jobPath);
+            if (!match) throw new Error(`Generated job omitted gitcrawl cluster ID: ${jobPath}`);
+            const content = fs.readFileSync(jobPath, "utf8");
+            const clusterId = Number(match[1]);
+            return {
+              cluster_id: clusterId,
+              path: jobPath,
+              content,
+              digest: crypto.createHash("sha256").update(content).digest("hex"),
+              dispatch_key: `cluster-intake:${repoSlug}:${clusterId}`,
+            };
+          });
+          const intent = {
+            schema: "clawsweeper-cluster-intake-intent-v1",
             target_repo: process.env.TARGET_REPO,
-            last_processed_store_sha256: process.env.STORE_SHA,
-            last_processed_store_exported_at: process.env.EXPORTED_AT,
+            repo_slug: repoSlug,
+            store_sha256: process.env.STORE_SHA,
+            store_exported_at: process.env.EXPORTED_AT,
             manifest_path: process.env.MANIFEST_PATH,
-            generated_count: Number(process.env.GENERATED_COUNT || generated.length || 0),
-            generated_jobs: generated,
-            selector: selection,
             run_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
-            updated_at: new Date().toISOString(),
+            accepted_at: new Date().toISOString(),
+            runner: process.env.WORKER_RUNNER,
+            execution_runner: process.env.EXECUTION_RUNNER,
+            model: process.env.MODEL,
+            selector_summary: {
+              evaluated: Number(selection.evaluated || 0),
+              rejected: Number(selection.rejected || 0),
+              reason_counts: selection.reason_counts || {},
+            },
+            jobs,
           };
-          fs.writeFileSync(process.env.LEDGER_PATH, `${JSON.stringify(ledger, null, 2)}\n`);
+          fs.writeFileSync(".artifacts/cluster-repair-intake/intent.json", `${JSON.stringify(intent, null, 2)}\n`);
           NODE
 
-      - name: Publish intake jobs and ledger
+      - name: Durably accept cluster intake
         if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
-          pnpm run repair:publish-main -- \
-            --message "chore: record cluster repair intake" \
-            --path jobs \
-            --path results/cluster-repair-intake \
-            --max-attempts 12 \
-            --push-attempts 4
+          pnpm run repair:publish-cluster-intake -- .artifacts/cluster-repair-intake/intent.json
 
-      - name: Dispatch imported cluster repair
-        if: ${{ steps.select.outputs.should_dispatch == 'true' }}
+      - name: Request immediate state materialization
+        if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
           GH_TOKEN: ${{ steps.central-token.outputs.token }}
-          RUNNER: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-          MODEL: internal
-        run: |
-          set -euo pipefail
-          mapfile -t jobs < .artifacts/cluster-repair-intake/generated-paths.txt
-          pnpm run repair:dispatch -- "${jobs[@]}" \
-            --mode autonomous \
-            --wait-for-capacity \
-            --runner "$RUNNER" \
-            --execution-runner "$EXECUTION_RUNNER" \
-            --model "$MODEL" \
-            --ref main
+        run: gh workflow run state-materializer.yml --ref main -f intake_priority=true

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: openclaw
+          repositories: clawsweeper
           permission-actions: read
           permission-contents: write
           permission-pull-requests: read
@@ -51,10 +52,22 @@ jobs:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
+      - name: Create target read token
+        id: target-read-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: openclaw
+          permission-contents: read
+          permission-pull-requests: read
+
       - uses: ./.github/actions/setup-state
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          coordinator-class: publication_batch
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: actions/setup-node@v6
@@ -145,7 +158,7 @@ jobs:
       - name: Publish result ledger
         if: ${{ steps.download.outputs.has_artifacts == '1' }}
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -195,11 +208,23 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
+          paths_file=".artifacts/cluster-result-state-paths.txt"
+          mkdir -p .artifacts
+          pnpm run repair:state-delta-paths -- \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --out "$paths_file" \
+            --root results \
+            --root jobs/openclaw \
+            --root repair-apply-report.json \
+            --root notifications
+          if [ ! -s "$paths_file" ]; then
+            echo "No cluster result state changed."
+            exit 0
+          fi
+          publish_args=()
+          while IFS= read -r path; do publish_args+=(--path "$path"); done < "$paths_file"
           pnpm run repair:publish-main -- \
             --message "chore: publish cluster result" \
-            --path results \
-            --path jobs/openclaw/closed \
-            --path repair-apply-report.json \
-            --path notifications \
+            "${publish_args[@]}" \
             --max-attempts 12 \
             --push-attempts 4

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -54,7 +54,8 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: openclaw
+          repositories: clawsweeper
           permission-actions: write
           permission-contents: write
 
@@ -80,6 +81,25 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         with:
           build-script: build:repair
+
+      - name: Retry failed cluster result publications
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          cutoff="$(date -u -v-12H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+          runs_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/repair-publish-results.yml/runs?status=completed&per_page=50")"
+          mapfile -t failed_publishers < <(jq -r --arg cutoff "$cutoff" '
+            .workflow_runs[]
+            | select(.created_at >= $cutoff)
+            | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")
+            | select(.run_attempt < 3)
+            | .id
+          ' <<<"$runs_json")
+          for run_id in "${failed_publishers[@]}"; do
+            echo "Retrying failed cluster result publisher $run_id"
+            gh run rerun "$run_id" --repo "$GITHUB_REPOSITORY"
+          done
 
       - name: Self-heal failed cluster runs
         env:

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -322,9 +322,11 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
   quality is not decided by word lists, scores, or semantic thresholds.
 - `CLAWSWEEPER_CLUSTER_REPAIR_CANDIDATE_BATCH` controls how many unprocessed
   clusters the scheduled selector model compares. The default is `8`; the model
-  still selects at most one cluster. The upstream gitcrawl-store refreshes every 15 minutes, and ClawSweeper
-  records the processed store SHA so repeated ticks against the same snapshot
-  skip.
+  still selects at most one cluster. The upstream gitcrawl-store refreshes every
+  15 minutes. Intake durably appends the selected job, store identity, selector
+  summary, and stable dispatch key before requesting materialization. The state
+  materializer projects only those exact paths and recovers pending dispatch
+  without duplicating completed worker execution.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS` overrides the `job_intent`-derived repair
   dispatch cap.
 - `CLAWSWEEPER_AUTOMERGE_MAX_LIVE_WORKERS` overrides

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -270,11 +270,11 @@ pnpm run repair:import-gitcrawl -- --from-gitcrawl --limit 40 --mode autonomous 
 
 # Automatic imported-cluster intake runs through repair-cluster-intake.yml.
 # gitcrawl-store refreshes openclaw/openclaw every 15 minutes; the ClawSweeper
-# intake runs daily, records the processed portable DB SHA in
-# results/cluster-repair-intake/<repo>.json, and skips repeated ticks for the
-# same store snapshot. The selector model compares the candidate batch without
-# word lists, scores, or semantic thresholds, and dispatches at most one cluster
-# through the two-worker cluster_repair lane.
+# intake runs daily and the selector model compares the candidate batch without
+# word lists, scores, or semantic thresholds. Intake appends the selected job,
+# store identity, selector summary, and stable dispatch key to the Cloudflare
+# durable window before dispatch. The state materializer projects only those
+# exact paths and recovers pending dispatch without duplicating completed work.
 
 # Dispatch reviewed jobs. Dispatch derives its default live-worker cap from the
 # job's job_intent and config/automation-limits.json. Existing repair lanes
@@ -380,6 +380,9 @@ The workflow needs:
   may reject the entire batch.
 - optional `CLAWSWEEPER_CLUSTER_REPAIR_CANDIDATE_BATCH` variable for the scheduled
   intake; default is `8` candidates, from which the model selects at most one.
+- imported-cluster intake is accepted into the Cloudflare durable window before
+  materialization or dispatch; publication recovery retains the exact selected
+  job and selector decision.
 - merge is separately gated by `CLAWSWEEPER_ALLOW_MERGE`, which defaults to `0`; merge-ready PRs are labeled `clawsweeper:human-review` and `clawsweeper:merge-ready` for a maintainer to merge manually when the global gate is closed
 - required `CLAWSWEEPER_MODEL` GitHub Actions secret containing the actual
   internal model name; workflows, dispatch payloads, comments, and reports use

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -602,9 +602,12 @@ Important gates:
   offered to the scheduled selector model; default `8`. The selector emits at
   most one cluster per daily `repair-cluster-intake.yml` run.
   The upstream `openclaw/gitcrawl-store` refreshes `openclaw/openclaw` every 15
-  minutes, so the intake records the processed portable DB SHA in
-  `results/cluster-repair-intake/<repo>.json` and skips duplicate ticks against
-  the same store snapshot.
+  minutes. Intake first appends the selected job, store identity, selector
+  summary, and stable dispatch key to the Cloudflare durable window. The state
+  materializer projects only those exact paths, retries after publication loss,
+  and recovers retained pending intent without duplicating completed workers.
+  Intake-triggered materializers receive one bounded priority turn before
+  yielding to queued batch or ordinary writers.
 - `CLAWSWEEPER_ALLOW_EXECUTE`: allows deterministic write lanes. Workflows treat
   any value except literal `1` as closed.
 - `CLAWSWEEPER_ALLOW_FIX_PR`: allows branch repair and replacement PR creation.

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -38,7 +38,9 @@ credentials.
 flowchart LR
   A[GitHub issue, PR, comment, or schedule] --> B[ClawSweeper intake]
   G[GitCrawl store snapshot] --> B
-  B --> C[Durable job in clawsweeper-state]
+  B --> Q[Authenticated durable intake queue]
+  Q --> S[Prioritized state materializer]
+  S --> C[Exact job and ledger paths in clawsweeper-state]
   C --> D[GitHub Actions repair worker]
   D --> E[Codex app-server thread]
   D --> F[CrabFleet action session]
@@ -169,9 +171,20 @@ The `repair-cluster-intake.yml` workflow:
    `results/cluster-repair-intake/<repo-slug>.json`.
 5. Skips a store snapshot that was already processed unless a maintainer uses
    the force input.
-6. Imports a bounded number of eligible clusters into durable job markdown.
-7. Publishes the jobs and updated intake ledger.
-8. Dispatches them through the `repair_cluster` lane with capacity waiting.
+6. Gives a bounded batch of hydrated live GitHub evidence to the selector model.
+   The model chooses one narrow, actionable cluster or rejects the batch; quality
+   is not decided by word lists, scores, or semantic thresholds.
+7. Appends one authenticated `cluster_intake` intent containing the exact job
+   bytes, digest, store identity, and selector report to the durable Cloudflare
+   state queue. An accepted append is the recovery boundary; the workflow does
+   not publish from its checkout.
+8. Wakes the prioritized state materializer. It projects only the accepted job
+   and ledger paths, preserving unrelated generated state, and keeps
+   capacity-blocked or publication-failed intent durable for a later cycle.
+9. Claims each stable dispatch key only after durable publication, starts the
+   `repair_cluster` worker once, and records the matching planning-job receipt.
+   A lost claim publication or a later execution failure is recovered from the
+   exact Actions receipt instead of dispatching the planning work again.
 
 Scheduled cluster intake is independently gated:
 
@@ -224,9 +237,11 @@ and one durable Codex thread state.
 
 ### GitCrawl Store Ledger
 
-Cluster intake records the processed store content hash. A delayed schedule or
-duplicate workflow tick against the same exported database does not enqueue the
-same snapshot again.
+Cluster intake records every processed store content hash and accepted cluster
+identity. Import history spans inbox jobs, archived jobs, result records, and
+the intake ledger, so a delayed schedule, a duplicate workflow tick, or a newer
+store containing an already completed cluster cannot enqueue the same work
+again. The durable dispatch receipt independently suppresses transport retries.
 
 ### GitHub Actions Concurrency
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "repair:select-cluster-candidate": "node dist/repair/select-cluster-candidate.js",
     "repair:publish-cluster-intake": "node dist/repair/publish-cluster-intake.js",
     "repair:restore-cluster-intake-job": "node dist/repair/restore-cluster-intake-job.js",
+    "repair:state-delta-paths": "node dist/repair/state-delta-paths.js",
     "repair:import-gitcrawl-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",
     "repair:import-ghcrawl": "node dist/repair/import-gitcrawl-clusters.js",
     "repair:import-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",

--- a/src/repair/state-delta-paths.ts
+++ b/src/repair/state-delta-paths.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+export function changedStatePaths(options: {
+  worktree: string;
+  stateRoot: string;
+  roots: readonly string[];
+}): string[] {
+  const paths = new Set<string>();
+  for (const root of options.roots) {
+    collectFiles(resolve(options.worktree, root), options.worktree, paths);
+    collectFiles(resolve(options.stateRoot, root), options.stateRoot, paths);
+  }
+  return [...paths]
+    .filter(
+      (path) =>
+        fileDigest(resolve(options.worktree, path)) !==
+        fileDigest(resolve(options.stateRoot, path)),
+    )
+    .sort();
+}
+
+function collectFiles(directory: string, base: string, paths: Set<string>): void {
+  if (!existsSync(directory)) return;
+  const stat = lstatSync(directory);
+  if (stat.isSymbolicLink())
+    throw new Error(`state delta root must not be a symlink: ${directory}`);
+  if (stat.isFile()) {
+    paths.add(relative(base, directory).split(sep).join("/"));
+    return;
+  }
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const target = resolve(directory, entry.name);
+    if (entry.isSymbolicLink())
+      throw new Error(`state delta path must not be a symlink: ${target}`);
+    if (entry.isDirectory()) collectFiles(target, base, paths);
+    else if (entry.isFile()) paths.add(relative(base, target).split(sep).join("/"));
+  }
+}
+
+function fileDigest(path: string): string | null {
+  if (!existsSync(path)) return null;
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink())
+    throw new Error(`state delta path is not a regular file: ${path}`);
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+if (process.argv[1]?.endsWith("state-delta-paths.js")) {
+  const values = process.argv.slice(2);
+  const value = (name: string): string => {
+    const index = values.indexOf(name);
+    if (index < 0 || !values[index + 1]) throw new Error(`${name} is required`);
+    return values[index + 1]!;
+  };
+  const roots = values.flatMap((item, index) =>
+    item === "--root" && values[index + 1] ? [values[index + 1]!] : [],
+  );
+  if (roots.length === 0) throw new Error("at least one --root is required");
+  const output = changedStatePaths({
+    worktree: process.cwd(),
+    stateRoot: resolve(value("--state-root")),
+    roots,
+  });
+  writeFileSync(resolve(value("--out")), `${output.join("\n")}${output.length ? "\n" : ""}`);
+  console.log(`state delta contains ${output.length} exact path(s)`);
+}

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2486,22 +2486,26 @@ test("repair workflows preserve existing dispatch while scheduled cluster intake
   assert.doesNotMatch(importLowSignal, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
 });
 
-test("cluster intake publishes generated repair state through state repo", () => {
+test("cluster intake durably accepts selected work before materialization", () => {
   const workflow = readText(".github/workflows/repair-cluster-intake.yml");
   const stateTokenIndex = workflow.indexOf("uses: ./.github/actions/create-state-token");
   const setupStateIndex = workflow.indexOf("uses: ./.github/actions/setup-state");
   const importIndex = workflow.indexOf("- name: Prepare unprocessed cluster candidates");
-  const publishIndex = workflow.indexOf("- name: Publish intake jobs and ledger");
+  const publishIndex = workflow.indexOf("- name: Durably accept cluster intake");
+  const materializeIndex = workflow.indexOf("- name: Request immediate state materialization");
 
   assert.notEqual(stateTokenIndex, -1);
   assert.notEqual(setupStateIndex, -1);
   assert.notEqual(importIndex, -1);
   assert.notEqual(publishIndex, -1);
+  assert.notEqual(materializeIndex, -1);
   assert.ok(stateTokenIndex < setupStateIndex, "state token must be created before setup-state");
   assert.ok(setupStateIndex < importIndex, "state repo must be hydrated before job import");
-  assert.ok(setupStateIndex < publishIndex, "state repo must be configured before publish-main");
-  assert.match(workflow, /--path jobs/);
-  assert.match(workflow, /--path results\/cluster-repair-intake/);
+  assert.ok(importIndex < publishIndex, "selection must finish before durable acceptance");
+  assert.ok(publishIndex < materializeIndex, "durable acceptance must precede materialization");
+  assert.match(workflow, /repair:publish-cluster-intake/);
+  assert.match(workflow, /gh workflow run state-materializer\.yml --ref main/);
+  assert.doesNotMatch(workflow, /repair:publish-main|pnpm run repair:dispatch/);
 });
 
 test("conflict self-heal publishes exact-head jobs before worker dispatch", () => {

--- a/test/repair/cluster-workflow-security.test.ts
+++ b/test/repair/cluster-workflow-security.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { parse } from "yaml";
+
+type Workflow = {
+  jobs?: Record<string, { steps?: Array<{ name?: string; run?: string; env?: unknown }> }>;
+};
+
+test("cluster worker passes workflow inputs through environment boundaries", () => {
+  const source = fs.readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8");
+  const workflow = parse(source) as Workflow;
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.run !== "string") continue;
+      assert.doesNotMatch(
+        step.run,
+        /\$\{\{\s*inputs\./,
+        `${jobName}/${step.name ?? "unnamed"} interpolates an input into shell source`,
+      );
+    }
+  }
+  assert.match(source, /job_auth:[\s\S]*Materializer HMAC/);
+  assert.equal(source.match(/run: pnpm run repair:restore-cluster-intake-job/g)?.length, 3);
+  assert.equal(source.match(/CLAWSWEEPER_WEBHOOK_SECRET: \$\{\{ secrets\./g)?.length, 4);
+  assert.ok(
+    source.indexOf("Authenticate durable intake before credentials") <
+      source.indexOf("Create GitHub App token"),
+  );
+  assert.doesNotMatch(source, /restore-durable-intake-job\.sh/);
+});
+
+test("cluster intake validates one safe repository token before exporting outputs", () => {
+  const source = fs.readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  const workflow = parse(source) as Workflow;
+  const resolveStep = workflow.jobs?.intake?.steps?.find(
+    (step) => step.name === "Resolve target repository",
+  );
+  assert.ok(resolveStep?.run);
+  assert.match(resolveStep.run, /\^\[A-Za-z0-9_\.-\]\+\/\[A-Za-z0-9_\.-\]\+\$/);
+  assert.match(resolveStep.run, /printf 'name=%s\\n'/);
+  assert.doesNotMatch(resolveStep.run, /echo "name=\$target_name"/);
+});

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -53,7 +53,11 @@ test("scheduled cluster repair intake follows gitcrawl-store freshness cadence",
   assert.match(workflow, /last_processed_store_sha256/);
   assert.match(workflow, /CLAWSWEEPER_CLUSTER_REPAIR_CANDIDATE_BATCH \|\| '8'/);
   assert.match(workflow, /repair:select-cluster-candidate/);
-  assert.match(workflow, /pnpm run repair:dispatch/);
+  assert.match(workflow, /repair:publish-cluster-intake/);
+  assert.match(workflow, /owner: \$\{\{ steps\.target\.outputs\.owner \}\}/);
+  assert.match(workflow, /repositories: \$\{\{ steps\.target\.outputs\.name \}\}/);
+  assert.match(workflow, /gh workflow run state-materializer\.yml --ref main/);
+  assert.doesNotMatch(workflow, /pnpm run repair:dispatch/);
   assert.doesNotMatch(workflow, /git pull --rebase origin main/);
   assert.match(limitsDocs, /one cluster or rejects the batch/);
   assert.match(repairDocs, /intake runs daily/);

--- a/test/repair/state-delta-paths.test.ts
+++ b/test/repair/state-delta-paths.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { changedStatePaths } from "../../dist/repair/state-delta-paths.js";
+
+test("result publication selects exact changes and preserves unrelated remote jobs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-delta-"));
+  const worktree = path.join(root, "worktree");
+  const state = path.join(root, "state");
+  for (const base of [worktree, state]) {
+    fs.mkdirSync(path.join(base, "results", "openclaw"), { recursive: true });
+    fs.mkdirSync(path.join(base, "jobs", "openclaw", "inbox"), { recursive: true });
+    fs.writeFileSync(path.join(base, "results", "openclaw", "existing.md"), "same\n");
+    fs.writeFileSync(path.join(base, "jobs", "openclaw", "inbox", "unrelated.md"), "keep\n");
+  }
+  fs.writeFileSync(path.join(worktree, "results", "openclaw", "gitcrawl-42.md"), "new result\n");
+  fs.writeFileSync(path.join(worktree, "results", "openclaw", "existing.md"), "updated\n");
+
+  assert.deepEqual(
+    changedStatePaths({ worktree, stateRoot: state, roots: ["results", "jobs/openclaw"] }),
+    ["results/openclaw/existing.md", "results/openclaw/gitcrawl-42.md"],
+  );
+});
+
+test("state hydration preserves state-only notification receipts before result diffing", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-notification-hydrate-"));
+  const worktree = path.join(root, "worktree");
+  const state = path.join(root, "state");
+  const receipt = path.join("notifications", "clawsweeper-event-ledger.json");
+  fs.mkdirSync(path.join(state, "notifications"), { recursive: true });
+  fs.mkdirSync(worktree, { recursive: true });
+  fs.writeFileSync(path.join(state, receipt), '{"notifications":[{"id":"unrelated"}]}\n');
+
+  const hydrated = spawnSync(
+    process.execPath,
+    ["scripts/hydrate-state.ts", "--state-dir", state, "--worktree", worktree],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(hydrated.status, 0, hydrated.stderr);
+  assert.equal(
+    fs.readFileSync(path.join(worktree, receipt), "utf8"),
+    fs.readFileSync(path.join(state, receipt), "utf8"),
+  );
+  assert.deepEqual(changedStatePaths({ worktree, stateRoot: state, roots: ["notifications"] }), []);
+});

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -30,6 +30,7 @@ const coordinatorUrl =
 const publicationEntryPoints = [
   /repair:publish-main\b/,
   /repair:publish-event-result\b/,
+  /repair:publish-cluster-intake\b/,
   /repair:exact-review-batch commit\b/,
   /scripts\/prepare-exact-review-batch\.mjs\b/,
   /dist\/repair\/state-materializer\.js\b/,
@@ -171,6 +172,7 @@ test("only bounded publication owners request priority admission", () => {
   }
   assert.deepEqual(prioritySetups, [
     ".github/workflows/exact-review-batch-publish.yml:publish",
+    ".github/workflows/repair-publish-results.yml:publish",
     ".github/workflows/state-materializer.yml:materialize",
   ]);
   const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;


### PR DESCRIPTION
## Summary

This is **5/5** in the cluster-fixer reliability stack, based on [PR 884](https://github.com/openclaw/clawsweeper/pull/884). This existing PR remains the top layer so its audit and review history are preserved.

- Cuts the production intake workflow from broad `repair:publish-main` publication to the durable cluster-intake append/materializer contract.
- Dispatches through durable materialization instead of directly from an intake checkout.
- Publishes worker results by exact changed paths, with bounded priority and automatic self-heal retry.
- Separates target-read and ClawSweeper-state-write credentials and moves untrusted workflow values across environment boundaries.
- Preserves deterministic mutation, security gates, fail-closed behavior, `allow_merge: false`, and all existing production gate settings.
- Updates operator documentation for the durable lifecycle and recovery semantics.

## Stack

1. [Candidate selection and historical dedupe](https://github.com/openclaw/clawsweeper/pull/881)
2. [Durable intake queue priority](https://github.com/openclaw/clawsweeper/pull/882)
3. [Durable intake intent contract](https://github.com/openclaw/clawsweeper/pull/883)
4. [Exactly-once dispatch and recovery](https://github.com/openclaw/clawsweeper/pull/884)
5. **This PR — workflow cutover and result publication hardening**

## Audit evidence

- [PR 813](https://github.com/openclaw/clawsweeper/pull/813) fixed stale comment-router publication deleting unrelated cluster jobs, but did not move cluster intake off the broad writer lane.
- [2026-07-24 intake run 30080946899](https://github.com/openclaw/clawsweeper/actions/runs/30080946899) succeeded after roughly 18 minutes of publication delay.
- [2026-07-25 intake run 30151799240](https://github.com/openclaw/clawsweeper/actions/runs/30151799240) waited 30 minutes and failed at writer position 2, losing its checkout-only intent before dispatch.
- [PR 866](https://github.com/openclaw/clawsweeper/pull/866) made Cloudflare canonical for exact-review records; cluster intake still used `repair:publish-main`.
- Historical intake also repeatedly selected completed clusters, result publication starved behind the shared writer, aggregate worker status hid actionable planning outcomes, and low-confidence cluster selection produced little landable work. The lower four PRs address those owner-boundary causes independently.

## Validation

- Every layer was built and tested in isolation.
- Full stack: `pnpm run build:all`, `pnpm run check:static`, lint, formatting, `git diff --check`, and focused concurrency/stale-checkout/lease-loss/duplicate/recovery/preservation/dispatch/security/ranking suites pass.
- The complete stacked HEAD has tree `463e53e2ac3fa016b582a8a7ee637028ba815817`, exactly matching the rebased unsplit implementation.
- The prescribed Crabbox configuration resolves `provider=aws`, but broker/AWS authentication is unavailable on this host; allocation failed before creating a lease. No provider override was used. Hosted Linux checks remain required on every PR.
- The full macOS aggregate was also run; failures were confined to pre-existing environment-sensitive tests (GNU `timeout` absent, Linux containment symbols, `/private/var` aliasing, and load-sensitive timing). Stack-specific suites passed.

## Post-merge production acceptance

Do not call the fixer healthy until production verifies two distinct clusters with no duplicate dispatch or state loss, and at least one eligible cluster produces a substantive review-ready PR. If a fresh batch has no eligible candidate, retain the selector rejection report as the correct outcome.

After all five PRs land, preserve current gates and run:

```bash
gh workflow run repair-cluster-intake.yml --repo openclaw/clawsweeper --ref main \
  -f enabled=1 \
  -f target_repo=openclaw/openclaw \
  -f limit=2 \
  -f force_store=true
```

Record append-to-publication and intake-to-dispatch latency, verify unrelated job/ledger hashes are unchanged, verify one planning worker per stable dispatch key, require explicit terminal outcomes, and replay the same store to prove idempotency. Do not enable automerge or merge generated production PRs as part of that proof.
