### PR TITLE
feat(state): snapshot+journal record hydration (phase 2)

### DIFF
--- a/.github/actions/setup-state/action.yml
+++ b/.github/actions/setup-state/action.yml
@@ -44,6 +44,22 @@ inputs:
     description: Durable state-writer scheduling class
     required: false
     default: ordinary
+  records-source:
+    description: Record transport used by hydrate-state (git or worker).
+    required: false
+    default: git
+  records-url:
+    description: Worker base URL used when records-source is worker.
+    required: false
+    default: https://clawsweeper.openclaw.ai
+  records-repo-slugs:
+    description: Optional comma/newline-separated record repository slugs; defaults to state checkout directories.
+    required: false
+    default: ""
+  records-secret:
+    description: HMAC secret used only when records-source is worker.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -85,8 +101,31 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Resolve Worker record snapshot cache key
+      id: records-snapshot
+      if: ${{ inputs.records-source == 'worker' }}
+      shell: bash
+      env:
+        CLAWSWEEPER_STATE_DIR: ${{ inputs.state-path }}
+        CLAWSWEEPER_RECORDS_URL: ${{ inputs.records-url }}
+        CLAWSWEEPER_RECORDS_REPO_SLUGS: ${{ inputs.records-repo-slugs }}
+        CLAWSWEEPER_RECORDS_SECRET: ${{ inputs.records-secret }}
+      run: node "${{ inputs.worktree-path }}/scripts/prepare-worker-record-cache.ts"
+
+    - name: Restore Worker record snapshot
+      if: ${{ inputs.records-source == 'worker' && steps.records-snapshot.outputs.available == 'true' }}
+      uses: actions/cache@v6
+      with:
+        path: ${{ inputs.worktree-path }}/.artifacts/worker-records-cache
+        key: clawsweeper-records-${{ runner.os }}-${{ steps.records-snapshot.outputs.cache-key }}
+
     - name: Hydrate generated state
       shell: bash
       env:
         CLAWSWEEPER_STATE_DIR: ${{ inputs.state-path }}
+        CLAWSWEEPER_RECORDS_SOURCE: ${{ inputs.records-source }}
+        CLAWSWEEPER_RECORDS_URL: ${{ inputs.records-url }}
+        CLAWSWEEPER_RECORDS_REPO_SLUGS: ${{ inputs.records-repo-slugs }}
+        CLAWSWEEPER_RECORDS_SECRET: ${{ inputs.records-secret }}
+        CLAWSWEEPER_RECORDS_CACHE_DIR: ${{ inputs.worktree-path }}/.artifacts/worker-records-cache
       run: node "${{ inputs.worktree-path }}/scripts/hydrate-state.ts" --state-dir "${{ inputs.state-path }}" --worktree "${{ inputs.worktree-path }}"

--- a/.github/workflows/backfill-worker-records.yml
+++ b/.github/workflows/backfill-worker-records.yml
@@ -1,0 +1,84 @@
+name: Backfill Worker records
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: Repository whose state records should be seeded (owner/name).
+        required: true
+        type: string
+        default: openclaw/openclaw
+      cursor:
+        description: Zero-based batch cursor from a prior interrupted run.
+        required: false
+        type: number
+        default: 0
+      max_batches:
+        description: Optional bounded batch count; 0 processes the remaining batches.
+        required: false
+        type: number
+        default: 0
+
+concurrency:
+  group: backfill-worker-records-${{ inputs.target_repo }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve target record slug
+        id: target
+        env:
+          TARGET_REPO: ${{ inputs.target_repo }}
+        run: |
+          if ! [[ "$TARGET_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "target_repo must be owner/name" >&2
+            exit 2
+          fi
+          echo "slug=${TARGET_REPO//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+          sparse-checkout: records/${{ steps.target.outputs.slug }}
+          persist-credentials: "false"
+          records-source: git
+          coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
+          coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+
+      - name: Seed revision-zero Worker records
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_RECORDS_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          BACKFILL_CURSOR: ${{ inputs.cursor }}
+          BACKFILL_MAX_BATCHES: ${{ inputs.max_batches }}
+          TARGET_SLUG: ${{ steps.target.outputs.slug }}
+        run: |
+          args=(--state-dir clawsweeper-state --repo-slug "$TARGET_SLUG" --cursor "$BACKFILL_CURSOR")
+          if (( BACKFILL_MAX_BATCHES > 0 )); then
+            args+=(--max-batches "$BACKFILL_MAX_BATCHES")
+          fi
+          node scripts/backfill-worker-records.ts "${args[@]}"

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1,6 +1,10 @@
 export const EXACT_REVIEW_DIRECT_PUBLICATION_TABLE = "exact_review_direct_publication_plans";
 export const EXACT_REVIEW_CANONICAL_RECORD_TABLE = "exact_review_canonical_records";
 export const EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE = "exact_review_canonical_record_chunks";
+export const EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE = "exact_review_record_export_index";
+export const EXACT_REVIEW_RECORD_BACKFILL_TABLE = "exact_review_record_backfill";
+export const EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE = "exact_review_record_backfill_chunks";
+export const EXACT_REVIEW_RECORD_EXPORT_META_TABLE = "exact_review_record_export_meta";
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES = 4 * 1024 * 1024;
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES = 4;
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES = 2 * 1024 * 1024;
@@ -11,7 +15,13 @@ export const EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1
 const DIRECT_PUBLICATION_TERMINAL_PRUNE_LIMIT = 256;
 const MAX_PATH_BYTES = 1024;
 const STATE_APPEND_WINDOW_TABLE = "state_append_window";
-const RECORD_SECTIONS = new Set<RecordSection>(["items", "closed", "plans", "decision-packets"]);
+const RECORD_SECTIONS = new Set<RecordSection>([
+  "items",
+  "closed",
+  "plans",
+  "decision-packets",
+  "commits",
+]);
 
 type SqlStorage = {
   exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
@@ -22,7 +32,8 @@ type DurableStorage = {
   transactionSync: <T>(callback: () => T) => T;
 };
 
-export type RecordSection = "items" | "closed" | "plans" | "decision-packets";
+export type RecordSection = "items" | "closed" | "plans" | "decision-packets" | "commits";
+export type ExactReviewTupleRecordSection = Exclude<RecordSection, "commits">;
 
 export type DirectPublicationOperation = {
   path: string;
@@ -43,7 +54,7 @@ export type DirectPublicationPlan = {
 
 export type CanonicalDirectPublicationOperation = DirectPublicationOperation & {
   repoSlug: string;
-  section: RecordSection;
+  section: ExactReviewTupleRecordSection;
   itemId: number;
   content: string | null;
   digest: string | null;
@@ -85,13 +96,38 @@ export type DirectPublicationProjectionLimits = {
 
 export type CanonicalRecord = {
   repoSlug: string;
-  section: RecordSection;
+  section: ExactReviewTupleRecordSection;
   itemId: number;
   content: string | null;
   digest: string | null;
   revision: number;
   updatedAt: number;
   deleted: boolean;
+};
+
+export type RecordExportEntry = {
+  repoSlug: string;
+  section: RecordSection;
+  id: string;
+  content: string | null;
+  digest: string | null;
+  revision: number;
+  storeRevision: number;
+  updatedAt: number;
+  deleted: boolean;
+};
+
+export type RecordBackfillInput = {
+  section: RecordSection;
+  id: string;
+  content: string;
+  digest: string;
+  bytes: number;
+};
+
+export type RecordSnapshotIdentity = {
+  section: RecordSection;
+  id: string;
 };
 
 export class DirectPublicationProjectionCapacityError extends Error {
@@ -169,6 +205,68 @@ export class ExactReviewDirectPublicationStore {
          PRIMARY KEY (repo_slug, section, item_id, chunk_index)
        ) STRICT`,
     );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RECORD_EXPORT_META_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         current_revision INTEGER NOT NULL CHECK (current_revision >= 0)
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `INSERT OR IGNORE INTO ${EXACT_REVIEW_RECORD_EXPORT_META_TABLE}
+         (singleton_id, current_revision) VALUES (1, 0)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE} (
+         repo_slug TEXT NOT NULL,
+         section TEXT NOT NULL CHECK (
+           section IN ('items', 'closed', 'plans', 'decision-packets', 'commits')
+         ),
+         record_id TEXT NOT NULL,
+         digest TEXT CHECK (digest IS NULL OR length(digest) = 64),
+         deleted INTEGER NOT NULL DEFAULT 0 CHECK (deleted IN (0, 1)),
+         revision INTEGER NOT NULL CHECK (revision >= 0),
+         store_revision INTEGER NOT NULL UNIQUE CHECK (store_revision >= 1),
+         source TEXT NOT NULL CHECK (source IN ('canonical', 'backfill')),
+         updated_at INTEGER NOT NULL,
+         PRIMARY KEY (repo_slug, section, record_id),
+         CHECK ((deleted = 1 AND digest IS NULL) OR (deleted = 0 AND digest IS NOT NULL))
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_record_export_by_repo_revision
+         ON ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+         (repo_slug, store_revision, section, record_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RECORD_BACKFILL_TABLE} (
+         repo_slug TEXT NOT NULL,
+         section TEXT NOT NULL CHECK (
+           section IN ('items', 'closed', 'plans', 'decision-packets', 'commits')
+         ),
+         record_id TEXT NOT NULL,
+         content TEXT,
+         digest TEXT NOT NULL CHECK (length(digest) = 64),
+         byte_length INTEGER NOT NULL CHECK (byte_length >= 0),
+         chunk_count INTEGER NOT NULL DEFAULT 0 CHECK (chunk_count >= 0),
+         updated_at INTEGER NOT NULL,
+         PRIMARY KEY (repo_slug, section, record_id),
+         CHECK ((content IS NOT NULL AND chunk_count = 0)
+           OR (content IS NULL AND chunk_count > 0))
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE} (
+         repo_slug TEXT NOT NULL,
+         section TEXT NOT NULL CHECK (
+           section IN ('items', 'closed', 'plans', 'decision-packets', 'commits')
+         ),
+         record_id TEXT NOT NULL,
+         chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+         content_base64 TEXT NOT NULL,
+         PRIMARY KEY (repo_slug, section, record_id, chunk_index)
+       ) STRICT`,
+    );
+    this.seedExportIndexFromCanonicalSync();
   }
 
   accept(
@@ -289,7 +387,11 @@ export class ExactReviewDirectPublicationStore {
     });
   }
 
-  readCanonical(repoSlug: string, section: RecordSection, itemId: number): CanonicalRecord | null {
+  readCanonical(
+    repoSlug: string,
+    section: ExactReviewTupleRecordSection,
+    itemId: number,
+  ): CanonicalRecord | null {
     const metadata = this.readCanonicalMetadataSync(repoSlug, section, itemId);
     if (!metadata) return null;
     if (metadata.deleted) return { ...metadata, content: null };
@@ -324,7 +426,7 @@ export class ExactReviewDirectPublicationStore {
 
   listCanonical(options: {
     repoSlug: string;
-    section: RecordSection;
+    section: ExactReviewTupleRecordSection;
     cursor: number;
     limit: number;
   }) {
@@ -347,6 +449,137 @@ export class ExactReviewDirectPublicationStore {
         updatedAt: Number(row.updated_at),
       }),
     );
+  }
+
+  exportRecords(options: {
+    repoSlug: string;
+    sections: readonly RecordSection[];
+    sinceRevision: number;
+    cursor: number;
+    limit: number;
+    maxBytes: number;
+  }): { records: RecordExportEntry[]; nextCursor: number | null; watermark: number } {
+    const placeholders = options.sections.map(() => "?").join(", ");
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT repo_slug, section, record_id, digest, deleted, revision, store_revision,
+                source, updated_at
+           FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+          WHERE repo_slug = ?
+            AND section IN (${placeholders})
+            AND store_revision > ?
+            AND store_revision > ?
+          ORDER BY store_revision
+          LIMIT ?`,
+        options.repoSlug,
+        ...options.sections,
+        options.sinceRevision,
+        options.cursor,
+        options.limit,
+      ),
+    );
+    const records: RecordExportEntry[] = [];
+    let responseBytes = 0;
+    for (const row of rows) {
+      const entry = this.recordExportEntrySync(row);
+      const entryBytes = new TextEncoder().encode(JSON.stringify(entry)).byteLength;
+      if (records.length && responseBytes + entryBytes > options.maxBytes) break;
+      records.push(entry);
+      responseBytes += entryBytes;
+    }
+    const watermark = this.currentExportRevisionSync();
+    const lastRevision = records.at(-1)?.storeRevision ?? null;
+    return {
+      records,
+      nextCursor:
+        lastRevision !== null && (records.length < rows.length || rows.length === options.limit)
+          ? lastRevision
+          : null,
+      watermark,
+    };
+  }
+
+  ingestBackfill(repoSlug: string, records: readonly RecordBackfillInput[], now: number) {
+    return this.storage.transactionSync(() => {
+      const result = { inserted: 0, unchanged: 0, skippedNewer: 0 };
+      for (const record of records) {
+        const existing = Array.from(
+          this.storage.sql.exec(
+            `SELECT digest, deleted, revision, source
+               FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+              WHERE repo_slug = ? AND section = ? AND record_id = ?`,
+            repoSlug,
+            record.section,
+            record.id,
+          ),
+        )[0];
+        if (existing) {
+          const revision = Number(existing.revision);
+          if (revision > 0 || String(existing.source) === "canonical") {
+            result.skippedNewer += 1;
+            continue;
+          }
+          if (Number(existing.deleted) === 0 && String(existing.digest) === record.digest) {
+            result.unchanged += 1;
+            continue;
+          }
+          throw new Error(
+            `conflicting revision-0 backfill for ${repoSlug}/${record.section}/${record.id}`,
+          );
+        }
+        this.writeBackfillRecordSync(repoSlug, record, now);
+        const storeRevision = this.nextExportRevisionSync();
+        this.storage.sql.exec(
+          `INSERT INTO ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+             (repo_slug, section, record_id, digest, deleted, revision, store_revision,
+              source, updated_at)
+           VALUES (?, ?, ?, ?, 0, 0, ?, 'backfill', ?)`,
+          repoSlug,
+          record.section,
+          record.id,
+          record.digest,
+          storeRevision,
+          now,
+        );
+        result.inserted += 1;
+      }
+      return { ...result, watermark: this.currentExportRevisionSync() };
+    });
+  }
+
+  currentExportRevision() {
+    return this.currentExportRevisionSync();
+  }
+
+  snapshotRecordIdentities(repoSlug: string): RecordSnapshotIdentity[] {
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT section, record_id
+           FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+          WHERE repo_slug = ? AND deleted = 0
+          ORDER BY section, record_id`,
+        repoSlug,
+      ),
+      (row) => ({
+        section: String(row.section) as RecordSection,
+        id: String(row.record_id),
+      }),
+    );
+  }
+
+  readExportRecord(repoSlug: string, section: RecordSection, id: string): RecordExportEntry | null {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT repo_slug, section, record_id, digest, deleted, revision, store_revision,
+                source, updated_at
+           FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+          WHERE repo_slug = ? AND section = ? AND record_id = ?`,
+        repoSlug,
+        section,
+        id,
+      ),
+    )[0];
+    return row ? this.recordExportEntrySync(row) : null;
   }
 
   list(): DirectPublicationRow[] {
@@ -413,7 +646,11 @@ export class ExactReviewDirectPublicationStore {
     return row ? directPublicationRow(row) : null;
   }
 
-  private readCanonicalMetadataSync(repoSlug: string, section: RecordSection, itemId: number) {
+  private readCanonicalMetadataSync(
+    repoSlug: string,
+    section: ExactReviewTupleRecordSection,
+    itemId: number,
+  ) {
     const row = Array.from(
       this.storage.sql.exec(
         `SELECT content, digest, byte_length, chunk_count, deleted, revision, updated_at
@@ -496,6 +733,195 @@ export class ExactReviewDirectPublicationStore {
         chunks[index],
       );
     }
+    const storeRevision = this.nextExportRevisionSync();
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+         (repo_slug, section, record_id, digest, deleted, revision, store_revision,
+          source, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'canonical', ?)
+       ON CONFLICT(repo_slug, section, record_id) DO UPDATE SET
+         digest = excluded.digest,
+         deleted = excluded.deleted,
+         revision = excluded.revision,
+         store_revision = excluded.store_revision,
+         source = 'canonical',
+         updated_at = excluded.updated_at`,
+      operation.repoSlug,
+      operation.section,
+      String(operation.itemId),
+      operation.digest,
+      operation.content === null ? 1 : 0,
+      plan.revision,
+      storeRevision,
+      now,
+    );
+  }
+
+  private seedExportIndexFromCanonicalSync() {
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT repo_slug, section, item_id, digest, deleted, revision, updated_at
+           FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+          WHERE NOT EXISTS (
+            SELECT 1 FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE} export
+             WHERE export.repo_slug = ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}.repo_slug
+               AND export.section = ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}.section
+               AND export.record_id = CAST(${EXACT_REVIEW_CANONICAL_RECORD_TABLE}.item_id AS TEXT)
+          )
+          ORDER BY repo_slug, section, item_id`,
+      ),
+    );
+    for (const row of rows) {
+      const storeRevision = this.nextExportRevisionSync();
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+           (repo_slug, section, record_id, digest, deleted, revision, store_revision,
+            source, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'canonical', ?)`,
+        String(row.repo_slug),
+        String(row.section),
+        String(row.item_id),
+        row.digest === null ? null : String(row.digest),
+        Number(row.deleted),
+        Number(row.revision),
+        storeRevision,
+        Number(row.updated_at),
+      );
+    }
+  }
+
+  private nextExportRevisionSync() {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `UPDATE ${EXACT_REVIEW_RECORD_EXPORT_META_TABLE}
+            SET current_revision = current_revision + 1
+          WHERE singleton_id = 1
+          RETURNING current_revision`,
+      ),
+    )[0];
+    const revision = Number(row?.current_revision);
+    if (!Number.isSafeInteger(revision) || revision < 1) {
+      throw new Error("record export revision allocation failed");
+    }
+    return revision;
+  }
+
+  private currentExportRevisionSync() {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT current_revision FROM ${EXACT_REVIEW_RECORD_EXPORT_META_TABLE}
+          WHERE singleton_id = 1`,
+      ),
+    )[0];
+    const revision = Number(row?.current_revision ?? 0);
+    if (!Number.isSafeInteger(revision) || revision < 0) {
+      throw new Error("invalid record export revision watermark");
+    }
+    return revision;
+  }
+
+  private recordExportEntrySync(row: Record<string, unknown>): RecordExportEntry {
+    const repoSlug = String(row.repo_slug);
+    const section = String(row.section) as RecordSection;
+    const id = String(row.record_id);
+    const deleted = Number(row.deleted) === 1;
+    let content: string | null = null;
+    if (!deleted) {
+      if (String(row.source) === "canonical") {
+        const itemId = Number(id);
+        if (section === "commits" || !Number.isSafeInteger(itemId) || itemId < 1) {
+          throw new Error(`invalid canonical export identity: ${repoSlug}/${section}/${id}`);
+        }
+        const canonical = this.readCanonical(repoSlug, section, itemId);
+        if (!canonical || canonical.deleted || canonical.content === null) {
+          throw new Error(`canonical export content missing: ${repoSlug}/${section}/${id}`);
+        }
+        content = canonical.content;
+      } else {
+        content = this.readBackfillContentSync(repoSlug, section, id);
+      }
+    }
+    return {
+      repoSlug,
+      section,
+      id,
+      content,
+      digest: row.digest === null ? null : String(row.digest),
+      revision: Number(row.revision),
+      storeRevision: Number(row.store_revision),
+      updatedAt: Number(row.updated_at),
+      deleted,
+    };
+  }
+
+  private writeBackfillRecordSync(repoSlug: string, record: RecordBackfillInput, now: number) {
+    const chunked = record.bytes > EXACT_REVIEW_CANONICAL_INLINE_BYTES;
+    const chunks = chunked ? byteChunks(record.content, EXACT_REVIEW_CANONICAL_CHUNK_BYTES) : [];
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
+         (repo_slug, section, record_id, content, digest, byte_length, chunk_count, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      repoSlug,
+      record.section,
+      record.id,
+      chunked ? null : record.content,
+      record.digest,
+      record.bytes,
+      chunks.length,
+      now,
+    );
+    for (let index = 0; index < chunks.length; index += 1) {
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE}
+           (repo_slug, section, record_id, chunk_index, content_base64)
+         VALUES (?, ?, ?, ?, ?)`,
+        repoSlug,
+        record.section,
+        record.id,
+        index,
+        chunks[index],
+      );
+    }
+  }
+
+  private readBackfillContentSync(repoSlug: string, section: RecordSection, id: string) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT content, byte_length, chunk_count
+           FROM ${EXACT_REVIEW_RECORD_BACKFILL_TABLE}
+          WHERE repo_slug = ? AND section = ? AND record_id = ?`,
+        repoSlug,
+        section,
+        id,
+      ),
+    )[0];
+    if (!row) throw new Error(`backfill export content missing: ${repoSlug}/${section}/${id}`);
+    if (row.content !== null) return String(row.content);
+    const chunks = Array.from(
+      this.storage.sql.exec(
+        `SELECT chunk_index, content_base64
+           FROM ${EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE}
+          WHERE repo_slug = ? AND section = ? AND record_id = ?
+          ORDER BY chunk_index`,
+        repoSlug,
+        section,
+        id,
+      ),
+    );
+    if (chunks.length !== Number(row.chunk_count)) {
+      throw new Error(`backfill export chunk count mismatch: ${repoSlug}/${section}/${id}`);
+    }
+    const parts = chunks.map((chunk) => base64Bytes(String(chunk.content_base64)));
+    const bytes = new Uint8Array(parts.reduce((sum, part) => sum + part.byteLength, 0));
+    let offset = 0;
+    for (const part of parts) {
+      bytes.set(part, offset);
+      offset += part.byteLength;
+    }
+    if (bytes.byteLength !== Number(row.byte_length)) {
+      throw new Error(`backfill export byte count mismatch: ${repoSlug}/${section}/${id}`);
+    }
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   }
 
   private insertSync(row: DirectPublicationRow) {
@@ -538,7 +964,7 @@ function canonicalTupleOperations(
   }
   const primaryWrite = primaryWrites[0];
   const first = operations[0]!;
-  const addDelete = (section: RecordSection): void => {
+  const addDelete = (section: ExactReviewTupleRecordSection): void => {
     if (operations.some((operation) => operation.section === section)) return;
     const extension = section === "decision-packets" ? "json" : "md";
     operations.push({
@@ -593,6 +1019,17 @@ function primaryReferencesDecisionPacket(content: string): boolean {
 export function validateRecordSection(value: unknown): RecordSection | null {
   const section = String(value || "").trim() as RecordSection;
   return RECORD_SECTIONS.has(section) ? section : null;
+}
+
+export function validateTupleRecordSection(value: unknown): ExactReviewTupleRecordSection | null {
+  const section = validateRecordSection(value);
+  return section && section !== "commits" ? section : null;
+}
+
+export function validateRecordId(section: RecordSection, value: unknown): string | null {
+  const id = String(value || "").trim();
+  if (section === "commits") return /^[0-9a-f]{40}$/.test(id) ? id : null;
+  return /^[1-9]\d*$/.test(id) && Number.isSafeInteger(Number(id)) ? id : null;
 }
 
 export function validateRepoSlug(value: unknown): string | null {
@@ -852,7 +1289,7 @@ function canonicalTuplePath(path: string) {
       path,
     );
   if (!match) return null;
-  const section = match[2] as RecordSection;
+  const section = match[2] as ExactReviewTupleRecordSection;
   if ((section === "decision-packets") !== (match[4] === "json")) return null;
   return { repoSlug: match[1]!, section, itemId: Number(match[3]) };
 }
@@ -910,7 +1347,7 @@ function byteChunks(content: string, maximumBytes: number) {
   return chunks;
 }
 
-async function sha256Hex(bytes: Uint8Array) {
+export async function sha256Hex(bytes: Uint8Array) {
   const digest = new Uint8Array(
     await crypto.subtle.digest("SHA-256", Uint8Array.from(bytes).buffer),
   );

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -21,10 +21,15 @@ import {
   DirectPublicationProjectionCapacityError,
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   ExactReviewDirectPublicationStore,
+  sha256Hex,
   validateDirectPublicationBlobOids,
+  validateRecordId,
   validateRecordSection,
   validateRepoSlug,
+  validateTupleRecordSection,
   type DirectPublicationPlan,
+  type RecordBackfillInput,
+  type RecordSection,
 } from "./exact-review-direct-publication.ts";
 import {
   REVIEW_TELEMETRY_DEGRADED_MS,
@@ -43,6 +48,12 @@ import {
   type DurableReviewRunTelemetry,
   normalizeReviewRunTelemetry,
 } from "./review-run-telemetry.ts";
+import {
+  ExactReviewRecordSnapshotStore,
+  RECORD_SNAPSHOT_DOWNLOAD_MAX_BYTES,
+  SnapshotStoreUnavailableError,
+  type RecordSnapshot,
+} from "./record-snapshots.ts";
 
 type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
 const GITHUB_TIMEOUT_MS = 4500;
@@ -480,6 +491,19 @@ const DEFAULT_STATE_WRITER_COORDINATOR_QUEUED_STALE_MS = 2 * 60_000;
 // push that outlives this absolute coordinator horizon.
 const DEFAULT_STATE_WRITER_COORDINATOR_MAX_LEASE_AGE_MS = 30 * 60_000;
 const EXACT_REVIEW_INGRESS_FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
+const RECORD_EXPORT_DEFAULT_LIMIT = 100;
+const RECORD_EXPORT_MAX_LIMIT = 200;
+const RECORD_EXPORT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const RECORD_INGEST_MAX_RECORDS = 100;
+const RECORD_INGEST_MAX_REQUEST_BYTES = 4 * 1024 * 1024;
+const RECORD_INGEST_MAX_FILE_BYTES = 2 * 1024 * 1024;
+const RECORD_EXPORT_SECTIONS: readonly RecordSection[] = [
+  "items",
+  "closed",
+  "plans",
+  "decision-packets",
+  "commits",
+];
 
 export class ExactReviewQueue {
   private storage;
@@ -490,6 +514,7 @@ export class ExactReviewQueue {
   private legacyMirrorWarningReported = false;
   private batchStore;
   private directPublicationStore;
+  private recordSnapshotStore;
   private stateWriterCoordinator;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
 
@@ -498,6 +523,11 @@ export class ExactReviewQueue {
     this.env = env;
     this.batchStore = new ExactReviewPublicationBatchStore(this.storage);
     this.directPublicationStore = new ExactReviewDirectPublicationStore(this.storage);
+    this.recordSnapshotStore = new ExactReviewRecordSnapshotStore(
+      this.storage,
+      this.directPublicationStore,
+      env.STATE_SNAPSHOTS,
+    );
     this.stateWriterCoordinator = new StateWriterCoordinator(this.storage);
     const initialize = () => this.initializeStorage();
     this.ready =
@@ -1935,7 +1965,7 @@ export class ExactReviewQueue {
         : null;
     if (canonicalRecordMatch) {
       const repoSlug = validateRepoSlug(canonicalRecordMatch[1]);
-      const section = validateRecordSection(canonicalRecordMatch[2]);
+      const section = validateTupleRecordSection(canonicalRecordMatch[2]);
       const itemId = Number(canonicalRecordMatch[3]);
       if (!repoSlug || !section || !Number.isSafeInteger(itemId)) {
         return json({ error: "invalid_canonical_record_identity" }, 400);
@@ -1968,7 +1998,7 @@ export class ExactReviewQueue {
     if (request.method === "POST" && url.pathname === "/records/list") {
       const body = objectValue(await request.json().catch(() => null));
       const repoSlug = validateRepoSlug(body.repoSlug);
-      const section = validateRecordSection(body.section);
+      const section = validateTupleRecordSection(body.section);
       const cursor = body.cursor === undefined || body.cursor === null ? 0 : Number(body.cursor);
       const limit = body.limit === undefined ? 100 : Number(body.limit);
       if (
@@ -2001,6 +2031,178 @@ export class ExactReviewQueue {
         })),
         nextCursor: records.length === limit ? (records.at(-1)?.id ?? null) : null,
       });
+    }
+
+    if (request.method === "POST" && url.pathname === "/records/export") {
+      const body = objectValue(await request.json().catch(() => null));
+      const repoSlug = validateRepoSlug(body.repoSlug);
+      const rawSections = body.sections === undefined ? RECORD_EXPORT_SECTIONS : body.sections;
+      const sections = Array.isArray(rawSections)
+        ? [...new Set(rawSections.map(validateRecordSection).filter(Boolean))]
+        : [];
+      const sinceRevision = body.sinceRevision === undefined ? 0 : Number(body.sinceRevision);
+      const cursor = body.cursor === undefined || body.cursor === null ? 0 : Number(body.cursor);
+      const limit = body.limit === undefined ? RECORD_EXPORT_DEFAULT_LIMIT : Number(body.limit);
+      if (
+        !repoSlug ||
+        !Array.isArray(rawSections) ||
+        !sections.length ||
+        sections.length !== rawSections.length ||
+        !Number.isSafeInteger(sinceRevision) ||
+        sinceRevision < 0 ||
+        !Number.isSafeInteger(cursor) ||
+        cursor < 0 ||
+        !Number.isSafeInteger(limit) ||
+        limit < 1 ||
+        limit > RECORD_EXPORT_MAX_LIMIT
+      ) {
+        return json({ error: "invalid_canonical_record_export" }, 400);
+      }
+      const exported = this.directPublicationStore.exportRecords({
+        repoSlug,
+        sections: sections as RecordSection[],
+        sinceRevision,
+        cursor,
+        limit,
+        maxBytes: RECORD_EXPORT_MAX_RESPONSE_BYTES,
+      });
+      return json({
+        repoSlug,
+        sections,
+        sinceRevision,
+        cursor,
+        limit,
+        revision: exported.watermark,
+        records: exported.records.map((record) => ({
+          section: record.section,
+          id: record.id,
+          content: record.content,
+          digest: record.digest,
+          revision: record.revision,
+          storeRevision: record.storeRevision,
+          updatedAt: new Date(record.updatedAt).toISOString(),
+          deleted: record.deleted,
+        })),
+        nextCursor: exported.nextCursor,
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === "/records/snapshots/latest") {
+      const body = objectValue(await request.json().catch(() => null));
+      const repoSlug = validateRepoSlug(body.repoSlug);
+      if (!repoSlug) return json({ error: "invalid_snapshot_repository" }, 400);
+      try {
+        const snapshot = await this.recordSnapshotStore.latest(repoSlug);
+        if (!snapshot) {
+          return json({ error: "snapshot_not_found", snapshotStoreAvailable: true, repoSlug }, 404);
+        }
+        return json({ ok: true, snapshotStoreAvailable: true, snapshot: snapshotJson(snapshot) });
+      } catch (error) {
+        return snapshotErrorResponse(error);
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/records/snapshots/trigger") {
+      const body = objectValue(await request.json().catch(() => null));
+      const repoSlug = validateRepoSlug(body.repoSlug);
+      if (!repoSlug) return json({ error: "invalid_snapshot_repository" }, 400);
+      try {
+        const snapshot = await this.recordSnapshotStore.produce(repoSlug);
+        return json(
+          { ok: true, snapshotStoreAvailable: true, snapshot: snapshotJson(snapshot) },
+          201,
+        );
+      } catch (error) {
+        return snapshotErrorResponse(error);
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/records/snapshots/chunk") {
+      const body = objectValue(await request.json().catch(() => null));
+      const repoSlug = validateRepoSlug(body.repoSlug);
+      if (!repoSlug) return json({ error: "invalid_snapshot_repository" }, 400);
+      try {
+        const result = await this.recordSnapshotStore.readRange(
+          repoSlug,
+          Number(body.revisionWatermark),
+          Number(body.offset),
+          Number(body.length),
+        );
+        return new Response(result.object.body, {
+          status: 206,
+          headers: {
+            "accept-ranges": "bytes",
+            "content-length": String(result.length),
+            "content-range": `bytes ${Number(body.offset)}-${Number(body.offset) + result.length - 1}/${result.snapshot.bytes}`,
+            "content-type": "application/gzip",
+            "x-clawsweeper-snapshot-revision": String(result.snapshot.revisionWatermark),
+          },
+        });
+      } catch (error) {
+        return snapshotErrorResponse(error);
+      }
+    }
+
+    if (request.method === "POST" && url.pathname === "/records/ingest") {
+      const bodyText = await request.text();
+      if (new TextEncoder().encode(bodyText).byteLength > RECORD_INGEST_MAX_REQUEST_BYTES) {
+        return json(
+          { error: "canonical_record_ingest_too_large", maxBytes: RECORD_INGEST_MAX_REQUEST_BYTES },
+          413,
+        );
+      }
+      let parsedBody: unknown;
+      try {
+        parsedBody = JSON.parse(bodyText || "null");
+      } catch {
+        return json({ error: "invalid_canonical_record_ingest" }, 400);
+      }
+      const body = objectValue(parsedBody);
+      const repoSlug = validateRepoSlug(body.repoSlug);
+      if (
+        !repoSlug ||
+        !Array.isArray(body.records) ||
+        body.records.length < 1 ||
+        body.records.length > RECORD_INGEST_MAX_RECORDS
+      ) {
+        return json({ error: "invalid_canonical_record_ingest" }, 400);
+      }
+      const records: RecordBackfillInput[] = [];
+      for (const value of body.records) {
+        const record = objectValue(value);
+        const section = validateRecordSection(record.section);
+        const id = section ? validateRecordId(section, record.id) : null;
+        const content = typeof record.content === "string" ? record.content : null;
+        const digest = String(record.digest || "").toLowerCase();
+        if (!section || !id || content === null || !/^[0-9a-f]{64}$/.test(digest)) {
+          return json({ error: "invalid_canonical_record_ingest" }, 400);
+        }
+        const bytes = new TextEncoder().encode(content);
+        if (bytes.byteLength > RECORD_INGEST_MAX_FILE_BYTES) {
+          return json(
+            {
+              error: "canonical_record_too_large",
+              section,
+              id,
+              maxBytes: RECORD_INGEST_MAX_FILE_BYTES,
+            },
+            413,
+          );
+        }
+        if ((await sha256Hex(bytes)) !== digest) {
+          return json({ error: "canonical_record_digest_mismatch", section, id }, 400);
+        }
+        records.push({ section, id, content, digest, bytes: bytes.byteLength });
+      }
+      try {
+        const ingested = this.directPublicationStore.ingestBackfill(repoSlug, records, Date.now());
+        return json({ ok: true, repoSlug, ...ingested }, 202);
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("conflicting revision-0 backfill")) {
+          return json({ error: "canonical_record_backfill_conflict" }, 409);
+        }
+        throw error;
+      }
     }
 
     if (request.method === "POST" && url.pathname === "/publication-results") {
@@ -4948,6 +5150,7 @@ export class ExactReviewQueue {
     this.ensureStorageSchemaSync();
     this.batchStore.ensureSchemaSync();
     this.directPublicationStore.ensureSchemaSync();
+    this.recordSnapshotStore.ensureSchemaSync();
     this.stateWriterCoordinator.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
@@ -11186,6 +11389,48 @@ function stringEnv(value) {
 function numberFrom(value, fallback) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
+}
+
+function snapshotJson(snapshot: RecordSnapshot) {
+  return {
+    repoSlug: snapshot.repoSlug,
+    revisionWatermark: snapshot.revisionWatermark,
+    objectKey: snapshot.objectKey,
+    bytes: snapshot.bytes,
+    uncompressedBytes: snapshot.uncompressedBytes,
+    fileCount: snapshot.fileCount,
+    createdAt: new Date(snapshot.createdAt).toISOString(),
+    access: {
+      mode: "worker_range_proxy",
+      maxChunkBytes: RECORD_SNAPSHOT_DOWNLOAD_MAX_BYTES,
+    },
+  };
+}
+
+function snapshotErrorResponse(error: unknown) {
+  if (error instanceof SnapshotStoreUnavailableError) {
+    console.error(`snapshot store unavailable: ${error.cause || error.message}`);
+    return json(
+      {
+        error: "snapshot_store_unavailable",
+        snapshotStoreAvailable: false,
+        detail: "STATE_SNAPSHOTS is not available",
+      },
+      503,
+    );
+  }
+  if (error instanceof RangeError) {
+    const notFound = error.message === "snapshot not found";
+    return json(
+      {
+        error: notFound ? "snapshot_not_found" : "invalid_snapshot_range",
+        snapshotStoreAvailable: true,
+      },
+      notFound ? 404 : 400,
+    );
+  }
+  console.error(`snapshot request failed: ${error}`);
+  return json({ error: "snapshot_request_failed", snapshotStoreAvailable: true }, 500);
 }
 
 function json(value, status = 200) {

--- a/dashboard/record-snapshots.ts
+++ b/dashboard/record-snapshots.ts
@@ -1,0 +1,454 @@
+import type {
+  ExactReviewDirectPublicationStore,
+  RecordSection,
+  RecordSnapshotIdentity,
+} from "./exact-review-direct-publication.ts";
+
+export const EXACT_REVIEW_RECORD_SNAPSHOT_TABLE = "exact_review_record_snapshots";
+export const RECORD_SNAPSHOT_KEEP = 2;
+export const RECORD_SNAPSHOT_DOWNLOAD_MAX_BYTES = 32 * 1024 * 1024;
+
+const R2_MULTIPART_PART_BYTES = 8 * 1024 * 1024;
+const TAR_BLOCK_BYTES = 512;
+const encoder = new TextEncoder();
+
+type SqlStorage = {
+  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
+};
+
+type DurableStorage = {
+  sql: SqlStorage;
+  transactionSync: <T>(callback: () => T) => T;
+};
+
+type UploadedPart = { partNumber: number; etag: string };
+
+type R2MultipartUploadLike = {
+  uploadPart: (partNumber: number, value: ArrayBuffer | Uint8Array) => Promise<UploadedPart>;
+  complete: (parts: UploadedPart[]) => Promise<unknown>;
+  abort: () => Promise<void>;
+};
+
+export type SnapshotR2Object = {
+  body: ReadableStream<Uint8Array>;
+  size: number;
+};
+
+export type SnapshotR2Bucket = {
+  createMultipartUpload: (
+    key: string,
+    options?: { httpMetadata?: { contentType?: string } },
+  ) => Promise<R2MultipartUploadLike>;
+  head: (key: string) => Promise<unknown | null>;
+  get: (
+    key: string,
+    options?: { range?: { offset: number; length: number } },
+  ) => Promise<SnapshotR2Object | null>;
+  delete: (keys: string | string[]) => Promise<void>;
+};
+
+export type RecordSnapshot = {
+  repoSlug: string;
+  revisionWatermark: number;
+  objectKey: string;
+  bytes: number;
+  uncompressedBytes: number;
+  fileCount: number;
+  createdAt: number;
+};
+
+export class SnapshotStoreUnavailableError extends Error {
+  constructor(message = "snapshot store unavailable", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SnapshotStoreUnavailableError";
+  }
+}
+
+export class ExactReviewRecordSnapshotStore {
+  private readonly storage: DurableStorage;
+  private readonly records: ExactReviewDirectPublicationStore;
+  private readonly bucket: SnapshotR2Bucket | null;
+
+  constructor(
+    storage: DurableStorage,
+    records: ExactReviewDirectPublicationStore,
+    bucket: unknown,
+  ) {
+    this.storage = storage;
+    this.records = records;
+    this.bucket = snapshotBucket(bucket);
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE} (
+         snapshot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+         repo_slug TEXT NOT NULL,
+         revision_watermark INTEGER NOT NULL CHECK (revision_watermark >= 0),
+         object_key TEXT NOT NULL UNIQUE,
+         bytes INTEGER NOT NULL CHECK (bytes >= 0),
+         uncompressed_bytes INTEGER NOT NULL CHECK (uncompressed_bytes >= 0),
+         file_count INTEGER NOT NULL CHECK (file_count >= 0),
+         created_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_record_snapshots_latest
+         ON ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE}
+         (repo_slug, created_at DESC, snapshot_id DESC)`,
+    );
+  }
+
+  available() {
+    return this.bucket !== null;
+  }
+
+  async latest(repoSlug: string): Promise<RecordSnapshot | null> {
+    const bucket = this.requireBucket();
+    const snapshot = this.latestSync(repoSlug);
+    if (!snapshot) return null;
+    try {
+      const object = await bucket.head(snapshot.objectKey);
+      if (!object) throw new Error(`snapshot object is missing: ${snapshot.objectKey}`);
+      return snapshot;
+    } catch (error) {
+      throw unavailable(error);
+    }
+  }
+
+  async produce(repoSlug: string): Promise<RecordSnapshot> {
+    const bucket = this.requireBucket();
+    const revisionWatermark = this.records.currentExportRevision();
+    const identities = this.records.snapshotRecordIdentities(repoSlug);
+    const createdAt = Date.now();
+    const objectKey = `${repoSlug}/${revisionWatermark}/${createdAt}-${crypto.randomUUID()}.tar.gz`;
+    let upload: R2MultipartUploadLike | null = null;
+    try {
+      try {
+        upload = await bucket.createMultipartUpload(objectKey, {
+          httpMetadata: { contentType: "application/gzip" },
+        });
+      } catch (error) {
+        throw unavailable(error);
+      }
+      const stats = { fileCount: 0, uncompressedBytes: 0 };
+      const compressed = tarStream(repoSlug, identities, this.records, stats).pipeThrough(
+        new CompressionStream("gzip") as unknown as TransformStream<Uint8Array, Uint8Array>,
+      );
+      const { bytes, parts } = await uploadMultipart(compressed, upload);
+      try {
+        await upload.complete(parts);
+      } catch (error) {
+        throw unavailable(error);
+      }
+      const snapshot: RecordSnapshot = {
+        repoSlug,
+        revisionWatermark,
+        objectKey,
+        bytes,
+        uncompressedBytes: stats.uncompressedBytes,
+        fileCount: stats.fileCount,
+        createdAt,
+      };
+      this.insertSync(snapshot);
+      await this.prune(repoSlug);
+      return snapshot;
+    } catch (error) {
+      if (upload) await upload.abort().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async readRange(
+    repoSlug: string,
+    revisionWatermark: number,
+    offset: number,
+    length: number,
+  ): Promise<{ snapshot: RecordSnapshot; object: SnapshotR2Object; length: number }> {
+    const bucket = this.requireBucket();
+    if (
+      !Number.isSafeInteger(revisionWatermark) ||
+      revisionWatermark < 0 ||
+      !Number.isSafeInteger(offset) ||
+      offset < 0 ||
+      !Number.isSafeInteger(length) ||
+      length < 1 ||
+      length > RECORD_SNAPSHOT_DOWNLOAD_MAX_BYTES
+    ) {
+      throw new RangeError("invalid snapshot range");
+    }
+    const snapshot = this.findSync(repoSlug, revisionWatermark);
+    if (!snapshot) throw new RangeError("snapshot not found");
+    if (offset >= snapshot.bytes) throw new RangeError("snapshot range starts past end");
+    const boundedLength = Math.min(length, snapshot.bytes - offset);
+    try {
+      const object = await bucket.get(snapshot.objectKey, {
+        range: { offset, length: boundedLength },
+      });
+      if (!object) throw new Error(`snapshot object is missing: ${snapshot.objectKey}`);
+      return { snapshot, object, length: boundedLength };
+    } catch (error) {
+      throw unavailable(error);
+    }
+  }
+
+  private requireBucket() {
+    if (!this.bucket) throw new SnapshotStoreUnavailableError();
+    return this.bucket;
+  }
+
+  private latestSync(repoSlug: string) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT repo_slug, revision_watermark, object_key, bytes, uncompressed_bytes,
+                file_count, created_at
+           FROM ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE}
+          WHERE repo_slug = ?
+          ORDER BY created_at DESC, snapshot_id DESC
+          LIMIT 1`,
+        repoSlug,
+      ),
+    )[0];
+    return row ? snapshotFromRow(row) : null;
+  }
+
+  private findSync(repoSlug: string, revisionWatermark: number) {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT repo_slug, revision_watermark, object_key, bytes, uncompressed_bytes,
+                file_count, created_at
+           FROM ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE}
+          WHERE repo_slug = ? AND revision_watermark = ?
+          ORDER BY created_at DESC, snapshot_id DESC
+          LIMIT 1`,
+        repoSlug,
+        revisionWatermark,
+      ),
+    )[0];
+    return row ? snapshotFromRow(row) : null;
+  }
+
+  private insertSync(snapshot: RecordSnapshot) {
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE}
+         (repo_slug, revision_watermark, object_key, bytes, uncompressed_bytes,
+          file_count, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      snapshot.repoSlug,
+      snapshot.revisionWatermark,
+      snapshot.objectKey,
+      snapshot.bytes,
+      snapshot.uncompressedBytes,
+      snapshot.fileCount,
+      snapshot.createdAt,
+    );
+  }
+
+  private async prune(repoSlug: string) {
+    const bucket = this.requireBucket();
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT snapshot_id, object_key
+           FROM ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE}
+          WHERE repo_slug = ?
+          ORDER BY created_at DESC, snapshot_id DESC
+          LIMIT -1 OFFSET ?`,
+        repoSlug,
+        RECORD_SNAPSHOT_KEEP,
+      ),
+    );
+    if (!rows.length) return;
+    const objectKeys = rows.map((row) => String(row.object_key));
+    try {
+      await bucket.delete(objectKeys);
+    } catch (error) {
+      throw unavailable(error);
+    }
+    const placeholders = rows.map(() => "?").join(", ");
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_RECORD_SNAPSHOT_TABLE}
+        WHERE snapshot_id IN (${placeholders})`,
+      ...rows.map((row) => Number(row.snapshot_id)),
+    );
+  }
+}
+
+function snapshotBucket(value: unknown): SnapshotR2Bucket | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<SnapshotR2Bucket>;
+  return typeof candidate.createMultipartUpload === "function" &&
+    typeof candidate.head === "function" &&
+    typeof candidate.get === "function" &&
+    typeof candidate.delete === "function"
+    ? (candidate as SnapshotR2Bucket)
+    : null;
+}
+
+function unavailable(error: unknown) {
+  return error instanceof SnapshotStoreUnavailableError
+    ? error
+    : new SnapshotStoreUnavailableError("snapshot store unavailable", {
+        cause: error instanceof Error ? error : undefined,
+      });
+}
+
+function snapshotFromRow(row: Record<string, unknown>): RecordSnapshot {
+  return {
+    repoSlug: String(row.repo_slug),
+    revisionWatermark: Number(row.revision_watermark),
+    objectKey: String(row.object_key),
+    bytes: Number(row.bytes),
+    uncompressedBytes: Number(row.uncompressed_bytes),
+    fileCount: Number(row.file_count),
+    createdAt: Number(row.created_at),
+  };
+}
+
+async function uploadMultipart(stream: ReadableStream<Uint8Array>, upload: R2MultipartUploadLike) {
+  const reader = stream.getReader();
+  const pending: Uint8Array[] = [];
+  let pendingBytes = 0;
+  let bytes = 0;
+  let partNumber = 1;
+  const parts: UploadedPart[] = [];
+  while (true) {
+    const next = await reader.read();
+    if (next.done) break;
+    pending.push(next.value);
+    pendingBytes += next.value.byteLength;
+    bytes += next.value.byteLength;
+    while (pendingBytes >= R2_MULTIPART_PART_BYTES) {
+      const part = takeBytes(pending, R2_MULTIPART_PART_BYTES);
+      pendingBytes -= part.byteLength;
+      try {
+        parts.push(await upload.uploadPart(partNumber++, part));
+      } catch (error) {
+        throw unavailable(error);
+      }
+    }
+  }
+  if (pendingBytes) {
+    try {
+      parts.push(await upload.uploadPart(partNumber, takeBytes(pending, pendingBytes)));
+    } catch (error) {
+      throw unavailable(error);
+    }
+  }
+  if (!parts.length) throw new Error("snapshot compression produced no data");
+  return { bytes, parts };
+}
+
+function takeBytes(chunks: Uint8Array[], size: number) {
+  const output = new Uint8Array(size);
+  let written = 0;
+  while (written < size) {
+    const chunk = chunks.shift();
+    if (!chunk) throw new Error("snapshot byte buffer underflow");
+    const take = Math.min(chunk.byteLength, size - written);
+    output.set(chunk.subarray(0, take), written);
+    written += take;
+    if (take < chunk.byteLength) chunks.unshift(chunk.subarray(take));
+  }
+  return output;
+}
+
+function tarStream(
+  repoSlug: string,
+  identities: readonly RecordSnapshotIdentity[],
+  records: ExactReviewDirectPublicationStore,
+  stats: { fileCount: number; uncompressedBytes: number },
+) {
+  const iterator = tarChunks(repoSlug, identities, records, stats)[Symbol.asyncIterator]();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const next = await iterator.next();
+        if (next.done) controller.close();
+        else controller.enqueue(next.value as Uint8Array);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      await iterator.return?.();
+    },
+  });
+}
+
+async function* tarChunks(
+  repoSlug: string,
+  identities: readonly RecordSnapshotIdentity[],
+  records: ExactReviewDirectPublicationStore,
+  stats: { fileCount: number; uncompressedBytes: number },
+) {
+  for (const identity of identities) {
+    const record = records.readExportRecord(repoSlug, identity.section, identity.id);
+    if (!record || record.deleted || record.content === null) continue;
+    const content = encoder.encode(record.content);
+    const relativePath = `${identity.section}/${identity.id}${recordExtension(identity.section)}`;
+    yield tarHeader(relativePath, content.byteLength);
+    yield content;
+    const padding = (TAR_BLOCK_BYTES - (content.byteLength % TAR_BLOCK_BYTES)) % TAR_BLOCK_BYTES;
+    if (padding) yield new Uint8Array(padding);
+    stats.fileCount += 1;
+    stats.uncompressedBytes += content.byteLength;
+  }
+  yield new Uint8Array(TAR_BLOCK_BYTES * 2);
+}
+
+function tarHeader(relativePath: string, size: number) {
+  const header = new Uint8Array(TAR_BLOCK_BYTES);
+  const { name, prefix } = splitTarPath(relativePath);
+  writeTarString(header, 0, 100, name);
+  writeTarOctal(header, 100, 8, 0o644);
+  writeTarOctal(header, 108, 8, 0);
+  writeTarOctal(header, 116, 8, 0);
+  writeTarOctal(header, 124, 12, size);
+  writeTarOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  writeTarString(header, 257, 6, "ustar\0");
+  writeTarString(header, 263, 2, "00");
+  writeTarString(header, 265, 32, "clawsweeper");
+  writeTarString(header, 297, 32, "clawsweeper");
+  writeTarString(header, 345, 155, prefix);
+  const checksum = header.reduce((sum, value) => sum + value, 0);
+  const checksumText = checksum.toString(8).padStart(6, "0");
+  writeTarString(header, 148, 6, checksumText);
+  header[154] = 0;
+  header[155] = 0x20;
+  return header;
+}
+
+function splitTarPath(relativePath: string) {
+  if (encoder.encode(relativePath).byteLength <= 100) return { name: relativePath, prefix: "" };
+  for (
+    let index = relativePath.lastIndexOf("/");
+    index > 0;
+    index = relativePath.lastIndexOf("/", index - 1)
+  ) {
+    const prefix = relativePath.slice(0, index);
+    const name = relativePath.slice(index + 1);
+    if (encoder.encode(prefix).byteLength <= 155 && encoder.encode(name).byteLength <= 100) {
+      return { name, prefix };
+    }
+  }
+  throw new Error(`snapshot tar path is too long: ${relativePath}`);
+}
+
+function writeTarString(target: Uint8Array, offset: number, length: number, value: string) {
+  const bytes = encoder.encode(value);
+  if (bytes.byteLength > length) throw new Error(`tar header value exceeds ${length} bytes`);
+  target.set(bytes, offset);
+}
+
+function writeTarOctal(target: Uint8Array, offset: number, length: number, value: number) {
+  const octal = value.toString(8).padStart(length - 1, "0");
+  if (octal.length >= length) throw new Error(`tar numeric value exceeds ${length} bytes`);
+  writeTarString(target, offset, length - 1, octal);
+  target[offset + length - 1] = 0;
+}
+
+function recordExtension(section: RecordSection) {
+  return section === "decision-packets" ? ".json" : ".md";
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -558,6 +558,16 @@ export default {
       );
     if (url.pathname === "/internal/state/records/list" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/records/list");
+    if (url.pathname === "/internal/state/records/export" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/export");
+    if (url.pathname === "/internal/state/records/ingest" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/ingest");
+    if (url.pathname === "/internal/state/records/snapshots/latest" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/snapshots/latest");
+    if (url.pathname === "/internal/state/records/snapshots/trigger" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/snapshots/trigger");
+    if (url.pathname === "/internal/state/records/snapshots/chunk" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/snapshots/chunk");
     if (url.pathname === "/internal/state/append" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/state/append");
     if (url.pathname === "/internal/state/drain" && request.method === "POST")

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -9,6 +9,11 @@ crons = ["*/5 * * * *"]
 
 [assets]
 directory = "./public"
+
+[[r2_buckets]]
+binding = "STATE_SNAPSHOTS"
+bucket_name = "clawsweeper-state-snapshots"
+
 [[durable_objects.bindings]]
 name = "STATUS_STORE"
 class_name = "StatusStore"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "repair:exact-review-batch": "node dist/repair/exact-review-batch-cli.js",
     "repair:exact-review-direct-publication": "node dist/repair/exact-review-direct-publication.js",
     "proof:state-publication-batching": "node scripts/state-publication-batching-proof.mjs",
+    "state:records:backfill": "node scripts/backfill-worker-records.ts",
+    "state:records:verify": "node scripts/verify-worker-record-parity.ts",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",
     "workflow": "node dist/repair/workflow-utils.js",

--- a/scripts/backfill-worker-records.ts
+++ b/scripts/backfill-worker-records.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { ingestGitRecords } from "./worker-records.ts";
+
+export async function backfillWorkerRecords(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+) {
+  const args = parseArgs(argv);
+  const repoSlug = args.repoSlug ?? env.CLAWSWEEPER_RECORDS_REPO_SLUG;
+  if (!repoSlug) throw new Error("--repo-slug is required");
+  const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  if (!webhookSecret) throw new Error("CLAWSWEEPER_WEBHOOK_SECRET is required");
+  const result = await ingestGitRecords({
+    stateRoot: path.resolve(args.stateDir ?? env.CLAWSWEEPER_STATE_DIR ?? "clawsweeper-state"),
+    repoSlug,
+    baseUrl:
+      args.recordsUrl ??
+      env.CLAWSWEEPER_RECORDS_URL ??
+      env.CLAWSWEEPER_STATE_COORDINATOR_URL ??
+      "https://clawsweeper.openclaw.ai",
+    webhookSecret,
+    fetch: fetchImpl,
+    cursor: args.cursor,
+    maxBatches: args.maxBatches,
+    onBatch: ({ completedCursor, totalBatches }) => {
+      console.error(
+        `[worker-record-backfill] cursor=${completedCursor}/${totalBatches} repo=${repoSlug}`,
+      );
+    },
+  });
+  console.log(JSON.stringify({ repoSlug, ...result }));
+  return result;
+}
+
+function parseArgs(argv: string[]) {
+  const result: {
+    stateDir?: string;
+    repoSlug?: string;
+    recordsUrl?: string;
+    cursor?: number;
+    maxBatches?: number;
+  } = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--state-dir") result.stateDir = requiredValue(argv, ++index, arg);
+    else if (arg === "--repo-slug") result.repoSlug = requiredValue(argv, ++index, arg);
+    else if (arg === "--records-url") result.recordsUrl = requiredValue(argv, ++index, arg);
+    else if (arg === "--cursor") result.cursor = nonNegativeInteger(argv, ++index, arg);
+    else if (arg === "--max-batches") result.maxBatches = positiveInteger(argv, ++index, arg);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return result;
+}
+
+function nonNegativeInteger(argv: string[], index: number, flag: string) {
+  const value = Number(requiredValue(argv, index, flag));
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${flag} must be at least 0`);
+  return value;
+}
+
+function positiveInteger(argv: string[], index: number, flag: string) {
+  const value = Number(requiredValue(argv, index, flag));
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${flag} must be at least 1`);
+  return value;
+}
+
+function requiredValue(argv: string[], index: number, flag: string) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  await backfillWorkerRecords(process.argv.slice(2));
+}

--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -1,47 +1,118 @@
 #!/usr/bin/env node
 import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  discoverRecordRepoSlugs,
+  materializeWorkerRecords,
+  WorkerSnapshotUnavailableError,
+} from "./worker-records.ts";
 
 const GENERATED_PATHS = [
   "records",
   "jobs",
   "results",
+  "ledger",
+  "notifications",
   "assets",
   "apply-report.json",
   "repair-apply-report.json",
-];
+] as const;
+const NON_RECORD_PATHS = GENERATED_PATHS.filter((relativePath) => relativePath !== "records");
 
 type Args = {
   stateDir?: string;
   worktree?: string;
+  recordsSource?: "git" | "worker";
+  recordsUrl?: string;
+  recordsRepoSlugs?: string[];
 };
 
-const args = parseArgs(process.argv.slice(2));
-const stateRoot = path.resolve(
-  args.stateDir ?? process.env.CLAWSWEEPER_STATE_DIR ?? "../clawsweeper-state",
-);
-const worktreeRoot = path.resolve(args.worktree ?? process.cwd());
-
-if (!existsSync(stateRoot)) {
-  throw new Error(`State directory does not exist: ${stateRoot}`);
-}
-
-if (!GENERATED_PATHS.some((relativePath) => existsSync(path.join(stateRoot, relativePath)))) {
-  throw new Error(
-    `State directory has no generated paths: ${stateRoot}. Check out the generated state branch first, for example: git -C ${stateRoot} switch state`,
+export async function hydrateState(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+) {
+  const args = parseArgs(argv);
+  const stateRoot = path.resolve(
+    args.stateDir ?? env.CLAWSWEEPER_STATE_DIR ?? "../clawsweeper-state",
   );
+  const worktreeRoot = path.resolve(args.worktree ?? process.cwd());
+  const recordsSource = args.recordsSource ?? parseRecordsSource(env.CLAWSWEEPER_RECORDS_SOURCE);
+
+  if (!existsSync(stateRoot)) throw new Error(`State directory does not exist: ${stateRoot}`);
+  if (!GENERATED_PATHS.some((relativePath) => existsSync(path.join(stateRoot, relativePath)))) {
+    throw new Error(
+      `State directory has no generated paths: ${stateRoot}. Check out the generated state branch first, for example: git -C ${stateRoot} switch state`,
+    );
+  }
+
+  const gitPaths = recordsSource === "git" ? GENERATED_PATHS : NON_RECORD_PATHS;
+  for (const relativePath of gitPaths) copyGeneratedPath(stateRoot, worktreeRoot, relativePath);
+
+  let worker: Awaited<ReturnType<typeof materializeWorkerRecords>> | undefined;
+  let recordsFallback: { reason: string; source: "git" } | undefined;
+  if (recordsSource === "worker") {
+    const repoSlugs =
+      args.recordsRepoSlugs ??
+      parseRepoSlugs(env.CLAWSWEEPER_RECORDS_REPO_SLUGS) ??
+      discoverRecordRepoSlugs(stateRoot);
+    const webhookSecret = env.CLAWSWEEPER_RECORDS_SECRET ?? env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+    if (repoSlugs.length && !webhookSecret) {
+      throw new Error("CLAWSWEEPER_RECORDS_SECRET is required for Worker record hydration");
+    }
+    try {
+      if (!repoSlugs.length) throw new WorkerSnapshotUnavailableError("snapshot_not_found");
+      worker = await materializeWorkerRecords({
+        worktreeRoot,
+        baseUrl:
+          args.recordsUrl ??
+          env.CLAWSWEEPER_RECORDS_URL ??
+          env.CLAWSWEEPER_STATE_COORDINATOR_URL ??
+          "https://clawsweeper.openclaw.ai",
+        webhookSecret: webhookSecret || "unused-empty-snapshot",
+        repoSlugs,
+        cacheRoot: env.CLAWSWEEPER_RECORDS_CACHE_DIR,
+        fetch: fetchImpl,
+      });
+    } catch (error) {
+      if (!(error instanceof WorkerSnapshotUnavailableError)) throw error;
+      const sourceRecords = path.join(stateRoot, "records");
+      if (!existsSync(sourceRecords)) {
+        throw new Error(
+          `Worker record cutover refused (${error.reason}), and git fallback records are unavailable at ${sourceRecords}`,
+          { cause: error },
+        );
+      }
+      console.error(
+        `[hydrate-state] WORKER RECORD CUTOVER REFUSED: ${error.message.toUpperCase()}; FALLING BACK TO GIT RECORDS`,
+      );
+      copyGeneratedPath(stateRoot, worktreeRoot, "records");
+      recordsFallback = { reason: error.reason, source: "git" };
+    }
+  }
+
+  const result = {
+    hydrated: worker || recordsFallback ? [...gitPaths, "records"] : [...gitPaths],
+    recordsSource: recordsFallback?.source ?? recordsSource,
+    ...(recordsFallback ? { requestedRecordsSource: recordsSource, recordsFallback } : {}),
+    source: stateRoot,
+    target: worktreeRoot,
+    ...(worker ? { worker: worker.repositories, manifest: worker.manifestPath } : {}),
+  };
+  console.log(JSON.stringify(result));
+  return result;
 }
 
-for (const relativePath of GENERATED_PATHS) {
+function copyGeneratedPath(stateRoot: string, worktreeRoot: string, relativePath: string) {
   const source = path.join(stateRoot, relativePath);
   const destination = path.join(worktreeRoot, relativePath);
   rmSync(destination, { force: true, recursive: true });
-  if (!existsSync(source)) continue;
+  if (!existsSync(source)) return;
   mkdirSync(path.dirname(destination), { recursive: true });
   cpSync(source, destination, { recursive: true });
 }
-
-console.log(JSON.stringify({ hydrated: GENERATED_PATHS, source: stateRoot, target: worktreeRoot }));
 
 function parseArgs(argv: string[]): Args {
   const parsed: Args = {};
@@ -50,13 +121,35 @@ function parseArgs(argv: string[]): Args {
     if (arg === "--") continue;
     if (arg === "--state-dir") parsed.stateDir = requiredValue(argv, ++index, arg);
     else if (arg === "--worktree") parsed.worktree = requiredValue(argv, ++index, arg);
-    else throw new Error(`Unknown argument: ${arg}`);
+    else if (arg === "--records-source") {
+      parsed.recordsSource = parseRecordsSource(requiredValue(argv, ++index, arg));
+    } else if (arg === "--records-url") parsed.recordsUrl = requiredValue(argv, ++index, arg);
+    else if (arg === "--records-repo-slugs") {
+      parsed.recordsRepoSlugs = parseRepoSlugs(requiredValue(argv, ++index, arg)) ?? [];
+    } else throw new Error(`Unknown argument: ${arg}`);
   }
   return parsed;
+}
+
+function parseRecordsSource(value: string | undefined): "git" | "worker" {
+  const source = value?.trim() || "git";
+  if (source !== "git" && source !== "worker") {
+    throw new Error(`CLAWSWEEPER_RECORDS_SOURCE must be git or worker, received: ${source}`);
+  }
+  return source;
+}
+
+function parseRepoSlugs(value: string | undefined) {
+  if (value === undefined) return undefined;
+  return [...new Set(value.split(/[\s,]+/).filter(Boolean))].sort();
 }
 
 function requiredValue(argv: string[], index: number, flag: string): string {
   const value = argv[index];
   if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
   return value;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  await hydrateState(process.argv.slice(2));
 }

--- a/scripts/prepare-worker-record-cache.ts
+++ b/scripts/prepare-worker-record-cache.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  discoverRecordRepoSlugs,
+  resolveWorkerSnapshotCacheKey,
+  WorkerSnapshotUnavailableError,
+} from "./worker-records.ts";
+
+const stateRoot = path.resolve(process.env.CLAWSWEEPER_STATE_DIR ?? "clawsweeper-state");
+const repoSlugs = parseRepoSlugs(process.env.CLAWSWEEPER_RECORDS_REPO_SLUGS);
+const resolvedRepoSlugs = repoSlugs.length ? repoSlugs : discoverRecordRepoSlugs(stateRoot);
+const webhookSecret =
+  process.env.CLAWSWEEPER_RECORDS_SECRET ?? process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+if (!webhookSecret) throw new Error("CLAWSWEEPER_RECORDS_SECRET is required");
+
+try {
+  if (!resolvedRepoSlugs.length) throw new WorkerSnapshotUnavailableError("snapshot_not_found");
+  const result = await resolveWorkerSnapshotCacheKey({
+    baseUrl: process.env.CLAWSWEEPER_RECORDS_URL ?? "https://clawsweeper.openclaw.ai",
+    webhookSecret,
+    repoSlugs: resolvedRepoSlugs,
+  });
+  writeOutput("available", "true");
+  writeOutput("cache-key", result.key);
+  console.log(JSON.stringify({ available: true, pairs: result.pairs }));
+} catch (error) {
+  if (!(error instanceof WorkerSnapshotUnavailableError)) throw error;
+  writeOutput("available", "false");
+  writeOutput("cache-key", "snapshot-unavailable");
+  console.error(
+    `[worker-record-cache] SNAPSHOT CACHE UNAVAILABLE (${error.reason}); HYDRATION WILL FALL BACK TO GIT`,
+  );
+}
+
+function parseRepoSlugs(value: string | undefined) {
+  return [...new Set((value ?? "").split(/[\s,]+/).filter(Boolean))].sort();
+}
+
+function writeOutput(name: string, value: string) {
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) appendFileSync(output, `${name}=${value}\n`, "utf8");
+}

--- a/scripts/verify-worker-record-parity.ts
+++ b/scripts/verify-worker-record-parity.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { hydrateState } from "./hydrate-state.ts";
+import { recordTreeDigests } from "./worker-records.ts";
+
+export async function verifyWorkerRecordParity(
+  options: {
+    stateRoot: string;
+    repoSlug: string;
+    recordsUrl: string;
+    webhookSecret: string;
+  },
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+) {
+  const scratch = mkdtempSync(path.join(tmpdir(), "clawsweeper-record-parity-"));
+  const gitRoot = path.join(scratch, "git");
+  const workerRoot = path.join(scratch, "worker");
+  try {
+    await hydrateState(
+      ["--state-dir", options.stateRoot, "--worktree", gitRoot, "--records-source", "git"],
+      {},
+      fetchImpl,
+    );
+    await hydrateState(
+      [
+        "--state-dir",
+        options.stateRoot,
+        "--worktree",
+        workerRoot,
+        "--records-source",
+        "worker",
+        "--records-url",
+        options.recordsUrl,
+        "--records-repo-slugs",
+        options.repoSlug,
+      ],
+      { CLAWSWEEPER_WEBHOOK_SECRET: options.webhookSecret },
+      fetchImpl,
+    );
+    const git = recordTreeDigests(gitRoot, options.repoSlug);
+    const worker = recordTreeDigests(workerRoot, options.repoSlug);
+    const paths = [...new Set([...git.keys(), ...worker.keys()])].sort();
+    const mismatches = paths.flatMap((recordPath) => {
+      const gitDigest = git.get(recordPath) ?? null;
+      const workerDigest = worker.get(recordPath) ?? null;
+      return gitDigest === workerDigest ? [] : [{ path: recordPath, gitDigest, workerDigest }];
+    });
+    return {
+      repoSlug: options.repoSlug,
+      gitRecords: git.size,
+      workerRecords: worker.size,
+      mismatches,
+    };
+  } finally {
+    rmSync(scratch, { force: true, recursive: true });
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const webhookSecret = process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  if (!webhookSecret) throw new Error("CLAWSWEEPER_WEBHOOK_SECRET is required");
+  const result = await verifyWorkerRecordParity({
+    stateRoot: path.resolve(
+      args.stateDir ?? process.env.CLAWSWEEPER_STATE_DIR ?? "clawsweeper-state",
+    ),
+    repoSlug: required(args.repoSlug, "--repo-slug"),
+    recordsUrl:
+      args.recordsUrl ?? process.env.CLAWSWEEPER_RECORDS_URL ?? "https://clawsweeper.openclaw.ai",
+    webhookSecret,
+  });
+  console.log(JSON.stringify(result));
+  if (result.mismatches.length) process.exitCode = 1;
+}
+
+function parseArgs(argv: string[]) {
+  const result: { stateDir?: string; repoSlug?: string; recordsUrl?: string } = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--state-dir") result.stateDir = requiredValue(argv, ++index, arg);
+    else if (arg === "--repo-slug") result.repoSlug = requiredValue(argv, ++index, arg);
+    else if (arg === "--records-url") result.recordsUrl = requiredValue(argv, ++index, arg);
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return result;
+}
+
+function requiredValue(argv: string[], index: number, flag: string) {
+  return required(argv[index], `${flag} value`);
+}
+
+function required(value: string | undefined, label: string) {
+  if (!value || value.startsWith("--")) throw new Error(`${label} is required`);
+  return value;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) await main();

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -1,0 +1,676 @@
+import { createHash, createHmac } from "node:crypto";
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+export const RECORD_SECTIONS = ["items", "closed", "plans", "decision-packets", "commits"] as const;
+export type RecordSection = (typeof RECORD_SECTIONS)[number];
+
+export type WorkerRecord = {
+  section: RecordSection;
+  id: string;
+  content: string | null;
+  digest: string | null;
+  revision: number;
+  storeRevision: number;
+  deleted: boolean;
+};
+
+type ExportPage = {
+  repoSlug: string;
+  revision: number;
+  records: WorkerRecord[];
+  nextCursor: number | null;
+};
+
+export type WorkerRecordSnapshot = {
+  repoSlug: string;
+  revision: number;
+  records: WorkerRecord[];
+};
+
+export type WorkerStoredSnapshot = {
+  repoSlug: string;
+  revisionWatermark: number;
+  objectKey: string;
+  bytes: number;
+  uncompressedBytes: number;
+  fileCount: number;
+  createdAt: string;
+  access: { mode: "worker_range_proxy"; maxChunkBytes: number };
+};
+
+export class WorkerSnapshotUnavailableError extends Error {
+  readonly reason: "snapshot_store_unavailable" | "snapshot_not_found";
+
+  constructor(reason: "snapshot_store_unavailable" | "snapshot_not_found") {
+    super(
+      reason === "snapshot_store_unavailable" ? "snapshot store unavailable" : "snapshot not found",
+    );
+    this.name = "WorkerSnapshotUnavailableError";
+    this.reason = reason;
+  }
+}
+
+class WorkerRecordRequestError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string) {
+    super(`Worker record request failed (${status}): ${code}`);
+    this.name = "WorkerRecordRequestError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export async function exportWorkerRecords(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  repoSlug: string;
+  sections?: readonly RecordSection[];
+  sinceRevision?: number;
+  limit?: number;
+  fetch?: typeof globalThis.fetch;
+}): Promise<WorkerRecordSnapshot> {
+  const sections = options.sections ?? RECORD_SECTIONS;
+  const sinceRevision = options.sinceRevision ?? 0;
+  const records = new Map<string, WorkerRecord>();
+  let cursor: number | null = 0;
+  let revision = sinceRevision;
+  do {
+    const page = await signedPost<ExportPage>({
+      baseUrl: options.baseUrl,
+      path: "/internal/state/records/export",
+      webhookSecret: options.webhookSecret,
+      body: {
+        repoSlug: options.repoSlug,
+        sections,
+        sinceRevision,
+        cursor,
+        limit: options.limit ?? 100,
+      },
+      fetch: options.fetch,
+    });
+    if (page.repoSlug !== options.repoSlug || !Number.isSafeInteger(page.revision)) {
+      throw new Error("Worker returned an invalid record export envelope");
+    }
+    revision = Math.max(revision, page.revision);
+    for (const record of page.records) {
+      validateWorkerRecord(record);
+      const key = `${record.section}/${record.id}`;
+      const prior = records.get(key);
+      if (!prior || prior.storeRevision < record.storeRevision) records.set(key, record);
+    }
+    if (
+      page.nextCursor !== null &&
+      (!Number.isSafeInteger(page.nextCursor) || page.nextCursor < 1)
+    ) {
+      throw new Error("Worker returned an invalid record export cursor");
+    }
+    if (page.nextCursor !== null && page.nextCursor === cursor) {
+      throw new Error("Worker record export cursor did not advance");
+    }
+    cursor = page.nextCursor;
+  } while (cursor !== null);
+  return {
+    repoSlug: options.repoSlug,
+    revision,
+    records: [...records.values()].sort((left, right) =>
+      recordRelativePath(left).localeCompare(recordRelativePath(right)),
+    ),
+  };
+}
+
+export async function materializeWorkerRecords(options: {
+  worktreeRoot: string;
+  baseUrl: string;
+  webhookSecret: string;
+  repoSlugs: readonly string[];
+  cacheRoot?: string;
+  fetch?: typeof globalThis.fetch;
+}) {
+  mkdirSync(options.worktreeRoot, { recursive: true });
+  const recordsRoot = path.join(options.worktreeRoot, "records");
+  const cacheRoot = path.resolve(
+    options.cacheRoot ?? path.join(options.worktreeRoot, ".artifacts", "worker-records-cache"),
+  );
+  mkdirSync(cacheRoot, { recursive: true });
+  const stagingRoot = mkdtempSync(path.join(options.worktreeRoot, ".worker-records-stage-"));
+  const stagedRecordsRoot = path.join(stagingRoot, "records");
+  mkdirSync(stagedRecordsRoot, { recursive: true });
+  const repositories: Record<
+    string,
+    {
+      revision: number;
+      snapshotRevision: number;
+      snapshotBytes: number;
+      snapshotCache: "hit" | "miss";
+      deltaRecords: number;
+      recordCount: number;
+    }
+  > = {};
+  try {
+    for (const repoSlug of options.repoSlugs) {
+      validateRepoSlug(repoSlug);
+      const storedSnapshot = await fetchWorkerStoredSnapshot({
+        baseUrl: options.baseUrl,
+        webhookSecret: options.webhookSecret,
+        repoSlug,
+        fetch: options.fetch,
+      });
+      const cached = await ensureSnapshotCache({
+        cacheRoot,
+        baseUrl: options.baseUrl,
+        webhookSecret: options.webhookSecret,
+        snapshot: storedSnapshot,
+        fetch: options.fetch,
+      });
+      const stagedRepoRoot = path.join(stagedRecordsRoot, repoSlug);
+      cpSync(cached.treeRoot, stagedRepoRoot, { recursive: true });
+      const journal = await exportWorkerRecords({
+        baseUrl: options.baseUrl,
+        webhookSecret: options.webhookSecret,
+        repoSlug,
+        sinceRevision: storedSnapshot.revisionWatermark,
+        fetch: options.fetch,
+      });
+      applyWorkerRecords(stagedRepoRoot, journal.records);
+      repositories[repoSlug] = {
+        revision: journal.revision,
+        snapshotRevision: storedSnapshot.revisionWatermark,
+        snapshotBytes: storedSnapshot.bytes,
+        snapshotCache: cached.cache,
+        deltaRecords: journal.records.length,
+        recordCount: collectGitRecords(stagingRoot, repoSlug).length,
+      };
+    }
+    rmSync(recordsRoot, { force: true, recursive: true });
+    renameSync(stagedRecordsRoot, recordsRoot);
+  } finally {
+    rmSync(stagingRoot, { force: true, recursive: true });
+  }
+  const manifestPath = path.join(
+    options.worktreeRoot,
+    ".artifacts",
+    "worker-records-manifest.json",
+  );
+  mkdirSync(path.dirname(manifestPath), { recursive: true });
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify({ schemaVersion: 2, source: "worker", repositories }, null, 2)}\n`,
+    "utf8",
+  );
+  return { recordsRoot, manifestPath, repositories };
+}
+
+export async function fetchWorkerStoredSnapshot(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  repoSlug: string;
+  fetch?: typeof globalThis.fetch;
+}): Promise<WorkerStoredSnapshot> {
+  try {
+    const envelope = await signedPost<{
+      snapshotStoreAvailable: boolean;
+      snapshot: WorkerStoredSnapshot;
+    }>({
+      ...options,
+      path: "/internal/state/records/snapshots/latest",
+      body: { repoSlug: options.repoSlug },
+    });
+    validateStoredSnapshot(envelope.snapshot, options.repoSlug);
+    return envelope.snapshot;
+  } catch (error) {
+    if (
+      error instanceof WorkerRecordRequestError &&
+      (error.code === "snapshot_store_unavailable" || error.code === "snapshot_not_found")
+    ) {
+      throw new WorkerSnapshotUnavailableError(error.code);
+    }
+    throw error;
+  }
+}
+
+export async function resolveWorkerSnapshotCacheKey(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  repoSlugs: readonly string[];
+  fetch?: typeof globalThis.fetch;
+}) {
+  const snapshots = [] as WorkerStoredSnapshot[];
+  for (const repoSlug of [...options.repoSlugs].sort()) {
+    snapshots.push(await fetchWorkerStoredSnapshot({ ...options, repoSlug }));
+  }
+  const pairs = snapshots.map((snapshot) => `${snapshot.repoSlug}:${snapshot.revisionWatermark}`);
+  return {
+    snapshots,
+    key: createHash("sha256").update(pairs.join("\n")).digest("hex").slice(0, 24),
+    pairs,
+  };
+}
+
+export function discoverRecordRepoSlugs(stateRoot: string): string[] {
+  const recordsRoot = path.join(stateRoot, "records");
+  if (!existsSync(recordsRoot)) return [];
+  return readdirSync(recordsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && isRepoSlug(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+export function collectGitRecords(stateRoot: string, repoSlug: string) {
+  validateRepoSlug(repoSlug);
+  const root = path.join(stateRoot, "records", repoSlug);
+  const records: Array<{
+    section: RecordSection;
+    id: string;
+    content: string;
+    digest: string;
+  }> = [];
+  for (const section of RECORD_SECTIONS) {
+    const directory = path.join(root, section);
+    if (!existsSync(directory)) continue;
+    const extension = recordExtension(section);
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(extension)) continue;
+      const id = entry.name.slice(0, -extension.length);
+      validateRecordId(section, id);
+      const content = readFileSync(path.join(directory, entry.name), "utf8");
+      records.push({ section, id, content, digest: sha256(content) });
+    }
+  }
+  return records.sort((left, right) =>
+    `${left.section}/${left.id}`.localeCompare(`${right.section}/${right.id}`),
+  );
+}
+
+export async function ingestGitRecords(options: {
+  stateRoot: string;
+  repoSlug: string;
+  baseUrl: string;
+  webhookSecret: string;
+  fetch?: typeof globalThis.fetch;
+  maxRecordsPerBatch?: number;
+  maxRequestBytes?: number;
+  cursor?: number;
+  maxBatches?: number;
+  onBatch?: (progress: { completedCursor: number; totalBatches: number }) => void;
+}) {
+  const records = collectGitRecords(options.stateRoot, options.repoSlug);
+  const batches = batchIngestRecords(
+    options.repoSlug,
+    records,
+    options.maxRecordsPerBatch ?? 50,
+    options.maxRequestBytes ?? 3 * 1024 * 1024,
+  );
+  const cursor = options.cursor ?? 0;
+  const maxBatches = options.maxBatches ?? Number.POSITIVE_INFINITY;
+  if (!Number.isSafeInteger(cursor) || cursor < 0 || cursor > batches.length) {
+    throw new Error(`Invalid backfill cursor: ${cursor}`);
+  }
+  if (
+    !(
+      maxBatches === Number.POSITIVE_INFINITY ||
+      (Number.isSafeInteger(maxBatches) && maxBatches > 0)
+    )
+  ) {
+    throw new Error(`Invalid backfill batch limit: ${maxBatches}`);
+  }
+  const totals = { inserted: 0, unchanged: 0, skippedNewer: 0, records: records.length };
+  let revision = 0;
+  const selected = batches.slice(cursor, cursor + maxBatches);
+  let completedCursor = cursor;
+  for (const body of selected) {
+    const response = await signedPost<{
+      inserted: number;
+      unchanged: number;
+      skippedNewer: number;
+      watermark: number;
+    }>({
+      baseUrl: options.baseUrl,
+      path: "/internal/state/records/ingest",
+      webhookSecret: options.webhookSecret,
+      body,
+      fetch: options.fetch,
+    });
+    totals.inserted += response.inserted;
+    totals.unchanged += response.unchanged;
+    totals.skippedNewer += response.skippedNewer;
+    revision = Math.max(revision, response.watermark);
+    completedCursor += 1;
+    options.onBatch?.({ completedCursor, totalBatches: batches.length });
+  }
+  return {
+    ...totals,
+    batches: selected.length,
+    totalBatches: batches.length,
+    cursor,
+    nextCursor: completedCursor < batches.length ? completedCursor : null,
+    revision,
+  };
+}
+
+export function recordTreeDigests(root: string, repoSlug: string) {
+  return new Map(
+    collectGitRecords(root, repoSlug).map((record) => [
+      `${record.section}/${record.id}${recordExtension(record.section)}`,
+      record.digest,
+    ]),
+  );
+}
+
+async function ensureSnapshotCache(options: {
+  cacheRoot: string;
+  baseUrl: string;
+  webhookSecret: string;
+  snapshot: WorkerStoredSnapshot;
+  fetch?: typeof globalThis.fetch;
+}) {
+  const cachePath = path.join(
+    options.cacheRoot,
+    options.snapshot.repoSlug,
+    String(options.snapshot.revisionWatermark),
+  );
+  const treeRoot = path.join(cachePath, "tree");
+  const manifestPath = path.join(cachePath, "snapshot.json");
+  if (validSnapshotCache(manifestPath, treeRoot, options.snapshot)) {
+    return { cache: "hit" as const, treeRoot };
+  }
+
+  rmSync(cachePath, { force: true, recursive: true });
+  mkdirSync(path.dirname(cachePath), { recursive: true });
+  const temporaryRoot = mkdtempSync(path.join(path.dirname(cachePath), ".download-"));
+  const archivePath = path.join(temporaryRoot, "snapshot.tar.gz");
+  const temporaryTree = path.join(temporaryRoot, "tree");
+  mkdirSync(temporaryTree, { recursive: true });
+  try {
+    await downloadSnapshot({ ...options, archivePath });
+    const unpacked = spawnSync("tar", ["-xzf", archivePath, "-C", temporaryTree], {
+      encoding: "utf8",
+    });
+    if (unpacked.status !== 0) {
+      throw new Error(`Snapshot archive could not be unpacked: ${unpacked.stderr.trim()}`);
+    }
+    const fileCount = validateSnapshotTree(temporaryTree);
+    if (fileCount !== options.snapshot.fileCount) {
+      throw new Error(
+        `Snapshot file count mismatch: expected ${options.snapshot.fileCount}, received ${fileCount}`,
+      );
+    }
+    mkdirSync(cachePath, { recursive: true });
+    renameSync(temporaryTree, treeRoot);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        repoSlug: options.snapshot.repoSlug,
+        revisionWatermark: options.snapshot.revisionWatermark,
+        bytes: options.snapshot.bytes,
+        fileCount: options.snapshot.fileCount,
+      })}\n`,
+      "utf8",
+    );
+    return { cache: "miss" as const, treeRoot };
+  } finally {
+    rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+}
+
+function validSnapshotCache(
+  manifestPath: string,
+  treeRoot: string,
+  snapshot: WorkerStoredSnapshot,
+) {
+  if (!existsSync(manifestPath) || !existsSync(treeRoot)) return false;
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    return (
+      manifest.schemaVersion === 1 &&
+      manifest.repoSlug === snapshot.repoSlug &&
+      manifest.revisionWatermark === snapshot.revisionWatermark &&
+      manifest.bytes === snapshot.bytes &&
+      manifest.fileCount === snapshot.fileCount &&
+      validateSnapshotTree(treeRoot) === snapshot.fileCount
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function downloadSnapshot(options: {
+  archivePath: string;
+  baseUrl: string;
+  webhookSecret: string;
+  snapshot: WorkerStoredSnapshot;
+  fetch?: typeof globalThis.fetch;
+}) {
+  const descriptor = openSync(options.archivePath, "wx");
+  let offset = 0;
+  try {
+    while (offset < options.snapshot.bytes) {
+      const length = Math.min(
+        options.snapshot.access.maxChunkBytes,
+        options.snapshot.bytes - offset,
+      );
+      const response = await signedRequest({
+        baseUrl: options.baseUrl,
+        path: "/internal/state/records/snapshots/chunk",
+        webhookSecret: options.webhookSecret,
+        body: {
+          repoSlug: options.snapshot.repoSlug,
+          revisionWatermark: options.snapshot.revisionWatermark,
+          offset,
+          length,
+        },
+        fetch: options.fetch,
+      });
+      if (!response.ok) throw await workerRequestError(response);
+      if (response.status !== 206) {
+        throw new Error(`Worker snapshot chunk returned status ${response.status}`);
+      }
+      const expectedRange = `bytes ${offset}-${offset + length - 1}/${options.snapshot.bytes}`;
+      if (response.headers.get("content-range") !== expectedRange) {
+        throw new Error("Worker snapshot chunk returned an invalid content range");
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (bytes.byteLength !== length) {
+        throw new Error(
+          `Worker snapshot chunk length mismatch: expected ${length}, received ${bytes.byteLength}`,
+        );
+      }
+      writeSync(descriptor, bytes);
+      offset += bytes.byteLength;
+    }
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function validateStoredSnapshot(snapshot: WorkerStoredSnapshot, repoSlug: string) {
+  if (
+    !snapshot ||
+    snapshot.repoSlug !== repoSlug ||
+    !Number.isSafeInteger(snapshot.revisionWatermark) ||
+    snapshot.revisionWatermark < 0 ||
+    !Number.isSafeInteger(snapshot.bytes) ||
+    snapshot.bytes < 1 ||
+    !Number.isSafeInteger(snapshot.fileCount) ||
+    snapshot.fileCount < 0 ||
+    !snapshot.access ||
+    snapshot.access.mode !== "worker_range_proxy" ||
+    !Number.isSafeInteger(snapshot.access.maxChunkBytes) ||
+    snapshot.access.maxChunkBytes < 1 ||
+    snapshot.access.maxChunkBytes > 32 * 1024 * 1024
+  ) {
+    throw new Error("Worker returned an invalid snapshot envelope");
+  }
+}
+
+function validateSnapshotTree(treeRoot: string) {
+  let fileCount = 0;
+  for (const entry of readdirSync(treeRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !RECORD_SECTIONS.includes(entry.name as RecordSection)) {
+      throw new Error(`Snapshot archive contains an invalid root entry: ${entry.name}`);
+    }
+    const section = entry.name as RecordSection;
+    const extension = recordExtension(section);
+    for (const record of readdirSync(path.join(treeRoot, section), { withFileTypes: true })) {
+      if (!record.isFile() || !record.name.endsWith(extension)) {
+        throw new Error(`Snapshot archive contains an invalid record entry: ${record.name}`);
+      }
+      validateRecordId(section, record.name.slice(0, -extension.length));
+      fileCount += 1;
+    }
+  }
+  return fileCount;
+}
+
+function applyWorkerRecords(repoRoot: string, records: readonly WorkerRecord[]) {
+  for (const record of records) {
+    const destination = path.join(repoRoot, recordRelativePath(record));
+    if (record.deleted) {
+      rmSync(destination, { force: true });
+      continue;
+    }
+    if (record.content === null)
+      throw new Error(`Worker record is missing content: ${destination}`);
+    mkdirSync(path.dirname(destination), { recursive: true });
+    writeFileSync(destination, record.content, "utf8");
+  }
+}
+
+export async function signedPost<T>(options: {
+  baseUrl: string;
+  path: string;
+  webhookSecret: string;
+  body: unknown;
+  fetch?: typeof globalThis.fetch;
+}): Promise<T> {
+  const response = await signedRequest(options);
+  const value = await response.json().catch(() => null);
+  if (!response.ok) throw await workerRequestError(response, value);
+  return value as T;
+}
+
+async function signedRequest(options: {
+  baseUrl: string;
+  path: string;
+  webhookSecret: string;
+  body: unknown;
+  fetch?: typeof globalThis.fetch;
+}) {
+  const baseUrl = options.baseUrl.replace(/\/$/, "");
+  if (!baseUrl.startsWith("https://") && !baseUrl.startsWith("http://127.0.0.1:")) {
+    throw new Error("Worker record URL must use HTTPS");
+  }
+  if (!options.webhookSecret) throw new Error("Worker records HMAC secret is required");
+  const body = JSON.stringify(options.body);
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
+  return (options.fetch ?? globalThis.fetch)(`${baseUrl}${options.path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+}
+
+async function workerRequestError(response: Response, parsedValue?: unknown) {
+  const value =
+    parsedValue ??
+    (await response
+      .clone()
+      .json()
+      .catch(() => null));
+  const code =
+    value && typeof value === "object" && "error" in value
+      ? String((value as { error: unknown }).error)
+      : String(response.status);
+  return new WorkerRecordRequestError(response.status, code);
+}
+
+function batchIngestRecords(
+  repoSlug: string,
+  records: ReturnType<typeof collectGitRecords>,
+  maxRecords: number,
+  maxBytes: number,
+) {
+  const batches: Array<{ repoSlug: string; records: typeof records }> = [];
+  let current: typeof records = [];
+  for (const record of records) {
+    const candidate = [...current, record];
+    const bytes = Buffer.byteLength(JSON.stringify({ repoSlug, records: candidate }));
+    if (current.length && (candidate.length > maxRecords || bytes > maxBytes)) {
+      batches.push({ repoSlug, records: current });
+      current = [record];
+    } else {
+      current = candidate;
+    }
+    if (Buffer.byteLength(JSON.stringify({ repoSlug, records: current })) > maxBytes) {
+      throw new Error(`Record exceeds ingest request limit: ${record.section}/${record.id}`);
+    }
+  }
+  if (current.length) batches.push({ repoSlug, records: current });
+  return batches;
+}
+
+function validateWorkerRecord(record: WorkerRecord) {
+  if (!RECORD_SECTIONS.includes(record.section)) throw new Error("Worker returned invalid section");
+  validateRecordId(record.section, record.id);
+  if (!Number.isSafeInteger(record.revision) || record.revision < 0) {
+    throw new Error("Worker returned invalid row revision");
+  }
+  if (!Number.isSafeInteger(record.storeRevision) || record.storeRevision < 1) {
+    throw new Error("Worker returned invalid store revision");
+  }
+  if (record.deleted) {
+    if (record.content !== null || record.digest !== null) {
+      throw new Error("Worker returned invalid deletion record");
+    }
+    return;
+  }
+  if (typeof record.content !== "string" || !/^[0-9a-f]{64}$/.test(record.digest || "")) {
+    throw new Error("Worker returned invalid record content");
+  }
+  if (sha256(record.content) !== record.digest) throw new Error("Worker record digest mismatch");
+}
+
+function recordRelativePath(record: Pick<WorkerRecord, "section" | "id">) {
+  return path.join(record.section, `${record.id}${recordExtension(record.section)}`);
+}
+
+function recordExtension(section: RecordSection) {
+  return section === "decision-packets" ? ".json" : ".md";
+}
+
+function validateRecordId(section: RecordSection, id: string) {
+  const valid = section === "commits" ? /^[0-9a-f]{40}$/.test(id) : /^[1-9]\d*$/.test(id);
+  if (!valid) throw new Error(`Invalid ${section} record id: ${id}`);
+}
+
+function validateRepoSlug(value: string) {
+  if (!isRepoSlug(value)) throw new Error(`Invalid record repository slug: ${value}`);
+}
+
+function isRepoSlug(value: string) {
+  return /^[A-Za-z0-9][A-Za-z0-9_.-]{0,199}$/.test(value);
+}
+
+function sha256(content: string) {
+  return createHash("sha256").update(content).digest("hex");
+}

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4,6 +4,7 @@ import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import { isDeepStrictEqual } from "node:util";
 import { createContext, Script } from "node:vm";
+import { gunzipSync } from "node:zlib";
 
 import worker, {
   automaticIssueWork,
@@ -2129,6 +2130,290 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
   });
 });
 
+test("record backfill and export authenticate, page, increment, dedupe, and preserve live revisions", async () => {
+  const storage = new MemoryDurableStorage();
+  const leased = leasedExactReviewQueueItem(711, "7110");
+  leased.revision = 4;
+  leased.leaseRevision = 4;
+  leased.claimGeneration = 2;
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [leased.key]: leased } });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const secret = "record-export-secret";
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const commitId = "a".repeat(40);
+  const seedRecords = [
+    { section: "items", id: "711", content: "legacy-item" },
+    { section: "plans", id: "712", content: "legacy-plan" },
+    { section: "commits", id: commitId, content: "legacy-commit" },
+  ].map((record) => ({
+    ...record,
+    digest: createHash("sha256").update(record.content).digest("hex"),
+  }));
+  const ingestPayload = { repoSlug: "openclaw-openclaw", records: seedRecords };
+  const ingestPath = "/internal/state/records/ingest";
+  const unsigned = await worker.fetch(
+    stateAppendQueueRequest(ingestPath, ingestPayload, "https://clawsweeper.openclaw.ai"),
+    env,
+  );
+  assert.equal(unsigned.status, 401);
+
+  const first = await worker.fetch(
+    signedStateAppendRequest(ingestPath, ingestPayload, secret),
+    env,
+  );
+  assert.equal(first.status, 202);
+  assert.deepEqual(await first.json(), {
+    ok: true,
+    repoSlug: "openclaw-openclaw",
+    inserted: 3,
+    unchanged: 0,
+    skippedNewer: 0,
+    watermark: 3,
+  });
+  const repeated = await worker.fetch(
+    signedStateAppendRequest(ingestPath, ingestPayload, secret),
+    env,
+  );
+  assert.deepEqual(await repeated.json(), {
+    ok: true,
+    repoSlug: "openclaw-openclaw",
+    inserted: 0,
+    unchanged: 3,
+    skippedNewer: 0,
+    watermark: 3,
+  });
+
+  const publication = {
+    itemKey: "openclaw/openclaw#711",
+    revision: 4,
+    identity: { itemKey: "openclaw/openclaw#711", revision: 4, claimGeneration: 2 },
+    operations: [
+      {
+        path: "records/openclaw-openclaw/items/711.md",
+        expectedOid: null,
+        targetOid: "b".repeat(40),
+        mode: "100644",
+        bytes: 4,
+        contentBase64: Buffer.from("live").toString("base64"),
+      },
+    ],
+    totalBytes: 4,
+  };
+  const publicationBody = JSON.stringify(publication);
+  const publicationSignature = `sha256=${createHmac("sha256", secret).update(publicationBody).digest("hex")}`;
+  const published = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publication-results", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": publicationSignature },
+      body: publicationBody,
+    }),
+    env,
+  );
+  assert.equal(published.status, 202);
+
+  const guarded = await worker.fetch(
+    signedStateAppendRequest(
+      ingestPath,
+      { repoSlug: "openclaw-openclaw", records: [seedRecords[0]] },
+      secret,
+    ),
+    env,
+  );
+  assert.equal(guarded.status, 202);
+  assert.equal((await guarded.json()).skippedNewer, 1);
+
+  const exportPath = "/internal/state/records/export";
+  const pageOnePayload = {
+    repoSlug: "openclaw-openclaw",
+    sections: ["items", "commits"],
+    limit: 1,
+  };
+  const unsignedExport = await worker.fetch(
+    stateAppendQueueRequest(exportPath, pageOnePayload, "https://clawsweeper.openclaw.ai"),
+    env,
+  );
+  assert.equal(unsignedExport.status, 401);
+  const pageOneResponse = await worker.fetch(
+    signedStateAppendRequest(exportPath, pageOnePayload, secret),
+    env,
+  );
+  assert.equal(pageOneResponse.status, 200);
+  const pageOne = await pageOneResponse.json();
+  assert.equal(pageOne.records.length, 1);
+  assert.equal(pageOne.nextCursor, 3);
+  const pageTwo = await (
+    await worker.fetch(
+      signedStateAppendRequest(
+        exportPath,
+        { ...pageOnePayload, cursor: pageOne.nextCursor },
+        secret,
+      ),
+      env,
+    )
+  ).json();
+  assert.equal(pageTwo.records.length, 1);
+  assert.equal(pageTwo.nextCursor, 4);
+  const terminalPage = await (
+    await worker.fetch(
+      signedStateAppendRequest(
+        exportPath,
+        { ...pageOnePayload, cursor: pageTwo.nextCursor },
+        secret,
+      ),
+      env,
+    )
+  ).json();
+  assert.deepEqual(terminalPage.records, []);
+  assert.equal(terminalPage.nextCursor, null);
+  assert.deepEqual(pageTwo.records[0], {
+    section: "items",
+    id: "711",
+    content: "live",
+    digest: createHash("sha256").update("live").digest("hex"),
+    revision: 4,
+    storeRevision: 4,
+    updatedAt: pageTwo.records[0].updatedAt,
+    deleted: false,
+  });
+  const incremental = await (
+    await worker.fetch(
+      signedStateAppendRequest(
+        exportPath,
+        { repoSlug: "openclaw-openclaw", sections: ["items"], sinceRevision: 3 },
+        secret,
+      ),
+      env,
+    )
+  ).json();
+  assert.deepEqual(incremental.records, pageTwo.records);
+
+  const conflictingContent = "changed-plan";
+  const conflict = await worker.fetch(
+    signedStateAppendRequest(
+      ingestPath,
+      {
+        repoSlug: "openclaw-openclaw",
+        records: [
+          {
+            section: "plans",
+            id: "712",
+            content: conflictingContent,
+            digest: createHash("sha256").update(conflictingContent).digest("hex"),
+          },
+        ],
+      },
+      secret,
+    ),
+    env,
+  );
+  assert.equal(conflict.status, 409);
+  assert.deepEqual(await conflict.json(), { error: "canonical_record_backfill_conflict" });
+});
+
+test("record snapshots authenticate, stream multipart R2 objects, serve ranges, prune, and fail closed", async () => {
+  const secret = "record-snapshot-secret";
+  const unavailableStorage = new MemoryDurableStorage();
+  const unavailableQueue = new ExactReviewQueue({ storage: unavailableStorage }, {});
+  const unavailableEnv = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(unavailableQueue),
+  };
+  const triggerPath = "/internal/state/records/snapshots/trigger";
+  const triggerBody = { repoSlug: "openclaw-openclaw" };
+  const unsigned = await worker.fetch(
+    stateAppendQueueRequest(triggerPath, triggerBody, "https://clawsweeper.openclaw.ai"),
+    unavailableEnv,
+  );
+  assert.equal(unsigned.status, 401);
+  const unavailable = await worker.fetch(
+    signedStateAppendRequest(triggerPath, triggerBody, secret),
+    unavailableEnv,
+  );
+  assert.equal(unavailable.status, 503);
+  assert.deepEqual(await unavailable.json(), {
+    error: "snapshot_store_unavailable",
+    snapshotStoreAvailable: false,
+    detail: "STATE_SNAPSHOTS is not available",
+  });
+
+  const storage = new MemoryDurableStorage();
+  const bucket = new MemoryR2Bucket();
+  const queue = new ExactReviewQueue({ storage }, { STATE_SNAPSHOTS: bucket });
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const records = [
+    { section: "items", id: "901", content: "snapshot item\n" },
+    { section: "decision-packets", id: "901", content: '{"decision":"snapshot"}\n' },
+  ].map((record) => ({
+    ...record,
+    digest: createHash("sha256").update(record.content).digest("hex"),
+  }));
+  const ingest = await worker.fetch(
+    signedStateAppendRequest(
+      "/internal/state/records/ingest",
+      { repoSlug: "openclaw-openclaw", records },
+      secret,
+    ),
+    env,
+  );
+  assert.equal(ingest.status, 202);
+
+  let latestSnapshot: {
+    revisionWatermark: number;
+    bytes: number;
+    fileCount: number;
+    objectKey: string;
+  } | null = null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await worker.fetch(
+      signedStateAppendRequest(triggerPath, triggerBody, secret),
+      env,
+    );
+    assert.equal(response.status, 201);
+    latestSnapshot = (await response.json()).snapshot;
+  }
+  assert.ok(latestSnapshot);
+  assert.equal(latestSnapshot.fileCount, records.length);
+  assert.equal(latestSnapshot.revisionWatermark, records.length);
+  assert.equal(bucket.keys().length, 2);
+  const snapshotRows = Array.from(
+    storage.sql.exec("SELECT object_key FROM exact_review_record_snapshots"),
+  );
+  assert.equal(snapshotRows.length, 2);
+
+  const latestResponse = await worker.fetch(
+    signedStateAppendRequest("/internal/state/records/snapshots/latest", triggerBody, secret),
+    env,
+  );
+  assert.equal(latestResponse.status, 200);
+  assert.equal((await latestResponse.json()).snapshot.objectKey, latestSnapshot.objectKey);
+
+  const chunkBody = {
+    repoSlug: "openclaw-openclaw",
+    revisionWatermark: latestSnapshot.revisionWatermark,
+    offset: 0,
+    length: latestSnapshot.bytes,
+  };
+  const chunk = await worker.fetch(
+    signedStateAppendRequest("/internal/state/records/snapshots/chunk", chunkBody, secret),
+    env,
+  );
+  assert.equal(chunk.status, 206);
+  assert.equal(
+    chunk.headers.get("content-range"),
+    `bytes 0-${latestSnapshot.bytes - 1}/${latestSnapshot.bytes}`,
+  );
+  const tar = gunzipSync(Buffer.from(await chunk.arrayBuffer()));
+  assert.match(tar.toString("utf8"), /items\/901\.md/);
+  assert.match(tar.toString("utf8"), /snapshot item/);
+  assert.match(tar.toString("utf8"), /decision-packets\/901\.json/);
+});
+
 test("exact-review queue counts only work that successfully leaves each lane", async () => {
   const storage = new MemoryDurableStorage();
   const directPublication = leasedExactReviewQueueItem(703, "7030");
@@ -3949,6 +4234,55 @@ class MemoryDurableNamespace {
 
   get() {
     return this.stub;
+  }
+}
+
+class MemoryR2Bucket {
+  private objects = new Map<string, Uint8Array>();
+
+  async createMultipartUpload(key: string) {
+    const parts = new Map<number, Uint8Array>();
+    return {
+      uploadPart: async (partNumber: number, value: ArrayBuffer | Uint8Array) => {
+        parts.set(partNumber, new Uint8Array(value).slice());
+        return { partNumber, etag: `part-${partNumber}` };
+      },
+      complete: async (completed: Array<{ partNumber: number }>) => {
+        const selected = completed.map((part) => parts.get(part.partNumber)!);
+        const bytes = new Uint8Array(selected.reduce((sum, part) => sum + part.byteLength, 0));
+        let offset = 0;
+        for (const part of selected) {
+          bytes.set(part, offset);
+          offset += part.byteLength;
+        }
+        this.objects.set(key, bytes);
+        return { key, size: bytes.byteLength };
+      },
+      abort: async () => undefined,
+    };
+  }
+
+  async head(key: string) {
+    const value = this.objects.get(key);
+    return value ? { key, size: value.byteLength } : null;
+  }
+
+  async get(key: string, options?: { range?: { offset: number; length: number } }) {
+    const value = this.objects.get(key);
+    if (!value) return null;
+    const offset = options?.range?.offset ?? 0;
+    const length = options?.range?.length ?? value.byteLength - offset;
+    const body = new Response(value.slice(offset, offset + length)).body;
+    assert.ok(body);
+    return { body, size: value.byteLength };
+  }
+
+  async delete(keys: string | string[]) {
+    for (const key of Array.isArray(keys) ? keys : [keys]) this.objects.delete(key);
+  }
+
+  keys() {
+    return [...this.objects.keys()].sort();
   }
 }
 

--- a/test/review-runtime-package.test.ts
+++ b/test/review-runtime-package.test.ts
@@ -80,13 +80,14 @@ test("review runtime artifact carries the TypeScript compiler service", () => {
       join(dirname(typescriptSource), "@typescript", nativePackageName),
     );
     const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-    const packed = JSON.parse(
+    const packOutput = JSON.parse(
       execFileSync(
         npmCommand,
         ["pack", nativeSource, "--pack-destination", fixture, "--ignore-scripts", "--json"],
         { encoding: "utf8" },
       ),
-    )[0];
+    );
+    const packed = Array.isArray(packOutput) ? packOutput[0] : Object.values(packOutput)[0];
     assert.equal(typeof packed?.filename, "string");
     assert.equal(typeof packed?.integrity, "string");
     const packageFile = join(fixture, packed.filename);

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -48,7 +48,7 @@ test("every generated-state checkout receives the explicit coordinator migration
     }
   }
 
-  assert.equal(setups.length, 27, "new state checkouts must join the repo-wide boundary");
+  assert.equal(setups.length, 28, "new state checkouts must join the repo-wide boundary");
   for (const { file, job, step } of setups) {
     assert.equal(step.with?.["coordinator-enabled"], coordinatorGate, `${file}:${job}`);
     assert.equal(step.with?.["coordinator-url"], coordinatorUrl, `${file}:${job}`);

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -1,0 +1,419 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { parse } from "yaml";
+
+import { hydrateState } from "../scripts/hydrate-state.ts";
+import { verifyWorkerRecordParity } from "../scripts/verify-worker-record-parity.ts";
+import { ingestGitRecords, type WorkerRecord } from "../scripts/worker-records.ts";
+
+const repoSlug = "openclaw-openclaw";
+const commitId = "c".repeat(40);
+const contents = new Map([
+  ["items/1", "---\nnumber: 1\n---\nbyte-identical item\n"],
+  ["decision-packets/1", '{"decision":"keep"}\n'],
+  [`commits/${commitId}`, "---\nsha: fixture\n---\ncommit finding\n"],
+]);
+
+test("hydrate-state Worker mode uses snapshot cold and warm paths before replaying the journal", async () => {
+  const fixture = createStateFixture();
+  const coldTarget = path.join(fixture.root, "worker-cold-target");
+  const warmTarget = path.join(fixture.root, "worker-warm-target");
+  const cacheRoot = path.join(fixture.root, "snapshot-cache");
+  const fetchStats = { chunkRequests: 0 };
+  const journal = [{ section: "closed" as const, id: "2", content: "journal delta\n" }];
+  try {
+    await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        coldTarget,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+        "--records-repo-slugs",
+        repoSlug,
+      ],
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret",
+        CLAWSWEEPER_RECORDS_CACHE_DIR: cacheRoot,
+      },
+      workerFetch(contents, fetchStats, journal),
+    );
+    const coldChunkRequests = fetchStats.chunkRequests;
+    assert.ok(coldChunkRequests > 0);
+    for (const [key, content] of contents) {
+      const [section, id] = key.split("/");
+      const extension = section === "decision-packets" ? ".json" : ".md";
+      assert.equal(
+        readFileSync(
+          path.join(coldTarget, "records", repoSlug, section!, `${id}${extension}`),
+          "utf8",
+        ),
+        content,
+      );
+    }
+    assert.equal(
+      readFileSync(path.join(coldTarget, "records", repoSlug, "closed", "2.md"), "utf8"),
+      "journal delta\n",
+    );
+    assert.equal(readFileSync(path.join(coldTarget, "jobs", "fixture.json"), "utf8"), "{}\n");
+    const manifest = JSON.parse(
+      readFileSync(path.join(coldTarget, ".artifacts", "worker-records-manifest.json"), "utf8"),
+    );
+    assert.deepEqual(manifest, {
+      schemaVersion: 2,
+      source: "worker",
+      repositories: {
+        [repoSlug]: {
+          revision: contents.size + journal.length,
+          snapshotRevision: contents.size,
+          snapshotBytes: snapshotArchive(contents).byteLength,
+          snapshotCache: "miss",
+          deltaRecords: journal.length,
+          recordCount: contents.size + journal.length,
+        },
+      },
+    });
+
+    await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        warmTarget,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+        "--records-repo-slugs",
+        repoSlug,
+      ],
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret",
+        CLAWSWEEPER_RECORDS_CACHE_DIR: cacheRoot,
+      },
+      workerFetch(contents, fetchStats, journal),
+    );
+    assert.equal(fetchStats.chunkRequests, coldChunkRequests);
+    const warmManifest = JSON.parse(
+      readFileSync(path.join(warmTarget, ".artifacts", "worker-records-manifest.json"), "utf8"),
+    );
+    assert.equal(warmManifest.repositories[repoSlug].snapshotCache, "hit");
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("hydrate-state refuses Worker cutover and loudly falls back to git without snapshots", async () => {
+  const fixture = createStateFixture();
+  const target = path.join(fixture.root, "fallback-target");
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...values) => errors.push(values.join(" "));
+  try {
+    const result = await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        target,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+        "--records-repo-slugs",
+        repoSlug,
+      ],
+      { CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret" },
+      async () =>
+        Response.json(
+          { error: "snapshot_store_unavailable", snapshotStoreAvailable: false },
+          { status: 503 },
+        ),
+    );
+    assert.equal(result.recordsSource, "git");
+    assert.equal(result.recordsFallback?.reason, "snapshot_store_unavailable");
+    assert.match(errors.join("\n"), /WORKER RECORD CUTOVER REFUSED.*FALLING BACK TO GIT/);
+    assert.equal(
+      readFileSync(path.join(target, "records", repoSlug, "items", "1.md"), "utf8"),
+      contents.get("items/1"),
+    );
+  } finally {
+    console.error = originalError;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("record parity verifier reports matching trees and exact path/digest mismatches", async () => {
+  const fixture = createStateFixture();
+  try {
+    const matching = await verifyWorkerRecordParity(
+      {
+        stateRoot: fixture.stateRoot,
+        repoSlug,
+        recordsUrl: "https://worker.example",
+        webhookSecret: "fixture-secret",
+      },
+      workerFetch(contents),
+    );
+    assert.deepEqual(matching, {
+      repoSlug,
+      gitRecords: contents.size,
+      workerRecords: contents.size,
+      mismatches: [],
+    });
+
+    const changed = new Map(contents);
+    changed.set("items/1", "different\n");
+    const mismatched = await verifyWorkerRecordParity(
+      {
+        stateRoot: fixture.stateRoot,
+        repoSlug,
+        recordsUrl: "https://worker.example",
+        webhookSecret: "fixture-secret",
+      },
+      workerFetch(changed),
+    );
+    assert.equal(mismatched.mismatches.length, 1);
+    assert.equal(mismatched.mismatches[0]?.path, "items/1.md");
+    assert.notEqual(mismatched.mismatches[0]?.gitDigest, mismatched.mismatches[0]?.workerDigest);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("backfill importer walks all record sections and sends digest-bearing rows", async () => {
+  const fixture = createStateFixture();
+  const requests: unknown[] = [];
+  try {
+    const result = await ingestGitRecords({
+      stateRoot: fixture.stateRoot,
+      repoSlug,
+      baseUrl: "https://worker.example",
+      webhookSecret: "fixture-secret",
+      fetch: async (_input, init) => {
+        const body = JSON.parse(String(init?.body));
+        requests.push(body);
+        return Response.json({
+          inserted: body.records.length,
+          unchanged: 0,
+          skippedNewer: 0,
+          watermark: body.records.length,
+        });
+      },
+    });
+    assert.equal(result.records, contents.size);
+    const rows = requests.flatMap(
+      (request) => (request as { records: unknown[] }).records,
+    ) as Array<{
+      section: string;
+      id: string;
+      content: string;
+      digest: string;
+    }>;
+    assert.deepEqual(
+      rows.map((row) => `${row.section}/${row.id}`).sort(),
+      [...contents.keys()].sort(),
+    );
+    for (const row of rows) {
+      assert.equal(row.digest, createHash("sha256").update(row.content).digest("hex"));
+    }
+
+    requests.length = 0;
+    const resumed = await ingestGitRecords({
+      stateRoot: fixture.stateRoot,
+      repoSlug,
+      baseUrl: "https://worker.example",
+      webhookSecret: "fixture-secret",
+      maxRecordsPerBatch: 1,
+      cursor: 1,
+      maxBatches: 1,
+      fetch: async (_input, init) => {
+        const body = JSON.parse(String(init?.body));
+        requests.push(body);
+        return Response.json({
+          inserted: body.records.length,
+          unchanged: 0,
+          skippedNewer: 0,
+          watermark: 2,
+        });
+      },
+    });
+    assert.equal(requests.length, 1);
+    assert.equal(resumed.cursor, 1);
+    assert.equal(resumed.nextCursor, 2);
+    assert.equal(resumed.totalBatches, contents.size);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("backfill workflow is manual per-target and setup-state plumbs the opt-in Worker flag", () => {
+  const workflowSource = readFileSync(".github/workflows/backfill-worker-records.yml", "utf8");
+  const workflow = parse(workflowSource) as {
+    on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+    jobs?: {
+      backfill?: { steps?: Array<{ uses?: string; with?: Record<string, unknown>; run?: string }> };
+    };
+  };
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.target_repo);
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.cursor);
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.max_batches);
+  const setupState = workflow.jobs?.backfill?.steps?.find(
+    (step) => step.uses === "./.github/actions/setup-state",
+  );
+  assert.equal(setupState?.with?.["records-source"], "git");
+  assert.match(workflowSource, /scripts\/backfill-worker-records\.ts/);
+  assert.match(workflowSource, /--cursor "\$BACKFILL_CURSOR"/);
+  assert.match(workflowSource, /records\/\$\{\{ steps\.target\.outputs\.slug \}\}/);
+
+  const action = readFileSync(".github/actions/setup-state/action.yml", "utf8");
+  assert.match(action, /records-source:[\s\S]*?default: git/);
+  assert.match(action, /CLAWSWEEPER_RECORDS_SOURCE: \$\{\{ inputs\.records-source \}\}/);
+  assert.match(action, /CLAWSWEEPER_RECORDS_URL: \$\{\{ inputs\.records-url \}\}/);
+  assert.match(action, /CLAWSWEEPER_RECORDS_REPO_SLUGS: \$\{\{ inputs\.records-repo-slugs \}\}/);
+  assert.match(action, /CLAWSWEEPER_RECORDS_SECRET: \$\{\{ inputs\.records-secret \}\}/);
+  assert.match(action, /uses: actions\/cache@v6/);
+  assert.match(action, /steps\.records-snapshot\.outputs\.cache-key/);
+  assert.match(action, /\.artifacts\/worker-records-cache/);
+});
+
+function createStateFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-worker-records-test-"));
+  const stateRoot = path.join(root, "state");
+  for (const [key, content] of contents) {
+    const [section, id] = key.split("/");
+    const extension = section === "decision-packets" ? ".json" : ".md";
+    write(path.join(stateRoot, "records", repoSlug, section!, `${id}${extension}`), content);
+  }
+  write(path.join(stateRoot, "jobs", "fixture.json"), "{}\n");
+  return { root, stateRoot };
+}
+
+function workerFetch(
+  recordsByKey: Map<string, string>,
+  stats: { chunkRequests: number } = { chunkRequests: 0 },
+  journal: Array<{ section: WorkerRecord["section"]; id: string; content: string }> = [],
+): typeof globalThis.fetch {
+  const archive = snapshotArchive(recordsByKey);
+  return async (input, init) => {
+    const url = new URL(String(input));
+    const bodyText = String(init?.body || "");
+    const signature = `sha256=${createHmac("sha256", "fixture-secret").update(bodyText).digest("hex")}`;
+    assert.equal(new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"), signature);
+    const body = JSON.parse(bodyText) as {
+      cursor: number;
+      sinceRevision?: number;
+      offset?: number;
+      length?: number;
+    };
+    if (url.pathname.endsWith("/snapshots/latest")) {
+      return Response.json({
+        ok: true,
+        snapshotStoreAvailable: true,
+        snapshot: {
+          repoSlug,
+          revisionWatermark: recordsByKey.size,
+          objectKey: `${repoSlug}/${recordsByKey.size}/fixture.tar.gz`,
+          bytes: archive.byteLength,
+          uncompressedBytes: [...recordsByKey.values()].reduce(
+            (sum, content) => sum + Buffer.byteLength(content),
+            0,
+          ),
+          fileCount: recordsByKey.size,
+          createdAt: "2026-07-26T00:00:00.000Z",
+          access: { mode: "worker_range_proxy", maxChunkBytes: 32 * 1024 * 1024 },
+        },
+      });
+    }
+    if (url.pathname.endsWith("/snapshots/chunk")) {
+      stats.chunkRequests += 1;
+      const offset = body.offset ?? 0;
+      const length = Math.min(body.length ?? archive.byteLength, archive.byteLength - offset);
+      return new Response(archive.subarray(offset, offset + length), {
+        status: 206,
+        headers: {
+          "content-range": `bytes ${offset}-${offset + length - 1}/${archive.byteLength}`,
+        },
+      });
+    }
+    assert.equal(body.cursor, 0);
+    const records: WorkerRecord[] = [...recordsByKey.entries()].map(([key, content], index) => {
+      const [section, id] = key.split("/") as [WorkerRecord["section"], string];
+      return {
+        section,
+        id,
+        content,
+        digest: createHash("sha256").update(content).digest("hex"),
+        revision: 0,
+        storeRevision: index + 1,
+        deleted: false,
+      };
+    });
+    const journalRecords: WorkerRecord[] = body.sinceRevision
+      ? journal.map((record, index) => ({
+          ...record,
+          digest: createHash("sha256").update(record.content).digest("hex"),
+          revision: records.length + index + 1,
+          storeRevision: records.length + index + 1,
+          deleted: false,
+        }))
+      : records;
+    return Response.json({
+      repoSlug,
+      revision: records.length + journal.length,
+      records: journalRecords,
+      nextCursor: null,
+    });
+  };
+}
+
+function snapshotArchive(recordsByKey: Map<string, string>) {
+  const chunks: Buffer[] = [];
+  for (const [key, content] of recordsByKey) {
+    const [section, id] = key.split("/");
+    const extension = section === "decision-packets" ? ".json" : ".md";
+    const bytes = Buffer.from(content);
+    chunks.push(testTarHeader(`${section}/${id}${extension}`, bytes.byteLength), bytes);
+    const padding = (512 - (bytes.byteLength % 512)) % 512;
+    if (padding) chunks.push(Buffer.alloc(padding));
+  }
+  chunks.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(chunks));
+}
+
+function testTarHeader(name: string, size: number) {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, "ascii");
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, size);
+  writeOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+  header[154] = 0;
+  header[155] = 0x20;
+  return header;
+}
+
+function writeOctal(target: Buffer, offset: number, length: number, value: number) {
+  target.write(value.toString(8).padStart(length - 1, "0"), offset, length - 1, "ascii");
+  target[offset + length - 1] = 0;
+}
+
+function write(file: string, content: string) {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content, "utf8");
+}


### PR DESCRIPTION
## Summary

Phase 2 moves canonical record hydration behind an opt-in Worker-backed snapshot+journal transport while keeping Git as the default source.

Per-repository gzip snapshots are streamed to R2 with multipart upload and keep-two pruning. Authenticated Worker endpoints trigger exports, expose the latest snapshot, and serve byte ranges through a 32 MiB proxy because R2 bindings cannot presign downloads. The measured `openclaw-openclaw` tree was 603 MB across 34,459 files and compressed to a 124.9 MiB snapshot; typical journal deltas were 44–87 KiB.

`hydrate-state` now supports `CLAWSWEEPER_RECORDS_SOURCE=worker`, using an Actions-cached snapshot plus `since-revision` deltas while preserving the byte-identical on-disk record layout. Snapshot-store unavailability takes the loud, fail-closed Git fallback path. A cursor-resumable `workflow_dispatch` workflow backfills Git records into canonical Worker storage one repository at a time, and a tree-based parity verifier is the cutover gate.

## Contracts

- Git remains the default records source; this PR does not cut production hydration over to Worker storage.
- The existing flat per-repository `items/` and `closed/` record layout remains byte-identical after hydration.
- Snapshot publication is per repository, journal deltas are revision-addressable, and only the two newest R2 snapshots are retained.
- Trigger, latest-snapshot, and range endpoints remain authenticated.
- Backfill is cursor-resumable and explicitly dispatched per repository.
- Tree parity must pass before any source-default cutover.
- Provisioning the `clawsweeper-state-snapshots` R2 bucket is the one pending manual deployment step.

## Proof

- Focused tests: 238/238 passed.
- Unit tests: 1,638 passed.
- Autoreview: CLEAN (0.98); TruffleHog clean.
- Broader local validation had only the previously identified environment-specific failures; exact-head hosted CI is the merge gate.
