### PR TITLE
ci(state): worker-records-ops workflow (snapshot trigger + parity verify)

### DIFF
--- a/.github/workflows/worker-records-ops.yml
+++ b/.github/workflows/worker-records-ops.yml
@@ -1,0 +1,159 @@
+name: Worker records operations
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: Repository whose Worker records should be operated on (owner/name).
+        required: true
+        type: string
+      action:
+        description: Worker records operation to run.
+        required: true
+        type: choice
+        options:
+          - snapshot
+          - verify
+          - both
+        default: both
+
+concurrency:
+  group: worker-records-ops-${{ inputs.target_repo }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+  CLAWSWEEPER_RECORDS_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+
+jobs:
+  snapshot:
+    name: Trigger Worker records snapshot
+    if: ${{ inputs.action == 'snapshot' || inputs.action == 'both' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Resolve target record slug
+        id: target
+        env:
+          TARGET_REPO: ${{ inputs.target_repo }}
+        run: |
+          if ! [[ "$TARGET_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "target_repo must be owner/name" >&2
+            exit 2
+          fi
+          echo "slug=${TARGET_REPO//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Worker records snapshot
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          TARGET_SLUG: ${{ steps.target.outputs.slug }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs";
+          import { signedPost } from "./scripts/worker-records.ts";
+
+          const result = await signedPost({
+            baseUrl: process.env.CLAWSWEEPER_RECORDS_URL,
+            path: "/internal/state/records/snapshots/trigger",
+            webhookSecret: process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+            body: { repoSlug: process.env.TARGET_SLUG },
+          });
+          if (result?.ok !== true || result.snapshot?.repoSlug !== process.env.TARGET_SLUG) {
+            throw new Error("Worker returned an invalid snapshot response");
+          }
+          const summary = {
+            repoSlug: result.snapshot.repoSlug,
+            revisionWatermark: result.snapshot.revisionWatermark,
+            bytes: result.snapshot.bytes,
+            fileCount: result.snapshot.fileCount,
+            createdAt: result.snapshot.createdAt,
+          };
+          console.log(JSON.stringify(summary));
+          appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            `### Worker records snapshot\n\n\`\`\`json\n${JSON.stringify(summary, null, 2)}\n\`\`\`\n`,
+          );
+          NODE
+
+  verify:
+    name: Verify Worker record parity
+    needs: snapshot
+    if: >-
+      ${{
+        always() &&
+        inputs.action != 'snapshot' &&
+        (inputs.action == 'verify' || needs.snapshot.result == 'success')
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Resolve target record slug
+        id: target
+        env:
+          TARGET_REPO: ${{ inputs.target_repo }}
+        run: |
+          if ! [[ "$TARGET_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "target_repo must be owner/name" >&2
+            exit 2
+          fi
+          echo "slug=${TARGET_REPO//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+          sparse-checkout: records/${{ steps.target.outputs.slug }}
+          persist-credentials: "false"
+          records-source: git
+          coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
+          coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+
+      - name: Verify Worker record parity
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          TARGET_SLUG: ${{ steps.target.outputs.slug }}
+        run: |
+          set -o pipefail
+          set +e
+          pnpm run state:records:verify -- \
+            --state-dir clawsweeper-state \
+            --repo-slug "$TARGET_SLUG" \
+            | tee "$RUNNER_TEMP/worker-record-parity.json"
+          verify_exit="${PIPESTATUS[0]}"
+          set -e
+          {
+            echo "### Worker record parity"
+            echo
+            echo '```json'
+            cat "$RUNNER_TEMP/worker-record-parity.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$verify_exit"

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -48,7 +48,7 @@ test("every generated-state checkout receives the explicit coordinator migration
     }
   }
 
-  assert.equal(setups.length, 28, "new state checkouts must join the repo-wide boundary");
+  assert.equal(setups.length, 29, "new state checkouts must join the repo-wide boundary");
   for (const { file, job, step } of setups) {
     assert.equal(step.with?.["coordinator-enabled"], coordinatorGate, `${file}:${job}`);
     assert.equal(step.with?.["coordinator-url"], coordinatorUrl, `${file}:${job}`);

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -285,6 +285,87 @@ test("backfill workflow is manual per-target and setup-state plumbs the opt-in W
   assert.match(action, /\.artifacts\/worker-records-cache/);
 });
 
+test("worker records ops workflow snapshots and verifies one requested repository", () => {
+  const workflowSource = readFileSync(".github/workflows/worker-records-ops.yml", "utf8");
+  const workflow = parse(workflowSource) as {
+    on?: {
+      workflow_dispatch?: {
+        inputs?: Record<
+          string,
+          { required?: boolean; type?: string; default?: string; options?: string[] }
+        >;
+      };
+    };
+    env?: Record<string, string>;
+    jobs?: Record<
+      string,
+      {
+        needs?: string;
+        steps?: Array<{ uses?: string; with?: Record<string, unknown>; run?: string }>;
+      }
+    >;
+  };
+  const inputs = workflow.on?.workflow_dispatch?.inputs;
+  assert.deepEqual(inputs?.target_repo, {
+    description: "Repository whose Worker records should be operated on (owner/name).",
+    required: true,
+    type: "string",
+  });
+  assert.deepEqual(inputs?.action, {
+    description: "Worker records operation to run.",
+    required: true,
+    type: "choice",
+    options: ["snapshot", "verify", "both"],
+    default: "both",
+  });
+  assert.match(workflow.env?.CLAWSWEEPER_RECORDS_URL ?? "", /CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL/);
+
+  const snapshot = workflow.jobs?.snapshot;
+  const verify = workflow.jobs?.verify;
+  assert.ok(snapshot);
+  assert.ok(verify);
+  assert.equal(verify.needs, "snapshot");
+  for (const job of [snapshot, verify]) {
+    assert.ok(job.steps?.some((step) => step.uses === "actions/checkout@v7"));
+    assert.ok(job.steps?.some((step) => step.uses === "./.github/actions/setup-pnpm"));
+  }
+  assert.equal(
+    snapshot.steps?.some((step) => step.uses === "./.github/actions/setup-state"),
+    false,
+  );
+  const setupState = verify.steps?.find((step) => step.uses === "./.github/actions/setup-state");
+  assert.equal(setupState?.with?.["records-source"], "git");
+  assert.equal(setupState?.with?.["persist-credentials"], "false");
+  assert.equal(
+    setupState?.with?.["coordinator-enabled"],
+    "${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}",
+  );
+  assert.equal(
+    setupState?.with?.["coordinator-url"],
+    "${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}",
+  );
+
+  assert.match(workflowSource, /inputs\.action == 'snapshot' \|\| inputs\.action == 'both'/);
+  assert.match(
+    workflowSource,
+    /inputs\.action == 'verify' \|\| needs\.snapshot\.result == 'success'/,
+  );
+  assert.match(workflowSource, /signedPost/);
+  assert.match(workflowSource, /\/internal\/state\/records\/snapshots\/trigger/);
+  assert.match(workflowSource, /body: \{ repoSlug: process\.env\.TARGET_SLUG \}/);
+  assert.equal(
+    workflowSource.match(
+      /CLAWSWEEPER_WEBHOOK_SECRET: \$\{\{ secrets\.CLAWSWEEPER_WEBHOOK_SECRET \}\}/g,
+    )?.length,
+    2,
+  );
+  assert.match(
+    workflowSource,
+    /pnpm run state:records:verify --[\s\\]*--state-dir clawsweeper-state[\s\\]*--repo-slug "\$TARGET_SLUG"/,
+  );
+  assert.match(workflowSource, /records\/\$\{\{ steps\.target\.outputs\.slug \}\}/);
+});
+
 function createStateFixture() {
   const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-worker-records-test-"));
   const stateRoot = path.join(root, "state");


### PR DESCRIPTION
Adds a dispatchable ops workflow for the Phase 2 worker-records cutover runbook:

- Inputs: target_repo (required) + action (snapshot | verify | both)
- Snapshot: HMAC-signed synchronous trigger against the Worker snapshot endpoint, metadata surfaced in the Actions summary
- Verify: sparse state checkout + parity verifier scoped via --repo-slug, mismatch exit code preserved, JSON summary
- "both" enforces snapshot-before-verify ordering

Focused tests: 98 passed (workflow assertions in test/worker-state-readers.test.ts, state-checkout count 28 -> 29). actionlint clean. Autoreview clean.

Part of the Cloudflare-canonical migration (Phase 2, follows #874).
