### PR TITLE
fix: maintainer commands fail before routing after state hydration changes

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -103,6 +103,7 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            scripts/worker-records.ts
             src
             package.json
             pnpm-lock.yaml

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -85,6 +85,7 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            scripts/worker-records.ts
             src
             package.json
             pnpm-lock.yaml

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -41,15 +41,18 @@ test("sparse repair build workflows include runtime dependencies", () => {
   }
 });
 
-test("state-hydrating sparse repair workflows keep their hydration script", () => {
+test("state-hydrating sparse repair workflows keep hydration dependencies", () => {
   for (const workflowPath of [
     ".github/workflows/repair-comment-router.yml",
     ".github/workflows/spam-scanner.yml",
   ]) {
-    assert.ok(
-      sparseEntriesCover(sourceSparseCheckoutEntries(workflowPath), "scripts/hydrate-state.ts"),
-      `${workflowPath} missing scripts/hydrate-state.ts`,
-    );
+    const entries = sourceSparseCheckoutEntries(workflowPath);
+    for (const requiredPath of ["scripts/hydrate-state.ts", "scripts/worker-records.ts"]) {
+      assert.ok(
+        sparseEntriesCover(entries, requiredPath),
+        `${workflowPath} missing ${requiredPath}`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainer commands such as `@clawsweeper automerge`
remain queued and never route because workflow setup cannot import a state
hydration dependency.

The live failure is visible in
https://github.com/openclaw/clawsweeper/actions/runs/30232938094: the repair
comment router stops in setup with `ERR_MODULE_NOT_FOUND` for
`scripts/worker-records.ts`.

## Why This Change Was Made

Include `scripts/worker-records.ts` in the sparse checkout for both workflows
that run `scripts/hydrate-state.ts`, and extend the workflow regression test to
cover the complete hydration dependency pair. This keeps the change limited to
the checkout boundary; runtime behavior is unchanged.

## User Impact

Maintainer commands can reach the comment router again instead of remaining
indefinitely queued. The spam scanner is protected from the same setup failure.

## Evidence

- **Real workflow proof:** https://github.com/openclaw/clawsweeper/actions/runs/30234736947
  ran `repair comment router` from exact head
  `52325f526a50a529db2e113e88d3e3e54c6da784`. Its checkout log lists both
  `scripts/hydrate-state.ts` and `scripts/worker-records.ts`; `setup-state`,
  Node 24 setup/build, `Route ClawSweeper comments`, ledger finalization, and
  ledger publication all completed successfully. The run targeted the already
  processed OpenClaw #105896 maintainer command with `execute=false`, proving
  the real path without re-dispatching or mutating the target PR.
- GitHub Node 24 `pnpm check` — passed:
  https://github.com/openclaw/clawsweeper/actions/runs/30233966305
- GitHub `sparse repair build smoke` — passed in the same CI run.
- `node --test test/repair/workflow-sparse-checkout.test.ts` — 7/7 passed.
- `./node_modules/.bin/oxfmt --check .github/workflows/repair-comment-router.yml .github/workflows/spam-scanner.yml test/repair/workflow-sparse-checkout.test.ts` — passed.
- `git diff --check` — passed.
- Local `corepack pnpm run check` completed formatting, builds, lint, focused
  coverage, and all but one full-suite test on Node 22. The sole failure is the
  unrelated existing Git publisher credential stress test
  `publishMainCommit escapes sustained immutable ledger races through a server
  merge`; the required Node 24 GitHub check passed in full.
