### PR TITLE
fix(state): route all record tuple writes through the canonical DO store

### DIFF
--- a/.github/workflows/backfill-worker-records.yml
+++ b/.github/workflows/backfill-worker-records.yml
@@ -18,6 +18,26 @@ on:
         required: false
         type: number
         default: 0
+      replay_projections:
+        description: Re-append canonical tuples after backfill so git projection can converge.
+        required: false
+        type: boolean
+        default: false
+      replay_item_ids:
+        description: Optional comma-separated item ids to replay; empty replays the bounded canonical set.
+        required: false
+        type: string
+        default: ""
+      max_replay_tuples:
+        description: Maximum tuples to replay in this run.
+        required: false
+        type: number
+        default: 500
+      replay_cursor:
+        description: Zero-based tuple replay cursor from a prior bounded run.
+        required: false
+        type: number
+        default: 0
 
 concurrency:
   group: backfill-worker-records-${{ inputs.target_repo }}
@@ -75,10 +95,20 @@ jobs:
           CLAWSWEEPER_RECORDS_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           BACKFILL_CURSOR: ${{ inputs.cursor }}
           BACKFILL_MAX_BATCHES: ${{ inputs.max_batches }}
+          REPLAY_PROJECTIONS: ${{ inputs.replay_projections }}
+          REPLAY_ITEM_IDS: ${{ inputs.replay_item_ids }}
+          MAX_REPLAY_TUPLES: ${{ inputs.max_replay_tuples }}
+          REPLAY_CURSOR: ${{ inputs.replay_cursor }}
           TARGET_SLUG: ${{ steps.target.outputs.slug }}
         run: |
           args=(--state-dir clawsweeper-state --repo-slug "$TARGET_SLUG" --cursor "$BACKFILL_CURSOR")
           if (( BACKFILL_MAX_BATCHES > 0 )); then
             args+=(--max-batches "$BACKFILL_MAX_BATCHES")
+          fi
+          if [ "$REPLAY_PROJECTIONS" = "true" ]; then
+            args+=(--replay-projections --max-replay-tuples "$MAX_REPLAY_TUPLES" --replay-cursor "$REPLAY_CURSOR")
+            if [ -n "$REPLAY_ITEM_IDS" ]; then
+              args+=(--replay-item-ids "$REPLAY_ITEM_IDS")
+            fi
           fi
           node scripts/backfill-worker-records.ts "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Made every item/closed/plan/decision-packet writer publish an atomic canonical Worker tuple first, leaving the git state tree as materializer-only projection; added bounded canonical projection replay for migration convergence.
 - Removed the Claude CLI runtime layer; ClawSweeper is Codex-only.
 - Allowed four isolated exact-review batches to prepare concurrently while
   retaining one fenced state-writer mutation boundary.

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -5,6 +5,7 @@ export const EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE = "exact_review_record_expor
 export const EXACT_REVIEW_RECORD_BACKFILL_TABLE = "exact_review_record_backfill";
 export const EXACT_REVIEW_RECORD_BACKFILL_CHUNK_TABLE = "exact_review_record_backfill_chunks";
 export const EXACT_REVIEW_RECORD_EXPORT_META_TABLE = "exact_review_record_export_meta";
+export const CANONICAL_RECORD_TUPLE_RECEIPT_TABLE = "canonical_record_tuple_receipts";
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES = 4 * 1024 * 1024;
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES = 4;
 export const EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES = 2 * 1024 * 1024;
@@ -105,6 +106,28 @@ export type CanonicalRecord = {
   deleted: boolean;
 };
 
+export type CanonicalRecordTupleMutationOperation = {
+  path: string;
+  expectedDigest: string | null;
+  contentBase64?: string;
+};
+
+export type CanonicalRecordTupleMutation = {
+  deliveryId: string;
+  key: string;
+  operations: CanonicalRecordTupleMutationOperation[];
+};
+
+export type ValidatedCanonicalRecordTupleMutation = {
+  deliveryId: string;
+  key: string;
+  repoSlug: string;
+  itemId: number;
+  operations: CanonicalDirectPublicationOperation[];
+  expectedDigests: Map<ExactReviewTupleRecordSection, string | null>;
+  fingerprint: string;
+};
+
 export type RecordExportEntry = {
   repoSlug: string;
   section: RecordSection;
@@ -137,6 +160,13 @@ export class DirectPublicationProjectionCapacityError extends Error {
   }
 }
 
+export class CanonicalRecordTupleConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CanonicalRecordTupleConflictError";
+  }
+}
+
 export class ExactReviewDirectPublicationStore {
   private readonly storage: DurableStorage;
 
@@ -166,6 +196,19 @@ export class ExactReviewDirectPublicationStore {
          failure_reason TEXT,
          PRIMARY KEY (item_key, revision)
        ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE} (
+         delivery_id TEXT PRIMARY KEY,
+         fingerprint TEXT NOT NULL CHECK (length(fingerprint) = 64),
+         revision INTEGER NOT NULL CHECK (revision >= 1),
+         sequence INTEGER NOT NULL CHECK (sequence >= 1),
+         received_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS canonical_record_tuple_receipt_retention
+         ON ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE} (received_at, delivery_id)`,
     );
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS exact_review_direct_publication_terminal_retention
@@ -320,29 +363,18 @@ export class ExactReviewDirectPublicationStore {
         return { outcome: "superseded" as const, row, supersededRevisions: [] };
       }
 
-      for (const operation of canonicalOperations) {
-        const current = this.readCanonicalMetadataSync(
-          operation.repoSlug,
-          operation.section,
-          operation.itemId,
-        );
-        if (current && current.revision > plan.revision) {
-          throw new Error(`canonical record revision advanced for ${operation.path}`);
-        }
-        if (
-          current &&
-          current.revision === plan.revision &&
-          (current.digest !== operation.digest || current.deleted !== (operation.content === null))
-        ) {
-          throw new Error(
-            `canonical record digest conflicts at revision ${plan.revision}: ${operation.path}`,
-          );
-        }
-      }
+      const canonicalRevision = Math.max(
+        plan.revision,
+        this.nextTupleRevisionSync(
+          canonicalOperations[0]!.repoSlug,
+          canonicalOperations[0]!.itemId,
+        ),
+      );
 
       const projection = recordTupleProjection(
         { ...plan, operations: canonicalOperations },
         limits.maxRecordBytes,
+        canonicalRevision,
       );
       const totals = stateAppendWindowTotalsSync(this.storage);
       if (
@@ -355,7 +387,7 @@ export class ExactReviewDirectPublicationStore {
       }
 
       for (const operation of canonicalOperations)
-        this.writeCanonicalOperationSync(operation, plan, now);
+        this.writeCanonicalOperationSync(operation, plan, now, canonicalRevision);
       const inserted = Array.from(
         this.storage.sql.exec(
           `INSERT INTO ${STATE_APPEND_WINDOW_TABLE}
@@ -384,6 +416,110 @@ export class ExactReviewDirectPublicationStore {
       });
       this.insertSync(row);
       return { outcome: "accepted" as const, row, supersededRevisions: [] };
+    });
+  }
+
+  acceptCanonicalTupleMutation(
+    mutation: ValidatedCanonicalRecordTupleMutation,
+    now: number,
+    limits: DirectPublicationProjectionLimits,
+  ) {
+    return this.storage.transactionSync(() => {
+      this.storage.sql.exec(
+        `DELETE FROM ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE}
+          WHERE delivery_id IN (
+            SELECT delivery_id FROM ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE}
+             WHERE received_at <= ?
+             ORDER BY received_at, delivery_id
+             LIMIT ${DIRECT_PUBLICATION_TERMINAL_PRUNE_LIMIT}
+          )`,
+        now - EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS,
+      );
+      const receipt = Array.from(
+        this.storage.sql.exec(
+          `SELECT fingerprint, revision, sequence
+             FROM ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE}
+            WHERE delivery_id = ?`,
+          mutation.deliveryId,
+        ),
+      )[0];
+      if (receipt) {
+        if (String(receipt.fingerprint) !== mutation.fingerprint) {
+          throw new CanonicalRecordTupleConflictError(
+            `canonical tuple delivery ${mutation.deliveryId} is bound to another payload`,
+          );
+        }
+        return {
+          outcome: "deduped" as const,
+          revision: Number(receipt.revision),
+          sequence: Number(receipt.sequence),
+        };
+      }
+
+      for (const operation of mutation.operations) {
+        const current = this.readExportRecord(
+          mutation.repoSlug,
+          operation.section,
+          String(mutation.itemId),
+        );
+        const currentDigest = current && !current.deleted ? current.digest : null;
+        const expectedDigest = mutation.expectedDigests.get(operation.section) ?? null;
+        if (currentDigest !== expectedDigest) {
+          throw new CanonicalRecordTupleConflictError(
+            `canonical record changed before tuple publication: ${operation.path}`,
+          );
+        }
+      }
+
+      const revision = this.nextTupleRevisionSync(mutation.repoSlug, mutation.itemId);
+      const plan: CanonicalDirectPublicationPlan = {
+        itemKey: mutation.key,
+        revision,
+        identity: { itemKey: mutation.key, revision, claimGeneration: 1 },
+        operations: mutation.operations,
+        totalBytes: mutation.operations.reduce((sum, operation) => sum + operation.bytes, 0),
+      };
+      const projection = recordTupleProjection(plan, limits.maxRecordBytes, revision);
+      const totals = stateAppendWindowTotalsSync(this.storage);
+      if (
+        totals.pendingRows + 1 > limits.maxPendingRows ||
+        totals.pendingBytes + projection.payloadBytes > limits.maxPendingBytes
+      ) {
+        throw new DirectPublicationProjectionCapacityError(
+          `record tuple projection capacity exceeded: rows=${totals.pendingRows}/${limits.maxPendingRows} bytes=${totals.pendingBytes}/${limits.maxPendingBytes} incoming=${projection.payloadBytes}`,
+        );
+      }
+      for (const operation of mutation.operations) {
+        this.writeCanonicalOperationSync(operation, plan, now, revision);
+      }
+      const inserted = Array.from(
+        this.storage.sql.exec(
+          `INSERT INTO ${STATE_APPEND_WINDOW_TABLE}
+             (kind, record_key, payload_json, payload_bytes, produced_at, delivery_id)
+           VALUES ('record_tuple', ?, ?, ?, ?, ?)
+           RETURNING seq`,
+          projection.key,
+          projection.payloadJson,
+          projection.payloadBytes,
+          new Date(now).toISOString(),
+          mutation.deliveryId,
+        ) as Iterable<{ seq: number }>,
+      )[0];
+      const sequence = Number(inserted?.seq);
+      if (!Number.isSafeInteger(sequence) || sequence < 1) {
+        throw new Error("canonical tuple publication failed to allocate a sequence");
+      }
+      this.storage.sql.exec(
+        `INSERT INTO ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE}
+           (delivery_id, fingerprint, revision, sequence, received_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        mutation.deliveryId,
+        mutation.fingerprint,
+        revision,
+        sequence,
+        now,
+      );
+      return { outcome: "accepted" as const, revision, sequence };
     });
   }
 
@@ -680,6 +816,7 @@ export class ExactReviewDirectPublicationStore {
     operation: CanonicalDirectPublicationOperation,
     plan: CanonicalDirectPublicationPlan,
     now: number,
+    revision = plan.revision,
   ) {
     this.storage.sql.exec(
       `DELETE FROM ${EXACT_REVIEW_CANONICAL_RECORD_CHUNK_TABLE}
@@ -716,7 +853,7 @@ export class ExactReviewDirectPublicationStore {
       operation.bytes,
       chunks.length,
       operation.content === null ? 1 : 0,
-      plan.revision,
+      revision,
       plan.itemKey,
       plan.identity.claimGeneration,
       now,
@@ -751,10 +888,27 @@ export class ExactReviewDirectPublicationStore {
       String(operation.itemId),
       operation.digest,
       operation.content === null ? 1 : 0,
-      plan.revision,
+      revision,
       storeRevision,
       now,
     );
+  }
+
+  private nextTupleRevisionSync(repoSlug: string, itemId: number): number {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT COALESCE(MAX(revision), 0) AS revision
+           FROM ${EXACT_REVIEW_CANONICAL_RECORD_TABLE}
+          WHERE repo_slug = ? AND item_id = ?`,
+        repoSlug,
+        itemId,
+      ),
+    )[0];
+    const current = Number(row?.revision ?? 0);
+    if (!Number.isSafeInteger(current) || current < 0 || current >= Number.MAX_SAFE_INTEGER) {
+      throw new Error(`invalid canonical tuple revision for ${repoSlug}/${itemId}`);
+    }
+    return current + 1;
   }
 
   private seedExportIndexFromCanonicalSync() {
@@ -1037,6 +1191,168 @@ export function validateRepoSlug(value: unknown): string | null {
   return /^[A-Za-z0-9][A-Za-z0-9_.-]{0,199}$/.test(slug) ? slug : null;
 }
 
+export async function validateCanonicalRecordTupleMutation(
+  value: CanonicalRecordTupleMutation,
+): Promise<ValidatedCanonicalRecordTupleMutation> {
+  const mutation =
+    value && typeof value === "object" ? value : ({} as CanonicalRecordTupleMutation);
+  const deliveryId = String(mutation.deliveryId || "").trim();
+  if (
+    !deliveryId ||
+    deliveryId.length > 512 ||
+    /[\r\n]/.test(deliveryId) ||
+    deliveryId.includes("\u0000")
+  ) {
+    throw new Error("invalid canonical tuple delivery id");
+  }
+  const key = String(mutation.key || "").trim();
+  const keyMatch = /^([A-Za-z0-9][A-Za-z0-9_.-]{0,199})\/([1-9]\d*)$/.exec(key);
+  const repoSlug = validateRepoSlug(keyMatch?.[1]);
+  const itemId = Number(keyMatch?.[2]);
+  if (!repoSlug || !Number.isSafeInteger(itemId) || itemId < 1) {
+    throw new Error("invalid canonical tuple key");
+  }
+  if (!Array.isArray(mutation.operations) || mutation.operations.length !== 4) {
+    throw new Error("canonical tuple publication must include all four record sections");
+  }
+  const expectedDigests = new Map<ExactReviewTupleRecordSection, string | null>();
+  const operations: CanonicalDirectPublicationOperation[] = [];
+  const sections = new Set<ExactReviewTupleRecordSection>();
+  for (const raw of mutation.operations) {
+    const operation =
+      raw && typeof raw === "object" ? raw : ({} as CanonicalRecordTupleMutationOperation);
+    const tuple = canonicalTuplePath(String(operation.path || ""));
+    if (!tuple || tuple.repoSlug !== repoSlug || tuple.itemId !== itemId) {
+      throw new Error(`canonical tuple path is outside ${key}: ${String(operation.path)}`);
+    }
+    if (sections.has(tuple.section)) {
+      throw new Error(`canonical tuple repeats section ${tuple.section}`);
+    }
+    sections.add(tuple.section);
+    const expectedDigest = operation.expectedDigest;
+    if (expectedDigest !== null && !/^[a-f0-9]{64}$/.test(String(expectedDigest))) {
+      throw new Error(`invalid expected digest for ${operation.path}`);
+    }
+    expectedDigests.set(tuple.section, expectedDigest);
+    if (operation.contentBase64 === undefined) {
+      operations.push({
+        path: operation.path,
+        expectedOid: null,
+        targetOid: null,
+        mode: "100644",
+        bytes: 0,
+        ...tuple,
+        content: null,
+        digest: null,
+      });
+      continue;
+    }
+    if (
+      typeof operation.contentBase64 !== "string" ||
+      !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+        operation.contentBase64,
+      )
+    ) {
+      throw new Error(`invalid canonical tuple content for ${operation.path}`);
+    }
+    const bytes = base64Bytes(operation.contentBase64);
+    if (bytes.byteLength > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES) {
+      throw new Error(`canonical tuple content is too large: ${operation.path}`);
+    }
+    let content: string;
+    try {
+      content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      throw new Error(`canonical tuple content is not UTF-8: ${operation.path}`);
+    }
+    operations.push({
+      path: operation.path,
+      expectedOid: null,
+      targetOid: "canonical",
+      mode: "100644",
+      bytes: bytes.byteLength,
+      contentBase64: operation.contentBase64,
+      ...tuple,
+      content,
+      digest: await sha256Hex(bytes),
+    });
+  }
+  const primaryCount = operations.filter(
+    (operation) =>
+      (operation.section === "items" || operation.section === "closed") &&
+      operation.content !== null,
+  ).length;
+  const sidecarCount = operations.filter(
+    (operation) =>
+      (operation.section === "plans" || operation.section === "decision-packets") &&
+      operation.content !== null,
+  ).length;
+  if (primaryCount > 1 || (primaryCount === 0 && sidecarCount > 0)) {
+    throw new Error(`canonical tuple has invalid primary/sidecar structure: ${key}`);
+  }
+  const closed = operations.find((operation) => operation.section === "closed")?.content;
+  const plan = operations.find((operation) => operation.section === "plans")?.content;
+  if (closed !== null && closed !== undefined && plan !== null && plan !== undefined) {
+    throw new Error(`canonical closed tuple retains a work plan: ${key}`);
+  }
+  validateCanonicalTuplePacketReference(key, operations);
+  const canonicalFingerprint = JSON.stringify({
+    key,
+    operations: operations.map((operation) => ({
+      path: operation.path,
+      expectedDigest: expectedDigests.get(operation.section) ?? null,
+      digest: operation.digest,
+    })),
+  });
+  return {
+    deliveryId,
+    key,
+    repoSlug,
+    itemId,
+    operations,
+    expectedDigests,
+    fingerprint: await sha256Hex(new TextEncoder().encode(canonicalFingerprint)),
+  };
+}
+
+function validateCanonicalTuplePacketReference(
+  key: string,
+  operations: readonly CanonicalDirectPublicationOperation[],
+) {
+  const primary = operations.find(
+    (operation) =>
+      (operation.section === "items" || operation.section === "closed") &&
+      operation.content !== null,
+  );
+  const packet = operations.find((operation) => operation.section === "decision-packets")!;
+  if (!primary) return;
+  const normalized = primary.content!.replace(/\r\n/g, "\n");
+  const end = normalized.startsWith("---\n") ? normalized.indexOf("\n---", 4) : -1;
+  const frontMatter = new Map<string, string>();
+  if (end !== -1) {
+    for (const line of normalized.slice(4, end).split("\n")) {
+      const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+      if (match?.[1]) frontMatter.set(match[1], match[2] ?? "");
+    }
+  }
+  const digest = frontMatter.get("decision_packet_sha256");
+  const pointer = frontMatter.get("decision_packet_path");
+  if (packet.content === null) {
+    if (
+      !(
+        (digest === undefined && pointer === undefined) ||
+        (digest === "none" && pointer === "none")
+      )
+    ) {
+      throw new Error(`canonical tuple references a missing decision packet: ${key}`);
+    }
+    return;
+  }
+  if (digest !== packet.digest || pointer !== packet.path) {
+    throw new Error(`canonical tuple decision packet reference is inconsistent: ${key}`);
+  }
+}
+
 export async function validateDirectPublicationPlan(
   value: DirectPublicationPlan,
 ): Promise<CanonicalDirectPublicationPlan> {
@@ -1134,14 +1450,18 @@ export async function validateDirectPublicationPlan(
 // The direct path now derives SHA-256 content digests and deliberately ignores Git blob OIDs.
 export const validateDirectPublicationBlobOids = validateDirectPublicationPlan;
 
-function recordTupleProjection(plan: CanonicalDirectPublicationPlan, maxRecordBytes: number) {
+function recordTupleProjection(
+  plan: CanonicalDirectPublicationPlan,
+  maxRecordBytes: number,
+  revision = plan.revision,
+) {
   const operationJson = (operation: CanonicalDirectPublicationOperation, inline: boolean) => ({
     path: operation.path,
     repoSlug: operation.repoSlug,
     section: operation.section,
     itemId: operation.itemId,
     digest: operation.digest,
-    revision: plan.revision,
+    revision,
     bytes: operation.bytes,
     deleted: operation.content === null,
     ...(operation.content === null
@@ -1152,7 +1472,7 @@ function recordTupleProjection(plan: CanonicalDirectPublicationPlan, maxRecordBy
   });
   const base = {
     itemKey: plan.itemKey,
-    revision: plan.revision,
+    revision,
     claimGeneration: plan.identity.claimGeneration,
     operations: plan.operations.map((operation) => operationJson(operation, true)),
   };

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -18,16 +18,19 @@ import {
   type PublicationBatchObservationStage,
 } from "./exact-review-publication-batches.ts";
 import {
+  CanonicalRecordTupleConflictError,
   DirectPublicationProjectionCapacityError,
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   ExactReviewDirectPublicationStore,
   sha256Hex,
+  validateCanonicalRecordTupleMutation,
   validateDirectPublicationBlobOids,
   validateRecordId,
   validateRecordSection,
   validateRepoSlug,
   validateTupleRecordSection,
   type DirectPublicationPlan,
+  type CanonicalRecordTupleMutation,
   type RecordBackfillInput,
   type RecordSection,
 } from "./exact-review-direct-publication.ts";
@@ -2205,7 +2208,63 @@ export class ExactReviewQueue {
       }
     }
 
-    if (request.method === "POST" && url.pathname === "/publication-results") {
+    if (request.method === "POST" && url.pathname === "/records/tuples") {
+      const bodyText = await request.text();
+      if (
+        new TextEncoder().encode(bodyText).byteLength >
+        EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES
+      ) {
+        return json({ error: "canonical_record_tuple_too_large" }, 413);
+      }
+      let mutation: CanonicalRecordTupleMutation;
+      try {
+        mutation = JSON.parse(bodyText) as CanonicalRecordTupleMutation;
+      } catch {
+        return json({ error: "invalid_canonical_record_tuple_json" }, 400);
+      }
+      try {
+        const validated = await validateCanonicalRecordTupleMutation(mutation);
+        const accepted = this.directPublicationStore.acceptCanonicalTupleMutation(
+          validated,
+          Date.now(),
+          {
+            maxRecordBytes: stateAppendMaxRecordBytes(this.env),
+            maxPendingRows: stateAppendMaxPendingRows(this.env),
+            maxPendingBytes: stateAppendMaxPendingBytes(this.env),
+          },
+        );
+        return json(
+          {
+            ok: true,
+            accepted: accepted.outcome === "accepted",
+            deduped: accepted.outcome === "deduped",
+            revision: accepted.revision,
+            sequence: accepted.sequence,
+          },
+          202,
+        );
+      } catch (error) {
+        if (error instanceof CanonicalRecordTupleConflictError) {
+          return json({ error: "canonical_record_tuple_conflict", detail: error.message }, 409);
+        }
+        if (error instanceof DirectPublicationProjectionCapacityError) {
+          return json({ error: "canonical_record_tuple_capacity", detail: error.message }, 429);
+        }
+        return json(
+          {
+            error: "invalid_canonical_record_tuple",
+            detail: error instanceof Error ? error.message : String(error),
+          },
+          400,
+        );
+      }
+    }
+
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/publication-results" || url.pathname === "/publication-batch-results")
+    ) {
+      const deferredBatchCompletion = url.pathname === "/publication-batch-results";
       if (!exactReviewDirectPublicationEnabled(this.env)) {
         return json({ error: "direct_publication_disabled", fallback_required: true }, 409);
       }
@@ -2256,7 +2315,7 @@ export class ExactReviewQueue {
           maxPendingRows: stateAppendMaxPendingRows(this.env),
           maxPendingBytes: stateAppendMaxPendingBytes(this.env),
         });
-        if (owned && validFence) {
+        if (owned && validFence && !deferredBatchCompletion) {
           const producerDecision = owned.decision.publication
             ? owned.decision.publication.producerDecision
             : (owned.leaseDecision ?? owned.decision);

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -562,6 +562,8 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/records/export");
     if (url.pathname === "/internal/state/records/ingest" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/records/ingest");
+    if (url.pathname === "/internal/state/records/tuples" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/tuples");
     if (url.pathname === "/internal/state/records/snapshots/latest" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/records/snapshots/latest");
     if (url.pathname === "/internal/state/records/snapshots/trigger" && request.method === "POST")
@@ -623,6 +625,11 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/publications/reconcile");
     if (url.pathname === "/internal/exact-review/publication-results" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/publication-results");
+    if (
+      url.pathname === "/internal/exact-review/publication-batch-results" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/publication-batch-results");
     if (url.pathname === "/internal/exact-review/review-telemetry" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/review-telemetry");
     if (url.pathname === "/internal/exact-review/review-run-telemetry" && request.method === "POST")

--- a/scripts/backfill-worker-records.ts
+++ b/scripts/backfill-worker-records.ts
@@ -2,7 +2,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { ingestGitRecords } from "./worker-records.ts";
+import { ingestGitRecords, replayWorkerRecordProjections } from "./worker-records.ts";
 
 export async function backfillWorkerRecords(
   argv: string[],
@@ -32,8 +32,32 @@ export async function backfillWorkerRecords(
       );
     },
   });
-  console.log(JSON.stringify({ repoSlug, ...result }));
-  return result;
+  let replay: Awaited<ReturnType<typeof replayWorkerRecordProjections>> | null = null;
+  if (args.replayProjections) {
+    if (result.nextCursor !== null) {
+      throw new Error("Projection replay requires the git backfill to reach its final cursor");
+    }
+    replay = await replayWorkerRecordProjections({
+      repoSlug,
+      baseUrl:
+        args.recordsUrl ??
+        env.CLAWSWEEPER_RECORDS_URL ??
+        env.CLAWSWEEPER_STATE_COORDINATOR_URL ??
+        "https://clawsweeper.openclaw.ai",
+      webhookSecret,
+      fetch: fetchImpl,
+      ...(args.replayItemIds?.length ? { itemIds: args.replayItemIds } : {}),
+      ...(args.maxReplayTuples ? { maxTuples: args.maxReplayTuples } : {}),
+      ...(args.replayCursor !== undefined ? { cursor: args.replayCursor } : {}),
+      onTuple: ({ completed, total, itemId }) => {
+        console.error(
+          `[worker-record-replay] tuple=${completed}/${total} repo=${repoSlug} item=${itemId}`,
+        );
+      },
+    });
+  }
+  console.log(JSON.stringify({ repoSlug, ...result, replay }));
+  return { ...result, replay };
 }
 
 function parseArgs(argv: string[]) {
@@ -43,6 +67,10 @@ function parseArgs(argv: string[]) {
     recordsUrl?: string;
     cursor?: number;
     maxBatches?: number;
+    replayProjections?: boolean;
+    replayItemIds?: string[];
+    maxReplayTuples?: number;
+    replayCursor?: number;
   } = {};
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -52,6 +80,16 @@ function parseArgs(argv: string[]) {
     else if (arg === "--records-url") result.recordsUrl = requiredValue(argv, ++index, arg);
     else if (arg === "--cursor") result.cursor = nonNegativeInteger(argv, ++index, arg);
     else if (arg === "--max-batches") result.maxBatches = positiveInteger(argv, ++index, arg);
+    else if (arg === "--replay-projections") result.replayProjections = true;
+    else if (arg === "--replay-item-ids")
+      result.replayItemIds = requiredValue(argv, ++index, arg)
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+    else if (arg === "--max-replay-tuples")
+      result.maxReplayTuples = positiveInteger(argv, ++index, arg);
+    else if (arg === "--replay-cursor")
+      result.replayCursor = nonNegativeInteger(argv, ++index, arg);
     else throw new Error(`Unknown argument: ${arg}`);
   }
   return result;

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -364,6 +364,99 @@ export async function ingestGitRecords(options: {
   };
 }
 
+export async function replayWorkerRecordProjections(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  repoSlug: string;
+  itemIds?: readonly string[];
+  maxTuples?: number;
+  cursor?: number;
+  fetch?: typeof globalThis.fetch;
+  onTuple?: (progress: { completed: number; total: number; itemId: string }) => void;
+}) {
+  const snapshot = await exportWorkerRecords({
+    baseUrl: options.baseUrl,
+    webhookSecret: options.webhookSecret,
+    repoSlug: options.repoSlug,
+    fetch: options.fetch,
+  });
+  const byKey = new Map(
+    snapshot.records.map((record) => [`${record.section}/${record.id}`, record]),
+  );
+  const selectedIds = options.itemIds?.length
+    ? [...new Set(options.itemIds.map(validateTupleItemId))].sort(compareNumericText)
+    : [
+        ...new Set(
+          snapshot.records.flatMap((record) => (record.section === "commits" ? [] : [record.id])),
+        ),
+      ].sort(compareNumericText);
+  const maximum = options.maxTuples ?? selectedIds.length;
+  if (!Number.isSafeInteger(maximum) || maximum < 1) {
+    throw new Error("Replay tuple limit must be a positive integer");
+  }
+  const cursor = options.cursor ?? 0;
+  if (!Number.isSafeInteger(cursor) || cursor < 0 || cursor > selectedIds.length) {
+    throw new Error("Replay tuple cursor must be a valid zero-based offset");
+  }
+  const ids = selectedIds.slice(cursor, cursor + maximum);
+  let deduped = 0;
+  for (let index = 0; index < ids.length; index += 1) {
+    const itemId = ids[index]!;
+    const operations = (["items", "closed", "plans", "decision-packets"] as const).map(
+      (section) => {
+        const record = byKey.get(`${section}/${itemId}`);
+        const extension = section === "decision-packets" ? "json" : "md";
+        const path = `records/${options.repoSlug}/${section}/${itemId}.${extension}`;
+        if (!record || record.deleted) return { path, expectedDigest: null };
+        if (record.content === null || record.digest === null) {
+          throw new Error(`Worker replay record is missing content: ${section}/${itemId}`);
+        }
+        return {
+          path,
+          expectedDigest: record.digest,
+          contentBase64: Buffer.from(record.content).toString("base64"),
+        };
+      },
+    );
+    const contentHash = createHash("sha256")
+      .update(JSON.stringify({ repoSlug: options.repoSlug, itemId, operations }))
+      .digest("hex");
+    const response = await signedPost<{ deduped?: boolean }>({
+      baseUrl: options.baseUrl,
+      path: "/internal/state/records/tuples",
+      webhookSecret: options.webhookSecret,
+      body: {
+        deliveryId: `record-replay:${options.repoSlug}:${itemId}:${contentHash}`,
+        key: `${options.repoSlug}/${itemId}`,
+        operations,
+      },
+      fetch: options.fetch,
+    });
+    if (response.deduped === true) deduped += 1;
+    options.onTuple?.({ completed: index + 1, total: ids.length, itemId });
+  }
+  const completedCursor = cursor + ids.length;
+  return {
+    replayed: ids.length,
+    deduped,
+    available: selectedIds.length,
+    cursor,
+    nextCursor: completedCursor < selectedIds.length ? completedCursor : null,
+    revision: snapshot.revision,
+  };
+}
+
+function validateTupleItemId(value: string) {
+  if (!/^[1-9]\d*$/.test(value) || !Number.isSafeInteger(Number(value))) {
+    throw new Error(`Invalid tuple item id: ${value}`);
+  }
+  return value;
+}
+
+function compareNumericText(left: string, right: string) {
+  return Number(left) - Number(right);
+}
+
 export function recordTreeDigests(root: string, repoSlug: string) {
   return new Map(
     collectGitRecords(root, repoSlug).map((record) => [

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
@@ -8,13 +9,9 @@ import {
   ExactReviewBatchQueueClient,
   type ExactReviewBatchQueueItem,
 } from "./exact-review-batch-queue-client.js";
-import { StatePublishContentionError } from "./git-publish.js";
-import { setStatePublishTelemetryObserver } from "./git-publish.js";
+import { runGit, setStatePublishTelemetryObserver } from "./git-publish.js";
 import { exactReviewBatchStateWriterProgressReporter } from "./exact-review-batch-state-writer-progress.js";
-import {
-  commitPreparedStateBatch,
-  type StateBatchQuarantinedItem,
-} from "./state-publication-batch.js";
+import { postDirectPublicationResult } from "./exact-review-direct-publication.js";
 import { StateWriterTelemetryRecorder } from "./state-writer-telemetry-recorder.js";
 import type { StateWriterOperation } from "../state-writer-telemetry.js";
 import {
@@ -165,7 +162,6 @@ async function commit() {
   const superseded: ExactReviewBatchCompletion[] = [];
   const commitMembers: ExactReviewBatchQueueItem[] = [];
   const plans: PreparedStateMutationPlan[] = [];
-  const outcomePathByItemKey = new Map<string, string>();
   for (const manifestItem of manifest.items) {
     const current = active.get(manifestItem.itemKey);
     if (!current || !existsSync(manifestItem.outcomePath)) continue;
@@ -190,12 +186,9 @@ async function commit() {
     }
     commitMembers.push(current);
     plans.push(plan);
-    outcomePathByItemKey.set(current.itemKey, manifestItem.outcomePath);
   }
 
-  let stateCommitSha: string | undefined;
   let stateWriter: StateWriterOperation | undefined;
-  let quarantined: readonly StateBatchQuarantinedItem[] = [];
   const progressObserver = exactReviewBatchStateWriterProgressReporter({
     queueUrl: env("EXACT_REVIEW_QUEUE_URL"),
     webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
@@ -216,25 +209,16 @@ async function commit() {
   const resetTelemetry = recorder ? setStatePublishTelemetryObserver(recorder) : () => undefined;
   try {
     if (plans.length) {
-      const committed = commitPreparedStateBatch({
-        batchId: manifest.batchId,
-        plans,
-      });
-      stateCommitSha = committed.commitSha ?? undefined;
-      if (committed.outcome === "committed")
-        recorder?.recordMaterializedCommit(committed.itemCount);
-      recorder?.finalize(committed.outcome === "committed" ? "materialized" : "unchanged");
+      await publishCanonicalBatch(plans);
+      recorder?.recordMaterializedCommit(plans.length);
+      recorder?.finalize("materialized");
       stateWriter = recorder?.toTerminalObject() ?? undefined;
-      quarantined = committed.quarantinedItems;
     }
   } catch (error) {
-    recorder?.finalize(
-      error instanceof StatePublishContentionError ? "contention_timeout" : "failed",
-    );
+    recorder?.finalize("failed");
     stateWriter = recorder?.toTerminalObject() ?? undefined;
     const fingerprint = failureFingerprint(error);
-    const reasonCode =
-      error instanceof StatePublishContentionError ? "state_contention" : "unknown_failure";
+    const reasonCode = "unknown_failure";
     const retryable = commitMembers.map((member) => ({
       ...member,
       terminalOutcome: "retryable_failure" as const,
@@ -258,45 +242,6 @@ async function commit() {
   } finally {
     resetTelemetry();
   }
-  if (quarantined.length) {
-    const quarantineReasons = new Map(quarantined.map((item) => [item.itemKey, item.reason]));
-    const quarantinedCompletions = commitMembers
-      .filter((member) => quarantineReasons.has(member.itemKey))
-      .map((member) =>
-        retryableCompletion(
-          member,
-          "state_conflict_quarantined",
-          failureFingerprint(new Error(quarantineReasons.get(member.itemKey))),
-        ),
-      );
-    try {
-      await acknowledge(manifest, quarantinedCompletions);
-    } catch (releaseError) {
-      console.error(
-        `Failed to acknowledge quarantined batch items: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
-      );
-    }
-  }
-  const quarantinedItemKeys = new Set(quarantined.map((item) => item.itemKey));
-  for (const itemKey of quarantinedItemKeys) {
-    const outcomePath = outcomePathByItemKey.get(itemKey);
-    if (!outcomePath || !existsSync(outcomePath)) continue;
-    const outcome = objectValue(JSON.parse(readFileSync(outcomePath, "utf8")));
-    // A quarantined item's local outcome file still says kind: "eligible"; the
-    // workflow's post-commit loop reads that file directly (not this receipt) to
-    // decide whether to dispatch comment-router or requeue effects, so it must be
-    // corrected here or the loop will run post-effects for state that was never
-    // committed.
-    writeFileSync(
-      outcomePath,
-      `${JSON.stringify(
-        { ...outcome, kind: "retryable_failure", reasonCode: "state_conflict_quarantined" },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-  }
   const receiptPath = batchReceiptPath();
   mkdirSync(dirname(receiptPath), { recursive: true });
   writeFileSync(
@@ -304,10 +249,8 @@ async function commit() {
     `${JSON.stringify(
       {
         batchId: manifest.batchId,
-        stateCommitSha: stateCommitSha ?? null,
-        publishedItemKeys: plans
-          .map((plan) => plan.identity.itemKey)
-          .filter((itemKey) => !quarantinedItemKeys.has(itemKey)),
+        stateCommitSha: null,
+        publishedItemKeys: plans.map((plan) => plan.identity.itemKey),
         stateWriter: stateWriter ?? null,
       },
       null,
@@ -319,12 +262,47 @@ async function commit() {
     JSON.stringify({
       ok: true,
       batch_id: manifest.batchId,
-      state_commit_sha: stateCommitSha ?? null,
-      materialized: plans.length - quarantined.length,
-      quarantined: quarantined.length,
+      state_commit_sha: null,
+      materialized: plans.length,
+      quarantined: 0,
       superseded: superseded.length,
     }),
   );
+}
+
+async function publishCanonicalBatch(plans: readonly PreparedStateMutationPlan[]): Promise<void> {
+  for (const plan of plans) {
+    const operations = plan.operations.map((operation) => {
+      if (operation.targetOid === null) return { ...operation };
+      const content = runGit(["cat-file", "blob", operation.targetOid], { quiet: true });
+      if (Buffer.byteLength(content) !== operation.bytes) {
+        throw new Error(`Prepared blob size changed for ${operation.path}`);
+      }
+      return { ...operation, contentBase64: Buffer.from(content).toString("base64") };
+    });
+    const result = await postDirectPublicationResult({
+      baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
+      webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
+      path: "/internal/exact-review/publication-batch-results",
+      payload: {
+        itemKey: plan.identity.itemKey,
+        revision: plan.identity.revision,
+        identity: { ...plan.identity },
+        operations,
+        totalBytes: plan.totalBytes,
+      },
+    });
+    if (result.kind !== "accepted") {
+      throw new Error(
+        `Canonical exact-review publication failed for ${plan.identity.itemKey}: ${result.reason}`,
+      );
+    }
+    if (result.response.superseded === true) {
+      throw new Error(
+        `Canonical exact-review publication was superseded: ${plan.identity.itemKey}`,
+      );
+    }
+  }
 }
 
 async function complete() {

--- a/src/repair/exact-review-direct-publication.ts
+++ b/src/repair/exact-review-direct-publication.ts
@@ -60,6 +60,9 @@ export async function postDirectPublicationResult(options: {
   attempts?: number;
   fetch?: typeof globalThis.fetch;
   sleep?: (milliseconds: number) => Promise<void>;
+  path?:
+    | "/internal/exact-review/publication-results"
+    | "/internal/exact-review/publication-batch-results";
 }): Promise<DirectPublicationPostResult> {
   const baseUrl = options.baseUrl.replace(/\/$/, "");
   if (!baseUrl.startsWith("https://")) throw new Error("Direct publication URL must use HTTPS");
@@ -82,15 +85,18 @@ export async function postDirectPublicationResult(options: {
   let lastStatus: number | undefined;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      const response = await request(`${baseUrl}/internal/exact-review/publication-results`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-clawsweeper-exact-review-signature": signature,
+      const response = await request(
+        `${baseUrl}${options.path ?? "/internal/exact-review/publication-results"}`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-clawsweeper-exact-review-signature": signature,
+          },
+          body,
+          signal: AbortSignal.timeout(20_000),
         },
-        body,
-        signal: AbortSignal.timeout(20_000),
-      });
+      );
       lastStatus = response.status;
       const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
       if (

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -11,8 +11,11 @@ import {
   type PublishResult,
   type RebaseStrategy,
 } from "./git-publish.js";
+import { recordTuplePaths, validateRecordTuple, type RecordTupleContents } from "./record-tuple.js";
 import {
+  postCanonicalRecordTuple,
   postStateAppend,
+  type CanonicalRecordTupleMutation,
   type StateAppendInputRecord,
   type StateAppendResult,
 } from "./state-append-client.js";
@@ -39,6 +42,11 @@ type StateAppendPlan = {
   records: StateAppendInputRecord[];
 };
 
+type CanonicalRecordPlan = {
+  mutations: CanonicalRecordTupleMutation[];
+  remainingPaths: string[];
+};
+
 const SWEEP_STATUS_DIRECTORY = "results/sweep-status";
 const SWEEP_STATUS_FILE_PATTERN = /^results\/sweep-status\/([A-Za-z0-9][A-Za-z0-9_.-]*)\.json$/;
 const COMMENT_ROUTER_LEDGER_PATH = "results/comment-router.json";
@@ -50,34 +58,55 @@ export async function publishMainWithStateAppend(
 ): Promise<PublishResult | "appended"> {
   const env = runtime.env ?? process.env;
   const publishGit = runtime.publishGit ?? publishMainCommit;
+  const root = runtime.root ?? process.cwd();
   const queueUrl = env.QUEUE_URL ?? "";
   const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  const canonicalPlan = planCanonicalRecordTuples(
+    options.paths,
+    root,
+    env.CLAWSWEEPER_STATE_DIR,
+    env,
+  );
+  if (canonicalPlan.mutations.length > 0) {
+    if (env.CLAWSWEEPER_STATE_APPEND_ENABLED !== "1" || !queueUrl || !webhookSecret) {
+      throw new Error("canonical record publication is required for record tuple changes");
+    }
+    for (const mutation of canonicalPlan.mutations) {
+      await postCanonicalRecordTuple({
+        queueUrl,
+        webhookSecret,
+        mutation,
+        ...(runtime.fetchImpl ? { fetchImpl: runtime.fetchImpl } : {}),
+      });
+    }
+  }
+  const canonicalAppended = canonicalPlan.mutations.length > 0;
+  const publicationOptions = { ...options, paths: canonicalPlan.remainingPaths };
+  if (publicationOptions.paths.length === 0) {
+    console.log(`Appended ${canonicalPlan.mutations.length} canonical record tuple(s)`);
+    return "appended";
+  }
   if (env.CLAWSWEEPER_STATE_APPEND_ENABLED !== "1" || !queueUrl || !webhookSecret) {
-    return publishGit(options);
+    return publishGit(publicationOptions);
   }
 
   let plan: StateAppendPlan;
   try {
-    plan = planStateAppend(
-      options.paths,
-      runtime.root ?? process.cwd(),
-      env.CLAWSWEEPER_STATE_DIR,
-      runtime.now,
-    );
+    plan = planStateAppend(publicationOptions.paths, root, env.CLAWSWEEPER_STATE_DIR, runtime.now);
   } catch {
     console.warn("state-append shed/failed; falling back to git publish");
-    return publishGit(options);
+    return publishGit(publicationOptions);
   }
-  if (plan.records.length === 0) return publishGit(options);
+  if (plan.records.length === 0) return publishGit(publicationOptions);
 
-  const remainingPaths = options.paths.filter((path) => !plan.consumedPaths.has(path));
+  const remainingPaths = publicationOptions.paths.filter((path) => !plan.consumedPaths.has(path));
   // Router replay is crash-recoverable through deterministic job paths, stable
   // dispatch keys, and live-run/status reconciliation. Publish those outputs
   // first so an interrupted append is retried instead of suppressing missing work.
   const publishRemainingFirst =
     remainingPaths.length > 0 && plan.records.some((record) => record.kind === "comment_router");
   const remainingResult = publishRemainingFirst
-    ? publishGit({ ...options, paths: remainingPaths })
+    ? publishGit({ ...publicationOptions, paths: remainingPaths })
     : undefined;
   const contentHash = stateAppendContentHash(plan.records);
   const deliveryId = `router:${stateAppendLane(plan.records)}-${deliveryPart(env.GITHUB_RUN_ID, "local")}-${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}-${contentHash}`;
@@ -93,17 +122,145 @@ export async function publishMainWithStateAppend(
     });
   } catch {
     console.warn("state-append shed/failed; falling back to git publish");
-    return publishGit(options);
+    return publishGit(publicationOptions);
   }
   if (!appendResult.ok || appendResult.shed) {
     console.warn("state-append shed/failed; falling back to git publish");
-    return publishGit(options);
+    return publishGit(publicationOptions);
   }
 
   if (remainingResult) return remainingResult;
-  if (remainingPaths.length > 0) return publishGit({ ...options, paths: remainingPaths });
-  console.log(`Appended ${plan.records.length} state record(s) to durable state`);
+  if (remainingPaths.length > 0)
+    return publishGit({ ...publicationOptions, paths: remainingPaths });
+  console.log(
+    `Appended ${plan.records.length} state record(s) and ${canonicalAppended ? canonicalPlan.mutations.length : 0} canonical tuple(s) to durable state`,
+  );
   return "appended";
+}
+
+const RECORD_TUPLE_PATH =
+  /^records\/([A-Za-z0-9][A-Za-z0-9_.-]*)\/(items|closed|plans|decision-packets)\/([1-9]\d*)\.(md|json)$/;
+const RECORD_TUPLE_SECTIONS = ["items", "closed", "plans", "decision-packets"] as const;
+
+function planCanonicalRecordTuples(
+  requestedPaths: readonly string[],
+  root: string,
+  stateRoot: string | undefined,
+  env: NodeJS.ProcessEnv,
+): CanonicalRecordPlan {
+  const recordRequests = requestedPaths.filter((path) => isRecordsPath(normalizedPath(path)));
+  if (recordRequests.length === 0) {
+    return { mutations: [], remainingPaths: [...requestedPaths] };
+  }
+  if (!stateRoot) throw new Error("record publication requires a hydrated state checkout");
+  const localFiles = collectRequestedRecordFiles(root, recordRequests);
+  const stateFiles = collectRequestedRecordFiles(stateRoot, recordRequests);
+  const changedPaths = new Set(
+    [...new Set([...localFiles.keys(), ...stateFiles.keys()])].filter(
+      (path) => localFiles.get(path) !== stateFiles.get(path),
+    ),
+  );
+  const changedTupleKeys = new Set<string>();
+  for (const path of changedPaths) {
+    const match = RECORD_TUPLE_PATH.exec(path);
+    if (match && (match[2] === "decision-packets") === (match[4] === "json")) {
+      changedTupleKeys.add(`${match[1]}/${match[3]}`);
+    } else if (/^records\/[^/]+\/(?:items|closed|plans|decision-packets)\//.test(path)) {
+      throw new Error(`record tuple path is not canonically addressable: ${path}`);
+    }
+  }
+  const mutations = [...changedTupleKeys].sort().map((key) => {
+    const [repository, number] = key.split("/");
+    if (!repository || !number) throw new Error(`invalid canonical tuple key: ${key}`);
+    const paths = recordTuplePaths({ repository, number });
+    const localContent = (path: string) =>
+      localFiles.has(path) ? localFiles.get(path)! : readOptionalRecordFile(root, path);
+    const stateContent = (path: string) =>
+      stateFiles.has(path) ? stateFiles.get(path)! : readOptionalRecordFile(stateRoot, path);
+    const tuple: RecordTupleContents = {
+      paths,
+      item: localContent(paths.item),
+      closed: localContent(paths.closed),
+      plan: localContent(paths.plan),
+      packet: localContent(paths.packet),
+    };
+    validateRecordTuple(tuple, "canonical publication tuple");
+    const operations = RECORD_TUPLE_SECTIONS.map((section) => {
+      const path =
+        section === "items"
+          ? paths.item
+          : section === "closed"
+            ? paths.closed
+            : section === "plans"
+              ? paths.plan
+              : paths.packet;
+      const content = localContent(path);
+      const expected = stateContent(path);
+      return {
+        path,
+        expectedDigest: expected === null ? null : sha256(expected),
+        ...(content === null ? {} : { contentBase64: Buffer.from(content).toString("base64") }),
+      };
+    });
+    const contentHash = createHash("sha256")
+      .update(JSON.stringify({ key, operations }))
+      .digest("hex");
+    return {
+      deliveryId: `record-tuple:${deliveryPart(env.GITHUB_RUN_ID, "local")}:${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}:${contentHash}`,
+      key,
+      operations,
+    };
+  });
+  const remainingPaths = requestedPaths.flatMap((requestedPath) => {
+    const normalized = normalizedPath(requestedPath);
+    if (!isRecordsPath(normalized)) return [requestedPath];
+    const coveredChanges = [...changedPaths].filter(
+      (path) => path === normalized || path.startsWith(`${normalized}/`),
+    );
+    const otherChanges = coveredChanges.filter((path) => !RECORD_TUPLE_PATH.test(path));
+    if (coveredChanges.some((path) => RECORD_TUPLE_PATH.test(path))) return otherChanges;
+    return [requestedPath];
+  });
+  return { mutations, remainingPaths: [...new Set(remainingPaths)] };
+}
+
+function isRecordsPath(path: string): boolean {
+  return path === "records" || path.startsWith("records/");
+}
+
+function readOptionalRecordFile(root: string, path: string): string | null {
+  const absolute = resolve(root, path);
+  if (!existsSync(absolute)) return null;
+  return readContainedRegularFile(root, path);
+}
+
+function collectRequestedRecordFiles(root: string, requestedPaths: readonly string[]) {
+  const files = new Map<string, string>();
+  for (const requestedPath of requestedPaths) {
+    collectRecordFiles(root, normalizedPath(requestedPath), files);
+  }
+  return files;
+}
+
+function collectRecordFiles(root: string, relativePath: string, files: Map<string, string>): void {
+  const absolute = resolve(root, relativePath);
+  if (!existsSync(absolute)) return;
+  const stat = lstatSync(absolute);
+  if (stat.isSymbolicLink())
+    throw new Error(`record publication path is symbolic: ${relativePath}`);
+  if (stat.isFile()) {
+    files.set(relativePath, readContainedRegularFile(root, relativePath));
+    return;
+  }
+  if (!stat.isDirectory())
+    throw new Error(`record publication path is not regular: ${relativePath}`);
+  for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+    collectRecordFiles(root, `${relativePath}/${entry.name}`, files);
+  }
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
 }
 
 function planStateAppend(

--- a/src/repair/state-append-client.ts
+++ b/src/repair/state-append-client.ts
@@ -12,6 +12,18 @@ export type StateAppendResult = {
   shed: boolean;
 };
 
+export type CanonicalRecordTupleOperation = {
+  path: string;
+  expectedDigest: string | null;
+  contentBase64?: string;
+};
+
+export type CanonicalRecordTupleMutation = {
+  deliveryId: string;
+  key: string;
+  operations: CanonicalRecordTupleOperation[];
+};
+
 export async function postStateAppend(options: {
   queueUrl: string;
   webhookSecret: string;
@@ -51,6 +63,53 @@ export async function postStateAppend(options: {
       throw new Error("POST /internal/state/append returned an invalid response");
     }
     return { ok: value.ok, shed: false };
+  } catch (error) {
+    throw new Error(redactStateAppendSecrets(errorMessage(error)));
+  }
+}
+
+export async function postCanonicalRecordTuple(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  mutation: CanonicalRecordTupleMutation;
+  fetchImpl?: typeof fetch;
+}): Promise<{ revision: number; sequence: number; deduped: boolean }> {
+  registerStateAppendSecretForRedaction(options.webhookSecret);
+  try {
+    const queueUrl = options.queueUrl.replace(/\/+$/, "");
+    if (!queueUrl) throw new Error("canonical record queue URL is required");
+    if (!options.webhookSecret) throw new Error("canonical record webhook secret is required");
+    const body = JSON.stringify(options.mutation);
+    const signature = `sha256=${createHmac("sha256", options.webhookSecret)
+      .update(body)
+      .digest("hex")}`;
+    const response = await (options.fetchImpl ?? fetch)(
+      `${queueUrl}/internal/state/records/tuples`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        body,
+      },
+    );
+    const value = (await response.json().catch(() => null)) as unknown;
+    if (!response.ok || !isRecord(value) || value.ok !== true) {
+      const code = isRecord(value) ? String(value.error || "unknown_error") : "invalid_response";
+      throw new Error(`POST /internal/state/records/tuples returned ${response.status}: ${code}`);
+    }
+    const revision = Number(value.revision);
+    const sequence = Number(value.sequence);
+    if (
+      !Number.isSafeInteger(revision) ||
+      revision < 1 ||
+      !Number.isSafeInteger(sequence) ||
+      sequence < 1
+    ) {
+      throw new Error("POST /internal/state/records/tuples returned an invalid receipt");
+    }
+    return { revision, sequence, deduped: value.deduped === true };
   } catch (error) {
     throw new Error(redactStateAppendSecrets(errorMessage(error)));
   }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2064,6 +2064,41 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     });
   }
 
+  const batchLeased = leasedExactReviewQueueItem(702, "7020");
+  batchLeased.revision = 4;
+  batchLeased.leaseRevision = 4;
+  batchLeased.claimGeneration = 2;
+  const queueState = (await storage.get("exact-review-queue")) as {
+    items: Record<string, typeof batchLeased>;
+  };
+  queueState.items[batchLeased.key] = batchLeased;
+  await storage.put("exact-review-queue", queueState);
+  const batchPayload = {
+    ...payload,
+    itemKey: "openclaw/openclaw#702",
+    identity: { itemKey: "openclaw/openclaw#702", revision: 4, claimGeneration: 2 },
+    operations: [
+      {
+        ...payload.operations[0],
+        path: "records/openclaw-openclaw/items/702.md",
+      },
+    ],
+  };
+  const batchBody = JSON.stringify(batchPayload);
+  const batchSignature = `sha256=${createHmac("sha256", "test-secret").update(batchBody).digest("hex")}`;
+  const batchResponse = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publication-batch-results", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": batchSignature },
+      body: batchBody,
+    }),
+    env,
+  );
+  assert.equal(batchResponse.status, 202);
+  assert.equal((await batchResponse.json()).accepted, true);
+  const afterBatch = (await storage.get("exact-review-queue")) as typeof queueState;
+  assert.equal(afterBatch.items[batchLeased.key]?.state, "leased");
+
   const recordUrl =
     "https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/items/701";
   const unsignedRecord = await worker.fetch(new Request(recordUrl), env);
@@ -2108,6 +2143,12 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
       digest: createHash("sha256").update("x").digest("hex"),
       revision: 4,
       updatedAt: listing.records[0].updatedAt,
+    },
+    {
+      id: 702,
+      digest: createHash("sha256").update("x").digest("hex"),
+      revision: 4,
+      updatedAt: listing.records[1].updatedAt,
     },
   ]);
   assert.equal(listing.nextCursor, null);
@@ -8117,6 +8158,65 @@ test("state append is idempotent by delivery and reports bounded-window stats", 
     max_pending_rows: 50_000,
     max_pending_bytes: 100 * 1024 * 1024,
   });
+});
+
+test("canonical tuple publication updates Worker authority and appends one projection", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const item =
+    "---\nrepo: openclaw/openclaw\nnumber: 42\nreviewed_at: 2026-07-26T02:00:00.000Z\n---\n\nreview\n";
+  const mutation = {
+    deliveryId: "record-tuple:run-1:42",
+    key: "openclaw-openclaw/42",
+    operations: [
+      {
+        path: "records/openclaw-openclaw/items/42.md",
+        expectedDigest: null,
+        contentBase64: Buffer.from(item).toString("base64"),
+      },
+      { path: "records/openclaw-openclaw/closed/42.md", expectedDigest: null },
+      { path: "records/openclaw-openclaw/plans/42.md", expectedDigest: null },
+      { path: "records/openclaw-openclaw/decision-packets/42.json", expectedDigest: null },
+    ],
+  };
+
+  const first = await queue.fetch(stateAppendQueueRequest("/records/tuples", mutation));
+  assert.equal(first.status, 202);
+  assert.deepEqual(await first.json(), {
+    ok: true,
+    accepted: true,
+    deduped: false,
+    revision: 1,
+    sequence: 1,
+  });
+  const duplicate = await queue.fetch(stateAppendQueueRequest("/records/tuples", mutation));
+  assert.equal(duplicate.status, 202);
+  assert.equal((await duplicate.json()).deduped, true);
+
+  const canonical = await (
+    await queue.fetch(
+      new Request("https://queue/records/openclaw-openclaw/items/42", { method: "GET" }),
+    )
+  ).json();
+  assert.equal(canonical.content, item);
+  assert.equal(canonical.digest, createHash("sha256").update(item).digest("hex"));
+  assert.equal(canonical.revision, 1);
+
+  const drained = await (
+    await queue.fetch(
+      stateAppendQueueRequest("/state/drain", { max_rows: 10, max_bytes: 1024 * 1024 }),
+    )
+  ).json();
+  assert.equal(drained.records.length, 1);
+  assert.equal(drained.records[0].kind, "record_tuple");
+  assert.equal(drained.records[0].key, "openclaw-openclaw/42");
+  assert.equal(drained.records[0].payload.operations.length, 4);
+
+  const conflict = structuredClone(mutation);
+  conflict.deliveryId = "record-tuple:run-2:42";
+  conflict.operations[0]!.expectedDigest = "0".repeat(64);
+  const rejected = await queue.fetch(stateAppendQueueRequest("/records/tuples", conflict));
+  assert.equal(rejected.status, 409);
+  assert.equal((await rejected.json()).error, "canonical_record_tuple_conflict");
 });
 
 test("state append sheds atomically at the configured cap without consuming its receipt", async () => {

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -199,16 +199,12 @@ test("batch failure cleanup completes manifest fences without a queue fetch", ()
   assert.doesNotMatch(releaseSource, /client\.fetch/);
 });
 
-test("batch commit rewrites quarantined outcome files before the receipt is written", () => {
+test("batch commit publishes every prepared tuple to canonical Worker state", () => {
   const commitSource = /async function commit\(\) \{([\s\S]*?)\n\}/.exec(cliSource)?.[1] ?? "";
-  assert.match(
-    commitSource,
-    /outcomePathByItemKey\.set\(current\.itemKey, manifestItem\.outcomePath\)/,
-  );
-  const quarantineRewrite = commitSource.indexOf("for (const itemKey of quarantinedItemKeys)");
-  const receiptWrite = commitSource.indexOf("const receiptPath = batchReceiptPath();");
-  assert.ok(quarantineRewrite >= 0 && receiptWrite >= 0 && quarantineRewrite < receiptWrite);
-  const rewriteWindow = commitSource.slice(quarantineRewrite, receiptWrite);
-  assert.match(rewriteWindow, /kind: "retryable_failure"/);
-  assert.match(rewriteWindow, /reasonCode: "state_conflict_quarantined"/);
+  assert.match(commitSource, /await publishCanonicalBatch\(plans\)/);
+  assert.match(cliSource, /postDirectPublicationResult/);
+  assert.match(cliSource, /publication-batch-results/);
+  assert.match(cliSource, /runGit\(\["cat-file", "blob", operation\.targetOid\]/);
+  assert.doesNotMatch(cliSource, /commitPreparedStateBatch/);
+  assert.doesNotMatch(cliSource, /state-publication-batch/);
 });

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -12,6 +12,77 @@ const statusPath = "results/sweep-status/openclaw-openclaw.json";
 const routerPath = "results/comment-router.json";
 const proofPath = `ledger/v1/import-bindings/events/${"a".repeat(64)}.json`;
 const oversizedProofPath = `ledger/v1/import-bindings/events/${"b".repeat(64)}.json`;
+const tupleRoot = "records/openclaw-openclaw";
+const tupleItemPath = `${tupleRoot}/items/42.md`;
+
+test("publish-main appends changed record tuples canonically and never invokes git", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-state-"));
+  const before = recordMarkdown("2026-07-26T01:00:00.000Z", "before");
+  const after = recordMarkdown("2026-07-26T02:00:00.000Z", "after");
+  writeText(stateRoot, tupleItemPath, before);
+  writeText(root, tupleItemPath, after);
+  const gitPublishes: GitPublishOptions[] = [];
+  let posted: Record<string, unknown> | undefined;
+
+  const result = await publishMainWithStateAppend(
+    { message: "chore: update sweep records", paths: [tupleRoot] },
+    {
+      root,
+      env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+      fetchImpl: (async (input: string | URL | Request, init?: RequestInit) => {
+        assert.equal(input.toString(), "https://queue.test/internal/state/records/tuples");
+        posted = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+        return Response.json(
+          { ok: true, accepted: true, deduped: false, revision: 7, sequence: 11 },
+          { status: 202 },
+        );
+      }) as typeof fetch,
+      publishGit: capturePublishes(gitPublishes),
+    },
+  );
+
+  assert.equal(result, "appended");
+  assert.equal(gitPublishes.length, 0);
+  assert.equal(posted?.key, "openclaw-openclaw/42");
+  assert.match(String(posted?.deliveryId), /^record-tuple:1234:2:[a-f0-9]{64}$/);
+  assert.deepEqual(posted?.operations, [
+    {
+      path: tupleItemPath,
+      expectedDigest: createHash("sha256").update(before).digest("hex"),
+      contentBase64: Buffer.from(after).toString("base64"),
+    },
+    { path: `${tupleRoot}/closed/42.md`, expectedDigest: null },
+    { path: `${tupleRoot}/plans/42.md`, expectedDigest: null },
+    { path: `${tupleRoot}/decision-packets/42.json`, expectedDigest: null },
+  ]);
+});
+
+test("publish-main fails closed when canonical tuple publication is rejected", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-state-"));
+  writeText(stateRoot, tupleItemPath, recordMarkdown("2026-07-26T01:00:00.000Z", "before"));
+  writeText(root, tupleItemPath, recordMarkdown("2026-07-26T02:00:00.000Z", "after"));
+  const gitPublishes: GitPublishOptions[] = [];
+
+  await assert.rejects(
+    publishMainWithStateAppend(
+      { message: "chore: update sweep records", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+        fetchImpl: (async () =>
+          Response.json(
+            { error: "canonical_record_tuple_conflict" },
+            { status: 409 },
+          )) as typeof fetch,
+        publishGit: capturePublishes(gitPublishes),
+      },
+    ),
+    /canonical_record_tuple_conflict/,
+  );
+  assert.equal(gitPublishes.length, 0);
+});
 
 test("publish-main appends sweep status instead of invoking the git publisher", async () => {
   const root = statusFixture();
@@ -344,6 +415,10 @@ function routerLedger(): Record<string, unknown> {
       },
     ],
   };
+}
+
+function recordMarkdown(reviewedAt: string, body: string): string {
+  return `---\nrepo: openclaw/openclaw\nnumber: 42\nreviewed_at: ${reviewedAt}\n---\n\n${body}\n`;
 }
 
 function appendEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {

--- a/test/repair/state-append-client.test.ts
+++ b/test/repair/state-append-client.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
 import test from "node:test";
 
-import { postStateAppend } from "../../dist/repair/state-append-client.js";
+import {
+  postCanonicalRecordTuple,
+  postStateAppend,
+} from "../../dist/repair/state-append-client.js";
 
 const webhookSecret = "state-append-test-secret";
 const records = [
@@ -13,6 +16,46 @@ const records = [
     produced_at: "2026-07-21T12:00:00.000Z",
   },
 ];
+
+test("postCanonicalRecordTuple signs the canonical tuple endpoint", async () => {
+  const mutation = {
+    deliveryId: "record-tuple:run:1:digest",
+    key: "openclaw-openclaw/42",
+    operations: [
+      {
+        path: "records/openclaw-openclaw/items/42.md",
+        expectedDigest: null,
+        contentBase64: Buffer.from("item\n").toString("base64"),
+      },
+      { path: "records/openclaw-openclaw/closed/42.md", expectedDigest: null },
+      { path: "records/openclaw-openclaw/plans/42.md", expectedDigest: null },
+      { path: "records/openclaw-openclaw/decision-packets/42.json", expectedDigest: null },
+    ],
+  };
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    assert.equal(input.toString(), "https://queue.test/internal/state/records/tuples");
+    const body = String(init?.body ?? "");
+    assert.deepEqual(JSON.parse(body), mutation);
+    assert.equal(
+      new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"),
+      `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`,
+    );
+    return Response.json(
+      { ok: true, accepted: true, deduped: false, revision: 3, sequence: 9 },
+      { status: 202 },
+    );
+  }) as typeof fetch;
+
+  assert.deepEqual(
+    await postCanonicalRecordTuple({
+      queueUrl: "https://queue.test",
+      webhookSecret,
+      mutation,
+      fetchImpl,
+    }),
+    { revision: 3, sequence: 9, deduped: false },
+  );
+});
 
 test("postStateAppend signs and posts the exact append body", async () => {
   const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -9,7 +9,11 @@ import { parse } from "yaml";
 
 import { hydrateState } from "../scripts/hydrate-state.ts";
 import { verifyWorkerRecordParity } from "../scripts/verify-worker-record-parity.ts";
-import { ingestGitRecords, type WorkerRecord } from "../scripts/worker-records.ts";
+import {
+  ingestGitRecords,
+  replayWorkerRecordProjections,
+  type WorkerRecord,
+} from "../scripts/worker-records.ts";
 
 const repoSlug = "openclaw-openclaw";
 const commitId = "c".repeat(40);
@@ -255,6 +259,63 @@ test("backfill importer walks all record sections and sends digest-bearing rows"
   }
 });
 
+test("canonical projection replay re-appends a complete tuple without overwriting from git", async () => {
+  const item = contents.get("items/1")!;
+  const packet = contents.get("decision-packets/1")!;
+  const requests: Array<Record<string, unknown>> = [];
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input.toString());
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    if (url.pathname === "/internal/state/records/export") {
+      return Response.json({
+        repoSlug,
+        revision: 4,
+        nextCursor: null,
+        records: [
+          workerRecord("items", "1", item, 1),
+          workerRecord("decision-packets", "1", packet, 2),
+        ],
+      });
+    }
+    assert.equal(url.pathname, "/internal/state/records/tuples");
+    requests.push(body);
+    return Response.json({ ok: true, accepted: true, deduped: false, revision: 2, sequence: 9 });
+  }) as typeof fetch;
+
+  const result = await replayWorkerRecordProjections({
+    baseUrl: "https://worker.example",
+    webhookSecret: "fixture-secret",
+    repoSlug,
+    itemIds: ["1"],
+    fetch: fetchImpl,
+  });
+
+  assert.deepEqual(result, {
+    replayed: 1,
+    deduped: 0,
+    available: 1,
+    cursor: 0,
+    nextCursor: null,
+    revision: 4,
+  });
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.key, `${repoSlug}/1`);
+  assert.deepEqual(requests[0]?.operations, [
+    {
+      path: `records/${repoSlug}/items/1.md`,
+      expectedDigest: createHash("sha256").update(item).digest("hex"),
+      contentBase64: Buffer.from(item).toString("base64"),
+    },
+    { path: `records/${repoSlug}/closed/1.md`, expectedDigest: null },
+    { path: `records/${repoSlug}/plans/1.md`, expectedDigest: null },
+    {
+      path: `records/${repoSlug}/decision-packets/1.json`,
+      expectedDigest: createHash("sha256").update(packet).digest("hex"),
+      contentBase64: Buffer.from(packet).toString("base64"),
+    },
+  ]);
+});
+
 test("backfill workflow is manual per-target and setup-state plumbs the opt-in Worker flag", () => {
   const workflowSource = readFileSync(".github/workflows/backfill-worker-records.yml", "utf8");
   const workflow = parse(workflowSource) as {
@@ -266,12 +327,17 @@ test("backfill workflow is manual per-target and setup-state plumbs the opt-in W
   assert.ok(workflow.on?.workflow_dispatch?.inputs?.target_repo);
   assert.ok(workflow.on?.workflow_dispatch?.inputs?.cursor);
   assert.ok(workflow.on?.workflow_dispatch?.inputs?.max_batches);
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.replay_projections);
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.replay_item_ids);
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.max_replay_tuples);
+  assert.ok(workflow.on?.workflow_dispatch?.inputs?.replay_cursor);
   const setupState = workflow.jobs?.backfill?.steps?.find(
     (step) => step.uses === "./.github/actions/setup-state",
   );
   assert.equal(setupState?.with?.["records-source"], "git");
   assert.match(workflowSource, /scripts\/backfill-worker-records\.ts/);
   assert.match(workflowSource, /--cursor "\$BACKFILL_CURSOR"/);
+  assert.match(workflowSource, /--replay-projections --max-replay-tuples/);
   assert.match(workflowSource, /records\/\$\{\{ steps\.target\.outputs\.slug \}\}/);
 
   const action = readFileSync(".github/actions/setup-state/action.yml", "utf8");
@@ -376,6 +442,23 @@ function createStateFixture() {
   }
   write(path.join(stateRoot, "jobs", "fixture.json"), "{}\n");
   return { root, stateRoot };
+}
+
+function workerRecord(
+  section: WorkerRecord["section"],
+  id: string,
+  content: string,
+  storeRevision: number,
+): WorkerRecord {
+  return {
+    section,
+    id,
+    content,
+    digest: createHash("sha256").update(content).digest("hex"),
+    revision: 1,
+    storeRevision,
+    deleted: false,
+  };
 }
 
 function workerFetch(


### PR DESCRIPTION
Parity verification for the worker-records cutover exposed records that exist only in git (including recent items) and 193 content-drifted records. Root cause: the exact-review batch lane, sweep reconcile, and apply/checkpoint lanes still wrote records/ tuples directly to the state repo, competing with the canonical DO store.

Fix:
- New authenticated DO operation /internal/state/records/tuples: requires all four tuple sections, SHA-256 expected-digest fences, primary/sidecar + decision-packet consistency validation, monotonic canonical revisions, atomic canonical rows + export indexes + record_tuple append entry, idempotent via bounded delivery receipts, fails closed (never falls back to git).
- Batch CLI, sweep publish-main, and apply lanes post tuples canonically; tuple paths are removed from the git publication set (materializer remains the only git tuple writer).
- backfill-worker-records.yml gains canonical projection replay (replay_projections, replay_item_ids, max_replay_tuples, resumable replay_cursor) to converge already-drifted records without a blanket force overwrite.

Proof: focused suite 266/266; full pnpm check green; autoreview clean. Evidence trail: parity run 30233647700; state commits fc867e0367 / 36c2e6d68a show the batch lane rewriting canonical-owned records.

Requires a Worker deploy after merge (new DO endpoint).
