### PR TITLE
fix(state): replay handles partial and stale-primary canonical tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Made canonical record replay normalize revision-ordered legacy tuple remnants, continue after per-item validation rejections, and fail once at the end with every rejected item id.
 - Allowed stuck-placeholder recovery to label pull requests by granting its target token pull-request write permission alongside issue write. Thanks @masatohoshino! (#865)
 - Kept root-level apply reports as digest-only action-ledger evidence so ledger-enabled apply runs can finish, publish their compatibility report, and advance their cursor. Thanks @yetval! (#833)
 - Restored repair and spam workflows by keeping the multi-owner repair policy out of the GitHub App token action's single-owner input. Thanks @yetval! (#834)

--- a/scripts/backfill-worker-records.ts
+++ b/scripts/backfill-worker-records.ts
@@ -54,9 +54,20 @@ export async function backfillWorkerRecords(
           `[worker-record-replay] tuple=${completed}/${total} repo=${repoSlug} item=${itemId}`,
         );
       },
+      onTupleFailure: ({ completed, total, itemId, status, code }) => {
+        console.error(
+          `[worker-record-replay] rejected tuple=${completed}/${total} repo=${repoSlug} item=${itemId} status=${status ?? "local"} code=${code}`,
+        );
+      },
     });
   }
   console.log(JSON.stringify({ repoSlug, ...result, replay }));
+  if (replay?.failed) {
+    const summary = replay.failures.map((failure) => `${failure.itemId}:${failure.code}`).join(",");
+    throw new Error(
+      `Worker record projection replay failed for ${replay.failed} tuple(s): ${summary}`,
+    );
+  }
   return { ...result, replay };
 }
 

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -53,6 +53,12 @@ export type WorkerStoredSnapshot = {
   access: { mode: "worker_range_proxy"; maxChunkBytes: number };
 };
 
+export type WorkerRecordReplayFailure = {
+  itemId: string;
+  status: number | null;
+  code: string;
+};
+
 export class WorkerSnapshotUnavailableError extends Error {
   readonly reason: "snapshot_store_unavailable" | "snapshot_not_found";
 
@@ -74,6 +80,15 @@ class WorkerRecordRequestError extends Error {
     this.name = "WorkerRecordRequestError";
     this.status = status;
     this.code = code;
+  }
+}
+
+class WorkerRecordReplayTupleError extends Error {
+  readonly code = "invalid_replay_record_tuple";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerRecordReplayTupleError";
   }
 }
 
@@ -373,6 +388,9 @@ export async function replayWorkerRecordProjections(options: {
   cursor?: number;
   fetch?: typeof globalThis.fetch;
   onTuple?: (progress: { completed: number; total: number; itemId: string }) => void;
+  onTupleFailure?: (
+    progress: WorkerRecordReplayFailure & { completed: number; total: number },
+  ) => void;
 }) {
   const snapshot = await exportWorkerRecords({
     baseUrl: options.baseUrl,
@@ -400,50 +418,179 @@ export async function replayWorkerRecordProjections(options: {
   }
   const ids = selectedIds.slice(cursor, cursor + maximum);
   let deduped = 0;
+  let replayed = 0;
+  const failures: WorkerRecordReplayFailure[] = [];
   for (let index = 0; index < ids.length; index += 1) {
     const itemId = ids[index]!;
-    const operations = (["items", "closed", "plans", "decision-packets"] as const).map(
-      (section) => {
-        const record = byKey.get(`${section}/${itemId}`);
-        const extension = section === "decision-packets" ? "json" : "md";
-        const path = `records/${options.repoSlug}/${section}/${itemId}.${extension}`;
-        if (!record || record.deleted) return { path, expectedDigest: null };
-        if (record.content === null || record.digest === null) {
-          throw new Error(`Worker replay record is missing content: ${section}/${itemId}`);
-        }
-        return {
-          path,
-          expectedDigest: record.digest,
-          contentBase64: Buffer.from(record.content).toString("base64"),
-        };
-      },
-    );
-    const contentHash = createHash("sha256")
-      .update(JSON.stringify({ repoSlug: options.repoSlug, itemId, operations }))
-      .digest("hex");
-    const response = await signedPost<{ deduped?: boolean }>({
-      baseUrl: options.baseUrl,
-      path: "/internal/state/records/tuples",
-      webhookSecret: options.webhookSecret,
-      body: {
-        deliveryId: `record-replay:${options.repoSlug}:${itemId}:${contentHash}`,
-        key: `${options.repoSlug}/${itemId}`,
-        operations,
-      },
-      fetch: options.fetch,
-    });
-    if (response.deduped === true) deduped += 1;
-    options.onTuple?.({ completed: index + 1, total: ids.length, itemId });
+    try {
+      const operations = replayTupleOperations(options.repoSlug, itemId, byKey);
+      const contentHash = createHash("sha256")
+        .update(JSON.stringify({ repoSlug: options.repoSlug, itemId, operations }))
+        .digest("hex");
+      const response = await signedPost<{ deduped?: boolean }>({
+        baseUrl: options.baseUrl,
+        path: "/internal/state/records/tuples",
+        webhookSecret: options.webhookSecret,
+        body: {
+          deliveryId: `record-replay:${options.repoSlug}:${itemId}:${contentHash}`,
+          key: `${options.repoSlug}/${itemId}`,
+          operations,
+        },
+        fetch: options.fetch,
+      });
+      replayed += 1;
+      if (response.deduped === true) deduped += 1;
+      options.onTuple?.({ completed: index + 1, total: ids.length, itemId });
+    } catch (error) {
+      const failure = replayFailure(itemId, error);
+      if (!failure) throw error;
+      failures.push(failure);
+      options.onTupleFailure?.({
+        ...failure,
+        completed: index + 1,
+        total: ids.length,
+      });
+    }
   }
   const completedCursor = cursor + ids.length;
   return {
-    replayed: ids.length,
+    attempted: ids.length,
+    replayed,
     deduped,
+    failed: failures.length,
+    failedIds: failures.map((failure) => failure.itemId),
+    failures,
     available: selectedIds.length,
     cursor,
     nextCursor: completedCursor < selectedIds.length ? completedCursor : null,
     revision: snapshot.revision,
   };
+}
+
+const REPLAY_TUPLE_SECTIONS = ["items", "closed", "plans", "decision-packets"] as const;
+
+function replayTupleOperations(
+  repoSlug: string,
+  itemId: string,
+  byKey: ReadonlyMap<string, WorkerRecord>,
+) {
+  const records = new Map(
+    REPLAY_TUPLE_SECTIONS.map((section) => [section, byKey.get(`${section}/${itemId}`)]),
+  );
+  const live = (section: (typeof REPLAY_TUPLE_SECTIONS)[number]) => {
+    const record = records.get(section);
+    return record && !record.deleted ? record : null;
+  };
+  let item = live("items");
+  let closed = live("closed");
+  let plan = live("plans");
+  let packet = live("decision-packets");
+
+  // Revision-zero backfill rows can expose an older section beside a canonical
+  // row. Replay may remove only the side whose lower revision proves it stale.
+  if (item && closed) {
+    if (item.revision === closed.revision) {
+      throw replayTupleError(itemId, "open and closed primary records have equal authority");
+    }
+    if (item.revision > closed.revision) closed = null;
+    else item = null;
+  }
+  const primary = item ?? closed;
+  if (!primary) {
+    if (plan || packet) {
+      throw replayTupleError(itemId, "sidecars have no authoritative primary record");
+    }
+  } else {
+    if (closed && plan) {
+      if (closed.revision <= plan.revision) {
+        throw replayTupleError(itemId, "closed primary does not supersede its work plan");
+      }
+      plan = null;
+    }
+    packet = replayDecisionPacket(repoSlug, itemId, primary, packet);
+  }
+
+  const targets = { items: item, closed, plans: plan, "decision-packets": packet };
+  return REPLAY_TUPLE_SECTIONS.map((section) => {
+    const current = live(section);
+    const target = targets[section];
+    const extension = section === "decision-packets" ? "json" : "md";
+    const path = `records/${repoSlug}/${section}/${itemId}.${extension}`;
+    return {
+      path,
+      expectedDigest: current?.digest ?? null,
+      ...(target ? { contentBase64: Buffer.from(target.content!).toString("base64") } : {}),
+    };
+  });
+}
+
+function replayDecisionPacket(
+  repoSlug: string,
+  itemId: string,
+  primary: WorkerRecord,
+  packet: WorkerRecord | null,
+) {
+  const frontMatter = recordFrontMatter(primary.content!);
+  const digest = frontMatter.get("decision_packet_sha256");
+  const pointer = frontMatter.get("decision_packet_path");
+  const noReference =
+    (digest === undefined && pointer === undefined) || (digest === "none" && pointer === "none");
+  if (noReference) {
+    if (!packet) return null;
+    if (primary.revision <= packet.revision) {
+      throw replayTupleError(itemId, "unreferenced decision packet is not older than its primary");
+    }
+    return null;
+  }
+  const expectedPath = `records/${repoSlug}/decision-packets/${itemId}.json`;
+  if (!packet || digest !== packet.digest || pointer !== expectedPath) {
+    throw replayTupleError(itemId, "decision packet reference does not match canonical content");
+  }
+  return packet;
+}
+
+function recordFrontMatter(markdown: string) {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  const end = normalized.startsWith("---\n") ? normalized.indexOf("\n---", 4) : -1;
+  const values = new Map<string, string>();
+  if (end === -1) return values;
+  for (const line of normalized.slice(4, end).split("\n")) {
+    const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+    if (!match?.[1]) continue;
+    const value = match[2] ?? "";
+    values.set(match[1], unquoteYamlScalar(value));
+  }
+  return values;
+}
+
+function unquoteYamlScalar(value: string) {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function replayTupleError(itemId: string, detail: string) {
+  return new WorkerRecordReplayTupleError(`Invalid replay tuple ${itemId}: ${detail}`);
+}
+
+function replayFailure(itemId: string, error: unknown): WorkerRecordReplayFailure | null {
+  if (error instanceof WorkerRecordReplayTupleError) {
+    return { itemId, status: null, code: error.code };
+  }
+  if (
+    error instanceof WorkerRecordRequestError &&
+    (error.code.startsWith("invalid_canonical_record_tuple") ||
+      error.code === "canonical_record_tuple_conflict" ||
+      error.code === "canonical_record_tuple_too_large")
+  ) {
+    return { itemId, status: error.status, code: error.code };
+  }
+  return null;
 }
 
 function validateTupleItemId(value: string) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -8219,6 +8219,65 @@ test("canonical tuple publication updates Worker authority and appends one proje
   assert.equal((await rejected.json()).error, "canonical_record_tuple_conflict");
 });
 
+test("canonical tuple publication accepts explicit absent sidecars and closed records", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const packet = '{"version":1}\n';
+  const packetDigest = createHash("sha256").update(packet).digest("hex");
+  const cases = [
+    {
+      itemId: 51,
+      primarySection: "items",
+      primary: [
+        "---",
+        `decision_packet_sha256: ${packetDigest}`,
+        "decision_packet_path: records/openclaw-openclaw/decision-packets/51.json",
+        "---",
+        "open item without a plan",
+        "",
+      ].join("\n"),
+      plan: null,
+      packet,
+    },
+    {
+      itemId: 52,
+      primarySection: "items",
+      primary:
+        "---\ndecision_packet_sha256: none\ndecision_packet_path: none\n---\nopen item without a packet\n",
+      plan: "---\nreviewed_at: 2026-07-26T01:00:00Z\n---\nwork plan\n",
+      packet: null,
+    },
+    {
+      itemId: 53,
+      primarySection: "closed",
+      primary: "---\ndecision_packet_sha256: none\ndecision_packet_path: none\n---\nclosed item\n",
+      plan: null,
+      packet: null,
+    },
+  ] as const;
+
+  for (const fixture of cases) {
+    const content = new Map<string, string | null>([
+      ["items", fixture.primarySection === "items" ? fixture.primary : null],
+      ["closed", fixture.primarySection === "closed" ? fixture.primary : null],
+      ["plans", fixture.plan],
+      ["decision-packets", fixture.packet],
+    ]);
+    const operations = [...content].map(([section, value]) => ({
+      path: `records/openclaw-openclaw/${section}/${fixture.itemId}.${section === "decision-packets" ? "json" : "md"}`,
+      expectedDigest: null,
+      ...(value === null ? {} : { contentBase64: Buffer.from(value).toString("base64") }),
+    }));
+    const response = await queue.fetch(
+      stateAppendQueueRequest("/records/tuples", {
+        deliveryId: `record-tuple:partial:${fixture.itemId}`,
+        key: `openclaw-openclaw/${fixture.itemId}`,
+        operations,
+      }),
+    );
+    assert.equal(response.status, 202, await response.text());
+  }
+});
+
 test("state append sheds atomically at the configured cap without consuming its receipt", async () => {
   const queue = new ExactReviewQueue(
     { storage: new MemoryDurableStorage() },

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -8,6 +8,7 @@ import { gzipSync } from "node:zlib";
 import { parse } from "yaml";
 
 import { hydrateState } from "../scripts/hydrate-state.ts";
+import { backfillWorkerRecords } from "../scripts/backfill-worker-records.ts";
 import { verifyWorkerRecordParity } from "../scripts/verify-worker-record-parity.ts";
 import {
   ingestGitRecords,
@@ -260,8 +261,17 @@ test("backfill importer walks all record sections and sends digest-bearing rows"
 });
 
 test("canonical projection replay re-appends a complete tuple without overwriting from git", async () => {
-  const item = contents.get("items/1")!;
   const packet = contents.get("decision-packets/1")!;
+  const packetDigest = createHash("sha256").update(packet).digest("hex");
+  const item = [
+    "---",
+    "number: 1",
+    `decision_packet_sha256: ${packetDigest}`,
+    `decision_packet_path: records/${repoSlug}/decision-packets/1.json`,
+    "---",
+    "byte-identical item",
+    "",
+  ].join("\n");
   const requests: Array<Record<string, unknown>> = [];
   const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
     const url = new URL(input.toString());
@@ -291,8 +301,12 @@ test("canonical projection replay re-appends a complete tuple without overwritin
   });
 
   assert.deepEqual(result, {
+    attempted: 1,
     replayed: 1,
     deduped: 0,
+    failed: 0,
+    failedIds: [],
+    failures: [],
     available: 1,
     cursor: 0,
     nextCursor: null,
@@ -314,6 +328,151 @@ test("canonical projection replay re-appends a complete tuple without overwritin
       contentBase64: Buffer.from(packet).toString("base64"),
     },
   ]);
+});
+
+test("canonical projection replay expresses partial and revision-ordered legacy tuples", async () => {
+  const packet = '{"decision":"keep"}\n';
+  const packetDigest = createHash("sha256").update(packet).digest("hex");
+  const itemWithPacket = [
+    "---",
+    `decision_packet_sha256: ${packetDigest}`,
+    `decision_packet_path: records/${repoSlug}/decision-packets/10.json`,
+    "---",
+    "item with no plan",
+    "",
+  ].join("\n");
+  const itemWithPlan = "---\ndecision_packet_sha256: none\ndecision_packet_path: none\n---\nitem\n";
+  const plan = "---\nreviewed_at: 2026-07-26T01:00:00Z\n---\nplan\n";
+  const closed = "---\ndecision_packet_sha256: none\ndecision_packet_path: none\n---\nclosed\n";
+  const staleOpen = "---\nreviewed_at: 2026-07-26T00:00:00Z\n---\nstale open\n";
+  const requests = new Map<string, Array<Record<string, unknown>>>();
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input.toString());
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    if (url.pathname === "/internal/state/records/export") {
+      return Response.json({
+        repoSlug,
+        revision: 12,
+        nextCursor: null,
+        records: [
+          workerRecord("items", "10", itemWithPacket, 1, 2),
+          workerRecord("decision-packets", "10", packet, 2, 2),
+          workerRecord("items", "11", itemWithPlan, 3, 2),
+          workerRecord("plans", "11", plan, 4, 2),
+          workerRecord("closed", "12", closed, 5, 3),
+          workerRecord("plans", "12", plan, 6, 1),
+          workerRecord("items", "13", staleOpen, 7, 1),
+          workerRecord("closed", "13", closed, 8, 4),
+        ],
+      });
+    }
+    const itemId = String(body.key).split("/").at(-1)!;
+    requests.set(itemId, body.operations);
+    return Response.json({ ok: true, accepted: true, deduped: false, revision: 5, sequence: 9 });
+  }) as typeof fetch;
+
+  const result = await replayWorkerRecordProjections({
+    baseUrl: "https://worker.example",
+    webhookSecret: "fixture-secret",
+    repoSlug,
+    itemIds: ["10", "11", "12", "13"],
+    fetch: fetchImpl,
+  });
+
+  assert.equal(result.replayed, 4);
+  assert.equal(result.failed, 0);
+  assert.equal(
+    requests.get("10")?.find((entry) => String(entry.path).includes("/plans/"))?.contentBase64,
+    undefined,
+  );
+  assert.equal(
+    requests.get("11")?.find((entry) => String(entry.path).includes("/decision-packets/"))
+      ?.contentBase64,
+    undefined,
+  );
+  const closedPlan = requests.get("12")?.find((entry) => String(entry.path).includes("/plans/"));
+  assert.equal(closedPlan?.expectedDigest, createHash("sha256").update(plan).digest("hex"));
+  assert.equal(closedPlan?.contentBase64, undefined);
+  const stalePrimary = requests.get("13")?.find((entry) => String(entry.path).includes("/items/"));
+  assert.equal(stalePrimary?.expectedDigest, createHash("sha256").update(staleOpen).digest("hex"));
+  assert.equal(stalePrimary?.contentBase64, undefined);
+});
+
+test("backfill replay continues after tuple rejection and fails once with every rejected id", async () => {
+  const fixture = createStateFixture();
+  const tupleIds: string[] = [];
+  const errors: string[] = [];
+  const output: string[] = [];
+  const originalError = console.error;
+  const originalLog = console.log;
+  console.error = (...values) => errors.push(values.join(" "));
+  console.log = (...values) => output.push(values.join(" "));
+  try {
+    await assert.rejects(
+      backfillWorkerRecords(
+        [
+          "--state-dir",
+          fixture.stateRoot,
+          "--repo-slug",
+          repoSlug,
+          "--replay-projections",
+          "--replay-item-ids",
+          "1,2,3",
+        ],
+        { CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret" },
+        (async (input: string | URL | Request, init?: RequestInit) => {
+          const url = new URL(input.toString());
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          if (url.pathname === "/internal/state/records/ingest") {
+            return Response.json({
+              inserted: body.records.length,
+              unchanged: 0,
+              skippedNewer: 0,
+              watermark: 1,
+            });
+          }
+          if (url.pathname === "/internal/state/records/export") {
+            return Response.json({
+              repoSlug,
+              revision: 3,
+              nextCursor: null,
+              records: [
+                workerRecord("items", "1", "---\n---\none\n", 1),
+                workerRecord("items", "2", "---\n---\ntwo\n", 2),
+                workerRecord("items", "3", "---\n---\nthree\n", 3),
+              ],
+            });
+          }
+          const itemId = String(body.key).split("/").at(-1)!;
+          tupleIds.push(itemId);
+          if (itemId === "2") {
+            return Response.json(
+              { error: "invalid_canonical_record_tuple", detail: "fixture rejection" },
+              { status: 400 },
+            );
+          }
+          return Response.json({ ok: true, accepted: true, deduped: false });
+        }) as typeof fetch,
+      ),
+      /failed for 1 tuple\(s\): 2:invalid_canonical_record_tuple/,
+    );
+  } finally {
+    console.error = originalError;
+    console.log = originalLog;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(tupleIds, ["1", "2", "3"]);
+  assert.ok(
+    errors.some((line) =>
+      line.includes(
+        "rejected tuple=2/3 repo=openclaw-openclaw item=2 status=400 code=invalid_canonical_record_tuple",
+      ),
+    ),
+  );
+  const summary = JSON.parse(output.at(-1)!);
+  assert.deepEqual(summary.replay.failedIds, ["2"]);
+  assert.equal(summary.replay.replayed, 2);
 });
 
 test("backfill workflow is manual per-target and setup-state plumbs the opt-in Worker flag", () => {
@@ -449,13 +608,14 @@ function workerRecord(
   id: string,
   content: string,
   storeRevision: number,
+  revision = 1,
 ): WorkerRecord {
   return {
     section,
     id,
     content,
     digest: createHash("sha256").update(content).digest("hex"),
-    revision: 1,
+    revision,
     storeRevision,
     deleted: false,
   };


### PR DESCRIPTION
Replay of canonical tuples aborted on item 111308: revision-zero backfill can expose a stale open primary beside the newer closed primary, and the tuples endpoint correctly rejects the dual-primary shape. The replay client now resolves revision-ordered stale primaries/sidecars (ambiguous tuples stay rejected), supports no-plan/no-packet/closed tuples, continues past per-item validation failures, and exits nonzero with the failed ids listed. Repro: run 30234934829. Focused replay tests 9/9, endpoint tests 2/2, CLI contract incl. continue-after-rejection, autoreview clean. No Worker redeploy needed.