### PR TITLE
fix(repair): rank cluster candidates for landable bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Ranked imported repair clusters for landable bugs using conservative historical dedupe, live-state, security, and quality gates. Thanks @RomneyDa! (#881)
 - The OpenClaw runner ships a built-in Z.AI provider: `CLAWSWEEPER_OPENCLAW_MODEL=zai/glm-5.2` runs GLM-5.2 on the GLM Coding Plan endpoint with only `ZAI_API_KEY` (validated live end to end).
 - The OpenClaw runner ships a built-in Cerebras provider: `CLAWSWEEPER_OPENCLAW_MODEL=cerebras/zai-glm-4.7` needs only `CEREBRAS_API_KEY` (validated live at ~474 tok/s on Cerebras Code Max); provider-key allowlist extended for Cerebras, Z.AI, DeepSeek, and Mistral.
 - Redesigned PR review comments into a scan-first layout: outcome and merge readiness up top, ratings and verification as compact tables, before-merge work as native checklists, evidence folded into details — with hardened fence-aware section parsing and Mermaid sanitization. Thanks @Patrick-Erichsen! (#776)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "repair:plan-cluster": "node dist/repair/plan-cluster.js",
     "repair:build-fix-artifact": "node dist/repair/plan-cluster.js",
     "repair:import-gitcrawl": "node dist/repair/import-gitcrawl-clusters.js",
+    "repair:filter-cluster-candidates-live": "node dist/repair/filter-cluster-candidates-live.js",
     "repair:import-gitcrawl-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",
     "repair:import-ghcrawl": "node dist/repair/import-gitcrawl-clusters.js",
     "repair:import-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",

--- a/src/repair/filter-cluster-candidates-live.ts
+++ b/src/repair/filter-cluster-candidates-live.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  hasClusterDecisionSignal,
+  hasClusterFeatureSignal,
+  hasClusterSecuritySignal,
+} from "./gitcrawl-cluster-ranking.js";
+
+type LiveItem = {
+  number: number;
+  state: string;
+  title: string;
+  body?: string;
+  updated_at: string;
+  labels: Array<{ name?: string }>;
+  pull_request?: unknown;
+};
+
+type LivePull = {
+  draft: boolean;
+  maintainer_can_modify: boolean;
+  head?: { repo?: { full_name?: string | null } | null };
+};
+
+export function filterClusterCandidatesLive(options: {
+  repo: string;
+  paths: readonly string[];
+  now?: Date;
+  maxAccepted?: number;
+  readItem?: (number: number) => LiveItem;
+  readPull?: (number: number) => LivePull;
+}): { accepted: string[]; rejected: Array<{ path: string; reasons: string[] }> } {
+  const now = options.now ?? new Date();
+  const readItem = options.readItem ?? ((number) => githubItem(options.repo, number));
+  const readPull = options.readPull ?? ((number) => githubPull(options.repo, number));
+  const accepted: string[] = [];
+  const rejected: Array<{ path: string; reasons: string[] }> = [];
+  for (const jobPath of options.paths) {
+    if (!/^jobs\/[A-Za-z0-9_.-]+\/inbox\/gitcrawl-[1-9]\d*-[^/]+\.md$/.test(jobPath)) {
+      throw new Error(`invalid live cluster candidate path: ${jobPath}`);
+    }
+    const content = readFileSync(resolve(jobPath), "utf8");
+    const candidateNumbers = frontmatterRefs(content, "candidates");
+    const clusterNumbers = frontmatterRefs(content, "cluster_refs");
+    if (
+      candidateNumbers.length < 2 ||
+      candidateNumbers.some((number) => !clusterNumbers.includes(number))
+    ) {
+      throw new Error("cluster context must contain at least two candidate refs");
+    }
+    const itemsByNumber = new Map(clusterNumbers.map((number) => [number, readItem(number)]));
+    const candidates = candidateNumbers.map((number) => itemsByNumber.get(number)!);
+    const clusterItems = [...itemsByNumber.values()];
+    const reasons: string[] = [];
+    const open = candidates.filter((item) => item.state.toLowerCase() === "open");
+    if (open.length < 2) {
+      reasons.push(`only ${open.length}/${candidates.length} candidates remain open`);
+    }
+    if (candidates.some((item) => item.state.toLowerCase() !== "open")) {
+      reasons.push("candidate closed or merged after gitcrawl export");
+    }
+    const latestUpdate = Math.max(
+      ...open.map((item) => Date.parse(item.updated_at)).filter(Number.isFinite),
+    );
+    if (!Number.isFinite(latestUpdate) || now.getTime() - latestUpdate > 45 * 86_400_000) {
+      reasons.push("live candidates are stale");
+    }
+    if (
+      clusterItems.some((item) =>
+        hasClusterSecuritySignal({
+          title: item.title,
+          body: item.body ?? "",
+          labels_json: JSON.stringify(item.labels.map((label) => label.name || "")),
+        }),
+      )
+    ) {
+      reasons.push("live cluster context has a security signal");
+    }
+    if (
+      clusterItems.some((item) =>
+        hasClusterFeatureSignal({
+          title: item.title,
+          body: item.body ?? "",
+          labels_json: JSON.stringify(item.labels),
+        }),
+      )
+    ) {
+      reasons.push("live cluster context is feature or proposal work");
+    }
+    if (
+      clusterItems.some((item) =>
+        hasClusterDecisionSignal({
+          title: item.title,
+          body: item.body ?? "",
+          labels_json: JSON.stringify(item.labels),
+        }),
+      )
+    ) {
+      reasons.push("live cluster context requires maintainer or product decision");
+    }
+    const pullCandidates = open.filter((item) => item.pull_request !== undefined);
+    if (
+      pullCandidates.length > 0 &&
+      pullCandidates
+        .map((item) => readPull(item.number))
+        .every((pull) => {
+          const sameRepositoryHead = pull.head?.repo?.full_name === options.repo;
+          return pull.draft || (!sameRepositoryHead && pull.maintainer_can_modify === false);
+        })
+    ) {
+      reasons.push("no repairable open implementation PR");
+    }
+    if (reasons.length === 0 && accepted.length >= (options.maxAccepted ?? Infinity)) {
+      reasons.push("lower-ranked eligible candidate beyond intake limit");
+    }
+    if (reasons.length > 0) rejected.push({ path: jobPath, reasons });
+    else accepted.push(jobPath);
+  }
+  return { accepted, rejected };
+}
+
+function frontmatterRefs(content: string, field: "candidates" | "cluster_refs"): number[] {
+  const block = new RegExp(`^${field}:\\n((?:  - .+\\n?)*)`, "m").exec(content)?.[1] ?? "";
+  const refs = [...block.matchAll(/#([1-9]\d*)/g)].map((match) => Number(match[1]));
+  if (refs.length < 1 || refs.length > 20 || new Set(refs).size !== refs.length) {
+    throw new Error(`cluster job requires bounded unique ${field} refs`);
+  }
+  return refs;
+}
+
+function githubItem(repo: string, number: number): LiveItem {
+  const output = execFileSync("gh", ["api", `repos/${repo}/issues/${number}`], {
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return JSON.parse(output) as LiveItem;
+}
+
+function githubPull(repo: string, number: number): LivePull {
+  const output = execFileSync("gh", ["api", `repos/${repo}/pulls/${number}`], {
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return JSON.parse(output) as LivePull;
+}
+
+if (process.argv[1]?.endsWith("filter-cluster-candidates-live.js")) {
+  const values = process.argv.slice(2);
+  const value = (name: string): string => {
+    const index = values.indexOf(name);
+    if (index < 0 || !values[index + 1]) throw new Error(`${name} is required`);
+    return values[index + 1]!;
+  };
+  const input = resolve(value("--paths-file"));
+  const output = resolve(value("--out"));
+  const report = resolve(value("--report"));
+  const paths = readFileSync(input, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const maxAccepted = Number(value("--limit"));
+  if (!Number.isSafeInteger(maxAccepted) || maxAccepted < 1 || maxAccepted > 20) {
+    throw new Error("--limit must be an integer from 1 to 20");
+  }
+  const result = filterClusterCandidatesLive({
+    repo: value("--repo"),
+    paths,
+    maxAccepted,
+  });
+  for (const rejection of result.rejected) {
+    console.error(`reject live cluster ${rejection.path}: ${rejection.reasons.join("; ")}`);
+  }
+  writeFileSync(output, `${result.accepted.join("\n")}${result.accepted.length ? "\n" : ""}`);
+  writeFileSync(report, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(`live cluster fence accepted ${result.accepted.length}/${paths.length} candidate(s)`);
+}

--- a/src/repair/gitcrawl-cluster-history.ts
+++ b/src/repair/gitcrawl-cluster-history.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./lib.js";
+
+export function existingGitcrawlMemberRefs(
+  roots: readonly string[],
+  targetRepo: string,
+  relativeTo = repoRoot(),
+): Map<number, string[]> {
+  const refs = new Map<number, string[]>();
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    for (const entry of fs.readdirSync(root, { recursive: true })) {
+      const file = path.join(root, String(entry));
+      if (!file.endsWith(".md") || !fs.statSync(file).isFile()) continue;
+      const text = fs.readFileSync(file, "utf8");
+      const frontmatter = text.match(/^---\n([\s\S]*?)\n---/);
+      if (frontmatterRepo(frontmatter?.[1] ?? "") !== targetRepo) continue;
+      const clusterRefs = frontmatter?.[1]?.match(/^cluster_refs:\n((?:  - .+\n?)*)/m)?.[1] ?? "";
+      for (const match of clusterRefs.matchAll(/#(\d+)/g)) {
+        const number = Number(match[1]);
+        if (!Number.isSafeInteger(number)) continue;
+        const files = refs.get(number) ?? [];
+        const relative = path.relative(relativeTo, file);
+        if (!files.includes(relative)) files.push(relative);
+        refs.set(number, files);
+      }
+    }
+  }
+  return refs;
+}
+
+export function existingGitcrawlClusterIds(
+  roots: readonly string[],
+  targetRepo: string,
+): Set<number> {
+  const ids = new Set<number>();
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    for (const entry of fs.readdirSync(root, { recursive: true })) {
+      const file = path.join(root, String(entry));
+      if (!fs.statSync(file).isFile()) continue;
+      if (file.endsWith(".md")) {
+        const text = fs.readFileSync(file, "utf8");
+        const frontmatter = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+        if (frontmatterRepo(frontmatter) !== targetRepo) continue;
+        for (const match of text.matchAll(/\b(?:ghcrawl|gitcrawl)-(\d+)\b/g)) {
+          ids.add(Number(match[1]));
+        }
+        continue;
+      }
+      if (!file.endsWith(".json")) continue;
+      try {
+        const ledger = JSON.parse(fs.readFileSync(file, "utf8")) as {
+          target_repo?: unknown;
+          clusters?: unknown;
+        };
+        if (ledger.target_repo !== targetRepo || !isRecord(ledger.clusters)) continue;
+        for (const clusterId of Object.keys(ledger.clusters)) {
+          const number = Number(clusterId);
+          if (Number.isSafeInteger(number) && number > 0) ids.add(number);
+        }
+      } catch {
+        // A malformed or unrelated JSON file is not authoritative history.
+      }
+    }
+  }
+  return ids;
+}
+
+function frontmatterRepo(frontmatter: string): string {
+  return /^repo:\s*["']?([^\s"']+)["']?\s*$/m.exec(frontmatter)?.[1] ?? "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/repair/gitcrawl-cluster-ranking.ts
+++ b/src/repair/gitcrawl-cluster-ranking.ts
@@ -1,0 +1,239 @@
+import { hasSecuritySignalText } from "./lib.js";
+import {
+  CLOSE_PROTECTED_LABEL_NAMES,
+  HUMAN_REVIEW_LABEL,
+  MANUAL_ONLY_LABEL,
+} from "./exact-review-guard-labels.js";
+
+export type GitcrawlClusterMember = {
+  number?: number;
+  kind?: string;
+  state?: string;
+  title?: string;
+  body?: string;
+  labels_json?: string;
+  updated_at?: string;
+  representative_title?: string;
+};
+
+export type GitcrawlClusterRanking = {
+  eligible: boolean;
+  score: number;
+  reasons: string[];
+  signals: string[];
+  openMembers: number;
+  totalMembers: number;
+  latestOpenUpdate: string | null;
+};
+
+const BUG_WORDS =
+  /\b(?:bug|broken|crash(?:es|ed|ing)?|error|fail(?:s|ed|ing|ure)?|incorrect|regression|hang(?:s|ing)?|panic|leak|corrupt|missing|cannot|can't|doesn't|not working)\b/i;
+const FEATURE_WORDS =
+  /^\s*\[?\s*(?:feature|enhancement|proposal|rfc)\b|\b(?:feature request|would be nice|please add|support for)\b/i;
+const DECISION_WORDS =
+  /\b(?:design decision|maintainer decision|needs? (?:a )?decision|product decision|roadmap|policy question|architecture discussion|breaking change proposal)\b/i;
+const SECURITY_WORDS =
+  /\b(?:credential|secret|token leak|reusable (?:command )?tokens?|expos(?:e|es|ed|ing).{0,40}(?:tokens?|secrets?|credentials?)|forgeable|hardcoded hmac|security|vulnerabilit(?:y|ies)|auth(?:entication|orization)? bypass|remote code execution|arbitrary code execution|code injection|command injection|sql injection|server-side request forgery|ssrf|sandbox escape|rce|xss|csrf|path traversal|privilege escalation)\b/i;
+
+export function hasClusterSecuritySignal(member: GitcrawlClusterMember): boolean {
+  const securityLabel = labels(member).some((label) =>
+    /(?:^|[^a-z0-9])(?:security|vulnerabilit(?:y|ies)|cve)(?:$|[^a-z0-9])/i.test(label),
+  );
+  return (
+    securityLabel ||
+    hasSecuritySignalText(member.title, member.body, labels(member)) ||
+    SECURITY_WORDS.test(`${member.title || ""}\n${member.body || ""}`)
+  );
+}
+const DECISION_LABELS = new Set([
+  "discussion",
+  "question",
+  "needs-maintainer-input",
+  "needs maintainer input",
+  "product-decision",
+  "product decision",
+  "rfc",
+  "clawsweeper:needs-maintainer-review",
+  "clawsweeper:needs-product-decision",
+  "clawsweeper:no-new-fix-pr",
+  HUMAN_REVIEW_LABEL,
+  MANUAL_ONLY_LABEL,
+  ...CLOSE_PROTECTED_LABEL_NAMES,
+]);
+const FEATURE_LABELS = new Set(["enhancement", "feature", "feature request", "proposal"]);
+const BUG_LABELS = new Set(["bug", "regression", "type: bug", "kind/bug"]);
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "be",
+  "for",
+  "from",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "the",
+  "to",
+  "with",
+  "fix",
+  "bug",
+  "issue",
+  "error",
+  "fails",
+  "failure",
+  "support",
+]);
+
+export function rankGitcrawlCluster(
+  members: readonly GitcrawlClusterMember[],
+  options: { asOf: Date; maxAgeDays?: number; maxMembers?: number; minOpenRatio?: number },
+): GitcrawlClusterRanking {
+  const reasons: string[] = [];
+  const signals: string[] = [];
+  const open = members.filter((member) => member.state === "open");
+  const maxAgeDays = options.maxAgeDays ?? 45;
+  const maxMembers = options.maxMembers ?? 8;
+  const minOpenRatio = options.minOpenRatio ?? 0.6;
+  const latestOpenMs = Math.max(
+    ...open.map((member) => Date.parse(String(member.updated_at || ""))).filter(Number.isFinite),
+    Number.NEGATIVE_INFINITY,
+  );
+  const latestOpenUpdate = Number.isFinite(latestOpenMs)
+    ? new Date(latestOpenMs).toISOString()
+    : null;
+  const ageDays = Number.isFinite(latestOpenMs)
+    ? Math.max(0, (options.asOf.getTime() - latestOpenMs) / 86_400_000)
+    : Number.POSITIVE_INFINITY;
+
+  if (members.length < 2) reasons.push("fewer than two related items");
+  if (members.length > maxMembers)
+    reasons.push(`broad cluster (${members.length} > ${maxMembers} items)`);
+  if (open.length < 2) reasons.push(`insufficient live evidence (${open.length} open item)`);
+  if (members.length > 0 && open.length / members.length < minOpenRatio) {
+    reasons.push(`closed-dominated (${open.length}/${members.length} open)`);
+  }
+  if (ageDays > maxAgeDays)
+    reasons.push(`stale (${Math.floor(ageDays)}d since latest open update)`);
+
+  const securityMembers = members.filter(hasClusterSecuritySignal);
+  if (securityMembers.length > 0) reasons.push("security-sensitive cluster member");
+
+  const featureMembers = open.filter(hasClusterFeatureSignal);
+  if (featureMembers.length > 0) reasons.push("feature/proposal live member");
+  const decisionMembers = open.filter(hasClusterDecisionSignal);
+  if (decisionMembers.length > 0) reasons.push("requires maintainer or product decision");
+
+  const bugMembers = open.filter((member) => {
+    const memberLabels = labels(member).map((label) => label.toLowerCase());
+    return (
+      BUG_WORDS.test(String(member.title || "")) ||
+      memberLabels.some((label) => BUG_LABELS.has(label))
+    );
+  });
+  if (bugMembers.length === 0) reasons.push("no high-confidence bug signal");
+  else signals.push(`${bugMembers.length}/${open.length} open items carry bug signals`);
+  const openIssueMembers = open.filter((member) => member.kind !== "pull_request");
+  const issueMembersWithoutBugEvidence = openIssueMembers.filter(
+    (member) => !bugMembers.includes(member),
+  );
+  if (issueMembersWithoutBugEvidence.length > 0) {
+    reasons.push(
+      `open issue candidates lack high-confidence bug evidence (${issueMembersWithoutBugEvidence.length}/${openIssueMembers.length})`,
+    );
+  }
+
+  const cohesion = titleCohesion(open);
+  if (open.length >= 2 && cohesion < 0.75)
+    reasons.push(`low title cohesion (${cohesion.toFixed(2)})`);
+  else signals.push(`title cohesion ${cohesion.toFixed(2)}`);
+
+  const openPulls = open.filter((member) => member.kind === "pull_request").length;
+  const openIssues = openIssueMembers.length;
+  if (openPulls > 0)
+    signals.push(`${openPulls} open implementation PR${openPulls === 1 ? "" : "s"}`);
+  if (latestOpenUpdate) signals.push(`latest open update ${latestOpenUpdate.slice(0, 10)}`);
+
+  let score = 100;
+  score -= Math.max(0, members.length - 2) * 6;
+  score -= Math.min(35, Math.floor(ageDays));
+  score -= Math.round((1 - cohesion) * 20);
+  score -= (open.length - bugMembers.length) * 5;
+  score += Math.min(12, openPulls * 6);
+  score += Math.min(6, openIssues * 2);
+  if (reasons.length > 0) score -= 100 + reasons.length * 10;
+
+  return {
+    eligible: reasons.length === 0,
+    score,
+    reasons,
+    signals,
+    openMembers: open.length,
+    totalMembers: members.length,
+    latestOpenUpdate,
+  };
+}
+
+export function hasClusterFeatureSignal(member: GitcrawlClusterMember): boolean {
+  const memberLabels = labels(member).map((label) => label.toLowerCase());
+  return (
+    FEATURE_WORDS.test(`${member.title || ""}\n${member.body || ""}`) ||
+    memberLabels.some((label) => FEATURE_LABELS.has(label))
+  );
+}
+
+export function hasClusterDecisionSignal(member: GitcrawlClusterMember): boolean {
+  const memberLabels = labels(member).map((label) => label.toLowerCase());
+  return (
+    DECISION_WORDS.test(`${member.title || ""}\n${member.body || ""}`) ||
+    memberLabels.some((label) => DECISION_LABELS.has(label))
+  );
+}
+
+function labels(member: GitcrawlClusterMember): string[] {
+  try {
+    const parsed = JSON.parse(String(member.labels_json || "[]"));
+    return Array.isArray(parsed)
+      ? parsed
+          .map((label) => {
+            if (typeof label === "string") return label;
+            if (label && typeof label === "object" && "name" in label) {
+              return String((label as { name?: unknown }).name || "");
+            }
+            return "";
+          })
+          .filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function titleCohesion(members: readonly GitcrawlClusterMember[]): number {
+  if (members.length <= 1) return 1;
+  const tokenSets = members.map((member) => titleTokens(String(member.title || "")));
+  let relatedPairs = 0;
+  let totalPairs = 0;
+  for (let index = 0; index < tokenSets.length; index += 1) {
+    for (let candidateIndex = index + 1; candidateIndex < tokenSets.length; candidateIndex += 1) {
+      totalPairs += 1;
+      const current = tokenSets[index]!;
+      const candidate = tokenSets[candidateIndex]!;
+      const shared = [...current].filter((token) => candidate.has(token));
+      if (shared.length >= 2) relatedPairs += 1;
+    }
+  }
+  return totalPairs > 0 ? relatedPairs / totalPairs : 1;
+}
+
+function titleTokens(title: string): Set<string> {
+  return new Set(
+    title
+      .toLowerCase()
+      .match(/[a-z0-9][a-z0-9_-]{2,}/g)
+      ?.filter((token) => !STOP_WORDS.has(token)) ?? [],
+  );
+}

--- a/src/repair/import-gitcrawl-clusters.ts
+++ b/src/repair/import-gitcrawl-clusters.ts
@@ -6,6 +6,11 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { hasSecuritySignalText, parseArgs, repoRoot } from "./lib.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
+import { rankGitcrawlCluster } from "./gitcrawl-cluster-ranking.js";
+import {
+  existingGitcrawlClusterIds,
+  existingGitcrawlMemberRefs,
+} from "./gitcrawl-cluster-history.js";
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
@@ -34,16 +39,24 @@ const limit = numberArg("limit", 40);
 const minSize = numberArg("min-size", 2);
 const minOpenMembers = numberArg("min-open-members", 1);
 const skipClosedPercent = percentArg("skip-closed-percent", 75);
-let clusterIds = args._.map((value: string) => Number(value)).filter(Boolean);
+const rankingAsOf = dateArg("as-of", new Date());
+const candidatePoolLimit = numberArg("candidate-pool-limit", Math.max(100, limit * 50));
+const selectionReportPath = typeof args.report === "string" ? path.resolve(args.report) : "";
+let selectionReport = {
+  evaluated: 0,
+  rejected: 0,
+  selected: 0,
+  reason_counts: {} as Record<string, number>,
+};
+let clusterIds: number[] = args._.map((value: string) => Number(value)).filter(Boolean);
 const selectingFromGitcrawl = clusterIds.length === 0 && fromGitcrawl;
 const clusterSource = detectClusterSource();
 
-if (selectingFromGitcrawl) {
-  clusterIds = selectClusterIds();
-}
+if (selectingFromGitcrawl) clusterIds = selectClusterIds();
 
 if (clusterIds.length === 0) {
   if (selectingFromGitcrawl && allowEmpty) {
+    writeSelectionReport();
     console.error("no eligible gitcrawl clusters found");
     process.exit(0);
   }
@@ -81,9 +94,40 @@ function resolveGitcrawlDbPath(repoFullName: string, explicitDb?: string): strin
 
 fs.mkdirSync(outDir, { recursive: true });
 
-const existingClusterIds = skipExisting ? existingGitcrawlClusterIds(outDir) : new Set();
-const existingMemberRefs = skipExisting ? existingGitcrawlMemberRefs(outDir, suffix) : new Map();
+const historyRoots = [
+  outDir,
+  path.join(repoRoot(), "jobs", repo.split("/")[0] ?? "unknown"),
+  path.join(repoRoot(), "results", repo.split("/")[0] ?? "unknown"),
+  path.join(repoRoot(), "results", "cluster-repair-intake"),
+];
+const existingClusterIds = skipExisting
+  ? existingGitcrawlClusterIds(historyRoots, repo)
+  : new Set<number>();
+const existingMemberRefs = skipExisting
+  ? existingGitcrawlMemberRefs(historyRoots, repo)
+  : new Map();
 const prefetchedMembers = selectingFromGitcrawl ? prefetchMembers(clusterIds) : null;
+if (selectingFromGitcrawl && prefetchedMembers) {
+  const ranked = clusterIds.map((clusterId) => ({
+    clusterId,
+    ranking: rankGitcrawlCluster(prefetchedMembers.get(clusterId) ?? [], { asOf: rankingAsOf }),
+  }));
+  selectionReport.evaluated = ranked.length;
+  for (const candidate of ranked.filter((entry) => !entry.ranking.eligible)) {
+    selectionReport.rejected += 1;
+    for (const reason of candidate.ranking.reasons) {
+      const category = reason.split(" (")[0]!;
+      selectionReport.reason_counts[category] = (selectionReport.reason_counts[category] ?? 0) + 1;
+    }
+    console.error(`reject cluster ${candidate.clusterId}: ${candidate.ranking.reasons.join("; ")}`);
+  }
+  clusterIds = ranked
+    .filter((entry) => entry.ranking.eligible)
+    .sort(
+      (left, right) => right.ranking.score - left.ranking.score || left.clusterId - right.clusterId,
+    )
+    .map((entry) => entry.clusterId);
+}
 let createdCount = 0;
 
 for (const clusterId of clusterIds) {
@@ -170,6 +214,7 @@ for (const clusterId of clusterIds) {
     .map((member: JsonValue) => member.updated_at)
     .sort()
     .at(-1);
+  const ranking = rankGitcrawlCluster(members, { asOf: rankingAsOf });
   const slug = slugify(representative.title || `cluster-${clusterId}`);
   const fileStem = suffix
     ? `gitcrawl-${clusterId}-${slugify(suffix)}`
@@ -240,6 +285,8 @@ for (const clusterId of clusterIds) {
     `- open candidates in local store: ${openMembers.length}`,
     `- representative: #${representative.number}, currently ${representative.state} in local store`,
     `- latest member update: ${latestUpdatedAt}`,
+    `- selection score: ${ranking.score}`,
+    `- selection signals: ${ranking.signals.join("; ")}`,
     "",
     "## Goal",
     "",
@@ -268,6 +315,15 @@ for (const clusterId of clusterIds) {
   createdCount += 1;
   console.log(path.relative(repoRoot(), filePath));
 }
+selectionReport.selected = createdCount;
+writeSelectionReport();
+
+function writeSelectionReport() {
+  if (selectionReportPath) {
+    fs.mkdirSync(path.dirname(selectionReportPath), { recursive: true });
+    fs.writeFileSync(selectionReportPath, `${JSON.stringify(selectionReport, null, 2)}\n`);
+  }
+}
 
 function selectClusterIds() {
   if (clusterSource === "portable") {
@@ -285,7 +341,10 @@ function selectClusterIds() {
       having member_count >= ${sqlNumber(minSize)}
         and open_count >= ${sqlNumber(minOpenMembers)}
         and ((closed_count * 100) / member_count) < ${sqlNumber(skipClosedPercent)}
-      order by member_count desc, cg.id asc
+      order by max(case when t.state = 'open' then t.updated_at else '' end) desc,
+        member_count asc,
+        cg.id asc
+      limit ${sqlNumber(candidatePoolLimit)}
     `)
       .map((row: JsonValue) => Number(row.id))
       .filter(Boolean);
@@ -304,7 +363,10 @@ function selectClusterIds() {
     having member_count >= ${sqlNumber(minSize)}
       and open_count >= ${sqlNumber(minOpenMembers)}
       and ((closed_count * 100) / member_count) < ${sqlNumber(skipClosedPercent)}
-    order by member_count desc, c.id asc
+    order by max(case when t.state = 'open' then t.updated_at else '' end) desc,
+      member_count asc,
+      c.id asc
+    limit ${sqlNumber(candidatePoolLimit)}
   `)
     .map((row: JsonValue) => Number(row.id))
     .filter(Boolean);
@@ -442,6 +504,14 @@ function percentArg(name: string, fallback: JsonValue) {
   return value;
 }
 
+function dateArg(name: string, fallback: Date): Date {
+  const raw = args[name];
+  if (raw === undefined) return fallback;
+  const value = new Date(String(raw));
+  if (!Number.isFinite(value.getTime())) throw new Error(`--${name} must be an ISO date`);
+  return value;
+}
+
 function booleanArg(name: string, fallback: JsonValue) {
   const value = args[name];
   if (value === undefined) return fallback;
@@ -469,40 +539,6 @@ function isProductFeatureRequest(title: JsonValue) {
   return /^\s*\[?\s*feature(?:\s+(?:request|proposal))?\b/i.test(String(title ?? ""));
 }
 
-function existingGitcrawlClusterIds(dir: string) {
-  if (!fs.existsSync(dir)) return new Set();
-  const ids = new Set();
-  for (const entry of fs.readdirSync(dir, { recursive: true })) {
-    const file = path.join(dir, String(entry));
-    if (!file.endsWith(".md") || !fs.statSync(file).isFile()) continue;
-    const text = fs.readFileSync(file, "utf8");
-    for (const match of text.matchAll(/\b(?:ghcrawl|gitcrawl)-(\d+)\b/g)) ids.add(Number(match[1]));
-  }
-  return ids;
-}
-
-function existingGitcrawlMemberRefs(dir: string, suffix: JsonValue) {
-  const refs = new Map();
-  if (!fs.existsSync(dir)) return refs;
-  const suffixSlug = suffix ? slugify(suffix) : "";
-  for (const entry of fs.readdirSync(dir, { recursive: true })) {
-    const file = path.join(dir, String(entry));
-    if (!file.endsWith(".md") || !fs.statSync(file).isFile()) continue;
-    if (suffixSlug && !path.basename(file).endsWith(`-${suffixSlug}.md`)) continue;
-    const text = fs.readFileSync(file, "utf8");
-    const frontmatter = text.match(/^---\n([\s\S]*?)\n---/);
-    const clusterRefs = frontmatter?.[1]?.match(/^cluster_refs:\n((?:  - .+\n?)*)/m)?.[1] ?? "";
-    for (const match of clusterRefs.matchAll(/#(\d+)/g)) {
-      const number = Number(match[1]);
-      if (!Number.isSafeInteger(number)) continue;
-      const files = refs.get(number) ?? [];
-      files.push(path.relative(repoRoot(), file));
-      refs.set(number, files);
-    }
-  }
-  return refs;
-}
-
 function yamlList(values: LooseRecord[]) {
   if (values.length === 0) return ["  []"];
   return values.map((value: string) => `  - ${quoteYaml(value)}`);
@@ -528,7 +564,7 @@ function goalText(mode: string) {
   return "Run one live autonomous classification pass. Classify open candidates only, verify live GitHub state, choose the current canonical issue or PR if the representative is obsolete, and emit only high-confidence planned close/comment/label actions. Closed context refs are evidence only and must not receive close actions.";
 }
 
-function jobNotes(clusterId: string, securitySensitiveMembers: JsonValue) {
+function jobNotes(clusterId: string | number, securitySensitiveMembers: JsonValue) {
   const base = `Generated from gitcrawl run cluster ${clusterId} on ${new Date().toISOString().slice(0, 10)}.`;
   if (securitySensitiveMembers.length === 0) return base;
   return `${base} Security-sensitive refs ${securitySensitiveMembers.map((member: JsonValue) => `#${member.number}`).join(", ")} must be routed with route_security and must not block unrelated non-security work.`;

--- a/test/repair/filter-cluster-candidates-live.test.ts
+++ b/test/repair/filter-cluster-candidates-live.test.ts
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { filterClusterCandidatesLive } from "../../dist/repair/filter-cluster-candidates-live.js";
+
+function job(root: string, clusterId: number, refs: number[], clusterRefs = refs): string {
+  const relative = `jobs/openclaw/inbox/gitcrawl-${clusterId}-candidate.md`;
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(
+    target,
+    `---\ncandidates:\n${refs.map((ref) => `  - "#${ref}"`).join("\n")}\ncluster_refs:\n${clusterRefs.map((ref) => `  - "#${ref}"`).join("\n")}\n---\n`,
+  );
+  return relative;
+}
+
+test("live fence rejects a cluster fixed after its stale gitcrawl snapshot", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 42, [100, 101]);
+  const items = new Map([
+    [
+      100,
+      {
+        number: 100,
+        state: "closed",
+        title: "Bug",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [],
+      },
+    ],
+    [
+      101,
+      {
+        number: 101,
+        state: "closed",
+        title: "Fix",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [],
+        pull_request: {},
+      },
+    ],
+  ]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => items.get(number),
+      readPull: () => ({ draft: false, maintainer_can_modify: true }),
+    });
+    assert.deepEqual(result.accepted, []);
+    assert.match(result.rejected[0].reasons.join("\n"), /closed or merged/);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence accepts two recent open non-security candidates", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 43, [200, 201]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: "open",
+        title: number === 200 ? "Telegram upload crashes" : "Fix Telegram upload crash",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: "bug" }],
+        ...(number === 201 ? { pull_request: {} } : {}),
+      }),
+      readPull: () => ({ draft: false, maintainer_can_modify: true }),
+    });
+    assert.deepEqual(result.accepted, [pathValue]);
+    assert.deepEqual(result.rejected, []);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence fills only the requested limit after rejecting a stale first choice", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const paths = [job(root, 44, [300, 301]), job(root, 45, [400, 401]), job(root, 46, [500, 501])];
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths,
+      maxAccepted: 1,
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: number < 400 ? "closed" : "open",
+        title: "Telegram upload crash",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: "bug" }],
+      }),
+      readPull: () => ({ draft: false, maintainer_can_modify: true }),
+    });
+    assert.deepEqual(result.accepted, [paths[1]]);
+    assert.match(result.rejected[0].reasons.join("\n"), /closed or merged/);
+    assert.match(result.rejected[1].reasons.join("\n"), /beyond intake limit/);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence rejects implementation PRs the worker cannot update", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 47, [600, 601]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: "open",
+        title: number === 600 ? "Telegram upload crashes" : "Fix Telegram upload crash",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: "bug" }],
+        ...(number === 601 ? { pull_request: {} } : {}),
+      }),
+      readPull: () => ({
+        draft: false,
+        maintainer_can_modify: false,
+        head: { repo: { full_name: "contributor/openclaw" } },
+      }),
+    });
+    assert.deepEqual(result.accepted, []);
+    assert.match(result.rejected[0].reasons.join("\n"), /no repairable open implementation PR/);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence keeps same-repository implementation PRs writable", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 54, [920, 921]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: "open",
+        title: number === 920 ? "Telegram upload crashes" : "Fix Telegram upload crash",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: "bug" }],
+        ...(number === 921 ? { pull_request: {} } : {}),
+      }),
+      readPull: () => ({
+        draft: false,
+        maintainer_can_modify: false,
+        head: { repo: { full_name: "openclaw/openclaw" } },
+      }),
+    });
+    assert.deepEqual(result.accepted, [pathValue]);
+    assert.deepEqual(result.rejected, []);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence rejects a security disclosure added to the current issue body", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 48, [700, 701]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: "open",
+        title: "Telegram upload crash",
+        body: number === 700 ? "This exposes a reusable authentication token." : "Fix upload.",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: "bug" }],
+      }),
+      readPull: () => ({ draft: false, maintainer_can_modify: true }),
+    });
+    assert.deepEqual(result.accepted, []);
+    assert.match(result.rejected[0].reasons.join("\n"), /security signal/);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence rejects newly added product, protected, and injection signals", () => {
+  const cases = [
+    {
+      clusterId: 49,
+      title: "Feature request: support Telegram upload themes",
+      body: "",
+      labels: [{ name: "enhancement" }],
+      reason: /feature or proposal/,
+    },
+    {
+      clusterId: 50,
+      title: "Telegram upload behavior",
+      body: "Needs a maintainer decision before changing compatibility.",
+      labels: [{ name: "clawsweeper:needs-product-decision" }],
+      reason: /maintainer or product decision/,
+    },
+    {
+      clusterId: 51,
+      title: "Fix SQL injection in Telegram webhook filter",
+      body: "A crafted query reaches the database.",
+      labels: [{ name: "bug" }],
+      reason: /security signal/,
+    },
+  ];
+  for (const fixture of cases) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+    const pathValue = job(root, fixture.clusterId, [800, 801]);
+    const previous = process.cwd();
+    process.chdir(root);
+    try {
+      const result = filterClusterCandidatesLive({
+        repo: "openclaw/openclaw",
+        paths: [pathValue],
+        now: new Date("2026-07-26T00:00:00Z"),
+        readItem: (number) => ({
+          number,
+          state: "open",
+          title: number === 800 ? fixture.title : "Fix Telegram upload behavior",
+          body: number === 800 ? fixture.body : "",
+          updated_at: "2026-07-25T00:00:00Z",
+          labels: number === 800 ? fixture.labels : [{ name: "bug" }],
+        }),
+        readPull: () => ({ draft: false, maintainer_can_modify: true }),
+      });
+      assert.deepEqual(result.accepted, []);
+      assert.match(result.rejected[0].reasons.join("\n"), fixture.reason);
+    } finally {
+      process.chdir(previous);
+    }
+  }
+});
+
+test("live fence screens closed context members outside the mutation candidates", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 52, [900, 901], [900, 901, 902]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: number === 902 ? "closed" : "open",
+        title:
+          number === 902
+            ? "Webhook filter permits SQL injection"
+            : "Webhook filter crashes on malformed predicates",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: "bug" }],
+      }),
+      readPull: () => ({ draft: false, maintainer_can_modify: true }),
+    });
+    assert.deepEqual(result.accepted, []);
+    assert.match(result.rejected[0].reasons.join("\n"), /cluster context has a security signal/);
+  } finally {
+    process.chdir(previous);
+  }
+});
+
+test("live fence rejects a label-only security escalation", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-live-cluster-"));
+  const pathValue = job(root, 53, [910, 911]);
+  const previous = process.cwd();
+  process.chdir(root);
+  try {
+    const result = filterClusterCandidatesLive({
+      repo: "openclaw/openclaw",
+      paths: [pathValue],
+      now: new Date("2026-07-26T00:00:00Z"),
+      readItem: (number) => ({
+        number,
+        state: "open",
+        title: "Webhook filter fails on malformed predicates",
+        updated_at: "2026-07-25T00:00:00Z",
+        labels: [{ name: number === 910 ? "impact:security" : "bug" }],
+      }),
+      readPull: () => ({ draft: false, maintainer_can_modify: true }),
+    });
+    assert.deepEqual(result.accepted, []);
+    assert.match(result.rejected[0].reasons.join("\n"), /cluster context has a security signal/);
+  } finally {
+    process.chdir(previous);
+  }
+});

--- a/test/repair/gitcrawl-cluster-history.test.ts
+++ b/test/repair/gitcrawl-cluster-history.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  existingGitcrawlClusterIds,
+  existingGitcrawlMemberRefs,
+} from "../../dist/repair/gitcrawl-cluster-history.js";
+
+test("member history spans inbox, archived jobs, and durable result roots", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-history-"));
+  const inbox = path.join(root, "jobs", "openclaw", "inbox");
+  const closed = path.join(root, "jobs", "openclaw", "closed");
+  const results = path.join(root, "results", "openclaw");
+  for (const directory of [inbox, closed, results]) fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(inbox, "gitcrawl-1.md"), report([101, 102]));
+  fs.writeFileSync(path.join(closed, "gitcrawl-2.md"), report([201, 202]));
+  fs.writeFileSync(path.join(results, "gitcrawl-3-result.md"), report([301, 302, 101]));
+  fs.writeFileSync(
+    path.join(results, "gitcrawl-4-foreign.md"),
+    report([101, 401], "openclaw/gogcli"),
+  );
+
+  const refs = existingGitcrawlMemberRefs(
+    [inbox, path.join(root, "jobs"), results],
+    "openclaw/openclaw",
+    root,
+  );
+  assert.deepEqual(
+    [...refs.keys()].sort((left, right) => left - right),
+    [101, 102, 201, 202, 301, 302],
+  );
+  assert.deepEqual(refs.get(201), ["jobs/openclaw/closed/gitcrawl-2.md"]);
+  assert.deepEqual(refs.get(301), ["results/openclaw/gitcrawl-3-result.md"]);
+  assert.deepEqual(refs.get(101), [
+    "jobs/openclaw/inbox/gitcrawl-1.md",
+    "results/openclaw/gitcrawl-3-result.md",
+  ]);
+});
+
+test("cluster history scopes repository-local IDs and reads the durable intake ledger", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-id-history-"));
+  fs.writeFileSync(
+    path.join(root, "gitcrawl-42-openclaw.md"),
+    report([101], "openclaw/openclaw", 42),
+  );
+  fs.writeFileSync(path.join(root, "gitcrawl-43-foreign.md"), report([101], "openclaw/gogcli", 43));
+  fs.writeFileSync(
+    path.join(root, "openclaw-openclaw.json"),
+    JSON.stringify({
+      target_repo: "openclaw/openclaw",
+      clusters: { 44: { status: "dispatched" } },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(root, "openclaw-gogcli.json"),
+    JSON.stringify({ target_repo: "openclaw/gogcli", clusters: { 45: { status: "dispatched" } } }),
+  );
+
+  assert.deepEqual(
+    [...existingGitcrawlClusterIds([root], "openclaw/openclaw")].sort(
+      (left, right) => left - right,
+    ),
+    [42, 44],
+  );
+});
+
+function report(refs: readonly number[], repo = "openclaw/openclaw", clusterId?: number): string {
+  const cluster = clusterId ? `cluster_id: gitcrawl-${clusterId}-proof\n` : "";
+  return `---\nrepo: ${repo}\n${cluster}cluster_refs:\n${refs.map((ref) => `  - #${ref}`).join("\n")}\n---\n`;
+}

--- a/test/repair/gitcrawl-cluster-ranking.test.ts
+++ b/test/repair/gitcrawl-cluster-ranking.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rankGitcrawlCluster } from "../../dist/repair/gitcrawl-cluster-ranking.js";
+
+const asOf = new Date("2026-07-26T00:00:00Z");
+const member = (overrides = {}) => ({
+  number: 1,
+  kind: "issue",
+  state: "open",
+  title: "Telegram upload crashes when media path contains spaces",
+  body: "Reproduction consistently throws an error.",
+  labels_json: '["bug"]',
+  updated_at: "2026-07-24T00:00:00Z",
+  ...overrides,
+});
+
+test("ranking favors recent narrow coherent bug clusters with a landable PR", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member(),
+      member({ number: 2, title: "Telegram media upload fails for paths with spaces" }),
+      member({
+        number: 3,
+        kind: "pull_request",
+        title: "Fix Telegram media upload paths containing spaces",
+      }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, true);
+  assert(ranking.score > 70);
+  assert.match(ranking.signals.join("\n"), /open implementation PR/);
+});
+
+test("ranking rejects closed, stale, broad, security, feature, and decision clusters", () => {
+  const fixtures = [
+    [member(), member({ number: 2, state: "closed" }), member({ number: 3, state: "closed" })],
+    [
+      member({ updated_at: "2026-01-01T00:00:00Z" }),
+      member({ number: 2, updated_at: "2026-01-02T00:00:00Z" }),
+    ],
+    Array.from({ length: 9 }, (_, index) => member({ number: index + 1 })),
+    [
+      member({ title: "Mattermost token forgeable via hardcoded HMAC" }),
+      member({ number: 2, title: "Fix forgeable Mattermost interaction token" }),
+    ],
+    [
+      member({ title: "Callback URLs expose reusable command tokens" }),
+      member({ number: 2, title: "Harden callback auth" }),
+    ],
+    [
+      member({ title: "Feature request: add Telegram themes" }),
+      member({ number: 2, title: "Feature: Telegram custom themes" }),
+    ],
+    [
+      member({ title: "Telegram transport needs a product decision" }),
+      member({ number: 2, labels_json: '["needs-maintainer-input"]' }),
+    ],
+  ];
+  for (const members of fixtures)
+    assert.equal(rankGitcrawlCluster(members, { asOf }).eligible, false);
+});
+
+test("ranking rejects unrelated clusters even when every member says bug", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member({ title: "Telegram upload crash" }),
+      member({ number: 2, title: "Windows installer error" }),
+      member({ number: 3, title: "Cron scheduler fails" }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, false);
+  assert.match(ranking.reasons.join("\n"), /low title cohesion/);
+});
+
+test("ranking rejects generic fix verbs without broken-behavior evidence", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member({
+        title: "Fix README typo in installation guide",
+        body: "Documentation cleanup.",
+        labels_json: "[]",
+      }),
+      member({
+        number: 2,
+        title: "Fix README spelling typo in installation guide",
+        body: "Documentation cleanup.",
+        labels_json: "[]",
+      }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, false);
+  assert.match(ranking.reasons.join("\n"), /no high-confidence bug signal/);
+});
+
+test("ranking requires bug evidence from every open issue candidate", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member({ title: "Telegram upload crashes in topic threads" }),
+      member({
+        number: 2,
+        title: "Telegram upload documentation for topic threads is unclear",
+        body: "The guide could explain this behavior more clearly.",
+        labels_json: "[]",
+      }),
+      member({
+        number: 3,
+        kind: "pull_request",
+        title: "Fix Telegram upload crash in topic threads",
+      }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, false);
+  assert.match(
+    ranking.reasons.join("\n"),
+    /open issue candidates lack high-confidence bug evidence \(1\/2\)/,
+  );
+});
+
+test("ranking rejects bridge clusters without pairwise root-cause overlap", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member({ title: "Telegram upload crashes on media paths" }),
+      member({ number: 2, title: "Telegram upload and cron scheduler fail" }),
+      member({ number: 3, title: "Cron scheduler hangs on missed runs" }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, false);
+  assert.match(ranking.reasons.join("\n"), /low title cohesion/);
+});
+
+test("ranking rejects an unrelated two-item bug cluster", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member({ title: "Telegram upload crash" }),
+      member({ number: 2, title: "Windows installer error" }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, false);
+  assert.match(ranking.reasons.join("\n"), /low title cohesion/);
+});
+
+test("ranking reads object-shaped bug and maintainer-decision labels", () => {
+  const eligible = rankGitcrawlCluster(
+    [
+      member({ labels_json: '[{"name":"bug"}]', title: "Telegram media behavior" }),
+      member({
+        number: 2,
+        labels_json: '[{"name":"bug"}]',
+        title: "Telegram media behavior regression",
+      }),
+    ],
+    { asOf },
+  );
+  assert.equal(eligible.eligible, true);
+
+  const blocked = rankGitcrawlCluster(
+    [
+      member({ labels_json: '[{"name":"bug"}]', title: "Telegram media behavior" }),
+      member({
+        number: 2,
+        labels_json: '[{"name":"needs-maintainer-input"}]',
+        title: "Telegram media behavior regression",
+      }),
+    ],
+    { asOf },
+  );
+  assert.equal(blocked.eligible, false);
+  assert.match(blocked.reasons.join("\n"), /maintainer or product decision/);
+});
+
+test("ranking rejects a single feature member and common vulnerability disclosures", () => {
+  const mixedProduct = rankGitcrawlCluster(
+    [
+      member({ title: "Telegram upload crashes" }),
+      member({ number: 2, title: "Feature request: support Telegram upload themes" }),
+    ],
+    { asOf },
+  );
+  assert.equal(mixedProduct.eligible, false);
+  assert.match(mixedProduct.reasons.join("\n"), /feature\/proposal/);
+
+  for (const disclosure of [
+    "Fix SQL injection in webhook filter",
+    "Prevent command injection in hook runner",
+    "Block SSRF in URL fetcher",
+    "Fix sandbox escape allowing arbitrary code execution",
+  ]) {
+    const ranking = rankGitcrawlCluster(
+      [member({ title: disclosure }), member({ number: 2, title: `${disclosure} regression` })],
+      { asOf },
+    );
+    assert.equal(ranking.eligible, false, disclosure);
+    assert.match(ranking.reasons.join("\n"), /security-sensitive/);
+  }
+});
+
+test("ranking rejects vulnerability evidence from a closed cluster member", () => {
+  const ranking = rankGitcrawlCluster(
+    [
+      member({ title: "Webhook filter crashes on malformed predicates" }),
+      member({ number: 2, title: "Webhook filter fails on malformed predicates" }),
+      member({
+        number: 3,
+        state: "closed",
+        title: "Webhook filter permits SQL injection",
+        body: "Security report for the same filter path.",
+      }),
+    ],
+    { asOf },
+  );
+  assert.equal(ranking.eligible, false);
+  assert.match(ranking.reasons.join("\n"), /security-sensitive cluster member/);
+});
+
+test("ranking rejects label-only security ownership", () => {
+  for (const label of ["impact:security", "clawsweeper:needs-security-review", "vulnerability"]) {
+    const ranking = rankGitcrawlCluster(
+      [
+        member({
+          title: "Webhook filter crashes on malformed predicates",
+          labels_json: `["${label}"]`,
+        }),
+        member({ number: 2, title: "Webhook filter fails on malformed predicates" }),
+      ],
+      { asOf },
+    );
+    assert.equal(ranking.eligible, false, label);
+    assert.match(ranking.reasons.join("\n"), /security-sensitive cluster member/);
+  }
+});


### PR DESCRIPTION
## Summary

This is **1/5** in the cluster-fixer reliability stack.

- Ranks clusters for recent, open, narrow, pairwise-coherent, high-confidence bugs.
- Rejects security-sensitive, feature/proposal, maintainer-decision, stale, closed-dominated, broad, unrelated, and unrepairable-PR clusters.
- Extends historical dedupe across inbox jobs, archived jobs, durable results, and the cluster-intake ledger so completed clusters are not selected again.
- Adds a live candidate fence before intake and emits durable rejection evidence when no candidate qualifies.

## Validation

- `pnpm run build:all`
- 22 focused ranking, history, and live-fence tests
- Included in the full stack's static, lint, and regression validation

## Stack

1. **This PR — candidate selection and historical dedupe**
2. [Durable intake queue priority](https://github.com/openclaw/clawsweeper/pull/882)
3. [Durable intake intent contract](https://github.com/openclaw/clawsweeper/pull/883)
4. [Exactly-once dispatch and recovery](https://github.com/openclaw/clawsweeper/pull/884)
5. [Workflow cutover and result publication hardening](https://github.com/openclaw/clawsweeper/pull/873)

Each later PR is based on the preceding branch. No merge/automerge or production gate is enabled by this stack.
