### PR TITLE
feat(state): prioritize durable cluster intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Prioritized durable cluster intake without starving sweep, router, proof, or canonical tuple rows during sustained intake. Thanks @RomneyDa! (#882)
 - Made every item/closed/plan/decision-packet writer publish an atomic canonical Worker tuple first, leaving the git state tree as materializer-only projection; added bounded canonical projection replay for migration convergence.
 - Removed the Claude CLI runtime layer; ClawSweeper is Codex-only.
 - Allowed four isolated exact-review batches to prepare concurrently while

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -330,7 +330,12 @@ type ExactReviewQueueMetricDelta = {
   publicationDeadLettered?: number;
   publicationRefreshed?: number;
 };
-type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof" | "record_tuple";
+type StateAppendKind =
+  | "sweep_status"
+  | "comment_router"
+  | "apply_proof"
+  | "record_tuple"
+  | "cluster_intake";
 type StateAppendRecord = {
   kind: StateAppendKind;
   key: string;
@@ -452,6 +457,7 @@ const STATE_APPEND_KINDS = new Set<StateAppendKind>([
   "sweep_status",
   "comment_router",
   "apply_proof",
+  "cluster_intake",
 ]);
 const DEFAULT_STATE_APPEND_MAX_PENDING_ROWS = 50_000;
 const DEFAULT_STATE_APPEND_MAX_PENDING_BYTES = 100 * 1024 * 1024;
@@ -5401,7 +5407,7 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_WINDOW_TABLE} (
          seq INTEGER PRIMARY KEY AUTOINCREMENT,
-         kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple')),
+         kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple', 'cluster_intake')),
          record_key TEXT NOT NULL,
          payload_json TEXT NOT NULL,
          payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
@@ -5413,42 +5419,9 @@ export class ExactReviewQueue {
          materialization_last_error TEXT
        ) STRICT`,
     );
-    const stateAppendTableRow = Array.from(
-      this.storage.sql.exec(
-        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`,
-        STATE_APPEND_WINDOW_TABLE,
-      ),
-    )[0] as { sql?: string } | undefined;
-    const stateAppendTableSql = String(stateAppendTableRow?.sql || "");
-    if (!stateAppendTableSql.includes("'record_tuple'")) {
-      this.storage.transactionSync(() => {
-        this.storage.sql.exec(
-          `CREATE TABLE state_append_window_v2 (
-             seq INTEGER PRIMARY KEY AUTOINCREMENT,
-             kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple')),
-             record_key TEXT NOT NULL,
-             payload_json TEXT NOT NULL,
-             payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
-             produced_at TEXT NOT NULL,
-             delivery_id TEXT NOT NULL,
-             drain_token TEXT,
-             materialization_attempts INTEGER NOT NULL DEFAULT 0 CHECK (materialization_attempts >= 0),
-             materialization_first_failed_at INTEGER,
-             materialization_last_error TEXT
-           ) STRICT`,
-        );
-        this.storage.sql.exec(
-          `INSERT INTO state_append_window_v2
-             (seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token)
-           SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token
-             FROM ${STATE_APPEND_WINDOW_TABLE}`,
-        );
-        this.storage.sql.exec(`DROP TABLE ${STATE_APPEND_WINDOW_TABLE}`);
-        this.storage.sql.exec(
-          `ALTER TABLE state_append_window_v2 RENAME TO ${STATE_APPEND_WINDOW_TABLE}`,
-        );
-      });
-    }
+    // Durable Objects can skip intermediate deployments. Normalize columns
+    // introduced by the retry-history migration before rebuilding an older
+    // kind constraint, because the copy below preserves those values.
     for (const [column, definition] of [
       [
         "materialization_attempts",
@@ -5468,6 +5441,44 @@ export class ExactReviewQueue {
           `ALTER TABLE ${STATE_APPEND_WINDOW_TABLE} ADD COLUMN ${column} ${definition}`,
         );
       }
+    }
+    const stateAppendTableRow = Array.from(
+      this.storage.sql.exec(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`,
+        STATE_APPEND_WINDOW_TABLE,
+      ),
+    )[0] as { sql?: string } | undefined;
+    const stateAppendTableSql = String(stateAppendTableRow?.sql || "");
+    if (!stateAppendTableSql.includes("'cluster_intake'")) {
+      this.storage.transactionSync(() => {
+        this.storage.sql.exec(
+          `CREATE TABLE state_append_window_v2 (
+             seq INTEGER PRIMARY KEY AUTOINCREMENT,
+             kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple', 'cluster_intake')),
+             record_key TEXT NOT NULL,
+             payload_json TEXT NOT NULL,
+             payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
+             produced_at TEXT NOT NULL,
+             delivery_id TEXT NOT NULL,
+             drain_token TEXT,
+             materialization_attempts INTEGER NOT NULL DEFAULT 0 CHECK (materialization_attempts >= 0),
+             materialization_first_failed_at INTEGER,
+             materialization_last_error TEXT
+           ) STRICT`,
+        );
+        this.storage.sql.exec(
+          `INSERT INTO state_append_window_v2
+             (seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token,
+              materialization_attempts, materialization_first_failed_at, materialization_last_error)
+           SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token,
+                  materialization_attempts, materialization_first_failed_at, materialization_last_error
+             FROM ${STATE_APPEND_WINDOW_TABLE}`,
+        );
+        this.storage.sql.exec(`DROP TABLE ${STATE_APPEND_WINDOW_TABLE}`);
+        this.storage.sql.exec(
+          `ALTER TABLE state_append_window_v2 RENAME TO ${STATE_APPEND_WINDOW_TABLE}`,
+        );
+      });
     }
     this.storage.sql.exec(
       `CREATE INDEX IF NOT EXISTS state_append_window_drain_seq
@@ -7050,7 +7061,7 @@ export class ExactReviewQueue {
                 materialization_attempts, materialization_first_failed_at, materialization_last_error
            FROM ${STATE_APPEND_WINDOW_TABLE}
           WHERE drain_token IS NULL
-          ORDER BY seq
+          ORDER BY CASE kind WHEN 'cluster_intake' THEN 0 ELSE 1 END, seq
           LIMIT ?`,
         maxRows,
       ) as Iterable<StateAppendWindowRow>,
@@ -7073,13 +7084,25 @@ export class ExactReviewQueue {
       now,
       expiresAt,
     );
-    this.storage.sql.exec(
-      `UPDATE ${STATE_APPEND_WINDOW_TABLE}
-          SET drain_token = ?
-        WHERE drain_token IS NULL AND seq <= ?`,
-      token,
-      rows.at(-1)?.seq,
-    );
+    const selectedSequences = rows.map((row) => Number(row.seq));
+    for (
+      let offset = 0;
+      offset < selectedSequences.length;
+      offset += EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH
+    ) {
+      const batch = selectedSequences.slice(
+        offset,
+        offset + EXACT_REVIEW_QUEUE_SQL_BINDING_ROW_BATCH,
+      );
+      const placeholders = batch.map(() => "?").join(",");
+      this.storage.sql.exec(
+        `UPDATE ${STATE_APPEND_WINDOW_TABLE}
+            SET drain_token = ?
+          WHERE drain_token IS NULL AND seq IN (${placeholders})`,
+        token,
+        ...batch,
+      );
+    }
     return { token, expiresAt, rows };
   }
 
@@ -10236,8 +10259,8 @@ function stateWriterTicketInput(value: unknown): StateWriterTicketInput | null {
   const runId = boundedStateWriterIdentity(body.run_id);
   const runAttempt = Number(body.run_attempt);
   const writerClass =
-    body.writer_class === "publication_batch"
-      ? "publication_batch"
+    body.writer_class === "publication_batch" || body.writer_class === "cluster_intake"
+      ? body.writer_class
       : body.writer_class === "ordinary" || body.writer_class === undefined
         ? "ordinary"
         : null;

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -466,6 +466,7 @@ const DEFAULT_STATE_APPEND_MAX_RECORD_BYTES = 256 * 1024;
 // residual lease contention during the #738 transition).
 const DEFAULT_STATE_APPEND_DRAIN_LEASE_MS = 30 * 60 * 1000;
 const STATE_APPEND_MATERIALIZATION_RETRY_LIMIT = 3;
+const STATE_APPEND_MAX_CONSECUTIVE_INTAKE_ONLY_DRAINS = 1;
 const EXACT_REVIEW_REVIEW_TELEMETRY_TABLE = "exact_review_review_telemetry";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
 const EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE = "exact_review_state_writer_operations";
@@ -5508,9 +5509,24 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${STATE_APPEND_META_TABLE} (
          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-         shed_since_reset INTEGER NOT NULL DEFAULT 0 CHECK (shed_since_reset >= 0)
+         shed_since_reset INTEGER NOT NULL DEFAULT 0 CHECK (shed_since_reset >= 0),
+         consecutive_intake_only_drains INTEGER NOT NULL DEFAULT 0
+           CHECK (consecutive_intake_only_drains >= 0)
        ) STRICT`,
     );
+    const intakeDrainBudgetPresent = Array.from(
+      this.storage.sql.exec(
+        `SELECT name FROM pragma_table_info('${STATE_APPEND_META_TABLE}')
+          WHERE name = 'consecutive_intake_only_drains'`,
+      ),
+    ).length;
+    if (!intakeDrainBudgetPresent) {
+      this.storage.sql.exec(
+        `ALTER TABLE ${STATE_APPEND_META_TABLE}
+           ADD COLUMN consecutive_intake_only_drains INTEGER NOT NULL DEFAULT 0
+             CHECK (consecutive_intake_only_drains >= 0)`,
+      );
+    }
     this.storage.sql.exec(
       `INSERT OR IGNORE INTO ${STATE_APPEND_META_TABLE} (singleton_id) VALUES (1)`,
     );
@@ -7055,14 +7071,26 @@ export class ExactReviewQueue {
       };
     }
 
+    const appendMeta = Array.from(
+      this.storage.sql.exec(
+        `SELECT consecutive_intake_only_drains
+           FROM ${STATE_APPEND_META_TABLE}
+          WHERE singleton_id = 1`,
+      ),
+    )[0] as { consecutive_intake_only_drains?: number } | undefined;
+    const prioritizeOrdinary =
+      Number(appendMeta?.consecutive_intake_only_drains || 0) >=
+      STATE_APPEND_MAX_CONSECUTIVE_INTAKE_ONLY_DRAINS;
     const candidates = Array.from(
       this.storage.sql.exec(
         `SELECT seq, kind, record_key, payload_json, payload_bytes, produced_at, delivery_id,
                 materialization_attempts, materialization_first_failed_at, materialization_last_error
            FROM ${STATE_APPEND_WINDOW_TABLE}
           WHERE drain_token IS NULL
-          ORDER BY CASE kind WHEN 'cluster_intake' THEN 0 ELSE 1 END, seq
+          ORDER BY CASE WHEN kind = 'cluster_intake' THEN ? ELSE ? END, seq
           LIMIT ?`,
+        prioritizeOrdinary ? 1 : 0,
+        prioritizeOrdinary ? 0 : 1,
         maxRows,
       ) as Iterable<StateAppendWindowRow>,
     );
@@ -7074,6 +7102,18 @@ export class ExactReviewQueue {
       bytes += Number(row.payload_bytes);
     }
     if (!rows.length) return { token: null, expiresAt: null, rows };
+
+    const intakeOnly = rows.every((row) => row.kind === "cluster_intake");
+    this.storage.sql.exec(
+      `UPDATE ${STATE_APPEND_META_TABLE}
+          SET consecutive_intake_only_drains = CASE
+                WHEN ? THEN MIN(consecutive_intake_only_drains + 1, ?)
+                ELSE 0
+              END
+        WHERE singleton_id = 1`,
+      intakeOnly ? 1 : 0,
+      STATE_APPEND_MAX_CONSECUTIVE_INTAKE_ONLY_DRAINS,
+    );
 
     const token = crypto.randomUUID();
     const expiresAt = now + stateAppendDrainLeaseMs(this.env);

--- a/dashboard/state-writer-coordinator.ts
+++ b/dashboard/state-writer-coordinator.ts
@@ -3,8 +3,10 @@ const STATE_WRITER_META_TABLE = "state_writer_meta";
 const STATE_WRITER_TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const STATE_WRITER_TERMINAL_PRUNE_LIMIT = 256;
 const MAX_CONSECUTIVE_BATCH_TURNS = 2;
+const MAX_CONSECUTIVE_INTAKE_TURNS = 1;
+const MAX_CONSECUTIVE_PRIORITY_TURNS = 2;
 
-export type StateWriterClass = "ordinary" | "publication_batch";
+export type StateWriterClass = "ordinary" | "publication_batch" | "cluster_intake";
 
 type SqlStorage = {
   exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
@@ -42,6 +44,7 @@ export type StateWriterTicket = {
 export type StateWriterCoordinatorStats = {
   queued: number;
   queued_batch: number;
+  queued_intake: number;
   queued_ordinary: number;
   leased: number;
   admitted: number;
@@ -51,6 +54,7 @@ export type StateWriterCoordinatorStats = {
   last_wait_ms: number;
   max_wait_ms: number;
   consecutive_batch_turns: number;
+  consecutive_intake_turns: number;
   active: null | {
     ticket_id: string;
     owner: string;
@@ -88,7 +92,7 @@ export class StateWriterCoordinator {
          run_id TEXT NOT NULL,
          run_attempt INTEGER NOT NULL CHECK (run_attempt >= 1),
          writer_class TEXT NOT NULL DEFAULT 'ordinary'
-           CHECK (writer_class IN ('ordinary', 'publication_batch')),
+           CHECK (writer_class IN ('ordinary', 'publication_batch', 'cluster_intake')),
          state TEXT NOT NULL CHECK (state IN ('queued', 'leased', 'completed', 'expired')),
          enqueued_at INTEGER NOT NULL,
          last_seen_at INTEGER NOT NULL,
@@ -101,6 +105,7 @@ export class StateWriterCoordinator {
        ) STRICT`,
     );
     this.ensureTicketColumnsSync();
+    this.ensureWriterClassSchemaSync();
     this.storage.sql.exec(
       `CREATE UNIQUE INDEX IF NOT EXISTS state_writer_one_active_ticket
          ON ${STATE_WRITER_TICKET_TABLE} (state)
@@ -124,7 +129,9 @@ export class StateWriterCoordinator {
          last_wait_ms INTEGER NOT NULL DEFAULT 0 CHECK (last_wait_ms >= 0),
          max_wait_ms INTEGER NOT NULL DEFAULT 0 CHECK (max_wait_ms >= 0),
          consecutive_batch_turns INTEGER NOT NULL DEFAULT 0
-           CHECK (consecutive_batch_turns >= 0)
+           CHECK (consecutive_batch_turns >= 0),
+         consecutive_intake_turns INTEGER NOT NULL DEFAULT 0
+           CHECK (consecutive_intake_turns >= 0)
        ) STRICT`,
     );
     this.ensureMetaColumnsSync();
@@ -203,11 +210,30 @@ export class StateWriterCoordinator {
                     max_wait_ms = MAX(max_wait_ms, ?),
                     consecutive_batch_turns = CASE
                       WHEN ? = 'publication_batch' THEN consecutive_batch_turns + 1
-                      ELSE 0
+                      WHEN ? = 'ordinary' THEN 0
+                      WHEN ? = 'cluster_intake' AND NOT EXISTS (
+                        SELECT 1 FROM ${STATE_WRITER_TICKET_TABLE}
+                         WHERE state = 'queued' AND writer_class = 'ordinary'
+                      ) THEN 0
+                      ELSE consecutive_batch_turns
+                    END,
+                    consecutive_intake_turns = CASE
+                      WHEN ? = 'cluster_intake' THEN consecutive_intake_turns + 1
+                      WHEN ? = 'ordinary' THEN 0
+                      WHEN ? = 'publication_batch' AND NOT EXISTS (
+                        SELECT 1 FROM ${STATE_WRITER_TICKET_TABLE}
+                         WHERE state = 'queued' AND writer_class = 'ordinary'
+                      ) THEN 0
+                      ELSE consecutive_intake_turns
                     END
               WHERE singleton_id = 1`,
             waitMs,
             waitMs,
+            input.writerClass,
+            input.writerClass,
+            input.writerClass,
+            input.writerClass,
+            input.writerClass,
             input.writerClass,
           );
         }
@@ -310,11 +336,12 @@ export class StateWriterCoordinator {
       const meta = Array.from(
         this.storage.sql.exec(
           `SELECT admitted_total, completed_total, expired_total, recovered_total,
-                  last_wait_ms, max_wait_ms, consecutive_batch_turns
+                  last_wait_ms, max_wait_ms, consecutive_batch_turns,
+                  consecutive_intake_turns
              FROM ${STATE_WRITER_META_TABLE} WHERE singleton_id = 1`,
         ),
       )[0] as Record<string, unknown> | undefined;
-      const queuedClasses = { publication_batch: 0, ordinary: 0 };
+      const queuedClasses = { cluster_intake: 0, publication_batch: 0, ordinary: 0 };
       for (const row of this.storage.sql.exec(
         `SELECT writer_class, COUNT(*) AS count FROM ${STATE_WRITER_TICKET_TABLE}
           WHERE state = 'queued' GROUP BY writer_class`,
@@ -327,6 +354,7 @@ export class StateWriterCoordinator {
       return {
         ...liveCounts,
         queued_batch: queuedClasses.publication_batch,
+        queued_intake: queuedClasses.cluster_intake,
         queued_ordinary: queuedClasses.ordinary,
         admitted: Number(meta?.admitted_total || 0),
         completed: Number(meta?.completed_total || 0),
@@ -335,6 +363,7 @@ export class StateWriterCoordinator {
         last_wait_ms: Number(meta?.last_wait_ms || 0),
         max_wait_ms: Number(meta?.max_wait_ms || 0),
         consecutive_batch_turns: Number(meta?.consecutive_batch_turns || 0),
+        consecutive_intake_turns: Number(meta?.consecutive_intake_turns || 0),
         active: active
           ? {
               ticket_id: String(active.ticket_id),
@@ -370,6 +399,7 @@ export class StateWriterCoordinator {
       "last_wait_ms",
       "max_wait_ms",
       "consecutive_batch_turns",
+      "consecutive_intake_turns",
     ]) {
       if (!columns.has(column)) {
         this.storage.sql.exec(
@@ -401,6 +431,55 @@ export class StateWriterCoordinator {
            ADD COLUMN writer_class TEXT NOT NULL DEFAULT 'ordinary'`,
       );
     }
+  }
+
+  private ensureWriterClassSchemaSync(): void {
+    const tableSql = String(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`,
+          STATE_WRITER_TICKET_TABLE,
+        ),
+      )[0]?.sql || "",
+    );
+    if (tableSql.includes("'cluster_intake'")) return;
+    this.storage.transactionSync(() => {
+      this.storage.sql.exec(
+        `CREATE TABLE state_writer_tickets_v2 (
+           seq INTEGER PRIMARY KEY AUTOINCREMENT,
+           ticket_id TEXT NOT NULL UNIQUE,
+           owner TEXT NOT NULL,
+           branch TEXT NOT NULL,
+           repository TEXT NOT NULL,
+           workflow TEXT NOT NULL,
+           job TEXT NOT NULL,
+           run_id TEXT NOT NULL,
+           run_attempt INTEGER NOT NULL CHECK (run_attempt >= 1),
+           writer_class TEXT NOT NULL DEFAULT 'ordinary'
+             CHECK (writer_class IN ('ordinary', 'publication_batch', 'cluster_intake')),
+           state TEXT NOT NULL CHECK (state IN ('queued', 'leased', 'completed', 'expired')),
+           enqueued_at INTEGER NOT NULL,
+           last_seen_at INTEGER NOT NULL,
+           leased_at INTEGER,
+           lease_token TEXT,
+           lease_generation INTEGER NOT NULL DEFAULT 0 CHECK (lease_generation >= 0),
+           lease_expires_at INTEGER,
+           lease_deadline_at INTEGER,
+           completed_at INTEGER
+         ) STRICT`,
+      );
+      this.storage.sql.exec(
+        `INSERT INTO state_writer_tickets_v2
+           SELECT seq, ticket_id, owner, branch, repository, workflow, job, run_id, run_attempt,
+                  writer_class, state, enqueued_at, last_seen_at, leased_at, lease_token,
+                  lease_generation, lease_expires_at, lease_deadline_at, completed_at
+             FROM ${STATE_WRITER_TICKET_TABLE}`,
+      );
+      this.storage.sql.exec(`DROP TABLE ${STATE_WRITER_TICKET_TABLE}`);
+      this.storage.sql.exec(
+        `ALTER TABLE state_writer_tickets_v2 RENAME TO ${STATE_WRITER_TICKET_TABLE}`,
+      );
+    });
   }
 
   private reclaimAndPruneSync(now: number, queuedStaleMs: number): void {
@@ -468,24 +547,43 @@ export class StateWriterCoordinator {
         `SELECT * FROM ${STATE_WRITER_TICKET_TABLE} WHERE state = 'queued' ORDER BY seq`,
       ),
     ) as Record<string, unknown>[];
+    const intakes = rows.filter((row) => row.writer_class === "cluster_intake");
     const batches = rows.filter((row) => row.writer_class === "publication_batch");
-    const ordinary = rows.filter((row) => row.writer_class !== "publication_batch");
+    const ordinary = rows.filter((row) => row.writer_class === "ordinary");
     const ordered: Record<string, unknown>[] = [];
     let consecutiveBatchTurns = this.consecutiveBatchTurnsSync();
-    while (batches.length || ordinary.length) {
+    let consecutiveIntakeTurns = this.consecutiveIntakeTurnsSync();
+    while (intakes.length || batches.length || ordinary.length) {
+      const priorityBudgetAvailable =
+        ordinary.length === 0 ||
+        consecutiveBatchTurns + consecutiveIntakeTurns < MAX_CONSECUTIVE_PRIORITY_TURNS;
+      if (
+        intakes.length > 0 &&
+        priorityBudgetAvailable &&
+        (batches.length + ordinary.length === 0 ||
+          consecutiveIntakeTurns < MAX_CONSECUTIVE_INTAKE_TURNS)
+      ) {
+        ordered.push(intakes.shift()!);
+        consecutiveIntakeTurns += 1;
+        if (ordinary.length === 0) consecutiveBatchTurns = 0;
+        continue;
+      }
       // A publication batch may skip the ordinary backlog, but after two such
       // turns an ordinary writer is guaranteed the next lease. This keeps the
       // incident lane serviceable without replacing one FIFO starvation mode
       // with permanent starvation of status, repair, and dashboard writers.
       if (
         batches.length > 0 &&
+        priorityBudgetAvailable &&
         (ordinary.length === 0 || consecutiveBatchTurns < MAX_CONSECUTIVE_BATCH_TURNS)
       ) {
         ordered.push(batches.shift()!);
         consecutiveBatchTurns += 1;
+        if (ordinary.length === 0) consecutiveIntakeTurns = 0;
       } else {
         ordered.push(ordinary.shift()!);
         consecutiveBatchTurns = 0;
+        consecutiveIntakeTurns = 0;
       }
     }
     return ordered;
@@ -498,6 +596,15 @@ export class StateWriterCoordinator {
       ),
     )[0] as { consecutive_batch_turns?: number } | undefined;
     return Number(row?.consecutive_batch_turns || 0);
+  }
+
+  private consecutiveIntakeTurnsSync(): number {
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT consecutive_intake_turns FROM ${STATE_WRITER_META_TABLE} WHERE singleton_id = 1`,
+      ),
+    )[0] as { consecutive_intake_turns?: number } | undefined;
+    return Number(row?.consecutive_intake_turns || 0);
   }
 
   private ticketJsonSync(row: Record<string, unknown>): StateWriterTicket {

--- a/src/repair/state-append-client.ts
+++ b/src/repair/state-append-client.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "node:crypto";
 
 export type StateAppendInputRecord = {
-  kind: "sweep_status" | "comment_router" | "apply_proof";
+  kind: "sweep_status" | "comment_router" | "apply_proof" | "cluster_intake";
   key: string;
   payload: unknown;
   produced_at: string;
@@ -10,6 +10,7 @@ export type StateAppendInputRecord = {
 export type StateAppendResult = {
   ok: boolean;
   shed: boolean;
+  deduped: boolean;
 };
 
 export type CanonicalRecordTupleOperation = {
@@ -55,14 +56,14 @@ export async function postStateAppend(options: {
       body,
     });
     const value = (await response.json().catch(() => null)) as unknown;
-    if (isRecord(value) && value.shed === true) return { ok: false, shed: true };
+    if (isRecord(value) && value.shed === true) return { ok: false, shed: true, deduped: false };
     if (!response.ok) {
       throw new Error(`POST /internal/state/append returned ${response.status}`);
     }
     if (!isRecord(value) || typeof value.ok !== "boolean") {
       throw new Error("POST /internal/state/append returned an invalid response");
     }
-    return { ok: value.ok, shed: false };
+    return { ok: value.ok, shed: false, deduped: value.deduped === true };
   } catch (error) {
     throw new Error(redactStateAppendSecrets(errorMessage(error)));
   }

--- a/src/repair/state-writer-coordinator.ts
+++ b/src/repair/state-writer-coordinator.ts
@@ -105,10 +105,11 @@ export function acquireStateWriterCoordinator(
         job: env.GITHUB_JOB || "local",
         run_id: env.GITHUB_RUN_ID || "local",
         run_attempt: positiveInteger(env.GITHUB_RUN_ATTEMPT, 1),
-        writer_class:
-          env.CLAWSWEEPER_STATE_COORDINATOR_CLASS === "publication_batch"
-            ? "publication_batch"
-            : "ordinary",
+        writer_class: ["publication_batch", "cluster_intake"].includes(
+          env.CLAWSWEEPER_STATE_COORDINATOR_CLASS || "",
+        )
+          ? env.CLAWSWEEPER_STATE_COORDINATOR_CLASS
+          : "ordinary",
       });
       ambiguousRequestFailures = 0;
     } catch (error) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -8617,6 +8617,68 @@ test("cluster intake jumps queued publication traffic without capturing unrelate
   );
 });
 
+test("continuous cluster intake cannot starve ordinary state append rows", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const ordinaryAppend = await queue.fetch(
+    stateAppendQueueRequest("/state/append", {
+      delivery_id: "ordinary-before-continuous-intake",
+      records: [
+        stateAppendRecord("sweep_status", "sweep", { n: 1 }),
+        stateAppendRecord("comment_router", "router", { n: 2 }),
+        stateAppendRecord("apply_proof", "proof", { n: 3 }),
+      ],
+    }),
+  );
+  assert.equal(ordinaryAppend.status, 202);
+  const item = "---\nrepo: openclaw/openclaw\nnumber: 42\n---\n\nreview\n";
+  const tupleAppend = await queue.fetch(
+    stateAppendQueueRequest("/records/tuples", {
+      deliveryId: "continuous-intake-record-tuple",
+      key: "openclaw-openclaw/42",
+      operations: [
+        {
+          path: "records/openclaw-openclaw/items/42.md",
+          expectedDigest: null,
+          contentBase64: Buffer.from(item).toString("base64"),
+        },
+        { path: "records/openclaw-openclaw/closed/42.md", expectedDigest: null },
+        { path: "records/openclaw-openclaw/plans/42.md", expectedDigest: null },
+        {
+          path: "records/openclaw-openclaw/decision-packets/42.json",
+          expectedDigest: null,
+        },
+      ],
+    }),
+  );
+  assert.equal(tupleAppend.status, 202);
+
+  const drainedKinds = [];
+  for (let round = 1; round <= 8; round += 1) {
+    await queue.fetch(
+      stateAppendQueueRequest("/state/append", {
+        delivery_id: `continuous-intake-${round}`,
+        records: [stateAppendRecord("cluster_intake", `cluster-${round}`, { jobs: [] })],
+      }),
+    );
+    const drained = await (
+      await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 1, max_bytes: 1024 }))
+    ).json();
+    drainedKinds.push(drained.records[0].kind);
+    await queue.fetch(stateAppendQueueRequest("/state/ack", { drain_token: drained.drain_token }));
+  }
+
+  assert.deepEqual(drainedKinds, [
+    "cluster_intake",
+    "sweep_status",
+    "cluster_intake",
+    "comment_router",
+    "cluster_intake",
+    "apply_proof",
+    "cluster_intake",
+    "record_tuple",
+  ]);
+});
+
 test("expired state drain leases make the same rows available under a new token", async () => {
   const originalNow = Date.now;
   let now = Date.parse("2026-07-20T12:00:00.000Z");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3985,8 +3985,12 @@ class MemorySqlCursor<T extends Record<string, unknown>> implements Iterable<T> 
 class MemorySqlStorage {
   private readonly database = new DatabaseSync(":memory:");
   private failure: { pattern: RegExp; error: Error } | undefined;
+  private bindingLimit = Number.POSITIVE_INFINITY;
 
   exec(query: string, ...bindings: unknown[]) {
+    if (bindings.length > this.bindingLimit) {
+      throw new Error(`test SQL binding limit exceeded: ${bindings.length}`);
+    }
     if (this.failure?.pattern.test(query)) {
       const { error } = this.failure;
       this.failure = undefined;
@@ -4015,6 +4019,10 @@ class MemorySqlStorage {
 
   failNext(pattern: RegExp, error = new Error("injected SQL failure")) {
     this.failure = { pattern, error };
+  }
+
+  setBindingLimit(limit: number) {
+    this.bindingLimit = limit;
   }
 
   hasNormalizedQueue() {
@@ -8278,6 +8286,112 @@ test("canonical tuple publication accepts explicit absent sidecars and closed re
   }
 });
 
+test("cluster intake schema migration preserves materialization retry history", () => {
+  const storage = new MemoryDurableStorage();
+  storage.sql.exec(`CREATE TABLE state_append_window (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple')),
+    record_key TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
+    produced_at TEXT NOT NULL,
+    delivery_id TEXT NOT NULL,
+    drain_token TEXT,
+    materialization_attempts INTEGER NOT NULL DEFAULT 0 CHECK (materialization_attempts >= 0),
+    materialization_first_failed_at INTEGER,
+    materialization_last_error TEXT
+  ) STRICT`);
+  storage.sql.exec(
+    `INSERT INTO state_append_window
+       (kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token,
+        materialization_attempts, materialization_first_failed_at, materialization_last_error)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    "record_tuple",
+    "openclaw-openclaw/42",
+    "{}",
+    2,
+    "2026-07-26T12:00:00.000Z",
+    "retry-history",
+    null,
+    2,
+    1_785_066_000_000,
+    "Shallow Git recovery deferred after deepening by 1024 commits",
+  );
+
+  new ExactReviewQueue({ storage }, {});
+
+  assert.deepEqual(
+    Array.from(
+      storage.sql.exec(
+        `SELECT materialization_attempts, materialization_first_failed_at,
+                materialization_last_error
+           FROM state_append_window WHERE record_key = ?`,
+        "openclaw-openclaw/42",
+      ),
+    ).map((row) => ({ ...row })),
+    [
+      {
+        materialization_attempts: 2,
+        materialization_first_failed_at: 1_785_066_000_000,
+        materialization_last_error: "Shallow Git recovery deferred after deepening by 1024 commits",
+      },
+    ],
+  );
+});
+
+test("cluster intake schema migration upgrades a pre-retry append table", () => {
+  const storage = new MemoryDurableStorage();
+  storage.sql.exec(`CREATE TABLE state_append_window (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL CHECK (kind IN ('sweep_status', 'comment_router', 'apply_proof', 'record_tuple')),
+    record_key TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    payload_bytes INTEGER NOT NULL CHECK (payload_bytes >= 0),
+    produced_at TEXT NOT NULL,
+    delivery_id TEXT NOT NULL,
+    drain_token TEXT
+  ) STRICT`);
+  storage.sql.exec(
+    `INSERT INTO state_append_window
+       (kind, record_key, payload_json, payload_bytes, produced_at, delivery_id, drain_token)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    "record_tuple",
+    "openclaw-openclaw/41",
+    "{}",
+    2,
+    "2026-07-25T12:00:00.000Z",
+    "pre-retry-schema",
+    null,
+  );
+
+  new ExactReviewQueue({ storage }, {});
+
+  assert.deepEqual(
+    Array.from(
+      storage.sql.exec(
+        `SELECT kind, materialization_attempts, materialization_first_failed_at,
+                materialization_last_error
+           FROM state_append_window WHERE record_key = ?`,
+        "openclaw-openclaw/41",
+      ),
+    ).map((row) => ({ ...row })),
+    [
+      {
+        kind: "record_tuple",
+        materialization_attempts: 0,
+        materialization_first_failed_at: null,
+        materialization_last_error: null,
+      },
+    ],
+  );
+  storage.sql.exec(
+    `INSERT INTO state_append_window
+       (kind, record_key, payload_json, payload_bytes, produced_at, delivery_id)
+     VALUES ('cluster_intake', 'openclaw-openclaw/store', '{}', 2,
+             '2026-07-26T12:00:00.000Z', 'cluster-intake-supported')`,
+  );
+});
+
 test("state append sheds atomically at the configured cap without consuming its receipt", async () => {
   const queue = new ExactReviewQueue(
     { storage: new MemoryDurableStorage() },
@@ -8433,6 +8547,73 @@ test("state disposition commits valid rows and dead-letters a poison row after b
         status: "open",
       },
     ],
+  );
+});
+
+test("state drain claims large prioritized batches within the SQL binding limit", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const records = Array.from({ length: 120 }, (_, index) =>
+    stateAppendRecord("cluster_intake", `cluster-${index + 1}`, { jobs: [], index }),
+  );
+  assert.equal(
+    (
+      await queue.fetch(
+        stateAppendQueueRequest("/state/append", {
+          delivery_id: "large-prioritized-drain",
+          records,
+        }),
+      )
+    ).status,
+    202,
+  );
+  storage.sql.setBindingLimit(51);
+
+  const drained = await (
+    await queue.fetch(
+      stateAppendQueueRequest("/state/drain", { max_rows: 120, max_bytes: 1024 * 1024 }),
+    )
+  ).json();
+  assert.equal(drained.records.length, 120);
+  assert.deepEqual(
+    drained.records.map((record) => record.seq),
+    Array.from({ length: 120 }, (_, index) => index + 1),
+  );
+});
+
+test("cluster intake jumps queued publication traffic without capturing unrelated rows", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  await queue.fetch(
+    stateAppendQueueRequest("/state/append", {
+      delivery_id: "ordinary-publications",
+      records: [
+        stateAppendRecord("sweep_status", "one", { n: 1 }),
+        stateAppendRecord("comment_router", "two", { n: 2 }),
+        stateAppendRecord("apply_proof", "three", { n: 3 }),
+      ],
+    }),
+  );
+  await queue.fetch(
+    stateAppendQueueRequest("/state/append", {
+      delivery_id: "cluster-intake-priority",
+      records: [stateAppendRecord("cluster_intake", "openclaw-openclaw/store", { jobs: [] })],
+    }),
+  );
+
+  const priority = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 1, max_bytes: 1024 }))
+  ).json();
+  assert.deepEqual(
+    priority.records.map((record) => [record.seq, record.kind]),
+    [[4, "cluster_intake"]],
+  );
+  await queue.fetch(stateAppendQueueRequest("/state/ack", { drain_token: priority.drain_token }));
+  const ordinary = await (
+    await queue.fetch(stateAppendQueueRequest("/state/drain", { max_rows: 10, max_bytes: 1024 }))
+  ).json();
+  assert.deepEqual(
+    ordinary.records.map((record) => record.seq),
+    [1, 2, 3],
   );
 });
 

--- a/test/repair/state-append-client.test.ts
+++ b/test/repair/state-append-client.test.ts
@@ -78,7 +78,23 @@ test("postStateAppend signs and posts the exact append body", async () => {
       records,
       fetchImpl,
     }),
-    { ok: true, shed: false },
+    { ok: true, shed: false, deduped: false },
+  );
+});
+
+test("postStateAppend propagates an idempotent delivery receipt", async () => {
+  const fetchImpl = (async () =>
+    Response.json({ ok: true, deduped: true }, { status: 202 })) as typeof fetch;
+
+  assert.deepEqual(
+    await postStateAppend({
+      queueUrl: "https://queue.test",
+      webhookSecret,
+      deliveryId: "delivery-duplicate",
+      records,
+      fetchImpl,
+    }),
+    { ok: true, shed: false, deduped: true },
   );
 });
 
@@ -94,7 +110,7 @@ test("postStateAppend reports a shed response without throwing", async () => {
       records,
       fetchImpl,
     }),
-    { ok: false, shed: true },
+    { ok: false, shed: true, deduped: false },
   );
 });
 
@@ -109,7 +125,7 @@ test("postStateAppend preserves an explicit unsuccessful response as a fallback 
       records,
       fetchImpl,
     }),
-    { ok: false, shed: false },
+    { ok: false, shed: false, deduped: false },
   );
 });
 

--- a/test/state-writer-coordinator.test.ts
+++ b/test/state-writer-coordinator.test.ts
@@ -236,6 +236,143 @@ test("publication batches skip ordinary backlog but yield after two consecutive 
   assert.equal(stats.consecutive_batch_turns, 0);
 });
 
+test("intake and publication priority share one bounded budget before ordinary traffic", () => {
+  const { coordinator } = fixture();
+  const active = writer("active-intake", "Sweep", "status");
+  const ordinary = writer("ordinary-intake", "Repair comment router", "route");
+  const batch = writer(
+    "batch-intake",
+    "Publish exact review batch",
+    "publish",
+    "publication_batch",
+  );
+  const intakeOne = writer(
+    "cluster-intake-one",
+    "Materialize queued state",
+    "materialize",
+    "cluster_intake",
+  );
+  const intakeTwo = writer(
+    "cluster-intake-two",
+    "Materialize queued state",
+    "materialize",
+    "cluster_intake",
+  );
+
+  const activeLease = acquire(coordinator, active, 1_000);
+  acquire(coordinator, ordinary, 1_100);
+  acquire(coordinator, batch, 1_200);
+  assert.equal(acquire(coordinator, intakeOne, 1_300).position, 1);
+  assert.equal(acquire(coordinator, intakeTwo, 1_400).position, 4);
+  assert.equal(
+    coordinator.release(
+      active.ticketId,
+      active.owner,
+      required(activeLease.leaseToken),
+      1_500,
+      QUEUED_STALE_MS,
+    ),
+    true,
+  );
+
+  const intakeLease = acquire(coordinator, intakeOne, 1_600);
+  assert.equal(intakeLease.state, "leased");
+  assert.equal(
+    coordinator.release(
+      intakeOne.ticketId,
+      intakeOne.owner,
+      required(intakeLease.leaseToken),
+      1_700,
+      QUEUED_STALE_MS,
+    ),
+    true,
+  );
+  assert.equal(acquire(coordinator, intakeTwo, 1_800).position, 3);
+  const batchLease = acquire(coordinator, batch, 1_801);
+  assert.equal(batchLease.state, "leased");
+  assert.equal(
+    coordinator.release(
+      batch.ticketId,
+      batch.owner,
+      required(batchLease.leaseToken),
+      1_900,
+      QUEUED_STALE_MS,
+    ),
+    true,
+  );
+  assert.equal(acquire(coordinator, intakeTwo, 2_000).position, 2);
+  const ordinaryLease = acquire(coordinator, ordinary, 2_001);
+  assert.equal(ordinaryLease.state, "leased");
+  const stats = coordinator.stats(2_001, QUEUED_STALE_MS);
+  assert.equal(stats.queued_intake, 1);
+  assert.equal(stats.queued_ordinary, 0);
+  assert.equal(stats.consecutive_intake_turns, 0);
+  assert.equal(stats.consecutive_batch_turns, 0);
+});
+
+test("publication batches yield back to intake when no ordinary writer is queued", () => {
+  const { coordinator } = fixture();
+  const active = writer("active-priority", "Sweep", "status");
+  const intakeOne = writer(
+    "intake-priority-one",
+    "Materialize queued state",
+    "materialize",
+    "cluster_intake",
+  );
+  const intakeTwo = writer(
+    "intake-priority-two",
+    "Materialize queued state",
+    "materialize",
+    "cluster_intake",
+  );
+  const batchOne = writer(
+    "batch-priority-one",
+    "Publish exact review batch",
+    "publish",
+    "publication_batch",
+  );
+  const batchTwo = writer(
+    "batch-priority-two",
+    "Publish exact review batch",
+    "publish",
+    "publication_batch",
+  );
+
+  const activeLease = acquire(coordinator, active, 1_000);
+  acquire(coordinator, intakeOne, 1_100);
+  acquire(coordinator, batchOne, 1_200);
+  acquire(coordinator, batchTwo, 1_300);
+  coordinator.release(
+    active.ticketId,
+    active.owner,
+    required(activeLease.leaseToken),
+    1_400,
+    QUEUED_STALE_MS,
+  );
+  const intakeOneLease = acquire(coordinator, intakeOne, 1_500);
+  coordinator.release(
+    intakeOne.ticketId,
+    intakeOne.owner,
+    required(intakeOneLease.leaseToken),
+    1_600,
+    QUEUED_STALE_MS,
+  );
+  acquire(coordinator, intakeTwo, 1_700);
+  const batchOneLease = acquire(coordinator, batchOne, 1_800);
+  assert.equal(batchOneLease.state, "leased");
+  coordinator.release(
+    batchOne.ticketId,
+    batchOne.owner,
+    required(batchOneLease.leaseToken),
+    1_900,
+    QUEUED_STALE_MS,
+  );
+
+  const intakeTwoLease = acquire(coordinator, intakeTwo, 2_000);
+  assert.equal(intakeTwoLease.state, "leased");
+  assert.equal(acquire(coordinator, batchTwo, 2_001).position, 1);
+});
+
 test("expired active and abandoned queue-head writers recover without accepting stale owners", () => {
   const { coordinator } = fixture();
   const active = writer("active", "Exact review batch publish", "publish");


### PR DESCRIPTION
## Summary

This is **2/5** in the cluster-fixer reliability stack, based on [PR 881](https://github.com/openclaw/clawsweeper/pull/881).

- Adds `cluster_intake` as a first-class durable state-append kind.
- Gives cluster intake bounded coordinator and queue priority so it cannot starve behind unrelated comment/review traffic.
- Preserves fairness by sharing a priority budget and yielding to ordinary writers.
- Carries coordinator class and queue metadata through the append client contract.
- Adds migration, fairness, lease, timeout, and priority regression coverage.

## Validation

- `pnpm run build:all`
- 253 focused dashboard queue, append-client, and coordinator tests
- Included in the full stack's static, lint, and regression validation

## Stack

1. [Candidate selection and historical dedupe](https://github.com/openclaw/clawsweeper/pull/881)
2. **This PR — durable intake queue priority**
3. [Durable intake intent contract](https://github.com/openclaw/clawsweeper/pull/883)
4. [Exactly-once dispatch and recovery](https://github.com/openclaw/clawsweeper/pull/884)
5. [Workflow cutover and result publication hardening](https://github.com/openclaw/clawsweeper/pull/873)

No timeout is enlarged, and no merge/automerge or production gate is enabled.
