### PR TITLE
feat(repair): dispatch durable cluster jobs exactly once

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -14,6 +14,21 @@ on:
         required: false
         default: ""
         type: string
+      job_payload:
+        description: "Optional base64 job content from durable cluster intake"
+        required: false
+        default: ""
+        type: string
+      job_digest:
+        description: "SHA-256 fence for job_payload"
+        required: false
+        default: ""
+        type: string
+      job_auth:
+        description: "Materializer HMAC binding the durable job dispatch"
+        required: false
+        default: ""
+        type: string
       automerge_session_id:
         description: "Stable automerge product telemetry session"
         required: false
@@ -82,6 +97,20 @@ env:
   GEMINI_API_KEY: ${{ vars.CLAWSWEEPER_RUNNER == 'openclaw' && secrets.GEMINI_API_KEY || '' }}
   KIMI_API_KEY: ${{ vars.CLAWSWEEPER_RUNNER == 'openclaw' && secrets.KIMI_API_KEY || '' }}
   OPENROUTER_API_KEY: ${{ vars.CLAWSWEEPER_RUNNER == 'openclaw' && secrets.OPENROUTER_API_KEY || '' }}
+  CLUSTER_JOB_PATH: ${{ inputs.job }}
+  CLUSTER_DISPATCH_KEY: ${{ inputs.dispatch_key }}
+  CLUSTER_JOB_PAYLOAD: ${{ inputs.job_payload }}
+  CLUSTER_JOB_DIGEST: ${{ inputs.job_digest }}
+  CLUSTER_JOB_AUTH: ${{ inputs.job_auth }}
+  CLUSTER_WORKER_MODE: ${{ inputs.mode }}
+  CLUSTER_WORKER_MODEL: ${{ inputs.model }}
+  CLUSTER_WORKER_DRY_RUN: ${{ inputs.dry_run }}
+  CLUSTER_WORKER_RUNNER: ${{ inputs.runner }}
+  CLUSTER_EXECUTION_RUNNER: ${{ inputs.execution_runner }}
+  CLUSTER_PLANNER_SANDBOX: ${{ inputs.planner_sandbox }}
+  CLUSTER_REQUEUE_DEPTH: ${{ inputs.requeue_depth }}
+  CLUSTER_AUTOMERGE_SESSION_ID: ${{ inputs.automerge_session_id }}
+  CLUSTER_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 concurrency:
   group: ${{ inputs.requeue && format('clawsweeper-repair-requeue-{0}-{1}', inputs.job, github.run_id) || format('clawsweeper-repair-{0}', inputs.job) }}
@@ -101,8 +130,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          sparse-checkout: scripts/dispatch-receipt-owner.sh
-          sparse-checkout-cone-mode: false
+          filter: blob:none
+
+      - uses: ./.github/actions/setup-pnpm
+        if: ${{ inputs.job_payload != '' }}
+        with:
+          build-script: build:repair
+
+      - name: Authenticate durable intake before credentials
+        if: ${{ inputs.job_payload != '' }}
+        env:
+          CLAWSWEEPER_ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run repair:restore-cluster-intake-job
 
       - id: receipt
         env:
@@ -219,6 +259,16 @@ jobs:
           fetch-depth: 1
           sparse-checkout: jobs
 
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Restore durable intake job
+        if: ${{ inputs.job_payload != '' }}
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run repair:restore-cluster-intake-job
+
       - name: Check job file
         id: check_job
         env:
@@ -246,11 +296,6 @@ jobs:
           echo "key=$key" >> "$GITHUB_OUTPUT"
           echo "codex_home=$codex_home" >> "$GITHUB_OUTPUT"
           echo "CLAWSWEEPER_CODEX_THREAD_STATE=$codex_home/clawsweeper-thread-state.json" >> "$GITHUB_ENV"
-
-      - uses: ./.github/actions/setup-pnpm
-        if: ${{ steps.check_job.outputs.job_exists == '1' }}
-        with:
-          build-script: build:repair
 
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.check_job.outputs.job_exists == '1' }}
@@ -281,7 +326,7 @@ jobs:
         env:
           CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN: ${{ secrets.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN }}
           CLAWSWEEPER_CRABFLEET_OWNER: ${{ vars.CLAWSWEEPER_CRABFLEET_OWNER }}
-        run: pnpm run repair:action-session -- register "${{ inputs.job }}"
+        run: pnpm run repair:action-session -- register "$CLUSTER_JOB_PATH"
 
       - name: Verify GitHub read token
         if: ${{ steps.check_job.outputs.job_exists == '1' }}
@@ -298,7 +343,7 @@ jobs:
         if: ${{ steps.check_job.outputs.job_exists == '1' }}
         env:
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:validate-job -- "${{ inputs.job }}"
+        run: pnpm run repair:validate-job -- "$CLUSTER_JOB_PATH"
 
       - name: Verify self-heal head
         id: self_heal_head
@@ -306,7 +351,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:conflict-self-heal -- --verify-job-head "${{ inputs.job }}"
+        run: pnpm run repair:conflict-self-heal -- --verify-job-head "$CLUSTER_JOB_PATH"
 
       - name: Publish automatic implementation planning status
         if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' }}
@@ -316,10 +361,10 @@ jobs:
           CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
         run: |
           pnpm run repair:issue-implementation-status -- \
-            --job "${{ inputs.job }}" \
+            --job "$CLUSTER_JOB_PATH" \
             --state "Planning" \
             --detail "Codex is reading the issue and repository, choosing an implementation, and planning validation." \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --run-url "$CLUSTER_RUN_URL"
 
       - name: Run worker
         id: run_worker
@@ -328,14 +373,14 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
         run: |
-          worker_mode="${{ inputs.mode }}"
+          worker_mode="$CLUSTER_WORKER_MODE"
           if [ "$worker_mode" != "plan" ] && [ "${CLAWSWEEPER_ALLOW_EXECUTE}" != "1" ]; then
             echo "CLAWSWEEPER_ALLOW_EXECUTE is not explicitly 1; rendering plan-only output for requested $worker_mode run"
             worker_mode="plan"
           fi
           echo "effective_mode=$worker_mode" >> "$GITHUB_OUTPUT"
-          args=("${{ inputs.job }}" --mode "$worker_mode" --model "${{ inputs.model }}")
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          args=("$CLUSTER_JOB_PATH" --mode "$worker_mode" --model "$CLUSTER_WORKER_MODEL")
+          if [ "$CLUSTER_WORKER_DRY_RUN" = "true" ]; then
             args+=(--dry-run)
           fi
           pnpm run repair:worker -- "${args[@]}"
@@ -398,8 +443,10 @@ jobs:
 
       - name: Record planning completion
         if: ${{ success() && steps.crabfleet_session.outcome == 'success' }}
+        env:
+          EFFECTIVE_MODE: ${{ steps.run_worker.outputs.effective_mode }}
         run: |
-          if [[ "${{ steps.run_worker.outputs.effective_mode }}" == "plan" || "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "$EFFECTIVE_MODE" == "plan" || "$CLUSTER_WORKER_DRY_RUN" == "true" ]]; then
             pnpm run repair:action-session -- update \
               --state completed \
               --phase "done" \
@@ -513,6 +560,17 @@ jobs:
             jobs
             ledger
 
+      - uses: ./.github/actions/setup-pnpm
+        id: execute-setup-pnpm
+        with:
+          build-script: build:repair
+
+      - name: Restore durable intake job
+        if: ${{ inputs.job_payload != '' }}
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run repair:restore-cluster-intake-job
+
       - name: Check job file
         id: check_job
         env:
@@ -531,12 +589,6 @@ jobs:
           echo "key=$key" >> "$GITHUB_OUTPUT"
           echo "codex_home=$codex_home" >> "$GITHUB_OUTPUT"
           echo "CLAWSWEEPER_CODEX_THREAD_STATE=$codex_home/clawsweeper-thread-state.json" >> "$GITHUB_ENV"
-
-      - uses: ./.github/actions/setup-pnpm
-        id: execute-setup-pnpm
-        if: ${{ steps.check_job.outputs.job_exists == '1' }}
-        with:
-          build-script: build:repair
 
       - uses: ./.github/actions/setup-codex
         if: ${{ env.CLAWSWEEPER_RUNNER != 'openclaw' && steps.check_job.outputs.job_exists == '1' }}
@@ -567,7 +619,7 @@ jobs:
         env:
           CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN: ${{ secrets.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN }}
           CLAWSWEEPER_CRABFLEET_OWNER: ${{ vars.CLAWSWEEPER_CRABFLEET_OWNER }}
-        run: pnpm run repair:action-session -- register "${{ inputs.job }}"
+        run: pnpm run repair:action-session -- register "$CLUSTER_JOB_PATH"
 
       - name: Download worker artifacts
         if: ${{ steps.check_job.outputs.job_exists == '1' }}
@@ -580,7 +632,7 @@ jobs:
         if: ${{ steps.check_job.outputs.job_exists == '1' }}
         env:
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:validate-job -- "${{ inputs.job }}"
+        run: pnpm run repair:validate-job -- "$CLUSTER_JOB_PATH"
 
       - name: Verify self-heal head
         id: self_heal_head
@@ -588,7 +640,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target_write_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:conflict-self-heal -- --verify-job-head "${{ inputs.job }}"
+        run: pnpm run repair:conflict-self-heal -- --verify-job-head "$CLUSTER_JOB_PATH"
 
       - name: Verify Linux validation containment
         if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' && env.CLAWSWEEPER_ALLOW_FIX_PR == '1' }}
@@ -608,10 +660,10 @@ jobs:
           CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
         run: |
           pnpm run repair:issue-implementation-status -- \
-            --job "${{ inputs.job }}" \
+            --job "$CLUSTER_JOB_PATH" \
             --state "Building" \
             --detail "Codex is editing, validating, and reviewing the implementation before a branch or pull request is published." \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --run-url "$CLUSTER_RUN_URL"
 
       - name: Execute credited fix artifact
         id: execute_fix
@@ -621,7 +673,7 @@ jobs:
           GH_TOKEN: ${{ steps.target_write_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
           CLAWSWEEPER_AUTOMERGE_SESSION_ID: ${{ inputs.automerge_session_id }}
-        run: pnpm run repair:execute-fix -- "${{ inputs.job }}" --latest --defer-publication
+        run: pnpm run repair:execute-fix -- "$CLUSTER_JOB_PATH" --latest --defer-publication
 
       - name: Renew target write token for post-flight
         id: target_post_flight_token
@@ -643,7 +695,7 @@ jobs:
           GH_TOKEN: ${{ steps.target_post_flight_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
           CLAWSWEEPER_AUTOMERGE_SESSION_ID: ${{ inputs.automerge_session_id }}
-        run: pnpm run repair:execute-fix -- "${{ inputs.job }}" --latest --publish-report-only
+        run: pnpm run repair:execute-fix -- "$CLUSTER_JOB_PATH" --latest --publish-report-only
 
       - name: Record deterministic validation phase
         if: ${{ success() && steps.crabfleet_session.outcome == 'success' }}
@@ -654,7 +706,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target_post_flight_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:apply-result -- "${{ inputs.job }}" --latest
+        run: pnpm run repair:apply-result -- "$CLUSTER_JOB_PATH" --latest
 
       - name: Post-flight finalize fix PRs
         id: post_flight
@@ -662,14 +714,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.target_post_flight_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:post-flight -- "${{ inputs.job }}" --latest
+        run: pnpm run repair:post-flight -- "$CLUSTER_JOB_PATH" --latest
 
       - name: Apply post-flight closeouts
         if: ${{ steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
         env:
           GH_TOKEN: ${{ steps.target_post_flight_token.outputs.token }}
           CLAWSWEEPER_ALLOWED_OWNER: ${{ steps.target.outputs.target_owner }}
-        run: pnpm run repair:apply-result -- "${{ inputs.job }}" --latest
+        run: pnpm run repair:apply-result -- "$CLUSTER_JOB_PATH" --latest
 
       - name: Tag ClawSweeper targets
         if: ${{ always() && steps.check_job.outputs.job_exists == '1' && steps.self_heal_head.outputs.matched != 'false' && env.CLAWSWEEPER_ALLOW_EXECUTE == '1' }}
@@ -768,10 +820,10 @@ jobs:
             fi
           fi
           pnpm run repair:issue-implementation-status -- \
-            --job "${{ inputs.job }}" \
+            --job "$CLUSTER_JOB_PATH" \
             --state "$state" \
             --detail "$detail" \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --run-url "$CLUSTER_RUN_URL" \
             --pr-url "$pr_url"
 
       - name: Detect repair requeue requests
@@ -792,20 +844,21 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.requeue-token.outputs.token }}
           CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
+          REQUEUE_COUNT: ${{ steps.repair_requeue.outputs.count }}
         run: |
           set -euo pipefail
-          echo "Requeueing ${{ steps.repair_requeue.outputs.count }} source-head race repair result(s) against the latest head."
-          pnpm run repair:requeue -- "${{ inputs.job }}" \
-            --mode "${{ inputs.mode }}" \
+          echo "Requeueing $REQUEUE_COUNT source-head race repair result(s) against the latest head."
+          pnpm run repair:requeue -- "$CLUSTER_JOB_PATH" \
+            --mode "$CLUSTER_WORKER_MODE" \
             --execute \
             --open-execute-window \
             --wait-for-capacity \
-            --source-job-path "${{ inputs.job }}" \
-            --requeue-depth "${{ inputs.requeue_depth }}" \
+            --source-job-path "$CLUSTER_JOB_PATH" \
+            --requeue-depth "$CLUSTER_REQUEUE_DEPTH" \
             --max-requeue-depth 1 \
-            --runner "${{ inputs.runner }}" \
-            --execution-runner "${{ inputs.execution_runner }}" \
-            --model "${{ inputs.model }}"
+            --runner "$CLUSTER_WORKER_RUNNER" \
+            --execution-runner "$CLUSTER_EXECUTION_RUNNER" \
+            --model "$CLUSTER_WORKER_MODEL"
 
       - name: Finalize repair requeue action ledger
         if: ${{ always() && steps.execute-setup-pnpm.outcome == 'success' && steps.repair-requeue-ledger.outcome == 'success' && steps.repair_requeue.outputs.count != '' && steps.repair_requeue.outputs.count != '0' }}

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -7,6 +7,12 @@ on:
     # 2h14m wait for a slot). Fire at the cadence a cycle can actually finish.
     - cron: "*/20 * * * *"
   workflow_dispatch:
+    inputs:
+      intake_priority:
+        description: "Prioritize a newly accepted durable cluster intake"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: clawsweeper-state-materializer
@@ -51,6 +57,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Create dispatch token
+        id: dispatch-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: clawsweeper
+          permission-actions: write
+          permission-contents: read
+
       - uses: ./.github/actions/setup-action-ledger
         continue-on-error: true
 
@@ -70,7 +87,7 @@ jobs:
           # turns (run 30003798477 timed out after 35 minutes at queue
           # position 3); the batch lane's two-turn cap still guarantees
           # ordinary writers a slot.
-          coordinator-class: publication_batch
+          coordinator-class: ${{ inputs.intake_priority && 'cluster_intake' || 'publication_batch' }}
           token: ${{ steps.state-token.outputs.token }}
           # depth-1 cannot fast-forward or rebuild against a branch other
           # writers keep advancing (non-fast-forward shallow push rejections,
@@ -94,10 +111,14 @@ jobs:
 
       - name: Materialize queued state
         env:
+          GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_STATE_REPO_TOKEN: ${{ steps.state-token.outputs.token }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_REPO: openclaw/clawsweeper
+          CLAWSWEEPER_WORKER_RUNNER: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          CLAWSWEEPER_EXECUTION_RUNNER: ${{ vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
         run: node dist/repair/state-materializer.js
 
       - name: Finalize materializer recovery action ledger

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "repair:import-gitcrawl": "node dist/repair/import-gitcrawl-clusters.js",
     "repair:select-cluster-candidate": "node dist/repair/select-cluster-candidate.js",
     "repair:publish-cluster-intake": "node dist/repair/publish-cluster-intake.js",
+    "repair:restore-cluster-intake-job": "node dist/repair/restore-cluster-intake-job.js",
     "repair:import-gitcrawl-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",
     "repair:import-ghcrawl": "node dist/repair/import-gitcrawl-clusters.js",
     "repair:import-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -335,8 +335,9 @@ export function dispatchClaimDecision({
   });
   const successfulRun = matchingRuns.find(
     (run) =>
-      String(run.conclusion ?? "").toLowerCase() === "success" &&
-      run.dispatch_execution_verified !== false,
+      run.dispatch_execution_verified === true ||
+      (String(run.conclusion ?? "").toLowerCase() === "success" &&
+        run.dispatch_execution_verified !== false),
   );
   if (successfulRun) return { action: "recover", run: successfulRun };
   const activeRun = matchingRuns.find((run) =>

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -690,7 +690,7 @@ function verifyDispatchExecutionRuns({
     const createdAtMs = Date.parse(String(run.created_at ?? run.createdAt ?? ""));
     if (
       String(run.display_title ?? run.displayTitle ?? "") !== expectedTitle ||
-      String(run.conclusion ?? "").toLowerCase() !== "success" ||
+      String(run.status ?? "").toLowerCase() !== "completed" ||
       !Number.isFinite(claimedAtMs) ||
       !Number.isFinite(createdAtMs) ||
       createdAtMs < claimedAtMs - 5_000

--- a/src/repair/restore-cluster-intake-job.ts
+++ b/src/repair/restore-cluster-intake-job.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  clusterJobTargetRepository,
+  validateClusterJobContent,
+  verifyClusterDispatchAuthenticationTag,
+} from "./cluster-intake-state.js";
+
+type RestoreClusterIntakeJobOptions = {
+  root: string;
+  jobPath: string;
+  payload: string;
+  digest: string;
+  dispatchKey: string;
+  authenticationTag: string;
+  authenticationSecret: string;
+  allowedOwner: string;
+  mode: string;
+  runner: string;
+  executionRunner: string;
+  plannerSandbox: string;
+  model: string;
+  dryRun: string;
+};
+
+export function restoreClusterIntakeJob(options: RestoreClusterIntakeJobOptions): void {
+  const match = options.jobPath.match(
+    /^jobs\/([A-Za-z0-9_.-]+)\/inbox\/gitcrawl-([1-9]\d*)-[A-Za-z0-9_.-]+\.md$/,
+  );
+  if (!match) throw new Error("invalid durable cluster intake job path");
+  const owner = match[1]!;
+  const clusterId = Number(match[2]);
+  if (owner !== options.allowedOwner || !/^[A-Za-z0-9_.-]+$/.test(options.allowedOwner)) {
+    throw new Error("durable cluster intake owner is not allowed");
+  }
+  if (!/^[a-f0-9]{64}$/.test(options.digest)) {
+    throw new Error("invalid durable cluster intake job digest");
+  }
+  if (
+    options.mode !== "autonomous" ||
+    options.plannerSandbox !== "read-only" ||
+    options.dryRun !== "false" ||
+    !/^[A-Za-z0-9._-]{1,80}$/.test(options.runner) ||
+    !/^[A-Za-z0-9._-]{1,80}$/.test(options.executionRunner) ||
+    !/^[A-Za-z0-9._-]{1,80}$/.test(options.model)
+  ) {
+    throw new Error("durable cluster intake execution settings are invalid");
+  }
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(options.payload) || options.payload.length % 4 !== 0) {
+    throw new Error("invalid durable cluster intake payload encoding");
+  }
+  verifyClusterDispatchAuthenticationTag(
+    options.authenticationSecret,
+    {
+      jobPath: options.jobPath,
+      jobDigest: options.digest,
+      dispatchKey: options.dispatchKey,
+      mode: options.mode,
+      runner: options.runner,
+      executionRunner: options.executionRunner,
+      plannerSandbox: options.plannerSandbox,
+      model: options.model,
+      dryRun: options.dryRun,
+    },
+    options.authenticationTag,
+  );
+  const content = Buffer.from(options.payload, "base64");
+  if (content.length === 0 || content.length > 32 * 1024) {
+    throw new Error("durable cluster intake payload size is invalid");
+  }
+  if (content.toString("base64") !== options.payload) {
+    throw new Error("durable cluster intake payload encoding is not canonical");
+  }
+  if (createHash("sha256").update(content).digest("hex") !== options.digest) {
+    throw new Error("durable cluster intake job digest mismatch");
+  }
+  const targetRepo = clusterJobTargetRepository(content.toString("utf8"));
+  if (
+    targetRepo.split("/")[0] !== owner ||
+    options.dispatchKey !== `cluster-intake:${targetRepo.replace("/", "-")}:${clusterId}`
+  ) {
+    throw new Error("durable cluster intake dispatch identity mismatch");
+  }
+  validateClusterJobContent(content.toString("utf8"), targetRepo, clusterId);
+
+  const root = resolve(options.root);
+  const destination = resolve(root, options.jobPath);
+  if (destination === root || !destination.startsWith(`${root}${sep}`)) {
+    throw new Error("durable cluster intake job escapes the checkout");
+  }
+  const parent = dirname(destination);
+  assertNoSymlinkComponents(root, parent);
+  mkdirSync(parent, { recursive: true });
+  assertNoSymlinkComponents(root, parent);
+  if (existsSync(destination) && lstatSync(destination).isSymbolicLink()) {
+    throw new Error("refusing durable cluster intake job symlink");
+  }
+  const temporary = resolve(parent, `.${basename(destination)}.restore-${randomUUID()}`);
+  let descriptor: number | undefined;
+  let temporaryCreated = false;
+  try {
+    descriptor = openSync(temporary, "wx", 0o600);
+    temporaryCreated = true;
+    writeFileSync(descriptor, content);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporary, destination);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    if (temporaryCreated) rmSync(temporary, { force: true });
+  }
+}
+
+function assertNoSymlinkComponents(root: string, target: string): void {
+  const relative = target.slice(root.length).split(sep).filter(Boolean);
+  let current = root;
+  for (const part of relative) {
+    current = resolve(current, part);
+    if (existsSync(current) && lstatSync(current).isSymbolicLink()) {
+      throw new Error("durable cluster intake path contains a symlink");
+    }
+  }
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name] ?? "";
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  restoreClusterIntakeJob({
+    root: process.cwd(),
+    jobPath: requiredEnv("CLUSTER_JOB_PATH"),
+    payload: requiredEnv("CLUSTER_JOB_PAYLOAD"),
+    digest: requiredEnv("CLUSTER_JOB_DIGEST"),
+    dispatchKey: requiredEnv("CLUSTER_DISPATCH_KEY"),
+    authenticationTag: requiredEnv("CLUSTER_JOB_AUTH"),
+    authenticationSecret: requiredEnv("CLAWSWEEPER_WEBHOOK_SECRET"),
+    allowedOwner: requiredEnv("CLAWSWEEPER_ALLOWED_OWNER"),
+    mode: requiredEnv("CLUSTER_WORKER_MODE"),
+    runner: requiredEnv("CLUSTER_WORKER_RUNNER"),
+    executionRunner: requiredEnv("CLUSTER_EXECUTION_RUNNER"),
+    plannerSandbox: requiredEnv("CLUSTER_PLANNER_SANDBOX"),
+    model: requiredEnv("CLUSTER_WORKER_MODEL"),
+    dryRun: requiredEnv("CLUSTER_WORKER_DRY_RUN"),
+  });
+}

--- a/src/repair/state-materializer.ts
+++ b/src/repair/state-materializer.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { createHash, createHmac } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import type { LooseRecord } from "./json-types.js";
 
 import {
   actionLedgerJson,
@@ -12,11 +14,18 @@ import {
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
 import { mergeCommentRouterLedgers } from "./comment-router-ledger-merge.js";
 import {
+  dispatchClaimDecision,
+  hasSuccessfulDispatchExecutionJob,
+} from "./comment-router-utils.js";
+import { ghJson } from "./github-cli.js";
+import {
   GitShallowHistoryExhaustionError,
   publishMainCommit,
   SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
   type ShallowHistoryExhaustionStrategy,
 } from "./git-publish.js";
+import { liveWorkerCapacity } from "./live-worker-capacity.js";
+import { workerLimit } from "./limits.js";
 import {
   convergeRecordTupleSidecars,
   recordTuplePaths,
@@ -24,6 +33,19 @@ import {
   type RecordTupleContents,
 } from "./record-tuple.js";
 import { mergeSweepStatusJson } from "./sweep-status-merge.js";
+import {
+  clusterDispatchAuthenticationTag,
+  clusterIntakeIntent,
+  clusterWorkflowDispatchInputs,
+  CLUSTER_INTAKE_LEDGER_SCHEMA,
+  markClusterIntakeDispatchClaimed,
+  markClusterIntakeDispatched,
+  mergeClusterIntakeLedger,
+  validateClusterJobContent,
+  type ClusterIntakeIntent,
+  type ClusterIntakeLedger,
+  type ClusterLedgerEntry,
+} from "./cluster-intake-state.js";
 
 export const DEFAULT_STATE_MATERIALIZER_MAX_ROWS = 2_000;
 export const DEFAULT_STATE_MATERIALIZER_MAX_BYTES = 20 * 1024 * 1024;
@@ -38,9 +60,15 @@ const STATE_APPEND_KINDS = new Set<StateAppendKind>([
   "comment_router",
   "apply_proof",
   "record_tuple",
+  "cluster_intake",
 ]);
 
-export type StateAppendKind = "sweep_status" | "comment_router" | "apply_proof" | "record_tuple";
+export type StateAppendKind =
+  | "sweep_status"
+  | "comment_router"
+  | "apply_proof"
+  | "record_tuple"
+  | "cluster_intake";
 
 type RecordTupleProjectionOperation = {
   path: string;
@@ -101,7 +129,22 @@ export type StateMaterializerRunOptions = {
   fetchImpl?: typeof fetch;
   now?: () => Date;
   publishCommit?: typeof publishMainCommit;
+  clusterCapacity?: (options: Record<string, unknown>) => {
+    active: number;
+    max_live_workers: number;
+  };
+  clusterDispatchObserver?: ClusterDispatchObserver;
 };
+
+export type ClusterDispatchObservation = {
+  action: "dispatch" | "wait" | "recover";
+  run: LooseRecord | null;
+};
+
+export type ClusterDispatchObserver = (
+  entry: ClusterLedgerEntry,
+  env: NodeJS.ProcessEnv,
+) => ClusterDispatchObservation;
 
 type StateDrainResponse = {
   token: string | null;
@@ -232,6 +275,35 @@ export function planStateMaterialization(
       continue;
     }
 
+    if (record.kind === "cluster_intake") {
+      const intent = clusterIntakeIntent(record.payload);
+      const ledgerPath = clusterIntakeLedgerPath(intent);
+      const sameRepository = selected.records
+        .filter((candidate) => candidate.kind === "cluster_intake")
+        .map((candidate) => clusterIntakeIntent(candidate.payload))
+        .filter((candidate) => candidate.target_repo === intent.target_repo);
+      const ledger = mergeClusterIntakeLedger(currentFiles.get(ledgerPath), sameRepository);
+      contentByPath.set(ledgerPath, `${JSON.stringify(ledger, null, 2)}\n`);
+      addPublishPath(ledgerPath);
+      for (const job of intent.jobs) {
+        const accepted = ledger.clusters[String(job.cluster_id)];
+        if (
+          accepted?.job !== job.path ||
+          accepted.dispatch_key !== job.dispatch_key ||
+          accepted.digest !== job.digest
+        ) {
+          continue;
+        }
+        const current = currentFiles.get(job.path);
+        if (current !== undefined && current !== job.content) {
+          throw new Error(`cluster intake job already has different content: ${job.path}`);
+        }
+        contentByPath.set(job.path, job.content);
+        addPublishPath(job.path);
+      }
+      continue;
+    }
+
     if (record.kind === "record_tuple") {
       const tuple = recordTupleProjection(record);
       const primaryWrites = tuple.operations.filter(
@@ -314,6 +386,8 @@ export async function runStateMaterializer(
   const fetchImpl = options.fetchImpl ?? fetch;
   const now = options.now ?? (() => new Date());
   const publishCommit = options.publishCommit ?? publishMainCommit;
+  const clusterCapacity = reserveClusterCapacity(options.clusterCapacity ?? liveWorkerCapacity);
+  const clusterDispatchObserver = options.clusterDispatchObserver ?? observeClusterDispatch;
   const queueUrl = (env.QUEUE_URL ?? "").replace(/\/$/, "");
   const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
   registerStateSecretForRedaction(webhookSecret);
@@ -362,6 +436,30 @@ export async function runStateMaterializer(
     summary.errors += 1;
     console.warn("state-materializer skipped: missing queue URL or webhook secret");
     return finish();
+  }
+
+  try {
+    const recovered = recoverPendingClusterIntakes(
+      process.cwd(),
+      env,
+      clusterCapacity,
+      clusterDispatchObserver,
+    );
+    if (recovered.updatedLedgers.length > 0) {
+      publishCommit({
+        message: STATE_MATERIALIZER_COMMIT_MESSAGE,
+        paths: recovered.updatedLedgers,
+        branch,
+        maxAttempts: publishMaxAttempts,
+        pushAttempts: publishPushAttempts,
+      });
+    }
+  } catch (error) {
+    // A durable pending ledger is an independent retry source. Report the
+    // dispatch failure, but keep draining unrelated state instead of turning
+    // worker capacity or Actions availability into a global publication lock.
+    summary.errors += 1;
+    console.warn(`cluster intake recovery failed: ${errorMessage(error)}`);
   }
 
   while (now().getTime() - startedAt < maximumRuntimeMs) {
@@ -439,6 +537,35 @@ export async function runStateMaterializer(
             });
           },
         });
+      }
+      const clusterIntakes = hydrated.records
+        .filter((record) => record.kind === "cluster_intake")
+        .map((record) => clusterIntakeIntent(record.payload));
+      if (clusterIntakes.length > 0) {
+        try {
+          const dispatch = dispatchClusterIntakes(
+            clusterIntakes,
+            process.cwd(),
+            env,
+            clusterCapacity,
+            clusterDispatchObserver,
+          );
+          if (dispatch.updatedLedgers.length > 0) {
+            publishCommit({
+              message: STATE_MATERIALIZER_COMMIT_MESSAGE,
+              paths: dispatch.updatedLedgers,
+              branch,
+              maxAttempts: publishMaxAttempts,
+              pushAttempts: publishPushAttempts,
+            });
+          }
+          if (dispatch.pending) {
+            console.warn("cluster intake remains durably pending until worker capacity frees");
+          }
+        } catch (error) {
+          summary.errors += 1;
+          console.warn(`cluster intake dispatch deferred: ${errorMessage(error)}`);
+        }
       }
       summary.committed += plan.selected - publicationFailureSeqs.size;
       summary.skipped += selected.skipped + hydrated.skipped + plan.skipped;
@@ -519,6 +646,24 @@ export async function runStateMaterializer(
     }
   }
   return finish();
+}
+
+export function reserveClusterCapacity(
+  capacity: (options: Record<string, unknown>) => {
+    active: number;
+    max_live_workers: number;
+  },
+): (options: Record<string, unknown>) => { active: number; max_live_workers: number } {
+  let reserved = 0;
+  return (options) => {
+    const snapshot = capacity(options);
+    const maximum = Math.max(0, Math.floor(Number(snapshot.max_live_workers) || 0));
+    const visibleActive = Math.max(0, Math.floor(Number(snapshot.active) || 0));
+    const effectiveActive = Math.min(maximum, visibleActive + reserved);
+    const requested = Math.max(0, Math.floor(Number(options.requested) || 0));
+    reserved += Math.min(requested, Math.max(0, maximum - effectiveActive));
+    return { active: effectiveActive, max_live_workers: maximum };
+  };
 }
 
 export function shallowHistoryExhaustionStrategyForRecords(
@@ -629,6 +774,16 @@ function materializationPaths(records: readonly StateAppendRecord[]): string[] {
       }
       continue;
     }
+    if (record.kind === "cluster_intake") {
+      const intent = clusterIntakeIntent(record.payload);
+      for (const recordPath of [
+        clusterIntakeLedgerPath(intent),
+        ...intent.jobs.map((job) => job.path),
+      ]) {
+        if (!paths.includes(recordPath)) paths.push(recordPath);
+      }
+      continue;
+    }
     const path =
       record.kind === "sweep_status"
         ? sweepStatusPathForStateKey(record.key)
@@ -644,6 +799,294 @@ function materializationPaths(records: readonly StateAppendRecord[]): string[] {
     }
   }
   return paths;
+}
+
+export function dispatchClusterIntakes(
+  intents: readonly ClusterIntakeIntent[],
+  root: string,
+  env: NodeJS.ProcessEnv = process.env,
+  capacity: (options: Record<string, unknown>) => {
+    active: number;
+    max_live_workers: number;
+  } = liveWorkerCapacity,
+  observe: ClusterDispatchObserver = observeClusterDispatch,
+): { updatedLedgers: string[]; pending: boolean } {
+  const updatedLedgers: string[] = [];
+  let pending = false;
+  const byRepository = new Map<string, ClusterIntakeIntent[]>();
+  for (const intent of intents) {
+    const values = byRepository.get(intent.target_repo) ?? [];
+    values.push(intent);
+    byRepository.set(intent.target_repo, values);
+  }
+  for (const repositoryIntents of byRepository.values()) {
+    const ledgerPath = clusterIntakeLedgerPath(repositoryIntents[0]!);
+    const absoluteLedger = resolve(root, ledgerPath);
+    const ledger = mergeClusterIntakeLedger(
+      readFileSync(absoluteLedger, "utf8"),
+      repositoryIntents,
+    );
+    const dispatch = dispatchClusterLedger(ledgerPath, ledger, root, env, capacity, observe, false);
+    if (dispatch.updated) updatedLedgers.push(ledgerPath);
+    pending ||= dispatch.pending;
+  }
+  return { updatedLedgers, pending };
+}
+
+export function recoverPendingClusterIntakes(
+  root: string,
+  env: NodeJS.ProcessEnv = process.env,
+  capacity: (options: Record<string, unknown>) => {
+    active: number;
+    max_live_workers: number;
+  } = liveWorkerCapacity,
+  observe: ClusterDispatchObserver = observeClusterDispatch,
+): { updatedLedgers: string[]; pending: boolean } {
+  const ledgerRoot = resolve(root, "results/cluster-repair-intake");
+  if (!existsSync(ledgerRoot)) return { updatedLedgers: [], pending: false };
+  const updatedLedgers: string[] = [];
+  let pending = false;
+  for (const name of readdirSync(ledgerRoot)
+    .filter((entry) => entry.endsWith(".json"))
+    .sort()) {
+    const ledgerPath = `results/cluster-repair-intake/${name}`;
+    const parsed = JSON.parse(readFileSync(resolve(root, ledgerPath), "utf8")) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as { schema?: unknown }).schema !== CLUSTER_INTAKE_LEDGER_SCHEMA
+    ) {
+      continue;
+    }
+    const dispatch = dispatchClusterLedger(
+      ledgerPath,
+      parsed as ClusterIntakeLedger,
+      root,
+      env,
+      capacity,
+      observe,
+      true,
+    );
+    if (dispatch.updated) updatedLedgers.push(ledgerPath);
+    pending ||= dispatch.pending;
+  }
+  return { updatedLedgers, pending };
+}
+
+function dispatchClusterLedger(
+  ledgerPath: string,
+  ledger: ClusterIntakeLedger,
+  root: string,
+  env: NodeJS.ProcessEnv,
+  capacity: (options: Record<string, unknown>) => {
+    active: number;
+    max_live_workers: number;
+  },
+  observe: ClusterDispatchObserver,
+  recoverUnclaimed: boolean,
+): { updated: boolean; pending: boolean } {
+  const repoSlug = ledger.target_repo.replace("/", "-");
+  const unresolvedJobs = Object.values(ledger.clusters)
+    .filter((entry) => entry.status !== "dispatched")
+    .sort(
+      (left, right) =>
+        left.accepted_at.localeCompare(right.accepted_at) || left.cluster_id - right.cluster_id,
+    )
+    .map((entry) => {
+      if (
+        entry.dispatch_key !== `cluster-intake:${repoSlug}:${entry.cluster_id}` ||
+        !/^[a-f0-9]{64}$/.test(entry.digest) ||
+        !/^[A-Za-z0-9._-]{1,80}$/.test(entry.runner) ||
+        !/^[A-Za-z0-9._-]{1,80}$/.test(entry.execution_runner) ||
+        !/^[A-Za-z0-9._-]{1,80}$/.test(entry.model)
+      ) {
+        throw new Error(`invalid unresolved cluster dispatch metadata: ${entry.cluster_id}`);
+      }
+      const absoluteJob = resolve(root, entry.job);
+      const resolvedRoot = resolve(root);
+      if (
+        absoluteJob === resolvedRoot ||
+        !absoluteJob.startsWith(`${resolvedRoot}${sep}`) ||
+        !existsSync(absoluteJob)
+      ) {
+        throw new Error(`unresolved cluster job is missing or outside checkout: ${entry.job}`);
+      }
+      const content = readFileSync(absoluteJob, "utf8");
+      if (createHash("sha256").update(content).digest("hex") !== entry.digest) {
+        throw new Error(`unresolved cluster job digest mismatch: ${entry.job}`);
+      }
+      validateClusterJobContent(content, ledger.target_repo, entry.cluster_id);
+      return {
+        cluster_id: entry.cluster_id,
+        path: entry.job,
+        content,
+        digest: entry.digest,
+        dispatch_key: entry.dispatch_key,
+        accepted_intent_digest: entry.accepted_intent_digest,
+        accepted_intent_receipt: entry.accepted_intent_receipt,
+        runner: entry.runner,
+        execution_runner: entry.execution_runner,
+        model: entry.model,
+        ledgerEntry: entry,
+      };
+    });
+  let pending = false;
+  let ledgerUpdated = false;
+  let workingLedger = ledger;
+  const dispatchableJobs = [] as (typeof unresolvedJobs)[number][];
+  for (const job of unresolvedJobs) {
+    if (job.ledgerEntry.status === "dispatch_pending" && !recoverUnclaimed) {
+      dispatchableJobs.push(job);
+      continue;
+    }
+    const observationEntry =
+      job.ledgerEntry.status === "dispatch_pending"
+        ? { ...job.ledgerEntry, dispatch_claimed_at: job.ledgerEntry.accepted_at }
+        : job.ledgerEntry;
+    if (!observationEntry.dispatch_claimed_at) {
+      throw new Error(`cluster dispatch claim has no timestamp: ${job.cluster_id}`);
+    }
+    const observation = observe(observationEntry, env);
+    if (observation.action === "recover") {
+      const runId = Number(observation.run?.id ?? observation.run?.databaseId ?? 0);
+      workingLedger = markClusterIntakeDispatched(workingLedger, [job], new Date().toISOString(), {
+        ...(Number.isSafeInteger(runId) && runId > 0 ? { id: runId } : {}),
+        ...(observation.run?.url || observation.run?.html_url
+          ? { url: String(observation.run.url ?? observation.run.html_url) }
+          : {}),
+      });
+      ledgerUpdated = true;
+      continue;
+    }
+    if (observation.action === "wait") {
+      pending = true;
+      continue;
+    }
+    dispatchableJobs.push(job);
+  }
+  let jobsToDispatch = dispatchableJobs;
+  if (dispatchableJobs.length > 0) {
+    const workerCapacity = capacity({
+      repo: env.CLAWSWEEPER_REPO || "openclaw/clawsweeper",
+      workflow: "repair-cluster-worker.yml",
+      requested: dispatchableJobs.length,
+      maxLiveWorkers: workerLimit("cluster_repair"),
+      env,
+    });
+    const available = Math.max(0, workerCapacity.max_live_workers - workerCapacity.active);
+    jobsToDispatch = dispatchableJobs.slice(0, available);
+    pending ||= jobsToDispatch.length < dispatchableJobs.length;
+  }
+  const dispatchClaimedAt = new Date().toISOString();
+  for (const job of jobsToDispatch) {
+    const jobAuthentication = clusterDispatchAuthenticationTag(
+      env.CLAWSWEEPER_WEBHOOK_SECRET ?? "",
+      {
+        jobPath: job.path,
+        jobDigest: job.digest,
+        dispatchKey: job.dispatch_key,
+        mode: "autonomous",
+        runner: job.runner,
+        executionRunner: job.execution_runner,
+        plannerSandbox: "read-only",
+        model: job.model,
+        dryRun: "false",
+      },
+    );
+    const dispatchInputs = clusterWorkflowDispatchInputs(job, {
+      runner: job.runner,
+      executionRunner: job.execution_runner,
+      model: job.model,
+      jobAuth: jobAuthentication,
+    });
+    const result = spawnSync(
+      "gh",
+      [
+        "workflow",
+        "run",
+        "repair-cluster-worker.yml",
+        "--repo",
+        env.CLAWSWEEPER_REPO || "openclaw/clawsweeper",
+        "--ref",
+        env.CLAWSWEEPER_DISPATCH_REF || "main",
+        ...Object.entries(dispatchInputs).flatMap(([key, value]) => ["-f", `${key}=${value}`]),
+      ],
+      { cwd: root, encoding: "utf8", env, stdio: "pipe" },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `cluster intake dispatch failed for ${ledger.target_repo} cluster ${job.cluster_id}: ${result.stderr || result.stdout || result.status}`,
+      );
+    }
+  }
+  if (jobsToDispatch.length > 0) {
+    workingLedger = markClusterIntakeDispatchClaimed(
+      workingLedger,
+      jobsToDispatch,
+      dispatchClaimedAt,
+    );
+    ledgerUpdated = true;
+    pending = true;
+  }
+  if (ledgerUpdated) {
+    writeFileSync(resolve(root, ledgerPath), `${JSON.stringify(workingLedger, null, 2)}\n`, "utf8");
+  }
+  return { updated: ledgerUpdated, pending };
+}
+
+export function observeClusterDispatch(
+  entry: ClusterLedgerEntry,
+  env: NodeJS.ProcessEnv,
+): ClusterDispatchObservation {
+  const repo = env.CLAWSWEEPER_REPO || "openclaw/clawsweeper";
+  const expectedTitle = `repair cluster ${entry.job} [${entry.dispatch_key}]`;
+  const runs = ghJson<LooseRecord[]>(
+    [
+      "run",
+      "list",
+      "--repo",
+      repo,
+      "--workflow",
+      "repair-cluster-worker.yml",
+      "--limit",
+      "100",
+      "--json",
+      "databaseId,displayTitle,status,conclusion,createdAt,updatedAt,url",
+    ],
+    { env },
+  ).map((run) => {
+    if (
+      String(run.displayTitle ?? run.display_title ?? "") !== expectedTitle ||
+      String(run.status ?? "").toLowerCase() !== "completed"
+    ) {
+      return run;
+    }
+    const runId = Number(run.databaseId ?? run.id ?? 0);
+    if (!Number.isSafeInteger(runId) || runId < 1) {
+      return { ...run, dispatch_execution_verified: false };
+    }
+    const response = ghJson<LooseRecord>(
+      ["api", `repos/${repo}/actions/runs/${runId}/jobs?per_page=100`],
+      { env },
+    );
+    const jobs = Array.isArray(response.jobs) ? response.jobs : [];
+    return {
+      ...run,
+      dispatch_execution_verified: hasSuccessfulDispatchExecutionJob(
+        jobs,
+        "Plan and review cluster",
+      ),
+    };
+  });
+  return dispatchClaimDecision({
+    claim: { processed_at: entry.dispatch_claimed_at },
+    runs,
+    expectedTitle,
+  }) as ClusterDispatchObservation;
+}
+
+function clusterIntakeLedgerPath(intent: ClusterIntakeIntent): string {
+  return `results/cluster-repair-intake/${intent.repo_slug}.json`;
 }
 
 function readCurrentFiles(paths: readonly string[], root: string): Map<string, string> {

--- a/test/repair/cluster-intake-state.test.ts
+++ b/test/repair/cluster-intake-state.test.ts
@@ -1,22 +1,37 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
   CLUSTER_INTAKE_SCHEMA,
+  CLUSTER_WORKFLOW_DISPATCH_MAX_PAYLOAD_BYTES,
   acceptClusterIntakeIntent,
   clusterAcceptedIntentDigest,
+  clusterDispatchAuthenticationTag,
   clusterIntakeIntent,
   clusterIntakeLedger,
+  clusterWorkflowDispatchInputs,
   markClusterIntakeDispatchClaimed,
   markClusterIntakeDispatched,
   mergeClusterIntakeLedger,
   verifyClusterLedgerEntryAcceptedIntent,
 } from "../../dist/repair/cluster-intake-state.js";
+import {
+  dispatchClusterIntakes,
+  observeClusterDispatch,
+  planStateMaterialization,
+  recoverPendingClusterIntakes,
+  reserveClusterCapacity,
+} from "../../dist/repair/state-materializer.js";
+import { restoreClusterIntakeJob } from "../../dist/repair/restore-cluster-intake-job.js";
 
+const dispatchSecret = "cluster-dispatch-test-secret";
 const receiptSecret = "cluster-accepted-intent-test-secret";
 
-function proposal() {
+function receiptProposal() {
   const content = `---
 repo: openclaw/openclaw
 cluster_id: gitcrawl-42-telegram-upload
@@ -101,9 +116,832 @@ function receiptFields(ledger: ReturnType<typeof mergeClusterIntakeLedger>) {
   };
 }
 
+function dispatchAuthenticationFields(job: ReturnType<typeof intent>["jobs"][number]) {
+  return {
+    jobPath: job.path,
+    jobDigest: job.digest,
+    dispatchKey: job.dispatch_key,
+    mode: "autonomous",
+    runner: "blacksmith-4vcpu-ubuntu-2404",
+    executionRunner: "blacksmith-16vcpu-ubuntu-2404",
+    plannerSandbox: "read-only",
+    model: "internal",
+    dryRun: "false",
+  };
+}
+
+function intent(clusterId = 42, storeSha = "a".repeat(64)) {
+  const content = `---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-${clusterId}-telegram-upload
+mode: autonomous
+job_intent: repair_cluster
+allowed_actions:
+  - comment
+  - label
+  - close
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - #${clusterId * 10}
+candidates:
+  - #${clusterId * 10}
+  - #${clusterId * 10 + 1}
+cluster_refs:
+  - #${clusterId * 10}
+  - #${clusterId * 10 + 1}
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_post_merge_close: true
+require_fix_before_close: true
+---
+
+# Cluster ${clusterId}
+`;
+  return acceptClusterIntakeIntent(
+    {
+      schema: CLUSTER_INTAKE_SCHEMA,
+      target_repo: "openclaw/openclaw",
+      repo_slug: "openclaw-openclaw",
+      store_sha256: storeSha,
+      store_exported_at: "2026-07-26T00:00:00Z",
+      manifest_path: "gitcrawl-store/data/openclaw__openclaw.sync.db.manifest.json",
+      run_url: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+      accepted_at: "2026-07-26T00:01:00Z",
+      runner: "blacksmith-4vcpu-ubuntu-2404",
+      execution_runner: "blacksmith-16vcpu-ubuntu-2404",
+      model: "internal",
+      selector_summary: { evaluated: 10, rejected: 9, reason_counts: { stale: 4 } },
+      jobs: [
+        {
+          cluster_id: clusterId,
+          path: `jobs/openclaw/inbox/gitcrawl-${clusterId}-telegram-upload.md`,
+          content,
+          digest: createHash("sha256").update(content).digest("hex"),
+          dispatch_key: `cluster-intake:openclaw-openclaw:${clusterId}`,
+        },
+      ],
+    },
+    receiptSecret,
+  );
+}
+
+function unsignedIntent(value: ReturnType<typeof intent>) {
+  return {
+    ...value,
+    jobs: value.jobs.map(
+      ({
+        accepted_intent_digest: _acceptedIntentDigest,
+        accepted_intent_receipt: _receipt,
+        ...job
+      }) => job,
+    ),
+  };
+}
+
+function resignIntent(value: ReturnType<typeof intent>) {
+  return acceptClusterIntakeIntent(unsignedIntent(value), receiptSecret);
+}
+
+function writeDurableIntents(root: string, intents: ReturnType<typeof intent>[]): string {
+  const ledgerPath = path.join(root, "results", "cluster-repair-intake");
+  fs.mkdirSync(ledgerPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(ledgerPath, "openclaw-openclaw.json"),
+    `${JSON.stringify(mergeClusterIntakeLedger(undefined, intents))}\n`,
+  );
+  for (const value of intents) {
+    for (const job of value.jobs) {
+      const target = path.join(root, job.path);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, job.content);
+    }
+  }
+  return ledgerPath;
+}
+
+test("cluster intake materializes exact paths without deleting unrelated jobs", () => {
+  const value = intent();
+  const unrelated = "jobs/openclaw/inbox/unrelated.md";
+  const plan = planStateMaterialization(
+    [
+      {
+        seq: 1,
+        kind: "cluster_intake",
+        key: `openclaw-openclaw/${value.store_sha256}`,
+        payload: value,
+        produced_at: value.accepted_at,
+        delivery_id: "delivery",
+      },
+    ],
+    new Map([[unrelated, "keep me"]]),
+  );
+  assert.deepEqual(plan.deletes, []);
+  assert.deepEqual(
+    plan.publishPaths.sort(),
+    [value.jobs[0].path, "results/cluster-repair-intake/openclaw-openclaw.json"].sort(),
+  );
+  assert.equal(
+    plan.writes.some((write) => write.path === unrelated),
+    false,
+  );
+});
+
+test("duplicate intake is idempotent and a completed dispatch never regresses", () => {
+  const value = intent();
+  const first = mergeClusterIntakeLedger(undefined, [value]);
+  const dispatched = markClusterIntakeDispatched(first, value.jobs, "2026-07-26T00:02:00Z");
+  const replayed = mergeClusterIntakeLedger(`${JSON.stringify(dispatched)}\n`, [value, value]);
+  assert.equal(Object.keys(replayed.clusters).length, 1);
+  assert.equal(replayed.clusters["42"].status, "dispatched");
+  assert.equal(replayed.stores.length, 1);
+});
+
+test("claiming a newer store preserves completed outcomes for older stores", () => {
+  const first = intent(42, "a".repeat(64));
+  const secondDraft = intent(43, "b".repeat(64));
+  secondDraft.store_exported_at = "2026-07-26T01:00:00Z";
+  secondDraft.accepted_at = "2026-07-26T01:01:00Z";
+  const second = resignIntent(secondDraft);
+  const merged = mergeClusterIntakeLedger(undefined, [first, second]);
+  const completed = markClusterIntakeDispatched(merged, first.jobs, "2026-07-26T01:02:00Z");
+  const claimed = markClusterIntakeDispatchClaimed(completed, second.jobs, "2026-07-26T01:03:00Z");
+  assert.equal(
+    claimed.stores.find((store) => store.store_sha256 === first.store_sha256)?.outcome,
+    "dispatched",
+  );
+  assert.equal(
+    claimed.stores.find((store) => store.store_sha256 === second.store_sha256)?.outcome,
+    "dispatch_claimed",
+  );
+});
+
+test("an older store replay cannot rewind the processed-store marker", () => {
+  const older = intent(42, "a".repeat(64));
+  const newerDraft = intent(43, "b".repeat(64));
+  newerDraft.store_exported_at = "2026-07-26T01:00:00Z";
+  newerDraft.accepted_at = "2026-07-26T01:01:00Z";
+  const newer = resignIntent(newerDraft);
+  const current = mergeClusterIntakeLedger(undefined, [older, newer]);
+  const replayed = mergeClusterIntakeLedger(`${JSON.stringify(current)}\n`, [older]);
+  assert.equal(replayed.last_processed_store_sha256, newer.store_sha256);
+  assert.equal(replayed.last_processed_store_exported_at, newer.store_exported_at);
+  assert.equal(replayed.run_url, newer.run_url);
+  assert.equal(replayed.updated_at, newer.accepted_at);
+});
+
+test("a newer store cannot overwrite or redispatch an already accepted cluster", () => {
+  const current = mergeClusterIntakeLedger(undefined, [intent()]);
+  const replacementDraft = intent(42, "b".repeat(64));
+  replacementDraft.jobs[0].path = "jobs/openclaw/inbox/gitcrawl-42-renamed.md";
+  const replacement = resignIntent(replacementDraft);
+  const merged = mergeClusterIntakeLedger(`${JSON.stringify(current)}\n`, [replacement]);
+  assert.equal(merged.clusters["42"].job, current.clusters["42"].job);
+  assert.equal(merged.stores.at(-1).outcome, "duplicate_skipped");
+  assert.deepEqual(merged.stores.at(-1).generated_jobs, []);
+  const plan = planStateMaterialization(
+    [
+      {
+        seq: 2,
+        kind: "cluster_intake",
+        key: `openclaw-openclaw/${replacement.store_sha256}`,
+        payload: replacement,
+        produced_at: replacement.accepted_at,
+        delivery_id: "replacement",
+      },
+    ],
+    new Map([
+      ["results/cluster-repair-intake/openclaw-openclaw.json", `${JSON.stringify(current)}\n`],
+      [current.clusters["42"].job, intent().jobs[0].content],
+    ]),
+  );
+  assert.equal(plan.publishPaths.includes(replacement.jobs[0].path), false);
+  assert.equal(
+    plan.writes.some((write) => write.path === replacement.jobs[0].path),
+    false,
+  );
+});
+
+test("same-path conflicting intents materialize only the ledger-accepted digest", () => {
+  const accepted = intent(42, "a".repeat(64));
+  const conflictingDraft = intent(42, "b".repeat(64));
+  conflictingDraft.jobs[0].content = conflictingDraft.jobs[0].content.replace(
+    "# Cluster 42",
+    "# Cluster 42 changed by a later snapshot",
+  );
+  conflictingDraft.jobs[0].digest = createHash("sha256")
+    .update(conflictingDraft.jobs[0].content)
+    .digest("hex");
+  const conflicting = resignIntent(conflictingDraft);
+  const plan = planStateMaterialization([
+    {
+      seq: 1,
+      kind: "cluster_intake",
+      key: `openclaw-openclaw/${accepted.store_sha256}`,
+      payload: accepted,
+      produced_at: accepted.accepted_at,
+      delivery_id: "accepted",
+    },
+    {
+      seq: 2,
+      kind: "cluster_intake",
+      key: `openclaw-openclaw/${conflicting.store_sha256}`,
+      payload: conflicting,
+      produced_at: conflicting.accepted_at,
+      delivery_id: "conflicting",
+    },
+  ]);
+  assert.equal(
+    plan.writes.find((write) => write.path === accepted.jobs[0].path)?.content,
+    accepted.jobs[0].content,
+  );
+  assert.doesNotMatch(
+    plan.writes.find((write) => write.path === accepted.jobs[0].path)?.content ?? "",
+    /later snapshot/,
+  );
+});
+
+test("oversize durable jobs are rejected before workflow dispatch", () => {
+  const value = intent();
+  const content = "x".repeat(32 * 1024 + 1);
+  assert.throws(
+    () =>
+      clusterIntakeIntent({
+        ...unsignedIntent(value),
+        jobs: [
+          {
+            ...unsignedIntent(value).jobs[0],
+            content,
+            digest: createHash("sha256").update(content).digest("hex"),
+          },
+        ],
+      }),
+    /invalid cluster intake job fence/,
+  );
+});
+
+test("every accepted job fits a complete workflow dispatch independently", () => {
+  const first = intent(42);
+  const second = intent(43);
+  const firstUnsigned = unsignedIntent(first);
+  const secondUnsigned = unsignedIntent(second);
+  const padToLimit = (job: (typeof firstUnsigned.jobs)[number]) => {
+    const content = `${job.content}${"x".repeat(32 * 1024 - Buffer.byteLength(job.content))}`;
+    return { ...job, content, digest: createHash("sha256").update(content).digest("hex") };
+  };
+  const accepted = acceptClusterIntakeIntent(
+    {
+      ...firstUnsigned,
+      jobs: [padToLimit(firstUnsigned.jobs[0]), padToLimit(secondUnsigned.jobs[0])],
+    },
+    receiptSecret,
+  );
+  assert(Buffer.byteLength(JSON.stringify(accepted)) > CLUSTER_WORKFLOW_DISPATCH_MAX_PAYLOAD_BYTES);
+  for (const job of accepted.jobs) {
+    const inputs = clusterWorkflowDispatchInputs(job, {
+      runner: accepted.runner,
+      executionRunner: accepted.execution_runner,
+      model: accepted.model,
+      jobAuth: `sha256=${"0".repeat(64)}`,
+    });
+    assert(
+      Buffer.byteLength(JSON.stringify({ ref: "r".repeat(255), inputs })) <=
+        CLUSTER_WORKFLOW_DISPATCH_MAX_PAYLOAD_BYTES,
+    );
+  }
+});
+
+test("durable intake binds embedded job semantics to its target and fail-closed policy", () => {
+  const value = intent();
+  for (const replacement of [
+    ["repo: openclaw/openclaw", "repo: attacker/elsewhere"],
+    ["allow_merge: false", "allow_merge: true"],
+    ["security_sensitive: false", "security_sensitive: true"],
+  ]) {
+    const content = value.jobs[0].content.replace(replacement[0], replacement[1]);
+    assert.throws(
+      () =>
+        clusterIntakeIntent({
+          ...unsignedIntent(value),
+          jobs: [
+            {
+              ...unsignedIntent(value).jobs[0],
+              content,
+              digest: createHash("sha256").update(content).digest("hex"),
+            },
+          ],
+        }),
+      /(?:semantic policy mismatch|security_sensitive jobs are out of scope)/,
+    );
+  }
+});
+
+test("dispatch recovery retries pending intent and completed dispatch is idempotent", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-dispatch-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const value = intent();
+  const ledgerPath = writeDurableIntents(root, [value]);
+  const gh = path.join(bin, "gh");
+  fs.writeFileSync(gh, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  const capacity = () => ({ active: 0, max_live_workers: 2 });
+  assert.throws(() => dispatchClusterIntakes([value], root, env, capacity), /dispatch failed/);
+  assert.equal(
+    JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8")).clusters[
+      "42"
+    ].status,
+    "dispatch_pending",
+  );
+
+  const calls = path.join(root, "calls.txt");
+  fs.writeFileSync(gh, `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, { mode: 0o755 });
+  assert.deepEqual(dispatchClusterIntakes([value], root, env, capacity), {
+    updatedLedgers: ["results/cluster-repair-intake/openclaw-openclaw.json"],
+    pending: true,
+  });
+  assert.equal(
+    JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8")).clusters[
+      "42"
+    ].status,
+    "dispatch_claimed",
+  );
+  assert.deepEqual(
+    dispatchClusterIntakes([value], root, env, capacity, () => ({
+      action: "recover",
+      run: { databaseId: 123, url: "https://github.com/openclaw/clawsweeper/actions/runs/123" },
+    })),
+    {
+      updatedLedgers: ["results/cluster-repair-intake/openclaw-openclaw.json"],
+      pending: false,
+    },
+  );
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 1);
+  assert.match(fs.readFileSync(calls, "utf8"), /dispatch_key=cluster-intake:openclaw-openclaw:42/);
+  assert.match(fs.readFileSync(calls, "utf8"), /job_auth=sha256=[a-f0-9]{64}/);
+});
+
+test("cluster dispatch retains pending intent while worker capacity is full", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-capacity-"));
+  const value = intent();
+  const ledgerPath = writeDurableIntents(root, [value]);
+  assert.deepEqual(
+    dispatchClusterIntakes([value], root, process.env, () => ({
+      active: 2,
+      max_live_workers: 2,
+    })),
+    { updatedLedgers: [], pending: true },
+  );
+  const ledger = JSON.parse(
+    fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"),
+  );
+  assert.equal(ledger.clusters["42"].status, "dispatch_pending");
+});
+
+test("one materializer run reserves capacity before Actions exposes new workers", () => {
+  const capacity = reserveClusterCapacity(() => ({ active: 0, max_live_workers: 2 }));
+  assert.deepEqual(capacity({ requested: 1 }), { active: 0, max_live_workers: 2 });
+  assert.deepEqual(capacity({ requested: 2 }), { active: 1, max_live_workers: 2 });
+  assert.deepEqual(capacity({ requested: 1 }), { active: 2, max_live_workers: 2 });
+});
+
+test("cluster dispatch persists an available subset and recovers the remainder", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-subset-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const first = intent(42, "a".repeat(64));
+  const second = intent(43, "b".repeat(64));
+  const ledgerPath = writeDurableIntents(root, [first, second]);
+  const calls = path.join(root, "calls.txt");
+  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
+    mode: 0o755,
+  });
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  const partial = dispatchClusterIntakes([first, second], root, env, () => ({
+    active: 1,
+    max_live_workers: 2,
+  }));
+  assert.deepEqual(partial, {
+    updatedLedgers: ["results/cluster-repair-intake/openclaw-openclaw.json"],
+    pending: true,
+  });
+  let ledger = JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"));
+  assert.equal(ledger.clusters["42"].status, "dispatch_claimed");
+  assert.equal(ledger.clusters["43"].status, "dispatch_pending");
+
+  const recovered = dispatchClusterIntakes(
+    [first, second],
+    root,
+    env,
+    () => ({ active: 0, max_live_workers: 2 }),
+    () => ({ action: "recover", run: { databaseId: 42 } }),
+  );
+  assert.equal(recovered.pending, true);
+  ledger = JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"));
+  assert.equal(ledger.clusters["42"].status, "dispatched");
+  assert.equal(ledger.clusters["43"].status, "dispatch_claimed");
+  assert.equal(
+    dispatchClusterIntakes(
+      [first, second],
+      root,
+      env,
+      () => ({ active: 0, max_live_workers: 2 }),
+      () => ({ action: "recover", run: { databaseId: 43 } }),
+    ).pending,
+    false,
+  );
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 2);
+});
+
+test("simultaneous conflicting snapshots dispatch the ledger-accepted job once", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-conflict-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const acceptedDraft = intent(42, "a".repeat(64));
+  acceptedDraft.runner = "accepted-runner";
+  acceptedDraft.execution_runner = "accepted-execution-runner";
+  const accepted = resignIntent(acceptedDraft);
+  const conflictingDraft = intent(42, "b".repeat(64));
+  conflictingDraft.jobs[0].path = "jobs/openclaw/inbox/gitcrawl-42-renamed.md";
+  conflictingDraft.runner = "conflicting-runner";
+  const conflicting = resignIntent(conflictingDraft);
+  writeDurableIntents(root, [accepted, conflicting]);
+  const calls = path.join(root, "calls.txt");
+  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
+    mode: 0o755,
+  });
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  dispatchClusterIntakes([accepted, conflicting], root, env, () => ({
+    active: 0,
+    max_live_workers: 2,
+  }));
+  const call = fs.readFileSync(calls, "utf8");
+  assert.equal(call.trim().split("\n").length, 1);
+  assert.match(call, /job=jobs\/openclaw\/inbox\/gitcrawl-42-telegram-upload.md/);
+  assert.match(call, /runner=accepted-runner/);
+  assert.doesNotMatch(call, /renamed|conflicting-runner/);
+});
+
+test("a capacity-blocked intake recovers from its durable ledger without the queue row", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-ledger-recovery-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const value = intent();
+  writeDurableIntents(root, [value]);
+  assert.deepEqual(
+    dispatchClusterIntakes([value], root, process.env, () => ({
+      active: 2,
+      max_live_workers: 2,
+    })),
+    { updatedLedgers: [], pending: true },
+  );
+
+  const calls = path.join(root, "calls.txt");
+  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
+    mode: 0o755,
+  });
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  assert.deepEqual(
+    recoverPendingClusterIntakes(
+      root,
+      env,
+      () => ({ active: 0, max_live_workers: 2 }),
+      () => ({ action: "dispatch", run: null }),
+    ),
+    {
+      updatedLedgers: ["results/cluster-repair-intake/openclaw-openclaw.json"],
+      pending: true,
+    },
+  );
+  assert.deepEqual(
+    recoverPendingClusterIntakes(
+      root,
+      env,
+      () => ({ active: 0, max_live_workers: 2 }),
+      () => ({ action: "recover", run: { databaseId: 42 } }),
+    ),
+    {
+      updatedLedgers: ["results/cluster-repair-intake/openclaw-openclaw.json"],
+      pending: false,
+    },
+  );
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 1);
+});
+
+test("failed or invisible worker claims retry without terminalizing durable intent", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-claim-retry-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const value = intent();
+  const ledgerPath = writeDurableIntents(root, [value]);
+  const calls = path.join(root, "calls.txt");
+  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
+    mode: 0o755,
+  });
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  const capacity = () => ({ active: 0, max_live_workers: 2 });
+  dispatchClusterIntakes([value], root, env, capacity);
+  dispatchClusterIntakes([value], root, env, capacity, () => ({ action: "dispatch", run: null }));
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 2);
+  let ledger = JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"));
+  assert.equal(ledger.clusters["42"].status, "dispatch_claimed");
+
+  assert.deepEqual(
+    dispatchClusterIntakes([value], root, env, capacity, () => ({ action: "wait", run: null })),
+    { updatedLedgers: [], pending: true },
+  );
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 2);
+  dispatchClusterIntakes([value], root, env, capacity, () => ({
+    action: "recover",
+    run: { databaseId: 99, url: "https://github.com/openclaw/clawsweeper/actions/runs/99" },
+  }));
+  ledger = JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"));
+  assert.equal(ledger.clusters["42"].status, "dispatched");
+  assert.equal(ledger.clusters["42"].dispatch_run_id, 99);
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 2);
+});
+
+test("recovery rediscovers a successful worker when the claim publication was lost", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-lost-claim-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const value = intent();
+  const ledgerPath = writeDurableIntents(root, [value]);
+  const durablePending = fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8");
+  const calls = path.join(root, "calls.txt");
+  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
+    mode: 0o755,
+  });
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  dispatchClusterIntakes([value], root, env, () => ({ active: 0, max_live_workers: 2 }));
+  fs.writeFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), durablePending);
+
+  let observedClaimTime = "";
+  const recovered = recoverPendingClusterIntakes(
+    root,
+    env,
+    () => ({ active: 0, max_live_workers: 2 }),
+    (entry) => {
+      observedClaimTime = entry.dispatch_claimed_at ?? "";
+      return { action: "recover", run: { databaseId: 123 } };
+    },
+  );
+  assert.equal(observedClaimTime, value.accepted_at);
+  assert.deepEqual(recovered, {
+    updatedLedgers: ["results/cluster-repair-intake/openclaw-openclaw.json"],
+    pending: false,
+  });
+  assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").length, 1);
+  const ledger = JSON.parse(
+    fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"),
+  );
+  assert.equal(ledger.clusters["42"].status, "dispatched");
+});
+
+test("a later batch dispatch failure does not hide the earlier successful worker", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-partial-dispatch-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const first = intent(42, "a".repeat(64));
+  const second = intent(43, "b".repeat(64));
+  const ledgerPath = writeDurableIntents(root, [first, second]);
+  const calls = path.join(root, "calls.txt");
+  const counter = path.join(root, "counter.txt");
+  fs.writeFileSync(
+    path.join(bin, "gh"),
+    `#!/bin/sh\ncount=0\nif test -f '${counter}'; then count="$(cat '${counter}')"; fi\ncount=$((count + 1))\nprintf '%s\\n' "$count" > '${counter}'\nprintf '%s\\n' "$*" >> '${calls}'\nif test "$count" -eq 2; then exit 1; fi\n`,
+    { mode: 0o755 },
+  );
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CLAWSWEEPER_WEBHOOK_SECRET: dispatchSecret,
+  };
+  const capacity = () => ({ active: 0, max_live_workers: 2 });
+  assert.throws(
+    () => dispatchClusterIntakes([first, second], root, env, capacity),
+    /dispatch failed.*cluster 43/,
+  );
+
+  const recovered = recoverPendingClusterIntakes(root, env, capacity, (entry) =>
+    entry.cluster_id === 42
+      ? { action: "recover", run: { databaseId: 42 } }
+      : { action: "dispatch", run: null },
+  );
+  assert.equal(recovered.pending, true);
+  let ledger = JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"));
+  assert.equal(ledger.clusters["42"].status, "dispatched");
+  assert.equal(ledger.clusters["43"].status, "dispatch_claimed");
+
+  recoverPendingClusterIntakes(root, env, capacity, () => ({
+    action: "recover",
+    run: { databaseId: 43 },
+  }));
+  ledger = JSON.parse(fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8"));
+  assert.equal(ledger.clusters["43"].status, "dispatched");
+  const dispatchCalls = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(dispatchCalls.length, 3);
+  assert.equal(dispatchCalls.filter((call) => call.includes("gitcrawl-42-")).length, 1);
+  assert.equal(dispatchCalls.filter((call) => call.includes("gitcrawl-43-")).length, 2);
+});
+
+test("dispatch observation terminalizes only a successful planning worker", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-observation-"));
+  const bin = path.join(root, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  const value = intent();
+  const ledger = mergeClusterIntakeLedger(undefined, [value]);
+  const claimedAt = new Date(Date.now() - 10_000).toISOString();
+  const entry = {
+    ...ledger.clusters["42"],
+    status: "dispatch_claimed" as const,
+    dispatch_claimed_at: claimedAt,
+  };
+  const displayTitle = `repair cluster ${entry.job} [${entry.dispatch_key}]`;
+  const runs = JSON.stringify([
+    {
+      databaseId: 99,
+      displayTitle,
+      status: "completed",
+      conclusion: "success",
+      createdAt: new Date(Date.now() - 5_000).toISOString(),
+      url: "https://github.com/openclaw/clawsweeper/actions/runs/99",
+    },
+  ]);
+  const successfulJobs = JSON.stringify({
+    jobs: [
+      { name: "Deduplicate command dispatch receipt", conclusion: "success" },
+      { name: "Plan and review cluster", conclusion: "success" },
+    ],
+  });
+  const gh = path.join(bin, "gh");
+  fs.writeFileSync(
+    gh,
+    `#!/bin/sh\ncase "$*" in\n  *"run list"*) printf '%s\\n' '${runs}' ;;\n  *) printf '%s\\n' '${successfulJobs}' ;;\nesac\n`,
+    { mode: 0o755 },
+  );
+  const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+  assert.deepEqual(observeClusterDispatch(entry, env), {
+    action: "recover",
+    run: { ...JSON.parse(runs)[0], dispatch_execution_verified: true },
+  });
+
+  const mixedResultRuns = JSON.stringify([
+    {
+      ...JSON.parse(runs)[0],
+      conclusion: "failure",
+    },
+  ]);
+  fs.writeFileSync(
+    gh,
+    `#!/bin/sh\ncase "$*" in\n  *"run list"*) printf '%s\\n' '${mixedResultRuns}' ;;\n  *) printf '%s\\n' '${successfulJobs}' ;;\nesac\n`,
+    { mode: 0o755 },
+  );
+  assert.deepEqual(observeClusterDispatch(entry, env), {
+    action: "recover",
+    run: { ...JSON.parse(mixedResultRuns)[0], dispatch_execution_verified: true },
+  });
+
+  const receiptOnlyJobs = JSON.stringify({
+    jobs: [
+      { name: "Deduplicate command dispatch receipt", conclusion: "success" },
+      { name: "Plan and review cluster", conclusion: "skipped" },
+    ],
+  });
+  fs.writeFileSync(
+    gh,
+    `#!/bin/sh\ncase "$*" in\n  *"run list"*) printf '%s\\n' '${runs}' ;;\n  *) printf '%s\\n' '${receiptOnlyJobs}' ;;\nesac\n`,
+    { mode: 0o755 },
+  );
+  assert.deepEqual(observeClusterDispatch(entry, env), { action: "wait", run: null });
+});
+
+test("worker restores only an authenticated semantically valid durable job", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-restore-"));
+  const value = intent();
+  const job = value.jobs[0];
+  const authenticationTag = clusterDispatchAuthenticationTag(
+    dispatchSecret,
+    dispatchAuthenticationFields(job),
+  );
+  const options = {
+    root,
+    jobPath: job.path,
+    payload: Buffer.from(job.content).toString("base64"),
+    digest: job.digest,
+    dispatchKey: job.dispatch_key,
+    authenticationTag,
+    authenticationSecret: dispatchSecret,
+    allowedOwner: "openclaw",
+    mode: "autonomous",
+    runner: "blacksmith-4vcpu-ubuntu-2404",
+    executionRunner: "blacksmith-16vcpu-ubuntu-2404",
+    plannerSandbox: "read-only",
+    model: "internal",
+    dryRun: "false",
+  };
+  restoreClusterIntakeJob(options);
+  const restored = path.join(root, job.path);
+  assert.equal(fs.readFileSync(restored, "utf8"), job.content);
+  assert.equal(fs.statSync(restored).mode & 0o777, 0o600);
+
+  assert.throws(
+    () => restoreClusterIntakeJob({ ...options, dispatchKey: `${job.dispatch_key}-forged` }),
+    /authentication failed/,
+  );
+  assert.throws(
+    () => restoreClusterIntakeJob({ ...options, runner: "attacker-runner" }),
+    /authentication failed/,
+  );
+  const unsafeContent = job.content.replace("allow_merge: false", "allow_merge: true");
+  const unsafeDigest = createHash("sha256").update(unsafeContent).digest("hex");
+  assert.throws(
+    () =>
+      restoreClusterIntakeJob({
+        ...options,
+        payload: Buffer.from(unsafeContent).toString("base64"),
+        digest: unsafeDigest,
+        authenticationTag: clusterDispatchAuthenticationTag(dispatchSecret, {
+          ...dispatchAuthenticationFields(job),
+          jobDigest: unsafeDigest,
+        }),
+      }),
+    /semantic policy mismatch/,
+  );
+});
+
+test("worker rejects path and payload substitution even with a valid job digest", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-cluster-restore-fence-"));
+  const job = intent().jobs[0];
+  const authenticationTag = clusterDispatchAuthenticationTag(
+    dispatchSecret,
+    dispatchAuthenticationFields(job),
+  );
+  const base = {
+    root,
+    payload: Buffer.from(job.content).toString("base64"),
+    digest: job.digest,
+    dispatchKey: job.dispatch_key,
+    authenticationTag,
+    authenticationSecret: dispatchSecret,
+    allowedOwner: "openclaw",
+    mode: "autonomous",
+    runner: "blacksmith-4vcpu-ubuntu-2404",
+    executionRunner: "blacksmith-16vcpu-ubuntu-2404",
+    plannerSandbox: "read-only",
+    model: "internal",
+    dryRun: "false",
+  };
+  assert.throws(
+    () => restoreClusterIntakeJob({ ...base, jobPath: `${job.path}\nforged=1` }),
+    /invalid durable cluster intake job path/,
+  );
+  assert.throws(
+    () => restoreClusterIntakeJob({ ...base, jobPath: job.path, payload: `${base.payload}\n` }),
+    /payload encoding/,
+  );
+});
+
 test("accepted-intent receipts bind durable recovery authority", () => {
-  assert.throws(() => clusterIntakeIntent(proposal()), /accepted-intent digest mismatch/);
-  const accepted = acceptClusterIntakeIntent(proposal(), receiptSecret);
+  assert.throws(() => clusterIntakeIntent(receiptProposal()), /accepted-intent digest mismatch/);
+  const accepted = acceptClusterIntakeIntent(receiptProposal(), receiptSecret);
   const reparsed = clusterIntakeIntent(JSON.parse(JSON.stringify(accepted)));
   const ledger = clusterIntakeLedger(
     JSON.parse(JSON.stringify(mergeClusterIntakeLedger(undefined, [reparsed]))),
@@ -141,7 +979,7 @@ test("accepted-intent receipts bind durable recovery authority", () => {
 
 test("v2 cluster intake ledgers reject unvalidated JSON shapes", () => {
   const ledger = mergeClusterIntakeLedger(undefined, [
-    acceptClusterIntakeIntent(proposal(), receiptSecret),
+    acceptClusterIntakeIntent(receiptProposal(), receiptSecret),
   ]);
   assert.deepEqual(clusterIntakeLedger(JSON.parse(JSON.stringify(ledger))), ledger);
 

--- a/test/repair/command-ops-action-ledger.test.ts
+++ b/test/repair/command-ops-action-ledger.test.ts
@@ -70,9 +70,11 @@ test("direct repair requeues forward a stable dispatch receipt and publish it", 
   assert.match(finalizeStep, /--lane repair-requeue/);
   assert.match(publishStep, /--lane repair-requeue/);
   assert.match(publishStep, /--message "chore: append repair requeue action ledger"/);
-  assert.match(workflow, /pnpm run repair:requeue -- "\$\{\{ inputs\.job \}\}"/);
-  assert.match(workflow, /--source-job-path "\$\{\{ inputs\.job \}\}"/);
-  assert.match(workflow, /--requeue-depth "\$\{\{ inputs\.requeue_depth \}\}"/);
+  assert.match(workflow, /CLUSTER_JOB_PATH: \$\{\{ inputs\.job \}\}/);
+  assert.match(workflow, /CLUSTER_REQUEUE_DEPTH: \$\{\{ inputs\.requeue_depth \}\}/);
+  assert.match(workflow, /pnpm run repair:requeue -- "\$CLUSTER_JOB_PATH"/);
+  assert.match(workflow, /--source-job-path "\$CLUSTER_JOB_PATH"/);
+  assert.match(workflow, /--requeue-depth "\$CLUSTER_REQUEUE_DEPTH"/);
   assert.match(workflow, /--max-requeue-depth 1/);
 });
 

--- a/test/repair/repair-cluster-worker-containment.test.ts
+++ b/test/repair/repair-cluster-worker-containment.test.ts
@@ -95,8 +95,9 @@ test("initial planning forwards the selected model like requeues", () => {
 
   assert.ok(runWorkerIndex >= 0);
   assert.ok(reviewWorkerIndex > runWorkerIndex);
-  assert.match(runWorker, /--model "\$\{\{ inputs\.model \}\}"/);
-  assert.equal(workflow.match(/--model "\$\{\{ inputs\.model \}\}"/g)?.length, 2);
+  assert.match(workflow, /CLUSTER_WORKER_MODEL: \$\{\{ inputs\.model \}\}/);
+  assert.match(runWorker, /--model "\$CLUSTER_WORKER_MODEL"/);
+  assert.match(workflow.slice(reviewWorkerIndex), /--model "\$CLUSTER_WORKER_MODEL"/);
 });
 
 test("execution-gate downgrades complete the planning session without starting execution", () => {
@@ -110,7 +111,7 @@ test("execution-gate downgrades complete the planning session without starting e
   assert.match(workflow.slice(runWorkerIndex, completionIndex), /effective_mode=\$worker_mode/);
   assert.match(
     workflow.slice(completionIndex, executeIndex),
-    /steps\.run_worker\.outputs\.effective_mode.*plan/,
+    /EFFECTIVE_MODE: \$\{\{ steps\.run_worker\.outputs\.effective_mode \}\}[\s\S]*?"\$EFFECTIVE_MODE" == "plan"/,
   );
   assert.match(
     workflow.slice(executeIndex),

--- a/test/repair/state-materializer.test.ts
+++ b/test/repair/state-materializer.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { actionLedgerJson } from "../../dist/action-ledger.js";
+import { acceptClusterIntakeIntent } from "../../dist/repair/cluster-intake-state.js";
 import {
   GitShallowHistoryExhaustionError,
   SHALLOW_MERGE_BASE_EXHAUSTION_DISPOSITION,
@@ -40,6 +41,82 @@ test("materializer preserves canonical apply-proof content supplied as a string"
     selected: 1,
     skipped: 0,
   });
+});
+
+test("capacity-full cluster intake is acknowledged without retaining unrelated drain rows", async () => {
+  const fixture = createStateFixture();
+  const records = [
+    record(1, "sweep_status", "openclaw-openclaw", sweepStatus("healthy", "12:00:00.000")),
+    record(2, "cluster_intake", "openclaw-openclaw/store", clusterIntentPayload()),
+  ];
+  let drains = 0;
+  let acked = false;
+  const fetchImpl = signedQueueFetch(async (url, body) => {
+    if (url.pathname === "/internal/state/drain") {
+      drains += 1;
+      return drains === 1
+        ? Response.json({ ok: true, drain_token: "cluster-drain", records })
+        : Response.json({ ok: true, drain_token: null, records: [] });
+    }
+    assert.equal(url.pathname, "/internal/state/ack");
+    assert.deepEqual(body, { drain_token: "cluster-drain" });
+    acked = true;
+    return Response.json({ ok: true, acked: records.length });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({
+      env: materializerEnv(),
+      fetchImpl,
+      clusterCapacity: () => ({ active: 2, max_live_workers: 2 }),
+    }),
+  );
+
+  assert.deepEqual(summary, { drained: 2, committed: 2, acked: 2, skipped: 0, errors: 0 });
+  assert.equal(acked, true);
+  const ledger = JSON.parse(
+    showState(fixture, "results/cluster-repair-intake/openclaw-openclaw.json"),
+  );
+  assert.equal(ledger.clusters["42"].status, "dispatch_pending");
+  assert.equal(
+    JSON.parse(showState(fixture, "results/sweep-status/openclaw-openclaw.json")).detail,
+    "healthy",
+  );
+});
+
+test("startup cluster recovery uses the configured isolated publisher", async () => {
+  const fixture = createStateFixture();
+  const intake = record(1, "cluster_intake", "openclaw-openclaw/store", clusterIntentPayload());
+  const plan = planStateMaterialization([intake]);
+  for (const write of plan.writes) {
+    const target = path.join(fixture.source, write.path);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, write.content);
+  }
+  const publishedPaths: string[][] = [];
+  const fetchImpl = signedQueueFetch(async (url) => {
+    assert.equal(url.pathname, "/internal/state/drain");
+    return Response.json({ ok: true, drain_token: null, records: [] });
+  });
+
+  const summary = await withMaterializerFixture(fixture, () =>
+    runStateMaterializer({
+      env: materializerEnv(),
+      fetchImpl,
+      clusterCapacity: () => ({ active: 0, max_live_workers: 2 }),
+      clusterDispatchObserver: () => ({
+        action: "recover",
+        run: { databaseId: 42, url: "https://github.com/openclaw/clawsweeper/actions/runs/42" },
+      }),
+      publishCommit: (options) => {
+        publishedPaths.push([...options.paths]);
+        return "committed";
+      },
+    }),
+  );
+
+  assert.deepEqual(summary, { drained: 0, committed: 0, acked: 0, skipped: 0, errors: 0 });
+  assert.deepEqual(publishedPaths, [["results/cluster-repair-intake/openclaw-openclaw.json"]]);
 });
 
 test("materializer applies every record kind in sequence and keeps the last value per key", async () => {
@@ -815,6 +892,75 @@ function routerLedger(key: string, time: string): Record<string, unknown> {
       },
     ],
   };
+}
+
+function clusterIntentPayload(): Record<string, unknown> {
+  const content = `---
+repo: openclaw/openclaw
+cluster_id: gitcrawl-42-capacity-proof
+mode: autonomous
+job_intent: repair_cluster
+allowed_actions:
+  - comment
+  - label
+  - close
+  - fix
+  - raise_pr
+blocked_actions:
+  - force_push
+  - bypass_checks
+  - merge
+require_human_for:
+  - security_sensitive
+  - failing_checks
+  - conflicting_prs
+  - unclear_canonical
+  - broad_code_delta
+canonical:
+  - "#420"
+candidates:
+  - "#420"
+  - "#421"
+cluster_refs:
+  - "#420"
+  - "#421"
+security_policy: central_security_only
+security_sensitive: false
+allow_instant_close: false
+allow_fix_pr: true
+allow_merge: false
+allow_post_merge_close: true
+require_fix_before_close: true
+---
+
+# Capacity proof
+`;
+  return acceptClusterIntakeIntent(
+    {
+      schema: "clawsweeper-cluster-intake-intent-v1",
+      target_repo: "openclaw/openclaw",
+      repo_slug: "openclaw-openclaw",
+      store_sha256: "a".repeat(64),
+      store_exported_at: "2026-07-20T11:59:00.000Z",
+      manifest_path: "gitcrawl-store/data/openclaw__openclaw.sync.db.manifest.json",
+      run_url: "https://github.com/openclaw/clawsweeper/actions/runs/1",
+      accepted_at: "2026-07-20T12:00:01.000Z",
+      runner: "blacksmith-4vcpu-ubuntu-2404",
+      execution_runner: "blacksmith-16vcpu-ubuntu-2404",
+      model: "internal",
+      selector_summary: { evaluated: 2, rejected: 1, reason_counts: {} },
+      jobs: [
+        {
+          cluster_id: 42,
+          path: "jobs/openclaw/inbox/gitcrawl-42-capacity-proof.md",
+          content,
+          digest: createHash("sha256").update(content).digest("hex"),
+          dispatch_key: "cluster-intake:openclaw-openclaw:42",
+        },
+      ],
+    },
+    webhookSecret,
+  );
 }
 
 function signedQueueFetch(

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -154,12 +154,16 @@ test("state materializer bounds its coordinator acquire below the job timeout", 
   assert.equal(budgetMs + 15 * 60_000 <= Number(materializer?.["timeout-minutes"]) * 60_000, true);
 });
 
-test("only the batch publisher and the state materializer request priority admission", () => {
+test("only bounded publication owners request priority admission", () => {
+  const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
   const prioritySetups: string[] = [];
   for (const { file, workflow } of workflows()) {
     for (const [job, definition] of Object.entries(workflow.jobs ?? {})) {
       for (const step of definition.steps ?? []) {
-        if (isSetupState(step) && step.with?.["coordinator-class"] === "publication_batch") {
+        if (
+          isSetupState(step) &&
+          String(step.with?.["coordinator-class"] || "").includes("publication_batch")
+        ) {
           prioritySetups.push(`${file}:${job}`);
         }
       }
@@ -169,6 +173,9 @@ test("only the batch publisher and the state materializer request priority admis
     ".github/workflows/exact-review-batch-publish.yml:publish",
     ".github/workflows/state-materializer.yml:materialize",
   ]);
+  const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
+  const setup = materializer?.steps?.find(isSetupState);
+  assert.match(String(setup?.with?.["coordinator-class"]), /cluster_intake/);
 });
 
 test("trusted generated-state mutation steps receive a step-scoped coordinator credential", () => {


### PR DESCRIPTION
## Summary

This is **4/5** in the cluster-fixer reliability stack, based on [PR 883](https://github.com/openclaw/clawsweeper/pull/883).

- Makes the state materializer the sole projector for accepted cluster-intake intents.
- Writes only ledger-accepted job and ledger paths and never deletes unrelated jobs.
- Dispatches only after durable publication with a stable claim bound to the exact planning workflow/job.
- Recovers lease loss, capacity exhaustion, invisible/ambiguous workflow creation, lost claim publication, and partial batch dispatch without duplicate planning.
- Reserves worker capacity within a materializer cycle so stale GitHub run listings cannot oversubscribe the cluster worker cap.
- Restores worker jobs only after HMAC, digest, path, dispatch-key, runner/model, sandbox, mode, and dry-run policy verification.
- Makes mixed worker outcomes explicit instead of treating aggregate workflow status as the planning result.

## Validation

- `pnpm run build:all`
- 30 focused durability, stale-checkout, capacity, recovery, security, and dispatch tests
- Included in the full stack's static, lint, and regression validation

## Stack

1. [Candidate selection and historical dedupe](https://github.com/openclaw/clawsweeper/pull/881)
2. [Durable intake queue priority](https://github.com/openclaw/clawsweeper/pull/882)
3. [Durable intake intent contract](https://github.com/openclaw/clawsweeper/pull/883)
4. **This PR — exactly-once dispatch and recovery**
5. [Workflow cutover and result publication hardening](https://github.com/openclaw/clawsweeper/pull/873)

No merge/automerge or production gate is enabled.
