### PR TITLE
fix(state): reconcile tolerates agreeing-but-stale placement

### DIFF
--- a/scripts/reconcile-worker-records.ts
+++ b/scripts/reconcile-worker-records.ts
@@ -27,13 +27,13 @@ export type RecordParityMismatch = {
 export type AuthorityDecision = {
   path: string;
   itemId: string;
-  verdict: "git-wins" | "canonical-wins" | "lag";
+  verdict: "git-wins" | "canonical-wins" | "both-stale" | "lag";
   reason: string;
 };
 
 export type AuthorityTupleDecision = {
   itemId: string;
-  verdict: "git-wins" | "canonical-wins";
+  verdict: "git-wins" | "canonical-wins" | "both-stale";
   reason: string;
 };
 
@@ -97,16 +97,25 @@ export function decideRecordAuthority(options: {
 
     let tuple: AuthorityTupleDecision;
     if (canonicalPrimary && canonicalPrimary !== expectedPrimary) {
-      if (!gitHasExpectedPrimary) {
+      if (gitHasExpectedPrimary) {
+        tuple = {
+          itemId,
+          verdict: "git-wins",
+          reason: `GitHub is ${githubState}; canonical ${canonicalPrimary} placement is stale`,
+        };
+      } else if (options.gitRecordPaths.has(recordPath(canonicalPrimary, itemId))) {
+        // Both stores agree on placement; only GitHub disagrees. Placement is not a
+        // parity problem — the normal sweep corrects it when it re-reviews the item.
+        tuple = {
+          itemId,
+          verdict: "both-stale",
+          reason: `GitHub is ${githubState} but git and canonical agree on ${canonicalPrimary}; sweep will correct placement`,
+        };
+      } else {
         throw new Error(
           `Canonical placement for ${itemId} contradicts GitHub, but git lacks ${expectedPrimary}`,
         );
       }
-      tuple = {
-        itemId,
-        verdict: "git-wins",
-        reason: `GitHub is ${githubState}; canonical ${canonicalPrimary} placement is stale`,
-      };
     } else if (
       canonicalPrimary === expectedPrimary &&
       gitHasOppositePrimary &&
@@ -252,13 +261,22 @@ export async function reconcileWorkerRecordAuthority(options: {
     revision: number;
     sequence: number;
   }> = [];
-  const gitWinners = authority.tuples.filter((tuple) => tuple.verdict === "git-wins");
+  const gitWinners = authority.tuples.filter(
+    (tuple) => tuple.verdict === "git-wins" || tuple.verdict === "both-stale",
+  );
   if (!options.dryRun) {
     for (const tuple of gitWinners) {
       const mutation = gitTupleMutation({
         repoSlug: options.repoSlug,
         itemId: tuple.itemId,
-        githubState: githubStates.get(tuple.itemId)!,
+        // A both-stale tuple keeps the placement both stores agree on, so the
+        // corrective tuple validates against the current canonical primary.
+        primarySection:
+          tuple.verdict === "both-stale"
+            ? canonicalPrimarySection(canonicalRecords, tuple.itemId)!
+            : githubStates.get(tuple.itemId)! === "open"
+              ? "items"
+              : "closed",
         gitRecords,
         canonicalRecords,
       });
@@ -327,11 +345,11 @@ export async function reconcileWorkerRecordAuthority(options: {
 function gitTupleMutation(options: {
   repoSlug: string;
   itemId: string;
-  githubState: GitHubState;
+  primarySection: "items" | "closed";
   gitRecords: ReadonlyMap<string, { content: string; digest: string }>;
   canonicalRecords: ReadonlyMap<string, WorkerRecord>;
 }) {
-  const primarySection = options.githubState === "open" ? "items" : "closed";
+  const primarySection = options.primarySection;
   const primary = options.gitRecords.get(recordPath(primarySection, options.itemId));
   if (!primary) {
     throw new Error(
@@ -495,7 +513,7 @@ function renderDecisionTable(
   dryRun: boolean,
   decisions: readonly AuthorityDecision[],
 ) {
-  const counts = { "git-wins": 0, "canonical-wins": 0, lag: 0 };
+  const counts = { "git-wins": 0, "canonical-wins": 0, "both-stale": 0, lag: 0 };
   for (const decision of decisions) counts[decision.verdict] += 1;
   const rows = decisions
     .map(
@@ -506,7 +524,7 @@ function renderDecisionTable(
   return [
     `### Worker record authority reconciliation: ${targetRepo}`,
     "",
-    `Mode: ${dryRun ? "dry run" : "apply"}. Git wins: ${counts["git-wins"]}; canonical wins: ${counts["canonical-wins"]}; projection lag: ${counts.lag}.`,
+    `Mode: ${dryRun ? "dry run" : "apply"}. Git wins: ${counts["git-wins"]}; canonical wins: ${counts["canonical-wins"]}; both stale: ${counts["both-stale"]}; projection lag: ${counts.lag}.`,
     "",
     "| Path | Verdict | Reason |",
     "| --- | --- | --- |",

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -10,7 +10,10 @@ import { parse } from "yaml";
 import { hydrateState } from "../scripts/hydrate-state.ts";
 import { backfillWorkerRecords } from "../scripts/backfill-worker-records.ts";
 import { verifyWorkerRecordParity } from "../scripts/verify-worker-record-parity.ts";
-import { decideRecordAuthority } from "../scripts/reconcile-worker-records.ts";
+import {
+  decideRecordAuthority,
+  reconcileWorkerRecordAuthority,
+} from "../scripts/reconcile-worker-records.ts";
 import {
   ingestGitRecords,
   replayWorkerRecordProjections,
@@ -244,6 +247,143 @@ test("authority reconciliation imports a git-only decision packet with its tuple
       reason: "git-only decision-packets must be imported with its atomic tuple",
     },
   ]);
+});
+
+test("authority reconciliation tolerates agreeing-but-stale placement and keeps the ambiguous throw", () => {
+  // Item 857: canonical and git both keep the item under items/, GitHub says
+  // closed, and the only parity mismatch is a git-only decision packet.
+  const canonicalOpen = workerRecord("items", "857", "canonical open\n", 4);
+  const result = decideRecordAuthority({
+    mismatches: [
+      { path: "decision-packets/857.json", gitDigest: "a".repeat(64), workerDigest: null },
+    ],
+    canonicalRecords: new Map([["items/857.md", canonicalOpen]]),
+    gitRecordPaths: new Set(["items/857.md", "decision-packets/857.json"]),
+    githubStates: new Map([["857", "closed"]]),
+    gitCommitTimes: new Map(),
+  });
+
+  assert.deepEqual(result.tuples, [
+    {
+      itemId: "857",
+      verdict: "both-stale",
+      reason: "GitHub is closed but git and canonical agree on items; sweep will correct placement",
+    },
+  ]);
+  assert.equal(
+    result.decisions.find((entry) => entry.path === "decision-packets/857.json")?.verdict,
+    "both-stale",
+  );
+
+  // Genuinely ambiguous: stores disagree on the primary and git lacks the
+  // GitHub-expected primary. This must still fail loudly.
+  assert.throws(
+    () =>
+      decideRecordAuthority({
+        mismatches: [
+          { path: "decision-packets/858.json", gitDigest: "b".repeat(64), workerDigest: null },
+        ],
+        canonicalRecords: new Map([["items/858.md", workerRecord("items", "858", "open\n", 5)]]),
+        gitRecordPaths: new Set(["decision-packets/858.json"]),
+        githubStates: new Map([["858", "closed"]]),
+        gitCommitTimes: new Map(),
+      }),
+    /Canonical placement for 858 contradicts GitHub, but git lacks closed/,
+  );
+});
+
+test("reconciliation imports a git-only packet for a both-stale item keyed to canonical placement", async () => {
+  const slug = "openclaw-clawsweeper";
+  const packet = '{"decision":"merge"}\n';
+  const packetDigest = createHash("sha256").update(packet).digest("hex");
+  const item = [
+    "---",
+    "number: 857",
+    `decision_packet_sha256: ${packetDigest}`,
+    `decision_packet_path: records/${slug}/decision-packets/857.json`,
+    "---",
+    "shared item body",
+    "",
+  ].join("\n");
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-both-stale-test-"));
+  const stateRoot = path.join(root, "state");
+  write(path.join(stateRoot, "records", slug, "items", "857.md"), item);
+  write(path.join(stateRoot, "records", slug, "decision-packets", "857.json"), packet);
+  const parityReport = path.join(root, "parity.json");
+  writeFileSync(
+    parityReport,
+    JSON.stringify({
+      repoSlug: slug,
+      gitRecords: 2,
+      workerRecords: 1,
+      mismatches: [
+        { path: "decision-packets/857.json", gitDigest: packetDigest, workerDigest: null },
+      ],
+    }),
+  );
+  const summaryFile = path.join(root, "summary.md");
+  writeFileSync(summaryFile, "");
+  const tupleRequests: Array<Record<string, unknown>> = [];
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input.toString());
+    if (url.pathname === "/internal/state/records/export") {
+      return Response.json({
+        repoSlug: slug,
+        revision: 4,
+        nextCursor: null,
+        records: [workerRecord("items", "857", item, 1)],
+      });
+    }
+    assert.equal(url.pathname, "/internal/state/records/tuples");
+    tupleRequests.push(JSON.parse(String(init?.body ?? "{}")));
+    return Response.json({ ok: true, accepted: true, deduped: false, revision: 2, sequence: 7 });
+  }) as typeof fetch;
+
+  try {
+    const result = await reconcileWorkerRecordAuthority({
+      stateRoot,
+      targetRepo: "openclaw/clawsweeper",
+      repoSlug: slug,
+      baseUrl: "https://worker.example",
+      webhookSecret: "fixture-secret",
+      parityReport,
+      summaryFile,
+      fetch: fetchImpl,
+      githubStates: () => new Map([["857", "closed"]]),
+      gitCommitTimes: () => new Map(),
+    });
+
+    assert.deepEqual(result.decisions, [
+      {
+        path: "decision-packets/857.json",
+        itemId: "857",
+        verdict: "both-stale",
+        reason:
+          "GitHub is closed but git and canonical agree on items; sweep will correct placement",
+      },
+    ]);
+    assert.deepEqual(result.corrections, [
+      { itemId: "857", deduped: false, revision: 2, sequence: 7 },
+    ]);
+    assert.equal(tupleRequests.length, 1);
+    assert.deepEqual(tupleRequests[0]?.operations, [
+      {
+        path: `records/${slug}/items/857.md`,
+        expectedDigest: createHash("sha256").update(item).digest("hex"),
+        contentBase64: Buffer.from(item).toString("base64"),
+      },
+      { path: `records/${slug}/closed/857.md`, expectedDigest: null },
+      { path: `records/${slug}/plans/857.md`, expectedDigest: null },
+      {
+        path: `records/${slug}/decision-packets/857.json`,
+        expectedDigest: null,
+        contentBase64: Buffer.from(packet).toString("base64"),
+      },
+    ]);
+    assert.match(readFileSync(summaryFile, "utf8"), /both-stale/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("authority reconciliation keeps canonical content when its provenance is newer", () => {


### PR DESCRIPTION
## Problem

`worker-records-ops` reconcile runs 30243420312 and 30243421643 failed on `openclaw-clawsweeper` item 857 with:

> Canonical placement for 857 contradicts GitHub, but git lacks closed

For 857, canonical and git **agree**: both keep the item under `items/`. The only parity mismatch is a git-only `decision-packets/857.json` sidecar. GitHub says the item is closed, so both stores are equally stale on placement — but that is not a parity problem. The normal sweep corrects placement when it re-reviews the item. `decideRecordAuthority` nevertheless hit the contradiction branch (canonical primary != GitHub-expected primary, git lacks `closed/857.md`) and threw, blocking the sidecar import entirely.

## Fix

- When canonical placement contradicts GitHub but git agrees with canonical (git has the canonical primary and lacks the GitHub-expected one), record the item with a new `both-stale` verdict instead of throwing, with the reason that the sweep will correct placement.
- `both-stale` items still get their mismatched records processed: the corrective tuple is built keyed to the **current canonical primary** placement (not the GitHub-derived one), so the git-only sidecar imports and the tuple validates against canonical digests. `gitTupleMutation` now takes the primary section explicitly.
- The throw remains only for the genuinely ambiguous case: stores disagree on the primary **and** git lacks the GitHub-expected primary.
- The decision table now counts and renders `both-stale` rows.

## Proof

- New regression tests mirror item 857: `decideRecordAuthority` returns `both-stale` without throwing (and the ambiguous case still throws), and an end-to-end `reconcileWorkerRecordAuthority` test proves the git-only packet is imported via `/internal/state/records/tuples` keyed to `items/`, the correction receipt is recorded, and the summary logs `both-stale`.
- `node --test test/worker-state-readers.test.ts`: 14/14 pass.
- `lint:scripts` and `oxfmt --check` clean on touched files; autoreview (Codex, local mode) clean.
