### PR TITLE
fix(state): surface worker request failures without cloning consumed bodies and retry transient 5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Worker record request failures now surface the real status, error code, and a body snippet instead of dying on `Response.clone: Body has already been consumed`, and signed Worker requests retry transient 5xx/network failures (3 attempts, exponential backoff) so Cloudflare 502s no longer kill long export/reconcile runs.
 - Made canonical record replay normalize revision-ordered legacy tuple remnants, continue after per-item validation rejections, and fail once at the end with every rejected item id.
 - Allowed stuck-placeholder recovery to label pull requests by granting its target token pull-request write permission alongside issue write. Thanks @masatohoshino! (#865)
 - Kept root-level apply reports as digest-only action-ledger evidence so ledger-enabled apply runs can finish, publish their compatibility report, and advance their cursor. Thanks @yetval! (#833)

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -75,12 +75,18 @@ export class WorkerSnapshotUnavailableError extends Error {
 class WorkerRecordRequestError extends Error {
   readonly status: number;
   readonly code: string;
+  readonly bodySnippet: string;
 
-  constructor(status: number, code: string) {
-    super(`Worker record request failed (${status}): ${code}`);
+  constructor(status: number, code: string, bodySnippet = "") {
+    super(
+      bodySnippet && bodySnippet !== code
+        ? `Worker record request failed (${status}): ${code} — ${bodySnippet}`
+        : `Worker record request failed (${status}): ${code}`,
+    );
     this.name = "WorkerRecordRequestError";
     this.status = status;
     this.code = code;
+    this.bodySnippet = bodySnippet;
   }
 }
 
@@ -719,7 +725,9 @@ async function downloadSnapshot(options: {
         },
         fetch: options.fetch,
       });
-      if (!response.ok) throw await workerRequestError(response);
+      if (!response.ok) {
+        throw workerRequestError(response.status, await response.text().catch(() => ""));
+      }
       if (response.status !== 206) {
         throw new Error(`Worker snapshot chunk returned status ${response.status}`);
       }
@@ -802,10 +810,19 @@ export async function signedPost<T>(options: {
   fetch?: typeof globalThis.fetch;
 }): Promise<T> {
   const response = await signedRequest(options);
-  const value = await response.json().catch(() => null);
-  if (!response.ok) throw await workerRequestError(response, value);
-  return value as T;
+  // Read the body exactly once; a Response body is a one-shot stream and a
+  // later clone() of a consumed response throws, masking the real failure.
+  const bodyText = await response.text().catch(() => "");
+  if (!response.ok) throw workerRequestError(response.status, bodyText);
+  try {
+    return JSON.parse(bodyText) as T;
+  } catch {
+    return null as T;
+  }
 }
+
+const SIGNED_REQUEST_MAX_ATTEMPTS = 3;
+const SIGNED_REQUEST_RETRY_BASE_MS = 250;
 
 async function signedRequest(options: {
   baseUrl: string;
@@ -821,28 +838,50 @@ async function signedRequest(options: {
   if (!options.webhookSecret) throw new Error("Worker records HMAC secret is required");
   const body = JSON.stringify(options.body);
   const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
-  return (options.fetch ?? globalThis.fetch)(`${baseUrl}${options.path}`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-clawsweeper-exact-review-signature": signature,
-    },
-    body,
-  });
+  const performFetch = options.fetch ?? globalThis.fetch;
+  // Bounded retry for transient failures: 5xx responses and network errors
+  // (GitHub/Cloudflare 502s regularly kill long reconcile/export runs). 4xx
+  // responses are deterministic and returned to the caller immediately.
+  for (let attempt = 1; ; attempt += 1) {
+    let response: Response;
+    try {
+      response = await performFetch(`${baseUrl}${options.path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        body,
+      });
+    } catch (error) {
+      if (attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) throw error;
+      await signedRequestBackoff(attempt);
+      continue;
+    }
+    if (response.status < 500 || attempt >= SIGNED_REQUEST_MAX_ATTEMPTS) return response;
+    await response.body?.cancel().catch(() => {});
+    await signedRequestBackoff(attempt);
+  }
 }
 
-async function workerRequestError(response: Response, parsedValue?: unknown) {
-  const value =
-    parsedValue ??
-    (await response
-      .clone()
-      .json()
-      .catch(() => null));
+function signedRequestBackoff(attempt: number) {
+  return new Promise((resolve) =>
+    setTimeout(resolve, SIGNED_REQUEST_RETRY_BASE_MS * 2 ** (attempt - 1)),
+  );
+}
+
+function workerRequestError(status: number, bodyText: string) {
+  let value: unknown = null;
+  try {
+    value = JSON.parse(bodyText);
+  } catch {
+    // Non-JSON error body (e.g. an HTML 502 page); fall through to the snippet.
+  }
   const code =
     value && typeof value === "object" && "error" in value
       ? String((value as { error: unknown }).error)
-      : String(response.status);
-  return new WorkerRecordRequestError(response.status, code);
+      : String(status);
+  return new WorkerRecordRequestError(status, code, bodyText.trim().slice(0, 200));
 }
 
 function batchIngestRecords(

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { exportWorkerRecords, signedPost } from "../scripts/worker-records.ts";
+
+const baseUrl = "http://127.0.0.1:8787";
+const webhookSecret = "test-secret";
+
+function jsonResponse(status: number, body: unknown, contentType = "application/json") {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers: { "content-type": contentType },
+  });
+}
+
+function fetchStub(responses: Array<Response | Error>) {
+  const calls: string[] = [];
+  const fetchImpl: typeof globalThis.fetch = async (input) => {
+    calls.push(String(input));
+    const next = responses.shift();
+    if (!next) throw new Error("fetch stub exhausted");
+    if (next instanceof Error) throw next;
+    return next;
+  };
+  return { calls, fetchImpl };
+}
+
+test("signedPost surfaces status and error code from a non-OK response without cloning", async () => {
+  const { calls, fetchImpl } = fetchStub([jsonResponse(422, { error: "invalid_repo" })]);
+  await assert.rejects(
+    signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
+    (error: Error & { status?: number; code?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.notEqual(error.name, "TypeError");
+      assert.equal(error.status, 422);
+      assert.equal(error.code, "invalid_repo");
+      assert.match(error.message, /422/);
+      assert.match(error.message, /invalid_repo/);
+      return true;
+    },
+  );
+  assert.equal(calls.length, 1, "4xx must not retry");
+});
+
+test("signedPost includes a body snippet for non-JSON error bodies", async () => {
+  const { fetchImpl } = fetchStub([jsonResponse(403, "<html>edge denied</html>", "text/html")]);
+  await assert.rejects(
+    signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
+    (error: Error & { status?: number; code?: string; bodySnippet?: string }) => {
+      assert.equal(error.status, 403);
+      assert.equal(error.code, "403");
+      assert.equal(error.bodySnippet, "<html>edge denied</html>");
+      assert.match(error.message, /edge denied/);
+      return true;
+    },
+  );
+});
+
+test("signedPost retries 5xx responses and succeeds within the attempt budget", async () => {
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(502, "<html>bad gateway</html>", "text/html"),
+    jsonResponse(502, { error: "upstream_unavailable" }),
+    jsonResponse(200, { ok: true }),
+  ]);
+  const value = await signedPost<{ ok: boolean }>({
+    baseUrl,
+    path: "/internal/test",
+    webhookSecret,
+    body: {},
+    fetch: fetchImpl,
+  });
+  assert.deepEqual(value, { ok: true });
+  assert.equal(calls.length, 3);
+});
+
+test("signedPost surfaces the final 5xx after exhausting retries", async () => {
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(502, { error: "upstream_unavailable" }),
+    jsonResponse(503, { error: "overloaded" }),
+    jsonResponse(502, { error: "upstream_unavailable" }),
+  ]);
+  await assert.rejects(
+    signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
+    (error: Error & { status?: number; code?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.equal(error.status, 502);
+      assert.equal(error.code, "upstream_unavailable");
+      return true;
+    },
+  );
+  assert.equal(calls.length, 3);
+});
+
+test("signedPost retries network errors and succeeds", async () => {
+  const { calls, fetchImpl } = fetchStub([
+    new TypeError("fetch failed"),
+    jsonResponse(200, { ok: true }),
+  ]);
+  const value = await signedPost<{ ok: boolean }>({
+    baseUrl,
+    path: "/internal/test",
+    webhookSecret,
+    body: {},
+    fetch: fetchImpl,
+  });
+  assert.deepEqual(value, { ok: true });
+  assert.equal(calls.length, 2);
+});
+
+test("exportWorkerRecords surfaces the worker error code for a consumed-body failure", async () => {
+  const { calls, fetchImpl } = fetchStub([jsonResponse(409, { error: "revision_conflict" })]);
+  await assert.rejects(
+    exportWorkerRecords({
+      baseUrl,
+      webhookSecret,
+      repoSlug: "openclaw-openclaw",
+      fetch: fetchImpl,
+    }),
+    (error: Error & { status?: number; code?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.equal(error.status, 409);
+      assert.equal(error.code, "revision_conflict");
+      return true;
+    },
+  );
+  assert.equal(calls.length, 1);
+});
+
+test("exportWorkerRecords rides out a transient 502 during export", async () => {
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(502, "<html>cloudflare 502</html>", "text/html"),
+    jsonResponse(200, {
+      repoSlug: "openclaw-openclaw",
+      revision: 7,
+      records: [],
+      nextCursor: null,
+    }),
+  ]);
+  const snapshot = await exportWorkerRecords({
+    baseUrl,
+    webhookSecret,
+    repoSlug: "openclaw-openclaw",
+    fetch: fetchImpl,
+  });
+  assert.equal(snapshot.revision, 7);
+  assert.deepEqual(snapshot.records, []);
+  assert.equal(calls.length, 2);
+});


### PR DESCRIPTION
## Problem

Failed signed Worker requests died with `TypeError: Response.clone: Body has already been consumed.` instead of the real failure. `signedPost` consumed the body via `response.json()`, then `workerRequestError` called `response.clone().json()` on the consumed response — live repro in run 30244550300, thrown from `signedPost` via `exportWorkerRecords`. On top of that, transient GitHub/Cloudflare 502s killed long export/reconcile runs outright because there was no retry.

## Fix

- `signedPost` reads the response body exactly once as text; the error path builds `WorkerRecordRequestError` from that text (JSON `error` code when present, else the status) plus a trimmed 200-char body snippet, so HTML edge error pages are visible too. `Response.clone()` is gone.
- The snapshot chunk download error path (`downloadSnapshot`) — the only sibling call site — now reads the body once the same way.
- `signedRequest` retries network errors and 5xx responses up to 3 attempts with exponential backoff (250ms base); 4xx responses return to the caller immediately. The `error.code` contract used by snapshot-availability and replay-failure matching is unchanged.

Real failures now surface as `WorkerRecordRequestError` with the actual HTTP status, the Worker's error code (e.g. `revision_conflict`, `snapshot_not_found`), and a body snippet for non-JSON bodies (Cloudflare 502 HTML, Access denials) — instead of a masking TypeError.

## Tests

`test/worker-records-request.test.ts` (mocked fetch, node:test): consumed-body 4xx surfaces status+code without TypeError and without retry; non-JSON error body yields status code + snippet; 5xx retries then succeeds (3 calls); exhausted retries surface the final 5xx; network error retries; `exportWorkerRecords` end-to-end for both the 409 error path and a transient-502-then-success export.

All 7 new tests pass, plus `test/worker-state-readers.test.ts` (14 pass). `lint:scripts` and `oxfmt --check` clean on touched files. Autoreview (Codex, local mode): clean, no actionable findings.
