### PR TITLE
fix(state): throw invalid_json_body when a 2xx worker response has no parsable JSON body

### DIFF
--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -814,18 +814,24 @@ export async function signedPost<T>(options: {
   // later clone() of a consumed response throws, masking the real failure.
   const bodyText = await response.text().catch(() => "");
   if (!response.ok) throw workerRequestError(response.status, bodyText);
+  let value: unknown;
   try {
-    return JSON.parse(bodyText) as T;
+    value = JSON.parse(bodyText);
   } catch {
-    // A 2xx with an empty or non-JSON body is a protocol violation (e.g. an
-    // edge proxy serving a blank 200). Returning null here crashes callers far
-    // from the request; fail loudly with the status and a body snippet instead.
+    value = undefined;
+  }
+  // A 2xx whose body is empty, non-JSON, or a JSON null/primitive (e.g. a
+  // literal "null" page) is a protocol violation — every endpoint returns an
+  // object envelope. Returning it would crash callers far from the request;
+  // fail loudly with the status and a body snippet instead.
+  if (typeof value !== "object" || value === null) {
     throw new WorkerRecordRequestError(
       response.status,
       "invalid_json_body",
       bodyText.trim().slice(0, 200),
     );
   }
+  return value as T;
 }
 
 const SIGNED_REQUEST_MAX_ATTEMPTS = 3;

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -817,7 +817,14 @@ export async function signedPost<T>(options: {
   try {
     return JSON.parse(bodyText) as T;
   } catch {
-    return null as T;
+    // A 2xx with an empty or non-JSON body is a protocol violation (e.g. an
+    // edge proxy serving a blank 200). Returning null here crashes callers far
+    // from the request; fail loudly with the status and a body snippet instead.
+    throw new WorkerRecordRequestError(
+      response.status,
+      "invalid_json_body",
+      bodyText.trim().slice(0, 200),
+    );
   }
 }
 

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -89,6 +89,21 @@ test("signedPost throws invalid_json_body with a snippet for a 2xx HTML body", a
   );
 });
 
+test("signedPost throws invalid_json_body for a 2xx response with a literal null body", async () => {
+  const { calls, fetchImpl } = fetchStub([jsonResponse(200, "null")]);
+  await assert.rejects(
+    signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
+    (error: Error & { status?: number; code?: string; bodySnippet?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.equal(error.status, 200);
+      assert.equal(error.code, "invalid_json_body");
+      assert.equal(error.bodySnippet, "null");
+      return true;
+    },
+  );
+  assert.equal(calls.length, 1);
+});
+
 test("signedPost resends the full JSON request body on a retry after a 502", async () => {
   const responses = [
     jsonResponse(502, "<html>bad gateway</html>", "text/html"),

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -56,6 +56,65 @@ test("signedPost includes a body snippet for non-JSON error bodies", async () =>
   );
 });
 
+test("signedPost throws invalid_json_body for a 2xx response with an empty body", async () => {
+  const { calls, fetchImpl } = fetchStub([jsonResponse(200, "")]);
+  await assert.rejects(
+    signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
+    (error: Error & { status?: number; code?: string; bodySnippet?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.equal(error.status, 200);
+      assert.equal(error.code, "invalid_json_body");
+      assert.equal(error.bodySnippet, "");
+      return true;
+    },
+  );
+  assert.equal(calls.length, 1, "2xx must not retry");
+});
+
+test("signedPost throws invalid_json_body with a snippet for a 2xx HTML body", async () => {
+  const { fetchImpl } = fetchStub([
+    jsonResponse(200, "<html><body>maintenance page</body></html>", "text/html"),
+  ]);
+  await assert.rejects(
+    signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
+    (error: Error & { status?: number; code?: string; bodySnippet?: string }) => {
+      assert.equal(error.name, "WorkerRecordRequestError");
+      assert.equal(error.status, 200);
+      assert.equal(error.code, "invalid_json_body");
+      assert.equal(error.bodySnippet, "<html><body>maintenance page</body></html>");
+      assert.match(error.message, /invalid_json_body/);
+      assert.match(error.message, /maintenance page/);
+      return true;
+    },
+  );
+});
+
+test("signedPost resends the full JSON request body on a retry after a 502", async () => {
+  const responses = [
+    jsonResponse(502, "<html>bad gateway</html>", "text/html"),
+    jsonResponse(200, { ok: true }),
+  ];
+  const bodies: string[] = [];
+  const fetchImpl: typeof globalThis.fetch = async (_input, init) => {
+    bodies.push(String(init?.body));
+    const next = responses.shift();
+    if (!next) throw new Error("fetch stub exhausted");
+    return next;
+  };
+  const payload = { repoSlug: "openclaw-openclaw", sections: ["items"], cursor: 0 };
+  const value = await signedPost<{ ok: boolean }>({
+    baseUrl,
+    path: "/internal/test",
+    webhookSecret,
+    body: payload,
+    fetch: fetchImpl,
+  });
+  assert.deepEqual(value, { ok: true });
+  assert.equal(bodies.length, 2);
+  assert.equal(bodies[0], JSON.stringify(payload), "first attempt must carry the full JSON body");
+  assert.equal(bodies[1], bodies[0], "retry must resend an identical body payload");
+});
+
 test("signedPost retries 5xx responses and succeeds within the attempt budget", async () => {
   const { calls, fetchImpl } = fetchStub([
     jsonResponse(502, "<html>bad gateway</html>", "text/html"),


### PR DESCRIPTION
## Problem

Regression from #887: `signedPost` in `scripts/worker-records.ts` swallowed JSON parse failures on 2xx responses and returned `null as T`. Callers then crashed far from the request site — live repro: the latest worker-records-ops reconcile run for openclaw/openclaw died with `TypeError: Cannot read properties of null (reading 'repoSlug')` at `exportWorkerRecords` (worker-records.ts:130).

## Fix

A 2xx response whose body is empty or not valid JSON now throws a `WorkerRecordRequestError` carrying the HTTP status, code `invalid_json_body`, and a 200-char trimmed body snippet. `signedPost` never returns `null`.

## Retry-path audit (#887)

Audited `signedRequest` for the hypothesized body-reuse bug (a consumed body stream yielding an empty-body 200 on retry). Not confirmed: the JSON body is serialized to a string once and a fresh init object literal is built per attempt, so nothing is consumed across retries. A new regression test pins that a retry after a 502 resends the identical full JSON payload.

## Tests

- 2xx with empty body throws `invalid_json_body` (no null return, no retry)
- 2xx with HTML body throws with the body snippet in code and message
- retry-after-502 resends the full JSON body; mock asserts identical payloads on both attempts

All 10 tests in `test/worker-records-request.test.ts` pass; oxlint/oxfmt clean on touched files; `tsc --noEmit` clean; autoreview (codex, local mode) clean.
