### PR TITLE
fix(queue): preserve empty legacy target branches

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -250,7 +250,7 @@ jobs:
           set -euo pipefail
           test -n "$CLAWSWEEPER_WEBHOOK_SECRET"
           queue_url="${QUEUE_URL%/}"
-          IFS=$'\t' read -r target_repo target_branch use_source_authority < <(node <<'NODE'
+          mapfile -d '' -t legacy_intake_fields < <(node <<'NODE'
           const payload = JSON.parse(process.env.CLIENT_PAYLOAD || "{}");
           const itemKind = payload.item_kind === "pull_request" ? "pull_request" : "issue";
           const queueClaim = payload.queue_claim && typeof payload.queue_claim === "object"
@@ -280,10 +280,17 @@ jobs:
             (payload.source_event === "pull_request" || payload.source_event === "pull_request_target") &&
             /^[0-9a-f]{64}$/.test(ingressFingerprint);
           process.stdout.write(
-            `${String(payload.target_repo || "openclaw/openclaw").trim()}\t${String(payload.target_branch || "").trim()}\t${itemKind === "pull_request" && payload.source_event === "pull_request" && payload.source_action === "edited" && Number.isInteger(installationId) && installationId > 0 && /^[0-9a-f]{40}$/.test(sourceHeadSha) && /^[0-9a-f]{40}$/.test(sourceBaseSha) && typeof sourceIsDraft === "boolean" && /^[0-9a-f]{64}$/.test(sourceContentRevision) && !targetDispatcherIngress ? "1" : "0"}\n`,
+            `${String(payload.target_repo || "openclaw/openclaw").trim()}\0${String(payload.target_branch || "").trim()}\0${itemKind === "pull_request" && payload.source_event === "pull_request" && payload.source_action === "edited" && Number.isInteger(installationId) && installationId > 0 && /^[0-9a-f]{40}$/.test(sourceHeadSha) && /^[0-9a-f]{40}$/.test(sourceBaseSha) && typeof sourceIsDraft === "boolean" && /^[0-9a-f]{64}$/.test(sourceContentRevision) && !targetDispatcherIngress ? "1" : "0"}\0`,
           );
           NODE
           )
+          if [ "${#legacy_intake_fields[@]}" -ne 3 ]; then
+            echo "Invalid legacy intake field count." >&2
+            exit 1
+          fi
+          target_repo="${legacy_intake_fields[0]}"
+          target_branch="${legacy_intake_fields[1]}"
+          use_source_authority="${legacy_intake_fields[2]}"
           if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
             echo "Invalid legacy target repository: $target_repo" >&2
             exit 1

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2627,7 +2627,77 @@ test("planned background reviews allow safe content-cache reuse without weakenin
   assert.doesNotMatch(eventReviewJob, /--planned-automatic-review/);
 });
 
-test("sweep event reviews and target fanout avoid storm amplification", () => {
+test("legacy event field serializer preserves branchless issue and PR intake", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }>;
+  };
+  const run = workflow.jobs["legacy-event-queue-intake"]?.steps.find(
+    (step) => step.name === "Enqueue legacy event through the durable control plane",
+  )?.run;
+  assert.ok(run);
+  const script = run.match(/node <<'NODE'\n([\s\S]*?)\nNODE\n/)?.[1];
+  assert.ok(script);
+
+  const serialize = (payload: Record<string, unknown>): string[] => {
+    const output = execFileSync(process.execPath, ["-"], {
+      encoding: "utf8",
+      env: { ...process.env, CLIENT_PAYLOAD: JSON.stringify(payload) },
+      input: script,
+    });
+    const fields = output.split("\0");
+    assert.equal(fields.pop(), "");
+    return fields;
+  };
+
+  assert.deepEqual(
+    serialize({
+      item_kind: "issue",
+      target_repo: "openclaw/openclaw",
+      source_event: "issues",
+      source_action: "opened",
+    }),
+    ["openclaw/openclaw", "", "0"],
+  );
+  assert.deepEqual(
+    serialize({
+      item_kind: "pull_request",
+      target_repo: "openclaw/clawhub",
+      item_number: 3273,
+      source_event: "pull_request_target",
+      source_action: "opened",
+      supersedes_in_progress: false,
+    }),
+    ["openclaw/clawhub", "", "0"],
+  );
+  assert.deepEqual(
+    serialize({
+      item_kind: "pull_request",
+      target_repo: "openclaw/clawhub",
+      source_event: "pull_request",
+      source_action: "edited",
+      queue_claim: {
+        installation_id: 1,
+        source_head_sha: "a".repeat(40),
+        source_base_sha: "b".repeat(40),
+        source_is_draft: false,
+        source_content_revision: "c".repeat(64),
+      },
+    }),
+    ["openclaw/clawhub", "", "1"],
+  );
+  assert.deepEqual(
+    serialize({
+      item_kind: "pull_request",
+      target_repo: "openclaw/clawhub",
+      target_branch: "main",
+      source_event: "issue_comment",
+      source_action: "created",
+    }),
+    ["openclaw/clawhub", "main", "0"],
+  );
+});
+
+test("sweep issue and PR event reviews and target fanout avoid storm amplification", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const legacyIntakeBlock = workflow.slice(
     workflow.indexOf("legacy-event-queue-intake:"),

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2656,6 +2656,13 @@ test("sweep event reviews and target fanout avoid storm amplification", () => {
   assert.match(legacyIntakeBlock, /gh api "repos\/\$target_repo" --jq \.default_branch/);
   assert.match(legacyIntakeBlock, /targetBranch: process\.env\.TARGET_BRANCH/);
   assert.doesNotMatch(legacyIntakeBlock, /targetBranch: payload\.target_branch \|\| "main"/);
+  assert.match(legacyIntakeBlock, /mapfile -d '' -t legacy_intake_fields/);
+  assert.match(legacyIntakeBlock, /\.trim\(\)\}\\0\$\{String\(payload\.target_branch/);
+  assert.match(legacyIntakeBlock, /target_branch="\$\{legacy_intake_fields\[1\]\}"/);
+  assert.doesNotMatch(
+    legacyIntakeBlock,
+    /IFS=\$'\\t' read -r target_repo target_branch use_source_authority/,
+  );
   assert.match(legacyIntakeBlock, /sourceBaseSha/);
   assert.match(legacyIntakeBlock, /sourceIsDraft/);
   assert.match(legacyIntakeBlock, /sourceContentRevision/);


### PR DESCRIPTION
## Summary

Preserve an omitted target-branch field on legacy issue and pull-request intake so the event resolves the target repository's default branch instead of trying to fetch branch `0`.

## Problem

#857 changed the legacy event parser to read three tab-separated fields with Bash `read`. Tabs are IFS whitespace, so Bash collapses an empty middle field. For a branchless event, the serialized values were effectively:

```text
openclaw/openclaw    <empty>    0
```

That shifted `0` into `target_branch`, and intake failed or admitted the wrong branch before normal review generation. The shared parser affects any legacy payload that omits `target_branch`:

- openclaw/openclaw issue intake: #114128 was the last successful comparable issue; #114129 was the first subsequent failure.
- openclaw/clawhub PR intake: [ClawHub #3273](https://github.com/openclaw/clawhub/pull/3273) dispatched a `pull_request_target/opened` payload without `target_branch` in [run 30235550150](https://github.com/openclaw/clawhub/actions/runs/30235550150), then hit the affected receiver in [run 30235555535](https://github.com/openclaw/clawsweeper/actions/runs/30235555535).

## Implementation

- Emit the three legacy intake values as NUL-delimited fields.
- Read them with Bash `mapfile`, which preserves the empty branch slot.
- Require exactly three parsed fields before continuing.
- Keep the existing empty-branch fallback to `gh api "repos/$target_repo" --jq .default_branch`.
- Execute the workflow's actual embedded Node serializer in regression tests for:
  - branchless issue-open;
  - the branchless ClawHub #3273 PR-open payload shape;
  - branchless edited-PR source authority;
  - explicit-`main` command re-review.

NUL is not legal in Git refs, so this avoids both whitespace collapsing and collisions with valid branch-name characters.

## After-fix runtime proof

On current head `9caa0704d744fdb94cc1ed3d625131cac3f40e4a`, Git Bash extracted and executed the workflow's embedded Node serializer, applied the NUL `mapfile` assignments, and ran the workflow's live public default-branch lookup with this redacted issue payload:

```json
{"item_kind":"issue","target_repo":"openclaw/openclaw","target_branch":"","source_event":"issues","source_action":"opened"}
```

Captured terminal output:

```text
proof=legacy-issue-intake-after-fix
head=9caa0704d744fdb94cc1ed3d625131cac3f40e4a
field_count=3
field[0].target_repo=openclaw/openclaw
field[1].target_branch_before_default=<empty>
field[2].use_source_authority=0
default_branch_api=main
fetch_branch=main
authority_used_as_fetch_branch=no
assertions=PASS
```

This demonstrates the required runtime behavior: exactly three fields survive; the target branch remains empty until GitHub resolves `main`; and `0` remains the authority field rather than becoming the fetch branch. No token, credential, or secret value is included.

## Validation

- `node --test --test-name-pattern "legacy event field serializer preserves branchless issue and PR intake|sweep issue and PR event reviews and target fanout avoid storm amplification" test/sweep-workflow.test.ts`
  - 2 passed, 0 failed.
  - The executable serializer cases produced:
    - issue-open: `["openclaw/openclaw", "", "0"]`
    - ClawHub PR-open: `["openclaw/clawhub", "", "0"]`
    - edited PR authority: `["openclaw/clawhub", "", "1"]`
    - explicit-branch re-review: `["openclaw/clawhub", "main", "0"]`
- `pnpm exec oxfmt --check .github/workflows/sweep.yml test/sweep-workflow.test.ts`
- `git diff --check`
- Parsed the workflow as YAML and passed the changed `run:` block through Git Bash `bash -n`.

`actionlint` is not installed on this host. The changed surface is an Ubuntu-hosted Bash step; the focused workflow tests and explicit Git Bash syntax/runtime proof passed. Known native-Windows aggregate failures invoke WSL's `docker-desktop` environment without `/bin/bash` and are outside this hosted workflow surface.

## Review proof

- Initial `codex review --uncommitted` found that a proposed `|` delimiter is legal in Git branch names. That finding was accepted; the parser was changed to NUL-delimited `mapfile`, and focused proof was rerun.
- After adding executable issue/PR regression coverage, `codex review --uncommitted` was clean: “The added regression coverage correctly executes the workflow serializer and verifies branchless issue and PR payload handling.”
- Final `codex review --base origin/main` on `9caa0704d744fdb94cc1ed3d625131cac3f40e4a` was clean: “The workflow now uses NUL-delimited fields, preserving an empty target branch before resolving the repository default branch. The added serializer coverage exercises branchless issue and PR payloads.”

## Risks / rollout

- This changes only shared legacy repository-dispatch field decoding. Queue, Worker, state, publication, and review logic are unchanged.
- The workflow-file change requires GitHub workflow write scope.
- ClawHub #3273's later maintainer re-review carried explicit `target_branch: main`, reached the durable control plane, and still did not publish before merge. That is not explained by this parser bug. It requires a separate trace of dispatch key `router-51dc3a77137b7009` through queue parking/retry and publication state; this PR does not claim to fix it.
- After merge, verify three independent fresh canaries: issue-open, PR-open, and maintainer `@clawsweeper re-review`.
- Existing missed, corrupted, or parked items need a separately authorized replay; this PR does not replay or mutate them.

## Links

- Regression source: #857
- Issue boundary: openclaw/openclaw#114128, openclaw/openclaw#114129
- Current issue reproduction: openclaw/openclaw#114402
- PR reproduction: [openclaw/clawhub#3273](https://github.com/openclaw/clawhub/pull/3273)
