### PR TITLE
fix: recover issue closes after GitHub state push failures

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -466,6 +466,20 @@ Use reason-specific anchors:
   release tag/version. If it is only on current `main`, say that and include the
   commit timestamp. If you cannot establish either the shipped release or the
   main-only timestamp with high confidence, keep the item open.
+- For `cannot_reproduce`, distinguish missing reporter evidence from a report
+  whose concrete mechanism is disproved. Search the complete current tree,
+  source history, renamed paths, and shipped version when identified; trace the
+  actual owner, callers, dependency contract, and relevant regression tests. If
+  the named implementation never existed or cannot perform the alleged
+  operation, and the real implementation or tests disprove the reported
+  failure, propose a high-confidence close with that source-backed evidence.
+  Do not keep a source-disproven issue open, ask for screenshots or logs, or
+  request maintainer follow-up merely because the reporter did not supply a
+  reproduction. Bulk filing is not itself a close reason, but repeated reports
+  about nonexistent files still close for `cannot_reproduce` when each claim is
+  independently disproved. Keep open when an affected shipped version, real
+  source path, observed user failure, or dependency behavior remains
+  unverified.
 - For `mostly_implemented_on_main`, use the same source/history/release
   provenance standard as `implemented_on_main`, but only for pull requests older
   than 60 days whose central useful change is already on current `main`.

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -2433,8 +2433,8 @@ function pushPublishedCommit(
       console.log(
         "State publish renewed its owner lease without the branch; recovering the lost state race",
       );
-      if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
-        return pushStateAndReceiptAfterCommitRefsFailure(
+      if (isCommitRefsTransactionFailure(pushed)) {
+        return recoverStatePublishAfterCommitRefsFailure(
           source,
           remote,
           branch,
@@ -2450,8 +2450,8 @@ function pushPublishedCommit(
         "State publish lease ownership changed before branch publication",
       );
     }
-    if (receiptRef && isCommitRefsTransactionFailure(pushed)) {
-      return pushStateAndReceiptAfterCommitRefsFailure(
+    if (isCommitRefsTransactionFailure(pushed)) {
+      return recoverStatePublishAfterCommitRefsFailure(
         source,
         remote,
         branch,
@@ -2480,11 +2480,11 @@ function commitRefsRetryDelayMs(attempt: number): number {
   );
 }
 
-function pushStateAndReceiptAfterCommitRefsFailure(
+function recoverStatePublishAfterCommitRefsFailure(
   source: string,
   remote: string,
   branch: string,
-  receiptRef: string,
+  receiptRef: string | undefined,
   expectedReceiptOid: string | null,
   lease: StatePublishLease,
 ): GitRunResult {
@@ -2493,13 +2493,13 @@ function pushStateAndReceiptAfterCommitRefsFailure(
   const sourceParent = runGit(["rev-parse", `${sourceCommit}^`], { quiet: true }).trim();
   const branchRef = `refs/heads/${branch}`;
   let remoteBranchOid = remoteRefOid(remote, branchRef);
-  let remoteReceiptOid = remoteRefOid(remote, receiptRef);
-  if (remoteReceiptOid !== expectedReceiptOid && remoteReceiptOid !== sourceCommit) {
+  let remoteReceiptOid = receiptRef ? remoteRefOid(remote, receiptRef) : null;
+  if (receiptRef && remoteReceiptOid !== expectedReceiptOid && remoteReceiptOid !== sourceCommit) {
     throw new StatePublishContentionError(
       `State batch receipt ${receiptRef} changed before commit_refs recovery`,
     );
   }
-  if (remoteBranchOid === sourceCommit && remoteReceiptOid === sourceCommit) {
+  if (remoteBranchOid === sourceCommit && (!receiptRef || remoteReceiptOid === sourceCommit)) {
     return { status: 0, stdout: "", stderr: "", timedOut: false };
   }
   if (remoteBranchOid !== sourceCommit && remoteBranchOid !== sourceParent) {
@@ -2510,9 +2510,11 @@ function pushStateAndReceiptAfterCommitRefsFailure(
   lease.coordinator?.assertActive();
 
   console.log(
-    "State publish retrying GitHub commit_refs failure with fenced single-ref receipt and state updates",
+    receiptRef
+      ? "State publish retrying GitHub commit_refs failure with fenced single-ref receipt and state updates"
+      : "State publish retrying GitHub commit_refs failure with fenced single-ref state updates",
   );
-  if (remoteReceiptOid !== sourceCommit) {
+  if (receiptRef && remoteReceiptOid !== sourceCommit) {
     // A batch-specific receipt may safely outlive this lease. A later retry
     // resumes only while state still equals sourceParent and otherwise fails
     // closed, so persist that progress before renewing the shared-state fence.

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -2770,6 +2770,103 @@ test("state publish lease renews and fences a push after the original TTL", () =
   );
 });
 
+test("receipt-less state publication recovers GitHub commit_refs rejections", () => {
+  const { origin, root, work } = createStateLeaseTestRepo(
+    "clawsweeper-state-materializer-commit-refs-",
+  );
+  const candidate = path.join(root, "candidate");
+  const number = 10_103;
+  const recordRoot = "records/openclaw-openclaw";
+  const tuple = writeRecordTuple(candidate, {
+    number,
+    marker: "materialized close proposal",
+    reviewedAt: "2026-07-27T10:00:00.000Z",
+    itemUpdatedAt: "2026-07-27T09:59:00Z",
+  });
+  const paths = [
+    `${recordRoot}/items/${number}.md`,
+    `${recordRoot}/closed/${number}.md`,
+    `${recordRoot}/plans/${number}.md`,
+    `${recordRoot}/decision-packets/${number}.json`,
+  ];
+  const rejectedStateMarker = path.join(origin, "hooks", "rejected-materializer-state-once");
+  const hook = path.join(origin, "hooks", "pre-receive");
+  fs.writeFileSync(
+    hook,
+    [
+      "#!/bin/sh",
+      "count=0",
+      'only_ref=""',
+      "while read -r old_oid new_oid ref_name; do",
+      "  count=$((count + 1))",
+      '  only_ref="$ref_name"',
+      "done",
+      'if [ "$count" -ge 2 ]; then',
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      `if [ "$only_ref" = "refs/heads/state" ] && [ ! -f '${rejectedStateMarker}' ]; then`,
+      `  touch '${rejectedStateMarker}'`,
+      '  echo "fatal error in commit_refs" >&2',
+      "  exit 1",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(hook, 0o755);
+
+  let result;
+  const lines = captureConsoleLog(() => {
+    result = withEnv(
+      {
+        CLAWSWEEPER_PUBLISH_ROOT: work,
+        CLAWSWEEPER_PUBLISH_BRANCH: "state",
+      },
+      () =>
+        withCwd(candidate, () =>
+          withStatePublishLease(
+            () =>
+              publishMainCommit({
+                message: "chore: materialize source-disproven close proposal",
+                paths,
+                branch: "state",
+                maxAttempts: 1,
+                pushAttempts: 1,
+                rebaseStrategy: "reconcile-records",
+              }),
+            { branch: "state", acquireTimeoutMs: 5_000, waitMs: 10 },
+          ),
+        ),
+    );
+  });
+
+  assert.equal(result, "committed");
+  assert.equal(fs.existsSync(rejectedStateMarker), true);
+  assert.equal(
+    lines.some((line) => line.includes("commit_refs failure with fenced single-ref state updates")),
+    true,
+  );
+  assert.equal(
+    run("git", ["--git-dir", origin, "show", `state:${recordRoot}/items/${number}.md`], root),
+    tuple.primary,
+  );
+  assert.equal(
+    run(
+      "git",
+      [
+        "--git-dir",
+        origin,
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads/clawsweeper-state-batches",
+      ],
+      root,
+    ),
+    "",
+  );
+});
+
 test("state publish lease survives a lost race without resetting the state worktree", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-lease-rebuild-"));
   const origin = path.join(root, "origin.git");
@@ -5333,6 +5430,19 @@ function installCheckoutHeader(work) {
     ["config", "--local", `includeIf.gitdir:${path.join(work, ".git")}.path`, credentialsConfig],
     work,
   );
+  // macOS resolves temporary `/var` repositories through `/private/var`.
+  // Probe first so matching gitdir includes never load the same header twice.
+  const checkoutHeaders = spawnSync(
+    "git",
+    ["config", "--includes", "--local", "--name-only", "--get-regexp", "^http\\..*\\.extraheader$"],
+    { cwd: work, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (checkoutHeaders.error) throw checkoutHeaders.error;
+  if (checkoutHeaders.status === 1) {
+    run("git", ["config", "--local", "include.path", credentialsConfig], work);
+  } else if (checkoutHeaders.status !== 0) {
+    throw new Error(`Failed to inspect fixture checkout headers: ${checkoutHeaders.stderr.trim()}`);
+  }
 }
 
 function installCheckpointFailureHook(work, other, branch) {

--- a/test/review-close-policy.test.ts
+++ b/test/review-close-policy.test.ts
@@ -56,6 +56,20 @@ test("review prompt documents gated backlog close policies", () => {
   );
 });
 
+test("review prompt closes independently disproven nonexistent-source bug reports", () => {
+  const prompt = readFileSync(new URL("../prompts/review-item.md", import.meta.url), "utf8");
+
+  assert.match(prompt, /For `cannot_reproduce`, distinguish missing reporter evidence/);
+  assert.match(prompt, /Search the complete current tree,\s+source history, renamed paths/);
+  assert.match(prompt, /actual owner, callers, dependency contract, and relevant regression tests/);
+  assert.match(prompt, /named implementation never existed or cannot perform the alleged/);
+  assert.match(prompt, /propose a high-confidence close with that source-backed evidence/);
+  assert.match(prompt, /Do not keep a source-disproven issue open/);
+  assert.match(prompt, /Bulk filing is not itself a close reason/);
+  assert.match(prompt, /each claim is\s+independently disproved/);
+  assert.match(prompt, /Keep open when an affected shipped version/);
+});
+
 test("unsponsored feature issue proposals emit source-bound trusted close markers", () => {
   const markers = reviewAutomationMarkersFromReport(
     reportFrontMatter({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers had to close independently disproven OpenClaw bug reports by hand because ClawSweeper either kept source-disproven reports open or failed to publish their close proposals after GitHub rejected an atomic state update.

The production materializer failed with `fatal error in commit_refs` and incorrectly fell into shallow-history recovery because its state-and-lease publish has no batch receipt: https://github.com/openclaw/clawsweeper/actions/runs/30251371305.

## Why This Change Was Made

Reuse the existing fenced, bounded `commit_refs` recovery for both receipt-based review batches and receipt-less materializer publications. Preserve authoritative branch checks, lease ownership, compare-and-swap writes, concurrent-writer protections, and safe failures.

Make the review prompt distinguish missing reporter evidence from a mechanism independently disproven by current source, full history, actual owner and callers, dependency contracts, and regressions. Bulk filing alone remains insufficient to close an issue.

## User Impact

Source-disproven reports can become high-confidence `cannot_reproduce` proposals, and GitHub state publication failures no longer strand those proposals before the normal guarded apply lane.

Protected issues, genuine unverified reports, batch receipts, and existing close safeguards remain unchanged.

## Evidence

- Fresh structured Codex autoreview: clean; TruffleHog: clean.
- Real bare-Git regression rejects the atomic state-plus-lease push and the first individual state push, then verifies successful fenced recovery without creating a batch receipt.
- Existing receipt publication, transient receipt failure, transient lease-renewal failure, and transient state-branch failure regressions pass.
- Immutable ledger server-merge regression passes on canonical and macOS temporary paths without loading checkout credentials twice.
- 90 close-policy, close-reason, and materializer regression tests passed.
- `pnpm run build:all`.
- `pnpm run check:static`.
- `pnpm run lint`.
- `git diff --check`.
