### PR TITLE
fix(review): reconcile terminal legacy publications

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2870,7 +2870,7 @@ export class ExactReviewQueue {
           decision: item.decision,
         })),
       );
-      if (terminalized) {
+      if (terminalized.length) {
         await this.scheduleNext(this.readStateSync(), Date.now());
         return;
       }
@@ -3492,11 +3492,12 @@ export class ExactReviewQueue {
 
   private async terminalizePublicationCandidates(
     candidates: Array<Pick<ExactReviewQueueItem, "key" | "revision" | "decision">>,
+    options: { apply?: boolean; legacyReconciliation?: boolean } = {},
   ) {
     const ordinaryCandidates = candidates.filter(
       (item) => !exactReviewQueueHasCommandContext(item),
     );
-    if (!ordinaryCandidates.length) return 0;
+    if (!ordinaryCandidates.length) return [];
 
     const targetTokens = new Map<string, Promise<string>>();
     const targetTokenFor = (targetRepo: string) => {
@@ -3533,30 +3534,51 @@ export class ExactReviewQueue {
     const checkedAt = Date.now();
     const checkedState = this.readStateSync();
     const batchOwnership = this.batchStore.activeLeaseSnapshot(checkedAt);
-    let completed = 0;
+    const checkedBatchItemKeys = new Set<string>(batchOwnership.itemKeys);
+    if (options.legacyReconciliation) {
+      for (const candidate of liveStates) {
+        if (candidate.state.state !== "terminal") continue;
+        const item = checkedState.items[candidate.key];
+        if (!item) continue;
+        reclaimExpiredExactReviewLease(
+          checkedState,
+          item.key,
+          item,
+          checkedAt,
+          exactReviewPublicationDispatchLeaseMs(this.env),
+          exactReviewHeartbeatGraceMs(this.env),
+        );
+      }
+    }
+    const legacyAuthorityByTarget = options.legacyReconciliation
+      ? exactReviewLegacyPublicationAuthorityIndex(checkedState, checkedBatchItemKeys)
+      : null;
+    const completedKeys: string[] = [];
     for (const candidate of liveStates) {
       const item = checkedState.items[candidate.key];
       if (
         !item ||
         item.revision !== candidate.revision ||
-        item.state !== "pending" ||
+        (item.state !== "pending" && (!options.legacyReconciliation || item.state !== "parked")) ||
         !exactReviewQueueIsPublication(item) ||
         exactReviewQueueHasCommandContext(item) ||
         batchOwnership.itemKeys.includes(item.key) ||
+        (options.legacyReconciliation &&
+          !exactReviewLegacyTerminalPublicationCandidate(item, legacyAuthorityByTarget!)) ||
         candidate.state.state !== "terminal"
       ) {
         continue;
       }
       delete checkedState.items[item.key];
-      completed += 1;
+      completedKeys.push(item.key);
     }
-    if (completed) {
+    if (options.apply !== false && completedKeys.length) {
       await this.writeState(checkedState, {
-        publicationCompleted: completed,
-        publicationSuperseded: completed,
+        publicationCompleted: completedKeys.length,
+        publicationSuperseded: completedKeys.length,
       });
     }
-    return completed;
+    return completedKeys;
   }
 
   private listDeadLetters(value: unknown) {
@@ -4361,14 +4383,33 @@ export class ExactReviewQueue {
     }
 
     const now = Date.now();
-    const activeBatchItemKeys = new Set(this.batchStore.activeLeaseSnapshot(now).itemKeys);
-    const state = this.readStateSync();
-    reclaimExpiredExactReviewLeases(
+    let activeBatchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(now).itemKeys);
+    let state = this.readStateSync();
+    const reclaimed = reclaimExpiredExactReviewLeases(
       state,
       now,
       exactReviewPublicationDispatchLeaseMs(this.env),
       exactReviewHeartbeatGraceMs(this.env),
     );
+    if (apply && reclaimed) {
+      // Persist expiry recovery before the bounded target reads release the
+      // Durable Object input gate, so a later alarm cannot revive this stale
+      // owner while reconciliation is validating it.
+      await this.writeState(state);
+      await this.scheduleNext(state, now);
+      state = this.readStateSync();
+      activeBatchItemKeys = new Set<string>(this.batchStore.activeLeaseSnapshot(now).itemKeys);
+    }
+    const legacyTerminalScanned = Object.values(state.items).length;
+    const legacyAuthorityByTarget = exactReviewLegacyPublicationAuthorityIndex(
+      state,
+      activeBatchItemKeys,
+    );
+    const legacyTerminalCandidates = Object.values(state.items)
+      .filter((item) =>
+        exactReviewLegacyTerminalPublicationCandidate(item, legacyAuthorityByTarget),
+      )
+      .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
     const newestByTarget = new Map<string, number>();
     const versioned = Object.values(state.items).flatMap((item) => {
       const revision = exactReviewPublicationRevision(item.decision);
@@ -4489,6 +4530,10 @@ export class ExactReviewQueue {
         left.item.createdAt - right.item.createdAt || left.item.key.localeCompare(right.item.key),
     );
     const selected = candidates.slice(0, limit);
+    const selectedLegacyTerminal = legacyTerminalCandidates.slice(
+      0,
+      Math.max(0, limit - selected.length),
+    );
     const changedKeys = new Set<string>();
     const changedLineages = new Set<string>();
     let staleRevisionChanged = 0;
@@ -4580,10 +4625,27 @@ export class ExactReviewQueue {
       if (changedKeys.size) await this.scheduleNext(state, now);
     }
 
+    const legacyTerminalEligibleKeys = await this.terminalizePublicationCandidates(
+      selectedLegacyTerminal,
+      {
+        apply,
+        legacyReconciliation: true,
+      },
+    );
+    const legacyTerminalEligibleKeySet = new Set(legacyTerminalEligibleKeys);
+    const legacyTerminalEligible = selectedLegacyTerminal.filter((item) =>
+      legacyTerminalEligibleKeySet.has(item.key),
+    );
+    const legacyTerminalChanged = apply ? legacyTerminalEligibleKeys : [];
+    if (legacyTerminalChanged.length) {
+      await this.scheduleNext(this.readStateSync(), Date.now());
+    }
+
     const remaining = apply
       ? candidates.filter(({ item }) => !changedKeys.has(item.key))
       : candidates;
-    const oldestAgeSeconds = (entries: ReconcileCandidate[]) =>
+    const remainingLegacyTerminal = apply ? [] : legacyTerminalEligible;
+    const oldestAgeSeconds = (entries: Array<{ item: ExactReviewQueueItem }>) =>
       entries.length
         ? Math.floor(
             Math.max(0, now - Math.min(...entries.map(({ item }) => item.createdAt))) / 1000,
@@ -4597,28 +4659,51 @@ export class ExactReviewQueue {
       ok: true,
       apply,
       scanned: versioned.length,
-      eligible: candidates.length,
-      changed: changedKeys.size,
-      eligible_remaining: remaining.length,
+      legacy_terminal_scanned: legacyTerminalScanned,
+      eligible: candidates.length + legacyTerminalEligible.length,
+      changed: changedKeys.size + legacyTerminalChanged.length,
+      eligible_remaining: remaining.length + remainingLegacyTerminal.length,
       stale_revision_eligible: staleRevisionEligible,
       stale_revision_changed: staleRevisionChanged,
       lineage_duplicate_eligible: lineageDuplicateEligible,
       lineage_duplicate_changed: lineageDuplicateChanged,
       lineage_refreshed: lineageRefreshed,
+      legacy_terminal_candidates: legacyTerminalCandidates.length,
+      legacy_terminal_selected: selectedLegacyTerminal.length,
+      legacy_terminal_eligible: legacyTerminalEligible.length,
+      legacy_terminal_changed: legacyTerminalChanged.length,
       protected_batch_items: activeBatchItemKeys.size,
       protected_lineage_items: protectedLineageItems,
-      oldest_eligible_age_seconds: oldestAgeSeconds(candidates),
-      oldest_remaining_age_seconds: oldestAgeSeconds(remaining),
-      sample: selected.slice(0, 20).map(({ item, revision, reason, lineage, retainedKey }) => ({
-        item_key: item.key,
-        queue_revision: item.revision,
-        reason,
-        target_key: revision.targetKey,
-        publication_revision: revision.sourceRevision,
-        superseded_by_revision: newestByTarget.get(revision.targetKey),
-        lineage_claim_generation: lineage?.claimGeneration ?? null,
-        retained_item_key: retainedKey ?? null,
-      })),
+      oldest_eligible_age_seconds: oldestAgeSeconds([
+        ...candidates,
+        ...legacyTerminalEligible.map((item) => ({ item })),
+      ]),
+      oldest_remaining_age_seconds: oldestAgeSeconds([
+        ...remaining,
+        ...remainingLegacyTerminal.map((item) => ({ item })),
+      ]),
+      sample: [
+        ...selected.map(({ item, revision, reason, lineage, retainedKey }) => ({
+          item_key: item.key,
+          queue_revision: item.revision,
+          reason,
+          target_key: revision.targetKey,
+          publication_revision: revision.sourceRevision,
+          superseded_by_revision: newestByTarget.get(revision.targetKey),
+          lineage_claim_generation: lineage?.claimGeneration ?? null,
+          retained_item_key: retainedKey ?? null,
+        })),
+        ...legacyTerminalEligible.map((item) => ({
+          item_key: item.key,
+          queue_revision: item.revision,
+          reason: "legacy_terminal" as const,
+          target_key: item.decision.publication!.itemKey.toLowerCase(),
+          publication_revision: null,
+          superseded_by_revision: null,
+          lineage_claim_generation: null,
+          retained_item_key: null,
+        })),
+      ].slice(0, 20),
     });
   }
 
@@ -8902,6 +8987,92 @@ function exactReviewQueueIsPublication(item: Pick<ExactReviewQueueItem, "decisio
 
 function exactReviewQueueHasCommandContext(item: Pick<ExactReviewQueueItem, "decision">) {
   return Boolean(item.decision.commandStatusMarker || item.decision.statusCommentId);
+}
+
+type ExactReviewLegacyPublicationAuthority = {
+  hasBaseAuthority: boolean;
+  hasActiveOwner: boolean;
+  hasVersionedPublication: boolean;
+  newestLegacyPublication: ExactReviewPublication | null;
+};
+
+function exactReviewLegacyPublicationAuthorityIndex(
+  state: ExactReviewQueueState,
+  activeBatchItemKeys: Set<string>,
+) {
+  const byTarget = new Map<string, ExactReviewLegacyPublicationAuthority>();
+  const authorityFor = (targetKey: string) => {
+    const existing = byTarget.get(targetKey);
+    if (existing) return existing;
+    const authority: ExactReviewLegacyPublicationAuthority = {
+      hasBaseAuthority: false,
+      hasActiveOwner: false,
+      hasVersionedPublication: false,
+      newestLegacyPublication: null,
+    };
+    byTarget.set(targetKey, authority);
+    return authority;
+  };
+
+  for (const item of Object.values(state.items)) {
+    const publication = item.decision.publication;
+    const targetKey = (publication?.itemKey || item.key).toLowerCase();
+    const authority = authorityFor(targetKey);
+    if (!publication) {
+      authority.hasBaseAuthority = true;
+      continue;
+    }
+    if (
+      activeBatchItemKeys.has(item.key) ||
+      item.state === "dispatching" ||
+      item.state === "leased"
+    ) {
+      authority.hasActiveOwner = true;
+    }
+    if (publication.protocolVersion === 2) {
+      authority.hasVersionedPublication = true;
+      continue;
+    }
+    if (
+      !authority.newestLegacyPublication ||
+      exactReviewPublicationProducerIsNewer(publication, authority.newestLegacyPublication)
+    ) {
+      authority.newestLegacyPublication = publication;
+    }
+  }
+  return byTarget;
+}
+
+function exactReviewLegacyTerminalPublicationCandidate(
+  item: ExactReviewQueueItem,
+  authorityByTarget: Map<string, ExactReviewLegacyPublicationAuthority>,
+) {
+  // Protocol-v1 rows have no durable terminal receipt. Reconcile only the
+  // ordinary delivery path after an explicit target-terminal read; command
+  // status rows keep their acknowledgement/completion workflow intact.
+  const publication = item.decision.publication;
+  if (
+    !publication ||
+    publication.protocolVersion !== 1 ||
+    !publication.liveProceeded ||
+    !exactReviewQueueIsPublication(item) ||
+    exactReviewQueueHasCommandContext(item) ||
+    (item.state !== "pending" && item.state !== "parked")
+  ) {
+    return false;
+  }
+
+  const authority = authorityByTarget.get(publication.itemKey.toLowerCase());
+  const newerLegacyPublication =
+    authority?.newestLegacyPublication &&
+    exactReviewPublicationProducerIsNewer(authority.newestLegacyPublication, publication);
+  return Boolean(
+    authority &&
+    !authority.hasBaseAuthority &&
+    !authority.hasActiveOwner &&
+    !authority.hasVersionedPublication &&
+    !newerLegacyPublication,
+  );
 }
 
 function exactReviewQueueLane(item: ExactReviewQueueItem) {

--- a/docs/state-publication-batching-plan.md
+++ b/docs/state-publication-batching-plan.md
@@ -212,11 +212,19 @@ the existing supersession behavior.
 Each dry-run or apply result records the total scanned and eligible rows, rows
 changed and remaining, stale-revision versus duplicate-lineage counts, refreshed
 retained lineages, protected ownership, and the oldest eligible and remaining
-ages. Operators should inspect a dry-run first, apply one bounded pass, then
-observe the public 15-minute and 60-minute publication flow. Another pass should
-wait for stable positive net drain and unchanged contention/dead-letter safety;
-historical cleanup is not a reason to raise publication concurrency or bypass
-the state-writer rollout gates.
+ages. A pass may also reconcile a protocol-v1 ordinary publication only when its
+producer recorded `live_proceeded`, the row is pending or parked without an
+active batch or lease, no newer target authority remains, and one bounded target
+read confirms the item is terminal. Protocol-v1 command/status rows are never
+reclaimed by this path because their acknowledgement completion has no equivalent
+durable receipt. Each pass reports protocol-v1 candidates separately from the
+bounded subset selected for a target read and the subset confirmed terminal; a
+dry run performs that same read without deleting a row. Operators should inspect
+a dry-run first, apply one bounded pass, then observe the public 15-minute and
+60-minute publication flow. Another pass should wait for stable positive net
+drain and unchanged contention/dead-letter safety; historical cleanup is not a
+reason to raise publication concurrency or bypass the state-writer rollout
+gates.
 
 ### Bounded fresh-authority admission
 

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -35,6 +35,7 @@ export type ExactReviewBatchFetch = {
 export type ExactReviewPublicationReconcileResult = {
   apply: boolean;
   scanned: number;
+  legacyTerminalScanned: number;
   eligible: number;
   changed: number;
   eligibleRemaining: number;
@@ -43,6 +44,10 @@ export type ExactReviewPublicationReconcileResult = {
   lineageDuplicateEligible: number;
   lineageDuplicateChanged: number;
   lineageRefreshed: number;
+  legacyTerminalCandidates: number;
+  legacyTerminalSelected: number;
+  legacyTerminalEligible: number;
+  legacyTerminalChanged: number;
   protectedBatchItems: number;
   protectedLineageItems: number;
   oldestEligibleAgeSeconds: number | null;
@@ -182,6 +187,10 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     return {
       apply: response.apply === true,
       scanned: nonNegativeInteger(response.scanned, "scanned"),
+      legacyTerminalScanned: nonNegativeInteger(
+        response.legacy_terminal_scanned ?? 0,
+        "legacy_terminal_scanned",
+      ),
       eligible: nonNegativeInteger(response.eligible, "eligible"),
       changed: nonNegativeInteger(response.changed, "changed"),
       eligibleRemaining: nonNegativeInteger(response.eligible_remaining, "eligible_remaining"),
@@ -202,6 +211,22 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
         "lineage_duplicate_changed",
       ),
       lineageRefreshed: nonNegativeInteger(response.lineage_refreshed ?? 0, "lineage_refreshed"),
+      legacyTerminalCandidates: nonNegativeInteger(
+        response.legacy_terminal_candidates ?? 0,
+        "legacy_terminal_candidates",
+      ),
+      legacyTerminalSelected: nonNegativeInteger(
+        response.legacy_terminal_selected ?? 0,
+        "legacy_terminal_selected",
+      ),
+      legacyTerminalEligible: nonNegativeInteger(
+        response.legacy_terminal_eligible ?? 0,
+        "legacy_terminal_eligible",
+      ),
+      legacyTerminalChanged: nonNegativeInteger(
+        response.legacy_terminal_changed ?? 0,
+        "legacy_terminal_changed",
+      ),
       protectedBatchItems: nonNegativeInteger(
         response.protected_batch_items,
         "protected_batch_items",

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5543,6 +5543,386 @@ test("exact-review queue terminalizes every admitted ordinary publication before
   }
 });
 
+test("publication reconcile terminalizes a completed protocol-v1 publication after its target closes", async () => {
+  let liveChecks = 0;
+  const harness = createExactReviewAdmissionHarness(() => {
+    liveChecks += 1;
+    return jsonResponse({ state: "closed" });
+  });
+  const itemNumber = 9301;
+  const itemKey = `openclaw/gogcli#${itemNumber}@publish:30091560737:1`;
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-terminal",
+            itemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            legacyExactReviewPublicationOverrides(itemNumber, "30091560737"),
+          ),
+        )
+      ).status,
+      202,
+    );
+
+    const reconciled = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: true, max_items: 100 }),
+        }),
+      )
+    ).json();
+
+    assert.equal(liveChecks, 1);
+    assert.equal(reconciled.changed, 1);
+    assert.equal(reconciled.legacy_terminal_eligible, 1);
+    assert.equal(reconciled.legacy_terminal_changed, 1);
+    assert.equal(reconciled.eligible_remaining, 0);
+    const state = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, unknown>;
+    };
+    assert.equal(state.items[itemKey], undefined);
+  } finally {
+    harness.restore();
+  }
+});
+
+test("publication reconcile dry runs verify terminal legacy rows without deleting them", async () => {
+  let terminal = false;
+  let liveChecks = 0;
+  const harness = createExactReviewAdmissionHarness(() => {
+    liveChecks += 1;
+    return jsonResponse({ state: terminal ? "closed" : "open" });
+  });
+  const itemNumber = 9307;
+  const itemKey = `openclaw/gogcli#${itemNumber}@publish:30091560744:1`;
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-dry-run",
+            itemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            legacyExactReviewPublicationOverrides(itemNumber, "30091560744"),
+          ),
+        )
+      ).status,
+      202,
+    );
+
+    const reconcile = () =>
+      harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: false, max_items: 100 }),
+        }),
+      );
+    const openResult = await (await reconcile()).json();
+    assert.equal(liveChecks, 1);
+    assert.equal(openResult.legacy_terminal_candidates, 1);
+    assert.equal(openResult.legacy_terminal_selected, 1);
+    assert.equal(openResult.legacy_terminal_eligible, 0);
+    assert.equal(openResult.changed, 0);
+
+    terminal = true;
+    const terminalResult = await (await reconcile()).json();
+    assert.equal(liveChecks, 2);
+    assert.equal(terminalResult.legacy_terminal_eligible, 1);
+    assert.equal(terminalResult.changed, 0);
+    const state = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, unknown>;
+    };
+    assert.ok(state.items[itemKey]);
+  } finally {
+    harness.restore();
+  }
+});
+
+test("publication reconcile terminalizes a closed legacy publication after its lease expires", async () => {
+  let liveChecks = 0;
+  let probeState: string | undefined;
+  const harness = createExactReviewAdmissionHarness(async () => {
+    liveChecks += 1;
+    const state = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, { state: string }>;
+    };
+    probeState = state.items[itemKey]?.state;
+    return jsonResponse({ state: "closed" });
+  });
+  const itemNumber = 9306;
+  const itemKey = `openclaw/gogcli#${itemNumber}@publish:30091560743:1`;
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-expired-lease",
+            itemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            legacyExactReviewPublicationOverrides(itemNumber, "30091560743"),
+          ),
+        )
+      ).status,
+      202,
+    );
+    const stored = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, Record<string, unknown>>;
+    };
+    const item = stored.items[itemKey]!;
+    Object.assign(item, {
+      state: "leased",
+      leaseId: "expired-legacy-lease",
+      leaseRevision: 1,
+      leaseExpiresAt: Date.now() - 1,
+      claimedRunId: "9306",
+      claimedAt: Date.now() - 60_000,
+      leaseDecision: item.decision,
+    });
+    await harness.storage.put("exact-review-queue", stored);
+
+    const reconciled = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: true, max_items: 100 }),
+        }),
+      )
+    ).json();
+
+    assert.equal(liveChecks, 1);
+    assert.equal(probeState, "pending");
+    assert.equal(reconciled.changed, 1);
+    const after = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, unknown>;
+    };
+    assert.equal(after.items[itemKey], undefined);
+  } finally {
+    harness.restore();
+  }
+});
+
+test("publication reconcile retains a legacy command publication awaiting acknowledgement", async () => {
+  let liveChecks = 0;
+  const harness = createExactReviewAdmissionHarness(() => {
+    liveChecks += 1;
+    return jsonResponse({ state: "closed" });
+  });
+  const itemNumber = 9302;
+  const itemKey = `openclaw/gogcli#${itemNumber}@publish:30091560738:1`;
+  const commandStatusMarker =
+    "<!-- clawsweeper-command-status:9302:re_review:0123456789abcdef0123456789abcdef01234567 -->";
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-command-awaiting-ack",
+            itemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            {
+              ...legacyExactReviewPublicationOverrides(itemNumber, "30091560738"),
+              commandStatusMarker,
+            },
+          ),
+        )
+      ).status,
+      202,
+    );
+
+    const reconciled = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: true, max_items: 100 }),
+        }),
+      )
+    ).json();
+
+    assert.equal(liveChecks, 0);
+    assert.equal(reconciled.changed, 0);
+    assert.equal(reconciled.legacy_terminal_eligible, 0);
+    const state = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, { decision: { commandStatusMarker?: string } }>;
+    };
+    assert.equal(state.items[itemKey]?.decision.commandStatusMarker, commandStatusMarker);
+  } finally {
+    harness.restore();
+  }
+});
+
+test("publication reconcile preserves a legacy publication owned by an active batch", async () => {
+  let liveChecks = 0;
+  const harness = createExactReviewAdmissionHarness(
+    () => {
+      liveChecks += 1;
+      return jsonResponse({ state: "closed" });
+    },
+    { publicationBatching: true },
+  );
+  const itemNumber = 9303;
+  const itemKey = `openclaw/gogcli#${itemNumber}@publish:30091560739:1`;
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-active-batch",
+            itemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            legacyExactReviewPublicationOverrides(itemNumber, "30091560739"),
+          ),
+        )
+      ).status,
+      202,
+    );
+    const claim = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
+          method: "POST",
+          body: JSON.stringify({
+            claim_id: "legacy-v1-active-batch",
+            lease_owner: "legacy-v1-owner",
+            max_items: 1,
+          }),
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true);
+
+    const reconciled = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: true, max_items: 100 }),
+        }),
+      )
+    ).json();
+
+    assert.equal(liveChecks, 0);
+    assert.equal(reconciled.changed, 0);
+    assert.equal(reconciled.legacy_terminal_eligible, 0);
+    const state = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, unknown>;
+    };
+    assert.ok(state.items[itemKey]);
+  } finally {
+    harness.restore();
+  }
+});
+
+test("publication reconcile preserves active legacy leases and newer publication authority", async () => {
+  let terminal = false;
+  let liveChecks = 0;
+  const harness = createExactReviewAdmissionHarness(() => {
+    liveChecks += 1;
+    return jsonResponse({ state: terminal ? "closed" : "open" });
+  });
+  const leasedItemNumber = 9304;
+  const leasedItemKey = `openclaw/gogcli#${leasedItemNumber}@publish:30091560740:1`;
+  const supersededItemNumber = 9305;
+  const supersededItemKey = `openclaw/gogcli#${supersededItemNumber}@publish:30091560741:1`;
+  try {
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-active-lease",
+            leasedItemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            legacyExactReviewPublicationOverrides(leasedItemNumber, "30091560740"),
+          ),
+        )
+      ).status,
+      202,
+    );
+    await harness.queue.alarm();
+    const dispatched = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, { leaseId?: string }>;
+    };
+    const leaseId = dispatched.items[leasedItemKey]?.leaseId;
+    assert.ok(leaseId);
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          new Request("https://clawsweeper-exact-review-queue/claim", {
+            method: "POST",
+            body: JSON.stringify({ lease_id: leaseId, run_id: "9304" }),
+          }),
+        )
+      ).status,
+      200,
+    );
+
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "legacy-v1-newer-authority",
+            supersededItemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            legacyExactReviewPublicationOverrides(supersededItemNumber, "30091560741"),
+          ),
+        )
+      ).status,
+      202,
+    );
+    assert.equal(
+      (
+        await harness.queue.fetch(
+          buildExactReviewQueueRequest(
+            "v2-newer-authority",
+            supersededItemNumber,
+            "exact_review_artifact_publish",
+            "issue",
+            "openclaw/gogcli",
+            exactReviewPublicationOverrides(supersededItemNumber, "30091560742", "opened", 2),
+          ),
+        )
+      ).status,
+      202,
+    );
+
+    terminal = true;
+    const checksBeforeReconcile = liveChecks;
+    const reconciled = await (
+      await harness.queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/publications/reconcile", {
+          method: "POST",
+          body: JSON.stringify({ apply: true, max_items: 100 }),
+        }),
+      )
+    ).json();
+
+    assert.equal(liveChecks, checksBeforeReconcile);
+    assert.equal(reconciled.changed, 0);
+    assert.equal(reconciled.legacy_terminal_eligible, 0);
+    const state = (await harness.storage.get("exact-review-queue")) as {
+      items: Record<string, { state: string }>;
+    };
+    assert.equal(state.items[leasedItemKey]?.state, "leased");
+    assert.ok(state.items[supersededItemKey]);
+  } finally {
+    harness.restore();
+  }
+});
+
 test("exact-review batch preflight follows the publisher owner selection", async () => {
   const checked: Array<[string, number]> = [];
   const harness = createExactReviewAdmissionHarness(
@@ -18025,6 +18405,29 @@ function exactReviewPublicationOverrides(
       liveTerminalMissing: false,
       liveGuardedOpen: false,
       producerDecision,
+    },
+  };
+}
+
+function legacyExactReviewPublicationOverrides(
+  itemNumber: number,
+  producerRunId: string,
+  producerSourceAction = "opened",
+  targetRepo = "openclaw/gogcli",
+) {
+  const publication = exactReviewPublicationOverrides(
+    itemNumber,
+    producerRunId,
+    producerSourceAction,
+    1,
+    targetRepo,
+  ).publication;
+  return {
+    publication: {
+      ...publication,
+      protocolVersion: 1,
+      leaseRevision: null,
+      claimGeneration: null,
     },
   };
 }

--- a/test/repair/exact-review-batch-coordinator.test.ts
+++ b/test/repair/exact-review-batch-coordinator.test.ts
@@ -211,6 +211,60 @@ test("queue client signs protocol calls and rejects malformed responses", async 
   });
 });
 
+test("queue client reports legacy terminal reconciliation counters", async () => {
+  const client = new ExactReviewBatchQueueClient({
+    baseUrl: "https://queue.example",
+    webhookSecret: "secret",
+    fetch: async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          apply: true,
+          scanned: 0,
+          legacy_terminal_scanned: 1,
+          eligible: 1,
+          changed: 1,
+          eligible_remaining: 0,
+          stale_revision_eligible: 0,
+          stale_revision_changed: 0,
+          lineage_duplicate_eligible: 0,
+          lineage_duplicate_changed: 0,
+          lineage_refreshed: 0,
+          legacy_terminal_candidates: 1,
+          legacy_terminal_selected: 1,
+          legacy_terminal_eligible: 1,
+          legacy_terminal_changed: 1,
+          protected_batch_items: 0,
+          protected_lineage_items: 0,
+          oldest_eligible_age_seconds: 60,
+          oldest_remaining_age_seconds: null,
+        }),
+      ),
+  });
+
+  assert.deepEqual(await client.reconcilePublications({ apply: true, maxItems: 100 }), {
+    apply: true,
+    scanned: 0,
+    legacyTerminalScanned: 1,
+    eligible: 1,
+    changed: 1,
+    eligibleRemaining: 0,
+    staleRevisionEligible: 0,
+    staleRevisionChanged: 0,
+    lineageDuplicateEligible: 0,
+    lineageDuplicateChanged: 0,
+    lineageRefreshed: 0,
+    legacyTerminalCandidates: 1,
+    legacyTerminalSelected: 1,
+    legacyTerminalEligible: 1,
+    legacyTerminalChanged: 1,
+    protectedBatchItems: 0,
+    protectedLineageItems: 0,
+    oldestEligibleAgeSeconds: 60,
+    oldestRemainingAgeSeconds: null,
+  });
+});
+
 test("queue client uses the current-main effective cap during a rolling deploy", async () => {
   const client = new ExactReviewBatchQueueClient({
     baseUrl: "https://queue.example",


### PR DESCRIPTION
## Summary

Reconcile stranded protocol-v1 exact-review publication rows when their target is terminal, without changing the direct-publication path, dashboard projection, publisher workflow, or state-writer behavior.

## Problem

`openclaw/openclaw#113313` was merged while its legacy row `openclaw/openclaw#113313@publish:30091560737:1` remained ownerless in the public publication queue. The source workflow run `30091560737` completed successfully on 2026-07-24, before the later direct-publication change in #859. Protocol-v1 rows had no revision tuple, so the existing reconciliation route did not consider them.

## Implementation

- Add an explicit, bounded protocol-v1 terminal-reconciliation path to `/publications/reconcile`.
- Require `live_proceeded`, a terminal target read, no active batch/lease, and no current or newer target authority.
- Never reclaim command/status-context rows; their acknowledgement completion has no matching durable terminal receipt.
- Index authority once per target before candidate selection, preserving the `max_items` bound without quadratic backlog scans.
- Persist expired-lease recovery before apply-mode target reads, and make dry runs perform the same read without deleting rows.
- Surface legacy candidate, selected, terminal-eligible, and changed counters through the maintenance client.

## Validation

- `pnpm run build:all`
- `pnpm run lint:dashboard`
- `pnpm run lint:repair`
- `node --test test/dashboard-worker.test.ts` (246 passing)
- `node --test test/repair/exact-review-batch-coordinator.test.ts` (7 passing)
- `codex review --uncommitted` — final result: no actionable correctness issues.
- `git fetch origin main --prune && codex review --base origin/main` — final result: no actionable correctness issues.

Focused coverage proves terminal removal, dry-run verification without mutation, expired-lease persistence, command acknowledgement retention, active batch/lease protection, and newer publication authority protection.

## Representative Docker proof

Ran a Docker-backed Crabbox `local-container` scenario on the PR head (lease `cbx_f9f31e55ac0f`, auto-stopped, exit 0). It used the actual `ExactReviewQueue` implementation with an isolated local Durable Object and a live public GitHub read of the terminal target. No production queue, state, deployment, workflow event, replay, or apply path was touched.

The fixture contains the stranded ordinary v1 row, an awaiting-command v1 row, and a v1 row owned by an active batch. The exact root target read was `openclaw/openclaw#113313`, which GitHub returned as closed at `2026-07-24T13:00:16Z`.

```json
{
  "target": {
    "number": 113313,
    "state": "closed",
    "closed_at": "2026-07-24T13:00:16Z"
  },
  "dry_run": {
    "candidates": 1,
    "selected": 1,
    "eligible": 1,
    "changed": 0,
    "ordinary_row_retained": true
  },
  "capped_apply": {
    "max_items": 1,
    "eligible": 1,
    "changed": 1,
    "ordinary_row_removed": true
  },
  "protected_rows": {
    "command_context_retained": true,
    "active_batch_retained": true,
    "protected_batch_items": 1
  }
}
```

This is representative non-production evidence, not an authorization to mutate the live queue. A production operator should still inspect a live dry run before any bounded maintenance apply.

## Risks and rollout

This changes only the explicit reconciliation endpoint. Each pass remains capped at 100 selected rows and uses bounded target reads; it does not deploy, poll broadly, alter the public dashboard, or mutate live queue state as part of this PR. Operators should inspect a dry run first, then apply one bounded pass and observe normal queue health.

## Links

- Root symptom: https://github.com/openclaw/openclaw/pull/113313
- Direct-publication transition: https://github.com/openclaw/clawsweeper/pull/859
