### PR TITLE
fix(state): retry gh provenance reads and degrade to canonical-wins on exhaustion

### DIFF
--- a/scripts/reconcile-worker-records.ts
+++ b/scripts/reconcile-worker-records.ts
@@ -39,14 +39,21 @@ export type AuthorityTupleDecision = {
 
 type ParsedRecordPath = { path: string; section: TupleSection | "commits"; id: string };
 
+export type GitCommitTimesResult = {
+  times: Map<string, string>;
+  unavailable: Set<string>;
+};
+
 export function decideRecordAuthority(options: {
   mismatches: readonly RecordParityMismatch[];
   canonicalRecords: ReadonlyMap<string, WorkerRecord>;
   gitRecordPaths: ReadonlySet<string>;
   githubStates: ReadonlyMap<string, GitHubState>;
   gitCommitTimes: ReadonlyMap<string, string>;
+  provenanceUnavailable?: ReadonlySet<string>;
 }) {
   const decisions: AuthorityDecision[] = [];
+  const degraded: string[] = [];
   const actionable = new Map<
     string,
     Array<{ mismatch: RecordParityMismatch; parsed: ParsedRecordPath }>
@@ -138,6 +145,29 @@ export function decideRecordAuthority(options: {
         verdict: "git-wins",
         reason: `git-only ${gitOnlySidecar.parsed.section} must be imported with its atomic tuple`,
       };
+    } else if (
+      records.some(
+        ({ mismatch, parsed }) =>
+          mismatch.workerDigest !== null && options.provenanceUnavailable?.has(parsed.path),
+      )
+    ) {
+      // Recency comparison is impossible without git provenance. Canonical is
+      // the designed authority (git is a projection being retired), so keeping
+      // it plus a projection replay is the safe degradation instead of aborting
+      // the whole run. This is not destructive: the divergent git content stays
+      // recoverable in the state repo's commit history, and every degraded path
+      // is printed and recorded in the decision table for operator follow-up.
+      for (const { mismatch, parsed } of records) {
+        if (mismatch.workerDigest !== null && options.provenanceUnavailable?.has(parsed.path)) {
+          degraded.push(parsed.path);
+        }
+      }
+      tuple = {
+        itemId,
+        verdict: "canonical-wins",
+        reason:
+          "provenance-unavailable: git commit recency could not be read; canonical stays authoritative",
+      };
     } else {
       let gitNewer: ParsedRecordPath | null = null;
       for (const { mismatch, parsed } of records) {
@@ -175,6 +205,7 @@ export function decideRecordAuthority(options: {
   return {
     decisions: decisions.sort((left, right) => left.path.localeCompare(right.path)),
     tuples,
+    degraded: degraded.sort((left, right) => left.localeCompare(right)),
   };
 }
 
@@ -193,7 +224,7 @@ export async function reconcileWorkerRecordAuthority(options: {
     stateRoot: string,
     repoSlug: string,
     recordPaths: readonly string[],
-  ) => Map<string, string>;
+  ) => GitCommitTimesResult;
 }) {
   validateTargetRepo(options.targetRepo);
   const parity = options.parityReport
@@ -236,7 +267,7 @@ export async function reconcileWorkerRecordAuthority(options: {
   const contentDifferPaths = parity.mismatches.flatMap((mismatch) =>
     mismatch.gitDigest !== null && mismatch.workerDigest !== null ? [mismatch.path] : [],
   );
-  const gitCommitTimes = (options.gitCommitTimes ?? loadGitCommitTimes)(
+  const provenance = (options.gitCommitTimes ?? loadGitCommitTimes)(
     options.stateRoot,
     options.repoSlug,
     contentDifferPaths,
@@ -246,12 +277,25 @@ export async function reconcileWorkerRecordAuthority(options: {
     canonicalRecords,
     gitRecordPaths: new Set(gitRecords.keys()),
     githubStates,
-    gitCommitTimes,
+    gitCommitTimes: provenance.times,
+    provenanceUnavailable: provenance.unavailable,
   });
+  if (authority.degraded.length) {
+    console.error(
+      `WARNING: git provenance unavailable for ${authority.degraded.length} record(s); ` +
+        "degraded to canonical-wins + projection replay:",
+    );
+    for (const degradedPath of authority.degraded) console.error(`  - ${degradedPath}`);
+  }
   if (options.summaryFile) {
     appendFileSync(
       options.summaryFile,
-      renderDecisionTable(options.targetRepo, options.dryRun === true, authority.decisions),
+      renderDecisionTable(
+        options.targetRepo,
+        options.dryRun === true,
+        authority.decisions,
+        authority.degraded.length,
+      ),
     );
   }
 
@@ -335,6 +379,8 @@ export async function reconcileWorkerRecordAuthority(options: {
     dryRun: options.dryRun === true,
     mismatchCount: parity.mismatches.length,
     decisions: authority.decisions,
+    degradedPaths: authority.degraded,
+    degradedCount: authority.degraded.length,
     corrections,
     replay,
   };
@@ -468,14 +514,31 @@ export function loadGitHubStates(targetRepo: string, itemIds: readonly string[])
   return states;
 }
 
+export type GhCommandResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+export type GitCommitTimesDeps = {
+  runGh?: (args: readonly string[]) => GhCommandResult;
+  sleep?: (ms: number) => void;
+};
+
+const PROVENANCE_MAX_ATTEMPTS = 4;
+const PROVENANCE_BASE_DELAY_MS = 2000;
+
 export function loadGitCommitTimes(
   _stateRoot: string,
   repoSlug: string,
   recordPaths: readonly string[],
-) {
+  deps?: GitCommitTimesDeps,
+): GitCommitTimesResult {
   const requested = new Set(recordPaths);
-  if (!requested.size) return new Map<string, string>();
-  const result = new Map<string, string>();
+  const times = new Map<string, string>();
+  const unavailable = new Set<string>();
+  if (!requested.size) return { times, unavailable };
   const paths = [...requested];
   for (let offset = 0; offset < paths.length; offset += 50) {
     const batch = paths.slice(offset, offset + 50);
@@ -486,32 +549,87 @@ export function loadGitCommitTimes(
       )
       .join("\n");
     const query = `query { repository(owner: "openclaw", name: "clawsweeper-state") { object(expression: "state") { ... on Commit { ${fields} } } } }`;
-    const command = spawnSync("gh", ["api", "graphql", "-f", `query=${query}`], {
-      encoding: "utf8",
-      maxBuffer: 8 * 1024 * 1024,
-    });
-    if (command.status !== 0) {
-      throw new Error(`gh api failed while reading git provenance: ${command.stderr.trim()}`);
+    const stdout = runProvenanceQueryWithRetry(query, deps);
+    if (stdout === null) {
+      // Retries exhausted on a transient failure: mark the batch degraded
+      // instead of aborting the whole reconcile run.
+      for (const recordPath of batch) unavailable.add(recordPath);
+      continue;
     }
-    const commit = JSON.parse(command.stdout).data?.repository?.object as
+    const commit = JSON.parse(stdout).data?.repository?.object as
       | Record<string, { nodes?: Array<{ committedDate?: string }> }>
       | undefined;
     for (let index = 0; index < batch.length; index += 1) {
       const recordPath = batch[index]!;
       const committedAt = commit?.[`p${index}`]?.nodes?.[0]?.committedDate;
-      if (committedAt) result.set(recordPath, committedAt);
+      if (committedAt) times.set(recordPath, committedAt);
     }
   }
   for (const recordPath of requested) {
-    if (!result.has(recordPath)) throw new Error(`Git provenance was not found for ${recordPath}`);
+    if (!times.has(recordPath) && !unavailable.has(recordPath)) {
+      throw new Error(`Git provenance was not found for ${recordPath}`);
+    }
   }
-  return result;
+  return { times, unavailable };
+}
+
+function runProvenanceQueryWithRetry(query: string, deps?: GitCommitTimesDeps): string | null {
+  const runGh = deps?.runGh ?? runGhCommand;
+  const sleep = deps?.sleep ?? sleepSync;
+  let lastFailure = "";
+  for (let attempt = 1; attempt <= PROVENANCE_MAX_ATTEMPTS; attempt += 1) {
+    const command = runGh(["api", "graphql", "-f", `query=${query}`]);
+    if (command.status === 0) return command.stdout;
+    lastFailure = (command.stderr.trim() || command.error?.message || "unknown failure").trim();
+    if (!isRetryableGhFailure(command)) {
+      throw new Error(`gh api failed while reading git provenance: ${lastFailure}`);
+    }
+    if (attempt < PROVENANCE_MAX_ATTEMPTS) {
+      const delayMs = PROVENANCE_BASE_DELAY_MS * 2 ** (attempt - 1);
+      console.error(
+        `gh git provenance read failed (attempt ${attempt}/${PROVENANCE_MAX_ATTEMPTS}): ` +
+          `${lastFailure}; retrying in ${delayMs / 1000}s`,
+      );
+      sleep(delayMs);
+    }
+  }
+  console.error(
+    `gh git provenance read failed after ${PROVENANCE_MAX_ATTEMPTS} attempts: ${lastFailure}`,
+  );
+  return null;
+}
+
+function isRetryableGhFailure(command: GhCommandResult) {
+  // Spawn failures (gh missing, EPERM, ...) are configuration problems.
+  if (command.error) return false;
+  const httpStatus = /HTTP\s+(\d{3})/.exec(command.stderr);
+  if (httpStatus?.[1]) return Number(httpStatus[1]) >= 500;
+  // No HTTP status in stderr: retry only transport-shaped failures, not
+  // GraphQL/query errors.
+  return /connect|connection|timeout|timed out|temporar|unavailable|reset by peer|unexpected EOF|dial tcp|TLS handshake|network/i.test(
+    command.stderr,
+  );
+}
+
+function runGhCommand(args: readonly string[]): GhCommandResult {
+  const command = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 });
+  return {
+    status: command.status,
+    stdout: command.stdout ?? "",
+    stderr: command.stderr ?? "",
+    ...(command.error ? { error: command.error } : {}),
+  };
+}
+
+function sleepSync(ms: number) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 function renderDecisionTable(
   targetRepo: string,
   dryRun: boolean,
   decisions: readonly AuthorityDecision[],
+  degradedCount: number,
 ) {
   const counts = { "git-wins": 0, "canonical-wins": 0, "both-stale": 0, lag: 0 };
   for (const decision of decisions) counts[decision.verdict] += 1;
@@ -524,7 +642,7 @@ function renderDecisionTable(
   return [
     `### Worker record authority reconciliation: ${targetRepo}`,
     "",
-    `Mode: ${dryRun ? "dry run" : "apply"}. Git wins: ${counts["git-wins"]}; canonical wins: ${counts["canonical-wins"]}; both stale: ${counts["both-stale"]}; projection lag: ${counts.lag}.`,
+    `Mode: ${dryRun ? "dry run" : "apply"}. Git wins: ${counts["git-wins"]}; canonical wins: ${counts["canonical-wins"]}; both stale: ${counts["both-stale"]}; projection lag: ${counts.lag}; provenance degradations: ${degradedCount}.`,
     "",
     "| Path | Verdict | Reason |",
     "| --- | --- | --- |",
@@ -538,13 +656,21 @@ function renderDecisionOutcome(result: {
   repoSlug: string;
   dryRun: boolean;
   decisions: readonly AuthorityDecision[];
+  degradedPaths: readonly string[];
   corrections: readonly { itemId: string; deduped: boolean }[];
   replay: { attempted: number; deduped: number } | null;
 }) {
   return [
     "#### Reconciliation outcome",
     "",
-    `Corrective tuples: ${result.corrections.length}; replayed canonical tuples: ${result.replay?.attempted ?? 0}; deduped receipts: ${result.corrections.filter((entry) => entry.deduped).length + (result.replay?.deduped ?? 0)}.`,
+    `Corrective tuples: ${result.corrections.length}; replayed canonical tuples: ${result.replay?.attempted ?? 0}; deduped receipts: ${result.corrections.filter((entry) => entry.deduped).length + (result.replay?.deduped ?? 0)}; provenance degradations: ${result.degradedPaths.length}.`,
+    ...(result.degradedPaths.length
+      ? [
+          "",
+          "Degraded (provenance-unavailable) paths:",
+          ...result.degradedPaths.map((degradedPath) => `- \`${escapeTable(degradedPath)}\``),
+        ]
+      : []),
     "",
   ].join("\n");
 }

--- a/test/reconcile-provenance-retry.test.ts
+++ b/test/reconcile-provenance-retry.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  decideRecordAuthority,
+  loadGitCommitTimes,
+  reconcileWorkerRecordAuthority,
+  type GhCommandResult,
+} from "../scripts/reconcile-worker-records.ts";
+import type { WorkerRecord } from "../scripts/worker-records.ts";
+
+const repoSlug = "openclaw-openclaw";
+
+function ghSuccess(committedDates: readonly (string | null)[]): GhCommandResult {
+  const object: Record<string, { nodes: Array<{ committedDate: string }> }> = {};
+  committedDates.forEach((committedDate, index) => {
+    object[`p${index}`] = { nodes: committedDate ? [{ committedDate }] : [] };
+  });
+  return {
+    status: 0,
+    stdout: JSON.stringify({ data: { repository: { object } } }),
+    stderr: "",
+  };
+}
+
+function ghHttpFailure(status: number): GhCommandResult {
+  return {
+    status: 1,
+    stdout: "",
+    stderr: `gh: HTTP ${status} (https://api.github.com/graphql)`,
+  };
+}
+
+test("git provenance read retries transient 502s with exponential backoff and then succeeds", () => {
+  const responses = [ghHttpFailure(502), ghHttpFailure(502), ghSuccess(["2026-07-26T10:00:00Z"])];
+  let calls = 0;
+  const sleeps: number[] = [];
+  const result = loadGitCommitTimes("unused", repoSlug, ["items/44.md"], {
+    runGh: () => responses[calls++]!,
+    sleep: (ms) => sleeps.push(ms),
+  });
+
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [2000, 4000]);
+  assert.deepEqual(result.times, new Map([["items/44.md", "2026-07-26T10:00:00Z"]]));
+  assert.deepEqual(result.unavailable, new Set());
+});
+
+test("persistent 502s exhaust retries and degrade to provenance-unavailable instead of throwing", () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  const result = loadGitCommitTimes("unused", repoSlug, ["items/44.md", "plans/44.md"], {
+    runGh: () => {
+      calls += 1;
+      return ghHttpFailure(502);
+    },
+    sleep: (ms) => sleeps.push(ms),
+  });
+
+  assert.equal(calls, 4);
+  assert.deepEqual(sleeps, [2000, 4000, 8000]);
+  assert.deepEqual(result.times, new Map());
+  assert.deepEqual(result.unavailable, new Set(["items/44.md", "plans/44.md"]));
+
+  const canonical = workerRecord("items", "44", "canonical body\n", 7);
+  canonical.updatedAt = "2026-07-26T12:00:00.000Z";
+  const authority = decideRecordAuthority({
+    mismatches: [
+      { path: "items/44.md", gitDigest: "d".repeat(64), workerDigest: canonical.digest },
+    ],
+    canonicalRecords: new Map([["items/44.md", canonical]]),
+    gitRecordPaths: new Set(["items/44.md"]),
+    githubStates: new Map([["44", "open"]]),
+    gitCommitTimes: result.times,
+    provenanceUnavailable: result.unavailable,
+  });
+  assert.deepEqual(authority.tuples, [
+    {
+      itemId: "44",
+      verdict: "canonical-wins",
+      reason:
+        "provenance-unavailable: git commit recency could not be read; canonical stays authoritative",
+    },
+  ]);
+  assert.deepEqual(authority.degraded, ["items/44.md"]);
+});
+
+test("a 4xx provenance failure throws immediately without retrying", () => {
+  let calls = 0;
+  const sleeps: number[] = [];
+  assert.throws(
+    () =>
+      loadGitCommitTimes("unused", repoSlug, ["items/44.md"], {
+        runGh: () => {
+          calls += 1;
+          return ghHttpFailure(404);
+        },
+        sleep: (ms) => sleeps.push(ms),
+      }),
+    /gh api failed while reading git provenance: gh: HTTP 404/,
+  );
+  assert.equal(calls, 1);
+  assert.deepEqual(sleeps, []);
+});
+
+test("reconciliation degrades unavailable provenance to canonical-wins with replay and a summary note", async () => {
+  const item = "---\nnumber: 44\n---\ncanonical body\n";
+  const gitItem = "---\nnumber: 44\n---\ndiverged git body\n";
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-provenance-degrade-test-"));
+  const stateRoot = path.join(root, "state");
+  write(path.join(stateRoot, "records", repoSlug, "items", "44.md"), gitItem);
+  const parityReport = path.join(root, "parity.json");
+  writeFileSync(
+    parityReport,
+    JSON.stringify({
+      repoSlug,
+      gitRecords: 1,
+      workerRecords: 1,
+      mismatches: [
+        {
+          path: "items/44.md",
+          gitDigest: createHash("sha256").update(gitItem).digest("hex"),
+          workerDigest: createHash("sha256").update(item).digest("hex"),
+        },
+      ],
+    }),
+  );
+  const summaryFile = path.join(root, "summary.md");
+  writeFileSync(summaryFile, "");
+  const tupleRequests: Array<Record<string, unknown>> = [];
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input.toString());
+    if (url.pathname === "/internal/state/records/export") {
+      return Response.json({
+        repoSlug,
+        revision: 4,
+        nextCursor: null,
+        records: [workerRecord("items", "44", item, 3)],
+      });
+    }
+    assert.equal(url.pathname, "/internal/state/records/tuples");
+    tupleRequests.push(JSON.parse(String(init?.body ?? "{}")));
+    return Response.json({ ok: true, accepted: true, deduped: false, revision: 5, sequence: 9 });
+  }) as typeof fetch;
+
+  try {
+    const result = await reconcileWorkerRecordAuthority({
+      stateRoot,
+      targetRepo: "openclaw/openclaw",
+      repoSlug,
+      baseUrl: "https://worker.example",
+      webhookSecret: "fixture-secret",
+      parityReport,
+      summaryFile,
+      fetch: fetchImpl,
+      githubStates: () => new Map([["44", "open"]]),
+      gitCommitTimes: () => ({ times: new Map(), unavailable: new Set(["items/44.md"]) }),
+    });
+
+    assert.deepEqual(result.decisions, [
+      {
+        path: "items/44.md",
+        itemId: "44",
+        verdict: "canonical-wins",
+        reason:
+          "provenance-unavailable: git commit recency could not be read; canonical stays authoritative",
+      },
+    ]);
+    assert.deepEqual(result.degradedPaths, ["items/44.md"]);
+    assert.equal(result.degradedCount, 1);
+    assert.deepEqual(result.corrections, []);
+    assert.equal(result.replay?.attempted, 1);
+    assert.equal(result.replay?.failed, 0);
+    assert.equal(tupleRequests.length, 1);
+    const summary = readFileSync(summaryFile, "utf8");
+    assert.match(summary, /provenance degradations: 1/);
+    assert.match(summary, /provenance-unavailable/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function workerRecord(
+  section: WorkerRecord["section"],
+  id: string,
+  content: string,
+  storeRevision: number,
+  revision = 1,
+): WorkerRecord {
+  return {
+    section,
+    id,
+    content,
+    digest: createHash("sha256").update(content).digest("hex"),
+    revision,
+    storeRevision,
+    deleted: false,
+  };
+}
+
+function write(filePath: string, content: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+}

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -350,7 +350,7 @@ test("reconciliation imports a git-only packet for a both-stale item keyed to ca
       summaryFile,
       fetch: fetchImpl,
       githubStates: () => new Map([["857", "closed"]]),
-      gitCommitTimes: () => new Map(),
+      gitCommitTimes: () => ({ times: new Map(), unavailable: new Set() }),
     });
 
     assert.deepEqual(result.decisions, [


### PR DESCRIPTION
## Problem

`scripts/reconcile-worker-records.ts` aborted entire reconcile runs with:

```
Error: gh api failed while reading git provenance: gh: HTTP 502
```

The GitHub path-history/commits GraphQL API 502s routinely against the 39.5 GiB `openclaw/clawsweeper-state` repo — that is normal operating behavior for a repo this size, not an exceptional condition. Live failures: runs 30244316713 and 30246566682 (openclaw/openclaw reconcile).

## Fix (two layers)

**1. Bounded retry on gh provenance reads.** Up to 4 attempts with exponential backoff starting at 2s (2s/4s/8s). Only 5xx and network/transport-shaped failures retry; 4xx, GraphQL/query errors, and spawn failures throw immediately as before.

**2. Graceful degradation when retries exhaust.** Provenance (git commit recency for a path) is only needed for content-differ recency comparisons. When it stays unavailable, the run no longer aborts: the affected tuples degrade to **canonical-wins + projection replay** (canonical is the designed authority; keeping it is the safe default, and the divergent git content remains recoverable in the state repo's history). The decision-table rows carry a `provenance-unavailable` note, degraded paths are printed to stderr and listed in the run summary with a degradation count, and the run exits 0 when everything else succeeds — degradations are warnings, not failures.

## Implementation notes

- `loadGitCommitTimes` now returns `{ times, unavailable }` and accepts injectable `runGh`/`sleep` deps for deterministic tests; the default sleep is a synchronous `Atomics.wait`.
- `decideRecordAuthority` takes an optional `provenanceUnavailable` set and reports degraded paths; a tuple containing any provenance-unavailable content-differ record degrades as a whole rather than risking a partial recency verdict.
- Result JSON gains `degradedPaths`/`degradedCount`; the summary table header and outcome section include the degradation count and paths.

## Tests

New `test/reconcile-provenance-retry.test.ts`:

- 502-then-success: 3 gh calls, backoff sleeps `[2000, 4000]`, times resolved.
- Persistent 502: 4 calls, sleeps `[2000, 4000, 8000]`, no throw; paths marked unavailable and `decideRecordAuthority` degrades to canonical-wins with the `provenance-unavailable` reason.
- 404: throws immediately, exactly 1 call, no sleeps.
- End-to-end `reconcileWorkerRecordAuthority` with unavailable provenance: canonical-wins decision with note, projection replay attempted, `degradedCount: 1`, summary contains `provenance degradations: 1`.

All 18 tests across `test/reconcile-provenance-retry.test.ts` + `test/worker-state-readers.test.ts` pass; touched files are oxlint/oxfmt clean; autoreview (codex, local mode) clean — "patch is correct (0.98)".
