### PR TITLE
feat(state): R2-backed ledger/v1 + assets blob transport, migration workflow, and opt-in dual-read (phase 3 foundation)

### DIFF
--- a/.github/workflows/migrate-state-blobs.yml
+++ b/.github/workflows/migrate-state-blobs.yml
@@ -1,0 +1,93 @@
+name: Migrate state blobs to R2
+
+on:
+  workflow_dispatch:
+    inputs:
+      trees:
+        description: State trees to migrate.
+        required: false
+        type: choice
+        options:
+          - both
+          - ledger
+          - assets
+        default: both
+      cursor:
+        description: Zero-based file cursor from a prior interrupted run.
+        required: false
+        type: number
+        default: 0
+      max_files:
+        description: Optional bounded file count; 0 processes the remaining files.
+        required: false
+        type: number
+        default: 0
+      verify:
+        description: Digest verification mode (multipart re-downloads only multipart uploads; all re-downloads every upload).
+        required: false
+        type: choice
+        options:
+          - multipart
+          - all
+        default: multipart
+
+concurrency:
+  group: migrate-state-blobs
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          filter: blob:none
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Create state token
+        id: state-token
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        with:
+          token: ${{ steps.state-token.outputs.token }}
+          fetch-depth: 1
+          sparse-checkout: |
+            ledger
+            assets
+          persist-credentials: "false"
+          records-source: git
+          coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
+          coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+
+      - name: Migrate ledger/assets blobs to R2
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_RECORDS_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          MIGRATE_TREES: ${{ inputs.trees }}
+          MIGRATE_CURSOR: ${{ inputs.cursor }}
+          MIGRATE_MAX_FILES: ${{ inputs.max_files }}
+          MIGRATE_VERIFY: ${{ inputs.verify }}
+        run: |
+          case "$MIGRATE_TREES" in
+            ledger) trees="ledger/v1" ;;
+            assets) trees="assets" ;;
+            *) trees="ledger/v1,assets" ;;
+          esac
+          args=(--state-dir clawsweeper-state --trees "$trees" --cursor "$MIGRATE_CURSOR" --verify "$MIGRATE_VERIFY")
+          if (( MIGRATE_MAX_FILES > 0 )); then
+            args+=(--max-files "$MIGRATE_MAX_FILES")
+          fi
+          node scripts/migrate-state-blobs.ts "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Added authenticated Worker blob endpoints (`/internal/state/blobs/*`) that serve the `ledger/v1` and `assets` state trees from R2 with create-only immutable ledger writes, a cursor-resumable `migrate-state-blobs` workflow with digest verification, and an opt-in `CLAWSWEEPER_LEDGER_SOURCE=worker` dual-read in `hydrate-state` (default stays git).
+
 - Ranked imported repair clusters for landable bugs using conservative historical dedupe, live-state, security, and quality gates. Thanks @RomneyDa! (#881)
 - The OpenClaw runner ships a built-in Z.AI provider: `CLAWSWEEPER_OPENCLAW_MODEL=zai/glm-5.2` runs GLM-5.2 on the GLM Coding Plan endpoint with only `ZAI_API_KEY` (validated live end to end).
 - The OpenClaw runner ships a built-in Cerebras provider: `CLAWSWEEPER_OPENCLAW_MODEL=cerebras/zai-glm-4.7` needs only `CEREBRAS_API_KEY` (validated live at ~474 tok/s on Cerebras Code Max); provider-key allowlist extended for Cerebras, Z.AI, DeepSeek, and Mistral.

--- a/dashboard/state-blobs.ts
+++ b/dashboard/state-blobs.ts
@@ -1,0 +1,470 @@
+/**
+ * R2-backed state blob store for the Cloudflare-canonical migration (phase 3).
+ *
+ * Serves the two remaining git-state trees from the shared STATE_SNAPSHOTS
+ * bucket under distinct key prefixes:
+ *   - `ledger/v1/...`  — immutable append-only action-ledger shards. Writes are
+ *     create-only: overwriting an existing key with a different content digest
+ *     is rejected; a same-digest PUT is idempotent.
+ *   - `assets/...`     — mutable published assets; overwrite is allowed.
+ *
+ * Record snapshots produced by the phase-2 code live under
+ * `<repoSlug>/<revision>/...` keys and never collide with these prefixes.
+ *
+ * R2 bindings cannot presign URLs, so reads are proxied through the Worker in
+ * bounded ranges (mirroring the record-snapshot chunk endpoint) and large
+ * writes stream through R2 multipart uploads with fixed-size base64 parts.
+ */
+
+export const STATE_BLOB_OPERATIONS = [
+  "put",
+  "stat",
+  "chunk",
+  "list",
+  "multipart/start",
+  "multipart/part",
+  "multipart/complete",
+  "multipart/abort",
+] as const;
+export type StateBlobOperation = (typeof STATE_BLOB_OPERATIONS)[number];
+
+export const STATE_BLOB_CHUNK_MAX_BYTES = 32 * 1024 * 1024;
+export const STATE_BLOB_PUT_MAX_BYTES = 24 * 1024 * 1024;
+export const STATE_BLOB_MULTIPART_PART_BYTES = 8 * 1024 * 1024;
+export const STATE_BLOB_MAX_BYTES = 1024 * 1024 * 1024;
+export const STATE_BLOB_LIST_MAX_LIMIT = 1000;
+
+const BLOB_PATH_PREFIXES = ["ledger/v1/", "assets/"] as const;
+const IMMUTABLE_PATH_PREFIXES = ["ledger/"] as const;
+const BLOB_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._+@-]{0,254}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+
+type BlobR2Object = {
+  key: string;
+  size: number;
+  customMetadata?: Record<string, string>;
+};
+
+type BlobR2ObjectBody = BlobR2Object & { body: ReadableStream<Uint8Array> };
+
+type BlobR2UploadedPart = { partNumber: number; etag: string };
+
+type BlobR2MultipartUpload = {
+  uploadId: string;
+  uploadPart: (partNumber: number, value: Uint8Array) => Promise<BlobR2UploadedPart>;
+  complete: (parts: BlobR2UploadedPart[]) => Promise<unknown>;
+  abort: () => Promise<void>;
+};
+
+type BlobR2Bucket = {
+  head: (key: string) => Promise<BlobR2Object | null>;
+  get: (
+    key: string,
+    options?: { range?: { offset: number; length: number } },
+  ) => Promise<BlobR2ObjectBody | null>;
+  put: (
+    key: string,
+    value: Uint8Array,
+    options?: {
+      httpMetadata?: { contentType?: string };
+      customMetadata?: Record<string, string>;
+    },
+  ) => Promise<unknown>;
+  list: (options?: {
+    prefix?: string;
+    cursor?: string;
+    limit?: number;
+    include?: string[];
+  }) => Promise<{ objects: BlobR2Object[]; truncated: boolean; cursor?: string }>;
+  createMultipartUpload: (
+    key: string,
+    options?: {
+      httpMetadata?: { contentType?: string };
+      customMetadata?: Record<string, string>;
+    },
+  ) => Promise<BlobR2MultipartUpload>;
+  resumeMultipartUpload: (key: string, uploadId: string) => BlobR2MultipartUpload;
+};
+
+export function isValidStateBlobPath(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 900) return false;
+  if (!BLOB_PATH_PREFIXES.some((prefix) => value.startsWith(prefix))) return false;
+  return value.split("/").every((segment) => BLOB_PATH_SEGMENT_PATTERN.test(segment));
+}
+
+export function isImmutableStateBlobPath(path: string): boolean {
+  return IMMUTABLE_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+export function isValidStateBlobListPrefix(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 900) return false;
+  const normalized = value.endsWith("/") ? value : `${value}/`;
+  if (!BLOB_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix) || prefix === normalized))
+    return false;
+  return normalized
+    .slice(0, -1)
+    .split("/")
+    .every((segment) => BLOB_PATH_SEGMENT_PATTERN.test(segment));
+}
+
+export async function handleStateBlobRequest(
+  bucketBinding: unknown,
+  operation: StateBlobOperation,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const bucket = blobBucket(bucketBinding);
+  if (!bucket) {
+    return blobJson(
+      { error: "blob_store_unavailable", detail: "STATE_SNAPSHOTS is not available" },
+      503,
+    );
+  }
+  try {
+    if (operation === "put") return await putBlob(bucket, body);
+    if (operation === "stat") return await statBlob(bucket, body);
+    if (operation === "chunk") return await chunkBlob(bucket, body);
+    if (operation === "list") return await listBlobs(bucket, body);
+    if (operation === "multipart/start") return await startMultipart(bucket, body);
+    if (operation === "multipart/part") return await uploadMultipartPart(bucket, body);
+    if (operation === "multipart/complete") return await completeMultipart(bucket, body);
+    if (operation === "multipart/abort") return await abortMultipart(bucket, body);
+    return blobJson({ error: "unknown_blob_operation" }, 404);
+  } catch (error) {
+    if (error instanceof BlobRequestError) return blobJson(error.body, error.status);
+    return blobJson(
+      {
+        error: "blob_store_unavailable",
+        detail: error instanceof Error ? error.message : String(error),
+      },
+      503,
+    );
+  }
+}
+
+class BlobRequestError extends Error {
+  readonly status: number;
+  readonly body: Record<string, unknown>;
+
+  constructor(status: number, body: Record<string, unknown>) {
+    super(String(body.error));
+    this.name = "BlobRequestError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function putBlob(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const digest = requireBlobDigest(body.digest);
+  const content = decodeBase64(body.contentBase64);
+  if (!content) throw new BlobRequestError(400, { error: "invalid_blob_content" });
+  if (content.byteLength > STATE_BLOB_PUT_MAX_BYTES) {
+    throw new BlobRequestError(413, {
+      error: "blob_too_large",
+      maxBytes: STATE_BLOB_PUT_MAX_BYTES,
+      detail: "use the multipart upload endpoints for larger blobs",
+    });
+  }
+  if ((await sha256Hex(content)) !== digest) {
+    throw new BlobRequestError(400, { error: "blob_digest_mismatch" });
+  }
+  const existing = await bucket.head(path);
+  const conflict = existingConflict(path, existing, digest, content.byteLength);
+  if (conflict === "unchanged") {
+    return blobJson({ ok: true, path, bytes: content.byteLength, digest, unchanged: true });
+  }
+  if (conflict) throw conflict;
+  await bucket.put(path, content, {
+    httpMetadata: { contentType: "application/octet-stream" },
+    customMetadata: { sha256: digest, verified: "server" },
+  });
+  return blobJson({ ok: true, path, bytes: content.byteLength, digest, unchanged: false }, 201);
+}
+
+async function statBlob(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const object = await bucket.head(path);
+  if (!object) return blobJson({ error: "blob_not_found", path }, 404);
+  return blobJson({ ok: true, blob: blobDescriptor(path, object) });
+}
+
+async function chunkBlob(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const offset = Number(body.offset);
+  const length = Number(body.length);
+  if (
+    !Number.isSafeInteger(offset) ||
+    offset < 0 ||
+    !Number.isSafeInteger(length) ||
+    length < 1 ||
+    length > STATE_BLOB_CHUNK_MAX_BYTES
+  ) {
+    throw new BlobRequestError(400, {
+      error: "invalid_blob_range",
+      maxChunkBytes: STATE_BLOB_CHUNK_MAX_BYTES,
+    });
+  }
+  const head = await bucket.head(path);
+  if (!head) return blobJson({ error: "blob_not_found", path }, 404);
+  if (offset >= head.size) {
+    throw new BlobRequestError(416, { error: "invalid_blob_range", bytes: head.size });
+  }
+  const boundedLength = Math.min(length, head.size - offset);
+  const object = await bucket.get(path, { range: { offset, length: boundedLength } });
+  if (!object) return blobJson({ error: "blob_not_found", path }, 404);
+  return new Response(object.body, {
+    status: 206,
+    headers: {
+      "accept-ranges": "bytes",
+      "content-length": String(boundedLength),
+      "content-range": `bytes ${offset}-${offset + boundedLength - 1}/${head.size}`,
+      "content-type": "application/octet-stream",
+      ...(head.customMetadata?.sha256
+        ? { "x-clawsweeper-blob-digest": head.customMetadata.sha256 }
+        : {}),
+    },
+  });
+}
+
+async function listBlobs(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  if (!isValidStateBlobListPrefix(body.prefix)) {
+    throw new BlobRequestError(400, { error: "invalid_blob_prefix" });
+  }
+  const prefix = body.prefix.endsWith("/") ? body.prefix : `${body.prefix}/`;
+  const cursor = body.cursor === undefined ? undefined : String(body.cursor);
+  const limit = body.limit === undefined ? STATE_BLOB_LIST_MAX_LIMIT : Number(body.limit);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > STATE_BLOB_LIST_MAX_LIMIT) {
+    throw new BlobRequestError(400, {
+      error: "invalid_blob_list_limit",
+      maxLimit: STATE_BLOB_LIST_MAX_LIMIT,
+    });
+  }
+  const page = await bucket.list({
+    prefix,
+    ...(cursor ? { cursor } : {}),
+    limit,
+    include: ["customMetadata"],
+  });
+  return blobJson({
+    ok: true,
+    prefix,
+    blobs: page.objects.map((object) => blobDescriptor(object.key, object)),
+    nextCursor: page.truncated ? (page.cursor ?? null) : null,
+  });
+}
+
+async function startMultipart(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const digest = requireBlobDigest(body.digest);
+  const bytes = Number(body.bytes);
+  if (!Number.isSafeInteger(bytes) || bytes < 1 || bytes > STATE_BLOB_MAX_BYTES) {
+    throw new BlobRequestError(400, {
+      error: "invalid_blob_bytes",
+      maxBytes: STATE_BLOB_MAX_BYTES,
+    });
+  }
+  const existing = await bucket.head(path);
+  const conflict = existingConflict(path, existing, digest, bytes);
+  if (conflict === "unchanged") {
+    return blobJson({ ok: true, path, bytes, digest, unchanged: true, uploadId: null });
+  }
+  if (conflict) throw conflict;
+  const upload = await bucket.createMultipartUpload(path, {
+    httpMetadata: { contentType: "application/octet-stream" },
+    // Multipart bodies stream through R2 part by part, so the Worker cannot
+    // recompute the whole-object digest; the claimed digest is verified by the
+    // uploader with a read-back before it is trusted.
+    customMetadata: { sha256: digest, verified: "client" },
+  });
+  return blobJson(
+    {
+      ok: true,
+      path,
+      digest,
+      unchanged: false,
+      uploadId: upload.uploadId,
+      partBytes: STATE_BLOB_MULTIPART_PART_BYTES,
+    },
+    201,
+  );
+}
+
+async function uploadMultipartPart(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const uploadId = requireUploadId(body.uploadId);
+  const partNumber = Number(body.partNumber);
+  if (!Number.isSafeInteger(partNumber) || partNumber < 1 || partNumber > 10000) {
+    throw new BlobRequestError(400, { error: "invalid_blob_part_number" });
+  }
+  const content = decodeBase64(body.contentBase64);
+  if (!content || content.byteLength < 1) {
+    throw new BlobRequestError(400, { error: "invalid_blob_content" });
+  }
+  if (content.byteLength > STATE_BLOB_MULTIPART_PART_BYTES) {
+    throw new BlobRequestError(413, {
+      error: "blob_part_too_large",
+      maxBytes: STATE_BLOB_MULTIPART_PART_BYTES,
+    });
+  }
+  try {
+    const part = await bucket.resumeMultipartUpload(path, uploadId).uploadPart(partNumber, content);
+    return blobJson({ ok: true, path, part: { partNumber: part.partNumber, etag: part.etag } });
+  } catch (error) {
+    throw invalidUpload(error);
+  }
+}
+
+async function completeMultipart(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const uploadId = requireUploadId(body.uploadId);
+  const digest = requireBlobDigest(body.digest);
+  const bytes = Number(body.bytes);
+  if (!Number.isSafeInteger(bytes) || bytes < 1 || bytes > STATE_BLOB_MAX_BYTES) {
+    throw new BlobRequestError(400, {
+      error: "invalid_blob_bytes",
+      maxBytes: STATE_BLOB_MAX_BYTES,
+    });
+  }
+  const parts = multipartParts(body.parts);
+  if (!parts) throw new BlobRequestError(400, { error: "invalid_blob_parts" });
+  const upload = bucket.resumeMultipartUpload(path, uploadId);
+  // Re-check immutability at completion: a concurrent writer may have created
+  // the key after multipart/start admitted this upload.
+  const existing = await bucket.head(path);
+  const conflict = existingConflict(path, existing, digest, bytes);
+  if (conflict === "unchanged" || conflict) {
+    await upload.abort().catch(() => undefined);
+    if (conflict === "unchanged")
+      return blobJson({ ok: true, path, bytes, digest, unchanged: true });
+    throw conflict;
+  }
+  try {
+    await upload.complete(parts);
+  } catch (error) {
+    throw invalidUpload(error);
+  }
+  const completed = await bucket.head(path);
+  if (!completed || completed.size !== bytes) {
+    throw new BlobRequestError(400, {
+      error: "blob_size_mismatch",
+      expectedBytes: bytes,
+      receivedBytes: completed?.size ?? 0,
+    });
+  }
+  return blobJson({ ok: true, path, bytes, digest, unchanged: false }, 201);
+}
+
+async function abortMultipart(bucket: BlobR2Bucket, body: Record<string, unknown>) {
+  const path = requireBlobPath(body.path);
+  const uploadId = requireUploadId(body.uploadId);
+  await bucket
+    .resumeMultipartUpload(path, uploadId)
+    .abort()
+    .catch(() => undefined);
+  return blobJson({ ok: true, path });
+}
+
+function existingConflict(
+  path: string,
+  existing: BlobR2Object | null,
+  digest: string,
+  bytes: number,
+): BlobRequestError | "unchanged" | null {
+  if (!existing) return null;
+  const existingDigest = existing.customMetadata?.sha256 ?? null;
+  if (existingDigest === digest && existing.size === bytes) return "unchanged";
+  if (!isImmutableStateBlobPath(path)) return null;
+  return new BlobRequestError(409, {
+    error: "ledger_blob_immutable_conflict",
+    path,
+    existingBytes: existing.size,
+    existingDigest,
+  });
+}
+
+function blobDescriptor(path: string, object: BlobR2Object) {
+  return {
+    path,
+    bytes: object.size,
+    digest: object.customMetadata?.sha256 ?? null,
+    digestVerified: object.customMetadata?.verified === "server",
+  };
+}
+
+function requireBlobPath(value: unknown): string {
+  if (!isValidStateBlobPath(value)) throw new BlobRequestError(400, { error: "invalid_blob_path" });
+  return value;
+}
+
+function requireBlobDigest(value: unknown): string {
+  if (typeof value !== "string" || !DIGEST_PATTERN.test(value)) {
+    throw new BlobRequestError(400, { error: "invalid_blob_digest" });
+  }
+  return value;
+}
+
+function requireUploadId(value: unknown): string {
+  if (typeof value !== "string" || !value || value.length > 4096) {
+    throw new BlobRequestError(400, { error: "invalid_blob_upload" });
+  }
+  return value;
+}
+
+function multipartParts(value: unknown): BlobR2UploadedPart[] | null {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 10000) return null;
+  const parts: BlobR2UploadedPart[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") return null;
+    const partNumber = Number((entry as { partNumber: unknown }).partNumber);
+    const etag = (entry as { etag: unknown }).etag;
+    if (!Number.isSafeInteger(partNumber) || partNumber < 1 || typeof etag !== "string")
+      return null;
+    parts.push({ partNumber, etag });
+  }
+  return parts;
+}
+
+function invalidUpload(error: unknown) {
+  return new BlobRequestError(400, {
+    error: "invalid_blob_upload",
+    detail: error instanceof Error ? error.message : String(error),
+  });
+}
+
+function blobBucket(value: unknown): BlobR2Bucket | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<BlobR2Bucket>;
+  return typeof candidate.head === "function" &&
+    typeof candidate.get === "function" &&
+    typeof candidate.put === "function" &&
+    typeof candidate.list === "function" &&
+    typeof candidate.createMultipartUpload === "function" &&
+    typeof candidate.resumeMultipartUpload === "function"
+    ? (candidate as BlobR2Bucket)
+    : null;
+}
+
+function decodeBase64(value: unknown): Uint8Array | null {
+  if (typeof value !== "string" || value.length % 4 !== 0) return null;
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as unknown as ArrayBuffer);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function blobJson(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -47,6 +47,11 @@ import {
   normalizeApplyObservabilityEvent,
   summarizeApplyObservability,
 } from "./apply-observability.ts";
+import {
+  STATE_BLOB_OPERATIONS,
+  handleStateBlobRequest,
+  type StateBlobOperation,
+} from "./state-blobs.ts";
 
 export {
   ExactReviewQueue,
@@ -570,6 +575,13 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/records/snapshots/trigger");
     if (url.pathname === "/internal/state/records/snapshots/chunk" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/records/snapshots/chunk");
+    if (url.pathname.startsWith("/internal/state/blobs/") && request.method === "POST") {
+      const operation = url.pathname.slice("/internal/state/blobs/".length);
+      if (STATE_BLOB_OPERATIONS.includes(operation as StateBlobOperation)) {
+        return authenticatedStateBlobRequest(request, env, operation as StateBlobOperation);
+      }
+      return json({ error: "not_found" }, 404);
+    }
     if (url.pathname === "/internal/state/append" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/state/append");
     if (url.pathname === "/internal/state/drain" && request.method === "POST")
@@ -1750,6 +1762,19 @@ async function authenticatedExactReviewQueueRead(request, env, path: string) {
     path,
     new Request(`https://clawsweeper-exact-review-queue${path}`, { method: "GET" }),
   );
+}
+
+async function authenticatedStateBlobRequest(request, env, operation: StateBlobOperation) {
+  const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
+  if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const bodyText = await request.text();
+  const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
+  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText }))) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+  const body = parseJsonObject(bodyText);
+  if (!body) return json({ error: "invalid_json" }, 400);
+  return handleStateBlobRequest(env.STATE_SNAPSHOTS, operation, body);
 }
 
 async function authenticatedExactReviewOperatorRequest(request, env, path: string) {

--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -3,6 +3,7 @@ import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { materializeStateBlobs, WorkerBlobsUnavailableError } from "./worker-blobs.ts";
 import {
   discoverRecordRepoSlugs,
   materializeWorkerRecords,
@@ -19,12 +20,15 @@ const GENERATED_PATHS = [
   "apply-report.json",
   "repair-apply-report.json",
 ] as const;
-const NON_RECORD_PATHS = GENERATED_PATHS.filter((relativePath) => relativePath !== "records");
+// The ledger/assets trees ride the blob transport together: both are plain
+// file trees served from R2 under the ledger/v1/... and assets/... prefixes.
+const BLOB_PATHS = ["ledger", "assets"] as const;
 
 type Args = {
   stateDir?: string;
   worktree?: string;
   recordsSource?: "git" | "worker";
+  ledgerSource?: "git" | "worker";
   recordsUrl?: string;
   recordsRepoSlugs?: string[];
 };
@@ -40,6 +44,8 @@ export async function hydrateState(
   );
   const worktreeRoot = path.resolve(args.worktree ?? process.cwd());
   const recordsSource = args.recordsSource ?? parseRecordsSource(env.CLAWSWEEPER_RECORDS_SOURCE);
+  const ledgerSource =
+    args.ledgerSource ?? parseSource(env.CLAWSWEEPER_LEDGER_SOURCE, "CLAWSWEEPER_LEDGER_SOURCE");
 
   if (!existsSync(stateRoot)) throw new Error(`State directory does not exist: ${stateRoot}`);
   if (!GENERATED_PATHS.some((relativePath) => existsSync(path.join(stateRoot, relativePath)))) {
@@ -48,8 +54,45 @@ export async function hydrateState(
     );
   }
 
-  const gitPaths = recordsSource === "git" ? GENERATED_PATHS : NON_RECORD_PATHS;
+  const gitPaths = GENERATED_PATHS.filter(
+    (relativePath) =>
+      (recordsSource === "git" || relativePath !== "records") &&
+      (ledgerSource === "git" || !BLOB_PATHS.includes(relativePath as "ledger" | "assets")),
+  );
   for (const relativePath of gitPaths) copyGeneratedPath(stateRoot, worktreeRoot, relativePath);
+
+  const baseUrl =
+    args.recordsUrl ??
+    env.CLAWSWEEPER_RECORDS_URL ??
+    env.CLAWSWEEPER_STATE_COORDINATOR_URL ??
+    "https://clawsweeper.openclaw.ai";
+  const webhookSecret = env.CLAWSWEEPER_RECORDS_SECRET ?? env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+
+  let blobs: Awaited<ReturnType<typeof materializeStateBlobs>> | undefined;
+  let ledgerFallback: { reason: string; source: "git" } | undefined;
+  if (ledgerSource === "worker") {
+    if (!webhookSecret) {
+      throw new Error("CLAWSWEEPER_RECORDS_SECRET is required for Worker ledger hydration");
+    }
+    try {
+      blobs = await materializeStateBlobs({
+        worktreeRoot,
+        baseUrl,
+        webhookSecret,
+        cacheRoot: env.CLAWSWEEPER_BLOBS_CACHE_DIR,
+        fetch: fetchImpl,
+      });
+    } catch (error) {
+      if (!(error instanceof WorkerBlobsUnavailableError)) throw error;
+      console.error(
+        `[hydrate-state] WORKER LEDGER CUTOVER REFUSED: ${error.message.toUpperCase()}; FALLING BACK TO GIT LEDGER/ASSETS`,
+      );
+      for (const relativePath of BLOB_PATHS) {
+        copyGeneratedPath(stateRoot, worktreeRoot, relativePath);
+      }
+      ledgerFallback = { reason: error.reason, source: "git" };
+    }
+  }
 
   let worker: Awaited<ReturnType<typeof materializeWorkerRecords>> | undefined;
   let recordsFallback: { reason: string; source: "git" } | undefined;
@@ -58,7 +101,6 @@ export async function hydrateState(
       args.recordsRepoSlugs ??
       parseRepoSlugs(env.CLAWSWEEPER_RECORDS_REPO_SLUGS) ??
       discoverRecordRepoSlugs(stateRoot);
-    const webhookSecret = env.CLAWSWEEPER_RECORDS_SECRET ?? env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
     if (repoSlugs.length && !webhookSecret) {
       throw new Error("CLAWSWEEPER_RECORDS_SECRET is required for Worker record hydration");
     }
@@ -66,11 +108,7 @@ export async function hydrateState(
       if (!repoSlugs.length) throw new WorkerSnapshotUnavailableError("snapshot_not_found");
       worker = await materializeWorkerRecords({
         worktreeRoot,
-        baseUrl:
-          args.recordsUrl ??
-          env.CLAWSWEEPER_RECORDS_URL ??
-          env.CLAWSWEEPER_STATE_COORDINATOR_URL ??
-          "https://clawsweeper.openclaw.ai",
+        baseUrl,
         webhookSecret: webhookSecret || "unused-empty-snapshot",
         repoSlugs,
         cacheRoot: env.CLAWSWEEPER_RECORDS_CACHE_DIR,
@@ -94,12 +132,19 @@ export async function hydrateState(
   }
 
   const result = {
-    hydrated: worker || recordsFallback ? [...gitPaths, "records"] : [...gitPaths],
+    hydrated: [
+      ...gitPaths,
+      ...(worker || recordsFallback ? ["records"] : []),
+      ...(blobs || ledgerFallback ? BLOB_PATHS : []),
+    ],
     recordsSource: recordsFallback?.source ?? recordsSource,
     ...(recordsFallback ? { requestedRecordsSource: recordsSource, recordsFallback } : {}),
+    ledgerSource: ledgerFallback?.source ?? ledgerSource,
+    ...(ledgerFallback ? { requestedLedgerSource: ledgerSource, ledgerFallback } : {}),
     source: stateRoot,
     target: worktreeRoot,
     ...(worker ? { worker: worker.repositories, manifest: worker.manifestPath } : {}),
+    ...(blobs ? { blobs } : {}),
   };
   console.log(JSON.stringify(result));
   return result;
@@ -123,6 +168,8 @@ function parseArgs(argv: string[]): Args {
     else if (arg === "--worktree") parsed.worktree = requiredValue(argv, ++index, arg);
     else if (arg === "--records-source") {
       parsed.recordsSource = parseRecordsSource(requiredValue(argv, ++index, arg));
+    } else if (arg === "--ledger-source") {
+      parsed.ledgerSource = parseSource(requiredValue(argv, ++index, arg), arg);
     } else if (arg === "--records-url") parsed.recordsUrl = requiredValue(argv, ++index, arg);
     else if (arg === "--records-repo-slugs") {
       parsed.recordsRepoSlugs = parseRepoSlugs(requiredValue(argv, ++index, arg)) ?? [];
@@ -132,9 +179,13 @@ function parseArgs(argv: string[]): Args {
 }
 
 function parseRecordsSource(value: string | undefined): "git" | "worker" {
+  return parseSource(value, "CLAWSWEEPER_RECORDS_SOURCE");
+}
+
+function parseSource(value: string | undefined, label: string): "git" | "worker" {
   const source = value?.trim() || "git";
   if (source !== "git" && source !== "worker") {
-    throw new Error(`CLAWSWEEPER_RECORDS_SOURCE must be git or worker, received: ${source}`);
+    throw new Error(`${label} must be git or worker, received: ${source}`);
   }
   return source;
 }

--- a/scripts/migrate-state-blobs.ts
+++ b/scripts/migrate-state-blobs.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Cursor-resumable migration of the git state repo's `ledger/v1` and `assets`
+ * trees into R2 through the Worker's `/internal/state/blobs/*` endpoints
+ * (Cloudflare-canonical phase 3). Walks the state checkout, uploads every file
+ * with digest verification, and prints a JSON summary. Idempotent: a repeat run
+ * reports already-uploaded files as unchanged, and a diverging immutable
+ * ledger key fails loudly with a 409.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  STATE_BLOB_TREES,
+  downloadStateBlob,
+  statStateBlob,
+  uploadStateBlob,
+} from "./worker-blobs.ts";
+
+type MigrateArgs = {
+  stateDir?: string;
+  trees?: string[];
+  recordsUrl?: string;
+  cursor?: number;
+  maxFiles?: number;
+  verify?: "multipart" | "all";
+};
+
+export async function migrateStateBlobs(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+) {
+  const args = parseArgs(argv);
+  const stateRoot = path.resolve(args.stateDir ?? env.CLAWSWEEPER_STATE_DIR ?? "clawsweeper-state");
+  if (!existsSync(stateRoot)) throw new Error(`State directory does not exist: ${stateRoot}`);
+  const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
+  if (!webhookSecret) throw new Error("CLAWSWEEPER_WEBHOOK_SECRET is required");
+  const trees = args.trees ?? [...STATE_BLOB_TREES];
+  for (const tree of trees) {
+    if (!STATE_BLOB_TREES.includes(tree as (typeof STATE_BLOB_TREES)[number])) {
+      throw new Error(`Unknown state blob tree: ${tree} (expected ${STATE_BLOB_TREES.join(", ")})`);
+    }
+  }
+  const request = {
+    baseUrl:
+      args.recordsUrl ??
+      env.CLAWSWEEPER_RECORDS_URL ??
+      env.CLAWSWEEPER_STATE_COORDINATOR_URL ??
+      "https://clawsweeper.openclaw.ai",
+    webhookSecret,
+    fetch: fetchImpl,
+  };
+
+  const files = trees.flatMap((tree) => collectTreeFiles(stateRoot, tree)).sort();
+  const cursor = args.cursor ?? 0;
+  if (!Number.isSafeInteger(cursor) || cursor < 0 || cursor > files.length) {
+    throw new Error(`Invalid migration cursor: ${cursor}`);
+  }
+  const maxFiles = args.maxFiles ?? Number.POSITIVE_INFINITY;
+  const selected = files.slice(
+    cursor,
+    maxFiles === Number.POSITIVE_INFINITY ? files.length : cursor + maxFiles,
+  );
+  const verifyMode = args.verify ?? "multipart";
+
+  const summary = {
+    trees,
+    files: files.length,
+    attempted: selected.length,
+    uploaded: 0,
+    unchanged: 0,
+    verified: 0,
+    bytesUploaded: 0,
+    cursor,
+    nextCursor: cursor + selected.length < files.length ? cursor + selected.length : null,
+  };
+  const verifyRoot = mkdtempSync(path.join(tmpdir(), "clawsweeper-blob-verify-"));
+  try {
+    let completed = cursor;
+    for (const blobPath of selected) {
+      const content = readFileSync(path.join(stateRoot, ...blobPath.split("/")));
+      const digest = createHash("sha256").update(content).digest("hex");
+      const existing = await statStateBlob({ ...request, blobPath });
+      if (existing && existing.digest === digest && existing.bytes === content.byteLength) {
+        summary.unchanged += 1;
+      } else {
+        const uploaded = await uploadStateBlob({ ...request, blobPath, content });
+        if (uploaded.unchanged) {
+          summary.unchanged += 1;
+        } else {
+          summary.uploaded += 1;
+          summary.bytesUploaded += content.byteLength;
+        }
+        // Single-shot uploads are digest-verified by the Worker before the
+        // object is written; multipart digests are client-claimed, so read
+        // them back. --verify all forces read-back for every upload.
+        if (!uploaded.unchanged && (uploaded.transport === "multipart" || verifyMode === "all")) {
+          const destination = path.join(verifyRoot, `verify-${summary.verified}`);
+          const downloaded = await downloadStateBlob({
+            ...request,
+            blobPath,
+            destination,
+            expected: { bytes: content.byteLength, digest },
+          });
+          rmSync(destination, { force: true });
+          if (downloaded.digest !== digest) {
+            throw new Error(`Post-upload digest mismatch for ${blobPath}`);
+          }
+          summary.verified += 1;
+        }
+      }
+      completed += 1;
+      console.error(`[state-blob-migration] file=${completed}/${files.length} path=${blobPath}`);
+    }
+  } finally {
+    rmSync(verifyRoot, { force: true, recursive: true });
+  }
+  console.log(JSON.stringify(summary));
+  return summary;
+}
+
+function collectTreeFiles(stateRoot: string, tree: string): string[] {
+  const root = path.join(stateRoot, ...tree.split("/"));
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const walk = (relative: string) => {
+    for (const entry of readdirSync(path.join(stateRoot, ...relative.split("/")), {
+      withFileTypes: true,
+    })) {
+      const child = `${relative}/${entry.name}`;
+      if (entry.isDirectory()) walk(child);
+      else if (entry.isFile()) files.push(child);
+      else throw new Error(`Unsupported state tree entry: ${child}`);
+    }
+  };
+  walk(tree);
+  return files;
+}
+
+function parseArgs(argv: string[]): MigrateArgs {
+  const parsed: MigrateArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--state-dir") parsed.stateDir = requiredValue(argv, ++index, arg);
+    else if (arg === "--trees") {
+      parsed.trees = requiredValue(argv, ++index, arg)
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+    } else if (arg === "--records-url") parsed.recordsUrl = requiredValue(argv, ++index, arg);
+    else if (arg === "--cursor") parsed.cursor = nonNegativeInteger(argv, ++index, arg);
+    else if (arg === "--max-files") parsed.maxFiles = positiveInteger(argv, ++index, arg);
+    else if (arg === "--verify") {
+      const value = requiredValue(argv, ++index, arg);
+      if (value !== "multipart" && value !== "all") {
+        throw new Error("--verify must be multipart or all");
+      }
+      parsed.verify = value;
+    } else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function nonNegativeInteger(argv: string[], index: number, flag: string) {
+  const value = Number(requiredValue(argv, index, flag));
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${flag} must be at least 0`);
+  return value;
+}
+
+function positiveInteger(argv: string[], index: number, flag: string) {
+  const value = Number(requiredValue(argv, index, flag));
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`${flag} must be at least 1`);
+  return value;
+}
+
+function requiredValue(argv: string[], index: number, flag: string) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  await migrateStateBlobs(process.argv.slice(2));
+}

--- a/scripts/worker-blobs.ts
+++ b/scripts/worker-blobs.ts
@@ -1,0 +1,382 @@
+/**
+ * Client helpers for the Worker's R2-backed state blob endpoints
+ * (`/internal/state/blobs/*`): the phase-3 transport for the immutable
+ * `ledger/v1` tree and the mutable `assets` tree. Reuses the signed-request
+ * retry machinery from worker-records.ts.
+ */
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+
+import { WorkerRecordRequestError, signedPost, signedRequest } from "./worker-records.ts";
+
+export const STATE_BLOB_TREES = ["ledger/v1", "assets"] as const;
+export const STATE_BLOB_SINGLE_PUT_MAX_BYTES = 24 * 1024 * 1024;
+export const STATE_BLOB_DOWNLOAD_CHUNK_BYTES = 32 * 1024 * 1024;
+
+export type StateBlobDescriptor = {
+  path: string;
+  bytes: number;
+  digest: string | null;
+  digestVerified: boolean;
+};
+
+export class WorkerBlobsUnavailableError extends Error {
+  readonly reason: "blob_store_unavailable" | "blobs_not_found";
+
+  constructor(reason: "blob_store_unavailable" | "blobs_not_found") {
+    super(reason === "blob_store_unavailable" ? "blob store unavailable" : "no state blobs found");
+    this.name = "WorkerBlobsUnavailableError";
+    this.reason = reason;
+  }
+}
+
+type BlobRequestOptions = {
+  baseUrl: string;
+  webhookSecret: string;
+  fetch?: typeof globalThis.fetch;
+};
+
+export async function uploadStateBlob(
+  options: BlobRequestOptions & {
+    blobPath: string;
+    content: Buffer;
+    // Test seams: production callers use the defaults.
+    singlePutMaxBytes?: number;
+    partBytes?: number;
+  },
+): Promise<{ path: string; bytes: number; digest: string; unchanged: boolean; transport: string }> {
+  const digest = sha256(options.content);
+  const singlePutMaxBytes = options.singlePutMaxBytes ?? STATE_BLOB_SINGLE_PUT_MAX_BYTES;
+  if (options.content.byteLength <= singlePutMaxBytes) {
+    const response = await blobPost<{ unchanged: boolean }>(options, "put", {
+      path: options.blobPath,
+      digest,
+      contentBase64: options.content.toString("base64"),
+    });
+    return {
+      path: options.blobPath,
+      bytes: options.content.byteLength,
+      digest,
+      unchanged: response.unchanged === true,
+      transport: "single",
+    };
+  }
+  const started = await blobPost<{
+    unchanged: boolean;
+    uploadId: string | null;
+    partBytes: number;
+  }>(options, "multipart/start", {
+    path: options.blobPath,
+    digest,
+    bytes: options.content.byteLength,
+  });
+  if (started.unchanged === true || !started.uploadId) {
+    return {
+      path: options.blobPath,
+      bytes: options.content.byteLength,
+      digest,
+      unchanged: true,
+      transport: "multipart",
+    };
+  }
+  const partBytes = options.partBytes ?? started.partBytes;
+  if (!Number.isSafeInteger(partBytes) || partBytes < 1 || partBytes > started.partBytes) {
+    throw new Error(`Worker returned an invalid multipart part size: ${started.partBytes}`);
+  }
+  try {
+    const parts: Array<{ partNumber: number; etag: string }> = [];
+    for (let offset = 0; offset < options.content.byteLength; offset += partBytes) {
+      const chunk = options.content.subarray(
+        offset,
+        Math.min(offset + partBytes, options.content.byteLength),
+      );
+      const uploaded = await blobPost<{ part: { partNumber: number; etag: string } }>(
+        options,
+        "multipart/part",
+        {
+          path: options.blobPath,
+          uploadId: started.uploadId,
+          partNumber: parts.length + 1,
+          contentBase64: Buffer.from(chunk).toString("base64"),
+        },
+      );
+      parts.push(uploaded.part);
+    }
+    await blobPost(options, "multipart/complete", {
+      path: options.blobPath,
+      uploadId: started.uploadId,
+      digest,
+      bytes: options.content.byteLength,
+      parts,
+    });
+  } catch (error) {
+    await blobPost(options, "multipart/abort", {
+      path: options.blobPath,
+      uploadId: started.uploadId,
+    }).catch(() => undefined);
+    throw error;
+  }
+  return {
+    path: options.blobPath,
+    bytes: options.content.byteLength,
+    digest,
+    unchanged: false,
+    transport: "multipart",
+  };
+}
+
+export async function statStateBlob(
+  options: BlobRequestOptions & { blobPath: string },
+): Promise<StateBlobDescriptor | null> {
+  try {
+    const response = await blobPost<{ blob: StateBlobDescriptor }>(options, "stat", {
+      path: options.blobPath,
+    });
+    return validateDescriptor(response.blob);
+  } catch (error) {
+    if (error instanceof WorkerRecordRequestError && error.code === "blob_not_found") return null;
+    throw error;
+  }
+}
+
+export async function listStateBlobs(
+  options: BlobRequestOptions & { prefix: string; pageLimit?: number },
+): Promise<StateBlobDescriptor[]> {
+  const blobs: StateBlobDescriptor[] = [];
+  let cursor: string | null = null;
+  do {
+    const page: { blobs: StateBlobDescriptor[]; nextCursor: string | null } = await blobPost(
+      options,
+      "list",
+      {
+        prefix: options.prefix,
+        ...(cursor ? { cursor } : {}),
+        ...(options.pageLimit ? { limit: options.pageLimit } : {}),
+      },
+    );
+    if (!Array.isArray(page.blobs)) throw new Error("Worker returned an invalid blob list page");
+    for (const blob of page.blobs) blobs.push(validateDescriptor(blob));
+    if (page.nextCursor !== null && typeof page.nextCursor !== "string") {
+      throw new Error("Worker returned an invalid blob list cursor");
+    }
+    if (page.nextCursor !== null && page.nextCursor === cursor) {
+      throw new Error("Worker blob list cursor did not advance");
+    }
+    cursor = page.nextCursor;
+  } while (cursor !== null);
+  return blobs.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export async function downloadStateBlob(
+  options: BlobRequestOptions & {
+    blobPath: string;
+    destination: string;
+    expected?: { bytes: number; digest: string | null };
+  },
+): Promise<{ path: string; bytes: number; digest: string }> {
+  const expected = options.expected ?? (await statStateBlob(options));
+  if (!expected) throw new WorkerBlobsUnavailableError("blobs_not_found");
+  mkdirSync(path.dirname(options.destination), { recursive: true });
+  rmSync(options.destination, { force: true });
+  const descriptor = openSync(options.destination, "wx");
+  const hash = createHash("sha256");
+  let offset = 0;
+  try {
+    while (offset < expected.bytes) {
+      const length = Math.min(STATE_BLOB_DOWNLOAD_CHUNK_BYTES, expected.bytes - offset);
+      const response = await signedRequest({
+        baseUrl: options.baseUrl,
+        path: "/internal/state/blobs/chunk",
+        webhookSecret: options.webhookSecret,
+        body: { path: options.blobPath, offset, length },
+        fetch: options.fetch,
+      });
+      if (!response.ok) {
+        throw await blobResponseError(response);
+      }
+      if (response.status !== 206) {
+        throw new Error(`Worker blob chunk returned status ${response.status}`);
+      }
+      const expectedRange = `bytes ${offset}-${offset + length - 1}/${expected.bytes}`;
+      if (response.headers.get("content-range") !== expectedRange) {
+        throw new Error("Worker blob chunk returned an invalid content range");
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (bytes.byteLength !== length) {
+        throw new Error(
+          `Worker blob chunk length mismatch: expected ${length}, received ${bytes.byteLength}`,
+        );
+      }
+      writeSync(descriptor, bytes);
+      hash.update(bytes);
+      offset += bytes.byteLength;
+    }
+  } finally {
+    closeSync(descriptor);
+  }
+  const digest = hash.digest("hex");
+  if (expected.digest !== null && digest !== expected.digest) {
+    rmSync(options.destination, { force: true });
+    throw new Error(
+      `Worker blob digest mismatch for ${options.blobPath}: expected ${expected.digest}, received ${digest}`,
+    );
+  }
+  return { path: options.blobPath, bytes: offset, digest };
+}
+
+export async function materializeStateBlobs(
+  options: BlobRequestOptions & {
+    worktreeRoot: string;
+    trees?: readonly string[];
+    cacheRoot?: string;
+  },
+) {
+  const trees = options.trees ?? STATE_BLOB_TREES;
+  mkdirSync(options.worktreeRoot, { recursive: true });
+  const blobsByTree = new Map<string, StateBlobDescriptor[]>();
+  let total = 0;
+  for (const tree of trees) {
+    const blobs = await listStateBlobs({ ...options, prefix: `${tree}/` });
+    blobsByTree.set(tree, blobs);
+    total += blobs.length;
+  }
+  // An entirely empty store means the migration has not seeded R2 yet; refuse
+  // the cutover so the caller can fall back to git loudly.
+  if (total === 0) throw new WorkerBlobsUnavailableError("blobs_not_found");
+
+  const cacheRoot = options.cacheRoot
+    ? path.resolve(options.cacheRoot)
+    : path.join(options.worktreeRoot, ".artifacts", "worker-blobs-cache");
+  mkdirSync(cacheRoot, { recursive: true });
+  const stagingRoot = mkdtempSync(path.join(options.worktreeRoot, ".worker-blobs-stage-"));
+  const summary = {
+    blobs: total,
+    bytes: 0,
+    cacheHits: 0,
+    downloads: 0,
+    trees: Object.fromEntries([...blobsByTree].map(([tree, blobs]) => [tree, blobs.length])),
+  };
+  try {
+    for (const [, blobs] of blobsByTree) {
+      for (const blob of blobs) {
+        const destination = path.join(stagingRoot, ...blob.path.split("/"));
+        const cached = blob.digest ? blobCachePath(cacheRoot, blob.digest) : null;
+        if (cached && existsSync(cached)) {
+          mkdirSync(path.dirname(destination), { recursive: true });
+          cpSync(cached, destination);
+          summary.cacheHits += 1;
+        } else {
+          await downloadStateBlob({
+            ...options,
+            blobPath: blob.path,
+            destination,
+            expected: { bytes: blob.bytes, digest: blob.digest },
+          });
+          summary.downloads += 1;
+          if (cached) {
+            mkdirSync(path.dirname(cached), { recursive: true });
+            const temporary = `${cached}.tmp-${process.pid}`;
+            cpSync(destination, temporary);
+            renameSync(temporary, cached);
+          }
+        }
+        summary.bytes += blob.bytes;
+      }
+    }
+    for (const root of new Set(trees.map((tree) => tree.split("/")[0]!))) {
+      const target = path.join(options.worktreeRoot, root);
+      const staged = path.join(stagingRoot, root);
+      rmSync(target, { force: true, recursive: true });
+      if (existsSync(staged)) renameSync(staged, target);
+    }
+  } finally {
+    rmSync(stagingRoot, { force: true, recursive: true });
+  }
+  const manifestPath = path.join(options.worktreeRoot, ".artifacts", "worker-blobs-manifest.json");
+  mkdirSync(path.dirname(manifestPath), { recursive: true });
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify({ schemaVersion: 1, source: "worker", ...summary }, null, 2)}\n`,
+    "utf8",
+  );
+  return { ...summary, manifestPath };
+}
+
+function blobCachePath(cacheRoot: string, digest: string) {
+  return path.join(cacheRoot, digest.slice(0, 2), digest);
+}
+
+async function blobPost<T>(
+  options: BlobRequestOptions,
+  operation: string,
+  body: unknown,
+): Promise<T> {
+  try {
+    return await signedPost<T>({
+      baseUrl: options.baseUrl,
+      path: `/internal/state/blobs/${operation}`,
+      webhookSecret: options.webhookSecret,
+      body,
+      fetch: options.fetch,
+    });
+  } catch (error) {
+    throw mapUnavailable(error);
+  }
+}
+
+async function blobResponseError(response: Response) {
+  const bodyText = await response.text().catch(() => "");
+  let code = String(response.status);
+  try {
+    const value = JSON.parse(bodyText);
+    if (value && typeof value === "object" && "error" in value) code = String(value.error);
+  } catch {
+    // Non-JSON error body; keep the status code.
+  }
+  if (code === "blob_store_unavailable") {
+    return new WorkerBlobsUnavailableError("blob_store_unavailable");
+  }
+  return new Error(`Worker blob request failed (${response.status}): ${code}`);
+}
+
+function mapUnavailable(error: unknown) {
+  if (error instanceof WorkerRecordRequestError && error.code === "blob_store_unavailable") {
+    return new WorkerBlobsUnavailableError("blob_store_unavailable");
+  }
+  return error;
+}
+
+function validateDescriptor(blob: StateBlobDescriptor): StateBlobDescriptor {
+  if (
+    !blob ||
+    typeof blob.path !== "string" ||
+    !blob.path ||
+    !Number.isSafeInteger(blob.bytes) ||
+    blob.bytes < 0 ||
+    (blob.digest !== null && !/^[0-9a-f]{64}$/.test(blob.digest))
+  ) {
+    throw new Error("Worker returned an invalid blob descriptor");
+  }
+  return {
+    path: blob.path,
+    bytes: blob.bytes,
+    digest: blob.digest,
+    digestVerified: blob.digestVerified === true,
+  };
+}
+
+function sha256(content: Buffer) {
+  return createHash("sha256").update(content).digest("hex");
+}

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -72,7 +72,7 @@ export class WorkerSnapshotUnavailableError extends Error {
   }
 }
 
-class WorkerRecordRequestError extends Error {
+export class WorkerRecordRequestError extends Error {
   readonly status: number;
   readonly code: string;
   readonly bodySnippet: string;
@@ -837,7 +837,7 @@ export async function signedPost<T>(options: {
 const SIGNED_REQUEST_MAX_ATTEMPTS = 3;
 const SIGNED_REQUEST_RETRY_BASE_MS = 250;
 
-async function signedRequest(options: {
+export async function signedRequest(options: {
   baseUrl: string;
   path: string;
   webhookSecret: string;

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -48,7 +48,7 @@ test("every generated-state checkout receives the explicit coordinator migration
     }
   }
 
-  assert.equal(setups.length, 30, "new state checkouts must join the repo-wide boundary");
+  assert.equal(setups.length, 31, "new state checkouts must join the repo-wide boundary");
   for (const { file, job, step } of setups) {
     assert.equal(step.with?.["coordinator-enabled"], coordinatorGate, `${file}:${job}`);
     assert.equal(step.with?.["coordinator-url"], coordinatorUrl, `${file}:${job}`);

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -1,0 +1,662 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import worker from "../dashboard/worker.ts";
+import { hydrateState } from "../scripts/hydrate-state.ts";
+import { migrateStateBlobs } from "../scripts/migrate-state-blobs.ts";
+import {
+  WorkerBlobsUnavailableError,
+  downloadStateBlob,
+  listStateBlobs,
+  materializeStateBlobs,
+  statStateBlob,
+  uploadStateBlob,
+} from "../scripts/worker-blobs.ts";
+
+const secret = "state-blob-secret";
+const baseUrl = "https://worker.example";
+const ledgerPath = "ledger/v1/events/2026/07/26/openclaw/openclaw/shard-000.jsonl";
+const assetPath = "assets/social/card.svg";
+
+test("state blob endpoints reject unsigned requests and fail closed without a bucket", async () => {
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const unsigned = await worker.fetch(
+    new Request(`${baseUrl}/internal/state/blobs/stat`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: ledgerPath }),
+    }),
+    env,
+  );
+  assert.equal(unsigned.status, 401);
+  assert.deepEqual(await unsigned.json(), { error: "invalid_signature" });
+
+  const unknownOperation = await worker.fetch(
+    signedBlobRequest("delete", { path: ledgerPath }),
+    env,
+  );
+  assert.equal(unknownOperation.status, 404);
+
+  const bucketless = { CLAWSWEEPER_WEBHOOK_SECRET: secret };
+  const unavailable = await worker.fetch(
+    signedBlobRequest("stat", { path: ledgerPath }),
+    bucketless,
+  );
+  assert.equal(unavailable.status, 503);
+  assert.equal((await unavailable.json()).error, "blob_store_unavailable");
+  await assert.rejects(
+    listStateBlobs({
+      baseUrl,
+      webhookSecret: secret,
+      prefix: "ledger/v1/",
+      fetch: viaWorker(bucketless),
+    }),
+    (error: unknown) =>
+      error instanceof WorkerBlobsUnavailableError && error.reason === "blob_store_unavailable",
+  );
+});
+
+test("single-shot blob uploads verify digests server-side and re-put idempotently", async () => {
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const options = { baseUrl, webhookSecret: secret, fetch: viaWorker(env) };
+  const content = Buffer.from('{"event":"opened"}\n');
+
+  const uploaded = await uploadStateBlob({ ...options, blobPath: ledgerPath, content });
+  assert.deepEqual(uploaded, {
+    path: ledgerPath,
+    bytes: content.byteLength,
+    digest: sha256(content),
+    unchanged: false,
+    transport: "single",
+  });
+  const repeat = await uploadStateBlob({ ...options, blobPath: ledgerPath, content });
+  assert.equal(repeat.unchanged, true);
+
+  const stat = await statStateBlob({ ...options, blobPath: ledgerPath });
+  assert.deepEqual(stat, {
+    path: ledgerPath,
+    bytes: content.byteLength,
+    digest: sha256(content),
+    digestVerified: true,
+  });
+  assert.equal(await statStateBlob({ ...options, blobPath: "ledger/v1/missing.jsonl" }), null);
+
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-blob-download-"));
+  try {
+    const destination = path.join(root, "downloaded.jsonl");
+    const downloaded = await downloadStateBlob({ ...options, blobPath: ledgerPath, destination });
+    assert.equal(downloaded.digest, sha256(content));
+    assert.equal(readFileSync(destination, "utf8"), content.toString("utf8"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  const corrupted = await worker.fetch(
+    signedBlobRequest("put", {
+      path: ledgerPath,
+      digest: "0".repeat(64),
+      contentBase64: content.toString("base64"),
+    }),
+    env,
+  );
+  assert.equal(corrupted.status, 400);
+  assert.equal((await corrupted.json()).error, "blob_digest_mismatch");
+
+  const badPath = await worker.fetch(
+    signedBlobRequest("put", {
+      path: "records/openclaw-openclaw/items/1.md",
+      digest: sha256(content),
+      contentBase64: content.toString("base64"),
+    }),
+    env,
+  );
+  assert.equal(badPath.status, 400);
+  assert.equal((await badPath.json()).error, "invalid_blob_path");
+
+  const traversal = await worker.fetch(
+    signedBlobRequest("put", {
+      path: "ledger/v1/../../records/escape.md",
+      digest: sha256(content),
+      contentBase64: content.toString("base64"),
+    }),
+    env,
+  );
+  assert.equal(traversal.status, 400);
+});
+
+test("ledger keys are create-only while asset keys may overwrite", async () => {
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const options = { baseUrl, webhookSecret: secret, fetch: viaWorker(env) };
+
+  await uploadStateBlob({ ...options, blobPath: ledgerPath, content: Buffer.from("immutable\n") });
+  await assert.rejects(
+    uploadStateBlob({ ...options, blobPath: ledgerPath, content: Buffer.from("different\n") }),
+    /ledger_blob_immutable_conflict/,
+  );
+  const kept = await statStateBlob({ ...options, blobPath: ledgerPath });
+  assert.equal(kept?.digest, sha256(Buffer.from("immutable\n")));
+
+  await uploadStateBlob({ ...options, blobPath: assetPath, content: Buffer.from("<svg one/>") });
+  const replaced = await uploadStateBlob({
+    ...options,
+    blobPath: assetPath,
+    content: Buffer.from("<svg two/>"),
+  });
+  assert.equal(replaced.unchanged, false);
+  const stat = await statStateBlob({ ...options, blobPath: assetPath });
+  assert.equal(stat?.digest, sha256(Buffer.from("<svg two/>")));
+});
+
+test("multipart uploads stream fixed-size parts and enforce immutability at completion", async () => {
+  const bucket = new FakeR2Bucket();
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: bucket };
+  const options = { baseUrl, webhookSecret: secret, fetch: viaWorker(env) };
+  const content = Buffer.from("0123456789abcdefghij");
+
+  const uploaded = await uploadStateBlob({
+    ...options,
+    blobPath: assetPath,
+    content,
+    singlePutMaxBytes: 8,
+    partBytes: 6,
+  });
+  assert.equal(uploaded.transport, "multipart");
+  assert.equal(uploaded.unchanged, false);
+  assert.equal(bucket.uploads.size, 0);
+
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-blob-multipart-"));
+  try {
+    const destination = path.join(root, "multipart.bin");
+    const downloaded = await downloadStateBlob({ ...options, blobPath: assetPath, destination });
+    assert.equal(downloaded.digest, sha256(content));
+    assert.equal(readFileSync(destination).toString("utf8"), content.toString("utf8"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  const repeat = await uploadStateBlob({
+    ...options,
+    blobPath: assetPath,
+    content,
+    singlePutMaxBytes: 8,
+    partBytes: 6,
+  });
+  assert.equal(repeat.unchanged, true);
+
+  // A concurrent single-shot writer lands the immutable key between
+  // multipart/start and multipart/complete: completion must refuse and abort.
+  const ledgerKey = "ledger/v1/import-bindings/events/race.json";
+  const raceContent = Buffer.from("multipart-body-that-loses-the-race");
+  const started = await signedJson(
+    env,
+    "multipart/start",
+    { path: ledgerKey, digest: sha256(raceContent), bytes: raceContent.byteLength },
+    201,
+  );
+  const part = await signedJson(env, "multipart/part", {
+    path: ledgerKey,
+    uploadId: started.uploadId,
+    partNumber: 1,
+    contentBase64: raceContent.toString("base64"),
+  });
+  await uploadStateBlob({ ...options, blobPath: ledgerKey, content: Buffer.from("winner\n") });
+  const conflicted = await worker.fetch(
+    signedBlobRequest("multipart/complete", {
+      path: ledgerKey,
+      uploadId: started.uploadId,
+      digest: sha256(raceContent),
+      bytes: raceContent.byteLength,
+      parts: [part.part],
+    }),
+    env,
+  );
+  assert.equal(conflicted.status, 409);
+  assert.equal((await conflicted.json()).error, "ledger_blob_immutable_conflict");
+  assert.equal(bucket.uploads.size, 0);
+  const winner = await statStateBlob({ ...options, blobPath: ledgerKey });
+  assert.equal(winner?.digest, sha256(Buffer.from("winner\n")));
+
+  const staleUpload = await worker.fetch(
+    signedBlobRequest("multipart/part", {
+      path: assetPath,
+      uploadId: "upload-does-not-exist",
+      partNumber: 1,
+      contentBase64: content.toString("base64"),
+    }),
+    env,
+  );
+  assert.equal(staleUpload.status, 400);
+  assert.equal((await staleUpload.json()).error, "invalid_blob_upload");
+});
+
+test("chunked downloads retry transient 5xx responses and reject invalid ranges", async () => {
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const workerFetch = viaWorker(env);
+  const options = { baseUrl, webhookSecret: secret, fetch: workerFetch };
+  const content = Buffer.from("retryable ledger shard\n");
+  await uploadStateBlob({ ...options, blobPath: ledgerPath, content });
+
+  let failuresLeft = 2;
+  const flaky: typeof globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/internal/state/blobs/chunk") && failuresLeft > 0) {
+      failuresLeft -= 1;
+      return new Response("edge 502", { status: 502 });
+    }
+    return workerFetch(input, init);
+  };
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-blob-retry-"));
+  try {
+    const downloaded = await downloadStateBlob({
+      baseUrl,
+      webhookSecret: secret,
+      fetch: flaky,
+      blobPath: ledgerPath,
+      destination: path.join(root, "retried.jsonl"),
+    });
+    assert.equal(downloaded.digest, sha256(content));
+    assert.equal(failuresLeft, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  const pastEnd = await worker.fetch(
+    signedBlobRequest("chunk", { path: ledgerPath, offset: content.byteLength, length: 1 }),
+    env,
+  );
+  assert.equal(pastEnd.status, 416);
+  const zeroLength = await worker.fetch(
+    signedBlobRequest("chunk", { path: ledgerPath, offset: 0, length: 0 }),
+    env,
+  );
+  assert.equal(zeroLength.status, 400);
+});
+
+test("blob listing pages with cursors and validates prefixes", async () => {
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const options = { baseUrl, webhookSecret: secret, fetch: viaWorker(env) };
+  const paths = [
+    "ledger/v1/events/2026/07/26/openclaw/openclaw/a.jsonl",
+    "ledger/v1/events/2026/07/26/openclaw/openclaw/b.jsonl",
+    "ledger/v1/import-bindings/events/c.json",
+  ];
+  for (const blobPath of paths) {
+    await uploadStateBlob({ ...options, blobPath, content: Buffer.from(blobPath) });
+  }
+  await uploadStateBlob({ ...options, blobPath: assetPath, content: Buffer.from("asset") });
+
+  const listed = await listStateBlobs({ ...options, prefix: "ledger/v1/", pageLimit: 1 });
+  assert.deepEqual(
+    listed.map((blob) => blob.path),
+    paths,
+  );
+  const assets = await listStateBlobs({ ...options, prefix: "assets" });
+  assert.deepEqual(
+    assets.map((blob) => blob.path),
+    [assetPath],
+  );
+
+  const invalidPrefix = await worker.fetch(signedBlobRequest("list", { prefix: "records/" }), env);
+  assert.equal(invalidPrefix.status, 400);
+  assert.equal((await invalidPrefix.json()).error, "invalid_blob_prefix");
+});
+
+test("state blob migration is cursor-resumable, idempotent, and loud on ledger divergence", async () => {
+  const fixture = createStateFixture();
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const fetchImpl = viaWorker(env);
+  const processEnv = { CLAWSWEEPER_WEBHOOK_SECRET: secret, CLAWSWEEPER_RECORDS_URL: baseUrl };
+  const migrate = (argv: string[]) =>
+    migrateStateBlobs(["--state-dir", fixture.stateRoot, ...argv], processEnv, fetchImpl);
+  try {
+    const bounded = await migrate(["--max-files", "1"]);
+    assert.equal(bounded.attempted, 1);
+    assert.equal(bounded.uploaded, 1);
+    assert.equal(bounded.nextCursor, 1);
+
+    const resumed = await migrate(["--cursor", "1"]);
+    assert.equal(resumed.uploaded, fixture.blobFiles.length - 1);
+    assert.equal(resumed.nextCursor, null);
+
+    const repeat = await migrate([]);
+    assert.equal(repeat.uploaded, 0);
+    assert.equal(repeat.unchanged, fixture.blobFiles.length);
+    assert.equal(repeat.files, fixture.blobFiles.length);
+
+    const options = { baseUrl, webhookSecret: secret, fetch: fetchImpl };
+    for (const blobPath of fixture.blobFiles) {
+      const stat = await statStateBlob({ ...options, blobPath });
+      assert.equal(stat?.digest, sha256(readFileSync(path.join(fixture.stateRoot, blobPath))));
+    }
+
+    writeFileSync(
+      path.join(fixture.stateRoot, fixture.ledgerFiles[0]!),
+      "locally rewritten history\n",
+      "utf8",
+    );
+    await assert.rejects(migrate([]), /ledger_blob_immutable_conflict/);
+
+    await assert.rejects(migrate(["--trees", "ledger"]), /Unknown state blob tree/);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("hydrate-state defaults ledger hydration to git and never calls the worker", async () => {
+  const fixture = createStateFixture();
+  const target = path.join(fixture.root, "git-target");
+  try {
+    const result = await hydrateState(
+      ["--state-dir", fixture.stateRoot, "--worktree", target],
+      {},
+      async () => {
+        throw new Error("unexpected worker fetch in git mode");
+      },
+    );
+    assert.equal(result.ledgerSource, "git");
+    assert.equal(result.recordsSource, "git");
+    for (const blobPath of fixture.blobFiles) {
+      assert.equal(
+        readFileSync(path.join(target, blobPath), "utf8"),
+        readFileSync(path.join(fixture.stateRoot, blobPath), "utf8"),
+      );
+    }
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("hydrate-state CLAWSWEEPER_LEDGER_SOURCE=worker materializes ledger/assets from R2 with a warm cache", async () => {
+  const fixture = createStateFixture();
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const fetchImpl = viaWorker(env);
+  const options = { baseUrl, webhookSecret: secret, fetch: fetchImpl };
+  const cacheRoot = path.join(fixture.root, "blob-cache");
+  try {
+    // Seed the worker store with content that differs from the git checkout to
+    // prove which source the hydrator used.
+    for (const blobPath of fixture.blobFiles) {
+      await uploadStateBlob({
+        ...options,
+        blobPath,
+        content: Buffer.from(`worker:${blobPath}\n`),
+      });
+    }
+    const coldTarget = path.join(fixture.root, "worker-cold");
+    const cold = await hydrateState(
+      ["--state-dir", fixture.stateRoot, "--worktree", coldTarget, "--records-url", baseUrl],
+      {
+        CLAWSWEEPER_LEDGER_SOURCE: "worker",
+        CLAWSWEEPER_WEBHOOK_SECRET: secret,
+        CLAWSWEEPER_BLOBS_CACHE_DIR: cacheRoot,
+      },
+      fetchImpl,
+    );
+    assert.equal(cold.ledgerSource, "worker");
+    assert.equal(cold.blobs?.blobs, fixture.blobFiles.length);
+    assert.equal(cold.blobs?.downloads, fixture.blobFiles.length);
+    assert.ok(cold.hydrated.includes("ledger"));
+    for (const blobPath of fixture.blobFiles) {
+      assert.equal(readFileSync(path.join(coldTarget, blobPath), "utf8"), `worker:${blobPath}\n`);
+    }
+    assert.equal(readFileSync(path.join(coldTarget, "jobs", "fixture.json"), "utf8"), "{}\n");
+    const manifest = JSON.parse(
+      readFileSync(path.join(coldTarget, ".artifacts", "worker-blobs-manifest.json"), "utf8"),
+    );
+    assert.equal(manifest.source, "worker");
+
+    const warmTarget = path.join(fixture.root, "worker-warm");
+    const warm = await hydrateState(
+      ["--state-dir", fixture.stateRoot, "--worktree", warmTarget, "--records-url", baseUrl],
+      {
+        CLAWSWEEPER_LEDGER_SOURCE: "worker",
+        CLAWSWEEPER_WEBHOOK_SECRET: secret,
+        CLAWSWEEPER_BLOBS_CACHE_DIR: cacheRoot,
+      },
+      fetchImpl,
+    );
+    assert.equal(warm.blobs?.cacheHits, fixture.blobFiles.length);
+    assert.equal(warm.blobs?.downloads, 0);
+
+    await assert.rejects(
+      hydrateState(
+        ["--state-dir", fixture.stateRoot, "--worktree", path.join(fixture.root, "no-secret")],
+        { CLAWSWEEPER_LEDGER_SOURCE: "worker" },
+        fetchImpl,
+      ),
+      /CLAWSWEEPER_RECORDS_SECRET is required for Worker ledger hydration/,
+    );
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("hydrate-state refuses the ledger cutover loudly and falls back to git", async () => {
+  const fixture = createStateFixture();
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...values: unknown[]) => errors.push(values.join(" "));
+  try {
+    // Bucket bound but empty: migration has not seeded R2 yet.
+    const emptyEnv = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+    const target = path.join(fixture.root, "fallback-target");
+    const result = await hydrateState(
+      ["--state-dir", fixture.stateRoot, "--worktree", target, "--records-url", baseUrl],
+      { CLAWSWEEPER_LEDGER_SOURCE: "worker", CLAWSWEEPER_WEBHOOK_SECRET: secret },
+      viaWorker(emptyEnv),
+    );
+    assert.equal(result.ledgerSource, "git");
+    assert.equal(result.requestedLedgerSource, "worker");
+    assert.equal(result.ledgerFallback?.reason, "blobs_not_found");
+    assert.match(errors.join("\n"), /WORKER LEDGER CUTOVER REFUSED.*FALLING BACK TO GIT/);
+    for (const blobPath of fixture.blobFiles) {
+      assert.equal(
+        readFileSync(path.join(target, blobPath), "utf8"),
+        readFileSync(path.join(fixture.stateRoot, blobPath), "utf8"),
+      );
+    }
+
+    const bucketlessTarget = path.join(fixture.root, "bucketless-target");
+    const bucketless = await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        bucketlessTarget,
+        "--records-url",
+        baseUrl,
+        "--ledger-source",
+        "worker",
+      ],
+      { CLAWSWEEPER_WEBHOOK_SECRET: secret },
+      viaWorker({ CLAWSWEEPER_WEBHOOK_SECRET: secret }),
+    );
+    assert.equal(bucketless.ledgerFallback?.reason, "blob_store_unavailable");
+  } finally {
+    console.error = originalError;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("materialize refuses partial trees only when the whole store is empty", async () => {
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const options = { baseUrl, webhookSecret: secret, fetch: viaWorker(env) };
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-blob-partial-"));
+  try {
+    // Assets seeded, ledger empty: the store is live, so materialize proceeds
+    // and produces only the assets tree.
+    await uploadStateBlob({ ...options, blobPath: assetPath, content: Buffer.from("asset") });
+    const summary = await materializeStateBlobs({ ...options, worktreeRoot: root });
+    assert.deepEqual(summary.trees, { "ledger/v1": 0, assets: 1 });
+    assert.equal(readFileSync(path.join(root, assetPath), "utf8"), "asset");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createStateFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-state-blobs-test-"));
+  const stateRoot = path.join(root, "state");
+  const ledgerFiles = [
+    "ledger/v1/events/2026/07/25/openclaw/openclaw/shard-000.jsonl",
+    "ledger/v1/import-bindings/producer-runs/" + "a".repeat(64) + ".json",
+  ];
+  const assetFiles = ["assets/social/card.svg", "assets/dashboards/summary.json"];
+  for (const file of [...ledgerFiles, ...assetFiles]) {
+    write(path.join(stateRoot, ...file.split("/")), `git:${file}\n`);
+  }
+  write(path.join(stateRoot, "jobs", "fixture.json"), "{}\n");
+  write(
+    path.join(stateRoot, "records", "openclaw-openclaw", "items", "1.md"),
+    "---\nnumber: 1\n---\nrecord\n",
+  );
+  return {
+    root,
+    stateRoot,
+    ledgerFiles,
+    assetFiles,
+    blobFiles: [...ledgerFiles, ...assetFiles].sort(),
+  };
+}
+
+function viaWorker(env: Record<string, unknown>): typeof globalThis.fetch {
+  return async (input, init) => worker.fetch(new Request(String(input), init), env);
+}
+
+function signedBlobRequest(operation: string, payload: unknown) {
+  const body = JSON.stringify(payload);
+  return new Request(`${baseUrl}/internal/state/blobs/${operation}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+    },
+    body,
+  });
+}
+
+async function signedJson(
+  env: Record<string, unknown>,
+  operation: string,
+  payload: unknown,
+  expectedStatus = 200,
+) {
+  const response = await worker.fetch(signedBlobRequest(operation, payload), env);
+  assert.equal(response.status, expectedStatus);
+  return response.json();
+}
+
+function sha256(content: Buffer) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function write(file: string, content: string) {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content, "utf8");
+}
+
+class FakeR2Bucket {
+  readonly objects = new Map<
+    string,
+    { bytes: Uint8Array; customMetadata: Record<string, string> }
+  >();
+  readonly uploads = new Map<
+    string,
+    { key: string; parts: Map<number, Uint8Array>; customMetadata: Record<string, string> }
+  >();
+  private uploadCounter = 0;
+
+  async head(key: string) {
+    const object = this.objects.get(key);
+    return object ? describe(key, object) : null;
+  }
+
+  async get(key: string, options?: { range?: { offset: number; length: number } }) {
+    const object = this.objects.get(key);
+    if (!object) return null;
+    const offset = options?.range?.offset ?? 0;
+    const length = options?.range?.length ?? object.bytes.byteLength - offset;
+    const body = new Response(object.bytes.slice(offset, offset + length)).body;
+    assert.ok(body);
+    return { ...describe(key, object), body };
+  }
+
+  async put(key: string, value: Uint8Array, options?: { customMetadata?: Record<string, string> }) {
+    this.objects.set(key, {
+      bytes: new Uint8Array(value).slice(),
+      customMetadata: options?.customMetadata ?? {},
+    });
+  }
+
+  async list(options?: { prefix?: string; cursor?: string; limit?: number }) {
+    const prefix = options?.prefix ?? "";
+    const limit = options?.limit ?? 1000;
+    const keys = [...this.objects.keys()].filter((key) => key.startsWith(prefix)).sort();
+    const start = options?.cursor ? Number(options.cursor) : 0;
+    const page = keys.slice(start, start + limit);
+    const truncated = start + page.length < keys.length;
+    return {
+      objects: page.map((key) => describe(key, this.objects.get(key)!)),
+      truncated,
+      ...(truncated ? { cursor: String(start + page.length) } : {}),
+    };
+  }
+
+  async createMultipartUpload(key: string, options?: { customMetadata?: Record<string, string> }) {
+    this.uploadCounter += 1;
+    const uploadId = `upload-${this.uploadCounter}`;
+    this.uploads.set(uploadId, {
+      key,
+      parts: new Map(),
+      customMetadata: options?.customMetadata ?? {},
+    });
+    return this.resumeMultipartUpload(key, uploadId);
+  }
+
+  resumeMultipartUpload(key: string, uploadId: string) {
+    const requireUpload = () => {
+      const upload = this.uploads.get(uploadId);
+      if (!upload || upload.key !== key) throw new Error(`unknown multipart upload: ${uploadId}`);
+      return upload;
+    };
+    return {
+      uploadId,
+      uploadPart: async (partNumber: number, value: Uint8Array) => {
+        requireUpload().parts.set(partNumber, new Uint8Array(value).slice());
+        return { partNumber, etag: `etag-${uploadId}-${partNumber}` };
+      },
+      complete: async (parts: Array<{ partNumber: number; etag: string }>) => {
+        const upload = requireUpload();
+        const selected = parts.map((part) => {
+          const bytes = upload.parts.get(part.partNumber);
+          if (!bytes || `etag-${uploadId}-${part.partNumber}` !== part.etag) {
+            throw new Error(`missing multipart part: ${part.partNumber}`);
+          }
+          return bytes;
+        });
+        const total = new Uint8Array(selected.reduce((sum, part) => sum + part.byteLength, 0));
+        let offset = 0;
+        for (const part of selected) {
+          total.set(part, offset);
+          offset += part.byteLength;
+        }
+        this.objects.set(key, { bytes: total, customMetadata: upload.customMetadata });
+        this.uploads.delete(uploadId);
+        return { key, size: total.byteLength };
+      },
+      abort: async () => {
+        this.uploads.delete(uploadId);
+      },
+    };
+  }
+}
+
+function describe(
+  key: string,
+  object: { bytes: Uint8Array; customMetadata: Record<string, string> },
+) {
+  return { key, size: object.bytes.byteLength, customMetadata: object.customMetadata };
+}


### PR DESCRIPTION
Phase 3 foundation of the Cloudflare-canonical migration: move the last two git-state consumers — the immutable `ledger/v1` tree (~315 MB) and the `assets` tree (~52 MB) — onto R2 via the Worker, so the git state lane can be deleted in a follow-up. This PR adds the transport, migration tooling, and an opt-in dual-read; **defaults stay git and no git-lane code is removed**.

## Worker endpoints (`dashboard/state-blobs.ts`, routed in `dashboard/worker.ts`)

New HMAC-authenticated routes under `/internal/state/blobs/*`, using the same `CLAWSWEEPER_WEBHOOK_SECRET` signature scheme as the existing `/internal/state/records/*` routes, backed by the existing `STATE_SNAPSHOTS` R2 binding (bucket `clawsweeper-state-snapshots`) under the distinct key prefixes `ledger/v1/...` and `assets/...` (phase-2 snapshots live under `<repoSlug>/<revision>/...`, so no collisions):

- `put` — single-shot base64 upload (≤24 MiB) with **server-side sha256 verification** before the object is written.
- `multipart/start|part|complete|abort` — chunked upload for larger blobs (8 MiB parts); the claimed digest is stored as client-verified metadata and read back by the migration tooling.
- `stat`, `list` (cursor-paged, digests included), and `chunk` — 32 MiB range-proxied downloads mirroring the phase-2 snapshot chunk endpoint (R2 bindings cannot presign).
- **Immutability**: `ledger/...` keys are create-only — a PUT over an existing key with a different digest is a 409 `ledger_blob_immutable_conflict`; a same-digest PUT is an idempotent no-op. `assets/...` may overwrite. The multipart path re-checks at completion and aborts on conflict.

## Client (`scripts/worker-blobs.ts`)

Upload/download/list/materialize helpers on the existing `signedPost`/`signedRequest` retry machinery from `scripts/worker-records.ts` (bounded 5xx/network retries). `materializeStateBlobs` rebuilds the `ledger/` + `assets/` trees into a worktree with a content-addressed digest cache (`CLAWSWEEPER_BLOBS_CACHE_DIR`), staged + atomically renamed, and refuses cutover when the store is empty or unbound.

## Migration (`scripts/migrate-state-blobs.ts` + `.github/workflows/migrate-state-blobs.yml`)

Cursor-resumable dispatch workflow (patterned on `backfill-worker-records.yml`): sparse-checks-out `ledger`/`assets` from the state repo and uploads every file with digest verification (single-shot uploads are server-verified; multipart uploads are re-downloaded and hashed — `--verify all` re-downloads everything). Idempotent: re-runs report `unchanged`; a locally diverged immutable ledger file fails loudly with the 409. Prints a JSON summary (`files/uploaded/unchanged/verified/bytesUploaded/cursor/nextCursor`).

Usage: dispatch **Migrate state blobs to R2** with `trees=both|ledger|assets`, optional `cursor`/`max_files` to resume a bounded run.

## Dual-read shim (`scripts/hydrate-state.ts`)

`CLAWSWEEPER_LEDGER_SOURCE=worker` (or `--ledger-source worker`) hydrates `ledger/` + `assets/` from R2 instead of the git checkout, with a loud `WORKER LEDGER CUTOVER REFUSED … FALLING BACK TO GIT` fallback when the blob store is unbound or unseeded. **Deny-by-default: unset ⇒ git**, byte-identical to today for every existing caller.

## Tests

`test/worker-state-blobs.test.ts` drives the real Worker `fetch` handler end-to-end through the client helpers against an in-memory R2 fake: endpoint auth + fail-closed 503, server-side digest rejection, ledger immutability (incl. the start/complete multipart race), asset overwrite, multipart round-trip, chunk range validation, client retry on transient 502s, cursor-paged listing, migration idempotency/resume/divergence, and hydrate dual-read selection incl. both fallback reasons.

## Not in this PR / follow-ups

- **Worker deploy is required** before the endpoints exist in production (`wrangler deploy` from `dashboard/`).
- Run the migration workflow to seed R2, then flip `CLAWSWEEPER_LEDGER_SOURCE=worker` per consumer.
- Ledger/asset **writer** paths still publish via git; pointing them at the blob endpoints, deleting the git lane (`git-publish.ts` lease machinery, publish workflows), and freezing the state repo remain the phase-3 cutover work.
