### PR TITLE
fix(repair): cut over durable cluster intake publication (rework of #873)

### DIFF
--- a/.github/actions/create-state-token/action.yml
+++ b/.github/actions/create-state-token/action.yml
@@ -15,6 +15,14 @@ inputs:
     description: State repository name.
     required: false
     default: clawsweeper-state
+  contents-permission:
+    description: Contents permission for the state repository token (read or write).
+    required: false
+    default: write
+  actions-permission:
+    description: Actions permission for the state repository token (read or write).
+    required: false
+    default: write
 outputs:
   token:
     description: GitHub App installation token for the state repository.
@@ -30,5 +38,5 @@ runs:
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repository }}
-        permission-actions: write
-        permission-contents: write
+        permission-actions: ${{ inputs.actions-permission }}
+        permission-contents: ${{ inputs.contents-permission }}

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -45,8 +45,7 @@ on:
     - cron: "8 8 * * *"
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -75,7 +74,7 @@ jobs:
           owner: openclaw
           repositories: clawsweeper
           permission-actions: write
-          permission-contents: write
+          permission-contents: read
 
       - name: Create gitcrawl-store token
         id: store-token
@@ -135,12 +134,17 @@ jobs:
         with:
           build-script: build:repair
 
+      # Intake never publishes state directly: acceptance goes through the
+      # authenticated durable append and the state materializer owns every
+      # write. The hydration credential is read-only and never persisted.
       - name: Create state token
         id: state-token
         uses: ./.github/actions/create-state-token
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          contents-permission: read
+          actions-permission: read
 
       - uses: ./.github/actions/setup-state
         with:
@@ -148,6 +152,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
+          persist-credentials: "false"
 
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -93,18 +93,36 @@ jobs:
           ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "$ALLOWED_OWNER" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+          # CLAWSWEEPER_ALLOWED_OWNER is a comma- or whitespace-separated owner
+          # list (issue #604; allowedRepairOwners in src/repair/lib.ts).
+          owners_normalized="$(printf '%s' "$ALLOWED_OWNER" | tr ',' ' ' | tr -s '[:space:]' ' ')"
+          read -r -a allowed_owners <<< "$owners_normalized"
+          if [ "${#allowed_owners[@]}" -eq 0 ]; then
             echo "Invalid allowed repository owner" >&2
             exit 2
           fi
+          for allowed_owner in "${allowed_owners[@]}"; do
+            if ! printf '%s' "$allowed_owner" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+              echo "Invalid allowed repository owner" >&2
+              exit 2
+            fi
+          done
           if ! printf '%s' "$TARGET_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
             echo "Invalid target repository" >&2
             exit 2
           fi
           target_owner="${TARGET_REPO%%/*}"
           target_name="${TARGET_REPO#*/}"
-          if [ "$target_owner" != "$ALLOWED_OWNER" ]; then
-            echo "Target repository must be owned by ${ALLOWED_OWNER}" >&2
+          target_owner_lower="$(printf '%s' "$target_owner" | tr '[:upper:]' '[:lower:]')"
+          owner_allowed=0
+          for allowed_owner in "${allowed_owners[@]}"; do
+            if [ "$target_owner_lower" = "$(printf '%s' "$allowed_owner" | tr '[:upper:]' '[:lower:]')" ]; then
+              owner_allowed=1
+              break
+            fi
+          done
+          if [ "$owner_allowed" != "1" ]; then
+            echo "Target repository must be owned by one of: ${ALLOWED_OWNER}" >&2
             exit 2
           fi
           {
@@ -365,8 +383,11 @@ jobs:
           set -euo pipefail
           pnpm run repair:publish-cluster-intake -- .artifacts/cluster-repair-intake/intent.json
 
+      # The wake targets the intake's own ref so intake and materializer run
+      # the same revision (identical to `main` for scheduled production runs;
+      # a branch dispatch proves the branch end-to-end before merge).
       - name: Request immediate state materialization
         if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
           GH_TOKEN: ${{ steps.central-token.outputs.token }}
-        run: gh workflow run state-materializer.yml --ref main -f intake_priority=true
+        run: gh workflow run state-materializer.yml --ref "$GITHUB_REF_NAME" -f intake_priority=true

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -87,18 +87,32 @@ jobs:
           repositories: gitcrawl-store
           permission-contents: read
 
-      - name: Resolve target owner
+      - name: Resolve target repository
         id: target
         env:
           TARGET_REPO: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+          ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
         run: |
           set -euo pipefail
-          owner="${TARGET_REPO%%/*}"
-          if ! printf '%s' "$owner" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
-            echo "Invalid target repository: $TARGET_REPO" >&2
-            exit 1
+          if ! printf '%s' "$ALLOWED_OWNER" | grep -Eq '^[A-Za-z0-9_.-]+$'; then
+            echo "Invalid allowed repository owner" >&2
+            exit 2
           fi
-          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid target repository" >&2
+            exit 2
+          fi
+          target_owner="${TARGET_REPO%%/*}"
+          target_name="${TARGET_REPO#*/}"
+          if [ "$target_owner" != "$ALLOWED_OWNER" ]; then
+            echo "Target repository must be owned by ${ALLOWED_OWNER}" >&2
+            exit 2
+          fi
+          {
+            printf 'owner=%s\n' "$target_owner"
+            printf 'name=%s\n' "$target_name"
+            printf 'full_name=%s/%s\n' "$target_owner" "$target_name"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create target read token
         id: target-token
@@ -107,7 +121,7 @@ jobs:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
-          permission-contents: read
+          repositories: ${{ steps.target.outputs.name }}
           permission-issues: read
           permission-pull-requests: read
 
@@ -154,7 +168,7 @@ jobs:
         env:
           ENABLED: ${{ github.event.inputs.enabled || '1' }}
           SCHEDULE_ENABLED: ${{ vars.CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED == '1' && '1' || '0' }}
-          TARGET_REPO: ${{ github.event.inputs.target_repo || vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+          TARGET_REPO: ${{ steps.target.outputs.full_name }}
           FORCE_STORE: ${{ github.event.inputs.force_store == 'true' && '1' || '0' }}
         run: |
           set -euo pipefail
@@ -277,19 +291,20 @@ jobs:
             fi
           } >> "$GITHUB_OUTPUT"
 
-      - name: Record intake ledger
+      - name: Build durable intake intent
         if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
-          LEDGER_PATH: ${{ steps.prepare.outputs.ledger_path }}
           TARGET_REPO: ${{ steps.prepare.outputs.target_repo }}
           STORE_SHA: ${{ steps.prepare.outputs.store_sha }}
           EXPORTED_AT: ${{ steps.prepare.outputs.exported_at }}
           MANIFEST_PATH: ${{ steps.prepare.outputs.manifest_path }}
-          GENERATED_COUNT: ${{ steps.select.outputs.count || '0' }}
+          WORKER_RUNNER: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+          MODEL: internal
         run: |
           set -euo pipefail
-          mkdir -p "$(dirname "$LEDGER_PATH")"
           node <<'NODE'
+          const crypto = require("crypto");
           const fs = require("fs");
           const generatedPath = ".artifacts/cluster-repair-intake/generated-paths.txt";
           const selectionPath = ".artifacts/cluster-repair-intake/selection-report.json";
@@ -300,48 +315,53 @@ jobs:
           const selection = fs.existsSync(selectionPath)
             ? JSON.parse(fs.readFileSync(selectionPath, "utf8"))
             : { evaluated: 0, rejected: 0, selected: 0, reason_counts: {}, decision: null, assessments: [] };
-          const ledger = {
-            schema: "clawsweeper-cluster-repair-intake-v1",
+          const repoSlug = process.env.TARGET_REPO.replace("/", "-");
+          const jobs = generated.map((jobPath) => {
+            const match = /\/gitcrawl-(\d+)-/.exec(jobPath);
+            if (!match) throw new Error(`Generated job omitted gitcrawl cluster ID: ${jobPath}`);
+            const content = fs.readFileSync(jobPath, "utf8");
+            const clusterId = Number(match[1]);
+            return {
+              cluster_id: clusterId,
+              path: jobPath,
+              content,
+              digest: crypto.createHash("sha256").update(content).digest("hex"),
+              dispatch_key: `cluster-intake:${repoSlug}:${clusterId}`,
+            };
+          });
+          const intent = {
+            schema: "clawsweeper-cluster-intake-intent-v1",
             target_repo: process.env.TARGET_REPO,
-            last_processed_store_sha256: process.env.STORE_SHA,
-            last_processed_store_exported_at: process.env.EXPORTED_AT,
+            repo_slug: repoSlug,
+            store_sha256: process.env.STORE_SHA,
+            store_exported_at: process.env.EXPORTED_AT,
             manifest_path: process.env.MANIFEST_PATH,
-            generated_count: Number(process.env.GENERATED_COUNT || generated.length || 0),
-            generated_jobs: generated,
-            selector: selection,
             run_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
-            updated_at: new Date().toISOString(),
+            accepted_at: new Date().toISOString(),
+            runner: process.env.WORKER_RUNNER,
+            execution_runner: process.env.EXECUTION_RUNNER,
+            model: process.env.MODEL,
+            selector_summary: {
+              evaluated: Number(selection.evaluated || 0),
+              rejected: Number(selection.rejected || 0),
+              reason_counts: selection.reason_counts || {},
+            },
+            jobs,
           };
-          fs.writeFileSync(process.env.LEDGER_PATH, `${JSON.stringify(ledger, null, 2)}\n`);
+          fs.writeFileSync(".artifacts/cluster-repair-intake/intent.json", `${JSON.stringify(intent, null, 2)}\n`);
           NODE
 
-      - name: Publish intake jobs and ledger
+      - name: Durably accept cluster intake
         if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
-          pnpm run repair:publish-main -- \
-            --message "chore: record cluster repair intake" \
-            --path jobs \
-            --path results/cluster-repair-intake \
-            --max-attempts 12 \
-            --push-attempts 4
+          pnpm run repair:publish-cluster-intake -- .artifacts/cluster-repair-intake/intent.json
 
-      - name: Dispatch imported cluster repair
-        if: ${{ steps.select.outputs.should_dispatch == 'true' }}
+      - name: Request immediate state materialization
+        if: ${{ steps.prepare.outputs.should_import == 'true' }}
         env:
           GH_TOKEN: ${{ steps.central-token.outputs.token }}
-          RUNNER: ${{ github.event.inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-          EXECUTION_RUNNER: ${{ github.event.inputs.execution_runner || vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-          MODEL: internal
-        run: |
-          set -euo pipefail
-          mapfile -t jobs < .artifacts/cluster-repair-intake/generated-paths.txt
-          pnpm run repair:dispatch -- "${jobs[@]}" \
-            --mode autonomous \
-            --wait-for-capacity \
-            --runner "$RUNNER" \
-            --execution-runner "$EXECUTION_RUNNER" \
-            --model "$MODEL" \
-            --ref main
+        run: gh workflow run state-materializer.yml --ref main -f intake_priority=true

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: openclaw
+          repositories: clawsweeper
           permission-actions: read
           permission-contents: write
           permission-pull-requests: read
@@ -51,10 +52,22 @@ jobs:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
 
+      - name: Create target read token
+        id: target-read-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: openclaw
+          permission-contents: read
+          permission-pull-requests: read
+
       - uses: ./.github/actions/setup-state
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          coordinator-class: publication_batch
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: actions/setup-node@v6
@@ -145,7 +158,7 @@ jobs:
       - name: Publish result ledger
         if: ${{ steps.download.outputs.has_artifacts == '1' }}
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -195,11 +208,23 @@ jobs:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
+          paths_file=".artifacts/cluster-result-state-paths.txt"
+          mkdir -p .artifacts
+          pnpm run repair:state-delta-paths -- \
+            --state-root "$CLAWSWEEPER_STATE_DIR" \
+            --out "$paths_file" \
+            --root results \
+            --root jobs/openclaw \
+            --root repair-apply-report.json \
+            --root notifications
+          if [ ! -s "$paths_file" ]; then
+            echo "No cluster result state changed."
+            exit 0
+          fi
+          publish_args=()
+          while IFS= read -r path; do publish_args+=(--path "$path"); done < "$paths_file"
           pnpm run repair:publish-main -- \
             --message "chore: publish cluster result" \
-            --path results \
-            --path jobs/openclaw/closed \
-            --path repair-apply-report.json \
-            --path notifications \
+            "${publish_args[@]}" \
             --max-attempts 12 \
             --push-attempts 4

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -8,7 +8,7 @@ on:
       - completed
 
 permissions:
-  contents: write
+  contents: read
   actions: read
   pull-requests: read
 
@@ -34,7 +34,7 @@ jobs:
           owner: openclaw
           repositories: clawsweeper
           permission-actions: read
-          permission-contents: write
+          permission-contents: read
           permission-pull-requests: read
 
       - uses: actions/checkout@v7
@@ -51,17 +51,6 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-
-      - name: Create target read token
-        id: target-read-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: openclaw
-          repositories: openclaw
-          permission-contents: read
-          permission-pull-requests: read
 
       - uses: ./.github/actions/setup-state
         with:
@@ -150,6 +139,36 @@ jobs:
           fi
           echo "has_artifacts=0" >> "$GITHUB_OUTPUT"
           echo "::notice title=No repair artifacts::No downloadable artifacts for worker run $RUN_ID."
+
+      # The reader token is minted for the validated target repositories the
+      # worker actually operated on (result.repo in the downloaded artifacts),
+      # so a valid non-default allowed-owner target can publish its results.
+      - name: Resolve result target repositories
+        id: result-targets
+        if: ${{ steps.download.outputs.has_artifacts == '1' }}
+        env:
+          ALLOWED_OWNER: ${{ vars.CLAWSWEEPER_ALLOWED_OWNER || 'openclaw' }}
+          FALLBACK_REPO: ${{ vars.CLAWSWEEPER_CLUSTER_REPAIR_TARGET_REPO || 'openclaw/openclaw' }}
+        run: |
+          set -euo pipefail
+          resolved="$(pnpm run --silent repair:resolve-result-targets -- \
+            --artifacts artifacts \
+            --allowed-owner "$ALLOWED_OWNER" \
+            --fallback "$FALLBACK_REPO")"
+          printf '%s\n' "$resolved"
+          printf '%s\n' "$resolved" | grep -E '^(owner|repositories)=' >> "$GITHUB_OUTPUT"
+
+      - name: Create target read token
+        id: target-read-token
+        if: ${{ steps.download.outputs.has_artifacts == '1' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.result-targets.outputs.owner }}
+          repositories: ${{ steps.result-targets.outputs.repositories }}
+          permission-contents: read
+          permission-pull-requests: read
 
       # This workflow_run job executes trusted main-branch code only; artifacts
       # from worker runs are downloaded as data and handled by repair publishers.

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -6,6 +6,16 @@ on:
       - repair cluster worker
     types:
       - completed
+  # Manual publication lane for a completed worker run: re-publish after a
+  # transient publisher failure, or prove a branch revision of this workflow
+  # end-to-end before merge. The run id is validated against the worker
+  # workflow before any artifact is touched.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Completed repair-cluster-worker run id to publish"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -37,13 +47,58 @@ jobs:
           permission-contents: read
           permission-pull-requests: read
 
+      # workflow_run events always execute trusted default-branch code; a
+      # manual dispatch runs the code of its requested (write-gated) ref.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.repository.default_branch }}
           filter: blob:none
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
           persist-credentials: false
+
+      - name: Resolve worker run
+        id: worker-run
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_RUN_ID: ${{ github.event.inputs.run_id }}
+          EVENT_RUN_ID: ${{ github.event.workflow_run.id }}
+          EVENT_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EVENT_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            {
+              echo "run_id=$EVENT_RUN_ID"
+              echo "run_attempt=$EVENT_RUN_ATTEMPT"
+              echo "run_url=$EVENT_RUN_URL"
+              echo "head_sha=$EVENT_HEAD_SHA"
+              echo "conclusion=$EVENT_CONCLUSION"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! printf '%s' "$DISPATCH_RUN_ID" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::run_id must be a positive integer."
+            exit 2
+          fi
+          run_json="$(gh run view "$DISPATCH_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json workflowName,status,conclusion,headSha,url,attempt)"
+          workflow_name="$(printf '%s' "$run_json" | jq -r .workflowName)"
+          status="$(printf '%s' "$run_json" | jq -r .status)"
+          if [ "$workflow_name" != "repair cluster worker" ] || [ "$status" != "completed" ]; then
+            echo "::error::run $DISPATCH_RUN_ID is not a completed repair-cluster-worker run (workflow=$workflow_name status=$status)."
+            exit 2
+          fi
+          {
+            echo "run_id=$DISPATCH_RUN_ID"
+            printf 'run_attempt=%s\n' "$(printf '%s' "$run_json" | jq -r .attempt)"
+            printf 'run_url=%s\n' "$(printf '%s' "$run_json" | jq -r .url)"
+            printf 'head_sha=%s\n' "$(printf '%s' "$run_json" | jq -r .headSha)"
+            printf 'conclusion=%s\n' "$(printf '%s' "$run_json" | jq -r .conclusion)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create state token
         id: state-token
@@ -116,8 +171,8 @@ jobs:
         id: download
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RUN_ID: ${{ steps.worker-run.outputs.run_id }}
+          RUN_ATTEMPT: ${{ steps.worker-run.outputs.run_attempt }}
         run: |
           set -euo pipefail
           rm -rf artifacts
@@ -178,10 +233,10 @@ jobs:
         if: ${{ steps.download.outputs.has_artifacts == '1' }}
         env:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ID: ${{ steps.worker-run.outputs.run_id }}
+          RUN_URL: ${{ steps.worker-run.outputs.run_url }}
+          HEAD_SHA: ${{ steps.worker-run.outputs.head_sha }}
+          CONCLUSION: ${{ steps.worker-run.outputs.conclusion }}
         run: |
           set -euo pipefail
           git fetch origin main
@@ -202,7 +257,7 @@ jobs:
       - name: Notify OpenClaw about ClawSweeper events
         if: ${{ steps.download.outputs.has_artifacts == '1' }}
         env:
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ steps.worker-run.outputs.run_id }}
           CLAWSWEEPER_OPENCLAW_HOOK_URL: ${{ secrets.CLAWSWEEPER_OPENCLAW_HOOK_URL }}
           CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: ${{ secrets.CLAWSWEEPER_OPENCLAW_HOOK_TOKEN }}
           CLAWSWEEPER_OPENCLAW_AGENT_ID: ${{ vars.CLAWSWEEPER_OPENCLAW_AGENT_ID || 'clawsweeper' }}

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -237,10 +237,14 @@ jobs:
           RUN_URL: ${{ steps.worker-run.outputs.run_url }}
           HEAD_SHA: ${{ steps.worker-run.outputs.head_sha }}
           CONCLUSION: ${{ steps.worker-run.outputs.conclusion }}
+          # workflow_run publishes trusted default-branch code; a manual
+          # dispatch publishes the code of its own write-gated ref (mixing the
+          # main tree with a branch-built dist/ broke run 30308450188).
+          PUBLISH_REF: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'main' }}
         run: |
           set -euo pipefail
-          git fetch origin main
-          git checkout -B main origin/main
+          git fetch origin "$PUBLISH_REF"
+          git checkout -B publish-ref "origin/$PUBLISH_REF"
           pnpm run repair:publish-result -- artifacts \
             --skip-dashboard \
             --run-id "$RUN_ID" \

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -54,7 +54,8 @@ jobs:
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: openclaw
+          repositories: clawsweeper
           permission-actions: write
           permission-contents: write
 
@@ -80,6 +81,25 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         with:
           build-script: build:repair
+
+      - name: Retry failed cluster result publications
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          cutoff="$(date -u -v-12H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+          runs_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/repair-publish-results.yml/runs?status=completed&per_page=50")"
+          mapfile -t failed_publishers < <(jq -r --arg cutoff "$cutoff" '
+            .workflow_runs[]
+            | select(.created_at >= $cutoff)
+            | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")
+            | select(.run_attempt < 3)
+            | .id
+          ' <<<"$runs_json")
+          for run_id in "${failed_publishers[@]}"; do
+            echo "Retrying failed cluster result publisher $run_id"
+            gh run rerun "$run_id" --repo "$GITHUB_REPOSITORY"
+          done
 
       - name: Self-heal failed cluster runs
         env:

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -96,9 +96,13 @@ jobs:
             | select(.run_attempt < 3)
             | .id
           ' <<<"$runs_json")
+          # Rerun failures are reported but never fatal: one flaky publisher
+          # rerun must not abort the later cluster self-heal steps.
           for run_id in "${failed_publishers[@]}"; do
             echo "Retrying failed cluster result publisher $run_id"
-            gh run rerun "$run_id" --repo "$GITHUB_REPOSITORY"
+            if ! gh run rerun "$run_id" --repo "$GITHUB_REPOSITORY"; then
+              echo "::warning title=Publisher rerun failed::Could not rerun publisher run ${run_id}; continuing with remaining recovery work."
+            fi
           done
 
       - name: Self-heal failed cluster runs

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -117,6 +117,10 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_REPO: openclaw/clawsweeper
+          # Dispatch workers at the materializer's own ref so the restore and
+          # receipt code lines up with the dispatching revision (this is
+          # `main` for every scheduled production run).
+          CLAWSWEEPER_DISPATCH_REF: ${{ github.ref_name }}
           CLAWSWEEPER_WORKER_RUNNER: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
           CLAWSWEEPER_EXECUTION_RUNNER: ${{ vars.CLAWSWEEPER_EXECUTION_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
         run: node dist/repair/state-materializer.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Added
 
+- Cut cluster repair intake over to durable state publication: intake appends an authenticated intent (exact job bytes, digest, store identity, selector report) and hydrates with a read-only non-persisted state credential; result publication mints its target-read token for the validated worker target repositories, projects exact changed state paths, and publisher-rerun failures no longer block subsequent self-heal. Thanks @RomneyDa! (#873)
 - Added authenticated Worker blob endpoints (`/internal/state/blobs/*`) that serve the `ledger/v1` and `assets` state trees from R2 with create-only immutable ledger writes, a cursor-resumable `migrate-state-blobs` workflow with digest verification, and an opt-in `CLAWSWEEPER_LEDGER_SOURCE=worker` dual-read in `hydrate-state` (default stays git).
 
 - Durable cluster intake now dispatches through the state materializer with receipt-verified recovery: git ledger/job files stay projection (dispatch requires the HMAC accepted-intent receipt minted at durable acceptance), the dispatch claim is published before the workflow side effect, malformed intake rows dead-letter per row instead of re-failing the drain, and the shell receipt gate matches the observer's successful-planning-job definition. At-least-once workflow creation with exactly-once worker execution intent. Thanks @RomneyDa! (#884)

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -322,9 +322,11 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
   quality is not decided by word lists, scores, or semantic thresholds.
 - `CLAWSWEEPER_CLUSTER_REPAIR_CANDIDATE_BATCH` controls how many unprocessed
   clusters the scheduled selector model compares. The default is `8`; the model
-  still selects at most one cluster. The upstream gitcrawl-store refreshes every 15 minutes, and ClawSweeper
-  records the processed store SHA so repeated ticks against the same snapshot
-  skip.
+  still selects at most one cluster. The upstream gitcrawl-store refreshes every
+  15 minutes. Intake durably appends the selected job, store identity, selector
+  summary, and stable dispatch key before requesting materialization. The state
+  materializer projects only those exact paths and recovers pending dispatch
+  without duplicating completed worker execution.
 - `CLAWSWEEPER_MAX_LIVE_WORKERS` overrides the `job_intent`-derived repair
   dispatch cap.
 - `CLAWSWEEPER_AUTOMERGE_MAX_LIVE_WORKERS` overrides

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -274,7 +274,10 @@ pnpm run repair:import-gitcrawl -- --from-gitcrawl --limit 40 --mode autonomous 
 # results/cluster-repair-intake/<repo>.json, and skips repeated ticks for the
 # same store snapshot. The selector model compares the candidate batch without
 # word lists, scores, or semantic thresholds, and dispatches at most one cluster
-# through the two-worker cluster_repair lane.
+# through the two-worker cluster_repair lane. Intake appends the selected job,
+# store identity, selector summary, and stable dispatch key to the Cloudflare
+# durable window before dispatch; the state materializer projects only those
+# exact paths and recovers pending dispatch without duplicating completed work.
 #
 # Durable intake dispatch guarantee: at-least-once workflow creation with
 # exactly-once worker execution intent. GitHub workflow_dispatch has no atomic
@@ -390,6 +393,9 @@ The workflow needs:
   may reject the entire batch.
 - optional `CLAWSWEEPER_CLUSTER_REPAIR_CANDIDATE_BATCH` variable for the scheduled
   intake; default is `8` candidates, from which the model selects at most one.
+- imported-cluster intake is accepted into the Cloudflare durable window before
+  materialization or dispatch; publication recovery retains the exact selected
+  job and selector decision.
 - merge is separately gated by `CLAWSWEEPER_ALLOW_MERGE`, which defaults to `0`; merge-ready PRs are labeled `clawsweeper:human-review` and `clawsweeper:merge-ready` for a maintainer to merge manually when the global gate is closed
 - required `CLAWSWEEPER_MODEL` GitHub Actions secret containing the actual
   internal model name; workflows, dispatch payloads, comments, and reports use

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -602,9 +602,12 @@ Important gates:
   offered to the scheduled selector model; default `8`. The selector emits at
   most one cluster per daily `repair-cluster-intake.yml` run.
   The upstream `openclaw/gitcrawl-store` refreshes `openclaw/openclaw` every 15
-  minutes, so the intake records the processed portable DB SHA in
-  `results/cluster-repair-intake/<repo>.json` and skips duplicate ticks against
-  the same store snapshot.
+  minutes. Intake first appends the selected job, store identity, selector
+  summary, and stable dispatch key to the Cloudflare durable window. The state
+  materializer projects only those exact paths, retries after publication loss,
+  and recovers retained pending intent without duplicating completed workers.
+  Intake-triggered materializers receive one bounded priority turn before
+  yielding to queued batch or ordinary writers.
 - `CLAWSWEEPER_ALLOW_EXECUTE`: allows deterministic write lanes. Workflows treat
   any value except literal `1` as closed.
 - `CLAWSWEEPER_ALLOW_FIX_PR`: allows branch repair and replacement PR creation.

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -38,7 +38,9 @@ credentials.
 flowchart LR
   A[GitHub issue, PR, comment, or schedule] --> B[ClawSweeper intake]
   G[GitCrawl store snapshot] --> B
-  B --> C[Durable job in clawsweeper-state]
+  B --> Q[Authenticated durable intake queue]
+  Q --> S[Prioritized state materializer]
+  S --> C[Exact job and ledger paths in clawsweeper-state]
   C --> D[GitHub Actions repair worker]
   D --> E[Codex app-server thread]
   D --> F[CrabFleet action session]
@@ -169,9 +171,20 @@ The `repair-cluster-intake.yml` workflow:
    `results/cluster-repair-intake/<repo-slug>.json`.
 5. Skips a store snapshot that was already processed unless a maintainer uses
    the force input.
-6. Imports a bounded number of eligible clusters into durable job markdown.
-7. Publishes the jobs and updated intake ledger.
-8. Dispatches them through the `repair_cluster` lane with capacity waiting.
+6. Gives a bounded batch of hydrated live GitHub evidence to the selector model.
+   The model chooses one narrow, actionable cluster or rejects the batch; quality
+   is not decided by word lists, scores, or semantic thresholds.
+7. Appends one authenticated `cluster_intake` intent containing the exact job
+   bytes, digest, store identity, and selector report to the durable Cloudflare
+   state queue. An accepted append is the recovery boundary; the workflow does
+   not publish from its checkout.
+8. Wakes the prioritized state materializer. It projects only the accepted job
+   and ledger paths, preserving unrelated generated state, and keeps
+   capacity-blocked or publication-failed intent durable for a later cycle.
+9. Claims each stable dispatch key only after durable publication, starts the
+   `repair_cluster` worker once, and records the matching planning-job receipt.
+   A lost claim publication or a later execution failure is recovered from the
+   exact Actions receipt instead of dispatching the planning work again.
 
 Scheduled cluster intake is independently gated:
 
@@ -224,9 +237,11 @@ and one durable Codex thread state.
 
 ### GitCrawl Store Ledger
 
-Cluster intake records the processed store content hash. A delayed schedule or
-duplicate workflow tick against the same exported database does not enqueue the
-same snapshot again.
+Cluster intake records every processed store content hash and accepted cluster
+identity. Import history spans inbox jobs, archived jobs, result records, and
+the intake ledger, so a delayed schedule, a duplicate workflow tick, or a newer
+store containing an already completed cluster cannot enqueue the same work
+again. The durable dispatch receipt independently suppresses transport retries.
 
 ### GitHub Actions Concurrency
 

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -181,10 +181,14 @@ The `repair-cluster-intake.yml` workflow:
 8. Wakes the prioritized state materializer. It projects only the accepted job
    and ledger paths, preserving unrelated generated state, and keeps
    capacity-blocked or publication-failed intent durable for a later cycle.
-9. Claims each stable dispatch key only after durable publication, starts the
-   `repair_cluster` worker once, and records the matching planning-job receipt.
-   A lost claim publication or a later execution failure is recovered from the
-   exact Actions receipt instead of dispatching the planning work again.
+9. Publishes a durable dispatch claim for each stable dispatch key, then starts
+   the `repair_cluster` worker and records the matching planning-job receipt.
+   Workflow creation is at-least-once: `workflow_dispatch` has no atomic run
+   receipt, so a crash inside the dispatch window can create another workflow
+   run. Worker execution is exactly-once by intent: the worker-side dispatch
+   receipt gate skips the duplicate planning pass. Recovery redispatches only
+   ledger entries whose HMAC accepted-intent receipt verifies against the
+   webhook secret; git ledger and job files are never dispatch authority.
 
 Scheduled cluster intake is independently gated:
 
@@ -245,14 +249,14 @@ again. The durable dispatch receipt independently suppresses transport retries.
 
 ### GitHub Actions Concurrency
 
-`repair-cluster-worker.yml` serializes identical job path and mode pairs:
+`repair-cluster-worker.yml` serializes runs for the same job path:
 
 ```text
-clawsweeper-repair-<job-path>-<mode>
+clawsweeper-repair-<job-path>
 ```
 
 Different jobs may run concurrently. The same logical job is queued instead of
-executed twice at the same time.
+executed twice at the same time, regardless of mode.
 
 ### Mutation Idempotency
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "repair:publish-cluster-intake": "node dist/repair/publish-cluster-intake.js",
     "repair:restore-cluster-intake-job": "node dist/repair/restore-cluster-intake-job.js",
     "repair:state-delta-paths": "node dist/repair/state-delta-paths.js",
+    "repair:resolve-result-targets": "node dist/repair/resolve-result-targets.js",
     "repair:import-gitcrawl-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",
     "repair:import-ghcrawl": "node dist/repair/import-gitcrawl-clusters.js",
     "repair:import-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "repair:select-cluster-candidate": "node dist/repair/select-cluster-candidate.js",
     "repair:publish-cluster-intake": "node dist/repair/publish-cluster-intake.js",
     "repair:restore-cluster-intake-job": "node dist/repair/restore-cluster-intake-job.js",
+    "repair:state-delta-paths": "node dist/repair/state-delta-paths.js",
     "repair:import-gitcrawl-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",
     "repair:import-ghcrawl": "node dist/repair/import-gitcrawl-clusters.js",
     "repair:import-low-signal": "node dist/repair/import-gitcrawl-low-signal-prs.js",

--- a/src/repair/import-gitcrawl-clusters.ts
+++ b/src/repair/import-gitcrawl-clusters.ts
@@ -134,6 +134,14 @@ for (const clusterId of clusterIds) {
     console.error(`skip closed-only cluster: ${clusterId} ${representative.title ?? ""}`);
     continue;
   }
+  // The durable cluster-intake acceptance contract requires at least two
+  // candidate references (cluster-intake-state reference policy); offering a
+  // single-candidate cluster would fail the whole intake run after selection
+  // (live proof run 30304188033). Single open items belong to other lanes.
+  if (selectingFromGitcrawl && openMembers.length < 2) {
+    console.error(`skip single-candidate cluster: ${clusterId} ${representative.title ?? ""}`);
+    continue;
+  }
   const issueCount = members.filter((member: JsonValue) => member.kind === "issue").length;
   const pullRequestCount = members.filter(
     (member: JsonValue) => member.kind === "pull_request",
@@ -253,7 +261,7 @@ function selectClusterIds() {
       join threads t on t.id = cm.thread_id
       where cg.status = 'active'
       group by cg.id
-      having open_count > 0
+      having open_count >= 2
       order by max(case when t.state = 'open' then t.updated_at else '' end) desc, cg.id asc
     `)
       .map((row: JsonValue) => Number(row.id))
@@ -270,7 +278,7 @@ function selectClusterIds() {
     join threads t on t.id = cm.thread_id
     where c.closed_at_local is null
     group by c.id
-    having open_count > 0
+    having open_count >= 2
     order by max(case when t.state = 'open' then t.updated_at else '' end) desc, c.id asc
   `)
     .map((row: JsonValue) => Number(row.id))

--- a/src/repair/publish-cluster-intake.ts
+++ b/src/repair/publish-cluster-intake.ts
@@ -44,7 +44,9 @@ export async function publishClusterIntake(
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
-  const intentPath = process.argv[2];
+  // `pnpm run <script> -- <arg>` forwards the `--` separator literally on the
+  // hosted runner's pnpm; accept the first real positional either way.
+  const intentPath = process.argv.slice(2).find((argument) => argument !== "--");
   if (!intentPath) {
     console.error("usage: publish-cluster-intake <intent.json>");
     process.exitCode = 2;

--- a/src/repair/resolve-result-targets.ts
+++ b/src/repair/resolve-result-targets.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { allowedRepairOwners } from "./lib.js";
 import { findResultPaths } from "./publish-files.js";
 
 const OWNER_PATTERN = /^[A-Za-z0-9_.-]+$/;
@@ -15,25 +16,31 @@ export type ResolvedResultTargets = {
 
 // Result publication must mint its target-read token for the repositories the
 // workers actually operated on, never a hard-coded default. The worker
-// artifacts carry `result.repo`; every value is validated against the single
-// allowed owner and the resolver fails closed on anything else.
+// artifacts carry `result.repo`; every value is validated against the shared
+// CLAWSWEEPER_ALLOWED_OWNER contract (a comma- or whitespace-separated owner
+// list, issue #604) and the resolver fails closed on anything else. One
+// publication mints one reader token, so all results must share one owner.
 export function resolveResultTargets(options: {
   artifactsDir: string;
   allowedOwner: string;
   fallbackRepo: string;
 }): ResolvedResultTargets {
-  const allowedOwner = options.allowedOwner.trim();
-  if (!OWNER_PATTERN.test(allowedOwner)) {
+  const allowedOwners = allowedRepairOwners(options.allowedOwner);
+  if (allowedOwners.length === 0 || allowedOwners.some((owner) => !OWNER_PATTERN.test(owner))) {
     throw new Error(`invalid allowed repository owner: ${JSON.stringify(options.allowedOwner)}`);
   }
+  const isAllowed = (owner: string) => allowedOwners.includes(owner.toLowerCase());
   const fallbackRepo = options.fallbackRepo.trim();
   if (!REPO_PATTERN.test(fallbackRepo)) {
     throw new Error(`invalid fallback repository: ${JSON.stringify(options.fallbackRepo)}`);
   }
-  if (fallbackRepo.split("/")[0] !== allowedOwner) {
-    throw new Error(`fallback repository must be owned by ${allowedOwner}: ${fallbackRepo}`);
+  if (!isAllowed(fallbackRepo.split("/")[0]!)) {
+    throw new Error(
+      `fallback repository must be owned by ${allowedOwners.join(",")}: ${fallbackRepo}`,
+    );
   }
 
+  let resolvedOwner = "";
   const names = new Set<string>();
   for (const resultPath of findResultPaths(resolve(options.artifactsDir))) {
     const parsed = JSON.parse(readFileSync(resultPath, "utf8")) as { repo?: unknown };
@@ -42,13 +49,25 @@ export function resolveResultTargets(options: {
       throw new Error(`worker result has an invalid target repository: ${JSON.stringify(repo)}`);
     }
     const [owner, name] = repo.split("/") as [string, string];
-    if (owner !== allowedOwner) {
-      throw new Error(`worker result targets a repository outside ${allowedOwner}: ${repo}`);
+    if (!isAllowed(owner)) {
+      throw new Error(
+        `worker result targets a repository outside ${allowedOwners.join(",")}: ${repo}`,
+      );
+    }
+    if (!resolvedOwner) {
+      resolvedOwner = owner;
+    } else if (resolvedOwner.toLowerCase() !== owner.toLowerCase()) {
+      throw new Error(
+        `worker results span multiple owners (${resolvedOwner}, ${owner}); one publication mints one reader token`,
+      );
     }
     names.add(name);
   }
-  if (names.size === 0) names.add(fallbackRepo.split("/")[1]!);
-  return { owner: allowedOwner, repositories: [...names].sort() };
+  if (names.size === 0) {
+    resolvedOwner = fallbackRepo.split("/")[0]!;
+    names.add(fallbackRepo.split("/")[1]!);
+  }
+  return { owner: resolvedOwner, repositories: [...names].sort() };
 }
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";

--- a/src/repair/resolve-result-targets.ts
+++ b/src/repair/resolve-result-targets.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { findResultPaths } from "./publish-files.js";
+
+const OWNER_PATTERN = /^[A-Za-z0-9_.-]+$/;
+const REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+export type ResolvedResultTargets = {
+  owner: string;
+  repositories: string[];
+};
+
+// Result publication must mint its target-read token for the repositories the
+// workers actually operated on, never a hard-coded default. The worker
+// artifacts carry `result.repo`; every value is validated against the single
+// allowed owner and the resolver fails closed on anything else.
+export function resolveResultTargets(options: {
+  artifactsDir: string;
+  allowedOwner: string;
+  fallbackRepo: string;
+}): ResolvedResultTargets {
+  const allowedOwner = options.allowedOwner.trim();
+  if (!OWNER_PATTERN.test(allowedOwner)) {
+    throw new Error(`invalid allowed repository owner: ${JSON.stringify(options.allowedOwner)}`);
+  }
+  const fallbackRepo = options.fallbackRepo.trim();
+  if (!REPO_PATTERN.test(fallbackRepo)) {
+    throw new Error(`invalid fallback repository: ${JSON.stringify(options.fallbackRepo)}`);
+  }
+  if (fallbackRepo.split("/")[0] !== allowedOwner) {
+    throw new Error(`fallback repository must be owned by ${allowedOwner}: ${fallbackRepo}`);
+  }
+
+  const names = new Set<string>();
+  for (const resultPath of findResultPaths(resolve(options.artifactsDir))) {
+    const parsed = JSON.parse(readFileSync(resultPath, "utf8")) as { repo?: unknown };
+    const repo = String(parsed.repo ?? "").trim();
+    if (!REPO_PATTERN.test(repo)) {
+      throw new Error(`worker result has an invalid target repository: ${JSON.stringify(repo)}`);
+    }
+    const [owner, name] = repo.split("/") as [string, string];
+    if (owner !== allowedOwner) {
+      throw new Error(`worker result targets a repository outside ${allowedOwner}: ${repo}`);
+    }
+    names.add(name);
+  }
+  if (names.size === 0) names.add(fallbackRepo.split("/")[1]!);
+  return { owner: allowedOwner, repositories: [...names].sort() };
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
+  const values = process.argv.slice(2);
+  const value = (name: string): string => {
+    const index = values.indexOf(name);
+    if (index < 0 || !values[index + 1]) throw new Error(`${name} is required`);
+    return values[index + 1]!;
+  };
+  try {
+    const resolved = resolveResultTargets({
+      artifactsDir: value("--artifacts"),
+      allowedOwner: value("--allowed-owner"),
+      fallbackRepo: value("--fallback"),
+    });
+    process.stdout.write(`owner=${resolved.owner}\n`);
+    process.stdout.write(`repositories=${resolved.repositories.join(",")}\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src/repair/restore-cluster-intake-job.ts
+++ b/src/repair/restore-cluster-intake-job.ts
@@ -18,6 +18,7 @@ import {
   validateClusterJobContent,
   verifyClusterDispatchAuthenticationTag,
 } from "./cluster-intake-state.js";
+import { allowedRepairOwners } from "./lib.js";
 
 type RestoreClusterIntakeJobOptions = {
   root: string;
@@ -43,7 +44,14 @@ export function restoreClusterIntakeJob(options: RestoreClusterIntakeJobOptions)
   if (!match) throw new Error("invalid durable cluster intake job path");
   const owner = match[1]!;
   const clusterId = Number(match[2]);
-  if (owner !== options.allowedOwner || !/^[A-Za-z0-9_.-]+$/.test(options.allowedOwner)) {
+  // CLAWSWEEPER_ALLOWED_OWNER is a comma- or whitespace-separated owner list
+  // (issue #604); the job-path owner must be one of the validated entries.
+  const allowedOwners = allowedRepairOwners(options.allowedOwner);
+  if (
+    allowedOwners.length === 0 ||
+    allowedOwners.some((entry) => !/^[A-Za-z0-9_.-]+$/.test(entry)) ||
+    !allowedOwners.includes(owner.toLowerCase())
+  ) {
     throw new Error("durable cluster intake owner is not allowed");
   }
   if (!/^[a-f0-9]{64}$/.test(options.digest)) {

--- a/src/repair/state-delta-paths.ts
+++ b/src/repair/state-delta-paths.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+export function changedStatePaths(options: {
+  worktree: string;
+  stateRoot: string;
+  roots: readonly string[];
+}): string[] {
+  const paths = new Set<string>();
+  for (const root of options.roots) {
+    collectFiles(resolve(options.worktree, root), options.worktree, paths);
+    collectFiles(resolve(options.stateRoot, root), options.stateRoot, paths);
+  }
+  return [...paths]
+    .filter(
+      (path) =>
+        fileDigest(resolve(options.worktree, path)) !==
+        fileDigest(resolve(options.stateRoot, path)),
+    )
+    .sort();
+}
+
+function collectFiles(directory: string, base: string, paths: Set<string>): void {
+  if (!existsSync(directory)) return;
+  const stat = lstatSync(directory);
+  if (stat.isSymbolicLink())
+    throw new Error(`state delta root must not be a symlink: ${directory}`);
+  if (stat.isFile()) {
+    paths.add(relative(base, directory).split(sep).join("/"));
+    return;
+  }
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const target = resolve(directory, entry.name);
+    if (entry.isSymbolicLink())
+      throw new Error(`state delta path must not be a symlink: ${target}`);
+    if (entry.isDirectory()) collectFiles(target, base, paths);
+    else if (entry.isFile()) paths.add(relative(base, target).split(sep).join("/"));
+  }
+}
+
+function fileDigest(path: string): string | null {
+  if (!existsSync(path)) return null;
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink())
+    throw new Error(`state delta path is not a regular file: ${path}`);
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+if (process.argv[1]?.endsWith("state-delta-paths.js")) {
+  const values = process.argv.slice(2);
+  const value = (name: string): string => {
+    const index = values.indexOf(name);
+    if (index < 0 || !values[index + 1]) throw new Error(`${name} is required`);
+    return values[index + 1]!;
+  };
+  const roots = values.flatMap((item, index) =>
+    item === "--root" && values[index + 1] ? [values[index + 1]!] : [],
+  );
+  if (roots.length === 0) throw new Error("at least one --root is required");
+  const output = changedStatePaths({
+    worktree: process.cwd(),
+    stateRoot: resolve(value("--state-root")),
+    roots,
+  });
+  writeFileSync(resolve(value("--out")), `${output.join("\n")}${output.length ? "\n" : ""}`);
+  console.log(`state delta contains ${output.length} exact path(s)`);
+}

--- a/test/actions-checkout-v7.test.ts
+++ b/test/actions-checkout-v7.test.ts
@@ -69,21 +69,21 @@ test("production crawl-remote checkout is pinned to the audited v7 commit", () =
 });
 
 test("trusted-event workflows explicitly checkout the default branch", () => {
-  for (const path of [
-    ".github/workflows/dashboard-ci.yml",
-    ".github/workflows/github-activity.yml",
-    ".github/workflows/repair-publish-results.yml",
-  ]) {
+  const expectedRefs: Record<string, string> = {
+    ".github/workflows/dashboard-ci.yml": "${{ github.event.repository.default_branch }}",
+    ".github/workflows/github-activity.yml": "${{ github.event.repository.default_branch }}",
+    // workflow_run events stay pinned to trusted default-branch code; the
+    // manual publication lane runs its own write-gated dispatch ref.
+    ".github/workflows/repair-publish-results.yml":
+      "${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.repository.default_branch }}",
+  };
+  for (const [path, expectedRef] of Object.entries(expectedRefs)) {
     const workflow = parse(readFileSync(path, "utf8")) as WorkflowDocument;
     const checkoutSteps = Object.values(workflow.jobs ?? {})
       .flatMap((job) => job.steps ?? [])
       .filter((step) => step.uses === "actions/checkout@v7");
     assert.equal(checkoutSteps.length, 1, path);
-    assert.equal(
-      checkoutSteps[0]?.with?.ref,
-      "${{ github.event.repository.default_branch }}",
-      path,
-    );
+    assert.equal(checkoutSteps[0]?.with?.ref, expectedRef, path);
   }
 });
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2486,22 +2486,26 @@ test("repair workflows preserve existing dispatch while scheduled cluster intake
   assert.doesNotMatch(importLowSignal, /CLAWSWEEPER_FEATURE_CLUSTER_REPAIR_ENABLED/);
 });
 
-test("cluster intake publishes generated repair state through state repo", () => {
+test("cluster intake durably accepts selected work before materialization", () => {
   const workflow = readText(".github/workflows/repair-cluster-intake.yml");
   const stateTokenIndex = workflow.indexOf("uses: ./.github/actions/create-state-token");
   const setupStateIndex = workflow.indexOf("uses: ./.github/actions/setup-state");
   const importIndex = workflow.indexOf("- name: Prepare unprocessed cluster candidates");
-  const publishIndex = workflow.indexOf("- name: Publish intake jobs and ledger");
+  const publishIndex = workflow.indexOf("- name: Durably accept cluster intake");
+  const materializeIndex = workflow.indexOf("- name: Request immediate state materialization");
 
   assert.notEqual(stateTokenIndex, -1);
   assert.notEqual(setupStateIndex, -1);
   assert.notEqual(importIndex, -1);
   assert.notEqual(publishIndex, -1);
+  assert.notEqual(materializeIndex, -1);
   assert.ok(stateTokenIndex < setupStateIndex, "state token must be created before setup-state");
   assert.ok(setupStateIndex < importIndex, "state repo must be hydrated before job import");
-  assert.ok(setupStateIndex < publishIndex, "state repo must be configured before publish-main");
-  assert.match(workflow, /--path jobs/);
-  assert.match(workflow, /--path results\/cluster-repair-intake/);
+  assert.ok(importIndex < publishIndex, "selection must finish before durable acceptance");
+  assert.ok(publishIndex < materializeIndex, "durable acceptance must precede materialization");
+  assert.match(workflow, /repair:publish-cluster-intake/);
+  assert.match(workflow, /gh workflow run state-materializer\.yml --ref main/);
+  assert.doesNotMatch(workflow, /repair:publish-main|pnpm run repair:dispatch/);
 });
 
 test("conflict self-heal publishes exact-head jobs before worker dispatch", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2504,7 +2504,7 @@ test("cluster intake durably accepts selected work before materialization", () =
   assert.ok(importIndex < publishIndex, "selection must finish before durable acceptance");
   assert.ok(publishIndex < materializeIndex, "durable acceptance must precede materialization");
   assert.match(workflow, /repair:publish-cluster-intake/);
-  assert.match(workflow, /gh workflow run state-materializer\.yml --ref main/);
+  assert.match(workflow, /gh workflow run state-materializer\.yml --ref "\$GITHUB_REF_NAME"/);
   assert.doesNotMatch(workflow, /repair:publish-main|pnpm run repair:dispatch/);
 });
 

--- a/test/repair/cluster-intake-state.test.ts
+++ b/test/repair/cluster-intake-state.test.ts
@@ -1046,6 +1046,18 @@ test("worker restores only an authenticated semantically valid durable job", () 
   assert.equal(fs.readFileSync(restored, "utf8"), job.content);
   assert.equal(fs.statSync(restored).mode & 0o777, 0o600);
 
+  // CLAWSWEEPER_ALLOWED_OWNER is a comma/whitespace-separated owner list in
+  // production (e.g. "openclaw,steipete"); membership must be honored.
+  restoreClusterIntakeJob({ ...options, allowedOwner: "steipete, openclaw" });
+  assert.throws(
+    () => restoreClusterIntakeJob({ ...options, allowedOwner: "steipete,elsewhere" }),
+    /owner is not allowed/,
+  );
+  assert.throws(
+    () => restoreClusterIntakeJob({ ...options, allowedOwner: "" }),
+    /owner is not allowed/,
+  );
+
   assert.throws(
     () => restoreClusterIntakeJob({ ...options, dispatchKey: `${job.dispatch_key}-forged` }),
     /authentication failed/,

--- a/test/repair/cluster-workflow-security.test.ts
+++ b/test/repair/cluster-workflow-security.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { parse } from "yaml";
+
+type Workflow = {
+  jobs?: Record<string, { steps?: Array<{ name?: string; run?: string; env?: unknown }> }>;
+};
+
+test("cluster worker passes workflow inputs through environment boundaries", () => {
+  const source = fs.readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8");
+  const workflow = parse(source) as Workflow;
+  for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.run !== "string") continue;
+      assert.doesNotMatch(
+        step.run,
+        /\$\{\{\s*inputs\./,
+        `${jobName}/${step.name ?? "unnamed"} interpolates an input into shell source`,
+      );
+    }
+  }
+  assert.match(source, /job_auth:[\s\S]*Materializer HMAC/);
+  assert.equal(source.match(/run: pnpm run repair:restore-cluster-intake-job/g)?.length, 3);
+  assert.equal(source.match(/CLAWSWEEPER_WEBHOOK_SECRET: \$\{\{ secrets\./g)?.length, 4);
+  assert.ok(
+    source.indexOf("Authenticate durable intake before credentials") <
+      source.indexOf("Create GitHub App token"),
+  );
+  assert.doesNotMatch(source, /restore-durable-intake-job\.sh/);
+});
+
+test("cluster intake validates one safe repository token before exporting outputs", () => {
+  const source = fs.readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  const workflow = parse(source) as Workflow;
+  const resolveStep = workflow.jobs?.intake?.steps?.find(
+    (step) => step.name === "Resolve target repository",
+  );
+  assert.ok(resolveStep?.run);
+  assert.match(resolveStep.run, /\^\[A-Za-z0-9_\.-\]\+\/\[A-Za-z0-9_\.-\]\+\$/);
+  assert.match(resolveStep.run, /printf 'name=%s\\n'/);
+  assert.doesNotMatch(resolveStep.run, /echo "name=\$target_name"/);
+});

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -56,7 +56,7 @@ test("scheduled cluster repair intake follows gitcrawl-store freshness cadence",
   assert.match(workflow, /repair:publish-cluster-intake/);
   assert.match(workflow, /owner: \$\{\{ steps\.target\.outputs\.owner \}\}/);
   assert.match(workflow, /repositories: \$\{\{ steps\.target\.outputs\.name \}\}/);
-  assert.match(workflow, /gh workflow run state-materializer\.yml --ref main/);
+  assert.match(workflow, /gh workflow run state-materializer\.yml --ref "\$GITHUB_REF_NAME"/);
   assert.doesNotMatch(workflow, /pnpm run repair:dispatch/);
   assert.doesNotMatch(workflow, /git pull --rebase origin main/);
   assert.match(limitsDocs, /one cluster or rejects the batch/);

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -42,6 +42,14 @@ test("gitcrawl cluster intake delegates candidate quality to the selector model"
   assert.match(repairDocs, /selector model compares/);
 });
 
+test("gitcrawl cluster intake only offers clusters that satisfy the acceptance contract", () => {
+  const source = readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8");
+  // Durable acceptance requires >= 2 candidate refs (cluster-intake-state
+  // reference policy); a single-candidate offer fails the whole intake run.
+  assert.equal(source.match(/having open_count >= 2/g)?.length, 2);
+  assert.match(source, /skip single-candidate cluster/);
+});
+
 test("scheduled cluster repair intake follows gitcrawl-store freshness cadence", () => {
   const workflow = readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
   const limitsDocs = readFileSync("docs/limits.md", "utf8");

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -53,7 +53,11 @@ test("scheduled cluster repair intake follows gitcrawl-store freshness cadence",
   assert.match(workflow, /last_processed_store_sha256/);
   assert.match(workflow, /CLAWSWEEPER_CLUSTER_REPAIR_CANDIDATE_BATCH \|\| '8'/);
   assert.match(workflow, /repair:select-cluster-candidate/);
-  assert.match(workflow, /pnpm run repair:dispatch/);
+  assert.match(workflow, /repair:publish-cluster-intake/);
+  assert.match(workflow, /owner: \$\{\{ steps\.target\.outputs\.owner \}\}/);
+  assert.match(workflow, /repositories: \$\{\{ steps\.target\.outputs\.name \}\}/);
+  assert.match(workflow, /gh workflow run state-materializer\.yml --ref main/);
+  assert.doesNotMatch(workflow, /pnpm run repair:dispatch/);
   assert.doesNotMatch(workflow, /git pull --rebase origin main/);
   assert.match(limitsDocs, /one cluster or rejects the batch/);
   assert.match(repairDocs, /intake runs daily/);

--- a/test/repair/publish-cluster-intake.test.ts
+++ b/test/repair/publish-cluster-intake.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -57,4 +58,15 @@ test("cluster intake publication exposes a repeated durable delivery", async () 
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("the CLI ignores the pnpm-forwarded -- separator instead of reading it as a path", () => {
+  // `pnpm run repair:publish-cluster-intake -- <intent>` forwards the literal
+  // `--` on the hosted runner (live proof run 30303202343 failed with
+  // ENOENT '.../--'); the CLI must use the first real positional.
+  const result = spawnSync(process.execPath, ["dist/repair/publish-cluster-intake.js", "--"], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /usage: publish-cluster-intake/);
 });

--- a/test/repair/resolve-result-targets.test.ts
+++ b/test/repair/resolve-result-targets.test.ts
@@ -46,6 +46,44 @@ test("result targets fall back to the configured default when artifacts carry no
   assert.deepEqual(resolved, { owner: "openclaw", repositories: ["openclaw"] });
 });
 
+test("result targets honor the production owner-list contract", () => {
+  // CLAWSWEEPER_ALLOWED_OWNER is a comma/whitespace-separated list (issue
+  // #604); production sets "openclaw,steipete".
+  const resolved = resolveResultTargets({
+    artifactsDir: artifactsWithResults(["steipete/vibetunnel"]),
+    allowedOwner: "openclaw,steipete",
+    fallbackRepo: "openclaw/openclaw",
+  });
+  assert.deepEqual(resolved, { owner: "steipete", repositories: ["vibetunnel"] });
+  const fallback = resolveResultTargets({
+    artifactsDir: artifactsWithResults([]),
+    allowedOwner: "openclaw, steipete",
+    fallbackRepo: "openclaw/openclaw",
+  });
+  assert.deepEqual(fallback, { owner: "openclaw", repositories: ["openclaw"] });
+  assert.throws(
+    () =>
+      resolveResultTargets({
+        artifactsDir: artifactsWithResults(["evil/openclaw"]),
+        allowedOwner: "openclaw,steipete",
+        fallbackRepo: "openclaw/openclaw",
+      }),
+    /outside openclaw,steipete/,
+  );
+});
+
+test("result targets fail closed when results span multiple owners", () => {
+  assert.throws(
+    () =>
+      resolveResultTargets({
+        artifactsDir: artifactsWithResults(["openclaw/openclaw", "steipete/vibetunnel"]),
+        allowedOwner: "openclaw,steipete",
+        fallbackRepo: "openclaw/openclaw",
+      }),
+    /span multiple owners/,
+  );
+});
+
 test("result targets fail closed on a repository outside the allowed owner", () => {
   assert.throws(
     () =>
@@ -99,6 +137,19 @@ test("intake hydrates state with a read-only, non-persisted credential", () => {
   assert.match(workflow, /actions-permission: read/);
   assert.match(workflow, /persist-credentials: "false"/);
   assert.doesNotMatch(workflow, /permission-contents: write/);
+});
+
+test("intake target validation honors the owner-list contract and version-coherent refs", () => {
+  const intake = fs.readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  // Owner membership must be checked against the parsed list, never a raw
+  // single-string comparison against CLAWSWEEPER_ALLOWED_OWNER.
+  assert.match(intake, /comma- or whitespace-separated owner/);
+  assert.match(intake, /owner_allowed=1/);
+  assert.doesNotMatch(intake, /\[ "\$target_owner" != "\$ALLOWED_OWNER" \]/);
+  // The materializer wake and worker dispatch stay on the invoking revision.
+  assert.match(intake, /gh workflow run state-materializer\.yml --ref "\$GITHUB_REF_NAME"/);
+  const materializer = fs.readFileSync(".github/workflows/state-materializer.yml", "utf8");
+  assert.match(materializer, /CLAWSWEEPER_DISPATCH_REF: \$\{\{ github\.ref_name \}\}/);
 });
 
 test("self-heal treats a failed publisher rerun as non-blocking", () => {

--- a/test/repair/resolve-result-targets.test.ts
+++ b/test/repair/resolve-result-targets.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveResultTargets } from "../../dist/repair/resolve-result-targets.js";
+
+function artifactsWithResults(repos: readonly string[]): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-result-targets-"));
+  for (const [index, repo] of repos.entries()) {
+    const runDir = path.join(root, `run-${index}`, `cluster-${index}`);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(runDir, "result.json"),
+      `${JSON.stringify({ repo, cluster_id: index })}\n`,
+    );
+  }
+  return root;
+}
+
+test("result targets resolve to the validated non-default repository from worker artifacts", () => {
+  const resolved = resolveResultTargets({
+    artifactsDir: artifactsWithResults(["openclaw", "openclaw"].map((o) => `${o}/gitcrawl`)),
+    allowedOwner: "openclaw",
+    fallbackRepo: "openclaw/openclaw",
+  });
+  assert.deepEqual(resolved, { owner: "openclaw", repositories: ["gitcrawl"] });
+});
+
+test("result targets dedupe and sort multiple allowed repositories", () => {
+  const resolved = resolveResultTargets({
+    artifactsDir: artifactsWithResults(["openclaw/zebra", "openclaw/alpha", "openclaw/zebra"]),
+    allowedOwner: "openclaw",
+    fallbackRepo: "openclaw/openclaw",
+  });
+  assert.deepEqual(resolved.repositories, ["alpha", "zebra"]);
+});
+
+test("result targets fall back to the configured default when artifacts carry no result", () => {
+  const resolved = resolveResultTargets({
+    artifactsDir: artifactsWithResults([]),
+    allowedOwner: "openclaw",
+    fallbackRepo: "openclaw/openclaw",
+  });
+  assert.deepEqual(resolved, { owner: "openclaw", repositories: ["openclaw"] });
+});
+
+test("result targets fail closed on a repository outside the allowed owner", () => {
+  assert.throws(
+    () =>
+      resolveResultTargets({
+        artifactsDir: artifactsWithResults(["evil/openclaw"]),
+        allowedOwner: "openclaw",
+        fallbackRepo: "openclaw/openclaw",
+      }),
+    /outside openclaw/,
+  );
+});
+
+test("result targets fail closed on malformed repository identities", () => {
+  assert.throws(
+    () =>
+      resolveResultTargets({
+        artifactsDir: artifactsWithResults(["unknown/unknown/extra"]),
+        allowedOwner: "openclaw",
+        fallbackRepo: "openclaw/openclaw",
+      }),
+    /invalid target repository/,
+  );
+  assert.throws(
+    () =>
+      resolveResultTargets({
+        artifactsDir: artifactsWithResults([]),
+        allowedOwner: "openclaw",
+        fallbackRepo: "elsewhere/openclaw",
+      }),
+    /must be owned by openclaw/,
+  );
+});
+
+test("result publication mints its reader token from resolved targets, not a fixed repository", () => {
+  const workflow = fs.readFileSync(".github/workflows/repair-publish-results.yml", "utf8");
+  assert.match(workflow, /repair:resolve-result-targets/);
+  assert.match(workflow, /owner: \$\{\{ steps\.result-targets\.outputs\.owner \}\}/);
+  assert.match(workflow, /repositories: \$\{\{ steps\.result-targets\.outputs\.repositories \}\}/);
+  const resolveIndex = workflow.indexOf("- name: Resolve result target repositories");
+  const downloadIndex = workflow.indexOf("- name: Download worker artifacts");
+  const mintIndex = workflow.indexOf("- name: Create target read token");
+  assert.ok(downloadIndex >= 0 && resolveIndex > downloadIndex && mintIndex > resolveIndex);
+  // The ClawSweeper app token needs read access only; state publication uses
+  // the state credential, and the target reader is minted per validated target.
+  assert.doesNotMatch(workflow, /permission-contents: write/);
+});
+
+test("intake hydrates state with a read-only, non-persisted credential", () => {
+  const workflow = fs.readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  assert.match(workflow, /contents-permission: read/);
+  assert.match(workflow, /actions-permission: read/);
+  assert.match(workflow, /persist-credentials: "false"/);
+  assert.doesNotMatch(workflow, /permission-contents: write/);
+});
+
+test("self-heal treats a failed publisher rerun as non-blocking", () => {
+  const workflow = fs.readFileSync(".github/workflows/repair-self-heal.yml", "utf8");
+  const rerunIndex = workflow.indexOf('if ! gh run rerun "$run_id"');
+  const selfHealIndex = workflow.indexOf("- name: Self-heal failed cluster runs");
+  assert.ok(rerunIndex >= 0 && selfHealIndex > rerunIndex);
+  assert.match(workflow, /warning title=Publisher rerun failed/);
+});

--- a/test/repair/state-delta-paths.test.ts
+++ b/test/repair/state-delta-paths.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { changedStatePaths } from "../../dist/repair/state-delta-paths.js";
+
+test("result publication selects exact changes and preserves unrelated remote jobs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-state-delta-"));
+  const worktree = path.join(root, "worktree");
+  const state = path.join(root, "state");
+  for (const base of [worktree, state]) {
+    fs.mkdirSync(path.join(base, "results", "openclaw"), { recursive: true });
+    fs.mkdirSync(path.join(base, "jobs", "openclaw", "inbox"), { recursive: true });
+    fs.writeFileSync(path.join(base, "results", "openclaw", "existing.md"), "same\n");
+    fs.writeFileSync(path.join(base, "jobs", "openclaw", "inbox", "unrelated.md"), "keep\n");
+  }
+  fs.writeFileSync(path.join(worktree, "results", "openclaw", "gitcrawl-42.md"), "new result\n");
+  fs.writeFileSync(path.join(worktree, "results", "openclaw", "existing.md"), "updated\n");
+
+  assert.deepEqual(
+    changedStatePaths({ worktree, stateRoot: state, roots: ["results", "jobs/openclaw"] }),
+    ["results/openclaw/existing.md", "results/openclaw/gitcrawl-42.md"],
+  );
+});
+
+test("state hydration preserves state-only notification receipts before result diffing", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-notification-hydrate-"));
+  const worktree = path.join(root, "worktree");
+  const state = path.join(root, "state");
+  const receipt = path.join("notifications", "clawsweeper-event-ledger.json");
+  fs.mkdirSync(path.join(state, "notifications"), { recursive: true });
+  fs.mkdirSync(worktree, { recursive: true });
+  fs.writeFileSync(path.join(state, receipt), '{"notifications":[{"id":"unrelated"}]}\n');
+
+  const hydrated = spawnSync(
+    process.execPath,
+    ["scripts/hydrate-state.ts", "--state-dir", state, "--worktree", worktree],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(hydrated.status, 0, hydrated.stderr);
+  assert.equal(
+    fs.readFileSync(path.join(worktree, receipt), "utf8"),
+    fs.readFileSync(path.join(state, receipt), "utf8"),
+  );
+  assert.deepEqual(changedStatePaths({ worktree, stateRoot: state, roots: ["notifications"] }), []);
+});

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -30,6 +30,7 @@ const coordinatorUrl =
 const publicationEntryPoints = [
   /repair:publish-main\b/,
   /repair:publish-event-result\b/,
+  /repair:publish-cluster-intake\b/,
   /repair:exact-review-batch commit\b/,
   /scripts\/prepare-exact-review-batch\.mjs\b/,
   /dist\/repair\/state-materializer\.js\b/,
@@ -171,6 +172,7 @@ test("only bounded publication owners request priority admission", () => {
   }
   assert.deepEqual(prioritySetups, [
     ".github/workflows/exact-review-batch-publish.yml:publish",
+    ".github/workflows/repair-publish-results.yml:publish",
     ".github/workflows/state-materializer.yml:materialize",
   ]);
   const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;


### PR DESCRIPTION
## Summary

Rework of #873 by @RomneyDa — the 5/5 cutover layer of the cluster-fixer reliability stack, re-applied on top of #900 (the reworked #884 dispatch layer) and reconciled with what #879/#899/#900 changed on `main`. RomneyDa's original commit is cherry-picked with authorship preserved; a maintainer fix commit addresses the review findings. #873 stays open for its audit and review history; this PR supersedes it.

What the cutover does (unchanged from #873 in intent):

- Cuts the production intake workflow from broad `repair:publish-main` publication to the durable cluster-intake append/materializer contract.
- Dispatches through durable materialization instead of directly from an intake checkout — now specifically through the #900 receipt-verified path: the materializer verifies the HMAC accepted-intent receipt, publishes the dispatch claim before the workflow side effect, and git ledger/job files are never dispatch authority.
- Publishes worker results by exact changed paths, with bounded priority and automatic self-heal retry.
- Preserves deterministic mutation, security gates, fail-closed behavior, `allow_merge: false`, and all existing production gate settings.

## Changes vs original #873 (review findings)

1. **Target-read tokens are minted for the validated target** (was: hard-coded `openclaw/openclaw`). New `repair:resolve-result-targets` resolves the target repositories from the downloaded worker artifacts (`result.repo`), fails closed on any repository outside the allowed owner or a malformed identity, falls back to the configured default when no result is present, and the reader token is minted for exactly those repositories after artifact download. Regression tests cover the non-default-target path.
2. **Intake uses a read-only, non-persisted state credential.** `create-state-token` now takes permission inputs; intake requests `contents: read` / `actions: read` and hydrates with `persist-credentials: "false"`. Intake's central token and workflow permissions drop to contents-read — intake never publishes from its checkout. Result publication narrows its ClawSweeper app token and workflow permissions to read; state writes go through the state credential and the durable append only.
3. **Publisher-rerun failures are non-blocking.** A failed `gh run rerun` in self-heal logs a warning per run and continues, so one transient API failure cannot suppress the remaining publisher retries or the cluster self-heal step.
4. **Docs state the accurate guarantee**: at-least-once workflow creation with exactly-once worker execution intent (receipt-gated worker-side dedupe), matching #900; also fixed the concurrency description — the worker group is keyed by job path only, not job path + mode.
5. **Rebase-reconciled with #879/#899/#900**: canonical-first record writes and blob transport are untouched by the cutover (cluster paths stay under `jobs/**`/`results/**`), and the intake wake (`state-materializer.yml -f intake_priority=true`) drives the #900 receipt-verified dispatch with claim-before-side-effect ordering.

## Validation

- `pnpm run build:all`, `pnpm run lint`, `pnpm run check:static` (includes format check) — clean.
- Focused suites: `resolve-result-targets`, `state-delta-paths`, `cluster-workflow-security`, `gitcrawl-store`, `cluster-intake-state`, `state-materializer`, `dispatch-receipt-owner`, `state-writer-workflow`, `actions-checkout-v7`, `clawsweeper` — all pass.
- Full `test:repair` category: only the two known environment-sensitive macOS failures (`process-tree-containment` Linux symbols, `state-publication-batching-proof` `/private/var` aliasing), both untouched by this diff and pre-existing on the base.
- Codex autoreview (branch diff vs base): clean, "patch is correct (0.98)".

## Pre-merge live proof checklist (design only — not yet executed)

One real durable cluster intake → receipt-verified dispatch → worker execution → result publication on a low-traffic allowed-owner target (not `openclaw/openclaw`), with all production gates preserved and no automerge.

- [ ] **Dispatch one real intake** against a low-traffic target:
  ```bash
  gh workflow run repair-cluster-intake.yml --repo openclaw/clawsweeper --ref main \
    -f enabled=1 -f target_repo=openclaw/<low-traffic-repo> -f limit=2 -f force_store=true
  ```
  Expect: intake log shows `durable cluster intake accepted: N job(s), delivery cluster-intake:<slug>:<store-sha>`; no state push from the intake run; the state token grant is read-only; a `state-materializer.yml` run starts with `intake_priority=true`.
- [ ] **Receipt-verified dispatch**: materializer log shows accepted-intent receipt verification and the dispatch claim published before `workflow_dispatch`; exactly one `repair-cluster-worker` run per stable dispatch key; the state ledger entry carries `accepted_intent_receipt`; only the accepted job and `results/cluster-repair-intake/<slug>.json` paths are projected — record unrelated job/ledger blob hashes before and after and verify they are unchanged.
- [ ] **Worker execution**: one successful "Plan and review cluster" job for the dispatch key; the dispatch receipt is recorded; record append-to-publication and intake-to-dispatch latency.
- [ ] **Result publication for a non-default target**: the `Resolve result target repositories` step resolves the actual target from the artifact, the reader token is minted for that repository, and the publish/finalize steps succeed — this is the live proof for finding 1.
- [ ] **Crash-window recovery**: cancel the materializer run in the window after the dispatch claim is published and before the run receipt is observed, then re-run the materializer. Expect: recovery verifies the accepted-intent receipt and may create a second workflow run (at-least-once creation), and the worker-side receipt gate skips the duplicate planning pass — assert exactly one planning execution in the ledger and no duplicated GitHub side effects.
- [ ] **Publisher-rerun non-blocking**: with at least one failed `repair-publish-results` run (< 3 attempts) present, trigger `repair-self-heal.yml` with `execute=false`; if a rerun fails, expect the per-run warning and the `Self-heal failed cluster runs` step still executing.
- [ ] **Idempotent replay**: re-dispatch intake for the same store snapshot (`force_store=true`); expect `already accepted` dedupe and no additional worker run.
- [ ] Do not enable automerge and do not merge generated production PRs as part of this proof. If the selector rejects the batch, retain the rejection report as the correct outcome and re-run against a store snapshot with an eligible cluster.

## Credits

Original implementation and stack design by @RomneyDa (#873, on top of #881–#884). Maintainer rework applies the review findings from the #873 review thread.
