### PR TITLE
fix(sweep): bound admission when queue pressure is unknown

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -274,10 +274,10 @@ jobs:
             active_background_workers="$(active_sweep_background_workers)"
             unpressured_page_size="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
             if ! pressure_json="$(pnpm --dir clawsweeper run --silent workflow -- queue-pressure --queue-url "$QUEUE_URL")"; then
-              pressure_json='{"ok":false,"reason":"probe_failed","level":"none"}'
+              pressure_json='{"ok":false,"reason":"probe_failed","level":"unknown"}'
             fi
-            if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard")' 2>/dev/null)"; then
-              pressure_level="none"
+            if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard" or . == "unknown")' 2>/dev/null)"; then
+              pressure_level="unknown"
             fi
             PAGE_SIZE="$(pnpm --dir clawsweeper run --silent workflow -- worker-limit commit_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"
             pressure_numbers="$(printf '%s' "$pressure_json" | jq -r 'if .ok then "pending=\(.pendingCount), oldest=\((.oldestPendingAgeMs / 3600000 * 10 | round) / 10)h" else "unavailable=\(.reason)" end' 2>/dev/null || printf 'unavailable=probe_failed')"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2685,15 +2685,15 @@ jobs:
           active_critical_workers="$(( $(active_run_count ".github/workflows/repair-cluster-worker.yml") + $(active_sweep_exact_workers) ))"
           active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"
-          pressure_level="none"
+          pressure_level="unknown"
           hot_intake_unpressured="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           normal_unpressured="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           if [ -z "$exact_item" ]; then
             if ! pressure_json="$(pnpm --dir clawsweeper run --silent workflow -- queue-pressure --queue-url "$QUEUE_URL")"; then
-              pressure_json='{"ok":false,"reason":"probe_failed","level":"none"}'
+              pressure_json='{"ok":false,"reason":"probe_failed","level":"unknown"}'
             fi
-            if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard")' 2>/dev/null)"; then
-              pressure_level="none"
+            if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard" or . == "unknown")' 2>/dev/null)"; then
+              pressure_level="unknown"
             fi
           fi
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -153,7 +153,8 @@ export function workerLimit(
       rawAvailable >= config.workers.minimum_background ? rawAvailable : Math.max(1, rawAvailable);
     const normalBudget = Math.max(1, Math.min(laneMax, withFloor));
     if (pressureLevel === "soft") return Math.ceil(normalBudget * 0.5);
-    if (pressureLevel === "hard") return Math.max(1, Math.floor(normalBudget * 0.1));
+    if (pressureLevel === "hard" || pressureLevel === "unknown")
+      return Math.max(1, Math.floor(normalBudget * 0.1));
     return normalBudget;
   }
 }

--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -4,7 +4,7 @@ export const QUEUE_PRESSURE_SOFT_AGE_MS = 30 * 60 * 1_000;
 export const QUEUE_PRESSURE_HARD_AGE_MS = 2 * 60 * 60 * 1_000;
 export const QUEUE_PRESSURE_FETCH_TIMEOUT_MS = 5_000;
 
-export type QueuePressureLevel = "none" | "soft" | "hard";
+export type QueuePressureLevel = "none" | "soft" | "hard" | "unknown";
 
 export type ExactReviewQueuePressure =
   | {
@@ -91,7 +91,10 @@ export async function fetchExactReviewQueuePressure({
 }
 
 export function queuePressureLevel(pressure: ExactReviewQueuePressure): QueuePressureLevel {
-  if (!pressure.ok) return "none";
+  // An unavailable control-plane signal is not evidence that the queue is empty.
+  // Background admission must retain a bounded capacity until the next healthy
+  // probe, while exact-item work keeps its independent interactive reservation.
+  if (!pressure.ok) return "unknown";
   if (pressure.publicationStatus === "critical") return "hard";
   const hardPending = envThreshold(
     "CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING",

--- a/src/repair/limits.ts
+++ b/src/repair/limits.ts
@@ -171,7 +171,8 @@ export function workerLimit(
       rawAvailable >= config.workers.minimum_background ? rawAvailable : Math.max(1, rawAvailable);
     const normalBudget = Math.max(1, Math.min(laneMax, withFloor));
     if (pressureLevel === "soft") return Math.ceil(normalBudget * 0.5);
-    if (pressureLevel === "hard") return Math.max(1, Math.floor(normalBudget * 0.1));
+    if (pressureLevel === "hard" || pressureLevel === "unknown")
+      return Math.max(1, Math.floor(normalBudget * 0.1));
     return normalBudget;
   }
 }

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -349,7 +349,7 @@ function requiredWorkerLane(value: string): WorkerLane {
 }
 
 function requiredQueuePressureLevel(value: string): QueuePressureLevel {
-  if (value === "none" || value === "soft" || value === "hard") return value;
+  if (value === "none" || value === "soft" || value === "hard" || value === "unknown") return value;
   throw new Error(`unknown queue pressure level: ${value}`);
 }
 

--- a/test/queue-pressure.test.ts
+++ b/test/queue-pressure.test.ts
@@ -28,7 +28,7 @@ test("queue pressure levels include threshold boundaries", () => {
   assert.equal(queuePressureLevel(pressure(0, QUEUE_PRESSURE_SOFT_AGE_MS)), "soft");
   assert.equal(queuePressureLevel(pressure(QUEUE_PRESSURE_HARD_PENDING, 0)), "hard");
   assert.equal(queuePressureLevel(pressure(0, QUEUE_PRESSURE_HARD_AGE_MS)), "hard");
-  assert.equal(queuePressureLevel({ ok: false, reason: "unavailable" }), "none");
+  assert.equal(queuePressureLevel({ ok: false, reason: "unavailable" }), "unknown");
 });
 
 test("queue pressure levels honor environment overrides", () => {
@@ -136,7 +136,7 @@ test("queue pressure uses review thresholds and elevates unhealthy publication",
   assert.deepEqual(emptyReviewLane, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
 });
 
-test("queue pressure fetch fails open on errors, timeouts, and malformed bodies", async () => {
+test("queue pressure fetch fails closed for background admission on errors, timeouts, and malformed bodies", async () => {
   const failed = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",
     fetchImpl: async () => {
@@ -144,7 +144,7 @@ test("queue pressure fetch fails open on errors, timeouts, and malformed bodies"
     },
   });
   assert.deepEqual(failed, { ok: false, reason: "network unavailable" });
-  assert.equal(queuePressureLevel(failed), "none");
+  assert.equal(queuePressureLevel(failed), "unknown");
 
   const timedOut = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",
@@ -155,7 +155,14 @@ test("queue pressure fetch fails open on errors, timeouts, and malformed bodies"
       }),
   });
   assert.deepEqual(timedOut, { ok: false, reason: "timeout" });
-  assert.equal(queuePressureLevel(timedOut), "none");
+  assert.equal(queuePressureLevel(timedOut), "unknown");
+
+  const serverError = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () => Response.json({ error: "unavailable" }, { status: 503 }),
+  });
+  assert.deepEqual(serverError, { ok: false, reason: "http_503" });
+  assert.equal(queuePressureLevel(serverError), "unknown");
 
   for (const body of [
     null,
@@ -169,7 +176,7 @@ test("queue pressure fetch fails open on errors, timeouts, and malformed bodies"
       fetchImpl: async () => Response.json(body),
     });
     assert.deepEqual(malformed, { ok: false, reason: "malformed_response" });
-    assert.equal(queuePressureLevel(malformed), "none");
+    assert.equal(queuePressureLevel(malformed), "unknown");
   }
 });
 
@@ -182,6 +189,10 @@ test("worker limits scale every background lane and leave priority lanes unchang
       workerLimit(lane, { pressureLevel: "hard" }),
       Math.max(1, Math.floor(normalBudget * 0.1)),
     );
+    assert.equal(
+      workerLimit(lane, { pressureLevel: "unknown" }),
+      workerLimit(lane, { pressureLevel: "hard" }),
+    );
   }
 
   const priorityLanes: WorkerLane[] = [
@@ -193,8 +204,21 @@ test("worker limits scale every background lane and leave priority lanes unchang
   ];
   for (const lane of priorityLanes) {
     assert.equal(workerLimit(lane, { pressureLevel: "hard" }), workerLimit(lane));
+    assert.equal(workerLimit(lane, { pressureLevel: "unknown" }), workerLimit(lane));
   }
   assert.equal(workerLimit("normal_review"), AUTOMATION_LIMITS.review_shards.normal_default);
+});
+
+test("a publication-critical unavailable probe cannot admit the normal 89-shard background burst", () => {
+  const normal = workerLimit("normal_review", { pressureLevel: "none" });
+  const conservative = workerLimit("normal_review", { pressureLevel: "unknown" });
+
+  assert.equal(normal, AUTOMATION_LIMITS.review_shards.normal_default);
+  assert.equal(conservative, workerLimit("normal_review", { pressureLevel: "hard" }));
+  assert.ok(conservative >= 1);
+  assert.ok(conservative < normal);
+  assert.notEqual(conservative, 89);
+  assert.equal(workerLimit("exact_item", { pressureLevel: "unknown" }), 1);
 });
 
 function pressure(pendingCount: number, oldestPendingAgeMs: number): ExactReviewQueuePressure {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2535,11 +2535,18 @@ test("background planners fetch exact-review queue pressure once and pass its le
     assert.match(block, /--pressure-level "\$pressure_level"/);
     assert.match(block, /queue pressure: \$pressure_level/);
     assert.match(block, /if ! pressure_json=/);
-    assert.match(block, /unavailable=probe_failed/);
+    assert.match(block, /"level":"unknown"/);
+    assert.match(block, /select\(. == "none" or . == "soft" or . == "hard" or . == "unknown"\)/);
+    assert.doesNotMatch(block, /"level":"none"/);
     assert.match(block, /CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING/);
     assert.match(block, /CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS/);
   }
   assert.match(sweepBlock, /if \[ -z "\$exact_item" \]; then/);
+  assert.ok(
+    sweepBlock.indexOf('if [ -z "$exact_item" ]; then') <
+      sweepBlock.indexOf("queue-pressure --queue-url"),
+    "only background planning may probe and apply queue-pressure admission",
+  );
   assert.match(sweepBlock, /hot_intake \$hot_intake_unpressured->\$hot_intake_shards/);
   assert.match(sweepBlock, /normal_review \$normal_unpressured->\$normal_shards/);
   assert.match(commitBlock, /commit_review \$unpressured_page_size->\$PAGE_SIZE/);


### PR DESCRIPTION
## Summary

Bound background review admission when the exact-review queue pressure probe is unavailable. Scheduled review and commit-review planners no longer interpret timeout, malformed, or 5xx probe outcomes as healthy capacity.

## Problem

Scheduled run 30297641317 timed out while probing queue pressure and then selected the normal 89-item background capacity. Publication was actually critical, so the burst magnified an already blocked publication path.

## Implementation

- Add an explicit `unknown` queue-pressure level for unavailable control-plane responses.
- Apply the existing hard-pressure bounded capacity to `unknown` for background review, hot intake, and commit-review admission.
- Preserve independent exact-item/interactive capacity.
- Make both workflow parsers retain `unknown` rather than falling back to `none`.

## Validation

- `pnpm run build:all`
- `node --test test/queue-pressure.test.ts test/repair/workflow-utils.test.ts`
- `node --test --test-name-pattern "background planners fetch exact-review queue pressure once and pass its level" test/sweep-workflow.test.ts`
- `pnpm run check:limits`
- `pnpm exec oxfmt --check .github/workflows/commit-review.yml .github/workflows/sweep.yml src/limits.ts src/queue-pressure.ts src/repair/limits.ts src/repair/workflow-utils.ts test/queue-pressure.test.ts test/sweep-workflow.test.ts`
- `git diff --check`

The focused proof covers healthy `none`, existing `soft`/`hard`, timeout, malformed, and HTTP 503 outcomes; it proves unknown pressure uses a nonzero hard-equivalent capacity instead of the normal 89-shard burst, while exact-item capacity remains one.

### Controlled Docker/Crabbox workflow trace

Executed on the PR head in a local Docker-backed Crabbox Linux container (`local-container`, Playwright Noble image; lease `cbx_479a8a77664d`). The controlled input used `http://127.0.0.1:1`, which cannot reach a queue service, so no queue, GitHub, state, or workflow-dispatch mutation occurred. After installing from the locked dependency graph and running `pnpm run build:all`, the production `workflow` utility produced this redacted trace:

```text
CSW-071 pressure admission controlled trace
queue_pressure={"ok":false,"reason":"fetch failed","level":"unknown"}
normal_review.none=89
normal_review.unknown=8
exact_item.unknown=1
```

The run exited 0. This exercises the unavailable-probe classification and the same production worker-limit utility called by the planner: the background allowance is bounded below normal capacity and cannot reproduce the 89-shard fan-out, while the exact-item lane remains independently admitted.

`actionlint` is unavailable on this workstation. The changed YAML parses in the repository validation; workflow-specific assertions passed.

The complete `test/sweep-workflow.test.ts` suite has six pre-existing Windows-host failures because its Linux workflow-helper tests invoke `bash` through WSL, whose default `docker-desktop` distro has no `/bin/bash`. This is an intentionally Linux-hosted workflow-test surface (platform-scope classification 3); this PR does not port it or broaden CI.

## Codex review

- Dirty review: `codex review --uncommitted`; no accepted/actionable findings; focused proof rerun afterward.
- Branch review: `codex review --base origin/main`; clean, no accepted/actionable findings.

## Risks and rollout

An unavailable probe intentionally reduces only background throughput to the current hard-pressure budget. It neither disables scheduled work nor changes manual/exact-item admission. No queue, state, deployment, gate, workflow-dispatch, or live-fixture mutation was performed.

## Scope and links

This is CSW-071 PR 1 of 3: pressure admission only. Scheduler bot-sync reconciliation and per-tuple publication/lifecycle isolation remain separate follow-on PRs. It is scoped to the scheduled-run surge and does not take over umbrella issue #898 or the active #901 cluster-intake cutover.

Incident evidence: https://github.com/openclaw/clawsweeper/actions/runs/30297641317
