### PR TITLE
fix(ci): self-dedupe superseded scheduled materializer runs

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -14,11 +14,6 @@ on:
         default: false
         type: boolean
 
-concurrency:
-  group: clawsweeper-state-materializer
-  cancel-in-progress: false
-  queue: max
-
 permissions:
   contents: read
 
@@ -26,10 +21,51 @@ env:
   CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
 
 jobs:
+  # Workflow-level concurrency left superseded runs in status "pending" with no
+  # job created, where neither GitHub's pending-run dedup nor an in-run step
+  # could touch them (observed twice on 2026-07-26: 6-9 pending runs each
+  # serializing up to an hour of lock time for a drain the newest run performs
+  # anyway). Scoping the group to the drain job lets every trigger start this
+  # dedupe job immediately while the drain job alone waits on the group.
+  dedupe:
+    name: Cancel superseded scheduled runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel older runs still waiting for the drain slot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Every cycle drains the whole append window, so any older run that
+          # has not started draining is redundant with this one. Only schedule
+          # runs are candidates: workflow_dispatch runs may carry explicit
+          # inputs (intake_priority) and are never cancelled.
+          gh api "repos/$GITHUB_REPOSITORY/actions/workflows/state-materializer.yml/runs?event=schedule&per_page=100" \
+            --jq ".workflow_runs[] | select(.conclusion == null) | select(.id != $GITHUB_RUN_ID) | select(.run_number < $GITHUB_RUN_NUMBER) | .id" |
+            while IFS= read -r run_id; do
+              # A run whose drain job already executes holds real progress;
+              # runs with only queued/waiting jobs (or none) are superseded.
+              in_progress_jobs="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
+                --jq '[.jobs[] | select(.status == "in_progress")] | length')"
+              if [ "$in_progress_jobs" -gt 0 ]; then
+                echo "Keeping run $run_id: a job is already in progress."
+                continue
+              fi
+              echo "Cancelling superseded scheduled run $run_id: this run drains the same append window."
+              gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/cancel"
+            done
+
   materialize:
     name: Drain queued state into one commit
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: clawsweeper-state-materializer
+      cancel-in-progress: false
+      queue: max
     env:
       CLAWSWEEPER_MODEL_RECOVERY_ENABLED: "1"
       # Priority intent wins a slot quickly; a long acquire budget just lets one

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -145,6 +145,34 @@ test("state materializer checks out a recovery-sized state history window", () =
   assert.equal(setupState?.with?.["fetch-depth"], 512);
 });
 
+test("state materializer self-dedupes superseded scheduled runs", () => {
+  const source = readFileSync(join(workflowDirectory, "state-materializer.yml"), "utf8");
+  const workflow = parse(source) as WorkflowDocument & { concurrency?: unknown };
+  // The drain slot must be job-scoped: workflow-level concurrency left
+  // superseded runs "pending" with no job created, where the dedupe job could
+  // never execute.
+  assert.equal(workflow.concurrency, undefined);
+  const materialize = workflow.jobs?.materialize as
+    | (WorkflowJob & { concurrency?: Record<string, unknown> })
+    | undefined;
+  assert.equal(materialize?.concurrency?.group, "clawsweeper-state-materializer");
+  assert.equal(materialize?.concurrency?.["cancel-in-progress"], false);
+
+  const dedupe = workflow.jobs?.dedupe as
+    | (WorkflowJob & { permissions?: Record<string, unknown>; needs?: unknown })
+    | undefined;
+  assert.ok(dedupe, "dedupe job");
+  assert.equal(dedupe.needs, undefined, "dedupe must start immediately on every trigger");
+  assert.deepEqual(dedupe.permissions, { actions: "write" });
+  const cancelStep = dedupe.steps?.find((step) => String(step.run || "").includes("/cancel"));
+  assert.ok(cancelStep, "cancel step");
+  const command = String(cancelStep.run);
+  // Only schedule-triggered runs are dedupe candidates; workflow_dispatch runs
+  // may carry explicit inputs and must survive.
+  assert.match(command, /\/runs\?event=schedule/);
+  assert.match(command, /run_number < \$GITHUB_RUN_NUMBER/);
+});
+
 test("state materializer bounds its coordinator acquire below the job timeout", () => {
   const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
   const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;


### PR DESCRIPTION
## Summary

Rework of #873 by @RomneyDa — the 5/5 cutover layer of the cluster-fixer reliability stack, re-applied on top of #900 (the reworked #884 dispatch layer) and reconciled with what #879/#899/#900 changed on `main`. RomneyDa's original commit is cherry-picked with authorship preserved; a maintainer fix commit addresses the review findings. #873 stays open for its audit and review history; this PR supersedes it.

What the cutover does (unchanged from #873 in intent):

- Cuts the production intake workflow from broad `repair:publish-main` publication to the durable cluster-intake append/materializer contract.
- Dispatches through durable materialization instead of directly from an intake checkout — now specifically through the #900 receipt-verified path: the materializer verifies the HMAC accepted-intent receipt, publishes the dispatch claim before the workflow side effect, and git ledger/job files are never dispatch authority.
- Publishes worker results by exact changed paths, with bounded priority and automatic self-heal retry.
- Preserves deterministic mutation, security gates, fail-closed behavior, `allow_merge: false`, and all existing production gate settings.

## Changes vs original #873 (review findings)

1. **Target-read tokens are minted for the validated target** (was: hard-coded `openclaw/openclaw`). New `repair:resolve-result-targets` resolves the target repositories from the downloaded worker artifacts (`result.repo`), fails closed on any repository outside the allowed owner or a malformed identity, falls back to the configured default when no result is present, and the reader token is minted for exactly those repositories after artifact download. Regression tests cover the non-default-target path.
2. **Intake uses a read-only, non-persisted state credential.** `create-state-token` now takes permission inputs; intake requests `contents: read` / `actions: read` and hydrates with `persist-credentials: "false"`. Intake's central token and workflow permissions drop to contents-read — intake never publishes from its checkout. Result publication narrows its ClawSweeper app token and workflow permissions to read; state writes go through the state credential and the durable append only.
3. **Publisher-rerun failures are non-blocking.** A failed `gh run rerun` in self-heal logs a warning per run and continues, so one transient API failure cannot suppress the remaining publisher retries or the cluster self-heal step.
4. **Docs state the accurate guarantee**: at-least-once workflow creation with exactly-once worker execution intent (receipt-gated worker-side dedupe), matching #900; also fixed the concurrency description — the worker group is keyed by job path only, not job path + mode.
5. **Rebase-reconciled with #879/#899/#900**: canonical-first record writes and blob transport are untouched by the cutover (cluster paths stay under `jobs/**`/`results/**`), and the intake wake (`state-materializer.yml -f intake_priority=true`) drives the #900 receipt-verified dispatch with claim-before-side-effect ordering.

## Validation

- `pnpm run build:all`, `pnpm run lint`, `pnpm run check:static` (includes format check) — clean.
- Focused suites: `resolve-result-targets`, `state-delta-paths`, `cluster-workflow-security`, `gitcrawl-store`, `cluster-intake-state`, `state-materializer`, `dispatch-receipt-owner`, `state-writer-workflow`, `actions-checkout-v7`, `clawsweeper` — all pass.
- Full `test:repair` category: only the two known environment-sensitive macOS failures (`process-tree-containment` Linux symbols, `state-publication-batching-proof` `/private/var` aliasing), both untouched by this diff and pre-existing on the base.
- Codex autoreview (branch diff vs base): clean, "patch is correct (0.98)".

## Pre-merge live proof checklist (design only — not yet executed)

One real durable cluster intake → receipt-verified dispatch → worker execution → result publication on a low-traffic allowed-owner target (not `openclaw/openclaw`), with all production gates preserved and no automerge.

- [ ] **Dispatch one real intake** against a low-traffic target:
  ```bash
  gh workflow run repair-cluster-intake.yml --repo openclaw/clawsweeper --ref main \
    -f enabled=1 -f target_repo=openclaw/<low-traffic-repo> -f limit=2 -f force_store=true
  ```
  Expect: intake log shows `durable cluster intake accepted: N job(s), delivery cluster-intake:<slug>:<store-sha>`; no state push from the intake run; the state token grant is read-only; a `state-materializer.yml` run starts with `intake_priority=true`.
- [ ] **Receipt-verified dispatch**: materializer log shows accepted-intent receipt verification and the dispatch claim published before `workflow_dispatch`; exactly one `repair-cluster-worker` run per stable dispatch key; the state ledger entry carries `accepted_intent_receipt`; only the accepted job and `results/cluster-repair-intake/<slug>.json` paths are projected — record unrelated job/ledger blob hashes before and after and verify they are unchanged.
- [ ] **Worker execution**: one successful "Plan and review cluster" job for the dispatch key; the dispatch receipt is recorded; record append-to-publication and intake-to-dispatch latency.
- [ ] **Result publication for a non-default target**: the `Resolve result target repositories` step resolves the actual target from the artifact, the reader token is minted for that repository, and the publish/finalize steps succeed — this is the live proof for finding 1.
- [ ] **Crash-window recovery**: cancel the materializer run in the window after the dispatch claim is published and before the run receipt is observed, then re-run the materializer. Expect: recovery verifies the accepted-intent receipt and may create a second workflow run (at-least-once creation), and the worker-side receipt gate skips the duplicate planning pass — assert exactly one planning execution in the ledger and no duplicated GitHub side effects.
- [ ] **Publisher-rerun non-blocking**: with at least one failed `repair-publish-results` run (< 3 attempts) present, trigger `repair-self-heal.yml` with `execute=false`; if a rerun fails, expect the per-run warning and the `Self-heal failed cluster runs` step still executing.
- [ ] **Idempotent replay**: re-dispatch intake for the same store snapshot (`force_store=true`); expect `already accepted` dedupe and no additional worker run.
- [ ] Do not enable automerge and do not merge generated production PRs as part of this proof. If the selector rejects the batch, retain the rejection report as the correct outcome and re-run against a store snapshot with an eligible cluster.

## Credits

Original implementation and stack design by @RomneyDa (#873, on top of #881–#884). Maintainer rework applies the review findings from the #873 review thread.
