### PR TITLE
fix(state): give the materializer drain a 180-minute budget

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -61,7 +61,13 @@ jobs:
   materialize:
     name: Drain queued state into one commit
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 60 minutes proved too tight once the queue runs deep: a late coordinator
+    # grant plus one push-contention recovery cycle (~7-8 min of re-fetching on
+    # the 39.5 GiB state repo per rejected atomic push) repeatedly ate the whole
+    # job (runs 30219467540, 30221544369 cancelled at the kill line). Give the
+    # drain room for a deep window plus several recovery cycles; the dedupe job
+    # keeps the queue short so long runs no longer starve followers.
+    timeout-minutes: 180
     concurrency:
       group: clawsweeper-state-materializer
       cancel-in-progress: false
@@ -80,7 +86,9 @@ jobs:
       CLAWSWEEPER_STATE_COORDINATOR_ACQUIRE_TIMEOUT_MS: "2100000"
       CLAWSWEEPER_STATE_LEASE_PRIORITY: "1"
       CLAWSWEEPER_STATE_LEASE_TTL_MS: "1200000"
-      CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS: "2400000"
+      # Sized to the 180-minute job: leave ~20 minutes of headroom for the
+      # coordinator wait, finalize, and action-event publication steps.
+      CLAWSWEEPER_STATE_MATERIALIZER_MAX_RUNTIME_MS: "9600000"
       # 2k publishes cleanly against the shallow state checkout (run 29913644079
       # committed 1974 paths); 10k batches are rejected at push with
       # "atomic push failed ... status: 5". Size to what demonstrably lands.


### PR DESCRIPTION
60 minutes proved too tight once the append window runs deep: a late coordinator grant plus one or two push-contention recovery cycles (~7-8 min of re-fetching per rejected atomic push on the 39.5 GiB state repo) repeatedly consumed the whole job (runs 30219467540 and 30221544369 died at the kill line mid-drain). Raises the job timeout to 180 minutes and MAX_RUNTIME_MS to 160 minutes so a single dispatched run can drain the entire backlog; #904's dedupe job keeps the queue short so a long run no longer starves followers. Workflow invariant tests pass; autoreview clean.