### PR TITLE
fix(state): give the blob migration a 350-minute budget

### DIFF
--- a/.github/workflows/migrate-state-blobs.yml
+++ b/.github/workflows/migrate-state-blobs.yml
@@ -44,7 +44,10 @@ env:
 jobs:
   migrate:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # 120 minutes was killed twice mid-migration (runs 30300581022, 30313938441):
+    # per-file HMAC uploads of the ~315MB many-file ledger tree need more room.
+    # Idempotent resume makes a long budget safe.
+    timeout-minutes: 350
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The 120-minute job timeout killed the R2 seeding twice mid-run (30300581022, 30313938441); per-file HMAC uploads of the many-file ~315MB ledger tree need more room, and idempotent resume makes a long budget safe.