### PR TITLE
feat(state): make the records-source cutover flippable via repo variable

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -151,6 +151,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           worktree-path: clawsweeper
           fetch-depth: 1
@@ -424,6 +427,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           worktree-path: clawsweeper
           fetch-depth: 1
@@ -547,6 +553,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -99,6 +99,9 @@ jobs:
           coordinator-class: publication_batch
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -168,6 +168,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           persist-credentials: "false"

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -255,6 +255,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: jobs
@@ -554,6 +557,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -163,6 +163,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/repair-commit-finding-intake.yml
+++ b/.github/workflows/repair-commit-finding-intake.yml
@@ -126,6 +126,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -71,6 +71,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -163,6 +163,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -111,6 +111,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           coordinator-class: publication_batch
           token: ${{ steps.state-token.outputs.token }}
 

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -76,6 +76,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -115,6 +115,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -126,6 +126,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           # The materializer is the designated bulk writer of the single-writer
           # plan (RFC #738). In the ordinary lane it starves behind batch-class
           # turns (run 30003798477 timed out after 35 minutes at queue

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1172,6 +1172,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.direct-state-token.outputs.token }}
           fetch-depth: 1
           persist-credentials: false
@@ -1778,6 +1781,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 
@@ -2402,6 +2408,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -2545,6 +2554,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           worktree-path: clawsweeper
           fetch-depth: 1
@@ -3293,6 +3305,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -4015,6 +4030,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -4215,6 +4233,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -4326,6 +4347,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ github.token }}
           persist-credentials: "false"
 
@@ -4539,6 +4563,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
           filter: blob:none
           fetch-depth: 1
@@ -4686,6 +4713,9 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -56,6 +56,38 @@ test("every generated-state checkout receives the explicit coordinator migration
   }
 });
 
+test("hydrating checkouts follow the records-source flip while git-lane tooling stays pinned", () => {
+  // These call sites seed, verify, or reconcile the Worker store *from* git;
+  // flipping them to the Worker transport would be circular.
+  const pinnedGitLane = [
+    ".github/workflows/backfill-worker-records.yml:backfill",
+    ".github/workflows/migrate-state-blobs.yml:migrate",
+    ".github/workflows/worker-records-ops.yml:reconcile",
+    ".github/workflows/worker-records-ops.yml:verify",
+  ];
+  const recordsGate = "${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}";
+  const recordsSecret = "${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}";
+  const pinned: string[] = [];
+  for (const { file, workflow } of workflows()) {
+    for (const [job, definition] of Object.entries(workflow.jobs ?? {})) {
+      for (const step of definition.steps ?? []) {
+        if (!isSetupState(step)) continue;
+        const site = `${file}:${job}`;
+        if (step.with?.["records-source"] === "git") {
+          pinned.push(site);
+          assert.equal(step.with?.["records-url"], undefined, site);
+          assert.equal(step.with?.["records-secret"], undefined, site);
+          continue;
+        }
+        assert.equal(step.with?.["records-source"], recordsGate, site);
+        assert.equal(step.with?.["records-url"], coordinatorUrl, site);
+        assert.equal(step.with?.["records-secret"], recordsSecret, site);
+      }
+    }
+  }
+  assert.deepEqual(pinned.sort(), pinnedGitLane);
+});
+
 test("the setup action exports no long-lived coordinator credential", () => {
   const actionPath = ".github/actions/setup-state/action.yml";
   const source = readFileSync(actionPath, "utf8");


### PR DESCRIPTION
## Summary

Phase 2 of the state-repo retirement needs a single switch to flip record hydration from the git state checkout to the Worker/R2 transport. This PR threads the flip through every hydrating `setup-state` call site as a repo Actions variable:

- `records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}`
- `records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}` (mirrors the existing coordinator-url pattern)
- `records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}` (step-scoped input; the action only consumes it when the source is `worker`)

The action's own default stays `git`, so an unset variable and every workflow not touched here remain on the fail-safe path. Setting `CLAWSWEEPER_RECORDS_SOURCE=worker` (or deleting it) flips/rolls back all 27 hydrating call sites at once, with the hydrator's existing loud git fallback still guarding the cold path.

## Flipped call sites (27)

- `sweep.yml` (10), `commit-review.yml` (3), `repair-cluster-worker.yml` (2): sweep/review runtime and repair execution — the primary record readers.
- `exact-review-batch-publish.yml`, `repair-publish-results.yml`, `state-materializer.yml`: publication/materializer writers that hydrate records before mutating state.
- `repair-cluster-intake.yml`, `repair-commit-finding-intake.yml`, `repair-issue-implementation-intake.yml`, `repair-comment-router.yml`, `repair-conflict-self-heal.yml`, `repair-finalize-open-prs.yml`, `repair-self-heal.yml`: intake/routing/self-heal lanes reading records for normal operation.
- `proof-nudges.yml`, `spam-scanner.yml`: audit/reporting readers.

## Pinned to `records-source: git` (4) and why

- `worker-records-ops.yml` (verify + reconcile jobs): parity verification and authority reconciliation compare the Worker store *against* the git tree; hydrating from the Worker would verify the Worker against itself.
- `backfill-worker-records.yml`: seeds revision-zero Worker records *from* the git checkout — circular on the Worker transport by construction.
- `migrate-state-blobs.yml`: migrates git-side ledger/assets blobs into R2; its input must stay the git checkout.

## Tests

- New shape test in `test/state-writer-workflow.test.ts`: every `setup-state` call site must either carry the vars-driven `records-source` + `records-url` + `records-secret` triple, or be one of the four explicitly enumerated pinned git-lane sites (which must not carry the Worker URL/secret). A new hydrating checkout that forgets the flip fails the suite.
- Existing invariants preserved: 31 setup-state checkouts, coordinator gate/URL on all of them, no job-scoped `CLAWSWEEPER_WEBHOOK_SECRET` in setup-state jobs (the secret rides a step-scoped `with:` input).

## Proof

- `node --test test/state-writer-workflow.test.ts test/worker-state-readers.test.ts`: 27/27 pass.
- `actionlint`: only pre-existing findings (shellcheck info in untouched `run:` blocks, the known `concurrency.queue` key); nothing introduced by this change.
- `pnpm run lint:scripts` and `pnpm run format:check`: clean.
- Autoreview (Codex, local mode): clean, no accepted/actionable findings.
