### PR TITLE
fix(security): keep operational errors out of public responses

### DIFF
--- a/dashboard/error-safety.ts
+++ b/dashboard/error-safety.ts
@@ -1,0 +1,19 @@
+const SERVER_ERROR_MAX_LENGTH = 500;
+const URL_CREDENTIAL_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/giu;
+const URL_SECRET_QUERY_PATTERN =
+  /([?&](?:access_?token|api_?key|key|password|secret|signature|token)=)[^&\s]+/giu;
+const NAMED_SECRET_PATTERN =
+  /\b(GH_TOKEN|GITHUB_TOKEN|OPENAI_API_KEY|CODEX_API_KEY|CLOUDFLARE_API_TOKEN)=([^\s"']+)/giu;
+const GITHUB_TOKEN_PATTERN = /\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]{20,}\b/gu;
+
+export function sanitizedServerError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const sanitized = message
+    .replace(URL_CREDENTIAL_PATTERN, "$1[REDACTED]@")
+    .replace(URL_SECRET_QUERY_PATTERN, "$1[REDACTED]")
+    .replace(NAMED_SECRET_PATTERN, "$1=[REDACTED]")
+    .replace(GITHUB_TOKEN_PATTERN, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/[\r\n\t]+/g, " ")
+    .trim();
+  return sanitized.slice(0, SERVER_ERROR_MAX_LENGTH) || "unknown error";
+}

--- a/dashboard/error-safety.ts
+++ b/dashboard/error-safety.ts
@@ -5,6 +5,7 @@ const URL_SECRET_QUERY_PATTERN =
 const NAMED_SECRET_PATTERN =
   /\b(GH_TOKEN|GITHUB_TOKEN|OPENAI_API_KEY|CODEX_API_KEY|CLOUDFLARE_API_TOKEN)=([^\s"']+)/giu;
 const GITHUB_TOKEN_PATTERN = /\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]{20,}\b/gu;
+const BEARER_CREDENTIAL_PATTERN = /\b((?:authorization\s*:\s*)?bearer\s+)[A-Za-z0-9._~+/-]+=*/giu;
 
 export function sanitizedServerError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -13,6 +14,7 @@ export function sanitizedServerError(error: unknown): string {
     .replace(URL_SECRET_QUERY_PATTERN, "$1[REDACTED]")
     .replace(NAMED_SECRET_PATTERN, "$1=[REDACTED]")
     .replace(GITHUB_TOKEN_PATTERN, "[REDACTED_GITHUB_TOKEN]")
+    .replace(BEARER_CREDENTIAL_PATTERN, "$1[REDACTED]")
     .replace(/[\r\n\t]+/g, " ")
     .trim();
   return sanitized.slice(0, SERVER_ERROR_MAX_LENGTH) || "unknown error";

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -57,6 +57,7 @@ import {
   SnapshotStoreUnavailableError,
   type RecordSnapshot,
 } from "./record-snapshots.ts";
+import { sanitizedServerError } from "./error-safety.ts";
 
 type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
 const GITHUB_TIMEOUT_MS = 4500;
@@ -2286,18 +2287,15 @@ export class ExactReviewQueue {
         );
       } catch (error) {
         if (error instanceof CanonicalRecordTupleConflictError) {
-          return json({ error: "canonical_record_tuple_conflict", detail: error.message }, 409);
+          console.warn(`canonical record tuple conflict: ${sanitizedServerError(error)}`);
+          return json({ error: "canonical_record_tuple_conflict" }, 409);
         }
         if (error instanceof DirectPublicationProjectionCapacityError) {
-          return json({ error: "canonical_record_tuple_capacity", detail: error.message }, 429);
+          console.warn(`canonical record tuple capacity rejected: ${sanitizedServerError(error)}`);
+          return json({ error: "canonical_record_tuple_capacity" }, 429);
         }
-        return json(
-          {
-            error: "invalid_canonical_record_tuple",
-            detail: error instanceof Error ? error.message : String(error),
-          },
-          400,
-        );
+        console.warn(`canonical record tuple rejected: ${sanitizedServerError(error)}`);
+        return json({ error: "invalid_canonical_record_tuple" }, 400);
       }
     }
 
@@ -2433,23 +2431,19 @@ export class ExactReviewQueue {
         );
       } catch (error) {
         if (error instanceof DirectPublicationProjectionCapacityError) {
-          console.warn(`direct publication projection rejected: ${error.message}`);
+          console.warn(`direct publication projection rejected: ${sanitizedServerError(error)}`);
           return json(
             {
               error: "direct_publication_projection_capacity",
-              detail: error.message,
               fallback_required: true,
             },
             429,
           );
         }
-        console.warn(
-          `direct publication plan rejected: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        console.warn(`direct publication plan rejected: ${sanitizedServerError(error)}`);
         return json(
           {
             error: "invalid_direct_publication_plan",
-            detail: error instanceof Error ? error.message : String(error),
             fallback_required: true,
           },
           400,
@@ -7725,11 +7719,9 @@ export class ExactReviewQueue {
       // indistinguishable from rollback-era mutations on the next upgrade.
       this.storage.kv.delete(EXACT_REVIEW_QUEUE_STATE_KEY);
     } catch (error) {
-      console.warn(
-        "exact-review stale legacy rollback shadow could not be removed",
-        error instanceof Error ? error.message : String(error),
-      );
-      throw error;
+      const detail = sanitizedServerError(error);
+      console.warn("exact-review stale legacy rollback shadow could not be removed", detail);
+      throw new Error("exact-review legacy rollback shadow cleanup failed");
     }
     this.reportLegacyMirrorUnavailable(reason);
   }
@@ -12026,7 +12018,9 @@ function snapshotJson(snapshot: RecordSnapshot) {
 
 function snapshotErrorResponse(error: unknown) {
   if (error instanceof SnapshotStoreUnavailableError) {
-    console.error(`snapshot store unavailable: ${error.cause || error.message}`);
+    console.error(
+      `snapshot store unavailable: ${sanitizedServerError(error.cause || error.message)}`,
+    );
     return json(
       {
         error: "snapshot_store_unavailable",
@@ -12046,7 +12040,7 @@ function snapshotErrorResponse(error: unknown) {
       notFound ? 404 : 400,
     );
   }
-  console.error(`snapshot request failed: ${error}`);
+  console.error(`snapshot request failed: ${sanitizedServerError(error)}`);
   return json({ error: "snapshot_request_failed", snapshotStoreAvailable: true }, 500);
 }
 

--- a/dashboard/state-blobs.ts
+++ b/dashboard/state-blobs.ts
@@ -16,6 +16,8 @@
  * writes stream through R2 multipart uploads with fixed-size base64 parts.
  */
 
+import { sanitizedServerError } from "./error-safety.ts";
+
 export const STATE_BLOB_OPERATIONS = [
   "put",
   "stat",
@@ -131,13 +133,8 @@ export async function handleStateBlobRequest(
     return blobJson({ error: "unknown_blob_operation" }, 404);
   } catch (error) {
     if (error instanceof BlobRequestError) return blobJson(error.body, error.status);
-    return blobJson(
-      {
-        error: "blob_store_unavailable",
-        detail: error instanceof Error ? error.message : String(error),
-      },
-      503,
-    );
+    console.error(`state blob request failed: ${sanitizedServerError(error)}`);
+    return blobJson({ error: "blob_store_unavailable" }, 503);
   }
 }
 
@@ -425,10 +422,8 @@ function multipartParts(value: unknown): BlobR2UploadedPart[] | null {
 }
 
 function invalidUpload(error: unknown) {
-  return new BlobRequestError(400, {
-    error: "invalid_blob_upload",
-    detail: error instanceof Error ? error.message : String(error),
-  });
+  console.warn(`state blob upload rejected: ${sanitizedServerError(error)}`);
+  return new BlobRequestError(400, { error: "invalid_blob_upload" });
 }
 
 function blobBucket(value: unknown): BlobR2Bucket | null {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -367,35 +367,63 @@ function gitSubcommand(args: readonly string[]): string | undefined {
 function safeGitDisplayAction(action: string | undefined): string {
   switch (action) {
     case "add":
+      return "add";
     case "commit":
+      return "commit";
     case "config":
+      return "config";
     case "diff":
+      return "diff";
     case "fetch":
+      return "fetch";
     case "checkout":
+      return "checkout";
     case "cat-file":
+      return "cat-file";
     case "check-ref-format":
+      return "check-ref-format";
     case "clean":
+      return "clean";
     case "log":
+      return "log";
     case "ls-remote":
+      return "ls-remote";
     case "ls-files":
+      return "ls-files";
     case "ls-tree":
+      return "ls-tree";
     case "merge-base":
+      return "merge-base";
     case "mktree":
+      return "mktree";
     case "push":
+      return "push";
     case "read-tree":
+      return "read-tree";
     case "rebase":
+      return "rebase";
     case "remote":
+      return "remote";
     case "restore":
+      return "restore";
     case "reset":
+      return "reset";
     case "rev-parse":
+      return "rev-parse";
     case "rm":
+      return "rm";
     case "status":
+      return "status";
     case "update-ref":
+      return "update-ref";
     case "update-index":
+      return "update-index";
     case "hash-object":
+      return "hash-object";
     case "write-tree":
+      return "write-tree";
     case "commit-tree":
-      return action;
+      return "commit-tree";
     default:
       return "command";
   }

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -266,7 +266,7 @@ export function runGit(args: readonly string[], options: GitRunOptions = {}): st
     const detail =
       result.stderr ||
       result.stdout ||
-      `${formatGitDisplayCommand(options.displayArgs ?? args)} exited ${result.status}`;
+      `${formatGitDisplayCommand(gitSubcommand(options.displayArgs ?? args))} exited ${result.status}`;
     throw new Error(detail.trim());
   }
   return result.stdout;
@@ -274,7 +274,7 @@ export function runGit(args: readonly string[], options: GitRunOptions = {}): st
 
 export function spawnGit(args: readonly string[], options: GitRunOptions = {}): GitRunResult {
   recordGitProcess(gitSubcommand(args));
-  console.log(`$ ${formatGitDisplayCommand(options.displayArgs ?? args)}`);
+  console.log(`$ ${formatGitDisplayCommand(gitSubcommand(options.displayArgs ?? args))}`);
   const child = spawnSync("git", [...args], {
     cwd: publishRoot(),
     env: options.env ?? process.env,
@@ -283,12 +283,16 @@ export function spawnGit(args: readonly string[], options: GitRunOptions = {}): 
     maxBuffer: options.maxBuffer ?? 16 * 1024 * 1024,
     timeout: options.timeout,
   });
-  if (!options.quiet && child.stdout) process.stdout.write(child.stdout);
-  if (!options.quiet && child.stderr) process.stderr.write(child.stderr);
+  const credentials = gitCredentialValues(args);
+  const rawStdout = child.stdout ?? "";
+  const safeStdout = redactGitProcessOutput(rawStdout, credentials);
+  const stderr = redactGitProcessOutput(child.stderr ?? "", credentials);
+  if (!options.quiet && safeStdout) process.stdout.write(safeStdout);
+  if (!options.quiet && stderr) process.stderr.write(stderr);
   return {
     status: child.status ?? 1,
-    stdout: child.stdout ?? "",
-    stderr: child.stderr ?? "",
+    stdout: child.status === 0 ? rawStdout : safeStdout,
+    stderr,
     timedOut: (child.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT",
   };
 }
@@ -344,8 +348,8 @@ function recordGitProcess(action: string | undefined): void {
   activeGitPublishMetrics.actions.set(key, (activeGitPublishMetrics.actions.get(key) ?? 0) + 1);
 }
 
-function formatGitDisplayCommand(args: readonly string[]): string {
-  return `git ${safeGitDisplayAction(gitSubcommand(args))} <redacted-args>`;
+function formatGitDisplayCommand(action: string | undefined): string {
+  return `git ${safeGitDisplayAction(action)} <redacted-args>`;
 }
 
 function gitSubcommand(args: readonly string[]): string | undefined {
@@ -1198,7 +1202,8 @@ function gitPublishPhase(phase: string, detail = ""): void {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message.replace(/[\r\n]+/g, " ") : String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return redactGitProcessOutput(message).replace(/[\r\n]+/g, " ");
 }
 
 function gitRunError(
@@ -1209,8 +1214,58 @@ function gitRunError(
   const detail =
     result.stderr ||
     result.stdout ||
-    `${formatGitDisplayCommand(displayArgs)} exited ${result.status}`;
+    `${formatGitDisplayCommand(gitSubcommand(displayArgs))} exited ${result.status}`;
   return new Error(detail.trim());
+}
+
+type GitCredentialValues = {
+  passwords: readonly string[];
+  usernames: readonly string[];
+};
+
+function gitCredentialValues(args: readonly string[]): GitCredentialValues {
+  const passwords = new Set<string>();
+  const usernames = new Set<string>();
+  for (const argument of args) {
+    if (!argument.includes("://")) continue;
+    try {
+      const url = new URL(argument);
+      if (url.username) usernames.add(decodeURIComponent(url.username));
+      if (url.password) passwords.add(decodeURIComponent(url.password));
+    } catch {
+      // Invalid URLs are still covered by the generic credential patterns below.
+    }
+  }
+  const longestFirst = (left: string, right: string) => right.length - left.length;
+  return {
+    passwords: [...passwords].filter(Boolean).sort(longestFirst),
+    usernames: [...usernames].filter(Boolean).sort(longestFirst),
+  };
+}
+
+function redactGitProcessOutput(
+  value: string,
+  credentials: GitCredentialValues = { passwords: [], usernames: [] },
+): string {
+  let redacted = value;
+  for (const secret of credentials.passwords) {
+    redacted = redacted.replaceAll(secret, "[REDACTED]");
+  }
+  for (const username of credentials.usernames) {
+    const escaped = username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    redacted = redacted.replace(
+      new RegExp(`(?<![A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`, "gu"),
+      "[REDACTED]",
+    );
+  }
+  return redacted
+    .replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/giu, "$1[REDACTED]@")
+    .replace(
+      /([?&](?:access_?token|api_?key|key|password|secret|signature|token)=)[^&\s]+/giu,
+      "$1[REDACTED]",
+    )
+    .replace(/\b(GH_TOKEN|GITHUB_TOKEN)=([^\s"']+)/giu, "$1=[REDACTED]")
+    .replace(/\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]{20,}\b/gu, "[REDACTED_GITHUB_TOKEN]");
 }
 
 export function mergeBaseWithShallowRecovery(

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -7601,20 +7601,29 @@ test("exact-review rolls SQL back when an obsolete shadow cannot be removed", as
   const queue = new ExactReviewQueue({ storage }, {});
   await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
   const originalShadow = structuredClone(storage.rawGet("exact-review-queue"));
+  const secret = "legacy-shadow-secret";
   storage.failNextPut("exact-review-queue");
-  storage.failNextDelete("exact-review-queue");
+  storage.failNextDelete(
+    "exact-review-queue",
+    new Error(
+      `legacy shadow delete failed at https://operator:${secret}@storage.example/shadow?token=${secret}`,
+    ),
+  );
   const warnings: unknown[][] = [];
   const originalWarn = console.warn;
   console.warn = (...args) => warnings.push(args);
   try {
     await assert.rejects(
       queue.fetch(buildExactReviewQueueRequest("delivery-atomic-shadow", 633, "opened")),
-      /injected storage delete failure/,
+      /exact-review legacy rollback shadow cleanup failed/,
     );
   } finally {
     console.warn = originalWarn;
   }
   assert.match(String(warnings[0][0]), /stale legacy rollback shadow could not be removed/);
+  assert.doesNotMatch(warnings.flat().join("\n"), new RegExp(secret));
+  assert.match(warnings.flat().join("\n"), /https:\/\/\[REDACTED\]@storage\.example/);
+  assert.match(warnings.flat().join("\n"), /token=\[REDACTED\]/);
   assert.deepEqual(storage.rawGet("exact-review-queue"), originalShadow);
   let state = (await storage.get("exact-review-queue")) as {
     deliveries: Record<string, number>;
@@ -9039,6 +9048,46 @@ test("canonical tuple publication updates Worker authority and appends one proje
   const rejected = await queue.fetch(stateAppendQueueRequest("/records/tuples", conflict));
   assert.equal(rejected.status, 409);
   assert.equal((await rejected.json()).error, "canonical_record_tuple_conflict");
+});
+
+test("canonical tuple failures return stable errors and sanitize server logs", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const secret = "canonical-storage-secret";
+  storage.failNextSql(
+    /INSERT INTO state_append_window/,
+    new Error(
+      `database unavailable at https://operator:${secret}@storage.example/records?token=${secret}`,
+    ),
+  );
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...values: unknown[]) => warnings.push(values.join(" "));
+  try {
+    const response = await queue.fetch(
+      stateAppendQueueRequest("/records/tuples", {
+        deliveryId: "record-tuple:failure:42",
+        key: "openclaw-openclaw/42",
+        operations: [
+          {
+            path: "records/openclaw-openclaw/items/42.md",
+            expectedDigest: null,
+            contentBase64: Buffer.from("record\n").toString("base64"),
+          },
+          { path: "records/openclaw-openclaw/closed/42.md", expectedDigest: null },
+          { path: "records/openclaw-openclaw/plans/42.md", expectedDigest: null },
+          { path: "records/openclaw-openclaw/decision-packets/42.json", expectedDigest: null },
+        ],
+      }),
+    );
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "invalid_canonical_record_tuple" });
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.doesNotMatch(warnings.join("\n"), new RegExp(secret));
+  assert.match(warnings.join("\n"), /https:\/\/\[REDACTED\]@storage\.example/);
+  assert.match(warnings.join("\n"), /token=\[REDACTED\]/);
 });
 
 test("canonical tuple publication accepts explicit absent sidecars and closed records", async () => {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -4877,12 +4877,10 @@ test("spawnGit never copies environment-derived command names into logs", () => 
   write(path.join(fakeBin, "git"), ["#!/bin/sh", "exit 0", ""].join("\n"));
   fs.chmodSync(path.join(fakeBin, "git"), 0o755);
 
-  const lines = withEnv(
-    { GITHUB_TOKEN: token, PATH: `${fakeBin}:${process.env.PATH}` },
-    () =>
-      captureConsoleLog(() => {
-        spawnGit([process.env.GITHUB_TOKEN ?? ""], { quiet: true });
-      }),
+  const lines = withEnv({ GITHUB_TOKEN: token, PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+    captureConsoleLog(() => {
+      spawnGit([process.env.GITHUB_TOKEN ?? ""], { quiet: true });
+    }),
   );
 
   assert.deepEqual(lines, ["$ git command <redacted-args>"]);

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -4870,6 +4870,25 @@ test("setTokenOrigin redacts tokens from command logs", () => {
   );
 });
 
+test("spawnGit never copies environment-derived command names into logs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-command-log-"));
+  const fakeBin = path.join(root, "bin");
+  const token = "environment-derived-secret";
+  write(path.join(fakeBin, "git"), ["#!/bin/sh", "exit 0", ""].join("\n"));
+  fs.chmodSync(path.join(fakeBin, "git"), 0o755);
+
+  const lines = withEnv(
+    { GITHUB_TOKEN: token, PATH: `${fakeBin}:${process.env.PATH}` },
+    () =>
+      captureConsoleLog(() => {
+        spawnGit([process.env.GITHUB_TOKEN ?? ""], { quiet: true });
+      }),
+  );
+
+  assert.deepEqual(lines, ["$ git command <redacted-args>"]);
+  assert.doesNotMatch(lines.join("\n"), new RegExp(token));
+});
+
 test("setTokenOrigin redacts credentials from subprocess failures", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-redaction-"));
   const fakeBin = path.join(root, "bin");

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -4870,6 +4870,97 @@ test("setTokenOrigin redacts tokens from command logs", () => {
   );
 });
 
+test("setTokenOrigin redacts credentials from subprocess failures", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-redaction-"));
+  const fakeBin = path.join(root, "bin");
+  const token = "super-secret-token";
+  write(
+    path.join(fakeBin, "git"),
+    [
+      "#!/bin/sh",
+      `echo "fatal: could not access 'https://x-access-token:${token}@github.com/openclaw/clawsweeper.git': denied" >&2`,
+      `echo "GITHUB_TOKEN=${token}" >&2`,
+      "exit 1",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(path.join(fakeBin, "git"), 0o755);
+
+  let failure: unknown;
+  const stderr: string[] = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = ((value: string | Uint8Array) => {
+    stderr.push(String(value));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () => {
+      try {
+        setTokenOrigin(token, "openclaw/clawsweeper");
+      } catch (error) {
+        failure = error;
+      }
+    });
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  assert.ok(failure instanceof Error);
+  assert.doesNotMatch(failure.message, new RegExp(token));
+  assert.doesNotMatch(stderr.join(""), new RegExp(token));
+  assert.match(failure.message, /https:\/\/\[REDACTED\]@github\.com/);
+  assert.match(failure.message, /GITHUB_TOKEN=\[REDACTED\]/);
+});
+
+test("spawnGit preserves ordinary successful output while sanitizing URL credentials", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-stdout-"));
+  const fakeBin = path.join(root, "bin");
+  write(
+    path.join(fakeBin, "git"),
+    ["#!/bin/sh", 'echo "refs/heads/digit"', "exit 0", ""].join("\n"),
+  );
+  fs.chmodSync(path.join(fakeBin, "git"), 0o755);
+
+  const stdout: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((value: string | Uint8Array) => {
+    stdout.push(String(value));
+    return true;
+  }) as typeof process.stdout.write;
+  let result;
+  try {
+    result = withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+      spawnGit(["ls-remote", "https://git:secret@github.com/openclaw/clawsweeper.git"]),
+    );
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "refs/heads/digit\n");
+  assert.doesNotMatch(stdout.join(""), /secret/);
+  assert.equal(stdout.at(-1), "refs/heads/digit\n");
+});
+
+test("spawnGit redacts username-only URL credentials from failures", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-username-"));
+  const fakeBin = path.join(root, "bin");
+  const token = "username-only-secret-token";
+  write(
+    path.join(fakeBin, "git"),
+    ["#!/bin/sh", `echo "fatal: credential ${token}. rejected" >&2`, "exit 1", ""].join("\n"),
+  );
+  fs.chmodSync(path.join(fakeBin, "git"), 0o755);
+
+  const result = withEnv({ PATH: `${fakeBin}:${process.env.PATH}` }, () =>
+    spawnGit(["fetch", `https://${token}@github.com/openclaw/clawsweeper.git`], { quiet: true }),
+  );
+
+  assert.equal(result.status, 1);
+  assert.doesNotMatch(result.stderr, new RegExp(token));
+  assert.match(result.stderr, /credential \[REDACTED\]\. rejected/);
+});
+
 function withCwd(cwd, callback) {
   const previous = process.cwd();
   process.chdir(cwd);

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -62,10 +62,11 @@ test("state blob endpoints reject unsigned requests and fail closed without a bu
 
 test("state blob failures return stable errors and sanitize server logs", async () => {
   const sensitive = "secret-state-token";
+  const bearerCredential = ["bearer", "credential", "value"].join("-");
   const bucket = new FakeR2Bucket();
   bucket.head = async () => {
     throw new Error(
-      `R2 request failed at https://operator:${sensitive}@storage.example/object?token=${sensitive}`,
+      `R2 request failed at https://operator:${sensitive}@storage.example/object?token=${sensitive}; Authorization: Bearer ${bearerCredential}`,
     );
   };
   const errors: string[] = [];
@@ -82,8 +83,10 @@ test("state blob failures return stable errors and sanitize server logs", async 
     console.error = originalError;
   }
   assert.doesNotMatch(errors.join("\n"), new RegExp(sensitive));
+  assert.doesNotMatch(errors.join("\n"), new RegExp(bearerCredential));
   assert.match(errors.join("\n"), /https:\/\/\[REDACTED\]@storage\.example/);
   assert.match(errors.join("\n"), /token=\[REDACTED\]/);
+  assert.match(errors.join("\n"), /Authorization: Bearer \[REDACTED\]/);
 });
 
 test("single-shot blob uploads verify digests server-side and re-put idempotently", async () => {

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -60,6 +60,32 @@ test("state blob endpoints reject unsigned requests and fail closed without a bu
   );
 });
 
+test("state blob failures return stable errors and sanitize server logs", async () => {
+  const sensitive = "secret-state-token";
+  const bucket = new FakeR2Bucket();
+  bucket.head = async () => {
+    throw new Error(
+      `R2 request failed at https://operator:${sensitive}@storage.example/object?token=${sensitive}`,
+    );
+  };
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...values: unknown[]) => errors.push(values.join(" "));
+  try {
+    const response = await worker.fetch(signedBlobRequest("stat", { path: ledgerPath }), {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      STATE_SNAPSHOTS: bucket,
+    });
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), { error: "blob_store_unavailable" });
+  } finally {
+    console.error = originalError;
+  }
+  assert.doesNotMatch(errors.join("\n"), new RegExp(sensitive));
+  assert.match(errors.join("\n"), /https:\/\/\[REDACTED\]@storage\.example/);
+  assert.match(errors.join("\n"), /token=\[REDACTED\]/);
+});
+
 test("single-shot blob uploads verify digests server-side and re-put idempotently", async () => {
   const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
   const options = { baseUrl, webhookSecret: secret, fetch: viaWorker(env) };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where backend storage and Git subprocess failures could expose credential-bearing URLs, tokens, or internal error details through API responses and operator logs.

## Why This Change Was Made

Public dashboard/blob responses now return stable error codes while sanitized, length-bounded details stay server-side. Git publishing redacts URL passwords, token query values, named token variables, and GitHub token forms from failed subprocess output without corrupting ordinary successful output.

## User Impact

Operators retain actionable stable diagnostics, while callers and logs no longer receive raw backend or credential-bearing failure strings.

## Evidence

- 70 repair tests passed
- 252 dashboard tests passed
- 12 blob tests passed
- focused redaction regression tests: 3/3 passed after maintainer correction
- TypeScript, oxfmt, oxlint, and `git diff --check` passed
- autoreview clean with no actionable findings

AI-assisted: yes; the complete diff and redaction behavior were maintainer-reviewed.
