### PR TITLE
perf(state): bounded-concurrency blob migration with contiguous resume cursors

### DIFF
--- a/.github/workflows/migrate-state-blobs.yml
+++ b/.github/workflows/migrate-state-blobs.yml
@@ -30,6 +30,11 @@ on:
           - multipart
           - all
         default: multipart
+      concurrency:
+        description: Concurrent blob uploads (per-file round trips dominate the runtime).
+        required: false
+        type: number
+        default: 12
 
 concurrency:
   group: migrate-state-blobs
@@ -44,9 +49,10 @@ env:
 jobs:
   migrate:
     runs-on: ubuntu-latest
-    # 120 minutes was killed twice mid-migration (runs 30300581022, 30313938441):
-    # per-file HMAC uploads of the ~315MB many-file ledger tree need more room.
-    # Idempotent resume makes a long budget safe.
+    # 120 minutes was killed twice mid-migration (runs 30300581022, 30313938441)
+    # and 350 once (run 30321613186) while uploads were strictly sequential;
+    # bounded concurrency (default 12) removes the per-file round-trip
+    # bottleneck, and idempotent resume makes the long budget safe regardless.
     timeout-minutes: 350
     steps:
       - uses: actions/checkout@v7
@@ -83,13 +89,14 @@ jobs:
           MIGRATE_CURSOR: ${{ inputs.cursor }}
           MIGRATE_MAX_FILES: ${{ inputs.max_files }}
           MIGRATE_VERIFY: ${{ inputs.verify }}
+          MIGRATE_CONCURRENCY: ${{ inputs.concurrency }}
         run: |
           case "$MIGRATE_TREES" in
             ledger) trees="ledger/v1" ;;
             assets) trees="assets" ;;
             *) trees="ledger/v1,assets" ;;
           esac
-          args=(--state-dir clawsweeper-state --trees "$trees" --cursor "$MIGRATE_CURSOR" --verify "$MIGRATE_VERIFY")
+          args=(--state-dir clawsweeper-state --trees "$trees" --cursor "$MIGRATE_CURSOR" --verify "$MIGRATE_VERIFY" --concurrency "$MIGRATE_CONCURRENCY")
           if (( MIGRATE_MAX_FILES > 0 )); then
             args+=(--max-files "$MIGRATE_MAX_FILES")
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- The `migrate-state-blobs` workflow uploads with bounded concurrency (default 12, input-configurable) instead of strictly sequential per-file round trips, reports a contiguous-prefix resume cursor that stays valid under out-of-order completion, and backs off adaptively on 429/5xx pressure; three prior runs had hit the job timeout before finishing the ledger tree.
 - Bound durable cluster dispatch recovery to a verifiable accepted-intent receipt and strictly validated v2 intake ledgers. Thanks @RomneyDa! (#883)
 - Prioritized durable cluster intake without starving sweep, router, proof, or canonical tuple rows during sustained intake. Thanks @RomneyDa! (#882)
 - Made every item/closed/plan/decision-packet writer publish an atomic canonical Worker tuple first, leaving the git state tree as materializer-only projection; added bounded canonical projection replay for migration convergence.

--- a/scripts/migrate-state-blobs.ts
+++ b/scripts/migrate-state-blobs.ts
@@ -2,10 +2,12 @@
 /**
  * Cursor-resumable migration of the git state repo's `ledger/v1` and `assets`
  * trees into R2 through the Worker's `/internal/state/blobs/*` endpoints
- * (Cloudflare-canonical phase 3). Walks the state checkout, uploads every file
- * with digest verification, and prints a JSON summary. Idempotent: a repeat run
- * reports already-uploaded files as unchanged, and a diverging immutable
- * ledger key fails loudly with a 409.
+ * (Cloudflare-canonical phase 3). Walks the state checkout, uploads files with
+ * bounded concurrency (--concurrency, default 12) and digest verification, and
+ * prints a JSON summary. Idempotent: a repeat run reports already-uploaded
+ * files as unchanged, and a diverging immutable ledger key fails loudly with a
+ * 409. Progress lines report a contiguous-prefix resume cursor that stays
+ * valid under out-of-order completion.
  */
 import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
@@ -19,6 +21,7 @@ import {
   statStateBlob,
   uploadStateBlob,
 } from "./worker-blobs.ts";
+import { WorkerRecordRequestError } from "./worker-records.ts";
 
 type MigrateArgs = {
   stateDir?: string;
@@ -27,7 +30,13 @@ type MigrateArgs = {
   cursor?: number;
   maxFiles?: number;
   verify?: "multipart" | "all";
+  concurrency?: number;
 };
+
+export const MIGRATE_DEFAULT_CONCURRENCY = 12;
+const MIGRATE_PRESSURE_MAX_ATTEMPTS = 6;
+const MIGRATE_BACKOFF_BASE_MS = 500;
+const MIGRATE_BACKOFF_MAX_MS = 30_000;
 
 export async function migrateStateBlobs(
   argv: string[],
@@ -66,6 +75,7 @@ export async function migrateStateBlobs(
     maxFiles === Number.POSITIVE_INFINITY ? files.length : cursor + maxFiles,
   );
   const verifyMode = args.verify ?? "multipart";
+  const concurrency = args.concurrency ?? MIGRATE_DEFAULT_CONCURRENCY;
 
   const summary = {
     trees,
@@ -80,26 +90,26 @@ export async function migrateStateBlobs(
   };
   const verifyRoot = mkdtempSync(path.join(tmpdir(), "clawsweeper-blob-verify-"));
   try {
-    let completed = cursor;
-    for (const blobPath of selected) {
+    const backoff = createAdaptiveBackoff(backoffBaseMs(env));
+    // Per-file migration: read lazily (only in-flight files stay in memory),
+    // digest-skip unchanged blobs, and re-download multipart uploads whose
+    // digest is client-claimed. Counters are applied only after the file's
+    // final successful attempt so a pressure retry never double-counts.
+    const migrateFile = async (blobPath: string, index: number) => {
       const content = readFileSync(path.join(stateRoot, ...blobPath.split("/")));
       const digest = createHash("sha256").update(content).digest("hex");
-      const existing = await statStateBlob({ ...request, blobPath });
-      if (existing && existing.digest === digest && existing.bytes === content.byteLength) {
-        summary.unchanged += 1;
-      } else {
-        const uploaded = await uploadStateBlob({ ...request, blobPath, content });
-        if (uploaded.unchanged) {
-          summary.unchanged += 1;
-        } else {
-          summary.uploaded += 1;
-          summary.bytesUploaded += content.byteLength;
+      const attemptOnce = async (): Promise<{ uploaded: boolean; verified: boolean }> => {
+        const existing = await statStateBlob({ ...request, blobPath });
+        if (existing && existing.digest === digest && existing.bytes === content.byteLength) {
+          return { uploaded: false, verified: false };
         }
+        const uploaded = await uploadStateBlob({ ...request, blobPath, content });
+        if (uploaded.unchanged) return { uploaded: false, verified: false };
         // Single-shot uploads are digest-verified by the Worker before the
         // object is written; multipart digests are client-claimed, so read
         // them back. --verify all forces read-back for every upload.
-        if (!uploaded.unchanged && (uploaded.transport === "multipart" || verifyMode === "all")) {
-          const destination = path.join(verifyRoot, `verify-${summary.verified}`);
+        if (uploaded.transport === "multipart" || verifyMode === "all") {
+          const destination = path.join(verifyRoot, `verify-${index}`);
           const downloaded = await downloadStateBlob({
             ...request,
             blobPath,
@@ -110,17 +120,120 @@ export async function migrateStateBlobs(
           if (downloaded.digest !== digest) {
             throw new Error(`Post-upload digest mismatch for ${blobPath}`);
           }
-          summary.verified += 1;
+          return { uploaded: true, verified: true };
+        }
+        return { uploaded: true, verified: false };
+      };
+      // Adaptive pressure retry: the transport already retries transient 5xx
+      // per request, so an escaping 429/5xx means sustained pressure. Pause
+      // every worker (shared backoff) and retry the whole file — the stat
+      // digest-skip makes a re-attempt after a partial success idempotent.
+      for (let attempt = 1; ; attempt += 1) {
+        await backoff.beforeAttempt();
+        try {
+          const outcome = await attemptOnce();
+          backoff.recordSuccess();
+          if (outcome.uploaded) {
+            summary.uploaded += 1;
+            summary.bytesUploaded += content.byteLength;
+            if (outcome.verified) summary.verified += 1;
+          } else {
+            summary.unchanged += 1;
+          }
+          return;
+        } catch (error) {
+          if (!isPressureError(error) || attempt >= MIGRATE_PRESSURE_MAX_ATTEMPTS) throw error;
+          backoff.recordPressure();
+          console.error(
+            `[state-blob-migration] pressure retry attempt=${attempt} path=${blobPath}`,
+          );
         }
       }
-      completed += 1;
-      console.error(`[state-blob-migration] file=${completed}/${files.length} path=${blobPath}`);
+    };
+
+    const done = Array.from({ length: selected.length }, () => false);
+    // `contiguous` counts the fully-completed prefix of `selected`: with
+    // out-of-order completion under concurrency, only `cursor + contiguous`
+    // is a safe resume cursor, so that is what the progress lines report.
+    let contiguous = 0;
+    let completedCount = 0;
+    let nextIndex = 0;
+    let firstError: unknown;
+    const runWorker = async () => {
+      while (firstError === undefined) {
+        const index = nextIndex++;
+        if (index >= selected.length) return;
+        const blobPath = selected[index]!;
+        try {
+          await migrateFile(blobPath, index);
+        } catch (error) {
+          firstError ??= error;
+          return;
+        }
+        done[index] = true;
+        while (contiguous < selected.length && done[contiguous]) contiguous += 1;
+        completedCount += 1;
+        // Flushed per file so a cancelled run's log tail still names the last
+        // safe resume cursor.
+        console.error(
+          `[state-blob-migration] file=${cursor + completedCount}/${files.length} resumeCursor=${cursor + contiguous} path=${blobPath}`,
+        );
+      }
+    };
+    const workerCount = Math.max(1, Math.min(concurrency, selected.length));
+    await Promise.all(Array.from({ length: workerCount }, runWorker));
+    if (firstError !== undefined) {
+      console.error(
+        `[state-blob-migration] aborting after failure; resume with --cursor ${cursor + contiguous}`,
+      );
+      throw firstError;
     }
   } finally {
     rmSync(verifyRoot, { force: true, recursive: true });
   }
   console.log(JSON.stringify(summary));
   return summary;
+}
+
+function isPressureError(error: unknown) {
+  return error instanceof WorkerRecordRequestError && (error.status === 429 || error.status >= 500);
+}
+
+// Shared across every upload worker: one 429/5xx pauses the whole pool, and
+// repeated pressure grows the pause exponentially (capped) until a request
+// succeeds again.
+function createAdaptiveBackoff(baseMs: number) {
+  let level = 0;
+  let pauseUntil = 0;
+  return {
+    async beforeAttempt() {
+      for (;;) {
+        const wait = pauseUntil - Date.now();
+        if (wait <= 0) return;
+        await new Promise((resolve) => setTimeout(resolve, wait));
+      }
+    },
+    recordSuccess() {
+      level = 0;
+    },
+    recordPressure() {
+      level += 1;
+      const delay = Math.min(baseMs * 2 ** (level - 1), MIGRATE_BACKOFF_MAX_MS);
+      pauseUntil = Math.max(pauseUntil, Date.now() + delay);
+    },
+  };
+}
+
+// Test seam: production runs use the default; tests shrink the base delay so
+// pressure-retry coverage does not sleep for real.
+function backoffBaseMs(env: NodeJS.ProcessEnv) {
+  const raw = env.CLAWSWEEPER_MIGRATE_BACKOFF_BASE_MS;
+  if (!raw) return MIGRATE_BACKOFF_BASE_MS;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Invalid CLAWSWEEPER_MIGRATE_BACKOFF_BASE_MS: ${raw}`);
+  }
+  return value;
 }
 
 function collectTreeFiles(stateRoot: string, tree: string): string[] {
@@ -155,6 +268,7 @@ function parseArgs(argv: string[]): MigrateArgs {
     } else if (arg === "--records-url") parsed.recordsUrl = requiredValue(argv, ++index, arg);
     else if (arg === "--cursor") parsed.cursor = nonNegativeInteger(argv, ++index, arg);
     else if (arg === "--max-files") parsed.maxFiles = positiveInteger(argv, ++index, arg);
+    else if (arg === "--concurrency") parsed.concurrency = positiveInteger(argv, ++index, arg);
     else if (arg === "--verify") {
       const value = requiredValue(argv, ++index, arg);
       if (value !== "multipart" && value !== "all") {

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -345,6 +345,143 @@ test("state blob migration is cursor-resumable, idempotent, and loud on ledger d
   }
 });
 
+test("concurrent migration uploads every file exactly once and repeat runs skip them", async () => {
+  const fixture = createWideStateFixture(9);
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const workerFetch = viaWorker(env);
+  const putPaths: string[] = [];
+  const counting: typeof globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/internal/state/blobs/put")) {
+      putPaths.push(JSON.parse(String(init?.body)).path);
+    }
+    return workerFetch(input, init);
+  };
+  const processEnv = { CLAWSWEEPER_WEBHOOK_SECRET: secret, CLAWSWEEPER_RECORDS_URL: baseUrl };
+  try {
+    const first = await migrateStateBlobs(
+      ["--state-dir", fixture.stateRoot, "--concurrency", "4"],
+      processEnv,
+      counting,
+    );
+    assert.equal(first.uploaded, fixture.blobFiles.length);
+    assert.equal(first.unchanged, 0);
+    assert.equal(first.nextCursor, null);
+    assert.deepEqual([...putPaths].sort(), fixture.blobFiles);
+
+    const options = { baseUrl, webhookSecret: secret, fetch: workerFetch };
+    for (const blobPath of fixture.blobFiles) {
+      const stat = await statStateBlob({ ...options, blobPath });
+      assert.equal(stat?.digest, sha256(readFileSync(path.join(fixture.stateRoot, blobPath))));
+    }
+
+    putPaths.length = 0;
+    const repeat = await migrateStateBlobs(
+      ["--state-dir", fixture.stateRoot, "--concurrency", "4"],
+      processEnv,
+      counting,
+    );
+    assert.equal(repeat.uploaded, 0);
+    assert.equal(repeat.unchanged, fixture.blobFiles.length);
+    assert.deepEqual(putPaths, []);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("migration progress reports a contiguous-prefix resume cursor under out-of-order completion", async () => {
+  const fixture = createWideStateFixture(6);
+  const firstPath = fixture.blobFiles[0]!;
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const workerFetch = viaWorker(env);
+  // Hold the sorted-first file's upload until two later files have landed, so
+  // completion order is provably out of order.
+  let releaseFirst!: () => void;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let otherPuts = 0;
+  const gated: typeof globalThis.fetch = async (input, init) => {
+    const isPut = String(input).endsWith("/internal/state/blobs/put");
+    const putPath = isPut ? JSON.parse(String(init?.body)).path : null;
+    if (putPath === firstPath) await firstGate;
+    const response = await workerFetch(input, init);
+    if (putPath !== null && putPath !== firstPath) {
+      otherPuts += 1;
+      if (otherPuts === 2) releaseFirst();
+    }
+    return response;
+  };
+  const lines: string[] = [];
+  const originalError = console.error;
+  console.error = (...values: unknown[]) => lines.push(values.join(" "));
+  try {
+    const summary = await migrateStateBlobs(
+      ["--state-dir", fixture.stateRoot, "--concurrency", "3"],
+      { CLAWSWEEPER_WEBHOOK_SECRET: secret, CLAWSWEEPER_RECORDS_URL: baseUrl },
+      gated,
+    );
+    assert.equal(summary.uploaded, fixture.blobFiles.length);
+
+    const progress = lines
+      .filter((line) => line.includes("resumeCursor="))
+      .map((line) => {
+        const match = line.match(/file=(\d+)\/\d+ resumeCursor=(\d+) path=(.+)$/);
+        assert.ok(match, `unparseable progress line: ${line}`);
+        return { file: Number(match[1]), resumeCursor: Number(match[2]), path: match[3]! };
+      });
+    // One flushed progress line per completed file.
+    assert.equal(progress.length, fixture.blobFiles.length);
+    const firstLineIndex = progress.findIndex((entry) => entry.path === firstPath);
+    assert.ok(firstLineIndex >= 2, "first file must complete after at least two later files");
+    // Until the first file lands, no prefix is complete: the safe resume
+    // cursor must stay at 0 even though later files already finished.
+    for (const entry of progress.slice(0, firstLineIndex)) {
+      assert.equal(entry.resumeCursor, 0);
+    }
+    for (let index = 1; index < progress.length; index += 1) {
+      assert.ok(progress[index]!.resumeCursor >= progress[index - 1]!.resumeCursor);
+    }
+    assert.equal(progress.at(-1)!.resumeCursor, fixture.blobFiles.length);
+  } finally {
+    console.error = originalError;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("migration backs off and retries when the worker signals 429 pressure", async () => {
+  const fixture = createWideStateFixture(4);
+  const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
+  const workerFetch = viaWorker(env);
+  let served429 = 0;
+  const throttled: typeof globalThis.fetch = async (input, init) => {
+    if (String(input).endsWith("/internal/state/blobs/put") && served429 === 0) {
+      served429 += 1;
+      return new Response(JSON.stringify({ error: "rate_limited" }), { status: 429 });
+    }
+    return workerFetch(input, init);
+  };
+  const lines: string[] = [];
+  const originalError = console.error;
+  console.error = (...values: unknown[]) => lines.push(values.join(" "));
+  try {
+    const summary = await migrateStateBlobs(
+      ["--state-dir", fixture.stateRoot, "--concurrency", "2"],
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: secret,
+        CLAWSWEEPER_RECORDS_URL: baseUrl,
+        CLAWSWEEPER_MIGRATE_BACKOFF_BASE_MS: "1",
+      },
+      throttled,
+    );
+    assert.equal(served429, 1);
+    assert.equal(summary.uploaded, fixture.blobFiles.length);
+    assert.match(lines.join("\n"), /pressure retry attempt=1/);
+  } finally {
+    console.error = originalError;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("hydrate-state defaults ledger hydration to git and never calls the worker", async () => {
   const fixture = createStateFixture();
   const target = path.join(fixture.root, "git-target");
@@ -520,6 +657,21 @@ function createStateFixture() {
     assetFiles,
     blobFiles: [...ledgerFiles, ...assetFiles].sort(),
   };
+}
+
+function createWideStateFixture(ledgerCount: number) {
+  const root = mkdtempSync(path.join(tmpdir(), "clawsweeper-state-blobs-wide-"));
+  const stateRoot = path.join(root, "state");
+  const files: string[] = [];
+  for (let index = 0; index < ledgerCount; index += 1) {
+    const file = `ledger/v1/events/2026/07/26/openclaw/openclaw/shard-${String(index).padStart(3, "0")}.jsonl`;
+    write(path.join(stateRoot, ...file.split("/")), `{"shard":${index}}\n`);
+    files.push(file);
+  }
+  const asset = "assets/dashboards/summary.json";
+  write(path.join(stateRoot, ...asset.split("/")), '{"summary":true}\n');
+  files.push(asset);
+  return { root, stateRoot, blobFiles: files.sort() };
 }
 
 function viaWorker(env: Record<string, unknown>): typeof globalThis.fetch {


### PR DESCRIPTION
## Problem

Three `migrate-state-blobs` runs died at their job timeout without finishing the ledger tree: 30300581022 and 30313938441 at 120 minutes, then 30321613186 at 350 minutes. The `ledger/v1` tree (~315MB across many thousands of small journal files) plus `assets` (~52MB) was uploaded strictly sequentially, one HMAC-signed round trip per file, so per-file latency — not bandwidth — dominated the runtime.

## Change

- The migration runs a bounded worker pool (`--concurrency`, default 12, exposed as a workflow input). Files are read lazily per task, so at most `concurrency` file buffers are in memory.
- Idempotency and immutability semantics are unchanged: stat digest-skip still counts unchanged files, ledger keys stay create-only, and a same-digest re-put remains a no-op.
- Progress lines now report a **contiguous-prefix resume cursor**: with out-of-order completion, only the fully-completed prefix is safe to skip, so each flushed per-file line (and the abort line on failure) names `resumeCursor=` / `--cursor` values that are always valid to resume from.
- Adaptive pressure backoff: the transport already retries transient 5xx per request; a 429 or an escaping 5xx now pauses the whole pool with capped exponential backoff and retries the file (bounded attempts), which stays idempotent through the digest-skip.
- Per-file summary counters are applied only on the final successful attempt so a pressure retry after a partial success can never double-count.

A packed multi-file upload endpoint was considered and skipped: it would add a new Worker surface in `dashboard/state-blobs.ts` for marginal gain, since concurrency alone removes the round-trip bottleneck (~12x fewer serialized round trips).

## Expected speedup

Sequential runtime was ~N x RTT for thousands of small files; with 12 in-flight uploads the same wall clock covers ~12 files, so the ledger tree should finish comfortably inside the existing 350-minute budget (roughly an order of magnitude faster), with `--concurrency` available to tune either direction.

## Proof

- `node --test test/worker-state-blobs.test.ts test/state-writer-workflow.test.ts` — 27 pass, including three new tests: concurrent exactly-once upload + idempotent repeat, contiguous-prefix cursor under provably out-of-order completion, and 429 backoff-and-retry.
- `pnpm run lint:scripts`, `pnpm run format:check`, `pnpm run build:all`, `pnpm run check:static` — clean.
- Autoreview (Codex, local mode) — clean, no accepted findings.

No `dashboard/` changes: no Worker redeploy needed.
