### PR TITLE
fix(state): carry slug, status, and body evidence through hydrate refusal diagnostics

### DIFF
--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -95,7 +95,20 @@ export async function hydrateState(
   }
 
   let worker: Awaited<ReturnType<typeof materializeWorkerRecords>> | undefined;
-  let recordsFallback: { reason: string; source: "git" } | undefined;
+  let recordsFallback:
+    | {
+        reason: string;
+        source: "git";
+        slug?: string;
+        detail?: {
+          endpoint?: string;
+          status?: number;
+          code?: string;
+          bodySnippet?: string;
+          succeededSlugs?: number;
+        };
+      }
+    | undefined;
   if (recordsSource === "worker") {
     const repoSlugs =
       args.recordsRepoSlugs ??
@@ -105,7 +118,11 @@ export async function hydrateState(
       throw new Error("CLAWSWEEPER_RECORDS_SECRET is required for Worker record hydration");
     }
     try {
-      if (!repoSlugs.length) throw new WorkerSnapshotUnavailableError("snapshot_not_found");
+      if (!repoSlugs.length) {
+        throw new WorkerSnapshotUnavailableError("snapshot_not_found", {
+          code: "no_record_repo_slugs",
+        });
+      }
       worker = await materializeWorkerRecords({
         worktreeRoot,
         baseUrl,
@@ -123,11 +140,23 @@ export async function hydrateState(
           { cause: error },
         );
       }
+      // Keep the reason shout-case for greppability, but append the request
+      // evidence verbatim: slug, endpoint, HTTP status, error code, body.
+      const reasonText =
+        error.reason === "snapshot_store_unavailable"
+          ? "SNAPSHOT STORE UNAVAILABLE"
+          : "SNAPSHOT NOT FOUND";
       console.error(
-        `[hydrate-state] WORKER RECORD CUTOVER REFUSED: ${error.message.toUpperCase()}; FALLING BACK TO GIT RECORDS`,
+        `[hydrate-state] WORKER RECORD CUTOVER REFUSED: ${reasonText}${error.detailText ? ` (${error.detailText})` : ""}; FALLING BACK TO GIT RECORDS`,
       );
       copyGeneratedPath(stateRoot, worktreeRoot, "records");
-      recordsFallback = { reason: error.reason, source: "git" };
+      const { repoSlug: failedSlug, ...detail } = error.detail;
+      recordsFallback = {
+        reason: error.reason,
+        source: "git",
+        ...(failedSlug ? { slug: failedSlug } : {}),
+        ...(Object.keys(detail).length ? { detail } : {}),
+      };
     }
   }
 

--- a/scripts/prepare-worker-record-cache.ts
+++ b/scripts/prepare-worker-record-cache.ts
@@ -30,7 +30,7 @@ try {
   writeOutput("available", "false");
   writeOutput("cache-key", "snapshot-unavailable");
   console.error(
-    `[worker-record-cache] SNAPSHOT CACHE UNAVAILABLE (${error.reason}); HYDRATION WILL FALL BACK TO GIT`,
+    `[worker-record-cache] SNAPSHOT CACHE UNAVAILABLE (${error.reason}${error.detailText ? `: ${error.detailText}` : ""}); HYDRATION WILL FALL BACK TO GIT`,
   );
 }
 

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -60,16 +60,45 @@ export type WorkerRecordReplayFailure = {
   code: string;
 };
 
+export type WorkerSnapshotUnavailableDetail = {
+  repoSlug?: string;
+  endpoint?: string;
+  status?: number;
+  code?: string;
+  bodySnippet?: string;
+  succeededSlugs?: number;
+};
+
 export class WorkerSnapshotUnavailableError extends Error {
   readonly reason: "snapshot_store_unavailable" | "snapshot_not_found";
+  readonly detail: WorkerSnapshotUnavailableDetail;
+  readonly detailText: string;
 
-  constructor(reason: "snapshot_store_unavailable" | "snapshot_not_found") {
-    super(
-      reason === "snapshot_store_unavailable" ? "snapshot store unavailable" : "snapshot not found",
-    );
+  constructor(
+    reason: "snapshot_store_unavailable" | "snapshot_not_found",
+    detail: WorkerSnapshotUnavailableDetail = {},
+    options?: { cause?: unknown },
+  ) {
+    const base =
+      reason === "snapshot_store_unavailable" ? "snapshot store unavailable" : "snapshot not found";
+    const detailText = snapshotUnavailableDetailText(detail);
+    super(detailText ? `${base} (${detailText})` : base, options);
     this.name = "WorkerSnapshotUnavailableError";
     this.reason = reason;
+    this.detail = detail;
+    this.detailText = detailText;
   }
+}
+
+function snapshotUnavailableDetailText(detail: WorkerSnapshotUnavailableDetail) {
+  const parts: string[] = [];
+  if (detail.repoSlug) parts.push(`repo=${detail.repoSlug}`);
+  if (detail.endpoint) parts.push(`endpoint=${detail.endpoint}`);
+  if (detail.status !== undefined) parts.push(`status=${detail.status}`);
+  if (detail.code) parts.push(`code=${detail.code}`);
+  if (detail.succeededSlugs !== undefined) parts.push(`succeededSlugs=${detail.succeededSlugs}`);
+  if (detail.bodySnippet) parts.push(`body=${JSON.stringify(detail.bodySnippet)}`);
+  return parts.join(" ");
 }
 
 export class WorkerRecordRequestError extends Error {
@@ -164,7 +193,9 @@ export async function materializeWorkerRecords(options: {
   repoSlugs: readonly string[];
   cacheRoot?: string;
   fetch?: typeof globalThis.fetch;
+  log?: (line: string) => void;
 }) {
+  const log = options.log ?? ((line: string) => console.error(line));
   mkdirSync(options.worktreeRoot, { recursive: true });
   const recordsRoot = path.join(options.worktreeRoot, "records");
   const cacheRoot = path.resolve(
@@ -187,38 +218,55 @@ export async function materializeWorkerRecords(options: {
   > = {};
   try {
     for (const repoSlug of options.repoSlugs) {
-      validateRepoSlug(repoSlug);
-      const storedSnapshot = await fetchWorkerStoredSnapshot({
-        baseUrl: options.baseUrl,
-        webhookSecret: options.webhookSecret,
-        repoSlug,
-        fetch: options.fetch,
-      });
-      const cached = await ensureSnapshotCache({
-        cacheRoot,
-        baseUrl: options.baseUrl,
-        webhookSecret: options.webhookSecret,
-        snapshot: storedSnapshot,
-        fetch: options.fetch,
-      });
-      const stagedRepoRoot = path.join(stagedRecordsRoot, repoSlug);
-      cpSync(cached.treeRoot, stagedRepoRoot, { recursive: true });
-      const journal = await exportWorkerRecords({
-        baseUrl: options.baseUrl,
-        webhookSecret: options.webhookSecret,
-        repoSlug,
-        sinceRevision: storedSnapshot.revisionWatermark,
-        fetch: options.fetch,
-      });
-      applyWorkerRecords(stagedRepoRoot, journal.records);
-      repositories[repoSlug] = {
-        revision: journal.revision,
-        snapshotRevision: storedSnapshot.revisionWatermark,
-        snapshotBytes: storedSnapshot.bytes,
-        snapshotCache: cached.cache,
-        deltaRecords: journal.records.length,
-        recordCount: collectGitRecords(stagingRoot, repoSlug).length,
-      };
+      try {
+        validateRepoSlug(repoSlug);
+        const storedSnapshot = await fetchWorkerStoredSnapshot({
+          baseUrl: options.baseUrl,
+          webhookSecret: options.webhookSecret,
+          repoSlug,
+          fetch: options.fetch,
+        });
+        const cached = await ensureSnapshotCache({
+          cacheRoot,
+          baseUrl: options.baseUrl,
+          webhookSecret: options.webhookSecret,
+          snapshot: storedSnapshot,
+          fetch: options.fetch,
+        });
+        const stagedRepoRoot = path.join(stagedRecordsRoot, repoSlug);
+        cpSync(cached.treeRoot, stagedRepoRoot, { recursive: true });
+        const journal = await exportWorkerRecords({
+          baseUrl: options.baseUrl,
+          webhookSecret: options.webhookSecret,
+          repoSlug,
+          sinceRevision: storedSnapshot.revisionWatermark,
+          fetch: options.fetch,
+        });
+        applyWorkerRecords(stagedRepoRoot, journal.records);
+        repositories[repoSlug] = {
+          revision: journal.revision,
+          snapshotRevision: storedSnapshot.revisionWatermark,
+          snapshotBytes: storedSnapshot.bytes,
+          snapshotCache: cached.cache,
+          deltaRecords: journal.records.length,
+          recordCount: collectGitRecords(stagingRoot, repoSlug).length,
+        };
+        const entry = repositories[repoSlug];
+        log(
+          `[worker-records] snapshot hydrated repo=${repoSlug} revision=${entry.revision} snapshotRevision=${entry.snapshotRevision} snapshotBytes=${entry.snapshotBytes} cache=${entry.snapshotCache} deltaRecords=${entry.deltaRecords} records=${entry.recordCount}`,
+        );
+      } catch (error) {
+        // Re-wrap so the refusal that aborts a multi-slug hydration names the
+        // failing slug and how many slugs had already hydrated cleanly.
+        if (error instanceof WorkerSnapshotUnavailableError) {
+          throw new WorkerSnapshotUnavailableError(
+            error.reason,
+            { repoSlug, ...error.detail, succeededSlugs: Object.keys(repositories).length },
+            { cause: error.cause ?? error },
+          );
+        }
+        throw error;
+      }
     }
     rmSync(recordsRoot, { force: true, recursive: true });
     renameSync(stagedRecordsRoot, recordsRoot);
@@ -245,13 +293,14 @@ export async function fetchWorkerStoredSnapshot(options: {
   repoSlug: string;
   fetch?: typeof globalThis.fetch;
 }): Promise<WorkerStoredSnapshot> {
+  const endpoint = "/internal/state/records/snapshots/latest";
   try {
     const envelope = await signedPost<{
       snapshotStoreAvailable: boolean;
       snapshot: WorkerStoredSnapshot;
     }>({
       ...options,
-      path: "/internal/state/records/snapshots/latest",
+      path: endpoint,
       body: { repoSlug: options.repoSlug },
     });
     validateStoredSnapshot(envelope.snapshot, options.repoSlug);
@@ -261,7 +310,19 @@ export async function fetchWorkerStoredSnapshot(options: {
       error instanceof WorkerRecordRequestError &&
       (error.code === "snapshot_store_unavailable" || error.code === "snapshot_not_found")
     ) {
-      throw new WorkerSnapshotUnavailableError(error.code);
+      // Preserve the request evidence: which repo, which endpoint, and what
+      // the Worker actually said. A bare reason is undebuggable at cutover.
+      throw new WorkerSnapshotUnavailableError(
+        error.code,
+        {
+          repoSlug: options.repoSlug,
+          endpoint,
+          status: error.status,
+          code: error.code,
+          bodySnippet: error.bodySnippet,
+        },
+        { cause: error },
+      );
     }
     throw error;
   }
@@ -275,7 +336,18 @@ export async function resolveWorkerSnapshotCacheKey(options: {
 }) {
   const snapshots = [] as WorkerStoredSnapshot[];
   for (const repoSlug of [...options.repoSlugs].sort()) {
-    snapshots.push(await fetchWorkerStoredSnapshot({ ...options, repoSlug }));
+    try {
+      snapshots.push(await fetchWorkerStoredSnapshot({ ...options, repoSlug }));
+    } catch (error) {
+      if (error instanceof WorkerSnapshotUnavailableError) {
+        throw new WorkerSnapshotUnavailableError(
+          error.reason,
+          { repoSlug, ...error.detail, succeededSlugs: snapshots.length },
+          { cause: error.cause ?? error },
+        );
+      }
+      throw error;
+    }
   }
   const pairs = snapshots.map((snapshot) => `${snapshot.repoSlug}:${snapshot.revisionWatermark}`);
   return {

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -149,7 +149,98 @@ test("hydrate-state refuses Worker cutover and loudly falls back to git without 
     );
     assert.equal(result.recordsSource, "git");
     assert.equal(result.recordsFallback?.reason, "snapshot_store_unavailable");
-    assert.match(errors.join("\n"), /WORKER RECORD CUTOVER REFUSED.*FALLING BACK TO GIT/);
+    assert.equal(result.recordsFallback?.slug, repoSlug);
+    assert.deepEqual(result.recordsFallback?.detail, {
+      endpoint: "/internal/state/records/snapshots/latest",
+      status: 503,
+      code: "snapshot_store_unavailable",
+      bodySnippet: '{"error":"snapshot_store_unavailable","snapshotStoreAvailable":false}',
+      succeededSlugs: 0,
+    });
+    const refusal = errors.join("\n");
+    assert.match(refusal, /WORKER RECORD CUTOVER REFUSED.*FALLING BACK TO GIT/);
+    assert.match(
+      refusal,
+      new RegExp(`repo=${repoSlug} .*status=503 code=snapshot_store_unavailable`),
+    );
+    assert.equal(
+      readFileSync(path.join(target, "records", repoSlug, "items", "1.md"), "utf8"),
+      contents.get("items/1"),
+    );
+  } finally {
+    console.error = originalError;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("hydrate-state refusal names the failing slug, request evidence, and prior successes", async () => {
+  const fixture = createStateFixture();
+  const target = path.join(fixture.root, "partial-fallback-target");
+  const cacheRoot = path.join(fixture.root, "snapshot-cache");
+  const missingSlug = "zz-missing";
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...values) => errors.push(values.join(" "));
+  const healthyFetch = workerFetch(contents);
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const body = JSON.parse(String(init?.body || "{}")) as { repoSlug?: string };
+    if (body.repoSlug === missingSlug) {
+      assert.ok(url.pathname.endsWith("/snapshots/latest"));
+      return Response.json(
+        { error: "snapshot_not_found", snapshotStoreAvailable: true },
+        { status: 404 },
+      );
+    }
+    return healthyFetch(input, init);
+  }) as typeof fetch;
+  try {
+    const result = await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        target,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+        "--records-repo-slugs",
+        `${repoSlug},${missingSlug}`,
+      ],
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret",
+        CLAWSWEEPER_RECORDS_CACHE_DIR: cacheRoot,
+      },
+      fetchImpl,
+    );
+    assert.equal(result.recordsSource, "git");
+    assert.equal(result.recordsFallback?.reason, "snapshot_not_found");
+    assert.equal(result.recordsFallback?.slug, missingSlug);
+    assert.deepEqual(result.recordsFallback?.detail, {
+      endpoint: "/internal/state/records/snapshots/latest",
+      status: 404,
+      code: "snapshot_not_found",
+      bodySnippet: '{"error":"snapshot_not_found","snapshotStoreAvailable":true}',
+      succeededSlugs: 1,
+    });
+    const log = errors.join("\n");
+    assert.match(
+      log,
+      new RegExp(
+        `WORKER RECORD CUTOVER REFUSED: SNAPSHOT NOT FOUND \\(repo=${missingSlug} ` +
+          `endpoint=/internal/state/records/snapshots/latest status=404 code=snapshot_not_found ` +
+          `succeededSlugs=1 body=.*\\); FALLING BACK TO GIT RECORDS`,
+      ),
+    );
+    assert.match(
+      log,
+      new RegExp(
+        `\\[worker-records\\] snapshot hydrated repo=${repoSlug} revision=\\d+ ` +
+          `snapshotRevision=\\d+ snapshotBytes=\\d+ cache=miss deltaRecords=\\d+ records=\\d+`,
+      ),
+    );
+    // Fallback still materialized the git records tree.
     assert.equal(
       readFileSync(path.join(target, "records", repoSlug, "items", "1.md"), "utf8"),
       contents.get("items/1"),


### PR DESCRIPTION
## Problem

We are debugging a live cutover where all 119 slugs have R2 snapshot objects and every snapshot-trigger ops run succeeded, yet hydration still refuses with `snapshot_not_found`. The refusal log was:

```
[hydrate-state] WORKER RECORD CUTOVER REFUSED: SNAPSHOT NOT FOUND; FALLING BACK TO GIT RECORDS
```

No slug, no endpoint, no HTTP status, no body — even though `WorkerRecordRequestError` has carried `status`/`code`/`bodySnippet` since #887/#888. The detail was discarded at the promotion site in `fetchWorkerStoredSnapshot`, which collapsed the request error into a bare `WorkerSnapshotUnavailableError(reason)`.

## Change

- `WorkerSnapshotUnavailableError` now carries a structured `detail` (`repoSlug`, `endpoint`, `status`, `code`, `bodySnippet`, `succeededSlugs`) plus a preformatted `detailText`, and chains the original `WorkerRecordRequestError` as `cause`. No catch site discards the underlying evidence anymore.
- `fetchWorkerStoredSnapshot` promotes with the full request evidence (slug, `/internal/state/records/snapshots/latest`, status, code, body snippet).
- `materializeWorkerRecords` re-wraps a per-slug refusal with the failing slug and the count of slugs that had already hydrated cleanly (`succeededSlugs`), and emits one auditable success line per slug: `[worker-records] snapshot hydrated repo=<slug> revision=<n> snapshotRevision=<n> snapshotBytes=<n> cache=hit|miss deltaRecords=<n> records=<n>` — a 119-slug hydration now shows exactly where it stopped.
- `resolveWorkerSnapshotCacheKey` gets the same slug/succeededSlugs annotation for the cache-key pre-pass.
- `hydrate-state` refusal line now includes the evidence: `WORKER RECORD CUTOVER REFUSED: SNAPSHOT NOT FOUND (repo=<slug> endpoint=/internal/state/records/snapshots/latest status=404 code=snapshot_not_found succeededSlugs=<n> body="..."); FALLING BACK TO GIT RECORDS` — and the `recordsFallback` JSON gains `slug` + `detail` fields with the same data.
- The "no repo slugs discovered" refusal is now distinguishable (`code=no_record_repo_slugs`) from a Worker 404.
- `prepare-worker-record-cache` cache-unavailable log line also prints the detail.

## Tests

- Existing single-slug 503 fallback test now asserts `slug`, full `detail` (endpoint/status/code/bodySnippet/succeededSlugs), and the detailed refusal line.
- New test: two slugs where `snapshots/latest` 404s for the second — asserts the refusal names the failing slug with status 404 / `code=snapshot_not_found` / `succeededSlugs=1`, the fallback JSON carries the detail, the per-slug success line was emitted for the healthy slug, and git records still materialize.

Gate: `test/worker-state-readers.test.ts` 15/15 green, `lint:scripts` clean, format applied, `tsc --noEmit` clean, autoreview local clean.
