### PR TITLE
fix(state): discover worker-mode record repo slugs from the canonical Worker store

### DIFF
--- a/.github/actions/setup-state/action.yml
+++ b/.github/actions/setup-state/action.yml
@@ -53,7 +53,7 @@ inputs:
     required: false
     default: https://clawsweeper.openclaw.ai
   records-repo-slugs:
-    description: Optional comma/newline-separated record repository slugs; defaults to state checkout directories.
+    description: Optional comma/newline-separated record repository slugs; defaults to the Worker record store's slug list.
     required: false
     default: ""
   records-secret:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Worker-mode hydration now discovers record repo slugs from the authenticated `/internal/state/records/slugs` Worker endpoint (canonical DO store, per-slug revisions) instead of reading the git state checkout's `records/` directory, which the worker-mode sparse checkout never materializes — this ended the permanent `no_record_repo_slugs` cutover refusal; explicit `CLAWSWEEPER_RECORDS_REPO_SLUGS`/`--records-repo-slugs` still wins, git-only (un-backfilled) slugs are warned about, and the snapshot cache key preparation uses the same discovery.
 - Worker record request failures now surface the real status, error code, and a body snippet instead of dying on `Response.clone: Body has already been consumed`, and signed Worker requests retry transient 5xx/network failures (3 attempts, exponential backoff) so Cloudflare 502s no longer kill long export/reconcile runs.
 - Made canonical record replay normalize revision-ordered legacy tuple remnants, continue after per-item validation rejections, and fail once at the end with every rejected item id.
 - Allowed stuck-placeholder recovery to label pull requests by granting its target token pull-request write permission alongside issue write. Thanks @masatohoshino! (#865)

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -587,6 +587,22 @@ export class ExactReviewDirectPublicationStore {
     );
   }
 
+  listRecordRepoSlugs(): Array<{ repoSlug: string; revision: number }> {
+    // Distinct repositories present in the canonical record store, with each
+    // repository's latest store revision. Tombstoned rows still count: a slug
+    // whose records were all deleted still exists in the store and hydration
+    // must learn about it to materialize the deletions.
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT repo_slug, MAX(store_revision) AS revision
+           FROM ${EXACT_REVIEW_RECORD_EXPORT_INDEX_TABLE}
+          GROUP BY repo_slug
+          ORDER BY repo_slug`,
+      ),
+      (row) => ({ repoSlug: String(row.repo_slug), revision: Number(row.revision) }),
+    );
+  }
+
   exportRecords(options: {
     repoSlug: string;
     sections: readonly RecordSection[];

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2040,6 +2040,10 @@ export class ExactReviewQueue {
       });
     }
 
+    if (request.method === "POST" && url.pathname === "/records/slugs") {
+      return json({ ok: true, repositories: this.directPublicationStore.listRecordRepoSlugs() });
+    }
+
     if (request.method === "POST" && url.pathname === "/records/list") {
       const body = objectValue(await request.json().catch(() => null));
       const repoSlug = validateRepoSlug(body.repoSlug);

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -561,6 +561,8 @@ export default {
         env,
         url.pathname.slice("/internal/state".length),
       );
+    if (url.pathname === "/internal/state/records/slugs" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/records/slugs");
     if (url.pathname === "/internal/state/records/list" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/records/list");
     if (url.pathname === "/internal/state/records/export" && request.method === "POST")

--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { materializeStateBlobs, WorkerBlobsUnavailableError } from "./worker-blobs.ts";
 import {
   discoverRecordRepoSlugs,
+  discoverWorkerRecordRepoSlugs,
   materializeWorkerRecords,
   WorkerSnapshotUnavailableError,
 } from "./worker-records.ts";
@@ -110,14 +111,18 @@ export async function hydrateState(
       }
     | undefined;
   if (recordsSource === "worker") {
-    const repoSlugs =
-      args.recordsRepoSlugs ??
-      parseRepoSlugs(env.CLAWSWEEPER_RECORDS_REPO_SLUGS) ??
-      discoverRecordRepoSlugs(stateRoot);
-    if (repoSlugs.length && !webhookSecret) {
+    const explicitRepoSlugs =
+      args.recordsRepoSlugs ?? parseRepoSlugs(env.CLAWSWEEPER_RECORDS_REPO_SLUGS);
+    // An explicitly empty slug list is the only worker-mode shape that never
+    // talks to the Worker; everything else (explicit slugs or endpoint
+    // discovery) signs requests and therefore needs the secret up front.
+    if (explicitRepoSlugs?.length !== 0 && !webhookSecret) {
       throw new Error("CLAWSWEEPER_RECORDS_SECRET is required for Worker record hydration");
     }
     try {
+      const repoSlugs =
+        explicitRepoSlugs ??
+        (await discoverHydrationRepoSlugs({ stateRoot, baseUrl, webhookSecret, fetchImpl }));
       if (!repoSlugs.length) {
         throw new WorkerSnapshotUnavailableError("snapshot_not_found", {
           code: "no_record_repo_slugs",
@@ -126,7 +131,7 @@ export async function hydrateState(
       worker = await materializeWorkerRecords({
         worktreeRoot,
         baseUrl,
-        webhookSecret: webhookSecret || "unused-empty-snapshot",
+        webhookSecret,
         repoSlugs,
         cacheRoot: env.CLAWSWEEPER_RECORDS_CACHE_DIR,
         fetch: fetchImpl,
@@ -177,6 +182,41 @@ export async function hydrateState(
   };
   console.log(JSON.stringify(result));
   return result;
+}
+
+// Worker-mode slug discovery: the canonical record store is the authority on
+// which repositories exist, because the worker-mode sparse checkout does not
+// materialize records/ and a readdir there silently discovers nothing. The git
+// tree, when present, is only consulted to warn about un-backfilled slugs.
+async function discoverHydrationRepoSlugs(options: {
+  stateRoot: string;
+  baseUrl: string;
+  webhookSecret: string;
+  fetchImpl: typeof globalThis.fetch;
+}): Promise<string[]> {
+  const discovered = await discoverWorkerRecordRepoSlugs({
+    baseUrl: options.baseUrl,
+    webhookSecret: options.webhookSecret,
+    fetch: options.fetchImpl,
+  });
+  const workerSlugs = discovered.map((entry) => entry.repoSlug);
+  console.error(
+    `[hydrate-state] worker slug discovery: ${workerSlugs.length} repositories ` +
+      `endpoint=/internal/state/records/slugs revisions=${discovered
+        .map((entry) => `${entry.repoSlug}:${entry.revision}`)
+        .join(",")}`,
+  );
+  const workerSlugSet = new Set(workerSlugs);
+  const gitOnlySlugs = discoverRecordRepoSlugs(options.stateRoot).filter(
+    (slug) => !workerSlugSet.has(slug),
+  );
+  if (gitOnlySlugs.length) {
+    console.error(
+      `[hydrate-state] WARNING: ${gitOnlySlugs.length} record repo slug(s) exist in the git ` +
+        `state checkout but not in the Worker record store (un-backfilled?): ${gitOnlySlugs.join(", ")}`,
+    );
+  }
+  return workerSlugs;
 }
 
 function copyGeneratedPath(stateRoot: string, worktreeRoot: string, relativePath: string) {

--- a/scripts/prepare-worker-record-cache.ts
+++ b/scripts/prepare-worker-record-cache.ts
@@ -1,24 +1,29 @@
 #!/usr/bin/env node
 import { appendFileSync } from "node:fs";
-import path from "node:path";
 
 import {
-  discoverRecordRepoSlugs,
+  discoverWorkerRecordRepoSlugs,
   resolveWorkerSnapshotCacheKey,
   WorkerSnapshotUnavailableError,
 } from "./worker-records.ts";
 
-const stateRoot = path.resolve(process.env.CLAWSWEEPER_STATE_DIR ?? "clawsweeper-state");
 const repoSlugs = parseRepoSlugs(process.env.CLAWSWEEPER_RECORDS_REPO_SLUGS);
-const resolvedRepoSlugs = repoSlugs.length ? repoSlugs : discoverRecordRepoSlugs(stateRoot);
+const baseUrl = process.env.CLAWSWEEPER_RECORDS_URL ?? "https://clawsweeper.openclaw.ai";
 const webhookSecret =
   process.env.CLAWSWEEPER_RECORDS_SECRET ?? process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
 if (!webhookSecret) throw new Error("CLAWSWEEPER_RECORDS_SECRET is required");
 
 try {
+  // Match hydrate-state discovery: the Worker record store is the slug
+  // authority (the worker-mode sparse checkout has no records/ tree to read).
+  const resolvedRepoSlugs = repoSlugs.length
+    ? repoSlugs
+    : (await discoverWorkerRecordRepoSlugs({ baseUrl, webhookSecret })).map(
+        (entry) => entry.repoSlug,
+      );
   if (!resolvedRepoSlugs.length) throw new WorkerSnapshotUnavailableError("snapshot_not_found");
   const result = await resolveWorkerSnapshotCacheKey({
-    baseUrl: process.env.CLAWSWEEPER_RECORDS_URL ?? "https://clawsweeper.openclaw.ai",
+    baseUrl,
     webhookSecret,
     repoSlugs: resolvedRepoSlugs,
   });

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -357,6 +357,53 @@ export async function resolveWorkerSnapshotCacheKey(options: {
   };
 }
 
+export async function discoverWorkerRecordRepoSlugs(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  fetch?: typeof globalThis.fetch;
+}): Promise<Array<{ repoSlug: string; revision: number }>> {
+  const endpoint = "/internal/state/records/slugs";
+  let envelope: { repositories?: unknown };
+  try {
+    envelope = await signedPost<{ repositories?: unknown }>({
+      baseUrl: options.baseUrl,
+      path: endpoint,
+      webhookSecret: options.webhookSecret,
+      body: {},
+      fetch: options.fetch,
+    });
+  } catch (error) {
+    // Any request failure (including a 404 from a Worker deployment that
+    // predates the endpoint) means the canonical slug list is unreachable;
+    // surface it as a cutover refusal so hydration falls back to git loudly.
+    if (error instanceof WorkerRecordRequestError) {
+      throw new WorkerSnapshotUnavailableError(
+        "snapshot_store_unavailable",
+        { endpoint, status: error.status, code: error.code, bodySnippet: error.bodySnippet },
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (!Array.isArray(envelope.repositories)) {
+    throw new Error("Worker returned an invalid record slug envelope");
+  }
+  const repositories = envelope.repositories.map((value) => {
+    const entry = value as { repoSlug?: unknown; revision?: unknown };
+    if (
+      !entry ||
+      typeof entry.repoSlug !== "string" ||
+      !isRepoSlug(entry.repoSlug) ||
+      !Number.isSafeInteger(entry.revision) ||
+      (entry.revision as number) < 0
+    ) {
+      throw new Error("Worker returned an invalid record slug entry");
+    }
+    return { repoSlug: entry.repoSlug, revision: entry.revision as number };
+  });
+  return repositories.sort((left, right) => left.repoSlug.localeCompare(right.repoSlug));
+}
+
 export function discoverRecordRepoSlugs(stateRoot: string): string[] {
   const recordsRoot = path.join(stateRoot, "records");
   if (!existsSync(recordsRoot)) return [];

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2425,6 +2425,57 @@ test("record backfill and export authenticate, page, increment, dedupe, and pres
   assert.deepEqual(await conflict.json(), { error: "canonical_record_backfill_conflict" });
 });
 
+test("record slug discovery authenticates and lists per-repository revisions", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const secret = "record-slug-secret";
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const slugsPath = "/internal/state/records/slugs";
+  const unsigned = await worker.fetch(
+    stateAppendQueueRequest(slugsPath, {}, "https://clawsweeper.openclaw.ai"),
+    env,
+  );
+  assert.equal(unsigned.status, 401);
+
+  const empty = await worker.fetch(signedStateAppendRequest(slugsPath, {}, secret), env);
+  assert.equal(empty.status, 200);
+  assert.deepEqual(await empty.json(), { ok: true, repositories: [] });
+
+  const seed = (slug: string, id: string, content: string) => ({
+    repoSlug: slug,
+    records: [
+      {
+        section: "items",
+        id,
+        content,
+        digest: createHash("sha256").update(content).digest("hex"),
+      },
+    ],
+  });
+  const ingestPath = "/internal/state/records/ingest";
+  for (const payload of [
+    seed("zz-later", "1", "later-first"),
+    seed("aa-early", "2", "early"),
+    seed("zz-later", "3", "later-second"),
+  ]) {
+    const ingested = await worker.fetch(signedStateAppendRequest(ingestPath, payload, secret), env);
+    assert.equal(ingested.status, 202);
+  }
+
+  const listed = await worker.fetch(signedStateAppendRequest(slugsPath, {}, secret), env);
+  assert.equal(listed.status, 200);
+  assert.deepEqual(await listed.json(), {
+    ok: true,
+    repositories: [
+      { repoSlug: "aa-early", revision: 2 },
+      { repoSlug: "zz-later", revision: 3 },
+    ],
+  });
+});
+
 test("record snapshots authenticate, stream multipart R2 objects, serve ranges, prune, and fail closed", async () => {
   const secret = "record-snapshot-secret";
   const unavailableStorage = new MemoryDurableStorage();

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash, createHmac } from "node:crypto";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -116,6 +116,169 @@ test("hydrate-state Worker mode uses snapshot cold and warm paths before replayi
     );
     assert.equal(warmManifest.repositories[repoSlug].snapshotCache, "hit");
   } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("worker-mode hydration discovers slugs from the Worker and warns about git-only slugs", async () => {
+  const fixture = createStateFixture();
+  write(path.join(fixture.stateRoot, "records", "git-only-repo", "items", "9.md"), "orphan\n");
+  const target = path.join(fixture.root, "discovery-target");
+  const cacheRoot = path.join(fixture.root, "snapshot-cache");
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...values) => errors.push(values.join(" "));
+  const healthyFetch = workerFetch(contents);
+  let slugRequests = 0;
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/internal/state/records/slugs") {
+      slugRequests += 1;
+      const bodyText = String(init?.body || "");
+      const signature = `sha256=${createHmac("sha256", "fixture-secret").update(bodyText).digest("hex")}`;
+      assert.equal(
+        new Headers(init?.headers).get("x-clawsweeper-exact-review-signature"),
+        signature,
+      );
+      assert.equal(bodyText, "{}");
+      return Response.json({
+        ok: true,
+        repositories: [{ repoSlug, revision: contents.size }],
+      });
+    }
+    return healthyFetch(input, init);
+  }) as typeof fetch;
+  try {
+    const result = await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        target,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+      ],
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret",
+        CLAWSWEEPER_RECORDS_CACHE_DIR: cacheRoot,
+      },
+      fetchImpl,
+    );
+    assert.equal(slugRequests, 1);
+    assert.equal(result.recordsSource, "worker");
+    assert.equal(result.recordsFallback, undefined);
+    assert.deepEqual(Object.keys(result.worker ?? {}), [repoSlug]);
+    assert.equal(
+      readFileSync(path.join(target, "records", repoSlug, "items", "1.md"), "utf8"),
+      contents.get("items/1"),
+    );
+    // The Worker list is canonical: the git-only slug is not hydrated, only warned about.
+    assert.equal(existsSync(path.join(target, "records", "git-only-repo")), false);
+    const log = errors.join("\n");
+    assert.match(
+      log,
+      new RegExp(
+        `worker slug discovery: 1 repositories endpoint=/internal/state/records/slugs ` +
+          `revisions=${repoSlug}:${contents.size}`,
+      ),
+    );
+    assert.match(
+      log,
+      /WARNING: 1 record repo slug\(s\) exist in the git state checkout but not in the Worker record store \(un-backfilled\?\): git-only-repo/,
+    );
+  } finally {
+    console.error = originalError;
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("explicit record repo slugs win over the environment and skip Worker discovery", async () => {
+  const fixture = createStateFixture();
+  const target = path.join(fixture.root, "explicit-target");
+  const cacheRoot = path.join(fixture.root, "snapshot-cache");
+  const healthyFetch = workerFetch(contents);
+  const requestedSlugs = new Set<string>();
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    assert.notEqual(url.pathname, "/internal/state/records/slugs");
+    const body = JSON.parse(String(init?.body || "{}")) as { repoSlug?: string };
+    if (body.repoSlug) requestedSlugs.add(body.repoSlug);
+    return healthyFetch(input, init);
+  }) as typeof fetch;
+  try {
+    const result = await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        target,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+        "--records-repo-slugs",
+        repoSlug,
+      ],
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret",
+        CLAWSWEEPER_RECORDS_REPO_SLUGS: "ignored-env-slug",
+        CLAWSWEEPER_RECORDS_CACHE_DIR: cacheRoot,
+      },
+      fetchImpl,
+    );
+    assert.equal(result.recordsSource, "worker");
+    assert.deepEqual(Object.keys(result.worker ?? {}), [repoSlug]);
+    assert.deepEqual([...requestedSlugs], [repoSlug]);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("hydrate-state refuses cutover with request evidence when slug discovery is unavailable", async () => {
+  const fixture = createStateFixture();
+  const target = path.join(fixture.root, "discovery-fallback-target");
+  const errors: string[] = [];
+  const originalError = console.error;
+  console.error = (...values) => errors.push(values.join(" "));
+  try {
+    const result = await hydrateState(
+      [
+        "--state-dir",
+        fixture.stateRoot,
+        "--worktree",
+        target,
+        "--records-source",
+        "worker",
+        "--records-url",
+        "https://worker.example",
+      ],
+      { CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret" },
+      (async (input: string | URL | Request) => {
+        // A Worker deployment that predates the slugs endpoint answers 404.
+        assert.equal(new URL(String(input)).pathname, "/internal/state/records/slugs");
+        return Response.json({ error: "not_found" }, { status: 404 });
+      }) as typeof fetch,
+    );
+    assert.equal(result.recordsSource, "git");
+    assert.equal(result.recordsFallback?.reason, "snapshot_store_unavailable");
+    assert.equal(result.recordsFallback?.slug, undefined);
+    assert.deepEqual(result.recordsFallback?.detail, {
+      endpoint: "/internal/state/records/slugs",
+      status: 404,
+      code: "not_found",
+      bodySnippet: '{"error":"not_found"}',
+    });
+    const refusal = errors.join("\n");
+    assert.match(refusal, /WORKER RECORD CUTOVER REFUSED.*FALLING BACK TO GIT/);
+    assert.match(refusal, /endpoint=\/internal\/state\/records\/slugs status=404 code=not_found/);
+    assert.equal(
+      readFileSync(path.join(target, "records", repoSlug, "items", "1.md"), "utf8"),
+      contents.get("items/1"),
+    );
+  } finally {
+    console.error = originalError;
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Problem

Three `migrate-state-blobs` runs died at their job timeout without finishing the ledger tree: 30300581022 and 30313938441 at 120 minutes, then 30321613186 at 350 minutes. The `ledger/v1` tree (~315MB across many thousands of small journal files) plus `assets` (~52MB) was uploaded strictly sequentially, one HMAC-signed round trip per file, so per-file latency — not bandwidth — dominated the runtime.

## Change

- The migration runs a bounded worker pool (`--concurrency`, default 12, exposed as a workflow input). Files are read lazily per task, so at most `concurrency` file buffers are in memory.
- Idempotency and immutability semantics are unchanged: stat digest-skip still counts unchanged files, ledger keys stay create-only, and a same-digest re-put remains a no-op.
- Progress lines now report a **contiguous-prefix resume cursor**: with out-of-order completion, only the fully-completed prefix is safe to skip, so each flushed per-file line (and the abort line on failure) names `resumeCursor=` / `--cursor` values that are always valid to resume from.
- Adaptive pressure backoff: the transport already retries transient 5xx per request; a 429 or an escaping 5xx now pauses the whole pool with capped exponential backoff and retries the file (bounded attempts), which stays idempotent through the digest-skip.
- Per-file summary counters are applied only on the final successful attempt so a pressure retry after a partial success can never double-count.

A packed multi-file upload endpoint was considered and skipped: it would add a new Worker surface in `dashboard/state-blobs.ts` for marginal gain, since concurrency alone removes the round-trip bottleneck (~12x fewer serialized round trips).

## Expected speedup

Sequential runtime was ~N x RTT for thousands of small files; with 12 in-flight uploads the same wall clock covers ~12 files, so the ledger tree should finish comfortably inside the existing 350-minute budget (roughly an order of magnitude faster), with `--concurrency` available to tune either direction.

## Proof

- `node --test test/worker-state-blobs.test.ts test/state-writer-workflow.test.ts` — 27 pass, including three new tests: concurrent exactly-once upload + idempotent repeat, contiguous-prefix cursor under provably out-of-order completion, and 429 backoff-and-retry.
- `pnpm run lint:scripts`, `pnpm run format:check`, `pnpm run build:all`, `pnpm run check:static` — clean.
- Autoreview (Codex, local mode) — clean, no accepted findings.

No `dashboard/` changes: no Worker redeploy needed.
