### PR TITLE
fix(state): treat an empty records-repo-slugs env as no override

### DIFF
--- a/scripts/hydrate-state.ts
+++ b/scripts/hydrate-state.ts
@@ -260,7 +260,11 @@ function parseSource(value: string | undefined, label: string): "git" | "worker"
 }
 
 function parseRepoSlugs(value: string | undefined) {
-  if (value === undefined) return undefined;
+  // setup-state always exports CLAWSWEEPER_RECORDS_REPO_SLUGS, usually as an
+  // empty string; an empty explicit list must mean "no override" so Worker
+  // discovery can run — [] would win over discovery via ?? and refuse cutover
+  // with no_record_repo_slugs (live: materializer runs 30348317111, 30352195592).
+  if (value === undefined || value.trim() === "") return undefined;
   return [...new Set(value.split(/[\s,]+/).filter(Boolean))].sort();
 }
 

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -162,6 +162,10 @@ test("worker-mode hydration discovers slugs from the Worker and warns about git-
       ],
       {
         CLAWSWEEPER_WEBHOOK_SECRET: "fixture-secret",
+        // setup-state always exports this env var, usually empty; an empty
+        // explicit list must not suppress Worker discovery (live regression:
+        // materializer runs 30348317111 / 30352195592 refused cutover).
+        CLAWSWEEPER_RECORDS_REPO_SLUGS: "",
         CLAWSWEEPER_RECORDS_CACHE_DIR: cacheRoot,
       },
       fetchImpl,


### PR DESCRIPTION
setup-state always exports CLAWSWEEPER_RECORDS_REPO_SLUGS (usually as an empty string), and hydrate-state's parseRepoSlugs turned that into an empty explicit list which won over Worker slug discovery via ?? — so worker-mode hydration always refused cutover with no_record_repo_slugs (live: materializer runs 30348317111, 30352195592, both on post-#912 code with the slugs endpoint deployed and answering). Empty/whitespace now means no override, matching prepare-worker-record-cache's existing behavior. Regression covered in the worker-discovery test with the env var set to the live shape. Tests 18/18, autoreview clean.