### PR TITLE
fix(ci): comment router and spam scanner fail every run after the hydrator gained new scripts

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -103,6 +103,8 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            scripts/prepare-worker-record-cache.ts
+            scripts/worker-blobs.ts
             scripts/worker-records.ts
             src
             package.json

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -85,6 +85,8 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            scripts/prepare-worker-record-cache.ts
+            scripts/worker-blobs.ts
             scripts/worker-records.ts
             src
             package.json

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -88,6 +88,35 @@ test("hydrating checkouts follow the records-source flip while git-lane tooling 
   assert.deepEqual(pinned.sort(), pinnedGitLane);
 });
 
+test("sparse hydrating checkouts carry the whole setup-state script closure", () => {
+  // A sparse checkout that names hydrator scripts one by one silently drops any
+  // script the shared action gains later, so derive the requirement from the
+  // action itself instead of restating today's list.
+  const required = setupStateScriptClosure();
+  const sparseSites: string[] = [];
+  for (const { file, workflow } of workflows()) {
+    for (const [job, definition] of Object.entries(workflow.jobs ?? {})) {
+      const steps = definition.steps ?? [];
+      if (!steps.some(isSetupState)) continue;
+      for (const step of steps) {
+        const sparse = step.with?.["sparse-checkout"];
+        if (!step.uses?.startsWith("actions/checkout")) continue;
+        if (step.with?.repository !== undefined || typeof sparse !== "string") continue;
+        const site = `${file}:${job}`;
+        sparseSites.push(site);
+        const listed = new Set(sparse.split("\n").map((entry) => entry.trim()));
+        for (const script of required) {
+          assert.ok(listed.has(script), `${site} must check out ${script}`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(sparseSites.sort(), [
+    ".github/workflows/repair-comment-router.yml:route-comments",
+    ".github/workflows/spam-scanner.yml:scan",
+  ]);
+});
+
 test("the setup action exports no long-lived coordinator credential", () => {
   const actionPath = ".github/actions/setup-state/action.yml";
   const source = readFileSync(actionPath, "utf8");
@@ -321,6 +350,31 @@ function workflows(): Array<{ file: string; workflow: WorkflowDocument }> {
       const file = join(workflowDirectory, name);
       return { file, workflow: parse(readFileSync(file, "utf8")) as WorkflowDocument };
     });
+}
+
+function setupStateScriptClosure(): string[] {
+  const action = parse(readFileSync(".github/actions/setup-state/action.yml", "utf8")) as {
+    runs?: { steps?: WorkflowStep[] };
+  };
+  const pending: string[] = [];
+  for (const step of action.runs?.steps ?? []) {
+    for (const match of String(step.run ?? "").matchAll(/scripts\/[\w.-]+\.ts/g)) {
+      if (match[0]) pending.push(match[0]);
+    }
+  }
+  const closure = new Set<string>();
+  while (pending.length > 0) {
+    const script = pending.pop();
+    if (!script || closure.has(script)) continue;
+    closure.add(script);
+    // Both static `from "./x.ts"` and dynamic `import("./x.ts")`, either quote style.
+    for (const match of readFileSync(script, "utf8").matchAll(
+      /(?:from|import\s*\()\s*["']\.\/([\w.-]+\.ts)["']/g,
+    )) {
+      if (match[1]) pending.push(`scripts/${match[1]}`);
+    }
+  }
+  return [...closure].sort();
 }
 
 function isSetupState(step: WorkflowStep): boolean {


### PR DESCRIPTION
Closes https://github.com/openclaw/clawsweeper/issues/914

## What Problem This Solves

Fixes an issue where every `repair comment router` and `spam scanner` run fails at
`setup-state`, before any routing or scanning happens, so `@clawsweeper` comment commands,
waiting repair-dispatch retries, and spam triage are not processed at all.

Both jobs sparse-check-out this repository and name the hydrator scripts one by one:

```yaml
scripts/hydrate-state.ts
scripts/worker-records.ts
```

`./.github/actions/setup-state` now needs two more scripts from that directory, and neither
is checked out, so the action cannot run:

- `scripts/worker-blobs.ts` — a **static** import at the top of `scripts/hydrate-state.ts`
  since #899. The blob transport is dormant by default (`CLAWSWEEPER_LEDGER_SOURCE`
  defaults to git), but a static import is resolved before that default is consulted, so
  the fail-safe does not cover it.
- `scripts/prepare-worker-record-cache.ts` — run by the `Resolve Worker record snapshot
  cache key` step whenever `records-source` is `worker`, which these two call sites became
  in #908.

The last successful router run was
[run 30297600459](https://github.com/openclaw/clawsweeper/actions/runs/30297600459) at
`2026-07-27T19:17:31Z` on `9b4c227`. `c32e826` landed at `19:20:52Z` and every run since
has failed: 483 failures and no successes for the router, 13 and no successes for the spam
scanner, still failing on `aad59aa` as of
[run 30352119688](https://github.com/openclaw/clawsweeper/actions/runs/30352119688)
(`2026-07-28T10:46:47Z`).

## Why This Change Was Made

The two missing paths are added to both sparse lists. Because a hand-maintained list is
exactly what drifted here, the accompanying test does not restate today's list: it reads
the scripts `setup-state` executes, follows their **relative** imports transitively
(`from "./x.ts"` and `import("./x.ts")`, either quote style), and asserts that every sparse
hydrating checkout contains that closure. It also pins the affected call sites to those two
jobs, so a third one has to be acknowledged deliberately. It is a drift guard for the
import style this repository actually uses, not a general module resolver — an
extensionless, package-relative, or re-exported dependency would still need a manual entry.

Two alternatives are deliberately not taken here, as both are product decisions: making the
blob import lazy so a dormant transport is not an import-time dependency, and dropping the
sparse checkout from these two jobs.

## User Impact

Both lanes hydrate generated state and run again. Operators also stop seeing the misleading
secondary failure: when `setup-state` fails, `setup-pnpm` is skipped but the next step
still runs, reporting `pnpm: command not found` (exit 127) and
`Could not access .../clawsweeper-state/jobs/jobs` instead of the real cause.

## Evidence

Production failure, first run after `c32e826`
([run 30298180330](https://github.com/openclaw/clawsweeper/actions/runs/30298180330),
`2026-07-27T19:25:32Z`, head `c32e826`):

```
##[group]Run node "./scripts/hydrate-state.ts" --state-dir "clawsweeper-state" --worktree "."
    throw new ERR_MODULE_NOT_FOUND(
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/runner/work/clawsweeper/clawsweeper/scripts/worker-blobs.ts' imported from /home/runner/work/clawsweeper/clawsweeper/scripts/
  code: 'ERR_MODULE_NOT_FOUND',
##[error]Process completed with exit code 1.
```

Production failure after `b9edc42`
([run 30328480253](https://github.com/openclaw/clawsweeper/actions/runs/30328480253),
`2026-07-28T04:20:35Z`, head `b9edc42`). The cache step now fails first; it only runs when
`records-source == 'worker'`, so its presence also shows the repository variable is set:

```
##[group]Run node "./scripts/prepare-worker-record-cache.ts"
  CLAWSWEEPER_RECORDS_URL: https://clawsweeper.openclaw.ai
  CLAWSWEEPER_RECORDS_SECRET: ***
Error: Cannot find module '/home/runner/work/clawsweeper/clawsweeper/scripts/prepare-worker-record-cache.ts'
  code: 'MODULE_NOT_FOUND',
##[error]Process completed with exit code 1.
```

Actions logs expire, so those lines are quoted rather than only linked.

The new test is red on the unfixed workflows and green with this patch:

```
# workflows reverted to b9edc42, test applied
$ node --test --test-name-pattern='sparse hydrating checkouts' test/state-writer-workflow.test.ts
ℹ pass 0
ℹ fail 1
  AssertionError [ERR_ASSERTION]: .github/workflows/repair-comment-router.yml:route-comments must check out scripts/prepare-worker-record-cache.ts

# with this patch, Node v24.18.0
$ node --test test/state-writer-workflow.test.ts
✔ sparse hydrating checkouts carry the whole setup-state script closure (56.326254ms)
✔ the rollout scans 50 and grants four concurrent size-8 preparations (0.108987ms)
ℹ fail 0
```

(The aggregate count that follows differs by runner aggregation mode, so only the per-test
lines and `fail 0` are quoted here.)

A local reproduction materializes exactly the sparse list of `repair-comment-router.yml`
at `b9edc42` and runs the two commands `setup-state` runs (Node `v24.18.0`):

```
# commit under test: b9edc42
# scripts/ in the simulated sparse checkout:
hydrate-state.ts
worker-records.ts
# A) hydrate-state.ts (runs on every setup-state call, any records-source)
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<work>/cs/scripts/worker-blobs.ts' imported from <work>/cs/scripts/hydrate-state.ts
# B) prepare-worker-record-cache.ts (runs when records-source is worker)
node:internal/modules/cjs/loader:1520
  throw err;
# C) same two commands after adding the missing closure members
{"hydrated":["records","jobs","results","ledger","notifications","assets","apply-report.json","repair-apply-report.json"],"recordsSource":"git","ledgerSource":"git",...}
if (!webhookSecret) throw new Error("CLAWSWEEPER_RECORDS_SECRET is required")
```

`A` reproduces the production error exactly. In `C` hydration completes and the cache
script resolves, stopping at its own missing-secret precondition.

Scope check: parsing every workflow shows these are the only two jobs that sparse-check-out
this repository *and* call `setup-state`. The closure is four scripts — `hydrate-state.ts`
and `prepare-worker-record-cache.ts` are the entry points, they reach `worker-blobs.ts` and
`worker-records.ts`, and `worker-records.ts` imports only Node builtins.

`pnpm run check` on Node `v24.18.0` ran 2,899 tests with 10 failures, all of which this
host causes and none of which this patch touches. Reverting the three changed files back to
`b9edc42` and re-running only the affected files reproduces the same ten by name:

```
# base b9edc42, same host
node --test test/repair/git-publish.test.ts test/repair/state-publication-batch.test.ts test/repair/target-validation.test.ts
✖ publishMainCommit continues after a bounded fetch restores an unavailable object
✖ publishMainCommit fails fast when unavailable ledger objects remain missing after recovery
✖ publishMainCommit escapes sustained immutable ledger races through a server merge
✖ deletion index records use the SHA-256 repository object width
✖ bun dependency setup rejects and reaps detached descendants
✖ npm dependency setup rejects and reaps detached descendants
✖ replacement branch plumbing bypasses checkout and reference hooks
✖ replacement branch plumbing restores overwritten refs when HEAD cannot switch
✖ replacement branch plumbing rejects branches attached to another worktree
✖ validation rejects and reaps an immediate detached double fork
ℹ tests 257  ℹ pass 247  ℹ fail 10
```

The causes are local: this host has Git `2.34.1`, so `Git must support --no-lazy-fetch for
bounded missing-object recovery` fails the ledger recovery paths, and the bun/npm
containment fixtures are absent. Everything else, including the whole workflow suite,
passed. CI is authoritative for these files.

### Proof summary

- **Behavior addressed:** `setup-state` aborts in the two sparse hydrating jobs because
  `scripts/worker-blobs.ts` and `scripts/prepare-worker-record-cache.ts` are not checked
  out, failing every `repair comment router` and `spam scanner` run.
- **Real environment tested:** production GitHub Actions runs on `c32e826` and `b9edc42`
  for the failure; a local Node `v24.18.0` reproduction of the exact sparse file set for
  before/after.
- **Exact steps or command run after this patch:**

  ```bash
  # 1. materialize exactly the sparse list of repair-comment-router.yml at b9edc42
  #    into an empty directory, then run the two commands setup-state runs:
  node scripts/hydrate-state.ts --state-dir ../state --worktree .
  node scripts/prepare-worker-record-cache.ts
  #    repeat after copying scripts/worker-blobs.ts and
  #    scripts/prepare-worker-record-cache.ts into scripts/
  # 2. the derived-closure regression test
  node --test test/state-writer-workflow.test.ts
  ```

- **Evidence after fix:** the reproduction block above — hydration returns its
  `{"hydrated":[...],"recordsSource":"git",...}` result instead of `ERR_MODULE_NOT_FOUND`,
  and the cache script resolves and stops at its own missing-secret precondition.
- **Observed result after fix:** the test block above —
  `sparse hydrating checkouts carry the whole setup-state script closure` passes with
  `fail 0`, and fails by name when the workflows are reverted.
- **What was not tested:** no secret was exported and no request reached the Worker, so a
  real `records-source=worker` hydration is not demonstrated end to end. What is
  demonstrated is module resolution plus the git-source hydration path; the outage itself
  rests on the two production run logs above. The ten unrelated local `pnpm run check`
  failures are host-caused and reproduce on the base commit, as shown above.
