### PR TITLE
feat(state): make the ledger-source cutover flippable via repo variable

### DIFF
--- a/.github/actions/setup-state/action.yml
+++ b/.github/actions/setup-state/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: HMAC secret used only when records-source is worker.
     required: false
     default: ""
+  ledger-source:
+    description: Ledger/assets blob transport used by hydrate-state (git or worker). Worker mode reuses records-url and records-secret.
+    required: false
+    default: git
 runs:
   using: composite
   steps:
@@ -119,6 +123,18 @@ runs:
         path: ${{ inputs.worktree-path }}/.artifacts/worker-records-cache
         key: clawsweeper-records-${{ runner.os }}-${{ steps.records-snapshot.outputs.cache-key }}
 
+    - name: Restore Worker blob cache
+      if: ${{ inputs.ledger-source == 'worker' }}
+      uses: actions/cache@v6
+      with:
+        path: ${{ inputs.worktree-path }}/.artifacts/worker-blobs-cache
+        # Blob cache entries are digest-addressed and immutable, so any prior
+        # cache is a valid warm start; the run-unique key makes every run save
+        # its grown cache for the next one to restore by prefix.
+        key: clawsweeper-blobs-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: |
+          clawsweeper-blobs-${{ runner.os }}-
+
     - name: Hydrate generated state
       shell: bash
       env:
@@ -128,4 +144,6 @@ runs:
         CLAWSWEEPER_RECORDS_REPO_SLUGS: ${{ inputs.records-repo-slugs }}
         CLAWSWEEPER_RECORDS_SECRET: ${{ inputs.records-secret }}
         CLAWSWEEPER_RECORDS_CACHE_DIR: ${{ inputs.worktree-path }}/.artifacts/worker-records-cache
+        CLAWSWEEPER_LEDGER_SOURCE: ${{ inputs.ledger-source }}
+        CLAWSWEEPER_BLOBS_CACHE_DIR: ${{ inputs.worktree-path }}/.artifacts/worker-blobs-cache
       run: node "${{ inputs.worktree-path }}/scripts/hydrate-state.ts" --state-dir "${{ inputs.state-path }}" --worktree "${{ inputs.worktree-path }}"

--- a/.github/workflows/backfill-worker-records.yml
+++ b/.github/workflows/backfill-worker-records.yml
@@ -85,6 +85,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: records/${{ steps.target.outputs.slug }}
           persist-credentials: "false"
+          ledger-source: git
           records-source: git
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}

--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -151,6 +151,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -427,6 +428,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -553,6 +555,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -99,6 +99,7 @@ jobs:
           coordinator-class: publication_batch
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/migrate-state-blobs.yml
+++ b/.github/workflows/migrate-state-blobs.yml
@@ -77,6 +77,7 @@ jobs:
             ledger
             assets
           persist-credentials: "false"
+          ledger-source: git
           records-source: git
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -168,6 +168,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -255,6 +255,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -557,6 +558,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -163,6 +163,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-commit-finding-intake.yml
+++ b/.github/workflows/repair-commit-finding-intake.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -163,6 +163,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1172,6 +1172,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -1781,6 +1782,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -2408,6 +2410,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -2554,6 +2557,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -3305,6 +3309,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -4030,6 +4035,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -4233,6 +4239,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -4347,6 +4354,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -4563,6 +4571,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -4713,6 +4722,7 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/.github/workflows/worker-records-ops.yml
+++ b/.github/workflows/worker-records-ops.yml
@@ -133,6 +133,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: records/${{ steps.target.outputs.slug }}
           persist-credentials: "false"
+          ledger-source: git
           records-source: git
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
@@ -199,6 +200,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: records/${{ steps.target.outputs.slug }}
           persist-credentials: "false"
+          ledger-source: git
           records-source: git
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -56,7 +56,7 @@ test("every generated-state checkout receives the explicit coordinator migration
   }
 });
 
-test("hydrating checkouts follow the records-source flip while git-lane tooling stays pinned", () => {
+test("hydrating checkouts follow the records/ledger-source flips while git-lane tooling stays pinned", () => {
   // These call sites seed, verify, or reconcile the Worker store *from* git;
   // flipping them to the Worker transport would be circular.
   const pinnedGitLane = [
@@ -66,6 +66,7 @@ test("hydrating checkouts follow the records-source flip while git-lane tooling 
     ".github/workflows/worker-records-ops.yml:verify",
   ];
   const recordsGate = "${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}";
+  const ledgerGate = "${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}";
   const recordsSecret = "${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}";
   const pinned: string[] = [];
   for (const { file, workflow } of workflows()) {
@@ -75,11 +76,13 @@ test("hydrating checkouts follow the records-source flip while git-lane tooling 
         const site = `${file}:${job}`;
         if (step.with?.["records-source"] === "git") {
           pinned.push(site);
+          assert.equal(step.with?.["ledger-source"], "git", site);
           assert.equal(step.with?.["records-url"], undefined, site);
           assert.equal(step.with?.["records-secret"], undefined, site);
           continue;
         }
         assert.equal(step.with?.["records-source"], recordsGate, site);
+        assert.equal(step.with?.["ledger-source"], ledgerGate, site);
         assert.equal(step.with?.["records-url"], coordinatorUrl, site);
         assert.equal(step.with?.["records-secret"], recordsSecret, site);
       }

--- a/test/worker-state-readers.test.ts
+++ b/test/worker-state-readers.test.ts
@@ -970,6 +970,7 @@ test("backfill workflow is manual per-target and setup-state plumbs the opt-in W
     (step) => step.uses === "./.github/actions/setup-state",
   );
   assert.equal(setupState?.with?.["records-source"], "git");
+  assert.equal(setupState?.with?.["ledger-source"], "git");
   assert.match(workflowSource, /scripts\/backfill-worker-records\.ts/);
   assert.match(workflowSource, /--cursor "\$BACKFILL_CURSOR"/);
   assert.match(workflowSource, /--replay-projections --max-replay-tuples/);
@@ -977,13 +978,21 @@ test("backfill workflow is manual per-target and setup-state plumbs the opt-in W
 
   const action = readFileSync(".github/actions/setup-state/action.yml", "utf8");
   assert.match(action, /records-source:[\s\S]*?default: git/);
+  assert.match(action, /ledger-source:[\s\S]*?default: git/);
   assert.match(action, /CLAWSWEEPER_RECORDS_SOURCE: \$\{\{ inputs\.records-source \}\}/);
   assert.match(action, /CLAWSWEEPER_RECORDS_URL: \$\{\{ inputs\.records-url \}\}/);
   assert.match(action, /CLAWSWEEPER_RECORDS_REPO_SLUGS: \$\{\{ inputs\.records-repo-slugs \}\}/);
   assert.match(action, /CLAWSWEEPER_RECORDS_SECRET: \$\{\{ inputs\.records-secret \}\}/);
+  assert.match(action, /CLAWSWEEPER_LEDGER_SOURCE: \$\{\{ inputs\.ledger-source \}\}/);
+  assert.match(
+    action,
+    /CLAWSWEEPER_BLOBS_CACHE_DIR: \$\{\{ inputs\.worktree-path \}\}\/\.artifacts\/worker-blobs-cache/,
+  );
   assert.match(action, /uses: actions\/cache@v6/);
   assert.match(action, /steps\.records-snapshot\.outputs\.cache-key/);
   assert.match(action, /\.artifacts\/worker-records-cache/);
+  assert.match(action, /inputs\.ledger-source == 'worker'/);
+  assert.match(action, /\.artifacts\/worker-blobs-cache/);
 });
 
 test("worker records ops workflow snapshots and verifies one requested repository", () => {
@@ -1038,6 +1047,7 @@ test("worker records ops workflow snapshots and verifies one requested repositor
   );
   const setupState = verify.steps?.find((step) => step.uses === "./.github/actions/setup-state");
   assert.equal(setupState?.with?.["records-source"], "git");
+  assert.equal(setupState?.with?.["ledger-source"], "git");
   assert.equal(setupState?.with?.["persist-credentials"], "false");
   assert.equal(
     setupState?.with?.["coordinator-enabled"],


### PR DESCRIPTION
Phase 3 of the state-repo retirement: make ledger/assets hydration flippable at runtime via a repo Actions variable, exactly mirroring what #908 did for records.

## What changed

- `.github/actions/setup-state/action.yml` gains a `ledger-source` input (git|worker, default git, following the `records-source` pattern from #874/#908). Worker mode reuses the existing `records-url`/`records-secret` inputs, exports `CLAWSWEEPER_LEDGER_SOURCE` and `CLAWSWEEPER_BLOBS_CACHE_DIR` to the hydrator, and restores a digest-addressed blob cache (`actions/cache`, run-unique key with prefix restore-keys, since blob cache entries are content-addressed and immutable).
- All 27 hydrating setup-state call sites that #908 flipped for records now also pass `ledger-source: vars.CLAWSWEEPER_LEDGER_SOURCE || 'git'` (commit-review x3, sweep x10, state-materializer, exact-review-batch-publish, proof-nudges, spam-scanner, and the repair-* workflows).
- The same four git-lane sites stay pinned with an explicit `ledger-source: git`: `worker-records-ops.yml` verify + reconcile, `backfill-worker-records.yml`, and `migrate-state-blobs.yml` — the migrator seeds R2 *from* the git tree and must never read through the Worker transport.
- The #908 shape test in `test/state-writer-workflow.test.ts` now asserts the ledger gate on hydrating sites and the git pin on the git-lane sites; `test/worker-state-readers.test.ts` asserts the new action input, env wiring, blob cache step, and the pinned call sites.

## Rollout

`scripts/hydrate-state.ts` already supports `--ledger-source` / `CLAWSWEEPER_LEDGER_SOURCE` with loud git fallback, and the R2 store is fully seeded (migration run 30340722175: 537k uploaded + 52k unchanged, zero failures). Defaults stay git everywhere; setting the repo variable `CLAWSWEEPER_LEDGER_SOURCE=worker` flips the fleet, deleting it rolls back. No Worker/dashboard change, so no redeploy is needed.

## Proof

- `node --test test/state-writer-workflow.test.ts` — 13 pass
- `node --test test/worker-state-readers.test.ts` — 18 pass
- `node --test test/worker-state-blobs.test.ts` — 15 pass
- `node --test test/sweep-workflow.test.ts test/clawsweeper.test.ts` — pass after `build`/`build:repair`
- `pnpm run lint:scripts`, `format:check`, `check:active-surface`, `check:limits` — clean
- autoreview (codex, local): clean, "patch is correct (0.98)"
