### PR TITLE
perf(state): unblock exact review publication checkout

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1177,6 +1177,7 @@ jobs:
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.direct-state-token.outputs.token }}
+          filter: blob:none
           fetch-depth: 1
           persist-credentials: false
 

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -107,6 +107,16 @@ test("the setup action exports no long-lived coordinator credential", () => {
   assert.match(source, /CLAWSWEEPER_STATE_COORDINATOR_CLASS=\$\{\{ inputs\.coordinator-class \}\}/);
 });
 
+test("exact-review direct publication partial-clones generated state", () => {
+  const sweep = workflows().find(({ file }) => file === ".github/workflows/sweep.yml")?.workflow;
+  const publisher = sweep?.jobs?.["event-review-apply"];
+  const setup = publisher?.steps?.find((step) => step.uses === "./.github/actions/setup-state");
+
+  assert.ok(setup, "event-review-apply setup-state step");
+  assert.equal(setup.with?.filter, "blob:none");
+  assert.equal(setup.with?.["fetch-depth"], 1);
+});
+
 test("state materializer and apply publishers enable model-guided recovery with the existing Codex key", () => {
   const expectedKey = "${{ secrets.OPENAI_API_KEY }}";
   const expectedModel = "${{ secrets.CLAWSWEEPER_MODEL }}";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact-item reviews could finish model evaluation in one or two minutes but then spend 18+ minutes cloning generated state before the review comment could be published.

## Why This Change Was Made

The direct exact-review publisher now requests the same blobless partial clone already used by sibling generated-state publication lanes. The shallow history depth and all state hydration/publication contracts remain unchanged.

## User Impact

Maintainers receive completed ClawSweeper review comments sooner, and stalled state checkout work holds fewer exact-review queue slots.

## Evidence

- Live runs `30366310681` and `30366505096`: Codex review completed in 85s and 88s, then both remained in `setup-state` for more than 18 minutes on the unfiltered checkout path.
- `node --test test/state-writer-workflow.test.ts`: 14/14 passed.
- `oxfmt --check .github/workflows/sweep.yml test/state-writer-workflow.test.ts`: passed.
- Exact-head CI `pnpm check`: passed on Linux. A parallel macOS run reached unrelated existing Linux-only containment/path assertions (`capset` missing and `/private/var` aliasing); the touched focused test passed locally.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
