### PR TITLE
perf(state): unblock queued review materialization

### DIFF
--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -137,6 +137,7 @@ jobs:
           # ordinary writers a slot.
           coordinator-class: ${{ inputs.intake_priority && 'cluster_intake' || 'publication_batch' }}
           token: ${{ steps.state-token.outputs.token }}
+          filter: blob:none
           # depth-1 cannot fast-forward or rebuild against a branch other
           # writers keep advancing (non-fast-forward shallow push rejections,
           # runs 29938808338 / 29957012043); a full clone of `state`'s own

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -187,6 +187,7 @@ test("state materializer checks out a recovery-sized state history window", () =
   const byFile = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
   const materializer = byFile.get(".github/workflows/state-materializer.yml")?.jobs?.materialize;
   const setupState = materializer?.steps?.find(isSetupState);
+  assert.equal(setupState?.with?.filter, "blob:none");
   assert.equal(setupState?.with?.["fetch-depth"], 512);
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the singleton state materializer could spend more than 90 minutes cloning the generated-state repository, leaving accepted exact reviews queued without publishing their GitHub comments.

## Why This Change Was Made

The materializer now combines its existing 512-commit recovery window with the same supported `blob:none` partial clone used by sibling state writers. History remains available for reconciliation, while untouched blobs are fetched only if the materializer actually reads them.

## User Impact

Accepted ClawSweeper review results can drain from the durable queue instead of waiting behind an oversized state checkout.

## Evidence

- Live materializer run `30362444031`: `setup-state` remained active from 13:13 UTC past 14:49 UTC, blocking run `30366186240` and all accepted exact-review comments behind it.
- `node --test test/state-writer-workflow.test.ts`: 14/14 passed.
- `oxfmt --check .github/workflows/state-materializer.yml test/state-writer-workflow.test.ts`: passed.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
