### PR TITLE
feat(state): default hydration sources to worker

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -151,8 +151,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -428,8 +428,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -555,8 +555,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -99,8 +99,8 @@ jobs:
           coordinator-class: publication_batch
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -110,8 +110,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -168,8 +168,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -255,8 +255,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -558,8 +558,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -163,8 +163,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-commit-finding-intake.yml
+++ b/.github/workflows/repair-commit-finding-intake.yml
@@ -126,8 +126,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -79,8 +79,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -71,8 +71,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -163,8 +163,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -111,8 +111,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           coordinator-class: publication_batch

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -76,8 +76,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -115,8 +115,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/state-materializer.yml
+++ b/.github/workflows/state-materializer.yml
@@ -126,8 +126,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           # The materializer is the designated bulk writer of the single-writer

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1172,8 +1172,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.direct-state-token.outputs.token }}
@@ -1783,8 +1783,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -2411,8 +2411,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -2558,8 +2558,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -3310,8 +3310,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -4036,8 +4036,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -4240,8 +4240,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -4364,8 +4364,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ github.token }}
@@ -4581,8 +4581,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}
@@ -4732,8 +4732,8 @@ jobs:
         with:
           coordinator-enabled: ${{ vars.CLAWSWEEPER_STATE_COORDINATOR_ENABLED || 'false' }}
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}
-          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}
+          ledger-source: ${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}
+          records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           token: ${{ steps.state-token.outputs.token }}

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -65,8 +65,8 @@ test("hydrating checkouts follow the records/ledger-source flips while git-lane 
     ".github/workflows/worker-records-ops.yml:reconcile",
     ".github/workflows/worker-records-ops.yml:verify",
   ];
-  const recordsGate = "${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'git' }}";
-  const ledgerGate = "${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'git' }}";
+  const recordsGate = "${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}";
+  const ledgerGate = "${{ vars.CLAWSWEEPER_LEDGER_SOURCE || 'worker' }}";
   const recordsSecret = "${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}";
   const pinned: string[] = [];
   for (const { file, workflow } of workflows()) {


### PR DESCRIPTION
The records cutover is verified (run 30358523596: 120/120 slugs hydrated from the Worker) and the R2 blob store is fully seeded, but both CLAWSWEEPER_RECORDS_SOURCE and CLAWSWEEPER_LEDGER_SOURCE repo variables were reverted to git by an unidentified automated actor at 17:42Z (16s apart; tripwire now watching). Flipping the workflow fallbacks from || 'git' to || 'worker' makes worker the default and turns the variable into what it should be: an explicit emergency-rollback switch (set to git to roll back). Pinned git-lane tooling (ops verify/reconcile, backfill, migrator) is untouched. Shape tests updated, 34/34 pass, autoreview clean.