### PR TITLE
fix(apply): publish reconciled records through a manifest

### DIFF
--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -132,12 +132,19 @@ publish_changes_with_strategy() {
   local rebase_strategy="$1"
   local message="$2"
   shift 2
-  local publish_args=(--message "$message" --rebase-strategy "$rebase_strategy")
-  local path
-  for path in "$@"; do
-    publish_args+=(--path "$path")
-  done
-  pnpm run repair:publish-main -- "${publish_args[@]}"
+  # Reconciliation publishes four paths per changed record, so a flag per path
+  # outgrows the kernel's single-argument limit and pnpm spawns with E2BIG.
+  # The manifest keeps the command a fixed size no matter how many records move.
+  local paths_file
+  paths_file="$(mktemp)"
+  printf '%s\n' "$@" >"$paths_file"
+  local status=0
+  pnpm run repair:publish-main -- \
+    --message "$message" \
+    --rebase-strategy "$rebase_strategy" \
+    --paths-file "$paths_file" || status=$?
+  rm -f "$paths_file"
+  return "$status"
 }
 
 publish_changes() {

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -698,6 +698,8 @@ function parseArgs(argv: readonly string[]): Args {
     if (arg === "--") continue;
     if (arg === "--message") parsed.message = requiredValue(argv, ++index, arg);
     else if (arg === "--path") parsed.paths.push(requiredValue(argv, ++index, arg));
+    else if (arg === "--paths-file")
+      parsed.paths.push(...readPathsFile(requiredValue(argv, ++index, arg)));
     else if (arg === "--restore") parsed.restorePaths.push(requiredValue(argv, ++index, arg));
     else if (arg === "--max-attempts")
       parsed.maxAttempts = parsePositiveInt(requiredValue(argv, ++index, arg), arg);
@@ -708,8 +710,20 @@ function parseArgs(argv: readonly string[]): Args {
     else throw new Error(`Unknown argument: ${arg}`);
   }
   if (!parsed.message) throw new Error("--message is required");
-  if (parsed.paths.length === 0) throw new Error("At least one --path is required");
+  if (parsed.paths.length === 0)
+    throw new Error("At least one --path or --paths-file entry is required");
   return parsed;
+}
+
+// A flag per path overflows the kernel's single-argument limit once a publish
+// covers a few hundred records, so callers with an unbounded list pass a manifest.
+function readPathsFile(file: string): string[] {
+  const paths = readFileSync(resolve(file), "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (paths.length === 0) throw new Error(`--paths-file has no entries: ${file}`);
+  return paths;
 }
 
 function requiredValue(argv: readonly string[], index: number, flag: string): string {

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -571,6 +572,62 @@ function conflictResponse(
     },
     { status: 409 },
   );
+}
+
+test("publish-main takes paths from a manifest and merges them with --path", () => {
+  const cli = path.resolve("dist/repair/publish-main.js");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-paths-file-"));
+  const manifest = path.join(dir, "manifest.txt");
+  const recordPath = "records/openclaw-openclaw/items/42.md";
+
+  // Padding and blank lines around the entry are dropped, and the record path
+  // survives to record publication — a stage only records/* paths reach.
+  fs.writeFileSync(manifest, `\n  ${recordPath}  \n\n`);
+  assert.match(
+    runPublishMain(cli, dir, ["--message", "probe", "--paths-file", manifest]),
+    /record publication requires a hydrated state checkout/,
+  );
+
+  // The same run without the manifest never reaches that stage, so the manifest
+  // is what carried the record path in.
+  assert.match(
+    runPublishMain(cli, dir, ["--message", "probe", "--path", "results/probe.json"]),
+    /not in a git directory/,
+  );
+
+  // Both flags feed one list.
+  assert.match(
+    runPublishMain(cli, dir, [
+      "--message",
+      "probe",
+      "--path",
+      "results/probe.json",
+      "--paths-file",
+      manifest,
+    ]),
+    /record publication requires a hydrated state checkout/,
+  );
+
+  fs.writeFileSync(manifest, "\n   \n");
+  assert.match(
+    runPublishMain(cli, dir, ["--message", "probe", "--paths-file", manifest]),
+    /--paths-file has no entries/,
+  );
+
+  assert.match(
+    runPublishMain(cli, dir, ["--message", "probe"]),
+    /At least one --path or --paths-file entry is required/,
+  );
+});
+
+function runPublishMain(cli: string, cwd: string, args: readonly string[]): string {
+  const result = spawnSync(process.execPath, [cli, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, CLAWSWEEPER_STATE_DIR: "", CLAWSWEEPER_STATE_APPEND_ENABLED: "" },
+  });
+  assert.notEqual(result.status, 0, "publish-main must not publish from a scratch directory");
+  return `${result.stdout}${result.stderr}`;
 }
 
 function appendEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1471,6 +1471,48 @@ test("reconcile publication batches large corrected tuple sets below exec argume
   ]);
 });
 
+test("record publication sizes its command by the flag list, not by the record count", () => {
+  const recordCount = 4000;
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'pnpm() { captured_manifest="${!#}"; printf "argc %s\\n" "$#"; printf "arg %s\\n" "$@"; printf "manifest_lines %s\\n" "$(wc -l < "$captured_manifest" | tr -d " ")"; }',
+        "paths=()",
+        `for index in $(seq 1 ${recordCount}); do paths+=("records/openclaw-openclaw/items/\${index}.md"); done`,
+        'publish_changes_with_strategy reconcile-records "persist reconciliation" "${paths[@]}"',
+        '[ -e "$captured_manifest" ] && printf "manifest_retained\\n" || printf "manifest_removed\\n"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  const lines = output.trim().split("\n");
+  const args = lines.filter((line) => line.startsWith("arg ")).map((line) => line.slice(4));
+
+  // A flag per path made this vector grow with the reconcile until the whole
+  // command passed the kernel's 128 KiB single-argument limit and pnpm died
+  // with E2BIG, taking the apply lane down before it applied anything.
+  assert.ok(lines.includes("argc 9"), `expected a fixed-size command, got ${lines[0]}`);
+  assert.deepEqual(args, [
+    "run",
+    "repair:publish-main",
+    "--",
+    "--message",
+    "persist reconciliation",
+    "--rebase-strategy",
+    "reconcile-records",
+    "--paths-file",
+    args[8],
+  ]);
+  assert.ok(!args.includes("--path"));
+  assert.ok(!args.some((arg) => arg.startsWith("records/")));
+  assert.ok(lines.includes(`manifest_lines ${recordCount}`));
+  assert.ok(lines.includes("manifest_removed"));
+});
+
 test("apply checkpoints split record tuples from auxiliary state", () => {
   const output = execFileSync(
     "bash",


### PR DESCRIPTION
Closes https://github.com/openclaw/clawsweeper/issues/923

## What Problem This Solves

The `openclaw/openclaw` close-apply lane fails before it applies anything. `Apply close
proposals` runs `Reconcile before apply preselect` first, and that step dies with
`spawn E2BIG`. The next step, `Apply unchanged proposed decisions with checkpoints`, carries
no `if:` condition, so it inherits the default `success()` and is skipped — every run loses
both the persisted reconciliation and the close application.

`publish_reconciled_records` builds four paths per changed record, and
`publish_changes_with_strategy` turns each one into its own `--path` flag before calling
`pnpm run repair:publish-main`. Paths average 44 bytes across the command, so the vector
crosses 128 KiB at roughly 2,550 arguments — about 630 changed records.

128 KiB is `MAX_ARG_STRLEN`, the limit on a **single** argument. The total was nowhere near
`ARG_MAX`: the whole command measured 131 KB to 197 KB against a 2 MiB total budget, and it
still failed, which leaves the per-argument limit as the only applicable one. That matches
the invocation, since pnpm spawns the script through a shell (`spawn3` in the stack below),
so the assembled command line arrives as one argument.

Across `2026-07-27T13:00Z .. 2026-07-28T22:07Z`, **every run of that lane that either
reconstruction below could see ended in failure or cancellation** — at least 72 failures and
40 cancellations, and no successes in either. The same code path still succeeds for
`openclaw/clawhub`, where the reconcile emits a single path and the command is 176 bytes —
runs [30269375248](https://github.com/openclaw/clawsweeper/actions/runs/30269375248),
[30273630712](https://github.com/openclaw/clawsweeper/actions/runs/30273630712) and
[30279679452](https://github.com/openclaw/clawsweeper/actions/runs/30279679452). The failure
is a function of record count, not of the target repository.

## Why This Change Was Made

`publish-main` gains `--paths-file`, and the helper writes the list to a manifest instead of
one flag per path. The manifest keeps one publish per reconcile, so `reconcile-records`
still rebases over the whole tuple set exactly as it does today.

The `--paths-file` contract is one path per line: entries are trimmed, blank lines are
dropped, and a file that yields no entries is an error. It composes with `--path` rather
than replacing it — both append to the same list, and every existing `--path` caller is
untouched. Record paths always satisfy that contract because `publish_reconciled_records`
already refuses to publish unless every changed record file matches
`^[a-z0-9][a-z0-9-]*-[0-9]+\.md$|^[0-9]+\.md$`, so a newline cannot reach a path segment.

The helper removes the manifest after the publish returns, on both the success and the
failure path — the exit status is captured first and returned afterwards, so a failing
publish still cleans up and still propagates its status. A signal that kills the step
mid-publish leaves the file behind in the runner's `TMPDIR`, which is discarded with the
ephemeral runner.

Chunking the list in the helper was the other option and is deliberately not taken: it
splits one reconcile across several commits, which changes what the `reconcile-records`
strategy sees per publish. That is a semantic decision rather than a mechanical one.

One other site has the same shape: `repair-publish-results.yml` already writes a `paths_file`
and then expands it back into `--path` flags, so `--paths-file` would delete two lines there.
It is deliberately left out of this PR — no run of that lane has failed this way, so it is
preventive hardening rather than part of this fix, and it is easy to take separately once
you have decided on the shape here.

The regression test asserts the property that failed: the publish command must keep a
**fixed argument count** regardless of how many records moved. Asserting a byte count would
pass again as soon as path lengths changed.

## User Impact

The reconcile step stops failing on argument size, which is what currently ends the run
before its apply step. This patch is not deployed, so the lane's recovery is the expected
effect rather than something demonstrated here; what is demonstrated is that the publish
command no longer grows with the record count. Callers that pass a bounded `--path` list
are unaffected.

## Evidence

Production failure —
[run 30353517320](https://github.com/openclaw/clawsweeper/actions/runs/30353517320),
`2026-07-28T11:07:27Z`, job `Apply close proposals`, failed step
`14. Reconcile before apply preselect`. Actions logs expire, so the lines are quoted:

```
$ node dist/repair/publish-main.js -- --message 'chore: persist sweep reconciliation' --rebase-strategy reconcile-records --path records/openclaw-openclaw/items/100001.md --path records/openclaw-openclaw/closed/100001.md ...

Error: spawn E2BIG
    at ChildProcess.spawn (node:internal/child_process:441:11)
    at spawn (node:child_process:796:9)
    at spawn3 (.../pnpm/11.10.0/dist/pnpm.mjs:110679:15)
    at runCmd (.../pnpm/11.10.0/dist/pnpm.mjs:133571:5)
  errno: -7,
  code: 'E2BIG',
  syscall: 'spawn'
[ELIFECYCLE] Command failed with exit code 1.
##[error]Process completed with exit code 1.
```

The log cuts that command at exactly 131,072 bytes; at the cut it already carries 2,495
`--path` arguments, and the 44-byte average is measured over them. The failing step and the
argument count come straight out of the public run:

```bash
gh api repos/openclaw/clawsweeper/actions/runs/30353517320/jobs \
  --jq '.jobs[] | select(.conclusion=="failure")
        | "\(.name)", (.steps[] | select(.conclusion=="failure") | "  step \(.number). \(.name)")'
# Apply close proposals
#   step 14. Reconcile before apply preselect

gh api repos/openclaw/clawsweeper/actions/runs/30353517320/logs > logs.zip   # count --path in
                                                                            # "Apply close proposals"
```

Sampled failures of the same job between `2026-07-27T13:13Z` and `2026-07-28T05:10Z` carry
the same signature in 9 of 12 runs, with 2,495 to 3,763 arguments — for example
[run 30316576731](https://github.com/openclaw/clawsweeper/actions/runs/30316576731). The lane
tally, one hour per query because the runs endpoint returns at most 1,000 rows:

```bash
lane="Apply default ClawSweeper closures for openclaw/openclaw"
for hour in $(seq 0 32); do
  start=$(date -u -d "2026-07-27T13:00:00Z +${hour} hours" +%Y-%m-%dT%H:%M:%SZ)
  end=$(date -u -d "2026-07-27T13:59:59Z +${hour} hours" +%Y-%m-%dT%H:%M:%SZ)
  for page in $(seq 1 10); do
    batch=$(gh api "repos/openclaw/clawsweeper/actions/runs?per_page=100&page=${page}&created=${start}..${end}")
    printf '%s' "$batch" | jq -r --arg lane "$lane" \
      '.workflow_runs[] | select(.name == $lane) | .conclusion'
    [ "$(printf '%s' "$batch" | jq '.workflow_runs | length')" -lt 100 ] && break
  done
done | sort | uniq -c
#      40 cancelled
#      72 failure
```

Those two numbers are floors rather than exact counts: 13 of the 33 hours in this window
carry more than 1,000 runs, so even an hourly query truncates. Sampling the same window
continuously instead, and re-fetching every run that was still in flight when it was first
seen, raises it to 76 failures and 47 cancellations. What does not move between the two
reconstructions is the part that matters — neither contains a single success.

The binding limit, bisected locally on Node `v24.18.0`:

```console
$ python3 -c "
import subprocess
for n in (131071, 131072):
    try:
        subprocess.run(['sh','-c','true '+'x'*(n-5)], capture_output=True); print(n,'ok')
    except OSError as e: print(n, e.strerror)"
131071 ok
131072 Argument list too long

$ getconf ARG_MAX
2097152
```

The regression test is red on the unfixed helper and green with this patch:

```
# scripts/apply-workflow-helpers.sh reverted to 10494a0, test applied
ℹ pass 0
ℹ fail 1
  AssertionError [ERR_ASSERTION]: expected a fixed-size command, got argc 8007

# with this patch
✔ record publication sizes its command by the flag list, not by the record count
ℹ pass 1
ℹ fail 0
```

`argc 8007` is 4,000 records expanded into flags plus the seven fixed arguments. With the
patch the count is 9 no matter how many records moved, the manifest holds all 4,000 paths,
and it is gone after the call.

A second test drives the CLI itself, since the helper only proves the calling shape. It runs
the built `publish-main` in a scratch directory and pins the manifest contract: an entry
padded with spaces between blank lines still reaches record publication (a stage only
`records/*` paths reach, and one the same run without the manifest does not get to), the two
flags feed one list, a manifest with nothing but whitespace fails with
`--paths-file has no entries`, and passing neither flag still fails with
`At least one --path or --paths-file entry is required`.

`pnpm run check` on Node `v24.18.0` ran 2,920 tests with 10 failures, all host-caused and
all in files this patch does not touch: seven report `Git must support --no-lazy-fetch`
(this host has Git 2.34.1) and three cannot resolve the bun/npm/pnpm containment fixtures.
CI is authoritative for those. Everything covering the changed surfaces passes.

### Proof summary

- **Behavior addressed:** `Reconcile before apply preselect` fails with `spawn E2BIG` once a
  reconcile touches roughly 630 records, so the `openclaw/openclaw` close-apply lane never
  reaches its apply step.
- **Real environment tested:** production GitHub Actions runs for the failure (run
  30353517320 and the sampled runs above); local Node `v24.18.0` for the kernel limit and
  for the before/after regression test.
- **Exact steps or command run after this patch:**

  ```bash
  # 1. the failing production step and its argument count (commands above)
  # 2. the regression test
  node --test --test-name-pattern='record publication sizes' test/sweep-workflow.test.ts
  ```

- **Evidence after fix:** the test block above — the publish command is 9 arguments for
  4,000 records, the manifest holds all 4,000 paths, and it is removed after the call.
- **Observed result after fix:** `pass 1 / fail 0`, and `fail 1` with `argc 8007` when the
  helper is reverted.
- **What was not tested:** this patch is not deployed, so no production run of the fixed lane
  exists — the outage rests on the run logs above and the fix rests on the before/after test.
  A real reconcile of ~630 records is not reproduced end to end locally, because it needs the
  state repository and write credentials; what is reproduced is the argument vector the
  reconcile builds and the kernel limit it crossed. The ten local `pnpm run check` failures
  are host-caused as described above. `repair-publish-results.yml` has the same unbounded
  shape but no observed failure, and is left for a separate change.
