### PR TITLE
fix: reconcile apply authority drift

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4533,9 +4533,22 @@ jobs:
             --report-path .artifacts/apply-proof/apply-report.json \
             --progress-every 1
 
+      - name: Create bound close coverage proof manifest
+        id: proof-manifest
+        if: ${{ always() && !cancelled() && steps.proof-select.outcome == 'success' && (steps.proof-select.outputs.item_numbers == '' || steps.generate-apply-proofs.outcome == 'success') }}
+        env:
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          source scripts/apply-workflow-helpers.sh
+          write_coverage_proof_manifest \
+            ".artifacts/apply-proof/pr-close-coverage-proof" \
+            "$TARGET_REPO" \
+            "${{ steps.proof-select.outputs.item_numbers }}"
+
       - name: Export primary apply proof result
         id: primary-proof-result
-        if: ${{ always() && !cancelled() && steps.proof-select.outcome == 'success' && (steps.proof-select.outputs.item_numbers == '' || steps.generate-apply-proofs.outcome == 'success') }}
+        if: ${{ always() && !cancelled() && steps.proof-select.outcome == 'success' && (steps.proof-select.outputs.item_numbers == '' || steps.generate-apply-proofs.outcome == 'success') && steps.proof-manifest.outcome == 'success' }}
         run: echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Finalize apply proof action ledger
@@ -4552,12 +4565,12 @@ jobs:
           pnpm run --silent finalize-action-events -- "${args[@]}"
 
       - name: Upload bound close coverage proofs
-        if: ${{ always() && steps.proof-select.outputs.item_numbers != '' }}
+        if: ${{ always() && steps.proof-manifest.outcome == 'success' }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.proof-artifact.outputs.name }}
-          path: .artifacts/apply-proof/pr-close-coverage-proof/*.proof.json
-          if-no-files-found: ignore
+          path: .artifacts/apply-proof/pr-close-coverage-proof/*
+          if-no-files-found: error
           retention-days: 1
 
       - name: Upload apply proof action events
@@ -4789,7 +4802,6 @@ jobs:
         continue-on-error: true
 
       - uses: actions/download-artifact@v8
-        continue-on-error: true
         with:
           name: ${{ needs.apply-proof.outputs.artifact_name }}
           path: .artifacts/apply-proof/pr-close-coverage-proof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Reconciled apply backlogs now publish record tuples in bounded batches, re-verify authority-superseded canonical revisions without weakening source/verdict guards, and always carry an explicit coverage-proof artifact manifest under reduced state hydration.
 - Restored close-backlog throughput by keeping apply jobs off the enormous immutable state-blob hydration path, and isolated operator-dispatched sweeps from background concurrency coalescing.
 
 - Prevented exact-review cancellation storms by sparsely checking out Worker-projected state and keeping completed review-generation leases fenced through final publication.

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -128,6 +128,13 @@ export type ValidatedCanonicalRecordTupleMutation = {
   fingerprint: string;
 };
 
+export type CanonicalRecordTupleConflictState = {
+  key: string;
+  revision: number;
+  deliveryId: string | null;
+  operations: CanonicalRecordTupleMutationOperation[];
+};
+
 export type RecordExportEntry = {
   repoSlug: string;
   section: RecordSection;
@@ -161,9 +168,12 @@ export class DirectPublicationProjectionCapacityError extends Error {
 }
 
 export class CanonicalRecordTupleConflictError extends Error {
-  constructor(message: string) {
+  readonly current: CanonicalRecordTupleConflictState | null;
+
+  constructor(message: string, current: CanonicalRecordTupleConflictState | null = null) {
     super(message);
     this.name = "CanonicalRecordTupleConflictError";
+    this.current = current;
   }
 }
 
@@ -467,6 +477,7 @@ export class ExactReviewDirectPublicationStore {
         if (currentDigest !== expectedDigest) {
           throw new CanonicalRecordTupleConflictError(
             `canonical record changed before tuple publication: ${operation.path}`,
+            this.canonicalTupleConflictStateSync(mutation.repoSlug, mutation.itemId),
           );
         }
       }
@@ -558,6 +569,38 @@ export class ExactReviewDirectPublicationStore {
       throw new Error(`canonical record byte count mismatch: ${repoSlug}/${section}/${itemId}`);
     }
     return { ...metadata, content };
+  }
+
+  private canonicalTupleConflictStateSync(
+    repoSlug: string,
+    itemId: number,
+  ): CanonicalRecordTupleConflictState | null {
+    const sections = ["items", "closed", "plans", "decision-packets"] as const;
+    const records = sections.map((section) => this.readCanonical(repoSlug, section, itemId));
+    const revisions = new Set(records.flatMap((record) => (record ? [record.revision] : [])));
+    if (records.some((record) => record === null) || revisions.size !== 1) return null;
+    const revision = records[0]!.revision;
+    const receiptPrefix = `record-reconcile:${repoSlug}:${itemId}:`;
+    const deliveryId = Array.from(
+      this.storage.sql.exec(
+        `SELECT delivery_id
+           FROM ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE}
+          WHERE revision = ?
+          ORDER BY received_at DESC, delivery_id`,
+        revision,
+      ),
+      (row) => String(row.delivery_id),
+    ).find((candidate) => candidate.startsWith(receiptPrefix));
+    return {
+      key: `${repoSlug}/${itemId}`,
+      revision,
+      deliveryId: deliveryId ?? null,
+      operations: records.map((record, index) => ({
+        path: `records/${repoSlug}/${sections[index]}/${itemId}.${sections[index] === "decision-packets" ? "json" : "md"}`,
+        expectedDigest: record!.deleted ? null : record!.digest,
+        ...(record!.content === null ? {} : { contentBase64: base64Text(record!.content) }),
+      })),
+    };
   }
 
   listCanonical(options: {
@@ -1669,6 +1712,13 @@ function stateAppendWindowTotalsSync(storage: DurableStorage) {
 function base64Bytes(value: string) {
   const binary = atob(value);
   return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+function base64Text(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 function byteChunks(content: string, maximumBytes: number) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2298,7 +2298,13 @@ export class ExactReviewQueue {
       } catch (error) {
         if (error instanceof CanonicalRecordTupleConflictError) {
           console.warn(`canonical record tuple conflict: ${sanitizedServerError(error)}`);
-          return json({ error: "canonical_record_tuple_conflict" }, 409);
+          return json(
+            {
+              error: "canonical_record_tuple_conflict",
+              ...(error.current ? { current: error.current } : {}),
+            },
+            409,
+          );
         }
         if (error instanceof DirectPublicationProjectionCapacityError) {
           console.warn(`canonical record tuple capacity rejected: ${sanitizedServerError(error)}`);

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -57,8 +57,26 @@ validate_coverage_proof_tree() {
     return 1
   fi
   local proof_files=()
+  local manifest_path="$proof_dir/manifest.json"
+  if [ ! -f "$manifest_path" ]; then
+    echo "Coverage proof artifact is missing manifest.json" >&2
+    return 1
+  fi
+  if ! jq -e '
+    type == "object" and
+    .schemaVersion == 1 and
+    (.targetRepo | type == "string" and test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")) and
+    (.selectedItems | type == "array" and all(.[]; type == "number" and . >= 1 and floor == .)) and
+    (.proofCount | type == "number" and . >= 0 and floor == .)
+  ' "$manifest_path" >/dev/null; then
+    echo "Coverage proof artifact manifest is invalid" >&2
+    return 1
+  fi
   local proof_file
   while IFS= read -r -d '' proof_file; do
+    if [ "$proof_file" = "$manifest_path" ]; then
+      continue
+    fi
     proof_files+=("$proof_file")
   done < <(find "$proof_dir" -mindepth 1 -maxdepth 1 -type f -print0)
   if [ "${#proof_files[@]}" -gt "$max_files" ]; then
@@ -80,10 +98,33 @@ validate_coverage_proof_tree() {
     fi
     total_bytes=$((total_bytes + proof_bytes))
   done
+  if [ "$(jq -r '.proofCount' "$manifest_path")" -ne "${#proof_files[@]}" ]; then
+    echo "Coverage proof artifact manifest count does not match proof files" >&2
+    return 1
+  fi
   if [ "$total_bytes" -gt "$max_total_bytes" ]; then
     echo "Coverage proof artifacts exceed the $max_total_bytes-byte total limit." >&2
     return 1
   fi
+}
+
+write_coverage_proof_manifest() {
+  local proof_dir="$1"
+  local target_repo="$2"
+  local selected_items_csv="${3:-}"
+  mkdir -p "$proof_dir"
+  local proof_count
+  proof_count="$(find "$proof_dir" -mindepth 1 -maxdepth 1 -type f -name '*.proof.json' | wc -l | tr -d ' ')"
+  jq -n \
+    --arg target_repo "$target_repo" \
+    --arg selected_items "$selected_items_csv" \
+    --argjson proof_count "$proof_count" \
+    '{
+      schemaVersion: 1,
+      targetRepo: $target_repo,
+      selectedItems: ($selected_items | split(",") | map(select(length > 0) | tonumber)),
+      proofCount: $proof_count
+    }' > "$proof_dir/manifest.json"
 }
 progress_every=10
 
@@ -140,6 +181,7 @@ publish_reconciled_records() {
   target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]')"
   target_slug="${target_slug//\//-}"
   local publish_paths=()
+  local tuple_count=0
   local record_file
   local number
 
@@ -162,23 +204,47 @@ publish_reconciled_records() {
       "records/${target_slug}/plans/${record_file}"
       "records/${target_slug}/decision-packets/${number}.json"
     )
+    tuple_count=$((tuple_count + 1))
+    if [ "$tuple_count" -ge 50 ]; then
+      CLAWSWEEPER_CANONICAL_PUBLICATION_KIND=reconcile \
+        CLAWSWEEPER_RECONCILE_DEFERRED_PATH=.artifacts/apply-reconcile-deferred.jsonl \
+        publish_changes_with_strategy reconcile-records "$message" "${publish_paths[@]}" || return 1
+      publish_paths=()
+      tuple_count=0
+    fi
   done < <(jq -r '.changedRecordFiles[]' <<<"$reconcile_json")
 
-  if [ "${#publish_paths[@]}" -eq 0 ]; then
+  if [ "${#publish_paths[@]}" -eq 0 ] && [ "$tuple_count" -eq 0 ]; then
+    if [ "$(jq '.changedRecordFiles | length' <<<"$reconcile_json")" -gt 0 ]; then
+      return 0
+    fi
     echo "Reconcile changed no durable record tuples."
     return 0
   fi
   # Reconciliation can move records in either direction. Preserve the newer
   # remote tuple when another publisher changes the same item, while applying
   # non-conflicting tuples independently.
-  publish_changes_with_strategy reconcile-records "$message" "${publish_paths[@]}"
+  CLAWSWEEPER_CANONICAL_PUBLICATION_KIND=reconcile \
+    CLAWSWEEPER_RECONCILE_DEFERRED_PATH=.artifacts/apply-reconcile-deferred.jsonl \
+    publish_changes_with_strategy reconcile-records "$message" "${publish_paths[@]}" || return 1
 }
 
 persist_reconciliation() {
   local reconcile_json
   reconcile_json="$(pnpm run --silent reconcile -- "$@")"
   echo "$reconcile_json"
-  publish_reconciled_records "chore: persist sweep reconciliation" "$reconcile_json"
+  publish_reconciled_records "chore: persist sweep reconciliation" "$reconcile_json" || return 1
+  load_reconciliation_deferred_items
+}
+
+load_reconciliation_deferred_items() {
+  deferred_item_numbers=""
+  if [ -s .artifacts/apply-reconcile-deferred.jsonl ]; then
+    deferred_item_numbers="$(jq -rs 'map(.itemNumber) | unique | join(",")' .artifacts/apply-reconcile-deferred.jsonl)"
+    echo "Deferring canonical conflict items to re-review: $deferred_item_numbers"
+  fi
+  CLAWSWEEPER_RECONCILIATION_DEFERRED_ITEM_NUMBERS="$deferred_item_numbers"
+  export CLAWSWEEPER_RECONCILIATION_DEFERRED_ITEM_NUMBERS
 }
 
 write_apply_health() {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -27411,6 +27411,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const bulkFilerRepositoryPermissionCache: BulkFilerRepositoryPermissionCache = new Map();
   const requestedItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
   const requestedItemNumberSet = new Set(requestedItemNumbers);
+  const reconciliationDeferredItemNumbers = new Set(
+    itemNumbersArg(
+      args.deferred_item_numbers ?? process.env.CLAWSWEEPER_RECONCILIATION_DEFERRED_ITEM_NUMBERS,
+      undefined,
+    ),
+  );
   const requestedItemOrder = orderedApplyItemNumbers(args.item_numbers, args.item_number);
   const requestedItemOrderIndex = new Map(
     requestedItemOrder.map((number, index) => [number, index]),
@@ -27631,7 +27637,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     return;
   }
   logProgress(
-    `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} suppress_automation_markers=${suppressAutomationMarkers} comment_sync_min_age_days=${commentSyncMinAgeDays} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"}`,
+    `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} suppress_automation_markers=${suppressAutomationMarkers} comment_sync_min_age_days=${commentSyncMinAgeDays} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"} reconciliation_deferred=${[...reconciliationDeferredItemNumbers].join(",") || "none"}`,
   );
   // oxfmt-ignore
   for (const entry of fileEntries) {
@@ -27798,6 +27804,17 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       markdown = replaceFrontMatterValue(markdown, "action_taken", actionTaken);
       return recordApplySkipped(actionTaken, reason, liveGuardVerified);
     };
+    if (reconciliationDeferredItemNumbers.has(number)) {
+      if (
+        markApplySkipped(
+          "skipped_changed_since_review",
+          "canonical record changed during reconciliation; fresh review required",
+        )
+      ) {
+        break;
+      }
+      continue;
+    }
     const markLabelSyncAuthSkipped = (labelKind: string): boolean => {
       const reason = `GitHub rejected ${labelKind} label sync with Requires authentication`;
       return staleCanonicalCommentSyncPending

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import {
+  appendFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
@@ -13,8 +24,10 @@ import {
 } from "./git-publish.js";
 import { recordTuplePaths, validateRecordTuple, type RecordTupleContents } from "./record-tuple.js";
 import {
+  CanonicalRecordTupleConflictError,
   postCanonicalRecordTuple,
   postStateAppend,
+  type CanonicalRecordTupleConflictState,
   type CanonicalRecordTupleMutation,
   type StateAppendInputRecord,
   type StateAppendResult,
@@ -72,10 +85,13 @@ export async function publishMainWithStateAppend(
       throw new Error("canonical record publication is required for record tuple changes");
     }
     for (const mutation of canonicalPlan.mutations) {
-      await postCanonicalRecordTuple({
+      await postCanonicalRecordTupleWithRecovery({
         queueUrl,
         webhookSecret,
         mutation,
+        root,
+        stateRoot: env.CLAWSWEEPER_STATE_DIR!,
+        env,
         ...(runtime.fetchImpl ? { fetchImpl: runtime.fetchImpl } : {}),
       });
     }
@@ -205,8 +221,12 @@ function planCanonicalRecordTuples(
     const contentHash = createHash("sha256")
       .update(JSON.stringify({ key, operations }))
       .digest("hex");
+    const deliveryPrefix =
+      env.CLAWSWEEPER_CANONICAL_PUBLICATION_KIND === "reconcile"
+        ? `record-reconcile:${repository}:${number}`
+        : `record-tuple:${deliveryPart(env.GITHUB_RUN_ID, "local")}:${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}`;
     return {
-      deliveryId: `record-tuple:${deliveryPart(env.GITHUB_RUN_ID, "local")}:${deliveryPart(env.GITHUB_RUN_ATTEMPT, "1")}:${contentHash}`,
+      deliveryId: `${deliveryPrefix}:${contentHash}`,
       key,
       operations,
     };
@@ -222,6 +242,226 @@ function planCanonicalRecordTuples(
     return [requestedPath];
   });
   return { mutations, remainingPaths: [...new Set(remainingPaths)] };
+}
+
+async function postCanonicalRecordTupleWithRecovery(options: {
+  queueUrl: string;
+  webhookSecret: string;
+  mutation: CanonicalRecordTupleMutation;
+  root: string;
+  stateRoot: string;
+  env: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  try {
+    await postCanonicalRecordTuple(options);
+    return;
+  } catch (error) {
+    if (
+      !(error instanceof CanonicalRecordTupleConflictError) ||
+      options.env.CLAWSWEEPER_CANONICAL_PUBLICATION_KIND !== "reconcile"
+    ) {
+      throw error;
+    }
+    const current = currentTupleFromConflict(error.current, options.mutation.key);
+    if (!current) throw error;
+    const [repoSlug, itemNumber] = options.mutation.key.split("/");
+    if (!repoSlug || !itemNumber) throw error;
+    const paths = recordTuplePaths({ repository: repoSlug, number: itemNumber });
+    const baseline = tupleFromRoot(options.stateRoot, paths);
+    const target = tupleFromMutation(options.mutation, paths);
+    const reconciliationReceipt = `record-reconcile:${repoSlug}:${itemNumber}:`;
+    const canReverify =
+      current.deliveryId?.startsWith(reconciliationReceipt) === true &&
+      sameCloseAuthorization(baseline, current.tuple) &&
+      sameCloseAuthorization(baseline, target);
+    if (canReverify) {
+      const operations = options.mutation.operations.map((operation) => {
+        const currentOperation = current.state.operations.find(
+          (candidate) => candidate.path === operation.path,
+        );
+        if (!currentOperation) throw new Error(`canonical CURRENT tuple omitted ${operation.path}`);
+        return { ...operation, expectedDigest: currentOperation.expectedDigest };
+      });
+      const contentHash = createHash("sha256")
+        .update(JSON.stringify({ key: options.mutation.key, operations }))
+        .digest("hex");
+      try {
+        await postCanonicalRecordTuple({
+          queueUrl: options.queueUrl,
+          webhookSecret: options.webhookSecret,
+          mutation: {
+            ...options.mutation,
+            deliveryId: `${reconciliationReceipt}${contentHash}`,
+            operations,
+          },
+          ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        });
+      } catch (retryError) {
+        if (!(retryError instanceof CanonicalRecordTupleConflictError)) throw retryError;
+        const retryCurrent = currentTupleFromConflict(retryError.current, options.mutation.key);
+        if (!retryCurrent) throw retryError;
+        deferCanonicalConflict(options, retryCurrent, itemNumber, reconciliationReceipt);
+        return;
+      }
+      console.warn(
+        `Reverified ${options.mutation.key} against canonical CURRENT reconciliation revision ${current.state.revision}`,
+      );
+      return;
+    }
+    deferCanonicalConflict(options, current, itemNumber, reconciliationReceipt);
+  }
+}
+
+function deferCanonicalConflict(
+  options: { root: string; env: NodeJS.ProcessEnv; mutation: CanonicalRecordTupleMutation },
+  current: {
+    state: CanonicalRecordTupleConflictState;
+    tuple: RecordTupleContents;
+    deliveryId: string | null;
+  },
+  itemNumber: string,
+  reconciliationReceipt: string,
+): void {
+  syncTupleToRoot(options.root, current.tuple);
+  recordReconciliationDeferral(options.env, {
+    itemNumber: Number(itemNumber),
+    key: options.mutation.key,
+    currentRevision: current.state.revision,
+    reason: current.deliveryId?.startsWith(reconciliationReceipt)
+      ? "canonical CURRENT close verdict or item source revision changed"
+      : "canonical CURRENT revision was not produced by authority reconciliation",
+  });
+  console.warn(
+    `Deferred ${options.mutation.key} to re-review after canonical CURRENT revision ${current.state.revision}`,
+  );
+}
+
+function currentTupleFromConflict(
+  state: CanonicalRecordTupleConflictState | null,
+  expectedKey: string,
+): {
+  state: CanonicalRecordTupleConflictState;
+  tuple: RecordTupleContents;
+  deliveryId: string | null;
+} | null {
+  if (!state || state.key !== expectedKey) return null;
+  const [repository, number] = expectedKey.split("/");
+  if (!repository || !number) return null;
+  const paths = recordTuplePaths({ repository, number });
+  const tuple = tupleFromMutation(
+    { deliveryId: "current", key: expectedKey, operations: state.operations },
+    paths,
+  );
+  validateRecordTuple(tuple, "canonical CURRENT tuple");
+  for (const operation of state.operations) {
+    const content = operation.contentBase64
+      ? Buffer.from(operation.contentBase64, "base64").toString("utf8")
+      : null;
+    if ((content === null ? null : sha256(content)) !== operation.expectedDigest) {
+      throw new Error(`canonical CURRENT digest does not match ${operation.path}`);
+    }
+  }
+  return { state, tuple, deliveryId: state.deliveryId };
+}
+
+function tupleFromMutation(
+  mutation: CanonicalRecordTupleMutation,
+  paths: ReturnType<typeof recordTuplePaths>,
+): RecordTupleContents {
+  const content = (path: string) => {
+    const operation = mutation.operations.find((candidate) => candidate.path === path);
+    if (!operation) throw new Error(`canonical tuple omitted ${path}`);
+    return operation.contentBase64 === undefined
+      ? null
+      : Buffer.from(operation.contentBase64, "base64").toString("utf8");
+  };
+  return {
+    paths,
+    item: content(paths.item),
+    closed: content(paths.closed),
+    plan: content(paths.plan),
+    packet: content(paths.packet),
+  };
+}
+
+function tupleFromRoot(
+  root: string,
+  paths: ReturnType<typeof recordTuplePaths>,
+): RecordTupleContents {
+  return {
+    paths,
+    item: readOptionalRecordFile(root, paths.item),
+    closed: readOptionalRecordFile(root, paths.closed),
+    plan: readOptionalRecordFile(root, paths.plan),
+    packet: readOptionalRecordFile(root, paths.packet),
+  };
+}
+
+function sameCloseAuthorization(left: RecordTupleContents, right: RecordTupleContents): boolean {
+  const leftPrimary = left.item ?? left.closed;
+  const rightPrimary = right.item ?? right.closed;
+  if (!leftPrimary || !rightPrimary) return false;
+  const leftFields = recordFrontMatter(leftPrimary);
+  const rightFields = recordFrontMatter(rightPrimary);
+  const sourceRevision = leftFields.get("item_source_revision");
+  return (
+    leftFields.get("decision") === "close" &&
+    rightFields.get("decision") === "close" &&
+    Boolean(sourceRevision && sourceRevision !== "unknown") &&
+    rightFields.get("item_source_revision") === sourceRevision &&
+    rightFields.get("close_reason") === leftFields.get("close_reason") &&
+    rightFields.get("decision_packet_sha256") === leftFields.get("decision_packet_sha256") &&
+    rightFields.get("decision_packet_path") === leftFields.get("decision_packet_path")
+  );
+}
+
+function recordFrontMatter(markdown: string): Map<string, string> {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  const end = normalized.startsWith("---\n") ? normalized.indexOf("\n---", 4) : -1;
+  const fields = new Map<string, string>();
+  if (end === -1) return fields;
+  for (const line of normalized.slice(4, end).split("\n")) {
+    const match = /^([a-z][a-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+    if (!match?.[1]) continue;
+    const value = match[2] ?? "";
+    fields.set(
+      match[1],
+      value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'")))
+        ? value.slice(1, -1)
+        : value,
+    );
+  }
+  return fields;
+}
+
+function syncTupleToRoot(root: string, tuple: RecordTupleContents): void {
+  for (const [path, content] of [
+    [tuple.paths.item, tuple.item],
+    [tuple.paths.closed, tuple.closed],
+    [tuple.paths.plan, tuple.plan],
+    [tuple.paths.packet, tuple.packet],
+  ] as const) {
+    const absolute = resolve(root, path);
+    if (content === null) {
+      if (existsSync(absolute)) unlinkSync(absolute);
+      continue;
+    }
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, content, "utf8");
+  }
+}
+
+function recordReconciliationDeferral(
+  env: NodeJS.ProcessEnv,
+  deferral: { itemNumber: number; key: string; currentRevision: number; reason: string },
+): void {
+  const path = env.CLAWSWEEPER_RECONCILE_DEFERRED_PATH;
+  if (!path) throw new Error("reconciliation deferral path is required for conflict recovery");
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(deferral)}\n`, "utf8");
 }
 
 function isRecordsPath(path: string): boolean {

--- a/src/repair/state-append-client.ts
+++ b/src/repair/state-append-client.ts
@@ -25,6 +25,23 @@ export type CanonicalRecordTupleMutation = {
   operations: CanonicalRecordTupleOperation[];
 };
 
+export type CanonicalRecordTupleConflictState = {
+  key: string;
+  revision: number;
+  deliveryId: string | null;
+  operations: CanonicalRecordTupleOperation[];
+};
+
+export class CanonicalRecordTupleConflictError extends Error {
+  readonly current: CanonicalRecordTupleConflictState | null;
+
+  constructor(current: CanonicalRecordTupleConflictState | null) {
+    super("POST /internal/state/records/tuples returned 409: canonical_record_tuple_conflict");
+    this.name = "CanonicalRecordTupleConflictError";
+    this.current = current;
+  }
+}
+
 export async function postStateAppend(options: {
   queueUrl: string;
   webhookSecret: string;
@@ -96,12 +113,18 @@ export async function postCanonicalRecordTuple(options: {
       },
     );
     const value = (await response.json().catch(() => null)) as unknown;
-    if (!response.ok || !isRecord(value) || value.ok !== true) {
-      const code = isRecord(value) ? String(value.error || "unknown_error") : "invalid_response";
+    const responseRecord = isRecord(value) ? value : null;
+    if (!response.ok || !responseRecord || responseRecord.ok !== true) {
+      const code = responseRecord
+        ? String(responseRecord.error || "unknown_error")
+        : "invalid_response";
+      if (response.status === 409 && code === "canonical_record_tuple_conflict") {
+        throw new CanonicalRecordTupleConflictError(parseConflictState(responseRecord?.current));
+      }
       throw new Error(`POST /internal/state/records/tuples returned ${response.status}: ${code}`);
     }
-    const revision = Number(value.revision);
-    const sequence = Number(value.sequence);
+    const revision = Number(responseRecord.revision);
+    const sequence = Number(responseRecord.sequence);
     if (
       !Number.isSafeInteger(revision) ||
       revision < 1 ||
@@ -110,10 +133,44 @@ export async function postCanonicalRecordTuple(options: {
     ) {
       throw new Error("POST /internal/state/records/tuples returned an invalid receipt");
     }
-    return { revision, sequence, deduped: value.deduped === true };
+    return { revision, sequence, deduped: responseRecord.deduped === true };
   } catch (error) {
+    if (error instanceof CanonicalRecordTupleConflictError) throw error;
     throw new Error(redactStateAppendSecrets(errorMessage(error)));
   }
+}
+
+function parseConflictState(value: unknown): CanonicalRecordTupleConflictState | null {
+  if (!isRecord(value)) return null;
+  const key = typeof value.key === "string" ? value.key : "";
+  const revision = Number(value.revision);
+  const deliveryId =
+    value.deliveryId === null || typeof value.deliveryId === "string"
+      ? value.deliveryId
+      : undefined;
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9_.-]{0,199}\/[1-9]\d*$/.test(key) ||
+    !Number.isSafeInteger(revision) ||
+    revision < 1 ||
+    deliveryId === undefined ||
+    !Array.isArray(value.operations) ||
+    value.operations.length !== 4
+  ) {
+    return null;
+  }
+  const operations: CanonicalRecordTupleOperation[] = [];
+  for (const raw of value.operations) {
+    if (!isRecord(raw) || typeof raw.path !== "string") return null;
+    const expectedDigest = raw.expectedDigest;
+    if (expectedDigest !== null && !/^[a-f0-9]{64}$/.test(String(expectedDigest))) return null;
+    if (raw.contentBase64 !== undefined && typeof raw.contentBase64 !== "string") return null;
+    operations.push({
+      path: raw.path,
+      expectedDigest: expectedDigest === null ? null : String(expectedDigest),
+      ...(typeof raw.contentBase64 === "string" ? { contentBase64: raw.contentBase64 } : {}),
+    });
+  }
+  return { key, revision, deliveryId, operations };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -65,6 +65,54 @@ test("event apply proof marks only live deterministic remain-open guards", () =>
   }
 });
 
+test("apply-decisions defers canonical reconciliation conflicts before live mutation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number: 321,
+        type: "pull_request",
+        title: "Reconciled PR",
+        url: "https://github.com/openclaw/openclaw/pull/321",
+        author: "reporter",
+        pull_head_sha: "head-sha",
+      }),
+      "utf8",
+    );
+
+    runApplyDecisionsForTest({
+      targetRepo: "openclaw/openclaw",
+      itemsDir,
+      closedDir,
+      plansDir,
+      reportPath,
+      extraArgs: ["--deferred-item-numbers", "321"],
+    });
+
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_changed_since_review",
+        reason: "canonical record changed during reconciliation; fresh review required",
+      },
+    ]);
+    assert.match(
+      readText(join(itemsDir, "321.md")),
+      /^action_taken: skipped_changed_since_review$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions rejects recorded PR review activity drift before mutations", () => {
   const reviewThreadComment = {
     id: 7003,

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -9121,12 +9121,44 @@ test("canonical tuple publication updates Worker authority and appends one proje
   assert.equal(drained.records[0].key, "openclaw-openclaw/42");
   assert.equal(drained.records[0].payload.operations.length, 4);
 
+  const reconciledItem = item.replace(
+    "reviewed_at: 2026-07-26T02:00:00.000Z",
+    "reviewed_at: 2026-07-26T02:00:00.000Z\nreconciled_at: 2026-07-27T02:00:00.000Z",
+  );
+  const reconciliation = structuredClone(mutation);
+  reconciliation.deliveryId = "record-reconcile:openclaw-openclaw:42:authority-fix";
+  reconciliation.operations[0]!.expectedDigest = createHash("sha256").update(item).digest("hex");
+  reconciliation.operations[0]!.contentBase64 = Buffer.from(reconciledItem).toString("base64");
+  const reconciled = await queue.fetch(stateAppendQueueRequest("/records/tuples", reconciliation));
+  assert.equal(reconciled.status, 202);
+  assert.equal((await reconciled.json()).revision, 2);
+
   const conflict = structuredClone(mutation);
   conflict.deliveryId = "record-tuple:run-2:42";
   conflict.operations[0]!.expectedDigest = "0".repeat(64);
   const rejected = await queue.fetch(stateAppendQueueRequest("/records/tuples", conflict));
   assert.equal(rejected.status, 409);
-  assert.equal((await rejected.json()).error, "canonical_record_tuple_conflict");
+  assert.deepEqual(await rejected.json(), {
+    error: "canonical_record_tuple_conflict",
+    current: {
+      key: "openclaw-openclaw/42",
+      revision: 2,
+      deliveryId: reconciliation.deliveryId,
+      operations: [
+        {
+          path: "records/openclaw-openclaw/items/42.md",
+          expectedDigest: createHash("sha256").update(reconciledItem).digest("hex"),
+          contentBase64: Buffer.from(reconciledItem).toString("base64"),
+        },
+        { path: "records/openclaw-openclaw/closed/42.md", expectedDigest: null },
+        { path: "records/openclaw-openclaw/plans/42.md", expectedDigest: null },
+        {
+          path: "records/openclaw-openclaw/decision-packets/42.json",
+          expectedDigest: null,
+        },
+      ],
+    },
+  });
 });
 
 test("canonical tuple failures return stable errors and sanitize server logs", async () => {

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -84,6 +84,107 @@ test("publish-main fails closed when canonical tuple publication is rejected", a
   assert.equal(gitPublishes.length, 0);
 });
 
+test("publish-main re-verifies reconciliation conflicts against canonical CURRENT", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-current-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-current-state-"));
+  const baseline = closeRecord("source-revision", "baseline");
+  const target = closeRecord("source-revision", "local reconciliation");
+  const current = closeRecord("source-revision", "authority reconciliation");
+  writeText(stateRoot, tupleItemPath, baseline);
+  writeText(root, tupleItemPath, target);
+  const posted: Array<Record<string, unknown>> = [];
+  const deferredPath = path.join(root, ".artifacts/deferred.jsonl");
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      { message: "chore: persist sweep reconciliation", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({
+          CLAWSWEEPER_STATE_DIR: stateRoot,
+          CLAWSWEEPER_CANONICAL_PUBLICATION_KIND: "reconcile",
+          CLAWSWEEPER_RECONCILE_DEFERRED_PATH: deferredPath,
+        }),
+        fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+          const mutation = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+          posted.push(mutation);
+          if (posted.length === 1) {
+            return conflictResponse(current, "record-reconcile:openclaw-openclaw:42:authority");
+          }
+          const operations = mutation.operations as Array<Record<string, unknown>>;
+          assert.equal(
+            operations[0]?.expectedDigest,
+            createHash("sha256").update(current).digest("hex"),
+          );
+          return Response.json(
+            { ok: true, accepted: true, deduped: false, revision: 3, sequence: 12 },
+            { status: 202 },
+          );
+        }) as typeof fetch,
+        publishGit: () => {
+          throw new Error("git publication must not run");
+        },
+      },
+    ),
+    "appended",
+  );
+  assert.equal(posted.length, 2);
+  assert.match(String(posted[0]?.deliveryId), /^record-reconcile:openclaw-openclaw:42:/);
+  assert.match(String(posted[1]?.deliveryId), /^record-reconcile:openclaw-openclaw:42:/);
+  assert.equal(fs.existsSync(deferredPath), false);
+  assert.equal(fs.readFileSync(path.join(root, tupleItemPath), "utf8"), target);
+});
+
+test("publish-main defers reconciliation conflicts when CURRENT changed source revision", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-defer-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-defer-state-"));
+  const baseline = closeRecord("old-source-revision", "baseline");
+  const target = closeRecord("old-source-revision", "local reconciliation");
+  const current = closeRecord("new-source-revision", "new review");
+  writeText(stateRoot, tupleItemPath, baseline);
+  writeText(root, tupleItemPath, target);
+  const deferredPath = path.join(root, ".artifacts/deferred.jsonl");
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      { message: "chore: persist sweep reconciliation", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({
+          CLAWSWEEPER_STATE_DIR: stateRoot,
+          CLAWSWEEPER_CANONICAL_PUBLICATION_KIND: "reconcile",
+          CLAWSWEEPER_RECONCILE_DEFERRED_PATH: deferredPath,
+        }),
+        fetchImpl: (async () =>
+          conflictResponse(
+            current,
+            "record-reconcile:openclaw-openclaw:42:new-review",
+          )) as typeof fetch,
+        publishGit: () => {
+          throw new Error("git publication must not run");
+        },
+      },
+    ),
+    "appended",
+  );
+  assert.equal(fs.readFileSync(path.join(root, tupleItemPath), "utf8"), current);
+  assert.deepEqual(
+    fs
+      .readFileSync(deferredPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)),
+    [
+      {
+        itemNumber: 42,
+        key: "openclaw-openclaw/42",
+        currentRevision: 2,
+        reason: "canonical CURRENT close verdict or item source revision changed",
+      },
+    ],
+  );
+});
+
 test("publish-main appends sweep status instead of invoking the git publisher", async () => {
   const root = statusFixture();
   const gitPublishes: GitPublishOptions[] = [];
@@ -419,6 +520,48 @@ function routerLedger(): Record<string, unknown> {
 
 function recordMarkdown(reviewedAt: string, body: string): string {
   return `---\nrepo: openclaw/openclaw\nnumber: 42\nreviewed_at: ${reviewedAt}\n---\n\n${body}\n`;
+}
+
+function closeRecord(sourceRevision: string, body: string): string {
+  return [
+    "---",
+    "repo: openclaw/openclaw",
+    "number: 42",
+    "kind: pull_request",
+    "decision: close",
+    "close_reason: duplicate_or_superseded",
+    `item_source_revision: ${sourceRevision}`,
+    "decision_packet_sha256: none",
+    "decision_packet_path: none",
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+function conflictResponse(current: string, deliveryId: string): Response {
+  return Response.json(
+    {
+      error: "canonical_record_tuple_conflict",
+      current: {
+        key: "openclaw-openclaw/42",
+        revision: 2,
+        deliveryId,
+        operations: [
+          {
+            path: tupleItemPath,
+            expectedDigest: createHash("sha256").update(current).digest("hex"),
+            contentBase64: Buffer.from(current).toString("base64"),
+          },
+          { path: `${tupleRoot}/closed/42.md`, expectedDigest: null },
+          { path: `${tupleRoot}/plans/42.md`, expectedDigest: null },
+          { path: `${tupleRoot}/decision-packets/42.json`, expectedDigest: null },
+        ],
+      },
+    },
+    { status: 409 },
+  );
 }
 
 function appendEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1201,6 +1201,7 @@ test("apply workflow isolates proof Codex and limits mutation Codex to model-gui
   const applyJob = workflow.slice(applyJobStart);
   const applyCondition = applyJob.match(/^\s+if: (.+)$/m)?.[1] ?? "";
   const proofGenerationStart = proofJob.indexOf("- name: Generate bound close coverage proofs");
+  const proofManifestStart = proofJob.indexOf("- name: Create bound close coverage proof manifest");
   const primaryProofResultStart = proofJob.indexOf("- name: Export primary apply proof result");
   const proofFinalizerStart = proofJob.indexOf("- name: Finalize apply proof action ledger");
 
@@ -1219,7 +1220,8 @@ test("apply workflow isolates proof Codex and limits mutation Codex to model-gui
   assert.match(proofJob, /--dry-run/);
   assert.match(proofJob, /--codex-model internal/);
   assert.match(proofJob, /--codex-reasoning-effort high/);
-  assert.match(proofJob, /\*\.proof\.json/);
+  assert.match(proofJob, /write_coverage_proof_manifest/);
+  assert.match(proofJob, /pr-close-coverage-proof\/\*/);
   assert.match(proofJob, /artifact_name: \$\{\{ steps\.proof-artifact\.outputs\.name \}\}/);
   assert.match(
     proofJob,
@@ -1244,11 +1246,12 @@ test("apply workflow isolates proof Codex and limits mutation Codex to model-gui
   assert.match(proofJob, /include-hidden-files: true/);
   assert.match(proofJob, /if-no-files-found: error/);
   assert.ok(proofGenerationStart >= 0);
-  assert.ok(primaryProofResultStart > proofGenerationStart);
+  assert.ok(proofManifestStart > proofGenerationStart);
+  assert.ok(primaryProofResultStart > proofManifestStart);
   assert.ok(proofFinalizerStart > primaryProofResultStart);
   assert.match(
     proofJob,
-    /id: primary-proof-result[\s\S]*if: \$\{\{ always\(\) && !cancelled\(\) && steps\.proof-select\.outcome == 'success' && \(steps\.proof-select\.outputs\.item_numbers == '' \|\| steps\.generate-apply-proofs\.outcome == 'success'\) \}\}[\s\S]*echo "ready=true" >> "\$GITHUB_OUTPUT"/,
+    /id: primary-proof-result[\s\S]*if: \$\{\{ always\(\) && !cancelled\(\) && steps\.proof-select\.outcome == 'success' && \(steps\.proof-select\.outputs\.item_numbers == '' \|\| steps\.generate-apply-proofs\.outcome == 'success'\) && steps\.proof-manifest\.outcome == 'success' \}\}[\s\S]*echo "ready=true" >> "\$GITHUB_OUTPUT"/,
   );
   assert.match(
     proofJob,
@@ -1285,6 +1288,13 @@ test("apply workflow isolates proof Codex and limits mutation Codex to model-gui
   assert.match(applyJob, /Create state token/);
   assert.match(applyJob, /hydrate-state-blobs: "false"/);
   assert.match(applyJob, /actions\/download-artifact@v8/);
+  assert.doesNotMatch(
+    applyJob.slice(
+      applyJob.indexOf("uses: actions/download-artifact@v8"),
+      applyJob.indexOf("uses: actions/download-artifact@v8") + 300,
+    ),
+    /continue-on-error/,
+  );
   assert.match(applyJob, /name: \$\{\{ needs\.apply-proof\.outputs\.artifact_name \}\}/);
   assert.doesNotMatch(applyJob, /action-ledger-proof/);
   assert.match(applyJob, /validate_coverage_proof_tree .* 8 262144 2097152/);
@@ -1370,6 +1380,30 @@ test("reconcile publication expands only exact changed record tuples", () => {
   assert.equal(emptyOutput.trim(), "Reconcile changed no durable record tuples.");
 });
 
+test("reconcile publication batches large corrected tuple sets below exec argument limits", () => {
+  const changedRecordFiles = Array.from({ length: 128 }, (_, index) => `${index + 1}.md`);
+  const reconcileJson = JSON.stringify({ changedItemNumbers: [], changedRecordFiles });
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'publish_changes_with_strategy() { printf "call=%s kind=%s deferred=%s\\n" "$#" "$CLAWSWEEPER_CANONICAL_PUBLICATION_KIND" "$CLAWSWEEPER_RECONCILE_DEFERRED_PATH"; }',
+        'TARGET_REPO="openclaw/openclaw"',
+        'publish_reconciled_records "persist reconciliation" "$RECONCILE_JSON"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8", env: { ...process.env, RECONCILE_JSON: reconcileJson } },
+  );
+
+  assert.deepEqual(output.trim().split("\n"), [
+    "call=202 kind=reconcile deferred=.artifacts/apply-reconcile-deferred.jsonl",
+    "call=202 kind=reconcile deferred=.artifacts/apply-reconcile-deferred.jsonl",
+    "call=114 kind=reconcile deferred=.artifacts/apply-reconcile-deferred.jsonl",
+  ]);
+});
+
 test("apply checkpoints split record tuples from auxiliary state", () => {
   const output = execFileSync(
     "bash",
@@ -1422,15 +1456,30 @@ test("apply workflow rejects malformed or oversized coverage proof artifact tree
       ],
       { encoding: "utf8", env: { ...process.env, PROOF_DIR: root } },
     );
+  const writeManifest = (selectedItems = "10,30") =>
+    execFileSync(
+      "bash",
+      [
+        "-lc",
+        'source scripts/apply-workflow-helpers.sh\nwrite_coverage_proof_manifest "$PROOF_DIR" openclaw/openclaw "$SELECTED_ITEMS"',
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PROOF_DIR: root, SELECTED_ITEMS: selectedItems },
+      },
+    );
 
   try {
     writeFileSync(join(root, "10-20.proof.json"), "{}\n");
     writeFileSync(join(root, "30-40.proof.json"), "{}\n");
+    writeManifest();
     assert.equal(validate(), "");
 
     writeFileSync(join(root, "50-60.proof.json"), "{}\n");
+    writeManifest("10,30,50");
     assert.throws(() => validate(), /maximum is 2/);
     rmSync(join(root, "50-60.proof.json"));
+    writeManifest();
 
     writeFileSync(join(root, "unexpected.json"), "{}\n");
     assert.throws(() => validate(3), /Unexpected coverage proof filename/);
@@ -1442,6 +1491,32 @@ test("apply workflow rejects malformed or oversized coverage proof artifact tree
 
     writeFileSync(join(root, "10-20.proof.json"), "x".repeat(65));
     assert.throws(() => validate(), /exceeds 64 bytes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("coverage proof manifest preserves an empty reduced-hydration artifact", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "source scripts/apply-workflow-helpers.sh",
+          'write_coverage_proof_manifest "$PROOF_DIR" openclaw/openclaw "107006,109946"',
+          'validate_coverage_proof_tree "$PROOF_DIR" 8 262144 2097152',
+        ].join("\n"),
+      ],
+      { encoding: "utf8", env: { ...process.env, PROOF_DIR: root } },
+    );
+    assert.deepEqual(JSON.parse(readFileSync(join(root, "manifest.json"), "utf8")), {
+      schemaVersion: 1,
+      targetRepo: "openclaw/openclaw",
+      selectedItems: [107006, 109946],
+      proofCount: 0,
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- publish apply reconciliation tuples in bounded 50-item batches so large authority repairs cannot overflow the runner's exec argument limit
- expose authenticated canonical CURRENT tuple state and reconciliation receipt provenance on compare-and-swap conflicts, then retry only when the close verdict, close reason, item source revision, and packet binding are unchanged; otherwise defer the item to fresh review
- always upload a validated coverage-proof manifest, including when selected proof candidates drift and produce zero proof files, while retaining `hydrate-state-blobs: false`

## Confirmed root cause

Run https://github.com/openclaw/clawsweeper/actions/runs/30412343807 did not fail on a digest mismatch. `digest-mismatch: error` was the configured `actions/download-artifact@v8` integrity policy printed in the step inputs. The hard failure came later: reconciliation expanded roughly 1,700 corrected record tuples into one `pnpm` invocation and Node failed to spawn it with `E2BIG` before any canonical tuple request reached the Worker.

The missing `apply-coverage-proofs-30412343807-1` artifact was independent. The proof lane selected https://github.com/openclaw/openclaw/pull/107006 and https://github.com/openclaw/openclaw/pull/109946, but the dry run skipped both (`kept_open` and `source_changed`), so no `*.proof.json` existed. `if-no-files-found: ignore` silently produced no artifact, the apply download was hidden by `continue-on-error`, and the empty-tree validator accepted the missing transfer.

## Safety boundary

Ordinary canonical conflicts still fail closed. Reconciliation recovery requires a CURRENT tuple whose retained receipt is specifically `record-reconcile:*`; the old, target, and CURRENT primaries must all preserve the same close authorization and non-unknown `item_source_revision`. A second race or any verdict/source/packet change refreshes the local tuple and records `skipped_changed_since_review` so no close mutation runs from stale authority.

## Proof

- `mise exec node@24 -- node --test test/repair/publish-main.test.ts test/sweep-workflow.test.ts test/apply-live-state.test.ts test/dashboard-worker.test.ts` — 351 passed
- `mise exec node@24 -- npx -y pnpm@11.10.0 run build:all` — passed
- `mise exec node@24 -- npx -y pnpm@11.10.0 run lint` — passed
- `mise exec node@24 -- npx -y pnpm@11.10.0 run format:check` — passed
- `mise exec node@24 -- npx -y pnpm@11.10.0 run check` — changed/static/build/lint coverage passed; the full macOS baseline retained five unrelated Linux Landlock `capset` failures and one unrelated `/var` versus `/private/var` assertion, matching the known failures reported in https://github.com/openclaw/clawsweeper/pull/920
- `~/.claude/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings (`overall: patch is correct`, 0.94)
