### PR TITLE
fix: wire canonical apply reconciliation

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4818,6 +4818,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           set -euo pipefail

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -58,6 +58,59 @@ test("publish-main appends changed record tuples canonically and never invokes g
   ]);
 });
 
+test("publish-main canonically moves reconciled records from items to closed", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-state-"));
+  const record = closeRecord("source-revision", "closed directly on GitHub");
+  const tupleClosedPath = `${tupleRoot}/closed/42.md`;
+  writeText(stateRoot, tupleItemPath, record);
+  writeText(root, tupleClosedPath, record);
+  const gitPublishes: GitPublishOptions[] = [];
+  let posted: Record<string, unknown> | undefined;
+
+  const result = await publishMainWithStateAppend(
+    {
+      message: "chore: persist sweep reconciliation",
+      paths: [tupleItemPath, tupleClosedPath],
+      rebaseStrategy: "reconcile-records",
+    },
+    {
+      root,
+      env: appendEnv({
+        CLAWSWEEPER_STATE_DIR: stateRoot,
+        CLAWSWEEPER_CANONICAL_PUBLICATION_KIND: "reconcile",
+      }),
+      fetchImpl: (async (input: string | URL | Request, init?: RequestInit) => {
+        assert.equal(input.toString(), "https://queue.test/internal/state/records/tuples");
+        posted = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+        return Response.json(
+          { ok: true, accepted: true, deduped: false, revision: 8, sequence: 12 },
+          { status: 202 },
+        );
+      }) as typeof fetch,
+      publishGit: capturePublishes(gitPublishes),
+    },
+  );
+
+  assert.equal(result, "appended");
+  assert.equal(gitPublishes.length, 0);
+  assert.equal(posted?.key, "openclaw-openclaw/42");
+  assert.match(String(posted?.deliveryId), /^record-reconcile:openclaw-openclaw:42:[a-f0-9]{64}$/);
+  assert.deepEqual(posted?.operations, [
+    {
+      path: tupleItemPath,
+      expectedDigest: createHash("sha256").update(record).digest("hex"),
+    },
+    {
+      path: tupleClosedPath,
+      expectedDigest: null,
+      contentBase64: Buffer.from(record).toString("base64"),
+    },
+    { path: `${tupleRoot}/plans/42.md`, expectedDigest: null },
+    { path: `${tupleRoot}/decision-packets/42.json`, expectedDigest: null },
+  ]);
+});
+
 test("publish-main fails closed when canonical tuple publication is rejected", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-source-"));
   const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-record-state-"));

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -330,6 +330,21 @@ test("trusted generated-state mutation steps receive a step-scoped coordinator c
   );
 });
 
+test("apply preselect reconciliation receives canonical record publication inputs", () => {
+  const sweep = workflows().find(({ file }) => file === ".github/workflows/sweep.yml")?.workflow;
+  const job = sweep?.jobs?.["apply-existing"];
+  const step = job?.steps?.find(
+    (candidate) => candidate.name === "Reconcile before apply preselect",
+  );
+
+  assert.ok(job, "apply-existing job");
+  assert.ok(step, "apply preselect reconciliation step");
+  assert.equal(job.env?.CLAWSWEEPER_STATE_APPEND_ENABLED, "1");
+  assert.equal(step.env?.CLAWSWEEPER_WEBHOOK_SECRET, "${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}");
+  assert.equal(step.env?.QUEUE_URL, coordinatorUrl);
+  assert.match(step.run ?? "", /persist_reconciliation/);
+});
+
 test("every immutable action-event publisher uses the state append window", () => {
   const publishers: string[] = [];
   for (const { file, workflow } of workflows()) {


### PR DESCRIPTION
## Summary

- pass the canonical state queue URL into the apply lane's preselect reconciliation step
- preserve the fail-closed canonical tuple guard added in #879
- cover the workflow contract and an `items/` to `closed/` reconciliation through the canonical tuple endpoint

## Root cause

Run https://github.com/openclaw/clawsweeper/actions/runs/30418846006 reached `publish-main` with `CLAWSWEEPER_STATE_APPEND_ENABLED=1` and the step-scoped webhook secret, but without `QUEUE_URL`. When reconciliation detected the 94 record tuple moves, the canonical publisher's required-input guard correctly stopped before posting to `/internal/state/records/tuples`.

The later apply/checkpoint step already carried all three inputs; the preselect step was the missed workflow call site.

## Proof

- `pnpm run build:repair && node --test test/state-writer-workflow.test.ts test/repair/publish-main.test.ts` (29 passed)
- `pnpm run check` (format check, builds, lint, and full coverage suite passed)
- `~/.claude/skills/autoreview/scripts/autoreview --mode local` (clean; no accepted/actionable findings)

No changelog entry: this is an internal workflow wiring fix.
