### PR TITLE
fix: preserve apply reconciliation tuple baselines

### DIFF
--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -231,9 +231,20 @@ publish_reconciled_records() {
 
 persist_reconciliation() {
   local reconcile_json
-  reconcile_json="$(pnpm run --silent reconcile -- "$@")"
+  local canonical_baseline_dir
+  mkdir -p .artifacts
+  canonical_baseline_dir="$(mktemp -d .artifacts/apply-reconcile-baseline.XXXXXX)"
+  if ! reconcile_json="$(pnpm run --silent reconcile -- "$@" --canonical-record-baseline-dir "$canonical_baseline_dir")"; then
+    rm -rf -- "$canonical_baseline_dir"
+    return 1
+  fi
   echo "$reconcile_json"
-  publish_reconciled_records "chore: persist sweep reconciliation" "$reconcile_json" || return 1
+  if ! CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR="$canonical_baseline_dir" \
+    publish_reconciled_records "chore: persist sweep reconciliation" "$reconcile_json"; then
+    rm -rf -- "$canonical_baseline_dir"
+    return 1
+  fi
+  rm -rf -- "$canonical_baseline_dir"
   load_reconciliation_deferred_items
 }
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4,6 +4,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
   closeSync,
+  copyFileSync,
   existsSync,
   fstatSync,
   mkdirSync,
@@ -31913,6 +31914,8 @@ function reconcileFolders(options: {
   closedDir: string;
   plansDir?: string;
   decisionPacketsDir?: string;
+  canonicalBaselineDir?: string;
+  repositorySlug?: string;
   maxPages?: number;
   dryRun?: boolean;
   fetchClosedAt?: boolean;
@@ -31922,6 +31925,48 @@ function reconcileFolders(options: {
   const dryRun = options.dryRun ?? false;
   const fetchClosedAt = options.fetchClosedAt ?? true;
   const plansDir = options.plansDir ?? defaultPlansDir();
+  if (options.canonicalBaselineDir && !options.repositorySlug) {
+    throw new Error("canonical reconciliation baseline requires a repository slug");
+  }
+  const capturedBaselines = new Set<number>();
+  const captureCanonicalBaseline = (number: number, file: string): void => {
+    if (
+      dryRun ||
+      !options.canonicalBaselineDir ||
+      !options.repositorySlug ||
+      capturedBaselines.has(number)
+    ) {
+      return;
+    }
+    const packetName = `${number}.json`;
+    const copies = [
+      { section: "items", name: file, source: join(options.itemsDir, file) },
+      { section: "closed", name: file, source: join(options.closedDir, file) },
+      { section: "plans", name: file, source: join(plansDir, file) },
+      ...(options.decisionPacketsDir
+        ? [
+            {
+              section: "decision-packets",
+              name: packetName,
+              source: join(options.decisionPacketsDir, packetName),
+            },
+          ]
+        : []),
+    ];
+    for (const copy of copies) {
+      if (!existsSync(copy.source)) continue;
+      const destination = join(
+        options.canonicalBaselineDir,
+        "records",
+        options.repositorySlug,
+        copy.section,
+        copy.name,
+      );
+      ensureDir(dirname(destination));
+      copyFileSync(copy.source, destination);
+    }
+    capturedBaselines.add(number);
+  };
   const syncReconciledDecisionPacket = (
     markdown: string,
     reportPath: string,
@@ -31963,7 +32008,6 @@ function reconcileFolders(options: {
     const planPath = workPlanPathForReport(reportPath, plansDir);
     let changed = existsSync(planPath);
     let nextMarkdown = markdown;
-    if (!dryRun && existsSync(planPath)) unlinkSync(planPath);
 
     const packetPath = options.decisionPacketsDir
       ? join(options.decisionPacketsDir, `${number}.json`)
@@ -31978,6 +32022,8 @@ function reconcileFolders(options: {
         hasPacketReference(packetReference) ||
         hasPacketReference(packetSha)),
     );
+    if (changed || shouldSyncPacket) captureCanonicalBaseline(number, file);
+    if (!dryRun && existsSync(planPath)) unlinkSync(planPath);
     if (shouldSyncPacket && packetPath) {
       if (dryRun) {
         changed = true;
@@ -32021,6 +32067,7 @@ function reconcileFolders(options: {
         );
       }
     }
+    captureCanonicalBaseline(number, file);
     const markdown = syncReconciledDecisionPacket(
       markReconciledState(sourceMarkdown, "closed", { closedAt }),
       destinationPath,
@@ -32044,6 +32091,7 @@ function reconcileFolders(options: {
       cleanAlreadyClosedSidecars(number, file, sourcePath, sourceMarkdown);
       continue;
     }
+    captureCanonicalBaseline(number, file);
     const destinationPath = join(options.itemsDir, file);
     if (existsSync(destinationPath)) {
       if (!dryRun) {
@@ -32086,7 +32134,7 @@ function reconcileFolders(options: {
 }
 
 function reconcileCommand(args: Args): void {
-  repoFromArgs(args);
+  const profile = repoFromArgs(args);
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
   const plansDir = resolve(stringArg(args.plans_dir, defaultPlansDir()));
@@ -32095,11 +32143,15 @@ function reconcileCommand(args: Args): void {
   const dryRun = boolArg(args.dry_run);
   const fetchClosedAt = !boolArg(args.skip_closed_at);
   const preserveItemNumbers = itemNumbersArg(args.item_numbers, args.item_number);
+  const canonicalBaselineDir = stringArg(args.canonical_record_baseline_dir, "").trim();
   const result = reconcileFolders({
     itemsDir,
     closedDir,
     plansDir,
     decisionPacketsDir,
+    ...(canonicalBaselineDir
+      ? { canonicalBaselineDir: resolve(canonicalBaselineDir), repositorySlug: profile.slug }
+      : {}),
     maxPages,
     dryRun,
     fetchClosedAt,

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -78,12 +78,9 @@ export async function publishMainWithStateAppend(
   const root = runtime.root ?? process.cwd();
   const queueUrl = env.QUEUE_URL ?? "";
   const webhookSecret = env.CLAWSWEEPER_WEBHOOK_SECRET ?? "";
-  const canonicalPlan = planCanonicalRecordTuples(
-    options.paths,
-    root,
-    env.CLAWSWEEPER_STATE_DIR,
-    env,
-  );
+  const canonicalBaselineRoot =
+    env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR?.trim() || env.CLAWSWEEPER_STATE_DIR;
+  const canonicalPlan = planCanonicalRecordTuples(options.paths, root, canonicalBaselineRoot, env);
   const canonicalItemCount = canonicalPlan.items.length;
   let canonicalResolvedCount = 0;
   let canonicalFailedCount = 0;
@@ -100,7 +97,7 @@ export async function publishMainWithStateAppend(
           webhookSecret,
           mutation: item.mutation,
           root,
-          stateRoot: env.CLAWSWEEPER_STATE_DIR!,
+          stateRoot: canonicalBaselineRoot!,
           env,
           ...(runtime.fetchImpl ? { fetchImpl: runtime.fetchImpl } : {}),
         });

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
 import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { isDeepStrictEqual } from "node:util";
 import { createContext, Script } from "node:vm";
@@ -26,6 +29,7 @@ import {
   TRIAGE_ROUTING_GROUPS,
   triageRoutingGroupsForLabels,
 } from "../dashboard/triage-routing-groups.ts";
+import { publishMainWithStateAppend } from "../dist/repair/publish-main.js";
 
 test("exact-review queue defaults to 64 of the 128 global workers", () => {
   assert.equal(exactReviewQueueCapacity({}), 64);
@@ -9159,6 +9163,133 @@ test("canonical tuple publication updates Worker authority and appends one proje
       ],
     },
   });
+});
+
+test("apply preselect moves a reconciliation-authored canonical tuple from items to closed", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-preselect-source-"));
+  const sparseStateRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "clawsweeper-apply-preselect-state-"),
+  );
+  const canonicalBaselineRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "clawsweeper-apply-preselect-baseline-"),
+  );
+  const itemId = 100078;
+  const tupleRoot = "records/openclaw-openclaw";
+  const itemPath = `${tupleRoot}/items/${itemId}.md`;
+  const closedPath = `${tupleRoot}/closed/${itemId}.md`;
+  const planPath = `${tupleRoot}/plans/${itemId}.md`;
+  const packetPath = `${tupleRoot}/decision-packets/${itemId}.json`;
+  const packet = (state: "open" | "closed", reportPath: string) =>
+    `${JSON.stringify(
+      {
+        version: 1,
+        generatedAt: "2026-07-27T18:00:00.000Z",
+        updatedAt: "2026-07-27T17:00:00.000Z",
+        subject: { repo: "openclaw/openclaw", kind: "issue", number: itemId, state },
+        source: { reportPath, reviewedAt: "2026-07-27T18:00:00.000Z" },
+      },
+      null,
+      2,
+    )}\n`;
+  const primary = (state: "open" | "closed", packetContent: string, reconciledAt: string) =>
+    [
+      "---",
+      `decision_packet_sha256: ${createHash("sha256").update(packetContent).digest("hex")}`,
+      `decision_packet_path: ${packetPath}`,
+      `number: ${itemId}`,
+      "repository: openclaw/openclaw",
+      `current_state: ${state}`,
+      "reviewed_at: 2026-07-27T18:00:00.000Z",
+      `reconciled_at: ${reconciledAt}`,
+      "---",
+      "",
+      "production-shaped canonical record",
+      "",
+    ].join("\n");
+
+  const openPacket = packet("open", itemPath);
+  const openPrimary = primary("open", openPacket, "2026-07-27T19:00:00.000Z");
+  const seeded = await queue.fetch(
+    stateAppendQueueRequest("/records/tuples", {
+      deliveryId: `record-reconcile:openclaw-openclaw:${itemId}:corrective-tuple`,
+      key: `openclaw-openclaw/${itemId}`,
+      operations: [
+        {
+          path: itemPath,
+          expectedDigest: null,
+          contentBase64: Buffer.from(openPrimary).toString("base64"),
+        },
+        { path: closedPath, expectedDigest: null },
+        { path: planPath, expectedDigest: null },
+        {
+          path: packetPath,
+          expectedDigest: null,
+          contentBase64: Buffer.from(openPacket).toString("base64"),
+        },
+      ],
+    }),
+  );
+  assert.equal(seeded.status, 202, await seeded.text());
+
+  const write = (base: string, relativePath: string, content: string) => {
+    const destination = path.join(base, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, content, "utf8");
+  };
+  // Worker hydration writes canonical records to the lane worktree. The state
+  // checkout is sparse and intentionally has no records/ baseline.
+  write(root, itemPath, openPrimary);
+  write(root, packetPath, openPacket);
+  write(canonicalBaselineRoot, itemPath, openPrimary);
+  write(canonicalBaselineRoot, packetPath, openPacket);
+
+  const closedPacket = packet("closed", closedPath);
+  const closedPrimary = primary("closed", closedPacket, "2026-07-28T04:33:00.000Z");
+  fs.unlinkSync(path.join(root, itemPath));
+  write(root, closedPath, closedPrimary);
+  write(root, packetPath, closedPacket);
+
+  const laneResponses: Array<{ status: number; body: Record<string, unknown> }> = [];
+  await publishMainWithStateAppend(
+    {
+      message: "chore: persist sweep reconciliation",
+      paths: [itemPath, closedPath, planPath, packetPath],
+      rebaseStrategy: "reconcile-records",
+    },
+    {
+      root,
+      env: {
+        CLAWSWEEPER_STATE_APPEND_ENABLED: "1",
+        CLAWSWEEPER_STATE_DIR: sparseStateRoot,
+        CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: canonicalBaselineRoot,
+        CLAWSWEEPER_CANONICAL_PUBLICATION_KIND: "reconcile",
+        QUEUE_URL: "https://queue.test",
+        CLAWSWEEPER_WEBHOOK_SECRET: "apply-preselect-test-secret",
+      },
+      fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+        const mutation = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        const response = await queue.fetch(stateAppendQueueRequest("/records/tuples", mutation));
+        const body = (await response.json()) as Record<string, unknown>;
+        laneResponses.push({ status: response.status, body });
+        return Response.json(body, { status: response.status });
+      }) as typeof fetch,
+      publishGit: () => {
+        throw new Error("canonical reconciliation must not use Git publication");
+      },
+    },
+  );
+
+  assert.equal(laneResponses[0]?.status, 202);
+  const closed = await queue.fetch(
+    new Request(`https://queue/records/openclaw-openclaw/closed/${itemId}`, { method: "GET" }),
+  );
+  assert.equal(
+    closed.status,
+    200,
+    "the legitimate items-to-closed move must reach canonical state",
+  );
+  assert.equal((await closed.json()).content, closedPrimary);
 });
 
 test("canonical tuple failures return stable errors and sanitize server logs", async () => {

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -13,6 +13,7 @@ test("reconcile reports every changed record tuple and cleans already-closed sid
   const closedDir = join(recordsDir, "closed");
   const plansDir = join(recordsDir, "plans");
   const packetsDir = join(recordsDir, "decision-packets");
+  const canonicalBaselineDir = join(root, "canonical-baseline");
   for (const dir of [itemsDir, closedDir, plansDir, packetsDir]) {
     mkdirSync(dir, { recursive: true });
   }
@@ -85,6 +86,8 @@ if (args[0] === "api" && args[1]?.includes("/issues?state=open")) {
           plansDir,
           "--decision-packets-dir",
           packetsDir,
+          "--canonical-record-baseline-dir",
+          canonicalBaselineDir,
           "--skip-closed-at",
         ],
         { encoding: "utf8" },
@@ -121,6 +124,25 @@ if (args[0] === "api" && args[1]?.includes("/issues?state=open")) {
     assert.match(readFileSync(join(closedDir, "5.md"), "utf8"), /^decision_packet_path: none$/m);
     assert.equal(existsSync(join(closedDir, "6.md")), true);
     assert.equal(existsSync(join(closedDir, "openclaw-openclaw-7.md")), true);
+    assert.equal(
+      readFileSync(join(canonicalBaselineDir, "records/openclaw-openclaw/items/1.md"), "utf8"),
+      report(1, "open"),
+    );
+    assert.equal(
+      readFileSync(join(canonicalBaselineDir, "records/openclaw-openclaw/plans/1.md"), "utf8"),
+      "stale plan for newly closed item\n",
+    );
+    assert.equal(
+      existsSync(join(canonicalBaselineDir, "records/openclaw-openclaw/closed/1.md")),
+      false,
+    );
+    assert.equal(
+      readFileSync(
+        join(canonicalBaselineDir, "records/openclaw-openclaw/decision-packets/5.json"),
+        "utf8",
+      ),
+      '{"subject":{"state":"open"}}\n',
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -188,6 +188,9 @@ test("publish-main fails closed when canonical tuple publication is rejected", a
 test("publish-main refetches CURRENT and retries a conflicted reconciliation move once", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-current-source-"));
   const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-current-state-"));
+  const sparseStateRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "clawsweeper-canonical-current-sparse-state-"),
+  );
   const baseline = closeRecord("old-source-revision", "baseline", "open");
   const target = closeRecord("old-source-revision", "baseline", "closed");
   const current = closeRecord("new-source-revision", "event-driven review", "open");
@@ -204,7 +207,8 @@ test("publish-main refetches CURRENT and retries a conflicted reconciliation mov
       {
         root,
         env: appendEnv({
-          CLAWSWEEPER_STATE_DIR: stateRoot,
+          CLAWSWEEPER_STATE_DIR: sparseStateRoot,
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: stateRoot,
           CLAWSWEEPER_CANONICAL_PUBLICATION_KIND: "reconcile",
           CLAWSWEEPER_RECONCILE_DEFERRED_PATH: deferredPath,
         }),

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -1373,6 +1374,40 @@ test("reconcile publication expands only exact changed record tuples", () => {
     { encoding: "utf8" },
   );
   assert.equal(emptyOutput.trim(), "Reconcile changed no durable record tuples.");
+});
+
+test("persist reconciliation publishes against its exact captured canonical baseline", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        "pnpm() {",
+        "  local previous='' baseline='' argument",
+        '  for argument in "$@"; do',
+        '    if [ "$previous" = "--canonical-record-baseline-dir" ]; then baseline="$argument"; fi',
+        '    previous="$argument"',
+        "  done",
+        '  test -n "$baseline"',
+        '  mkdir -p "$baseline/records/openclaw-openclaw/items"',
+        '  printf "before\\n" > "$baseline/records/openclaw-openclaw/items/42.md"',
+        '  printf \'{"changedItemNumbers":[42],"changedRecordFiles":["42.md"]}\\n\'',
+        "}",
+        "publish_reconciled_records() {",
+        '  test -f "$CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR/records/openclaw-openclaw/items/42.md"',
+        '  printf "baseline=%s\\n" "$CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR"',
+        "}",
+        "load_reconciliation_deferred_items() { :; }",
+        'TARGET_REPO="openclaw/openclaw"',
+        'persist_reconciliation --target-repo "$TARGET_REPO"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  const baseline = /^baseline=(.+)$/m.exec(output)?.[1];
+  assert.ok(baseline);
+  assert.equal(existsSync(baseline), false);
 });
 
 test("reconcile publication batches large corrected tuple sets below exec argument limits", () => {


### PR DESCRIPTION
## Summary

- capture the exact pre-mutation canonical tuple for every record reconciliation change
- publish reconciliation moves against that captured baseline instead of the sparse state checkout
- keep CURRENT-based single-retry conflict handling and per-item failure isolation intact

## Root cause

Apply run https://github.com/openclaw/clawsweeper/actions/runs/30422286379 hydrated Worker-owned records into the ClawSweeper worktree, while `CLAWSWEEPER_STATE_DIR` correctly remained a sparse checkout with no `records/` tree. `publish-main` nevertheless used that sparse checkout as the compare-and-swap baseline.

For an open record such as `openclaw-openclaw/100078`, the preselect lane therefore sent `expectedDigest: null` for the live `items/100078.md` and `decision-packets/100078.json` rows. The Durable Object correctly rejected the `items` operation with `canonical_record_tuple_conflict`. #928's CURRENT recovery could not prove the move because its local baseline location was also null, so the legitimate items-to-closed transition was treated as obsolete rather than published.

The endpoint fences are unchanged. Reconciliation now snapshots only the four-section tuples it actually mutates, passes that exact snapshot through a step-scoped temporary directory, and deletes it after publication. A genuinely concurrent canonical writer still trips the digest fence and goes through the existing CURRENT-based single retry.

## Proof

- in-process real-handler reproduction in `test/dashboard-worker.test.ts`: before the fix the lane received 409 instead of 202; after the fix the canonical row moves from items to closed
- exact reconciliation snapshot coverage in `test/reconcile.test.ts`
- CURRENT retry and poison-item sibling isolation in `test/repair/publish-main.test.ts`
- shell baseline handoff and batching coverage in `test/sweep-workflow.test.ts`
- all scoped tests, builds, linters, and format checks pass
- `~/.claude/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings

`pnpm run check` reaches the full coverage suite but has six unrelated macOS baseline failures: five Linux Landlock fixtures cannot resolve `capset` from macOS libc, and one temporary-path assertion compares `/var/...` with macOS's `/private/var/...` resolution.

## Deployment

No Worker redeploy is required. The Durable Object endpoint is unchanged; merging updates the apply workflow's checked-out lane code for the next run.
