### PR TITLE
fix: capture canonical tuple baselines

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3427,6 +3427,7 @@ jobs:
         id: apply-review-artifacts
         if: ${{ always() && !cancelled() && steps.sync-review-artifacts.outcome == 'success' }}
         env:
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: .artifacts/review-canonical-baseline
           GH_TOKEN: ${{ github.token }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
           EXPECTED_METRIC_COUNT: ${{ needs.plan.outputs.planned_shards }}
@@ -3509,6 +3510,7 @@ jobs:
         id: commit-review-records
         if: ${{ always() && !cancelled() && steps.apply-review-artifacts.outputs.artifacts_applied == 'true' }}
         env:
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: .artifacts/review-canonical-baseline
           CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
@@ -3522,7 +3524,10 @@ jobs:
           if [ "$HOT_INTAKE" = "true" ] && [ -z "$EXACT_ITEM" ]; then
             echo "Skipping full reconcile for broad hot-intake publish."
           else
-            pnpm run reconcile -- --target-repo "$TARGET_REPO" --skip-closed-at
+            pnpm run reconcile -- \
+              --target-repo "$TARGET_REPO" \
+              --skip-closed-at \
+              --canonical-record-baseline-dir "$CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR"
           fi
           pnpm run repair:publish-main -- \
             --message "chore: update sweep records" \
@@ -3732,6 +3737,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
+          source scripts/apply-workflow-helpers.sh
+          begin_canonical_record_mutation
           target_slug="$TARGET_REPO"
           target_slug="${target_slug//\//-}"
           item_numbers="$(pnpm run --silent workflow -- artifact-item-numbers --artifact-dir artifacts)"
@@ -4283,12 +4290,17 @@ jobs:
 
       - name: Refresh Audit Health
         env:
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: .artifacts/audit-canonical-baseline
           GH_TOKEN: ${{ steps.target-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           set -euo pipefail
           git pull --rebase --autostash
-          reconcile_json="$(pnpm run --silent reconcile -- --target-repo "$TARGET_REPO" --max-pages 250 --skip-closed-at)"
+          reconcile_json="$(pnpm run --silent reconcile -- \
+            --target-repo "$TARGET_REPO" \
+            --max-pages 250 \
+            --skip-closed-at \
+            --canonical-record-baseline-dir "$CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR")"
           echo "$reconcile_json"
           moved_to_closed="$(jq -r '.movedToClosed' <<<"$reconcile_json")"
           moved_to_items="$(jq -r '.movedToItems' <<<"$reconcile_json")"
@@ -4311,6 +4323,7 @@ jobs:
 
       - name: Commit Audit Health
         env:
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: .artifacts/audit-canonical-baseline
           CLAWSWEEPER_STATE_APPEND_ENABLED: "1"
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
@@ -5001,10 +5014,7 @@ jobs:
             --state "Apply in progress" \
             --detail "Starting apply/comment-sync run for up to $limit fresh $apply_kind closes. Close reasons: $apply_close_reasons.$candidate_quality_detail Scan window: $close_processed_limit records ($adaptive_apply_scan_reason). Existing Codex automated review comments are updated in place when closing or when comment-only sync is stale by ${comment_sync_min_age_days} day(s); checkpoints commit every $checkpoint_size fresh closes; close delay is ${close_delay_ms}ms; sync-comments-only=$sync_comments_only; item numbers=${item_numbers:-all}." \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          if ! publish_changes "chore: mark sweep apply in progress" records results/sweep-status; then
-            echo "Best-effort apply start status update failed"
-            git restore results/sweep-status || true
-          fi
+          publish_status "chore: mark sweep apply in progress"
           closed_total=0
           continue_apply=false
           checkpoint=0
@@ -5012,6 +5022,7 @@ jobs:
             checkpoint=1
             echo "::group::Apply checkpoint $checkpoint"
             echo "Syncing durable review comments only for item numbers: ${item_numbers:-all}"
+            begin_canonical_record_mutation
             pnpm run apply-decisions -- \
               --target-repo "$TARGET_REPO" \
               --skip-dashboard \
@@ -5072,6 +5083,7 @@ jobs:
               cursor_trace_arg=(--cursor-trace "$cursor_trace_path")
             fi
             echo "::group::Apply checkpoint $checkpoint"
+            begin_canonical_record_mutation
             CLAWSWEEPER_APPLY_CHECKPOINT="$checkpoint" pnpm run apply-decisions -- \
               --target-repo "$TARGET_REPO" \
               --skip-dashboard \

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -168,10 +168,23 @@ publish_changes() {
 
 publish_status() {
   local message="$1"
-  if ! publish_changes "$message" results/sweep-status; then
+  local target_slug
+  local status_path
+  target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]')"
+  target_slug="${target_slug//\//-}"
+  status_path="results/sweep-status/${target_slug}.json"
+  if ! publish_changes "$message" "$status_path"; then
     echo "Best-effort status update failed: $message"
-    git restore results/sweep-status || true
+    if git ls-files --error-unmatch -- "$status_path" >/dev/null 2>&1; then
+      git restore -- "$status_path"
+    fi
   fi
+}
+
+begin_canonical_record_mutation() {
+  mkdir -p .artifacts
+  CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR="$(mktemp -d .artifacts/canonical-record-baseline.XXXXXX)"
+  export CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR
 }
 
 publish_reconciled_records() {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4,7 +4,6 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   chmodSync,
   closeSync,
-  copyFileSync,
   existsSync,
   fstatSync,
   mkdirSync,
@@ -144,6 +143,7 @@ import {
   MANUAL_ONLY_LABEL,
   PR_AUTO_CLOSE_EXEMPT_LABEL_NAMES,
 } from "./repair/exact-review-guard-labels.js";
+import { captureCanonicalRecordBaseline } from "./repair/canonical-record-baseline.js";
 import {
   buildOpenClawPrSurfaceStats,
   renderOpenClawPrSurfaceSummary,
@@ -1923,6 +1923,12 @@ const ISSUE_STALE_PROTECTION_LABEL = {
   description: "Exempts this issue from stale automation.",
 } as const;
 const PROTECTED_LABELS = new Set<string>(CLOSE_PROTECTED_LABEL_NAMES);
+const APPLY_PROTECTED_LABELS = new Set<string>([
+  ...CLOSE_PROTECTED_LABEL_NAMES,
+  "clawsweeper:needs-security-review",
+  "clawsweeper:needs-maintainer-review",
+  "clawsweeper:needs-product-decision",
+]);
 const ALLOWED_REASONS = new Set<CloseReason>([
   "implemented_on_main",
   "mostly_implemented_on_main",
@@ -4228,7 +4234,12 @@ export function isProtectedItem(item: Pick<Item, "labels">): boolean {
 }
 
 function applyBlockingProtectedLabels(labels: readonly string[], closeReason: unknown): string[] {
-  const blocked = protectedLabels(labels);
+  const blocked = labels
+    .map((label) => normalizeLabelName(label))
+    .filter(
+      (label, index, normalized) =>
+        APPLY_PROTECTED_LABELS.has(label) && normalized.indexOf(label) === index,
+    );
   if (!isVerifiedFixedCloseReason(closeReason)) return blocked;
   return blocked.filter((label) => label !== "maintainer");
 }
@@ -27362,7 +27373,7 @@ function applyDecisionsCommand(args: Args): void {
 }
 
 function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudget): void {
-  repoFromArgs(args);
+  const profile = repoFromArgs(args);
   const recordRoot = resolve(stringArg(args.record_root, ROOT));
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
@@ -27381,6 +27392,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   const closeDelayMs = numberArg(args.close_delay_ms, 2_000);
   const progressEvery = Math.max(1, numberArg(args.progress_every, 10));
   const dryRun = boolArg(args.dry_run);
+  const canonicalBaselineDir = stringArg(
+    args.canonical_record_baseline_dir,
+    process.env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR ?? "",
+  ).trim();
   const requirePrecomputedPrCloseCoverageProof = boolArg(
     args.require_precomputed_pr_close_coverage_proof,
   );
@@ -27469,6 +27484,27 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
         location,
         ...applyQueueSortFields(entry.markdown, syncCommentsOnly, applyKind),
       }));
+  const captureApplyCanonicalBaseline = (reportPath: string): void => {
+    if (dryRun || !canonicalBaselineDir) return;
+    const file = basename(reportPath);
+    const number = numberForMarkdownFile(file);
+    const packetName = `${number}.json`;
+    captureCanonicalRecordBaseline({
+      baselineRoot: canonicalBaselineDir,
+      repositorySlug: profile.slug,
+      itemNumber: number,
+      sources: [
+        { section: "items", name: file, path: join(itemsDir, file) },
+        { section: "closed", name: file, path: join(closedDir, file) },
+        { section: "plans", name: file, path: join(plansDir, file) },
+        {
+          section: "decision-packets",
+          name: packetName,
+          path: join(decisionPacketsDir, packetName),
+        },
+      ],
+    });
+  };
   const syncDecisionPacketMarkdown = (
     reportPath: string,
     nextMarkdown: string,
@@ -27486,6 +27522,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     nextMarkdown: string,
     subjectState: DecisionPacketSubjectState = "open",
   ): void => {
+    captureApplyCanonicalBaseline(reportPath);
     writeFileSync(
       reportPath,
       syncDecisionPacketMarkdown(reportPath, nextMarkdown, subjectState),
@@ -27752,6 +27789,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       counterpartRepo === repo && closedThisRun.has(pairCloseKey(repo, counterpartNumber));
     const archiveClosed = (nextMarkdown: string): void => {
       if (dryRun) return;
+      captureApplyCanonicalBaseline(path);
       ensureDir(closedDir);
       const closedPath = join(closedDir, file);
       const syncedMarkdown = syncDecisionPacketMarkdown(closedPath, nextMarkdown, "closed");
@@ -27831,7 +27869,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       const detail = error instanceof Error ? error.message : String(error);
       const reason = `invalid maintainer_decision: ${detail}`;
       markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
-      if (!dryRun) writeFileSync(path, markdown, "utf8");
+      if (!dryRun) {
+        captureApplyCanonicalBaseline(path);
+        writeFileSync(path, markdown, "utf8");
+      }
       results.push({ number, action: "kept_open", reason });
       processedCount += 1;
       maybeLogProgress(`skipped #${number}: ${reason}`);
@@ -27901,6 +27942,24 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       continue;
     }
     const { item, state } = liveItem;
+    if (
+      state === "open" &&
+      decision === "close" &&
+      closeReason &&
+      applyBlockingProtectedLabels(item.labels, closeReason).length === 0 &&
+      !prAutoCloseExemptDecisionReason(item, closeReason) &&
+      !isAutoCloseAllowed(repositoryProfileFor(repo), item.kind, closeReason)
+    ) {
+      if (
+        markApplySkipped(
+          "skipped_invalid_decision",
+          `${closeReason} is not allowed for ${repo} ${item.kind} apply policy`,
+        )
+      ) {
+        break;
+      }
+      continue;
+    }
     const previousLabels = [...item.labels];
     const reportLabelsBeforeApply = frontMatterStringArray(markdown, "labels");
     let currentContext: ItemContext | undefined;
@@ -31185,13 +31244,17 @@ function botProofCommand(args: Args): void {
 }
 
 function applyArtifactsCommand(args: Args): void {
-  repoFromArgs(args);
+  const profile = repoFromArgs(args);
   const artifactDir = resolve(stringArg(args.artifact_dir, "artifacts"));
   const recordRoot = resolve(stringArg(args.record_root, ROOT));
   const itemsDir = resolve(stringArg(args.items_dir, defaultItemsDir()));
   const closedDir = resolve(stringArg(args.closed_dir, defaultClosedDir()));
   const plansDir = resolve(stringArg(args.plans_dir, defaultPlansDir()));
   const decisionPacketsDir = decisionPacketsDirFromArgs(args, itemsDir, closedDir);
+  const canonicalBaselineDir = stringArg(
+    args.canonical_record_baseline_dir,
+    process.env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR ?? "",
+  ).trim();
   const skipReconcile = boolArg(args.skip_reconcile);
   const replayClosedArtifacts = boolArg(args.replay_closed_artifacts);
   const maxPages = numberArg(args.max_pages, 250);
@@ -31389,6 +31452,24 @@ function applyArtifactsCommand(args: Args): void {
           destination,
           mutation: false,
         };
+        if (canonicalBaselineDir) {
+          const packetName = `${number}.json`;
+          captureCanonicalRecordBaseline({
+            baselineRoot: canonicalBaselineDir,
+            repositorySlug: profile.slug,
+            itemNumber: number,
+            sources: [
+              { section: "items", name: destinationFile, path: join(itemsDir, destinationFile) },
+              { section: "closed", name: destinationFile, path: join(closedDir, destinationFile) },
+              { section: "plans", name: destinationFile, path: join(plansDir, destinationFile) },
+              {
+                section: "decision-packets",
+                name: packetName,
+                path: join(decisionPacketsDir, packetName),
+              },
+            ],
+          });
+        }
         const stalePath = join(destinationDir === itemsDir ? closedDir : itemsDir, destinationFile);
         if (existsSync(stalePath)) {
           unlinkSync(stalePath);
@@ -31429,7 +31510,14 @@ function applyArtifactsCommand(args: Args): void {
     console.error(
       `[apply-artifacts] applied=${appliedArtifacts} skipped_closed=${skippedClosedArtifacts}`,
     );
-    if (!skipReconcile) reconcileFolders({ itemsDir, closedDir, plansDir, decisionPacketsDir });
+    if (!skipReconcile)
+      reconcileFolders({
+        itemsDir,
+        closedDir,
+        plansDir,
+        decisionPacketsDir,
+        ...(canonicalBaselineDir ? { canonicalBaselineDir, repositorySlug: profile.slug } : {}),
+      });
     finishPublication();
   } catch (error) {
     const interruptedMutation = activePublication?.mutation ?? false;
@@ -31939,32 +32027,25 @@ function reconcileFolders(options: {
       return;
     }
     const packetName = `${number}.json`;
-    const copies = [
-      { section: "items", name: file, source: join(options.itemsDir, file) },
-      { section: "closed", name: file, source: join(options.closedDir, file) },
-      { section: "plans", name: file, source: join(plansDir, file) },
-      ...(options.decisionPacketsDir
-        ? [
-            {
-              section: "decision-packets",
-              name: packetName,
-              source: join(options.decisionPacketsDir, packetName),
-            },
-          ]
-        : []),
-    ];
-    for (const copy of copies) {
-      if (!existsSync(copy.source)) continue;
-      const destination = join(
-        options.canonicalBaselineDir,
-        "records",
-        options.repositorySlug,
-        copy.section,
-        copy.name,
-      );
-      ensureDir(dirname(destination));
-      copyFileSync(copy.source, destination);
-    }
+    captureCanonicalRecordBaseline({
+      baselineRoot: options.canonicalBaselineDir,
+      repositorySlug: options.repositorySlug,
+      itemNumber: number,
+      sources: [
+        { section: "items" as const, name: file, path: join(options.itemsDir, file) },
+        { section: "closed" as const, name: file, path: join(options.closedDir, file) },
+        { section: "plans" as const, name: file, path: join(plansDir, file) },
+        ...(options.decisionPacketsDir
+          ? [
+              {
+                section: "decision-packets" as const,
+                name: packetName,
+                path: join(options.decisionPacketsDir, packetName),
+              },
+            ]
+          : []),
+      ],
+    });
     capturedBaselines.add(number);
   };
   const syncReconciledDecisionPacket = (

--- a/src/repair/canonical-record-baseline.ts
+++ b/src/repair/canonical-record-baseline.ts
@@ -1,0 +1,81 @@
+import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const CAPTURE_DIRECTORY = ".clawsweeper-canonical-record-baselines";
+const REPOSITORY_SLUG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+const ITEM_NUMBER_PATTERN = /^[1-9]\d*$/;
+
+type CanonicalRecordBaselineSource = {
+  section: "items" | "closed" | "plans" | "decision-packets";
+  name: string;
+  path: string;
+};
+
+export function captureCanonicalRecordBaseline(options: {
+  baselineRoot: string;
+  repositorySlug: string;
+  itemNumber: number | string;
+  sources: readonly CanonicalRecordBaselineSource[];
+}): void {
+  const repositorySlug = validatedRepositorySlug(options.repositorySlug);
+  const itemNumber = validatedItemNumber(options.itemNumber);
+  const markerPath = join(
+    options.baselineRoot,
+    CAPTURE_DIRECTORY,
+    repositorySlug,
+    `${itemNumber}.json`,
+  );
+  if (existsSync(markerPath)) return;
+
+  for (const source of options.sources) {
+    if (!existsSync(source.path)) continue;
+    const destination = join(
+      options.baselineRoot,
+      "records",
+      repositorySlug,
+      source.section,
+      source.name,
+    );
+    mkdirSync(dirname(destination), { recursive: true });
+    copyFileSync(source.path, destination);
+  }
+  mkdirSync(dirname(markerPath), { recursive: true });
+  writeFileSync(
+    markerPath,
+    `${JSON.stringify({ schema_version: 1, repositorySlug, itemNumber })}\n`,
+  );
+}
+
+export function capturedCanonicalRecordBaselineKeys(baselineRoot: string): Set<string> {
+  const captureRoot = join(baselineRoot, CAPTURE_DIRECTORY);
+  const keys = new Set<string>();
+  if (!existsSync(captureRoot)) return keys;
+  for (const repositoryEntry of readdirSync(captureRoot, { withFileTypes: true })) {
+    if (!repositoryEntry.isDirectory() || !REPOSITORY_SLUG_PATTERN.test(repositoryEntry.name)) {
+      continue;
+    }
+    const repositoryRoot = join(captureRoot, repositoryEntry.name);
+    for (const itemEntry of readdirSync(repositoryRoot, { withFileTypes: true })) {
+      if (!itemEntry.isFile()) continue;
+      const match = /^([1-9]\d*)\.json$/.exec(itemEntry.name);
+      if (!match?.[1]) continue;
+      keys.add(`${repositoryEntry.name}/${match[1]}`);
+    }
+  }
+  return keys;
+}
+
+function validatedRepositorySlug(value: string): string {
+  if (!REPOSITORY_SLUG_PATTERN.test(value)) {
+    throw new Error(`invalid canonical baseline repository slug: ${value}`);
+  }
+  return value;
+}
+
+function validatedItemNumber(value: number | string): string {
+  const normalized = String(value);
+  if (!ITEM_NUMBER_PATTERN.test(normalized)) {
+    throw new Error(`invalid canonical baseline item number: ${normalized}`);
+  }
+  return normalized;
+}

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -16,6 +16,7 @@ import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { isActionEventPublishPath } from "../action-ledger-paths.js";
+import { capturedCanonicalRecordBaselineKeys } from "./canonical-record-baseline.js";
 import {
   publishMainCommit,
   type GitPublishOptions,
@@ -192,8 +193,33 @@ function planCanonicalRecordTuples(
     return { items: [], remainingPaths: [...requestedPaths] };
   }
   if (!stateRoot) throw new Error("record publication requires a hydrated state checkout");
-  const localFiles = collectRequestedRecordFiles(root, recordRequests);
-  const stateFiles = collectRequestedRecordFiles(stateRoot, recordRequests);
+  const explicitBaselineRoot = env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR?.trim();
+  const capturedKeys = explicitBaselineRoot
+    ? capturedCanonicalRecordBaselineKeys(explicitBaselineRoot)
+    : null;
+  if (capturedKeys) {
+    for (const requestedPath of recordRequests) {
+      const match = RECORD_TUPLE_PATH.exec(normalizedPath(requestedPath));
+      if (!match?.[1] || !match[3]) continue;
+      const key = `${match[1]}/${match[3]}`;
+      if (!capturedKeys.has(key)) {
+        throw new Error(`canonical tuple ${key} was not captured before mutation`);
+      }
+    }
+  }
+  const includeFile = (path: string): boolean => {
+    if (!capturedKeys) return true;
+    const match = RECORD_TUPLE_PATH.exec(path);
+    return Boolean(match?.[1] && match[3] && capturedKeys.has(`${match[1]}/${match[3]}`));
+  };
+  const localFiles = new Map(
+    [...collectRequestedRecordFiles(root, recordRequests)].filter(([path]) => includeFile(path)),
+  );
+  const stateFiles = new Map(
+    [...collectRequestedRecordFiles(stateRoot, recordRequests)].filter(([path]) =>
+      includeFile(path),
+    ),
+  );
   const changedPaths = new Set(
     [...new Set([...localFiles.keys(), ...stateFiles.keys()])].filter(
       (path) => localFiles.get(path) !== stateFiles.get(path),

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { guardedOpenApplyProofFields } from "../dist/clawsweeper.js";
+import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.js";
 import {
   implementedCloseReport,
@@ -565,8 +566,96 @@ process.exit(1);
   }
 });
 
+test("apply rejects a repo-policy-forbidden close class before comment sync", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const previousBaselineDir = process.env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR;
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const baselineDir = join(root, "canonical-baseline");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const original = implementedCloseReport({
+      action_taken: "proposed_close",
+      close_reason: "duplicate_or_superseded",
+    });
+    writeFileSync(join(itemsDir, "321.md"), original, "utf8");
+    process.env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR = baselineDir;
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Policy-forbidden duplicate",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+    body: "",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 0,
+    pull_request: null
+  }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only"],
+      });
+    });
+
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_invalid_decision",
+        reason:
+          "duplicate_or_superseded is not allowed for openclaw/clawsweeper issue apply policy",
+      },
+    ]);
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: skipped_invalid_decision$/m);
+    assert.equal(
+      readText(join(baselineDir, "records/openclaw-clawsweeper/items/321.md")),
+      original,
+    );
+    assert.deepEqual(
+      [...capturedCanonicalRecordBaselineKeys(baselineDir)],
+      ["openclaw-clawsweeper/321"],
+    );
+  } finally {
+    if (previousBaselineDir === undefined) {
+      delete process.env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR;
+    } else {
+      process.env.CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR = previousBaselineDir;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("event apply emits proof only while a captured protected-label guard remains live", () => {
-  for (const labels of [["security"], []]) {
+  for (const labels of [
+    ["security"],
+    ["clawsweeper:needs-security-review"],
+    ["clawsweeper:needs-maintainer-review"],
+    ["clawsweeper:needs-product-decision"],
+    [],
+  ]) {
     const root = mkdtempSync(tmpPrefix);
     try {
       const itemsDir = join(root, "items");
@@ -641,7 +730,7 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
               {
                 number: 321,
                 action: "skipped_protected_label",
-                reason: "protected label: security",
+                reason: `protected label: ${labels[0]}`,
                 guardedOpenStateVerified: true,
               },
             ]
@@ -861,9 +950,9 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
           : [
               {
                 number: 321,
-                action: "kept_open",
+                action: "skipped_invalid_decision",
                 reason:
-                  "no visible dated proof request (needs-proof label event or proof nudge) on the live PR",
+                  "stalled_unproven_pr is not allowed for openclaw/clawsweeper pull_request apply policy",
               },
             ],
       );

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -283,7 +283,7 @@ if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   }
 });
 
-test("apply-decisions writes decision packets for changed-since-review reports", () => {
+test("apply-decisions writes decision packets for protected close-guard reports", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -345,8 +345,8 @@ if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
     assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
       {
         number: 321,
-        action: "skipped_changed_since_review",
-        reason: "updated_at changed",
+        action: "skipped_protected_label",
+        reason: "protected label: clawsweeper:needs-product-decision",
       },
     ]);
     assert.equal(existsSync(join(root, "decision-packets", "321.json")), true);
@@ -444,13 +444,8 @@ if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
     assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
       {
         number: 321,
-        action: "review_comment_synced",
-        reason: "updated durable Codex review comment",
-      },
-      {
-        number: 321,
-        action: "kept_open",
-        reason: `maintainer decision required: ${maintainerDecision.question}`,
+        action: "skipped_protected_label",
+        reason: "protected label: clawsweeper:needs-product-decision",
       },
     ]);
   } finally {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -29,6 +29,7 @@ import {
   TRIAGE_ROUTING_GROUPS,
   triageRoutingGroupsForLabels,
 } from "../dashboard/triage-routing-groups.ts";
+import { captureCanonicalRecordBaseline } from "../dist/repair/canonical-record-baseline.js";
 import { publishMainWithStateAppend } from "../dist/repair/publish-main.js";
 
 test("exact-review queue defaults to 64 of the 128 global workers", () => {
@@ -9165,7 +9166,7 @@ test("canonical tuple publication updates Worker authority and appends one proje
   });
 });
 
-test("apply preselect moves a reconciliation-authored canonical tuple from items to closed", async () => {
+test("apply preselect and checkpoint publish captured canonical tuple baselines", async () => {
   const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-apply-preselect-source-"));
   const sparseStateRoot = fs.mkdtempSync(
@@ -9180,24 +9181,29 @@ test("apply preselect moves a reconciliation-authored canonical tuple from items
   const closedPath = `${tupleRoot}/closed/${itemId}.md`;
   const planPath = `${tupleRoot}/plans/${itemId}.md`;
   const packetPath = `${tupleRoot}/decision-packets/${itemId}.json`;
-  const packet = (state: "open" | "closed", reportPath: string) =>
+  const packet = (state: "open" | "closed", reportPath: string, number = itemId) =>
     `${JSON.stringify(
       {
         version: 1,
         generatedAt: "2026-07-27T18:00:00.000Z",
         updatedAt: "2026-07-27T17:00:00.000Z",
-        subject: { repo: "openclaw/openclaw", kind: "issue", number: itemId, state },
+        subject: { repo: "openclaw/openclaw", kind: "issue", number, state },
         source: { reportPath, reviewedAt: "2026-07-27T18:00:00.000Z" },
       },
       null,
       2,
     )}\n`;
-  const primary = (state: "open" | "closed", packetContent: string, reconciledAt: string) =>
+  const primary = (
+    state: "open" | "closed",
+    packetContent: string,
+    reconciledAt: string,
+    number = itemId,
+  ) =>
     [
       "---",
       `decision_packet_sha256: ${createHash("sha256").update(packetContent).digest("hex")}`,
-      `decision_packet_path: ${packetPath}`,
-      `number: ${itemId}`,
+      `decision_packet_path: ${tupleRoot}/decision-packets/${number}.json`,
+      `number: ${number}`,
       "repository: openclaw/openclaw",
       `current_state: ${state}`,
       "reviewed_at: 2026-07-27T18:00:00.000Z",
@@ -9241,8 +9247,21 @@ test("apply preselect moves a reconciliation-authored canonical tuple from items
   // checkout is sparse and intentionally has no records/ baseline.
   write(root, itemPath, openPrimary);
   write(root, packetPath, openPacket);
-  write(canonicalBaselineRoot, itemPath, openPrimary);
-  write(canonicalBaselineRoot, packetPath, openPacket);
+  captureCanonicalRecordBaseline({
+    baselineRoot: canonicalBaselineRoot,
+    repositorySlug: "openclaw-openclaw",
+    itemNumber: itemId,
+    sources: [
+      { section: "items", name: `${itemId}.md`, path: path.join(root, itemPath) },
+      { section: "closed", name: `${itemId}.md`, path: path.join(root, closedPath) },
+      { section: "plans", name: `${itemId}.md`, path: path.join(root, planPath) },
+      {
+        section: "decision-packets",
+        name: `${itemId}.json`,
+        path: path.join(root, packetPath),
+      },
+    ],
+  });
 
   const closedPacket = packet("closed", closedPath);
   const closedPrimary = primary("closed", closedPacket, "2026-07-28T04:33:00.000Z");
@@ -9290,6 +9309,115 @@ test("apply preselect moves a reconciliation-authored canonical tuple from items
     "the legitimate items-to-closed move must reach canonical state",
   );
   assert.equal((await closed.json()).content, closedPrimary);
+
+  // The checkpoint lane mutates a hydrated record after preselect. Its state
+  // checkout still has no records/, and the broad records path must be scoped
+  // to the tuple captured immediately before this mutation.
+  const applyItemId = itemId + 1;
+  const applyItemPath = `${tupleRoot}/items/${applyItemId}.md`;
+  const applyClosedPath = `${tupleRoot}/closed/${applyItemId}.md`;
+  const applyPlanPath = `${tupleRoot}/plans/${applyItemId}.md`;
+  const applyPacketPath = `${tupleRoot}/decision-packets/${applyItemId}.json`;
+  const applyPacket = packet("open", applyItemPath, applyItemId);
+  const applyBefore = primary("open", applyPacket, "2026-07-28T04:34:00.000Z", applyItemId);
+  const applySeed = await queue.fetch(
+    stateAppendQueueRequest("/records/tuples", {
+      deliveryId: `record-reconcile:openclaw-openclaw:${applyItemId}:seed`,
+      key: `openclaw-openclaw/${applyItemId}`,
+      operations: [
+        {
+          path: applyItemPath,
+          expectedDigest: null,
+          contentBase64: Buffer.from(applyBefore).toString("base64"),
+        },
+        { path: applyClosedPath, expectedDigest: null },
+        { path: applyPlanPath, expectedDigest: null },
+        {
+          path: applyPacketPath,
+          expectedDigest: null,
+          contentBase64: Buffer.from(applyPacket).toString("base64"),
+        },
+      ],
+    }),
+  );
+  assert.equal(applySeed.status, 202, await applySeed.text());
+  write(root, applyItemPath, applyBefore);
+  write(root, applyPacketPath, applyPacket);
+
+  const applyBaselineRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "clawsweeper-apply-checkpoint-baseline-"),
+  );
+  captureCanonicalRecordBaseline({
+    baselineRoot: applyBaselineRoot,
+    repositorySlug: "openclaw-openclaw",
+    itemNumber: applyItemId,
+    sources: [
+      { section: "items", name: `${applyItemId}.md`, path: path.join(root, applyItemPath) },
+      {
+        section: "closed",
+        name: `${applyItemId}.md`,
+        path: path.join(root, applyClosedPath),
+      },
+      { section: "plans", name: `${applyItemId}.md`, path: path.join(root, applyPlanPath) },
+      {
+        section: "decision-packets",
+        name: `${applyItemId}.json`,
+        path: path.join(root, applyPacketPath),
+      },
+    ],
+  });
+  const applyAfter = applyBefore.replace(
+    "reconciled_at: 2026-07-28T04:34:00.000Z",
+    "reconciled_at: 2026-07-28T04:34:00.000Z\napply_checked_at: 2026-07-28T05:24:00.000Z",
+  );
+  write(root, applyItemPath, applyAfter);
+
+  const unrelatedItemId = applyItemId + 1;
+  const unrelatedItemPath = `${tupleRoot}/items/${unrelatedItemId}.md`;
+  const unrelatedPacketPath = `${tupleRoot}/decision-packets/${unrelatedItemId}.json`;
+  const unrelatedPacket = packet("open", unrelatedItemPath, unrelatedItemId);
+  write(
+    root,
+    unrelatedItemPath,
+    primary("open", unrelatedPacket, "2026-07-28T04:35:00.000Z", unrelatedItemId),
+  );
+  write(root, unrelatedPacketPath, unrelatedPacket);
+
+  const applyMutations: Array<Record<string, unknown>> = [];
+  await publishMainWithStateAppend(
+    {
+      message: "chore: apply sweep decisions checkpoint 1",
+      paths: [tupleRoot],
+      rebaseStrategy: "reconcile-records",
+    },
+    {
+      root,
+      env: {
+        CLAWSWEEPER_STATE_APPEND_ENABLED: "1",
+        CLAWSWEEPER_STATE_DIR: sparseStateRoot,
+        CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: applyBaselineRoot,
+        QUEUE_URL: "https://queue.test",
+        CLAWSWEEPER_WEBHOOK_SECRET: "apply-checkpoint-test-secret",
+      },
+      fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+        const mutation = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        applyMutations.push(mutation);
+        const response = await queue.fetch(stateAppendQueueRequest("/records/tuples", mutation));
+        return Response.json(await response.json(), { status: response.status });
+      }) as typeof fetch,
+      publishGit: () => {
+        throw new Error("canonical apply checkpoint must not use Git publication");
+      },
+    },
+  );
+
+  assert.equal(applyMutations.length, 1);
+  assert.equal(applyMutations[0]?.key, `openclaw-openclaw/${applyItemId}`);
+  const applied = await queue.fetch(
+    new Request(`https://queue/records/openclaw-openclaw/items/${applyItemId}`, { method: "GET" }),
+  );
+  assert.equal(applied.status, 200);
+  assert.equal((await applied.json()).content, applyAfter);
 });
 
 test("canonical tuple failures return stable errors and sanitize server logs", async () => {

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "node:path";
 import test from "node:test";
 
+import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { reportFrontMatter, tmpPrefix, withMockGh } from "./helpers.ts";
 
 test("reconcile reports every changed record tuple and cleans already-closed sidecars", () => {
@@ -143,6 +144,14 @@ if (args[0] === "api" && args[1]?.includes("/issues?state=open")) {
       ),
       '{"subject":{"state":"open"}}\n',
     );
+    assert.deepEqual([...capturedCanonicalRecordBaselineKeys(canonicalBaselineDir)].sort(), [
+      "openclaw-openclaw/1",
+      "openclaw-openclaw/2",
+      "openclaw-openclaw/3",
+      "openclaw-openclaw/4",
+      "openclaw-openclaw/5",
+      "openclaw-openclaw/7",
+    ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { captureCanonicalRecordBaseline } from "../../dist/repair/canonical-record-baseline.js";
 import { publishMainWithStateAppend } from "../../dist/repair/publish-main.js";
 import type { GitPublishOptions, PublishResult } from "../../dist/repair/git-publish.js";
 
@@ -191,12 +192,34 @@ test("publish-main refetches CURRENT and retries a conflicted reconciliation mov
   const sparseStateRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), "clawsweeper-canonical-current-sparse-state-"),
   );
+  const canonicalBaselineRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "clawsweeper-canonical-current-baseline-"),
+  );
   const baseline = closeRecord("old-source-revision", "baseline", "open");
   const target = closeRecord("old-source-revision", "baseline", "closed");
   const current = closeRecord("new-source-revision", "event-driven review", "open");
   const rebased = closeRecord("new-source-revision", "event-driven review", "closed");
   const tupleClosedPath = `${tupleRoot}/closed/42.md`;
   writeText(stateRoot, tupleItemPath, baseline);
+  captureCanonicalRecordBaseline({
+    baselineRoot: canonicalBaselineRoot,
+    repositorySlug: "openclaw-openclaw",
+    itemNumber: 42,
+    sources: [
+      { section: "items", name: "42.md", path: path.join(stateRoot, tupleItemPath) },
+      { section: "closed", name: "42.md", path: path.join(stateRoot, tupleClosedPath) },
+      {
+        section: "plans",
+        name: "42.md",
+        path: path.join(stateRoot, `${tupleRoot}/plans/42.md`),
+      },
+      {
+        section: "decision-packets",
+        name: "42.json",
+        path: path.join(stateRoot, `${tupleRoot}/decision-packets/42.json`),
+      },
+    ],
+  });
   writeText(root, tupleClosedPath, target);
   const posted: Array<Record<string, unknown>> = [];
   const deferredPath = path.join(root, ".artifacts/deferred.jsonl");
@@ -208,7 +231,7 @@ test("publish-main refetches CURRENT and retries a conflicted reconciliation mov
         root,
         env: appendEnv({
           CLAWSWEEPER_STATE_DIR: sparseStateRoot,
-          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: stateRoot,
+          CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: canonicalBaselineRoot,
           CLAWSWEEPER_CANONICAL_PUBLICATION_KIND: "reconcile",
           CLAWSWEEPER_RECONCILE_DEFERRED_PATH: deferredPath,
         }),

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1178,6 +1178,50 @@ test("broad record publishers isolate tuple reconciliation from status and auxil
   }
 });
 
+test("every sweep tuple mutator hands publish-main a captured canonical baseline", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const stepBlock = (name: string): string => {
+    const start = workflow.indexOf(`- name: ${name}`);
+    assert.notEqual(start, -1, name);
+    const end = workflow.indexOf("\n      - ", start + 1);
+    return workflow.slice(start, end === -1 ? undefined : end);
+  };
+
+  const applyArtifacts = stepBlock("Apply review artifacts");
+  assert.match(
+    applyArtifacts,
+    /CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: \.artifacts\/review-canonical-baseline/,
+  );
+  const commitReview = stepBlock("Commit review records");
+  assert.match(
+    commitReview,
+    /CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: \.artifacts\/review-canonical-baseline/,
+  );
+  assert.match(commitReview, /--canonical-record-baseline-dir/);
+
+  const selectedComments = stepBlock("Sync selected review comments");
+  assert.ok(
+    selectedComments.indexOf("begin_canonical_record_mutation") <
+      selectedComments.indexOf("pnpm run apply-decisions"),
+  );
+  assert.ok(
+    selectedComments.indexOf("pnpm run apply-decisions") <
+      selectedComments.indexOf("chore: sync selected review comments"),
+  );
+
+  const refreshAudit = stepBlock("Refresh Audit Health");
+  const commitAudit = stepBlock("Commit Audit Health");
+  assert.match(
+    refreshAudit,
+    /CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: \.artifacts\/audit-canonical-baseline/,
+  );
+  assert.match(refreshAudit, /--canonical-record-baseline-dir/);
+  assert.match(
+    commitAudit,
+    /CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: \.artifacts\/audit-canonical-baseline/,
+  );
+});
+
 test("apply workflow isolates proof Codex and limits mutation Codex to model-guided recovery", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const workflowConcurrency = workflow.slice(
@@ -1473,6 +1517,29 @@ test("apply checkpoints split record tuples from auxiliary state", () => {
     { encoding: "utf8" },
   );
   assert.equal(failedOutput.trim(), "reconcile-records");
+});
+
+test("best-effort apply status publishes one sparse-safe file without noisy restore", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'publish_changes() { printf "publish=%s\\npath=%s\\n" "$1" "$2"; return 1; }',
+        'git() { if [ "$1" = restore ]; then printf "unexpected restore\\n"; fi; return 1; }',
+        'TARGET_REPO="OpenClaw/OpenClaw"',
+        'publish_status "apply status"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.deepEqual(output.trim().split("\n"), [
+    "publish=apply status",
+    "path=results/sweep-status/openclaw-openclaw.json",
+    "Best-effort status update failed: apply status",
+  ]);
 });
 
 test("apply workflow rejects malformed or oversized coverage proof artifact trees", () => {
@@ -1843,7 +1910,17 @@ test("apply workflow finalization retries only target status after checkpointed 
   ]) {
     assert.ok(applyStep.indexOf(laterBranch) > closeCheckpoint);
   }
+  assert.match(applyStep, /publish_status "chore: mark sweep apply in progress"/);
   assert.match(applyStep, /publish_status "chore: mark sweep apply finished"/);
+  assert.doesNotMatch(
+    applyStep,
+    /publish_changes "chore: mark sweep apply in progress"[^\n]*records/,
+  );
+  assert.equal(
+    [...applyStep.matchAll(/begin_canonical_record_mutation/g)].length,
+    2,
+    "comment-sync and close checkpoints each need a fresh pre-mutation tuple baseline",
+  );
 
   assert.match(finalStatusStep, /APPLY_NOOP:-false/);
   assert.match(finalStatusStep, /--message "chore: mark sweep apply finished"/);

--- a/test/work-plan-artifacts.test.ts
+++ b/test/work-plan-artifacts.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { renderWorkPlanFromReport } from "../dist/clawsweeper.js";
+import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { tmpPrefix, workPlanCandidateReport } from "./helpers.ts";
 
 test("renderWorkPlanFromReport renders dashboard plan artifacts for fresh queue_fix_pr candidates", () => {
@@ -83,6 +84,54 @@ test("apply-artifacts writes and removes generated work plans", () => {
       "--skip-reconcile",
     ]);
     assert.equal(existsSync(planPath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply-artifacts captures the hydrated tuple before replacing a review record", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const artifactDir = join(root, "artifacts");
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const baselineDir = join(root, "canonical-baseline");
+    mkdirSync(artifactDir, { recursive: true });
+    mkdirSync(itemsDir, { recursive: true });
+    const before = workPlanCandidateReport({ reviewed_at: "2026-05-20T00:00:00.000Z" });
+    const after = workPlanCandidateReport({ reviewed_at: "2026-05-21T00:00:00.000Z" });
+    writeFileSync(join(itemsDir, "321.md"), before, "utf8");
+    writeFileSync(join(artifactDir, "321.md"), after, "utf8");
+
+    execFileSync(process.execPath, [
+      "dist/clawsweeper.js",
+      "apply-artifacts",
+      "--target-repo",
+      "openclaw/clawsweeper",
+      "--artifact-dir",
+      artifactDir,
+      "--items-dir",
+      itemsDir,
+      "--closed-dir",
+      closedDir,
+      "--plans-dir",
+      plansDir,
+      "--canonical-record-baseline-dir",
+      baselineDir,
+      "--replay-closed-artifacts",
+      "--skip-reconcile",
+    ]);
+
+    assert.equal(
+      readFileSync(join(baselineDir, "records/openclaw-clawsweeper/items/321.md"), "utf8"),
+      before,
+    );
+    assert.deepEqual(
+      [...capturedCanonicalRecordBaselineKeys(baselineDir)],
+      ["openclaw-clawsweeper/321"],
+    );
+    assert.match(readFileSync(join(itemsDir, "321.md"), "utf8"), /reviewed_at: 2026-05-21/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- capture each canonically hydrated record tuple immediately before review, reconcile, or apply mutation and use that snapshot as the compare-and-swap baseline
- scope broad record publication to the captured tuple manifest, so a Worker-hydrated worktree never treats every record omitted from the sparse Git checkout as a new row
- wire the baseline through review artifact publication, selected comment sync, audit reconciliation, and every apply checkpoint
- publish best-effort sweep status through its exact file and avoid noisy restore attempts for generated paths outside the source checkout
- protect the three namespaced review guard labels during apply and flag repository-policy-forbidden close classes before comment sync

## Root cause

PR #931 fixed preselect reconciliation by handing `publish-main` a pre-mutation tuple snapshot. Apply run https://github.com/openclaw/clawsweeper/actions/runs/30423708926 then exposed the same stale-baseline defect in checkpoint publication: `apply-decisions` mutated canonically hydrated records, but the later publisher computed `expectedDigest` from `CLAWSWEEPER_STATE_DIR`, whose sparse checkout intentionally has no `records/` tree. The first checkpoint therefore sent null or stale digests and received `canonical_record_tuple_conflict` after four review comments had already synced.

The shared capture manifest makes the ownership explicit. Mutation commands snapshot the four tuple sections before their first write. `publish-main` accepts only captured keys when an explicit baseline is present, while the two direct Worker maintenance writers continue to use digests from their live canonical exports.

## Caller audit

| Tuple writer | CAS baseline |
| --- | --- |
| `src/repair/publish-main.ts` initial post and CURRENT retry | pre-mutation capture manifest for Worker-hydrated lanes; full Git state checkout remains the rollback path |
| `scripts/reconcile-worker-records.ts` corrective tuple post | digests from the canonical Worker export |
| `scripts/worker-records.ts` projection replay | digests from the canonical Worker snapshot |

## Proof

- real Durable Object handler test seeds canonical state, captures an apply tuple, mutates it, publishes the broad checkpoint path, and proves only that tuple is sent while an unrelated hydrated record is ignored
- apply, review-artifact, reconcile, policy-class, namespaced-label, sparse-status, publish-main, and sweep-workflow focused tests pass
- `pnpm run format`, `pnpm run build`, and `pnpm run lint` pass
- `pnpm run check` passes static checks, all builds, lint, changed coverage, and task tests; the final all-files coverage run retains the six unrelated macOS baseline failures already documented on #931: five Linux Landlock fixtures cannot resolve `capset`, and one temp-path assertion compares `/var` with `/private/var`
- `~/.claude/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings

No Worker deployment or protocol change is required.
