### PR TITLE
fix: treat apply budget stops as resumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Treat apply runtime-budget exhaustion as a successful resumable yield, preserve the safe next-cycle cursor, and stage immutable action events safely from sparse state checkouts.
 - The `migrate-state-blobs` workflow uploads with bounded concurrency (default 12, input-configurable) instead of strictly sequential per-file round trips, reports a contiguous-prefix resume cursor that stays valid under out-of-order completion, and backs off adaptively on 429/5xx pressure; three prior runs had hit the job timeout before finishing the ledger tree.
 - Bound durable cluster dispatch recovery to a verifiable accepted-intent receipt and strictly validated v2 intake ledgers. Thanks @RomneyDa! (#883)
 - Prioritized durable cluster intake without starving sweep, router, proof, or canonical tuple rows during sustained intake. Thanks @RomneyDa! (#882)

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -27657,17 +27657,24 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
   };
   runtimeBudget.onYield = (reason: string, resumeCurrent = true): void => {
     releaseActiveApplyMutationLease();
-    const interruptedItem = resumeCurrent && activeApplyItem !== null;
-    const currentNumber = examinedItemNumbers.at(-1);
-    if (resumeCurrent && currentNumber !== undefined) {
-      removeCurrentCursorTraceItem(examinedItemNumbers, currentNumber);
+    const interruptedItem = resumeCurrent ? activeApplyItem : null;
+    if (interruptedItem) {
+      removeCurrentCursorTraceItem(examinedItemNumbers, interruptedItem.number);
     }
-    results.push({ number: 0, action: "skipped_runtime_budget", reason });
-    logProgress(`stopping apply: ${reason}`);
-    finishApply(
-      interruptedItem,
-      interruptedItem ? new GitHubRuntimeBudgetError(reason) : undefined,
-    );
+    for (const result of interruptedItem
+      ? applyRuntimeBudgetYieldResults(interruptedItem.number, reason)
+      : [{ number: 0, action: "skipped_runtime_budget" as const, reason }]) {
+      if (
+        !results.some(
+          (existing) =>
+            existing.number === result.number && existing.action === "skipped_runtime_budget",
+        )
+      ) {
+        results.push(result);
+      }
+    }
+    logProgress(`budget stop, resume next cycle: ${reason}`);
+    finishApply();
   };
   if (fileEntries.length === 0 && !existsSync(itemsDir)) {
     console.log("No items directory.");
@@ -27685,13 +27692,8 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
       const reason =
         runtimeBudget.limitReason ?? `max runtime ${maxRuntimeMs}ms reached`;
-      results.push({
-        number: 0,
-        action: "skipped_runtime_budget",
-        reason,
-      });
-      logProgress(`stopping apply: ${reason}`);
-      break;
+      runtimeBudget.onYield?.(reason, false);
+      return;
     }
     let markdown = entry.markdown;
     const repo = entry.repo;
@@ -28535,7 +28537,7 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       }
       removeCurrentCursorTraceItem(examinedItemNumbers, number);
       results.push(...applyRuntimeBudgetYieldResults(number, reason));
-      logProgress(`stopping apply: ${reason}`);
+      logProgress(`budget stop, resume next cycle: ${reason}`);
     };
     const sameAuthorPairStartCloseable = new Map<string, boolean>();
     const currentCloseGatesPassed = (): boolean => {

--- a/src/repair/git-publish.ts
+++ b/src/repair/git-publish.ts
@@ -448,7 +448,10 @@ export function stagePaths(paths: readonly string[]): void {
     });
     skippedMissing += batch.length - stageable.length;
     if (stageable.length > 0) {
-      runGit(["add", "-A", "--", ...stageable.map(({ gitPath }) => gitPath)]);
+      const sparseArgs = stageable.every(({ gitPath }) => isActionEventPublishPath(gitPath))
+        ? ["--sparse"]
+        : [];
+      runGit(["add", "-A", ...sparseArgs, "--", ...stageable.map(({ gitPath }) => gitPath)]);
     }
   }
   if (skippedMissing > 0) {

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
@@ -38,13 +39,14 @@ function assertRuntimeYield(
 ) {
   const report = JSON.parse(readFileSync(fixture.reportPath, "utf8"));
   const cursorTrace = JSON.parse(readFileSync(fixture.cursorTracePath, "utf8"));
-  assert.deepEqual(report, [
-    {
-      number: 0,
-      action: "skipped_runtime_budget",
-      reason: report[0]?.reason,
-    },
-  ]);
+  assert.equal(report.length, 2);
+  assert.ok(report[0]?.number > 0);
+  assert.equal(report[0]?.action, "skipped_runtime_budget");
+  assert.deepEqual(report[1], {
+    number: 0,
+    action: "skipped_runtime_budget",
+    reason: report[0]?.reason,
+  });
   assert.match(report[0]?.reason ?? "", new RegExp(`max runtime ${maxRuntimeMs}ms reached`));
   assert.deepEqual(cursorTrace, { schema_version: 1, examined_item_numbers: [] });
 }
@@ -142,15 +144,37 @@ test("apply-decisions bounds a hung GitHub command and writes a resumable runtim
   try {
     const startedAt = Date.now();
     withMockGh(fixture.root, "setTimeout(() => {}, 10_000);", () => {
-      runApplyDecisionsForTest({
-        ...fixture,
-        extraArgs: [
+      const result = spawnSync(
+        process.execPath,
+        [
+          "dist/clawsweeper.js",
+          "apply-decisions",
+          "--target-repo",
+          "openclaw/clawsweeper",
+          "--items-dir",
+          fixture.itemsDir,
+          "--closed-dir",
+          fixture.closedDir,
+          "--plans-dir",
+          fixture.plansDir,
+          "--report-path",
+          fixture.reportPath,
+          "--limit",
+          "10",
+          "--processed-limit",
+          "1",
+          "--close-delay-ms",
+          "0",
           "--max-runtime-ms",
           String(maxRuntimeMs),
           "--cursor-trace",
           fixture.cursorTracePath,
         ],
-      });
+        { encoding: "utf8", env: process.env },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stderr, /budget stop, resume next cycle:/);
+      assert.doesNotMatch(result.stderr, /failed apply/);
     });
 
     assert.ok(Date.now() - startedAt < 4_000, "hung gh command exceeded the apply runtime bound");

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -559,9 +559,11 @@ test("apply receipts start per item and persist mutation observation before fina
     yieldStart,
     source.indexOf("if (fileEntries.length === 0", yieldStart),
   );
-  assert.match(yieldHandler, /const interruptedItem = resumeCurrent && activeApplyItem !== null/);
-  assert.match(yieldHandler, /finishApply\(\s*interruptedItem,/);
-  assert.doesNotMatch(yieldHandler, /finishApply\(\);/);
+  assert.match(yieldHandler, /const interruptedItem = resumeCurrent \? activeApplyItem : null/);
+  assert.match(yieldHandler, /applyRuntimeBudgetYieldResults\(interruptedItem\.number, reason\)/);
+  assert.match(yieldHandler, /budget stop, resume next cycle/);
+  assert.match(yieldHandler, /finishApply\(\);/);
+  assert.doesNotMatch(yieldHandler, /finishApply\(\s*true/);
 });
 
 test("apply mutation receipts bind every GitHub request attempt and preserve no-op truth", () => {

--- a/test/repair/git-publish.test.ts
+++ b/test/repair/git-publish.test.ts
@@ -293,6 +293,28 @@ test("stagePaths normalizes tracked deletion pathspecs", () => {
   assert.equal(run("git", ["diff", "--cached", "--name-only"], root), `${file}\n`);
 });
 
+test("stagePaths stages immutable action events outside a sparse checkout", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-stage-sparse-ledger-"));
+  const eventPath =
+    "ledger/v1/events/2026/07/29/apply/apply-existing/00000000-0000-4000-8000-000000000001.jsonl";
+  try {
+    run("git", ["init"], root);
+    configureUser(root);
+    write(path.join(root, "results/keep.txt"), "tracked\n");
+    run("git", ["add", "."], root);
+    run("git", ["commit", "-m", "initial"], root);
+    run("git", ["sparse-checkout", "init", "--no-cone"], root);
+    run("git", ["sparse-checkout", "set", "--no-cone", "/results/"], root);
+    write(path.join(root, eventPath), '{"event":"yielded"}\n');
+
+    withCwd(root, () => stagePaths([eventPath]));
+
+    assert.equal(run("git", ["diff", "--cached", "--name-only"], root), `${eventPath}\n`);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("publishMainCommit commits selected paths and restores volatile tracked files", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-publish-"));
   const origin = path.join(root, "origin.git");

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -2553,6 +2553,66 @@ test("workflow utilities advance fast and coverage-proof cursors from the exact 
   assert.equal(cursor.coverage_proof_cursor.next_after_number, 40);
 });
 
+test("runtime-budget cursor resumes the next candidate without rescanning the completed prefix", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/apply-cursors/openclaw-openclaw.json");
+  const reportPath = path.join(root, "apply-report.json");
+  const tracePath = path.join(root, "apply-cursor-trace.json");
+  const options = {
+    targetRepo: "openclaw/openclaw",
+    applyKind: "all",
+    applyCloseReasons: "all",
+    staleMinAgeDays: 60,
+    minAgeDays: 0,
+    minAgeMinutes: null,
+    batchSize: 5,
+    cursorPath,
+  };
+  try {
+    for (const [number, day] of [
+      [10, "01"],
+      [20, "02"],
+      [30, "03"],
+      [40, "04"],
+      [50, "05"],
+    ] as const) {
+      writeProposedRecord(
+        root,
+        number,
+        "issue",
+        "proposed_close",
+        "implemented_on_main",
+        "2024-01-01T00:00:00Z",
+        { applyCheckedAt: `2026-01-${day}T00:00:00Z` },
+      );
+    }
+    assert.deepEqual(
+      withCwd(root, () => proposedItemNumbers(options)),
+      [10, 20, 30, 40, 50],
+    );
+    write(reportPath, JSON.stringify([{ number: 0, action: "skipped_runtime_budget" }]));
+    write(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 20] }));
+
+    withCwd(root, () =>
+      writeApplyCursor(
+        cursorPath,
+        reportPath,
+        "openclaw/openclaw",
+        "10,20,30,40,50",
+        "",
+        tracePath,
+      ),
+    );
+
+    assert.deepEqual(
+      withCwd(root, () => proposedItemNumbers({ ...options, batchSize: 3 })),
+      [30, 40, 50],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("workflow utilities count records advanced by the apply cursor", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const reportPath = path.join(root, "apply-report.json");


### PR DESCRIPTION
## Summary

- finalize apply runtime-budget exhaustion as an expected yielded batch instead of an in-flight failure
- retain only fully examined items in the apply cursor so the next scheduled cycle resumes after the completed prefix
- allow validated immutable action-event paths to use Git's sparse staging opt-in when Worker append falls back to Git
- keep owned review-lease cleanup best-effort and non-fatal during budget exhaustion

## Proof

- `node --test test/apply-runtime-budget.test.ts`
- `node --test test/clawsweeper-action-ledger.test.ts`
- `node --test test/repair/git-publish.test.ts`
- `node --test test/repair/workflow-utils.test.ts`
- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run format:check`
- source-blind CLI behavior contract: budget stop exits 0, prints the resume summary, preserves an empty interrupted-item cursor, and invalid commands still exit 1
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings

`pnpm run check` passed formatting, builds, lint, coverage thresholds, and the changed surfaces. Its full macOS run retains six unrelated baseline failures in the untouched containment and state-publication batching tests: Linux `capset` is unavailable on macOS, and one temp-path assertion compares `/var` with `/private/var`.

Operational evidence: https://github.com/openclaw/clawsweeper/actions/runs/30426575885
