### PR TITLE
fix(repair): skip cluster intake blob hydration

### DIFF
--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -172,6 +172,8 @@ jobs:
           records-source: ${{ vars.CLAWSWEEPER_RECORDS_SOURCE || 'worker' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          # Intake reads jobs and results only; ledger/assets hydration is unrelated and unbounded.
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           persist-credentials: "false"

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -71,6 +71,16 @@ test("scheduled cluster repair intake follows gitcrawl-store freshness cadence",
   assert.match(internalDocs, /refreshes `openclaw\/openclaw` every 15\s+minutes/);
 });
 
+test("cluster intake skips unrelated ledger and asset blob hydration", () => {
+  const workflow = readFileSync(".github/workflows/repair-cluster-intake.yml", "utf8");
+  const setupStateIndex = workflow.indexOf("uses: ./.github/actions/setup-state");
+  const nextStepIndex = workflow.indexOf("\n      - ", setupStateIndex + 1);
+
+  assert.notEqual(setupStateIndex, -1);
+  assert.notEqual(nextStepIndex, -1);
+  assert.match(workflow.slice(setupStateIndex, nextStepIndex), /hydrate-state-blobs: "false"/);
+});
+
 test("gitcrawl cluster import is not blocked by the scheduled intake gate", () => {
   const source = readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8");
   const lowSignalSource = readFileSync("src/repair/import-gitcrawl-low-signal-prs.ts", "utf8");


### PR DESCRIPTION
## Summary

- prevent cluster intake from reconstructing the unrelated Worker-backed ledger and assets trees
- preserve hydration of the jobs and results state that intake actually reads
- add a workflow regression test locking the blob-hydration opt-out

## Incident

The controlled intake run https://github.com/openclaw/clawsweeper/actions/runs/30424408866 spent 44 minutes in hydrate-state before its 45-minute job timeout. Candidate import, model selection, durable acceptance, materialization, and dispatch never ran.

## Validation

- `node --test test/repair/gitcrawl-store.test.ts`
- `pnpm run build:all`
- Linux CI `pnpm check`: https://github.com/openclaw/clawsweeper/actions/runs/30429003978
- CodeQL: https://github.com/openclaw/clawsweeper/actions/runs/30429003526
- controlled PR-branch intake proof: https://github.com/openclaw/clawsweeper/actions/runs/30429326369 completed successfully in 2m4s with `enabled=0`; setup-state completed and import, selection, acceptance, materialization, and dispatch were skipped

The local macOS full gate reached unrelated platform/environment failures in Linux containment probes, `/private/var` path canonicalization, and sandboxed pnpm registry access; the same full gate passed on Linux CI.

No merge, automerge, apply, or close settings are changed.