### PR TITLE
fix(ci): restore maintainer command routing

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -104,6 +104,7 @@ jobs:
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
             scripts/prepare-worker-record-cache.ts
+            scripts/worker-blobs.ts
             scripts/worker-records.ts
             src
             package.json

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -103,6 +103,7 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            scripts/prepare-worker-record-cache.ts
             scripts/worker-records.ts
             src
             package.json

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -85,6 +85,8 @@ jobs:
             results
             schema/clawsweeper-pr-close-coverage-proof.schema.json
             scripts/hydrate-state.ts
+            scripts/prepare-worker-record-cache.ts
+            scripts/worker-blobs.ts
             scripts/worker-records.ts
             src
             package.json

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -50,6 +50,7 @@ test("state-hydrating sparse repair workflows keep hydration dependencies", () =
     for (const requiredPath of [
       "scripts/hydrate-state.ts",
       "scripts/prepare-worker-record-cache.ts",
+      "scripts/worker-blobs.ts",
       "scripts/worker-records.ts",
     ]) {
       assert.ok(

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -47,7 +47,11 @@ test("state-hydrating sparse repair workflows keep hydration dependencies", () =
     ".github/workflows/spam-scanner.yml",
   ]) {
     const entries = sourceSparseCheckoutEntries(workflowPath);
-    for (const requiredPath of ["scripts/hydrate-state.ts", "scripts/worker-records.ts"]) {
+    for (const requiredPath of [
+      "scripts/hydrate-state.ts",
+      "scripts/prepare-worker-record-cache.ts",
+      "scripts/worker-records.ts",
+    ]) {
       assert.ok(
         sparseEntriesCover(entries, requiredPath),
         `${workflowPath} missing ${requiredPath}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawSweeper command comments would remain stuck at "Command router queued" because the router failed during state hydration.

## Why This Change Was Made

The router and spam scanner sparse source checkouts now include the complete helper graph required by the shared state setup action. The existing sparse-checkout contract test covers all four hydration dependencies.

## User Impact

Maintainer commands such as `@clawsweeper re-review` can reach the review worker again instead of failing before routing.

## Evidence

- First live failure: https://github.com/openclaw/clawsweeper/actions/runs/30442998824
- The first failure was `MODULE_NOT_FOUND` for `scripts/prepare-worker-record-cache.ts`.
- Branch acceptance run: https://github.com/openclaw/clawsweeper/actions/runs/30443145811
- That run passed the snapshot helper and exposed the next omitted transitive import, `scripts/worker-blobs.ts`.
- `git diff --check` passes.
- Local dependency-backed tests were unavailable because this Codex worktree's shared install is stale; clean PR CI owns the full install, formatting, and test proof.
