### PR TITLE
fix: scope per-target state hydration

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -83,6 +83,7 @@ jobs:
       target_repo: ${{ steps.target.outputs.target_repo }}
       target_repo_name: ${{ steps.target.outputs.target_repo_name }}
       target_repo_owner: ${{ steps.target.outputs.target_repo_owner }}
+      target_slug: ${{ steps.target.outputs.target_slug }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -120,10 +121,12 @@ jobs:
           fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
+          target_slug="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           {
             echo "target_repo=$target_repo"
             echo "target_repo_owner=$target_owner"
             echo "target_repo_name=$target_name"
+            echo "target_slug=$target_slug"
             echo "target_checkout_dir=target-$target_name"
           } >> "$GITHUB_OUTPUT"
 
@@ -145,8 +148,10 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
           worktree-path: clawsweeper
           hydrate-git-state: "false"
+          hydrate-state-blobs: "false"
 
       - uses: ./clawsweeper/.github/actions/setup-pnpm
         with:
@@ -411,8 +416,10 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ needs.plan.outputs.target_slug }}
           worktree-path: clawsweeper
           hydrate-git-state: "false"
+          hydrate-state-blobs: "false"
 
       - uses: ./clawsweeper/.github/actions/setup-pnpm
         with:
@@ -527,7 +534,9 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ needs.plan.outputs.target_slug }}
           hydrate-git-state: "false"
+          hydrate-state-blobs: "false"
 
       - uses: ./.github/actions/setup-pnpm
         with:

--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -91,7 +91,9 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.batch.outputs.records_repo_slugs }}
           hydrate-git-state: "false"
+          hydrate-state-blobs: "false"
 
       - name: Prepare each item independently
         if: ${{ steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}

--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -81,10 +81,12 @@ jobs:
           fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
+          target_slug="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           {
             echo "target_repo=$target_repo"
             echo "target_repo_owner=$target_owner"
             echo "target_repo_name=$target_name"
+            echo "target_slug=$target_slug"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create target proof-nudge token
@@ -111,6 +113,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/repair-cluster-intake.yml
+++ b/.github/workflows/repair-cluster-intake.yml
@@ -114,6 +114,7 @@ jobs:
           target_owner="${TARGET_REPO%%/*}"
           target_name="${TARGET_REPO#*/}"
           target_owner_lower="$(printf '%s' "$target_owner" | tr '[:upper:]' '[:lower:]')"
+          target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           owner_allowed=0
           for allowed_owner in "${allowed_owners[@]}"; do
             if [ "$target_owner_lower" = "$(printf '%s' "$allowed_owner" | tr '[:upper:]' '[:lower:]')" ]; then
@@ -129,6 +130,7 @@ jobs:
             printf 'owner=%s\n' "$target_owner"
             printf 'name=%s\n' "$target_name"
             printf 'full_name=%s/%s\n' "$target_owner" "$target_name"
+            printf 'slug=%s\n' "$target_slug"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create target read token
@@ -166,6 +168,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.slug }}
           # Intake reads jobs and results only; ledger/assets hydration is unrelated and unbounded.
           hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}

--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -256,6 +256,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: jobs
@@ -556,6 +557,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -128,6 +128,7 @@ jobs:
             echo "target_repo=$target_repo"
             echo "target_repo_owner=${target_repo%%/*}"
             echo "target_repo_name=${target_repo#*/}"
+            echo "target_slug=$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create target GitHub App token
@@ -166,6 +167,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/repair-commit-finding-intake.yml
+++ b/.github/workflows/repair-commit-finding-intake.yml
@@ -102,6 +102,19 @@ jobs:
         with:
           build-script: build:repair
 
+      - name: Resolve target repository
+        id: target
+        env:
+          TARGET_REPO: ${{ github.event.inputs.target_repo || github.event.client_payload.target_repo || 'openclaw/openclaw' }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid target repository: $TARGET_REPO" >&2
+            exit 1
+          fi
+          target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
+          echo "target_slug=$target_slug" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -127,6 +140,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -68,6 +68,19 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
 
+      - name: Resolve target repository
+        id: target
+        env:
+          TARGET_REPO: ${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLAWSWEEPER_TARGET_REPO || 'openclaw/openclaw' }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid target repository: $TARGET_REPO" >&2
+            exit 1
+          fi
+          target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
+          echo "target_slug=$target_slug" >> "$GITHUB_OUTPUT"
+
       - name: Create state token
         id: state-token
         uses: ./.github/actions/create-state-token
@@ -80,6 +93,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -72,6 +72,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/repair-issue-implementation-intake.yml
+++ b/.github/workflows/repair-issue-implementation-intake.yml
@@ -164,6 +164,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -113,6 +113,7 @@ jobs:
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           coordinator-class: publication_batch
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -77,6 +77,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -95,6 +95,19 @@ jobs:
             tsconfig.repair.json
           sparse-checkout-cone-mode: false
 
+      - name: Resolve target repository
+        id: target
+        env:
+          TARGET_REPO: ${{ github.event_name == 'repository_dispatch' && (github.event.client_payload.target_repo || 'openclaw/openclaw') || github.event.inputs.target_repo || vars.CLAWSWEEPER_TARGET_REPO || 'openclaw/openclaw' }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$TARGET_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid target repository: $TARGET_REPO" >&2
+            exit 1
+          fi
+          target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
+          echo "target_slug=$target_slug" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub App token
         id: app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -118,6 +131,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           fetch-depth: 1
 

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -633,6 +633,7 @@ jobs:
           const mediaTimeout =
             Number.isInteger(mediaValue) && mediaValue > 0 ? Math.min(480_000, mediaValue) : 0;
           const [owner, name] = targetRepo.split("/");
+          const targetSlug = targetRepo.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
           const checkoutDir = targetRepo === process.env.GITHUB_REPOSITORY ? `${name}-target` : name;
           const hasCommandContext = Boolean(decision.commandStatusMarker || decision.statusCommentId);
           const targetEnabled =
@@ -641,6 +642,7 @@ jobs:
             target_repo: targetRepo,
             target_repo_owner: owner,
             target_repo_name: name,
+            target_slug: targetSlug,
             target_checkout_dir: checkoutDir,
             item_number: itemNumber,
             codex_timeout_ms: Math.min(
@@ -1196,7 +1198,9 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
           hydrate-git-state: "false"
+          hydrate-state-blobs: "false"
 
       - name: Deliver GitHub effects and prepare direct state mutation
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-setup-state.outcome == 'success' }}
@@ -1628,6 +1632,7 @@ jobs:
                 if (!Number.isInteger(claimGeneration) || claimGeneration < 1) process.exit(1);
                 const targetRepo = String(decision.targetRepo);
                 const [targetRepoOwner, targetRepoName] = targetRepo.split("/");
+                const targetSlug = targetRepo.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
                 const values = {
                   artifact_name: publication.artifactName,
                   generation_attempt: publication.producerRunAttempt,
@@ -1641,6 +1646,7 @@ jobs:
                   target_repo: targetRepo,
                   target_repo_owner: targetRepoOwner,
                   target_repo_name: targetRepoName,
+                  target_slug: targetSlug,
                   target_branch: decision.targetBranch,
                   item_number: decision.itemNumber,
                   item_kind: decision.itemKind,
@@ -1793,7 +1799,9 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.publication-context.outputs.target_slug }}
           hydrate-git-state: "false"
+          hydrate-state-blobs: "false"
 
       - name: Publish event result and apply safe close
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.validate-exact-review-bundle.outcome == 'success' && steps.legacy-exact-artifact.outputs.legacy_tupleless != 'true' }}
@@ -2417,6 +2425,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -2505,6 +2514,7 @@ jobs:
       target_repo: ${{ steps.target.outputs.target_repo }}
       target_repo_name: ${{ steps.target.outputs.target_repo_name }}
       target_repo_owner: ${{ steps.target.outputs.target_repo_owner }}
+      target_slug: ${{ steps.target.outputs.target_slug }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -2533,6 +2543,7 @@ jobs:
           fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
+          target_slug="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           target_checkout_dir="$target_name"
           if [ "$target_repo" = "${{ github.repository }}" ]; then
             target_checkout_dir="${target_name}-target"
@@ -2541,6 +2552,7 @@ jobs:
             echo "target_repo=$target_repo"
             echo "target_repo_owner=$target_owner"
             echo "target_repo_name=$target_name"
+            echo "target_slug=$target_slug"
             echo "target_branch=$target_branch"
             echo "target_checkout_dir=$target_checkout_dir"
           } >> "$GITHUB_OUTPUT"
@@ -2570,6 +2582,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
           worktree-path: clawsweeper
           fetch-depth: 1
@@ -3317,6 +3331,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ needs.plan.outputs.target_slug }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -4018,6 +4034,8 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: openclaw-openclaw
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -4210,6 +4228,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
@@ -4319,7 +4338,13 @@ jobs:
               *) target_repo="openclaw/openclaw" ;;
             esac
           fi
+          if ! printf '%s' "$target_repo" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Invalid target repository: $target_repo" >&2
+            exit 1
+          fi
+          target_slug="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           echo "target_repo=$target_repo" >> "$GITHUB_OUTPUT"
+          echo "target_slug=$target_slug" >> "$GITHUB_OUTPUT"
 
       - name: Resolve proof artifact identity
         id: proof-artifact
@@ -4332,6 +4357,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
           hydrate-state-blobs: "false"
           token: ${{ github.token }}
           persist-credentials: "false"
@@ -4628,10 +4654,12 @@ jobs:
           fi
           target_owner="${target_repo%%/*}"
           target_name="${target_repo#*/}"
+          target_slug="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
           {
             echo "target_repo=$target_repo"
             echo "target_repo_owner=$target_owner"
             echo "target_repo_name=$target_name"
+            echo "target_slug=$target_slug"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish apply telemetry start
@@ -4673,6 +4701,7 @@ jobs:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.target.outputs.target_slug }}
           hydrate-state-blobs: "false"
           token: ${{ steps.state-token.outputs.token }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.
 - Doubled exact-review admission to 128 global and 120 per target with a separate 194-slot Actions budget that preserves verdict publication at full review load, doubled scheduled fleet review fanout and canonical publication batch preparation, prioritized six-day oldest-review coverage before hot-item churn, exposed a six-hour fleet coverage summary, and raised automatic apply to 40 closes with proportional scan/runtime budgets without changing close eligibility.
 - Completed the Cloudflare-canonical state migration: records publish only to the Durable Object, action ledgers and assets publish only to R2, canonical-only workflows no longer check out `clawsweeper-state`, the former materializer only compacts the legacy append window, and the remaining `jobs`/`results`/`notifications`/apply-report Git writers use the Durable Object coordinator without Git lease refs or rebuild recovery.
 

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -11,6 +11,7 @@ import {
 import { exactReviewBatchStateWriterProgressReporter } from "./exact-review-batch-state-writer-progress.js";
 import { postDirectPublicationResult } from "./exact-review-direct-publication.js";
 import { StateWriterTelemetryRecorder } from "./state-writer-telemetry-recorder.js";
+import { normalizeRepo, slugForRepo } from "../repository-profiles.js";
 import type { StateWriterOperation } from "../state-writer-telemetry.js";
 import {
   validatePreparedStateMutationPlans,
@@ -102,6 +103,10 @@ async function claim() {
   output(
     "target_repositories",
     [...new Set(targets.map((target) => target.split("/")[1]))].join(","),
+  );
+  output(
+    "records_repo_slugs",
+    [...new Set(targets.map((target) => slugForRepo(normalizeRepo(target))))].sort().join(","),
   );
 }
 

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -115,7 +115,10 @@ test("batch workflow uses owner-scoped mutation credentials and canonical Worker
   assert.match(source, /repositories: \$\{\{ steps\.batch\.outputs\.target_repositories \}\}/);
   assert.doesNotMatch(source, /uses: \.\/\.github\/actions\/create-state-token/);
   assert.match(source, /uses: \.\/\.github\/actions\/setup-state/);
+  assert.match(source, /records-repo-slugs: \$\{\{ steps\.batch\.outputs\.records_repo_slugs \}\}/);
   assert.match(source, /hydrate-git-state: "false"/);
+  assert.match(source, /hydrate-state-blobs: "false"/);
+  assert.match(cliSource, /slugForRepo\(normalizeRepo\(target\)\)/);
   assert.doesNotMatch(source, /permissions:\n(?:.*\n)*?\s+issues: write/);
   assert.match(prepareSource, /cpSync\(recordsSource, join\(root, "records"\)/);
   assert.doesNotMatch(prepareSource, /stateClone|CLAWSWEEPER_STATE_DIR|"clone"/);

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -53,6 +53,61 @@ test("every state hydration uses the canonical Worker with an explicit git-state
   );
 });
 
+test("per-target state hydration is slug-scoped while fleet lanes retain discovery", () => {
+  const setups: Array<{ site: string; step: WorkflowStep }> = [];
+  for (const { file, workflow } of workflows()) {
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      for (const step of job.steps ?? []) {
+        if (isSetupState(step)) setups.push({ site: `${file}:${jobName}`, step });
+      }
+    }
+  }
+
+  assert.deepEqual(
+    setups
+      .filter(({ step }) => step.with?.["records-repo-slugs"] !== undefined)
+      .map(({ site }) => site),
+    [
+      ".github/workflows/commit-review.yml:plan",
+      ".github/workflows/commit-review.yml:review",
+      ".github/workflows/commit-review.yml:publish",
+      ".github/workflows/exact-review-batch-publish.yml:publish",
+      ".github/workflows/proof-nudges.yml:proof-nudges",
+      ".github/workflows/repair-cluster-intake.yml:intake",
+      ".github/workflows/repair-comment-router.yml:route-comments",
+      ".github/workflows/repair-commit-finding-intake.yml:intake",
+      ".github/workflows/repair-conflict-self-heal.yml:self-heal",
+      ".github/workflows/repair-issue-implementation-intake.yml:intake",
+      ".github/workflows/spam-scanner.yml:scan",
+      ".github/workflows/sweep.yml:event-review-apply",
+      ".github/workflows/sweep.yml:event-review-publish",
+      ".github/workflows/sweep.yml:plan",
+      ".github/workflows/sweep.yml:publish",
+      ".github/workflows/sweep.yml:retry-failed-reviews",
+      ".github/workflows/sweep.yml:apply-proof",
+      ".github/workflows/sweep.yml:apply-existing",
+    ],
+  );
+  assert.deepEqual(
+    setups
+      .filter(({ step }) => step.with?.["records-repo-slugs"] === undefined)
+      .map(({ site }) => site),
+    [
+      ".github/workflows/repair-cluster-worker.yml:cluster",
+      ".github/workflows/repair-cluster-worker.yml:execute",
+      ".github/workflows/repair-finalize-open-prs.yml:finalize",
+      ".github/workflows/repair-publish-results.yml:publish",
+      ".github/workflows/repair-self-heal.yml:self-heal",
+      ".github/workflows/sweep.yml:target-fanout",
+      ".github/workflows/sweep.yml:audit-dashboard",
+    ],
+  );
+
+  for (const { site, step } of setups) {
+    assert.equal(step.with?.["hydrate-state-blobs"], "false", site);
+  }
+});
+
 test("setup-state checks out only the remaining operational git tree", () => {
   const source = readFileSync(".github/actions/setup-state/action.yml", "utf8");
   const action = parse(source) as {


### PR DESCRIPTION
## Summary

- scope canonical record hydration to the target repository for 18 per-target or batch-selected workflow call sites
- retain Worker repository discovery for the seven fleet-wide or pre-target-resolution lanes that need it
- skip the unrelated full `ledger/v1` and `assets` R2 download at all 25 workflow `setup-state` callers
- lock the scope split into workflow-shape tests and document the operational fix in the changelog

## Root cause

An empty `records-repo-slugs` input makes both snapshot-cache preparation and `hydrate-state` discover every repository in the canonical Worker store. `materializeWorkerRecords` then hydrates each discovered slug sequentially. After #937 raised exact-review concurrency, every exact-item publication run repeated that roughly 120-slug sequence through the same Worker/DO path.

Live evidence matched the code path: a queue snapshot showed 30 exact-item runs simultaneously in progress and no exact-item completion among the latest 100 runs. In https://github.com/openclaw/clawsweeper/actions/runs/30449281061 the actual review completed in 70 seconds, then `setup-state` remained in progress from 11:54 UTC onward.

## Setup-state classification

| Class | Call sites | Records behavior | Blob behavior |
| --- | --- | --- | --- |
| Target-scoped commit review | `commit-review.yml`: plan, review, publish | target slug | skip |
| Selected exact-review batch | `exact-review-batch-publish.yml`: publish | sorted unique slugs from the claimed batch | skip |
| Target-scoped repair/support | proof nudges; cluster intake; comment router; commit-finding intake; conflict self-heal; issue-implementation intake; spam scanner | target slug | skip |
| Target-scoped sweep | exact event review apply/publish; plan; review publish; failed-review retry; apply proof; apply existing | target slug | skip |
| Pre-target repair | repair cluster worker plan/execute; repair result publisher | discovery because the repository is resolved from the hydrated job or downloaded result artifact | skip |
| Fleet repair | finalize open PRs; repair self-heal | discovery | skip |
| Fleet sweep | target fanout/coverage; audit dashboard | discovery | skip |

The slug derivation mirrors canonical record storage: trim/lowercase the `owner/name`, then replace the slash or other non-`[a-z0-9_.-]` separators with `-`. Batch publication calls the shared `normalizeRepo` + `slugForRepo` helpers directly.

## Expected impact

Exact-item setup drops from roughly 120 serial repository hydrations to one, a 99.2% reduction per run. At 33 concurrent reviews that changes the hot path from roughly 3,960 slug hydration sequences to 33, while also eliminating the full R2 ledger/assets tree download. Once the existing DO backlog drains, per-review hydration should return to seconds rather than 60-90+ minutes.

## Proof

- `node --test test/state-writer-workflow.test.ts test/sweep-workflow.test.ts test/clawsweeper.test.ts test/review-reliability-workflow.test.ts test/repair/exact-review-batch-workflow.test.ts test/repair/gitcrawl-store.test.ts test/repair/repair-cluster-worker-containment.test.ts` — 188 passed
- `pnpm run check` — formatting, all TypeScript builds, all lint targets, and coverage thresholds passed; the macOS run reached 2,755 passes and hit five unrelated Linux containment harness failures because Apple libc does not export `capset`
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings

This PR intentionally does not change Worker serialization or the full-fleet discovery contract; it removes unnecessary callers from that path.
