### PR TITLE
feat: raise scheduled review throughput

### DIFF
--- a/.github/workflows/commit-review.yml
+++ b/.github/workflows/commit-review.yml
@@ -184,7 +184,7 @@ jobs:
               for run_status in in_progress pending queued waiting requested; do
                 gh api "repos/${{ github.repository }}/actions/runs?per_page=100&status=${run_status}" \
                   --paginate \
-                  --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
+                  --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, event:.event, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
                   || true
               done
             } | jq -s 'unique_by(.databaseId)'
@@ -261,7 +261,7 @@ jobs:
           }
           active_sweep_exact_count() {
             printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select((.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) and (.displayTitle | startswith("Review event item ")))] | length' 2>/dev/null \
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq '[.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select((.displayTitle | startswith("Review exact item ")) or (.displayTitle | startswith("Review scheduled hot item ")) or (.displayTitle | startswith("Review scheduled normal item ")) or (.event == "workflow_dispatch" and (.displayTitle | startswith("Review event item "))))] | length' 2>/dev/null \
               || printf '0'
           }
           # An explicit CLAWSWEEPER_COMMIT_REVIEW_PAGE_SIZE is an operator escape hatch:

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -17,6 +17,12 @@ run-name: >-
       github.event.action == 'clawsweeper_target_sweep') &&
       format('Review target repo {0}', github.event.client_payload.target_repo || 'openclaw/openclaw') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '') &&
+      github.event.client_payload.source_action == 'scheduled_hot_intake' &&
+      format('Review scheduled hot item {0} rev {1}', github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || '?', github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision || '?') ||
+    (github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '') &&
+      github.event.client_payload.source_action == 'scheduled_normal_backfill' &&
+      format('Review scheduled normal item {0} rev {1}', github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || '?', github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision || '?') ||
+    (github.event_name == 'repository_dispatch' && github.event.client_payload.queue_lease_id != '') &&
       format('Review exact item {0} rev {1} head {2}', github.event.client_payload.queue_claim.item_key || github.event.client_payload.item_key || '?', github.event.client_payload.queue_claim.lease_revision || github.event.client_payload.lease_revision || '?', github.event.client_payload.queue_claim.source_head_sha || github.event.client_payload.source_head_sha || 'na') ||
     (github.event_name == 'repository_dispatch' && github.event.client_payload.dispatch_key != '') &&
       format('Review event item {0}#{1} [{2}]', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.item_number || '?', github.event.client_payload.dispatch_key) ||
@@ -2496,6 +2502,13 @@ jobs:
       batch_size: ${{ steps.mode.outputs.batch_size }}
       codex_timeout_ms: ${{ steps.mode.outputs.codex_timeout_ms }}
       hot_intake: ${{ steps.mode.outputs.hot_intake }}
+      queue_feed: ${{ steps.mode.outputs.queue_feed }}
+      queue_offered: ${{ steps.enqueue-scheduled.outputs.offered || '0' }}
+      queue_attempted: ${{ steps.enqueue-scheduled.outputs.attempted || '0' }}
+      queue_enqueued: ${{ steps.enqueue-scheduled.outputs.queued || '0' }}
+      queue_deduped: ${{ steps.enqueue-scheduled.outputs.deduped || '0' }}
+      queue_shed: ${{ steps.enqueue-scheduled.outputs.shed || '0' }}
+      queue_deferred: ${{ steps.enqueue-scheduled.outputs.deferred || '0' }}
       matrix: ${{ steps.select.outputs.matrix }}
       max_pages: ${{ steps.mode.outputs.max_pages }}
       min_active_shards: ${{ steps.mode.outputs.min_active_shards }}
@@ -2633,7 +2646,7 @@ jobs:
               for run_status in in_progress pending queued waiting requested; do
                 gh api "repos/${{ github.repository }}/actions/runs?per_page=100&status=${run_status}" \
                   --paginate \
-                  --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
+                  --jq '.workflow_runs[] | {databaseId:.id, workflowPath:.path, displayTitle:.display_title, event:.event, status:.status, createdAt:.created_at, updatedAt:.updated_at}' 2>/dev/null \
                   || true
               done
             } | jq -s 'unique_by(.databaseId)'
@@ -2646,19 +2659,19 @@ jobs:
               || printf '0'
           }
           active_sweep_exact_workers() {
-            local runs total id title status jobs_json active_shards total_shards
+            local runs total id title status run_event jobs_json active_shards total_shards
             local reserved_shards hard_cap requested_shards item_numbers commas item_count
             total=0
             hard_cap="$(limit review_shards.hard_cap)"
             runs="$(printf '%s' "$ACTIVE_RUNS_JSON" \
-              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select((.displayTitle | startswith("Review event item ")) or (.displayTitle | startswith("Review event items "))) | [.databaseId, .displayTitle, .status] | @tsv' 2>/dev/null || true)"
-            while IFS=$'\t' read -r id title status; do
+              | STALE_QUEUED_CUTOFF="$STALE_QUEUED_CUTOFF" jq -r '.[] | select(.workflowPath == ".github/workflows/sweep.yml") | select(.status == "in_progress" or ((.status == "pending" or .status == "queued" or .status == "waiting" or .status == "requested") and ((.updatedAt // .createdAt // "") >= env.STALE_QUEUED_CUTOFF))) | select((.displayTitle | startswith("Review exact item ")) or (.displayTitle | startswith("Review scheduled hot item ")) or (.displayTitle | startswith("Review scheduled normal item ")) or (.event == "workflow_dispatch" and ((.displayTitle | startswith("Review event item ")) or (.displayTitle | startswith("Review event items "))))) | [.databaseId, .displayTitle, .status, .event] | @tsv' 2>/dev/null || true)"
+            while IFS=$'\t' read -r id title status run_event; do
               if [ -z "$id" ]; then
                 continue
               fi
               active_shards=0
               total_shards=0
-              if [[ "$title" == Review\ event\ item\ * ]]; then
+              if [[ "$title" == Review\ exact\ item\ * ]] || [[ "$title" == Review\ scheduled\ hot\ item\ * ]] || [[ "$title" == Review\ scheduled\ normal\ item\ * ]] || { [ "$run_event" = "workflow_dispatch" ] && [[ "$title" == Review\ event\ item\ * ]]; }; then
                 active_shards=1
                 total=$((total + active_shards))
                 continue
@@ -2776,6 +2789,7 @@ jobs:
             echo "queue pressure: $pressure_level ($pressure_numbers) — hot_intake $hot_intake_unpressured->$hot_intake_shards, normal_review $normal_unpressured->$normal_shards"
           fi
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
+          queue_feed="${{ ((github.event_name == 'repository_dispatch' && github.event.action == 'clawsweeper_target_sweep') || github.event_name == 'schedule') && 'true' || 'false' }}"
           target_repo="${{ steps.target.outputs.target_repo }}"
           if [ "$hot_intake" = "true" ] && [ -n "$exact_item" ]; then
             batch_size="1"
@@ -2812,6 +2826,14 @@ jobs:
             min_active_shards="0"
             min_backfill_review_age_minutes="360"
           fi
+          if [ "$queue_feed" = "true" ] && [ -z "$exact_item" ]; then
+            # The Durable Object turns every selected item into an independent exact-review
+            # workflow. Plan a bounded feed batch here; the Worker owns the global 200/hour
+            # admission target and queue backpressure across overlapping target sweeps.
+            batch_size="20"
+            shard_count="1"
+            min_active_shards="0"
+          fi
           if ! [[ "$shard_count" =~ ^[0-9]+$ ]]; then
             shard_count="$normal_shards"
           fi
@@ -2835,6 +2857,7 @@ jobs:
             echo "batch_size=$batch_size"
             echo "codex_timeout_ms=${{ github.event.client_payload.review_options.codex_timeout_ms || github.event.client_payload.codex_timeout_ms || github.event.inputs.codex_timeout_ms || vars.CLAWSWEEPER_CODEX_TIMEOUT_MS || '1200000' }}"
             echo "hot_intake=$hot_intake"
+            echo "queue_feed=$queue_feed"
             echo "max_pages=$max_pages"
             echo "min_active_shards=$min_active_shards"
             echo "min_backfill_review_age_minutes=$min_backfill_review_age_minutes"
@@ -2887,7 +2910,47 @@ jobs:
             --shard-count "$SHARD_COUNT" >> "$GITHUB_OUTPUT"
           cat plan.json
 
+      - name: Enqueue scheduled review candidates
+        id: enqueue-scheduled
+        if: ${{ steps.mode.outputs.queue_feed == 'true' && steps.select.outputs.planned_count != '0' }}
+        working-directory: clawsweeper
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+        run: |
+          set -euo pipefail
+          lane="normal_backfill"
+          if [ "${{ steps.mode.outputs.hot_intake }}" = "true" ]; then
+            lane="hot_intake"
+          fi
+          result="$(pnpm run --silent repair:scheduled-review-enqueue -- \
+            --plan plan.json \
+            --lane "$lane" \
+            --target-repo "${{ steps.target.outputs.target_repo }}" \
+            --target-branch "${{ steps.target.outputs.target_branch }}" \
+            --queue-url "$QUEUE_URL" \
+            --delivery-prefix "scheduled:${{ github.run_id }}:${{ github.run_attempt }}")"
+          jq -e '.offered >= .attempted and .attempted >= (.queued + .deduped + .shed + .rejected)' <<<"$result" >/dev/null
+          {
+            echo "offered=$(jq -r .offered <<<"$result")"
+            echo "attempted=$(jq -r .attempted <<<"$result")"
+            echo "queued=$(jq -r .queued <<<"$result")"
+            echo "deduped=$(jq -r .deduped <<<"$result")"
+            echo "shed=$(jq -r .shed <<<"$result")"
+            echo "deferred=$(jq -r .deferred <<<"$result")"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Scheduled review funnel"
+            echo
+            echo "| Selected | Attempted | Enqueued | Deduped | Shed | Deferred |"
+            echo "| ---: | ---: | ---: | ---: | ---: | ---: |"
+            echo "| $(jq -r .offered <<<"$result") | $(jq -r .attempted <<<"$result") | $(jq -r .queued <<<"$result") | $(jq -r .deduped <<<"$result") | $(jq -r .shed <<<"$result") | $(jq -r .deferred <<<"$result") |"
+            echo
+            echo "Selected candidate age (hours): p50 $(jq -r '.ageHours.p50 // "n/a"' <<<"$result"), p90 $(jq -r '.ageHours.p90 // "n/a"' <<<"$result"), oldest $(jq -r '.ageHours.max // "n/a"' <<<"$result")."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Prepare review runtime artifact
+        if: ${{ steps.mode.outputs.queue_feed != 'true' }}
         working-directory: clawsweeper
         env:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -2901,6 +2964,7 @@ jobs:
           tar -czf .artifacts/review-runtime.tar.gz -C .artifacts/review-runtime .
 
       - uses: actions/upload-artifact@v7
+        if: ${{ steps.mode.outputs.queue_feed != 'true' }}
         with:
           name: clawsweeper-runtime-dist
           path: clawsweeper/.artifacts/review-runtime.tar.gz
@@ -2909,7 +2973,7 @@ jobs:
           retention-days: 1
 
       - name: Publish planning status
-        if: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.apply_existing != 'true') && (steps.mode.outputs.hot_intake != 'true' || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
+        if: ${{ steps.mode.outputs.queue_feed != 'true' && (github.event_name != 'workflow_dispatch' || github.event.inputs.apply_existing != 'true') && (steps.mode.outputs.hot_intake != 'true' || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
         continue-on-error: true
         working-directory: clawsweeper
         env:
@@ -2940,6 +3004,7 @@ jobs:
   review:
     name: Review shard ${{ matrix.shard }} · ${{ needs.plan.outputs.target_repo }}#${{ matrix.item_numbers }}
     needs: plan
+    if: ${{ needs.plan.outputs.queue_feed != 'true' }}
     runs-on: ${{ vars.CLAWSWEEPER_REVIEW_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 75
     continue-on-error: true
@@ -3288,7 +3353,7 @@ jobs:
   publish:
     name: Publish review artifacts
     needs: [plan, review]
-    if: ${{ always() && needs.plan.result == 'success' && needs.review.result != 'cancelled' && needs.plan.outputs.target_repo != '' && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.queue_feed != 'true' && needs.review.result != 'cancelled' && needs.plan.outputs.target_repo != '' && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && !((github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_existing == 'true' || github.event.inputs.audit_dashboard == 'true')) || (github.event_name == 'schedule' && ((github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '6,21,36,51 * * * *') || (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *')))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -3860,7 +3925,7 @@ jobs:
   recover-review-failures:
     name: Recover failed review shards
     needs: [plan, review, publish]
-    if: ${{ always() && needs.plan.result == 'success' && needs.review.result != 'skipped' && !contains(github.event.inputs.additional_prompt || '', '[clawsweeper-recovery-attempt=1]') && needs.plan.outputs.planned_item_numbers != '' && github.event_name != 'repository_dispatch' }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.queue_feed != 'true' && needs.review.result != 'skipped' && !contains(github.event.inputs.additional_prompt || '', '[clawsweeper-recovery-attempt=1]') && needs.plan.outputs.planned_item_numbers != '' && github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Routed scheduled review through the durable exact-review queue, raised each target plan from one to 20 candidates, and added oldest-age funnel telemetry plus a fleet-wide 200-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
 - Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.
 - Doubled exact-review admission to 128 global and 120 per target with a separate 194-slot Actions budget that preserves verdict publication at full review load, doubled scheduled fleet review fanout and canonical publication batch preparation, prioritized six-day oldest-review coverage before hot-item churn, exposed a six-hour fleet coverage summary, and raised automatic apply to 40 closes with proportional scan/runtime budgets without changing close eligibility.
 - Completed the Cloudflare-canonical state migration: records publish only to the Durable Object, action ledgers and assets publish only to R2, canonical-only workflows no longer check out `clawsweeper-state`, the former materializer only compacts the legacy append window, and the remaining `jobs`/`results`/`notifications`/apply-report Git writers use the Durable Object coordinator without Git lease refs or rebuild recovery.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -66,6 +66,8 @@ const FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION = "failed_review_shard_recovery
 const EXACT_REVIEW_ARTIFACT_PUBLISH_SOURCE_ACTION = "exact_review_artifact_publish";
 const EXACT_REVIEW_ARTIFACT_RETENTION_RECOVERY_SOURCE_ACTION = "artifact_retention_recovery";
 const EXACT_REVIEW_SOURCE_DRIFT_REQUEUE_SOURCE_ACTION = "source_drift_requeue";
+const EXACT_REVIEW_SCHEDULED_HOT_SOURCE_ACTION = "scheduled_hot_intake";
+const EXACT_REVIEW_SCHEDULED_NORMAL_SOURCE_ACTION = "scheduled_normal_backfill";
 // Direct publication synthesizes its receipt inside the Durable Object and does
 // not have a state-batch artifact source SHA. Keep that path out of the
 // historical state-batch reconciliation below.
@@ -410,6 +412,11 @@ const DEFAULT_EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = 60_000;
 const DEFAULT_EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = 90_000;
 const DEFAULT_EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = 3 * 60_000;
 const DEFAULT_EXACT_REVIEW_PENDING_SOFT_LIMIT = 300;
+const DEFAULT_EXACT_REVIEW_TARGET_RATE_PER_HOUR = 200;
+const DEFAULT_EXACT_REVIEW_TARGET_BURST = 50;
+const EXACT_REVIEW_SCHEDULED_FEED_KEY_PREFIX = "exact-review-scheduled-feed:v1";
+type ExactReviewScheduledLane = "hot_intake" | "normal_backfill";
+type ExactReviewScheduledBucket = ExactReviewScheduledLane | "global";
 const EXACT_REVIEW_COMPLETION_RETRY_MAX_MS = 2 * 60 * 60 * 1000;
 const EXACT_REVIEW_ARTIFACT_RETRY_MAX_MS = 80 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_PUBLICATION_TRANSIENT_RETRY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -1250,6 +1257,15 @@ export class ExactReviewQueue {
           }
         }
         const current = state.items[key];
+        if (current && exactReviewScheduledLane(decision)) {
+          this.writeStateSync(state);
+          return {
+            deduped: true as const,
+            scheduled: true as const,
+            key,
+            state,
+          };
+        }
         let supersededRunId: string | null = null;
         let supersessionAudit: ExactReviewSupersessionAudit | null = null;
         let ingressAdmitted = false;
@@ -1357,13 +1373,25 @@ export class ExactReviewQueue {
         } else {
           if (
             !decision.publication &&
-            isLowPriorityExactReviewDecision(decision) &&
+            (isLowPriorityExactReviewDecision(decision) || exactReviewScheduledLane(decision)) &&
             exactReviewQueuePendingCount(state) >= exactReviewPendingSoftLimit(this.env)
           ) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
             this.writeStateSync(state);
             this.incrementQueueMetricsSync({ reviewShed: 1 });
-            return { shed: true as const };
+            return { shed: true as const, reason: "backpressure" as const };
+          }
+          if (
+            exactReviewScheduledLane(decision) &&
+            !this.takeScheduledReviewTokenSync(decision, now)
+          ) {
+            state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
+            this.writeStateSync(state);
+            this.incrementQueueMetricsSync({ reviewShed: 1 });
+            return { shed: true as const, reason: "scheduled_rate" as const };
+          }
+          if (!decision.publication && !exactReviewScheduledLane(decision)) {
+            this.consumeScheduledReviewCapacitySync(now);
           }
           state.items[key] = {
             key,
@@ -1440,6 +1468,12 @@ export class ExactReviewQueue {
                   dedupe_reason: "unchanged_pull_request_edit",
                 }
               : {}),
+            ...("scheduled" in accepted && accepted.scheduled
+              ? {
+                  dedupe_scope: "scheduled_queue_item",
+                  dedupe_reason: "item_already_pending_or_active",
+                }
+              : {}),
             ...("staleSource" in accepted && accepted.staleSource ? { stale_source: true } : {}),
             ...(accepted.superseded
               ? {
@@ -1456,7 +1490,7 @@ export class ExactReviewQueue {
         );
       }
       if (accepted.shed) {
-        return json({ ok: true, shed: true, reason: "backpressure" }, 202);
+        return json({ ok: true, shed: true, reason: accepted.reason }, 202);
       }
       await this.scheduleNext(accepted.state, now);
       return json(
@@ -2789,6 +2823,7 @@ export class ExactReviewQueue {
           },
         },
         delivery_receipts: this.deliveryReceiptCountSync(),
+        scheduled_feed: this.scheduledReviewFeedStatusSync(now),
         review_telemetry_health: reviewTelemetryHealth,
         reservation_claim_observability: reservationClaimObservability,
         state_writer: { ...stateWriter, coordinator: stateWriterCoordinator },
@@ -6421,6 +6456,72 @@ export class ExactReviewQueue {
       this.env,
       this.storage.kv.get(EXACT_REVIEW_PUBLICATION_CONTROL_KEY),
     );
+  }
+
+  private takeScheduledReviewTokenSync(decision: ExactReviewDecision, now: number) {
+    const lane = exactReviewScheduledLane(decision);
+    if (!lane) return true;
+    const global = this.scheduledReviewBucketSync("global", now);
+    const bucket = this.scheduledReviewBucketSync(lane, now);
+    const admitted = global.tokens >= 1 && bucket.tokens >= 1;
+    this.storage.kv.put(exactReviewScheduledFeedKey("global"), {
+      tokens: admitted ? global.tokens - 1 : global.tokens,
+      updatedAt: now,
+    });
+    this.storage.kv.put(exactReviewScheduledFeedKey(lane), {
+      tokens: admitted ? bucket.tokens - 1 : bucket.tokens,
+      updatedAt: now,
+    });
+    return admitted;
+  }
+
+  private consumeScheduledReviewCapacitySync(now: number) {
+    const global = this.scheduledReviewBucketSync("global", now);
+    this.storage.kv.put(exactReviewScheduledFeedKey("global"), {
+      tokens: Math.max(-global.burst, global.tokens - 1),
+      updatedAt: now,
+    });
+  }
+
+  private scheduledReviewBucketSync(lane: ExactReviewScheduledBucket, now: number) {
+    const ratePerHour = exactReviewScheduledRatePerHour(this.env, lane);
+    const burst = exactReviewScheduledBurst(this.env, lane);
+    const stored = objectValue(this.storage.kv.get(exactReviewScheduledFeedKey(lane)));
+    const updatedAt = Number(stored.updatedAt);
+    const storedTokens = Number(stored.tokens);
+    if (!Number.isFinite(updatedAt) || !Number.isFinite(storedTokens)) {
+      return { tokens: burst, updatedAt: now, ratePerHour, burst };
+    }
+    const elapsedMs = Math.max(0, now - updatedAt);
+    return {
+      tokens: Math.min(burst, Math.max(0, storedTokens) + (elapsedMs * ratePerHour) / 3_600_000),
+      updatedAt: now,
+      ratePerHour,
+      burst,
+    };
+  }
+
+  private scheduledReviewFeedStatusSync(now: number) {
+    const global = this.scheduledReviewBucketSync("global", now);
+    const hot = this.scheduledReviewBucketSync("hot_intake", now);
+    const normal = this.scheduledReviewBucketSync("normal_backfill", now);
+    return {
+      target_rate_per_hour: global.ratePerHour,
+      burst: global.burst,
+      token_balance: Math.floor(global.tokens),
+      lanes: {
+        hot_intake: {
+          target_rate_per_hour: hot.ratePerHour,
+          burst: hot.burst,
+          token_balance: Math.floor(hot.tokens),
+        },
+        normal_backfill: {
+          target_rate_per_hour: normal.ratePerHour,
+          burst: normal.burst,
+          token_balance: Math.floor(normal.tokens),
+        },
+      },
+    };
   }
 
   private refreshPublicationControlSync(state: ExactReviewQueueState, now: number) {
@@ -10641,6 +10742,50 @@ function exactReviewPendingSoftLimit(env) {
       numberFrom(env.EXACT_REVIEW_PENDING_SOFT_LIMIT, DEFAULT_EXACT_REVIEW_PENDING_SOFT_LIMIT),
     ),
   );
+}
+
+function exactReviewScheduledLane(decision: ExactReviewDecision): ExactReviewScheduledLane | null {
+  if (decision.sourceAction === EXACT_REVIEW_SCHEDULED_HOT_SOURCE_ACTION) return "hot_intake";
+  if (decision.sourceAction === EXACT_REVIEW_SCHEDULED_NORMAL_SOURCE_ACTION) {
+    return "normal_backfill";
+  }
+  return null;
+}
+
+function exactReviewScheduledFeedKey(lane: ExactReviewScheduledBucket) {
+  return `${EXACT_REVIEW_SCHEDULED_FEED_KEY_PREFIX}:${lane}`;
+}
+
+function exactReviewScheduledRatePerHour(env, lane: ExactReviewScheduledBucket) {
+  const total = Math.max(
+    2,
+    Math.min(
+      2_000,
+      Math.floor(
+        numberFrom(
+          env.EXACT_REVIEW_TARGET_RATE_PER_HOUR,
+          DEFAULT_EXACT_REVIEW_TARGET_RATE_PER_HOUR,
+        ),
+      ),
+    ),
+  );
+  if (lane === "global") return total;
+  const hot = Math.max(1, Math.floor(total * 0.35));
+  return lane === "hot_intake" ? hot : total - hot;
+}
+
+function exactReviewScheduledBurst(env, lane: ExactReviewScheduledBucket) {
+  const total = Math.max(
+    2,
+    Math.min(
+      exactReviewScheduledRatePerHour(env, "hot_intake") +
+        exactReviewScheduledRatePerHour(env, "normal_backfill"),
+      Math.floor(numberFrom(env.EXACT_REVIEW_TARGET_BURST, DEFAULT_EXACT_REVIEW_TARGET_BURST)),
+    ),
+  );
+  if (lane === "global") return total;
+  const hot = Math.max(1, Math.floor(total * 0.35));
+  return lane === "hot_intake" ? hot : total - hot;
 }
 
 function stateAppendMaxPendingRows(env) {

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -64,6 +64,8 @@ EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = "60000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = "90000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "300"
+EXACT_REVIEW_TARGET_RATE_PER_HOUR = "200"
+EXACT_REVIEW_TARGET_BURST = "50"
 # Keep each mutation lease at 8 while allowing four isolated workflows to prepare
 # concurrently. Final commits still cross the single state-writer coordinator.
 # A full-window publish moves ~2k paths and observed ~40 min; the drain lease

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -108,9 +108,11 @@ Formula summary:
 
 ## Dynamic Scheduling
 
-Normal review, hot intake, and commit review are background lanes. Before they
-dispatch, the workflow asks `pnpm run workflow -- worker-limit <lane>` for the
-current allowance.
+Manual normal review, manual hot intake, and commit review are background lanes.
+Before they dispatch, the workflow asks
+`pnpm run workflow -- worker-limit <lane>` for the current allowance. Automated
+normal and hot cycles enqueue exact-review work instead, so the Durable Object's
+rate, backlog, and claim limits own their concurrency.
 
 The scheduler does this for background lanes:
 
@@ -147,9 +149,10 @@ unset, empty, or invalid values use the defaults.
 | `CLAWSWEEPER_QUEUE_PRESSURE_SOFT_AGE_MS`  | 1800000 |
 | `CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS`  | 7200000 |
 
-Only normal review, hot intake, and commit review use this pressure multiplier.
-Repair, assist, issue implementation, cluster repair, and exact-item review keep
-their existing priority budgets.
+Only manual normal review, manual hot intake, and commit review use this pressure
+multiplier. Scheduled review uses the queue's 300-item soft limit and 200/hour
+admission target. Repair, assist, issue implementation, cluster repair, and
+exact-item review keep their existing priority budgets.
 
 Background planner jobs serialize per target repository. A sweep that is still
 planning, queued, or expanding its matrix reserves its quiet lane size. Once
@@ -200,8 +203,14 @@ on the lease claim tuple, so they cannot terminate the sole valid owner. An olde
 unclaimed workflow cannot pass the replacement lease tuple and exits before
 review compute. Explicit command work and publication work bypass the delay.
 When pending depth reaches
-`EXACT_REVIEW_PENDING_SOFT_LIMIT` (300 by default), new recovery-only work is
-shed; existing items, webhook events, commands, and publications remain admitted.
+`EXACT_REVIEW_PENDING_SOFT_LIMIT` (300 by default), new recovery and scheduled
+feed work is shed; existing items, webhook events, commands, and publications
+remain admitted. All newly queued review work debits a durable 200-review/hour
+budget with a 50-item burst. Organic work is always admitted and consumes the
+budget first; scheduled work fills the remainder and is split 35% hot intake and
+65% normal backfill so hot churn cannot starve oldest-first coverage. Re-offering an item
+that is already pending, dispatching, or leased is a semantic dedupe: it does not
+advance the queue revision, revoke a lease, or count as new work.
 
 Exact-review result publication has a separate adaptive Actions lane. Source
 fallbacks start at 24 and rise in steps of 8 up to 48; production currently
@@ -240,7 +249,10 @@ Candidates absent from those pages fall back to exact run lookup. This keeps
 steady-state GitHub API work constant without losing an older claim, while a
 terminal burst does not consume one Actions runner per review. Unclaimed
 dispatches expire after six minutes and receive a new opaque lease; delayed
-workflows holding the expired lease cannot claim it.
+workflows holding the expired lease cannot claim it. The six-minute timer covers
+only the GitHub dispatch-to-claim handoff. Once the first workflow step claims
+the item, the 130-minute execution lease and one-minute heartbeats take over, so
+the handoff recycler cannot race a normal four-minute review completion.
 Run-attempt binding and a per-claim generation check keep delayed terminal
 decisions from releasing a later rerun; queued and in-progress runs are never
 released. If a workflow never claims or completes, the Durable Object reclaims
@@ -262,9 +274,10 @@ resolve, and exact-revision supersede records without exposing decisions publicl
 
 Examples with the current config:
 
-- Quiet system: scheduled and manual normal review can request 89 shards, with
-  104 background slots available after reserving 16 for interactive work and 8
-  for matrix expansion.
+- Quiet system: manual normal review can request 89 shards, with 104 background
+  slots available after reserving 16 for interactive work and 8 for matrix
+  expansion. Scheduled plans offer up to 20 candidates to the 200/hour durable
+  admission budget instead of starting matrix shards.
 - 4 active repair workers and 96 active background workers: normal review gets
   4 because `128 - 16 interactive reserve - 8 expansion reserve - 4 priority
   - 96 background = 4`.
@@ -318,7 +331,12 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS` overrides the 180,000 ms maximum
   coalescing window measured from the item's first enqueue.
 - `EXACT_REVIEW_PENDING_SOFT_LIMIT` overrides the pending-depth threshold for
-  shedding new recovery-only exact-review work; the default is 300.
+  shedding new recovery and scheduled exact-review work; the default is 300.
+- `EXACT_REVIEW_TARGET_RATE_PER_HOUR` sets the fleet-wide review
+  admission target; the default is 200, organic reviews consume it first, and
+  the scheduled remainder is split 35/65 between hot intake and normal backfill.
+- `EXACT_REVIEW_TARGET_BURST` bounds the scheduled admission burst; the
+  default is 50 and uses the same lane split.
 - `EXACT_REVIEW_HEARTBEAT_GRACE_MS` overrides the 1,200,000 ms exact-review worker heartbeat
   grace. It is clamped to at least 420,000 ms so a configured grace can never dip
   near the one-minute worker heartbeat interval during scheduler or network stalls.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -241,31 +241,34 @@ Current defaults:
 
 - exact event review: 1 shard, 1 item
 - exact manual hot intake: 1 shard, 1 item
-- broad hot intake: up to 44 shards when quiet, batch size 1, scans up to 10
-  GitHub pages
-- scheduled normal backfill: up to 89 shards when quiet, batch size 1, scans up
-  to 250 GitHub pages after reserving interactive and expansion capacity
-- normal active floor: 38 shards for `openclaw/openclaw` scheduled runs and
-  workflow-dispatch continuations; stale current-review backfill is eligible
-  after 6 hours
+- scheduled hot intake and normal backfill: select up to 20 due items per target
+  cycle, then enqueue each item through the durable exact-review queue; every
+  admitted item receives its own parallel workflow
+- total review admission target: 200 items/hour across the fleet; organic work
+  consumes the budget first and scheduled backfill fills the remainder, split
+  35% hot intake and 65% normal backfill, with a 50-item burst
+- fleet fanout: 20 hot targets every 15 minutes and 12 normal targets hourly;
+  each target cycle can offer up to 20 due items to the shared admission budget
+- manual broad hot intake: up to 44 shards when quiet
 - manual normal backfill: defaults to 89 shards, batch size 3, and scans up to
   250 GitHub pages unless overridden
 
 The hard planner cap is 128 shards. The workflow clamps invalid or larger
 `shard_count` inputs to 128.
 
-Broad background review also clamps manual `shard_count` input to the current
+Broad background review clamps manual `shard_count` input to the current
 lane allowance from `worker-limit`. Pending or planning background sweeps reserve
 their quiet lane size until their matrix shards exist, so overlapping manual or
-scheduled dispatches cannot temporarily exceed the shared worker budget while
-GitHub is still expanding jobs.
+operator dispatches cannot temporarily exceed the shared worker budget while
+GitHub is still expanding jobs. Scheduled feeds use one planner shard because
+the Durable Object, not the matrix, owns review concurrency.
 
-Planning is also the runtime build point for matrix review. The plan job installs
+Planning is also the runtime build point for manual matrix review. The plan job installs
 with pinned Node 24 and `pnpm@11.10.0`, builds `dist/` once, and uploads that
 runtime artifact. Review shards download the built `dist/` and run
 `node dist/clawsweeper.js review` directly instead of running a per-shard pnpm
-install and build. This keeps 44-89 shard waves from stampeding the npm
-registry or Corepack metadata endpoints.
+install and build. Scheduled queue feeds skip this artifact because each exact
+review workflow builds from its immutable queue decision.
 
 Each review shard also wraps the review command in a shell timeout derived from
 the per-item Codex timeout and the shard batch size, with a 70-minute ceiling so
@@ -280,13 +283,12 @@ hydrating historical records. Publish and apply jobs keep full state history
 because they may rebase and push generated records.
 
 Normal backfill runs every 5 minutes for `openclaw/openclaw`. Its planner
-serializes per target repository, but the run-scoped workflow group allows a
-new wave to overlap an older wave that is finishing slow shards or publishing.
-One quiet-system run can hold up to 89 Codex review shards with up to three
-items per shard; each later planner subtracts the older wave's live shards
-before choosing its own matrix size.
+serializes per target repository, selects globally before sharding, and offers
+the oldest due candidates to the durable queue. Queue admission is fleet-wide,
+so overlapping core and fanout cycles fill only the residual of the configured
+200/hour model-spend target after organic review demand.
 
-The quiet-system ceiling is not a promise that every scheduled run dispatches
+The manual quiet-system ceiling is not a promise that every operator run dispatches
 that many shards. The `mode` step checks active repair workers, exact-item sweep
 runs, commit-review pages, and live normal/hot review shard jobs, then asks
 `worker-limit normal_review` or `worker-limit hot_intake` for the current
@@ -300,13 +302,28 @@ Background lanes also subtract an 8-worker expansion reserve so independently
 planned exact-item and commit-review runs have room to start without pushing the
 live Codex count past the global budget.
 
-The active floor is not a separate lane and does not change close/apply safety.
+The manual active floor is not a separate lane and does not change close/apply safety.
 It only changes normal planning when due backlog is below the desired floor:
 after selecting all due candidates, the planner fills up to 38 nonempty shards
 with eligible items whose latest complete review is at least 6 hours old.
 Capacity status reports this as `floor: due backlog below active floor`. If the
 central worker scheduler returns fewer than 38 allowed shards, the smaller
 worker allowance wins.
+
+Scheduled planning does not use the active-floor backfill. It selects only due
+items, records each candidate's previous-review age in `plan.json`, and writes a
+run-summary funnel for selected, attempted, enqueued, deduped, shed, and deferred
+items. The queue exposes the configured rate, burst, and currently available
+token balance under `scheduled_feed` in `GET /api/exact-review-queue`.
+
+At the configured target, the installation-token estimate is
+`200 reviews/hour * 30 calls/review = 6,000 calls/hour`. That is half of the
+roughly 12,000-call or 400-review/hour ceiling, leaving equivalent headroom for
+planning, retries, publication, and traffic variance. At a 4.1-minute mean
+service time, 200/hour needs about `200 * 4.1 / 60 = 13.7` concurrent review
+workers, well below the 120 per-target and 128 global claim limits. Model usage
+is nevertheless about five times a 40-review/hour baseline; lower
+`EXACT_REVIEW_TARGET_RATE_PER_HOUR` to dial spend down.
 
 On saturated queues, normal planning reads the complete bounded open-item scan
 before selecting candidates. For the current largest repository this is about
@@ -613,10 +630,11 @@ can be newer than local files.
 
 ## Common Changes
 
-To change how many normal Codex sessions can run, update both
-`.github/workflows/sweep.yml` and the planner constants in `src/clawsweeper.ts`.
-The workflow can otherwise continue with stale defaults during continuation
-runs.
+To change review spend, set
+`EXACT_REVIEW_TARGET_RATE_PER_HOUR`; the Worker applies the fleet-wide rate
+while the workflow's 20-item plan batch keeps enough candidates available. To
+change manual normal Codex sessions, update the worker limits and workflow
+defaults together.
 
 To change review cadence, update the cadence constants and the scheduler bucket
 logic in `src/clawsweeper.ts`, then update dashboard labels and this document.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -315,6 +315,9 @@ items, records each candidate's previous-review age in `plan.json`, and writes a
 run-summary funnel for selected, attempted, enqueued, deduped, shed, and deferred
 items. The queue exposes the configured rate, burst, and currently available
 token balance under `scheduled_feed` in `GET /api/exact-review-queue`.
+The producer probes that field before its first enqueue and fails closed while
+an older Worker is still deployed, preventing a workflow-first rollout from
+bypassing the rate limiter.
 
 At the configured target, the installation-token estimate is
 `200 reviews/hour * 30 calls/review = 6,000 calls/hour`. That is half of the

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "repair:spam-scan": "node dist/repair/spam-scanner.js",
     "repair:exact-review-bundle": "node dist/repair/exact-review-bundle-cli.js",
     "repair:exact-review-queue-maintenance": "node dist/repair/exact-review-queue-maintenance.js",
+    "repair:scheduled-review-enqueue": "node dist/repair/scheduled-review-enqueue.js",
     "repair:exact-review-dead-letters": "node scripts/exact-review-dead-letter-operator.mjs",
     "repair:exact-review-batch": "node dist/repair/exact-review-batch-cli.js",
     "repair:exact-review-direct-publication": "node dist/repair/exact-review-direct-publication.js",

--- a/scripts/review-run-observer.mjs
+++ b/scripts/review-run-observer.mjs
@@ -39,22 +39,26 @@ export function classifyReviewRun(run) {
   const event = String(run.event || "");
   if (/^(Apply |Sync |Audit |Fan out )/.test(title)) return null;
   let triggerLane;
-  if (title.startsWith("Review event item")) triggerLane = "exact_event";
+  if (title.startsWith("Review scheduled hot item")) triggerLane = "hot_intake";
+  else if (title.startsWith("Review scheduled normal item")) triggerLane = "normal_backfill";
+  else if (title.startsWith("Review event item")) triggerLane = "exact_event";
   else if (/^Review hot (?:ClawSweeper items|target repo)/.test(title)) triggerLane = "hot_intake";
   else if (title.startsWith("Retry failed Codex reviews")) triggerLane = "recovery";
   else if (/^Review (?:target repo|ClawSweeper items)/.test(title)) triggerLane = "normal_backfill";
   else return null;
 
   const command = /\[(?:router-|command:)/i.test(title);
-  const triggerOrigin = command
-    ? "command"
-    : event === "schedule"
-      ? "schedule"
-      : event === "workflow_dispatch"
-        ? "manual"
-        : event === "repository_dispatch"
-          ? "webhook"
-          : "system";
+  const triggerOrigin = title.startsWith("Review scheduled ")
+    ? "schedule"
+    : command
+      ? "command"
+      : event === "schedule"
+        ? "schedule"
+        : event === "workflow_dispatch"
+          ? "manual"
+          : event === "repository_dispatch"
+            ? "webhook"
+            : "system";
   const targetMatch = title.match(
     /\b(?:repo |item |items |for )([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?:#|\b)/,
   );

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1139,6 +1139,15 @@ interface PlanCandidateResult {
   oldestUnreviewedAt: string | undefined;
   capacityReason: string;
   floorBackfill: number;
+  selection: PlanSelectionTelemetry[];
+}
+
+interface PlanSelectionTelemetry {
+  itemNumber: number;
+  bucket: SchedulerDueCandidate["bucket"];
+  lastReviewedAt: string | null;
+  ageMs: number;
+  nextDueAt: string;
 }
 
 const DEFAULT_PLAN_BATCH_SIZE = 3;
@@ -9068,6 +9077,23 @@ function planCapacityReason(options: {
   return "under capacity: due backlog below planned capacity";
 }
 
+function planSelectionTelemetry(
+  selected: readonly DueCandidate[],
+  now: number,
+): PlanSelectionTelemetry[] {
+  return selected.map((candidate) => {
+    const createdAt = Date.parse(candidate.item.createdAt);
+    const referenceAt = candidate.reviewedAt > 0 ? candidate.reviewedAt : createdAt;
+    return {
+      itemNumber: candidate.item.number,
+      bucket: candidate.bucket,
+      lastReviewedAt: candidate.review?.reviewedAt ?? null,
+      ageMs: Number.isFinite(referenceAt) ? Math.max(0, now - referenceAt) : 0,
+      nextDueAt: new Date(candidate.nextDueAt).toISOString(),
+    };
+  });
+}
+
 function planCandidates(options: {
   batchSize: number;
   maxPages: number;
@@ -9103,6 +9129,7 @@ function planCandidates(options: {
       activeCodexTarget: activeCodexTarget(shards),
       oldestUnreviewedAt: undefined,
       floorBackfill: 0,
+      selection: [],
       capacityReason: planCapacityReason({
         selectedCount: candidates.length,
         dueBacklog: candidates.length,
@@ -9125,6 +9152,7 @@ function planCandidates(options: {
       activeCodexTarget: activeCodexTarget(shards),
       oldestUnreviewedAt: undefined,
       floorBackfill: 0,
+      selection: [],
       capacityReason: planCapacityReason({
         selectedCount: candidates.length,
         dueBacklog: candidates.length,
@@ -9150,9 +9178,8 @@ function planCandidates(options: {
       );
       if (candidate) due.push(candidate);
     }
-    const candidates = selectDueCandidates(due, capacity, compareHotIntakeDueCandidates, now).map(
-      ({ item }) => item,
-    );
+    const selected = selectDueCandidates(due, capacity, compareHotIntakeDueCandidates, now);
+    const candidates = selected.map(({ item }) => item);
     const shards = Array.from(
       { length: Math.max(1, Math.min(shardCount, candidates.length || 1)) },
       (_, shard) => ({ shard, itemNumbers: [] as number[] }),
@@ -9169,6 +9196,7 @@ function planCandidates(options: {
       activeCodexTarget: activeCodexTarget(shards),
       oldestUnreviewedAt: oldestUnreviewedAt(due),
       floorBackfill: 0,
+      selection: planSelectionTelemetry(selected, now),
       capacityReason: planCapacityReason({
         selectedCount: candidates.length,
         dueBacklog: due.length,
@@ -9231,6 +9259,7 @@ function planCandidates(options: {
     activeCodexTarget: activeCodexTarget(shards),
     oldestUnreviewedAt: oldestUnreviewedAt(due),
     floorBackfill,
+    selection: planSelectionTelemetry(selected, now),
     capacityReason: planCapacityReason({
       selectedCount: candidates.length,
       dueBacklog: due.length,

--- a/src/repair/scheduled-review-enqueue.ts
+++ b/src/repair/scheduled-review-enqueue.ts
@@ -47,6 +47,23 @@ export async function enqueueScheduledReviewPlan(
   options: EnqueueOptions,
 ): Promise<ScheduledReviewEnqueueSummary> {
   const fetchImpl = options.fetchImpl ?? fetch;
+  for (const candidate of options.plan.candidates) validateCandidate(candidate, options.targetRepo);
+  const queueUrl = options.queueUrl.replace(/\/$/, "");
+  const capabilityResponse = await fetchImpl(`${queueUrl}/api/exact-review-queue`, {
+    signal: AbortSignal.timeout(20_000),
+  });
+  const capability = (await capabilityResponse.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const scheduledFeed = capability?.scheduled_feed as Record<string, unknown> | undefined;
+  if (
+    !capabilityResponse.ok ||
+    !scheduledFeed ||
+    !Number.isFinite(Number(scheduledFeed.target_rate_per_hour))
+  ) {
+    throw new Error("exact-review queue does not advertise scheduled feed admission");
+  }
   const ages = (options.plan.selection ?? [])
     .map((selection) => Number(selection.ageMs))
     .filter((age) => Number.isFinite(age) && age >= 0)
@@ -75,7 +92,6 @@ export async function enqueueScheduledReviewPlan(
   };
 
   for (const [index, candidate] of options.plan.candidates.entries()) {
-    validateCandidate(candidate, options.targetRepo);
     const payload = JSON.stringify({
       delivery_id: `${options.deliveryPrefix}:${index}:${candidate.number}`,
       decision: {
@@ -92,18 +108,15 @@ export async function enqueueScheduledReviewPlan(
     });
     const signature = `sha256=${createHmac("sha256", options.secret).update(payload).digest("hex")}`;
     summary.attempted += 1;
-    const response = await fetchImpl(
-      `${options.queueUrl.replace(/\/$/, "")}/internal/exact-review/enqueue`,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-clawsweeper-exact-review-signature": signature,
-        },
-        body: payload,
-        signal: AbortSignal.timeout(20_000),
+    const response = await fetchImpl(`${queueUrl}/internal/exact-review/enqueue`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-clawsweeper-exact-review-signature": signature,
       },
-    );
+      body: payload,
+      signal: AbortSignal.timeout(20_000),
+    });
     const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
     if (!response.ok || !body || body.ok !== true) {
       throw new Error(

--- a/src/repair/scheduled-review-enqueue.ts
+++ b/src/repair/scheduled-review-enqueue.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "./lib.js";
+
+type ScheduledReviewLane = "hot_intake" | "normal_backfill";
+
+type PlanCandidate = {
+  repo: string;
+  number: number;
+  kind: "issue" | "pull_request";
+  updatedAt: string;
+};
+
+type ScheduledReviewPlan = {
+  candidates: PlanCandidate[];
+  selection?: Array<{ ageMs?: number }>;
+};
+
+export type ScheduledReviewEnqueueSummary = {
+  lane: ScheduledReviewLane;
+  offered: number;
+  attempted: number;
+  queued: number;
+  deduped: number;
+  shed: number;
+  rateLimited: number;
+  backpressured: number;
+  rejected: number;
+  deferred: number;
+  ageHours: { p50: number | null; p90: number | null; max: number | null };
+};
+
+type EnqueueOptions = {
+  plan: ScheduledReviewPlan;
+  lane: ScheduledReviewLane;
+  targetRepo: string;
+  targetBranch: string;
+  queueUrl: string;
+  secret: string;
+  deliveryPrefix: string;
+  fetchImpl?: typeof fetch;
+};
+
+export async function enqueueScheduledReviewPlan(
+  options: EnqueueOptions,
+): Promise<ScheduledReviewEnqueueSummary> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const ages = (options.plan.selection ?? [])
+    .map((selection) => Number(selection.ageMs))
+    .filter((age) => Number.isFinite(age) && age >= 0)
+    .sort((left, right) => left - right);
+  const percentileHours = (quantile: number): number | null => {
+    if (!ages.length) return null;
+    const value = ages[Math.ceil(ages.length * quantile) - 1] ?? ages.at(-1);
+    return value === undefined ? null : Math.round((value / 3_600_000) * 10) / 10;
+  };
+  const summary: ScheduledReviewEnqueueSummary = {
+    lane: options.lane,
+    offered: options.plan.candidates.length,
+    attempted: 0,
+    queued: 0,
+    deduped: 0,
+    shed: 0,
+    rateLimited: 0,
+    backpressured: 0,
+    rejected: 0,
+    deferred: 0,
+    ageHours: {
+      p50: percentileHours(0.5),
+      p90: percentileHours(0.9),
+      max: percentileHours(1),
+    },
+  };
+
+  for (const [index, candidate] of options.plan.candidates.entries()) {
+    validateCandidate(candidate, options.targetRepo);
+    const payload = JSON.stringify({
+      delivery_id: `${options.deliveryPrefix}:${index}:${candidate.number}`,
+      decision: {
+        targetRepo: options.targetRepo,
+        targetBranch: options.targetBranch,
+        itemNumber: candidate.number,
+        itemKind: candidate.kind,
+        sourceEvent: candidate.kind === "pull_request" ? "pull_request" : "issues",
+        sourceAction:
+          options.lane === "hot_intake" ? "scheduled_hot_intake" : "scheduled_normal_backfill",
+        supersedesInProgress: false,
+        sourceUpdatedAt: candidate.updatedAt,
+      },
+    });
+    const signature = `sha256=${createHmac("sha256", options.secret).update(payload).digest("hex")}`;
+    summary.attempted += 1;
+    const response = await fetchImpl(
+      `${options.queueUrl.replace(/\/$/, "")}/internal/exact-review/enqueue`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        body: payload,
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!response.ok || !body || body.ok !== true) {
+      throw new Error(
+        `scheduled review queue rejected ${candidate.repo}#${candidate.number}: HTTP ${response.status}`,
+      );
+    }
+    if (body.queued === true) summary.queued += 1;
+    else if (body.deduped === true) summary.deduped += 1;
+    else if (body.shed === true) {
+      summary.shed += 1;
+      if (body.reason === "scheduled_rate") summary.rateLimited += 1;
+      else summary.backpressured += 1;
+      summary.deferred = options.plan.candidates.length - index - 1;
+      break;
+    } else if (body.accepted === false) summary.rejected += 1;
+    else {
+      throw new Error(
+        `scheduled review queue returned an unknown disposition for ${candidate.repo}#${candidate.number}`,
+      );
+    }
+  }
+
+  return summary;
+}
+
+function validateCandidate(candidate: PlanCandidate, targetRepo: string): void {
+  if (candidate.repo !== targetRepo)
+    throw new Error("scheduled review candidate repository mismatch");
+  if (!Number.isSafeInteger(candidate.number) || candidate.number < 1) {
+    throw new Error("scheduled review candidate number is invalid");
+  }
+  if (candidate.kind !== "issue" && candidate.kind !== "pull_request") {
+    throw new Error("scheduled review candidate kind is invalid");
+  }
+  if (!Number.isFinite(Date.parse(candidate.updatedAt))) {
+    throw new Error("scheduled review candidate updatedAt is invalid");
+  }
+}
+
+function readPlan(filePath: string): ScheduledReviewPlan {
+  const parsed = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+  if (!Array.isArray(parsed.candidates)) throw new Error("scheduled review plan has no candidates");
+  return {
+    candidates: parsed.candidates as PlanCandidate[],
+    ...(Array.isArray(parsed.selection)
+      ? { selection: parsed.selection as Array<{ ageMs?: number }> }
+      : {}),
+  };
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(`${label} is required`);
+}
+
+function scheduledReviewLane(value: unknown): ScheduledReviewLane {
+  if (value === "hot_intake" || value === "normal_backfill") return value;
+  throw new Error("--lane must be hot_intake or normal_backfill");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await enqueueScheduledReviewPlan({
+    plan: readPlan(requiredString(args.plan, "--plan")),
+    lane: scheduledReviewLane(args.lane),
+    targetRepo: requiredString(args["target-repo"], "--target-repo"),
+    targetBranch: requiredString(args["target-branch"], "--target-branch"),
+    queueUrl: requiredString(args["queue-url"], "--queue-url"),
+    secret: requiredString(process.env.CLAWSWEEPER_WEBHOOK_SECRET, "CLAWSWEEPER_WEBHOOK_SECRET"),
+    deliveryPrefix: requiredString(args["delivery-prefix"], "--delivery-prefix"),
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -73,6 +73,7 @@ interface FanoutOptions {
 
 const DEFAULT_CURSOR_DIR = join(repoRoot(), "results", "target-fanout-cursors");
 const PUBLIC_INVENTORY_TOKEN = "__public__";
+export const SCHEDULED_REVIEW_PLAN_BATCH_SIZE = 20;
 
 export async function runTargetFanout(argv: string[]): Promise<void> {
   const args = parseArgs(argv);
@@ -275,7 +276,7 @@ function workflowDispatchArgs(repository: SelectedRepository, options: FanoutOpt
       "-f",
       `client_payload[hot_intake]=${options.mode === "hot-intake" ? "true" : "false"}`,
       "-f",
-      "client_payload[batch_size]=1",
+      `client_payload[batch_size]=${SCHEDULED_REVIEW_PLAN_BATCH_SIZE}`,
       "-f",
       "client_payload[shard_count]=1",
     ];

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -53,6 +53,8 @@ test("production doubles exact review claims and canonical publication batches",
   assert.match(wrangler, /EXACT_REVIEW_ACTIONS_BUDGET = "194"/);
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"/);
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT = "8"/);
+  assert.match(wrangler, /EXACT_REVIEW_TARGET_RATE_PER_HOUR = "200"/);
+  assert.match(wrangler, /EXACT_REVIEW_TARGET_BURST = "50"/);
 });
 
 test("full exact-review admission preserves production verdict publication capacity", () => {
@@ -1885,6 +1887,115 @@ test("exact-review queue sheds only new recovery work above the pending soft lim
     retry_amplification: null,
   });
   assert.equal(stats.lanes.publication.enqueued_total, 1);
+});
+
+test("scheduled review feed is lane-paced and exposes its configured target", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_TARGET_RATE_PER_HOUR: "2",
+      EXACT_REVIEW_TARGET_BURST: "2",
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "600000",
+    },
+  );
+
+  for (const [lane, sourceAction, start] of [
+    ["hot_intake", "scheduled_hot_intake", 780],
+    ["normal_backfill", "scheduled_normal_backfill", 790],
+  ] as const) {
+    const admitted = await queue.fetch(
+      buildExactReviewQueueRequest(`scheduled-${lane}-1`, start, sourceAction),
+    );
+    assert.equal((await admitted.json()).queued, true);
+    const limited = await queue.fetch(
+      buildExactReviewQueueRequest(`scheduled-${lane}-2`, start + 1, sourceAction),
+    );
+    assert.deepEqual(await limited.json(), {
+      ok: true,
+      shed: true,
+      reason: "scheduled_rate",
+    });
+  }
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 2);
+  assert.equal(stats.shed_since_reset, 2);
+  assert.deepEqual(stats.scheduled_feed, {
+    target_rate_per_hour: 2,
+    burst: 2,
+    token_balance: 0,
+    lanes: {
+      hot_intake: { target_rate_per_hour: 1, burst: 1, token_balance: 0 },
+      normal_backfill: { target_rate_per_hour: 1, burst: 1, token_balance: 0 },
+    },
+  });
+});
+
+test("organic reviews consume the global target before scheduled backfill", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_TARGET_RATE_PER_HOUR: "2",
+      EXACT_REVIEW_TARGET_BURST: "2",
+    },
+  );
+  await queue.fetch(buildExactReviewQueueRequest("organic-1", 795, "opened"));
+  await queue.fetch(buildExactReviewQueueRequest("organic-2", 796, "opened"));
+  const scheduled = await queue.fetch(
+    buildExactReviewQueueRequest("scheduled-after-organic", 797, "scheduled_normal_backfill"),
+  );
+  assert.deepEqual(await scheduled.json(), {
+    ok: true,
+    shed: true,
+    reason: "scheduled_rate",
+  });
+});
+
+test("scheduled review feed dedupes untouched queued items without superseding them", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  assert.equal(
+    (await queue.fetch(buildExactReviewQueueRequest("ordinary-before-schedule", 800, "opened")))
+      .status,
+    202,
+  );
+
+  const duplicate = await queue.fetch(
+    buildExactReviewQueueRequest("scheduled-duplicate", 800, "scheduled_normal_backfill"),
+  );
+  assert.deepEqual(await duplicate.json(), {
+    ok: true,
+    deduped: true,
+    item_key: "openclaw/gogcli#800",
+    dedupe_scope: "scheduled_queue_item",
+    dedupe_reason: "item_already_pending_or_active",
+  });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { revision: number; decision: { sourceAction: string } }>;
+  };
+  assert.equal(state.items["openclaw/gogcli#800"].revision, 1);
+  assert.equal(state.items["openclaw/gogcli#800"].decision.sourceAction, "opened");
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.lanes.review.enqueued_total, 1);
+  assert.equal(stats.lanes.review.superseded_total, 0);
+});
+
+test("scheduled review feed stops at the pending soft limit", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_PENDING_SOFT_LIMIT: "1" });
+  await queue.fetch(
+    buildExactReviewQueueRequest("scheduled-pending-1", 810, "scheduled_hot_intake"),
+  );
+  const shed = await queue.fetch(
+    buildExactReviewQueueRequest("scheduled-pending-2", 811, "scheduled_hot_intake"),
+  );
+  assert.deepEqual(await shed.json(), { ok: true, shed: true, reason: "backpressure" });
 });
 
 test("exact-review queue does not count work for a disabled target", async () => {

--- a/test/repair/scheduled-review-enqueue.test.ts
+++ b/test/repair/scheduled-review-enqueue.test.ts
@@ -29,6 +29,9 @@ test("scheduled review enqueue reports the full selection-to-queue funnel and st
     secret,
     deliveryPrefix: "scheduled:100:1",
     fetchImpl: async (_input, init) => {
+      if (!init?.method) {
+        return Response.json({ scheduled_feed: { target_rate_per_hour: 200 } });
+      }
       const body = String(init?.body || "");
       const headers = (init?.headers ?? {}) as Record<string, string>;
       requests.push({
@@ -63,6 +66,22 @@ test("scheduled review enqueue reports the full selection-to-queue funnel and st
   assert.equal(second.decision.sourceAction, "scheduled_normal_backfill");
   assert.equal(second.decision.sourceEvent, "pull_request");
   assert.equal(second.decision.supersedesInProgress, false);
+});
+
+test("scheduled review enqueue fails closed until the queue advertises pacing", async () => {
+  await assert.rejects(
+    enqueueScheduledReviewPlan({
+      plan: { candidates: [] },
+      lane: "normal_backfill",
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      queueUrl: "https://queue.example",
+      secret: "secret",
+      deliveryPrefix: "scheduled:100:1",
+      fetchImpl: async () => Response.json({ lanes: {} }),
+    }),
+    /does not advertise scheduled feed admission/,
+  );
 });
 
 test("scheduled review enqueue rejects cross-repository plan candidates", async () => {

--- a/test/repair/scheduled-review-enqueue.test.ts
+++ b/test/repair/scheduled-review-enqueue.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+
+import { enqueueScheduledReviewPlan } from "../../dist/repair/scheduled-review-enqueue.js";
+
+test("scheduled review enqueue reports the full selection-to-queue funnel and stops on rate limit", async () => {
+  const secret = "scheduled-review-test-secret";
+  const requests: Array<{ body: string; signature: string }> = [];
+  const dispositions = [
+    { ok: true, queued: true },
+    { ok: true, deduped: true },
+    { ok: true, shed: true, reason: "scheduled_rate" },
+  ];
+  const summary = await enqueueScheduledReviewPlan({
+    plan: {
+      candidates: [1, 2, 3, 4].map((number) => ({
+        repo: "openclaw/openclaw",
+        number,
+        kind: number === 2 ? ("pull_request" as const) : ("issue" as const),
+        updatedAt: `2026-07-${String(20 + number).padStart(2, "0")}T00:00:00Z`,
+      })),
+      selection: [1, 6, 24, 240].map((hours) => ({ ageMs: hours * 3_600_000 })),
+    },
+    lane: "normal_backfill",
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    queueUrl: "https://queue.example/",
+    secret,
+    deliveryPrefix: "scheduled:100:1",
+    fetchImpl: async (_input, init) => {
+      const body = String(init?.body || "");
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      requests.push({
+        body,
+        signature: String(headers["x-clawsweeper-exact-review-signature"]),
+      });
+      return Response.json(dispositions[requests.length - 1], { status: 202 });
+    },
+  });
+
+  assert.deepEqual(summary, {
+    lane: "normal_backfill",
+    offered: 4,
+    attempted: 3,
+    queued: 1,
+    deduped: 1,
+    shed: 1,
+    rateLimited: 1,
+    backpressured: 0,
+    rejected: 0,
+    deferred: 1,
+    ageHours: { p50: 6, p90: 240, max: 240 },
+  });
+  assert.equal(requests.length, 3);
+  for (const request of requests) {
+    assert.equal(
+      request.signature,
+      `sha256=${createHmac("sha256", secret).update(request.body).digest("hex")}`,
+    );
+  }
+  const second = JSON.parse(requests[1]!.body);
+  assert.equal(second.decision.sourceAction, "scheduled_normal_backfill");
+  assert.equal(second.decision.sourceEvent, "pull_request");
+  assert.equal(second.decision.supersedesInProgress, false);
+});
+
+test("scheduled review enqueue rejects cross-repository plan candidates", async () => {
+  await assert.rejects(
+    enqueueScheduledReviewPlan({
+      plan: {
+        candidates: [
+          {
+            repo: "openclaw/other",
+            number: 1,
+            kind: "issue",
+            updatedAt: "2026-07-29T00:00:00Z",
+          },
+        ],
+      },
+      lane: "hot_intake",
+      targetRepo: "openclaw/openclaw",
+      targetBranch: "main",
+      queueUrl: "https://queue.example",
+      secret: "secret",
+      deliveryPrefix: "scheduled:100:1",
+      fetchImpl: async () => {
+        throw new Error("fetch must not run");
+      },
+    }),
+    /candidate repository mismatch/,
+  );
+});

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -336,8 +336,8 @@ process.exit(2);
   assert.deepEqual(
     calls.filter((call) => call.args[0] === "api").map((call) => call.args.join(" ")),
     [
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=true -f client_payload[batch_size]=1 -f client_payload[shard_count]=1",
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=true -f client_payload[batch_size]=1 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=true -f client_payload[batch_size]=20 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=true -f client_payload[batch_size]=20 -f client_payload[shard_count]=1",
     ],
   );
 });

--- a/test/review-run-telemetry.test.ts
+++ b/test/review-run-telemetry.test.ts
@@ -53,6 +53,26 @@ test("review observer attributes each review entry path without counting support
       ?.trigger_lane,
     "normal_backfill",
   );
+  assert.deepEqual(
+    classifyReviewRun(
+      run({ display_title: "Review scheduled hot item openclaw/openclaw#674 rev 2" }),
+    ),
+    {
+      trigger_lane: "hot_intake",
+      trigger_origin: "schedule",
+      target_repo: "openclaw/openclaw",
+    },
+  );
+  assert.deepEqual(
+    classifyReviewRun(
+      run({ display_title: "Review scheduled normal item openclaw/openclaw#674 rev 2" }),
+    ),
+    {
+      trigger_lane: "normal_backfill",
+      trigger_origin: "schedule",
+      target_repo: "openclaw/openclaw",
+    },
+  );
   assert.equal(
     classifyReviewRun(run({ display_title: "Retry failed Codex reviews", event: "schedule" }))
       ?.trigger_lane,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -375,7 +375,7 @@ test("review execution tokens can read check runs and commit statuses", () => {
   );
 });
 
-test("scheduled review shards receive the compiler-backed runtime artifact", () => {
+test("manual review shards receive the compiler-backed runtime artifact", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const planJobStart = workflow.indexOf("\n  plan:");
   const reviewJobStart = workflow.indexOf("\n  review:", planJobStart);
@@ -398,6 +398,8 @@ test("scheduled review shards receive the compiler-backed runtime artifact", () 
     planJob,
     /name: clawsweeper-runtime-dist\s+path: clawsweeper\/\.artifacts\/review-runtime\.tar\.gz\s+include-hidden-files: true/,
   );
+  assert.match(planJob, /if: \$\{\{ steps\.mode\.outputs\.queue_feed != 'true' \}\}/);
+  assert.match(reviewJob, /if: \$\{\{ needs\.plan\.outputs\.queue_feed != 'true' \}\}/);
   assert.match(reviewJob, /name: clawsweeper-runtime-dist\s+path: clawsweeper\/\.artifacts/);
   assert.doesNotMatch(reviewJob, /name: clawsweeper-runtime-dist\s+path: clawsweeper\/dist/);
   assert.match(reviewJob, /tar -xzf \.artifacts\/review-runtime\.tar\.gz/);
@@ -2427,7 +2429,7 @@ test("comment router prunes bare ack comments after updating shared automerge st
   assert.match(postComment, /pruned_ack_comment_id: String\(precreatedId\)/);
 });
 
-test("manual exact-item review dispatches reserve their live shard capacity", () => {
+test("exact queue and manual item dispatches reserve their live shard capacity", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const runName = workflow.slice(workflow.indexOf("run-name:"), workflow.indexOf("\non:"));
   const exactCapacityBlock = workflow.slice(
@@ -2465,8 +2467,14 @@ test("manual exact-item review dispatches reserve their live shard capacity", ()
   );
   assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event item "\)/);
   assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review event items "\)/);
+  assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review exact item "\)/);
+  assert.match(exactCapacityBlock, /\.displayTitle \| startswith\("Review scheduled hot item "\)/);
+  assert.match(
+    exactCapacityBlock,
+    /\.displayTitle \| startswith\("Review scheduled normal item "\)/,
+  );
   const singularFastPath = exactCapacityBlock.slice(
-    exactCapacityBlock.indexOf('if [[ "$title" == Review\\ event\\ item\\ * ]]'),
+    exactCapacityBlock.indexOf('if [[ "$title" == Review\\ exact\\ item\\ * ]]'),
     exactCapacityBlock.indexOf('if [ "$status" = "in_progress" ]'),
   );
   assert.match(singularFastPath, /active_shards=1/);
@@ -2552,6 +2560,26 @@ test("target hot sweep dispatches honor shard cap payload", () => {
     /shard_count="\$\{\{ github\.event\.client_payload\.shard_count \|\| '' \}\}"/,
   );
   assert.match(modeBlock, /shard_count="\$hot_intake_shards"/);
+});
+
+test("scheduled reviews feed the durable queue instead of one-item matrix workers", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const modeBlock = workflow.slice(
+    workflow.indexOf("- id: mode"),
+    workflow.indexOf("\n      - id: select"),
+  );
+  const enqueueBlock = workflow.slice(
+    workflow.indexOf("- name: Enqueue scheduled review candidates"),
+    workflow.indexOf("\n      - name: Prepare review runtime artifact"),
+  );
+
+  assert.match(modeBlock, /queue_feed=.*clawsweeper_target_sweep/);
+  assert.match(modeBlock, /batch_size="20"[\s\S]*shard_count="1"/);
+  assert.match(enqueueBlock, /repair:scheduled-review-enqueue/);
+  assert.match(enqueueBlock, /Scheduled review funnel/);
+  assert.match(workflow, /Review scheduled hot item/);
+  assert.match(workflow, /Review scheduled normal item/);
+  assert.match(workflow, /needs\.plan\.outputs\.queue_feed != 'true'/);
 });
 
 test("review git info follows checked-out target branch", () => {
@@ -2790,17 +2818,16 @@ test("target review queues coalesce background work without delaying exact plann
   assert.match(planHeader, /cancel-in-progress: false/);
 });
 
-test("scheduled normal review uses one item per shard for lease coverage", () => {
+test("scheduled normal review offers a 20-item queue batch on one planner shard", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const modeBlock = workflow.slice(
     workflow.indexOf("- id: mode"),
     workflow.indexOf("- id: select"),
   );
 
-  assert.match(
-    modeBlock,
-    /if \[ "\$\{\{ github\.event_name \}\}" = "schedule" \]; then\s+batch_size="1"/,
-  );
+  assert.match(modeBlock, /if \[ "\$queue_feed" = "true" \] && \[ -z "\$exact_item" \]; then/);
+  assert.match(modeBlock, /batch_size="20"[\s\S]*shard_count="1"/);
+  assert.match(modeBlock, /min_active_shards="0"/);
 });
 
 test("planned background reviews allow safe content-cache reuse without weakening exact reviews", () => {


### PR DESCRIPTION
## Summary

- route automated hot-intake and normal-backfill selections through the durable exact-review queue instead of direct one-item matrix workers
- raise each scheduled target plan from one candidate to 20 and pace total new review admission at 200/hour, with organic work consuming the budget before scheduled backfill
- preserve oldest-first selection, expose per-cycle selection age plus selected/enqueued/deduped/shed/deferred counters, and attribute scheduled claims/completions to their real lanes
- bound overload with a 50-item burst, the existing 300-pending soft limit, semantic dedupe for untouched items, and the existing 128-global/120-per-target claim caps
- fix live capacity accounting to count actual exact/scheduled review workers instead of short legacy ingress wrappers

## Measured bottleneck

The six-hour window from 2026-07-29 08:45–14:45 UTC contained 121 completed broad scheduler cycles: 44 core cycles and 77 fleet target cycles. They planned only 51 items total (8.5/hour). Just 43 cycles selected anything; 78 cycles were empty. Fleet hot and normal cycles never selected more than one item because target fanout hard-coded both `batch_size=1` and `shard_count=1`. Scheduled work then bypassed the Durable Object, so scheduled queue enqueues and claims were both zero even while the public queue showed 122 of 128 review slots available.

| Stage | Before | After configuration |
| --- | ---: | ---: |
| Completed broad planner cycles, sampled 6h | 121 | cadence unchanged |
| Candidates selected | 51 total; 8.5/hour | up to 20 per target cycle |
| Nonempty / empty cycles | 43 / 78 | measured in every run summary |
| Scheduled queue enqueues | 0 | fills the residual of a 200/hour total target |
| Scheduled queue claims | 0 | one exact workflow per admitted item |
| Review concurrency needed at 4.1-minute mean | n/a | about 13.7 workers |
| Durable claim ceiling | unused by scheduled work | 128 global / 120 per target |

This identifies the feed as the cap: not shard claim capacity, claim pacing, or the lease recycler. The post-https://github.com/openclaw/clawsweeper/pull/938 worker windows also demonstrated that exact-review execution can exceed 200 completions/hour while backlog is available.

## Selection-age finding

The retained pre-selection artifacts covered 39 completed scheduled items from those 51 plans. The selected reference age was p50 223.3 hours (9.3 days), p90 493.9 hours (20.6 days), and max 759.8 hours (31.7 days):

| Reference age | Selected items |
| --- | ---: |
| Under 1 hour | 0 |
| 1–6 hours | 2 |
| 6–24 hours | 4 |
| 1–6 days | 9 |
| At least 6 days | 24 |

Only one item was reselected across hot and normal lanes, and both selections were about 20.6 days old. The oldest-first coverage comparator from https://github.com/openclaw/clawsweeper/pull/937 is working; the problem was one-item feed capacity and overlapping planners. The queue now collapses such overlap without advancing a revision or revoking a lease.

## Rate and spend math

The Worker target is 200 new reviews/hour. Organic work is never shed and debits the global token balance first; scheduled hot/normal work fills the remainder with a 35/65 lane split. At the conservative 30 calls/review estimate:

`200 reviews/hour * 30 calls/review = 6,000 calls/hour`

That is about 50% of the roughly 12,000-call or 400-review/hour App-token ceiling, leaving comparable headroom for planning, retries, publication, and variance. At 4.1 minutes/review, the target needs `200 * 4.1 / 60 = 13.7` concurrent workers. Model use is still roughly five times a 40-review/hour baseline; `EXACT_REVIEW_TARGET_RATE_PER_HOUR` is the spend dial.

## Backpressure and lease behavior

- scheduled offers stop at the 200/hour organic-first token budget and 50-item burst
- new scheduled/recovery work sheds at 300 pending; webhook, command, and publication work retains priority
- an untouched pending, dispatching, or leased item is a semantic dedupe, not a superseding revision
- the six-minute lease remains unchanged because it covers only dispatch-to-claim handoff; claimed workers use the 130-minute execution lease and one-minute heartbeat/20-minute grace, so it cannot race a normal four-minute review
- producers fail closed until the deployed Worker advertises `scheduled_feed`, preventing a workflow-first rollout from bypassing pacing

## Proof

- focused scheduler, fanout, queue, telemetry, enqueue-helper, and workflow-shape tests: pass
- `pnpm run check:static`: pass
- `pnpm run build:all`: pass on Node 26.5.0
- `pnpm run lint`: pass
- full coverage thresholds: pass (77.70% lines, 72.64% branches, 85.43% functions)
- full `pnpm run check`: only the five known macOS Linux-containment harness failures remain because Apple libc does not export `capset`; this branch does not touch that subsystem
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode local`: clean for the full change, then clean again for the rollout-capability delta; no accepted/actionable findings
- `git diff --check`

## Rollout risks

- model spend rises materially if organic demand stays below the target and scheduled backlog is deep
- organic bursts can create token debt and temporarily suppress scheduled coverage by design
- the 50-item initial burst may briefly raise runner demand, but remains below both claim caps
- deploy the Worker capability before expecting the new scheduled feed; the producer intentionally fails closed against the old public status shape

This PR does not change review/close policy, protected-label handling, snapshot guards, or apply eligibility.
