### PR TITLE
Add MiniMax built-in provider defaults for the OpenClaw runner

### DIFF
--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -250,12 +250,14 @@ otherwise ClawSweeper runs `openclaw` from `PATH`.
 Providers that are not bundled with OpenClaw can be supplied through
 `CLAWSWEEPER_OPENCLAW_PROVIDERS_JSON`, a JSON object merged into
 `models.providers`; referenced provider API-key environment variables must also
-be present. Three providers ship as built-in defaults and need only their API key
+be present. Four providers ship as built-in defaults and need only their API key
 in the environment: `kimi/…` (Kimi Code endpoint, `KIMI_API_KEY`; models
 `kimi-for-coding` and `k3`), `cerebras/…` (Cerebras Code plans,
 `CEREBRAS_API_KEY`; model `zai-glm-4.7` until Cerebras retires it on
-2026-08-17), and `zai/…` (Z.AI GLM Coding Plan endpoint, `ZAI_API_KEY`;
-model `glm-5.2` — plan keys only work on the coding endpoint). The subprocess environment is deny-by-default: only the base OS
+2026-08-17), `zai/…` (Z.AI GLM Coding Plan endpoint, `ZAI_API_KEY`;
+model `glm-5.2` — plan keys only work on the coding endpoint), and `minimax/…`
+(MiniMax global OpenAI-compatible endpoint, `MINIMAX_API_KEY`; models
+`MiniMax-M3` and `MiniMax-M2.7`). The subprocess environment is deny-by-default: only the base OS
 surface, `OPENCLAW_*` controls, proxy settings, and known provider API keys
 reach the agent. ClawSweeper gives OpenClaw a fresh state directory, a coding tool
 profile limited to the target workspace, and the lane's existing timeout and

--- a/src/openclaw-process.ts
+++ b/src/openclaw-process.ts
@@ -353,6 +353,19 @@ const BUILTIN_PROVIDERS = {
     api: "openai-completions",
     models: [{ id: "glm-5.2", name: "GLM-5.2", contextWindow: 1000000, maxTokens: 131072 }],
   },
+  // MiniMax serves its text models over a global OpenAI-compatible endpoint;
+  // ship those defaults so `minimax/...` models run without extra provider
+  // config. Context windows are from the MiniMax model catalog (MiniMax-M3 1M,
+  // MiniMax-M2.7 200K).
+  minimax: {
+    baseUrl: "https://api.minimax.io/v1",
+    apiKey: "${MINIMAX_API_KEY}",
+    api: "openai-completions",
+    models: [
+      { id: "MiniMax-M3", name: "MiniMax-M3", contextWindow: 1000000 },
+      { id: "MiniMax-M2.7", name: "MiniMax-M2.7", contextWindow: 204800 },
+    ],
+  },
 } as const;
 
 function builtinProviderBlock(model: string): Record<string, unknown> | undefined {

--- a/test/openclaw-process.test.ts
+++ b/test/openclaw-process.test.ts
@@ -436,3 +436,42 @@ test("OpenClaw zai models get built-in Coding Plan endpoint defaults", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("OpenClaw minimax models get built-in provider defaults", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-openclaw-test-"));
+  const recordPath = join(root, "record.json");
+  const binary = fakeOpenclaw(root);
+  try {
+    const result = runOpenclawProcess({
+      label: "minimax-defaults",
+      prompt: "hi",
+      model: "minimax/MiniMax-M3",
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAWSWEEPER_OPENCLAW_BIN: binary,
+        CLAWSWEEPER_OPENCLAW_MODEL: "minimax/MiniMax-M3",
+        OPENCLAW_TEST_RECORD: recordPath,
+      },
+      timeoutMs: 60_000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const record = JSON.parse(readFileSync(recordPath, "utf8"));
+    assert.deepEqual(record.config.models, {
+      mode: "merge",
+      providers: {
+        minimax: {
+          baseUrl: "https://api.minimax.io/v1",
+          apiKey: "${MINIMAX_API_KEY}",
+          api: "openai-completions",
+          models: [
+            { id: "MiniMax-M3", name: "MiniMax-M3", contextWindow: 1000000 },
+            { id: "MiniMax-M2.7", name: "MiniMax-M2.7", contextWindow: 204800 },
+          ],
+        },
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Reason: There is no MiniMax provider configuration, so `minimax/...` models cannot run through the OpenClaw runner without hand-written provider config.

## Changes
- Add a `minimax` entry to the built-in OpenClaw provider defaults in `src/openclaw-process.ts`, using MiniMax's global OpenAI-compatible endpoint (`https://api.minimax.io/v1`, `${MINIMAX_API_KEY}`, `openai-completions`) with the `MiniMax-M3` (1M context) and `MiniMax-M2.7` (200K context) text models. `MINIMAX_API_KEY` was already on the subprocess environment allowlist, so no key wiring changes were needed.
- Add a unit test asserting the generated provider config for a `minimax/...` model, mirroring the existing kimi/cerebras/zai built-in provider coverage.
- Update `docs/repair/operations.md` to list MiniMax among the built-in providers.

## Checks
- pnpm run build
- pnpm run lint:src
- pnpm run lint:scripts
- pnpm run format:check

Note: the repository's `node --test` TypeScript suite targets Node >=24 and could not be executed in this Node 20 environment; the change was validated by the type build, lint, and format checks above.
