### PR TITLE
docs: require fresh review before landing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,32 @@ not split reports into issue/PR subtrees.
 - Locked-comment 403s from GitHub are terminal apply skips, not retryable API
   failures.
 
+## PR Validation and Landing
+
+- For code-bearing changes, run focused validation that exercises the changed
+  behavior, then run a fresh Codex `/review` before committing and again on the
+  committed branch against its base before landing. Address every accepted or
+  actionable finding and repeat the relevant proof and review. CI, an older
+  ClawSweeper comment, prior review comments, or manual self-review alone do
+  not replace this loop.
+- Keep real-behavior proof current in the PR body. Tests, mocks, snapshots,
+  lint, typechecks, and CI support the claim but do not by themselves prove a
+  changed runtime, workflow, queue, API, UI, package, or integration path.
+  Use the narrowest meaningful proof first and broaden it for shared or
+  higher-risk behavior. Docs-only changes normally need `git diff --check` and
+  relevant link or command sanity instead.
+- Before merge or automerge, the latest ClawSweeper review must apply to the
+  current PR head and body. Resolve every accepted finding. Apply each
+  applicable `Rank-up moves:` item, or explicitly justify the exception in the
+  PR body; Rank-up moves remain optional and do not by themselves block merge.
+  Do not merge while proof is missing or while the review has an unresolved
+  contributor-facing blocker.
+- Land only after the current review and status evidence is ready for
+  maintainer look, including `proof: sufficient` or `proof: override` when the
+  proof label applies. This does not replace the user's explicit merge approval
+  in the current conversation; agents must not merge or enable/execute
+  automerge without it.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a root `AGENTS.md` **PR Validation and Landing** section for code-bearing ClawSweeper changes.

## Problem

The repository had only a `pnpm run check`-before-handoff instruction. It did not tell agents to wait for a fresh current-head/body ClawSweeper review, keep real-behavior proof current, resolve accepted findings, or preserve explicit user approval before landing.

The CSW-072 audit found recent maintainer-account merges that bypassed the intended review wait: [#939](https://github.com/openclaw/clawsweeper/pull/939) and [#901](https://github.com/openclaw/clawsweeper/pull/901) merged after same-head ClawSweeper comments required proof before merge; [#938](https://github.com/openclaw/clawsweeper/pull/938), [#937](https://github.com/openclaw/clawsweeper/pull/937), [#936](https://github.com/openclaw/clawsweeper/pull/936), and [#922](https://github.com/openclaw/clawsweeper/pull/922) had no ClawSweeper comment. This is a policy gap, not proof of an autonomous merge actor.

## Policy change

- Require focused validation and fresh Codex `/review` before commit and again against the branch base before landing.
- Require current real-behavior proof in the PR body; tests and CI remain supporting evidence.
- Require the latest ClawSweeper review to apply to the current PR head and body; accepted findings must be resolved.
- Require agents to apply or explicitly justify applicable `Rank-up moves:` while preserving their existing non-blocking semantics.
- Require ready-for-maintainer evidence and preserve the user's explicit merge-approval requirement.

## Validation

- `git fetch origin main --prune`; rebased this one-commit branch onto current `origin/main` (`6b3a2cef36f553b943c22502f05576e4a1f7616a`).
- `git diff --check origin/main...HEAD` passed.
- Focused policy-contract probe compared the base and current root instructions: base had no `PR Validation and Landing` section; this head has the section and all six required clauses (fresh review before commit and against base, current PR-body proof, current head/body review, accepted findings, and explicit approval). `git` and `codex review` are available in the validation environment.
- `codex review --uncommitted` on the staged rebased patch: clean, no actionable findings.
- `codex review --base origin/main` on this final head: clean, no actionable findings.

## Real Behavior Proof

- Claim: an agent reading the repository root instructions now receives explicit validation and no-land gates that were absent on the base revision.
- Surface: root `AGENTS.md`, the policy entrypoint agents read before repository work.
- Scenario / fixture: compare `origin/main:AGENTS.md` with this PR head and assert the new section plus its six mandatory clauses.
- Command / environment: PowerShell on the rebased branch; `git diff --check origin/main...HEAD`; a focused text-contract probe; `codex review --uncommitted`; `codex review --base origin/main`.
- Observed result: the base lacks the section; this head contains all six clauses; whitespace validation and both final Codex review passes are clean.
- Artifact / trace: head `59fdd05f98c6a158c1b6095493f20acf1746b6be`; [`AGENTS.md`](https://github.com/openclaw/clawsweeper/blob/59fdd05f98c6a158c1b6095493f20acf1746b6be/AGENTS.md#L66-L90).
- Limits: this is an instruction-policy change, not a technical enforcement control. It cannot prevent a direct maintainer merge or independently verify a conversational user approval. A protected required-status/ruleset enforcement follow-up remains intentionally out of scope.

## Codex review closeout

The initial branch review found that treating `Rank-up moves:` as blockers contradicted the repository's existing optional semantics. The wording was corrected to require application or PR-body justification while keeping Rank-up moves non-blocking. The final dirty-patch and branch-against-base reviews reported no accepted/actionable findings.

## Maintainer decision

The user explicitly approved merging this repository-wide documentation policy in the current conversation on 2026-07-29. That satisfies the sole ClawSweeper `Rank-up moves:` item: obtain maintainer confirmation that the policy scope is intended, without treating the optional improvement as a merge blocker.

## Risks / rollout

No runtime, workflow, queue, labels, or merge-gate configuration changes. The new policy deliberately does not enable automerge or authorize a merge.
