### PR TITLE
fix: harden scaled review scheduling

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -908,10 +908,32 @@ jobs:
           codex_timeout_seconds=$(((CODEX_TIMEOUT_MS + 999) / 1000))
           media_preprocessing_reserve_seconds=480
           review_timeout_ms=$(((codex_timeout_seconds + media_preprocessing_reserve_seconds + 180) * 1000))
-          reservation="$(pnpm run --silent reserve-review-lease -- \
-            --target-repo "$TARGET_REPO" \
-            --item-number "$ITEM_NUMBER" \
-            --review-timeout-ms "$review_timeout_ms")"
+          reservation=""
+          reservation_error="$(mktemp)"
+          trap 'rm -f "$reservation_error"' EXIT
+          for attempt in 1 2 3 4 5; do
+            : > "$reservation_error"
+            if reservation="$(pnpm run --silent reserve-review-lease -- \
+              --target-repo "$TARGET_REPO" \
+              --item-number "$ITEM_NUMBER" \
+              --review-timeout-ms "$review_timeout_ms" 2>"$reservation_error")"; then
+              break
+            else
+              reserve_exit=$?
+            fi
+            if ! grep -Eqi '(exact-review queue authority changed|review revision changed|could not (confirm|identify).+review lease).+retry required' "$reservation_error"; then
+              cat "$reservation_error" >&2
+              exit "$reserve_exit"
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::notice::Exact-review reservation contention did not settle after 5 attempts; queue authority moved on, so this run is a successful no-op."
+              reservation='{"status":"superseded"}'
+              break
+            fi
+            delay_seconds=$((attempt * 2 + RANDOM % 4))
+            echo "::notice::Exact-review reservation contention on attempt $attempt/5; retrying in ${delay_seconds}s."
+            sleep "$delay_seconds"
+          done
           echo "$reservation"
           RESERVATION="$reservation" node <<'NODE'
           const fs = require("node:fs");
@@ -935,16 +957,26 @@ jobs:
             append("retry_at", new Date(retryAt).toISOString());
             process.exit(0);
           }
+          if (reservation.status === "superseded") {
+            append("status", "superseded");
+            process.exit(0);
+          }
           process.exit(1);
           NODE
 
       # At-least-once queue delivery can overlap an exact-head review that is already
       # running. The durable queue owns retry, so lease contention is deferred work.
       - name: Defer exact review while same-head lease is held
-        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.reserve-exact-review-lease.outputs.status == 'held' }}
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && (steps.reserve-exact-review-lease.outputs.status == 'held' || steps.reserve-exact-review-lease.outputs.status == 'superseded') }}
         env:
+          RESERVATION_STATUS: ${{ steps.reserve-exact-review-lease.outputs.status }}
           RETRY_AT: ${{ steps.reserve-exact-review-lease.outputs.retry_at }}
-        run: echo "::notice::Another exact-head review is already active; retry deferred until $RETRY_AT."
+        run: |
+          if [ "$RESERVATION_STATUS" = "superseded" ]; then
+            echo "::notice::Exact-review queue authority moved to another worker; this run completed as a successful no-op."
+          else
+            echo "::notice::Another exact-head review is already active; retry deferred until $RETRY_AT."
+          fi
 
       - name: Review exact event item
         id: review-exact-event-item
@@ -1116,7 +1148,10 @@ jobs:
           fi
           if [ -f "$superseded_marker" ]; then
             wait_for_review_group
-            review_exit_code=143
+            echo "superseded=true" >> "$GITHUB_OUTPUT"
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::Exact-review generation stopped because another worker owns the newer queue authority; completing this run as a successful no-op."
+            exit 0
           fi
           set -e
           echo "exit_code=$review_exit_code" >> "$GITHUB_OUTPUT"
@@ -1154,9 +1189,10 @@ jobs:
         env:
           REVIEW_EXIT_CODE: ${{ steps.review-exact-event-item.outputs.exit_code || '' }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome || 'not_started' }}
+          REVIEW_SUPERSEDED: ${{ steps.review-exact-event-item.outputs.superseded || 'false' }}
         run: |
           args=()
-          if [ "$REVIEW_OUTCOME" = "cancelled" ] || [ "$REVIEW_EXIT_CODE" = "130" ] || [ "$REVIEW_EXIT_CODE" = "143" ]; then
+          if [ "$REVIEW_SUPERSEDED" = "true" ] || [ "$REVIEW_OUTCOME" = "cancelled" ] || [ "$REVIEW_EXIT_CODE" = "130" ] || [ "$REVIEW_EXIT_CODE" = "143" ]; then
             args=(--interrupt-open-attempts --reason cancelled)
           elif [ "$REVIEW_EXIT_CODE" = "124" ] || [ "$REVIEW_EXIT_CODE" = "137" ]; then
             args=(--interrupt-open-attempts --reason timeout)
@@ -1167,7 +1203,7 @@ jobs:
 
       - name: Create exact review artifact bundle
         id: create-exact-review-bundle
-        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && !cancelled() && steps.target.outputs.target_enabled == 'true' && steps.live-item.outcome == 'success' && steps.setup-pnpm.outcome == 'success' && (steps.live-item.outputs.proceed != 'true' || (steps.review-exact-event-item.outcome == 'success' && steps.review-exact-event-item.outputs.retry_at == '')) }}
+        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && !cancelled() && steps.target.outputs.target_enabled == 'true' && steps.live-item.outcome == 'success' && steps.setup-pnpm.outcome == 'success' && steps.review-exact-event-item.outputs.superseded != 'true' && (steps.live-item.outputs.proceed != 'true' || (steps.review-exact-event-item.outcome == 'success' && steps.review-exact-event-item.outputs.retry_at == '')) }}
         env:
           EXACT_REVIEW_ACTION_LEDGER_ROOT: ${{ env.CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT }}
           EXACT_REVIEW_BUNDLE_DIR: .artifacts/exact-review-bundle
@@ -1372,13 +1408,17 @@ jobs:
           STATUS_COMMENT_ID: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).statusCommentId || '' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
+          REVIEW_SUPERSEDED: ${{ steps.review-exact-event-item.outputs.superseded || 'false' }}
           RESERVATION_STATUS: ${{ steps.reserve-exact-review-lease.outputs.status }}
           RETRY_AT: ${{ steps.reserve-exact-review-lease.outputs.retry_at || steps.review-exact-event-item.outputs.retry_at }}
           CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1"
         run: |
           state="Failed"
           detail="The exact review did not produce a publishable artifact. The durable queue will retry it."
-          if [ "$RESERVATION_STATUS" = "held" ]; then
+          if [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then
+            state="Waiting"
+            detail="A newer exact-review queue owner superseded this run. This run completed as a no-op."
+          elif [ "$RESERVATION_STATUS" = "held" ]; then
             state="Waiting"
             detail="Another exact-head review is already active. The durable queue will retry after its lease expires."
           elif [ "$REVIEW_OUTCOME" = "cancelled" ] || [ -n "$RETRY_AT" ]; then
@@ -1401,11 +1441,15 @@ jobs:
           TARGET_ENABLED: ${{ steps.target.outputs.target_enabled }}
           LIVE_OUTCOME: ${{ steps.live-item.outcome }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
+          REVIEW_SUPERSEDED: ${{ steps.review-exact-event-item.outputs.superseded || 'false' }}
+          RESERVATION_STATUS: ${{ steps.reserve-exact-review-lease.outputs.status }}
           PUBLICATION_QUEUE_OUTCOME: ${{ steps.queue-exact-review-publication.outcome }}
           DIRECT_PUBLICATION_ACCEPTED: ${{ steps.direct-exact-review-publication.outputs.accepted }}
         run: |
           outcome=failure
           if [ "$TARGET_ENABLED" = "false" ]; then
+            outcome=success
+          elif [ "$RESERVATION_STATUS" = "superseded" ] || [ "$REVIEW_SUPERSEDED" = "true" ]; then
             outcome=success
           elif [ "$REVIEW_OUTCOME" = "cancelled" ]; then
             outcome=cancelled
@@ -1526,15 +1570,24 @@ jobs:
             (
               (
                 steps.direct-exact-review-publication.outputs.accepted != 'true' &&
-                steps.complete-exact-review-queue.outcome != 'success'
+                steps.complete-exact-review-queue.outcome != 'success' &&
+                steps.reserve-exact-review-lease.outputs.status != 'superseded' &&
+                steps.review-exact-event-item.outputs.superseded != 'true'
               ) ||
               (
                 steps.exact-review-generation-result.outputs.outcome != 'success' &&
-                steps.reserve-exact-review-lease.outputs.status != 'held'
+                steps.reserve-exact-review-lease.outputs.status != 'held' &&
+                steps.reserve-exact-review-lease.outputs.status != 'superseded'
               )
             )
           }}
-        run: exit 1
+        env:
+          RESERVATION_STATUS: ${{ steps.reserve-exact-review-lease.outputs.status || 'unknown' }}
+          REVIEW_EXIT_CODE: ${{ steps.review-exact-event-item.outputs.exit_code || 'unknown' }}
+          REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome || 'not_started' }}
+        run: |
+          echo "::error::Exact review generation failed: classification=codex_or_content_failure reservation=$RESERVATION_STATUS review_outcome=$REVIEW_OUTCOME review_exit=$REVIEW_EXIT_CODE"
+          exit 1
 
   event-review-publish:
     name: Publish exact review artifact
@@ -2479,7 +2532,9 @@ jobs:
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ github.token }}
           CLAWSWEEPER_INVENTORY_TOKEN_OPENCLAW: ${{ steps.openclaw-token.outputs.token }}
           CLAWSWEEPER_INVENTORY_TOKEN_STEIPETE: ${{ steps.steipete-token.outputs.token || '__public__' }}
-        run: pnpm run target-fanout -- coverage --window-days 7 >> "$GITHUB_STEP_SUMMARY"
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          REVIEW_COVERAGE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+        run: pnpm run target-fanout -- coverage --window-days 7 --publish-url "$REVIEW_COVERAGE_URL" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish fanout cursor
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, renewed overdue canonical records ahead of unseen backlog, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
 - Routed scheduled review through the durable exact-review queue, raised each target plan from one to 20 candidates, and added oldest-age funnel telemetry plus a fleet-wide 200-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
 - Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.
 - Doubled exact-review admission to 128 global and 120 per target with a separate 194-slot Actions budget that preserves verdict publication at full review load, doubled scheduled fleet review fanout and canonical publication batch preparation, prioritized six-day oldest-review coverage before hot-item churn, exposed a six-hour fleet coverage summary, and raised automatic apply to 40 closes with proportional scan/runtime budgets without changing close eligibility.

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -13,6 +13,8 @@ export const EXACT_REVIEW_CANONICAL_INLINE_BYTES = Math.floor(1.5 * 1024 * 1024)
 export const EXACT_REVIEW_CANONICAL_CHUNK_BYTES = 512 * 1024;
 export const EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 export const REVIEW_COVERAGE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+export const REVIEW_COVERAGE_INVENTORY_KEY = "review-coverage-inventory:v1";
+export const REVIEW_COVERAGE_INVENTORY_STALE_MS = 12 * 60 * 60 * 1000;
 // Front matter always leads a canonical record; 4 KiB comfortably bounds it.
 export const REVIEW_COVERAGE_HEAD_BYTES = 4096;
 
@@ -546,11 +548,15 @@ export class ExactReviewDirectPublicationStore {
     );
   }
 
-  reviewCoverageSync(now: number, windowMs = REVIEW_COVERAGE_WINDOW_MS): ReviewCoverageSummary {
-    // Canonical `items` records are the open-item universe after the state-repo
-    // retirement: one record per open item, front matter carries reviewed_at and
-    // review_status. Only the front matter is needed, so read a bounded head of
-    // each record instead of hydrating full markdown bodies.
+  reviewCoverageSync(
+    now: number,
+    windowMs = REVIEW_COVERAGE_WINDOW_MS,
+    inventory: ReviewCoverageInventorySnapshot | null = null,
+  ): ReviewCoverageSummary {
+    // Canonical `items` records cover items that have reached publication; they
+    // are not a complete GitHub-open inventory. Only the front matter is needed,
+    // so read a bounded head and combine it with the periodically published live
+    // fleet counts instead of treating missing records as nonexistent work.
     const rows = this.storage.sql.exec(
       `SELECT r.repo_slug AS repo_slug,
               CASE
@@ -570,61 +576,127 @@ export class ExactReviewDirectPublicationStore {
     for (const row of rows) {
       const head = reviewCoverageHeadText(row.head, Number(row.chunked) === 1);
       const fields = reviewCoverageFrontMatter(head);
-      const repo = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(fields.repo ?? "")
-        ? fields.repo!
-        : String(row.repo_slug);
-      const fleet = fleets.get(repo) ?? {
+      const repoSlug = String(row.repo_slug);
+      const repo = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(fields.repository ?? "")
+        ? fields.repository!
+        : /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(fields.repo ?? "")
+          ? fields.repo!
+          : repoSlug;
+      const fleet = fleets.get(repoSlug) ?? {
         repo,
-        repo_slug: String(row.repo_slug),
-        open_records: 0,
+        repo_slug: repoSlug,
+        tracked_records: 0,
         reviewed_recent: 0,
         stale: 0,
         failed: 0,
-        pending: 0,
+        expired: 0,
+        unreviewed_records: 0,
+        excluded: 0,
         oldest_reviewed_at: null as string | null,
       };
-      fleet.open_records += 1;
+      fleet.tracked_records += 1;
       const status = fields.review_status ?? "";
       const reviewedAtMs = fields.reviewed_at ? Date.parse(fields.reviewed_at) : Number.NaN;
       const fresh =
-        status === "complete" && Number.isFinite(reviewedAtMs) && now - reviewedAtMs < windowMs;
-      if (fresh) fleet.reviewed_recent += 1;
+        status === "complete" &&
+        Number.isFinite(reviewedAtMs) &&
+        reviewedAtMs <= now &&
+        now - reviewedAtMs < windowMs;
+      if (reviewCoverageRecordExcluded(fields.labels)) fleet.excluded += 1;
+      else if (fresh) fleet.reviewed_recent += 1;
       else if (status.startsWith("stale_")) fleet.stale += 1;
       else if (status === "failed") fleet.failed += 1;
-      else fleet.pending += 1;
+      else if (status === "complete" && Number.isFinite(reviewedAtMs)) fleet.expired += 1;
+      else fleet.unreviewed_records += 1;
       if (
         Number.isFinite(reviewedAtMs) &&
         (fleet.oldest_reviewed_at === null || reviewedAtMs < Date.parse(fleet.oldest_reviewed_at))
       ) {
         fleet.oldest_reviewed_at = new Date(reviewedAtMs).toISOString();
       }
-      fleets.set(repo, fleet);
+      fleets.set(repoSlug, fleet);
+    }
+    const inventoryBySlug = new Map(
+      (inventory?.repositories ?? []).map((entry) => [entry.repo_slug, entry] as const),
+    );
+    for (const entry of inventory?.repositories ?? []) {
+      if (fleets.has(entry.repo_slug)) continue;
+      fleets.set(entry.repo_slug, {
+        repo: entry.repo,
+        repo_slug: entry.repo_slug,
+        tracked_records: 0,
+        reviewed_recent: 0,
+        stale: 0,
+        failed: 0,
+        expired: 0,
+        unreviewed_records: 0,
+        excluded: 0,
+        oldest_reviewed_at: null,
+      });
     }
     const fleetList = [...fleets.values()]
-      .map((fleet) => ({
-        ...fleet,
-        coverage_percent: fleet.open_records
-          ? Math.round((fleet.reviewed_recent / fleet.open_records) * 1000) / 10
-          : null,
-      }))
+      .map((fleet) =>
+        projectReviewCoverageFleet(
+          fleet,
+          inventoryBySlug.get(fleet.repo_slug) ?? null,
+          inventory !== null,
+        ),
+      )
       .sort((left, right) => left.repo.localeCompare(right.repo));
     const totals = fleetList.reduce(
-      (sum, fleet) => ({
-        open_records: sum.open_records + fleet.open_records,
-        reviewed_recent: sum.reviewed_recent + fleet.reviewed_recent,
-        stale: sum.stale + fleet.stale,
-        failed: sum.failed + fleet.failed,
-        pending: sum.pending + fleet.pending,
-      }),
-      { open_records: 0, reviewed_recent: 0, stale: 0, failed: 0, pending: 0 },
+      (sum, fleet) => {
+        if (!fleet.schedulable) {
+          sum.unschedulable_records += fleet.unschedulable_records;
+          return sum;
+        }
+        sum.open_records += fleet.open_records;
+        sum.reviewable_records += fleet.reviewable_records;
+        sum.tracked_records += fleet.tracked_records;
+        sum.reviewed_recent += fleet.reviewed_recent;
+        sum.stale += fleet.stale;
+        sum.failed += fleet.failed;
+        sum.expired += fleet.expired;
+        sum.unreviewed_records += fleet.unreviewed_records;
+        sum.untracked_open += fleet.untracked_open;
+        sum.pending += fleet.pending;
+        sum.excluded += fleet.excluded;
+        sum.record_drift += fleet.record_drift;
+        return sum;
+      },
+      {
+        open_records: 0,
+        reviewable_records: 0,
+        tracked_records: 0,
+        reviewed_recent: 0,
+        stale: 0,
+        failed: 0,
+        expired: 0,
+        unreviewed_records: 0,
+        untracked_open: 0,
+        pending: 0,
+        excluded: 0,
+        unschedulable_records: 0,
+        record_drift: 0,
+      },
     );
+    const inventoryGeneratedAt = inventory?.generated_at ?? null;
+    const inventoryGeneratedAtMs = Date.parse(inventoryGeneratedAt ?? "");
+    const inventoryStatus =
+      inventory === null
+        ? "missing"
+        : !Number.isFinite(inventoryGeneratedAtMs) ||
+            now - inventoryGeneratedAtMs > REVIEW_COVERAGE_INVENTORY_STALE_MS
+          ? "stale"
+          : "current";
     return {
       window_days: Math.round(windowMs / (24 * 60 * 60 * 1000)),
+      inventory_generated_at: inventoryGeneratedAt,
+      inventory_status: inventoryStatus,
       fleets: fleetList,
       totals: {
         ...totals,
-        coverage_percent: totals.open_records
-          ? Math.round((totals.reviewed_recent / totals.open_records) * 1000) / 10
+        coverage_percent: totals.reviewable_records
+          ? Math.round((totals.reviewed_recent / totals.reviewable_records) * 1000) / 10
           : null,
       },
     };
@@ -1598,30 +1670,177 @@ function canonicalPath(value: unknown) {
 type MutableReviewCoverageFleet = {
   repo: string;
   repo_slug: string;
-  open_records: number;
+  tracked_records: number;
   reviewed_recent: number;
   stale: number;
   failed: number;
-  pending: number;
+  expired: number;
+  unreviewed_records: number;
+  excluded: number;
   oldest_reviewed_at: string | null;
 };
 
+export type ReviewCoverageInventoryRepository = {
+  repo: string;
+  repo_slug: string;
+  open_issues: number;
+  open_pull_requests: number;
+};
+
+export type ReviewCoverageInventorySnapshot = {
+  generated_at: string;
+  repositories: ReviewCoverageInventoryRepository[];
+};
+
 export type ReviewCoverageFleet = MutableReviewCoverageFleet & {
+  open_records: number;
+  reviewable_records: number;
+  untracked_open: number;
+  pending: number;
+  unschedulable_records: number;
+  record_drift: number;
+  schedulable: boolean;
   coverage_percent: number | null;
 };
 
 export type ReviewCoverageSummary = {
   window_days: number;
+  inventory_generated_at: string | null;
+  inventory_status: "current" | "stale" | "missing";
   fleets: ReviewCoverageFleet[];
   totals: {
     open_records: number;
+    reviewable_records: number;
+    tracked_records: number;
     reviewed_recent: number;
     stale: number;
     failed: number;
+    expired: number;
+    unreviewed_records: number;
+    untracked_open: number;
     pending: number;
+    excluded: number;
+    unschedulable_records: number;
+    record_drift: number;
     coverage_percent: number | null;
   };
 };
+
+export function normalizeReviewCoverageInventory(
+  value: unknown,
+): ReviewCoverageInventorySnapshot | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const input = value as Record<string, unknown>;
+  const generatedAt = String(input.generated_at ?? "").trim();
+  const generatedAtMs = Date.parse(generatedAt);
+  if (!Number.isFinite(generatedAtMs) || !Array.isArray(input.repositories)) return null;
+  if (input.repositories.length > 2_000) return null;
+  const seen = new Set<string>();
+  const repositories: ReviewCoverageInventoryRepository[] = [];
+  for (const candidate of input.repositories) {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const entry = candidate as Record<string, unknown>;
+    const repo = String(entry.repo ?? "")
+      .trim()
+      .toLowerCase();
+    const repoSlug = String(entry.repo_slug ?? "")
+      .trim()
+      .toLowerCase();
+    const openIssues = Number(entry.open_issues);
+    const openPullRequests = Number(entry.open_pull_requests);
+    if (
+      !/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(repo) ||
+      !/^[a-z0-9][a-z0-9_.-]*$/.test(repoSlug) ||
+      repo.replace("/", "-") !== repoSlug ||
+      !Number.isSafeInteger(openIssues) ||
+      openIssues < 0 ||
+      !Number.isSafeInteger(openPullRequests) ||
+      openPullRequests < 0 ||
+      seen.has(repoSlug)
+    ) {
+      return null;
+    }
+    seen.add(repoSlug);
+    repositories.push({
+      repo,
+      repo_slug: repoSlug,
+      open_issues: openIssues,
+      open_pull_requests: openPullRequests,
+    });
+  }
+  return { generated_at: new Date(generatedAtMs).toISOString(), repositories };
+}
+
+function projectReviewCoverageFleet(
+  fleet: MutableReviewCoverageFleet,
+  inventory: ReviewCoverageInventoryRepository | null,
+  hasInventory: boolean,
+): ReviewCoverageFleet {
+  if (hasInventory && inventory === null) {
+    return {
+      ...fleet,
+      open_records: 0,
+      reviewable_records: 0,
+      reviewed_recent: 0,
+      stale: 0,
+      failed: 0,
+      expired: 0,
+      unreviewed_records: 0,
+      untracked_open: 0,
+      pending: 0,
+      excluded: 0,
+      unschedulable_records: fleet.tracked_records,
+      record_drift: 0,
+      schedulable: false,
+      coverage_percent: null,
+    };
+  }
+  const openRecords = inventory
+    ? inventory.open_issues + inventory.open_pull_requests
+    : fleet.tracked_records;
+  const excluded = Math.min(fleet.excluded, openRecords);
+  const reviewableRecords = Math.max(0, openRecords - excluded);
+  let remaining = reviewableRecords;
+  const take = (count: number) => {
+    const accepted = Math.min(Math.max(0, count), remaining);
+    remaining -= accepted;
+    return accepted;
+  };
+  const reviewedRecent = take(fleet.reviewed_recent);
+  const stale = take(fleet.stale);
+  const failed = take(fleet.failed);
+  const expired = take(fleet.expired);
+  const unreviewedRecords = take(fleet.unreviewed_records);
+  const untrackedOpen = remaining;
+  return {
+    ...fleet,
+    repo: inventory?.repo ?? fleet.repo,
+    open_records: openRecords,
+    reviewable_records: reviewableRecords,
+    reviewed_recent: reviewedRecent,
+    stale,
+    failed,
+    expired,
+    unreviewed_records: unreviewedRecords,
+    untracked_open: untrackedOpen,
+    pending: expired + unreviewedRecords + untrackedOpen,
+    excluded,
+    unschedulable_records: 0,
+    record_drift: Math.max(0, fleet.tracked_records - openRecords),
+    schedulable: true,
+    coverage_percent: reviewableRecords
+      ? Math.round((reviewedRecent / reviewableRecords) * 1000) / 10
+      : null,
+  };
+}
+
+const REVIEW_COVERAGE_EXCLUDED_LABELS = new Set<string>(
+  CLOSE_PROTECTED_LABEL_NAMES.filter((label) => label !== "maintainer"),
+);
+
+function reviewCoverageRecordExcluded(labels: readonly string[]): boolean {
+  return labels.some((label) => REVIEW_COVERAGE_EXCLUDED_LABELS.has(label.toLowerCase()));
+}
 
 function reviewCoverageHeadText(head: unknown, chunked: boolean): string {
   const raw = typeof head === "string" ? head : "";
@@ -1636,18 +1855,36 @@ function reviewCoverageHeadText(head: unknown, chunked: boolean): string {
 }
 
 function reviewCoverageFrontMatter(head: string): {
+  repository: string | null;
   repo: string | null;
   reviewed_at: string | null;
   review_status: string | null;
+  labels: string[];
 } {
-  const result: { repo: string | null; reviewed_at: string | null; review_status: string | null } =
-    { repo: null, reviewed_at: null, review_status: null };
+  const result: {
+    repository: string | null;
+    repo: string | null;
+    reviewed_at: string | null;
+    review_status: string | null;
+    labels: string[];
+  } = { repository: null, repo: null, reviewed_at: null, review_status: null, labels: [] };
   if (!head.startsWith("---")) return result;
   const end = head.indexOf("\n---", 3);
   const frontMatter = end === -1 ? head : head.slice(0, end);
-  for (const key of ["repo", "reviewed_at", "review_status"] as const) {
+  for (const key of ["repository", "repo", "reviewed_at", "review_status"] as const) {
     const match = frontMatter.match(new RegExp(`^${key}:[ \\t]*"?([^"\\n]*)"?[ \\t]*$`, "m"));
     if (match) result[key] = match[1].trim() || null;
+  }
+  const labels = frontMatter.match(/^labels:[ \t]*(.+?)[ \t]*$/m)?.[1]?.trim();
+  if (labels) {
+    try {
+      const parsed = JSON.parse(labels);
+      if (Array.isArray(parsed)) {
+        result.labels = parsed.filter((label): label is string => typeof label === "string");
+      }
+    } catch {
+      result.labels = labels === "none" ? [] : labels.split(",").map((label) => label.trim());
+    }
   }
   return result;
 }
@@ -1682,3 +1919,4 @@ export async function sha256Hex(bytes: Uint8Array) {
   );
   return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
+import { CLOSE_PROTECTED_LABEL_NAMES } from "../src/repair/exact-review-guard-labels.ts";

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -20,7 +20,9 @@ import {
 import {
   CanonicalRecordTupleConflictError,
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
+  REVIEW_COVERAGE_INVENTORY_KEY,
   ExactReviewDirectPublicationStore,
+  normalizeReviewCoverageInventory,
   sha256Hex,
   validateCanonicalRecordTupleMutation,
   validateDirectPublicationPlan,
@@ -569,6 +571,19 @@ export class ExactReviewQueue {
     await this.ready;
     this.cleanupLegacyCompatibilitySync();
     const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/review-coverage/inventory") {
+      const inventory = normalizeReviewCoverageInventory(await request.json().catch(() => null));
+      if (!inventory) return json({ error: "invalid_review_coverage_inventory" }, 400);
+      const stored = normalizeReviewCoverageInventory(
+        this.storage.kv.get(REVIEW_COVERAGE_INVENTORY_KEY),
+      );
+      if (stored && Date.parse(stored.generated_at) > Date.parse(inventory.generated_at)) {
+        return json({ ok: true, accepted: false, stale: true }, 202);
+      }
+      this.storage.kv.put(REVIEW_COVERAGE_INVENTORY_KEY, inventory);
+      this.reviewCoverageCache = null;
+      return json({ ok: true, accepted: true }, 202);
+    }
     if (request.method === "POST" && url.pathname === "/source-authority") {
       const body = objectValue(await request.json().catch(() => null));
       const deliveryId = String(body.delivery_id || "").trim();
@@ -2512,7 +2527,11 @@ export class ExactReviewQueue {
       if (!this.reviewCoverageCache || now - this.reviewCoverageCache.at > 60_000) {
         this.reviewCoverageCache = {
           at: now,
-          summary: this.directPublicationStore.reviewCoverageSync(now),
+          summary: this.directPublicationStore.reviewCoverageSync(
+            now,
+            undefined,
+            normalizeReviewCoverageInventory(this.storage.kv.get(REVIEW_COVERAGE_INVENTORY_KEY)),
+          ),
         };
       }
       return json({

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -547,6 +547,8 @@ export default {
       return authenticatedExactReviewEnqueue(request, env);
     if (url.pathname === "/internal/exact-review/source-authority" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/source-authority");
+    if (url.pathname === "/internal/review-coverage/inventory" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/review-coverage/inventory");
     const canonicalRecordPath =
       request.method === "GET"
         ? /^\/internal\/state\/records\/[^/]+\/(?:items|closed|plans|decision-packets)\/[1-9]\d*$/.exec(
@@ -9297,9 +9299,13 @@ function renderReviewCoverage() {
   }
   const totals = payload.totals || {};
   const windowDays = Number(payload.window_days) || 7;
+  const inventorySuffix = payload.inventory_status === "stale"
+    ? " · live inventory stale"
+    : payload.inventory_status === "missing" ? " · awaiting live inventory" : "";
   note.textContent = totals.open_records
-    ? fmt.format(totals.reviewed_recent || 0) + " of " + fmt.format(totals.open_records) + " open records reviewed in the trailing " + windowDays + " days" +
+    ? fmt.format(totals.reviewed_recent || 0) + " of " + fmt.format(totals.reviewable_records || totals.open_records) + " reviewable open items reviewed in the trailing " + windowDays + " days" +
       (totals.coverage_percent == null ? "" : " · " + totals.coverage_percent + "%") +
+      inventorySuffix +
       " · updated " + since(payload.generated_at)
     : "Open items reviewed in the trailing " + windowDays + " days";
   const fleets = Array.isArray(payload.fleets) ? payload.fleets : [];
@@ -9314,9 +9320,17 @@ function renderReviewCoverage() {
     const flags =
       (fleet.stale ? '<span class="coverage-flag stale">' + fmt.format(fleet.stale) + ' stale</span>' : '') +
       (fleet.failed ? '<span class="coverage-flag failed">' + fmt.format(fleet.failed) + ' failed</span>' : '') +
+      (fleet.expired ? '<span class="coverage-flag stale">' + fmt.format(fleet.expired) + ' expired</span>' : '') +
+      (fleet.untracked_open ? '<span class="coverage-flag">' + fmt.format(fleet.untracked_open) + ' never reviewed</span>' : '') +
+      (fleet.excluded ? '<span class="coverage-flag">' + fmt.format(fleet.excluded) + ' protected</span>' : '') +
+      (fleet.unschedulable_records ? '<span class="coverage-flag">' + fmt.format(fleet.unschedulable_records) + ' unmanaged records</span>' : '') +
       (fleet.pending ? '<span class="coverage-flag">' + fmt.format(fleet.pending) + ' pending</span>' : '');
     return '<div class="coverage-fleet">' +
-      '<div class="coverage-fleet-name"><strong>' + esc(fleet.repo) + '</strong><span>' + fmt.format(fleet.reviewed_recent || 0) + ' of ' + fmt.format(fleet.open_records || 0) + ' open records reviewed</span></div>' +
+      '<div class="coverage-fleet-name"><strong>' + esc(fleet.repo) + '</strong><span>' +
+        (fleet.schedulable === false
+          ? fmt.format(fleet.tracked_records || 0) + ' canonical records outside the current fleet'
+          : fmt.format(fleet.reviewed_recent || 0) + ' of ' + fmt.format(fleet.reviewable_records || 0) + ' reviewable open items reviewed') +
+      '</span></div>' +
       '<div><div class="coverage-bar ' + band + '"><i style="width:' + Math.max(0, Math.min(100, percent ?? 0)) + '%"></i></div></div>' +
       '<div class="coverage-value"><strong>' + (percent == null ? "n/a" : percent + "%") + '</strong>' +
       (flags ? '<span class="coverage-flags">' + flags + '</span>' : '<span>fully current</span>') +
@@ -9362,7 +9376,7 @@ function renderHealthStrip() {
   if (lastReviewCoverage?.ok === true) {
     const coverage = lastReviewCoverage.totals?.coverage_percent;
     const stale = Number(lastReviewCoverage.totals?.stale || 0);
-    chips.push(healthChip("7d coverage", (coverage == null ? "n/a" : coverage + "%") + (stale ? " · " + fmt.format(stale) + " stale" : ""), coverage == null ? "" : coverageBand(coverage), "Share of open records with a completed review in the trailing 7 days."));
+    chips.push(healthChip("7d coverage", (coverage == null ? "n/a" : coverage + "%") + (stale ? " · " + fmt.format(stale) + " stale" : ""), coverage == null ? "" : coverageBand(coverage), "Share of reviewable live open items with a completed review in the trailing 7 days."));
   }
   target.innerHTML = chips.join("");
 }

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -10310,6 +10310,27 @@ function codexFailureReason(detail: string, errorCode?: string | null): string {
   return "codex execution failed";
 }
 
+function codexFailureLogKind(markdown: string): string {
+  if (/retryable codex transport failure \(capacity\)/i.test(markdown)) {
+    return "provider_throttle";
+  }
+  if (/retryable codex transport failure \(network\)/i.test(markdown)) {
+    return "transport_network";
+  }
+  if (
+    /missing structured output|invalid structured output|output buffer overflow/i.test(markdown)
+  ) {
+    return "content_or_output";
+  }
+  if (/model unavailable or access denied/i.test(markdown)) return "model_access";
+  if (/Codex review failed: timeout/i.test(markdown)) return "timeout";
+  return "codex_execution";
+}
+
+export function codexFailureLogKindForTest(markdown: string): string {
+  return codexFailureLogKind(markdown);
+}
+
 function codexFallbackMinBudgetMs(): number {
   const configured = Number(process.env.CLAWSWEEPER_CODEX_FALLBACK_MIN_BUDGET_MS?.trim());
   return Number.isFinite(configured) && configured > 0
@@ -25055,6 +25076,12 @@ function reviewCommand(args: Args): void {
       );
     }
     if (codexFailures > 0) {
+      for (const reportPath of codexFailureReports) {
+        const failureKind = codexFailureLogKind(readFileSync(reportPath, "utf8"));
+        console.error(
+          `[review] ${new Date().toISOString()} codex-failure classification=${failureKind} report=${displayPath(reportPath)}`,
+        );
+      }
       const message = `Codex failed for ${codexFailures} item${
         codexFailures === 1 ? "" : "s"
       }; review artifacts were written and the workflow recovery lane can requeue the planned set.${

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
+import { createHmac } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -54,6 +55,16 @@ export interface FleetReviewCoverage {
   requiredItemsPerHourWithHeadroom: number;
 }
 
+export interface ReviewCoverageInventorySnapshot {
+  generated_at: string;
+  repositories: Array<{
+    repo: string;
+    repo_slug: string;
+    open_issues: number;
+    open_pull_requests: number;
+  }>;
+}
+
 interface SelectionResult {
   repositories: SelectedRepository[];
   cursor: number;
@@ -94,7 +105,19 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
   if (args._[0] === "coverage") {
     const windowDays = positiveNumber(stringArg(args["window-days"], "7"), "window-days");
     const openCounts = loadRepositoryOpenCounts(repositories);
-    const coverage = summarizeFleetReviewCoverage({ repositories, openCounts, windowDays });
+    const now = Date.now();
+    const coverage = summarizeFleetReviewCoverage({ repositories, openCounts, windowDays, now });
+    const publishUrl = stringArg(args["publish-url"], "");
+    if (publishUrl) {
+      await publishReviewCoverageInventory({
+        baseUrl: publishUrl,
+        webhookSecret: stringValue(
+          process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+          "CLAWSWEEPER_WEBHOOK_SECRET",
+        ),
+        snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
+      });
+    }
     process.stdout.write(renderFleetReviewCoverage(coverage));
     return;
   }
@@ -453,6 +476,68 @@ export function summarizeFleetReviewCoverage(options: {
     requiredItemsPerHourWithHeadroom:
       openTotal > 0 ? (openTotal / (options.windowDays * 24)) * 1.3 : 0,
   };
+}
+
+export function reviewCoverageInventorySnapshot(
+  repositories: readonly SelectedRepository[],
+  openCounts: ReadonlyMap<string, RepositoryOpenCounts>,
+  now = Date.now(),
+): ReviewCoverageInventorySnapshot {
+  return {
+    generated_at: new Date(now).toISOString(),
+    repositories: repositories.map((repository) => {
+      const counts = openCounts.get(repository.targetRepo) ?? { issues: 0, pullRequests: 0 };
+      return {
+        repo: repository.targetRepo,
+        repo_slug: repository.targetRepo.toLowerCase().replace("/", "-"),
+        open_issues: counts.issues,
+        open_pull_requests: counts.pullRequests,
+      };
+    }),
+  };
+}
+
+export async function publishReviewCoverageInventory(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  snapshot: ReviewCoverageInventorySnapshot;
+  attempts?: number;
+  fetchImpl?: typeof globalThis.fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+}): Promise<void> {
+  const baseUrl = options.baseUrl.replace(/\/$/, "");
+  if (!baseUrl.startsWith("https://")) {
+    throw new Error("Review coverage inventory URL must use HTTPS");
+  }
+  const body = JSON.stringify(options.snapshot);
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
+  const attempts = Math.max(1, Math.min(5, Math.floor(options.attempts ?? 3)));
+  const request = options.fetchImpl ?? globalThis.fetch;
+  const sleep =
+    options.sleep ??
+    ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  let lastFailure = "review coverage inventory publication failed";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await request(`${baseUrl}/internal/review-coverage/inventory`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        body,
+        signal: AbortSignal.timeout(20_000),
+      });
+      const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      if (response.ok && payload.ok === true) return;
+      lastFailure = String(payload.error || `http_${response.status}`);
+      if (response.status >= 400 && response.status < 500 && response.status !== 429) break;
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt < attempts) await sleep(attempt * 5_000);
+  }
+  throw new Error(`Review coverage inventory publication failed: ${lastFailure}`);
 }
 
 export function renderFleetReviewCoverage(coverage: FleetReviewCoverage): string {

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -317,6 +317,13 @@ export function selectDueCandidates<
         weeklyCoverageReferenceMs(left) - weeklyCoverageReferenceMs(right) ||
         compare(left, right),
     );
+  // A never-reviewed backlog can contain years-old items. If all of those sort
+  // ahead of an already-tracked record, the rolling coverage set never gets
+  // refreshed even though the scheduler is busy. Renew overdue canonical
+  // records first; unseen items still consume every remaining coverage slot.
+  for (const candidate of weeklyCoverageDue) {
+    if (candidate.review != null) take(candidate);
+  }
   for (const candidate of weeklyCoverageDue) take(candidate);
   for (const [bucket, candidates] of buckets) {
     buckets.set(

--- a/test/codex-review-runner.test.ts
+++ b/test/codex-review-runner.test.ts
@@ -14,10 +14,28 @@ import test from "node:test";
 
 import {
   codexFailureDecisionForTest,
+  codexFailureLogKindForTest,
   redactInternalCodexModel,
   runCodexForTest,
 } from "../dist/clawsweeper.js";
 import { closeDecision, item, tmpPrefix } from "./helpers.ts";
+
+test("Codex failure logs distinguish provider throttling from content output failures", () => {
+  assert.equal(
+    codexFailureLogKindForTest(
+      "Codex review failed: retryable codex transport failure (capacity).",
+    ),
+    "provider_throttle",
+  );
+  assert.equal(
+    codexFailureLogKindForTest("Codex review failed: invalid structured output."),
+    "content_or_output",
+  );
+  assert.equal(
+    codexFailureLogKindForTest("Codex review failed: codex execution failed."),
+    "codex_execution",
+  );
+});
 
 test("runCodex accepts valid structured output after non-zero Codex exit", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -167,12 +167,13 @@ test("exact-review queue durably coalesces concurrent unchanged pull request edi
   ]);
   const responses = await Promise.all([first.json(), duplicate.json()]);
   assert.equal(responses.filter((response) => response.queued === true).length, 1);
+  const deduped = responses.find((response) => response.deduped === true);
   assert.deepEqual(
-    responses.find((response) => response.deduped === true),
+    { ...deduped, item_key: String(deduped?.item_key).toLowerCase() },
     {
       ok: true,
       deduped: true,
-      item_key: "Steipete/Nameplate#750",
+      item_key: "steipete/nameplate#750",
       dedupe_scope: "semantic_edited",
       dedupe_reason: "unchanged_pull_request_edit",
     },
@@ -9343,10 +9344,47 @@ test("review coverage summarizes canonical item records per fleet", async () => 
     itemRecord("openclaw/openclaw", 4, `reviewed_at: ${fresh}\nreview_status: failed\n`),
   );
   await publish(
+    "openclaw-openclaw",
+    5,
+    itemRecord(
+      "openclaw/openclaw",
+      5,
+      `labels: ["security"]\nreviewed_at: ${fresh}\nreview_status: complete\n`,
+    ),
+  );
+  await publish(
     "other-repo",
     9,
     itemRecord(null, 9, `reviewed_at: "${fresh}"\nreview_status: "complete"\n`),
   );
+  await publish(
+    "unmanaged-repo",
+    10,
+    itemRecord(null, 10, `reviewed_at: "${fresh}"\nreview_status: "complete"\n`),
+  );
+  const inventory = await queue.fetch(
+    new Request("https://queue/review-coverage/inventory", {
+      method: "POST",
+      body: JSON.stringify({
+        generated_at: new Date(now).toISOString(),
+        repositories: [
+          {
+            repo: "openclaw/openclaw",
+            repo_slug: "openclaw-openclaw",
+            open_issues: 5,
+            open_pull_requests: 2,
+          },
+          {
+            repo: "other/repo",
+            repo_slug: "other-repo",
+            open_issues: 1,
+            open_pull_requests: 1,
+          },
+        ],
+      }),
+    }),
+  );
+  assert.equal(inventory.status, 202);
 
   const response = await queue.fetch(new Request("https://queue/review-coverage"));
   assert.equal(response.status, 200);
@@ -9359,28 +9397,46 @@ test("review coverage summarizes canonical item records per fleet", async () => 
   };
   assert.equal(payload.ok, true);
   assert.equal(payload.window_days, 7);
-  assert.equal(payload.fleets.length, 2);
-  const [openclaw, other] = payload.fleets;
+  assert.equal(payload.inventory_status, "current");
+  assert.equal(payload.fleets.length, 3);
+  const [openclaw, other, unmanaged] = payload.fleets;
   assert.equal(openclaw.repo, "openclaw/openclaw");
   assert.equal(openclaw.repo_slug, "openclaw-openclaw");
-  assert.equal(openclaw.open_records, 4);
+  assert.equal(openclaw.open_records, 7);
+  assert.equal(openclaw.reviewable_records, 6);
+  assert.equal(openclaw.tracked_records, 5);
   assert.equal(openclaw.reviewed_recent, 1);
   assert.equal(openclaw.stale, 1);
   assert.equal(openclaw.failed, 1);
-  assert.equal(openclaw.pending, 1);
-  assert.equal(openclaw.coverage_percent, 25);
+  assert.equal(openclaw.expired, 1);
+  assert.equal(openclaw.untracked_open, 2);
+  assert.equal(openclaw.pending, 3);
+  assert.equal(openclaw.excluded, 1);
+  assert.equal(openclaw.coverage_percent, 16.7);
   assert.equal(openclaw.oldest_reviewed_at, new Date(Date.parse(outdated)).toISOString());
-  assert.equal(other.repo, "other-repo");
-  assert.equal(other.open_records, 1);
+  assert.equal(other.repo, "other/repo");
+  assert.equal(other.open_records, 2);
   assert.equal(other.reviewed_recent, 1);
-  assert.equal(other.coverage_percent, 100);
+  assert.equal(other.untracked_open, 1);
+  assert.equal(other.coverage_percent, 50);
+  assert.equal(unmanaged.schedulable, false);
+  assert.equal(unmanaged.tracked_records, 1);
+  assert.equal(unmanaged.unschedulable_records, 1);
   assert.deepEqual(payload.totals, {
-    open_records: 5,
+    open_records: 9,
+    reviewable_records: 8,
+    tracked_records: 6,
     reviewed_recent: 2,
     stale: 1,
     failed: 1,
-    pending: 1,
-    coverage_percent: 40,
+    expired: 1,
+    unreviewed_records: 0,
+    untracked_open: 3,
+    pending: 4,
+    excluded: 1,
+    unschedulable_records: 1,
+    record_drift: 0,
+    coverage_percent: 25,
   });
 
   // Deleting the record tombstones it out of the open universe.
@@ -9409,12 +9465,38 @@ test("review coverage summarizes canonical item records per fleet", async () => 
   };
   // Responses are cached for up to a minute; the tombstone appears on refresh.
   assert.equal(cached.generated_at, payload.generated_at);
-  assert.equal(cached.totals.open_records, 5);
+  assert.equal(cached.totals.open_records, 9);
+  assert.equal(cached.totals.tracked_records, 6);
 });
 
 test("worker exposes review coverage through the public API route", async () => {
   const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
-  const env = { EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue) };
+  const secret = "coverage-secret";
+  const env = {
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+  };
+  const inventoryBody = JSON.stringify({
+    generated_at: new Date().toISOString(),
+    repositories: [
+      {
+        repo: "openclaw/openclaw",
+        repo_slug: "openclaw-openclaw",
+        open_issues: 1,
+        open_pull_requests: 0,
+      },
+    ],
+  });
+  const inventorySignature = `sha256=${createHmac("sha256", secret).update(inventoryBody).digest("hex")}`;
+  const inventoryResponse = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/review-coverage/inventory", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": inventorySignature },
+      body: inventoryBody,
+    }),
+    env,
+  );
+  assert.equal(inventoryResponse.status, 202);
   const response = await worker.fetch(
     new Request("https://clawsweeper.openclaw.ai/api/review-coverage"),
     env,
@@ -9422,7 +9504,7 @@ test("worker exposes review coverage through the public API route", async () => 
   assert.equal(response.status, 200);
   const payload = (await response.json()) as { ok: boolean; fleets: unknown[] };
   assert.equal(payload.ok, true);
-  assert.deepEqual(payload.fleets, []);
+  assert.equal(payload.fleets.length, 1);
 
   const unconfigured = await worker.fetch(
     new Request("https://clawsweeper.openclaw.ai/api/review-coverage"),

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHmac } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,7 +9,9 @@ import test from "node:test";
 import {
   defaultLimit,
   filterEligibleRepositories,
+  publishReviewCoverageInventory,
   renderFleetReviewCoverage,
+  reviewCoverageInventorySnapshot,
   selectRepositories,
   summarizeFleetReviewCoverage,
   type InventoryConfig,
@@ -84,6 +87,69 @@ test("target fanout summarizes trailing weekly coverage from canonical open reco
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("target fanout publishes signed live open counts for dashboard coverage", async () => {
+  const now = Date.parse("2026-07-29T12:00:00Z");
+  const repositories = [
+    { targetRepo: "openclaw/openclaw", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "steipete/tool", defaultBranch: "main", visibility: "PUBLIC" },
+  ];
+  const snapshot = reviewCoverageInventorySnapshot(
+    repositories,
+    new Map([
+      ["openclaw/openclaw", { issues: 3596, pullRequests: 2319 }],
+      ["steipete/tool", { issues: 2, pullRequests: 1 }],
+    ]),
+    now,
+  );
+  assert.deepEqual(snapshot, {
+    generated_at: "2026-07-29T12:00:00.000Z",
+    repositories: [
+      {
+        repo: "openclaw/openclaw",
+        repo_slug: "openclaw-openclaw",
+        open_issues: 3596,
+        open_pull_requests: 2319,
+      },
+      {
+        repo: "steipete/tool",
+        repo_slug: "steipete-tool",
+        open_issues: 2,
+        open_pull_requests: 1,
+      },
+    ],
+  });
+
+  const requests: Array<{ body: string; signature: string }> = [];
+  const waits: number[] = [];
+  await publishReviewCoverageInventory({
+    baseUrl: "https://queue.example/",
+    webhookSecret: "coverage-secret",
+    snapshot,
+    attempts: 2,
+    fetchImpl: async (_input, init) => {
+      const body = String(init?.body ?? "");
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      requests.push({
+        body,
+        signature: String(headers["x-clawsweeper-exact-review-signature"]),
+      });
+      return requests.length === 1
+        ? Response.json({ error: "busy" }, { status: 503 })
+        : Response.json({ ok: true }, { status: 202 });
+    },
+    sleep: async (milliseconds) => {
+      waits.push(milliseconds);
+    },
+  });
+  assert.equal(requests.length, 2);
+  assert.deepEqual(waits, [5_000]);
+  assert.equal(requests[0]?.body, JSON.stringify(snapshot));
+  assert.equal(
+    requests[0]?.signature,
+    `sha256=${createHmac("sha256", "coverage-secret").update(JSON.stringify(snapshot)).digest("hex")}`,
+  );
 });
 
 test("target fanout filters eligible repositories conservatively", () => {

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -13,7 +13,7 @@ import { item } from "./helpers.ts";
 function schedulerCandidate(candidate) {
   return {
     item: candidate.item,
-    review: null,
+    review: candidate.review ?? null,
     priority: candidate.priority ?? reviewPriority(candidate.item, null),
     reviewedAt: candidate.reviewedAt ?? 0,
     nextDueAt: candidate.nextDueAt ?? 0,
@@ -497,6 +497,36 @@ test("normal scheduler prioritizes oldest weekly-coverage timestamps before hot 
   ];
 
   assert.deepEqual(selectedNumbers(due, 3, now), [3, 2, 1]);
+});
+
+test("weekly coverage renews overdue canonical records before growing the unseen backlog", () => {
+  const now = Date.parse("2026-06-14T12:00:00Z");
+  const due = [
+    {
+      item: item({ number: 1, createdAt: "2020-01-01T00:00:00Z" }),
+      bucket: "weekly_issue",
+      priority: 6,
+      reviewedAt: 0,
+      nextDueAt: 0,
+    },
+    {
+      item: item({ number: 2, createdAt: "2021-01-01T00:00:00Z" }),
+      bucket: "weekly_issue",
+      priority: 6,
+      reviewedAt: 0,
+      nextDueAt: 0,
+    },
+    {
+      item: item({ number: 3, createdAt: "2026-01-01T00:00:00Z" }),
+      review: { reviewStatus: "complete", reviewedAt: "2026-06-07T12:00:00Z" },
+      bucket: "weekly_issue",
+      priority: 6,
+      reviewedAt: Date.parse("2026-06-07T12:00:00Z"),
+      nextDueAt: 0,
+    },
+  ];
+
+  assert.deepEqual(selectedNumbers(due, 2, now), [3, 1]);
 });
 
 test("weekly freshness preselection still fills remaining scheduler capacity", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -462,6 +462,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.equal(reserveLease.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
   assert.match(reserveLease.run ?? "", /pnpm run --silent reserve-review-lease/);
   assert.match(reserveLease.run ?? "", /review-timeout-ms/);
+  assert.match(reserveLease.run ?? "", /for attempt in 1 2 3 4 5/);
+  assert.match(reserveLease.run ?? "", /RANDOM % 4/);
+  assert.match(reserveLease.run ?? "", /status.*superseded/);
+  assert.match(reserveLease.run ?? "", /successful no-op/);
   assert.match(source, /Review exact item \{0\} rev \{1\} head \{2\}/);
   assert.equal(
     reserveLease.env?.EXACT_REVIEW_ITEM_KEY,
@@ -511,6 +515,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   const releaseGeneration = step(reviewer, "Release unsuccessful workflow-owned review lease");
   assert.match(create.if ?? "", /review-exact-event-item\.outcome == 'success'/);
   assert.match(create.if ?? "", /review-exact-event-item\.outputs\.retry_at == ''/);
+  assert.match(create.if ?? "", /review-exact-event-item\.outputs\.superseded != 'true'/);
   assert.equal(create.env?.EXACT_REVIEW_PRODUCER_JOB, "event-review-apply");
   assert.equal(
     create.env?.EXACT_REVIEW_DECISION,
@@ -536,6 +541,11 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
   assert.match(deferHeldReview.run ?? "", /retry deferred/);
   assert.match(failGeneration.if ?? "", /reserve-exact-review-lease\.outputs\.status != 'held'/);
+  assert.match(
+    failGeneration.if ?? "",
+    /reserve-exact-review-lease\.outputs\.status != 'superseded'/,
+  );
+  assert.match(failGeneration.if ?? "", /review-exact-event-item\.outputs\.superseded != 'true'/);
   assert.match(failGeneration.if ?? "", /complete-exact-review-queue\.outcome != 'success'/);
   assert.match(releaseGeneration.if ?? "", /reserve-exact-review-lease\.outputs\.status != 'held'/);
   assert.match(releaseGeneration.run ?? "", /content == "eyes"/);
@@ -2580,6 +2590,16 @@ test("scheduled reviews feed the durable queue instead of one-item matrix worker
   assert.match(workflow, /Review scheduled hot item/);
   assert.match(workflow, /Review scheduled normal item/);
   assert.match(workflow, /needs\.plan\.outputs\.queue_feed != 'true'/);
+});
+
+test("fleet coverage publishes live open inventory to the dashboard worker", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const coverageStep = workflow.slice(
+    workflow.indexOf("- name: Summarize trailing weekly review coverage"),
+    workflow.indexOf("\n      - name: Publish fanout cursor"),
+  );
+  assert.match(coverageStep, /CLAWSWEEPER_WEBHOOK_SECRET/);
+  assert.match(coverageStep, /--publish-url "\$REVIEW_COVERAGE_URL"/);
 });
 
 test("review git info follows checked-out target branch", () => {


### PR DESCRIPTION
## Summary

- retry expected exact-review reservation races up to five times with jittered backoff, and finish green when a newer queue owner has superseded the run
- treat queue-authority loss during review generation as a successful fenced no-op instead of a model/content failure
- keep the existing bounded Codex transport retries, but emit a distinct `provider_throttle` classification when capacity errors survive them
- publish signed live GitHub open-item inventory into the Worker so dashboard coverage includes never-reviewed items and separates expired, untracked, protected, and unmanaged cohorts
- renew overdue canonical records before expanding the unseen backlog so the rolling coverage cohort cannot remain permanently stale

## Failure classification

The scale tail is queue contention, not a model ceiling.

- Runs [30472278499](https://github.com/openclaw/clawsweeper/actions/runs/30472278499), [30472272826](https://github.com/openclaw/clawsweeper/actions/runs/30472272826), [30472273778](https://github.com/openclaw/clawsweeper/actions/runs/30472273778), and [30472964231](https://github.com/openclaw/clawsweeper/actions/runs/30472964231) all fail `Reserve exact review lease` with `exact-review queue authority changed ... retry required`. Eleven of 16 sampled failed exact-review runs had this shape.
- The requested generation failure [30472661385](https://github.com/openclaw/clawsweeper/actions/runs/30472661385), plus [30471602542](https://github.com/openclaw/clawsweeper/actions/runs/30471602542), [30469872057](https://github.com/openclaw/clawsweeper/actions/runs/30469872057), [30469629021](https://github.com/openclaw/clawsweeper/actions/runs/30469629021), and [30468471613](https://github.com/openclaw/clawsweeper/actions/runs/30468471613), reached Codex and were then terminated only after `Exact-review heartbeat lost its lease tuple`; the resulting exit 143 was mislabeled as unsuccessful generation.
- [30471565802](https://github.com/openclaw/clawsweeper/actions/runs/30471565802) is the sampled genuine Codex failure: it wrote a fallback review artifact and exited 1. None of the sampled full logs contains a 429, TPM/RPM limit, quota, spend-cap, or overload signal.
- `setup-codex` configures an isolated CLI and local Responses proxy but has no 128-call or provider-concurrency cap. The repository's 128 value is ClawSweeper worker admission. Existing review execution already performs bounded transient transport retries; this change makes surviving provider throttles observable without reducing throughput for a ceiling the evidence does not show.

## Coverage root cause

At 2026-07-29 16:58 UTC the public endpoint reported 1,754 `open_records`, 1,317 recent reviews, and the unchanged 426 pending records. Live GitHub held 3,596 open issues plus 2,319 open pull requests: 5,915 open items.

`reviewCoverageSync` treated canonical `items` records as the entire open universe, but those records exist only after an item has reached publication. Its `pending` fallback also combined old `review_status: complete` records outside the seven-day window with records missing usable review metadata. Meanwhile the scheduler correctly selected older never-reviewed GitHub items, creating fresh canonical records outside the old denominator while the 426 tracked records remained behind that unseen backlog. The dashboard therefore showed rising verdict throughput with a flat pending cohort.

The fix reuses the existing authenticated six-hour fleet scan to publish live per-repository issue/PR totals to the Worker. Coverage now uses live reviewable open items as the denominator, exposes tracked/untracked and expired/unreviewed breakdowns, excludes protected canonical records, and reports canonical records from repositories no longer in the eligible fleet as unmanaged instead of degrading active-fleet coverage. The scheduler gives already-tracked six-day-overdue records first claim on coverage slots, then fills all remaining capacity from unseen items.

## Proof

- focused queue/Worker, scheduler, target-fanout, workflow, and Codex-runner suite: 385 passed, 0 failed
- `pnpm run format:check`: passed
- `pnpm run lint`: passed
- `pnpm run build:all`: passed on Node 26.5.0
- `pnpm run check`: static/build/lint gates and coverage thresholds passed; the full suite retains the five known macOS-only Linux-containment failures because Apple libc does not export `capset`, matching the documented #940 baseline
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings
- `git diff --check`: passed

## Rollout

A Worker redeploy is required for the signed inventory endpoint and corrected coverage response. After deploy, the next `37 */6 * * *` fleet coverage scan seeds the live inventory; until then the API explicitly reports `inventory_status: missing` and retains the canonical-record fallback. This PR does not deploy, merge, or run the live apply/close path.
