### PR TITLE
fix(ci): publish review-coverage inventory on audit dispatches

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2526,7 +2526,11 @@ jobs:
             --ref main
 
       - name: Summarize trailing weekly review coverage
-        if: ${{ github.event.schedule == '37 */6 * * *' }}
+        # Also runs for operator dispatches of the audit lane: the signed live
+        # inventory is what gives /api/review-coverage its true denominator, and
+        # gating it on one cron string left the metric reporting "missing" for
+        # up to six hours after a deploy or an on-demand audit.
+        if: ${{ github.event.schedule == '37 */6 * * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') }}
         env:
           GH_TOKEN: ${{ github.token }}
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
/api/review-coverage reports inventory_status=missing and falls back to the record-only denominator (1,865 records / 75%) instead of the true live-item basis (~5,915), because the inventory publication step is gated on the exact cron string '37 */6 * * *' — operator dispatches of the audit lane skip it, so after a deploy the corrected metric from #943 stays blind for up to six hours. Extends the condition to workflow_dispatch runs with audit_dashboard=true. Workflow tests 80/80, autoreview clean.