### PR TITLE
docs: clarify contributor proof lifecycle

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -62,4 +62,9 @@ changes when it clarifies the result.
 
 Reviewers will inspect the code, tests, and CI. Use this section to make the
 validation easy to understand, not to restate the diff.
+
+For code-bearing changes, include the current `## Real Behavior Proof` package
+described in [CONTRIBUTING.md](../CONTRIBUTING.md). After review feedback, update
+this main PR body and request a re-review only after the branch, proof, and body
+are current.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,14 @@ not split reports into issue/PR subtrees.
   Use the narrowest meaningful proof first and broaden it for shared or
   higher-risk behavior. Docs-only changes normally need `git diff --check` and
   relevant link or command sanity instead.
+- A ClawSweeper result that requires proof or identifies an accepted/actionable
+  finding remains PR-owner work, not a handoff. Before a manually requested
+  review or re-review, put current proof and the finding disposition or evidence
+  in the main PR body. A head or PR-body change after the durable review marker
+  makes that review and any affected proof stale: rerun the affected proof and
+  obtain a review for the current head and body. CI, labels, readiness, and
+  maintainer permissions are evidence only; the explicit-user-approval boundary
+  below still controls landing.
 - Before merge or automerge, the latest ClawSweeper review must apply to the
   current PR head and body. Resolve every accepted finding. Apply each
   applicable `Rank-up moves:` item, or explicitly justify the exception in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to ClawSweeper
+
+ClawSweeper is the conservative maintenance bot for OpenClaw repositories. This
+guide is for people and coding agents preparing or updating a ClawSweeper pull
+request. It complements the repository's [README](README.md) and
+[AGENTS.md](AGENTS.md); the latter is the binding instruction file for agents.
+
+## Before You Start
+
+- Keep one focused problem and one pull request together. Check open pull
+  requests first so a new change does not duplicate active work.
+- Start an issue or ask a maintainer before broad product, architecture,
+  automation, workflow, or security work. Route security-sensitive work through
+  the repository's security handling instead of a normal public PR.
+- For an `openclaw/openclaw` target PR, do not submit a normal PR that edits
+  `CHANGELOG.md`. That changelog is release-owned; put release-note context in
+  the PR body and commit message. For ClawSweeper or another target repository,
+  follow that repository's release-note policy.
+- Read the root `AGENTS.md`, then any scoped instructions for files you touch.
+  Coding agents must follow those instructions even when this guide is shorter.
+
+## Local Setup and Focused Validation
+
+ClawSweeper requires Node 24 or newer.
+
+```bash
+corepack enable
+pnpm install
+pnpm run build
+pnpm run check
+```
+
+Use the narrowest meaningful validation for the changed surface first. For a
+docs-only change, run `git diff --check` and verify the changed links and
+commands. For code, test, workflow, queue, API, UI, package, or integration
+changes, follow `AGENTS.md`: run focused behavior validation and the mandatory
+Codex review loop before opening or updating a PR.
+
+## Create or Update a Pull Request
+
+Use the [pull request template](.github/pull_request_template.md). Keep these
+main-body sections current:
+
+- **What Problem This Solves** — the concrete user, product, or operator
+  problem and trigger.
+- **Why This Change Was Made** — the shipped solution, important boundary, and
+  non-goals.
+- **User Impact** — the observable benefit, or a clear statement that there is
+  no user-visible change.
+- **Evidence** — focused tests, CI, screenshots, terminal output, live
+  observations, redacted logs, or artifact links that make the validation easy
+  to inspect.
+
+For code-bearing changes, keep an executed `## Real Behavior Proof` package in
+the main PR body. State the claim, exercised surface, scenario or fixture,
+command and environment, observed result, artifact or trace, and limits. Tests
+and CI support the claim but do not replace proof of a changed runtime,
+workflow, queue, API, UI, package, or integration path. Redact tokens, private
+URLs, user data, and unrelated logs before posting evidence.
+
+## Review Conversations Are Author-Owned
+
+Treat a ClawSweeper or maintainer result as the next-step checklist for the PR,
+not as a handoff.
+
+1. Read the latest durable ClawSweeper comment, its reviewed head, proof
+   guidance, accepted findings, and any contributor-facing blocker.
+2. Address every accepted or actionable finding. Apply an applicable
+   `Rank-up moves:` item, or explain the exception in the main PR body; those
+   optional moves are not blockers by themselves.
+3. Put the updated proof and each finding's disposition or supporting evidence
+   in the main PR body. Do not leave required proof only in a comment.
+4. If the branch head or PR body changed after the latest durable review, treat
+   that review and any affected proof as stale. Rerun the affected proof and
+   wait until the next review applies to the current head and body.
+5. Request `@clawsweeper re-review` only after the branch, body, proof, and
+   relevant checks are current. PR authors and users with repository write
+   access may use `@clawsweeper re-review` or `@clawsweeper re-run`; plain
+   `@clawsweeper review` is maintainer-only. Do not dispatch a review workflow
+   directly.
+
+`status: ⏳ waiting on author` or `status: 📣 needs proof` means the next action
+belongs to the author. Let the normal queue finish after a current re-review;
+repeated commands before the requested changes are present add noise rather
+than evidence.
+
+## Readiness and Landing
+
+`proof: sufficient` and `status: 👀 ready for maintainer look` are evidence for
+maintainer review, not approval to merge. Contributors must not use maintainer
+repair, autofix, automerge, approve, or workflow-dispatch routes. Agents must
+not merge or enable/execute automerge without the user's explicit approval in
+the current conversation, even when a PR is otherwise ready. Normal ClawSweeper
+mutation and merge routes remain maintainer-controlled and subject to their
+separate exact-head, check, mergeability, and policy gates.
+
+If a human maintainer is already actively repairing or reviewing the PR, do not
+work on the branch or summon a parallel ClawSweeper lane. Keep the discussion on
+the PR; ask for maintainer direction only when the next decision or proof
+requires it.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ self-review for `openclaw/clawsweeper`.
 
 Project vision and boundaries: [`VISION.md`](VISION.md)
 
+## Contributing
+
+For local setup, PR scope, main-body proof, and the author-owned review loop,
+read [CONTRIBUTING.md](CONTRIBUTING.md) before opening or updating a pull
+request. The guide explains when to use `@clawsweeper re-review`, why a changed
+head or PR body needs fresh evidence, and why readiness is not merge authority.
+
 The OpenClaw-hosted ClawSweeper instance is not a public review service and does
 not provide free reviews for third-party repositories. If you want ClawSweeper
 for your own project, fork this repository, deploy it in your own organization,

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -4,6 +4,10 @@ Read when: changing issue/PR review comments, ClawSweeper repair dispatch,
 comment-sync behavior, or the trusted marker contract between ClawSweeper review
 and repair lanes.
 
+> This is implementation documentation. PR authors responding to proof or review
+> feedback should follow the public [contributor workflow](../CONTRIBUTING.md)
+> instead of treating comment markers or repair details as author instructions.
+
 ## Purpose
 
 ClawSweeper keeps one durable public Codex review comment per issue or pull

--- a/docs/proof-nudges.md
+++ b/docs/proof-nudges.md
@@ -2,6 +2,11 @@
 
 Read when changing the ClawSweeper lane that reminds pull request authors to add real behavior proof.
 
+> This is lane-maintenance documentation. A PR author who receives a proof nudge
+> should use the [contributor workflow](../CONTRIBUTING.md): update the main PR
+> body with current proof, then request a re-review only after the branch and
+> relevant checks are current.
+
 ## Scope
 
 The proof-nudge lane is read-mostly triage hygiene. It can post a polite reminder comment when the latest ClawSweeper review still requires real behavior proof, but it does not close pull requests, merge pull requests, change labels, request reviews, or modify review records.

--- a/docs/repair/automerge-flow.md
+++ b/docs/repair/automerge-flow.md
@@ -57,8 +57,6 @@ Repairable states include:
 - `mergeable: CONFLICTING`;
 - `mergeStateStatus: DIRTY`;
 - `mergeStateStatus: BEHIND`;
-- missing `CHANGELOG.md` entry for user-facing OpenClaw `fix`, `feat`, or
-  `perf` PRs;
 - terminal required-check failures such as `FAILURE`, `ERROR`,
   `ACTION_REQUIRED`, `STARTUP_FAILURE`, or `TIMED_OUT`;
 - accepted ClawSweeper repair verdicts or action markers for the exact current
@@ -78,19 +76,24 @@ and generated config checksum conflicts where the replayed commit changed only
 selected checksum entries. That deterministic fast path is only for explicit
 base-sync-only artifacts.
 
-For adopted PR repairs that add only docs or changelog files after the reviewed
-source head, ClawSweeper runs repair-delta validation and skips the internal
-Codex `/review`. The exact-head ClawSweeper review and GitHub checks still gate
-the pushed head before merge.
+For adopted `openclaw/openclaw` contributor-branch repairs that add only docs
+or `CHANGELOG.md` after the reviewed source head, ClawSweeper runs repair-delta
+validation and skips the internal Codex `/review`. The exact-head ClawSweeper
+review and GitHub checks still gate the pushed head before merge. That target's
+`CHANGELOG.md` is release-owned: this validation path does not authorize a
+repair worker to add or update it outside separately authorized release work.
 
 For adopted automerge/autofix PR repairs, the cluster worker skips the
 read-only Codex planning pass after it hydrates the live PR. It writes a generic
 structured `build_fix_artifact` result deterministically: repair the contributor
 branch, keep the source PR credited, rebase onto latest `main`, address PR
-comments/review findings/check failures, add the changelog entry when required,
-and validate. This removes one model round trip from every opted-in repair while
-keeping live evidence, permissions, security boundaries, push, review, checks,
-and merge gating in deterministic code.
+comments/review findings/check failures, preserve release-note context in the PR
+body and commit message, and validate. For an `openclaw/openclaw` target, it
+must not add or update `CHANGELOG.md` outside separately authorized release
+work. Other target repositories retain their own release-note policy, including
+an eligible changelog-only mechanical repair. This removes one model round trip
+from every opted-in repair while keeping live evidence, permissions, security
+boundaries, push, review, checks, and merge gating in deterministic code.
 
 For automerge, failed exact-head checks are repair scope even when the failing
 file is outside the original PR's changed files. The Codex edit pass should


### PR DESCRIPTION
## Summary

Add a public contributor journey for ClawSweeper, with the proof and review
ownership rules surfaced from the README and PR template.

## Problem

ClawSweeper's stricter author obligations were mainly discoverable through
agent and implementation documentation. Contributors could receive a review or
proof result without a concise public path for updating main-body evidence,
handling findings, obtaining a fresh review after a head/body change, and
understanding that readiness is not landing authority. Repair documentation also
gave an over-broad changelog instruction.

## Implementation

- Add `CONTRIBUTING.md` covering setup, focused validation, PR-body proof, the
  author-owned review loop, re-review routing, and maintainer-controlled landing.
- Link it from the README, PR template, proof-nudge, and review-comment docs.
- Add the minimum corresponding discovery/owner-loop clarification to `AGENTS.md`.
- Scope changelog guidance to `openclaw/openclaw` and document the implemented
  target-and-strategy boundaries for repair-delta validation and mechanical
  changelog repair.

## Validation

- `git diff --check origin/main...HEAD`
- `git diff --check`
- Focused PowerShell documentation contract probe:
  - confirms all changed entry points contain their required contributor-flow
    wording;
  - resolves local relative Markdown links;
  - rejects the obsolete generic changelog-repair instructions; and
  - confirms the implemented `openclaw/openclaw` and
    `repair_contributor_branch` guards in repair validation.

Observed result: `CSW-074 docs behavior proof: PASS`.

## Real Behavior Proof

- **Claim:** a contributor starting at the README, PR template, proof nudge, or
  review-comment documentation is directed to a single public workflow that
  requires current main-body proof, finding disposition, and fresh review after
  a changed head or body, while preserving maintainer-only mutation and explicit
  current-user merge approval.
- **Exercised surface:** all four contributor-facing discovery points,
  `CONTRIBUTING.md`, root `AGENTS.md`, and the repair-flow changelog rules.
- **Scenario / fixture:** the focused contract probe reads those Markdown files,
  resolves every local `.md` link they introduce, asserts the author-loop and
  readiness boundaries, rejects the two stale generic repair instructions, and
  checks the target/strategy guards in the live repair source.
- **Command / environment:** PowerShell in this repository on commit
  `3ed24ac8bdcc8590483399f12d005fd7d110547e`, using the validation commands
  above and the focused contract probe.
- **Observed result:** all checks passed; every new local Markdown link resolved;
  the instructions route to the current-head/current-body proof loop; and the
  OpenClaw-specific changelog exception matches the implementation.
- **Artifact / trace:** this PR body plus the reviewed commit and the recorded
  `CSW-074 docs behavior proof: PASS` command output.
- **Limits:** this is documentation behavior, not a GitHub enforcement change.
  Labels, queues, workflows, reviewer permissions, and merge gates are
  intentionally unchanged.

## Codex Review Closeout

- `codex review --uncommitted`: final clean run reported no accepted/actionable
  findings.
- `codex review --base origin/main`: final clean run reported no actionable
  regressions.
- Accepted review findings narrowed changelog language to the implemented
  `openclaw/openclaw` release-owned policy and limited the repair-delta fast path
  to adopted OpenClaw contributor-branch repairs. Focused proof and review were
  rerun after each correction.

## Risks / Rollout

Documentation-only change. It improves discovery and makes the author loop
explicit, but cannot itself prevent a direct merge or enforce proof freshness;
the existing maintainer and GitHub controls remain the enforcement boundary.

## Links

CSW-074 contributor proof-lifecycle documentation follow-up.
