### PR TITLE
fix: fence exact-review batch publication identity

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -161,12 +161,21 @@ jobs:
 
           pnpm run --silent repair:exact-review-batch commit
           test ! -f "$heartbeat_failed"
+          receipt_path="$(dirname "$EXACT_REVIEW_BATCH_MANIFEST")/state-receipt.json"
           jq -c '.items[]' "$EXACT_REVIEW_BATCH_MANIFEST" | while IFS= read -r item; do
             test ! -f "$heartbeat_failed"
             outcome_path="$(jq -r '.outcomePath' <<<"$item")"
             [ -f "$outcome_path" ] || continue
             if ! jq -e '.kind == "eligible" or (.kind == "superseded" and .disposition.requeueLatestExpected == true)' "$outcome_path" >/dev/null; then
               continue
+            fi
+            if jq -e '.kind == "eligible"' "$outcome_path" >/dev/null; then
+              fence_key="$(jq -r '.itemKey' <<<"$item")"
+              if ! jq -e --arg fence_key "$fence_key" \
+                'any(.outcomes[]?; .fenceKey == $fence_key and (.outcome == "accepted" or .outcome == "deduped"))' \
+                "$receipt_path" >/dev/null; then
+                continue
+              fi
             fi
             target_repo="$(jq -r '.decision.targetRepo' <<<"$item")"
             target_branch="$(jq -r '.decision.targetBranch' <<<"$item")"

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -49,9 +49,15 @@ export type DirectPublicationOperation = {
 };
 
 export type DirectPublicationPlan = {
-  itemKey: string;
+  canonicalTargetKey: string;
+  fenceKey: string;
   revision: number;
-  identity: { itemKey: string; revision: number; claimGeneration: number };
+  identity: {
+    canonicalTargetKey: string;
+    fenceKey: string;
+    revision: number;
+    claimGeneration: number;
+  };
   operations: DirectPublicationOperation[];
   totalBytes: number;
 };
@@ -178,6 +184,8 @@ export class ExactReviewDirectPublicationStore {
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE} (
          item_key TEXT NOT NULL,
+         canonical_target_key TEXT NOT NULL DEFAULT '',
+         fence_key TEXT NOT NULL DEFAULT '',
          revision INTEGER NOT NULL CHECK (revision >= 1),
          identity_item_key TEXT NOT NULL,
          identity_revision INTEGER NOT NULL CHECK (identity_revision >= 1),
@@ -196,6 +204,42 @@ export class ExactReviewDirectPublicationStore {
          failure_reason TEXT,
          PRIMARY KEY (item_key, revision)
        ) STRICT`,
+    );
+    const directPublicationColumns = new Set(
+      Array.from(
+        this.storage.sql.exec(
+          `SELECT name FROM pragma_table_info('${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}')`,
+        ),
+      ).map((row) => String(row.name || "")),
+    );
+    if (!directPublicationColumns.has("canonical_target_key")) {
+      this.storage.sql.exec(
+        `ALTER TABLE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+           ADD COLUMN canonical_target_key TEXT NOT NULL DEFAULT ''`,
+      );
+    }
+    if (!directPublicationColumns.has("fence_key")) {
+      this.storage.sql.exec(
+        `ALTER TABLE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+           ADD COLUMN fence_key TEXT NOT NULL DEFAULT ''`,
+      );
+    }
+    // Every pre-envelope receipt used its sole item key for both roles. Keep
+    // those completed receipts dedupe-compatible while all new writes preserve
+    // the explicit dual identity below.
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+          SET canonical_target_key = item_key
+        WHERE canonical_target_key = ''`,
+    );
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
+          SET fence_key = item_key
+        WHERE fence_key = ''`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_direct_publication_target_revision
+         ON ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE} (canonical_target_key, revision)`,
     );
     this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${CANONICAL_RECORD_TUPLE_RECEIPT_TABLE} (
@@ -317,29 +361,34 @@ export class ExactReviewDirectPublicationStore {
     const canonicalOperations = canonicalTupleOperations(plan);
     return this.storage.transactionSync(() => {
       this.pruneTerminalSync(now);
-      const existing = this.readSync(plan.itemKey, plan.revision);
+      const existing = this.readSync(plan.fenceKey, plan.revision);
       if (existing) {
         if (["pending", "committing", "retryable"].includes(existing.state)) {
           this.storage.sql.exec(
             `DELETE FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
               WHERE item_key = ? AND revision = ?`,
-            plan.itemKey,
+            plan.fenceKey,
             plan.revision,
           );
         } else {
           if (canonicalStoredPlan(existing) !== canonicalIncomingPlan(plan, storedOperations)) {
             throw new Error("conflicting direct publication retry");
           }
-          return { outcome: "deduped" as const, row: existing, supersededRevisions: [] };
+          return {
+            outcome:
+              existing.state === "superseded" ? ("superseded" as const) : ("deduped" as const),
+            row: existing,
+            supersededRevisions: [],
+          };
         }
       }
 
       const newer = Array.from(
         this.storage.sql.exec(
           `SELECT revision FROM ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-            WHERE item_key = ? AND revision > ?
+            WHERE fence_key = ? AND revision > ?
             ORDER BY revision DESC LIMIT 1`,
-          plan.itemKey,
+          plan.fenceKey,
           plan.revision,
         ),
       )[0];
@@ -429,9 +478,15 @@ export class ExactReviewDirectPublicationStore {
 
       const revision = this.nextTupleRevisionSync(mutation.repoSlug, mutation.itemId);
       const plan: CanonicalDirectPublicationPlan = {
-        itemKey: mutation.key,
+        canonicalTargetKey: mutation.key,
+        fenceKey: mutation.key,
         revision,
-        identity: { itemKey: mutation.key, revision, claimGeneration: 1 },
+        identity: {
+          canonicalTargetKey: mutation.key,
+          fenceKey: mutation.key,
+          revision,
+          claimGeneration: 1,
+        },
         operations: mutation.operations,
         totalBytes: mutation.operations.reduce((sum, operation) => sum + operation.bytes, 0),
       };
@@ -961,7 +1016,7 @@ export class ExactReviewDirectPublicationStore {
       chunks.length,
       operation.content === null ? 1 : 0,
       revision,
-      plan.itemKey,
+      plan.canonicalTargetKey,
       plan.identity.claimGeneration,
       now,
     );
@@ -1192,13 +1247,16 @@ export class ExactReviewDirectPublicationStore {
   private insertSync(row: DirectPublicationRow) {
     this.storage.sql.exec(
       `INSERT INTO ${EXACT_REVIEW_DIRECT_PUBLICATION_TABLE}
-       (item_key, revision, identity_item_key, identity_revision, claim_generation,
+       (item_key, canonical_target_key, fence_key, revision,
+        identity_item_key, identity_revision, claim_generation,
         operations_json, total_bytes, file_count, state, attempts, created_at, updated_at,
         next_attempt_at, commit_sha, failure_reason)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      row.itemKey,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      row.fenceKey,
+      row.canonicalTargetKey,
+      row.fenceKey,
       row.revision,
-      row.identity.itemKey,
+      row.identity.fenceKey,
       row.identity.revision,
       row.identity.claimGeneration,
       JSON.stringify(row.operations),
@@ -1225,7 +1283,9 @@ function canonicalTupleOperations(
       operation.content !== null,
   );
   if (primaryWrites.length > 1) {
-    throw new Error(`direct publication tuple writes both primary sections: ${plan.itemKey}`);
+    throw new Error(
+      `direct publication tuple writes both primary sections: ${plan.canonicalTargetKey}`,
+    );
   }
   const primaryWrite = primaryWrites[0];
   const first = operations[0]!;
@@ -1260,7 +1320,7 @@ function canonicalTupleOperations(
     addDelete("decision-packets");
   }
   if (operations.length > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES) {
-    throw new Error(`canonical record tuple exceeds its file limit: ${plan.itemKey}`);
+    throw new Error(`canonical record tuple exceeds its file limit: ${plan.canonicalTargetKey}`);
   }
   return operations;
 }
@@ -1465,16 +1525,19 @@ export async function validateDirectPublicationPlan(
   value: DirectPublicationPlan,
 ): Promise<CanonicalDirectPublicationPlan> {
   const plan = value && typeof value === "object" ? value : ({} as DirectPublicationPlan);
-  const itemKey = boundedItemKey(plan.itemKey);
-  const itemIdentity = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#([1-9]\d*)$/.exec(itemKey);
-  if (!itemIdentity) throw new Error("invalid direct publication item key");
+  const canonicalTargetKey = boundedItemKey(plan.canonicalTargetKey);
+  const itemIdentity = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#([1-9]\d*)$/.exec(canonicalTargetKey);
+  if (!itemIdentity) throw new Error("invalid direct publication canonical target key");
+  const fenceKey = boundedItemKey(plan.fenceKey);
+  if (!fenceKey) throw new Error("invalid direct publication fence key");
   if (!Number.isSafeInteger(plan.revision) || plan.revision < 1) {
     throw new Error("invalid direct publication revision");
   }
   const identity = plan.identity;
   if (
     !identity ||
-    boundedItemKey(identity.itemKey) !== itemKey ||
+    boundedItemKey(identity.canonicalTargetKey) !== canonicalTargetKey ||
+    boundedItemKey(identity.fenceKey) !== fenceKey ||
     identity.revision !== plan.revision ||
     !Number.isSafeInteger(identity.claimGeneration) ||
     identity.claimGeneration < 1
@@ -1546,9 +1609,15 @@ export async function validateDirectPublicationPlan(
     throw new Error("direct publication plan exceeds the per-POST byte limit");
   }
   return {
-    itemKey,
+    canonicalTargetKey,
+    fenceKey,
     revision: plan.revision,
-    identity: { itemKey, revision: plan.revision, claimGeneration: identity.claimGeneration },
+    identity: {
+      canonicalTargetKey,
+      fenceKey,
+      revision: plan.revision,
+      claimGeneration: identity.claimGeneration,
+    },
     operations,
     totalBytes,
   };
@@ -1574,7 +1643,8 @@ function directPublicationRowFromPlan(options: {
   failureReason: string | null;
 }): DirectPublicationRow {
   return {
-    itemKey: options.plan.itemKey,
+    canonicalTargetKey: options.plan.canonicalTargetKey,
+    fenceKey: options.plan.fenceKey,
     revision: options.plan.revision,
     identity: options.plan.identity,
     operations: options.operations,
@@ -1591,10 +1661,12 @@ function directPublicationRowFromPlan(options: {
 
 function directPublicationRow(row: Record<string, unknown>): DirectPublicationRow {
   return {
-    itemKey: String(row.item_key),
+    canonicalTargetKey: String(row.canonical_target_key),
+    fenceKey: String(row.fence_key),
     revision: Number(row.revision),
     identity: {
-      itemKey: String(row.identity_item_key),
+      canonicalTargetKey: String(row.canonical_target_key),
+      fenceKey: String(row.fence_key),
       revision: Number(row.identity_revision),
       claimGeneration: Number(row.claim_generation),
     },
@@ -1615,9 +1687,13 @@ function canonicalIncomingPlan(
   operations: DirectPublicationStoredOperation[],
 ) {
   return JSON.stringify({
-    itemKey: plan.itemKey,
+    canonicalTargetKey: plan.canonicalTargetKey,
+    fenceKey: plan.fenceKey,
     revision: plan.revision,
-    identity: plan.identity,
+    // The claim generation fences completion ownership, not the immutable
+    // state tuple. A reclaimed batch must be able to dedupe an accepted tuple
+    // after its prior worker died before completion.
+    identity: stablePublicationIdentity(plan.identity),
     operations,
     totalBytes: plan.totalBytes,
   });
@@ -1625,12 +1701,21 @@ function canonicalIncomingPlan(
 
 function canonicalStoredPlan(plan: DirectPublicationRow) {
   return JSON.stringify({
-    itemKey: plan.itemKey,
+    canonicalTargetKey: plan.canonicalTargetKey,
+    fenceKey: plan.fenceKey,
     revision: plan.revision,
-    identity: plan.identity,
+    identity: stablePublicationIdentity(plan.identity),
     operations: plan.operations,
     totalBytes: plan.totalBytes,
   });
+}
+
+function stablePublicationIdentity(identity: DirectPublicationPlan["identity"]) {
+  return {
+    canonicalTargetKey: identity.canonicalTargetKey,
+    fenceKey: identity.fenceKey,
+    revision: identity.revision,
+  };
 }
 
 function canonicalTuplePath(path: string) {
@@ -1645,8 +1730,10 @@ function canonicalTuplePath(path: string) {
 }
 
 function boundedItemKey(value: unknown) {
-  const text = String(value || "").trim();
-  return text && text.length <= 500 && !text.includes("\0") && !/[\r\n]/.test(text) ? text : "";
+  if (typeof value !== "string" || value !== value.trim()) return "";
+  return value && value.length <= 500 && !value.includes("\0") && !/[\r\n]/.test(value)
+    ? value
+    : "";
 }
 
 function canonicalPath(value: unknown) {

--- a/dashboard/exact-review-publication-batches.ts
+++ b/dashboard/exact-review-publication-batches.ts
@@ -364,6 +364,34 @@ export class ExactReviewPublicationBatchStore {
     });
   }
 
+  ownsActiveFence(
+    fence: { itemKey: string; revision: number; claimGeneration: number },
+    now: number,
+  ): boolean {
+    return this.storage.transactionSync(() => {
+      this.reclaimExpiredSync(now);
+      return Boolean(
+        Array.from(
+          this.storage.sql.exec(
+            `SELECT 1
+               FROM ${EXACT_REVIEW_PUBLICATION_BATCH_ITEM_TABLE} AS membership
+               JOIN ${EXACT_REVIEW_PUBLICATION_BATCH_TABLE} AS batch
+                 ON batch.batch_id = membership.batch_id
+              WHERE batch.state = 'leased'
+                AND membership.terminal_outcome IS NULL
+                AND membership.item_key = ?
+                AND membership.revision = ?
+                AND membership.claim_generation = ?
+              LIMIT 1`,
+            fence.itemKey,
+            fence.revision,
+            fence.claimGeneration,
+          ),
+        )[0],
+      );
+    });
+  }
+
   recordObservation(
     batchId: string,
     leaseOwner: string,

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2398,24 +2398,65 @@ export class ExactReviewQueue {
       try {
         const validated = await validateDirectPublicationPlan(plan);
         const state = this.readStateSync();
-        const owned = state.items[validated.itemKey];
-        const existing = this.directPublicationStore.get(validated.itemKey, validated.revision);
-        const validFence =
+        const owned = state.items[validated.fenceKey];
+        const existing = this.directPublicationStore.get(validated.fenceKey, validated.revision);
+        const now = Date.now();
+        const targetMatchesFence =
+          owned &&
+          `${owned.decision.targetRepo}#${owned.decision.itemNumber}` ===
+            validated.canonicalTargetKey;
+        const directlyOwned =
+          targetMatchesFence &&
           owned &&
           owned.revision === validated.revision &&
           exactReviewClaimGeneration(owned.claimGeneration) ===
             validated.identity.claimGeneration &&
-          validated.identity.itemKey === validated.itemKey &&
+          validated.identity.canonicalTargetKey === validated.canonicalTargetKey &&
+          validated.identity.fenceKey === validated.fenceKey &&
           validated.identity.revision === validated.revision &&
           (owned.state === "leased" ||
             (owned.state === "parked" && owned.parkedReason === "direct_publication"));
+        const batchOwned =
+          deferredBatchCompletion &&
+          targetMatchesFence &&
+          owned &&
+          owned.revision === validated.revision &&
+          this.batchStore.ownsActiveFence(
+            {
+              itemKey: validated.fenceKey,
+              revision: validated.revision,
+              claimGeneration: validated.identity.claimGeneration,
+            },
+            now,
+          );
+        const publicationRevision = owned && exactReviewPublicationRevision(owned.decision);
+        const staleBatchFence =
+          batchOwned &&
+          publicationRevision &&
+          publicationRevision.sourceRevision <
+            this.publicationHeadRevisionSync(publicationRevision.targetKey);
+        if (staleBatchFence) {
+          return json(
+            {
+              ok: true,
+              accepted: false,
+              deduped: false,
+              superseded: true,
+              superseded_revisions: [],
+              canonical_target_key: validated.canonicalTargetKey,
+              fence_key: validated.fenceKey,
+              state_commit_sha: null,
+            },
+            202,
+          );
+        }
+        const validFence = directlyOwned || batchOwned;
         if (!validFence && !existing) {
           return json(
             { error: "direct_publication_fence_not_owned", fallback_required: true },
             409,
           );
         }
-        const now = Date.now();
         const accepted = this.directPublicationStore.accept(validated, now);
         if (owned && validFence && !deferredBatchCompletion) {
           const producerDecision = owned.decision.publication
@@ -2435,7 +2476,7 @@ export class ExactReviewQueue {
             producerRunId,
             producerRunAttempt,
             sourceSha: EXACT_REVIEW_DIRECT_PUBLICATION_SOURCE_SHA,
-            itemKey: validated.itemKey,
+            itemKey: validated.fenceKey,
             protocolVersion: 2,
             leaseRevision: validated.revision,
             claimGeneration: validated.identity.claimGeneration,
@@ -2488,6 +2529,8 @@ export class ExactReviewQueue {
             deduped: accepted.outcome === "deduped",
             superseded: accepted.outcome === "superseded",
             superseded_revisions: accepted.supersededRevisions,
+            canonical_target_key: accepted.row.canonicalTargetKey,
+            fence_key: accepted.row.fenceKey,
             state_commit_sha: accepted.row.commitSha,
           },
           202,

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -29,8 +29,19 @@ type BatchManifest = {
 type BatchReceipt = {
   batchId: string;
   publishedItemKeys: Set<string>;
+  outcomes: Map<string, BatchPublicationOutcome>;
   stateCommitSha?: string;
   stateWriter?: StateWriterOperation;
+};
+
+type BatchPublicationOutcome = {
+  canonicalTargetKey: string;
+  fenceKey: string;
+  revision: number;
+  claimGeneration: number;
+  outcome: "accepted" | "deduped" | "superseded" | "retryable" | "permanent";
+  reasonCode?: "tuple_protocol_invalid" | "unknown_failure";
+  errorFingerprint?: string;
 };
 
 const command = process.argv[2];
@@ -163,8 +174,11 @@ async function commit() {
   });
   const active = new Map(fetched.items.map((item) => [item.itemKey, item]));
   const superseded: ExactReviewBatchCompletion[] = [];
-  const commitMembers: ExactReviewBatchQueueItem[] = [];
-  const plans: PreparedStateMutationPlan[] = [];
+  const commitCandidates: Array<{
+    member: ExactReviewBatchQueueItem;
+    plan: PreparedStateMutationPlan;
+  }> = [];
+  const publicationOutcomes: BatchPublicationOutcome[] = [];
   for (const manifestItem of manifest.items) {
     const current = active.get(manifestItem.itemKey);
     if (!current || !existsSync(manifestItem.outcomePath)) continue;
@@ -172,24 +186,35 @@ async function commit() {
     if (outcome.kind === "superseded") {
       if (optionalObjectValue(outcome.disposition).requeueLatestExpected !== true) {
         superseded.push({ ...current, terminalOutcome: "superseded" });
+        publicationOutcomes.push(supersededPublicationOutcome(current));
       }
       continue;
     }
     if (outcome.kind !== "eligible") continue;
-    const [plan] = validatePreparedStateMutationPlans([
-      outcome.plan as PreparedStateMutationPlan,
-    ]).plans;
-    if (
-      !plan ||
-      plan.identity.itemKey !== current.itemKey ||
-      plan.identity.revision !== current.revision ||
-      plan.identity.claimGeneration !== current.claimGeneration
-    ) {
-      throw new Error(`Batch outcome identity does not match ${current.itemKey}`);
+    try {
+      const [plan] = validatePreparedStateMutationPlans([
+        outcome.plan as PreparedStateMutationPlan,
+      ]).plans;
+      const publication = plan?.publication;
+      const canonicalTargetKey = canonicalTargetKeyForMember(current);
+      if (
+        !plan ||
+        !publication ||
+        plan.identity.itemKey !== current.itemKey ||
+        plan.identity.revision !== current.revision ||
+        plan.identity.claimGeneration !== current.claimGeneration ||
+        publication.canonicalTargetKey !== canonicalTargetKey ||
+        publication.fenceKey !== current.itemKey
+      ) {
+        throw new Error(`Batch outcome identity does not match ${current.itemKey}`);
+      }
+      commitCandidates.push({ member: current, plan });
+    } catch (error) {
+      publicationOutcomes.push(permanentPublicationOutcome(current, failureFingerprint(error)));
     }
-    commitMembers.push(current);
-    plans.push(plan);
   }
+
+  const plans = commitCandidates.map((candidate) => candidate.plan);
 
   let stateWriter: StateWriterOperation | undefined;
   const progressObserver = exactReviewBatchStateWriterProgressReporter({
@@ -209,38 +234,15 @@ async function commit() {
         ...(progressObserver ? { observer: progressObserver } : {}),
       })
     : null;
-  try {
-    if (plans.length) {
-      await publishCanonicalBatch(plans);
-      recorder?.recordMaterializedCommit(plans.length);
-      recorder?.finalize("materialized");
-      stateWriter = recorder?.toTerminalObject() ?? undefined;
-    }
-  } catch (error) {
-    recorder?.finalize("failed");
+  if (plans.length) {
+    const published = await publishCanonicalBatch(commitCandidates);
+    publicationOutcomes.push(...published);
+    const materialized = published.filter(
+      (outcome) => outcome.outcome === "accepted" || outcome.outcome === "deduped",
+    ).length;
+    if (materialized) recorder?.recordMaterializedCommit(materialized);
+    recorder?.finalize(materialized ? "materialized" : "failed");
     stateWriter = recorder?.toTerminalObject() ?? undefined;
-    const fingerprint = failureFingerprint(error);
-    const reasonCode = "unknown_failure";
-    const retryable = commitMembers.map((member) => ({
-      ...member,
-      terminalOutcome: "retryable_failure" as const,
-      reasonCode,
-      errorFingerprint: fingerprint,
-    }));
-    try {
-      await acknowledge(
-        manifest,
-        [...superseded, ...retryable],
-        undefined,
-        fingerprint,
-        stateWriter,
-      );
-    } catch (releaseError) {
-      console.error(
-        `Failed to release batch after commit error: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
-      );
-    }
-    throw error;
   }
   const receiptPath = batchReceiptPath();
   mkdirSync(dirname(receiptPath), { recursive: true });
@@ -250,7 +252,12 @@ async function commit() {
       {
         batchId: manifest.batchId,
         stateCommitSha: null,
-        publishedItemKeys: plans.map((plan) => plan.identity.itemKey),
+        // Retained for pre-envelope receipt readers. New completion logic uses
+        // the per-member outcomes below, including both identities.
+        publishedItemKeys: publicationOutcomes
+          .filter((outcome) => outcome.outcome === "accepted" || outcome.outcome === "deduped")
+          .map((outcome) => outcome.fenceKey),
+        outcomes: publicationOutcomes,
         stateWriter: stateWriter ?? null,
       },
       null,
@@ -263,39 +270,42 @@ async function commit() {
       ok: true,
       batch_id: manifest.batchId,
       state_commit_sha: null,
-      materialized: plans.length,
+      materialized: publicationOutcomes.filter(
+        (outcome) => outcome.outcome === "accepted" || outcome.outcome === "deduped",
+      ).length,
       quarantined: 0,
       superseded: superseded.length,
     }),
   );
 }
 
-async function publishCanonicalBatch(plans: readonly PreparedStateMutationPlan[]): Promise<void> {
-  for (const plan of plans) {
+async function publishCanonicalBatch(
+  candidates: ReadonlyArray<{ member: ExactReviewBatchQueueItem; plan: PreparedStateMutationPlan }>,
+): Promise<BatchPublicationOutcome[]> {
+  const outcomes: BatchPublicationOutcome[] = [];
+  for (const { member, plan } of candidates) {
+    const publication = plan.publication!;
     const operations = plan.operations.map((operation) => ({ ...operation }));
-    const result = await postDirectPublicationResult({
-      baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
-      webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
-      path: "/internal/exact-review/publication-batch-results",
-      payload: {
-        itemKey: plan.identity.itemKey,
-        revision: plan.identity.revision,
-        identity: { ...plan.identity },
-        operations,
-        totalBytes: plan.totalBytes,
-      },
-    });
-    if (result.kind !== "accepted") {
-      throw new Error(
-        `Canonical exact-review publication failed for ${plan.identity.itemKey}: ${result.reason}`,
-      );
-    }
-    if (result.response.superseded === true) {
-      throw new Error(
-        `Canonical exact-review publication was superseded: ${plan.identity.itemKey}`,
-      );
+    try {
+      const result = await postDirectPublicationResult({
+        baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
+        webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
+        path: "/internal/exact-review/publication-batch-results",
+        payload: {
+          canonicalTargetKey: publication.canonicalTargetKey,
+          fenceKey: publication.fenceKey,
+          revision: plan.identity.revision,
+          identity: { ...publication, ...plan.identity },
+          operations,
+          totalBytes: plan.totalBytes,
+        },
+      });
+      outcomes.push(publicationOutcomeFromResult(member, publication, result));
+    } catch (error) {
+      outcomes.push(retryablePublicationOutcome(member, publication, failureFingerprint(error)));
     }
   }
+  return outcomes;
 }
 
 async function complete() {
@@ -328,6 +338,11 @@ async function complete() {
     const failure = failureCompletion(current, outcome);
     if (failure) {
       completions.push(failure);
+      continue;
+    }
+    const publicationOutcome = receipt.outcomes.get(current.itemKey);
+    if (publicationOutcome) {
+      completions.push(publicationCompletion(current, publicationOutcome, outcome));
       continue;
     }
     if (outcome.kind !== "eligible" || !receipt.publishedItemKeys.has(current.itemKey)) {
@@ -377,6 +392,8 @@ async function release() {
       }
       const failure = failureCompletion(member, outcome);
       if (failure) return failure;
+      const publicationOutcome = receipt?.outcomes.get(member.itemKey);
+      if (publicationOutcome) return publicationCompletion(member, publicationOutcome, outcome);
       // A receipt proves the state mutation committed. A member is safe to
       // acknowledge as published only after every required post-commit effect
       // is also durable; otherwise requeueing preserves that unfinished work.
@@ -462,6 +479,192 @@ function retryableCompletion(
   };
 }
 
+function publicationOutcomeFromResult(
+  member: ExactReviewBatchQueueItem,
+  publication: NonNullable<PreparedStateMutationPlan["publication"]>,
+  result: Awaited<ReturnType<typeof postDirectPublicationResult>>,
+): BatchPublicationOutcome {
+  const identity = publicationOutcomeIdentity(member, publication);
+  if (result.kind === "accepted") {
+    if (result.response.superseded === true) return { ...identity, outcome: "superseded" };
+    if (result.response.deduped === true) return { ...identity, outcome: "deduped" };
+    return { ...identity, outcome: "accepted" };
+  }
+  const fingerprint = failureFingerprint(new Error(result.reason));
+  if (result.reason === "direct_publication_fence_not_owned") {
+    return {
+      ...identity,
+      outcome: "retryable",
+      reasonCode: "unknown_failure",
+      errorFingerprint: fingerprint,
+    };
+  }
+  if (result.status === 400 || result.status === 413) {
+    return {
+      ...identity,
+      outcome: "permanent",
+      reasonCode: "tuple_protocol_invalid",
+      errorFingerprint: fingerprint,
+    };
+  }
+  return {
+    ...identity,
+    outcome: "retryable",
+    reasonCode: "unknown_failure",
+    errorFingerprint: fingerprint,
+  };
+}
+
+function supersededPublicationOutcome(member: ExactReviewBatchQueueItem): BatchPublicationOutcome {
+  return { ...publicationOutcomeIdentity(member), outcome: "superseded" };
+}
+
+function permanentPublicationOutcome(
+  member: ExactReviewBatchQueueItem,
+  errorFingerprint: string,
+): BatchPublicationOutcome {
+  return {
+    ...publicationOutcomeIdentity(member),
+    outcome: "permanent",
+    reasonCode: "tuple_protocol_invalid",
+    errorFingerprint,
+  };
+}
+
+function retryablePublicationOutcome(
+  member: ExactReviewBatchQueueItem,
+  publication: NonNullable<PreparedStateMutationPlan["publication"]>,
+  errorFingerprint: string,
+): BatchPublicationOutcome {
+  return {
+    ...publicationOutcomeIdentity(member, publication),
+    outcome: "retryable",
+    reasonCode: "unknown_failure",
+    errorFingerprint,
+  };
+}
+
+function publicationOutcomeIdentity(
+  member: ExactReviewBatchQueueItem,
+  publication?: NonNullable<PreparedStateMutationPlan["publication"]>,
+): Pick<
+  BatchPublicationOutcome,
+  "canonicalTargetKey" | "fenceKey" | "revision" | "claimGeneration"
+> {
+  const canonicalTargetKey = canonicalTargetKeyForMember(member);
+  if (
+    publication &&
+    (publication.canonicalTargetKey !== canonicalTargetKey ||
+      publication.fenceKey !== member.itemKey)
+  ) {
+    throw new Error(`Batch publication identity does not match ${member.itemKey}`);
+  }
+  return {
+    canonicalTargetKey,
+    fenceKey: member.itemKey,
+    revision: member.revision,
+    claimGeneration: member.claimGeneration,
+  };
+}
+
+function canonicalTargetKeyForMember(member: ExactReviewBatchQueueItem): string {
+  const decision = objectValue(member.decision);
+  const targetRepo = targetRepoFromDecision(decision);
+  const itemNumber = positiveInteger(decision.itemNumber);
+  return `${targetRepo}#${itemNumber}`;
+}
+
+function publicationOutcomeMatchesMember(
+  publication: BatchPublicationOutcome,
+  member: ExactReviewBatchQueueItem,
+): boolean {
+  return (
+    publication.fenceKey === member.itemKey &&
+    publication.revision === member.revision &&
+    publication.claimGeneration === member.claimGeneration &&
+    publication.canonicalTargetKey === canonicalTargetKeyForMember(member)
+  );
+}
+
+function publicationOutcomeMatchesManifest(
+  publication: BatchPublicationOutcome,
+  manifest: BatchManifest,
+): boolean {
+  const member = manifest.items.find((item) => item.itemKey === publication.fenceKey);
+  return !!member && publicationOutcomeMatchesMember(publication, member);
+}
+
+function batchPublicationOutcome(value: unknown): BatchPublicationOutcome {
+  const outcome = objectValue(value);
+  const canonicalTargetKey = exactIdentityValue(outcome.canonicalTargetKey, "canonicalTargetKey");
+  if (!/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#([1-9]\d*)$/.test(canonicalTargetKey)) {
+    throw new Error("Invalid batch receipt canonical target key");
+  }
+  const fenceKey = exactIdentityValue(outcome.fenceKey, "fenceKey");
+  const terminal = String(outcome.outcome || "");
+  if (
+    !(["accepted", "deduped", "superseded", "retryable", "permanent"] as string[]).includes(
+      terminal,
+    )
+  ) {
+    throw new Error("Invalid batch receipt publication outcome");
+  }
+  const reasonCode =
+    outcome.reasonCode === undefined
+      ? undefined
+      : exactIdentityValue(outcome.reasonCode, "reasonCode");
+  if (reasonCode && reasonCode !== "tuple_protocol_invalid" && reasonCode !== "unknown_failure") {
+    throw new Error("Invalid batch receipt publication reason code");
+  }
+  const errorFingerprint =
+    outcome.errorFingerprint === undefined
+      ? undefined
+      : exactIdentityValue(outcome.errorFingerprint, "errorFingerprint");
+  if (errorFingerprint && !/^[a-f0-9]{64}$/.test(errorFingerprint)) {
+    throw new Error("Invalid batch receipt publication error fingerprint");
+  }
+  const parsed: BatchPublicationOutcome = {
+    canonicalTargetKey,
+    fenceKey,
+    revision: positiveInteger(outcome.revision),
+    claimGeneration: positiveInteger(outcome.claimGeneration),
+    outcome: terminal as BatchPublicationOutcome["outcome"],
+  };
+  if (reasonCode) {
+    parsed.reasonCode = reasonCode as NonNullable<BatchPublicationOutcome["reasonCode"]>;
+  }
+  if (errorFingerprint) parsed.errorFingerprint = errorFingerprint;
+  return parsed;
+}
+
+function publicationCompletion(
+  member: ExactReviewBatchQueueItem,
+  publication: BatchPublicationOutcome,
+  outcome: Record<string, unknown>,
+): ExactReviewBatchCompletion {
+  if (!publicationOutcomeMatchesMember(publication, member)) {
+    return retryableCompletion(member, "unknown_failure", publication.errorFingerprint);
+  }
+  if (publication.outcome === "superseded") {
+    return { ...member, terminalOutcome: "superseded" };
+  }
+  if (publication.outcome === "retryable") {
+    return retryableCompletion(member, "unknown_failure", publication.errorFingerprint);
+  }
+  if (publication.outcome === "permanent") {
+    return {
+      ...member,
+      terminalOutcome: "permanent_failure",
+      reasonCode: "tuple_protocol_invalid",
+      ...(publication.errorFingerprint ? { errorFingerprint: publication.errorFingerprint } : {}),
+    };
+  }
+  if (outcome.kind !== "eligible" || hasPendingPostEffects(outcome)) {
+    return retryableCompletion(member, "unknown_failure", publication.errorFingerprint);
+  }
+  return { ...member, terminalOutcome: "published" };
+}
+
 function hasPendingPostEffects(outcome: Record<string, unknown>): boolean {
   const disposition = optionalObjectValue(outcome.disposition);
   const requiresPostEffects =
@@ -513,6 +716,17 @@ function readBatchReceipt(manifest: BatchManifest, required: boolean): BatchRece
       ? receipt.publishedItemKeys.map((value) => stringValue(value, "publishedItemKey"))
       : [],
   );
+  const outcomes = new Map<string, BatchPublicationOutcome>();
+  if (Array.isArray(receipt.outcomes)) {
+    for (const value of receipt.outcomes) {
+      const parsed = batchPublicationOutcome(value);
+      if (!publicationOutcomeMatchesManifest(parsed, manifest)) {
+        throw new Error("Batch receipt outcome identity mismatch");
+      }
+      if (outcomes.has(parsed.fenceKey)) throw new Error("Batch receipt repeats a fence key");
+      outcomes.set(parsed.fenceKey, parsed);
+    }
+  }
   const stateCommitSha =
     typeof receipt.stateCommitSha === "string" && receipt.stateCommitSha
       ? receipt.stateCommitSha
@@ -524,6 +738,7 @@ function readBatchReceipt(manifest: BatchManifest, required: boolean): BatchRece
   return {
     batchId,
     publishedItemKeys,
+    outcomes,
     ...(stateCommitSha ? { stateCommitSha } : {}),
     ...(stateWriter ? { stateWriter } : {}),
   };
@@ -591,6 +806,14 @@ function optionalObjectValue(value: unknown): Record<string, unknown> {
 function stringValue(value: unknown, name: string): string {
   if (typeof value !== "string" || !value.trim()) throw new Error(`Invalid ${name}`);
   return value;
+}
+
+function exactIdentityValue(value: unknown, name: string): string {
+  const text = stringValue(value, name);
+  if (text !== text.trim() || text.includes("\0") || /[\r\n]/.test(text)) {
+    throw new Error(`Invalid exact ${name}`);
+  }
+  return text;
 }
 
 function positiveInteger(value: unknown): number {

--- a/src/repair/exact-review-direct-publication.ts
+++ b/src/repair/exact-review-direct-publication.ts
@@ -2,6 +2,7 @@ import { createHmac } from "node:crypto";
 import fs from "node:fs";
 
 import type {
+  BatchPublicationIdentity,
   PreparedStateMutationOperation,
   PreparedStateMutationPlan,
 } from "./state-publication-mutation.js";
@@ -14,9 +15,10 @@ export type DirectPublicationOperation = PreparedStateMutationOperation & {
 };
 
 export type DirectPublicationPayload = {
-  itemKey: string;
+  canonicalTargetKey: string;
+  fenceKey: string;
   revision: number;
-  identity: PreparedStateMutationPlan["identity"];
+  identity: BatchPublicationIdentity & PreparedStateMutationPlan["identity"];
   operations: DirectPublicationOperation[];
   totalBytes: number;
 };
@@ -30,14 +32,18 @@ export function exactReviewDirectPublicationEnabled(value: string | undefined) {
 }
 
 export function prepareDirectPublicationPayload(options: {
-  itemKey: string;
   revision: number;
   plan: PreparedStateMutationPlan;
 }): DirectPublicationPayload {
+  const publication = options.plan.publication ?? {
+    canonicalTargetKey: options.plan.identity.itemKey,
+    fenceKey: options.plan.identity.itemKey,
+  };
   return {
-    itemKey: options.itemKey,
+    canonicalTargetKey: publication.canonicalTargetKey,
+    fenceKey: publication.fenceKey,
     revision: options.revision,
-    identity: { ...options.plan.identity },
+    identity: { ...publication, ...options.plan.identity },
     operations: options.plan.operations.map((operation) => ({ ...operation })),
     totalBytes: options.plan.totalBytes,
   };
@@ -135,7 +141,6 @@ export async function runExactReviewDirectPublicationFromEnv() {
     return;
   }
   const payload = prepareDirectPublicationPayload({
-    itemKey: requiredEnv("EXACT_REVIEW_DIRECT_ITEM_KEY"),
     revision: positiveInteger(requiredEnv("EXACT_REVIEW_DIRECT_REVISION"), "revision"),
     plan: outcome.plan,
   });

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -359,6 +359,10 @@ function prepareBatchMutation({
       revision: positiveEnvInteger("EXACT_REVIEW_BATCH_REVISION"),
       claimGeneration: positiveEnvInteger("EXACT_REVIEW_BATCH_CLAIM_GENERATION"),
     },
+    {
+      canonicalTargetKey: `${options.targetRepo}#${options.itemNumber}`,
+      fenceKey: envValue("EXACT_REVIEW_BATCH_ITEM_KEY"),
+    },
     "Batch",
   );
   // These expectations are emitted with the plan so the batch workflow can run
@@ -382,6 +386,7 @@ function prepareTupleMutationPlan(
   paths: EventRecordPaths,
   contentRoot: string,
   identity: StateMutationIdentity,
+  publication: PreparedStateMutationPlan["publication"] | undefined,
   label: string,
 ): PreparedStateMutationPlan {
   const commitPaths = [
@@ -405,7 +410,11 @@ function prepareTupleMutationPlan(
   if (!operations.length) {
     throw new Error(`${label} mutation for ${paths.targetSlug} is empty`);
   }
-  return prepareStateMutationPlan({ identity, operations });
+  return prepareStateMutationPlan({
+    identity,
+    ...(publication ? { publication } : {}),
+    operations,
+  });
 }
 
 function runApplyDecisions(options: EventOptions, paths: EventRecordPaths): void {
@@ -593,6 +602,10 @@ async function publishSnapshot({
         revision,
         claimGeneration: positiveEnvInteger("EXACT_REVIEW_CLAIM_GENERATION"),
       },
+      {
+        canonicalTargetKey: `${options.targetRepo}#${options.itemNumber}`,
+        fenceKey: itemKey,
+      },
       "Exact event",
     );
     const publication = await postDirectPublicationResult({
@@ -600,7 +613,6 @@ async function publishSnapshot({
       webhookSecret: envValue("CLAWSWEEPER_WEBHOOK_SECRET"),
       path: "/internal/exact-review/publication-batch-results",
       payload: prepareDirectPublicationPayload({
-        itemKey,
         revision,
         plan,
       }),

--- a/src/repair/state-publication-mutation.ts
+++ b/src/repair/state-publication-mutation.ts
@@ -12,6 +12,17 @@ export type StateMutationIdentity = {
   claimGeneration: number;
 };
 
+/**
+ * The canonical record target and the queue ownership key have different
+ * responsibilities.  Keep them explicit when a prepared mutation is carried
+ * through the batch-publication boundary: the former names the tuple, while
+ * the latter is the exact fenced queue member allowed to publish it.
+ */
+export type BatchPublicationIdentity = {
+  canonicalTargetKey: string;
+  fenceKey: string;
+};
+
 export type StateMutationSourceOperation =
   | { path: string; content: string | Uint8Array; mode?: "100644" }
   | { path: string; delete: true };
@@ -26,6 +37,7 @@ export type PreparedStateMutationOperation = {
 
 export type PreparedStateMutationPlan = {
   identity: StateMutationIdentity;
+  publication?: BatchPublicationIdentity;
   operations: readonly PreparedStateMutationOperation[];
   totalBytes: number;
 };
@@ -39,9 +51,11 @@ export const STATE_MUTATION_MAX_PATH_BYTES = 1024;
 
 export function prepareStateMutationPlan(options: {
   identity: StateMutationIdentity;
+  publication?: BatchPublicationIdentity;
   operations: readonly StateMutationSourceOperation[];
 }): PreparedStateMutationPlan {
   validateIdentity(options.identity);
+  if (options.publication) validateBatchPublicationIdentity(options.publication, options.identity);
   if (options.operations.length === 0) throw new Error("A state mutation plan must change a path");
   if (options.operations.length > EXACT_REVIEW_BUNDLE_MAX_FILES) {
     throw new Error("A state mutation plan exceeds the exact-review file limit");
@@ -69,7 +83,12 @@ export function prepareStateMutationPlan(options: {
       bytes: content.byteLength,
     };
   });
-  return { identity: { ...options.identity }, operations, totalBytes };
+  return {
+    identity: { ...options.identity },
+    ...(options.publication ? { publication: { ...options.publication } } : {}),
+    operations,
+    totalBytes,
+  };
 }
 
 export function validatePreparedStateMutationPlans(
@@ -78,6 +97,7 @@ export function validatePreparedStateMutationPlans(
   let batchBytes = 0;
   const validated = plans.map((plan): PreparedStateMutationPlan => {
     validateIdentity(plan.identity);
+    if (plan.publication) validateBatchPublicationIdentity(plan.publication, plan.identity);
     if (!Array.isArray(plan.operations) || plan.operations.length === 0) {
       throw new Error("A prepared state mutation plan must change a path");
     }
@@ -124,7 +144,12 @@ export function validatePreparedStateMutationPlans(
       throw new Error(`Prepared state mutation total is invalid for ${plan.identity.itemKey}`);
     }
     batchBytes += totalBytes;
-    return { identity: { ...plan.identity }, operations, totalBytes };
+    return {
+      identity: { ...plan.identity },
+      ...(plan.publication ? { publication: { ...plan.publication } } : {}),
+      operations,
+      totalBytes,
+    };
   });
   return { plans: validated, totalBytes: batchBytes };
 }
@@ -143,6 +168,25 @@ function validateIdentity(identity: StateMutationIdentity): void {
   }
   if (!Number.isSafeInteger(identity.claimGeneration) || identity.claimGeneration < 1) {
     throw new Error("State mutation claim generations must be positive safe integers");
+  }
+}
+
+function validateBatchPublicationIdentity(
+  publication: BatchPublicationIdentity,
+  identity: StateMutationIdentity,
+): void {
+  if (
+    !publication.canonicalTargetKey ||
+    publication.canonicalTargetKey !== publication.canonicalTargetKey.trim() ||
+    publication.canonicalTargetKey.includes("\0") ||
+    /[\r\n]/.test(publication.canonicalTargetKey) ||
+    !publication.fenceKey ||
+    publication.fenceKey !== publication.fenceKey.trim() ||
+    publication.fenceKey.includes("\0") ||
+    /[\r\n]/.test(publication.fenceKey) ||
+    publication.fenceKey !== identity.itemKey
+  ) {
+    throw new Error("Batch publication identities must retain the exact fenced mutation key");
   }
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -30,6 +30,7 @@ import {
   TRIAGE_ROUTING_GROUPS,
   triageRoutingGroupsForLabels,
 } from "../dashboard/triage-routing-groups.ts";
+import { ExactReviewPublicationBatchStore } from "../dashboard/exact-review-publication-batches.ts";
 import { captureCanonicalRecordBaseline } from "../dist/repair/canonical-record-baseline.js";
 import { publishMainWithStateAppend } from "../dist/repair/publish-main.js";
 
@@ -2270,9 +2271,15 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
   };
   const payload = {
-    itemKey: "openclaw/openclaw#701",
+    canonicalTargetKey: "openclaw/openclaw#701",
+    fenceKey: "openclaw/openclaw#701",
     revision: 4,
-    identity: { itemKey: "openclaw/openclaw#701", revision: 4, claimGeneration: 2 },
+    identity: {
+      canonicalTargetKey: "openclaw/openclaw#701",
+      fenceKey: "openclaw/openclaw#701",
+      revision: 4,
+      claimGeneration: 2,
+    },
     operations: [
       {
         path: "records/openclaw-openclaw/items/701.md",
@@ -2309,23 +2316,44 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
       ...expected,
       superseded: false,
       superseded_revisions: [],
+      canonical_target_key: "openclaw/openclaw#701",
+      fence_key: "openclaw/openclaw#701",
       state_commit_sha: "do-revision:4",
     });
   }
 
-  const batchLeased = leasedExactReviewQueueItem(702, "7020");
+  const batchLeased = leasedExactReviewPublicationItem(702, "7020");
   batchLeased.revision = 4;
   batchLeased.leaseRevision = 4;
   batchLeased.claimGeneration = 2;
+  batchLeased.state = "pending";
   const queueState = (await storage.get("exact-review-queue")) as {
     items: Record<string, typeof batchLeased>;
   };
   queueState.items[batchLeased.key] = batchLeased;
   await storage.put("exact-review-queue", queueState);
+  const batches = new ExactReviewPublicationBatchStore(storage);
+  batches.ensureSchemaSync();
+  const batch = batches.claim({
+    batchId: "worker-publication-proof",
+    leaseOwner: "proof-worker",
+    leaseExpiresAt: Date.now() + 60_000,
+    now: Date.now(),
+    maxItems: 1,
+    candidates: [{ itemKey: batchLeased.key, revision: 4 }],
+  });
+  const batchMember = batch?.items[0];
+  assert.ok(batchMember);
   const batchPayload = {
     ...payload,
-    itemKey: "openclaw/openclaw#702",
-    identity: { itemKey: "openclaw/openclaw#702", revision: 4, claimGeneration: 2 },
+    canonicalTargetKey: "openclaw/openclaw#702",
+    fenceKey: batchLeased.key,
+    identity: {
+      canonicalTargetKey: "openclaw/openclaw#702",
+      fenceKey: batchLeased.key,
+      revision: 4,
+      claimGeneration: batchMember.claimGeneration,
+    },
     operations: [
       {
         ...payload.operations[0],
@@ -2333,6 +2361,32 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
       },
     ],
   };
+  const targetMismatchPayload = {
+    ...batchPayload,
+    canonicalTargetKey: "openclaw/openclaw#703",
+    identity: { ...batchPayload.identity, canonicalTargetKey: "openclaw/openclaw#703" },
+    operations: [
+      {
+        ...batchPayload.operations[0],
+        path: "records/openclaw-openclaw/items/703.md",
+      },
+    ],
+  };
+  const targetMismatchBody = JSON.stringify(targetMismatchPayload);
+  const targetMismatchSignature = `sha256=${createHmac("sha256", "test-secret").update(targetMismatchBody).digest("hex")}`;
+  const targetMismatch = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publication-batch-results", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": targetMismatchSignature },
+      body: targetMismatchBody,
+    }),
+    env,
+  );
+  assert.equal(targetMismatch.status, 409);
+  assert.deepEqual(await targetMismatch.json(), {
+    error: "direct_publication_fence_not_owned",
+    fallback_required: true,
+  });
   const batchBody = JSON.stringify(batchPayload);
   const batchSignature = `sha256=${createHmac("sha256", "test-secret").update(batchBody).digest("hex")}`;
   const batchResponse = await worker.fetch(
@@ -2344,9 +2398,73 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     env,
   );
   assert.equal(batchResponse.status, 202);
-  assert.equal((await batchResponse.json()).accepted, true);
+  assert.deepEqual(await batchResponse.json(), {
+    ok: true,
+    accepted: true,
+    deduped: false,
+    superseded: false,
+    superseded_revisions: [],
+    canonical_target_key: "openclaw/openclaw#702",
+    fence_key: batchLeased.key,
+    state_commit_sha: "do-revision:4",
+  });
+  const repeatedBatch = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publication-batch-results", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": batchSignature },
+      body: batchBody,
+    }),
+    env,
+  );
+  assert.equal((await repeatedBatch.json()).deduped, true);
+  const wrongFencePayload = {
+    ...batchPayload,
+    fenceKey: "openclaw/openclaw#702",
+    identity: { ...batchPayload.identity, fenceKey: "openclaw/openclaw#702" },
+  };
+  const wrongFenceBody = JSON.stringify(wrongFencePayload);
+  const wrongFenceSignature = `sha256=${createHmac("sha256", "test-secret").update(wrongFenceBody).digest("hex")}`;
+  const wrongFence = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publication-batch-results", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": wrongFenceSignature },
+      body: wrongFenceBody,
+    }),
+    env,
+  );
+  assert.equal(wrongFence.status, 409);
+  assert.deepEqual(await wrongFence.json(), {
+    error: "direct_publication_fence_not_owned",
+    fallback_required: true,
+  });
+  storage.sql.exec(
+    `INSERT INTO exact_review_publication_heads (target_key, source_revision, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(target_key) DO UPDATE SET source_revision = excluded.source_revision`,
+    "openclaw/openclaw#702",
+    2,
+    Date.now(),
+  );
+  const staleBatch = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publication-batch-results", {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": batchSignature },
+      body: batchBody,
+    }),
+    env,
+  );
+  assert.deepEqual(await staleBatch.json(), {
+    ok: true,
+    accepted: false,
+    deduped: false,
+    superseded: true,
+    superseded_revisions: [],
+    canonical_target_key: "openclaw/openclaw#702",
+    fence_key: batchLeased.key,
+    state_commit_sha: null,
+  });
   const afterBatch = (await storage.get("exact-review-queue")) as typeof queueState;
-  assert.equal(afterBatch.items[batchLeased.key]?.state, "leased");
+  assert.equal(afterBatch.items[batchLeased.key]?.state, "pending");
 
   const recordUrl =
     "https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/items/701";
@@ -2474,9 +2592,15 @@ test("canonical commit records and tuples export with one monotonic revision", a
   });
 
   const publication = {
-    itemKey: "openclaw/openclaw#711",
+    canonicalTargetKey: "openclaw/openclaw#711",
+    fenceKey: "openclaw/openclaw#711",
     revision: 4,
-    identity: { itemKey: "openclaw/openclaw#711", revision: 4, claimGeneration: 2 },
+    identity: {
+      canonicalTargetKey: "openclaw/openclaw#711",
+      fenceKey: "openclaw/openclaw#711",
+      revision: 4,
+      claimGeneration: 2,
+    },
     operations: [
       {
         path: "records/openclaw-openclaw/items/711.md",

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -117,19 +117,22 @@ const candidates = [
 ];
 
 function directPlan(
-  itemKey: string,
+  canonicalTargetKey: string,
   revision: number,
   options: {
     path?: string;
     content?: Buffer;
     files?: number;
+    fenceKey?: string;
+    claimGeneration?: number;
   } = {},
 ): DirectPublicationPlan {
   const content = options.content ?? Buffer.from(`result-${revision}`);
   const files = options.files ?? 1;
-  const match = /^([^/]+)\/([^#]+)#(\d+)$/.exec(itemKey)!;
+  const match = /^([^/]+)\/([^#]+)#(\d+)$/.exec(canonicalTargetKey)!;
   const root = `records/${match[1]}-${match[2]}`;
   const number = match[3];
+  const fenceKey = options.fenceKey ?? canonicalTargetKey;
   const tuplePaths = [
     `${root}/items/${number}.md`,
     `${root}/plans/${number}.md`,
@@ -137,9 +140,15 @@ function directPlan(
     `${root}/closed/${number}.md`,
   ];
   return {
-    itemKey,
+    canonicalTargetKey,
+    fenceKey,
     revision,
-    identity: { itemKey, revision, claimGeneration: 1 },
+    identity: {
+      canonicalTargetKey,
+      fenceKey,
+      revision,
+      claimGeneration: options.claimGeneration ?? 1,
+    },
     operations: Array.from({ length: files }, (_, index) => ({
       path: options.path ?? tuplePaths[index]!,
       deleted: false,
@@ -211,6 +220,114 @@ test("direct publication idempotency compares canonical content", async () => {
   assert.equal(store.accept(retry, 1_001).outcome, "deduped");
 });
 
+test("direct publication preserves canonical targets and exact publication fences independently", async () => {
+  const storage = new TestStorage();
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  const plan = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#22", 1, {
+      fenceKey: "openclaw/openclaw#22@publish:77:3",
+    }),
+  );
+
+  assert.equal(plan.canonicalTargetKey, "openclaw/openclaw#22");
+  assert.equal(plan.fenceKey, "openclaw/openclaw#22@publish:77:3");
+  assert.equal(store.accept(plan, 1_000).outcome, "accepted");
+  assert.equal(store.accept(plan, 1_001).outcome, "deduped");
+  const receipt = store.get(plan.fenceKey, plan.revision);
+  assert.equal(receipt?.canonicalTargetKey, plan.canonicalTargetKey);
+  assert.equal(receipt?.fenceKey, plan.fenceKey);
+  assert.equal(receipt?.identity.canonicalTargetKey, plan.canonicalTargetKey);
+  assert.equal(receipt?.identity.fenceKey, plan.fenceKey);
+  await assert.rejects(
+    validateDirectPublicationPlan({
+      ...plan,
+      identity: { ...plan.identity, fenceKey: "openclaw/openclaw#22@publish:77:4" },
+    }),
+    /invalid direct publication identity/,
+  );
+  await assert.rejects(
+    validateDirectPublicationPlan({ ...plan, canonicalTargetKey: `${plan.canonicalTargetKey} ` }),
+    /canonical target key/,
+  );
+});
+
+test("direct publication dedupes an accepted tuple after its batch fence is reclaimed", async () => {
+  const storage = new TestStorage();
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  const first = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#23", 1, {
+      fenceKey: "openclaw/openclaw#23@publish:78:3",
+      claimGeneration: 1,
+    }),
+  );
+  assert.equal(store.accept(first, 1_000).outcome, "accepted");
+  const reclaimed = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#23", 1, {
+      fenceKey: "openclaw/openclaw#23@publish:78:3",
+      claimGeneration: 2,
+    }),
+  );
+  assert.equal(store.accept(reclaimed, 1_001).outcome, "deduped");
+  assert.equal(store.readCanonical("openclaw-openclaw", "items", 23)?.content, "result-1");
+});
+
+test("direct publication preserves a reclaimed superseded fence outcome", async () => {
+  const storage = new TestStorage();
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  const fenceKey = "openclaw/openclaw#24@publish:79:3";
+  assert.equal(
+    store.accept(
+      await validateDirectPublicationPlan(
+        directPlan("openclaw/openclaw#24", 2, { fenceKey, claimGeneration: 1 }),
+      ),
+      1_000,
+    ).outcome,
+    "accepted",
+  );
+  const stale = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#24", 1, { fenceKey, claimGeneration: 1 }),
+  );
+  assert.equal(store.accept(stale, 1_001).outcome, "superseded");
+  const reclaimed = await validateDirectPublicationPlan(
+    directPlan("openclaw/openclaw#24", 1, { fenceKey, claimGeneration: 2 }),
+  );
+  assert.equal(store.accept(reclaimed, 1_002).outcome, "superseded");
+});
+
+test("direct publication does not order independent fences by their local revisions", async () => {
+  const storage = new TestStorage();
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  assert.equal(
+    store.accept(
+      await validateDirectPublicationPlan(
+        directPlan("openclaw/openclaw#25", 2, {
+          fenceKey: "openclaw/openclaw#25@publish:80:1",
+          content: Buffer.from("older-fence"),
+        }),
+      ),
+      1_000,
+    ).outcome,
+    "accepted",
+  );
+  assert.equal(
+    store.accept(
+      await validateDirectPublicationPlan(
+        directPlan("openclaw/openclaw#25", 1, {
+          fenceKey: "openclaw/openclaw#25@publish:81:1",
+          content: Buffer.from("later-fence"),
+        }),
+      ),
+      1_001,
+    ).outcome,
+    "accepted",
+  );
+  assert.equal(store.readCanonical("openclaw-openclaw", "items", 25)?.content, "later-fence");
+});
+
 test("direct publication chunks large canonical values without projection rows", async () => {
   const storage = new TestStorage();
   const store = new ExactReviewDirectPublicationStore(storage);
@@ -252,9 +369,9 @@ test("direct publication replaces a retired pending plan with canonical state", 
         operations_json, total_bytes, file_count, state, attempts, created_at, updated_at,
         next_attempt_at, commit_sha, failure_reason)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, 1000, 1000, 1000, NULL, NULL)`,
-    legacy.itemKey,
+    legacy.fenceKey,
     legacy.revision,
-    legacy.identity.itemKey,
+    legacy.identity.fenceKey,
     legacy.identity.revision,
     legacy.identity.claimGeneration,
     JSON.stringify(legacy.operations),

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("batch commit records an invalid member permanently while publishing its healthy peer", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-"));
+  try {
+    const healthy = batchMember("openclaw/openclaw#801@publish:8010:1", 801);
+    const invalid = batchMember("openclaw/openclaw#802@publish:8020:1", 802);
+    const healthyOutcome = join(root, "healthy.json");
+    const invalidOutcome = join(root, "invalid.json");
+    const manifestPath = join(root, "manifest.json");
+    const receiptPath = join(root, "receipt.json");
+    const postsPath = join(root, "posts.json");
+    writeFileSync(
+      healthyOutcome,
+      JSON.stringify({ kind: "eligible", plan: mutationPlan(healthy) }),
+    );
+    writeFileSync(
+      invalidOutcome,
+      JSON.stringify({
+        kind: "eligible",
+        plan: {
+          ...mutationPlan(invalid),
+          publication: {
+            canonicalTargetKey: "openclaw/openclaw#999",
+            fenceKey: invalid.itemKey,
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        batchId: "batch-cli-proof",
+        leaseOwner: "proof-worker",
+        configuredBatchSize: 2,
+        batchWaitMs: 0,
+        items: [
+          { ...healthy, outcomePath: healthyOutcome },
+          { ...invalid, outcomePath: invalidOutcome },
+        ],
+      }),
+    );
+    const preloadPath = join(root, "fetch-preload.cjs");
+    writeFileSync(
+      preloadPath,
+      `const fs = require("node:fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.EXACT_REVIEW_BATCH_MANIFEST, "utf8"));
+const response = (value) => new Response(JSON.stringify(value), { status: 200, headers: { "content-type": "application/json" } });
+const wireItems = manifest.items.map((item) => ({ item_key: item.itemKey, revision: item.revision, claim_generation: item.claimGeneration, decision: item.decision }));
+globalThis.fetch = async (url, init) => {
+  const target = String(url);
+  if (target.endsWith("/publication-batches/fetch")) {
+    return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-01T00:00:00.000Z", items: wireItems }, items: wireItems, superseded: 0 });
+  }
+  if (target.endsWith("/publication-batches/heartbeat")) {
+    return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-01T00:00:00.000Z", items: wireItems } });
+  }
+  if (target.endsWith("/publication-batch-results")) {
+    const posts = fs.existsSync(process.env.BATCH_CLI_POSTS) ? JSON.parse(fs.readFileSync(process.env.BATCH_CLI_POSTS, "utf8")) : [];
+    posts.push(JSON.parse(init.body));
+    fs.writeFileSync(process.env.BATCH_CLI_POSTS, JSON.stringify(posts));
+    return response({ ok: true, accepted: true, deduped: false, superseded: false });
+  }
+  throw new Error("unexpected mock fetch target: " + target);
+};
+`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      ["--require", preloadPath, "dist/repair/exact-review-batch-cli.js", "commit"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAWSWEEPER_WEBHOOK_SECRET: "proof-secret",
+          EXACT_REVIEW_QUEUE_URL: "https://queue.example.test",
+          EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+          EXACT_REVIEW_BATCH_RECEIPT: receiptPath,
+          BATCH_CLI_POSTS: postsPath,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8")) as {
+      publishedItemKeys: string[];
+      outcomes: Array<{
+        canonicalTargetKey: string;
+        fenceKey: string;
+        outcome: string;
+        errorFingerprint?: string;
+      }>;
+    };
+    assert.deepEqual(receipt.publishedItemKeys, [healthy.itemKey]);
+    assert.match(receipt.outcomes[0]?.errorFingerprint ?? "", /^[a-f0-9]{64}$/);
+    assert.deepEqual(receipt.outcomes, [
+      {
+        canonicalTargetKey: "openclaw/openclaw#802",
+        fenceKey: invalid.itemKey,
+        outcome: "permanent",
+        reasonCode: "tuple_protocol_invalid",
+        errorFingerprint: receipt.outcomes[0]?.errorFingerprint,
+        revision: 1,
+        claimGeneration: 1,
+      },
+      {
+        canonicalTargetKey: "openclaw/openclaw#801",
+        fenceKey: healthy.itemKey,
+        outcome: "accepted",
+        revision: 1,
+        claimGeneration: 1,
+      },
+    ]);
+    assert.deepEqual(JSON.parse(readFileSync(postsPath, "utf8")), [
+      {
+        canonicalTargetKey: "openclaw/openclaw#801",
+        fenceKey: healthy.itemKey,
+        revision: 1,
+        identity: {
+          canonicalTargetKey: "openclaw/openclaw#801",
+          fenceKey: healthy.itemKey,
+          itemKey: healthy.itemKey,
+          revision: 1,
+          claimGeneration: 1,
+        },
+        operations: mutationPlan(healthy).operations,
+        totalBytes: 1,
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function batchMember(itemKey: string, itemNumber: number) {
+  return {
+    itemKey,
+    revision: 1,
+    claimGeneration: 1,
+    decision: {
+      targetRepo: "openclaw/openclaw",
+      itemNumber,
+    },
+  };
+}
+
+function mutationPlan(member: ReturnType<typeof batchMember>) {
+  const canonicalTargetKey = `openclaw/openclaw#${member.decision.itemNumber}`;
+  return {
+    identity: {
+      itemKey: member.itemKey,
+      revision: member.revision,
+      claimGeneration: member.claimGeneration,
+    },
+    publication: {
+      canonicalTargetKey,
+      fenceKey: member.itemKey,
+    },
+    operations: [
+      {
+        path: `records/openclaw-openclaw/items/${member.decision.itemNumber}.md`,
+        deleted: false,
+        mode: "100644",
+        bytes: 1,
+        contentBase64: "eA==",
+      },
+    ],
+    totalBytes: 1,
+  };
+}

--- a/test/repair/exact-review-batch-publisher.test.ts
+++ b/test/repair/exact-review-batch-publisher.test.ts
@@ -58,14 +58,17 @@ test("shared commit failure leaves only commit candidates retryable", async () =
 
 test("direct producer retries bounded failures then requests legacy enqueue fallback", async () => {
   let calls = 0;
+  const requests: Array<{ url: string; body: unknown }> = [];
+  const payload = directPayload();
   const result = await postDirectPublicationResult({
     baseUrl: "https://clawsweeper.openclaw.ai",
     webhookSecret: "test-secret",
-    payload: directPayload(),
+    payload,
     attempts: 3,
     sleep: async () => undefined,
-    fetch: async () => {
+    fetch: async (url, init) => {
       calls += 1;
+      requests.push({ url: String(url), body: JSON.parse(String(init?.body)) });
       return new Response(JSON.stringify({ error: "worker_unavailable" }), {
         status: 503,
         headers: { "content-type": "application/json" },
@@ -73,6 +76,13 @@ test("direct producer retries bounded failures then requests legacy enqueue fall
     },
   });
   assert.equal(calls, 3);
+  assert.deepEqual(
+    requests,
+    Array.from({ length: 3 }, () => ({
+      url: "https://clawsweeper.openclaw.ai/internal/exact-review/publication-results",
+      body: payload,
+    })),
+  );
   assert.deepEqual(result, {
     kind: "fallback",
     attempts: 3,
@@ -127,9 +137,14 @@ function plan(member: (typeof members)[number]) {
 
 function directPayload() {
   return {
-    itemKey: "openclaw/openclaw#1",
+    canonicalTargetKey: "openclaw/openclaw#1",
+    fenceKey: "openclaw/openclaw#1",
     revision: 1,
-    identity: members[0]!,
+    identity: {
+      canonicalTargetKey: "openclaw/openclaw#1",
+      fenceKey: "openclaw/openclaw#1",
+      ...members[0]!,
+    },
     operations: [
       {
         path: "records/openclaw-openclaw/items/1.md",

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -63,6 +63,10 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
     publisherSource,
     /if \(options\.batchMutationOutput\)[\s\S]*?writeBatchMutationResult\(options\.batchMutationOutput, \{[\s\S]*?kind: completionKind,[\s\S]*?reasonCode,/,
   );
+  assert.match(
+    publisherSource,
+    /canonicalTargetKey: `\$\{options\.targetRepo\}#\$\{options\.itemNumber\}`,\s*fenceKey: itemKey/,
+  );
   // Keep the fixture from looking like an embedded credential while still
   // proving that artifact downloads use the owner-scoped repository token.
   const ghToken = ["GH", "TOKEN"].join("_");
@@ -71,6 +75,8 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
   assert.match(source, /internal\/exact-review\/enqueue/);
   assert.match(source, /source_drift_requeue/);
   assert.match(source, /\.kind == "superseded" and \.disposition\.requeueLatestExpected == true/);
+  assert.match(source, /state-receipt\.json/);
+  assert.match(source, /\.outcome == "accepted" or \.outcome == "deduped"/);
   assert.match(source, /deferredCloseCoverageExpected == true/);
   assert.match(source, /scheduled proof lane/);
   assert.match(source, /jq '\.postEffectsComplete = true'/);
@@ -183,6 +189,7 @@ test("batch failure cleanup completes manifest fences without a queue fetch", ()
   const releaseSource = /async function release\(\) \{([\s\S]*?)\n\}/.exec(cliSource)?.[1] ?? "";
   assert.match(releaseSource, /manifest\.items\.map/);
   assert.match(releaseSource, /readBatchReceipt\(manifest, false\)/);
+  assert.match(releaseSource, /receipt\?\.outcomes\.get\(member\.itemKey\)/);
   assert.match(releaseSource, /receipt\?\.publishedItemKeys\.has\(member\.itemKey\)/);
   assert.match(releaseSource, /terminalOutcome: "published"/);
   assert.match(releaseSource, /receipt\?\.stateCommitSha/);
@@ -192,7 +199,11 @@ test("batch failure cleanup completes manifest fences without a queue fetch", ()
 
 test("batch commit publishes every prepared tuple to canonical Worker state", () => {
   const commitSource = /async function commit\(\) \{([\s\S]*?)\n\}/.exec(cliSource)?.[1] ?? "";
-  assert.match(commitSource, /await publishCanonicalBatch\(plans\)/);
+  assert.match(commitSource, /await publishCanonicalBatch\(commitCandidates\)/);
+  assert.match(commitSource, /permanentPublicationOutcome\(current, failureFingerprint\(error\)\)/);
+  assert.match(commitSource, /outcomes: publicationOutcomes/);
+  assert.match(cliSource, /canonicalTargetKey/);
+  assert.match(cliSource, /fenceKey/);
   assert.match(cliSource, /postDirectPublicationResult/);
   assert.match(cliSource, /publication-batch-results/);
   assert.match(cliSource, /plan\.operations\.map\(\(operation\) => \(\{ \.\.\.operation \}\)\)/);


### PR DESCRIPTION
## Summary

Implements the CSW-075 Workstream 1 post-cutover publication contract: batch state publication now carries a typed dual identity, with a bare canonical target key separated from the exact decorated queue fence key.

Related to #898. CSW-073 remains the audit and approval record.

## Problem

The batch queue owns decorated keys such as `owner/repo#42@publish:run:attempt`, while canonical state validation accepts only `owner/repo#42`. Treating either representation as the other loses fencing or fails validation. Retried and concurrent batches also need per-member durable outcomes without allowing a stale fence to overwrite current canonical state.

## Implementation

- Add `canonicalTargetKey` and `fenceKey` to batch mutation plans, direct-publication payloads, Worker validation, and durable publication receipts.
- Validate the bare target and exact fence independently. The Worker binds both to the owned queue decision and active batch membership; it does not trim or normalize a client key at the boundary.
- Persist both identities in direct-publication rows and CLI batch receipts/outcomes. Retried accepted tuples dedupe across reclaimed claim generations, while reclaimed superseded tuples stay superseded.
- Return independent member outcomes (`accepted`, `deduped`, `superseded`, `retryable`, or `permanent`) and continue healthy members when a peer plan is invalid.
- Gate workflow post-effects on a matching `accepted` or `deduped` receipt. Source-drift supersession keeps its separate fenced route.
- Keep revision ordering fence-local, then reject a batch publication if its durable per-target source head has advanced before the canonical write.
- Preserve the existing legacy path by emitting its explicit bare canonical target alongside its decorated fence.

## Validation

- `pnpm run build:repair`
- `pnpm run build:dashboard`
- `node --test test/dashboard-worker.test.ts test/exact-review-publication-batches.test.ts test/repair/exact-review-batch-cli.test.ts test/repair/exact-review-batch-publisher.test.ts`
  - 327 tests passed locally.
- Linux controlled proof (Docker-backed Crabbox, `mcr.microsoft.com/playwright:v1.60.0-noble`): the same builds plus `test/repair/exact-review-batch-workflow.test.ts`.
  - 337 tests passed, including the real Bash workflow syntax fixture.
- `git diff --check`

`actionlint` is not installed on the host. The workflow’s Bash syntax test is a known baseline failure through this host's `bash.exe`/`docker-desktop` WSL route; the controlled Linux proof above exercised and passed that fixture. No platform files or CI matrix were changed.

## Real Behavior Proof

**Claim.** A state-publication batch preserves a bare canonical target independently from the exact fence, fences ownership at the Worker, isolates poison members, and can retry publication transport without duplicating the stable effect path.

**Exercised surface.** The controlled Worker/Durable Object SQLite fixture exercised `/internal/exact-review/publication-batch-results`, batch membership fencing, direct-publication durable receipts, the batch CLI receipt/outcome protocol, and the existing batch workflow post-effect selector.

**Scenarios and observed result.**

- An invalid member whose canonical key disagrees with its owned target is recorded as `permanent`; its healthy peer reaches `accepted` and is the only peer posted to the Worker.
- A decorated active batch fence is accepted, repeated delivery is deduped, a bare-fence substitution is rejected, and a canonical target that disagrees with the owned fence is rejected.
- A reclaimed accepted tuple dedupes across claim generations; a reclaimed superseded tuple remains superseded; independent fences are not globally ordered by their local queue revisions; and an older source revision is terminally superseded before it can overwrite canonical state.
- The direct state-publication retry fixture makes only repeated signed requests to the Worker direct-publication endpoint with the same full dual-identity payload; it does not invoke a GitHub mutation path. Workflow post-effects run only for receipt outcomes that materialized state (`accepted` or `deduped`).

**Command/environment.**

```text
Docker Engine 29.5.2; Crabbox local-container image mcr.microsoft.com/playwright:v1.60.0-noble

corepack pnpm install --frozen-lockfile
corepack pnpm run build:repair
corepack pnpm run build:dashboard
node --test test/exact-review-publication-batches.test.ts test/dashboard-worker.test.ts test/repair/exact-review-batch-cli.test.ts test/repair/exact-review-batch-publisher.test.ts test/repair/exact-review-batch-workflow.test.ts
```

**Artifact/trace.** Local-container lease `cbx_9230d8582b40` (`amber-krill-8f5d`), stopped automatically. It synced the exact dirty branch, built repair/dashboard, and reported 337 passing tests with exit code 0.

**Limits.** This is a controlled Linux Worker/R2-style fixture with mocked external fetches; it does not mutate production Worker/R2 state, live queues, GitHub effects, workflows, or review gates.

## Codex review closeout

- Dirty patch: `codex review --uncommitted` — final result: no actionable correctness issues. Earlier findings on post-effect gating, reclaimed receipts, legacy dual identity, fence-local revision ordering, and durable source-head staleness were accepted, repaired, and reproven.
- Branch against current base: rebased onto `origin/main` at `8365a79af8` (docs-only #945), then `codex review --base origin/main` — no actionable correctness issues.

## Risks and non-goals

This intentionally does not implement Workstream 2 Completed/command-acknowledgement semantics, change Bay/Overview presentation, broaden scheduler policy, alter replay behavior, expand platform support, add CI, or mutate production state. The remaining evidence limit is live production behavior, which this PR deliberately does not exercise.
