### PR TITLE
fix(ci): build the main bundle in the jobs that publish the action ledger

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -566,7 +566,10 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         id: execute-setup-pnpm
         with:
-          build-script: build:repair
+          # This job publishes the action ledger with dist/clawsweeper.js, which
+          # only the main build emits, so build both Node bundles and skip the
+          # dashboard leg the job never runs.
+          build-script: build:node
 
       - name: Restore durable intake job
         if: ${{ inputs.job_payload != '' }}

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -110,6 +110,7 @@ jobs:
             package.json
             pnpm-lock.yaml
             pnpm-workspace.yaml
+            tsconfig.json
             tsconfig.repair.json
           sparse-checkout-cone-mode: false
 
@@ -177,7 +178,10 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         id: setup-pnpm
         with:
-          build-script: build:repair
+          # This job publishes the action ledger with dist/clawsweeper.js, which
+          # only the main build emits, so build both Node bundles and skip the
+          # dashboard leg the job never runs.
+          build-script: build:node
 
       - name: Route ClawSweeper comments
         id: route-comments

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "build:repair": "tsc -p tsconfig.repair.json",
     "build:dashboard": "tsc -p tsconfig.dashboard.json",
+    "build:node": "pnpm run build && pnpm run build:repair",
     "build:all": "pnpm run build && pnpm run build:repair && pnpm run build:dashboard",
     "plan": "node dist/clawsweeper.js plan",
     "reserve-review-lease": "node dist/clawsweeper.js reserve-review-lease",

--- a/test/repair/workflow-sparse-checkout-helpers.ts
+++ b/test/repair/workflow-sparse-checkout-helpers.ts
@@ -42,3 +42,50 @@ export function sourceSparseCheckoutEntries(workflowPath: string): string[] {
 export function sparseEntriesCover(entries: readonly string[], requiredPath: string): boolean {
   return entries.some((entry) => requiredPath === entry || requiredPath.startsWith(`${entry}/`));
 }
+
+// `build` compiles tsconfig.json to dist/clawsweeper.js and `build:repair` compiles
+// tsconfig.repair.json; neither emits the other's entry point. Resolve a build-script
+// through package.json instead of restating which script names cover which bundle, so
+// a job that gains a bundle invocation cannot keep a build that omits it.
+function packageScripts(): Record<string, string> {
+  const manifest = JSON.parse(readFileSync("package.json", "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  return manifest.scripts ?? {};
+}
+
+function resolveScriptClosure(script: string): Set<string> {
+  const scripts = packageScripts();
+  const value = script.trim().replace(/^["']|["']$/g, "");
+  const pending = /^\/(.+)\/$/.exec(value)
+    ? Object.keys(scripts).filter((name) => new RegExp(/^\/(.+)\/$/.exec(value)![1]!).test(name))
+    : [value];
+  const closure = new Set<string>();
+  while (pending.length > 0) {
+    const name = pending.pop();
+    if (!name || closure.has(name)) continue;
+    const body = scripts[name];
+    if (body === undefined) continue;
+    closure.add(name);
+    for (const match of body.matchAll(/pnpm run (?:--silent )?([\w:.-]+)/g)) {
+      if (match[1]) pending.push(match[1]);
+    }
+  }
+  return closure;
+}
+
+export function buildScriptEmitsMainBundle(script: string): boolean {
+  return resolveScriptClosure(script).has("build");
+}
+
+export function buildScriptEmitsRepairBundle(script: string): boolean {
+  return resolveScriptClosure(script).has("build:repair");
+}
+
+export function workflowBuildScripts(workflowPath: string): string[] {
+  const workflow = parse(readFileSync(workflowPath, "utf8")) as Workflow;
+  return Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .filter((step) => String(step.uses ?? "").includes("actions/setup-pnpm"))
+    .map((step) => String(step.with?.["build-script"] ?? ""));
+}

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -2,10 +2,15 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 
+import { parse } from "yaml";
+
 import { readText } from "../helpers.ts";
 import {
+  buildScriptEmitsMainBundle,
+  buildScriptEmitsRepairBundle,
   sourceSparseCheckoutEntries,
   sparseEntriesCover,
+  workflowBuildScripts,
   SPARSE_REPAIR_BUILD_WORKFLOWS,
 } from "./workflow-sparse-checkout-helpers.ts";
 
@@ -20,10 +25,16 @@ const REPAIR_RUNTIME_PATHS = [
   "tsconfig.repair.json",
 ] as const;
 
+const MAIN_BUNDLE = "dist/clawsweeper.js";
+const RUNTIME_DIST_ARTIFACT = "clawsweeper-runtime-dist";
+
 test("sparse repair build workflows include runtime dependencies", () => {
   for (const workflowPath of SPARSE_REPAIR_BUILD_WORKFLOWS) {
-    const workflow = readText(workflowPath);
-    assert.match(workflow, /build-script: build:repair/);
+    const buildScripts = workflowBuildScripts(workflowPath);
+    assert.ok(
+      buildScripts.some(buildScriptEmitsRepairBundle),
+      `${workflowPath} must build the repair bundle, got ${JSON.stringify(buildScripts)}`,
+    );
 
     const entries = sourceSparseCheckoutEntries(workflowPath);
     assert.ok(entries.includes("src"), `${workflowPath} must checkout the complete src tree`);
@@ -39,6 +50,64 @@ test("sparse repair build workflows include runtime dependencies", () => {
       );
     }
   }
+});
+
+test("every workflow job that runs the main bundle directly obtains it", () => {
+  const audited: string[] = [];
+  for (const workflowPath of fs.globSync(".github/workflows/*.yml").sort()) {
+    const text = fs.readFileSync(workflowPath, "utf8");
+    if (!text.includes(MAIN_BUNDLE)) continue;
+    const workflow = parse(text) as {
+      jobs?: Record<
+        string,
+        { steps?: { uses?: unknown; run?: unknown; with?: Record<string, unknown> }[] }
+      >;
+    };
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      const steps = job.steps ?? [];
+      // Direct invocations only. A job that reaches the bundle through a package
+      // script is not audited here, because build-script values can be GitHub
+      // expressions that only a live run resolves.
+      if (!steps.some((step) => String(step.run ?? "").includes(MAIN_BUNDLE))) continue;
+      const site = `${workflowPath}:${jobName}`;
+      audited.push(site);
+
+      // A job may restore the compiled runtime instead of building it, as sweep's
+      // review shard does. Only that exact artifact counts: other jobs download
+      // unrelated artifacts and still have to build the bundle themselves.
+      const restoresRuntime = steps.some(
+        (step) =>
+          String(step.uses ?? "").startsWith("actions/download-artifact@") &&
+          String(step.with?.["name"] ?? "") === RUNTIME_DIST_ARTIFACT,
+      );
+      if (restoresRuntime) continue;
+
+      const buildScripts = steps
+        .filter((step) => String(step.uses ?? "").includes("actions/setup-pnpm"))
+        .map((step) => String(step.with?.["build-script"] ?? ""));
+      assert.ok(
+        buildScripts.some(buildScriptEmitsMainBundle),
+        `${site} runs ${MAIN_BUNDLE} but no build-script emits it: ${JSON.stringify(buildScripts)}`,
+      );
+
+      // The main build reads tsconfig.json, so a curated checkout has to carry it.
+      const checkout = steps.find((step) =>
+        String(step.uses ?? "").startsWith("actions/checkout@"),
+      );
+      const sparseCheckout = checkout?.with?.["sparse-checkout"];
+      if (typeof sparseCheckout === "string") {
+        const entries = sparseCheckout
+          .split(/\r?\n/)
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        assert.ok(
+          sparseEntriesCover(entries, "tsconfig.json"),
+          `${site} builds ${MAIN_BUNDLE} from a sparse checkout that omits tsconfig.json`,
+        );
+      }
+    }
+  }
+  assert.ok(audited.length > 0, `no job invoking ${MAIN_BUNDLE} was audited`);
 });
 
 test("state-hydrating sparse repair workflows keep hydration dependencies", () => {


### PR DESCRIPTION
Fixes #946.

## What this fixes

`repair comment router` and `repair cluster worker`'s `execute` job run
`node dist/clawsweeper.js publish-action-event-paths`, but both asked `setup-pnpm`
for `build-script: build:repair`. That script is `tsc -p tsconfig.repair.json` and
does not emit `dist/clawsweeper.js`, which comes from the main build. The
`Publish immutable command action ledger` step therefore failed with
`MODULE_NOT_FOUND` on every run that reached it.

Both jobs now request `build:node`, a new script that chains the two Node bundles
they use and leaves out the dashboard leg neither runs. The router's curated sparse
checkout also gains `tsconfig.json` so the main build can find its config; the
execute job already checks out the whole tree.

`build:node` chains rather than selecting both scripts by regex, because pnpm runs
regex-selected scripts concurrently and `tsconfig.repair.json` also compiles five
non-repair sources (`src/repository-profiles.ts`, `src/codex-output-capture.ts`,
`src/codex-spawn.ts`, `src/codex-app-server-worker.ts`,
`src/codex-process-worker.ts`) that `tsconfig.json` emits to the same paths. Two
concurrent compilers would race on those outputs.

## Rebased onto current main

Head `c5ab9976`, base `origin/main` `9e464d65`. The review on this PR asked for the
proof to be re-taken against current main, so every capture below was re-run at
this head. The diff is unchanged at +128 −4.

The two workflow files this PR edits are byte-identical between the earlier base
`8365a79a` and current main, and both direct main-bundle call sites are still
present:

```
$ git diff --stat 8365a79a origin/main -- .github/workflows/repair-comment-router.yml .github/workflows/repair-cluster-worker.yml
(no output: identical)

$ git log --oneline 8365a79a..origin/main -- .github/workflows/repair-comment-router.yml .github/workflows/repair-cluster-worker.yml
(no output: no commit touched them)

$ git grep -n "node dist/clawsweeper.js publish-action-event-paths" origin/main -- .github/workflows/repair-comment-router.yml .github/workflows/repair-cluster-worker.yml
origin/main:.github/workflows/repair-cluster-worker.yml:905:          node dist/clawsweeper.js publish-action-event-paths \
origin/main:.github/workflows/repair-comment-router.yml:521:          node dist/clawsweeper.js publish-action-event-paths \
```

The router's sparse checkout at current main still carries the broad `src` entry
and still omits `tsconfig.json`, which is exactly what the added entry supplies:

```
$ git show origin/main:.github/workflows/repair-comment-router.yml | sed -n "99,114p"
            .github
            config
            jobs
            prompts/pr-close-coverage-proof.md
            results
            schema/clawsweeper-pr-close-coverage-proof.schema.json
            scripts/hydrate-state.ts
            scripts/prepare-worker-record-cache.ts
            scripts/worker-blobs.ts
            scripts/worker-records.ts
            src
            package.json
            pnpm-lock.yaml
            pnpm-workspace.yaml
            tsconfig.repair.json
          sparse-checkout-cone-mode: false
```

## Evidence

Driving the exact build-script value each job passes at head `c5ab9976`, then
invoking the bundle the failing step invokes:

```
# clawsweeper @ c5ab9976, base origin/main 9e464d65

## BEFORE - the build-script these jobs used to pass
$ rm -rf dist && pnpm run --silent build:repair
$ node dist/clawsweeper.js publish-action-event-paths --paths-file /dev/null
Error: Cannot find module '/home/masato/dev/clawsweeper/dist/clawsweeper.js'

## AFTER - the build-script this patch passes
$ rm -rf dist && pnpm run --silent build:node
$ tsc -p tsconfig.json
$ tsc -p tsconfig.repair.json
$ ls dist/clawsweeper.js dist/repair/action-ledger-cli.js
dist/clawsweeper.js
dist/repair/action-ledger-cli.js
$ ls dist/dashboard    # the leg neither job runs is still skipped
ls: cannot access 'dist/dashboard': No such file or directory
$ node dist/clawsweeper.js publish-action-event-paths --paths-file /dev/null
Error: action event publish path manifest is not a file: /dev/null
    at publishActionEventPathsCommand (file:///home/masato/dev/clawsweeper/dist/clawsweeper.js:26136:15)
    at main (file:///home/masato/dev/clawsweeper/dist/clawsweeper.js:26198:19)
```

After the change the module resolves and execution reaches
`publishActionEventPathsCommand` inside `dist/clawsweeper.js`, failing only on the
placeholder argument. That is the discriminator: the subcommand is reachable.

The router's sparse entry is load-bearing on its own. Its checkout is
`cone-mode: false` with a curated list, so a file it does not name is absent:

```
# clawsweeper @ c5ab9976
$ mv tsconfig.json /tmp/ && pnpm run build:node
$ tsc -p tsconfig.json
error TS5058: The specified path does not exist: '/home/masato/dev/clawsweeper/tsconfig.json'.
[ELIFECYCLE] Command failed with exit code 1.
[ELIFECYCLE] Command failed with exit code 1.
```

## The guard

`test/repair/workflow-sparse-checkout.test.ts` gains a check that walks every
workflow, finds each job with a step that runs `dist/clawsweeper.js` directly, and
requires that job to obtain the bundle — by a build-script that builds it, or by
restoring the `clawsweeper-runtime-dist` artifact, which is how `sweep.yml`'s
`review` shard gets it. Jobs that build from a sparse checkout must also carry
`tsconfig.json`. It audits every job that invokes the bundle directly — nine jobs
carrying fifteen invocation lines today: two jobs in `assist.yml` (five lines),
five in `sweep.yml` (eight lines), and the two changed here (one line each).

Two details are deliberate. The helper resolves a build-script *through
package.json*, following `pnpm run` chains, so `build`, `build:node` and
`build:all` are all recognised without restating which name covers which bundle.
And the artifact exemption requires that exact artifact name rather than accepting
`actions/download-artifact` in general — the execute job downloads unrelated worker
artifacts, and a looser check would let it revert silently.

The audit is deliberately limited to direct invocations. A job that reaches the
bundle through a package script is not covered, because some `build-script` values
are GitHub expressions that only a live run resolves — `sweep.yml`'s
`event-review-apply` picks between `build:all` and `build:repair` that way. Widening
the audit would mean evaluating those expressions, so it is left out rather than
guessed at.

Reverting any one of the three parts fails the guard, and nothing else:

```
# clawsweeper @ c5ab9976  guard: node --test test/repair/workflow-sparse-checkout.test.ts

### revert router build-script only  (:184 build:node -> build:repair)
reverted line:           build-script: build:repair
ℹ pass 7
ℹ fail 1
  AssertionError: .github/workflows/repair-comment-router.yml:route-comments runs dist/clawsweeper.js but no build-script emits it: ["build:repair"]

### revert cluster-worker build-script only  (:572 build:node -> build:repair)
reverted line:           build-script: build:repair
ℹ pass 7
ℹ fail 1
  AssertionError: .github/workflows/repair-cluster-worker.yml:execute runs dist/clawsweeper.js but no build-script emits it: ["build:repair"]

### revert router sparse tsconfig.json only  (delete :113)
line 113 is now:             tsconfig.repair.json
ℹ pass 7
ℹ fail 1
  AssertionError: .github/workflows/repair-comment-router.yml:route-comments builds dist/clawsweeper.js from a sparse checkout that omits tsconfig.json

### restored
ℹ pass 8
ℹ fail 0
```

The pre-existing `build-script: build:repair` string assertion became the same kind
of resolved check, since the router no longer passes that literal.

## Proof summary

- **Behavior addressed:** the `Publish immutable command action ledger` step in
  `repair comment router` and in `repair cluster worker`'s `execute` job aborts
  with `MODULE_NOT_FOUND` because the job never builds `dist/clawsweeper.js`.
- **Real environment tested:** production GitHub Actions runs for the router
  failure (see #946); local Node `v24.18.0` running the exact build-script values
  the workflows pass, plus the built CLI itself.
- **Exact steps or command run after this patch:**

  ```bash
  rm -rf dist && pnpm run build:node
  node dist/clawsweeper.js publish-action-event-paths --paths-file /dev/null
  node --test test/repair/workflow-sparse-checkout.test.ts
  ```

- **Evidence after fix:** the capture above — the bundle exists, the dashboard leg
  is still skipped, and the CLI reaches `publishActionEventPathsCommand`.
- **Observed result after fix:** `pass 8 / fail 0` on the guard file, and
  `fail 1` naming the exact missing piece when any one part is reverted.
- **What was not tested:** this patch is not deployed, so there is no production
  run of the fixed jobs. #946 documents the router failing repeatedly in
  production; for the `execute` job the same defect is established by reading the
  workflow — it passes `build:repair` and runs the bundle — rather than by an
  observed run, because that job is conditional and I did not catch it in the act.
  `pnpm run check` at this head on Node `v24.18.0` ran 2,812 tests with 6 failures,
  all host-caused and all inside `test/repair/target-validation.test.ts`, which this
  patch does not touch: three need `git worktree list -z` (this host has Git
  2.34.1, `-z` arrived in 2.36) and three cannot resolve the bun/npm/pnpm
  containment fixtures. `pnpm run build:all` exits 0, and every static check and
  lint lane passes.

## Not in scope

- `sweep.yml` and `assist.yml` already pass a build that emits the bundle
  (`build:all` and `build`), so they are unchanged.
- The exact-review batch publication failures on the same infrastructure are a
  different defect and are tracked in #898.
