### PR TITLE
fix: prevent stable labels from leaking across surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Restricted `maturity:stable` issue labeling to the primary taxonomy owner surface, with below-M4 exclusions in the review helper so incidental Gateway or CLI plumbing no longer promotes Beta, Alpha, or Experimental issues.
 - Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, renewed overdue canonical records ahead of unseen backlog, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
 - Routed scheduled review through the durable exact-review queue, raised each target plan from one to 20 candidates, and added oldest-age funnel telemetry plus a fleet-wide 200-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
 - Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Restricted `maturity:stable` issue labeling to the primary taxonomy owner surface, with below-M4 exclusions in the review helper so incidental Gateway or CLI plumbing no longer promotes Beta, Alpha, or Experimental issues.
 - Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, renewed overdue canonical records ahead of unseen backlog, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
 - Routed scheduled review through the durable exact-review queue, raised each target plan from one to 20 candidates, and added oldest-age funnel telemetry plus a fleet-wide 200-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
 - Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -218,12 +218,18 @@ Prefer `impact:ux-release-blocker` over `impact:ux-friction` when the same
 evidence supports both.
 
 Set `maturityLabels` for issues only; use `[]` for PRs or unsupported matches.
-`maturity:stable`: Issue affects a taxonomy feature currently scored M4/M5.
+`maturity:stable`: The issue's primary taxonomy surface is currently scored M4/M5.
 First run `node "$CLAWSWEEPER_PROOF_SCRATCH_DIR/maturity-stable-shortlist.mjs"`
-from the target checkout and compare the issue against the M4+ shortlist. Read
+from the target checkout. Identify exactly one primary owner surface from the
+broken or missing product behavior and the source owner boundary. Shared
+Gateway/CLI transit, APIs, hosting, diagnostics, or implementation plumbing do
+not qualify an issue whose primary owner is below M4. A feature proposal does
+not qualify merely because implementing it would modify a stable surface.
+The helper lists both eligible M4+ surfaces and below-M4 exclusions. Read
 `taxonomy.yaml`, the full checked-out `qa/maturity-scores.yaml`, or
-`docs/maturity/` only if the shortlist is ambiguous. Select `maturity:stable`
-only for M4/M5 matches. Cite the feature id/name and score in `evidence` and
+`docs/maturity/` when the primary owner or category is ambiguous. Select
+`maturity:stable` only when that primary surface is M4/M5. Cite the primary
+surface id/name/code and the matching category in `evidence` and
 `labelJustifications`.
 Stable maturity supports priority, but does not automatically escalate it.
 

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -311,7 +311,7 @@
         "type": "string",
         "enum": ["maturity:stable"]
       },
-      "description": "Issue-only labels for mature taxonomy matches. Use [] for PRs. Select maturity:stable only when an active matched feature is currently M4/M5 in qa/maturity-scores.yaml."
+      "description": "Issue-only labels for mature taxonomy matches. Use [] for PRs. Select maturity:stable only when the issue's primary owner surface is currently M4/M5 in qa/maturity-scores.yaml; incidental Gateway/CLI transit or implementation plumbing does not qualify a lower-maturity surface."
     },
     "mergeRiskOptions": {
       "type": "array",

--- a/scripts/maturity-stable-shortlist.mjs
+++ b/scripts/maturity-stable-shortlist.mjs
@@ -14,19 +14,34 @@ console.log(stableShortlist(readFileSync(scorecardPath, "utf8")));
 function stableShortlist(text) {
   const scorecard = parse(text);
   const surfaces = Array.isArray(scorecard?.surfaces) ? scorecard.surfaces : [];
-  const rows = surfaces
-    .map(surfaceSummary)
-    .filter((surface) => Number(surface.code.replace(/^M/, "")) >= 4);
+  const rows = surfaces.map(surfaceSummary);
+  const stableRows = rows.filter((surface) => maturityCode(surface) >= 4);
+  const nonStableRows = rows.filter((surface) => maturityCode(surface) < 4);
 
-  if (rows.length === 0) return "No M4+ maturity scorecard surfaces found.";
-  return rows
-    .map((surface) => {
-      const categories = surface.categories.length
-        ? ` | categories: ${surface.categories.join("; ")}`
-        : "";
-      return `${surface.id} | ${surface.name} | ${surface.code} ${surface.label} | q${surface.quality} c${surface.completeness}${categories}`;
-    })
-    .join("\n");
+  return [
+    "Primary-surface rule: classify the issue by the product surface that owns the broken or missing behavior. Shared Gateway/CLI transit, APIs, hosting, or diagnostics do not make a lower-maturity owner eligible.",
+    "",
+    "M4+ primary surfaces (eligible for maturity:stable):",
+    ...(stableRows.length > 0
+      ? stableRows.map((surface) => {
+          const categories = surface.categories.length
+            ? ` | categories: ${surface.categories.join("; ")}`
+            : "";
+          return `${surface.id} | ${surface.name} | ${surface.code} ${surface.label} | q${surface.quality} c${surface.completeness}${categories}`;
+        })
+      : ["No M4+ maturity scorecard surfaces found."]),
+    "",
+    "Below-M4 primary surfaces (not eligible for maturity:stable):",
+    ...(nonStableRows.length > 0
+      ? nonStableRows.map(
+          (surface) => `${surface.id} | ${surface.name} | ${surface.code} ${surface.label}`,
+        )
+      : ["No below-M4 maturity scorecard surfaces found."]),
+  ].join("\n");
+}
+
+function maturityCode(surface) {
+  return Number(surface.code.replace(/^M/, ""));
 }
 
 function surfaceSummary(surface) {

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -1802,7 +1802,7 @@ const MATURITY_LABELS = [
   {
     name: "maturity:stable",
     color: "1F883D",
-    description: "Issue affects a taxonomy feature currently scored M4/M5.",
+    description: "Issue's primary taxonomy surface is currently scored M4/M5.",
   },
 ] as const satisfies readonly {
   name: MaturityLabelName;

--- a/test/maturity-shortlist-script.test.ts
+++ b/test/maturity-shortlist-script.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-test("maturity shortlist script emits only M4+ surfaces", () => {
+test("maturity shortlist script distinguishes eligible primary surfaces from exclusions", () => {
   const dir = mkdtempSync(join(tmpdir(), "clawsweeper-maturity-"));
   try {
     const scorecard = join(dir, "maturity-scores.yaml");
@@ -38,9 +38,12 @@ test("maturity shortlist script emits only M4+ surfaces", () => {
       scorecard,
     ]).toString();
 
+    assert.match(output, /Primary-surface rule:/);
+    assert.match(output, /M4\+ primary surfaces \(eligible for maturity:stable\):/);
     assert.match(output, /gateway-runtime \| Gateway runtime \| M4 Stable \| q81 c89/);
     assert.match(output, /categories: HTTP APIs/);
-    assert.doesNotMatch(output, /agent-runtime/);
+    assert.match(output, /Below-M4 primary surfaces \(not eligible for maturity:stable\):/);
+    assert.match(output, /agent-runtime \| Agent runtime \| M3 Beta/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/pr-label-policy.test.ts
+++ b/test/pr-label-policy.test.ts
@@ -733,7 +733,7 @@ test("ClawSweeper maturity labels remove stale owned labels and preserve unrelat
     {
       name: "maturity:stable",
       color: "1F883D",
-      description: "Issue affects a taxonomy feature currently scored M4/M5.",
+      description: "Issue's primary taxonomy surface is currently scored M4/M5.",
     },
   ]);
   assert.deepEqual(maturityLabelsForTest(["bug"], ["maturity:stable"]), ["bug", "maturity:stable"]);

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -436,7 +436,9 @@ test("review prompt uses token-light maturity shortlist helper", () => {
   );
 
   assert.match(prompt, /maturity-stable-shortlist\.mjs/);
-  assert.match(prompt, /compare the issue against the M4\+ shortlist/);
+  assert.match(prompt, /Identify exactly one primary owner surface/);
+  assert.match(prompt, /Shared\s+Gateway\/CLI transit/);
+  assert.match(prompt, /feature proposal does\s+not qualify/);
   assert.match(
     runtimePrompt,
     /node "\$CLAWSWEEPER_PROOF_SCRATCH_DIR\/maturity-stable-shortlist\.mjs"/,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where lower-maturity OpenClaw issues could receive `maturity:stable` when their implementation happened to pass through Gateway or CLI code.

## Why This Change Was Made

ClawSweeper now identifies exactly one primary taxonomy owner surface before applying the label. The scorecard helper presents both eligible M4+ surfaces and explicit below-M4 exclusions, so incidental shared plumbing cannot promote Beta, Alpha, or Experimental work.

## User Impact

Maintainers can treat `maturity:stable` as a signal about the issue's owning product surface instead of an incidental implementation dependency. Existing labels are not bulk-rewritten by this PR.

## Evidence

- `pnpm run build`
- `node --test test/maturity-shortlist-script.test.ts test/review-prompt-policy.test.ts test/pr-label-policy.test.ts` (75 passed)
- `git diff --check`
- Autoreview: clean, patch correct, confidence 0.94
- `pnpm run check`: changed surfaces, build, formatting, lint, and the broad suite ran; the local macOS run ended on unrelated platform/flaky failures:
  - `test/dashboard-worker.test.ts`: clock-boundary expectation `9060` vs `9061`
  - `test/repair/process-tree-containment.test.ts`: Linux `capset`/Landlock symbols unavailable on macOS

## Real Behavior Proof

- **Claim:** the review helper clearly excludes below-M4 primary owners and prevents incidental Gateway/CLI plumbing from qualifying them for `maturity:stable`.
- **Exercised surface:** `scripts/maturity-stable-shortlist.mjs` against OpenClaw's current `qa/maturity-scores.yaml`.
- **Command/environment:** Node 26 on macOS; `node scripts/maturity-stable-shortlist.mjs <openclaw>/qa/maturity-scores.yaml`.
- **Observed result:** output begins with the primary-owner rule, lists the seven M4+ eligible surfaces with their scorecard categories, and separately lists 39 below-M4 surfaces as ineligible.
- **Artifact/trace:** focused tests assert the rule text, eligible stable rows, below-M4 exclusions, and matching prompt/schema label policy.
- **Limits:** this changes future review classification. The separately audited existing issue cohort is being corrected manually; this PR does not bulk-edit GitHub labels.
