### PR TITLE
fix: unthrottle exact review admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Isolated review admission, pressure, and backpressure accounting from the publication lane so stale publication work cannot throttle review throughput, made top-level queue health review-specific, and added durable shed counters by reason.
 - Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, renewed overdue canonical records ahead of unseen backlog, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
 - Routed scheduled review through the durable exact-review queue, raised each target plan from one to 20 candidates, and added oldest-age funnel telemetry plus a fleet-wide 200-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
 - Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.

--- a/dashboard/exact-review-health.ts
+++ b/dashboard/exact-review-health.ts
@@ -53,9 +53,7 @@ export type ExactReviewPressureSummary = {
     | "no_admissible_backlog"
     | "dispatcher_inactive"
     | "handoff_unknown"
-    | "capacity_full_with_backlog"
-    | "publication_degraded"
-    | "publication_critical";
+    | "capacity_full_with_backlog";
   capacity: number;
   active: number;
   pending: number;
@@ -65,6 +63,13 @@ export type ExactReviewPressureSummary = {
 
 export type ExactReviewPublicationHealth = {
   status?: "idle" | "healthy" | "degraded" | "critical";
+};
+
+export type ExactReviewPublicationLaneSummary = {
+  pending: number;
+  active: number;
+  parked: number;
+  oldest_pending_age_seconds: number | null;
 };
 
 const PHASES: ExactReviewPhase[] = ["pending", "dispatching", "leased"];
@@ -252,17 +257,36 @@ export function summarizeExactReviewPressure({
   };
 }
 
-export function elevateExactReviewPressureForPublication(
-  pressure: ExactReviewPressureSummary,
-  publication: ExactReviewPublicationHealth,
-): ExactReviewPressureSummary {
-  if (publication.status === "critical" && pressure.status !== "saturated") {
-    return { ...pressure, status: "saturated", reason: "publication_critical" };
+export function summarizeExactReviewPublicationHealth(
+  lane: ExactReviewPublicationLaneSummary,
+  flow: { last_15_minutes: { net_drain_rate_per_hour: number } },
+): ExactReviewPublicationHealth & { reason: string | null } {
+  const pending = nonNegativeInteger(lane.pending);
+  const active = nonNegativeInteger(lane.active);
+  const parked = nonNegativeInteger(lane.parked);
+  const oldestAge = nonNegativeInteger(lane.oldest_pending_age_seconds);
+
+  // Dead letters and retired state-writer history are reported independently.
+  // Neither is current publication demand, so an empty lane must stay idle.
+  if (pending === 0 && active === 0 && parked === 0) {
+    return { status: "idle", reason: null };
   }
-  if (publication.status === "degraded" && pressure.status === "idle") {
-    return { ...pressure, status: "congested", reason: "publication_degraded" };
+  if (parked > 0 || oldestAge >= 6 * 60 * 60) {
+    return {
+      status: "critical",
+      reason: parked > 0 ? "dead_letter_capacity" : "oldest_pending_over_6h",
+    };
   }
-  return pressure;
+  if (
+    oldestAge >= 60 * 60 ||
+    (pending >= 100 && flow.last_15_minutes.net_drain_rate_per_hour <= 0)
+  ) {
+    return {
+      status: "degraded",
+      reason: oldestAge >= 60 * 60 ? "oldest_pending_over_1h" : "not_draining",
+    };
+  }
+  return { status: "healthy", reason: null };
 }
 
 function exactReviewPhaseStartedAt(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -6,10 +6,9 @@ import {
   type StateWriterOperation,
 } from "../src/state-writer-telemetry.ts";
 import {
-  elevateExactReviewPressureForPublication,
+  summarizeExactReviewPublicationHealth,
   summarizeExactReviewHandoff,
   summarizeExactReviewPressure,
-  type ExactReviewPublicationHealth,
 } from "./exact-review-health.ts";
 import {
   ExactReviewPublicationBatchStore,
@@ -295,7 +294,15 @@ type ExactReviewQueueStorageMeta = {
   shed_since_reset?: number;
 };
 type ExactReviewQueueMetricTotals = {
-  review: { enqueued: number; completed: number; superseded: number; semanticDeduped: number };
+  review: {
+    enqueued: number;
+    completed: number;
+    superseded: number;
+    semanticDeduped: number;
+    shed: number;
+    shedBackpressure: number;
+    shedScheduledRate: number;
+  };
   publication: {
     enqueued: number;
     completed: number;
@@ -331,6 +338,8 @@ type ExactReviewQueueMetricDelta = {
   reviewSemanticDeduped?: number;
   reviewRetried?: number;
   reviewShed?: number;
+  reviewShedBackpressure?: number;
+  reviewShedScheduledRate?: number;
   publicationEnqueued?: number;
   publicationCompleted?: number;
   publicationPublished?: number;
@@ -1391,11 +1400,14 @@ export class ExactReviewQueue {
           if (
             !decision.publication &&
             (isLowPriorityExactReviewDecision(decision) || exactReviewScheduledLane(decision)) &&
-            exactReviewQueuePendingCount(state) >= exactReviewPendingSoftLimit(this.env)
+            exactReviewQueuePendingReviewCount(state) >= exactReviewPendingSoftLimit(this.env)
           ) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
             this.writeStateSync(state);
-            this.incrementQueueMetricsSync({ reviewShed: 1 });
+            this.incrementQueueMetricsSync({ reviewShed: 1, reviewShedBackpressure: 1 });
+            console.warn(
+              `exact-review admission shed: reason=backpressure item=${key} review_pending=${exactReviewQueuePendingReviewCount(state)} limit=${exactReviewPendingSoftLimit(this.env)}`,
+            );
             return { shed: true as const, reason: "backpressure" as const };
           }
           if (
@@ -1404,7 +1416,10 @@ export class ExactReviewQueue {
           ) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
             this.writeStateSync(state);
-            this.incrementQueueMetricsSync({ reviewShed: 1 });
+            this.incrementQueueMetricsSync({ reviewShed: 1, reviewShedScheduledRate: 1 });
+            console.warn(
+              `exact-review admission shed: reason=scheduled_rate item=${key} lane=${exactReviewScheduledLane(decision)}`,
+            );
             return { shed: true as const, reason: "scheduled_rate" as const };
           }
           if (!decision.publication && !exactReviewScheduledLane(decision)) {
@@ -2805,10 +2820,9 @@ export class ExactReviewQueue {
         legacyExcludedItemKeys,
         publicationBatches.nextLeaseExpiresAt,
       );
-      const publicationHealth = exactReviewPublicationHealth(
+      const publicationHealth = summarizeExactReviewPublicationHealth(
         stats.lanes.publication,
         publicationFlow,
-        deadLetters,
       );
       const reservationClaimObservability = exactReviewReservationClaimObservability({
         now,
@@ -2821,7 +2835,6 @@ export class ExactReviewQueue {
       });
       return json({
         ...stats,
-        pressure: elevateExactReviewPressureForPublication(stats.pressure, publicationHealth),
         bay_projection: exactReviewQueueBayProjection(
           Object.values(state.items),
           bayPriorityKeys,
@@ -2834,6 +2847,11 @@ export class ExactReviewQueue {
             completed_total: metrics.review.completed,
             superseded_total: metrics.review.superseded,
             semantic_deduped_total: metrics.review.semanticDeduped,
+            shed_reasons_since_reset: {
+              backpressure: metrics.review.shedBackpressure,
+              scheduled_rate: metrics.review.shedScheduledRate,
+              unattributed: Math.max(0, exactReviewShedSinceReset(state) - metrics.review.shed),
+            },
             flow: reviewFlow,
           },
           publication: {
@@ -3009,17 +3027,13 @@ export class ExactReviewQueue {
     let batchTerminalPreflightReady = false;
     if (snapshotBatchDeparture?.due && !snapshotDispatcherBackoffActive) {
       const batchTerminalProbe = exactReviewPublicationBatchCandidateProbe(snapshotBatchCandidates);
-      const terminalized = await this.terminalizePublicationCandidates(
+      await this.terminalizePublicationCandidates(
         snapshotBatchCandidates.map((item) => ({
           key: item.key,
           revision: item.revision,
           decision: item.decision,
         })),
       );
-      if (terminalized.length) {
-        await this.scheduleNext(this.readStateSync(), Date.now());
-        return;
-      }
 
       // Target reads release the Durable Object input gate. Recompute the
       // departure and admit a workflow only when its exact eventual claim is
@@ -5893,6 +5907,11 @@ export class ExactReviewQueue {
            CHECK (review_superseded_total >= 0),
          review_semantic_deduped_total INTEGER NOT NULL DEFAULT 0
            CHECK (review_semantic_deduped_total >= 0),
+         review_shed_total INTEGER NOT NULL DEFAULT 0 CHECK (review_shed_total >= 0),
+         review_shed_backpressure_total INTEGER NOT NULL DEFAULT 0
+           CHECK (review_shed_backpressure_total >= 0),
+         review_shed_scheduled_rate_total INTEGER NOT NULL DEFAULT 0
+           CHECK (review_shed_scheduled_rate_total >= 0),
          publication_enqueued_total INTEGER NOT NULL DEFAULT 0
            CHECK (publication_enqueued_total >= 0),
          publication_completed_total INTEGER NOT NULL CHECK (publication_completed_total >= 0)
@@ -5903,6 +5922,9 @@ export class ExactReviewQueue {
       "review_completed_total",
       "review_superseded_total",
       "review_semantic_deduped_total",
+      "review_shed_total",
+      "review_shed_backpressure_total",
+      "review_shed_scheduled_rate_total",
       "publication_enqueued_total",
       "publication_published_total",
       "publication_superseded_total",
@@ -6053,6 +6075,10 @@ export class ExactReviewQueue {
          review_superseded INTEGER NOT NULL DEFAULT 0 CHECK (review_superseded >= 0),
          review_retried INTEGER NOT NULL DEFAULT 0 CHECK (review_retried >= 0),
          review_shed INTEGER NOT NULL DEFAULT 0 CHECK (review_shed >= 0),
+         review_shed_backpressure INTEGER NOT NULL DEFAULT 0
+           CHECK (review_shed_backpressure >= 0),
+         review_shed_scheduled_rate INTEGER NOT NULL DEFAULT 0
+           CHECK (review_shed_scheduled_rate >= 0),
          publication_enqueued INTEGER NOT NULL DEFAULT 0 CHECK (publication_enqueued >= 0),
          publication_resolved INTEGER NOT NULL DEFAULT 0 CHECK (publication_resolved >= 0),
          publication_published INTEGER NOT NULL DEFAULT 0 CHECK (publication_published >= 0),
@@ -6070,6 +6096,8 @@ export class ExactReviewQueue {
       "review_superseded",
       "review_retried",
       "review_shed",
+      "review_shed_backpressure",
+      "review_shed_scheduled_rate",
       "publication_semantic_deduped",
     ]) {
       const present = Array.from(
@@ -6636,7 +6664,8 @@ export class ExactReviewQueue {
     const row = Array.from(
       this.storage.sql.exec(
         `SELECT review_enqueued_total, review_completed_total, review_superseded_total,
-                review_semantic_deduped_total,
+                review_semantic_deduped_total, review_shed_total,
+                review_shed_backpressure_total, review_shed_scheduled_rate_total,
                 publication_enqueued_total, publication_completed_total,
                 publication_published_total, publication_superseded_total,
                 publication_semantic_deduped_total,
@@ -6651,6 +6680,9 @@ export class ExactReviewQueue {
           review_completed_total?: number;
           review_superseded_total?: number;
           review_semantic_deduped_total?: number;
+          review_shed_total?: number;
+          review_shed_backpressure_total?: number;
+          review_shed_scheduled_rate_total?: number;
           publication_enqueued_total?: number;
           publication_completed_total?: number;
           publication_published_total?: number;
@@ -6667,6 +6699,9 @@ export class ExactReviewQueue {
         completed: exactReviewMetricTotal(row?.review_completed_total),
         superseded: exactReviewMetricTotal(row?.review_superseded_total),
         semanticDeduped: exactReviewMetricTotal(row?.review_semantic_deduped_total),
+        shed: exactReviewMetricTotal(row?.review_shed_total),
+        shedBackpressure: exactReviewMetricTotal(row?.review_shed_backpressure_total),
+        shedScheduledRate: exactReviewMetricTotal(row?.review_shed_scheduled_rate_total),
       },
       publication: {
         enqueued: exactReviewMetricTotal(row?.publication_enqueued_total),
@@ -6688,6 +6723,8 @@ export class ExactReviewQueue {
     const reviewSemanticDeduped = exactReviewMetricDelta(delta.reviewSemanticDeduped);
     const reviewRetried = exactReviewMetricDelta(delta.reviewRetried);
     const reviewShed = exactReviewMetricDelta(delta.reviewShed);
+    const reviewShedBackpressure = exactReviewMetricDelta(delta.reviewShedBackpressure);
+    const reviewShedScheduledRate = exactReviewMetricDelta(delta.reviewShedScheduledRate);
     const publicationEnqueued = exactReviewMetricDelta(delta.publicationEnqueued);
     const publicationCompleted = exactReviewMetricDelta(delta.publicationCompleted);
     const publicationPublished = exactReviewMetricDelta(delta.publicationPublished);
@@ -6703,6 +6740,8 @@ export class ExactReviewQueue {
       !reviewSemanticDeduped &&
       !reviewRetried &&
       !reviewShed &&
+      !reviewShedBackpressure &&
+      !reviewShedScheduledRate &&
       !publicationEnqueued &&
       !publicationCompleted &&
       !publicationPublished &&
@@ -6720,6 +6759,9 @@ export class ExactReviewQueue {
               review_completed_total = review_completed_total + ?,
               review_superseded_total = review_superseded_total + ?,
               review_semantic_deduped_total = review_semantic_deduped_total + ?,
+              review_shed_total = review_shed_total + ?,
+              review_shed_backpressure_total = review_shed_backpressure_total + ?,
+              review_shed_scheduled_rate_total = review_shed_scheduled_rate_total + ?,
               publication_enqueued_total = publication_enqueued_total + ?,
               publication_completed_total = publication_completed_total + ?,
               publication_published_total = publication_published_total + ?,
@@ -6733,6 +6775,9 @@ export class ExactReviewQueue {
       reviewCompleted,
       reviewSuperseded,
       reviewSemanticDeduped,
+      reviewShed,
+      reviewShedBackpressure,
+      reviewShedScheduledRate,
       publicationEnqueued,
       publicationCompleted,
       publicationPublished,
@@ -6748,6 +6793,8 @@ export class ExactReviewQueue {
       reviewSuperseded,
       reviewRetried,
       reviewShed,
+      reviewShedBackpressure,
+      reviewShedScheduledRate,
       publicationEnqueued,
       publicationCompleted,
       publicationPublished,
@@ -6764,6 +6811,8 @@ export class ExactReviewQueue {
     reviewSuperseded,
     reviewRetried,
     reviewShed,
+    reviewShedBackpressure,
+    reviewShedScheduledRate,
     publicationEnqueued,
     publicationCompleted,
     publicationPublished,
@@ -6777,6 +6826,8 @@ export class ExactReviewQueue {
     reviewSuperseded: number;
     reviewRetried: number;
     reviewShed: number;
+    reviewShedBackpressure: number;
+    reviewShedScheduledRate: number;
     publicationEnqueued: number;
     publicationCompleted: number;
     publicationPublished: number;
@@ -6791,6 +6842,8 @@ export class ExactReviewQueue {
       !reviewSuperseded &&
       !reviewRetried &&
       !reviewShed &&
+      !reviewShedBackpressure &&
+      !reviewShedScheduledRate &&
       !publicationEnqueued &&
       !publicationCompleted &&
       !publicationPublished &&
@@ -6807,17 +6860,21 @@ export class ExactReviewQueue {
     this.storage.sql.exec(
       `INSERT INTO ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
          (bucket_start, review_enqueued, review_completed, review_superseded, review_retried,
-          review_shed,
+          review_shed, review_shed_backpressure, review_shed_scheduled_rate,
           publication_enqueued, publication_resolved, publication_published,
           publication_superseded, publication_semantic_deduped,
           publication_retried, publication_dead_lettered)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(bucket_start) DO UPDATE SET
          review_enqueued = review_enqueued + excluded.review_enqueued,
          review_completed = review_completed + excluded.review_completed,
          review_superseded = review_superseded + excluded.review_superseded,
          review_retried = review_retried + excluded.review_retried,
          review_shed = review_shed + excluded.review_shed,
+         review_shed_backpressure =
+           review_shed_backpressure + excluded.review_shed_backpressure,
+         review_shed_scheduled_rate =
+           review_shed_scheduled_rate + excluded.review_shed_scheduled_rate,
          publication_enqueued = publication_enqueued + excluded.publication_enqueued,
          publication_resolved = publication_resolved + excluded.publication_resolved,
          publication_published = publication_published + excluded.publication_published,
@@ -6833,6 +6890,8 @@ export class ExactReviewQueue {
       reviewSuperseded,
       reviewRetried,
       reviewShed,
+      reviewShedBackpressure,
+      reviewShedScheduledRate,
       publicationEnqueued,
       publicationCompleted,
       publicationPublished,
@@ -6995,7 +7054,9 @@ export class ExactReviewQueue {
         `SELECT COALESCE(SUM(review_enqueued), 0) AS enqueued,
                 COALESCE(SUM(review_completed), 0) AS completed,
                 COALESCE(SUM(review_retried), 0) AS retried,
-                COALESCE(SUM(review_shed), 0) AS shed
+                COALESCE(SUM(review_shed), 0) AS shed,
+                COALESCE(SUM(review_shed_backpressure), 0) AS shed_backpressure,
+                COALESCE(SUM(review_shed_scheduled_rate), 0) AS shed_scheduled_rate
            FROM ${EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE}
           WHERE bucket_start >= ?`,
         now - windowMs,
@@ -7006,6 +7067,8 @@ export class ExactReviewQueue {
     const successful = Number(row?.completed || 0);
     const retried = Number(row?.retried || 0);
     const shed = Number(row?.shed || 0);
+    const shedBackpressure = Number(row?.shed_backpressure || 0);
+    const shedScheduledRate = Number(row?.shed_scheduled_rate || 0);
     const arrival = enqueued + shed;
     return {
       last_15_minutes: {
@@ -7014,6 +7077,10 @@ export class ExactReviewQueue {
         successful,
         retried,
         shed,
+        shed_reasons: {
+          backpressure: shedBackpressure,
+          scheduled_rate: shedScheduledRate,
+        },
         arrival_rate_per_hour: Math.round(arrival * multiplier * 10) / 10,
         successful_rate_per_hour: Math.round(successful * multiplier * 10) / 10,
         retried_rate_per_hour: Math.round(retried * multiplier * 10) / 10,
@@ -9335,8 +9402,10 @@ function isLowPriorityExactReviewDecision(decision: ExactReviewDecision) {
   return EXACT_REVIEW_LOW_PRIORITY_SOURCE_ACTIONS.has(decision.sourceAction);
 }
 
-function exactReviewQueuePendingCount(state: ExactReviewQueueState) {
-  return Object.values(state.items).filter((item) => item.state === "pending").length;
+function exactReviewQueuePendingReviewCount(state: ExactReviewQueueState) {
+  return Object.values(state.items).filter(
+    (item) => item.state === "pending" && !exactReviewQueueIsPublication(item),
+  ).length;
 }
 
 function exactReviewShedSinceReset(state: Pick<ExactReviewQueueState, "shedSinceReset">) {
@@ -9755,28 +9824,33 @@ export function exactReviewQueueAdmittedItems(
     const target = item.decision.targetRepo;
     activeTargets.set(target, (activeTargets.get(target) || 0) + 1);
   }
-  const admitted: ExactReviewQueueItem[] = [];
-  const admittedPublicationItems = new Set<string>();
-  let admittedReviews = 0;
   const pending = Object.values(state.items)
     .filter(
       (item) =>
         item.state === "pending" && item.nextAttemptAt <= now && !excludedItemKeys.has(item.key),
     )
     .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
-  const prioritizedPublications = exactReviewPrioritizePublicationItems(
+  const pendingReviews = pending.filter((item) => !exactReviewQueueIsPublication(item));
+  const pendingPublications = exactReviewPrioritizePublicationItems(
     pending.filter(exactReviewQueueIsPublication),
     freshPublicationItemKeys,
     freshPublicationReserve,
   );
-  let publicationIndex = 0;
-  const ordered = pending.map((item) =>
-    exactReviewQueueIsPublication(item) ? prioritizedPublications[publicationIndex++]! : item,
-  );
-  for (const item of ordered) {
-    const publication = exactReviewQueueIsPublication(item);
-    if (publication) {
-      if (publicationAdmissionBlocked) continue;
+  const admittedReviews: ExactReviewQueueItem[] = [];
+  for (const item of pendingReviews) {
+    if (admittedReviews.length >= reviewSlots) break;
+    const target = item.decision.targetRepo;
+    const active = activeTargets.get(target) || 0;
+    if (active >= targetCapacity) continue;
+    activeTargets.set(target, active + 1);
+    admittedReviews.push(item);
+  }
+
+  const admittedPublications: ExactReviewQueueItem[] = [];
+  const admittedPublicationItems = new Set<string>();
+  if (!publicationAdmissionBlocked) {
+    for (const item of pendingPublications) {
+      if (activePublishers >= publicationCapacity) break;
       // Distinct publication events may target the same durable record path. A batch
       // must serialize those events across commits or their prepared mutations can
       // disagree even though their queue keys and fencing revisions are independent.
@@ -9784,21 +9858,15 @@ export function exactReviewQueueAdmittedItems(
         ? `${item.decision.targetRepo.toLowerCase()}#${item.decision.itemNumber}`
         : "";
       if (uniquePublicationItems && admittedPublicationItems.has(publicationItem)) continue;
-      if (activePublishers >= publicationCapacity) continue;
       activePublishers += 1;
       if (uniquePublicationItems) admittedPublicationItems.add(publicationItem);
-      admitted.push(item);
-      continue;
+      admittedPublications.push(item);
     }
-    if (admittedReviews >= reviewSlots) continue;
-    const target = item.decision.targetRepo;
-    const active = activeTargets.get(target) || 0;
-    if (active >= targetCapacity) continue;
-    activeTargets.set(target, active + 1);
-    admittedReviews += 1;
-    admitted.push(item);
   }
-  return admitted;
+
+  // Review admission owns its capacity and is intentionally ordered first.
+  // A blocked or slow publication key cannot delay an available review slot.
+  return [...admittedReviews, ...admittedPublications];
 }
 
 function sumFor(rows: Array<Record<string, number | string | null>>, field: string) {
@@ -9836,7 +9904,7 @@ function exactReviewQueueStats(
   const items = Object.values(state.items);
   const handoffItems = items.filter(
     (item): item is ExactReviewQueueItem & { state: "pending" | "dispatching" | "leased" } =>
-      item.state !== "parked",
+      item.state !== "parked" && !exactReviewQueueIsPublication(item),
   );
   const handoffHealth = summarizeExactReviewHandoff({
     // Parked poison items are reported by publication health and cannot take a
@@ -9927,9 +9995,6 @@ function exactReviewQueueStats(
       publicationCapacity,
     ),
   };
-  const readyPending = items.filter(
-    (item) => item.state === "pending" && item.nextAttemptAt <= now,
-  ).length;
   const admissibleItems = exactReviewQueueAdmittedItems(
     state,
     now,
@@ -9939,7 +10004,6 @@ function exactReviewQueueStats(
     excludedItemKeys,
     publicationBlockedUntil !== null && publicationBlockedUntil > now,
   );
-  const admissiblePending = admissibleItems.length;
   const reviewAdmissiblePending = admissibleItems.filter(
     (item) => !exactReviewQueueIsPublication(item),
   ).length;
@@ -9955,9 +10019,9 @@ function exactReviewQueueStats(
   });
   return {
     generated_at: handoffHealth.observed_at,
-    pending: handoffHealth.phases.pending.count,
-    ready_pending: readyPending,
-    admissible_pending: admissiblePending,
+    pending: lanes.review.pending,
+    ready_pending: lanes.review.ready,
+    admissible_pending: reviewAdmissiblePending,
     shed_since_reset: exactReviewShedSinceReset(state),
     dispatching: handoffHealth.phases.dispatching.count,
     leased: handoffHealth.phases.leased.count,
@@ -10054,36 +10118,6 @@ function exactReviewQueueLaneStats(
       oldestBackoffAt === null ? null : Math.max(0, Math.floor((now - oldestBackoffAt) / 1_000)),
     next_attempt_at: nextAttemptAt === null ? null : new Date(nextAttemptAt).toISOString(),
   };
-}
-
-function exactReviewPublicationHealth(
-  lane: ReturnType<typeof exactReviewQueueLaneStats>,
-  flow: { last_15_minutes: { net_drain_rate_per_hour: number } },
-  deadLetters: { open: number },
-): ExactReviewPublicationHealth & { reason: string | null } {
-  const oldestAge = Number(lane.oldest_pending_age_seconds || 0);
-  if (lane.parked > 0 || oldestAge >= 6 * 60 * 60) {
-    return {
-      status: "critical",
-      reason: lane.parked > 0 ? "dead_letter_capacity" : "oldest_pending_over_6h",
-    };
-  }
-  if (
-    deadLetters.open > 0 ||
-    oldestAge >= 60 * 60 ||
-    (lane.pending >= 100 && flow.last_15_minutes.net_drain_rate_per_hour <= 0)
-  ) {
-    return {
-      status: "degraded",
-      reason:
-        deadLetters.open > 0
-          ? "open_dead_letters"
-          : oldestAge >= 60 * 60
-            ? "oldest_pending_over_1h"
-            : "not_draining",
-    };
-  }
-  return { status: lane.pending || lane.active ? "healthy" : "idle", reason: null };
 }
 
 export function exactReviewQueueNextWakeAt(

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9787,11 +9787,7 @@ function renderExactReviewHandoff(queue) {
   const pressureStatus = ["idle", "congested", "saturated", "unknown"].includes(pressure?.status)
     ? pressure.status
     : "unknown";
-  const pressureLabel = pressure?.reason === "publication_critical"
-    ? "publication critical"
-    : pressure?.reason === "publication_degraded"
-      ? "publication degraded"
-      : "pressure " + pressureStatus;
+  const pressureLabel = "pressure " + pressureStatus;
   const labels = {
     pending: ["Pending", "waiting for admission"],
     dispatching: ["Dispatching", "waiting for run claim"],

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -128,9 +128,12 @@ The scheduler does this for background lanes:
 
 The normal result is then reduced when the exact-review queue is under pressure.
 Each planner reads the public, unauthenticated `GET /api/exact-review-queue`
-endpoint once and uses its top-level pending count and oldest-pending age. A
-failed, timed-out, or malformed response is treated as no pressure so a dashboard
-outage cannot stall reviews.
+endpoint once and uses its review-lane pending count and oldest-pending age. The
+top-level pending, ready, admissible, handoff, and pressure fields are aliases
+for that review lane; publication health and backlog remain under
+`lanes.publication` and never throttle review producers. A failed, timed-out, or
+malformed response uses the conservative unavailable-pressure budget until the
+next healthy probe.
 
 | Tier | Trigger, either condition                                     | Background budget                            |
 | ---- | ------------------------------------------------------------- | -------------------------------------------- |
@@ -204,8 +207,12 @@ unclaimed workflow cannot pass the replacement lease tuple and exits before
 review compute. Explicit command work and publication work bypass the delay.
 When pending depth reaches
 `EXACT_REVIEW_PENDING_SOFT_LIMIT` (300 by default), new recovery and scheduled
-feed work is shed; existing items, webhook events, commands, and publications
-remain admitted. All newly queued review work debits a durable 200-review/hour
+feed work is shed; this threshold counts review work only, so publication
+backlog cannot consume review admission capacity. Existing items, webhook
+events, commands, and publications remain admitted. The queue reports shed
+counts under `lanes.review.shed_reasons_since_reset` and the rolling flow by
+`backpressure` versus `scheduled_rate`; pre-migration totals remain
+`unattributed`. All newly queued review work debits a durable 200-review/hour
 budget with a 50-item burst. Organic work is always admitted and consumes the
 budget first; scheduled work fills the remainder and is split 35% hot intake and
 65% normal backfill so hot churn cannot starve oldest-first coverage. Re-offering an item

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -247,6 +247,9 @@ Current defaults:
 - total review admission target: 200 items/hour across the fleet; organic work
   consumes the budget first and scheduled backfill fills the remainder, split
   35% hot intake and 65% normal backfill, with a 50-item burst
+- review admission and pressure are computed independently from publication;
+  top-level queue health describes reviews while `lanes.publication` retains
+  publication backlog, retry, DLQ, and health telemetry
 - fleet fanout: 20 hot targets every 15 minutes and 12 normal targets hourly;
   each target cycle can offer up to 20 due items to the shared admission budget
 - manual broad hot intake: up to 44 shards when quiet
@@ -314,7 +317,9 @@ Scheduled planning does not use the active-floor backfill. It selects only due
 items, records each candidate's previous-review age in `plan.json`, and writes a
 run-summary funnel for selected, attempted, enqueued, deduped, shed, and deferred
 items. The queue exposes the configured rate, burst, and currently available
-token balance under `scheduled_feed` in `GET /api/exact-review-queue`.
+token balance under `scheduled_feed` in `GET /api/exact-review-queue`. It also
+exposes backpressure and scheduled-rate shed counts separately so an operator
+can distinguish a full review queue from intentional 200/hour pacing.
 The producer probes that field before its first enqueue and fails closed while
 an older Worker is still deployed, preventing a workflow-first rollout from
 bypassing the rate limiter.

--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -11,7 +11,6 @@ export type ExactReviewQueuePressure =
       ok: true;
       pendingCount: number;
       oldestPendingAgeMs: number;
-      publicationStatus?: "degraded" | "critical";
     }
   | {
       ok: false;
@@ -40,19 +39,10 @@ export async function fetchExactReviewQueuePressure({
 
     const body: unknown = await response.json();
     if (!isRecord(body)) return malformedPressure();
-    // Review backlog controls the normal capacity thresholds. Publication
-    // health can still elevate pressure because producing decisions faster
-    // than they can be published compounds durable queue debt.
+    // Review and publication have independent capacity and durable ownership.
+    // Only review backlog may throttle review producers.
     const reviewLane =
       isRecord(body.lanes) && isRecord(body.lanes.review) ? body.lanes.review : null;
-    const publicationLane =
-      isRecord(body.lanes) && isRecord(body.lanes.publication) ? body.lanes.publication : null;
-    const publicationHealth =
-      publicationLane && isRecord(publicationLane.health) ? publicationLane.health : null;
-    const publicationStatus =
-      publicationHealth?.status === "critical" || publicationHealth?.status === "degraded"
-        ? publicationHealth.status
-        : undefined;
     const pendingCount =
       reviewLane && isNonNegativeInteger(reviewLane.pending) ? reviewLane.pending : body.pending;
     const oldestPendingAgeSeconds =
@@ -65,7 +55,6 @@ export async function fetchExactReviewQueuePressure({
         ok: true,
         pendingCount,
         oldestPendingAgeMs: 0,
-        ...(publicationStatus ? { publicationStatus } : {}),
       };
     }
     // A null age with a positive backlog is inconsistent data — fail open
@@ -78,7 +67,6 @@ export async function fetchExactReviewQueuePressure({
       ok: true,
       pendingCount,
       oldestPendingAgeMs,
-      ...(publicationStatus ? { publicationStatus } : {}),
     };
   } catch (error) {
     return {
@@ -95,7 +83,6 @@ export function queuePressureLevel(pressure: ExactReviewQueuePressure): QueuePre
   // Background admission must retain a bounded capacity until the next healthy
   // probe, while exact-item work keeps its independent interactive reservation.
   if (!pressure.ok) return "unknown";
-  if (pressure.publicationStatus === "critical") return "hard";
   const hardPending = envThreshold(
     "CLAWSWEEPER_QUEUE_PRESSURE_HARD_PENDING",
     QUEUE_PRESSURE_HARD_PENDING,
@@ -107,8 +94,6 @@ export function queuePressureLevel(pressure: ExactReviewQueuePressure): QueuePre
   if (pressure.pendingCount >= hardPending || pressure.oldestPendingAgeMs >= hardAgeMs) {
     return "hard";
   }
-  if (pressure.publicationStatus === "degraded") return "soft";
-
   const softPending = envThreshold(
     "CLAWSWEEPER_QUEUE_PRESSURE_SOFT_PENDING",
     QUEUE_PRESSURE_SOFT_PENDING,

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1869,19 +1869,25 @@ test("exact-review queue sheds only new recovery work above the pending soft lim
   const stats = await (
     await restarted.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
   ).json();
-  assert.equal(stats.pending, 4);
+  assert.equal(stats.pending, 3);
   assert.equal(stats.shed_since_reset, 3);
-  assert.equal(stats.handoff_health.pending_depth, 4);
+  assert.equal(stats.handoff_health.pending_depth, 3);
   assert.equal(stats.handoff_health.shed_since_reset, 3);
   assert.equal(stats.lanes.review.pending_depth, 3);
   assert.equal(stats.lanes.review.shed_since_reset, 3);
   assert.equal(stats.lanes.review.enqueued_total, 3);
+  assert.deepEqual(stats.lanes.review.shed_reasons_since_reset, {
+    backpressure: 3,
+    scheduled_rate: 0,
+    unattributed: 0,
+  });
   assert.deepEqual(stats.lanes.review.flow.last_15_minutes, {
     window_minutes: 15,
     arrival: 6,
     successful: 0,
     retried: 0,
     shed: 3,
+    shed_reasons: { backpressure: 3, scheduled_rate: 0 },
     arrival_rate_per_hour: 24,
     successful_rate_per_hour: 0,
     retried_rate_per_hour: 0,
@@ -1998,6 +2004,46 @@ test("scheduled review feed stops at the pending soft limit", async () => {
     buildExactReviewQueueRequest("scheduled-pending-2", 811, "scheduled_hot_intake"),
   );
   assert.deepEqual(await shed.json(), { ok: true, shed: true, reason: "backpressure" });
+});
+
+test("publication backlog does not consume the review pending soft limit", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PENDING_SOFT_LIMIT: "1", EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "600000" },
+  );
+  const publication = await queue.fetch(
+    buildExactReviewQueueRequest(
+      "publication-before-review-limit",
+      812,
+      "exact_review_artifact_publish",
+      "issue",
+      undefined,
+      exactReviewPublicationOverrides(812, "8120"),
+    ),
+  );
+  assert.equal((await publication.json()).queued, true);
+
+  const admitted = await queue.fetch(
+    buildExactReviewQueueRequest("scheduled-with-publication-backlog", 813, "scheduled_hot_intake"),
+  );
+  assert.equal((await admitted.json()).queued, true);
+
+  const shed = await queue.fetch(
+    buildExactReviewQueueRequest("scheduled-over-review-limit", 814, "scheduled_hot_intake"),
+  );
+  assert.deepEqual(await shed.json(), { ok: true, shed: true, reason: "backpressure" });
+
+  const stats = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(stats.pending, 1);
+  assert.equal(stats.lanes.publication.pending, 1);
+  assert.deepEqual(stats.lanes.review.shed_reasons_since_reset, {
+    backpressure: 1,
+    scheduled_rate: 0,
+    unattributed: 0,
+  });
 });
 
 test("exact-review queue does not count work for a disabled target", async () => {
@@ -3068,6 +3114,45 @@ test("exact-review queue admits and wakes up to 24 publishers", () => {
   );
 });
 
+test("publish-keyed backlog cannot block review admission from filling capacity", () => {
+  const now = 1_000_000;
+  const publication = {
+    key: "openclaw/openclaw#1@publish:100:1",
+    state: "pending",
+    createdAt: now - 60_000,
+    updatedAt: now - 60_000,
+    nextAttemptAt: now,
+    attempts: 0,
+    revision: 1,
+    decision: {
+      sourceAction: "exact_review_artifact_publish",
+      targetRepo: "openclaw/openclaw",
+      itemNumber: 1,
+    },
+  };
+  const reviews = Array.from({ length: 200 }, (_, index) => ({
+    key: `openclaw/openclaw#${index + 2}`,
+    state: "pending",
+    createdAt: now - 30_000 + index,
+    updatedAt: now - 30_000 + index,
+    nextAttemptAt: now,
+    attempts: 0,
+    revision: 1,
+    decision: {
+      sourceAction: "scheduled_normal_backfill",
+      targetRepo: "openclaw/openclaw",
+      itemNumber: index + 2,
+    },
+  }));
+  const state = {
+    items: Object.fromEntries([publication, ...reviews].map((item) => [item.key, item])),
+  } as never;
+
+  const admitted = exactReviewQueueAdmittedItems(state, now, 128, 128, 0);
+  assert.equal(admitted.length, 128);
+  assert.ok(admitted.every((item) => !item.key.includes("@publish:")));
+});
+
 test("dashboard status reads the exact-review handoff model from the durable queue", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
@@ -3115,7 +3200,7 @@ test("dashboard status reads the exact-review handoff model from the durable que
   assert.equal(status.ready_pending, 2);
   assert.equal(status.admissible_pending, 2);
   assert.equal(status.dispatching, 0);
-  assert.equal(status.leased, 2);
+  assert.equal(status.leased, 1);
   assert.equal(status.handoff_health.status, "healthy");
   assert.equal(status.handoff_health.phases.pending.count, 3);
   assert.equal(status.lanes.review.enqueued_total, 4);
@@ -5957,6 +6042,49 @@ test("exact-review queue terminalizes every admitted ordinary publication before
   }
 });
 
+test("terminal publication cleanup does not block review admission in the same alarm", async () => {
+  const publicationNumber = 9220;
+  const reviewNumber = 9221;
+  const harness = createExactReviewAdmissionHarness(
+    (_targetRepo, itemNumber) =>
+      jsonResponse({ state: itemNumber === publicationNumber ? "closed" : "open" }),
+    {
+      maxConcurrent: "1",
+      publicationBatching: true,
+      publicationBatchSize: "1",
+      captureBatchDispatch: true,
+    },
+  );
+  try {
+    await harness.queue.fetch(
+      buildExactReviewQueueRequest(
+        "terminal-publication-ahead-of-review",
+        publicationNumber,
+        "exact_review_artifact_publish",
+        "issue",
+        "openclaw/gogcli",
+        exactReviewPublicationOverrides(publicationNumber, "92200"),
+      ),
+    );
+    await harness.queue.fetch(
+      buildExactReviewQueueRequest("review-behind-terminal-publication", reviewNumber, "opened"),
+    );
+
+    await harness.queue.alarm();
+
+    assert.equal(harness.batchDispatches, 0);
+    assert.equal(harness.dispatched.length, 1);
+    assert.equal(harness.dispatched[0]?.client_payload.item_number, reviewNumber);
+    const stats = await (
+      await harness.queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+    ).json();
+    assert.equal(stats.lanes.publication.completed_total, 1);
+    assert.equal(stats.lanes.review.dispatching, 1);
+  } finally {
+    harness.restore();
+  }
+});
+
 test("publication reconcile terminalizes a completed protocol-v1 publication after its target closes", async () => {
   let liveChecks = 0;
   const harness = createExactReviewAdmissionHarness(() => {
@@ -7639,6 +7767,7 @@ test("exact-review queue upgrades flow metrics without losing publication comple
     successful: 0,
     retried: 0,
     shed: 0,
+    shed_reasons: { backpressure: 0, scheduled_rate: 0 },
     arrival_rate_per_hour: 0,
     successful_rate_per_hour: 0,
     retried_rate_per_hour: 0,
@@ -14246,7 +14375,7 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   status.recent.apply_health.items = [];
   status.exact_review_queue.handoff_health.status = "stalled";
   status.exact_review_queue.pressure.status = "saturated";
-  status.exact_review_queue.pressure.reason = "publication_critical";
+  status.exact_review_queue.pressure.reason = "capacity_full_with_backlog";
   status.exact_review_queue.handoff_health.message =
     "A dispatched review has not been claimed within the expected handoff window.";
   context.renderDashboard(status, "");
@@ -14254,7 +14383,7 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   assert.equal(elementFor("hero-dot").className, "hero-dot red");
   assert.match(elementFor("hero-headline").textContent, /^Needs attention/);
   assert.match(elementFor("exact-review-handoff").innerHTML, /health-badge stalled/);
-  assert.match(elementFor("exact-review-handoff").innerHTML, /publication critical/);
+  assert.match(elementFor("exact-review-handoff").innerHTML, /pressure saturated/);
 
   Object.assign(status, { exact_review_queue: null });
   status.diagnostics.exact_review_queue_error = "exact-review queue timed out";

--- a/test/exact-review-health.test.ts
+++ b/test/exact-review-health.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  elevateExactReviewPressureForPublication,
   summarizeExactReviewHandoff,
+  summarizeExactReviewPublicationHealth,
   summarizeExactReviewPressure,
 } from "../dashboard/exact-review-health.ts";
 
@@ -272,37 +272,16 @@ test("exact-review pressure preserves non-dispatchable and unknown states", () =
   );
 });
 
-test("publication health elevates an otherwise idle review pressure signal", () => {
-  const idle = summarizeExactReviewPressure({
-    pending: 1,
-    readyPending: 1,
-    admissiblePending: 1,
-    dispatching: 0,
-    leased: 1,
-    capacity: 64,
-    dispatcherState: "active",
-    handoffStatus: "healthy",
-  });
-
-  assert.deepEqual(elevateExactReviewPressureForPublication(idle, { status: "degraded" }), {
-    ...idle,
-    status: "congested",
-    reason: "publication_degraded",
-  });
-  assert.deepEqual(elevateExactReviewPressureForPublication(idle, { status: "critical" }), {
-    ...idle,
-    status: "saturated",
-    reason: "publication_critical",
-  });
-  assert.deepEqual(elevateExactReviewPressureForPublication(idle, { status: "healthy" }), idle);
-
-  const saturated = {
-    ...idle,
-    status: "saturated" as const,
-    reason: "capacity_full_with_backlog" as const,
-  };
-  assert.deepEqual(
-    elevateExactReviewPressureForPublication(saturated, { status: "critical" }),
-    saturated,
+test("idle publication activity is healthy regardless of retired writer history", () => {
+  const idle = summarizeExactReviewPublicationHealth(
+    { pending: 0, active: 0, parked: 0, oldest_pending_age_seconds: null },
+    { last_15_minutes: { net_drain_rate_per_hour: -100 } },
   );
+  assert.deepEqual(idle, { status: "idle", reason: null });
+
+  const delayed = summarizeExactReviewPublicationHealth(
+    { pending: 1, active: 0, parked: 0, oldest_pending_age_seconds: 3_601 },
+    { last_15_minutes: { net_drain_rate_per_hour: 10 } },
+  );
+  assert.deepEqual(delayed, { status: "degraded", reason: "oldest_pending_over_1h" });
 });

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -874,7 +874,7 @@ test("queue batch claim defaults off and additive schema keeps the legacy versio
   assert.equal(stats.lanes.publication.batches.leased, 0);
 });
 
-test("queue pressure cannot stay idle while publication health is critical", async () => {
+test("critical publication health does not override review pressure", async () => {
   const originalNow = Date.now;
   let now = 1_000_000;
   Date.now = () => now;
@@ -888,8 +888,8 @@ test("queue pressure cannot stay idle while publication health is critical", asy
       status: "critical",
       reason: "oldest_pending_over_6h",
     });
-    assert.equal(stats.pressure.status, "saturated");
-    assert.equal(stats.pressure.reason, "publication_critical");
+    assert.equal(stats.pressure.status, "idle");
+    assert.equal(stats.pressure.reason, "no_ready_backlog");
   } finally {
     Date.now = originalNow;
   }

--- a/test/queue-pressure.test.ts
+++ b/test/queue-pressure.test.ts
@@ -69,7 +69,7 @@ test("queue pressure fetch reads public aggregate stats", async () => {
   assert.deepEqual(empty, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
 });
 
-test("queue pressure uses review thresholds and elevates unhealthy publication", async () => {
+test("queue pressure uses review thresholds and ignores independent publication health", async () => {
   const healthyPublication = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",
     fetchImpl: async () =>
@@ -107,22 +107,8 @@ test("queue pressure uses review thresholds and elevates unhealthy publication",
         },
       }),
   });
-  assert.deepEqual(criticalPublication, {
-    ok: true,
-    pendingCount: 0,
-    oldestPendingAgeMs: 0,
-    publicationStatus: "critical",
-  });
-  assert.equal(queuePressureLevel(criticalPublication), "hard");
-  assert.equal(
-    queuePressureLevel({
-      ok: true,
-      pendingCount: QUEUE_PRESSURE_HARD_PENDING,
-      oldestPendingAgeMs: 0,
-      publicationStatus: "degraded",
-    }),
-    "hard",
-  );
+  assert.deepEqual(criticalPublication, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
+  assert.equal(queuePressureLevel(criticalPublication), "none");
 
   const emptyReviewLane = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",


### PR DESCRIPTION
## Summary

- isolate review admission, handoff health, queue pressure, and backpressure from the independently-capacitated publication lane
- prevent terminal or blocked publication keys from delaying review admission, and prove a review backlog can fill all 128 global claim slots
- split shed telemetry into `backpressure` and `scheduled_rate`, retaining pre-migration history as `unattributed`

## Root causes

The production status surface combined two lanes that do not share admission capacity. At 2026-07-30 09:12 UTC, the public API reported 20 top-level pending items and named `openclaw/openclaw#114855@publish:30522572065:1` as the oldest handoff key, while `lanes.review.pending` was only 1 and `lanes.publication.pending` was 19. Likewise, `ready_pending` and `admissible_pending` were aggregate fields even though publication batching intentionally excludes publication rows from the legacy dispatcher. That made an independently-owned publication backlog look like review head-of-line blocking.

There were two real coupling bugs behind that misleading surface:

1. Review backpressure used the combined pending count, so publication backlog could cross `EXACT_REVIEW_PENDING_SOFT_LIMIT` and shed new scheduled/recovery reviews while review capacity was empty.
2. A terminal publication discovered during batch preflight returned from the alarm immediately. A stream of terminal publication keys could therefore consume successive alarms before ready reviews were considered.

Publication health was not derived from `state_writer` acquisitions or commits. The zero-commit state-writer sample after #936 was unrelated. Health was degraded by historical open dead letters and over-age publication rows; even an otherwise idle lane consulted dead letters before returning idle. Dead letters already have their own health signal, so current publication health now describes current pending/active/parked flow only. Publication health remains visible, but it no longer overrides review pressure or throttles review producers.

Finally, `shed_since_reset` combined true pending-limit backpressure with intentional 200/hour token pacing. The total 1,119 could not be attributed after the fact. New cumulative and 15-minute counters identify `backpressure` versus `scheduled_rate`; the already-persisted total is exposed as `unattributed` after migration.

## Behavior after this change

- top-level pending/ready/admissible, phase ages, oldest keys, handoff health, and pressure describe the review lane
- publication backlog, health, retries, and DLQ remain under `lanes.publication`
- review selection runs independently and first; publication keys cannot consume review slots or delay the same alarm after terminal cleanup
- the pending soft limit counts review rows only
- admission still respects 128 global and 120 per-target review caps, and a 200-item test backlog fills all 128 global slots

At the configured 200 reviews/hour and measured 4.1-minute mean service time, expected steady-state concurrency is about `200 * 4.1 / 60 = 13.7`. The 50-item burst plus organic events can temporarily run higher; the production API already showed 23 active reviews later in the investigation. This change removes false publication coupling without changing the spend target or lowering the 128 claim ceiling.

## Proof

- `node --test test/exact-review-health.test.ts test/queue-pressure.test.ts test/dashboard-worker.test.ts test/exact-review-publication-batches.test.ts` — 342 passed
- `pnpm run build:dashboard` — passed
- `pnpm run build` — passed
- `pnpm run format:check` — passed
- `pnpm run lint` — passed
- `pnpm run check` — static/build/lint/changed coverage passed; full suite had 2,778 passes and only the five documented unrelated macOS failures in `process-tree-containment.test.ts` because Apple libc does not export Linux `capset`
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode local` — TruffleHog clean; one complete pass; no accepted/actionable findings; correctness 0.97
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — TruffleHog clean; one complete pass; no accepted/actionable findings; correctness 0.98

## Rollout

A Worker redeploy is required. Until then, the production API will continue to expose aggregate top-level queue fields and `publication_degraded` review pressure, and it will not expose shed reasons.

This PR does not deploy the Worker, run live apply/close commands, or merge itself.
