### PR TITLE
docs: generalize foreign PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ not split reports into issue/PR subtrees.
   store; the Worker/R2 pair is authoritative for records, ledger, and assets.
   Check current Actions and the canonical owner before trusting local generated
   timestamps.
-- When Peter asks about PRs outside `openclaw/clawsweeper`, treat the task as
+- When asked about PRs outside `openclaw/clawsweeper`, treat the task as
   monitoring/debugging how ClawSweeper workflows operate on that PR. Do not fix
   foreign PR branches directly; ClawSweeper repair/automerge workflows own those
   branch edits.


### PR DESCRIPTION
## Summary

- remove person-specific wording from the foreign-PR operating guidance
- preserve the existing ClawSweeper ownership and safety rule

## Validation

- `git diff --check`