### PR TITLE
feat(queue): raise review feed to 600/hour

### DIFF
--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -63,9 +63,14 @@ EXACT_REVIEW_HEARTBEAT_GRACE_MS = "1200000"
 EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = "60000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = "90000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
-EXACT_REVIEW_PENDING_SOFT_LIMIT = "300"
-EXACT_REVIEW_TARGET_RATE_PER_HOUR = "200"
-EXACT_REVIEW_TARGET_BURST = "50"
+EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"
+# 200/h only sustained ~14 concurrent reviews against a 128-slot pool; with the
+# review/publication lane split (#953) the queue drains to zero pending while
+# 3,306 items have never been reviewed at all (42.9% weekly coverage). 600/h at
+# the measured 4.1-minute service time targets ~41 concurrent, clearing the
+# first-pass backlog in hours instead of days. Model spend scales with this dial.
+EXACT_REVIEW_TARGET_RATE_PER_HOUR = "600"
+EXACT_REVIEW_TARGET_BURST = "120"
 # Keep each mutation lease at 8 while allowing four isolated workflows to prepare
 # concurrently. Final commits still cross the single state-writer coordinator.
 # A full-window publish moves ~2k paths and observed ~40 min; the drain lease

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -54,8 +54,9 @@ test("production doubles exact review claims and canonical publication batches",
   assert.match(wrangler, /EXACT_REVIEW_ACTIONS_BUDGET = "194"/);
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"/);
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT = "8"/);
-  assert.match(wrangler, /EXACT_REVIEW_TARGET_RATE_PER_HOUR = "200"/);
-  assert.match(wrangler, /EXACT_REVIEW_TARGET_BURST = "50"/);
+  assert.match(wrangler, /EXACT_REVIEW_TARGET_RATE_PER_HOUR = "600"/);
+  assert.match(wrangler, /EXACT_REVIEW_TARGET_BURST = "120"/);
+  assert.match(wrangler, /EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"/);
 });
 
 test("full exact-review admission preserves production verdict publication capacity", () => {


### PR DESCRIPTION
With the review/publication lane split (#953) deployed, the queue drains to zero pending while active sits at 18 of 128 slots — the feed, not the queue, is now the limiter. Coverage is 42.9% with 3,306 items never reviewed. 600/h at the measured 4.1-min service time targets ~41 concurrent and clears the first-pass backlog in hours rather than a day and a half; burst 120 and pending soft limit 600 scale with it. Model spend scales with this dial — revert by lowering the same three vars. Tests 265/265, autoreview clean.