### PR TITLE
fix: schedule never-reviewed items before weekly refreshes

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2514,8 +2514,10 @@ jobs:
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ github.token }}
           CLAWSWEEPER_INVENTORY_TOKEN_OPENCLAW: ${{ steps.openclaw-token.outputs.token }}
           CLAWSWEEPER_INVENTORY_TOKEN_STEIPETE: ${{ steps.steipete-token.outputs.token || '__public__' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           FANOUT_MODE: ${{ github.event.schedule == '41 * * * *' && 'normal-review' || (github.event.schedule == '37 */6 * * *' && 'audit' || 'hot-intake') }}
           FANOUT_LIMIT: ${{ github.event.schedule == '41 * * * *' && '12' || (github.event.schedule == '37 */6 * * *' && '12' || '20') }}
+          REVIEW_COVERAGE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           pnpm run target-fanout -- \
@@ -2523,7 +2525,8 @@ jobs:
             --limit "$FANOUT_LIMIT" \
             --repo "$GITHUB_REPOSITORY" \
             --workflow sweep.yml \
-            --ref main
+            --ref main \
+            --publish-url "$REVIEW_COVERAGE_URL"
 
       - name: Summarize trailing weekly review coverage
         # Also runs for operator dispatches of the audit lane: the signed live
@@ -2887,9 +2890,9 @@ jobs:
           fi
           if [ "$queue_feed" = "true" ] && [ -z "$exact_item" ]; then
             # The Durable Object turns every selected item into an independent exact-review
-            # workflow. Plan a bounded feed batch here; the Worker owns the global 200/hour
+            # workflow. Plan a bounded feed batch here; the Worker owns the global 600/hour
             # admission target and queue backpressure across overlapping target sweeps.
-            batch_size="20"
+            batch_size="50"
             shard_count="1"
             min_active_shards="0"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Changed
 
 - Isolated review admission, pressure, and backpressure accounting from the publication lane so stale publication work cannot throttle review throughput, made top-level queue health review-specific, and added durable shed counters by reason.
-- Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, renewed overdue canonical records ahead of unseen backlog, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
-- Routed scheduled review through the durable exact-review queue, raised each target plan from one to 20 candidates, and added oldest-age funnel telemetry plus a fleet-wide 200-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
+- Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, prioritized never-reviewed open items before oldest-reviewed canonical refreshes, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
+- Routed scheduled review through the durable exact-review queue, raised each target plan from one to 50 candidates, and added oldest-age funnel telemetry plus a fleet-wide 600-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.
 - Scoped per-target canonical record hydration to the selected repository and skipped unused ledger/assets downloads in workflow lanes, preventing exact-item review publication from collapsing under concurrent full-fleet state setup.
 - Doubled exact-review admission to 128 global and 120 per target with a separate 194-slot Actions budget that preserves verdict publication at full review load, doubled scheduled fleet review fanout and canonical publication batch preparation, prioritized six-day oldest-review coverage before hot-item churn, exposed a six-hour fleet coverage summary, and raised automatic apply to 40 closes with proportional scan/runtime budgets without changing close eligibility.
 - Completed the Cloudflare-canonical state migration: records publish only to the Durable Object, action ledgers and assets publish only to R2, canonical-only workflows no longer check out `clawsweeper-state`, the former materializer only compacts the legacy append window, and the remaining `jobs`/`results`/`notifications`/apply-report Git writers use the Durable Object coordinator without Git lease refs or rebuild recovery.
@@ -152,6 +152,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Prevented weekly coverage from endlessly refreshing tracked records while never-reviewed live items remained invisible behind a full candidate batch; normal fanout now refreshes and consumes the signed live inventory, skips empty repositories, and prioritizes repositories with untracked work.
 - Reconciled apply backlogs now publish record tuples in bounded batches, re-verify authority-superseded canonical revisions without weakening source/verdict guards, and always carry an explicit coverage-proof artifact manifest under reduced state hydration.
 - Restored close-backlog throughput by keeping apply jobs off the enormous immutable state-blob hydration path, and isolated operator-dispatched sweeps from background concurrency coalescing.
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -153,7 +153,7 @@ unset, empty, or invalid values use the defaults.
 | `CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS`  | 7200000 |
 
 Only manual normal review, manual hot intake, and commit review use this pressure
-multiplier. Scheduled review uses the queue's 300-item soft limit and 200/hour
+multiplier. Scheduled review uses the queue's 600-item soft limit and 600/hour
 admission target. Repair, assist, issue implementation, cluster repair, and
 exact-item review keep their existing priority budgets.
 
@@ -206,14 +206,14 @@ on the lease claim tuple, so they cannot terminate the sole valid owner. An olde
 unclaimed workflow cannot pass the replacement lease tuple and exits before
 review compute. Explicit command work and publication work bypass the delay.
 When pending depth reaches
-`EXACT_REVIEW_PENDING_SOFT_LIMIT` (300 by default), new recovery and scheduled
+`EXACT_REVIEW_PENDING_SOFT_LIMIT` (600 by default), new recovery and scheduled
 feed work is shed; this threshold counts review work only, so publication
 backlog cannot consume review admission capacity. Existing items, webhook
 events, commands, and publications remain admitted. The queue reports shed
 counts under `lanes.review.shed_reasons_since_reset` and the rolling flow by
 `backpressure` versus `scheduled_rate`; pre-migration totals remain
-`unattributed`. All newly queued review work debits a durable 200-review/hour
-budget with a 50-item burst. Organic work is always admitted and consumes the
+`unattributed`. All newly queued review work debits a durable 600-review/hour
+budget with a 120-item burst. Organic work is always admitted and consumes the
 budget first; scheduled work fills the remainder and is split 35% hot intake and
 65% normal backfill so hot churn cannot starve oldest-first coverage. Re-offering an item
 that is already pending, dispatching, or leased is a semantic dedupe: it does not

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -139,6 +139,12 @@ manual workflow inputs. Scheduled fanout uses:
 - normal review: `41 * * * *`, 12 target repositories per cursor step
 - audit: `37 */6 * * *`, 12 target repositories per cursor step
 
+Normal fanout refreshes the same signed live-open inventory consumed by
+`GET /api/review-coverage`, skips repositories with no open items, and visits
+repositories whose live count exceeds their canonical-record count before
+tracked-only repositories. The cursor still rotates within that bounded set;
+one large repository does not receive multiple slots in one fanout step.
+
 The six-hour audit fanout also writes a GitHub Actions summary with canonical
 open-item reports reviewed in the trailing seven days versus batched live open
 issue and PR totals across the complete dynamic inventory.
@@ -241,17 +247,17 @@ Current defaults:
 
 - exact event review: 1 shard, 1 item
 - exact manual hot intake: 1 shard, 1 item
-- scheduled hot intake and normal backfill: select up to 20 due items per target
+- scheduled hot intake and normal backfill: select up to 50 due items per target
   cycle, then enqueue each item through the durable exact-review queue; every
   admitted item receives its own parallel workflow
-- total review admission target: 200 items/hour across the fleet; organic work
+- total review admission target: 600 items/hour across the fleet; organic work
   consumes the budget first and scheduled backfill fills the remainder, split
-  35% hot intake and 65% normal backfill, with a 50-item burst
+  35% hot intake and 65% normal backfill, with a 120-item burst
 - review admission and pressure are computed independently from publication;
   top-level queue health describes reviews while `lanes.publication` retains
   publication backlog, retry, DLQ, and health telemetry
 - fleet fanout: 20 hot targets every 15 minutes and 12 normal targets hourly;
-  each target cycle can offer up to 20 due items to the shared admission budget
+  each target cycle can offer up to 50 due items to the shared admission budget
 - manual broad hot intake: up to 44 shards when quiet
 - manual normal backfill: defaults to 89 shards, batch size 3, and scans up to
   250 GitHub pages unless overridden
@@ -287,9 +293,10 @@ because they may rebase and push generated records.
 
 Normal backfill runs every 5 minutes for `openclaw/openclaw`. Its planner
 serializes per target repository, selects globally before sharding, and offers
-the oldest due candidates to the durable queue. Queue admission is fleet-wide,
+never-reviewed candidates before the oldest due tracked candidates to the
+durable queue. Queue admission is fleet-wide,
 so overlapping core and fanout cycles fill only the residual of the configured
-200/hour model-spend target after organic review demand.
+600/hour model-spend target after organic review demand.
 
 The manual quiet-system ceiling is not a promise that every operator run dispatches
 that many shards. The `mode` step checks active repair workers, exact-item sweep
@@ -319,19 +326,20 @@ run-summary funnel for selected, attempted, enqueued, deduped, shed, and deferre
 items. The queue exposes the configured rate, burst, and currently available
 token balance under `scheduled_feed` in `GET /api/exact-review-queue`. It also
 exposes backpressure and scheduled-rate shed counts separately so an operator
-can distinguish a full review queue from intentional 200/hour pacing.
+can distinguish a full review queue from intentional 600/hour pacing.
 The producer probes that field before its first enqueue and fails closed while
 an older Worker is still deployed, preventing a workflow-first rollout from
 bypassing the rate limiter.
 
-At the configured target, the installation-token estimate is
-`200 reviews/hour * 30 calls/review = 6,000 calls/hour`. That is half of the
-roughly 12,000-call or 400-review/hour ceiling, leaving equivalent headroom for
-planning, retries, publication, and traffic variance. At a 4.1-minute mean
-service time, 200/hour needs about `200 * 4.1 / 60 = 13.7` concurrent review
-workers, well below the 120 per-target and 128 global claim limits. Model usage
-is nevertheless about five times a 40-review/hour baseline; lower
-`EXACT_REVIEW_TARGET_RATE_PER_HOUR` to dial spend down.
+Each hourly normal-fanout step can offer
+`50 items/target * 12 targets = 600 items/hour`. The direct five-minute hot and
+normal schedules can each offer `50 * 12 = 600 items/hour`, so either lane has
+enough candidates to keep its token bucket fed despite dedupe or uneven fleet
+distribution. At a 4.1-minute mean service time, 600/hour needs about
+`600 * 4.1 / 60 = 41` concurrent review workers, below the 120 per-target and
+128 global claim limits. The target rate, burst, and pending limit are explicit
+spend and GitHub API dials; lower them together when sustained traffic warrants
+more headroom.
 
 On saturated queues, normal planning reads the complete bounded open-item scan
 before selecting candidates. For the current largest repository this is about
@@ -382,13 +390,15 @@ older issue backlog forever. The normal scheduler cycles through:
 - weekly older issues
 
 Within each bucket, earlier due times and older reviews win before item number.
-The weekly coverage lane becomes eligible after six days of review age, then
-selects the oldest latest-review timestamp (or creation time when never
-reviewed) across all buckets before hot-item churn. Normal planning completes
-its bounded open-item scan before applying that ordering, so a saturated
-item-number prefix cannot hide older review timestamps. The weighted mix
-applies to remaining capacity; the extra day is operational headroom before
-the seven-day freshness deadline.
+The live open-item scan is compared with the canonical record index first.
+Items with no canonical record consume capacity before any re-review. Within
+that never-reviewed cohort, six-day coverage ordering and the existing weighted
+bucket mix still apply. Once first-review candidates are exhausted, tracked
+items enter the six-day coverage lane in oldest-`reviewed_at` order across all
+buckets before hot-item churn. Normal planning completes its bounded scan before
+applying that ordering, so a saturated item-number prefix cannot hide either
+untracked items or older review timestamps. The extra day is operational
+headroom before the seven-day freshness deadline.
 
 ## Planning
 

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -65,6 +65,12 @@ export interface ReviewCoverageInventorySnapshot {
   }>;
 }
 
+export interface ReviewPlanningRepository extends SelectedRepository {
+  openItems: number;
+  trackedRecords: number;
+  untrackedOpen: number;
+}
+
 interface SelectionResult {
   repositories: SelectedRepository[];
   cursor: number;
@@ -84,7 +90,7 @@ interface FanoutOptions {
 
 const DEFAULT_CURSOR_DIR = join(repoRoot(), "results", "target-fanout-cursors");
 const PUBLIC_INVENTORY_TOKEN = "__public__";
-export const SCHEDULED_REVIEW_PLAN_BATCH_SIZE = 20;
+export const SCHEDULED_REVIEW_PLAN_BATCH_SIZE = 50;
 
 export async function runTargetFanout(argv: string[]): Promise<void> {
   const args = parseArgs(argv);
@@ -121,14 +127,6 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
     process.stdout.write(renderFleetReviewCoverage(coverage));
     return;
   }
-  const selection = selectRepositories(repositories, {
-    limit: options.limit,
-    cursor: readCursor(options.cursorPath),
-  });
-
-  const commands = selection.repositories.map((repository) =>
-    workflowDispatchArgs(repository, options),
-  );
 
   if (args._[0] === "list") {
     process.stdout.write(
@@ -136,6 +134,32 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
     );
     return;
   }
+
+  let planningRepositories: readonly SelectedRepository[] = repositories;
+  if (mode === "normal-review") {
+    const openCounts = loadRepositoryOpenCounts(repositories);
+    const now = Date.now();
+    const publishUrl = stringArg(args["publish-url"], "");
+    if (publishUrl) {
+      await publishReviewCoverageInventory({
+        baseUrl: publishUrl,
+        webhookSecret: stringValue(
+          process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+          "CLAWSWEEPER_WEBHOOK_SECRET",
+        ),
+        snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
+      });
+    }
+    planningRepositories = reviewPlanningRepositories({ repositories, openCounts });
+  }
+  const selection = selectRepositories(planningRepositories, {
+    limit: options.limit,
+    cursor: readCursor(options.cursorPath),
+  });
+
+  const commands = selection.repositories.map((repository) =>
+    workflowDispatchArgs(repository, options),
+  );
 
   if (args._[0] === "plan") {
     process.stdout.write(`${JSON.stringify({ ...selection, commands }, null, 2)}\n`);
@@ -243,6 +267,44 @@ export function selectRepositories(
     cursor: (start + limit) % repositories.length,
     total: repositories.length,
   };
+}
+
+export function reviewPlanningRepositories(options: {
+  repositories: readonly SelectedRepository[];
+  openCounts: ReadonlyMap<string, RepositoryOpenCounts>;
+  recordsRoot?: string;
+}): ReviewPlanningRepository[] {
+  const recordsRoot = options.recordsRoot ?? join(repoRoot(), "records");
+  return options.repositories
+    .map((repository) => {
+      const counts = options.openCounts.get(repository.targetRepo) ?? {
+        issues: 0,
+        pullRequests: 0,
+      };
+      const openItems = counts.issues + counts.pullRequests;
+      const itemsDir = join(
+        recordsRoot,
+        repository.targetRepo.toLowerCase().replace("/", "-"),
+        "items",
+      );
+      const trackedRecords = existsSync(itemsDir)
+        ? readdirSync(itemsDir, { withFileTypes: true }).filter(
+            (entry) => entry.isFile() && entry.name.endsWith(".md"),
+          ).length
+        : 0;
+      return {
+        ...repository,
+        openItems,
+        trackedRecords,
+        untrackedOpen: Math.max(0, openItems - trackedRecords),
+      };
+    })
+    .filter((repository) => repository.openItems > 0)
+    .sort(
+      (left, right) =>
+        Number(right.untrackedOpen > 0) - Number(left.untrackedOpen > 0) ||
+        left.targetRepo.localeCompare(right.targetRepo),
+    );
 }
 
 function listOwnerRepositories(owner: string): ListedRepository[] {

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -51,9 +51,11 @@ export const WEEKLY_COVERAGE_REVIEW_DAYS = 6;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const BULK_FILED_LABEL = "clawsweeper:bulk-filed";
 
+function isBulkFiled(item: SchedulerItem): boolean {
+  return item.labels?.some((label) => label.toLowerCase() === BULK_FILED_LABEL) ?? false;
+}
+
 function bulkFiledComparison(left: SchedulerDueCandidate, right: SchedulerDueCandidate): number {
-  const isBulkFiled = (item: SchedulerItem): boolean =>
-    item.labels?.some((label) => label.toLowerCase() === BULK_FILED_LABEL) ?? false;
   return Number(isBulkFiled(left.item)) - Number(isBulkFiled(right.item));
 }
 
@@ -303,10 +305,34 @@ export function selectDueCandidates<
     selected.push(candidate);
   };
 
-  // Weekly freshness is the outer SLO. Start the coverage lane one day before
-  // the deadline, then select the oldest last-review timestamps across every
-  // cadence bucket before spending capacity on hot-item churn.
-  const weeklyCoverageDue = due
+  const takeWeighted = (candidates: Array<SchedulerDueCandidate<ItemT, ReviewT>>): void => {
+    const cohort = new Map<SchedulerBucket, Array<SchedulerDueCandidate<ItemT, ReviewT>>>();
+    for (const [bucket] of SCHEDULER_BUCKET_WEIGHTS) cohort.set(bucket, []);
+    for (const candidate of candidates) cohort.get(candidate.bucket)?.push(candidate);
+    for (const bucketCandidates of cohort.values()) bucketCandidates.sort(compare);
+    while (selected.length < capacity) {
+      const before = selected.length;
+      for (const [bucket, weight] of SCHEDULER_BUCKET_WEIGHTS) {
+        const bucketCandidates = cohort.get(bucket);
+        if (!bucketCandidates?.length) continue;
+        for (
+          let index = 0;
+          index < weight && bucketCandidates.length && selected.length < capacity;
+          index += 1
+        ) {
+          take(bucketCandidates.shift());
+        }
+      }
+      if (selected.length === before) break;
+    }
+  };
+
+  // A missing canonical record means the live GitHub item has never had a
+  // review. Fill first-review coverage before renewing tracked records, while
+  // retaining the weekly-coverage and weighted bucket ordering within that
+  // cohort.
+  const neverReviewed = due.filter((candidate) => candidate.review === null);
+  const neverReviewedCoverageDue = neverReviewed
     .filter(
       (candidate) =>
         weeklyCoverageReferenceMs(candidate) + WEEKLY_COVERAGE_REVIEW_DAYS * DAY_MS <= now,
@@ -317,13 +343,29 @@ export function selectDueCandidates<
         weeklyCoverageReferenceMs(left) - weeklyCoverageReferenceMs(right) ||
         compare(left, right),
     );
-  // A never-reviewed backlog can contain years-old items. If all of those sort
-  // ahead of an already-tracked record, the rolling coverage set never gets
-  // refreshed even though the scheduler is busy. Renew overdue canonical
-  // records first; unseen items still consume every remaining coverage slot.
-  for (const candidate of weeklyCoverageDue) {
-    if (candidate.review != null) take(candidate);
-  }
+  for (const candidate of neverReviewedCoverageDue) take(candidate);
+  takeWeighted(
+    neverReviewed.filter(
+      (candidate) =>
+        !selectedKeys.has(schedulerItemKey(candidate.item.repo, candidate.item.number)),
+    ),
+  );
+
+  // Weekly freshness remains the outer SLO for canonical records. Start the
+  // coverage lane one day before the deadline, then select the oldest
+  // last-review timestamps across every cadence bucket before hot-item churn.
+  const weeklyCoverageDue = due
+    .filter(
+      (candidate) =>
+        candidate.review !== null &&
+        weeklyCoverageReferenceMs(candidate) + WEEKLY_COVERAGE_REVIEW_DAYS * DAY_MS <= now,
+    )
+    .sort(
+      (left, right) =>
+        bulkFiledComparison(left, right) ||
+        weeklyCoverageReferenceMs(left) - weeklyCoverageReferenceMs(right) ||
+        compare(left, right),
+    );
   for (const candidate of weeklyCoverageDue) take(candidate);
   for (const [bucket, candidates] of buckets) {
     buckets.set(

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -7,11 +7,13 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  SCHEDULED_REVIEW_PLAN_BATCH_SIZE,
   defaultLimit,
   filterEligibleRepositories,
   publishReviewCoverageInventory,
   renderFleetReviewCoverage,
   reviewCoverageInventorySnapshot,
+  reviewPlanningRepositories,
   selectRepositories,
   summarizeFleetReviewCoverage,
   type InventoryConfig,
@@ -32,6 +34,73 @@ test("target fanout defaults match the scheduled cursor batch sizes", () => {
   assert.equal(defaultLimit("hot-intake"), "20");
   assert.equal(defaultLimit("normal-review"), "12");
   assert.equal(defaultLimit("audit"), "12");
+});
+
+test("scheduled normal fanout can offer the configured hourly review target", () => {
+  const wrangler = readFileSync("dashboard/wrangler.toml", "utf8");
+  const configuredRate = Number(
+    wrangler.match(/^EXACT_REVIEW_TARGET_RATE_PER_HOUR = "(\d+)"$/m)?.[1],
+  );
+  const offersPerHour = SCHEDULED_REVIEW_PLAN_BATCH_SIZE * Number(defaultLimit("normal-review"));
+
+  assert.equal(configuredRate, 600);
+  assert.equal(SCHEDULED_REVIEW_PLAN_BATCH_SIZE, 50);
+  assert.equal(offersPerHour, 600);
+  assert.ok(offersPerHour >= configuredRate);
+});
+
+test("normal fanout prioritizes repositories with untracked live items and skips empty repos", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-planning-inventory-"));
+  const repositories = [
+    { targetRepo: "openclaw/empty", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "openclaw/huge", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "openclaw/tracked", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "steipete/small", defaultBranch: "main", visibility: "PUBLIC" },
+  ];
+  try {
+    const hugeItems = join(root, "openclaw-huge", "items");
+    const trackedItems = join(root, "openclaw-tracked", "items");
+    mkdirSync(hugeItems, { recursive: true });
+    mkdirSync(trackedItems, { recursive: true });
+    writeFileSync(join(hugeItems, "1.md"), "---\nreview_status: complete\n---\n");
+    writeFileSync(join(trackedItems, "1.md"), "---\nreview_status: complete\n---\n");
+    writeFileSync(join(trackedItems, "2.md"), "---\nreview_status: complete\n---\n");
+
+    assert.deepEqual(
+      reviewPlanningRepositories({
+        repositories,
+        recordsRoot: root,
+        openCounts: new Map([
+          ["openclaw/empty", { issues: 0, pullRequests: 0 }],
+          ["openclaw/huge", { issues: 100, pullRequests: 1 }],
+          ["openclaw/tracked", { issues: 1, pullRequests: 1 }],
+          ["steipete/small", { issues: 1, pullRequests: 0 }],
+        ]),
+      }),
+      [
+        {
+          ...repositories[1],
+          openItems: 101,
+          trackedRecords: 1,
+          untrackedOpen: 100,
+        },
+        {
+          ...repositories[3],
+          openItems: 1,
+          trackedRecords: 0,
+          untrackedOpen: 1,
+        },
+        {
+          ...repositories[2],
+          openItems: 2,
+          trackedRecords: 2,
+          untrackedOpen: 0,
+        },
+      ],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("target fanout summarizes trailing weekly coverage from canonical open records", () => {
@@ -402,8 +471,8 @@ process.exit(2);
   assert.deepEqual(
     calls.filter((call) => call.args[0] === "api").map((call) => call.args.join(" ")),
     [
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=true -f client_payload[batch_size]=20 -f client_payload[shard_count]=1",
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=true -f client_payload[batch_size]=20 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=true -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=true -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
     ],
   );
 });

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -147,6 +147,23 @@ test("weekly coverage becomes due at six days to preserve deadline headroom", ()
   assert.equal(shouldReviewItem(oldIssue, review, reviewedAt + 6 * 86_400_000, "current"), true);
 });
 
+test("never-reviewed items are due while fresh tracked items stay excluded", () => {
+  const now = Date.parse("2026-07-30T12:00:00Z");
+  const candidate = item({
+    createdAt: "2026-07-29T12:00:00Z",
+    updatedAt: "2026-07-29T12:00:00Z",
+  });
+  const freshReview = {
+    reviewedAt: "2026-07-30T11:00:00Z",
+    itemUpdatedAt: "2026-07-29T12:00:00Z",
+    reviewStatus: "complete",
+    reviewPolicy: "current",
+  };
+
+  assert.equal(shouldReviewItem(candidate, null, now, "current"), true);
+  assert.equal(shouldReviewItem(candidate, freshReview, now, "current"), false);
+});
+
 test("scheduler keeps ambiguous post-sync activity due after review", () => {
   const reviewedAt = "2026-04-30T12:52:57Z";
   const review = {
@@ -467,6 +484,7 @@ test("normal scheduler prioritizes oldest weekly-coverage timestamps before hot 
         kind: "issue",
         createdAt: "2026-06-13T00:00:00Z",
       }),
+      review: { reviewStatus: "complete", reviewedAt: "2026-06-08T11:00:00Z" },
       bucket: "hot_issue",
       priority: 0,
       reviewedAt: Date.parse("2026-06-08T11:00:00Z"),
@@ -478,6 +496,7 @@ test("normal scheduler prioritizes oldest weekly-coverage timestamps before hot 
         kind: "pull_request",
         createdAt: "2026-06-01T00:00:00Z",
       }),
+      review: { reviewStatus: "complete", reviewedAt: "2026-06-07T12:00:00Z" },
       bucket: "daily_pull_request",
       priority: 3,
       reviewedAt: Date.parse("2026-06-07T12:00:00Z"),
@@ -489,6 +508,7 @@ test("normal scheduler prioritizes oldest weekly-coverage timestamps before hot 
         kind: "issue",
         createdAt: "2026-05-01T00:00:00Z",
       }),
+      review: { reviewStatus: "complete", reviewedAt: "2026-06-06T12:00:00Z" },
       bucket: "weekly_issue",
       priority: 6,
       reviewedAt: Date.parse("2026-06-06T12:00:00Z"),
@@ -499,34 +519,35 @@ test("normal scheduler prioritizes oldest weekly-coverage timestamps before hot 
   assert.deepEqual(selectedNumbers(due, 3, now), [3, 2, 1]);
 });
 
-test("weekly coverage renews overdue canonical records before growing the unseen backlog", () => {
+test("normal scheduling ranks untracked items above stale records, then oldest review first", () => {
   const now = Date.parse("2026-06-14T12:00:00Z");
   const due = [
     {
-      item: item({ number: 1, createdAt: "2020-01-01T00:00:00Z" }),
-      bucket: "weekly_issue",
-      priority: 6,
+      item: item({ number: 1, createdAt: "2026-06-13T00:00:00Z" }),
+      bucket: "hot_issue",
+      priority: 0,
       reviewedAt: 0,
       nextDueAt: 0,
     },
     {
-      item: item({ number: 2, createdAt: "2021-01-01T00:00:00Z" }),
-      bucket: "weekly_issue",
-      priority: 6,
-      reviewedAt: 0,
-      nextDueAt: 0,
-    },
-    {
-      item: item({ number: 3, createdAt: "2026-01-01T00:00:00Z" }),
+      item: item({ number: 2, createdAt: "2026-01-01T00:00:00Z" }),
       review: { reviewStatus: "complete", reviewedAt: "2026-06-07T12:00:00Z" },
       bucket: "weekly_issue",
       priority: 6,
       reviewedAt: Date.parse("2026-06-07T12:00:00Z"),
       nextDueAt: 0,
     },
+    {
+      item: item({ number: 3, createdAt: "2026-01-01T00:00:00Z" }),
+      review: { reviewStatus: "complete", reviewedAt: "2026-06-06T12:00:00Z" },
+      bucket: "weekly_issue",
+      priority: 6,
+      reviewedAt: Date.parse("2026-06-06T12:00:00Z"),
+      nextDueAt: 0,
+    },
   ];
 
-  assert.deepEqual(selectedNumbers(due, 2, now), [3, 1]);
+  assert.deepEqual(selectedNumbers(due, 3, now), [1, 3, 2]);
 });
 
 test("weekly freshness preselection still fills remaining scheduler capacity", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2584,7 +2584,7 @@ test("scheduled reviews feed the durable queue instead of one-item matrix worker
   );
 
   assert.match(modeBlock, /queue_feed=.*clawsweeper_target_sweep/);
-  assert.match(modeBlock, /batch_size="20"[\s\S]*shard_count="1"/);
+  assert.match(modeBlock, /batch_size="50"[\s\S]*shard_count="1"/);
   assert.match(enqueueBlock, /repair:scheduled-review-enqueue/);
   assert.match(enqueueBlock, /Scheduled review funnel/);
   assert.match(workflow, /Review scheduled hot item/);
@@ -2845,7 +2845,7 @@ test("target review queues coalesce background work without delaying exact plann
   assert.match(planHeader, /cancel-in-progress: false/);
 });
 
-test("scheduled normal review offers a 20-item queue batch on one planner shard", () => {
+test("scheduled normal review offers a 50-item queue batch on one planner shard", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const modeBlock = workflow.slice(
     workflow.indexOf("- id: mode"),
@@ -2853,7 +2853,7 @@ test("scheduled normal review offers a 20-item queue batch on one planner shard"
   );
 
   assert.match(modeBlock, /if \[ "\$queue_feed" = "true" \] && \[ -z "\$exact_item" \]; then/);
-  assert.match(modeBlock, /batch_size="20"[\s\S]*shard_count="1"/);
+  assert.match(modeBlock, /batch_size="50"[\s\S]*shard_count="1"/);
   assert.match(modeBlock, /min_active_shards="0"/);
 });
 
@@ -3002,6 +3002,7 @@ test("sweep issue and PR event reviews and target fanout avoid storm amplificati
     /FANOUT_LIMIT: \$\{\{ github\.event\.schedule == '41 \* \* \* \*' && '12' \|\| \(github\.event\.schedule == '37 \*\/6 \* \* \*' && '12' \|\| '20'\) \}\}/,
   );
   assert.match(fanoutBlock, /Summarize trailing weekly review coverage/);
+  assert.match(fanoutBlock, /--publish-url "\$REVIEW_COVERAGE_URL"/);
   assert.match(fanoutBlock, /target-fanout -- coverage --window-days 7/);
   assert.match(fanoutBlock, /GITHUB_STEP_SUMMARY/);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled review could keep renewing already-tracked items while thousands of live open issues and pull requests had never received a canonical review. With a full 20-item plan, the tracked-first preselection filled every slot, so the queue could have banked feed tokens and idle workers while first-review coverage barely moved.

## Why This Change Was Made

The per-repository planner already scans live open GitHub items and marks a missing canonical record as due. This change makes that untracked cohort consume capacity before any re-review, while preserving six-day coverage order and weighted bucket fairness within the cohort and oldest-`reviewed_at` fairness for tracked records.

Normal target fanout now refreshes the same signed live-open inventory used by `/api/review-coverage`, skips repositories with no open items, and visits repositories whose live count exceeds their canonical-record count before tracked-only repositories. Scheduled plans grow from 20 to 50 candidates: `50 items × 12 normal target cycles/hour = 600 offers/hour`, enough to feed the configured queue rate without changing Worker admission, dedupe, supersession, backpressure, or concurrency safety.

No Worker redeploy is required. The signed inventory endpoint and queue contracts are unchanged; the workflow and compiled planner behavior take effect from `main` after merge.

## User Impact

Operators should see `untracked_open` fall continuously instead of seeing mostly tracked re-reviews. At a net 600 first reviews/hour, the observed 3,298-item untracked cohort takes about `3298 / 600 = 5.50 hours` to burn down. Organic demand, semantic dedupe while publication catches up, retries, or provider limits can extend the wall-clock time.

At the measured 4.1-minute mean review time, 600 reviews/hour needs about `600 × 4.1 / 60 = 41` concurrent workers, within the 128 global and 120 per-target limits. Each fanout dispatch remains capped at 50 candidates, and repository selection remains cursor-based so one large target cannot occupy multiple fanout slots in a cycle.

## Evidence

- Focused scheduler, fanout, and workflow proof: `pnpm run build:all && node --test test/scheduler-policy.test.ts test/repair/target-fanout.test.ts test/sweep-workflow.test.ts` — 108/108 passed.
- Formatting and lint: `pnpm run format:check && pnpm run lint` — all checks passed.
- Local autoreview: `~/.claude/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.
- Committed branch autoreview: `~/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- Full `pnpm run check`: static checks, format, all builds, lint, and changed-surface coverage passed; the all-file suite passed 2,781 tests and failed five untouched macOS containment fixtures because the embedded Linux runtime imports the unavailable Darwin `libc.capset` symbol.

## Real Behavior Proof

**Claim:** The scheduled fleet planner now spends cycles on repositories with live open work, puts untracked repositories first, and emits enough candidate volume to feed 600 reviews/hour.

**Exercised surface:** Built `dist/repair/target-fanout.js` using the authenticated live GitHub repository inventory, without dispatching workflows or publishing inventory.

**Scenario:** Ran a normal-review plan for 12 repository cycles from this branch:

```text
pnpm run --silent target-fanout -- plan --mode normal-review --limit 12 --repo openclaw/clawsweeper --workflow sweep.yml --ref main
```

**Observed result:** The planner found 56 repositories with open work, excluded empty repositories, selected 12 repositories from the untracked-first cohort, and emitted `client_payload[batch_size]=50` for every command. The local checkout intentionally had no hydrated canonical records, so every selected live-open repository appeared untracked; production Actions hydrates canonical records before this step and will compute the actual per-repository difference.

**Limits:** This was a read-only planner execution. Queue admission and end-to-end coverage movement begin only after the workflow change reaches `main`; the existing Worker needs no redeploy.
