### PR TITLE
fix(fanout): move rotation cursor to canonical store

### DIFF
--- a/.github/workflows/proof-nudges.yml
+++ b/.github/workflows/proof-nudges.yml
@@ -205,10 +205,12 @@ jobs:
             fi
           fi
           if [ ${#cursor_publish_args[@]} -gt 0 ]; then
-            pnpm run repair:publish-main -- \
+            if ! pnpm run repair:publish-main -- \
               --message "chore: update proof handling cursors" \
               --rebase-strategy theirs \
-              "${cursor_publish_args[@]}"
+              "${cursor_publish_args[@]}"; then
+              echo "::warning title=Proof cursor publish failed::Proof handling completed; continuing without the best-effort Git cursor update."
+            fi
           fi
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/repair-conflict-self-heal.yml
+++ b/.github/workflows/repair-conflict-self-heal.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Commit conflict self-heal ledger
         if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.execute) || (github.event_name == 'schedule' && vars.CLAWSWEEPER_CONFLICT_SELF_HEAL_EXECUTE == '1')) }}
+        continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |

--- a/.github/workflows/repair-finalize-open-prs.yml
+++ b/.github/workflows/repair-finalize-open-prs.yml
@@ -101,6 +101,7 @@ jobs:
           pnpm run repair:publish-result -- --skip-dashboard
 
       - name: Commit finalizer ledger
+        continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |

--- a/.github/workflows/repair-self-heal.yml
+++ b/.github/workflows/repair-self-heal.yml
@@ -133,6 +133,7 @@ jobs:
 
       - name: Commit self-heal ledger
         if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.execute) || (github.event_name == 'schedule' && vars.CLAWSWEEPER_SELF_HEAL_EXECUTE == '1')) }}
+        continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -189,6 +189,7 @@ jobs:
 
       - name: Commit spam scanner audit
         if: always()
+        continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2472,20 +2472,13 @@ jobs:
           filter: blob:none
           fetch-depth: 0
 
-      - name: Create state token
-        id: state-token
-        uses: ./.github/actions/create-state-token
-        with:
-          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-
       - uses: ./.github/actions/setup-state
         with:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          hydrate-git-state: "false"
           hydrate-state-blobs: "false"
-          token: ${{ steps.state-token.outputs.token }}
 
       - uses: ./.github/actions/setup-pnpm
         with:
@@ -2526,6 +2519,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --workflow sweep.yml \
             --ref main \
+            --cursor-store-url "$REVIEW_COVERAGE_URL" \
             --publish-url "$REVIEW_COVERAGE_URL"
 
       - name: Summarize trailing weekly review coverage
@@ -2542,15 +2536,6 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           REVIEW_COVERAGE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: pnpm run target-fanout -- coverage --window-days 7 --publish-url "$REVIEW_COVERAGE_URL" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Publish fanout cursor
-        env:
-          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
-        run: |
-          pnpm run repair:publish-main -- \
-            --message "chore: update target fanout cursor" \
-            --path results/target-fanout-cursors \
-            --rebase-strategy theirs
 
   plan:
     name: Plan review candidates
@@ -3630,10 +3615,12 @@ jobs:
             --path "records/${target_slug}" \
             --rebase-strategy normal
           echo "records_published=true" >> "$GITHUB_OUTPUT"
-          pnpm run repair:publish-main -- \
+          if ! pnpm run repair:publish-main -- \
             --message "chore: update sweep status" \
             --path "results/sweep-status/${target_slug}.json" \
-            --rebase-strategy theirs
+            --rebase-strategy theirs; then
+            echo "::warning title=Sweep status publish failed::Review records are canonical; continuing without the best-effort Git dashboard update."
+          fi
 
       - name: Dispatch reproducible bug implementation candidates
         if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && needs.plan.outputs.target_repo == 'openclaw/openclaw' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_REPRO_BUGS == '1' }}
@@ -3878,11 +3865,13 @@ jobs:
             --message "chore: sync selected review comments" \
             --path "records/${target_slug}" \
             --rebase-strategy normal
-          pnpm run repair:publish-main -- \
+          if ! pnpm run repair:publish-main -- \
             --message "chore: publish selected review comment status" \
             --path apply-report.json \
             --path "results/sweep-status/${target_slug}.json" \
-            --rebase-strategy theirs
+            --rebase-strategy theirs; then
+            echo "::warning title=Selected-comment bookkeeping failed::Canonical comment records are published; continuing without the best-effort Git report update."
+          fi
 
       - name: Finalize selected review comment action ledger
         id: finalize-selected-review-comment-action-ledger
@@ -4225,6 +4214,7 @@ jobs:
 
       - name: Publish failed-review retry state
         if: ${{ always() && vars.CLAWSWEEPER_FAILED_REVIEW_RETRY_ENABLED == '1' && hashFiles('results/failed-review-retries/openclaw-openclaw/*.json') != '' }}
+        continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
@@ -4408,12 +4398,14 @@ jobs:
             --message "chore: update sweep audit state" \
             --path "records/${target_slug}" \
             --rebase-strategy normal
-          pnpm run repair:publish-main -- \
+          if ! pnpm run repair:publish-main -- \
             --message "chore: publish sweep audit status" \
             --path README.md \
             --path "results/audit/${target_slug}.json" \
             --path "results/sweep-status/${target_slug}.json" \
-            --rebase-strategy theirs
+            --rebase-strategy theirs; then
+            echo "::warning title=Audit dashboard publish failed::Canonical reconciliation is complete; continuing without the best-effort Git dashboard update."
+          fi
 
       - name: Refresh state dashboard
         env:
@@ -5275,6 +5267,7 @@ jobs:
       - name: Retry final apply status publication
         id: retry-final-apply-status-publication
         if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' }}
+        continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -462,6 +462,14 @@ const EXACT_REVIEW_QUEUE_ROLLBACK_CLOCK_SKEW_MS = 5 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX = "__clawsweeper_sql_generation:";
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
 const EXACT_REVIEW_SOURCE_AUTHORITY_SEQUENCE_KEY = "exact-review-source-authority-sequence:v1";
+const TARGET_FANOUT_CURSOR_KEY_PREFIX = "target-fanout-cursor:v1:";
+type TargetFanoutMode = "hot-intake" | "normal-review" | "audit";
+type TargetFanoutCursor = {
+  mode: TargetFanoutMode;
+  nextCursor: number;
+  revision: number;
+  updatedAt: number;
+};
 const EXACT_REVIEW_SOURCE_AUTHORITY_RESERVATION_PREFIX =
   "exact-review-source-authority-reservation:v1:";
 const EXACT_REVIEW_SOURCE_AUTHORITY_RETRY_LIMIT = 16;
@@ -592,6 +600,13 @@ export class ExactReviewQueue {
       this.storage.kv.put(REVIEW_COVERAGE_INVENTORY_KEY, inventory);
       this.reviewCoverageCache = null;
       return json({ ok: true, accepted: true }, 202);
+    }
+    const targetFanoutMode = targetFanoutModeFromPath(url.pathname);
+    if (targetFanoutMode && request.method === "GET") {
+      return this.readTargetFanoutCursor(targetFanoutMode);
+    }
+    if (targetFanoutMode && request.method === "PUT") {
+      return this.writeTargetFanoutCursor(targetFanoutMode, await request.json().catch(() => null));
     }
     if (request.method === "POST" && url.pathname === "/source-authority") {
       const body = objectValue(await request.json().catch(() => null));
@@ -2939,6 +2954,64 @@ export class ExactReviewQueue {
     }
 
     return new Response("not found", { status: 404 });
+  }
+
+  private readTargetFanoutCursor(mode: TargetFanoutMode) {
+    const stored = readTargetFanoutCursor(this.storage.kv.get(targetFanoutCursorKey(mode)), mode);
+    if (stored === "invalid") return json({ error: "fanout_cursor_store_invalid" }, 500);
+    return json(targetFanoutCursorJson(stored ?? emptyTargetFanoutCursor(mode)));
+  }
+
+  private writeTargetFanoutCursor(mode: TargetFanoutMode, value: unknown) {
+    const body = objectValue(value);
+    const nextCursor = Number(body.next_cursor);
+    const expectedRevision = Number(body.expected_revision);
+    if (
+      !Number.isSafeInteger(nextCursor) ||
+      nextCursor < 0 ||
+      !Number.isSafeInteger(expectedRevision) ||
+      expectedRevision < 0
+    ) {
+      return json({ error: "invalid_fanout_cursor" }, 400);
+    }
+    try {
+      const result = this.storage.transactionSync(() => {
+        const stored = readTargetFanoutCursor(
+          this.storage.kv.get(targetFanoutCursorKey(mode)),
+          mode,
+        );
+        if (stored === "invalid") return { kind: "invalid" as const };
+        const current = stored ?? emptyTargetFanoutCursor(mode);
+        if (current.revision !== expectedRevision) {
+          return { kind: "conflict" as const, current };
+        }
+        if (current.revision >= Number.MAX_SAFE_INTEGER) {
+          return { kind: "invalid" as const };
+        }
+        const next: TargetFanoutCursor = {
+          mode,
+          nextCursor,
+          revision: current.revision + 1,
+          updatedAt: Date.now(),
+        };
+        this.storage.kv.put(targetFanoutCursorKey(mode), next);
+        return { kind: "written" as const, cursor: next };
+      });
+      if (result.kind === "invalid") return json({ error: "fanout_cursor_store_invalid" }, 500);
+      if (result.kind === "conflict") {
+        return json(
+          {
+            error: "fanout_cursor_revision_conflict",
+            current: targetFanoutCursorJson(result.current),
+          },
+          409,
+        );
+      }
+      return json(targetFanoutCursorJson(result.cursor), 202);
+    } catch (error) {
+      console.error(`fanout cursor write failed: ${sanitizedServerError(error)}`);
+      return json({ error: "fanout_cursor_store_unavailable" }, 503);
+    }
   }
 
   async alarm() {
@@ -11987,6 +12060,52 @@ function exactReviewPublicationBatchTimestamp(value) {
 
 function objectValue(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function targetFanoutModeFromPath(path: string): TargetFanoutMode | null {
+  const match = /^\/cursors\/(hot-intake|normal-review|audit)$/.exec(path);
+  return (match?.[1] as TargetFanoutMode | undefined) ?? null;
+}
+
+function targetFanoutCursorKey(mode: TargetFanoutMode): string {
+  return `${TARGET_FANOUT_CURSOR_KEY_PREFIX}${mode}`;
+}
+
+function emptyTargetFanoutCursor(mode: TargetFanoutMode): TargetFanoutCursor {
+  return { mode, nextCursor: 0, revision: 0, updatedAt: 0 };
+}
+
+function readTargetFanoutCursor(
+  value: unknown,
+  mode: TargetFanoutMode,
+): TargetFanoutCursor | "invalid" | null {
+  if (value === undefined) return null;
+  const cursor = objectValue(value);
+  const nextCursor = Number(cursor.nextCursor);
+  const revision = Number(cursor.revision);
+  const updatedAt = Number(cursor.updatedAt);
+  if (
+    cursor.mode !== mode ||
+    !Number.isSafeInteger(nextCursor) ||
+    nextCursor < 0 ||
+    !Number.isSafeInteger(revision) ||
+    revision < 1 ||
+    !Number.isSafeInteger(updatedAt) ||
+    updatedAt < 1
+  ) {
+    return "invalid";
+  }
+  return { mode, nextCursor, revision, updatedAt };
+}
+
+function targetFanoutCursorJson(cursor: TargetFanoutCursor) {
+  return {
+    ok: true,
+    mode: cursor.mode,
+    next_cursor: cursor.nextCursor,
+    revision: cursor.revision,
+    updated_at: cursor.updatedAt > 0 ? new Date(cursor.updatedAt).toISOString() : null,
+  };
 }
 
 function repoName(repo) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -549,6 +549,15 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/source-authority");
     if (url.pathname === "/internal/review-coverage/inventory" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/review-coverage/inventory");
+    const fanoutCursorPath = /^\/internal\/state\/cursors\/(hot-intake|normal-review|audit)$/.exec(
+      url.pathname,
+    );
+    if (fanoutCursorPath && (request.method === "GET" || request.method === "PUT"))
+      return authenticatedExactReviewQueueCursorRequest(
+        request,
+        env,
+        url.pathname.slice("/internal/state".length),
+      );
     const canonicalRecordPath =
       request.method === "GET"
         ? /^\/internal\/state\/records\/[^/]+\/(?:items|closed|plans|decision-packets)\/[1-9]\d*$/.exec(
@@ -1765,6 +1774,26 @@ async function authenticatedExactReviewQueueRead(request, env, path: string) {
     env,
     path,
     new Request(`https://clawsweeper-exact-review-queue${path}`, { method: "GET" }),
+  );
+}
+
+async function authenticatedExactReviewQueueCursorRequest(request, env, path: string) {
+  const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
+  if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const body = await request.text();
+  const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
+  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+  const init: RequestInit = {
+    method: request.method,
+    headers: { "content-type": "application/json" },
+  };
+  if (request.method === "PUT") init.body = body;
+  return exactReviewQueueRequest(
+    env,
+    path,
+    new Request(`https://clawsweeper-exact-review-queue${path}`, init),
   );
 }
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -139,6 +139,12 @@ manual workflow inputs. Scheduled fanout uses:
 - normal review: `41 * * * *`, 12 target repositories per cursor step
 - audit: `37 */6 * * *`, 12 target repositories per cursor step
 
+Each mode's cursor lives in the authenticated ExactReviewQueue Durable Object,
+not generated Git state. Reads and writes use a monotonic revision. If the
+canonical cursor endpoint is unavailable, fanout warns and continues dispatch
+from a safe default; cursor persistence failure after dispatch never fails the
+productive lane.
+
 Normal fanout refreshes the same signed live-open inventory consumed by
 `GET /api/review-coverage`, skips repositories with no open items, and visits
 repositories whose live count exceeds their canonical-record count before

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -8,6 +8,7 @@ operational paths that have not migrated yet.
 | Logical paths | Canonical owner | Git state status |
 | --- | --- | --- |
 | `records/**` | Durable Object record store with R2 snapshots | Never checked out or written |
+| fanout cursor per mode | ExactReviewQueue Durable Object KV | Never checked out or written |
 | `ledger/v1/**` | R2 immutable blobs | Never checked out or written |
 | `assets/**` | R2 mutable blobs | Never checked out or written |
 | `jobs/**` | `clawsweeper-state` `state` branch | Retained until its own migration |
@@ -24,6 +25,19 @@ Remaining Git writers use the Durable Object state-writer coordinator and one
 ordinary fetch/commit/push. The former Git lease refs, atomic multi-ref pushes,
 shallow-history deepening, remote-head rebuilds, record reconciliation, and
 immutable-ledger scratch branches no longer exist.
+
+Target fanout reads and updates `/internal/state/cursors/<mode>` with the same
+HMAC authentication as canonical record operations. Each record carries a
+monotonic revision so concurrent writers cannot silently overwrite one another.
+Cursor reads and writes are fail-open: an unavailable store emits a prominent
+warning, but repository dispatch continues so bookkeeping cannot block fleet
+coverage.
+
+Git-backed reports, dashboard status, and post-dispatch cursors are best-effort
+after their productive side effect or canonical publication succeeds. Git
+publication remains mandatory where it is still the durability fence before a
+dispatch, notably `jobs/**` intake and comment-router claims, and in the
+dedicated cluster-result publisher whose failure must stay visible for retry.
 
 The former state materializer is retained only as a bounded append-window
 compactor. It drains and acknowledges legacy projection rows so the Durable

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -61,7 +61,8 @@ Batch rollout should use target fanout:
 - use `pnpm run target-fanout -- plan --mode hot-intake --limit 10 --dry-run`
   to inspect the current owner inventory and selected dispatch commands
 - let the scheduled fanout cursor dispatch small batches across
-  `target_inventory.owners`
+  `target_inventory.owners`; the cursor is stored in the authenticated
+  ExactReviewQueue Durable Object rather than `clawsweeper-state`
 - fanout passes each repository's default branch as `target_branch`, so repos
   that use `master` or another branch do not fall back to `main`
 - add config entries only for repos that need repo-specific guidance or broader

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -162,7 +162,9 @@ publish_changes() {
     publish_changes_with_strategy normal "$message" "${record_paths[@]}" || return 1
   fi
   if [ "${#other_paths[@]}" -gt 0 ]; then
-    publish_changes_with_strategy theirs "$message" "${other_paths[@]}" || return 1
+    if ! publish_changes_with_strategy theirs "$message" "${other_paths[@]}"; then
+      echo "::warning title=Operational state publish failed::Canonical work remains valid; continuing after best-effort Git bookkeeping failed: $message" >&2
+    fi
   fi
 }
 

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createHmac } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveCommand } from "../command.js";
 import { parseArgs, repoRoot } from "./lib.js";
@@ -77,10 +77,26 @@ interface SelectionResult {
   total: number;
 }
 
+export interface FanoutCursorSnapshot {
+  mode: FanoutMode;
+  nextCursor: number;
+  revision: number;
+  updatedAt: string | null;
+}
+
+export type FanoutCursorStoreOptions = {
+  baseUrl: string;
+  webhookSecret: string;
+  mode: FanoutMode;
+  attempts?: number;
+  fetchImpl?: typeof globalThis.fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
 interface FanoutOptions {
   mode: FanoutMode;
   limit: number;
-  cursorPath: string;
+  cursorStoreUrl: string;
   dispatchRepo: string;
   workflow: string;
   ref: string;
@@ -88,7 +104,6 @@ interface FanoutOptions {
   owners: readonly string[] | undefined;
 }
 
-const DEFAULT_CURSOR_DIR = join(repoRoot(), "results", "target-fanout-cursors");
 const PUBLIC_INVENTORY_TOKEN = "__public__";
 export const SCHEDULED_REVIEW_PLAN_BATCH_SIZE = 50;
 
@@ -99,7 +114,10 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
   const options: FanoutOptions = {
     mode,
     limit: positiveNumber(stringArg(args.limit, defaultLimit(mode)), "limit"),
-    cursorPath: stringArg(args["cursor-path"], join(DEFAULT_CURSOR_DIR, `${mode}.json`)),
+    cursorStoreUrl: stringArg(
+      args["cursor-store-url"],
+      process.env.CLAWSWEEPER_CURSOR_STORE_URL ?? stringArg(args["publish-url"], ""),
+    ),
     dispatchRepo: stringArg(args.repo, process.env.GITHUB_REPOSITORY ?? "openclaw/clawsweeper"),
     workflow: stringArg(args.workflow, "sweep.yml"),
     ref: stringArg(args.ref, "main"),
@@ -115,14 +133,20 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
     const coverage = summarizeFleetReviewCoverage({ repositories, openCounts, windowDays, now });
     const publishUrl = stringArg(args["publish-url"], "");
     if (publishUrl) {
-      await publishReviewCoverageInventory({
-        baseUrl: publishUrl,
-        webhookSecret: stringValue(
-          process.env.CLAWSWEEPER_WEBHOOK_SECRET,
-          "CLAWSWEEPER_WEBHOOK_SECRET",
-        ),
-        snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
-      });
+      try {
+        await publishReviewCoverageInventory({
+          baseUrl: publishUrl,
+          webhookSecret: stringValue(
+            process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+            "CLAWSWEEPER_WEBHOOK_SECRET",
+          ),
+          snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
+        });
+      } catch (error) {
+        console.error(
+          `[target-fanout] WARNING: live review inventory did not publish; continuing without blocking scheduled fanout work: ${errorMessage(error)}`,
+        );
+      }
     }
     process.stdout.write(renderFleetReviewCoverage(coverage));
     return;
@@ -141,20 +165,31 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
     const now = Date.now();
     const publishUrl = stringArg(args["publish-url"], "");
     if (publishUrl) {
-      await publishReviewCoverageInventory({
-        baseUrl: publishUrl,
-        webhookSecret: stringValue(
-          process.env.CLAWSWEEPER_WEBHOOK_SECRET,
-          "CLAWSWEEPER_WEBHOOK_SECRET",
-        ),
-        snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
-      });
+      try {
+        await publishReviewCoverageInventory({
+          baseUrl: publishUrl,
+          webhookSecret: stringValue(
+            process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+            "CLAWSWEEPER_WEBHOOK_SECRET",
+          ),
+          snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
+        });
+      } catch (error) {
+        console.error(
+          `[target-fanout] WARNING: live review inventory did not publish; continuing without blocking scheduled fanout work: ${errorMessage(error)}`,
+        );
+      }
     }
     planningRepositories = reviewPlanningRepositories({ repositories, openCounts });
   }
+  const cursor = await loadFanoutCursor({
+    baseUrl: options.cursorStoreUrl,
+    webhookSecret: process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "",
+    mode,
+  });
   const selection = selectRepositories(planningRepositories, {
     limit: options.limit,
-    cursor: readCursor(options.cursorPath),
+    cursor: cursor.nextCursor,
   });
 
   const commands = selection.repositories.map((repository) =>
@@ -178,9 +213,17 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
     dispatched.push(repository.targetRepo);
   }
 
-  if (!options.dryRun) {
-    writeCursor(options.cursorPath, selection.cursor);
-  }
+  const cursorPersisted = options.dryRun
+    ? false
+    : await persistFanoutCursorFailOpen(
+        {
+          baseUrl: options.cursorStoreUrl,
+          webhookSecret: process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "",
+          mode,
+        },
+        selection.cursor,
+        cursor.revision,
+      );
   process.stdout.write(
     `${JSON.stringify(
       {
@@ -189,7 +232,8 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
         dispatched,
         next_cursor: selection.cursor,
         dry_run: options.dryRun,
-        cursor_written: !options.dryRun,
+        cursor_loaded: cursor.loaded,
+        cursor_persisted: cursorPersisted,
       },
       null,
       2,
@@ -381,23 +425,112 @@ function workflowDispatchArgs(repository: SelectedRepository, options: FanoutOpt
   return args;
 }
 
-function readCursor(cursorPath: string): number {
-  if (!existsSync(cursorPath)) return 0;
-  const parsed = JSON.parse(readFileSync(cursorPath, "utf8")) as unknown;
-  const cursor = record(parsed, "cursor");
-  return typeof cursor.next_cursor === "number" && Number.isInteger(cursor.next_cursor)
-    ? cursor.next_cursor
-    : 0;
+export async function fetchFanoutCursor(
+  options: FanoutCursorStoreOptions,
+): Promise<FanoutCursorSnapshot> {
+  const payload = await fanoutCursorRequest(options, "GET", "");
+  if (payload.mode !== options.mode) throw new Error("fanout cursor response mode mismatch");
+  return {
+    mode: options.mode,
+    nextCursor: nonNegativeNumber(payload.next_cursor, "fanout cursor next_cursor"),
+    revision: nonNegativeNumber(payload.revision, "fanout cursor revision"),
+    updatedAt:
+      payload.updated_at === null || typeof payload.updated_at === "string"
+        ? payload.updated_at
+        : null,
+  };
 }
 
-function writeCursor(cursorPath: string, cursor: number): void {
-  writeFileSyncWithDirs(cursorPath, `${JSON.stringify({ next_cursor: cursor }, null, 2)}\n`);
+export async function putFanoutCursor(
+  options: FanoutCursorStoreOptions,
+  nextCursor: number,
+  expectedRevision: number,
+): Promise<FanoutCursorSnapshot> {
+  const body = JSON.stringify({
+    next_cursor: nonNegativeNumber(nextCursor, "fanout cursor next_cursor"),
+    expected_revision: nonNegativeNumber(expectedRevision, "fanout cursor expected_revision"),
+  });
+  const payload = await fanoutCursorRequest(options, "PUT", body);
+  if (payload.mode !== options.mode) throw new Error("fanout cursor response mode mismatch");
+  return {
+    mode: options.mode,
+    nextCursor: nonNegativeNumber(payload.next_cursor, "fanout cursor next_cursor"),
+    revision: nonNegativeNumber(payload.revision, "fanout cursor revision"),
+    updatedAt: typeof payload.updated_at === "string" ? payload.updated_at : null,
+  };
 }
 
-function writeFileSyncWithDirs(filePath: string, content: string): void {
-  const dir = dirname(filePath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(filePath, content);
+export async function loadFanoutCursor(
+  options: FanoutCursorStoreOptions,
+): Promise<FanoutCursorSnapshot & { loaded: boolean }> {
+  try {
+    return { ...(await fetchFanoutCursor(options)), loaded: true };
+  } catch (error) {
+    console.error(
+      `[target-fanout] WARNING: canonical ${options.mode} cursor is unavailable; continuing dispatch from cursor 0 without blocking productive work: ${errorMessage(error)}`,
+    );
+    return { mode: options.mode, nextCursor: 0, revision: 0, updatedAt: null, loaded: false };
+  }
+}
+
+export async function persistFanoutCursorFailOpen(
+  options: FanoutCursorStoreOptions,
+  nextCursor: number,
+  expectedRevision: number,
+): Promise<boolean> {
+  try {
+    await putFanoutCursor(options, nextCursor, expectedRevision);
+    return true;
+  } catch (error) {
+    console.error(
+      `[target-fanout] WARNING: canonical ${options.mode} cursor did not persist after dispatch; dispatched work remains valid and the next cycle will retry: ${errorMessage(error)}`,
+    );
+    return false;
+  }
+}
+
+async function fanoutCursorRequest(
+  options: FanoutCursorStoreOptions,
+  method: "GET" | "PUT",
+  body: string,
+): Promise<JsonRecord> {
+  const baseUrl = options.baseUrl.replace(/\/$/, "");
+  if (!baseUrl.startsWith("https://")) {
+    throw new Error("fanout cursor store URL must use HTTPS");
+  }
+  if (!options.webhookSecret) throw new Error("fanout cursor webhook secret is required");
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
+  const attempts = Math.max(1, Math.min(5, Math.floor(options.attempts ?? 3)));
+  const request = options.fetchImpl ?? globalThis.fetch;
+  const sleep =
+    options.sleep ??
+    ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  let lastFailure = "fanout cursor request failed";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const init: RequestInit = {
+        method,
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        signal: AbortSignal.timeout(5_000),
+      };
+      if (method === "PUT") init.body = body;
+      const response = await request(
+        `${baseUrl}/internal/state/cursors/${encodeURIComponent(options.mode)}`,
+        init,
+      );
+      const payload = record(await response.json().catch(() => ({})), "fanout cursor response");
+      if (response.ok && payload.ok === true) return payload;
+      lastFailure = String(payload.error || `http_${response.status}`);
+      if (response.status >= 400 && response.status < 500 && response.status !== 429) break;
+    } catch (error) {
+      lastFailure = errorMessage(error);
+    }
+    if (attempt < attempts) await sleep(attempt * 1_000);
+  }
+  throw new Error(`${method} fanout cursor failed: ${lastFailure}`);
 }
 
 function runGh(args: readonly string[], env: NodeJS.ProcessEnv): string {
@@ -631,6 +764,12 @@ function nonNegativeNumber(value: unknown, label: string): number {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 0) throw new Error(`${label} must be non-negative`);
   return parsed;
+}
+
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error))
+    .replace(/[\r\n]+/g, " ")
+    .slice(0, 300);
 }
 
 function positiveNumber(value: string, label: string): number {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -2585,6 +2585,68 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
   });
 });
 
+test("authenticated fanout cursors round-trip through durable storage", async () => {
+  const storage = new MemoryDurableStorage();
+  const secret = "fanout-cursor-secret";
+  let queue = new ExactReviewQueue({ storage }, {});
+  let env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const path = "/internal/state/cursors/normal-review";
+  const request = (method: "GET" | "PUT", payload?: unknown, signed = true) => {
+    const body = method === "PUT" ? JSON.stringify(payload) : "";
+    return new Request(`https://clawsweeper.openclaw.ai${path}`, {
+      method,
+      headers: signed
+        ? {
+            "content-type": "application/json",
+            "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+          }
+        : undefined,
+      ...(method === "PUT" ? { body } : {}),
+    });
+  };
+
+  assert.equal((await worker.fetch(request("GET", undefined, false), env)).status, 401);
+  assert.deepEqual(await (await worker.fetch(request("GET"), env)).json(), {
+    ok: true,
+    mode: "normal-review",
+    next_cursor: 0,
+    revision: 0,
+    updated_at: null,
+  });
+
+  const writtenResponse = await worker.fetch(
+    request("PUT", { next_cursor: 12, expected_revision: 0 }),
+    env,
+  );
+  assert.equal(writtenResponse.status, 202);
+  const written = await writtenResponse.json();
+  assert.deepEqual(written, {
+    ok: true,
+    mode: "normal-review",
+    next_cursor: 12,
+    revision: 1,
+    updated_at: written.updated_at,
+  });
+  assert.equal(Number.isFinite(Date.parse(written.updated_at)), true);
+
+  const conflict = await worker.fetch(
+    request("PUT", { next_cursor: 24, expected_revision: 0 }),
+    env,
+  );
+  assert.equal(conflict.status, 409);
+  assert.equal((await conflict.json()).error, "fanout_cursor_revision_conflict");
+
+  queue = new ExactReviewQueue({ storage }, {});
+  env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  assert.deepEqual(await (await worker.fetch(request("GET"), env)).json(), written);
+});
+
 test("canonical commit records and tuples export with one monotonic revision", async () => {
   const storage = new MemoryDurableStorage();
   const leased = leasedExactReviewQueueItem(711, "7110");

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -9,8 +9,12 @@ import test from "node:test";
 import {
   SCHEDULED_REVIEW_PLAN_BATCH_SIZE,
   defaultLimit,
+  fetchFanoutCursor,
   filterEligibleRepositories,
+  loadFanoutCursor,
+  persistFanoutCursorFailOpen,
   publishReviewCoverageInventory,
+  putFanoutCursor,
   renderFleetReviewCoverage,
   reviewCoverageInventorySnapshot,
   reviewPlanningRepositories,
@@ -241,7 +245,6 @@ test("target fanout filters eligible repositories conservatively", () => {
 test("target fanout skips owners without minted inventory tokens in Actions", () => {
   const dir = mkdtempSync(join(tmpdir(), "clawsweeper-fanout-"));
   const logPath = join(dir, "gh.log");
-  const cursorPath = join(dir, "cursor.json");
   const ghPath = join(dir, "gh.js");
   writeFileSync(
     ghPath,
@@ -269,8 +272,6 @@ process.exit(2);
       "hot-intake",
       "--limit",
       "2",
-      "--cursor-path",
-      cursorPath,
       "--repo",
       "openclaw/clawsweeper",
     ],
@@ -283,6 +284,7 @@ process.exit(2);
         ...mockGhBinEnv(ghPath),
         GH_TOKEN: "workflow-token",
         CLAWSWEEPER_DISPATCH_TOKEN: "dispatch-token",
+        CLAWSWEEPER_WEBHOOK_SECRET: "cursor-secret",
         CLAWSWEEPER_INVENTORY_TOKEN_OPENCLAW: "inventory-openclaw",
         CLAWSWEEPER_INVENTORY_TOKEN_STEIPETE: "",
       },
@@ -305,7 +307,6 @@ process.exit(2);
 test("target fanout can use anonymous public inventory in Actions", () => {
   const dir = mkdtempSync(join(tmpdir(), "clawsweeper-fanout-"));
   const logPath = join(dir, "gh.log");
-  const cursorPath = join(dir, "cursor.json");
   const ghPath = join(dir, "gh.js");
   writeFileSync(
     ghPath,
@@ -335,8 +336,6 @@ process.exit(2);
       "hot-intake",
       "--limit",
       "2",
-      "--cursor-path",
-      cursorPath,
       "--repo",
       "openclaw/clawsweeper",
     ],
@@ -394,10 +393,88 @@ test("target fanout selection advances cursor with wraparound", () => {
   });
 });
 
-test("target fanout CLI lists repos and dispatches selected workflow runs", () => {
+test("target fanout advances across canonical cursor-store cycles", async () => {
+  let stored = { next_cursor: 0, revision: 0, updated_at: null as string | null };
+  const requests: Array<{ method: string; body: string; signature: string }> = [];
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    const method = String(init?.method || "GET");
+    const body = String(init?.body || "");
+    const signature = new Headers(init?.headers).get("x-clawsweeper-exact-review-signature")!;
+    requests.push({ method, body, signature });
+    if (method === "PUT") {
+      const update = JSON.parse(body) as { next_cursor: number; expected_revision: number };
+      assert.equal(update.expected_revision, stored.revision);
+      stored = {
+        next_cursor: update.next_cursor,
+        revision: stored.revision + 1,
+        updated_at: "2026-07-30T12:00:00.000Z",
+      };
+    }
+    return Response.json({ ok: true, mode: "hot-intake", ...stored });
+  };
+  const store = {
+    baseUrl: "https://queue.example",
+    webhookSecret: "cursor-secret",
+    mode: "hot-intake" as const,
+    fetchImpl,
+  };
+  const repositories = [
+    { targetRepo: "openclaw/a", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "openclaw/b", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "openclaw/c", defaultBranch: "main", visibility: "PUBLIC" },
+  ];
+
+  const firstCursor = await fetchFanoutCursor(store);
+  const first = selectRepositories(repositories, { limit: 2, cursor: firstCursor.nextCursor });
+  assert.deepEqual(first.repositories, [repositories[0], repositories[1]]);
+  assert.equal((await putFanoutCursor(store, first.cursor, firstCursor.revision)).revision, 1);
+
+  const secondCursor = await fetchFanoutCursor(store);
+  const second = selectRepositories(repositories, { limit: 2, cursor: secondCursor.nextCursor });
+  assert.deepEqual(second.repositories, [repositories[2], repositories[0]]);
+  assert.equal((await putFanoutCursor(store, second.cursor, secondCursor.revision)).revision, 2);
+  assert.deepEqual(stored, {
+    next_cursor: 1,
+    revision: 2,
+    updated_at: "2026-07-30T12:00:00.000Z",
+  });
+  for (const request of requests) {
+    assert.equal(
+      request.signature,
+      `sha256=${createHmac("sha256", "cursor-secret").update(request.body).digest("hex")}`,
+    );
+  }
+});
+
+test("target fanout cursor-store outage fails open", async () => {
+  const warnings: string[] = [];
+  const originalError = console.error;
+  console.error = (...values) => warnings.push(values.join(" "));
+  try {
+    const store = {
+      baseUrl: "unavailable",
+      webhookSecret: "cursor-secret",
+      mode: "normal-review" as const,
+    };
+    assert.deepEqual(await loadFanoutCursor(store), {
+      mode: "normal-review",
+      nextCursor: 0,
+      revision: 0,
+      updatedAt: null,
+      loaded: false,
+    });
+    assert.equal(await persistFanoutCursorFailOpen(store, 12, 0), false);
+    assert.equal(warnings.length, 2);
+    assert.match(warnings[0]!, /continuing dispatch from cursor 0/);
+    assert.match(warnings[1]!, /dispatched work remains valid/);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test("normal target fanout dispatches even when canonical storage is unavailable", () => {
   const dir = mkdtempSync(join(tmpdir(), "clawsweeper-fanout-"));
   const logPath = join(dir, "gh.log");
-  const cursorPath = join(dir, "cursor.json");
   const ghPath = join(dir, "gh.js");
   writeFileSync(
     ghPath,
@@ -418,6 +495,13 @@ if (args[0] === "repo" && args[1] === "list") {
   process.stdout.write(JSON.stringify(data));
   process.exit(0);
 }
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({data:{
+    r0:{issues:{totalCount:1},pullRequests:{totalCount:0}},
+    r1:{issues:{totalCount:1},pullRequests:{totalCount:0}}
+  }}));
+  process.exit(0);
+}
 if ((args[0] === "workflow" && args[1] === "run") || (args[0] === "api" && args[1].endsWith("/dispatches"))) process.exit(0);
 process.exit(2);
 `,
@@ -429,11 +513,13 @@ process.exit(2);
     [
       "dist/repair/target-fanout.js",
       "--mode",
-      "hot-intake",
+      "normal-review",
       "--limit",
       "2",
-      "--cursor-path",
-      cursorPath,
+      "--cursor-store-url",
+      "unavailable",
+      "--publish-url",
+      "unavailable",
       "--repo",
       "openclaw/clawsweeper",
     ],
@@ -445,16 +531,21 @@ process.exit(2);
         ...mockGhBinEnv(ghPath),
         GH_TOKEN: "workflow-token",
         CLAWSWEEPER_DISPATCH_TOKEN: "dispatch-token",
+        CLAWSWEEPER_WEBHOOK_SECRET: "cursor-secret",
         CLAWSWEEPER_INVENTORY_TOKEN_OPENCLAW: "inventory-openclaw",
         CLAWSWEEPER_INVENTORY_TOKEN_STEIPETE: "inventory-steipete",
       },
     },
   );
 
-  const summary = JSON.parse(output) as { dispatched: string[]; next_cursor: number };
+  const summary = JSON.parse(output) as {
+    dispatched: string[];
+    next_cursor: number;
+    cursor_persisted: boolean;
+  };
   assert.deepEqual(summary.dispatched, ["openclaw/b", "steipete/a"]);
   assert.equal(summary.next_cursor, 0);
-  assert.match(readFileSync(cursorPath, "utf8"), /"next_cursor": 0/);
+  assert.equal(summary.cursor_persisted, false);
 
   const calls = readFileSync(logPath, "utf8")
     .trim()
@@ -465,24 +556,26 @@ process.exit(2);
     ["inventory-openclaw", "inventory-steipete"],
   );
   assert.deepEqual(
-    calls.filter((call) => call.args[0] === "api").map((call) => call.ghToken),
+    calls
+      .filter((call) => call.args[0] === "api" && call.args[1]?.endsWith("/dispatches"))
+      .map((call) => call.ghToken),
     ["dispatch-token", "dispatch-token"],
   );
   assert.deepEqual(
-    calls.filter((call) => call.args[0] === "api").map((call) => call.args.join(" ")),
+    calls
+      .filter((call) => call.args[0] === "api" && call.args[1]?.endsWith("/dispatches"))
+      .map((call) => call.args.join(" ")),
     [
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=true -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=true -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=false -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=false -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
     ],
   );
 });
 
-test("target fanout dry-run does not advance cursor", () => {
+test("target fanout dry-run does not persist its selected cursor", () => {
   const dir = mkdtempSync(join(tmpdir(), "clawsweeper-fanout-"));
   const logPath = join(dir, "gh.log");
-  const cursorPath = join(dir, "cursor.json");
   const ghPath = join(dir, "gh.js");
-  writeFileSync(cursorPath, `${JSON.stringify({ next_cursor: 1 }, null, 2)}\n`);
   writeFileSync(
     ghPath,
     `#!/usr/bin/env node
@@ -510,8 +603,8 @@ process.exit(2);
       "hot-intake",
       "--limit",
       "1",
-      "--cursor-path",
-      cursorPath,
+      "--cursor-store-url",
+      "unavailable",
       "--dry-run",
       "--owners",
       "openclaw",
@@ -529,11 +622,10 @@ process.exit(2);
 
   const summary = JSON.parse(output.slice(output.indexOf("{\n"))) as {
     dispatched: string[];
-    cursor_written: boolean;
+    cursor_persisted: boolean;
   };
-  assert.deepEqual(summary.dispatched, ["openclaw/b"]);
-  assert.equal(summary.cursor_written, false);
-  assert.match(readFileSync(cursorPath, "utf8"), /"next_cursor": 1/);
+  assert.deepEqual(summary.dispatched, ["openclaw/a"]);
+  assert.equal(summary.cursor_persisted, false);
   const calls = readFileSync(logPath, "utf8")
     .trim()
     .split("\n")

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -8,6 +8,7 @@ type WorkflowStep = {
   name?: string;
   uses?: string;
   run?: string;
+  "continue-on-error"?: boolean;
   env?: Record<string, unknown>;
   with?: Record<string, unknown>;
 };
@@ -49,6 +50,7 @@ test("every state hydration uses the canonical Worker with an explicit git-state
       ".github/workflows/exact-review-batch-publish.yml:publish",
       ".github/workflows/sweep.yml:event-review-apply",
       ".github/workflows/sweep.yml:event-review-publish",
+      ".github/workflows/sweep.yml:target-fanout",
     ],
   );
 });
@@ -153,7 +155,55 @@ test("all remaining git publishers join setup-state and receive a step-scoped co
       }
     }
   }
-  assert.equal(publishers, 24, "git publisher count is an audited invariant");
+  assert.equal(publishers, 23, "git publisher count is an audited invariant");
+});
+
+test("post-side-effect git bookkeeping is non-fatal while durability fences stay strict", () => {
+  const documents = new Map(workflows().map(({ file, workflow }) => [file, workflow]));
+  const step = (file: string, job: string, name: string) => {
+    const found = documents
+      .get(file)
+      ?.jobs?.[job]?.steps?.find((candidate) => candidate.name === name);
+    assert.ok(found, `${file}:${job}:${name}`);
+    return found;
+  };
+
+  for (const [file, job, name] of [
+    [".github/workflows/spam-scanner.yml", "scan", "Commit spam scanner audit"],
+    [
+      ".github/workflows/repair-conflict-self-heal.yml",
+      "self-heal",
+      "Commit conflict self-heal ledger",
+    ],
+    [".github/workflows/repair-self-heal.yml", "self-heal", "Commit self-heal ledger"],
+    [".github/workflows/repair-finalize-open-prs.yml", "finalize", "Commit finalizer ledger"],
+    [".github/workflows/sweep.yml", "retry-failed-reviews", "Publish failed-review retry state"],
+    [".github/workflows/sweep.yml", "apply-existing", "Retry final apply status publication"],
+  ]) {
+    assert.equal(step(file, job, name)["continue-on-error"], true, `${file}:${job}:${name}`);
+  }
+
+  for (const [file, job, name] of [
+    [
+      ".github/workflows/repair-comment-router.yml",
+      "route-comments",
+      "Commit comment router ledger",
+    ],
+    [".github/workflows/repair-commit-finding-intake.yml", "intake", "Commit intake ledger"],
+    [".github/workflows/repair-issue-implementation-intake.yml", "intake", "Commit intake ledger"],
+    [".github/workflows/repair-publish-results.yml", "publish", "Commit result ledger"],
+  ]) {
+    assert.notEqual(step(file, job, name)["continue-on-error"], true, `${file}:${job}:${name}`);
+  }
+
+  assert.match(
+    readFileSync("scripts/apply-workflow-helpers.sh", "utf8"),
+    /Operational state publish failed.*Canonical work remains valid/,
+  );
+  assert.match(
+    readFileSync(".github/workflows/proof-nudges.yml", "utf8"),
+    /Proof cursor publish failed.*Proof handling completed/,
+  );
 });
 
 test("every immutable action-event publisher targets R2 without a state-repo token", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1522,6 +1522,27 @@ test("apply checkpoints split record tuples from auxiliary state", () => {
     { encoding: "utf8" },
   );
   assert.equal(failedOutput.trim(), "normal");
+
+  const auxiliaryFailure = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'publish_changes_with_strategy() { printf "%s\\n" "$1"; [ "$1" != theirs ]; }',
+        'TARGET_REPO="openclaw/openclaw"',
+        'publish_changes "apply checkpoint" records apply-report.json results/apply-cursors 2>&1',
+        'printf "exit=%s\\n" "$?"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+  assert.deepEqual(auxiliaryFailure.trim().split("\n"), [
+    "normal",
+    "theirs",
+    "::warning title=Operational state publish failed::Canonical work remains valid; continuing after best-effort Git bookkeeping failed: apply checkpoint",
+    "exit=0",
+  ]);
 });
 
 test("best-effort apply status publishes one sparse-safe file without noisy restore", () => {
@@ -2596,10 +2617,25 @@ test("fleet coverage publishes live open inventory to the dashboard worker", () 
   const workflow = readText(".github/workflows/sweep.yml");
   const coverageStep = workflow.slice(
     workflow.indexOf("- name: Summarize trailing weekly review coverage"),
-    workflow.indexOf("\n      - name: Publish fanout cursor"),
+    workflow.indexOf("\n  plan:"),
   );
   assert.match(coverageStep, /CLAWSWEEPER_WEBHOOK_SECRET/);
   assert.match(coverageStep, /--publish-url "\$REVIEW_COVERAGE_URL"/);
+});
+
+test("target fanout uses the canonical cursor store without a git publisher", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const fanoutBlock = workflow.slice(
+    workflow.indexOf("\n  target-fanout:"),
+    workflow.indexOf("\n  plan:"),
+  );
+
+  assert.match(fanoutBlock, /hydrate-git-state: "false"/);
+  assert.match(fanoutBlock, /--cursor-store-url "\$REVIEW_COVERAGE_URL"/);
+  assert.doesNotMatch(fanoutBlock, /Create state token/);
+  assert.doesNotMatch(fanoutBlock, /repair:publish-main/);
+  assert.doesNotMatch(fanoutBlock, /results\/target-fanout-cursors/);
+  assert.doesNotMatch(workflow, /Publish fanout cursor/);
 });
 
 test("review git info follows checked-out target branch", () => {
@@ -3002,6 +3038,7 @@ test("sweep issue and PR event reviews and target fanout avoid storm amplificati
     /FANOUT_LIMIT: \$\{\{ github\.event\.schedule == '41 \* \* \* \*' && '12' \|\| \(github\.event\.schedule == '37 \*\/6 \* \* \*' && '12' \|\| '20'\) \}\}/,
   );
   assert.match(fanoutBlock, /Summarize trailing weekly review coverage/);
+  assert.match(fanoutBlock, /--cursor-store-url "\$REVIEW_COVERAGE_URL"/);
   assert.match(fanoutBlock, /--publish-url "\$REVIEW_COVERAGE_URL"/);
   assert.match(fanoutBlock, /target-fanout -- coverage --window-days 7/);
   assert.match(fanoutBlock, /GITHUB_STEP_SUMMARY/);


### PR DESCRIPTION
## Summary

- move the per-mode target-fanout cursor from `clawsweeper-state` into authenticated ExactReviewQueue Durable Object KV
- expose HMAC-authenticated `GET`/`PUT /internal/state/cursors/<mode>` with optimistic monotonic revisions
- make cursor reads, writes, and live-inventory publication fail open so canonical-store trouble never blocks repository dispatch
- remove the fanout job's state token, Git-state checkout, and `repair:publish-main` cursor step
- audit the remaining operational Git writers and make post-side-effect bookkeeping non-fatal while preserving strict pre-dispatch durability fences

## Root cause

The scheduled fanout dispatched its selected repositories and then ran a mandatory Git publication for `results/target-fanout-cursors/**`. Run https://github.com/openclaw/clawsweeper/actions/runs/30533320020 reached that final step, but GitHub rejected the `clawsweeper-state` push with `fatal error in commit_refs`. The workflow therefore left the previous cursor in Git. Every later cycle hydrated that same cursor and selected the same head-of-list repositories, so nominal queue capacity did not translate into fleet coverage.

The cursor is now a small Durable Object record keyed by mode. A write includes the revision read before dispatch; a stale writer receives `409 fanout_cursor_revision_conflict` instead of silently overwriting a newer cursor. If either read or write fails, fanout emits a prominent warning and continues. Dispatched work remains valid even when cursor persistence is unavailable.

## Remaining `clawsweeper-state` writers

| Surface | Change in this PR | Failure policy after this PR |
| --- | --- | --- |
| Target-fanout cursors | Converted to ExactReviewQueue Durable Object KV | No Git writer remains |
| Sweep/review/apply/audit dashboard status and auxiliary apply reports/cursors | Left in Git for now | Best-effort after canonical publication or GitHub mutation |
| Proof-nudge and bot-proof cursors | Left in Git for now | Best-effort after proof handling |
| Spam, self-heal, conflict-self-heal, finalizer, and failed-review retry bookkeeping | Left in Git for now | Step-level non-fatal publication |
| Comment-router `jobs/**` and command ledger | Left in Git | Strict: publication is the durability fence before retry dispatch |
| Commit/issue implementation intake `jobs/**` and `results/**` | Left in Git | Strict: publication owns durable intake state |
| Cluster result `jobs/**`, `results/**`, `notifications/**`, and report state | Left in Git | Strict dedicated publisher so failure remains visible and retryable |
| State-history compaction | Left in Git | Strict maintenance-only writer |

Yes, writers to `openclaw/clawsweeper-state` still remain, so that repository cannot be archived yet. This PR removes the live fanout dependency that is blocking fleet coverage, but the strict rows above still need canonical owners before archival.

## Proof

- `node --test test/repair/target-fanout.test.ts test/state-writer-workflow.test.ts test/sweep-workflow.test.ts test/dashboard-worker.test.ts` — 369 passed
- `pnpm run format:check` — clean
- `pnpm run build:all` — clean
- `pnpm run lint` — all four linters clean
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings

`pnpm run check` passed static checks, formatting, builds, lint, and coverage thresholds, but the full macOS run still exits on five unchanged Linux Landlock containment tests. Their generated Python runtime resolves `libc.capset`, which is unavailable on macOS; this branch does not touch that runtime or test file.

## Coverage trajectory

With 138 configured repositories, the 20-repository hot cursor can traverse the fleet in seven 15-minute cycles (about 105 minutes), and the 12-repository normal cursor can traverse it in 12 hourly cycles. Normal fanout can again offer its configured 600 review candidates per hour instead of repeatedly feeding the same repositories. At the observed 127 completed reviews/hour, a static 3,260-item untracked backlog has an ideal drain time of roughly 26 hours; real convergence will vary with new intake, eligible open-item distribution, and queue health.

## Deployment

The dashboard Worker must be redeployed so the new Durable Object endpoint is live. Until that redeploy, the merged workflow would still dispatch selected repositories and warn instead of failing, but cursor rotation would restart from the safe default each cycle and would not persist.
