### PR TITLE
fix(scheduler): scale per-cycle candidate volume

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -2819,6 +2819,7 @@ jobs:
           active_background_workers="$(( $(active_run_count ".github/workflows/commit-review.yml") * commit_page_size + $(active_sweep_background_workers) ))"
           exact_item="${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}"
           pressure_level="unknown"
+          queue_candidate_capacity="50"
           hot_intake_unpressured="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           normal_unpressured="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers")"
           if [ -z "$exact_item" ]; then
@@ -2828,11 +2829,17 @@ jobs:
             if ! pressure_level="$(printf '%s' "$pressure_json" | jq -er '.level | select(. == "none" or . == "soft" or . == "hard" or . == "unknown")' 2>/dev/null)"; then
               pressure_level="unknown"
             fi
+            if ! queue_candidate_capacity="$(printf '%s' "$pressure_json" | jq -er '.availableCandidateCapacity | select(type == "number" and floor == . and . >= 0)' 2>/dev/null)"; then
+              queue_candidate_capacity="50"
+            fi
+            if [ "$queue_candidate_capacity" -lt 1 ]; then
+              queue_candidate_capacity="1"
+            fi
           fi
           hot_intake_shards="$(worker_limit hot_intake --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"
           normal_shards="$(worker_limit normal_review --active-critical "$active_critical_workers" --active-background "$active_background_workers" --pressure-level "$pressure_level")"
           if [ -z "$exact_item" ]; then
-            pressure_numbers="$(printf '%s' "$pressure_json" | jq -r 'if .ok then "pending=\(.pendingCount), oldest=\((.oldestPendingAgeMs / 3600000 * 10 | round) / 10)h" else "unavailable=\(.reason)" end' 2>/dev/null || printf 'unavailable=probe_failed')"
+            pressure_numbers="$(printf '%s' "$pressure_json" | jq -r 'if .ok then "pending=\(.pendingCount), active=\(.activeCount // "unknown")/\(.capacity // "unknown"), candidate-capacity=\(.availableCandidateCapacity // "unknown"), oldest=\((.oldestPendingAgeMs / 3600000 * 10 | round) / 10)h" else "unavailable=\(.reason)" end' 2>/dev/null || printf 'unavailable=probe_failed')"
             echo "queue pressure: $pressure_level ($pressure_numbers) — hot_intake $hot_intake_unpressured->$hot_intake_shards, normal_review $normal_unpressured->$normal_shards"
           fi
           hot_intake="${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.hot_intake == 'true') || (github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'true' || 'false' }}"
@@ -2875,9 +2882,20 @@ jobs:
           fi
           if [ "$queue_feed" = "true" ] && [ -z "$exact_item" ]; then
             # The Durable Object turns every selected item into an independent exact-review
-            # workflow. Plan a bounded feed batch here; the Worker owns the global 600/hour
-            # admission target and queue backpressure across overlapping target sweeps.
-            batch_size="50"
+            # workflow. Direct schedules use current free queue capacity; target fanout may
+            # request a smaller backlog-weighted share. The Worker remains the final owner of
+            # the fleet-wide 600/hour admission target and queue backpressure.
+            requested_batch_size="${{ github.event.client_payload.batch_size || '' }}"
+            if ! [[ "$requested_batch_size" =~ ^[0-9]+$ ]] || [ "$requested_batch_size" -lt 1 ]; then
+              requested_batch_size="$queue_candidate_capacity"
+            fi
+            if [ "$requested_batch_size" -gt "$queue_candidate_capacity" ]; then
+              requested_batch_size="$queue_candidate_capacity"
+            fi
+            if [ "$requested_batch_size" -gt "$hard_shard_cap" ]; then
+              requested_batch_size="$hard_shard_cap"
+            fi
+            batch_size="$requested_batch_size"
             shard_count="1"
             min_active_shards="0"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Sized scheduled candidate batches from live free review capacity, apportioned fleet fanout by untracked backlog while retaining round-robin fairness, and skipped empty repositories before both normal and hot fanout so a dominant backlog can fill idle review slots without starving smaller targets.
 - Isolated review admission, pressure, and backpressure accounting from the publication lane so stale publication work cannot throttle review throughput, made top-level queue health review-specific, and added durable shed counters by reason.
 - Made exact-review reservation races and mid-generation supersession successful no-ops with bounded jittered retries, surfaced provider throttling separately from content/output failures, prioritized never-reviewed open items before oldest-reviewed canonical refreshes, and based dashboard coverage on signed live open-item inventory with explicit expired, untracked, protected, and unmanaged cohorts.
 - Routed scheduled review through the durable exact-review queue, raised each target plan from one to 50 candidates, and added oldest-age funnel telemetry plus a fleet-wide 600-review/hour admission budget with duplicate, backlog, and lease-safe backpressure.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -344,6 +344,10 @@ hot intake `14`, and commit review `2`. Existing repair lanes keep their
   the scheduled remainder is split 35/65 between hot intake and normal backfill.
 - `EXACT_REVIEW_TARGET_BURST` bounds the scheduled admission burst; the
   default is 50 and uses the same lane split.
+- Scheduled planners subtract active and pending review work from the 128-slot
+  review capacity before selecting candidates. Target fanout gives every
+  cursor-selected repository a one-candidate floor, then apportions the
+  remaining free capacity by untracked backlog.
 - `EXACT_REVIEW_HEARTBEAT_GRACE_MS` overrides the 1,200,000 ms exact-review worker heartbeat
   grace. It is clamped to at least 420,000 ms so a configured grace can never dip
   near the one-minute worker heartbeat interval during scheduler or network stalls.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -146,10 +146,12 @@ from a safe default; cursor persistence failure after dispatch never fails the
 productive lane.
 
 Normal fanout refreshes the same signed live-open inventory consumed by
-`GET /api/review-coverage`, skips repositories with no open items, and visits
-repositories whose live count exceeds their canonical-record count before
-tracked-only repositories. The cursor still rotates within that bounded set;
-one large repository does not receive multiple slots in one fanout step.
+`GET /api/review-coverage`, and both normal and hot fanout skip repositories
+with no open items. Normal fanout reserves a rotating slot for every selected
+repository, keeps the largest untracked backlog in each cycle, and apportions
+the remaining candidate volume by backlog share. The rotating slice is
+dispatched first, so one large repository can fill otherwise-idle capacity
+without permanently consuming smaller repositories' scheduled-feed budget.
 
 The six-hour audit fanout also writes a GitHub Actions summary with canonical
 open-item reports reviewed in the trailing seven days versus batched live open
@@ -656,9 +658,10 @@ can be newer than local files.
 
 To change review spend, set
 `EXACT_REVIEW_TARGET_RATE_PER_HOUR`; the Worker applies the fleet-wide rate
-while the workflow's 20-item plan batch keeps enough candidates available. To
-change manual normal Codex sessions, update the worker limits and workflow
-defaults together.
+while scheduled planners size their candidate batch to free review capacity.
+Target fanout divides that capacity by untracked backlog after reserving its
+round-robin fairness slice. To change manual normal Codex sessions, update the
+worker limits and workflow defaults together.
 
 To change review cadence, update the cadence constants and the scheduler bucket
 logic in `src/clawsweeper.ts`, then update dashboard labels and this document.

--- a/src/queue-pressure.ts
+++ b/src/queue-pressure.ts
@@ -11,6 +11,9 @@ export type ExactReviewQueuePressure =
       ok: true;
       pendingCount: number;
       oldestPendingAgeMs: number;
+      activeCount?: number;
+      capacity?: number;
+      availableCandidateCapacity?: number;
     }
   | {
       ok: false;
@@ -50,11 +53,25 @@ export async function fetchExactReviewQueuePressure({
         ? reviewLane.oldest_pending_age_seconds
         : body.oldest_pending_age_seconds;
     if (!isNonNegativeInteger(pendingCount)) return malformedPressure();
+    const capacityFields =
+      reviewLane &&
+      isNonNegativeInteger(reviewLane.active) &&
+      isNonNegativeInteger(reviewLane.capacity)
+        ? {
+            activeCount: reviewLane.active,
+            capacity: reviewLane.capacity,
+            availableCandidateCapacity: Math.max(
+              0,
+              reviewLane.capacity - reviewLane.active - pendingCount,
+            ),
+          }
+        : {};
     if (pendingCount === 0) {
       return {
         ok: true,
         pendingCount,
         oldestPendingAgeMs: 0,
+        ...capacityFields,
       };
     }
     // A null age with a positive backlog is inconsistent data — fail open
@@ -67,6 +84,7 @@ export async function fetchExactReviewQueuePressure({
       ok: true,
       pendingCount,
       oldestPendingAgeMs,
+      ...capacityFields,
     };
   } catch (error) {
     return {

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveCommand } from "../command.js";
+import { fetchExactReviewQueuePressure } from "../queue-pressure.js";
 import { parseArgs, repoRoot } from "./lib.js";
 
 type JsonRecord = Record<string, unknown>;
@@ -71,10 +72,14 @@ export interface ReviewPlanningRepository extends SelectedRepository {
   untrackedOpen: number;
 }
 
-interface SelectionResult {
-  repositories: SelectedRepository[];
+interface SelectionResult<RepositoryT extends SelectedRepository = SelectedRepository> {
+  repositories: RepositoryT[];
   cursor: number;
   total: number;
+}
+
+export interface ReviewFanoutRepository extends ReviewPlanningRepository {
+  candidateCapacity: number;
 }
 
 export interface FanoutCursorSnapshot {
@@ -160,40 +165,61 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
   }
 
   let planningRepositories: readonly SelectedRepository[] = repositories;
-  if (mode === "normal-review") {
+  let reviewCandidateCapacity: number | null = null;
+  if (mode === "normal-review" || mode === "hot-intake") {
     const openCounts = loadRepositoryOpenCounts(repositories);
     const now = Date.now();
-    const publishUrl = stringArg(args["publish-url"], "");
-    if (publishUrl) {
-      try {
-        await publishReviewCoverageInventory({
-          baseUrl: publishUrl,
-          webhookSecret: stringValue(
-            process.env.CLAWSWEEPER_WEBHOOK_SECRET,
-            "CLAWSWEEPER_WEBHOOK_SECRET",
-          ),
-          snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
-        });
-      } catch (error) {
-        console.error(
-          `[target-fanout] WARNING: live review inventory did not publish; continuing without blocking scheduled fanout work: ${errorMessage(error)}`,
-        );
+    if (mode === "normal-review") {
+      const publishUrl = stringArg(args["publish-url"], "");
+      if (publishUrl) {
+        try {
+          await publishReviewCoverageInventory({
+            baseUrl: publishUrl,
+            webhookSecret: stringValue(
+              process.env.CLAWSWEEPER_WEBHOOK_SECRET,
+              "CLAWSWEEPER_WEBHOOK_SECRET",
+            ),
+            snapshot: reviewCoverageInventorySnapshot(repositories, openCounts, now),
+          });
+        } catch (error) {
+          console.error(
+            `[target-fanout] WARNING: live review inventory did not publish; continuing without blocking scheduled fanout work: ${errorMessage(error)}`,
+          );
+        }
       }
+      planningRepositories = reviewPlanningRepositories({ repositories, openCounts });
+    } else {
+      planningRepositories = repositoriesWithOpenItems(repositories, openCounts);
     }
-    planningRepositories = reviewPlanningRepositories({ repositories, openCounts });
   }
   const cursor = await loadFanoutCursor({
     baseUrl: options.cursorStoreUrl,
     webhookSecret: process.env.CLAWSWEEPER_WEBHOOK_SECRET ?? "",
     mode,
   });
-  const selection = selectRepositories(planningRepositories, {
-    limit: options.limit,
-    cursor: cursor.nextCursor,
-  });
+  let selection: SelectionResult;
+  if (mode === "normal-review") {
+    const fallbackCapacity =
+      SCHEDULED_REVIEW_PLAN_BATCH_SIZE * Math.min(options.limit, planningRepositories.length);
+    const pressure = await fetchExactReviewQueuePressure({ queueUrl: options.cursorStoreUrl });
+    reviewCandidateCapacity =
+      pressure.ok && pressure.availableCandidateCapacity !== undefined
+        ? pressure.availableCandidateCapacity
+        : fallbackCapacity;
+    selection = planReviewFanout(planningRepositories as readonly ReviewPlanningRepository[], {
+      limit: options.limit,
+      cursor: cursor.nextCursor,
+      candidateCapacity: reviewCandidateCapacity,
+    });
+  } else {
+    selection = selectRepositories(planningRepositories, {
+      limit: options.limit,
+      cursor: cursor.nextCursor,
+    });
+  }
 
   const commands = selection.repositories.map((repository) =>
-    workflowDispatchArgs(repository, options),
+    workflowDispatchArgs(repository, options, candidateCapacityFor(repository)),
   );
 
   if (args._[0] === "plan") {
@@ -234,11 +260,26 @@ export async function runTargetFanout(argv: string[]): Promise<void> {
         dry_run: options.dryRun,
         cursor_loaded: cursor.loaded,
         cursor_persisted: cursorPersisted,
+        review_candidate_capacity: reviewCandidateCapacity,
+        candidate_batches: Object.fromEntries(
+          selection.repositories.flatMap((repository) =>
+            candidateCapacityFor(repository) === undefined
+              ? []
+              : [[repository.targetRepo, candidateCapacityFor(repository)] as const],
+          ),
+        ),
       },
       null,
       2,
     )}\n`,
   );
+}
+
+function candidateCapacityFor(repository: SelectedRepository): number | undefined {
+  if (!("candidateCapacity" in repository)) return undefined;
+  return typeof repository.candidateCapacity === "number"
+    ? repository.candidateCapacity
+    : undefined;
 }
 
 export function readInventoryConfig(
@@ -295,22 +336,32 @@ export function filterEligibleRepositories(
     }));
 }
 
-export function selectRepositories(
-  repositories: readonly SelectedRepository[],
+export function selectRepositories<RepositoryT extends SelectedRepository>(
+  repositories: readonly RepositoryT[],
   options: { limit: number; cursor: number },
-): SelectionResult {
+): SelectionResult<RepositoryT> {
   if (repositories.length === 0) return { repositories: [], cursor: 0, total: 0 };
   const limit = Math.max(1, Math.min(options.limit, repositories.length));
   const start = normalizeCursor(options.cursor, repositories.length);
-  const selected: SelectedRepository[] = [];
+  const selected: RepositoryT[] = [];
   for (let offset = 0; offset < limit; offset += 1) {
-    selected.push(repositories[(start + offset) % repositories.length] as SelectedRepository);
+    selected.push(repositories[(start + offset) % repositories.length] as RepositoryT);
   }
   return {
     repositories: selected,
     cursor: (start + limit) % repositories.length,
     total: repositories.length,
   };
+}
+
+export function repositoriesWithOpenItems<RepositoryT extends SelectedRepository>(
+  repositories: readonly RepositoryT[],
+  openCounts: ReadonlyMap<string, RepositoryOpenCounts>,
+): RepositoryT[] {
+  return repositories.filter((repository) => {
+    const counts = openCounts.get(repository.targetRepo);
+    return Boolean(counts && counts.issues + counts.pullRequests > 0);
+  });
 }
 
 export function reviewPlanningRepositories(options: {
@@ -349,6 +400,111 @@ export function reviewPlanningRepositories(options: {
         Number(right.untrackedOpen > 0) - Number(left.untrackedOpen > 0) ||
         left.targetRepo.localeCompare(right.targetRepo),
     );
+}
+
+export function planReviewFanout(
+  repositories: readonly ReviewPlanningRepository[],
+  options: { limit: number; cursor: number; candidateCapacity: number },
+): SelectionResult<ReviewFanoutRepository> {
+  if (repositories.length === 0) return { repositories: [], cursor: 0, total: 0 };
+  const limit = Math.max(1, Math.min(options.limit, repositories.length));
+  const dominant = repositories.reduce<ReviewPlanningRepository | null>((largest, repository) => {
+    if (repository.untrackedOpen < 1) return largest;
+    if (!largest || repository.untrackedOpen > largest.untrackedOpen) return repository;
+    if (
+      repository.untrackedOpen === largest.untrackedOpen &&
+      repository.targetRepo.localeCompare(largest.targetRepo) < 0
+    ) {
+      return repository;
+    }
+    return largest;
+  }, null);
+  const fairnessPool = dominant
+    ? repositories.filter((repository) => repository.targetRepo !== dominant.targetRepo)
+    : repositories;
+  const fairnessLimit = dominant ? limit - 1 : limit;
+  const fairness =
+    fairnessLimit > 0 && fairnessPool.length > 0
+      ? selectRepositories(fairnessPool, { limit: fairnessLimit, cursor: options.cursor })
+      : { repositories: [] as ReviewPlanningRepository[], cursor: 0, total: fairnessPool.length };
+  // Dispatch the rotating fairness slice first so a dominant repository cannot
+  // consume every scheduled-feed token before smaller planners reach enqueue.
+  const selected = dominant ? [...fairness.repositories, dominant] : fairness.repositories;
+  const allocations = allocateReviewCandidateCapacity(selected, options.candidateCapacity);
+  return {
+    repositories: selected.map((repository) => ({
+      ...repository,
+      candidateCapacity: allocations.get(repository.targetRepo) ?? 1,
+    })),
+    cursor: fairness.cursor,
+    total: repositories.length,
+  };
+}
+
+export function allocateReviewCandidateCapacity(
+  repositories: readonly ReviewPlanningRepository[],
+  candidateCapacity: number,
+): Map<string, number> {
+  if (repositories.length === 0) return new Map();
+  // One candidate per selected repository is the fairness reservation. If the
+  // live queue has fewer free slots, the bounded over-offer is intentional: the
+  // Worker remains the final admission owner and the cursor still makes progress.
+  const budget = Math.max(repositories.length, Math.floor(Math.max(0, candidateCapacity)));
+  const allocations = new Map(repositories.map((repository) => [repository.targetRepo, 1]));
+  const remainingDemand = new Map(
+    repositories.map((repository) => [
+      repository.targetRepo,
+      Math.max(0, Math.max(1, repository.untrackedOpen) - 1),
+    ]),
+  );
+  let available = budget - repositories.length;
+  while (available > 0) {
+    const active = repositories.filter(
+      (repository) => (remainingDemand.get(repository.targetRepo) ?? 0) > 0,
+    );
+    if (active.length === 0) break;
+    const totalDemand = active.reduce(
+      (total, repository) => total + (remainingDemand.get(repository.targetRepo) ?? 0),
+      0,
+    );
+    const roundCapacity = available;
+    const remainders: Array<{ repository: ReviewPlanningRepository; remainder: number }> = [];
+    let assigned = 0;
+    for (const repository of active) {
+      const demand = remainingDemand.get(repository.targetRepo) ?? 0;
+      const quota = (roundCapacity * demand) / totalDemand;
+      const extra = Math.min(demand, Math.floor(quota));
+      if (extra > 0) {
+        allocations.set(
+          repository.targetRepo,
+          (allocations.get(repository.targetRepo) ?? 0) + extra,
+        );
+        remainingDemand.set(repository.targetRepo, demand - extra);
+        assigned += extra;
+      }
+      remainders.push({ repository, remainder: quota - Math.floor(quota) });
+    }
+    available -= assigned;
+    if (available <= 0) break;
+    remainders.sort(
+      (left, right) =>
+        right.remainder - left.remainder ||
+        right.repository.untrackedOpen - left.repository.untrackedOpen ||
+        left.repository.targetRepo.localeCompare(right.repository.targetRepo),
+    );
+    let remainderAssigned = 0;
+    for (const { repository } of remainders) {
+      if (available <= 0) break;
+      const demand = remainingDemand.get(repository.targetRepo) ?? 0;
+      if (demand <= 0) continue;
+      allocations.set(repository.targetRepo, (allocations.get(repository.targetRepo) ?? 0) + 1);
+      remainingDemand.set(repository.targetRepo, demand - 1);
+      available -= 1;
+      remainderAssigned += 1;
+    }
+    if (assigned === 0 && remainderAssigned === 0) break;
+  }
+  return allocations;
 }
 
 function listOwnerRepositories(owner: string): ListedRepository[] {
@@ -391,7 +547,11 @@ function listedRepository(value: unknown, label: string): ListedRepository {
   };
 }
 
-function workflowDispatchArgs(repository: SelectedRepository, options: FanoutOptions): string[] {
+function workflowDispatchArgs(
+  repository: SelectedRepository,
+  options: FanoutOptions,
+  candidateCapacity = SCHEDULED_REVIEW_PLAN_BATCH_SIZE,
+): string[] {
   if (options.mode !== "audit") {
     return [
       "api",
@@ -405,7 +565,7 @@ function workflowDispatchArgs(repository: SelectedRepository, options: FanoutOpt
       "-f",
       `client_payload[hot_intake]=${options.mode === "hot-intake" ? "true" : "false"}`,
       "-f",
-      `client_payload[batch_size]=${SCHEDULED_REVIEW_PLAN_BATCH_SIZE}`,
+      `client_payload[batch_size]=${candidateCapacity}`,
       "-f",
       "client_payload[shard_count]=1",
     ];

--- a/test/queue-pressure.test.ts
+++ b/test/queue-pressure.test.ts
@@ -122,6 +122,32 @@ test("queue pressure uses review thresholds and ignores independent publication 
   assert.deepEqual(emptyReviewLane, { ok: true, pendingCount: 0, oldestPendingAgeMs: 0 });
 });
 
+test("queue pressure exposes free candidate capacity after active and pending review work", async () => {
+  const result = await fetchExactReviewQueuePressure({
+    queueUrl: "https://clawsweeper.example",
+    fetchImpl: async () =>
+      Response.json({
+        lanes: {
+          review: {
+            pending: 5,
+            active: 3,
+            capacity: 128,
+            oldest_pending_age_seconds: 30,
+          },
+        },
+      }),
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    pendingCount: 5,
+    oldestPendingAgeMs: 30_000,
+    activeCount: 3,
+    capacity: 128,
+    availableCandidateCapacity: 120,
+  });
+});
+
 test("queue pressure fetch fails closed for background admission on errors, timeouts, and malformed bodies", async () => {
   const failed = await fetchExactReviewQueuePressure({
     queueUrl: "https://clawsweeper.example",

--- a/test/repair/target-fanout.test.ts
+++ b/test/repair/target-fanout.test.ts
@@ -8,16 +8,19 @@ import test from "node:test";
 
 import {
   SCHEDULED_REVIEW_PLAN_BATCH_SIZE,
+  allocateReviewCandidateCapacity,
   defaultLimit,
   fetchFanoutCursor,
   filterEligibleRepositories,
   loadFanoutCursor,
   persistFanoutCursorFailOpen,
+  planReviewFanout,
   publishReviewCoverageInventory,
   putFanoutCursor,
   renderFleetReviewCoverage,
   reviewCoverageInventorySnapshot,
   reviewPlanningRepositories,
+  repositoriesWithOpenItems,
   selectRepositories,
   summarizeFleetReviewCoverage,
   type InventoryConfig,
@@ -40,17 +43,8 @@ test("target fanout defaults match the scheduled cursor batch sizes", () => {
   assert.equal(defaultLimit("audit"), "12");
 });
 
-test("scheduled normal fanout can offer the configured hourly review target", () => {
-  const wrangler = readFileSync("dashboard/wrangler.toml", "utf8");
-  const configuredRate = Number(
-    wrangler.match(/^EXACT_REVIEW_TARGET_RATE_PER_HOUR = "(\d+)"$/m)?.[1],
-  );
-  const offersPerHour = SCHEDULED_REVIEW_PLAN_BATCH_SIZE * Number(defaultLimit("normal-review"));
-
-  assert.equal(configuredRate, 600);
+test("scheduled fanout retains a bounded fallback when queue capacity is unavailable", () => {
   assert.equal(SCHEDULED_REVIEW_PLAN_BATCH_SIZE, 50);
-  assert.equal(offersPerHour, 600);
-  assert.ok(offersPerHour >= configuredRate);
 });
 
 test("normal fanout prioritizes repositories with untracked live items and skips empty repos", () => {
@@ -105,6 +99,75 @@ test("normal fanout prioritizes repositories with untracked live items and skips
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("review fanout gives a single repository enough candidates to saturate free capacity", () => {
+  const huge = planningRepository("openclaw/openclaw", 3_084);
+  const plan = planReviewFanout([huge], {
+    limit: 12,
+    cursor: 0,
+    candidateCapacity: 128,
+  });
+
+  assert.equal(plan.repositories.length, 1);
+  assert.equal(plan.repositories[0]?.targetRepo, huge.targetRepo);
+  assert.equal(plan.repositories[0]?.candidateCapacity, 128);
+  assert.deepEqual(allocateReviewCandidateCapacity([huge], 128), new Map([[huge.targetRepo, 128]]));
+});
+
+test("dominant review backlog stays hot while all other 137 repositories rotate without starvation", () => {
+  const dominant = planningRepository("openclaw/openclaw", 3_084);
+  const small = Array.from({ length: 137 }, (_, index) =>
+    planningRepository(`openclaw/small-${String(index).padStart(3, "0")}`, 1),
+  );
+  const repositories = [dominant, ...small];
+  const seenSmall = new Set<string>();
+  let cursor = 0;
+  const cyclesNeeded = Math.ceil(small.length / (Number(defaultLimit("normal-review")) - 1));
+
+  for (let cycle = 0; cycle < cyclesNeeded; cycle += 1) {
+    const plan = planReviewFanout(repositories, {
+      limit: Number(defaultLimit("normal-review")),
+      cursor,
+      candidateCapacity: 128,
+    });
+    cursor = plan.cursor;
+    const dominantDispatch = plan.repositories.find(
+      (repository) => repository.targetRepo === dominant.targetRepo,
+    );
+    assert.ok(dominantDispatch);
+    assert.equal(dominantDispatch.candidateCapacity, 117);
+    for (const repository of plan.repositories) {
+      if (repository.targetRepo === dominant.targetRepo) continue;
+      seenSmall.add(repository.targetRepo);
+      assert.equal(repository.candidateCapacity, 1);
+    }
+    assert.equal(
+      plan.repositories.reduce((total, repository) => total + repository.candidateCapacity, 0),
+      128,
+    );
+  }
+
+  assert.equal(cyclesNeeded, 13);
+  assert.equal(seenSmall.size, 137);
+  assert.ok(cyclesNeeded < 7 * 24, "the hourly cursor covers every small repo within a week");
+});
+
+test("hot fanout drops repositories with no live open items before cursor selection", () => {
+  const repositories = [
+    { targetRepo: "openclaw/empty", defaultBranch: "main", visibility: "PUBLIC" },
+    { targetRepo: "openclaw/live", defaultBranch: "main", visibility: "PUBLIC" },
+  ];
+  assert.deepEqual(
+    repositoriesWithOpenItems(
+      repositories,
+      new Map([
+        ["openclaw/empty", { issues: 0, pullRequests: 0 }],
+        ["openclaw/live", { issues: 1, pullRequests: 0 }],
+      ]),
+    ),
+    [repositories[1]],
+  );
 });
 
 test("target fanout summarizes trailing weekly coverage from canonical open records", () => {
@@ -258,6 +321,10 @@ if (args[0] === "repo" && args[1] === "list") {
   ]));
   process.exit(0);
 }
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({data:{r0:{issues:{totalCount:1},pullRequests:{totalCount:0}}}}));
+  process.exit(0);
+}
 if (args[0] === "api" && args[1].endsWith("/dispatches")) process.exit(0);
 process.exit(2);
 `,
@@ -320,6 +387,13 @@ if (args[0] === "repo" && args[1] === "list") {
     ? [{nameWithOwner:"openclaw/B",isArchived:false,isDisabled:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}}]
     : [{nameWithOwner:"steipete/A",isArchived:false,isDisabled:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}}];
   process.stdout.write(JSON.stringify(data));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({data:{
+    r0:{issues:{totalCount:1},pullRequests:{totalCount:0}},
+    r1:{issues:{totalCount:1},pullRequests:{totalCount:0}}
+  }}));
   process.exit(0);
 }
 if (args[0] === "api" && args[1].endsWith("/dispatches")) process.exit(0);
@@ -542,10 +616,14 @@ process.exit(2);
     dispatched: string[];
     next_cursor: number;
     cursor_persisted: boolean;
+    review_candidate_capacity: number;
+    candidate_batches: Record<string, number>;
   };
-  assert.deepEqual(summary.dispatched, ["openclaw/b", "steipete/a"]);
+  assert.deepEqual(summary.dispatched, ["steipete/a", "openclaw/b"]);
   assert.equal(summary.next_cursor, 0);
   assert.equal(summary.cursor_persisted, false);
+  assert.equal(summary.review_candidate_capacity, 100);
+  assert.deepEqual(summary.candidate_batches, { "steipete/a": 1, "openclaw/b": 1 });
 
   const calls = readFileSync(logPath, "utf8")
     .trim()
@@ -566,8 +644,8 @@ process.exit(2);
       .filter((call) => call.args[0] === "api" && call.args[1]?.endsWith("/dispatches"))
       .map((call) => call.args.join(" ")),
     [
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=false -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
-      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=false -f client_payload[batch_size]=50 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=steipete/a -f client_payload[target_branch]=master -f client_payload[hot_intake]=false -f client_payload[batch_size]=1 -f client_payload[shard_count]=1",
+      "api repos/openclaw/clawsweeper/dispatches -f event_type=clawsweeper_target_sweep -f client_payload[target_repo]=openclaw/b -f client_payload[target_branch]=main -f client_payload[hot_intake]=false -f client_payload[batch_size]=1 -f client_payload[shard_count]=1",
     ],
   );
 });
@@ -587,6 +665,13 @@ if (args[0] === "repo" && args[1] === "list") {
     {nameWithOwner:"openclaw/A",isArchived:false,isDisabled:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}},
     {nameWithOwner:"openclaw/B",isArchived:false,isDisabled:false,isFork:false,hasIssuesEnabled:true,visibility:"PUBLIC",defaultBranchRef:{name:"main"}}
   ]));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({data:{
+    r0:{issues:{totalCount:1},pullRequests:{totalCount:0}},
+    r1:{issues:{totalCount:0},pullRequests:{totalCount:0}}
+  }}));
   process.exit(0);
 }
 if ((args[0] === "workflow" && args[1] === "run") || (args[0] === "api" && args[1].endsWith("/dispatches"))) process.exit(0);
@@ -630,7 +715,8 @@ process.exit(2);
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line) as string[]);
-  assert.equal(calls.filter((call) => call[0] === "api").length, 0);
+  assert.equal(calls.filter((call) => call[0] === "api" && call[1] === "graphql").length, 1);
+  assert.equal(calls.filter((call) => call[1]?.endsWith("/dispatches")).length, 0);
 });
 
 function repo(nameWithOwner: string, overrides: Partial<ListedRepository> = {}): ListedRepository {
@@ -643,5 +729,16 @@ function repo(nameWithOwner: string, overrides: Partial<ListedRepository> = {}):
     visibility: "PUBLIC",
     defaultBranch: "main",
     ...overrides,
+  };
+}
+
+function planningRepository(targetRepo: string, untrackedOpen: number) {
+  return {
+    targetRepo,
+    defaultBranch: "main",
+    visibility: "PUBLIC",
+    openItems: untrackedOpen,
+    trackedRecords: 0,
+    untrackedOpen,
   };
 }

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -550,6 +550,25 @@ test("normal scheduling ranks untracked items above stale records, then oldest r
   assert.deepEqual(selectedNumbers(due, 3, now), [1, 3, 2]);
 });
 
+test("one repository's untracked backlog fills the queue-sized candidate limit", () => {
+  const now = Date.parse("2026-07-30T12:00:00Z");
+  const due = Array.from({ length: 3_084 }, (_, index) => ({
+    item: item({
+      number: index + 1,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    }),
+    bucket: "weekly_issue",
+    priority: 6,
+    reviewedAt: 0,
+    nextDueAt: 0,
+  }));
+
+  const selected = selectedNumbers(due, 128, now);
+  assert.equal(selected.length, 128);
+  assert.equal(new Set(selected).size, 128);
+});
+
 test("weekly freshness preselection still fills remaining scheduler capacity", () => {
   const now = Date.parse("2026-06-14T12:00:00Z");
   const due = Array.from({ length: 5 }, (_, index) => ({

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2605,7 +2605,9 @@ test("scheduled reviews feed the durable queue instead of one-item matrix worker
   );
 
   assert.match(modeBlock, /queue_feed=.*clawsweeper_target_sweep/);
-  assert.match(modeBlock, /batch_size="50"[\s\S]*shard_count="1"/);
+  assert.match(modeBlock, /requested_batch_size=.*client_payload\.batch_size/);
+  assert.match(modeBlock, /requested_batch_size="\$queue_candidate_capacity"/);
+  assert.match(modeBlock, /batch_size="\$requested_batch_size"[\s\S]*shard_count="1"/);
   assert.match(enqueueBlock, /repair:scheduled-review-enqueue/);
   assert.match(enqueueBlock, /Scheduled review funnel/);
   assert.match(workflow, /Review scheduled hot item/);
@@ -2881,7 +2883,7 @@ test("target review queues coalesce background work without delaying exact plann
   assert.match(planHeader, /cancel-in-progress: false/);
 });
 
-test("scheduled normal review offers a 50-item queue batch on one planner shard", () => {
+test("scheduled normal review sizes one planner shard to live candidate capacity", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const modeBlock = workflow.slice(
     workflow.indexOf("- id: mode"),
@@ -2889,7 +2891,10 @@ test("scheduled normal review offers a 50-item queue batch on one planner shard"
   );
 
   assert.match(modeBlock, /if \[ "\$queue_feed" = "true" \] && \[ -z "\$exact_item" \]; then/);
-  assert.match(modeBlock, /batch_size="50"[\s\S]*shard_count="1"/);
+  assert.match(modeBlock, /availableCandidateCapacity/);
+  assert.match(modeBlock, /requested_batch_size=.*client_payload\.batch_size/);
+  assert.match(modeBlock, /if \[ "\$requested_batch_size" -gt "\$queue_candidate_capacity" \]/);
+  assert.match(modeBlock, /batch_size="\$requested_batch_size"[\s\S]*shard_count="1"/);
   assert.match(modeBlock, /min_active_shards="0"/);
 });
 


### PR DESCRIPTION
## Problem

Coverage burn stalled even though target fanout and its canonical cursor were healthy. Live run [30540950555](https://github.com/openclaw/clawsweeper/actions/runs/30540950555) showed the `openclaw/openclaw` planner finding 5,189 due candidates but selecting exactly 50: scheduled queue feed forced `batch_size=50` and `shard_count=1`, so `selectDueCandidates` could not offer more than 50 in one cycle. Fleet fanout also assigned that same flat batch to every selected repository and treated untracked backlog as a boolean, so cursor fairness spent equal plan jobs on tiny repositories while the 3,084-item dominant gap could not absorb idle capacity.

The 120-active per-target Worker limit and the legacy 44/89 broad-review shard limits are not the limiter here. Scheduled review uses one planner shard and turns selected candidates into independent exact-review leases.

## Fix

- Read review-lane `active`, `pending`, and `capacity` from the public queue probe and expose `capacity - active - pending` as candidate capacity.
- Size direct scheduled plans to that live free capacity, clamped by any fanout allocation and the existing 128 hard cap. The Worker remains the final 600/hour rate and backpressure owner.
- Keep the largest untracked repository in each normal fanout cycle, reserve the rotating cursor slice for smaller repositories, dispatch that fairness slice first, and divide remaining candidate capacity by untracked backlog.
- Skip zero-open repositories before hot fanout as well as normal fanout.
- Emit total candidate capacity and per-repository batch allocations in fanout output.

With 128 slots and a 4.1-minute mean service time, service capacity is about `128 * 60 / 4.1 = 1,873/hour`; the configured 600/hour feed is the bottleneck and needs only about 41 concurrent workers. A 3,084-item backlog therefore takes about 5.1 hours at the full feed, or 7.9 hours at the current 65% normal-backfill share (390/hour), rather than weeks.

## Proof

- `node --test test/queue-pressure.test.ts test/repair/target-fanout.test.ts test/scheduler-policy.test.ts test/sweep-workflow.test.ts` — 123 passed.
- `pnpm run check` — build, format, static checks, all lint targets, changed coverage, and the full coverage thresholds passed; final command status was red only because five unrelated macOS containment fixtures unconditionally resolve Linux `capset` (`test/repair/process-tree-containment.test.ts`).
- Linux Crabbox fallback was attempted with resolved provider `aws`; the coordinator returned HTTP 401 before lease creation, including the one permitted debug retry, so no lease ID exists.
- `~/.claude/skills/autoreview/scripts/autoreview --mode local` — clean, one pass, correctness 0.96.
- `~/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, one pass, correctness 0.98.

No Worker redeploy is required: this changes the workflow planner/fanout code and consumes queue fields the deployed Worker already publishes. Do not merge until the current-head CI and ClawSweeper review gates are ready.
