### PR TITLE
fix(queue): recover parked scheduled reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Made scheduled exact reviews immediately ready after fleet admission, automatically retried recoverable parked reviews on a bounded 5/10/20-minute cycle, and exposed backoff/park reason counts in queue status and the dashboard.
 - Aligned normal fanout and planner priority with the dashboard's canonical tuple coverage identities, so legacy backfill reports no longer hide untracked open items behind canonical re-reviews.
 - Sized scheduled candidate batches from live free review capacity, apportioned fleet fanout by untracked backlog while retaining round-robin fairness, and skipped empty repositories before both normal and hot fanout so a dominant backlog can fill idle review slots without starving smaller targets.
 - Isolated review admission, pressure, and backpressure accounting from the publication lane so stale publication work cannot throttle review throughput, made top-level queue health review-specific, and added durable shed counters by reason.

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -123,6 +123,17 @@ export type ExactReviewIngress = {
   route: "direct_webhook" | "target_dispatcher";
   fingerprint: string;
 };
+type ExactReviewBackoffReason =
+  | "dispatch_debounce"
+  | "dispatcher_backoff"
+  | "admission_retry"
+  | "review_retry"
+  | "publication_retry";
+type ExactReviewParkedReason =
+  | "dead_letter_capacity"
+  | "dispatch_rejected"
+  | "review_retry_exhausted"
+  | "direct_publication";
 export type ExactReviewQueueItem = {
   key: string;
   decision: ExactReviewDecision;
@@ -134,6 +145,7 @@ export type ExactReviewQueueItem = {
   createdAt: number;
   updatedAt: number;
   nextAttemptAt: number;
+  backoffReason?: ExactReviewBackoffReason;
   attempts: number;
   leaseId?: string;
   leaseRevision?: number;
@@ -146,11 +158,8 @@ export type ExactReviewQueueItem = {
   claimProtocolVersion?: 1 | 2;
   dispatchedAt?: number;
   claimedAt?: number;
-  parkedReason?:
-    | "dead_letter_capacity"
-    | "dispatch_rejected"
-    | "review_retry_exhausted"
-    | "direct_publication";
+  parkedReason?: ExactReviewParkedReason;
+  parkedRecoveryAttempts?: number;
   dispatchFailureStatus?: number;
   dispatchFailureClass?: ExactReviewDispatchFailureClass;
   dispatchFailureAt?: number;
@@ -438,6 +447,9 @@ const EXACT_REVIEW_PUBLICATION_PERMANENT_RETRY_LIMIT = 3;
 const EXACT_REVIEW_PUBLICATION_UNKNOWN_RETRY_LIMIT = 5;
 const EXACT_REVIEW_PUBLICATION_ARTIFACT_RETRY_LIMIT = 3;
 const EXACT_REVIEW_RETRY_LIMIT = 8;
+const EXACT_REVIEW_PARKED_RECOVERY_LIMIT = 3;
+const EXACT_REVIEW_PARKED_RECOVERY_BASE_MS = 5 * 60_000;
+const EXACT_REVIEW_PARKED_RECOVERY_MAX_MS = 30 * 60_000;
 const EXACT_REVIEW_RECONCILE_RUN_LIMIT = 128;
 const EXACT_REVIEW_RECONCILE_CLAIM_MATCH_LIMIT = EXACT_REVIEW_RECONCILE_RUN_LIMIT * 2;
 export const EXACT_REVIEW_RECONCILE_CONCURRENCY = 8;
@@ -1389,18 +1401,22 @@ export class ExactReviewQueue {
             // Immediacy must come from the merged decision: a pending explicit command
             // keeps its command marker through the merge, and a later plain webhook
             // event must not re-debounce it.
-            current.nextAttemptAt = mergeable
-              ? exactReviewQueueDebouncedAttemptAt(
-                  state,
-                  current.decision,
-                  now,
-                  current.createdAt,
-                  this.env,
-                )
-              : exactReviewQueueEnqueueAttemptAt(state, now);
+            Object.assign(
+              current,
+              mergeable
+                ? exactReviewQueueDebouncedAttempt(
+                    state,
+                    current.decision,
+                    now,
+                    current.createdAt,
+                    this.env,
+                  )
+                : exactReviewQueueEnqueueAttempt(state, now),
+            );
             if (mergeable) {
               current.state = "pending";
               current.parkedReason = undefined;
+              current.parkedRecoveryAttempts = 0;
               clearExactReviewDispatchFailure(current);
               current.attempts = 0;
               current.publicationFailureAttempts = 0;
@@ -1448,7 +1464,7 @@ export class ExactReviewQueue {
             revision: this.nextExactReviewItemRevisionSync(key),
             createdAt: now,
             updatedAt: now,
-            nextAttemptAt: exactReviewQueueDebouncedAttemptAt(state, decision, now, now, this.env),
+            ...exactReviewQueueDebouncedAttempt(state, decision, now, now, this.env),
             attempts: 0,
             ...(exactReviewSourceAuthorityWatermark(decision)
               ? { sourceAuthorityWatermark: exactReviewSourceAuthorityWatermark(decision)! }
@@ -2640,6 +2656,7 @@ export class ExactReviewQueue {
       ) {
         return json({ error: "invalid_item_identity" }, 400);
       }
+      const now = Date.now();
       const state = this.readStateSync();
       const matches = Object.values(state.items).filter(
         (item) =>
@@ -2649,6 +2666,11 @@ export class ExactReviewQueue {
         lane: exactReviewQueueLane(item),
         state: item.state,
         parked_reason: item.parkedReason ?? null,
+        parked_recovery_attempts: item.parkedRecoveryAttempts ?? 0,
+        backoff_reason:
+          item.state === "pending" && item.nextAttemptAt > now
+            ? exactReviewQueueBackoffReason(item, state, now)
+            : null,
         revision: item.revision,
         attempts: item.attempts,
         dispatch_failure_status: item.dispatchFailureStatus ?? null,
@@ -2665,7 +2687,7 @@ export class ExactReviewQueue {
           (candidate) =>
             exactReviewQueueLane(candidate) === exactReviewQueueLane(item) &&
             candidate.state === "pending" &&
-            candidate.nextAttemptAt <= Date.now() &&
+            candidate.nextAttemptAt <= now &&
             (candidate.createdAt < item.createdAt ||
               (candidate.createdAt === item.createdAt && candidate.key < item.key)),
         ).length,
@@ -3036,8 +3058,9 @@ export class ExactReviewQueue {
       exactReviewPublicationDispatchLeaseMs(this.env),
       exactReviewHeartbeatGraceMs(this.env),
     );
+    const recoveredParkedSnapshot = recoverParkedExactReviewItems(snapshot, startedAt);
     const expiredSnapshot = expireExactReviewPublicationItems(snapshot, startedAt, this.env);
-    let snapshotChanged = reclaimedSnapshot || expiredSnapshot;
+    let snapshotChanged = reclaimedSnapshot || recoveredParkedSnapshot > 0 || expiredSnapshot;
     if (
       snapshot.dispatcher?.publicationBatchTerminalProbe &&
       Number(snapshot.dispatcher.publicationBatchDispatchPendingUntil || 0) <= startedAt
@@ -3468,8 +3491,9 @@ export class ExactReviewQueue {
           item.decision = exactReviewDecisionAtLiveHead(item.decision, candidate.state.headSha);
           item.revision += 1;
           item.updatedAt = checkedAt;
-          item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(checkedState, checkedAt);
+          Object.assign(item, exactReviewQueueEnqueueAttempt(checkedState, checkedAt));
           item.parkedReason = undefined;
+          item.parkedRecoveryAttempts = 0;
           item.attempts = 0;
           item.publicationFailureAttempts = 0;
           item.reviewFailureAttempts = 0;
@@ -3494,6 +3518,7 @@ export class ExactReviewQueue {
         if (failureAttempts >= EXACT_REVIEW_RETRY_LIMIT) {
           item.state = "parked";
           item.parkedReason = "review_retry_exhausted";
+          item.backoffReason = undefined;
           item.updatedAt = checkedAt;
           continue;
         }
@@ -3501,6 +3526,10 @@ export class ExactReviewQueue {
           exactReviewQueueEnqueueAttemptAt(checkedState, checkedAt),
           checkedAt + exactReviewRetryDelayMs(item.attempts),
         );
+        item.backoffReason =
+          exactReviewQueueEnqueueAttemptAt(checkedState, checkedAt) >= item.nextAttemptAt
+            ? "dispatcher_backoff"
+            : "admission_retry";
         item.updatedAt = checkedAt;
       }
     }
@@ -3695,9 +3724,11 @@ export class ExactReviewQueue {
       if (failure.attempted && failure.failure.scope === "item") {
         item.state = "parked";
         item.parkedReason = "dispatch_rejected";
+        item.backoffReason = undefined;
       } else {
         item.state = "pending";
         item.nextAttemptAt = completedAt;
+        item.backoffReason = undefined;
       }
       item.updatedAt = completedAt;
       currentChanged = true;
@@ -3984,6 +4015,8 @@ export class ExactReviewQueue {
         clearExactReviewLease(item);
         item.state = "pending";
         item.parkedReason = undefined;
+        item.parkedRecoveryAttempts = 0;
+        item.backoffReason = undefined;
         item.attempts = 0;
         item.publicationFailureAttempts = 0;
         item.firstFailureAt = undefined;
@@ -4087,13 +4120,7 @@ export class ExactReviewQueue {
           revision: this.nextExactReviewItemRevisionSync(recovery.key),
           createdAt: now,
           updatedAt: now,
-          nextAttemptAt: exactReviewQueueDebouncedAttemptAt(
-            state,
-            recovery.decision,
-            now,
-            now,
-            this.env,
-          ),
+          ...exactReviewQueueDebouncedAttempt(state, recovery.decision, now, now, this.env),
           attempts: 0,
         };
         this.storage.sql.exec(
@@ -9010,6 +9037,13 @@ function finishExactReviewPublicationQueueItem({
     item.firstFailureAt = undefined;
     item.lastFailureReason = undefined;
     item.nextAttemptAt = Math.max(exactReviewQueueEnqueueAttemptAt(state, now), requestedRetryAt);
+    item.backoffReason =
+      item.nextAttemptAt > now
+        ? requestedRetryAt >= item.nextAttemptAt
+          ? "publication_retry"
+          : "dispatcher_backoff"
+        : undefined;
+    item.parkedRecoveryAttempts = 0;
     item.updatedAt = now;
     return {
       requeued: true,
@@ -9072,6 +9106,7 @@ function finishExactReviewPublicationQueueItem({
     clearExactReviewLease(item);
     item.state = "parked";
     item.parkedReason = "dead_letter_capacity";
+    item.backoffReason = undefined;
     item.attempts = attempt;
     item.publicationFailureAttempts = attempt;
     item.firstFailureAt = firstFailureAt;
@@ -9092,6 +9127,10 @@ function finishExactReviewPublicationQueueItem({
     now + exactReviewPublicationRetryDelayMs(item.key, completion, attempt),
     requestedRetryAt,
   );
+  item.backoffReason =
+    exactReviewQueueEnqueueAttemptAt(state, now) >= item.nextAttemptAt
+      ? "dispatcher_backoff"
+      : "publication_retry";
   item.updatedAt = now;
   return { requeued: true, retried: true, refreshed: false, parked: false };
 }
@@ -9212,6 +9251,7 @@ function finishExactReviewQueueItem(
       if (failureAttempts >= EXACT_REVIEW_RETRY_LIMIT) {
         item.state = "parked";
         item.parkedReason = "review_retry_exhausted";
+        item.backoffReason = undefined;
         item.updatedAt = now;
         return { requeued: false, parked: true };
       }
@@ -9221,11 +9261,16 @@ function finishExactReviewQueueItem(
       now + exactReviewRetryDelayMs(item.attempts),
       hasNewerRevision ? 0 : requestedRetryAt,
     );
+    item.backoffReason =
+      exactReviewQueueEnqueueAttemptAt(state, now) >= item.nextAttemptAt
+        ? "dispatcher_backoff"
+        : "review_retry";
   } else {
-    item.nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+    Object.assign(item, exactReviewQueueEnqueueAttempt(state, now));
     item.attempts = 0;
     item.reviewFailureAttempts = 0;
     item.parkedReason = undefined;
+    item.parkedRecoveryAttempts = 0;
   }
   item.updatedAt = now;
   return { requeued: true, parked: false };
@@ -9358,6 +9403,7 @@ function reclaimExpiredExactReviewLease(
   clearExactReviewLease(item);
   item.state = "pending";
   item.nextAttemptAt = now;
+  item.backoffReason = undefined;
   if (hasNewerRevision) {
     item.attempts = 0;
     item.publicationFailureAttempts = 0;
@@ -9367,6 +9413,48 @@ function reclaimExpiredExactReviewLease(
   }
   item.updatedAt = now;
   return true;
+}
+
+function exactReviewParkedRecoveryAt(item: ExactReviewQueueItem) {
+  if (
+    item.state !== "parked" ||
+    exactReviewQueueIsPublication(item) ||
+    (item.parkedReason !== "dispatch_rejected" && item.parkedReason !== "review_retry_exhausted")
+  ) {
+    return null;
+  }
+  const recoveries = exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts);
+  if (recoveries >= EXACT_REVIEW_PARKED_RECOVERY_LIMIT) return null;
+  const delay = Math.min(
+    EXACT_REVIEW_PARKED_RECOVERY_MAX_MS,
+    EXACT_REVIEW_PARKED_RECOVERY_BASE_MS * 2 ** recoveries,
+  );
+  return item.updatedAt + delay;
+}
+
+function recoverParkedExactReviewItems(state: ExactReviewQueueState, now: number) {
+  let recovered = 0;
+  for (const item of Object.values(state.items)) {
+    const retryAt = exactReviewParkedRecoveryAt(item);
+    if (retryAt === null || retryAt > now) continue;
+    item.state = "pending";
+    item.parkedReason = undefined;
+    item.parkedRecoveryAttempts =
+      exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts) + 1;
+    item.nextAttemptAt = now;
+    item.backoffReason = undefined;
+    item.attempts = 0;
+    item.reviewFailureAttempts = 0;
+    item.updatedAt = now;
+    clearExactReviewDispatchFailure(item);
+    recovered += 1;
+  }
+  return recovered;
+}
+
+function exactReviewParkedRecoveryAttempts(value: unknown) {
+  const attempts = Number(value || 0);
+  return Number.isSafeInteger(attempts) && attempts > 0 ? attempts : 0;
 }
 
 function expireExactReviewPublicationItems(state: ExactReviewQueueState, now: number, env) {
@@ -9410,17 +9498,15 @@ function refreshExactReviewPublicationItem(
       current.decision = mergePendingExactReviewDecision(current.decision, decision);
       current.state = "pending";
       current.parkedReason = undefined;
+      current.parkedRecoveryAttempts = 0;
     } else {
       return;
     }
     current.revision += 1;
     current.updatedAt = now;
-    current.nextAttemptAt = exactReviewQueueDebouncedAttemptAt(
-      state,
-      current.decision,
-      now,
-      current.createdAt,
-      env,
+    Object.assign(
+      current,
+      exactReviewQueueDebouncedAttempt(state, current.decision, now, current.createdAt, env),
     );
     current.attempts = 0;
     current.publicationFailureAttempts = 0;
@@ -9438,8 +9524,17 @@ function refreshExactReviewPublicationItem(
     revision: 1,
     createdAt: now,
     updatedAt: now,
-    nextAttemptAt: exactReviewQueueDebouncedAttemptAt(state, decision, now, now, env),
+    ...exactReviewQueueDebouncedAttempt(state, decision, now, now, env),
     attempts: 0,
+  };
+}
+
+function exactReviewQueueEnqueueAttempt(state: ExactReviewQueueState, now: number) {
+  const nextAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+  return {
+    nextAttemptAt,
+    backoffReason:
+      nextAttemptAt > now ? ("dispatcher_backoff" as ExactReviewBackoffReason) : undefined,
   };
 }
 
@@ -9451,7 +9546,7 @@ function exactReviewQueueEnqueueAttemptAt(state: ExactReviewQueueState, now: num
     : now;
 }
 
-function exactReviewQueueDebouncedAttemptAt(
+function exactReviewQueueDebouncedAttempt(
   state: ExactReviewQueueState,
   decision: ExactReviewDecision,
   now: number,
@@ -9459,16 +9554,27 @@ function exactReviewQueueDebouncedAttemptAt(
   env,
 ) {
   const baseAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
-  if (isImmediateExactReviewDecision(decision)) return baseAttemptAt;
+  if (isImmediateExactReviewDecision(decision)) return exactReviewQueueEnqueueAttempt(state, now);
   const debounceAt = Math.min(
     now + exactReviewDispatchDebounceMs(env),
     firstEnqueuedAt + exactReviewDispatchDebounceMaxMs(env),
   );
-  return Math.max(baseAttemptAt, debounceAt);
+  const nextAttemptAt = Math.max(baseAttemptAt, debounceAt);
+  return {
+    nextAttemptAt,
+    backoffReason:
+      nextAttemptAt > now
+        ? ((baseAttemptAt >= debounceAt
+            ? "dispatcher_backoff"
+            : "dispatch_debounce") as ExactReviewBackoffReason)
+        : undefined,
+  };
 }
 
 function isImmediateExactReviewDecision(decision: ExactReviewDecision) {
-  return Boolean(decision.commandStatusMarker || decision.publication);
+  return Boolean(
+    decision.commandStatusMarker || decision.publication || exactReviewScheduledLane(decision),
+  );
 }
 
 function isLowPriorityExactReviewDecision(decision: ExactReviewDecision) {
@@ -10061,11 +10167,14 @@ function exactReviewQueueStats(
       now,
       capacity,
       exactReviewShedSinceReset(state),
+      state,
     ),
     publication: exactReviewQueueLaneStats(
       items.filter(exactReviewQueueIsPublication),
       now,
       publicationCapacity,
+      0,
+      state,
     ),
   };
   const admissibleItems = exactReviewQueueAdmittedItems(
@@ -10138,6 +10247,7 @@ function exactReviewQueueLaneStats(
   now: number,
   capacity: number,
   shedSinceReset = 0,
+  state: ExactReviewQueueState = { items: {} },
 ) {
   const pendingItems = items.filter((item) => item.state === "pending");
   const readyItems = pendingItems.filter((item) => item.nextAttemptAt <= now);
@@ -10173,9 +10283,15 @@ function exactReviewQueueLaneStats(
     shed_since_reset: shedSinceReset,
     ready: readyItems.length,
     backoff: backoffItems.length,
+    backoff_reasons: exactReviewQueueReasonCounts(
+      backoffItems.map((item) => exactReviewQueueBackoffReason(item, state, now)),
+    ),
     dispatching: dispatchingItems.length,
     leased: leasedItems.length,
     parked: parkedItems.length,
+    parked_reasons: exactReviewQueueReasonCounts(
+      parkedItems.map((item) => item.parkedReason || "unknown"),
+    ),
     capacity,
     active,
     available_slots: Math.max(0, capacity - active),
@@ -10191,6 +10307,34 @@ function exactReviewQueueLaneStats(
       oldestBackoffAt === null ? null : Math.max(0, Math.floor((now - oldestBackoffAt) / 1_000)),
     next_attempt_at: nextAttemptAt === null ? null : new Date(nextAttemptAt).toISOString(),
   };
+}
+
+function exactReviewQueueBackoffReason(
+  item: ExactReviewQueueItem,
+  state: ExactReviewQueueState,
+  now: number,
+) {
+  if (item.backoffReason) return item.backoffReason;
+  if (item.publicationFailureAttempts || (exactReviewQueueIsPublication(item) && item.attempts)) {
+    return "publication_retry";
+  }
+  if (item.reviewFailureAttempts || item.attempts) return "retry_backoff";
+  const retryAt = Number(state.dispatcher?.retryAt || 0);
+  if (
+    (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
+    retryAt > now &&
+    item.nextAttemptAt >= retryAt
+  ) {
+    return "dispatcher_backoff";
+  }
+  return "dispatch_debounce";
+}
+
+function exactReviewQueueReasonCounts(reasons: string[]) {
+  return reasons.reduce<Record<string, number>>((counts, reason) => {
+    counts[reason] = (counts[reason] || 0) + 1;
+    return counts;
+  }, {});
 }
 
 export function exactReviewQueueNextWakeAt(
@@ -10294,6 +10438,10 @@ export function exactReviewQueueNextWakeAt(
           capacityBlockedUntil.length ? Math.min(...capacityBlockedUntil) : item.nextAttemptAt,
         ),
       ];
+    }
+    if (item.state === "parked") {
+      const recoveryAt = exactReviewParkedRecoveryAt(item);
+      return recoveryAt === null ? [] : [recoveryAt];
     }
     const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(
       item,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9789,6 +9789,15 @@ function renderExactReviewLanes(queue) {
       ? " · DLQ " + fmt.format(deadLetters.open || 0) +
         (deadLetters.oldest_failed_at ? " · oldest DLQ " + since(deadLetters.oldest_failed_at) : "")
       : "";
+    const reasonSummary = (label, reasons) => {
+      const values = Object.entries(reasons || {})
+        .filter(([, count]) => Number(count) > 0)
+        .sort((left, right) => Number(right[1]) - Number(left[1]) || left[0].localeCompare(right[0]))
+        .map(([reason, count]) => reason.replaceAll("_", " ") + " " + fmt.format(Number(count)));
+      return values.length ? " · " + label + ": " + values.join(", ") : "";
+    };
+    const queueReasonNote = reasonSummary("backoff", lane.backoff_reasons) +
+      reasonSummary("parked", lane.parked_reasons);
     return '<div class="exact-lane"><div class="exact-lane-head"><strong>' + esc(label) + '</strong><span>' + fmt.format(active) + ' of ' + fmt.format(capacity) + ' active</span></div>' +
       '<div class="lane-count"><span>Pending</span><strong>' + fmt.format(lane.pending || 0) + '</strong></div>' +
       exactReviewTrend(samples, label) +
@@ -9798,9 +9807,10 @@ function renderExactReviewLanes(queue) {
       '<div class="lane-count"><span>Ready</span><strong>' + fmt.format(lane.ready || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Backoff</span><strong>' + fmt.format(lane.backoff || 0) + '</strong></div>' +
       '<div class="lane-count"><span>Dispatching</span><strong>' + fmt.format(lane.dispatching || 0) + '</strong></div>' +
-      '<div class="lane-count"><span>Leased</span><strong>' + fmt.format(lane.leased || 0) + '</strong></div></div>' +
+      '<div class="lane-count"><span>Leased</span><strong>' + fmt.format(lane.leased || 0) + '</strong></div>' +
+      '<div class="lane-count"><span>Parked</span><strong>' + fmt.format(lane.parked || 0) + '</strong></div></div>' +
       '<div class="lane-bar"><i style="width:' + used + '%"></i></div>' +
-      '<div class="lane-foot">' + fmt.format(lane.available_slots || 0) + ' ' + esc(label.toLowerCase()) + ' slots open' + esc(oldest + oldestReady + oldestBackoff + capacityNote + cooldown + deadLetterNote) + '</div></div>';
+      '<div class="lane-foot">' + fmt.format(lane.available_slots || 0) + ' ' + esc(label.toLowerCase()) + ' slots open' + esc(oldest + oldestReady + oldestBackoff + capacityNote + cooldown + deadLetterNote + queueReasonNote) + '</div></div>';
   }).join("");
 }
 function renderExactReviewHandoff(queue) {

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -289,6 +289,15 @@ workflow state, check time, and retry time so an intentional pause cannot look
 like occupied executor capacity. Re-enabling the workflow does not require a
 queue mutation; the next status check resumes normal admission.
 
+Scheduled hot and normal-backfill decisions have already passed the queue's
+fleet-wide rate and burst controls, so they skip the webhook-churn debounce and
+become ready immediately unless the dispatcher itself is paused or blocked.
+Review items parked after retry exhaustion or a permanent dispatch rejection
+retry automatically after 5, 10, and 20 minutes. A successful newer decision
+resets that recovery budget; after three unsuccessful recovery cycles the item
+stays parked for operator inspection. Publication dead-letter-capacity parks
+retain their separate operator-controlled recovery path.
+
 The same endpoint exposes `generated_at`, `ready_pending`,
 `admissible_pending`, `pressure`, `handoff_health`, and oldest timestamps and
 ages for the pending, dispatching, and leased phases. `ready_pending` excludes
@@ -318,8 +327,10 @@ making the otherwise-current fleet snapshot eligible for stale fallback.
 For capacity displays, `/api/exact-review-queue` also exposes compatible
 `lanes.review` and `lanes.publication` objects. Each lane reports its own
 pending, ready, backoff, dispatching, leased, capacity, active, available-slot,
-oldest-pending, and next-attempt values. The existing top-level aggregate fields
-remain available for older consumers. Both lanes additionally report
+oldest-pending, and next-attempt values. `backoff_reasons` and `parked_reasons`
+count the causes represented by those lane totals, and the dashboard renders
+the same breakdown beside the lane counts. The existing top-level aggregate
+fields remain available for older consumers. Both lanes additionally report
 `enqueued_total` and `completed_total`; the review lane's existing
 `shed_since_reset` supplies overload demand. Publication also exposes
 `capacity_control` with the adaptive base, maximum, current ceiling, cooldown,

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1943,6 +1943,81 @@ test("scheduled review feed is lane-paced and exposes its configured target", as
   });
 });
 
+test("scheduled untracked reviews are ready and claimable within one tick when 122 slots are free", async () => {
+  const storage = new MemoryDurableStorage();
+  const active = Object.fromEntries(
+    Array.from({ length: 6 }, (_, index) => {
+      const item = leasedExactReviewQueueItem(120_000 + index, String(120_000 + index));
+      return [item.key, item];
+    }),
+  );
+  await storage.put("exact-review-queue", { items: active });
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_ACTIONS_BUDGET: "194",
+      EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "128",
+      EXACT_REVIEW_TARGET_MAX_CONCURRENT: "120",
+      EXACT_REVIEW_TARGET_RATE_PER_HOUR: "600",
+      EXACT_REVIEW_TARGET_BURST: "120",
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "90000",
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS: "180000",
+    },
+  );
+
+  for (let index = 0; index < 31; index += 1) {
+    const response = await queue.fetch(
+      buildExactReviewQueueRequest(
+        `scheduled-untracked-${index}`,
+        121_000 + index,
+        "scheduled_normal_backfill",
+        index % 2 === 0 ? "issue" : "pull_request",
+        "openclaw/openclaw",
+        { sourceUpdatedAt: "2026-07-30T13:00:00Z" },
+      ),
+    );
+    assert.equal((await response.json()).queued, true);
+  }
+
+  const status = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.equal(status.lanes.review.available_slots, 122);
+  assert.equal(status.lanes.review.pending, 31);
+  assert.equal(status.lanes.review.ready, 31);
+  assert.equal(status.lanes.review.backoff, 0);
+  assert.equal(status.admissible_pending, 31);
+});
+
+test("exact-review lane status counts backoff and parked reasons", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue(
+    { storage },
+    {
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "600000",
+      EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS: "600000",
+    },
+  );
+  await queue.fetch(buildExactReviewQueueRequest("reason-backoff", 121_100, "opened"));
+  await queue.fetch(buildExactReviewQueueRequest("reason-parked", 121_101, "opened"));
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { state: string; parkedReason?: string; backoffReason?: string; updatedAt: number }
+    >;
+  };
+  state.items["openclaw/gogcli#121101"].state = "parked";
+  state.items["openclaw/gogcli#121101"].parkedReason = "dispatch_rejected";
+  state.items["openclaw/gogcli#121101"].backoffReason = undefined;
+  await storage.put("exact-review-queue", state);
+
+  const status = await (
+    await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+  ).json();
+  assert.deepEqual(status.lanes.review.backoff_reasons, { dispatch_debounce: 1 });
+  assert.deepEqual(status.lanes.review.parked_reasons, { dispatch_rejected: 1 });
+});
+
 test("organic reviews consume the global target before scheduled backfill", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue(
@@ -8759,11 +8834,11 @@ test("exact-review queue admits at most one active item per target repository", 
   }
 });
 
-test("exact-review review retries stop at the attempt ceiling and park the item", async () => {
+test("exact-review review retries park at the attempt ceiling and recover after cooldown", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const dispatched: Record<string, unknown>[] = [];
-  let liveHeadSha = `956eaead7f${"0".repeat(30)}`;
+  const liveHeadSha = `956eaead7f${"0".repeat(30)}`;
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
@@ -8873,7 +8948,13 @@ test("exact-review review retries stop at the attempt ceiling and park the item"
       const state = (await storage.get("exact-review-queue")) as {
         items: Record<
           string,
-          { state: string; attempts: number; nextAttemptAt: number; parkedReason?: string }
+          {
+            state: string;
+            attempts: number;
+            nextAttemptAt: number;
+            parkedReason?: string;
+            parkedRecoveryAttempts?: number;
+          }
         >;
       };
       return state.items[itemKey];
@@ -8895,9 +8976,7 @@ test("exact-review review retries stop at the attempt ceiling and park the item"
     assert.equal(parked.parkedReason, "review_retry_exhausted");
     assert.equal(dispatched.length, 8);
 
-    for (let cycle = 9; cycle <= 11; cycle += 1) {
-      assert.equal(await failOnce(cycle), false);
-    }
+    assert.equal(await failOnce(9), false);
     assert.equal(dispatched.length, 8);
     assert.equal((await readItem()).state, "parked");
 
@@ -8919,39 +8998,51 @@ test("exact-review review retries stop at the attempt ceiling and park the item"
       [["parked", "review_retry_exhausted"]],
     );
 
-    liveHeadSha = `1234abcd56${"0".repeat(30)}`;
-    assert.equal(
-      (
-        await queue.fetch(
-          buildExactReviewQueueRequest(
-            "ceiling-rescue",
-            113_341,
-            "synchronize",
-            "pull_request",
-            "openclaw/openclaw",
-            {
-              sourceHeadSha: `1234abcd56${"0".repeat(30)}`,
-              sourceHeadVerified: true,
-              sourceAuthoritySeq: 2,
-              sourceUpdatedAt: new Date(Date.now() + 60_000).toISOString(),
-            },
-          ),
-        )
-      ).status,
-      202,
-    );
-    const rescued = await readItem();
-    assert.equal(rescued.state, "pending");
-    assert.equal(rescued.attempts, 0);
-    assert.equal(rescued.parkedReason, undefined);
-    assert.equal(await failOnce(12), true);
+    const due = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { updatedAt: number }>;
+    };
+    due.items[itemKey].updatedAt = Date.now() - 6 * 60_000;
+    await storage.put("exact-review-queue", due);
+    await queue.alarm();
     assert.equal(dispatched.length, 9);
-    const afterRescue = await readItem();
-    assert.equal(afterRescue.state, "pending");
-    assert.equal(afterRescue.attempts, 1);
+    const recovered = await readItem();
+    assert.equal(recovered.state, "dispatching");
+    assert.equal(recovered.attempts, 0);
+    assert.equal(recovered.parkedReason, undefined);
+    assert.equal(recovered.parkedRecoveryAttempts, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("exact-review automatic parked recovery remains bounded", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
+  await queue.fetch(buildExactReviewQueueRequest("bounded-parked-recovery", 113_342, "opened"));
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      {
+        state: string;
+        parkedReason?: string;
+        parkedRecoveryAttempts?: number;
+        updatedAt: number;
+      }
+    >;
+  };
+  const item = state.items["openclaw/gogcli#113342"];
+  item.state = "parked";
+  item.parkedReason = "review_retry_exhausted";
+  item.parkedRecoveryAttempts = 3;
+  item.updatedAt = Date.now() - 24 * 60 * 60_000;
+  await storage.put("exact-review-queue", state);
+
+  await queue.alarm();
+
+  const retained = (await storage.get("exact-review-queue")) as typeof state;
+  assert.equal(retained.items["openclaw/gogcli#113342"].state, "parked");
+  assert.equal(retained.items["openclaw/gogcli#113342"].parkedRecoveryAttempts, 3);
+  assert.equal(await storage.getAlarm(), null);
 });
 
 test("exact-review requeue_latest and publication completions ignore the review ceiling", async () => {
@@ -9437,7 +9528,10 @@ test("exact-review queue defers retained backlog until a paused dispatcher retry
 
     const state = (await storage.get("exact-review-queue")) as {
       dispatcher?: Record<string, unknown>;
-      items: Record<string, { leaseExpiresAt?: number; nextAttemptAt: number }>;
+      items: Record<
+        string,
+        { leaseExpiresAt?: number; nextAttemptAt: number; state: string; backoffReason?: string }
+      >;
     };
     const leaseExpiresAt = Date.now() + 60_000;
     const retryAt = Date.now() + 15 * 60_000;
@@ -9450,6 +9544,7 @@ test("exact-review queue defers retained backlog until a paused dispatcher retry
     };
     state.items["openclaw/gogcli#801"].leaseExpiresAt = leaseExpiresAt;
     state.items["openclaw/gogcli#802"].nextAttemptAt = retryAt;
+    state.items["openclaw/gogcli#802"].backoffReason = "dispatcher_backoff";
     state.items["openclaw/gogcli#803"].nextAttemptAt = retainedAttemptAt;
     await storage.put("exact-review-queue", state);
     await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"));
@@ -9465,6 +9560,7 @@ test("exact-review queue defers retained backlog until a paused dispatcher retry
     assert.equal(dispatched.length, 1);
     const after = (await storage.get("exact-review-queue")) as typeof state;
     assert.equal(after.items["openclaw/gogcli#802"].nextAttemptAt, retryAt);
+    assert.equal(after.items["openclaw/gogcli#802"].backoffReason, "dispatcher_backoff");
     assert.equal(after.items["openclaw/gogcli#803"].nextAttemptAt, retainedAttemptAt);
   } finally {
     globalThis.fetch = originalFetch;
@@ -11024,7 +11120,7 @@ test("exact-review queue retries dispatch failures and reclaims an unclaimed lea
   }
 });
 
-test("exact-review queue parks structured client-payload validation and explicit command recovers it", async () => {
+test("exact-review queue automatically retries a parked dispatch rejection after cooldown", async () => {
   const originalFetch = globalThis.fetch;
   const storage = new MemoryDurableStorage();
   const { privateKey } = generateKeyPairSync("rsa", {
@@ -11100,23 +11196,11 @@ test("exact-review queue parks structured client-payload validation and explicit
     assert.doesNotMatch(persisted, /must-not-persist|private\.example|token=/);
 
     dispatchStatus = 204;
-    assert.equal(
-      (
-        await queue.fetch(
-          buildExactReviewQueueRequest(
-            "dispatch-rejected-command",
-            600,
-            "legacy_dispatch",
-            "pull_request",
-            undefined,
-            {
-              commandStatusMarker: "<!-- clawsweeper-command-status:600:re_review:na -->",
-            },
-          ),
-        )
-      ).status,
-      202,
-    );
+    const due = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { updatedAt: number }>;
+    };
+    due.items["openclaw/gogcli#600"].updatedAt = Date.now() - 6 * 60_000;
+    await storage.put("exact-review-queue", due);
     await queue.alarm();
     const recovered = (await storage.get("exact-review-queue")) as {
       items: Record<
@@ -11124,6 +11208,7 @@ test("exact-review queue parks structured client-payload validation and explicit
         {
           state: string;
           parkedReason?: string;
+          parkedRecoveryAttempts?: number;
           dispatchFailureClass?: string;
           attempts: number;
         }
@@ -11131,6 +11216,7 @@ test("exact-review queue parks structured client-payload validation and explicit
     };
     assert.equal(recovered.items["openclaw/gogcli#600"].state, "dispatching");
     assert.equal(recovered.items["openclaw/gogcli#600"].parkedReason, undefined);
+    assert.equal(recovered.items["openclaw/gogcli#600"].parkedRecoveryAttempts, 1);
     assert.equal(recovered.items["openclaw/gogcli#600"].dispatchFailureClass, undefined);
     assert.equal(recovered.items["openclaw/gogcli#600"].attempts, 0);
   } finally {


### PR DESCRIPTION
## Summary

- make scheduled hot/backfill decisions ready immediately after the durable queue has already admitted and rate-paced them, instead of applying the 90-180 second webhook debounce again
- retry review-lane parks caused by `dispatch_rejected` or `review_retry_exhausted` after 5, 10, and 20 minutes, then stop after three automatic recovery cycles; publication DLQ-capacity parks keep their operator-owned path
- expose `backoff_reasons` and `parked_reasons` per lane and render Parked plus both reason breakdowns on the dashboard

## Root cause and reproduction

The scheduler fix in https://github.com/openclaw/clawsweeper/pull/960 made canonical-coverage gaps reach queue admission, but the queue classified scheduled decisions as ordinary webhook churn. A production-shaped in-process Durable Object reproduction (128 global slots, 120 target slots, six active leases, 31 newly enqueued scheduled items) failed on prior main with `ready: 0`, `backoff: 31`, and `admissible_pending: 0`.

Parked review rows had a second leak. `dispatch_rejected` and `review_retry_exhausted` changed the item state to `parked`, while normal alarms and wake calculation ignored parked review work. A newer authoritative event could clear a park, but recurring scheduled intake deduped before that recovery branch, so scheduled coverage could not revive it. Public live samples from the 106 parked reviews all showed the same `dispatch_rejected` 422 fingerprint and timestamp.

The regression test now sends both issues and pull requests through the real `ExactReviewQueue.fetch()` handler under the production-shaped state and asserts all 31 are ready and target-admissible in the enqueue tick. Recovery tests cover both park reasons, the cooldown, the three-cycle ceiling, and status reason counts.

## Proof

- `pnpm run build:all`
- `node --test test/dashboard-worker.test.ts test/repair/scheduled-review-enqueue.test.ts` (273 passed)
- `pnpm run format:check`
- `pnpm run lint:dashboard`
- focused Oxlint for both changed test files
- `~/.claude/skills/autoreview/scripts/autoreview --mode local` (clean)
- `~/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)

`pnpm run check` cleared static checks, formatting, all builds, all lint targets, and reached 77.39% line / 72.58% branch coverage. Its aggregate test command then hit five unrelated macOS containment failures because Apple Python's libc has no `capset` symbol; the queue/dashboard-focused suite above is clean.

## Expected throughput and rollout

With free slots, a normal-backfill cycle can now feed the queue at its configured 390 reviews/hour share (65% of the 600/hour fleet target), rather than waiting in queue debounce and accumulating unrecoverable parks. That is about 65 normal-backfill items per 10 minutes, versus the observed coverage burn of roughly 24 items per 25 minutes. At that ceiling, 2,721 untracked items are roughly seven hours of normal-lane work before organic demand and service-time variance; hot intake can use the other 210/hour share for eligible work.

This changes `dashboard/` and requires a dashboard Worker redeploy after merge. The first post-deploy alarm will reconsider the old review parks: terminal items will be removed by the existing live-state preflight, open items will retry, and persistently bad items stop after the bounded recovery budget.
