### PR TITLE
fix(apply): remove coverage-proof scratch files from the uploaded proof tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Close-coverage proof runs now remove their model scratch files (`N-M.model.json`, `N-M.prompt.md`) from the proof artifact tree, which the apply-lane validator was correctly rejecting and failing every apply run.
 - Repaired legacy exact-review decisions whose empty branch was shifted to the string `0`, resolved invalid queued branches from the target repository default, and requeued temporary branch-resolution failures without spending the eight-attempt review-failure budget.
 - Made scheduled exact reviews immediately ready after fleet admission, automatically retried recoverable parked reviews on a bounded 5/10/20-minute cycle, and exposed backoff/park reason counts in queue status and the dashboard.
 - Aligned normal fanout and planner priority with the dashboard's canonical tuple coverage identities, so legacy backfill reports no longer hide untracked open items behind canonical re-reviews.

--- a/src/pr-close-coverage-proof.ts
+++ b/src/pr-close-coverage-proof.ts
@@ -276,6 +276,7 @@ export function runPrCloseCoverageProofModel(options: {
   mkdirSync(options.runtime.workDir, { recursive: true });
   const prefix = `${options.source.number}-${options.covering.number}`;
   const outputPath = join(options.runtime.workDir, `${prefix}.model.json`);
+  const promptPath = join(options.runtime.workDir, `${prefix}.prompt.md`);
   const prompt = buildPrCloseCoverageProofPrompt({
     source: options.source,
     covering: options.covering,
@@ -283,8 +284,17 @@ export function runPrCloseCoverageProofModel(options: {
     relationshipSignalSnippets: options.relationshipSignalSnippets,
     promptTemplate: options.runtime.promptTemplate,
   });
-  writeFileSync(join(options.runtime.workDir, `${prefix}.prompt.md`), prompt, "utf8");
+  writeFileSync(promptPath, prompt, "utf8");
   if (existsSync(outputPath)) unlinkSync(outputPath);
+  // workDir doubles as the uploaded proof-artifact tree, whose downstream
+  // validator only admits N-M.proof.json plus manifest.json — scratch files
+  // must never survive a successful proof run.
+  const readValidatedOutputAndCleanUp = (): PrCloseCoverageProofModelResult => {
+    const proof = readPrCloseCoverageProofModelOutput(outputPath);
+    unlinkSync(outputPath);
+    unlinkSync(promptPath);
+    return proof;
+  };
   const codexConfig = [codexLoginConfig(), 'approval_policy="never"'];
   if (options.runtime.serviceTier) {
     codexConfig.unshift(`service_tier="${options.runtime.serviceTier}"`);
@@ -320,7 +330,7 @@ export function runPrCloseCoverageProofModel(options: {
   if (result.status !== 0) {
     if (existsSync(outputPath)) {
       try {
-        return readPrCloseCoverageProofModelOutput(outputPath);
+        return readValidatedOutputAndCleanUp();
       } catch (error) {
         throw new Error(
           `Codex PR close coverage proof failed for #${options.source.number} with exit ${
@@ -340,7 +350,7 @@ export function runPrCloseCoverageProofModel(options: {
   if (!existsSync(outputPath)) {
     throw new Error(`Codex PR close coverage proof did not write ${outputPath}.`);
   }
-  return readPrCloseCoverageProofModelOutput(outputPath);
+  return readValidatedOutputAndCleanUp();
 }
 
 export function prCloseCoverageProofEnvelopePath(

--- a/test/pr-close-coverage-proof.test.ts
+++ b/test/pr-close-coverage-proof.test.ts
@@ -1,9 +1,20 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
   buildPrCloseCoverageProofPrompt,
+  runPrCloseCoverageProofModel,
   createPrCloseCoverageProofEnvelope,
   parsePrCloseCoverageProofEnvelope,
   prCloseCoverageProofEnvelopePath,
@@ -414,3 +425,67 @@ test("PR close coverage proof prompt requires concrete coverage proof", () => {
   assert.doesNotMatch(prompt, /must not be auto-closed/);
   assert.doesNotMatch(prompt, /patchSignature/);
 });
+
+test(
+  "PR close coverage proof model run leaves no scratch files in the proof tree",
+  { skip: process.platform === "win32" },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-proof-scratch-test-"));
+    try {
+      const workDir = join(root, "pr-close-coverage-proof");
+      const binDir = join(root, "bin");
+      mkdirSync(binDir, { recursive: true });
+      const fakeCodex = join(binDir, "codex");
+      writeFileSync(
+        fakeCodex,
+        [
+          "#!/bin/sh",
+          'out=""',
+          'prev=""',
+          'for a in "$@"; do',
+          '  if [ "$prev" = "--output-last-message" ]; then out="$a"; fi',
+          '  prev="$a"',
+          "done",
+          "cat > /dev/null",
+          "cat > \"$out\" <<'JSON'",
+          JSON.stringify(concreteCoverageProof),
+          "JSON",
+          "exit 0",
+        ].join("\n"),
+      );
+      chmodSync(fakeCodex, 0o755);
+      const schemaPath = join(root, "schema.json");
+      writeFileSync(schemaPath, "{}\n");
+      const previousCodexBin = process.env.CODEX_BIN;
+      process.env.CODEX_BIN = fakeCodex;
+      try {
+        const proof = runPrCloseCoverageProofModel({
+          source: proofPullRequest(95982),
+          covering: proofPullRequest(111523),
+          markdown: "Report markdown.",
+          relationshipSignalSnippets: [],
+          runtime: {
+            model: "gpt-test",
+            reasoningEffort: "low",
+            sandboxMode: "read-only",
+            serviceTier: "",
+            timeoutMs: 30_000,
+            workDir,
+            rootDir: root,
+            schemaPath,
+            promptTemplate: "Prove close coverage.",
+          },
+        });
+        assert.equal(proof.decision, "covered");
+      } finally {
+        if (previousCodexBin === undefined) delete process.env.CODEX_BIN;
+        else process.env.CODEX_BIN = previousCodexBin;
+      }
+      // The workDir is uploaded verbatim as the close-coverage proof artifact;
+      // its validator only admits N-M.proof.json and manifest.json.
+      assert.deepEqual(readdirSync(workDir), []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Problem

Every apply run today failed at "Validate downloaded close coverage proof tree" with:

```
Unexpected coverage proof filename: 95982-111523.model.json
```

`runPrCloseCoverageProofModel` writes its scratch files (`N-M.prompt.md` prompt dump, `N-M.model.json` model output) into `runtime.workDir` — but that directory doubles as the uploaded proof artifact tree (`.artifacts/apply-proof/pr-close-coverage-proof/*`), and the downstream validator only admits `N-M.proof.json` plus `manifest.json`. Any successful model-backed proof therefore poisoned the artifact and hard-failed the entire apply lane (0 successful applies in the last 24h).

## Fix

Successful proof runs now unlink both scratch files immediately after the model output validates, on both success paths (exit 0, and nonzero exit with valid output). Failed runs keep their scratch files for debugging — those runs never reach upload.

## Proof

- New regression test drives the real runner against a fake `CODEX_BIN` and asserts the workDir is empty of scratch files afterward; verified red on pre-fix code, green on the fix.
- Full `test/pr-close-coverage-proof.test.ts` suite: 26/26 pass.
- Autoreview (codex, xhigh): clean, no actionable findings.
