### PR TITLE
fix(state): recover non-reconcile canonical tuple 409 conflicts with rebase-or-skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Apply and comment-sync publications now recover from canonical record tuple 409 conflicts instead of crashing mid-checkpoint: an equivalent concurrent write is absorbed, an unrelated-section race is rebased onto CURRENT with a single deterministic retry, and a same-section race skips just that item while the rest of the run continues.
 - Prevented weekly coverage from endlessly refreshing tracked records while never-reviewed live items remained invisible behind a full candidate batch; normal fanout now refreshes and consumes the signed live inventory, skips empty repositories, and prioritizes repositories with untracked work.
 - Reconciled apply backlogs now publish record tuples in bounded batches, re-verify authority-superseded canonical revisions without weakening source/verdict guards, and always carry an explicit coverage-proof artifact manifest under reduced state hydration.
 - Restored close-backlog throughput by keeping apply jobs off the enormous immutable state-blob hydration path, and isolated operator-dispatched sweeps from background concurrency coalescing.

--- a/src/repair/publish-main.ts
+++ b/src/repair/publish-main.ts
@@ -73,6 +73,7 @@ export async function publishMainWithStateAppend(
   const canonicalItemCount = canonicalPlan.items.length;
   let canonicalResolvedCount = 0;
   let canonicalFailedCount = 0;
+  let canonicalSkippedCount = 0;
   if (canonicalItemCount > 0) {
     if (!queueUrl || !webhookSecret) {
       throw new Error("canonical record publication is required for record tuple changes");
@@ -81,7 +82,7 @@ export async function publishMainWithStateAppend(
     for (const item of canonicalPlan.items) {
       try {
         if ("error" in item) throw item.error;
-        await postCanonicalRecordTupleWithRecovery({
+        const outcome = await postCanonicalRecordTupleWithRecovery({
           queueUrl,
           webhookSecret,
           mutation: item.mutation,
@@ -90,7 +91,8 @@ export async function publishMainWithStateAppend(
           env,
           ...(runtime.fetchImpl ? { fetchImpl: runtime.fetchImpl } : {}),
         });
-        canonicalResolvedCount += 1;
+        if (outcome === "skipped") canonicalSkippedCount += 1;
+        else canonicalResolvedCount += 1;
       } catch (error) {
         if (!isolateFailures || isCanonicalInfrastructureError(error)) throw error;
         canonicalFailedCount += 1;
@@ -102,9 +104,19 @@ export async function publishMainWithStateAppend(
         `Canonical reconciliation failed for all ${canonicalItemCount} item(s); see per-item errors above`,
       );
     }
+    if (canonicalSkippedCount === canonicalItemCount) {
+      throw new Error(
+        `Canonical publication conflicted for all ${canonicalItemCount} item(s); see per-item warnings above`,
+      );
+    }
     if (canonicalFailedCount > 0) {
       console.warn(
         `[canonical reconcile] continued after ${canonicalFailedCount} of ${canonicalItemCount} item(s) failed`,
+      );
+    }
+    if (canonicalSkippedCount > 0) {
+      console.warn(
+        `[canonical publish] continued after ${canonicalSkippedCount} of ${canonicalItemCount} conflicted item(s) were skipped`,
       );
     }
   }
@@ -297,7 +309,9 @@ function isRecordTupleProjectionPath(path: string): boolean {
   );
 }
 
-async function postCanonicalRecordTupleWithRecovery(options: {
+type CanonicalPublicationOutcome = "published" | "skipped";
+
+type CanonicalPublicationOptions = {
   queueUrl: string;
   webhookSecret: string;
   mutation: CanonicalRecordTupleMutation;
@@ -305,16 +319,18 @@ async function postCanonicalRecordTupleWithRecovery(options: {
   stateRoot: string;
   env: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
-}): Promise<void> {
+};
+
+async function postCanonicalRecordTupleWithRecovery(
+  options: CanonicalPublicationOptions,
+): Promise<CanonicalPublicationOutcome> {
   try {
     await postCanonicalRecordTuple(options);
-    return;
+    return "published";
   } catch (error) {
-    if (
-      !(error instanceof CanonicalRecordTupleConflictError) ||
-      options.env.CLAWSWEEPER_CANONICAL_PUBLICATION_KIND !== "reconcile"
-    ) {
-      throw error;
+    if (!(error instanceof CanonicalRecordTupleConflictError)) throw error;
+    if (options.env.CLAWSWEEPER_CANONICAL_PUBLICATION_KIND !== "reconcile") {
+      return recoverNonReconcilePublicationConflict(options, error);
     }
     const current = currentTupleFromConflict(error.current, options.mutation.key);
     if (!current) throw error;
@@ -331,7 +347,7 @@ async function postCanonicalRecordTupleWithRecovery(options: {
       console.warn(
         `Skipped ${options.mutation.key}: canonical CURRENT revision ${current.state.revision} already has ${targetLocation ?? "deleted"} placement`,
       );
-      return;
+      return "published";
     }
     if (
       baselineLocation === targetLocation ||
@@ -342,7 +358,7 @@ async function postCanonicalRecordTupleWithRecovery(options: {
       console.warn(
         `Skipped ${options.mutation.key}: canonical CURRENT revision ${current.state.revision} made the reconcile move obsolete`,
       );
-      return;
+      return "published";
     }
 
     const rebasedTarget = rebaseReconciliationMove({ baseline, target, current: current.tuple });
@@ -378,7 +394,7 @@ async function postCanonicalRecordTupleWithRecovery(options: {
         console.warn(
           `Skipped ${options.mutation.key} after retry conflict with invalid CURRENT state: ${publishErrorMessage(parseError)}`,
         );
-        return;
+        return "published";
       }
       if (retryCurrent) {
         syncTupleToRoot(options.root, retryCurrent.tuple);
@@ -394,13 +410,133 @@ async function postCanonicalRecordTupleWithRecovery(options: {
       console.warn(
         `Skipped ${options.mutation.key}: canonical CURRENT changed again during the single retry`,
       );
-      return;
+      return "published";
     }
     syncTupleToRoot(options.root, rebasedTarget);
     console.warn(
       `Retried ${options.mutation.key} against canonical CURRENT revision ${current.state.revision}`,
     );
+    return "published";
   }
+}
+
+// Non-reconcile publications (apply checkpoints, comment sync, review artifacts)
+// race the ~70 concurrent review workers that continuously bump canonical record
+// revisions, so a 409 is routine rather than exceptional. Recover by rebasing only
+// the sections this publication changed onto canonical CURRENT; anything murkier
+// is skipped per item so one contested tuple cannot kill the whole run.
+async function recoverNonReconcilePublicationConflict(
+  options: CanonicalPublicationOptions,
+  error: CanonicalRecordTupleConflictError,
+): Promise<CanonicalPublicationOutcome> {
+  const current = currentTupleFromConflict(error.current, options.mutation.key);
+  if (!current) throw error;
+  const [repoSlug, itemNumber] = options.mutation.key.split("/");
+  if (!repoSlug || !itemNumber) throw error;
+  const paths = recordTuplePaths({ repository: repoSlug, number: itemNumber });
+  const target = tupleFromMutation(options.mutation, paths);
+  const baselineDigests = new Map(
+    options.mutation.operations.map((operation) => [operation.path, operation.expectedDigest]),
+  );
+  // Sections this publication changed: the mutation's content differs from the
+  // state-baseline digest the mutation asserted for that section.
+  const changedPaths = RECORD_TUPLE_SECTIONS.map((section) =>
+    tuplePathForSection(paths, section),
+  ).filter(
+    (path) => contentDigest(tupleContentForPath(target, path)) !== baselineDigests.get(path),
+  );
+  const conflictingPaths = changedPaths.filter(
+    (path) => tupleContentForPath(current.tuple, path) !== tupleContentForPath(target, path),
+  );
+  if (conflictingPaths.length === 0) {
+    syncTupleToRoot(options.root, current.tuple);
+    console.warn(
+      `Skipped ${options.mutation.key}: canonical CURRENT revision ${current.state.revision} already contains this publication`,
+    );
+    return "published";
+  }
+  // GitHub-side effects for this item already happened (capture-before-mutate), so
+  // a skipped publication may repeat the action next cycle. Comment idempotency
+  // fences and the unchanged-edit dedupe (#857) make that repeat a no-op; never
+  // weaken those fences to compensate here.
+  if (
+    conflictingPaths.some(
+      (path) =>
+        contentDigest(tupleContentForPath(current.tuple, path)) !== baselineDigests.get(path),
+    )
+  ) {
+    syncTupleToRoot(options.root, current.tuple);
+    console.warn(
+      `Skipped ${options.mutation.key}: canonical CURRENT revision ${current.state.revision} concurrently changed a section this publication also changed`,
+    );
+    return "skipped";
+  }
+  const changed = new Set(changedPaths);
+  const rebasedContent = (path: string) =>
+    changed.has(path)
+      ? tupleContentForPath(target, path)
+      : tupleContentForPath(current.tuple, path);
+  const rebased: RecordTupleContents = {
+    paths,
+    item: rebasedContent(paths.item),
+    closed: rebasedContent(paths.closed),
+    plan: rebasedContent(paths.plan),
+    packet: rebasedContent(paths.packet),
+  };
+  try {
+    validateRecordTuple(rebased, "rebased canonical publication tuple");
+  } catch (validationError) {
+    syncTupleToRoot(options.root, current.tuple);
+    console.warn(
+      `Skipped ${options.mutation.key}: rebase onto canonical CURRENT revision ${current.state.revision} is invalid: ${publishErrorMessage(validationError)}`,
+    );
+    return "skipped";
+  }
+  const operations = current.state.operations.map((operation) => {
+    const content = tupleContentForPath(rebased, operation.path);
+    return {
+      path: operation.path,
+      expectedDigest: operation.expectedDigest,
+      ...(content === null ? {} : { contentBase64: Buffer.from(content).toString("base64") }),
+    };
+  });
+  const contentHash = createHash("sha256")
+    .update(JSON.stringify({ key: options.mutation.key, operations }))
+    .digest("hex");
+  const retryMutation: CanonicalRecordTupleMutation = {
+    ...options.mutation,
+    deliveryId: `record-tuple-rebase:${deliveryPart(options.env.GITHUB_RUN_ID, "local")}:${deliveryPart(options.env.GITHUB_RUN_ATTEMPT, "1")}:${contentHash}`,
+    operations,
+  };
+  try {
+    await postCanonicalRecordTuple({
+      queueUrl: options.queueUrl,
+      webhookSecret: options.webhookSecret,
+      mutation: retryMutation,
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    });
+  } catch (retryError) {
+    if (!(retryError instanceof CanonicalRecordTupleConflictError)) throw retryError;
+    try {
+      const retryCurrent = currentTupleFromConflict(retryError.current, options.mutation.key);
+      if (retryCurrent) syncTupleToRoot(options.root, retryCurrent.tuple);
+    } catch {
+      // Keep the single-retry skip even when the retry CURRENT payload is unusable.
+    }
+    console.warn(
+      `Skipped ${options.mutation.key}: canonical CURRENT changed again during the single rebase retry`,
+    );
+    return "skipped";
+  }
+  syncTupleToRoot(options.root, rebased);
+  console.warn(
+    `Rebased ${options.mutation.key} onto canonical CURRENT revision ${current.state.revision}`,
+  );
+  return "published";
+}
+
+function contentDigest(content: string | null): string | null {
+  return content === null ? null : sha256(content);
 }
 
 function currentTupleFromConflict(

--- a/test/repair/publish-main.test.ts
+++ b/test/repair/publish-main.test.ts
@@ -362,6 +362,190 @@ test("publish-main isolates a poison reconciliation tuple and publishes its sibl
   assert.deepEqual(warnings, ["[canonical reconcile] continued after 1 of 2 item(s) failed"]);
 });
 
+test("publish-main resolves a non-reconcile conflict whose CURRENT already contains the change", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-equivalent-source-"));
+  const stateRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "clawsweeper-canonical-equivalent-state-"),
+  );
+  const before = recordMarkdown("2026-07-26T01:00:00.000Z", "before");
+  const after = recordMarkdown("2026-07-26T02:00:00.000Z", "after");
+  const concurrentPlan = "concurrent work plan\n";
+  writeText(stateRoot, tupleItemPath, before);
+  writeText(root, tupleItemPath, after);
+  const warnings: string[] = [];
+  let posts = 0;
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      { message: "chore: update sweep records", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+        fetchImpl: (async () => {
+          posts += 1;
+          return tupleConflictResponse({ item: after, plan: concurrentPlan });
+        }) as typeof fetch,
+        publishGit: () => {
+          throw new Error("git publication must not run");
+        },
+      },
+    ),
+    "appended",
+  );
+  assert.equal(posts, 1);
+  assert.equal(fs.readFileSync(path.join(root, tupleItemPath), "utf8"), after);
+  assert.equal(
+    fs.readFileSync(path.join(root, `${tupleRoot}/plans/42.md`), "utf8"),
+    concurrentPlan,
+  );
+  assert.deepEqual(warnings, [
+    "Skipped openclaw-openclaw/42: canonical CURRENT revision 2 already contains this publication",
+  ]);
+});
+
+test("publish-main rebases a non-reconcile conflict on an unrelated section and retries once", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-rebase-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-rebase-state-"));
+  const before = recordMarkdown("2026-07-26T01:00:00.000Z", "before");
+  const after = recordMarkdown("2026-07-26T02:00:00.000Z", "after");
+  const concurrentPlan = "concurrent work plan\n";
+  writeText(stateRoot, tupleItemPath, before);
+  writeText(root, tupleItemPath, after);
+  const warnings: string[] = [];
+  const posted: Array<Record<string, unknown>> = [];
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      { message: "chore: update sweep records", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+        fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+          const mutation = JSON.parse(String(init?.body ?? "")) as Record<string, unknown>;
+          posted.push(mutation);
+          if (posted.length === 1) {
+            return tupleConflictResponse({ item: before, plan: concurrentPlan });
+          }
+          return Response.json(
+            { ok: true, accepted: true, deduped: false, revision: 3, sequence: 12 },
+            { status: 202 },
+          );
+        }) as typeof fetch,
+        publishGit: () => {
+          throw new Error("git publication must not run");
+        },
+      },
+    ),
+    "appended",
+  );
+  assert.equal(posted.length, 2);
+  assert.match(String(posted[0]?.deliveryId), /^record-tuple:1234:2:[a-f0-9]{64}$/);
+  assert.match(String(posted[1]?.deliveryId), /^record-tuple-rebase:1234:2:[a-f0-9]{64}$/);
+  const retryOperations = posted[1]?.operations as Array<Record<string, unknown>>;
+  assert.equal(
+    retryOperations[0]?.expectedDigest,
+    createHash("sha256").update(before).digest("hex"),
+  );
+  assert.equal(
+    Buffer.from(String(retryOperations[0]?.contentBase64), "base64").toString("utf8"),
+    after,
+  );
+  assert.equal(
+    retryOperations[2]?.expectedDigest,
+    createHash("sha256").update(concurrentPlan).digest("hex"),
+  );
+  assert.equal(
+    Buffer.from(String(retryOperations[2]?.contentBase64), "base64").toString("utf8"),
+    concurrentPlan,
+  );
+  assert.equal(fs.readFileSync(path.join(root, tupleItemPath), "utf8"), after);
+  assert.equal(
+    fs.readFileSync(path.join(root, `${tupleRoot}/plans/42.md`), "utf8"),
+    concurrentPlan,
+  );
+  assert.deepEqual(warnings, ["Rebased openclaw-openclaw/42 onto canonical CURRENT revision 2"]);
+});
+
+test("publish-main skips a non-reconcile conflict on its own section and publishes its sibling", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-own-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-own-state-"));
+  const before = recordMarkdown("2026-07-26T01:00:00.000Z", "before");
+  const after = recordMarkdown("2026-07-26T02:00:00.000Z", "after");
+  const concurrent = recordMarkdown("2026-07-26T03:00:00.000Z", "concurrent review");
+  writeText(stateRoot, tupleItemPath, before);
+  writeText(root, tupleItemPath, after);
+  const siblingItemPath = `${tupleRoot}/items/43.md`;
+  writeText(stateRoot, siblingItemPath, before.replace("number: 42", "number: 43"));
+  writeText(root, siblingItemPath, after.replace("number: 42", "number: 43"));
+  const warnings: string[] = [];
+  const postedKeys: string[] = [];
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+
+  assert.equal(
+    await publishMainWithStateAppend(
+      { message: "chore: update sweep records", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+        fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+          const mutation = JSON.parse(String(init?.body ?? "")) as { key: string };
+          postedKeys.push(mutation.key);
+          if (mutation.key === "openclaw-openclaw/42") {
+            return tupleConflictResponse({ item: concurrent });
+          }
+          return Response.json(
+            { ok: true, accepted: true, deduped: false, revision: 7, sequence: 11 },
+            { status: 202 },
+          );
+        }) as typeof fetch,
+        publishGit: () => {
+          throw new Error("git publication must not run");
+        },
+      },
+    ),
+    "appended",
+  );
+  assert.deepEqual(postedKeys, ["openclaw-openclaw/42", "openclaw-openclaw/43"]);
+  assert.equal(fs.readFileSync(path.join(root, tupleItemPath), "utf8"), concurrent);
+  assert.equal(
+    fs.readFileSync(path.join(root, siblingItemPath), "utf8"),
+    after.replace("number: 42", "number: 43"),
+  );
+  assert.deepEqual(warnings, [
+    "Skipped openclaw-openclaw/42: canonical CURRENT revision 2 concurrently changed a section this publication also changed",
+    "[canonical publish] continued after 1 of 2 conflicted item(s) were skipped",
+  ]);
+});
+
+test("publish-main fails when every non-reconcile item conflicts on its own section", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-allskip-source-"));
+  const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-canonical-allskip-state-"));
+  const before = recordMarkdown("2026-07-26T01:00:00.000Z", "before");
+  const after = recordMarkdown("2026-07-26T02:00:00.000Z", "after");
+  const concurrent = recordMarkdown("2026-07-26T03:00:00.000Z", "concurrent review");
+  writeText(stateRoot, tupleItemPath, before);
+  writeText(root, tupleItemPath, after);
+  t.mock.method(console, "warn", () => {});
+
+  await assert.rejects(
+    publishMainWithStateAppend(
+      { message: "chore: update sweep records", paths: [tupleRoot] },
+      {
+        root,
+        env: appendEnv({ CLAWSWEEPER_STATE_DIR: stateRoot }),
+        fetchImpl: (async () => tupleConflictResponse({ item: concurrent })) as typeof fetch,
+        publishGit: () => {
+          throw new Error("git publication must not run");
+        },
+      },
+    ),
+    /Canonical publication conflicted for all 1 item\(s\)/,
+  );
+  assert.equal(fs.readFileSync(path.join(root, tupleItemPath), "utf8"), concurrent);
+});
+
 test("publish-main keeps sweep status on the git-backed operational lane", async () => {
   const root = statusFixture();
   const gitPublishes: GitPublishOptions[] = [];
@@ -566,6 +750,37 @@ function conflictResponse(
             : { path: `${tupleRoot}/closed/42.md`, expectedDigest: null },
           { path: `${tupleRoot}/plans/42.md`, expectedDigest: null },
           { path: `${tupleRoot}/decision-packets/42.json`, expectedDigest: null },
+        ],
+      },
+    },
+    { status: 409 },
+  );
+}
+
+function tupleConflictResponse(
+  contents: { item?: string; closed?: string; plan?: string; packet?: string },
+  revision = 2,
+): Response {
+  const operation = (operationPath: string, content?: string) =>
+    content === undefined
+      ? { path: operationPath, expectedDigest: null }
+      : {
+          path: operationPath,
+          expectedDigest: createHash("sha256").update(content).digest("hex"),
+          contentBase64: Buffer.from(content).toString("base64"),
+        };
+  return Response.json(
+    {
+      error: "canonical_record_tuple_conflict",
+      current: {
+        key: "openclaw-openclaw/42",
+        revision,
+        deliveryId: "record-tuple:concurrent-run:1",
+        operations: [
+          operation(tupleItemPath, contents.item),
+          operation(`${tupleRoot}/closed/42.md`, contents.closed),
+          operation(`${tupleRoot}/plans/42.md`, contents.plan),
+          operation(`${tupleRoot}/decision-packets/42.json`, contents.packet),
         ],
       },
     },


### PR DESCRIPTION
## Problem

Comment-sync and apply runs crash with `CanonicalRecordTupleConflictError: POST /internal/state/records/tuples returned 409: canonical_record_tuple_conflict` (sample run 30555649490, step "Apply unchanged proposed decisions with checkpoints").

`publishMainWithStateAppend` posts canonical record tuples per item, but `postCanonicalRecordTupleWithRecovery` only recovers 409 conflicts when `CLAWSWEEPER_CANONICAL_PUBLICATION_KIND === "reconcile"` (set only by `scripts/apply-workflow-helpers.sh`). Apply-lane and comment-sync publications run without that kind, so the first conflict kills the entire run mid-checkpoint. With ~70 concurrent review workers constantly bumping record revisions in the ExactReviewQueue DO, these races are now routine — the lane fails continuously.

## Fix

Non-reconcile conflicts now go through a dedicated recovery path in `src/repair/publish-main.ts` (`recoverNonReconcilePublicationConflict`) that reuses the existing reconcile helpers and never force-writes:

- **Sections we changed** are computed from the mutation itself: a section is ours when its content digest differs from the state-baseline `expectedDigest` the mutation asserted.
- **Equivalent concurrent write**: if CURRENT already matches our target on every section we changed, sync CURRENT into the working root and count the item as resolved (no retry).
- **Unrelated-section race**: rebase once — CURRENT's digests as `expectedDigest`, our content for sections we changed, CURRENT's content for the rest — under a deterministic `record-tuple-rebase:<run>:<attempt>:<contentHash>` delivery id (mirrors the `record-reconcile:` retry pattern in a separate non-reconcile namespace). The rebased tuple is validated before posting; an invalid combination skips instead.
- **Same-section race, or the single retry conflicts again**: skip just that item — sync CURRENT to root, warn with key and revision, continue with the remaining items. If every item in the plan is skipped this way, the run still throws (mirrors the reconcile all-failed guard). Infrastructure errors (`isCanonicalInfrastructureError`) still throw immediately.

A skipped item may repeat its GitHub action next cycle since side effects happen before publication (capture-before-mutate); comment idempotency fences and the unchanged-edit dedupe (#857) make that repeat a no-op, and the code comments call out that those fences must not be weakened. Reconcile behavior is preserved exactly — its recovery block is unchanged aside from returning an explicit outcome.

## Proof

Four new tests in `test/repair/publish-main.test.ts`, each proven red against the origin/main implementation (all four fail pre-fix: the old code rethrows the 409 for every non-reconcile conflict):

- non-reconcile conflict whose CURRENT already contains the change → resolved, CURRENT synced to root, single POST
- conflict on an unrelated section → rebased retry succeeds with CURRENT digests + our section content, `record-tuple-rebase:` delivery id
- conflict on our own section → item skipped with key+revision warning, sibling tuple still publishes
- every item conflicting on its own section → run throws

Full gate: `pnpm run build:all`, focused suite 15/15, `pnpm run format`, `pnpm run lint`, `pnpm run check` green, autoreview clean.
