### PR TITLE
fix(queue): complete head-drifted exact reviews as superseded no-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Exact reviews whose pull request head moved past the queued authority now complete as superseded no-ops (the newer push owns its own review) instead of failing and burning the item's review-failure budget.
 - Close-coverage proof runs now remove their model scratch files (`N-M.model.json`, `N-M.prompt.md`) from the proof artifact tree, which the apply-lane validator was correctly rejecting and failing every apply run.
 - Repaired legacy exact-review decisions whose empty branch was shifted to the string `0`, resolved invalid queued branches from the target repository default, and requeued temporary branch-resolution failures without spending the eight-attempt review-failure budget.
 - Made scheduled exact reviews immediately ready after fleet admission, automatically retried recoverable parked reviews on a bounded 5/10/20-minute cycle, and exposed backoff/park reason counts in queue status and the dashboard.

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -22944,9 +22944,15 @@ function reserveReviewLeaseCommand(args: Args): void {
     item.kind === "pull_request" &&
     queueAuthority.sourceHeadSha !== currentRevision
   ) {
-    throw new UserFacingCommandError(
-      "Exact-review queue authority source head does not match the current pull request.",
+    // The PR moved past the queued head. The push that moved it enqueues its
+    // own exact-head event (and the scheduled sweep backstops a lost webhook),
+    // so this stale entry completes as a superseded no-op instead of burning
+    // the item's review-failure budget.
+    console.error(
+      `Exact-review queue authority source head ${queueAuthority.sourceHeadSha} does not match the current pull request head ${currentRevision}; completing as superseded.`,
     );
+    console.log(JSON.stringify({ status: "superseded", reason: "source_head_drift" }));
+    return;
   }
   const reservationAuthority =
     queueAuthority && item.kind === "pull_request" && !queueAuthority.sourceHeadSha

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -276,6 +276,93 @@ process.stdout.write("200");
   }
 });
 
+test("reserve-review-lease completes as superseded when the PR head drifted past the queue authority", () => {
+  const root = mkdtempSync(join(tmpdir(), "cmd-reserve-lease-drift-"));
+  const binDir = join(root, "bin");
+  const ghPath = join(binDir, "gh.js");
+  const leasePath = join(root, "lease.json");
+  const headSha = "0123456789abcdef0123456789abcdef01234567";
+  const queuedHeadSha = "f".repeat(40);
+  try {
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      ghPath,
+      `
+const { readFileSync, writeFileSync } = require("node:fs");
+const leasePath = ${JSON.stringify(leasePath)};
+const headSha = ${JSON.stringify(headSha)};
+const args = process.argv.slice(2);
+const path = args[1] || "";
+if (args[0] === "api" && path === "repos/openclaw/openclaw/issues/357") {
+  console.log(JSON.stringify({
+    number: 357,
+    title: "Reserve durable exact review lease",
+    html_url: "https://github.com/openclaw/openclaw/pull/357",
+    created_at: "2026-07-15T00:00:00Z",
+    updated_at: "2026-07-15T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    pull_request: {}
+  }));
+} else if (args[0] === "api" && path === "repos/openclaw/openclaw/pulls/357") {
+  console.log(JSON.stringify({ head: { sha: headSha } }));
+} else if (args[0] === "api" && path === "repos/openclaw/openclaw/issues/357/comments" && args.includes("--method")) {
+  writeFileSync(leasePath, readFileSync(args[args.indexOf("--input") + 1], "utf8"));
+  console.log(JSON.stringify({ id: 9992 }));
+} else if (args[0] === "api" && path.startsWith("repos/openclaw/openclaw/issues/357/comments")) {
+  console.log(JSON.stringify(args.includes("--slurp") ? [[]] : []));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`,
+      "utf8",
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "reserve-review-lease",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--item-number",
+        "357",
+        "--review-timeout-ms",
+        "600000",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...mockGhBinEnv(ghPath, binDir),
+          GITHUB_RUN_ID: "999",
+          GITHUB_RUN_ATTEMPT: "1",
+          EXACT_REVIEW_QUEUE_URL: "https://queue.example.invalid",
+          EXACT_REVIEW_ITEM_KEY: "openclaw/openclaw#357",
+          EXACT_REVIEW_LEASE_ID: "lease-357",
+          EXACT_REVIEW_LEASE_REVISION: "1",
+          EXACT_REVIEW_CLAIM_GENERATION: "1",
+          EXACT_REVIEW_SOURCE_HEAD_SHA: queuedHeadSha,
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const reservation = JSON.parse(result.stdout);
+    assert.equal(reservation.status, "superseded");
+    assert.equal(reservation.reason, "source_head_drift");
+    assert.match(result.stderr, /does not match the current pull request head/);
+    assert.equal(existsSync(leasePath), false, "no lease comment may be posted on drift");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("reserve-review-lease stale A preserves newer-head lease B", () => {
   const root = mkdtempSync(join(tmpdir(), "cmd-reserve-lease-race-"));
   const binDir = join(root, "bin");


### PR DESCRIPTION
## Problem

~9% of review runs still fail post-#962 with `Exact-review queue authority source head does not match the current pull request.` (sample runs 30558755321, 30558626014). The queued exact-head entry is simply stale — the PR received a newer push, which enqueued its own exact-head event. The reservation command threw, the run failed as `codex_or_content_failure`, and the item burned one of its eight review-failure park attempts for what is ordinary drift.

## Fix

`reserve-review-lease` now reports `{"status":"superseded","reason":"source_head_drift"}` on head drift instead of throwing. The workflow already maps a `superseded` reservation to a successful no-op with a clean queue completion (`Export exact review generation result` → outcome=success); the newer push's own event (backstopped by the scheduled sweep) owns reviewing the current head. No lease comment is posted on this path.

## Proof

- Regression test: fake `gh` serves a live PR head different from `EXACT_REVIEW_SOURCE_HEAD_SHA`; asserts exit 0, superseded JSON, and that no lease comment is created. Red on pre-fix code (command exits 1), green with the fix.
- Full `test/command.test.ts` suite passes.
- Autoreview (codex, xhigh): clean, "patch is correct (0.99)".
