### PR TITLE
fix(state): retry transient invalid 2xx bodies in worker record requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.
 - Exact reviews of items that closed after enqueue now complete as superseded no-ops, and GitHub-throttled reservations defer as held retries — neither spends the item's review-failure budget.
 - Trimmed the exact-review feed rate from 600/h to 450/h after the resumed apply and comment-sync lanes pushed the shared GitHub App installation token into rate-limit 403s.
 - Exact reviews whose pull request head moved past the queued authority now complete as superseded no-ops (the newer push owns its own review) instead of failing and burning the item's review-failure budget.

--- a/scripts/worker-records.ts
+++ b/scripts/worker-records.ts
@@ -734,29 +734,36 @@ export async function signedPost<T>(options: {
   body: unknown;
   fetch?: typeof globalThis.fetch;
 }): Promise<T> {
-  const response = await signedRequest(options);
-  // Read the body exactly once; a Response body is a one-shot stream and a
-  // later clone() of a consumed response throws, masking the real failure.
-  const bodyText = await response.text().catch(() => "");
-  if (!response.ok) throw workerRequestError(response.status, bodyText);
-  let value: unknown;
-  try {
-    value = JSON.parse(bodyText);
-  } catch {
-    value = undefined;
+  for (let attempt = 1; ; attempt += 1) {
+    const response = await signedRequest(options);
+    // Read the body exactly once; a Response body is a one-shot stream and a
+    // later clone() of a consumed response throws, masking the real failure.
+    const bodyText = await response.text().catch(() => "");
+    if (!response.ok) throw workerRequestError(response.status, bodyText);
+    let value: unknown;
+    try {
+      value = JSON.parse(bodyText);
+    } catch {
+      value = undefined;
+    }
+    // A 2xx whose body is empty, non-JSON, or a JSON null/primitive (e.g. a
+    // literal "null" page) is a protocol violation — every endpoint returns an
+    // object envelope. The edge occasionally serves such bodies transiently
+    // (observed as blank 200s), so retry within the bounded budget before
+    // failing loudly with the status and a body snippet.
+    if (typeof value !== "object" || value === null) {
+      if (attempt < SIGNED_REQUEST_MAX_ATTEMPTS) {
+        await signedRequestBackoff(attempt);
+        continue;
+      }
+      throw new WorkerRecordRequestError(
+        response.status,
+        "invalid_json_body",
+        bodyText.trim().slice(0, 200),
+      );
+    }
+    return value as T;
   }
-  // A 2xx whose body is empty, non-JSON, or a JSON null/primitive (e.g. a
-  // literal "null" page) is a protocol violation — every endpoint returns an
-  // object envelope. Returning it would crash callers far from the request;
-  // fail loudly with the status and a body snippet instead.
-  if (typeof value !== "object" || value === null) {
-    throw new WorkerRecordRequestError(
-      response.status,
-      "invalid_json_body",
-      bodyText.trim().slice(0, 200),
-    );
-  }
-  return value as T;
 }
 
 const SIGNED_REQUEST_MAX_ATTEMPTS = 3;

--- a/test/worker-records-request.test.ts
+++ b/test/worker-records-request.test.ts
@@ -60,8 +60,12 @@ test("signedPost includes a body snippet for non-JSON error bodies", async () =>
   );
 });
 
-test("signedPost throws invalid_json_body for a 2xx response with an empty body", async () => {
-  const { calls, fetchImpl } = fetchStub([jsonResponse(200, "")]);
+test("signedPost throws invalid_json_body for persistently empty 2xx bodies", async () => {
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(200, ""),
+    jsonResponse(200, ""),
+    jsonResponse(200, ""),
+  ]);
   await assert.rejects(
     signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
     (error: Error & { status?: number; code?: string; bodySnippet?: string }) => {
@@ -72,11 +76,26 @@ test("signedPost throws invalid_json_body for a 2xx response with an empty body"
       return true;
     },
   );
-  assert.equal(calls.length, 1, "2xx must not retry");
+  assert.equal(calls.length, 3, "transient blank 2xx bodies retry within the bounded budget");
+});
+
+test("signedPost recovers when a blank 2xx body clears on retry", async () => {
+  const { calls, fetchImpl } = fetchStub([jsonResponse(200, ""), jsonResponse(200, { ok: true })]);
+  const value = await signedPost<{ ok: boolean }>({
+    baseUrl,
+    path: "/internal/test",
+    webhookSecret,
+    body: {},
+    fetch: fetchImpl,
+  });
+  assert.deepEqual(value, { ok: true });
+  assert.equal(calls.length, 2);
 });
 
 test("signedPost throws invalid_json_body with a snippet for a 2xx HTML body", async () => {
   const { fetchImpl } = fetchStub([
+    jsonResponse(200, "<html><body>maintenance page</body></html>", "text/html"),
+    jsonResponse(200, "<html><body>maintenance page</body></html>", "text/html"),
     jsonResponse(200, "<html><body>maintenance page</body></html>", "text/html"),
   ]);
   await assert.rejects(
@@ -94,7 +113,11 @@ test("signedPost throws invalid_json_body with a snippet for a 2xx HTML body", a
 });
 
 test("signedPost throws invalid_json_body for a 2xx response with a literal null body", async () => {
-  const { calls, fetchImpl } = fetchStub([jsonResponse(200, "null")]);
+  const { calls, fetchImpl } = fetchStub([
+    jsonResponse(200, "null"),
+    jsonResponse(200, "null"),
+    jsonResponse(200, "null"),
+  ]);
   await assert.rejects(
     signedPost({ baseUrl, path: "/internal/test", webhookSecret, body: {}, fetch: fetchImpl }),
     (error: Error & { status?: number; code?: string; bodySnippet?: string }) => {
@@ -105,7 +128,7 @@ test("signedPost throws invalid_json_body for a 2xx response with a literal null
       return true;
     },
   );
-  assert.equal(calls.length, 1);
+  assert.equal(calls.length, 3);
 });
 
 test("signedPost resends the full JSON request body on a retry after a 502", async () => {


### PR DESCRIPTION
## Problem

Run 30569173886 failed hydration with `WorkerRecordRequestError: Worker record request failed (200): invalid_json_body` — the edge transiently served a blank 200. #888 made this fail loudly (correct — better than crashing callers far from the request), but a single transient blank body still kills the whole review run.

## Fix

`signedPost` now retries invalid 2xx bodies within the existing `SIGNED_REQUEST_MAX_ATTEMPTS` budget (3 attempts, exponential backoff), throwing the same `invalid_json_body` error with body snippet if the condition persists. 4xx behavior unchanged (deterministic, no retry); 5xx/network retry behavior unchanged.

## Proof

- Updated tests: persistent blank/HTML/null 2xx bodies now assert 3 attempts before the error; new recovery test asserts a blank 200 followed by a valid 200 returns the value on attempt 2.
- Suite: worker-records-request 13/13.
- Autoreview (codex, xhigh): clean, "patch is correct (0.99)".
