### PR TITLE
fix(review): stop re-reviewing unchanged heads after duplicate checks

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -54,6 +54,7 @@ import {
 } from "./github-retry.js";
 import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
 import { stableJson } from "./stable-json.js";
+import { reviewPullChecksDigestParts } from "./review-checks-digest.js";
 import { coverageTrackedItemIdsFromManifest } from "./review-coverage-manifest.js";
 import {
   LEGACY_FIXED_CLOSE_SKIP_ACTIONS,
@@ -3184,7 +3185,7 @@ function itemContentDigest(item: Item, context: ItemContext, git?: GitInfo): str
         ? (context.pullReviewCommentsRevision ??
           reviewCommentDigestParts(context.pullReviewComments))
         : null,
-      checks: isPull ? (context.pullChecks ?? null) : null,
+      checks: isPull ? reviewPullChecksDigestParts(context.pullChecks ?? null) : null,
     }),
   );
 }
@@ -9165,7 +9166,7 @@ function fetchReviewStructuralRecord(options: {
     if (!headSha) return null;
     const pullChecks = pullChecksContext(options.item.number, headSha);
     if (!completePullChecksContext(pullChecks)) return null;
-    pullChecksDigest = sha256(stableJson(pullChecks));
+    pullChecksDigest = sha256(stableJson(reviewPullChecksDigestParts(pullChecks)));
   }
   return reviewStructuralRecordFromGraphql({
     response,

--- a/src/review-checks-digest.ts
+++ b/src/review-checks-digest.ts
@@ -1,0 +1,17 @@
+import { stableJsonCodeUnit } from "./stable-json.js";
+
+export function reviewPullChecksDigestParts(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const checks = value as Record<string, unknown>;
+  if (!Array.isArray(checks.checkRuns)) return value;
+
+  const seen = new Set<string>();
+  const checkRuns = checks.checkRuns.filter((checkRun) => {
+    const identity = stableJsonCodeUnit(checkRun);
+    if (seen.has(identity)) return false;
+    seen.add(identity);
+    return true;
+  });
+
+  return checkRuns.length === checks.checkRuns.length ? value : { ...checks, checkRuns };
+}

--- a/src/review-semantic-cache.ts
+++ b/src/review-semantic-cache.ts
@@ -6,6 +6,7 @@ import { createVirtualFileSystem, type FileSystem } from "typescript/unstable/fs
 import { API } from "typescript/unstable/sync";
 
 import { REVIEW_CACHE_MAX_AGE_DAYS } from "./scheduler-policy.js";
+import { reviewPullChecksDigestParts } from "./review-checks-digest.js";
 import { stableJsonCodeUnit as stableJson } from "./stable-json.js";
 
 export const REVIEW_SEMANTIC_CACHE_VERSION = 10;
@@ -782,7 +783,7 @@ function semanticContext(input: ReviewSemanticInput): {
     reviewComments:
       input.context.pullReviewCommentsRevision ??
       normalizedComments(input.context.pullReviewComments),
-    checks: input.context.pullChecks ?? null,
+    checks: reviewPullChecksDigestParts(input.context.pullChecks ?? null),
     completeness: {
       commentsTruncated: input.context.counts?.commentsTruncated ?? null,
       timelineTruncated: input.context.counts?.timelineTruncated ?? null,

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -166,7 +166,10 @@ test("structural cache probes before hydration but acquires a lease before carry
     source.indexOf("function collectItemContext"),
   );
   assert.match(structuralProbeSource, /pullChecksContext\(options\.item\.number, headSha\)/);
-  assert.match(structuralProbeSource, /pullChecksDigest = sha256\(stableJson\(pullChecks\)\)/);
+  assert.match(
+    structuralProbeSource,
+    /pullChecksDigest = sha256\(stableJson\(reviewPullChecksDigestParts\(pullChecks\)\)\)/,
+  );
   assert.match(structuralProbeSource, /if \(!options\.git\.releaseStateComplete\) return null/);
   const gitInfoBlock = source.slice(
     source.indexOf("function gitInfo("),

--- a/test/review-content-cache.test.ts
+++ b/test/review-content-cache.test.ts
@@ -294,6 +294,101 @@ test("content digest busts when bounded PR check state changes", () => {
   assert.notEqual(passing, failing);
 });
 
+test("content digest ignores duplicate compacted PR check runs", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const notify = {
+    name: "notify",
+    status: "completed",
+    conclusion: "success",
+    app: "github-actions",
+  };
+  const once = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullChecks: {
+        complete: true,
+        checkRuns: [notify],
+        checkRunsTruncated: false,
+        statuses: [],
+        statusesTruncated: false,
+      },
+    }),
+  );
+  const repeated = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullChecks: {
+        complete: true,
+        checkRuns: [notify, notify],
+        checkRunsTruncated: false,
+        statuses: [],
+        statusesTruncated: false,
+      },
+    }),
+  );
+
+  assert.equal(once, repeated);
+});
+
+test("content digest keeps check runs that differ only in name or app", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const check = {
+    name: "smoke",
+    status: "completed",
+    conclusion: "success",
+    app: "github-actions",
+  };
+  const digest = (checkRuns) =>
+    itemContentDigestForTest(
+      pull,
+      pullContext({
+        pullChecks: {
+          complete: true,
+          checkRuns,
+          checkRunsTruncated: false,
+          statuses: [],
+          statusesTruncated: false,
+        },
+      }),
+    );
+
+  const alone = digest([check]);
+  const byName = digest([check, { ...check, name: "smoke (windows)" }]);
+  const byApp = digest([check, { ...check, app: "blacksmith-sh" }]);
+
+  assert.notEqual(alone, byName);
+  assert.notEqual(alone, byApp);
+  assert.notEqual(byName, byApp);
+});
+
+test("content digest busts when one of several repeated check runs newly fails", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const notify = {
+    name: "notify",
+    status: "completed",
+    conclusion: "success",
+    app: "github-actions",
+  };
+  const digest = (checkRuns) =>
+    itemContentDigestForTest(
+      pull,
+      pullContext({
+        pullChecks: {
+          complete: true,
+          checkRuns,
+          checkRunsTruncated: false,
+          statuses: [],
+          statusesTruncated: false,
+        },
+      }),
+    );
+
+  const allPassing = digest([notify, notify, notify]);
+  const oneFailing = digest([notify, notify, { ...notify, conclusion: "failure" }]);
+
+  assert.notEqual(allPassing, oneFailing);
+});
+
 test("review comment revision covers comments outside the bounded prompt window", () => {
   const comments = Array.from({ length: 81 }, (_, index) => ({
     id: index + 1,
@@ -351,6 +446,48 @@ function cacheHit(overrides = {}) {
 
 test("cache hits when content is unchanged, fresh, complete, and policy matches", () => {
   assert.equal(cacheHit(), true);
+});
+
+test("cache hits after an equivalent check run is repeated on an unchanged head", () => {
+  const pull = item({ kind: "pull_request", number: 200 });
+  const notify = {
+    name: "notify",
+    status: "completed",
+    conclusion: "success",
+    app: "github-actions",
+  };
+  const priorDigest = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullChecks: {
+        complete: true,
+        checkRuns: [notify],
+        checkRunsTruncated: false,
+        statuses: [],
+        statusesTruncated: false,
+      },
+    }),
+  );
+  const currentDigest = itemContentDigestForTest(
+    pull,
+    pullContext({
+      pullChecks: {
+        complete: true,
+        checkRuns: [notify, notify],
+        checkRunsTruncated: false,
+        statuses: [],
+        statusesTruncated: false,
+      },
+    }),
+  );
+
+  assert.equal(
+    cacheHit({
+      review: freshReview({ contentDigest: priorDigest }),
+      contentDigest: currentDigest,
+    }),
+    true,
+  );
 });
 
 test("cache misses when the content digest differs", () => {

--- a/test/review-semantic-cache.test.ts
+++ b/test/review-semantic-cache.test.ts
@@ -1079,6 +1079,22 @@ test("changed discussion, reviews, checks, or target context busts the context d
   }
 });
 
+test("duplicate compacted check runs do not perturb the semantic context digest", () => {
+  const prior = record();
+  const checkRuns = input().context.pullChecks.checkRuns;
+  const repeated = record({
+    context: {
+      pullChecks: {
+        ...input().context.pullChecks,
+        checkRuns: [...checkRuns, ...checkRuns],
+      },
+    },
+  });
+
+  assert.equal(prior.contextDigest, repeated.contextDigest);
+  assert.equal(decision({ priorRecord: prior, currentRecord: repeated }).reason, "hit");
+});
+
 test("head SHA churn alone does not perturb semantic or context digests", () => {
   const prior = record();
   const rebased = record({


### PR DESCRIPTION
Closes #967

## What Problem This Solves

Fixes an issue where contributors with an unchanged pull-request head could receive repeated full ClawSweeper reviews after equivalent GitHub Actions check runs accumulated on that head. Those unnecessary cycles consume review capacity and can expose contributors to different model verdicts despite no change to their code or discussion.

## Why This Change Was Made

Cache-key construction now de-duplicates equivalent compacted check-run tuples across the structural, semantic, and content review caches. The full check context supplied to the reviewer is deliberately unchanged; distinct names, apps, statuses, or conclusions still invalidate the relevant caches, and existing completeness/truncation safeguards remain intact.

This keeps the repair at the cache identity boundary requested in #967 rather than introducing a workflow-name allowlist or hiding repeated runs from review context.

## User Impact

An unchanged PR head no longer receives another full review solely because automation appended another equivalent check run. Meaningful CI changes—such as a previously successful check failing—continue to trigger fresh evaluation.

## Evidence

- Added a regression proving one additional `{name,status,conclusion,app}` duplicate leaves the content digest unchanged.
- Added an end-to-end cache-predicate regression proving the unchanged head is reused instead of sent through another full review.
- Added semantic-cache coverage and updated the structural-cache source assertion so all three cache layers use the same normalization boundary.
- Added contributor-suggested identity regressions proving runs that differ only by name or app remain distinct, and that one failure among several repeated runs invalidates the cache.
- Mutation proof: narrowing the identity to name-only makes exactly those two guard tests fail (38/40); restoring full-object identity returns the content-cache suite to 40/40.
- The new regression failed on unmodified `main` before the fix: the two equivalent contexts produced different content digests.
- Rebased onto current `main` at `c8f44886fde43c44187a2f239dc0623fdaa279de`.
- `pnpm run check:static`, `pnpm run build:all`, and `pnpm run lint` pass on Node 26.5.0 / pnpm 11.10.0.
- 148 focused content, semantic, structural, and review-flow tests pass.
- `pnpm run check` completes all changed-surface validation; its five remaining failures are in repair files unchanged from `origin/main` and are Linux Landlock/capability tests running on macOS (`capset` is absent from Darwin libc). Hosted Linux CI is the authoritative full-suite result.
- Codex review of both the uncommitted change and committed branch found no actionable defects.

## Real Behavior Proof

**Claim:** Adding another equivalent compacted check run to an unchanged PR head preserves the review cache identity, while a distinct failure still invalidates it.

**Exercised surface:** The production `itemContentDigestForTest` export and `reviewContentCacheHit` predicate from the built package.

**Scenario:** The fixture keeps the PR source revision, head, base, files, timeline, and check outcome fixed. It compares one successful `notify` run with two byte-equivalent successful `notify` runs, then changes the second run's conclusion to `failure`.

**Command and environment:** A Node 26.5.0 ESM harness against `pnpm run build` output on macOS 15.

**Observed result:**

```json
{
  "priorDigest": "aadae6eeaf1ce3ecfc7c0ef8eeeb72b8d1c18c6c693ff9fd38268154e260cbf5",
  "repeatedDigest": "aadae6eeaf1ce3ecfc7c0ef8eeeb72b8d1c18c6c693ff9fd38268154e260cbf5",
  "duplicateStable": true,
  "distinctFailureInvalidates": true,
  "cacheHit": true
}
```

**Trace:** The executable fixture is captured as the focused regression in `test/review-content-cache.test.ts`; semantic identity is independently covered in `test/review-semantic-cache.test.ts`.

**Limits:** This does not alter check-run collection, the reviewer-visible context, the 100-run completeness boundary, scheduler cadence, explicit re-review commands, or maintainer-request behavior.

## AI Assistance

This PR was implemented and reviewed with OpenAI Codex assistance. The author ran and inspected the reported validation and remains responsible for the change.
