### PR TITLE
fix: prioritize safe closures over bounded comment maintenance

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4961,13 +4961,14 @@ jobs:
           stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
           close_delay_ms="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_close_delay_ms || '2000' }}"
           checkpoint_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_checkpoint_size || '40' }}"
-          comment_sync_processed_limit=1000
+          comment_sync_processed_limit=40
           base_close_processed_limit=600
           close_processed_limit="$base_close_processed_limit"
           adaptive_apply_scan_reason="base_window"
           sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
-          sync_open_pr_batch="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}"
+          scheduled_comment_sync="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}"
+          sync_open_pr_batch="$scheduled_comment_sync"
           if [ "$item_numbers" = "__cursor__" ]; then
             sync_open_pr_batch="true"
             item_numbers=""
@@ -5011,11 +5012,8 @@ jobs:
           candidate_counts_json=""
           cursor_advance_count=""
           coverage_proof_item_numbers=""
-          if [ "$sync_open_pr_batch" = "true" ]; then
-            sync_comments_only="true"
-            apply_kind="pull_request"
-            comment_sync_min_age_days="0"
-          fi
+          normalize_comment_sync_mode
+          prepare_comment_sync_batch
           sync_comments_arg=()
           if [ "$sync_comments_only" = "true" ]; then
             sync_comments_arg=(--sync-comments-only)
@@ -5123,18 +5121,16 @@ jobs:
               --close-delay-ms "$close_delay_ms" \
               --progress-every "$progress_every" \
               --processed-limit "$comment_sync_processed_limit" \
+              --max-runtime-ms 300000 \
+              --cursor-trace ".artifacts/comment-sync-trace-$checkpoint.json" \
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
               "${sync_comments_arg[@]}"
             cp apply-report.json ".artifacts/apply-reports/apply-report-$checkpoint.json"
             result_count="$(pnpm run --silent workflow -- count-report --report ".artifacts/apply-reports/apply-report-$checkpoint.json")"
             synced_count="$(pnpm run --silent workflow -- count-actions --report ".artifacts/apply-reports/apply-report-$checkpoint.json" --action review_comment_synced)"
-            if [ "$sync_open_pr_batch" = "true" ]; then
-              pnpm run workflow -- write-comment-sync-cursor \
-                --cursor-path "$cursor_path" \
-                --next-cursor "$next_cursor" \
-                --target-repo "$TARGET_REPO"
-            fi
+            comment_sync_checkpoint_items="$item_numbers"
+            complete_comment_sync_batch ".artifacts/apply-reports/apply-report-$checkpoint.json" ".artifacts/comment-sync-trace-$checkpoint.json"
             publish_changes "chore: sync sweep review comments checkpoint $checkpoint" records apply-report.json results/comment-sync-cursors
             comment_sync_health_cursor_path=""
             comment_sync_health_cursor_required="false"
@@ -5144,11 +5140,11 @@ jobs:
               comment_sync_health_cursor_required="true"
               comment_sync_health_processed_limit="$sync_batch_size"
             fi
-            write_apply_health ".artifacts/apply-reports/apply-report-$checkpoint.json" ".artifacts/apply-health-$checkpoint.json" "comment_sync" "$comment_sync_health_processed_limit" "$comment_sync_health_cursor_path" "$comment_sync_health_cursor_required" "" "" ""
+            write_comment_sync_health ".artifacts/apply-reports/apply-report-$checkpoint.json" ".artifacts/apply-health-$checkpoint.json"
             pnpm run status -- \
               --target-repo "$TARGET_REPO" \
               --state "Apply comments synced" \
-              --detail "Comment-only apply checkpoint $checkpoint finished. Synced durable review comments: $synced_count. Result records: $result_count. Item numbers: ${item_numbers:-all}. Next cursor: ${next_cursor:-none}." \
+              --detail "Comment-only apply checkpoint $checkpoint finished. Synced durable review comments: $synced_count. Result records: $result_count. Item numbers: ${comment_sync_checkpoint_items:-all}. Next cursor: ${next_cursor:-none}." \
               --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
               --apply-health-file ".artifacts/apply-health-$checkpoint.json"
             publish_status "chore: update sweep comment sync status"
@@ -5281,6 +5277,7 @@ jobs:
               final_health_cursor_path="$cursor_path"
               final_health_cursor_required="true"
               final_health_processed_limit="$sync_batch_size"
+              final_health_cursor_advance_count="$comment_sync_cursor_advance_count"
             fi
           fi
           write_apply_health "apply-report.json" ".artifacts/apply-health-final.json" "$final_health_mode" "$final_health_processed_limit" "$final_health_cursor_path" "$final_health_cursor_required" "$final_health_candidate_count" "$final_health_scheduled_interval_minutes" "$final_health_cursor_advance_count" "$final_health_candidate_counts_json"
@@ -5397,11 +5394,6 @@ jobs:
             echo "Apply checkpoint has no continuation work; not queueing another apply run."
             exit 0
           fi
-          if [ "${APPLY_SYNC_COMMENTS_ONLY:-false}" = "true" ]; then
-            echo "Comment-only apply run finished; not queueing another apply run."
-            exit 0
-          fi
-
           can_share_apply_continuation=false
           if [ "${APPLY_AUTO_SELECTED_BATCH:-false}" = "true" ] &&
             [ -z "${APPLY_ITEM_NUMBERS:-}" ] &&

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5045,6 +5045,8 @@ jobs:
             item_numbers="$(awk -F= '$1 == "item_numbers" { print $2 }' "$batch_env")"
             next_cursor="$(awk -F= '$1 == "next_cursor" { print $2 }' "$batch_env")"
             batch_count="$(awk -F= '$1 == "count" { print $2 }' "$batch_env")"
+            trim_comment_sync_cycle_batch
+            [ -n "$item_numbers" ] || batch_count=0
             if [ "${batch_count:-0}" -eq 0 ]; then
               pnpm run status -- \
                 --target-repo "$TARGET_REPO" \

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -44,6 +44,225 @@ report_apply_token_budget_stop() {
   fi
 }
 
+normalize_comment_sync_mode() {
+  if [ "${sync_open_pr_batch:-false}" != "true" ]; then
+    return 0
+  fi
+  sync_comments_only=true
+  if [ "${scheduled_comment_sync:-false}" = "true" ]; then
+    apply_kind="pull_request"
+    comment_sync_min_age_days=0
+  fi
+}
+
+prepare_comment_sync_batch() {
+  comment_sync_pending_items=""
+  comment_sync_cursor_advance_count=0
+  comment_sync_initial_cursor=0
+  comment_sync_cycle_start=0
+  comment_sync_cycle_wrapped=false
+  if [ "${sync_comments_only:-false}" != "true" ]; then
+    return 0
+  fi
+  if [ -z "${item_numbers:-}" ] &&
+    [ "${scheduled_comment_sync:-false}" != "true" ] &&
+    { [ "${apply_kind:-all}" != "pull_request" ] ||
+      [ "${comment_sync_min_age_days:-0}" != "0" ]; }; then
+    cursor_path="results/comment-sync-cursors/${target_slug}-${apply_kind:-all}-age${comment_sync_min_age_days:-0}.json"
+  fi
+  if [ -f "${cursor_path:-}" ]; then
+    comment_sync_initial_cursor="$(jq -er '
+      if (.next_after_number | type) == "number" and .next_after_number >= 0 and
+         (.next_after_number | floor) == .next_after_number
+      then .next_after_number
+      else error("comment sync cursor is invalid")
+      end
+    ' "$cursor_path")"
+    comment_sync_cycle_start="$(jq -er --argjson cursor "$comment_sync_initial_cursor" '
+      .cycle_start_after_number // $cursor
+      | if type == "number" and . >= 0 and floor == . then .
+        else error("comment sync cycle start is invalid") end
+    ' "$cursor_path")"
+    comment_sync_cycle_wrapped="$(jq -r '
+      .cycle_wrapped // false
+      | if type == "boolean" then . else error("comment sync cycle state is invalid") end
+    ' "$cursor_path")"
+  fi
+  if [ "$sync_batch_size" -le 0 ]; then
+    sync_batch_size="$comment_sync_processed_limit"
+  fi
+  if [ "$sync_batch_size" -gt "$comment_sync_processed_limit" ]; then
+    echo "Capping comment sync batch at $comment_sync_processed_limit items."
+    sync_batch_size="$comment_sync_processed_limit"
+  fi
+  if [ -z "${item_numbers:-}" ] && [ "${sync_open_pr_batch:-false}" != "true" ]; then
+    mkdir -p .artifacts
+    local batch_env
+    batch_env="$(mktemp .artifacts/comment-sync-all.XXXXXX)"
+    cursor_path="${cursor_path:-results/comment-sync-cursors/${target_slug}.json}"
+    pnpm run --silent workflow -- comment-sync-batch \
+      --target-repo "$TARGET_REPO" \
+      --apply-kind "$apply_kind" \
+      --batch-size "$comment_sync_processed_limit" \
+      --cursor-path "$cursor_path" > "$batch_env"
+    item_numbers="$(awk -F= '$1 == "item_numbers" { print $2 }' "$batch_env")"
+    next_cursor="$(awk -F= '$1 == "next_cursor" { print $2 }' "$batch_env")"
+    sync_open_pr_batch=true
+    sync_batch_size="$comment_sync_processed_limit"
+  fi
+  if [ -n "${item_numbers:-}" ]; then
+    local requested_item_numbers="$item_numbers"
+    item_numbers="$(jq -nr --arg selected "$item_numbers" '
+      reduce (
+        $selected | split(",")[] | gsub("^\\s+|\\s+$"; "")
+        | select(length > 0) | tonumber?
+        | select(. > 0 and . == floor)
+      ) as $item ([]; if index($item) == null then . + [$item] else . end)
+      | sort | map(tostring) | join(",")
+    ')"
+    if [ -z "$item_numbers" ]; then
+      echo "Comment sync request contains no valid positive item numbers: $requested_item_numbers" >&2
+      return 1
+    fi
+    local requested_items
+    IFS=, read -r -a requested_items <<<"$item_numbers"
+    if [ "${#requested_items[@]}" -gt "$comment_sync_processed_limit" ]; then
+      comment_sync_pending_items="$(IFS=,; printf '%s' "${requested_items[*]:comment_sync_processed_limit}")"
+      item_numbers="$(IFS=,; printf '%s' "${requested_items[*]:0:comment_sync_processed_limit}")"
+      echo "Splitting comment sync into $comment_sync_processed_limit-item checkpoints."
+    fi
+  fi
+}
+
+complete_comment_sync_batch() {
+  local report_path="$1"
+  local trace_path="$2"
+  local completed_csv
+  if ! completed_csv="$(jq -er --arg selected "${item_numbers:-}" '
+    .examined_item_numbers as $examined
+    | ($selected | if . == "" then [] else split(",") | map(tonumber) end) as $selected
+    | if .schema_version == 1 and
+        ($examined | type) == "array" and
+        (($selected | length) == 0 or
+          (all($examined[]; . as $number | $selected | index($number) != null) and
+            ($examined | unique | length) == ($examined | length)))
+      then $examined | join(",")
+      else error("comment sync trace contains invalid or unselected items")
+      end
+  ' "$trace_path")"; then
+    echo "::warning::Comment sync trace could not be trusted; preserving the canonical checkpoint without cursor advancement."
+    completed_csv=""
+  fi
+  local selected_items=()
+  if [ -n "${item_numbers:-}" ]; then
+    IFS=, read -r -a selected_items <<<"$item_numbers"
+  fi
+  local completed_count=0
+  local cursor_count=0
+  local safe_cursor=""
+  local blocked_prefix=false
+  local unfinished_items=()
+  local selected_item
+  for selected_item in "${selected_items[@]}"; do
+    case ",$completed_csv," in
+      *",$selected_item,"*)
+        completed_count=$((completed_count + 1))
+        if [ "$blocked_prefix" != "true" ]; then
+          safe_cursor="$selected_item"
+          cursor_count=$((cursor_count + 1))
+        fi
+        ;;
+      *)
+        blocked_prefix=true
+        unfinished_items+=("$selected_item")
+        ;;
+    esac
+  done
+  if [ "${#selected_items[@]}" -eq 0 ] && [ -n "$completed_csv" ]; then
+    completed_count="$(awk -F, '{ print NF }' <<<"$completed_csv")"
+  fi
+  comment_sync_cursor_advance_count="$cursor_count"
+
+  if [ "$sync_open_pr_batch" = "true" ]; then
+    if [ "$cursor_count" -eq 0 ]; then
+      echo "Comment sync made no cursor progress; the next scheduled batch retries it."
+      next_cursor=""
+      return 0
+    fi
+    next_cursor="$safe_cursor"
+    pnpm run workflow -- write-comment-sync-cursor \
+      --cursor-path "$cursor_path" \
+      --next-cursor "$next_cursor" \
+      --target-repo "$TARGET_REPO"
+    if [ "$TARGET_REPO" != "openclaw/openclaw" ] ||
+      [ "${apply_kind:-pull_request}" != "pull_request" ] ||
+      [ "${comment_sync_min_age_days:-0}" != "0" ]; then
+      local initial_cursor="${comment_sync_initial_cursor:-0}"
+      local cycle_start="${comment_sync_cycle_start:-0}"
+      local cycle_wrapped="${comment_sync_cycle_wrapped:-false}"
+      if [ "${#selected_items[@]}" -gt 0 ] &&
+        [ "${selected_items[0]}" -le "$initial_cursor" ] &&
+        [ "$initial_cursor" -gt 0 ]; then
+        cycle_wrapped=true
+      fi
+      local lookahead_env
+      lookahead_env="$(mktemp .artifacts/comment-sync-lookahead.XXXXXX)"
+      pnpm run --silent workflow -- comment-sync-batch \
+        --target-repo "$TARGET_REPO" \
+        --apply-kind "$apply_kind" \
+        --batch-size "$sync_batch_size" \
+        --cursor-path "$cursor_path" > "$lookahead_env"
+      local lookahead_wrapped
+      lookahead_wrapped="$(awk -F= '$1 == "wrapped" { print $2 }' "$lookahead_env")"
+      local lookahead_count
+      lookahead_count="$(awk -F= '$1 == "count" { print $2 }' "$lookahead_env")"
+      if [ "$lookahead_wrapped" = "true" ]; then
+        if [ "$cycle_start" -gt 0 ] && [ "$cycle_wrapped" != "true" ]; then
+          cycle_wrapped=true
+        else
+          lookahead_count=0
+        fi
+      fi
+      if [ "$cycle_wrapped" = "true" ] &&
+        [ "${#selected_items[@]}" -gt 0 ] &&
+        [ "${selected_items[0]}" -le "$cycle_start" ] &&
+        [ "$safe_cursor" -ge "$cycle_start" ]; then
+        lookahead_count=0
+      fi
+      if [ "$lookahead_count" -gt 0 ]; then
+        local cycle_cursor_path
+        cycle_cursor_path="$(mktemp "${cursor_path}.cycle.XXXXXX")"
+        jq --argjson start "$cycle_start" \
+          --argjson wrapped "$cycle_wrapped" \
+          '. + {cycle_start_after_number: $start, cycle_wrapped: $wrapped}' \
+          "$cursor_path" > "$cycle_cursor_path"
+        mv "$cycle_cursor_path" "$cursor_path"
+        item_numbers="__cursor__"
+        continue_apply=true
+        echo "Queued the next bounded comment-sync window outside scheduled maintenance coverage."
+        return 0
+      fi
+    fi
+    echo "Comment synchronization yielded its bounded cursor window to scheduled maintenance."
+    return 0
+  fi
+
+  if [ "${#unfinished_items[@]}" -gt 0 ]; then
+    local unfinished
+    unfinished="$(IFS=,; printf '%s' "${unfinished_items[*]}")"
+    comment_sync_pending_items="${unfinished}${comment_sync_pending_items:+,$comment_sync_pending_items}"
+  fi
+  if [ -n "$comment_sync_pending_items" ] && [ "$completed_count" -gt 0 ]; then
+    item_numbers="$comment_sync_pending_items"
+    continue_apply=true
+    echo "Queued the unfinished durable comment-sync checkpoint for continuation."
+  elif [ -n "$comment_sync_pending_items" ]; then
+    echo "Comment sync made no progress; stopping instead of occupying the apply lane with an endless retry."
+  elif jq -e 'any(.[]; .action == "skipped_runtime_budget")' "$report_path" >/dev/null; then
+    echo "Comment sync reached its runtime budget after its selected records completed."
+  fi
+}
+
 validate_coverage_proof_tree() {
   local proof_dir="$1"
   local max_files="${2:-2}"
@@ -148,6 +367,7 @@ publish_changes() {
   target_slug="${target_slug//\//-}"
   local record_paths=()
   local other_paths=()
+  local publishes_comment_sync_cursor=false
   local path
   for path in "$@"; do
     if [ "$path" = "records" ]; then
@@ -156,6 +376,10 @@ publish_changes() {
       record_paths+=("$path")
     else
       other_paths+=("$path")
+      if [ "$path" = "results/comment-sync-cursors" ] ||
+        [[ "$path" = results/comment-sync-cursors/* ]]; then
+        publishes_comment_sync_cursor=true
+      fi
     fi
   done
   if [ "${#record_paths[@]}" -gt 0 ]; then
@@ -164,6 +388,12 @@ publish_changes() {
   if [ "${#other_paths[@]}" -gt 0 ]; then
     if ! publish_changes_with_strategy theirs "$message" "${other_paths[@]}"; then
       echo "::warning title=Operational state publish failed::Canonical work remains valid; continuing after best-effort Git bookkeeping failed: $message" >&2
+      if [ "$publishes_comment_sync_cursor" = "true" ] &&
+        [ "${sync_open_pr_batch:-false}" = "true" ] &&
+        [ "${continue_apply:-false}" = "true" ]; then
+        continue_apply=false
+        echo "Stopping comment-sync continuation because its cursor was not published."
+      fi
     fi
   fi
 }
@@ -310,6 +540,14 @@ write_apply_health() {
     health_args+=(--cursor-advance-count "$health_cursor_advance_count")
   fi
   pnpm run --silent workflow -- summarize-apply-report "${health_args[@]}" > "$output_path"
+}
+
+write_comment_sync_health() {
+  write_apply_health "$1" "$2" "comment_sync" \
+    "$comment_sync_health_processed_limit" \
+    "$comment_sync_health_cursor_path" \
+    "$comment_sync_health_cursor_required" "" "" \
+    "$comment_sync_cursor_advance_count"
 }
 
 apply_checkpoint_examined_count() {

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -55,6 +55,31 @@ normalize_comment_sync_mode() {
   fi
 }
 
+trim_comment_sync_cycle_batch() {
+  if [ "${comment_sync_cycle_wrapped:-false}" != "true" ] ||
+    [ "${comment_sync_cycle_start:-0}" -le 0 ] ||
+    [ -z "${item_numbers:-}" ]; then
+    return 0
+  fi
+  local untrimmed_items="$item_numbers"
+  item_numbers="$(jq -nr \
+    --arg selected "$item_numbers" \
+    --argjson boundary "$comment_sync_cycle_start" '
+      $selected | split(",")
+      | map(tonumber? | select(. > 0 and . <= $boundary))
+      | unique | sort | map(tostring) | join(",")
+    ')"
+  if [ -z "$item_numbers" ]; then
+    local reset_cursor_path
+    reset_cursor_path="$(mktemp "${cursor_path}.reset.XXXXXX")"
+    jq 'del(.cycle_start_after_number, .cycle_wrapped)' "$cursor_path" > "$reset_cursor_path"
+    mv "$reset_cursor_path" "$cursor_path"
+    comment_sync_cycle_start="${comment_sync_initial_cursor:-0}"
+    comment_sync_cycle_wrapped=false
+    item_numbers="$untrimmed_items"
+  fi
+}
+
 prepare_comment_sync_batch() {
   comment_sync_pending_items=""
   comment_sync_cursor_advance_count=0
@@ -131,6 +156,9 @@ prepare_comment_sync_batch() {
       item_numbers="$(IFS=,; printf '%s' "${requested_items[*]:0:comment_sync_processed_limit}")"
       echo "Splitting comment sync into $comment_sync_processed_limit-item checkpoints."
     fi
+  fi
+  if [ "${sync_open_pr_batch:-false}" = "true" ]; then
+    trim_comment_sync_cycle_batch
   fi
 }
 
@@ -228,6 +256,14 @@ complete_comment_sync_batch() {
         [ "${selected_items[0]}" -le "$cycle_start" ] &&
         [ "$safe_cursor" -ge "$cycle_start" ]; then
         lookahead_count=0
+      fi
+      if [ "$cycle_wrapped" = "true" ] && [ "$lookahead_count" -gt 0 ]; then
+        local lookahead_items
+        lookahead_items="$(awk -F= '$1 == "item_numbers" { print $2 }' "$lookahead_env")"
+        local first_lookahead_item="${lookahead_items%%,*}"
+        if [ "$first_lookahead_item" -gt "$cycle_start" ]; then
+          lookahead_count=0
+        fi
       fi
       if [ "$lookahead_count" -gt 0 ]; then
         local cycle_cursor_path

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -2206,6 +2206,7 @@ function commentSyncCandidates(targetRepo: string, applyKind: string): number[] 
         actionTaken !== "kept_open" &&
         actionTaken !== "proposed_close" &&
         actionTaken !== "skipped_pr_close_coverage_proof" &&
+        actionTaken !== "retry_pr_close_coverage_proof" &&
         actionTaken !== "retry_stale_canonical_comment_sync" &&
         !changedDuplicateClose
       ) {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -2642,6 +2642,7 @@ test("workflow utilities select cursor-based PR comment sync batches", () => {
     reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/34#issuecomment-9034",
   });
   writeCommentSyncRecord(root, 35, "pull_request", "retry_stale_canonical_comment_sync");
+  writeCommentSyncRecord(root, 39, "pull_request", "retry_pr_close_coverage_proof");
   writeCommentSyncRecord(root, 36, "pull_request", "corrected_stale_canonical_comment");
   writeCommentSyncRecord(root, 37, "pull_request", "skipped_changed_since_review", {
     decision: "close",
@@ -2684,10 +2685,10 @@ test("workflow utilities select cursor-based PR comment sync batches", () => {
       }),
     ),
     {
-      item_numbers: "30,34,35",
-      count: "3",
+      item_numbers: "30,34,35,39",
+      count: "4",
       cursor: "20",
-      next_cursor: "35",
+      next_cursor: "39",
       wrapped: "false",
     },
   );

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2512,6 +2512,7 @@ test("unscheduled wrapped synchronization drains every bounded window and then s
           "  prepare_comment_sync_batch",
           '  pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path" > next.env',
           "  item_numbers=$(awk -F= '$1 == \"item_numbers\" { print $2 }' next.env)",
+          "  trim_comment_sync_cycle_batch",
           "done",
           'printf "continue=%s\\ncursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
         ].join("\n"),
@@ -2531,9 +2532,96 @@ test("unscheduled wrapped synchronization drains every bounded window and then s
     assert.match(output, /^window=6,7$/m);
     assert.match(output, /^window=1,2$/m);
     assert.match(output, /^window=3,4$/m);
-    assert.match(output, /^window=5,6$/m);
+    assert.match(output, /^window=5$/m);
+    assert.doesNotMatch(output, /^window=5,6$/m);
     assert.match(output, /^continue=false$/m);
-    assert.match(output, /^cursor=6$/m);
+    assert.match(output, /^cursor=5$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wrapped cursor state never widens an explicit comment-sync selection", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const cursor = join(root, "cursor.json");
+  writeFileSync(
+    cursor,
+    '{"next_after_number":2,"cycle_start_after_number":5,"cycle_wrapped":true}\n',
+  );
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          'cursor_path="$CURSOR_PATH"',
+          "item_numbers=99",
+          "prepare_comment_sync_batch",
+          'printf "selected=%s\\n" "$item_numbers"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CURSOR_PATH: cursor,
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=99$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wrapped cursor resets when every remaining boundary record disappears", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const cursor = join(root, "cursor.json");
+  writeFileSync(
+    cursor,
+    '{"next_after_number":2,"cycle_start_after_number":5,"cycle_wrapped":true}\n',
+  );
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=true",
+          'cursor_path="$CURSOR_PATH"',
+          "item_numbers=6,7",
+          "prepare_comment_sync_batch",
+          'printf "selected=%s\\nwrapped=%s\\nhas_cycle=%s\\n" "$item_numbers" "$comment_sync_cycle_wrapped" "$(jq -r \'has(\"cycle_wrapped\")\' "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CURSOR_PATH: cursor,
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=6,7$/m);
+    assert.match(output, /^wrapped=false$/m);
+    assert.match(output, /^has_cycle=false$/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2605,7 +2605,7 @@ test("wrapped cursor resets when every remaining boundary record disappears", ()
           'cursor_path="$CURSOR_PATH"',
           "item_numbers=6,7",
           "prepare_comment_sync_batch",
-          'printf "selected=%s\\nwrapped=%s\\nhas_cycle=%s\\n" "$item_numbers" "$comment_sync_cycle_wrapped" "$(jq -r \'has(\"cycle_wrapped\")\' "$cursor_path")"',
+          'printf "selected=%s\\nwrapped=%s\\nhas_cycle=%s\\n" "$item_numbers" "$comment_sync_cycle_wrapped" "$(jq -r \'has("cycle_wrapped")\' "$cursor_path")"',
         ].join("\n"),
       ],
       {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1909,8 +1909,21 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
     `apply run expression is ${runBody.length} characters; keep margin below GitHub's 21,000-character limit`,
   );
   assert.match(applyStep, /processed-limit "\$close_processed_limit"/);
-  assert.match(applyStep, /comment_sync_processed_limit=1000/);
+  assert.match(applyStep, /comment_sync_processed_limit=40/);
   assert.match(applyStep, /--processed-limit "\$comment_sync_processed_limit"/);
+  assert.match(applyStep, /prepare_comment_sync_batch/);
+  const commentSyncBranch = applyStep.slice(
+    applyStep.indexOf('if [ "$sync_comments_only" = "true" ]; then\n            checkpoint=1'),
+    applyStep.indexOf('\n          while [ "$closed_total" -lt "$limit" ]; do'),
+  );
+  assert.match(commentSyncBranch, /--max-runtime-ms 300000/);
+  assert.match(commentSyncBranch, /complete_comment_sync_batch/);
+  assert.match(
+    commentSyncBranch,
+    /--cursor-trace "\.artifacts\/comment-sync-trace-\$checkpoint\.json"/,
+  );
+  assert.match(commentSyncBranch, /write_comment_sync_health/);
+  assert.match(applyHelper, /"\$comment_sync_cursor_advance_count"/);
   const applyFlagInit = applyStep.indexOf('explicit_item_numbers="$item_numbers"');
   assert.ok(applyFlagInit > applyStep.indexOf('item_numbers="${{'));
   assert.ok(applyFlagInit < applyStep.indexOf("auto_selected_apply_batch=true"));
@@ -2127,6 +2140,842 @@ test("apply workflow finalization retries only target status after checkpointed 
   assert.doesNotMatch(actionLedgerStep, /repair:publish-main/);
   assert.doesNotMatch(actionLedgerStep, /continue-on-error: true/);
   assert.match(actionLedgerStep, /no paths were imported[\s\S]*exit 1/i);
+});
+
+test("comment synchronization splits oversized explicit requests into durable checkpoints", () => {
+  const oversizedItems = Array.from({ length: 41 }, (_, index) => index + 1).join(",");
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        "comment_sync_processed_limit=40",
+        "sync_batch_size=75",
+        "sync_comments_only=false",
+        "item_numbers=",
+        "prepare_comment_sync_batch",
+        'printf "close_batch=%s\\n" "$sync_batch_size"',
+        "sync_comments_only=true",
+        "item_numbers=1",
+        "sync_open_pr_batch=false",
+        "prepare_comment_sync_batch",
+        'printf "comment_batch=%s\\n" "$sync_batch_size"',
+        'item_numbers="$OVERSIZED_ITEMS"',
+        "prepare_comment_sync_batch",
+        'printf "selected=%s\\n" "$item_numbers"',
+        'printf "remaining=%s\\n" "$comment_sync_pending_items"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8", env: { ...process.env, OVERSIZED_ITEMS: oversizedItems } },
+  );
+
+  assert.match(output, /^close_batch=75$/m);
+  assert.match(output, /^comment_batch=40$/m);
+  assert.match(output, /^selected=1,2,3,4,5,6,7,8,9,10,/m);
+  assert.match(output, /^selected=.*39,40$/m);
+  assert.match(output, /^remaining=41$/m);
+});
+
+test("comment synchronization normalizes only valid positive explicit item numbers", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        "comment_sync_processed_limit=40",
+        "sync_batch_size=40",
+        "sync_comments_only=true",
+        "sync_open_pr_batch=false",
+        'item_numbers="3, 0, 02, -4, 2, 1.5, invalid, 001,,"',
+        "prepare_comment_sync_batch",
+        'printf "selected=%s\\n" "$item_numbers"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.match(output, /^selected=1,2,3$/m);
+});
+
+test("comment synchronization rejects explicit requests without valid item numbers", () => {
+  assert.throws(
+    () =>
+      execFileSync(
+        "bash",
+        [
+          "-lc",
+          [
+            "set -euo pipefail",
+            "source scripts/apply-workflow-helpers.sh",
+            "comment_sync_processed_limit=40",
+            "sync_batch_size=40",
+            "sync_comments_only=true",
+            "sync_open_pr_batch=false",
+            'item_numbers="0,-4,1.5,invalid,,"',
+            "prepare_comment_sync_batch",
+          ].join("\n"),
+        ],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    (error: Error & { stderr?: Buffer | string }) =>
+      /contains no valid positive item numbers/.test(String(error.stderr)),
+  );
+});
+
+test("scheduled comment sync broadens only its own maintenance filters", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        "sync_open_pr_batch=true",
+        "sync_comments_only=true",
+        "scheduled_comment_sync=false",
+        "apply_kind=issue",
+        "comment_sync_min_age_days=9",
+        "normalize_comment_sync_mode",
+        'printf "manual=%s|%s\\n" "$apply_kind" "$comment_sync_min_age_days"',
+        "scheduled_comment_sync=true",
+        "normalize_comment_sync_mode",
+        'printf "scheduled=%s|%s\\n" "$apply_kind" "$comment_sync_min_age_days"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.match(output, /^manual=issue\|9$/m);
+  assert.match(output, /^scheduled=pull_request\|0$/m);
+});
+
+test("cursor synchronization replaces a zero-item operator limit with its bounded default", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        "comment_sync_processed_limit=40",
+        "sync_batch_size=0",
+        "sync_comments_only=true",
+        "sync_open_pr_batch=true",
+        "item_numbers=10",
+        "prepare_comment_sync_batch",
+        'printf "batch=%s\\n" "$sync_batch_size"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.match(output, /^batch=40$/m);
+});
+
+test("uncursored synchronization continues repositories without scheduled maintenance", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 41; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-clawhub-${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/clawhub"',
+          "target_slug=openclaw-clawhub",
+          "apply_kind=all",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'printf "selected=%s\\n" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\nnext=%s\\ncursor=%s\\n" "$continue_apply" "$item_numbers" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^selected=1,2,3,/m);
+    assert.match(output, /^next=__cursor__$/m);
+    assert.match(output, /^cursor=40$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("manual OpenClaw issue synchronization continues beyond scheduled PR coverage", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-openclaw", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 41; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-openclaw-${number}.md`),
+      `---\nrepository: openclaw/openclaw\ntype: issue\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  const sharedCursor = join(root, "results", "comment-sync-cursors", "openclaw-openclaw.json");
+  mkdirSync(dirname(sharedCursor), { recursive: true });
+  writeFileSync(sharedCursor, '{"next_after_number":50}\n');
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/openclaw"',
+          "target_slug=openclaw-openclaw",
+          "apply_kind=issue",
+          "comment_sync_min_age_days=9",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'printf "selected=%s\\n" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\nnext=%s\\ncursor=%s\\n" "$continue_apply" "$item_numbers" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^selected=1,2,3,/m);
+    assert.match(output, /^next=__cursor__$/m);
+    assert.match(output, /^cursor=40$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unscheduled cursor synchronization continues lower-numbered records after wraparound", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  mkdirSync(records, { recursive: true });
+  for (const number of [5, 21]) {
+    writeFileSync(
+      join(records, `openclaw-clawhub-${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  const scopedCursor = join(
+    root,
+    "results",
+    "comment-sync-cursors",
+    "openclaw-clawhub-all-age0.json",
+  );
+  mkdirSync(dirname(scopedCursor), { recursive: true });
+  writeFileSync(scopedCursor, '{"next_after_number":20}\n');
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/clawhub"',
+          "target_slug=openclaw-clawhub",
+          "apply_kind=all",
+          "comment_sync_min_age_days=0",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'printf "selected=%s\\n" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\nnext=%s\\ncursor=%s\\n" "$continue_apply" "$item_numbers" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=21$/m);
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^next=__cursor__$/m);
+    assert.match(output, /^cursor=21$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unscheduled wrapped synchronization drains every bounded window and then stops", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 7; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-clawhub-${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  const scopedCursor = join(
+    root,
+    "results",
+    "comment-sync-cursors",
+    "openclaw-clawhub-all-age0.json",
+  );
+  mkdirSync(dirname(scopedCursor), { recursive: true });
+  writeFileSync(scopedCursor, '{"next_after_number":5}\n');
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=2",
+          "sync_batch_size=2",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/clawhub"',
+          "target_slug=openclaw-clawhub",
+          "apply_kind=all",
+          "comment_sync_min_age_days=0",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          "while :; do",
+          '  printf "window=%s\\n" "$item_numbers"',
+          '  jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "  printf '[]' > report.json",
+          "  continue_apply=false",
+          "  complete_comment_sync_batch report.json trace.json",
+          '  if [ "$continue_apply" != "true" ]; then break; fi',
+          "  item_numbers=",
+          "  sync_open_pr_batch=true",
+          "  prepare_comment_sync_batch",
+          '  pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path" > next.env',
+          "  item_numbers=$(awk -F= '$1 == \"item_numbers\" { print $2 }' next.env)",
+          "done",
+          'printf "continue=%s\\ncursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^window=6,7$/m);
+    assert.match(output, /^window=1,2$/m);
+    assert.match(output, /^window=3,4$/m);
+    assert.match(output, /^window=5,6$/m);
+    assert.match(output, /^continue=false$/m);
+    assert.match(output, /^cursor=6$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unscheduled cursor synchronization stops after its final full batch", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 40; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-clawhub-${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/clawhub"',
+          "target_slug=openclaw-clawhub",
+          "apply_kind=all",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\ncursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^continue=false$/m);
+    assert.match(output, /^cursor=40$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("uncursored comment synchronization selects and continues the full eligible inventory", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-openclaw", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 1002; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-openclaw-${number}.md`),
+      `---\nrepository: openclaw/openclaw\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: ${number === 1002 ? "retry_pr_close_coverage_proof" : "kept_open"}\n---\n`,
+    );
+  }
+  writeFileSync(
+    join(records, "openclaw-openclaw-1003.md"),
+    "---\nrepository: openclaw/openclaw\ntype: pull_request\nreview_status: failed\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n",
+  );
+  writeFileSync(
+    join(records, "openclaw-openclaw-1004.md"),
+    "---\nrepository: openclaw/openclaw\ntype: pull_request\nreview_status: complete\naction_taken: kept_open\n---\n",
+  );
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          'TARGET_REPO="openclaw/openclaw"',
+          "target_slug=openclaw-openclaw",
+          "apply_kind=all",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'printf "selected=%s\\ncursor_path=%s\\n" "$item_numbers" "$cursor_path"',
+          'mkdir -p "$(dirname "$cursor_path")"',
+          'printf \'{"next_after_number":980}\\n\' > "$cursor_path"',
+          "item_numbers=",
+          "sync_open_pr_batch=false",
+          "prepare_comment_sync_batch",
+          'printf "resumed=%s\\n" "$item_numbers"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=1,2,3,/m);
+    assert.match(output, /^selected=.*39,40$/m);
+    assert.match(output, /^resumed=981,982,/m);
+    assert.match(output, /^resumed=.*1001,1002$/m);
+    assert.doesNotMatch(output, /^resumed=.*1003/m);
+    assert.doesNotMatch(output, /^resumed=.*1004/m);
+    assert.match(output, /results\/comment-sync-cursors\/openclaw-openclaw-all-age0\.json/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("comment synchronization checkpoints only completed records after a runtime yield", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const completeReport = join(root, "complete.json");
+  const partialReport = join(root, "partial.json");
+  const untouchedReport = join(root, "untouched.json");
+  const completeTrace = join(root, "complete-trace.json");
+  const partialTrace = join(root, "partial-trace.json");
+  const untouchedTrace = join(root, "untouched-trace.json");
+  const invalidTrace = join(root, "invalid-trace.json");
+  const cursorPath = join(root, "comment-sync-cursor.json");
+  writeFileSync(completeReport, JSON.stringify([{ number: 50, action: "review_comment_synced" }]));
+  writeFileSync(
+    partialReport,
+    JSON.stringify([
+      { number: 10, action: "review_comment_synced" },
+      { number: 20, action: "skipped_stale_review_comment_sync" },
+      { number: 30, action: "skipped_runtime_budget" },
+      { number: 0, action: "skipped_runtime_budget" },
+    ]),
+  );
+  writeFileSync(
+    untouchedReport,
+    JSON.stringify([
+      { number: 10, action: "skipped_runtime_budget" },
+      { number: 0, action: "skipped_runtime_budget" },
+    ]),
+  );
+  writeFileSync(
+    completeTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 20, 30, 40, 50] }),
+  );
+  writeFileSync(
+    partialTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [10, 20] }),
+  );
+  writeFileSync(untouchedTrace, JSON.stringify({ schema_version: 1, examined_item_numbers: [] }));
+  writeFileSync(invalidTrace, JSON.stringify({ schema_version: 1, examined_item_numbers: [30] }));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          "source scripts/apply-workflow-helpers.sh",
+          'TARGET_REPO="openclaw/openclaw"',
+          'cursor_path="$CURSOR_PATH"',
+          "sync_open_pr_batch=true",
+          "comment_sync_pending_items=",
+          "continue_apply=false",
+          "item_numbers=10,20,30,40,50",
+          "next_cursor=50",
+          'complete_comment_sync_batch "$COMPLETE_REPORT" "$COMPLETE_TRACE"',
+          'printf "complete=%s|count=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count"',
+          "next_cursor=50",
+          'complete_comment_sync_batch "$PARTIAL_REPORT" "$PARTIAL_TRACE"',
+          'printf "partial=%s|count=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count"',
+          "next_cursor=50",
+          'complete_comment_sync_batch "$UNTOUCHED_REPORT" "$UNTOUCHED_TRACE"',
+          'printf "untouched=%s|next=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$next_cursor"',
+          'if complete_comment_sync_batch "$PARTIAL_REPORT" "$INVALID_TRACE" 2>/dev/null; then echo missing_prefix_published; else echo missing_prefix_rejected; fi',
+          'printf "missing_prefix_cursor=%s\\n" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+          COMPLETE_REPORT: completeReport,
+          PARTIAL_REPORT: partialReport,
+          UNTOUCHED_REPORT: untouchedReport,
+          COMPLETE_TRACE: completeTrace,
+          PARTIAL_TRACE: partialTrace,
+          UNTOUCHED_TRACE: untouchedTrace,
+          INVALID_TRACE: invalidTrace,
+          CURSOR_PATH: cursorPath,
+        },
+      },
+    );
+
+    assert.match(output, /^complete=50\|count=5$/m);
+    assert.match(output, /^partial=20\|count=2$/m);
+    assert.match(output, /^untouched=20\|next=$/m);
+    assert.match(output, /^missing_prefix_published$/m);
+    assert.match(output, /^missing_prefix_cursor=20$/m);
+    assert.doesNotMatch(output, /^missing_prefix_rejected$/m);
+    assert.doesNotMatch(output, /^partial=30$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("explicit comment synchronization stops an unproductive continuation before it can loop", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const reportPath = join(root, "report.json");
+  const tracePath = join(root, "trace.json");
+  writeFileSync(reportPath, JSON.stringify([{ number: 0, action: "skipped_runtime_budget" }]));
+  writeFileSync(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [] }));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "source scripts/apply-workflow-helpers.sh",
+          "sync_open_pr_batch=false",
+          "comment_sync_pending_items=",
+          "continue_apply=false",
+          "item_numbers=42",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'printf "continue=%s\\nremaining=%s\\n" "$continue_apply" "$item_numbers"',
+        ].join("\n"),
+      ],
+      { encoding: "utf8", env: { ...process.env, REPORT_PATH: reportPath, TRACE_PATH: tracePath } },
+    );
+
+    assert.match(output, /^continue=false$/m);
+    assert.match(output, /^remaining=42$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("cursor-based comment synchronization never continues after operational publication fails", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const reportPath = join(root, "report.json");
+  const tracePath = join(root, "trace.json");
+  const cursorPath = join(root, "comment-sync-cursor.json");
+  writeFileSync(reportPath, JSON.stringify([{ number: 10, action: "review_comment_synced" }]));
+  writeFileSync(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [10] }));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          "source scripts/apply-workflow-helpers.sh",
+          'TARGET_REPO="openclaw/openclaw"',
+          'cursor_path="$CURSOR_PATH"',
+          "sync_open_pr_batch=true",
+          "comment_sync_pending_items=",
+          "continue_apply=false",
+          "item_numbers=10,20",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'publish_changes_with_strategy() { [ "$1" = normal ]; }',
+          'publish_changes "test cursor publication" records results/comment-sync-cursors',
+          'printf "continue=%s\\ncursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+          REPORT_PATH: reportPath,
+          TRACE_PATH: tracePath,
+          CURSOR_PATH: cursorPath,
+        },
+      },
+    );
+
+    assert.match(output, /^continue=false$/m);
+    assert.match(output, /^cursor=10$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unscheduled cursor synchronization never continues after cursor publication fails", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  mkdirSync(records, { recursive: true });
+  for (const number of [10, 20]) {
+    writeFileSync(
+      join(records, `openclaw-clawhub-${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  const reportPath = join(root, "report.json");
+  const tracePath = join(root, "trace.json");
+  writeFileSync(reportPath, JSON.stringify([{ number: 10, action: "review_comment_synced" }]));
+  writeFileSync(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [10] }));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          'TARGET_REPO="openclaw/clawhub"',
+          "target_slug=openclaw-clawhub",
+          "apply_kind=all",
+          'cursor_path="results/comment-sync-cursors/openclaw-clawhub.json"',
+          "sync_open_pr_batch=true",
+          "sync_batch_size=1",
+          "comment_sync_pending_items=",
+          "continue_apply=false",
+          "item_numbers=10",
+          "mkdir -p .artifacts",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'printf "before=%s\\n" "$continue_apply"',
+          'publish_changes_with_strategy() { [ "$1" = normal ]; }',
+          'publish_changes "test cursor publication" records results/comment-sync-cursors',
+          'printf "after=%s\\n" "$continue_apply"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+          REPORT_PATH: reportPath,
+          TRACE_PATH: tracePath,
+        },
+      },
+    );
+
+    assert.match(output, /^before=true$/m);
+    assert.match(output, /^after=false$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("explicit item continuation survives unrelated cursor bookkeeping failure", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        'TARGET_REPO="openclaw/clawhub"',
+        "sync_open_pr_batch=false",
+        "continue_apply=true",
+        'publish_changes_with_strategy() { [ "$1" = normal ]; }',
+        'publish_changes "test cursor publication" records results/comment-sync-cursors',
+        'printf "continue=%s\\n" "$continue_apply"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.match(output, /^continue=true$/m);
+});
+
+test("explicit comment synchronization preserves all unfinished items after a runtime yield", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const reportPath = join(root, "report.json");
+  const tracePath = join(root, "trace.json");
+  const selected = Array.from({ length: 43 }, (_, index) => index + 1).join(",");
+  writeFileSync(
+    reportPath,
+    JSON.stringify([
+      { number: 1, action: "review_comment_synced" },
+      { number: 2, action: "review_comment_synced" },
+      { number: 3, action: "skipped_runtime_budget" },
+      { number: 0, action: "skipped_runtime_budget" },
+    ]),
+  );
+  writeFileSync(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [1, 2] }));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "source scripts/apply-workflow-helpers.sh",
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=43",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=false",
+          "continue_apply=false",
+          'item_numbers="$SELECTED_ITEMS"',
+          "prepare_comment_sync_batch",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'printf "continue=%s\\nremaining=%s\\ncount=%s\\n" "$continue_apply" "$item_numbers" "$comment_sync_cursor_advance_count"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SELECTED_ITEMS: selected,
+          REPORT_PATH: reportPath,
+          TRACE_PATH: tracePath,
+        },
+      },
+    );
+
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^remaining=3,4,5,/m);
+    assert.match(output, /^remaining=.*40,41,42,43$/m);
+    assert.match(output, /^count=2$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("apply workflow does not queue runtime-yield continuation without cursor progress", () => {
@@ -2622,6 +3471,7 @@ test("sweep workflow publishes target-scoped state paths", () => {
 
 test("sweep workflow schedules cursor-based PR comment sync batches", () => {
   const workflow = readText(".github/workflows/sweep.yml");
+  const applyHelper = readText("scripts/apply-workflow-helpers.sh");
 
   assert.match(workflow, /cron: "6,21,36,51 \* \* \* \*"/);
   assert.doesNotMatch(workflow, /apply_sync_open_pr_batch:/);
@@ -2631,10 +3481,17 @@ test("sweep workflow schedules cursor-based PR comment sync batches", () => {
   );
   assert.match(workflow, /\$item_numbers" = "__cursor__"/);
   assert.match(workflow, /comment-sync-batch/);
-  assert.match(workflow, /write-comment-sync-cursor/);
+  assert.match(workflow, /complete_comment_sync_batch/);
+  assert.match(applyHelper, /write-comment-sync-cursor/);
   assert.match(workflow, /results\/comment-sync-cursors\/\$\{target_slug\}\.json/);
+  assert.match(workflow, /normalize_comment_sync_mode/);
+  assert.match(applyHelper, /sync_open_pr_batch:-false.*[\s\S]*?apply_kind="pull_request"/);
   assert.match(workflow, /APPLY_SYNC_OPEN_PR_BATCH/);
   assert.match(workflow, /github\.event\.schedule == '6,21,36,51 \* \* \* \*'/);
+  assert.match(
+    applyHelper,
+    /if \[ "\$\{scheduled_comment_sync:-false\}" = "true" \]; then\s+apply_kind="pull_request"\s+comment_sync_min_age_days=0\s+fi/,
+  );
 });
 
 test("sweep target checkouts retry without cached references", () => {


### PR DESCRIPTION
## What changes

- Give genuinely actionable OpenClaw issue/PR closures a reliable opening in the serialized target apply lane: background durable-review comment maintenance is now bounded to **40 items / 5 minutes** instead of monopolizing that lane for roughly an hour.
- Preserve narrow, safe closure eligibility, immutable source checkouts, full reviewed inventory scans, and independent close-coverage evidence; include retryable close-proof records while rejecting failed reviews and missing item snapshots.
- Keep scheduled PR comment maintenance separate from closure and from issue-linked-PR guards; preserve explicit operator item/kind/age filters and use independently scoped manual cursors.
- Finish arbitrary-size unscheduled/manual comment-sync inventories without starvation, unsafe cursor advancement, skipped cursor wraparound, endless continuation, or continuing after cursor-state publication failed.
- Persist only completed exact-prefix progress, retain unfinished explicit items, stop zero-progress continuations, and preserve canonical records when best-effort operational bookkeeping fails.

## Real runtime proof

- Live OpenClaw maintenance was processing approximately **1,000 durable review comments for 55 minutes** inside the same serialized apply lane used by actual issue/PR closures; scheduled closure runs accumulated behind it. Cancelling the stale maintenance window immediately allowed the bot to safely close https://github.com/openclaw/openclaw/pull/82085 at `2026-07-31T14:52:37Z` as `clawsweeper[bot]`. A later stale maintenance run again blocked scheduled automatic closure, reproducing the same production bottleneck.
- Real production helper/CLI-path proof populated **1,002 canonical Markdown review reports**, selected eligible closure records through the actual workflow selector, included the final `retry_pr_close_coverage_proof` item, excluded failed/missing-snapshot reports, and proved the closure window no longer stops after a 600-record unproductive prefix.
- Real shell + workflow utility integration proof starts from an existing cursor, performs exact-prefix checkpoint publication, resumes every bounded window across cursor wraparound until the original cycle boundary, and terminates cleanly; it also proves dedicated manual issue scopes are unaffected by the scheduled PR cursor, preserves explicit-item continuation after unrelated bookkeeping failure, refuses continuation after cursor publication failure, rejects malformed selections, and avoids empty/no-progress retry loops.
- **150/150 focused workflow and repair utility tests passed**, including exact wrap-boundary trimming without duplicate work, safe cycle reset after boundary records disappear, preservation of explicitly scoped selections, arbitrary-window cursor-wrap draining, bounded 40-record/5-minute maintenance, retryable close-coverage selection, 1,000+-item real report inventory, and production workflow body-size limits.

Directly reviewable current-head executable shell/CLI regression output:

```text
✔ unscheduled wrapped synchronization drains every bounded window and then stops
✔ wrapped cursor state never widens an explicit comment-sync selection
✔ wrapped cursor resets when every remaining boundary record disappears
✔ manual OpenClaw issue synchronization continues beyond scheduled PR coverage
✔ unscheduled cursor synchronization never continues after cursor publication fails
✔ explicit item continuation survives unrelated cursor bookkeeping failure
tests 150 | pass 150 | fail 0
```

Directly reviewable observed production close after the blocked serialized lane was recovered:

```text
item: https://github.com/openclaw/openclaw/pull/82085
action: closed
actor: clawsweeper[bot]
closed_at: 2026-07-31T14:52:37Z
```
- Static checks, builds, workflow formatting, repair lint, shell syntax, and independent fresh precommit Codex review passed; the fresh review confirmed bounded synchronization, durable cursor progress, continuation safety, and retryable coverage-proof eligibility.
- Independent precommit and committed-range Codex reviews identified and resolved every accepted cursor finding: dedicated manual cursor scopes prevent shared-cursor omission; durable cycle anchors drain arbitrary inventories; the final selected window is trimmed **before mutation**; explicit item requests are never widened; disappeared boundary records reset obsolete cycle state instead of stranding synchronization.

The repository owner explicitly requested automatic safe closure, simplified maintenance, automatic service-PR landing, live mutation, and end-to-end production monitoring in this session. No maintainer/protected/security close guards are weakened.
