### PR TITLE
fix: isolate disposable OpenClaw changed-gate compiler cache

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1250,12 +1250,20 @@ export function runAllowedValidationCommandsWithBinding(
               validationIdentityProofDeadlineAt(deadlineAt),
             );
           }
-          const restoreRuntimeBuildCache = runtimeBuild
+          const restoreValidationCache = runtimeBuild
             ? prepareDisposableRuntimeBuildCache(cwd, validationEnv, ignoredValidationInputs)
-            : null;
+            : options.targetRepo === "openclaw/openclaw" && isChangedGateCommand(parts, options)
+              ? prepareDisposableRuntimeBuildCache(
+                  cwd,
+                  validationEnv,
+                  ignoredValidationInputs,
+                  "tsgo-cache",
+                  "changed-gate validation",
+                )
+              : null;
           const executionBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
           if (executionBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
-            restoreRuntimeBuildCache?.();
+            restoreValidationCache?.();
             throw validationCommandBudgetError(rendered);
           }
           try {
@@ -1266,7 +1274,7 @@ export function runAllowedValidationCommandsWithBinding(
               writableRoots: [cwd, path.dirname(String(validationEnv.HOME))],
             });
           } finally {
-            restoreRuntimeBuildCache?.();
+            restoreValidationCache?.();
           }
           if (runtimeBuild) {
             assertGeneratedRuntimeBuildOutput(cwd);
@@ -2644,9 +2652,11 @@ function prepareDisposableRuntimeBuildCache(
   cwd: string,
   validationEnv: NodeJS.ProcessEnv,
   ignoredValidationInputs: readonly string[],
+  cacheName: "build-all-cache" | "tsgo-cache" = "build-all-cache",
+  context = "runtime artifact build",
 ) {
   const artifacts = path.join(cwd, ".artifacts");
-  const cache = path.join(artifacts, "build-all-cache");
+  const cache = path.join(artifacts, cacheName);
   const artifactsStat = fs.lstatSync(artifacts, { throwIfNoEntry: false });
   if (
     artifactsStat &&
@@ -2654,11 +2664,11 @@ function prepareDisposableRuntimeBuildCache(
       !artifactsStat.isDirectory() ||
       artifactsStat.isSymbolicLink())
   ) {
-    throw new Error("runtime artifact build has an unsafe existing artifacts directory");
+    throw new Error(`${context} has an unsafe existing artifacts directory`);
   }
   const cacheStat = fs.lstatSync(cache, { throwIfNoEntry: false });
   if (cacheStat && (!cacheStat.isDirectory() || cacheStat.isSymbolicLink())) {
-    throw new Error("runtime artifact build has an unsafe existing build cache");
+    throw new Error(`${context} has an unsafe existing ${cacheName}`);
   }
   const savedCache = path.join(
     path.dirname(String(validationEnv.HOME)),
@@ -2675,7 +2685,7 @@ function prepareDisposableRuntimeBuildCache(
           (currentArtifactsStat.dev !== artifactsStat.dev ||
             currentArtifactsStat.ino !== artifactsStat.ino)))
     ) {
-      throw new Error("runtime artifact build changed its protected artifacts directory");
+      throw new Error(`${context} changed its protected artifacts directory`);
     }
     fs.rmSync(cache, { recursive: true, force: true });
     if (cacheStat) {

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1346,20 +1346,35 @@ export function runAllowedValidationCommandsWithBinding(
             let fallbackError: Error | null = null;
             try {
               resetValidationEnvironment(deadlineAt - identityReserveMs);
-              const fallbackBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
-              if (fallbackBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
-                throw validationCommandBudgetError(rendered, executionError);
+              const restoreFallbackValidationCache =
+                options.targetRepo === "openclaw/openclaw" &&
+                isChangedGateCommand(fallbackParts, options)
+                  ? prepareDisposableRuntimeBuildCache(
+                      cwd,
+                      validationEnv,
+                      ignoredValidationInputs,
+                      "tsgo-cache",
+                      "changed-gate validation",
+                    )
+                  : null;
+              try {
+                const fallbackBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
+                if (fallbackBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
+                  throw validationCommandBudgetError(rendered, executionError);
+                }
+                const executionParts = validationCommandWithDisposableArchive(
+                  validationCommandForExecution(fallbackParts),
+                  validationEnv,
+                );
+                runContainedCommand(executionParts[0]!, executionParts.slice(1), {
+                  cwd,
+                  env: validationEnv,
+                  timeoutMs: fallbackBudgetMs,
+                  writableRoots: [cwd, path.dirname(String(validationEnv.HOME))],
+                });
+              } finally {
+                restoreFallbackValidationCache?.();
               }
-              const executionParts = validationCommandWithDisposableArchive(
-                validationCommandForExecution(fallbackParts),
-                validationEnv,
-              );
-              runContainedCommand(executionParts[0]!, executionParts.slice(1), {
-                cwd,
-                env: validationEnv,
-                timeoutMs: fallbackBudgetMs,
-                writableRoots: [cwd, path.dirname(String(validationEnv.HOME))],
-              });
             } catch (error) {
               fallbackError = error as Error;
             }

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4096,6 +4096,57 @@ test("changed-gate compiler cache isolation still rejects unrelated ignored-inpu
   assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
 });
 
+test("changed-gate merge-base fallback also isolates its disposable compiler cache", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+  fs.appendFileSync(path.join(cwd, ".gitignore"), ".artifacts/\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  const artifacts = path.join(cwd, ".artifacts");
+  fs.mkdirSync(artifacts, { recursive: true });
+  fs.writeFileSync(path.join(artifacts, "stable.txt"), "existing artifact\n");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-tsgo-fallback-"));
+  const attemptPath = path.join(binDir, "attempt");
+  writeNodeCommandShim(
+    binDir,
+    "pnpm",
+    [
+      'const fs = require("node:fs");',
+      `const attemptPath = ${JSON.stringify(attemptPath)};`,
+      'const attempt = fs.existsSync(attemptPath) ? Number(fs.readFileSync(attemptPath, "utf8")) : 0;',
+      "fs.writeFileSync(attemptPath, String(attempt + 1));",
+      "if (attempt === 0) {",
+      '  console.error("fatal: no merge base");',
+      "  process.exit(1);",
+      "}",
+      'fs.mkdirSync(".artifacts/tsgo-cache", { recursive: true });',
+      'fs.writeFileSync(".artifacts/tsgo-cache/test-root.tsbuildinfo", "generated compiler cache\\n");',
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    withPathOnlyPrefix(binDir, () =>
+      runAllowedValidationCommands(
+        ["pnpm check:changed"],
+        cwd,
+        validationOptions("openclaw/openclaw", {
+          pinnedBaseRef: "origin/main",
+          toolchain: {
+            packageManager: "pnpm",
+            baseValidationCommands: [],
+            changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+          },
+        }),
+      ),
+    ),
+    ["pnpm check:changed"],
+  );
+  assert.equal(fs.readFileSync(attemptPath, "utf8"), "2");
+  assert.equal(fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"), "existing artifact\n");
+  assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
+});
+
 test("OpenClaw archive smoke cannot pass by reusing a pre-existing stale build", () => {
   const cwd = gitPackageFixture({ "build:ci-artifacts": "node scripts/build-runtime.mjs" });
   fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n");

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3990,6 +3990,112 @@ test("changed-gate fallback preserves and protects pending fresh runtime output"
   }
 });
 
+test("OpenClaw changed-gate compiler cache is disposable and preserves existing state", () => {
+  for (const existingCompilerCache of [false, true]) {
+    const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+    fs.appendFileSync(path.join(cwd, ".gitignore"), ".artifacts/\n");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+
+    const artifacts = path.join(cwd, ".artifacts");
+    const compilerCache = path.join(artifacts, "tsgo-cache");
+    fs.mkdirSync(artifacts, { recursive: true });
+    fs.writeFileSync(path.join(artifacts, "stable.txt"), "existing artifact\n");
+    if (existingCompilerCache) {
+      fs.mkdirSync(compilerCache, { recursive: true });
+      fs.writeFileSync(
+        path.join(compilerCache, "test-root.tsbuildinfo"),
+        "trusted previous cache\n",
+      );
+    }
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-tsgo-cache-"));
+    writeNodeCommandShim(
+      binDir,
+      "pnpm",
+      [
+        'const fs = require("node:fs");',
+        'fs.mkdirSync(".artifacts/tsgo-cache", { recursive: true });',
+        'fs.writeFileSync(".artifacts/tsgo-cache/test-root.tsbuildinfo", "generated compiler cache\\n");',
+      ].join("\n"),
+    );
+
+    assert.deepEqual(
+      withPathOnlyPrefix(binDir, () =>
+        runAllowedValidationCommands(
+          ["pnpm check:changed"],
+          cwd,
+          validationOptions("openclaw/openclaw", {
+            pinnedBaseRef: "origin/main",
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: [],
+              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+            },
+          }),
+        ),
+      ),
+      ["pnpm check:changed"],
+    );
+    assert.equal(
+      fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"),
+      "existing artifact\n",
+    );
+    if (existingCompilerCache) {
+      assert.equal(
+        fs.readFileSync(path.join(compilerCache, "test-root.tsbuildinfo"), "utf8"),
+        "trusted previous cache\n",
+      );
+    } else {
+      assert.equal(fs.existsSync(compilerCache), false);
+    }
+  }
+});
+
+test("changed-gate compiler cache isolation still rejects unrelated ignored-input poisoning", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+  fs.appendFileSync(path.join(cwd, ".gitignore"), ".artifacts/\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  const artifacts = path.join(cwd, ".artifacts");
+  fs.mkdirSync(artifacts, { recursive: true });
+  fs.writeFileSync(path.join(artifacts, "stable.txt"), "existing artifact\n");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-tsgo-poison-"));
+  writeNodeCommandShim(
+    binDir,
+    "pnpm",
+    [
+      'const fs = require("node:fs");',
+      'fs.mkdirSync(".artifacts/tsgo-cache", { recursive: true });',
+      'fs.writeFileSync(".artifacts/tsgo-cache/test-root.tsbuildinfo", "generated compiler cache\\n");',
+      'fs.writeFileSync(".artifacts/stable.txt", "poisoned artifact\\n");',
+    ].join("\n"),
+  );
+
+  assert.throws(
+    () =>
+      withPathOnlyPrefix(binDir, () =>
+        runAllowedValidationCommands(
+          ["pnpm check:changed"],
+          cwd,
+          validationOptions("openclaw/openclaw", {
+            pinnedBaseRef: "origin/main",
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: [],
+              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+            },
+          }),
+        ),
+      ),
+    /unsafe validation command mutated checkout identity \(pnpm check:changed\): runtimeInputsSha256/,
+  );
+  assert.equal(fs.existsSync(path.join(artifacts, "tsgo-cache")), false);
+});
+
 test("OpenClaw archive smoke cannot pass by reusing a pre-existing stale build", () => {
   const cwd = gitPackageFixture({ "build:ci-artifacts": "node scripts/build-runtime.mjs" });
   fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n");


### PR DESCRIPTION
## What changes

- Restore actual OpenClaw root-cause-fix PR publication after the production writer successfully implements and validates a real issue.
- Make only OpenClaw's exact `pnpm check:changed` compiler cache, `.artifacts/tsgo-cache`, disposable for the duration of that trusted changed gate.
- Restore any existing compiler-cache contents byte-for-byte, preserve unrelated existing `.artifacts` contents, reject artifacts-directory/cache symlinks or replacement, and continue rejecting unrelated ignored-input tampering.
- Preserve the already-merged fresh-build/archive-smoke bindings, maintainer/security guards, and required actual writer model `openai/gpt-5.6-sol` with `xhigh` reasoning.

## Direct production root-cause proof

Actual autonomous OpenClaw issue writer https://github.com/openclaw/clawsweeper/actions/runs/30645662878 implemented a narrow root-cause repair for https://github.com/openclaw/openclaw/issues/98276 and passed its complete local validation before the deterministic publisher incorrectly rejected the changed gate's ordinary TypeScript compiler cache:

```text
CLAWSWEEPER_OPENCLAW_MODEL: openai/gpt-5.6-sol
CLAWSWEEPER_CODEX_REASONING_EFFORT: xhigh
PASS node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts (93 tests)
PASS pnpm build:ci-artifacts
PASS node scripts/dist-runtime-build-artifact.mjs pack-and-smoke --archive "$TMPDIR/..."
PASS pnpm check:changed

[check:changed] typecheck test root
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json \
    --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo

Error: unsafe validation command mutated checkout identity (pnpm check:changed): runtimeInputsSha256
```

### Actual after-fix production proof on this PR's service code

The trusted real OpenClaw issue writer then ran this exact compiler-cache fix against https://github.com/openclaw/openclaw/issues/98276 in https://github.com/openclaw/clawsweeper/actions/runs/30647636922. Its real execution environment confirmed the required writing model and reasoning effort:

```text
CLAWSWEEPER_OPENCLAW_MODEL: openai/gpt-5.6-sol
CLAWSWEEPER_CODEX_REASONING_EFFORT: xhigh

2026-07-31T16:47:06Z Codex edit pass finished {"mode":"replacement","attempt":1,"status":0}
2026-07-31T16:47:09Z starting validation/review loop {"mode":"replacement","attempt":1}
2026-07-31T16:49:35Z Codex /review replacement attempt 1 still running (60s elapsed)
2026-07-31T16:51:18Z Codex review-fix worker replacement attempt 1 still running (60s elapsed)
2026-07-31T16:52:03Z Error: target index differs from unchanged worktree content
```

This is the requested actual after-fix production behavior, not a fixture: the formerly fatal real OpenClaw `pnpm check:changed` compiler-cache identity check passed, allowing the real writer to proceed through validation into Codex `/review` and its review-fix pass. The later, separately identifiable review-checkpoint index inconsistency is downstream of—and proves successful passage through—the previously failing changed gate; it will be fixed separately without weakening this PR's identity protections.

Directly reviewable executable subprocess proof from this exact current PR head:

```text
✔ changed-gate fallback preserves and protects pending fresh runtime output (11066ms)
✔ OpenClaw changed-gate compiler cache is disposable and preserves existing state (3295ms)
✔ changed-gate compiler cache isolation still rejects unrelated ignored-input poisoning (1669ms)
✔ changed-gate merge-base fallback also isolates its disposable compiler cache (2132ms)
✔ runtime build cache cleanup never follows a replaced artifacts-root symlink (3203ms)
tests 5 | pass 5 | fail 0 | duration 20299ms

repair lint: PASS
script/test lint: PASS
repository static/format checks: PASS
```

The positive production-mirror fixture covers both no existing compiler cache and an existing cache restored exactly. The negative fixture modifies an unrelated existing ignored artifact and still receives `unsafe validation command mutated checkout identity`; the existing malicious artifacts-root symlink defense remains green. The accepted independent-review finding about the existing `no merge base` fallback is resolved: the retry receives the same disposable cache protection and recalculates its timeout **after** cache preparation. No untrusted path receives broader write authority or an identity-check bypass.

After this service fix lands, the same trusted production worker will be dispatched against ClawSweeper `main` with `gpt-5.6-sol`/`xhigh` and monitored until it creates the actual narrow OpenClaw root-cause repair PR.
