### PR TITLE
fix(ci): complete event-review publication as superseded when the reviewed branch vanished

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3599,11 +3599,23 @@ jobs:
       - name: Sync before applying artifacts
         id: sync-review-artifacts
         if: ${{ always() && !cancelled() && steps.setup-publish-state.outcome == 'success' && steps.setup-publish-pnpm.outcome == 'success' && steps.download-review-artifacts.outcome == 'success' }}
-        run: git pull --rebase --autostash
+        run: |
+          if ! pull_output="$(git pull --rebase --autostash 2>&1)"; then
+            printf '%s\n' "$pull_output" >&2
+            # A reviewed PR head branch can vanish mid-review (force-push or
+            # deletion). The newer head triggers its own review event, so this
+            # publication completes as a superseded no-op instead of failing.
+            if grep -qiE "no such ref was fetched|couldn.t find remote ref" <<<"$pull_output"; then
+              echo "::notice::The reviewed branch disappeared upstream; the newer head owns its own review. Skipping artifact publication as a superseded no-op."
+              echo "superseded=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
 
       - name: Apply review artifacts
         id: apply-review-artifacts
-        if: ${{ always() && !cancelled() && steps.sync-review-artifacts.outcome == 'success' }}
+        if: ${{ always() && !cancelled() && steps.sync-review-artifacts.outcome == 'success' && steps.sync-review-artifacts.outputs.superseded != 'true' }}
         env:
           CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: .artifacts/review-canonical-baseline
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Event-review artifact publication completes as a superseded no-op when the reviewed branch vanished upstream (force-push or deletion) instead of failing the run.
 - Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.
 - Exact reviews of items that closed after enqueue now complete as superseded no-ops, and GitHub-throttled reservations defer as held retries — neither spends the item's review-failure budget.
 - Trimmed the exact-review feed rate from 600/h to 450/h after the resumed apply and comment-sync lanes pushed the shared GitHub App installation token into rate-limit 403s.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -195,8 +195,19 @@ test("review and apply primary boundaries ignore ledger-only failures", () => {
   assert.match(artifactSync.if ?? "", /setup-publish-pnpm\.outcome == 'success'/);
   assert.match(artifactSync.if ?? "", /download-review-artifacts\.outcome == 'success'/);
   assert.doesNotMatch(artifactSync.if ?? "", /action-ledger/);
+  assert.match(
+    artifactSync.run ?? "",
+    /no such ref was fetched\|couldn.t find remote ref/,
+    "a vanished reviewed branch must complete publication as a superseded no-op",
+  );
+  assert.match(artifactSync.run ?? "", /superseded=true/);
   const artifactApply = step("publish", "Apply review artifacts");
   assert.match(artifactApply.if ?? "", /sync-review-artifacts\.outcome == 'success'/);
+  assert.match(
+    artifactApply.if ?? "",
+    /sync-review-artifacts\.outputs\.superseded != 'true'/,
+    "superseded sync must skip artifact application",
+  );
   assert.match(artifactApply.run ?? "", /review_batch_succeeded=/);
   assert.match(artifactApply.run ?? "", /artifacts_applied=true/);
   const artifactLedger = step("publish", "Publish review artifact action ledger");


### PR DESCRIPTION
## Problem

Event reviews of clawsweeper's own PRs fail at "Publish review artifacts → Sync before applying artifacts" when the reviewed head branch is force-pushed or deleted mid-review: `git pull --rebase` errors with "Your configuration specifies to merge with the ref ... but no such ref was fetched" (runs 30646613269, 30646627620 — both on the same contributor PR batch).

The stale review is worthless anyway — the newer head triggers its own review event — so a red run here is pure noise, same family as the #966 head-drift and #968 closed-item cases.

## Fix

The sync step captures the pull output; on the vanished-ref signature it emits a notice, sets `superseded=true`, and exits 0. "Apply review artifacts" (and everything downstream keyed off `artifacts_applied`) is gated on `superseded != 'true'`. Any other pull failure still fails the step.

## Proof

- Workflow-shape assertions for the vanished-ref branch and the superseded gate; sweep-workflow suite 80/80.
- Autoreview (codex, xhigh): clean, "patch is correct (0.98)".
