### PR TITLE
fix: preserve validated legacy checkout blobs

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -3066,7 +3066,7 @@ function buildRawWorktreeTree(
   const indexEnv = { ...objectEnv, GIT_INDEX_FILE: indexFile };
   git.run(["read-tree", "HEAD"], "raw worktree temporary index", { env: indexEnv });
   const updates: string[] = [];
-  const canonicalEntries: Array<{ mode: string; relativePath: string }> = [];
+  const canonicalEntries: Array<{ mode: string; relativePath: string; sourceOid?: string }> = [];
   const rawEntries: Array<{ mode: string; relativePath: string; sourcePath: string }> = [];
   const worktreeLeafPaths = new Set<string>();
   const zeroOid = "0".repeat(headSha.length);
@@ -3146,7 +3146,11 @@ function buildRawWorktreeTree(
         }
         throw new Error(`unsafe changed target Git ${unsafeAttribute} attribute: ${relativePath}`);
       }
-      canonicalEntries.push({ mode, relativePath });
+      canonicalEntries.push({
+        mode,
+        relativePath,
+        ...(sourceEntry?.mode === mode ? { sourceOid: sourceEntry.oid } : {}),
+      });
       continue;
     }
     rawEntries.push({ mode, relativePath, sourcePath });
@@ -3162,8 +3166,29 @@ function buildRawWorktreeTree(
     if (oids.length !== canonicalEntries.length) {
       throw new Error("canonical worktree hash output did not match target paths");
     }
+    const noncanonicalEntries = canonicalEntries
+      .map((entry, index) => ({ entry, oid: oids[index]! }))
+      .filter(({ entry, oid }) => entry.sourceOid && entry.sourceOid !== oid);
+    const rawOids =
+      noncanonicalEntries.length === 0
+        ? []
+        : hashTargetWorktreeFiles(
+            git,
+            noncanonicalEntries.map(({ entry }) => entry.relativePath),
+            true,
+            "hash noncanonical worktree files",
+            objectEnv,
+          );
+    if (rawOids.length !== noncanonicalEntries.length) {
+      throw new Error("noncanonical worktree hash output did not match target paths");
+    }
+    const matchingRawOids = new Map(
+      noncanonicalEntries.map(({ entry }, index) => [entry.relativePath, rawOids[index]]),
+    );
     for (const [index, entry] of canonicalEntries.entries()) {
-      updates.push(`${entry.mode} ${oids[index]}\t${entry.relativePath}\0`);
+      const rawOid = matchingRawOids.get(entry.relativePath);
+      const oid = rawOid && rawOid === entry.sourceOid ? rawOid : oids[index];
+      updates.push(`${entry.mode} ${oid}\t${entry.relativePath}\0`);
     }
   }
   if (rawEntries.length > 0) {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -5257,6 +5257,127 @@ test("checkpoint plumbing commits raw modified, added, and deleted worktree cont
   assert.equal(result.tree, git(cwd, "rev-parse", "HEAD^{tree}"));
 });
 
+test("checkpoint plumbing preserves a review fix restoring a legacy CRLF blob", () => {
+  const cwd = gitPackageFixture({ check: 'node -e ""' });
+  const wrapper = "apps/android/gradlew.bat";
+  const wrapperPath = path.join(cwd, wrapper);
+  fs.mkdirSync(path.dirname(wrapperPath), { recursive: true });
+  fs.writeFileSync(path.join(cwd, ".gitattributes"), "*.bat text=auto eol=lf\n");
+  fs.writeFileSync(wrapperPath, "@echo off\r\nexit /b 0\r\n");
+  git(cwd, "add", ".");
+  const legacyBlob = git(cwd, "hash-object", "-w", "--no-filters", wrapper);
+  git(cwd, "update-index", "--cacheinfo", `100644,${legacyBlob},${wrapper}`);
+  git(cwd, "commit", "-m", "legacy CRLF base");
+  const base = git(cwd, "rev-parse", "HEAD");
+  const identity = {
+    name: "clawsweeper",
+    email: "274271284+clawsweeper[bot]@users.noreply.github.com",
+  };
+
+  fs.writeFileSync(path.join(cwd, "repair.txt"), "validated repair\n");
+  const initial = createTargetCheckpointWithPlumbing({
+    cwd,
+    messages: ["initial validated repair"],
+    identity,
+  });
+  assert.equal(initial.status, "committed");
+  assert.equal(git(cwd, "rev-parse", `HEAD:${wrapper}`), legacyBlob);
+  git(cwd, "add", "--renormalize", "--", wrapper);
+  git(cwd, "commit", "-m", "simulate previously normalized wrapper");
+  assert.notEqual(git(cwd, "rev-parse", `HEAD:${wrapper}`), legacyBlob);
+
+  git(cwd, "restore", `--source=${base}`, "--staged", "--worktree", "--", wrapper);
+  assert.equal(git(cwd, "status", "--porcelain"), `M  ${wrapper}`);
+
+  const corrected = createTargetCheckpointWithPlumbing({
+    cwd,
+    messages: ["restore unrelated legacy wrapper"],
+    identity,
+  });
+
+  assert.equal(corrected.status, "committed");
+  assert.equal(git(cwd, "rev-parse", `HEAD:${wrapper}`), legacyBlob);
+  assert.equal(git(cwd, "show", "HEAD:repair.txt"), "validated repair");
+  assert.equal(git(cwd, "status", "--porcelain"), "");
+
+  const accepted = captureTargetCheckoutBinding(cwd);
+  assert.equal(captureFinalTargetCheckoutBinding(cwd, accepted, corrected.commit).status, "");
+  const compacted = compactTargetHistoryWithPlumbing({
+    cwd,
+    baseRef: base,
+    messages: ["compact validated repair"],
+    identity,
+  });
+  assert.equal(git(cwd, "rev-parse", `HEAD:${wrapper}`), legacyBlob);
+  assert.equal(captureFinalTargetCheckoutBinding(cwd, accepted, compacted.commit).status, "");
+});
+
+test("checkpoint plumbing preserves staged CRLF restorations alongside review edits", () => {
+  const cwd = gitPackageFixture({ check: 'node -e ""' });
+  const wrapper = "apps/android/gradlew.bat";
+  const wrapperPath = path.join(cwd, wrapper);
+  fs.mkdirSync(path.dirname(wrapperPath), { recursive: true });
+  fs.writeFileSync(path.join(cwd, ".gitattributes"), "*.bat text=auto eol=lf\n");
+  fs.writeFileSync(wrapperPath, "@echo off\r\nexit /b 0\r\n");
+  git(cwd, "add", ".");
+  const legacyBlob = git(cwd, "hash-object", "-w", "--no-filters", wrapper);
+  git(cwd, "update-index", "--cacheinfo", `100644,${legacyBlob},${wrapper}`);
+  git(cwd, "commit", "-m", "legacy CRLF base");
+  const base = git(cwd, "rev-parse", "HEAD");
+  const identity = {
+    name: "clawsweeper",
+    email: "274271284+clawsweeper[bot]@users.noreply.github.com",
+  };
+  fs.writeFileSync(path.join(cwd, "repair.txt"), "initial repair\n");
+  createTargetCheckpointWithPlumbing({ cwd, messages: ["initial repair"], identity });
+  git(cwd, "add", "--renormalize", "--", wrapper);
+  git(cwd, "commit", "-m", "simulate previously normalized wrapper");
+
+  git(cwd, "restore", `--source=${base}`, "--staged", "--worktree", "--", wrapper);
+  fs.writeFileSync(path.join(cwd, "repair.txt"), "review-corrected repair\n");
+
+  const corrected = createTargetCheckpointWithPlumbing({
+    cwd,
+    messages: ["review repair and restore unrelated wrapper"],
+    identity,
+  });
+
+  assert.equal(corrected.status, "committed");
+  assert.equal(git(cwd, "rev-parse", `HEAD:${wrapper}`), legacyBlob);
+  assert.equal(git(cwd, "show", "HEAD:repair.txt"), "review-corrected repair");
+  assert.equal(git(cwd, "status", "--porcelain"), "");
+});
+
+test("checkpoint plumbing rejects a staged blob that disagrees with unchanged worktree", () => {
+  for (const source of ["source.txt", ":(exclude)*"]) {
+    const cwd = gitPackageFixture({ check: 'node -e ""' });
+    fs.writeFileSync(path.join(cwd, source), "validated content\n");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "validated base");
+    const previousHead = git(cwd, "rev-parse", "HEAD");
+    const poisonedBlob = execFileSync("git", ["hash-object", "-w", "--stdin"], {
+      cwd,
+      input: "poisoned staged content\n",
+      encoding: "utf8",
+    }).trim();
+    git(cwd, "update-index", "--cacheinfo", `100644,${poisonedBlob},${source}`);
+
+    assert.throws(
+      () =>
+        createTargetCheckpointWithPlumbing({
+          cwd,
+          messages: ["reject poisoned index"],
+          identity: {
+            name: "clawsweeper",
+            email: "274271284+clawsweeper[bot]@users.noreply.github.com",
+          },
+        }),
+      /target index differs from unchanged worktree content/,
+    );
+    assert.equal(git(cwd, "rev-parse", "HEAD"), previousHead);
+  }
+});
+
 test("checkpoint plumbing supports replacing a tracked file with a directory", () => {
   const cwd = gitPackageFixture({ check: 'node -e ""' });
   fs.writeFileSync(path.join(cwd, "shape"), "file\n");

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -5349,7 +5349,8 @@ test("checkpoint plumbing preserves staged CRLF restorations alongside review ed
 });
 
 test("checkpoint plumbing rejects a staged blob that disagrees with unchanged worktree", () => {
-  for (const source of ["source.txt", ":(exclude)*"]) {
+  const sources = process.platform === "win32" ? ["source.txt"] : ["source.txt", ":(exclude)*"];
+  for (const source of sources) {
     const cwd = gitPackageFixture({ check: 'node -e ""' });
     fs.writeFileSync(path.join(cwd, source), "validated content\n");
     git(cwd, "add", ".");


### PR DESCRIPTION
## What changes

- Preserve an already-tracked Git blob byte-for-byte when its exact raw worktree bytes still match the index, even if current `.gitattributes` would normalize those bytes differently.
- Prevent autonomous OpenClaw repair from silently rewriting unrelated legacy CRLF files during its first checkpoint; also allow a review fix to restore the exact pinned-base blob while making substantive changes elsewhere.
- Apply the same faithful checkout-tree construction to validation bindings, checkpoint commits, final publication identity, and replacement-history compaction.
- Preserve existing poisoned-index rejection, filtered-file/submodule safeguards, executable modes, and the required actual PR writer `openai/gpt-5.6-sol` / `xhigh` configuration.

## Real production root cause and integration proof

The trusted real writer https://github.com/openclaw/clawsweeper/actions/runs/30647636922 implemented https://github.com/openclaw/openclaw/issues/98276, passed its actual OpenClaw validation, and reached Codex review under the required model:

```text
CLAWSWEEPER_OPENCLAW_MODEL: openai/gpt-5.6-sol
CLAWSWEEPER_CODEX_REASONING_EFFORT: xhigh

2026-07-31T16:47:06Z Codex edit pass finished {"mode":"replacement","attempt":1,"status":0}
2026-07-31T16:47:09Z starting validation/review loop {"mode":"replacement","attempt":1}
2026-07-31T16:49:35Z Codex /review replacement attempt 1 still running (60s elapsed)
2026-07-31T16:51:18Z Codex review-fix worker replacement attempt 1 still running (60s elapsed)
2026-07-31T16:52:03Z Error: target index differs from unchanged worktree content
```

The actual exported execution artifact records exactly why: checkpoint normalization changed unrelated `apps/android/gradlew.bat` from the pinned base's legacy CRLF blob to LF. Codex review correctly identified that unrelated change; its repair restored the exact original blob with `git restore --source=<base> --staged --worktree`, passed actual `pnpm check:changed`, and reduced the intended final tree to only these three files:

```text
base blob 8508ef684d4e1f8473dcbbfdacf52a131beaee0e
head blob a51ec4f5886d3bb106b26724ee4507addbbe3fa8
apps/android/gradlew.bat: text: auto
apps/android/gradlew.bat: eol: lf

-- effective final delta --
M .github/workflows/ci.yml
A scripts/dist-runtime-build-artifact.mjs
M test/scripts/ci-workflow-guards.test.ts

pnpm check:changed: PASS
git diff --check <pinned-base> <final-tree>: PASS
```

The publisher then incorrectly rejected the legitimate staged restoration because its canonical checkout tree ignored the exact already-tracked bytes. This PR fixes the actual initial root cause: an unchanged existing tracked blob is recognized from its byte-for-byte raw Git object hash, so it is preserved throughout every downstream identity surface rather than rewritten and patched later.

The current head's executable subprocess integration exercises the complete relevant publication chain, not checkpoint behavior alone: existing CRLF blob preservation, a separately simulated pre-fix normalized checkpoint, staged pinned-base restore, a simultaneous substantive review edit, accepted final checkout binding, replacement-history compaction, and the post-compaction final checkout binding. Hostile staged-index poisoning is rejected for both an ordinary filename and the literal Git pathspec-magic filename `:(exclude)*`.

```text
✔ checkpoint plumbing preserves a review fix restoring a legacy CRLF blob
  includes successful final checkout binding and replacement-history compaction
✔ checkpoint plumbing preserves staged CRLF restorations alongside review edits
✔ checkpoint plumbing rejects a staged blob that disagrees with unchanged worktree
  includes malicious literal filename :(exclude)*

focused validation: tests 21 | pass 21 | fail 0
repair source/test lint: PASS
source/test formatting: PASS
repository git diff --check: PASS
```

## Accepted review-finding disposition

- **P1 mixed staged restore plus substantive review changes:** fixed at shared checkout-tree construction rather than a checkpoint-only special case; regression verifies both edits survive.
- **P1 final validation binding and replacement-history compaction:** fixed by using the same preserved raw blob for checkpoint, identity capture, final binding, and history compaction; integration verifies all three live-path operations.
- **P1 pathspec-magic staged-index injection:** eliminated entirely by removing the staged-pathspec overlay approach; explicit hostile filename regression still rejects poisoned staged content.
- **P2 Windows-incompatible adversarial filename fixture:** resolved by running the literal `:(exclude)*` case only on platforms whose filesystems permit that filename; the ordinary poisoned-index rejection still runs on Windows, and existing Windows launcher coverage remains intact.

No untrusted Git callback, filter, pathspec override, identity-check bypass, or broader write permission is introduced.
