### PR TITLE
fix(apply): prevent exact review publication memory exhaustion

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1289,6 +1289,7 @@ jobs:
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           records-repo-slugs: ${{ steps.target.outputs.target_slug }}
+          records-item-number: ${{ steps.target.outputs.item_number }}
           hydrate-git-state: "false"
           hydrate-state-blobs: "false"
 
@@ -2254,6 +2255,7 @@ jobs:
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           records-repo-slugs: ${{ steps.publication-context.outputs.target_slug }}
+          records-item-number: ${{ steps.publication-context.outputs.item_number }}
           hydrate-git-state: "false"
           hydrate-state-blobs: "false"
 

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -23460,7 +23460,10 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
       applyCheckedAt: number;
     }
   > =>
-    reportEntriesForDir(dir)
+    reportEntriesForDir(
+      dir,
+      filterRequested && requestedItemNumberSet.size > 0 ? requestedItemNumberSet : undefined,
+    )
       .filter(
         (entry) =>
           entry.repo === targetRepo() &&
@@ -23530,7 +23533,12 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
           left.number - right.number,
   );
   const files = fileEntries.map((entry) => entry.name);
-  const allOpenFileEntries = applyReportEntriesForDir(itemsDir, "items", false);
+  const boundedExactSelection = exactEventPublication && requestedItemNumberSet.size > 0;
+  // Exact-event publication handles one leased item and cannot pair-close with
+  // limit=1. Keep unrelated canonical records out of this memory-bounded path.
+  const allOpenFileEntries = boundedExactSelection
+    ? fileEntries
+    : applyReportEntriesForDir(itemsDir, "items", false);
   const openFileEntryByNumber = new Map(allOpenFileEntries.map((entry) => [entry.number, entry]));
   const closedThisRun = new Set<string>();
   const authorPrBudgetClosesThisRun = new Map<string, number>();
@@ -23590,10 +23598,16 @@ function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudg
     } catch (error) {
       publicationError = error;
     }
+    const finalEntryNumbers = boundedExactSelection
+      ? new Set([
+          ...requestedItemNumberSet,
+          ...results.flatMap((result) => (result.number > 0 ? [result.number] : [])),
+        ])
+      : undefined;
     const finalEntries = new Map<number, ReportEntry>();
     for (const finalEntry of [
-      ...reportEntriesForDir(itemsDir),
-      ...reportEntriesForDir(closedDir),
+      ...reportEntriesForDir(itemsDir, finalEntryNumbers),
+      ...reportEntriesForDir(closedDir, finalEntryNumbers),
     ].filter((candidate) => candidate.repo === targetRepo())) {
       finalEntries.set(finalEntry.number, finalEntry);
     }
@@ -26899,18 +26913,20 @@ function markdownFiles(dir: string): string[] {
     : [];
 }
 
-function reportEntriesForDir(dir: string): ReportEntry[] {
-  return markdownFiles(dir).map((name) => {
-    const path = join(dir, name);
-    const markdown = readFileSync(path, "utf8");
-    return {
-      name,
-      number: numberForMarkdownFile(name),
-      path,
-      repo: markdownRepository(markdown, path),
-      markdown,
-    };
-  });
+function reportEntriesForDir(dir: string, itemNumbers?: ReadonlySet<number>): ReportEntry[] {
+  return markdownFiles(dir)
+    .filter((name) => !itemNumbers || itemNumbers.has(numberForMarkdownFile(name)))
+    .map((name) => {
+      const path = join(dir, name);
+      const markdown = readFileSync(path, "utf8");
+      return {
+        name,
+        number: numberForMarkdownFile(name),
+        path,
+        repo: markdownRepository(markdown, path),
+        markdown,
+      };
+    });
 }
 
 function numberForMarkdownFile(file: string): number {

--- a/test/apply-cursor-trace.test.ts
+++ b/test/apply-cursor-trace.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -57,6 +57,51 @@ test("apply-decisions preserves auto-selected order and traces only examined rec
     const trace = JSON.parse(readFileSync(tracePath, "utf8"));
     assert.equal(report[0]?.number, 20);
     assert.deepEqual(trace, { schema_version: 1, examined_item_numbers: [20] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("exact-event apply does not read unrelated canonical records", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "20.md"),
+      workPlanCandidateReport({
+        repository: "openclaw/openclaw",
+        number: 20,
+        local_checkout_access: "unverified",
+        decision: "keep_open",
+        action_taken: "kept_open",
+      }),
+      "utf8",
+    );
+    symlinkSync(join(root, "missing-record.md"), join(itemsDir, "999.md"));
+
+    runApplyDecisionsForTest({
+      itemsDir,
+      closedDir,
+      plansDir,
+      reportPath,
+      extraArgs: [
+        "--target-repo",
+        "openclaw/openclaw",
+        "--item-numbers",
+        "20",
+        "--exact-event-publication",
+        "--limit",
+        "1",
+      ],
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(report[0]?.number, 20);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -170,6 +170,7 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
 
 test("exact-review producer uses direct publication with bounded legacy fallback", () => {
   assert.match(sweepSource, /name: Deliver GitHub effects and prepare direct state mutation/);
+  assert.match(sweepSource, /records-item-number: \$\{\{ steps\.target\.outputs\.item_number \}\}/);
   assert.match(
     sweepSource,
     /EXACT_REVIEW_BATCH_MUTATION_OUTPUT: \.artifacts\/direct-publication-outcome\.json/,

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -666,6 +666,14 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(step(reviewer, "Review exact event item").run ?? "", /sleep 60/);
 
   const create = step(reviewer, "Create exact review artifact bundle");
+  const directSetupState = reviewer.steps.find(
+    (candidate) => candidate.id === "direct-setup-state",
+  );
+  assert.ok(directSetupState);
+  assert.equal(
+    directSetupState.with?.["records-item-number"],
+    "${{ steps.target.outputs.item_number }}",
+  );
   const prepareDirect = step(reviewer, "Deliver GitHub effects and prepare direct state mutation");
   const postDirect = step(reviewer, "Post direct exact review publication result");
   const finalizeDirect = step(reviewer, "Finalize direct exact review lifecycle");
@@ -843,6 +851,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   const targetWriteStep = step(publisher, "Create target write token");
   const stateSetup = publisher.steps.find((candidate) => candidate.uses?.endsWith("/setup-state"));
   assert.ok(stateSetup);
+  assert.equal(
+    stateSetup.with?.["records-item-number"],
+    "${{ steps.publication-context.outputs.item_number }}",
+  );
   const publisherCheckout = publisher.steps.find(
     (candidate) => candidate.uses === "actions/checkout@v7",
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact-review publication could exhaust the Node heap after a review completed because a one-item run hydrated and rescanned the full canonical review corpus. The deferred publisher could repeat the same full hydration when direct publication or lifecycle finalization fell back to the queued path.

## Why This Change Was Made

Direct and deferred exact-event publication now hydrate only the requested canonical record and carry the same bounded item set through report discovery and final-state reads. Broad apply modes keep their existing full-corpus behavior.

## User Impact

Exact ClawSweeper reviews can publish without memory use scaling with every historical review record, including the queued fallback path. There is no user-facing configuration change.

## Evidence

- Live failure before the fix: https://github.com/openclaw/clawsweeper/actions/runs/30652803108 reached roughly 1.95 GB heap after hydrating about 49,000 revisions, then queued the fallback publication path.
- Live linked observation: https://github.com/openclaw/clawsweeper/actions/runs/30680211674 completed review generation quickly but spent about 12 minutes in state setup/publication before the durable comment appeared.
- `pnpm run build:all`
- `node --test test/sweep-workflow.test.ts test/apply-cursor-trace.test.ts test/repair/exact-review-batch-workflow.test.ts`
- Result: 115 tests passed.
- Formatting and `git diff --check` passed.
- Fresh uncommitted and committed-branch autoreview: no accepted or actionable findings.
- Production-scale local A/B fixture: 50,000 canonical records at 8,873 bytes each, with the same exact-event command run against base `16f01b29508632ab3a904087191e39b20968ab68` and fixed head `093ffeeb6d84deba015a309750dc343f1799bb74`.
- Base: exact apply selected item `20` in 4,056 ms and peaked at 1,109,803,008 bytes RSS (1,058.4 MiB).
- Fixed: exact apply selected item `20` in 149 ms and peaked at 113,999,872 bytes RSS (108.7 MiB).
- Delta: 96.3% lower exact-apply latency and 89.7% lower peak RSS on the same corpus.

## Real Behavior Proof

- **Claim:** an exact-event apply reads only its requested canonical record, does not touch unrelated dangling records, and both direct and deferred publication hydrate that exact record rather than the full repository corpus.
- **Exercised surface:** exact review setup-state hydration, deferred publication setup-state hydration, report discovery, apply finalization, and workflow wiring.
- **Scenario:** the regression fixture provides item `20` plus an unrelated unreadable `999.md` record. The scale fixture provides 50,000 valid 8,873-byte canonical records and requests only item `20`. Workflow assertions bind both direct and deferred setup-state calls to their exact item-number outputs.
- **Command and environment:** Node 26.4.0 on macOS. A controlled canonical-record directory was executed through the built production CLI as `node dist/clawsweeper.js apply-decisions --target-repo openclaw/openclaw --items-dir <fixture>/items --closed-dir <fixture>/closed --plans-dir <fixture>/plans --report-path <fixture>/apply-report.json --item-numbers 20 --exact-event-publication --limit 1 --processed-limit 1 --close-delay-ms 0`. The same `/usr/bin/time -l` invocation ran against both measured heads.
- **Observed result:** the unreadable-neighbor fixture completed without opening item `999`; all 115 focused tests passed. On the 50,000-record fixture, the base used 1,058.4 MiB RSS and 4,056 ms while the fixed head used 108.7 MiB RSS and 149 ms.
- **Trace:** the workflow tests verify `records-item-number` is bound to the exact target for both direct and deferred publication; the behavior test verifies bounded discovery and rereads; the scale run reports selected item, apply elapsed time, and process peak RSS.
- **Limits:** the scale measurement is a production-sized local corpus rather than the live canonical Worker store. The first post-land exact publication should still be observed operationally, but the before/after read amplification and memory claim are directly measured.

Redacted production-CLI transcript:

```text
base=16f01b29508632ab3a904087191e39b20968ab68
{"corpus_records":50000,"record_bytes":8873,"outcome":"success","selected":20,"apply_elapsed_ms":4056}
1109803008 maximum resident set size

head=093ffeeb6d84deba015a309750dc343f1799bb74
{"corpus_records":50000,"record_bytes":8873,"outcome":"success","selected":20,"apply_elapsed_ms":149}
113999872 maximum resident set size
```

## ClawSweeper Review Disposition - August 1, 2026

- Removed the release-owned `CHANGELOG.md` entry requested by the exact-head review; release context remains in this PR body.

- Rebased onto current `main` at `b07ab751813c722d45f07ef955a8b5752ebbbb19`.
- The direct and deferred one-item publication paths both pass `records-item-number` through the existing focused hydration contract.
- Step-specific workflow assertions cover both paths; the focused suite passes 115 tests.
- The existing corpus-scale proof remains applicable to the bounded apply/read path. The deferred workflow correction closes the remaining sibling setup-state gap found during review.
- The prior rank-up move remains post-land operational monitoring: observe the first canonical Worker publication and retain a redacted result if it differs from the fixture outcome.