### PR TITLE
fix(review): avoid false persistent data-model findings

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -13768,7 +13768,10 @@ function dataModelChangeFromContext(repo: string, context: ItemContext): DataMod
     const previousPath =
       typeof file.previous_filename === "string" ? file.previous_filename.trim() : "";
     const candidates = [path, previousPath].filter(Boolean);
-    const likelyPath = candidates.find(isLikelyOpenClawDataModelPath) ?? "";
+    const productionCandidates = candidates.filter(
+      (candidate) => !isOpenClawDataModelTestPath(candidate),
+    );
+    const likelyPath = productionCandidates.find(isLikelyOpenClawDataModelPath) ?? "";
     const patch = typeof file.patch === "string" ? file.patch : null;
     const lines = patch === null ? [] : changedPatchLines(patch);
 
@@ -13779,7 +13782,7 @@ function dataModelChangeFromContext(repo: string, context: ItemContext): DataMod
       surfaces.add(dataModelSurfaceLabel(likelyPath, "unknown-data-model-change"));
     }
 
-    for (const candidate of candidates) {
+    for (const candidate of productionCandidates) {
       if (isDocsPath(candidate)) {
         if (patch !== null && !configSurfacePatchIsTruncated(patch)) {
           dataModelSurfacesFromPatch(candidate, lines, { docsOnly: true }).forEach((surface) =>
@@ -14024,7 +14027,7 @@ function dataModelSurfacesFromPatch(
   ) {
     add("database schema");
   }
-  if (/\b(?:migration|migrate|upgrade|backfill|doctor|repair|reindex|rehydrat\w*)\b/i.test(text)) {
+  if (/\b(?:migrations?|migrat(?:e|ed|es|ing)|backfill\w*)\b/i.test(text)) {
     add("migration/backfill/repair");
   }
   if (
@@ -14034,22 +14037,26 @@ function dataModelSurfacesFromPatch(
   ) {
     add("durable storage schema");
   }
-  if (
-    /\b(?:JSON\.(?:parse|stringify)|readFile|writeFile|localStorage|sessionStorage|workspaceState|globalState|serialized|persisted?|statePath)\b/i.test(
-      text,
-    )
-  ) {
+  const hasExplicitSerializedState =
+    /\b(?:localStorage|sessionStorage|workspaceState|globalState|statePath)\b/i.test(text);
+  const hasJsonFilePersistence = lines.some((_, index) => {
+    const operation = lines.slice(Math.max(0, index - 2), index + 3).join("\n");
+    return (
+      /\b(?:readFile|writeFile)\w*\b/i.test(operation) &&
+      /\bJSON\.(?:parse|stringify)\b/i.test(operation) &&
+      /\b(?:state|checkpoint|snapshot|cache|store|storage|record|session|history|queue|registry|cursor|profile|credential|memory|database|db)(?:[ _-]?(?:path|file|dir(?:ectory)?)){0,2}\b/i.test(
+        operation,
+      )
+    );
+  });
+  if (hasExplicitSerializedState || hasJsonFilePersistence) {
     add("serialized state");
   }
-  if (
-    /\b(?:cache(?:Key|Version|Schema|Namespace)?|cache[_-]?(?:key|version|schema|namespace)|ttl)\b/i.test(
-      text,
-    )
-  ) {
+  if (/\bcache[ _-]?(?:key|version|schema|namespace|ttl)\b/i.test(text)) {
     add("persistent cache schema");
   }
   if (
-    /\b(?:embedding|vector|collection|dimension|metadata|row[_-]?id|document[_-]?id|chunk[_-]?id|similarity[_-]?index)\b/i.test(
+    /\b(?:embedding[ _-]?dimension|vector[ _-]?dimension|collection[ _-]?name|row[ _-]?id|document[ _-]?id|chunk[ _-]?id|similarity[ _-]?index)\b/i.test(
       text,
     )
   ) {
@@ -14070,6 +14077,14 @@ function dataModelLineLooksSemantic(line: string, options: { docsOnly: boolean }
 function isLikelyOpenClawDataModelPath(path: string): boolean {
   if (!path || isDocsPath(path)) return false;
   return Boolean(dataModelPathHint(path)) || /\.(?:sql|sqlite|db|prisma)$/.test(path);
+}
+
+function isOpenClawDataModelTestPath(path: string): boolean {
+  return (
+    /(^|\/)(?:__tests__|test|tests|fixtures|__snapshots__)(?:\/|$)/i.test(path) ||
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/i.test(path) ||
+    /\.snap$/i.test(path)
+  );
 }
 
 function dataModelPathHint(path: string): string {
@@ -14098,7 +14113,7 @@ function dataModelPathHint(path: string): string {
     return "vector/embedding metadata";
   }
   if (
-    /(^|\/)(?:migrations?|backfill|doctor|repair|upgrade)(?:\/|[-_.])|(?:migration|backfill|doctor|repair|upgrade)\.(?:ts|js)$/i.test(
+    /(^|\/)(?:migrations?|backfill|doctor|repair|upgrade)(?:\/|[-_.])|(^|\/)(?:migration|backfill|doctor|repair|upgrade)\.(?:ts|js)$/i.test(
       path,
     )
   ) {

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -294,6 +294,136 @@ test("data model detector ignores query-only and non-semantic docs changes", () 
   assert.deepEqual(detection, { change: false, surfaces: [] });
 });
 
+test("data model detector ignores runtime repair, telemetry, and test vocabulary", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/agents/embedded-agent-runner/run/code-mode-tool-call-repair.ts",
+        patch: "@@\n+  return repairSmallModelToolCall(payload);",
+      },
+      {
+        filename: "src/agents/tool-search-runtime.ts",
+        patch: "@@\n+  const repaired = repairToolResult(result);",
+      },
+      {
+        filename: "src/agents/tool-search-telemetry.ts",
+        patch: "@@\n+  metadata: toolMetadata,\n+  cacheRead: usage.cacheRead,",
+      },
+      {
+        filename: "src/agents/code-mode-tool-input-repair.ts",
+        patch: "@@\n+  return JSON.parse(candidate);",
+      },
+      {
+        filename: "extensions/qa-lab/src/code-mode-model-matrix.options.test.ts",
+        patch: "@@\n+  it('preserves cache fields', () => JSON.stringify(result));",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, { change: false, surfaces: [] });
+});
+
+test("data model detector keeps explicit repair and persistence surfaces", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/doctor/repair.ts",
+        patch: "@@\n+  await repair(database);",
+      },
+      {
+        filename: "src/cache/schema.ts",
+        patch: "@@\n+  entryFingerprint: string;",
+      },
+      {
+        filename: "src/runtime/checkpoint.ts",
+        patch:
+          "@@\n+  const raw = await readFile(checkpointPath, 'utf8');\n+  return JSON.parse(raw);",
+      },
+      {
+        filename: "scripts/config-fixture.ts",
+        patch:
+          "@@\n+  await writeFile(configPath, JSON.stringify(config));\n+  return readFile(resultPath, 'utf8');",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "migration/backfill/repair: src/doctor/repair.ts",
+      "persistent cache schema: src/cache/schema.ts",
+      "serialized state: src/runtime/checkpoint.ts",
+    ],
+  });
+});
+
+test("data model detector keeps production snapshot schemas", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/storage/snapshots/schema.sql",
+        patch: "@@\n+ALTER TABLE snapshots ADD COLUMN format_version INTEGER;",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: ["database schema: src/storage/snapshots/schema.sql"],
+  });
+});
+
+test("data model detector recognizes semantic prose forms", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "docs/storage.md",
+        patch:
+          "@@\n+The cache version changes when persisted entries become incompatible.\n+The embedding dimension remains part of stored vector metadata.",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "persistent cache schema: docs/storage.md",
+      "vector/embedding metadata: docs/storage.md",
+    ],
+  });
+});
+
+test("data model detector recognizes compound persisted path identifiers", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/runtime/load-checkpoint.ts",
+        patch:
+          "@@\n+  const raw = await readFile(checkpointFilePath, 'utf8');\n+  return JSON.parse(raw);",
+      },
+      {
+        filename: "src/runtime/load-state.ts",
+        patch:
+          "@@\n+  const raw = await readFile(state_file_path, 'utf8');\n+  return JSON.parse(raw);",
+      },
+      {
+        filename: "src/runtime/load-cache.ts",
+        patch:
+          "@@\n+  const raw = await readFile(cacheDirectoryPath, 'utf8');\n+  return JSON.parse(raw);",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "serialized state: src/runtime/load-cache.ts",
+      "serialized state: src/runtime/load-checkpoint.ts",
+      "serialized state: src/runtime/load-state.ts",
+    ],
+  });
+});
+
 test("data model detector flags path-hinted persisted field declarations", () => {
   const detection = dataModelChangeFromPullFilesForTest({
     pullFiles: [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw pull requests with runtime repair, telemetry, cache-usage, or test-fixture vocabulary could be reported as persistent data-model changes even when they did not alter stored state. This produced misleading merge risk in reviews such as https://github.com/openclaw/openclaw/pull/115869.

## Why This Change Was Made

The detector now keeps persistence matching tied to explicit storage operations, semantic schema language, and production data-model paths while excluding test-only surfaces. It preserves real schema, migration, cache, vector, serialized-state, compound-path, prose, and production snapshot signals.

## User Impact

Maintainers get fewer false stored-data warnings without losing review gates for actual persistence or migration changes.

## Evidence

- `pnpm run build && node --test test/pr-surface-policy.test.ts`: 28/28 passed.
- Focused regressions cover production snapshot schemas, prose forms such as `cache version` and `embedding dimension`, and compound identifiers such as `checkpointFilePath`.
- `git diff --check`: clean.
- Fresh autoreview: clean, 0 accepted/actionable findings.

## Real Behavior Proof

**Claim:** the detector no longer classifies the Code Mode reliability patch as a stored data-model change while retaining concrete persistence findings.

**Exercised surface:** `dataModelChangeFromPullFilesForTest`, using the complete 118-file GitHub pull-file fixture from https://github.com/openclaw/openclaw/pull/115869.

**Command and environment:** built `@openclaw/clawsweeper` on Node 26, then executed the compiled detector 50 times over the captured 118-file fixture.

**Observed result:** `{ "change": false, "surfaces": [] }`; p50 3.77 ms, p90 3.87 ms, max 7.53 ms. The prior published review reported 12 unrelated data-model surfaces.

**Artifact or trace:** focused test output and benchmark summary are included in the task handoff; CI will rerun repository gates on this exact branch.

**Limits:** this PR fixes classifier precision only. Complete pull-file materialization for PRs above the compact review limit remains a separate change.


## Combined Integration Proof - July 31, 2026

Both exact merge orders were tested from base `16f01b29508632ab3a904087191e39b20968ab68`:

- `983 -> 984`: clean cherry-picks; 66/66 focused tests passed.
- `984 -> 983`: clean cherry-picks; 66/66 focused tests passed.
- Both orders produced identical Git tree `609478921e5b04e2b1844001bfe81ca713f4f099`, with 6 files changed, 560 insertions, and 25 deletions.
- `git diff --check 16f01b29508632ab3a904087191e39b20968ab68..HEAD` passed in both worktrees.
- Live GitHub pagination for OpenClaw PR 115869 returned pages of 100 and 18 files, exactly 118 total.
- Both orders produced the same compiled-detector output: `{ "config": { "change": false, "keys": [] }, "data": { "change": false, "surfaces": [] } }`.
- Positive persistence guards remained green in both orders, including schema, serialized-state, cache, vector metadata, production snapshot, compound persisted-path, missing-patch, and truncated-input fixtures.
- Complete-file guards also remained green in both orders: exact count, unique filenames, stable base/head snapshot, fetch failure, and the 3,000-file API ceiling all fail closed.

Commands used direct `tsc` plus `node --test test/context.test.ts test/pr-surface-policy.test.ts test/review-prompt-context.test.ts`; no dependency reconciliation occurred in the proof worktrees.

## Maintainer Decision - July 31, 2026

Approved: retain the narrower production-path and explicit-signal classifier boundary. The demonstrated Code Mode false positive is not useful merge-risk signal, while the positive schema, migration, serialized-state, cache, vector, compound-path, missing-patch, and truncated-input guards preserve the conservative cases that matter. No broader vocabulary fallback is requested.