### PR TITLE
fix(review): inspect complete file lists for large pull requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Large OpenClaw pull requests now reuse each paginated file-list page for bounded context and deterministic classification, accepting the complete sidecar only when filenames are unique and the PR base/head snapshot remains stable.
 - Event-review artifact publication completes as a superseded no-op when the reviewed branch vanished upstream (force-push or deletion) instead of failing the run.
 - Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.
 - Exact reviews of items that closed after enqueue now complete as superseded no-ops, and GitHub-throttled reservations defer as held retries — neither spends the item's review-failure budget.

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -8,6 +8,7 @@ import type { SchedulerDueCandidate } from "./scheduler-policy.js";
 
 /** Shared ClawSweeper domain, review, scheduling, and dashboard shapes. */
 export const completeActivityContextSymbol = Symbol("completeActivityContext");
+export const completePullFilesSymbol = Symbol("completePullFiles");
 
 export type ItemKind = "issue" | "pull_request";
 export type ApplyKind = ItemKind | "all";
@@ -535,6 +536,7 @@ export interface CompleteActivityContext {
 
 export interface ItemContext {
   [completeActivityContextSymbol]?: CompleteActivityContext;
+  [completePullFilesSymbol]?: readonly unknown[];
   issue: unknown;
   comments: unknown[];
   timeline: unknown[];

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4473,30 +4473,118 @@ function compactSemanticPullFile(value: unknown): unknown {
   };
 }
 
+type PullFileSnapshot = {
+  baseSha: string;
+  headSha: string;
+};
+
+const GITHUB_PULL_FILES_MAX = 3000;
+
+function pullFileSnapshot(value: unknown): PullFileSnapshot | null {
+  const pull = asRecord(value);
+  const baseSha = stringOrUndefined(asRecord(pull.base).sha)?.toLowerCase() ?? "";
+  const headSha = stringOrUndefined(asRecord(pull.head).sha)?.toLowerCase() ?? "";
+  return /^[0-9a-f]{40}$/.test(baseSha) && /^[0-9a-f]{40}$/.test(headSha)
+    ? { baseSha, headSha }
+    : null;
+}
+
 function completePullFilesForDeterministicReview(options: {
+  initialPullRequest: unknown;
   repo: string;
   total: number;
   truncated: boolean;
   fetchAll: () => unknown[];
+  fetchPullRequest: () => unknown;
 }): unknown[] | null {
-  if (options.repo !== "openclaw/openclaw" || !options.truncated) return null;
+  if (
+    options.repo !== "openclaw/openclaw" ||
+    !options.truncated ||
+    options.total > GITHUB_PULL_FILES_MAX
+  ) {
+    return null;
+  }
   try {
+    const initialSnapshot = pullFileSnapshot(options.initialPullRequest);
+    if (!initialSnapshot) return null;
     const files = options.fetchAll();
-    return files.length === options.total ? files.map(compactSemanticPullFile) : null;
+    if (files.length !== options.total) return null;
+    const filenames = files.map((file) => stringOrUndefined(asRecord(file).filename)?.trim() ?? "");
+    if (filenames.some((filename) => !filename) || new Set(filenames).size !== filenames.length) {
+      return null;
+    }
+    const refreshedSnapshot = pullFileSnapshot(options.fetchPullRequest());
+    if (
+      !refreshedSnapshot ||
+      refreshedSnapshot.baseSha !== initialSnapshot.baseSha ||
+      refreshedSnapshot.headSha !== initialSnapshot.headSha
+    ) {
+      return null;
+    }
+    return files.map(compactSemanticPullFile);
   } catch {
     // Keep the bounded window usable; deterministic classifiers retain the unknown marker.
     return null;
   }
 }
 
+function pullFileReviewHydration(options: {
+  repo: string;
+  path: string;
+  total: unknown;
+  pullRequest: unknown;
+  fetchPage: (path: string, page: number) => unknown[];
+  fetchPullRequest: () => unknown;
+}): { window: ContextHydration<unknown>; completeFiles: unknown[] | null } {
+  const pages = new Map<number, unknown[]>();
+  const readPage = (path: string, page: number): unknown[] => {
+    const cached = pages.get(page);
+    if (cached) return cached;
+    const files = options.fetchPage(path, page);
+    pages.set(page, files);
+    return files;
+  };
+  const window = ghPagedContextWindow<unknown>(options.path, options.total, 80, {
+    page: readPage,
+  });
+  const completeFiles = completePullFilesForDeterministicReview({
+    initialPullRequest: options.pullRequest,
+    repo: options.repo,
+    total: window.total,
+    truncated: window.truncated,
+    fetchAll: () => {
+      const files: unknown[] = [];
+      const pageCount = Math.ceil(window.total / 100);
+      for (let page = 1; page <= pageCount; page += 1) {
+        const pageFiles = readPage(options.path, page);
+        files.push(...pageFiles);
+        if (pageFiles.length < 100) break;
+      }
+      return files;
+    },
+    fetchPullRequest: options.fetchPullRequest,
+  });
+  return { window, completeFiles };
+}
+
 export function completePullFilesForDeterministicReviewForTest(options: {
+  initialBaseSha?: string;
+  initialHeadSha?: string;
+  refreshedBaseSha?: string;
+  refreshedHeadSha?: string;
   repo?: string;
   total: number;
   truncated: boolean;
   files: unknown[];
   fetchError?: Error;
 }): unknown[] | null {
+  const initialBaseSha = options.initialBaseSha ?? "a".repeat(40);
+  const initialHeadSha = options.initialHeadSha ?? "b".repeat(40);
   return completePullFilesForDeterministicReview({
+    initialPullRequest: {
+      base: { sha: initialBaseSha },
+      head: { sha: initialHeadSha },
+    },
     repo: options.repo ?? "openclaw/openclaw",
     total: options.total,
     truncated: options.truncated,
@@ -4504,7 +4592,42 @@ export function completePullFilesForDeterministicReviewForTest(options: {
       if (options.fetchError) throw options.fetchError;
       return options.files;
     },
+    fetchPullRequest: () => ({
+      base: { sha: options.refreshedBaseSha ?? initialBaseSha },
+      head: { sha: options.refreshedHeadSha ?? initialHeadSha },
+    }),
   });
+}
+
+export function pullFileReviewHydrationForTest(options: {
+  total: number;
+  pages: readonly unknown[][];
+}): {
+  completeFiles: unknown[] | null;
+  hydrated: number;
+  pageCalls: number[];
+} {
+  const pageCalls: number[] = [];
+  const pullRequest = {
+    base: { sha: "a".repeat(40) },
+    head: { sha: "b".repeat(40) },
+  };
+  const result = pullFileReviewHydration({
+    repo: "openclaw/openclaw",
+    path: "repos/openclaw/openclaw/pulls/123/files",
+    total: options.total,
+    pullRequest,
+    fetchPage: (_path, page) => {
+      pageCalls.push(page);
+      return [...(options.pages[page - 1] ?? [])];
+    },
+    fetchPullRequest: () => pullRequest,
+  });
+  return {
+    completeFiles: result.completeFiles,
+    hydrated: result.window.hydrated,
+    pageCalls,
+  };
 }
 
 function normalizedPullFileStatus(value: unknown): string {
@@ -6597,18 +6720,19 @@ function collectItemContext(
   if (item.kind === "pull_request") {
     pullRequest = ghJson<unknown>(["api", `repos/${targetRepo()}/pulls/${item.number}`]);
     const pullRecord = asRecord(pullRequest);
-    const pullFilesWindow = ghPagedContextWindow<unknown>(
-      `repos/${targetRepo()}/pulls/${item.number}/files`,
-      pullRecord.changed_files,
-      80,
-    );
-    const pullFiles = pullFilesWindow.items;
-    const completePullFiles = completePullFilesForDeterministicReview({
+    const pullFilesPath = `repos/${targetRepo()}/pulls/${item.number}/files`;
+    const pullFileHydration = pullFileReviewHydration({
       repo: targetRepo(),
-      total: pullFilesWindow.total,
-      truncated: pullFilesWindow.truncated,
-      fetchAll: () => ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/files`),
+      path: pullFilesPath,
+      total: pullRecord.changed_files,
+      pullRequest,
+      fetchPage: ghPage,
+      fetchPullRequest: () =>
+        ghJson<unknown>(["api", `repos/${targetRepo()}/pulls/${item.number}`]),
     });
+    const pullFilesWindow = pullFileHydration.window;
+    const pullFiles = pullFilesWindow.items;
+    const completePullFiles = pullFileHydration.completeFiles;
     const pullCommitsWindow = ghPagedContextWindow<unknown>(
       `repos/${targetRepo()}/pulls/${item.number}/commits`,
       pullRecord.commits,

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -234,7 +234,7 @@ import {
   themedRatingName,
 } from "./clawsweeper-rating.js";
 
-import { completeActivityContextSymbol } from "./clawsweeper-types.js";
+import { completeActivityContextSymbol, completePullFilesSymbol } from "./clawsweeper-types.js";
 import type {
   AcquiredReviewStartLease,
   Action,
@@ -4473,6 +4473,40 @@ function compactSemanticPullFile(value: unknown): unknown {
   };
 }
 
+function completePullFilesForDeterministicReview(options: {
+  repo: string;
+  total: number;
+  truncated: boolean;
+  fetchAll: () => unknown[];
+}): unknown[] | null {
+  if (options.repo !== "openclaw/openclaw" || !options.truncated) return null;
+  try {
+    const files = options.fetchAll();
+    return files.length === options.total ? files.map(compactSemanticPullFile) : null;
+  } catch {
+    // Keep the bounded window usable; deterministic classifiers retain the unknown marker.
+    return null;
+  }
+}
+
+export function completePullFilesForDeterministicReviewForTest(options: {
+  repo?: string;
+  total: number;
+  truncated: boolean;
+  files: unknown[];
+  fetchError?: Error;
+}): unknown[] | null {
+  return completePullFilesForDeterministicReview({
+    repo: options.repo ?? "openclaw/openclaw",
+    total: options.total,
+    truncated: options.truncated,
+    fetchAll: () => {
+      if (options.fetchError) throw options.fetchError;
+      return options.files;
+    },
+  });
+}
+
 function normalizedPullFileStatus(value: unknown): string {
   const status = typeof value === "string" ? value.trim().toLowerCase() : "";
   if (status === "m" || status === "modified" || status === "changed") return "modified";
@@ -6569,6 +6603,12 @@ function collectItemContext(
       80,
     );
     const pullFiles = pullFilesWindow.items;
+    const completePullFiles = completePullFilesForDeterministicReview({
+      repo: targetRepo(),
+      total: pullFilesWindow.total,
+      truncated: pullFilesWindow.truncated,
+      fetchAll: () => ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/files`),
+    });
     const pullCommitsWindow = ghPagedContextWindow<unknown>(
       `repos/${targetRepo()}/pulls/${item.number}/commits`,
       pullRecord.commits,
@@ -6599,6 +6639,12 @@ function collectItemContext(
       fullPullReviewComments.length >= pullReviewCommentsWindow.total;
     context.pullRequest = compactPullRequest(pullRequest);
     context.pullFiles = compactMappedWindow(pullFiles, pullFilesWindow.total, 80, compactPullFile);
+    if (completePullFiles) {
+      Object.defineProperty(context, completePullFilesSymbol, {
+        value: completePullFiles,
+        enumerable: false,
+      });
+    }
     context.semanticPullFiles =
       options.reviewCacheDigest &&
       options.reviewCacheGitDir &&
@@ -10724,13 +10770,28 @@ function pullRequestFilePathsFromReport(markdown: string): string[] {
   return frontMatterStringArray(markdown, "pull_files");
 }
 
+function deterministicPullFilesFromContext(context: ItemContext): {
+  complete: boolean;
+  files: readonly unknown[];
+} {
+  const completePullFiles = context[completePullFilesSymbol];
+  if (context.counts?.pullFilesTruncated && completePullFiles) {
+    return { complete: true, files: completePullFiles };
+  }
+  return {
+    complete: context.counts?.pullFilesTruncated !== true,
+    files: context.pullFiles ?? [],
+  };
+}
+
 function configSurfaceChangeFromContext(repo: string, context: ItemContext): ConfigSurfaceChange {
   if (repo !== "openclaw/openclaw") {
     return { change: false, keys: [] };
   }
 
   const keys = new Set<string>();
-  for (const entry of context.pullFiles ?? []) {
+  const deterministicPullFiles = deterministicPullFilesFromContext(context);
+  for (const entry of deterministicPullFiles.files) {
     const file = asRecord(entry);
     const path = typeof file.filename === "string" ? file.filename.trim() : "";
     const previousPath =
@@ -10760,7 +10821,7 @@ function configSurfaceChangeFromContext(repo: string, context: ItemContext): Con
     }
   }
 
-  if (context.counts?.pullFilesTruncated) {
+  if (!deterministicPullFiles.complete) {
     keys.add("unknown-truncated-pull-files");
   }
 
@@ -10768,6 +10829,7 @@ function configSurfaceChangeFromContext(repo: string, context: ItemContext): Con
 }
 
 export function configSurfaceChangeFromPullFilesForTest(options: {
+  completePullFiles?: readonly unknown[];
   repo?: string;
   pullFiles?: unknown[];
   pullFilesTruncated?: boolean;
@@ -10782,6 +10844,8 @@ export function configSurfaceChangeFromPullFilesForTest(options: {
     counts,
   };
   if (options.pullFiles !== undefined) context.pullFiles = options.pullFiles;
+  if (options.completePullFiles !== undefined)
+    context[completePullFilesSymbol] = options.completePullFiles;
   return configSurfaceChangeFromContext(options.repo ?? "openclaw/openclaw", context);
 }
 
@@ -10791,7 +10855,8 @@ function dataModelChangeFromContext(repo: string, context: ItemContext): DataMod
   }
 
   const surfaces = new Set<string>();
-  for (const entry of context.pullFiles ?? []) {
+  const deterministicPullFiles = deterministicPullFilesFromContext(context);
+  for (const entry of deterministicPullFiles.files) {
     const file = asRecord(entry);
     const path = typeof file.filename === "string" ? file.filename.trim() : "";
     const previousPath =
@@ -10823,7 +10888,7 @@ function dataModelChangeFromContext(repo: string, context: ItemContext): DataMod
     }
   }
 
-  if (context.counts?.pullFilesTruncated) {
+  if (!deterministicPullFiles.complete) {
     surfaces.add("unknown-truncated-pull-files");
   }
 
@@ -10831,6 +10896,7 @@ function dataModelChangeFromContext(repo: string, context: ItemContext): DataMod
 }
 
 export function dataModelChangeFromPullFilesForTest(options: {
+  completePullFiles?: readonly unknown[];
   repo?: string;
   pullFiles?: unknown[];
   pullFilesTruncated?: boolean;
@@ -10845,6 +10911,8 @@ export function dataModelChangeFromPullFilesForTest(options: {
     counts,
   };
   if (options.pullFiles !== undefined) context.pullFiles = options.pullFiles;
+  if (options.completePullFiles !== undefined)
+    context[completePullFilesSymbol] = options.completePullFiles;
   return dataModelChangeFromContext(options.repo ?? "openclaw/openclaw", context);
 }
 

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -15,6 +15,7 @@ import {
   githubContextWindowPlan,
   githubLinkLastPageNumber,
   githubPaginatedPath,
+  pullFileReviewHydrationForTest,
   stripEmptyMaintainerRulingFieldsForTest,
 } from "../dist/clawsweeper.js";
 
@@ -141,6 +142,69 @@ test("complete pull-file hydration requires the exact reported count", () => {
     })?.length,
     118,
   );
+});
+
+test("complete pull-file hydration requires unique filenames and a stable pull snapshot", () => {
+  const files = Array.from({ length: 118 }, (_, index) => ({
+    filename: `src/file-${index}.ts`,
+    patch: `+export const value${index} = ${index};`,
+  }));
+
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      total: 118,
+      truncated: true,
+      files: [...files.slice(0, 117), files[0]],
+    }),
+    null,
+  );
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      total: 118,
+      truncated: true,
+      files,
+      refreshedHeadSha: "c".repeat(40),
+    }),
+    null,
+  );
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      total: 118,
+      truncated: true,
+      files,
+      refreshedBaseSha: "d".repeat(40),
+    }),
+    null,
+  );
+});
+
+test("complete pull-file hydration fetches each page at most once", () => {
+  const files = Array.from({ length: 118 }, (_, index) => ({
+    filename: `src/file-${index}.ts`,
+    patch: `+export const value${index} = ${index};`,
+  }));
+  const result = pullFileReviewHydrationForTest({
+    total: files.length,
+    pages: [files.slice(0, 100), files.slice(100)],
+  });
+
+  assert.equal(result.hydrated, 80);
+  assert.equal(result.completeFiles?.length, 118);
+  assert.deepEqual(result.pageCalls, [1, 2]);
+});
+
+test("complete pull-file hydration fails closed above GitHub's file-list limit", () => {
+  const files = Array.from({ length: 100 }, (_, index) => ({
+    filename: `src/file-${index}.ts`,
+    patch: `+export const value${index} = ${index};`,
+  }));
+  const result = pullFileReviewHydrationForTest({
+    total: 5000,
+    pages: [files],
+  });
+
+  assert.equal(result.completeFiles, null);
+  assert.deepEqual(result.pageCalls, [1, 50]);
 });
 
 test("complete pull-file hydration fails closed when the full fetch throws", () => {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -6,6 +6,7 @@ import {
   assistPromptContextForTest,
   compactMappedSlice,
   compactMappedWindow,
+  completePullFilesForDeterministicReviewForTest,
   extractLatestClawSweeperReviewForTest,
   extractLatestClawSweeperReviewFromHydrationForTest,
   filterReviewContextCommentsForTest,
@@ -107,6 +108,51 @@ test("compactMappedWindow keeps bounded hydrated context when total is larger th
     100,
   ]);
   assert.deepEqual(mapped, [1, 2, 99, 100]);
+});
+
+test("complete pull-file hydration requires the exact reported count", () => {
+  const files = Array.from({ length: 118 }, (_, index) => ({
+    filename: `src/file-${index}.ts`,
+    patch: `+export const value${index} = ${index};`,
+  }));
+
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      total: 118,
+      truncated: true,
+      files: files.slice(0, 117),
+    }),
+    null,
+  );
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      repo: "openclaw/clawhub",
+      total: 118,
+      truncated: true,
+      files,
+    }),
+    null,
+  );
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      total: 118,
+      truncated: true,
+      files,
+    })?.length,
+    118,
+  );
+});
+
+test("complete pull-file hydration fails closed when the full fetch throws", () => {
+  assert.equal(
+    completePullFilesForDeterministicReviewForTest({
+      total: 118,
+      truncated: true,
+      files: [],
+      fetchError: new Error("GitHub pagination failed"),
+    }),
+    null,
+  );
 });
 
 function issueComment(

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -238,6 +238,29 @@ test("config surface detector fails closed for truncated pull files", () => {
   });
 });
 
+test("config surface detector uses complete files without a truncation marker", () => {
+  const completePullFiles = Array.from({ length: 118 }, (_, index) => ({
+    filename: index === 59 ? "src/config/schema.ts" : `src/agents/generated/file-${index}.test.ts`,
+    patch: index === 59 ? "@@\n+  codeMode: z.boolean().optional()," : "@@\n+  const value = true;",
+  }));
+  const compactPullFiles = [
+    ...completePullFiles.slice(0, 40),
+    { omitted: 38, note: "middle entries omitted from prompt context" },
+    ...completePullFiles.slice(-40),
+  ];
+
+  const detection = configSurfaceChangeFromPullFilesForTest({
+    completePullFiles,
+    pullFiles: compactPullFiles,
+    pullFilesTruncated: true,
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    keys: ["codeMode"],
+  });
+});
+
 test("data model detector finds persistent schema and embedding metadata changes", () => {
   const detection = dataModelChangeFromPullFilesForTest({
     pullFiles: [
@@ -344,6 +367,27 @@ test("data model detector fails closed for missing and truncated likely-surface 
       "unknown-data-model-change: src/storage/session-state.ts",
       "unknown-truncated-pull-files",
     ],
+  });
+});
+
+test("data model detector uses complete files without a truncation marker", () => {
+  const completePullFiles = Array.from({ length: 118 }, (_, index) => ({
+    filename: index === 58 ? "packages/database/schema.sql" : `src/runtime/file-${index}.ts`,
+    patch:
+      index === 58
+        ? "@@\n+ALTER TABLE sessions ADD COLUMN last_model TEXT;"
+        : "@@\n+export const value = true;",
+  }));
+
+  const detection = dataModelChangeFromPullFilesForTest({
+    completePullFiles,
+    pullFiles: [...completePullFiles.slice(0, 40), ...completePullFiles.slice(-40)],
+    pullFilesTruncated: true,
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: ["database schema: packages/database/schema.sql"],
   });
 });
 

--- a/test/review-prompt-context.test.ts
+++ b/test/review-prompt-context.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   compactPullRequestForTest,
+  itemContentDigestForTest,
   renderReviewContextBudgetForTest,
   reviewContextLedgerForTest,
   reviewDecisionSchemaText,
@@ -11,6 +12,7 @@ import {
   reviewPromptTelemetryForTest,
   reviewPromptTemplate,
 } from "../dist/clawsweeper.js";
+import { completePullFilesSymbol } from "../dist/clawsweeper-types.js";
 import { parseArgs as parseClawsweeperArgs } from "../dist/clawsweeper-args.js";
 import { git, item } from "./helpers.ts";
 
@@ -210,4 +212,43 @@ test("review context ledger records ordered section budgets", () => {
   );
   assert.match(renderReviewContextBudgetForTest(context), /- timeline events: 1\/1 hydrated/);
   assert.match(renderReviewContextBudgetForTest(context), /- previous ClawSweeper review: 1 entry/);
+});
+
+test("review prompt, ledger, and content digest exclude complete deterministic pull files", () => {
+  const context = {
+    issue: { number: 123, title: "Large PR" },
+    comments: [],
+    timeline: [],
+    pullRequest: { number: 123, additions: 120 },
+    pullFiles: [{ filename: "src/first.ts", patch: "+first" }],
+    pullCommits: [],
+    pullReviewComments: [],
+    counts: {
+      comments: 0,
+      timeline: 0,
+      pullFiles: 118,
+      pullFilesHydrated: 80,
+      pullFilesTruncated: true,
+    },
+  };
+  const digestWithoutSidecar = itemContentDigestForTest(
+    item({ kind: "pull_request", number: 123 }),
+    context,
+    git,
+  );
+  Object.defineProperty(context, completePullFilesSymbol, {
+    value: [{ filename: "src/private-middle.ts", patch: "+middle" }],
+  });
+
+  const prompt = reviewPromptForTest(item({ kind: "pull_request", number: 123 }), context, git);
+  const ledger = reviewContextLedgerForTest(context);
+  const digestWithSidecar = itemContentDigestForTest(
+    item({ kind: "pull_request", number: 123 }),
+    context,
+    git,
+  );
+
+  assert.doesNotMatch(prompt, /private-middle/);
+  assert.equal(ledger.find((entry) => entry.section === "pullFiles")?.entries, 1);
+  assert.equal(digestWithSidecar, digestWithoutSidecar);
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/983

## What Problem This Solves

Fixes an issue where large OpenClaw pull requests could hide config or persistent-data files in the omitted middle of the bounded 80-file review context, leaving deterministic merge-risk classification incomplete.

## Why This Change Was Made

For truncated openclaw/openclaw pull requests only, ClawSweeper now fetches the complete file list into a compact non-enumerable sidecar. It reuses every bounded-context page, requires the exact count and unique filenames, verifies that base and head SHAs stayed stable across pagination, and fails closed above GitHub's 3,000-file response limit. Deterministic config and data-model classifiers consume that sidecar, while prompts, ledgers, and cache digests keep the existing bounded context.

## User Impact

Large OpenClaw pull requests receive complete deterministic surface classification without increasing model prompt size or changing review cache identity. Fetch or count failures retain the existing unknown-truncated fail-closed marker.

## Evidence

- Direct TypeScript build passed.
- Focused context, surface-policy, and prompt-context tests: 61/61 passed.
- Fresh uncommitted and committed-branch autoreview: no accepted or actionable findings; final exact-branch confidence 0.91.
- `git diff --check`: clean.
- GitHub's current `List pull requests files` contract caps responses at 3,000 files: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files. Totals above that limit fail closed before complete pagination.
- The ClawSweeper changelog entry is intentional: this PR changes ClawSweeper itself. The current `origin/main` release-owned exception applies to OpenClaw's changelog during foreign-target PR work, not this repository's own operational release notes.

## Real Behavior Proof

- **Claim:** a truncated 118-file pull request supplies all files to deterministic classifiers without exposing the hidden payload to model context or cache identity.
- **Exercised surface:** live GitHub pull-file pagination for https://github.com/openclaw/openclaw/pull/115869, complete-count validation, deterministic config/data classifier input, prompt ledger, and content digest.
- **Observed result:** live pagination returned exactly 118 files; the sidecar accepted all 118, the config classifier reported no config change, and no unknown-truncated marker remained. The page cache fetched pages `[1,2]` exactly once rather than refetching both pages. The semantic false-positive cleanup is independently reviewable in https://github.com/openclaw/clawsweeper/pull/983.
- **Failure proof:** count mismatch, duplicate filenames, changed base/head snapshots, paginated-fetch exceptions, and totals above GitHub's 3,000-file response limit return no sidecar, preserving `unknown-truncated-pull-files`.
- **Limits:** production review output reflects both this complete-file input fix and the separately reviewed classifier semantics fix after those drafts are landed.



## Live Pagination And Merge-Order Proof - July 31, 2026

Redacted live pagination transcript for OpenClaw PR 115869:

```text
captured_at=2026-07-31T21:02:46Z
review_head=4a434e7e1fc530785a6700e088bdbb93b04091a6
page_1_count=100
page_2_count=18
page_3_count=0
total=118
first=docs/providers/huggingface.md
last=src/commands/agent-exec.ts
```

The transcript was produced with authenticated read-only `ghx api` requests to:

```text
repos/openclaw/openclaw/pulls/115869/files?per_page=100&page=1
repos/openclaw/openclaw/pulls/115869/files?per_page=100&page=2
repos/openclaw/openclaw/pulls/115869/files?per_page=100&page=3
```

Both exact merge orders were tested from base `16f01b29508632ab3a904087191e39b20968ab68`:

- `983 -> 984`: clean cherry-picks; 66/66 focused tests passed.
- `984 -> 983`: clean cherry-picks; 66/66 focused tests passed.
- Both orders produced identical Git tree `609478921e5b04e2b1844001bfe81ca713f4f099`, with 6 files changed, 560 insertions, and 25 deletions.
- `git diff --check 16f01b29508632ab3a904087191e39b20968ab68..HEAD` passed in both worktrees.
- Both orders produced `{ "config": { "change": false, "keys": [] }, "data": { "change": false, "surfaces": [] } }` over the live 118-file payload.
- The same suite passed count-mismatch, duplicate-filename, snapshot-drift, fetch-exception, and over-3,000-file cases, which preserve the conservative `unknown-truncated-pull-files` fallback.
- Prompt, ledger, and content-digest tests confirmed the complete sidecar remains outside model context and cache identity.

Commands used direct `tsc` plus `node --test test/context.test.ts test/pr-surface-policy.test.ts test/review-prompt-context.test.ts`; no dependency reconciliation occurred in the proof worktrees.

## Maintainer Decision - July 31, 2026

Approved: accept the bounded pagination cost. For a truncated OpenClaw pull request at GitHub's 3,000-file ceiling, the complete classifier path performs at most 30 file-list page reads plus one refreshed pull snapshot. Already-read bounded-context pages are reused, non-OpenClaw targets do not enter this path, and totals above 3,000 or any count, uniqueness, fetch, or source-snapshot mismatch fail closed to the existing unknown-truncated marker. This trade is acceptable for deterministic config and stored-data classification.