### PR TITLE
fix: isolate repair command mocks on Windows

### DIFF
--- a/scripts/dispatch-issue-implementation-candidates.mjs
+++ b/scripts/dispatch-issue-implementation-candidates.mjs
@@ -118,13 +118,35 @@ function parseArgs(argv) {
 }
 
 function run(command, args) {
-  const result = spawnSync(command, args, { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 });
+  const invocation = resolveCommand(command, args);
+  const result = spawnSync(invocation.command, invocation.args, {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
   if (result.error) fail(`${command} failed: ${result.error.message}`);
   if (result.status !== 0) {
     if (result.stderr) process.stderr.write(result.stderr);
     fail(`${command} exited ${result.status ?? "without a status"}`);
   }
   return result.stdout.trim();
+}
+
+function resolveCommand(command, args) {
+  const key = command.replace(/[^A-Za-z0-9]/g, "_").toUpperCase();
+  const configured = process.env[`${key}_BIN`]?.trim();
+  if (!configured) return { command, args };
+  const configuredArgs = process.env[`${key}_BIN_ARGS`];
+  if (!configuredArgs) return { command: configured, args };
+  let parsed;
+  try {
+    parsed = JSON.parse(configuredArgs);
+  } catch {
+    fail(`${key}_BIN_ARGS must be a JSON array`);
+  }
+  if (!Array.isArray(parsed) || parsed.some((value) => typeof value !== "string")) {
+    fail(`${key}_BIN_ARGS must be a JSON array`);
+  }
+  return { command: configured, args: [...parsed, ...args] };
 }
 
 function fail(message) {

--- a/src/repair/cluster-intake-dispatch.ts
+++ b/src/repair/cluster-intake-dispatch.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 
+import { resolveSpawnCommand } from "../command.js";
 import type { LooseRecord } from "./json-types.js";
 import {
   dispatchClaimDecision,
@@ -278,7 +279,7 @@ function dispatchClusterLedger(
       model: job.model,
       jobAuth: jobAuthentication,
     });
-    const result = spawnSync(
+    const invocation = resolveSpawnCommand(
       "gh",
       [
         "workflow",
@@ -290,8 +291,15 @@ function dispatchClusterLedger(
         env.CLAWSWEEPER_DISPATCH_REF || "main",
         ...Object.entries(dispatchInputs).flatMap(([key, value]) => ["-f", `${key}=${value}`]),
       ],
-      { cwd: root, encoding: "utf8", env, stdio: "pipe" },
+      { cwd: root, env },
     );
+    const result = spawnSync(invocation.command, invocation.args, {
+      cwd: root,
+      encoding: "utf8",
+      env,
+      stdio: "pipe",
+      ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+    });
     if (result.status !== 0) {
       throw new Error(
         `cluster intake dispatch failed for ${ledger.target_repo} cluster ${job.cluster_id}: ${result.stderr || result.stdout || result.status}`,

--- a/test/repair/cluster-intake-state.test.ts
+++ b/test/repair/cluster-intake-state.test.ts
@@ -31,6 +31,53 @@ import { restoreClusterIntakeJob } from "../../dist/repair/restore-cluster-intak
 const dispatchSecret = "cluster-dispatch-test-secret";
 const receiptSecret = "cluster-accepted-intent-test-secret";
 
+function mockGhBinEnv(bin: string): NodeJS.ProcessEnv {
+  return {
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([path.join(bin, "gh.mjs")]),
+  };
+}
+
+function writeGhMock(bin: string, source: string) {
+  fs.writeFileSync(path.join(bin, "gh.mjs"), source, { mode: 0o755 });
+}
+
+function ghExit(status: number) {
+  return `process.exit(${status});\n`;
+}
+
+function ghCallLog(calls: string) {
+  return [
+    'import { appendFileSync } from "node:fs";',
+    `appendFileSync(${JSON.stringify(calls)}, process.argv.slice(2).join(" ") + "\\n");`,
+  ].join("\n");
+}
+
+function ghEvent(events: string, event: string) {
+  return [
+    'import { appendFileSync } from "node:fs";',
+    `appendFileSync(${JSON.stringify(events)}, ${JSON.stringify(`${event}\n`)});`,
+  ].join("\n");
+}
+
+function ghFailsOnCall(counter: string, calls: string, failedCall: number) {
+  return [
+    'import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";',
+    `const counter = ${JSON.stringify(counter)};`,
+    'const count = (existsSync(counter) ? Number(readFileSync(counter, "utf8")) : 0) + 1;',
+    "writeFileSync(counter, `${count}\\n`);",
+    `appendFileSync(${JSON.stringify(calls)}, process.argv.slice(2).join(" ") + "\\n");`,
+    `process.exit(count === ${failedCall} ? 1 : 0);`,
+  ].join("\n");
+}
+
+function ghObservation(runs: string, jobs: string) {
+  return [
+    "const args = process.argv.slice(2);",
+    `process.stdout.write(args.includes("list") ? ${JSON.stringify(`${runs}\n`)} : ${JSON.stringify(`${jobs}\n`)});`,
+  ].join("\n");
+}
+
 function receiptProposal() {
   const content = `---
 repo: openclaw/openclaw
@@ -486,11 +533,11 @@ test("dispatch recovery retries pending intent and completed dispatch is idempot
   fs.mkdirSync(bin, { recursive: true });
   const value = intent();
   const ledgerPath = writeDurableIntents(root, [value]);
-  const gh = path.join(bin, "gh");
-  fs.writeFileSync(gh, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  const gh = path.join(bin, "gh.mjs");
+  fs.writeFileSync(gh, ghExit(1), { mode: 0o755 });
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const capacity = () => ({ active: 0, max_live_workers: 2 });
@@ -506,7 +553,7 @@ test("dispatch recovery retries pending intent and completed dispatch is idempot
   );
 
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(gh, `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, { mode: 0o755 });
+  fs.writeFileSync(gh, ghCallLog(calls), { mode: 0o755 });
   assert.deepEqual(
     dispatchClusterIntakes([value], root, env, capacity, () => ({
       action: "dispatch",
@@ -575,12 +622,10 @@ test("cluster dispatch persists an available subset and recovers the remainder",
   const second = intent(43, "b".repeat(64));
   const ledgerPath = writeDurableIntents(root, [first, second]);
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghCallLog(calls));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const partial = dispatchClusterIntakes([first, second], root, env, () => ({
@@ -633,12 +678,10 @@ test("simultaneous conflicting snapshots dispatch the ledger-accepted job once",
   const conflicting = resignIntent(conflictingDraft);
   writeDurableIntents(root, [accepted, conflicting]);
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghCallLog(calls));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   dispatchClusterIntakes([accepted, conflicting], root, env, () => ({
@@ -672,12 +715,10 @@ test("a capacity-blocked intake recovers from its durable ledger without the que
   );
 
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghCallLog(calls));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   assert.deepEqual(
@@ -714,12 +755,10 @@ test("failed or invisible worker claims retry without terminalizing durable inte
   const value = intent();
   const ledgerPath = writeDurableIntents(root, [value]);
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghCallLog(calls));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const capacity = () => ({ active: 0, max_live_workers: 2 });
@@ -752,12 +791,10 @@ test("recovery rediscovers a successful worker when the claim publication was lo
   const ledgerPath = writeDurableIntents(root, [value]);
   const durablePending = fs.readFileSync(path.join(ledgerPath, "openclaw-openclaw.json"), "utf8");
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghCallLog(calls));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   dispatchClusterIntakes([value], root, env, () => ({ active: 0, max_live_workers: 2 }));
@@ -792,12 +829,10 @@ test("the durable claim is published before the workflow dispatch side effect", 
   const value = intent();
   writeDurableIntents(root, [value]);
   const events = path.join(root, "events.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf 'dispatch\\n' >> '${events}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghEvent(events, "dispatch"));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const persistedStatuses: string[] = [];
@@ -824,13 +859,13 @@ test("a crash between claim publication and dispatch redispatches exactly one wo
   fs.mkdirSync(bin, { recursive: true });
   const value = intent();
   const ledgerPath = writeDurableIntents(root, [value]);
-  const gh = path.join(bin, "gh");
+  const gh = path.join(bin, "gh.mjs");
   // The dispatch side effect never happens, exactly like a runner crash right
   // after the durable claim publication.
-  fs.writeFileSync(gh, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  fs.writeFileSync(gh, ghExit(1), { mode: 0o755 });
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const capacity = () => ({ active: 0, max_live_workers: 2 });
@@ -858,7 +893,7 @@ test("a crash between claim publication and dispatch redispatches exactly one wo
   );
 
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(gh, `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, { mode: 0o755 });
+  fs.writeFileSync(gh, ghCallLog(calls), { mode: 0o755 });
   const recovered = recoverPendingClusterIntakes(root, env, capacity, () => ({
     action: "dispatch",
     run: null,
@@ -888,9 +923,7 @@ test("recovery refuses git state without a verifiable accepted-intent receipt", 
   const value = intent();
   const ledgerPath = writeDurableIntents(root, [value]);
   const calls = path.join(root, "calls.txt");
-  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\n`, {
-    mode: 0o755,
-  });
+  writeGhMock(bin, ghCallLog(calls));
   const capacity = () => ({ active: 0, max_live_workers: 2 });
   const observer = () => ({ action: "dispatch" as const, run: null });
 
@@ -899,7 +932,7 @@ test("recovery refuses git state without a verifiable accepted-intent receipt", 
   // before any dispatch instead of blessing it with a fresh signature.
   const wrongSecretEnv = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: "not-the-accepting-secret",
   };
   assert.throws(
@@ -916,7 +949,7 @@ test("recovery refuses git state without a verifiable accepted-intent receipt", 
   // instead of becoming dispatch authority.
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const ledgerFile = path.join(ledgerPath, "openclaw-openclaw.json");
@@ -939,14 +972,10 @@ test("a later batch dispatch failure does not hide the earlier successful worker
   const ledgerPath = writeDurableIntents(root, [first, second]);
   const calls = path.join(root, "calls.txt");
   const counter = path.join(root, "counter.txt");
-  fs.writeFileSync(
-    path.join(bin, "gh"),
-    `#!/bin/sh\ncount=0\nif test -f '${counter}'; then count="$(cat '${counter}')"; fi\ncount=$((count + 1))\nprintf '%s\\n' "$count" > '${counter}'\nprintf '%s\\n' "$*" >> '${calls}'\nif test "$count" -eq 2; then exit 1; fi\n`,
-    { mode: 0o755 },
-  );
+  writeGhMock(bin, ghFailsOnCall(counter, calls, 2));
   const env = {
     ...process.env,
-    PATH: `${bin}:${process.env.PATH}`,
+    ...mockGhBinEnv(bin),
     CLAWSWEEPER_WEBHOOK_SECRET: receiptSecret,
   };
   const capacity = () => ({ active: 0, max_live_workers: 2 });
@@ -1006,13 +1035,9 @@ test("dispatch observation terminalizes only a successful planning worker", () =
       { name: "Plan and review cluster", conclusion: "success" },
     ],
   });
-  const gh = path.join(bin, "gh");
-  fs.writeFileSync(
-    gh,
-    `#!/bin/sh\ncase "$*" in\n  *"run list"*) printf '%s\\n' '${runs}' ;;\n  *) printf '%s\\n' '${successfulJobs}' ;;\nesac\n`,
-    { mode: 0o755 },
-  );
-  const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+  const gh = path.join(bin, "gh.mjs");
+  fs.writeFileSync(gh, ghObservation(runs, successfulJobs), { mode: 0o755 });
+  const env = { ...process.env, ...mockGhBinEnv(bin) };
   assert.deepEqual(observeClusterDispatch(entry, env), {
     action: "recover",
     run: { ...JSON.parse(runs)[0], dispatch_execution_verified: true },
@@ -1024,11 +1049,7 @@ test("dispatch observation terminalizes only a successful planning worker", () =
       conclusion: "failure",
     },
   ]);
-  fs.writeFileSync(
-    gh,
-    `#!/bin/sh\ncase "$*" in\n  *"run list"*) printf '%s\\n' '${mixedResultRuns}' ;;\n  *) printf '%s\\n' '${successfulJobs}' ;;\nesac\n`,
-    { mode: 0o755 },
-  );
+  fs.writeFileSync(gh, ghObservation(mixedResultRuns, successfulJobs), { mode: 0o755 });
   assert.deepEqual(observeClusterDispatch(entry, env), {
     action: "recover",
     run: { ...JSON.parse(mixedResultRuns)[0], dispatch_execution_verified: true },
@@ -1040,11 +1061,7 @@ test("dispatch observation terminalizes only a successful planning worker", () =
       { name: "Plan and review cluster", conclusion: "skipped" },
     ],
   });
-  fs.writeFileSync(
-    gh,
-    `#!/bin/sh\ncase "$*" in\n  *"run list"*) printf '%s\\n' '${runs}' ;;\n  *) printf '%s\\n' '${receiptOnlyJobs}' ;;\nesac\n`,
-    { mode: 0o755 },
-  );
+  fs.writeFileSync(gh, ghObservation(runs, receiptOnlyJobs), { mode: 0o755 });
   assert.deepEqual(observeClusterDispatch(entry, env), { action: "wait", run: null });
 });
 
@@ -1075,7 +1092,11 @@ test("worker restores only an authenticated semantically valid durable job", () 
   restoreClusterIntakeJob(options);
   const restored = path.join(root, job.path);
   assert.equal(fs.readFileSync(restored, "utf8"), job.content);
-  assert.equal(fs.statSync(restored).mode & 0o777, 0o600);
+  // Windows does not expose the POSIX mode requested by openSync, but Linux
+  // workers must keep restored intake jobs private.
+  if (process.platform !== "win32") {
+    assert.equal(fs.statSync(restored).mode & 0o777, 0o600);
+  }
 
   // CLAWSWEEPER_ALLOWED_OWNER is a comma/whitespace-separated owner list in
   // production (e.g. "openclaw,steipete"); membership must be honored.

--- a/test/repair/execute-fix-publication.test.ts
+++ b/test/repair/execute-fix-publication.test.ts
@@ -33,15 +33,31 @@ test("execute-fix CLI defers outcome publication until fresh-token invocation", 
       actions: [],
     })}\n`,
   );
-  const ghPath = path.join(binDir, "gh");
+  const ghPath = path.join(binDir, "gh.mjs");
   fs.writeFileSync(
     ghPath,
-    `#!/bin/sh\nset -eu\ncase "$*" in\n  *"issues/494/comments?per_page=100"*) printf '[]\\n' ;;\n  "pr view 494 "*) printf '{"state":"CLOSED","headRefOid":"%s","statusCheckRollup":[]}\\n' "${"a".repeat(40)}" ;;\n  *"issues/494/comments --method POST"*) printf '%s\\n' "\${GH_TOKEN:-}" >> "$TOKEN_LOG" ;;\n  *) printf 'unexpected gh args: %s\\n' "$*" >&2; exit 1 ;;\nesac\n`,
+    [
+      "#!/usr/bin/env node",
+      'import { appendFileSync } from "node:fs";',
+      "const args = process.argv.slice(2);",
+      'const rendered = args.join(" ");',
+      'if (rendered.includes("issues/494/comments?per_page=100")) {',
+      '  process.stdout.write("[]\\n");',
+      '} else if (args[0] === "pr" && args[1] === "view" && args[2] === "494") {',
+      `  process.stdout.write(${JSON.stringify(`{"state":"CLOSED","headRefOid":"${"a".repeat(40)}","statusCheckRollup":[]}\n`)});`,
+      '} else if (rendered.includes("issues/494/comments") && args.includes("POST")) {',
+      '  appendFileSync(process.env.TOKEN_LOG, `${process.env.GH_TOKEN ?? ""}\\n`);',
+      "} else {",
+      "  process.stderr.write(`unexpected gh args: ${rendered}\\n`);",
+      "  process.exit(1);",
+      "}",
+    ].join("\n"),
     { mode: 0o755 },
   );
   const baseEnv = {
     ...process.env,
-    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([ghPath]),
     CLAWSWEEPER_ALLOW_EXECUTE: "1",
     CLAWSWEEPER_ALLOWED_OWNER: "openclaw",
     CLAWSWEEPER_MODEL: "fixture-model",

--- a/test/repair/issue-implementation-dispatch.test.ts
+++ b/test/repair/issue-implementation-dispatch.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -13,23 +13,37 @@ test("automatic issue dispatcher filters exact issues and preserves bounded back
     const bin = join(root, "bin");
     const log = join(root, "dispatch.log");
     mkdirSync(bin);
-    writeExecutable(
-      join(bin, "pnpm"),
-      `#!/bin/sh
-if [ "$3" = "workflow" ]; then printf '2\\n'; exit 0; fi
-printf '%s\\n' '{"candidates":[{"item_number":41,"report_path":"records/openclaw-openclaw/items/41.md","report_url":"https://example.test/41"},{"item_number":42,"report_path":"records/openclaw-openclaw/items/42.md","report_url":"https://example.test/42"},{"item_number":43,"report_path":"records/openclaw-openclaw/items/43.md","report_url":"https://example.test/43"}]}'
-`,
+    const pnpm = join(bin, "pnpm.mjs");
+    const gh = join(bin, "gh.mjs");
+    writeFileSync(
+      pnpm,
+      [
+        "const args = process.argv.slice(2);",
+        'if (args[2] === "workflow") {',
+        '  process.stdout.write("2\\n");',
+        "  process.exit(0);",
+        "}",
+        "process.stdout.write(JSON.stringify({ candidates: [",
+        '  { item_number: 41, report_path: "records/openclaw-openclaw/items/41.md", report_url: "https://example.test/41" },',
+        '  { item_number: 42, report_path: "records/openclaw-openclaw/items/42.md", report_url: "https://example.test/42" },',
+        '  { item_number: 43, report_path: "records/openclaw-openclaw/items/43.md", report_url: "https://example.test/43" },',
+        '] }) + "\\n");',
+      ].join("\n"),
     );
-    writeExecutable(
-      join(bin, "gh"),
-      `#!/bin/sh
-printf '%s\\n' "$*" >> "$DISPATCH_LOG"
-if [ "$FAIL_GH" = "1" ]; then exit 9; fi
-`,
+    writeFileSync(
+      gh,
+      [
+        'import { appendFileSync } from "node:fs";',
+        'appendFileSync(process.env.DISPATCH_LOG, process.argv.slice(2).join(" ") + "\\n");',
+        'process.exit(process.env.FAIL_GH === "1" ? 9 : 0);',
+      ].join("\n"),
     );
     const env = {
       ...process.env,
-      PATH: `${bin}:${process.env.PATH}`,
+      GH_BIN: process.execPath,
+      GH_BIN_ARGS: JSON.stringify([gh]),
+      PNPM_BIN: process.execPath,
+      PNPM_BIN_ARGS: JSON.stringify([pnpm]),
       DISPATCH_LOG: log,
       GITHUB_REPOSITORY: "openclaw/clawsweeper",
     };
@@ -95,8 +109,3 @@ test("automatic issue dispatcher rejects unsafe repositories and unbounded limit
     assert.match(result.stderr, /\[issue-implementation-dispatch\]/);
   }
 });
-
-function writeExecutable(path: string, content: string) {
-  writeFileSync(path, content, "utf8");
-  chmodSync(path, 0o755);
-}

--- a/test/repair/run-worker.test.ts
+++ b/test/repair/run-worker.test.ts
@@ -44,8 +44,9 @@ test("run-worker starts Codex in the target checkout when one is available", () 
   fs.mkdirSync(fakeBin, { recursive: true });
   fs.mkdirSync(targetCheckout, { recursive: true });
   fs.writeFileSync(path.join(targetCheckout, "target-marker.txt"), "target\n");
+  const ghPath = path.join(fakeBin, "gh.mjs");
   fs.writeFileSync(
-    path.join(fakeBin, "gh"),
+    ghPath,
     [
       "#!/usr/bin/env node",
       "const args = process.argv.slice(2);",
@@ -125,7 +126,9 @@ test("run-worker starts Codex in the target checkout when one is available", () 
         CLAWSWEEPER_CODEX_STDIO_MAX_BUFFER_MB: "1",
         CLAWSWEEPER_CODEX_PLANNER_SANDBOX: "danger-full-access",
         CLAWSWEEPER_STEERABLE_CODEX: "0",
-        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        CODEX_BIN: path.join(fakeBin, "codex"),
+        GH_BIN: process.execPath,
+        GH_BIN_ARGS: JSON.stringify([ghPath]),
       },
       stdio: "pipe",
     });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -10,7 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
 import YAML from "yaml";
 
@@ -494,7 +494,7 @@ esac
           GH_TOKEN: "test-token",
           GITHUB_OUTPUT: outputPath,
           ITEM_NUMBER: "42",
-          PATH: `${fakeBin}:${process.env.PATH}`,
+          PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}`,
           TARGET_REPO: "openclaw/openclaw",
         },
       });


### PR DESCRIPTION
## Summary

Fix Windows test fixtures that could fall through to the authenticated `gh` or `codex` executables instead of their fakes. The reported cluster-intake test used colon-separated `PATH` entries and POSIX shell stubs; on Windows this selected the real `gh.exe`, which could create real repair-worker runs and notification email.

- Route the cluster workflow dispatch and issue-implementation dispatcher through the repository's `*_BIN` override convention.
- Replace the mutation-capable test stubs with explicit Node command fixtures (`GH_BIN`, `PNPM_BIN`, and `CODEX_BIN`).
- Correct the remaining test-only `PATH` delimiter and preserve its hosted-Bash execution boundary.
- Keep the POSIX-private-file assertion on POSIX systems while avoiding an invalid Windows mode assertion.

## Scope audit

The original hard-coded `:` PATH pattern occurred in three fixtures: cluster intake, issue implementation dispatch, and the sweep workflow fixture. The audit also found two already-delimited fixtures that could still select real Windows command executables: the outcome-publication `gh` fixture and the repair-worker `gh`/`codex` fixture. All five now use explicit command injection where the command is executed.

The sweep and dispatch-receipt Bash fixtures remain Linux-hosted workflow tests. This PR does not port workflow helpers or expand the CI platform matrix.

## Validation

- `pnpm run build:repair`
- `GH_TOKEN=invalid-test-token node --test --test-concurrency=1 test/repair/cluster-intake-state.test.ts test/repair/issue-implementation-dispatch.test.ts test/repair/execute-fix-publication.test.ts test/repair/run-worker.test.ts` — 35/35 passed.
- `pnpm exec oxfmt --check scripts/dispatch-issue-implementation-candidates.mjs src/repair/cluster-intake-dispatch.ts test/repair/cluster-intake-state.test.ts test/repair/execute-fix-publication.test.ts test/repair/issue-implementation-dispatch.test.ts test/repair/run-worker.test.ts test/sweep-workflow.test.ts`
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- Linux workflow-fixture proof: Crabbox local-container `cbx_f9227e40ef50` ran the focused `exact event branch guard resolves empty and numeric claims to the repository default` scenario after installing its missing disposable `jq` dependency; 1/1 passed. The one-shot lease was automatically released.

`pnpm run format:check` remains a Windows-checkout baseline failure because it reports CRLF formatting differences across all 525 matched files; the seven touched files pass the focused formatter check above.

## Real Behavior Proof

- Claim: repair test fixtures cannot accidentally invoke the logged-in GitHub or Codex commands on Windows, so fixture jobs such as `gitcrawl-42/43-telegram-upload.md` stay local and cannot dispatch real repair workers.
- Surface: the real compiled cluster intake dispatcher, issue implementation dispatcher, outcome-publication CLI, and repair worker CLI.
- Scenario / fixture: run cluster dispatch/recovery for synthetic clusters 42 and 43, issue candidate dispatch, outcome publication, and repair-worker planning with explicit Node fake binaries and `GH_TOKEN=invalid-test-token`.
- Command / environment: after `pnpm run build:repair`, Windows PowerShell ran `node C:\clawsweeper-work\notes\csw-083-windows-proof.mjs C:\clawsweeper-work\worktrees\csw-083-portable-test-mocks`. The proof used the compiled dispatcher, valid signed intake records, `GH_BIN=node.exe`, a temporary Node fake supplied by `GH_BIN_ARGS`, and `GH_TOKEN=invalid-test-token`.
- Observed result: the focused suite remains 35/35 passed. In the direct Windows proof, the real `C:\Program Files\GitHub CLI\gh.exe` was present on `PATH`, but the compiled dispatcher selected the injected Node fake twice—once for cluster 42 and once for 43. Each fake trace recorded the expected job and dispatch key; `job_auth` was redacted. The fake exits locally, so neither call reached GitHub.
- Artifact / trace: commit `9a91e1021c`; direct terminal transcript from this Windows host:

  ```text
  platform=win32
  configured GH_BIN=C:\Program Files\nodejs\node.exe
  real gh on PATH=C:\Program Files\GitHub CLI\gh.exe
  dispatcher result={"updatedLedgers":["results/cluster-repair-intake/openclaw-openclaw.json"],"pending":true}
  fake invocation count=2
  fake selected=injected-node-gh-fake; exec=C:\Program Files\nodejs\node.exe; job=job=jobs/openclaw/inbox/gitcrawl-42-telegram-upload.md; dispatch_key=dispatch_key=cluster-intake:openclaw-openclaw:42; job_auth=<redacted>
  fake selected=injected-node-gh-fake; exec=C:\Program Files\nodejs\node.exe; job=job=jobs/openclaw/inbox/gitcrawl-43-telegram-upload.md; dispatch_key=dispatch_key=cluster-intake:openclaw-openclaw:43; job_auth=<redacted>
  network result=no GitHub CLI selected; both workflow-run calls terminated in the injected local Node fake
  ```

  Linux hosted-Bash counterpart passed in Crabbox local-container lease `cbx_f9227e40ef50`.
- Limits: the controlled intake records run the complete validation, signed-intent, durable-ledger, and real compiled-dispatch path, but intentionally replace the final GitHub CLI process. No live GitHub dispatch was performed. The full hosted-Bash test file has unrelated Windows-checkout CRLF/helper-tool baseline failures; its relevant Bash scenario was instead run in Linux. No claim is made that the hosted workflow itself is native-Windows software.

## Codex review

- `codex review --uncommitted` — clean; no accepted/actionable findings.
- `codex review --base origin/main` — clean; no actionable defects identified.
