### PR TITLE
fix(review): keep changelog policy target-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Review guidance now limits OpenClaw's release-owned changelog rule to `openclaw/openclaw`, preventing false removal findings against ClawSweeper and other repositories.
 - Event-review artifact publication completes as a superseded no-op when the reviewed branch vanished upstream (force-push or deletion) instead of failing the run.
 - Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.
 - Exact reviews of items that closed after enqueue now complete as superseded no-ops, and GitHub-throttled reservations defer as held retries — neither spends the item's review-failure budget.

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -679,14 +679,18 @@ Keep open any item whose GitHub author association is `OWNER`, `MEMBER`, or `COL
 
 Keep open any item with a protected label: `security`, `beta-blocker`, `release-blocker`, or `maintainer`. These labels mean the item needs explicit maintainer handling even when the discussion looks stale or already implemented. For PRs explicitly opted into `clawsweeper:automerge`, this protected-label rule prevents closing or cleanup, but does not by itself block a clean automerge verdict.
 
-For OpenClaw PR release-note review, `CHANGELOG.md` is release-owned. Normal
-PRs, repair workers, and automerge/autofix lanes should not edit it. Do not
-make missing `CHANGELOG.md` a review finding, merge blocker, work item, or
-next-step blocker. If release-note context is needed, ask for PR-body or commit
-message context: user-visible behavior, affected surface, issue/PR refs, and
-credited human author/reporter when known. Never request `Thanks @steipete`,
-`Thanks @openclaw`, `Thanks @clawsweeper`, or other forbidden bot/maintainer
-changelog attributions.
+Only when the target repository is exactly `openclaw/openclaw`,
+`CHANGELOG.md` is release-owned. Normal PRs, repair workers, and
+automerge/autofix lanes should not edit it. Do not make missing
+`CHANGELOG.md` a review finding, merge blocker, work item, or next-step
+blocker. This rule does not apply to `openclaw/clawsweeper` or any other
+repository; follow that target repository's release-note policy and do not
+infer that its changelog entry should be removed. If OpenClaw release-note
+context is needed, ask for PR-body or commit message context: user-visible
+behavior, affected surface, issue/PR refs, and credited human author/reporter
+when known. Never request `Thanks @steipete`, `Thanks @openclaw`,
+`Thanks @clawsweeper`, or other forbidden bot/maintainer changelog
+attributions.
 
 When citing docs in the close comment, link the public `docs.openclaw.ai` page rather than the internal `docs/*.md` GitHub file whenever a public page exists. The docs site publishes the same content and is the user-facing target. Keep `file`, `line`, and `sha` populated in the structured `evidence` object for auditability, but the prose/comment should prefer links like `https://docs.openclaw.ai/plugins/building-plugins` over `https://github.com/openclaw/openclaw/blob/.../docs/plugins/building-plugins.md`.
 

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2544,8 +2544,13 @@ test("review prompt keeps automerge opt-in from becoming generic manual review",
   assert.match(prompt, /`maintainer` label/);
   assert.match(prompt, /large `size:\*` label/);
   assert.match(prompt, /choose `queue_fix_pr` even when the\s+finding is process-only or P3/);
-  assert.match(prompt, /`CHANGELOG\.md` is release-owned/);
-  assert.match(prompt, /Do not\s+make missing `CHANGELOG\.md` a review finding/i);
+  assert.match(
+    prompt,
+    /Only when the target repository is exactly `openclaw\/openclaw`,\s+`CHANGELOG\.md` is release-owned/,
+  );
+  assert.match(prompt, /Do not\s+make missing\s+`CHANGELOG\.md` a review finding/i);
+  assert.match(prompt, /does not apply to `openclaw\/clawsweeper` or any other\s+repository/);
+  assert.match(prompt, /do not\s+infer that its changelog entry should be removed/);
   assert.match(prompt, /ask for PR-body or commit\s+message context/);
   assert.doesNotMatch(prompt, /missing required changelog\s+entry/);
   assert.match(prompt, /does not by itself block a clean automerge verdict/);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawSweeper could apply OpenClaw's release-owned changelog rule to ClawSweeper or another target repository and incorrectly request removal of a valid release-note entry.

## Why This Change Was Made

The review prompt now limits release-owned `CHANGELOG.md` handling to the exact `openclaw/openclaw` target and explicitly requires every other repository's own release-note policy to win. Focused prompt assertions preserve that boundary.

## User Impact

Maintainers no longer receive false changelog-removal findings when reviewing ClawSweeper or another repository that intentionally tracks changes in its own changelog.

## Evidence

- `./node_modules/.bin/tsc -p tsconfig.json`: passed.
- `node --test test/clawsweeper.test.ts`: 76/76 passed.
- `git diff --check`: clean.
- Uncommitted autoreview: clean, 0.98 confidence.
- Committed branch autoreview against `origin/main`: clean, 0.97 confidence.

## Real Behavior Proof

- **Claim:** the review prompt cannot describe a non-OpenClaw target changelog as release-owned based on the OpenClaw-only rule.
- **Exercised surface:** the exact review prompt consumed by ClawSweeper review workers.
- **Scenario:** inspect the rendered prompt contract and assert the exact `openclaw/openclaw` scope, explicit `openclaw/clawsweeper` exclusion, and prohibition on inferred changelog-removal findings.
- **Observed result:** all 76 focused prompt and workflow assertions pass, including the new repository boundary.
- **Limits:** this is a prompt-policy regression test; production review output changes after the prompt ships.

## Finding Disposition

- PR 981's repeated request to remove ClawSweeper's own changelog entry is rejected as a target-policy leak. `AGENTS.md` limits release ownership to the OpenClaw target, while `CONTRIBUTING.md` says other repositories follow their own release-note policy. This PR encodes that distinction directly in the worker prompt.