### PR TITLE
fix: preserve partial-clone base validation during repairs

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -69,6 +69,8 @@ export type TargetValidationOptions = {
   setupTimeoutMs?: number;
   validationTimeoutMs?: number;
   pinnedBaseRef?: string;
+  /** Trusted upstream override for deterministic local integration fixtures. */
+  pinnedBaseRemoteUrl?: string;
   /**
    * Optional override of the per-repo toolchain (package manager, base validation
    * commands, changed gate). If omitted, it is resolved from
@@ -231,8 +233,86 @@ export function reproduceValidationFailureAtPinnedBase({
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-base-validation-"));
   const checkout = path.join(root, "target");
   try {
-    run("git", ["clone", "--shared", "--no-checkout", targetDir, checkout]);
-    run("git", ["checkout", "--detach", options.pinnedBaseRef], { cwd: checkout });
+    try {
+      const pinnedBaseSha = run(
+        "git",
+        ["rev-parse", "--verify", `${options.pinnedBaseRef}^{commit}`],
+        {
+          cwd: targetDir,
+        },
+      ).trim();
+      const sourceGitDir = path.resolve(
+        targetDir,
+        run("git", ["rev-parse", "--git-common-dir"], { cwd: targetDir }).trim(),
+      );
+      const sourceObjectDir = fs.realpathSync(path.join(sourceGitDir, "objects"));
+      if (/[\r\n]/.test(sourceObjectDir)) return null;
+      const sourceObjectFormat = run("git", ["rev-parse", "--show-object-format"], {
+        cwd: targetDir,
+      }).trim();
+      if (sourceObjectFormat !== "sha1" && sourceObjectFormat !== "sha256") return null;
+      let sourceBaseSha = pinnedBaseSha;
+      try {
+        sourceBaseSha = run("git", ["rev-parse", "--verify", `refs/heads/${baseBranch}^{commit}`], {
+          cwd: targetDir,
+        }).trim();
+      } catch {
+        // Detached-only source checkouts have no local default branch to mirror.
+      }
+      if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(options.targetRepo)) return null;
+      const remoteUrl =
+        options.pinnedBaseRemoteUrl ?? `https://github.com/${options.targetRepo}.git`;
+
+      run("git", ["init", "--quiet", `--object-format=${sourceObjectFormat}`, checkout]);
+      const checkoutGitDir = path.join(checkout, ".git");
+      fs.mkdirSync(path.join(checkoutGitDir, "objects", "info"), { recursive: true });
+      fs.writeFileSync(
+        path.join(checkoutGitDir, "objects", "info", "alternates"),
+        `${sourceObjectDir}\n`,
+      );
+      const sourceShallowPath = path.join(sourceGitDir, "shallow");
+      if (fs.existsSync(sourceShallowPath)) {
+        fs.copyFileSync(sourceShallowPath, path.join(checkoutGitDir, "shallow"));
+      }
+      run("git", ["remote", "add", "origin", remoteUrl], { cwd: checkout });
+      let partialCloneFilter = "";
+      try {
+        const promisor = run(
+          "git",
+          ["config", "--local", "--no-includes", "--get", "remote.origin.promisor"],
+          { cwd: targetDir },
+        ).trim();
+        if (/^(?:1|on|true|yes)$/i.test(promisor)) {
+          partialCloneFilter = run(
+            "git",
+            ["config", "--local", "--no-includes", "--get", "remote.origin.partialclonefilter"],
+            { cwd: targetDir },
+          ).trim();
+        }
+      } catch {
+        // Ordinary non-promisor checkouts do not need lazy object hydration.
+      }
+      if (partialCloneFilter) {
+        if (!/^[A-Za-z0-9][A-Za-z0-9%:+=._/@{}^~,-]*$/.test(partialCloneFilter)) return null;
+        run("git", ["config", "--local", "remote.origin.promisor", "true"], { cwd: checkout });
+        run("git", ["config", "--local", "remote.origin.partialclonefilter", partialCloneFilter], {
+          cwd: checkout,
+        });
+      }
+      run("git", ["update-ref", `refs/remotes/origin/${baseBranch}`, sourceBaseSha], {
+        cwd: checkout,
+      });
+      run("git", ["checkout", "--quiet", "--detach", pinnedBaseSha], {
+        cwd: checkout,
+        timeoutMs: targetValidationTimeoutMs(
+          "CLAWSWEEPER_TARGET_SETUP_TIMEOUT_MS",
+          options.setupTimeoutMs ?? DEFAULT_TARGET_SETUP_TIMEOUT_MS,
+          options.setupTimeoutMs,
+        ),
+      });
+    } catch {
+      return null;
+    }
     try {
       prepareTargetToolchain(checkout, options);
     } catch {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 import {
   assertTargetCheckoutBinding,
@@ -2025,6 +2026,234 @@ test("pinned-base validation reproduction proves the same base failure", () => {
   });
 
   assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+});
+
+test("pinned-base reproduction avoids fetching unrelated missing partial-clone history", () => {
+  const source = gitPackageFixture({ "check:changed": "node check.js" });
+  fs.mkdirSync(path.join(source, "src"));
+  fs.writeFileSync(
+    path.join(source, "check.js"),
+    [
+      "const fs = require('node:fs');",
+      "if (!fs.existsSync('.git/shallow')) throw new Error('shallow boundary was not preserved');",
+      "console.error('src/base.ts:1: lint failed');",
+      "process.exit(1);",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(source, "src/base.ts"), "export const base = true;\n");
+  fs.writeFileSync(path.join(source, "historical.txt"), "omitted historical blob\n");
+  git(source, "add", ".");
+  git(source, "commit", "-m", "historical base");
+  const omittedHistoricalBlob = git(source, "rev-parse", "HEAD:historical.txt");
+  git(source, "rm", "historical.txt");
+  git(source, "commit", "-m", "current base");
+  const pinnedBaseRef = git(source, "rev-parse", "HEAD");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-validation-promisor-"));
+  const remote = path.join(root, "origin.git");
+  const target = path.join(root, "target");
+  git(root, "init", "--bare", remote);
+  git(remote, "config", "uploadpack.allowFilter", "true");
+  git(source, "push", remote, "main:main");
+  git(
+    root,
+    "clone",
+    "--filter=blob:none",
+    "--depth=2",
+    "--branch",
+    "main",
+    pathToFileURL(remote).href,
+    target,
+  );
+  const missingObjects = execFileSync("git", ["rev-list", "--objects", "--missing=print", "HEAD"], {
+    cwd: target,
+    encoding: "utf8",
+    env: { ...process.env, GIT_NO_LAZY_FETCH: "1" },
+  });
+  assert.match(missingObjects, new RegExp(`^\\?${omittedHistoricalBlob}$`, "m"));
+  git(target, "remote", "set-url", "origin", "https://invalid.invalid/offline.git");
+
+  const baseError = reproduceValidationFailureAtPinnedBase({
+    commands: ["pnpm check:changed"],
+    targetDir: target,
+    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+  });
+
+  assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+  assert.match(
+    execFileSync("git", ["rev-list", "--objects", "--missing=print", "HEAD"], {
+      cwd: target,
+      encoding: "utf8",
+      env: { ...process.env, GIT_NO_LAZY_FETCH: "1" },
+    }),
+    new RegExp(`^\\?${omittedHistoricalBlob}$`, "m"),
+  );
+});
+
+test("pinned-base reproduction preserves the source comparison branch for changed gates", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node check.js" });
+  fs.mkdirSync(path.join(cwd, "src"));
+  fs.writeFileSync(
+    path.join(cwd, "check.js"),
+    [
+      "const { execFileSync } = require('node:child_process');",
+      "const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();",
+      "if (git('rev-parse', 'origin/main') === git('rev-parse', 'HEAD')) process.exit(0);",
+      "console.error('src/base.ts:1: lint failed');",
+      "process.exit(1);",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(path.join(cwd, "src/base.ts"), "export const base = 1;\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "local main");
+  const sourceMainSha = git(cwd, "rev-parse", "HEAD");
+  git(cwd, "checkout", "-b", "advanced");
+  fs.writeFileSync(path.join(cwd, "src/base.ts"), "export const base = 2;\n");
+  git(cwd, "commit", "-am", "advanced upstream base");
+  const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
+  git(cwd, "checkout", "main");
+  git(cwd, "update-ref", "refs/remotes/origin/main", pinnedBaseRef);
+  assert.notEqual(sourceMainSha, pinnedBaseRef);
+
+  const baseError = reproduceValidationFailureAtPinnedBase({
+    commands: ["pnpm check:changed"],
+    targetDir: cwd,
+    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+  });
+
+  assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+});
+
+test("pinned-base reproduction hydrates blobs required by the older pinned snapshot", () => {
+  const source = gitPackageFixture({ "check:changed": "node check.js" });
+  fs.mkdirSync(path.join(source, "src"));
+  fs.writeFileSync(
+    path.join(source, "check.js"),
+    "console.error('src/base.ts:1: lint failed'); process.exit(1);\n",
+  );
+  fs.writeFileSync(path.join(source, "src/base.ts"), "export const base = true;\n");
+  fs.writeFileSync(path.join(source, "historical.txt"), "required pinned-base blob\n");
+  git(source, "add", ".");
+  git(source, "commit", "-m", "older pinned base");
+  const pinnedBaseRef = git(source, "rev-parse", "HEAD");
+  const requiredBlob = git(source, "rev-parse", "HEAD:historical.txt");
+  git(source, "rm", "historical.txt");
+  git(source, "commit", "-m", "current checkout");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-validation-pinned-blob-"));
+  const remote = path.join(root, "origin.git");
+  const target = path.join(root, "target");
+  git(root, "init", "--bare", remote);
+  git(remote, "config", "uploadpack.allowFilter", "true");
+  git(remote, "config", "uploadpack.allowAnySHA1InWant", "true");
+  git(source, "push", remote, "main:main");
+  git(
+    root,
+    "clone",
+    "--filter=blob:none",
+    "--depth=2",
+    "--branch",
+    "main",
+    pathToFileURL(remote).href,
+    target,
+  );
+  assert.match(
+    execFileSync("git", ["rev-list", "--objects", "--missing=print", pinnedBaseRef], {
+      cwd: target,
+      encoding: "utf8",
+      env: { ...process.env, GIT_NO_LAZY_FETCH: "1" },
+    }),
+    new RegExp(`^\\?${requiredBlob}$`, "m"),
+  );
+
+  const baseError = reproduceValidationFailureAtPinnedBase({
+    commands: ["pnpm check:changed"],
+    targetDir: target,
+    options: validationOptions("openclaw/openclaw", {
+      pinnedBaseRef,
+      pinnedBaseRemoteUrl: pathToFileURL(remote).href,
+    }),
+  });
+
+  assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+});
+
+test("pinned-base reproduction preserves the source SHA-256 object format", () => {
+  const cwd = packageFixture({ "check:changed": "node check.js" });
+  fs.writeFileSync(path.join(cwd, ".gitignore"), "node_modules/\n");
+  git(cwd, "init", "--object-format=sha256", "-b", "main");
+  git(cwd, "config", "user.email", "clawsweeper@example.invalid");
+  git(cwd, "config", "user.name", "ClawSweeper Test");
+  fs.mkdirSync(path.join(cwd, "src"));
+  fs.writeFileSync(
+    path.join(cwd, "check.js"),
+    "console.error('src/base.ts:1: lint failed'); process.exit(1);\n",
+  );
+  fs.writeFileSync(path.join(cwd, "src/base.ts"), "export const base = true;\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "sha256 base");
+  const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
+  assert.equal(pinnedBaseRef.length, 64);
+
+  const baseError = reproduceValidationFailureAtPinnedBase({
+    commands: ["pnpm check:changed"],
+    targetDir: cwd,
+    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+  });
+
+  assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+});
+
+test("pinned-base reproduction bounds checkout and possible promisor fetches", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node check.js" });
+  fs.writeFileSync(path.join(cwd, "check.js"), "process.exit(1);\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "base");
+  const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
+  const startedAt = Date.now();
+
+  assert.equal(
+    reproduceValidationFailureAtPinnedBase({
+      commands: ["pnpm check:changed"],
+      targetDir: cwd,
+      options: validationOptions("openclaw/openclaw", { pinnedBaseRef, setupTimeoutMs: 1 }),
+    }),
+    null,
+  );
+  assert.ok(Date.now() - startedAt < 2_000);
+});
+
+test("pinned-base reproduction does not inherit target-controlled checkout hooks", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node check.js" });
+  fs.mkdirSync(path.join(cwd, "src"));
+  fs.writeFileSync(
+    path.join(cwd, "check.js"),
+    "console.error('src/base.ts:1: lint failed'); process.exit(1);\n",
+  );
+  fs.writeFileSync(path.join(cwd, "src/base.ts"), "export const base = true;\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "base");
+  const pinnedBaseRef = git(cwd, "rev-parse", "HEAD");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-validation-hooks-"));
+  const hooks = path.join(root, "hooks");
+  const marker = path.join(root, "post-checkout-ran");
+  fs.mkdirSync(hooks);
+  fs.writeFileSync(path.join(hooks, "post-checkout"), `#!/bin/sh\nprintf ran > '${marker}'\n`, {
+    mode: 0o755,
+  });
+  git(cwd, "config", "core.hooksPath", hooks);
+
+  const baseError = reproduceValidationFailureAtPinnedBase({
+    commands: ["pnpm check:changed"],
+    targetDir: cwd,
+    options: validationOptions("openclaw/openclaw", { pinnedBaseRef }),
+  });
+
+  assert.match(String(baseError), /src\/base\.ts:1: lint failed/);
+  assert.equal(fs.existsSync(marker), false);
 });
 
 test("pinned-base reproduction fails closed when dependency inputs changed", () => {


### PR DESCRIPTION
## Summary

- Fix the production OpenClaw issue-repair executor crash when final base validation clones a shallow, blob-filtered target checkout.
- Build the disposable pinned-base checkout directly against the existing Git object store, preserve its shallow boundary and SHA-1/SHA-256 object format, avoid fetching unrelated promised history, and keep target-controlled hooks out of the independent checkout.
- Preserve the source checkout's actual comparison branch so OpenClaw's real `pnpm check:changed` cannot silently become a no-op; fetch only genuinely needed pinned-base blobs from the trusted repository upstream.
- Apply the existing bounded setup timeout to the pinned-base checkout, including any required promisor fetch, so unavailable credentials or upstreams cannot stall a repair worker indefinitely.
- Fail closed when the pinned checkout cannot be safely prepared, so best-effort base diagnosis cannot replace the original validation failure with an infrastructure exception.
- Preserve offline local review and generated-issue PRs' create-only/manual-merge policy unchanged.

## Production root cause and runtime proof

Real issue: https://github.com/openclaw/openclaw/issues/98276

Real failed worker: https://github.com/openclaw/clawsweeper/actions/runs/30665369090

The production worker used `gpt-5.6-sol` with `xhigh` reasoning, produced a narrow three-file OpenClaw fix, passed focused validation and an independent Codex review, and explicitly retained `CLAWSWEEPER_ALLOW_MERGE=0`. After `origin/main` advanced, final base validation attempted `git clone --shared --no-checkout` against its shallow, blob-filtered target checkout and failed before the PR could be published:

```text
final base sync result {"mode":"replacement","attempt":1,"status":"rebased"}
remote: warning: lazy fetching disabled; some objects may not be available
remote: fatal: could not fetch 25f90d7d4ced4c152779e7b78f1c6c1d7ead9f8a from promisor remote
fatal: git upload-pack: aborting due to possible repository corruption on the remote side
```

The new regression creates an actual two-commit shallow `--filter=blob:none` Git repository with a promised historical blob missing, checks out its current base, then changes the promisor remote to `https://invalid.invalid/offline.git`. The previous implementation reproduces the identical production `git upload-pack` failure. The corrected production entrypoint independently materializes the pinned base, preserves `.git/shallow`, reports the genuine base validation failure, leaves the unrelated promised blob absent, and never reaches the disabled upstream. A second real filtered-clone fixture pins an older snapshot whose required blob is missing and proves the independent promisor checkout retrieves only that required object from its trusted upstream. A real changed-gate fixture verifies the comparison branch differs from the pinned head, preventing OpenClaw's `check:changed` no-op; a SHA-256 Git repository and hostile target `core.hooksPath` fixture separately prove object-format and hook isolation.

```json
{
  "realShallowPartialClone": true,
  "unrelatedHistoricalBlobMissing": true,
  "upstream": "https://invalid.invalid/offline.git",
  "shallowBoundaryPreserved": true,
  "pinnedBaseBlobHydratedWhenRequired": true,
  "changedGateComparisonPreserved": true,
  "sha256GitRepositoriesSupported": true,
  "pinnedCheckoutAndPromisorFetchTimeoutBounded": true,
  "targetControlledCheckoutHookExecuted": false,
  "baseFailureReproduced": "src/base.ts:1: lint failed",
  "promisedHistoricalBlobStillMissingAfterValidation": true,
  "generatedIssueMergeAllowed": false,
  "issueExecutionModel": "gpt-5.6-sol",
  "issueExecutionReasoningEffort": "xhigh",
  "offlineLocalReviewStillAvailable": true
}
```

## Validation

- `pnpm run build`
- `pnpm run build:repair`
- `node --test --test-name-pattern='pinned-base reproduction|pinned-base validation reproduction' test/repair/target-validation.test.ts` — **11 passed, 0 failed**; directly exercises the actual production failure, meaningful changed-gate comparison, selective pinned-base blob hydration, bounded checkout/network timeout, SHA-256 repositories, preserved shallow boundaries, independent toolchains, and hostile Git hooks.
- `node --test test/repair/target-validation.test.ts test/repair/git-network-isolation.test.ts` — **183 passed, 0 failed, 3 platform-specific skips** before adding the four focused reviewer regressions; full CI reruns the expanded suite.
- `node --test test/local-review.test.ts test/local-range-review.test.ts test/repair/cluster-workflow-security.test.ts` — **23 passed, 0 failed**; includes offline local review, committed-range local review, credential scrubbing, no web search, `gpt-5.6-sol` + `xhigh`, and generated issue jobs' non-merge policy.
- `pnpm exec oxlint src/repair/target-validation.ts test/repair/target-validation.test.ts --tsconfig tsconfig.repair.json --deny-warnings --report-unused-disable-directives -D correctness`
- `git diff --check`
- Fresh pre-commit Codex reviews identified and resolved five findings: preserve the meaningful source comparison ref, hydrate required pinned-base blobs without fetching unrelated history, initialize temporary repositories in the source SHA-1/SHA-256 object format, bound network-capable pinned-base checkout time, and construct filtered-clone fixture URLs portably for Windows; fresh pre-commit and committed-branch reviews rerun after those fixes.

Generated OpenClaw issue PRs remain **create-only and require manual merge**. Standalone `pnpm run local-review` remains available and offline.
