### PR TITLE
fix: unblock create-only OpenClaw repair validation

### DIFF
--- a/.github/workflows/repair-cluster-worker.yml
+++ b/.github/workflows/repair-cluster-worker.yml
@@ -282,6 +282,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
         with:
+          node-version: "24.18.1"
           build-script: build:repair
 
       - name: Restore durable intake job
@@ -605,6 +606,8 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
         id: execute-setup-pnpm
         with:
+          # OpenClaw's runtime contract rejects the stale Node 24.13 runner cache.
+          node-version: "24.18.1"
           # This job publishes the action ledger with dist/clawsweeper.js, which
           # only the main build emits, so build both Node bundles and skip the
           # dashboard leg the job never runs.

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1220,6 +1220,11 @@ export function runAllowedValidationCommandsWithBinding(
   const needsRustToolchain = targetValidationNeedsRustToolchain(cwd, requiredCommands);
   const preparedPnpmRuntime = preparedPnpmRuntimeForValidation(cwd, options);
   return withTargetValidationEnvironment((validationEnv, resetValidationEnvironment) => {
+    if (options.targetRepo === "openclaw/openclaw") {
+      // Vitest's scheduling telemetry rewrites an existing ignored artifact, which
+      // violates checkout identity despite having no bearing on validation proof.
+      validationEnv.OPENCLAW_TEST_PROJECTS_TIMINGS = "0";
+    }
     const validationTimeoutMs = targetValidationTimeoutMs(
       "CLAWSWEEPER_TARGET_VALIDATION_TIMEOUT_MS",
       options.validationTimeoutMs ?? DEFAULT_TARGET_VALIDATION_TIMEOUT_MS,

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4282,6 +4282,62 @@ test("OpenClaw changed-gate compiler cache is disposable and preserves existing 
   }
 });
 
+test("OpenClaw validation disables shard timing writes without weakening ignored-input protection", () => {
+  for (const existingTimingArtifact of [false, true]) {
+    const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+    fs.appendFileSync(path.join(cwd, ".gitignore"), ".artifacts/\n");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+
+    const artifacts = path.join(cwd, ".artifacts");
+    fs.mkdirSync(artifacts, { recursive: true });
+    fs.writeFileSync(path.join(artifacts, "stable.txt"), "existing artifact\n");
+    const timings = path.join(artifacts, "vitest-shard-timings.json");
+    if (existingTimingArtifact) fs.writeFileSync(timings, "trusted previous timings\n");
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-vitest-timings-"));
+    writeNodeCommandShim(
+      binDir,
+      "pnpm",
+      [
+        'const fs = require("node:fs");',
+        'if (process.env.OPENCLAW_TEST_PROJECTS_TIMINGS !== "0") {',
+        '  fs.mkdirSync(".artifacts", { recursive: true });',
+        '  fs.writeFileSync(".artifacts/vitest-shard-timings.json", "generated timings\\n");',
+        "}",
+      ].join("\n"),
+    );
+
+    assert.deepEqual(
+      withPathOnlyPrefix(binDir, () =>
+        runAllowedValidationCommands(
+          ["pnpm check:changed"],
+          cwd,
+          validationOptions("openclaw/openclaw", {
+            pinnedBaseRef: "origin/main",
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: [],
+              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+            },
+          }),
+        ),
+      ),
+      ["pnpm check:changed"],
+    );
+    assert.equal(
+      fs.readFileSync(path.join(artifacts, "stable.txt"), "utf8"),
+      "existing artifact\n",
+    );
+    if (existingTimingArtifact) {
+      assert.equal(fs.readFileSync(timings, "utf8"), "trusted previous timings\n");
+    } else {
+      assert.equal(fs.existsSync(timings), false);
+    }
+  }
+});
+
 test("changed-gate compiler cache isolation still rejects unrelated ignored-input poisoning", () => {
   const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
   fs.appendFileSync(path.join(cwd, ".gitignore"), ".artifacts/\n");

--- a/test/repair/workflow-sparse-checkout.test.ts
+++ b/test/repair/workflow-sparse-checkout.test.ts
@@ -28,6 +28,23 @@ const REPAIR_RUNTIME_PATHS = [
 const MAIN_BUNDLE = "dist/clawsweeper.js";
 const RUNTIME_DIST_ARTIFACT = "clawsweeper-runtime-dist";
 
+test("repair planning and execution use a Node runtime accepted by current OpenClaw", () => {
+  const workflow = parse(
+    fs.readFileSync(".github/workflows/repair-cluster-worker.yml", "utf8"),
+  ) as {
+    jobs?: Record<
+      string,
+      { steps?: { id?: unknown; uses?: unknown; with?: Record<string, unknown> }[] }
+    >;
+  };
+  for (const jobName of ["cluster", "execute"]) {
+    const setup = workflow.jobs?.[jobName]?.steps?.find(
+      (step) => step.uses === "./.github/actions/setup-pnpm",
+    );
+    assert.equal(setup?.with?.["node-version"], "24.18.1", `${jobName} runtime`);
+  }
+});
+
 test("sparse repair build workflows include runtime dependencies", () => {
   for (const workflowPath of SPARSE_REPAIR_BUILD_WORKFLOWS) {
     const buildScripts = workflowBuildScripts(workflowPath);


### PR DESCRIPTION
## Summary

- run both repair planning and PR execution on Node 24.18.1, satisfying the current OpenClaw runtime contract instead of reusing unsupported cached Node 24.13/24.14
- disable OpenClaw's optional Vitest shard-timing telemetry inside the disposable validation environment so legitimate checks cannot mutate a pre-existing ignored runtime artifact
- preserve strict checkout/runtime-input identity verification, ignored-input poisoning detection, offline local review, `gpt-5.6-sol`/`xhigh` issue-fix execution, and the generated-issue-PR no-merge policy

## Production failure reproduced

- Live generated issue worker https://github.com/openclaw/clawsweeper/actions/runs/30670627735 failed after producing and independently reviewing a narrow fix for https://github.com/openclaw/openclaw/issues/98276 with `unsafe validation command mutated checkout identity (pnpm check:changed): runtimeInputsSha256`.
- Its saved Codex execution report independently proved the worker's cached `v24.13.0` also fails OpenClaw's declared `>=24.15.0 <25` runtime requirement during the real `pnpm build:ci-artifacts` proof.
- Real OpenClaw runtime proof imported `scripts/lib/vitest-shard-timings.mjs`, seeded an actual `.artifacts/vitest-shard-timings.json`, and exercised both branches: `OPENCLAW_TEST_PROJECTS_TIMINGS=0` preserved the original artifact exactly; the positive control without that switch rewrote it.
- Verified Node 24.18.1 exists in the current official GitHub Actions Node manifest with a Linux x64 distribution.

### Inspectable real OpenClaw after-fix transcript

The pinned **official Node 24.18.1 distribution** executed the actual current OpenClaw package-engine checker and the actual `scripts/lib/vitest-shard-timings.mjs` implementation against a real pre-existing ignored artifact. The same invocation parsed this PR's production workflow, independently proving both repair jobs select that supported runtime:

```console
$ PATH=/tmp/node-v24.18.1-darwin-arm64/bin:$PATH node /tmp/clawsweeper-runtime-proof.mjs
{"node":"v24.18.1","required":">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0","acceptedByRealOpenClawGuard":true}
{"job":"cluster","nodeVersion":"24.18.1"}
{"job":"execute","nodeVersion":"24.18.1"}
{"target":"real OpenClaw Vitest helper","timingsDisabled":true,"existingArtifactUnchanged":true}
{"target":"real OpenClaw Vitest helper","timingsDisabled":false,"positiveControlChangedArtifact":true}

$ PATH=/tmp/node-v24.18.1-darwin-arm64/bin:$PATH node --test --test-name-pattern='OpenClaw validation disables shard timing writes|changed-gate compiler cache isolation still rejects|repair planning and execution use a Node runtime' test/repair/target-validation.test.ts test/repair/workflow-sparse-checkout.test.ts
✔ OpenClaw validation disables shard timing writes without weakening ignored-input protection (2918.558166ms)
✔ changed-gate compiler cache isolation still rejects unrelated ignored-input poisoning (1412.126959ms)
✔ repair planning and execution use a Node runtime accepted by current OpenClaw (23.4405ms)
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

Independently reviewable Linux evidence on this exact PR head: [successful `pnpm check`, sparse repair build, and Windows launcher run](https://github.com/openclaw/clawsweeper/actions/runs/30675879749) and [successful production automerge-flow artifact](https://github.com/openclaw/clawsweeper/actions/runs/30675879741).

## Validation

- `pnpm run build:node`
- complete target-validation integration suite: **180 passed, 3 expected platform skips, 0 failed**
- focused offline/local-review, local-range, bounded changed-blob hydration, and workflow integration suites: **33 passed, 0 failed**
- focused security regressions retained: existing and absent compiler caches, changed-gate fallback isolation, unrelated ignored-input poisoning, fresh runtime output protection, pinned-base validation, and malicious dependency poisoning
- `pnpm exec oxfmt --check src/repair/target-validation.ts test/repair/target-validation.test.ts test/repair/workflow-sparse-checkout.test.ts .github/workflows/repair-cluster-worker.yml`
- `git diff --check`
- independent fresh Codex review required before commit and again on the committed branch; initial actionable finding (also pin planning runtime) addressed and regression-tested for both jobs

## Safety boundaries

- `pnpm run local-review` remains `node dist/commit-sweeper.js local-review`; offline network prohibition and credential scrubbing remain tested.
- OpenClaw issue workers still use `gpt-5.6-sol` with `xhigh` reasoning.
- Generated OpenClaw issue PRs remain create-only: `CLAWSWEEPER_ALLOW_MERGE=0`; this PR changes no merge gate or publication policy.
