### PR TITLE
feat: add exact review lifecycle telemetry

### DIFF
--- a/dashboard/exact-review-lifecycle-telemetry.ts
+++ b/dashboard/exact-review-lifecycle-telemetry.ts
@@ -1,0 +1,419 @@
+import {
+  EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE,
+  commandAcknowledgementState,
+  lifecycleState,
+  type ExactReviewLifecycleProjection,
+  type LifecycleTerminalDisposition,
+} from "./exact-review-lifecycle.ts";
+
+export const EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE =
+  "exact_review_lifecycle_telemetry_direct_v1";
+export const EXACT_REVIEW_LIFECYCLE_TELEMETRY_BATCH_TABLE =
+  "exact_review_lifecycle_telemetry_batch_v1";
+export const EXACT_REVIEW_LIFECYCLE_TELEMETRY_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+type SqlStorage = {
+  exec: (query: string, ...bindings: unknown[]) => Iterable<Record<string, unknown>>;
+};
+
+type DurableStorage = {
+  sql: SqlStorage;
+  transactionSync: <T>(callback: () => T) => T;
+};
+
+export type DirectPublicationTelemetryOutcome = "accepted" | "deduped" | "superseded" | "fallback";
+
+export type BatchPublicationTelemetryOutcome = "superseded" | "retryable" | "permanent";
+
+/**
+ * Producer-only durable telemetry contract. Its counts are derived from the
+ * lifecycle projection and server-observed publication results, never from a
+ * workflow run or a visible command-status acknowledgement.
+ */
+export type ExactReviewLifecycleTelemetryV1 = {
+  version: 1;
+  generatedAt: number;
+  inventory: {
+    uniqueTargets: number;
+    targetRevisions: number;
+    lifecycleRecords: number;
+  };
+  age: {
+    activeRecords: number;
+    oldestActiveMs: number | null;
+  };
+  terminalCoverage: {
+    trackedRecords: number;
+    currentRecords: number;
+    durableTerminalRecords: number;
+    durableTerminalCoveragePercent: number | null;
+    unknownTerminalRecords: number;
+    acknowledgementPendingRecords: number;
+    nonCurrentRecords: number;
+    terminalClasses: Record<LifecycleTerminalDisposition, number>;
+  };
+  publication: {
+    direct: Record<DirectPublicationTelemetryOutcome | "unknown", number>;
+    batch: Record<"accepted" | "deduped" | BatchPublicationTelemetryOutcome, number>;
+    lifecycleRetries: number;
+    lastSuccessfulCanonicalAcceptanceAt: number | null;
+  };
+  invalidProjectionRows: number;
+};
+
+export type ExactReviewLifecycleTelemetrySummary = ExactReviewLifecycleTelemetryV1;
+
+type DirectOutcomeInput = {
+  canonicalTargetKey: string;
+  fenceKey: string;
+  revision: number;
+  claimGeneration: number;
+  outcome: DirectPublicationTelemetryOutcome;
+  observedAt: number;
+};
+
+type BatchOutcomeInput = {
+  batchId: string;
+  canonicalTargetKey: string;
+  fenceKey: string;
+  revision: number;
+  claimGeneration: number;
+  outcome: BatchPublicationTelemetryOutcome;
+  observedAt: number;
+};
+
+const TERMINAL_CLASSES: LifecycleTerminalDisposition[] = [
+  "review_completed_routed",
+  "superseded",
+  "requeue",
+  "dead_letter",
+  "target_closed",
+  "target_missing",
+  "policy_noop",
+  "guarded_open",
+  "failure",
+];
+
+export class ExactReviewLifecycleTelemetryStore {
+  private readonly storage: DurableStorage;
+
+  constructor(storage: DurableStorage) {
+    this.storage = storage;
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE} (
+         event_id TEXT PRIMARY KEY,
+         canonical_target_key TEXT NOT NULL,
+         fence_key TEXT NOT NULL,
+         revision INTEGER NOT NULL CHECK (revision >= 1),
+         claim_generation INTEGER NOT NULL CHECK (claim_generation >= 1),
+         outcome TEXT NOT NULL CHECK (outcome IN ('accepted', 'deduped', 'superseded', 'fallback')),
+         observed_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_lifecycle_telemetry_direct_retention
+         ON ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE} (observed_at, event_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_BATCH_TABLE} (
+         event_id TEXT PRIMARY KEY,
+         batch_id TEXT NOT NULL,
+         canonical_target_key TEXT NOT NULL,
+         fence_key TEXT NOT NULL,
+         revision INTEGER NOT NULL CHECK (revision >= 1),
+         claim_generation INTEGER NOT NULL CHECK (claim_generation >= 1),
+         outcome TEXT NOT NULL CHECK (outcome IN ('superseded', 'retryable', 'permanent')),
+         observed_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_lifecycle_telemetry_batch_retention
+         ON ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_BATCH_TABLE} (observed_at, event_id)`,
+    );
+  }
+
+  recordDirectOutcome(input: DirectOutcomeInput) {
+    validateIdentity(input);
+    if (!DIRECT_OUTCOMES.has(input.outcome)) throw new Error("invalid direct telemetry outcome");
+    const eventId = `direct:${input.fenceKey}:${input.revision}:${input.claimGeneration}:${input.outcome}`;
+    this.storage.transactionSync(() => {
+      this.pruneSync(input.observedAt);
+      this.storage.sql.exec(
+        `INSERT OR IGNORE INTO ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE}
+           (event_id, canonical_target_key, fence_key, revision, claim_generation, outcome, observed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        eventId,
+        input.canonicalTargetKey,
+        input.fenceKey,
+        input.revision,
+        input.claimGeneration,
+        input.outcome,
+        input.observedAt,
+      );
+    });
+  }
+
+  recordBatchOutcome(input: BatchOutcomeInput) {
+    validateIdentity(input);
+    if (!BATCH_OUTCOMES.has(input.outcome)) throw new Error("invalid batch telemetry outcome");
+    if (!validText(input.batchId, 1, 200)) throw new Error("invalid telemetry batch id");
+    const eventId = `batch:${input.batchId}:${input.fenceKey}:${input.revision}:${input.claimGeneration}:${input.outcome}`;
+    this.storage.transactionSync(() => {
+      this.pruneSync(input.observedAt);
+      this.storage.sql.exec(
+        `INSERT OR IGNORE INTO ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_BATCH_TABLE}
+           (event_id, batch_id, canonical_target_key, fence_key, revision, claim_generation, outcome, observed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        eventId,
+        input.batchId,
+        input.canonicalTargetKey,
+        input.fenceKey,
+        input.revision,
+        input.claimGeneration,
+        input.outcome,
+        input.observedAt,
+      );
+    });
+  }
+
+  /**
+   * Intentionally has no queue fetch route in Workstream 3. A future,
+   * maintainer-approved authenticated operator reader may aggregate this
+   * producer contract, but must not turn it into Bay/public status data.
+   */
+  summary(now: number): ExactReviewLifecycleTelemetrySummary {
+    const retentionCutoff = now - EXACT_REVIEW_LIFECYCLE_TELEMETRY_RETENTION_MS;
+    const projections: ExactReviewLifecycleProjection[] = [];
+    let invalidProjectionRows = 0;
+    for (const row of this.storage.sql.exec(
+      `SELECT projection_json FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}`,
+    )) {
+      const projection = projectionFromRow(String(row.projection_json || ""));
+      if (projection) projections.push(projection);
+      else invalidProjectionRows += 1;
+    }
+
+    const maxRevisionByTarget = new Map<string, number>();
+    for (const projection of projections) {
+      maxRevisionByTarget.set(
+        projection.canonicalTargetKey,
+        Math.max(maxRevisionByTarget.get(projection.canonicalTargetKey) ?? 0, projection.revision),
+      );
+    }
+
+    const terminalClasses = Object.fromEntries(TERMINAL_CLASSES.map((kind) => [kind, 0])) as Record<
+      LifecycleTerminalDisposition,
+      number
+    >;
+    const direct = emptyDirectOutcomes();
+    const batch = emptyBatchOutcomes();
+    let activeRecords = 0;
+    let oldestActiveMs: number | null = null;
+    let durableTerminalRecords = 0;
+    let unknownTerminalRecords = 0;
+    let acknowledgementPendingRecords = 0;
+    let nonCurrentRecords = 0;
+    let lifecycleRetries = 0;
+    let lastSuccessfulCanonicalAcceptanceAt: number | null = null;
+    const directKnownByRecord = new Set<string>();
+
+    for (const row of this.storage.sql.exec(
+      `SELECT canonical_target_key, fence_key, revision
+         FROM ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE}
+        WHERE observed_at >= ?`,
+      retentionCutoff,
+    )) {
+      directKnownByRecord.add(
+        identityKey({
+          canonicalTargetKey: String(row.canonical_target_key || ""),
+          fenceKey: String(row.fence_key || ""),
+          revision: Number(row.revision),
+        }),
+      );
+    }
+    for (const row of this.storage.sql.exec(
+      `SELECT outcome, COUNT(*) AS count FROM ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE}
+        WHERE observed_at >= ?
+        GROUP BY outcome`,
+      retentionCutoff,
+    )) {
+      const outcome = String(row.outcome || "") as DirectPublicationTelemetryOutcome;
+      if (DIRECT_OUTCOMES.has(outcome)) direct[outcome] = Number(row.count || 0);
+    }
+    for (const row of this.storage.sql.exec(
+      `SELECT outcome, COUNT(*) AS count FROM ${EXACT_REVIEW_LIFECYCLE_TELEMETRY_BATCH_TABLE}
+        WHERE observed_at >= ?
+        GROUP BY outcome`,
+      retentionCutoff,
+    )) {
+      const outcome = String(row.outcome || "") as BatchPublicationTelemetryOutcome;
+      if (BATCH_OUTCOMES.has(outcome)) batch[outcome] = Number(row.count || 0);
+    }
+
+    for (const projection of projections) {
+      const state = lifecycleState(projection);
+      const acknowledgement = commandAcknowledgementState(projection);
+      const terminal = projection.terminalDisposition?.kind ?? null;
+      const isCurrent =
+        projection.revision === maxRevisionByTarget.get(projection.canonicalTargetKey) &&
+        state !== "superseded" &&
+        state !== "requeue";
+      if (!isCurrent) nonCurrentRecords += 1;
+      if (terminal) {
+        durableTerminalRecords += 1;
+        terminalClasses[terminal] += 1;
+      } else {
+        unknownTerminalRecords += 1;
+        activeRecords += 1;
+        const age = Math.max(0, now - projection.admission.admittedAt);
+        oldestActiveMs = Math.max(oldestActiveMs ?? 0, age);
+      }
+      if (acknowledgement === "pending") acknowledgementPendingRecords += 1;
+      lifecycleRetries += Math.max(0, projection.claims.length - 1);
+      for (const receipt of projection.canonicalReceipts) {
+        if (receipt.observedAt < retentionCutoff) continue;
+        if (receipt.outcome === "accepted" || receipt.outcome === "deduped") {
+          lastSuccessfulCanonicalAcceptanceAt = Math.max(
+            lastSuccessfulCanonicalAcceptanceAt ?? 0,
+            receipt.observedAt,
+          );
+        }
+        if (isBatchFence(projection.fenceKey)) batch[receipt.outcome] += 1;
+      }
+      if (!isBatchFence(projection.fenceKey)) {
+        const key = identityKey(projection);
+        if (!directKnownByRecord.has(key) && !projection.canonicalReceipts.length)
+          direct.unknown += 1;
+      }
+    }
+
+    const targetRevisions = new Set(
+      projections.map((projection) => `${projection.canonicalTargetKey}:${projection.revision}`),
+    ).size;
+    return {
+      version: 1,
+      generatedAt: now,
+      inventory: {
+        uniqueTargets: maxRevisionByTarget.size,
+        targetRevisions,
+        lifecycleRecords: projections.length,
+      },
+      age: { activeRecords, oldestActiveMs },
+      terminalCoverage: {
+        trackedRecords: projections.length,
+        currentRecords: projections.length - nonCurrentRecords,
+        durableTerminalRecords,
+        durableTerminalCoveragePercent: projections.length
+          ? Math.round((durableTerminalRecords / projections.length) * 10_000) / 100
+          : null,
+        unknownTerminalRecords,
+        acknowledgementPendingRecords,
+        nonCurrentRecords,
+        terminalClasses,
+      },
+      publication: {
+        direct,
+        batch,
+        lifecycleRetries,
+        lastSuccessfulCanonicalAcceptanceAt,
+      },
+      invalidProjectionRows,
+    };
+  }
+
+  private pruneSync(now: number) {
+    const cutoff = now - EXACT_REVIEW_LIFECYCLE_TELEMETRY_RETENTION_MS;
+    for (const table of [
+      EXACT_REVIEW_LIFECYCLE_TELEMETRY_DIRECT_TABLE,
+      EXACT_REVIEW_LIFECYCLE_TELEMETRY_BATCH_TABLE,
+    ]) {
+      this.storage.sql.exec(
+        `DELETE FROM ${table}
+          WHERE rowid IN (
+            SELECT rowid FROM ${table} WHERE observed_at < ? ORDER BY observed_at, event_id LIMIT 256
+          )`,
+        cutoff,
+      );
+    }
+  }
+}
+
+const DIRECT_OUTCOMES = new Set<DirectPublicationTelemetryOutcome>([
+  "accepted",
+  "deduped",
+  "superseded",
+  "fallback",
+]);
+const BATCH_OUTCOMES = new Set<BatchPublicationTelemetryOutcome>([
+  "superseded",
+  "retryable",
+  "permanent",
+]);
+
+function emptyDirectOutcomes() {
+  return { accepted: 0, deduped: 0, superseded: 0, fallback: 0, unknown: 0 };
+}
+
+function emptyBatchOutcomes() {
+  return { accepted: 0, deduped: 0, superseded: 0, retryable: 0, permanent: 0 };
+}
+
+function projectionFromRow(value: string): ExactReviewLifecycleProjection | null {
+  try {
+    const projection = JSON.parse(value) as ExactReviewLifecycleProjection;
+    if (
+      !projection ||
+      projection.version !== 1 ||
+      !validCanonicalTargetKey(projection.canonicalTargetKey) ||
+      !validText(projection.fenceKey, 1, 512) ||
+      !positiveInteger(projection.revision)
+    ) {
+      return null;
+    }
+    return projection;
+  } catch {
+    return null;
+  }
+}
+
+function validateIdentity(input: {
+  canonicalTargetKey: string;
+  fenceKey: string;
+  revision: number;
+  claimGeneration: number;
+  observedAt: number;
+}) {
+  if (
+    !validCanonicalTargetKey(input.canonicalTargetKey) ||
+    !validText(input.fenceKey, 1, 512) ||
+    !positiveInteger(input.revision) ||
+    !positiveInteger(input.claimGeneration) ||
+    !Number.isSafeInteger(input.observedAt) ||
+    input.observedAt < 1
+  ) {
+    throw new Error("invalid lifecycle telemetry identity");
+  }
+}
+
+function identityKey(input: { canonicalTargetKey: string; fenceKey: string; revision: number }) {
+  return `${input.canonicalTargetKey}\u0000${input.fenceKey}\u0000${input.revision}`;
+}
+
+function isBatchFence(fenceKey: string) {
+  return fenceKey.includes("@publish:");
+}
+
+function validCanonicalTargetKey(value: string) {
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(value);
+}
+
+function positiveInteger(value: number) {
+  return Number.isSafeInteger(value) && value >= 1;
+}
+
+function validText(value: string, min: number, max: number) {
+  return value.length >= min && value.length <= max && !/[\r\n]/.test(value);
+}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -68,6 +68,7 @@ import {
   type ExactReviewLifecycleProjection,
   type LifecycleTerminalDisposition,
 } from "./exact-review-lifecycle.ts";
+import { ExactReviewLifecycleTelemetryStore } from "./exact-review-lifecycle-telemetry.ts";
 import { sanitizedServerError } from "./error-safety.ts";
 
 type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
@@ -563,6 +564,7 @@ export class ExactReviewQueue {
   private recordSnapshotStore;
   private stateWriterCoordinator;
   private lifecycleProjectionStore;
+  private lifecycleTelemetryStore;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
 
@@ -578,6 +580,7 @@ export class ExactReviewQueue {
     );
     this.stateWriterCoordinator = new StateWriterCoordinator(this.storage);
     this.lifecycleProjectionStore = new ExactReviewLifecycleProjectionStore(this.storage);
+    this.lifecycleTelemetryStore = new ExactReviewLifecycleTelemetryStore(this.storage);
     const initialize = () => this.initializeStorage();
     this.ready =
       typeof state.blockConcurrencyWhile === "function"
@@ -1947,6 +1950,15 @@ export class ExactReviewQueue {
         lifecycleTerminal,
         now,
       });
+      if (publicationItem && publicationCompletion) {
+        this.recordLifecycleTelemetryNonBatchPublication({
+          identity: lifecycleIdentity,
+          claimGeneration: lifecycleClaimGeneration,
+          completion: publicationCompletion,
+          projection: projectionBeforeTerminalCommit,
+          observedAt: now,
+        });
+      }
       const projectionAfterCompletion = this.lifecycleProjectionStore.read(
         lifecycleIdentity.canonicalTargetKey,
         lifecycleIdentity.fenceKey,
@@ -2463,12 +2475,24 @@ export class ExactReviewQueue {
         }
         const validFence = directlyOwned || batchOwned;
         if (!validFence && !existing) {
+          if (!deferredBatchCompletion) {
+            this.recordLifecycleTelemetryDirect({
+              validated,
+              outcome: "fallback",
+              observedAt: now,
+            });
+          }
           return json(
             { error: "direct_publication_fence_not_owned", fallback_required: true },
             409,
           );
         }
         if (!deferredBatchCompletion && !validated.sourceSha) {
+          this.recordLifecycleTelemetryDirect({
+            validated,
+            outcome: "fallback",
+            observedAt: now,
+          });
           return json(
             { error: "direct_publication_source_sha_required", fallback_required: true },
             400,
@@ -2476,6 +2500,13 @@ export class ExactReviewQueue {
         }
         const accepted = this.directPublicationStore.accept(validated, now);
         this.recordLifecycleDirectPublication({ validated, owned, accepted, now });
+        if (!deferredBatchCompletion) {
+          this.recordLifecycleTelemetryDirect({
+            validated,
+            outcome: accepted.outcome,
+            observedAt: now,
+          });
+        }
         if (owned && validFence && !deferredBatchCompletion && !owned.decision.publication) {
           const producerDecision = owned.decision.publication
             ? owned.decision.publication.producerDecision
@@ -5505,14 +5536,38 @@ export class ExactReviewQueue {
         revision: number;
         kind: LifecycleTerminalDisposition;
       }> = [];
+      const lifecycleTelemetryBatchOutcomes: Array<{
+        canonicalTargetKey: string;
+        fenceKey: string;
+        revision: number;
+        claimGeneration: number;
+        outcome: "superseded";
+      }> = [];
       batch = this.batchStore.complete(batchId, leaseOwner, stale, now, {}, (accepted) => {
         const current = this.readStateSync();
         let superseded = 0;
         for (const completion of accepted) {
           const item = current.items[completion.itemKey];
           if (item) {
+            const canonicalTargetKey = `${item.decision.targetRepo}#${item.decision.itemNumber}`;
+            const projection = this.lifecycleProjectionStore.read(
+              canonicalTargetKey,
+              completion.itemKey,
+              completion.revision,
+            );
+            if (
+              !projection?.canonicalReceipts.some((receipt) => receipt.outcome === "superseded")
+            ) {
+              lifecycleTelemetryBatchOutcomes.push({
+                canonicalTargetKey,
+                fenceKey: completion.itemKey,
+                revision: completion.revision,
+                claimGeneration: completion.claimGeneration,
+                outcome: "superseded",
+              });
+            }
             lifecycleTerminals.push({
-              canonicalTargetKey: `${item.decision.targetRepo}#${item.decision.itemNumber}`,
+              canonicalTargetKey,
               fenceKey: completion.itemKey,
               revision: completion.revision,
               kind: "superseded",
@@ -5550,6 +5605,9 @@ export class ExactReviewQueue {
       if (!batch) return json({ error: "batch_lease_not_active" }, 409);
       for (const terminal of lifecycleTerminals) {
         this.recordLifecycleTerminal(terminal, now);
+      }
+      for (const outcome of lifecycleTelemetryBatchOutcomes) {
+        this.recordLifecycleTelemetryBatch({ batchId, ...outcome, observedAt: now });
       }
       state = this.readStateSync();
       await this.scheduleNext(state, now);
@@ -5677,6 +5735,13 @@ export class ExactReviewQueue {
       revision: number;
       kind: LifecycleTerminalDisposition;
     }> = [];
+    const lifecycleTelemetryBatchOutcomes: Array<{
+      canonicalTargetKey: string;
+      fenceKey: string;
+      revision: number;
+      claimGeneration: number;
+      outcome: "superseded" | "retryable" | "permanent";
+    }> = [];
     let batch = this.batchStore.complete(
       batchId,
       leaseOwner,
@@ -5719,8 +5784,25 @@ export class ExactReviewQueue {
             continue;
           }
           if (completion.terminalOutcome === "superseded") {
+            const canonicalTargetKey = `${item.decision.targetRepo}#${item.decision.itemNumber}`;
+            const projection = this.lifecycleProjectionStore.read(
+              canonicalTargetKey,
+              completion.itemKey,
+              completion.revision,
+            );
+            if (
+              !projection?.canonicalReceipts.some((receipt) => receipt.outcome === "superseded")
+            ) {
+              lifecycleTelemetryBatchOutcomes.push({
+                canonicalTargetKey,
+                fenceKey: completion.itemKey,
+                revision: completion.revision,
+                claimGeneration: completion.claimGeneration,
+                outcome: "superseded",
+              });
+            }
             lifecycleTerminals.push({
-              canonicalTargetKey: `${item.decision.targetRepo}#${item.decision.itemNumber}`,
+              canonicalTargetKey,
               fenceKey: completion.itemKey,
               revision: completion.revision,
               kind: "superseded",
@@ -5781,6 +5863,18 @@ export class ExactReviewQueue {
             if (result.deadLetter) {
               this.insertDeadLetterSync(result.deadLetter);
               deadLettered += 1;
+            }
+            const telemetryOutcome = exactReviewLifecycleTelemetryPublicationOutcome(
+              requested.publicationCompletion,
+            );
+            if (telemetryOutcome) {
+              lifecycleTelemetryBatchOutcomes.push({
+                canonicalTargetKey: `${item.decision.targetRepo}#${item.decision.itemNumber}`,
+                fenceKey: completion.itemKey,
+                revision: completion.revision,
+                claimGeneration: completion.claimGeneration,
+                outcome: telemetryOutcome,
+              });
             }
             const lifecycleTerminal = result.deadLetter
               ? "dead_letter"
@@ -5871,6 +5965,9 @@ export class ExactReviewQueue {
     if (!batch) return json({ error: "batch_lease_not_active" }, 409);
     for (const terminal of lifecycleTerminals) {
       this.recordLifecycleTerminal(terminal, now);
+    }
+    for (const outcome of lifecycleTelemetryBatchOutcomes) {
+      this.recordLifecycleTelemetryBatch({ batchId, ...outcome, observedAt: now });
     }
     if (stateWriter?.commit_count === 1) {
       batch =
@@ -6100,6 +6197,82 @@ export class ExactReviewQueue {
         observedAt: now,
       });
     }
+  }
+
+  private recordLifecycleTelemetryDirect({ validated, outcome, observedAt }) {
+    try {
+      this.lifecycleTelemetryStore.recordDirectOutcome({
+        canonicalTargetKey: validated.canonicalTargetKey,
+        fenceKey: validated.fenceKey,
+        revision: validated.revision,
+        claimGeneration: validated.identity.claimGeneration,
+        outcome,
+        observedAt,
+      });
+    } catch (error) {
+      console.warn(
+        `lifecycle telemetry direct outcome not recorded: ${sanitizedServerError(error)}`,
+      );
+    }
+  }
+
+  private recordLifecycleTelemetryBatch({
+    batchId,
+    canonicalTargetKey,
+    fenceKey,
+    revision,
+    claimGeneration,
+    outcome,
+    observedAt,
+  }) {
+    try {
+      this.lifecycleTelemetryStore.recordBatchOutcome({
+        batchId,
+        canonicalTargetKey,
+        fenceKey,
+        revision,
+        claimGeneration,
+        outcome,
+        observedAt,
+      });
+    } catch (error) {
+      console.warn(
+        `lifecycle telemetry batch outcome not recorded: ${sanitizedServerError(error)}`,
+      );
+    }
+  }
+
+  private recordLifecycleTelemetryNonBatchPublication({
+    identity,
+    claimGeneration,
+    completion,
+    projection,
+    observedAt,
+  }: {
+    identity: ExactReviewLifecycleProjectionIdentity;
+    claimGeneration: number;
+    completion: ExactReviewPublicationCompletion;
+    projection: ExactReviewLifecycleProjection | null;
+    observedAt: number;
+  }) {
+    const outcome = exactReviewLifecycleTelemetryPublicationOutcome(completion);
+    if (!outcome) return;
+    if (
+      outcome === "superseded" &&
+      projection?.canonicalReceipts.some((receipt) => receipt.outcome === "superseded")
+    ) {
+      return;
+    }
+    this.recordLifecycleTelemetryBatch({
+      // The table retains a batch identifier for replay-safe event keys. This
+      // established completion route has no batch lease, so a fixed source
+      // label preserves that distinction without inventing one.
+      batchId: "non-batch-completion",
+      ...identity,
+      claimGeneration,
+      outcome,
+      observedAt,
+    });
   }
 
   private recordLifecycleCompletion({
@@ -6847,6 +7020,7 @@ export class ExactReviewQueue {
     this.recordSnapshotStore.ensureSchemaSync();
     this.stateWriterCoordinator.ensureSchemaSync();
     this.lifecycleProjectionStore.ensureSchemaSync();
+    this.lifecycleTelemetryStore.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
     const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as
@@ -9832,6 +10006,16 @@ function exactReviewPublicationCompletionKind(value): ExactReviewPublicationComp
     normalized === "permanent_failure"
     ? normalized
     : null;
+}
+
+function exactReviewLifecycleTelemetryPublicationOutcome(
+  completion: ExactReviewPublicationCompletion,
+): "superseded" | "retryable" | "permanent" | null {
+  if (completion.kind === "superseded") return "superseded";
+  if (completion.kind === "retryable_failure" || completion.kind === "refresh_required") {
+    return "retryable";
+  }
+  return completion.kind === "permanent_failure" ? "permanent" : null;
 }
 
 function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCode | null {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -38,6 +38,7 @@ import {
   ExactReviewLifecycleProjectionStore,
   lifecycleState,
 } from "../dashboard/exact-review-lifecycle.ts";
+import { ExactReviewLifecycleTelemetryStore } from "../dashboard/exact-review-lifecycle-telemetry.ts";
 import { captureCanonicalRecordBaseline } from "../dist/repair/canonical-record-baseline.js";
 import { publishMainWithStateAppend } from "../dist/repair/publish-main.js";
 
@@ -555,6 +556,186 @@ test("exact-review lifecycle projection keeps immutable per-revision facts and t
     });
     assert.equal(lifecycleState(projection), state);
   }
+});
+
+test("lifecycle telemetry counts durable terminal coverage without treating acknowledgement pending as completed", () => {
+  const storage = new MemoryDurableStorage();
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const telemetry = new ExactReviewLifecycleTelemetryStore(storage);
+  lifecycle.ensureSchemaSync();
+  telemetry.ensureSchemaSync();
+  const admittedAt = 1_700_000_000_000;
+  const add = ({
+    number,
+    revision = 1,
+    fenceKey = `openclaw/openclaw#${number}@exact:${revision}`,
+    commandOriginated = false,
+    terminal,
+    receipt,
+  }: {
+    number: number;
+    revision?: number;
+    fenceKey?: string;
+    commandOriginated?: boolean;
+    terminal?: Parameters<
+      ExactReviewLifecycleProjectionStore["recordTerminalDisposition"]
+    >[0]["kind"];
+    receipt?: "accepted" | "deduped" | "superseded";
+  }) => {
+    const identity = {
+      canonicalTargetKey: `openclaw/openclaw#${number}`,
+      fenceKey,
+      revision,
+    };
+    lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `telemetry:${number}:${revision}`,
+      sourceAction: "re_review",
+      commandOriginated,
+      statusMarker: commandOriginated
+        ? `<!-- clawsweeper-command-status:${number}:token -->`
+        : null,
+      statusCommentId: commandOriginated ? number : null,
+      observedAt: admittedAt + number,
+    });
+    lifecycle.recordClaim({
+      ...identity,
+      claimGeneration: 1,
+      runId: String(number),
+      runAttempt: 1,
+      observedAt: admittedAt + number + 1,
+    });
+    if (receipt) {
+      lifecycle.recordCanonicalReceipt({
+        ...identity,
+        outcome: receipt,
+        receiptId: `telemetry:${number}:${receipt}`,
+        observedAt: admittedAt + number + 2,
+      });
+    }
+    if (terminal) {
+      lifecycle.recordTerminalDisposition({
+        ...identity,
+        kind: terminal,
+        observedAt: admittedAt + number + 3,
+      });
+    }
+    return identity;
+  };
+
+  const acknowledgementPending = add({
+    number: 810,
+    commandOriginated: true,
+    receipt: "accepted",
+    terminal: "review_completed_routed",
+  });
+  lifecycle.recordRouterReceipt({
+    ...acknowledgementPending,
+    outcome: "durable",
+    receiptId: "telemetry:810:router",
+    observedAt: admittedAt + 815,
+  });
+  lifecycle.recordClaim({
+    ...acknowledgementPending,
+    claimGeneration: 2,
+    runId: "810",
+    runAttempt: 2,
+    observedAt: admittedAt + 816,
+  });
+  telemetry.recordDirectOutcome({
+    ...acknowledgementPending,
+    claimGeneration: 1,
+    outcome: "accepted",
+    observedAt: admittedAt + 817,
+  });
+
+  add({ number: 811 }); // Unresolved durable lifecycle fact, not a workflow-success proxy.
+  const supersededDirect = add({ number: 812, revision: 1, terminal: "superseded" });
+  add({ number: 812, revision: 2 });
+  telemetry.recordDirectOutcome({
+    ...supersededDirect,
+    claimGeneration: 1,
+    outcome: "superseded",
+    observedAt: admittedAt + 818,
+  });
+  telemetry.recordDirectOutcome({
+    ...acknowledgementPending,
+    claimGeneration: 1,
+    outcome: "fallback",
+    observedAt: admittedAt - 7 * 24 * 60 * 60 * 1_000 - 1,
+  });
+  add({
+    number: 813,
+    fenceKey: "openclaw/openclaw#813@publish:1",
+    receipt: "accepted",
+    terminal: "review_completed_routed",
+  });
+  add({
+    number: 814,
+    fenceKey: "openclaw/openclaw#814@publish:1",
+    receipt: "deduped",
+    terminal: "review_completed_routed",
+  });
+  add({
+    number: 815,
+    fenceKey: "openclaw/openclaw#815@publish:1",
+    receipt: "superseded",
+    terminal: "superseded",
+  });
+  const retryable = add({ number: 816, fenceKey: "openclaw/openclaw#816@publish:1" });
+  const permanent = add({ number: 817, fenceKey: "openclaw/openclaw#817@publish:1" });
+  telemetry.recordBatchOutcome({
+    batchId: "batch-816",
+    ...retryable,
+    claimGeneration: 1,
+    outcome: "retryable",
+    observedAt: admittedAt + 900,
+  });
+  telemetry.recordBatchOutcome({
+    batchId: "batch-817",
+    ...permanent,
+    claimGeneration: 1,
+    outcome: "permanent",
+    observedAt: admittedAt + 901,
+  });
+  telemetry.recordBatchOutcome({
+    batchId: "expired-batch-816",
+    ...retryable,
+    claimGeneration: 1,
+    outcome: "retryable",
+    observedAt: admittedAt - 7 * 24 * 60 * 60 * 1_000 - 1,
+  });
+  const expiredBatchReceipt = add({
+    number: 818,
+    fenceKey: "openclaw/openclaw#818@publish:1",
+  });
+  lifecycle.recordCanonicalReceipt({
+    ...expiredBatchReceipt,
+    outcome: "accepted",
+    receiptId: "expired-batch-receipt-818",
+    observedAt: admittedAt - 7 * 24 * 60 * 60 * 1_000 - 1,
+  });
+
+  const summary = telemetry.summary(admittedAt + 10_000);
+  assert.equal(summary.terminalCoverage.acknowledgementPendingRecords, 1);
+  assert.equal(summary.terminalCoverage.unknownTerminalRecords, 5);
+  assert.equal(summary.terminalCoverage.nonCurrentRecords, 2);
+  assert.equal(summary.terminalCoverage.terminalClasses.review_completed_routed, 3);
+  assert.equal(summary.terminalCoverage.terminalClasses.superseded, 2);
+  assert.equal(summary.publication.direct.accepted, 1);
+  assert.equal(summary.publication.direct.superseded, 1);
+  assert.equal(summary.publication.direct.fallback, 0);
+  assert.equal(summary.publication.direct.unknown, 2);
+  assert.deepEqual(summary.publication.batch, {
+    accepted: 1,
+    deduped: 1,
+    superseded: 1,
+    retryable: 1,
+    permanent: 1,
+  });
+  assert.equal(summary.publication.lifecycleRetries, 1);
+  assert.equal(summary.publication.lastSuccessfulCanonicalAcceptanceAt, admittedAt + 816);
+  assert.equal(JSON.stringify(summary).includes("openclaw/openclaw"), false);
 });
 
 test("full exact-review admission preserves production verdict publication capacity", () => {
@@ -3148,6 +3329,14 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
       ?.admission.deliveryId,
     "direct-publication-delivery:701",
   );
+  const directTelemetry = new ExactReviewLifecycleTelemetryStore(storage).summary(Date.now());
+  assert.deepEqual(directTelemetry.publication.direct, {
+    accepted: 1,
+    deduped: 1,
+    superseded: 0,
+    fallback: 1,
+    unknown: 0,
+  });
   const directState = (await storage.get("exact-review-queue")) as {
     items: Record<
       string,
@@ -3366,8 +3555,35 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     fence_key: batchLeased.key,
     state_commit_sha: null,
   });
+  assert.deepEqual(
+    new ExactReviewLifecycleTelemetryStore(storage).summary(Date.now()).publication.batch,
+    { accepted: 1, deduped: 1, superseded: 0, retryable: 0, permanent: 0 },
+  );
   const afterBatch = (await storage.get("exact-review-queue")) as typeof queueState;
   assert.equal(afterBatch.items[batchLeased.key]?.state, "pending");
+  const staleBatchCompletion = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/publication-batches/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        batch_id: "worker-publication-proof",
+        lease_owner: "proof-worker",
+        items: [
+          {
+            item_key: batchLeased.key,
+            revision: 4,
+            claim_generation: batchMember.claimGeneration,
+            terminal_outcome: "superseded",
+          },
+        ],
+      }),
+    }),
+  );
+  assert.equal(staleBatchCompletion.status, 200);
+  assert.equal((await staleBatchCompletion.json()).accepted, 1);
+  assert.deepEqual(
+    new ExactReviewLifecycleTelemetryStore(storage).summary(Date.now()).publication.batch,
+    { accepted: 1, deduped: 1, superseded: 1, retryable: 0, permanent: 0 },
+  );
 
   const recordUrl =
     "https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/items/701";
@@ -3439,6 +3655,106 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     max_bytes: 4 * 1024 * 1024,
     fallback_required: true,
   });
+});
+
+test("fetching a stale publication batch records a durable superseded telemetry outcome", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(719, "7190");
+  item.revision = 4;
+  item.leaseRevision = 4;
+  item.claimGeneration = 2;
+  item.state = "pending";
+  await storage.put("exact-review-queue", { deliveries: {}, items: { [item.key]: item } });
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1", EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "1" },
+  );
+  const claim = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/publication-batches/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          claim_id: "fetch-stale-telemetry-batch",
+          lease_owner: "fetch-stale-telemetry-owner",
+          max_items: 1,
+        }),
+      }),
+    )
+  ).json();
+  assert.equal(claim.claimed, true);
+  storage.sql.exec(
+    `INSERT INTO exact_review_publication_heads (target_key, source_revision, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(target_key) DO UPDATE SET source_revision = excluded.source_revision`,
+    "openclaw/openclaw#719",
+    2,
+    Date.now(),
+  );
+  const fetched = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/publication-batches/fetch", {
+      method: "POST",
+      body: JSON.stringify({
+        batch_id: "fetch-stale-telemetry-batch",
+        lease_owner: "fetch-stale-telemetry-owner",
+      }),
+    }),
+  );
+  assert.equal(fetched.status, 200);
+  const fetchedBody = (await fetched.json()) as { items: unknown[]; superseded: number };
+  assert.equal(fetchedBody.superseded, 1);
+  assert.deepEqual(fetchedBody.items, []);
+  assert.deepEqual(
+    new ExactReviewLifecycleTelemetryStore(storage).summary(Date.now()).publication.batch,
+    { accepted: 0, deduped: 0, superseded: 1, retryable: 0, permanent: 0 },
+  );
+});
+
+test("non-batch publication completions record durable terminal outcomes without inferring acceptance", async () => {
+  const storage = new MemoryDurableStorage();
+  const retryable = leasedExactReviewPublicationItem(720, "7200");
+  const permanent = leasedExactReviewPublicationItem(721, "7210");
+  const superseded = leasedExactReviewPublicationItem(722, "7220");
+  const published = leasedExactReviewPublicationItem(723, "7230");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: Object.fromEntries(
+      [retryable, permanent, superseded, published].map((item) => [item.key, item]),
+    ),
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+  const complete = async (
+    item: ExactReviewQueueItem,
+    outcome: "success" | "failure",
+    completionKind: string,
+    reasonCode: string,
+  ) => {
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: item.leaseId,
+          item_key: item.key,
+          lease_revision: item.leaseRevision,
+          claim_generation: item.claimGeneration,
+          run_id: item.claimedRunId,
+          run_attempt: item.claimedRunAttempt,
+          outcome,
+          completion_kind: completionKind,
+          reason_code: reasonCode,
+        }),
+      }),
+    );
+    assert.equal(response.status, 200);
+  };
+  await complete(retryable, "failure", "retryable_failure", "github_transient");
+  await complete(permanent, "failure", "permanent_failure", "invalid_artifact");
+  await complete(superseded, "success", "superseded", "remote_newer_tuple");
+  await complete(published, "success", "published", "publication_applied");
+
+  assert.deepEqual(
+    new ExactReviewLifecycleTelemetryStore(storage).summary(Date.now()).publication.batch,
+    { accepted: 0, deduped: 0, superseded: 1, retryable: 1, permanent: 1 },
+  );
 });
 
 test("direct lifecycle requeue becomes a fresh fenced source-drift revision", async () => {


### PR DESCRIPTION
## Summary

Implements #898 Workstream 3 as a producer-only Durable Object telemetry contract: `ExactReviewLifecycleTelemetryV1`.

- Derives terminal coverage from the existing lifecycle projection, with explicit durable-terminal, acknowledgement-pending, unknown-terminal, and non-current counts.
- Records server-observed direct outcomes and per-item publication terminal outcomes. Canonical accepted/deduped results remain receipts; a workflow success is never counted as a canonical acceptance.
- Retains event counters for seven days, reports only aggregate counts, and keeps identity only inside Durable Object event keys for idempotency.

## Problem

Actions/public item status can show a visible acknowledgement without proving the durable lifecycle is Completed. Operators need producer facts that distinguish a terminal lifecycle projection, an acknowledgement still pending observation, and unresolved/unknown work without treating workflow success as per-item lifecycle truth.

## Implementation

- Add `dashboard/exact-review-lifecycle-telemetry.ts`, the `ExactReviewLifecycleTelemetryV1` aggregate contract and bounded telemetry tables.
- Hook only existing queue publication paths in `dashboard/exact-review-queue.ts`: direct fallback/accepted/deduped/superseded outcomes; batch and non-batch retryable/permanent/superseded terminal outcomes; lifecycle receipt-derived accepted/deduped counts.
- Add controlled Worker coverage for acknowledgement-pending versus Completed, retention, direct outcomes, batch stale supersession (before fetch and before completion), and non-batch terminal completions.

## Real Behavior Proof

Claim: telemetry reports durable lifecycle facts, not Actions success or visible command status.

Exercised surface: an in-memory Durable Object Worker with signed direct publication results and fenced publication batch/complete routes.

Scenarios and observed results:

- A command-originated revision with a durable routed terminal remains `acknowledgementPending` until its acknowledgement is observed; it is not represented as Completed.
- Direct publication records fallback, accepted, deduped, and superseded facts. Batch receipt counters record accepted/deduped; terminal batch and normal completion paths record retryable/permanent/superseded facts exactly once.
- A batch made stale before fetch reports a durable superseded outcome. A successful non-batch `published` completion does **not** create a synthetic accepted result.
- Seven-day expiry is applied when reading outcome events and canonical batch receipts; aggregate output contains no target identities.

Commands and results:

```text
pnpm run build:dashboard
node --test --test-name-pattern "lifecycle telemetry counts durable terminal coverage|direct publication endpoint authenticates|fetching a stale publication batch|non-batch publication completions" test/dashboard-worker.test.ts
pnpm run lint:dashboard
pnpm run lint:scripts
node --test test/dashboard-worker.test.ts
```

All passed; the full Worker suite completed 290/290. `git diff --check` and targeted `oxfmt --check` passed.

### Controlled Linux/Docker current-head trace

Provider: Crabbox `local-container` on Linux Docker image `mcr.microsoft.com/playwright:v1.60.0-noble`; one-shot lease `cbx_8f5e8735cc4d` (automatically stopped). The script asserted the reviewed head before building the repair dependency and exercising the actual Worker/queue producer entrypoints. The redacted terminal trace was:

```text
CSW-087_HEAD=8920e416368a1c36db3aaf712b97f4dbcdd99c50
CSW-087_PROOF=direct-and-batch-producer-paths
v24.15.0
11.10.0
CRABBOX_PHASE:repair-build
$ tsc -p tsconfig.repair.json
CRABBOX_PHASE:producer-runtime
✔ lifecycle telemetry counts durable terminal coverage without treating acknowledgement pending as completed
✔ direct publication endpoint authenticates, dedupes, and returns a structured 413
✔ fetching a stale publication batch records a durable superseded telemetry outcome
✔ non-batch publication completions record durable terminal outcomes without inferring acceptance
ℹ tests 4
ℹ pass 4
ℹ fail 0
CSW-087_RESULT=producer-runtime-proof-passed
```

Limits: this is a controlled, isolated Docker proof of the current-head Worker/queue routes and durable-object storage behavior. It makes no production call, changes no queue/workflow authority, and adds no reader or public status surface.

## Review

- `codex review --uncommitted`: final closeout reported no correctness issues.
- `codex review --base origin/main`: no actionable correctness issues.
- Review findings led to retention-at-read filtering plus coverage of stale-before-fetch, stale-before-complete, and ordinary non-batch terminal completion paths.

## Scope and risks

This PR is deliberately not a consumer or presentation change. It adds no Bay/Overview UI, public status/API expansion, authenticated operator route, R2 scan/backfill/replay, workflow/queue authority change, Workstream 1/2 semantic change, deployment, gate change, merge, or automerge.

The aggregate contract is producer-only by design. A future exact per-revision operator reader needs separate maintainer approval and must stay authenticated, redacted, and outside Bay/public status semantics. Telemetry write failures are non-blocking and cannot change publication/lifecycle behavior.

Rebased on current `origin/main` at `8e620fc4fb3fe04761a8b0245b9e89cb553ebb5a` (#990); its batch post-effect workflow/test ordering is preserved.

Relates to #898, #947, #952, and #990.
