### PR TITLE
fix(review): suppress fresh exact hot-intake duplicates

### DIFF
--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -4463,6 +4463,7 @@ type HotIntakeExactReviewSnapshot = {
   sourceRevision: string;
   pullStateDigest: string;
   reviewActivityCursor: string;
+  itemUpdatedAt: string;
 };
 
 function hotIntakeExactReviewSnapshotFromReport(
@@ -4482,6 +4483,7 @@ function hotIntakeExactReviewSnapshotFromReport(
   const sourceRevision = review.itemSourceRevision?.trim();
   const pullStateDigest = frontMatterValue(review.markdown, "reviewed_pull_state_digest");
   const reviewActivityCursor = frontMatterValue(review.markdown, "review_activity_cursor");
+  const itemUpdatedAt = review.itemUpdatedAt?.trim();
   if (
     !headSha ||
     !sourceRevision ||
@@ -4489,19 +4491,27 @@ function hotIntakeExactReviewSnapshotFromReport(
     !pullStateDigest ||
     pullStateDigest === "unknown" ||
     pullStateDigest === "none" ||
-    !isReviewedPrActivityCursor(reviewActivityCursor)
+    !isReviewedPrActivityCursor(reviewActivityCursor) ||
+    !itemUpdatedAt
   ) {
     return null;
   }
-  return { headSha, sourceRevision, pullStateDigest, reviewActivityCursor };
+  return { headSha, sourceRevision, pullStateDigest, reviewActivityCursor, itemUpdatedAt };
 }
 
 function currentHotIntakePullReviewSnapshot(item: Item): HotIntakeExactReviewSnapshot | null {
   try {
+    const reviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+      fetchReviewedPrActivityCursor(item.number),
+    );
+    if (!reviewActivityCursor) return null;
+    const comments = ghPaged<unknown>(`repos/${item.repo}/issues/${item.number}/comments`);
     const pull = ghJson<unknown>(["api", `repos/${item.repo}/pulls/${item.number}`]);
     const source = asRecord(pull);
     const headSha = stringOrUndefined(asRecord(source.head).sha)?.trim().toLowerCase();
     if (!headSha) return null;
+    const itemUpdatedAt = stringOrUndefined(source.updated_at)?.trim();
+    if (!itemUpdatedAt) return null;
     const baseSha = stringOrUndefined(asRecord(source.base).sha)?.trim().toLowerCase();
     const draft = source.draft;
     const mergeable = source.mergeable;
@@ -4534,16 +4544,16 @@ function currentHotIntakePullReviewSnapshot(item: Item): HotIntakeExactReviewSna
       commitCount,
     });
     if (!pullStateDigest) return null;
-    const reviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+    const revalidatedReviewActivityCursor = readStableReviewedPrActivityCursor(() =>
       fetchReviewedPrActivityCursor(item.number),
     );
-    if (!reviewActivityCursor) return null;
-    const comments = ghPaged<unknown>(`repos/${item.repo}/issues/${item.number}/comments`);
+    if (revalidatedReviewActivityCursor !== reviewActivityCursor) return null;
     return {
       headSha,
       sourceRevision: itemSourceRevisionSha256(pull, comments),
       pullStateDigest,
       reviewActivityCursor,
+      itemUpdatedAt,
     };
   } catch (error) {
     console.error(
@@ -4584,6 +4594,11 @@ function shouldSkipScheduledHotIntakeExactReview(
   const current = currentHotIntakePullReviewSnapshot(item);
   return (
     current !== null &&
+    (current.itemUpdatedAt === reviewed.itemUpdatedAt ||
+      !hasUncapturedActivitySinceExactReview(
+        { ...item, updatedAt: current.itemUpdatedAt },
+        review,
+      )) &&
     current.headSha === reviewed.headSha &&
     current.sourceRevision === reviewed.sourceRevision &&
     current.pullStateDigest === reviewed.pullStateDigest &&
@@ -4602,6 +4617,7 @@ export function shouldSkipScheduledHotIntakeExactReviewForTest(options: {
   currentSourceRevision?: string;
   currentPullStateDigest?: string;
   currentReviewActivityCursor?: string;
+  currentItemUpdatedAt?: string;
   itemUpdatedAt?: string;
   reviewItemUpdatedAt?: string;
   reviewCommentSyncedAt?: string;
@@ -4632,11 +4648,17 @@ export function shouldSkipScheduledHotIntakeExactReviewForTest(options: {
     !options.currentHeadSha ||
     !options.currentSourceRevision ||
     !options.currentPullStateDigest ||
-    !options.currentReviewActivityCursor
+    !options.currentReviewActivityCursor ||
+    !options.currentItemUpdatedAt
   ) {
     return false;
   }
   return (
+    (options.currentItemUpdatedAt === reviewed.itemUpdatedAt ||
+      !hasUncapturedActivitySinceExactReview(
+        { kind: "pull_request", updatedAt: options.currentItemUpdatedAt } as Item,
+        review,
+      )) &&
     reviewed.headSha === options.currentHeadSha.trim().toLowerCase() &&
     reviewed.sourceRevision === options.currentSourceRevision.trim() &&
     reviewed.pullStateDigest === options.currentPullStateDigest.trim() &&

--- a/src/clawsweeper.ts
+++ b/src/clawsweeper.ts
@@ -73,6 +73,7 @@ import {
   reviewStructuralRecordMatchesHydratedPull,
   reviewStructuralRecordMatchesObservedUpdate,
   reviewStructuralRecordsDescribeSameVerdictInput,
+  reviewStructuralPullStateDigest,
   reviewStructuralQuery,
   reviewStructuralRecordFromGraphql,
   reviewStructuralCacheDecision,
@@ -112,6 +113,7 @@ import {
   schedulerBucket,
   selectDueCandidates,
   shouldReviewItem,
+  HOT_INTAKE_FRESHNESS_MS,
   WEEKLY_COVERAGE_REVIEW_DAYS,
 } from "./scheduler-policy.js";
 import {
@@ -1465,6 +1467,17 @@ function reviewPolicyHash(options: {
       schema: reviewDecisionSchemaText(),
     }),
   ).slice(0, 16);
+}
+
+export function reviewPolicyHashForTest(
+  options: {
+    model?: string;
+    reasoningEffort?: string;
+    sandboxMode?: string;
+    serviceTier?: string;
+  } = {},
+): string {
+  return reviewPolicyHash(options);
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -4445,6 +4458,192 @@ function dueCandidate(
   };
 }
 
+type HotIntakeExactReviewSnapshot = {
+  headSha: string;
+  sourceRevision: string;
+  pullStateDigest: string;
+  reviewActivityCursor: string;
+};
+
+function hotIntakeExactReviewSnapshotFromReport(
+  review: ExistingReview | null,
+  now: number,
+): HotIntakeExactReviewSnapshot | null {
+  if (review?.reviewStatus !== "complete" || !review.reviewedAt) return null;
+  const reviewedAt = Date.parse(review.reviewedAt);
+  if (
+    !Number.isFinite(reviewedAt) ||
+    now < reviewedAt ||
+    now - reviewedAt >= HOT_INTAKE_FRESHNESS_MS
+  ) {
+    return null;
+  }
+  const headSha = pullHeadShaFromReport(review.markdown)?.toLowerCase();
+  const sourceRevision = review.itemSourceRevision?.trim();
+  const pullStateDigest = frontMatterValue(review.markdown, "reviewed_pull_state_digest");
+  const reviewActivityCursor = frontMatterValue(review.markdown, "review_activity_cursor");
+  if (
+    !headSha ||
+    !sourceRevision ||
+    sourceRevision === "unknown" ||
+    !pullStateDigest ||
+    pullStateDigest === "unknown" ||
+    pullStateDigest === "none" ||
+    !isReviewedPrActivityCursor(reviewActivityCursor)
+  ) {
+    return null;
+  }
+  return { headSha, sourceRevision, pullStateDigest, reviewActivityCursor };
+}
+
+function currentHotIntakePullReviewSnapshot(item: Item): HotIntakeExactReviewSnapshot | null {
+  try {
+    const pull = ghJson<unknown>(["api", `repos/${item.repo}/pulls/${item.number}`]);
+    const source = asRecord(pull);
+    const headSha = stringOrUndefined(asRecord(source.head).sha)?.trim().toLowerCase();
+    if (!headSha) return null;
+    const baseSha = stringOrUndefined(asRecord(source.base).sha)?.trim().toLowerCase();
+    const draft = source.draft;
+    const mergeable = source.mergeable;
+    const mergeStateStatus = stringOrUndefined(source.mergeable_state);
+    const additions = githubCount(source.additions);
+    const deletions = githubCount(source.deletions);
+    const changedFiles = githubCount(source.changed_files);
+    const commitCount = githubCount(source.commits);
+    if (
+      !baseSha ||
+      typeof draft !== "boolean" ||
+      (mergeable !== null && typeof mergeable !== "boolean" && typeof mergeable !== "string") ||
+      !mergeStateStatus ||
+      additions === null ||
+      deletions === null ||
+      changedFiles === null ||
+      commitCount === null
+    ) {
+      return null;
+    }
+    const pullStateDigest = reviewStructuralPullStateDigest({
+      headSha,
+      baseSha,
+      draft,
+      mergeable,
+      mergeStateStatus,
+      additions,
+      deletions,
+      changedFiles,
+      commitCount,
+    });
+    if (!pullStateDigest) return null;
+    const reviewActivityCursor = readStableReviewedPrActivityCursor(() =>
+      fetchReviewedPrActivityCursor(item.number),
+    );
+    if (!reviewActivityCursor) return null;
+    const comments = ghPaged<unknown>(`repos/${item.repo}/issues/${item.number}/comments`);
+    return {
+      headSha,
+      sourceRevision: itemSourceRevisionSha256(pull, comments),
+      pullStateDigest,
+      reviewActivityCursor,
+    };
+  } catch (error) {
+    console.error(
+      `[plan] unable to verify fresh exact-review snapshot for ${item.repo}#${item.number}; leaving it eligible: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+function hasUncapturedActivitySinceExactReview(item: Item, review: ExistingReview): boolean {
+  const updatedAt = Date.parse(item.updatedAt);
+  const reviewedAt = review.reviewedAt ? Date.parse(review.reviewedAt) : Number.NaN;
+  if (!Number.isFinite(updatedAt) || !Number.isFinite(reviewedAt)) return true;
+  if (review.itemUpdatedAt && item.updatedAt === review.itemUpdatedAt) return false;
+  if (updatedAt <= reviewedAt) return false;
+  const reviewCommentSyncedAt = review.reviewCommentSyncedAt
+    ? Date.parse(review.reviewCommentSyncedAt)
+    : Number.NaN;
+  const labelsSyncedAt = review.labelsSyncedAt ? Date.parse(review.labelsSyncedAt) : Number.NaN;
+  const botOwnedSyncedAt = Math.max(
+    Number.isFinite(reviewCommentSyncedAt) ? reviewCommentSyncedAt : -Infinity,
+    Number.isFinite(labelsSyncedAt) ? labelsSyncedAt : -Infinity,
+  );
+  return !Number.isFinite(botOwnedSyncedAt) || updatedAt > botOwnedSyncedAt;
+}
+
+function shouldSkipScheduledHotIntakeExactReview(
+  item: Item,
+  review: ExistingReview | null,
+  now: number,
+  reviewPolicy: string,
+): boolean {
+  if (item.kind !== "pull_request") return false;
+  if (hasReviewPolicyMismatch(review, reviewPolicy)) return false;
+  if (!review || hasUncapturedActivitySinceExactReview(item, review)) return false;
+  const reviewed = hotIntakeExactReviewSnapshotFromReport(review, now);
+  if (!reviewed) return false;
+  const current = currentHotIntakePullReviewSnapshot(item);
+  return (
+    current !== null &&
+    current.headSha === reviewed.headSha &&
+    current.sourceRevision === reviewed.sourceRevision &&
+    current.pullStateDigest === reviewed.pullStateDigest &&
+    current.reviewActivityCursor === reviewed.reviewActivityCursor
+  );
+}
+
+export function shouldSkipScheduledHotIntakeExactReviewForTest(options: {
+  reviewStatus?: string;
+  reviewedAt?: string;
+  reviewHeadSha?: string;
+  reviewSourceRevision?: string;
+  reviewPullStateDigest?: string;
+  reviewActivityCursor?: string;
+  currentHeadSha?: string;
+  currentSourceRevision?: string;
+  currentPullStateDigest?: string;
+  currentReviewActivityCursor?: string;
+  itemUpdatedAt?: string;
+  reviewItemUpdatedAt?: string;
+  reviewCommentSyncedAt?: string;
+  labelsSyncedAt?: string;
+  reviewPolicy?: string;
+  currentReviewPolicy?: string;
+  now: number;
+}): boolean {
+  const review = {
+    reviewStatus: options.reviewStatus,
+    reviewedAt: options.reviewedAt,
+    markdown: `---\npull_head_sha: ${options.reviewHeadSha ?? "unknown"}\nreviewed_pull_state_digest: ${options.reviewPullStateDigest ?? "unknown"}\nreview_activity_cursor: ${options.reviewActivityCursor ?? "unknown"}\n---\n`,
+    itemSourceRevision: options.reviewSourceRevision,
+    reviewPolicy: options.reviewPolicy,
+    itemUpdatedAt: options.reviewItemUpdatedAt,
+    reviewCommentSyncedAt: options.reviewCommentSyncedAt,
+    labelsSyncedAt: options.labelsSyncedAt,
+  } as ExistingReview;
+  if (hasReviewPolicyMismatch(review, options.currentReviewPolicy)) return false;
+  const item = {
+    kind: "pull_request",
+    updatedAt: options.itemUpdatedAt ?? options.reviewedAt ?? "",
+  } as Item;
+  if (hasUncapturedActivitySinceExactReview(item, review)) return false;
+  const reviewed = hotIntakeExactReviewSnapshotFromReport(review, options.now);
+  if (
+    !reviewed ||
+    !options.currentHeadSha ||
+    !options.currentSourceRevision ||
+    !options.currentPullStateDigest ||
+    !options.currentReviewActivityCursor
+  ) {
+    return false;
+  }
+  return (
+    reviewed.headSha === options.currentHeadSha.trim().toLowerCase() &&
+    reviewed.sourceRevision === options.currentSourceRevision.trim() &&
+    reviewed.pullStateDigest === options.currentPullStateDigest.trim() &&
+    reviewed.reviewActivityCursor === options.currentReviewActivityCursor.trim()
+  );
+}
+
 function reviewBackfillCandidate(
   item: Item,
   itemsDir: string,
@@ -5133,7 +5332,12 @@ function planCandidates(options: {
         reviewIndex,
         options.coverageTrackedItemIds,
       );
-      if (candidate) due.push(candidate);
+      if (
+        candidate &&
+        !shouldSkipScheduledHotIntakeExactReview(item, candidate.review, now, options.reviewPolicy)
+      ) {
+        due.push(candidate);
+      }
     }
     const selected = selectDueCandidates(due, capacity, compareHotIntakeDueCandidates, now);
     const candidates = selected.map(({ item }) => item);
@@ -15284,6 +15488,7 @@ function markdownFor(options: {
   const configSurfaceChange = configSurfaceChangeFromContext(options.item.repo, options.context);
   const dataModelChange = dataModelChangeFromContext(options.item.repo, options.context);
   const prSurfaceFiles = prSurfaceFilesFromContext(options.context);
+  const reviewedPullStateDigest = reviewStructuralPullStateFromContext(options.context);
   return `---
 number: ${options.item.number}
 repository: ${options.item.repo}
@@ -15302,6 +15507,11 @@ review_lease_owner: ${options.reviewLeaseOwner ?? "unknown"}
 review_lease_comment_id: ${options.reviewLeaseCommentId ?? "unknown"}
 main_sha: ${options.git.mainSha}
 pull_head_sha: ${pullHeadShaFromContext(options.context) ?? "unknown"}
+reviewed_pull_state_digest: ${
+    reviewedPullStateDigest
+      ? (reviewStructuralPullStateDigest(reviewedPullStateDigest) ?? "unknown")
+      : "unknown"
+  }
 latest_release: ${options.git.latestRelease?.tagName ?? "unknown"}
 latest_release_sha: ${options.git.latestRelease?.sha ?? "unknown"}
 fixed_release: ${options.decision.fixedRelease ?? "unknown"}

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -46,6 +46,10 @@ export interface SchedulerDueCandidate<
 const HOT_REVIEW_DAYS = 7;
 const RECENT_ISSUE_DAYS = 30;
 const HOURLY_REVIEW_MS = 60 * 60 * 1000;
+// Hot-intake activity is eligible again after this existing hourly cadence. Keep
+// exact-review suppression inside the same window so it only coalesces the
+// immediate scheduled follow-up, rather than changing normal review cadence.
+export const HOT_INTAKE_FRESHNESS_MS = HOURLY_REVIEW_MS;
 const DAILY_REVIEW_DAYS = 1;
 const WEEKLY_REVIEW_DAYS = 7;
 export const WEEKLY_COVERAGE_REVIEW_DAYS = 6;

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -36,7 +36,6 @@ import {
   runtimeBudgetExceeded,
   safeOutputTail,
   shardItemNumbers,
-  shouldSkipScheduledHotIntakeExactReviewForTest,
   shouldSyncReviewComment,
   shouldRetryGh,
   timeoutWithinRuntimeBudget,
@@ -81,81 +80,6 @@ const maintainerDecision = {
     confidence: "high",
   },
 };
-
-test("CSW-088 suppresses only the immediate same-head and same-body hot-intake review", () => {
-  const reviewedAt = "2026-07-31T02:25:10.000Z";
-  const now = Date.parse("2026-07-31T02:30:00.000Z");
-  const head = "0a3959fe0123456789abcdef0123456789abcdef";
-  const sourceRevision = "4055368d78b5997d42460145ba92e74397576bb4b0aaf91bb063725f2f1cb63d";
-  const pullStateDigest = "b".repeat(64);
-  const reviewActivityCursor = `v1:0:${"c".repeat(64)}`;
-  const sameSnapshot = {
-    reviewStatus: "complete",
-    reviewedAt,
-    reviewHeadSha: head,
-    reviewSourceRevision: sourceRevision,
-    reviewPullStateDigest: pullStateDigest,
-    reviewActivityCursor,
-    currentHeadSha: head.toUpperCase(),
-    currentSourceRevision: sourceRevision,
-    currentPullStateDigest: pullStateDigest,
-    currentReviewActivityCursor: reviewActivityCursor,
-    itemUpdatedAt: reviewedAt,
-    now,
-  };
-
-  assert.equal(shouldSkipScheduledHotIntakeExactReviewForTest(sameSnapshot), true);
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      currentHeadSha: "f".repeat(40),
-    }),
-    false,
-  );
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      currentSourceRevision: "a".repeat(64),
-    }),
-    false,
-  );
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      currentPullStateDigest: "c".repeat(64),
-    }),
-    false,
-  );
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      currentReviewActivityCursor: `v1:1:${"d".repeat(64)}`,
-    }),
-    false,
-  );
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      itemUpdatedAt: new Date(Date.parse(reviewedAt) + 1).toISOString(),
-    }),
-    false,
-  );
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      now: Date.parse(reviewedAt) + 60 * 60 * 1000,
-    }),
-    false,
-  );
-  assert.equal(
-    shouldSkipScheduledHotIntakeExactReviewForTest({
-      ...sameSnapshot,
-      reviewPolicy: "previous-policy",
-      currentReviewPolicy: "current-policy",
-    }),
-    false,
-  );
-});
 
 test("review comments include a compact maintainer decision packet block", () => {
   const comment = renderReviewCommentFromReport(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -36,6 +36,7 @@ import {
   runtimeBudgetExceeded,
   safeOutputTail,
   shardItemNumbers,
+  shouldSkipScheduledHotIntakeExactReviewForTest,
   shouldSyncReviewComment,
   shouldRetryGh,
   timeoutWithinRuntimeBudget,
@@ -80,6 +81,81 @@ const maintainerDecision = {
     confidence: "high",
   },
 };
+
+test("CSW-088 suppresses only the immediate same-head and same-body hot-intake review", () => {
+  const reviewedAt = "2026-07-31T02:25:10.000Z";
+  const now = Date.parse("2026-07-31T02:30:00.000Z");
+  const head = "0a3959fe0123456789abcdef0123456789abcdef";
+  const sourceRevision = "4055368d78b5997d42460145ba92e74397576bb4b0aaf91bb063725f2f1cb63d";
+  const pullStateDigest = "b".repeat(64);
+  const reviewActivityCursor = `v1:0:${"c".repeat(64)}`;
+  const sameSnapshot = {
+    reviewStatus: "complete",
+    reviewedAt,
+    reviewHeadSha: head,
+    reviewSourceRevision: sourceRevision,
+    reviewPullStateDigest: pullStateDigest,
+    reviewActivityCursor,
+    currentHeadSha: head.toUpperCase(),
+    currentSourceRevision: sourceRevision,
+    currentPullStateDigest: pullStateDigest,
+    currentReviewActivityCursor: reviewActivityCursor,
+    itemUpdatedAt: reviewedAt,
+    now,
+  };
+
+  assert.equal(shouldSkipScheduledHotIntakeExactReviewForTest(sameSnapshot), true);
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentHeadSha: "f".repeat(40),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentSourceRevision: "a".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentPullStateDigest: "c".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentReviewActivityCursor: `v1:1:${"d".repeat(64)}`,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      itemUpdatedAt: new Date(Date.parse(reviewedAt) + 1).toISOString(),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      now: Date.parse(reviewedAt) + 60 * 60 * 1000,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      reviewPolicy: "previous-policy",
+      currentReviewPolicy: "current-policy",
+    }),
+    false,
+  );
+});
 
 test("review comments include a compact maintainer decision packet block", () => {
   const comment = renderReviewCommentFromReport(

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -100,7 +100,7 @@ test("local exact reviews default to item-specific artifacts", () => {
   assert.equal(defaultReviewArtifactDirForTest(false, 357, undefined), "artifacts/reviews");
 });
 
-test("CSW-088 scheduled hot planning suppresses #117063 while explicit re-review remains eligible", () => {
+test("CSW-088 scheduled hot planning suppresses #117063, observes an in-flight update, and leaves explicit re-review eligible", () => {
   const root = mkdtempSync(join(tmpdir(), "cmd-csw-088-"));
   const binDir = join(root, "bin");
   const itemsDir = join(root, "items");
@@ -123,6 +123,12 @@ test("CSW-088 scheduled hot planning suppresses #117063 while explicit re-review
     deletions: 2,
     changed_files: 2,
     commits: 1,
+    updated_at: reviewedAt,
+  };
+  const updatedPull = { ...pull, body: "The PR body changed during the snapshot read." };
+  const commentUpdatedPull = {
+    ...pull,
+    updated_at: new Date(Date.parse(reviewedAt) + 1).toISOString(),
   };
   const issue = {
     number,
@@ -177,6 +183,7 @@ test("CSW-088 scheduled hot planning suppresses #117063 while explicit re-review
         title: pull.title,
         reviewed_at: reviewedAt,
         review_policy: reviewPolicyHashForTest(),
+        item_updated_at: reviewedAt,
         item_source_revision: sourceRevision,
         pull_head_sha: headSha,
         reviewed_pull_state_digest: pullStateDigest,
@@ -198,6 +205,15 @@ const path = args[1] || "";
 const listItem = ${JSON.stringify(listItem)};
 const issue = ${JSON.stringify(issue)};
 const pull = ${JSON.stringify(pull)};
+const updatedPull = ${JSON.stringify(updatedPull)};
+const commentUpdatedPull = ${JSON.stringify(commentUpdatedPull)};
+const raceMarker = process.env.CSW_RACE_MARKER;
+const race = process.env.CSW_RACE === "1";
+const activityRaceMarker = process.env.CSW_ACTIVITY_RACE_MARKER;
+const activityRace = process.env.CSW_ACTIVITY_RACE === "1";
+const commentRaceMarker = process.env.CSW_COMMENT_RACE_MARKER;
+const commentRace = process.env.CSW_COMMENT_RACE === "1";
+const updatedReview = { id: 1, user: { login: "reviewer" }, state: "COMMENTED", body: "new review activity", submitted_at: "2026-07-31T00:00:00Z", commit_id: pull.head.sha };
 if (args[0] === "api" && /issues\\?state=open/.test(path)) {
   console.log(JSON.stringify(listItem));
   process.exit(0);
@@ -207,15 +223,22 @@ if (args[0] === "api" && path === "repos/openclaw/openclaw/issues/${number}") {
   process.exit(0);
 }
 if (args[0] === "api" && path === "repos/openclaw/openclaw/pulls/${number}") {
-  console.log(JSON.stringify(pull));
+  if (activityRace && activityRaceMarker) require("node:fs").writeFileSync(activityRaceMarker, "seen");
+  console.log(JSON.stringify(race && raceMarker && require("node:fs").existsSync(raceMarker) ? updatedPull : commentRace && commentRaceMarker && require("node:fs").existsSync(commentRaceMarker) ? commentUpdatedPull : pull));
   process.exit(0);
 }
-if (args[0] === "api" && /(issues|pulls)\\/${number}\\/comments/.test(path)) {
+if (args[0] === "api" && path.startsWith("repos/openclaw/openclaw/issues/${number}/comments")) {
+  if (commentRace && commentRaceMarker) require("node:fs").writeFileSync(commentRaceMarker, "seen");
+  console.log(JSON.stringify([[]]));
+  process.exit(0);
+}
+if (args[0] === "api" && path.startsWith("repos/openclaw/openclaw/pulls/${number}/comments")) {
+  if (race && raceMarker) require("node:fs").writeFileSync(raceMarker, "seen");
   console.log(JSON.stringify([[]]));
   process.exit(0);
 }
 if (args[0] === "api" && /pulls\\/${number}\\/reviews/.test(path)) {
-  console.log(JSON.stringify([[]]));
+  console.log(JSON.stringify(activityRace && activityRaceMarker && require("node:fs").existsSync(activityRaceMarker) ? [[updatedReview]] : [[]]));
   process.exit(0);
 }
 console.error("unexpected gh args " + JSON.stringify(args));
@@ -247,6 +270,105 @@ process.exit(1);
     );
     assert.equal(scheduled.status, 0, scheduled.stderr);
     assert.deepEqual(JSON.parse(scheduled.stdout).candidates, []);
+
+    const raced = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "plan",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--coverage-tracked-items-manifest",
+        coverageManifest,
+        "--hot-intake",
+        "--max-pages",
+        "1",
+        "--batch-size",
+        "1",
+        "--shard-count",
+        "1",
+      ],
+      { encoding: "utf8", env: { ...env, CSW_RACE: "1", CSW_RACE_MARKER: join(root, "race") } },
+    );
+    assert.equal(raced.status, 0, raced.stderr);
+    assert.deepEqual(
+      JSON.parse(raced.stdout).candidates.map((candidate: { number: number }) => candidate.number),
+      [number],
+    );
+
+    const commentRaced = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "plan",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--coverage-tracked-items-manifest",
+        coverageManifest,
+        "--hot-intake",
+        "--max-pages",
+        "1",
+        "--batch-size",
+        "1",
+        "--shard-count",
+        "1",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...env,
+          CSW_COMMENT_RACE: "1",
+          CSW_COMMENT_RACE_MARKER: join(root, "comment-race"),
+        },
+      },
+    );
+    assert.equal(commentRaced.status, 0, commentRaced.stderr);
+    assert.deepEqual(
+      JSON.parse(commentRaced.stdout).candidates.map(
+        (candidate: { number: number }) => candidate.number,
+      ),
+      [number],
+    );
+
+    const activityRaced = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "plan",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--coverage-tracked-items-manifest",
+        coverageManifest,
+        "--hot-intake",
+        "--max-pages",
+        "1",
+        "--batch-size",
+        "1",
+        "--shard-count",
+        "1",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...env,
+          CSW_ACTIVITY_RACE: "1",
+          CSW_ACTIVITY_RACE_MARKER: join(root, "activity-race"),
+        },
+      },
+    );
+    assert.equal(activityRaced.status, 0, activityRaced.stderr);
+    assert.deepEqual(
+      JSON.parse(activityRaced.stdout).candidates.map(
+        (candidate: { number: number }) => candidate.number,
+      ),
+      [number],
+    );
 
     const explicit = spawnSync(
       process.execPath,

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -17,12 +17,15 @@ import { fileURLToPath } from "node:url";
 import {
   defaultReviewArtifactDirForTest,
   exactEventReviewLeaseDispositionForTest,
+  itemSourceRevisionSha256ForTest,
   isSuppliedReviewStartLeaseForTest,
   prepareManagedLocalReviewCheckoutForTest,
+  reviewPolicyHashForTest,
   reviewLeaseStillMatchesContextForTest,
 } from "../dist/clawsweeper.js";
 import { runText, UserFacingCommandError } from "../dist/command.js";
-import { mockGhBinEnv } from "./helpers.ts";
+import { reviewStructuralPullStateDigest } from "../dist/review-structural-cache.js";
+import { mockGhBinEnv, workPlanCandidateReport } from "./helpers.ts";
 
 const CLI = fileURLToPath(new URL("../dist/clawsweeper.js", import.meta.url));
 
@@ -95,6 +98,180 @@ test("local exact reviews default to item-specific artifacts", () => {
   assert.equal(defaultReviewArtifactDirForTest(true, 357, undefined), "artifacts/local-review-357");
   assert.equal(defaultReviewArtifactDirForTest(true, 357, [357]), "artifacts/reviews");
   assert.equal(defaultReviewArtifactDirForTest(false, 357, undefined), "artifacts/reviews");
+});
+
+test("CSW-088 scheduled hot planning suppresses #117063 while explicit re-review remains eligible", () => {
+  const root = mkdtempSync(join(tmpdir(), "cmd-csw-088-"));
+  const binDir = join(root, "bin");
+  const itemsDir = join(root, "items");
+  const coverageManifest = join(root, "coverage.json");
+  const ghPath = join(binDir, "gh.js");
+  const number = 117063;
+  const headSha = "0a3959fe0123456789abcdef0123456789abcdef";
+  const reviewedAt = new Date().toISOString();
+  const pull = {
+    number,
+    title: "CSW-088 scheduled hot review fixture",
+    body: "The reviewed PR body is unchanged.",
+    labels: ["needs-review"],
+    head: { sha: headSha },
+    base: { sha: "b".repeat(40) },
+    draft: false,
+    mergeable: true,
+    mergeable_state: "clean",
+    additions: 5,
+    deletions: 2,
+    changed_files: 2,
+    commits: 1,
+  };
+  const issue = {
+    number,
+    title: pull.title,
+    body: pull.body,
+    html_url: `https://github.com/openclaw/openclaw/pull/${number}`,
+    created_at: "2026-07-30T00:00:00Z",
+    updated_at: reviewedAt,
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "contributor" },
+    labels: pull.labels,
+    pull_request: {},
+  };
+  const listItem = {
+    number,
+    title: pull.title,
+    html_url: issue.html_url,
+    created_at: issue.created_at,
+    updated_at: issue.updated_at,
+    author_association: issue.author_association,
+    user: issue.user,
+    labels: issue.labels,
+    pull_request: {},
+  };
+  const sourceRevision = itemSourceRevisionSha256ForTest(pull, []);
+  const pullStateDigest = reviewStructuralPullStateDigest({
+    headSha,
+    baseSha: pull.base.sha,
+    draft: pull.draft,
+    mergeable: pull.mergeable,
+    mergeStateStatus: pull.mergeable_state,
+    additions: pull.additions,
+    deletions: pull.deletions,
+    changedFiles: pull.changed_files,
+    commitCount: pull.commits,
+  });
+  assert.ok(pullStateDigest);
+
+  try {
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(itemsDir, { recursive: true });
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      workPlanCandidateReport({
+        repository: "openclaw/openclaw",
+        type: "pull_request",
+        number,
+        title: pull.title,
+        reviewed_at: reviewedAt,
+        review_policy: reviewPolicyHashForTest(),
+        item_source_revision: sourceRevision,
+        pull_head_sha: headSha,
+        reviewed_pull_state_digest: pullStateDigest,
+      }),
+    );
+    writeFileSync(
+      coverageManifest,
+      JSON.stringify({
+        schemaVersion: 3,
+        source: "worker",
+        repositories: { "openclaw-openclaw": { coverageTrackedItemIds: [] } },
+      }),
+    );
+    writeFileSync(
+      ghPath,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const path = args[1] || "";
+const listItem = ${JSON.stringify(listItem)};
+const issue = ${JSON.stringify(issue)};
+const pull = ${JSON.stringify(pull)};
+if (args[0] === "api" && /issues\\?state=open/.test(path)) {
+  console.log(JSON.stringify(listItem));
+  process.exit(0);
+}
+if (args[0] === "api" && path === "repos/openclaw/openclaw/issues/${number}") {
+  console.log(JSON.stringify(issue));
+  process.exit(0);
+}
+if (args[0] === "api" && path === "repos/openclaw/openclaw/pulls/${number}") {
+  console.log(JSON.stringify(pull));
+  process.exit(0);
+}
+if (args[0] === "api" && /(issues|pulls)\\/${number}\\/comments/.test(path)) {
+  console.log(JSON.stringify([[]]));
+  process.exit(0);
+}
+if (args[0] === "api" && /pulls\\/${number}\\/reviews/.test(path)) {
+  console.log(JSON.stringify([[]]));
+  process.exit(0);
+}
+console.error("unexpected gh args " + JSON.stringify(args));
+process.exit(1);
+`,
+    );
+    chmodSync(ghPath, 0o755);
+    const env = { ...process.env, ...mockGhBinEnv(ghPath) };
+    const scheduled = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "plan",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--coverage-tracked-items-manifest",
+        coverageManifest,
+        "--hot-intake",
+        "--max-pages",
+        "1",
+        "--batch-size",
+        "1",
+        "--shard-count",
+        "1",
+      ],
+      { encoding: "utf8", env },
+    );
+    assert.equal(scheduled.status, 0, scheduled.stderr);
+    assert.deepEqual(JSON.parse(scheduled.stdout).candidates, []);
+
+    const explicit = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "plan",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--item-number",
+        String(number),
+      ],
+      { encoding: "utf8", env },
+    );
+    assert.equal(explicit.status, 0, explicit.stderr);
+    assert.deepEqual(
+      JSON.parse(explicit.stdout).candidates.map(
+        (candidate: { number: number }) => candidate.number,
+      ),
+      [number],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("exact event publication requeues legacy tuples and source drift before mutation", () => {

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -8,6 +8,7 @@ import {
   selectDueCandidates,
   shouldReviewItem,
 } from "../dist/scheduler-policy.js";
+import { shouldSkipScheduledHotIntakeExactReviewForTest } from "../dist/clawsweeper.js";
 import { item } from "./helpers.ts";
 
 function schedulerCandidate(candidate) {
@@ -714,5 +715,80 @@ test("hot intake recency prefers newly updated or created issues", () => {
       }),
     ),
     Date.parse("2026-04-29T22:30:00Z"),
+  );
+});
+
+test("CSW-088 suppresses only the immediate same-head and same-body hot-intake review", () => {
+  const reviewedAt = "2026-07-31T02:25:10.000Z";
+  const now = Date.parse("2026-07-31T02:30:00.000Z");
+  const head = "0a3959fe0123456789abcdef0123456789abcdef";
+  const sourceRevision = "4055368d78b5997d42460145ba92e74397576bb4b0aaf91bb063725f2f1cb63d";
+  const pullStateDigest = "b".repeat(64);
+  const reviewActivityCursor = `v1:0:${"c".repeat(64)}`;
+  const sameSnapshot = {
+    reviewStatus: "complete",
+    reviewedAt,
+    reviewHeadSha: head,
+    reviewSourceRevision: sourceRevision,
+    reviewPullStateDigest: pullStateDigest,
+    reviewActivityCursor,
+    currentHeadSha: head.toUpperCase(),
+    currentSourceRevision: sourceRevision,
+    currentPullStateDigest: pullStateDigest,
+    currentReviewActivityCursor: reviewActivityCursor,
+    itemUpdatedAt: reviewedAt,
+    now,
+  };
+
+  assert.equal(shouldSkipScheduledHotIntakeExactReviewForTest(sameSnapshot), true);
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentHeadSha: "f".repeat(40),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentSourceRevision: "a".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentPullStateDigest: "c".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentReviewActivityCursor: `v1:1:${"d".repeat(64)}`,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      itemUpdatedAt: new Date(Date.parse(reviewedAt) + 1).toISOString(),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      now: Date.parse(reviewedAt) + 60 * 60 * 1000,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      reviewPolicy: "previous-policy",
+      currentReviewPolicy: "current-policy",
+    }),
+    false,
   );
 });

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -737,6 +737,8 @@ test("CSW-088 suppresses only the immediate same-head and same-body hot-intake r
     currentPullStateDigest: pullStateDigest,
     currentReviewActivityCursor: reviewActivityCursor,
     itemUpdatedAt: reviewedAt,
+    reviewItemUpdatedAt: reviewedAt,
+    currentItemUpdatedAt: reviewedAt,
     now,
   };
 
@@ -768,6 +770,21 @@ test("CSW-088 suppresses only the immediate same-head and same-body hot-intake r
       currentReviewActivityCursor: `v1:1:${"d".repeat(64)}`,
     }),
     false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentItemUpdatedAt: new Date(Date.parse(reviewedAt) + 1).toISOString(),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSkipScheduledHotIntakeExactReviewForTest({
+      ...sameSnapshot,
+      currentItemUpdatedAt: new Date(Date.parse(reviewedAt) + 1).toISOString(),
+      reviewCommentSyncedAt: new Date(Date.parse(reviewedAt) + 1).toISOString(),
+    }),
+    true,
   );
   assert.equal(
     shouldSkipScheduledHotIntakeExactReviewForTest({


### PR DESCRIPTION
## Summary

Prevent the scheduled hot-intake planner from immediately starting a second review for a freshly completed exact review of the same OpenClaw PR state.

## Problem

OpenClaw PR #117063 showed multiple recent ClawSweeper review-start comments despite one observed merge-related event. The hot scheduler could select a PR again immediately after an exact review because it did not confirm that the persisted review still matched the live PR head, relevant source/body state, structural pull state, and review activity.

## Implementation

- Suppress only a fresh, completed scheduled hot-intake review whose persisted exact snapshot still matches.
- Fence the snapshot with stable review-activity reads and the final pull `updated_at`; unknown or changed state fails open and remains eligible.
- Preserve explicit re-review routes, normal cadence, capacity/selection ordering, leases/claims, and all routing/workflow behavior.
- Keep the pure snapshot assertions in `test/scheduler-policy.test.ts`; retain the CLI integration scenario in `test/command.test.ts`.
- Rebased deliberately onto #993 / `8fd1140e7aa97790513afaab43eba4dd1085f85a`, preserving its planner refactor and source-revision helpers while applying the exact-snapshot guard at the current planner boundary.

## Validation

- `pnpm run build` — passed.
- `node --test --test-name-pattern "CSW-088" test/scheduler-policy.test.ts test/command.test.ts` — 2 passed.
- `pnpm run lint` — passed.
- `pnpm exec oxfmt --check src/clawsweeper.ts src/scheduler-policy.ts test/command.test.ts test/scheduler-policy.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `pnpm run format:check` reports 541 repository-wide formatter findings already present on rebased main/#993; no unrelated reformat is included here.

## Real Behavior Proof

- Claim: a freshly completed exact review of the same PR state is omitted from scheduled hot intake; a changed in-flight snapshot and an explicit re-review route remain eligible.
- Surface: the built `clawsweeper plan --hot-intake` CLI, exercised through the #117063-shaped integration fixture in `test/command.test.ts`.
- Scenario / fixture: a completed persisted record matches head, `item_updated_at`, source revision, structural pull-state digest, and review-activity cursor. The same controlled run then changes the body during snapshot reads, changes ordinary comment activity, and invokes the explicit item route.
- Command / environment: current head `54e6e4786cfa90be3a51e307e49ad9488a7a3247`; Docker-backed Crabbox Linux `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_40c99cfc0573`; Node `v24.15.0`, Corepack pnpm `11.10.0`; `corepack pnpm install --frozen-lockfile`, `corepack pnpm run build`, then `node --test --test-name-pattern 'CSW-088 scheduled hot planning suppresses #117063' test/command.test.ts`.
- Observed result: the matching scheduled snapshot returned no candidate; each changed-snapshot case returned #117063; the explicit route returned #117063. One test passed, exit code 0, with `CSW_088_REBASED_PROOF=PASS`.
- Artifact / trace: Crabbox lease `cbx_40c99cfc0573`, provider `local-container`, synced 645 files / 24.1 MiB; command phases install 8.262s, build 1.562s, proof 2.821s; total 19.734s.
- Limits: controlled, read-only CLI proof; it does not mutate GitHub or execute a live scheduled workflow.

## Codex Review Closeout

- `codex review --uncommitted` — no staged, unstaged, or untracked changes after the clean rebase.
- `codex review --base origin/main` — clean: “No actionable correctness issues were identified in the diff.”

## Accepted Residual Risks

The maintainer accepted these bounded external-snapshot and scheduling limits for this narrow PR; no further probe, routing, capacity, or selection change is included:

- A change that lands in the final non-atomic external-read tail can defer its hot-intake follow-up by at most one hot cycle.
- A fresh legacy report absent from the Worker coverage manifest can defer canonical coverage restoration by at most one hot cycle.
- A check-only change during a bot-owned update can defer the next follow-up by at most one hot cycle.

These cases do not create a stale review effect, completion, or data loss; the next hot cycle remains eligible.

## Links

- CSW-088 audit target: https://github.com/openclaw/openclaw/pull/117063
- Related lifecycle ordering fix: https://github.com/openclaw/clawsweeper/pull/990
- Rebase base: https://github.com/openclaw/clawsweeper/pull/993
