### PR TITLE
fix: keep Codex package operations from installing Git hooks

### DIFF
--- a/src/repair/fix-prompt-builder.test.ts
+++ b/src/repair/fix-prompt-builder.test.ts
@@ -103,7 +103,7 @@ test("fix prompt makes Codex own the validation loop", () => {
   assert.match(prompt, /use one repair loop against the pinned base/);
   assert.match(prompt, /use the dependency toolchain ClawSweeper already prepared/);
   assert.match(prompt, /never run an unrestricted package-manager install/);
-  assert.match(prompt, /use --ignore-scripts/);
+  assert.match(prompt, /every package-manager install or deploy must include --ignore-scripts/);
   assert.match(prompt, /never change core\.hooksPath/);
   assert.doesNotMatch(prompt, /always fetch latest origin\/main/);
   assert.match(prompt, /run the changed-surface validation in this checkout before returning/);

--- a/src/repair/fix-prompt-builder.ts
+++ b/src/repair/fix-prompt-builder.ts
@@ -42,7 +42,7 @@ export function buildFixPrompt({
     "- after validation passes against the pinned base, return the repair; ClawSweeper performs one deterministic final base sync, then exact-head review and GitHub checks provide the final proof;",
     "- keep built runtime outputs needed for validation, but place generated archives under TMPDIR and remove checkout-local temporary archives or incremental validation caches you created before returning; independent validation must preserve the target checkout identity;",
     "- run local git status/diff/log/rebase/merge commands needed to reconcile this branch with the pinned base;",
-    "- use the dependency toolchain ClawSweeper already prepared; never run an unrestricted package-manager install, hook installer, git config, or git config write; if an installation is unavoidable, use --ignore-scripts and never change core.hooksPath or other Git callback settings;",
+    "- use the dependency toolchain ClawSweeper already prepared; never run an unrestricted package-manager install, hook installer, git config, or git config write; every package-manager install or deploy must include --ignore-scripts; never change core.hooksPath or other Git callback settings;",
     "- when git conflicts exist, resolve every conflict marker and leave the checkout in a normal non-rebasing state;",
     "- use one repair loop against the pinned base: inspect review comments and failing checks, make the narrowest fix, run validation, and repeat only for actionable failures until the branch is merge-ready or a concrete external blocker is proven;",
     "- preserve contributor credit in the PR body or commit history; edit a changelog only when the artifact explicitly requires it and repository policy permits it;",

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -1,6 +1,11 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { codexLoginConfig, codexModelArgs, internalCodexModel } from "../codex-env.js";
 
 export { codexLoginConfig, codexModelArgs, internalCodexModel };
+
+const guardedBunDirectories = new Map<string, string>();
 
 export function ghCliEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return withoutColor({ ...process.env, ...overrides });
@@ -15,8 +20,18 @@ export function codexSubprocessEnv(): NodeJS.ProcessEnv {
     ...process.env,
     ...clawsweeperGitIdentityEnv(),
     PNPM_CONFIG_IGNORE_SCRIPTS: "true",
+    PNPM_CONFIG_IGNORE_PNPMFILE: "true",
     npm_config_ignore_scripts: "true",
   };
+  const bunExecutable = findExecutable("bun", env.PATH);
+  if (bunExecutable) {
+    if (process.platform === "win32") {
+      throw new Error(
+        "Bun repair execution requires a Linux runner; refusing unsafe lifecycle scripts",
+      );
+    }
+    env.PATH = `${guardedBunDirectory(bunExecutable)}${path.delimiter}${env.PATH ?? ""}`;
+  }
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN;
@@ -77,4 +92,71 @@ function withoutColor(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   env.CLICOLOR = "0";
   delete env.FORCE_COLOR;
   return env;
+}
+
+function findExecutable(name: string, searchPath: string | undefined): string | null {
+  if (!searchPath) return null;
+  const extensions =
+    process.platform === "win32"
+      ? ["", ...(process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").toLowerCase().split(";")]
+      : [""];
+  for (const directory of searchPath.split(path.delimiter)) {
+    if (!directory) continue;
+    for (const extension of extensions) {
+      const candidate = path.join(directory, `${name}${extension}`);
+      try {
+        fs.accessSync(
+          candidate,
+          process.platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK,
+        );
+        if (fs.statSync(candidate).isFile()) return fs.realpathSync(candidate);
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+function guardedBunDirectory(executable: string): string {
+  const cached = guardedBunDirectories.get(executable);
+  if (cached) return cached;
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-safe-bun-"));
+  fs.chmodSync(directory, 0o700);
+  const shim = `#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+const args = process.argv.slice(2);
+const optionsWithValues = new Set(["-C", "-c", "--cwd", "--config", "--filter", "-F"]);
+let commandIndex = -1;
+for (let index = 0; index < args.length; index += 1) {
+  const argument = args[index];
+  if (argument === "--") break;
+  if (/^(?:-[^-]*[rep].*|--(?:preload|require|import|loader|experimental-loader|eval|print)(?:=.*)?)$/.test(argument)) {
+    console.error("ClawSweeper blocked a Bun preload or evaluation callback.");
+    process.exit(2);
+  }
+  if (optionsWithValues.has(argument)) { index += 1; continue; }
+  if (argument.startsWith("-")) continue;
+  commandIndex = index;
+  break;
+}
+const command = commandIndex < 0 ? "" : args[commandIndex];
+if (["install", "i", "add", "a", "update", "upgrade", "remove", "rm", "link", "unlink"].includes(command)) {
+  if (args.some((argument) => /^--(?:no-ignore-scripts|ignore-scripts=(?:false|0)|trust)$/.test(argument))) {
+    console.error("ClawSweeper blocked a Bun lifecycle-script override.");
+    process.exit(2);
+  }
+  args.splice(commandIndex + 1, 0, "--ignore-scripts");
+} else if (command === "pm" && args[commandIndex + 1] === "trust") {
+  console.error("ClawSweeper blocked Bun trusted lifecycle execution.");
+  process.exit(2);
+}
+const result = spawnSync(${JSON.stringify(executable)}, args, { stdio: "inherit", env: process.env });
+if (result.error) { console.error(result.error.message); process.exit(1); }
+process.exit(result.status ?? 1);
+`;
+  fs.writeFileSync(path.join(directory, "bun"), shim, { mode: 0o700 });
+  guardedBunDirectories.set(executable, directory);
+  return directory;
 }

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -23,14 +23,16 @@ export function codexSubprocessEnv(): NodeJS.ProcessEnv {
     PNPM_CONFIG_IGNORE_PNPMFILE: "true",
     npm_config_ignore_scripts: "true",
   };
-  const bunExecutable = findExecutable("bun", env.PATH);
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const searchPath = env[pathKey];
+  const bunExecutable = findExecutable("bun", searchPath);
   if (bunExecutable) {
     if (process.platform === "win32") {
       throw new Error(
         "Bun repair execution requires a Linux runner; refusing unsafe lifecycle scripts",
       );
     }
-    env.PATH = `${guardedBunDirectory(bunExecutable)}${path.delimiter}${env.PATH ?? ""}`;
+    env[pathKey] = `${guardedBunDirectory(bunExecutable)}${path.delimiter}${searchPath ?? ""}`;
   }
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
@@ -128,6 +130,7 @@ function guardedBunDirectory(executable: string): string {
 const { spawnSync } = require("node:child_process");
 const args = process.argv.slice(2);
 const optionsWithValues = new Set(["-C", "-c", "--cwd", "--config", "--filter", "-F"]);
+const bunCommands = new Set(["run", "test", "x", "repl", "exec", "install", "i", "add", "a", "remove", "rm", "update", "audit", "outdated", "link", "unlink", "publish", "patch", "pm", "info", "why", "build", "init", "create", "c", "upgrade", "feedback"]);
 let commandIndex = -1;
 for (let index = 0; index < args.length; index += 1) {
   const argument = args[index];
@@ -138,6 +141,7 @@ for (let index = 0; index < args.length; index += 1) {
   }
   if (optionsWithValues.has(argument)) { index += 1; continue; }
   if (argument.startsWith("-")) continue;
+  if (!bunCommands.has(argument)) continue;
   commandIndex = index;
   break;
 }

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -11,7 +11,12 @@ export function repairGhEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEn
 }
 
 export function codexSubprocessEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env, ...clawsweeperGitIdentityEnv() };
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...clawsweeperGitIdentityEnv(),
+    PNPM_CONFIG_IGNORE_SCRIPTS: "true",
+    npm_config_ignore_scripts: "true",
+  };
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN;

--- a/test/repair/process-env.test.ts
+++ b/test/repair/process-env.test.ts
@@ -32,6 +32,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL: "wss://example.invalid/secret",
       CLAWSWEEPER_CRABFLEET_WORK_STATE_URL: "https://example.invalid/secret",
       PNPM_CONFIG_IGNORE_SCRIPTS: "false",
+      PNPM_CONFIG_IGNORE_PNPMFILE: "false",
       npm_config_ignore_scripts: "false",
     },
     () => {
@@ -52,6 +53,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       assert.equal(env.CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL, undefined);
       assert.equal(env.CLAWSWEEPER_CRABFLEET_WORK_STATE_URL, undefined);
       assert.equal(env.PNPM_CONFIG_IGNORE_SCRIPTS, "true");
+      assert.equal(env.PNPM_CONFIG_IGNORE_PNPMFILE, "true");
       assert.equal(env.npm_config_ignore_scripts, "true");
       assert.equal(internalCodexModel("internal"), "secret-model");
       assert.deepEqual(codexModelArgs("internal"), []);
@@ -146,7 +148,174 @@ test("Codex subprocess prevents pnpm deploy from installing target Git hooks", (
       encoding: "utf8",
     });
     assert.equal(hooks.status, 1);
+
+    fs.writeFileSync(
+      path.join(root, ".pnpmfile.cjs"),
+      'require("node:child_process").execFileSync("git", ["config", "core.hooksPath", "git-hooks"], { cwd: process.cwd() }); module.exports = { hooks: {} };\n',
+    );
+    const unsafePnpmfile = deploy("unsafe-pnpmfile", {
+      ...codexSubprocessEnv(),
+      PNPM_CONFIG_IGNORE_PNPMFILE: "false",
+    });
+    assert.equal(unsafePnpmfile.status, 0, unsafePnpmfile.stderr || unsafePnpmfile.stdout);
+    assert.equal(git("config", "--local", "--get", "core.hooksPath"), "git-hooks");
+    git("config", "--local", "--unset-all", "core.hooksPath");
+
+    const safePnpmfile = deploy("safe-pnpmfile", codexSubprocessEnv());
+    assert.equal(safePnpmfile.status, 0, safePnpmfile.stderr || safePnpmfile.stdout);
+    const pnpmfileHooks = spawnSync("git", ["config", "--local", "--get", "core.hooksPath"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.equal(pnpmfileHooks.status, 1);
   } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex subprocess forces Bun installs to ignore lifecycle scripts", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-bun-hooks-"));
+  const bin = path.join(root, "bin");
+  const argsPath = path.join(root, "bun-args.json");
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+
+  try {
+    fs.mkdirSync(bin);
+    fs.mkdirSync(path.join(root, "git-hooks"));
+    fs.writeFileSync(
+      path.join(bin, "bun"),
+      `#!/usr/bin/env node
+const { execFileSync } = require("node:child_process");
+const { writeFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(args));
+if (args.includes("--version")) { console.log("fake-bun"); process.exit(0); }
+if (!args.includes("--ignore-scripts")) {
+  execFileSync("git", ["config", "core.hooksPath", "git-hooks"], { cwd: process.cwd() });
+}
+`,
+      { mode: 0o755 },
+    );
+    git("init", "-q");
+    const originalPath = `${bin}${path.delimiter}${process.env.PATH ?? ""}`;
+
+    const unsafe = spawnSync("bun", ["install"], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: originalPath },
+    });
+    assert.equal(unsafe.status, 0, unsafe.stderr);
+    assert.equal(git("config", "--local", "--get", "core.hooksPath"), "git-hooks");
+    git("config", "--local", "--unset-all", "core.hooksPath");
+
+    withEnv({ PATH: originalPath }, () => {
+      const env = codexSubprocessEnv();
+      const safe = spawnSync("bun", ["--cwd", root, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      });
+      assert.equal(safe.status, 0, safe.stderr);
+      assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf8")), [
+        "--cwd",
+        root,
+        "install",
+        "--ignore-scripts",
+      ]);
+      const shortCwd = spawnSync("bun", ["-C", root, "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      });
+      assert.equal(shortCwd.status, 0, shortCwd.stderr);
+      assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf8")), [
+        "-C",
+        root,
+        "install",
+        "--ignore-scripts",
+      ]);
+      const hooks = spawnSync("git", ["config", "--local", "--get", "core.hooksPath"], {
+        cwd: root,
+        encoding: "utf8",
+      });
+      assert.equal(hooks.status, 1);
+
+      const passthrough = spawnSync("bun", ["--version"], { cwd: root, encoding: "utf8", env });
+      assert.equal(passthrough.status, 0, passthrough.stderr);
+      assert.equal(passthrough.stdout.trim(), "fake-bun");
+
+      const override = spawnSync("bun", ["install", "--no-ignore-scripts"], {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      });
+      assert.equal(override.status, 2);
+      assert.match(override.stderr, /blocked a Bun lifecycle-script override/);
+
+      const installTrusted = spawnSync("bun", ["add", "--trust", "fixture"], {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      });
+      assert.equal(installTrusted.status, 2);
+      assert.match(installTrusted.stderr, /blocked a Bun lifecycle-script override/);
+
+      for (const preloadArgs of [
+        ["--preload", "./hook.ts", "install"],
+        ["--preload=./hook.ts", "install"],
+        ["-r./hook.ts", "install"],
+        ["--require", "./hook.ts", "install"],
+        ["--import=./hook.ts", "install"],
+        ["--eval", "callback()", "install"],
+        ["--eval=callback()", "install"],
+        ["-e", "callback()", "install"],
+        ["-ecallback()", "install"],
+        ["--print", "callback()", "install"],
+        ["--print=callback()", "install"],
+        ["-p", "callback()", "install"],
+        ["-be", "callback()", "install"],
+        ["-bp", "callback()", "install"],
+        ["-br", "./hook.ts", "install"],
+      ]) {
+        const preload = spawnSync("bun", preloadArgs, { cwd: root, encoding: "utf8", env });
+        assert.equal(preload.status, 2, preloadArgs.join(" "));
+        assert.match(preload.stderr, /blocked a Bun preload or evaluation callback/);
+      }
+
+      const productionInstall = spawnSync("bun", ["install", "-p"], {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      });
+      assert.equal(productionInstall.status, 0, productionInstall.stderr);
+      assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf8")), [
+        "install",
+        "--ignore-scripts",
+        "-p",
+      ]);
+
+      const trusted = spawnSync("bun", ["pm", "trust"], { cwd: root, encoding: "utf8", env });
+      assert.equal(trusted.status, 2);
+      assert.match(trusted.stderr, /blocked Bun trusted lifecycle execution/);
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Codex subprocess fails closed when Bun repair would run on Windows", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-windows-bun-"));
+  const platform = Object.getOwnPropertyDescriptor(process, "platform");
+
+  try {
+    fs.writeFileSync(path.join(root, "bun.exe"), "fixture");
+    Object.defineProperty(process, "platform", { ...platform, value: "win32" });
+    withEnv({ PATH: root, PATHEXT: ".EXE;.CMD" }, () => {
+      assert.throws(codexSubprocessEnv, /Bun repair execution requires a Linux runner/);
+    });
+  } finally {
+    if (platform) Object.defineProperty(process, "platform", platform);
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/repair/process-env.test.ts
+++ b/test/repair/process-env.test.ts
@@ -183,6 +183,7 @@ test("Codex subprocess forces Bun installs to ignore lifecycle scripts", () => {
   try {
     fs.mkdirSync(bin);
     fs.mkdirSync(path.join(root, "git-hooks"));
+    fs.writeFileSync(path.join(root, ".env"), "");
     fs.writeFileSync(
       path.join(bin, "bun"),
       `#!/usr/bin/env node
@@ -232,6 +233,18 @@ if (!args.includes("--ignore-scripts")) {
       assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf8")), [
         "-C",
         root,
+        "install",
+        "--ignore-scripts",
+      ]);
+      const envFile = spawnSync("bun", ["--env-file", ".env", "install"], {
+        cwd: root,
+        encoding: "utf8",
+        env,
+      });
+      assert.equal(envFile.status, 0, envFile.stderr);
+      assert.deepEqual(JSON.parse(fs.readFileSync(argsPath, "utf8")), [
+        "--env-file",
+        ".env",
         "install",
         "--ignore-scripts",
       ]);
@@ -312,6 +325,9 @@ test("Codex subprocess fails closed when Bun repair would run on Windows", () =>
     fs.writeFileSync(path.join(root, "bun.exe"), "fixture");
     Object.defineProperty(process, "platform", { ...platform, value: "win32" });
     withEnv({ PATH: root, PATHEXT: ".EXE;.CMD" }, () => {
+      assert.throws(codexSubprocessEnv, /Bun repair execution requires a Linux runner/);
+    });
+    withEnv({ PATH: "", Path: root, PATHEXT: ".EXE;.CMD" }, () => {
       assert.throws(codexSubprocessEnv, /Bun repair execution requires a Linux runner/);
     });
   } finally {

--- a/test/repair/process-env.test.ts
+++ b/test/repair/process-env.test.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -27,6 +31,8 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN: "service-secret",
       CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL: "wss://example.invalid/secret",
       CLAWSWEEPER_CRABFLEET_WORK_STATE_URL: "https://example.invalid/secret",
+      PNPM_CONFIG_IGNORE_SCRIPTS: "false",
+      npm_config_ignore_scripts: "false",
     },
     () => {
       const env = codexSubprocessEnv();
@@ -45,6 +51,8 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       assert.equal(env.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN, undefined);
       assert.equal(env.CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL, undefined);
       assert.equal(env.CLAWSWEEPER_CRABFLEET_WORK_STATE_URL, undefined);
+      assert.equal(env.PNPM_CONFIG_IGNORE_SCRIPTS, "true");
+      assert.equal(env.npm_config_ignore_scripts, "true");
       assert.equal(internalCodexModel("internal"), "secret-model");
       assert.deepEqual(codexModelArgs("internal"), []);
       assert.deepEqual(codexModelArgs("secret-model"), []);
@@ -82,6 +90,65 @@ test("repair OpenClaw env preserves provider auth without exposing Codex auth", 
       assert.equal(env.CODEX_API_KEY, undefined);
     },
   );
+});
+
+test("Codex subprocess prevents pnpm deploy from installing target Git hooks", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-pnpm-hooks-"));
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+
+  try {
+    fs.mkdirSync(path.join(root, "scripts"));
+    fs.mkdirSync(path.join(root, "git-hooks"));
+    fs.writeFileSync(
+      path.join(root, "scripts", "prepare.mjs"),
+      'import { execFileSync } from "node:child_process"; execFileSync("git", ["config", "core.hooksPath", "git-hooks"], { cwd: process.cwd() });\n',
+    );
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "clawsweeper-hook-fixture",
+        version: "1.0.0",
+        scripts: { prepare: "node scripts/prepare.mjs" },
+      }),
+    );
+    fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), 'packages:\n  - "."\n');
+    git("init", "-q");
+
+    const deploy = (name: string, env: NodeJS.ProcessEnv) =>
+      spawnSync(
+        "pnpm",
+        [
+          "--filter",
+          "clawsweeper-hook-fixture",
+          "deploy",
+          "--prod",
+          "--legacy",
+          path.join(root, name),
+        ],
+        { cwd: root, encoding: "utf8", env },
+      );
+
+    const unsafe = deploy("unsafe", {
+      ...process.env,
+      PNPM_CONFIG_IGNORE_SCRIPTS: "false",
+      npm_config_ignore_scripts: "false",
+    });
+    assert.equal(unsafe.status, 0, unsafe.stderr || unsafe.stdout);
+    assert.equal(git("config", "--local", "--get", "core.hooksPath"), "git-hooks");
+    git("config", "--local", "--unset-all", "core.hooksPath");
+
+    const safe = deploy("safe", codexSubprocessEnv());
+    assert.equal(safe.status, 0, safe.stderr || safe.stdout);
+    assert.doesNotMatch(safe.stdout, /prepare\$/);
+    const hooks = spawnSync("git", ["config", "--local", "--get", "core.hooksPath"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.equal(hooks.status, 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("repair Codex config reserves xhigh for explicit issue-fix execution", () => {


### PR DESCRIPTION
## Summary

- Fix the actual production ClawSweeper repair failure in https://github.com/openclaw/clawsweeper/actions/runs/30685905174 while repairing https://github.com/openclaw/openclaw/pull/117144.
- The model's review-fix pass ran `pnpm deploy --prod --legacy` without `--ignore-scripts`. That executed OpenClaw's `prepare` lifecycle script, installed `core.hooksPath=git-hooks` into the target checkout, and correctly triggered ClawSweeper's existing fail-closed `unsafe target Git callback configuration: core.hookspath` publication guard after 16 minutes of successful edit/review work.
- Enforce `PNPM_CONFIG_IGNORE_SCRIPTS=true` plus `npm_config_ignore_scripts=true` in every Codex subprocess environment, overriding inherited false values before any model-owned package command runs. `PNPM_CONFIG_IGNORE_SCRIPTS` is the setting that actually stops `pnpm deploy`; ordinary lowercase/uppercase npm settings alone demonstrably do not.
- Also enforce `PNPM_CONFIG_IGNORE_PNPMFILE=true`: an untrusted target `.pnpmfile.cjs` executes before lifecycle scripts and can install the same Git hooks even when `--ignore-scripts` is active.
- Wrap supported Bun repair commands in a private, trusted per-process PATH shim that injects `--ignore-scripts` for install/add/update and aliases, correctly recognizes commands after arbitrary value-bearing global options including `-C` and `--env-file`, rejects lifecycle overrides/`--trust`/`bun pm trust`/repository-controlled preload and evaluation callbacks, and preserves ordinary Bun commands and package-manager production flags. Bun ignores pnpm/npm suppression environment variables, so explicit argument enforcement is required.
- Repair execution runners are explicitly Linux-only. If a Windows process has a Bun executable in `PATHEXT`, fail closed instead of running an unprotected repair, including when Windows presents its executable path as `Path` instead of `PATH`; the existing Windows launcher-only CI behavior remains unchanged.
- Make the repair prompt explicitly require `--ignore-scripts` on every package-manager install **or deploy**.
- Preserve Git callback rejection, credential/token stripping, ClawSweeper commit identity, local offline review, single-record repair hydration, Sol/xhigh issue-fix creation, and create-only generated OpenClaw PR safety.
- Add an executable regression that initializes a real Git worktree with an OpenClaw-style `prepare` hook, proves an ordinary `pnpm deploy` installs `core.hooksPath`, then proves the actual built Codex subprocess environment suppresses that lifecycle script and leaves no hooks path.
- Add actual pnpmfile and Bun Git-worktree regressions, including the accepted `bun -C` bypass, trusted-install rejection, normal command passthrough, and simulated Windows fail-closed behavior.

## Current-head real behavior proof

The original production run's completed logs show:

```text
[clawsweeper repair] ... starting Codex edit pass
. prepare$ node scripts/prepare-git-hooks.mjs
Error: unsafe target Git callback configuration: core.hookspath
CLAWSWEEPER_ALLOW_MERGE: 0
[worker-records] direct record hydrated repo=openclaw-openclaw item=117144
```

Replayed the exact failure with a fresh Git worktree and the real `pnpm --filter fixture-root deploy --prod --legacy` command. The fixture's `prepare` script writes `core.hooksPath`, matching OpenClaw's actual package lifecycle behavior; the last case uses the real built `dist/repair/process-env.js` production subprocess environment:

```json
{"name":"baseline","exitCode":0,"hooksPath":"git-hooks","ranPrepare":true,"failure":null}
{"name":"lowercase","exitCode":0,"hooksPath":"git-hooks","ranPrepare":true,"failure":null}
{"name":"uppercase","exitCode":0,"hooksPath":"git-hooks","ranPrepare":true,"failure":null}
{"name":"pnpm_config","exitCode":0,"hooksPath":null,"ranPrepare":false,"failure":null}
{"name":"actual_codex_subprocess","exitCode":0,"hooksPath":null,"ranPrepare":false,"failure":null}
```

Replayed the same publication-blocking callback mutation through both target package-manager escape hatches, using pnpm and the production-pinned real Bun `1.3.14` binary against a fresh Git worktree:

```json
{"name":"pnpm_unsafe_lifecycle","packageManagerStatus":0,"hooksPath":"git-hooks"}
{"name":"pnpm_guarded_lifecycle","packageManagerStatus":0,"hooksPath":null}
{"name":"pnpm_unsafe_pnpmfile","packageManagerStatus":0,"hooksPath":"git-hooks"}
{"name":"pnpm_guarded_pnpmfile","packageManagerStatus":0,"hooksPath":null}
{"name":"bun_1.3.14_unsafe_lifecycle","packageManagerStatus":0,"hooksPath":"git-hooks"}
{"name":"bun_1.3.14_guarded_lifecycle","packageManagerStatus":0,"hooksPath":null}
{"name":"bun_unsafe_override","blocked":true,"hooksPath":null}
{"name":"bun_1.3.14_unsafe_eval","packageManagerStatus":0,"hooksPath":"git-hooks"}
{"name":"bun_1.3.14_guarded_eval","blocked":true,"hooksPath":null}
{"name":"bun_1.3.14_unsafe_grouped_eval","packageManagerStatus":0,"hooksPath":"git-hooks"}
{"name":"bun_1.3.14_guarded_grouped_eval","blocked":true,"hooksPath":null}
```

Generated OpenClaw PR https://github.com/openclaw/openclaw/pull/117144 remains open, unmerged, and has no auto-merge request.

## Accepted review findings and disposition

- **Target `.pnpmfile.cjs` bypass:** accepted; forced `PNPM_CONFIG_IGNORE_PNPMFILE=true`, overriding inherited values, and proved the real malicious target file executes in the unsafe baseline but cannot run through the actual repair subprocess environment.
- **Bun ignores npm/pnpm lifecycle environment flags:** accepted; added a private trusted Bun argument guard and proved both the actual pinned Bun baseline and guarded invocation against target Git configuration.
- **Bun `-C <directory> install` bypass:** accepted; parse the supported short global directory option before identifying the install command and cover the exact former bypass with an executable regression.
- **Bun preload callback bypass:** accepted; reject `--preload`, `-r`, `--require`, `--import`, and loader variants before Bun can execute target-controlled callback code, covering separated, attached, and equals-sign option forms.
- **Bun inline-evaluation callback bypass:** accepted; reject `--eval`, `-e`, `--print`, and `-p` before the Bun subcommand while preserving the legitimate `bun install -p` package-manager production flag. Independent review verified the original bypass against production-pinned Bun `1.3.14` and reproduced `core.hooksPath=git-hooks`.
- **Grouped short-option callback bypass:** accepted; also reject callback flags inside grouped forms such as `bun -be '<callback>' install` and `bun -bp '<callback>' install`, with real pinned-Bun unsafe/guarded production-path proof.
- **Unrecognized value-bearing global options:** accepted; recognize the actual supported Bun subcommand instead of mistaking an unfamiliar option's argument for the command, with direct `bun --env-file .env install` regression coverage.
- **Windows `Path` casing:** accepted; locate the executable search path case-insensitively and prove Bun repair is rejected for both standard `PATH` and Windows-native `Path` environments.
- **Windows Bun protection:** accepted as a fail-closed boundary, not an execution platform expansion; production repair workflow explicitly requires a Linux execution runner, while Windows CI only validates the native launcher. A Windows environment with a detectable Bun executable now refuses to construct an unsafe repair environment, with an executable platform-simulated regression.

## Validation

- `pnpm run build:all` passed.
- `pnpm run check:static` passed.
- 58 focused process-environment, actual `pnpm deploy`, pnpmfile, Bun, Windows fail-closed, prompt-generation, repair-execution, merge-security, and offline-local-review tests passed.
- `node /tmp/clawsweeper-package-lifecycle-env-proof.mjs` reproduced the failure and proved real built-subprocess suppression.
- `node /tmp/clawsweeper-safe-package-manager-proof.mjs` proved both malicious pnpmfile and real pinned-Bun callback baselines, guarded suppression, and blocked unsafe Bun overrides.
- `node /tmp/clawsweeper-focused-modules-proof.mjs` reproved offline local review, one-record repair hydration, CRLF compatibility, blocked generated-PR merge authority, protected-label denial, and explicit ClawSweeper-service automerge.
- Fresh independent current-head precommit Codex reviews: clean, including the exact Bun global-option and Windows Path findings; the focused environment suite passed.
- Fresh independent committed-branch Codex review against origin/main: clean; all 19 requested focused tests and the complete real pinned-Bun/pnpm executable behavior proof passed, with no concrete reproducible current-head findings.
