### PR TITLE
fix: restore generated outputs after changed-gate validation

### DIFF
--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1339,20 +1339,40 @@ export function runAllowedValidationCommandsWithBinding(
               validationIdentityProofDeadlineAt(deadlineAt),
             );
           }
-          const restoreValidationCache = runtimeBuild
-            ? prepareDisposableRuntimeBuildCache(cwd, validationEnv, ignoredValidationInputs)
-            : options.targetRepo === "openclaw/openclaw" && isChangedGateCommand(parts, options)
-              ? prepareDisposableRuntimeBuildCache(
+          const restoreChangedGateOutputs =
+            options.targetRepo === "openclaw/openclaw" &&
+            isChangedGateCommand(parts, options) &&
+            !pendingRuntimeBuild
+              ? prepareDisposableChangedGateBuildOutputs(
                   cwd,
                   validationEnv,
                   ignoredValidationInputs,
-                  "tsgo-cache",
-                  "changed-gate validation",
                 )
               : null;
+          let restoreValidationCache: (() => void) | null;
+          try {
+            restoreValidationCache = runtimeBuild
+              ? prepareDisposableRuntimeBuildCache(cwd, validationEnv, ignoredValidationInputs)
+              : options.targetRepo === "openclaw/openclaw" && isChangedGateCommand(parts, options)
+                ? prepareDisposableRuntimeBuildCache(
+                    cwd,
+                    validationEnv,
+                    ignoredValidationInputs,
+                    "tsgo-cache",
+                    "changed-gate validation",
+                  )
+                : null;
+          } catch (error) {
+            restoreChangedGateOutputs?.();
+            throw error;
+          }
           const executionBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
           if (executionBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
-            restoreValidationCache?.();
+            try {
+              restoreChangedGateOutputs?.();
+            } finally {
+              restoreValidationCache?.();
+            }
             throw validationCommandBudgetError(rendered);
           }
           try {
@@ -1363,7 +1383,11 @@ export function runAllowedValidationCommandsWithBinding(
               writableRoots: [cwd, path.dirname(String(validationEnv.HOME))],
             });
           } finally {
-            restoreValidationCache?.();
+            try {
+              restoreChangedGateOutputs?.();
+            } finally {
+              restoreValidationCache?.();
+            }
           }
           if (runtimeBuild) {
             assertGeneratedRuntimeBuildOutput(cwd);
@@ -1435,17 +1459,33 @@ export function runAllowedValidationCommandsWithBinding(
             let fallbackError: Error | null = null;
             try {
               resetValidationEnvironment(deadlineAt - identityReserveMs);
-              const restoreFallbackValidationCache =
+              const restoreFallbackChangedGateOutputs =
                 options.targetRepo === "openclaw/openclaw" &&
-                isChangedGateCommand(fallbackParts, options)
-                  ? prepareDisposableRuntimeBuildCache(
+                isChangedGateCommand(fallbackParts, options) &&
+                !pendingRuntimeBuild
+                  ? prepareDisposableChangedGateBuildOutputs(
                       cwd,
                       validationEnv,
                       ignoredValidationInputs,
-                      "tsgo-cache",
-                      "changed-gate validation",
                     )
                   : null;
+              let restoreFallbackValidationCache: (() => void) | null;
+              try {
+                restoreFallbackValidationCache =
+                  options.targetRepo === "openclaw/openclaw" &&
+                  isChangedGateCommand(fallbackParts, options)
+                    ? prepareDisposableRuntimeBuildCache(
+                        cwd,
+                        validationEnv,
+                        ignoredValidationInputs,
+                        "tsgo-cache",
+                        "changed-gate validation",
+                      )
+                    : null;
+              } catch (error) {
+                restoreFallbackChangedGateOutputs?.();
+                throw error;
+              }
               try {
                 const fallbackBudgetMs = remainingCommandBudget(deadlineAt, identityReserveMs);
                 if (fallbackBudgetMs < MIN_VALIDATION_COMMAND_BUDGET_MS) {
@@ -1462,7 +1502,11 @@ export function runAllowedValidationCommandsWithBinding(
                   writableRoots: [cwd, path.dirname(String(validationEnv.HOME))],
                 });
               } finally {
-                restoreFallbackValidationCache?.();
+                try {
+                  restoreFallbackChangedGateOutputs?.();
+                } finally {
+                  restoreFallbackValidationCache?.();
+                }
               }
             } catch (error) {
               fallbackError = error as Error;
@@ -2796,6 +2840,113 @@ function runtimeArtifactBuildOutputRoots(cwd: string): string[] {
     }
   }
   return roots;
+}
+
+function prepareDisposableChangedGateBuildOutputs(
+  cwd: string,
+  validationEnv: NodeJS.ProcessEnv,
+  ignoredValidationInputs: readonly string[],
+) {
+  const checkout = fs.realpathSync(cwd);
+  const backupRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-changed-gate-output-")),
+  );
+  const validationHomeRoot = fs.realpathSync(path.dirname(String(validationEnv.HOME)));
+  if (
+    backupRoot === checkout ||
+    backupRoot.startsWith(`${checkout}${path.sep}`) ||
+    backupRoot === validationHomeRoot ||
+    backupRoot.startsWith(`${validationHomeRoot}${path.sep}`)
+  ) {
+    fs.rmSync(backupRoot, { recursive: true, force: true });
+    throw new Error("changed-gate validation backup must be outside writable sandbox roots");
+  }
+  const snapshots: Array<{
+    relativePath: string;
+    existed: boolean;
+    parentRealPath: string;
+    parentDevice: number;
+    parentInode: number;
+  }> = [];
+  try {
+    for (const relativePath of runtimeArtifactBuildOutputRoots(cwd)) {
+      const output = path.join(checkout, relativePath);
+      const parent = path.dirname(output);
+      const parentStat = fs.lstatSync(parent, { throwIfNoEntry: false });
+      if (!parentStat) continue;
+      if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
+        throw new Error(`changed-gate validation has an unsafe output parent: ${relativePath}`);
+      }
+      const parentRealPath = fs.realpathSync(parent);
+      assertPathWithin(checkout, parentRealPath, relativePath);
+      const outputStat = fs.lstatSync(output, { throwIfNoEntry: false });
+      if (
+        outputStat &&
+        (!ignoredValidationInputs.includes(relativePath) ||
+          !outputStat.isDirectory() ||
+          outputStat.isSymbolicLink())
+      ) {
+        throw new Error(`changed-gate validation has an unsafe existing output: ${relativePath}`);
+      }
+      if (outputStat) {
+        const backup = path.join(backupRoot, relativePath);
+        fs.mkdirSync(path.dirname(backup), { recursive: true });
+        fs.cpSync(output, backup, { recursive: true, verbatimSymlinks: true });
+      }
+      snapshots.push({
+        relativePath,
+        existed: Boolean(outputStat),
+        parentRealPath,
+        parentDevice: parentStat.dev,
+        parentInode: parentStat.ino,
+      });
+    }
+  } catch (error) {
+    fs.rmSync(backupRoot, { recursive: true, force: true });
+    throw error;
+  }
+  return () => {
+    let restorationFailure: unknown = null;
+    let preserveBackup = false;
+    for (const snapshot of snapshots) {
+      try {
+        const output = path.join(checkout, snapshot.relativePath);
+        const parent = path.dirname(output);
+        const parentStat = fs.lstatSync(parent, { throwIfNoEntry: false });
+        if (
+          !parentStat?.isDirectory() ||
+          parentStat.isSymbolicLink() ||
+          parentStat.dev !== snapshot.parentDevice ||
+          parentStat.ino !== snapshot.parentInode ||
+          fs.realpathSync(parent) !== snapshot.parentRealPath
+        ) {
+          throw new Error(
+            `changed-gate validation changed its protected output parent: ${snapshot.relativePath}`,
+          );
+        }
+        const outputStat = fs.lstatSync(output, { throwIfNoEntry: false });
+        if (outputStat && (!outputStat.isDirectory() || outputStat.isSymbolicLink())) {
+          restorationFailure ??= new Error(
+            `changed-gate validation produced an unsafe output: ${snapshot.relativePath}`,
+          );
+        }
+        fs.rmSync(output, { recursive: true, force: true });
+        if (snapshot.existed) {
+          fs.cpSync(path.join(backupRoot, snapshot.relativePath), output, {
+            recursive: true,
+            verbatimSymlinks: true,
+          });
+        }
+      } catch (error) {
+        restorationFailure ??= error;
+        preserveBackup = true;
+      }
+    }
+    if (!preserveBackup) {
+      fs.rmSync(backupRoot, { recursive: true, force: true });
+    }
+    if (restorationFailure) throw restorationFailure;
+  };
 }
 
 function prepareDisposableRuntimeBuildCache(

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -4220,6 +4220,203 @@ test("changed-gate fallback preserves and protects pending fresh runtime output"
   }
 });
 
+test("OpenClaw changed-gate rebuilds are disposable and restore existing runtime outputs", () => {
+  for (const existingOutputs of [false, true]) {
+    const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+    fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\npackages/*/dist/\n");
+    const packageDir = path.join(cwd, "packages", "plugin-sdk");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(path.join(packageDir, "package.json"), '{"name":"plugin-sdk"}\n');
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+
+    for (const output of ["dist", "packages/plugin-sdk/dist"]) {
+      if (!existingOutputs) continue;
+      const directory = path.join(cwd, output);
+      fs.mkdirSync(directory, { recursive: true });
+      fs.writeFileSync(path.join(directory, "runtime.js"), `${output}: trusted original\n`);
+    }
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-gate-build-output-"));
+    writeNodeCommandShim(
+      binDir,
+      "pnpm",
+      [
+        'const fs = require("node:fs");',
+        'for (const root of ["dist", "packages/plugin-sdk/dist"]) {',
+        "  fs.mkdirSync(root, { recursive: true });",
+        "  fs.writeFileSync(`${root}/runtime.js`, `${root}: regenerated\\n`);",
+        "}",
+      ].join("\n"),
+    );
+
+    assert.deepEqual(
+      withPathOnlyPrefix(binDir, () =>
+        runAllowedValidationCommands(
+          ["pnpm check:changed"],
+          cwd,
+          validationOptions("openclaw/openclaw", {
+            pinnedBaseRef: "origin/main",
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: [],
+              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+            },
+          }),
+        ),
+      ),
+      ["pnpm check:changed"],
+    );
+    for (const output of ["dist", "packages/plugin-sdk/dist"]) {
+      const generated = path.join(cwd, output, "runtime.js");
+      if (existingOutputs) {
+        assert.equal(fs.readFileSync(generated, "utf8"), `${output}: trusted original\n`);
+      } else {
+        assert.equal(fs.existsSync(generated), false);
+      }
+    }
+  }
+});
+
+test("changed-gate output restoration still rejects unrelated ignored-input poisoning", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+  fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  const dist = path.join(cwd, "dist");
+  fs.mkdirSync(dist, { recursive: true });
+  fs.writeFileSync(path.join(dist, "runtime.js"), "trusted original\n");
+  const dependency = path.join(cwd, "node_modules", "dependency", "runtime.js");
+  fs.mkdirSync(path.dirname(dependency), { recursive: true });
+  fs.writeFileSync(dependency, "safe\n");
+
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-gate-build-poison-"));
+  writeNodeCommandShim(
+    binDir,
+    "pnpm",
+    [
+      'const fs = require("node:fs");',
+      'fs.writeFileSync("dist/runtime.js", "regenerated\\n");',
+      'fs.writeFileSync("node_modules/dependency/runtime.js", "poisoned\\n");',
+    ].join("\n"),
+  );
+
+  assert.throws(
+    () =>
+      withPathOnlyPrefix(binDir, () =>
+        runAllowedValidationCommands(
+          ["pnpm check:changed"],
+          cwd,
+          validationOptions("openclaw/openclaw", {
+            pinnedBaseRef: "origin/main",
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: [],
+              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+            },
+          }),
+        ),
+      ),
+    /runtimeInputsSha256; changed runtime roots: node_modules$/,
+  );
+  assert.equal(fs.readFileSync(path.join(dist, "runtime.js"), "utf8"), "trusted original\n");
+});
+
+test("changed-gate output preparation failures preserve the existing compiler cache", () => {
+  const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+  fs.appendFileSync(path.join(cwd, ".gitignore"), "dist\n.artifacts/\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-m", "initial");
+  attachOrigin(cwd);
+
+  fs.writeFileSync(path.join(cwd, "dist"), "unsafe regular-file output\n");
+  const cache = path.join(cwd, ".artifacts", "tsgo-cache", "state.json");
+  fs.mkdirSync(path.dirname(cache), { recursive: true });
+  fs.writeFileSync(cache, "trusted compiler state\n");
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-gate-output-cache-"));
+  writeNodeCommandShim(binDir, "pnpm", "");
+
+  assert.throws(
+    () =>
+      withPathOnlyPrefix(binDir, () =>
+        runAllowedValidationCommands(
+          ["pnpm check:changed"],
+          cwd,
+          validationOptions("openclaw/openclaw", {
+            pinnedBaseRef: "origin/main",
+            toolchain: {
+              packageManager: "pnpm",
+              baseValidationCommands: [],
+              changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+            },
+          }),
+        ),
+      ),
+    /changed-gate validation has an unsafe existing output: dist/,
+  );
+  assert.equal(fs.readFileSync(cache, "utf8"), "trusted compiler state\n");
+});
+
+test(
+  "changed-gate output restoration rejects replaced output roots before following symlinks",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });
+    fs.appendFileSync(path.join(cwd, ".gitignore"), "dist/\n");
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+
+    const dist = path.join(cwd, "dist");
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(path.join(dist, "runtime.js"), "trusted original\n");
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-protected-output-"));
+    fs.writeFileSync(path.join(outside, "runtime.js"), "outside must survive\n");
+
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-gate-build-symlink-"));
+    writeNodeCommandShim(
+      binDir,
+      "pnpm",
+      [
+        'const fs = require("node:fs");',
+        'fs.rmSync("dist", { recursive: true, force: true });',
+        `fs.symlinkSync(${JSON.stringify(outside)}, "dist");`,
+      ].join("\n"),
+    );
+
+    assert.throws(
+      () =>
+        withPathOnlyPrefix(binDir, () =>
+          runAllowedValidationCommands(
+            ["pnpm check:changed"],
+            cwd,
+            validationOptions("openclaw/openclaw", {
+              pinnedBaseRef: "origin/main",
+              toolchain: {
+                packageManager: "pnpm",
+                baseValidationCommands: [],
+                changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+              },
+            }),
+          ),
+        ),
+      (error: Error) =>
+        /validation command failed \(pnpm check:changed\)/.test(error.message) &&
+        /changed-gate validation produced an unsafe output: dist/.test(
+          String((error as Error & { cause?: unknown }).cause),
+        ),
+    );
+    assert.equal(
+      fs.readFileSync(path.join(outside, "runtime.js"), "utf8"),
+      "outside must survive\n",
+    );
+    assert.equal(fs.readFileSync(path.join(dist, "runtime.js"), "utf8"), "trusted original\n");
+  },
+);
+
 test("OpenClaw changed-gate compiler cache is disposable and preserves existing state", () => {
   for (const existingCompilerCache of [false, true]) {
     const cwd = gitPackageFixture({ "check:changed": "node scripts/check-changed.mjs" });


### PR DESCRIPTION
## Root cause

The live repair of https://github.com/openclaw/openclaw/pull/117144 reached a successful Codex edit, then failed because OpenClaw's trusted `pnpm check:changed` regenerates ignored `dist` and `packages/plugin-sdk/dist` outputs. ClawSweeper compared those legitimate build outputs against its immutable runtime snapshot and aborted before publishing the fixed branch.

## Fix

- Snapshot only canonical, ignored OpenClaw build output roots outside every contained-command writable root.
- Restore original output trees (or remove newly created output trees) before immutable checkout verification.
- Keep fresh build-and-smoke output binding strict; reject unrelated `node_modules`/artifact poisoning, unsafe output roots, swapped parents, and symlink targets.
- Restore every safely recoverable output even when another output was replaced, and preserve trusted compiler cache on preparation failures.
- Generated OpenClaw PRs remain create-only: this change neither grants nor requests merge permission.

## Real behavior proof

Production failure reproduced from https://github.com/openclaw/clawsweeper/actions/runs/30692961470:

```
Error: unsafe validation command mutated checkout identity (pnpm check:changed): runtimeInputsSha256; changed runtime roots: dist, packages/plugin-sdk/dist
```

The actual contained changed-gate runtime now rebuilds both ignored output roots and returns successfully; existing trusted outputs are restored and newly created outputs are removed. Unrelated ignored-input poisoning and output symlink replacement still fail closed; the symlink target and original trusted output both remain intact. Existing fresh build/smoke tamper guards and compiler-cache isolation continue passing.

```
node --test --test-name-pattern='changed-gate rebuilds|output restoration|output preparation failures|compiler cache|fresh runtime output|runtime root diagnostics identify|changed-gate fallback' test/repair/target-validation.test.ts

tests 11
pass 11
fail 0
```

Additional proof: `pnpm run build:all`, repair-file lint, focused offline/create-only/exact-item runtime proof (GitHub calls: 0; generated autofix merge allowed: false; replacement PR auto-merge allowed: false).

## Review disposition

The fresh independent precommit review originally identified three issues: canonicalize backup roots, prepare outputs before moving the compiler cache, and preserve/restore original outputs on restoration failures. All three were fixed with new regression coverage. Fresh re-review: **No actionable findings. All 11 focused validation tests passed.**
