### PR TITLE
fix: prepare frozen Knip for network-isolated OpenClaw validation

### DIFF
--- a/config/openclaw-knip-6.8.0.pnpm-lock.yaml
+++ b/config/openclaw-knip-6.8.0.pnpm-lock.yaml
@@ -1,0 +1,838 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      knip:
+        specifier: 6.8.0
+        version: 6.8.0
+
+packages:
+  "@emnapi/core@1.10.0":
+    resolution:
+      {
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
+  "@emnapi/core@1.11.2":
+    resolution:
+      {
+        integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==,
+      }
+
+  "@emnapi/runtime@1.10.0":
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+      }
+
+  "@emnapi/runtime@1.11.2":
+    resolution:
+      {
+        integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
+      }
+
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
+      }
+
+  "@emnapi/wasi-threads@1.2.2":
+    resolution:
+      {
+        integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
+      }
+
+  "@napi-rs/wasm-runtime@1.1.6":
+    resolution:
+      {
+        integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==,
+      }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
+
+  "@oxc-parser/binding-android-arm-eabi@0.128.0":
+    resolution:
+      {
+        integrity: sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-parser/binding-android-arm64@0.128.0":
+    resolution:
+      {
+        integrity: sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-parser/binding-darwin-arm64@0.128.0":
+    resolution:
+      {
+        integrity: sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-parser/binding-darwin-x64@0.128.0":
+    resolution:
+      {
+        integrity: sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-parser/binding-freebsd-x64@0.128.0":
+    resolution:
+      {
+        integrity: sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.128.0":
+    resolution:
+      {
+        integrity: sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.128.0":
+    resolution:
+      {
+        integrity: sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.128.0":
+    resolution:
+      {
+        integrity: sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-arm64-musl@0.128.0":
+    resolution:
+      {
+        integrity: sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.128.0":
+    resolution:
+      {
+        integrity: sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.128.0":
+    resolution:
+      {
+        integrity: sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.128.0":
+    resolution:
+      {
+        integrity: sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.128.0":
+    resolution:
+      {
+        integrity: sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-gnu@0.128.0":
+    resolution:
+      {
+        integrity: sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-musl@0.128.0":
+    resolution:
+      {
+        integrity: sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-openharmony-arm64@0.128.0":
+    resolution:
+      {
+        integrity: sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-parser/binding-wasm32-wasi@0.128.0":
+    resolution:
+      {
+        integrity: sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.128.0":
+    resolution:
+      {
+        integrity: sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.128.0":
+    resolution:
+      {
+        integrity: sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-x64-msvc@0.128.0":
+    resolution:
+      {
+        integrity: sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@oxc-project/types@0.128.0":
+    resolution:
+      {
+        integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==,
+      }
+
+  "@oxc-resolver/binding-android-arm-eabi@11.24.2":
+    resolution:
+      {
+        integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==,
+      }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-resolver/binding-android-arm64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==,
+      }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-resolver/binding-darwin-arm64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-resolver/binding-darwin-x64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-resolver/binding-freebsd-x64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==,
+      }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2":
+    resolution:
+      {
+        integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm-musleabihf@11.24.2":
+    resolution:
+      {
+        integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-arm64-musl@11.24.2":
+    resolution:
+      {
+        integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-resolver/binding-linux-ppc64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-riscv64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-riscv64-musl@11.24.2":
+    resolution:
+      {
+        integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-resolver/binding-linux-s390x-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==,
+      }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-x64-gnu@11.24.2":
+    resolution:
+      {
+        integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-resolver/binding-linux-x64-musl@11.24.2":
+    resolution:
+      {
+        integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-resolver/binding-openharmony-arm64@11.24.2":
+    resolution:
+      {
+        integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==,
+      }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-resolver/binding-wasm32-wasi@11.24.2":
+    resolution:
+      {
+        integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==,
+      }
+    engines: { node: ">=14.0.0" }
+    cpu: [wasm32]
+
+  "@oxc-resolver/binding-win32-arm64-msvc@11.24.2":
+    resolution:
+      {
+        integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-resolver/binding-win32-x64-msvc@11.24.2":
+    resolution:
+      {
+        integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  "@tybys/wasm-util@0.10.3":
+    resolution:
+      {
+        integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
+      }
+
+  fd-package-json@2.0.0:
+    resolution:
+      {
+        integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==,
+      }
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  formatly@0.3.0:
+    resolution:
+      {
+        integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==,
+      }
+    engines: { node: ">=18.3.0" }
+    hasBin: true
+
+  get-tsconfig@4.14.0:
+    resolution:
+      {
+        integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==,
+      }
+
+  jiti@2.7.0:
+    resolution:
+      {
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+      }
+    hasBin: true
+
+  knip@6.8.0:
+    resolution:
+      {
+        integrity: sha512-FaTrNiqc74KTUMI4KZ5CWWxR2oVTm/bEEik16NKz7usiUJXG4+Df2XA2SPAm+mG9bBY22NvBMM4IeBcUZFslyg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
+  minimist@1.2.8:
+    resolution:
+      {
+        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
+
+  oxc-parser@0.128.0:
+    resolution:
+      {
+        integrity: sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+
+  oxc-resolver@11.24.2:
+    resolution:
+      {
+        integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==,
+      }
+
+  picomatch@4.0.5:
+    resolution:
+      {
+        integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
+      }
+    engines: { node: ">=12" }
+
+  resolve-pkg-maps@1.0.0:
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
+
+  smol-toml@1.7.0:
+    resolution:
+      {
+        integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==,
+      }
+    engines: { node: ">= 18" }
+
+  strip-json-comments@5.0.3:
+    resolution:
+      {
+        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+      }
+    engines: { node: ">=14.16" }
+
+  tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  unbash@3.0.0:
+    resolution:
+      {
+        integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==,
+      }
+    engines: { node: ">=14" }
+
+  walk-up-path@4.0.0:
+    resolution:
+      {
+        integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==,
+      }
+    engines: { node: 20 || >=22 }
+
+  yaml@2.9.0:
+    resolution:
+      {
+        integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
+      }
+    engines: { node: ">= 14.6" }
+    hasBin: true
+
+  zod@4.4.3:
+    resolution:
+      {
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
+      }
+
+snapshots:
+  "@emnapi/core@1.10.0":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/core@1.11.2":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.10.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.11.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@tybys/wasm-util": 0.10.3
+    optional: true
+
+  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)":
+    dependencies:
+      "@emnapi/core": 1.11.2
+      "@emnapi/runtime": 1.11.2
+      "@tybys/wasm-util": 0.10.3
+    optional: true
+
+  "@oxc-parser/binding-android-arm-eabi@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-android-arm64@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-arm64@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-x64@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-freebsd-x64@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-musl@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-gnu@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-musl@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-openharmony-arm64@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-wasm32-wasi@0.128.0":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.128.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-x64-msvc@0.128.0":
+    optional: true
+
+  "@oxc-project/types@0.128.0": {}
+
+  "@oxc-resolver/binding-android-arm-eabi@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-android-arm64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-darwin-arm64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-darwin-x64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-freebsd-x64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm-musleabihf@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm64-musl@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-ppc64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-riscv64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-riscv64-musl@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-s390x-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-x64-gnu@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-linux-x64-musl@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-openharmony-arm64@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-wasm32-wasi@11.24.2":
+    dependencies:
+      "@emnapi/core": 1.11.2
+      "@emnapi/runtime": 1.11.2
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  "@oxc-resolver/binding-win32-arm64-msvc@11.24.2":
+    optional: true
+
+  "@oxc-resolver/binding-win32-x64-msvc@11.24.2":
+    optional: true
+
+  "@tybys/wasm-util@0.10.3":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  jiti@2.7.0: {}
+
+  knip@6.8.0:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      minimist: 1.2.8
+      oxc-parser: 0.128.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.5
+      smol-toml: 1.7.0
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 3.0.0
+      yaml: 2.9.0
+      zod: 4.4.3
+
+  minimist@1.2.8: {}
+
+  oxc-parser@0.128.0:
+    dependencies:
+      "@oxc-project/types": 0.128.0
+    optionalDependencies:
+      "@oxc-parser/binding-android-arm-eabi": 0.128.0
+      "@oxc-parser/binding-android-arm64": 0.128.0
+      "@oxc-parser/binding-darwin-arm64": 0.128.0
+      "@oxc-parser/binding-darwin-x64": 0.128.0
+      "@oxc-parser/binding-freebsd-x64": 0.128.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.128.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.128.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.128.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.128.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.128.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.128.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.128.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.128.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.128.0
+      "@oxc-parser/binding-linux-x64-musl": 0.128.0
+      "@oxc-parser/binding-openharmony-arm64": 0.128.0
+      "@oxc-parser/binding-wasm32-wasi": 0.128.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.128.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.128.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.128.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      "@oxc-resolver/binding-android-arm-eabi": 11.24.2
+      "@oxc-resolver/binding-android-arm64": 11.24.2
+      "@oxc-resolver/binding-darwin-arm64": 11.24.2
+      "@oxc-resolver/binding-darwin-x64": 11.24.2
+      "@oxc-resolver/binding-freebsd-x64": 11.24.2
+      "@oxc-resolver/binding-linux-arm-gnueabihf": 11.24.2
+      "@oxc-resolver/binding-linux-arm-musleabihf": 11.24.2
+      "@oxc-resolver/binding-linux-arm64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-arm64-musl": 11.24.2
+      "@oxc-resolver/binding-linux-ppc64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-riscv64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-riscv64-musl": 11.24.2
+      "@oxc-resolver/binding-linux-s390x-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-x64-gnu": 11.24.2
+      "@oxc-resolver/binding-linux-x64-musl": 11.24.2
+      "@oxc-resolver/binding-openharmony-arm64": 11.24.2
+      "@oxc-resolver/binding-wasm32-wasi": 11.24.2
+      "@oxc-resolver/binding-win32-arm64-msvc": 11.24.2
+      "@oxc-resolver/binding-win32-x64-msvc": 11.24.2
+
+  picomatch@4.0.5: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  smol-toml@1.7.0: {}
+
+  strip-json-comments@5.0.3: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tslib@2.8.1:
+    optional: true
+
+  unbash@3.0.0: {}
+
+  walk-up-path@4.0.0: {}
+
+  yaml@2.9.0: {}
+
+  zod@4.4.3: {}

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -1488,7 +1488,6 @@ function tryAutomergeFastRebaseRepair({
     return { status: "fallback", reason: "deterministic rebase left working tree changes" };
   }
 
-  prepareTargetToolchain(targetDir, currentTargetValidationOptions());
   const targetBaseSha = pinRepairBase(() =>
     run("git", ["rev-parse", `origin/${baseBranch}`], { cwd: targetDir }),
   ).sha;
@@ -1500,6 +1499,7 @@ function tryAutomergeFastRebaseRepair({
     { fixArtifact, targetDir, sourceHead },
     validationOptions,
   );
+  prepareTargetToolchain(targetDir, validationPlan.options, validationPlan.commands);
   const validationExecution = runAllowedValidationCommandsWithBinding(
     validationPlan.commands,
     targetDir,
@@ -2873,7 +2873,6 @@ function validateAndReviewLoop({
   let validationCommands: LooseRecord[] = [];
   let checkoutBinding = null;
   for (let attempt = 1; attempt <= maxReviewAttempts; attempt += 1) {
-    prepareTargetToolchain(targetDir, currentTargetValidationOptions());
     const validationOptions = {
       ...currentTargetValidationOptions(),
       pinnedBaseRef: targetBaseSha,
@@ -2882,6 +2881,7 @@ function validateAndReviewLoop({
       { fixArtifact, targetDir, sourceHead },
       validationOptions,
     );
+    prepareTargetToolchain(targetDir, validationPlan.options, validationPlan.commands);
     try {
       const validationExecution = runAllowedValidationCommandsWithBinding(
         validationPlan.commands,
@@ -2993,11 +2993,11 @@ function validateAndReviewLoop({
         targetBaseSha,
       });
       onReviewFix?.(`${attempt}-final`);
-      prepareTargetToolchain(targetDir, currentTargetValidationOptions());
       const finalValidationPlan = repairDeltaValidationPlan(
         { fixArtifact, targetDir, sourceHead },
         validationOptions,
       );
+      prepareTargetToolchain(targetDir, finalValidationPlan.options, finalValidationPlan.commands);
       const validationExecution = runAllowedValidationCommandsWithBinding(
         finalValidationPlan.commands,
         targetDir,
@@ -3049,7 +3049,6 @@ function validateAndReviewSynchronizedTree({
   sourceHead,
   repairDeltaPaths,
 }: LooseRecord) {
-  prepareTargetToolchain(targetDir, currentTargetValidationOptions());
   const validationOptions = {
     ...currentTargetValidationOptions(),
     pinnedBaseRef: targetBaseSha,
@@ -3058,6 +3057,7 @@ function validateAndReviewSynchronizedTree({
     { fixArtifact, targetDir, sourceHead },
     validationOptions,
   );
+  prepareTargetToolchain(targetDir, validationPlan.options, validationPlan.commands);
   let validationCommands;
   let checkoutBinding;
   try {

--- a/src/repair/pinned-openclaw-validation-helper.ts
+++ b/src/repair/pinned-openclaw-validation-helper.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import { parse as parseYaml } from "yaml";
+
+import { runContainedCommand } from "./command-runner.js";
+
+const PINNED_OPENCLAW_KNIP_VERSION = "6.8.0";
+const PREPARED_PNPM_HELPER_CACHE = ".__clawsweeper_pnpm_helper_cache__";
+const MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES = 48 * 60;
+const PINNED_OPENCLAW_KNIP_LOCK = fileURLToPath(
+  new URL("../../config/openclaw-knip-6.8.0.pnpm-lock.yaml", import.meta.url),
+);
+
+export function preparePinnedOpenClawValidationHelper({
+  cwd,
+  targetRepo,
+  validationEnv,
+  installRegistry,
+  remainingTimeoutMs,
+}: {
+  cwd: string;
+  targetRepo: string;
+  validationEnv: NodeJS.ProcessEnv;
+  installRegistry: string;
+  remainingTimeoutMs: () => number;
+}): void {
+  if (targetRepo !== "openclaw/openclaw") return;
+  const runnerPath = path.join(cwd, "scripts", "deadcode-knip-runner.mjs");
+  if (!fs.existsSync(runnerPath)) return;
+  const runner = fs.readFileSync(runnerPath, "utf8");
+  if (!/^const KNIP_VERSION = ["']6\.8\.0["'];/m.test(runner)) return;
+
+  // Materialize the complete reviewed dependency graph with frozen resolution;
+  // lifecycle scripts and downloaded package code never execute during setup.
+  // Seed pnpm's dlx layout from that exact install so the real repository gate
+  // can reuse it offline without ever resolving floating transitive versions.
+  const profileRoot = path.dirname(String(validationEnv.HOME));
+  const helperCache = path.join(String(validationEnv.COREPACK_HOME), PREPARED_PNPM_HELPER_CACHE);
+  const minimumReleaseAge = openClawMinimumReleaseAge(cwd);
+  const cacheRoot = path.join(
+    helperCache,
+    "pnpm",
+    "dlx",
+    pinnedOpenClawDlxCacheKey(installRegistry),
+  );
+  const helperProject = path.join(cacheRoot, "pinned");
+  fs.mkdirSync(helperProject, { recursive: true, mode: 0o700 });
+  fs.copyFileSync(PINNED_OPENCLAW_KNIP_LOCK, path.join(helperProject, "pnpm-lock.yaml"));
+  fs.writeFileSync(
+    path.join(helperProject, "package.json"),
+    JSON.stringify({
+      name: "clawsweeper-pinned-openclaw-knip",
+      private: true,
+      dependencies: { knip: PINNED_OPENCLAW_KNIP_VERSION },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(helperProject, "pnpm-workspace.yaml"),
+    `minimumReleaseAge: ${minimumReleaseAge}\n`,
+  );
+  runContainedCommand(
+    "pnpm",
+    [
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--ignore-pnpmfile",
+      `--config.minimum-release-age=${minimumReleaseAge}`,
+      "--config.enable-pre-post-scripts=false",
+      "--config.enable-global-virtual-store=false",
+      `--config.registry=${installRegistry}`,
+    ],
+    {
+      cwd: helperProject,
+      env: { ...validationEnv, XDG_CACHE_HOME: helperCache },
+      isolateNetwork: false,
+      timeoutMs: remainingTimeoutMs(),
+      writableRoots: [profileRoot],
+    },
+  );
+  scopePinnedOpenClawJitiCache(helperProject);
+  fs.symlinkSync("pinned", path.join(cacheRoot, "pkg"));
+  seedOfflinePinnedOpenClawMetadata(helperCache, installRegistry);
+  assertPinnedOpenClawValidationHelperLock(helperCache);
+}
+
+function scopePinnedOpenClawJitiCache(helperProject: string): void {
+  const knipBin = path.join(helperProject, "node_modules", ".bin", "knip");
+  const originalBin = path.join(path.dirname(knipBin), "knip-real");
+  const mode = fs.statSync(knipBin).mode;
+  fs.renameSync(knipBin, originalBin);
+  fs.writeFileSync(
+    knipBin,
+    '#!/bin/sh\nJITI_FS_CACHE=0\nexport JITI_FS_CACHE\nexec "${0%/*}/knip-real" "$@"\n',
+    { mode },
+  );
+}
+
+function pinnedOpenClawDlxCacheKey(installRegistry: string): string {
+  const resolvedPackages = [`knip@${PINNED_OPENCLAW_KNIP_VERSION}`];
+  const registries = [
+    ["@jsr", "https://npm.jsr.io/"],
+    ["default", installRegistry],
+  ];
+  return createHash("sha256")
+    .update(JSON.stringify([resolvedPackages, registries]))
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function seedOfflinePinnedOpenClawMetadata(helperCache: string, installRegistry: string): void {
+  const cacheRoot = path.join(helperCache, "pnpm");
+  const versions = fs.readdirSync(cacheRoot).filter((entry) => /^v\d+$/.test(entry));
+  // pnpm's encode-registry package replaces the host/port separator with `+`.
+  const registryHost = new URL(installRegistry).host.replace(":", "+");
+  let seeded = false;
+  for (const version of versions) {
+    const metadata = path.join(cacheRoot, version, "metadata-full", registryHost, "knip.jsonl");
+    if (!fs.existsSync(metadata)) continue;
+    const filtered = path.join(
+      cacheRoot,
+      version,
+      "metadata-full-filtered",
+      registryHost,
+      "knip.jsonl",
+    );
+    fs.mkdirSync(path.dirname(filtered), { recursive: true });
+    fs.copyFileSync(metadata, filtered);
+    seeded = true;
+  }
+  if (!seeded) {
+    throw new Error("pinned OpenClaw Knip registry metadata was not created by frozen install");
+  }
+}
+
+function openClawMinimumReleaseAge(cwd: string): number {
+  const workspacePath = path.join(cwd, "pnpm-workspace.yaml");
+  if (!fs.existsSync(workspacePath)) return MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES;
+  const workspace = parseYaml(fs.readFileSync(workspacePath, "utf8")) as {
+    minimumReleaseAge?: unknown;
+  } | null;
+  const configured = Number(workspace?.minimumReleaseAge);
+  return Number.isSafeInteger(configured)
+    ? Math.max(MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES, configured)
+    : MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES;
+}
+
+function assertPinnedOpenClawValidationHelperLock(helperCache: string): void {
+  const dlxRoot = path.join(helperCache, "pnpm", "dlx");
+  const generatedLocks = fs
+    .readdirSync(dlxRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(dlxRoot, entry.name, "pkg", "pnpm-lock.yaml"))
+    .filter((lockPath) => fs.existsSync(lockPath));
+  if (generatedLocks.length !== 1) {
+    throw new Error("pinned OpenClaw Knip dependency lockfile is missing or ambiguous");
+  }
+  const expected = parseYaml(fs.readFileSync(PINNED_OPENCLAW_KNIP_LOCK, "utf8")) as {
+    importers?: unknown;
+    packages?: unknown;
+    snapshots?: unknown;
+  };
+  const actual = parseYaml(fs.readFileSync(generatedLocks[0]!, "utf8")) as typeof expected;
+  if (
+    !isDeepStrictEqual(actual.importers, expected.importers) ||
+    !isDeepStrictEqual(actual.packages, expected.packages) ||
+    !isDeepStrictEqual(actual.snapshots, expected.snapshots)
+  ) {
+    throw new Error("pinned OpenClaw Knip dependency lockfile does not match the trusted graph");
+  }
+}
+
+export function restorePinnedOpenClawValidationHelperCache(
+  corepackHome: string,
+  cache: string,
+): void {
+  const helperCache = path.join(corepackHome, PREPARED_PNPM_HELPER_CACHE);
+  if (!fs.existsSync(helperCache)) return;
+  fs.cpSync(helperCache, cache, {
+    recursive: true,
+    verbatimSymlinks: true,
+  });
+}

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -14,6 +14,10 @@ import {
 import { parsePullRequestUrl } from "./github-ref.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import {
+  preparePinnedOpenClawValidationHelper,
+  restorePinnedOpenClawValidationHelperCache,
+} from "./pinned-openclaw-validation-helper.js";
+import {
   resolveTargetRepoToolchain,
   type TargetChangedGate,
   type TargetRepoToolchain,
@@ -318,7 +322,7 @@ export function reproduceValidationFailureAtPinnedBase({
       return null;
     }
     try {
-      prepareTargetToolchain(checkout, options);
+      prepareTargetToolchain(checkout, options, commands);
     } catch {
       return null;
     }
@@ -347,7 +351,11 @@ function isDependencyOrToolchainInputPath(filePath: string) {
   );
 }
 
-export function prepareTargetToolchain(cwd: string, options: TargetValidationOptions) {
+export function prepareTargetToolchain(
+  cwd: string,
+  options: TargetValidationOptions,
+  validationCommands?: LooseRecord[],
+) {
   clearPreparedTargetPnpmRuntime(cwd);
   if (!options.installTargetDeps) return;
   const packagePath = path.join(cwd, "package.json");
@@ -410,6 +418,12 @@ export function prepareTargetToolchain(cwd: string, options: TargetValidationOpt
       } else {
         preparedPnpmPackageManager = preparePnpmToolchain({
           cwd,
+          targetRepo: options.targetRepo,
+          preparePinnedOpenClawHelper: openClawValidationNeedsPinnedHelper(
+            cwd,
+            options,
+            validationCommands,
+          ),
           packageJson,
           validationEnv,
           setupTimeoutMs,
@@ -442,6 +456,8 @@ export function prepareTargetToolchain(cwd: string, options: TargetValidationOpt
 
 function preparePnpmToolchain({
   cwd,
+  targetRepo,
+  preparePinnedOpenClawHelper,
   packageJson,
   validationEnv,
   setupTimeoutMs,
@@ -450,6 +466,8 @@ function preparePnpmToolchain({
   installRegistry,
 }: {
   cwd: string;
+  targetRepo: string;
+  preparePinnedOpenClawHelper: boolean;
   packageJson: LooseRecord;
   validationEnv: NodeJS.ProcessEnv;
   setupTimeoutMs: number;
@@ -502,7 +520,50 @@ function preparePnpmToolchain({
     restoreTargetFile(cwd, lockfileSnapshot);
     runPnpmInstall(installArgs, "pnpm frozen reinstall");
   }
+  if (preparePinnedOpenClawHelper) {
+    preparePinnedOpenClawValidationHelper({
+      cwd,
+      targetRepo,
+      validationEnv,
+      installRegistry,
+      remainingTimeoutMs: () =>
+        targetToolchainCommandTimeout(
+          deadlineAt,
+          installTimeoutMs,
+          "pinned OpenClaw deadcode helper setup",
+        ),
+    });
+  }
   return packageManager;
+}
+
+function openClawValidationNeedsPinnedHelper(
+  cwd: string,
+  options: TargetValidationOptions,
+  validationCommands: LooseRecord[] | undefined,
+): boolean {
+  if (
+    options.targetRepo !== "openclaw/openclaw" ||
+    options.skipOpenClawChangedGate ||
+    validationCommands === undefined
+  ) {
+    return false;
+  }
+  const commands = requiredValidationCommands(validationCommands, cwd, options);
+  if (!commands.some((command) => isOpenClawChangedGateValidationCommand(command))) return false;
+  const changedPaths = options.pinnedBaseRef
+    ? gitChangedFilesFromRef(cwd, options.pinnedBaseRef)
+    : gitChangedFiles(cwd, DEFAULT_BASE_BRANCH);
+  return changedPaths.some((file) =>
+    /^(?:src|extensions|ui|packages)\/.+\.[cm]?[jt]sx?$/.test(file),
+  );
+}
+
+function isOpenClawChangedGateValidationCommand(command: LooseRecord): boolean {
+  if (typeof command !== "string") return false;
+  return /^(?:env\s+(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*)?pnpm\s+(?:-s\s+|--silent\s+)?(?:run\s+)?check:changed$/.test(
+    command.trim(),
+  );
 }
 
 function prepareBunToolchain({
@@ -1228,6 +1289,9 @@ export function runAllowedValidationCommandsWithBinding(
       // Vitest's scheduling telemetry rewrites an existing ignored artifact, which
       // violates checkout identity despite having no bearing on validation proof.
       validationEnv.OPENCLAW_TEST_PROJECTS_TIMINGS = "0";
+      // The changed gate invokes `pnpm dlx`; require its resolver to use the
+      // frozen helper metadata instead of attempting a network-only refresh.
+      validationEnv.npm_config_offline = "true";
     }
     const validationTimeoutMs = targetValidationTimeoutMs(
       "CLAWSWEEPER_TARGET_VALIDATION_TIMEOUT_MS",
@@ -4460,6 +4524,7 @@ function withTargetValidationEnvironment<T>(
         throw new Error("prepared target pnpm toolchain copy changed before validation");
       }
       assertPreparedTargetPnpmRuntime(preparedPnpmRuntime, deadlineAt);
+      restorePinnedOpenClawValidationHelperCache(corepackHome, cache);
     }
     fs.mkdirSync(corepackBin, { recursive: true, mode: 0o700 });
     fs.writeFileSync(globalConfig, "", { mode: 0o600 });

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -1753,9 +1753,17 @@ export function requiredValidationCommands(
 
 function isMutatingFormatterValidationHint(command: LooseRecord): boolean {
   if (typeof command !== "string") return false;
-  return /^(?:pnpm(?: +run)?|npm +run|bun +run) +format(?: +(?!-)[A-Za-z0-9@_./-]+)+$/.test(
-    command.replace(/^ +| +$/g, ""),
-  );
+  const text = command.replace(/^ +| +$/g, "");
+  if (!/^(?:pnpm(?: +run)?|npm +run|bun +run) +format(?: +(?!-)[A-Za-z0-9@_./-]+)+$/.test(text)) {
+    return false;
+  }
+  const parts = text.split(/ +/);
+  return parts.slice(parts.indexOf("format") + 1).every((file) => {
+    return (
+      !file.startsWith("/") &&
+      file.split("/").every((part) => part && part !== "." && part !== "..")
+    );
+  });
 }
 
 /**

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -554,7 +554,12 @@ function openClawValidationNeedsPinnedHelper(
   const changedPaths = options.pinnedBaseRef
     ? gitChangedFilesFromRef(cwd, options.pinnedBaseRef)
     : gitChangedFiles(cwd, DEFAULT_BASE_BRANCH);
-  return changedPaths.some((file) =>
+  const untrackedPaths = run("git", ["ls-files", "--others", "--exclude-standard", "-z"], {
+    cwd,
+  })
+    .split("\0")
+    .filter(Boolean);
+  return [...changedPaths, ...untrackedPaths].some((file) =>
     /^(?:src|extensions|ui|packages)\/.+\.[cm]?[jt]sx?$/.test(file),
   );
 }
@@ -1290,7 +1295,11 @@ export function runAllowedValidationCommandsWithBinding(
       // violates checkout identity despite having no bearing on validation proof.
       validationEnv.OPENCLAW_TEST_PROJECTS_TIMINGS = "0";
       // The changed gate invokes `pnpm dlx`; require its resolver to use the
-      // frozen helper metadata instead of attempting a network-only refresh.
+      // frozen helper metadata and the same approved registry used for setup.
+      // pnpm 11 ignores legacy npm_config_* environment configuration, while
+      // pnpm 10 ignores the newer PNPM_CONFIG_OFFLINE environment variable.
+      validationEnv.PNPM_CONFIG_REGISTRY = approvedTargetInstallRegistry(validationEnv);
+      validationEnv.PNPM_CONFIG_OFFLINE = "true";
       validationEnv.npm_config_offline = "true";
     }
     const validationTimeoutMs = targetValidationTimeoutMs(

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -109,6 +109,10 @@ test("formatter-hint filtering does not hide shell injection or write flags", ()
     "pnpm format src/index.ts\r\ntouch escaped",
     "pnpm format src/index.ts\r touch escaped",
     "pnpm format src/index.ts\t touch escaped",
+    "pnpm format ../outside.ts",
+    "pnpm format /absolute.ts",
+    "pnpm format src/../outside.ts",
+    "pnpm format ./src/index.ts",
   ]) {
     assert.throws(
       () =>

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3627,6 +3627,182 @@ if (args[0] === "enable") {
 });
 
 test(
+  "OpenClaw stages pinned Knip without package execution and restores its offline cache per command",
+  { skip: process.platform === "win32" },
+  () => {
+    const cwd = gitPackageFixture({ first: 'node -e ""', second: 'node -e ""' });
+    const runnerPath = path.join(cwd, "scripts", "deadcode-knip-runner.mjs");
+    fs.mkdirSync(path.dirname(runnerPath), { recursive: true });
+    fs.writeFileSync(runnerPath, 'const KNIP_VERSION = "6.8.0";\n');
+    git(cwd, "add", ".");
+    git(cwd, "commit", "-m", "initial");
+    attachOrigin(cwd);
+    const changedSource = path.join(cwd, "src", "index.ts");
+    fs.mkdirSync(path.dirname(changedSource), { recursive: true });
+    fs.writeFileSync(changedSource, "export const changed = true;\n");
+    git(cwd, "add", "src/index.ts");
+
+    const hostBin = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-knip-prefetch-"));
+    const targetBin = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-knip-pnpm-"));
+    const logPath = path.join(hostBin, "invocations.jsonl");
+    writeNodeCommandShim(
+      targetBin,
+      "pnpm",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args, cwd: process.cwd(), cache: process.env.XDG_CACHE_HOME, jitiFsCache: process.env.JITI_FS_CACHE, offline: process.env.npm_config_offline }) + "\\n");
+if (args[0] === "install") {
+  fs.mkdirSync("node_modules", { recursive: true });
+  if (process.cwd().includes(".__clawsweeper_pnpm_helper_cache__")) {
+    const helper = path.dirname(process.cwd());
+    fs.writeFileSync(path.join(helper, "marker"), "frozen helper");
+    fs.symlinkSync("marker", path.join(helper, "marker-link"));
+    const bin = path.join(process.cwd(), "node_modules", ".bin", "knip");
+    fs.mkdirSync(path.dirname(bin), { recursive: true });
+    fs.writeFileSync(bin, "#!/bin/sh\\nexit 0\\n", { mode: 0o755 });
+    if (fs.existsSync(${JSON.stringify(path.join(hostBin, "tamper-lock"))})) {
+      const lock = path.join(process.cwd(), "pnpm-lock.yaml");
+      fs.writeFileSync(lock, fs.readFileSync(lock, "utf8").replace("specifier: 6.8.0", "specifier: 6.8.1"));
+    }
+    const configuredRegistry = args.find((arg) => arg.startsWith("--config.registry="))?.slice("--config.registry=".length);
+    const registryHost = new URL(configuredRegistry).host.replace(":", "+");
+    const metadata = path.join(process.env.XDG_CACHE_HOME, "pnpm", "v11", "metadata-full", registryHost, "knip.jsonl");
+    fs.mkdirSync(path.dirname(metadata), { recursive: true });
+    fs.writeFileSync(metadata, "{}\\n");
+  }
+}
+if (args.at(-1) === "first" || args.at(-1) === "second") {
+  const marker = path.join(process.env.XDG_CACHE_HOME, "pnpm", "dlx", "a6769c4cf56f1a323ac28af3b6359f2b", "marker");
+  if (fs.readFileSync(marker, "utf8") !== "frozen helper") process.exit(42);
+  const knip = path.join(path.dirname(marker), "pinned", "node_modules", ".bin", "knip");
+  if (!fs.readFileSync(knip, "utf8").includes("JITI_FS_CACHE=0")) process.exit(43);
+  if (args.at(-1) === "first") fs.writeFileSync(marker, "validation mutated its own cache");
+}
+`,
+    );
+    writeNodeCommandShim(
+      hostBin,
+      "corepack",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args[0] === "enable") {
+  const destination = args[args.indexOf("--install-directory") + 1];
+  fs.mkdirSync(destination, { recursive: true });
+  const source = path.join(${JSON.stringify(targetBin)}, "pnpm");
+  const target = path.join(destination, "pnpm");
+  fs.copyFileSync(source, target);
+  fs.chmodSync(target, fs.statSync(source).mode);
+}
+`,
+    );
+    const options = {
+      ...validationOptions("openclaw/openclaw", {
+        toolchain: {
+          packageManager: "pnpm",
+          baseValidationCommands: [],
+          changedGate: { command: "pnpm check:changed", requiredScript: "check:changed" },
+        },
+      }),
+      installTargetDeps: true,
+      installTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+      setupTimeoutMs: FAKE_TOOLCHAIN_TIMEOUT_MS,
+    };
+
+    withCommandOverridesUnset(["corepack", "pnpm"], () =>
+      withPathOnlyPrefix(hostBin, () => {
+        prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+        assert.deepEqual(
+          runAllowedValidationCommands(["pnpm first", "pnpm second"], cwd, options),
+          ["pnpm first", "pnpm second"],
+        );
+      }),
+    );
+
+    const invocations = fs
+      .readFileSync(logPath, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    const prefetch = invocations.find(
+      ({ args, cwd: invocationCwd }) =>
+        args[0] === "install" && invocationCwd.includes(".__clawsweeper_pnpm_helper_cache__"),
+    );
+    assert.ok(prefetch);
+    assert.notEqual(prefetch.cwd, cwd);
+    assert.match(prefetch.cache, /[/\\]corepack[/\\]\.__clawsweeper_pnpm_helper_cache__$/);
+    assert.equal(prefetch.args[0], "install");
+    assert.ok(prefetch.args.includes("--frozen-lockfile"));
+    assert.ok(prefetch.args.includes("--ignore-scripts"));
+    assert.ok(prefetch.args.includes("--config.minimum-release-age=2880"));
+    assert.ok(prefetch.args.includes("--ignore-pnpmfile"));
+    assert.ok(prefetch.args.includes("--config.enable-pre-post-scripts=false"));
+    assert.ok(prefetch.args.includes("--config.enable-global-virtual-store=false"));
+    const validations = invocations.filter(({ args }) => ["first", "second"].includes(args.at(-1)));
+    assert.equal(validations.length, 2);
+    assert.notEqual(validations[0].cache, prefetch.cache);
+    assert.equal(validations[0].cache, validations[1].cache);
+    assert.ok(validations.every(({ jitiFsCache }) => jitiFsCache === undefined));
+    assert.ok(validations.every(({ offline }) => offline === "true"));
+
+    withCommandOverridesUnset(["corepack", "pnpm"], () =>
+      withPathOnlyPrefix(hostBin, () => {
+        fs.writeFileSync(path.join(hostBin, "tamper-lock"), "1");
+        assert.throws(
+          () => prepareTargetToolchain(cwd, options, ["pnpm check:changed"]),
+          /dependency lockfile does not match the trusted graph/,
+        );
+        fs.rmSync(path.join(hostBin, "tamper-lock"));
+
+        const previousRegistry = process.env.npm_config_registry;
+        process.env.npm_config_registry = "https://registry.example.invalid:8443/";
+        try {
+          prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+        } finally {
+          restoreEnv("npm_config_registry", previousRegistry);
+        }
+
+        const previousPrefetches = fs
+          .readFileSync(logPath, "utf8")
+          .split(/\r?\n/)
+          .filter((line) => {
+            if (!line) return false;
+            const invocation = JSON.parse(line);
+            return (
+              invocation.args[0] === "install" &&
+              invocation.cwd.includes(".__clawsweeper_pnpm_helper_cache__")
+            );
+          }).length;
+        prepareTargetToolchain(cwd, options);
+        prepareTargetToolchain(cwd, { ...options, skipOpenClawChangedGate: true }, [
+          "git diff --check",
+        ]);
+        git(cwd, "reset", "--", "src/index.ts");
+        fs.rmSync(changedSource);
+        fs.writeFileSync(path.join(cwd, "README.md"), "# Docs-only repair\n");
+        git(cwd, "add", "README.md");
+        prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+        const subsequentPrefetches = fs
+          .readFileSync(logPath, "utf8")
+          .split(/\r?\n/)
+          .filter((line) => {
+            if (!line) return false;
+            const invocation = JSON.parse(line);
+            return (
+              invocation.args[0] === "install" &&
+              invocation.cwd.includes(".__clawsweeper_pnpm_helper_cache__")
+            );
+          }).length;
+        assert.equal(subsequentPrefetches, previousPrefetches);
+      }),
+    );
+  },
+);
+
+test(
   "pnpm validation refreshes the prepared executable before every command",
   { skip: process.platform === "win32" },
   () => {

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3656,7 +3656,7 @@ test(
 const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
-fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args, cwd: process.cwd(), cache: process.env.XDG_CACHE_HOME, jitiFsCache: process.env.JITI_FS_CACHE, offline: process.env.npm_config_offline }) + "\\n");
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args, cwd: process.cwd(), cache: process.env.XDG_CACHE_HOME, jitiFsCache: process.env.JITI_FS_CACHE, offline: process.env.PNPM_CONFIG_OFFLINE, legacyOffline: process.env.npm_config_offline, registry: process.env.PNPM_CONFIG_REGISTRY }) + "\\n");
 if (args[0] === "install") {
   fs.mkdirSync("node_modules", { recursive: true });
   if (process.cwd().includes(".__clawsweeper_pnpm_helper_cache__")) {
@@ -3678,7 +3678,13 @@ if (args[0] === "install") {
   }
 }
 if (args.at(-1) === "first" || args.at(-1) === "second") {
-  const marker = path.join(process.env.XDG_CACHE_HOME, "pnpm", "dlx", "a6769c4cf56f1a323ac28af3b6359f2b", "marker");
+  const registry = process.env.PNPM_CONFIG_REGISTRY;
+  const cacheKey = require("node:crypto")
+    .createHash("sha256")
+    .update(JSON.stringify([["knip@6.8.0"], [["@jsr", "https://npm.jsr.io/"], ["default", registry]]]))
+    .digest("hex")
+    .slice(0, 32);
+  const marker = path.join(process.env.XDG_CACHE_HOME, "pnpm", "dlx", cacheKey, "marker");
   if (fs.readFileSync(marker, "utf8") !== "frozen helper") process.exit(42);
   const knip = path.join(path.dirname(marker), "pinned", "node_modules", ".bin", "knip");
   if (!fs.readFileSync(knip, "utf8").includes("JITI_FS_CACHE=0")) process.exit(43);
@@ -3751,6 +3757,8 @@ if (args[0] === "enable") {
     assert.equal(validations[0].cache, validations[1].cache);
     assert.ok(validations.every(({ jitiFsCache }) => jitiFsCache === undefined));
     assert.ok(validations.every(({ offline }) => offline === "true"));
+    assert.ok(validations.every(({ legacyOffline }) => legacyOffline === "true"));
+    assert.ok(validations.every(({ registry }) => registry === "https://registry.npmjs.org/"));
 
     withCommandOverridesUnset(["corepack", "pnpm"], () =>
       withPathOnlyPrefix(hostBin, () => {
@@ -3765,6 +3773,18 @@ if (args[0] === "enable") {
         process.env.npm_config_registry = "https://registry.example.invalid:8443/";
         try {
           prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+          assert.deepEqual(runAllowedValidationCommands(["pnpm first"], cwd, options), [
+            "pnpm first",
+          ]);
+          const customValidation = fs
+            .readFileSync(logPath, "utf8")
+            .trim()
+            .split(/\r?\n/)
+            .map((line) => JSON.parse(line))
+            .findLast(({ args }) => args.at(-1) === "first");
+          assert.equal(customValidation.registry, "https://registry.example.invalid:8443/");
+          assert.equal(customValidation.offline, "true");
+          assert.equal(customValidation.legacyOffline, "true");
         } finally {
           restoreEnv("npm_config_registry", previousRegistry);
         }
@@ -3789,6 +3809,11 @@ if (args[0] === "enable") {
         fs.writeFileSync(path.join(cwd, "README.md"), "# Docs-only repair\n");
         git(cwd, "add", "README.md");
         prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+        const untrackedSource = path.join(cwd, "src", "new-feature", "new.ts");
+        fs.mkdirSync(path.dirname(untrackedSource), { recursive: true });
+        fs.writeFileSync(untrackedSource, "export const untracked = true;\n");
+        prepareTargetToolchain(cwd, options, ["pnpm check:changed"]);
+        fs.rmSync(untrackedSource);
         const subsequentPrefetches = fs
           .readFileSync(logPath, "utf8")
           .split(/\r?\n/)
@@ -3800,7 +3825,7 @@ if (args[0] === "enable") {
               invocation.cwd.includes(".__clawsweeper_pnpm_helper_cache__")
             );
           }).length;
-        assert.equal(subsequentPrefetches, previousPrefetches);
+        assert.equal(subsequentPrefetches, previousPrefetches + 1);
       }),
     );
   },


### PR DESCRIPTION
## Problem

OpenClaw root-cause issue repairs were reaching their real changed-validation gate and then failing because `pnpm dlx --package knip@6.8.0 knip` tried to download Knip inside ClawSweeper's deliberately network-isolated validation sandbox. For example, repair run [30695474227](https://github.com/openclaw/clawsweeper/actions/runs/30695474227) reached `ERR_PNPM_META_FETCH_FAIL`/`EAI_AGAIN` instead of creating its OpenClaw pull request. A green outer workflow alone did not indicate successful repair.

## Changes

- Extract the pinned OpenClaw validation helper into its own narrow repair module.
- Prepare only the checked-in, exactly pinned `knip@6.8.0` helper when the selected changed-validation plan actually includes an OpenClaw source file scanned by Knip; docs-only repairs, disabled changed gates, and ordinary toolchain preparation never fetch it.
- Preserve OpenClaw's **48-hour minimum release age** and any stricter repository policy; install every transitive dependency directly from the committed `config/openclaw-knip-6.8.0.pnpm-lock.yaml` with `--frozen-lockfile`, and fail closed on any graph mismatch before downloaded package code can execute.
- Populate pnpm's existing offline `dlx` cache from that frozen installation without running downloaded package code or package lifecycle scripts.
- Explicitly disable package lifecycle scripts, pnpmfiles, pre/post scripts, and the global virtual store while staging the helper in the disposable validation profile outside the protected OpenClaw checkout.
- Bind its cache into the already immutable Corepack runtime and copy it afresh into each network-isolated validation profile, preserving the real changed-gate dead-code check without granting validation network access.
- Scope Jiti's no-filesystem-cache setting to the trusted Knip launcher only, so Knip cannot write `node_modules/.cache/jiti` while OpenClaw's own plugin-loader cache tests retain their normal behavior.
- Match pnpm's registry-host encoding, including approved registries using nondefault HTTPS ports.
- Configure pnpm 11 with its supported `PNPM_CONFIG_OFFLINE=true` and `PNPM_CONFIG_REGISTRY` variables, while preserving pnpm 10's legacy `npm_config_offline=true`, so either supported pnpm generation remains network-isolated and cannot silently fall back to the public registry or a fresh package download.
- Expand NUL-delimited, ignored-file-aware untracked paths before source classification so a newly created source directory receives the same frozen helper as a modified tracked source file.
- Reject absolute paths, `.` segments, and `..` traversal segments in otherwise trusted mutating formatter hints.
- Preserve standalone local review and leave OpenClaw issue-PR creation on `gpt-5.6-sol` / `xhigh` with `CLAWSWEEPER_ALLOW_MERGE=0`; generated OpenClaw PRs remain create-only and never enable auto-merge.

## Security-boundary disposition

The frozen dependency graph is completely committed and integrity-bound; package staging uses `--frozen-lockfile` and rejects any mismatch before helper execution. Lifecycle scripts, pnpmfiles, pre/post scripts, and the global virtual store are disabled. Setup can write only to a disposable private profile outside the protected OpenClaw checkout. The digest-bound cache is frozen, then copied privately for each isolated validation command. Only the fixed Knip launcher disables Jiti's filesystem cache. Production pnpm is explicitly forced offline and bound to the same approved registry used during frozen setup, including custom registries and nondefault ports. The real pinned helper, the protected target checkout, and the existing plugin-loader suite were verified end to end. OpenClaw fix PRs remain create-only; no target PR receives merge or auto-merge authority.

## Real behavior proof

Verified head: `2261169240cbb4d570a956c521767d7735c786ca`.

The actual pinned package was installed with `--frozen-lockfile`, full lifecycle execution disabled, and release-age enforcement enabled; then the real OpenClaw-style `pnpm check:changed` gate executed real `knip@6.8.0` with networking unavailable:

```json
{
  "actualPinnedKnipExecuted": true,
  "offlineValidationSucceeded": true,
  "commands": ["pnpm check:changed"],
  "targetJitiCacheCreated": false
}
```

The same actual end-to-end proof also succeeds when the target repository's policy is increased to seven days:

```json
{
  "actualPinnedKnipExecuted": true,
  "offlineValidationSucceeded": true,
  "minimumReleaseAgeMinutes": 10080,
  "frozenDependencyGraph": true
}
```

Separately, copying only the staged pnpm cache into a fresh profile and pointing HTTP/HTTPS/all proxies at an unreachable listener still ran the actual pinned package successfully and printed `6.8.0`.

Independent execution also confirmed that real pnpm 11 runs the frozen pinned helper with `PNPM_CONFIG_OFFLINE=true`, while pnpm 10 reports offline mode only when the preserved legacy `npm_config_offline=true` accompanies it. Focused integration coverage requires both settings and the same approved registry for every isolated validation command.

Focused coverage asserts that helper setup never writes to the OpenClaw checkout, installs only its complete frozen `knip@6.8.0` dependency graph, preserves the 48-hour release-age policy, rejects a tampered transitive dependency graph, works with registries on nondefault HTTPS ports, never downloads Knip for docs-only or disabled-gate validation, disables every package execution hook and the global virtual store, restores a clean private cache for each validation command, prevents Knip-only Jiti checkout writes without breaking existing plugin-loader tests, and rejects absolute/traversal formatter paths.

## Verification

- `pnpm run build:all`
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `pnpm run format:check`
- `pnpm run check:active-surface`
- `pnpm run check:limits`
- Focused target-validation and process-tree-containment integration suites.
- The existing OpenClaw `src/plugins/plugin-module-loader-cache.test.ts` suite: **19/19 passed** with Knip's cache override scoped to Knip alone.
- Full affected target-validation/source/workflow regression suite: **228 passed**, **3 expected skips**.
- Actual real-Knip, offline, protected-checkout proof described above.
- Independent Codex `/review` on the exact current head.
