### PR TITLE
fix(ci): release throttled live-item checks for delayed retry

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -758,6 +758,22 @@ jobs:
               echo "::notice::Completing $TARGET_REPO#$ITEM_NUMBER because the repository is accessible but the item is missing."
               exit 0
             fi
+            if grep -Eqi 'rate limit exceeded|secondary rate limit|HTTP 429' "$live_item_error"; then
+              cat "$live_item_error" >&2
+              rm -f "$live_item_error"
+              retry_at="$(node -e 'process.stdout.write(new Date(Date.now() + 20 * 60_000).toISOString())')"
+              echo "::notice::GitHub throttled the live-item check for $TARGET_REPO#$ITEM_NUMBER; releasing the claim for retry at $retry_at without spending failure budget."
+              {
+                echo "admission_retry=true"
+                echo "retry_at=$retry_at"
+                echo "proceed=false"
+                echo "terminal_noop=false"
+                echo "terminal_missing=false"
+                echo "guarded_open=false"
+                echo "guarded_open_action="
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             cat "$live_item_error" >&2
             rm -f "$live_item_error"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- GitHub-throttled live-item checks now release the review claim for a delayed retry instead of failing the run and spending failure budget.
 - Event-review artifact publication completes as a superseded no-op when the reviewed branch vanished upstream (force-push or deletion) instead of failing the run.
 - Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.
 - Exact reviews of items that closed after enqueue now complete as superseded no-ops, and GitHub-throttled reservations defer as held retries — neither spends the item's review-failure budget.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -649,6 +649,12 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(liveItem.run ?? "", /Resolved invalid queued target branch/);
   assert.match(liveItem.run ?? "", /admission_retry=true/);
+  assert.match(
+    liveItem.run ?? "",
+    /rate limit exceeded\|secondary rate limit\|HTTP 429/,
+    "a throttled live-item check must release the claim for retry instead of failing",
+  );
+  assert.match(liveItem.run ?? "", /throttled the live-item check/);
   assert.match(liveItem.run ?? "", /decision\.targetBranch = process\.env\.TARGET_BRANCH/);
   assert.match(
     step(reviewer, "Review exact event item").if ?? "",


### PR DESCRIPTION
## Problem

An 11-run failure burst at 13:12Z (e.g. run 30701241184) failed at "Check live target item state" with installation-token rate-limit 403s. #968 covered throttles at the reservation step, but the live-item check runs earlier and still fails the run — burning each item's 8-attempt review-failure budget on end-of-window API exhaustion.

## Fix

The live-item step now recognizes rate-limit stderr (`rate limit exceeded|secondary rate limit|HTTP 429`) on the item fetch and releases the claim via the existing `admission_retry` path (#962 machinery: requeue with `retry_at` +20 min, failure counters untouched). All other fetch errors still fail the step; the 404-missing-item completion is unchanged.

## Proof

- Workflow-shape assertions for the throttle branch; sweep-workflow suite 101/101 (after `build:all` — one pre-existing test appeared red locally purely from stale `dist/repair`).
- Autoreview (codex, xhigh): clean, "patch is correct (0.99)".
