### PR TITLE
fix: keep frozen Knip validation compatible across pnpm versions

### DIFF
--- a/src/repair/pinned-openclaw-validation-helper.ts
+++ b/src/repair/pinned-openclaw-validation-helper.ts
@@ -8,6 +8,7 @@ import { parse as parseYaml } from "yaml";
 import { runContainedCommand } from "./command-runner.js";
 
 const PINNED_OPENCLAW_KNIP_VERSION = "6.8.0";
+const PINNED_OPENCLAW_KNIP_PUBLISHED_AT = "2026-04-29T06:27:29.928Z";
 const PREPARED_PNPM_HELPER_CACHE = ".__clawsweeper_pnpm_helper_cache__";
 const MINIMUM_OPENCLAW_RELEASE_AGE_MINUTES = 48 * 60;
 const PINNED_OPENCLAW_KNIP_LOCK = fileURLToPath(
@@ -40,12 +41,9 @@ export function preparePinnedOpenClawValidationHelper({
   const profileRoot = path.dirname(String(validationEnv.HOME));
   const helperCache = path.join(String(validationEnv.COREPACK_HOME), PREPARED_PNPM_HELPER_CACHE);
   const minimumReleaseAge = openClawMinimumReleaseAge(cwd);
-  const cacheRoot = path.join(
-    helperCache,
-    "pnpm",
-    "dlx",
-    pinnedOpenClawDlxCacheKey(installRegistry),
-  );
+  const dlxRoot = path.join(helperCache, "pnpm", "dlx");
+  const fullCacheKey = pinnedOpenClawDlxCacheKey(installRegistry);
+  const cacheRoot = path.join(dlxRoot, fullCacheKey);
   const helperProject = path.join(cacheRoot, "pinned");
   fs.mkdirSync(helperProject, { recursive: true, mode: 0o700 });
   fs.copyFileSync(PINNED_OPENCLAW_KNIP_LOCK, path.join(helperProject, "pnpm-lock.yaml"));
@@ -83,8 +81,9 @@ export function preparePinnedOpenClawValidationHelper({
   );
   scopePinnedOpenClawJitiCache(helperProject);
   fs.symlinkSync("pinned", path.join(cacheRoot, "pkg"));
-  seedOfflinePinnedOpenClawMetadata(helperCache, installRegistry);
+  fs.symlinkSync(fullCacheKey, path.join(dlxRoot, fullCacheKey.slice(0, 32)));
   assertPinnedOpenClawValidationHelperLock(helperCache);
+  seedOfflinePinnedOpenClawMetadata(helperCache, helperProject, installRegistry);
 }
 
 function scopePinnedOpenClawJitiCache(helperProject: string): void {
@@ -107,32 +106,60 @@ function pinnedOpenClawDlxCacheKey(installRegistry: string): string {
   ];
   return createHash("sha256")
     .update(JSON.stringify([resolvedPackages, registries]))
-    .digest("hex")
-    .slice(0, 32);
+    .digest("hex");
 }
 
-function seedOfflinePinnedOpenClawMetadata(helperCache: string, installRegistry: string): void {
+function seedOfflinePinnedOpenClawMetadata(
+  helperCache: string,
+  helperProject: string,
+  installRegistry: string,
+): void {
   const cacheRoot = path.join(helperCache, "pnpm");
   const versions = fs.readdirSync(cacheRoot).filter((entry) => /^v\d+$/.test(entry));
   // pnpm's encode-registry package replaces the host/port separator with `+`.
   const registryHost = new URL(installRegistry).host.replace(":", "+");
-  let seeded = false;
-  for (const version of versions) {
-    const metadata = path.join(cacheRoot, version, "metadata-full", registryHost, "knip.jsonl");
-    if (!fs.existsSync(metadata)) continue;
-    const filtered = path.join(
-      cacheRoot,
-      version,
-      "metadata-full-filtered",
-      registryHost,
-      "knip.jsonl",
-    );
-    fs.mkdirSync(path.dirname(filtered), { recursive: true });
-    fs.copyFileSync(metadata, filtered);
-    seeded = true;
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(helperProject, "node_modules", "knip", "package.json"), "utf8"),
+  ) as Record<string, unknown>;
+  if (manifest.name !== "knip" || manifest.version !== PINNED_OPENCLAW_KNIP_VERSION) {
+    throw new Error("pinned OpenClaw Knip package does not match the trusted dependency graph");
   }
-  if (!seeded) {
-    throw new Error("pinned OpenClaw Knip registry metadata was not created by frozen install");
+  const lock = parseYaml(fs.readFileSync(PINNED_OPENCLAW_KNIP_LOCK, "utf8")) as {
+    packages?: Record<string, { resolution?: { integrity?: string } }>;
+  };
+  const integrity = lock.packages?.[`knip@${PINNED_OPENCLAW_KNIP_VERSION}`]?.resolution?.integrity;
+  if (typeof integrity !== "string" || !integrity.startsWith("sha512-")) {
+    throw new Error("pinned OpenClaw Knip integrity is missing from the trusted dependency graph");
+  }
+  const version = {
+    ...manifest,
+    dist: {
+      integrity,
+      tarball: new URL(`knip/-/knip-${PINNED_OPENCLAW_KNIP_VERSION}.tgz`, installRegistry).href,
+    },
+  };
+  const metadata = {
+    name: "knip",
+    "dist-tags": { latest: PINNED_OPENCLAW_KNIP_VERSION },
+    versions: { [PINNED_OPENCLAW_KNIP_VERSION]: version },
+    time: { [PINNED_OPENCLAW_KNIP_VERSION]: PINNED_OPENCLAW_KNIP_PUBLISHED_AT },
+    modified: PINNED_OPENCLAW_KNIP_PUBLISHED_AT,
+    cachedAt: Date.now(),
+  };
+  for (const version of versions) {
+    for (const layout of ["metadata", "metadata-full", "metadata-full-filtered"]) {
+      const destination = path.join(cacheRoot, version, layout, registryHost, "knip.jsonl");
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(
+        destination,
+        `${JSON.stringify({ modified: PINNED_OPENCLAW_KNIP_PUBLISHED_AT })}\n${JSON.stringify(metadata)}\n`,
+      );
+    }
+  }
+  for (const layout of ["metadata-v1.3", "metadata-full-v1.3", "metadata-ff-v1.3"]) {
+    const destination = path.join(cacheRoot, layout, registryHost, "knip.json");
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, JSON.stringify(metadata));
   }
 }
 

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -3666,6 +3666,9 @@ if (args[0] === "install") {
     const bin = path.join(process.cwd(), "node_modules", ".bin", "knip");
     fs.mkdirSync(path.dirname(bin), { recursive: true });
     fs.writeFileSync(bin, "#!/bin/sh\\nexit 0\\n", { mode: 0o755 });
+    const manifest = path.join(process.cwd(), "node_modules", "knip", "package.json");
+    fs.mkdirSync(path.dirname(manifest), { recursive: true });
+    fs.writeFileSync(manifest, JSON.stringify({ name: "knip", version: "6.8.0" }));
     if (fs.existsSync(${JSON.stringify(path.join(hostBin, "tamper-lock"))})) {
       const lock = path.join(process.cwd(), "pnpm-lock.yaml");
       fs.writeFileSync(lock, fs.readFileSync(lock, "utf8").replace("specifier: 6.8.0", "specifier: 6.8.1"));
@@ -3679,13 +3682,23 @@ if (args[0] === "install") {
 }
 if (args.at(-1) === "first" || args.at(-1) === "second") {
   const registry = process.env.PNPM_CONFIG_REGISTRY;
-  const cacheKey = require("node:crypto")
+  const fullCacheKey = require("node:crypto")
     .createHash("sha256")
     .update(JSON.stringify([["knip@6.8.0"], [["@jsr", "https://npm.jsr.io/"], ["default", registry]]]))
-    .digest("hex")
-    .slice(0, 32);
+    .digest("hex");
+  const cacheKey = fullCacheKey.slice(0, 32);
   const marker = path.join(process.env.XDG_CACHE_HOME, "pnpm", "dlx", cacheKey, "marker");
   if (fs.readFileSync(marker, "utf8") !== "frozen helper") process.exit(42);
+  if (fs.readFileSync(path.join(process.env.XDG_CACHE_HOME, "pnpm", "dlx", fullCacheKey, "marker"), "utf8") !== "frozen helper") process.exit(44);
+  const host = new URL(registry).host.replace(":", "+");
+  for (const metadataPath of [
+    path.join(process.env.XDG_CACHE_HOME, "pnpm", "v11", "metadata-full-filtered", host, "knip.jsonl"),
+    path.join(process.env.XDG_CACHE_HOME, "pnpm", "metadata-ff-v1.3", host, "knip.json"),
+  ]) {
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8").trim().split("\\n").at(-1));
+    if (Object.keys(metadata.versions).join(",") !== "6.8.0") process.exit(45);
+    if (!metadata.versions["6.8.0"].dist.integrity.startsWith("sha512-")) process.exit(46);
+  }
   const knip = path.join(path.dirname(marker), "pinned", "node_modules", ".bin", "knip");
   if (!fs.readFileSync(knip, "utf8").includes("JITI_FS_CACHE=0")) process.exit(43);
   if (args.at(-1) === "first") fs.writeFileSync(marker, "validation mutated its own cache");


### PR DESCRIPTION
## Problem

Deep independent review of the newly deployed frozen Knip helper found that pnpm 10 and early pnpm 11 use a 64-character `dlx` cache key, while current pnpm 11 uses a 32-character key. Their registry metadata layouts also differ. The original helper could therefore miss its own reviewed frozen dependency graph or reject older package-manager checkouts before validation.

## Changes

- Create one integrity-verified frozen dependency installation and expose both package-manager cache keys as aliases to the exact same immutable package graph.
- Generate exact-version, integrity-bound registry metadata directly from the reviewed lock and installed package manifest for both legacy pnpm 10 and current pnpm 11 layouts.
- Preserve the actual pinned package publication time and target release-age policy.
- Verify the complete generated dependency graph before publishing any synthetic registry metadata.
- Keep every validation offline, retain package lifecycle restrictions and private per-command cache copies, preserve standalone local review, and leave OpenClaw fix PRs create-only on `gpt-5.6-sol` / `xhigh` with merge and auto-merge disabled.

## Real behavior proof

Real offline execution of pinned `knip@6.8.0`, each using the exact same frozen reviewed dependency graph:

```json
[
  {"packageManager":"pnpm 10.33","exitCode":0,"output":"6.8.0"},
  {"packageManager":"pnpm 11.0","exitCode":0,"output":"6.8.0"},
  {"packageManager":"pnpm 11.15","exitCode":0,"output":"6.8.0"}
]
```

The real OpenClaw-style changed-validation command also succeeds with its minimum release-age policy raised to seven days:

```json
{"actualPinnedKnipExecuted":true,"offlineValidationSucceeded":true,"commands":["pnpm check:changed"],"targetJitiCacheCreated":false}
{"minimumReleaseAgeMinutes":10080,"frozenDependencyGraph":true}
```

Focused regression coverage asserts that both cache keys reach the same verified installation, both metadata formats expose only version `6.8.0`, the metadata carries the exact committed SHA-512 integrity, custom registry ports remain bound, and tampered dependency graphs still fail closed.

## Security-boundary disposition

This narrows the existing dependency boundary: generated metadata advertises exactly one reviewed version and its integrity is taken directly from the committed frozen lock. Both cache aliases resolve to the same verified installation; no second package graph can be created. Package staging remains frozen, lifecycle scripts and pnpmfiles remain disabled, package code cannot execute during installation, every command gets a private cache copy, and OpenClaw PRs remain create-only.

## Verification

- `pnpm run build:repair`
- `pnpm run lint:repair`
- `pnpm run lint:scripts`
- `pnpm exec oxfmt --check src/repair/pinned-openclaw-validation-helper.ts test/repair/target-validation.test.ts`
- Focused target-validation integration tests.
- Real network-isolated pinned-Knip execution under pnpm 10.33, 11.0, and 11.15.
- Real OpenClaw-style changed validation with a seven-day minimum release-age policy.
- Independent Codex `/review`.
