### PR TITLE
fix(ci): keep throttled terminal status updates from failing finalization runs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3202,12 +3202,21 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
+          update_log="$(mktemp)"
+          trap 'rm -f "$update_log"' EXIT
           pnpm run repair:update-command-status -- \
             --repo "$TARGET_REPO" --item-number "$ITEM_NUMBER" \
             --marker "$COMMAND_STATUS_MARKER" --status-comment-id "$STATUS_COMMENT_ID" \
             --state "$STATUS_STATE" --detail "$STATUS_DETAIL" --run-url "$RUN_URL" \
-            --require-mutation --locked-conversation-terminal-skip --verify-terminal-status-receipt || {
+            --require-mutation --locked-conversation-terminal-skip --verify-terminal-status-receipt 2>&1 | tee "$update_log" || {
               update_status="$?"
+              # End-of-window installation throttling is self-healing: the
+              # requeue step re-arms the driver for after the rate window, so
+              # the failure sentinel must not turn this run red.
+              if grep -Eqi 'rate limit exceeded|secondary rate limit|HTTP 429' "$update_log"; then
+                echo "throttled=true" >> "$GITHUB_OUTPUT"
+                echo "::notice::GitHub throttled the terminal status update; the requeue step retries after the rate window."
+              fi
               failure_payload="$(node -e '
                 const revision = Number(process.env.REVISION);
                 if (!process.env.FENCE_KEY || !process.env.ATTEMPT_ID || !Number.isInteger(revision) || revision < 1) process.exit(1);
@@ -3354,7 +3363,7 @@ jobs:
           jq -e '.ok == true and (.requeued == true or .completed == true)' "$response_file" >/dev/null
 
       - name: Fail failed terminal acknowledgement
-        if: ${{ steps.update-final-command-status.outcome == 'failure' || steps.complete-locked-terminal-acknowledgement.outcome == 'failure' || steps.terminal-acknowledgement.outcome == 'failure' || steps.target-write-token.outcome == 'failure' }}
+        if: ${{ (steps.update-final-command-status.outcome == 'failure' && steps.update-final-command-status.outputs.throttled != 'true') || steps.complete-locked-terminal-acknowledgement.outcome == 'failure' || steps.terminal-acknowledgement.outcome == 'failure' || steps.target-write-token.outcome == 'failure' }}
         run: exit 1
 
   target-fanout:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
+
+
 - GitHub-throttled live-item checks now release the review claim for a delayed retry instead of failing the run and spending failure budget.
 - Event-review artifact publication completes as a superseded no-op when the reviewed branch vanished upstream (force-push or deletion) instead of failing the run.
 - Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1215,6 +1215,20 @@ test("exact event publication derives lifecycle receipt and final command acknow
   );
   assert.match(retry.run ?? "", /response_status/);
   assert.match(retry.run ?? "", /lease_not_active/);
+  assert.match(
+    statusEdit?.run ?? "",
+    /rate limit exceeded\|secondary rate limit\|HTTP 429/,
+    "throttled terminal status updates must be marked for the failure sentinel",
+  );
+  assert.match(statusEdit?.run ?? "", /throttled=true/);
+  const failSentinel = finalizer.steps.find(
+    (candidate) => candidate.name === "Fail failed terminal acknowledgement",
+  );
+  assert.match(
+    failSentinel?.if ?? "",
+    /update-final-command-status\.outcome == 'failure' && steps\.update-final-command-status\.outputs\.throttled != 'true'/,
+    "a throttled update must not red the run — the requeue step already re-arms the driver",
+  );
   const workflowSource = readText(".github/workflows/sweep.yml");
   assert.ok(
     workflowSource.indexOf("Complete durable exact review publication") <


### PR DESCRIPTION
## Problem

Three terminal-finalization runs went red at 18:11Z (e.g. run 30711958776) when the installation token hit its window-end rate limit during "Update final command status once". The requeue step already re-arms the acknowledgement for after the rate window — the run only turned red because the failure sentinel fires on any update failure. Same self-healing-noise family as #968/#1002.

## Fix

The update step tees its output and, on a rate-limit signature, sets `throttled=true`; the "Fail failed terminal acknowledgement" sentinel ignores update failures marked throttled. All other update failures (and all other sentinel triggers) still fail the run. The failed-ack lifecycle POST still fires, so the DO sees the attempt outcome either way.

## Proof

- Workflow-shape assertions for the throttle marker and the sentinel guard; sweep-workflow suite 102/102.
- Autoreview (codex, xhigh): clean, "patch is correct (0.97)".
