### PR TITLE
fix: prevent guarded dead-letter reconciliation starvation

### DIFF
--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -18,10 +18,13 @@ const ACTIVE_RECOVERY_REASONS = new Set(["fresh_review_already_active", "publica
 const IDEMPOTENCY_KEY = /^[A-Za-z0-9:._-]{1,200}$/;
 
 class DeadLetterInventoryChangedError extends Error {
-  constructor(summary) {
+  constructor(summary, rowIds, targetKeys, blockedGroups) {
     super("dead-letter cleanup changed during reconciliation; refusing stale recovery");
     this.name = "DeadLetterInventoryChangedError";
     this.summary = summary;
+    this.rowIds = [...new Set(rowIds)];
+    this.targetKeys = [...new Set(targetKeys.filter(Boolean).map(normalizeRecoveryTargetKey))];
+    this.blockedGroups = blockedGroups ?? [{ rowIds: this.rowIds, targetKeys: this.targetKeys }];
   }
 }
 
@@ -69,7 +72,14 @@ async function main(argv) {
   }
 
   if (args.action === "reconcile") {
-    const progress = { summary: null };
+    const progress = {
+      summary: null,
+      blockedRows: new Set(),
+      blockedTargets: new Set(),
+      countedSkippedTargets: new Set(),
+      inspectedTargetIds: new Set(),
+      pendingRecoveryTargetIds: new Set(),
+    };
     for (let refreshes = 0; refreshes <= MAX_RECONCILE_INVENTORY_REFRESHES; refreshes += 1) {
       try {
         await reconcileDeadLetters({ inventory, queueUrl, secret, args, progress });
@@ -78,12 +88,17 @@ async function main(argv) {
         if (!(error instanceof DeadLetterInventoryChangedError)) throw error;
         // Guarded resolution is one Worker transaction: an inventory race skips
         // every requested row. Refuse recovery if that safety contract changes.
-        if (error.summary.resolved !== 0 || error.summary.unparked !== 0) {
+        if (
+          error.summary.resolved !== 0 ||
+          error.summary.unparked !== 0 ||
+          error.summary.skipped !== error.rowIds.length
+        ) {
           throw new Error("guarded dead-letter cleanup was not atomic; refusing stale recovery");
         }
         if (
           refreshes === MAX_RECONCILE_INVENTORY_REFRESHES ||
-          progress.summary.inspected_targets >= args.maxTargets
+          (progress.summary.inspected_targets >= args.maxTargets &&
+            progress.pendingRecoveryTargetIds.size === 0)
         ) {
           // Never recover against stale aliases if producers keep changing the
           // inventory faster than this bounded operator can inspect it. Keep
@@ -100,6 +115,24 @@ async function main(argv) {
           secret,
           maxPages: MAX_RECONCILE_INVENTORY_PAGES,
         });
+        const openRowIds = new Set(inventory.dead_letters.map((row) => row.dead_letter_id));
+        for (const blocked of error.blockedGroups) {
+          const unchangedRowIds = blocked.rowIds.filter((id) => openRowIds.has(id));
+          for (const id of unchangedRowIds) progress.blockedRows.add(id);
+          if (unchangedRowIds.length) {
+            if (
+              blocked.targetKeys.every((target) => !/^([^/]+)\/([^#]+)#([1-9]\d*)$/.test(target))
+            ) {
+              for (const row of inventory.dead_letters) {
+                const target = row.fresh_recovery.item_key;
+                if (!target || !/^([^/]+)\/([^#]+)#([1-9]\d*)$/.test(target)) {
+                  progress.blockedRows.add(row.dead_letter_id);
+                }
+              }
+            }
+            for (const target of blocked.targetKeys) progress.blockedTargets.add(target);
+          }
+        }
         await writeFile(args.output, `${JSON.stringify(inventory, null, 2)}\n`, "utf8");
       }
     }
@@ -253,12 +286,13 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
   });
   summary.inventory_complete = inventory.complete;
   summary.queue_pressure = initialPressure.status;
+  progress.pendingRecoveryTargetIds.clear();
   const groups = new Map();
   const invalidRows = [];
   for (const row of inventory.dead_letters) {
     const target = row.fresh_recovery.item_key;
     if (!target || !/^([^/]+)\/([^#]+)#([1-9]\d*)$/.test(target)) {
-      invalidRows.push(row);
+      if (!progress.blockedRows.has(row.dead_letter_id)) invalidRows.push(row);
       continue;
     }
     const key = normalizeRecoveryTargetKey(target);
@@ -266,13 +300,57 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
     group.rows.push(row);
     groups.set(key, group);
   }
+  const blockedResolutions = [];
+  const resolveForReconciliation = async (options) => {
+    try {
+      return await reconcileResolve(options);
+    } catch (error) {
+      if (
+        !(error instanceof DeadLetterInventoryChangedError) ||
+        error.summary.resolved !== 0 ||
+        error.summary.unparked !== 0 ||
+        error.summary.skipped !== error.rowIds.length
+      ) {
+        throw error;
+      }
+      blockedResolutions.push(error);
+      return { ...error.summary, blocked: true };
+    }
+  };
+  const refreshBlockedInventory = () => {
+    if (!blockedResolutions.length) return;
+    throw new DeadLetterInventoryChangedError(
+      {
+        resolved: 0,
+        skipped: blockedResolutions.reduce((total, error) => total + error.summary.skipped, 0),
+        unparked: 0,
+      },
+      blockedResolutions.flatMap((error) => error.rowIds),
+      blockedResolutions.flatMap((error) => error.targetKeys),
+      blockedResolutions.flatMap((error) => error.blockedGroups),
+    );
+  };
+  const accountSkippedTarget = (nodeId) => {
+    if (progress.countedSkippedTargets.has(nodeId)) return;
+    progress.countedSkippedTargets.add(nodeId);
+    summary.skipped_targets += 1;
+  };
+  const canInspectTarget = (nodeId) =>
+    progress.inspectedTargetIds.has(nodeId) || summary.inspected_targets < args.maxTargets;
+  const reserveTargetInspection = (nodeId) => {
+    if (progress.inspectedTargetIds.has(nodeId)) return true;
+    if (summary.inspected_targets >= args.maxTargets) return false;
+    progress.inspectedTargetIds.add(nodeId);
+    summary.inspected_targets += 1;
+    return true;
+  };
 
   // A partial page window cannot prove that a transferred alias or an active
   // sibling was observed. Invalid rows are independently terminal and safe to
   // drain; every GitHub-targeted mutation waits for a complete inventory.
   if (!inventory.complete) {
     if (invalidRows.length) {
-      const resolution = await reconcileResolve({
+      const resolution = await resolveForReconciliation({
         queueUrl,
         secret,
         rows: invalidRows.slice(0, MAX_RESOLUTION_IDS),
@@ -283,6 +361,7 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
       summary.resolved_rows += resolution.resolved;
       summary.invalid_rows += resolution.resolved;
     }
+    refreshBlockedInventory();
     summary.skipped_targets += groups.size;
     printResult(summary);
     return;
@@ -293,7 +372,7 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
     identities = await inspectCanonicalTargets([...groups.values()], args.maxTargets);
   } catch {
     if (invalidRows.length) {
-      const resolution = await reconcileResolve({
+      const resolution = await resolveForReconciliation({
         queueUrl,
         secret,
         rows: invalidRows.slice(0, MAX_RESOLUTION_IDS),
@@ -304,6 +383,7 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
       summary.resolved_rows += resolution.resolved;
       summary.invalid_rows += resolution.resolved;
     }
+    refreshBlockedInventory();
     summary.skipped_targets += groups.size;
     printResult(summary);
     return;
@@ -342,31 +422,35 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
         ...(live.canonical_target ? [normalizeRecoveryTargetKey(live.canonical_target)] : []),
       ]),
     ];
+    if (groupAliases.some((alias) => progress.blockedTargets.has(alias))) {
+      accountSkippedTarget(live.node_id);
+      continue;
+    }
     if (
       hasActiveWork ||
       (live.state === "open" && !rows.some((row) => row.fresh_recovery.eligible))
     ) {
-      summary.skipped_targets += 1;
+      accountSkippedTarget(live.node_id);
       continue;
     }
     if (live.state === "closed") {
-      if (summary.inspected_targets >= args.maxTargets) {
-        summary.skipped_targets += 1;
+      if (!canInspectTarget(live.node_id)) {
+        accountSkippedTarget(live.node_id);
         continue;
       }
       let current;
       try {
         current = await inspectRecoveryTarget(canonicalTarget);
       } catch {
-        summary.skipped_targets += 1;
+        accountSkippedTarget(live.node_id);
         continue;
       }
       if (current.state !== "closed" || current.node_id !== live.node_id) {
-        summary.skipped_targets += 1;
+        accountSkippedTarget(live.node_id);
         continue;
       }
-      summary.inspected_targets += 1;
-      const resolution = await reconcileResolve({
+      reserveTargetInspection(live.node_id);
+      const resolution = await resolveForReconciliation({
         queueUrl,
         secret,
         rows: rows.slice(0, MAX_RESOLUTION_IDS),
@@ -376,6 +460,9 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
         canonicalTarget: current.canonical_target,
         aliases: groupAliases,
       });
+      if (resolution.blocked) {
+        continue;
+      }
       summary.resolved_rows += resolution.resolved;
       summary.closed_rows += resolution.resolved;
       if (resolution.unparked) {
@@ -391,24 +478,23 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
           row.fresh_recovery.source_head_sha === live.head_sha),
     );
     if (!primary || summary.recovered_targets + recoveries.length >= args.maxRecoveries) {
-      summary.skipped_targets += 1;
+      accountSkippedTarget(live.node_id);
       continue;
     }
     const pressure = await readQueuePressure(queueUrl);
     summary.queue_pressure = pressure.status;
     if (pressure.status !== "idle" || pressure.availableSlots <= recoveries.length) {
-      summary.skipped_targets += 1;
+      accountSkippedTarget(live.node_id);
       continue;
     }
-    if (summary.inspected_targets >= args.maxTargets) {
-      summary.skipped_targets += 1;
+    if (!reserveTargetInspection(live.node_id)) {
+      accountSkippedTarget(live.node_id);
       continue;
     }
-    summary.inspected_targets += 1;
     const duplicates = rows.filter((row) => row.dead_letter_id !== primary.dead_letter_id);
     if (duplicates.length) {
       const selectedDuplicates = duplicates.slice(0, MAX_RESOLUTION_IDS);
-      const resolution = await reconcileResolve({
+      const resolution = await resolveForReconciliation({
         queueUrl,
         secret,
         rows: selectedDuplicates,
@@ -418,6 +504,9 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
         canonicalTarget: live.canonical_target,
         aliases: groupAliases,
       });
+      if (resolution.blocked) {
+        continue;
+      }
       summary.resolved_rows += resolution.resolved;
       summary.duplicate_rows += resolution.resolved;
       if (
@@ -425,7 +514,7 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
         resolution.resolved !== selectedDuplicates.length ||
         duplicates.length > MAX_RESOLUTION_IDS
       ) {
-        summary.skipped_targets += 1;
+        accountSkippedTarget(live.node_id);
         if (resolution.unparked) {
           printResult(summary);
           return;
@@ -439,10 +528,11 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
       live,
       aliases: groupAliases,
     });
+    progress.pendingRecoveryTargetIds.add(live.node_id);
   }
 
   if (invalidRows.length) {
-    const resolution = await reconcileResolve({
+    const resolution = await resolveForReconciliation({
       queueUrl,
       secret,
       rows: invalidRows.slice(0, MAX_RESOLUTION_IDS),
@@ -458,6 +548,7 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
     }
   }
 
+  refreshBlockedInventory();
   if (recoveries.length) {
     for (const recovery of recoveries) {
       let current;
@@ -601,7 +692,15 @@ async function reconcileResolve({
   });
   const summary = mutationSummary("resolve", result);
   if (summary.resolved !== rows.length || summary.skipped !== 0) {
-    throw new DeadLetterInventoryChangedError(summary);
+    throw new DeadLetterInventoryChangedError(
+      summary,
+      rows.map((row) => row.dead_letter_id),
+      [
+        ...rows.map((row) => row.fresh_recovery.item_key),
+        ...(canonicalTarget ? [canonicalTarget] : []),
+        ...aliases,
+      ],
+    );
   }
   for (const row of rows) openIds?.delete(row.dead_letter_id);
   return summary;

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -428,6 +428,465 @@ test("concurrent duplicate cleanup refreshes inventory before safe recovery", as
   assert.deepEqual(scenario.recoveries[0]?.ids, ["primary"]);
 });
 
+test("an unchanged blocked cleanup cannot starve independent fresh recovery", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "blocked",
+        "publication:blocked",
+        1,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#1",
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+    ],
+    closedNumbers: [1],
+    blockedCleanupIds: ["blocked"],
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 2);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(summary.skipped_targets, 1);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.resolutions.map((resolution) => resolution.ids),
+    [["blocked"]],
+  );
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+});
+
+test("a blocked targetless legacy row cannot starve independent fresh recovery", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "legacy-blocked",
+        "publication:legacy-blocked",
+        1,
+        "tuple_protocol_invalid",
+        false,
+        "invalid_dead_letter_item",
+        null,
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+    ],
+    blockedCleanupIds: ["legacy-blocked"],
+    maxTargets: 1,
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 1);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(summary.invalid_rows, 0);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.resolutions.map((resolution) => resolution.ids),
+    [["legacy-blocked"]],
+  );
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+});
+
+test("many blocked targetless legacy rows cannot exhaust the inventory refresh budget", async () => {
+  const blocked = Array.from({ length: 60 }, (_, index) =>
+    row(
+      `legacy-${index}`,
+      `publication:legacy-${index}`,
+      index + 1,
+      "tuple_protocol_invalid",
+      false,
+      "invalid_dead_letter_item",
+      null,
+    ),
+  );
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      ...blocked,
+      row(
+        "recoverable",
+        "publication:recoverable",
+        61,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+    ],
+    blockedCleanupIds: blocked.map((entry) => entry.dead_letter_id),
+    maxTargets: 1,
+    maxRecoveries: 1,
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 1);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.equal(scenario.resolutions.length, 1);
+  assert.equal(scenario.resolutions[0]?.ids.length, 20);
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+});
+
+test("multiple independently blocked groups share one authoritative refresh", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      ...Array.from({ length: 3 }, (_, index) =>
+        row(
+          `blocked-${index + 1}`,
+          `publication:blocked-${index + 1}`,
+          index + 1,
+          "retry_exhausted",
+          true,
+          "eligible",
+          `openclaw/repo#${index + 1}`,
+        ),
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        4,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#4",
+      ),
+    ],
+    closedNumbers: [1, 2, 3],
+    blockedCleanupIds: ["blocked-1", "blocked-2", "blocked-3"],
+    maxTargets: 4,
+    maxRecoveries: 1,
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 4);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(summary.skipped_targets, 3);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.resolutions.map((resolution) => resolution.ids),
+    [["blocked-1"], ["blocked-2"], ["blocked-3"]],
+  );
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+});
+
+test("blocked canonical targets are counted only once across inventory refreshes", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      ...Array.from({ length: 2 }, (_, index) =>
+        row(
+          `blocked-${index + 1}`,
+          `publication:blocked-${index + 1}`,
+          index + 1,
+          "retry_exhausted",
+          true,
+          "eligible",
+          `openclaw/repo#${index + 1}`,
+        ),
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        3,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#3",
+      ),
+    ],
+    closedNumbers: [1, 2],
+    blockedCleanupIds: ["blocked-1", "blocked-2"],
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 3);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(summary.skipped_targets, 2);
+  assert.equal(scenario.inventoryRequests, 2);
+});
+
+test("active and capped targets are counted only once across blocked inventory refreshes", async () => {
+  for (const active of [true, false]) {
+    const scenario = await automaticReconcileScenario({
+      rows: [
+        row(
+          "blocked",
+          "publication:blocked",
+          1,
+          "retry_exhausted",
+          true,
+          "eligible",
+          "openclaw/repo#1",
+        ),
+        row(
+          "recoverable",
+          "publication:recoverable",
+          2,
+          "retry_exhausted",
+          true,
+          "eligible",
+          "openclaw/repo#2",
+        ),
+        row(
+          "deferred",
+          "publication:deferred",
+          3,
+          "retry_exhausted",
+          !active,
+          active ? "fresh_review_already_active" : "eligible",
+          "openclaw/repo#3",
+        ),
+      ],
+      closedNumbers: [1],
+      blockedCleanupIds: ["blocked"],
+      maxTargets: 3,
+      maxRecoveries: 1,
+    });
+
+    assert.equal(scenario.first.code, 0, scenario.first.stderr);
+    const summary = JSON.parse(scenario.first.stdout);
+    assert.equal(summary.recovered_targets, 1);
+    assert.equal(summary.skipped_targets, 2);
+    assert.equal(scenario.inventoryRequests, 2);
+  }
+});
+
+test("staged recovery retains its original target budget across a blocked refresh", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "blocked",
+        "publication:blocked",
+        1,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#1",
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+      row(
+        "over-budget",
+        "publication:over-budget",
+        3,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#3",
+      ),
+    ],
+    closedNumbers: [1],
+    blockedCleanupIds: ["blocked"],
+    maxTargets: 2,
+    maxRecoveries: 1,
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 2);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+});
+
+test("blocked duplicate cleanup fences its primary without starving another target", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "blocked-primary",
+        "publication:blocked-primary",
+        1,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#1",
+      ),
+      row(
+        "blocked-duplicate",
+        "publication:blocked-duplicate",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#1",
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        3,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+    ],
+    blockedCleanupIds: ["blocked-duplicate"],
+    maxTargets: 2,
+    maxRecoveries: 1,
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 2);
+  assert.equal(summary.recovered_targets, 1);
+  assert.equal(summary.skipped_targets, 1);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+});
+
+test("only unchanged blocked groups fence aliases after an aggregated refresh", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "blocked",
+        "publication:blocked",
+        1,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#1",
+      ),
+      row(
+        "primary",
+        "publication:primary",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+      row(
+        "duplicate",
+        "publication:duplicate",
+        3,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        4,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#3",
+      ),
+    ],
+    closedNumbers: [1],
+    blockedCleanupIds: ["blocked"],
+    skipDuplicateCleanupCount: 1,
+    maxTargets: 3,
+    maxRecoveries: 2,
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.inspected_targets, 3);
+  assert.equal(summary.recovered_targets, 2);
+  assert.equal(summary.skipped_targets, 1);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.resolutions.map((resolution) => resolution.ids),
+    [["blocked"], ["duplicate"]],
+  );
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["primary", "recoverable"]],
+  );
+});
+
+test("a blocked transferred alias fences its whole target without starving another", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "blocked-old",
+        "publication:blocked-old",
+        1,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/old#1",
+      ),
+      row(
+        "blocked-new",
+        "publication:blocked-new",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/new#19",
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        3,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+    ],
+    closedNumbers: [1, 19],
+    blockedCleanupIds: ["blocked-old"],
+    nodeId: (number) => (number === 2 ? "INDEPENDENT" : "BLOCKED_TRANSFER"),
+  });
+
+  assert.equal(scenario.first.code, 0, scenario.first.stderr);
+  assert.equal(JSON.parse(scenario.first.stdout).recovered_targets, 1);
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["recoverable"]],
+  );
+  assert.equal(scenario.resolutions.length, 1);
+});
+
 test("reconciliation rejects a non-atomic guarded cleanup response", async () => {
   const scenario = await automaticReconcileScenario({
     rows: [
@@ -468,7 +927,39 @@ test("reconciliation rejects a non-atomic guarded cleanup response", async () =>
   assert.equal(scenario.recoveries.length, 0);
 });
 
-test("repeated cleanup races remain bounded and never recover stale aliases", async () => {
+test("reconciliation rejects a malformed zero-mutation guarded cleanup response", async () => {
+  const scenario = await automaticReconcileScenario({
+    rows: [
+      row(
+        "blocked",
+        "publication:blocked",
+        1,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#1",
+      ),
+      row(
+        "recoverable",
+        "publication:recoverable",
+        2,
+        "retry_exhausted",
+        true,
+        "eligible",
+        "openclaw/repo#2",
+      ),
+    ],
+    closedNumbers: [1],
+    malformedGuardIds: ["blocked"],
+  });
+
+  assert.equal(scenario.first.code, 1);
+  assert.match(scenario.first.stderr, /guarded dead-letter cleanup was not atomic/);
+  assert.equal(scenario.inventoryRequests, 1);
+  assert.equal(scenario.recoveries.length, 0);
+});
+
+test("independent cleanup races refresh once before recovering current aliases", async () => {
   const rows = Array.from({ length: 3 }, (_, index) => [
     row(
       `primary-${index}`,
@@ -495,10 +986,18 @@ test("repeated cleanup races remain bounded and never recover stale aliases", as
   });
 
   assert.equal(scenario.first.code, 0, scenario.first.stderr);
-  assert.equal(JSON.parse(scenario.first.stdout).inventory_changed, true);
-  assert.equal(JSON.parse(scenario.first.stdout).recovered_targets, 0);
-  assert.equal(scenario.inventoryRequests, 3);
-  assert.equal(scenario.recoveries.length, 0);
+  const summary = JSON.parse(scenario.first.stdout);
+  assert.equal(summary.recovered_targets, 3);
+  assert.equal(summary.inspected_targets, 3);
+  assert.equal(scenario.inventoryRequests, 2);
+  assert.deepEqual(
+    scenario.resolutions.map((resolution) => resolution.ids),
+    [["duplicate-0"], ["duplicate-1"], ["duplicate-2"]],
+  );
+  assert.deepEqual(
+    scenario.recoveries.map((recovery) => recovery.ids),
+    [["primary-0", "primary-1", "primary-2"]],
+  );
 });
 
 test("inventory refreshes preserve the original per-run target budget", async () => {
@@ -1571,6 +2070,16 @@ async function automaticReconcileScenario(options) {
       return;
     }
     resolutions.push(body);
+    if (options.malformedGuardIds?.some((id) => body.ids.includes(id))) {
+      response.end(JSON.stringify({ ok: true, resolved: 0, skipped: 0, unparked: 0 }));
+      return;
+    }
+    if (options.blockedCleanupIds?.some((id) => body.ids.includes(id))) {
+      response.end(
+        JSON.stringify({ ok: true, resolved: 0, skipped: body.ids.length, unparked: 0 }),
+      );
+      return;
+    }
     if (duplicateSkipsRemaining > 0 || options.skipCleanupAtResolution === resolutions.length) {
       if (duplicateSkipsRemaining > 0) duplicateSkipsRemaining -= 1;
       for (const id of body.ids) {


### PR DESCRIPTION
## Summary

- Aggregate every atomically rejected guarded cleanup from one inventory scan, refresh authoritative inventory once, then fence still-open blocked rows and every transferred/canonical alias instead of repeatedly spending the retry budget on unchanged targets.
- Preserve recovery for any number of targetless legacy rows, multiple independently blocked groups, and recovery candidates staged at the original target cap; keep distinct canonical inspections/skipped counts stable across refreshes and reject malformed guarded cleanup responses.
- Preserve atomic guarded cleanup, active-review/publication fences, source-head validation, conservative capacity checks, and create-only OpenClaw PR behavior.

## Direct production failure

The first production run after landing the bounded-refresh fix succeeded as a workflow but recovered no work because it kept inspecting the same unchanged blocked target:

https://github.com/openclaw/clawsweeper/actions/runs/30757712437

```json
{"action":"reconcile","dry_run":false,"inventory_complete":true,"queue_pressure":"idle","inspected_targets":3,"recovered_targets":0,"resolved_rows":0,"invalid_rows":0,"closed_rows":0,"duplicate_rows":0,"active_review_rows":0,"skipped_targets":3,"inventory_changed":true,"skipped_rows":1}
```

Its sanitized production artifact contained 1,387 open dead letters and 1,384 fresh-recovery-eligible rows, so zero recoveries reflected starvation rather than lack of recoverable work.

## After-fix real operator subprocess

This executes the actual production operator as a separate Node process against real signed local HTTP endpoints. A closed target rejects guarded cleanup without changing inventory; after one authoritative refresh, its aliases remain fenced and an independent open target is recovered:

```console
$ node /tmp/clawsweeper-starvation-proof.mjs
{
  "exit_code": 0,
  "summary": {
    "action": "reconcile",
    "dry_run": false,
    "inventory_complete": true,
    "queue_pressure": "idle",
    "inspected_targets": 2,
    "recovered_targets": 1,
    "resolved_rows": 1,
    "invalid_rows": 0,
    "closed_rows": 0,
    "duplicate_rows": 0,
    "active_review_rows": 0,
    "skipped_targets": 1
  },
  "inventory_requests": 2,
  "guarded_cleanup_calls": [["blocked"]],
  "fresh_recovery_calls": [["recoverable"]]
}
```

```console
$ node /tmp/clawsweeper-starvation-edge-proofs.mjs
{"proof":"targetless_guard","exit_code":0,"inspected_targets":1,"recovered_targets":1,"skipped_targets":0,"inventory_requests":2,"guarded_cleanup_calls":[["legacy-blocked"]],"fresh_recovery_calls":[["recoverable"]]}
{"proof":"sixty_blocked_legacy_rows","exit_code":0,"inspected_targets":1,"recovered_targets":1,"skipped_targets":0,"inventory_requests":2,"guarded_cleanup_calls":[["legacy-0","legacy-1","legacy-2","legacy-3","legacy-4","legacy-5","legacy-6","legacy-7","legacy-8","legacy-9","legacy-10","legacy-11","legacy-12","legacy-13","legacy-14","legacy-15","legacy-16","legacy-17","legacy-18","legacy-19"]],"fresh_recovery_calls":[["recoverable"]]}
{"proof":"three_blocked_targets","exit_code":0,"inspected_targets":4,"recovered_targets":1,"skipped_targets":3,"inventory_requests":2,"guarded_cleanup_calls":[["blocked-1"],["blocked-2"],["blocked-3"]],"fresh_recovery_calls":[["recoverable"]]}
{"proof":"mixed_blocked_and_disappeared_groups","exit_code":0,"inspected_targets":3,"recovered_targets":2,"skipped_targets":1,"inventory_requests":2,"guarded_cleanup_calls":[["blocked"],["duplicate"]],"fresh_recovery_calls":[["primary","recoverable"]]}
```

```console
$ node --test test/exact-review-dead-letter-operator.test.ts
✔ an unchanged blocked cleanup cannot starve independent fresh recovery
✔ a blocked targetless legacy row cannot starve independent fresh recovery
✔ many blocked targetless legacy rows cannot exhaust the inventory refresh budget
✔ multiple independently blocked groups share one authoritative refresh
✔ blocked canonical targets are counted only once across inventory refreshes
✔ active and capped targets are counted only once across blocked inventory refreshes
✔ staged recovery retains its original target budget across a blocked refresh
✔ blocked duplicate cleanup fences its primary without starving another target
✔ only unchanged blocked groups fence aliases after an aggregated refresh
✔ a blocked transferred alias fences its whole target without starving another
✔ reconciliation rejects a malformed zero-mutation guarded cleanup response
ℹ tests 50
ℹ pass 50
ℹ fail 0
```

```console
$ node --test --test-name-pattern='guarded dead-letter (recovery|resolution)' test/dashboard-worker.test.ts
ℹ tests 8
ℹ pass 8
ℹ fail 0
```

The existing independent counter-regression reproduction still reports `resolved_rows=2`, `closed_rows=1`, `invalid_rows=1`, and both original target/recovery caps remain unchanged. Non-atomic cleanup responses still fail closed, stale transferred/active aliases remain fenced, and fresh recovery is never sent before the authoritative inventory refresh.
