### PR TITLE
fix: stop durable comment sync from starving automatic closures

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -239,7 +239,7 @@ env:
   OPENROUTER_API_KEY: ${{ vars.CLAWSWEEPER_RUNNER == 'openclaw' && secrets.OPENROUTER_API_KEY || '' }}
 
 concurrency:
-  group: ${{ (github.event_name == 'schedule' && (github.event.schedule == '4/5 * * * *' || github.event.schedule == '41/10 * * * *' || github.event.schedule == '37 */6 * * *')) && format('clawsweeper-target-fanout-{0}', github.event.schedule || github.run_id) || github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.queue_lease_id || github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', (github.event_name == 'schedule' && github.event.schedule == '13 * * * *') && 'clawsweeper-failed-review-retry' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && format('clawsweeper-comment-sync-{0}', github.run_id) || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && 'clawsweeper-comment-sync' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') && format('clawsweeper-apply-{0}', github.run_id) || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *')) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-{0}', github.event.inputs.item_number || github.event.inputs.item_numbers) || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing != 'true') && format('clawsweeper-operator-dispatch-{0}', github.run_id) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'clawsweeper-intake-v2' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || 'clawsweeper-review', github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
+  group: ${{ (github.event_name == 'schedule' && (github.event.schedule == '4/5 * * * *' || github.event.schedule == '41/10 * * * *' || github.event.schedule == '37 */6 * * *')) && format('clawsweeper-target-fanout-{0}', github.event.schedule || github.run_id) || github.event_name == 'repository_dispatch' && format('clawsweeper-event-{0}-{1}', github.event.client_payload.target_repo || 'openclaw/openclaw', github.event.client_payload.queue_lease_id || github.event.client_payload.item_number || github.run_id) || format('{0}-{1}', (github.event_name == 'schedule' && github.event.schedule == '13 * * * *') && 'clawsweeper-failed-review-retry' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true' && github.event.inputs.apply_sync_comments_only == 'true') && (github.event.inputs.apply_item_numbers == '__cursor__' && github.event.inputs.apply_kind == 'all' && github.event.inputs.apply_comment_sync_min_age_days == '0' && github.event.inputs.apply_limit == '40' && github.event.inputs.apply_min_age_days == '0' && github.event.inputs.apply_min_age_minutes == '' && (github.event.inputs.apply_close_reasons == '' || github.event.inputs.apply_close_reasons == (vars.CLAWSWEEPER_AUTO_CLOSE_REASONS || 'all')) && github.event.inputs.apply_stale_min_age_days == '60' && github.event.inputs.apply_close_delay_ms == '2000' && github.event.inputs.apply_checkpoint_size == '40' && 'clawsweeper-comment-sync' || format('clawsweeper-comment-sync-{0}', github.run_id)) || (github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && 'clawsweeper-comment-sync' || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing == 'true') && format('clawsweeper-apply-{0}', github.run_id) || (github.event_name == 'schedule' && (github.event.schedule == '3 * * * *' || github.event.schedule == '18 * * * *' || github.event.schedule == '33 * * * *' || github.event.schedule == '48 * * * *' || github.event.schedule == '8,23,38,53 * * * *')) && 'clawsweeper-apply' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '')) && format('clawsweeper-intake-exact-{0}', github.event.inputs.item_number || github.event.inputs.item_numbers) || (github.event_name == 'workflow_dispatch' && github.event.inputs.apply_existing != 'true') && format('clawsweeper-operator-dispatch-{0}', github.run_id) || ((github.event_name == 'workflow_dispatch' && github.event.inputs.hot_intake == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '*/5 * * * *' || github.event.schedule == '2/5 * * * *'))) && 'clawsweeper-intake-v2' || ((github.event_name == 'workflow_dispatch' && github.event.inputs.audit_dashboard == 'true') || (github.event_name == 'schedule' && (github.event.schedule == '7 */6 * * *' || github.event.schedule == '12 */6 * * *' || github.event.schedule == '17 */6 * * *'))) && 'clawsweeper-audit' || 'clawsweeper-review', github.event.inputs.target_repo || github.event.client_payload.target_repo || ((github.event.schedule == '17 */6 * * *') && 'openclaw/clawsweeper' || ((github.event.schedule == '2/5 * * * *' || github.event.schedule == '22 * * * *' || github.event.schedule == '8,23,38,53 * * * *' || github.event.schedule == '12 */6 * * *') && 'openclaw/clawhub' || 'openclaw/openclaw'))) }}
   cancel-in-progress: false
 
 jobs:
@@ -4711,10 +4711,12 @@ jobs:
               -f target_repo="$TARGET_REPO" \
               -f apply_existing=true \
               -f apply_sync_comments_only=true \
-              -f apply_item_numbers="$item_numbers" \
-              -f apply_limit=0 \
-              -f apply_comment_sync_min_age_days=7; then
-              echo "Dispatched background comment sync for item numbers: $item_numbers"
+              -f apply_item_numbers=__cursor__ \
+              -f apply_kind=all \
+              -f apply_limit=40 \
+              -f apply_min_age_days=0 \
+              -f apply_comment_sync_min_age_days=0; then
+              echo "Dispatched coalesced durable comment sync for item numbers: $item_numbers"
               exit 0
             fi
             sleep "$((attempt * 10))"
@@ -5400,6 +5402,7 @@ jobs:
           build-script: build:all
 
       - name: Reconcile read-only proof inputs
+        if: ${{ !(github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && !(github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_sync_comments_only == 'true' || github.event.inputs.apply_item_numbers == '__cursor__')) }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -5428,6 +5431,10 @@ jobs:
           stale_min_age_days="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_stale_min_age_days || '60' }}"
           item_numbers="${{ github.event.inputs.apply_item_numbers || '' }}"
           sync_comments_only="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"
+          if [ "${{ github.event_name }}" = "schedule" ] &&
+            [ "${{ github.event.schedule || '' }}" = "6,21,36,51 * * * *" ]; then
+            sync_comments_only="true"
+          fi
           if [ "$item_numbers" = "__cursor__" ]; then
             item_numbers=""
             sync_comments_only="true"
@@ -5767,13 +5774,18 @@ jobs:
           set -euo pipefail
           source scripts/apply-workflow-helpers.sh
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
+          if [ "${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}" = "true" ]; then
+            echo "Deferring reconciliation until the bounded comment-sync cursor is selected."
+            exit 0
+          fi
           if [ "$item_numbers" = "__cursor__" ]; then
+            if [ "${{ github.event.inputs.apply_sync_comments_only || 'false' }}" = "true" ]; then
+              echo "Deferring reconciliation until the bounded comment-sync cursor is selected."
+              exit 0
+            fi
             item_numbers=""
           fi
-          reconcile_args=(--target-repo "$TARGET_REPO" --skip-closed-at)
-          if [ -n "$item_numbers" ]; then
-            reconcile_args+=(--item-numbers "$item_numbers")
-          fi
+          prepare_apply_reconciliation_args
           persist_reconciliation "${reconcile_args[@]}"
 
       - name: Apply unchanged proposed decisions with checkpoints
@@ -5806,7 +5818,7 @@ jobs:
           base_close_processed_limit=600
           close_processed_limit="$base_close_processed_limit"
           adaptive_apply_scan_reason="base_window"
-          sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '25' }}"
+          sync_batch_size="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_limit || '40' }}"
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
           scheduled_comment_sync="${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}"
           sync_open_pr_batch="$scheduled_comment_sync"
@@ -5853,6 +5865,10 @@ jobs:
           candidate_counts_json=""
           cursor_advance_count=""
           coverage_proof_item_numbers=""
+          if [ "$checkpoint_size" -gt 40 ]; then
+            echo "Capping apply checkpoint size at 40"
+            checkpoint_size=40
+          fi
           normalize_comment_sync_mode
           prepare_comment_sync_batch
           sync_comments_arg=()
@@ -5863,18 +5879,8 @@ jobs:
           if [ -n "$min_age_minutes" ]; then
             min_age_minutes_arg=(--min-age-minutes "$min_age_minutes")
           fi
-          if [ "$checkpoint_size" -gt 40 ]; then
-            echo "Capping apply checkpoint size at 40"
-            checkpoint_size=40
-          fi
           select_adaptive_apply_batch
           mkdir -p .artifacts/apply-reports
-          reconcile_args=(--target-repo "$TARGET_REPO" --skip-closed-at)
-          if [ -n "$item_numbers" ]; then
-            reconcile_args+=(--item-numbers "$item_numbers")
-          fi
-          persist_reconciliation "${reconcile_args[@]}"
-          summarize_apply_candidate_quality
           if [ "$sync_open_pr_batch" = "true" ] && [ -z "$item_numbers" ]; then
             batch_env=".artifacts/comment-sync-batch.env"
             pnpm run --silent workflow -- comment-sync-batch \
@@ -5917,6 +5923,9 @@ jobs:
             fi
             echo "Selected cursor-based comment sync batch: $item_numbers"
           fi
+          prepare_apply_reconciliation_args
+          persist_reconciliation "${reconcile_args[@]}"
+          summarize_apply_candidate_quality
           if [ "$sync_comments_only" != "true" ] && [ -z "$item_numbers" ]; then
             auto_selected_apply_batch=true
             select_apply_candidate_inventory

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -50,7 +50,7 @@ normalize_comment_sync_mode() {
   fi
   sync_comments_only=true
   if [ "${scheduled_comment_sync:-false}" = "true" ]; then
-    apply_kind="pull_request"
+    apply_kind="all"
     comment_sync_min_age_days=0
   fi
 }
@@ -80,6 +80,27 @@ trim_comment_sync_cycle_batch() {
   fi
 }
 
+comment_sync_uses_default_mutation_policy() {
+  [ "${apply_close_reasons:-${CLAWSWEEPER_AUTO_CLOSE_REASONS:-all}}" = "${CLAWSWEEPER_AUTO_CLOSE_REASONS:-all}" ] &&
+    [ "${stale_min_age_days:-60}" = "60" ] &&
+    [ "${close_delay_ms:-2000}" = "2000" ] &&
+    [ "${checkpoint_size:-40}" = "40" ] &&
+    [ "${limit:-40}" = "40" ]
+}
+
+comment_sync_uses_automatic_policy() {
+  [ "${sync_open_pr_batch:-false}" = "true" ] &&
+    comment_sync_matches_automatic_policy
+}
+
+comment_sync_matches_automatic_policy() {
+  [ "${apply_kind:-all}:${comment_sync_min_age_days:-0}" = "all:0" ] &&
+    [ "${sync_batch_size:-40}" = "40" ] &&
+    [ "${min_age_days:-0}" = "0" ] &&
+    [ -z "${min_age_minutes:-}" ] &&
+    comment_sync_uses_default_mutation_policy
+}
+
 prepare_comment_sync_batch() {
   comment_sync_pending_items=""
   comment_sync_cursor_advance_count=0
@@ -91,9 +112,27 @@ prepare_comment_sync_batch() {
   fi
   if [ -z "${item_numbers:-}" ] &&
     [ "${scheduled_comment_sync:-false}" != "true" ] &&
-    { [ "${apply_kind:-all}" != "pull_request" ] ||
-      [ "${comment_sync_min_age_days:-0}" != "0" ]; }; then
+    ! comment_sync_matches_automatic_policy; then
     cursor_path="results/comment-sync-cursors/${target_slug}-${apply_kind:-all}-age${comment_sync_min_age_days:-0}.json"
+    if ! comment_sync_uses_default_mutation_policy ||
+      [ "${sync_batch_size:-40}" != "40" ] ||
+      [ "${min_age_days:-0}" != "0" ] ||
+      [ -n "${min_age_minutes:-}" ]; then
+      local mutation_policy
+      mutation_policy="$(printf '%s\n' \
+        "${apply_close_reasons:-${CLAWSWEEPER_AUTO_CLOSE_REASONS:-all}}" \
+        "${stale_min_age_days:-60}" \
+        "${close_delay_ms:-2000}" \
+        "${checkpoint_size:-40}" \
+        "${limit:-40}" \
+        "${sync_batch_size:-40}" \
+        "${min_age_days:-0}" \
+        "${min_age_minutes:-}" | sha256sum | cut -c1-16)"
+      cursor_path="${cursor_path%.json}-policy-${mutation_policy}.json"
+    fi
+  fi
+  if [ -z "${cursor_path:-}" ] && [ -z "${item_numbers:-}" ]; then
+    cursor_path="results/comment-sync-cursors/${target_slug}.json"
   fi
   if [ -f "${cursor_path:-}" ]; then
     comment_sync_initial_cursor="$(jq -er '
@@ -185,18 +224,62 @@ complete_comment_sync_batch() {
   if [ -n "${item_numbers:-}" ]; then
     IFS=, read -r -a selected_items <<<"$item_numbers"
   fi
+  local canonical_target_slug="${target_slug:-}"
+  if [ -z "$canonical_target_slug" ]; then
+    canonical_target_slug="$(printf '%s' "$TARGET_REPO" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_.-]/-/g')"
+  fi
+  local selected_item
+  for selected_item in "${selected_items[@]}"; do
+    case ",$completed_csv," in
+      *",$selected_item,"*) continue ;;
+    esac
+    local canonical_items_dir="records/${canonical_target_slug}/items"
+    local canonical_closed_dir="records/${canonical_target_slug}/closed"
+    if [ ! -f "${canonical_items_dir}/${selected_item}.md" ] &&
+      [ ! -f "${canonical_items_dir}/${canonical_target_slug}-${selected_item}.md" ] &&
+      { [ -f "${canonical_closed_dir}/${selected_item}.md" ] ||
+        [ -f "${canonical_closed_dir}/${canonical_target_slug}-${selected_item}.md" ]; }; then
+      completed_csv="${completed_csv:+$completed_csv,}$selected_item"
+    fi
+  done
   local completed_count=0
   local cursor_count=0
   local safe_cursor=""
   local blocked_prefix=false
+  local initial_cursor="${comment_sync_initial_cursor:-0}"
   local unfinished_items=()
-  local selected_item
   for selected_item in "${selected_items[@]}"; do
     case ",$completed_csv," in
       *",$selected_item,"*)
         completed_count=$((completed_count + 1))
         if [ "$blocked_prefix" != "true" ]; then
-          safe_cursor="$selected_item"
+          if [ "$sync_open_pr_batch" = "true" ] && [ -n "${next_cursor:-}" ] &&
+            { [ "$selected_item" -gt "$next_cursor" ] ||
+              { [ "$selected_item" -le "$initial_cursor" ] &&
+                [ "$next_cursor" -ge "$initial_cursor" ]; }; }; then
+            continue
+          fi
+          local blocks_cursor_advance=false
+          local pending_item
+          for pending_item in "${selected_items[@]}"; do
+            case ",$completed_csv," in
+              *",$pending_item,"*) continue ;;
+            esac
+            if [ "$pending_item" -lt "$selected_item" ] &&
+              { { [ "$selected_item" -gt "$initial_cursor" ] &&
+                [ "$pending_item" -gt "$initial_cursor" ]; } ||
+                { [ "$selected_item" -le "$initial_cursor" ] &&
+                  [ "$pending_item" -le "$initial_cursor" ]; }; }; then
+              blocks_cursor_advance=true
+              break
+            fi
+          done
+          if [ "$blocks_cursor_advance" = "true" ]; then
+            continue
+          fi
+          if [ -z "$safe_cursor" ] || [ "$selected_item" -gt "$safe_cursor" ]; then
+            safe_cursor="$selected_item"
+          fi
           cursor_count=$((cursor_count + 1))
         fi
         ;;
@@ -222,15 +305,15 @@ complete_comment_sync_batch() {
       --cursor-path "$cursor_path" \
       --next-cursor "$next_cursor" \
       --target-repo "$TARGET_REPO"
-    if [ "$TARGET_REPO" != "openclaw/openclaw" ] ||
-      [ "${apply_kind:-pull_request}" != "pull_request" ] ||
-      [ "${comment_sync_min_age_days:-0}" != "0" ]; then
-      local initial_cursor="${comment_sync_initial_cursor:-0}"
+    if [ "${scheduled_comment_sync:-false}" != "true" ] &&
+      { [ "$TARGET_REPO" != "openclaw/openclaw" ] ||
+        ! comment_sync_uses_automatic_policy; }; then
       local cycle_start="${comment_sync_cycle_start:-0}"
       local cycle_wrapped="${comment_sync_cycle_wrapped:-false}"
       if [ "${#selected_items[@]}" -gt 0 ] &&
         [ "${selected_items[0]}" -le "$initial_cursor" ] &&
-        [ "$initial_cursor" -gt 0 ]; then
+        [ "$initial_cursor" -gt 0 ] &&
+        [ "$safe_cursor" -le "$initial_cursor" ]; then
         cycle_wrapped=true
       fi
       local lookahead_env
@@ -260,8 +343,11 @@ complete_comment_sync_batch() {
       if [ "$cycle_wrapped" = "true" ] && [ "$lookahead_count" -gt 0 ]; then
         local lookahead_items
         lookahead_items="$(awk -F= '$1 == "item_numbers" { print $2 }' "$lookahead_env")"
-        local first_lookahead_item="${lookahead_items%%,*}"
-        if [ "$first_lookahead_item" -gt "$cycle_start" ]; then
+        if ! jq -enr --arg selected "$lookahead_items" --argjson boundary "$cycle_start" '
+          $selected | split(",")
+          | map(tonumber? | select(. > 0 and . <= $boundary))
+          | length > 0
+        ' >/dev/null; then
           lookahead_count=0
         fi
       fi
@@ -508,6 +594,18 @@ publish_reconciled_records() {
   CLAWSWEEPER_CANONICAL_PUBLICATION_KIND=reconcile \
     CLAWSWEEPER_RECONCILE_DEFERRED_PATH=.artifacts/apply-reconcile-deferred.jsonl \
     publish_changes_with_strategy normal "$message" "${publish_paths[@]}" || return 1
+}
+
+prepare_apply_reconciliation_args() {
+  reconcile_args=(--target-repo "$TARGET_REPO" --skip-closed-at)
+  if [ -z "${item_numbers:-}" ]; then
+    return 0
+  fi
+  reconcile_args+=(--item-numbers "$item_numbers")
+  if [ "${sync_comments_only:-false}" = "true" ] &&
+    [ "${sync_open_pr_batch:-false}" = "true" ]; then
+    reconcile_args+=(--only-item-numbers)
+  fi
 }
 
 persist_reconciliation() {

--- a/src/clawsweeper-apply-close-guards.ts
+++ b/src/clawsweeper-apply-close-guards.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import type { CreateApplyDecisionWorkflowDependencies } from "./clawsweeper-apply-dependencies.js";
 import { STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS } from "./clawsweeper-policy.js";
 import type {
+  ActionTaken,
   ApplyKind,
   AuthorPrBudgetApplyGate,
   CloseReason,
@@ -11,6 +12,109 @@ import type {
   ReportEntry,
 } from "./clawsweeper-types.js";
 import { maintainerDecisionBlocksClose, type MaintainerDecision } from "./decision-packets.js";
+
+export function markLockedConversationApplySkipped(
+  reason: string | null,
+  staleCanonicalCommentSyncPending: boolean,
+  markApplySkipped: (action: ActionTaken, reason: string, liveGuardVerified?: boolean) => boolean,
+): boolean | null {
+  if (!reason) return null;
+  const action = staleCanonicalCommentSyncPending
+    ? "retry_stale_canonical_comment_sync"
+    : "skipped_locked_conversation";
+  return markApplySkipped(
+    action,
+    staleCanonicalCommentSyncPending
+      ? `${reason}; stale canonical comment correction remains pending`
+      : reason,
+    !staleCanonicalCommentSyncPending,
+  );
+}
+
+export function isGuardedApplyReviewAction(
+  action: string | undefined,
+  isLiveRecheckGuardClose: boolean,
+): boolean {
+  return (
+    isLiveRecheckGuardClose ||
+    action === "skipped_protected_label" ||
+    action === "skipped_close_exempt_label" ||
+    action === "skipped_maintainer_authored" ||
+    action === "skipped_invalid_decision"
+  );
+}
+
+export function requiresLockedReviewCommentMutation(
+  {
+    commentBody,
+    commentBodyMatches,
+    frontMatterValue,
+    markedReviewCommentBody,
+    renderReviewCommentFromReport,
+    shouldSyncReviewComment,
+  }: Pick<
+    CreateApplyDecisionWorkflowDependencies,
+    | "commentBody"
+    | "commentBodyMatches"
+    | "frontMatterValue"
+    | "markedReviewCommentBody"
+    | "renderReviewCommentFromReport"
+    | "shouldSyncReviewComment"
+  >,
+  options: {
+    action: string | undefined;
+    closeReason: CloseReason;
+    commentSyncMinAgeDays: number;
+    existingReviewComment: Record<string, unknown> | undefined;
+    hasOpenLinkedPullRequest?: boolean;
+    isCloseProposal: boolean;
+    isLiveRecheckGuardClose: boolean;
+    markdown: string;
+    number: number;
+    previousLabels: string[];
+    reviewedSourceFresh: boolean;
+    staleCanonicalCommentSyncPending: boolean;
+    suppressAutomationMarkers: boolean;
+  },
+): boolean {
+  const previousReviewCommentBody = commentBody(options.existingReviewComment);
+  const expectedReviewComment = markedReviewCommentBody(
+    options.number,
+    renderReviewCommentFromReport(options.markdown, options.closeReason, {
+      previousLabels: options.previousLabels,
+      suppressAutomationMarkers: options.suppressAutomationMarkers,
+      ...(options.hasOpenLinkedPullRequest === undefined
+        ? {}
+        : { hasOpenLinkedPullRequest: options.hasOpenLinkedPullRequest }),
+      ...(previousReviewCommentBody?.trim() ? { previousReviewCommentBody } : {}),
+    }),
+  );
+  if (
+    !options.staleCanonicalCommentSyncPending &&
+    commentBodyMatches(options.existingReviewComment, expectedReviewComment)
+  ) {
+    return false;
+  }
+  const guarded =
+    options.reviewedSourceFresh &&
+    isGuardedApplyReviewAction(options.action, options.isLiveRecheckGuardClose);
+  return shouldSyncReviewComment({
+    syncCommentsOnly: true,
+    isCloseProposal: options.isCloseProposal,
+    commentSyncMinAgeDays: options.commentSyncMinAgeDays,
+    reviewCommentSyncedAt: frontMatterValue(options.markdown, "review_comment_synced_at"),
+    reviewedAt: frontMatterValue(options.markdown, "reviewed_at"),
+    lastFullReviewAt: frontMatterValue(options.markdown, "last_full_review_at"),
+    guardedReviewedAt: guarded ? frontMatterValue(options.markdown, "apply_checked_at") : undefined,
+    hasExistingReviewComment: Boolean(options.existingReviewComment),
+    needsReviewCommentBodySync: true,
+    needsReviewCommentHashSync: false,
+    needsReviewCommentReferenceSync:
+      /^(?:none|unknown)?$/.test(frontMatterValue(options.markdown, "review_comment_id") ?? "") ||
+      /^(?:none|unknown)?$/.test(frontMatterValue(options.markdown, "review_comment_url") ?? ""),
+    forceReviewCommentBodySync: options.staleCanonicalCommentSyncPending || guarded,
+  });
+}
 
 interface ApplyCloseGuardContext {
   applyCloseReasons: ReadonlySet<CloseReason> | null;

--- a/src/clawsweeper-apply-close-guards.ts
+++ b/src/clawsweeper-apply-close-guards.ts
@@ -286,8 +286,12 @@ export function createApplyCloseGuards(
               { allowApplyCloseActionUpgrade: counterpartAllowApplyCloseActionUpgrade },
             ),
             needsReviewCommentReferenceSync:
-              frontMatterValue(counterpartMarkdown, "review_comment_id") === "unknown" ||
-              frontMatterValue(counterpartMarkdown, "review_comment_url") === "unknown",
+              /^(?:none|unknown)?$/.test(
+                frontMatterValue(counterpartMarkdown, "review_comment_id") ?? "",
+              ) ||
+              /^(?:none|unknown)?$/.test(
+                frontMatterValue(counterpartMarkdown, "review_comment_url") ?? "",
+              ),
             forceReviewCommentBodySync: false,
           });
           const counterpartReviewCommentOnlyUpdate =

--- a/src/clawsweeper-apply-close-guards.ts
+++ b/src/clawsweeper-apply-close-guards.ts
@@ -103,6 +103,7 @@ export function requiresLockedReviewCommentMutation(
     isCloseProposal: options.isCloseProposal,
     commentSyncMinAgeDays: options.commentSyncMinAgeDays,
     reviewCommentSyncedAt: frontMatterValue(options.markdown, "review_comment_synced_at"),
+    reviewCommentVerifiedAt: frontMatterValue(options.markdown, "review_comment_checked_at"),
     reviewedAt: frontMatterValue(options.markdown, "reviewed_at"),
     lastFullReviewAt: frontMatterValue(options.markdown, "last_full_review_at"),
     guardedReviewedAt: guarded ? frontMatterValue(options.markdown, "apply_checked_at") : undefined,

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -2,7 +2,12 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { createApplyCandidateGuards } from "./clawsweeper-apply-candidate-guards.js";
 import { executeApplyClose } from "./clawsweeper-apply-close-execution.js";
-import { createApplyCloseGuards } from "./clawsweeper-apply-close-guards.js";
+import {
+  createApplyCloseGuards,
+  isGuardedApplyReviewAction,
+  markLockedConversationApplySkipped,
+  requiresLockedReviewCommentMutation,
+} from "./clawsweeper-apply-close-guards.js";
 import { evaluateApplyClosePolicy } from "./clawsweeper-apply-close-policies.js";
 import type { CreateApplyDecisionWorkflowDependencies } from "./clawsweeper-apply-dependencies.js";
 import { createApplyLeaseGuards } from "./clawsweeper-apply-lease-guards.js";
@@ -12,7 +17,11 @@ import { promoteApplyPullRequest } from "./clawsweeper-apply-pull-request-promot
 import { syncApplyReportLabels } from "./clawsweeper-apply-report-labels.js";
 import { createApplyReviewActivityGuard } from "./clawsweeper-apply-review-activity.js";
 import { createApplyReviewGuards } from "./clawsweeper-apply-review-guards.js";
-import { createApplySourceFreshness } from "./clawsweeper-apply-source-freshness.js";
+import {
+  applyReviewedSourceDriftEvidence,
+  createApplyChangedSinceReviewMarker,
+  createApplySourceFreshness,
+} from "./clawsweeper-apply-source-freshness.js";
 import { createApplyRecordOperations } from "./clawsweeper-apply-records.js";
 import {
   boolArg,
@@ -100,7 +109,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     isRetryablePrCloseCoverageProofReport,
     issueReviewComment,
     isVerifiedFixedCloseReason,
-    itemSnapshotHash,
     liveIssueSourceRevision,
     lockedConversationApplyReason,
     lowSignalUnmergeablePrApplyBlockReasonSafe,
@@ -588,6 +596,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         markdown = replaceFrontMatterValue(markdown, "action_taken", actionTaken);
         return recordApplySkipped(actionTaken, reason, liveGuardVerified);
       };
+      const skipLockedConversation = (reason: string | null): boolean | null =>
+        markLockedConversationApplySkipped(reason, staleCanonicalCommentSyncPending, markApplySkipped);
       if (reconciliationDeferredItemNumbers.has(number)) {
         if (
           markApplySkipped(
@@ -799,11 +809,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           activeApplyMutationLease = lease;
         },
       });
-
-
-
-
-
       currentApplyMutationGuard = currentApplyMutationLeaseBlockReason;
       let existingReviewComment: Record<string, unknown> | undefined;
       const pendingStaleCanonicalCommentReason = staleCanonicalCommentSyncPending
@@ -1141,11 +1146,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         continue;
       }
       const {
-        automationOnlyUpdate,
         labelSyncFreshEnough,
+        reviewedSourceFresh,
         retryCloseCoverageCommandStatusOnlyUpdate,
-        reviewCommentOnlyUpdate,
-        updatedSinceReview,
       } = createApplySourceFreshness(dependencies, {
         action,
         allowedSelfMutationUpdatedAts,
@@ -1160,12 +1163,28 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         reportReviewLeaseCommentId,
         reportReviewLeaseOwner,
         requiresApplyMutationLease,
+        storedHash,
+      });
+      const markChangedSinceReview = createApplyChangedSinceReviewMarker(dependencies, {
+        dryRun,
+        emitEventApplyProof,
+        getMarkdown: () => markdown,
+        getProcessedCount: () => processedCount,
+        maybeLogProgress,
+        number,
+        path,
+        processedLimit,
+        results,
+        setMarkdown: (next) => { markdown = next; },
+        setProcessedCount: (next) => { processedCount = next; },
+        writeReportMarkdown,
       });
       const stalePrReviewHead =
         state === "open" && item.kind === "pull_request"
           ? stalePullRequestReviewHead(markdown, currentItemContext())
           : null;
       let currentPrStatusKind: PrStatusLabelKind | null = null;
+      let lockedMetadataOnly = false;
       if (state === "open") {
         const reviewActivityBlock = currentReviewActivityBlock();
         if (reviewActivityBlock) {
@@ -1186,9 +1205,56 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           if (recordActiveReviewLeaseSkip(lateLeaseState.lease.expiresAt)) break;
           continue;
         }
-        const mutationLeaseBlockReason = acquireApplyMutationLease(lateLeaseState);
-        if (mutationLeaseBlockReason) {
-          if (recordReviewLeaseSkip(mutationLeaseBlockReason)) break;
+        const isLockable = syncCommentsOnly && requiresApplyMutationLease && item.kind === "issue";
+        const lockedIssueReason = isLockable ? lockedConversationApplyReason(item) : null;
+        if (lockedIssueReason && previousLabels.includes("clawsweeper:linked-pr-open")) {
+          currentClosingPullRequests ??= closingPullRequestsForIssue(number);
+        }
+        const needsLockedCommentMutation =
+          lockedIssueReason &&
+          requiresLockedReviewCommentMutation(dependencies, {
+            action,
+            closeReason: closeReason ?? "none",
+            commentSyncMinAgeDays,
+            existingReviewComment,
+            ...(currentClosingPullRequests
+              ? {
+                  hasOpenLinkedPullRequest:
+                    openClosingPullRequestApplyReason(currentClosingPullRequests) !== null,
+                }
+              : {}),
+            isCloseProposal,
+            isLiveRecheckGuardClose,
+            markdown,
+            number,
+            previousLabels,
+            reviewedSourceFresh: reviewedSourceFresh(),
+            staleCanonicalCommentSyncPending,
+            suppressAutomationMarkers,
+          });
+        lockedMetadataOnly = Boolean(lockedIssueReason && !lateLeaseState.lease);
+        if (!lockedMetadataOnly) {
+          const mutationLeaseBlockReason = acquireApplyMutationLease(lateLeaseState);
+          if (mutationLeaseBlockReason) {
+            if (recordReviewLeaseSkip(mutationLeaseBlockReason)) break;
+            continue;
+          }
+        }
+        if (lockedIssueReason && isCloseProposal && !reviewedSourceFresh()) {
+          if (
+            markChangedSinceReview(
+              applyReviewedSourceDriftEvidence(dependencies, {
+                currentItemContext,
+                item,
+                storedUpdatedAt,
+              }),
+            )
+          )
+            break;
+          continue;
+        }
+        if (needsLockedCommentMutation) {
+          if (skipLockedConversation(lockedIssueReason)) break;
           continue;
         }
       }
@@ -1268,42 +1334,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           break;
         continue;
       }
-      const markChangedSinceReview = (options: {
-        reason: string;
-        currentUpdatedAt?: string | undefined;
-        currentSnapshotHash?: string | undefined;
-      }): boolean => {
-        markdown = replaceFrontMatterValue(
-          markdown,
-          "action_taken",
-          "skipped_changed_since_review",
-        );
-        if (options.currentUpdatedAt) {
-          markdown = replaceFrontMatterValue(
-            markdown,
-            "current_item_updated_at",
-            options.currentUpdatedAt,
-          );
-        }
-        if (options.currentSnapshotHash) {
-          markdown = replaceFrontMatterValue(
-            markdown,
-            "current_item_snapshot_hash",
-            options.currentSnapshotHash,
-          );
-        }
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
-        if (!dryRun) writeReportMarkdown(path, markdown);
-        results.push({
-          number,
-          action: "skipped_changed_since_review",
-          reason: options.reason,
-          ...eventApplyDispositionProof("skipped_changed_since_review"),
-        });
-        processedCount += 1;
-        maybeLogProgress(`skipped #${number}: ${options.reason}`);
-        return processedCount >= processedLimit;
-      };
       const { postProofCoveringPrFreshnessBlock, postProofFreshnessBlock } =
         createApplyProofFreshnessGuards({
           ...dependencies,
@@ -1317,7 +1347,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           number,
           retryCloseCoverageCommandStatusOnlyUpdate,
         });
-
       if (state !== "open") {
         if (item.closedAt) {
           markdown = replaceFrontMatterValue(markdown, "current_item_closed_at", item.closedAt);
@@ -1378,56 +1407,21 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           break;
         continue;
       }
-      if (isCloseProposal && updatedSinceReview && !automationOnlyUpdate) {
-        markdown = replaceFrontMatterValue(
-          markdown,
-          "action_taken",
-          "skipped_changed_since_review",
-        );
-        markdown = replaceFrontMatterValue(markdown, "current_item_updated_at", item.updatedAt);
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
-        if (!dryRun) writeReportMarkdown(path, markdown);
-        results.push({
-          number,
-          action: "skipped_changed_since_review",
-          reason: "updated_at changed",
-          ...eventApplyDispositionProof("skipped_changed_since_review"),
-        });
-        processedCount += 1;
-        maybeLogProgress(`skipped #${number}: changed since review`);
-        if (processedCount >= processedLimit) break;
+      if (isCloseProposal && !reviewedSourceFresh()) {
+        if (
+          markChangedSinceReview(
+            applyReviewedSourceDriftEvidence(dependencies, {
+              currentItemContext,
+              item,
+              storedUpdatedAt,
+            }),
+          )
+        )
+          break;
         continue;
       }
-      if (isCloseProposal && !storedUpdatedAt) {
-        const currentHash = itemSnapshotHash(item, currentItemContext());
-        if (currentHash !== storedHash && !reviewCommentOnlyUpdate) {
-          markdown = replaceFrontMatterValue(
-            markdown,
-            "action_taken",
-            "skipped_changed_since_review",
-          );
-          markdown = replaceFrontMatterValue(markdown, "current_item_snapshot_hash", currentHash);
-          markdown = replaceFrontMatterValue(
-            markdown,
-            "apply_checked_at",
-            new Date().toISOString(),
-          );
-          if (!dryRun) writeReportMarkdown(path, markdown);
-          results.push({
-            number,
-            action: "skipped_changed_since_review",
-            reason: "snapshot changed",
-            ...eventApplyDispositionProof("skipped_changed_since_review"),
-          });
-          processedCount += 1;
-          maybeLogProgress(`skipped #${number}: snapshot changed`);
-          if (processedCount >= processedLimit) break;
-          continue;
-        }
-      }
-      const isCurrentLabelSyncReport = !stalePrReviewHead && labelSyncFreshEnough();
-      const isCurrentCompleteReport =
-        frontMatterValue(markdown, "review_status") === "complete" && isCurrentLabelSyncReport;
+      const labelsCanSync = !lockedMetadataOnly && !stalePrReviewHead && labelSyncFreshEnough();
+      const complete = frontMatterValue(markdown, "review_status") === "complete" && labelsCanSync;
       const reportLabelSync = syncApplyReportLabels(dependencies, {
         bulkFilerRepositoryPermissionCache,
         clawSweeperLabelsChanged,
@@ -1436,8 +1430,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         currentItemContext,
         dryRun,
         isCloseProposal,
-        isCurrentCompleteReport,
-        isCurrentLabelSyncReport,
+        isCurrentCompleteReport: complete,
+        isCurrentLabelSyncReport: labelsCanSync,
         item,
         markLabelSyncAuthSkipped,
         markdown,
@@ -1488,6 +1482,10 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       let needsReviewCommentReferenceSync =
         /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
         /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
+      const guarded =
+        isGuardedApplyReviewAction(action, isLiveRecheckGuardClose) &&
+        reviewedSourceFresh() &&
+        !stalePrReviewHead;
       let needsReviewCommentSync = shouldSyncReviewComment({
         syncCommentsOnly,
         isCloseProposal,
@@ -1495,15 +1493,14 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
         reviewedAt: frontMatterValue(markdown, "reviewed_at"),
         lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
-        guardedReviewedAt: isLiveRecheckGuardClose
-          ? frontMatterValue(markdown, "apply_checked_at")
-          : undefined,
+        guardedReviewedAt: guarded ? frontMatterValue(markdown, "apply_checked_at") : undefined,
         hasExistingReviewComment: Boolean(existingReviewComment),
         needsReviewCommentBodySync,
         needsReviewCommentHashSync,
         needsReviewCommentReferenceSync,
         forceReviewCommentBodySync:
-          clawSweeperLabelsChanged || Boolean(closeBlockedForCommentSync) || isLiveRecheckGuardClose,
+          clawSweeperLabelsChanged || Boolean(closeBlockedForCommentSync) || guarded ||
+          Boolean(stalePrReviewHead),
       });
       if (
         isCloseProposal &&
@@ -1687,18 +1684,11 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           if (processedCount >= processedLimit) break;
           continue;
         }
-        const lockedReason = needsReviewCommentBodySync
-          ? lockedConversationApplyReason(item)
-          : null;
-        if (lockedReason) {
-          const actionTaken: ActionTaken = staleCanonicalCommentSyncPending
-            ? "retry_stale_canonical_comment_sync"
-            : "skipped_locked_conversation";
-          const reason = staleCanonicalCommentSyncPending
-            ? `${lockedReason}; stale canonical comment correction remains pending`
-            : lockedReason;
-          if (markApplySkipped(actionTaken, reason, actionTaken === "skipped_locked_conversation"))
-            break;
+        const lockedCommentSkip = skipLockedConversation(
+          needsReviewCommentBodySync ? lockedConversationApplyReason(item) : null,
+        );
+        if (lockedCommentSkip !== null) {
+          if (lockedCommentSkip) break;
           continue;
         }
         let syncedComment = existingReviewComment;

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -1183,6 +1183,16 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         state === "open" && item.kind === "pull_request"
           ? stalePullRequestReviewHead(markdown, currentItemContext())
           : null;
+      const guardedReviewAction = isGuardedApplyReviewAction(action, isLiveRecheckGuardClose);
+      const markReviewedSourceDrift = () =>
+        markChangedSinceReview({
+          ...applyReviewedSourceDriftEvidence(dependencies, {
+            currentItemContext,
+            item,
+            storedUpdatedAt,
+          }),
+          preserveAction: guardedReviewAction ? action : undefined,
+        });
       let currentPrStatusKind: PrStatusLabelKind | null = null;
       let lockedMetadataOnly = false;
       if (state === "open") {
@@ -1240,17 +1250,12 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
             continue;
           }
         }
-        if (lockedIssueReason && isCloseProposal && !reviewedSourceFresh()) {
-          if (
-            markChangedSinceReview(
-              applyReviewedSourceDriftEvidence(dependencies, {
-                currentItemContext,
-                item,
-                storedUpdatedAt,
-              }),
-            )
-          )
-            break;
+        if (
+          lockedIssueReason &&
+          (isCloseProposal || guardedReviewAction) &&
+          !reviewedSourceFresh()
+        ) {
+          if (markReviewedSourceDrift()) break;
           continue;
         }
         if (needsLockedCommentMutation) {
@@ -1263,7 +1268,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           currentItemContext,
           dryRun,
           item,
-          labelSyncFreshEnough,
+          labelSyncFreshEnough: () =>
+            labelSyncFreshEnough() && (!guardedReviewAction || reviewedSourceFresh()),
           markdown,
           number,
           onMutation: recordMutation,
@@ -1277,6 +1283,53 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
       if (clawSweeperLabelsChanged && !dryRun) {
         rememberSelfMutationUpdatedAt();
+      }
+      if (
+        state === "open" &&
+        isCloseProposal &&
+        applyBlockingProtectedLabels(item.labels, closeReason).length > 0
+      ) {
+        if (
+          markApplySkipped(
+            "skipped_protected_label",
+            applyProtectedLabelReason(item.labels, closeReason),
+            true,
+          )
+        )
+          break;
+        continue;
+      }
+      const currentAuthorAssociation = normalizeAuthorAssociation(item.authorAssociation);
+      const reviewedAuthorAssociation = normalizeAuthorAssociation(storedAuthorAssociation);
+      if (
+        isCloseProposal &&
+        !isVerifiedFixedCloseReason(closeReason) &&
+        (isMaintainerAuthorAssociation(currentAuthorAssociation) ||
+          isMaintainerAuthorAssociation(reviewedAuthorAssociation))
+      ) {
+        const authorAssociation = isMaintainerAuthorAssociation(currentAuthorAssociation)
+          ? currentAuthorAssociation
+          : reviewedAuthorAssociation;
+        markdown = replaceFrontMatterValue(markdown, "author_association", authorAssociation);
+        markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_maintainer_authored");
+        if (
+          recordApplySkipped(
+            "skipped_maintainer_authored",
+            `author association is ${authorAssociation}`,
+            true,
+          )
+        )
+          break;
+        continue;
+      }
+      if (
+        state === "open" &&
+        (isCloseProposal || guardedReviewAction) &&
+        !stalePrReviewHead &&
+        !reviewedSourceFresh()
+      ) {
+        if (markReviewedSourceDrift()) break;
+        continue;
       }
       const renderOptions: ReviewCommentRenderOptions = {
         prStatusKind: currentPrStatusKind,
@@ -1304,36 +1357,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         reviewComment = renderCurrentReviewComment();
       }
       let markedReviewComment = markedReviewCommentForApply(reviewComment);
-      const protectedApplyReason = applyProtectedLabelReason(item.labels, closeReason);
-      if (applyBlockingProtectedLabels(item.labels, closeReason).length > 0) {
-        if (isCloseProposal) {
-          if (markApplySkipped("skipped_protected_label", protectedApplyReason, true)) break;
-        }
-        if (isCloseProposal) continue;
-      }
-      const currentAuthorAssociation = normalizeAuthorAssociation(item.authorAssociation);
-      const reviewedAuthorAssociation = normalizeAuthorAssociation(storedAuthorAssociation);
-      if (
-        isCloseProposal &&
-        !isVerifiedFixedCloseReason(closeReason) &&
-        (isMaintainerAuthorAssociation(currentAuthorAssociation) ||
-          isMaintainerAuthorAssociation(reviewedAuthorAssociation))
-      ) {
-        const authorAssociation = isMaintainerAuthorAssociation(currentAuthorAssociation)
-          ? currentAuthorAssociation
-          : reviewedAuthorAssociation;
-        markdown = replaceFrontMatterValue(markdown, "author_association", authorAssociation);
-        markdown = replaceFrontMatterValue(markdown, "action_taken", "skipped_maintainer_authored");
-        if (
-          recordApplySkipped(
-            "skipped_maintainer_authored",
-            `author association is ${authorAssociation}`,
-            true,
-          )
-        )
-          break;
-        continue;
-      }
       const { postProofCoveringPrFreshnessBlock, postProofFreshnessBlock } =
         createApplyProofFreshnessGuards({
           ...dependencies,
@@ -1407,19 +1430,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           break;
         continue;
       }
-      if (isCloseProposal && !reviewedSourceFresh()) {
-        if (
-          markChangedSinceReview(
-            applyReviewedSourceDriftEvidence(dependencies, {
-              currentItemContext,
-              item,
-              storedUpdatedAt,
-            }),
-          )
-        )
-          break;
-        continue;
-      }
       const labelsCanSync = !lockedMetadataOnly && !stalePrReviewHead && labelSyncFreshEnough();
       const complete = frontMatterValue(markdown, "review_status") === "complete" && labelsCanSync;
       const reportLabelSync = syncApplyReportLabels(dependencies, {
@@ -1483,7 +1493,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
         /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
       const guarded =
-        isGuardedApplyReviewAction(action, isLiveRecheckGuardClose) &&
+        guardedReviewAction &&
         reviewedSourceFresh() &&
         !stalePrReviewHead;
       let needsReviewCommentSync = shouldSyncReviewComment({
@@ -1491,6 +1501,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         isCloseProposal,
         commentSyncMinAgeDays,
         reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+        reviewCommentVerifiedAt: frontMatterValue(markdown, "review_comment_checked_at"),
         reviewedAt: frontMatterValue(markdown, "reviewed_at"),
         lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
         guardedReviewedAt: guarded ? frontMatterValue(markdown, "apply_checked_at") : undefined,

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -930,8 +930,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         requiredMaintainerDecision,
         staleMinAgeDays,
       });
-
-
       if (syncCommentsOnly && state !== "open") {
         markApplyChecked("closed");
         results.push({
@@ -1032,7 +1030,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         if (recordRefreshedReviewStaleReason(earlyStaleReason)) break;
         continue;
       }
-      if (isUpgradedCloseCandidate) {
+      if (isUpgradedCloseCandidate && !syncCommentsOnly) {
         markdown = replaceFrontMatterValue(markdown, "action_taken", "proposed_close");
       }
       const promotion = promoteApplyPullRequest(dependencies, {
@@ -1473,7 +1471,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         }
       }
       let reviewCommentHash = reviewCommentBodyDigest(markedReviewComment);
-      const allowApplyCloseActionUpgrade = isUpgradedCloseCandidate;
+      const allowApplyCloseActionUpgrade = isUpgradedCloseCandidate && !syncCommentsOnly;
       let existingReviewCommentMatches = commentBodyMatches(
         existingReviewComment,
         markedReviewComment,
@@ -1488,18 +1486,24 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         { allowApplyCloseActionUpgrade },
       );
       let needsReviewCommentReferenceSync =
-        frontMatterValue(markdown, "review_comment_id") === "unknown" ||
-        frontMatterValue(markdown, "review_comment_url") === "unknown";
+        /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
+        /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
       let needsReviewCommentSync = shouldSyncReviewComment({
         syncCommentsOnly,
         isCloseProposal,
         commentSyncMinAgeDays,
         reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+        reviewedAt: frontMatterValue(markdown, "reviewed_at"),
+        lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
+        guardedReviewedAt: isLiveRecheckGuardClose
+          ? frontMatterValue(markdown, "apply_checked_at")
+          : undefined,
         hasExistingReviewComment: Boolean(existingReviewComment),
         needsReviewCommentBodySync,
         needsReviewCommentHashSync,
         needsReviewCommentReferenceSync,
-        forceReviewCommentBodySync: clawSweeperLabelsChanged || Boolean(closeBlockedForCommentSync),
+        forceReviewCommentBodySync:
+          clawSweeperLabelsChanged || Boolean(closeBlockedForCommentSync) || isLiveRecheckGuardClose,
       });
       if (
         isCloseProposal &&
@@ -1567,13 +1571,15 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
             needsReviewCommentHashSync =
               frontMatterValue(markdown, "review_comment_sha256") !== reviewCommentHash;
             needsReviewCommentReferenceSync =
-              frontMatterValue(markdown, "review_comment_id") === "unknown" ||
-              frontMatterValue(markdown, "review_comment_url") === "unknown";
+              /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
+              /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
             needsReviewCommentSync = shouldSyncReviewComment({
               syncCommentsOnly,
               isCloseProposal,
               commentSyncMinAgeDays,
               reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+              reviewedAt: frontMatterValue(markdown, "reviewed_at"),
+              lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
               hasExistingReviewComment: Boolean(existingReviewComment),
               needsReviewCommentBodySync,
               needsReviewCommentHashSync,
@@ -1645,13 +1651,15 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           needsReviewCommentHashSync =
             frontMatterValue(markdown, "review_comment_sha256") !== reviewCommentHash;
           needsReviewCommentReferenceSync =
-            frontMatterValue(markdown, "review_comment_id") === "unknown" ||
-            frontMatterValue(markdown, "review_comment_url") === "unknown";
+            /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_id") ?? "") ||
+            /^(?:none|unknown)?$/.test(frontMatterValue(markdown, "review_comment_url") ?? "");
           needsReviewCommentSync = shouldSyncReviewComment({
             syncCommentsOnly,
             isCloseProposal,
             commentSyncMinAgeDays,
             reviewCommentSyncedAt: frontMatterValue(markdown, "review_comment_synced_at"),
+            reviewedAt: frontMatterValue(markdown, "reviewed_at"),
+            lastFullReviewAt: frontMatterValue(markdown, "last_full_review_at"),
             hasExistingReviewComment: Boolean(existingReviewComment),
             needsReviewCommentBodySync,
             needsReviewCommentHashSync,
@@ -1819,11 +1827,11 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         } else {
           syncReasons.push("recorded existing durable comment metadata");
         }
+        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
         markdown = updateReviewCommentMetadata(markdown, syncedComment, markedReviewComment);
         if (staleCanonicalCommentSyncPending) {
           markdown = completeStaleCanonicalCommentSyncReport(markdown);
         }
-        markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
         if (!dryRun) writeReportMarkdown(path, markdown);
         results.push({
           number,

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -426,6 +426,9 @@ export interface CreateApplyDecisionWorkflowDependencies {
     isCloseProposal: boolean;
     commentSyncMinAgeDays: number;
     reviewCommentSyncedAt: string | undefined;
+    reviewedAt?: string | undefined;
+    lastFullReviewAt?: string | undefined;
+    guardedReviewedAt?: string | undefined;
     hasExistingReviewComment: boolean;
     needsReviewCommentBodySync: boolean;
     needsReviewCommentHashSync: boolean;

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -426,6 +426,7 @@ export interface CreateApplyDecisionWorkflowDependencies {
     isCloseProposal: boolean;
     commentSyncMinAgeDays: number;
     reviewCommentSyncedAt: string | undefined;
+    reviewCommentVerifiedAt?: string | undefined;
     reviewedAt?: string | undefined;
     lastFullReviewAt?: string | undefined;
     guardedReviewedAt?: string | undefined;

--- a/src/clawsweeper-apply-source-freshness.ts
+++ b/src/clawsweeper-apply-source-freshness.ts
@@ -1,5 +1,5 @@
 import type { CreateApplyDecisionWorkflowDependencies } from "./clawsweeper-apply-dependencies.js";
-import type { Item, ItemContext } from "./clawsweeper-types.js";
+import type { ApplyResult, Item, ItemContext } from "./clawsweeper-types.js";
 
 type ApplySourceFreshnessDependencies = Pick<
   CreateApplyDecisionWorkflowDependencies,
@@ -12,6 +12,7 @@ type ApplySourceFreshnessDependencies = Pick<
   | "fetchIssueReviewComments"
   | "freshPullRequestReviewHead"
   | "frontMatterValue"
+  | "itemSnapshotHash"
   | "login"
   | "recordedLabelSyncCoversUpdate"
   | "reviewStartLeaseOwner"
@@ -37,6 +38,84 @@ interface ApplySourceFreshnessOptions {
   reportReviewLeaseCommentId: number;
   reportReviewLeaseOwner: string | undefined;
   requiresApplyMutationLease: boolean;
+  storedHash: string | undefined;
+}
+
+interface ApplyChangedSinceReviewMarkerOptions {
+  dryRun: boolean;
+  emitEventApplyProof: boolean;
+  getMarkdown: () => string;
+  getProcessedCount: () => number;
+  maybeLogProgress: (message: string) => void;
+  number: number;
+  path: string;
+  processedLimit: number;
+  results: ApplyResult[];
+  setMarkdown: (markdown: string) => void;
+  setProcessedCount: (count: number) => void;
+  writeReportMarkdown: (path: string, markdown: string) => void;
+}
+
+export function createApplyChangedSinceReviewMarker(
+  {
+    replaceFrontMatterValue,
+  }: Pick<CreateApplyDecisionWorkflowDependencies, "replaceFrontMatterValue">,
+  options: ApplyChangedSinceReviewMarkerOptions,
+) {
+  return ({
+    reason,
+    currentUpdatedAt,
+    currentSnapshotHash,
+  }: {
+    reason: string;
+    currentUpdatedAt?: string | undefined;
+    currentSnapshotHash?: string | undefined;
+  }): boolean => {
+    let markdown = replaceFrontMatterValue(
+      options.getMarkdown(),
+      "action_taken",
+      "skipped_changed_since_review",
+    );
+    if (currentUpdatedAt) {
+      markdown = replaceFrontMatterValue(markdown, "current_item_updated_at", currentUpdatedAt);
+    }
+    if (currentSnapshotHash) {
+      markdown = replaceFrontMatterValue(
+        markdown,
+        "current_item_snapshot_hash",
+        currentSnapshotHash,
+      );
+    }
+    markdown = replaceFrontMatterValue(markdown, "apply_checked_at", new Date().toISOString());
+    options.setMarkdown(markdown);
+    if (!options.dryRun) options.writeReportMarkdown(options.path, markdown);
+    options.results.push({
+      number: options.number,
+      action: "skipped_changed_since_review",
+      reason,
+      ...(options.emitEventApplyProof ? { sourceDriftVerified: true } : {}),
+    });
+    const processedCount = options.getProcessedCount() + 1;
+    options.setProcessedCount(processedCount);
+    options.maybeLogProgress(`skipped #${options.number}: ${reason}`);
+    return processedCount >= options.processedLimit;
+  };
+}
+
+export function applyReviewedSourceDriftEvidence(
+  { itemSnapshotHash }: Pick<CreateApplyDecisionWorkflowDependencies, "itemSnapshotHash">,
+  options: {
+    currentItemContext: () => ItemContext;
+    item: Item;
+    storedUpdatedAt: string | undefined;
+  },
+): { reason: string; currentUpdatedAt?: string; currentSnapshotHash?: string } {
+  return options.storedUpdatedAt
+    ? { reason: "updated_at changed", currentUpdatedAt: options.item.updatedAt }
+    : {
+        reason: "snapshot changed",
+        currentSnapshotHash: itemSnapshotHash(options.item, options.currentItemContext()),
+      };
 }
 
 export function createApplySourceFreshness(
@@ -53,6 +132,7 @@ export function createApplySourceFreshness(
     fetchIssueReviewComments,
     freshPullRequestReviewHead,
     frontMatterValue,
+    itemSnapshotHash,
     login,
     recordedLabelSyncCoversUpdate,
     reviewStartLeaseOwner,
@@ -73,6 +153,7 @@ export function createApplySourceFreshness(
     reportReviewLeaseCommentId,
     reportReviewLeaseOwner,
     requiresApplyMutationLease,
+    storedHash,
   } = options;
   const existingReviewCommentUpdatedAt = commentUpdatedAt(existingReviewComment);
   if (existingReviewCommentUpdatedAt) {
@@ -167,6 +248,10 @@ export function createApplySourceFreshness(
     labelSyncOnlyUpdate ||
     ownedIssueReviewLeaseOnlyUpdate ||
     commandStatusOnlyUpdate;
+  const reviewedSourceFresh = (): boolean =>
+    storedUpdatedAt
+      ? !updatedSinceReview || automationOnlyUpdate
+      : reviewCommentOnlyUpdate || itemSnapshotHash(item, currentItemContext()) === storedHash;
   const labelSyncFreshEnough = (): boolean => {
     const { isCloseProposal, markdown, storedUpdatedAt } = currentState();
     if (!storedUpdatedAt) return false;
@@ -194,6 +279,7 @@ export function createApplySourceFreshness(
   return {
     automationOnlyUpdate,
     labelSyncFreshEnough,
+    reviewedSourceFresh,
     retryCloseCoverageCommandStatusOnlyUpdate,
     reviewCommentOnlyUpdate,
     updatedSinceReview,

--- a/src/clawsweeper-apply-source-freshness.ts
+++ b/src/clawsweeper-apply-source-freshness.ts
@@ -66,16 +66,23 @@ export function createApplyChangedSinceReviewMarker(
     reason,
     currentUpdatedAt,
     currentSnapshotHash,
+    currentLabels,
+    preserveAction,
   }: {
     reason: string;
     currentUpdatedAt?: string | undefined;
     currentSnapshotHash?: string | undefined;
+    currentLabels?: string[] | undefined;
+    preserveAction?: string | undefined;
   }): boolean => {
     let markdown = replaceFrontMatterValue(
       options.getMarkdown(),
       "action_taken",
-      "skipped_changed_since_review",
+      preserveAction ?? "skipped_changed_since_review",
     );
+    if (currentLabels) {
+      markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(currentLabels));
+    }
     if (currentUpdatedAt) {
       markdown = replaceFrontMatterValue(markdown, "current_item_updated_at", currentUpdatedAt);
     }
@@ -109,12 +116,22 @@ export function applyReviewedSourceDriftEvidence(
     item: Item;
     storedUpdatedAt: string | undefined;
   },
-): { reason: string; currentUpdatedAt?: string; currentSnapshotHash?: string } {
+): {
+  reason: string;
+  currentUpdatedAt?: string;
+  currentSnapshotHash?: string;
+  currentLabels: string[];
+} {
   return options.storedUpdatedAt
-    ? { reason: "updated_at changed", currentUpdatedAt: options.item.updatedAt }
+    ? {
+        reason: "updated_at changed",
+        currentUpdatedAt: options.item.updatedAt,
+        currentLabels: options.item.labels,
+      }
     : {
         reason: "snapshot changed",
         currentSnapshotHash: itemSnapshotHash(options.item, options.currentItemContext()),
+        currentLabels: options.item.labels,
       };
 }
 

--- a/src/clawsweeper-dashboard-audit.ts
+++ b/src/clawsweeper-dashboard-audit.ts
@@ -38,6 +38,7 @@ import type {
   WorkflowStatusSummary,
 } from "./clawsweeper-types.js";
 import { syncDecisionPacketRecord, type DecisionPacketSubjectState } from "./decision-packets.js";
+import { isGitHubNotFoundError } from "./github-retry.js";
 import { captureCanonicalRecordBaseline } from "./repair/canonical-record-baseline.js";
 import {
   REPOSITORY_PROFILES,
@@ -87,6 +88,7 @@ interface CreateDashboardAuditDependencies {
   formatTimestamp: (iso: string | undefined) => string;
   frontMatterStringArray: (markdown: string, key: string) => string[];
   frontMatterValue: (markdown: string, key: string) => string | undefined;
+  ghJson: <T>(args: string[]) => T;
   isCurrentForCadence: (options: {
     reviewedAt: string | undefined;
     reviewStatus: string | undefined;
@@ -190,6 +192,7 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
     formatTimestamp,
     frontMatterStringArray,
     frontMatterValue,
+    ghJson,
     isCurrentForCadence,
     isFresh,
     isMaintainerAuthored,
@@ -337,6 +340,7 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
     dryRun?: boolean;
     fetchClosedAt?: boolean;
     preserveItemNumbers?: readonly number[];
+    onlyItemNumbers?: boolean;
   }): ReconcileResult {
     const maxPages = options.maxPages ?? 250;
     const dryRun = options.dryRun ?? false;
@@ -393,10 +397,23 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
     };
     ensureDir(options.itemsDir);
     ensureDir(options.closedDir);
-    const { numbers: openNumbers, pagesScanned } = fetchOpenItemNumbers(maxPages);
+    const scopedItemNumbers = options.onlyItemNumbers
+      ? new Set(options.preserveItemNumbers ?? [])
+      : null;
+    if (scopedItemNumbers?.size === 0) {
+      throw new Error("scoped reconciliation requires at least one item number");
+    }
+    const { numbers: openNumbers, pagesScanned } = scopedItemNumbers
+      ? { numbers: new Set<number>(), pagesScanned: 0 }
+      : fetchOpenItemNumbers(maxPages);
     for (const number of options.preserveItemNumbers ?? []) {
-      const { state } = fetchItem(number);
-      if (state === "open") openNumbers.add(number);
+      try {
+        const { state } = fetchItem(number);
+        if (state === "open") openNumbers.add(number);
+      } catch (error) {
+        if (!scopedItemNumbers || !isGitHubNotFoundError(error)) throw error;
+        ghJson<unknown>(["api", `repos/${targetRepo()}`]);
+      }
     }
     let movedToClosed = 0;
     let movedToItems = 0;
@@ -458,6 +475,7 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
 
     for (const file of markdownFiles(options.itemsDir)) {
       const number = numberForMarkdownFile(file);
+      if (scopedItemNumbers && !scopedItemNumbers.has(number)) continue;
       const sourcePath = join(options.itemsDir, file);
       const sourceMarkdown = readFileSync(sourcePath, "utf8");
       if (!isMarkdownForActiveRepo(sourceMarkdown, file)) continue;
@@ -494,6 +512,7 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
 
     for (const file of markdownFiles(options.closedDir)) {
       const number = numberForMarkdownFile(file);
+      if (scopedItemNumbers && !scopedItemNumbers.has(number)) continue;
       const sourcePath = join(options.closedDir, file);
       const sourceMarkdown = readFileSync(sourcePath, "utf8");
       if (!isMarkdownForActiveRepo(sourceMarkdown, file)) continue;
@@ -566,6 +585,7 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
       dryRun,
       fetchClosedAt,
       preserveItemNumbers,
+      onlyItemNumbers: boolArg(args.only_item_numbers),
     });
     console.log(JSON.stringify(result, null, 2));
   }

--- a/src/clawsweeper-record-metadata.ts
+++ b/src/clawsweeper-record-metadata.ts
@@ -188,6 +188,9 @@ export function createRecordMetadata({
     isCloseProposal: boolean;
     commentSyncMinAgeDays: number;
     reviewCommentSyncedAt: string | undefined;
+    reviewedAt?: string | undefined;
+    lastFullReviewAt?: string | undefined;
+    guardedReviewedAt?: string | undefined;
     hasExistingReviewComment: boolean;
     needsReviewCommentBodySync: boolean;
     needsReviewCommentHashSync: boolean;
@@ -195,12 +198,24 @@ export function createRecordMetadata({
     forceReviewCommentBodySync?: boolean;
     now?: number;
   }): boolean {
+    const syncedAt = Date.parse(options.reviewCommentSyncedAt ?? "");
+    const reviewedAt = Math.max(
+      Date.parse(options.reviewedAt ?? "") || 0,
+      Date.parse(options.lastFullReviewAt ?? "") || 0,
+      Date.parse(options.guardedReviewedAt ?? "") || 0,
+    );
+    const needsReviewCommentTimestampSync =
+      options.syncCommentsOnly &&
+      options.hasExistingReviewComment &&
+      (!Number.isFinite(syncedAt) ||
+        reviewedAt > syncedAt ||
+        (options.now ?? Date.now()) - syncedAt >= 7 * 24 * 60 * 60 * 1_000);
     if (
       !options.needsReviewCommentBodySync &&
       !options.needsReviewCommentHashSync &&
       !options.needsReviewCommentReferenceSync
     ) {
-      return false;
+      return needsReviewCommentTimestampSync;
     }
     if (!options.syncCommentsOnly || options.isCloseProposal) return true;
     if (options.forceReviewCommentBodySync && options.needsReviewCommentBodySync) return true;

--- a/src/clawsweeper-record-metadata.ts
+++ b/src/clawsweeper-record-metadata.ts
@@ -188,6 +188,7 @@ export function createRecordMetadata({
     isCloseProposal: boolean;
     commentSyncMinAgeDays: number;
     reviewCommentSyncedAt: string | undefined;
+    reviewCommentVerifiedAt?: string | undefined;
     reviewedAt?: string | undefined;
     lastFullReviewAt?: string | undefined;
     guardedReviewedAt?: string | undefined;
@@ -199,6 +200,11 @@ export function createRecordMetadata({
     now?: number;
   }): boolean {
     const syncedAt = Date.parse(options.reviewCommentSyncedAt ?? "");
+    const verifiedAt = Date.parse(options.reviewCommentVerifiedAt ?? "");
+    const confirmedAt = Math.max(
+      Number.isFinite(syncedAt) ? syncedAt : 0,
+      Number.isFinite(verifiedAt) ? verifiedAt : 0,
+    );
     const reviewedAt = Math.max(
       Date.parse(options.reviewedAt ?? "") || 0,
       Date.parse(options.lastFullReviewAt ?? "") || 0,
@@ -208,8 +214,8 @@ export function createRecordMetadata({
       options.syncCommentsOnly &&
       options.hasExistingReviewComment &&
       (!Number.isFinite(syncedAt) ||
-        reviewedAt > syncedAt ||
-        (options.now ?? Date.now()) - syncedAt >= 7 * 24 * 60 * 60 * 1_000);
+        reviewedAt > confirmedAt ||
+        (options.now ?? Date.now()) - confirmedAt >= 7 * 24 * 60 * 60 * 1_000);
     if (
       !options.needsReviewCommentBodySync &&
       !options.needsReviewCommentHashSync &&

--- a/src/clawsweeper-review-comments-workflow.ts
+++ b/src/clawsweeper-review-comments-workflow.ts
@@ -1121,7 +1121,13 @@ export function createReviewCommentWorkflow({
     const url = commentUrl(comment);
     if (id !== null) next = replaceFrontMatterValue(next, "review_comment_id", String(id));
     if (url) next = replaceFrontMatterValue(next, "review_comment_url", url);
-    next = replaceFrontMatterValue(next, "review_comment_synced_at", new Date().toISOString());
+    const checkedAt = new Date().toISOString();
+    next = replaceFrontMatterValue(
+      next,
+      "review_comment_synced_at",
+      commentUpdatedAt(comment) ?? checkedAt,
+    );
+    next = replaceFrontMatterValue(next, "review_comment_checked_at", checkedAt);
     return next;
   }
 

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -2407,6 +2407,7 @@ const dashboardAudit = createDashboardAudit({
   formatTimestamp,
   frontMatterStringArray,
   frontMatterValue,
+  ghJson,
   isCurrentForCadence,
   isFresh,
   isMaintainerAuthored,

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -2245,7 +2245,9 @@ function commentSyncCandidates(
       if (repoFor(markdown, name) !== targetRepo) return [];
       const type = frontMatterValue(markdown, "type");
       if (applyKind !== "all" && type !== applyKind) return [];
-      if (frontMatterValue(markdown, "review_status") !== "complete") return [];
+      const reviewStatus = frontMatterValue(markdown, "review_status");
+      const failedReview = reviewStatus === "failed";
+      if (reviewStatus !== "complete" && !failedReview) return [];
       if (!frontMatterValue(markdown, "item_snapshot_hash")) return [];
       const actionTaken = frontMatterValue(markdown, "action_taken");
       if (actionTaken === "skipped_invalid_decision") {
@@ -2286,18 +2288,46 @@ function commentSyncCandidates(
       const invalidReviewCommentHash =
         !reviewCommentHash || !/^[a-f\d]{64}$/i.test(reviewCommentHash);
       const syncedAt = Date.parse(frontMatterValue(markdown, "review_comment_synced_at") ?? "");
+      const hasSyncedTimestamp = Number.isFinite(syncedAt);
+      const verifiedAt = Date.parse(frontMatterValue(markdown, "review_comment_checked_at") ?? "");
+      const commentConfirmedAt = Math.max(
+        hasSyncedTimestamp ? syncedAt : 0,
+        Number.isFinite(verifiedAt) ? verifiedAt : 0,
+      );
+      const guardedSourceDrift =
+        guardedReview &&
+        Boolean(
+          frontMatterValue(markdown, "current_item_updated_at") ||
+          frontMatterValue(markdown, "current_item_snapshot_hash"),
+        );
       const reviewedAt = Math.max(
         Date.parse(frontMatterValue(markdown, "last_full_review_at") || "") || 0,
         Date.parse(frontMatterValue(markdown, "reviewed_at") || "") || 0,
-        guardedReview ? Date.parse(frontMatterValue(markdown, "apply_checked_at") || "") || 0 : 0,
+        guardedReview && !guardedSourceDrift
+          ? Date.parse(frontMatterValue(markdown, "apply_checked_at") || "") || 0
+          : 0,
       );
-      const freshlyReviewedSinceSync = Number.isFinite(syncedAt) && reviewedAt > syncedAt;
+      const freshlyReviewedSinceSync = commentConfirmedAt > 0 && reviewedAt > commentConfirmedAt;
+      if (
+        failedReview &&
+        hasStoredReviewComment &&
+        !requiresDurableCommentRepair &&
+        hasSyncedTimestamp &&
+        commentConfirmedAt > 0 &&
+        !freshlyReviewedSinceSync &&
+        Date.now() - commentConfirmedAt < 7 * 24 * 60 * 60 * 1000
+      ) {
+        return [];
+      }
       if (
         guardedReview &&
+        type === "issue" &&
         hasStoredReviewComment &&
         !invalidReviewCommentHash &&
-        Number.isFinite(syncedAt) &&
-        !freshlyReviewedSinceSync
+        hasSyncedTimestamp &&
+        commentConfirmedAt > 0 &&
+        !freshlyReviewedSinceSync &&
+        (!failedReview || Date.now() - commentConfirmedAt < 7 * 24 * 60 * 60 * 1000)
       ) {
         return [];
       }
@@ -2306,12 +2336,13 @@ function commentSyncCandidates(
         automaticAllItemCursor &&
         type === "issue" &&
         hasStoredReviewComment &&
-        !requiresDurableCommentRepair
+        !requiresDurableCommentRepair &&
+        hasSyncedTimestamp
       ) {
         if (
-          Number.isFinite(syncedAt) &&
-          (!Number.isFinite(reviewedAt) || reviewedAt <= syncedAt) &&
-          Date.now() - syncedAt < 7 * 24 * 60 * 60 * 1000
+          commentConfirmedAt > 0 &&
+          (!Number.isFinite(reviewedAt) || reviewedAt <= commentConfirmedAt) &&
+          Date.now() - commentConfirmedAt < 7 * 24 * 60 * 60 * 1000
         ) {
           return [];
         }
@@ -2333,7 +2364,8 @@ function commentSyncCandidates(
         verifiedLocalCheckout &&
         (!hasStoredReviewComment ||
           invalidReviewCommentHash ||
-          (guardedReview && !Number.isFinite(syncedAt)) ||
+          (!hasSyncedTimestamp && Number.isFinite(verifiedAt)) ||
+          (guardedReview && commentConfirmedAt <= 0) ||
           ((actionTaken === "kept_open" || actionTaken === "proposed_close" || guardedReview) &&
             freshlyReviewedSinceSync))
       ) {

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -15,6 +15,7 @@ import {
   isLiveRecheckCloseGuardAction,
   isSelectableApplyCloseAction,
 } from "../apply-close-actions.js";
+import { repositoryProfileFor } from "../repository-profiles.js";
 
 type ApplyAction = {
   action: string;
@@ -1895,20 +1896,73 @@ function closePromotionSignalTexts(markdown: string): string[] {
 }
 
 export function commentSyncBatchOutput(options: CommentSyncBatchOptions): Record<string, string> {
-  const candidates = commentSyncCandidates(options.targetRepo, options.applyKind);
+  const urgentCandidates = new Map<number, number>();
+  const targetSlug = commentSyncTargetSlug(options.targetRepo);
+  const automaticAllItemCursor =
+    options.applyKind === "all" && path.basename(options.cursorPath) === `${targetSlug}.json`;
+  const candidates = commentSyncCandidates(
+    options.targetRepo,
+    options.applyKind,
+    urgentCandidates,
+    automaticAllItemCursor,
+  );
   const cursor = readCommentSyncCursor(options.cursorPath);
-  const afterCursor = candidates.filter((number) => number > cursor).slice(0, options.batchSize);
-  const selected =
-    afterCursor.length > 0
+  const hasCandidatesAfterCursor = candidates.some((number) => number > cursor);
+  const urgentAfterCursor = candidates.filter(
+    (number) => number > cursor && urgentCandidates.has(number),
+  );
+  const reviewedUrgent = candidates.filter((number) => (urgentCandidates.get(number) ?? 0) > 0);
+  let urgent = (
+    reviewedUrgent.length > 0
+      ? reviewedUrgent
+      : urgentAfterCursor.length > 0
+        ? urgentAfterCursor
+        : candidates.filter((number) => urgentCandidates.has(number))
+  )
+    .sort(
+      (left, right) =>
+        (urgentCandidates.get(right) ?? 0) - (urgentCandidates.get(left) ?? 0) || left - right,
+    )
+    .slice(0, options.batchSize);
+  let urgentSet = new Set(urgent);
+  const blockedCursorCandidate = candidates.find(
+    (number) => !urgentSet.has(number) && (!hasCandidatesAfterCursor || number > cursor),
+  );
+  if (
+    options.batchSize > 1 &&
+    urgent.length === options.batchSize &&
+    blockedCursorCandidate !== undefined
+  ) {
+    urgent = urgent.slice(0, -1);
+    urgentSet = new Set(urgent);
+  }
+  const afterCursor = candidates
+    .filter((number) => number > cursor && !urgentSet.has(number))
+    .slice(0, options.batchSize - urgent.length);
+  const regular =
+    afterCursor.length > 0 || hasCandidatesAfterCursor
       ? afterCursor
-      : candidates.filter((number) => number > 0).slice(0, options.batchSize);
-  const nextCursor = selected.length > 0 ? selected[selected.length - 1] : cursor;
+      : candidates
+          .filter((number) => number > 0 && !urgentSet.has(number))
+          .slice(0, options.batchSize - urgent.length);
+  const selected = [...urgent, ...regular];
+  const highestUrgent = urgent.length > 0 ? Math.max(...urgent) : cursor;
+  const urgentCanAdvanceCursor =
+    urgent.length > 0 &&
+    (urgent.every((number) => number > cursor) || !hasCandidatesAfterCursor) &&
+    !candidates.some(
+      (number) =>
+        !urgentSet.has(number) &&
+        number < highestUrgent &&
+        (number > cursor || !hasCandidatesAfterCursor),
+    );
+  const nextCursor = regular.at(-1) ?? (urgentCanAdvanceCursor ? highestUrgent : cursor);
   return {
     item_numbers: selected.join(","),
     count: String(selected.length),
     cursor: String(cursor),
     next_cursor: String(nextCursor),
-    wrapped: String(candidates.length > 0 && afterCursor.length === 0),
+    wrapped: String(candidates.length > 0 && !hasCandidatesAfterCursor),
   };
 }
 
@@ -2173,11 +2227,13 @@ function commentSyncBatchOptions(): CommentSyncBatchOptions {
   };
 }
 
-function commentSyncCandidates(targetRepo: string, applyKind: string): number[] {
-  const targetSlug = targetRepo
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+function commentSyncCandidates(
+  targetRepo: string,
+  applyKind: string,
+  urgentCandidates = new Map<number, number>(),
+  automaticAllItemCursor = false,
+): number[] {
+  const targetSlug = commentSyncTargetSlug(targetRepo);
   const itemsDir = path.join("records", targetSlug, "items");
   if (!fs.existsSync(itemsDir)) return [];
 
@@ -2192,6 +2248,25 @@ function commentSyncCandidates(targetRepo: string, applyKind: string): number[] 
       if (frontMatterValue(markdown, "review_status") !== "complete") return [];
       if (!frontMatterValue(markdown, "item_snapshot_hash")) return [];
       const actionTaken = frontMatterValue(markdown, "action_taken");
+      if (actionTaken === "skipped_invalid_decision") {
+        const decision = frontMatterValue(markdown, "decision");
+        const closeReason = frontMatterValue(markdown, "close_reason");
+        if (
+          decision === "close" &&
+          !repositoryProfileFor(targetRepo).applyCloseRules[
+            type === "pull_request" ? "pull_request" : "issue"
+          ]?.some((allowedReason) => allowedReason === closeReason)
+        ) {
+          return [];
+        }
+      }
+      const guardedReview =
+        actionTaken === "skipped_protected_label" ||
+        actionTaken === "skipped_maintainer_authored" ||
+        actionTaken === "skipped_close_exempt_label" ||
+        actionTaken === "skipped_invalid_decision";
+      const verifiedLocalCheckout =
+        frontMatterValue(markdown, "local_checkout_access") === "verified";
       const storedReviewCommentId = frontMatterValue(markdown, "review_comment_id");
       const storedReviewCommentUrl = frontMatterValue(markdown, "review_comment_url");
       const hasStoredReviewComment =
@@ -2202,19 +2277,75 @@ function commentSyncCandidates(targetRepo: string, applyKind: string): number[] 
         frontMatterValue(markdown, "decision") === "close" &&
         frontMatterValue(markdown, "close_reason") === "duplicate_or_superseded" &&
         hasStoredReviewComment;
+      const reviewCommentHash = frontMatterValue(markdown, "review_comment_sha256");
+      const requiresDurableCommentRepair =
+        actionTaken === "retry_stale_canonical_comment_sync" ||
+        changedDuplicateClose ||
+        !reviewCommentHash ||
+        !/^[a-f\d]{64}$/i.test(reviewCommentHash);
+      const invalidReviewCommentHash =
+        !reviewCommentHash || !/^[a-f\d]{64}$/i.test(reviewCommentHash);
+      const syncedAt = Date.parse(frontMatterValue(markdown, "review_comment_synced_at") ?? "");
+      const reviewedAt = Math.max(
+        Date.parse(frontMatterValue(markdown, "last_full_review_at") || "") || 0,
+        Date.parse(frontMatterValue(markdown, "reviewed_at") || "") || 0,
+        guardedReview ? Date.parse(frontMatterValue(markdown, "apply_checked_at") || "") || 0 : 0,
+      );
+      const freshlyReviewedSinceSync = Number.isFinite(syncedAt) && reviewedAt > syncedAt;
+      if (
+        guardedReview &&
+        hasStoredReviewComment &&
+        !invalidReviewCommentHash &&
+        Number.isFinite(syncedAt) &&
+        !freshlyReviewedSinceSync
+      ) {
+        return [];
+      }
+      // PR head changes are discoverable only through the executor's live fetch.
+      if (
+        automaticAllItemCursor &&
+        type === "issue" &&
+        hasStoredReviewComment &&
+        !requiresDurableCommentRepair
+      ) {
+        if (
+          Number.isFinite(syncedAt) &&
+          (!Number.isFinite(reviewedAt) || reviewedAt <= syncedAt) &&
+          Date.now() - syncedAt < 7 * 24 * 60 * 60 * 1000
+        ) {
+          return [];
+        }
+      }
       if (
         actionTaken !== "kept_open" &&
         actionTaken !== "proposed_close" &&
         actionTaken !== "skipped_pr_close_coverage_proof" &&
         actionTaken !== "retry_pr_close_coverage_proof" &&
         actionTaken !== "retry_stale_canonical_comment_sync" &&
+        !guardedReview &&
         !changedDuplicateClose
       ) {
         return [];
       }
-      return [numberFor(name)];
+      const number = numberFor(name);
+      if (
+        automaticAllItemCursor &&
+        verifiedLocalCheckout &&
+        (!hasStoredReviewComment ||
+          invalidReviewCommentHash ||
+          (guardedReview && !Number.isFinite(syncedAt)) ||
+          ((actionTaken === "kept_open" || actionTaken === "proposed_close" || guardedReview) &&
+            freshlyReviewedSinceSync))
+      ) {
+        urgentCandidates.set(number, reviewedAt);
+      }
+      return [number];
     })
     .sort((left, right) => left - right);
+}
+
+function commentSyncTargetSlug(targetRepo: string): string {
+  return targetRepo.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
 }
 
 function readCommentSyncCursor(cursorPath: string): number {

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -1,13 +1,21 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
-import { guardedOpenApplyProofFields, shouldSyncReviewComment } from "../dist/clawsweeper.js";
+import {
+  guardedOpenApplyProofFields,
+  itemSourceRevisionSha256ForTest,
+  renderReviewCommentFromReport,
+  renderReviewStartStatusComment,
+  shouldSyncReviewComment,
+} from "../dist/clawsweeper.js";
 import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.js";
 import {
   implementedCloseReport,
+  markedReviewCommentForTest,
   promotionGhMock,
   readText,
   reportWithSyncedReviewComment,
@@ -146,6 +154,23 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
       inlineComments: [],
     },
     {
+      name: "locked review",
+      locked: true,
+      reviewedInlineComments: [],
+      reviewedThreads: [],
+      reviews: [
+        {
+          id: 7004,
+          user: { login: "maintainer" },
+          state: "COMMENTED",
+          body: "this locked PR still changed after review",
+          submitted_at: "2026-05-01T00:30:00Z",
+          commit_id: "head-sha",
+        },
+      ],
+      inlineComments: [],
+    },
+    {
       name: "inline comment",
       reviewedInlineComments: [],
       reviewedThreads: [],
@@ -220,7 +245,7 @@ test("apply-decisions rejects recorded PR review activity drift before mutations
           pullReviewComments: scenario.inlineComments,
           reviewThreads: scenario.reviewThreads,
           itemUpdatedAtAfterLabelSyncLogPath: mutationLogPath,
-        }),
+        }).replace("locked: false,", `locked: ${scenario.locked === true},`),
         () => {
           runApplyDecisionsForTest({
             targetRepo: "openclaw/openclaw",
@@ -844,6 +869,938 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   }
 });
 
+test("comment-only apply skips a locked issue before acquiring its mutation lease", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    const issue = {
+      number: 321,
+      title: "Locked reopened issue",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      body: "",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        decision: "keep_open",
+        close_reason: "none",
+        action_taken: "kept_open",
+        author_association: "CONTRIBUTOR",
+        labels: "[]",
+        item_source_revision: itemSourceRevisionSha256ForTest(issue, []),
+        review_lease_owner: "review-owner",
+        review_lease_comment_id: "77",
+      }),
+    );
+
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) {
+    console.error("mutation lease must not be posted on a locked issue");
+    process.exit(1);
+  }
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--sync-comments-only",
+          "--item-number",
+          "321",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+      });
+    });
+
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "skipped_locked_conversation",
+        reason: "conversation is locked (resolved)",
+      },
+    ]);
+    assert.match(
+      readText(join(itemsDir, "321.md")),
+      /^action_taken: skipped_locked_conversation$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("exact-event source drift wins over a locked conversation guard", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    const issue = {
+      number: 321,
+      title: "Locked reopened issue",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      body: "updated issue body",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    const reviewedIssue = { ...issue, body: "reviewed issue body" };
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        action_taken: "skipped_locked_conversation",
+        labels: "[]",
+        item_source_revision: itemSourceRevisionSha256ForTest(reviewedIssue, []),
+        review_lease_owner: "review-owner",
+        review_lease_comment_id: "77",
+      }),
+    );
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) {
+    console.error("locked issue source drift must not attempt mutation");
+    process.exit(1);
+  }
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--dry-run",
+          "--item-number",
+          "321",
+          "--event-apply-proof",
+          "--exact-event-publication",
+        ],
+      });
+    });
+
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.action, "skipped_changed_since_review");
+    assert.equal(result.sourceDriftVerified, true);
+    assert.doesNotMatch(JSON.stringify(result), /guardedOpenStateVerified/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("locked exact-event PRs classify timestamp drift before their conversation lock", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const number = 337;
+    const head = "abcdef1234567890abcdef1234567890abcdef12";
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number,
+        type: "pull_request",
+        title: "Locked PR with updated-at drift",
+        url: `https://github.com/openclaw/openclaw/pull/${number}`,
+        author: "reporter",
+        author_association: "CONTRIBUTOR",
+        labels: "[]",
+        pull_head_sha: head,
+        review_lease_owner: "review-owner",
+        review_lease_comment_id: "77",
+      }),
+      number,
+      "implemented_on_main",
+    );
+    writeFileSync(join(itemsDir, `${number}.md`), reviewed.report);
+    withMockGh(
+      root,
+      promotionGhMock({
+        number,
+        title: "Locked PR with updated-at drift",
+        labels: [],
+        headSha: head,
+        itemUpdatedAt: "2026-05-02T00:00:00Z",
+        comment: reviewed.comment,
+      }).replace("locked: false,", "locked: true,"),
+      () =>
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--sync-comments-only",
+            "--apply-kind",
+            "all",
+            "--item-number",
+            String(number),
+            "--dry-run",
+            "--event-apply-proof",
+            "--exact-event-publication",
+          ],
+        }),
+    );
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.action, "skipped_changed_since_review");
+    assert.equal(result.sourceDriftVerified, true);
+    assert.equal(result.guardedOpenStateVerified, undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("locked issue timestamp drift persists the observed current revision evidence", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const issue = {
+      number: 321,
+      title: "Locked issue with timestamp drift",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      body: "Reviewed source.",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-02T00:00:00Z",
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        item_source_revision: itemSourceRevisionSha256ForTest(issue, []),
+        review_lease_owner: "review-owner",
+        review_lease_comment_id: "77",
+        labels: "[]",
+      }),
+    );
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("drift must not mutate a locked issue");
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-number", "321", "--event-apply-proof"],
+      });
+    });
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.action, "skipped_changed_since_review");
+    assert.equal(result.sourceDriftVerified, true);
+    assert.match(
+      readText(join(itemsDir, "321.md")),
+      /^current_item_updated_at: 2026-05-02T00:00:00Z$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("locked issue snapshot drift wins over its lock when updated_at is absent", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const issue = {
+      number: 321,
+      title: "Locked issue with snapshot drift",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      body: "Reviewed source.",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        item_source_revision: itemSourceRevisionSha256ForTest(issue, []),
+        review_lease_owner: "review-owner",
+        review_lease_comment_id: "77",
+        labels: "[]",
+      }).replace(/^item_updated_at:.*\n/m, ""),
+    );
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("drift must not mutate a locked issue");
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-number", "321", "--event-apply-proof"],
+      });
+    });
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.action, "skipped_changed_since_review");
+    assert.equal(result.reason, "snapshot changed");
+    assert.equal(result.sourceDriftVerified, true);
+    assert.match(readText(join(itemsDir, "321.md")), /^current_item_snapshot_hash: /m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("guarded reports never publish changed snapshots without a reviewed updated_at", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const commentWrites = join(root, "comment-writes.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const reviewedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const syncedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const issue = {
+      number: 321,
+      title: "Changed issue body after review",
+      body: "Human edited after review.",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: new Date().toISOString(),
+      closed_at: null,
+      state: "open",
+      locked: false,
+      active_lock_reason: null,
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 1,
+      pull_request: null,
+    };
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        title: "Old reviewed issue body",
+        action_taken: "skipped_invalid_decision",
+        confidence: "low",
+        reviewed_at: reviewedAt,
+        labels: "[]",
+      }),
+      321,
+      "implemented_on_main",
+    );
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      reviewed.report
+        .replace(/^review_comment_synced_at:.*$/m, `review_comment_synced_at: ${syncedAt}`)
+        .replace(/^item_updated_at:.*\n/m, "")
+        .replaceAll(
+          "https://github.com/openclaw/clawsweeper/issues/321",
+          "https://github.com/openclaw/openclaw/issues/321",
+        ),
+    );
+    const durable = {
+      id: 9321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: syncedAt,
+      updated_at: syncedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: `${reviewed.comment}\n\nprevious current verdict`,
+    };
+    const ghMock = `
+const fs = require("node:fs");
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("unexpected posting");
+  console.log(JSON.stringify([[${JSON.stringify(durable)}]]));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/9321$/.test(path) && args.includes("PATCH")) {
+  fs.writeFileSync(${JSON.stringify(commentWrites)}, "written");
+  console.log(JSON.stringify(${JSON.stringify(durable)}));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--skip-dashboard",
+          "--sync-comments-only",
+          "--item-number",
+          "321",
+          "--comment-sync-min-age-days",
+          "7",
+        ],
+      });
+    });
+    assert.deepEqual(JSON.parse(readText(reportPath)), []);
+    assert.equal(existsSync(commentWrites), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("locked failed reviews honor the comment-sync cooldown and release their lease", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const leaseDeleted = join(root, "lease-deleted");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const reviewedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const syncedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const issue = {
+      number: 321,
+      title: "Locked failed review within cooldown",
+      body: "Reviewed source.",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: reviewedAt,
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 2,
+      pull_request: null,
+    };
+    const revision = itemSourceRevisionSha256ForTest(issue, []);
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        title: issue.title,
+        decision: "keep_open",
+        close_reason: "none",
+        action_taken: "kept_open",
+        review_status: "failed",
+        reviewed_at: reviewedAt,
+        item_updated_at: reviewedAt,
+        item_source_revision: revision,
+        review_lease_owner: "completed-review",
+        review_lease_comment_id: "700321",
+        labels: "[]",
+      }),
+      321,
+      "none",
+    );
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      reviewed.report
+        .replace(/^review_comment_synced_at:.*$/m, `review_comment_synced_at: ${syncedAt}`)
+        .replaceAll(
+          "https://github.com/openclaw/clawsweeper/issues/321",
+          "https://github.com/openclaw/openclaw/issues/321",
+        ),
+    );
+    const durable = {
+      id: 9321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: syncedAt,
+      updated_at: syncedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: `${reviewed.comment}\n\nlegacy comment suffix`,
+    };
+    const startedAt = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const lease = {
+      id: 700321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-700321",
+      created_at: startedAt,
+      updated_at: startedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: renderReviewStartStatusComment({
+        number: 321,
+        kind: "issue",
+        title: issue.title,
+        headSha: revision,
+        startedAt,
+        leaseExpiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+        leaseOwner: "completed-review",
+      }),
+    };
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("unexpected posting");
+  console.log(JSON.stringify([[${JSON.stringify(durable)}, ${JSON.stringify(lease)}]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/700321$/.test(path) && args.includes("DELETE")) {
+  require("node:fs").writeFileSync(${JSON.stringify(leaseDeleted)}, "deleted");
+  console.log("");
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--skip-dashboard",
+          "--sync-comments-only",
+          "--item-number",
+          "321",
+          "--comment-sync-min-age-days",
+          "7",
+        ],
+      });
+    });
+    assert.deepEqual(JSON.parse(readText(reportPath)), []);
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: kept_open$/m);
+    assert.equal(existsSync(leaseDeleted), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("closed legacy reports archive without hydrating their irrelevant source snapshot", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        action_taken: "skipped_open_closing_pr",
+        close_reason: "duplicate_or_superseded",
+      })
+        .replace(/^local_checkout_access: verified\n/m, "")
+        .replace(/^item_updated_at:.*\n/m, ""),
+    );
+    const closedIssue = {
+      number: 321,
+      title: "Render work plans",
+      html_url: "https://github.com/openclaw/clawsweeper/issues/321",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+      closed_at: "2026-05-02T00:00:00Z",
+      state: "closed",
+      locked: false,
+      active_lock_reason: null,
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(closedIssue)}));
+} else {
+  throw new Error("closed records must not hydrate source context: " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--skip-dashboard", "--item-number", "321"],
+      });
+    });
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.action, "skipped_already_closed");
+    assert.equal(existsSync(join(closedDir, "321.md")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("locked issues preserve already-synchronized linked-PR review comments", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const leaseDeleted = join(root, "lease-deleted");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const reviewedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const syncedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const labels = [
+      "issue-rating: 🦀 challenger crab",
+      "clawsweeper:current-main-repro",
+      "clawsweeper:linked-pr-open",
+      "clawsweeper:no-new-fix-pr",
+    ];
+    const issue = {
+      number: 321,
+      title: "Locked issue with linked PR",
+      body: "Reviewed source.",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: reviewedAt,
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels,
+      comments: 2,
+      pull_request: null,
+    };
+    const revision = itemSourceRevisionSha256ForTest(issue, []);
+    let report = implementedCloseReport({
+      repository: "openclaw/openclaw",
+      title: issue.title,
+      decision: "keep_open",
+      close_reason: "none",
+      action_taken: "kept_open",
+      work_candidate: "none",
+      work_status: "none",
+      reviewed_at: reviewedAt,
+      item_updated_at: reviewedAt,
+      labels: JSON.stringify(labels),
+      item_source_revision: revision,
+      review_lease_owner: "completed-review",
+      review_lease_comment_id: "700321",
+    });
+    const body = markedReviewCommentForTest(
+      321,
+      renderReviewCommentFromReport(report, "none", {
+        previousLabels: labels,
+        hasOpenLinkedPullRequest: true,
+      }),
+    );
+    report = report.replace(
+      /^---\n/,
+      [
+        "---",
+        `review_comment_sha256: ${createHash("sha256").update(body.trim()).digest("hex")}`,
+        "review_comment_id: 9321",
+        "review_comment_url: https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+        `review_comment_synced_at: ${syncedAt}`,
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(itemsDir, "321.md"), report);
+    const durable = {
+      id: 9321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: syncedAt,
+      updated_at: syncedAt,
+      user: { login: "clawsweeper[bot]" },
+      body,
+    };
+    const startedAt = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const lease = {
+      id: 700321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-700321",
+      created_at: startedAt,
+      updated_at: startedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: renderReviewStartStatusComment({
+        number: 321,
+        kind: "issue",
+        title: issue.title,
+        headSha: revision,
+        startedAt,
+        leaseExpiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+        leaseOwner: "completed-review",
+      }),
+    };
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("must not mutate a locked comment");
+  console.log(JSON.stringify([[${JSON.stringify(durable)}, ${JSON.stringify(lease)}]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "api" && /\\/pulls\\/400$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 400,
+    title: "Existing fix",
+    state: "open",
+    html_url: "https://github.com/openclaw/openclaw/pull/400",
+    user: { login: "contributor" },
+    head: { sha: "head" },
+    base: { sha: "base" },
+  }));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/700321$/.test(path) && args.includes("DELETE")) {
+  require("node:fs").writeFileSync(${JSON.stringify(leaseDeleted)}, "deleted");
+  console.log("");
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [{ number: 400 }] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--skip-dashboard",
+          "--sync-comments-only",
+          "--item-number",
+          "321",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+      });
+    });
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.action, "review_comment_synced");
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: kept_open$/m);
+    assert.equal(existsSync(leaseDeleted), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("locked conversations preserve pending stale canonical comment repairs", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "records", "openclaw-openclaw", "items");
+    const closedDir = join(root, "records", "openclaw-openclaw", "closed");
+    const plansDir = join(root, "records", "openclaw-openclaw", "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    const issue = {
+      number: 321,
+      title: "Pending locked review correction",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      body: "",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 0,
+      pull_request: null,
+    };
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        decision: "keep_open",
+        close_reason: "none",
+        confidence: "low",
+        action_taken: "retry_stale_canonical_comment_sync",
+        stale_canonical_pull_request_number: "400",
+        labels: "[]",
+      }),
+    );
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) {
+    console.error("locked stale-canonical repair must not attempt mutation");
+    process.exit(1);
+  }
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only", "--item-number", "321", "--apply-kind", "all"],
+      });
+    });
+
+    const [result] = JSON.parse(readText(reportPath));
+    assert.equal(result.number, 321);
+    assert.equal(result.action, "retry_stale_canonical_comment_sync");
+    assert.match(result.reason, /stale comment correction/);
+    assert.match(
+      readText(join(itemsDir, "321.md")),
+      /^action_taken: retry_stale_canonical_comment_sync$/m,
+    );
+    assert.match(readText(join(itemsDir, "321.md")), /^stale_canonical_pull_request_number: 400$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("comment-only apply synchronizes guarded reviews without promoting their close actions", () => {
   for (const guard of [
     { action: "skipped_protected_label", labels: ["security"], association: "CONTRIBUTOR" },
@@ -993,6 +1950,256 @@ test("matching durable comments repair stale, missing, and refreshed sync timest
     { guardedReviewedAt: "2026-08-02T11:00:00Z" },
   ]) {
     assert.equal(shouldSyncReviewComment({ ...base, ...metadata }), true);
+  }
+});
+
+test("locked, already-synchronized maintainer and invalid reports refresh local metadata", () => {
+  for (const action of ["skipped_maintainer_authored", "skipped_invalid_decision"]) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "records", "openclaw-openclaw", "items");
+      const closedDir = join(root, "records", "openclaw-openclaw", "closed");
+      const plansDir = join(root, "records", "openclaw-openclaw", "plans");
+      const reportPath = join(root, "apply-report.json");
+      for (const directory of [itemsDir, closedDir, plansDir]) {
+        mkdirSync(directory, { recursive: true });
+      }
+      const reviewedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      const syncedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const association = action === "skipped_maintainer_authored" ? "MEMBER" : "CONTRIBUTOR";
+      const issue = {
+        number: 321,
+        title: "Guarded issue",
+        html_url: "https://github.com/openclaw/openclaw/issues/321",
+        body: "",
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-01T00:00:00Z",
+        closed_at: null,
+        state: "open",
+        locked: true,
+        active_lock_reason: "resolved",
+        author_association: association,
+        user: { login: "reporter" },
+        labels: [],
+        comments: 1,
+        pull_request: null,
+      };
+      const reviewed = reportWithSyncedReviewComment(
+        implementedCloseReport({
+          repository: "openclaw/openclaw",
+          action_taken: action,
+          author_association: association,
+          confidence: action === "skipped_invalid_decision" ? "low" : "high",
+          labels: "[]",
+          reviewed_at: reviewedAt,
+          item_source_revision: itemSourceRevisionSha256ForTest(issue, []),
+          review_lease_owner: "review-owner",
+          review_lease_comment_id: "77",
+        }),
+        321,
+        "implemented_on_main",
+      );
+      const report = reviewed.report
+        .replace(/^review_comment_synced_at:.*$/m, `review_comment_synced_at: ${syncedAt}`)
+        .replaceAll(
+          "https://github.com/openclaw/clawsweeper/issues/321",
+          "https://github.com/openclaw/openclaw/issues/321",
+        )
+        .replace(/^---\n/, `---\napply_checked_at: ${new Date().toISOString()}\n`);
+      writeFileSync(join(itemsDir, "321.md"), report);
+      const existing = {
+        id: 9321,
+        html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+        created_at: syncedAt,
+        updated_at: syncedAt,
+        user: { login: "clawsweeper[bot]" },
+        body: reviewed.comment,
+      };
+      const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) {
+    console.error("matching durable review comment must not be edited");
+    process.exit(1);
+  }
+  console.log(JSON.stringify([[${JSON.stringify(existing)}]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+      withMockGh(root, ghMock, () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--sync-comments-only",
+            "--item-number",
+            "321",
+            "--comment-sync-min-age-days",
+            "0",
+          ],
+        });
+      });
+
+      assert.deepEqual(JSON.parse(readText(reportPath)), [
+        {
+          number: 321,
+          action: "review_comment_synced",
+          reason: "recorded existing durable comment metadata",
+        },
+      ]);
+      const updatedReport = readText(join(itemsDir, "321.md"));
+      assert.match(updatedReport, new RegExp(`^action_taken: ${action}$`, "m"));
+      const refreshedSyncTime = updatedReport.match(/^review_comment_synced_at:\s*(.*)$/m)?.[1];
+      const checkedTime = updatedReport.match(/^apply_checked_at:\s*(.*)$/m)?.[1];
+      assert.ok(refreshedSyncTime && checkedTime);
+      assert.ok(Date.parse(refreshedSyncTime) >= Date.parse(checkedTime), action);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("locked metadata synchronization adopts and releases its existing review lease", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const deletedLeasePath = join(root, "deleted-lease");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const reviewedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const syncedAt = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const issue = {
+      number: 321,
+      title: "Locked metadata with matching lease",
+      body: "Reviewed source.",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: reviewedAt,
+      closed_at: null,
+      state: "open",
+      locked: true,
+      active_lock_reason: "resolved",
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 2,
+      pull_request: null,
+    };
+    const sourceRevision = itemSourceRevisionSha256ForTest(issue, []);
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        title: issue.title,
+        decision: "keep_open",
+        close_reason: "none",
+        action_taken: "kept_open",
+        reviewed_at: reviewedAt,
+        item_updated_at: reviewedAt,
+        labels: "[]",
+        item_source_revision: sourceRevision,
+        review_lease_owner: "completed-review",
+        review_lease_comment_id: "700321",
+      }),
+      321,
+      "none",
+    );
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      reviewed.report
+        .replace(/^review_comment_synced_at:.*$/m, `review_comment_synced_at: ${syncedAt}`)
+        .replaceAll(
+          "https://github.com/openclaw/clawsweeper/issues/321",
+          "https://github.com/openclaw/openclaw/issues/321",
+        ),
+    );
+    const durable = {
+      id: 9321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: syncedAt,
+      updated_at: syncedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: reviewed.comment,
+    };
+    const leaseStartedAt = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const lease = {
+      id: 700321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-700321",
+      created_at: leaseStartedAt,
+      updated_at: leaseStartedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: renderReviewStartStatusComment({
+        number: 321,
+        kind: "issue",
+        title: issue.title,
+        headSha: sourceRevision,
+        startedAt: leaseStartedAt,
+        leaseExpiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+        leaseOwner: "completed-review",
+      }),
+    };
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("locked issue must not post a new lease");
+  console.log(JSON.stringify([[${JSON.stringify(durable)}, ${JSON.stringify(lease)}]]));
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/700321$/.test(path) && args.includes("DELETE")) {
+  require("node:fs").writeFileSync(${JSON.stringify(deletedLeasePath)}, "deleted");
+  console.log("");
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--sync-comments-only",
+          "--item-number",
+          "321",
+          "--comment-sync-min-age-days",
+          "7",
+        ],
+      });
+    });
+    assert.equal(JSON.parse(readText(reportPath))[0].action, "review_comment_synced");
+    assert.equal(existsSync(deletedLeasePath), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../dist/clawsweeper.js";
 import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.js";
+import { shouldReviewItem } from "../dist/scheduler-policy.js";
 import {
   implementedCloseReport,
   markedReviewCommentForTest,
@@ -1265,7 +1266,7 @@ if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(p
   }
 });
 
-test("guarded reports never publish changed snapshots without a reviewed updated_at", () => {
+test("guarded reports reject changed snapshots even with a zero publication cooldown", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -1361,14 +1362,321 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
           "--item-number",
           "321",
           "--comment-sync-min-age-days",
-          "7",
+          "0",
         ],
       });
     });
-    assert.deepEqual(JSON.parse(readText(reportPath)), []);
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      { number: 321, action: "skipped_changed_since_review", reason: "snapshot changed" },
+    ]);
     assert.equal(existsSync(commentWrites), false);
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: skipped_invalid_decision$/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("guarded PR source drift is rejected before any label mutation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const mutationLog = join(root, "mutations.log");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number: 321,
+        type: "pull_request",
+        title: "Protected PR changed after review",
+        url: "https://github.com/openclaw/openclaw/pull/321",
+        action_taken: "skipped_protected_label",
+        author: "reporter",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify(["security"]),
+        pull_head_sha: "reviewed-head",
+        item_updated_at: "2026-05-01T00:00:00Z",
+      }),
+      321,
+      "implemented_on_main",
+    );
+    writeFileSync(join(itemsDir, "321.md"), reviewed.report);
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 321,
+        title: "Protected PR changed after review",
+        labels: ["security"],
+        headSha: "reviewed-head",
+        itemUpdatedAt: "2026-05-02T00:00:00Z",
+        itemUpdatedAtAfterLabelSyncLogPath: mutationLog,
+        comment: reviewed.comment,
+      }),
+      () =>
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--sync-comments-only", "--apply-kind", "all", "--item-number", "321"],
+        }),
+    );
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      { number: 321, action: "skipped_changed_since_review", reason: "updated_at changed" },
+    ]);
+    assert.equal(existsSync(mutationLog), false);
+    assert.match(readText(join(itemsDir, "321.md")), /^action_taken: skipped_protected_label$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("protected stale-head proposals clear obsolete readiness labels before exiting", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const mutationLog = join(root, "mutations.log");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const labels = ["security", "proof: sufficient", "status: 👀 ready for maintainer look"];
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        number: 321,
+        type: "pull_request",
+        title: "Protected stale-head proposal",
+        url: "https://github.com/openclaw/openclaw/pull/321",
+        action_taken: "proposed_close",
+        author: "reporter",
+        author_association: "CONTRIBUTOR",
+        labels: JSON.stringify(labels),
+        pull_head_sha: "reviewed-head",
+        item_updated_at: "2026-05-01T00:00:00Z",
+      }),
+      321,
+      "implemented_on_main",
+    );
+    writeFileSync(join(itemsDir, "321.md"), reviewed.report);
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 321,
+        title: "Protected stale-head proposal",
+        labels,
+        headSha: "new-head",
+        itemUpdatedAtAfterLabelSyncLogPath: mutationLog,
+        comment: reviewed.comment,
+      }),
+      () =>
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--sync-comments-only", "--apply-kind", "all", "--item-number", "321"],
+        }),
+    );
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      { number: 321, action: "skipped_protected_label", reason: "protected label: security" },
+    ]);
+    const stored = readText(join(itemsDir, "321.md"));
+    assert.equal(existsSync(mutationLog), true);
+    assert.match(stored, /^current_pull_head_sha: new-head$/m);
+    assert.match(stored, /^labels: \["security"\]$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("protected source drift preserves its original guard after lock or label removal", () => {
+  for (const scenario of [
+    { locked: true, labels: ["security", "good first issue"], syncOnly: true },
+    { locked: false, labels: [], syncOnly: false },
+  ]) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const targetRepo = scenario.locked ? "openclaw/openclaw" : "openclaw/clawsweeper";
+      const itemsDir = join(root, "items");
+      const closedDir = join(root, "closed");
+      const plansDir = join(root, "plans");
+      const reportPath = join(root, "apply-report.json");
+      for (const directory of [itemsDir, closedDir, plansDir])
+        mkdirSync(directory, { recursive: true });
+      const issue = {
+        number: 321,
+        title: "Protected locked issue",
+        html_url: `https://github.com/${targetRepo}/issues/321`,
+        body: "Reviewed source.",
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-02T00:00:00Z",
+        closed_at: null,
+        state: "open",
+        locked: scenario.locked,
+        active_lock_reason: scenario.locked ? "resolved" : null,
+        author_association: "CONTRIBUTOR",
+        user: { login: "reporter" },
+        labels: scenario.labels,
+        comments: 0,
+        pull_request: null,
+      };
+      writeFileSync(
+        join(itemsDir, "321.md"),
+        implementedCloseReport({
+          repository: targetRepo,
+          title: issue.title,
+          action_taken: "skipped_protected_label",
+          labels: JSON.stringify(["security"]),
+          item_updated_at: "2026-05-01T00:00:00Z",
+          item_source_revision: itemSourceRevisionSha256ForTest(issue, []),
+          ...(scenario.locked
+            ? { review_lease_owner: "review-owner", review_lease_comment_id: "77" }
+            : {}),
+        }),
+      );
+      const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("protected locked source must not be mutated");
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+      withMockGh(root, ghMock, () =>
+        runApplyDecisionsForTest({
+          targetRepo,
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            ...(scenario.syncOnly ? ["--sync-comments-only"] : []),
+            "--item-number",
+            "321",
+            "--event-apply-proof",
+          ],
+        }),
+      );
+      const [result] = JSON.parse(readText(reportPath));
+      assert.equal(result.action, "skipped_changed_since_review");
+      assert.equal(result.sourceDriftVerified, true);
+      const stored = readText(join(itemsDir, "321.md"));
+      assert.match(stored, /^action_taken: skipped_protected_label$/m);
+      assert.match(stored, /^current_item_updated_at: 2026-05-02T00:00:00Z$/m);
+      assert.ok(stored.includes(`\nlabels: ${JSON.stringify(scenario.labels)}\n`));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("live protected labels and maintainer ownership take precedence over source drift", () => {
+  for (const scenario of [
+    {
+      targetRepo: "openclaw/clawsweeper",
+      labels: ["security"],
+      association: "CONTRIBUTOR",
+      closeReason: "implemented_on_main",
+      action: "skipped_protected_label",
+      reason: "protected label: security",
+    },
+    {
+      targetRepo: "openclaw/openclaw",
+      labels: ["triage"],
+      association: "MEMBER",
+      closeReason: "cannot_reproduce",
+      action: "skipped_maintainer_authored",
+      reason: "author association is MEMBER",
+    },
+  ]) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "items");
+      const closedDir = join(root, "closed");
+      const plansDir = join(root, "plans");
+      const reportPath = join(root, "apply-report.json");
+      for (const directory of [itemsDir, closedDir, plansDir])
+        mkdirSync(directory, { recursive: true });
+      writeFileSync(
+        join(itemsDir, "321.md"),
+        implementedCloseReport({
+          repository: scenario.targetRepo,
+          labels: "[]",
+          author_association: "CONTRIBUTOR",
+          close_reason: scenario.closeReason,
+        }),
+      );
+      const issue = {
+        number: 321,
+        title: "Live protected or maintainer issue",
+        html_url: `https://github.com/${scenario.targetRepo}/issues/321`,
+        body: "",
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-02T00:00:00Z",
+        closed_at: null,
+        state: "open",
+        locked: false,
+        active_lock_reason: null,
+        author_association: scenario.association,
+        user: { login: "reporter" },
+        labels: scenario.labels,
+        comments: 0,
+        pull_request: null,
+      };
+      const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321\\/(comments|timeline)(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else {
+  throw new Error("live protected source must not be mutated: " + JSON.stringify(args));
+}`;
+      withMockGh(root, ghMock, () =>
+        runApplyDecisionsForTest({
+          targetRepo: scenario.targetRepo,
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--skip-dashboard", "--item-number", "321", "--event-apply-proof"],
+        }),
+      );
+      assert.deepEqual(JSON.parse(readText(reportPath)), [
+        {
+          number: 321,
+          action: scenario.action,
+          reason: scenario.reason,
+          guardedOpenStateVerified: true,
+        },
+      ]);
+      const stored = readText(join(itemsDir, "321.md"));
+      assert.ok(stored.includes(`\nlabels: ${JSON.stringify(scenario.labels)}\n`));
+      assert.match(stored, new RegExp(`^author_association: ${scenario.association}$`, "m"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   }
 });
 
@@ -1953,6 +2261,130 @@ test("matching durable comments repair stale, missing, and refreshed sync timest
   }
 });
 
+test("metadata-only comment verification never hides newer human source activity", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const now = Date.now();
+    const reviewedAt = new Date(now - 2 * 60 * 60 * 1000).toISOString();
+    const humanUpdatedAt = new Date(now - 60 * 60 * 1000).toISOString();
+    const commentUpdatedAt = new Date(now - 90 * 60 * 1000).toISOString();
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        decision: "keep_open",
+        close_reason: "none",
+        action_taken: "kept_open",
+        reviewed_at: reviewedAt,
+        item_updated_at: reviewedAt,
+        labels: "[]",
+      }),
+      321,
+      "none",
+    );
+    writeFileSync(
+      join(itemsDir, "321.md"),
+      reviewed.report
+        .replace(/^review_comment_synced_at:.*\n/m, "")
+        .replaceAll(
+          "https://github.com/openclaw/clawsweeper/issues/321",
+          "https://github.com/openclaw/openclaw/issues/321",
+        ),
+    );
+    const durable = {
+      id: 9321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: commentUpdatedAt,
+      updated_at: commentUpdatedAt,
+      user: { login: "clawsweeper[bot]" },
+      body: reviewed.comment,
+    };
+    const issue = {
+      number: 321,
+      title: "Render work plans",
+      html_url: "https://github.com/openclaw/openclaw/issues/321",
+      body: "Human updated after review.",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: humanUpdatedAt,
+      closed_at: null,
+      state: "open",
+      locked: false,
+      active_lock_reason: null,
+      author_association: "CONTRIBUTOR",
+      user: { login: "reporter" },
+      labels: [],
+      comments: 1,
+      pull_request: null,
+    };
+    const schedulerItem = {
+      repo: "openclaw/openclaw",
+      number: 321,
+      kind: "issue" as const,
+      createdAt: issue.created_at,
+      updatedAt: humanUpdatedAt,
+    };
+    const review = { reviewedAt, itemUpdatedAt: reviewedAt, reviewStatus: "complete" as const };
+    assert.equal(shouldReviewItem(schedulerItem, review, now), true);
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) throw new Error("metadata-only must not mutate GitHub");
+  console.log(JSON.stringify([[${JSON.stringify(durable)}]]));
+} else if (/\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (/\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify(${JSON.stringify(issue)}));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  throw new Error("unexpected gh args " + JSON.stringify(args));
+}`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        targetRepo: "openclaw/openclaw",
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--skip-dashboard",
+          "--sync-comments-only",
+          "--item-number",
+          "321",
+          "--comment-sync-min-age-days",
+          "0",
+        ],
+      });
+    });
+    const updated = readText(join(itemsDir, "321.md"));
+    const syncedAt = updated.match(/^review_comment_synced_at:\s*(.+)$/m)?.[1];
+    assert.equal(syncedAt, commentUpdatedAt);
+    assert.match(updated, /^review_comment_checked_at: /m);
+    assert.equal(
+      shouldReviewItem(schedulerItem, { ...review, reviewCommentSyncedAt: syncedAt }, Date.now()),
+      true,
+    );
+    assert.deepEqual(JSON.parse(readText(reportPath)), [
+      {
+        number: 321,
+        action: "review_comment_synced",
+        reason: "recorded existing durable comment metadata",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("locked, already-synchronized maintainer and invalid reports refresh local metadata", () => {
   for (const action of ["skipped_maintainer_authored", "skipped_invalid_decision"]) {
     const root = mkdtempSync(tmpPrefix);
@@ -2068,8 +2500,10 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
       assert.match(updatedReport, new RegExp(`^action_taken: ${action}$`, "m"));
       const refreshedSyncTime = updatedReport.match(/^review_comment_synced_at:\s*(.*)$/m)?.[1];
       const checkedTime = updatedReport.match(/^apply_checked_at:\s*(.*)$/m)?.[1];
-      assert.ok(refreshedSyncTime && checkedTime);
-      assert.ok(Date.parse(refreshedSyncTime) >= Date.parse(checkedTime), action);
+      const verifiedTime = updatedReport.match(/^review_comment_checked_at:\s*(.*)$/m)?.[1];
+      assert.equal(refreshedSyncTime, syncedAt);
+      assert.ok(verifiedTime && checkedTime);
+      assert.ok(Date.parse(verifiedTime) >= Date.parse(checkedTime), action);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { join } from "node:path";
 import test from "node:test";
 
-import { guardedOpenApplyProofFields } from "../dist/clawsweeper.js";
+import { guardedOpenApplyProofFields, shouldSyncReviewComment } from "../dist/clawsweeper.js";
 import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { createReviewedPrActivityCursor } from "../dist/review-activity-cursor.js";
 import {
@@ -841,6 +841,281 @@ if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  }
+});
+
+test("comment-only apply synchronizes guarded reviews without promoting their close actions", () => {
+  for (const guard of [
+    { action: "skipped_protected_label", labels: ["security"], association: "CONTRIBUTOR" },
+    { action: "skipped_maintainer_authored", labels: [], association: "MEMBER" },
+    {
+      action: "skipped_close_exempt_label",
+      labels: ["clawsweeper:human-review"],
+      association: "CONTRIBUTOR",
+    },
+    { action: "skipped_invalid_decision", labels: [], association: "CONTRIBUTOR" },
+  ]) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "items");
+      const closedDir = join(root, "closed");
+      const plansDir = join(root, "plans");
+      const reportPath = join(root, "apply-report.json");
+      mkdirSync(itemsDir, { recursive: true });
+      mkdirSync(plansDir, { recursive: true });
+      writeFileSync(
+        join(itemsDir, "321.md"),
+        implementedCloseReport({
+          repository: "openclaw/openclaw",
+          action_taken: guard.action,
+          author_association: guard.association,
+          labels: JSON.stringify(guard.labels),
+          confidence: guard.action === "skipped_invalid_decision" ? "low" : "high",
+        }),
+        "utf8",
+      );
+
+      const ghMock = `
+const fs = require("node:fs");
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+const commentPath = ${JSON.stringify(join(root, "comment.json"))};
+if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method")) {
+    const payload = JSON.parse(fs.readFileSync(args[args.indexOf("--input") + 1], "utf8"));
+    const comment = {
+      id: 9321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: "2026-08-02T00:00:00Z",
+      updated_at: "2026-08-02T00:00:00Z",
+      user: { login: "clawsweeper[bot]" },
+      body: payload.body,
+    };
+    fs.writeFileSync(commentPath, JSON.stringify(comment));
+    console.log(JSON.stringify(comment));
+  } else {
+    console.log(JSON.stringify([fs.existsSync(commentPath)
+      ? [JSON.parse(fs.readFileSync(commentPath, "utf8"))]
+      : []]));
+  }
+} else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Guarded issue",
+    html_url: "https://github.com/openclaw/openclaw/issues/321",
+    body: "",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: ${JSON.stringify(guard.association)},
+    user: { login: "reporter" },
+    labels: ${JSON.stringify(guard.labels)},
+    comments: fs.existsSync(commentPath) ? 1 : 0,
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+      withMockGh(root, ghMock, () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--sync-comments-only",
+            "--item-number",
+            "321",
+            "--processed-limit",
+            "1",
+            "--comment-sync-min-age-days",
+            "0",
+          ],
+        });
+      });
+
+      const [result] = JSON.parse(readText(reportPath));
+      assert.equal(result.number, 321);
+      assert.equal(result.action, "review_comment_synced");
+      assert.match(result.reason, /^(?:created|updated) durable Codex review comment$/);
+      assert.match(
+        readText(join(itemsDir, "321.md")),
+        new RegExp(`^action_taken: ${guard.action}$`, "m"),
+      );
+      assert.equal(existsSync(join(root, "comment.json")), true);
+      assert.doesNotMatch(
+        JSON.parse(readText(join(root, "comment.json"))).body,
+        /action_taken[=:] proposed_close/i,
+      );
+      assert.equal(existsSync(join(closedDir, "321.md")), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("matching durable comments repair stale, missing, and refreshed sync timestamps", () => {
+  const now = Date.parse("2026-08-02T12:00:00Z");
+  const base = {
+    syncCommentsOnly: true,
+    isCloseProposal: false,
+    commentSyncMinAgeDays: 7,
+    reviewCommentSyncedAt: "2026-08-01T12:00:00Z",
+    hasExistingReviewComment: true,
+    needsReviewCommentBodySync: false,
+    needsReviewCommentHashSync: false,
+    needsReviewCommentReferenceSync: false,
+    now,
+  };
+
+  assert.equal(shouldSyncReviewComment(base), false);
+  for (const metadata of [
+    { reviewCommentSyncedAt: undefined },
+    { reviewCommentSyncedAt: "not-a-timestamp" },
+    { reviewCommentSyncedAt: "2026-07-26T12:00:00Z" },
+    { reviewedAt: "2026-08-02T11:00:00Z" },
+    { lastFullReviewAt: "2026-08-02T11:00:00Z" },
+    { guardedReviewedAt: "2026-08-02T11:00:00Z" },
+  ]) {
+    assert.equal(shouldSyncReviewComment({ ...base, ...metadata }), true);
+  }
+});
+
+test("comment-only apply repairs timestamps and references without editing GitHub", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const reviewed = reportWithSyncedReviewComment(
+      implementedCloseReport({
+        repository: "openclaw/openclaw",
+        decision: "keep_open",
+        close_reason: "none",
+        action_taken: "kept_open",
+        reviewed_at: "2026-08-02T10:00:00Z",
+      }),
+      321,
+      "none",
+    );
+    const canonicalReport = reviewed.report.replaceAll(
+      "https://github.com/openclaw/clawsweeper/issues/321",
+      "https://github.com/openclaw/openclaw/issues/321",
+    );
+    const existing = {
+      id: 9_321,
+      html_url: "https://github.com/openclaw/openclaw/issues/321#issuecomment-9321",
+      created_at: "2026-08-01T01:00:00Z",
+      updated_at: "2026-08-01T01:00:00Z",
+      user: { login: "clawsweeper[bot]" },
+      body: reviewed.comment,
+    };
+    const ghMock = `
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+if (/\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") || args.includes("-X")) {
+    console.error("unchanged durable review comment must not be edited");
+    process.exit(1);
+  }
+  console.log(JSON.stringify([[${JSON.stringify(existing)}]]));
+} else if (/\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[]]));
+} else if (/\\/issues\\/321$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 321,
+    title: "Render work plans",
+    html_url: "https://github.com/openclaw/openclaw/issues/321",
+    body: "",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 1,
+    pull_request: null
+  }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+
+    const freshSyncedAt = new Date().toISOString();
+    const currentReport = canonicalReport.replace(
+      /^review_comment_synced_at:.*$/m,
+      `review_comment_synced_at: ${freshSyncedAt}`,
+    );
+    for (const report of [
+      canonicalReport.replace(/^review_comment_synced_at:.*\n/m, ""),
+      currentReport.replace(/^review_comment_id:.*$/m, "review_comment_id: none"),
+      currentReport.replace(/^review_comment_id:.*\n/m, ""),
+      currentReport.replace(/^review_comment_url:.*$/m, "review_comment_url: none"),
+    ]) {
+      writeFileSync(join(itemsDir, "321.md"), report, "utf8");
+      withMockGh(root, ghMock, () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--sync-comments-only",
+            "--item-number",
+            "321",
+            "--comment-sync-min-age-days",
+            "7",
+          ],
+        });
+      });
+
+      assert.deepEqual(JSON.parse(readText(reportPath)), [
+        {
+          number: 321,
+          action: "review_comment_synced",
+          reason: "recorded existing durable comment metadata",
+        },
+      ]);
+      const repaired = readText(join(itemsDir, "321.md"));
+      assert.match(repaired, /^review_comment_synced_at: /m);
+      assert.match(repaired, /^review_comment_id: 9321$/m);
+      assert.match(
+        repaired,
+        /^review_comment_url: https:\/\/github\.com\/openclaw\/openclaw\/issues\/321#issuecomment-9321$/m,
+      );
+      assert.match(repaired, /^action_taken: kept_open$/m);
+      assert.equal(existsSync(join(closedDir, "321.md")), false);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/apply-pr-duplicate-proof.test.ts
+++ b/test/apply-pr-duplicate-proof.test.ts
@@ -116,6 +116,302 @@ test("apply-decisions blocks duplicate close when linked canonical PR closed unm
   }
 });
 
+test("locked duplicate reviews retain newly discovered canonical correction work", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "records", "openclaw-openclaw", "items");
+    const closedDir = join(root, "records", "openclaw-openclaw", "closed");
+    const plansDir = join(root, "records", "openclaw-openclaw", "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    const canonicalUrl = "https://github.com/openclaw/openclaw/pull/400";
+    const synced = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number: 336,
+        title: "Locked duplicate review",
+        close_reason: "duplicate_or_superseded",
+        work_cluster_refs: JSON.stringify([`Superseded by ${canonicalUrl}`]),
+      }),
+      336,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(join(itemsDir, "336.md"), synced.report);
+    withMockGh(
+      root,
+      promotionGhMock({
+        number: 336,
+        title: "Locked duplicate review",
+        comment: synced.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Closed unmerged canonical PR",
+            html_url: canonicalUrl,
+            state: "closed",
+            merged_at: null,
+            labels: [],
+          },
+        },
+      }).replace("locked: false,", "locked: true,"),
+      () => {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--sync-comments-only", "--item-number", "336", "--apply-kind", "all"],
+        });
+      },
+    );
+
+    const [result] = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(result.action, "retry_stale_canonical_comment_sync");
+    assert.match(result.reason, /stale canonical comment correction/);
+    const report = readFileSync(join(itemsDir, "336.md"), "utf8");
+    assert.match(report, /^action_taken: retry_stale_canonical_comment_sync$/m);
+    assert.match(report, /^stale_canonical_pull_request_number: 400$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function assertChangedReviewNeverRepublishes(action: string): void {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const number = 336;
+    const labels = ["proof: override", "rating: 🦞 diamond lobster"];
+    const reviewed = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number,
+        title: "Changed PR with stale close verdict",
+        close_reason: "implemented_on_main",
+        labels: JSON.stringify(labels),
+        pull_head_sha: "head-sha",
+        reviewed_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      }),
+      number,
+      "implemented_on_main",
+    );
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      reviewed.report
+        .replace(/^action_taken: proposed_close$/m, `action_taken: ${action}`)
+        .replace(
+          /^review_comment_synced_at:.*$/m,
+          `review_comment_synced_at: ${new Date().toISOString()}`,
+        ),
+    );
+    const commentWrites = join(root, "comment-writes.log");
+    withMockGh(
+      root,
+      promotionGhMock({
+        number,
+        title: "Changed PR with stale close verdict",
+        labels,
+        itemUpdatedAt: "2026-05-02T00:00:00Z",
+        comment: reviewed.comment,
+        commentWriteLogPath: commentWrites,
+      }),
+      () =>
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--sync-comments-only",
+            "--apply-kind",
+            "all",
+            "--item-number",
+            String(number),
+            "--comment-sync-min-age-days",
+            "7",
+          ],
+        }),
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(reportPath, "utf8")),
+      action === "skipped_invalid_decision"
+        ? [{ number, action: "skipped_changed_since_review", reason: "updated_at changed" }]
+        : [],
+    );
+    assert.equal(existsSync(commentWrites), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("changed PR reviews never force a recently synchronized stale close verdict", () => {
+  assertChangedReviewNeverRepublishes("skipped_changed_since_review");
+});
+
+test("invalid PR decisions never force stale close verdicts after source drift", () => {
+  assertChangedReviewNeverRepublishes("skipped_invalid_decision");
+});
+
+test("protected PR head changes immediately replace obsolete close markers", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const commentWrites = join(root, "comment-writes.log");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const number = 336;
+    const labels = ["security"];
+    const reviewed = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number,
+        title: "Protected PR stale head",
+        action_taken: "skipped_protected_label",
+        close_reason: "implemented_on_main",
+        labels: JSON.stringify(labels),
+        pull_head_sha: "old-head",
+        reviewed_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      }),
+      number,
+      "implemented_on_main",
+    );
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      reviewed.report.replace(
+        /^review_comment_synced_at:.*$/m,
+        `review_comment_synced_at: ${new Date(Date.now() - 60 * 60 * 1000).toISOString()}`,
+      ),
+    );
+    withMockGh(
+      root,
+      promotionGhMock({
+        number,
+        title: "Protected PR stale head",
+        labels,
+        headSha: "new-head",
+        comment: reviewed.comment,
+        commentWriteLogPath: commentWrites,
+      }),
+      () =>
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--skip-dashboard",
+            "--sync-comments-only",
+            "--apply-kind",
+            "all",
+            "--item-number",
+            String(number),
+            "--comment-sync-min-age-days",
+            "7",
+          ],
+        }),
+    );
+    const [result] = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.equal(result.action, "review_comment_synced");
+    assert.equal(existsSync(commentWrites), true);
+    const updated = readFileSync(join(itemsDir, `${number}.md`), "utf8");
+    assert.match(updated, /^action_taken: skipped_protected_label$/m);
+    assert.match(updated, /^current_pull_head_sha: new-head$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unchanged changed-duplicate records do not consume a bounded comment-sync slot", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    for (const directory of [itemsDir, closedDir, plansDir])
+      mkdirSync(directory, { recursive: true });
+    const number = 338;
+    const canonicalUrl = "https://github.com/openclaw/openclaw/pull/400";
+    const labels = ["proof: override", "rating: 🦞 diamond lobster"];
+    const reviewed = reportWithSyncedReviewComment(
+      lowSignalCloseReport({
+        number,
+        title: "Changed duplicate with open canonical",
+        action_taken: "skipped_changed_since_review",
+        close_reason: "duplicate_or_superseded",
+        labels: JSON.stringify(labels),
+        work_cluster_refs: JSON.stringify([`Superseded by ${canonicalUrl}`]),
+        pull_head_sha: "head-sha",
+        reviewed_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      }),
+      number,
+      "duplicate_or_superseded",
+    );
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      reviewed.report
+        .replace(
+          /^review_comment_synced_at:.*$/m,
+          `review_comment_synced_at: ${new Date(Date.now() - 60 * 60 * 1000).toISOString()}`,
+        )
+        .replace(/^---\n/, `---\napply_checked_at: ${new Date().toISOString()}\n`),
+    );
+    withMockGh(
+      root,
+      promotionGhMock({
+        number,
+        title: "Changed duplicate with open canonical",
+        labels,
+        comment: reviewed.comment,
+        linkedPulls: {
+          400: {
+            number: 400,
+            title: "Open canonical PR",
+            html_url: canonicalUrl,
+            state: "open",
+            merged_at: null,
+            labels: [],
+          },
+        },
+      }),
+      () =>
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: [
+            "--sync-comments-only",
+            "--apply-kind",
+            "all",
+            "--item-number",
+            String(number),
+            "--comment-sync-min-age-days",
+            "7",
+          ],
+        }),
+    );
+    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), []);
+    assert.match(
+      readFileSync(join(itemsDir, `${number}.md`), "utf8"),
+      /^action_taken: skipped_changed_since_review$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("apply-decisions blocks duplicate close when canonical PR is only in close comment", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -7,6 +7,179 @@ import test from "node:test";
 import { capturedCanonicalRecordBaselineKeys } from "../dist/repair/canonical-record-baseline.js";
 import { reportFrontMatter, tmpPrefix, withMockGh } from "./helpers.ts";
 
+test("scoped reconciliation never changes records outside its selected batch", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const recordsDir = join(root, "records", "openclaw-openclaw");
+  const itemsDir = join(recordsDir, "items");
+  const closedDir = join(recordsDir, "closed");
+  const plansDir = join(recordsDir, "plans");
+  const canonicalBaselineDir = join(root, "canonical-baseline");
+  for (const dir of [itemsDir, closedDir, plansDir]) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const report = (number: number, currentState: "open" | "closed") =>
+    reportFrontMatter({ number, current_state: currentState });
+  writeFileSync(join(itemsDir, "1.md"), report(1, "open"));
+  writeFileSync(join(itemsDir, "2.md"), report(2, "open"));
+  writeFileSync(join(closedDir, "3.md"), report(3, "closed"));
+  const unrelatedPlan = "preserve unrelated closed sidecar\n";
+  writeFileSync(join(plansDir, "3.md"), unrelatedPlan);
+  const ghMock = `
+const args = process.argv.slice(2);
+if (args[0] === "api" && args[1]?.endsWith("/issues/2")) {
+  process.stdout.write(JSON.stringify({number:2,state:"closed",closed_at:"2026-08-02T00:00:00Z"}));
+} else {
+  process.stderr.write("unexpected gh args: " + JSON.stringify(args) + "\\n");
+  process.exit(1);
+}
+`;
+
+  try {
+    let stdout = "";
+    withMockGh(root, ghMock, () => {
+      stdout = execFileSync(
+        process.execPath,
+        [
+          "dist/clawsweeper.js",
+          "reconcile",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--closed-dir",
+          closedDir,
+          "--plans-dir",
+          plansDir,
+          "--canonical-record-baseline-dir",
+          canonicalBaselineDir,
+          "--skip-closed-at",
+          "--item-numbers",
+          "2",
+          "--only-item-numbers",
+        ],
+        { encoding: "utf8" },
+      );
+    });
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.pagesScanned, 0);
+    assert.deepEqual(result.changedItemNumbers, [2]);
+    assert.deepEqual(result.changedRecordFiles, ["2.md"]);
+    assert.equal(existsSync(join(itemsDir, "1.md")), true);
+    assert.equal(existsSync(join(closedDir, "1.md")), false);
+    assert.equal(existsSync(join(itemsDir, "2.md")), false);
+    assert.equal(existsSync(join(closedDir, "2.md")), true);
+    assert.equal(readFileSync(join(plansDir, "3.md"), "utf8"), unrelatedPlan);
+    assert.deepEqual(
+      [...capturedCanonicalRecordBaselineKeys(canonicalBaselineDir)],
+      ["openclaw-openclaw/2"],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scoped reconciliation archives a deleted item only after confirming repository access", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const itemsDir = join(root, "items");
+  const closedDir = join(root, "closed");
+  const plansDir = join(root, "plans");
+  for (const dir of [itemsDir, closedDir, plansDir]) mkdirSync(dir, { recursive: true });
+  writeFileSync(join(itemsDir, "41.md"), reportFrontMatter({ number: 41, current_state: "open" }));
+  const ghMock = `
+const args = process.argv.slice(2);
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/issues/41") {
+  process.stderr.write("gh: Not Found (HTTP 404)\\n");
+  process.exit(1);
+}
+if (args[0] === "api" && args[1] === "repos/openclaw/openclaw") {
+  process.stdout.write(JSON.stringify({id:41}));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh args: " + JSON.stringify(args) + "\\n");
+process.exit(1);
+`;
+
+  try {
+    let stdout = "";
+    withMockGh(root, ghMock, () => {
+      stdout = execFileSync(
+        process.execPath,
+        [
+          "dist/clawsweeper.js",
+          "reconcile",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--closed-dir",
+          closedDir,
+          "--plans-dir",
+          plansDir,
+          "--skip-closed-at",
+          "--item-numbers",
+          "41",
+          "--only-item-numbers",
+        ],
+        { encoding: "utf8" },
+      );
+    });
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.pagesScanned, 0);
+    assert.equal(result.movedToClosed, 1);
+    assert.deepEqual(result.changedItemNumbers, [41]);
+    assert.equal(existsSync(join(itemsDir, "41.md")), false);
+    assert.equal(existsSync(join(closedDir, "41.md")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scoped reconciliation never archives an item when repository access is missing", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const itemsDir = join(root, "items");
+  const closedDir = join(root, "closed");
+  const plansDir = join(root, "plans");
+  for (const dir of [itemsDir, closedDir, plansDir]) mkdirSync(dir, { recursive: true });
+  writeFileSync(join(itemsDir, "41.md"), reportFrontMatter({ number: 41, current_state: "open" }));
+  const ghMock = `
+process.stderr.write("gh: Not Found (HTTP 404)\\n");
+process.exit(1);
+`;
+
+  try {
+    withMockGh(root, ghMock, () => {
+      assert.throws(() =>
+        execFileSync(
+          process.execPath,
+          [
+            "dist/clawsweeper.js",
+            "reconcile",
+            "--target-repo",
+            "openclaw/openclaw",
+            "--items-dir",
+            itemsDir,
+            "--closed-dir",
+            closedDir,
+            "--plans-dir",
+            plansDir,
+            "--skip-closed-at",
+            "--item-numbers",
+            "41",
+            "--only-item-numbers",
+          ],
+          { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+        ),
+      );
+    });
+    assert.equal(existsSync(join(itemsDir, "41.md")), true);
+    assert.equal(existsSync(join(closedDir, "41.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("reconcile reports every changed record tuple and cleans already-closed sidecars", () => {
   const root = mkdtempSync(tmpPrefix);
   const recordsDir = join(root, "records", "openclaw-openclaw");

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -2836,13 +2836,195 @@ test("durable all-item sync publishes guarded reviews without selecting terminal
         }),
       ),
       {
-        item_numbers: "160,170,180,30,70,150,10,20,40,50,60,80,90,100,110,190",
-        count: "16",
+        item_numbers: "160,170,180,30,70,150,10,20,40,50,60,80,90,100,110,190,210",
+        count: "17",
         cursor: "0",
-        next_cursor: "190",
+        next_cursor: "210",
         wrapped: "false",
       },
     );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("automatic comment sync publishes failed reviews and rechecks guarded PR heads", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const now = Date.now();
+  const reviewedAt = new Date(now - 30 * 60 * 1000).toISOString();
+  const syncedAt = new Date(now - 60 * 60 * 1000).toISOString();
+  try {
+    writeCommentSyncRecord(root, 101, "pull_request", "kept_open", {
+      reviewStatus: "failed",
+      reviewCommentId: "9101",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/101#issuecomment-9101",
+      reviewCommentHash: "a".repeat(64),
+      reviewedAt,
+      reviewCommentSyncedAt: syncedAt,
+    });
+    writeCommentSyncRecord(root, 102, "pull_request", "skipped_protected_label", {
+      reviewCommentId: "9102",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/102#issuecomment-9102",
+      reviewCommentHash: "b".repeat(64),
+      reviewedAt,
+      reviewCommentSyncedAt: syncedAt,
+      pullHeadSha: "reviewed-head",
+      currentPullHeadSha: "new-head",
+    });
+    writeCommentSyncRecord(root, 103, "issue", "skipped_protected_label", {
+      reviewCommentId: "9103",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/issues/103#issuecomment-9103",
+      reviewCommentHash: "c".repeat(64),
+      reviewedAt: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+      reviewCommentSyncedAt: syncedAt,
+    });
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      }),
+    );
+    assert.deepEqual(result.item_numbers.split(",").map(Number), [101, 102]);
+    const failedRecord = path.join(
+      root,
+      "records/openclaw-openclaw/items/openclaw-openclaw-101.md",
+    );
+    fs.writeFileSync(
+      failedRecord,
+      fs
+        .readFileSync(failedRecord, "utf8")
+        .replace(/^---\n/, `---\nreview_comment_checked_at: ${new Date(now).toISOString()}\n`),
+    );
+    const afterPublication = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      }),
+    );
+    assert.deepEqual(afterPublication.item_numbers.split(",").map(Number), [102]);
+    const overdue = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+    fs.writeFileSync(
+      failedRecord,
+      fs
+        .readFileSync(failedRecord, "utf8")
+        .replace(/^review_comment_synced_at:.*$/m, `review_comment_synced_at: ${overdue}`)
+        .replace(/^review_comment_checked_at:.*$/m, `review_comment_checked_at: ${overdue}`)
+        .replace(/^reviewed_at:.*$/m, `reviewed_at: ${overdue}`),
+    );
+    for (const [number, action] of [
+      [104, "skipped_protected_label"],
+      [105, "skipped_maintainer_authored"],
+    ] as const) {
+      writeCommentSyncRecord(root, number, "issue", action, {
+        reviewStatus: "failed",
+        reviewCommentId: String(9_000 + number),
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "d".repeat(64),
+        reviewedAt: overdue,
+        reviewCommentSyncedAt: overdue,
+      });
+    }
+    const afterMaintenanceInterval = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      }),
+    );
+    assert.deepEqual(
+      afterMaintenanceInterval.item_numbers
+        .split(",")
+        .map(Number)
+        .sort((left, right) => left - right),
+      [101, 102, 104, 105],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("checked-only comments and failed durable repairs remain eligible until synchronized", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const checkedAt = new Date().toISOString();
+  try {
+    for (const [number, type, action, status] of [
+      [201, "issue", "kept_open", "complete"],
+      [202, "issue", "skipped_protected_label", "complete"],
+      [203, "pull_request", "kept_open", "failed"],
+      [204, "pull_request", "retry_stale_canonical_comment_sync", "failed"],
+    ] as const) {
+      writeCommentSyncRecord(root, number, type, action, {
+        reviewStatus: status,
+        reviewCommentId: String(9_000 + number),
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt: "2020-01-01T00:00:00Z",
+        ...(number === 204 ? { reviewCommentSyncedAt: checkedAt } : {}),
+      });
+      const reportPath = path.join(
+        root,
+        `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`,
+      );
+      fs.writeFileSync(
+        reportPath,
+        fs
+          .readFileSync(reportPath, "utf8")
+          .replace(/^---\n/, `---\nreview_comment_checked_at: ${checkedAt}\n`),
+      );
+    }
+    writeCommentSyncRecord(root, 500, "pull_request", "kept_open", {
+      reviewCommentId: "9500",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/500#issuecomment-9500",
+      reviewCommentHash: "a".repeat(64),
+      reviewedAt: "2020-01-01T00:00:00Z",
+      reviewCommentSyncedAt: checkedAt,
+    });
+    writeCommentSyncCursor(cursorPath, 250, "openclaw/openclaw");
+    assert.equal(
+      withCwd(root, () =>
+        commentSyncBatchOutput({
+          targetRepo: "openclaw/openclaw",
+          applyKind: "all",
+          batchSize: 1,
+          cursorPath,
+        }),
+      ).item_numbers,
+      "201",
+    );
+    writeCommentSyncCursor(cursorPath, 0, "openclaw/openclaw");
+    const select = () =>
+      withCwd(root, () =>
+        commentSyncBatchOutput({
+          targetRepo: "openclaw/openclaw",
+          applyKind: "all",
+          batchSize: 40,
+          cursorPath,
+        }),
+      )
+        .item_numbers.split(",")
+        .filter(Boolean)
+        .map(Number);
+    assert.deepEqual(select(), [201, 202, 203, 204, 500]);
+    for (const number of [201, 202, 203]) {
+      const reportPath = path.join(
+        root,
+        `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`,
+      );
+      fs.writeFileSync(
+        reportPath,
+        fs
+          .readFileSync(reportPath, "utf8")
+          .replace(/^---\n/, `---\nreview_comment_synced_at: ${checkedAt}\n`),
+      );
+    }
+    assert.deepEqual(select(), [204, 500]);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -2940,8 +3122,8 @@ test("post-sync guarded action changes return to the durable comment queue", () 
       }),
     );
 
-    assert.equal(result.item_numbers, "10,20,30");
-    assert.equal(result.count, "3");
+    assert.equal(result.item_numbers, "10,20,30,40");
+    assert.equal(result.count, "4");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -3322,7 +3504,7 @@ function writeCommentSyncRecord(root, number, type, actionTaken, options = {}) {
     "---",
     `repository: ${targetRepo}`,
     `type: ${type}`,
-    "review_status: complete",
+    `review_status: ${options.reviewStatus ?? "complete"}`,
     `local_checkout_access: ${options.localCheckoutAccess ?? "verified"}`,
     "item_snapshot_hash: abc123",
     `action_taken: ${actionTaken}`,

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -2714,6 +2714,565 @@ test("workflow utilities select cursor-based PR comment sync batches", () => {
   );
 });
 
+test("durable all-item sync publishes guarded reviews without selecting terminal records", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const now = Date.now();
+  const fresh = new Date(now - 60_000).toISOString();
+  const stale = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+  try {
+    writeCommentSyncRecord(root, 10, "issue", "kept_open");
+    writeCommentSyncRecord(root, 20, "pull_request", "kept_open", {
+      reviewCommentId: "9020",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/20#issuecomment-9020",
+      reviewCommentHash: "a".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 30, "issue", "kept_open", {
+      reviewCommentId: "9030",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/issues/30#issuecomment-9030",
+      reviewCommentHash: "b".repeat(64),
+      reviewedAt: fresh,
+      reviewCommentSyncedAt: stale,
+    });
+    writeCommentSyncRecord(root, 40, "pull_request", "kept_open", {
+      reviewCommentId: "9040",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/40#issuecomment-9040",
+      reviewCommentHash: "c".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: stale,
+    });
+    writeCommentSyncRecord(root, 50, "pull_request", "retry_stale_canonical_comment_sync", {
+      reviewCommentId: "9050",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/50#issuecomment-9050",
+      reviewCommentHash: "d".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 60, "pull_request", "skipped_changed_since_review", {
+      decision: "close",
+      closeReason: "duplicate_or_superseded",
+      reviewCommentId: "9060",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/60#issuecomment-9060",
+      reviewCommentHash: "e".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 70, "pull_request", "kept_open", {
+      reviewCommentId: "9070",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/70#issuecomment-9070",
+      reviewCommentHash: "none",
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 80, "issue", "skipped_protected_label");
+    writeCommentSyncRecord(root, 90, "pull_request", "skipped_maintainer_authored");
+    writeCommentSyncRecord(root, 100, "pull_request", "skipped_close_exempt_label");
+    writeCommentSyncRecord(root, 110, "issue", "skipped_invalid_decision");
+    writeCommentSyncRecord(root, 120, "pull_request", "skipped_comment_auth");
+    writeCommentSyncRecord(root, 130, "issue", "skipped_stale_review_comment_sync");
+    writeCommentSyncRecord(root, 140, "issue", "skipped_low_signal_live_guard");
+    writeCommentSyncRecord(root, 150, "pull_request", "kept_open", {
+      reviewCommentId: "9150",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/150#issuecomment-9150",
+      reviewCommentHash: "corrupt-comment-hash",
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 160, "issue", "kept_open", {
+      reviewCommentId: "9160",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/issues/160#issuecomment-9160",
+      reviewCommentHash: "f".repeat(64),
+      reviewedAt: new Date(now - 30_000).toISOString(),
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 170, "pull_request", "kept_open", {
+      reviewCommentId: "9170",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/170#issuecomment-9170",
+      reviewCommentHash: "1".repeat(64),
+      lastFullReviewAt: new Date(now - 30_000).toISOString(),
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 180, "pull_request", "kept_open", {
+      reviewCommentId: "9180",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/180#issuecomment-9180",
+      reviewCommentHash: "2".repeat(64),
+      lastFullReviewAt: stale,
+      reviewedAt: new Date(now - 30_000).toISOString(),
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 190, "pull_request", "kept_open", {
+      reviewCommentId: "9190",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/190#issuecomment-9190",
+      reviewCommentHash: "3".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+      pullHeadSha: "reviewed-head",
+      currentPullHeadSha: "new-head",
+    });
+    writeCommentSyncRecord(root, 200, "issue", "skipped_protected_label", {
+      reviewCommentId: "9200",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/issues/200#issuecomment-9200",
+      reviewCommentHash: "4".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+    writeCommentSyncRecord(root, 210, "pull_request", "skipped_maintainer_authored", {
+      reviewCommentId: "9210",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/210#issuecomment-9210",
+      reviewCommentHash: "5".repeat(64),
+      reviewedAt: stale,
+      reviewCommentSyncedAt: fresh,
+    });
+
+    assert.deepEqual(
+      withCwd(root, () =>
+        commentSyncBatchOutput({
+          targetRepo: "openclaw/openclaw",
+          applyKind: "all",
+          batchSize: 20,
+          cursorPath,
+        }),
+      ),
+      {
+        item_numbers: "160,170,180,30,70,150,10,20,40,50,60,80,90,100,110,190",
+        count: "16",
+        cursor: "0",
+        next_cursor: "190",
+        wrapped: "false",
+      },
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("refreshed and timestamp-less guarded reviews cross an existing automatic cursor", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const now = Date.now();
+  const syncedAt = new Date(now - 60_000).toISOString();
+  try {
+    for (let number = 101; number <= 140; number += 1) {
+      writeCommentSyncRecord(root, number, "pull_request", "kept_open", {
+        reviewCommentId: `${9_000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/pull/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt: syncedAt,
+        reviewCommentSyncedAt: syncedAt,
+      });
+    }
+    for (const { number, action, reviewedAt, reviewCommentSyncedAt } of [
+      {
+        number: 5,
+        action: "skipped_protected_label",
+        reviewedAt: new Date(now - 10_000).toISOString(),
+        reviewCommentSyncedAt: syncedAt,
+      },
+      {
+        number: 6,
+        action: "skipped_maintainer_authored",
+        reviewedAt: new Date(now - 30_000).toISOString(),
+      },
+      {
+        number: 7,
+        action: "skipped_close_exempt_label",
+        reviewedAt: new Date(now - 20_000).toISOString(),
+        reviewCommentSyncedAt: "not-a-timestamp",
+      },
+    ]) {
+      writeCommentSyncRecord(root, number, "issue", action, {
+        reviewCommentId: `${9_000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "b".repeat(64),
+        reviewedAt,
+        reviewCommentSyncedAt,
+      });
+    }
+    writeCommentSyncCursor(cursorPath, 100, "openclaw/openclaw");
+
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      }),
+    );
+    const selected = result.item_numbers.split(",").map(Number);
+
+    assert.deepEqual(selected.slice(0, 3), [5, 7, 6]);
+    assert.equal(selected.length, 40);
+    assert.equal(result.next_cursor, "137");
+    assert.equal(result.wrapped, "false");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("post-sync guarded action changes return to the durable comment queue", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  try {
+    for (const [number, actionTaken, applyCheckedAt] of [
+      [10, "skipped_protected_label", "2026-08-02T00:00:00Z"],
+      [20, "skipped_maintainer_authored", "2026-08-02T00:00:00Z"],
+      [30, "skipped_close_exempt_label", "2026-08-02T00:00:00Z"],
+      [40, "skipped_protected_label", "2026-08-01T00:30:00Z"],
+    ] as const) {
+      writeCommentSyncRecord(root, number, "pull_request", actionTaken, {
+        reviewCommentId: String(9_000 + number),
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/pull/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt: "2026-08-01T00:00:00Z",
+        reviewCommentSyncedAt: "2026-08-01T01:00:00Z",
+        applyCheckedAt,
+      });
+    }
+
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      }),
+    );
+
+    assert.equal(result.item_numbers, "10,20,30");
+    assert.equal(result.count, "3");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("invalid decisions never enqueue close reasons forbidden by their target repository", () => {
+  for (const { targetRepo, expected } of [
+    { targetRepo: "openclaw/openclaw", expected: "1,2,3" },
+    { targetRepo: "openclaw/clawhub", expected: "2,3" },
+    { targetRepo: "openclaw/clawsweeper", expected: "2,3" },
+    { targetRepo: "steipete/tool.v2_debug", expected: "3" },
+  ]) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+    const targetSlug = targetRepo.replace(/[^a-z0-9_.-]+/g, "-");
+    const cursorPath = path.join(root, `results/comment-sync-cursors/${targetSlug}.json`);
+    try {
+      writeCommentSyncRecord(root, 1, "issue", "skipped_invalid_decision", {
+        targetRepo,
+        decision: "close",
+        closeReason: "duplicate_or_superseded",
+      });
+      writeCommentSyncRecord(root, 2, "issue", "skipped_invalid_decision", {
+        targetRepo,
+        decision: "close",
+        closeReason: "implemented_on_main",
+      });
+      writeCommentSyncRecord(root, 3, "issue", "skipped_invalid_decision", {
+        targetRepo,
+        decision: "keep_open",
+      });
+
+      const result = withCwd(root, () =>
+        commentSyncBatchOutput({ targetRepo, applyKind: "all", batchSize: 40, cursorPath }),
+      );
+      assert.equal(result.item_numbers, expected, targetRepo);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("unverified checkouts and timestamp-less comments never monopolize urgent sync", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const syncedAt = new Date().toISOString();
+  try {
+    for (let number = 1; number <= 45; number += 1) {
+      writeCommentSyncRecord(root, number, "pull_request", "kept_open", {
+        reviewCommentId: `${9_000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/pull/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt: "2025-01-01T00:00:00Z",
+        reviewCommentSyncedAt: syncedAt,
+      });
+    }
+    for (let number = 1_001; number <= 1_040; number += 1) {
+      writeCommentSyncRecord(root, number, "issue", "kept_open", {
+        localCheckoutAccess: "unverified",
+        reviewedAt: syncedAt,
+      });
+    }
+    for (let number = 2_001; number <= 2_040; number += 1) {
+      writeCommentSyncRecord(root, number, "issue", "kept_open", {
+        reviewCommentId: `${9_000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${9_000 + number}`,
+        reviewCommentHash: "b".repeat(64),
+        reviewedAt: "2025-01-01T00:00:00Z",
+      });
+    }
+
+    const options = {
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      batchSize: 40,
+      cursorPath,
+    };
+    const first = withCwd(root, () => commentSyncBatchOutput(options));
+    assert.equal(first.item_numbers, Array.from({ length: 40 }, (_, index) => index + 1).join(","));
+    assert.equal(first.next_cursor, "40");
+
+    writeCommentSyncCursor(cursorPath, Number(first.next_cursor), options.targetRepo);
+    const second = withCwd(root, () => commentSyncBatchOutput(options));
+    assert.equal(second.item_numbers.startsWith("41,42,43,44,45,"), true);
+    assert.equal(
+      second.item_numbers.split(",").some((number) => Number(number) > 2_000),
+      false,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("all-item sync prioritizes a newly reviewed record ahead of fresh PR maintenance", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const fresh = new Date(Date.now() - 60_000).toISOString();
+  try {
+    for (let number = 1; number <= 45; number += 1) {
+      writeCommentSyncRecord(root, number, "pull_request", "kept_open", {
+        reviewCommentId: `${9000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/pull/${number}#issuecomment-${9000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt: fresh,
+        reviewCommentSyncedAt: fresh,
+      });
+    }
+    writeCommentSyncRecord(root, 9999, "issue", "kept_open");
+
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      }),
+    );
+    const selected = result.item_numbers.split(",").map(Number);
+
+    assert.equal(selected.length, 40);
+    assert.equal(selected[0], 9999);
+    assert.equal(selected.includes(40), false);
+    assert.equal(result.wrapped, "false");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wrapped urgent comment-sync batches reserve one advancing cursor record", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  try {
+    for (let number = 1; number <= 41; number += 1) {
+      writeCommentSyncRecord(root, number, "issue", "kept_open", {
+        reviewedAt: new Date(Date.now() + number * 1_000).toISOString(),
+      });
+    }
+    writeCommentSyncCursor(cursorPath, 1_000, "openclaw/openclaw");
+    const options = {
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      batchSize: 40,
+      cursorPath,
+    };
+
+    const first = withCwd(root, () => commentSyncBatchOutput(options));
+    assert.equal(first.count, "40");
+    assert.equal(first.item_numbers.split(",").includes("1"), true);
+    assert.equal(first.next_cursor, "1");
+    assert.equal(first.wrapped, "true");
+
+    writeCommentSyncCursor(cursorPath, Number(first.next_cursor), options.targetRepo);
+    const second = withCwd(root, () => commentSyncBatchOutput(options));
+    assert.equal(second.item_numbers.split(",").includes("2"), true);
+    assert.equal(second.next_cursor, "41");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fresh proof retries cannot monopolize successive all-item cursor windows", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const syncedAt = new Date().toISOString();
+  try {
+    for (let number = 1; number <= 45; number += 1) {
+      writeCommentSyncRecord(root, number, "pull_request", "skipped_pr_close_coverage_proof", {
+        reviewCommentId: `${9000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/pull/${number}#issuecomment-${9000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt: new Date(Date.now() - (46 - number) * 1000).toISOString(),
+        reviewCommentSyncedAt: syncedAt,
+      });
+    }
+    writeCommentSyncRecord(root, 999, "pull_request", "kept_open", {
+      reviewCommentId: "9999",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/999#issuecomment-9999",
+      reviewCommentHash: "b".repeat(64),
+      reviewedAt: syncedAt,
+      reviewCommentSyncedAt: syncedAt,
+    });
+    const options = {
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      batchSize: 40,
+      cursorPath,
+    };
+    const first = withCwd(root, () => commentSyncBatchOutput(options));
+    writeCommentSyncCursor(cursorPath, Number(first.next_cursor), options.targetRepo);
+    const second = withCwd(root, () => commentSyncBatchOutput(options));
+
+    assert.equal(first.item_numbers.split(",").length, 40);
+    assert.equal(second.item_numbers, "41,42,43,44,45,999");
+    assert.equal(second.next_cursor, "999");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("synchronized stale-sync retries cannot pin the urgent cursor", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const syncedAt = new Date().toISOString();
+  try {
+    for (const [number, action] of [
+      [10, "retry_stale_canonical_comment_sync"],
+      [20, "kept_open"],
+      [30, "kept_open"],
+    ] as const) {
+      writeCommentSyncRecord(root, number, "pull_request", action, {
+        reviewCommentId: `${9000 + number}`,
+        reviewCommentUrl: `https://github.com/openclaw/openclaw/pull/${number}#issuecomment-${9000 + number}`,
+        reviewCommentHash: "a".repeat(64),
+        reviewedAt:
+          number === 10 ? new Date(Date.now() + 1000).toISOString() : "2026-01-01T00:00:00.000Z",
+        reviewCommentSyncedAt: syncedAt,
+      });
+    }
+    const options = {
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      batchSize: 1,
+      cursorPath,
+    };
+    for (const expectedNumber of [10, 20, 30]) {
+      const result = withCwd(root, () => commentSyncBatchOutput(options));
+      assert.equal(result.item_numbers, String(expectedNumber));
+      writeCommentSyncCursor(cursorPath, Number(result.next_cursor), options.targetRepo);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("manual all-item cursors still include recently synchronized issues", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorDir = path.join(root, "results/comment-sync-cursors");
+  const syncedAt = new Date().toISOString();
+  try {
+    writeCommentSyncRecord(root, 5, "issue", "kept_open", {
+      reviewCommentId: "9005",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/issues/5#issuecomment-9005",
+      reviewCommentHash: "a".repeat(64),
+      reviewedAt: "2026-01-01T00:00:00.000Z",
+      reviewCommentSyncedAt: syncedAt,
+    });
+    const options = {
+      targetRepo: "openclaw/openclaw",
+      applyKind: "all",
+      batchSize: 40,
+    };
+    const automatic = withCwd(root, () =>
+      commentSyncBatchOutput({
+        ...options,
+        cursorPath: path.join(cursorDir, "openclaw-openclaw.json"),
+      }),
+    );
+    const manual = withCwd(root, () =>
+      commentSyncBatchOutput({
+        ...options,
+        cursorPath: path.join(cursorDir, "openclaw-openclaw-all-age0.json"),
+      }),
+    );
+
+    assert.equal(automatic.count, "0");
+    assert.equal(manual.item_numbers, "5");
+    assert.equal(manual.count, "1");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("comment synchronization preserves canonical dotted and underscored repository slugs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const targetRepo = "steipete/tool.v2_debug";
+  const targetSlug = "steipete-tool.v2_debug";
+  const cursorPath = path.join(root, `results/comment-sync-cursors/${targetSlug}.json`);
+  const reportPath = path.join(root, `records/${targetSlug}/items/${targetSlug}-41.md`);
+  try {
+    write(
+      reportPath,
+      [
+        "---",
+        `repository: ${targetRepo}`,
+        "type: issue",
+        "review_status: complete",
+        "item_snapshot_hash: abc123",
+        "action_taken: kept_open",
+        "---",
+        "",
+      ].join("\n"),
+    );
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({ targetRepo, applyKind: "all", batchSize: 40, cursorPath }),
+    );
+
+    assert.equal(result.item_numbers, "41");
+    assert.equal(result.next_cursor, "41");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fresh review priority crosses an existing maintenance cursor", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  try {
+    writeCommentSyncRecord(root, 5, "issue", "kept_open", {
+      reviewedAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    writeCommentSyncRecord(root, 30, "pull_request", "kept_open", {
+      reviewedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    writeCommentSyncCursor(cursorPath, 20, "openclaw/openclaw");
+
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 1,
+        cursorPath,
+      }),
+    );
+
+    assert.equal(result.item_numbers, "5");
+    assert.equal(result.count, "1");
+    assert.equal(result.next_cursor, "20");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 function withCwd(cwd, callback) {
   const previous = process.cwd();
   process.chdir(cwd);
@@ -2757,11 +3316,14 @@ function writeProposedRecord(
 }
 
 function writeCommentSyncRecord(root, number, type, actionTaken, options = {}) {
+  const targetRepo = options.targetRepo ?? "openclaw/openclaw";
+  const targetSlug = targetRepo.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-");
   const lines = [
     "---",
-    "repository: openclaw/openclaw",
+    `repository: ${targetRepo}`,
     `type: ${type}`,
     "review_status: complete",
+    `local_checkout_access: ${options.localCheckoutAccess ?? "verified"}`,
     "item_snapshot_hash: abc123",
     `action_taken: ${actionTaken}`,
   ];
@@ -2769,9 +3331,18 @@ function writeCommentSyncRecord(root, number, type, actionTaken, options = {}) {
   if (options.closeReason) lines.push(`close_reason: ${options.closeReason}`);
   if (options.reviewCommentId) lines.push(`review_comment_id: ${options.reviewCommentId}`);
   if (options.reviewCommentUrl) lines.push(`review_comment_url: ${options.reviewCommentUrl}`);
+  if (options.reviewCommentHash) lines.push(`review_comment_sha256: ${options.reviewCommentHash}`);
+  if (options.pullHeadSha) lines.push(`pull_head_sha: ${options.pullHeadSha}`);
+  if (options.currentPullHeadSha)
+    lines.push(`current_pull_head_sha: ${options.currentPullHeadSha}`);
+  if (options.lastFullReviewAt) lines.push(`last_full_review_at: ${options.lastFullReviewAt}`);
+  if (options.reviewedAt) lines.push(`reviewed_at: ${options.reviewedAt}`);
+  if (options.applyCheckedAt) lines.push(`apply_checked_at: ${options.applyCheckedAt}`);
+  if (options.reviewCommentSyncedAt)
+    lines.push(`review_comment_synced_at: ${options.reviewCommentSyncedAt}`);
   lines.push("---", "");
   write(
-    path.join(root, `records/openclaw-openclaw/items/openclaw-openclaw-${number}.md`),
+    path.join(root, `records/${targetSlug}/items/${targetSlug}-${number}.md`),
     lines.join("\n"),
   );
 }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -1834,7 +1835,44 @@ test("apply workflow isolates proof Codex and keeps mutation free of Git recover
   assert.match(applyJob, /queue: max/);
 });
 
-test("apply workflow durably publishes each reconciliation before no-op exits", () => {
+test("comment-only proof preparation never scans the full target repository", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: Array<{ name?: string; if?: string; run?: string }> }>;
+  };
+  const steps = workflow.jobs["apply-proof"]!.steps;
+  const reconcile = steps.find((step) => step.name === "Reconcile read-only proof inputs");
+  const select = steps.find((step) => step.name === "Select bounded coverage proof work");
+  assert.ok(reconcile?.if, "proof reconciliation must explicitly exclude comment-only runs");
+  assert.ok(select?.run, "proof selection must recognize scheduled comment-only maintenance");
+
+  const expression = reconcile.if.replace(/^\$\{\{\s*|\s*\}\}$/g, "");
+  const shouldReconcile = new Function("github", `return (${expression});`) as (
+    github: Record<string, unknown>,
+  ) => boolean;
+  const dispatch = (syncCommentsOnly: string, itemNumbers = "") => ({
+    event_name: "workflow_dispatch",
+    event: {
+      schedule: "",
+      inputs: { apply_sync_comments_only: syncCommentsOnly, apply_item_numbers: itemNumbers },
+    },
+  });
+  const schedule = (cron: string) => ({
+    event_name: "schedule",
+    event: { schedule: cron, inputs: {} },
+  });
+
+  assert.equal(shouldReconcile(dispatch("true", "__cursor__")), false);
+  assert.equal(shouldReconcile(dispatch("true", "10,20")), false);
+  assert.equal(shouldReconcile(dispatch("false", "__cursor__")), false);
+  assert.equal(shouldReconcile(schedule("6,21,36,51 * * * *")), false);
+  assert.equal(shouldReconcile(dispatch("false")), true);
+  assert.equal(shouldReconcile(schedule("3 * * * *")), true);
+  assert.match(select.run, /github\.event\.schedule \|\| ''/);
+  assert.match(select.run, /6,21,36,51 \* \* \* \*/);
+  assert.match(select.run, /sync_comments_only="true"/);
+});
+
+test("apply workflow scopes cursor reconciliation and publishes close reconciliation before idle", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const applyJob = workflow.slice(workflow.indexOf("\n  apply-existing:"));
   const preselectReconcile = applyJob.indexOf('persist_reconciliation "${reconcile_args[@]}"');
@@ -1853,7 +1891,7 @@ test("apply workflow durably publishes each reconciliation before no-op exits", 
   assert.ok(preselectReconcile < applyStart);
   assert.ok(policyNoop > preselectReconcile);
   assert.ok(applyReconcile > policyNoop);
-  assert.ok(commentIdle > applyReconcile);
+  assert.ok(commentIdle < applyReconcile);
   assert.ok(closeIdle > applyReconcile);
 });
 
@@ -2568,7 +2606,94 @@ test("scheduled comment sync broadens only its own maintenance filters", () => {
   );
 
   assert.match(output, /^manual=issue\|9$/m);
-  assert.match(output, /^scheduled=pull_request\|0$/m);
+  assert.match(output, /^scheduled=all\|0$/m);
+});
+
+test("custom all-item sync never overwrites the shared automatic cursor", () => {
+  const output = execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "source scripts/apply-workflow-helpers.sh",
+        "comment_sync_processed_limit=40",
+        "sync_comments_only=true",
+        "sync_open_pr_batch=true",
+        "scheduled_comment_sync=false",
+        "target_slug=openclaw-openclaw",
+        "apply_kind=all",
+        "comment_sync_min_age_days=0",
+        "item_numbers=",
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "sync_batch_size=1",
+        "min_age_days=30",
+        "prepare_comment_sync_batch",
+        'printf "custom=%s|%s\\n" "$cursor_path" "$sync_batch_size"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "sync_batch_size=40",
+        "min_age_days=0",
+        "min_age_minutes=30",
+        "prepare_comment_sync_batch",
+        'printf "minute=%s\\n" "$cursor_path"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "min_age_minutes=15",
+        "prepare_comment_sync_batch",
+        'printf "minute-fifteen=%s\\n" "$cursor_path"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "min_age_minutes=",
+        "min_age_days=30",
+        "prepare_comment_sync_batch",
+        'printf "day-thirty=%s\\n" "$cursor_path"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "min_age_days=60",
+        "prepare_comment_sync_batch",
+        'printf "day-sixty=%s\\n" "$cursor_path"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "min_age_days=0",
+        "apply_close_reasons=duplicate_or_superseded",
+        "stale_min_age_days=1",
+        "close_delay_ms=500",
+        "checkpoint_size=10",
+        "limit=40",
+        "prepare_comment_sync_batch",
+        'printf "policy=%s\\n" "$cursor_path"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "apply_close_reasons=all",
+        "stale_min_age_days=60",
+        "close_delay_ms=2000",
+        "checkpoint_size=40",
+        "apply_kind=pull_request",
+        "prepare_comment_sync_batch",
+        'printf "pull-request=%s\\n" "$cursor_path"',
+        "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+        "apply_kind=all",
+        "prepare_comment_sync_batch",
+        'printf "automatic=%s\\n" "$cursor_path"',
+      ].join("\n"),
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.match(
+    output,
+    /^custom=results\/comment-sync-cursors\/openclaw-openclaw-all-age0-policy-[a-f\d]{16}\.json\|1$/m,
+  );
+  assert.match(
+    output,
+    /^minute=results\/comment-sync-cursors\/openclaw-openclaw-all-age0-policy-[a-f\d]{16}\.json$/m,
+  );
+  const policyPath = (label: string) => output.match(new RegExp(`^${label}=(.+)$`, "m"))?.[1];
+  assert.notEqual(policyPath("minute"), policyPath("minute-fifteen"));
+  assert.notEqual(policyPath("day-thirty"), policyPath("day-sixty"));
+  assert.match(
+    output,
+    /^policy=results\/comment-sync-cursors\/openclaw-openclaw-all-age0-policy-[a-f\d]{16}\.json$/m,
+  );
+  assert.match(
+    output,
+    /^pull-request=results\/comment-sync-cursors\/openclaw-openclaw-pull_request-age0\.json$/m,
+  );
+  assert.match(output, /^automatic=results\/comment-sync-cursors\/openclaw-openclaw\.json$/m);
 });
 
 test("cursor synchronization replaces a zero-item operator limit with its bounded default", () => {
@@ -2591,6 +2716,386 @@ test("cursor synchronization replaces a zero-item operator limit with its bounde
   );
 
   assert.match(output, /^batch=40$/m);
+});
+
+test("scheduled all-item comment sync remains bounded to one cursor window", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-openclaw", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 41; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-openclaw-${number}.md`),
+      `---\nrepository: openclaw/openclaw\ntype: issue\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=true",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/openclaw"',
+          "target_slug=openclaw-openclaw",
+          "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+          "apply_kind=pull_request",
+          "comment_sync_min_age_days=7",
+          "item_numbers=",
+          "normalize_comment_sync_mode",
+          "prepare_comment_sync_batch",
+          'batch="$(pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path")"',
+          'item_numbers=$(awk -F= \'$1 == "item_numbers" { print $2 }\' <<< "$batch")',
+          'printf "selected=%s\\n" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\nkind=%s\\ncursor=%s\\n" "$continue_apply" "$apply_kind" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=1,2,3,/m);
+    assert.match(output, /^continue=false$/m);
+    assert.match(output, /^kind=all$/m);
+    assert.match(output, /^cursor=40$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("background and scheduled maintenance advance the same immediate all-item cursor", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-openclaw", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 41; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-openclaw-${number}.md`),
+      `---\nrepository: openclaw/openclaw\ntype: issue\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/openclaw"',
+          "target_slug=openclaw-openclaw",
+          "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+          "apply_kind=all",
+          "comment_sync_min_age_days=0",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'batch="$(pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path")"',
+          'item_numbers=$(awk -F= \'$1 == "item_numbers" { print $2 }\' <<< "$batch")',
+          'next_cursor=$(awk -F= \'$1 == "next_cursor" { print $2 }\' <<< "$batch")',
+          'printf "background-cursor=%s\\nbackground-selected=%s\\n" "$cursor_path" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "background-continue=%s\\n" "$continue_apply"',
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=true",
+          "continue_apply=false",
+          "item_numbers=",
+          "normalize_comment_sync_mode",
+          "prepare_comment_sync_batch",
+          'batch="$(pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path")"',
+          'item_numbers=$(awk -F= \'$1 == "item_numbers" { print $2 }\' <<< "$batch")',
+          'next_cursor=$(awk -F= \'$1 == "next_cursor" { print $2 }\' <<< "$batch")',
+          'printf "scheduled-cursor=%s\\nscheduled-selected=%s\\nscheduled-age=%s\\n" "$cursor_path" "$item_numbers" "$comment_sync_min_age_days"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "scheduled-continue=%s\\nfinal-cursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(
+      output,
+      /^background-cursor=results\/comment-sync-cursors\/openclaw-openclaw\.json$/m,
+    );
+    assert.match(output, /^background-selected=1,2,3,/m);
+    assert.match(output, /^background-continue=false$/m);
+    assert.match(
+      output,
+      /^scheduled-cursor=results\/comment-sync-cursors\/openclaw-openclaw\.json$/m,
+    );
+    assert.match(output, /^scheduled-selected=41$/m);
+    assert.match(output, /^scheduled-age=0$/m);
+    assert.match(output, /^scheduled-continue=false$/m);
+    assert.match(output, /^final-cursor=41$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("uncursored default comment sync preserves the same cross-repository continuation cursor", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    for (const targetRepo of ["openclaw/openclaw", "openclaw/clawhub"]) {
+      const targetSlug = targetRepo.replace("/", "-");
+      const records = join(root, "records", targetSlug, "items");
+      mkdirSync(records, { recursive: true });
+      for (let number = 1; number <= 41; number += 1) {
+        writeFileSync(
+          join(records, `${targetSlug}-${number}.md`),
+          `---\nrepository: ${targetRepo}\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+        );
+      }
+    }
+
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "for TARGET_REPO in openclaw/openclaw openclaw/clawhub; do",
+          '  target_slug="$(printf "%s" "$TARGET_REPO" | tr / -)"',
+          "  comment_sync_processed_limit=40",
+          "  sync_batch_size=40",
+          "  sync_comments_only=true",
+          "  sync_open_pr_batch=false",
+          "  scheduled_comment_sync=false",
+          "  continue_apply=false",
+          "  apply_kind=all",
+          "  comment_sync_min_age_days=0",
+          "  min_age_days=0",
+          "  min_age_minutes=",
+          "  apply_close_reasons=all",
+          "  stale_min_age_days=60",
+          "  close_delay_ms=2000",
+          "  checkpoint_size=80",
+          '  if [ "$checkpoint_size" -gt 40 ]; then checkpoint_size=40; fi',
+          "  limit=40",
+          "  item_numbers=",
+          '  cursor_path="results/comment-sync-cursors/${target_slug}.json"',
+          "  prepare_comment_sync_batch",
+          '  printf "%s initial=%s\\n" "$TARGET_REPO" "$cursor_path"',
+          '  jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "  printf '[]' > report.json",
+          "  complete_comment_sync_batch report.json trace.json",
+          '  printf "%s continue=%s cursor=%s\\n" "$TARGET_REPO" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
+          '  if [ "$continue_apply" = "true" ]; then',
+          "    item_numbers=",
+          "    sync_open_pr_batch=true",
+          '    cursor_path="results/comment-sync-cursors/${target_slug}.json"',
+          "    prepare_comment_sync_batch",
+          '    batch="$(pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path")"',
+          '    printf "%s resumed=%s initial-cursor=%s next=%s\\n" "$TARGET_REPO" "$cursor_path" "$comment_sync_initial_cursor" "$(awk -F= \'$1 == "item_numbers" { print $2 }\' <<< "$batch")"',
+          "  fi",
+          "done",
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(
+      output,
+      /^openclaw\/openclaw initial=results\/comment-sync-cursors\/openclaw-openclaw\.json$/m,
+    );
+    assert.match(output, /^openclaw\/openclaw continue=false cursor=40$/m);
+    assert.match(
+      output,
+      /^openclaw\/clawhub initial=results\/comment-sync-cursors\/openclaw-clawhub\.json$/m,
+    );
+    assert.match(output, /^openclaw\/clawhub continue=true cursor=40$/m);
+    assert.match(
+      output,
+      /^openclaw\/clawhub resumed=results\/comment-sync-cursors\/openclaw-clawhub\.json initial-cursor=40 next=41$/m,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("custom mutation-policy comment sync retains its own cursor and continuation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-openclaw", "items");
+  mkdirSync(records, { recursive: true });
+  for (let number = 1; number <= 41; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-openclaw-${number}.md`),
+      `---\nrepository: openclaw/openclaw\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "mkdir -p .artifacts",
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/openclaw"',
+          "target_slug=openclaw-openclaw",
+          "cursor_path=results/comment-sync-cursors/openclaw-openclaw.json",
+          "apply_kind=all",
+          "comment_sync_min_age_days=0",
+          "apply_close_reasons=duplicate_or_superseded",
+          "stale_min_age_days=1",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'batch="$(pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path")"',
+          'item_numbers=$(awk -F= \'$1 == "item_numbers" { print $2 }\' <<< "$batch")',
+          'next_cursor=$(awk -F= \'$1 == "next_cursor" { print $2 }\' <<< "$batch")',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "custom-cursor=%s\\ncontinue=%s\\nnext=%s\\npersisted=%s\\n" "$cursor_path" "$continue_apply" "$item_numbers" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(
+      output,
+      /^custom-cursor=results\/comment-sync-cursors\/openclaw-openclaw-all-age0-policy-[a-f\d]{16}\.json$/m,
+    );
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^next=__cursor__$/m);
+    assert.match(output, /^persisted=40$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("urgent records do not falsely wrap a customized comment-sync cursor", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  const cursors = join(root, "results", "comment-sync-cursors");
+  const now = new Date().toISOString();
+  mkdirSync(records, { recursive: true });
+  mkdirSync(cursors, { recursive: true });
+  writeFileSync(join(cursors, "openclaw-clawhub.json"), '{"next_after_number":20}\n');
+  writeFileSync(
+    join(records, "5.md"),
+    `---\nrepository: openclaw/clawhub\ntype: issue\nreview_status: complete\nlocal_checkout_access: verified\nitem_snapshot_hash: abc123\naction_taken: kept_open\nreviewed_at: ${now}\n---\n`,
+  );
+  for (let number = 21; number <= 61; number += 1) {
+    writeFileSync(
+      join(records, `${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\nreviewed_at: 2025-01-01T00:00:00Z\nreview_comment_id: 9000\nreview_comment_url: https://github.com/openclaw/clawhub/pull/${number}#issuecomment-9000\nreview_comment_sha256: ${"a".repeat(64)}\nreview_comment_synced_at: ${now}\n---\n`,
+    );
+  }
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "mkdir -p .artifacts",
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          'TARGET_REPO="openclaw/clawhub"',
+          "target_slug=openclaw-clawhub",
+          "cursor_path=results/comment-sync-cursors/openclaw-clawhub.json",
+          "apply_kind=all",
+          "comment_sync_min_age_days=0",
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'batch="$(pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path")"',
+          'item_numbers=$(awk -F= \'$1 == "item_numbers" { print $2 }\' <<< "$batch")',
+          'next_cursor=$(awk -F= \'$1 == "next_cursor" { print $2 }\' <<< "$batch")',
+          'printf "selected=%s\\n" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\nnext=%s\\npersisted=%s\\n" "$continue_apply" "$item_numbers" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=5,21,22,/m);
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^next=__cursor__$/m);
+    assert.match(output, /^persisted=59$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("uncursored synchronization continues repositories without scheduled maintenance", () => {
@@ -2723,12 +3228,7 @@ test("unscheduled cursor synchronization continues lower-numbered records after 
       `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
     );
   }
-  const scopedCursor = join(
-    root,
-    "results",
-    "comment-sync-cursors",
-    "openclaw-clawhub-all-age0.json",
-  );
+  const scopedCursor = join(root, "results", "comment-sync-cursors", "openclaw-clawhub.json");
   mkdirSync(dirname(scopedCursor), { recursive: true });
   writeFileSync(scopedCursor, '{"next_after_number":20}\n');
 
@@ -2791,11 +3291,15 @@ test("unscheduled wrapped synchronization drains every bounded window and then s
       `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
     );
   }
+  const policyFingerprint = createHash("sha256")
+    .update(`${["all", "60", "2000", "40", "40", "2", "0", ""].join("\n")}\n`)
+    .digest("hex")
+    .slice(0, 16);
   const scopedCursor = join(
     root,
     "results",
     "comment-sync-cursors",
-    "openclaw-clawhub-all-age0.json",
+    `openclaw-clawhub-all-age0-policy-${policyFingerprint}.json`,
   );
   mkdirSync(dirname(scopedCursor), { recursive: true });
   writeFileSync(scopedCursor, '{"next_after_number":5}\n');
@@ -2833,6 +3337,7 @@ test("unscheduled wrapped synchronization drains every bounded window and then s
           "  prepare_comment_sync_batch",
           '  pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path" > next.env',
           "  item_numbers=$(awk -F= '$1 == \"item_numbers\" { print $2 }' next.env)",
+          "  next_cursor=$(awk -F= '$1 == \"next_cursor\" { print $2 }' next.env)",
           "  trim_comment_sync_cycle_batch",
           "done",
           'printf "continue=%s\\ncursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
@@ -2857,6 +3362,110 @@ test("unscheduled wrapped synchronization drains every bounded window and then s
     assert.doesNotMatch(output, /^window=5,6$/m);
     assert.match(output, /^continue=false$/m);
     assert.match(output, /^cursor=5$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("wrapped cursor synchronization continues past newer out-of-cycle urgent records", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const records = join(root, "records", "openclaw-clawhub", "items");
+  const cursorPath = join(root, "results", "comment-sync-cursors", "openclaw-clawhub.json");
+  mkdirSync(records, { recursive: true });
+  mkdirSync(dirname(cursorPath), { recursive: true });
+  mkdirSync(join(root, ".artifacts"), { recursive: true });
+  const syncedAt = "2026-08-01T00:00:00Z";
+  for (let number = 41; number <= 100; number += 1) {
+    writeFileSync(
+      join(records, `openclaw-clawhub-${number}.md`),
+      [
+        "---",
+        "repository: openclaw/clawhub",
+        "type: pull_request",
+        "review_status: complete",
+        "local_checkout_access: verified",
+        "item_snapshot_hash: abc123",
+        "action_taken: kept_open",
+        `review_comment_id: ${9_000 + number}`,
+        `review_comment_url: https://github.com/openclaw/clawhub/pull/${number}#issuecomment-${9_000 + number}`,
+        `review_comment_sha256: ${"a".repeat(64)}`,
+        `reviewed_at: ${syncedAt}`,
+        `review_comment_synced_at: ${syncedAt}`,
+        "---",
+        "",
+      ].join("\n"),
+    );
+  }
+  writeFileSync(
+    join(records, "openclaw-clawhub-150.md"),
+    [
+      "---",
+      "repository: openclaw/clawhub",
+      "type: pull_request",
+      "review_status: complete",
+      "local_checkout_access: verified",
+      "item_snapshot_hash: abc123",
+      "action_taken: kept_open",
+      "reviewed_at: 2026-08-02T00:00:00Z",
+      "---",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    cursorPath,
+    JSON.stringify({ next_after_number: 40, cycle_start_after_number: 100, cycle_wrapped: true }),
+  );
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "comment_sync_processed_limit=40",
+          "sync_batch_size=40",
+          "sync_comments_only=true",
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=false",
+          "continue_apply=false",
+          "TARGET_REPO=openclaw/clawhub",
+          "target_slug=openclaw-clawhub",
+          "apply_kind=all",
+          "comment_sync_min_age_days=0",
+          'cursor_path="$CURSOR_PATH"',
+          "item_numbers=",
+          "prepare_comment_sync_batch",
+          'pnpm run --silent workflow -- comment-sync-batch --target-repo "$TARGET_REPO" --apply-kind "$apply_kind" --batch-size "$sync_batch_size" --cursor-path "$cursor_path" > batch.env',
+          "item_numbers=$(awk -F= '$1 == \"item_numbers\" { print $2 }' batch.env)",
+          "next_cursor=$(awk -F= '$1 == \"next_cursor\" { print $2 }' batch.env)",
+          "trim_comment_sync_cycle_batch",
+          'printf "selected=%s\\n" "$item_numbers"',
+          'jq -n --arg selected "$item_numbers" \'{schema_version:1,examined_item_numbers:($selected|split(",")|map(tonumber))}\' > trace.json',
+          "printf '[]' > report.json",
+          "complete_comment_sync_batch report.json trace.json",
+          'printf "continue=%s\\ncursor=%s\\n" "$continue_apply" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          CURSOR_PATH: cursorPath,
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^selected=41,42,/m);
+    assert.match(output, /^selected=.*78,79$/m);
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^cursor=79$/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3067,7 +3676,7 @@ test("uncursored comment synchronization selects and continues the full eligible
     assert.match(output, /^resumed=.*1001,1002$/m);
     assert.doesNotMatch(output, /^resumed=.*1003/m);
     assert.doesNotMatch(output, /^resumed=.*1004/m);
-    assert.match(output, /results\/comment-sync-cursors\/openclaw-openclaw-all-age0\.json/);
+    assert.match(output, /results\/comment-sync-cursors\/openclaw-openclaw\.json/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3164,6 +3773,163 @@ test("comment synchronization checkpoints only completed records after a runtime
     assert.match(output, /^missing_prefix_cursor=20$/m);
     assert.doesNotMatch(output, /^missing_prefix_rejected$/m);
     assert.doesNotMatch(output, /^partial=30$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("comment synchronization advances past records archived during scoped reconciliation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const targetSlug = "openclaw-clawhub";
+  const recordsDir = join(root, "records", targetSlug);
+  const cursorPath = join(root, "results", "comment-sync-cursors", `${targetSlug}.json`);
+  const tracePath = join(root, "trace.json");
+  const reportPath = join(root, "report.json");
+  mkdirSync(join(recordsDir, "items"), { recursive: true });
+  mkdirSync(join(recordsDir, "closed"), { recursive: true });
+  mkdirSync(dirname(cursorPath), { recursive: true });
+  mkdirSync(join(root, ".artifacts"), { recursive: true });
+  writeFileSync(join(recordsDir, "closed", `${targetSlug}-10.md`), "closed\n");
+  for (const number of [20, 30]) {
+    writeFileSync(
+      join(recordsDir, "items", `${targetSlug}-${number}.md`),
+      `---\nrepository: openclaw/clawhub\ntype: pull_request\nreview_status: complete\nitem_snapshot_hash: abc123\naction_taken: kept_open\n---\n`,
+    );
+  }
+  writeFileSync(tracePath, JSON.stringify({ schema_version: 1, examined_item_numbers: [20] }));
+  writeFileSync(reportPath, JSON.stringify([{ number: 20, action: "review_comment_synced" }]));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          "TARGET_REPO=openclaw/clawhub",
+          "target_slug=openclaw-clawhub",
+          'cursor_path="$CURSOR_PATH"',
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=false",
+          "sync_batch_size=40",
+          "apply_kind=all",
+          "comment_sync_initial_cursor=0",
+          "continue_apply=false",
+          "item_numbers=10,20",
+          "next_cursor=20",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'printf "cursor=%s\\ncount=%s\\ncontinue=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count" "$continue_apply"',
+          "continue_apply=false",
+          "item_numbers=5,20",
+          "next_cursor=20",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'printf "unknown_count=%s\\nunknown_next=%s\\n" "$comment_sync_cursor_advance_count" "$next_cursor"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          CURSOR_PATH: cursorPath,
+          TRACE_PATH: tracePath,
+          REPORT_PATH: reportPath,
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+        },
+      },
+    );
+
+    assert.match(output, /^cursor=20$/m);
+    assert.match(output, /^count=2$/m);
+    assert.match(output, /^continue=true$/m);
+    assert.match(output, /^unknown_count=0$/m);
+    assert.match(output, /^unknown_next=$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("urgent synchronization never advances past unfinished lower-numbered records", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const cursorPath = join(root, "comment-sync-cursor.json");
+  const urgentTrace = join(root, "urgent-trace.json");
+  const partialTrace = join(root, "partial-trace.json");
+  const reorderedUrgentTrace = join(root, "reordered-urgent-trace.json");
+  const reorderedCompleteTrace = join(root, "reordered-complete-trace.json");
+  const reportPath = join(root, "report.json");
+  writeFileSync(cursorPath, JSON.stringify({ next_after_number: 100 }));
+  writeFileSync(urgentTrace, JSON.stringify({ schema_version: 1, examined_item_numbers: [1000] }));
+  writeFileSync(
+    partialTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [1000, 110] }),
+  );
+  writeFileSync(
+    reorderedUrgentTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [120] }),
+  );
+  writeFileSync(
+    reorderedCompleteTrace,
+    JSON.stringify({ schema_version: 1, examined_item_numbers: [120, 110] }),
+  );
+  writeFileSync(reportPath, JSON.stringify([{ number: 1000, action: "review_comment_synced" }]));
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          "source scripts/apply-workflow-helpers.sh",
+          "TARGET_REPO=openclaw/openclaw",
+          'cursor_path="$CURSOR_PATH"',
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=true",
+          "comment_sync_initial_cursor=100",
+          "item_numbers=1000,110,120",
+          "next_cursor=120",
+          'complete_comment_sync_batch "$REPORT_PATH" "$URGENT_TRACE"',
+          'printf "urgent-only=%s\\n" "$(jq -r .next_after_number "$cursor_path")"',
+          "item_numbers=1000,110,120",
+          "next_cursor=120",
+          'complete_comment_sync_batch "$REPORT_PATH" "$PARTIAL_TRACE"',
+          'printf "urgent-and-first=%s\\n" "$(jq -r .next_after_number "$cursor_path")"',
+          'pnpm run workflow -- write-comment-sync-cursor --cursor-path "$cursor_path" --next-cursor 100 --target-repo "$TARGET_REPO"',
+          "item_numbers=120,110",
+          "next_cursor=120",
+          'complete_comment_sync_batch "$REPORT_PATH" "$REORDERED_URGENT_TRACE"',
+          'printf "reordered-urgent-only=%s\\n" "$(jq -r .next_after_number "$cursor_path")"',
+          "item_numbers=120,110",
+          "next_cursor=120",
+          'complete_comment_sync_batch "$REPORT_PATH" "$REORDERED_COMPLETE_TRACE"',
+          'printf "reordered-complete=%s\\n" "$(jq -r .next_after_number "$cursor_path")"',
+        ].join("\n"),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+          CURSOR_PATH: cursorPath,
+          REPORT_PATH: reportPath,
+          URGENT_TRACE: urgentTrace,
+          PARTIAL_TRACE: partialTrace,
+          REORDERED_URGENT_TRACE: reorderedUrgentTrace,
+          REORDERED_COMPLETE_TRACE: reorderedCompleteTrace,
+        },
+      },
+    );
+
+    assert.match(output, /^urgent-only=100$/m);
+    assert.match(output, /^urgent-and-first=110$/m);
+    assert.match(output, /^reordered-urgent-only=100$/m);
+    assert.match(output, /^reordered-complete=120$/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3878,7 +4644,7 @@ test("sweep workflow publishes target-scoped state paths", () => {
   assert.doesNotMatch(workflow, /--path results\/sweep-status\s*\\/);
 });
 
-test("sweep workflow schedules cursor-based PR comment sync batches", () => {
+test("sweep workflow coalesces durable issue and PR comment sync batches", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const applyHelper = readText("scripts/apply-workflow-helpers.sh");
 
@@ -3886,7 +4652,7 @@ test("sweep workflow schedules cursor-based PR comment sync batches", () => {
   assert.doesNotMatch(workflow, /apply_sync_open_pr_batch:/);
   assert.match(
     workflow,
-    /sync_batch_size="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.apply_limit \|\| '25' \}\}"/,
+    /sync_batch_size="\$\{\{ github\.event_name == 'workflow_dispatch' && github\.event\.inputs\.apply_limit \|\| '40' \}\}"/,
   );
   assert.match(workflow, /\$item_numbers" = "__cursor__"/);
   assert.match(workflow, /comment-sync-batch/);
@@ -3894,12 +4660,50 @@ test("sweep workflow schedules cursor-based PR comment sync batches", () => {
   assert.match(applyHelper, /write-comment-sync-cursor/);
   assert.match(workflow, /results\/comment-sync-cursors\/\$\{target_slug\}\.json/);
   assert.match(workflow, /normalize_comment_sync_mode/);
-  assert.match(applyHelper, /sync_open_pr_batch:-false.*[\s\S]*?apply_kind="pull_request"/);
+  const checkpointCap = workflow.indexOf('if [ "$checkpoint_size" -gt 40 ]; then');
+  assert.ok(checkpointCap >= 0);
+  assert.ok(checkpointCap < workflow.indexOf("          prepare_comment_sync_batch"));
+  assert.match(applyHelper, /sync_open_pr_batch:-false.*[\s\S]*?apply_kind="all"/);
   assert.match(workflow, /APPLY_SYNC_OPEN_PR_BATCH/);
   assert.match(workflow, /github\.event\.schedule == '6,21,36,51 \* \* \* \*'/);
   assert.match(
     applyHelper,
-    /if \[ "\$\{scheduled_comment_sync:-false\}" = "true" \]; then\s+apply_kind="pull_request"\s+comment_sync_min_age_days=0\s+fi/,
+    /if \[ "\$\{scheduled_comment_sync:-false\}" = "true" \]; then\s+apply_kind="all"\s+comment_sync_min_age_days=0\s+fi/,
+  );
+  const backgroundSyncStart = workflow.indexOf("- name: Dispatch background review comment sync");
+  const selectedSyncStart = workflow.indexOf("- name: Sync selected review comments");
+  const backgroundSync = workflow.slice(backgroundSyncStart, selectedSyncStart);
+  const cursorPreselectStart = workflow.indexOf("- name: Reconcile before apply preselect");
+  const cursorApplyStart = workflow.indexOf(
+    "- name: Apply unchanged proposed decisions with checkpoints",
+    cursorPreselectStart,
+  );
+  const cursorPreselect = workflow.slice(cursorPreselectStart, cursorApplyStart);
+  const cursorExecution = workflow.slice(cursorApplyStart);
+  assert.match(backgroundSync, /-f apply_item_numbers=__cursor__/);
+  assert.match(backgroundSync, /-f apply_kind=all/);
+  assert.match(backgroundSync, /-f apply_min_age_days=0/);
+  assert.match(backgroundSync, /-f apply_comment_sync_min_age_days=0/);
+  assert.doesNotMatch(backgroundSync, /-f apply_item_numbers="\$item_numbers"/);
+  assert.match(
+    cursorPreselect,
+    /if \[ "\$item_numbers" = "__cursor__" \]; then\s+if \[ "\$\{\{ github\.event\.inputs\.apply_sync_comments_only \|\| 'false' \}\}" = "true" \]; then\s+echo "Deferring reconciliation until the bounded comment-sync cursor is selected\."\s+exit 0/,
+  );
+  assert.match(
+    cursorPreselect,
+    /if \[ "\$\{\{ github\.event_name == 'schedule' && github\.event\.schedule == '6,21,36,51 \* \* \* \*' && 'true' \|\| 'false' \}\}" = "true" \]; then\s+echo "Deferring reconciliation until the bounded comment-sync cursor is selected\."\s+exit 0/,
+    "scheduled comment maintenance must never scan or reconcile the entire repository before selecting its batch",
+  );
+  assert.ok(
+    cursorExecution.indexOf('echo "Selected cursor-based comment sync batch: $item_numbers"') <
+      cursorExecution.indexOf('persist_reconciliation "${reconcile_args[@]}"'),
+    "cursor-based synchronization must select its exact items before reconciliation",
+  );
+  assert.match(cursorExecution, /prepare_apply_reconciliation_args/);
+  assert.match(
+    readText("scripts/apply-workflow-helpers.sh"),
+    /if \[ "\$\{sync_comments_only:-false\}" = "true" \] &&\s+\[ "\$\{sync_open_pr_batch:-false\}" = "true" \]; then\s+reconcile_args\+=\(--only-item-numbers\)/,
+    "cursor reconciliation must not archive or rewrite unrelated durable records",
   );
 });
 
@@ -4209,6 +5013,12 @@ test("target review queues coalesce background work without delaying exact plann
     /github\.event\.client_payload\.queue_lease_id \|\| github\.event\.client_payload\.item_number/,
   );
   assert.match(concurrencyBlock, /format\('clawsweeper-comment-sync-\{0\}', github\.run_id\)/);
+  assert.match(concurrencyBlock, /apply_item_numbers == '__cursor__'/);
+  assert.match(concurrencyBlock, /apply_kind == 'all'/);
+  assert.match(concurrencyBlock, /apply_comment_sync_min_age_days == '0'/);
+  assert.match(concurrencyBlock, /apply_limit == '40'/);
+  assert.match(concurrencyBlock, /apply_min_age_days == '0'/);
+  assert.match(concurrencyBlock, /apply_min_age_minutes == ''/);
   assert.match(concurrencyBlock, /format\('clawsweeper-apply-\{0\}', github\.run_id\)/);
   assert.match(
     concurrencyBlock,
@@ -4225,6 +5035,166 @@ test("target review queues coalesce background work without delaying exact plann
   assert.match(planHeader, /\|\| github\.run_id/);
   assert.doesNotMatch(planHeader, /queue: max/);
   assert.match(planHeader, /cancel-in-progress: false/);
+});
+
+test("durable cursor sync coalesces safely without discarding targeted batches", () => {
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    concurrency: { group: string };
+    jobs: Record<string, { concurrency: { group: string; "cancel-in-progress": boolean } }>;
+  };
+  const applyJob = workflow.jobs["apply-existing"]!;
+  const expression = workflow.concurrency.group.replace(/^\$\{\{\s*|\s*\}\}$/g, "");
+  const format = (template: string, ...values: string[]) =>
+    template.replace(/\{(\d+)\}/g, (_, index: string) => values[Number(index)] ?? "");
+  const evaluateExpression = new Function(
+    "github",
+    "format",
+    "vars",
+    `return (${expression});`,
+  ) as (
+    github: Record<string, unknown>,
+    formatter: typeof format,
+    variables: Record<string, string>,
+  ) => string;
+  const evaluate = (
+    github: Record<string, unknown>,
+    formatter: typeof format,
+    variables: Record<string, string> = { CLAWSWEEPER_AUTO_CLOSE_REASONS: "all" },
+  ) => evaluateExpression(github, formatter, variables);
+  const event = (
+    runId: number,
+    itemNumbers: string,
+    scheduled = false,
+    kind = "all",
+    minimumAge = "0",
+    applyLimit = "40",
+    minimumItemAge = "0",
+    minimumItemAgeMinutes = "",
+    closeReasons = "",
+    staleMinimumAge = "60",
+    closeDelay = "2000",
+    checkpointSize = "40",
+  ) => ({
+    event_name: scheduled ? "schedule" : "workflow_dispatch",
+    run_id: runId,
+    event: {
+      schedule: scheduled ? "6,21,36,51 * * * *" : "",
+      inputs: {
+        target_repo: "openclaw/openclaw",
+        apply_existing: scheduled ? "" : "true",
+        apply_sync_comments_only: scheduled ? "" : "true",
+        apply_item_numbers: itemNumbers,
+        apply_kind: kind,
+        apply_comment_sync_min_age_days: minimumAge,
+        apply_limit: applyLimit,
+        apply_min_age_days: minimumItemAge,
+        apply_min_age_minutes: minimumItemAgeMinutes,
+        apply_close_reasons: closeReasons,
+        apply_stale_min_age_days: staleMinimumAge,
+        apply_close_delay_ms: closeDelay,
+        apply_checkpoint_size: checkpointSize,
+        item_number: "",
+        item_numbers: "",
+        hot_intake: "",
+        audit_dashboard: "",
+      },
+      client_payload: { target_repo: "", queue_lease_id: "", item_number: "" },
+    },
+  });
+
+  assert.equal(
+    evaluate(event(1, "__cursor__"), format),
+    evaluate(event(2, "__cursor__"), format),
+    "durable background cursors must coalesce",
+  );
+  assert.equal(
+    evaluate(event(1, "__cursor__"), format),
+    evaluate(event(3, "", true), format),
+    "scheduled maintenance must share the durable background cursor",
+  );
+  for (const targetRepo of ["openclaw/openclaw", "openclaw/clawhub"]) {
+    const initial = event(22, "__cursor__");
+    const continuation = event(23, "__cursor__", false, "all", "0", "40", "0", "", "all");
+    initial.event.inputs.target_repo = targetRepo;
+    continuation.event.inputs.target_repo = targetRepo;
+    assert.equal(
+      evaluate(initial, format),
+      evaluate(continuation, format),
+      `automatic ${targetRepo} continuations must normalize the default close policy`,
+    );
+  }
+  const customDefault = { CLAWSWEEPER_AUTO_CLOSE_REASONS: "duplicate_or_superseded" };
+  assert.equal(
+    evaluate(event(24, "__cursor__"), format, customDefault),
+    evaluate(
+      event(25, "__cursor__", false, "all", "0", "40", "0", "", "duplicate_or_superseded"),
+      format,
+      customDefault,
+    ),
+    "configured default close reasons must share their continuation group",
+  );
+  assert.notEqual(
+    evaluate(event(26, "__cursor__"), format, customDefault),
+    evaluate(
+      event(27, "__cursor__", false, "all", "0", "40", "0", "", "all"),
+      format,
+      customDefault,
+    ),
+    "explicit all must remain independent when the configured default is narrower",
+  );
+  assert.notEqual(
+    evaluate(event(4, "101,102"), format),
+    evaluate(event(5, "103"), format),
+    "explicit issue and PR batches must never cancel each other",
+  );
+  assert.notEqual(
+    evaluate(event(6, "", false, "issue", "9"), format),
+    evaluate(event(7, "", false, "pull_request", "0"), format),
+    "custom manual selections must never cancel each other",
+  );
+  assert.notEqual(
+    evaluate(event(8, "__cursor__", false, "all", "0", "1"), format),
+    evaluate(event(9, "__cursor__"), format),
+    "an operator-selected batch limit must not share the automatic cursor group",
+  );
+  assert.notEqual(
+    evaluate(event(10, "__cursor__", false, "all", "0", "40", "30"), format),
+    evaluate(event(11, "__cursor__"), format),
+    "an operator-selected item age must not share the automatic cursor group",
+  );
+  assert.notEqual(
+    evaluate(event(12, "__cursor__", false, "all", "0", "40", "0", "30"), format),
+    evaluate(event(13, "__cursor__"), format),
+    "an operator-selected minute-level item age must not share the automatic cursor group",
+  );
+  assert.notEqual(
+    evaluate(
+      event(14, "__cursor__", false, "all", "0", "40", "0", "", "duplicate_or_superseded"),
+      format,
+    ),
+    evaluate(event(15, "__cursor__"), format),
+    "an operator-selected close reason must not share the automatic cursor group",
+  );
+  assert.notEqual(
+    evaluate(event(16, "__cursor__", false, "all", "0", "40", "0", "", "", "1"), format),
+    evaluate(event(17, "__cursor__"), format),
+    "an operator-selected stale-item age must not share the automatic cursor group",
+  );
+  assert.notEqual(
+    evaluate(event(18, "__cursor__", false, "all", "0", "40", "0", "", "", "60", "0"), format),
+    evaluate(event(19, "__cursor__"), format),
+    "an operator-selected close delay must not share the automatic cursor group",
+  );
+  assert.notEqual(
+    evaluate(
+      event(20, "__cursor__", false, "all", "0", "40", "0", "", "", "60", "2000", "5"),
+      format,
+    ),
+    evaluate(event(21, "__cursor__"), format),
+    "an operator-selected checkpoint size must not share the automatic cursor group",
+  );
+  assert.match(applyJob.concurrency.group, /^clawsweeper-target-apply-/);
+  assert.equal(applyJob.concurrency["cancel-in-progress"], false);
 });
 
 test("scheduled normal review sizes one planner shard to live candidate capacity", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -3673,8 +3673,7 @@ test("uncursored comment synchronization selects and continues the full eligible
     assert.match(output, /^selected=1,2,3,/m);
     assert.match(output, /^selected=.*39,40$/m);
     assert.match(output, /^resumed=981,982,/m);
-    assert.match(output, /^resumed=.*1001,1002$/m);
-    assert.doesNotMatch(output, /^resumed=.*1003/m);
+    assert.match(output, /^resumed=.*1001,1002,1003$/m);
     assert.doesNotMatch(output, /^resumed=.*1004/m);
     assert.match(output, /results\/comment-sync-cursors\/openclaw-openclaw\.json/);
   } finally {


### PR DESCRIPTION
## Why

Real production closure jobs were being starved by stale background comment-sync workflows sharing the same repository mutation lock:

- The live queue contained 75 pending apply workflows, including 69 comment-sync jobs; the oldest background sync had been waiting since 2026-08-02T12:59:15Z.
- 69 obsolete pending workflows were cancelled successfully, with zero cancellation failures. After the mutation lane was released, the real production close job completed successfully, closing 5 items, synchronizing 18 comments, and preserving 2 security/maintainer protection skips.
- Verified real outcomes include already-fixed issue https://github.com/openclaw/openclaw/issues/84217, already-implemented PR https://github.com/openclaw/openclaw/pull/98632, external-plugin-only report https://github.com/openclaw/openclaw/issues/116231, unsupported/low-value issue https://github.com/openclaw/openclaw/issues/117428, and the latest live bot closures https://github.com/openclaw/openclaw/issues/118244 and https://github.com/openclaw/openclaw/issues/116296.
- The repaired issue-implementation lane generated five recent, still-open root-cause fixes: browser extension deep-doctor snapshots https://github.com/openclaw/openclaw/pull/118361, failed tool turns https://github.com/openclaw/openclaw/pull/118315, duplicate Claude transcript turns https://github.com/openclaw/openclaw/pull/118309, MiniMax vision routing https://github.com/openclaw/openclaw/pull/118303, and legacy exec approvals https://github.com/openclaw/openclaw/pull/118282. All five have auto-merge disabled; the configured creation model is `gpt-5.6-sol` with `xhigh` reasoning. A separately generated candidate, https://github.com/openclaw/openclaw/pull/118325, was automatically closed unmerged by ClawSweeper itself after fresh source-backed review proved its behavior was already implemented on `main`.
- A real upstream cron regression, https://github.com/openclaw/openclaw/issues/102534, remains open.
- The live publication dead-letter backlog has already dropped from 1,391 to 876 while review/publication lanes continue processing real GitHub items.

## Change

- Replace one background sync workflow per published batch with one interchangeable, repository-scoped durable cursor workflow covering both issues and PRs, including failed reviews whose `needs-human` verdicts must replace earlier passing comments.
- Coalesce only the exact automatic policy: `__cursor__`, kind `all`, batch/checkpoint `40`, zero item/comment age, no minute-level override, configured default close reasons (including equivalent explicit-default continuations), default 60-day stale gate, and default 2-second delay. Preserve unique workflow groups, independently SHA-256-fingerprinted cursors, and bounded continuations for manual batches, PR-only maintenance, custom limits, custom close reasons, stale gates, delays, checkpoints, and every distinct day/minute age setting. Normalize oversized checkpoints before cursor classification; uncursored default runs consistently use the same shared cursor before and after continuation.
- Share the same durable cursor between automatic background publication and scheduled maintenance, while bounding both automatic and scheduled passes to one 40-item window so closure jobs can acquire the mutation lock promptly. Manual/custom policies and targets without scheduled maintenance retain their existing bounded continuations.
- Refresh new/cached reviews immediately using the newest `reviewed_at`/`last_full_review_at`, repair missing/corrupt metadata, and always inspect PRs live so new heads are never hidden behind a recently synchronized comment. Shared automatic cursors skip genuinely fresh issues while explicit/manual all-item cursors still inspect them. Already-synchronized proof/stale-sync retries stay in normal cursor order rather than repeatedly monopolizing the urgent lane, and urgent out-of-order work can never advance the persisted cursor past unfinished lower-numbered records.
- Prioritize newly reviewed/unsynchronized records ahead of routine fresh-PR maintenance while reserving one advancing cursor slot when a full urgent window would otherwise stall after wraparound. Skip the proof job's repository-wide reconciliation and proof generation entirely for background, scheduled, targeted, and custom comment-only runs; defer mutation-lane reconciliation until the exact 40-item cursor window has been selected and restrict it to those exact records. Scoped reconciliation performs zero full-repository inventory scans across both workflow stages, so unrelated open reports and closed-item sidecars cannot be archived or rewritten and repositories exceeding 250 inventory pages cannot break comment synchronization.
- Skip genuinely locked issues before acquiring a new mutation lease, but only after exact-event source revisions, timestamp/snapshot drift, PR review activity, and canonical duplicate relationships are validated; adopt and release already-owned leases normally, preserve both existing and newly discovered stale-canonical correction records while a locked conversation prevents mutation, honor comment-sync cooldowns for failed/keep-open records, and refresh metadata-only guarded maintainer/invalid-decision records so they leave the urgent queue.
- Publish missing, refreshed, or timestamp-corrupt durable review comments for protected, close-exempt, maintainer-owned, failed, and source-valid low-confidence/invalid-decision reports without promoting or closing those guarded records; requeue guarded reports whenever a later apply decision supersedes an existing close-marker comment, and exclude invalid decisions whose close reason the repository explicitly forbids. Reject stale guarded source even at zero publication cooldown. Preserve the durable comment's actual GitHub mutation timestamp separately from local verification time so metadata-only repairs never hide newer human source edits. Keep guarded PRs eligible for live-head maintenance while avoiding repeated guarded-issue publication. Repair stale/missing timestamps and absent/`none`/`unknown` comment references without rewriting an already-correct GitHub comment. Advance safely past canonically archived selected records, continue wrapped scans when a newer urgent item sits outside the cycle boundary, and exclude locked/terminal records, unverified checkouts, and ordinary legacy comment records lacking a synchronization timestamp from urgent priority. Preserve the canonical repository slug, including dots and underscores, when locating records and automatic cursors.
- Preserve the existing shared per-target GitHub mutation lock and all source-revision, protected-label, maintainer-ownership, proof, and age gates.
- Do not change local/offline review, generated-PR creation, OpenClaw merge policy, or repair-model selection.

## Real behavior proof

1. **Production queue:** inspected 75 real pending workflows, cancelled 69 stale background sync workflows with 69 successful cancellations and 0 errors, then verified the actual close workflow completed with `closed=5`, `review_comment_synced=18`, and `skipped_protected_label=2`.
2. **Real GitHub mutation:** verified the `closed` timeline actor is `clawsweeper[bot]` for the external-plugin issue https://github.com/openclaw/openclaw/issues/116231, the low-value issue https://github.com/openclaw/openclaw/issues/117428, and the latest live closures https://github.com/openclaw/openclaw/issues/118244 and https://github.com/openclaw/openclaw/issues/116296; the issue-fix lane created https://github.com/openclaw/openclaw/pull/118361, https://github.com/openclaw/openclaw/pull/118315, https://github.com/openclaw/openclaw/pull/118309, https://github.com/openclaw/openclaw/pull/118303, and https://github.com/openclaw/openclaw/pull/118282 without requesting auto-merge. ClawSweeper also closed its own superseded candidate https://github.com/openclaw/openclaw/pull/118325 unmerged after independently proving the requested behavior already exists.
3. **Real safe contrast:** https://github.com/openclaw/openclaw/issues/102534 remains `OPEN`; OpenClaw has 26 open ClawSweeper-generated PRs, and each of the five new root-cause PRs has `auto_merge: null`.
4. **Actual GitHub Actions expression:** evaluated the parsed workflow concurrency expression against real automatic, scheduled, targeted, customized batch-size, customized day-age, customized minute-age, and overridden repository close-policy inputs. Automatic/scheduled groups match, implicit/configured-explicit-default continuations coalesce for both OpenClaw and ClawHub, and every targeted/customized group stays distinct.
5. **Actual shell/cursor path:** sourced `scripts/apply-workflow-helpers.sh`, created 41 real canonical markdown records, and exercised the background cursor followed by the scheduled cursor. Background selected items 1–40, scheduled selected item 41 from the same durable cursor, scheduled continuation stayed `false`, and the final cursor was 41.
6. **Actual canonical record filtering:** filesystem-backed fixtures cover ordinary issues, fresh issue comments, cached re-reviews, stale PR heads, corrupted hashes, duplicate-comment repair, retry-only records, protected labels, maintainer ownership, source-valid low-confidence/invalid decisions, excluded repository-forbidden decisions across four target profiles, locked/terminal outcomes, independently continued custom mutation and age policies, uncursored OpenClaw/ClawHub default continuations, urgent refreshed/invalid-timestamp guarded records crossing an existing cursor without falsely ending the scan, protected decisions made after the previous comment sync, a full wrapped urgent window that still advances, wrapped continuations behind a newer out-of-cycle urgent record, proven canonical archives between selection and execution, unusable unverified/ordinary legacy rows, canonical repository names containing dots and underscores, and immediate prioritization of a newly reviewed item ahead of 45 existing PRs. Parsed real workflow conditions prove every comment-only proof lane skips global reconciliation while actual close workflows retain it; non-dry-run mocked GitHub comment creation proves protected, maintainer-owned, close-exempt, and low-confidence/invalid reviews publish without closing or promoting the guarded reports, metadata-only maintainer/invalid reports leave the urgent queue, locked issues never attempt lease/comment writes, newer locked source revisions still requeue, and locked stale-canonical repairs retain both their pending action and canonical identity.
7. **Actual scoped reconciliation:** invoked the real compiled `clawsweeper reconcile` CLI against records 1–3 with only item 2 selected; item 2 moved to closed, unselected open item 1 stayed open, unselected closed item 3 kept its sidecar, only the selected canonical tuple was captured or changed, and the test fails if any full open-inventory scan is attempted (`pagesScanned=0`). A deleted selected item is archived only after live repository access is verified; an inaccessible repository preserves the item and fails safely.
8. **Full repository validation:** an independently reviewed earlier state passed `pnpm run check` across all 3,056 repository tests (3,047 passed and 9 intentionally skipped), and an earlier strengthened follow-up passed the complete single-build unit suite across 1,839 tests (1,837 passed, 2 intentionally skipped, 0 failed). The final state additionally passes 373 focused workflow/cursor/reconciliation/guarded-apply/duplicate-correction/PR-label/lease-ordering/legacy-protected-decision/local-review regression tests plus every static, formatting, and lint check, including independently identified modern locked-review tuples, matching completed lease cleanup, issue/PR timestamp drift, snapshot-only drift without `item_updated_at`, persisted observed revisions, canonical invalidation, stale close verdicts, guarded snapshot freshness even at zero cooldown, failed-review publication and weekly maintenance, truthful metadata-only verification timestamps, checked-only synchronization repair behind the cursor, protected disposition preservation even after label removal, protected-close and maintainer-ownership priority, persisted live protected/maintainer labels, guarded stale-head readiness cleanup, command-only re-review label restoration, pre-mutation guarded PR freshness, guarded PR live-head maintenance, seven-day locked-review cooldowns, closed legacy records, open-linked locked issue metadata, protected stale-PR-head corrections, proof labels, and guarded freshness cases. All 9 dedicated offline local-review tests pass. Fresh independent reviews separately ran 203 and 206 apply-path regression tests and complete repository checks; an earlier independent review exercised 1,662 cursor-ordering scenarios with zero skipped or oversized batches. The original 14,216-line entry point is now 19 lines, and its largest extracted apply workflow is 1,999 lines.

## Review finding disposition

- Independent committed-head review found that locked issues could post a lease before checking GitHub's lock, and that maintainer/invalid reports could recycle indefinitely. Both are fixed with non-dry-run mocked GitHub regressions.
- Earlier lock-guard revisions were independently found to precede exact-event source validation, PR review-activity validation, canonical invalidation, ordinary source-drift validation, stale proof-label cleanup, or metadata-only synchronization and could overwrite pending stale-canonical actions. The final pre-lease guard is limited to actual tuple-bound locked-issue comment mutations; matching durable comments bypass new lease posting and label writes so their local metadata can be repaired, while already-existing matching leases are adopted and deleted normally. Early locked-issue source-drift decisions preserve the live `current_item_updated_at`, and the restored late guard preserves ordinary PR source/label ordering. Existing and newly discovered stale-canonical correction state remain retryable.
- An independent precommit review additionally reproduced stale PR close-verdict publication and false-positive duplicate metadata refresh caused by applying guarded-review freshness to every `skipped_*` action. Guarded freshness and forced publication now have an explicit protected/maintainer/invalid-decision action allowlist and also require unchanged reviewed source; source-drift skips neither publish close verdicts nor consume the 40-item comment-sync window. Every reviewer-provided mocked reproduction now passes alongside permanent regression coverage.
- A subsequent independent precommit review reproduced four further edge cases: the source-inspected mutation-lease acquisition invariant, locked snapshot-only drift being misclassified as a lock, stale guarded snapshots overriding the publication cooldown, and locked failed reviews consuming bounded comment-sync capacity. The acquisition invariant is restored, timestamp/snapshot drift now shares one persisted proof-backed marker, existing owned leases are always released, guarded actions require fresh reviewed source, and locked non-actionable reviews follow the same cooldown as normal comment publication. Each finding has a direct permanent mocked-GitHub regression and the reviewer's original standalone reproductions now pass.
- The next independent baseline-comparison review identified three remaining edge cases. Protected stale-head notices now force immediate durable correction independently of the guarded-verdict cooldown; source snapshots are hydrated lazily so already-closed legacy reports archive without unrelated timeline calls; and preliminary locked-comment comparisons use the same actual linked-PR state as final rendering. All three reviewer-provided old-vs-new reproductions now match the safe baseline and have permanent regression coverage.
- A complete independent committed-branch review then found four cross-module regressions. Failed review artifacts are now eligible for coalesced cursor publication; guarded source changes fail closed even with the automatic zero-day cooldown; metadata-only repairs retain the comment's real `updated_at` while recording a separate local verification timestamp; and guarded PRs remain eligible for live-head invalidation. A subsequent throughput review additionally proved synchronized failed reviews must leave the urgent lane; failed reports now receive immediate durable publication once and stop monopolizing bounded cursor capacity afterward. Permanent regressions cover failed-review selection and post-publication retirement, guarded stale-source publication, scheduler re-review after human edits, and protected PR head maintenance.
- The final independent whole-repository review reproduced three additional boundary cases while all 3,053 existing tests passed: unchanged-head guarded PRs could mutate proof/rating labels before rejecting timestamp drift, protected locked records could lose their permanent protected disposition, and checked-only or failed-repair records could disappear before their true synchronization timestamp was restored. Freshness now precedes every guarded PR-label mutation, protected actions survive source-drift evidence, checked-only records remain executable, and failed canonical-repair retries stay eligible. Three permanent mocked-GitHub/canonical-record regressions reproduce each original failure.
- A second whole-repository review additionally reproduced an existing protected-close decision-packet regression, a removed protection briefly leaving a stale `proposed_close` eligible for later closure, and a checked-only repair being stranded behind the automatic cursor. Protected labels now win before source-drift shortcuts, the original guarded action is explicitly restored rather than preserving a transient promotion, and checked-only repairs receive bounded urgent priority without prioritizing ordinary legacy records. Existing protected decision-packet tests and new removed-label/cursor-position regressions all pass.
- A final full-coverage review caught two policy-ordering details after all 3,056 tests passed: newly applied security labels must be saved to canonical report metadata before taking the protected exit, and live maintainer ownership must be recognized before ordinary source-drift rejection. Both guards now persist their live evidence and retain existing verified exact-event proof semantics; a permanent parameterized mocked-GitHub regression covers security and maintainer ownership.
- A bounded follow-up review reproduced stale proof/status labels surviving a protected PR head change, stale live-label metadata on removed protections or maintainer exits, and failed reviews never receiving seven-day durable-comment verification. One shared label-snapshot/PR-maintenance phase now precedes early protection guards without permitting same-head stale guarded mutations, while failed reviews return to the normal cursor only when weekly verification is due. Dedicated stale-head, changed-label, weekly-failed-review, and command-only re-review regressions all pass.
- The final exact-name sign-off additionally covered locked protected reports whose live labels change and failed protected/maintainer reports reaching their weekly maintenance deadline. Shared source-drift evidence now snapshots authoritative live labels for locked and unlocked paths alike, and all failed guard categories become selectable only after the seven-day interval.
- GitHub timestamps use UTC: August 3 UTC corresponds to August 2 in America/Los_Angeles. The apparent date discrepancy in the previous bot review is timezone rollover, not future-dated activity.

## Deployment invariants

- `CLAWSWEEPER_AUTO_CLOSE_REASONS=all`
- `CLAWSWEEPER_ALLOW_FIX_PR=1`
- `CLAWSWEEPER_FIX_PR_MODEL=gpt-5.6-sol`
- `CLAWSWEEPER_FIX_PR_REASONING_EFFORT=xhigh`
- `CLAWSWEEPER_ALLOW_AUTOMERGE=0`
- `CLAWSWEEPER_ALLOW_MERGE=0`

Generated OpenClaw fixes remain **PR-only**; this PR changes only the ClawSweeper service.
