### PR TITLE
feat(prompts): reviewers emit a production-vs-test LOC delta metric

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -303,6 +303,13 @@ briefly explain why that measured fact matters before merge. Do not use vague
 labels or values, and do not restate full `risks`, `bestSolution`,
 `mergeRiskOptions`, or label rationale in `reviewMetrics`.
 
+For PRs that meaningfully grow the codebase, or when the target repository's
+contribution policy asks for it, emit a production-vs-test LOC delta metric:
+count production and test lines separately in `value` (for example `production
++12, tests +85`) and use `reason` to state whether the production growth has a
+stated justification. Put any unjustified-production-growth concern itself in
+`risks`, not here.
+
 Fill `labelJustifications` with one object for every selected ClawSweeper-managed
 label. Include the selected `triagePriority` unless it is `none`, every selected
 `impactLabels` entry, every selected `maturityLabels` entry, and every selected


### PR DESCRIPTION
## What Problem This Solves

openclaw/openclaw's root AGENTS.md now directs ClawSweeper PR reviews to emit a production-vs-test LOC delta `reviewMetrics` entry (landed in openclaw/openclaw#118330). The generic review prompt had no matching guidance, so workers would emit the metric inconsistently — or only for repos whose AGENTS.md spells it out — and had no canonical `value`/`reason` shape for it.

## Why This Change Was Made

Adds one paragraph to the `reviewMetrics` guidance in `prompts/review-item.md`: for PRs that meaningfully grow the codebase, or when the target repository's contribution policy asks for it, emit a production-vs-test LOC delta metric with production and test lines counted separately (example shape `production +12, tests +85`), the justification status noted in `reason`, and any unjustified-growth concern routed to `risks` rather than duplicated in the metric. The guidance stays repo-agnostic per the prompt's design: the metric is generic; repo policy (like OpenClaw's Repair Doctrine) supplies the justification vocabulary. No schema change — the existing `reviewMetrics` item shape already fits.

## User Impact

Maintainers reading ClawSweeper reviews get a consistent, comparable LOC-growth digest at the top of PR reports, with production growth separated from test growth. No behavior change for issues or PRs where the metric would not help; `reviewMetrics: []` guidance is unchanged.

## Evidence

Prompt-only diff (+7 lines, one file). `git diff --check` clean. Focused prompt-policy suites pass locally on Node 24: `node --test test/review-prompt-policy.test.ts test/review-prompt-context.test.ts` — 41 pass, 0 fail. Codex autoreview (gpt-5.6-sol, high) on the exact diff: clean, no accepted/actionable findings, "patch is correct (0.99)". Note: `pnpm run test:unit` has pre-existing failures on this local macOS environment (stable-json, sweep-status, sweep-workflow, work-plan-artifacts) in files that never read `prompts/review-item.md`; clawsweeper CI on `main` was green as of 2026-08-02 19:15 UTC, so PR CI is the arbiter there.

## Real Behavior Proof (post-change review run)

Ran the documented advisory local review lane from this branch (modified prompt live, no GitHub writes): `pnpm run review -- --local-only --target-repo openclaw/openclaw --item-number 118332`, reviewing openclaw/openclaw#118332 (`fix(chat): preserve reasoning and tool trace after navigation`, a representative code PR with mixed production/test growth: +247/−51 across 9 files). Run completed in 8m 31s, `review_status: complete`, `decision: keep_open`, `confidence: high`.

The generated report's structured `review_metrics` (verbatim from `artifacts/local-review-118332/118332.md` frontmatter; all content is from the public PR, nothing to redact):

```json
[
  {"label":"Production versus test LOC","value":"production +11 net; tests +185 net; generated inventory 0 net","reason":"The production growth is justified by a shared owner-boundary repair, but its new payload contracts require the missing safety coverage."},
  {"label":"Default session-tool consumers","value":"2 affected","reason":"Both sessions_history and sessions_list rely on the same whole-message-only tool filter."}
]
```

This demonstrates both halves of the new guidance in a real run: production and test lines counted separately in `value`, and the `reason` stating the justification status of the production growth. The reviewer also still emitted an unrelated second metric and used the metric only where useful, showing the `reviewMetrics: []` default is undisturbed.
