### PR TITLE
fix: finalize legacy command acknowledgements without webhook races

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -222,7 +222,8 @@ jobs:
             item_numbers="${{ github.event.client_payload.item_number || '' }}"
             comment_ids="${{ github.event.client_payload.comment_id || '' }}"
             status_comment_id="${{ github.event.client_payload.status_comment_id || '' }}"
-            source_event="${{ github.event.client_payload.source_event || '' }}"
+            source_delivery_id="${{ github.event.client_payload.source_delivery_id || '' }}"
+            source_event="${{ github.event.client_payload.source_event || 'issue_comment' }}"
             source_action="${{ github.event.client_payload.source_action || '' }}"
             dispatch_actor="${{ github.actor }}"
             comment_event_auth="${{ github.event.client_payload.comment_event_auth || '' }}"
@@ -232,6 +233,7 @@ jobs:
             attempt_id="${{ github.event.client_payload.attempt_id || '' }}"
           else
             status_comment_id=""
+            source_delivery_id=""
             source_event=""
             source_action=""
             dispatch_actor=""
@@ -270,6 +272,9 @@ jobs:
           fi
           if [ -n "$status_comment_id" ]; then
             args+=(--status-comment-id "$status_comment_id")
+          fi
+          if [ -n "$source_delivery_id" ]; then
+            args+=(--source-delivery-id "$source_delivery_id")
           fi
           if [ -n "$source_event" ]; then
             args+=(--source-event "$source_event")
@@ -373,7 +378,8 @@ jobs:
             item_numbers="${{ github.event.client_payload.item_number || '' }}"
             comment_ids="${{ github.event.client_payload.comment_id || '' }}"
             status_comment_id="${{ github.event.client_payload.status_comment_id || '' }}"
-            source_event="${{ github.event.client_payload.source_event || '' }}"
+            source_delivery_id="${{ github.event.client_payload.source_delivery_id || '' }}"
+            source_event="${{ github.event.client_payload.source_event || 'issue_comment' }}"
             source_action="${{ github.event.client_payload.source_action || '' }}"
             dispatch_actor="${{ github.actor }}"
             comment_event_auth="${{ github.event.client_payload.comment_event_auth || '' }}"
@@ -383,6 +389,7 @@ jobs:
             attempt_id="${{ github.event.client_payload.attempt_id || '' }}"
           else
             status_comment_id=""
+            source_delivery_id=""
             source_event=""
             source_action=""
             dispatch_actor=""
@@ -421,6 +428,9 @@ jobs:
           fi
           if [ -n "$status_comment_id" ]; then
             args+=(--status-comment-id "$status_comment_id")
+          fi
+          if [ -n "$source_delivery_id" ]; then
+            args+=(--source-delivery-id "$source_delivery_id")
           fi
           if [ -n "$source_event" ]; then
             args+=(--source-event "$source_event")

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3252,6 +3252,7 @@ jobs:
           STATUS_COMMENT_ID: ${{ steps.finalization-context.outputs.status_comment_id }}
           COMMAND_COMMENT_ID: ${{ steps.update-final-command-status.outputs.command_comment_id }}
           COMPLETION_COMMENT_ID: ${{ steps.update-final-command-status.outputs.completion_comment_id }}
+          COMPLETION_COMPLETED_AT: ${{ steps.update-final-command-status.outputs.completion_completed_at }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
@@ -3261,17 +3262,21 @@ jobs:
             const statusCommentId = process.env.STATUS_COMMENT_ID === "" ? null : Number(process.env.STATUS_COMMENT_ID);
             const commandCommentId = Number(process.env.COMMAND_COMMENT_ID);
             const completionCommentId = Number(process.env.COMPLETION_COMMENT_ID);
+            const completedAt = process.env.COMPLETION_COMPLETED_AT || "";
             if (
               (!statusMarker && statusCommentId === null) ||
               (statusCommentId !== null && (!Number.isInteger(statusCommentId) || statusCommentId < 1)) ||
               !Number.isInteger(commandCommentId) || commandCommentId < 1 ||
-              !Number.isInteger(completionCommentId) || completionCommentId < 1
+              !Number.isInteger(completionCommentId) || completionCommentId < 1 ||
+              !completedAt || !Number.isFinite(Date.parse(completedAt))
             ) process.exit(1);
             process.stdout.write(JSON.stringify({
               canonical_target_key: `${process.env.TARGET_REPO}#${process.env.ITEM_NUMBER}`,
               ...(statusMarker ? { status_marker: statusMarker } : {}),
+              ...(statusCommentId === null ? {} : { status_comment_id: statusCommentId }),
               command_comment_id: commandCommentId,
               completion_comment_id: completionCommentId,
+              completed_at: completedAt,
               observed_at: Date.now(),
             }));
           ')"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -335,6 +335,9 @@ jobs:
           const queueClaim = payload.queue_claim && typeof payload.queue_claim === "object"
             ? payload.queue_claim
             : {};
+          const reviewOptions = payload.review_options && typeof payload.review_options === "object"
+            ? payload.review_options
+            : {};
           const dispatchKey = String(payload.dispatch_key || "").trim();
           const ingressFingerprint = String(payload.ingress_fingerprint || "").trim().toLowerCase();
           const ingress =
@@ -366,6 +369,9 @@ jobs:
                 sourceEvent,
                 sourceAction: payload.source_action || "legacy_dispatch",
                 supersedesInProgress: payload.supersedes_in_progress === true,
+                ...(typeof payload.source_delivery_id === "string" && payload.source_delivery_id
+                  ? { sourceDeliveryId: payload.source_delivery_id }
+                  : {}),
                 ...(/^[0-9a-f]{40}$/.test(sourceHeadSha)
                   ? { sourceHeadSha }
                   : {}),
@@ -379,15 +385,27 @@ jobs:
                 ...(sourceUpdatedAt && Number.isFinite(Date.parse(sourceUpdatedAt))
                   ? { sourceUpdatedAt }
                   : {}),
-                ...(Number.isFinite(Number(queueClaim.codex_timeout_ms ?? payload.codex_timeout_ms))
-                  ? { codexTimeoutMs: Number(queueClaim.codex_timeout_ms ?? payload.codex_timeout_ms) }
+                ...(Number.isFinite(
+                  Number(queueClaim.codex_timeout_ms ?? reviewOptions.codex_timeout_ms ?? payload.codex_timeout_ms),
+                )
+                  ? {
+                      codexTimeoutMs: Number(
+                        queueClaim.codex_timeout_ms ?? reviewOptions.codex_timeout_ms ?? payload.codex_timeout_ms,
+                      ),
+                    }
                   : {}),
                 ...(Number.isFinite(
-                  Number(queueClaim.media_proof_timeout_ms ?? payload.media_proof_timeout_ms),
+                  Number(
+                    queueClaim.media_proof_timeout_ms ??
+                      reviewOptions.media_proof_timeout_ms ??
+                      payload.media_proof_timeout_ms,
+                  ),
                 )
                   ? {
                       mediaProofTimeoutMs: Number(
-                        queueClaim.media_proof_timeout_ms ?? payload.media_proof_timeout_ms,
+                        queueClaim.media_proof_timeout_ms ??
+                          reviewOptions.media_proof_timeout_ms ??
+                          payload.media_proof_timeout_ms,
                       ),
                     }
                   : {}),
@@ -3248,6 +3266,8 @@ jobs:
         env:
           TARGET_REPO: ${{ steps.finalization-context.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.finalization-context.outputs.item_number }}
+          FENCE_KEY: ${{ steps.finalization-context.outputs.lifecycle_fence_key }}
+          REVISION: ${{ steps.finalization-context.outputs.lifecycle_revision }}
           STATUS_MARKER: ${{ steps.finalization-context.outputs.status_marker }}
           STATUS_COMMENT_ID: ${{ steps.finalization-context.outputs.status_comment_id }}
           COMMAND_COMMENT_ID: ${{ steps.update-final-command-status.outputs.command_comment_id }}
@@ -3258,12 +3278,15 @@ jobs:
         run: |
           set -euo pipefail
           payload="$(node -e '
+            const fenceKey = process.env.FENCE_KEY || "";
+            const revision = Number(process.env.REVISION);
             const statusMarker = process.env.STATUS_MARKER || null;
             const statusCommentId = process.env.STATUS_COMMENT_ID === "" ? null : Number(process.env.STATUS_COMMENT_ID);
             const commandCommentId = Number(process.env.COMMAND_COMMENT_ID);
             const completionCommentId = Number(process.env.COMPLETION_COMMENT_ID);
             const completedAt = process.env.COMPLETION_COMPLETED_AT || "";
             if (
+              !fenceKey || !Number.isSafeInteger(revision) || revision < 1 ||
               (!statusMarker && statusCommentId === null) ||
               (statusCommentId !== null && (!Number.isInteger(statusCommentId) || statusCommentId < 1)) ||
               !Number.isInteger(commandCommentId) || commandCommentId < 1 ||
@@ -3272,6 +3295,8 @@ jobs:
             ) process.exit(1);
             process.stdout.write(JSON.stringify({
               canonical_target_key: `${process.env.TARGET_REPO}#${process.env.ITEM_NUMBER}`,
+              fence_key: fenceKey,
+              revision,
               ...(statusMarker ? { status_marker: statusMarker } : {}),
               ...(statusCommentId === null ? {} : { status_comment_id: statusCommentId }),
               command_comment_id: commandCommentId,

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -684,6 +684,7 @@ export class ExactReviewLifecycleProjectionStore {
     statusMarker: string | null;
     commandCommentId: number;
     completionCommentId: number;
+    statusCommentId?: number;
     requireExactStatusComment?: boolean;
     observedAt: number;
   }) {
@@ -691,7 +692,8 @@ export class ExactReviewLifecycleProjectionStore {
       !validCanonicalTargetKey(input.canonicalTargetKey) ||
       (input.statusMarker !== null && !validText(input.statusMarker, 1, 300)) ||
       !positiveInteger(input.commandCommentId) ||
-      !positiveInteger(input.completionCommentId)
+      !positiveInteger(input.completionCommentId) ||
+      (input.statusCommentId !== undefined && !positiveInteger(input.statusCommentId))
     ) {
       throw new Error("invalid lifecycle acknowledgement receipt");
     }
@@ -707,17 +709,19 @@ export class ExactReviewLifecycleProjectionStore {
         const projection = projectionFromRow(String(row.projection_json || ""));
         const attempted = projection.acknowledgement.attempts.some(
           (attempt) =>
-            (attempt.statusCommentId === input.completionCommentId &&
+            (input.statusCommentId === undefined ||
+              attempt.statusCommentId === input.statusCommentId) &&
+            ((attempt.statusCommentId === input.completionCommentId &&
               (attempt.statusMarker === input.statusMarker ||
                 attempt.statusMarker === null ||
                 (!input.requireExactStatusComment && input.statusMarker === null))) ||
-            (input.requireExactStatusComment &&
-              attempt.statusCommentId === null &&
-              input.statusMarker !== null &&
-              attempt.statusMarker === input.statusMarker) ||
-            (!input.requireExactStatusComment &&
-              input.statusMarker !== null &&
-              attempt.statusMarker === input.statusMarker),
+              (input.requireExactStatusComment &&
+                attempt.statusCommentId === null &&
+                input.statusMarker !== null &&
+                attempt.statusMarker === input.statusMarker) ||
+              (!input.requireExactStatusComment &&
+                input.statusMarker !== null &&
+                attempt.statusMarker === input.statusMarker)),
         );
         if (!attempted || !projection.acknowledgement.required) continue;
         const observed = {

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -684,6 +684,7 @@ export class ExactReviewLifecycleProjectionStore {
     statusMarker: string | null;
     commandCommentId: number;
     completionCommentId: number;
+    requireExactStatusComment?: boolean;
     observedAt: number;
   }) {
     if (
@@ -706,8 +707,17 @@ export class ExactReviewLifecycleProjectionStore {
         const projection = projectionFromRow(String(row.projection_json || ""));
         const attempted = projection.acknowledgement.attempts.some(
           (attempt) =>
-            attempt.statusCommentId === input.completionCommentId ||
-            (input.statusMarker !== null && attempt.statusMarker === input.statusMarker),
+            (attempt.statusCommentId === input.completionCommentId &&
+              (attempt.statusMarker === input.statusMarker ||
+                attempt.statusMarker === null ||
+                (!input.requireExactStatusComment && input.statusMarker === null))) ||
+            (input.requireExactStatusComment &&
+              attempt.statusCommentId === null &&
+              input.statusMarker !== null &&
+              attempt.statusMarker === input.statusMarker) ||
+            (!input.requireExactStatusComment &&
+              input.statusMarker !== null &&
+              attempt.statusMarker === input.statusMarker),
         );
         if (!attempted || !projection.acknowledgement.required) continue;
         const observed = {

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -205,6 +205,7 @@ export type ExactReviewLifecycleProjection = {
   revision: number;
   admission: {
     deliveryId: string;
+    sourceDeliveryId?: string;
     sourceAction: string;
     commandOriginated: boolean;
     statusMarker: string | null;
@@ -297,6 +298,7 @@ export class ExactReviewLifecycleProjectionStore {
   recordAdmission(
     input: ProjectionIdentity & {
       deliveryId: string;
+      sourceDeliveryId?: string;
       sourceAction: string;
       commandOriginated: boolean;
       statusMarker: string | null;
@@ -307,6 +309,9 @@ export class ExactReviewLifecycleProjectionStore {
     this.validateIdentity(input);
     if (!validText(input.deliveryId, 1, 300) || !validText(input.sourceAction, 1, 200)) {
       throw new Error("invalid lifecycle admission fact");
+    }
+    if (input.sourceDeliveryId !== undefined && !validText(input.sourceDeliveryId, 1, 200)) {
+      throw new Error("invalid lifecycle source delivery identity");
     }
     if (input.statusMarker !== null && !validText(input.statusMarker, 1, 300)) {
       throw new Error("invalid lifecycle status marker");
@@ -322,6 +327,7 @@ export class ExactReviewLifecycleProjectionStore {
         const admission = existing.admission;
         if (
           admission.deliveryId !== input.deliveryId ||
+          admission.sourceDeliveryId !== input.sourceDeliveryId ||
           admission.sourceAction !== input.sourceAction ||
           admission.commandOriginated !== input.commandOriginated ||
           admission.statusMarker !== input.statusMarker ||
@@ -338,6 +344,7 @@ export class ExactReviewLifecycleProjectionStore {
         revision: input.revision,
         admission: {
           deliveryId: input.deliveryId,
+          ...(input.sourceDeliveryId ? { sourceDeliveryId: input.sourceDeliveryId } : {}),
           sourceAction: input.sourceAction,
           commandOriginated: input.commandOriginated,
           statusMarker: input.statusMarker,
@@ -681,6 +688,8 @@ export class ExactReviewLifecycleProjectionStore {
 
   observeCommandAcknowledgement(input: {
     canonicalTargetKey: string;
+    fenceKey?: string;
+    revision?: number;
     statusMarker: string | null;
     commandCommentId: number;
     completionCommentId: number;
@@ -690,6 +699,9 @@ export class ExactReviewLifecycleProjectionStore {
   }) {
     if (
       !validCanonicalTargetKey(input.canonicalTargetKey) ||
+      (input.fenceKey === undefined) !== (input.revision === undefined) ||
+      (input.fenceKey !== undefined && !validFenceKey(input.fenceKey)) ||
+      (input.revision !== undefined && !positiveInteger(input.revision)) ||
       (input.statusMarker !== null && !validText(input.statusMarker, 1, 300)) ||
       !positiveInteger(input.commandCommentId) ||
       !positiveInteger(input.completionCommentId) ||
@@ -705,8 +717,15 @@ export class ExactReviewLifecycleProjectionStore {
           input.canonicalTargetKey,
         ),
       );
+      const matchedProjections: ExactReviewLifecycleProjection[] = [];
       for (const row of rows) {
         const projection = projectionFromRow(String(row.projection_json || ""));
+        if (
+          input.fenceKey !== undefined &&
+          (projection.fenceKey !== input.fenceKey || projection.revision !== input.revision)
+        ) {
+          continue;
+        }
         const attempted = projection.acknowledgement.attempts.some(
           (attempt) =>
             (input.statusCommentId === undefined ||
@@ -723,7 +742,26 @@ export class ExactReviewLifecycleProjectionStore {
                 input.statusMarker !== null &&
                 attempt.statusMarker === input.statusMarker)),
         );
-        if (!attempted || !projection.acknowledgement.required) continue;
+        if (attempted && projection.acknowledgement.required) matchedProjections.push(projection);
+      }
+      const exactStatusCommentMatches =
+        input.fenceKey === undefined && matchedProjections.length > 1
+          ? matchedProjections.filter((projection) =>
+              projection.acknowledgement.attempts.some(
+                (attempt) => attempt.statusCommentId === input.completionCommentId,
+              ),
+            )
+          : [];
+      if (
+        input.fenceKey === undefined &&
+        matchedProjections.length > 1 &&
+        exactStatusCommentMatches.length !== 1
+      ) {
+        return { accepted: false, projection: null, state: null, acknowledgement: null };
+      }
+      for (const projection of exactStatusCommentMatches.length
+        ? exactStatusCommentMatches
+        : matchedProjections) {
         const observed = {
           statusMarker: input.statusMarker,
           commandCommentId: input.commandCommentId,
@@ -1669,6 +1707,8 @@ function validDurableLifecycleBayProjection(value: ExactReviewLifecycleProjectio
     !positiveInteger(value.revision) ||
     !finiteTimestamp(value.updatedAt) ||
     !validText(value.admission.deliveryId, 1, 300) ||
+    (value.admission.sourceDeliveryId !== undefined &&
+      !validText(value.admission.sourceDeliveryId, 1, 200)) ||
     !validText(value.admission.sourceAction, 1, 200) ||
     (value.admission.statusMarker !== null && !validText(value.admission.statusMarker, 1, 300)) ||
     (value.admission.statusCommentId !== null &&

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -106,6 +106,7 @@ export type ExactReviewBaseDecision = {
   sourceHeadVerified?: boolean;
   sourceAuthoritySeq?: number;
   sourceUpdatedAt?: string;
+  sourceDeliveryId?: string;
   codexTimeoutMs?: number;
   mediaProofTimeoutMs?: number;
   commandStatusMarker?: string;
@@ -6105,6 +6106,9 @@ export class ExactReviewQueue {
         commandOriginated,
         statusMarker: sourceDecision.commandStatusMarker ?? null,
         statusCommentId: sourceDecision.statusCommentId ?? null,
+        ...(sourceDecision.sourceDeliveryId
+          ? { sourceDeliveryId: sourceDecision.sourceDeliveryId }
+          : {}),
         observedAt: now,
       });
     }
@@ -6154,6 +6158,9 @@ export class ExactReviewQueue {
           ),
           statusMarker: sourceDecision.commandStatusMarker ?? null,
           statusCommentId: sourceDecision.statusCommentId ?? null,
+          ...(sourceDecision.sourceDeliveryId
+            ? { sourceDeliveryId: sourceDecision.sourceDeliveryId }
+            : {}),
           observedAt: now,
         });
       }
@@ -6234,6 +6241,9 @@ export class ExactReviewQueue {
         commandOriginated,
         statusMarker,
         statusCommentId,
+        ...(sourceDecision?.sourceDeliveryId
+          ? { sourceDeliveryId: sourceDecision.sourceDeliveryId }
+          : {}),
         observedAt: now,
       });
     }
@@ -6837,6 +6847,8 @@ export class ExactReviewQueue {
     const body = objectValue(value);
     const canonicalTargetKey =
       typeof body.canonical_target_key === "string" ? body.canonical_target_key : "";
+    const fenceKey = body.fence_key;
+    const revision = body.revision;
     const statusMarker =
       body.status_marker === undefined || body.status_marker === null
         ? null
@@ -6846,10 +6858,14 @@ export class ExactReviewQueue {
     const commandCommentId = Number(body.command_comment_id);
     const completionCommentId = Number(body.completion_comment_id);
     const statusCommentId = body.status_comment_id;
+    const includeDeliveryIdentity = body.include_delivery_identity;
     const requireExactStatusComment = body.require_exact_status_comment;
     const observedAt = Number(body.observed_at);
     if (
       !canonicalTargetKey ||
+      (fenceKey === undefined) !== (revision === undefined) ||
+      (fenceKey !== undefined && (typeof fenceKey !== "string" || !fenceKey)) ||
+      (revision !== undefined && (!Number.isSafeInteger(revision) || Number(revision) < 1)) ||
       (statusMarker !== null && !statusMarker) ||
       !Number.isSafeInteger(commandCommentId) ||
       commandCommentId < 1 ||
@@ -6857,6 +6873,7 @@ export class ExactReviewQueue {
       completionCommentId < 1 ||
       (statusCommentId !== undefined &&
         (!Number.isSafeInteger(statusCommentId) || Number(statusCommentId) < 1)) ||
+      (includeDeliveryIdentity !== undefined && typeof includeDeliveryIdentity !== "boolean") ||
       (requireExactStatusComment !== undefined && typeof requireExactStatusComment !== "boolean") ||
       !Number.isSafeInteger(observedAt) ||
       observedAt < 1
@@ -6866,6 +6883,9 @@ export class ExactReviewQueue {
     try {
       const result = this.lifecycleProjectionStore.observeCommandAcknowledgement({
         canonicalTargetKey,
+        ...(fenceKey === undefined
+          ? {}
+          : { fenceKey: String(fenceKey), revision: Number(revision) }),
         statusMarker,
         commandCommentId,
         completionCommentId,
@@ -6896,6 +6916,10 @@ export class ExactReviewQueue {
         lifecycle_state: result.state,
         acknowledgement_state: result.acknowledgement,
         ...(result.projection ? { version: result.projection.version } : {}),
+        ...((fenceKey !== undefined || includeDeliveryIdentity === true) &&
+        result.projection?.admission.sourceDeliveryId
+          ? { source_delivery_id: result.projection.admission.sourceDeliveryId }
+          : {}),
       });
     } catch (error) {
       console.warn(`lifecycle acknowledgement receipt rejected: ${sanitizedServerError(error)}`);
@@ -9488,6 +9512,8 @@ function exactReviewBaseDecisionFrom(value): ExactReviewBaseDecision | null {
   const sourceUpdatedAt = hasSourceUpdatedAt
     ? String(decision.sourceUpdatedAt || "").trim()
     : undefined;
+  const hasSourceDeliveryId = Object.hasOwn(decision, "sourceDeliveryId");
+  const sourceDeliveryId = hasSourceDeliveryId ? decision.sourceDeliveryId : undefined;
   const hasCommandStatusMarker = Object.hasOwn(decision, "commandStatusMarker");
   const commandStatusMarker = hasCommandStatusMarker ? decision.commandStatusMarker : undefined;
   const hasStatusCommentId = Object.hasOwn(decision, "statusCommentId");
@@ -9514,6 +9540,12 @@ function exactReviewBaseDecisionFrom(value): ExactReviewBaseDecision | null {
     return null;
   }
   if (hasSourceUpdatedAt && !Number.isFinite(Date.parse(sourceUpdatedAt || ""))) return null;
+  if (
+    hasSourceDeliveryId &&
+    (typeof sourceDeliveryId !== "string" || !/^[A-Za-z0-9_.:-]{1,200}$/.test(sourceDeliveryId))
+  ) {
+    return null;
+  }
   if (
     hasCommandStatusMarker &&
     (typeof commandStatusMarker !== "string" ||
@@ -9550,6 +9582,7 @@ function exactReviewBaseDecisionFrom(value): ExactReviewBaseDecision | null {
     ...(hasSourceHeadVerified ? { sourceHeadVerified: decision.sourceHeadVerified } : {}),
     ...(hasSourceAuthoritySeq ? { sourceAuthoritySeq } : {}),
     ...(hasSourceUpdatedAt ? { sourceUpdatedAt } : {}),
+    ...(hasSourceDeliveryId ? { sourceDeliveryId } : {}),
     ...(Number.isFinite(Number(decision.codexTimeoutMs))
       ? { codexTimeoutMs: Number(decision.codexTimeoutMs) }
       : {}),
@@ -9755,12 +9788,17 @@ function mergePendingExactReviewDecision(
   next: ExactReviewDecision,
 ): ExactReviewDecision {
   const merged = { ...current, ...next };
-  if (
+  const commandMarkerChanged =
     Object.hasOwn(next, "commandStatusMarker") &&
-    next.commandStatusMarker !== current.commandStatusMarker &&
-    !Object.hasOwn(next, "statusCommentId")
-  ) {
+    next.commandStatusMarker !== current.commandStatusMarker;
+  if (commandMarkerChanged && !Object.hasOwn(next, "statusCommentId")) {
     delete merged.statusCommentId;
+  }
+  if (
+    (Object.hasOwn(next, "commandStatusMarker") || Object.hasOwn(next, "statusCommentId")) &&
+    !Object.hasOwn(next, "sourceDeliveryId")
+  ) {
+    delete merged.sourceDeliveryId;
   }
   return merged;
 }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -6845,6 +6845,7 @@ export class ExactReviewQueue {
           : "";
     const commandCommentId = Number(body.command_comment_id);
     const completionCommentId = Number(body.completion_comment_id);
+    const requireExactStatusComment = body.require_exact_status_comment;
     const observedAt = Number(body.observed_at);
     if (
       !canonicalTargetKey ||
@@ -6853,6 +6854,7 @@ export class ExactReviewQueue {
       commandCommentId < 1 ||
       !Number.isSafeInteger(completionCommentId) ||
       completionCommentId < 1 ||
+      (requireExactStatusComment !== undefined && typeof requireExactStatusComment !== "boolean") ||
       !Number.isSafeInteger(observedAt) ||
       observedAt < 1
     ) {
@@ -6864,6 +6866,7 @@ export class ExactReviewQueue {
         statusMarker,
         commandCommentId,
         completionCommentId,
+        ...(requireExactStatusComment ? { requireExactStatusComment: true } : {}),
         observedAt,
       });
       if (result.accepted && result.projection) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -6845,6 +6845,7 @@ export class ExactReviewQueue {
           : "";
     const commandCommentId = Number(body.command_comment_id);
     const completionCommentId = Number(body.completion_comment_id);
+    const statusCommentId = body.status_comment_id;
     const requireExactStatusComment = body.require_exact_status_comment;
     const observedAt = Number(body.observed_at);
     if (
@@ -6854,6 +6855,8 @@ export class ExactReviewQueue {
       commandCommentId < 1 ||
       !Number.isSafeInteger(completionCommentId) ||
       completionCommentId < 1 ||
+      (statusCommentId !== undefined &&
+        (!Number.isSafeInteger(statusCommentId) || Number(statusCommentId) < 1)) ||
       (requireExactStatusComment !== undefined && typeof requireExactStatusComment !== "boolean") ||
       !Number.isSafeInteger(observedAt) ||
       observedAt < 1
@@ -6866,6 +6869,7 @@ export class ExactReviewQueue {
         statusMarker,
         commandCommentId,
         completionCommentId,
+        ...(statusCommentId === undefined ? {} : { statusCommentId: Number(statusCommentId) }),
         ...(requireExactStatusComment ? { requireExactStatusComment: true } : {}),
         observedAt,
       });

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2109,15 +2109,11 @@ async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
       const receipt = objectValue(parseJsonObject(body));
       const statusMarker = String(receipt.status_marker || "");
       const target = String(receipt.canonical_target_key || "").match(/^([^#]+)#(\d+)$/);
-      const admittedCommentId = Number(receipt.status_comment_id);
       const completionCommentId = Number(receipt.completion_comment_id);
       const completedAt = exactWebhookTimestamp(receipt.completed_at);
       if (
         result.accepted === true &&
         target &&
-        Number.isSafeInteger(admittedCommentId) &&
-        admittedCommentId > 0 &&
-        admittedCommentId !== completionCommentId &&
         completedAt &&
         /<!--\s*clawsweeper-command-status:\d+:(review|re_review):/i.test(statusMarker)
       ) {
@@ -4244,6 +4240,14 @@ export function mergeBayJourneyState(previous, triggers, completions, generatedA
     const completion = normalizeBayJourneyCompletion(value);
     if (!completion) continue;
     const current =
+      [...records.values()].find(
+        (record) =>
+          record.repository === completion.repository &&
+          record.number === completion.number &&
+          record.source_comment_id === completion.source_comment_id &&
+          record.completion_comment_id === completion.completion_comment_id &&
+          record.completed_at === completion.completed_at,
+      ) ||
       [...records.values()]
         .filter(
           (record) =>
@@ -4259,14 +4263,6 @@ export function mergeBayJourneyState(previous, triggers, completions, generatedA
             (Date.parse(String(right.triggered_at || "")) || 0) -
             (Date.parse(String(left.triggered_at || "")) || 0),
         )[0] ||
-      [...records.values()].find(
-        (record) =>
-          record.repository === completion.repository &&
-          record.number === completion.number &&
-          record.source_comment_id === completion.source_comment_id &&
-          record.completion_comment_id === completion.completion_comment_id &&
-          record.completed_at === completion.completed_at,
-      ) ||
       records.get(completion.id) ||
       {};
     const recordId = current.id || completion.id;

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -695,7 +695,7 @@ export default {
       url.pathname === "/internal/exact-review/lifecycle/command-ack/observed" &&
       request.method === "POST"
     )
-      return authenticatedExactReviewQueueRequest(request, env, "/lifecycle/command-ack/observed");
+      return authenticatedLifecycleCommandAcknowledgement(request, env, ctx);
     if (url.pathname === "/internal/exact-review/review-telemetry" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/review-telemetry");
     if (url.pathname === "/internal/exact-review/review-run-telemetry" && request.method === "POST")
@@ -1158,13 +1158,23 @@ async function githubWebhook(request, env, ctx) {
 
   const completion = bayJourneyCompletionFromGithubWebhook({ event, payload, env });
   if (completion) {
-    await recordLifecycleCommandAcknowledgement(env, completion);
+    if (!(await recordLifecycleCommandAcknowledgement(env, completion))) {
+      return json(
+        { ok: true, accepted: false, reason: "unmatched lifecycle acknowledgement" },
+        202,
+      );
+    }
     await recordBayJourneyTelemetry(env, ctx, [], [completion]);
     return json({ ok: true, accepted: false, reason: "recorded Bay journey completion" }, 202);
   }
   const acknowledgement = lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env });
   if (acknowledgement) {
-    await recordLifecycleCommandAcknowledgement(env, acknowledgement);
+    if (!(await recordLifecycleCommandAcknowledgement(env, acknowledgement))) {
+      return json(
+        { ok: true, accepted: false, reason: "unmatched lifecycle acknowledgement" },
+        202,
+      );
+    }
     return json({ ok: true, accepted: false, reason: "recorded lifecycle acknowledgement" }, 202);
   }
 
@@ -1412,6 +1422,7 @@ function lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env 
     completion_kind: "final_command_status",
     completion_comment_id: Number(comment.id),
     status_marker: status?.[0] ?? null,
+    ...(legacyCommand ? { require_exact_status_comment: true } : {}),
   };
 }
 
@@ -1717,7 +1728,7 @@ function exactReviewQueueStub(env): DurableObjectStub | null {
 
 async function recordLifecycleCommandAcknowledgement(env, completion) {
   const queue = exactReviewQueueStub(env);
-  if (!queue) return;
+  if (!queue) return true;
   const observedAt = Date.parse(String(completion.completed_at || ""));
   const response = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
@@ -1728,11 +1739,14 @@ async function recordLifecycleCommandAcknowledgement(env, completion) {
         status_marker: completion.status_marker,
         command_comment_id: completion.source_comment_id,
         completion_comment_id: completion.completion_comment_id,
+        ...(completion.require_exact_status_comment ? { require_exact_status_comment: true } : {}),
         observed_at: Number.isFinite(observedAt) ? observedAt : Date.now(),
       }),
     }),
   );
   if (!response.ok) throw new Error("lifecycle acknowledgement receipt unavailable");
+  const result = objectValue(await response.json());
+  return result.accepted !== false;
 }
 
 async function reserveExactReviewSourceAuthority(
@@ -2053,7 +2067,12 @@ async function authenticatedExactReviewEnqueue(request, env) {
   );
 }
 
-async function authenticatedExactReviewQueueRequest(request, env, path: string) {
+async function authenticatedExactReviewQueueRequest(
+  request,
+  env,
+  path: string,
+  onAuthenticatedResponse?: (body: string, response: Response) => Promise<void>,
+) {
   const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
   if (!secret) return json({ error: "webhook_not_configured" }, 503);
   const body = await request.text();
@@ -2061,7 +2080,7 @@ async function authenticatedExactReviewQueueRequest(request, env, path: string) 
   if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {
     return json({ error: "invalid_signature" }, 401);
   }
-  return exactReviewQueueRequest(
+  const response = await exactReviewQueueRequest(
     env,
     path,
     new Request(`https://clawsweeper-exact-review-queue${path}`, {
@@ -2069,6 +2088,56 @@ async function authenticatedExactReviewQueueRequest(request, env, path: string) 
       headers: { "content-type": "application/json" },
       body,
     }),
+  );
+  if (onAuthenticatedResponse) await onAuthenticatedResponse(body, response);
+  return response;
+}
+
+async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
+  return authenticatedExactReviewQueueRequest(
+    request,
+    env,
+    "/lifecycle/command-ack/observed",
+    async (body, response) => {
+      if (!env.STATUS_STORE || !response.ok) return;
+      const result = objectValue(
+        await response
+          .clone()
+          .json()
+          .catch(() => null),
+      );
+      const receipt = objectValue(parseJsonObject(body));
+      const statusMarker = String(receipt.status_marker || "");
+      const target = String(receipt.canonical_target_key || "").match(/^([^#]+)#(\d+)$/);
+      const admittedCommentId = Number(receipt.status_comment_id);
+      const completionCommentId = Number(receipt.completion_comment_id);
+      const completedAt = exactWebhookTimestamp(receipt.completed_at);
+      if (
+        result.accepted === true &&
+        target &&
+        Number.isSafeInteger(admittedCommentId) &&
+        admittedCommentId > 0 &&
+        admittedCommentId !== completionCommentId &&
+        completedAt &&
+        /<!--\s*clawsweeper-command-status:\d+:(review|re_review):/i.test(statusMarker)
+      ) {
+        await recordBayJourneyTelemetry(
+          env,
+          ctx,
+          [],
+          [
+            {
+              repository: target[1],
+              number: Number(target[2]),
+              source_comment_id: Number(receipt.command_comment_id),
+              completed_at: completedAt,
+              completion_kind: "final_command_status",
+              completion_comment_id: completionCommentId,
+            },
+          ],
+        );
+      }
+    },
   );
 }
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1345,7 +1345,10 @@ function bayJourneyTriggerFromGithubWebhook({ decision, payload, deliveryId }) {
 
 function bayJourneyCompletionFromGithubWebhook({ event, payload, env }) {
   const completion = lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env });
-  return completion?.status_marker ? completion : null;
+  return completion?.status_marker &&
+    /<!--\s*clawsweeper-command-status:\d+:(review|re_review):/i.test(completion.status_marker)
+    ? completion
+    : null;
 }
 
 function lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env }) {
@@ -1359,8 +1362,24 @@ function lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env 
   const repository = canonicalRepository.toLowerCase();
   const number = Number(issue.number);
   const body = String(comment.body || "");
-  const sourceCommentId = Number(body.match(/<!--\s*clawsweeper-command-ack:(\d+)\s*-->/i)?.[1]);
-  const status = body.match(/<!--\s*clawsweeper-command-status:(\d+):(review|re_review):[^>]*-->/i);
+  const acknowledgement = body.match(/<!--\s*clawsweeper-command-ack:(\d+)\s*-->/i);
+  const hasAcknowledgement = /<!--\s*clawsweeper-command-ack:[^>]*-->/i.test(body);
+  const status = body.match(/<!--\s*clawsweeper-command-status:(\d+):([^:\s>]+):([^:\s>]+)\s*-->/i);
+  const legacyCommands =
+    !hasAcknowledgement && status
+      ? Array.from(
+          body.matchAll(
+            /<!--\s*clawsweeper-command:(\d+):(?:[^>]*:)?([^:\s>]+):([^:\s>]+)\s*-->/gi,
+          ),
+        )
+      : [];
+  const legacyCommand =
+    legacyCommands.length === 1 &&
+    legacyCommands[0]![2] === status?.[2] &&
+    legacyCommands[0]![3] === status?.[3]
+      ? legacyCommands[0]![1]
+      : undefined;
+  const sourceCommentId = Number(acknowledgement?.[1] ?? legacyCommand ?? Number.NaN);
   const completedAt = exactWebhookTimestamp(comment.updated_at || comment.created_at);
   const progress =
     /<!--\s*clawsweeper-command-progress:start\s*-->([\s\S]*?)<!--\s*clawsweeper-command-progress:end\s*-->/i.exec(

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1158,18 +1158,28 @@ async function githubWebhook(request, env, ctx) {
 
   const completion = bayJourneyCompletionFromGithubWebhook({ event, payload, env });
   if (completion) {
-    if (!(await recordLifecycleCommandAcknowledgement(env, completion))) {
+    const acknowledgement = await recordLifecycleCommandAcknowledgement(env, completion);
+    if (!acknowledgement.accepted) {
       return json(
         { ok: true, accepted: false, reason: "unmatched lifecycle acknowledgement" },
         202,
       );
     }
-    await recordBayJourneyTelemetry(env, ctx, [], [completion]);
+    await recordBayJourneyTelemetry(
+      env,
+      ctx,
+      [],
+      [
+        acknowledgement.sourceDeliveryId
+          ? { ...completion, source_delivery_id: acknowledgement.sourceDeliveryId }
+          : completion,
+      ],
+    );
     return json({ ok: true, accepted: false, reason: "recorded Bay journey completion" }, 202);
   }
   const acknowledgement = lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env });
   if (acknowledgement) {
-    if (!(await recordLifecycleCommandAcknowledgement(env, acknowledgement))) {
+    if (!(await recordLifecycleCommandAcknowledgement(env, acknowledgement)).accepted) {
       return json(
         { ok: true, accepted: false, reason: "unmatched lifecycle acknowledgement" },
         202,
@@ -1308,6 +1318,7 @@ async function githubWebhook(request, env, ctx) {
     token: dispatchToken,
     decision: commentDecision,
     statusCommentId,
+    sourceDeliveryId: trigger?.source_delivery_id,
   });
   settleFastAckComments({
     token: targetToken,
@@ -1728,7 +1739,7 @@ function exactReviewQueueStub(env): DurableObjectStub | null {
 
 async function recordLifecycleCommandAcknowledgement(env, completion) {
   const queue = exactReviewQueueStub(env);
-  if (!queue) return true;
+  if (!queue) return { accepted: true, sourceDeliveryId: null };
   const observedAt = Date.parse(String(completion.completed_at || ""));
   const response = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
@@ -1739,6 +1750,7 @@ async function recordLifecycleCommandAcknowledgement(env, completion) {
         status_marker: completion.status_marker,
         command_comment_id: completion.source_comment_id,
         completion_comment_id: completion.completion_comment_id,
+        include_delivery_identity: true,
         ...(completion.require_exact_status_comment ? { require_exact_status_comment: true } : {}),
         observed_at: Number.isFinite(observedAt) ? observedAt : Date.now(),
       }),
@@ -1746,7 +1758,10 @@ async function recordLifecycleCommandAcknowledgement(env, completion) {
   );
   if (!response.ok) throw new Error("lifecycle acknowledgement receipt unavailable");
   const result = objectValue(await response.json());
-  return result.accepted !== false;
+  return {
+    accepted: result.accepted !== false,
+    sourceDeliveryId: nullableString(result.source_delivery_id),
+  };
 }
 
 async function reserveExactReviewSourceAuthority(
@@ -2126,6 +2141,9 @@ async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
               repository: target[1],
               number: Number(target[2]),
               source_comment_id: Number(receipt.command_comment_id),
+              ...(nullableString(result.source_delivery_id)
+                ? { source_delivery_id: nullableString(result.source_delivery_id) }
+                : {}),
               completed_at: completedAt,
               completion_kind: "final_command_status",
               completion_comment_id: completionCommentId,
@@ -2604,7 +2622,7 @@ async function addIssueCommentReaction({ token, repo, commentId, content }) {
   });
 }
 
-async function dispatchClawsweeperComment({ token, decision, statusCommentId }) {
+async function dispatchClawsweeperComment({ token, decision, statusCommentId, sourceDeliveryId }) {
   const exactVersion =
     decision.commentUpdatedAt && typeof decision.commentBody === "string"
       ? {
@@ -2625,8 +2643,9 @@ async function dispatchClawsweeperComment({ token, decision, statusCommentId }) 
         item_number: decision.itemNumber,
         comment_id: decision.commentId,
         status_comment_id: statusCommentId,
-        source_event: "issue_comment",
+        ...(sourceDeliveryId ? {} : { source_event: "issue_comment" }),
         source_action: decision.sourceAction,
+        ...(sourceDeliveryId ? { source_delivery_id: sourceDeliveryId } : {}),
         ...exactVersion,
       },
     },
@@ -4096,13 +4115,15 @@ function bayJourneyCompletionId(
   sourceCommentId,
   completionCommentId,
   completedAt,
+  sourceDeliveryId,
 ) {
   const completedMarker = Date.parse(completedAt);
   const marker =
     Number.isSafeInteger(Number(completionCommentId)) && Number(completionCommentId) > 0
       ? `comment:${Number(completionCommentId)}:at:${completedMarker}`
       : `at:${completedMarker}`;
-  return `${String(repository || "").toLowerCase()}#${Number(itemNumber)}:command:${Number(sourceCommentId)}:completion:${marker}`;
+  const delivery = sourceDeliveryId ? `:delivery:${sourceDeliveryId}` : "";
+  return `${String(repository || "").toLowerCase()}#${Number(itemNumber)}:command:${Number(sourceCommentId)}${delivery}:completion:${marker}`;
 }
 
 function bayJourneyTimestamp(value) {
@@ -4143,6 +4164,7 @@ function normalizeBayJourneyCompletion(value) {
   const repository = nullableString(completion.repository)?.toLowerCase() || null;
   const number = Number(completion.number);
   const sourceCommentId = Number(completion.source_comment_id);
+  const sourceDeliveryId = nullableString(completion.source_delivery_id);
   const completedAt = bayJourneyTimestamp(completion.completed_at);
   const completionKind = nullableString(completion.completion_kind);
   const completionCommentId = Number(completion.completion_comment_id);
@@ -4163,11 +4185,13 @@ function normalizeBayJourneyCompletion(value) {
       sourceCommentId,
       completionCommentId,
       completedAt,
+      sourceDeliveryId,
     ),
     item_key: `${repository}#${number}`,
     repository,
     number,
     source_comment_id: sourceCommentId,
+    ...(sourceDeliveryId ? { source_delivery_id: sourceDeliveryId } : {}),
     completed_at: completedAt,
     completion_kind: completionKind || "final_command_status",
     completion_comment_id:
@@ -4180,7 +4204,10 @@ function normalizeBayJourneyCompletion(value) {
 function normalizeBayJourneyRecord(value) {
   const record = objectValue(value);
   const trigger = normalizeBayJourneyTrigger(record);
-  const completion = normalizeBayJourneyCompletion(record);
+  const completion = normalizeBayJourneyCompletion({
+    ...record,
+    source_delivery_id: nullableString(record.completion_source_delivery_id),
+  });
   if (!trigger && !completion) return null;
   const source = trigger || completion;
   return {
@@ -4189,11 +4216,14 @@ function normalizeBayJourneyRecord(value) {
     repository: source.repository,
     number: source.number,
     source_comment_id: source.source_comment_id,
-    source_delivery_id: trigger?.source_delivery_id || null,
+    source_delivery_id: trigger?.source_delivery_id || completion?.source_delivery_id || null,
     triggered_at: trigger?.triggered_at || null,
     completed_at: completion?.completed_at || null,
     completion_kind: completion?.completion_kind || null,
     completion_comment_id: completion?.completion_comment_id || null,
+    ...(completion?.source_delivery_id
+      ? { completion_source_delivery_id: completion.source_delivery_id }
+      : {}),
   };
 }
 
@@ -4219,13 +4249,20 @@ export function mergeBayJourneyState(previous, triggers, completions, generatedA
           record.repository === trigger.repository &&
           record.number === trigger.number &&
           record.source_comment_id === trigger.source_comment_id &&
+          (!record.source_delivery_id ||
+            !trigger.source_delivery_id ||
+            record.source_delivery_id === trigger.source_delivery_id) &&
           !record.triggered_at &&
           (Date.parse(String(record.completed_at || "")) || 0) >= Date.parse(trigger.triggered_at),
       )
       .sort(
         (left, right) =>
+          (trigger.source_delivery_id
+            ? Number(right.source_delivery_id === trigger.source_delivery_id) -
+              Number(left.source_delivery_id === trigger.source_delivery_id)
+            : 0) ||
           (Date.parse(String(left.completed_at || "")) || 0) -
-          (Date.parse(String(right.completed_at || "")) || 0),
+            (Date.parse(String(right.completed_at || "")) || 0),
       )[0];
     const current = records.get(trigger.id) || completedOrphan || {};
     if (completedOrphan && completedOrphan.id !== trigger.id) records.delete(completedOrphan.id);
@@ -4239,36 +4276,122 @@ export function mergeBayJourneyState(previous, triggers, completions, generatedA
   for (const value of Array.isArray(completions) ? completions : []) {
     const completion = normalizeBayJourneyCompletion(value);
     if (!completion) continue;
-    const current =
-      [...records.values()].find(
+    if (completion.source_delivery_id) {
+      const legacyCompletionOnIdentifiedJourney = [...records.values()].find(
         (record) =>
           record.repository === completion.repository &&
           record.number === completion.number &&
           record.source_comment_id === completion.source_comment_id &&
-          record.completion_comment_id === completion.completion_comment_id &&
-          record.completed_at === completion.completed_at,
-      ) ||
+          record.source_delivery_id === completion.source_delivery_id &&
+          record.triggered_at &&
+          record.completed_at &&
+          !record.completion_source_delivery_id &&
+          (record.completed_at !== completion.completed_at ||
+            record.completion_comment_id !== completion.completion_comment_id),
+      );
+      if (legacyCompletionOnIdentifiedJourney) {
+        const legacyCompletion = normalizeBayJourneyCompletion({
+          ...legacyCompletionOnIdentifiedJourney,
+          source_delivery_id: undefined,
+        });
+        if (legacyCompletion) {
+          records.set(legacyCompletion.id, {
+            ...legacyCompletion,
+            id: legacyCompletion.id,
+            source_delivery_id: null,
+            triggered_at: null,
+            completed_at: legacyCompletion.completed_at,
+            completion_kind: legacyCompletion.completion_kind,
+            completion_comment_id: legacyCompletion.completion_comment_id,
+          });
+        }
+        records.set(legacyCompletionOnIdentifiedJourney.id, {
+          ...legacyCompletionOnIdentifiedJourney,
+          completed_at: null,
+          completion_kind: null,
+          completion_comment_id: null,
+        });
+      }
+    }
+    let exactCompletion = [...records.values()].find(
+      (record) =>
+        record.repository === completion.repository &&
+        record.number === completion.number &&
+        record.source_comment_id === completion.source_comment_id &&
+        (!completion.source_delivery_id ||
+          !record.completion_source_delivery_id ||
+          record.completion_source_delivery_id === completion.source_delivery_id) &&
+        record.completion_comment_id === completion.completion_comment_id &&
+        record.completed_at === completion.completed_at,
+    );
+    if (
+      exactCompletion &&
+      completion.source_delivery_id &&
+      exactCompletion.source_delivery_id !== completion.source_delivery_id &&
+      !exactCompletion.completion_source_delivery_id
+    ) {
+      if (!exactCompletion.triggered_at) {
+        records.delete(exactCompletion.id);
+      } else {
+        records.set(exactCompletion.id, {
+          ...exactCompletion,
+          completed_at: null,
+          completion_kind: null,
+          completion_comment_id: null,
+        });
+      }
+      exactCompletion = undefined;
+    }
+    const current =
+      exactCompletion ||
+      (completion.source_delivery_id
+        ? [...records.values()].find(
+            (record) =>
+              record.repository === completion.repository &&
+              record.number === completion.number &&
+              record.source_comment_id === completion.source_comment_id &&
+              record.source_delivery_id === completion.source_delivery_id &&
+              record.completion_source_delivery_id === completion.source_delivery_id &&
+              (!record.triggered_at ||
+                Date.parse(record.triggered_at) <= Date.parse(completion.completed_at)),
+          )
+        : undefined) ||
       [...records.values()]
         .filter(
           (record) =>
             record.repository === completion.repository &&
             record.number === completion.number &&
             record.source_comment_id === completion.source_comment_id &&
+            (!completion.source_delivery_id ||
+              !record.source_delivery_id ||
+              record.source_delivery_id === completion.source_delivery_id) &&
             record.triggered_at &&
             !record.completed_at &&
             Date.parse(record.triggered_at) <= Date.parse(completion.completed_at),
         )
         .sort(
           (left, right) =>
+            (completion.source_delivery_id
+              ? Number(right.source_delivery_id === completion.source_delivery_id) -
+                Number(left.source_delivery_id === completion.source_delivery_id)
+              : 0) ||
             (Date.parse(String(right.triggered_at || "")) || 0) -
-            (Date.parse(String(left.triggered_at || "")) || 0),
+              (Date.parse(String(left.triggered_at || "")) || 0),
         )[0] ||
       records.get(completion.id) ||
       {};
     const recordId = current.id || completion.id;
     const currentCompletedAt = Date.parse(String(current.completed_at || ""));
     const completionAt = Date.parse(completion.completed_at);
-    if (Number.isFinite(currentCompletedAt) && currentCompletedAt > completionAt) continue;
+    if (
+      Number.isFinite(currentCompletedAt) &&
+      (currentCompletedAt > completionAt ||
+        (currentCompletedAt === completionAt &&
+          Number(current.completion_comment_id || 0) >
+            Number(completion.completion_comment_id || 0)))
+    ) {
+      continue;
+    }
     if (current.id && current.id !== recordId) records.delete(current.id);
     records.set(recordId, {
       ...current,
@@ -4277,6 +4400,49 @@ export function mergeBayJourneyState(previous, triggers, completions, generatedA
       completed_at: completion.completed_at,
       completion_kind: completion.completion_kind,
       completion_comment_id: completion.completion_comment_id,
+      ...(completion.source_delivery_id
+        ? { completion_source_delivery_id: completion.source_delivery_id }
+        : {}),
+    });
+  }
+  for (const record of records.values()) {
+    if (!record.triggered_at || record.completed_at || !record.source_delivery_id) continue;
+    const completedOrphan = [...records.values()]
+      .filter(
+        (candidate) =>
+          !candidate.triggered_at &&
+          candidate.completed_at &&
+          candidate.repository === record.repository &&
+          candidate.number === record.number &&
+          candidate.source_comment_id === record.source_comment_id &&
+          (candidate.source_delivery_id === record.source_delivery_id ||
+            (!candidate.source_delivery_id &&
+              [...records.values()].filter(
+                (journey) =>
+                  journey.triggered_at &&
+                  !journey.completed_at &&
+                  journey.repository === candidate.repository &&
+                  journey.number === candidate.number &&
+                  journey.source_comment_id === candidate.source_comment_id &&
+                  Date.parse(journey.triggered_at) <= Date.parse(candidate.completed_at),
+              ).length === 1)) &&
+          Date.parse(candidate.completed_at) >= Date.parse(record.triggered_at),
+      )
+      .sort(
+        (left, right) =>
+          (Date.parse(String(left.completed_at || "")) || 0) -
+          (Date.parse(String(right.completed_at || "")) || 0),
+      )[0];
+    if (!completedOrphan) continue;
+    records.delete(completedOrphan.id);
+    records.set(record.id, {
+      ...record,
+      completed_at: completedOrphan.completed_at,
+      completion_kind: completedOrphan.completion_kind,
+      completion_comment_id: completedOrphan.completion_comment_id,
+      ...(completedOrphan.completion_source_delivery_id
+        ? { completion_source_delivery_id: completedOrphan.completion_source_delivery_id }
+        : {}),
     });
   }
   const journeys = [...records.values()]

--- a/src/repair/comment-router-ledger-merge.ts
+++ b/src/repair/comment-router-ledger-merge.ts
@@ -13,7 +13,41 @@ export function mergeCommentRouterLedgers(localText: string, remoteText: string)
   for (const entry of [...remote.commands, ...local.commands]) {
     const key = ledgerEntryKey(entry);
     const previous = byKey.get(key);
-    if (!previous || compareEntries(previous, entry) < 0) byKey.set(key, entry);
+    if (!previous) {
+      byKey.set(key, entry);
+      continue;
+    }
+    const winner = compareEntries(previous, entry) < 0 ? entry : previous;
+    const alternate = winner === entry ? previous : entry;
+    const matchingCommentIdentity =
+      winner.repo === alternate.repo &&
+      winner.comment_id === alternate.comment_id &&
+      winner.comment_updated_at === alternate.comment_updated_at &&
+      typeof winner.comment_body_sha256 === "string" &&
+      /^[a-f0-9]{64}$/i.test(winner.comment_body_sha256) &&
+      winner.comment_body_sha256 === alternate.comment_body_sha256;
+    const deliveryIds = [winner.source_delivery_id, alternate.source_delivery_id]
+      .map((value) => String(value ?? ""))
+      .filter((value) => /^[A-Za-z0-9_.:-]{1,200}$/.test(value))
+      .sort();
+    const conflicted =
+      winner.source_delivery_conflict === true ||
+      alternate.source_delivery_conflict === true ||
+      (!matchingCommentIdentity &&
+        (deliveryIds.length > 0 ||
+          typeof winner.comment_body_sha256 === "string" ||
+          typeof alternate.comment_body_sha256 === "string"));
+    if (conflicted) {
+      const { source_delivery_id: _discardedDeliveryId, ...unverifiedWinner } = winner;
+      byKey.set(key, { ...unverifiedWinner, source_delivery_conflict: true });
+    } else {
+      byKey.set(
+        key,
+        matchingCommentIdentity && deliveryIds.length > 0
+          ? { ...winner, source_delivery_id: deliveryIds[0] }
+          : winner,
+      );
+    }
   }
 
   const commands = [...byKey.values()]
@@ -59,7 +93,16 @@ function compareEntries(left: JsonRecord, right: JsonRecord): number {
   if (status !== 0) return status;
   const processed = timestamp(left.processed_at) - timestamp(right.processed_at);
   if (processed !== 0) return processed;
-  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+  return canonicalEntryText(left).localeCompare(canonicalEntryText(right));
+}
+
+function canonicalEntryText(entry: JsonRecord): string {
+  const {
+    source_delivery_id: _sourceDeliveryId,
+    source_delivery_conflict: _sourceDeliveryConflict,
+    ...canonical
+  } = entry;
+  return JSON.stringify(canonical);
 }
 
 function compareLedgerOrder(left: JsonRecord, right: JsonRecord): number {

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -21,6 +21,7 @@ const LEDGER_COMMAND_STRING_FIELDS = [
   "comment_version_key",
   "comment_created_at",
   "comment_updated_at",
+  "source_delivery_id",
   "repo",
   "processed_at",
 ] as const;
@@ -196,6 +197,47 @@ export function exactCommentVersionMatchesLive(command: LooseRecord, live: JsonV
     String(comment.updated_at ?? "") === String(command.comment_updated_at ?? "") &&
     commentBodySha256(comment.body) === String(command.comment_body_sha256 ?? "")
   );
+}
+
+export function routedCommentSourceDeliveryId({
+  comment,
+  event,
+  priorClaim,
+  targetRepo,
+}: {
+  comment: JsonValue;
+  event: {
+    authenticated: boolean;
+    commentId: JsonValue;
+    commentUpdatedAt: JsonValue;
+    commentBodySha256: JsonValue;
+    sourceDeliveryId: JsonValue;
+  };
+  priorClaim: LooseRecord | null;
+  targetRepo: string;
+}): string | null {
+  if (priorClaim?.source_delivery_conflict === true) return null;
+  const eventDeliveryId = String(event.sourceDeliveryId ?? "").trim();
+  if (
+    event.authenticated &&
+    /^[A-Za-z0-9_.:-]{1,200}$/.test(eventDeliveryId) &&
+    exactCommentVersionMatchesLive(
+      {
+        comment_id: event.commentId,
+        comment_updated_at: event.commentUpdatedAt,
+        comment_body_sha256: event.commentBodySha256,
+      },
+      comment,
+    )
+  ) {
+    return eventDeliveryId;
+  }
+  const claimedDeliveryId = String(priorClaim?.source_delivery_id ?? "").trim();
+  return priorClaim?.repo === targetRepo &&
+    /^[A-Za-z0-9_.:-]{1,200}$/.test(claimedDeliveryId) &&
+    exactCommentVersionMatchesLive(priorClaim, comment)
+    ? claimedDeliveryId
+    : null;
 }
 
 export function exactCommentVersionFastPathDecision({
@@ -497,6 +539,9 @@ export function readLedger(file: JsonValue) {
 }
 
 export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
+  const byCommentVersion = new Map(
+    (current.commands ?? []).map((entry: JsonValue) => [ledgerEntryKey(entry), entry]),
+  );
   const compact = entries
     .filter((entry: JsonValue) =>
       ["claimed", "executed", "skipped", "waiting"].includes(entry.status),
@@ -504,6 +549,9 @@ export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
     .filter((entry: JsonValue) => !isNoopSkip(entry))
     .map((entry: JsonValue) => {
       const actions = compactLedgerActions(entry.actions);
+      const previous = byCommentVersion.get(ledgerEntryKey(entry)) as LooseRecord | undefined;
+      const deliveryConflicted =
+        entry.source_delivery_conflict === true || previous?.source_delivery_conflict === true;
       return {
         idempotency_key: entry.idempotency_key,
         comment_id: entry.comment_id,
@@ -512,6 +560,11 @@ export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
         comment_created_at: entry.comment_created_at ?? null,
         comment_updated_at: entry.comment_updated_at ?? null,
         ...(entry.comment_body_sha256 ? { comment_body_sha256: entry.comment_body_sha256 } : {}),
+        ...(deliveryConflicted
+          ? { source_delivery_conflict: true }
+          : /^[A-Za-z0-9_.:-]{1,200}$/.test(String(entry.source_delivery_id ?? ""))
+            ? { source_delivery_id: entry.source_delivery_id }
+            : {}),
         repo: entry.repo,
         issue_number: entry.issue_number,
         author: entry.author,
@@ -543,9 +596,6 @@ export function appendLedger(current: LooseRecord, entries: LooseRecord[]) {
       };
     });
   if (compact.length === 0) return false;
-  const byCommentVersion = new Map(
-    (current.commands ?? []).map((entry: JsonValue) => [ledgerEntryKey(entry), entry]),
-  );
   let changed = false;
   for (const entry of compact) {
     const key = ledgerEntryKey(entry);
@@ -574,6 +624,19 @@ function validatedLedgerCommand(entry: JsonValue): LooseRecord {
   }
   if (!LEDGER_COMMAND_STATUSES.has(command.status)) {
     throw new Error("comment router ledger command status is invalid");
+  }
+  if (
+    command.source_delivery_id !== undefined &&
+    command.source_delivery_id !== null &&
+    !/^[A-Za-z0-9_.:-]{1,200}$/.test(String(command.source_delivery_id))
+  ) {
+    throw new Error("comment router ledger command source_delivery_id is invalid");
+  }
+  if (
+    command.source_delivery_conflict !== undefined &&
+    (command.source_delivery_conflict !== true || command.source_delivery_id !== undefined)
+  ) {
+    throw new Error("comment router ledger delivery conflict must suppress delivery provenance");
   }
   if (
     typeof command.processed_at !== "string" ||

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -3307,10 +3307,6 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
   const requiresCommandStatus = ["re_review", "autofix", "automerge"].includes(
     String(command.intent ?? ""),
   );
-  if (requiresCommandStatus) {
-    const retainedStatusComment = findExistingCommandStatusComment(command);
-    if (retainedStatusComment?.id) command.status_comment_id = Number(retainedStatusComment.id);
-  }
   let dispatchKey = dispatchReceiptKey(command);
   const expectedTitle = `Review event item ${command.repo}#${command.issue_number} [${dispatchKey}]`;
   const claimed = claimedDispatchState({
@@ -3320,6 +3316,10 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
     expectedTitle,
   });
   if (claimed) return { ...claimed, workflow: reviewWorkflow, repo: reviewRepo };
+  if (requiresCommandStatus) {
+    const retainedStatusComment = findExistingCommandStatusComment(command);
+    if (retainedStatusComment?.id) command.status_comment_id = Number(retainedStatusComment.id);
+  }
   dispatchKey = dispatchReceiptKey(command);
   const reviewBudget =
     command.target?.kind === "pull_request"
@@ -4840,6 +4840,7 @@ function postComment(command: LooseRecord, body: string) {
         payloadPath,
       ],
     );
+    issueCommentsCache.delete(Number(command.issue_number));
     const precreatedId = Number(precreated?.id ?? 0) || 0;
     const existingId = Number(existing.id ?? 0) || 0;
     if (existingStatus && precreatedId > 0 && precreatedId !== existingId) {
@@ -4877,6 +4878,7 @@ function postComment(command: LooseRecord, body: string) {
       payloadPath,
     ],
   );
+  issueCommentsCache.delete(Number(command.issue_number));
   return { mode: "created", comment_id: null };
 }
 
@@ -5134,7 +5136,8 @@ function findExistingCommandStatusComment(command: LooseRecord) {
     : ["autofix"].includes(String(command.intent ?? ""))
       ? commandStatusMarkerPrefix(command)
       : null;
-  return ghPaged(`repos/${command.repo}/issues/${command.issue_number}/comments?per_page=100`)
+  return cachedIssueComments(command.issue_number)
+    .slice()
     .reverse()
     .find((comment: JsonValue) => {
       if (!isTrustedStatusComment(comment)) return false;

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -3269,6 +3269,13 @@ function trustedAutomationReviewLeaseBlockReason(
 }
 
 function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
+  const requiresCommandStatus = ["re_review", "autofix", "automerge"].includes(
+    String(command.intent ?? ""),
+  );
+  if (requiresCommandStatus) {
+    const retainedStatusComment = findExistingCommandStatusComment(command);
+    if (retainedStatusComment?.id) command.status_comment_id = Number(retainedStatusComment.id);
+  }
   let dispatchKey = dispatchReceiptKey(command);
   const expectedTitle = `Review event item ${command.repo}#${command.issue_number} [${dispatchKey}]`;
   const claimed = claimedDispatchState({
@@ -3288,7 +3295,7 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
   const fallbackCodexTimeoutMs = reviewBudget
     ? reviewBudget.codexTimeoutMs + MAX_MEDIA_PREPROCESSING_TIMEOUT_MS
     : null;
-  const commandStatus = ["re_review", "autofix", "automerge"].includes(String(command.intent ?? ""))
+  const commandStatus = requiresCommandStatus
     ? {
         command_status_marker: commandStatusMarker(command),
         ...(command.status_comment_id

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -113,6 +113,7 @@ import {
   isGitHubAppIntegrationAuthError,
   readLedger,
   routerDispatchReceiptKey,
+  routedCommentSourceDeliveryId,
   selectCommentsForRouting,
   shouldSuppressProcessedCommentVersion,
   stripAnsi,
@@ -224,9 +225,14 @@ if (exactCommentVersionFastPath.suppress && !exactCommentVersionFastPathCommand)
   exactCommentVersionFastPath = { suppress: false, reason: "source_drift" };
 }
 const priorDispatchClaims = new Map<string, LooseRecord>();
+const priorCommandDeliveryClaims = new Map<string, LooseRecord>();
 for (const entry of ledger.commands ?? []) {
-  if (entry.status !== "claimed") continue;
-  for (const key of dispatchClaimLookupKeys(entry)) priorDispatchClaims.set(key, entry);
+  if (entry.status === "claimed") {
+    for (const key of dispatchClaimLookupKeys(entry)) priorDispatchClaims.set(key, entry);
+  }
+  if (!["claimed", "waiting"].includes(String(entry.status ?? ""))) continue;
+  if (!entry.source_delivery_id && entry.source_delivery_conflict !== true) continue;
+  for (const key of dispatchClaimLookupKeys(entry)) priorCommandDeliveryClaims.set(key, entry);
 }
 const processedCommentVersions = forceReprocess
   ? new Set()
@@ -476,9 +482,29 @@ function routedCommandForComment(comment: JsonValue): LooseRecord | null {
   const parsed: LooseRecord = parseRoutedCommentCommand(comment, { trustedAuthors: trustedBots });
   if (!parsed) return null;
   const issueNumber = issueNumberFromUrl(comment.issue_url);
-  return {
+  const commandIdentity = {
     idempotency_key: idempotencyKey(parsed, issueNumber, comment.id, comment.updated_at),
     comment_id: String(comment.id),
+    comment_updated_at: comment.updated_at,
+    ...forcedReplayCommandFields({ forceReprocess, attemptId }),
+  };
+  const sourceDeliveryId = routedCommentSourceDeliveryId({
+    comment,
+    event: {
+      authenticated:
+        args["comment-event-auth"] === "github_webhook_v1" &&
+        args["source-event"] === "issue_comment" &&
+        isAllowedMutationActor(args["dispatch-actor"], trustedBots),
+      commentId: commentIds.size === 1 ? [...commentIds][0] : null,
+      commentUpdatedAt: args["comment-updated-at"],
+      commentBodySha256: args["comment-body-sha256"],
+      sourceDeliveryId: args["source-delivery-id"],
+    },
+    priorClaim: priorCommandDeliveryClaim(commandIdentity),
+    targetRepo,
+  });
+  return {
+    ...commandIdentity,
     comment_version_key: commentVersionKey({
       comment_id: comment.id,
       comment_updated_at: comment.updated_at,
@@ -493,6 +519,7 @@ function routedCommandForComment(comment: JsonValue): LooseRecord | null {
     comment_created_at: comment.created_at,
     comment_updated_at: comment.updated_at,
     comment_body_sha256: commentBodySha256(comment.body),
+    ...(sourceDeliveryId ? { source_delivery_id: sourceDeliveryId } : {}),
     status_comment_id:
       statusCommentId &&
       commentIds.size <= 1 &&
@@ -578,6 +605,14 @@ function actionNeedsDurableDispatchClaim(action: JsonValue) {
 function priorDispatchClaim(command: LooseRecord) {
   for (const key of dispatchClaimLookupKeys(command)) {
     const claim = priorDispatchClaims.get(key);
+    if (claim) return claim;
+  }
+  return null;
+}
+
+function priorCommandDeliveryClaim(command: LooseRecord) {
+  for (const key of dispatchClaimLookupKeys(command)) {
+    const claim = priorCommandDeliveryClaims.get(key);
     if (claim) return claim;
   }
   return null;
@@ -3311,11 +3346,16 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
       item_number: String(command.issue_number),
       item_kind: command.target?.kind ?? "",
       dispatch_key: dispatchKey,
+      ...(command.source_delivery_id
+        ? { source_delivery_id: String(command.source_delivery_id) }
+        : {}),
       additional_prompt: freeformReviewPrompt(command),
       ...(reviewBudget
         ? {
-            codex_timeout_ms: reviewBudget.codexTimeoutMs,
-            media_proof_timeout_ms: reviewBudget.mediaProofTimeoutMs,
+            review_options: {
+              codex_timeout_ms: reviewBudget.codexTimeoutMs,
+              media_proof_timeout_ms: reviewBudget.mediaProofTimeoutMs,
+            },
           }
         : {}),
       ...commandStatus,

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -54,6 +54,7 @@ type TerminalStatusReceipt = {
 type CommandStatusUpdateResult = {
   outcome: CommandStatusUpdateOutcome;
   terminalStatusReceipt?: TerminalStatusReceipt;
+  terminalStatusCompletedAt?: string;
 };
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -113,7 +114,11 @@ async function updateCommandStatus(options: Options): Promise<CommandStatusUpdat
       status: "unchanged",
       mutation: false,
     });
-    return { outcome: "unchanged", terminalStatusReceipt };
+    return {
+      outcome: "unchanged",
+      terminalStatusReceipt,
+      terminalStatusCompletedAt: verifiedTerminalStatusCompletedAt(comment),
+    };
   }
   const body = mergeCommandProgressSection(comment.body, options);
   if (body === comment.body) {
@@ -125,8 +130,9 @@ async function updateCommandStatus(options: Options): Promise<CommandStatusUpdat
     return { outcome: "unchanged" };
   }
   const payload = writePayload(repoRoot(), `command-status-progress-${comment.id}`, { body });
+  let mutationResponse: string;
   try {
-    runCommandLifecycleMutation(lifecycle, {
+    mutationResponse = runCommandLifecycleMutation(lifecycle, {
       kind: "status_comment_update",
       identity: {
         repository: options.repo,
@@ -156,7 +162,14 @@ async function updateCommandStatus(options: Options): Promise<CommandStatusUpdat
   const verifiedReceipt = verifiedTerminalStatusReceipt({ ...comment, body }, options);
   return {
     outcome: "completed",
-    ...(verifiedReceipt ? { terminalStatusReceipt: verifiedReceipt } : {}),
+    ...(verifiedReceipt
+      ? {
+          terminalStatusReceipt: verifiedReceipt,
+          terminalStatusCompletedAt: verifiedTerminalStatusCompletedAt(
+            JSON.parse(mutationResponse),
+          ),
+        }
+      : {}),
   };
 }
 
@@ -164,10 +177,12 @@ async function runCommandStatusUpdate(options: Options) {
   let commandError: unknown = null;
   let outcome: CommandStatusUpdateOutcome | null = null;
   let terminalStatusReceipt: TerminalStatusReceipt | undefined;
+  let terminalStatusCompletedAt: string | undefined;
   try {
     const result = await updateCommandStatus(options);
     outcome = result.outcome;
     terminalStatusReceipt = result.terminalStatusReceipt;
+    terminalStatusCompletedAt = result.terminalStatusCompletedAt;
   } catch (error) {
     commandError = error;
     recordCommandLifecycleFailure(commandStatusLifecycle(options), {
@@ -201,11 +216,20 @@ async function runCommandStatusUpdate(options: Options) {
         "terminal_status_verified=true",
         `command_comment_id=${terminalStatusReceipt.commandCommentId}`,
         `completion_comment_id=${terminalStatusReceipt.completionCommentId}`,
+        `completion_completed_at=${terminalStatusCompletedAt}`,
         "",
       ].join("\n"),
     );
   }
   if (commandError) throw commandError;
+}
+
+function verifiedTerminalStatusCompletedAt(comment: LooseRecord): string {
+  const completedAt = String(comment.updated_at ?? "").trim();
+  if (!completedAt || !Number.isFinite(Date.parse(completedAt))) {
+    throw new Error("verified terminal status comment has no valid update timestamp");
+  }
+  return completedAt;
 }
 
 export function terminalLockedConversationSkip(
@@ -266,6 +290,13 @@ async function findCommandStatusComment(
     }
     const match = selectCommandStatusComment(comments, options);
     if (match) {
+      if (
+        options.statusCommentId &&
+        Number(match.id) !== options.statusCommentId &&
+        (!exact || statusMarkerDiffersFromRequested(exact.body, options.marker))
+      ) {
+        options.statusCommentId = Number(match.id);
+      }
       pruneDuplicateCommandAckComments({ comments, keep: match, options, lifecycle });
       return match;
     }
@@ -474,7 +505,9 @@ export function verifiedTerminalStatusReceipt(
     const commandCommentId =
       commandCommentIds.length === 1
         ? commandCommentIds[0]!
-        : commandCommentIds.length === 0 && !hasCommandAckMarker(comment.body)
+        : commandCommentIds.length === 0 &&
+            !hasCommandAckMarker(comment.body) &&
+            (options.statusCommentId === null || completionCommentId === options.statusCommentId)
           ? legacyCommandCommentId(comment.body, options.marker)
           : null;
     return commandCommentId === null ? null : { commandCommentId, completionCommentId };

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -153,7 +153,11 @@ async function updateCommandStatus(options: Options): Promise<CommandStatusUpdat
     status: "completed",
     mutation: true,
   });
-  return { outcome: "completed" };
+  const verifiedReceipt = verifiedTerminalStatusReceipt({ ...comment, body }, options);
+  return {
+    outcome: "completed",
+    ...(verifiedReceipt ? { terminalStatusReceipt: verifiedReceipt } : {}),
+  };
 }
 
 async function runCommandStatusUpdate(options: Options) {
@@ -464,14 +468,16 @@ export function verifiedTerminalStatusReceipt(
     return null;
   }
   if (options.marker) {
-    if (
-      commandCommentIds.length !== 1 ||
-      statusMarkers.length !== 1 ||
-      statusMarkers[0] !== options.marker
-    ) {
+    if (statusMarkers.length !== 1 || statusMarkers[0] !== options.marker) {
       return null;
     }
-    return { commandCommentId: commandCommentIds[0]!, completionCommentId };
+    const commandCommentId =
+      commandCommentIds.length === 1
+        ? commandCommentIds[0]!
+        : commandCommentIds.length === 0 && !hasCommandAckMarker(comment.body)
+          ? legacyCommandCommentId(comment.body, options.marker)
+          : null;
+    return commandCommentId === null ? null : { commandCommentId, completionCommentId };
   }
   const statusCommentId = options.statusCommentId;
   if (
@@ -510,6 +516,27 @@ function commandAckCommentIdsFromBody(body: JsonValue) {
     String(body ?? "").matchAll(/<!--\s*clawsweeper-command-ack:(\d+)\s*-->/g),
     (match) => Number(match[1]),
   ).filter((id) => Number.isSafeInteger(id) && id > 0);
+}
+
+function hasCommandAckMarker(body: JsonValue) {
+  return /<!--\s*clawsweeper-command-ack:[^>]*-->/.test(String(body ?? ""));
+}
+
+function legacyCommandCommentId(body: JsonValue, statusMarker: string) {
+  const status = /^<!--\s*clawsweeper-command-status:\d+:([^:\s>]+):([^:\s>]+)\s*-->$/.exec(
+    statusMarker,
+  );
+  if (!status) return null;
+  const commands = Array.from(
+    String(body ?? "").matchAll(
+      /<!--\s*clawsweeper-command:(\d+):(?:[^>]*:)?([^:\s>]+):([^:\s>]+)\s*-->/g,
+    ),
+  );
+  if (commands.length !== 1 || commands[0]![2] !== status[1] || commands[0]![3] !== status[2]) {
+    return null;
+  }
+  const commandCommentId = Number(commands[0]![1]);
+  return Number.isSafeInteger(commandCommentId) && commandCommentId > 0 ? commandCommentId : null;
 }
 
 function commandStatusMarkersFromBody(body: JsonValue) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1684,6 +1684,81 @@ test("exact-review queue bypasses debounce for commands and publications", async
   }
 });
 
+test("replacing a queued command cannot inherit another command's delivery identity", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const firstMarker = "<!-- clawsweeper-command-status:751:re_review:first -->";
+  const replacementMarker = "<!-- clawsweeper-command-status:751:autofix:replacement -->";
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "delivery-first-command",
+      751,
+      "legacy_dispatch",
+      "issue",
+      undefined,
+      {
+        commandStatusMarker: firstMarker,
+        statusCommentId: 9301,
+        sourceDeliveryId: "github-first-command-delivery",
+      },
+    ),
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "delivery-replacement-command",
+      751,
+      "legacy_dispatch",
+      "issue",
+      undefined,
+      {
+        commandStatusMarker: replacementMarker,
+        statusCommentId: 9401,
+      },
+    ),
+  );
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: Record<string, unknown> }>;
+  };
+  assert.equal(state.items["openclaw/gogcli#751"]?.decision.commandStatusMarker, replacementMarker);
+  assert.equal(state.items["openclaw/gogcli#751"]?.decision.statusCommentId, 9401);
+  assert.equal(state.items["openclaw/gogcli#751"]?.decision.sourceDeliveryId, undefined);
+
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "delivery-shared-original",
+      752,
+      "legacy_dispatch",
+      "issue",
+      undefined,
+      {
+        commandStatusMarker: firstMarker,
+        statusCommentId: 9301,
+        sourceDeliveryId: "github-shared-original-delivery",
+      },
+    ),
+  );
+  await queue.fetch(
+    buildExactReviewQueueRequest(
+      "delivery-shared-replacement",
+      752,
+      "legacy_dispatch",
+      "issue",
+      undefined,
+      {
+        commandStatusMarker: firstMarker,
+        statusCommentId: 9301,
+      },
+    ),
+  );
+  const sameMarkerState = (await storage.get("exact-review-queue")) as typeof state;
+  assert.equal(
+    sameMarkerState.items["openclaw/gogcli#752"]?.decision.commandStatusMarker,
+    firstMarker,
+  );
+  assert.equal(sameMarkerState.items["openclaw/gogcli#752"]?.decision.statusCommentId, 9301);
+  assert.equal(sameMarkerState.items["openclaw/gogcli#752"]?.decision.sourceDeliveryId, undefined);
+});
+
 test("exact-review queue coalesces one pending publication lineage across producer runs", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
@@ -6363,12 +6438,13 @@ test("signed migrated receipts cannot complete a newer same-marker lifecycle rev
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
   const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const statusStore = new MemoryKv();
   const now = Date.now();
   const target = "openclaw/openclaw#917";
   const marker = "<!-- clawsweeper-command-status:917:re_review:same-head -->";
   for (const [revision, statusCommentId, name] of [
     [1, 9301, "older"],
-    [2, 9401, "newer"],
+    [2, 9301, "newer"],
   ] as const) {
     const identity = {
       canonicalTargetKey: target,
@@ -6377,7 +6453,8 @@ test("signed migrated receipts cannot complete a newer same-marker lifecycle rev
     };
     lifecycle.recordAdmission({
       ...identity,
-      deliveryId: `same-head:${name}`,
+      deliveryId: `publisher:${name}:1`,
+      sourceDeliveryId: `github-delivery:${name}`,
       sourceAction: "re_review",
       commandOriginated: true,
       statusMarker: marker,
@@ -6410,8 +6487,41 @@ test("signed migrated receipts cannot complete a newer same-marker lifecycle rev
   }
 
   const secret = "same-head-revision-secret";
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    STATUS_STORE: statusStore,
+  };
+  await statusStore.put(
+    "openclaw-bay:journey-state:v1",
+    JSON.stringify(
+      mergeBayJourneyState(
+        null,
+        [
+          {
+            repository: "openclaw/openclaw",
+            number: 917,
+            source_comment_id: 555,
+            source_delivery_id: "github-delivery:older",
+            triggered_at: new Date(now + 1).toISOString(),
+          },
+          {
+            repository: "openclaw/openclaw",
+            number: 917,
+            source_comment_id: 555,
+            source_delivery_id: "github-delivery:newer",
+            triggered_at: new Date(now + 2).toISOString(),
+          },
+        ],
+        [],
+        new Date(now).toISOString(),
+      ),
+    ),
+  );
   const payload = {
     canonical_target_key: target,
+    fence_key: `${target}@exact:older`,
+    revision: 1,
     status_marker: marker,
     status_comment_id: 9301,
     command_comment_id: 555,
@@ -6419,6 +6529,47 @@ test("signed migrated receipts cannot complete a newer same-marker lifecycle rev
     completed_at: new Date(now + 50).toISOString(),
     observed_at: now + 51,
   };
+  const ambiguousWebhook = await worker.fetch(
+    signedGithubWebhookRequest({
+      event: "issue_comment",
+      secret,
+      payload: {
+        action: "edited",
+        repository: {
+          full_name: "openclaw/openclaw",
+          private: false,
+          archived: false,
+          fork: false,
+          has_issues: true,
+        },
+        issue: { number: 917 },
+        comment: {
+          id: 9302,
+          body: [
+            "<!-- clawsweeper-command-ack:555 -->",
+            marker,
+            "<!-- clawsweeper-command-progress:start -->",
+            "- State: Complete",
+            "- Detail: Done.",
+            "<!-- clawsweeper-command-progress:end -->",
+          ].join("\n"),
+          created_at: payload.completed_at,
+          updated_at: payload.completed_at,
+          user: { login: "clawsweeper[bot]" },
+        },
+      },
+    }),
+    env,
+  );
+  assert.equal((await ambiguousWebhook.json()).reason, "unmatched lifecycle acknowledgement");
+  assert.equal(
+    lifecycleState(lifecycle.read(target, `${target}@exact:older`, 1)!),
+    "acknowledgement_pending",
+  );
+  assert.equal(
+    lifecycleState(lifecycle.read(target, `${target}@exact:newer`, 2)!),
+    "acknowledgement_pending",
+  );
   const body = JSON.stringify(payload);
   const response = await worker.fetch(
     new Request(
@@ -6434,18 +6585,27 @@ test("signed migrated receipts cannot complete a newer same-marker lifecycle rev
         body,
       },
     ),
-    {
-      CLAWSWEEPER_WEBHOOK_SECRET: secret,
-      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
-    },
+    env,
   );
 
-  assert.equal((await response.json()).accepted, true);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    accepted: true,
+    lifecycle_state: "completed",
+    acknowledgement_state: "observed",
+    version: 1,
+    source_delivery_id: "github-delivery:older",
+  });
   assert.equal(lifecycleState(lifecycle.read(target, `${target}@exact:older`, 1)!), "completed");
   assert.equal(
     lifecycleState(lifecycle.read(target, `${target}@exact:newer`, 2)!),
     "acknowledgement_pending",
   );
+  const journeys = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
+  const older = journeys.find((journey) => journey.source_delivery_id === "github-delivery:older");
+  const newer = journeys.find((journey) => journey.source_delivery_id === "github-delivery:newer");
+  assert.equal(older.completed_at, payload.completed_at);
+  assert.equal(newer.completed_at, null);
 
   const malformed = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
@@ -6455,6 +6615,453 @@ test("signed migrated receipts cannot complete a newer same-marker lifecycle rev
     }),
   );
   assert.equal(malformed.status, 400);
+
+  for (const invalidIdentity of [
+    { fence_key: `${target}@exact:older`, revision: undefined },
+    { fence_key: undefined, revision: 1 },
+    { fence_key: `${target}@exact:older`, revision: "1" },
+  ]) {
+    const malformedIdentity = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...payload, ...invalidIdentity }),
+      }),
+    );
+    assert.equal(malformedIdentity.status, 400);
+  }
+});
+
+test("unfenced acknowledgements prefer a unique exact status comment over a shared marker", () => {
+  const storage = new MemoryDurableStorage();
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const canonicalTargetKey = "openclaw/openclaw#918";
+  const statusMarker = "<!-- clawsweeper-command-status:918:re_review:same-head -->";
+  const observedAt = 1_780_000_000_000;
+  for (const [revision, statusCommentId] of [
+    [1, 9301],
+    [2, 9401],
+  ] as const) {
+    const identity = {
+      canonicalTargetKey,
+      fenceKey: `${canonicalTargetKey}@exact:${revision}`,
+      revision,
+    };
+    lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `publisher:${revision}`,
+      sourceDeliveryId: `github-command-delivery:${revision}`,
+      sourceAction: "re_review",
+      commandOriginated: true,
+      statusMarker,
+      statusCommentId,
+      observedAt: observedAt + revision,
+    });
+    lifecycle.recordCanonicalReceipt({
+      ...identity,
+      outcome: "accepted",
+      receiptId: `canonical:${revision}`,
+      observedAt: observedAt + 10 + revision,
+    });
+    lifecycle.recordRouterReceipt({
+      ...identity,
+      outcome: "durable",
+      receiptId: `router:${revision}`,
+      observedAt: observedAt + 20 + revision,
+    });
+    lifecycle.recordTerminalDisposition({
+      ...identity,
+      kind: "review_completed_routed",
+      observedAt: observedAt + 30 + revision,
+    });
+    lifecycle.authorizeCommandAcknowledgement({
+      ...identity,
+      statusMarker,
+      statusCommentId,
+      observedAt: observedAt + 40 + revision,
+    });
+  }
+
+  const observation = lifecycle.observeCommandAcknowledgement({
+    canonicalTargetKey,
+    statusMarker,
+    commandCommentId: 555,
+    completionCommentId: 9301,
+    observedAt: observedAt + 100,
+  });
+  assert.equal(observation.accepted, true);
+  assert.equal(observation.projection?.revision, 1);
+  assert.equal(
+    lifecycleState(lifecycle.read(canonicalTargetKey, `${canonicalTargetKey}@exact:1`, 1)!),
+    "completed",
+  );
+  assert.equal(
+    lifecycleState(lifecycle.read(canonicalTargetKey, `${canonicalTargetKey}@exact:2`, 2)!),
+    "acknowledgement_pending",
+  );
+});
+
+test("Bay reconciles fenced completion delivery, legacy journeys, and same-second orphans", () => {
+  const generatedAt = "2026-08-03T12:00:06.000Z";
+  const completedAt = "2026-08-03T12:00:05.000Z";
+  const triggers = ["delivery-a", "delivery-b"].map((sourceDeliveryId, index) => ({
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+    source_delivery_id: sourceDeliveryId,
+    triggered_at: `2026-08-03T12:00:0${index}.000Z`,
+  }));
+  const completion = {
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+    completed_at: completedAt,
+    completion_comment_id: 9302,
+  };
+
+  for (const order of ["webhook-first", "receipt-first"] as const) {
+    let state = mergeBayJourneyState(null, triggers, [], generatedAt);
+    for (const source of order === "webhook-first"
+      ? ["webhook", "receipt"]
+      : ["receipt", "webhook"]) {
+      state = mergeBayJourneyState(
+        state,
+        [],
+        [
+          {
+            ...completion,
+            ...(source === "receipt" ? { source_delivery_id: "delivery-a" } : {}),
+          },
+        ],
+        generatedAt,
+      );
+    }
+    const older = state.journeys.find((journey) => journey.source_delivery_id === "delivery-a");
+    const newer = state.journeys.find((journey) => journey.source_delivery_id === "delivery-b");
+    assert.equal(older?.completed_at, completedAt, order);
+    assert.equal(newer?.completed_at, null, order);
+    assert.equal(summarizeBayJourneyTimings(state.journeys, generatedAt).overall.samples, 1, order);
+  }
+
+  const legacy = mergeBayJourneyState(
+    {
+      schema_version: 1,
+      journeys: [
+        {
+          id: "openclaw/openclaw#917:command:555:at:1785758400000",
+          item_key: "openclaw/openclaw#917",
+          repository: "openclaw/openclaw",
+          number: 917,
+          source_comment_id: 555,
+          triggered_at: "2026-08-03T12:00:00.000Z",
+          completed_at: null,
+          completion_kind: null,
+          completion_comment_id: null,
+        },
+      ],
+    },
+    [],
+    [{ ...completion, source_delivery_id: "delivery-a" }],
+    generatedAt,
+  );
+  assert.equal(legacy.journeys.length, 1);
+  assert.equal(legacy.journeys[0]?.completed_at, completedAt);
+
+  const orphaned = mergeBayJourneyState(
+    null,
+    [],
+    [
+      { ...completion, source_delivery_id: "delivery-a" },
+      { ...completion, source_delivery_id: "delivery-b" },
+    ],
+    generatedAt,
+  );
+  assert.equal(orphaned.journeys.length, 2);
+  assert.notEqual(orphaned.journeys[0]?.id, orphaned.journeys[1]?.id);
+  const resolved = mergeBayJourneyState(orphaned, triggers, [], generatedAt);
+  assert.equal(resolved.journeys.length, 2);
+  assert.equal(
+    resolved.journeys.filter((journey) => journey.completed_at === completedAt).length,
+    2,
+  );
+
+  const identifiedOrphan = mergeBayJourneyState(
+    null,
+    [],
+    [{ ...completion, source_delivery_id: "delivery-a" }],
+    generatedAt,
+  );
+  const legacyTrigger = mergeBayJourneyState(
+    identifiedOrphan,
+    [{ ...triggers[0], source_delivery_id: undefined }],
+    [],
+    generatedAt,
+  );
+  assert.equal(legacyTrigger.journeys.length, 1);
+  assert.equal(legacyTrigger.journeys[0]?.completed_at, completedAt);
+  assert.equal(summarizeBayJourneyTimings(legacyTrigger.journeys, generatedAt).overall.samples, 1);
+
+  let legacyThenTagged = mergeBayJourneyState(
+    null,
+    [{ ...triggers[0], source_delivery_id: undefined }],
+    [],
+    generatedAt,
+  );
+  legacyThenTagged = mergeBayJourneyState(legacyThenTagged, [], [completion], generatedAt);
+  legacyThenTagged = mergeBayJourneyState(legacyThenTagged, [triggers[0]], [], generatedAt);
+  legacyThenTagged = mergeBayJourneyState(
+    legacyThenTagged,
+    [],
+    [{ ...completion, source_delivery_id: "delivery-a" }],
+    generatedAt,
+  );
+  legacyThenTagged = mergeBayJourneyState(legacyThenTagged, [], [], generatedAt);
+  assert.equal(legacyThenTagged.journeys.length, 2);
+  assert.equal(
+    legacyThenTagged.journeys.find((journey) => journey.source_delivery_id === "delivery-a")
+      ?.completed_at,
+    completedAt,
+  );
+  assert.equal(
+    legacyThenTagged.journeys.find((journey) => !journey.source_delivery_id)?.completed_at,
+    null,
+  );
+  assert.equal(
+    summarizeBayJourneyTimings(legacyThenTagged.journeys, generatedAt).overall.samples,
+    1,
+  );
+
+  const newerCompletion = {
+    ...completion,
+    completed_at: "2026-08-03T12:00:05.500Z",
+    completion_comment_id: 9303,
+    source_delivery_id: "delivery-b",
+  };
+  const events = [
+    { triggers: [triggers[0]], completions: [] },
+    { triggers: [triggers[1]], completions: [] },
+    { triggers: [], completions: [completion] },
+    { triggers: [], completions: [newerCompletion] },
+    { triggers: [], completions: [{ ...completion, source_delivery_id: "delivery-a" }] },
+  ];
+  function* permutations<T>(values: T[]): Generator<T[]> {
+    if (values.length === 0) {
+      yield [];
+      return;
+    }
+    for (let index = 0; index < values.length; index += 1) {
+      for (const tail of permutations(values.filter((_value, position) => position !== index))) {
+        yield [values[index]!, ...tail];
+      }
+    }
+  }
+  for (const [index, order] of [...permutations(events)].entries()) {
+    let state = null;
+    for (const event of order) {
+      state = mergeBayJourneyState(state, event.triggers, event.completions, generatedAt);
+    }
+    const older = state!.journeys.find((journey) => journey.source_delivery_id === "delivery-a");
+    const newer = state!.journeys.find((journey) => journey.source_delivery_id === "delivery-b");
+    assert.equal(state!.journeys.length, 2, `permutation ${index}`);
+    assert.equal(older?.completed_at, completedAt, `older permutation ${index}`);
+    assert.equal(newer?.completed_at, newerCompletion.completed_at, `newer permutation ${index}`);
+    assert.equal(
+      summarizeBayJourneyTimings(state!.journeys, generatedAt).overall.samples,
+      2,
+      `samples permutation ${index}`,
+    );
+  }
+});
+
+test("Bay transfers a stolen legacy completion when the correct fenced completion arrives", () => {
+  const generatedAt = "2026-08-03T12:00:20.000Z";
+  const shared = {
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+  };
+  const modernTrigger = {
+    ...shared,
+    source_delivery_id: "modern-a",
+    triggered_at: "2026-08-03T12:00:01.000Z",
+  };
+  const legacyTrigger = {
+    ...shared,
+    source_delivery_id: "legacy-b",
+    triggered_at: "2026-08-03T12:00:02.000Z",
+  };
+  const legacyCompletion = {
+    ...shared,
+    completed_at: "2026-08-03T12:00:07.000Z",
+    completion_comment_id: 9301,
+  };
+  const modernCompletion = {
+    ...shared,
+    source_delivery_id: "modern-a",
+    completed_at: "2026-08-03T12:00:08.000Z",
+    completion_comment_id: 9301,
+  };
+
+  let state = mergeBayJourneyState(null, [modernTrigger], [], generatedAt);
+  state = mergeBayJourneyState(state, [], [legacyCompletion], generatedAt);
+  state = mergeBayJourneyState(state, [], [modernCompletion], generatedAt);
+  state = mergeBayJourneyState(state, [legacyTrigger], [], generatedAt);
+
+  assert.equal(
+    state.journeys.find((journey) => journey.source_delivery_id === "modern-a")?.completed_at,
+    modernCompletion.completed_at,
+  );
+  assert.equal(
+    state.journeys.find((journey) => journey.source_delivery_id === "legacy-b")?.completed_at,
+    legacyCompletion.completed_at,
+  );
+  assert.equal(summarizeBayJourneyTimings(state.journeys, generatedAt).overall.samples, 2);
+});
+
+test("Bay prefers a delivery-matched orphan over an earlier anonymous completion", () => {
+  const generatedAt = "2026-08-03T12:00:30.000Z";
+  const shared = {
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+  };
+  const identifiedCompletion = {
+    ...shared,
+    source_delivery_id: "delivery-a",
+    completed_at: "2026-08-03T12:00:08.000Z",
+    completion_comment_id: 9302,
+  };
+  const earlierAnonymousCompletion = {
+    ...shared,
+    completed_at: "2026-08-03T12:00:05.000Z",
+    completion_comment_id: 9301,
+  };
+  const trigger = {
+    ...shared,
+    source_delivery_id: "delivery-a",
+    triggered_at: "2026-08-03T12:00:01.000Z",
+  };
+
+  const orphaned = mergeBayJourneyState(
+    null,
+    [],
+    [identifiedCompletion, earlierAnonymousCompletion],
+    generatedAt,
+  );
+  const resolved = mergeBayJourneyState(orphaned, [trigger], [], generatedAt);
+
+  assert.equal(
+    resolved.journeys.find((journey) => journey.source_delivery_id === "delivery-a")?.completed_at,
+    identifiedCompletion.completed_at,
+  );
+  assert.equal(
+    resolved.journeys.find((journey) => !journey.source_delivery_id)?.completed_at,
+    earlierAnonymousCompletion.completed_at,
+  );
+});
+
+test("Bay reassigns a displaced anonymous completion once its sole journey is identifiable", () => {
+  const generatedAt = "2026-08-03T12:00:30.000Z";
+  const shared = {
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+  };
+  const modernTrigger = {
+    ...shared,
+    source_delivery_id: "delivery-a",
+    triggered_at: "2026-08-03T12:00:01.000Z",
+  };
+  const legacyTrigger = {
+    ...shared,
+    source_delivery_id: "delivery-b",
+    triggered_at: "2026-08-03T12:00:02.000Z",
+  };
+  const anonymousCompletion = {
+    ...shared,
+    completed_at: "2026-08-03T12:00:06.000Z",
+    completion_comment_id: 9311,
+  };
+  const fencedCompletion = {
+    ...shared,
+    source_delivery_id: "delivery-a",
+    completed_at: "2026-08-03T12:00:05.000Z",
+    completion_comment_id: 9310,
+  };
+
+  let state = mergeBayJourneyState(null, [modernTrigger], [], generatedAt);
+  state = mergeBayJourneyState(state, [], [anonymousCompletion], generatedAt);
+  state = mergeBayJourneyState(state, [legacyTrigger], [], generatedAt);
+  state = mergeBayJourneyState(state, [], [fencedCompletion], generatedAt);
+
+  assert.equal(
+    state.journeys.find((journey) => journey.source_delivery_id === "delivery-a")?.completed_at,
+    fencedCompletion.completed_at,
+  );
+  assert.equal(
+    state.journeys.find((journey) => journey.source_delivery_id === "delivery-b")?.completed_at,
+    anonymousCompletion.completed_at,
+  );
+  assert.equal(summarizeBayJourneyTimings(state.journeys, generatedAt).overall.samples, 2);
+});
+
+test("Bay keeps the newest fenced completion received before its trigger", () => {
+  const generatedAt = "2026-08-03T12:00:30.000Z";
+  const shared = {
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+    source_delivery_id: "delivery-a",
+  };
+  const first = {
+    ...shared,
+    completed_at: "2026-08-03T12:00:05.000Z",
+    completion_comment_id: 9310,
+  };
+  const newer = {
+    ...shared,
+    completed_at: "2026-08-03T12:00:06.000Z",
+    completion_comment_id: 9311,
+  };
+  const trigger = { ...shared, triggered_at: "2026-08-03T12:00:01.000Z" };
+
+  for (const completions of [
+    [first, newer],
+    [newer, first],
+  ]) {
+    let state = mergeBayJourneyState(null, [], completions, generatedAt);
+    state = mergeBayJourneyState(state, [trigger], [], generatedAt);
+    assert.equal(state.journeys.length, 1);
+    assert.equal(state.journeys[0]?.completed_at, newer.completed_at);
+    assert.equal(state.journeys[0]?.completion_comment_id, newer.completion_comment_id);
+  }
+});
+
+test("same-second fenced completions deterministically retain the newest comment identity", () => {
+  const generatedAt = "2026-08-03T12:00:30.000Z";
+  const shared = {
+    repository: "openclaw/openclaw",
+    number: 917,
+    source_comment_id: 555,
+    source_delivery_id: "delivery-a",
+  };
+  const trigger = { ...shared, triggered_at: "2026-08-03T12:00:01.000Z" };
+  const completedAt = "2026-08-03T12:00:05.000Z";
+  const first = { ...shared, completed_at: completedAt, completion_comment_id: 9310 };
+  const second = { ...shared, completed_at: completedAt, completion_comment_id: 9311 };
+
+  for (const completions of [
+    [first, second],
+    [second, first],
+  ]) {
+    let state = mergeBayJourneyState(null, [trigger], [], generatedAt);
+    for (const completion of completions) {
+      state = mergeBayJourneyState(state, [], [completion], generatedAt);
+    }
+    assert.equal(state.journeys.length, 1);
+    assert.equal(state.journeys[0]?.completed_at, completedAt);
+    assert.equal(state.journeys[0]?.completion_comment_id, second.completion_comment_id);
+  }
 });
 
 test("verified unchanged legacy receipts complete Bay journeys without a webhook", async () => {
@@ -25012,7 +25619,7 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
           installation: { id: 123 },
           comment: {
             id: 456,
-            body: "@clawsweeper status",
+            body: "@clawsweeper review",
             updated_at: "2026-07-12T20:00:00Z",
             author_association: "OWNER",
             user: { login: "steipete" },
@@ -25024,6 +25631,7 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
         CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
         CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
         CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
+        STATUS_STORE: new MemoryKv(),
       },
     );
 
@@ -25038,17 +25646,16 @@ test("hosted webhook reuses existing fast ack comments on redelivery", async () 
         item_number: 597,
         comment_id: 456,
         status_comment_id: 777,
-        source_event: "issue_comment",
         source_action: "created",
+        source_delivery_id: "test-delivery",
         comment_event_auth: "github_webhook_v1",
         comment_updated_at: "2026-07-12T20:00:00Z",
-        comment_body_sha256: createHash("sha256").update("@clawsweeper status").digest("hex"),
+        comment_body_sha256: createHash("sha256").update("@clawsweeper review").digest("hex"),
       },
     });
-    assert.equal(
+    assert.ok(
       Object.keys((dispatchBody as { client_payload: Record<string, unknown> }).client_payload)
-        .length,
-      10,
+        .length <= 10,
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
   } finally {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5996,6 +5996,117 @@ test("Worker lifecycle acknowledgement preserves canonical GitHub repository cas
   );
 });
 
+test("Worker converges legacy and non-review acknowledgement receipts without webhook races", async () => {
+  let itemNumber = 780;
+  for (const intent of ["re_review", "automerge", "autofix"]) {
+    for (const legacy of [false, true]) {
+      itemNumber += 1;
+      const storage = new MemoryDurableStorage();
+      const queue = new ExactReviewQueue({ storage }, {});
+      const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+      const statusMarker = `<!-- clawsweeper-command-status:${itemNumber}:${intent}:head -->`;
+      const identity = {
+        canonicalTargetKey: `openclaw/openclaw#${itemNumber}`,
+        fenceKey: `openclaw/openclaw#${itemNumber}@exact`,
+        revision: 1,
+      };
+      lifecycle.recordAdmission({
+        ...identity,
+        deliveryId: `legacy-acknowledgement:${itemNumber}`,
+        sourceAction: intent,
+        commandOriginated: true,
+        statusMarker,
+        statusCommentId: itemNumber + 10_000,
+        observedAt: 1_700_000_000_000,
+      });
+      lifecycle.recordCanonicalReceipt({
+        ...identity,
+        outcome: "accepted",
+        receiptId: `legacy-acknowledgement:${itemNumber}:canonical`,
+        observedAt: 1_700_000_000_001,
+      });
+      lifecycle.recordRouterReceipt({
+        ...identity,
+        outcome: "durable",
+        receiptId: `legacy-acknowledgement:${itemNumber}:router`,
+        observedAt: 1_700_000_000_002,
+      });
+      lifecycle.recordTerminalDisposition({
+        ...identity,
+        kind: "review_completed_routed",
+        observedAt: 1_700_000_000_003,
+      });
+      assert.equal(
+        lifecycle.authorizeCommandAcknowledgement({
+          ...identity,
+          statusMarker,
+          statusCommentId: itemNumber + 10_000,
+          observedAt: 1_700_000_000_004,
+        }).allowed,
+        true,
+      );
+
+      const marker = legacy
+        ? `<!-- clawsweeper-command:123:2026-08-01T08:13:51Z:${intent}:head -->`
+        : "<!-- clawsweeper-command-ack:123 -->";
+      const response = await worker.fetch(
+        signedGithubWebhookRequest({
+          event: "issue_comment",
+          secret: "legacy-acknowledgement-secret",
+          payload: {
+            action: "edited",
+            repository: {
+              full_name: "openclaw/openclaw",
+              private: false,
+              archived: false,
+              fork: false,
+              has_issues: true,
+            },
+            issue: { number: itemNumber },
+            comment: {
+              id: itemNumber + 10_000,
+              body: [
+                marker,
+                statusMarker,
+                "<!-- clawsweeper-command-progress:start -->",
+                "- State: Complete",
+                "- Detail: Done.",
+                "<!-- clawsweeper-command-progress:end -->",
+              ].join("\n"),
+              created_at: "2026-07-30T00:00:00.000Z",
+              updated_at: "2026-07-30T00:01:00.000Z",
+              user: { login: "clawsweeper[bot]" },
+            },
+          },
+        }),
+        {
+          CLAWSWEEPER_WEBHOOK_SECRET: "legacy-acknowledgement-secret",
+          EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+          STATUS_STORE: new MemoryKv(),
+        },
+      );
+      assert.deepEqual(await response.json(), {
+        ok: true,
+        accepted: false,
+        reason:
+          intent === "re_review"
+            ? "recorded Bay journey completion"
+            : "recorded lifecycle acknowledgement",
+      });
+      assert.equal(
+        lifecycle.observeCommandAcknowledgement({
+          canonicalTargetKey: identity.canonicalTargetKey,
+          statusMarker,
+          commandCommentId: 123,
+          completionCommentId: itemNumber + 10_000,
+          observedAt: 1_700_000_000_005,
+        }).accepted,
+        true,
+      );
+    }
+  }
+});
+
 test("Worker lifecycle keeps retryable publication work ineligible for final acknowledgement", async () => {
   const storage = new MemoryDurableStorage();
   const leased = leasedExactReviewPublicationItem(779, "7790");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -6218,7 +6218,7 @@ test("Worker binds legacy webhooks while preserving marker-only command addresse
   }
 });
 
-test("signed terminal receipts complete Bay journeys only after legacy status migration", async () => {
+test("signed terminal receipts bind legacy migration to its admitted status comment", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
   const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
@@ -6317,7 +6317,7 @@ test("signed terminal receipts complete Bay journeys only after legacy status mi
     );
   };
 
-  assert.equal((await (await sendReceipt(9302)).json()).accepted, true);
+  assert.equal((await (await sendReceipt(9302)).json()).accepted, false);
   const incomplete = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
   assert.equal(incomplete.length, 1);
   assert.equal(incomplete[0].completed_at ?? null, null);
@@ -6357,6 +6357,222 @@ test("signed terminal receipts complete Bay journeys only after legacy status mi
     lifecycleState(lifecycle.read(canonicalTargetKey, identity.fenceKey, 1)!),
     "completed",
   );
+});
+
+test("signed migrated receipts cannot complete a newer same-marker lifecycle revision", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const now = Date.now();
+  const target = "openclaw/openclaw#917";
+  const marker = "<!-- clawsweeper-command-status:917:re_review:same-head -->";
+  for (const [revision, statusCommentId, name] of [
+    [1, 9301, "older"],
+    [2, 9401, "newer"],
+  ] as const) {
+    const identity = {
+      canonicalTargetKey: target,
+      fenceKey: `${target}@exact:${name}`,
+      revision,
+    };
+    lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `same-head:${name}`,
+      sourceAction: "re_review",
+      commandOriginated: true,
+      statusMarker: marker,
+      statusCommentId,
+      observedAt: now + revision,
+    });
+    lifecycle.recordCanonicalReceipt({
+      ...identity,
+      outcome: "accepted",
+      receiptId: `same-head:canonical:${name}`,
+      observedAt: now + 10 + revision,
+    });
+    lifecycle.recordRouterReceipt({
+      ...identity,
+      outcome: "durable",
+      receiptId: `same-head:router:${name}`,
+      observedAt: now + 20 + revision,
+    });
+    lifecycle.recordTerminalDisposition({
+      ...identity,
+      kind: "review_completed_routed",
+      observedAt: now + 30 + revision,
+    });
+    lifecycle.authorizeCommandAcknowledgement({
+      ...identity,
+      statusMarker: marker,
+      statusCommentId,
+      observedAt: now + 40 + revision,
+    });
+  }
+
+  const secret = "same-head-revision-secret";
+  const payload = {
+    canonical_target_key: target,
+    status_marker: marker,
+    status_comment_id: 9301,
+    command_comment_id: 555,
+    completion_comment_id: 9302,
+    completed_at: new Date(now + 50).toISOString(),
+    observed_at: now + 51,
+  };
+  const body = JSON.stringify(payload);
+  const response = await worker.fetch(
+    new Request(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/command-ack/observed",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret)
+            .update(body)
+            .digest("hex")}`,
+        },
+        body,
+      },
+    ),
+    {
+      CLAWSWEEPER_WEBHOOK_SECRET: secret,
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    },
+  );
+
+  assert.equal((await response.json()).accepted, true);
+  assert.equal(lifecycleState(lifecycle.read(target, `${target}@exact:older`, 1)!), "completed");
+  assert.equal(
+    lifecycleState(lifecycle.read(target, `${target}@exact:newer`, 2)!),
+    "acknowledgement_pending",
+  );
+
+  const malformed = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...payload, status_comment_id: "9301" }),
+    }),
+  );
+  assert.equal(malformed.status, 400);
+});
+
+test("verified unchanged legacy receipts complete Bay journeys without a webhook", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const statusStore = new MemoryKv();
+  const now = Date.now();
+  const marker = "<!-- clawsweeper-command-status:918:re_review:unchanged -->";
+  const identity = {
+    canonicalTargetKey: "openclaw/openclaw#918",
+    fenceKey: "openclaw/openclaw#918@exact",
+    revision: 1,
+  };
+  lifecycle.recordAdmission({
+    ...identity,
+    deliveryId: "unchanged-legacy:918",
+    sourceAction: "re_review",
+    commandOriginated: true,
+    statusMarker: marker,
+    statusCommentId: 9501,
+    observedAt: now,
+  });
+  lifecycle.recordCanonicalReceipt({
+    ...identity,
+    outcome: "accepted",
+    receiptId: "unchanged-legacy:canonical",
+    observedAt: now + 1,
+  });
+  lifecycle.recordRouterReceipt({
+    ...identity,
+    outcome: "durable",
+    receiptId: "unchanged-legacy:router",
+    observedAt: now + 2,
+  });
+  lifecycle.recordTerminalDisposition({
+    ...identity,
+    kind: "review_completed_routed",
+    observedAt: now + 3,
+  });
+  lifecycle.authorizeCommandAcknowledgement({
+    ...identity,
+    statusMarker: marker,
+    statusCommentId: 9501,
+    observedAt: now + 4,
+  });
+  await statusStore.put(
+    "openclaw-bay:journey-state:v1",
+    JSON.stringify(
+      mergeBayJourneyState(
+        null,
+        [
+          {
+            repository: "openclaw/openclaw",
+            number: 918,
+            source_comment_id: 558,
+            source_delivery_id: "older-legacy-delivery",
+            triggered_at: new Date(now - 10).toISOString(),
+          },
+          {
+            repository: "openclaw/openclaw",
+            number: 918,
+            source_comment_id: 558,
+            source_delivery_id: "unchanged-legacy-delivery",
+            triggered_at: new Date(now).toISOString(),
+          },
+        ],
+        [],
+        new Date(now).toISOString(),
+      ),
+    ),
+  );
+
+  const secret = "unchanged-legacy-secret";
+  const completedAt = new Date(now + 5).toISOString();
+  const body = JSON.stringify({
+    canonical_target_key: identity.canonicalTargetKey,
+    status_marker: marker,
+    status_comment_id: 9501,
+    command_comment_id: 558,
+    completion_comment_id: 9501,
+    completed_at: completedAt,
+    observed_at: now + 15,
+  });
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    STATUS_STORE: statusStore,
+  };
+  const sendReceipt = () =>
+    worker.fetch(
+      new Request(
+        "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/command-ack/observed",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret)
+              .update(body)
+              .digest("hex")}`,
+          },
+          body,
+        },
+      ),
+      env,
+    );
+
+  assert.equal((await (await sendReceipt()).json()).accepted, true);
+  assert.equal((await (await sendReceipt()).json()).accepted, true);
+  const journeys = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
+  const completed = journeys.find(
+    (journey) => journey.source_delivery_id === "unchanged-legacy-delivery",
+  );
+  const older = journeys.find((journey) => journey.source_delivery_id === "older-legacy-delivery");
+  assert.equal(journeys.length, 2);
+  assert.equal(completed.completion_comment_id, 9501);
+  assert.equal(completed.completed_at, completedAt);
+  assert.equal(older.completed_at, null);
 });
 
 test("migrated modern acknowledgement receipts preserve the webhook completion identity", async () => {
@@ -6409,6 +6625,13 @@ test("migrated modern acknowledgement receipts preserve the webhook completion i
       mergeBayJourneyState(
         null,
         [
+          {
+            repository: "openclaw/openclaw",
+            number: 916,
+            source_comment_id: 556,
+            source_delivery_id: "older-modern-delivery",
+            triggered_at: new Date(now - 10).toISOString(),
+          },
           {
             repository: "openclaw/openclaw",
             number: 916,
@@ -6492,9 +6715,13 @@ test("migrated modern acknowledgement receipts preserve the webhook completion i
 
   assert.equal((await receipt.json()).accepted, true);
   const journeys = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
-  assert.equal(journeys.length, 1);
-  assert.equal(journeys[0].source_delivery_id, "modern-migration-delivery");
-  assert.equal(journeys[0].completed_at, completedAt);
+  const completed = journeys.find(
+    (journey) => journey.source_delivery_id === "modern-migration-delivery",
+  );
+  const older = journeys.find((journey) => journey.source_delivery_id === "older-modern-delivery");
+  assert.equal(journeys.length, 2);
+  assert.equal(completed.completed_at, completedAt);
+  assert.equal(older.completed_at, null);
 });
 
 test("unsigned terminal receipts are rejected before their JSON body is parsed", async () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -6107,6 +6107,526 @@ test("Worker converges legacy and non-review acknowledgement receipts without we
   }
 });
 
+test("Worker binds legacy webhooks while preserving marker-only command addresses", async () => {
+  for (const mismatch of ["comment", "marker", "marker-only", "id-only"]) {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue({ storage }, {});
+    const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+    const itemNumber =
+      mismatch === "comment"
+        ? 910
+        : mismatch === "marker"
+          ? 911
+          : mismatch === "marker-only"
+            ? 912
+            : 914;
+    const expectedMarker = `<!-- clawsweeper-command-status:${itemNumber}:re_review:expected -->`;
+    const admissionMarker = mismatch === "id-only" ? null : expectedMarker;
+    const receivedMarker =
+      mismatch === "marker"
+        ? `<!-- clawsweeper-command-status:${itemNumber}:re_review:other -->`
+        : expectedMarker;
+    const identity = {
+      canonicalTargetKey: `openclaw/openclaw#${itemNumber}`,
+      fenceKey: `openclaw/openclaw#${itemNumber}@exact`,
+      revision: 1,
+    };
+    lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `legacy-source-fence:${itemNumber}`,
+      sourceAction: "re_review",
+      commandOriginated: true,
+      statusMarker: admissionMarker,
+      statusCommentId: mismatch === "marker-only" ? null : 9101,
+      observedAt: 1_700_000_000_000,
+    });
+    lifecycle.recordCanonicalReceipt({
+      ...identity,
+      outcome: "accepted",
+      receiptId: `legacy-source-fence:${itemNumber}:canonical`,
+      observedAt: 1_700_000_000_001,
+    });
+    lifecycle.recordRouterReceipt({
+      ...identity,
+      outcome: "durable",
+      receiptId: `legacy-source-fence:${itemNumber}:router`,
+      observedAt: 1_700_000_000_002,
+    });
+    lifecycle.recordTerminalDisposition({
+      ...identity,
+      kind: "review_completed_routed",
+      observedAt: 1_700_000_000_003,
+    });
+    lifecycle.authorizeCommandAcknowledgement({
+      ...identity,
+      statusMarker: admissionMarker,
+      statusCommentId: mismatch === "marker-only" ? null : 9101,
+      observedAt: 1_700_000_000_004,
+    });
+
+    const response = await worker.fetch(
+      signedGithubWebhookRequest({
+        event: "issue_comment",
+        secret: "legacy-source-fence-secret",
+        payload: {
+          action: "edited",
+          repository: {
+            full_name: "openclaw/openclaw",
+            private: false,
+            archived: false,
+            fork: false,
+            has_issues: true,
+          },
+          issue: { number: itemNumber },
+          comment: {
+            id: mismatch === "comment" || mismatch === "marker-only" ? 9102 : 9101,
+            body: [
+              `<!-- clawsweeper-command:456:2026-08-01T08:13:51Z:re_review:${mismatch === "marker" ? "other" : "expected"} -->`,
+              receivedMarker,
+              "<!-- clawsweeper-command-progress:start -->",
+              "- State: Complete",
+              "- Detail: Done.",
+              "<!-- clawsweeper-command-progress:end -->",
+            ].join("\n"),
+            created_at: "2026-07-30T00:00:00.000Z",
+            updated_at: "2026-07-30T00:01:00.000Z",
+            user: { login: "clawsweeper[bot]" },
+          },
+        },
+      }),
+      {
+        CLAWSWEEPER_WEBHOOK_SECRET: "legacy-source-fence-secret",
+        EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+        STATUS_STORE: new MemoryKv(),
+      },
+    );
+
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      accepted: false,
+      reason:
+        mismatch === "marker-only" || mismatch === "id-only"
+          ? "recorded Bay journey completion"
+          : "unmatched lifecycle acknowledgement",
+    });
+    assert.equal(
+      lifecycleState(lifecycle.read(identity.canonicalTargetKey, identity.fenceKey, 1)!),
+      mismatch === "marker-only" || mismatch === "id-only"
+        ? "completed"
+        : "acknowledgement_pending",
+    );
+  }
+});
+
+test("signed terminal receipts complete Bay journeys only after legacy status migration", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const statusStore = new MemoryKv();
+  const now = Date.now();
+  const canonicalTargetKey = "openclaw/openclaw#915";
+  const statusMarker = "<!-- clawsweeper-command-status:915:re_review:migrated -->";
+  const identity = {
+    canonicalTargetKey,
+    fenceKey: `${canonicalTargetKey}@exact`,
+    revision: 1,
+  };
+  lifecycle.recordAdmission({
+    ...identity,
+    deliveryId: "migrated-bay:915",
+    sourceAction: "re_review",
+    commandOriginated: true,
+    statusMarker,
+    statusCommentId: 9301,
+    observedAt: now,
+  });
+  lifecycle.recordCanonicalReceipt({
+    ...identity,
+    outcome: "accepted",
+    receiptId: "migrated-bay:canonical",
+    observedAt: now + 1,
+  });
+  lifecycle.recordRouterReceipt({
+    ...identity,
+    outcome: "durable",
+    receiptId: "migrated-bay:router",
+    observedAt: now + 2,
+  });
+  lifecycle.recordTerminalDisposition({
+    ...identity,
+    kind: "review_completed_routed",
+    observedAt: now + 3,
+  });
+  lifecycle.authorizeCommandAcknowledgement({
+    ...identity,
+    statusMarker,
+    statusCommentId: 9301,
+    observedAt: now + 4,
+  });
+  await statusStore.put(
+    "openclaw-bay:journey-state:v1",
+    JSON.stringify(
+      mergeBayJourneyState(
+        null,
+        [
+          {
+            repository: "openclaw/openclaw",
+            number: 915,
+            source_comment_id: 555,
+            source_delivery_id: "migrated-bay-delivery",
+            triggered_at: new Date(now).toISOString(),
+          },
+        ],
+        [],
+        new Date(now).toISOString(),
+      ),
+    ),
+  );
+
+  const secret = "migrated-bay-secret";
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    STATUS_STORE: statusStore,
+  };
+  const sendReceipt = (admittedCommentId: number) => {
+    const body = JSON.stringify({
+      canonical_target_key: canonicalTargetKey,
+      status_marker: statusMarker,
+      status_comment_id: admittedCommentId,
+      command_comment_id: 555,
+      completion_comment_id: 9302,
+      completed_at: new Date(now + 5).toISOString(),
+      observed_at: now + 15,
+    });
+    return worker.fetch(
+      new Request(
+        "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/command-ack/observed",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret)
+              .update(body)
+              .digest("hex")}`,
+          },
+          body,
+        },
+      ),
+      env,
+    );
+  };
+
+  assert.equal((await (await sendReceipt(9302)).json()).accepted, true);
+  const incomplete = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
+  assert.equal(incomplete.length, 1);
+  assert.equal(incomplete[0].completed_at ?? null, null);
+
+  await statusStore.put(
+    "openclaw-bay:journey-state:v1",
+    JSON.stringify(
+      mergeBayJourneyState(
+        { schema_version: 1, journeys: incomplete },
+        [
+          {
+            repository: "openclaw/openclaw",
+            number: 915,
+            source_comment_id: 555,
+            source_delivery_id: "newer-edit",
+            triggered_at: new Date(now + 10).toISOString(),
+          },
+        ],
+        [],
+        new Date(now + 10).toISOString(),
+      ),
+    ),
+  );
+
+  const response = await sendReceipt(9301);
+
+  assert.equal((await response.json()).accepted, true);
+  const journeys = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
+  const completed = journeys.find(
+    (journey) => journey.source_delivery_id === "migrated-bay-delivery",
+  );
+  const newer = journeys.find((journey) => journey.source_delivery_id === "newer-edit");
+  assert.equal(completed.completion_comment_id, 9302);
+  assert.equal(completed.completed_at, new Date(now + 5).toISOString());
+  assert.equal(newer.completed_at, null);
+  assert.equal(
+    lifecycleState(lifecycle.read(canonicalTargetKey, identity.fenceKey, 1)!),
+    "completed",
+  );
+});
+
+test("migrated modern acknowledgement receipts preserve the webhook completion identity", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const statusStore = new MemoryKv();
+  const now = Date.now();
+  const marker = "<!-- clawsweeper-command-status:916:re_review:migrated -->";
+  const identity = {
+    canonicalTargetKey: "openclaw/openclaw#916",
+    fenceKey: "openclaw/openclaw#916@exact",
+    revision: 1,
+  };
+  lifecycle.recordAdmission({
+    ...identity,
+    deliveryId: "modern-migration:916",
+    sourceAction: "re_review",
+    commandOriginated: true,
+    statusMarker: marker,
+    statusCommentId: 9401,
+    observedAt: now,
+  });
+  lifecycle.recordCanonicalReceipt({
+    ...identity,
+    outcome: "accepted",
+    receiptId: "modern-migration:canonical",
+    observedAt: now + 1,
+  });
+  lifecycle.recordRouterReceipt({
+    ...identity,
+    outcome: "durable",
+    receiptId: "modern-migration:router",
+    observedAt: now + 2,
+  });
+  lifecycle.recordTerminalDisposition({
+    ...identity,
+    kind: "review_completed_routed",
+    observedAt: now + 3,
+  });
+  lifecycle.authorizeCommandAcknowledgement({
+    ...identity,
+    statusMarker: marker,
+    statusCommentId: 9401,
+    observedAt: now + 4,
+  });
+  await statusStore.put(
+    "openclaw-bay:journey-state:v1",
+    JSON.stringify(
+      mergeBayJourneyState(
+        null,
+        [
+          {
+            repository: "openclaw/openclaw",
+            number: 916,
+            source_comment_id: 556,
+            source_delivery_id: "modern-migration-delivery",
+            triggered_at: new Date(now).toISOString(),
+          },
+        ],
+        [],
+        new Date(now).toISOString(),
+      ),
+    ),
+  );
+
+  const secret = "modern-migration-secret";
+  const completedAt = new Date(now + 5).toISOString();
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+    STATUS_STORE: statusStore,
+  };
+  const webhook = await worker.fetch(
+    signedGithubWebhookRequest({
+      event: "issue_comment",
+      secret,
+      payload: {
+        action: "edited",
+        repository: {
+          full_name: "openclaw/openclaw",
+          private: false,
+          archived: false,
+          fork: false,
+          has_issues: true,
+        },
+        issue: { number: 916 },
+        comment: {
+          id: 9402,
+          body: [
+            "<!-- clawsweeper-command-ack:556 -->",
+            marker,
+            "<!-- clawsweeper-command-progress:start -->",
+            "- State: Complete",
+            "- Detail: Done.",
+            "<!-- clawsweeper-command-progress:end -->",
+          ].join("\n"),
+          created_at: completedAt,
+          updated_at: completedAt,
+          user: { login: "clawsweeper[bot]" },
+        },
+      },
+    }),
+    env,
+  );
+  assert.equal((await webhook.json()).reason, "recorded Bay journey completion");
+
+  const body = JSON.stringify({
+    canonical_target_key: identity.canonicalTargetKey,
+    status_marker: marker,
+    status_comment_id: 9401,
+    command_comment_id: 556,
+    completion_comment_id: 9402,
+    completed_at: completedAt,
+    observed_at: now + 15,
+  });
+  const receipt = await worker.fetch(
+    new Request(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/command-ack/observed",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret)
+            .update(body)
+            .digest("hex")}`,
+        },
+        body,
+      },
+    ),
+    env,
+  );
+
+  assert.equal((await receipt.json()).accepted, true);
+  const journeys = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1"))!).journeys;
+  assert.equal(journeys.length, 1);
+  assert.equal(journeys[0].source_delivery_id, "modern-migration-delivery");
+  assert.equal(journeys[0].completed_at, completedAt);
+});
+
+test("unsigned terminal receipts are rejected before their JSON body is parsed", async () => {
+  const originalJson = Request.prototype.json;
+  let bodyParses = 0;
+  Request.prototype.json = function (...args) {
+    bodyParses += 1;
+    return originalJson.apply(this, args);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request(
+        "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/command-ack/observed",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-clawsweeper-exact-review-signature": "sha256=invalid",
+          },
+          body: JSON.stringify({ values: Array.from({ length: 100 }, (_, index) => index) }),
+        },
+      ),
+      { CLAWSWEEPER_WEBHOOK_SECRET: "real-secret" },
+    );
+    assert.equal(response.status, 401);
+    assert.equal(bodyParses, 0);
+  } finally {
+    Request.prototype.json = originalJson;
+  }
+});
+
+test("modern shared status comments acknowledge only the matching command marker", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const canonicalTargetKey = "openclaw/openclaw#913";
+  for (const [head, runId] of [
+    ["old", "100"],
+    ["new", "200"],
+  ]) {
+    const identity = {
+      canonicalTargetKey,
+      fenceKey: `${canonicalTargetKey}@publish:${runId}:1`,
+      revision: 1,
+    };
+    const statusMarker = `<!-- clawsweeper-command-status:913:automerge:${head} -->`;
+    lifecycle.recordAdmission({
+      ...identity,
+      deliveryId: `shared-status:${runId}`,
+      sourceAction: "automerge",
+      commandOriginated: true,
+      statusMarker,
+      statusCommentId: 9201,
+      observedAt: 1_700_000_000_000,
+    });
+    lifecycle.recordCanonicalReceipt({
+      ...identity,
+      outcome: "accepted",
+      receiptId: `shared-status:${runId}:canonical`,
+      observedAt: 1_700_000_000_001,
+    });
+    lifecycle.recordRouterReceipt({
+      ...identity,
+      outcome: "durable",
+      receiptId: `shared-status:${runId}:router`,
+      observedAt: 1_700_000_000_002,
+    });
+    lifecycle.recordTerminalDisposition({
+      ...identity,
+      kind: "review_completed_routed",
+      observedAt: 1_700_000_000_003,
+    });
+    lifecycle.authorizeCommandAcknowledgement({
+      ...identity,
+      statusMarker,
+      statusCommentId: 9201,
+      observedAt: 1_700_000_000_004,
+    });
+  }
+
+  const response = await worker.fetch(
+    signedGithubWebhookRequest({
+      event: "issue_comment",
+      secret: "shared-status-secret",
+      payload: {
+        action: "edited",
+        repository: {
+          full_name: "openclaw/openclaw",
+          private: false,
+          archived: false,
+          fork: false,
+          has_issues: true,
+        },
+        issue: { number: 913 },
+        comment: {
+          id: 9201,
+          body: [
+            "<!-- clawsweeper-command-ack:456 -->",
+            "<!-- clawsweeper-command-status:913:automerge:new -->",
+            "<!-- clawsweeper-command-progress:start -->",
+            "- State: Complete",
+            "- Detail: Done.",
+            "<!-- clawsweeper-command-progress:end -->",
+          ].join("\n"),
+          created_at: "2026-07-30T00:00:00.000Z",
+          updated_at: "2026-07-30T00:01:00.000Z",
+          user: { login: "clawsweeper[bot]" },
+        },
+      },
+    }),
+    {
+      CLAWSWEEPER_WEBHOOK_SECRET: "shared-status-secret",
+      EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+      STATUS_STORE: new MemoryKv(),
+    },
+  );
+
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    accepted: false,
+    reason: "recorded lifecycle acknowledgement",
+  });
+  assert.equal(
+    lifecycleState(lifecycle.read(canonicalTargetKey, `${canonicalTargetKey}@publish:100:1`, 1)!),
+    "acknowledgement_pending",
+  );
+  assert.equal(
+    lifecycleState(lifecycle.read(canonicalTargetKey, `${canonicalTargetKey}@publish:200:1`, 1)!),
+    "completed",
+  );
+});
+
 test("Worker lifecycle keeps retryable publication work ineligible for final acknowledgement", async () => {
   const storage = new MemoryDurableStorage();
   const leased = leasedExactReviewPublicationItem(779, "7790");

--- a/test/repair/comment-router-core.test.ts
+++ b/test/repair/comment-router-core.test.ts
@@ -2267,6 +2267,31 @@ test("comment router durably claims dispatch commands and recovers exact workflo
   assert.match(claimFunction, /commandHasAction\(command,\s*"dispatch_assist"\)/);
   assert.match(source, /function claimedDispatchState/);
   assert.match(source, /function refreshDispatchClaim/);
+  const reviewDispatch = source.slice(
+    source.indexOf("function dispatchClawSweeperReview"),
+    source.indexOf("function dispatchCompletedReviewVerdict"),
+  );
+  assert.ok(
+    reviewDispatch.indexOf("claimedDispatchState({") <
+      reviewDispatch.indexOf("findExistingCommandStatusComment(command)"),
+    "existing durable dispatch claims must short-circuit before status-comment lookup",
+  );
+  const statusCommentLookup = source.slice(
+    source.indexOf("function findExistingCommandStatusComment"),
+    source.indexOf("function isTrustedStatusComment"),
+  );
+  assert.match(statusCommentLookup, /cachedIssueComments\(command\.issue_number\)/);
+  assert.doesNotMatch(statusCommentLookup, /ghPaged\(/);
+  const statusCommentWriter = source.slice(
+    source.indexOf("function postComment"),
+    source.indexOf("function findPrecreatedCommandStatusComment"),
+  );
+  assert.equal(
+    statusCommentWriter.match(/issueCommentsCache\.delete\(Number\(command\.issue_number\)\)/g)
+      ?.length,
+    3,
+    "both successful mutations and optional temporary-comment deletion invalidate stale history",
+  );
   assert.match(source, /writeLedger\(ledgerPath\(\), ledger\)/);
   assert.match(source, /function verifyDispatchExecutionRuns/);
   assert.match(source, /actions\/runs\/\$\{runId\}\/jobs\?per_page=100/);

--- a/test/repair/comment-router-ledger-merge.test.ts
+++ b/test/repair/comment-router-ledger-merge.test.ts
@@ -30,6 +30,114 @@ test("comment router ledger merge keeps terminal progress for the same command",
   assert.equal(merged.commands[0].status, "executed");
 });
 
+test("concurrent ledger merges retain the verified delivery for the exact comment body", () => {
+  const identified = {
+    ...command("same", "2026-07-18T22:10:31Z"),
+    repo: "openclaw/openclaw",
+    comment_body_sha256: "a".repeat(64),
+    source_delivery_id: "github-original-delivery",
+    status: "claimed",
+  };
+  const { source_delivery_id: _sourceDeliveryId, ...scheduledIdentity } = identified;
+  const scheduled = {
+    ...scheduledIdentity,
+    status: "waiting",
+    processed_at: "2026-07-18T22:10:32Z",
+  };
+
+  for (const [first, second] of [
+    [ledger([identified]), ledger([scheduled])],
+    [ledger([scheduled]), ledger([identified])],
+  ]) {
+    const merged = JSON.parse(mergeCommentRouterLedgers(first, second));
+    assert.equal(merged.commands[0].status, "waiting");
+    assert.equal(merged.commands[0].source_delivery_id, "github-original-delivery");
+  }
+
+  const changedBody = { ...scheduled, comment_body_sha256: "b".repeat(64) };
+  assert.equal(
+    JSON.parse(mergeCommentRouterLedgers(ledger([identified]), ledger([changedBody]))).commands[0]
+      .source_delivery_id,
+    undefined,
+  );
+});
+
+test("concurrent comment delivery merges converge regardless of grouping", () => {
+  const base = {
+    ...command("same", "2026-07-18T22:10:31Z"),
+    repo: "openclaw/openclaw",
+    comment_body_sha256: "a".repeat(64),
+  };
+  const variants = ["claimed", "waiting", "skipped", "executed"].flatMap((status) =>
+    [undefined, "a".repeat(64), "b".repeat(64)].flatMap((bodySha256) =>
+      [undefined, "delivery-a", "delivery-b"].map((sourceDeliveryId) => ({
+        ...base,
+        status,
+        ...(bodySha256 === undefined
+          ? { comment_body_sha256: undefined }
+          : { comment_body_sha256: bodySha256 }),
+        ...(sourceDeliveryId ? { source_delivery_id: sourceDeliveryId } : {}),
+      })),
+    ),
+  );
+
+  for (const first of variants) {
+    for (const second of variants) {
+      assert.equal(
+        mergeCommentRouterLedgers(ledger([first]), ledger([second])),
+        mergeCommentRouterLedgers(ledger([second]), ledger([first])),
+      );
+      for (const third of variants) {
+        assert.equal(
+          mergeCommentRouterLedgers(
+            mergeCommentRouterLedgers(ledger([first]), ledger([second])),
+            ledger([third]),
+          ),
+          mergeCommentRouterLedgers(
+            ledger([first]),
+            mergeCommentRouterLedgers(ledger([second]), ledger([third])),
+          ),
+        );
+      }
+    }
+  }
+});
+
+test("conflicting comment bodies permanently discard delivery provenance", () => {
+  const first = {
+    ...command("same", "2026-07-18T22:10:31Z"),
+    repo: "openclaw/openclaw",
+    comment_body_sha256: "a".repeat(64),
+    source_delivery_id: "delivery-a",
+    status: "claimed",
+  };
+  const incompatible = {
+    ...first,
+    comment_body_sha256: "b".repeat(64),
+    status: "waiting",
+  };
+  const later = {
+    ...first,
+    status: "executed",
+  };
+
+  for (const merged of [
+    mergeCommentRouterLedgers(
+      mergeCommentRouterLedgers(ledger([first]), ledger([incompatible])),
+      ledger([later]),
+    ),
+    mergeCommentRouterLedgers(
+      ledger([first]),
+      mergeCommentRouterLedgers(ledger([incompatible]), ledger([later])),
+    ),
+  ]) {
+    const entry = JSON.parse(merged).commands[0];
+    assert.equal(entry.status, "executed");
+    assert.equal(entry.source_delivery_id, undefined);
+    assert.equal(entry.source_delivery_conflict, true);
+  }
+});
+
 test("comment router ledger merge never regresses executed evidence to a later skip", () => {
   const executed = { ...command("same", "2026-07-18T22:10:31Z"), status: "executed" };
   const skipped = { ...executed, status: "skipped", processed_at: "2026-07-18T22:10:32Z" };

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -19,6 +19,7 @@ import {
   normalizeGitHubActor,
   readLedger,
   routerDispatchReceiptKey,
+  routedCommentSourceDeliveryId,
   selectCommentsForRouting,
   shouldSuppressProcessedCommentVersion,
   sortCommentsForRouting,
@@ -115,6 +116,84 @@ test("terminal cleanup requires the same live comment version", () => {
       body: `${body} now`,
     }),
     false,
+  );
+});
+
+test("command delivery identity follows only its authenticated exact comment version", () => {
+  const body = "@clawsweeper re-review";
+  const comment = {
+    id: 456,
+    updated_at: "2026-07-12T20:00:00Z",
+    body,
+  };
+  const event = {
+    authenticated: true,
+    commentId: 456,
+    commentUpdatedAt: comment.updated_at,
+    commentBodySha256: commentBodySha256(body),
+    sourceDeliveryId: "github-original-delivery",
+  };
+  const options = {
+    comment,
+    event,
+    priorClaim: null,
+    targetRepo: "openclaw/openclaw",
+  };
+
+  assert.equal(routedCommentSourceDeliveryId(options), "github-original-delivery");
+  assert.equal(
+    routedCommentSourceDeliveryId({
+      ...options,
+      comment: { ...comment, updated_at: "2026-07-12T20:01:00Z" },
+    }),
+    null,
+  );
+  assert.equal(
+    routedCommentSourceDeliveryId({ ...options, comment: { ...comment, body: `${body} edited` } }),
+    null,
+  );
+  assert.equal(
+    routedCommentSourceDeliveryId({
+      ...options,
+      event: { ...event, authenticated: false },
+    }),
+    null,
+  );
+  const priorClaim = {
+    repo: "openclaw/openclaw",
+    comment_id: "456",
+    comment_updated_at: comment.updated_at,
+    comment_body_sha256: commentBodySha256(body),
+    source_delivery_id: "github-durable-delivery",
+  };
+  assert.equal(
+    routedCommentSourceDeliveryId({
+      ...options,
+      event: { ...event, authenticated: false, sourceDeliveryId: null },
+      priorClaim,
+    }),
+    "github-durable-delivery",
+  );
+  assert.equal(
+    routedCommentSourceDeliveryId({
+      ...options,
+      comment: { ...comment, body: `${body} edited` },
+      event: { ...event, authenticated: false, sourceDeliveryId: null },
+      priorClaim,
+    }),
+    null,
+  );
+  assert.equal(
+    routedCommentSourceDeliveryId({
+      ...options,
+      priorClaim: {
+        ...priorClaim,
+        source_delivery_id: undefined,
+        source_delivery_conflict: true,
+      },
+    }),
+    null,
+    "an authenticated redelivery must never resurrect conflicted durable provenance",
   );
 });
 
@@ -1032,6 +1111,77 @@ test("appendLedger preserves the original timestamp while a claim waits", () => 
   ]);
 
   assert.equal(ledger.commands[0].processed_at, processedAt);
+});
+
+test("appendLedger persists authenticated delivery identities across durable dispatch retries", () => {
+  const ledger = { updated_at: null, commands: [] };
+  const body = "@clawsweeper re-review";
+  appendLedger(ledger, [
+    {
+      idempotency_key: "claim-before-dispatch",
+      comment_id: "125",
+      comment_version_key: "125:2026-04-29T03:01:00Z",
+      comment_updated_at: "2026-04-29T03:01:00Z",
+      comment_body_sha256: commentBodySha256(body),
+      source_delivery_id: "github-original-command-delivery",
+      status: "claimed",
+      intent: "clawsweeper_re_review",
+      issue_number: 74499,
+      repo: "openclaw/openclaw",
+      actions: [{ action: "dispatch_clawsweeper", status: "claimed" }],
+    },
+  ]);
+  const restoredClaim = ledger.commands[0];
+  assert.equal(restoredClaim.source_delivery_id, "github-original-command-delivery");
+  assert.equal(
+    routedCommentSourceDeliveryId({
+      comment: { id: 125, updated_at: "2026-04-29T03:01:00Z", body },
+      event: {
+        authenticated: false,
+        commentId: null,
+        commentUpdatedAt: null,
+        commentBodySha256: null,
+        sourceDeliveryId: null,
+      },
+      priorClaim: restoredClaim,
+      targetRepo: "openclaw/openclaw",
+    }),
+    "github-original-command-delivery",
+  );
+});
+
+test("appendLedger keeps delivery-conflict tombstones while durable commands advance", () => {
+  const base = {
+    idempotency_key: "claim-before-dispatch",
+    comment_id: "125",
+    comment_version_key: "125:2026-04-29T03:01:00Z",
+    comment_updated_at: "2026-04-29T03:01:00Z",
+    comment_body_sha256: commentBodySha256("@clawsweeper re-review"),
+    status: "waiting",
+    intent: "clawsweeper_re_review",
+    issue_number: 74499,
+    repo: "openclaw/openclaw",
+    processed_at: "2026-04-29T03:01:00Z",
+  };
+  const ledger = {
+    updated_at: null,
+    commands: [{ ...base, source_delivery_conflict: true }],
+  };
+
+  assert.equal(
+    appendLedger(ledger, [
+      {
+        ...base,
+        status: "executed",
+        source_delivery_id: "must-not-be-resurrected",
+        actions: [{ action: "dispatch_clawsweeper", status: "executed" }],
+      },
+    ]),
+    true,
+  );
+  assert.equal(ledger.commands[0]?.status, "executed");
+  assert.equal(ledger.commands[0]?.source_delivery_conflict, true);
+  assert.equal(ledger.commands[0]?.source_delivery_id, undefined);
 });
 
 test("appendLedger upgrades claimed dispatch commands after execution", () => {

--- a/test/repair/update-command-status.test.ts
+++ b/test/repair/update-command-status.test.ts
@@ -264,6 +264,8 @@ test("terminal receipt verification accepts the matching legacy command marker",
     "115286",
     "--marker",
     marker,
+    "--status-comment-id",
+    "5150578737",
     "--state",
     "Complete",
     "--detail",
@@ -288,6 +290,22 @@ test("terminal receipt verification accepts the matching legacy command marker",
     commandCommentId: 5150571675,
     completionCommentId: 5150578737,
   });
+  assert.equal(verifiedTerminalStatusReceipt({ ...comment, id: 5150578738 }, options), null);
+  assert.deepEqual(
+    verifiedTerminalStatusReceipt(
+      comment,
+      parseOptions([
+        "--marker",
+        marker,
+        "--state",
+        "Complete",
+        "--detail",
+        "A newer review tuple already exists; this stale result was superseded.",
+        "--verify-terminal-status-receipt",
+      ]),
+    ),
+    { commandCommentId: 5150571675, completionCommentId: 5150578737 },
+  );
   assert.equal(
     verifiedTerminalStatusReceipt(
       {
@@ -375,7 +393,13 @@ test("terminal locked-conversation skip covers status selection and duplicate cl
 function runUpdateCommandStatus(
   tmp: string,
   args: string[],
-  comment?: { id: number; body: string; user: { login: string } },
+  comment?: { id: number; body: string; user: { login: string }; updated_at?: string },
+  additionalComments: Array<{
+    id: number;
+    body: string;
+    user: { login: string };
+    updated_at?: string;
+  }> = [],
 ) {
   const ghPath = path.join(tmp, "gh.js");
   const patchPath = path.join(tmp, "patched-comment.json");
@@ -386,12 +410,18 @@ function runUpdateCommandStatus(
       "const args = process.argv.slice(2);",
       "if (!args.join(' ').includes('/comments')) process.exit(1);",
       "const comment = JSON.parse(process.env.GH_TEST_STATUS_COMMENT || 'null');",
+      "const comments = JSON.parse(process.env.GH_TEST_STATUS_COMMENTS || '[]');",
       "if (args.includes('PATCH')) {",
       "  const payload = JSON.parse(fs.readFileSync(args[args.indexOf('--input') + 1], 'utf8'));",
       "  fs.writeFileSync(process.env.GH_TEST_STATUS_PATCH_PATH, JSON.stringify(payload));",
-      "  process.stdout.write(JSON.stringify({ ...comment, body: payload.body }));",
+      "  process.stdout.write(JSON.stringify({ ...comment, body: payload.body, updated_at: '2026-08-01T08:14:07Z' }));",
+      "} else if (args.some((arg) => /\\/issues\\/comments\\/\\d+$/.test(arg))) {",
+      "  const commentId = Number(args.find((arg) => /\\/issues\\/comments\\/\\d+$/.test(arg)).split('/').at(-1));",
+      "  const exact = comments.find((candidate) => Number(candidate.id) === commentId);",
+      "  if (!exact) { console.error('HTTP 404: Not Found'); process.exit(1); }",
+      "  process.stdout.write(JSON.stringify({ ...exact, issue_url: process.env.GH_TEST_ISSUE_URL }));",
       "} else {",
-      "  process.stdout.write(JSON.stringify(comment ? [[comment]] : [[]]));",
+      "  process.stdout.write(JSON.stringify([comments]));",
       "}",
     ].join("\n"),
   );
@@ -408,6 +438,11 @@ function runUpdateCommandStatus(
         GH_BIN: process.execPath,
         GH_BIN_ARGS: JSON.stringify([ghPath]),
         GH_TEST_STATUS_COMMENT: JSON.stringify(comment ?? null),
+        GH_TEST_STATUS_COMMENTS: JSON.stringify([
+          ...additionalComments,
+          ...(comment ? [comment] : []),
+        ]),
+        GH_TEST_ISSUE_URL: `https://api.github.com/repos/openclaw/openclaw/issues/${args[args.indexOf("--item-number") + 1]}`,
         GH_TEST_STATUS_PATCH_PATH: patchPath,
         GITHUB_OUTPUT: outputPath,
         CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1",
@@ -431,53 +466,75 @@ function runUpdateCommandStatus(
 
 test("legacy command updates verify their receipt without creating duplicate acknowledgements", () => {
   for (const alreadyComplete of [false, true]) {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-legacy-command-status-"));
-    try {
-      const marker = "<!-- clawsweeper-command-status:115286:re_review:80a1f1 -->";
-      const comment = {
-        id: 5150578737,
-        user: { login: "clawsweeper[bot]" },
-        body: [
-          marker,
-          "<!-- clawsweeper-command:5150571675:2026-08-01T08:13:51Z:re_review:80a1f1 -->",
-          "<!-- clawsweeper-command-progress:start -->",
-          `- State: ${alreadyComplete ? "Complete" : "In progress"}`,
-          `- Detail: ${alreadyComplete ? "Done." : "Waiting."}`,
-          "<!-- clawsweeper-command-progress:end -->",
-        ].join("\n"),
-      };
-      const result = runUpdateCommandStatus(
-        tmp,
-        [
-          "--repo",
-          "openclaw/openclaw",
-          "--item-number",
-          "115286",
-          "--marker",
-          marker,
-          "--state",
-          "Complete",
-          "--detail",
-          "Done.",
-          "--require-mutation",
-          "--verify-terminal-status-receipt",
-        ],
-        comment,
-      );
+    for (const statusAddress of ["exact", "marker-only", "deleted", "replaced"]) {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-legacy-command-status-"));
+      try {
+        const marker = "<!-- clawsweeper-command-status:115286:re_review:80a1f1 -->";
+        const comment = {
+          id: 5150578737,
+          user: { login: "clawsweeper[bot]" },
+          updated_at: "2026-08-01T08:13:59Z",
+          body: [
+            marker,
+            "<!-- clawsweeper-command:5150571675:2026-08-01T08:13:51Z:re_review:80a1f1 -->",
+            "<!-- clawsweeper-command-progress:start -->",
+            `- State: ${alreadyComplete ? "Complete" : "In progress"}`,
+            `- Detail: ${alreadyComplete ? "Done." : "Waiting."}`,
+            "<!-- clawsweeper-command-progress:end -->",
+          ].join("\n"),
+        };
+        const result = runUpdateCommandStatus(
+          tmp,
+          [
+            "--repo",
+            "openclaw/openclaw",
+            "--item-number",
+            "115286",
+            "--marker",
+            marker,
+            ...(statusAddress === "marker-only"
+              ? []
+              : ["--status-comment-id", statusAddress === "exact" ? "5150578737" : "5150578738"]),
+            "--state",
+            "Complete",
+            "--detail",
+            "Done.",
+            "--require-mutation",
+            "--verify-terminal-status-receipt",
+          ],
+          comment,
+          statusAddress === "replaced"
+            ? [
+                {
+                  id: 5150578738,
+                  user: { login: "clawsweeper[bot]" },
+                  body: "<!-- clawsweeper-command-status:115286:re_review:old -->\n<!-- clawsweeper-command-ack:999 -->",
+                },
+              ]
+            : [],
+        );
 
-      assert.equal(result.status, 0, result.stderr);
-      assert.match(result.output, /^terminal_status_verified=true$/m);
-      assert.match(result.output, /^command_comment_id=5150571675$/m);
-      assert.match(result.output, /^completion_comment_id=5150578737$/m);
-      if (alreadyComplete) {
-        assert.equal(result.patchedBody, null);
-      } else {
-        assert.doesNotMatch(result.patchedBody ?? "", /clawsweeper-command-ack:/);
-        assert.match(result.patchedBody ?? "", /clawsweeper-command:5150571675:/);
+        assert.equal(result.status, 0, result.stderr);
+        assert.match(result.output, /^terminal_status_verified=true$/m);
+        assert.match(result.output, /^command_comment_id=5150571675$/m);
+        assert.match(result.output, /^completion_comment_id=5150578737$/m);
+        assert.match(
+          result.output,
+          new RegExp(
+            `^completion_completed_at=2026-08-01T08:${alreadyComplete ? "13:59" : "14:07"}Z$`,
+            "m",
+          ),
+        );
+        if (alreadyComplete) {
+          assert.equal(result.patchedBody, null);
+        } else {
+          assert.doesNotMatch(result.patchedBody ?? "", /clawsweeper-command-ack:/);
+          assert.match(result.patchedBody ?? "", /clawsweeper-command:5150571675:/);
+        }
+        assert.match(result.patchedBody ?? comment.body, /- State: Complete\n- Detail: Done\./);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
       }
-      assert.match(result.patchedBody ?? comment.body, /- State: Complete\n- Detail: Done\./);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
     }
   }
 });

--- a/test/repair/update-command-status.test.ts
+++ b/test/repair/update-command-status.test.ts
@@ -252,6 +252,89 @@ test("terminal receipt verification accepts a status-ID-only final status", () =
   );
 });
 
+test("terminal receipt verification accepts the matching legacy command marker", () => {
+  const marker =
+    "<!-- clawsweeper-command-status:115286:re_review:80a1f1ecec31e5611087de2ee662eb27fec2abc1 -->";
+  const legacyMarker =
+    "<!-- clawsweeper-command:5150571675:2026-08-01T08:13:51Z:re_review:80a1f1ecec31e5611087de2ee662eb27fec2abc1 -->";
+  const options = parseOptions([
+    "--repo",
+    "openclaw/openclaw",
+    "--item-number",
+    "115286",
+    "--marker",
+    marker,
+    "--state",
+    "Complete",
+    "--detail",
+    "A newer review tuple already exists; this stale result was superseded.",
+    "--verify-terminal-status-receipt",
+  ]);
+  const comment = {
+    id: 5150578737,
+    body: [
+      marker,
+      legacyMarker,
+      "ClawSweeper re-review requested.",
+      "<!-- clawsweeper-command-progress:start -->",
+      "Re-review progress:",
+      "- State: Complete",
+      "- Detail: A newer review tuple already exists; this stale result was superseded.",
+      "<!-- clawsweeper-command-progress:end -->",
+    ].join("\n"),
+  };
+
+  assert.deepEqual(verifiedTerminalStatusReceipt(comment, options), {
+    commandCommentId: 5150571675,
+    completionCommentId: 5150578737,
+  });
+  assert.equal(
+    verifiedTerminalStatusReceipt(
+      {
+        ...comment,
+        body: comment.body.replace(
+          legacyMarker,
+          legacyMarker.replace(":re_review:", ":automerge:"),
+        ),
+      },
+      options,
+    ),
+    null,
+  );
+  assert.equal(
+    verifiedTerminalStatusReceipt(
+      {
+        ...comment,
+        body: comment.body.replace(
+          legacyMarker,
+          legacyMarker.replace("80a1f1ecec31e5611087de2ee662eb27fec2abc1", "mismatch"),
+        ),
+      },
+      options,
+    ),
+    null,
+  );
+  assert.equal(
+    verifiedTerminalStatusReceipt(
+      { ...comment, body: `${legacyMarker}\n${comment.body}` },
+      options,
+    ),
+    null,
+  );
+  for (const invalidAck of ["0", "9007199254740992", "invalid"]) {
+    assert.equal(
+      verifiedTerminalStatusReceipt(
+        {
+          ...comment,
+          body: `<!-- clawsweeper-command-ack:${invalidAck} -->\n${comment.body}`,
+        },
+        options,
+      ),
+      null,
+    );
+  }
+});
+
 test("parseOptions enables the terminal locked-conversation skip only when requested", () => {
   const options = parseOptions([
     "--repo",
@@ -289,14 +372,27 @@ test("terminal locked-conversation skip covers status selection and duplicate cl
   assert.match(source.slice(selection, caught), /catch \(error\)/);
 });
 
-function runUpdateCommandStatus(tmp: string, args: string[]) {
+function runUpdateCommandStatus(
+  tmp: string,
+  args: string[],
+  comment?: { id: number; body: string; user: { login: string } },
+) {
   const ghPath = path.join(tmp, "gh.js");
+  const patchPath = path.join(tmp, "patched-comment.json");
   fs.writeFileSync(
     ghPath,
     [
-      "const args = process.argv.slice(2).join(' ');",
-      "if (!args.includes('/comments')) process.exit(1);",
-      "process.stdout.write(JSON.stringify([[]]));",
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "if (!args.join(' ').includes('/comments')) process.exit(1);",
+      "const comment = JSON.parse(process.env.GH_TEST_STATUS_COMMENT || 'null');",
+      "if (args.includes('PATCH')) {",
+      "  const payload = JSON.parse(fs.readFileSync(args[args.indexOf('--input') + 1], 'utf8'));",
+      "  fs.writeFileSync(process.env.GH_TEST_STATUS_PATCH_PATH, JSON.stringify(payload));",
+      "  process.stdout.write(JSON.stringify({ ...comment, body: payload.body }));",
+      "} else {",
+      "  process.stdout.write(JSON.stringify(comment ? [[comment]] : [[]]));",
+      "}",
     ].join("\n"),
   );
   const outputPath = path.join(tmp, "github-output");
@@ -311,6 +407,8 @@ function runUpdateCommandStatus(tmp: string, args: string[]) {
         ...process.env,
         GH_BIN: process.execPath,
         GH_BIN_ARGS: JSON.stringify([ghPath]),
+        GH_TEST_STATUS_COMMENT: JSON.stringify(comment ?? null),
+        GH_TEST_STATUS_PATCH_PATH: patchPath,
         GITHUB_OUTPUT: outputPath,
         CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1",
       },
@@ -321,8 +419,68 @@ function runUpdateCommandStatus(tmp: string, args: string[]) {
     status = failure.status ?? 1;
     stderr = String(failure.stderr ?? "");
   }
-  return { status, stderr, output: fs.readFileSync(outputPath, "utf8") };
+  return {
+    status,
+    stderr,
+    output: fs.readFileSync(outputPath, "utf8"),
+    patchedBody: fs.existsSync(patchPath)
+      ? (JSON.parse(fs.readFileSync(patchPath, "utf8")) as { body: string }).body
+      : null,
+  };
 }
+
+test("legacy command updates verify their receipt without creating duplicate acknowledgements", () => {
+  for (const alreadyComplete of [false, true]) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-legacy-command-status-"));
+    try {
+      const marker = "<!-- clawsweeper-command-status:115286:re_review:80a1f1 -->";
+      const comment = {
+        id: 5150578737,
+        user: { login: "clawsweeper[bot]" },
+        body: [
+          marker,
+          "<!-- clawsweeper-command:5150571675:2026-08-01T08:13:51Z:re_review:80a1f1 -->",
+          "<!-- clawsweeper-command-progress:start -->",
+          `- State: ${alreadyComplete ? "Complete" : "In progress"}`,
+          `- Detail: ${alreadyComplete ? "Done." : "Waiting."}`,
+          "<!-- clawsweeper-command-progress:end -->",
+        ].join("\n"),
+      };
+      const result = runUpdateCommandStatus(
+        tmp,
+        [
+          "--repo",
+          "openclaw/openclaw",
+          "--item-number",
+          "115286",
+          "--marker",
+          marker,
+          "--state",
+          "Complete",
+          "--detail",
+          "Done.",
+          "--require-mutation",
+          "--verify-terminal-status-receipt",
+        ],
+        comment,
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.output, /^terminal_status_verified=true$/m);
+      assert.match(result.output, /^command_comment_id=5150571675$/m);
+      assert.match(result.output, /^completion_comment_id=5150578737$/m);
+      if (alreadyComplete) {
+        assert.equal(result.patchedBody, null);
+      } else {
+        assert.doesNotMatch(result.patchedBody ?? "", /clawsweeper-command-ack:/);
+        assert.match(result.patchedBody ?? "", /clawsweeper-command:5150571675:/);
+      }
+      assert.match(result.patchedBody ?? comment.body, /- State: Complete\n- Detail: Done\./);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+});
 
 test("missing status comment completes the terminal acknowledgement as a skip", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-update-command-status-"));

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1179,6 +1179,14 @@ test("exact event publication derives lifecycle receipt and final command acknow
   );
   assert.match(observedReceipt.if ?? "", /terminal_status_verified == 'true'/);
   assert.equal(
+    observedReceipt.env?.FENCE_KEY,
+    "${{ steps.finalization-context.outputs.lifecycle_fence_key }}",
+  );
+  assert.equal(
+    observedReceipt.env?.REVISION,
+    "${{ steps.finalization-context.outputs.lifecycle_revision }}",
+  );
+  assert.equal(
     observedReceipt.env?.STATUS_COMMENT_ID,
     "${{ steps.finalization-context.outputs.status_comment_id }}",
   );
@@ -1191,6 +1199,8 @@ test("exact event publication derives lifecycle receipt and final command acknow
     observedReceipt.run ?? "",
     /const statusCommentId = process\.env\.STATUS_COMMENT_ID/,
   );
+  assert.match(observedReceipt.run ?? "", /fence_key: fenceKey/);
+  assert.match(observedReceipt.run ?? "", /revision,/);
   assert.match(
     observedReceipt.run ?? "",
     /\.\.\.\(statusMarker \? \{ status_marker: statusMarker \} : \{\}\)/,
@@ -4547,6 +4557,11 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
     /status_comment_id="\$\{\{ github\.event\.client_payload\.status_comment_id \|\| '' \}\}"/,
   );
   assert.match(routerWorkflow, /--status-comment-id "\$status_comment_id"/);
+  assert.match(
+    routerWorkflow,
+    /source_delivery_id="\$\{\{ github\.event\.client_payload\.source_delivery_id \|\| '' \}\}"/,
+  );
+  assert.match(routerWorkflow, /--source-delivery-id "\$source_delivery_id"/);
   assert.match(routerWorkflow, /dispatch_actor="\$\{\{ github\.actor \}\}"/);
   assert.match(routerWorkflow, /--dispatch-actor "\$dispatch_actor"/);
   assert.match(routerWorkflow, /--comment-event-auth "\$comment_event_auth"/);
@@ -4559,13 +4574,18 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   );
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
   assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);
+  assert.match(routerSource, /review_options:\s*\{/);
   assert.match(routerSource, /media_proof_timeout_ms: reviewBudget\.mediaProofTimeoutMs/);
   assert.match(routerSource, /dispatch_key:\s*dispatchKey/);
+  assert.match(routerSource, /source_delivery_id:\s*String\(command\.source_delivery_id\)/);
   assert.match(routerSource, /`item_numbers=\$\{dispatchKey\}`/);
   assert.match(routerSource, /event:\s*"workflow_dispatch"/);
   assert.match(sweepWorkflow, /types:\s*\[clawsweeper_item,\s*clawsweeper_target_sweep\]/);
   assert.match(sweepWorkflow, /Review event item \{0\}#\{1\} \[\{2\}\]/);
   assert.match(sweepWorkflow, /startsWith\(github\.event\.inputs\.item_numbers, 'router-'\)/);
+  assert.match(sweepWorkflow, /sourceDeliveryId:\s*payload\.source_delivery_id/);
+  assert.match(sweepWorkflow, /reviewOptions\.codex_timeout_ms/);
+  assert.match(sweepWorkflow, /reviewOptions\.media_proof_timeout_ms/);
   assert.doesNotMatch(sweepWorkflow, /types:\s*\[[^\]]*clawsweeper_comment/);
 });
 
@@ -5254,8 +5274,10 @@ test("legacy event field serializer preserves branchless issue and PR intake", (
     (step) => step.name === "Enqueue legacy event through the durable control plane",
   )?.run;
   assert.ok(run);
-  const script = run.match(/node <<'NODE'\n([\s\S]*?)\nNODE\n/)?.[1];
+  const scripts = [...run.matchAll(/node <<'NODE'\n([\s\S]*?)\nNODE\n/g)].map((match) => match[1]);
+  const script = scripts[0];
   assert.ok(script);
+  assert.equal(scripts.length, 2);
 
   const serialize = (payload: Record<string, unknown>): string[] => {
     const output = execFileSync(process.execPath, ["-"], {
@@ -5314,6 +5336,31 @@ test("legacy event field serializer preserves branchless issue and PR intake", (
     }),
     ["openclaw/clawhub", "main", "0"],
   );
+
+  const reviewDecision = JSON.parse(
+    execFileSync(process.execPath, ["-"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLIENT_PAYLOAD: JSON.stringify({
+          target_repo: "openclaw/openclaw",
+          item_number: 117838,
+          item_kind: "pull_request",
+          source_delivery_id: "original-review-delivery",
+          review_options: {
+            codex_timeout_ms: 1_200_000,
+            media_proof_timeout_ms: 480_000,
+          },
+        }),
+        TARGET_REPO: "openclaw/openclaw",
+        TARGET_BRANCH: "main",
+      },
+      input: scripts[1],
+    }),
+  );
+  assert.equal(reviewDecision.decision.codexTimeoutMs, 1_200_000);
+  assert.equal(reviewDecision.decision.mediaProofTimeoutMs, 480_000);
+  assert.equal(reviewDecision.decision.sourceDeliveryId, "original-review-delivery");
 });
 
 test("sweep issue and PR event reviews and target fanout avoid storm amplification", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1196,7 +1196,16 @@ test("exact event publication derives lifecycle receipt and final command acknow
     /\.\.\.\(statusMarker \? \{ status_marker: statusMarker \} : \{\}\)/,
   );
   assert.match(observedReceipt.run ?? "", /command_comment_id: commandCommentId/);
+  assert.match(
+    observedReceipt.run ?? "",
+    /\.\.\.\(statusCommentId === null \? \{\} : \{ status_comment_id: statusCommentId \}\)/,
+  );
   assert.match(observedReceipt.run ?? "", /completion_comment_id: completionCommentId/);
+  assert.match(observedReceipt.run ?? "", /completed_at: completedAt/);
+  assert.equal(
+    observedReceipt.env?.COMPLETION_COMPLETED_AT,
+    "${{ steps.update-final-command-status.outputs.completion_completed_at }}",
+  );
   assert.match(observedReceipt.run ?? "", /acknowledgement_state == "observed"/);
   assert.match(lockedSkip.if ?? "", /locked_conversation == 'true'/);
   assert.match(lockedSkip.if ?? "", /missing_status_comment == 'true'/);
@@ -4544,6 +4553,10 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   assert.match(routerWorkflow, /--comment-updated-at "\$comment_updated_at"/);
   assert.match(routerWorkflow, /--comment-body-sha256 "\$comment_body_sha256"/);
   assert.match(routerWorkflow, /\.short_circuited == true/);
+  assert.match(
+    routerSource,
+    /if \(requiresCommandStatus\) \{\s*const retainedStatusComment = findExistingCommandStatusComment\(command\);\s*if \(retainedStatusComment\?\.id\) command\.status_comment_id = Number\(retainedStatusComment\.id\);\s*\}\s*let dispatchKey = dispatchReceiptKey\(command\);/,
+  );
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
   assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);
   assert.match(routerSource, /media_proof_timeout_ms: reviewBudget\.mediaProofTimeoutMs/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -4570,7 +4570,7 @@ test("comment commands keep the router-to-sweep dispatch contract", () => {
   assert.match(routerWorkflow, /\.short_circuited == true/);
   assert.match(
     routerSource,
-    /if \(requiresCommandStatus\) \{\s*const retainedStatusComment = findExistingCommandStatusComment\(command\);\s*if \(retainedStatusComment\?\.id\) command\.status_comment_id = Number\(retainedStatusComment\.id\);\s*\}\s*let dispatchKey = dispatchReceiptKey\(command\);/,
+    /if \(claimed\) return \{ \.\.\.claimed, workflow: reviewWorkflow, repo: reviewRepo \};\s*if \(requiresCommandStatus\) \{\s*const retainedStatusComment = findExistingCommandStatusComment\(command\);\s*if \(retainedStatusComment\?\.id\) command\.status_comment_id = Number\(retainedStatusComment\.id\);\s*\}/,
   );
   assert.match(routerSource, /event_type:\s*"clawsweeper_item"/);
   assert.match(routerSource, /adaptiveReviewBudgetForPullRequest\(command\.target\)/);


### PR DESCRIPTION
## Summary

- Complete the legacy terminal finalizer stuck on `openclaw/openclaw#115286` by recognizing its exact, action/head-bound legacy command marker in both the repair CLI and authoritative Worker.
- Bind legacy receipts to the actual authorized status comment and exact status marker; reject forged comment IDs, mismatched markers, duplicate identities, and malformed acknowledgement markers.
- Fence modern shared status comments to their exact action/head marker so reused comments cannot finalize an older projection.
- Preserve marker-only commands, migrate pre-existing deleted/replaced status-comment addresses, and bind future router dispatches to the retained comment before convergence can delete a temporary fast acknowledgement.
- Complete Bay journeys idempotently for every authenticated, durably accepted review receipt, preserving the verified GitHub comment's actual `updated_at`; unchanged legacy completions work without a webhook, modern webhook completions remain single-counted, and command edits keep their correct journey.
- Bind signed migrated receipts to their originally admitted status-comment ID so repeated same-head reviews cannot finalize a different lifecycle revision; unsigned request bodies are never parsed.
- Preserve offline/local review, automatic OpenClaw fix PR creation with `gpt-5.6-sol` / `xhigh`, and disabled OpenClaw automatic merging.

## Root cause and real production proof

The public exact-review queue repeatedly reported:

```text
terminal-finalization:openclaw/openclaw#115286:5
health: critical / oldest_pending_over_6h
```

The real bot status comment `5150578737` contains the original command marker for source comment `5150571675`, but predates canonical `clawsweeper-command-ack` markers. Existing finalization updates the comment successfully but cannot verify its source receipt, leaving the publication permanently retryable.

A fresh GitHub API fetch of that actual production comment, passed through the newly compiled production receipt parser, now proves:

```json
{"verified":true,"issue":"openclaw/openclaw#115286","receipt":{"commandCommentId":5150571675,"completionCommentId":5150578737},"spoofRejected":true,"markerOnlyVerified":true}
```

The same production parser rejects the exact comment body when its comment ID is forged and still verifies authorized legacy commands that have only an exact status marker. Hosted Worker integration covers legacy and canonical acknowledgements across re-review, autofix, and automerge; the authoritative lifecycle rejects wrong IDs/markers without updating Bay telemetry, binds reused modern comments to the matching head marker, and preserves marker-only attempts. End-to-end repair CLI fixtures additionally recover legacy admissions whose advertised temporary comment was already deleted or whose advertised comment belongs to an older marker. Router workflow coverage proves the retained existing comment is selected before dispatch advertises its ID.

Executing the newly compiled production router dispatch function against a precreated-to-retained comment transition confirms the actual dispatched identity:

```json
{"precreatedStatusCommentId":4466202000,"retainedStatusCommentId":4466201000,"dispatchedStatusCommentId":4466201000,"originalGithubDeliveryId":"github-original-command-delivery","dispatchPayloadProperties":10,"nestedReviewTimeouts":{"codex_timeout_ms":1200000,"media_proof_timeout_ms":480000},"retainedCommentDispatched":true}
```

Executing the newly compiled production status-update CLI against the real comment body and two stale predeployment addresses produces verified terminal receipts in both cases:

```json
{"issue":"openclaw/openclaw#115286","legacyAddressRecovery":[{"mode":"deleted","advertisedCommentId":5150578738,"retainedCommentId":5150578737,"completedAt":"2026-08-03T05:43:18Z","verified":true},{"mode":"replaced","advertisedCommentId":5150578738,"retainedCommentId":5150578737,"completedAt":"2026-08-03T05:43:18Z","verified":true}]}
```

The existing guarded dead-letter reconciler separately resolved 45 stale rows. Generated OpenClaw fix PRs remain create-only; both OpenClaw merge switches are disabled.

## Review disposition

A fresh Codex review of the original committed head found two actionable P1 provenance gaps: a legacy webhook could acknowledge a different same-marker status comment, and the repair CLI could select a different same-marker status comment than the one requested. Legacy acknowledgements now carry a strict status-comment provenance flag through the authoritative queue, and the repair verifier honors the expected status-comment ID.

The first follow-up precommit review identified marker-only legacy commands and precreated fast acknowledgements that router convergence replaces with an older existing status comment. Both are preserved explicitly: marker-only attempts bind to the exact authorized marker, and dispatch resolves the retained comment before publishing its status-comment ID.

The next precommit review identified reused modern shared comments that could complete the wrong fence and pre-existing admissions that still pointed at a deleted/replaced status comment. Modern receipt matching now requires agreement when both markers exist. Legacy finalization securely rebinds only when the advertised comment no longer exists or demonstrably belongs to a different status marker; a still-valid same-marker advertised comment remains mandatory.

The latest fresh precommit review identified ID-only legacy admissions and Bay journeys completed through a signed direct receipt after a migrated webhook was rejected. Exact comment-ID matches now remain valid when the admission has no marker, and the authenticated lifecycle endpoint updates Bay only after the durable queue accepts a review/re-review receipt. All eight accepted findings have focused regression coverage.

A subsequent review identified double-counted normal review completions and parsing before signature verification. Signed receipts now carry their admitted status-comment ID; Bay repair runs only when that ID differs from the verified completion comment, and request JSON is parsed only after signature verification. All ten accepted findings have focused regression coverage.

The latest precommit review reproduced one additional P2 timestamp-provenance finding: synthesizing a migrated completion from receipt-processing time duplicated modern completions and could incorrectly complete a newer edit of the same source command. The repair CLI now extracts the verified GitHub comment's actual `updated_at` (including the returned PATCH response), signs that exact timestamp into the workflow receipt, and reuses it for Bay repair. Focused regressions independently cover migrated modern deduplication and preserving an older completion when a newer command edit exists.

The first committed-branch review reproduced a P1 cross-revision provenance gap and a P2 missed legacy completion: a migrated signed receipt could complete a newer same-head projection when its admitted comment ID was ignored, and unchanged legacy comments produced no new webhook. The authoritative queue now validates and forwards the signed admitted comment ID, lifecycle observation matches that exact authorized attempt, and every accepted signed review receipt completes its Bay journey using the verified GitHub timestamp.

A subsequent precommit review identified that replaying the same verified completion while another edit of the same source command remained pending could consume that unrelated edit. Bay merging now recognizes an exact existing completion identity before choosing another pending journey. End-to-end Worker regressions independently cover same-head cross-revision isolation, unchanged legacy receipt recovery, malformed admitted IDs, duplicate signed receipts, and webhook-plus-signed replay with multiple edits of the same source command.

The next committed-branch review reproduced an additional same-comment cross-revision collision. Terminal workflow receipts now sign the immutable lifecycle fence and revision, the authoritative queue requires that identity as an all-or-nothing pair, and the projection store matches the exact admitted revision. Its follow-up precommit review independently reproduced an unfenced GitHub webhook completing the wrong revision and a fenced older receipt completing a newer Bay journey. Ambiguous unfenced observations now fail closed without mutating either revision.

The following fresh review proved that lifecycle admission IDs (`router:...` / `publisher:...`) are not GitHub webhook delivery IDs, and reproduced unidentified-webhook races, legacy records without delivery IDs, and same-second orphan collisions. The original authenticated GitHub delivery ID now travels end-to-end through the hosted webhook, router workflow and command, sweep intake decision, immutable lifecycle admission, verified finalization receipt, and Bay reducer. Webhook completions receive the same canonical delivery identity from the authoritative queue. The reducer repairs a previously misattributed unidentified completion, accepts unambiguous legacy journeys, and keys identified orphan completions by delivery. The compiled production router proof above verifies both retained status-comment identity and the unchanged original GitHub delivery ID.

The next independent review found six additional production defects: both repository-dispatch hops exceeded GitHub's hard ten-property limit; edited comments could inherit an older delivery ID; scheduled recovery lost delivery provenance after a durable claim; identified completion orphans did not join legacy triggers; and a newer scoped receipt arriving before an older receipt left its journey permanently pending. The hosted webhook now omits redundant `source_event` only when carrying delivery identity, while the router workflow infers its fixed `issue_comment` source. Routed PR budgets share one `review_options` field, with backwards-compatible support for existing flat timeout fields. Delivery identity is accepted only for an authenticated matching comment timestamp and body digest, persisted in claimed/waiting durable ledger entries, and recovered only for that exact comment version. Bay accepts unambiguous mixed-version completion orphans and rejoins detached scoped receipts after correcting provisional matches. The real compiled PR dispatch proof above carries both adaptive timeouts, the original delivery identity, retained status-comment ID and command marker in exactly ten payload properties. All 120 possible trigger/webhook/scoped-receipt arrival permutations converge to two correctly attributed completed journeys.

The latest independent precommit review reproduced one P1 and two P2 integration regressions: the nested review-budget variable was accidentally declared in an earlier, separate Node heredoc; replacing a queued command without a new delivery ID retained the previous command's provenance; and shared-marker revisions with distinct status-comment IDs incorrectly rejected a uniquely identifiable webhook. The actual workflow serializer now declares its own nested options, and an executable regression runs both isolated Node heredocs against a real nested PR payload. Queue merges clear delivery identity whenever the marker or status-comment changes without a replacement identity. Unfenced lifecycle observations now prefer a single exact status-comment match while continuing to reject genuinely ambiguous same-comment attempts. All three behaviors have focused production-path regressions.

A second fresh review found three remaining same-comment race conditions. Concurrent state-ledger publication could discard a verified delivery when a scheduled waiting entry outranked the authenticated claim; same-head replacements could reuse both marker and status-comment ID while inheriting the old delivery; and an untagged legacy journey could capture a later tagged completion and disappear after normalization. Concurrent ledger union now preserves delivery only when repository, comment ID, exact comment timestamp and SHA-256 body digest all match. Any explicit command replacement without its own identity clears inherited provenance, including same-marker/same-comment replacements. Tagged completions detach provisional legacy observations and prefer their exact delivery-matched trigger before source-less legacy fallbacks. Regression tests exercise both concurrent merge directions, edited-body rejection, same-head replacements, and normalization after mixed legacy/scoped receipt arrival.

A further independent review stress-tested concurrent delivery permutations and exposed two additional convergence failures: three independently published command snapshots could choose different authenticated delivery IDs depending on merge grouping, and a provisional anonymous completion could consume the only identified journey before its genuine fenced completion arrived. Ledger union now chooses one canonical authenticated delivery deterministically, permanently discards provenance after conflicting or partially missing exact-comment identities, and is proven commutative and associative across **46,656** three-way status/delivery/body combinations, including legacy commands without body fingerprints. Bay now moves misassigned anonymous completions back to their own orphan, prefers exact delivery-matched orphans over earlier anonymous completions, safely assigns anonymous receipts only when exactly one compatible journey remains, keeps the newest of repeated delivery-fenced receipts, and breaks same-second completion ties by canonical comment ID. All **600 exhaustive permutations across nine identified/legacy/repeated-completion scenarios** converge to identical journeys. The corrected reducer also passed **30,000 randomized, mixed-order trigger/retry/webhook/fenced-receipt scenarios** without a dropped or misattributed journey.

The latest completed independent precommit reviews identified two related actionable P2 gaps: durable `appendLedger()` command advancement dropped the invalidated-delivery tombstone, and the router's in-memory prior-claim index discarded tombstones before an authenticated redelivery was dispatched. The authoritative ledger now preserves conflict tombstones across every status transition, suppresses all delivery IDs on conflicted commands, rejects malformed tombstones during durable loading, indexes conflicted pending commands even without a delivery ID, and rejects event delivery provenance whenever the matching prior command is tombstoned. Regressions advance a conflicted waiting command to executed with a forged replacement delivery and replay an authenticated exact-comment webhook; neither path restores delivery provenance.

The first committed-branch review identified one actionable P2 throughput regression: comment-history pagination ran before durable dispatch deduplication and repeated again when the status reply was written. Existing dispatch claims now short-circuit before any status-comment lookup, and retained status-comment selection reuses the router's existing per-issue comment cache. A follow-up precommit review correctly noted that a reused cache must be invalidated after successful comment creation, update, or temporary-ack deletion; all three mutation paths now evict the affected issue. The real compiled retained-comment dispatch proof remains unchanged while source-level coverage verifies the deduplication order, absence of duplicate `ghPaged` history scans, and all mutation invalidation paths.

## Validation

- **651 focused tests passed, zero failed**, covering the authoritative Worker, repair status updater, router core and durable ledger, executable isolated workflow heredocs, sweep workflows, spoofed receipts, wrong markers, marker-only/ID-only commands, temporary-to-retained convergence, deleted/replaced pre-existing addresses, immutable same-comment cross-revision fencing, ambiguous webhook rejection, exact status-comment precedence, queued command-replacement delivery isolation, concurrent ledger publication, associative concurrent command merges, permanently invalidated conflicting provenance, durable conflict-tombstone advancement, original GitHub delivery identity through synthetic publisher admissions, ten-property dispatch payload bounds, nested backwards-compatible adaptive review budgets, exact authenticated comment-version provenance, durable retry recovery, webhook-first and receipt-first reconciliation, source-less legacy journeys, source-less legacy/scoped completion reassignment, source-less provisional completion transfer, safely disambiguated anonymous completion, newest repeated fenced completion, same-second canonical completion identity, delivery-matched orphan priority, same-second identified completion orphans, all 120 event-arrival permutations, exact GitHub completion timestamps, unchanged legacy completion, modern migration deduplication, command-edit journey isolation, and authenticate-before-parse enforcement.
- Real live GitHub-comment receipt verification, forged-ID rejection, and marker-only verification passed.
- A real Worker request with an invalid signature returned `401` after **zero JSON parses**.
- Repair and dashboard TypeScript builds, changed-file lint, formatting, and `git diff --check` passed.
- Fresh precommit Codex review, committed-branch Codex review, exact-head ClawSweeper review, and current-head GitHub CI are required before merge.
