### PR TITLE
chore: bump hosted Codex executor to 0.146.0

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -3,7 +3,7 @@ description: Cache, install, and authenticate the OpenAI Codex CLI.
 inputs:
   codex-version:
     description: Exact Codex CLI npm package version.
-    default: "0.139.0"
+    default: "0.146.0"
   proxy-version:
     description: Exact Codex Responses proxy npm package version.
     default: "0.139.0"

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2333,7 +2333,7 @@ test("agent workflows install pinned CLI releases and keep runner models secret"
     ".github/workflows/sweep.yml",
   ].map((file) => readText(file));
 
-  assert.match(action, /codex-version:[\s\S]*default: "0\.139\.0"/);
+  assert.match(action, /codex-version:[\s\S]*default: "0\.146\.0"/);
   assert.match(action, /proxy-version:[\s\S]*default: "0\.139\.0"/);
   assert.match(action, /@openai\/codex@\$\{\{ inputs\['codex-version'\] \}\}/);
   assert.match(action, /@openai\/codex-responses-api-proxy@\$\{\{ inputs\['proxy-version'\] \}\}/);


### PR DESCRIPTION
## Summary

Update the hosted Codex executor default from `@openai/codex` 0.139.0 to
0.146.0.

## Problem

The shared Setup Codex composite action still defaulted hosted review and repair
workers to 0.139.0 while the current npm stable package and OpenClaw's managed
Codex runtime are 0.146.0.

## Implementation

- Change only `codex-version` in `.github/actions/setup-codex/action.yml`.
- Update the existing source regression assertion for that exact default.
- Leave `proxy-version` at 0.139.0: updating the separate Responses proxy is
  outside this executor-only change.

The change keeps the one-action-file boundary of the prior hosted-pin change,
[`6c695ead`](https://github.com/openclaw/clawsweeper/commit/6c695eadf9fb97e426774c6aa9e0454fba6def5f).

## Validation

- `node --test --test-name-pattern="agent workflows install pinned CLI releases and keep runner models secret" test/clawsweeper.test.ts` — pass.
- `pnpm run build` — pass.
- `git diff --check` — pass.
- `pnpm exec oxfmt --check .github/actions/setup-codex/action.yml test/clawsweeper.test.ts` — pass.
- YAML parse of the composite action — pass.
- `actionlint` was not installed on this host. The changed installer shell path
  was executed in the Linux proof below.
- `pnpm run check` was attempted. Its `format:check` stage reports 628
  pre-existing formatting issues in unmodified files and stops the aggregate
  gate before later stages; this change does not broaden into a formatting PR.

### Codex review closeout

- `codex review --uncommitted` — clean; no accepted/actionable findings.
- `codex review --base origin/main` — the final unchanged retry completed
  clean; no accepted/actionable findings. (An earlier base-review attempt
  timed out at the 10-minute execution limit, then the required same-base retry
  completed clean.)

## Real Behavior Proof

- Claim: the hosted Setup Codex action's default resolves and executes
  `@openai/codex` 0.146.0 in its isolated prefix.
- Surface: the checked-in composite action's actual install block, with the
  checked-in `codex-version` expression resolved to its default.
- Scenario / fixture: Linux Docker-backed Crabbox local-container; isolated
  temporary `HOME`, npm cache, and
  `~/.clawsweeper-repair/codex` prefix; all OpenAI/Codex/proxy/model variables
  removed; proxy setup disabled so no credentials are required.
- Command / environment: `C:\Users\marti\.local\bin\crabbox.exe run --provider local-container --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble --no-hydrate --timing-json --script .artifacts/csw-104-prove-setup-codex.sh`, at head `b76ea07da24cb1ad7fc594e51ca9c2b95be2d1c6`.
- Observed result: `CSW104_RESOLVED_PACKAGE=@openai/codex@0.146.0` and
  `CSW104_EXECUTED_VERSION=codex-cli 0.146.0`; exit 0.
- Artifact / trace: provider `local-container`, image
  `mcr.microsoft.com/playwright:v1.60.0-noble`, lease
  `cbx_c532bda5376e` / slug `violet-lobster` (auto-stopped). Timing: sync
  12.955s; command 20.294s; read-action 25ms; install 19.699s; verify 144ms.
  The trace contains no credentials.
- Limits: no GitHub Actions dispatch/rerun, cache-service integration,
  Responses-proxy/auth flow, or live model call. The Codex CLI printed a
  non-fatal temporary-CODEX_HOME PATH-alias warning but the isolated-prefix
  binary executed successfully.

## Risks / rollout

This is a draft for maintainer inspection only. It does not change the local
desktop CLI, OpenClaw's plugin, proxy pin, gates, deployment, queues, or
workflows. No workflow was dispatched or rerun for this change.
