### PR TITLE
fix: reviews whose repository inspection failed still publish a rating and close items

### DIFF
--- a/src/clawsweeper-record-metadata.ts
+++ b/src/clawsweeper-record-metadata.ts
@@ -478,7 +478,13 @@ export function createRecordMetadata({
   }
 
   function hasVerifiedLocalCheckoutAccess(markdown: string): boolean {
-    return frontMatterValue(markdown, "local_checkout_access") === "verified";
+    // The front-matter value is written unconditionally by the review writer, so on its own it
+    // only records that the reviewer was expected to have a checkout. When the review reports
+    // that its read-only inspection never ran, that expectation did not hold.
+    return (
+      frontMatterValue(markdown, "local_checkout_access") === "verified" &&
+      !hasBlockedLocalCheckoutAccess(markdown)
+    );
   }
 
   function effectiveReviewStatus(markdown: string): string {

--- a/test/apply-blocked-local-checkout.test.ts
+++ b/test/apply-blocked-local-checkout.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  implementedCloseReport,
+  reportWithSyncedReviewComment,
+  runApplyDecisionsForTest,
+  tmpPrefix,
+  withMockGh,
+} from "./helpers.ts";
+
+const SANDBOX_FAILURE =
+  "Inspection infrastructure failure: the only permitted local read command failed before opening repository files: `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`. Consequently, current-main source, history, and dependency contracts were not independently inspected.";
+
+test("apply withholds close when the review reports a blocked local checkout", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+
+    const synced = reportWithSyncedReviewComment(
+      implementedCloseReport({ number: 10 }),
+      10,
+      "implemented_on_main",
+    );
+    // The review record keeps the front-matter value the review writer always emits.
+    assert.match(synced.report, /^local_checkout_access: verified$/m);
+    writeFileSync(join(itemsDir, "10.md"), `${synced.report}\n${SANDBOX_FAILURE}\n`, "utf8");
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] === "-i" ? args[2] || "" : args[1] || "";
+const comment = ${JSON.stringify(synced.comment)};
+if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/10\\/timeline(?:\\?|$)/.test(path)) {
+  console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && /\\/issues\\/10\\/comments(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify([[
+    {
+      id: 9010,
+      html_url: "https://github.com/openclaw/clawsweeper/issues/10#issuecomment-9010",
+      body: comment,
+      user: { login: "github-actions[bot]" },
+      created_at: "2026-05-01T01:00:00Z",
+      updated_at: "2026-05-01T01:00:00Z"
+    }
+  ]]));
+} else if (args[0] === "api" && /\\/issues\\/10$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 10,
+    title: "Blocked local checkout",
+    html_url: "https://github.com/openclaw/clawsweeper/issues/10",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: 0,
+    pull_request: null
+  }));
+} else if (args[0] === "api" && path.startsWith("search/issues?")) {
+  console.log(JSON.stringify({ items: [] }));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--dry-run", "--item-numbers", "10", "--processed-limit", "2"],
+      });
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    assert.deepEqual(report, [
+      {
+        number: 10,
+        action: "kept_open",
+        reason: "review lacks verified local checkout access",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
> **History-rewrite recovery.** GitHub auto-closed the original contributor PR https://github.com/openclaw/clawsweeper/pull/988 on August 4, 2026 when `main` was rewritten to remove generated-state history. GitHub would not reopen it because the fork no longer shares a commit ancestor. This draft reapplies the original single commit to rewritten `main`. The original author, authored date, commit message, and co-author trailer are preserved; the predicate change is ported from retired `src/clawsweeper.ts` to current `src/clawsweeper-record-metadata.ts`. No unrelated behavior is included.

## Recovery Validation

**Current range.** Base `bb69d1fc582d46298df0f26f9192f721f976e9f4`; head `96b73e3bc5c058b57ca73ee3337ec351c3c727df`.

**Equivalence.** The original commit message, author identity/date, co-author trailer, and test blob are byte-for-byte preserved. The seven-line predicate change is identical after accounting for the module move on current `main`.

**Commands.** `./node_modules/.bin/tsc -p tsconfig.json`; `node --test test/apply-blocked-local-checkout.test.ts`; pre-commit `codex review --uncommitted`; committed-range `codex review --base origin/main`.

**Observed result.** The focused test passed, both Codex reviews reported no actionable findings, and the committed-range review passed 80 relevant tests plus typecheck, lint, and formatting.

**Limit.** This replacement preserves the original contributor patch and proof package; it does not broaden blocked-checkout phrase detection or change repair candidate selection.

## What Problem This Solves

When ClawSweeper's read-only repository inspection fails to start, the review it publishes still
carries a **Patch quality** tier and a merge-readiness verdict, and the item stays eligible for the
apply lane to close. The review text says the opposite in the same comment — for example:

> Inspection infrastructure failure: The only permitted local read command failed before opening
> repository files: `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`. Consequently,
> current-main source, scoped AGENTS guidance, history, and dependency contracts were not
> independently inspected.

while the scores table in the same comment reports:

> | **Patch quality** | 🦐 gold shrimp **(3/6)** | No actionable review findings were identified. |

Maintainers and contributors read a rating and a "no findings" rationale produced by an inspection
that provably did not run, and the item can be closed on that basis.

This is not rare. Of the ClawSweeper comment bodies on `openclaw/openclaw` last updated between
2026-07-27 and 07-31T12:00Z, **203 of 8,515** currently match `bwrap`/`RTM_NEWADDR` — a steady
**2.4%** share on each of those days. Among bodies last updated during 2026-07-31T14:00Z and
15:00Z that share was **37.2%** and **49.3%**. Because reviews land as in-place comment edits these
are lower bounds, and they count comment bodies rather than review runs; the exact collection method
and what it does and does not prove are in Real Behavior Proof below.

## Why This Change Was Made

The repository already has the guard for this case. `hasBlockedLocalCheckoutAccess` detects a review
that reports its inspection never ran, and three apply-lane call sites gate on
`hasVerifiedLocalCheckoutAccess`: the guard whose skip reason is literally
`review lacks verified local checkout access`, the comment-sync guard, and the counterpart check in
the same-author PR+issue pair close.

Those guards could not distinguish this case. `local_checkout_access: verified` is emitted as a
literal by the review-record writer, so for every record that writer produces
`hasVerifiedLocalCheckoutAccess` was true regardless of what the review reported. The blocked
predicate's only consumer was `effectiveReviewStatus`, which classifies the record
`stale_local_checkout_blocked` — that affects re-review scheduling, not publication or close.

The change requires both signals, so the existing guards apply to reviews that already report a
blocked inspection. No new configuration, no new state, no change to how ratings are rendered.

`effectiveReviewStatus` is unchanged for every input: it tests the blocked predicate first, so
blocked records still return `stale_local_checkout_blocked`, and non-blocked records fall through to
the same front-matter check as before. That is an invariant by construction in a four-line function,
not something a new test asserts.

**Non-goals.**

- bubblewrap, the runner image, and network-namespace permissions — the sandbox failure originates
  in the review runtime, not here.
- `src/repair/workflow-utils.ts` reads `local_checkout_access` from the front matter directly and is
  built as a separate module that does not import this predicate. It is **unchanged**: blocked
  records remain selectable there. That site produces close *candidates* for the apply lane rather
  than closing anything itself, so the apply guard above is still what withholds the close — but the
  selection is wasted work and making that module agree is left for a separate change.
- widening which phrasings count as a blocked inspection (see Limits).
- the rendered scores table; withholding or marking the patch-quality axis for a blocked review is a
  separate question.

## User Impact

On the ordinary apply path, a review whose report matches the existing blocked-inspection predicate
no longer syncs its comment and is not eligible to close. Such a record is already classified
`stale_local_checkout_blocked`, so it stays due for re-review. This change does not remove or edit a
blocked comment that was already published, and it does not make the scheduled re-review succeed; it
stops the lane from publishing a new one or closing on it.

A matching record also no longer qualifies as the counterpart in a same-author PR+issue pair close,
so that pair is kept open instead. Same fail-safe direction, and no focused test covers that path.

The withholding is bounded in two ways, both deliberate:

- It applies to reports the existing predicate recognises, not to every failed inspection. The
  promisor/DNS variant in Limits below is a counterexample that this change does not catch.
- Two pre-existing bypasses are unchanged: `shouldProbeClosedState` skips the apply guard, and
  `staleCanonicalCommentSyncPending` skips the comment-sync guard. Both are narrow recovery states,
  and this change does not alter either condition.

For records that do not match the predicate, nothing changes.

## Evidence

`src/clawsweeper.ts` +7/−1, plus one focused test in the narrowest matching file
(`test/apply-blocked-local-checkout.test.ts`, alongside the existing `apply-*` policy tests).

## Real Behavior Proof

**Claim.** A review record whose body reports that its read-only inspection never ran is admitted
past the apply lane's local-checkout guard on `main`, and is withheld after this change with the skip
reason the guard already defines. The claim is scoped to the ordinary apply path — the exception
branches above and `src/repair/workflow-utils.ts` are not exercised.

**Environment.** Node v24.18.0, Linux. Base `0ee212e35`. Branch head `69926bd38`.

### 1. Non-mocked dry-run against a live GitHub item

Real `gh` at `/usr/bin/gh`, **no `GH_BIN` / `GH_BIN_ARGS` override** (`env | grep -c '^GH_BIN'` → `0`).
`--dry-run` short-circuits before the comment upsert (`src/clawsweeper.ts:29492`) and before the close
(`src/clawsweeper.ts:29827`), so every path below is read-only. Following the apply-repro guidance in
`AGENTS.md`, one record for the real open issue `openclaw/clawsweeper#951` was copied into a temp
`items/` dir with a temp `--record-root`, `--closed-dir`, and `--plans-dir`. The record declares
`local_checkout_access: verified` and `labels: []`, and its body carries the sandbox-failure sentence.

```
$ node dist/clawsweeper.js apply-decisions --target-repo openclaw/clawsweeper \
    --record-root $R --items-dir $R/items --closed-dir $R/closed --plans-dir $R/plans \
    --report-path $R/apply-report.json --item-numbers 951 --dry-run \
    --limit 1 --processed-limit 2 --close-delay-ms 0
```

With this change (head `69926bd38`):

```
[apply] 2026-07-31T23:50:41.883Z starting apply: files=1 dry_run=true apply_kind=issue ... item_numbers=951 ... counts={}
[apply] 2026-07-31T23:50:43.350Z finished apply closed=0/1 processed=1/2 counts={"kept_open":1}

$ cat $R/apply-report.json
[
  {
    "number": 951,
    "action": "kept_open",
    "reason": "review lacks verified local checkout access"
  }
]
```

Same record, same command, unmodified base `0ee212e35`:

```
[apply] 2026-07-31T23:51:21.636Z starting apply: files=1 dry_run=true ... item_numbers=951 ... counts={}
[apply] 2026-07-31T23:51:27.937Z finished apply closed=0/1 processed=1/2 counts={"skipped_protected_label":1}

$ cat $R/apply-report.json
[
  {
    "number": 951,
    "action": "skipped_protected_label",
    "reason": "protected label: clawsweeper:needs-maintainer-review, clawsweeper:needs-product-decision, clawsweeper:needs-security-review"
  }
]
```

On base the record is admitted past the local-checkout guard and evaluated further, reaching the live
protected-label check. That check reports labels the record never declared, so the run genuinely
queried GitHub — `gh` was not mocked. With the change the same record stops at the guard.

This particular item carries protected labels, so on base it stops there rather than at
`would close`; the admitted-through-to-close path is what the harness test below shows.

### 2. Focused harness test (before / after)

**Exercised surface.** The same apply entry point, `node dist/clawsweeper.js apply-decisions`, driven
end to end through `runApplyDecisionsForTest`, with `gh` mocked at the process boundary via
`withMockGh` so the close proposal can be carried to completion deterministically.

**Scenario / fixture.** One review record in a temp `items/` dir, carrying the front-matter value the
review writer emits (`local_checkout_access: verified`, asserted in the test) and, in the body, the
sandbox-failure sentence quoted above. Decision `close` / `implemented_on_main`, with the durable
review comment already synced.

**Command.**

```
./node_modules/.bin/tsc -p tsconfig.json
node --test test/apply-blocked-local-checkout.test.ts
```

**Observed result — on `main` (fix reverted, test kept):**

```
✖ apply withholds close when the review reports a blocked local checkout
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

    [
      {
  +     action: 'review_comment_synced',
  -     action: 'kept_open',
        number: 10,
  +     reason: 'would update durable Codex review comment'
  -     reason: 'review lacks verified local checkout access'
      },
  +   {
  +     action: 'closed',
  +     number: 10,
  +     reason: 'dry-run: would close as already implemented on main'
  +   }
    ]
```

The item is comment-synced and closed. The guard never fires.

**Observed result — with this change:**

```
✔ apply withholds close when the review reports a blocked local checkout (155.679ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

Reverting only `src/clawsweeper.ts` to `0ee212e35` and rebuilding reproduces the failure above, so the
test has teeth.

### 3. Public measurement

Reproducible from the GitHub API. For every `clawsweeper[bot]` issue comment on `openclaw/openclaw`
whose body was last updated in the window, the current body was matched against `/bwrap|RTM_NEWADDR/`
and bucketed by `updated_at`.

```
## Bodies last updated 2026-07-27 -> 07-31T12:00Z
2026-07-27  bodies= 973  matching= 18  share=  1.8%
2026-07-28  bodies= 915  matching= 24  share=  2.6%
2026-07-29  bodies=1121  matching= 27  share=  2.4%
2026-07-30  bodies=3148  matching= 74  share=  2.4%
2026-07-31  bodies=2358  matching= 60  share=  2.5%
TOTAL       bodies=8515  matching=203  share=  2.4%

## Bodies last updated 2026-07-31T12:00Z -> 16:51Z (hour buckets, UTC)
2026-07-31T12  bodies= 290  matching=  5  share=  1.7%
2026-07-31T13  bodies= 228  matching=  5  share=  2.2%
2026-07-31T14  bodies= 129  matching= 48  share= 37.2%
2026-07-31T15  bodies= 150  matching= 74  share= 49.3%
2026-07-31T16  bodies= 330  matching= 32  share=  9.7%
TOTAL          bodies=1127  matching=164  share= 14.6%
```

What this is and is not: `matching` counts **bodies matching `/bwrap|RTM_NEWADDR/`**, which is a
narrower query than `hasBlockedLocalCheckoutAccess` — the predicate also recognises five other
sandbox phrasings, so the true share is at least this. Buckets are **comment bodies last updated in
that bucket**, not publication events and not per-day review incidence. Reviews land as in-place
edits, so a body written during an outage and re-reviewed afterwards now reads clean and is counted
clean. A match shows the published text reports a failed inspection; it is not by itself evidence
that any apply action ran on that item.

### 4. Suite and static checks

`node scripts/run-node-tests.mjs all` → 2851 tests, 2845 pass, 6 fail. The same 6 fail on
unmodified `0ee212e35` in this environment (`test/repair/target-validation.test.ts` — detached-process
reaping and git branch plumbing, both needing a real pnpm install and worktree setup this checkout does
not have). `oxfmt --check`, `oxlint` (src / scripts+test), `check:active-surface`, `check:limits`,
`check:dashboard-queue-boundary` all pass.

### Limits — what this proof does not cover

- **Coverage is one path.** Both runs exercise the ordinary apply path only. The same-author
  pair-close counterpart check, the `shouldProbeClosedState` and `staleCanonicalCommentSyncPending`
  bypasses, and the close-promotion selector in `src/repair/workflow-utils.ts` are untested here.
  The `effectiveReviewStatus` invariant is argued by construction, not asserted by a new test.
- **The non-mocked run stops earlier on base than the harness run does.** `openclaw/clawsweeper#951`
  carries protected labels, so on base it reaches `skipped_protected_label` rather than a close. The
  non-mocked run therefore demonstrates that the checkout guard does not fire on base and does fire
  after the change; the close consequence itself is shown only under the mocked harness.
- **No auto-close on a blocked review was observed in production.** The close path is reachable —
  `clawsweeper[bot]` closed 10 `openclaw/openclaw` items in the last 7 days — but none of the items
  closed during the sampled window carried a matching review. The 39 matching items closed between
  14:00Z and 16:51Z were all closed by humans. The close behaviour above is demonstrated on the real
  apply path, not observed in the wild; the published-rating harm is what is observed.
- **The measurement counts comment bodies, not review runs**, and is a lower bound. See the method
  note above it.
- **The claim about the writer is scoped to the writer.** `hasVerifiedLocalCheckoutAccess` was true for
  every record the current review-record writer produces, because that writer emits the literal. It says
  nothing about hand-edited, malformed, or pre-existing records that lack the key; those already
  resolved to unverified and still do.
- **Detection coverage is unchanged and is known to be incomplete.** A re-review of one affected PR
  replaced the `bwrap` failure with `promisor objects; Git attempted to fetch them and failed because
  github.com could not resolve` — plausibly the same root, but `hasBlockedLocalCheckoutAccess` does not
  match that phrasing, so such a review is not even classified stale. Widening the predicate from one
  observed sample seemed worse than leaving it to a decision about how the reviewer should report
  inspection failure structurally; the review prompt currently asks for prose only.
- **False-positive direction.** The predicate matches the whole record, so a review of a PR that
  legitimately discusses `bwrap: loopback` would be treated as blocked. That already causes permanent
  staleness on `main`; with this change it would also withhold the comment on the ordinary path. The
  direction is fail-safe — the lane declines to act rather than acting on a review it cannot trust — but
  it is a real behaviour change for that case.
