### PR TITLE
fix(review): restore exact review schema admission

### DIFF
--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -858,93 +858,63 @@
     },
     "regressionAssessment": {
       "description": "A non-blaming preliminary regression assessment. Do not name a predecessor here; a PR link is published only through independently verified regressionProvenance.",
-      "oneOf": [
-        {
-          "type": "null"
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["confidence", "supportingEvidence"],
+      "properties": {
+        "confidence": {
+          "type": "string",
+          "enum": ["suspected", "probable"]
         },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["confidence", "supportingEvidence"],
-          "properties": {
-            "confidence": {
-              "type": "string",
-              "enum": ["suspected", "probable"]
-            },
-            "supportingEvidence": {
-              "type": "array",
-              "minItems": 1,
-              "maxItems": 3,
-              "uniqueItems": true,
-              "items": {
-                "type": "string",
-                "enum": [
-                  "reproduction",
-                  "reviewed_change",
-                  "failure_trace",
-                  "known_regression_link"
-                ]
-              }
-            }
-          },
-          "allOf": [
-            {
-              "if": {
-                "properties": { "confidence": { "const": "probable" } }
-              },
-              "then": {
-                "properties": { "supportingEvidence": { "minItems": 2 } }
-              }
-            }
-          ]
+        "supportingEvidence": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 3,
+          "items": {
+            "type": "string",
+            "enum": ["reproduction", "reviewed_change", "failure_trace", "known_regression_link"]
+          }
         }
-      ]
+      }
     },
     "regressionProvenance": {
       "description": "An untrusted candidate predecessor link. The runtime publishes it only after exact GitHub PR metadata and local blame agree on the merge commit; use null unless one exact relevant source line and prior merged PR are known.",
-      "oneOf": [
-        {
-          "type": "null"
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": [
+        "repo",
+        "pullRequestNumber",
+        "pullRequestUrl",
+        "mergeCommitSha",
+        "sourcePath",
+        "sourceLine"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "Target owner/repository only."
         },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "repo",
-            "pullRequestNumber",
-            "pullRequestUrl",
-            "mergeCommitSha",
-            "sourcePath",
-            "sourceLine"
-          ],
-          "properties": {
-            "repo": {
-              "type": "string",
-              "description": "Target owner/repository only."
-            },
-            "pullRequestNumber": {
-              "type": "integer",
-              "minimum": 1
-            },
-            "pullRequestUrl": {
-              "type": "string",
-              "description": "Canonical https://github.com/<owner>/<repo>/pull/<number> URL."
-            },
-            "mergeCommitSha": {
-              "type": "string",
-              "pattern": "^[0-9a-fA-F]{40}$"
-            },
-            "sourcePath": {
-              "type": "string",
-              "description": "One exact repository-relative tracked source path; no absolute or traversal path."
-            },
-            "sourceLine": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
+        "pullRequestNumber": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pullRequestUrl": {
+          "type": "string",
+          "description": "Canonical https://github.com/<owner>/<repo>/pull/<number> URL."
+        },
+        "mergeCommitSha": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{40}$"
+        },
+        "sourcePath": {
+          "type": "string",
+          "description": "One exact repository-relative tracked source path; no absolute or traversal path."
+        },
+        "sourceLine": {
+          "type": "integer",
+          "minimum": 1
         }
-      ]
+      }
     },
     "closeComment": {
       "type": "string"

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -690,6 +690,7 @@ ${extra}
       fixedSha: null,
       fixedAt: null,
       fixedPullRequest: null,
+      regressionAssessment: null,
       regressionProvenance: null,
       closeComment: "",
       workCandidate: "none",

--- a/test/codex-review-runner.test.ts
+++ b/test/codex-review-runner.test.ts
@@ -20,6 +20,30 @@ import {
 } from "../dist/clawsweeper.js";
 import { closeDecision, item, tmpPrefix } from "./helpers.ts";
 
+test("Codex decision schema avoids unsupported strict-output keywords recursively", () => {
+  const schema = JSON.parse(
+    readFileSync(join(process.cwd(), "schema", "clawsweeper-decision.schema.json"), "utf8"),
+  ) as unknown;
+  const forbidden = new Set(["oneOf", "allOf", "if", "then", "uniqueItems"]);
+  const found: string[] = [];
+
+  const visit = (value: unknown, path: string): void => {
+    if (!value || typeof value !== "object") return;
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => visit(entry, `${path}[${index}]`));
+      return;
+    }
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = `${path}.${key}`;
+      if (forbidden.has(key)) found.push(childPath);
+      visit(child, childPath);
+    }
+  };
+
+  visit(schema, "$");
+  assert.deepEqual(found, []);
+});
+
 test("Codex failure logs distinguish provider throttling from content output failures", () => {
   assert.equal(
     codexFailureLogKindForTest(
@@ -343,6 +367,7 @@ test("codex failure decisions expose stderr and stdout separately", () => {
     decision.evidence.find((entry) => entry.label === "codex stderr")?.detail,
     "user\nThe reviewed prompt discusses rate limits.",
   );
+  assert.equal(decision.regressionAssessment, null);
   assert.match(
     decision.evidence.find((entry) => entry.label === "codex stdout")?.detail ?? "",
     /"type":"turn.failed"/,

--- a/test/decision-parser.test.ts
+++ b/test/decision-parser.test.ts
@@ -445,6 +445,18 @@ test("decision parser accepts non-blaming regression assessments only with norma
       parseDecision(
         closeDecision({
           regressionAssessment: {
+            confidence: "probable",
+            supportingEvidence: ["reproduction", "reproduction"],
+          },
+        }),
+      ),
+    /decision\.regressionAssessment has insufficient or duplicate supporting evidence/,
+  );
+  assert.throws(
+    () =>
+      parseDecision(
+        closeDecision({
+          regressionAssessment: {
             confidence: "confirmed",
             supportingEvidence: ["reproduction", "reviewed_change"],
           },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact ClawSweeper reviews failed before source review when the decision schema contained strict-output keywords rejected by the current Codex Responses path.

The failure started after regression provenance fields added `oneOf`, `allOf`, `if`, `then`, and `uniqueItems`. Reviews terminated with:

```text
Invalid schema for response_format 'codex_output_schema':
In context=('properties', 'regressionAssessment'), 'oneOf' is not permitted.
```

## Why This Change Was Made

The decision schema now expresses nullable regression objects with supported type unions and leaves conditional and uniqueness enforcement in the existing runtime parser. A schema regression test recursively rejects the unsupported strict-output keywords, and synthetic failure decisions now populate the required assessment field.

OpenClaw Bay is unaffected: this changes review admission only, not the public status data contract or any observer/action surface.

## User Impact

Exact reviews reach the source-review phase again instead of failing at Codex request admission. Regression assessment and provenance validation remain enforced before publication.

## Evidence

### Real Behavior Proof

- **Claim:** the current ClawSweeper decision schema is accepted by Codex strict output and an exact OpenClaw review completes.
- **Exercised surface:** `clawsweeper review` -> Codex `--output-schema` -> exact review report.
- **Scenario:** re-ran the same mutation-free review of https://github.com/openclaw/openclaw/pull/119050 that previously failed with the `oneOf` schema error.
- **Environment:** macOS, Node 26.5.0, current Codex CLI, read-only sandbox, local-only ClawSweeper review, exact OpenClaw head `03ba86544e8f3051a1275a4b4a4646e10078a9f9`.
- **Command:** `node dist/clawsweeper.js review --target-repo openclaw/openclaw --target-dir <clean-openclaw-worktree> --artifact-dir <temp-artifact-dir> --batch-size 1 --max-pages 1 --codex-model internal --codex-reasoning-effort high --codex-sandbox read-only --codex-timeout-ms 1200000 --item-numbers 119050 --readonly-openclaw --local-only --skip-start-comment --shard-index 0 --shard-count 1`
- **Observable result:** exit 0; `review_status: complete`; `review_terminal_failure: false`; reviewed exact head `03ba86544e8f3051a1275a4b4a4646e10078a9f9`; source review completed and returned two concrete findings instead of an admission error.
- **Trace:** review completed August 4, 2026 at `2026-08-04T02:59:27Z`; Codex review elapsed 579,770 ms.
- **Limits:** local-only proof did not publish a GitHub review comment or exercise the hosted workflow runner. CI covers the hosted build/test lanes.

### Automated validation

- `node --test test/codex-review-runner.test.ts test/decision-parser.test.ts` - 25 passed
- direct TypeScript builds for main and repair projects
- focused source/test `oxlint` - clean
- repository-wide `oxfmt --check` - 632 files clean
- active-surface, dashboard queue-boundary, and limits checks - clean
- structured autoreview - clean, patch correct at 0.99 confidence

The aggregate `pnpm run check` wrapper was not used because this GWT links a shared `node_modules` tree and pnpm attempted an interactive dependency purge. The equivalent changed-surface build, static, lint, format, parser tests, and live review proof above completed without modifying shared dependencies.
