### PR TITLE
feat(review): clarify regression provenance output

### DIFF
--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -857,7 +857,7 @@
       "description": "ISO-8601 commit or merge timestamp for the fix/proof SHA when known. Required for implemented_on_main and mostly_implemented_on_main when fixedRelease is null so maintainers know when it became fixed on main."
     },
     "regressionAssessment": {
-      "description": "A non-blaming preliminary regression assessment. Do not name a predecessor here; a PR link is published only through independently verified regressionProvenance.",
+      "description": "A non-blaming preliminary regression assessment. Do not name a predecessor here; runtime verification may separately publish either verified canonical provenance or a cautiously labeled, non-causal rewrite-equivalent PR relationship.",
       "type": ["object", "null"],
       "additionalProperties": false,
       "required": ["confidence", "supportingEvidence"],
@@ -878,7 +878,7 @@
       }
     },
     "regressionProvenance": {
-      "description": "An untrusted candidate predecessor link. The runtime publishes it only after exact GitHub PR metadata and local blame agree on the merge commit; use null unless one exact relevant source line and prior merged PR are known.",
+      "description": "An untrusted candidate predecessor link. Use null unless one exact relevant source line and prior merged PR are known. Runtime verification may publish verified provenance when blame matches the canonical merge commit, or cautiously label a related PR as non-causal only when canonical metadata plus an exact, location-and-context-preserving rewritten patch match; all other associations fail closed.",
       "type": ["object", "null"],
       "additionalProperties": false,
       "required": [

--- a/src/clawsweeper-regression-provenance.ts
+++ b/src/clawsweeper-regression-provenance.ts
@@ -110,9 +110,9 @@ export function createRegressionProvenanceVerifier({
       if (hasBlameBoundary(blame) || !sourceCommitSha) return null;
 
       const sourceAuthor = blamedAuthor(blame);
-      if (!sourceAuthor || !isSafeSourceAuthor(sourceAuthor)) return null;
 
       if (sourceCommitSha !== candidate.mergeCommitSha) {
+        if (!sourceAuthor || !isSafeSourceAuthor(sourceAuthor)) return null;
         runGit(["merge-base", "--is-ancestor", sourceCommitSha, reviewedBaseCommitSha], {
           cwd: options.checkoutDir,
           env,
@@ -151,8 +151,9 @@ export function createRegressionProvenanceVerifier({
         evidenceType: "blame_to_merge_commit",
         mergedAt: pull.mergedAt,
         reviewedCommitSha: checkoutHeadSha,
-        sourceCommitSha: candidate.mergeCommitSha,
-        sourceAuthor,
+        ...(sourceAuthor && isSafeSourceAuthor(sourceAuthor)
+          ? { sourceCommitSha: candidate.mergeCommitSha, sourceAuthor }
+          : {}),
       };
     } catch {
       // Metadata, checkout history, and tracked-path failures are unknown, not

--- a/src/clawsweeper-regression-provenance.ts
+++ b/src/clawsweeper-regression-provenance.ts
@@ -2,6 +2,7 @@ import type {
   RegressionAssessment,
   RegressionProvenanceCandidate,
   RegressionSupportingEvidence,
+  SuspectedRegressionProvenance,
   VerifiedRegressionProvenance,
 } from "./clawsweeper-types.js";
 
@@ -20,11 +21,17 @@ const regressionSupportingEvidence = new Set<RegressionSupportingEvidence>([
 
 export interface RegressionProvenanceVerifierDependencies {
   fetchPull: (repo: string, number: number) => unknown;
+  fetchPullDiff: (repo: string, number: number) => string;
   runGit: (args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }) => string;
 }
 
 export interface VerifyRegressionProvenanceOptions {
-  candidate: RegressionProvenanceCandidate | VerifiedRegressionProvenance | null | undefined;
+  candidate:
+    | RegressionProvenanceCandidate
+    | VerifiedRegressionProvenance
+    | SuspectedRegressionProvenance
+    | null
+    | undefined;
   item: { repo: string; number: number };
   checkoutDir: string;
   targetBranch: string | undefined;
@@ -33,25 +40,37 @@ export interface VerifyRegressionProvenanceOptions {
 
 type VerifiedPullMetadata = {
   mergedAt: string;
+  headSha: string;
 };
 
 /**
  * Independently verifies the only public predecessor-provenance form we
- * support: a reviewed source line blames exactly to a PR's merge commit.
+ * support: a reviewed source line either blames exactly to a PR's merge
+ * commit, or retains a cautiously labeled non-causal relationship after the
+ * conservative rewrite-equivalence checks below.
  *
  * This module never accepts a command from model output. It executes only the
  * fixed read-only Git commands below, after rejecting malformed candidates.
  */
 export function createRegressionProvenanceVerifier({
   fetchPull,
+  fetchPullDiff,
   runGit,
 }: RegressionProvenanceVerifierDependencies) {
-  function verify(options: VerifyRegressionProvenanceOptions): VerifiedRegressionProvenance | null {
+  function verify(
+    options: VerifyRegressionProvenanceOptions,
+  ): VerifiedRegressionProvenance | SuspectedRegressionProvenance | null {
     const candidate = normalizeCandidate(options.candidate, options.item);
     const reviewedCommitShas = options.reviewedCommitShas
       .map((sha) => fullSha(sha ?? ""))
       .filter((sha): sha is string => sha !== null);
-    if (!candidate || !isSafeTargetBranch(options.targetBranch) || !reviewedCommitShas.length) {
+    const reviewedBaseCommitSha = fullSha(options.reviewedCommitShas[0] ?? "");
+    if (
+      !candidate ||
+      !isSafeTargetBranch(options.targetBranch) ||
+      !reviewedCommitShas.length ||
+      !reviewedBaseCommitSha
+    ) {
       return null;
     }
 
@@ -87,13 +106,53 @@ export function createRegressionProvenanceVerifier({
         ],
         { cwd: options.checkoutDir, env },
       );
-      if (hasBlameBoundary(blame) || blamedSha(blame) !== candidate.mergeCommitSha) return null;
+      const sourceCommitSha = blamedSha(blame);
+      if (hasBlameBoundary(blame) || !sourceCommitSha) return null;
+
+      const sourceAuthor = blamedAuthor(blame);
+      if (!sourceAuthor || !isSafeSourceAuthor(sourceAuthor)) return null;
+
+      if (sourceCommitSha !== candidate.mergeCommitSha) {
+        runGit(["merge-base", "--is-ancestor", sourceCommitSha, reviewedBaseCommitSha], {
+          cwd: options.checkoutDir,
+          env,
+        });
+        let rewriteEquivalent = false;
+        try {
+          rewriteEquivalent = isConservativeRewriteEquivalent({
+            candidate,
+            pull,
+            sourceCommitSha,
+            sourceAuthor,
+            pullDiff: fetchPullDiff(candidate.repo, candidate.pullRequestNumber),
+            checkoutDir: options.checkoutDir,
+            env,
+            runGit,
+          });
+        } catch {
+          // The local blame result remains useful even when the optional
+          // canonical-PR diff cannot be fetched or compared. Fail closed only
+          // for the related-PR association.
+        }
+        return {
+          evidenceType: rewriteEquivalent ? "rewrite_equivalent" : "source_line",
+          sourceCommitSha,
+          sourceAuthor,
+          sourcePath: candidate.sourcePath,
+          sourceLine: candidate.sourceLine,
+          relatedPullRequestNumber: rewriteEquivalent ? candidate.pullRequestNumber : null,
+          relatedPullRequestUrl: rewriteEquivalent ? candidate.pullRequestUrl : null,
+          relatedRepo: rewriteEquivalent ? candidate.repo : null,
+        };
+      }
 
       return {
         ...candidate,
         evidenceType: "blame_to_merge_commit",
         mergedAt: pull.mergedAt,
         reviewedCommitSha: checkoutHeadSha,
+        sourceCommitSha: candidate.mergeCommitSha,
+        sourceAuthor,
       };
     } catch {
       // Metadata, checkout history, and tracked-path failures are unknown, not
@@ -116,13 +175,72 @@ export function isVerifiedRegressionProvenance(
     typeof candidate.mergedAt === "string" &&
     isIsoTimestamp(candidate.mergedAt) &&
     typeof candidate.reviewedCommitSha === "string" &&
-    fullSha(candidate.reviewedCommitSha) !== null
+    fullSha(candidate.reviewedCommitSha) !== null &&
+    ((candidate.sourceCommitSha === undefined && candidate.sourceAuthor === undefined) ||
+      (typeof candidate.sourceCommitSha === "string" &&
+        fullSha(candidate.sourceCommitSha) !== null &&
+        fullSha(candidate.sourceCommitSha) === fullSha(candidate.mergeCommitSha ?? "") &&
+        typeof candidate.sourceAuthor === "string" &&
+        isSafeSourceAuthor(candidate.sourceAuthor)))
   );
 }
 
-export function regressionProvenancePublicLine(value: unknown): string | null {
-  if (!isVerifiedRegressionProvenance(value)) return null;
-  return `Verified regression provenance: [#${value.pullRequestNumber}](${value.pullRequestUrl}) introduced the reviewed source line (blame-to-merge-commit; \`${value.mergeCommitSha.slice(0, 12)}\`).`;
+export function regressionProvenancePublicLine(
+  value: unknown,
+  regressionAssessment?: unknown,
+): string | null {
+  if (isVerifiedRegressionProvenance(value)) {
+    const sourceCommitSha = fullSha(value.sourceCommitSha ?? value.mergeCommitSha)!;
+    const sourceAuthor = value.sourceAuthor
+      ? markdownText(value.sourceAuthor)
+      : "source author not recorded in this legacy report";
+    return `Regression provenance — verified: source commit \`${sourceCommitSha.slice(0, 12)}\` by ${sourceAuthor}; canonical PR [#${value.pullRequestNumber}](${value.pullRequestUrl}) (blame-to-merge-commit).`;
+  }
+  if (!isSuspectedRegressionProvenance(value)) return null;
+  if (!isRegressionAssessment(regressionAssessment)) return null;
+  const related = value.relatedPullRequestUrl
+    ? `safely related PR [#${value.relatedPullRequestNumber}](${value.relatedPullRequestUrl}) (rewrite-equivalent)`
+    : "no PR verified";
+  return `Regression provenance — suspected predecessor, not a causality claim: source commit \`${value.sourceCommitSha.slice(0, 12)}\` by ${markdownText(value.sourceAuthor)}; ${related}.`;
+}
+
+export function isSuspectedRegressionProvenance(
+  value: unknown,
+): value is SuspectedRegressionProvenance {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Partial<SuspectedRegressionProvenance>;
+  const hasRelated =
+    typeof candidate.relatedRepo === "string" &&
+    repositoryPattern.test(candidate.relatedRepo) &&
+    typeof candidate.relatedPullRequestNumber === "number" &&
+    Number.isSafeInteger(candidate.relatedPullRequestNumber) &&
+    candidate.relatedPullRequestNumber > 0 &&
+    typeof candidate.relatedPullRequestUrl === "string" &&
+    candidate.relatedPullRequestUrl ===
+      `https://github.com/${candidate.relatedRepo}/pull/${candidate.relatedPullRequestNumber}`;
+  return (
+    (candidate.evidenceType === "source_line" || candidate.evidenceType === "rewrite_equivalent") &&
+    fullSha(candidate.sourceCommitSha ?? "") !== null &&
+    typeof candidate.sourceAuthor === "string" &&
+    isSafeSourceAuthor(candidate.sourceAuthor) &&
+    typeof candidate.sourcePath === "string" &&
+    isSafeSourcePath(candidate.sourcePath) &&
+    typeof candidate.sourceLine === "number" &&
+    Number.isSafeInteger(candidate.sourceLine) &&
+    candidate.sourceLine > 0 &&
+    candidate.sourceLine <= MAX_SOURCE_LINE &&
+    ((candidate.evidenceType === "source_line" &&
+      candidate.relatedPullRequestNumber === null &&
+      candidate.relatedPullRequestUrl === null &&
+      candidate.relatedRepo === null) ||
+      (candidate.evidenceType === "rewrite_equivalent" && hasRelated))
+  );
+}
+
+export function isPublicRegressionProvenance(
+  value: unknown,
+): value is VerifiedRegressionProvenance | SuspectedRegressionProvenance {
+  return isVerifiedRegressionProvenance(value) || isSuspectedRegressionProvenance(value);
 }
 
 export function isRegressionAssessment(value: unknown): value is RegressionAssessment {
@@ -140,14 +258,23 @@ export function isRegressionAssessment(value: unknown): value is RegressionAsses
   );
 }
 
-export function regressionAssessmentPublicLine(value: unknown): string | null {
+export function regressionAssessmentPublicLine(
+  value: unknown,
+  options: { predecessorAttributed?: boolean } = {},
+): string | null {
   if (!isRegressionAssessment(value)) return null;
   const evidence = value.supportingEvidence.map(regressionEvidenceLabel).join("; ");
-  return `Possible regression — ${value.confidence} (${evidence}). No predecessor PR is attributed.`;
+  const attribution = options.predecessorAttributed ? "" : " No predecessor PR is attributed.";
+  return `Possible regression — ${value.confidence} (${evidence}).${attribution}`;
 }
 
 function normalizeCandidate(
-  value: RegressionProvenanceCandidate | VerifiedRegressionProvenance | null | undefined,
+  value:
+    | RegressionProvenanceCandidate
+    | VerifiedRegressionProvenance
+    | SuspectedRegressionProvenance
+    | null
+    | undefined,
   item: { repo: string; number: number },
 ): RegressionProvenanceCandidate | null {
   const candidate = normalizedCandidateFields(value);
@@ -216,7 +343,74 @@ function verifiedPullMetadata(
   ) {
     return null;
   }
-  return { mergedAt: pull.merged_at };
+  const head = pull.head;
+  const rawHeadSha =
+    head && typeof head === "object" && !Array.isArray(head)
+      ? (head as Record<string, unknown>).sha
+      : null;
+  const headSha = typeof rawHeadSha === "string" ? fullSha(rawHeadSha) : null;
+  if (!headSha) return null;
+  return { mergedAt: pull.merged_at, headSha };
+}
+
+function isConservativeRewriteEquivalent(options: {
+  candidate: RegressionProvenanceCandidate;
+  pull: VerifiedPullMetadata;
+  sourceCommitSha: string;
+  sourceAuthor: string;
+  pullDiff: string;
+  checkoutDir: string;
+  env: NodeJS.ProcessEnv;
+  runGit: RegressionProvenanceVerifierDependencies["runGit"];
+}): boolean {
+  try {
+    const sourceSubject = options.runGit(["show", "-s", "--format=%s", options.sourceCommitSha], {
+      cwd: options.checkoutDir,
+      env: options.env,
+    });
+    if (!new RegExp(`\\(#${options.candidate.pullRequestNumber}\\)\\s*$`).test(sourceSubject)) {
+      return false;
+    }
+    const sourceParents = options
+      .runGit(["show", "-s", "--format=%P", options.sourceCommitSha], {
+        cwd: options.checkoutDir,
+        env: options.env,
+      })
+      .trim()
+      .split(/\s+/);
+    if (sourceParents.length !== 1) return false;
+    const diffArgs = (parent: string, sha: string) => [
+      "diff",
+      "--unified=3",
+      "--no-renames",
+      parent,
+      sha,
+      "--",
+    ];
+    const sourceDiff = options.runGit(diffArgs(sourceParents[0]!, options.sourceCommitSha), {
+      cwd: options.checkoutDir,
+      env: options.env,
+    });
+    const normalizedSourceDiff = normalizedTextPatch(sourceDiff);
+    const normalizedHeadDiff = normalizedTextPatch(options.pullDiff);
+    return normalizedSourceDiff !== null && normalizedSourceDiff === normalizedHeadDiff;
+  } catch {
+    return false;
+  }
+}
+
+function normalizedTextPatch(value: string): string | null {
+  if (!value.trim() || /(?:GIT binary patch|Binary files .* differ)/.test(value)) return null;
+  return value
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith("index "))
+    .map((line) => line.replace(/^(@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@).*/, "$1"))
+    .join("\n")
+    .trim();
+}
+
+function markdownText(value: string): string {
+  return value.replace(/@/g, "@\u200b").replace(/[\\`*_[\]<>]/g, "\\$&");
 }
 
 function isSafeSourcePath(path: string): boolean {
@@ -240,6 +434,17 @@ function hasControlCharacter(value: string): boolean {
   return false;
 }
 
+function hasUnsafeUnicodeFormat(value: string): boolean {
+  return /[\p{Cf}\p{Zl}\p{Zp}]/u.test(value);
+}
+
+function isSafeSourceAuthor(value: string): boolean {
+  const author = value.trim();
+  return (
+    author.length > 0 && !hasUnsafeUnicodeFormat(author) && !/[^\s<>@]+@[^\s<>@]+/.test(author)
+  );
+}
+
 function isSafeTargetBranch(value: string | undefined): value is string {
   return (
     typeof value === "string" &&
@@ -258,6 +463,12 @@ function blamedSha(value: string): string | null {
   const firstLine = value.split(/\r?\n/, 1)[0] ?? "";
   const sha = firstLine.split(/\s+/, 1)[0] ?? "";
   return fullSha(sha);
+}
+
+function blamedAuthor(value: string): string | null {
+  const match = /(?:^|\r?\n)author (.+)(?:\r?\n|$)/.exec(value);
+  const author = match?.[1]?.trim() ?? "";
+  return author && author.length <= 200 && !hasControlCharacter(author) ? author : null;
 }
 
 function hasBlameBoundary(value: string): boolean {

--- a/src/clawsweeper-report-comment-helpers.ts
+++ b/src/clawsweeper-report-comment-helpers.ts
@@ -15,11 +15,12 @@ import type {
   ReviewFinding,
   ReviewRuntime,
   RootCauseClusterAssessment,
-  VerifiedRegressionProvenance,
+  PublicRegressionProvenance,
   SecurityReview,
 } from "./clawsweeper-types.js";
 import {
   isRegressionAssessment,
+  isPublicRegressionProvenance,
   isVerifiedRegressionProvenance,
   regressionAssessmentPublicLine,
   regressionProvenancePublicLine,
@@ -88,7 +89,7 @@ export function createReportCommentHelpers(
     likelyOwners?: LikelyOwner[];
     fixedPullRequest?: FixedPullRequest | null;
     regressionAssessment?: RegressionAssessment | null;
-    regressionProvenance?: VerifiedRegressionProvenance | null;
+    regressionProvenance?: PublicRegressionProvenance | null;
     securityReview?: SecurityReview;
     rootCauseCluster?: RootCauseClusterAssessment;
     reviewLine: string;
@@ -107,10 +108,17 @@ export function createReportCommentHelpers(
         )}.`,
       );
     }
-    const regressionProvenanceLine =
-      regressionProvenancePublicLine(options.regressionProvenance) ??
-      regressionAssessmentPublicLine(options.regressionAssessment);
+    const regressionProvenanceLine = regressionProvenancePublicLine(
+      options.regressionProvenance,
+      options.regressionAssessment,
+    );
+    const regressionAssessmentLine = regressionAssessmentPublicLine(options.regressionAssessment, {
+      predecessorAttributed: options.regressionProvenance?.evidenceType === "rewrite_equivalent",
+    });
     if (regressionProvenanceLine) lines.push("", regressionProvenanceLine);
+    if (regressionAssessmentLine && !isVerifiedRegressionProvenance(options.regressionProvenance)) {
+      lines.push("", regressionAssessmentLine);
+    }
     const rootCauseCluster = publicRootCauseClusterBlock(options.rootCauseCluster);
     if (rootCauseCluster) lines.push("", "**Root-cause cluster**", rootCauseCluster);
     const bestSolutionLine = sentence(options.bestSolution ?? "");
@@ -232,7 +240,7 @@ export function createReportCommentHelpers(
       regressionAssessment: isRegressionAssessment(decision.regressionAssessment)
         ? decision.regressionAssessment
         : null,
-      regressionProvenance: isVerifiedRegressionProvenance(decision.regressionProvenance)
+      regressionProvenance: isPublicRegressionProvenance(decision.regressionProvenance)
         ? decision.regressionProvenance
         : null,
       securityReview: decision.securityReview,

--- a/src/clawsweeper-report-comment-presentation.ts
+++ b/src/clawsweeper-report-comment-presentation.ts
@@ -1,5 +1,6 @@
 import type { CloseReason, ItemKind, ReviewCommentRenderOptions } from "./clawsweeper-types.js";
 import {
+  isVerifiedRegressionProvenance,
   regressionAssessmentPublicLine,
   regressionProvenancePublicLine,
 } from "./clawsweeper-regression-provenance.js";
@@ -113,9 +114,21 @@ export function createReportCommentPresentation(
     const mantisRecommendation = reportMantisRecommendation(markdown);
     const agentsPolicyStatus = reportAgentsPolicyStatus(markdown);
     const rootCauseCluster = reportRootCauseCluster(markdown);
-    const regressionProvenanceLine =
-      regressionProvenancePublicLine(regressionProvenanceFromReport(markdown)) ??
-      regressionAssessmentPublicLine(regressionAssessmentFromReport(markdown));
+    const regressionProvenance = regressionProvenanceFromReport(markdown);
+    const regressionAssessment = regressionAssessmentFromReport(markdown);
+    const regressionProvenanceLine = regressionProvenancePublicLine(
+      regressionProvenance,
+      regressionAssessment,
+    );
+    const regressionAssessmentLine = regressionAssessmentPublicLine(regressionAssessment, {
+      predecessorAttributed: regressionProvenance?.evidenceType === "rewrite_equivalent",
+    });
+    const regressionPublicLine = [
+      regressionProvenanceLine,
+      !isVerifiedRegressionProvenance(regressionProvenance) ? regressionAssessmentLine : null,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n\n");
     const summary = reviewSectionValue(markdown, "summary");
     const changeSummary = reviewSectionValue(markdown, "changeSummary");
     const systemContext = neutralizeOwnedSectionSpoofing(
@@ -306,8 +319,8 @@ export function createReportCommentPresentation(
       });
       lines.push("# ClawSweeper review", "");
       appendHeadingSection(lines, "What this changes", changeSummaryLine);
-      if (regressionProvenanceLine) {
-        appendHeadingSection(lines, "Regression provenance", regressionProvenanceLine);
+      if (regressionPublicLine) {
+        appendHeadingSection(lines, "Regression provenance", regressionPublicLine);
       }
       appendHeadingSection(
         lines,
@@ -428,8 +441,8 @@ export function createReportCommentPresentation(
       lines.push("", collapsedDetailsBlock("<strong>Agent review details</strong>", agentDetails));
     } else {
       appendPublicSection(lines, "Summary", publicSummaryBody(summaryLine, reproductionAssessment));
-      if (regressionProvenanceLine) {
-        appendPublicSection(lines, "Regression provenance", regressionProvenanceLine);
+      if (regressionPublicLine) {
+        appendPublicSection(lines, "Regression provenance", regressionPublicLine);
       }
       if (rootCauseClusterBlock) {
         appendPublicSection(lines, "Root-cause cluster", rootCauseClusterBlock);

--- a/src/clawsweeper-report-document.ts
+++ b/src/clawsweeper-report-document.ts
@@ -7,6 +7,8 @@ import { REVIEW_SECTIONS } from "./clawsweeper-policy.js";
 import { hasShinyProof, themedRatingName } from "./clawsweeper-rating.js";
 import {
   isRegressionAssessment,
+  isPublicRegressionProvenance,
+  isSuspectedRegressionProvenance,
   isVerifiedRegressionProvenance,
   regressionAssessmentPublicLine,
   regressionProvenancePublicLine,
@@ -455,16 +457,31 @@ export function createReportDocumentRendering(
     const labels = options.item.labels.length ? options.item.labels.join(", ") : "none";
     const reviewedAt = new Date().toISOString();
     const fixedPullRequest = options.decision.fixedPullRequest;
-    const regressionProvenance = isVerifiedRegressionProvenance(
-      options.decision.regressionProvenance,
-    )
+    const regressionProvenance = isPublicRegressionProvenance(options.decision.regressionProvenance)
       ? options.decision.regressionProvenance
       : null;
     const regressionAssessment = isRegressionAssessment(options.decision.regressionAssessment)
       ? options.decision.regressionAssessment
       : null;
-    const regressionProvenanceLine = regressionProvenancePublicLine(regressionProvenance);
-    const regressionAssessmentLine = regressionAssessmentPublicLine(regressionAssessment);
+    const regressionProvenanceLine = regressionProvenancePublicLine(
+      regressionProvenance,
+      regressionAssessment,
+    );
+    const regressionAssessmentLine = regressionAssessmentPublicLine(regressionAssessment, {
+      predecessorAttributed: regressionProvenance?.evidenceType === "rewrite_equivalent",
+    });
+    const verifiedRegressionProvenance = isVerifiedRegressionProvenance(regressionProvenance)
+      ? regressionProvenance
+      : null;
+    const suspectedRegressionProvenance = isSuspectedRegressionProvenance(regressionProvenance)
+      ? regressionProvenance
+      : null;
+    const regressionPublicLines = [
+      regressionProvenanceLine,
+      !verifiedRegressionProvenance ? regressionAssessmentLine : null,
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n\n");
     const evidence = options.decision.evidence.length
       ? options.decision.evidence
           .map((entry) => {
@@ -557,15 +574,20 @@ fixed_pr_confidence: ${fixedPullRequest?.confidence ?? "unknown"}
 fixed_pr_source: ${fixedPullRequest ? JSON.stringify(fixedPullRequest.source) : "unknown"}
 regression_assessment_confidence: ${regressionAssessment?.confidence ?? "unknown"}
 regression_assessment_evidence: ${regressionAssessment?.supportingEvidence.join(",") ?? "unknown"}
-regression_provenance_repo: ${regressionProvenance?.repo ?? "unknown"}
-regression_provenance_pr_url: ${regressionProvenance?.pullRequestUrl ?? "unknown"}
-regression_provenance_pr_number: ${regressionProvenance?.pullRequestNumber ?? "unknown"}
-regression_provenance_merge_sha: ${regressionProvenance?.mergeCommitSha ?? "unknown"}
+regression_provenance_repo: ${verifiedRegressionProvenance?.repo ?? "unknown"}
+regression_provenance_pr_url: ${verifiedRegressionProvenance?.pullRequestUrl ?? "unknown"}
+regression_provenance_pr_number: ${verifiedRegressionProvenance?.pullRequestNumber ?? "unknown"}
+regression_provenance_merge_sha: ${verifiedRegressionProvenance?.mergeCommitSha ?? "unknown"}
 regression_provenance_source_path: ${regressionProvenance?.sourcePath ?? "unknown"}
 regression_provenance_source_line: ${regressionProvenance?.sourceLine ?? "unknown"}
 regression_provenance_evidence_type: ${regressionProvenance?.evidenceType ?? "unknown"}
-regression_provenance_merged_at: ${regressionProvenance?.mergedAt ?? "unknown"}
-regression_provenance_reviewed_sha: ${regressionProvenance?.reviewedCommitSha ?? "unknown"}
+regression_provenance_merged_at: ${verifiedRegressionProvenance?.mergedAt ?? "unknown"}
+regression_provenance_reviewed_sha: ${regressionProvenance && "reviewedCommitSha" in regressionProvenance ? regressionProvenance.reviewedCommitSha : "unknown"}
+regression_provenance_source_commit_sha: ${regressionProvenance?.sourceCommitSha ?? "unknown"}
+regression_provenance_source_author: ${regressionProvenance?.sourceAuthor ?? "unknown"}
+regression_provenance_related_pr_url: ${suspectedRegressionProvenance?.relatedPullRequestUrl ?? "unknown"}
+regression_provenance_related_pr_number: ${suspectedRegressionProvenance?.relatedPullRequestNumber ?? "unknown"}
+regression_provenance_related_repo: ${suspectedRegressionProvenance?.relatedRepo ?? "unknown"}
 review_policy: ${options.reviewPolicy}
 review_model: ${options.runtime.model}
 review_reasoning_effort: ${options.runtime.reasoningEffort}
@@ -701,7 +723,7 @@ Latest release at review time: ${
 
 Fixed in: ${fixedInText(options.decision)}
 
-${regressionProvenanceLine ?? regressionAssessmentLine ?? "Regression provenance: not assessed."}
+${regressionPublicLines || "Regression provenance: not assessed."}
 
 ## Decision
 

--- a/src/clawsweeper-report-orchestration-dependencies.ts
+++ b/src/clawsweeper-report-orchestration-dependencies.ts
@@ -29,7 +29,7 @@ import type {
   RegressionAssessment,
   PullRequestLiveActivity,
   RealBehaviorProof,
-  VerifiedRegressionProvenance,
+  PublicRegressionProvenance,
   ReviewFinding,
   RootCauseClusterAssessment,
   SecurityConcern,
@@ -70,7 +70,7 @@ export interface CreateReportOrchestrationDependencies {
   fixedInText: (decision: Decision) => string;
   fixedPullRequestFromReport: (markdown: string) => FixedPullRequest | null;
   regressionAssessmentFromReport: (markdown: string) => RegressionAssessment | null;
-  regressionProvenanceFromReport: (markdown: string) => VerifiedRegressionProvenance | null;
+  regressionProvenanceFromReport: (markdown: string) => PublicRegressionProvenance | null;
   formatReviewFreshnessTimestamp: (iso: string | undefined) => string;
   formatTimestamp: (iso: string | undefined) => string;
   frontMatterBoolean: (markdown: string, key: string) => boolean;

--- a/src/clawsweeper-report-rendering-dependencies.ts
+++ b/src/clawsweeper-report-rendering-dependencies.ts
@@ -18,7 +18,7 @@ import type {
   PublicPriority,
   RegressionAssessment,
   RealBehaviorProof,
-  VerifiedRegressionProvenance,
+  PublicRegressionProvenance,
   ReviewCommentRenderOptions,
   ReviewFinding,
   ReviewMetric,
@@ -65,7 +65,7 @@ export interface CreateReportRenderingDependencies {
   fixedInText: (decision: Decision) => string;
   fixedPullRequestFromReport: (markdown: string) => FixedPullRequest | null;
   regressionAssessmentFromReport: (markdown: string) => RegressionAssessment | null;
-  regressionProvenanceFromReport: (markdown: string) => VerifiedRegressionProvenance | null;
+  regressionProvenanceFromReport: (markdown: string) => PublicRegressionProvenance | null;
   formatReviewFreshnessTimestamp: (iso: string | undefined) => string;
   formattedMarkdownList: (
     values: readonly string[],

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -806,6 +806,13 @@ const regressionProvenanceVerifier = createRegressionProvenanceVerifier({
       "-H",
       "Accept: application/vnd.github+json",
     ]),
+  fetchPullDiff: (repo, number) =>
+    run("gh", [
+      "api",
+      `repos/${repo}/pulls/${number}`,
+      "-H",
+      "Accept: application/vnd.github.v3.diff",
+    ]),
   runGit: (args, options) => run("git", args, options),
 });
 

--- a/src/clawsweeper-status-context.ts
+++ b/src/clawsweeper-status-context.ts
@@ -8,12 +8,12 @@ import type {
   Item,
   ItemContext,
   RegressionAssessment,
-  VerifiedRegressionProvenance,
+  PublicRegressionProvenance,
   WorkflowStatusSummary,
 } from "./clawsweeper-types.js";
 import {
   isRegressionAssessment,
-  isVerifiedRegressionProvenance,
+  isPublicRegressionProvenance,
 } from "./clawsweeper-regression-provenance.js";
 import { isGitHubNotFoundError } from "./github-retry.js";
 import type { RepositoryProfile } from "./repository-profiles.js";
@@ -544,9 +544,15 @@ ${profileStatusEnd(profile)}`;
     };
   }
 
-  function regressionProvenanceFromReport(markdown: string): VerifiedRegressionProvenance | null {
+  function regressionProvenanceFromReport(markdown: string): PublicRegressionProvenance | null {
     const rawNumber = frontMatterValue(markdown, "regression_provenance_pr_number");
     const sourceLine = frontMatterValue(markdown, "regression_provenance_source_line");
+    const sourceCommitSha = nonUnknownFrontMatter(
+      markdown,
+      "regression_provenance_source_commit_sha",
+    );
+    const rawSourceAuthor = frontMatterValue(markdown, "regression_provenance_source_author");
+    const sourceAuthor = sourceCommitSha && rawSourceAuthor ? rawSourceAuthor : null;
     const provenance = {
       repo: frontMatterValue(markdown, "regression_provenance_repo"),
       pullRequestNumber: rawNumber ? Number(rawNumber) : NaN,
@@ -557,8 +563,17 @@ ${profileStatusEnd(profile)}`;
       evidenceType: frontMatterValue(markdown, "regression_provenance_evidence_type"),
       mergedAt: frontMatterValue(markdown, "regression_provenance_merged_at"),
       reviewedCommitSha: frontMatterValue(markdown, "regression_provenance_reviewed_sha"),
+      ...(sourceCommitSha ? { sourceCommitSha } : {}),
+      ...(sourceAuthor ? { sourceAuthor } : {}),
+      relatedPullRequestUrl:
+        nonUnknownFrontMatter(markdown, "regression_provenance_related_pr_url") ?? null,
+      relatedPullRequestNumber: (() => {
+        const raw = nonUnknownFrontMatter(markdown, "regression_provenance_related_pr_number");
+        return raw ? Number(raw) : null;
+      })(),
+      relatedRepo: nonUnknownFrontMatter(markdown, "regression_provenance_related_repo") ?? null,
     };
-    return isVerifiedRegressionProvenance(provenance) ? provenance : null;
+    return isPublicRegressionProvenance(provenance) ? provenance : null;
   }
 
   function regressionAssessmentFromReport(markdown: string): RegressionAssessment | null {

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -443,7 +443,23 @@ export interface VerifiedRegressionProvenance extends RegressionProvenanceCandid
   evidenceType: "blame_to_merge_commit";
   mergedAt: string;
   reviewedCommitSha: string;
+  sourceCommitSha?: string;
+  sourceAuthor?: string;
 }
+
+export interface SuspectedRegressionProvenance {
+  evidenceType: "source_line" | "rewrite_equivalent";
+  sourceCommitSha: string;
+  sourceAuthor: string;
+  sourcePath: string;
+  sourceLine: number;
+  relatedPullRequestNumber: number | null;
+  relatedPullRequestUrl: string | null;
+  relatedRepo: string | null;
+}
+export type PublicRegressionProvenance =
+  | VerifiedRegressionProvenance
+  | SuspectedRegressionProvenance;
 
 /**
  * A non-blaming, preliminary regression signal. It intentionally cannot name
@@ -544,7 +560,11 @@ export interface Decision {
   fixedAt?: string | null;
   fixedPullRequest?: FixedPullRequest | null;
   regressionAssessment?: RegressionAssessment | null;
-  regressionProvenance?: RegressionProvenanceCandidate | VerifiedRegressionProvenance | null;
+  regressionProvenance?:
+    | RegressionProvenanceCandidate
+    | VerifiedRegressionProvenance
+    | SuspectedRegressionProvenance
+    | null;
   closeComment: string;
   workCandidate: WorkCandidateKind;
   workConfidence: Confidence;

--- a/test/regression-provenance.test.ts
+++ b/test/regression-provenance.test.ts
@@ -26,6 +26,7 @@ function mergedPull(overrides = {}) {
     merged: true,
     merged_at: "2026-07-31T12:00:00Z",
     merge_commit_sha: mergeSha,
+    head: { sha: otherSha },
     base: { ref: "main" },
     ...overrides,
   };
@@ -45,6 +46,8 @@ function verify(
       pullCalls += 1;
       return options.pull ?? mergedPull();
     },
+    fetchPullDiff: () =>
+      "diff --git a/source b/source\n--- a/source\n+++ b/source\n@@ -1 +1 @@\n-old\n+new\n",
     runGit: (args, invocation) => {
       gitCalls.push({ args, options: invocation });
       if (options.git) return options.git(args, invocation);
@@ -74,6 +77,8 @@ test("regression provenance publishes only an exact blame-to-merge match", () =>
     evidenceType: "blame_to_merge_commit",
     mergedAt: "2026-07-31T12:00:00Z",
     reviewedCommitSha: reviewedSha,
+    sourceCommitSha: mergeSha,
+    sourceAuthor: "test",
   });
   assert.equal(pullCalls, 1);
   assert.deepEqual(
@@ -118,13 +123,22 @@ test("regression provenance omits stale, shallow, incorrect, and unavailable his
   const stale = verify({
     git: (args) => {
       if (args[0] === "rev-parse") return reviewedSha;
-      if (args[0] === "blame") return `${otherSha} 42 42 1\n`;
+      if (args[0] === "blame") return `${otherSha} 42 42 1\nauthor test\n`;
       return "src/clawsweeper-review-runtime.ts\n";
     },
   });
-  assert.equal(stale.result, null);
+  assert.deepEqual(stale.result, {
+    evidenceType: "source_line",
+    sourceCommitSha: otherSha,
+    sourceAuthor: "test",
+    sourcePath: "src/clawsweeper-review-runtime.ts",
+    sourceLine: 42,
+    relatedPullRequestNumber: null,
+    relatedPullRequestUrl: null,
+    relatedRepo: null,
+  });
   assert.equal(stale.pullCalls, 1);
-  assert.equal(stale.gitCalls.length, 3);
+  assert.equal(stale.gitCalls.length, 5);
 
   const shallow = verify({
     git: (args) => {
@@ -206,10 +220,11 @@ test("regression provenance permits an exact recorded PR-head checkout", () => {
   const gitCalls: string[][] = [];
   const verifier = createRegressionProvenanceVerifier({
     fetchPull: () => mergedPull(),
+    fetchPullDiff: () => "",
     runGit: (args) => {
       gitCalls.push(args);
       if (args[0] === "rev-parse") return prHead;
-      if (args[0] === "blame") return `${mergeSha} 42 42 1\n`;
+      if (args[0] === "blame") return `${mergeSha} 42 42 1\nauthor test\n`;
       return "src/clawsweeper-review-runtime.ts\n";
     },
   });
@@ -224,4 +239,223 @@ test("regression provenance permits an exact recorded PR-head checkout", () => {
 
   assert.equal(result?.reviewedCommitSha, prHead);
   assert.equal(gitCalls[2]?.[4], prHead);
+});
+
+test("regression provenance conservatively links an exact rewritten patch", () => {
+  const rewrittenSha = "e".repeat(40);
+  const headSha = "f".repeat(40);
+  const sourceParent = "1".repeat(40);
+  const headParent = "2".repeat(40);
+  const verifier = createRegressionProvenanceVerifier({
+    fetchPull: () => mergedPull({ head: { sha: headSha } }),
+    fetchPullDiff: () =>
+      "diff --git a/source.ts b/source.ts\n--- a/source.ts\n+++ b/source.ts\n@@ -39,7 +39,7 @@ function changed() {\n context\n-old\n+new\n context\n",
+    runGit: (args) => {
+      if (args[0] === "rev-parse") return reviewedSha;
+      if (args[0] === "ls-files") return candidate().sourcePath;
+      if (args[0] === "blame") {
+        return `${rewrittenSha} 42 42 1\nauthor Source Author\nauthor-mail <source@example.test>\n`;
+      }
+      if (args[0] === "merge-base") return "";
+      if (args[0] === "show" && args[2] === "--format=%s") return "feat: provenance (#936)";
+      if (args[0] === "show" && args[2] === "--format=%ae") return "source@example.test";
+      if (args[0] === "show" && args[2] === "--format=%P") {
+        return args[3] === rewrittenSha ? sourceParent : headParent;
+      }
+      if (args[0] === "diff") {
+        return "diff --git a/source.ts b/source.ts\n--- a/source.ts\n+++ b/source.ts\n@@ -39,7 +39,7 @@\n context\n-old\n+new\n context\n";
+      }
+      throw new Error(`unexpected git call: ${args.join(" ")}`);
+    },
+  });
+
+  assert.deepEqual(
+    verifier.verify({
+      candidate: candidate(),
+      item: { repo: "openclaw/clawsweeper", number: 946 },
+      checkoutDir: "/rewritten-checkout",
+      targetBranch: "main",
+      reviewedCommitShas: [reviewedSha],
+    }),
+    {
+      evidenceType: "rewrite_equivalent",
+      sourceCommitSha: rewrittenSha,
+      sourceAuthor: "Source Author",
+      sourcePath: candidate().sourcePath,
+      sourceLine: 42,
+      relatedPullRequestNumber: 936,
+      relatedPullRequestUrl: candidate().pullRequestUrl,
+      relatedRepo: "openclaw/clawsweeper",
+    },
+  );
+});
+
+test("regression provenance rejects equal text edits at different hunk locations", () => {
+  const rewrittenSha = "e".repeat(40);
+  const verifier = createRegressionProvenanceVerifier({
+    fetchPull: () => mergedPull({ head: { sha: "f".repeat(40) } }),
+    fetchPullDiff: () =>
+      "diff --git a/source.ts b/source.ts\n--- a/source.ts\n+++ b/source.ts\n@@ -84 +84 @@\n-old\n+new\n",
+    runGit: (args) => {
+      if (args[0] === "rev-parse") return reviewedSha;
+      if (args[0] === "ls-files") return candidate().sourcePath;
+      if (args[0] === "blame") {
+        return `${rewrittenSha} 42 42 1\nauthor Source Author\nauthor-mail <source@example.test>\n`;
+      }
+      if (args[0] === "merge-base") return "";
+      if (args[0] === "show" && args[2] === "--format=%s") return "feat: provenance (#936)";
+      if (args[0] === "show" && args[2] === "--format=%ae") return "source@example.test";
+      if (args[0] === "show" && args[2] === "--format=%P") return "1".repeat(40);
+      if (args[0] === "diff") {
+        return "diff --git a/source.ts b/source.ts\n--- a/source.ts\n+++ b/source.ts\n@@ -42 +42 @@\n-old\n+new\n";
+      }
+      throw new Error(`unexpected git call: ${args.join(" ")}`);
+    },
+  });
+
+  assert.equal(
+    verifier.verify({
+      candidate: candidate(),
+      item: { repo: "openclaw/clawsweeper", number: 946 },
+      checkoutDir: "/rewritten-checkout",
+      targetBranch: "main",
+      reviewedCommitShas: [reviewedSha],
+    })?.evidenceType,
+    "source_line",
+  );
+});
+
+test("regression provenance rejects equal edits with different surrounding context", () => {
+  const rewrittenSha = "e".repeat(40);
+  const verifier = createRegressionProvenanceVerifier({
+    fetchPull: () => mergedPull({ head: { sha: "f".repeat(40) } }),
+    fetchPullDiff: () =>
+      "diff --git a/source.ts b/source.ts\n--- a/source.ts\n+++ b/source.ts\n@@ -39,7 +39,7 @@\n pull context\n-old\n+new\n",
+    runGit: (args) => {
+      if (args[0] === "rev-parse") return reviewedSha;
+      if (args[0] === "ls-files") return candidate().sourcePath;
+      if (args[0] === "blame") {
+        return `${rewrittenSha} 42 42 1\nauthor Source Author\nauthor-mail <source@example.test>\n`;
+      }
+      if (args[0] === "merge-base") return "";
+      if (args[0] === "show" && args[2] === "--format=%s") return "feat: provenance (#936)";
+      if (args[0] === "show" && args[2] === "--format=%ae") return "source@example.test";
+      if (args[0] === "show" && args[2] === "--format=%P") return "1".repeat(40);
+      if (args[0] === "diff") {
+        return "diff --git a/source.ts b/source.ts\n--- a/source.ts\n+++ b/source.ts\n@@ -39,7 +39,7 @@\n source context\n-old\n+new\n";
+      }
+      throw new Error(`unexpected git call: ${args.join(" ")}`);
+    },
+  });
+
+  assert.equal(
+    verifier.verify({
+      candidate: candidate(),
+      item: { repo: "openclaw/clawsweeper", number: 946 },
+      checkoutDir: "/rewritten-checkout",
+      targetBranch: "main",
+      reviewedCommitShas: [reviewedSha],
+    })?.evidenceType,
+    "source_line",
+  );
+});
+
+test("regression provenance omits a PR when rewritten-history signals disagree", () => {
+  const rewrittenSha = "e".repeat(40);
+  const verifier = createRegressionProvenanceVerifier({
+    fetchPull: () => mergedPull({ head: { sha: "f".repeat(40) } }),
+    fetchPullDiff: () => "different patch\n",
+    runGit: (args) => {
+      if (args[0] === "rev-parse") return reviewedSha;
+      if (args[0] === "ls-files") return candidate().sourcePath;
+      if (args[0] === "blame") {
+        return `${rewrittenSha} 42 42 1\nauthor Source Author\nauthor-mail <source@example.test>\n`;
+      }
+      if (args[0] === "merge-base") return "";
+      if (args[0] === "show" && args[2] === "--format=%s") return "feat: ambiguous rewrite";
+      throw new Error("rewrite verification must fail closed");
+    },
+  });
+  const result = verifier.verify({
+    candidate: candidate(),
+    item: { repo: "openclaw/clawsweeper", number: 946 },
+    checkoutDir: "/rewritten-checkout",
+    targetBranch: "main",
+    reviewedCommitShas: [reviewedSha],
+  });
+  assert.deepEqual(result, {
+    evidenceType: "source_line",
+    sourceCommitSha: rewrittenSha,
+    sourceAuthor: "Source Author",
+    sourcePath: candidate().sourcePath,
+    sourceLine: 42,
+    relatedPullRequestNumber: null,
+    relatedPullRequestUrl: null,
+    relatedRepo: null,
+  });
+});
+
+test("regression provenance retains source-line evidence when PR diff lookup fails", () => {
+  const rewrittenSha = "e".repeat(40);
+  const verifier = createRegressionProvenanceVerifier({
+    fetchPull: () => mergedPull({ head: { sha: "f".repeat(40) } }),
+    fetchPullDiff: () => {
+      throw new Error("diff unavailable");
+    },
+    runGit: (args) => {
+      if (args[0] === "rev-parse") return reviewedSha;
+      if (args[0] === "ls-files") return candidate().sourcePath;
+      if (args[0] === "blame") {
+        return `${rewrittenSha} 42 42 1\nauthor Source Author\nauthor-mail <source@example.test>\n`;
+      }
+      if (args[0] === "merge-base") return "";
+      throw new Error(`unexpected git command: ${args.join(" ")}`);
+    },
+  });
+
+  assert.deepEqual(
+    verifier.verify({
+      candidate: candidate(),
+      item: { repo: "openclaw/clawsweeper", number: 946 },
+      checkoutDir: "/rewritten-checkout",
+      targetBranch: "main",
+      reviewedCommitShas: [reviewedSha],
+    }),
+    {
+      evidenceType: "source_line",
+      sourceCommitSha: rewrittenSha,
+      sourceAuthor: "Source Author",
+      sourcePath: candidate().sourcePath,
+      sourceLine: candidate().sourceLine,
+      relatedPullRequestNumber: null,
+      relatedPullRequestUrl: null,
+      relatedRepo: null,
+    },
+  );
+});
+
+test("regression provenance rejects a branch-only blamed commit", () => {
+  const branchSha = "e".repeat(40);
+  const verifier = createRegressionProvenanceVerifier({
+    fetchPull: () => mergedPull({ head: { sha: "f".repeat(40) } }),
+    fetchPullDiff: () => "unused",
+    runGit: (args) => {
+      if (args[0] === "rev-parse") return reviewedSha;
+      if (args[0] === "ls-files") return candidate().sourcePath;
+      if (args[0] === "blame") return `${branchSha} 42 42 1\nauthor Current Contributor\n`;
+      if (args[0] === "merge-base") throw new Error("not an ancestor");
+      throw new Error(`unexpected git command: ${args.join(" ")}`);
+    },
+  });
+
+  assert.equal(
+    verifier.verify({
+      candidate: candidate(),
+      item: { repo: "openclaw/clawsweeper", number: 946 },
+      checkoutDir: "/branch-checkout",
+      targetBranch: "main",
+      reviewedCommitShas: [reviewedSha, "f".repeat(40)],
+    }),
+    null,
+  );
 });

--- a/test/regression-provenance.test.ts
+++ b/test/regression-provenance.test.ts
@@ -104,6 +104,25 @@ test("regression provenance publishes only an exact blame-to-merge match", () =>
   }
 });
 
+test("exact verified provenance survives unsafe author redaction", () => {
+  const { result } = verify({
+    git: (args) => {
+      if (args[0] === "rev-parse") return `${reviewedSha}\n`;
+      if (args[0] === "blame") {
+        return `${mergeSha} 42 42 1\nauthor Private Author <private@example.test>\n`;
+      }
+      return "src/clawsweeper-review-runtime.ts\n";
+    },
+  });
+
+  assert.deepEqual(result, {
+    ...candidate(),
+    evidenceType: "blame_to_merge_commit",
+    mergedAt: "2026-07-31T12:00:00Z",
+    reviewedCommitSha: reviewedSha,
+  });
+});
+
 test("regression provenance rejects malformed or self candidates before metadata or Git", () => {
   for (const invalid of [
     candidate({ sourcePath: "../secrets" }),

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -910,14 +910,16 @@ test("verified regression provenance renders the predecessor PR without local so
       regression_provenance_evidence_type: "blame_to_merge_commit",
       regression_provenance_merged_at: "2026-07-31T12:00:00Z",
       regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: mergeSha,
+      regression_provenance_source_author: "Source Author",
     }),
     "implemented_on_main",
   );
   assert.match(
     closeComment,
-    /Verified regression provenance: \[#936\]\(https:\/\/github\.com\/openclaw\/clawsweeper\/pull\/936\)/,
+    /Regression provenance — verified: source commit `aaaaaaaaaaaa` by Source Author; canonical PR \[#936\]\(https:\/\/github\.com\/openclaw\/clawsweeper\/pull\/936\)/,
   );
-  assert.match(closeComment, /blame-to-merge-commit; `aaaaaaaaaaaa`/);
+  assert.match(closeComment, /\(blame-to-merge-commit\)/);
   assert.doesNotMatch(closeComment, /src\/clawsweeper-review-runtime\.ts/);
   assert.doesNotMatch(closeComment, new RegExp(mergeSha));
 
@@ -934,6 +936,8 @@ test("verified regression provenance renders the predecessor PR without local so
       regression_provenance_evidence_type: "blame_to_merge_commit",
       regression_provenance_merged_at: "2026-07-31T12:00:00Z",
       regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: mergeSha,
+      regression_provenance_source_author: "Source Author",
     })}
 
 ## Summary
@@ -946,6 +950,33 @@ Keep open while the regression is fixed.
   assert.match(
     keepOpenComment,
     /\[#936\]\(https:\/\/github\.com\/openclaw\/clawsweeper\/pull\/936\)/,
+  );
+});
+
+test("legacy verified regression provenance remains visible without inventing an author", () => {
+  const mergeSha = "a".repeat(40);
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_provenance_repo: "openclaw/clawsweeper",
+      regression_provenance_pr_url: "https://github.com/openclaw/clawsweeper/pull/936",
+      regression_provenance_pr_number: "936",
+      regression_provenance_merge_sha: mergeSha,
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_evidence_type: "blame_to_merge_commit",
+      regression_provenance_merged_at: "2026-07-31T12:00:00Z",
+      regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: "unknown",
+      regression_provenance_source_author: "unknown",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.match(comment, /source commit `aaaaaaaaaaaa`/);
+  assert.match(comment, /source author not recorded in this legacy report/);
+  assert.match(
+    comment,
+    /canonical PR \[#936\]\(https:\/\/github\.com\/openclaw\/clawsweeper\/pull\/936\)/,
   );
 });
 
@@ -967,6 +998,256 @@ test("unverified regression-provenance front matter cannot render a predecessor"
 
   assert.doesNotMatch(comment, /Verified regression provenance/);
   assert.doesNotMatch(comment, /pull\/936/);
+});
+
+test("verified provenance rejects a source commit that differs from the merge commit", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_provenance_repo: "openclaw/clawsweeper",
+      regression_provenance_pr_url: "https://github.com/openclaw/clawsweeper/pull/936",
+      regression_provenance_pr_number: "936",
+      regression_provenance_merge_sha: "a".repeat(40),
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_evidence_type: "blame_to_merge_commit",
+      regression_provenance_merged_at: "2026-07-31T12:00:00Z",
+      regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "Source Author",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.doesNotMatch(comment, /Regression provenance.*verified|canonical PR \[#936\]/);
+});
+
+test("verified provenance accepts equivalent normalized source commit text", () => {
+  const sha = "a".repeat(40);
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_provenance_repo: "openclaw/clawsweeper",
+      regression_provenance_pr_url: "https://github.com/openclaw/clawsweeper/pull/936",
+      regression_provenance_pr_number: "936",
+      regression_provenance_merge_sha: sha,
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_evidence_type: "blame_to_merge_commit",
+      regression_provenance_merged_at: "2026-07-31T12:00:00Z",
+      regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: ` ${sha.toUpperCase()} `,
+      regression_provenance_source_author: "Source Author",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.match(comment, /Regression provenance.*verified/);
+  assert.match(comment, /source commit `aaaaaaaaaaaa`/);
+});
+
+test("verified provenance rejects Unicode direction controls in author names", () => {
+  const sha = "a".repeat(40);
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_provenance_repo: "openclaw/clawsweeper",
+      regression_provenance_pr_url: "https://github.com/openclaw/clawsweeper/pull/936",
+      regression_provenance_pr_number: "936",
+      regression_provenance_merge_sha: sha,
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_evidence_type: "blame_to_merge_commit",
+      regression_provenance_merged_at: "2026-07-31T12:00:00Z",
+      regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: sha,
+      regression_provenance_source_author: "safe\u202eevil",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.doesNotMatch(comment, /Regression provenance.*verified|safe/);
+});
+
+test("verified provenance rejects email-shaped author names", () => {
+  const sha = "a".repeat(40);
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_provenance_repo: "openclaw/clawsweeper",
+      regression_provenance_pr_url: "https://github.com/openclaw/clawsweeper/pull/936",
+      regression_provenance_pr_number: "936",
+      regression_provenance_merge_sha: sha,
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_evidence_type: "blame_to_merge_commit",
+      regression_provenance_merged_at: "2026-07-31T12:00:00Z",
+      regression_provenance_reviewed_sha: "b".repeat(40),
+      regression_provenance_source_commit_sha: sha,
+      regression_provenance_source_author: "Private Author <private@localhost>",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.doesNotMatch(comment, /Regression provenance.*verified|private@/);
+});
+
+test("suspected provenance renders commit, author, status, and only a verified related PR", () => {
+  const base = {
+    regression_assessment_confidence: "suspected",
+    regression_assessment_evidence: "reviewed_change",
+    regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+    regression_provenance_source_line: "42",
+    regression_provenance_source_commit_sha: "c".repeat(40),
+    regression_provenance_source_author: "Source Author",
+    regression_provenance_evidence_type: "source_line",
+  };
+  const unlinked = renderReviewCommentFromReport(
+    implementedCloseReport(base),
+    "implemented_on_main",
+  );
+  assert.match(unlinked, /suspected predecessor, not a causality claim/);
+  assert.match(unlinked, /source commit `cccccccccccc` by Source Author; no PR verified/);
+
+  const linked = renderReviewCommentFromReport(
+    implementedCloseReport({
+      ...base,
+      regression_provenance_evidence_type: "rewrite_equivalent",
+      regression_provenance_related_pr_number: "1023",
+      regression_provenance_related_pr_url: "https://github.com/openclaw/clawsweeper/pull/1023",
+      regression_provenance_related_repo: "openclaw/clawsweeper",
+    }),
+    "implemented_on_main",
+  );
+  assert.match(linked, /safely related PR \[#1023\]/);
+
+  const spoofed = renderReviewCommentFromReport(
+    implementedCloseReport({
+      ...base,
+      regression_provenance_evidence_type: "rewrite_equivalent",
+      regression_provenance_related_pr_number: "1023",
+      regression_provenance_related_pr_url: "https://example.test/not-a-pr",
+      regression_provenance_related_repo: "openclaw/clawsweeper",
+    }),
+    "implemented_on_main",
+  );
+  assert.doesNotMatch(spoofed, /example\.test|safely related PR/);
+
+  const impossibleLine = renderReviewCommentFromReport(
+    implementedCloseReport({
+      ...base,
+      regression_provenance_source_line: "0",
+    }),
+    "implemented_on_main",
+  );
+  assert.doesNotMatch(impossibleLine, /suspected predecessor|source commit `cccccccccccc`/);
+});
+
+test("suspected provenance supplements rather than suppresses regression assessment", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_assessment_confidence: "probable",
+      regression_assessment_evidence: "reproduction,reviewed_change",
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "Source Author",
+      regression_provenance_evidence_type: "source_line",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.match(comment, /suspected predecessor, not a causality claim/);
+  assert.match(comment, /Possible regression \u2014 probable \(reproduction; reviewed change\)/);
+});
+
+test("rewrite-equivalent provenance and assessment do not contradict each other", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_assessment_confidence: "probable",
+      regression_assessment_evidence: "reproduction,reviewed_change",
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "Source Author",
+      regression_provenance_evidence_type: "rewrite_equivalent",
+      regression_provenance_related_pr_number: "1023",
+      regression_provenance_related_pr_url: "https://github.com/openclaw/clawsweeper/pull/1023",
+      regression_provenance_related_repo: "openclaw/clawsweeper",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.match(comment, /safely related PR \[#1023\]/);
+  assert.match(comment, /Possible regression \u2014 probable \(reproduction; reviewed change\)\./);
+  assert.doesNotMatch(comment, /No predecessor PR is attributed/);
+});
+
+test("provenance author names cannot trigger GitHub mentions", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_assessment_confidence: "suspected",
+      regression_assessment_evidence: "reviewed_change",
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "@openclaw/maintainers",
+      regression_provenance_evidence_type: "source_line",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.doesNotMatch(comment, /@openclaw\/maintainers/);
+  assert.match(comment, /@\u200bopenclaw\/maintainers/);
+});
+
+test("a provenance author literally named unknown remains visible", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_assessment_confidence: "suspected",
+      regression_assessment_evidence: "reviewed_change",
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "unknown",
+      regression_provenance_evidence_type: "source_line",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.match(comment, /source commit `cccccccccccc` by unknown; no PR verified/);
+});
+
+test("suspected provenance rejects Unicode direction controls in author names", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_assessment_confidence: "suspected",
+      regression_assessment_evidence: "reviewed_change",
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "safe\u202eevil",
+      regression_provenance_evidence_type: "source_line",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.doesNotMatch(comment, /suspected predecessor|safe/);
+  assert.match(comment, /Possible regression \u2014 suspected/);
+});
+
+test("suspected provenance rejects email-shaped author names", () => {
+  const comment = renderReviewCommentFromReport(
+    implementedCloseReport({
+      regression_assessment_confidence: "suspected",
+      regression_assessment_evidence: "reviewed_change",
+      regression_provenance_source_path: "src/clawsweeper-review-runtime.ts",
+      regression_provenance_source_line: "42",
+      regression_provenance_source_commit_sha: "c".repeat(40),
+      regression_provenance_source_author: "Private Author <private@localhost>",
+      regression_provenance_evidence_type: "source_line",
+    }),
+    "implemented_on_main",
+  );
+
+  assert.doesNotMatch(comment, /suspected predecessor|private@/);
+  assert.match(comment, /Possible regression \u2014 suspected/);
 });
 
 test("probable regression assessments render evidence without attributing a predecessor", () => {


### PR DESCRIPTION
## Summary

- show regression provenance status, source commit, source author, and a canonical or conservatively related pull request together
- distinguish verified blame-to-merge provenance from cautious, non-causal suspected predecessor evidence
- resolve rewritten-history relationships only when canonical metadata, mainline history, subject association, and a location/context-preserving patch comparison agree
- retain exact verified commit/PR attribution when an unsafe author value must be omitted

## Problem

The exact review added by #1023 could identify a rewritten-history source commit and author without visibly connecting it to the associated PR. That made otherwise useful provenance incomplete for maintainers. This follow-up preserves the strict verified contract while making cautious evidence explicit and useful.

## Implementation

- verified output includes normalized source commit, canonical PR, source author when safe, and verified status
- suspected output requires an independent regression assessment and includes source commit, safe author, cautious status, and either a conservatively resolved related PR or `no PR verified`
- rewrite equivalence requires canonical merged metadata, a single-parent source commit, a `(#PR)` subject association, mainline ancestry, and exact normalized patch equality preserving paths, hunk locations, and surrounding context; ambiguity fails closed
- exact blame-to-merge verification remains authoritative when an unsafe author must be redacted; the commit/author pair is omitted together while the verified canonical PR remains
- durable report persistence and all public rendering paths preserve suspected/verified provenance and independent regression confidence
- public author validation rejects Unicode direction/format controls and email-shaped values; rendering neutralizes GitHub mentions
- legacy verified reports remain readable without inventing missing authors
- provider-schema compatibility, exact review admission, parser validation, and the public status data contract are unchanged

## Maintainer policy decision

Martin explicitly chose the public-attribution behavior implemented here: when evidence exists, show the source commit, linked PR when safely resolved, source author, and clear `suspected` versus `verified` status together. Suspected output is non-blaming and must not claim causality. Rewritten-history association remains conservative and fails closed to `no PR verified`. If an author is unsafe to publish, verified canonical attribution is retained while the author/source pair is omitted.

## Validation

Current head: `62fc8a6cb4ba169697e6bb61561ef7fde76eec84`  
Current base and merge-base: `463edfe33f39954bc2483a4d9b2ae382cd5ffa10`

- TypeScript builds: `tsc -p tsconfig.json`, `tsc -p tsconfig.repair.json`, `tsc -p tsconfig.dashboard.json` — passed
- `node --test test/regression-provenance.test.ts test/review-comment-rendering.test.ts test/decision-parser.test.ts test/codex-review-runner.test.ts` — 92 passed, 0 failed
- `git diff --check origin/main...HEAD` — passed
- dirty-patch `codex.exe review --uncommitted` for the unsafe-author repair — clean; no actionable findings
- committed `codex.exe review --base origin/main` on the exact current head/base — clean; no actionable correctness defect (conservative validation, safe rendering/persistence, focused coverage)
- mutation-free local ClawSweeper range review from an exact clean checkout — `keep_open`, high confidence, `action=kept_open`, no failure; artifact `local-range-1786356010815-25756`

## Real Behavior Proof

Crabbox source sync failed before command execution across both the required `local-container` lane and configured AWS fallback with zero-byte rsync protocol error 12. Martin explicitly authorized direct local Docker as a bounded exception for this PR. No Crabbox run is claimed as successful.

### Focused direct-Docker proof

This first receipt predates the final rebase and established the focused deterministic contract at head `2953c076bd81e245041137c4ba560d3fb2d00d76`; the same focused suite was rerun locally at the current head with 92/92 passing.

- **Claim:** the implementation builds and its focused provenance, rendering, parser, and Codex-runner suite passes unchanged on Linux/Node 24
- **Environment:** Docker Desktop 29.5.2; `mcr.microsoft.com/playwright:v1.60.0-noble`; image digest `sha256:9bd26ad900bb5e0f4dee75839e957a89ae89c2b7ab1e76050e559790e946b948`; Node 24.15.0; pnpm 11.10.0
- **Script integrity:** unchanged script SHA-256 `02094ad489913a1f78ac9a27b12685cd5643a1cb24da23a34753dce1de705397`
- **Container:** `csw116-pr1027-proof-20260810a` / `774b7942f99cc3aa91e48eaf3f29aeebcc007eedb277d8f2c0bc084f0cda9936`
- **Observed:** frozen install and all three builds passed; 91 tests passed, 0 failed; exit 0; 21.720s
- **Cleanup:** Docker emitted `die exitCode=0` then `destroy`; no matching container remained
- **Limits:** focused deterministic receipt on the earlier rebased head; source Git metadata was not present inside this first container; no live GitHub, queue, workflow, deployment, publication, or production mutation

### Current-head end-to-end provenance trace

- **Claim:** on the exact current head/base, the real verifier, durable front-matter serialization/parser, and final public comment renderer preserve conservative suspected/verified provenance and safely redact an unsafe author without dropping verified canonical attribution
- **Environment:** direct local Docker; same pinned image/digest; Node 24.15.0; pnpm 11.10.0
- **Identity:** head `62fc8a6cb4ba169697e6bb61561ef7fde76eec84`; base/merge-base `463edfe33f39954bc2483a4d9b2ae382cd5ffa10`; harness SHA-256 `82eb36be2d703c8eb195e79661c3d949a804071db270a6ac5966adc46d8133de`
- **Container:** `csw116-pr1027-e2e-finalbase-20260810a` / `7d6d7d471beeee643c32c2af86129385ad963aa3d5c16f4d904ec3904856e474`
- **Isolation:** source worktree and common `.git` mounted read-only; source copied to container-only storage; exact head, merge-base, and harness hash verified in-container
- **Canonical evidence:** immutable #1023 canonical metadata/head diff plus current rewritten blame at `src/clawsweeper-policy.ts:759`, commit `bb69d1fc582d46298df0f26f9192f721f976e9f4` by Martin Cleary
- **Observed scenarios:**
  - rewrite-equivalent history rendered the rewritten source commit/author as a suspected predecessor and safely related PR #1023
  - missing canonical diff retained source-only evidence and omitted an unverified PR
  - exact canonical blame rendered verified commit/author/canonical PR
  - a legacy verified report remained readable without inventing an author
  - an unsafe verified author was omitted while the canonical PR remained
  - metadata verification failure returned null and rendered no predecessor attribution
- **Result:** frozen install passed with the 72-entry supply-chain policy check; `build:all` passed; 6 end-to-end tests passed, 0 failed; container exit 0; 18.700s
- **Cleanup:** Docker recorded create/start/die `exitCode=0`/destroy; no residual container
- **Artifact:** captured terminal trace plus image/container/Docker event identities; no persistent artifact file
- **Limits:** real local immutable Git metadata and deterministic canonical fixtures; no live GitHub API call, comment, queue, workflow, deployment, publication, or production mutation; direct Docker exception, not a Crabbox lease/run/timing receipt

### Crabbox limitation

Crabbox 0.40.0 provisioned local-container and AWS leases, but every valid attempt failed before the proof script with rsync protocol error 12 and zero bytes transferred, including a local `--debug --full-resync` recovery. All owned leases were released. The direct-Docker proofs above exercise the changed behavior but do not repair or validate Crabbox transport.

## Risks / Rollout

- rewritten-history PR association is intentionally conservative and may omit a valid relationship when any required signal is unavailable or ambiguous
- source authors resembling private email data or containing unsafe formatting controls are omitted; verified canonical attribution remains available without inventing or exposing an author
- this changes review/report provenance presentation only; it does not touch Bay intake, queues, retry policy, publication, schedules, workflows, or the public status data contract, so OpenClaw Bay behavior is unaffected
- normal CI and the fresh exact-head/current-body ClawSweeper review must be terminal clear before merge

## Related

- builds on exact-review and regression-provenance behavior from #1023
- preserves the supported strict-output admission restored by #1026

Release-note context: ClawSweeper regression provenance now presents commit, author, status, and a verified or safely related PR together without overstating causality.