### PR TITLE
fix(queue): preserve review budget for temporary deferrals

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -791,6 +791,7 @@ jobs:
               echo "::notice::GitHub throttled the live-item check for $TARGET_REPO#$ITEM_NUMBER; releasing the claim for retry at $retry_at without spending failure budget."
               {
                 echo "admission_retry=true"
+                echo "retry_kind=throttle"
                 echo "retry_at=$retry_at"
                 echo "proceed=false"
                 echo "terminal_noop=false"
@@ -1008,7 +1009,7 @@ jobs:
             if grep -Eqi 'rate limit exceeded|secondary rate limit|HTTP 429' "$reservation_error"; then
               retry_at="$(date -u -d "@$(( $(date -u +%s) + 1200 ))" +%Y-%m-%dT%H:%M:%SZ)"
               echo "::notice::GitHub throttled the exact-review reservation; deferring until $retry_at so the durable queue retries without spending failure budget."
-              reservation="{\"status\":\"held\",\"retryAt\":\"$retry_at\"}"
+              reservation="{\"status\":\"held\",\"retryAt\":\"$retry_at\",\"retryKind\":\"throttle\"}"
               break
             fi
             if ! grep -Eqi '(exact-review queue authority changed|review revision changed|could not (confirm|identify).+review lease).+retry required' "$reservation_error"; then
@@ -1043,7 +1044,10 @@ jobs:
           if (reservation.status === "held") {
             const retryAt = String(reservation.retryAt || "");
             if (!Number.isFinite(Date.parse(retryAt))) process.exit(1);
+            const retryKind =
+              reservation.retryKind === "throttle" ? "throttle" : "coordination";
             append("status", "held");
+            append("retry_kind", retryKind);
             append("retry_at", new Date(retryAt).toISOString());
             process.exit(0);
           }
@@ -1258,6 +1262,7 @@ jobs:
               if (!value || !Number.isFinite(timestamp)) process.exit(1);
               process.stdout.write(new Date(timestamp).toISOString());
             ' "$coordination_held_path")"
+            echo "retry_kind=coordination" >> "$GITHUB_OUTPUT"
             echo "retry_at=$retry_at" >> "$GITHUB_OUTPUT"
             echo "::notice::Review coordination is held until $retry_at."
           fi
@@ -1661,6 +1666,7 @@ jobs:
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && always() }}
         env:
           ADMISSION_RETRY: ${{ steps.live-item.outputs.admission_retry }}
+          RETRY_KIND: ${{ steps.live-item.outputs.retry_kind || steps.reserve-exact-review-lease.outputs.retry_kind || steps.review-exact-event-item.outputs.retry_kind }}
           TARGET_ENABLED: ${{ steps.target.outputs.target_enabled }}
           LIVE_OUTCOME: ${{ steps.live-item.outcome }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
@@ -1674,7 +1680,7 @@ jobs:
         run: |
           outcome=failure
           requeue_latest=false
-          if [ "$ADMISSION_RETRY" = "true" ]; then
+          if [ "$ADMISSION_RETRY" = "true" ] && [ -z "$RETRY_KIND" ]; then
             outcome=success
             requeue_latest=true
           elif [ "$TARGET_ENABLED" = "false" ]; then
@@ -1706,6 +1712,7 @@ jobs:
           QUEUE_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           REQUEUE_LATEST: ${{ steps.exact-review-generation-result.outputs.requeue_latest }}
+          RETRY_KIND: ${{ steps.live-item.outputs.retry_kind || steps.reserve-exact-review-lease.outputs.retry_kind || steps.review-exact-event-item.outputs.retry_kind }}
           RETRY_AT: ${{ steps.live-item.outputs.retry_at || steps.reserve-exact-review-lease.outputs.retry_at || steps.review-exact-event-item.outputs.retry_at }}
           DIRECT_PUBLICATION_ACCEPTED: ${{ steps.direct-exact-review-publication.outputs.accepted }}
           DIRECT_PUBLICATION_SUPERSEDED: ${{ steps.direct-exact-review-publication.outputs.superseded }}
@@ -1736,7 +1743,10 @@ jobs:
               ? primaryOutcome
               : "failure";
             const requeueLatest = process.env.REQUEUE_LATEST === "true";
+            const retryKind = String(process.env.RETRY_KIND || "").trim();
             const retryAt = String(process.env.RETRY_AT || "").trim();
+            if (retryKind && !["coordination", "throttle"].includes(retryKind)) process.exit(1);
+            if (retryKind && !retryAt) process.exit(1);
             const directPublicationCompleted =
               process.env.DIRECT_PUBLICATION_ACCEPTED === "true" &&
               process.env.DIRECT_LIFECYCLE_OUTCOME === "success";
@@ -1758,6 +1768,7 @@ jobs:
               run_attempt: runAttempt,
               outcome,
               ...(requeueLatest ? { requeue_latest: true } : {}),
+              ...(retryKind ? { retry_kind: retryKind } : {}),
               ...(directPublicationCompleted
                 ? directPublicationSuperseded
                   ? { completion_kind: "superseded", reason_code: "remote_newer_tuple" }

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -147,6 +147,8 @@ type ExactReviewBackoffReason =
   | "dispatch_debounce"
   | "dispatcher_backoff"
   | "admission_retry"
+  | "coordination_retry"
+  | "throttle_retry"
   | "review_retry"
   | "publication_retry";
 type ExactReviewParkedReason =
@@ -212,6 +214,7 @@ export type ExactReviewQueueItem = {
   terminalFinalization?: ExactReviewTerminalFinalization;
 };
 export type ExactReviewCompletionOutcome = "success" | "failure" | "cancelled";
+type ExactReviewRetryKind = "coordination" | "throttle";
 type ExactReviewPublicationFailureKind = "github_rate_limit" | "github_transient";
 type ExactReviewDispatchFailureClass =
   | "permanent_rejection"
@@ -1702,6 +1705,17 @@ export class ExactReviewQueue {
       if (body.retry_at !== undefined && requestedRetryAt === null) {
         return json({ error: "invalid_retry_at" }, 400);
       }
+      const retryKind =
+        body.retry_kind === undefined ? undefined : exactReviewRetryKind(body.retry_kind);
+      if (body.retry_kind !== undefined && !retryKind) {
+        return json({ error: "invalid_retry_kind" }, 400);
+      }
+      if (retryKind && outcome !== "failure") {
+        return json({ error: "retry_kind_without_failure" }, 400);
+      }
+      if (retryKind && requestedRetryAt === null) {
+        return json({ error: "retry_kind_without_retry_at" }, 400);
+      }
       const state = this.readStateSync();
       const item = tupleCompletion ? state.items[itemKey] : exactReviewItemForLease(state, leaseId);
       if (
@@ -1752,6 +1766,9 @@ export class ExactReviewQueue {
       }
       if (failureKind && !publicationItem) {
         return json({ error: "failure_kind_outside_publication" }, 400);
+      }
+      if (retryKind && publicationItem) {
+        return json({ error: "retry_kind_outside_regular_review" }, 400);
       }
       const leasedDirectLifecycle = item.leaseDecision?.publication?.directLifecycle;
       const directLifecycleLeasePublication =
@@ -1854,6 +1871,7 @@ export class ExactReviewQueue {
                 outcome,
                 requestedRetryAt ?? undefined,
                 requeueLatest,
+                retryKind,
               ),
               retried: outcome !== "success",
               refreshed: false,
@@ -10717,22 +10735,35 @@ function finishExactReviewQueueItem(
   outcome: ExactReviewCompletionOutcome,
   requestedRetryAt = 0,
   requeueLatest = false,
+  retryKind?: ExactReviewRetryKind,
 ) {
   const retryingFailure = outcome !== "success";
   const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
+  const typedDeferral = retryKind !== undefined && !hasNewerRevision && !requeueLatest;
   // A regular queue item may back off and retry after a failed lease. Failed
   // sweep shards already consumed their one recovery attempt before reaching
   // the queue, so only a newer source revision may supersede that recovery.
   const oneShotRecovery =
     item.leaseDecision?.sourceAction === FAILED_REVIEW_SHARD_RECOVERY_SOURCE_ACTION;
-  const requeued = (!oneShotRecovery && retryingFailure) || hasNewerRevision || requeueLatest;
+  const requeued =
+    typedDeferral || (!oneShotRecovery && retryingFailure) || hasNewerRevision || requeueLatest;
   if (!requeued) {
     delete state.items[item.key];
     return { requeued: false, parked: false };
   }
   clearExactReviewLease(item);
   item.state = "pending";
-  if (retryingFailure && !hasNewerRevision && !requeueLatest) {
+  if (typedDeferral) {
+    const dispatcherAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
+    item.nextAttemptAt = Math.max(dispatcherAttemptAt, requestedRetryAt);
+    item.backoffReason =
+      dispatcherAttemptAt >= item.nextAttemptAt
+        ? "dispatcher_backoff"
+        : retryKind === "coordination"
+          ? "coordination_retry"
+          : "throttle_retry";
+    item.parkedReason = undefined;
+  } else if (retryingFailure && !hasNewerRevision && !requeueLatest) {
     item.attempts += 1;
     if (!exactReviewQueueIsPublication(item)) {
       const failureAttempts = Number(item.reviewFailureAttempts || 0) + 1;
@@ -10771,6 +10802,11 @@ function exactReviewCompletionRetryAt(value, now: number): number | null {
   if (!Number.isFinite(retryAt)) return null;
   if (retryAt > now + EXACT_REVIEW_COMPLETION_RETRY_MAX_MS) return null;
   return Math.max(now, retryAt);
+}
+
+function exactReviewRetryKind(value): ExactReviewRetryKind | null {
+  const normalized = String(value || "");
+  return normalized === "coordination" || normalized === "throttle" ? normalized : null;
 }
 
 function clearExactReviewLease(item: ExactReviewQueueItem) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -19381,7 +19381,52 @@ test("failed shard recovery replaces an expired recovery lease", async () => {
   assert.equal(replacement.leaseId, undefined);
 });
 
-test("exact-review queue defers a coordination-held failure until the lease expires", async () => {
+for (const retryKind of ["coordination", "throttle"] as const) {
+  test(`exact-review queue defers ${retryKind} without spending review attempts`, async () => {
+    const storage = new MemoryDurableStorage();
+    const retryAt = Date.now() + 45 * 60_000;
+    const item = leasedExactReviewQueueItem(711, "7110");
+    item.attempts = 3;
+    item.reviewFailureAttempts = 2;
+    await storage.put("exact-review-queue", {
+      deliveries: {},
+      items: {
+        "openclaw/openclaw#711": item,
+      },
+    });
+    const queue = new ExactReviewQueue({ storage }, {});
+
+    const response = await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          lease_id: "lease-711",
+          item_key: "openclaw/openclaw#711",
+          lease_revision: 1,
+          claim_generation: 1,
+          run_id: "7110",
+          run_attempt: 1,
+          outcome: "failure",
+          retry_kind: retryKind,
+          retry_at: new Date(retryAt).toISOString(),
+        }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, requeued: true });
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, Record<string, unknown>>;
+    };
+    const deferred = state.items["openclaw/openclaw#711"];
+    assert.ok(Number(deferred.nextAttemptAt) >= retryAt);
+    assert.equal(deferred.attempts, 3);
+    assert.equal(deferred.reviewFailureAttempts, 2);
+    assert.equal(deferred.backoffReason, `${retryKind}_retry`);
+  });
+}
+
+test("exact-review queue spends review attempts for an untyped retry deadline", async () => {
   const storage = new MemoryDurableStorage();
   const retryAt = Date.now() + 45 * 60_000;
   await storage.put("exact-review-queue", {
@@ -19409,18 +19454,19 @@ test("exact-review queue defers a coordination-held failure until the lease expi
   );
 
   assert.equal(response.status, 200);
-  assert.deepEqual(await response.json(), { ok: true, requeued: true });
   const state = (await storage.get("exact-review-queue")) as {
     items: Record<string, Record<string, unknown>>;
   };
-  assert.ok(Number(state.items["openclaw/openclaw#711"].nextAttemptAt) >= retryAt);
   assert.equal(state.items["openclaw/openclaw#711"].attempts, 1);
+  assert.equal(state.items["openclaw/openclaw#711"].reviewFailureAttempts, 1);
 });
 
 test("exact-review queue does not carry an old coordination deadline to a newer revision", async () => {
   const storage = new MemoryDurableStorage();
   const retryAt = Date.now() + 45 * 60_000;
   const item = leasedExactReviewQueueItem(712, "7120");
+  item.attempts = 3;
+  item.reviewFailureAttempts = 2;
   item.revision = Number(item.leaseRevision) + 1;
   await storage.put("exact-review-queue", {
     deliveries: {},
@@ -19439,6 +19485,7 @@ test("exact-review queue does not carry an old coordination deadline to a newer 
         run_id: "7120",
         run_attempt: 1,
         outcome: "failure",
+        retry_kind: "coordination",
         retry_at: new Date(retryAt).toISOString(),
       }),
     }),
@@ -19449,11 +19496,35 @@ test("exact-review queue does not carry an old coordination deadline to a newer 
     items: Record<string, Record<string, unknown>>;
   };
   assert.ok(Number(state.items["openclaw/openclaw#712"].nextAttemptAt) < retryAt);
+  assert.equal(state.items["openclaw/openclaw#712"].attempts, 0);
+  assert.equal(state.items["openclaw/openclaw#712"].reviewFailureAttempts, 0);
 });
 
-test("exact-review queue rejects invalid coordination retry deadlines", async () => {
+test("exact-review queue rejects invalid retry deferral contracts", async () => {
   const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
-  for (const retryAt of ["not-a-timestamp", new Date(Date.now() + 3 * 60 * 60_000).toISOString()]) {
+  for (const [payload, error] of [
+    [
+      { retry_kind: "capacity", retry_at: new Date(Date.now() + 60_000).toISOString() },
+      "invalid_retry_kind",
+    ],
+    [{ retry_kind: "coordination" }, "retry_kind_without_retry_at"],
+    [
+      {
+        outcome: "success",
+        retry_kind: "coordination",
+        retry_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      "retry_kind_without_failure",
+    ],
+    [{ retry_kind: "coordination", retry_at: "not-a-timestamp" }, "invalid_retry_at"],
+    [
+      {
+        retry_kind: "throttle",
+        retry_at: new Date(Date.now() + 3 * 60 * 60_000).toISOString(),
+      },
+      "invalid_retry_at",
+    ],
+  ] as const) {
     const response = await queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/complete", {
         method: "POST",
@@ -19465,13 +19536,43 @@ test("exact-review queue rejects invalid coordination retry deadlines", async ()
           run_id: "7120",
           run_attempt: 1,
           outcome: "failure",
-          retry_at: retryAt,
+          ...payload,
         }),
       }),
     );
     assert.equal(response.status, 400);
-    assert.deepEqual(await response.json(), { error: "invalid_retry_at" });
+    assert.deepEqual(await response.json(), { error });
   }
+});
+
+test("exact-review queue rejects regular-review retry kinds for publication work", async () => {
+  const storage = new MemoryDurableStorage();
+  const item = leasedExactReviewPublicationItem(712, "7120");
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: { [item.key]: item },
+  });
+  const queue = new ExactReviewQueue({ storage }, {});
+
+  const response = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/complete", {
+      method: "POST",
+      body: JSON.stringify({
+        lease_id: item.leaseId,
+        item_key: item.key,
+        lease_revision: item.leaseRevision,
+        claim_generation: item.claimGeneration,
+        run_id: item.claimedRunId,
+        run_attempt: item.claimedRunAttempt,
+        outcome: "failure",
+        retry_kind: "throttle",
+        retry_at: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "retry_kind_outside_regular_review" });
 });
 
 test("exact-review queue requeues a verified source drift exactly once without failure backoff", async () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -413,6 +413,7 @@ test("review workflow gives Codex a read-only inspection token", () => {
     /report_path="artifacts\/event\/\$\{\{ steps\.target\.outputs\.item_number \}\}\.md"/,
   );
   assert.match(exactReviewStep, /coordination-held\.json/);
+  assert.match(exactReviewStep, /echo "retry_kind=coordination" >> "\$GITHUB_OUTPUT"/);
   assert.match(exactReviewStep, /echo "retry_at=\$retry_at" >> "\$GITHUB_OUTPUT"/);
   assert.match(exactReviewStep, /Exact review produced no artifact for open item/);
   assert.match(reviewJob, /uses: \.\/clawsweeper\/\.github\/actions\/setup-codex/);
@@ -614,7 +615,12 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     /rate limit exceeded\|secondary rate limit\|HTTP 429/,
     "throttled reservations must defer as held instead of failing",
   );
-  assert.match(reserveLease.run ?? "", /\\"status\\":\\"held\\",\\"retryAt\\":\\"\$retry_at\\"/);
+  assert.match(
+    reserveLease.run ?? "",
+    /\\"status\\":\\"held\\",\\"retryAt\\":\\"\$retry_at\\",\\"retryKind\\":\\"throttle\\"/,
+  );
+  assert.match(reserveLease.run ?? "", /reservation\.retryKind === "throttle"/);
+  assert.match(reserveLease.run ?? "", /append\("retry_kind", retryKind\)/);
   assert.match(source, /Review exact item \{0\} rev \{1\} head \{2\}/);
   assert.equal(
     reserveLease.env?.EXACT_REVIEW_ITEM_KEY,
@@ -650,6 +656,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(liveItem.run ?? "", /Resolved invalid queued target branch/);
   assert.match(liveItem.run ?? "", /admission_retry=true/);
+  assert.match(liveItem.run ?? "", /echo "retry_kind=throttle"/);
   assert.match(
     liveItem.run ?? "",
     /rate limit exceeded\|secondary rate limit\|HTTP 429/,
@@ -764,6 +771,8 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     generationResult.env?.ADMISSION_RETRY,
     "${{ steps.live-item.outputs.admission_retry }}",
   );
+  assert.match(generationResult.env?.RETRY_KIND ?? "", /live-item\.outputs\.retry_kind/);
+  assert.match(generationResult.run ?? "", /ADMISSION_RETRY.*true.*-z.*RETRY_KIND/s);
   assert.match(generationResult.run ?? "", /ADMISSION_RETRY.*true[\s\S]*outcome=success/);
   assert.match(generationResult.run ?? "", /requeue_latest=true/);
   assert.equal(
@@ -806,6 +815,8 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
   assert.match(complete.env?.REQUEUE_LATEST ?? "", /exact-review-generation-result/);
   assert.match(complete.env?.RETRY_AT ?? "", /live-item\.outputs\.retry_at/);
+  assert.match(complete.env?.RETRY_KIND ?? "", /live-item\.outputs\.retry_kind/);
+  assert.match(complete.run ?? "", /retry_kind: retryKind/);
   assert.match(complete.run ?? "", /requeue_latest: true/);
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
   assert.match(deferHeldReview.run ?? "", /retry deferred/);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact reviews delayed by an active same-head review or GitHub throttling consumed normal review failure attempts. Repeated temporary deferrals could therefore park valid review work as `review_retry_exhausted` without a content or model failure.

## Why This Change Was Made

The regular-review completion contract now accepts an explicit `retry_kind` of `coordination` or `throttle`, paired with a bounded `retry_at`. Same-revision typed deferrals retain their existing attempt counters and wait until the requested deadline; newer revisions discard the stale deadline. Untyped review failures keep the existing failure-budget behavior.

The workflow propagates the typed reason only for known lease coordination and GitHub throttle paths. Publication completions and invalid type/outcome/deadline combinations are rejected. Systemic outage recovery, parked-item revival, lease expiry, and unrelated review noise remain out of scope.

## User Impact

Temporary coordination and rate-limit delays no longer consume the eight-attempt review failure budget. Actual review failures still back off, spend attempts, and park at the existing limit.

OpenClaw Bay can display the new `coordination retry` and `throttle retry` backoff reasons through its existing generic reason renderer. No Bay mutation or control surface changes are needed; Bay remains observer-only.

## Evidence

- `node --test --test-name-pattern='exact-review queue (defers coordination|defers throttle|spends|does not carry|rejects invalid retry|rejects regular-review retry)' test/dashboard-worker.test.ts` - 6/6 passed.
- `node --test test/sweep-workflow.test.ts` - 113/113 passed.
- Direct equivalents of `pnpm run check` passed with the existing linked toolchain: active-surface, dashboard queue-boundary, limits, full format check, dashboard/test lint, and all three TypeScript builds.
- GitHub CI `pnpm check`, CodeQL, workflow analysis, JavaScript/TypeScript analysis, sparse repair smoke, and Windows Codex launcher all passed on `0e3ad79a538767c92f85a4214391cff7d754f5ab`.
- Direct AWS Crabbox fresh-PR proof passed: provider `aws`, run `run_238ea8cc8d52`, lease `cbx_f52b2ff84eca`, image-backed machine `c7a.8xlarge`, exact head `0e3ad79a538767c92f85a4214391cff7d754f5ab`, artifact `.artifacts/retry-deferral-crabbox-proof.md`.
- Pre-commit structured autoreview: clean, no accepted/actionable findings.
- `git diff --check` - passed.

`pnpm run check` itself could not start locally because this shared worktree's linked `node_modules` was installed by a different pnpm state and pnpm attempted a destructive module purge. The same commands were run directly from the existing linked binaries instead.

## Real Behavior Proof

- **Claim:** completing a regular exact-review lease with a typed coordination or throttle deferral keeps `attempts` and `reviewFailureAttempts` unchanged, persists the requested deadline/backoff reason, and returns `{ ok: true, requeued: true }`; an untyped failure still increments both counters.
- **Exercised surface:** the real `ExactReviewQueue` `/complete` HTTP handler and durable queue transition, plus the event-review workflow payload builder.
- **Fixture:** claimed protocol-v2 regular-review items at the same revision, with existing nonzero counters; coordination and throttle callbacks; an untyped callback; a newer-revision callback; invalid contract and publication-item callbacks.
- **Command/environment:** a clean `--fresh-pr openclaw/clawsweeper#1028` checkout on direct AWS Crabbox, Node 24+, `corepack pnpm install --frozen-lockfile`, all three TypeScript builds, the six focused queue cases, and the complete 113-case workflow suite.
- **Observed result:** typed same-revision deferrals preserved counters and set `coordination_retry` / `throttle_retry`; the untyped failure incremented both counters; the newer revision reset counters and ignored the old deadline; invalid combinations returned HTTP 400.
- **Trace:** run portal `https://crabbox.openclaw.ai/portal/runs/run_238ea8cc8d52`; proof artifact `.artifacts/retry-deferral-crabbox-proof.md`; test names and assertions are in `test/dashboard-worker.test.ts`; workflow propagation assertions are in `test/sweep-workflow.test.ts`.
- **Limits:** no production Worker was deployed and no live GitHub throttle was induced. The isolated run exercised the actual queue handler with deterministic Durable Object storage and the shipped workflow payload contract.