### PR TITLE
fix(reconcile): stop stale search counts from failing recovery

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -215,7 +215,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_WRITE_TOKEN: ${{ steps.target-write-token.outputs.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
-          REVIEW_PLACEHOLDER_BACKLOG_ALERT: ${{ vars.REVIEW_PLACEHOLDER_BACKLOG_ALERT || '480' }}
           REVIEW_PLACEHOLDER_LOOKBACK_HOURS: ${{ vars.REVIEW_PLACEHOLDER_LOOKBACK_HOURS || '48' }}
           REVIEW_PLACEHOLDER_MAX_CHECKS: ${{ vars.REVIEW_PLACEHOLDER_MAX_CHECKS || '20' }}
           REVIEW_PLACEHOLDER_MAX_RECOVERIES: ${{ vars.REVIEW_PLACEHOLDER_MAX_RECOVERIES || '5' }}

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -326,6 +326,10 @@ and hot intake `14`. Existing repair lanes keep their
   the maximum is 720 hours.
 - `REVIEW_PLACEHOLDER_MAX_RECOVERIES` overrides the number of orphaned review
   placeholders enqueued per recovery pass; the default is 5 and the maximum is 100.
+- Placeholder recovery logs GitHub Search `matched` and derived `remaining`
+  counts for backlog telemetry. Search counts can lag comment mutations, so
+  only failed cleanup or enqueue actions for live-verified orphans make the
+  scheduled run fail.
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MS` overrides the 90,000 ms coalescing delay
   for fresh non-command exact-review events.
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS` overrides the 180,000 ms maximum

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -10,7 +10,6 @@ export const DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES = 5;
 export const DEFAULT_REVIEW_PLACEHOLDER_STUCK_HOURS = 12;
 export const REVIEW_PLACEHOLDER_STUCK_LABEL = "clawsweeper-recovery-stuck";
 export const DEFAULT_REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
-export const DEFAULT_REVIEW_PLACEHOLDER_BACKLOG_ALERT = 480;
 
 const SEARCH_PAGE_SIZE = 100;
 const SEARCH_MAX_PAGES = 2;
@@ -40,6 +39,7 @@ export type ReviewPlaceholderRecoverySummary = {
   cleaned: number;
   escalated: number;
   errors: number;
+  actionFailures: number;
   matched: number;
   remaining: number;
 };
@@ -50,14 +50,10 @@ export type ReviewPlaceholderRecoverySummary = {
 // Escalation labels are visibility, not resolution, so they never count.
 export function reviewPlaceholderRecoveryFailureReason(
   summary: ReviewPlaceholderRecoverySummary,
-  backlogAlert: number = DEFAULT_REVIEW_PLACEHOLDER_BACKLOG_ALERT,
 ): string | null {
   const resolved = summary.enqueued + summary.cleaned;
-  if (summary.orphaned > 0 && summary.errors > 0 && resolved === 0) {
+  if (summary.orphaned > 0 && summary.actionFailures > 0 && resolved === 0) {
     return "orphaned placeholders remain and every recovery action failed";
-  }
-  if (backlogAlert > 0 && summary.remaining >= backlogAlert) {
-    return `${summary.remaining} matching placeholders were left unexamined (backlog alert threshold ${backlogAlert})`;
   }
   return null;
 }
@@ -216,14 +212,25 @@ export async function runReviewPlaceholderRecovery(
   let cleaned = 0;
   let escalated = 0;
   let errors = 0;
+  let actionFailures = 0;
   let matched = 0;
 
   const summary = (): ReviewPlaceholderRecoverySummary => {
     const remaining = Math.max(0, matched - checked);
     console.log(
-      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} cleaned=${cleaned} escalated=${escalated} errors=${errors} matched=${matched} remaining=${remaining}`,
+      `review-placeholder recovery: checked=${checked} orphaned=${orphaned} enqueued=${enqueued} cleaned=${cleaned} escalated=${escalated} errors=${errors} action_failures=${actionFailures} matched=${matched} remaining=${remaining}`,
     );
-    return { checked, orphaned, enqueued, cleaned, escalated, errors, matched, remaining };
+    return {
+      checked,
+      orphaned,
+      enqueued,
+      cleaned,
+      escalated,
+      errors,
+      actionFailures,
+      matched,
+      remaining,
+    };
   };
   if (
     !token ||
@@ -465,6 +472,7 @@ export async function runReviewPlaceholderRecovery(
           }
         } catch (cleanupError) {
           errors += 1;
+          actionFailures += 1;
           console.warn(
             `#${number} closed-item placeholder cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
           );
@@ -510,6 +518,7 @@ export async function runReviewPlaceholderRecovery(
       );
     } catch (error) {
       errors += 1;
+      actionFailures += 1;
       console.warn(
         `#${candidate.number} review-placeholder recovery skipped: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -522,14 +531,7 @@ const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
   try {
     const summary = await runReviewPlaceholderRecovery();
-    const failureReason = reviewPlaceholderRecoveryFailureReason(
-      summary,
-      boundedPositiveInteger(
-        process.env.REVIEW_PLACEHOLDER_BACKLOG_ALERT,
-        DEFAULT_REVIEW_PLACEHOLDER_BACKLOG_ALERT,
-        1_000_000,
-      ),
-    );
+    const failureReason = reviewPlaceholderRecoveryFailureReason(summary);
     if (failureReason) {
       console.error(`review-placeholder recovery failed: ${failureReason}`);
       process.exitCode = 1;

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -179,6 +179,7 @@ test("review placeholder runner fails open and sends a signed exact-review decis
     cleaned: 0,
     escalated: 0,
     errors: 1,
+    actionFailures: 0,
     matched: 4,
     remaining: 1,
   });
@@ -253,6 +254,7 @@ test("review placeholder runner fills the recovery cap with the oldest orphans f
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 4,
     remaining: 2,
   });
@@ -325,6 +327,7 @@ test("review placeholder runner escalates orphans stuck well beyond the minimum 
     cleaned: 0,
     escalated: 1,
     errors: 0,
+    actionFailures: 0,
     matched: 4,
     remaining: 2,
   });
@@ -379,6 +382,7 @@ test("stuck escalation without a target write token is a visible error, not a wr
     cleaned: 0,
     escalated: 0,
     errors: 1,
+    actionFailures: 0,
     matched: 2,
     remaining: 1,
   });
@@ -452,6 +456,7 @@ test("orphaned placeholders on closed items are deleted instead of re-enqueued",
     cleaned: 1,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 1,
     remaining: 0,
   });
@@ -503,13 +508,18 @@ test("closed-item cleanup without a target write token is a visible error", asyn
     cleaned: 0,
     escalated: 0,
     errors: 1,
+    actionFailures: 1,
     matched: 1,
     remaining: 0,
   });
   assert.equal(deleteRequests, 0);
+  assert.equal(
+    reviewPlaceholderRecoveryFailureReason(summary),
+    "orphaned placeholders remain and every recovery action failed",
+  );
 });
 
-test("closed-item cleanup revalidates and skips a placeholder that became a real review", async () => {
+test("discovery errors do not fail a closed orphan that changed during revalidation", async () => {
   let deleteRequests = 0;
   const mockFetch = async (
     input: string | URL | Request,
@@ -519,7 +529,7 @@ test("closed-item cleanup revalidates and skips a placeholder that became a real
     if (url.pathname === "/search/issues") {
       const query = url.searchParams.get("q") ?? "";
       if (query.includes("is:closed")) return Response.json({ items: [{ number: 403 }] });
-      return Response.json({ items: [] });
+      return new Response("unavailable", { status: 503 });
     }
     if (url.pathname === "/repos/openclaw/openclaw/issues/403/comments") {
       return Response.json([
@@ -569,11 +579,13 @@ test("closed-item cleanup revalidates and skips a placeholder that became a real
     enqueued: 0,
     cleaned: 0,
     escalated: 0,
-    errors: 0,
+    errors: 1,
+    actionFailures: 0,
     matched: 1,
     remaining: 0,
   });
   assert.equal(deleteRequests, 0);
+  assert.equal(reviewPlaceholderRecoveryFailureReason(summary), null);
 });
 
 test("locked closed items are terminal skips, not retrying cleanup errors", async () => {
@@ -636,6 +648,7 @@ test("locked closed items are terminal skips, not retrying cleanup errors", asyn
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 1,
     remaining: 0,
   });
@@ -712,13 +725,14 @@ test("closed cleanup keeps its own check budget when open placeholders fill the 
     cleaned: 1,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 2,
     remaining: 0,
   });
   assert.deepEqual(deletedComments, ["/repos/openclaw/openclaw/issues/comments/9502"]);
 });
 
-test("recovery failure reason fires on total action failure and on an undrainable backlog", () => {
+test("recovery failure reason fires only when every live-verified action fails", () => {
   assert.equal(
     reviewPlaceholderRecoveryFailureReason({
       checked: 5,
@@ -727,6 +741,7 @@ test("recovery failure reason fires on total action failure and on an undrainabl
       cleaned: 0,
       escalated: 0,
       errors: 2,
+      actionFailures: 2,
       matched: 5,
       remaining: 0,
     }),
@@ -740,6 +755,7 @@ test("recovery failure reason fires on total action failure and on an undrainabl
       cleaned: 0,
       escalated: 0,
       errors: 1,
+      actionFailures: 1,
       matched: 5,
       remaining: 0,
     }),
@@ -753,6 +769,7 @@ test("recovery failure reason fires on total action failure and on an undrainabl
       cleaned: 0,
       escalated: 0,
       errors: 1,
+      actionFailures: 0,
       matched: 5,
       remaining: 0,
     }),
@@ -766,28 +783,24 @@ test("recovery failure reason fires on total action failure and on an undrainabl
       cleaned: 0,
       escalated: 1,
       errors: 2,
+      actionFailures: 0,
       matched: 5,
       remaining: 0,
     }),
-    "orphaned placeholders remain and every recovery action failed",
+    null,
   );
-  const backlogged = {
-    checked: 40,
-    orphaned: 1,
-    enqueued: 1,
-    cleaned: 0,
-    escalated: 0,
-    errors: 0,
-    matched: 1_240,
-    remaining: 1_200,
-  };
   assert.equal(
-    reviewPlaceholderRecoveryFailureReason(backlogged),
-    "1200 matching placeholders were left unexamined (backlog alert threshold 480)",
-  );
-  assert.equal(reviewPlaceholderRecoveryFailureReason(backlogged, 1_201), null);
-  assert.equal(
-    reviewPlaceholderRecoveryFailureReason({ ...backlogged, matched: 60, remaining: 20 }),
+    reviewPlaceholderRecoveryFailureReason({
+      checked: 40,
+      orphaned: 1,
+      enqueued: 1,
+      cleaned: 0,
+      escalated: 0,
+      errors: 0,
+      actionFailures: 0,
+      matched: 1_240,
+      remaining: 1_200,
+    }),
     null,
   );
 });
@@ -866,6 +879,7 @@ test("discovery ranks the whole search page before it applies the check budget",
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 4,
     remaining: 2,
   });
@@ -934,13 +948,14 @@ test("an edited durable verdict no longer masks the marker-tagged placeholder", 
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 1,
     remaining: 0,
   });
   assert.deepEqual(enqueuedNumbers, [611]);
 });
 
-test("a backlog the sweep cannot examine is reported and fails the run", async (t) => {
+test("a large search count remains telemetry and does not fail the run", async (t) => {
   const logged: string[] = [];
   t.mock.method(console, "log", (...parts: unknown[]) => {
     logged.push(parts.join(" "));
@@ -995,6 +1010,7 @@ test("a backlog the sweep cannot examine is reported and fails the run", async (
     cleaned: 0,
     escalated: 0,
     errors: 0,
+    actionFailures: 0,
     matched: 900,
     remaining: 899,
   });
@@ -1002,10 +1018,7 @@ test("a backlog the sweep cannot examine is reported and fails the run", async (
     logged.some((line) => line.includes("matched=900 remaining=899")),
     "summary line reports the discovery backlog",
   );
-  assert.equal(
-    reviewPlaceholderRecoveryFailureReason(summary),
-    "899 matching placeholders were left unexamined (backlog alert threshold 480)",
-  );
+  assert.equal(reviewPlaceholderRecoveryFailureReason(summary), null);
 });
 
 test("placeholder refreshed recently by an active recovery is not orphaned", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1560,6 +1560,7 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
     sweepJob,
     /REVIEW_PLACEHOLDER_MAX_CHECKS: \$\{\{ vars\.REVIEW_PLACEHOLDER_MAX_CHECKS \|\| '20' \}\}/,
   );
+  assert.doesNotMatch(sweepJob, /REVIEW_PLACEHOLDER_BACKLOG_ALERT/);
   assert.match(
     sweepJob,
     /REVIEW_PLACEHOLDER_MAX_RECOVERIES: \$\{\{ vars\.REVIEW_PLACEHOLDER_MAX_RECOVERIES \|\| '5' \}\}/,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the scheduled exact-review reconciler could report failure after successfully recovering every live placeholder it examined because GitHub Search still reported stale matches for comments that had already been edited or deleted.

## Why This Change Was Made

GitHub Search `total_count` is eventually consistent and is not an authoritative count of live orphaned placeholders. The reconciler now retains `matched` and derived `remaining` as telemetry, while failure policy is owned by the live-verified recovery actions: a run fails only when orphaned placeholders were found, every attempted cleanup or enqueue action failed, and nothing was resolved.

The canonical owner is `src/review-placeholder-recovery.ts`; the scheduled workflow only supplies its live credentials and limits. This removes the stale `REVIEW_PLACEHOLDER_BACKLOG_ALERT` path, its default constant, and the threshold-based failure branch.

## User Impact

Operators no longer get false-red reconciliation runs from stale GitHub Search indexing. Real cleanup and enqueue failures still fail closed and remain visible.

OpenClaw Bay is not affected. This does not change its observer-only status contract or any dashboard schema; `action_failures` is reconciler log telemetry used to distinguish live action failures from discovery errors.

## Evidence

- Focused unit and workflow contract tests passed on commit `1ad563e676a533d1b4f2828f318efa90be5d7a36`.
- Independent committed-branch review found no actionable issues.
- Branch workflow proof: https://github.com/openclaw/clawsweeper/actions/runs/30962799590
- Live summary: `checked=120 orphaned=28 enqueued=5 cleaned=8 escalated=11 errors=0 action_failures=0 matched=933 remaining=813`.
- The workflow completed successfully despite the stale derived `remaining=813`, while retaining both Search telemetry fields.
- ClawSweeper finding disposition: removed the release-owned `CHANGELOG.md` edit. The release context remains in this PR body.

Production LOC:

- Runtime TypeScript: `+18/-16` (net `+2`) to record the authoritative action-failure fact at the recovery owner.
- Workflow: `+0/-1`, removing the obsolete backlog threshold input.
- Tests: `+40/-26` across focused recovery and workflow-contract coverage.
- Documentation: `+4/-0`.

Sibling coverage includes closed-item cleanup, enqueue failure, discovery-only error, locked-item skip, large stale Search counts, and scheduled workflow configuration.

## Real Behavior Proof

- **Claim:** stale GitHub Search totals remain visible but cannot fail a reconciliation run when live-verified recovery actions succeed.
- **Exercised surface:** `workflow_dispatch` of `.github/workflows/exact-review-reconcile.yml` on the pushed branch head.
- **Scenario:** the live sweep observed 933 Search matches and derived 813 remaining matches while processing current open and closed placeholder candidates.
- **Command/environment:** GitHub Actions workflow dispatch on `openclaw/clawsweeper`, branch `fix/placeholder-search-signal`, exact head `1ad563e676a533d1b4f2828f318efa90be5d7a36`.
- **Observable result:** the sweep enqueued 5, cleaned 8, reported `action_failures=0`, retained `matched=933 remaining=813`, and completed green.
- **Artifact:** https://github.com/openclaw/clawsweeper/actions/runs/30962799590
- **Limits:** this proves the scheduled workflow and live GitHub/queue integration for successful recovery. Focused tests cover the fail-closed path where every live-verified action fails.

## Punchcard

Session alias: `amber-orchard-valley-s4`.

Punchcard compliance finding: commit and PR attestation each returned `INVALID_INPUT` because the parent org-wide session is registered against a different repository. The required `Punchcard-Session` trailer is present; no receipt was issued.
