### PR TITLE
fix: simplify review proof, recovery, and GitHub throttling

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -46,7 +46,7 @@ jobs:
       EXACT_REVIEW_BATCH_MANIFEST: .artifacts/exact-review-batch/manifest.json
       # Scan the full queue window so owner filtering can still fill the 32-item lease cap.
       EXACT_REVIEW_BATCH_MAX_ITEMS: "50"
-      EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY: "4"
+      EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY: "1"
       CLAWSWEEPER_APP_CLIENT_ID: Iv23liOECG0slfuhz093
       CLAWSWEEPER_APP_PRIVATE_KEY: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
     steps:

--- a/prompts/review-commit.md
+++ b/prompts/review-commit.md
@@ -10,7 +10,10 @@ copies when applying repository policy. Treat `AGENTS.md` as optional
 repository-authored review policy and review guidance for that target, not only
 as setup instructions. Apply concrete target-specific instructions or guidance
 when they do not conflict with this prompt or higher-priority system/developer
-instructions. If `AGENTS.md` is absent, unrelated, or lower-confidence than the
+instructions. For a reviewed diff, read every applicable ancestor `AGENTS.md`
+for each changed path. Nested instructions apply only within their own subtree;
+do not import policy from sibling or consumer directories.
+If `AGENTS.md` is absent, unrelated, or lower-confidence than the
 repository's observed behavior, continue with ClawSweeper's existing repository
 profiles and owner/default fallback behavior. The checkout is current target `main`, not the commit snapshot. Review the commit SHA and base range provided in the prompt
 with commands such as `git show <sha>` and `git diff <base>..<sha>`, then read

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -19,7 +19,10 @@ copies when applying repository policy. Treat `AGENTS.md` as optional
 repository-authored review policy and review guidance for that target, not only
 as setup instructions. Apply concrete target-specific instructions or guidance
 when they do not conflict with this prompt or higher-priority system/developer
-instructions. If `AGENTS.md` is absent, unrelated, or lower-confidence than the
+instructions. For a reviewed diff, read every applicable ancestor `AGENTS.md`
+for each changed path. Nested instructions apply only within their own subtree;
+do not import policy from sibling or consumer directories.
+If `AGENTS.md` is absent, unrelated, or lower-confidence than the
 repository's observed behavior, continue with ClawSweeper's existing repository
 profiles and owner/default fallback behavior. Inspect the current `main` code, docs, tests,
 and history as needed. The provided GitHub context includes compact related
@@ -372,7 +375,19 @@ For PRs, include a dedicated security review pass in addition to the functional 
 
 For PRs, include a dedicated `realBehaviorProof` assessment before any pass, automerge, or repair verdict. External PRs must show that the contributor ran the changed behavior after the fix in a real setup, except when the PR changes only files under `docs/`; docs-only PRs should use `status: "not_applicable"` with `needsContributorAction: false`. Unit tests, mocks, snapshots, lint, typechecks, and CI are supplemental only; they are not real behavior proof by themselves. Treat screenshots, recordings, terminal screenshots, console output, copied live output, linked artifacts, and redacted runtime logs as valid proof, including for non-visual CLI, console, text, or error-message changes. Prefer asking for screenshots or videos when they can show the behavior, including terminal screenshots for text or console changes, while keeping logs and live output acceptable. Remind contributors to redact private information like IP addresses, API keys, phone numbers, non-public endpoints, and other private details before posting evidence. A plain app screenshot is sufficient only for behavior it directly shows. Do not mark screenshot-only proof sufficient for browser runtime, CSP, CORS, `connect-src`, auth callback, network, or security changes when the proof only says no console error, warning, or violation is visible; require console output, a network trace, terminal/live output, logs, a recording with diagnostics, or a linked artifact that actually shows the runtime path. Use your tools and best judgement: inspect the PR body, comments, links, screenshots, videos, logs, terminal output, and changed behavior context; you may download/open GitHub attachment links, generate stills or contact sheets from videos, inspect terminal screenshots and logs, and compare the proof against the PR diff. Use the provided scratch directory for downloaded artifacts and keep the target checkout read-only. Use `status: "sufficient"` only when the evidence convincingly shows after-fix real behavior and an observed improved result. Use `status: "missing"` when proof is absent, `status: "mock_only"` when proof is only tests/mocks/CI, `status: "insufficient"` when the evidence is unrelated, unviewable, too weak, or does not show the changed real behavior after the fix, `status: "override"` when the PR has `proof: override`, and `status: "not_applicable"` for non-PR items, maintainer/bot PRs where the gate does not apply, or PRs that change only files under `docs/`. When proof is missing, mock-only, or insufficient, set `needsContributorAction: true`, make the PR a human-only merge blocker, and do not request ClawSweeper repair markers because automation cannot prove the contributor's setup for them.
 
-For PRs, always fill `telegramVisibleProof`. Use `status: "needed"` only when the PR touches Telegram behavior and the user-visible change can be easily demonstrated by the `telegram-crabbox-e2e-proof` skill, such as message formatting, slash-command output, reply text, attachments, reactions, threading, mentions, or other visible Telegram chat behavior. Use `status: "not_needed"` for non-Telegram PRs and for Telegram changes that are internal-only, test-only, docs-only, logging-only, retry/network reliability only, auth/secret plumbing only, or otherwise not meaningfully visible in a short Telegram Desktop recording.
+For internal retry, ordering, delivery, or network-reliability changes, the
+actual production owner and real transport client exercising an injected fault
+through the production boundary, with a recorded request/response trace showing
+observed after-fix recovery, is real behavior proof. Use `status: "sufficient"`
+and `needsContributorAction: false`; do not require unrelated live-channel
+access or a full application. Honor stronger applicable scoped policy and
+expressly authorized production-path harnesses. Mocked transport clients and
+isolated unit tests remain `mock_only`; preserve existing browser-runtime, CSP,
+auth, and security safeguards.
+
+For PRs, always fill `telegramVisibleProof`. Use `status: "needed"` only when the PR touches Telegram behavior and the user-visible change can be easily demonstrated by the `telegram-crabbox-e2e-proof` skill, such as message formatting, slash-command output, reply text, attachments, reactions, threading, mentions, or other visible Telegram chat behavior. Use `status: "not_needed"` for non-Telegram PRs and for Telegram changes that are internal-only, test-only, docs-only, logging-only, retry/network reliability only, auth/secret plumbing only, or otherwise not meaningfully visible in a short Telegram Desktop recording. A label, title, consumer, or example does not make internal shared retry/ordering work visible. For that work, set
+`telegramVisibleProof.status: "not_needed"` and
+`mantisRecommendation.status: "not_recommended"`.
 
 For PRs, also emit Codex `/review`-style findings in `reviewFindings`.
 Review the diff as another engineer's proposed patch and list every discrete,
@@ -875,11 +890,8 @@ confidence. Use an empty array for `S`, `A`, and `NA`, and usually for `B`
 unless one specific action materially reduces risk. Do not invent optional
 polish work or create churn for already-good PRs.
 
-Always fill `telegramVisibleProof`. This only controls the
-`mantis: telegram-visible-proof` label. Mark it `needed` when a Telegram PR has
-visible chat behavior the `telegram-crabbox-e2e-proof` skill can show in a
-short recording. Mark it `not_needed` for non-Telegram PRs or Telegram work
-that is not usefully visible in that recording.
+Always fill `telegramVisibleProof` using the changed-behavior classification
+above. It only controls the `mantis: telegram-visible-proof` label.
 
 Always fill `mantisRecommendation`. This is maintainer guidance only: it must
 never trigger OpenClaw Mantis, claim Mantis has run, ask ClawSweeper to dispatch

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -557,7 +557,7 @@
     "agentsPolicyStatus": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Structured status for the target repository AGENTS.md review policy check. Report whether AGENTS.md was found, read fully, and applied to this review without duplicating policy text.",
+      "description": "Structured status for the target repository root and applicable ancestor-scoped AGENTS.md review policy. Nested instructions apply only within their own subtree, never to sibling or consumer directories. Report whether applicable policy was found, read fully, and applied without duplicating policy text.",
       "required": ["found", "readFully", "applied", "status", "summary"],
       "properties": {
         "found": {
@@ -698,7 +698,7 @@
     "realBehaviorProof": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Dedicated PR proof assessment. For external PRs, after-fix evidence from a real setup is required unless the PR only changes files under docs/; tests, mocks, snapshots, lint, typechecks, and CI are supplemental only.",
+      "description": "Dedicated PR proof assessment. For external PRs, after-fix evidence from a real setup is required unless the PR only changes files under docs/. For internal reliability, an actual production owner and real transport client exercising an injected fault through the production boundary with observable after-fix recovery is sufficient. Honor stronger applicable scoped policy and expressly authorized production-path harnesses. Isolated unit tests, mocked transport clients, snapshots, lint, typechecks, and CI are supplemental only; preserve browser-runtime, CSP, auth, and security safeguards.",
       "required": ["status", "summary", "evidenceKind", "needsContributorAction"],
       "properties": {
         "status": {
@@ -774,7 +774,7 @@
     "telegramVisibleProof": {
       "type": "object",
       "additionalProperties": false,
-      "description": "For Telegram PRs, classify whether the change is user-visible and easy to demonstrate with the telegram-crabbox-e2e-proof skill.",
+      "description": "For Telegram PRs, classify whether the change is user-visible and easy to demonstrate with the telegram-crabbox-e2e-proof skill. Internal retry, ordering, or transport reliability without changed visible chat behavior is not_needed.",
       "required": ["status", "summary"],
       "properties": {
         "status": {
@@ -790,7 +790,7 @@
     "mantisRecommendation": {
       "type": "object",
       "additionalProperties": false,
-      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when Telegram, Discord, or web UI chat proof would materially help review. Mantis is proof-only: it may reproduce or inspect those surfaces and return redacted screenshots, transcripts, logs, or interaction results. Do not ask Mantis to edit code, fix CI, update branches, push commits, repair PRs, change labels or comments, close items, or perform other GitHub mutations; those belong to ClawSweeper's deterministic repair, apply, and automerge lanes. Do not claim Mantis has run and do not dispatch any workflow.",
+      "description": "For PRs, recommend a copy-paste maintainer comment for OpenClaw Mantis only when Telegram, Discord, or web UI chat proof would materially help review. Do not recommend it for internal reliability without changed visible chat behavior. Mantis is proof-only: it may reproduce or inspect those surfaces and return redacted screenshots, transcripts, logs, or interaction results. Do not ask Mantis to edit code, fix CI, update branches, push commits, repair PRs, change labels or comments, close items, or perform other GitHub mutations; those belong to ClawSweeper's deterministic repair, apply, and automerge lanes. Do not claim Mantis has run and do not dispatch any workflow.",
       "required": ["status", "scenario", "reason", "maintainerComment"],
       "properties": {
         "status": {

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -242,6 +242,7 @@ async function worker(itemPath, root, workspace) {
     cwd: root,
     env: {
       ...process.env,
+      CLAWSWEEPER_GH_RETRY_ATTEMPTS: "2",
       CLAWSWEEPER_CODE_ROOT: workspace,
       EXACT_REVIEW_WORK_ROOT: root,
       TARGET_REPO: targetRepo,

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -68,6 +68,10 @@ import {
 } from "./github-retry.js";
 import { type PrCloseCoverageProofRuntime } from "./pr-close-coverage-proof.js";
 import { isReviewedPrActivityCursor } from "./review-activity-cursor.js";
+import {
+  clearResolvedReviewRecoveryLabel,
+  REVIEW_RECOVERY_STUCK_LABEL,
+} from "./review-recovery-label-backfill.js";
 import { isAutoCloseAllowed, repositoryProfileFor } from "./repository-profiles.js";
 import { stableJson } from "./stable-json.js";
 
@@ -106,6 +110,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     frontMatterStringArray,
     frontMatterValue,
     ghJson,
+    GitHubRuntimeBudgetError,
     guardedOpenApplyProofFields,
     hasVerifiedLocalCheckoutAccess,
     isApplyCloseCandidateReport,
@@ -134,6 +139,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     recordApplyActionLedgerItemResults,
     recordApplyMutationBoundary,
     removeCurrentCursorTraceItem,
+    removeIssueLabel,
     renderReviewCommentFromReport,
     replaceFrontMatterValue,
     repoFromArgs,
@@ -1899,6 +1905,42 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
                 comments: latestLeaseState.comments,
                 keepCommentIds: placeholderKeepCommentIds,
               });
+              if (complete && item.labels.includes(REVIEW_RECOVERY_STUCK_LABEL)) {
+                try {
+                  if (
+                    clearResolvedReviewRecoveryLabel({
+                      number,
+                      labels: item.labels,
+                      complete,
+                      removeLabel: removeIssueLabel,
+                      onMutation: recordMutation,
+                    })
+                  ) {
+                    markdown = replaceFrontMatterValue(
+                      markdown,
+                      "labels",
+                      JSON.stringify(item.labels),
+                    );
+                    markdown = replaceFrontMatterValue(
+                      markdown,
+                      "labels_synced_at",
+                      new Date().toISOString(),
+                    );
+                    rememberSelfMutationUpdatedAt();
+                    syncReasons.push("cleared resolved review recovery label");
+                    console.error(
+                      `[apply] cleared resolved review recovery label for #${number}`,
+                    );
+                  }
+                } catch (error) {
+                  if (error instanceof GitHubRuntimeBudgetError) throw error;
+                  console.error(
+                    `[apply] could not clear resolved review recovery label for #${number}: ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  );
+                }
+              }
             } catch (error) {
               const commentAuthError = isGitHubRequiresAuthenticationError(error);
               if (!commentAuthError && !isLockedConversationCommentError(error)) throw error;

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -1907,31 +1907,21 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
               });
               if (complete && item.labels.includes(REVIEW_RECOVERY_STUCK_LABEL)) {
                 try {
-                  if (
-                    clearResolvedReviewRecoveryLabel({
-                      number,
-                      labels: item.labels,
-                      complete,
-                      removeLabel: removeIssueLabel,
-                      onMutation: recordMutation,
-                    })
-                  ) {
-                    markdown = replaceFrontMatterValue(
-                      markdown,
-                      "labels",
-                      JSON.stringify(item.labels),
-                    );
-                    markdown = replaceFrontMatterValue(
-                      markdown,
-                      "labels_synced_at",
-                      new Date().toISOString(),
-                    );
-                    rememberSelfMutationUpdatedAt();
-                    syncReasons.push("cleared resolved review recovery label");
-                    console.error(
-                      `[apply] cleared resolved review recovery label for #${number}`,
-                    );
-                  }
+                  clearResolvedReviewRecoveryLabel({
+                    number,
+                    labels: item.labels,
+                    complete,
+                    removeLabel: removeIssueLabel,
+                    onMutation: recordMutation,
+                  });
+                  markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+                  markdown = replaceFrontMatterValue(
+                    markdown,
+                    "labels_synced_at",
+                    new Date().toISOString(),
+                  );
+                  rememberSelfMutationUpdatedAt();
+                  syncReasons.push("cleared resolved review recovery label");
                 } catch (error) {
                   if (error instanceof GitHubRuntimeBudgetError) throw error;
                   console.error(

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -341,6 +341,7 @@ export interface CreateApplyDecisionWorkflowDependencies {
     hasNonAutomationActivity: boolean;
   }) => boolean;
   removeCurrentCursorTraceItem: (examinedItemNumbers: number[], currentNumber: number) => void;
+  removeIssueLabel: (number: number, label: string, onMutation?: () => void) => void;
   renderReviewCommentFromReport: (
     markdown: string,
     reason: CloseReason,

--- a/src/clawsweeper-github-execution.ts
+++ b/src/clawsweeper-github-execution.ts
@@ -101,7 +101,11 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
     }
   }
 
-  function ghWithRetry(args: string[], attempts = 12, options: GitHubRetryOptions = {}): string {
+  function ghWithRetry(
+    args: string[],
+    attempts = configuredGitHubRetryAttempts(),
+    options: GitHubRetryOptions = {},
+  ): string {
     let lastError: unknown;
     for (let attempt = 0; attempt < attempts; attempt += 1) {
       try {
@@ -178,7 +182,7 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
     prepareRequest?: ((args: string[], attempt: number) => () => string) | undefined;
     sleepBeforeRetry?: ((waitMs: number) => void) | undefined;
   }): string {
-    return ghWithRetry(options.args, options.attempts ?? 12, {
+    return ghWithRetry(options.args, options.attempts ?? configuredGitHubRetryAttempts(), {
       request: (args, attempt) => {
         let operation: () => string;
         if (options.prepareRequest) {
@@ -419,4 +423,11 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
       throttleHeartbeatContext = value;
     },
   };
+}
+
+function configuredGitHubRetryAttempts(): number {
+  const configured = process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
+  if (configured === undefined || configured.trim() === "") return 12;
+  const attempts = Number(configured);
+  return Number.isFinite(attempts) ? Math.max(1, Math.floor(attempts)) : 12;
 }

--- a/src/clawsweeper-report-parser.ts
+++ b/src/clawsweeper-report-parser.ts
@@ -437,12 +437,31 @@ export function createReportParser({
       ? (evidenceKindValue as RealBehaviorProofEvidenceKind)
       : undefined;
     if (!status || !evidenceKind || !summary) return defaultRealBehaviorProof(markdown);
-    return normalizeRealBehaviorProof({
+    const proof = normalizeRealBehaviorProof({
       status,
       summary,
       evidenceKind,
       needsContributorAction: /^true$/i.test(needsContributorActionValue ?? ""),
     });
+    if (
+      frontMatterValue(markdown, "type") !== "pull_request" ||
+      isExternalPullRequestReport(markdown) ||
+      (!proof.needsContributorAction &&
+        proof.status !== "missing" &&
+        proof.status !== "mock_only" &&
+        proof.status !== "insufficient")
+    ) {
+      return proof;
+    }
+    if (proof.status === "sufficient") {
+      return { ...proof, needsContributorAction: false };
+    }
+    return {
+      status: "not_applicable",
+      summary: "Real behavior proof is not required for maintainer- or bot-authored pull requests.",
+      evidenceKind: "not_applicable",
+      needsContributorAction: false,
+    };
   }
 
   function reportTelegramVisibleProof(markdown: string): TelegramVisibleProof {
@@ -461,6 +480,7 @@ export function createReportParser({
 
   function reportPrRating(markdown: string): PrRating {
     const section = reviewSectionValue(markdown, "prRating");
+    const proof = reportRealBehaviorProof(markdown);
     const proofTierValue =
       sectionLineValue(section, "Proof tier") ?? frontMatterValue(markdown, "pr_rating_proof");
     const patchTierValue =
@@ -473,7 +493,13 @@ export function createReportParser({
       PR_RATING_TIERS.has(proofTierValue as PrRatingTier) &&
       PR_RATING_TIERS.has(patchTierValue as PrRatingTier) &&
       PR_RATING_TIERS.has(overallTierValue as PrRatingTier) &&
-      summary
+      summary &&
+      !(
+        frontMatterValue(markdown, "type") === "pull_request" &&
+        !isExternalPullRequestReport(markdown) &&
+        proof.status === "not_applicable" &&
+        (proofTierValue === "D" || proofTierValue === "F")
+      )
     ) {
       return normalizePrRating({
         proofTier: proofTierValue as PrRatingTier,
@@ -483,7 +509,6 @@ export function createReportParser({
         nextSteps,
       });
     }
-    const proof = reportRealBehaviorProof(markdown);
     return derivedPrRating({
       isPullRequest: frontMatterValue(markdown, "type") === "pull_request",
       proof,

--- a/src/repair/comment-router-utils.ts
+++ b/src/repair/comment-router-utils.ts
@@ -13,7 +13,7 @@ const DEFAULT_IGNORED_CHECKS = [
   "notify",
   "Stale",
 ];
-const TRANSIENT_CANCELLED_CHECKS = new Set(["real behavior proof"]);
+const TRANSIENT_CANCELLED_CHECKS = new Set(["real behavior proof", "pr context and evidence"]);
 const LEDGER_COMMAND_STATUSES = new Set(["claimed", "executed", "skipped", "waiting"]);
 const LEDGER_COMMAND_STRING_FIELDS = [
   "idempotency_key",

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -66,6 +66,7 @@ type ReviewPlaceholderRecoveryRunOptions = {
   env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
   now?: Date;
+  reconcileRecoveryLabels?: boolean;
 };
 
 function boundedPositiveInteger(
@@ -298,23 +299,30 @@ export async function runReviewPlaceholderRecovery(
       throw new Error("POST /internal/exact-review/enqueue was not admitted");
     }
   };
-  const addLabel = async (number: number, label: string): Promise<void> => {
+  const mutateRecoveryLabel = async (
+    number: number,
+    label: string,
+    method: "POST" | "DELETE",
+  ): Promise<"removed" | "missing"> => {
     if (!targetWriteToken) {
       throw new Error("TARGET_WRITE_TOKEN is missing; cannot write labels on the target repo");
     }
-    const response = await fetchImpl(`${apiUrl}/repos/${repo}/issues/${number}/labels`, {
-      method: "POST",
+    const path = `/repos/${repo}/issues/${number}/labels${
+      method === "DELETE" ? `/${encodeURIComponent(label)}` : ""
+    }`;
+    const response = await fetchImpl(`${apiUrl}${path}`, {
+      method,
       headers: {
         accept: "application/vnd.github+json",
         authorization: `Bearer ${targetWriteToken}`,
-        "content-type": "application/json",
+        ...(method === "POST" ? { "content-type": "application/json" } : {}),
         "x-github-api-version": "2022-11-28",
       },
-      body: JSON.stringify({ labels: [label] }),
+      ...(method === "POST" ? { body: JSON.stringify({ labels: [label] }) } : {}),
     });
-    if (!response.ok) {
-      throw new Error(`POST /repos/${repo}/issues/${number}/labels returned ${response.status}`);
-    }
+    if (method === "DELETE" && response.status === 404) return "missing";
+    if (!response.ok) throw new Error(`${method} ${path} returned ${response.status}`);
+    return "removed";
   };
   const deletePlaceholderComment = async (
     number: number,
@@ -369,9 +377,10 @@ export async function runReviewPlaceholderRecovery(
     }
     return "deleted";
   };
-  const fetchPlaceholderComment = async (
+  const fetchReviewComments = async (
     number: number,
-  ): Promise<ReviewPlaceholderComment | null> => {
+    stopAtPlaceholder = false,
+  ): Promise<{ comments: ReviewPlaceholderComment[]; complete: boolean }> => {
     const marker = reviewStartStatusMarker(number);
     const comments: ReviewPlaceholderComment[] = [];
     for (let page = 1; page <= COMMENT_MAX_PAGES; page += 1) {
@@ -379,17 +388,22 @@ export async function runReviewPlaceholderRecovery(
         `/repos/${repo}/issues/${number}/comments?sort=created&direction=desc&per_page=${COMMENT_PAGE_SIZE}&page=${page}`,
       );
       comments.push(...pageComments);
-      if (pageComments.length < COMMENT_PAGE_SIZE) break;
+      if (pageComments.length < COMMENT_PAGE_SIZE) return { comments, complete: true };
       if (
+        stopAtPlaceholder &&
         pageComments.some(
           (comment) => typeof comment.body === "string" && comment.body.includes(marker),
         )
       ) {
-        break;
+        return { comments, complete: false };
       }
     }
-    return selectReviewPlaceholderComment(number, comments);
+    return { comments, complete: false };
   };
+  const fetchPlaceholderComment = async (
+    number: number,
+  ): Promise<ReviewPlaceholderComment | null> =>
+    selectReviewPlaceholderComment(number, (await fetchReviewComments(number, true)).comments);
 
   const candidates = new Map<number, { candidate: ReviewPlaceholderCandidate; closed: boolean }>();
   const updatedSince = new Date(now.getTime() - lookbackHours * 60 * 60 * 1_000).toISOString();
@@ -491,7 +505,7 @@ export async function runReviewPlaceholderRecovery(
         !candidateLabelNames(candidate).includes(REVIEW_PLACEHOLDER_STUCK_LABEL)
       ) {
         try {
-          await addLabel(number, REVIEW_PLACEHOLDER_STUCK_LABEL);
+          await mutateRecoveryLabel(number, REVIEW_PLACEHOLDER_STUCK_LABEL, "POST");
           escalated += 1;
           console.error(
             `review-placeholder recovery: escalated #${number} as stuck after repeated orphan cycles`,
@@ -528,27 +542,37 @@ export async function runReviewPlaceholderRecovery(
       );
     }
   }
+  if (options.reconcileRecoveryLabels && targetWriteToken) {
+    try {
+      const backfill = await runReviewRecoveryLabelBackfill({
+        repository: repo,
+        now,
+        maximumChecks: Math.min(maximumChecks, 100),
+        maximumRecoveries: Math.min(maximumRecoveries, 20),
+        github,
+        fetchComments: fetchReviewComments,
+        removeLabel: (number) =>
+          mutateRecoveryLabel(number, REVIEW_PLACEHOLDER_STUCK_LABEL, "DELETE"),
+        isBotComment: isClawSweeperBotComment,
+      });
+      console.log(
+        `review-recovery label reconciliation: checked=${backfill.checked} cleared=${backfill.cleared} retained=${backfill.retained} errors=${backfill.errors} matched=${backfill.matched} remaining=${backfill.remaining}`,
+      );
+    } catch (error) {
+      console.warn(
+        `review-recovery label reconciliation skipped: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
   return summary();
 }
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
   try {
-    const summary = await runReviewPlaceholderRecovery();
-    if (process.env.TARGET_WRITE_TOKEN) {
-      try {
-        const backfill = await runReviewRecoveryLabelBackfill();
-        console.log(
-          `review-recovery label reconciliation: checked=${backfill.checked} cleared=${backfill.cleared} already_cleared=${backfill.alreadyCleared} retained=${backfill.retained} errors=${backfill.errors} matched=${backfill.matched} remaining=${backfill.remaining}`,
-        );
-      } catch (error) {
-        console.warn(
-          `review-recovery label reconciliation skipped: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    }
+    const summary = await runReviewPlaceholderRecovery({ reconcileRecoveryLabels: true });
     const failureReason = reviewPlaceholderRecoveryFailureReason(summary);
     if (failureReason) {
       console.error(`review-placeholder recovery failed: ${failureReason}`);

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -2,13 +2,17 @@
 import { createHmac } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  REVIEW_RECOVERY_STUCK_LABEL,
+  runReviewRecoveryLabelBackfill,
+} from "./review-recovery-label-backfill.js";
 
 export const REVIEW_PLACEHOLDER_MARKER = "ClawSweeper status: review started.";
 export const DEFAULT_REVIEW_PLACEHOLDER_MAX_CHECKS = 20;
 export const DEFAULT_REVIEW_PLACEHOLDER_MIN_AGE_HOURS = 2;
 export const DEFAULT_REVIEW_PLACEHOLDER_MAX_RECOVERIES = 5;
 export const DEFAULT_REVIEW_PLACEHOLDER_STUCK_HOURS = 12;
-export const REVIEW_PLACEHOLDER_STUCK_LABEL = "clawsweeper-recovery-stuck";
+export const REVIEW_PLACEHOLDER_STUCK_LABEL = REVIEW_RECOVERY_STUCK_LABEL;
 export const DEFAULT_REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
 
 const SEARCH_PAGE_SIZE = 100;
@@ -531,6 +535,20 @@ const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 if (invokedPath && invokedPath === fileURLToPath(import.meta.url)) {
   try {
     const summary = await runReviewPlaceholderRecovery();
+    if (process.env.TARGET_WRITE_TOKEN) {
+      try {
+        const backfill = await runReviewRecoveryLabelBackfill();
+        console.log(
+          `review-recovery label reconciliation: checked=${backfill.checked} cleared=${backfill.cleared} already_cleared=${backfill.alreadyCleared} retained=${backfill.retained} errors=${backfill.errors} matched=${backfill.matched} remaining=${backfill.remaining}`,
+        );
+      } catch (error) {
+        console.warn(
+          `review-recovery label reconciliation skipped: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
     const failureReason = reviewPlaceholderRecoveryFailureReason(summary);
     if (failureReason) {
       console.error(`review-placeholder recovery failed: ${failureReason}`);

--- a/src/review-recovery-label-backfill.ts
+++ b/src/review-recovery-label-backfill.ts
@@ -1,0 +1,306 @@
+import { trailingHtmlComments } from "./review-comment-markers.js";
+
+export const REVIEW_RECOVERY_STUCK_LABEL = "clawsweeper-recovery-stuck";
+export const DEFAULT_REVIEW_RECOVERY_LABEL_MAX_CHECKS = 20;
+export const DEFAULT_REVIEW_RECOVERY_LABEL_MAX_REMOVALS = 5;
+
+const MAXIMUM_REVIEW_RECOVERY_LABEL_CHECKS = 100;
+const MAXIMUM_REVIEW_RECOVERY_LABEL_REMOVALS = 20;
+const MAXIMUM_SEARCH_RESULTS = 1_000;
+const BACKFILL_PAGE_ROTATION_MS = 15 * 60 * 1_000;
+const COMMENT_PAGE_SIZE = 100;
+const MAXIMUM_COMMENT_PAGES = 3;
+const TRUSTED_CLAWSWEEPER_BOT_LOGINS = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
+
+type ReviewComment = {
+  body?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+  user?: { login?: unknown; type?: unknown } | null;
+};
+
+type ReviewRecoveryLabelBackfillOptions = {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: Date;
+};
+
+export type ReviewRecoveryLabelBackfillSummary = {
+  checked: number;
+  cleared: number;
+  alreadyCleared: number;
+  retained: number;
+  errors: number;
+  matched: number;
+  remaining: number;
+};
+
+export function clearResolvedReviewRecoveryLabel(options: {
+  number: number;
+  labels: string[];
+  complete: boolean;
+  removeLabel: (number: number, label: string, onMutation?: () => void) => void;
+  onMutation?: () => void;
+}): boolean {
+  if (!options.complete) return false;
+  const index = options.labels.indexOf(REVIEW_RECOVERY_STUCK_LABEL);
+  if (index < 0) return false;
+
+  options.removeLabel(options.number, REVIEW_RECOVERY_STUCK_LABEL, options.onMutation);
+  options.labels.splice(index, 1);
+  return true;
+}
+
+function boundedPositiveInteger(value: string | undefined, fallback: number, maximum: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+}
+
+function isTrustedClawSweeperComment(comment: ReviewComment): boolean {
+  const login = typeof comment.user?.login === "string" ? comment.user.login.toLowerCase() : "";
+  const type = typeof comment.user?.type === "string" ? comment.user.type.toLowerCase() : "";
+  return type === "bot" && TRUSTED_CLAWSWEEPER_BOT_LOGINS.has(login);
+}
+
+function commentActivityMs(comment: ReviewComment): number | null {
+  const createdAt =
+    typeof comment.created_at === "string" ? Date.parse(comment.created_at) : Number.NaN;
+  const updatedAt =
+    typeof comment.updated_at === "string" ? Date.parse(comment.updated_at) : Number.NaN;
+  const activity = Math.max(
+    Number.isFinite(createdAt) ? createdAt : Number.NEGATIVE_INFINITY,
+    Number.isFinite(updatedAt) ? updatedAt : Number.NEGATIVE_INFINITY,
+  );
+  return Number.isFinite(activity) ? activity : null;
+}
+
+function markerItemNumber(marker: string): number | null {
+  const match = marker.match(/\bitem=(\d+)(?=\s|-->)/i);
+  if (!match?.[1]) return null;
+  const number = Number(match[1]);
+  return Number.isSafeInteger(number) && number > 0 ? number : null;
+}
+
+function markerReviewedAtMs(marker: string): number | null {
+  const match = marker.match(/\breviewed_at=([^\s>]+)/i);
+  if (!match?.[1]) return null;
+  const reviewedAt = Date.parse(match[1]);
+  return Number.isFinite(reviewedAt) ? reviewedAt : null;
+}
+
+function validHeadSha(value: unknown): string | null {
+  if (typeof value !== "string" || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(value)) {
+    return null;
+  }
+  return value.toLowerCase();
+}
+
+function markerHeadSha(marker: string): string | null {
+  return validHeadSha(marker.match(/\bsha=([^\s>]+)/i)?.[1]);
+}
+
+function completedReviewActivityMs(
+  number: number,
+  comment: ReviewComment,
+  markers: readonly string[],
+  expectedHeadSha?: string,
+): number | null {
+  const canonicalMarker = markers.some(
+    (marker) =>
+      /^<!--\s*clawsweeper-review\s+item=\d+(?:\s+[^>]*)?\s*-->$/i.test(marker) &&
+      markerItemNumber(marker) === number,
+  );
+  if (!canonicalMarker) return null;
+
+  // Legacy started leases append the canonical review marker to a placeholder.
+  // A stale review also has that marker, but neither is a completed publication.
+  if (
+    markers.some(
+      (marker) =>
+        /^<!--\s*clawsweeper-review-status:(?:started|stale)\b/i.test(marker) &&
+        markerItemNumber(marker) === number,
+    )
+  ) {
+    return null;
+  }
+
+  const versionMarker = markers.find(
+    (marker) =>
+      /^<!--\s*clawsweeper-review-version\b/i.test(marker) && markerItemNumber(marker) === number,
+  );
+  if (expectedHeadSha) {
+    if (!versionMarker || markerHeadSha(versionMarker) !== expectedHeadSha) return null;
+    return markerReviewedAtMs(versionMarker);
+  }
+  return (versionMarker ? markerReviewedAtMs(versionMarker) : null) ?? commentActivityMs(comment);
+}
+
+function completedReviewSupersedesPlaceholder(
+  number: number,
+  comments: readonly ReviewComment[],
+  expectedHeadSha?: string,
+): boolean {
+  let latestCompletedReview = Number.NEGATIVE_INFINITY;
+  let latestStartedPlaceholder = Number.NEGATIVE_INFINITY;
+
+  for (const comment of comments) {
+    if (!isTrustedClawSweeperComment(comment) || typeof comment.body !== "string") continue;
+    const markers = trailingHtmlComments(comment.body);
+    const hasStartedPlaceholder = markers.some(
+      (marker) =>
+        /^<!--\s*clawsweeper-review-status:started\b/i.test(marker) &&
+        markerItemNumber(marker) === number,
+    );
+    if (hasStartedPlaceholder) {
+      const activity = commentActivityMs(comment);
+      // Missing timestamps cannot establish that a completed review superseded
+      // this lease. Keep the escalation visible rather than guessing.
+      if (activity === null) return false;
+      latestStartedPlaceholder = Math.max(latestStartedPlaceholder, activity);
+    }
+
+    const completedAt = completedReviewActivityMs(number, comment, markers, expectedHeadSha);
+    if (completedAt !== null) {
+      latestCompletedReview = Math.max(latestCompletedReview, completedAt);
+    }
+  }
+
+  return (
+    Number.isFinite(latestCompletedReview) && latestCompletedReview >= latestStartedPlaceholder
+  );
+}
+
+export async function runReviewRecoveryLabelBackfill(
+  options: ReviewRecoveryLabelBackfillOptions = {},
+): Promise<ReviewRecoveryLabelBackfillSummary> {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? new Date();
+  const readToken = env.GH_TOKEN ?? env.GITHUB_TOKEN ?? "";
+  const targetWriteToken = env.TARGET_WRITE_TOKEN ?? "";
+  const repository = env.TARGET_REPO ?? "openclaw/openclaw";
+  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+  const maximumChecks = boundedPositiveInteger(
+    env.REVIEW_PLACEHOLDER_MAX_CHECKS,
+    DEFAULT_REVIEW_RECOVERY_LABEL_MAX_CHECKS,
+    MAXIMUM_REVIEW_RECOVERY_LABEL_CHECKS,
+  );
+  const maximumRemovals = boundedPositiveInteger(
+    env.REVIEW_PLACEHOLDER_MAX_RECOVERIES,
+    DEFAULT_REVIEW_RECOVERY_LABEL_MAX_REMOVALS,
+    MAXIMUM_REVIEW_RECOVERY_LABEL_REMOVALS,
+  );
+
+  if (!readToken || !targetWriteToken || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error(
+      "review-recovery label backfill is misconfigured: missing read token, target write token, or valid target repository",
+    );
+  }
+
+  const summary: ReviewRecoveryLabelBackfillSummary = {
+    checked: 0,
+    cleared: 0,
+    alreadyCleared: 0,
+    retained: 0,
+    errors: 0,
+    matched: 0,
+    remaining: 0,
+  };
+  const github = async <T>(path: string): Promise<T> => {
+    const response = await fetchImpl(`${apiUrl}${path}`, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${readToken}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!response.ok) throw new Error(`GET ${path} returned ${response.status}`);
+    return (await response.json()) as T;
+  };
+
+  const query = `repo:${repository} is:open label:"${REVIEW_RECOVERY_STUCK_LABEL}"`;
+  const searchPath = (page: number) =>
+    `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=${maximumChecks}&page=${page}`;
+  let search = await github<{ items?: unknown; total_count?: unknown }>(searchPath(1));
+  const firstPageCandidates = Array.isArray(search.items) ? search.items : [];
+  summary.matched =
+    typeof search.total_count === "number" && Number.isFinite(search.total_count)
+      ? Math.max(0, Math.trunc(search.total_count))
+      : firstPageCandidates.length;
+  // Truly stuck old items must not monopolize every 20-item sweep. Rotate
+  // through GitHub's bounded 1,000-result search window without durable cursors
+  // or new operator configuration; discovering total_count costs one request.
+  const searchable = Math.min(summary.matched, MAXIMUM_SEARCH_RESULTS);
+  const pageCount = Math.max(1, Math.ceil(searchable / maximumChecks));
+  const page = (Math.floor(now.getTime() / BACKFILL_PAGE_ROTATION_MS) % pageCount) + 1;
+  if (page !== 1) search = await github<{ items?: unknown }>(searchPath(page));
+  const candidates = Array.isArray(search.items) ? search.items : [];
+  const seen = new Set<number>();
+
+  for (const candidate of candidates) {
+    if (summary.checked >= maximumChecks || summary.cleared >= maximumRemovals) break;
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
+    const number = Number((candidate as { number?: unknown }).number);
+    if (!Number.isSafeInteger(number) || number <= 0 || seen.has(number)) continue;
+    seen.add(number);
+    summary.checked += 1;
+
+    try {
+      const comments: ReviewComment[] = [];
+      for (let page = 1; page <= MAXIMUM_COMMENT_PAGES; page += 1) {
+        const pageComments = await github<ReviewComment[]>(
+          `/repos/${repository}/issues/${number}/comments?sort=created&direction=desc&per_page=${COMMENT_PAGE_SIZE}&page=${page}`,
+        );
+        comments.push(...pageComments);
+        if (pageComments.length < COMMENT_PAGE_SIZE) break;
+      }
+
+      let expectedHeadSha: string | undefined;
+      if ((candidate as { pull_request?: unknown }).pull_request) {
+        const pull = await github<{ head?: { sha?: unknown } }>(
+          `/repos/${repository}/pulls/${number}`,
+        );
+        const currentHeadSha = validHeadSha(pull.head?.sha);
+        if (!currentHeadSha) {
+          summary.retained += 1;
+          continue;
+        }
+        expectedHeadSha = currentHeadSha;
+      }
+
+      if (!completedReviewSupersedesPlaceholder(number, comments, expectedHeadSha)) {
+        summary.retained += 1;
+        continue;
+      }
+
+      const path = `/repos/${repository}/issues/${number}/labels/${encodeURIComponent(REVIEW_RECOVERY_STUCK_LABEL)}`;
+      const response = await fetchImpl(`${apiUrl}${path}`, {
+        method: "DELETE",
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${targetWriteToken}`,
+          "x-github-api-version": "2022-11-28",
+        },
+      });
+      if (response.status === 404) {
+        summary.alreadyCleared += 1;
+        continue;
+      }
+      if (!response.ok) throw new Error(`DELETE ${path} returned ${response.status}`);
+
+      summary.cleared += 1;
+      console.log(`review-recovery label backfill: cleared resolved #${number}`);
+    } catch (error) {
+      summary.errors += 1;
+      console.warn(
+        `#${number} review-recovery label backfill skipped: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  summary.remaining = Math.max(0, summary.matched - summary.checked);
+  console.log(
+    `review-recovery label backfill: checked=${summary.checked} cleared=${summary.cleared} already_cleared=${summary.alreadyCleared} retained=${summary.retained} errors=${summary.errors} matched=${summary.matched} remaining=${summary.remaining} at=${now.toISOString()}`,
+  );
+  return summary;
+}

--- a/src/review-recovery-label-backfill.ts
+++ b/src/review-recovery-label-backfill.ts
@@ -60,6 +60,7 @@ function completedReviewSupersedesPlaceholder(
 ): boolean {
   let completedAt = Number.NEGATIVE_INFINITY;
   let startedAt = Number.NEGATIVE_INFINITY;
+  let failedAt = Number.NEGATIVE_INFINITY;
   for (const comment of comments) {
     if (!isBotComment(comment) || typeof comment.body !== "string") continue;
     const markers = trailingHtmlComments(comment.body);
@@ -74,17 +75,27 @@ function completedReviewSupersedesPlaceholder(
       if (!Number.isFinite(activity)) return false;
       startedAt = Math.max(startedAt, activity);
     }
-    if (
-      started ||
-      markers.some((marker) => markerForItem(marker, "review-status:stale")) ||
+    const canonical = markers.some(
+      (marker) =>
+        /^<!--\s*clawsweeper-review\s+item=\d+(?:\s+[^>]*)?\s*-->$/i.test(marker) &&
+        markerAttribute(marker, "item") === String(number),
+    );
+    const failed =
       /^ClawSweeper review:\s*did not complete due to Codex infrastructure failure\./i.test(
         comment.body.trimStart(),
-      ) ||
-      !markers.some(
-        (marker) =>
-          /^<!--\s*clawsweeper-review\s+item=\d+(?:\s+[^>]*)?\s*-->$/i.test(marker) &&
-          markerAttribute(marker, "item") === String(number),
-      )
+      );
+    if (failed && canonical) {
+      const version = markers.findLast((marker) => markerForItem(marker, "review-version"));
+      const reviewedAt = version ? Date.parse(markerAttribute(version, "reviewed_at") ?? "") : NaN;
+      const activity = Number.isFinite(reviewedAt) ? reviewedAt : commentActivity(comment);
+      if (!Number.isFinite(activity)) return false;
+      failedAt = Math.max(failedAt, activity);
+    }
+    if (
+      started ||
+      failed ||
+      markers.some((marker) => markerForItem(marker, "review-status:stale")) ||
+      !canonical
     ) {
       continue;
     }
@@ -102,7 +113,7 @@ function completedReviewSupersedesPlaceholder(
     const activity = Number.isFinite(reviewedAt) ? reviewedAt : commentActivity(comment);
     if (Number.isFinite(activity)) completedAt = Math.max(completedAt, activity);
   }
-  return Number.isFinite(completedAt) && completedAt >= startedAt;
+  return Number.isFinite(completedAt) && completedAt >= startedAt && completedAt > failedAt;
 }
 
 export async function runReviewRecoveryLabelBackfill(

--- a/src/review-recovery-label-backfill.ts
+++ b/src/review-recovery-label-backfill.ts
@@ -1,29 +1,7 @@
 import { trailingHtmlComments } from "./review-comment-markers.js";
+import type { ReviewPlaceholderComment } from "./review-placeholder-recovery.js";
 
 export const REVIEW_RECOVERY_STUCK_LABEL = "clawsweeper-recovery-stuck";
-export const DEFAULT_REVIEW_RECOVERY_LABEL_MAX_CHECKS = 20;
-export const DEFAULT_REVIEW_RECOVERY_LABEL_MAX_REMOVALS = 5;
-
-const MAXIMUM_REVIEW_RECOVERY_LABEL_CHECKS = 100;
-const MAXIMUM_REVIEW_RECOVERY_LABEL_REMOVALS = 20;
-const MAXIMUM_SEARCH_RESULTS = 1_000;
-const BACKFILL_PAGE_ROTATION_MS = 15 * 60 * 1_000;
-const COMMENT_PAGE_SIZE = 100;
-const MAXIMUM_COMMENT_PAGES = 3;
-const TRUSTED_CLAWSWEEPER_BOT_LOGINS = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
-
-type ReviewComment = {
-  body?: unknown;
-  created_at?: unknown;
-  updated_at?: unknown;
-  user?: { login?: unknown; type?: unknown } | null;
-};
-
-type ReviewRecoveryLabelBackfillOptions = {
-  env?: NodeJS.ProcessEnv;
-  fetchImpl?: typeof fetch;
-  now?: Date;
-};
 
 export type ReviewRecoveryLabelBackfillSummary = {
   checked: number;
@@ -33,6 +11,19 @@ export type ReviewRecoveryLabelBackfillSummary = {
   errors: number;
   matched: number;
   remaining: number;
+};
+
+type ReviewRecoveryLabelBackfillOptions = {
+  repository: string;
+  now: Date;
+  maximumChecks: number;
+  maximumRecoveries: number;
+  github: <T>(path: string) => Promise<T>;
+  fetchComments: (
+    number: number,
+  ) => Promise<{ comments: ReviewPlaceholderComment[]; complete: boolean }>;
+  removeLabel: (number: number) => Promise<"removed" | "missing">;
+  isBotComment: (comment: ReviewPlaceholderComment) => boolean;
 };
 
 export function clearResolvedReviewRecoveryLabel(options: {
@@ -45,158 +36,80 @@ export function clearResolvedReviewRecoveryLabel(options: {
   if (!options.complete) return false;
   const index = options.labels.indexOf(REVIEW_RECOVERY_STUCK_LABEL);
   if (index < 0) return false;
-
   options.removeLabel(options.number, REVIEW_RECOVERY_STUCK_LABEL, options.onMutation);
   options.labels.splice(index, 1);
   return true;
 }
 
-function boundedPositiveInteger(value: string | undefined, fallback: number, maximum: number) {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : fallback;
+function markerAttribute(marker: string, name: string): string | undefined {
+  return marker.match(new RegExp(`\\b${name}=([^\\s>]+)`, "i"))?.[1];
 }
 
-function isTrustedClawSweeperComment(comment: ReviewComment): boolean {
-  const login = typeof comment.user?.login === "string" ? comment.user.login.toLowerCase() : "";
-  const type = typeof comment.user?.type === "string" ? comment.user.type.toLowerCase() : "";
-  return type === "bot" && TRUSTED_CLAWSWEEPER_BOT_LOGINS.has(login);
-}
-
-function commentActivityMs(comment: ReviewComment): number | null {
-  const createdAt =
-    typeof comment.created_at === "string" ? Date.parse(comment.created_at) : Number.NaN;
-  const updatedAt =
-    typeof comment.updated_at === "string" ? Date.parse(comment.updated_at) : Number.NaN;
-  const activity = Math.max(
-    Number.isFinite(createdAt) ? createdAt : Number.NEGATIVE_INFINITY,
-    Number.isFinite(updatedAt) ? updatedAt : Number.NEGATIVE_INFINITY,
+function commentActivity(comment: ReviewPlaceholderComment): number {
+  const times = [comment.created_at, comment.updated_at].map((value) =>
+    typeof value === "string" ? Date.parse(value) : Number.NaN,
   );
-  return Number.isFinite(activity) ? activity : null;
-}
-
-function markerItemNumber(marker: string): number | null {
-  const match = marker.match(/\bitem=(\d+)(?=\s|-->)/i);
-  if (!match?.[1]) return null;
-  const number = Number(match[1]);
-  return Number.isSafeInteger(number) && number > 0 ? number : null;
-}
-
-function markerReviewedAtMs(marker: string): number | null {
-  const match = marker.match(/\breviewed_at=([^\s>]+)/i);
-  if (!match?.[1]) return null;
-  const reviewedAt = Date.parse(match[1]);
-  return Number.isFinite(reviewedAt) ? reviewedAt : null;
-}
-
-function validHeadSha(value: unknown): string | null {
-  if (typeof value !== "string" || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(value)) {
-    return null;
-  }
-  return value.toLowerCase();
-}
-
-function markerHeadSha(marker: string): string | null {
-  return validHeadSha(marker.match(/\bsha=([^\s>]+)/i)?.[1]);
-}
-
-function completedReviewActivityMs(
-  number: number,
-  comment: ReviewComment,
-  markers: readonly string[],
-  expectedHeadSha?: string,
-): number | null {
-  const canonicalMarker = markers.some(
-    (marker) =>
-      /^<!--\s*clawsweeper-review\s+item=\d+(?:\s+[^>]*)?\s*-->$/i.test(marker) &&
-      markerItemNumber(marker) === number,
-  );
-  if (!canonicalMarker) return null;
-
-  // Legacy started leases append the canonical review marker to a placeholder.
-  // A stale review also has that marker, but neither is a completed publication.
-  if (
-    markers.some(
-      (marker) =>
-        /^<!--\s*clawsweeper-review-status:(?:started|stale)\b/i.test(marker) &&
-        markerItemNumber(marker) === number,
-    )
-  ) {
-    return null;
-  }
-
-  const versionMarker = markers.find(
-    (marker) =>
-      /^<!--\s*clawsweeper-review-version\b/i.test(marker) && markerItemNumber(marker) === number,
-  );
-  if (expectedHeadSha) {
-    if (!versionMarker || markerHeadSha(versionMarker) !== expectedHeadSha) return null;
-    return markerReviewedAtMs(versionMarker);
-  }
-  return (versionMarker ? markerReviewedAtMs(versionMarker) : null) ?? commentActivityMs(comment);
+  return Math.max(...times.filter(Number.isFinite));
 }
 
 function completedReviewSupersedesPlaceholder(
   number: number,
-  comments: readonly ReviewComment[],
-  expectedHeadSha?: string,
+  comments: readonly ReviewPlaceholderComment[],
+  isBotComment: ReviewRecoveryLabelBackfillOptions["isBotComment"],
+  headSha?: string,
 ): boolean {
-  let latestCompletedReview = Number.NEGATIVE_INFINITY;
-  let latestStartedPlaceholder = Number.NEGATIVE_INFINITY;
-
+  let completedAt = Number.NEGATIVE_INFINITY;
+  let startedAt = Number.NEGATIVE_INFINITY;
   for (const comment of comments) {
-    if (!isTrustedClawSweeperComment(comment) || typeof comment.body !== "string") continue;
+    if (!isBotComment(comment) || typeof comment.body !== "string") continue;
     const markers = trailingHtmlComments(comment.body);
-    const hasStartedPlaceholder = markers.some(
-      (marker) =>
-        /^<!--\s*clawsweeper-review-status:started\b/i.test(marker) &&
-        markerItemNumber(marker) === number,
-    );
-    if (hasStartedPlaceholder) {
-      const activity = commentActivityMs(comment);
-      // Missing timestamps cannot establish that a completed review superseded
-      // this lease. Keep the escalation visible rather than guessing.
-      if (activity === null) return false;
-      latestStartedPlaceholder = Math.max(latestStartedPlaceholder, activity);
+    const markerForItem = (marker: string, kind: string) =>
+      new RegExp(`^<!--\\s*clawsweeper-${kind}\\b`, "i").test(marker) &&
+      markerAttribute(marker, "item") === String(number);
+    const started =
+      markers.some((marker) => markerForItem(marker, "review-status:started")) ||
+      /^ClawSweeper status:\s*review started\./i.test(comment.body.trimStart());
+    if (started) {
+      const activity = commentActivity(comment);
+      if (!Number.isFinite(activity)) return false;
+      startedAt = Math.max(startedAt, activity);
     }
-
-    const completedAt = completedReviewActivityMs(number, comment, markers, expectedHeadSha);
-    if (completedAt !== null) {
-      latestCompletedReview = Math.max(latestCompletedReview, completedAt);
+    if (
+      started ||
+      markers.some((marker) => markerForItem(marker, "review-status:stale")) ||
+      /^ClawSweeper review:\s*did not complete due to Codex infrastructure failure\./i.test(
+        comment.body.trimStart(),
+      ) ||
+      !markers.some(
+        (marker) =>
+          /^<!--\s*clawsweeper-review\s+item=\d+(?:\s+[^>]*)?\s*-->$/i.test(marker) &&
+          markerAttribute(marker, "item") === String(number),
+      )
+    ) {
+      continue;
     }
+    const version = markers.findLast((marker) => markerForItem(marker, "review-version"));
+    if (version && markerAttribute(version, "v") !== "1") continue;
+    const reviewedAt = version ? Date.parse(markerAttribute(version, "reviewed_at") ?? "") : NaN;
+    if (
+      headSha &&
+      (!version ||
+        !Number.isFinite(reviewedAt) ||
+        markerAttribute(version, "sha")?.toLowerCase() !== headSha)
+    ) {
+      continue;
+    }
+    const activity = Number.isFinite(reviewedAt) ? reviewedAt : commentActivity(comment);
+    if (Number.isFinite(activity)) completedAt = Math.max(completedAt, activity);
   }
-
-  return (
-    Number.isFinite(latestCompletedReview) && latestCompletedReview >= latestStartedPlaceholder
-  );
+  return Number.isFinite(completedAt) && completedAt >= startedAt;
 }
 
 export async function runReviewRecoveryLabelBackfill(
-  options: ReviewRecoveryLabelBackfillOptions = {},
+  options: ReviewRecoveryLabelBackfillOptions,
 ): Promise<ReviewRecoveryLabelBackfillSummary> {
-  const env = options.env ?? process.env;
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const now = options.now ?? new Date();
-  const readToken = env.GH_TOKEN ?? env.GITHUB_TOKEN ?? "";
-  const targetWriteToken = env.TARGET_WRITE_TOKEN ?? "";
-  const repository = env.TARGET_REPO ?? "openclaw/openclaw";
-  const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
-  const maximumChecks = boundedPositiveInteger(
-    env.REVIEW_PLACEHOLDER_MAX_CHECKS,
-    DEFAULT_REVIEW_RECOVERY_LABEL_MAX_CHECKS,
-    MAXIMUM_REVIEW_RECOVERY_LABEL_CHECKS,
-  );
-  const maximumRemovals = boundedPositiveInteger(
-    env.REVIEW_PLACEHOLDER_MAX_RECOVERIES,
-    DEFAULT_REVIEW_RECOVERY_LABEL_MAX_REMOVALS,
-    MAXIMUM_REVIEW_RECOVERY_LABEL_REMOVALS,
-  );
-
-  if (!readToken || !targetWriteToken || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
-    throw new Error(
-      "review-recovery label backfill is misconfigured: missing read token, target write token, or valid target repository",
-    );
-  }
-
+  const { repository, now, maximumChecks, maximumRecoveries, github, fetchComments, removeLabel } =
+    options;
   const summary: ReviewRecoveryLabelBackfillSummary = {
     checked: 0,
     cleared: 0,
@@ -206,90 +119,51 @@ export async function runReviewRecoveryLabelBackfill(
     matched: 0,
     remaining: 0,
   };
-  const github = async <T>(path: string): Promise<T> => {
-    const response = await fetchImpl(`${apiUrl}${path}`, {
-      headers: {
-        accept: "application/vnd.github+json",
-        authorization: `Bearer ${readToken}`,
-        "x-github-api-version": "2022-11-28",
-      },
-    });
-    if (!response.ok) throw new Error(`GET ${path} returned ${response.status}`);
-    return (await response.json()) as T;
-  };
-
   const query = `repo:${repository} is:open label:"${REVIEW_RECOVERY_STUCK_LABEL}"`;
   const searchPath = (page: number) =>
     `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=${maximumChecks}&page=${page}`;
-  let search = await github<{ items?: unknown; total_count?: unknown }>(searchPath(1));
-  const firstPageCandidates = Array.isArray(search.items) ? search.items : [];
+  type Search = { items?: unknown; total_count?: unknown };
+  let search = await github<Search>(searchPath(1));
+  const firstPage = Array.isArray(search.items) ? search.items : [];
   summary.matched =
     typeof search.total_count === "number" && Number.isFinite(search.total_count)
       ? Math.max(0, Math.trunc(search.total_count))
-      : firstPageCandidates.length;
-  // Truly stuck old items must not monopolize every 20-item sweep. Rotate
-  // through GitHub's bounded 1,000-result search window without durable cursors
-  // or new operator configuration; discovering total_count costs one request.
-  const searchable = Math.min(summary.matched, MAXIMUM_SEARCH_RESULTS);
-  const pageCount = Math.max(1, Math.ceil(searchable / maximumChecks));
-  const page = (Math.floor(now.getTime() / BACKFILL_PAGE_ROTATION_MS) % pageCount) + 1;
-  if (page !== 1) search = await github<{ items?: unknown }>(searchPath(page));
-  const candidates = Array.isArray(search.items) ? search.items : [];
+      : firstPage.length;
+  const pages = Math.max(1, Math.ceil(Math.min(summary.matched, 1_000) / maximumChecks));
+  const page = (Math.floor(now.getTime() / (15 * 60 * 1_000)) % pages) + 1;
+  if (page !== 1) search = await github<Search>(searchPath(page));
   const seen = new Set<number>();
-
-  for (const candidate of candidates) {
-    if (summary.checked >= maximumChecks || summary.cleared >= maximumRemovals) break;
+  for (const candidate of Array.isArray(search.items) ? search.items : []) {
+    if (summary.checked >= maximumChecks || summary.cleared >= maximumRecoveries) break;
     if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
     const number = Number((candidate as { number?: unknown }).number);
     if (!Number.isSafeInteger(number) || number <= 0 || seen.has(number)) continue;
     seen.add(number);
     summary.checked += 1;
-
     try {
-      const comments: ReviewComment[] = [];
-      for (let page = 1; page <= MAXIMUM_COMMENT_PAGES; page += 1) {
-        const pageComments = await github<ReviewComment[]>(
-          `/repos/${repository}/issues/${number}/comments?sort=created&direction=desc&per_page=${COMMENT_PAGE_SIZE}&page=${page}`,
-        );
-        comments.push(...pageComments);
-        if (pageComments.length < COMMENT_PAGE_SIZE) break;
-      }
-
-      let expectedHeadSha: string | undefined;
-      if ((candidate as { pull_request?: unknown }).pull_request) {
+      const { comments, complete } = await fetchComments(number);
+      let headSha: string | undefined;
+      if (complete && (candidate as { pull_request?: unknown }).pull_request) {
         const pull = await github<{ head?: { sha?: unknown } }>(
           `/repos/${repository}/pulls/${number}`,
         );
-        const currentHeadSha = validHeadSha(pull.head?.sha);
-        if (!currentHeadSha) {
+        const sha = pull.head?.sha;
+        if (typeof sha === "string" && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(sha)) {
+          headSha = sha.toLowerCase();
+        } else {
           summary.retained += 1;
           continue;
         }
-        expectedHeadSha = currentHeadSha;
       }
-
-      if (!completedReviewSupersedesPlaceholder(number, comments, expectedHeadSha)) {
+      if (
+        !complete ||
+        !completedReviewSupersedesPlaceholder(number, comments, options.isBotComment, headSha)
+      ) {
         summary.retained += 1;
         continue;
       }
-
-      const path = `/repos/${repository}/issues/${number}/labels/${encodeURIComponent(REVIEW_RECOVERY_STUCK_LABEL)}`;
-      const response = await fetchImpl(`${apiUrl}${path}`, {
-        method: "DELETE",
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${targetWriteToken}`,
-          "x-github-api-version": "2022-11-28",
-        },
-      });
-      if (response.status === 404) {
-        summary.alreadyCleared += 1;
-        continue;
-      }
-      if (!response.ok) throw new Error(`DELETE ${path} returned ${response.status}`);
-
-      summary.cleared += 1;
-      console.log(`review-recovery label backfill: cleared resolved #${number}`);
+      if ((await removeLabel(number)) === "missing") summary.alreadyCleared += 1;
+      else summary.cleared += 1;
     } catch (error) {
       summary.errors += 1;
       console.warn(
@@ -297,10 +171,6 @@ export async function runReviewRecoveryLabelBackfill(
       );
     }
   }
-
   summary.remaining = Math.max(0, summary.matched - summary.checked);
-  console.log(
-    `review-recovery label backfill: checked=${summary.checked} cleared=${summary.cleared} already_cleared=${summary.alreadyCleared} retained=${summary.retained} errors=${summary.errors} matched=${summary.matched} remaining=${summary.remaining} at=${now.toISOString()}`,
-  );
   return summary;
 }

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -2554,7 +2554,7 @@ Full review comments:
   }
 });
 
-test("apply-decisions refreshes recent PR comments after label sync adds justifications", () => {
+test("apply-decisions clears a recovery escalation only after publishing a completed PR review", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -2581,7 +2581,7 @@ test("apply-decisions refreshes recent PR comments after label sync adds justifi
         local_checkout_access: "verified",
         author: "contributor",
         author_association: "CONTRIBUTOR",
-        labels: JSON.stringify([]),
+        labels: JSON.stringify(["clawsweeper-recovery-stuck"]),
         item_snapshot_hash: "snapshot-a",
         item_updated_at: "2026-05-19T20:00:00Z",
         pull_head_sha: "abc123def456",
@@ -2632,7 +2632,7 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
     user: { login: "contributor" },
-    labels: [],
+    labels: ["clawsweeper-recovery-stuck"],
     pull_request: {}
   }));
 } else if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/74479\\/timeline(?:\\?|$)/.test(args[2] || "")) {
@@ -2706,12 +2706,24 @@ if (args[0] === "api" && /\\/issues\\/74479$/.test(path)) {
     assert.match(patchedBody, /`proof: sufficient`/);
     assert.match(patchedBody, /`proof: 📸 screenshot`/);
     assert.match(patchedBody, /`rating: 🦞 diamond lobster`/);
-    assert.match(readFileSync(itemPath, "utf8"), /^labels_synced_at: /m);
+    const publicationIndex = calls.findIndex((args) => args[0] === "patched-review-body");
+    const recoveryCleanupIndex = calls.findIndex(
+      (args) =>
+        args[0] === "issue" &&
+        args[1] === "edit" &&
+        args.includes("--remove-label") &&
+        args.includes("clawsweeper-recovery-stuck"),
+    );
+    assert.ok(publicationIndex >= 0);
+    assert.ok(recoveryCleanupIndex > publicationIndex);
+    const updatedReport = readFileSync(itemPath, "utf8");
+    assert.match(updatedReport, /^labels_synced_at: /m);
+    assert.doesNotMatch(updatedReport, /clawsweeper-recovery-stuck/);
     assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
       {
         number: 74479,
         action: "review_comment_synced",
-        reason: "updated durable Codex review comment",
+        reason: "updated durable Codex review comment; cleared resolved review recovery label",
       },
     ]);
   } finally {

--- a/test/pr-proof-automation.test.ts
+++ b/test/pr-proof-automation.test.ts
@@ -207,6 +207,127 @@ Full review comments:
   assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
 });
 
+test("maintainer and bot proof exemptions keep readiness, ratings, and security consistent", () => {
+  const reportFor = (options: {
+    author: string;
+    association: string;
+    status?: "missing" | "mock_only" | "insufficient" | "sufficient";
+    securityAttention?: boolean;
+  }) => {
+    const status = options.status ?? "missing";
+    const sufficient = status === "sufficient";
+    const proofTier = sufficient ? "A" : status === "missing" ? "F" : "D";
+    return `${reportFrontMatter({
+      type: "pull_request",
+      number: "119610",
+      decision: "keep_open",
+      close_reason: "none",
+      review_status: "complete",
+      confidence: "high",
+      author: options.author,
+      author_association: options.association,
+      labels: JSON.stringify(["clawsweeper:automerge"]),
+      work_candidate: "none",
+      pull_head_sha: "abc123def456",
+    })}
+
+## Summary
+
+Keep this focused pull request open for maintainer review.
+
+## What This Changes
+
+Keeps pull request evidence checks aligned with their actual scope.
+
+## Best Possible Solution
+
+Continue normal maintainer review.
+
+${realBehaviorProofReportSection({
+  status,
+  evidenceKind: sufficient ? "terminal" : "none",
+  needsContributorAction: !sufficient,
+  summary: sufficient
+    ? "The maintainer supplied terminal output from the changed production path."
+    : "The reviewer did not find contributor-supplied live proof.",
+})}
+
+${prRatingReportSection({
+  overallTier: proofTier,
+  proofTier,
+  patchTier: "A",
+  summary: "The model capped readiness based on its recorded proof assessment.",
+  nextSteps: sufficient ? "- none" : "- Add real behavior proof.",
+})}
+
+${
+  options.securityAttention
+    ? `## Security Review
+
+Status: needs_attention
+
+Summary: The changed authorization boundary requires maintainer review.
+
+`
+    : ""
+}## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.9
+
+Full review comments:
+
+- none
+`;
+  };
+
+  for (const scenario of [
+    { author: "maintainer", association: "MEMBER", status: "missing" as const },
+    { author: "owner", association: "OWNER", status: "mock_only" as const },
+    { author: "collaborator", association: "COLLABORATOR", status: "insufficient" as const },
+    { author: "dependabot[bot]", association: "NONE", status: "missing" as const },
+    { author: "app/clawsweeper", association: "NONE", status: "insufficient" as const },
+  ]) {
+    const report = reportFor(scenario);
+    const comment = renderReviewCommentFromReport(report, "none", {
+      prStatusKind: "ready_for_maintainer_look",
+    });
+    const markers = reviewAutomationMarkersFromReport(report);
+
+    assert.match(comment, /✅ \*\*Ready for maintainer review\*\*/, scenario.author);
+    assert.match(comment, /\| \*\*Overall readiness\*\* \| 🦞 diamond lobster/, scenario.author);
+    assert.match(comment, /\| \*\*Proof confidence\*\* \| 🌊 off-meta tidepool/, scenario.author);
+    assert.doesNotMatch(comment, /blocked until .*real behavior proof/i, scenario.author);
+    assert.doesNotMatch(comment, /status: 📣 needs proof/, scenario.author);
+    assert.match(markers, /clawsweeper-verdict:pass/, scenario.author);
+    assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/, scenario.author);
+  }
+
+  const suppliedComment = renderReviewCommentFromReport(
+    reportFor({ author: "maintainer", association: "MEMBER", status: "sufficient" }),
+    "none",
+  );
+  assert.match(suppliedComment, /maintainer supplied terminal output/);
+  assert.match(suppliedComment, /\| \*\*Proof confidence\*\* \| 🦞 diamond lobster/);
+
+  const contributorReport = reportFor({ author: "contributor", association: "CONTRIBUTOR" });
+  const contributorComment = renderReviewCommentFromReport(contributorReport, "none");
+  assert.match(contributorComment, /blocked until real behavior proof is added/i);
+  assert.match(
+    reviewAutomationMarkersFromReport(contributorReport),
+    /clawsweeper-verdict:needs-human/,
+  );
+
+  const securityComment = renderReviewCommentFromReport(
+    reportFor({ author: "maintainer", association: "MEMBER", securityAttention: true }),
+    "none",
+  );
+  assert.match(securityComment, /blocked by patch quality or review findings/i);
+  assert.match(securityComment, /\| \*\*Security\*\* \| Needs attention/);
+  assert.doesNotMatch(securityComment, /blocked until .*real behavior proof/i);
+});
+
 test("production-owner HTTP fault-boundary proof unblocks shared channel reliability PRs", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",

--- a/test/pr-proof-automation.test.ts
+++ b/test/pr-proof-automation.test.ts
@@ -207,6 +207,97 @@ Full review comments:
   assert.doesNotMatch(markers, /clawsweeper-verdict:pass/);
 });
 
+test("production-owner HTTP fault-boundary proof unblocks shared channel reliability PRs", () => {
+  const report = `${reportFrontMatter({
+    type: "pull_request",
+    number: "112370",
+    decision: "keep_open",
+    close_reason: "none",
+    review_status: "complete",
+    confidence: "high",
+    author: "contributor",
+    author_association: "CONTRIBUTOR",
+    labels: JSON.stringify(["channel: telegram", "clawsweeper:automerge"]),
+    work_candidate: "none",
+    pull_head_sha: "abc123def456",
+    pull_files: JSON.stringify([
+      "src/channels/draft-stream-loop.ts",
+      "src/channels/draft-stream-loop.test.ts",
+    ]),
+    pull_files_truncated: false,
+  })}
+
+## Summary
+
+Keep this shared channel reliability PR open for automerge.
+
+## What This Changes
+
+Preserves the newest message when an older delivery receives an HTTP 429.
+
+## Best Possible Solution
+
+Merge after the production-owner transport-boundary proof and required checks pass.
+
+${realBehaviorProofReportSection({
+  status: "sufficient",
+  evidenceKind: "terminal",
+  needsContributorAction: false,
+  summary:
+    "The real production owner and grammY HTTP client sent requests to a fault-injecting local HTTP server; the recorded 429 older → 200 newest trace confirms the after-fix ordering.",
+})}
+
+## Telegram Visible Proof
+
+Status: not_needed
+
+Summary: Shared retry and ordering work does not change visible Telegram chat behavior.
+
+## Mantis Recommendation
+
+Status: not_recommended
+
+Scenario: none
+
+Reason: The production HTTP transport boundary already proves this internal reliability change.
+
+Maintainer comment:
+
+## Review Findings
+
+Overall correctness: patch is correct
+
+Overall confidence: 0.97
+
+Full review comments:
+
+- none
+`;
+
+  const comment = renderReviewCommentFromReport(report, "none");
+  const markers = reviewAutomationMarkersFromReport(report);
+
+  assert.doesNotMatch(comment, /needs real behavior proof before merge/i);
+  assert.doesNotMatch(comment, /Mantis proof suggestion/);
+  assert.match(markers, /clawsweeper-verdict:pass/);
+  assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/);
+
+  const mockOnlyReport = report
+    .replace("Status: sufficient", "Status: mock_only")
+    .replace("Evidence kind: terminal", "Evidence kind: none")
+    .replace("Needs contributor action: false", "Needs contributor action: true")
+    .replace(
+      "The real production owner and grammY HTTP client sent requests to a fault-injecting local HTTP server; the recorded 429 older → 200 newest trace confirms the after-fix ordering.",
+      "Isolated unit tests stub the transport client and never execute the production HTTP boundary.",
+    );
+  const mockOnlyComment = renderReviewCommentFromReport(mockOnlyReport, "none");
+  const mockOnlyMarkers = reviewAutomationMarkersFromReport(mockOnlyReport);
+
+  assert.match(mockOnlyComment, /needs real behavior proof before merge/i);
+  assert.match(mockOnlyMarkers, /clawsweeper-verdict:needs-human/);
+  assert.doesNotMatch(mockOnlyMarkers, /clawsweeper-verdict:pass/);
+});
+
 test("screenshot-only browser runtime proof blocks pass markers", () => {
   const report = `${reportFrontMatter({
     type: "pull_request",

--- a/test/repair/comment-router-utils.test.ts
+++ b/test/repair/comment-router-utils.test.ts
@@ -1466,19 +1466,21 @@ test("summarizeChecks still blocks cancelled required checks", () => {
   assert.deepEqual(checks.terminalBlockers, ["required-build:CANCELLED"]);
 });
 
-test("summarizeChecks waits for a cancelled real behavior proof replacement", () => {
-  const checks = summarizeChecks([
-    {
-      name: "Real behavior proof",
-      workflowName: "Real behavior proof",
-      status: "COMPLETED",
-      conclusion: "CANCELLED",
-    },
-  ]);
+test("summarizeChecks waits for cancelled evidence-check replacements under both names", () => {
+  for (const name of ["Real behavior proof", "PR context and evidence"]) {
+    const checks = summarizeChecks([
+      {
+        name,
+        workflowName: name,
+        status: "COMPLETED",
+        conclusion: "CANCELLED",
+      },
+    ]);
 
-  assert.deepEqual(checks.blockers, ["Real behavior proof:CANCELLED"]);
-  assert.deepEqual(checks.pending, ["Real behavior proof:CANCELLED"]);
-  assert.deepEqual(checks.terminalBlockers, []);
+    assert.deepEqual(checks.blockers, [`${name}:CANCELLED`]);
+    assert.deepEqual(checks.pending, [`${name}:CANCELLED`]);
+    assert.deepEqual(checks.terminalBlockers, []);
+  }
 });
 
 test("summarizeChecks separates pending checks from terminal blockers", () => {

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -4,6 +4,8 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import YAML from "yaml";
 
+import { createGitHubExecution } from "../../dist/clawsweeper-github-execution.js";
+
 const path = ".github/workflows/exact-review-batch-publish.yml";
 const source = readFileSync(path, "utf8");
 const cliSource = readFileSync("src/repair/exact-review-batch-cli.ts", "utf8");
@@ -37,10 +39,61 @@ test("batch publisher is event-driven and queue-bounded instead of workflow-seri
     "dispatched_at",
   ]);
   assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_MAX_ITEMS, "50");
-  assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY, "4");
+  assert.equal(workflow.jobs.publish!.env.EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY, "1");
   assert.equal(workflow.jobs.publish!.env.CLAWSWEEPER_APP_CLIENT_ID, "Iv23liOECG0slfuhz093");
   assert.equal(workflow.concurrency, undefined);
   assert.deepEqual(workflow.permissions, { actions: "write", contents: "read" });
+});
+
+test("batch publication bounds shared GitHub retries without dropping failed artifacts", () => {
+  assert.match(
+    prepareSource,
+    /publish-event-result\.js"\)\],[\s\S]*?\.\.\.process\.env,\s*CLAWSWEEPER_GH_RETRY_ATTEMPTS: "2"/,
+  );
+  assert.match(
+    prepareSource,
+    /if \(result\.code !== 0 && !existsSync\(outcomePath\)\) \{\s*writeFailure\(outcomePath, "retryable_failure", "unknown_failure"\)/,
+  );
+  assert.match(cliSource, /const failure = failureCompletion\(current, outcome\)/);
+  assert.match(cliSource, /completions\.push\(failure\)/);
+});
+
+test("GitHub retry defaults stay unchanged while publisher attempts are bounded", () => {
+  const previous = process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
+  try {
+    delete process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
+    const defaultExecution = githubRetryExecution(2);
+    assert.equal(defaultExecution.execution.ghWithRetry(["api", "repos/test/item"]), "ok");
+    assert.equal(defaultExecution.calls(), 3);
+
+    process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS = "2";
+    const boundedExecution = githubRetryExecution(3);
+    assert.throws(
+      () => boundedExecution.execution.ghWithRetry(["api", "repos/test/item"]),
+      /API rate limit exceeded/,
+    );
+    assert.equal(boundedExecution.calls(), 2);
+    assert.deepEqual(boundedExecution.waits, [30_000]);
+
+    const mutationExecution = githubRetryExecution(3);
+    assert.throws(
+      () =>
+        mutationExecution.execution.ghObservedMutationCommand({
+          args: ["api", "repos/test/item"],
+          identity: "batch-publication",
+        }),
+      /API rate limit exceeded/,
+    );
+    assert.equal(mutationExecution.calls(), 2);
+    assert.deepEqual(mutationExecution.waits, [30_000]);
+
+    const explicitExecution = githubRetryExecution(2);
+    assert.equal(explicitExecution.execution.ghWithRetry(["api", "repos/test/item"], 3), "ok");
+    assert.equal(explicitExecution.calls(), 3);
+  } finally {
+    if (previous === undefined) delete process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
+    else process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS = previous;
+  }
 });
 
 test("batch workflow signs queue ownership, isolates item failures, and commits once", () => {
@@ -301,3 +354,38 @@ test("batch commit publishes every prepared tuple to canonical Worker state", ()
   assert.doesNotMatch(cliSource, /commitPreparedStateBatch/);
   assert.doesNotMatch(cliSource, /state-publication-batch/);
 });
+
+function githubRetryExecution(failures: number) {
+  let calls = 0;
+  const waits: number[] = [];
+  class TestGitHubRuntimeBudgetError extends Error {}
+  const request = () => {
+    calls += 1;
+    if (calls <= failures) {
+      throw new Error("API rate limit exceeded for installation ID 122230863 (HTTP 403)");
+    }
+    return "ok";
+  };
+  const execution = createGitHubExecution({
+    ROOT: process.cwd(),
+    run: request,
+    gitHubRuntime: {
+      GitHubRuntimeBudgetError: TestGitHubRuntimeBudgetError,
+      ensureGitHubRetryFits: () => undefined,
+      ensureGitHubRuntimeAvailable: () => undefined,
+      gh: request,
+      ghOnce: request,
+      ghWithPreparedTimeout: request,
+      githubCommandTimeoutMs: () => undefined,
+      githubRuntimeBudgetError: () => new TestGitHubRuntimeBudgetError(),
+      sleepBeforeGitHubRetry: (waitMs: number) => waits.push(waitMs),
+    },
+    sweepStatus: {
+      sweepStatusRelativePath: () => "status.json",
+      writeSweepStatus: () => undefined,
+    },
+    labelAlreadyExistsError: () => false,
+  } as unknown as Parameters<typeof createGitHubExecution>[0]);
+
+  return { execution, calls: () => calls, waits };
+}

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -1485,6 +1485,22 @@ test("publishing the durable review comment sweeps superseded placeholders", () 
   assert.match(applyWindow, /cleanupSupersededReviewPlaceholderComments\(\{/);
 });
 
+test("completed durable publication clears a recovery escalation only after the review exists", () => {
+  const source = readFileSync("src/clawsweeper-apply-decision-workflow.ts", "utf8");
+  const publication = source.indexOf("syncedComment = upsertReviewComment(");
+  const recoveryCleanup = source.indexOf("clearResolvedReviewRecoveryLabel({", publication);
+  const nextCatch = source.indexOf("} catch (error)", recoveryCleanup);
+
+  assert.ok(publication >= 0);
+  assert.ok(recoveryCleanup > publication);
+  assert.match(
+    source.slice(publication, recoveryCleanup),
+    /if \(complete && item\.labels\.includes\(REVIEW_RECOVERY_STUCK_LABEL\)\)/,
+  );
+  assert.match(source.slice(recoveryCleanup, nextCatch), /removeLabel:\s*removeIssueLabel/);
+  assert.match(source.slice(recoveryCleanup, nextCatch), /"labels_synced_at"/);
+});
+
 test("placeholder sweep retries on every apply pass independent of comment body sync", () => {
   const source = readFileSync("src/clawsweeper-apply-decision-workflow.ts", "utf8");
   const earlyLeaseStart = source.indexOf("const earlyLeaseState = refreshReviewStartLeaseState();");

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -9,6 +10,18 @@ import {
   runReviewPlaceholderRecovery,
   selectReviewPlaceholderComment,
 } from "../dist/review-placeholder-recovery.js";
+
+test("scheduled placeholder recovery also performs bounded recovery-label reconciliation", () => {
+  const source = readFileSync("src/review-placeholder-recovery.ts", "utf8");
+  const cli = source.slice(source.indexOf("if (invokedPath && invokedPath ==="));
+  const recovery = cli.indexOf("await runReviewPlaceholderRecovery()");
+  const backfill = cli.indexOf("await runReviewRecoveryLabelBackfill()");
+
+  assert.ok(recovery >= 0);
+  assert.ok(backfill > recovery);
+  assert.match(cli.slice(recovery, backfill), /if \(process\.env\.TARGET_WRITE_TOKEN\)/);
+  assert.match(cli.slice(backfill), /review-recovery label reconciliation skipped:/);
+});
 
 const now = new Date("2026-07-17T12:00:00.000Z");
 const bot = { login: "clawsweeper[bot]", type: "Bot" };

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -14,13 +14,73 @@ import {
 test("scheduled placeholder recovery also performs bounded recovery-label reconciliation", () => {
   const source = readFileSync("src/review-placeholder-recovery.ts", "utf8");
   const cli = source.slice(source.indexOf("if (invokedPath && invokedPath ==="));
-  const recovery = cli.indexOf("await runReviewPlaceholderRecovery()");
-  const backfill = cli.indexOf("await runReviewRecoveryLabelBackfill()");
+  const runner = source.slice(source.indexOf("export async function runReviewPlaceholderRecovery"));
 
-  assert.ok(recovery >= 0);
-  assert.ok(backfill > recovery);
-  assert.match(cli.slice(recovery, backfill), /if \(process\.env\.TARGET_WRITE_TOKEN\)/);
-  assert.match(cli.slice(backfill), /review-recovery label reconciliation skipped:/);
+  assert.match(cli, /runReviewPlaceholderRecovery\(\{ reconcileRecoveryLabels: true \}\)/);
+  assert.match(runner, /if \(options\.reconcileRecoveryLabels && targetWriteToken\)/);
+  assert.match(runner, /runReviewRecoveryLabelBackfill\(\{/);
+  assert.match(runner, /github,[\s\S]*fetchComments: fetchReviewComments/);
+  assert.match(runner, /review-recovery label reconciliation skipped:/);
+});
+
+test("the scheduled reconciler reuses recovery transport to clear an exact-head completed PR", async () => {
+  const head = "da73f50fbca83cc89f3e8f33f61e27963351403b";
+  let deletions = 0;
+  const fetchImpl = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      return Response.json(
+        query.includes("label:")
+          ? { total_count: 1, items: [{ number: 112370, pull_request: {} }] }
+          : { total_count: 0, items: [] },
+      );
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/112370/comments") {
+      return Response.json([
+        {
+          body: [
+            "ClawSweeper review: keep open.",
+            `<!-- clawsweeper-review-version item=112370 reviewed_at=2026-08-05T08:07:22.093Z sha=${head} v=1 -->`,
+            "<!-- clawsweeper-review item=112370 -->",
+          ].join("\n\n"),
+          created_at: "2026-08-05T08:07:22.093Z",
+          user: { login: "clawsweeper[bot]", type: "Bot" },
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/pulls/112370") {
+      return Response.json({ head: { sha: head } });
+    }
+    if (
+      url.pathname === "/repos/openclaw/openclaw/issues/112370/labels/clawsweeper-recovery-stuck"
+    ) {
+      assert.equal(init?.method, "DELETE");
+      assert.equal(new Headers(init?.headers).get("authorization"), "Bearer target-token");
+      deletions += 1;
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "read-token",
+      TARGET_WRITE_TOKEN: "target-token",
+      CLAWSWEEPER_WEBHOOK_SECRET: "webhook-secret",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+    },
+    fetchImpl: fetchImpl as typeof fetch,
+    now: new Date("2026-08-05T12:00:00.000Z"),
+    reconcileRecoveryLabels: true,
+  });
+
+  assert.equal(deletions, 1);
 });
 
 const now = new Date("2026-07-17T12:00:00.000Z");

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -81,6 +81,9 @@ test("review prompts treat target AGENTS as optional review policy", () => {
       prompt,
       /do not conflict with this prompt or higher-priority\s+system\/developer\s+instructions/,
     );
+    assert.match(prompt, /read every applicable ancestor `AGENTS\.md`\s+for each changed path/);
+    assert.match(prompt, /Nested instructions apply only within their own subtree/);
+    assert.match(prompt, /do not import policy from sibling or consumer directories/);
     assert.match(prompt, /existing repository\s+profiles and owner\/default fallback behavior/);
     assert.match(prompt, /Use target `AGENTS\.md` policy as review input/);
   }
@@ -204,6 +207,67 @@ test("review prompt requires real behavior proof for PR reviews", () => {
     /Unit tests, mocks, snapshots, lint, typechecks, and CI are supplemental only/,
   );
   assert.match(prompt, /do not request ClawSweeper repair markers/);
+});
+
+test("review prompt accepts real production transport-boundary proof for reliability fixes", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+  const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));
+
+  assert.match(prompt, /actual production owner and real transport client/);
+  assert.match(prompt, /exercising an injected fault/);
+  assert.match(prompt, /recorded request\/response trace/);
+  assert.match(prompt, /`status: "sufficient"`\s+and `needsContributorAction: false`/);
+  assert.match(prompt, /do not require unrelated live-channel\s+access or a full application/);
+  assert.match(prompt, /expressly authorized production-path harnesses/);
+  assert.match(prompt, /Mocked transport clients and\s+isolated unit tests remain `mock_only`/);
+  assert.match(prompt, /preserve existing browser-runtime, CSP,\s+auth, and security safeguards/);
+  assert.match(
+    schema.properties.realBehaviorProof.description,
+    /actual production owner and real transport client exercising an injected fault/,
+  );
+  assert.match(
+    schema.properties.realBehaviorProof.description,
+    /authorized production-path harnesses/,
+  );
+  assert.match(schema.properties.realBehaviorProof.description, /mocked transport clients/);
+  assert.match(schema.properties.agentsPolicyStatus.description, /applicable ancestor-scoped/);
+  assert.match(schema.properties.telegramVisibleProof.description, /Internal retry/);
+  assert.match(
+    schema.properties.mantisRecommendation.description,
+    /Do not recommend it for internal reliability/,
+  );
+});
+
+test("generated shared-channel review prompt preserves scoped policy and real fault evidence", () => {
+  const proof =
+    "The real production owner and grammY HTTP client produced a recorded 429 older → 200 newest trace against a local HTTP server.";
+  const runtimePrompt = reviewPromptForTest(
+    item({
+      kind: "pull_request",
+      number: 112370,
+      title: "fix: preserve newest shared channel draft across Telegram flood waits",
+      labels: ["channel: telegram"],
+      url: "https://github.com/openclaw/openclaw/pull/112370",
+    }),
+    {
+      issue: { number: 112370, body: proof },
+      comments: [{ author: "contributor", body: proof }],
+      timeline: [],
+      pullFiles: [
+        { filename: "src/channels/draft-stream-loop.ts" },
+        { filename: "src/channels/draft-stream-loop.test.ts" },
+      ],
+    },
+    { mainSha: "abc123", latestRelease: null },
+  );
+
+  assert.match(runtimePrompt, /"filename": "src\/channels\/draft-stream-loop\.ts"/);
+  assert.match(runtimePrompt, /grammY HTTP client produced a recorded 429 older → 200 newest/);
+  assert.match(runtimePrompt, /do not import policy from sibling or consumer directories/);
+  assert.doesNotMatch(runtimePrompt, /extensions\/telegram\/AGENTS\.md/);
+  assert.match(runtimePrompt, /actual production owner and real transport client/);
+  assert.match(runtimePrompt, /`telegramVisibleProof\.status: "not_needed"`/);
+  assert.match(runtimePrompt, /`mantisRecommendation\.status: "not_recommended"`/);
 });
 
 test("media proof preparation extracts browser-unplayable ffmpeg-decodeable video proof", () => {
@@ -466,6 +530,11 @@ test("review prompt classifies Telegram visible proof candidates", () => {
   assert.match(prompt, /telegramVisibleProof/);
   assert.match(prompt, /telegram-crabbox-e2e-proof/);
   assert.match(prompt, /message formatting/);
+  assert.match(prompt, /retry\/network reliability only/);
+  assert.match(prompt, /shared retry\/ordering work/);
+  assert.match(prompt, /A label, title, consumer, or example does not make internal/);
+  assert.match(prompt, /`telegramVisibleProof\.status: "not_needed"`/);
+  assert.match(prompt, /`mantisRecommendation\.status: "not_recommended"`/);
   assert.match(prompt, /mantis: telegram-visible-proof/);
   assert.match(prompt, /mantisRecommendation/);
   assert.match(prompt, /@openclaw-mantis/);

--- a/test/review-recovery-label-backfill.test.ts
+++ b/test/review-recovery-label-backfill.test.ts
@@ -6,6 +6,7 @@ import {
   REVIEW_RECOVERY_STUCK_LABEL,
   runReviewRecoveryLabelBackfill,
 } from "../dist/review-recovery-label-backfill.js";
+import { isClawSweeperBotComment } from "../dist/review-placeholder-recovery.js";
 
 const now = new Date("2026-08-05T12:00:00.000Z");
 const trustedBot = { login: "clawsweeper[bot]", type: "Bot" };
@@ -128,6 +129,48 @@ function githubFixture(options: {
   return { fetchImpl: fetchImpl as typeof fetch, deletions, commentPages, searchPages };
 }
 
+async function runBackfill(
+  fixture: ReturnType<typeof githubFixture>,
+  options: { now?: Date; maximumChecks?: number; maximumRecoveries?: number } = {},
+) {
+  const github = async <T>(path: string): Promise<T> => {
+    const response = await fixture.fetchImpl(`${env.GITHUB_API_URL}${path}`, {
+      headers: { authorization: `Bearer ${env.GH_TOKEN}` },
+    });
+    if (!response.ok) throw new Error(`GET ${path} returned ${response.status}`);
+    return (await response.json()) as T;
+  };
+  return runReviewRecoveryLabelBackfill({
+    repository: env.TARGET_REPO,
+    now: options.now ?? now,
+    maximumChecks: options.maximumChecks ?? 20,
+    maximumRecoveries: options.maximumRecoveries ?? 5,
+    github,
+    fetchComments: async (number) => {
+      const comments: TestComment[] = [];
+      for (let page = 1; page <= 3; page += 1) {
+        const values = await github<TestComment[]>(
+          `/repos/${env.TARGET_REPO}/issues/${number}/comments?sort=created&direction=desc&per_page=100&page=${page}`,
+        );
+        comments.push(...values);
+        if (values.length < 100) return { comments, complete: true };
+      }
+      return { comments, complete: false };
+    },
+    removeLabel: async (number) => {
+      const path = `/repos/${env.TARGET_REPO}/issues/${number}/labels/${REVIEW_RECOVERY_STUCK_LABEL}`;
+      const response = await fixture.fetchImpl(`${env.GITHUB_API_URL}${path}`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${env.TARGET_WRITE_TOKEN}` },
+      });
+      if (response.status === 404) return "missing";
+      if (!response.ok) throw new Error(`DELETE ${path} returned ${response.status}`);
+      return "removed";
+    },
+    isBotComment: isClawSweeperBotComment,
+  });
+}
+
 test("completed publication clears its recovery label and preserves other labels", () => {
   const labels = ["priority: high", REVIEW_RECOVERY_STUCK_LABEL, "maturity: ready"];
   const calls: { number: number; label: string; onMutation?: () => void }[] = [];
@@ -211,11 +254,7 @@ test("recovery-label backfill clears only trusted, canonical completed reviews",
     ]),
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture);
 
   assert.deepEqual(fixture.deletions, [101, 107]);
   assert.deepEqual(summary, {
@@ -260,11 +299,7 @@ test("a newer started lease overrides old review publication and unrelated comme
     ]),
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture);
 
   assert.deepEqual(fixture.deletions, [202]);
   assert.equal(summary.cleared, 1);
@@ -315,17 +350,67 @@ test("pull-request cleanup requires a completed durable review of its exact live
     ]),
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture);
 
   assert.deepEqual(fixture.deletions, [211]);
   assert.equal(summary.checked, 4);
   assert.equal(summary.cleared, 1);
   assert.equal(summary.retained, 3);
   assert.equal(summary.errors, 0);
+});
+
+test("failed infrastructure reviews never clear issue or exact-head pull-request escalation", async () => {
+  const sha = "c".repeat(40);
+  const failedIssue = completedReview(221);
+  const failedPull = completedReview(222, {
+    reviewedAt: "2026-08-05T10:00:00.000Z",
+    sha,
+  });
+  for (const comment of [failedIssue, failedPull]) {
+    comment.body = comment.body.replace(
+      "ClawSweeper review: keep open.",
+      "ClawSweeper review: did not complete due to Codex infrastructure failure.",
+    );
+  }
+  const fixture = githubFixture({
+    numbers: [221, 222],
+    pullHeads: new Map([[222, sha]]),
+    comments: new Map([
+      [221, [failedIssue]],
+      [222, [failedPull]],
+    ]),
+  });
+
+  const summary = await runBackfill(fixture);
+
+  assert.deepEqual(fixture.deletions, []);
+  assert.equal(summary.cleared, 0);
+  assert.equal(summary.retained, 2);
+});
+
+test("legacy created-only timestamps and human-only placeholders remain conservative", async () => {
+  const legacyReview = completedReview(231, { at: "2026-08-05T10:00:00.000Z" });
+  const oldPlaceholder = startedPlaceholder(231, "2026-08-05T09:00:00.000Z");
+  delete legacyReview.updated_at;
+  delete oldPlaceholder.updated_at;
+  const humanOnlyPlaceholder: TestComment = {
+    body: "ClawSweeper status: review started.\n\nLegacy placeholder without machine marker.",
+    created_at: "2026-08-05T11:00:00.000Z",
+    user: trustedBot,
+  };
+  const fixture = githubFixture({
+    numbers: [231, 232],
+    comments: new Map([
+      [231, [legacyReview, oldPlaceholder]],
+      [232, [completedReview(232), humanOnlyPlaceholder]],
+    ]),
+  });
+
+  const summary = await runBackfill(fixture);
+
+  assert.deepEqual(fixture.deletions, [231]);
+  assert.equal(summary.cleared, 1);
+  assert.equal(summary.retained, 1);
 });
 
 test("backfill treats a missing label as an idempotent result without claiming removal", async () => {
@@ -335,11 +420,7 @@ test("backfill treats a missing label as an idempotent result without claiming r
     deleteStatus: 404,
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture);
 
   assert.deepEqual(fixture.deletions, [301]);
   assert.equal(summary.alreadyCleared, 1);
@@ -356,11 +437,7 @@ test("backfill reports forbidden label removal without claiming cleanup", async 
     deleteStatus: 403,
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture);
 
   assert.deepEqual(fixture.deletions, [302]);
   assert.equal(summary.cleared, 0);
@@ -377,15 +454,7 @@ test("backfill enforces the existing recovery limits and reports its remaining b
     totalCount: 753,
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env: {
-      ...env,
-      REVIEW_PLACEHOLDER_MAX_CHECKS: "4",
-      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "2",
-    },
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture, { maximumChecks: 4, maximumRecoveries: 2 });
 
   assert.deepEqual(fixture.deletions, [400, 401]);
   assert.equal(summary.checked, 2);
@@ -420,11 +489,7 @@ test("backfill rotates beyond genuinely stuck oldest items without a persisted c
     ]),
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now: rotatedNow,
-  });
+  const summary = await runBackfill(fixture, { now: rotatedNow });
 
   assert.deepEqual(fixture.searchPages, [1, 2]);
   assert.deepEqual(fixture.deletions, [resolved]);
@@ -446,11 +511,7 @@ test("backfill finds canonical review ownership on a bounded later comments page
     comments: new Map([[500, [...noise, completedReview(500)]]]),
   });
 
-  const summary = await runReviewRecoveryLabelBackfill({
-    env,
-    fetchImpl: fixture.fetchImpl,
-    now,
-  });
+  const summary = await runBackfill(fixture);
 
   assert.deepEqual(fixture.commentPages, [
     { number: 500, page: 1 },
@@ -460,19 +521,30 @@ test("backfill finds canonical review ownership on a bounded later comments page
   assert.equal(summary.cleared, 1);
 });
 
-test("backfill refuses to use the read token for target-repository writes", async () => {
-  let requests = 0;
-  await assert.rejects(
-    () =>
-      runReviewRecoveryLabelBackfill({
-        env: { ...env, TARGET_WRITE_TOKEN: "" },
-        fetchImpl: (async () => {
-          requests += 1;
-          return Response.json({});
-        }) as typeof fetch,
-        now,
-      }),
-    /missing read token, target write token, or valid target repository/,
+test("backfill refuses cleanup when bounded comment pagination is incomplete", async () => {
+  const canonical = completedReview(510);
+  const noise = Array.from({ length: 299 }, (_, index) =>
+    completedReview(510, { user: { login: `other-${index}[bot]`, type: "Bot" } }),
   );
-  assert.equal(requests, 0);
+  const fixture = githubFixture({
+    numbers: [510],
+    comments: new Map([[510, [canonical, ...noise]]]),
+  });
+
+  const summary = await runBackfill(fixture);
+
+  assert.equal(fixture.commentPages.length, 3);
+  assert.deepEqual(fixture.deletions, []);
+  assert.equal(summary.cleared, 0);
+  assert.equal(summary.retained, 1);
+});
+
+test("backfill never invokes label removal without trusted canonical completion", async () => {
+  const fixture = githubFixture({
+    numbers: [501],
+    comments: new Map([[501, [startedPlaceholder(501, "2026-08-05T09:00:00.000Z")]]]),
+  });
+  const summary = await runBackfill(fixture);
+  assert.deepEqual(fixture.deletions, []);
+  assert.equal(summary.retained, 1);
 });

--- a/test/review-recovery-label-backfill.test.ts
+++ b/test/review-recovery-label-backfill.test.ts
@@ -1,0 +1,478 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearResolvedReviewRecoveryLabel,
+  REVIEW_RECOVERY_STUCK_LABEL,
+  runReviewRecoveryLabelBackfill,
+} from "../dist/review-recovery-label-backfill.js";
+
+const now = new Date("2026-08-05T12:00:00.000Z");
+const trustedBot = { login: "clawsweeper[bot]", type: "Bot" };
+const env = {
+  GH_TOKEN: "read-token",
+  TARGET_WRITE_TOKEN: "target-write-token",
+  TARGET_REPO: "openclaw/openclaw",
+  GITHUB_API_URL: "https://api.github.test",
+};
+
+type TestComment = {
+  body: string;
+  created_at?: string;
+  updated_at?: string;
+  user: { login: string; type: string };
+};
+
+function completedReview(
+  number: number,
+  options: {
+    at?: string;
+    reviewedAt?: string;
+    sha?: string;
+    user?: { login: string; type: string };
+    body?: string;
+  } = {},
+): TestComment {
+  const at = options.at ?? "2026-08-05T10:00:00.000Z";
+  const version = options.reviewedAt
+    ? `\n\n<!-- clawsweeper-review-version item=${number} reviewed_at=${options.reviewedAt}${options.sha ? ` sha=${options.sha}` : ""} v=1 -->`
+    : "";
+  return {
+    body:
+      options.body ??
+      `ClawSweeper review: keep open.${version}\n\n<!-- clawsweeper-review item=${number} -->`,
+    created_at: at,
+    updated_at: at,
+    user: options.user ?? trustedBot,
+  };
+}
+
+function startedPlaceholder(number: number, at: string): TestComment {
+  return {
+    body: `ClawSweeper status: review started.\n\n<!-- clawsweeper-review-status:started item=${number} sha=abc v=1 -->\n\n<!-- clawsweeper-review item=${number} -->`,
+    created_at: at,
+    updated_at: at,
+    user: trustedBot,
+  };
+}
+
+function githubFixture(options: {
+  numbers: number[];
+  comments: Map<number, TestComment[]>;
+  pullHeads?: Map<number, string | undefined>;
+  searchPages?: Map<number, number[]>;
+  deleteStatus?: number;
+  totalCount?: number;
+}) {
+  const deletions: number[] = [];
+  const commentPages: { number: number; page: number }[] = [];
+  const searchPages: number[] = [];
+  const fetchImpl = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const headers = new Headers(init?.headers);
+
+    if (url.pathname === "/search/issues") {
+      assert.equal(headers.get("authorization"), "Bearer read-token");
+      assert.equal(
+        url.searchParams.get("q"),
+        `repo:openclaw/openclaw is:open label:"${REVIEW_RECOVERY_STUCK_LABEL}"`,
+      );
+      const page = Number(url.searchParams.get("page"));
+      searchPages.push(page);
+      const numbers = options.searchPages?.get(page) ?? options.numbers;
+      return Response.json({
+        items: numbers.map((number) => ({
+          number,
+          ...(options.pullHeads?.has(number) ? { pull_request: { url: "pull-request" } } : {}),
+        })),
+        total_count: options.totalCount ?? options.numbers.length,
+      });
+    }
+
+    const pullMatch = url.pathname.match(/^\/repos\/openclaw\/openclaw\/pulls\/(\d+)$/);
+    if (pullMatch?.[1]) {
+      assert.equal(headers.get("authorization"), "Bearer read-token");
+      const sha = options.pullHeads?.get(Number(pullMatch[1]));
+      return Response.json({ head: sha ? { sha } : {} });
+    }
+
+    const commentMatch = url.pathname.match(
+      /^\/repos\/openclaw\/openclaw\/issues\/(\d+)\/comments$/,
+    );
+    if (commentMatch?.[1]) {
+      assert.equal(headers.get("authorization"), "Bearer read-token");
+      const number = Number(commentMatch[1]);
+      const page = Number(url.searchParams.get("page"));
+      const pageSize = Number(url.searchParams.get("per_page"));
+      commentPages.push({ number, page });
+      const comments = options.comments.get(number) ?? [];
+      return Response.json(comments.slice((page - 1) * pageSize, page * pageSize));
+    }
+
+    const labelMatch = url.pathname.match(
+      /^\/repos\/openclaw\/openclaw\/issues\/(\d+)\/labels\/clawsweeper-recovery-stuck$/,
+    );
+    if (labelMatch?.[1]) {
+      assert.equal(init?.method, "DELETE");
+      assert.equal(headers.get("authorization"), "Bearer target-write-token");
+      deletions.push(Number(labelMatch[1]));
+      return new Response(null, { status: options.deleteStatus ?? 204 });
+    }
+
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  return { fetchImpl: fetchImpl as typeof fetch, deletions, commentPages, searchPages };
+}
+
+test("completed publication clears its recovery label and preserves other labels", () => {
+  const labels = ["priority: high", REVIEW_RECOVERY_STUCK_LABEL, "maturity: ready"];
+  const calls: { number: number; label: string; onMutation?: () => void }[] = [];
+  const onMutation = () => {};
+
+  assert.equal(
+    clearResolvedReviewRecoveryLabel({
+      number: 112370,
+      labels,
+      complete: true,
+      removeLabel: (number, label, callback) => {
+        calls.push({ number, label, ...(callback ? { onMutation: callback } : {}) });
+      },
+      onMutation,
+    }),
+    true,
+  );
+  assert.deepEqual(labels, ["priority: high", "maturity: ready"]);
+  assert.deepEqual(calls, [{ number: 112370, label: REVIEW_RECOVERY_STUCK_LABEL, onMutation }]);
+});
+
+test("incomplete publication and an absent recovery label never mutate", () => {
+  for (const options of [
+    { complete: false, labels: [REVIEW_RECOVERY_STUCK_LABEL] },
+    { complete: true, labels: ["priority: high"] },
+  ]) {
+    assert.equal(
+      clearResolvedReviewRecoveryLabel({
+        number: 112370,
+        ...options,
+        removeLabel: () => assert.fail("unexpected label mutation"),
+      }),
+      false,
+    );
+  }
+});
+
+test("failed recovery-label removal preserves local labels and propagates its error", () => {
+  const labels = [REVIEW_RECOVERY_STUCK_LABEL];
+  assert.throws(
+    () =>
+      clearResolvedReviewRecoveryLabel({
+        number: 112370,
+        labels,
+        complete: true,
+        removeLabel: () => {
+          throw new Error("GitHub refused the label mutation");
+        },
+      }),
+    /GitHub refused the label mutation/,
+  );
+  assert.deepEqual(labels, [REVIEW_RECOVERY_STUCK_LABEL]);
+});
+
+test("recovery-label backfill clears only trusted, canonical completed reviews", async () => {
+  const numbers = [101, 102, 103, 104, 105, 106, 107];
+  const fixture = githubFixture({
+    numbers,
+    comments: new Map([
+      [101, [completedReview(101)]],
+      [102, [completedReview(102, { user: { login: "clawsweeper[bot]", type: "User" } })]],
+      [103, [completedReview(103, { user: { login: "untrusted[bot]", type: "Bot" } })]],
+      [104, [completedReview(999)]],
+      [105, [startedPlaceholder(105, "2026-08-05T08:00:00.000Z")]],
+      [
+        106,
+        [
+          completedReview(106, {
+            body: "ClawSweeper review: stale.\n\n<!-- clawsweeper-review-status:stale item=106 v=1 -->\n\n<!-- clawsweeper-review item=106 -->",
+          }),
+        ],
+      ],
+      [
+        107,
+        [
+          completedReview(107, {
+            user: { login: "openclaw-clawsweeper[bot]", type: "Bot" },
+          }),
+        ],
+      ],
+    ]),
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.deletions, [101, 107]);
+  assert.deepEqual(summary, {
+    checked: 7,
+    cleared: 2,
+    alreadyCleared: 0,
+    retained: 5,
+    errors: 0,
+    matched: 7,
+    remaining: 0,
+  });
+});
+
+test("a newer started lease overrides old review publication and unrelated comment edits", async () => {
+  const missingPlaceholderTimestamp = startedPlaceholder(203, "2026-08-05T09:00:00.000Z");
+  delete missingPlaceholderTimestamp.created_at;
+  delete missingPlaceholderTimestamp.updated_at;
+  const fixture = githubFixture({
+    numbers: [201, 202, 203],
+    comments: new Map([
+      [
+        201,
+        [
+          completedReview(201, {
+            at: "2026-08-05T11:30:00.000Z",
+            reviewedAt: "2026-08-05T08:00:00.000Z",
+          }),
+          startedPlaceholder(201, "2026-08-05T10:00:00.000Z"),
+        ],
+      ],
+      [
+        202,
+        [
+          startedPlaceholder(202, "2026-08-05T09:00:00.000Z"),
+          completedReview(202, {
+            at: "2026-08-05T11:00:00.000Z",
+            reviewedAt: "2026-08-05T10:00:00.000Z",
+          }),
+        ],
+      ],
+      [203, [completedReview(203), missingPlaceholderTimestamp]],
+    ]),
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.deletions, [202]);
+  assert.equal(summary.cleared, 1);
+  assert.equal(summary.retained, 2);
+  assert.equal(summary.errors, 0);
+});
+
+test("pull-request cleanup requires a completed durable review of its exact live head", async () => {
+  const currentHead = "a".repeat(40);
+  const oldHead = "b".repeat(40);
+  const fixture = githubFixture({
+    numbers: [211, 212, 213, 214],
+    pullHeads: new Map([
+      [211, currentHead],
+      [212, currentHead],
+      [213, currentHead],
+      [214, undefined],
+    ]),
+    comments: new Map([
+      [
+        211,
+        [
+          completedReview(211, {
+            reviewedAt: "2026-08-05T10:00:00.000Z",
+            sha: currentHead.toUpperCase(),
+          }),
+        ],
+      ],
+      [
+        212,
+        [
+          completedReview(212, {
+            reviewedAt: "2026-08-05T10:00:00.000Z",
+            sha: oldHead,
+          }),
+        ],
+      ],
+      [213, [completedReview(213)]],
+      [
+        214,
+        [
+          completedReview(214, {
+            reviewedAt: "2026-08-05T10:00:00.000Z",
+            sha: currentHead,
+          }),
+        ],
+      ],
+    ]),
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.deletions, [211]);
+  assert.equal(summary.checked, 4);
+  assert.equal(summary.cleared, 1);
+  assert.equal(summary.retained, 3);
+  assert.equal(summary.errors, 0);
+});
+
+test("backfill treats a missing label as an idempotent result without claiming removal", async () => {
+  const fixture = githubFixture({
+    numbers: [301],
+    comments: new Map([[301, [completedReview(301)]]]),
+    deleteStatus: 404,
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.deletions, [301]);
+  assert.equal(summary.alreadyCleared, 1);
+  assert.equal(summary.cleared, 0);
+  assert.equal(summary.errors, 0);
+});
+
+test("backfill reports forbidden label removal without claiming cleanup", async (t) => {
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (message: string) => warnings.push(message));
+  const fixture = githubFixture({
+    numbers: [302],
+    comments: new Map([[302, [completedReview(302)]]]),
+    deleteStatus: 403,
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.deletions, [302]);
+  assert.equal(summary.cleared, 0);
+  assert.equal(summary.alreadyCleared, 0);
+  assert.equal(summary.errors, 1);
+  assert.match(warnings[0] ?? "", /returned 403/);
+});
+
+test("backfill enforces the existing recovery limits and reports its remaining backlog", async () => {
+  const numbers = Array.from({ length: 8 }, (_, index) => 400 + index);
+  const fixture = githubFixture({
+    numbers,
+    comments: new Map(numbers.map((number) => [number, [completedReview(number)]])),
+    totalCount: 753,
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env: {
+      ...env,
+      REVIEW_PLACEHOLDER_MAX_CHECKS: "4",
+      REVIEW_PLACEHOLDER_MAX_RECOVERIES: "2",
+    },
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.deletions, [400, 401]);
+  assert.equal(summary.checked, 2);
+  assert.equal(summary.cleared, 2);
+  assert.equal(summary.matched, 753);
+  assert.equal(summary.remaining, 751);
+});
+
+test("backfill rotates beyond genuinely stuck oldest items without a persisted cursor", async () => {
+  const rotationMs = 15 * 60 * 1_000;
+  const currentSlot = Math.floor(now.getTime() / rotationMs);
+  const secondPageSlot = currentSlot + ((1 - (currentSlot % 3) + 3) % 3);
+  const rotatedNow = new Date(secondPageSlot * rotationMs);
+  const genuinelyStuck = Array.from({ length: 20 }, (_, index) => 600 + index);
+  const resolved = 620;
+  const fixture = githubFixture({
+    numbers: genuinelyStuck,
+    totalCount: 60,
+    searchPages: new Map([
+      [1, genuinelyStuck],
+      [2, [resolved]],
+    ]),
+    comments: new Map([
+      ...genuinelyStuck.map(
+        (number) =>
+          [number, [startedPlaceholder(number, "2026-08-05T08:00:00.000Z")]] as [
+            number,
+            TestComment[],
+          ],
+      ),
+      [resolved, [completedReview(resolved)]],
+    ]),
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now: rotatedNow,
+  });
+
+  assert.deepEqual(fixture.searchPages, [1, 2]);
+  assert.deepEqual(fixture.deletions, [resolved]);
+  assert.equal(summary.checked, 1);
+  assert.equal(summary.cleared, 1);
+  assert.equal(summary.matched, 60);
+  assert.equal(summary.remaining, 59);
+});
+
+test("backfill finds canonical review ownership on a bounded later comments page", async () => {
+  const noise = Array.from({ length: 100 }, (_, index) =>
+    completedReview(500, {
+      at: new Date(now.getTime() - index * 1_000).toISOString(),
+      user: { login: `other-${index}[bot]`, type: "Bot" },
+    }),
+  );
+  const fixture = githubFixture({
+    numbers: [500],
+    comments: new Map([[500, [...noise, completedReview(500)]]]),
+  });
+
+  const summary = await runReviewRecoveryLabelBackfill({
+    env,
+    fetchImpl: fixture.fetchImpl,
+    now,
+  });
+
+  assert.deepEqual(fixture.commentPages, [
+    { number: 500, page: 1 },
+    { number: 500, page: 2 },
+  ]);
+  assert.deepEqual(fixture.deletions, [500]);
+  assert.equal(summary.cleared, 1);
+});
+
+test("backfill refuses to use the read token for target-repository writes", async () => {
+  let requests = 0;
+  await assert.rejects(
+    () =>
+      runReviewRecoveryLabelBackfill({
+        env: { ...env, TARGET_WRITE_TOKEN: "" },
+        fetchImpl: (async () => {
+          requests += 1;
+          return Response.json({});
+        }) as typeof fetch,
+        now,
+      }),
+    /missing read token, target write token, or valid target repository/,
+  );
+  assert.equal(requests, 0);
+});

--- a/test/review-recovery-label-backfill.test.ts
+++ b/test/review-recovery-label-backfill.test.ts
@@ -388,6 +388,45 @@ test("failed infrastructure reviews never clear issue or exact-head pull-request
   assert.equal(summary.retained, 2);
 });
 
+test("a newer failed canonical review blocks recovery until a later successful review", async () => {
+  const sha = "d".repeat(40);
+  const failedReview = (number: number, at: string, pull = false): TestComment => {
+    const comment = completedReview(number, {
+      at,
+      ...(pull ? { reviewedAt: at, sha } : {}),
+    });
+    comment.body = comment.body.replace(
+      "ClawSweeper review: keep open.",
+      "ClawSweeper review: did not complete due to Codex infrastructure failure.",
+    );
+    return comment;
+  };
+  const successReview = (number: number, at: string, pull = false) =>
+    completedReview(number, { at, ...(pull ? { reviewedAt: at, sha } : {}) });
+  const older = "2026-08-05T08:00:00.000Z";
+  const newer = "2026-08-05T10:00:00.000Z";
+  const fixture = githubFixture({
+    numbers: [223, 224, 225, 226],
+    pullHeads: new Map([
+      [225, sha],
+      [226, sha],
+    ]),
+    comments: new Map([
+      [223, [successReview(223, older), failedReview(223, newer)]],
+      [224, [successReview(224, newer), failedReview(224, older)]],
+      [225, [failedReview(225, newer, true), successReview(225, older, true)]],
+      [226, [failedReview(226, older, true), successReview(226, newer, true)]],
+    ]),
+  });
+
+  const summary = await runBackfill(fixture);
+
+  assert.deepEqual(fixture.deletions, [224, 226]);
+  assert.equal(summary.cleared, 2);
+  assert.equal(summary.retained, 2);
+  assert.equal(summary.errors, 0);
+});
+
 test("legacy created-only timestamps and human-only placeholders remain conservative", async () => {
   const legacyReview = completedReview(231, { at: "2026-08-05T10:00:00.000Z" });
   const oldPlaceholder = startedPlaceholder(231, "2026-08-05T09:00:00.000Z");


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper incorrectly blocked https://github.com/openclaw/openclaw/pull/112370 despite real production-owner transport evidence, left hundreds of obsolete recovery labels behind, contradicted its own maintainer proof exemption, and exhausted a shared GitHub App installation quota with concurrent publication retries.

## Changes

- Apply scoped AGENTS guidance only to changed-path ancestors and accept real production-owner transport/fault-boundary proof while preserving contributor, browser, auth, and security safeguards.
- Normalize maintainer and bot proof exemptions once at the report parser so verdicts, ratings, labels, and public review agree.
- Remove recovery-stuck labels after completed publication; reconcile historical open items through the existing scheduled recovery lane, with trusted markers, exact current PR heads, failed-review chronology, bounded pagination, and five-write caps.
- Reduce publication GitHub clients from 32 to 8 and bound batch-only retry attempts while preserving durable retry outcomes.
- Recognize both the existing and renamed PR evidence check before https://github.com/openclaw/openclaw/pull/119610 lands.

## Evidence

- Main, repair, and dashboard TypeScript builds all pass.
- 150 combined proof, recovery, parser, compatibility, and publication regressions pass.
- Recovery-specific coverage: 100% lines, 100% functions; 27 end-to-end apply tests and 113 reconciler/workflow tests passed independently.
- Independent review reproduced and corrected a newer-failed-review edge case, then verified no actionable findings.
- External contributor proof still blocks without evidence; maintainers/bots preserve valid evidence; security findings remain blocking.
- No dashboard or Worker deployment is required.