### PR TITLE
fix(github): reserve App quota for privileged operations

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -195,6 +195,7 @@ jobs:
         id: route-comments
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ github.token }}
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
@@ -351,6 +352,7 @@ jobs:
         if: ${{ steps.waiting-repair-dispatches.outputs.count != '' && steps.waiting-repair-dispatches.outputs.count != '0' }}
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ github.token }}
           CLAWSWEEPER_DISPATCH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
           CLAWSWEEPER_MUTATION_TOKEN_SOURCE: clawsweeper-app
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -723,7 +723,7 @@ jobs:
         id: live-item
         env:
           CLAIM_DECISION: ${{ steps.claim-exact-review-queue.outputs.decision }}
-          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
+          GH_TOKEN: ${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
           CLAIM_TARGET_BRANCH: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).targetBranch }}

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -151,7 +151,7 @@ export function ghPagedLimitWithRetry<T = JsonValue>(
 }
 
 export function ghText(ghArgs: string[], options: GhRunOptions = {}): string {
-  const env = ghEnv(options.env);
+  const env = ghCommandEnv(ghArgs, options);
   const command = ghCommand(ghArgs, env);
   const text = execFileSync(command.command, command.args, {
     cwd: options.cwd ?? repoRoot(),
@@ -203,7 +203,7 @@ export async function ghTextWithRetryAsync(
 
 export async function ghTextAsync(ghArgs: string[], options: GhRunOptions = {}): Promise<string> {
   if (options.input !== undefined) return ghText(ghArgs, options);
-  const env = ghEnv(options.env);
+  const env = ghCommandEnv(ghArgs, options);
   const command = ghCommand(ghArgs, env);
   const { stdout } = await execFileAsync(command.command, command.args, {
     cwd: options.cwd ?? repoRoot(),
@@ -247,6 +247,50 @@ export function ghSpawn(ghArgs: string[], options: GhRunOptions = {}) {
 
 export function ghEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return ghCliEnv(overrides);
+}
+
+function ghCommandEnv(ghArgs: readonly string[], options: GhRunOptions): NodeJS.ProcessEnv {
+  const overrides = options.env ?? {};
+  const env = ghEnv(overrides);
+  const publicToken = process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN?.trim();
+  if (
+    !publicToken ||
+    options.input !== undefined ||
+    Object.hasOwn(overrides, "GH_TOKEN") ||
+    Object.hasOwn(overrides, "GITHUB_TOKEN") ||
+    (env.GH_HOST && env.GH_HOST.toLowerCase() !== "github.com") ||
+    !isPublicOpenClawReadOnlyRequest(ghArgs)
+  ) {
+    return env;
+  }
+  return ghEnv({ ...overrides, GH_TOKEN: publicToken });
+}
+
+function isPublicOpenClawReadOnlyRequest(ghArgs: readonly string[]): boolean {
+  if (ghArgs[0] !== "api") return false;
+  const endpoint = ghArgs[1] ?? "";
+  const endpointPath = endpoint.split("?", 1)[0] ?? "";
+  if (!/^repos\/openclaw\/openclaw\/(?:issues|pulls)(?:\/|$)/.test(endpointPath)) {
+    return false;
+  }
+  if (
+    endpointPath.includes("\\") ||
+    endpointPath.split("/").some((segment) => segment === "." || segment === "..") ||
+    /%(?:2e|2f|5c)/i.test(endpointPath)
+  ) {
+    return false;
+  }
+
+  for (let index = 2; index < ghArgs.length; index += 1) {
+    const flag = ghArgs[index];
+    if (flag === "--paginate" || flag === "--slurp") continue;
+    if ((flag === "--jq" || flag === "-q") && index + 1 < ghArgs.length) {
+      index += 1;
+      continue;
+    }
+    return false;
+  }
+  return true;
 }
 
 export function ghErrorText(error: unknown): string {

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -54,6 +54,25 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
   }
 });
 
+test("comment router isolates public target reads from its GitHub App mutation identity", () => {
+  const source = readText("src/repair/github-cli.ts");
+  const workflow = readText(".github/workflows/repair-comment-router.yml");
+
+  assert.equal(
+    workflow.match(/CLAWSWEEPER_PUBLIC_GH_TOKEN: \$\{\{ github\.token \}\}/g)?.length,
+    2,
+  );
+  assert.equal(
+    workflow.match(/GH_TOKEN: \$\{\{ steps\.app_token\.outputs\.token \}\}/g)?.length,
+    2,
+  );
+  assert.match(source, /process\.env\.CLAWSWEEPER_PUBLIC_GH_TOKEN\?\.trim\(\)/);
+  assert.match(source, /Object\.hasOwn\(overrides, "GH_TOKEN"\)/);
+  assert.match(source, /Object\.hasOwn\(overrides, "GITHUB_TOKEN"\)/);
+  assert.match(source, /function isPublicOpenClawReadOnlyRequest/);
+  assert.match(source, /repos\\\/openclaw\\\/openclaw\\\/\(\?:issues\|pulls\)/);
+});
+
 test("exact comment convergence classifies a missing comment as no mutation", () => {
   const source = readText("src/repair/comment-router.ts");
   const fastPath = source.slice(source.indexOf("function convergeExactCommentVersionFastPathAck"));

--- a/test/repair/github-cli.test.ts
+++ b/test/repair/github-cli.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { githubLimitedPagePath, githubPaginatedPath } from "../../dist/repair/github-cli.js";
+import {
+  ghJson,
+  ghJsonWithRetryAsync,
+  ghSpawn,
+  githubLimitedPagePath,
+  githubPaginatedPath,
+} from "../../dist/repair/github-cli.js";
 
 test("githubPaginatedPath requests maximum REST page size by default", () => {
   assert.equal(
@@ -35,4 +41,93 @@ test("githubLimitedPagePath caps one REST page and preserves existing filters", 
     githubLimitedPagePath("repos/openclaw/openclaw/pulls/123/files", 0, 0),
     "repos/openclaw/openclaw/pulls/123/files?per_page=1&page=1",
   );
+});
+
+test("public target reads preserve GitHub App mutations and every explicit credential", async () => {
+  const fixtureEnv = {
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([
+      "--eval",
+      "process.stdout.write(JSON.stringify({ token: process.env.GH_TOKEN, args: process.argv.slice(1) }))",
+      "--",
+    ]),
+    GH_TOKEN: "app-mutation-token",
+    CLAWSWEEPER_PUBLIC_GH_TOKEN: "public-read-token",
+  };
+  const previous = Object.fromEntries(
+    Object.keys(fixtureEnv).map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, fixtureEnv);
+
+  const observed = (args: string[], options?: { env?: NodeJS.ProcessEnv; input?: string }) =>
+    ghJson<{ token: string; args: string[] }>(args, options);
+
+  try {
+    for (const args of [
+      ["api", "repos/openclaw/openclaw/issues/comments/123"],
+      ["api", "repos/openclaw/openclaw/issues/123"],
+      ["api", "repos/openclaw/openclaw/issues?state=open&per_page=100"],
+      ["api", "repos/openclaw/openclaw/issues/123/comments?per_page=100", "--paginate", "--slurp"],
+      ["api", "repos/openclaw/openclaw/pulls/123/reviews?per_page=100"],
+      ["api", "repos/openclaw/openclaw/pulls/123", "--jq", ".requested_reviewers"],
+    ]) {
+      assert.equal(observed(args).token, "public-read-token", args.join(" "));
+    }
+
+    assert.equal(
+      (await ghJsonWithRetryAsync<{ token: string }>(["api", "repos/openclaw/openclaw/issues/123"]))
+        .token,
+      "public-read-token",
+    );
+
+    for (const args of [
+      ["api", "user"],
+      ["api", "repos/openclaw/openclaw/collaborators/person/permission"],
+      ["api", "repos/openclaw/clawsweeper/issues/123"],
+      ["api", "repos/private/secret/issues/123"],
+      ["api", "https://api.github.com/repos/openclaw/openclaw/issues/123"],
+      ["api", "repos/openclaw/openclaw/issues/../../clawsweeper/issues/123"],
+      ["api", "repos/openclaw/openclaw/issues/%2e%2e/clawsweeper"],
+      ["api", "repos/openclaw/openclaw/issues%2f123"],
+      ["api", "repos/openclaw/openclaw/issues\\123"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--method", "GET"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--method", "POST"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--method=DELETE"],
+      ["api", "repos/openclaw/openclaw/issues/123", "-X", "PATCH"],
+      ["api", "repos/openclaw/openclaw/issues/123", "-XDELETE"],
+      ["api", "repos/openclaw/openclaw/issues/123", "-f", "body=mutated"],
+      ["api", "repos/openclaw/openclaw/issues/123", "-F", "body=mutated"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--field=body=mutated"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--raw-field", "body=mutated"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--input", "payload.json"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--header", "X-HTTP-Method-Override: DELETE"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--hostname", "example.invalid"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--jq"],
+      ["pr", "view", "123", "--repo", "openclaw/openclaw"],
+    ]) {
+      assert.equal(observed(args).token, "app-mutation-token", args.join(" "));
+    }
+
+    const publicArgs = ["api", "repos/openclaw/openclaw/issues/comments/123"];
+    assert.equal(
+      observed(publicArgs, { env: { GH_TOKEN: "explicit-dispatch-token" } }).token,
+      "explicit-dispatch-token",
+    );
+    assert.equal(
+      observed(publicArgs, { env: { GITHUB_TOKEN: "explicit-token" } }).token,
+      "app-mutation-token",
+    );
+    assert.equal(observed(publicArgs, { input: "request body" }).token, "app-mutation-token");
+
+    const spawned = ghSpawn(publicArgs);
+    assert.equal(JSON.parse(spawned.stdout).token, "app-mutation-token");
+
+    delete process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN;
+    assert.equal(observed(publicArgs).token, "app-mutation-token");
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
 });

--- a/test/repair/process-env.test.ts
+++ b/test/repair/process-env.test.ts
@@ -21,6 +21,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       CLAWSWEEPER_GIT_USER_NAME: "clawsweeper-repair",
       CLAWSWEEPER_GIT_USER_EMAIL: "bot@example.invalid",
       CLAWSWEEPER_TARGET_GH_TOKEN: "secret",
+      CLAWSWEEPER_PUBLIC_GH_TOKEN: "public-read-secret",
       GH_TOKEN: "secret",
       GITHUB_TOKEN: "secret",
       GITHUB_ACTIONS: "true",
@@ -45,6 +46,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       assert.equal(env.GH_TOKEN, undefined);
       assert.equal(env.GITHUB_TOKEN, undefined);
       assert.equal(env.CLAWSWEEPER_TARGET_GH_TOKEN, undefined);
+      assert.equal(env.CLAWSWEEPER_PUBLIC_GH_TOKEN, undefined);
       assert.equal(env.OPENAI_API_KEY, undefined);
       assert.equal(env.CODEX_API_KEY, undefined);
       assert.equal(env.CLAWSWEEPER_INTERNAL_MODEL, undefined);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -649,6 +649,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     liveItem.env?.CLAIM_DECISION,
     "${{ steps.claim-exact-review-queue.outputs.decision }}",
   );
+  assert.equal(
+    liveItem.env?.GH_TOKEN,
+    "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}",
+  );
   assert.match(liveItem.run ?? "", /grep -Eq '\^\[0-9\]\+\$'/);
   assert.match(
     liveItem.run ?? "",


### PR DESCRIPTION
## Why

Production routers and review admission repeatedly fail with HTTP 403 for GitHub App installation 122230863 because public reads share the limited installation quota required for bot authorization and mutations.

## Change

- Route only read-only REST requests for the exact public openclaw/openclaw issue and PR endpoints through the existing workflow token.
- Keep private repositories, explicit credentials, GraphQL, collaborator checks, actor verification, every mutation, and every untrusted subprocess on their original credential boundaries.
- Use the workflow token only for the public pre-review live-item check; keep reviewer execution and bot writes on scoped App tokens.
- Preserve all existing workflows and avoid a dashboard Worker deployment.

## Verification

- 129 focused router, workflow, security, and environment tests passed.
- 42 independent adversarial credential-boundary cases passed.
- Main and repair TypeScript builds, lint, formatting, and an independent security review passed.
- Production baseline before this fix: 50 throttle-deferred reviews and 62 publication retries versus six resolutions over 15 minutes.