### PR TITLE
fix(review): verify redacted maintainers before proof gating

### DIFF
--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -2,6 +2,10 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ACTION_EVENT_REASON_CODES, ACTION_EVENT_STATUSES } from "./action-ledger.js";
 import type { Args } from "./clawsweeper-args.js";
+import {
+  isBulkFilerExemptRepositoryPermission as isVerifiedMaintainerRepositoryPermission,
+  isMaintainerAuthorAssociation,
+} from "./clawsweeper-item-policy.js";
 import { mediaProofRuntimeHints, prepareMediaProofArtifacts } from "./clawsweeper-media-proof.js";
 import type {
   AcquiredReviewStartLease,
@@ -38,6 +42,29 @@ import {
 import { reviewContentCacheHit } from "./scheduler-policy.js";
 import type { CreateReviewCommandWorkflowDependencies } from "./clawsweeper-review-command-dependencies.js";
 import { prepareReviewCommand } from "./clawsweeper-review-preparation.js";
+
+export function restoreVerifiedMaintainerPullRequestAuthorAssociation(
+  item: Pick<Item, "kind" | "author" | "authorAssociation" | "labels">,
+  repositoryPermission: (author: string) => string | null,
+): boolean {
+  if (
+    item.kind !== "pull_request" ||
+    !item.author.trim() ||
+    isMaintainerAuthorAssociation(item.authorAssociation) ||
+    !item.labels.some((label) => label.trim().toLowerCase() === "maintainer")
+  ) {
+    return false;
+  }
+  let permission: string | null;
+  try {
+    permission = repositoryPermission(item.author);
+  } catch {
+    return false;
+  }
+  if (!isVerifiedMaintainerRepositoryPermission(permission)) return false;
+  item.authorAssociation = "MEMBER";
+  return true;
+}
 
 export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWorkflowDependencies) {
   const {
@@ -238,6 +265,11 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
       const leaseAcquisitionFailureDetails: string[] = [];
       // oxfmt-ignore
       for (const item of candidates) {
+        const restoredMaintainerAssociation =
+          !localOnly &&
+          restoreVerifiedMaintainerPullRequestAuthorAssociation(item, (author) =>
+            bulkFilerRepositoryPermission(author, bulkFilerRepositoryPermissionCache),
+          );
         activeReviewItem = item;
         let reviewItemFailed = false;
         const previousReviewMutationRunner = dependencies.activeReviewMutationRunner;
@@ -301,9 +333,16 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           )
             ? null
             : existingPriorReview;
-        if (bulkFilerPolicyInvalidatesCachedReview(priorReview?.markdown ?? null, bulkFilerExemptionApplied)) {
-          // A prior full review was made under a now-inapplicable bulk-filer policy.
-          // Re-run it instead of refreshing its cached suppression fields.
+        if (
+          (restoredMaintainerAssociation &&
+            priorReview !== null &&
+            !isMaintainerAuthorAssociation(
+              frontMatterValue(priorReview.markdown, "author_association"),
+            )) ||
+          bulkFilerPolicyInvalidatesCachedReview(priorReview?.markdown ?? null, bulkFilerExemptionApplied)
+        ) {
+          // Ownership and bulk-filer policy changes require a fresh decision;
+          // carrying stale front matter would preserve the wrong safeguards.
           priorReview = null;
         }
         const expectedPreviousReviewDigest = priorReview

--- a/test/pr-proof-automation.test.ts
+++ b/test/pr-proof-automation.test.ts
@@ -8,6 +8,7 @@ import {
   renderReviewCommentFromReport,
   reviewAutomationMarkersFromReport,
 } from "../dist/clawsweeper.js";
+import { restoreVerifiedMaintainerPullRequestAuthorAssociation } from "../dist/clawsweeper-review-command-workflow.js";
 import {
   changelogReviewDecision,
   item,
@@ -302,6 +303,94 @@ Full review comments:
     assert.doesNotMatch(comment, /status: 📣 needs proof/, scenario.author);
     assert.match(markers, /clawsweeper-verdict:pass/, scenario.author);
     assert.doesNotMatch(markers, /clawsweeper-verdict:needs-human/, scenario.author);
+  }
+
+  for (const permission of ["admin", "maintain"]) {
+    const canary = item({
+      kind: "pull_request",
+      number: 113345,
+      author: "steipete",
+      authorAssociation: "CONTRIBUTOR",
+      labels: ["maintainer", "size: XS", "status: 📣 needs proof"],
+    });
+    const redactedReport = reportFor({
+      author: canary.author,
+      association: canary.authorAssociation,
+      status: "mock_only",
+    });
+    assert.match(
+      renderReviewCommentFromReport(redactedReport, "none"),
+      /blocked until real behavior proof from a real setup is added/i,
+    );
+    let lookups = 0;
+    assert.equal(
+      restoreVerifiedMaintainerPullRequestAuthorAssociation(canary, (author) => {
+        lookups += 1;
+        assert.equal(author, "steipete");
+        return permission;
+      }),
+      true,
+    );
+    assert.equal(lookups, 1);
+    assert.equal(canary.authorAssociation, "MEMBER");
+
+    const correctedReport = reportFor({
+      author: canary.author,
+      association: canary.authorAssociation,
+      status: "mock_only",
+    });
+    assert.match(
+      renderReviewCommentFromReport(correctedReport, "none"),
+      /✅ \*\*Ready for maintainer review\*\*/,
+    );
+    assert.match(reviewAutomationMarkersFromReport(correctedReport), /clawsweeper-verdict:pass/);
+  }
+
+  for (const permission of ["write", "read", null]) {
+    const unverified = item({
+      kind: "pull_request",
+      author: "external",
+      authorAssociation: "CONTRIBUTOR",
+      labels: ["maintainer"],
+    });
+    assert.equal(
+      restoreVerifiedMaintainerPullRequestAuthorAssociation(unverified, () => permission),
+      false,
+      String(permission),
+    );
+    assert.equal(unverified.authorAssociation, "CONTRIBUTOR");
+  }
+
+  const unavailable = item({
+    kind: "pull_request",
+    authorAssociation: "CONTRIBUTOR",
+    labels: ["maintainer"],
+  });
+  assert.equal(
+    restoreVerifiedMaintainerPullRequestAuthorAssociation(unavailable, () => {
+      throw new Error("GitHub permission lookup failed");
+    }),
+    false,
+  );
+  assert.equal(unavailable.authorAssociation, "CONTRIBUTOR");
+
+  for (const ineligible of [
+    item({ kind: "issue", authorAssociation: "CONTRIBUTOR", labels: ["maintainer"] }),
+    item({ kind: "pull_request", authorAssociation: "CONTRIBUTOR", labels: [] }),
+    item({ kind: "pull_request", authorAssociation: "OWNER", labels: ["maintainer"] }),
+    item({ kind: "pull_request", authorAssociation: "MEMBER", labels: ["maintainer"] }),
+    item({ kind: "pull_request", authorAssociation: "COLLABORATOR", labels: ["maintainer"] }),
+    item({ kind: "pull_request", author: "", labels: ["maintainer"] }),
+  ]) {
+    let lookups = 0;
+    assert.equal(
+      restoreVerifiedMaintainerPullRequestAuthorAssociation(ineligible, () => {
+        lookups += 1;
+        return "admin";
+      }),
+      false,
+    );
+    assert.equal(lookups, 0);
   }
 
   const suppliedComment = renderReviewCommentFromReport(


### PR DESCRIPTION
## Production failure

A fresh production review of openclaw/openclaw#113345 identified @steipete as CONTRIBUTOR even though owner-authenticated GitHub REST and GraphQL report MEMBER. GitHub App installation tokens can redact organization membership, causing maintainer PRs to receive contributor-only proof blockers.

## Fix

- Recover maintainer identity before review, prompt generation, report rendering, and label decisions only when an exact protected maintainer label and an independently verified author admin/maintain repository permission both agree.
- Reuse the existing cached author-permission verifier; failed lookups, missing labels, ordinary contributors, issues, and lower permissions remain fail-closed.
- Invalidate cached reports created with a stale contributor association while preserving raw GitHub context and snapshot integrity.

## Verification

- 119 proof-policy, review-cache, contributor, permission, and security tests passed.
- The actual production report artifact reproduces the failure before the fix and clears the false proof blocker, proof status label, and capped rating afterward.
- Main and repair TypeScript builds, formatting, lint, and independent security review passed.