### PR TITLE
fix(review): stop scheduled review storms on unchanged issues

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1089,6 +1089,7 @@ jobs:
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           REVIEW_LEASE_OWNER: ${{ steps.reserve-exact-review-lease.outputs.owner }}
           REVIEW_LEASE_COMMENT_ID: ${{ steps.reserve-exact-review-lease.outputs.comment_id }}
+          SOURCE_ACTION: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction || '' }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -1230,6 +1231,7 @@ jobs:
             --review-lease-comment-id "$REVIEW_LEASE_COMMENT_ID" \
             --shard-index 0 \
             --shard-count 1 \
+            --review-source-action "$SOURCE_ACTION" \
             "${additional_prompt_arg[@]}" &
           review_pid=$!
           review_pgid=$review_pid

--- a/src/clawsweeper-review-preparation.ts
+++ b/src/clawsweeper-review-preparation.ts
@@ -17,6 +17,18 @@ import {
 import type { Args } from "./clawsweeper-args.js";
 import type { CreateReviewCommandWorkflowDependencies } from "./clawsweeper-review-command-dependencies.js";
 
+const AUTOMATIC_REVIEW_SOURCE_ACTIONS = new Set([
+  "scheduled_hot_intake",
+  "scheduled_normal_backfill",
+]);
+
+export function isExplicitReviewDispatch(args: Args, hasExplicitItemSelection: boolean): boolean {
+  const sourceAction = stringArg(args.review_source_action, "").trim();
+  const plannedAutomaticReview =
+    boolArg(args.planned_automatic_review) || AUTOMATIC_REVIEW_SOURCE_ACTIONS.has(sourceAction);
+  return !plannedAutomaticReview && hasExplicitItemSelection;
+}
+
 export function prepareReviewCommand(
   args: Args,
   dependencies: CreateReviewCommandWorkflowDependencies,
@@ -159,9 +171,10 @@ export function prepareReviewCommand(
     ? { mainSha: localRangeData.baseSha, releaseStateComplete: true, latestRelease: null }
     : loadReviewGitInfo();
   const reviewPolicy = reviewPolicyHash({ model, reasoningEffort, sandboxMode, serviceTier });
-  const plannedAutomaticReview = boolArg(args.planned_automatic_review);
-  const explicitDispatch =
-    !plannedAutomaticReview && (itemNumber !== undefined || itemNumbers !== undefined);
+  const explicitDispatch = isExplicitReviewDispatch(
+    args,
+    itemNumber !== undefined || itemNumbers !== undefined,
+  );
   const maintainerRequest = additionalPrompt.trim().length > 0;
 
   return {

--- a/test/review-preparation.test.ts
+++ b/test/review-preparation.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseArgs } from "../dist/clawsweeper-args.js";
+import { isExplicitReviewDispatch } from "../dist/clawsweeper-review-preparation.js";
+
+test("scheduled queue source actions are automatic while exact actions remain explicit", () => {
+  for (const sourceAction of ["scheduled_hot_intake", "scheduled_normal_backfill"]) {
+    const args = parseArgs(["--review-source-action", sourceAction]);
+    assert.equal(isExplicitReviewDispatch(args, true), false, sourceAction);
+  }
+
+  for (const sourceAction of ["issues_opened", "exact_review_command", "legacy_dispatch", ""]) {
+    const args = sourceAction ? parseArgs(["--review-source-action", sourceAction]) : parseArgs([]);
+    assert.equal(isExplicitReviewDispatch(args, true), true, sourceAction || "missing action");
+  }
+});
+
+test("planned review compatibility and non-exact selection preserve existing behavior", () => {
+  assert.equal(isExplicitReviewDispatch(parseArgs(["--planned-automatic-review"]), true), false);
+  assert.equal(isExplicitReviewDispatch(parseArgs([]), false), false);
+});

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -5486,6 +5486,11 @@ test("planned background reviews allow safe content-cache reuse without weakenin
     reviewJob,
     /--item-numbers "\$\{\{ matrix\.item_numbers \}\}" \\\n+\s+"\$\{planned_automatic_review_arg\[@\]\}"/,
   );
+  assert.match(
+    eventReviewJob,
+    /SOURCE_ACTION: \$\{\{ fromJSON\(steps\.claim-exact-review-queue\.outputs\.decision\)\.sourceAction \|\| '' \}\}/,
+  );
+  assert.match(eventReviewJob, /--review-source-action "\$SOURCE_ACTION"/);
   assert.doesNotMatch(eventReviewJob, /--planned-automatic-review/);
 });
 


### PR DESCRIPTION
Closes #1032.

## What Problem This Solves

Fixes an issue where unchanged issues could be reviewed repeatedly when scheduled hot or normal queue deliveries were handled as explicit reviews. Those duplicate runs generated repeated contributor notifications and consumed review capacity even when only ClawSweeper-owned labels or comments had changed.

## Why This Change Was Made

The exact-review worker now forwards the claimed queue decision's source action as a typed internal review input. Review preparation owns the source-action classification beside the existing explicit-dispatch decision: only `scheduled_hot_intake` and `scheduled_normal_backfill` are automatic, while commands, webhook events, legacy dispatches, unknown actions, and missing actions remain explicit.

## User Impact

Scheduled review lanes can reuse a verified structural receipt for unchanged items instead of starting another full review. Explicit reruns still force fresh work.

OpenClaw Bay is unaffected because this changes review invocation classification only; it does not alter observer schemas, status projections, or dashboard contracts.

## Evidence

The regression failed on current main because exact queued reviews reached review preparation with an item number but no scheduled source input, making them explicit and ineligible for receipt reuse. The focused runtime regression now exercises both scheduled actions, representative explicit actions, missing and unknown actions, the legacy compatibility flag, and non-exact selection.

Validation:

```text
pnpm run build:all
node --test test/review-preparation.test.ts test/sweep-workflow.test.ts test/review-structural-cache.test.ts test/review-semantic-cache.test.ts test/review-content-cache.test.ts test/repair/scheduled-review-enqueue.test.ts
pnpm run check
git diff --check origin/main...HEAD
```

Results: the focused runtime, workflow, scheduler, and cache suites passed on Node 24.16.0. The full check passed formatting, static policy checks, all TypeScript builds, lint, and the exercised test assertions, but its local test process retained an open handle after its last output and required termination; CI is the clean-environment confirmation for that full aggregate command.

## Real Behavior Proof

**Claim:** the shipped workflow forwards claimed queue provenance into the real review-preparation boundary, where both scheduled actions are cache-eligible and sampled non-scheduled actions remain explicit.

**Exercised surface:** the built review-preparation module and the current `event-review-apply` workflow at head `4196b8bf29072d938f6b4330094ec42c1e455e51`.

**Observed runtime behavior:**

```text
scheduled_hot_intake => automatic
scheduled_normal_backfill => automatic
issues_opened => explicit
exact_review_command => explicit
legacy_dispatch => explicit
unknown action => explicit
missing action => explicit
```

A Docker-backed Crabbox `local-container` environment was also verified as available. A live claimed-delivery trace through the GitHub receipt-cache boundary remains pending because no least-privilege read-only GitHub credential was available for that container. No production review jobs were dispatched, no model capacity was consumed, and no contributor notifications were generated while validating this change.

Disclosure: AI was used to understand the codebase and review the fix.
