### PR TITLE
fix: defer stalled reviews when GitHub API quota is exhausted

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1596,7 +1596,7 @@ jobs:
           exit 1
 
       - name: Release unsuccessful workflow-owned review lease
-        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' && steps.reserve-exact-review-lease.outputs.status != 'held' && steps.direct-exact-review-publication.outputs.accepted != 'true' && steps.queue-exact-review-publication.outcome != 'success' }}
+        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' && steps.reserve-exact-review-lease.outputs.status != 'held' && steps.prepare-direct-exact-review-publication.outputs.failure_kind != 'github_rate_limit' && steps.prepare-direct-exact-review-publication.outputs.failure_kind != 'github_transient' && steps.direct-exact-review-publication.outputs.accepted != 'true' && steps.queue-exact-review-publication.outcome != 'success' }}
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -1625,7 +1625,7 @@ jobs:
           done <<< "$reaction_ids"
 
       - name: Mark unsuccessful re-review
-        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.target.outputs.has_command_context == 'true' && steps.setup-pnpm.outcome == 'success' && steps.direct-exact-review-publication.outputs.accepted != 'true' && steps.queue-exact-review-publication.outcome != 'success' && steps.target-write-token.outputs.token != '' }}
+        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.target.outputs.has_command_context == 'true' && steps.setup-pnpm.outcome == 'success' && steps.prepare-direct-exact-review-publication.outputs.failure_kind != 'github_rate_limit' && steps.prepare-direct-exact-review-publication.outputs.failure_kind != 'github_transient' && steps.direct-exact-review-publication.outputs.accepted != 'true' && steps.queue-exact-review-publication.outcome != 'success' && steps.target-write-token.outputs.token != '' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -2713,7 +2713,7 @@ jobs:
           done <<< "$reaction_ids"
 
       - name: Release superseded or unsuccessful publisher-owned review lease
-        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.publication-context.outputs.live_proceeded == 'true' && (steps.publish-event-result.outputs.completion_kind == 'superseded' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.requeue_latest == 'true' && steps.queue-source-drift-review.outcome != 'success')) }}
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.publication-context.outputs.live_proceeded == 'true' && steps.publish-event-result.outputs.failure_kind != 'github_rate_limit' && steps.publish-event-result.outputs.failure_kind != 'github_transient' && (steps.publish-event-result.outputs.completion_kind == 'superseded' || steps.publish-event-result.outcome != 'success' || (steps.publish-event-result.outputs.requeue_latest == 'true' && steps.queue-source-drift-review.outcome != 'success')) }}
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
@@ -2735,28 +2735,6 @@ jobs:
             gh api "repos/$TARGET_REPO/issues/$ITEM_NUMBER/reactions/$reaction_id" --method DELETE
           done <<< "$reaction_ids"
 
-      - name: Probe GitHub pressure after publication failure
-        id: publication-pressure
-        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && failure() }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          test -n "$GH_TOKEN"
-          pressure_error="$(mktemp)"
-          if rate_limit="$(gh api rate_limit 2>"$pressure_error")"; then
-            if jq -e '(.resources.core.limit // 0) > 0 and ((.resources.core.remaining // 0) <= 100 or (.resources.core.remaining * 20) <= .resources.core.limit)' <<< "$rate_limit" >/dev/null; then
-              echo "failure_kind=github_rate_limit" >> "$GITHUB_OUTPUT"
-            fi
-          elif grep -Eqi 'HTTP 429|secondary rate limit|API rate limit|rate limit (exceeded|reached)' "$pressure_error"; then
-            echo "failure_kind=github_rate_limit" >> "$GITHUB_OUTPUT"
-          elif grep -Eqi 'HTTP 5[0-9]{2}|status( code)? 5[0-9]{2}|Bad Gateway|Service Unavailable|Gateway Timeout' "$pressure_error"; then
-            echo "failure_kind=github_transient" >> "$GITHUB_OUTPUT"
-          fi
-          cat "$pressure_error" >&2
-          rm -f "$pressure_error"
-
       - name: Export exact review publication result
         id: exact-review-publication-result
         if: ${{ steps.publication-context.outputs.claimed == 'true' && always() }}
@@ -2772,7 +2750,7 @@ jobs:
           LEGACY_TUPLELESS: ${{ steps.legacy-exact-artifact.outputs.legacy_tupleless }}
           SOURCE_DRIFT_OUTCOME: ${{ steps.queue-source-drift-review.outcome }}
           DEFERRED_ROUTE_OUTCOME: ${{ steps.queue-deferred-verdict-router.outcome }}
-          FAILURE_KIND: ${{ steps.publish-event-result.outputs.failure_kind || steps.publication-pressure.outputs.failure_kind }}
+          FAILURE_KIND: ${{ steps.publish-event-result.outputs.failure_kind }}
           DOWNLOAD_OUTCOME: ${{ steps.download-exact-review-bundle.outcome }}
           VALIDATE_OUTCOME: ${{ steps.validate-exact-review-bundle.outcome }}
           PUBLISH_COMPLETION_KIND: ${{ steps.publish-event-result.outputs.completion_kind }}
@@ -2861,6 +2839,7 @@ jobs:
           elif [ "$outcome" != "success" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
             completion_kind=retryable_failure
             reason_code="$FAILURE_KIND"
+            retry_at="$PUBLISH_RETRY_AT"
           elif [ "$outcome" != "success" ] && [ "$DOWNLOAD_OUTCOME" = "failure" ]; then
             completion_kind=retryable_failure
             reason_code=artifact_unavailable
@@ -5837,10 +5816,6 @@ jobs:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
           CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS: ${{ steps.target-write-token.outputs.minted-at-ms }}
-          CLAWSWEEPER_PUBLISH_THROTTLE_STATUS: "true"
-          CLAWSWEEPER_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CLAWSWEEPER_THROTTLE_STATUS_MIN_WAIT_MS: "60000"
-          CLAWSWEEPER_THROTTLE_STATUS_MIN_INTERVAL_MS: "120000"
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1667,6 +1667,9 @@ jobs:
         env:
           ADMISSION_RETRY: ${{ steps.live-item.outputs.admission_retry }}
           RETRY_KIND: ${{ steps.live-item.outputs.retry_kind || steps.reserve-exact-review-lease.outputs.retry_kind || steps.review-exact-event-item.outputs.retry_kind }}
+          RETRY_AT: ${{ steps.live-item.outputs.retry_at || steps.reserve-exact-review-lease.outputs.retry_at || steps.review-exact-event-item.outputs.retry_at }}
+          DIRECT_PUBLICATION_FAILURE_KIND: ${{ steps.prepare-direct-exact-review-publication.outputs.failure_kind }}
+          DIRECT_PUBLICATION_RETRY_AT: ${{ steps.prepare-direct-exact-review-publication.outputs.retry_at }}
           TARGET_ENABLED: ${{ steps.target.outputs.target_enabled }}
           LIVE_OUTCOME: ${{ steps.live-item.outcome }}
           REVIEW_OUTCOME: ${{ steps.review-exact-event-item.outcome }}
@@ -1680,7 +1683,14 @@ jobs:
         run: |
           outcome=failure
           requeue_latest=false
-          if [ "$ADMISSION_RETRY" = "true" ] && [ -z "$RETRY_KIND" ]; then
+          retry_kind="$RETRY_KIND"
+          retry_at="$RETRY_AT"
+          if [ "$DIRECT_PUBLICATION_FAILURE_KIND" = "github_rate_limit" ] && [ "$PUBLICATION_QUEUE_OUTCOME" != "success" ]; then
+            test -n "$DIRECT_PUBLICATION_RETRY_AT"
+            retry_kind=throttle
+            retry_at="$DIRECT_PUBLICATION_RETRY_AT"
+          fi
+          if [ "$ADMISSION_RETRY" = "true" ] && [ -z "$retry_kind" ]; then
             outcome=success
             requeue_latest=true
           elif [ "$TARGET_ENABLED" = "false" ]; then
@@ -1698,6 +1708,8 @@ jobs:
           echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
           echo "requeue_latest=$requeue_latest" >> "$GITHUB_OUTPUT"
           echo "direct_lifecycle_requeue=$DIRECT_LIFECYCLE_REQUEUE" >> "$GITHUB_OUTPUT"
+          echo "retry_kind=$retry_kind" >> "$GITHUB_OUTPUT"
+          echo "retry_at=$retry_at" >> "$GITHUB_OUTPUT"
 
       - name: Complete exact-review queue lease
         id: complete-exact-review-queue
@@ -1712,8 +1724,8 @@ jobs:
           QUEUE_LEASE_REVISION: ${{ steps.claim-exact-review-queue.outputs.lease_revision }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           REQUEUE_LATEST: ${{ steps.exact-review-generation-result.outputs.requeue_latest }}
-          RETRY_KIND: ${{ steps.live-item.outputs.retry_kind || steps.reserve-exact-review-lease.outputs.retry_kind || steps.review-exact-event-item.outputs.retry_kind }}
-          RETRY_AT: ${{ steps.live-item.outputs.retry_at || steps.reserve-exact-review-lease.outputs.retry_at || steps.review-exact-event-item.outputs.retry_at }}
+          RETRY_KIND: ${{ steps.exact-review-generation-result.outputs.retry_kind }}
+          RETRY_AT: ${{ steps.exact-review-generation-result.outputs.retry_at }}
           DIRECT_PUBLICATION_ACCEPTED: ${{ steps.direct-exact-review-publication.outputs.accepted }}
           DIRECT_PUBLICATION_SUPERSEDED: ${{ steps.direct-exact-review-publication.outputs.superseded }}
           DIRECT_LIFECYCLE_OUTCOME: ${{ steps.finalize-direct-exact-review-lifecycle.outcome }}
@@ -1843,6 +1855,7 @@ jobs:
               ) ||
               (
                 steps.exact-review-generation-result.outputs.outcome != 'success' &&
+                steps.exact-review-generation-result.outputs.retry_kind == '' &&
                 steps.reserve-exact-review-lease.outputs.status != 'held' &&
                 steps.reserve-exact-review-lease.outputs.status != 'superseded'
               )

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -62,6 +62,7 @@ import {
   type MaintainerDecision,
 } from "./decision-packets.js";
 import {
+  GitHubRateLimitError,
   isGitHubNotFoundError,
   isGitHubRequiresAuthenticationError,
   isLockedConversationCommentError,
@@ -239,8 +240,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     const examinedItemNumbers: number[] = [];
     let closedCount = 0;
     let processedCount = 0;
-    dependencies.throttleHeartbeatContext = () =>
-      `Progress: ${closedCount}/${limit} fresh closes, ${processedCount}/${processedLimit} processed records in this apply chunk.`;
     const logProgress = (message: string): void => {
       const counts = results.reduce<Record<string, number>>((accumulator, result) => {
         accumulator[result.action] = (accumulator[result.action] ?? 0) + 1;
@@ -400,6 +399,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           throwOnError: true,
         });
       } catch (error) {
+        if (error instanceof GitHubRateLimitError) throw error;
         console.error(
           `[apply] could not delete owned review lease comment ${active.lease.commentId}: ${mutationErrorMessage(error)}`,
         );
@@ -1923,7 +1923,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
                   rememberSelfMutationUpdatedAt();
                   syncReasons.push("cleared resolved review recovery label");
                 } catch (error) {
-                  if (error instanceof GitHubRuntimeBudgetError) throw error;
+                  if (error instanceof GitHubRuntimeBudgetError || error instanceof GitHubRateLimitError)
+                    throw error;
                   console.error(
                     `[apply] could not clear resolved review recovery label for #${number}: ${
                       error instanceof Error ? error.message : String(error)
@@ -2077,6 +2078,10 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           continue;
         }
         applyItemFailed = true;
+        if (error instanceof GitHubRateLimitError) {
+          // Keep the durable lease until expiry; releasing it would spend the exhausted quota.
+          activeApplyMutationLease = null;
+        }
         throw error;
       } finally {
         releaseActiveApplyMutationLease();

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -589,7 +589,6 @@ export interface CreateApplyDecisionWorkflowDependencies {
     dryRun?: boolean;
   }) => boolean;
   targetRepo: () => string;
-  throttleHeartbeatContext: (() => string) | null;
   timeoutWithinRuntimeBudget: (
     startedAtMs: number,
     maxRuntimeMs: number,

--- a/src/clawsweeper-apply-lease-guards.ts
+++ b/src/clawsweeper-apply-lease-guards.ts
@@ -1,6 +1,7 @@
 import type { CreateApplyDecisionWorkflowDependencies } from "./clawsweeper-apply-dependencies.js";
 import { trimMiddle } from "./clawsweeper-text.js";
 import type { AcquiredReviewStartLease, Item } from "./clawsweeper-types.js";
+import { GitHubRateLimitError } from "./github-retry.js";
 import { freshExactHeadReviewStartLease } from "./repair/comment-router-core.js";
 
 type ActiveApplyMutationLease = { itemNumber: number; lease: AcquiredReviewStartLease } | null;
@@ -148,7 +149,8 @@ export function createApplyLeaseGuards({
         comments: refreshed.comments,
       };
     } catch (error) {
-      if (error instanceof GitHubRuntimeBudgetError) throw error;
+      if (error instanceof GitHubRuntimeBudgetError || error instanceof GitHubRateLimitError)
+        throw error;
       const detail = trimMiddle(
         (error instanceof Error ? error.message : String(error)).replace(/\s+/g, " "),
         180,
@@ -202,7 +204,8 @@ export function createApplyLeaseGuards({
         refreshed.reviewComment,
       );
     } catch (error) {
-      if (error instanceof GitHubRuntimeBudgetError) throw error;
+      if (error instanceof GitHubRuntimeBudgetError || error instanceof GitHubRateLimitError)
+        throw error;
       const detail = trimMiddle(
         (error instanceof Error ? error.message : String(error)).replace(/\s+/g, " "),
         180,

--- a/src/clawsweeper-github-execution.ts
+++ b/src/clawsweeper-github-execution.ts
@@ -1,29 +1,27 @@
 import { spawnSync } from "node:child_process";
 import { resolveCommand } from "./command.js";
 import { parseGhJson, parseGhJsonLinesWithRetry, parseGhJsonWithRetry } from "./github-json.js";
-import { ghRetryKind, ghRetryWaitMs, summarizeGhArgs } from "./github-retry.js";
+import {
+  GitHubRateLimitError,
+  ghRetryKind,
+  ghRetryWaitMs,
+  summarizeGhArgs,
+} from "./github-retry.js";
 import type {
   GitHubDispatchOutcome,
   GitHubRetryOptions,
   MutationRunner,
 } from "./clawsweeper-types.js";
 import type { createGitHubRuntime } from "./clawsweeper-github-runtime.js";
-import type { createSweepStatus } from "./clawsweeper-sweep-status.js";
 
 interface CreateGitHubExecutionDependencies {
   ROOT: string;
-  run: (
-    command: string,
-    args: string[],
-    options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number | undefined },
-  ) => string;
   gitHubRuntime: ReturnType<typeof createGitHubRuntime>;
-  sweepStatus: ReturnType<typeof createSweepStatus>;
   labelAlreadyExistsError: (error: unknown) => boolean;
 }
 
 export function createGitHubExecution(dependencies: CreateGitHubExecutionDependencies) {
-  const { ROOT, run, gitHubRuntime, sweepStatus, labelAlreadyExistsError } = dependencies;
+  const { ROOT, gitHubRuntime, labelAlreadyExistsError } = dependencies;
   const {
     GitHubRuntimeBudgetError,
     ensureGitHubRetryFits,
@@ -35,72 +33,6 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
     githubRuntimeBudgetError,
     sleepBeforeGitHubRetry,
   } = gitHubRuntime;
-  const { sweepStatusRelativePath, writeSweepStatus } = sweepStatus;
-
-  let lastThrottleHeartbeatAt = 0;
-
-  let throttleHeartbeatContext: (() => string) | null = null;
-
-  function maybePublishThrottleHeartbeat(options: {
-    args: string[];
-    attempt: number;
-    attempts: number;
-    waitMs: number;
-  }): void {
-    if (process.env.CLAWSWEEPER_PUBLISH_THROTTLE_STATUS !== "true") return;
-    const minWaitMs = Number(process.env.CLAWSWEEPER_THROTTLE_STATUS_MIN_WAIT_MS ?? 60_000);
-    if (options.waitMs < minWaitMs) return;
-    const minIntervalMs = Number(
-      process.env.CLAWSWEEPER_THROTTLE_STATUS_MIN_INTERVAL_MS ?? 120_000,
-    );
-    const now = Date.now();
-    if (now - lastThrottleHeartbeatAt < minIntervalMs) return;
-    lastThrottleHeartbeatAt = now;
-
-    try {
-      const context = throttleHeartbeatContext?.();
-      const checkpoint = process.env.CLAWSWEEPER_APPLY_CHECKPOINT;
-      const checkpointText = checkpoint ? `Checkpoint ${checkpoint}. ` : "";
-      const detail = [
-        `${checkpointText}GitHub throttled while applying close decisions.`,
-        context,
-        `Last throttled command: \`${summarizeGhArgs(options.args)}\`.`,
-        `Retry ${options.attempt + 1}/${Math.max(1, options.attempts - 1)} in ${Math.round(options.waitMs / 1000)}s.`,
-      ]
-        .filter(Boolean)
-        .join(" ");
-      const statusOptions: {
-        state: string;
-        detail: string;
-        runUrl?: string;
-      } = {
-        state: "Apply throttled",
-        detail,
-      };
-      if (process.env.CLAWSWEEPER_RUN_URL) {
-        statusOptions.runUrl = process.env.CLAWSWEEPER_RUN_URL;
-      }
-      writeSweepStatus(statusOptions);
-      run("git", ["add", sweepStatusRelativePath()]);
-      const diff = spawnSync("git", ["diff", "--cached", "--quiet"], { cwd: ROOT });
-      if (diff.status === 0) return;
-      run("git", ["commit", "-m", "chore: update sweep apply throttle status"]);
-      try {
-        run("git", ["push"], { timeoutMs: githubCommandTimeoutMs() });
-      } catch (error) {
-        if (error instanceof GitHubRuntimeBudgetError) throw error;
-        console.error(
-          `Best-effort throttle status push failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    } catch (error) {
-      if (error instanceof GitHubRuntimeBudgetError) throw error;
-      console.error(
-        `Best-effort throttle status update failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
-
   function ghWithRetry(
     args: string[],
     attempts = configuredGitHubRetryAttempts(),
@@ -113,19 +45,15 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         lastError = error;
-        ensureGitHubRuntimeAvailable("after GitHub operation");
         const retryKind = ghRetryKind(error);
+        if (retryKind === "throttle") throw new GitHubRateLimitError(error);
+        ensureGitHubRuntimeAvailable("after GitHub operation");
         if (retryKind === "none" || attempt === attempts - 1) throw error;
         const waitMs = ghRetryWaitMs(retryKind, attempt);
         ensureGitHubRetryFits(waitMs);
-        const retryLabel =
-          retryKind === "throttle" ? "GitHub throttled" : "Transient GitHub API failure";
         console.error(
-          `${retryLabel}; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
+          `Transient GitHub API failure; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
         );
-        if (retryKind === "throttle") {
-          maybePublishThrottleHeartbeat({ args, attempt, attempts, waitMs });
-        }
         if (options.sleepBeforeRetry) options.sleepBeforeRetry(waitMs);
         else sleepBeforeGitHubRetry(waitMs);
       }
@@ -208,7 +136,7 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
   }
 
   function observedGitHubMutationAttemptsForTest(
-    outcomes: readonly ("not_started" | "transient" | "accepted" | "already_exists")[],
+    outcomes: readonly ("not_started" | "transient" | "throttle" | "accepted" | "already_exists")[],
   ): Array<{
     identity: string;
     idempotencyIdentity: string;
@@ -258,6 +186,7 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
           return () => {
             if (outcome === "accepted") return "ok";
             if (outcome === "already_exists") throw new Error("label already exists");
+            if (outcome === "throttle") throw new Error("HTTP 403: API rate limit exceeded");
             throw new Error("HTTP 502: transient upstream failure");
           };
         },
@@ -415,12 +344,6 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
     },
     set activeReviewMutationRunner(value: MutationRunner | null) {
       activeReviewMutationRunner = value;
-    },
-    get throttleHeartbeatContext() {
-      return throttleHeartbeatContext;
-    },
-    set throttleHeartbeatContext(value: (() => string) | null) {
-      throttleHeartbeatContext = value;
     },
   };
 }

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -316,9 +316,7 @@ const { GitHubRuntimeBudgetError, sleepMs, untrustedCodexEnv } = gitHubRuntime;
 
 const githubExecution = createGitHubExecution({
   ROOT,
-  run,
   gitHubRuntime,
-  sweepStatus,
   labelAlreadyExistsError: (error) => labelAlreadyExistsError(error),
 });
 export const { classifyGitHubDispatchResultForTest, observedGitHubMutationAttemptsForTest } =
@@ -1311,12 +1309,6 @@ const { applyDecisionsCommandInner } = createApplyDecisionWorkflow({
   sha256,
   stringOrUndefined,
   targetRepo,
-  get throttleHeartbeatContext() {
-    return githubExecution.throttleHeartbeatContext;
-  },
-  set throttleHeartbeatContext(value: (() => string) | null) {
-    githubExecution.throttleHeartbeatContext = value;
-  },
   timestampMs,
   validateCloseDecision,
 });

--- a/src/github-retry.ts
+++ b/src/github-retry.ts
@@ -1,5 +1,29 @@
 export type GhRetryKind = "none" | "throttle" | "transient";
 
+export class GitHubRateLimitError extends Error {
+  readonly retryAt: string;
+
+  constructor(cause: unknown, now = Date.now()) {
+    const message = ghErrorText(cause);
+    // gh normally omits response headers; defer safely without probing GitHub,
+    // but preserve any reset hints already present in the observed error.
+    const retryAfter = message.match(/\bretry-after\s*[:=]\s*(\d+)\b/i)?.[1];
+    const reset = message.match(/\bx-ratelimit-reset\s*[:=]\s*(\d+)\b/i)?.[1];
+    const propagated = message.match(/\brate limited until\s+(\d{4}-\d{2}-\d{2}T[\d:.]+Z)/i)?.[1];
+    const retryAt = new Date(
+      Math.max(
+        now + 60_000,
+        retryAfter ? now + Number(retryAfter) * 1_000 : 0,
+        reset ? Number(reset) * 1_000 : 0,
+        propagated ? Date.parse(propagated) || 0 : 0,
+      ),
+    ).toISOString();
+    super(`GitHub API rate limited until ${retryAt}: ${message}`, { cause });
+    this.name = "GitHubRateLimitError";
+    this.retryAt = retryAt;
+  }
+}
+
 const GH_THROTTLE_PATTERNS = [
   /was submitted too quickly/i,
   /secondary rate/i,

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -135,10 +135,10 @@ import {
   ghPagedWithRetry as ghPaged,
   ghPagedWithRetryAsync as ghPagedAsync,
   ghSpawn,
-  ghText,
+  ghTextWithRetry,
   type GhRetryOptions,
 } from "./github-cli.js";
-import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
+import { GitHubRateLimitError, ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 import { issueSourceRevisionSha256 } from "./issue-source-guard.js";
 import { compactText, escapeRegExp } from "./text-utils.js";
 import {
@@ -652,6 +652,7 @@ function claimedDispatchState({
       if (pageRuns.length < 100) break;
     }
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     return {
       status: "claimed",
       dispatch_key: dispatchReceiptKey(command),
@@ -668,6 +669,7 @@ function claimedDispatchState({
       expectedTitle,
     });
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     return {
       status: "claimed",
       dispatch_key: dispatchReceiptKey(command),
@@ -2549,7 +2551,7 @@ function runGitHubTextMutation(
   return runCommandMutationWithRetry(command, {
     kind,
     identity,
-    operation: () => ghText(ghArgs, runOptions),
+    operation: () => ghTextWithRetry(ghArgs, { ...runOptions, attempts: 1 }),
     attempts,
     shouldRetry: (error) => {
       try {
@@ -2557,9 +2559,9 @@ function runGitHubTextMutation(
       } catch {
         // The receipt already conservatively classified a failing predicate as unknown.
       }
-      return ghRetryKind(error) !== "none";
+      return ghRetryKind(error) === "transient";
     },
-    beforeRetry: (error, attempt) => sleepMs(ghRetryWaitMs(ghRetryKind(error), attempt - 1)),
+    beforeRetry: (_error, attempt) => sleepMs(ghRetryWaitMs("transient", attempt - 1)),
     ...(knownNoMutation ? { knownNoMutation } : {}),
   });
 }
@@ -2569,13 +2571,13 @@ function runGitHubTextMutationOnce(
   kind: string,
   identity: unknown,
   ghArgs: string[],
-  options: Parameters<typeof ghText>[1] = {},
+  options: GhRetryOptions = {},
   knownNoMutation?: (error: unknown) => boolean,
 ) {
   return runCommandMutation(command, {
     kind,
     identity,
-    operation: () => ghText(ghArgs, options),
+    operation: () => ghTextWithRetry(ghArgs, { ...options, attempts: 1 }),
     ...(knownNoMutation ? { knownNoMutation } : {}),
   });
 }
@@ -2590,7 +2592,13 @@ function runGitHubSpawnMutation(
   return runCommandMutation(command, {
     kind,
     identity,
-    operation: () => ghSpawn(ghArgs, options),
+    operation: () => {
+      const result = ghSpawn(ghArgs, options);
+      if (result.status !== 0 && ghRetryKind(result) === "throttle") {
+        throw new GitHubRateLimitError(result);
+      }
+      return result;
+    },
     outcome: (result) => (result.status === 0 && !result.error ? "accepted" : "unknown"),
   });
 }
@@ -2605,7 +2613,8 @@ function runGitHubBestEffortMutation(
   try {
     runGitHubTextMutationOnce(command, kind, identity, ghArgs, {}, knownNoMutation);
     return true;
-  } catch {
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     return false;
   }
 }
@@ -2825,10 +2834,15 @@ function acknowledgeTerminalNoopMaintainerCommand(command: LooseRecord) {
   const targetedProcessedComment =
     itemNumbers.size > 0 && reason === "comment version already processed in ledger";
   if (!targetedProcessedComment && !/already enabled for this PR/i.test(reason)) return;
+  let quotaExhausted = false;
   try {
     reactToComment(command, "eyes");
+  } catch (error) {
+    quotaExhausted = error instanceof GitHubRateLimitError;
+    throw error;
   } finally {
-    clearTerminalMaintainerCommandReaction(command);
+    // A throttled reaction must not spend another privileged request on cleanup.
+    if (!quotaExhausted) clearTerminalMaintainerCommandReaction(command);
   }
 }
 
@@ -3757,6 +3771,7 @@ function executeAutoclose(command: LooseRecord) {
       closeIssueOrPullRequest(command, liveTarget.number, liveTarget.kind);
       results.push({ ...liveTarget, status: "closed", closed_at: new Date().toISOString() });
     } catch (error) {
+      if (error instanceof GitHubRateLimitError) throw error;
       results.push({
         ...liveTarget,
         status: "blocked",
@@ -3784,7 +3799,8 @@ function discoverAutocloseTargets({ command, issue, pull }: LooseRecord): JsonVa
       const target = issueTargetFromIssue(candidate);
       if (target.state !== "open") continue;
       targets.push(target);
-    } catch {
+    } catch (error) {
+      if (error instanceof GitHubRateLimitError) throw error;
       // Broken or private references should not block the explicit target close.
     }
   }
@@ -4745,7 +4761,8 @@ function fetchCollaboratorPermission(login: JsonValue) {
       `repos/${targetRepo}/collaborators/${encodeURIComponent(login)}/permission`,
     ]);
     permission = result?.permission ? String(result.permission).toLowerCase() : null;
-  } catch {
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     permission = null;
   }
   collaboratorPermissionCache.set(key, permission);
@@ -4762,7 +4779,8 @@ async function fetchCollaboratorPermissionAsync(login: JsonValue) {
       `repos/${targetRepo}/collaborators/${encodeURIComponent(login)}/permission`,
     ]);
     permission = result?.permission ? String(result.permission).toLowerCase() : null;
-  } catch {
+  } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     permission = null;
   }
   collaboratorPermissionCache.set(key, permission);
@@ -4902,6 +4920,7 @@ function convergePrecreatedCommandAckComments(command: LooseRecord) {
   try {
     return convergePrecreatedCommandAckCommentsInner(command);
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     console.warn(
       `[comment-router] warning: fast ack convergence failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
     );
@@ -4913,6 +4932,7 @@ function exactCommentVersionStillCurrent(command: LooseRecord) {
   try {
     return exactCommentVersionMatchesLive(command, fetchIssueComment(command.comment_id));
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     console.warn(
       `[comment-router] warning: exact comment cleanup verification failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
     );
@@ -4955,6 +4975,7 @@ function convergeExactCommentVersionFastPathAck(command: LooseRecord, commentId:
     issueCommentsCache.delete(Number(command.issue_number));
     return "updated";
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     if (githubNotFoundNoMutation(error)) return "already_converged";
     console.warn(
       `[comment-router] warning: exact comment acknowledgement convergence failed for ${command.repo}#${command.issue_number}: ${compactText(ghErrorText(error), 160)}`,
@@ -5184,6 +5205,7 @@ function reactToComment(command: LooseRecord, content: string) {
       githubAlreadyExistsNoMutation,
     );
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     const message = stripAnsi(error?.message ?? error);
     if (/already exists/i.test(message) || /\b422\b/.test(message)) return;
     console.warn(
@@ -5210,6 +5232,7 @@ function removeOwnCommentReaction(command: LooseRecord, content: string) {
     );
     if (Array.isArray(fetched)) reactions = fetched;
   } catch (error) {
+    if (error instanceof GitHubRateLimitError) throw error;
     const message = compactText(ghErrorText(error), 220);
     console.warn(
       `warning: failed to list ${content} reactions for comment ${command.comment_id}: ${message}`,
@@ -5244,6 +5267,7 @@ function removeOwnCommentReaction(command: LooseRecord, content: string) {
       );
       removed = true;
     } catch (error) {
+      if (error instanceof GitHubRateLimitError) throw error;
       const message = compactText(ghErrorText(error), 220);
       if (/\b404\b|not found/i.test(message)) continue;
       deleteFailed = true;

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -4,7 +4,7 @@ import { promisify } from "node:util";
 import { stripAnsi } from "./comment-router-utils.js";
 import { ghCliEnv } from "./process-env.js";
 import { repoRoot } from "./paths.js";
-import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
+import { GitHubRateLimitError, ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 import { parseGhJsonWithRetry, parseGhJsonWithRetryAsync } from "../github-json.js";
 import { resolveCommand } from "../command.js";
 
@@ -143,6 +143,7 @@ export function ghPagedLimitWithRetry<T = JsonValue>(
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
+      if (retryKind === "throttle") throw new GitHubRateLimitError(error);
       if (attempt >= attempts || retryKind === "none") throw error;
       sleepMs(ghRetryWaitMs(retryKind, attempt - 1));
     }
@@ -174,6 +175,7 @@ export function ghTextWithRetry(ghArgs: string[], options: GhRetryOptions | numb
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
+      if (retryKind === "throttle") throw new GitHubRateLimitError(error);
       if (attempt >= attempts || retryKind === "none") throw error;
       sleepMs(ghRetryWaitMs(retryKind, attempt - 1));
     }
@@ -194,6 +196,7 @@ export async function ghTextWithRetryAsync(
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
+      if (retryKind === "throttle") throw new GitHubRateLimitError(error);
       if (attempt >= attempts || retryKind === "none") throw error;
       await sleepAsync(ghRetryWaitMs(retryKind, attempt - 1));
     }

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -24,6 +24,7 @@ import {
 } from "./event-apply-proof.js";
 import { isJsonObject } from "./json-types.js";
 import { RecordTupleError } from "./record-tuple.js";
+import { GitHubRateLimitError, ghRetryKind } from "../github-retry.js";
 import {
   postDirectPublicationResult,
   prepareDirectPublicationPayload,
@@ -83,6 +84,7 @@ class PublicationResultError extends Error {
       | "missing_record_tuple"
       | "tuple_protocol_invalid"
       | "policy_invariant"
+      | "state_contention"
       | "unknown_failure",
     message: string,
   ) {
@@ -94,13 +96,21 @@ const options = eventOptionsFromEnv();
 try {
   await publishEventResult(options);
 } catch (error) {
-  const completionKind = "permanent_failure";
+  const retryableFailure =
+    error instanceof GitHubRateLimitError ||
+    ghRetryKind(error) === "transient" ||
+    (error instanceof PublicationResultError && error.reasonCode === "state_contention");
+  const completionKind = retryableFailure ? "retryable_failure" : "permanent_failure";
   const reasonCode =
-    error instanceof PublicationResultError
-      ? error.reasonCode
-      : error instanceof RecordTupleError
-        ? "tuple_protocol_invalid"
-        : "unknown_failure";
+    error instanceof GitHubRateLimitError
+      ? "github_rate_limit"
+      : ghRetryKind(error) === "transient"
+        ? "github_transient"
+        : error instanceof PublicationResultError
+          ? error.reasonCode
+          : error instanceof RecordTupleError
+            ? "tuple_protocol_invalid"
+            : "unknown_failure";
   const fingerprint = errorFingerprint(error);
   if (options.batchMutationOutput) {
     writeBatchMutationResult(options.batchMutationOutput, {
@@ -109,7 +119,12 @@ try {
       errorFingerprint: fingerprint,
     });
   }
-  writePublicationCompletionOutputs(completionKind, reasonCode, fingerprint);
+  writePublicationCompletionOutputs(
+    completionKind,
+    reasonCode,
+    fingerprint,
+    error instanceof GitHubRateLimitError ? error.retryAt : undefined,
+  );
   throw error;
 }
 
@@ -279,28 +294,6 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     summary();
     return;
   }
-  for (let attempt = 1; attempt <= 20; attempt += 1) {
-    const published = await publishSnapshot({
-      paths: recordPaths,
-      options,
-      summary,
-      guardedOpenAction,
-      requeueLatestExpected,
-      routableSyncExpected,
-      deferredCloseCoverageExpected,
-      terminalClosedExpected: closedCount > 0,
-      terminalMissingExpected: missingCount > 0,
-    });
-    if (published) {
-      writeEventDispositionOutputs(published);
-      return;
-    }
-    const delaySeconds = attempt * 3 + Math.floor(Math.random() * 11);
-    console.log(
-      `Event publish attempt ${attempt} failed; retrying from origin/main in ${delaySeconds}s`,
-    );
-    await sleep(delaySeconds * 1000);
-  }
   const published = await publishSnapshot({
     paths: recordPaths,
     options,
@@ -312,11 +305,6 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     terminalClosedExpected: closedCount > 0,
     terminalMissingExpected: missingCount > 0,
   });
-  if (!published) {
-    throw new Error(
-      `Failed to publish event result for ${options.targetRepo}#${options.itemNumber}`,
-    );
-  }
   writeEventDispositionOutputs(published);
 }
 
@@ -489,7 +477,7 @@ async function publishSnapshot({
   deferredCloseCoverageExpected: boolean;
   terminalClosedExpected: boolean;
   terminalMissingExpected: boolean;
-}): Promise<PublishedEventSnapshot | null> {
+}): Promise<PublishedEventSnapshot> {
   const complete = (
     candidateApplied: boolean,
     supersededReason?: "remote_newer_tuple" | "remote_closed",
@@ -618,24 +606,20 @@ async function publishSnapshot({
       }),
     });
     if (publication.kind === "fallback") {
-      throw new Error(`Canonical exact-event publication failed: ${publication.reason}`);
+      throw new PublicationResultError(
+        publication.status === undefined || publication.status === 429 || publication.status >= 500
+          ? "state_contention"
+          : "policy_invariant",
+        `Canonical exact-event publication failed: ${publication.reason}`,
+      );
     }
     if (publication.response.superseded === true) {
       return complete(false, "remote_newer_tuple");
     }
     return complete(true);
   } catch (error) {
-    if (
-      error instanceof RecordTupleError ||
-      error instanceof GuardedOpenPublishRaceError ||
-      error instanceof RoutableSyncPublishRaceError ||
-      error instanceof SourceDriftPublishRaceError ||
-      error instanceof TerminalClosedPublishRaceError ||
-      error instanceof TerminalMissingPublishRaceError
-    )
-      throw error;
     console.error(error instanceof Error ? error.message : String(error));
-    return null;
+    throw error;
   }
 }
 
@@ -776,6 +760,7 @@ function writePublicationCompletionOutputs(
     | "remote_newer_tuple"
     | "remote_closed"
     | "close_coverage_deferred"
+    | "github_rate_limit"
     | "github_transient"
     | "state_contention"
     | "review_lease_active"
@@ -793,6 +778,9 @@ function writePublicationCompletionOutputs(
     [
       `completion_kind=${completionKind}`,
       `reason_code=${reasonCode}`,
+      ...(reasonCode === "github_rate_limit" || reasonCode === "github_transient"
+        ? [`failure_kind=${reasonCode}`]
+        : []),
       ...(fingerprint ? [`error_fingerprint=${fingerprint}`] : []),
       ...(retryAt ? [`retry_at=${retryAt}`] : []),
       "",
@@ -826,14 +814,19 @@ function runClawsweeper(options: EventOptions, args: readonly string[]): void {
   const cli = join(options.codeRoot, "dist/clawsweeper.js");
   const child = spawnSync(process.execPath, [cli, ...args], {
     cwd: options.workRoot,
-    stdio: "inherit",
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+    stdio: ["inherit", "inherit", "pipe"],
     env: process.env,
   });
+  const stderr = child.stderr ?? "";
+  if (stderr) process.stderr.write(stderr);
+  if (child.error) throw Object.assign(child.error, { stderr });
   if (child.status !== 0) {
-    throw new Error(`${process.execPath} ${cli} ${args.join(" ")} exited ${child.status}`);
+    const error = Object.assign(
+      new Error(`${process.execPath} ${cli} ${args.join(" ")} exited ${child.status}`),
+      { stderr },
+    );
+    throw ghRetryKind(error) === "throttle" ? new GitHubRateLimitError(error) : error;
   }
-}
-
-function sleep(milliseconds: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -23,6 +23,8 @@ import {
   untrustedCodexEnvForTest,
 } from "../dist/clawsweeper.js";
 import { actionIdempotencyKey } from "../dist/action-ledger.js";
+import { createApplyLeaseGuards } from "../dist/clawsweeper-apply-lease-guards.js";
+import { GitHubRateLimitError } from "../dist/github-retry.js";
 import { readText } from "./helpers.ts";
 
 test("primary command success survives best-effort action ledger flush failure", async (t) => {
@@ -610,6 +612,13 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
       outcome: "rejected",
     },
   ]);
+  assert.deepEqual(observedGitHubMutationAttemptsForTest(["throttle", "accepted"]), [
+    {
+      identity: "test_mutation:request_attempt:1",
+      idempotencyIdentity: "test_mutation",
+      outcome: "unknown",
+    },
+  ]);
   assert.deepEqual(observedGitHubMutationAttemptsForTest(["not_started"]), []);
   assert.deepEqual(heldReviewStartStatusCommentResultForTest("2026-07-12T12:00:00Z", false), {
     status: "held",
@@ -649,6 +658,62 @@ test("apply mutation receipts bind every GitHub request attempt and preserve no-
     /return \{\s*status: "posted",\s*lease: \{ \.\.\.acquired, comment: winner\.comment \},\s*didMutate: true,?\s*\}/,
   );
   assert.deepEqual(applyPhaseSequenceForTest(6), [2, 3, 4, 5, 6, 7]);
+});
+
+test("GitHub throttles abort apply lease checks and preserve durable lease ownership", () => {
+  const rateLimit = new GitHubRateLimitError(new Error("HTTP 403: API rate limit exceeded"));
+  let requests = 0;
+  const lease = { owner: "review-owner", commentId: 7, headSha: "abc123" };
+  const guards = createApplyLeaseGuards({
+    asRecord: (value: unknown) => value,
+    canonicalBoundStaleReviewReason: () => null,
+    closeDelayMs: 0,
+    currentReviewActivityBlock: () => null,
+    dryRun: false,
+    frontMatterValue: () => undefined,
+    getActiveApplyMutationLease: () => ({ itemNumber: 42, lease }),
+    ghJson: () => {
+      requests += 1;
+      throw rateLimit;
+    },
+    GitHubRuntimeBudgetError: class extends Error {},
+    initialReviewHeadSha: "abc123",
+    issueReviewCommentState: () => ({ comments: [], leaseComments: [] }),
+    item: { kind: "pull_request" },
+    liveIssueSourceRevision: () => "abc123",
+    markdownBeforeApplyDecisionMutations: "",
+    number: 42,
+    PATCHABLE_REVIEW_COMMENT_AUTHORS: new Set(["clawsweeper[bot]"]),
+    postReviewStartStatusComment: () => ({ status: "posted", lease }),
+    reportReviewRevision: null,
+    requiresApplyMutationLease: true,
+    reviewLeaseRevisionFromReport: () => null,
+    setActiveApplyMutationLease: () => undefined,
+    shouldPreserveReviewStartLease: () => false,
+    targetRepo: () => "openclaw/openclaw",
+  } as unknown as Parameters<typeof createApplyLeaseGuards>[0]);
+
+  assert.throws(
+    () => guards.refreshReviewStartLeaseState(),
+    (error) => error === rateLimit,
+  );
+  assert.throws(
+    () => guards.currentApplyMutationLeaseBlockReason(),
+    (error) => error === rateLimit,
+  );
+  assert.equal(requests, 2);
+
+  const applySource = readText("src/clawsweeper-apply-decision-workflow.ts");
+  const releaseStart = applySource.indexOf("const releaseActiveApplyMutationLease =");
+  const releaseEnd = applySource.indexOf("runtimeBudget.onFailure", releaseStart);
+  assert.match(
+    applySource.slice(releaseStart, releaseEnd),
+    /catch \(error\) \{\s*if \(error instanceof GitHubRateLimitError\) throw error;/,
+  );
+  assert.match(
+    applySource,
+    /if \(error instanceof GitHubRateLimitError\) \{[\s\S]*?activeApplyMutationLease = null;[\s\S]*?throw error;\s*\} finally \{\s*releaseActiveApplyMutationLease\(\);/,
+  );
 });
 
 test("runtime yields bind the active item and terminal Codex failures preserve retryability", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -41,6 +41,7 @@ import {
   timeoutWithinRuntimeBudget,
 } from "../dist/clawsweeper.js";
 import { parseArgs as parseClawsweeperArgs } from "../dist/clawsweeper-args.js";
+import { GitHubRateLimitError } from "../dist/github-retry.js";
 import { AUTOMATION_LIMITS } from "../dist/limits.js";
 import {
   auditRecord,
@@ -3294,6 +3295,26 @@ test("GitHub not found errors are recognizable non-retryable lookup misses", () 
   );
   assert.equal(isGitHubNotFoundError(error), true);
   assert.equal(shouldRetryGh(error), false);
+});
+
+test("GitHub rate-limit deferrals preserve available reset hints and safe defaults", () => {
+  const now = Date.parse("2026-08-05T10:00:00.000Z");
+  const retryAfter = new GitHubRateLimitError(
+    new Error("HTTP 429: secondary rate limit\nRetry-After: 120"),
+    now,
+  );
+  assert.equal(retryAfter.retryAt, "2026-08-05T10:02:00.000Z");
+
+  const reset = new GitHubRateLimitError(
+    new Error(`HTTP 403: API rate limit exceeded\nx-ratelimit-reset: ${now / 1_000 + 300}`),
+    now,
+  );
+  assert.equal(reset.retryAt, "2026-08-05T10:05:00.000Z");
+  assert.equal(new GitHubRateLimitError(reset, now + 1_000).retryAt, reset.retryAt);
+  assert.equal(
+    new GitHubRateLimitError(new Error("HTTP 429: rate limit reached"), now).retryAt,
+    "2026-08-05T10:01:00.000Z",
+  );
 });
 
 test("closing pull request references preserve fork repository identity", () => {

--- a/test/e2e/automerge/Dockerfile
+++ b/test/e2e/automerge/Dockerfile
@@ -10,6 +10,6 @@ COPY . .
 # Docker COPY preserves restrictive source directory modes but assigns root
 # ownership. Keep the image runnable by the host UID selected by the wrapper.
 RUN chmod -R a+rX /workspace
-RUN pnpm run build:repair
+RUN pnpm run build:node
 
 CMD ["node", "scripts/e2e/automerge.mjs", "--scenario", "all"]

--- a/test/e2e/automerge/Dockerfile.base
+++ b/test/e2e/automerge/Dockerfile.base
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.title="ClawSweeper automerge E2E base"
 LABEL org.opencontainers.image.source="https://github.com/openclaw/clawsweeper"
 
 RUN apt-get update \
-  && apt-get install --yes --no-install-recommends ca-certificates git python3 \
+  && apt-get install --yes --no-install-recommends ca-certificates gh git python3 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable

--- a/test/e2e/automerge/github-quota-fault.mjs
+++ b/test/e2e/automerge/github-quota-fault.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const self = fileURLToPath(import.meta.url);
+
+export function runGitHubQuotaFault({ runtimeRoot, artifacts, fixture }) {
+  runtimeRoot = fs.realpathSync(runtimeRoot);
+  const root = fs.mkdtempSync("/tmp/clawsweeper-quota-");
+  const ghBinary = execFileSync("which", ["gh"], { encoding: "utf8" }).trim();
+  const ghVersion = execFileSync(ghBinary, ["--version"], { encoding: "utf8" }).split("\n")[0];
+  const results = [];
+
+  try {
+    for (const status of [403, 429]) {
+      const workRoot = path.join(root, String(status));
+      const socket = path.join(root, `${status}.sock`);
+      const ready = path.join(workRoot, "server-ready");
+      const requests = path.join(workRoot, "requests.jsonl");
+      const output = path.join(workRoot, "github-output");
+      const batch = path.join(workRoot, "batch.json");
+      const artifactDir = path.join(workRoot, "artifacts", "event");
+      fs.mkdirSync(artifactDir, { recursive: true });
+      fs.writeFileSync(path.join(artifactDir, "42.md"), quotaProofReport());
+
+      const env = {
+        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+        HOME: workRoot,
+        GH_BIN: ghBinary,
+        GH_BIN_ARGS: "[]",
+        GH_CONFIG_DIR: path.join(workRoot, "gh-config"),
+        GH_ENTERPRISE_TOKEN: "offline-quota-proof-token",
+        GH_HOST: "127.0.0.1",
+        GH_PROMPT_DISABLED: "1",
+        GH_NO_UPDATE_NOTIFIER: "1",
+        GH_NO_EXTENSION_UPDATE_NOTIFIER: "1",
+        GH_TELEMETRY: "0",
+        NO_PROXY: "127.0.0.1,localhost",
+        no_proxy: "127.0.0.1,localhost",
+        CLAWSWEEPER_CODE_ROOT: runtimeRoot,
+        CLAWSWEEPER_GH_RETRY_ATTEMPTS: "12",
+        CLAWSWEEPER_ACTION_LEDGER_DISABLED: "1",
+        EXACT_EVENT_PUBLICATION: "true",
+        EXACT_REVIEW_BATCH_MUTATION_OUTPUT: batch,
+        EXACT_REVIEW_WORK_ROOT: workRoot,
+        GITHUB_OUTPUT: output,
+        ITEM_NUMBER: "42",
+        TARGET_REPO: "openclaw/openclaw",
+      };
+
+      const help = execFileSync(ghBinary, ["config", "--help"], { env, encoding: "utf8" });
+      assert.match(help, /http_unix_socket/, "installed GitHub CLI lacks local HTTP transport");
+      execFileSync(ghBinary, ["config", "set", "http_unix_socket", socket], { env });
+
+      const serverLog = fs.openSync(path.join(artifacts, `github-${status}.server.log`), "w");
+      const server = spawn(
+        process.execPath,
+        [self, "--serve", socket, ready, requests, String(status)],
+        {
+          env,
+          stdio: ["ignore", serverLog, serverLog],
+        },
+      );
+      fs.closeSync(serverLog);
+
+      try {
+        waitForServer(server, ready);
+        const startedAt = Date.now();
+        const publisher = spawnSync(
+          process.execPath,
+          [path.join(runtimeRoot, "dist", "repair", "publish-event-result.js")],
+          { cwd: workRoot, env, encoding: "utf8", maxBuffer: 8 * 1024 * 1024 },
+        );
+        fs.writeFileSync(
+          path.join(artifacts, `github-${status}.stdout.log`),
+          publisher.stdout ?? "",
+        );
+        fs.writeFileSync(
+          path.join(artifacts, `github-${status}.stderr.log`),
+          publisher.stderr ?? "",
+        );
+        if (publisher.error) throw publisher.error;
+        assert.equal(publisher.status, 1, `HTTP ${status} publisher must fail honestly`);
+
+        const calls = fs.readFileSync(requests, "utf8").trim().split("\n").map(JSON.parse);
+        assert.equal(calls.length, 1, `HTTP ${status} must stop after its first real request`);
+        assert.equal(calls[0].method, "GET");
+        assert.match(calls[0].path, /\/api\/v3\/repos\/openclaw\/openclaw\/issues\/42$/);
+        assert.equal(calls[0].authenticated, true);
+        assert.equal(calls.filter((call) => call.method === "DELETE").length, 0);
+
+        const fields = Object.fromEntries(
+          fs
+            .readFileSync(output, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => {
+              const separator = line.indexOf("=");
+              return [line.slice(0, separator), line.slice(separator + 1)];
+            }),
+        );
+        const durable = JSON.parse(fs.readFileSync(batch, "utf8"));
+        assert.equal(fields.completion_kind, "retryable_failure");
+        assert.equal(fields.failure_kind, "github_rate_limit");
+        assert.equal(fields.reason_code, "github_rate_limit");
+        assert.ok(Date.parse(fields.retry_at) >= startedAt + 59_000);
+        assert.equal(durable.kind, "retryable_failure");
+        assert.equal(durable.reasonCode, "github_rate_limit");
+
+        results.push({
+          http_status: status,
+          requests: calls.length,
+          request: calls[0],
+          publisher_exit: publisher.status,
+          completion_kind: fields.completion_kind,
+          failure_kind: fields.failure_kind,
+          retry_at: fields.retry_at,
+          batch_kind: durable.kind,
+          cleanup_deletes: 0,
+        });
+      } finally {
+        server.kill();
+        fs.rmSync(socket, { force: true });
+      }
+    }
+
+    const summary = {
+      status: "passed",
+      fixture,
+      scenario: "github-api-quota-fail-fast",
+      container: fs.existsSync("/.dockerenv"),
+      gh_version: ghVersion,
+      transport: "actual gh HTTP over an owned Unix socket",
+      results,
+    };
+    fs.writeFileSync(path.join(artifacts, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+    return { status: "passed", fixture, scenario: summary.scenario, artifacts };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function quotaProofReport() {
+  return [
+    "---",
+    "number: 42",
+    "repository: openclaw/openclaw",
+    "type: issue",
+    "review_status: complete",
+    "local_checkout_access: verified",
+    "decision: keep_open",
+    "action_taken: kept_open",
+    "item_snapshot_hash: quota-proof",
+    `reviewed_at: ${new Date().toISOString()}`,
+    "---",
+    "",
+    "# GitHub quota fault injection",
+    "",
+  ].join("\n");
+}
+
+function waitForServer(server, ready) {
+  const deadline = Date.now() + 10_000;
+  while (!fs.existsSync(ready)) {
+    if (server.exitCode !== null) throw new Error(`quota server exited ${server.exitCode}`);
+    if (Date.now() >= deadline) throw new Error("quota HTTP server did not become ready");
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === self && process.argv[2] === "--serve") {
+  const [, , , socket, ready, log, rawStatus] = process.argv;
+  const status = Number(rawStatus);
+  const server = http.createServer((request, response) => {
+    fs.appendFileSync(
+      log,
+      `${JSON.stringify({
+        method: request.method,
+        path: request.url,
+        user_agent: request.headers["user-agent"],
+        authenticated: Boolean(request.headers.authorization),
+      })}\n`,
+    );
+    response.writeHead(status, {
+      "content-type": "application/json",
+      "retry-after": "120",
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 300),
+    });
+    response.end(
+      JSON.stringify({
+        message: status === 403 ? "API rate limit exceeded for installation" : "Too Many Requests",
+        status: String(status),
+      }),
+    );
+  });
+  server.listen(socket, () => fs.writeFileSync(ready, "ready\n"));
+}

--- a/test/e2e/automerge/run.mjs
+++ b/test/e2e/automerge/run.mjs
@@ -10,6 +10,7 @@ import {
   createCiRegressionFixture,
   createTargetFixture,
 } from "./target-fixtures.mjs";
+import { runGitHubQuotaFault } from "./github-quota-fault.mjs";
 import { repairCommentRouterGroup, WorkflowScheduler } from "./workflow-scheduler.mjs";
 
 const helperRoot = path.dirname(fileURLToPath(import.meta.url));
@@ -18,6 +19,7 @@ export const AUTOMERGE_E2E_SCENARIOS = [
   "completed-verdict-resume",
   "completed-verdict-source-drift",
   "dependency-setup-mutation",
+  "github-api-quota-fail-fast",
   "happy-path",
   "pending-checks",
   "planning-head-drift",
@@ -67,6 +69,9 @@ export function runAutomergeE2E({
 
   try {
     const runtimeRoot = createCandidateRuntime(root, candidateRoot);
+    if (scenario === "github-api-quota-fail-fast") {
+      return runGitHubQuotaFault({ runtimeRoot, artifacts, fixture });
+    }
     if (scenario === "resume-intent-persistence") {
       assertDeferredVerdictHandoffIsolation(candidateRoot);
     }

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -25,13 +25,20 @@ test("comment router records receipts after durable command boundaries", () => {
 test("comment router wraps every GitHub mutation at the request boundary", () => {
   const source = readText("src/repair/comment-router.ts");
 
-  assert.equal(source.match(/\bghText\(/g)?.length, 2);
+  assert.doesNotMatch(source, /\bghText\(/);
   assert.equal(source.match(/\bghSpawn\(/g)?.length, 1);
   assert.doesNotMatch(source, /\bghBestEffort\b/);
   assert.doesNotMatch(source, /ghTextWithRetry as ghText/);
   assert.match(source, /function runGitHubTextMutation[\s\S]*runCommandMutationWithRetry/);
+  assert.match(source, /ghTextWithRetry\(ghArgs, \{ \.\.\.runOptions, attempts: 1 \}\)/);
+  assert.match(source, /ghTextWithRetry\(ghArgs, \{ \.\.\.options, attempts: 1 \}\)/);
+  assert.match(source, /return ghRetryKind\(error\) === "transient"/);
   assert.match(source, /function runGitHubBestEffortMutation[\s\S]*runGitHubTextMutationOnce/);
   assert.match(source, /function runGitHubSpawnMutation[\s\S]*runCommandMutation/);
+  assert.match(
+    source,
+    /const result = ghSpawn\(ghArgs, options\);\s*if \(result\.status !== 0 && ghRetryKind\(result\) === "throttle"\) \{\s*throw new GitHubRateLimitError\(result\);/,
+  );
   for (const kind of [
     "label_create",
     "label_add",
@@ -52,6 +59,38 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
   ]) {
     assert.match(source, new RegExp(`"${kind}"`), kind);
   }
+});
+
+test("router stops autoclose and reaction fan-out after the first GitHub throttle", () => {
+  const source = readText("src/repair/comment-router.ts");
+  for (const [name, expectedGuards] of [
+    ["claimedDispatchState", 2],
+    ["runGitHubBestEffortMutation", 1],
+    ["executeAutoclose", 1],
+    ["discoverAutocloseTargets", 1],
+    ["fetchCollaboratorPermission", 1],
+    ["fetchCollaboratorPermissionAsync", 1],
+    ["convergePrecreatedCommandAckComments", 1],
+    ["exactCommentVersionStillCurrent", 1],
+    ["convergeExactCommentVersionFastPathAck", 1],
+    ["reactToComment", 1],
+    ["removeOwnCommentReaction", 2],
+  ] as const) {
+    const start = source.indexOf(`function ${name}(`);
+    assert.ok(start >= 0, name);
+    const remainder = source.slice(start + 1);
+    const end = remainder.search(/\n(?:async )?function /);
+    const body = end < 0 ? remainder : remainder.slice(0, end);
+    assert.equal(
+      body.match(/if \(error instanceof GitHubRateLimitError\) throw error;/g)?.length,
+      expectedGuards,
+      name,
+    );
+  }
+  assert.match(
+    source,
+    /quotaExhausted = error instanceof GitHubRateLimitError;[\s\S]*?finally \{[\s\S]*?if \(!quotaExhausted\) clearTerminalMaintainerCommandReaction\(command\);/,
+  );
 });
 
 test("comment router isolates public target reads from its GitHub App mutation identity", () => {

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -58,7 +58,7 @@ test("batch publication bounds shared GitHub retries without dropping failed art
   assert.match(cliSource, /completions\.push\(failure\)/);
 });
 
-test("GitHub retry defaults stay unchanged while publisher attempts are bounded", () => {
+test("transient retries stay bounded while GitHub throttles defer immediately", () => {
   const previous = process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
   try {
     delete process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
@@ -70,22 +70,32 @@ test("GitHub retry defaults stay unchanged while publisher attempts are bounded"
     const boundedExecution = githubRetryExecution(3);
     assert.throws(
       () => boundedExecution.execution.ghWithRetry(["api", "repos/test/item"]),
-      /API rate limit exceeded/,
+      /HTTP 502/,
     );
     assert.equal(boundedExecution.calls(), 2);
-    assert.deepEqual(boundedExecution.waits, [30_000]);
+    assert.deepEqual(boundedExecution.waits, [2_000]);
 
-    const mutationExecution = githubRetryExecution(3);
-    assert.throws(
-      () =>
-        mutationExecution.execution.ghObservedMutationCommand({
-          args: ["api", "repos/test/item"],
-          identity: "batch-publication",
-        }),
-      /API rate limit exceeded/,
-    );
-    assert.equal(mutationExecution.calls(), 2);
-    assert.deepEqual(mutationExecution.waits, [30_000]);
+    for (const kind of ["throttle-403", "throttle-429"] as const) {
+      const throttledExecution = githubRetryExecution(3, kind);
+      assert.throws(
+        () => throttledExecution.execution.ghWithRetry(["api", "repos/test/item"]),
+        /API rate limit exceeded|HTTP 429/,
+      );
+      assert.equal(throttledExecution.calls(), 1);
+      assert.deepEqual(throttledExecution.waits, []);
+
+      const mutationExecution = githubRetryExecution(3, kind);
+      assert.throws(
+        () =>
+          mutationExecution.execution.ghObservedMutationCommand({
+            args: ["api", "repos/test/item"],
+            identity: "batch-publication",
+          }),
+        /API rate limit exceeded|HTTP 429/,
+      );
+      assert.equal(mutationExecution.calls(), 1);
+      assert.deepEqual(mutationExecution.waits, []);
+    }
 
     const explicitExecution = githubRetryExecution(2);
     assert.equal(explicitExecution.execution.ghWithRetry(["api", "repos/test/item"], 3), "ok");
@@ -355,14 +365,23 @@ test("batch commit publishes every prepared tuple to canonical Worker state", ()
   assert.doesNotMatch(cliSource, /state-publication-batch/);
 });
 
-function githubRetryExecution(failures: number) {
+function githubRetryExecution(
+  failures: number,
+  kind: "transient" | "throttle-403" | "throttle-429" = "transient",
+) {
   let calls = 0;
   const waits: number[] = [];
   class TestGitHubRuntimeBudgetError extends Error {}
   const request = () => {
     calls += 1;
     if (calls <= failures) {
-      throw new Error("API rate limit exceeded for installation ID 122230863 (HTTP 403)");
+      throw new Error(
+        kind === "throttle-403"
+          ? "API rate limit exceeded for installation ID 122230863 (HTTP 403)"
+          : kind === "throttle-429"
+            ? "HTTP 429: Too Many Requests"
+            : "HTTP 502: transient upstream failure",
+      );
     }
     return "ok";
   };

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -833,6 +833,14 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(failGeneration.if ?? "", /complete-exact-review-queue\.outcome != 'success'/);
   assert.match(releaseGeneration.if ?? "", /reserve-exact-review-lease\.outputs\.status != 'held'/);
   assert.match(releaseGeneration.run ?? "", /content == "eyes"/);
+  for (const cleanup of [releaseGeneration, step(reviewer, "Mark unsuccessful re-review")]) {
+    for (const kind of ["github_rate_limit", "github_transient"]) {
+      assert.match(
+        cleanup.if ?? "",
+        new RegExp(`prepare-direct-exact-review-publication\\.outputs\\.failure_kind != '${kind}'`),
+      );
+    }
+  }
   assert.ok(reviewer.steps.indexOf(upload) < reviewer.steps.indexOf(complete));
 
   assert.equal(publisher.needs, undefined);
@@ -962,7 +970,12 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   const publishResult = step(publisher, "Export exact review publication result");
   const publishComplete = step(publisher, "Complete durable exact review publication");
   const activeLeaseWaiting = step(publisher, "Mark active lease retry waiting");
-  const publicationPressure = step(publisher, "Probe GitHub pressure after publication failure");
+  assert.equal(
+    publisher.steps.some(
+      (candidate) => candidate.name === "Probe GitHub pressure after publication failure",
+    ),
+    false,
+  );
   const releaseTerminal = step(publisher, "Release terminal review leases");
   const releaseUnsuccessful = step(
     publisher,
@@ -974,10 +987,16 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(releaseUnsuccessful.run ?? "", /content == "eyes"/);
   assert.match(releaseUnsuccessful.if ?? "", /completion_kind == 'superseded'/);
   assert.doesNotMatch(releaseUnsuccessful.if ?? "", /completion_kind == 'deferred'/);
+  for (const kind of ["github_rate_limit", "github_transient"]) {
+    assert.match(
+      releaseUnsuccessful.if ?? "",
+      new RegExp(`publish-event-result\\.outputs\\.failure_kind != '${kind}'`),
+    );
+  }
   assert.match(publishResult.env?.PRIOR_JOB_STATUS ?? "", /job\.status/);
   assert.match(publishResult.env?.LEGACY_TUPLELESS ?? "", /legacy-exact-artifact/);
   assert.match(publishResult.env?.FAILURE_KIND ?? "", /publish-event-result/);
-  assert.match(publishResult.env?.FAILURE_KIND ?? "", /publication-pressure/);
+  assert.doesNotMatch(publishResult.env?.FAILURE_KIND ?? "", /publication-pressure/);
   assert.match(publishResult.env?.DOWNLOAD_OUTCOME ?? "", /download-exact-review-bundle/);
   assert.match(publishResult.env?.VALIDATE_OUTCOME ?? "", /validate-exact-review-bundle/);
   assert.match(publishResult.env?.PUBLISH_COMPLETION_KIND ?? "", /publish-event-result/);
@@ -986,12 +1005,6 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(publishResult.env?.DIRECT_RECOVERY_DIRECT_REQUEUE ?? "", /replay-direct-lifecycle/);
   assert.match(publishResult.run ?? "", /DIRECT_RECOVERY_OUTCOME/);
   assert.match(publishResult.run ?? "", /direct_requeue=/);
-  assert.match(publicationPressure.if ?? "", /failure\(\)/);
-  assert.match(publicationPressure.run ?? "", /gh api rate_limit/);
-  assert.match(publicationPressure.run ?? "", /failure_kind=github_rate_limit/);
-  assert.match(publicationPressure.run ?? "", /failure_kind=github_transient/);
-  assert.match(publicationPressure.run ?? "", /HTTP 429/);
-  assert.doesNotMatch(publicationPressure.run ?? "", /HTTP \(403\|429\)/);
   assert.match(publishResult.run ?? "", /REQUEUE_LATEST.*SOURCE_DRIFT_OUTCOME/);
   assert.match(publishResult.run ?? "", /LEGACY_TUPLELESS.*SOURCE_DRIFT_OUTCOME/);
   assert.match(publishResult.run ?? "", /completion_kind=superseded/);
@@ -1002,6 +1015,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(publishResult.run ?? "", /reason_code=review_lease_active/);
   assert.match(publishResult.run ?? "", /reason_code=review_lease_active[\s\S]*?outcome=success/);
   assert.match(publishResult.run ?? "", /retry_at="\$PUBLISH_RETRY_AT"/);
+  assert.match(
+    publishResult.run ?? "",
+    /reason_code="\$FAILURE_KIND"\s+retry_at="\$PUBLISH_RETRY_AT"/,
+  );
   assert.match(
     publishResult.run ?? "",
     /completion_kind" != "superseded".*completion_kind" != "deferred".*completion_kind" != "refresh_required".*completion_kind" != "retryable_failure"/,
@@ -1067,11 +1084,13 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(publisherSource, /\/internal\/exact-review\/publication-batch-results/);
   assert.doesNotMatch(publisherSource, /\bstagePaths\b|\bpushSingleRecordTupleCommit\b/);
   assert.doesNotMatch(publisherSource, /GitCommandTimeoutError|publishRoot|hardResetToRemoteMain/);
-  assert.match(publisherSource, /const completionKind = "permanent_failure"/);
-  assert.match(
-    publisherSource,
-    /writePublicationCompletionOutputs\(completionKind, reasonCode, fingerprint\);/,
-  );
+  assert.match(publisherSource, /const retryableFailure =/);
+  assert.match(publisherSource, /error instanceof GitHubRateLimitError/);
+  assert.match(publisherSource, /error\.retryAt : undefined/);
+  assert.match(publisherSource, /failure_kind=\$\{reasonCode\}/);
+  assert.match(publisherSource, /publication\.status === 429/);
+  assert.match(publisherSource, /\? "state_contention"\s*: "policy_invariant"/);
+  assert.doesNotMatch(publisherSource, /attempt <= 20|Event publish attempt/);
   assert.doesNotMatch(publisherSource, /retryableFailure \? "github_transient" : undefined/);
   const directPublisherSource = readText("src/repair/exact-review-direct-publication.ts");
   assert.match(directPublisherSource, /invalid_direct_source_action/);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -776,9 +776,92 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     "${{ steps.live-item.outputs.admission_retry }}",
   );
   assert.match(generationResult.env?.RETRY_KIND ?? "", /live-item\.outputs\.retry_kind/);
-  assert.match(generationResult.run ?? "", /ADMISSION_RETRY.*true.*-z.*RETRY_KIND/s);
+  assert.match(generationResult.env?.RETRY_AT ?? "", /live-item\.outputs\.retry_at/);
+  assert.equal(
+    generationResult.env?.DIRECT_PUBLICATION_FAILURE_KIND,
+    "${{ steps.prepare-direct-exact-review-publication.outputs.failure_kind }}",
+  );
+  assert.equal(
+    generationResult.env?.DIRECT_PUBLICATION_RETRY_AT,
+    "${{ steps.prepare-direct-exact-review-publication.outputs.retry_at }}",
+  );
+  assert.match(
+    generationResult.run ?? "",
+    /DIRECT_PUBLICATION_FAILURE_KIND.*github_rate_limit.*PUBLICATION_QUEUE_OUTCOME.*!=.*success[\s\S]*retry_kind=throttle[\s\S]*retry_at="\$DIRECT_PUBLICATION_RETRY_AT"/,
+  );
+  assert.match(generationResult.run ?? "", /ADMISSION_RETRY.*true.*-z.*retry_kind/s);
   assert.match(generationResult.run ?? "", /ADMISSION_RETRY.*true[\s\S]*outcome=success/);
   assert.match(generationResult.run ?? "", /requeue_latest=true/);
+  assert.match(generationResult.run ?? "", /echo "retry_kind=\$retry_kind"/);
+  assert.match(generationResult.run ?? "", /echo "retry_at=\$retry_at"/);
+  const runGenerationResult = (overrides: Record<string, string>) => {
+    const root = mkdtempSync(`${tmpPrefix}exact-review-generation-result-`);
+    const outputPath = join(root, "github-output");
+    try {
+      execFileSync("bash", ["-c", generationResult.run ?? ""], {
+        env: {
+          ...process.env,
+          ADMISSION_RETRY: "false",
+          RETRY_KIND: "",
+          RETRY_AT: "",
+          DIRECT_PUBLICATION_FAILURE_KIND: "",
+          DIRECT_PUBLICATION_RETRY_AT: "",
+          TARGET_ENABLED: "true",
+          LIVE_OUTCOME: "success",
+          REVIEW_OUTCOME: "success",
+          REVIEW_SUPERSEDED: "false",
+          RESERVATION_STATUS: "",
+          PUBLICATION_QUEUE_OUTCOME: "failure",
+          DIRECT_PUBLICATION_ACCEPTED: "false",
+          DIRECT_PUBLICATION_SUPERSEDED: "false",
+          DIRECT_LIFECYCLE_OUTCOME: "failure",
+          DIRECT_LIFECYCLE_REQUEUE: "false",
+          GITHUB_OUTPUT: outputPath,
+          ...overrides,
+        },
+      });
+      return Object.fromEntries(
+        readFileSync(outputPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => {
+            const separator = line.indexOf("=");
+            return [line.slice(0, separator), line.slice(separator + 1)];
+          }),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+  const directRetryAt = "2026-08-06T00:00:00.000Z";
+  assert.deepEqual(
+    runGenerationResult({
+      DIRECT_PUBLICATION_FAILURE_KIND: "github_rate_limit",
+      DIRECT_PUBLICATION_RETRY_AT: directRetryAt,
+      PUBLICATION_QUEUE_OUTCOME: "success",
+    }),
+    {
+      outcome: "success",
+      requeue_latest: "false",
+      direct_lifecycle_requeue: "false",
+      retry_kind: "",
+      retry_at: "",
+    },
+  );
+  assert.deepEqual(
+    runGenerationResult({
+      DIRECT_PUBLICATION_FAILURE_KIND: "github_rate_limit",
+      DIRECT_PUBLICATION_RETRY_AT: directRetryAt,
+      PUBLICATION_QUEUE_OUTCOME: "failure",
+    }),
+    {
+      outcome: "failure",
+      requeue_latest: "false",
+      direct_lifecycle_requeue: "false",
+      retry_kind: "throttle",
+      retry_at: directRetryAt,
+    },
+  );
   assert.equal(
     step(reviewer, "Export exact review generation result").env?.DIRECT_LIFECYCLE_OUTCOME,
     "${{ steps.finalize-direct-exact-review-lifecycle.outcome }}",
@@ -818,8 +901,14 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(complete.run ?? "", /completion_kind: "superseded"/);
   assert.match(complete.env?.PRIMARY_OUTCOME ?? "", /exact-review-generation-result/);
   assert.match(complete.env?.REQUEUE_LATEST ?? "", /exact-review-generation-result/);
-  assert.match(complete.env?.RETRY_AT ?? "", /live-item\.outputs\.retry_at/);
-  assert.match(complete.env?.RETRY_KIND ?? "", /live-item\.outputs\.retry_kind/);
+  assert.equal(
+    complete.env?.RETRY_AT,
+    "${{ steps.exact-review-generation-result.outputs.retry_at }}",
+  );
+  assert.equal(
+    complete.env?.RETRY_KIND,
+    "${{ steps.exact-review-generation-result.outputs.retry_kind }}",
+  );
   assert.match(complete.run ?? "", /retry_kind: retryKind/);
   assert.match(complete.run ?? "", /requeue_latest: true/);
   assert.match(deferHeldReview.if ?? "", /reserve-exact-review-lease\.outputs\.status == 'held'/);
@@ -831,6 +920,95 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.match(failGeneration.if ?? "", /review-exact-event-item\.outputs\.superseded != 'true'/);
   assert.match(failGeneration.if ?? "", /complete-exact-review-queue\.outcome != 'success'/);
+  assert.match(
+    failGeneration.if ?? "",
+    /exact-review-generation-result\.outputs\.retry_kind == ''/,
+  );
+  const evaluateFailureGate = (values: Record<string, string>): boolean => {
+    const expression = (failGeneration.if ?? "")
+      .replace(/^\s*\$\{\{\s*|\s*\}\}\s*$/g, "")
+      .replace(/\balways\(\)/g, "true")
+      .replace(
+        /steps\.([a-z0-9-]+)\.(outputs\.([a-z0-9_]+)|outcome)/g,
+        (_match, stepId: string, access: string, outputName?: string) =>
+          JSON.stringify(values[`${stepId}.${outputName ?? access}`] ?? ""),
+      );
+    return Boolean(Function(`"use strict"; return (${expression});`)());
+  };
+  const failureGateCases = [
+    {
+      name: "typed throttle with durable completion",
+      values: {
+        "claim-exact-review-queue.claimed": "true",
+        "direct-exact-review-publication.accepted": "false",
+        "complete-exact-review-queue.outcome": "success",
+        "reserve-exact-review-lease.status": "",
+        "review-exact-event-item.superseded": "false",
+        "exact-review-generation-result.outcome": "failure",
+        "exact-review-generation-result.retry_kind": "throttle",
+      },
+      expected: false,
+    },
+    {
+      name: "typed coordination with durable completion",
+      values: {
+        "claim-exact-review-queue.claimed": "true",
+        "direct-exact-review-publication.accepted": "false",
+        "complete-exact-review-queue.outcome": "success",
+        "reserve-exact-review-lease.status": "held",
+        "review-exact-event-item.superseded": "false",
+        "exact-review-generation-result.outcome": "failure",
+        "exact-review-generation-result.retry_kind": "coordination",
+      },
+      expected: false,
+    },
+    {
+      name: "typed throttle with failed completion",
+      values: {
+        "claim-exact-review-queue.claimed": "true",
+        "direct-exact-review-publication.accepted": "false",
+        "complete-exact-review-queue.outcome": "failure",
+        "reserve-exact-review-lease.status": "",
+        "review-exact-event-item.superseded": "false",
+        "exact-review-generation-result.outcome": "failure",
+        "exact-review-generation-result.retry_kind": "throttle",
+      },
+      expected: true,
+    },
+    {
+      name: "ordinary failure after durable completion",
+      values: {
+        "claim-exact-review-queue.claimed": "true",
+        "direct-exact-review-publication.accepted": "false",
+        "complete-exact-review-queue.outcome": "success",
+        "reserve-exact-review-lease.status": "",
+        "review-exact-event-item.superseded": "false",
+        "exact-review-generation-result.outcome": "failure",
+        "exact-review-generation-result.retry_kind": "",
+      },
+      expected: true,
+    },
+    {
+      name: "superseded reservation",
+      values: {
+        "claim-exact-review-queue.claimed": "true",
+        "direct-exact-review-publication.accepted": "false",
+        "complete-exact-review-queue.outcome": "success",
+        "reserve-exact-review-lease.status": "superseded",
+        "review-exact-event-item.superseded": "false",
+        "exact-review-generation-result.outcome": "failure",
+        "exact-review-generation-result.retry_kind": "",
+      },
+      expected: false,
+    },
+  ] as const;
+  for (const failureGateCase of failureGateCases) {
+    assert.equal(
+      evaluateFailureGate(failureGateCase.values),
+      failureGateCase.expected,
+      failureGateCase.name,
+    );
+  }
   assert.match(releaseGeneration.if ?? "", /reserve-exact-review-lease\.outputs\.status != 'held'/);
   assert.match(releaseGeneration.run ?? "", /content == "eyes"/);
   for (const cleanup of [releaseGeneration, step(reviewer, "Mark unsuccessful re-review")]) {


### PR DESCRIPTION
## Maintainer Repair - Exact Head `da805e7fa441579b450abe29d72ddce4eda8874c`

The workflow retry contract is now canonical at the generation-result owner:

- direct `github_rate_limit` becomes typed `retry_kind=throttle` with its original deadline only when durable fallback enqueue fails;
- a successful fallback enqueue clears typed retry metadata so Worker terminal-success validation remains valid;
- coordination and throttle outcomes stay `outcome=failure` for queue budgeting;
- the generic failure sentinel is suppressed only after successful durable completion or supersession; completion failures and ordinary failures remain red.

Current-head proof before hosted CI:

- signed commit and clean two-file diff (`.github/workflows/sweep.yml`, `test/sweep-workflow.test.ts`);
- `pnpm run build:node`: passed;
- focused workflow contract: 1 passed;
- Worker retry contract: 2 passed;
- host quota E2E, both `tiny` and `openclaw-shaped`: passed;
- targeted oxfmt/oxlint and `git diff --check`: passed;
- local full `pnpm check`: static/build/lint/changed-coverage lanes passed; the broad coverage runner stalled locally and was stopped, so exact-head hosted CI is authoritative;
- completed local branch review found one P1 (successful fallback incorrectly retained throttle metadata); fixed in this head. The required second local review exceeded its configured bound without a report, so no verdict is claimed.

Exact-head hosted proof is green: [CI run 31056114824](https://github.com/openclaw/clawsweeper/actions/runs/31056114824) passed full `pnpm check`, Windows launcher, and sparse repair build; [Docker E2E run 31056114696](https://github.com/openclaw/clawsweeper/actions/runs/31056114696) passed all hermetic scenarios and uploaded proof; [CodeQL run 31056118193](https://github.com/openclaw/clawsweeper/actions/runs/31056118193) passed both lanes. Durable ClawSweeper exact-head review remains before merge.

### Exact-Head Workflow-Boundary Proof

[Hosted Docker run 31056114696](https://github.com/openclaw/clawsweeper/actions/runs/31056114696) is pinned to exact head `da805e7fa441579b450abe29d72ddce4eda8874c`. Its retained [artifact 8950428420](https://github.com/openclaw/clawsweeper/actions/runs/31056114696/artifacts/8950428420) (`sha256:fa9f7f29ddd012a37b669de90014c77d5b7f0e095e69087c0e5852f52efd2a67`) contains real GitHub CLI HTTP 403/429 results for both fixtures: one authenticated request, `completion_kind=retryable_failure`, `failure_kind=github_rate_limit`, a concrete `retry_at`, and zero cleanup deletes.

To prove the changed workflow handoff at the same head, the exact YAML bodies for `Export exact review generation result` and `Complete exact-review queue lease` were executed unchanged. Each retained artifact result supplied the direct-publication kind/deadline; an owned local HTTP receiver accepted the actual completion POST. This is a queue-boundary fixture, not a live production Worker claim. The resulting redacted transcript shows the deadline survives as typed `throttle`, queue completion remains `outcome=failure` for budget accounting, and the generic failure sentinel stays suppressed only after the durable completion returns HTTP 200.

```json
{"head":"da805e7fa441","fixture":"tiny","http_status":403,"publisher_requests":1,"cleanup_deletes":0,"generation_result":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:24:34.584Z"},"queue_completion_http":200,"queue_completion_payload":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:24:34.584Z","requeue_latest":false},"generic_failure_sentinel_after_durable_completion":false}
{"head":"da805e7fa441","fixture":"tiny","http_status":429,"publisher_requests":1,"cleanup_deletes":0,"generation_result":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:24:34.907Z"},"queue_completion_http":200,"queue_completion_payload":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:24:34.907Z","requeue_latest":false},"generic_failure_sentinel_after_durable_completion":false}
{"head":"da805e7fa441","fixture":"openclaw-shaped","http_status":403,"publisher_requests":1,"cleanup_deletes":0,"generation_result":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:27:05.390Z"},"queue_completion_http":200,"queue_completion_payload":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:27:05.390Z","requeue_latest":false},"generic_failure_sentinel_after_durable_completion":false}
{"head":"da805e7fa441","fixture":"openclaw-shaped","http_status":429,"publisher_requests":1,"cleanup_deletes":0,"generation_result":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:27:05.779Z"},"queue_completion_http":200,"queue_completion_payload":{"outcome":"failure","retry_kind":"throttle","retry_at":"2026-08-05T23:27:05.779Z","requeue_latest":false},"generic_failure_sentinel_after_durable_completion":false}
```

---

## What Problem This Solves

Maintainers waiting for ClawSweeper review completion can instead see an indefinitely started-only placeholder when the GitHub App exhausts its API quota. Publication previously retried the exhausted API for roughly 21 minutes, attempted additional quota probes, mutation fallbacks, reactions, permission reads and lease cleanup, and could report workflow success without a durably published review.

## Why This Change Was Made

Classify real GitHub HTTP 403/429 throttles at the canonical execution, router-mutation and dispatch boundaries; stop after the first exhausted request; preserve a typed retry timestamp across the publication child; and persist a truthful retryable outcome through the existing durable queue. When stock `gh api` does not expose response headers, defer safely for at least 60 seconds without extra requests; use observed reset hints only when they actually exist in error text.

Preserve bounded transient retry configuration; public-read versus privileged GitHub App token isolation; exact-head fences; mutation receipts and idempotency; signed publication; capability-bound acknowledgements; ordinary cleanup; locked-conversation terminal behavior; and non-throttle/404 compatibility. Propagate quota exhaustion through recovery labels, both lease guards, privileged permission/dispatch/acknowledgement paths, autoclose/reaction fan-out, best-effort mutations and dispatch fallback. An already acquired remote lease remains intact until expiry without issuing a post-throttle cleanup request.

Remove the obsolete throttle-status publication, duplicate retry loop and post-failure quota probe. Relative to reviewed branch base `14bd27bc8fa1232dd866aba9a9b525496fba200e`: **production source -34 LOC; workflow -25 LOC; regression/integration tests +369 LOC**. The additional integration changes are confined to the existing Docker E2E harness: install the distribution's actual GitHub CLI in its existing test image, build existing core+repair artifacts, and register one genuine HTTP quota-fault scenario.

## User Impact

Rate-limited reviews stop consuming GitHub App quota immediately, expose the actual failure, and remain durably retryable after a safe delay. Maintainers avoid silent review stalls, false-success publication and repeated privileged cleanup/mutation requests while ordinary transient retries, locked-conversation handling and upstream credential routing remain unchanged.

OpenClaw Bay is unaffected: this changes only internal publication/retry owners and existing workflow outputs. No Bay observer contract, dashboard mutation, queue-control action, deployment or workflow control is introduced.

Named distinct follow-up outside this CLI/router owner: **clawsweeper: make direct-fetch review-placeholder recovery share durable GitHub throttle classification**.

## Evidence

- Exact committed head: `b1840c9a91e0131df18142f06697bc574f209373`; reviewed branch base: `14bd27bc8fa1232dd866aba9a9b525496fba200e`.
- Required fresh independent full-branch autoreview: `--mode branch --base 14bd27bc8fa1232dd866aba9a9b525496fba200e --engine codex --model gpt-5.6-sol --thinking xhigh`; complete 68,415-byte, 19-file branch bundle; **no accepted/actionable findings**, confidence **0.94**. The required pre-commit review also passed at **0.98**.
- Exact-head `pnpm run build:node`, targeted oxlint/oxfmt, syntax and staged-diff checks: **passed**.
- Exact-head grouped existing owner/workflow regression tests: **13 passed, 0 failed**; covers token routing, bounded transient retry, quota classification, lease guards, router fan-out, dispatch/idempotency, locked behavior and all three workflow cleanup guards.
- Exact-head existing E2E harness on this Mac: **both fixtures passed** (`tiny`, `openclaw-shaped`); each fixture executed real production publication through the actual GitHub CLI and an owned HTTP transport against both real **403** and **429** responses.
- Exact-head authoritative repository-owned hosted Ubuntu full `pnpm run check`, Windows launcher, sparse-checkout/build and CodeQL: **SUCCESS**.
- Exact-head existing repository-owned **Docker production E2E including actual HTTP 403/429 quota injection: SUCCESS**; [Blacksmith run 31034348973, production automerge flow job 92402582522](https://github.com/openclaw/clawsweeper/actions/runs/31034348973/job/92402582522); retained [Docker proof artifact automerge-e2e-31034348973-1](https://github.com/openclaw/clawsweeper/actions/runs/31034348973/artifacts/8942142013), ID `8942142013`, digest `sha256:2ba9422bb61d1312dac94477929c342ca61e8886737230ed117a637bae7578c8`; **28 passing scenario summaries**, including both fixtures with real in-container 403 and 429 results.
- This remains a draft; no merge or automerge is requested.

## Real Behavior Proof

**Claim:** Real HTTP 403 and 429 responses stop the actual compiled publisher and GitHub transport after one request and durably emit a retryable publication outcome. Existing exact-head owner regressions separately prove acquired lease retention, cleanup-first throttle handling, one-attempt router mutations and dispatch fallback suppression.

**Exercised production boundary:** Existing E2E runner -> compiled `dist/repair/publish-event-result.js` -> compiled `dist/clawsweeper.js apply-artifacts` / `apply-decisions` -> actual installed `gh` binary selected through production `GH_BIN` -> real owned Unix-domain HTTP server returning actual HTTP status/body/headers -> on-disk `GITHUB_OUTPUT` and publication batch artifact. No fake `gh` executable, network replay, mocked HTTP client or synthetic production entry point is used.

**Container route:** The existing repository-owned GitHub Actions / Blacksmith Docker E2E workflow automatically builds its existing Linux test image with Debian's actual `gh` package and the repository's existing core+repair build, then runs `github-api-quota-fail-fast` for both existing fixtures alongside every preexisting production scenario. The same helper ran successfully against actual GitHub CLI **2.96.0** on this Mac. The exact-head hosted Docker execution **PASSED** on repository-owned GitHub Actions / Blacksmith provider `blacksmith-16vcpu-ubuntu-2404`, runner `blacksmith-scale1-01kz9jht7m3dq05jrzwckpjh8d-16vcpu`; application image `clawsweeper-automerge-e2e:local`, repository-built base `clawsweeper-automerge-e2e-base:repository`; [run 31034348973, job 92402582522](https://github.com/openclaw/clawsweeper/actions/runs/31034348973/job/92402582522); retained [artifact 8942142013](https://github.com/openclaw/clawsweeper/actions/runs/31034348973/artifacts/8942142013), `sha256:2ba9422bb61d1312dac94477929c342ca61e8886737230ed117a637bae7578c8`, **28 passing scenario summaries**. The execution lease/isolated resource identity is the existing GitHub Actions job and workflow-run allocation; this was not a Crabbox allocation and no Crabbox lease is claimed. The image ran actual Debian GitHub CLI **2.23.0+dfsg1-1** and persisted both fixture summaries with `container: true`.

**Observed exact-head hosted Docker artifact transcript (redacted):**

```json
{"head":"b1840c9a91e0","provider":"blacksmith-16vcpu-ubuntu-2404","run":31034348973,"job":92402582522,"artifact":8942142013,"fixture":"openclaw-shaped","container":true,"client":"gh version 2.23.0 (2023-02-27 Debian 2.23.0+dfsg1-1)","scenario":"github-api-quota-fail-fast","http_status":403,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","authenticatedWithFakeToken":true,"publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:26:50.596Z","batch_kind":"retryable_failure","cleanup_deletes":0}
{"head":"b1840c9a91e0","provider":"blacksmith-16vcpu-ubuntu-2404","run":31034348973,"job":92402582522,"artifact":8942142013,"fixture":"openclaw-shaped","container":true,"client":"gh version 2.23.0 (2023-02-27 Debian 2.23.0+dfsg1-1)","scenario":"github-api-quota-fail-fast","http_status":429,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","authenticatedWithFakeToken":true,"publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:26:50.921Z","batch_kind":"retryable_failure","cleanup_deletes":0}
{"head":"b1840c9a91e0","provider":"blacksmith-16vcpu-ubuntu-2404","run":31034348973,"job":92402582522,"artifact":8942142013,"fixture":"tiny","container":true,"client":"gh version 2.23.0 (2023-02-27 Debian 2.23.0+dfsg1-1)","scenario":"github-api-quota-fail-fast","http_status":403,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","authenticatedWithFakeToken":true,"publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:24:07.666Z","batch_kind":"retryable_failure","cleanup_deletes":0}
{"head":"b1840c9a91e0","provider":"blacksmith-16vcpu-ubuntu-2404","run":31034348973,"job":92402582522,"artifact":8942142013,"fixture":"tiny","container":true,"client":"gh version 2.23.0 (2023-02-27 Debian 2.23.0+dfsg1-1)","scenario":"github-api-quota-fail-fast","http_status":429,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","authenticatedWithFakeToken":true,"publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:24:07.973Z","batch_kind":"retryable_failure","cleanup_deletes":0}
```

**Observed exact-head host transcript (redacted):**

```json
{"head":"b1840c9a91e0","fixture":"tiny","scenario":"github-api-quota-fail-fast","client":"GitHub CLI 2.96.0","transport":"actual HTTP via owned Unix socket","http_status":403,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","authenticatedWithFakeToken":true,"publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:24:58.722Z","batch_kind":"retryable_failure","cleanup_deletes":0}
{"head":"b1840c9a91e0","fixture":"tiny","scenario":"github-api-quota-fail-fast","http_status":429,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:25:04.015Z","batch_kind":"retryable_failure","cleanup_deletes":0}
{"head":"b1840c9a91e0","fixture":"openclaw-shaped","scenario":"github-api-quota-fail-fast","http_status":403,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:25:04.774Z","batch_kind":"retryable_failure","cleanup_deletes":0}
{"head":"b1840c9a91e0","fixture":"openclaw-shaped","scenario":"github-api-quota-fail-fast","http_status":429,"requests":1,"method":"GET","path":"/api/v3/repos/openclaw/openclaw/issues/42","publisher_exit":1,"completion_kind":"retryable_failure","failure_kind":"github_rate_limit","retry_at":"2026-08-05T18:25:07.081Z","batch_kind":"retryable_failure","cleanup_deletes":0}
```

Each case asserts exactly one authenticated request, a truthful nonzero publisher exit, persisted `completion_kind=retryable_failure`, `failure_kind=github_rate_limit`, `reason_code=github_rate_limit`, `retry_at >= now + 59s`, durable batch `kind=retryable_failure`/`reasonCode=github_rate_limit`, and zero cleanup `DELETE` requests. These first-fetch cases do not acquire a lease; already-held lease retention and cleanup-first throttles are covered by separate focused production-owner regressions and the previously observed actual-client traces.

The real HTTP server returns `Retry-After`, `X-RateLimit-Remaining: 0` and `X-RateLimit-Reset`; stock `gh api` does not expose headers without `--include`, so production truthfully uses its observed **>=60-second fallback** rather than claiming header extraction or adding a quota probe. Only isolated temporary `GH_CONFIG_DIR`/`HOME`, an owned Unix socket and a synthetic enterprise token are used; credentials/proxies are not inherited, tokens never enter artifacts, and no external network, real GitHub, live Worker, user GitHub configuration, trust store, gateway, workflow dispatch, deployment or service is contacted.





