### PR TITLE
fix(publication): isolate public reads and preserve close safeguards

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1347,6 +1347,7 @@ jobs:
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          REPO_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
           MIN_AGE_MINUTES: "0"

--- a/src/clawsweeper-github-context.ts
+++ b/src/clawsweeper-github-context.ts
@@ -1,4 +1,5 @@
 import { parseGhJson } from "./github-json.js";
+import { exactPublicationPublicReadToken } from "./github-public-read.js";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
   REVIEWED_PR_ACTIVITY_THREADS_QUERY,
@@ -41,8 +42,12 @@ export function createGitHubContext({
     return serialized ? `${base}?${serialized}` : base;
   }
 
-  function ghPaged<T>(path: string): T[] {
-    const pages = ghJson<unknown[]>(["api", githubPaginatedPath(path), "--paginate", "--slurp"]);
+  function ghPaged<T>(path: string, options: { requireApp?: boolean } = {}): T[] {
+    const args = ["api", githubPaginatedPath(path), "--paginate", "--slurp"];
+    if (options.requireApp && exactPublicationPublicReadToken(args, targetRepo())) {
+      args.push("--method", "GET");
+    }
+    const pages = ghJson<unknown[]>(args);
     if (!Array.isArray(pages)) return [];
     return pages.flatMap((page) => (Array.isArray(page) ? (page as T[]) : []));
   }

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import type { GitHubRuntimeBudget } from "./clawsweeper-types.js";
 import { codexEnv } from "./codex-env.js";
 import { resolveCommand } from "./command.js";
+import { exactPublicationPublicReadToken } from "./github-public-read.js";
 
 interface CreateGitHubRuntimeDependencies {
   ROOT: string;
@@ -98,8 +99,12 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
   }
 
   function ghWithPreparedTimeout(args: string[], timeoutMs: number | undefined): string {
-    if (args[0] === "api") return run("gh", args, { timeoutMs });
-    return run("gh", ["--repo", targetRepo(), ...args], { timeoutMs });
+    const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
+    const publicReadToken = exactPublicationPublicReadToken(resolvedArgs, targetRepo());
+    return run("gh", resolvedArgs, {
+      timeoutMs,
+      ...(publicReadToken ? { env: { GH_TOKEN: publicReadToken } } : {}),
+    });
   }
 
   function gh(args: string[]): string {
@@ -108,7 +113,12 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
 
   function ghOnce(args: string[], timeoutMs: number): string {
     const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
-    const env = { ...process.env, GIT_OPTIONAL_LOCKS: "0" };
+    const publicReadToken = exactPublicationPublicReadToken(resolvedArgs, targetRepo());
+    const env = {
+      ...process.env,
+      GIT_OPTIONAL_LOCKS: "0",
+      ...(publicReadToken ? { GH_TOKEN: publicReadToken } : {}),
+    };
     const command = resolveCommand("gh", resolvedArgs, env);
     const commandTimeoutMs = githubCommandTimeoutMs(timeoutMs) ?? timeoutMs;
     const runtimeLimitedTimeout = commandTimeoutMs < timeoutMs;

--- a/src/clawsweeper-review-comment-publication.ts
+++ b/src/clawsweeper-review-comment-publication.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { closeReasonText } from "./clawsweeper-close-reasons.js";
@@ -140,10 +141,11 @@ export function createReviewCommentPublication(
   }
 
   function writeCommentPayload(number: number, body: string): string {
-    const commentFile = join(ROOT, ".artifacts", `comment-${number}.md`);
+    const commentPath = join(ROOT, ".artifacts", `comment-${number}-${randomUUID()}`);
+    const commentFile = `${commentPath}.md`;
     ensureDir(dirname(commentFile));
     writeFileSync(commentFile, body, "utf8");
-    const commentPayloadFile = join(ROOT, ".artifacts", `comment-${number}.json`);
+    const commentPayloadFile = `${commentPath}.json`;
     writeFileSync(commentPayloadFile, JSON.stringify({ body }), "utf8");
     return commentPayloadFile;
   }

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -35,6 +35,7 @@ import { createDashboardAudit } from "./clawsweeper-dashboard-audit.js";
 import { createGitHubContext } from "./clawsweeper-github-context.js";
 import { createGitHubExecution } from "./clawsweeper-github-execution.js";
 import { createGitHubRuntime } from "./clawsweeper-github-runtime.js";
+import { exactPublicationPublicReadToken } from "./github-public-read.js";
 import { createItemContext } from "./clawsweeper-item-context.js";
 import {
   applyBlockingProtectedLabels,
@@ -511,8 +512,11 @@ const applyGuards = createApplyGuards({
   authorPrBudget: () => authorPrBudget(),
   authorPrBudgetAgeSkipReason,
   authorPrBudgetCloseEnabled: () => authorPrBudgetCloseEnabled(),
-  ghJson,
-  ghPaged,
+  ghJson: <T>(args: string[]): T =>
+    ghJson<T>(
+      exactPublicationPublicReadToken(args, targetRepo()) ? [...args, "--method", "GET"] : args,
+    ),
+  ghPaged: <T>(path: string): T[] => ghPaged<T>(path, { requireApp: true }),
   isMaintainerAuthorAssociation,
   isMaintainerAuthored,
   isOlderThanDays,

--- a/src/codex-env.ts
+++ b/src/codex-env.ts
@@ -72,6 +72,7 @@ export function codexEnv(options: CodexEnvOptions = {}): NodeJS.ProcessEnv {
   const ghToken = options.ghToken?.trim();
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
+  delete env.REPO_TOKEN;
   delete env.COMMIT_SWEEPER_TARGET_GH_TOKEN;
   delete env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN;
   delete env.CLAWSWEEPER_APP_ID;
@@ -80,6 +81,9 @@ export function codexEnv(options: CodexEnvOptions = {}): NodeJS.ProcessEnv {
   delete env.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL;
   delete env.CLAWSWEEPER_CRABFLEET_WORK_STATE_URL;
+  for (const key of Object.keys(env)) {
+    if (/^CLAWSWEEPER_.*GH_TOKEN$/.test(key)) delete env[key];
+  }
   if (!options.preserveCodexAuth) {
     if (env.CLAWSWEEPER_RUNNER !== "openclaw") delete env.OPENAI_API_KEY;
     delete env.CODEX_API_KEY;

--- a/src/github-public-read.ts
+++ b/src/github-public-read.ts
@@ -1,0 +1,42 @@
+export function isPublicOpenClawReadOnlyRequest(ghArgs: readonly string[]): boolean {
+  if (ghArgs[0] !== "api") return false;
+  const endpoint = ghArgs[1] ?? "";
+  const endpointPath = endpoint.split("?", 1)[0] ?? "";
+  if (!/^repos\/openclaw\/openclaw\/(?:issues|pulls)(?:\/|$)/.test(endpointPath)) {
+    return false;
+  }
+  if (
+    endpointPath.includes("\\") ||
+    endpointPath.split("/").some((segment) => segment === "." || segment === "..") ||
+    /%(?:2e|2f|5c)/i.test(endpointPath)
+  ) {
+    return false;
+  }
+
+  for (let index = 2; index < ghArgs.length; index += 1) {
+    const flag = ghArgs[index];
+    if (flag === "--paginate" || flag === "--slurp") continue;
+    if ((flag === "--jq" || flag === "-q") && index + 1 < ghArgs.length) {
+      index += 1;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+export function exactPublicationPublicReadToken(
+  ghArgs: readonly string[],
+  targetRepo: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  if (
+    env.EXACT_EVENT_PUBLICATION !== "true" ||
+    targetRepo !== "openclaw/openclaw" ||
+    (env.GH_HOST && env.GH_HOST.toLowerCase() !== "github.com") ||
+    !isPublicOpenClawReadOnlyRequest(ghArgs)
+  ) {
+    return null;
+  }
+  return env.REPO_TOKEN?.trim() || null;
+}

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -6,6 +6,7 @@ import { ghCliEnv } from "./process-env.js";
 import { repoRoot } from "./paths.js";
 import { ghRetryKind, ghRetryWaitMs } from "../github-retry.js";
 import { parseGhJsonWithRetry, parseGhJsonWithRetryAsync } from "../github-json.js";
+import { isPublicOpenClawReadOnlyRequest } from "../github-public-read.js";
 import { resolveCommand } from "../command.js";
 
 const execFileAsync = promisify(execFile);
@@ -264,33 +265,6 @@ function ghCommandEnv(ghArgs: readonly string[], options: GhRunOptions): NodeJS.
     return env;
   }
   return ghEnv({ ...overrides, GH_TOKEN: publicToken });
-}
-
-function isPublicOpenClawReadOnlyRequest(ghArgs: readonly string[]): boolean {
-  if (ghArgs[0] !== "api") return false;
-  const endpoint = ghArgs[1] ?? "";
-  const endpointPath = endpoint.split("?", 1)[0] ?? "";
-  if (!/^repos\/openclaw\/openclaw\/(?:issues|pulls)(?:\/|$)/.test(endpointPath)) {
-    return false;
-  }
-  if (
-    endpointPath.includes("\\") ||
-    endpointPath.split("/").some((segment) => segment === "." || segment === "..") ||
-    /%(?:2e|2f|5c)/i.test(endpointPath)
-  ) {
-    return false;
-  }
-
-  for (let index = 2; index < ghArgs.length; index += 1) {
-    const flag = ghArgs[index];
-    if (flag === "--paginate" || flag === "--slurp") continue;
-    if ((flag === "--jq" || flag === "-q") && index + 1 < ghArgs.length) {
-      index += 1;
-      continue;
-    }
-    return false;
-  }
-  return true;
 }
 
 export function ghErrorText(error: unknown): string {

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -36,6 +36,7 @@ export function codexSubprocessEnv(): NodeJS.ProcessEnv {
   }
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
+  delete env.REPO_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_AGENT_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_SERVICE_TOKEN;
   delete env.CLAWSWEEPER_CRABFLEET_RUNNER_PTY_URL;

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -9,6 +9,7 @@ import {
   itemSourceRevisionSha256ForTest,
   renderReviewStartStatusComment,
 } from "../dist/clawsweeper.js";
+import { createReviewCommentPublication } from "../dist/clawsweeper-review-comment-publication.js";
 
 import {
   implementedCloseReport,
@@ -23,6 +24,29 @@ import {
   withMockGh,
   workPlanCandidateReport,
 } from "./helpers.ts";
+
+test("same-item comment payloads never overwrite an earlier pending mutation", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const publication = createReviewCommentPublication({
+      root,
+      ensureDir: (directory: string) => mkdirSync(directory, { recursive: true }),
+    } as Parameters<typeof createReviewCommentPublication>[0]);
+
+    const firstBody = "ClawSweeper applied the proposed close for this PR.";
+    const secondBody = "A concurrent worker published a different durable review.";
+    const firstPayload = publication.writeCommentPayload(321, firstBody);
+    const secondPayload = publication.writeCommentPayload(321, secondBody);
+
+    assert.notEqual(firstPayload, secondPayload);
+    assert.deepEqual(JSON.parse(readFileSync(firstPayload, "utf8")), { body: firstBody });
+    assert.deepEqual(JSON.parse(readFileSync(secondPayload, "utf8")), { body: secondBody });
+    assert.equal(readFileSync(firstPayload.replace(/\.json$/, ".md"), "utf8"), firstBody);
+    assert.equal(readFileSync(secondPayload.replace(/\.json$/, ".md"), "utf8"), secondBody);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("partial label-sync authentication failures preserve labels already applied", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/apply-stalled-pr-policies.test.ts
+++ b/test/apply-stalled-pr-policies.test.ts
@@ -114,6 +114,8 @@ function stalledPrApplyGhMock(
     forcePushAt?: string;
     forcePushCommitId?: string;
     maintainerComment?: boolean;
+    viewerDependentMaintainerComment?: boolean;
+    tokenLogPath?: string;
     proofRequestedAt?: string;
     mergeable?: boolean | null;
     mergeableState?: string | null;
@@ -150,7 +152,11 @@ function stalledPrApplyGhMock(
       html_url: "https://github.com/openclaw/openclaw/pull/321#issuecomment-9901",
       created_at: "2026-05-11T00:00:00Z",
       updated_at: "2026-05-11T00:00:00Z",
-      author_association: "MEMBER",
+      author_association: ${
+        options.viewerDependentMaintainerComment
+          ? 'process.env.GH_TOKEN === "target-app-token" ? "MEMBER" : "CONTRIBUTOR"'
+          : '"MEMBER"'
+      },
       user: { login: "maintainer" },
       body: "Taking a look at this branch."
     }`
@@ -159,6 +165,11 @@ function stalledPrApplyGhMock(
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 const path = args[1] || "";
+${
+  options.tokenLogPath
+    ? `require("node:fs").appendFileSync(${JSON.stringify(options.tokenLogPath)}, JSON.stringify({ path, token: process.env.GH_TOKEN, method: args.includes("--method") ? args[args.indexOf("--method") + 1] : null }) + "\\n");`
+    : ""
+}
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
@@ -475,6 +486,74 @@ test("stalled-unproven apply keeps a PR open when a maintainer commented", () =>
     },
   ]);
   assert.equal(result.closedExists, false);
+});
+
+test("public publication reads cannot hide maintainer identity from destructive close guards", () => {
+  const fixtureEnv = {
+    EXACT_EVENT_PUBLICATION: "true",
+    GH_TOKEN: "target-app-token",
+    REPO_TOKEN: "workflow-public-token",
+  };
+  const previous = Object.fromEntries(
+    [...Object.keys(fixtureEnv), "GH_HOST"].map((key) => [key, process.env[key]]),
+  );
+  const logRoot = mkdtempSync(tmpPrefix);
+  const tokenLogPath = join(logRoot, "github-token-calls.jsonl");
+  Object.assign(process.env, fixtureEnv);
+  delete process.env.GH_HOST;
+
+  try {
+    const result = runStalledPrApply({
+      report: stalledUnprovenCloseReport(),
+      closeReason: "stalled_unproven_pr",
+      ghOptions: {
+        maintainerComment: true,
+        viewerDependentMaintainerComment: true,
+        tokenLogPath,
+      },
+    });
+    assert.deepEqual(result.entries, [
+      {
+        number: 321,
+        action: "kept_open",
+        reason: "maintainer issue comment blocks inactivity auto-close",
+      },
+    ]);
+    assert.equal(result.closedExists, false);
+
+    const calls = readFileSync(tokenLogPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { path: string; token: string; method: string | null });
+    assert.ok(
+      calls.some((call) => call.token === "workflow-public-token" && call.method === null),
+      "ordinary publication reads did not use the workflow token",
+    );
+    assert.ok(
+      calls.some(
+        (call) =>
+          /\/issues\/321\/comments(?:\?|$)/.test(call.path) &&
+          call.token === "target-app-token" &&
+          call.method === "GET",
+      ),
+      "destructive engagement guards did not preserve the App-authoritative maintainer identity",
+    );
+    assert.ok(
+      calls.some(
+        (call) =>
+          call.path.endsWith("/issues/321") &&
+          call.token === "target-app-token" &&
+          call.method === "GET",
+      ),
+      "destructive engagement guards did not preserve App-authoritative issue metadata",
+    );
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(logRoot, { recursive: true, force: true });
+  }
 });
 
 test("apply dry-run closes an abandoned PR with failing checks", () => {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2898,7 +2898,10 @@ test("codex subprocess env strips GitHub and App credentials", () => {
   try {
     process.env.GH_TOKEN = "gh";
     process.env.GITHUB_TOKEN = "github";
+    process.env.REPO_TOKEN = "workflow-repository";
     process.env.COMMIT_SWEEPER_TARGET_GH_TOKEN = "target";
+    process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN = "workflow-public";
+    process.env.CLAWSWEEPER_TARGET_GH_TOKEN = "target-app";
     process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN = "codex-target";
     process.env.CLAWSWEEPER_APP_ID = "123";
     process.env.CLAWSWEEPER_APP_PRIVATE_KEY = "private";
@@ -2913,7 +2916,10 @@ test("codex subprocess env strips GitHub and App credentials", () => {
 
     assert.equal(env.GH_TOKEN, undefined);
     assert.equal(env.GITHUB_TOKEN, undefined);
+    assert.equal(env.REPO_TOKEN, undefined);
     assert.equal(env.COMMIT_SWEEPER_TARGET_GH_TOKEN, undefined);
+    assert.equal(env.CLAWSWEEPER_PUBLIC_GH_TOKEN, undefined);
+    assert.equal(env.CLAWSWEEPER_TARGET_GH_TOKEN, undefined);
     assert.equal(env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN, undefined);
     assert.equal(env.CLAWSWEEPER_APP_ID, undefined);
     assert.equal(env.CLAWSWEEPER_APP_PRIVATE_KEY, undefined);
@@ -2952,14 +2958,18 @@ test("codex subprocess env can expose an explicit read-only GitHub token", () =>
   try {
     process.env.GH_TOKEN = "ambient";
     process.env.GITHUB_TOKEN = "github";
+    process.env.REPO_TOKEN = "workflow-repository";
     process.env.COMMIT_SWEEPER_TARGET_GH_TOKEN = "hidden";
+    process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN = "workflow-public";
     process.env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN = "hidden-codex";
 
     const env = codexEnv({ ghToken: "target-read" });
 
     assert.equal(env.GH_TOKEN, "target-read");
     assert.equal(env.GITHUB_TOKEN, undefined);
+    assert.equal(env.REPO_TOKEN, undefined);
     assert.equal(env.COMMIT_SWEEPER_TARGET_GH_TOKEN, undefined);
+    assert.equal(env.CLAWSWEEPER_PUBLIC_GH_TOKEN, undefined);
     assert.equal(env.CLAWSWEEPER_PROOF_INSPECTION_TOKEN, undefined);
     assert.equal(env.GIT_OPTIONAL_LOCKS, "0");
   } finally {

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -56,6 +56,7 @@ test("comment router wraps every GitHub mutation at the request boundary", () =>
 
 test("comment router isolates public target reads from its GitHub App mutation identity", () => {
   const source = readText("src/repair/github-cli.ts");
+  const publicReadSource = readText("src/github-public-read.ts");
   const workflow = readText(".github/workflows/repair-comment-router.yml");
 
   assert.equal(
@@ -69,8 +70,9 @@ test("comment router isolates public target reads from its GitHub App mutation i
   assert.match(source, /process\.env\.CLAWSWEEPER_PUBLIC_GH_TOKEN\?\.trim\(\)/);
   assert.match(source, /Object\.hasOwn\(overrides, "GH_TOKEN"\)/);
   assert.match(source, /Object\.hasOwn\(overrides, "GITHUB_TOKEN"\)/);
-  assert.match(source, /function isPublicOpenClawReadOnlyRequest/);
-  assert.match(source, /repos\\\/openclaw\\\/openclaw\\\/\(\?:issues\|pulls\)/);
+  assert.match(source, /isPublicOpenClawReadOnlyRequest/);
+  assert.match(publicReadSource, /function isPublicOpenClawReadOnlyRequest/);
+  assert.match(publicReadSource, /repos\\\/openclaw\\\/openclaw\\\/\(\?:issues\|pulls\)/);
 });
 
 test("exact comment convergence classifies a missing comment as no mutation", () => {

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import YAML from "yaml";
 
 import { createGitHubExecution } from "../../dist/clawsweeper-github-execution.js";
+import { createGitHubRuntime } from "../../dist/clawsweeper-github-runtime.js";
 
 const path = ".github/workflows/exact-review-batch-publish.yml";
 const source = readFileSync(path, "utf8");
@@ -93,6 +94,128 @@ test("GitHub retry defaults stay unchanged while publisher attempts are bounded"
   } finally {
     if (previous === undefined) delete process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS;
     else process.env.CLAWSWEEPER_GH_RETRY_ATTEMPTS = previous;
+  }
+});
+
+test("exact publication spends workflow credentials only on public target REST reads", () => {
+  const fixtureEnv = {
+    EXACT_EVENT_PUBLICATION: "true",
+    GH_TOKEN: "target-app-token",
+    REPO_TOKEN: "workflow-repository-token",
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([
+      "--eval",
+      "process.stdout.write(JSON.stringify({ token: process.env.GH_TOKEN, args: process.argv.slice(1) }))",
+      "--",
+    ]),
+  };
+  const previous = Object.fromEntries(
+    [...Object.keys(fixtureEnv), "GH_HOST"].map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, fixtureEnv);
+  delete process.env.GH_HOST;
+
+  let currentTarget = "openclaw/openclaw";
+  const requests: Array<{ args: string[]; token: string | undefined; timeoutMs?: number }> = [];
+  const run = (
+    _command: string,
+    args: string[],
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number },
+  ) => {
+    const request = {
+      args,
+      token: options?.env?.GH_TOKEN ?? process.env.GH_TOKEN,
+      ...(options?.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+    };
+    requests.push(request);
+    return JSON.stringify(request);
+  };
+  const runtime = createGitHubRuntime({
+    ROOT: process.cwd(),
+    run,
+    targetRepo: () => currentTarget,
+  });
+  const observed = (args: string[], timeoutMs: number | undefined = 5_000) =>
+    JSON.parse(runtime.ghWithPreparedTimeout(args, timeoutMs)) as {
+      token: string;
+      args: string[];
+      timeoutMs?: number;
+    };
+
+  try {
+    for (const args of [
+      ["api", "repos/openclaw/openclaw/issues/123"],
+      ["api", "repos/openclaw/openclaw/issues/123/comments?per_page=100", "--paginate", "--slurp"],
+      ["api", "repos/openclaw/openclaw/pulls/123/reviews?per_page=100", "--paginate", "--slurp"],
+      ["api", "repos/openclaw/openclaw/pulls/123", "--jq", ".requested_reviewers"],
+    ]) {
+      assert.equal(observed(args).token, "workflow-repository-token", args.join(" "));
+    }
+
+    const publicArgs = ["api", "repos/openclaw/openclaw/issues/comments/123"];
+    assert.equal(observed(publicArgs, 1234).timeoutMs, 1234);
+    assert.equal(JSON.parse(runtime.gh(publicArgs)).token, "workflow-repository-token");
+    assert.equal(JSON.parse(runtime.ghOnce(publicArgs, 10_000)).token, "workflow-repository-token");
+
+    const privateRequests = [
+      ["api", "user"],
+      ["api", "repos/openclaw/openclaw/collaborators/person/permission"],
+      ["api", "repos/openclaw/private/issues/123"],
+      ["api", "repos/openclaw/clawsweeper/issues/123"],
+      ["api", "repos/openclaw/openclaw/issues/../../clawsweeper/issues/123"],
+      ["api", "repos/openclaw/openclaw/issues/%2e%2e/clawsweeper"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--method", "PATCH"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--method=DELETE"],
+      ["api", "repos/openclaw/openclaw/issues/123", "-f", "body=mutated"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--input", "payload.json"],
+      ["api", "repos/openclaw/openclaw/issues/123", "--hostname", "example.invalid"],
+      ["pr", "view", "123"],
+    ];
+    for (const args of privateRequests) {
+      assert.equal(observed(args).token, "target-app-token", args.join(" "));
+    }
+    assert.equal(JSON.parse(runtime.ghOnce(privateRequests[6]!, 10_000)).token, "target-app-token");
+
+    const execution = createGitHubExecution({
+      ROOT: process.cwd(),
+      run,
+      gitHubRuntime: runtime,
+      sweepStatus: {
+        sweepStatusRelativePath: () => "status.json",
+        writeSweepStatus: () => undefined,
+      },
+      labelAlreadyExistsError: () => false,
+    } as unknown as Parameters<typeof createGitHubExecution>[0]);
+    assert.equal(
+      JSON.parse(
+        execution.ghObservedMutationCommand({
+          args: ["api", "repos/openclaw/openclaw/issues/123", "--method", "PATCH"],
+          identity: "exact-publication-target-mutation",
+        }),
+      ).token,
+      "target-app-token",
+    );
+
+    process.env.EXACT_EVENT_PUBLICATION = "false";
+    assert.equal(observed(publicArgs).token, "target-app-token");
+    process.env.EXACT_EVENT_PUBLICATION = "true";
+
+    currentTarget = "openclaw/private";
+    assert.equal(observed(publicArgs).token, "target-app-token");
+    currentTarget = "openclaw/openclaw";
+
+    process.env.GH_HOST = "enterprise.example.invalid";
+    assert.equal(observed(publicArgs).token, "target-app-token");
+    delete process.env.GH_HOST;
+
+    delete process.env.REPO_TOKEN;
+    assert.equal(observed(publicArgs).token, "target-app-token");
+    assert.ok(requests.length > privateRequests.length);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 });
 

--- a/test/repair/process-env.test.ts
+++ b/test/repair/process-env.test.ts
@@ -24,6 +24,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       CLAWSWEEPER_PUBLIC_GH_TOKEN: "public-read-secret",
       GH_TOKEN: "secret",
       GITHUB_TOKEN: "secret",
+      REPO_TOKEN: "workflow-repository-secret",
       GITHUB_ACTIONS: "true",
       OPENAI_API_KEY: "secret",
       CODEX_API_KEY: "secret",
@@ -45,6 +46,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       assert.equal(env.GIT_COMMITTER_EMAIL, "bot@example.invalid");
       assert.equal(env.GH_TOKEN, undefined);
       assert.equal(env.GITHUB_TOKEN, undefined);
+      assert.equal(env.REPO_TOKEN, undefined);
       assert.equal(env.CLAWSWEEPER_TARGET_GH_TOKEN, undefined);
       assert.equal(env.CLAWSWEEPER_PUBLIC_GH_TOKEN, undefined);
       assert.equal(env.OPENAI_API_KEY, undefined);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -601,6 +601,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     step(reviewer, "Review exact event item").env?.GH_TOKEN,
     "${{ steps.target-read-token.outputs.token }}",
   );
+  assert.equal(step(reviewer, "Review exact event item").env?.REPO_TOKEN, undefined);
   assert.match(step(reviewer, "Review exact event item").run ?? "", /--skip-start-comment/);
   const reserveLease = step(reviewer, "Reserve exact review lease");
   assert.equal(reserveLease.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
@@ -718,6 +719,8 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.equal(upload.uses, "actions/upload-artifact@v7");
   assert.match(prepareDirect.run ?? "", /repair:publish-event-result/);
+  assert.equal(prepareDirect.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
+  assert.equal(prepareDirect.env?.REPO_TOKEN, "${{ github.token }}");
   assert.equal(
     prepareDirect.env?.EXACT_REVIEW_BATCH_MUTATION_OUTPUT,
     ".artifacts/direct-publication-outcome.json",


### PR DESCRIPTION
## Production problem

GitHub App installation 122230863 is exhausted by public issue and PR reads during exact-review publication. Production showed 81 throttle-deferred reviews, eight occupied publication batches, and repeated 30/60-second retry loops even after the incoming event burst stopped.

Hosted CI also exposed a real cross-process publication race: every writer used the same comment-NUMBER.json payload, so concurrent same-item operations could post another operation payload before closing a PR.

## Simplification and safety

- Reuse one fail-closed public-read classifier across comment routing and all three publication paths: direct, deferred, and batch.
- Reserve the target App token for every mutation, private repository, collaborator lookup, actor check, and the entire destructive-close guard boundary.
- Add the existing workflow token only to the trusted post-review direct-publication step.
- Remove repository and alternate GitHub tokens from both untrusted subprocess environment builders.
- Give every Markdown/JSON comment payload a unique UUID-bound pathname so concurrent publishers cannot overwrite one another.
- Preserve maintainer protections even when different GitHub tokens expose different author associations.

## Verification

- 244 focused publication, security, workflow, router, sparse-build, and maintainer-guard tests passed.
- Independent security review passed 30 adversarial credential-boundary cases.
- Deterministic same-item payload corruption regression failed before the fix and passed afterward; the previously failing hosted close-note test passes locally.
- A production-faithful test shows a workflow token reporting CONTRIBUTOR and an App token reporting MEMBER; the maintainer close veto still holds.
- Main and repair builds, lint, and formatting passed; no dashboard Worker deployment or new configuration.