### PR TITLE
fix(workflow): scope comment-only reconciliation

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5800,6 +5800,7 @@ jobs:
           validate_coverage_proof_tree ".artifacts/apply-proof/pr-close-coverage-proof" 8 262144 2097152
 
       - name: Reconcile before apply preselect
+        if: ${{ !(github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && !(github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_sync_comments_only == 'true' || github.event.inputs.apply_item_numbers == '__cursor__')) }}
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -5809,17 +5810,6 @@ jobs:
           set -euo pipefail
           source scripts/apply-workflow-helpers.sh
           item_numbers="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.item_number || github.event.inputs.apply_item_numbers || '' }}"
-          if [ "${{ github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *' && 'true' || 'false' }}" = "true" ]; then
-            echo "Deferring reconciliation until the bounded comment-sync cursor is selected."
-            exit 0
-          fi
-          if [ "$item_numbers" = "__cursor__" ]; then
-            if [ "${{ github.event.inputs.apply_sync_comments_only || 'false' }}" = "true" ]; then
-              echo "Deferring reconciliation until the bounded comment-sync cursor is selected."
-              exit 0
-            fi
-            item_numbers=""
-          fi
           prepare_apply_reconciliation_args
           persist_reconciliation "${reconcile_args[@]}"
 

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -602,8 +602,7 @@ prepare_apply_reconciliation_args() {
     return 0
   fi
   reconcile_args+=(--item-numbers "$item_numbers")
-  if [ "${sync_comments_only:-false}" = "true" ] &&
-    [ "${sync_open_pr_batch:-false}" = "true" ]; then
+  if [ "${sync_comments_only:-false}" = "true" ]; then
     reconcile_args+=(--only-item-numbers)
   fi
 }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2077,14 +2077,18 @@ test("apply workflow isolates proof Codex and keeps mutation free of Git recover
   assert.match(applyJob, /queue: max/);
 });
 
-test("comment-only proof preparation never scans the full target repository", () => {
+test("comment-only apply preparation never scans the full target repository", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
     jobs: Record<string, { steps: Array<{ name?: string; if?: string; run?: string }> }>;
   };
   const steps = workflow.jobs["apply-proof"]!.steps;
   const reconcile = steps.find((step) => step.name === "Reconcile read-only proof inputs");
+  const applyReconcile = workflow.jobs["apply-existing"]!.steps.find(
+    (step) => step.name === "Reconcile before apply preselect",
+  );
   const select = steps.find((step) => step.name === "Select bounded coverage proof work");
   assert.ok(reconcile?.if, "proof reconciliation must explicitly exclude comment-only runs");
+  assert.equal(applyReconcile?.if, reconcile.if, "apply preselect must use the same skip gate");
   assert.ok(select?.run, "proof selection must recognize scheduled comment-only maintenance");
 
   const expression = reconcile.if.replace(/^\$\{\{\s*|\s*\}\}$/g, "");
@@ -2112,6 +2116,38 @@ test("comment-only proof preparation never scans the full target repository", ()
   assert.match(select.run, /github\.event\.schedule \|\| ''/);
   assert.match(select.run, /6,21,36,51 \* \* \* \*/);
   assert.match(select.run, /sync_comments_only="true"/);
+});
+
+test("comment-only apply reconciliation scopes only selected items", () => {
+  const reconcileArgs = (itemNumbers: string, syncCommentsOnly: boolean) =>
+    execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          "source scripts/apply-workflow-helpers.sh",
+          'TARGET_REPO="openclaw/openclaw"',
+          `item_numbers="${itemNumbers}"`,
+          `sync_comments_only=${syncCommentsOnly}`,
+          "sync_open_pr_batch=false",
+          "prepare_apply_reconciliation_args",
+          'printf "%s\\n" "${reconcile_args[@]}"',
+        ].join("\n"),
+      ],
+      { encoding: "utf8" },
+    )
+      .trimEnd()
+      .split("\n");
+  const baseArgs = ["--target-repo", "openclaw/openclaw", "--skip-closed-at"];
+
+  assert.deepEqual(reconcileArgs("119890", true), [
+    ...baseArgs,
+    "--item-numbers",
+    "119890",
+    "--only-item-numbers",
+  ]);
+  assert.deepEqual(reconcileArgs("119890", false), [...baseArgs, "--item-numbers", "119890"]);
+  assert.deepEqual(reconcileArgs("", true), baseArgs);
 });
 
 test("apply workflow scopes cursor reconciliation and publishes close reconciliation before idle", () => {
@@ -4942,12 +4978,14 @@ test("sweep workflow coalesces durable issue and PR comment sync batches", () =>
   assert.doesNotMatch(backgroundSync, /-f apply_item_numbers="\$item_numbers"/);
   assert.match(
     cursorPreselect,
-    /if \[ "\$item_numbers" = "__cursor__" \]; then\s+if \[ "\$\{\{ github\.event\.inputs\.apply_sync_comments_only \|\| 'false' \}\}" = "true" \]; then\s+echo "Deferring reconciliation until the bounded comment-sync cursor is selected\."\s+exit 0/,
+    /if: \$\{\{ .*github\.event\.inputs\.apply_sync_comments_only == 'true' \|\| github\.event\.inputs\.apply_item_numbers == '__cursor__'.*\}\}/,
   );
-  assert.match(
-    cursorPreselect,
-    /if \[ "\$\{\{ github\.event_name == 'schedule' && github\.event\.schedule == '6,21,36,51 \* \* \* \*' && 'true' \|\| 'false' \}\}" = "true" \]; then\s+echo "Deferring reconciliation until the bounded comment-sync cursor is selected\."\s+exit 0/,
-    "scheduled comment maintenance must never scan or reconcile the entire repository before selecting its batch",
+  assert.doesNotMatch(cursorPreselect, /Deferring reconciliation/);
+  assert.ok(
+    cursorExecution.indexOf(
+      `sync_comments_only="\${{ github.event_name == 'workflow_dispatch' && github.event.inputs.apply_sync_comments_only || 'false' }}"`,
+    ) < cursorExecution.indexOf("prepare_apply_reconciliation_args"),
+    "comment-only mode must be known before execution reconciliation is prepared",
   );
   assert.ok(
     cursorExecution.indexOf('echo "Selected cursor-based comment sync batch: $item_numbers"') <
@@ -4957,8 +4995,8 @@ test("sweep workflow coalesces durable issue and PR comment sync batches", () =>
   assert.match(cursorExecution, /prepare_apply_reconciliation_args/);
   assert.match(
     readText("scripts/apply-workflow-helpers.sh"),
-    /if \[ "\$\{sync_comments_only:-false\}" = "true" \] &&\s+\[ "\$\{sync_open_pr_batch:-false\}" = "true" \]; then\s+reconcile_args\+=\(--only-item-numbers\)/,
-    "cursor reconciliation must not archive or rewrite unrelated durable records",
+    /if \[ "\$\{sync_comments_only:-false\}" = "true" \]; then\s+reconcile_args\+=\(--only-item-numbers\)/,
+    "comment-only reconciliation must not archive or rewrite unrelated durable records",
   );
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where comment-only apply runs could perform redundant broad
reconciliation before selecting their bounded item batch, and explicit
comment-only selections were not guaranteed to constrain execution
reconciliation to those items.

## Why This Change Was Made

Comment-only schedules, cursor runs, and manual comment-sync runs now share the
existing read-only preselection skip gate. Once the bounded selection exists,
execution reconciliation adds `--only-item-numbers` for every non-empty
comment-only selection.

Explicit close runs remain broadly reconcilable, and an empty selector remains
unscoped. This changes only the internal apply workflow reconciliation path; it
does not change public schemas, status payloads, observer surfaces, or release
publishing.

## User Impact

Comment synchronization no longer scans or rewrites unrelated durable records
before or during a selected batch. Normal closure reconciliation behavior is
unchanged.

## Evidence

- Exact changed-surface proof passed: 9 tests, 9 passed, 0 failed.
- The exact-base Codex review against
  `0588bda948653c59a60b65c01d9ff3ce1f780df4` found no regressions.
- Targeted formatting and `git diff --check` passed.
- Production TypeScript delta: 0 lines. The workflow/helper production diff is
  net negative.
- The prior ClawSweeper P2 is resolved: the release-owned `CHANGELOG.md` edit
  was removed while rebasing onto the exact main SHA above.

## Real Behavior Proof

**Claim**

Every comment-only apply run skips redundant broad preselection
reconciliation. After selection, a non-empty comment-only batch reconciles only
the selected items, while explicit close runs remain broad and an empty
selection remains unscoped.

**Exercised surface**

The proof executes the real Bash workflow helper, parses the checked-in GitHub
Actions workflow, and runs the compiled reconciliation CLI against filesystem
records and a controlled GitHub CLI fixture.

**Scenario or fixture**

- Selected manual comment sync: item `119890`,
  `sync_comments_only=true`, `sync_open_pr_batch=false`.
- Explicit close: item `119890`, `sync_comments_only=false`.
- Empty comment-only selector.
- Scoped reconciliation: item `2` closes while open item `1` and an unrelated
  closed-item plan remain unchanged.

**Command and environment**

```text
node --test --test-concurrency=1 \
  --test-name-pattern='comment-only apply|apply workflow scopes cursor|sweep workflow coalesces durable issue and PR comment sync batches|scoped reconciliation|reconcile reports every changed record tuple' \
  test/sweep-workflow.test.ts test/reconcile.test.ts
```

Executed on macOS with Node 26.5.0 from head
`69edd98eb250a406d223c211371dc2c822581281`, based on
`0588bda948653c59a60b65c01d9ff3ce1f780df4`.

**Observed result**

- Selected comment sync produced:
  `--item-numbers 119890 --only-item-numbers`.
- Explicit close produced: `--item-numbers 119890` without
  `--only-item-numbers`.
- Empty selection produced only the base reconciliation arguments.
- Scoped reconciliation reported `pagesScanned=0`, changed only item `2`, and
  preserved unrelated records and sidecars.
- The apply preselection step uses the same comment-only skip expression as the
  read-only proof reconciliation step.

**Artifact or trace**

The executable assertions are in `test/sweep-workflow.test.ts` and
`test/reconcile.test.ts`; reviewed head is
`69edd98eb250a406d223c211371dc2c822581281`.

**Limits**

- No live workflow, apply, comment, or recovery dispatch was performed.
- The referenced public item was not mutated.
- The complete local workflow test file hit a pre-existing Homebrew Bash
  heredoc deadlock in an unrelated publication-batching test. The exact changed
  surface passed, and fresh Linux CI remains the full gate for this head.
- No npm publishing or release action was performed.
