### PR TITLE
fix(ci): restore AWS Crabbox provisioning

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,7 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  rootGB: 400
 sync:
   delete: true
   checksum: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where trusted AWS Crabbox checks could not provision because the repository still requested a 160 GB root volume while the current ClawSweeper snapshot requires 400 GB.

## Why This Change Was Made

The repository now requests a 400 GB AWS root volume, matching the current provisioning floor without changing Crabbox itself or adding a root-size environment override. The changelog records the operational allocation change.

## User Impact

Maintainers can provision the trusted `clawsweeper-check` AWS environment and run the repository check suite again. The configured allocation increases from 160 GB to 400 GB: +240 GB, or 2.5x.

## Evidence

- Exact base: `480d56953f381b127bdc0b5a7029efeeaa717595`
- Exact head: `212856c38f52cdf3e13b57afde1751e6e7dc5d86`
- `git diff --check 480d56953f381b127bdc0b5a7029efeeaa717595..212856c38f52cdf3e13b57afde1751e6e7dc5d86` passed.
- Production code delta: 0 lines. The diff changes one Crabbox configuration value and adds one changelog bullet.
- Exact-head review found no issue introduced by this two-file change. Two unrelated pre-existing findings surfaced in a broad repository review and were escalated separately instead of widening this release-infrastructure fix.

## Real Behavior Proof

**Claim:** the repository's checked-in configuration provisions a trusted AWS Crabbox lease with a 400 GB root volume, hydrates it, runs `pnpm run check`, and cleans the lease up without any root-size override.

**Exercised surface:** `.crabbox.yaml` AWS provisioning, GitHub-runner hydration, the full ClawSweeper check script, and lease cleanup.

**Scenario and environment:**

- Crabbox `0.40.0`
- provider `aws`
- profile `clawsweeper-check`
- region `eu-west-1`
- successful proof market `on-demand`
- `CRABBOX_AWS_ROOT_GB`, `CRABBOX_ROOT_GB`, and `CRABBOX_ROOTGB` unset

**Commands and observed result:**

1. `env -u CRABBOX_AWS_ROOT_GB -u CRABBOX_ROOT_GB -u CRABBOX_ROOTGB crabbox config show -json`
   - resolved provider `aws`
   - resolved profile `clawsweeper-check`
   - resolved `aws.rootGB` `400`
2. Provisioned task-owned lease `cbx_60a6245cec4e`.
   - provider telemetry reported `415381426176` total disk bytes, consistent with the requested 400 GB allocation
3. Hydrated with GitHub-runner Actions run `31092888514`.
4. Aligned the proof host with CI's Corepack-managed `pnpm@11.10.0`, then ran `pnpm run check`.
   - Crabbox run `run_424c321f6cf1`
   - exit code `0`
   - command duration approximately 2m31s
5. Stopped the task-owned lease and checked the authoritative lease list.
   - `cbx_60a6245cec4e` absent
   - earlier interrupted spot lease `cbx_3e6ea60e17f0` also absent
   - remaining task-owned lease count `0`

**Trace:** the first task-owned spot lease, `cbx_3e6ea60e17f0`, provisioned the same 400 GB disk but was interrupted by AWS during the full check. It was stopped and verified absent before the on-demand replacement was created. An initial on-demand check exposed a hydration-only `pnpm/action-setup` PATH mismatch; the final proof used the same Corepack setup as repository CI. No repository code or configuration was changed to accommodate either proof-environment event.

**Limits:** this change does not modify application/runtime behavior, Crabbox retry behavior, hydration workflow code, or the upstream fatal block-device handling path. It only restores the repository's current AWS allocation requirement.

## Review Disposition

- **Changelog finding:** declined. `AGENTS.md` reserves the **OpenClaw** `CHANGELOG.md` for release ownership; this pull request targets the ClawSweeper repository. `CONTRIBUTING.md` explicitly distinguishes ClawSweeper and other target repositories from that OpenClaw-only rule. This repository's unreleased changelog entry is intentional and was requested with the operational fix.
- **Allocation decision:** accepted. The owner-approved 400 GB value matches Crabbox's canonical AWS default and the current snapshot minimum. The recurring per-lease capacity increase from 160 GB to 400 GB is acknowledged; the volume is ephemeral, encrypted, and deleted with the task-owned lease.
