### PR TITLE
fix(apply): prevent one-sided paired closes after live drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Prevented same-author pair closes from starting when the counterpart fails its reason-specific live policy, refreshed stale-version and obsolete-fix guards again at the final close boundary, and made new and existing pre-close decision notes status-neutral while those final guards run.
 - Terminal command acknowledgements whose status comment was deleted (or never existed) now complete as a durable `missing_status_comment` skip instead of requeueing the finalization driver forever every ~20 minutes.
 - Apply and comment-sync publications now recover from canonical record tuple 409 conflicts instead of crashing mid-checkpoint: an equivalent concurrent write is absorbed, an unrelated-section race is rebased onto CURRENT with a single deterministic retry, and a same-section race skips just that item while the rest of the run continues.
 - Prevented weekly coverage from endlessly refreshing tracked records while never-reviewed live items remained invisible behind a full candidate batch; normal fanout now refreshes and consumes the signed live inventory, skips empty repositories, and prioritizes repositories with untracked work.

--- a/src/clawsweeper-apply-candidate-guards.ts
+++ b/src/clawsweeper-apply-candidate-guards.ts
@@ -73,13 +73,13 @@ export function createApplyCandidateGuards(
     prCloseCoverageProofStartedAtMs: null,
   };
 
-  const currentStaleVersionBugBlockReason = (): string | null => {
+  const candidateStaleVersionBugBlockReason = (): string | null => {
     if (cachedStaleVersionBugBlockReason === undefined) {
       cachedStaleVersionBugBlockReason = staleVersionBugApplyBlockReasonSafe(number, item);
     }
     return cachedStaleVersionBugBlockReason;
   };
-  const currentObsoleteFixPrBlockReason = (): string | null => {
+  const candidateObsoleteFixPrBlockReason = (): string | null => {
     if (cachedObsoleteFixPrBlockReason === undefined) {
       cachedObsoleteFixPrBlockReason = obsoleteFixPrApplyBlockReasonSafe(number, item);
     }
@@ -187,11 +187,11 @@ export function createApplyCandidateGuards(
   };
 
   return {
+    candidateObsoleteFixPrBlockReason,
+    candidateStaleVersionBugBlockReason,
     coverageProofState,
     currentAuthorPrBudgetApplyGate,
-    currentObsoleteFixPrBlockReason,
     currentPrCloseCoverageProofGateBlock,
-    currentStaleVersionBugBlockReason,
     resetCoverageProof: () => {
       coverageProofState.cachedPrCloseCoverageProofGateResult = undefined;
     },

--- a/src/clawsweeper-apply-close-execution.ts
+++ b/src/clawsweeper-apply-close-execution.ts
@@ -35,12 +35,14 @@ type ApplyCloseExecutionDependencies = Pick<
   | "issueRecentHumanCommentBlockReasonSafe"
   | "lowSignalUnmergeablePrApplyBlockReasonSafe"
   | "normalizeLabelName"
+  | "obsoleteFixPrApplyBlockReasonSafe"
   | "removeCurrentCursorTraceItem"
   | "replaceFrontMatterValue"
   | "replaceSectionValue"
   | "reportDecision"
   | "sha256"
   | "sleepMs"
+  | "staleVersionBugApplyBlockReasonSafe"
   | "stalledUnprovenPrApplyBlockReasonSafe"
   | "unsponsoredFeatureApplyBlockReasonSafe"
   | "validateCloseDecision"
@@ -63,9 +65,8 @@ interface ApplyCloseExecutionOptions {
   closedDir: string;
   currentApplyMutationLeaseBlockReason: () => string | null;
   currentAuthorPrBudgetApplyGate: () => AuthorPrBudgetApplyGate;
-  currentObsoleteFixPrBlockReason: () => string | null;
   currentPrCloseCoverageProofGateBlock: () => PrCloseCoverageProofGateBlock | null;
-  currentStaleVersionBugBlockReason: () => string | null;
+  currentSameAuthorPairBlockReason: () => string | null;
   dryRun: boolean;
   examinedItemNumbers: number[];
   getMarkdown: () => string;
@@ -114,12 +115,14 @@ export function executeApplyClose(
     issueRecentHumanCommentBlockReasonSafe,
     lowSignalUnmergeablePrApplyBlockReasonSafe,
     normalizeLabelName,
+    obsoleteFixPrApplyBlockReasonSafe,
     removeCurrentCursorTraceItem,
     replaceFrontMatterValue,
     replaceSectionValue,
     reportDecision,
     sha256,
     sleepMs,
+    staleVersionBugApplyBlockReasonSafe,
     stalledUnprovenPrApplyBlockReasonSafe,
     unsponsoredFeatureApplyBlockReasonSafe,
     validateCloseDecision,
@@ -134,9 +137,8 @@ export function executeApplyClose(
     closedDir,
     currentApplyMutationLeaseBlockReason,
     currentAuthorPrBudgetApplyGate,
-    currentObsoleteFixPrBlockReason,
     currentPrCloseCoverageProofGateBlock,
-    currentStaleVersionBugBlockReason,
+    currentSameAuthorPairBlockReason,
     dryRun,
     emitEventApplyProof,
     examinedItemNumbers,
@@ -254,19 +256,26 @@ export function executeApplyClose(
       const gate = currentAuthorPrBudgetApplyGate();
       return gate.allowed ? null : gate.reason;
     },
-    stale_version_bug: currentStaleVersionBugBlockReason,
-    obsolete_fix_pr: currentObsoleteFixPrBlockReason,
+    stale_version_bug: () => staleVersionBugApplyBlockReasonSafe(number, item),
+    obsolete_fix_pr: () => obsoleteFixPrApplyBlockReasonSafe(number, item),
     stale_insufficient_info: () =>
       issueRecentHumanCommentBlockReasonSafe(number, STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS),
   } satisfies Partial<Record<CloseReason, () => string | null>>;
-  const inactivityCloseBlockReason =
-    closeReason in inactivityPolicy
-      ? inactivityPolicy[closeReason as keyof typeof inactivityPolicy]()
-      : null;
-  if (inactivityCloseBlockReason) return skip("kept_open", inactivityCloseBlockReason);
+  const currentClosePolicyBlock = (): ApplyCloseFlow | null => {
+    const inactivityReason =
+      closeReason in inactivityPolicy
+        ? inactivityPolicy[closeReason as keyof typeof inactivityPolicy]()
+        : null;
+    if (inactivityReason) return skip("kept_open", inactivityReason);
+    const pairReason = currentSameAuthorPairBlockReason();
+    return pairReason ? skip("skipped_same_author_pair", pairReason, true) : null;
+  };
 
   const closeMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
   if (closeMutationLeaseBlockReason) return skipLease(closeMutationLeaseBlockReason);
+  // Pair state is outside the current item's lease; re-read it before any close announcement.
+  const preCommentPolicyBlock = currentClosePolicyBlock();
+  if (preCommentPolicyBlock) return preCommentPolicyBlock;
   logProgress(`closing #${number}`);
   const closeAppliedCommentReason =
     item.kind === "pull_request"
@@ -297,6 +306,8 @@ export function executeApplyClose(
 
   const preCloseMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
   if (preCloseMutationLeaseBlockReason) return skipLease(preCloseMutationLeaseBlockReason);
+  const preClosePolicyBlock = currentClosePolicyBlock();
+  if (preClosePolicyBlock) return preClosePolicyBlock;
   ensureRuntimeDelayFits(closeDelayMs, "before close");
   if (closeReason === "unsponsored_feature_request") {
     const needsIdeaArchiveLabel = !item.labels.map(normalizeLabelName).includes(IDEA_ARCHIVE_LABEL);

--- a/src/clawsweeper-apply-close-guards.ts
+++ b/src/clawsweeper-apply-close-guards.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import type { CreateApplyDecisionWorkflowDependencies } from "./clawsweeper-apply-dependencies.js";
-import { STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS } from "./clawsweeper-policy.js";
+import { evaluateApplyCloseReasonPolicy } from "./clawsweeper-apply-close-policies.js";
 import type {
   ActionTaken,
   ApplyKind,
@@ -179,7 +179,6 @@ export function createApplyCloseGuards(
   }: ApplyCloseGuardContext,
 ) {
   const {
-    abandonedPrApplyBlockReasonSafe,
     applyBlockingProtectedLabels,
     closeReasonApplyAgeSkipReason,
     closeReasonEnabled,
@@ -195,10 +194,10 @@ export function createApplyCloseGuards(
     isApplyCloseCandidateReport,
     isMaintainerAuthorAssociation,
     isRetryableCloseSkipReport,
-    issueRecentHumanCommentBlockReasonSafe,
-    issueReviewComment,
+    issueReviewCommentState,
     isVerifiedFixedCloseReason,
     itemSnapshotHash,
+    lockedConversationApplyReason,
     markdownRepository,
     markedReviewCommentBody,
     normalizeAuthorAssociation,
@@ -212,13 +211,8 @@ export function createApplyCloseGuards(
     reviewSectionValue,
     sameAuthorCounterpartApplyReason,
     shouldSyncReviewComment,
-    stalledUnprovenPrApplyBlockReasonSafe,
-    unconfirmedProductDirectionApplyBlockReasonSafe,
-    unsponsoredFeatureApplyBlockReasonSafe,
     validateCloseDecision,
   } = dependencies;
-
-  const sameAuthorPairStartCloseable = new Map<string, boolean>();
 
   const currentCloseGatesPassed = (): boolean => {
     const { closeReason, markdown, needsReviewCommentSync, storedUpdatedAt } = currentCloseState();
@@ -263,45 +257,21 @@ export function createApplyCloseGuards(
     ) {
       return false;
     }
+    const policyOptions = {
+      closeReason,
+      currentAuthorPrBudgetApplyGate,
+      currentObsoleteFixPrBlockReason,
+      currentStaleVersionBugBlockReason,
+      item,
+      markdown,
+      number,
+      storedUpdatedAt,
+    };
     if (
-      closeReason === "unconfirmed_product_direction" &&
-      unconfirmedProductDirectionApplyBlockReasonSafe(
-        number,
-        item,
-        storedUpdatedAt,
-        frontMatterValue(markdown, "reviewed_at"),
+      (["before-canonical", "after-canonical"] as const).some(
+        (phase) => evaluateApplyCloseReasonPolicy(dependencies, { ...policyOptions, phase }).block,
       )
     ) {
-      return false;
-    }
-    if (
-      closeReason === "unsponsored_feature_request" &&
-      unsponsoredFeatureApplyBlockReasonSafe(number, item)
-    ) {
-      return false;
-    }
-    if (closeReason === "stale_version_bug" && currentStaleVersionBugBlockReason()) {
-      return false;
-    }
-    if (closeReason === "obsolete_fix_pr" && currentObsoleteFixPrBlockReason()) {
-      return false;
-    }
-    if (closeReason === "author_pr_budget_exceeded" && !currentAuthorPrBudgetApplyGate().allowed) {
-      return false;
-    }
-    if (
-      closeReason === "stale_insufficient_info" &&
-      issueRecentHumanCommentBlockReasonSafe(number, STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS)
-    ) {
-      return false;
-    }
-    if (
-      closeReason === "stalled_unproven_pr" &&
-      stalledUnprovenPrApplyBlockReasonSafe(number, item)
-    ) {
-      return false;
-    }
-    if (closeReason === "abandoned_pr" && abandonedPrApplyBlockReasonSafe(number, item)) {
       return false;
     }
     if (currentPrCloseCoverageProofGateBlock()) return false;
@@ -313,10 +283,6 @@ export function createApplyCloseGuards(
     counterpartKind: ItemKind,
   ): boolean => {
     const { closedCount, processedCount } = currentCloseState();
-    const cacheKey = `${counterpartNumber}:${counterpartKind}`;
-    const cached = sameAuthorPairStartCloseable.get(cacheKey);
-    if (cached !== undefined) return cached;
-
     let result = false;
     if (
       item.kind === "pull_request" &&
@@ -328,6 +294,9 @@ export function createApplyCloseGuards(
     ) {
       const counterpartEntry = openFileEntryByNumber.get(counterpartNumber);
       if (counterpartEntry) {
+        const queueCounterpartEntry = () =>
+          fileEntries.some((entry) => entry.number === counterpartNumber) ||
+          fileEntries.push(counterpartEntry) > 0;
         const counterpartMarkdown = readFileSync(counterpartEntry.path, "utf8");
         const counterpartMaintainerDecisionBlocked =
           maintainerDecisionBlocksClose(counterpartMarkdown);
@@ -344,6 +313,8 @@ export function createApplyCloseGuards(
           hasVerifiedLocalCheckoutAccess(counterpartMarkdown)
         ) {
           const { item: counterpartItem, state: counterpartState } = fetchItem(counterpartNumber);
+          if (counterpartState !== "open")
+            return counterpartState === "closed" && queueCounterpartEntry();
           const counterpartReviewedAuthorAssociation = normalizeAuthorAssociation(
             frontMatterValue(counterpartMarkdown, "author_association"),
           );
@@ -356,10 +327,11 @@ export function createApplyCloseGuards(
             counterpartMarkdown,
             counterpartReason,
           );
-          const counterpartReviewComment = issueReviewComment(counterpartNumber, [
+          const counterpartReviewState = issueReviewCommentState(counterpartNumber, [
             counterpartReviewCommentBody,
             reviewSectionValue(counterpartMarkdown, "closeComment"),
           ]);
+          const counterpartReviewComment = counterpartReviewState.reviewComment;
           const counterpartMarkedReviewComment = markedReviewCommentBody(
             counterpartNumber,
             counterpartReviewCommentBody,
@@ -425,8 +397,32 @@ export function createApplyCloseGuards(
               canClosePairCounterpartInThisRun(relatedNumber) ||
               (relatedNumber === number && relatedKind === item.kind),
           );
+          const policyOptions = {
+            closeReason: counterpartReason,
+            comments: counterpartReviewState.comments,
+            currentAuthorPrBudgetApplyGate: () =>
+              dependencies.authorPrBudgetApplyGateSafe(
+                counterpartNumber,
+                counterpartItem,
+                counterpartMarkdown,
+              ),
+            currentObsoleteFixPrBlockReason: () =>
+              dependencies.obsoleteFixPrApplyBlockReasonSafe(counterpartNumber, counterpartItem),
+            currentStaleVersionBugBlockReason: () =>
+              dependencies.staleVersionBugApplyBlockReasonSafe(counterpartNumber, counterpartItem),
+            item: counterpartItem,
+            markdown: counterpartMarkdown,
+            number: counterpartNumber,
+            storedUpdatedAt: counterpartStoredUpdatedAt,
+          };
+          const counterpartReasonPolicyPassed = (
+            ["before-canonical", "after-canonical"] as const
+          ).every(
+            (phase) =>
+              !evaluateApplyCloseReasonPolicy(dependencies, { ...policyOptions, phase }).block,
+          );
           result =
-            counterpartState === "open" &&
+            lockedConversationApplyReason(counterpartItem) === null &&
             counterpartItem.kind === counterpartKind &&
             applyBlockingProtectedLabels(counterpartItem.labels, counterpartReason).length === 0 &&
             (isVerifiedFixedCloseReason(counterpartReason) ||
@@ -452,16 +448,14 @@ export function createApplyCloseGuards(
               minAgeDescription,
               staleMinAgeDays,
             }) === null &&
+            counterpartReasonPolicyPassed &&
             counterpartOpenClosingPullRequestReason === null &&
             counterpartSameAuthorReason === null;
-          if (result && !fileEntries.some((entry) => entry.number === counterpartNumber)) {
-            fileEntries.push(counterpartEntry);
-          }
+          if (result) queueCounterpartEntry();
         }
       }
     }
 
-    sameAuthorPairStartCloseable.set(cacheKey, result);
     return result;
   };
 

--- a/src/clawsweeper-apply-close-policies.ts
+++ b/src/clawsweeper-apply-close-policies.ts
@@ -8,6 +8,7 @@ type ApplyClosePolicyDependencies = Pick<
   | "applyAuthorPrBudgetStateToReport"
   | "closeReasonEnabled"
   | "frontMatterValue"
+  | "issueRecentHumanCommentBlockReasonFromComments"
   | "issueRecentHumanCommentBlockReasonSafe"
   | "stalledUnprovenPrApplyBlockReasonSafe"
   | "unconfirmedProductDirectionApplyBlockReasonSafe"
@@ -20,6 +21,7 @@ interface ApplyClosePolicyOptions {
   applyCloseReasons: ReadonlySet<CloseReason> | null;
   applyKind: ApplyKind;
   closeReason: CloseReason | undefined;
+  comments?: readonly unknown[];
   currentAuthorPrBudgetApplyGate: () => AuthorPrBudgetApplyGate;
   currentObsoleteFixPrBlockReason: () => string | null;
   currentStaleVersionBugBlockReason: () => string | null;
@@ -33,86 +35,59 @@ interface ApplyClosePolicyOptions {
   syncCommentsOnly: boolean;
 }
 
-export function evaluateApplyClosePolicy(
+type ApplyCloseReasonPolicyOptions = Omit<
+  ApplyClosePolicyOptions,
+  "applyCloseReasons" | "applyKind" | "isCloseProposal" | "state" | "syncCommentsOnly"
+> & { closeReason: CloseReason };
+export function evaluateApplyCloseReasonPolicy(
   dependencies: ApplyClosePolicyDependencies,
-  options: ApplyClosePolicyOptions,
-): {
-  block: { reason: string; preserveOriginalAction: boolean } | null;
-  markdown: string;
-} {
-  const {
-    abandonedPrApplyBlockReasonSafe,
-    applyAuthorPrBudgetStateToReport,
-    closeReasonEnabled,
-    frontMatterValue,
-    issueRecentHumanCommentBlockReasonSafe,
-    stalledUnprovenPrApplyBlockReasonSafe,
-    unconfirmedProductDirectionApplyBlockReasonSafe,
-    unconfirmedProductDirectionCloseEnabled,
-    unsponsoredFeatureApplyBlockReasonSafe,
-    unsponsoredFeatureCloseEnabled,
-  } = dependencies;
-  const {
-    applyCloseReasons,
-    applyKind,
-    closeReason,
-    currentAuthorPrBudgetApplyGate,
-    currentObsoleteFixPrBlockReason,
-    currentStaleVersionBugBlockReason,
-    isCloseProposal,
-    item,
-    number,
-    phase,
-    state,
-    storedUpdatedAt,
-    syncCommentsOnly,
-  } = options;
-  let { markdown } = options;
+  options: ApplyCloseReasonPolicyOptions,
+) {
   const blocked = (reason: string, preserveOriginalAction = false) => ({
+    authorPrBudgetGate: undefined,
     block: { reason, preserveOriginalAction },
-    markdown,
   });
-  const allowed = () => ({ block: null, markdown });
-
-  if (
-    state !== "open" ||
-    !isCloseProposal ||
-    !closeReason ||
-    syncCommentsOnly ||
-    (applyKind !== "all" && item.kind !== applyKind) ||
-    !closeReasonEnabled(closeReason, applyCloseReasons)
-  ) {
-    return allowed();
-  }
+  const allowed = (authorPrBudgetGate?: AuthorPrBudgetApplyGate) => ({
+    authorPrBudgetGate,
+    block: null,
+  });
+  const { closeReason, phase } = options;
 
   if (phase === "before-canonical") {
     switch (closeReason) {
       case "author_pr_budget_exceeded": {
-        const gate = currentAuthorPrBudgetApplyGate();
-        if (!gate.allowed) return blocked(gate.reason);
-        markdown = applyAuthorPrBudgetStateToReport(markdown, gate.state);
-        return allowed();
+        const gate = options.currentAuthorPrBudgetApplyGate();
+        return gate.allowed ? allowed(gate) : blocked(gate.reason);
       }
       case "unsponsored_feature_request": {
-        if (!unsponsoredFeatureCloseEnabled()) {
+        if (!dependencies.unsponsoredFeatureCloseEnabled()) {
           return blocked("unsponsored feature-request apply policy is disabled", true);
         }
-        const reason = unsponsoredFeatureApplyBlockReasonSafe(number, item);
+        const reason = dependencies.unsponsoredFeatureApplyBlockReasonSafe(
+          options.number,
+          options.item,
+        );
         return reason ? blocked(reason) : allowed();
       }
       case "stale_version_bug": {
-        const reason = currentStaleVersionBugBlockReason();
+        const reason = options.currentStaleVersionBugBlockReason();
         return reason ? blocked(reason) : allowed();
       }
       case "obsolete_fix_pr": {
-        const reason = currentObsoleteFixPrBlockReason();
+        const reason = options.currentObsoleteFixPrBlockReason();
         return reason ? blocked(reason) : allowed();
       }
       case "stale_insufficient_info": {
-        const reason = issueRecentHumanCommentBlockReasonSafe(
-          number,
-          STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS,
-        );
+        const reason =
+          options.comments === undefined
+            ? dependencies.issueRecentHumanCommentBlockReasonSafe(
+                options.number,
+                STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS,
+              )
+            : dependencies.issueRecentHumanCommentBlockReasonFromComments(
+                options.comments,
+                STALE_INSUFFICIENT_INFO_MIN_INACTIVE_DAYS,
+              );
         return reason ? blocked(reason) : allowed();
       }
       default:
@@ -122,26 +97,70 @@ export function evaluateApplyClosePolicy(
 
   switch (closeReason) {
     case "unconfirmed_product_direction": {
-      if (!unconfirmedProductDirectionCloseEnabled()) {
+      if (!dependencies.unconfirmedProductDirectionCloseEnabled()) {
         return blocked("unconfirmed product-direction apply policy is disabled", true);
       }
-      const reason = unconfirmedProductDirectionApplyBlockReasonSafe(
-        number,
-        item,
-        storedUpdatedAt,
-        frontMatterValue(markdown, "reviewed_at"),
+      const reason = dependencies.unconfirmedProductDirectionApplyBlockReasonSafe(
+        options.number,
+        options.item,
+        options.storedUpdatedAt,
+        dependencies.frontMatterValue(options.markdown, "reviewed_at"),
       );
       return reason ? blocked(reason) : allowed();
     }
     case "stalled_unproven_pr": {
-      const reason = stalledUnprovenPrApplyBlockReasonSafe(number, item);
+      const reason = dependencies.stalledUnprovenPrApplyBlockReasonSafe(
+        options.number,
+        options.item,
+      );
       return reason ? blocked(reason) : allowed();
     }
     case "abandoned_pr": {
-      const reason = abandonedPrApplyBlockReasonSafe(number, item);
+      const reason = dependencies.abandonedPrApplyBlockReasonSafe(options.number, options.item);
       return reason ? blocked(reason) : allowed();
     }
     default:
       return allowed();
   }
+}
+
+export function evaluateApplyClosePolicy(
+  dependencies: ApplyClosePolicyDependencies,
+  options: ApplyClosePolicyOptions,
+): {
+  block: { reason: string; preserveOriginalAction: boolean } | null;
+  markdown: string;
+} {
+  const {
+    applyCloseReasons,
+    applyKind,
+    closeReason,
+    isCloseProposal,
+    item,
+    state,
+    syncCommentsOnly,
+  } = options;
+  let { markdown } = options;
+  const allowed = () => ({ block: null, markdown });
+
+  if (
+    state !== "open" ||
+    !isCloseProposal ||
+    !closeReason ||
+    syncCommentsOnly ||
+    (applyKind !== "all" && item.kind !== applyKind) ||
+    !dependencies.closeReasonEnabled(closeReason, applyCloseReasons)
+  ) {
+    return allowed();
+  }
+
+  const policy = evaluateApplyCloseReasonPolicy(dependencies, { ...options, closeReason });
+  if (policy.block) return { block: policy.block, markdown };
+  if (policy.authorPrBudgetGate?.allowed) {
+    markdown = dependencies.applyAuthorPrBudgetStateToReport(
+      markdown,
+      policy.authorPrBudgetGate.state,
+    );
+  }
+  return allowed();
 }

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -968,11 +968,11 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         startedAtMs,
       });
       const {
+        candidateObsoleteFixPrBlockReason,
+        candidateStaleVersionBugBlockReason,
         coverageProofState,
         currentAuthorPrBudgetApplyGate,
-        currentObsoleteFixPrBlockReason,
         currentPrCloseCoverageProofGateBlock,
-        currentStaleVersionBugBlockReason,
       } = candidateGuards;
       const recordRuntimeBudgetYield = (reason: string): void => {
         if (clawSweeperLabelsChanged && !dryRun) {
@@ -1002,9 +1002,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           processedCount,
           storedUpdatedAt,
         }),
-        currentObsoleteFixPrBlockReason,
+        currentObsoleteFixPrBlockReason: candidateObsoleteFixPrBlockReason,
         currentPrCloseCoverageProofGateBlock,
-        currentStaleVersionBugBlockReason,
+        currentStaleVersionBugBlockReason: candidateStaleVersionBugBlockReason,
         fileEntries,
         isRetryableSkippedClose,
         item,
@@ -1147,9 +1147,10 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           applyCloseReasons,
           applyKind,
           closeReason,
+          comments: earlyLeaseState.comments,
           currentAuthorPrBudgetApplyGate,
-          currentObsoleteFixPrBlockReason,
-          currentStaleVersionBugBlockReason,
+          currentObsoleteFixPrBlockReason: candidateObsoleteFixPrBlockReason,
+          currentStaleVersionBugBlockReason: candidateStaleVersionBugBlockReason,
           isCloseProposal,
           item,
           markdown,
@@ -1713,14 +1714,16 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           }
         }
       }
-      if (isCloseProposal) {
-        const sameAuthorCounterpartReason = sameAuthorCounterpartApplyReason(
+      const currentSameAuthorPairBlockReason = (): string | null =>
+        sameAuthorCounterpartApplyReason(
           item,
-          currentItemContext().relatedItems ?? [],
+          dependencies.refreshRelatedItemsContext(item, currentItemContext()),
           (counterpartNumber, counterpartKind) =>
             canClosePairCounterpartInThisRun(counterpartNumber) ||
             canStartSameAuthorPairCloseInThisRun(counterpartNumber, counterpartKind),
         );
+      if (isCloseProposal) {
+        const sameAuthorCounterpartReason = currentSameAuthorPairBlockReason();
         if (sameAuthorCounterpartReason) {
           if (markApplySkipped("skipped_same_author_pair", sameAuthorCounterpartReason, true))
             break;
@@ -2030,9 +2033,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         closedDir,
         currentApplyMutationLeaseBlockReason,
         currentAuthorPrBudgetApplyGate,
-        currentObsoleteFixPrBlockReason,
         currentPrCloseCoverageProofGateBlock,
-        currentStaleVersionBugBlockReason,
+        currentSameAuthorPairBlockReason,
         dryRun,
         emitEventApplyProof,
         examinedItemNumbers,

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -222,6 +222,10 @@ export interface CreateApplyDecisionWorkflowDependencies {
       locked?: boolean;
     },
   ) => IssueAdvisoryLabelState;
+  issueRecentHumanCommentBlockReasonFromComments: (
+    comments: readonly unknown[],
+    days: number,
+  ) => string | null;
   issueRecentHumanCommentBlockReasonSafe: (number: number, days: number) => string | null;
   issueReviewComment: (
     number: number,
@@ -405,6 +409,7 @@ export interface CreateApplyDecisionWorkflowDependencies {
       | "closeComment",
   ) => string;
   reviewStartLeaseOwner: (comment: Record<string, unknown> | undefined) => string | null;
+  refreshRelatedItemsContext: (item: Item, context: ItemContext) => unknown[];
   ROOT: string;
   runtimeBudgetExceeded: (startedAtMs: number, maxRuntimeMs: number, nowMs: number) => boolean;
   sameAuthorCounterpartApplyReason: (

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -840,13 +840,14 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
 
     const issue = asRecord(record.issue);
     const pullRequest = asRecord(record.pullRequest);
-    const isPullRequest = Object.keys(pullRequest).length > 0;
-    const state = isPullRequest ? pullRequest.state : issue.state;
+    const pullRequestLoaded = Object.keys(pullRequest).length > 0;
+    const isPullRequest = pullRequestLoaded || Boolean(record.pullRequestError);
+    const counterpart = pullRequestLoaded ? pullRequest : issue;
     return {
       number: typeof issue.number === "number" ? issue.number : null,
       kind: isPullRequest ? "pull_request" : "issue",
-      author: normalizeAuthorLogin(isPullRequest ? pullRequest.author : issue.author),
-      state: typeof state === "string" ? state.toLowerCase() : "",
+      author: normalizeAuthorLogin(counterpart.author),
+      state: typeof counterpart.state === "string" ? counterpart.state.toLowerCase() : "",
       title: typeof issue.title === "string" ? issue.title : "",
     };
   }
@@ -867,11 +868,15 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
     const itemAuthor = normalizeAuthorLogin(item.author);
     if (!itemAuthor) return null;
     for (const relatedItem of relatedItems) {
+      const refreshFailed = Boolean(asRecord(relatedItem).error);
       const related = relatedCounterpartInfo(relatedItem);
       if (related.number === null || related.number === item.number) continue;
       if (!related.kind || related.kind === item.kind) continue;
-      if (related.state !== "open") continue;
+      if (related.state !== "open" && !refreshFailed) continue;
       if (related.author !== itemAuthor) continue;
+      if (refreshFailed) {
+        return `could not revalidate paired ${itemKindLabel(related.kind)} #${related.number}${related.title ? ` (${related.title})` : ""} by the same author before closing this ${itemKindLabel(item.kind)}`;
+      }
       if (canPairClose?.(related.number, related.kind)) continue;
       return `open ${itemKindLabel(related.kind)} #${related.number}${related.title ? ` (${related.title})` : ""} by the same author is paired with this ${itemKindLabel(item.kind)}`;
     }

--- a/src/clawsweeper-related-context.ts
+++ b/src/clawsweeper-related-context.ts
@@ -792,7 +792,8 @@ export function createRelatedContext({
         const mentionedIn = Array.isArray(record.mentionedIn)
           ? record.mentionedIn.filter((entry): entry is string => typeof entry === "string")
           : [];
-        return compactRelatedItem(number, mentionedIn);
+        const refreshed = asRecord(compactRelatedItem(number, mentionedIn));
+        return refreshed.error ? { ...record, ...refreshed } : refreshed;
       })
       .filter((entry) => entry !== null);
     appendUniqueRelatedItems(related, seen, refreshedExplicit);

--- a/src/clawsweeper-review-comment-publication.ts
+++ b/src/clawsweeper-review-comment-publication.ts
@@ -246,9 +246,9 @@ export function createReviewCommentPublication(
   }): string {
     const coverageProofLine = closeAppliedCoverageProofLine(options.markdown);
     return [
-      "ClawSweeper applied the proposed close for this PR.",
+      "ClawSweeper recorded the close decision for this PR.",
       "",
-      "- Action: closed this PR.",
+      "- Execution: a close command runs only if the final live guards pass.",
       `- Close reason: ${closeReasonText(options.closeReason)}.`,
       `- Evidence: ${closeAppliedEvidenceLink(options.markdown, options.itemUrl)}.`,
       coverageProofLine,
@@ -278,24 +278,30 @@ export function createReviewCommentPublication(
     dryRun: boolean;
   }): string {
     const marker = closeAppliedCommentMarker(options.number);
-    if (issueCommentWithMarker(options.number, marker)) {
+    const existing = issueCommentWithMarker(options.number, marker);
+    const existingId = commentId(existing);
+    const patchExisting = existingId !== null && canPatchReviewComment(existing);
+    const body = renderCloseAppliedComment(options);
+    if (existing && (!patchExisting || existing.body === body)) {
       return "matching ClawSweeper close-applied comment already exists";
     }
-    const body = renderCloseAppliedComment(options);
-    if (options.dryRun) return "dry-run: would post close-applied comment";
+    if (options.dryRun)
+      return `dry-run: would ${patchExisting ? "update" : "post"} close-applied comment`;
     const payload = writeCommentPayload(options.number, body);
     ghObservedMutationCommand({
       identity: `close_applied_comment:${options.number}:${sha256(body)}`,
       args: [
         "api",
-        `repos/${targetRepo()}/issues/${options.number}/comments`,
+        patchExisting
+          ? `repos/${targetRepo()}/issues/comments/${existingId}`
+          : `repos/${targetRepo()}/issues/${options.number}/comments`,
         "--method",
-        "POST",
+        patchExisting ? "PATCH" : "POST",
         "--input",
         payload,
       ],
     });
-    return "posted close-applied comment";
+    return patchExisting ? "updated close-applied comment" : "posted close-applied comment";
   }
 
   return {

--- a/test/apply-close-policy-guards.test.ts
+++ b/test/apply-close-policy-guards.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createApplyCloseGuards } from "../dist/clawsweeper-apply-close-guards.js";
+import { executeApplyClose } from "../dist/clawsweeper-apply-close-execution.js";
+import type { ReportEntry } from "../src/clawsweeper-types.ts";
+import { implementedCloseReport, item, tmpPrefix } from "./helpers.ts";
+
+const currentItem = {
+  ...item(),
+  number: 321,
+  kind: "pull_request" as const,
+  author: "reporter",
+  authorAssociation: "CONTRIBUTOR",
+};
+function counterpartAdmission(
+  closeReason: "implemented_on_main" | "stale_version_bug" | "stale_insufficient_info",
+  changeAfterAdmission: "locked" | "closed" | "unknown" | null = null,
+) {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const path = join(root, "320.md");
+    const markdown = implementedCloseReport({
+      repository: "openclaw/openclaw",
+      number: 320,
+      type: "issue",
+      title: "Paired issue",
+      author: "reporter",
+      close_reason: closeReason,
+      item_category: "bug",
+      item_created_at: "2026-01-01T00:00:00Z",
+      item_updated_at: "2026-01-01T00:00:00Z",
+    });
+    writeFileSync(path, markdown, "utf8");
+    const counterpartItem = { ...currentItem, number: 320, kind: "issue" as const };
+    const fileEntries: ReportEntry[] = [];
+    let liveLocked = false;
+    let liveState = changeAfterAdmission === "closed" ? "closed" : "open";
+    let reviewStateReads = 0;
+    const frontMatterValue = (source: string, key: string) =>
+      new RegExp(`^${key}: (.*)$`, "m").exec(source)?.[1];
+    const guards = createApplyCloseGuards(
+      {
+        applyBlockingProtectedLabels: () => [],
+        closeReasonApplyAgeSkipReason: () => null,
+        closeReasonEnabled: () => true,
+        closingPullRequestsForIssue: () => [],
+        collectItemContext: () => ({ relatedItems: [] }),
+        commentBodyMatches: () => true,
+        commentUpdatedAt: () => counterpartItem.updatedAt,
+        duplicateCanonicalPullRequestBlockReason: () => null,
+        fetchItem: () => ({ item: counterpartItem, state: liveState }),
+        frontMatterValue,
+        hasAutoCloseAllowedMetadata: () => true,
+        hasVerifiedLocalCheckoutAccess: () => true,
+        isApplyCloseCandidateReport: () => true,
+        isMaintainerAuthorAssociation: () => false,
+        isRetryableCloseSkipReport: () => false,
+        issueRecentHumanCommentBlockReasonFromComments: () =>
+          closeReason === "stale_insufficient_info"
+            ? "issue has a non-bot comment within the last 60 days"
+            : null,
+        issueRecentHumanCommentBlockReasonSafe: () => {
+          throw new Error("counterpart policy must reuse the complete comment read");
+        },
+        issueReviewCommentState: () => {
+          reviewStateReads += 1;
+          return { comments: [{}], reviewComment: { updated_at: counterpartItem.updatedAt } };
+        },
+        isVerifiedFixedCloseReason: () => false,
+        itemSnapshotHash: () => "reviewed-snapshot",
+        lockedConversationApplyReason: () => (liveLocked ? "conversation is locked" : null),
+        markdownRepository: () => "openclaw/openclaw",
+        markedReviewCommentBody: (_number: number, body: string) => body,
+        normalizeAuthorAssociation: (value: unknown) => (typeof value === "string" ? value : ""),
+        openClosingPullRequestApplyReason: () => null,
+        renderReviewCommentFromReport: () => "review",
+        reportCloseReason: () => closeReason,
+        reportDecision: () => ({}),
+        reportItemKind: () => "issue",
+        reviewCommentBodyDigest: () => "digest",
+        reviewCommentHashMatches: () => true,
+        reviewSectionValue: () => "",
+        sameAuthorCounterpartApplyReason: () => null,
+        shouldSyncReviewComment: () => false,
+        staleVersionBugApplyBlockReasonSafe: () =>
+          closeReason === "stale_version_bug" ? "stale-version bug apply policy is disabled" : null,
+        validateCloseDecision: () => ({ ok: true }),
+      } as never,
+      {
+        applyCloseReasons: null,
+        applyKind: "all",
+        canClosePairCounterpartInThisRun: () => false,
+        closedDir: join(root, "closed"),
+        commentSyncMinAgeDays: 0,
+        currentCloseState: () => ({
+          closedCount: 0,
+          closeReason: "implemented_on_main",
+          markdown: "",
+          needsReviewCommentSync: false,
+          processedCount: 0,
+          storedUpdatedAt: currentItem.updatedAt,
+        }),
+        currentPrCloseCoverageProofGateBlock: () => null,
+        fileEntries,
+        isRetryableSkippedClose: false,
+        item: currentItem,
+        itemsDir: root,
+        limit: 2,
+        minAgeDescription: "0 days",
+        minAgeMs: 0,
+        number: currentItem.number,
+        openFileEntryByNumber: new Map([
+          [320, { name: "320.md", number: 320, path, repo: "openclaw/openclaw", markdown }],
+        ]),
+        processedLimit: 2,
+        repo: "openclaw/openclaw",
+        requiredMaintainerDecision: null,
+        staleMinAgeDays: 0,
+      },
+    );
+    const admitted = guards.canStartSameAuthorPairCloseInThisRun(320, "issue");
+    liveLocked = changeAfterAdmission === "locked";
+    liveState =
+      changeAfterAdmission === "closed" || changeAfterAdmission === "unknown"
+        ? changeAfterAdmission
+        : "open";
+    const revalidated =
+      !changeAfterAdmission || guards.canStartSameAuthorPairCloseInThisRun(320, "issue");
+    return { admitted, fileEntries, revalidated, reviewStateReads };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+for (const closeReason of ["stale_version_bug", "stale_insufficient_info"] as const) {
+  test(`same-author pair preflight blocks ${closeReason} counterpart policy`, () => {
+    const r = counterpartAdmission(closeReason);
+    assert.deepEqual([r.admitted, r.fileEntries.length, r.reviewStateReads], [false, 0, 1]);
+  });
+}
+for (const change of ["locked", "closed", "unknown"] as const) {
+  test(`same-author pair revalidation handles counterpart state ${change}`, () => {
+    const { admitted, fileEntries, revalidated } = counterpartAdmission(
+      "implemented_on_main",
+      change,
+    );
+    assert.deepEqual([admitted, revalidated, fileEntries.length], [true, change === "closed", 1]);
+  });
+}
+for (const [closeReason, dryRun, blockOnRead, pairBlockOn] of [
+  ["stale_version_bug", false, 1, 0],
+  ["stale_version_bug", false, 2, 0],
+  ["obsolete_fix_pr", false, 2, 0],
+  ["stale_version_bug", true, 0, 1],
+  ["stale_version_bug", false, 0, 2],
+] as const) {
+  test(`${dryRun ? "dry-run pair" : `${closeReason} policy read ${blockOnRead}`} blocks before close`, () => {
+    let policyReads = 0;
+    const order: string[] = [];
+    const record = (step: string, result: null | false) => () => (order.push(step), result);
+    const livePolicyReason = () => {
+      order.push(closeReason);
+      return !dryRun && ++policyReads === blockOnRead ? `fresh ${closeReason} blocker` : null;
+    };
+    executeApplyClose(
+      {
+        closeReasonApplyAgeSkipReason: () => null,
+        closeReasonEnabled: () => true,
+        ensureRuntimeDelayFits: () => {},
+        ensureCloseAppliedComment: record("comment", null),
+        obsoleteFixPrApplyBlockReasonSafe: () =>
+          closeReason === "obsolete_fix_pr" ? livePolicyReason() : null,
+        reportDecision: () => ({}),
+        staleVersionBugApplyBlockReasonSafe: () =>
+          closeReason === "stale_version_bug" ? livePolicyReason() : null,
+        validateCloseDecision: () => ({ ok: true }),
+      } as never,
+      {
+        applyKind: "all",
+        closeLimitReached: false,
+        closeReason,
+        currentApplyMutationLeaseBlockReason: record("lease", null),
+        currentSameAuthorPairBlockReason: () => {
+          order.push("pair");
+          return order.filter((step) => step === "pair").length === pairBlockOn
+            ? "paired issue changed"
+            : null;
+        },
+        dryRun,
+        getMarkdown: () => "",
+        item: currentItem,
+        logProgress: () => {},
+        markApplySkipped: record("skip", false),
+        postProofCoveringPrFreshnessBlock: () => null,
+        postProofFreshnessBlock: () => null,
+      } as never,
+    );
+    const expected = ["lease", closeReason];
+    if (blockOnRead !== 1) expected.push("pair");
+    if (!dryRun && blockOnRead !== 1) expected.push("comment", "lease", closeReason);
+    if (pairBlockOn === 2) expected.push("pair");
+    expected.push("skip");
+    assert.deepEqual(order, expected);
+  });
+}

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -3167,7 +3167,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   }
 });
 
-test("apply-decisions posts an explicit close-time note before closing PR proposals", () => {
+test("apply-decisions updates an explicit close-time note before closing PR proposals", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -3221,10 +3221,11 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
       updated_at: "2026-05-01T01:00:00Z",
       user: { login: "clawsweeper[bot]" },
       body: comment
-    }]]));
+    }, { id: 9322, user: { login: "clawsweeper[bot]" }, body: "ClawSweeper applied the proposed close for this PR.\\n\\n- Action: closed this PR.\\n\\n<!-- clawsweeper-close-applied item=321 -->" }]]));
   }
-} else if (args[0] === "api" && /\\/issues\\/comments\\/9321$/.test(path)) {
-  console.log(JSON.stringify({ id: 9321, html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9321" }));
+} else if (args[0] === "api" && /\\/issues\\/comments\\/(9321|9322)$/.test(path)) {
+  if (path.endsWith("/9322")) appendFileSync(postedBodiesPath, JSON.stringify(JSON.parse(readFileSync(args[args.indexOf("--input") + 1], "utf8")).body) + "\\n");
+  console.log(JSON.stringify({ id: Number(path.match(/\\d+$/)[0]), html_url: "https://github.com/openclaw/clawsweeper/pull/321#issuecomment-9322" }));
 } else if (args[0] === "api" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
@@ -3284,23 +3285,23 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
       .split("\n")
       .filter(Boolean)
       .map((line) => JSON.parse(line) as string[]);
-    const postIndex = calls.findIndex(
+    const mutationIndex = calls.findIndex(
       (args) =>
         args[0] === "api" &&
-        (args[1] ?? "").endsWith("/issues/321/comments") &&
-        args.includes("POST"),
+        (args[1] ?? "").endsWith("/issues/comments/9322") &&
+        args.includes("PATCH"),
     );
     const closeIndex = calls.findIndex(
       (args) => args[0] === "pr" && args[1] === "close" && args[2] === "321",
     );
-    assert.ok(postIndex >= 0);
-    assert.ok(closeIndex > postIndex);
+    assert.ok(mutationIndex >= 0);
+    assert.ok(closeIndex > mutationIndex);
     const postedBodies = readFileSync(postedBodiesPath, "utf8")
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as string);
     assert.equal(postedBodies.length, 1);
-    assert.match(postedBodies[0], /ClawSweeper applied the proposed close for this PR/);
+    assert.match(postedBodies[0], /recorded the close decision/);
     assert.match(postedBodies[0], /Close reason: already implemented on main/);
     assert.match(postedBodies[0], /durable ClawSweeper review/);
     assert.match(postedBodies[0], /clawsweeper-close-applied item=321/);
@@ -3314,7 +3315,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
       {
         number: 321,
         action: "closed",
-        reason: "already implemented on main; posted close-applied comment",
+        reason: "already implemented on main; updated close-applied comment",
       },
     ]);
   } finally {

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -503,7 +503,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   }
 });
 
-test("apply-decisions keeps same-author PR blocked when counterpart drifted", () => {
+function assertSameAuthorPairTerminalRefresh(mode: "reopens" | "fails") {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -548,6 +548,8 @@ const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 const path = args[1] || "";
 const issueNumber = (path.match(/\\/issues\\/(\\d+)/) || [])[1];
+const fs = require("node:fs");
+const refreshFails = ${JSON.stringify(mode === "fails")};
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && /\\/issues\\/(320|321)\\/comments(?:\\?|$)/.test(path)) {
@@ -563,6 +565,9 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
 } else if (args[0] === "api" && /\\/issues\\/(320|321)\\/timeline(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[]]));
 } else if (args[0] === "api" && /\\/issues\\/320$/.test(path)) {
+  const counterpartRefreshed = fs.existsSync(${JSON.stringify(join(root, "counterpart-refreshed"))});
+  if (counterpartRefreshed && refreshFails) process.exit(1);
+  if (!counterpartRefreshed) fs.writeFileSync(${JSON.stringify(join(root, "counterpart-refreshed"))}, "");
   console.log(JSON.stringify({
     number: 320,
     title: "Paired issue",
@@ -570,8 +575,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     body: "See #321.",
     created_at: "2026-05-01T00:00:00Z",
     updated_at: "2026-05-02T00:00:00Z",
-    closed_at: null,
-    state: "open",
+    closed_at: counterpartRefreshed ? null : "2026-05-01T12:00:00Z",
+    state: counterpartRefreshed ? "open" : "closed",
     locked: false,
     active_lock_reason: null,
     author_association: "CONTRIBUTOR",
@@ -646,7 +651,10 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
       {
         number: 321,
         action: "skipped_same_author_pair",
-        reason: "open issue #320 (Paired issue) by the same author is paired with this PR",
+        reason:
+          mode === "fails"
+            ? "could not revalidate paired issue #320 (Paired issue) by the same author before closing this PR"
+            : "open issue #320 (Paired issue) by the same author is paired with this PR",
         guardedOpenStateVerified: true,
         terminalPolicyNoopVerified: true,
       },
@@ -654,7 +662,11 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
-});
+}
+for (const mode of ["reopens", "fails"] as const) {
+  test(`apply-decisions keeps same-author PR blocked when counterpart ${mode}`, () =>
+    assertSameAuthorPairTerminalRefresh(mode));
+}
 
 test("apply-decisions keeps same-author PR blocked when counterpart needs a maintainer decision", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/close-reasons.test.ts
+++ b/test/close-reasons.test.ts
@@ -1222,12 +1222,7 @@ test("same-author open issue and PR pairs block one-sided apply closes", () => {
           state: "open",
           author: "alice",
         },
-        pullRequest: {
-          number: 43,
-          title: "Fix the same bug",
-          state: "open",
-          author: "alice",
-        },
+        pullRequestError: "transient pull request lookup failure",
       },
     ]),
     "open PR #43 (Fix the same bug) by the same author is paired with this issue",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawSweeper could approve a same-author issue/PR pair from
stale candidate context, then close one side after the counterpart changed,
became policy-ineligible, or could no longer be revalidated.

It also fixes close-time notes that described a PR as already closed before the
final live guards and close command had completed.

## Why This Change Was Made

The apply workflow now uses one mutation-free close-reason policy evaluator for
both the current item and its paired counterpart. Candidate results remain a
cheap prefilter; the final path rechecks live stale-version, obsolete-fix,
comment-activity, lease, and pair state before the close-time note and again
immediately before closing.

Related-item refreshes preserve prior identity plus refresh errors, and a known
same-author pair fails closed when its live relation cannot be revalidated.
Confirmed-closed counterparts still enter the normal archive path. The
close-time PR note is status-neutral, and legacy ClawSweeper-owned notes are
updated before the final guards.

No release publishing, npm publishing, or live apply/close operation is part of
this change.

## User Impact

Operators can expect paired issue/PR closes to remain atomic from the apply
workflow's perspective: one side is not closed when the other side has reopened,
become blocked by current policy, or cannot be refreshed safely.

PR comments no longer claim that a close already happened while a final live
guard can still keep the PR open.

## Evidence

- Frozen base: `0588bda948653c59a60b65c01d9ff3ce1f780df4`.
- Reviewed head: `1c23b39f3174cdd2a0f90ba9e2c1d7882cce454d`.
- Direct TypeScript build passed: `./node_modules/.bin/tsc -p tsconfig.json`.
- Focused runtime/policy proof passed: 112 tests, 112 passed, 0 failed.
- Exact-head Codex review found no actionable defects; its direct build, lint,
  and 85 affected tests passed.
- Independent committed-range ClawSweeper review found no code or security
  blocker against the exact frozen base/head.
- Type-aware oxlint passed for all changed production files with warnings denied.
- `oxfmt` and `git diff --check` passed.
- Production TypeScript delta: `+43` net lines.
- Test delta: `+215` net lines.
- The merged https://github.com/openclaw/clawsweeper/pull/1040 touches workflow
  reconciliation only; it has no overlapping files or runtime ownership with
  this apply-close change.

## Real Behavior Proof

**Claim**

ClawSweeper does not close one side of a same-author issue/PR pair when the
counterpart reopens, fails a current close policy, or cannot be revalidated.
No public close note claims success before final live guards pass.

**Exercised surface**

The proof executes the compiled apply-decision workflow with controlled GitHub
CLI fixtures, the real pair admission/terminal guard path, the real close-reason
policy evaluator, the close-time comment mutation path, and final lease/policy
sequencing.

**Scenario or fixture**

- A counterpart is closed during initial context hydration, then reopens before
  terminal pair validation.
- A counterpart is closed during initial hydration, then its terminal GitHub
  refresh fails.
- `stale_version_bug` is disabled for the counterpart.
- `stale_insufficient_info` gains recent human activity.
- The counterpart becomes locked, closed, or unknown after admission.
- Current-item stale-version and obsolete-fix policy changes occur after the
  close-time comment/lease step.
- A legacy ClawSweeper-owned close note is updated before the final guards.

**Command and environment**

```text
./node_modules/.bin/tsc -p tsconfig.json
node --test --test-concurrency=2 \
  test/apply-close-policy-guards.test.ts \
  test/apply-same-author-pair-close.test.ts \
  test/apply-stale-version-bug-policy.test.ts \
  test/apply-obsolete-fix-pr-policy.test.ts \
  test/apply-label-sync.test.ts \
  test/close-reasons.test.ts
```

Executed on macOS with Node 26.5.0 from head
`1c23b39f3174cdd2a0f90ba9e2c1d7882cce454d`, based on
`0588bda948653c59a60b65c01d9ff3ce1f780df4`.

**Observed result**

- Both closed-to-open and closed-to-refresh-error counterparts produced
  `skipped_same_author_pair`; no close command ran.
- Counterpart policy blockers prevented pair admission before queue mutation.
- A confirmed-closed counterpart was queued for the existing archive path.
- Final stale-version, obsolete-fix, pair, and lease changes prevented close
  after earlier candidate approval.
- The close-time note says execution is conditional on final live guards.
- An owned legacy note was patched before the final guard and close sequence.

**Artifact or trace**

The executable assertions are in:

- `test/apply-close-policy-guards.test.ts`
- `test/apply-same-author-pair-close.test.ts`
- `test/apply-label-sync.test.ts`
- `test/close-reasons.test.ts`

**Limits**

- Blacksmith Testbox could not start because the repository has no matching
  workflow configuration.
- AWS Crabbox hydration rejected `pnpm/action-setup@v6.0.9`; the no-hydrate
  fallback then hit coordinator error 1101 before a lease was created.
- The full local coverage command remains blocked by the existing package mirror
  miss for `pnpm@10.33.0`; focused changed-surface proof passed.
- The committed-range reviewer classified the current proof as controlled
  mock/fixture evidence and requested a redacted production-path apply trace
  before merge. This draft intentionally stops before that final merge gate.
- No live GitHub item was applied, commented, or closed.
- No npm or release publishing was performed.

## OpenClaw Bay Impact

None. This changes internal apply-close policy and mutation sequencing only; it
does not change dashboard, observer, public status, or data-contract surfaces.

## Architecture Notes

- Root cause: pair and liveness facts were cached at candidate time and reused
  after later mutations.
- Owner: apply close-policy evaluation and terminal apply sequencing.
- Canonical fix: one policy evaluator, live terminal revalidation, and
  fail-closed relation refresh.
- Removed paths: pair-start memoization and final reliance on cached
  stale-version/obsolete-fix candidate results.
- Sibling coverage: issue/PR pair direction, stale-version, obsolete-fix,
  stale-insufficient-info, locked/closed/unknown state, legacy note migration,
  and dry-run sequencing.
