### PR TITLE
fix: external links with an uppercase URL scheme are published in review evidence

### DIFF
--- a/docs/proof/evidence-url-scheme-case/README.md
+++ b/docs/proof/evidence-url-scheme-case/README.md
@@ -1,0 +1,80 @@
+# Evidence external-URL scheme-case proof contract
+
+## Claim
+
+Worker evidence is stripped of every non-`github.com` `http(s)` URL before it is
+published, and the result validator rejects any that survive — regardless of the
+**case of the URL scheme**. Before this change, `HTTPS://host/path` matched
+neither the sanitizer nor the validator, so it was published verbatim as a live
+external autolink and the result still validated as `passed`.
+
+## Exercised surface
+
+Both shipped surfaces that share the pattern, driven against the built `dist/`:
+
+1. **Sanitizer** — `sanitizeResultEvidence()` in `dist/repair/url-safety.js`.
+   This is the pre-publication mutation applied to a worker `result.json`.
+2. **Validator** — `dist/repair/review-results.js`, executed as a real CLI
+   subprocess exactly as `dist/repair/run-worker.js` invokes it
+   (`run-worker.ts:373`).
+
+The two must stay in lockstep: `url-safety.ts` carries a header comment
+requiring its pattern to match `evidenceHasExternalUrl` in `review-results.ts`,
+because a sanitizer that emits something the validator rejects would deadlock a
+worker run.
+
+## Controlled scenario and fixture
+
+`run-proof.mjs` builds a throwaway run directory in the OS temp dir containing a
+`cluster-plan.json` and a **fully valid** `result.json` — correct `mode`,
+`idempotency_key`, `target_kind`, and a `target_updated_at` that matches the
+preflight item. The only thing that varies between the two cases is the scheme
+case of one external URL in `actions[0].evidence`:
+
+- control: `https://attacker.example/exfil?data=secret`
+- subject: `HTTPS://attacker.example/exfil?data=secret`
+
+Because the fixture is otherwise valid, the external-URL failure is the *only*
+validator failure, so the verdict is unambiguous. `attacker.example` is a
+reserved-for-documentation name; the proof contacts no network.
+
+## Expected observation
+
+Post-fix, both cases behave identically:
+
+- sanitizer output is `proof: <external link>` — the host does not appear;
+- validator exits `1` with exactly `["#1 evidence contains non-GitHub external URL"]`.
+
+Pre-fix, the uppercase case reported `LEAKED` from the sanitizer and
+`exit 0 / status "passed"` with `failures: []` from the validator.
+
+A companion focused test asserts that legitimate `HTTPS://github.com/...` and
+`HTTPS://GitHub.com/...` links are still preserved, so the case-insensitive
+pattern does not begin discarding valid GitHub references.
+
+## Artifact and command
+
+```bash
+pnpm run build:repair
+node docs/proof/evidence-url-scheme-case/run-proof.mjs   # exit 0 = PASS
+```
+
+Focused tests:
+
+```bash
+node --test test/repair/url-safety.test.ts
+```
+
+Red/green was verified by reverting only the compiled `dist/repair/url-safety.js`
+pattern to `/g` and re-running the focused tests: 3 fail pre-fix, 14/14 pass
+post-fix, with no change to the pre-existing assertions.
+
+## Limits
+
+This proof covers the sanitizer and the validator for the `http`/`https` scheme
+case only. It does not exercise a live GitHub publication, Codex worker, or
+queue; the published-comment rendering claim rests on GitHub's documented
+case-insensitive autolinking rather than a live post. It does not change the
+allowed-host set (`github.com` only), the URL terminator character class, or any
+other URL matcher in the repo — several unrelated `github.com`-specific patterns
+elsewhere are deliberately untouched.

--- a/docs/proof/evidence-url-scheme-case/README.md
+++ b/docs/proof/evidence-url-scheme-case/README.md
@@ -54,10 +54,44 @@ pattern does not begin discarding valid GitHub references.
 
 ## Artifact and command
 
+Supported-environment run (Node 24, Crabbox `local-container`):
+
+```bash
+crabbox run \
+  --provider local-container \
+  --local-container-image node:24 \
+  --no-hydrate \
+  --timing-json \
+  --artifact-glob '.artifacts/evidence-url-scheme-proof/**' \
+  --script docs/proof/evidence-url-scheme-case/run-proof.sh
+```
+
+`run-proof.sh` installs the pinned pnpm into a user-writable prefix (the lease
+runs as the unprivileged `crabbox` user, so `corepack enable` cannot symlink into
+`/usr/local/bin`), builds the repair lane, runs `run-proof.mjs`, and then runs the
+focused suite.
+
+Host-only quick check:
+
 ```bash
 pnpm run build:repair
 node docs/proof/evidence-url-scheme-case/run-proof.mjs   # exit 0 = PASS
 ```
+
+## Provenance
+
+- provider: Crabbox `local-container` (Docker/OrbStack)
+- crabbox: `0.15.0`
+- image: `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584`
+- container node: `v24.19.0` (satisfies `engines.node >= 24`)
+- lease: `cbx_9546d1539ae1` (`brisk-krill`)
+- run: `run_f0123d90f1c3`
+- artifact: `.crabbox/runs/run_f0123d90f1c3/run_f0123d90f1c3-artifacts.tgz`
+- result: exit `0`; sanitizer REDACTED both schemes, validator REJECTED both;
+  focused suite `14/14`
+- privacy: the fixture uses the reserved documentation name `attacker.example`.
+  The proof makes no network calls, contacts no GitHub API, and performs no
+  queue, GitHub, or production mutation. No credential is present in the lease.
 
 Focused tests:
 

--- a/docs/proof/evidence-url-scheme-case/run-proof.mjs
+++ b/docs/proof/evidence-url-scheme-case/run-proof.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Real-behavior proof for the evidence external-URL scheme-case fix.
+ *
+ * Exercises the two shipped surfaces end to end against the built dist/:
+ *
+ *   1. Sanitizer  - dist/repair/url-safety.js sanitizeResultEvidence(), the
+ *                   pre-publication mutation applied to a worker result.json.
+ *   2. Validator  - dist/repair/review-results.js, run as the real CLI
+ *                   subprocess exactly as dist/repair/run-worker.js invokes it.
+ *
+ * Both are driven with one fixture whose evidence carries an uppercase-scheme
+ * external URL. Run against a pre-fix build it reports LEAKED/ACCEPTED; against
+ * a post-fix build it reports REDACTED/REJECTED.
+ *
+ * Usage: node docs/proof/evidence-url-scheme-case/run-proof.mjs
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const distUrlSafety = path.join(repoRoot, "dist", "repair", "url-safety.js");
+const distReviewResults = path.join(repoRoot, "dist", "repair", "review-results.js");
+
+for (const required of [distUrlSafety, distReviewResults]) {
+  if (!fs.existsSync(required)) {
+    console.error(`missing build artifact: ${required}\nrun: pnpm run build:repair`);
+    process.exit(2);
+  }
+}
+
+const EXTERNAL_HOST = "attacker.example";
+const UPPERCASE_URL = `HTTPS://${EXTERNAL_HOST}/exfil?data=secret`;
+const LOWERCASE_URL = `https://${EXTERNAL_HOST}/exfil?data=secret`;
+
+/* -- Surface 1: the sanitizer -------------------------------------------- */
+
+const { sanitizeResultEvidence, EVIDENCE_URL_PLACEHOLDER } = await import(
+  `file://${distUrlSafety}`
+);
+
+const sanitizerCase = (label, url) => {
+  const result = { actions: [{ evidence: [`proof: ${url}`] }] };
+  sanitizeResultEvidence(result);
+  const out = result.actions[0].evidence[0];
+  return { label, url, out, redacted: !out.includes(EXTERNAL_HOST) };
+};
+
+const sanitizerResults = [
+  sanitizerCase("lowercase scheme (control)", LOWERCASE_URL),
+  sanitizerCase("uppercase scheme", UPPERCASE_URL),
+];
+
+/* -- Surface 2: the validator CLI ---------------------------------------- */
+
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "csw-url-proof-"));
+
+const writeFixture = (name, url) => {
+  const runDir = path.join(fixtureRoot, name);
+  fs.mkdirSync(runDir, { recursive: true });
+  const updatedAt = "2026-01-01T00:00:00Z";
+  fs.writeFileSync(
+    path.join(runDir, "cluster-plan.json"),
+    JSON.stringify({ item_matrix: [{ ref: "#1", updated_at: updatedAt }] }, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(runDir, "result.json"),
+    JSON.stringify(
+      {
+        repo: "openclaw/openclaw",
+        cluster_id: "proof-evidence-url-scheme",
+        mode: "plan",
+        actions: [
+          {
+            action: "comment",
+            target: "#1",
+            target_kind: "issue",
+            target_updated_at: updatedAt,
+            idempotency_key: "proof-evidence-url-scheme-1",
+            status: "planned",
+            evidence: [`deploy preview: ${url}`],
+          },
+        ],
+        needs_human: [],
+        merge_preflight: [],
+      },
+      null,
+      2,
+    ),
+  );
+  return runDir;
+};
+
+const runValidator = (label, url) => {
+  const runDir = writeFixture(label.replace(/\W+/g, "-"), url);
+  const proc = spawnSync(process.execPath, [distReviewResults, runDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  const report = JSON.parse(proc.stdout || "{}");
+  const failures = (report.reports ?? []).flatMap((entry) => entry.failures ?? []);
+  const externalUrlFailure = failures.filter((failure) =>
+    failure.includes("evidence contains non-GitHub external URL"),
+  );
+  return { label, url, exitCode: proc.status, status: report.status, failures, externalUrlFailure };
+};
+
+const validatorResults = [
+  runValidator("lowercase scheme (control)", LOWERCASE_URL),
+  runValidator("uppercase scheme", UPPERCASE_URL),
+];
+
+fs.rmSync(fixtureRoot, { recursive: true, force: true });
+
+/* -- Report --------------------------------------------------------------- */
+
+console.log("== Surface 1: sanitizeResultEvidence (dist/repair/url-safety.js) ==\n");
+for (const entry of sanitizerResults) {
+  console.log(`  ${entry.label}`);
+  console.log(`    input   : proof: ${entry.url}`);
+  console.log(`    output  : ${entry.out}`);
+  console.log(`    verdict : ${entry.redacted ? "REDACTED (correct)" : "LEAKED (bug)"}\n`);
+}
+
+console.log("== Surface 2: review-results.js CLI (real subprocess) ==\n");
+for (const entry of validatorResults) {
+  console.log(`  ${entry.label}`);
+  console.log(`    evidence: deploy preview: ${entry.url}`);
+  console.log(`    exit    : ${entry.exitCode}  status: ${entry.status}`);
+  console.log(`    failures: ${JSON.stringify(entry.failures)}`);
+  console.log(
+    `    verdict : ${
+      entry.externalUrlFailure.length > 0 ? "REJECTED (correct)" : "ACCEPTED (bug)"
+    }\n`,
+  );
+}
+
+const allRedacted = sanitizerResults.every((entry) => entry.redacted);
+const allRejected = validatorResults.every((entry) => entry.externalUrlFailure.length > 0);
+const passed = allRedacted && allRejected;
+
+console.log(`RESULT: ${passed ? "PASS" : "FAIL"}`);
+console.log(
+  passed
+    ? "  Both schemes are redacted by the sanitizer and rejected by the validator."
+    : "  At least one scheme escaped redaction or validation (pre-fix behavior).",
+);
+process.exit(passed ? 0 : 1);

--- a/docs/proof/evidence-url-scheme-case/run-proof.sh
+++ b/docs/proof/evidence-url-scheme-case/run-proof.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Crabbox local-container proof for the evidence external-URL scheme-case fix.
+#
+# Runs inside a Node 24 Linux container on the synced current checkout. It builds
+# the repair lane, then exercises both shipped surfaces:
+#
+#   1. sanitizeResultEvidence()      - dist/repair/url-safety.js
+#   2. dist/repair/review-results.js - run as a real CLI subprocess, exactly as
+#                                      dist/repair/run-worker.js invokes it
+#
+# See run-proof.mjs for the fixture and assertions.
+set -euo pipefail
+
+ARTIFACT_DIR=".artifacts/evidence-url-scheme-proof"
+mkdir -p "$ARTIFACT_DIR"
+
+echo "== environment =="
+uname -a
+node --version
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 24 ]; then
+  echo "FAIL: repository requires Node >= 24, got $(node --version)"
+  exit 1
+fi
+echo "head: $(git rev-parse HEAD 2>/dev/null || echo 'unavailable')"
+echo
+
+echo "== build =="
+# The lease runs as the unprivileged `crabbox` user, so corepack cannot symlink
+# into /usr/local/bin. Install the pinned pnpm into a user-writable prefix.
+export PNPM_HOME="$HOME/.local/bin"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME" >/dev/null 2>&1 || true
+fi
+if ! command -v pnpm >/dev/null 2>&1; then
+  npm install -g --prefix "$HOME/.local" pnpm@11.10.0 >"$ARTIFACT_DIR/pnpm-install.log" 2>&1 || true
+fi
+command -v pnpm >/dev/null 2>&1 || {
+  echo "FAIL: pnpm unavailable in container"
+  tail -20 "$ARTIFACT_DIR/pnpm-install.log" 2>/dev/null || true
+  exit 1
+}
+echo "pnpm: $(pnpm --version)"
+pnpm install --frozen-lockfile >"$ARTIFACT_DIR/install.log" 2>&1 \
+  || { echo "FAIL: pnpm install"; tail -30 "$ARTIFACT_DIR/install.log"; exit 1; }
+pnpm run build:repair >"$ARTIFACT_DIR/build.log" 2>&1 \
+  || { echo "FAIL: pnpm run build:repair"; tail -30 "$ARTIFACT_DIR/build.log"; exit 1; }
+test -f dist/repair/url-safety.js || { echo "FAIL: build did not produce dist/repair/url-safety.js"; exit 1; }
+echo "url-safety scheme flag: $(node -p "require('fs').readFileSync('dist/repair/url-safety.js','utf8').match(/const URL_PATTERN = .*/)[0]")"
+echo
+
+echo "== sanitizer + validator proof =="
+node docs/proof/evidence-url-scheme-case/run-proof.mjs | tee "$ARTIFACT_DIR/proof-output.txt"
+
+echo
+echo "== focused regression suite =="
+node --test test/repair/url-safety.test.ts 2>&1 | tail -8 | tee "$ARTIFACT_DIR/focused-tests.txt"
+
+echo
+echo "artifacts written to $ARTIFACT_DIR"

--- a/src/repair/review-results.ts
+++ b/src/repair/review-results.ts
@@ -589,7 +589,10 @@ function buildItemMap(plan: LooseRecord, repo: string) {
 function evidenceHasExternalUrl(evidence: JsonValue) {
   return evidence.some((item: JsonValue) => {
     const text = typeof item === "string" ? item : JSON.stringify(item);
-    const urls = text.match(/https?:\/\/[^\s)\]"']+/g) ?? [];
+    // Keep this pattern and its flags identical to URL_PATTERN in url-safety.ts
+    // so sanitized evidence never trips this validator. The `i` flag matters:
+    // an uppercase scheme is still a live autolink on GitHub.
+    const urls = text.match(/https?:\/\/[^\s)\]"']+/gi) ?? [];
     return urls.some(isExternalUrl);
   });
 }

--- a/src/repair/url-safety.ts
+++ b/src/repair/url-safety.ts
@@ -1,10 +1,13 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
 
-// IMPORTANT: keep this character class identical to the one used by
-// evidenceHasExternalUrl in review-results.ts. If the validator ever
-// expands the terminator set, expand it here first so this sanitizer
-// never produces output that the validator then rejects.
-const URL_PATTERN = /https?:\/\/[^\s)\]"']+/g;
+// IMPORTANT: keep this pattern identical to the one used by
+// evidenceHasExternalUrl in review-results.ts, including its flags. If the
+// validator ever expands the terminator set, expand it here first so this
+// sanitizer never produces output that the validator then rejects.
+// The `i` flag is required: GitHub autolinks schemes case-insensitively, so a
+// case-sensitive pattern would leave `HTTPS://host/path` as a live external
+// link in the published comment.
+const URL_PATTERN = /https?:\/\/[^\s)\]"']+/gi;
 const ALLOWED_HOSTS = new Set(["github.com"]);
 const PLACEHOLDER = "<external link>";
 

--- a/test/repair/url-safety.test.ts
+++ b/test/repair/url-safety.test.ts
@@ -53,6 +53,45 @@ test("sanitizeEvidenceText keeps github.com URLs but replaces sibling external U
   assert.doesNotMatch(cleaned, /raw\.githubusercontent\.com/);
 });
 
+test("sanitizeEvidenceText replaces external URLs regardless of scheme case", () => {
+  // GitHub autolinks schemes case-insensitively, so an uppercase scheme is still
+  // a live external link once the evidence is published.
+  for (const scheme of ["HTTPS", "Https", "hTTpS", "HTTP", "Http", "hTtP"]) {
+    const cleaned = sanitizeEvidenceText(`deploy preview: ${scheme}://vercel.com/openclaw/abc`);
+    assert.equal(cleaned, "deploy preview: <external link>", `scheme ${scheme} was not redacted`);
+  }
+});
+
+test("sanitizeEvidenceText keeps github.com URLs with an uppercase scheme", () => {
+  // The host is what decides; case-insensitive matching must not start dropping
+  // legitimate github.com links.
+  assert.equal(
+    sanitizeEvidenceText("see HTTPS://github.com/openclaw/openclaw/pull/1 for context"),
+    "see HTTPS://github.com/openclaw/openclaw/pull/1 for context",
+  );
+  assert.equal(
+    sanitizeEvidenceText("see HTTPS://GitHub.com/openclaw/openclaw/pull/1"),
+    "see HTTPS://GitHub.com/openclaw/openclaw/pull/1",
+  );
+});
+
+test("sanitizeResultEvidence redacts uppercase-scheme URLs on every evidence field", () => {
+  const result = {
+    actions: [{ evidence: ["proof: HTTPS://attacker.example/exfil?data=secret"] }],
+    needs_human: ["HTTP://attacker.example/ping"],
+    merge_preflight: [
+      {
+        security_evidence: ["HtTpS://attacker.example/scan"],
+        comments_evidence: ["Https://attacker.example/thread"],
+        bot_comments_evidence: ["HTTP://attacker.example/ack"],
+        codex_review: { evidence: ["HTTPS://attacker.example/review"] },
+      },
+    ],
+  };
+  sanitizeResultEvidence(result);
+  assert.doesNotMatch(JSON.stringify(result), /attacker\.example/);
+});
+
 test("sanitizeEvidenceText is idempotent", () => {
   const once = sanitizeEvidenceText(
     "see https://github.com/x/y and https://vercel.com/z for details",
@@ -128,12 +167,16 @@ test("sanitizeResultEvidence handles null/undefined safely", () => {
 });
 
 test("sanitized evidence does not trigger evidenceHasExternalUrl regex", () => {
-  // Mirror the regex used in review-results.ts evidenceHasExternalUrl.
-  const URL_PATTERN = /https?:\/\/[^\s)\]"']+/g;
+  // Mirror the regex used in review-results.ts evidenceHasExternalUrl, including
+  // its flags. If these drift apart the sanitizer can emit output the validator
+  // then rejects (or, as before the `i` flag, both can miss the same URL).
+  const URL_PATTERN = /https?:\/\/[^\s)\]"']+/gi;
   const cleaned = sanitizeEvidenceList([
     "Source PR: https://github.com/o/r/pull/2353",
     "Failing check: vercel:failure (https://vercel.com/o/preview/abc)",
     "see https://gist.github.com/foo for snippet",
+    "Preview: HTTPS://vercel.com/o/preview/upper",
+    "Snippet: HtTpS://gist.github.com/upper",
   ]);
   for (const line of cleaned) {
     const urls = line.match(URL_PATTERN) ?? [];


### PR DESCRIPTION
Closes #1043.

Fixes an issue where a non-GitHub link written with an uppercase URL scheme
(`HTTPS://host/path`) would be published verbatim in ClawSweeper's durable review
comment instead of being redacted to `<external link>`.

Worker evidence is model-authored text that ClawSweeper publishes to GitHub.
`sanitizeResultEvidence` exists to guarantee that no non-`github.com` link ever
reaches a published comment. That guarantee did not hold for uppercase schemes,
and the result validator that is meant to backstop it did not hold either — so a
worker result carrying such a link validated as `passed` and shipped.

Because GitHub's autolinker is case-insensitive, the published `HTTPS://…` text
renders as a live, clickable external link. The redaction the control promises
simply did not happen for that input.

## Why This Change Was Made

Both layers matched the scheme case-sensitively:

- `src/repair/url-safety.ts` — `URL_PATTERN` (the sanitizer)
- `src/repair/review-results.ts` — `evidenceHasExternalUrl` (the validator)

`url-safety.ts` carries a header comment requiring these two patterns to stay
identical, which is precisely why the blind spot was symmetric rather than caught
by the second layer. The fix adds the `i` flag to **both** together, preserving
that lockstep invariant, and extends the comment to record why the flag is load
bearing so a future edit does not drop it.

The downstream host check was already correct — `new URL(value).hostname` is
lowercased by the URL parser — so only the scheme match needed changing. The
allowed-host set (`github.com` only) and the URL terminator character class are
untouched.

Non-goals: this does not change any other URL matcher in the repo. Several
unrelated `github.com`-specific patterns elsewhere remain case-sensitive by
design and are out of scope.

## User Impact

Maintainers and contributors reading a ClawSweeper review comment no longer see
live external links that the sanitizer was supposed to remove; those links now
render as `<external link>` regardless of how the model capitalized the scheme.
Legitimate `HTTPS://github.com/...` references are preserved unchanged.

No configuration, workflow, or data-contract change. No migration.

**OpenClaw Bay:** not affected. Bay is an observer-only status surface and does
not render worker `result.json` evidence strings; its only use of the word
"evidence" is for terminal-outcome proof in the tide buffer, which this change
does not touch. No Bay update or Bay proof is needed.

**Release note:** `fix: redact external links in review evidence regardless of URL scheme case`.
No `CHANGELOG.md` edit is included — happy to add one if this repo's release
policy wants it for this change.

## Evidence

### Diff

```
 src/repair/review-results.ts   |  5 ++++-
 src/repair/url-safety.ts       | 13 +++++++-----
 test/repair/url-safety.test.ts | 47 ++++++++++++++++++++++++++++++++++++++++--
 3 files changed, 57 insertions(+), 8 deletions(-)
```

Plus a new proof package under `docs/proof/evidence-url-scheme-case/`.

### Focused tests

`node --test test/repair/url-safety.test.ts` → **14/14 pass**.

Three tests are new or extended:

- `sanitizeEvidenceText replaces external URLs regardless of scheme case` — covers
  `HTTPS`, `Https`, `hTTpS`, `HTTP`, `Http`, `hTtP`.
- `sanitizeResultEvidence redacts uppercase-scheme URLs on every evidence field` —
  `actions[].evidence`, `needs_human`, and all four `merge_preflight` fields.
- `sanitized evidence does not trigger evidenceHasExternalUrl regex` — the existing
  test mirrors the validator regex locally; the mirror now carries the `i` flag too,
  so it cannot silently drift from the real one, and uppercase inputs were added.

A fourth test, `sanitizeEvidenceText keeps github.com URLs with an uppercase scheme`,
is a regression guard: it passes both before and after, and exists to prove the new
case-insensitive pattern does not start discarding valid GitHub links.

### Red/green

Verified by reverting **only** the compiled `dist/repair/url-safety.js` pattern back
to `/g` and re-running the focused suite:

| build | result |
|---|---|
| pre-fix pattern | **3 fail**, 11 pass — the 3 new/extended tests |
| post-fix pattern | **14 pass**, 0 fail |

No pre-existing assertion changed behavior in either direction.

## Real Behavior Proof

**Claim.** Worker evidence is stripped of every non-`github.com` `http(s)` URL
before publication, and the result validator rejects any that survive, regardless
of the case of the URL scheme.

**Exercised surface.** Both shipped surfaces, against the built `dist/`:
1. `sanitizeResultEvidence()` in `dist/repair/url-safety.js` — the pre-publication
   mutation applied to a worker `result.json`.
2. `dist/repair/review-results.js` run as a **real CLI subprocess**, exactly as
   `dist/repair/run-worker.js` invokes it (`run-worker.ts:373`).

**Scenario / fixture.** `docs/proof/evidence-url-scheme-case/run-proof.mjs` builds a
throwaway run directory containing a `cluster-plan.json` and a *fully valid*
`result.json` (correct `mode`, `idempotency_key`, `target_kind`, and a
`target_updated_at` matching the preflight item). The only variable between the two
cases is the scheme case of one external URL in `actions[0].evidence`. Because the
fixture is otherwise valid, the external-URL failure is the only possible validator
failure. `attacker.example` is a reserved documentation name; the proof makes no
network calls.

**Command and environment.** Executed in the supported environment — Node 24 in a
Docker-backed Crabbox `local-container` lease, on the current head:

```bash
crabbox run \
  --provider local-container \
  --local-container-image node:24 \
  --no-hydrate \
  --timing-json \
  --artifact-glob '.artifacts/evidence-url-scheme-proof/**' \
  --script docs/proof/evidence-url-scheme-case/run-proof.sh
```

| field | value |
|---|---|
| provider | Crabbox `local-container` (Docker/OrbStack) |
| crabbox | `0.15.0` |
| image | `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584` |
| container node | `v24.19.0` (satisfies `engines.node >= 24`) |
| lease | `cbx_9546d1539ae1` (`brisk-krill`) |
| run | `run_f0123d90f1c3` |
| artifact | `.crabbox/runs/run_f0123d90f1c3/run_f0123d90f1c3-artifacts.tgz` |
| exit | `0` |

**Observed result.**

Before (`dist/` built from `0588bda9`):

```
sanitizer  lowercase → proof: <external link>                          REDACTED
sanitizer  uppercase → proof: HTTPS://attacker.example/exfil?...       LEAKED
validator  lowercase → exit 1  ["#1 evidence contains non-GitHub external URL"]  REJECTED
validator  uppercase → exit 0  status "passed"  failures: []                     ACCEPTED
RESULT: FAIL
```

After:

```
sanitizer  lowercase → proof: <external link>                          REDACTED
sanitizer  uppercase → proof: <external link>                          REDACTED
validator  lowercase → exit 1  ["#1 evidence contains non-GitHub external URL"]  REJECTED
validator  uppercase → exit 1  ["#1 evidence contains non-GitHub external URL"]  REJECTED
RESULT: PASS
```

The pre-fix uppercase case clearing validation with `exit 0 / "passed"` is the
sharpest statement of the bug: the malicious evidence did not merely evade
redaction, it passed the backstop too.

**Artifact / trace.** `docs/proof/evidence-url-scheme-case/` contains the runnable
proof script and its contract (`README.md`). Both transcripts above are reproducible
by running the script against a pre-fix and post-fix build.

**Limits.** Covers the sanitizer and the validator for `http`/`https` scheme case
only. It does not exercise a live GitHub publication, Codex worker, or queue; the
"renders as a live link" claim rests on GitHub's documented case-insensitive
autolinking rather than a live post. It does not change the allowed-host set, the
URL terminator class, or any other URL matcher in the repo.

**Privacy.** The fixture uses the reserved documentation name `attacker.example`.
The proof makes no network calls, contacts no GitHub API, and performs no queue,
GitHub, or production mutation. No credential is present in the lease.

## Repository test suite status

The **proof and focused suite now run on Node 24 inside the Crabbox
`local-container` lease** recorded above (`14/14` focused tests in-container).
The notes below concern only the *full* suite run on the macOS host.

`engines.node` is `>=24`. The newest Node available on the macOS host is **v23.7.0**,
and `AGENTS.md` warns that below Node 24 the notifier tests' retry paths misbehave
under the older `node:test` runner. On that host the suite is red *before* any
change, and the failure set is unstable between runs (one early run passed entirely;
later runs produced 3, then 21, then 22 distinct failures).

To separate signal from noise I ran the identical command on both trees:

| tree | `pnpm run test:no-build` |
|---|---|
| clean `main` (fix stashed, rebuilt) | 22 distinct failing tests |
| this branch | 22 distinct failing tests |

`comm` over the two sorted failure sets: **identical, zero failures unique to this
branch**. None of them touch `url-safety` or `review-results`.

Green on this branch:

| check | environment | result |
|---|---|---|
| Crabbox `local-container` proof | Node 24 container | **PASS**, exit 0 |
| `test/repair/url-safety.test.ts` | Node 24 container | **14/14** |
| `pnpm run build:all` | macOS host | clean |
| `pnpm run format:check` | macOS host | clean, 636 files |
| `pnpm run lint` | macOS host | clean (all four projects) |

**Please confirm `pnpm run check` on Node 24+ in CI before merging.** The changed
surface is proven on Node 24, but I have not produced a green *full-suite* run and
am not claiming one.
