### PR TITLE
Fix/scheduler duplicate candidate stranding

### DIFF
--- a/docs/proof/scheduler-duplicate-candidate-stranding/README.md
+++ b/docs/proof/scheduler-duplicate-candidate-stranding/README.md
@@ -3,67 +3,133 @@
 ## Claim
 
 `selectDueCandidates` fills the review batch up to capacity from the candidates
-it is given, even when the same item appears twice in the due list. Before this
-change, a single duplicated entry could end selection early and strand every
-remaining candidate while capacity was still free.
+it is given, even when the same item appears more than once in the due list.
+Before this change, a run of duplicates could end selection early and strand
+every remaining candidate while capacity was still free.
 
 ## Exercised surface
 
-The shipped planner path, not the comparator in isolation:
+`run-proof.sh` drives the real `plan` CLI end to end — **no application function
+is substituted**:
 
 ```
-createReviewPlanningSelection(...).selectCandidates()
-  -> src/clawsweeper-review-planning-selection.ts:90-111
-  -> selectDueCandidates()   (src/scheduler-policy.ts)
+node dist/clawsweeper.js plan
+  -> createReviewPlanningSelection().selectCandidates()
+  -> fetchOpenItemPage()  -> ghJsonLines() -> spawnSync -> `gh` subprocess
+                          -> JSON-lines parse -> item mapping
+  -> dueCandidate()       -> bucket / priority / due derivation
+  -> selectDueCandidates()
 ```
 
-The only injected behavior is `fetchOpenItemPage`, which reproduces the real
-GitHub artifact that triggers this: `GET /issues` is sorted by `updated`, so an
-item touched between two page reads shifts pages and is returned on both. Every
-step after that is the real planner. The `selectedKeys` dedup set inside
-`selectDueCandidates` exists precisely because this case is expected.
+Only the `gh` **binary** is replaced, standing in for GitHub's server.
+ClawSweeper's own transport — subprocess spawn, argument construction,
+JSON-lines parsing, pagination loop — runs unchanged. The `selectedKeys` dedup
+set inside `selectDueCandidates` exists precisely because duplicate page entries
+are expected.
 
 ## Controlled scenario and fixture
 
-`run-proof.mjs` builds one planner per scenario over three distinct open issues
-(`#1`, `#2`, `#3`) with `batchSize: 10` — far above the number of due items, so
-capacity can never be the limiting factor.
+Three distinct open PRs, `--batch_size 10` (far above the due count, so capacity
+is never the limiting factor), `--max_pages 5`. The stub `gh` returns `#1` on four
+consecutive pages, reproducing the `updated`-sorted pagination race in which an
+item touched mid-scan is listed again on later pages:
 
-- **control** — two pages, no race: `[[#1, #2], [#3]]`
-- **subject** — two pages, `#1` shifted onto page 2 as well: `[[#1, #2], [#1, #3]]`
+```
+page 1: [#1, #2]   page 2: [#1, #3]   page 3: [#1]   page 4: [#1]   page 5+: []
+```
 
-Every candidate is placed in the `weekly_issue` bucket, whose weight is **1**, so
-one duplicate is enough to consume a whole weighted pass.
+Four entries are needed because these land in `hot_pull_request`, whose weight is
+2 — a stall requires one whole weighted pass to consume nothing but duplicates.
+See **Reachability** below for the per-bucket thresholds.
 
-### Timing detail that matters
+### Two details that are load bearing
 
-`selectCandidates()` calls `selectDueCandidates()` **without** a `now` argument,
-so the scheduler uses the real `Date.now()`. The fixture therefore anchors
-`reviewedAt` to `Date.now() - 1h`, which keeps the candidates *out* of the
-weekly-coverage preselect lane (that lane needs 6 days).
+Both of these silently turn the proof vacuous — it passes on a pre-fix build and
+demonstrates nothing. Do not "simplify" either one away.
 
-This is load bearing. An earlier version of this proof used a fixed past
-timestamp; every candidate then qualified as weekly-coverage-due and was taken by
-the plain `for (const candidate of weeklyCoverageDue) take(candidate)` loop, which
-never reaches the weighted drain. That version passed on a pre-fix build and
-proved nothing.
+1. **Clock.** `selectCandidates()` calls `selectDueCandidates()` **without** a `now`
+   argument, so the scheduler uses the real `Date.now()`. Candidates must be recent
+   enough to stay *out* of the weekly-coverage preselect lane (which needs 6 days).
+   An earlier version used a fixed past timestamp; every candidate then qualified as
+   weekly-coverage-due and was taken by the plain
+   `for (const candidate of weeklyCoverageDue) take(candidate)` loop, which never
+   reaches the weighted drain.
+
+2. **Prior reports.** Items with no existing report are *coverage-untracked* and go
+   through `takeWeighted`, whose cohort is a separate copy of the bucket lists — the
+   final loop then recovers the survivors and nothing is stranded. The fixture
+   therefore writes a prior report per item so the candidates are coverage-tracked
+   and the final weighted drain owns selection.
 
 ## Expected observation
 
-| build | control | subject |
-|---|---|---|
-| pre-fix | `[1, 2, 3]` | `[1]` — `#2` and `#3` stranded |
-| post-fix | `[1, 2, 3]` | `[1, 2, 3]` |
+`shards[0].itemNumbers` from the real `plan` CLI, same fixture and invocation:
 
-The proof also asserts the subject result stays deduplicated, so the fix cannot
-be satisfied by simply letting the duplicate through.
+| build | selected | dueBacklog |
+|---|---|---|
+| pre-fix | `[1]` — `#2` and `#3` stranded | 6 |
+| post-fix | `[1, 2, 3]` | 6 |
+
+The proof also asserts the selection stays deduplicated, so the fix cannot be
+satisfied by simply letting the duplicate through.
 
 ## Artifact and command
+
+Supported-environment run (Node 24, Crabbox `local-container`). `run-proof.sh`
+drives the **real `plan` CLI** with only the `gh` binary stubbed:
+
+```bash
+crabbox run \
+  --provider local-container \
+  --local-container-image node:24 \
+  --no-hydrate \
+  --timing-json \
+  --artifact-glob '.artifacts/scheduler-duplicate-proof/**' \
+  --script docs/proof/scheduler-duplicate-candidate-stranding/run-proof.sh
+```
+
+It installs the pinned pnpm into a user-writable prefix (the lease runs as the
+unprivileged `crabbox` user, so `corepack enable` cannot symlink into
+`/usr/local/bin`), builds, runs the planner fixture, and runs the focused suite.
+
+Host-only quick check of the selection logic (injects `fetchOpenItemPage` rather
+than the `gh` binary, so it does **not** exercise the transport):
 
 ```bash
 pnpm run build
 node docs/proof/scheduler-duplicate-candidate-stranding/run-proof.mjs   # exit 0 = PASS
 ```
+
+## Provenance
+
+- provider: Crabbox `local-container` (Docker/OrbStack)
+- crabbox: `0.15.0`
+- image: `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584`
+- container node: `v24.19.0` (satisfies `engines.node >= 24`)
+- lease: `cbx_7c89c5c91f66` (`brave-lobster`)
+- run: `run_71734de37d18`
+- artifact: `.crabbox/runs/run_71734de37d18/run_71734de37d18-artifacts.tgz`
+  (`plan.json`, `summary.json`, `focused-tests.txt`, `install.log`, `build.log`)
+- result: exit `0`; selected `[1,2,3]`, `dueBacklog` 6, deduped; focused suite `24/24`
+- privacy: synthetic `contributor` login and public-shaped item numbers only. The
+  stub `gh` makes no network call; the proof performs no queue, GitHub, or
+  production mutation, and no credential is present in the lease.
+
+## Reachability
+
+A stall needs a whole weighted pass to consume nothing but duplicates, so the
+threshold is per bucket. Derived by driving the real `dueCandidate()` logic
+against a pre-fix build:
+
+| bucket | weight | page entries for one item needed to strand |
+|---|---:|---:|
+| `hot_pull_request`, `activity`, `recent_issue` | 2 | 4 |
+| `daily_pull_request` | 3 | 6 |
+| `hot_issue` | 4 | 8 |
+| `weekly_issue` | 1 | unreachable |
+
+`weekly_issue` is unreachable because "due" and "weekly-coverage-due" share the
+same 6-day threshold there, so the coverage preselect lane always claims it.
 
 Focused tests:
 
@@ -71,16 +137,19 @@ Focused tests:
 node --test test/scheduler-policy.test.ts
 ```
 
-Red/green was verified by stashing only `src/scheduler-policy.ts`, rebuilding, and
-re-running the focused suite with the new tests present: 3 fail pre-fix, 23/23
-pass post-fix, with all 20 pre-existing assertions unchanged in both directions.
+Red/green was verified by swapping only the compiled `dist/scheduler-policy.js`
+for a pre-fix build of the same file and re-running the focused suite with the new
+tests present: 4 fail pre-fix, 24/24 pass post-fix, with all 20 pre-existing
+assertions unchanged in both directions.
 
 ## Limits
 
-Covers the batch-selection path only. It does not exercise a live GitHub listing,
-Worker, or queue — the duplicate is injected at the `fetchOpenItemPage` boundary
-rather than produced by a real pagination race, because that race is timing
-dependent and not reproducible on demand.
+Covers the batch-selection path only. The duplicate is injected at the `gh`
+**binary** boundary rather than produced by a real pagination race, since that race
+is timing dependent and not reproducible on demand — so GitHub's own server
+behavior is modeled, not exercised. No live GitHub, Worker, or queue is contacted,
+and the proof performs no mutation. The lease is a local Docker container, not a
+cloud host, so it proves the Linux/Node 24 runtime but not cross-host isolation.
 
 The fix changes only the loop's termination signal (candidates drained instead of
 candidates selected). It does not deduplicate the `due` list up front, does not

--- a/docs/proof/scheduler-duplicate-candidate-stranding/README.md
+++ b/docs/proof/scheduler-duplicate-candidate-stranding/README.md
@@ -1,0 +1,89 @@
+# Scheduler duplicate-candidate stranding proof contract
+
+## Claim
+
+`selectDueCandidates` fills the review batch up to capacity from the candidates
+it is given, even when the same item appears twice in the due list. Before this
+change, a single duplicated entry could end selection early and strand every
+remaining candidate while capacity was still free.
+
+## Exercised surface
+
+The shipped planner path, not the comparator in isolation:
+
+```
+createReviewPlanningSelection(...).selectCandidates()
+  -> src/clawsweeper-review-planning-selection.ts:90-111
+  -> selectDueCandidates()   (src/scheduler-policy.ts)
+```
+
+The only injected behavior is `fetchOpenItemPage`, which reproduces the real
+GitHub artifact that triggers this: `GET /issues` is sorted by `updated`, so an
+item touched between two page reads shifts pages and is returned on both. Every
+step after that is the real planner. The `selectedKeys` dedup set inside
+`selectDueCandidates` exists precisely because this case is expected.
+
+## Controlled scenario and fixture
+
+`run-proof.mjs` builds one planner per scenario over three distinct open issues
+(`#1`, `#2`, `#3`) with `batchSize: 10` — far above the number of due items, so
+capacity can never be the limiting factor.
+
+- **control** — two pages, no race: `[[#1, #2], [#3]]`
+- **subject** — two pages, `#1` shifted onto page 2 as well: `[[#1, #2], [#1, #3]]`
+
+Every candidate is placed in the `weekly_issue` bucket, whose weight is **1**, so
+one duplicate is enough to consume a whole weighted pass.
+
+### Timing detail that matters
+
+`selectCandidates()` calls `selectDueCandidates()` **without** a `now` argument,
+so the scheduler uses the real `Date.now()`. The fixture therefore anchors
+`reviewedAt` to `Date.now() - 1h`, which keeps the candidates *out* of the
+weekly-coverage preselect lane (that lane needs 6 days).
+
+This is load bearing. An earlier version of this proof used a fixed past
+timestamp; every candidate then qualified as weekly-coverage-due and was taken by
+the plain `for (const candidate of weeklyCoverageDue) take(candidate)` loop, which
+never reaches the weighted drain. That version passed on a pre-fix build and
+proved nothing.
+
+## Expected observation
+
+| build | control | subject |
+|---|---|---|
+| pre-fix | `[1, 2, 3]` | `[1]` — `#2` and `#3` stranded |
+| post-fix | `[1, 2, 3]` | `[1, 2, 3]` |
+
+The proof also asserts the subject result stays deduplicated, so the fix cannot
+be satisfied by simply letting the duplicate through.
+
+## Artifact and command
+
+```bash
+pnpm run build
+node docs/proof/scheduler-duplicate-candidate-stranding/run-proof.mjs   # exit 0 = PASS
+```
+
+Focused tests:
+
+```bash
+node --test test/scheduler-policy.test.ts
+```
+
+Red/green was verified by stashing only `src/scheduler-policy.ts`, rebuilding, and
+re-running the focused suite with the new tests present: 3 fail pre-fix, 23/23
+pass post-fix, with all 20 pre-existing assertions unchanged in both directions.
+
+## Limits
+
+Covers the batch-selection path only. It does not exercise a live GitHub listing,
+Worker, or queue — the duplicate is injected at the `fetchOpenItemPage` boundary
+rather than produced by a real pagination race, because that race is timing
+dependent and not reproducible on demand.
+
+The fix changes only the loop's termination signal (candidates drained instead of
+candidates selected). It does not deduplicate the `due` list up front, does not
+change bucket weights, ordering, or the dedup key, and does not change behavior at
+all for a due list with no duplicates. A duplicate still consumes one weighted
+slot in its pass; only the premature `break` is removed.

--- a/docs/proof/scheduler-duplicate-candidate-stranding/run-proof.mjs
+++ b/docs/proof/scheduler-duplicate-candidate-stranding/run-proof.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Real-behavior proof for the scheduler duplicate-candidate stranding fix.
+ *
+ * Drives the SHIPPED planner path, not just the pure comparator:
+ *
+ *   createReviewPlanningSelection(...).selectCandidates()
+ *     -> src/clawsweeper-review-planning-selection.ts:90-111
+ *     -> selectDueCandidates()  (src/scheduler-policy.ts)
+ *
+ * The only injected behavior is `fetchOpenItemPage`, which reproduces the real
+ * GitHub artifact that triggers this: the paginated issue listing is sorted by
+ * `updated`, so an item touched mid-pagination shifts pages and is returned
+ * twice. Everything downstream is the real planner.
+ *
+ * Pre-fix the planner silently returns a truncated batch; post-fix it returns
+ * every distinct due item.
+ *
+ * Usage: node docs/proof/scheduler-duplicate-candidate-stranding/run-proof.mjs
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const distPlanner = path.join(repoRoot, "dist", "clawsweeper-review-planning-selection.js");
+
+if (!fs.existsSync(distPlanner)) {
+  console.error(`missing build artifact: ${distPlanner}\nrun: pnpm run build`);
+  process.exit(2);
+}
+
+const { createReviewPlanningSelection } = await import(`file://${distPlanner}`);
+
+// selectCandidates() calls selectDueCandidates() without a `now` argument, so the
+// scheduler uses the real Date.now(). Anchor to it: a candidate reviewed an hour
+// ago is NOT weekly-coverage-due (that lane needs 6 days), so selection falls
+// through to the weighted drain loop this proof is about. Using a fixed past
+// timestamp instead would route everything through the coverage preselect lane,
+// which takes candidates in a plain loop and never exercises the defect.
+const REVIEWED_AT = Date.now() - 60 * 60 * 1000;
+const REPO = "openclaw/openclaw";
+
+const makeItem = (number) => ({
+  repo: REPO,
+  number,
+  kind: "issue",
+  title: `Item ${number}`,
+  url: `https://github.com/${REPO}/issues/${number}`,
+  createdAt: "2020-01-01T00:00:00Z",
+  updatedAt: "2020-01-01T00:00:00Z",
+  author: "contributor",
+  authorAssociation: "NONE",
+  labels: [],
+});
+
+/**
+ * Two pages of open issues. #1 is touched between the two reads, so GitHub's
+ * `updated`-sorted listing shifts it onto page 2 as well - it is returned twice.
+ */
+const pagesWithDuplicate = [
+  [makeItem(1), makeItem(2)],
+  [makeItem(1), makeItem(3)],
+];
+
+/** Same distinct items, no pagination race. */
+const pagesWithoutDuplicate = [
+  [makeItem(1), makeItem(2)],
+  [makeItem(3)],
+];
+
+const buildPlanner = (pages) =>
+  createReviewPlanningSelection({
+    maxPlanShardCount: 8,
+    targetRepo: () => REPO,
+    shouldPlanItem: () => true,
+    buildExistingReviewIndex: () => new Map(),
+    fetchOpenItemPage: (page) => pages[page - 1] ?? [],
+    fetchHotIntakeItems: () => ({ items: [], pagesScanned: 0 }),
+    fetchItem: () => ({ item: null, state: "open" }),
+    shouldSkipScheduledHotIntakeExactReview: () => false,
+    reviewBackfillCandidate: () => null,
+    // Every item is due, in the weight-1 weekly_issue bucket, already reviewed
+    // recently enough that the weekly-coverage preselect lane does not claim it.
+    dueCandidate: (item) => ({
+      item,
+      review: { reviewStatus: "complete", reviewedAt: new Date(REVIEWED_AT).toISOString() },
+      priority: 6,
+      reviewedAt: REVIEWED_AT,
+      nextDueAt: 0,
+      bucket: "weekly_issue",
+      coverageTracked: true,
+    }),
+  });
+
+const run = (pages) =>
+  buildPlanner(pages)
+    .selectCandidates({
+      batchSize: 10, // capacity far above the 3 distinct due items
+      maxPages: pages.length,
+      shardIndex: 0,
+      shardCount: 1,
+      itemsDir: path.join(repoRoot, "does-not-exist"),
+    })
+    .candidates.map((item) => item.number);
+
+const control = run(pagesWithoutDuplicate);
+const subject = run(pagesWithDuplicate);
+
+const expected = [1, 2, 3];
+const sameSet = (left, right) =>
+  left.length === right.length && [...left].sort().every((value, i) => value === [...right].sort()[i]);
+
+console.log("== planner selectCandidates(), batchSize 10, 3 distinct due items ==\n");
+console.log(`  control  (no pagination race)  -> [${control.join(", ")}]`);
+console.log(`  subject  (#1 returned twice)   -> [${subject.join(", ")}]`);
+console.log(`  expected                       -> [${expected.join(", ")}]\n`);
+
+const controlOk = sameSet(control, expected);
+const subjectOk = sameSet(subject, expected);
+const noDuplicates = new Set(subject).size === subject.length;
+
+console.log(`  control selects every due item : ${controlOk ? "yes" : "NO"}`);
+console.log(`  subject selects every due item : ${subjectOk ? "yes" : "NO  <- stranded"}`);
+console.log(`  subject is still deduplicated  : ${noDuplicates ? "yes" : "NO  <- duplicate leaked"}\n`);
+
+const passed = controlOk && subjectOk && noDuplicates;
+console.log(`RESULT: ${passed ? "PASS" : "FAIL"}`);
+console.log(
+  passed
+    ? "  A duplicated page entry no longer costs the batch its remaining candidates."
+    : "  The pagination duplicate truncated the batch (pre-fix behavior).",
+);
+process.exit(passed ? 0 : 1);

--- a/src/scheduler-policy.ts
+++ b/src/scheduler-policy.ts
@@ -322,7 +322,11 @@ export function selectDueCandidates<
     for (const candidate of candidates) cohort.get(candidate.bucket)?.push(candidate);
     for (const bucketCandidates of cohort.values()) bucketCandidates.sort(compare);
     while (selected.length < capacity) {
-      const before = selected.length;
+      // Stop on candidates drained, not candidates selected. take() silently
+      // drops an already-selected duplicate, so a pass that consumed only
+      // duplicates is not evidence that the buckets are empty; measuring
+      // selection here would strand every candidate queued behind them.
+      let drained = 0;
       for (const [bucket, weight] of SCHEDULER_BUCKET_WEIGHTS) {
         const bucketCandidates = cohort.get(bucket);
         if (!bucketCandidates?.length) continue;
@@ -332,9 +336,10 @@ export function selectDueCandidates<
           index += 1
         ) {
           take(bucketCandidates.shift());
+          drained += 1;
         }
       }
-      if (selected.length === before) break;
+      if (drained === 0) break;
     }
   };
 
@@ -388,15 +393,21 @@ export function selectDueCandidates<
   }
 
   while (selected.length < capacity) {
-    const before = selected.length;
+    // Stop on candidates drained, not candidates selected. GitHub's paginated
+    // issue listing is sorted by `updated`, so an item touched mid-pagination
+    // can appear on two pages; take() drops that duplicate silently. Measuring
+    // selection here would read "hit a duplicate" as "buckets are drained" and
+    // abandon every remaining candidate while capacity is still free.
+    let drained = 0;
     for (const [bucket, weight] of SCHEDULER_BUCKET_WEIGHTS) {
       const candidates = buckets.get(bucket);
       if (!candidates?.length) continue;
       for (let i = 0; i < weight && candidates.length && selected.length < capacity; i += 1) {
         take(candidates.shift());
+        drained += 1;
       }
     }
-    if (selected.length === before) break;
+    if (drained === 0) break;
   }
 
   return selected;

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 import {
   appendFloorBackfillCandidates,
   hotIntakeRecencyMs,
+  nextReviewDueAtMs,
   reviewPriority,
+  reviewedAtMs,
+  schedulerBucket,
   selectDueCandidates,
   shouldReviewItem,
 } from "../dist/scheduler-policy.js";
@@ -977,5 +980,54 @@ test("duplicates across separate buckets do not stall the weighted drain", () =>
   assert.deepEqual(
     selectedNumbers(due, 6, now).sort((a, b) => a - b),
     [1, 2, 3, 4],
+  );
+});
+
+test("pagination duplicates do not strand candidates the real planner produces", () => {
+  // The three cases above build candidates by hand. This one derives them the way
+  // dueCandidate() does, so it pins the shape the production planner actually
+  // emits: a PR created two days ago with a prior report is coverage-tracked,
+  // due at the 1-day cadence, and NOT weekly-coverage-due at 6 days - so the
+  // weighted drain, not the coverage preselect lane, owns selection.
+  //
+  // Reachability differs per bucket because a stall needs a whole weighted pass
+  // to consume only duplicates. hot_pull_request has weight 2, so it takes four
+  // page entries for one PR. weekly_issue is unreachable: there, "due" and
+  // "weekly-coverage-due" share the same 6-day threshold, and that lane takes
+  // candidates in a plain loop.
+  const now = Date.parse("2026-06-10T00:00:00Z");
+  const reviewedAt = now - 2 * 24 * 60 * 60 * 1000;
+  const review = {
+    reviewStatus: "complete",
+    reviewedAt: new Date(reviewedAt).toISOString(),
+  };
+  const pull = (number) =>
+    item({
+      number,
+      kind: "pull_request",
+      createdAt: new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      updatedAt: new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+  const derived = (number) => {
+    const target = pull(number);
+    assert.equal(schedulerBucket(target, review, now), "hot_pull_request");
+    assert.equal(shouldReviewItem(target, review, now), true, "must be due");
+    return {
+      item: target,
+      review,
+      coverageTracked: true,
+      priority: reviewPriority(target, review, now),
+      reviewedAt: reviewedAtMs(review) ?? 0,
+      nextDueAt: nextReviewDueAtMs(target, review, now),
+      bucket: schedulerBucket(target, review, now),
+    };
+  };
+
+  // #1 listed on four pages: hot_pull_request weight 2, so one full pass
+  // consumes nothing but duplicates.
+  const due = [derived(1), derived(1), derived(1), derived(1), derived(2), derived(3)];
+  assert.deepEqual(
+    selectDueCandidates(due, 10, undefined, now).map((candidate) => candidate.item.number),
+    [1, 2, 3],
   );
 });

--- a/test/scheduler-policy.test.ts
+++ b/test/scheduler-policy.test.ts
@@ -902,3 +902,80 @@ test("CSW-088 suppresses only the immediate same-head and same-body hot-intake r
     false,
   );
 });
+
+test("duplicate due candidates do not strand the rest of the batch", () => {
+  // GitHub's paginated issue listing is sorted by `updated`, so an item touched
+  // mid-pagination can be returned on two pages. selectDueCandidates already
+  // dedupes by repo#number; the weighted drain must not read that skip as
+  // "buckets are empty" and abandon the candidates queued behind it.
+  const now = Date.parse("2026-06-10T00:00:00Z");
+  const reviewedAt = now - 24 * 60 * 60 * 1000; // reviewed yesterday: not weekly-coverage-due
+  const weekly = (number) => ({
+    item: item({ number, kind: "issue", createdAt: "2020-01-01T00:00:00Z" }),
+    review: { reviewStatus: "complete", reviewedAt: new Date(reviewedAt).toISOString() },
+    priority: 6,
+    reviewedAt,
+    nextDueAt: 0,
+    bucket: "weekly_issue", // weight 1: a single duplicate fills one pass
+    coverageTracked: true,
+  });
+
+  // Control: no duplicates.
+  assert.deepEqual(selectedNumbers([weekly(1), weekly(2), weekly(3)], 4, now), [1, 2, 3]);
+
+  // One duplicate of #1 must not cost us #2 and #3.
+  assert.deepEqual(
+    selectedNumbers([weekly(1), weekly(1), weekly(2), weekly(3)], 4, now),
+    [1, 2, 3],
+  );
+
+  // Duplicates are still deduped, and capacity is still respected.
+  assert.deepEqual(selectedNumbers([weekly(1), weekly(1)], 4, now), [1]);
+  assert.deepEqual(selectedNumbers([weekly(1), weekly(1), weekly(2), weekly(3)], 2, now), [1, 2]);
+});
+
+test("a run of duplicates larger than the bucket weight still drains", () => {
+  // hot_issue has weight 4, so eight copies of #1 span two full passes with no
+  // new selection in the second one.
+  const now = Date.parse("2026-06-10T00:00:00Z");
+  const reviewedAt = now - 24 * 60 * 60 * 1000;
+  const hot = (number) => ({
+    item: item({ number, kind: "issue", createdAt: "2020-01-01T00:00:00Z" }),
+    review: { reviewStatus: "complete", reviewedAt: new Date(reviewedAt).toISOString() },
+    priority: 0,
+    reviewedAt,
+    nextDueAt: 0,
+    bucket: "hot_issue",
+    coverageTracked: true,
+  });
+  const due = [...Array.from({ length: 8 }, () => hot(1)), hot(2), hot(3)];
+
+  assert.deepEqual(selectedNumbers(due, 5, now), [1, 2, 3]);
+});
+
+test("duplicates across separate buckets do not stall the weighted drain", () => {
+  const now = Date.parse("2026-06-10T00:00:00Z");
+  const reviewedAt = now - 24 * 60 * 60 * 1000;
+  const candidate = (number, bucket, kind) => ({
+    item: item({ number, kind, createdAt: "2020-01-01T00:00:00Z" }),
+    review: { reviewStatus: "complete", reviewedAt: new Date(reviewedAt).toISOString() },
+    priority: 6,
+    reviewedAt,
+    nextDueAt: 0,
+    bucket,
+    coverageTracked: true,
+  });
+  const due = [
+    candidate(1, "weekly_issue", "issue"),
+    candidate(1, "weekly_issue", "issue"),
+    candidate(2, "daily_pull_request", "pull_request"),
+    candidate(2, "daily_pull_request", "pull_request"),
+    candidate(3, "weekly_issue", "issue"),
+    candidate(4, "daily_pull_request", "pull_request"),
+  ];
+
+  assert.deepEqual(
+    selectedNumbers(due, 6, now).sort((a, b) => a - b),
+    [1, 2, 3, 4],
+  );
+});


### PR DESCRIPTION
Closes #1045.

## What Problem This Solves

Fixes an issue where a sweep would review fewer items than it had capacity for,
with no error and no telemetry signal, whenever the same item appeared twice in
the due list.

Duplicates are a normal GitHub pagination artifact: `GET /issues` is sorted by
`updated`, so an item touched between two page reads shifts pages and is returned
on both. `selectDueCandidates` already dedupes by `repo#number` — the dedup was
never the problem. The problem was that hitting a duplicate ended selection
entirely, stranding every candidate queued behind it while capacity sat free.

Through the real `plan` CLI with three distinct due PRs and `#1` listed on four
pages, the pre-fix sweep selected `[1]` where the fix selects `[1, 2, 3]` —
`dueBacklog` reported 6 in both cases.

The stranded items stay due, so the effect is delay and wasted capacity rather
than permanent starvation — but it compounds against the weekly-coverage SLO,
which is the outer freshness deadline for canonical records.

**Reachability, precisely.** A stall needs a whole weighted pass to consume
nothing but duplicates, so the threshold is per bucket. Derived by driving the
real `dueCandidate()` logic against a pre-fix build:

| bucket | weight | page entries for one item needed to strand |
|---|---:|---:|
| `hot_pull_request`, `activity`, `recent_issue` | 2 | **4** |
| `daily_pull_request` | 3 | 6 |
| `hot_issue` | 4 | 8 |
| `weekly_issue` | 1 | **unreachable** |

`weekly_issue` cannot reach it: "due" and "weekly-coverage-due" share the same
6-day threshold there, so such an item is always claimed by the coverage preselect
lane, which takes candidates in a plain loop. The candidate must also be
coverage-tracked and reviewed inside the window between its cadence (1 day) and
the 6-day coverage deadline; untracked items are recovered by the final loop.

I originally wrote that a single duplicate was enough. That was wrong — it came
from a hand-built `weekly_issue` candidate the real planner never emits in a
due-but-not-coverage-due state. The defect and the fix are unchanged; the
severity is narrower than I first stated, and this section is the correction.

## Why This Change Was Made

`take()` collapses three outcomes into "nothing happened": capacity reached,
bucket empty, and *duplicate skipped*. The weighted drain's no-progress guard then
read a pass that consumed only duplicates as "all buckets are drained" and broke
out of the loop.

The fix changes what the loop measures — candidates **drained** instead of
candidates **selected** — in the final drain loop and in `takeWeighted`, which has
the same shape. Two lines per loop.

Deliberately minimal. It does **not**:

- deduplicate the `due` list up front (that would change which entry wins when two
  copies carry different `review`/`bucket` fields — a larger behavioral change
  than this defect calls for);
- change bucket weights, ordering, comparators, or the dedup key;
- change behavior at all for a due list with no duplicates.

A duplicate still consumes one weighted slot in its pass; only the premature
`break` is removed. Termination is unchanged in kind: each pass either drains at
least one candidate or breaks, and `due` is finite.

## User Impact

Sweeps fill their configured batch size when the GitHub listing returns an item
twice, instead of silently truncating. Operators see the review throughput the
capacity settings imply; no configuration change is needed.

No data-contract, workflow, or schema change. No migration.

**OpenClaw Bay:** not affected. This changes how many candidates a sweep selects,
not any status, lifecycle, or telemetry shape Bay renders. `dueBacklog`,
`capacityReason`, and `planSelectionTelemetry` keep their existing meanings — the
selected count simply stops being wrong. No Bay update or Bay proof is needed.

**Release note:** `fix: stop duplicate due candidates from truncating the review batch`.
No `CHANGELOG.md` edit is included — happy to add one if this repo's release policy
wants it.

## Evidence

### Diff

```
 src/scheduler-policy.ts       |  19 +++++--
 test/scheduler-policy.test.ts | 129 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 144 insertions(+), 4 deletions(-)
```

Plus a new proof package under `docs/proof/scheduler-duplicate-candidate-stranding/`.

### Focused tests

`node --test test/scheduler-policy.test.ts` → **24/24 pass** (20 pre-existing + 4 new).

New tests:

- `duplicate due candidates do not strand the rest of the batch` — contract-level,
  plus assertions that duplicates are still deduped and capacity is still respected.
- `a run of duplicates larger than the bucket weight still drains` — eight entries
  in the weight-4 `hot_issue` bucket, spanning two full passes with no new
  selection in the second.
- `duplicates across separate buckets do not stall the weighted drain` — duplicates
  in two buckets simultaneously.
- `pagination duplicates do not strand candidates the real planner produces` —
  builds its candidate the way `dueCandidate()` does, asserting the derived bucket
  and due-ness first, so the regression guard is pinned to a shape production
  actually emits rather than a hand-built one.

### Red/green

Swapped **only** the compiled `dist/scheduler-policy.js` for a pre-fix build of the
same file, and re-ran with the new tests present:

| build | result |
|---|---|
| pre-fix | **4 fail**, 20 pass — exactly the 4 new tests |
| post-fix | **24 pass**, 0 fail |

All 20 pre-existing assertions were unchanged in both directions.

## Real Behavior Proof

**Claim.** `selectDueCandidates` fills the batch to capacity from the candidates it
is given, even when an item appears twice.

**Exercised surface.** The real `plan` CLI, end to end — **no application function
is substituted**:

```
node dist/clawsweeper.js plan
  -> createReviewPlanningSelection().selectCandidates()
  -> fetchOpenItemPage()  -> ghJsonLines() -> spawnSync -> `gh` subprocess
                          -> JSON-lines parse -> item mapping
  -> dueCandidate()       -> bucket / priority / due derivation
  -> selectDueCandidates()
```

Only the `gh` **binary** is replaced, standing in for GitHub's server. ClawSweeper's
own transport — subprocess spawn, argument construction, JSON-lines parsing,
pagination loop — runs unchanged. This addresses the previous review's finding that
the artifact "substitutes fetchOpenItemPage, so it does not exercise a real
transport client".

**Scenario / fixture.** Three distinct open PRs, `--batch_size 10` (far above the due
count, so capacity is never the limiting factor), `--max_pages 5`. The stub `gh`
returns `#1` on four consecutive pages, reproducing the `updated`-sorted pagination
race in which an item touched mid-scan is listed again on later pages:

```
page 1: [#1, #2]   page 2: [#1, #3]   page 3: [#1]   page 4: [#1]   page 5+: []
```

A prior report exists for each PR in the items dir, making them coverage-tracked —
the state in which the weighted drain, not the coverage preselect lane, owns
selection.

**Command and environment.** Executed in the supported environment — Node 24 in a
Docker-backed Crabbox `local-container` lease, on the current head:

```bash
crabbox run \
  --provider local-container \
  --local-container-image node:24 \
  --no-hydrate \
  --timing-json \
  --artifact-glob '.artifacts/scheduler-duplicate-proof/**' \
  --script docs/proof/scheduler-duplicate-candidate-stranding/run-proof.sh
```

| field | value |
|---|---|
| provider | Crabbox `local-container` (Docker/OrbStack) |
| crabbox | `0.15.0` |
| image | `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584` |
| container node | `v24.19.0` (satisfies `engines.node >= 24`) |
| lease | `cbx_7c89c5c91f66` (`brave-lobster`) |
| run | `run_71734de37d18` |
| artifact | `.crabbox/runs/run_71734de37d18/run_71734de37d18-artifacts.tgz` |
| exit | `0` |

**Observed result.** In-container, on the current head:

```
selected   : [1,2,3]
expected   : [1,2,3]
dueBacklog : 6        (6 page entries for 3 distinct PRs)
deduped    : true
RESULT: PASS

focused suite: 24/24 pass
```

`summary.json` from the artifact tarball:

```json
{ "selected": [1,2,3], "expected": [1,2,3], "dueBacklog": 6,
  "scannedPages": 5, "duplicateFreeSelection": true, "pass": true }
```

Against a pre-fix build of `dist/scheduler-policy.js`, the identical fixture and
CLI invocation yields `shards[0].itemNumbers = [1]` — `#2` and `#3` stranded with
`dueBacklog` still 6.

The proof also asserts the selection stays deduplicated, so the fix cannot be
satisfied by simply letting the duplicate through.

**Two traps worth recording**, both documented in the proof README so the next
person does not silently reintroduce a vacuous proof:

1. `selectCandidates()` calls `selectDueCandidates()` without a `now` argument, so
   the scheduler uses the real `Date.now()`. An earlier fixture used a fixed past
   `reviewedAt`; every candidate then qualified as weekly-coverage-due and was taken
   by the plain `for (const candidate of weeklyCoverageDue) take(candidate)` lane,
   which never reaches the weighted drain — so it **passed on a pre-fix build and
   proved nothing.**
2. Items with **no prior report** take the untracked lane, where survivors are
   recovered by the final loop and nothing is stranded. The fixture therefore writes
   a prior report per item; without that, the proof is also vacuous.

**Artifact / trace.** `docs/proof/scheduler-duplicate-candidate-stranding/` contains
`run-proof.sh` (the Crabbox entry point), `run-proof.mjs` (host-only quick check),
and the contract README. The lease artifact tarball holds `plan.json`,
`summary.json`, `focused-tests.txt`, `install.log`, and `build.log`.

**Limits.** Covers batch selection only. The duplicate is injected at the `gh`
**binary** boundary rather than produced by a real pagination race, since that race
is timing dependent and not reproducible on demand — so GitHub's own server
behavior is modeled, not exercised. No live GitHub, Worker, or queue is contacted,
and the proof performs no mutation. The lease is a local Docker container, not a
cloud host, so it proves the Linux/Node 24 runtime but not cross-host isolation.

**Privacy.** The fixture uses only `openclaw/openclaw` public-shaped item numbers
and a synthetic `contributor` login. No credential is present in the lease; the
stub `gh` makes no network call.

## Repository test suite status

The **proof and focused suite now run on Node 24 inside the Crabbox
`local-container` lease** recorded above (`24/24` focused tests in-container). The
notes below concern only the *full* suite run on the macOS host.


`engines.node` is `>=24`; the newest Node available on the macOS host is **v23.7.0**,
and `AGENTS.md` warns about test misbehavior below Node 24.

| run | tree | distinct failing tests |
|---|---|---|
| clean `main` | fix stashed, rebuilt | 20 |
| run 1 | this branch | 22 |
| run 2 | this branch | 21 |

**Two runs of the identical branch disagree with each other** — `comm -3` over
run 1 and run 2 shows three tests flipping. That is direct evidence of flakiness
rather than a regression.

The two tests that appeared only on the fix branch in run 1
(`comment webhook settles duplicate fast ack comments after dispatch`,
`webhook signature verification uses sha256 body hmac`) both **passed in run 2**,
and both pass **25/25, three runs in a row**, in isolation on *both* the clean tree
and this branch. A module-graph walk from `dist/repair/comment-webhook.js` confirms
`scheduler-policy` is **not reachable** from that code at all.

**No scheduler test failed in any run, on either tree.**

Green on this branch:

| check | environment | result |
|---|---|---|
| Crabbox `local-container` proof | Node 24 container | **PASS**, exit 0 |
| `test/scheduler-policy.test.ts` | Node 24 container | **24/24** |
| `pnpm run build:all` | macOS host | clean |
| `pnpm run format:check` | macOS host | clean, 636 files |
| `pnpm run lint` | macOS host | clean (all four projects) |

**Please confirm `pnpm run check` on Node 24+ in CI before merging.** The changed
surface is proven on Node 24, but I have not produced a green *full-suite* run and
am not claiming one.