### PR TITLE
fix(ci): unblock exact-review claims from reconcile flooding and telemetry poisoning

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -22,7 +22,21 @@ concurrency:
 jobs:
   reconcile:
     name: Observe and reconcile terminal review run
-    if: ${{ github.event_name == 'workflow_run' }}
+    # Support runs carry no exact-review lease and produce no review telemetry;
+    # the observer skips them by title (classifyReviewRun in
+    # scripts/review-run-observer.mjs). Skip them here too so every completed
+    # apply/sync/audit/fan-out run stops spawning a runner just to print
+    # "skipped" — at current sweep cadence that is hundreds of wasted runner
+    # slots per day competing with review claims. Keep this prefix list in
+    # sync with the observer.
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        !startsWith(github.event.workflow_run.display_title, 'Apply ') &&
+        !startsWith(github.event.workflow_run.display_title, 'Sync ') &&
+        !startsWith(github.event.workflow_run.display_title, 'Audit ') &&
+        !startsWith(github.event.workflow_run.display_title, 'Fan out ')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -22,20 +22,24 @@ concurrency:
 jobs:
   reconcile:
     name: Observe and reconcile terminal review run
-    # Support runs carry no exact-review lease and produce no review telemetry;
-    # the observer skips them by title (classifyReviewRun in
-    # scripts/review-run-observer.mjs). Skip them here too so every completed
-    # apply/sync/audit/fan-out run stops spawning a runner just to print
-    # "skipped" — at current sweep cadence that is hundreds of wasted runner
-    # slots per day competing with review claims. Keep this prefix list in
-    # sync with the observer.
+    # Schedule a runner only for titles the observer can classify. Queue-backed
+    # "Review exact item" runs and support runs otherwise start an ubuntu runner
+    # only to print "skipped", starving the Blacksmith jobs that must claim their
+    # six-minute queue reservations. The test suite keeps this allowlist aligned
+    # with REVIEW_RUN_OBSERVER_TITLE_LANES.
     if: >-
       ${{
         github.event_name == 'workflow_run' &&
-        !startsWith(github.event.workflow_run.display_title, 'Apply ') &&
-        !startsWith(github.event.workflow_run.display_title, 'Sync ') &&
-        !startsWith(github.event.workflow_run.display_title, 'Audit ') &&
-        !startsWith(github.event.workflow_run.display_title, 'Fan out ')
+        (
+          startsWith(github.event.workflow_run.display_title, 'Review scheduled hot item ') ||
+          startsWith(github.event.workflow_run.display_title, 'Review scheduled normal item ') ||
+          startsWith(github.event.workflow_run.display_title, 'Review event item') ||
+          startsWith(github.event.workflow_run.display_title, 'Review hot ClawSweeper items') ||
+          startsWith(github.event.workflow_run.display_title, 'Review hot target repo ') ||
+          startsWith(github.event.workflow_run.display_title, 'Retry failed Codex reviews') ||
+          startsWith(github.event.workflow_run.display_title, 'Review target repo ') ||
+          startsWith(github.event.workflow_run.display_title, 'Review ClawSweeper items')
+        )
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/queued-run-janitor.yml
+++ b/.github/workflows/queued-run-janitor.yml
@@ -38,7 +38,7 @@ jobs:
           cutoff="$(date -u -d "${STALE_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ')"
           stale_lines="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
             -f status=queued -f "created=<${cutoff}" -F per_page=100 \
-            --jq '.workflow_runs[] | "\(.id)\t\(.created_at)\t\(.display_title)"')"
+            --jq '.workflow_runs[] | [.id, .created_at, .display_title] | @tsv')"
           if [ -z "$stale_lines" ]; then
             echo "no queued runs created before ${cutoff}"
             exit 0

--- a/.github/workflows/queued-run-janitor.yml
+++ b/.github/workflows/queued-run-janitor.yml
@@ -1,0 +1,66 @@
+name: Reap stale queued workflow runs
+
+# GitHub occasionally strands queued runs forever (observed runs queued since
+# July that both cancel endpoints now 500 on). Reap stale queued runs while
+# the API still accepts cancellation, before they decay into unkillable
+# zombies that pollute run lists and queue-age telemetry. Approval-gated
+# runs report status "waiting", never "queued", so deployment gates are
+# structurally out of scope here.
+
+on:
+  schedule:
+    - cron: "24 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: queued-run-janitor
+  cancel-in-progress: false
+
+env:
+  STALE_HOURS: 24
+  MAX_CANCELLATIONS: 20
+
+jobs:
+  reap:
+    name: Cancel runs stuck in queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel queued runs older than the stale window
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cutoff="$(date -u -d "${STALE_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ')"
+          stale_lines="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
+            -f status=queued -f "created=<${cutoff}" -F per_page=100 \
+            --jq '.workflow_runs[] | "\(.id)\t\(.created_at)\t\(.display_title)"')"
+          if [ -z "$stale_lines" ]; then
+            echo "no queued runs created before ${cutoff}"
+            exit 0
+          fi
+          cancelled=0
+          wedged=0
+          while IFS= read -r line; do
+            if [ "$((cancelled + wedged))" -ge "$MAX_CANCELLATIONS" ]; then
+              echo "cancellation bound ${MAX_CANCELLATIONS} reached; remaining runs wait for the next pass"
+              break
+            fi
+            run_id="${line%%$'\t'*}"
+            if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null 2>&1 \
+              || gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" >/dev/null 2>&1; then
+              cancelled=$((cancelled + 1))
+              echo "cancelled: ${line}"
+            else
+              # Runs stranded long enough return 500 from both cancel endpoints
+              # and only GitHub can clear them. Report without failing so the
+              # janitor keeps reaping the runs it still can.
+              wedged=$((wedged + 1))
+              echo "::warning::uncancellable queued run (likely wedged server-side): ${line}"
+            fi
+          done <<<"$stale_lines"
+          echo "stale=$(wc -l <<<"$stale_lines" | tr -d ' ') cancelled=${cancelled} wedged=${wedged}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Completed ClawSweeper support runs (apply, comment sync, audit, fan-out) no longer spawn a reconcile-observer runner each — at current sweep cadence roughly 600 wasted runner slots per day that competed with exact-review claims — and a new hourly janitor cancels runs stuck in `queued` for over 24 hours before they decay into uncancellable zombies.
+- Deployment runs waiting for human approval no longer count as runner-queue congestion in operational health: a forgotten approval gate had pinned `oldest_queued_minutes` at eight-plus days and held work-execution status away from healthy; approval-gated runs now report separately (count and oldest age) in the API and the execution alert.
 - Terminal command acknowledgements whose status comment was deleted (or never existed) now complete as a durable `missing_status_comment` skip instead of requeueing the finalization driver forever every ~20 minutes.
 - Apply and comment-sync publications now recover from canonical record tuple 409 conflicts instead of crashing mid-checkpoint: an equivalent concurrent write is absorbed, an unrelated-section race is rebased onto CURRENT with a single deterministic retry, and a same-section race skips just that item while the rest of the run continues.
 - Prevented weekly coverage from endlessly refreshing tracked records while never-reviewed live items remained invisible behind a full candidate batch; normal fanout now refreshes and consumes the signed live inventory, skips empty repositories, and prioritizes repositories with untracked work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ checkpoint, and status-only commits are intentionally omitted.
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 
-
 - GitHub-throttled live-item checks now release the review claim for a delayed retry instead of failing the run and spending failure budget.
 - Event-review artifact publication completes as a superseded no-op when the reviewed branch vanished upstream (force-push or deletion) instead of failing the run.
 - Worker record requests now retry transient blank/invalid 2xx bodies from the edge within the bounded budget instead of failing hydration on the first occurrence.
@@ -176,7 +175,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Completed ClawSweeper support runs (apply, comment sync, audit, fan-out) no longer spawn a reconcile-observer runner each — at current sweep cadence roughly 600 wasted runner slots per day that competed with exact-review claims — and a new hourly janitor cancels runs stuck in `queued` for over 24 hours before they decay into uncancellable zombies.
+- Reconcile observers now start only for review titles they can classify, so queue-backed `Review exact item` and support runs no longer consume runner slots merely to report `skipped`; a new hourly janitor also cancels runs stuck in `queued` for over 24 hours before they decay into uncancellable zombies.
 - Deployment runs waiting for human approval no longer count as runner-queue congestion in operational health: a forgotten approval gate had pinned `oldest_queued_minutes` at eight-plus days and held work-execution status away from healthy; approval-gated runs now report separately (count and oldest age) in the API and the execution alert.
 - Terminal command acknowledgements whose status comment was deleted (or never existed) now complete as a durable `missing_status_comment` skip instead of requeueing the finalization driver forever every ~20 minutes.
 - Apply and comment-sync publications now recover from canonical record tuple 409 conflicts instead of crashing mid-checkpoint: an equivalent concurrent write is absorbed, an unrelated-section race is rebased onto CURRENT with a single deterministic retry, and a same-section race skips just that item while the rest of the run continues.

--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -3,7 +3,12 @@ export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;
 export const HEALTH_HISTORY_SAMPLE_MS = 5 * 60 * 1000;
 export const HEALTH_HISTORY_RETENTION_DAYS = 7;
 
-const QUEUED_STATUSES = new Set(["queued", "waiting", "requested", "pending"]);
+// "waiting" runs sit behind a deployment approval gate: a human decision, not
+// runner congestion. A forgotten approval would otherwise pin
+// oldest_queued_minutes for weeks and hold status at degraded, so they are
+// counted separately instead of inside the queue-pressure metrics.
+const QUEUED_STATUSES = new Set(["queued", "requested", "pending"]);
+const APPROVAL_GATED_STATUSES = new Set(["waiting"]);
 
 type WorkflowRun = {
   status?: string;
@@ -19,6 +24,8 @@ export type OperationalHealth = {
   queued_over_threshold: number;
   queued_threshold_minutes: number;
   oldest_queued_minutes: number;
+  approval_gated_runs: number;
+  oldest_approval_gated_minutes: number;
   running_runs: number;
   running_over_threshold: number;
   running_threshold_minutes: number;
@@ -76,6 +83,9 @@ export function summarizeOperationalHealth(
   const checkedAtMs = Date.parse(checkedAt);
   const now = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const queuedRuns = runs.filter((run) => QUEUED_STATUSES.has(String(run.status || "")));
+  const approvalGatedRuns = runs.filter((run) =>
+    APPROVAL_GATED_STATUSES.has(String(run.status || "")),
+  );
   const runningRuns = runs.filter((run) => run.status === "in_progress");
   const queuedAges = queuedRuns.map((run) => ageMs(run.created_at, now));
   const runningAges = runningRuns
@@ -109,6 +119,12 @@ export function summarizeOperationalHealth(
     queued_over_threshold: queuedOverThreshold,
     queued_threshold_minutes: OPERATIONAL_QUEUE_DEGRADED_MS / 60_000,
     oldest_queued_minutes: oldestMinutes(validQueuedAges),
+    approval_gated_runs: approvalGatedRuns.length,
+    oldest_approval_gated_minutes: oldestMinutes(
+      approvalGatedRuns
+        .map((run) => ageMs(run.created_at, now))
+        .filter((age): age is number => age !== null),
+    ),
     running_runs: runningRuns.length,
     running_over_threshold: runningOverThreshold,
     running_threshold_minutes: OPERATIONAL_RUNNING_STALLED_MS / 60_000,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9807,7 +9807,8 @@ function renderExecutionAlert(current) {
   if (queued) parts.push(fmt.format(queued) + " workflow" + (queued === 1 ? "" : "s") + " waiting for a runner over 30m");
   if (running) parts.push(fmt.format(running) + " execution" + (running === 1 ? "" : "s") + " over 150m");
   if (incomplete) parts.push("work execution telemetry is incomplete");
-  const details = "Total GitHub queued " + fmt.format(Number(current?.queued_runs) || 0) + " · oldest queued " + formatAgeMinutes(current?.oldest_queued_minutes) + " · oldest running " + formatAgeMinutes(current?.oldest_running_minutes);
+  const approvalGated = Number(current?.approval_gated_runs) || 0;
+  const details = "Total GitHub queued " + fmt.format(Number(current?.queued_runs) || 0) + " · oldest queued " + formatAgeMinutes(current?.oldest_queued_minutes) + " · oldest running " + formatAgeMinutes(current?.oldest_running_minutes) + (approvalGated ? " · " + fmt.format(approvalGated) + " awaiting deployment approval (oldest " + formatAgeMinutes(current?.oldest_approval_gated_minutes) + ")" : "");
   target.innerHTML = '<details class="execution-alert"><summary><span class="execution-alert-title"><strong>⚠ Work execution needs attention</strong><span>' + esc(parts.join(" · ")) + '</span></span><span class="execution-alert-toggle">Details ▾</span></summary><div class="execution-alert-body">' + esc(details) + '</div></details>';
 }
 

--- a/scripts/review-run-observer.mjs
+++ b/scripts/review-run-observer.mjs
@@ -34,18 +34,25 @@ Examples:
 `;
 }
 
+export const REVIEW_RUN_OBSERVER_TITLE_LANES = Object.freeze({
+  "Review scheduled hot item ": "hot_intake",
+  "Review scheduled normal item ": "normal_backfill",
+  "Review event item": "exact_event",
+  "Review hot ClawSweeper items": "hot_intake",
+  "Review hot target repo ": "hot_intake",
+  "Retry failed Codex reviews": "recovery",
+  "Review target repo ": "normal_backfill",
+  "Review ClawSweeper items": "normal_backfill",
+});
+
 export function classifyReviewRun(run) {
   const title = String(run.display_title || run.name || "").trim();
   const event = String(run.event || "");
-  if (/^(Apply |Sync |Audit |Fan out )/.test(title)) return null;
-  let triggerLane;
-  if (title.startsWith("Review scheduled hot item")) triggerLane = "hot_intake";
-  else if (title.startsWith("Review scheduled normal item")) triggerLane = "normal_backfill";
-  else if (title.startsWith("Review event item")) triggerLane = "exact_event";
-  else if (/^Review hot (?:ClawSweeper items|target repo)/.test(title)) triggerLane = "hot_intake";
-  else if (title.startsWith("Retry failed Codex reviews")) triggerLane = "recovery";
-  else if (/^Review (?:target repo|ClawSweeper items)/.test(title)) triggerLane = "normal_backfill";
-  else return null;
+  const titleRule = Object.entries(REVIEW_RUN_OBSERVER_TITLE_LANES).find(([prefix]) =>
+    title.startsWith(prefix),
+  );
+  if (!titleRule) return null;
+  const triggerLane = titleRule[1];
 
   const command = /\[(?:router-|command:)/i.test(title);
   const triggerOrigin = title.startsWith("Review scheduled ")

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -54,6 +54,25 @@ test("operational health classifies over-age queue pressure and stuck runs", () 
   assert.equal(stalled.oldest_running_minutes, 180);
 });
 
+test("operational health reports approval-gated runs outside queue congestion", () => {
+  const health = summarizeOperationalHealth(
+    [
+      // A deployment waiting a week for human approval is not runner
+      // congestion and must not degrade status or pin oldest_queued_minutes.
+      run("waiting", "2026-07-08T14:00:00Z"),
+      run("queued", "2026-07-15T13:55:00Z"),
+    ],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(health.status, "healthy");
+  assert.equal(health.queued_runs, 1);
+  assert.equal(health.queued_over_threshold, 0);
+  assert.equal(health.oldest_queued_minutes, 5);
+  assert.equal(health.approval_gated_runs, 1);
+  assert.equal(health.oldest_approval_gated_minutes, 7 * 24 * 60);
+});
+
 test("operational health fails closed when active-run telemetry is incomplete", () => {
   const health = summarizeOperationalHealth([], CHECKED_AT, false);
   assert.equal(health.status, "unknown");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -21103,6 +21103,17 @@ test("dashboard hero treats apply and exact-review handoff health as attention",
   );
   context.renderExecutionAlert({
     ...healthyOperational,
+    queued_runs: 2,
+    queued_over_threshold: 2,
+    approval_gated_runs: 1,
+    oldest_approval_gated_minutes: 7 * 24 * 60,
+  });
+  assert.match(
+    elementFor("execution-alert").innerHTML,
+    /1 awaiting deployment approval \(oldest 168h\)/,
+  );
+  context.renderExecutionAlert({
+    ...healthyOperational,
     running_runs: 1,
     running_over_threshold: 1,
   });

--- a/test/review-reliability-workflow.test.ts
+++ b/test/review-reliability-workflow.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import test from "node:test";
 import { parse } from "yaml";
+import {
+  classifyReviewRun,
+  REVIEW_RUN_OBSERVER_TITLE_LANES,
+} from "../scripts/review-run-observer.mjs";
 
 test("review reliability telemetry shares the terminal reconciler workflow", () => {
   assert.equal(existsSync(".github/workflows/review-reliability-observer.yml"), false);
@@ -12,7 +16,23 @@ test("review reliability telemetry shares the terminal reconciler workflow", () 
     types: ["completed"],
   });
   assert.deepEqual(workflow.permissions, {});
-  assert.equal(workflow.jobs.reconcile.if, "${{ github.event_name == 'workflow_run' }}");
+  const reconcileIf = String(workflow.jobs.reconcile.if);
+  assert.match(reconcileIf, /github\.event_name == 'workflow_run'/);
+  const gatedPrefixes = [
+    ...reconcileIf.matchAll(/startsWith\(github\.event\.workflow_run\.display_title, '([^']+)'\)/g),
+  ].map((match) => match[1]);
+  assert.deepEqual(gatedPrefixes, Object.keys(REVIEW_RUN_OBSERVER_TITLE_LANES));
+  for (const [prefix, lane] of Object.entries(REVIEW_RUN_OBSERVER_TITLE_LANES)) {
+    assert.equal(
+      classifyReviewRun({
+        display_title: `${prefix}openclaw/openclaw#1`,
+        event: "repository_dispatch",
+      })?.trigger_lane,
+      lane,
+      prefix,
+    );
+  }
+  assert.doesNotMatch(reconcileIf, /Review exact item/);
   assert.deepEqual(workflow.jobs.reconcile.permissions, { actions: "read", contents: "read" });
   const checkout = workflow.jobs.reconcile.steps.find((candidate: Record<string, unknown>) =>
     String(candidate.uses || "").startsWith("actions/checkout@"),
@@ -34,6 +54,28 @@ test("review reliability telemetry shares the terminal reconciler workflow", () 
     /format\('\{0\}-\{1\}', github\.event\.workflow_run\.id, github\.event\.workflow_run\.run_attempt\)/,
   );
   assert.equal(workflow.concurrency["cancel-in-progress"], false);
+});
+
+test("queued workflow janitor is bounded to stale queued runs", () => {
+  const workflow = parse(
+    readFileSync(".github/workflows/queued-run-janitor.yml", "utf8"),
+  ) as Record<string, any>;
+  assert.deepEqual(workflow.permissions, {});
+  assert.deepEqual(workflow.on.schedule, [{ cron: "24 * * * *" }]);
+  assert.ok(Object.hasOwn(workflow.on, "workflow_dispatch"));
+  assert.equal(workflow.concurrency.group, "queued-run-janitor");
+  assert.equal(workflow.concurrency["cancel-in-progress"], false);
+  assert.equal(workflow.env.STALE_HOURS, 24);
+  assert.equal(workflow.env.MAX_CANCELLATIONS, 20);
+  assert.deepEqual(workflow.jobs.reap.permissions, { actions: "write" });
+  const run = String(workflow.jobs.reap.steps[0].run);
+  assert.match(run, /-f status=queued/);
+  assert.match(run, /-f "created=<\$\{cutoff\}"/);
+  assert.match(run, /\[\.id, \.created_at, \.display_title\] \| @tsv/);
+  assert.match(run, /actions\/runs\/\$\{run_id\}\/cancel/);
+  assert.match(run, /actions\/runs\/\$\{run_id\}\/force-cancel/);
+  assert.match(run, /cancelled \+ wedged/);
+  assert.doesNotMatch(run, /status=waiting/);
 });
 
 test("exact review generation enters finalization before state hydration", () => {

--- a/test/review-run-telemetry.test.ts
+++ b/test/review-run-telemetry.test.ts
@@ -87,6 +87,15 @@ test("review observer attributes each review entry path without counting support
     classifyReviewRun(run({ display_title: "Apply default ClawSweeper closures" })),
     null,
   );
+  assert.equal(
+    classifyReviewRun(
+      run({
+        display_title:
+          "Review exact item openclaw/openclaw#674 rev 2 head aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+    ),
+    null,
+  );
   assert.equal(classifyReviewRun(run({ display_title: "Reconcile exact-review leases" })), null);
 });
 

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1705,7 +1705,7 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
     /group: exact-review-reconcile-\$\{\{ github\.event_name == 'workflow_run' && format\('\{0\}-\{1\}', github\.event\.workflow_run\.id, github\.event\.workflow_run\.run_attempt\) \|\| 'sweep' \}\}/,
   );
   assert.match(workflow, /cancel-in-progress: false/);
-  assert.match(eventJob, /if: \$\{\{ github\.event_name == 'workflow_run' \}\}/);
+  assert.match(eventJob, /if: >-\s+\$\{\{\s+github\.event_name == 'workflow_run' &&/);
   assert.match(eventJob, /permissions:\s+actions: read\s+contents: read/);
   assert.match(eventJob, /github\.event\.workflow_run\.event == 'repository_dispatch'/);
   assert.match(


### PR DESCRIPTION
## What Problem This Solves

Resolves an incident where completed workflow runs flooded GitHub Actions with
`Reconcile exact-review leases` observers. At 2026-08-06T18:39:56Z the live
system had 1,200 reconcile runs queued, 1,436 total runs queued, 125 exact
reviews dispatching, zero claimed leases, and a 358-second oldest dispatch
against a six-minute reservation. Handoff health was
`stalled: claim_stalled`, blocking exact reviews needed for the OpenClaw OTEL
landing.

It also fixes two related operational blind spots found during the incident:
queued runs can become permanently uncancellable after sitting for days, and
deployment runs waiting for human approval were counted as runner congestion.

## Why This Change Was Made

The reconcile job now uses a positive allowlist of review titles that
`classifyReviewRun` can actually observe. Queue-backed `Review exact item` runs
and support workflows no longer allocate an Ubuntu runner merely to report
`skipped`. A contract test keeps the workflow allowlist exactly synchronized
with `REVIEW_RUN_OBSERVER_TITLE_LANES`.

A bounded hourly janitor cancels runs that remain in `queued` for more than 24
hours. It attempts at most 20 records per pass, scopes `actions: write` to the
single job, TSV-escapes API fields before parsing, and excludes `waiting`
approval-gated runs. Operational health now reports those approval gates
separately instead of treating them as runner pressure.

OpenClaw Bay behavior is unchanged. This affects Actions scheduling, queue
health telemetry, and the dashboard execution alert only.

## User Impact

Exact-review jobs can reach Blacksmith and claim their queue reservations
instead of expiring behind observer noise. Operators get truthful runner-queue
health, visibility into forgotten deployment approvals, and bounded cleanup of
future stale queued runs.

## Evidence

- Exact PR head: `a3b6f321215af748091c6fb25205457c6cb84949`.
- Live incident snapshot at 2026-08-06T18:39:56Z:
  - reconcile queued: 1,200
  - total Actions queued: 1,436
  - exact-review dispatching / leased: 125 / 0
  - oldest dispatching: 358 seconds
  - handoff: `stalled: claim_stalled`
- Live janitor query reproduced the three known runs queued since July 13-17;
  both cancellation endpoints already return server errors for those zombies.
- `actionlint 1.7.12` passed across all workflows.
- Focused workflow, observer, queue, dashboard, and operational-health suite:
  456 passed.
- Static gates passed: active-surface, dashboard queue boundary, limits,
  formatting (638 files), three TypeScript builds, and all four lint lanes.
- Changed coverage: 12 passed; 100% lines/functions and 88.61% branches.
- Full test inventory: all cases passed across the required local pnpm
  toolchains. The pnpm-10 run covered 3,150 tests and cleared coverage
  thresholds; its sole pnpm-11-specific process-env fixture passed 7/7 under
  the repo pnpm 11 toolchain. The isolated target-validation lane passed
  198 with 3 platform skips under pinned pnpm 10.
- Full coverage: 81.02% lines, 73.78% branches, 87.26% functions.
- Dirty-diff and committed-branch Codex autoreviews were clean with no
  accepted or actionable findings.

## Real Behavior Proof

- Claim: unsupported completion events no longer schedule reconcile runners;
  only titles attributable to a review lane can run the observer.
- Exercised surface: workflow job-level `if`, observer title classifier,
  bounded janitor script, operational-health summarizer, and dashboard alert.
- Scenario: live `openclaw/clawsweeper` incident state plus exact workflow and
  queue fixtures.
- Observable result: every workflow-gated title classifies to the expected
  lane, `Review exact item` and support titles classify as no observer,
  approval-gated runs remain visible without degrading queue health, and the
  janitor cannot exceed its stale queued-run cancellation bound.
- Recovery step after merge: cancel only pre-fix queued
  `workflow_run` reconcile runs, then verify new observer runs skip without a
  runner and exact-review leases begin claiming.

## Limits

The janitor cannot repair the three GitHub-side zombie runs whose normal and
force-cancel endpoints already fail. Those remain an external GitHub cleanup
issue and are excluded from runner-congestion health once their status is not
`queued`.
