### PR TITLE
test(ci): assert the gated reconcile observer condition

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -30,13 +30,11 @@ jobs:
     # slots per day competing with review claims. Keep this prefix list in
     # sync with the observer.
     if: >-
-      ${{
-        github.event_name == 'workflow_run' &&
-        !startsWith(github.event.workflow_run.display_title, 'Apply ') &&
-        !startsWith(github.event.workflow_run.display_title, 'Sync ') &&
-        !startsWith(github.event.workflow_run.display_title, 'Audit ') &&
-        !startsWith(github.event.workflow_run.display_title, 'Fan out ')
-      }}
+      ${{ github.event_name == 'workflow_run' &&
+      !startsWith(github.event.workflow_run.display_title, 'Apply ') &&
+      !startsWith(github.event.workflow_run.display_title, 'Sync ') &&
+      !startsWith(github.event.workflow_run.display_title, 'Audit ') &&
+      !startsWith(github.event.workflow_run.display_title, 'Fan out ') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -22,7 +22,21 @@ concurrency:
 jobs:
   reconcile:
     name: Observe and reconcile terminal review run
-    if: ${{ github.event_name == 'workflow_run' }}
+    # Support runs carry no exact-review lease and produce no review telemetry;
+    # the observer skips them by title (classifyReviewRun in
+    # scripts/review-run-observer.mjs). Skip them here too so every completed
+    # apply/sync/audit/fan-out run stops spawning a runner just to print
+    # "skipped" — at current sweep cadence that is hundreds of wasted runner
+    # slots per day competing with review claims. Keep this prefix list in
+    # sync with the observer.
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        !startsWith(github.event.workflow_run.display_title, 'Apply ') &&
+        !startsWith(github.event.workflow_run.display_title, 'Sync ') &&
+        !startsWith(github.event.workflow_run.display_title, 'Audit ') &&
+        !startsWith(github.event.workflow_run.display_title, 'Fan out ')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/queued-run-janitor.yml
+++ b/.github/workflows/queued-run-janitor.yml
@@ -1,0 +1,66 @@
+name: Reap stale queued workflow runs
+
+# GitHub occasionally strands queued runs forever (observed runs queued since
+# July that both cancel endpoints now 500 on). Reap stale queued runs while
+# the API still accepts cancellation, before they decay into unkillable
+# zombies that pollute run lists and queue-age telemetry. Approval-gated
+# runs report status "waiting", never "queued", so deployment gates are
+# structurally out of scope here.
+
+on:
+  schedule:
+    - cron: "24 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: queued-run-janitor
+  cancel-in-progress: false
+
+env:
+  STALE_HOURS: 24
+  MAX_CANCELLATIONS: 20
+
+jobs:
+  reap:
+    name: Cancel runs stuck in queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel queued runs older than the stale window
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cutoff="$(date -u -d "${STALE_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ')"
+          stale_lines="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
+            -f status=queued -f "created=<${cutoff}" -F per_page=100 \
+            --jq '.workflow_runs[] | "\(.id)\t\(.created_at)\t\(.display_title)"')"
+          if [ -z "$stale_lines" ]; then
+            echo "no queued runs created before ${cutoff}"
+            exit 0
+          fi
+          cancelled=0
+          wedged=0
+          while IFS= read -r line; do
+            if [ "$((cancelled + wedged))" -ge "$MAX_CANCELLATIONS" ]; then
+              echo "cancellation bound ${MAX_CANCELLATIONS} reached; remaining runs wait for the next pass"
+              break
+            fi
+            run_id="${line%%$'\t'*}"
+            if gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null 2>&1 \
+              || gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" >/dev/null 2>&1; then
+              cancelled=$((cancelled + 1))
+              echo "cancelled: ${line}"
+            else
+              # Runs stranded long enough return 500 from both cancel endpoints
+              # and only GitHub can clear them. Report without failing so the
+              # janitor keeps reaping the runs it still can.
+              wedged=$((wedged + 1))
+              echo "::warning::uncancellable queued run (likely wedged server-side): ${line}"
+            fi
+          done <<<"$stale_lines"
+          echo "stale=$(wc -l <<<"$stale_lines" | tr -d ' ') cancelled=${cancelled} wedged=${wedged}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Completed ClawSweeper support runs (apply, comment sync, audit, fan-out) no longer spawn a reconcile-observer runner each — at current sweep cadence roughly 600 wasted runner slots per day that competed with exact-review claims — and a new hourly janitor cancels runs stuck in `queued` for over 24 hours before they decay into uncancellable zombies.
+- Deployment runs waiting for human approval no longer count as runner-queue congestion in operational health: a forgotten approval gate had pinned `oldest_queued_minutes` at eight-plus days and held work-execution status away from healthy; approval-gated runs now report separately (count and oldest age) in the API and the execution alert.
 - Terminal command acknowledgements whose status comment was deleted (or never existed) now complete as a durable `missing_status_comment` skip instead of requeueing the finalization driver forever every ~20 minutes.
 - Apply and comment-sync publications now recover from canonical record tuple 409 conflicts instead of crashing mid-checkpoint: an equivalent concurrent write is absorbed, an unrelated-section race is rebased onto CURRENT with a single deterministic retry, and a same-section race skips just that item while the rest of the run continues.
 - Prevented weekly coverage from endlessly refreshing tracked records while never-reviewed live items remained invisible behind a full candidate batch; normal fanout now refreshes and consumes the signed live inventory, skips empty repositories, and prioritizes repositories with untracked work.

--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -3,7 +3,12 @@ export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;
 export const HEALTH_HISTORY_SAMPLE_MS = 5 * 60 * 1000;
 export const HEALTH_HISTORY_RETENTION_DAYS = 7;
 
-const QUEUED_STATUSES = new Set(["queued", "waiting", "requested", "pending"]);
+// "waiting" runs sit behind a deployment approval gate: a human decision, not
+// runner congestion. A forgotten approval would otherwise pin
+// oldest_queued_minutes for weeks and hold status at degraded, so they are
+// counted separately instead of inside the queue-pressure metrics.
+const QUEUED_STATUSES = new Set(["queued", "requested", "pending"]);
+const APPROVAL_GATED_STATUSES = new Set(["waiting"]);
 
 type WorkflowRun = {
   status?: string;
@@ -19,6 +24,8 @@ export type OperationalHealth = {
   queued_over_threshold: number;
   queued_threshold_minutes: number;
   oldest_queued_minutes: number;
+  approval_gated_runs: number;
+  oldest_approval_gated_minutes: number;
   running_runs: number;
   running_over_threshold: number;
   running_threshold_minutes: number;
@@ -76,6 +83,9 @@ export function summarizeOperationalHealth(
   const checkedAtMs = Date.parse(checkedAt);
   const now = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const queuedRuns = runs.filter((run) => QUEUED_STATUSES.has(String(run.status || "")));
+  const approvalGatedRuns = runs.filter((run) =>
+    APPROVAL_GATED_STATUSES.has(String(run.status || "")),
+  );
   const runningRuns = runs.filter((run) => run.status === "in_progress");
   const queuedAges = queuedRuns.map((run) => ageMs(run.created_at, now));
   const runningAges = runningRuns
@@ -109,6 +119,12 @@ export function summarizeOperationalHealth(
     queued_over_threshold: queuedOverThreshold,
     queued_threshold_minutes: OPERATIONAL_QUEUE_DEGRADED_MS / 60_000,
     oldest_queued_minutes: oldestMinutes(validQueuedAges),
+    approval_gated_runs: approvalGatedRuns.length,
+    oldest_approval_gated_minutes: oldestMinutes(
+      approvalGatedRuns
+        .map((run) => ageMs(run.created_at, now))
+        .filter((age): age is number => age !== null),
+    ),
     running_runs: runningRuns.length,
     running_over_threshold: runningOverThreshold,
     running_threshold_minutes: OPERATIONAL_RUNNING_STALLED_MS / 60_000,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9807,7 +9807,8 @@ function renderExecutionAlert(current) {
   if (queued) parts.push(fmt.format(queued) + " workflow" + (queued === 1 ? "" : "s") + " waiting for a runner over 30m");
   if (running) parts.push(fmt.format(running) + " execution" + (running === 1 ? "" : "s") + " over 150m");
   if (incomplete) parts.push("work execution telemetry is incomplete");
-  const details = "Total GitHub queued " + fmt.format(Number(current?.queued_runs) || 0) + " · oldest queued " + formatAgeMinutes(current?.oldest_queued_minutes) + " · oldest running " + formatAgeMinutes(current?.oldest_running_minutes);
+  const approvalGated = Number(current?.approval_gated_runs) || 0;
+  const details = "Total GitHub queued " + fmt.format(Number(current?.queued_runs) || 0) + " · oldest queued " + formatAgeMinutes(current?.oldest_queued_minutes) + " · oldest running " + formatAgeMinutes(current?.oldest_running_minutes) + (approvalGated ? " · " + fmt.format(approvalGated) + " awaiting deployment approval (oldest " + formatAgeMinutes(current?.oldest_approval_gated_minutes) + ")" : "");
   target.innerHTML = '<details class="execution-alert"><summary><span class="execution-alert-title"><strong>⚠ Work execution needs attention</strong><span>' + esc(parts.join(" · ")) + '</span></span><span class="execution-alert-toggle">Details ▾</span></summary><div class="execution-alert-body">' + esc(details) + '</div></details>';
 }
 

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -54,6 +54,25 @@ test("operational health classifies over-age queue pressure and stuck runs", () 
   assert.equal(stalled.oldest_running_minutes, 180);
 });
 
+test("operational health reports approval-gated runs outside queue congestion", () => {
+  const health = summarizeOperationalHealth(
+    [
+      // A deployment waiting a week for human approval is not runner
+      // congestion and must not degrade status or pin oldest_queued_minutes.
+      run("waiting", "2026-07-08T14:00:00Z"),
+      run("queued", "2026-07-15T13:55:00Z"),
+    ],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(health.status, "healthy");
+  assert.equal(health.queued_runs, 1);
+  assert.equal(health.queued_over_threshold, 0);
+  assert.equal(health.oldest_queued_minutes, 5);
+  assert.equal(health.approval_gated_runs, 1);
+  assert.equal(health.oldest_approval_gated_minutes, 7 * 24 * 60);
+});
+
 test("operational health fails closed when active-run telemetry is incomplete", () => {
   const health = summarizeOperationalHealth([], CHECKED_AT, false);
   assert.equal(health.status, "unknown");

--- a/test/review-reliability-workflow.test.ts
+++ b/test/review-reliability-workflow.test.ts
@@ -12,7 +12,16 @@ test("review reliability telemetry shares the terminal reconciler workflow", () 
     types: ["completed"],
   });
   assert.deepEqual(workflow.permissions, {});
-  assert.equal(workflow.jobs.reconcile.if, "${{ github.event_name == 'workflow_run' }}");
+  // The job-level gate mirrors the classifyReviewRun skip prefixes in
+  // scripts/review-run-observer.mjs so support runs never spawn a runner.
+  assert.equal(
+    workflow.jobs.reconcile.if,
+    "${{ github.event_name == 'workflow_run' && " +
+      "!startsWith(github.event.workflow_run.display_title, 'Apply ') && " +
+      "!startsWith(github.event.workflow_run.display_title, 'Sync ') && " +
+      "!startsWith(github.event.workflow_run.display_title, 'Audit ') && " +
+      "!startsWith(github.event.workflow_run.display_title, 'Fan out ') }}",
+  );
   assert.deepEqual(workflow.jobs.reconcile.permissions, { actions: "read", contents: "read" });
   const checkout = workflow.jobs.reconcile.steps.find((candidate: Record<string, unknown>) =>
     String(candidate.uses || "").startsWith("actions/checkout@"),

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1705,7 +1705,15 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
     /group: exact-review-reconcile-\$\{\{ github\.event_name == 'workflow_run' && format\('\{0\}-\{1\}', github\.event\.workflow_run\.id, github\.event\.workflow_run\.run_attempt\) \|\| 'sweep' \}\}/,
   );
   assert.match(workflow, /cancel-in-progress: false/);
-  assert.match(eventJob, /if: \$\{\{ github\.event_name == 'workflow_run' \}\}/);
+  assert.match(eventJob, /if: >-\s+\$\{\{\s+github\.event_name == 'workflow_run' &&/);
+  for (const prefix of ["Apply ", "Sync ", "Audit ", "Fan out "]) {
+    assert.match(
+      eventJob,
+      new RegExp(
+        `!startsWith\\(github\\.event\\.workflow_run\\.display_title, '${prefix}'\\)`,
+      ),
+    );
+  }
   assert.match(eventJob, /permissions:\s+actions: read\s+contents: read/);
   assert.match(eventJob, /github\.event\.workflow_run\.event == 'repository_dispatch'/);
   assert.match(


### PR DESCRIPTION
Repairs main after #1047: that PR was merged while its CI was still queued in the congested runner pool, and the queued run later surfaced two workflow-shape test failures — `test/review-reliability-workflow.test.ts` and `test/sweep-workflow.test.ts` pin the reconcile job's exact `if:` condition, which #1047 gated on the support-run title prefixes.

This updates both suites to assert the new gated condition (including all four `classifyReviewRun` skip prefixes, keeping the observer-sync contract tested) and reflows the folded YAML expression to uniform indent so it parses as a single-line string.

Proof: `node --test test/review-reliability-workflow.test.ts` (2 pass) and full `test/sweep-workflow.test.ts` (114 pass); `actionlint` clean under CI's `-shellcheck=` flags; `oxfmt --check` clean. Codex autoreview: clean, 0.99.
