### PR TITLE
fix: scheduled reviews re-run on unchanged items because the review cache is unreachable

### DIFF
--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -1,20 +1,28 @@
-# Proof: the exact-event lane could not reach its own structural receipt
+# Proof: scheduled reviews never reused a cached verdict
 
 ## Claim
 
-`.github/workflows/sweep.yml` reserves the durable review lease in its own
-write-token step, so it must invoke the review command with
-`--skip-start-comment`. That flag also decided `coordinationEnabled`, which
-`reviewStructuralCacheProbeDecision` consults before anything else. Scheduled
-deliveries therefore returned `coordination_disabled`, skipped the probe, and
-re-ran full hydration plus Codex on unchanged items — and because the probe
-never ran, `preHydrationStructuralRecord` stayed `null` and the seeding branch
-could never persist a receipt for the next review either.
+A scheduled delivery of an unchanged item re-ran full hydration and Codex every
+pass. Three conditions on the same cache-eligibility path each blocked reuse, and
+all three had to go for the outcome to change:
+
+1. **`coordination_disabled`** — `sweep.yml` reserves the review lease in its own
+   write-token step, so it must pass `--skip-start-comment`; that flag also
+   decided `coordinationEnabled`, which the probe consults before anything else.
+   The probe never ran, so `preHydrationStructuralRecord` stayed `null` and the
+   seeding branch could never persist a receipt for the next review either.
+2. **`activity_changed`** — the reservation the workflow posts is itself the
+   item's newest activity, landing after the sync markers the prior review
+   recorded, so ClawSweeper's own write read as reporter activity.
+3. **`target_changed`** — the decision compared the target repository's default
+   branch head across reviews. That head advances for reasons unrelated to the
+   item, so where it moves faster than the review cadence the key can never match.
 
 ## Level
 
-Module-level proof against the built `dist/` output, using production argument
-values. It is not a live end-to-end trace; see Limits.
+Module-level captures against the built `dist/` output using production argument
+values, plus end-to-end runs of the shipped `review` command against a live
+GitHub item. Not a trace against a production target; see Limits.
 
 ## Exercised surface
 
@@ -117,13 +125,12 @@ hydrated and re-reviewed in full.
   limit. The end-to-end section below closes part of this gap on a repository the
   proof author owns.
 - The end-to-end section below reaches a structural cache hit with no hydration
-  and no Codex call. Separately, this change does not by
-  itself produce cache hits on `openclaw/openclaw`, because `reviewStructuralCacheDecision`
-  separately compares the target repository's `main` head between reviews
-  (`src/review-structural-cache.ts:1280`), and that head advances roughly every
-  13 minutes there (100 commits in 21h11m, measured 2026-08-07). Whether an
-  unrelated `main` commit should invalidate a pull request's verdict is a design
-  question, filed separately.
+  and no Codex call, including after the target branch advanced. The runs use one
+  repository the proof author owns; behaviour on a production target is inferred
+  from the shipped code being identical, not observed. `openclaw/openclaw` is the
+  case that motivates this: its default branch advanced 100 times in the 21h11m
+  ending 2026-08-07, roughly once every 13 minutes, against a daily review
+  cadence.
 - No production review jobs were dispatched, no model capacity was consumed, and
   no contributor notifications were generated while validating this change.
 
@@ -225,6 +232,36 @@ review_structural_cache_hit: true
 `hydrations=0` is the point: the run neither hydrated GitHub context nor called
 Codex. It took 8 seconds end to end, against 70-150 seconds for the full reviews
 in runs 1-3.
+
+### An unrelated commit on the target branch no longer forces a full review
+
+The runs above kept the target repository's `main` still. Advancing it by one
+commit that has nothing to do with the item — a comment appended to `README.md`,
+where the item is about `src/slug.js` — was enough to lose the hit before this
+change:
+
+```text
+structural_cache_reasons: { "target_changed": 1 }
+cache_hits=0  hydrations=1                      (103 s, full hydration + Codex)
+```
+
+Same item, same reserved-lease flow, same advanced `main`, after the change:
+
+```text
+[review] shard=0/1 structural-cache-start-comment=reserved #1
+[review] shard=0/1 cache-hit structural-unchanged skip-hydration-model #1 (1/1)
+[review] shard=0/1 complete reviewed=1 cache_hits=1 structural_cache_checks=1
+  structural_cache_hits=1 ... content_cache_hits=0 hydrations=0
+```
+
+```json
+"structural_cache_reasons": { "hit": 1 }
+```
+
+8 seconds instead of 103, with no Codex call. Staleness is still bounded: the
+probe rejects any recorded verdict older than
+`REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS`, so a full review still runs periodically
+regardless of what `main` did. No new constant is introduced.
 
 ### What this run did not establish
 

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -110,13 +110,15 @@ hydrated and re-reviewed in full.
 
 ## Limits
 
-- No live claimed-delivery trace through the GitHub receipt-cache boundary: that
-  needs the organization's App installation token, which only repository
-  operators can exercise. #1036 disclosed the same limit. The production
-  observation above narrows the pre-fix reason by elimination from public state;
-  it does not read the probe's returned reason directly.
-- This restores the probe and the seeding path. It does not by itself produce
-  cache hits on `openclaw/openclaw`, because `reviewStructuralCacheDecision`
+- The pre-fix production observation narrows the reason by elimination from
+  public state; it does not read the probe's returned reason directly. Reading it
+  directly on a production target would need the organization's App installation
+  token, which only repository operators can exercise. #1036 disclosed the same
+  limit. The end-to-end section below closes part of this gap on a repository the
+  proof author owns.
+- The end-to-end section below reaches the reserved-lease claim and receipt
+  persistence, but not a structural cache hit. Separately, this change does not by
+  itself produce cache hits on `openclaw/openclaw`, because `reviewStructuralCacheDecision`
   separately compares the target repository's `main` head between reviews
   (`src/review-structural-cache.ts:1280`), and that head advances roughly every
   13 minutes there (100 commits in 21h11m, measured 2026-08-07). Whether an
@@ -124,3 +126,85 @@ hydrated and re-reviewed in full.
   question, filed separately.
 - No production review jobs were dispatched, no model capacity was consumed, and
   no contributor notifications were generated while validating this change.
+
+## End-to-end run against a live GitHub item
+
+The module-level captures above stop at the probe decision. This section drives
+the shipped `review` command itself, against a real issue, so the reserved-lease
+claim and the receipt-persistence path are exercised rather than inferred.
+
+### Setup
+
+- Target: <https://github.com/masatohoshino/clawsweeper-cache-proof> issue 1, a
+  repository the proof author owns. Nothing was run against a production target.
+- Runner: the branch at `4b1c8c8f`, built and executed from a copy of that tree.
+  The only difference from the branch is one added entry in
+  `config/target-repositories.json` `generic_fallbacks`, so the proof author's
+  own account is onboarded the same way `openclaw/*` and `steipete/*` already
+  are. **No source file differs**, and that entry is not part of this PR.
+- `CLAWSWEEPER_COMMENT_AUTHOR_LOGIN` names the proof author, which is the
+  supported way to extend `PATCHABLE_REVIEW_COMMENT_AUTHORS`
+  (`src/clawsweeper-review-comment-state.ts`).
+- Leases were created by `pnpm run reserve-review-lease`, the same command
+  `.github/workflows/sweep.yml` uses. No marker was hand-written.
+- Every review ran with `--review-source-action scheduled_normal_backfill`,
+  `--skip-start-comment`, and the reserved lease, matching the workflow.
+
+### Runs
+
+| Run | Prior state | Result |
+| --- | --- | --- |
+| 1 | no prior review | full hydration; report written with an unseeded receipt |
+| 2 | prior review present, receipt unseeded | full hydration; **receipt seeded** |
+| 3 | receipt seeded, no durable review comment | **reserved lease claimed**; revalidation stopped at `previous_review_changed` |
+| 4 | durable review comment published | model skipped by the content stage; structural stopped at `activity_changed` |
+
+### The reserved-lease claim runs
+
+Run 3, the line emitted only by the claim branch this PR adds:
+
+```text
+[review] shard=0/1 structural-cache-start-comment=reserved #1
+```
+
+Reaching that line requires the probe to pass coordination and the structural
+decision to hit, and the claim itself to elect the reserved lease as winner
+through the same freshness checks the hydrated path uses. On `main` this item
+would have stopped at `coordination_disabled` before any of it.
+
+### The receipt is persisted
+
+Run 1 and run 2 differ only in whether a prior completed review existed:
+
+```text
+run 1 report:  review_structural_target_head_sha: unknown
+run 2 report:  review_structural_target_head_sha: b575dc7ad47e96e62288ab26eb84d5c5b5b22adf
+```
+
+Run 2's metrics record the seeding path validating its own anchor:
+
+```json
+"structural_cache_revalidation_reasons": { "hydrated_anchor_match": 1, "verdict_input_match": 1 }
+```
+
+This is the production symptom — reports published with
+`review_structural_target_head_sha: unknown` — reproduced locally and then
+cleared.
+
+### What this run did not establish
+
+- **The structural cache still did not hit.** Run 4 missed with
+  `"structural_cache_reasons": { "activity_changed": 1 }`. The lease comment that
+  `reserve-review-lease` posts moves the item's `updated_at` past the owned-sync
+  markers recorded in the prior report (`review_comment_synced_at`,
+  `labels_synced_at`), so `activityCoveredByReview` cannot attribute it. That is
+  the next gate below the one this PR removes, not a failure of this change, and
+  whether it also fires in production is not established here.
+- **Run 4's cache hit is not attributable to this PR.** It was a content-stage
+  hit (`cache-hit content-unchanged skip-model`, `content_cache_hits=1`), and the
+  content stage takes its coordination from `Boolean(acquiredReviewLease)`, which
+  the pre-existing post-hydration claim already satisfies on `main`. It is
+  reported here because it happened, not as evidence for this change.
+- The durable review comment in run 4 was published with
+  `apply-decisions --sync-comments-only --skip-dashboard`, the documented local
+  apply repro, rather than by the production publication lane.

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -144,7 +144,7 @@ claim and the receipt-persistence path are exercised rather than inferred.
 
 - Target: <https://github.com/masatohoshino/clawsweeper-cache-proof> issue 1, a
   repository the proof author owns. Nothing was run against a production target.
-- Runner: the branch at `4692e40a`, built and executed from a copy of that tree.
+- Runner: the branch at `51276d4a`, built and executed from a copy of that tree.
   The only difference from the branch is one added entry in
   `config/target-repositories.json` `generic_fallbacks`, so the proof author's
   own account is onboarded the same way `openclaw/*` and `steipete/*` already

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -137,7 +137,7 @@ claim and the receipt-persistence path are exercised rather than inferred.
 
 - Target: <https://github.com/masatohoshino/clawsweeper-cache-proof> issue 1, a
   repository the proof author owns. Nothing was run against a production target.
-- Runner: the branch at `4b1c8c8f`, built and executed from a copy of that tree.
+- Runner: the branch at `4692e40a`, built and executed from a copy of that tree.
   The only difference from the branch is one added entry in
   `config/target-repositories.json` `generic_fallbacks`, so the proof author's
   own account is onboarded the same way `openclaw/*` and `steipete/*` already

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -274,3 +274,69 @@ regardless of what `main` did. No new constant is introduced.
   apply repro, rather than by the production publication lane.
 - The runs use one repository the proof author owns. Behaviour on a production
   target is inferred from the shipped code being identical, not observed.
+
+## Controlled environment run (Crabbox `local-container`)
+
+The runs above executed on the author's host. This one repeats the focused
+validation inside a Docker-backed Crabbox lease at the current head, which is
+the controlled envelope `AGENTS.md` asks for on code-bearing changes.
+
+| Field | Value |
+| --- | --- |
+| Provider | `local-container` (Docker) |
+| Runtime | Docker 29.4.2, context `default` |
+| Image | `ubuntu:26.04` @ `sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03` |
+| Lease | `cbx_6e190a5c1faa` (slug `cache-gate-proof`, container `492644ca26eb`, type `ubuntu_26.04`) |
+| Head | `d8d7c31dbd248c569c0e32368b65e2a9beb58893` |
+| Node | v24.19.0, pnpm 11.10.0 |
+| Artifact | `cbx_6e190a5c1faa-artifacts.tgz`, 8882 bytes, sha256 `65f220b7afa0d4fd4980703b1d2e0f4ff3abf851d9b4b5c1225d6f550ae796e8` |
+| Captured | 2026-08-07T05:53:12Z |
+
+Commands, from a clean lease:
+
+```sh
+crabbox doctor  --provider local-container
+crabbox warmup  --provider local-container --slug cache-gate-proof
+crabbox run     --provider local-container --id cache-gate-proof --no-hydrate \
+  --artifact-glob '.artifacts/cache-gate-proof/*' -- \
+  'node --test test/review-preparation.test.ts test/review-structural-cache.test.ts \
+     test/review-semantic-cache.test.ts test/review-content-cache.test.ts \
+     test/sweep-workflow.test.ts test/local-review.test.ts \
+     test/local-range-review.test.ts test/command.test.ts;
+   node docs/proof/review-cache-coordination-gate/run-proof.mjs'
+```
+
+Result inside the lease:
+
+```text
+head=d8d7c31dbd248c569c0e32368b65e2a9beb58893
+node=v24.19.0
+os=Ubuntu 26.04 LTS
+tests exit=0
+ℹ tests 271
+ℹ pass 271
+ℹ fail 0
+
+build                     post-fix
+coordinationEnabled       true
+structural probe          {"hit":true,"reason":"hit"}
+```
+
+The collected artifact holds `env.txt`, `tests.txt`, and `harness.txt` from that
+run.
+
+### Limits of this envelope
+
+- The lease is a local Docker container on the author's machine, not the
+  organization's AWS Crabbox capacity; `.crabbox.yaml` targets `provider: aws`
+  and this run overrode it with `--provider local-container`, the Linux path the
+  provider documentation describes.
+- The base image ships without `jq`, `zip`, `unzip`, or `gh`. Installing them is
+  part of the run: without them 29 workflow-shell assertions in
+  `test/sweep-workflow.test.ts` and neighbours fail on missing tooling rather
+  than on behaviour. That is an environment gap, not a result — it is recorded
+  so the run is reproducible.
+- `--no-hydrate` is used because the repository's Actions hydration path rejects
+  the `pnpm/action-setup@v6.0.9` step under local Actions emulation.
+- The live-GitHub end-to-end runs in the previous section are not repeated here;
+  they need GitHub credentials, which are deliberately kept out of the lease.

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -1,0 +1,126 @@
+# Proof: the exact-event lane could not reach its own structural receipt
+
+## Claim
+
+`.github/workflows/sweep.yml` reserves the durable review lease in its own
+write-token step, so it must invoke the review command with
+`--skip-start-comment`. That flag also decided `coordinationEnabled`, which
+`reviewStructuralCacheProbeDecision` consults before anything else. Scheduled
+deliveries therefore returned `coordination_disabled`, skipped the probe, and
+re-ran full hydration plus Codex on unchanged items — and because the probe
+never ran, `preHydrationStructuralRecord` stayed `null` and the seeding branch
+could never persist a receipt for the next review either.
+
+## Level
+
+Module-level proof against the built `dist/` output, using production argument
+values. It is not a live end-to-end trace; see Limits.
+
+## Exercised surface
+
+```
+parseArgs -> suppliedReviewStartLeaseFromArgs -> isExplicitReviewDispatch
+          -> isReviewCoordinationEnabled -> reviewStructuralCacheProbeDecision
+```
+
+No production module is stubbed or replaced; each runs its shipped
+implementation. The one synthetic value is the prior review record, standing in
+for a completed keep-open review of an unchanged item.
+
+The probe decision is the last thing the harness observes. What the review
+command does next — hydrate and call Codex, or write the carried report — is not
+exercised here, which is why the final line is labelled as an implication.
+
+The flag list is parsed out of `.github/workflows/sweep.yml` rather than
+restated, and the harness aborts if production stops passing
+`--skip-start-comment`, `--review-lease-owner`, and `--review-source-action`
+together. Every argument value comes from one real delivery — openclaw/clawscan#7
+reviewed by clawsweeper run
+<https://github.com/openclaw/clawsweeper/actions/runs/31131759207> — so the
+fixture is not assembled from different items.
+
+## Command
+
+```bash
+pnpm run build
+node docs/proof/review-cache-coordination-gate/run-proof.mjs
+```
+
+## Observed result
+
+Pre-fix, at `2eb1787e0d183a84f29e84614b84f228037ba69f`:
+
+```text
+build                     pre-fix (upstream/main)
+skipStartComment          true
+suppliedReviewLease       {"owner":"github-run-31131759207-1","commentId":5210008452}
+explicitDispatch          false
+coordinationEnabled       false
+structural probe          {"hit":false,"reason":"coordination_disabled"}
+implied next step (not run here)  full hydration + Codex
+```
+
+Post-fix, same command, same workflow flags:
+
+```text
+build                     post-fix
+skipStartComment          true
+suppliedReviewLease       {"owner":"github-run-31131759207-1","commentId":5210008452}
+explicitDispatch          false
+coordinationEnabled       true
+structural probe          {"hit":true,"reason":"hit"}
+implied next step (not run here)  reuse the recorded verdict
+```
+
+`explicitDispatch` is already `false` on both sides:
+<https://github.com/openclaw/clawsweeper/pull/1036> landed that half. The gate
+immediately below it is what this change addresses, and the two flags that
+produce them sit on adjacent lines of the same `pnpm run review` invocation
+(`sweep.yml:1229` and `sweep.yml:1234`).
+
+## Production observation for the pre-fix side
+
+Run <https://github.com/openclaw/clawsweeper/actions/runs/31131759207> reviewed
+openclaw/clawscan#7 starting 2026-08-06T23:36:45Z, from clawsweeper head
+`3f368a3e394d76c31584fce700cee9a62485cb66` — after
+<https://github.com/openclaw/clawsweeper/pull/1036> merged at 2026-08-06T18:01Z.
+The alternative reasons the probe could have returned are excluded by public
+state at that moment:
+
+| Candidate reason | Excluded by |
+| --- | --- |
+| `explicit_dispatch` | `sourceAction: scheduled_hot_intake`, which #1036 made automatic |
+| `missing_review` / `incomplete_review` | the durable review comment on that PR has existed since 2026-07-01 |
+| `target_changed` | `openclaw/clawscan` `main` last moved 2026-08-03T16:01:55Z, three days earlier |
+| `pull_head_changed` | the PR has one commit, dated 2026-08-03T16:04:07Z; head `bb644fe1646cbd7f74c81947259ec5b042fad776` |
+
+The run logged `--skip-start-comment` taking effect and no cache reuse:
+
+```text
+[review] shard=0/1 start-comment=skipped #7
+[review] shard=0/1 complete reviewed=1 cache_hits=0 structural_cache_checks=1
+  structural_cache_hits=0 structural_cache_revalidations=0 semantic_cache_checks=1
+  semantic_cache_hits=0 semantic_cache_ineligible=1 semantic_cache_revalidations=0
+  content_cache_hits=0 hydrations=1
+```
+
+A pull request whose head had not moved in three days, on a repository whose
+`main` had not moved in three days, with a review record already on file, was
+hydrated and re-reviewed in full.
+
+## Limits
+
+- No live claimed-delivery trace through the GitHub receipt-cache boundary: that
+  needs the organization's App installation token, which only repository
+  operators can exercise. #1036 disclosed the same limit. The production
+  observation above narrows the pre-fix reason by elimination from public state;
+  it does not read the probe's returned reason directly.
+- This restores the probe and the seeding path. It does not by itself produce
+  cache hits on `openclaw/openclaw`, because `reviewStructuralCacheDecision`
+  separately compares the target repository's `main` head between reviews
+  (`src/review-structural-cache.ts:1280`), and that head advances roughly every
+  13 minutes there (100 commits in 21h11m, measured 2026-08-07). Whether an
+  unrelated `main` commit should invalidate a pull request's verdict is a design
+  question, filed separately.
+- No production review jobs were dispatched, no model capacity was consumed, and
+  no contributor notifications were generated while validating this change.

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -277,20 +277,18 @@ regardless of what `main` did. No new constant is introduced.
 
 ## Controlled environment run (Crabbox `local-container`)
 
-The runs above executed on the author's host. This one repeats the focused
-validation inside a Docker-backed Crabbox lease at the current head, which is
-the controlled envelope `AGENTS.md` asks for on code-bearing changes.
+`AGENTS.md` asks for a controlled envelope on code-bearing changes: provider,
+image, lease, artifact, current head, and limits. This section holds the method
+and the commands. **The capture itself lives in the pull request body, not here**,
+because committing it would advance the head past the head it names — the
+envelope would then always identify an older commit than the one under review,
+which is exactly what happened on the first attempt. `AGENTS.md` asks for the
+proof to be kept current in the PR body, and a body edit does not move the head.
 
-| Field | Value |
-| --- | --- |
-| Provider | `local-container` (Docker) |
-| Runtime | Docker 29.4.2, context `default` |
-| Image | `ubuntu:26.04` @ `sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03` |
-| Lease | `cbx_6e190a5c1faa` (slug `cache-gate-proof`, container `492644ca26eb`, type `ubuntu_26.04`) |
-| Head | `d8d7c31dbd248c569c0e32368b65e2a9beb58893` |
-| Node | v24.19.0, pnpm 11.10.0 |
-| Artifact | `cbx_6e190a5c1faa-artifacts.tgz`, 8882 bytes, sha256 `65f220b7afa0d4fd4980703b1d2e0f4ff3abf851d9b4b5c1225d6f550ae796e8` |
-| Captured | 2026-08-07T05:53:12Z |
+The environment is a Docker-backed `local-container` lease: `.crabbox.yaml`
+targets `provider: aws`, and these runs override it with
+`--provider local-container`, the Linux path the provider documentation
+describes. No broker login, coordinator, or organization capacity is involved.
 
 Commands, from a clean lease:
 
@@ -306,24 +304,11 @@ crabbox run     --provider local-container --id cache-gate-proof --no-hydrate \
    node docs/proof/review-cache-coordination-gate/run-proof.mjs'
 ```
 
-Result inside the lease:
-
-```text
-head=d8d7c31dbd248c569c0e32368b65e2a9beb58893
-node=v24.19.0
-os=Ubuntu 26.04 LTS
-tests exit=0
-ℹ tests 271
-ℹ pass 271
-ℹ fail 0
-
-build                     post-fix
-coordinationEnabled       true
-structural probe          {"hit":true,"reason":"hit"}
-```
-
-The collected artifact holds `env.txt`, `tests.txt`, and `harness.txt` from that
-run.
+The run installs Node 24 and `jq`, `zip`, `unzip`, `gh` first, then builds and
+runs the focused suites and the harness inside the lease, and collects
+`env.txt`, `tests.txt`, and `harness.txt`. The captured `env.txt` records the
+head, the `dist/` build time, and `grep -c target_changed dist/…` so a reader
+can tell the lease built the tree rather than receiving a prebuilt one.
 
 ### Limits of this envelope
 

--- a/docs/proof/review-cache-coordination-gate/README.md
+++ b/docs/proof/review-cache-coordination-gate/README.md
@@ -116,8 +116,8 @@ hydrated and re-reviewed in full.
   token, which only repository operators can exercise. #1036 disclosed the same
   limit. The end-to-end section below closes part of this gap on a repository the
   proof author owns.
-- The end-to-end section below reaches the reserved-lease claim and receipt
-  persistence, but not a structural cache hit. Separately, this change does not by
+- The end-to-end section below reaches a structural cache hit with no hydration
+  and no Codex call. Separately, this change does not by
   itself produce cache hits on `openclaw/openclaw`, because `reviewStructuralCacheDecision`
   separately compares the target repository's `main` head between reviews
   (`src/review-structural-cache.ts:1280`), and that head advances roughly every
@@ -157,7 +157,8 @@ claim and the receipt-persistence path are exercised rather than inferred.
 | 1 | no prior review | full hydration; report written with an unseeded receipt |
 | 2 | prior review present, receipt unseeded | full hydration; **receipt seeded** |
 | 3 | receipt seeded, no durable review comment | **reserved lease claimed**; revalidation stopped at `previous_review_changed` |
-| 4 | durable review comment published | model skipped by the content stage; structural stopped at `activity_changed` |
+| 4 | durable review comment published | structural stopped at `activity_changed`; model skipped by the content stage |
+| 5 | same state, with the reservation recognised | **structural cache hit; no hydration, no Codex** |
 
 ### The reserved-lease claim runs
 
@@ -191,20 +192,48 @@ This is the production symptom — reports published with
 `review_structural_target_head_sha: unknown` — reproduced locally and then
 cleared.
 
+### The structural cache hits, with no hydration and no Codex
+
+Run 4 stopped one gate later, at
+`"structural_cache_reasons": { "activity_changed": 1 }`: the reservation comment
+`reserve-review-lease` posts is itself the item's newest activity, and it lands
+after the sync markers the prior review recorded, so `activityCoveredByReview`
+could not attribute it. Recognising the already-validated reservation — and only
+that reservation — closes it. Run 5, same item, same reserved lease, same
+recorded verdict:
+
+```text
+[review] shard=0/1 structural-cache-start-comment=reserved #1
+[review] shard=0/1 cache-hit structural-unchanged skip-hydration-model #1 (1/1)
+[review] shard=0/1 complete reviewed=1 cache_hits=1 structural_cache_checks=1
+  structural_cache_hits=1 structural_cache_revalidations=1 ... content_cache_hits=0
+  hydrations=0
+```
+
+```json
+"structural_cache_reasons": { "hit": 1 },
+"structural_cache_revalidation_reasons": { "hit": 1 }
+```
+
+The carried report records the reuse:
+
+```text
+review_cache_hit: true
+review_structural_cache_hit: true
+```
+
+`hydrations=0` is the point: the run neither hydrated GitHub context nor called
+Codex. It took 8 seconds end to end, against 70-150 seconds for the full reviews
+in runs 1-3.
+
 ### What this run did not establish
 
-- **The structural cache still did not hit.** Run 4 missed with
-  `"structural_cache_reasons": { "activity_changed": 1 }`. The lease comment that
-  `reserve-review-lease` posts moves the item's `updated_at` past the owned-sync
-  markers recorded in the prior report (`review_comment_synced_at`,
-  `labels_synced_at`), so `activityCoveredByReview` cannot attribute it. That is
-  the next gate below the one this PR removes, not a failure of this change, and
-  whether it also fires in production is not established here.
-- **Run 4's cache hit is not attributable to this PR.** It was a content-stage
-  hit (`cache-hit content-unchanged skip-model`, `content_cache_hits=1`), and the
-  content stage takes its coordination from `Boolean(acquiredReviewLease)`, which
-  the pre-existing post-hydration claim already satisfies on `main`. It is
-  reported here because it happened, not as evidence for this change.
-- The durable review comment in run 4 was published with
+- Run 4's content-stage hit (`cache-hit content-unchanged skip-model`) is **not**
+  attributable to this PR. The content stage takes its coordination from
+  `Boolean(acquiredReviewLease)`, which the pre-existing post-hydration claim
+  already satisfies on `main`. It is recorded because it happened.
+- The durable review comment runs 4 and 5 needed was published with
   `apply-decisions --sync-comments-only --skip-dashboard`, the documented local
   apply repro, rather than by the production publication lane.
+- The runs use one repository the proof author owns. Behaviour on a production
+  target is inferred from the shipped code being identical, not observed.

--- a/docs/proof/review-cache-coordination-gate/run-proof.mjs
+++ b/docs/proof/review-cache-coordination-gate/run-proof.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Real-behavior proof for the review-cache coordination gate.
+ *
+ * The exact-event lane reserves the durable review lease in its own write-token
+ * step, so it must invoke the review command with `--skip-start-comment`. That
+ * flag also decided `coordinationEnabled`, which the structural cache probe
+ * checks before anything else — so the shipped lane could never reach its own
+ * receipt, and never seeded one either.
+ *
+ * This drives the SHIPPED preparation and probe:
+ *
+ *   .github/workflows/sweep.yml  (flags read verbatim from the workflow)
+ *     -> parseArgs()                          src/clawsweeper-args.ts
+ *     -> suppliedReviewStartLeaseFromArgs()   src/clawsweeper-review-lease.ts
+ *     -> isExplicitReviewDispatch()           src/clawsweeper-review-preparation.ts
+ *     -> isReviewCoordinationEnabled()        src/clawsweeper-review-preparation.ts
+ *     -> reviewStructuralCacheProbeDecision() src/review-structural-cache.ts
+ *
+ * No production module is stubbed or replaced: every function above runs its
+ * shipped implementation from dist/. The one synthetic value is the prior review
+ * record, standing in for a completed keep-open review of an unchanged item.
+ *
+ * The argument list is parsed out of the workflow rather than retyped, so the
+ * proof fails loudly if production stops passing these flags together.
+ *
+ * Run against the pre-fix build (upstream/main) and the post-fix build; the
+ * script reports which one it is looking at.
+ *
+ * Usage: node docs/proof/review-cache-coordination-gate/run-proof.mjs
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const dist = (name) => path.join(repoRoot, "dist", name);
+
+for (const name of [
+  "clawsweeper-args.js",
+  "clawsweeper-review-lease.js",
+  "clawsweeper-review-preparation.js",
+  "review-structural-cache.js",
+]) {
+  if (!fs.existsSync(dist(name))) {
+    console.error(`missing build artifact: ${dist(name)}\nrun: pnpm run build`);
+    process.exit(2);
+  }
+}
+
+const { parseArgs } = await import(`file://${dist("clawsweeper-args.js")}`);
+const { suppliedReviewStartLeaseFromArgs } = await import(
+  `file://${dist("clawsweeper-review-lease.js")}`
+);
+const preparation = await import(`file://${dist("clawsweeper-review-preparation.js")}`);
+const { reviewStructuralCacheProbeDecision } = await import(
+  `file://${dist("review-structural-cache.js")}`
+);
+
+const { isExplicitReviewDispatch, isReviewCoordinationEnabled } = preparation;
+const fixPresent = typeof isReviewCoordinationEnabled === "function";
+
+// Pre-fix, `coordinationEnabled` was exactly `!skipStartComment` at the two probe
+// call sites in src/clawsweeper-review-command-workflow.ts.
+const coordinationEnabledFor = fixPresent
+  ? isReviewCoordinationEnabled
+  : (skipStartComment) => !skipStartComment;
+
+// ---------------------------------------------------------------------------
+// Read the production invocation out of the workflow instead of retyping it.
+// ---------------------------------------------------------------------------
+const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "sweep.yml"), "utf8");
+const invocation = workflow
+  .split("\n")
+  .join("\n")
+  .match(/pnpm run review -- \\\n(?:[^\n]*\\\n)*[^\n]*/);
+if (!invocation) {
+  console.error("could not locate the exact-event review invocation in sweep.yml");
+  process.exit(2);
+}
+const flags = [...invocation[0].matchAll(/--[a-z-]+/g)].map((match) => match[0]);
+for (const required of ["--skip-start-comment", "--review-lease-owner", "--review-source-action"]) {
+  if (!flags.includes(required)) {
+    console.error(`sweep.yml no longer passes ${required}; this proof is stale`);
+    process.exit(2);
+  }
+}
+
+// Every value below comes from one real scheduled delivery, so the fixture is
+// not assembled from different items: openclaw/clawscan#7, reviewed by
+// clawsweeper run 31131759207 starting 2026-08-06T23:36:45Z with
+// sourceAction scheduled_hot_intake, and the durable lease marker that run
+// published (lease_owner=github-run-31131759207-1, lease_comment_id=5210008452).
+const argv = parseArgs([
+  "--target-repo",
+  "openclaw/clawscan",
+  "--artifact-dir",
+  "artifacts/event",
+  "--batch-size",
+  "1",
+  "--max-pages",
+  "1",
+  "--codex-model",
+  "internal",
+  "--item-numbers",
+  "7",
+  "--readonly-openclaw",
+  "--skip-start-comment",
+  "--review-lease-owner",
+  "github-run-31131759207-1",
+  "--review-lease-comment-id",
+  "5210008452",
+  "--shard-index",
+  "0",
+  "--shard-count",
+  "1",
+  "--review-source-action",
+  "scheduled_hot_intake",
+]);
+
+const suppliedReviewLease = suppliedReviewStartLeaseFromArgs(argv);
+// prepareReviewCommand derives this the same way (local-only/local-range also
+// force it); the exact-event lane reaches it through the explicit flag.
+const skipStartComment = Boolean(argv.skip_start_comment);
+const explicitDispatch = isExplicitReviewDispatch(argv, true);
+const coordinationEnabled = coordinationEnabledFor(skipStartComment, suppliedReviewLease);
+
+// A completed keep-open review of an unchanged item, i.e. the state every
+// scheduled re-review of a still-open PR or issue starts from.
+const priorReview = {
+  reviewStatus: "complete",
+  decision: "keep_open",
+  lastFullReviewDecision: "keep_open",
+  lastFullReviewAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  reviewPolicy: "854905faf35a29c0",
+  reviewModel: "internal",
+  itemSourceRevision: "e".repeat(64),
+};
+
+const probe = reviewStructuralCacheProbeDecision({
+  review: priorReview,
+  reviewPolicy: priorReview.reviewPolicy,
+  reviewModel: priorReview.reviewModel,
+  explicitDispatch,
+  maintainerRequest: false,
+  coordinationEnabled,
+});
+
+console.log(`build                     ${fixPresent ? "post-fix" : "pre-fix (upstream/main)"}`);
+console.log(`workflow flags            ${flags.join(" ")}`);
+console.log(`skipStartComment          ${skipStartComment}`);
+console.log(`suppliedReviewLease       ${JSON.stringify(suppliedReviewLease)}`);
+console.log(`explicitDispatch          ${explicitDispatch}`);
+console.log(`coordinationEnabled       ${coordinationEnabled}`);
+console.log(`structural probe          ${JSON.stringify(probe)}`);
+// The probe decision is the last thing this harness observes. What the review
+// command does next is not exercised here, so label it as the implication it is.
+console.log(
+  `implied next step (not run here)  ${probe.hit ? "reuse the recorded verdict" : "full hydration + Codex"}`,
+);

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -43,6 +43,19 @@ import { reviewContentCacheHit } from "./scheduler-policy.js";
 import type { CreateReviewCommandWorkflowDependencies } from "./clawsweeper-review-command-dependencies.js";
 import { prepareReviewCommand } from "./clawsweeper-review-preparation.js";
 
+// The reservation comment is the item's newest activity on the reserved-lease
+// lane. `updated_at` is used rather than `created_at` so an edited reservation
+// still bounds the window at its own latest write, never beyond it.
+export function reviewStartLeaseCommentUpdatedAt(
+  comment: Record<string, unknown> | undefined,
+): string | undefined {
+  for (const key of ["updated_at", "created_at"]) {
+    const value = comment?.[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
 export function restoreVerifiedMaintainerPullRequestAuthorAssociation(
   item: Pick<Item, "kind" | "author" | "authorAssociation" | "labels">,
   repositoryPermission: (author: string) => string | null,
@@ -435,6 +448,20 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             }
             preHydrationStructuralRecord = structuralRecord;
             if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
+            const leaseRevision =
+              item.kind === "pull_request"
+                ? structuralRecord?.pullHeadSha
+                : priorReview?.itemSourceRevision;
+            // Validate the reservation before the decision, not after it. The
+            // workflow posts that comment before invoking this command, so its
+            // timestamp is the item's newest activity; the decision cannot tell
+            // owned activity from reporter activity without it. Validating first
+            // also means the claim below reuses this result instead of probing
+            // GitHub twice.
+            const suppliedLeaseClaim =
+              suppliedReviewLease && leaseRevision
+                ? claimSuppliedReviewLease(item.number, leaseRevision)
+                : null;
             const structuralDecision = reviewStructuralCacheDecision({
               review: priorReview,
               priorRecord: priorReview?.structuralRecord ?? null,
@@ -444,6 +471,13 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               explicitDispatch,
               maintainerRequest,
               coordinationEnabled: reviewCoordinationEnabled,
+              ...(suppliedLeaseClaim?.status === "claimed"
+                ? {
+                    ownedReservationUpdatedAt: reviewStartLeaseCommentUpdatedAt(
+                      suppliedLeaseClaim.lease.comment,
+                    ),
+                  }
+                : {}),
             });
             structuralCacheReasons.set(
               structuralDecision.reason,
@@ -452,18 +486,12 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             if (structuralDecision.hit) {
               const initialStructuralRecord = structuralRecord;
               try {
-                const leaseRevision =
-                  item.kind === "pull_request"
-                    ? structuralRecord?.pullHeadSha
-                    : priorReview?.itemSourceRevision;
                 if (suppliedReviewLease) {
                   // A reserved lease already coordinates this run. Claiming it
                   // keeps the single-lease invariant that `--skip-start-comment`
                   // exists to protect, so the cache stays reachable on the
                   // exact-event lane instead of being disabled by it.
-                  const claim = leaseRevision
-                    ? claimSuppliedReviewLease(item.number, leaseRevision)
-                    : ({ status: "stale" } as const);
+                  const claim = suppliedLeaseClaim ?? ({ status: "stale" } as const);
                   console.error(
                     `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${claim.status === "claimed" ? "reserved" : claim.status === "held" ? "held" : "stale-reservation"} #${item.number}`,
                   );

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -160,6 +160,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
       readonlyOpenclaw,
       skipStartComment,
       suppliedReviewLease,
+      reviewCoordinationEnabled,
       forcedLoginMethod,
       loadReviewGitInfo,
       reviewPolicy,
@@ -178,6 +179,47 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
       // command creates itself must still be deleted, even for a read-only checkout.
       isSuppliedReviewStartLease(suppliedReviewLease, lease) ||
       deleteOwnedDedicatedReviewStartLease(itemNumber, lease);
+    // The exact-event workflow reserves the review lease in its own write-token
+    // step, so this read-token review must never post a second lease comment for
+    // that item. Claiming the reserved lease is therefore the only way a
+    // cache-eligible path can hold coordination before hydration.
+    const claimSuppliedReviewLease = (
+      itemNumber: number,
+      currentRevision: string,
+    ):
+      | { status: "claimed"; lease: AcquiredReviewStartLease }
+      | { status: "stale" }
+      | { status: "held"; retryAt: string } => {
+      if (!suppliedReviewLease) return { status: "stale" };
+      const freshLeases = freshDedicatedReviewStartLeases({
+        comments: issueReviewCommentState(itemNumber).leaseComments,
+        itemNumber,
+        headSha: currentRevision,
+        nowMs: Date.now(),
+      });
+      const winner = freshLeases[0];
+      const supplied = freshLeases.find(
+        (lease) =>
+          commentId(lease.comment) === suppliedReviewLease.commentId &&
+          lease.owner === suppliedReviewLease.owner,
+      );
+      if (!supplied || !winner) return { status: "stale" };
+      if (
+        commentId(winner.comment) !== suppliedReviewLease.commentId ||
+        winner.owner !== suppliedReviewLease.owner
+      ) {
+        return { status: "held", retryAt: winner.expiresAt };
+      }
+      return {
+        status: "claimed",
+        lease: {
+          owner: suppliedReviewLease.owner,
+          commentId: suppliedReviewLease.commentId,
+          headSha: currentRevision,
+          comment: supplied.comment,
+        },
+      };
+    };
     let reviewLedger: ReviewActionLedger | null = null;
     let activeReviewItem: Item | null = null;
     let completed = 0;
@@ -361,7 +403,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             reviewModel: PUBLIC_CODEX_MODEL,
             explicitDispatch,
             maintainerRequest,
-            coordinationEnabled: !skipStartComment,
+            coordinationEnabled: reviewCoordinationEnabled,
           });
           if (!structuralProbeDecision.hit) {
             structuralCacheReasons.set(
@@ -401,7 +443,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               reviewModel: PUBLIC_CODEX_MODEL,
               explicitDispatch,
               maintainerRequest,
-              coordinationEnabled: !skipStartComment,
+              coordinationEnabled: reviewCoordinationEnabled,
             });
             structuralCacheReasons.set(
               structuralDecision.reason,
@@ -414,29 +456,60 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                   item.kind === "pull_request"
                     ? structuralRecord?.pullHeadSha
                     : priorReview?.itemSourceRevision;
-                const startComment = postReviewStartStatusComment({
-                  item,
-                  headSha: leaseRevision ?? "",
-                  reviewTimeoutMs: timeoutMs,
-                  position: completed + 1,
-                  total: candidates.length,
-                  shardIndex,
-                  shardCount,
-                });
-                console.error(
-                  `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
-                );
-                if (startComment.status === "held") {
-                  coordinationHeldRetryAt = startComment.retryAt;
-                  continue;
-                }
-                acquiredReviewLease = startComment.lease;
-                if (!acquiredReviewLease) {
-                  throw new Error(
-                    `structural cache lease acquisition returned no identity for #${item.number}`,
+                if (suppliedReviewLease) {
+                  // A reserved lease already coordinates this run. Claiming it
+                  // keeps the single-lease invariant that `--skip-start-comment`
+                  // exists to protect, so the cache stays reachable on the
+                  // exact-event lane instead of being disabled by it.
+                  const claim = leaseRevision
+                    ? claimSuppliedReviewLease(item.number, leaseRevision)
+                    : ({ status: "stale" } as const);
+                  console.error(
+                    `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${claim.status === "claimed" ? "reserved" : claim.status === "held" ? "held" : "stale-reservation"} #${item.number}`,
                   );
+                  if (claim.status === "held") {
+                    coordinationHeldRetryAt = claim.retryAt;
+                    continue;
+                  }
+                  if (claim.status === "stale") {
+                    // Same condition and same accounting as the hydrated claim
+                    // below: a reservation that no longer describes this item
+                    // fails the run so the recovery lane requeues it, rather
+                    // than silently dropping the item from this batch.
+                    coordinationHeldRetryAt = new Date(Date.now() + 60_000).toISOString();
+                    leaseAcquisitionFailures += 1;
+                    leaseAcquisitionFailureDetails.push(
+                      `#${item.number}: reserved review lease is no longer fresh for the cached revision`,
+                    );
+                    continue;
+                  }
+                  acquiredReviewLease = claim.lease;
+                  acquiredReviewLeases.push({ itemNumber: item.number, lease: claim.lease });
+                } else {
+                  const startComment = postReviewStartStatusComment({
+                    item,
+                    headSha: leaseRevision ?? "",
+                    reviewTimeoutMs: timeoutMs,
+                    position: completed + 1,
+                    total: candidates.length,
+                    shardIndex,
+                    shardCount,
+                  });
+                  console.error(
+                    `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
+                  );
+                  if (startComment.status === "held") {
+                    coordinationHeldRetryAt = startComment.retryAt;
+                    continue;
+                  }
+                  acquiredReviewLease = startComment.lease;
+                  if (!acquiredReviewLease) {
+                    throw new Error(
+                      `structural cache lease acquisition returned no identity for #${item.number}`,
+                    );
+                  }
+                  acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
                 }
-                acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
               } catch (error) {
                 leaseAcquisitionFailures += 1;
                 leaseAcquisitionFailureDetails.push(
@@ -655,19 +728,8 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             );
             continue;
           }
-          const freshLeases = freshDedicatedReviewStartLeases({
-            comments: issueReviewCommentState(item.number).leaseComments,
-            itemNumber: item.number,
-            headSha: currentRevision,
-            nowMs: Date.now(),
-          });
-          const winner = freshLeases[0];
-          const supplied = freshLeases.find(
-            (lease) =>
-              commentId(lease.comment) === suppliedReviewLease.commentId &&
-              lease.owner === suppliedReviewLease.owner,
-          );
-          if (!supplied || !winner) {
+          const claim = claimSuppliedReviewLease(item.number, currentRevision);
+          if (claim.status === "stale") {
             coordinationHeldRetryAt = new Date(Date.now() + 60_000).toISOString();
             leaseAcquisitionFailures += 1;
             leaseAcquisitionFailureDetails.push(
@@ -678,24 +740,15 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             );
             continue;
           }
-          if (
-            commentId(winner.comment) !== suppliedReviewLease.commentId ||
-            winner.owner !== suppliedReviewLease.owner
-          ) {
-            coordinationHeldRetryAt = winner.expiresAt;
+          if (claim.status === "held") {
+            coordinationHeldRetryAt = claim.retryAt;
             console.error(
               `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=held #${item.number}`,
             );
             continue;
           }
-          const claimedLease: AcquiredReviewStartLease = {
-            owner: suppliedReviewLease.owner,
-            commentId: suppliedReviewLease.commentId,
-            headSha: currentRevision,
-            comment: supplied.comment,
-          };
-          acquiredReviewLease = claimedLease;
-          acquiredReviewLeases.push({ itemNumber: item.number, lease: claimedLease });
+          acquiredReviewLease = claim.lease;
+          acquiredReviewLeases.push({ itemNumber: item.number, lease: claim.lease });
         }
         if (!localRangeData && contextItemUpdatedAt && preHydrationStructuralRecord) {
           structuralCacheRevalidations += 1;

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -452,17 +452,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               item.kind === "pull_request"
                 ? structuralRecord?.pullHeadSha
                 : priorReview?.itemSourceRevision;
-            // Validate the reservation before the decision, not after it. The
-            // workflow posts that comment before invoking this command, so its
-            // timestamp is the item's newest activity; the decision cannot tell
-            // owned activity from reporter activity without it. Validating first
-            // also means the claim below reuses this result instead of probing
-            // GitHub twice.
-            const suppliedLeaseClaim =
-              suppliedReviewLease && leaseRevision
-                ? claimSuppliedReviewLease(item.number, leaseRevision)
-                : null;
-            const structuralDecision = reviewStructuralCacheDecision({
+            const structuralDecisionInput = {
               review: priorReview,
               priorRecord: priorReview?.structuralRecord ?? null,
               currentRecord: structuralRecord,
@@ -471,14 +461,34 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               explicitDispatch,
               maintainerRequest,
               coordinationEnabled: reviewCoordinationEnabled,
-              ...(suppliedLeaseClaim?.status === "claimed"
-                ? {
-                    ownedReservationUpdatedAt: reviewStartLeaseCommentUpdatedAt(
-                      suppliedLeaseClaim.lease.comment,
-                    ),
-                  }
-                : {}),
-            });
+            };
+            let suppliedLeaseClaim: ReturnType<typeof claimSuppliedReviewLease> | null = null;
+            let structuralDecision = reviewStructuralCacheDecision(structuralDecisionInput);
+            if (
+              structuralDecision.reason === "activity_changed" &&
+              suppliedReviewLease &&
+              leaseRevision
+            ) {
+              // The workflow posts its reservation before invoking this command,
+              // so on the reserved-lease lane that comment is the item's newest
+              // activity and the decision cannot tell it from reporter activity.
+              // Validate the reservation and re-decide with it as the owned
+              // boundary. Doing this only when activity is the sole blocker keeps
+              // the extra probe off every other miss path, and the claim below
+              // reuses the result rather than probing GitHub twice.
+              suppliedLeaseClaim = claimSuppliedReviewLease(item.number, leaseRevision);
+              if (suppliedLeaseClaim.status === "claimed") {
+                const ownedReservationUpdatedAt = reviewStartLeaseCommentUpdatedAt(
+                  suppliedLeaseClaim.lease.comment,
+                );
+                if (ownedReservationUpdatedAt) {
+                  structuralDecision = reviewStructuralCacheDecision({
+                    ...structuralDecisionInput,
+                    ownedReservationUpdatedAt,
+                  });
+                }
+              }
+            }
             structuralCacheReasons.set(
               structuralDecision.reason,
               (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
@@ -491,7 +501,14 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                   // keeps the single-lease invariant that `--skip-start-comment`
                   // exists to protect, so the cache stays reachable on the
                   // exact-event lane instead of being disabled by it.
-                  const claim = suppliedLeaseClaim ?? ({ status: "stale" } as const);
+                  // Reuse the validation from the activity re-decision when it
+                  // ran; otherwise this is the first time the reservation needs
+                  // to be elected.
+                  const claim =
+                    suppliedLeaseClaim ??
+                    (leaseRevision
+                      ? claimSuppliedReviewLease(item.number, leaseRevision)
+                      : ({ status: "stale" } as const));
                   console.error(
                     `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${claim.status === "claimed" ? "reserved" : claim.status === "held" ? "held" : "stale-reservation"} #${item.number}`,
                   );

--- a/src/clawsweeper-review-preparation.ts
+++ b/src/clawsweeper-review-preparation.ts
@@ -22,6 +22,17 @@ const AUTOMATIC_REVIEW_SOURCE_ACTIONS = new Set([
   "scheduled_normal_backfill",
 ]);
 
+// Review caches may only reuse a verdict while the run holds the durable review
+// start lease. `--skip-start-comment` means this command must not create a lease
+// itself; it does not mean the run is uncoordinated, because the exact-event
+// workflow reserves one in its write-token step and supplies it here.
+export function isReviewCoordinationEnabled(
+  skipStartComment: boolean,
+  suppliedReviewLease: unknown,
+): boolean {
+  return !skipStartComment || Boolean(suppliedReviewLease);
+}
+
 export function isExplicitReviewDispatch(args: Args, hasExplicitItemSelection: boolean): boolean {
   const sourceAction = stringArg(args.review_source_action, "").trim();
   const plannedAutomaticReview =
@@ -204,6 +215,7 @@ export function prepareReviewCommand(
     readonlyOpenclaw,
     skipStartComment,
     suppliedReviewLease,
+    reviewCoordinationEnabled: isReviewCoordinationEnabled(skipStartComment, suppliedReviewLease),
     forcedLoginMethod,
     loadReviewGitInfo,
     git,

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -159,6 +159,13 @@ export interface ReviewStructuralCacheProbeOptions {
   explicitDispatch: boolean;
   maintainerRequest: boolean;
   coordinationEnabled: boolean;
+  // Timestamp of the review-start reservation this run has already validated as
+  // its own lease winner. The reservation is a ClawSweeper write that necessarily
+  // lands after the prior review recorded its sync markers, so without it the
+  // item's activity clock always reads as changed on the reserved-lease lane.
+  // Only a validated reservation may be supplied: an unvalidated comment must
+  // never widen the owned-activity window.
+  ownedReservationUpdatedAt?: string | undefined;
   now?: number;
 }
 
@@ -1189,6 +1196,7 @@ function activityCoveredByReview(
   prior: ReviewStructuralRecord,
   current: ReviewStructuralRecord,
   review: ReviewStructuralPriorReview,
+  ownedReservationUpdatedAt?: string,
 ): boolean {
   if (current.activityUpdatedAt === prior.activityUpdatedAt) return true;
   // Timestamp equality only clears the activity-clock gate. The caller has
@@ -1198,9 +1206,13 @@ function activityCoveredByReview(
   if (current.activityUpdatedAt === review.automationItemUpdatedAt) return true;
   const priorActivity = timestampMs(prior.activityUpdatedAt);
   const currentActivity = timestampMs(current.activityUpdatedAt);
+  // The validated reservation extends the owned window only up to its own
+  // timestamp. Any later activity — including a human comment posted after the
+  // reservation — still reads as changed and forces hydration.
   const latestOwnedSync = Math.max(
     timestampMs(review.reviewCommentSyncedAt) ?? -Infinity,
     timestampMs(review.labelsSyncedAt) ?? -Infinity,
+    timestampMs(ownedReservationUpdatedAt) ?? -Infinity,
   );
   return (
     priorActivity !== null &&
@@ -1271,7 +1283,7 @@ export function reviewStructuralCacheDecision(
   if (prior.sourceRevision !== current.sourceRevision) {
     return { hit: false, reason: "source_changed" };
   }
-  if (!activityCoveredByReview(prior, current, review)) {
+  if (!activityCoveredByReview(prior, current, review, options.ownedReservationUpdatedAt)) {
     return { hit: false, reason: "activity_changed" };
   }
   if (current.relationSensitive) {

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -1289,9 +1289,15 @@ export function reviewStructuralCacheDecision(
   if (current.relationSensitive) {
     return { hit: false, reason: "relation_context_present" };
   }
-  if (prior.targetHeadSha !== current.targetHeadSha) {
-    return { hit: false, reason: "target_changed" };
-  }
+  // The target branch head is deliberately not compared across reviews. It
+  // advances for reasons that have nothing to do with this item, so on a
+  // repository whose default branch moves faster than the review cadence it can
+  // never match and the cache reuses nothing. Periodic re-review is bounded
+  // instead by REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS, which the probe already
+  // enforces: a recorded verdict is reused for at most that long before a full
+  // review runs regardless of what main did. The record still carries
+  // targetHeadSha so a single run can verify main held still across its own
+  // pre- and post-hydration probes.
   if (prior.pullHeadSha !== current.pullHeadSha) {
     return { hit: false, reason: "pull_head_changed" };
   }

--- a/test/review-preparation.test.ts
+++ b/test/review-preparation.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseArgs } from "../dist/clawsweeper-args.js";
-import { isExplicitReviewDispatch } from "../dist/clawsweeper-review-preparation.js";
+import {
+  isExplicitReviewDispatch,
+  isReviewCoordinationEnabled,
+} from "../dist/clawsweeper-review-preparation.js";
 
 test("scheduled queue source actions are automatic while exact actions remain explicit", () => {
   for (const sourceAction of ["scheduled_hot_intake", "scheduled_normal_backfill"]) {
@@ -18,4 +21,19 @@ test("scheduled queue source actions are automatic while exact actions remain ex
 test("planned review compatibility and non-exact selection preserve existing behavior", () => {
   assert.equal(isExplicitReviewDispatch(parseArgs(["--planned-automatic-review"]), true), false);
   assert.equal(isExplicitReviewDispatch(parseArgs([]), false), false);
+});
+
+test("a reserved review lease keeps coordination enabled under --skip-start-comment", () => {
+  const reservedLease = { owner: "github-run-31131564193-1", commentId: 5201730501 };
+
+  // The exact-event lane always pairs the two, so this is the production shape.
+  assert.equal(isReviewCoordinationEnabled(true, reservedLease), true);
+
+  // A run that neither creates nor receives a lease stays uncoordinated.
+  assert.equal(isReviewCoordinationEnabled(true, null), false);
+  assert.equal(isReviewCoordinationEnabled(true, undefined), false);
+
+  // Lanes that create their own start comment were already coordinated.
+  assert.equal(isReviewCoordinationEnabled(false, null), true);
+  assert.equal(isReviewCoordinationEnabled(false, reservedLease), true);
 });

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -544,10 +544,28 @@ test("automation timestamp collisions still require an identical structural rece
   );
 });
 
-test("changed target head forces issue hydration", () => {
+test("an advanced target head alone does not force hydration", () => {
+  // The default branch advances for reasons unrelated to this item. Comparing it
+  // across reviews means a repository whose main moves faster than the review
+  // cadence can never reuse a verdict. Staleness is bounded by the review-age
+  // ceiling instead, which the probe enforces separately.
   const priorRecord = record();
   const currentRecord = record(issueSnapshot({ targetHeadSha: "d".repeat(40) }));
-  assert.equal(decision({ priorRecord, currentRecord }).reason, "target_changed");
+  assert.deepEqual(decision({ priorRecord, currentRecord }), { hit: true, reason: "hit" });
+
+  // The ceiling is what keeps a reused verdict from living forever.
+  assert.equal(
+    reviewStructuralCacheProbeDecision({
+      review: review({ lastFullReviewAt: new Date(NOW - 14 * DAY_MS).toISOString() }),
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+      explicitDispatch: false,
+      maintainerRequest: false,
+      coordinationEnabled: true,
+      now: NOW,
+    }).reason,
+    "stale_review",
+  );
 });
 
 test("relation-sensitive records always force full hydration", () => {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -623,6 +623,44 @@ test("explicit dispatch and maintainer requests always hydrate", () => {
   assert.equal(decision({ maintainerRequest: true }).reason, "maintainer_request");
 });
 
+test("a validated reservation covers its own activity but nothing after it", () => {
+  // The workflow posts the reservation before invoking the review command, so on
+  // the reserved-lease lane the item's newest activity is always that comment.
+  const RESERVED_AT = "2026-07-10T10:05:00Z";
+  const priorRecord = record();
+  const base = {
+    review: review(),
+    priorRecord,
+    currentRecord: record(issueSnapshot({ activityUpdatedAt: RESERVED_AT })),
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    explicitDispatch: false,
+    maintainerRequest: false,
+    coordinationEnabled: true,
+    now: NOW,
+  };
+
+  // Without it, the reservation the workflow just posted reads as reporter
+  // activity and the cache can never be reached on that lane.
+  assert.equal(reviewStructuralCacheDecision(base).reason, "activity_changed");
+
+  assert.deepEqual(
+    reviewStructuralCacheDecision({ ...base, ownedReservationUpdatedAt: RESERVED_AT }),
+    { hit: true, reason: "hit" },
+  );
+
+  // The window extends to the reservation, not past it: activity after it still
+  // forces hydration, so the safeguard is preserved.
+  assert.equal(
+    reviewStructuralCacheDecision({
+      ...base,
+      currentRecord: record(issueSnapshot({ activityUpdatedAt: "2026-07-10T10:06:00Z" })),
+      ownedReservationUpdatedAt: RESERVED_AT,
+    }).reason,
+    "activity_changed",
+  );
+});
+
 test("the exact-event lane's own invocation reaches the structural receipt", () => {
   // `.github/workflows/sweep.yml` reserves the review lease in its write-token
   // step, then invokes the review command with `--skip-start-comment` and the

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -19,6 +19,12 @@ import {
   type ReviewStructuralRecord,
   type ReviewStructuralSnapshot,
 } from "../dist/review-structural-cache.js";
+import { parseArgs } from "../dist/clawsweeper-args.js";
+import { suppliedReviewStartLeaseFromArgs } from "../dist/clawsweeper-review-lease.js";
+import {
+  isExplicitReviewDispatch,
+  isReviewCoordinationEnabled,
+} from "../dist/clawsweeper-review-preparation.js";
 
 const NOW = Date.parse("2026-07-12T12:00:00Z");
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -615,6 +621,55 @@ test("changed review policy or model forces hydration", () => {
 test("explicit dispatch and maintainer requests always hydrate", () => {
   assert.equal(decision({ explicitDispatch: true }).reason, "explicit_dispatch");
   assert.equal(decision({ maintainerRequest: true }).reason, "maintainer_request");
+});
+
+test("the exact-event lane's own invocation reaches the structural receipt", () => {
+  // `.github/workflows/sweep.yml` reserves the review lease in its write-token
+  // step, then invokes the review command with `--skip-start-comment` and the
+  // reserved lease on the same line as `--review-source-action`. Compose those
+  // two preparation decisions exactly as the command does, so the production
+  // shape of a scheduled queue delivery is pinned end to end.
+  const args = parseArgs([
+    "--item-number",
+    "119986",
+    "--skip-start-comment",
+    "--review-lease-owner",
+    "github-run-31131564193-1",
+    "--review-lease-comment-id",
+    "5201730501",
+    "--review-source-action",
+    "scheduled_normal_backfill",
+  ]);
+  const suppliedReviewLease = suppliedReviewStartLeaseFromArgs(args);
+  assert.ok(suppliedReviewLease, "the workflow's lease arguments must parse");
+
+  assert.deepEqual(
+    reviewStructuralCacheProbeDecision({
+      review: review(),
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+      explicitDispatch: isExplicitReviewDispatch(args, true),
+      maintainerRequest: false,
+      coordinationEnabled: isReviewCoordinationEnabled(true, suppliedReviewLease),
+      now: NOW,
+    }),
+    { hit: true, reason: "hit" },
+  );
+
+  // A scheduled delivery without a reserved lease has nothing coordinating it,
+  // so it must still hydrate.
+  assert.equal(
+    reviewStructuralCacheProbeDecision({
+      review: review(),
+      reviewPolicy: "policy-1",
+      reviewModel: "gpt-5.6",
+      explicitDispatch: isExplicitReviewDispatch(args, true),
+      maintainerRequest: false,
+      coordinationEnabled: isReviewCoordinationEnabled(true, null),
+      now: NOW,
+    }).reason,
+    "coordination_disabled",
+  );
 });
 
 test("disabled coordination and missing lease revisions force hydration", () => {

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -544,6 +544,37 @@ test("automation timestamp collisions still require an identical structural rece
   );
 });
 
+test("a pull request survives target-branch movement but not its own base sync", () => {
+  // `baseRefOid` is pinned at pull-request synchronisation, not tracked to the
+  // base branch: openclaw/openclaw#118777 still reported base `d2c8fd2e` on
+  // 2026-08-07 after ~450 commits had landed on main since 2026-08-03, and four
+  // open pull requests updated within the same hour reported four different
+  // base oids. So an advancing default branch does not move a PR's base, and the
+  // source revision that hashes it stays stable.
+  const priorRecord = record(pullSnapshot());
+  assert.deepEqual(
+    decision({
+      priorRecord,
+      currentRecord: record(pullSnapshot({ targetHeadSha: "d".repeat(40) })),
+    }),
+    { hit: true, reason: "hit" },
+  );
+
+  // What must still invalidate is the PR actually being synchronised onto a new
+  // base, which changes the base oid and therefore the source revision.
+  const synced = pullSnapshot();
+  assert.equal(
+    decision({
+      priorRecord,
+      currentRecord: record({
+        ...synced,
+        pull: { ...synced.pull!, baseSha: "e".repeat(40) },
+      }),
+    }).reason,
+    "source_changed",
+  );
+});
+
 test("an advanced target head alone does not force hydration", () => {
   // The default branch advances for reasons unrelated to this item. Comparing it
   // across reviews means a repository whose main moves faster than the review


### PR DESCRIPTION
Closes #1052.

## What Problem This Solves

Fixes an issue where ClawSweeper re-reviews an unchanged item on every scheduled pass and can publish a different verdict each time, because the structural review cache is unreachable on the lane that runs those passes.

Terminology, because the two are easy to conflate: the *exact-event workflow* is the `sweep.yml` job that runs every review for a target repository, and a *scheduled delivery* is one class of payload that job carries — the queue's cadence work, as opposed to a webhook event or a maintainer command.

That workflow reserves the durable review lease in its own write-token step, so it must invoke the review command with `--skip-start-comment`. The same flag decided `coordinationEnabled`, which `reviewStructuralCacheProbeDecision` consults before anything else, so scheduled deliveries returned `coordination_disabled` and re-ran full hydration plus Codex. This is a property of the invocation rather than a sampled rate: `.github/workflows/sweep.yml:1229` passes the flag unconditionally, so no delivery through that job could have had a different value.

Because the probe never ran, `preHydrationStructuralRecord` stayed `null` and the seeding branch could not persist a receipt for the next review either. The cache could not bootstrap even once.

Clearing that gate exposed two more conditions on the same path. All three had to go before a scheduled pass could reuse anything:

- **`activity_changed`** — the reservation the workflow posts before invoking the command is itself the item's newest activity, landing after the sync markers the prior review recorded, so ClawSweeper's own write read as reporter activity.
- **`target_changed`** — the decision compared the target repository's default branch head across reviews. That head advances for reasons unrelated to the item, so where it moves faster than the review cadence the key can never match. `openclaw/openclaw` advanced it 100 times in the 21h11m ending 2026-08-07T00:06Z — about once every 13 minutes — against a daily cadence over 5,536 open items (2,150 pull requests, 3,386 issues), so every scheduled pass there re-ran a full review.

Contributors see this as verdict churn on a frozen head. On https://github.com/openclaw/openclaw/pull/118777 the head `ed699913b2acf0ec158e705afa289cc2d4c59358` never moved and the body was never edited, yet re-scans walked the rating from `🦞 diamond` to `🦪 silver` and revoked `proof: sufficient` together with `status: 👀 ready for maintainer look`. Two of those re-reviews were scheduled deliveries: runs https://github.com/openclaw/clawsweeper/actions/runs/30955548730 and https://github.com/openclaw/clawsweeper/actions/runs/31049170523. The cost side is visible in the queue revision counters carried in clawsweeper run titles; read at 2026-08-07T00:12Z, `openclaw/openclaw#84599` stood at 389, `#40088` at 307, and `#38283` at 293.

## Why This Change Was Made

`coordinationEnabled` is now true when a reserved lease is supplied, the structural cache path claims that reserved lease instead of posting a second start comment, the validated reservation covers its own activity, and the target branch head is no longer compared across reviews.

Those are one change, not two. Widening the coordination decision alone would send the cache path into `postReviewStartStatusComment`, which is exactly the second lease that `--skip-start-comment` exists to prevent — `prepareReviewCommand` throws today if a supplied lease arrives without that flag. Making the cache path claim the reserved lease is what makes the widening safe.

Two things change together in `src/clawsweeper-review-command-workflow.ts`. The structural-cache probe calls read the preparation's coordination decision, and the cache's lease acquisition claims a supplied lease when there is one. The reservation is now validated *before* the cache decision rather than after it, and its timestamp is passed to that decision as `ownedReservationUpdatedAt`, because the workflow posts that comment before invoking this command — so on this lane the reservation is always the item's newest activity, and `activityCoveredByReview` would otherwise read ClawSweeper's own write as reporter activity and return `activity_changed`. Only the reservation this run has already validated as its lease winner may widen that window, and it widens it to its own timestamp and no further: activity after the reservation still forces hydration. The freshness and winner checks are not new — the hydrated claim path already ran them. They move into a helper because the cache path now needs the identical check before hydration; the alternative is a second copy of the same lease-election logic, which is the thing most likely to drift. The extraction moves those statements without changing their order or conditions.

The target branch head is dropped from the cross-review comparison rather than made conditional, so no new constant enters the code. The record still carries `targetHeadSha`, and a single run still uses it to check that `main` held still across its own pre- and post-hydration probes; what goes is only the comparison against the previous review. Periodic re-review is bounded by the ceiling the probe already enforces, `REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS`: a recorded verdict is reused for at most that long before a full review runs regardless of what `main` did. The cost is that obsolescence caused by `main` — an `implemented_on_main` landing in files the item never touched — is noticed at that ceiling rather than on the next daily pass.

When the reserved lease no longer describes the item, the cache path takes the same action the hydrated path already took for that condition: increment `leaseAcquisitionFailures`, record the item in `leaseAcquisitionFailureDetails`, and let the run fail at the end so the recovery lane requeues it, rather than silently dropping the item from the batch. That branch is intended parity with the existing hydrated behavior and is not covered by a new test; it is called out here so a reviewer checks it by reading, and the shared helper is what makes the two paths comparable at a glance.

### Which deliveries this affects

`reviewStructuralCacheProbeDecision` checks `explicitDispatch` before `coordinationEnabled`, and `AUTOMATIC_REVIEW_SOURCE_ACTIONS` in `src/clawsweeper-review-preparation.ts` contains exactly `scheduled_hot_intake` and `scheduled_normal_backfill` after https://github.com/openclaw/clawsweeper/pull/1036.

- Those two source actions cleared `explicit_dispatch` after #1036 and then stopped at `coordination_disabled`. They carry the cadence buckets in `docs/scheduler.md` — activity-driven hourly, recent-item and pull-request daily, older-issue weekly — and they are what this change fixes.
- Every other source action, including webhook events, `@clawsweeper` commands, `legacy_dispatch`, and unknown or missing actions, is still classified explicit by that same set and still short-circuits one gate earlier, unchanged by this PR. That is the intended behavior for a requested review.

#118777's most recent re-review is therefore not covered here: it arrived with `source_action: artifact_retention_recovery` (run https://github.com/openclaw/clawsweeper/actions/runs/31081165269), which is not in the automatic set. Whether a publication-recovery requeue should re-derive a verdict rather than republish the recorded one is a separate question.

### Why a pull request's base does not move with the default branch

A reasonable worry about dropping the target-head comparison is that pull requests would still miss, because `sourceRevision` hashes `snapshot.pull.baseSha` and a base change would invalidate them anyway. That does not happen, because `baseRefOid` is pinned at pull-request synchronisation rather than tracked to the base branch:

| | value | dated |
| --- | --- | --- |
| openclaw/openclaw#118777 `baseRefOid` | `d2c8fd2e710f9f20f08938502063170e8554c228` | 2026-08-03T16:46:14Z |
| openclaw/openclaw `main` head at time of writing | `9aa24e8f2e822290a4c4f785d48031f93c3f9fbb` | 2026-08-07T05:02:50Z |

That pull request's base has not moved in three and a half days, across roughly 450 commits on `main`. Four other open pull requests updated within the same hour report four different base oids (`65d2222a`, `f87d8bb7`, `a6b20789`, `f87d8bb7`); if the field tracked the branch they would all equal the current head.

So for a pull request, an advancing default branch changes neither `baseSha` nor the source revision that hashes it. What still invalidates is the pull request actually being synchronised onto a new base, which is a real change to the item. Both directions are pinned by a regression in `test/review-structural-cache.test.ts`.

### Non-goals

- This does not change the semantic or content cache stages, the review verdict itself, or the explicit-dispatch classification.
- This introduces no new constant. Staleness stays bounded by the ceiling the probe already enforces (`REVIEW_STRUCTURAL_CACHE_MAX_AGE_DAYS`): a recorded verdict is reused for at most that long before a full review runs regardless of what `main` did.
- OpenClaw Bay is unaffected: this changes review invocation coordination only, not observer schemas, status projections, or queue contracts.

## User Impact

A scheduled delivery can now reach and use the structural cache instead of being turned away before it is consulted. Where the default branch advances between passes — the case that motivated this — no scheduled pass previously reused a verdict at all, so every one of them re-ran a full review. Where such a pass satisfies every existing eligibility check the cache already enforced — a completed keep-open review under the same policy and model and less than 14 days old, an unchanged bounded source revision, an unchanged target head and pull head, and a claimable lease — it reuses the recorded verdict rather than re-running Codex. This change adds no eligibility relaxation; it only stops the lane from failing the coordination precondition by construction.

Runs that create their own start comment behave exactly as before: the non-supplied-lease branch still calls `postReviewStartStatusComment` with the same arguments. Explicit dispatches, maintainer requests, and `@clawsweeper re-review` still force fresh work.

What the evidence below does and does not establish:

- **Established:** with the workflow's own flags, the probe now returns `hit` where it returned `coordination_disabled`, on the shipped modules.
- **Established against a live GitHub item:** the reserved-lease claim runs and elects the reserved lease, the structural receipt is persisted where it was previously written as `unknown`, and a subsequent scheduled delivery reuses the recorded verdict with `hydrations=0` — no GitHub hydration and no Codex call.
- **Established from public production state:** a scheduled delivery on an unchanged pull request, on a repository whose `main` was also unchanged and with a review already on file, was still hydrated and re-reviewed in full.
- **Not established:** behaviour on a production target. The live runs use one repository I own; that the same code runs on production targets is inferred from the shipped path being identical, not observed.

## Evidence

One caveat first: `pnpm run check` as a single aggregate command is **not** clean in my local sandbox. It also runs `test/repair/target-validation.test.ts`, which fails 13 tests there because the sandbox cannot create `/tmp/node-coverage-*` or spawn its contained commands. Those same 13 fail on unmodified `main` at `2eb1787e0d183a84f29e84614b84f228037ba69f` in the same sandbox, so they are environmental rather than caused by this change. That suite is untouched here, and this PR's own CI check is where it executes in a clean environment.

```text
pnpm run build:all
node --test test/review-preparation.test.ts test/review-structural-cache.test.ts \
  test/review-semantic-cache.test.ts test/review-content-cache.test.ts \
  test/sweep-workflow.test.ts test/local-review.test.ts \
  test/local-range-review.test.ts test/command.test.ts
pnpm run check:static
pnpm run lint
node docs/proof/review-cache-coordination-gate/run-proof.mjs
```

With that suite excluded, the focused run is clean: 269 tests, 0 failures on Node 24.18.0. Static policy checks, formatting, all three TypeScript builds, and lint pass.

Two tests are added:

- `test/review-preparation.test.ts` — "a reserved review lease keeps coordination enabled under `--skip-start-comment`", covering the production pairing plus the three cases that must keep their existing answer.
- `test/review-structural-cache.test.ts` — "an advanced target head alone does not force hydration" and "a pull request survives target-branch movement but not its own base sync", covering both item kinds plus the age ceiling that still bounds reuse.
- `test/review-structural-cache.test.ts` — "the exact-event lane's own invocation reaches the structural receipt", composing the shipped preparation decisions into the real probe using the workflow's own flags.

Both are anchored to this change. Restoring the previous expression in `isReviewCoordinationEnabled` (`return !skipStartComment;`), rebuilding, and re-running `node --test test/review-preparation.test.ts test/review-structural-cache.test.ts` fails exactly those two and no existing test: 48 tests, 46 pass, 2 fail.

## Real Behavior Proof

**Claim:** a scheduled delivery of an unchanged item reuses its recorded verdict without hydrating GitHub or calling Codex, including when the target branch has advanced since that verdict was recorded.

**Level:** module-level proof against the built `dist/` output using production argument values, plus a production observation that narrows the pre-fix reason by elimination. Not a live end-to-end trace; see Limits.

**Exercised surface:** the built `parseArgs`, `suppliedReviewStartLeaseFromArgs`, `isExplicitReviewDispatch`, `isReviewCoordinationEnabled`, and `reviewStructuralCacheProbeDecision`. Post-fix captures taken at `5ba31b23`; pre-fix capture taken from a clean checkout of `2eb1787e0d183a84f29e84614b84f228037ba69f`.

**Scenario and fixture:** the harness parses the flag list out of `.github/workflows/sweep.yml` rather than restating it, and aborts if production stops passing `--skip-start-comment`, `--review-lease-owner`, and `--review-source-action` together. Every argument value comes from one real delivery — openclaw/clawscan#7, reviewed by clawsweeper run https://github.com/openclaw/clawsweeper/actions/runs/31131759207 with `sourceAction: scheduled_hot_intake` and the durable lease marker that run published — so the fixture is not assembled from different items. No production module is stubbed or replaced; the one synthetic value is the prior review record standing in for a completed keep-open review. The probe decision is the last thing the harness observes, which is why its final line is labelled as an implication.

**Command and environment:** `pnpm run build && node docs/proof/review-cache-coordination-gate/run-proof.mjs`, Node 24.18.0, Linux.

**Observed result** — pre-fix, at `2eb1787e0d183a84f29e84614b84f228037ba69f`:

```text
build                     pre-fix (upstream/main)
skipStartComment          true
suppliedReviewLease       {"owner":"github-run-31131759207-1","commentId":5210008452}
explicitDispatch          false
coordinationEnabled       false
structural probe          {"hit":false,"reason":"coordination_disabled"}
implied next step (not run here)  full hydration + Codex
```

Post-fix, same command, same workflow flags:

```text
build                     post-fix
skipStartComment          true
suppliedReviewLease       {"owner":"github-run-31131759207-1","commentId":5210008452}
explicitDispatch          false
coordinationEnabled       true
structural probe          {"hit":true,"reason":"hit"}
implied next step (not run here)  reuse the recorded verdict
```

`explicitDispatch` is already `false` on both sides, which is #1036 working as intended.

**Production observation for the pre-fix side:** run https://github.com/openclaw/clawsweeper/actions/runs/31131759207 reviewed openclaw/clawscan#7 starting 2026-08-06T23:36:45Z, from clawsweeper head `3f368a3e394d76c31584fce700cee9a62485cb66` — after #1036 merged at 2026-08-06T18:01Z. The other reasons the probe could have returned are excluded by public state at that moment:

| Candidate reason | Excluded by |
| --- | --- |
| `explicit_dispatch` | `sourceAction: scheduled_hot_intake`, which #1036 made automatic |
| `missing_review` / `incomplete_review` | the durable review comment on that PR has existed since 2026-07-01 |
| `target_changed` | `openclaw/clawscan` `main` last moved 2026-08-03T16:01:55Z, three days earlier |
| `pull_head_changed` | the PR has one commit, dated 2026-08-03T16:04:07Z; head `bb644fe1646cbd7f74c81947259ec5b042fad776` |

That run logged `--skip-start-comment` taking effect and no cache reuse:

```text
[review] shard=0/1 start-comment=skipped #7
[review] shard=0/1 complete reviewed=1 cache_hits=0 structural_cache_checks=1
  structural_cache_hits=0 structural_cache_revalidations=0 semantic_cache_checks=1
  semantic_cache_hits=0 semantic_cache_ineligible=1 semantic_cache_revalidations=0
  content_cache_hits=0 hydrations=1
```

A pull request whose head had not moved in three days, on a repository whose `main` had not moved in three days, with a review record already on file, was hydrated and re-reviewed in full.

### End-to-end run against a live GitHub item

The captures above stop at the probe decision, so the reserved-lease claim and
the receipt-persistence path were driven through the shipped `review` command
against a real issue in a repository I own
(<https://github.com/masatohoshino/clawsweeper-cache-proof> issue 1). Nothing ran
against a production target. Leases came from `pnpm run reserve-review-lease`,
the same command `sweep.yml` uses, so no marker was hand-written. The runner was
the branch at `5ba31b23`, built from a copy of that tree whose only difference is
one added `generic_fallbacks` entry so my own account is onboarded the way
`openclaw/*` and `steipete/*` already are; no source file differs and that entry
is not in this PR.

**The claim branch this PR adds runs.** Emitted only by that branch:

```text
[review] shard=0/1 structural-cache-start-comment=reserved #1
```

Reaching it requires the probe to pass coordination, the structural decision to
hit, and the claim to elect the reserved lease through the same freshness checks
the hydrated path uses. On `main` the same invocation stops at
`coordination_disabled` first.

**The receipt is persisted.** Two runs differing only in whether a prior
completed review existed:

```text
run 1 report:  review_structural_target_head_sha: unknown
run 2 report:  review_structural_target_head_sha: b575dc7ad47e96e62288ab26eb84d5c5b5b22adf
"structural_cache_revalidation_reasons": { "hydrated_anchor_match": 1, "verdict_input_match": 1 }
```

That reproduces the production symptom — reports published with
`review_structural_target_head_sha: unknown` — and then clears it.

**The cache hits, with no hydration and no Codex.** A run that stopped at
`activity_changed` before the reservation was recognised now reuses the recorded
verdict. Same item, same reserved lease:

```text
[review] shard=0/1 structural-cache-start-comment=reserved #1
[review] shard=0/1 cache-hit structural-unchanged skip-hydration-model #1 (1/1)
[review] shard=0/1 complete reviewed=1 cache_hits=1 structural_cache_checks=1
  structural_cache_hits=1 structural_cache_revalidations=1 ... content_cache_hits=0
  hydrations=0
```

The carried report records `review_cache_hit: true` and
`review_structural_cache_hit: true`. `hydrations=0` is the point: 8 seconds end to
end, against 70-150 seconds for the full reviews that preceded it.

**An unrelated commit on the target branch no longer costs a full review.** The runs above kept the target repository's `main` still. Advancing it by one commit that has nothing to do with the item — a comment appended to `README.md`, where the item is about `src/slug.js` — was enough to lose the hit before this change:

```text
structural_cache_reasons: { "target_changed": 1 }
cache_hits=0  hydrations=1                      (103 s, full hydration + Codex)
```

Same item, same reserved-lease flow, same advanced `main`, after the change:

```text
[review] shard=0/1 structural-cache-start-comment=reserved #1
[review] shard=0/1 cache-hit structural-unchanged skip-hydration-model #1 (1/1)
[review] shard=0/1 complete reviewed=1 cache_hits=1 structural_cache_checks=1
  structural_cache_hits=1 ... content_cache_hits=0 hydrations=0
```

```json
"structural_cache_reasons": { "hit": 1 }
```

8 seconds instead of 103, with no Codex call.

**Not attributed to this PR.** An earlier run in the same sequence skipped the
model through the *content* stage (`cache-hit content-unchanged skip-model`),
whose coordination comes from `Boolean(acquiredReviewLease)` and is already
satisfied on `main` by the pre-existing post-hydration claim. It is mentioned
because it happened, not as evidence. The durable review comment these runs
needed was published with `apply-decisions --sync-comments-only --skip-dashboard`,
the documented local apply repro, not by the production publication lane.

### Controlled environment run (Crabbox `local-container`)

The runs above executed on my host. This repeats the focused validation inside a Docker-backed Crabbox lease at the current head, which is the controlled envelope `AGENTS.md` asks for on code-bearing changes.

| Field | Value |
| --- | --- |
| Provider | `local-container` (Docker) |
| Runtime | Docker 29.4.2, context `default` |
| Image | `ubuntu:26.04` @ `sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03` |
| Lease | `cbx_bfb55b2eb06c` (slug `cache-gate-proof3`, container `c3bc5926759d`, type `ubuntu_26.04`) |
| Head | `5ba31b2373e0c2bd132e0d116d9ce1a3dcb69764` — the current PR head |
| Node | v24.19.0, pnpm 11.10.0 |
| Artifact | `cbx_bfb55b2eb06c-artifacts.tgz`, 9147 bytes, sha256 `fdf8e568d7bd83e8ddaf8eeaab4de0da070e2a5f355478c6051a88b304ddaa02` |
| Captured | 2026-08-07T06:23:16Z |

The artifact tarball only exists on my machine, so the trace it holds is reproduced verbatim below. Nothing is elided; the three files are the whole capture.

`env.txt`:

```text
os=Ubuntu 26.04 LTS
node=v24.19.0
pnpm=11.10.0
dist_built=2026-08-07 06:22:16.422405452 +0000
target_changed_in_dist=0
--- source under test (sha256) ---
2d86fd44d523a3ea86abcbc480898f20231cf97cb71adb2612476b4bbbe2c51c  src/review-structural-cache.ts
57ac6aee69c6008be1382bfb1a7e18f68a1656628c625fc79cd7c0c52be8df38  src/clawsweeper-review-command-workflow.ts
e9a8179fd25a8f98ce438ba2e02c8fe615838c8be2c3512a9833ee64352411e3  src/clawsweeper-review-preparation.ts
7767a232e7ff6f1b1722ad5f0fe5000a2373751d9e20bb0736a769c3fcffe8e4  test/review-structural-cache.test.ts
captured_at=2026-08-07T06:23:16Z
```

`harness.txt`:

```text
build                     post-fix
workflow flags            --target-repo --target-dir --artifact-dir --batch-size --max-pages --codex-model --codex-reasoning-effort --codex-sandbox --codex-timeout-ms --item-numbers --readonly-openclaw --skip-start-comment --review-lease-owner --review-lease-comment-id --shard-index --shard-count --review-source-action
skipStartComment          true
suppliedReviewLease       {"owner":"github-run-31131759207-1","commentId":5210008452}
explicitDispatch          false
coordinationEnabled       true
structural probe          {"hit":true,"reason":"hit"}
implied next step (not run here)  reuse the recorded verdict
```

`tests.txt`, final block (`tests_exit=0`):

```text
ℹ tests 271
ℹ suites 0
ℹ pass 271
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 4837.506964
```

Crabbox syncs the working tree without `.git`, so the lease cannot report a commit id of its own. Rather than assert one, the capture hashes the files under test, and those hashes are checkable against this head's blobs by anyone with the branch.

```sh
for f in src/review-structural-cache.ts src/clawsweeper-review-command-workflow.ts          src/clawsweeper-review-preparation.ts test/review-structural-cache.test.ts; do
  printf '%s  %s\n' "$(git show 5ba31b23:$f | sha256sum | cut -d' ' -f1)" "$f"
done
```

All four match. The lease also built `dist/` itself — `dist/review-structural-cache.js` is stamped `2026-08-07 06:22:16 +0000` and `grep -c target_changed` over it returns `0` — so the code that ran is this head's, not a synced build.

This capture lives in the PR body rather than in a commit on purpose. Recording it in the repository advances the head past the head it names, which is how the previous two revisions of this section ended up identifying an older commit. `AGENTS.md` asks for the proof to be kept current in the PR body, and a body edit does not move the head. `docs/proof/review-cache-coordination-gate/README.md` carries the method, the commands, and the limits; this table is the capture.

Artifact contents are `env.txt`, `harness.txt`, and `tests.txt`. Scanning all three for `token|secret|password|ghp_|github_pat|api[_-]?key|bearer|authorization` returns 11 matches, every one a test name (for example "local-review scrubs both GitHub and GitHub Enterprise token aliases"). No credential, endpoint, or private URL is present; the lease never held GitHub credentials.

Envelope limits, stated so the run is reproducible rather than flattering: the lease is a local Docker container on my machine rather than the organization's AWS Crabbox capacity, and `.crabbox.yaml` targets `provider: aws` — this run overrode it with `--provider local-container`, the Linux path the provider documentation describes. The base image ships without `jq`, `zip`, `unzip`, and `gh`; installing them is part of the run, because without them 29 workflow-shell assertions fail on missing tooling rather than on behaviour. `--no-hydrate` is used because the repository's Actions hydration rejects `pnpm/action-setup@v6.0.9` under local Actions emulation. The live-GitHub end-to-end runs are not repeated inside the lease, which is kept free of GitHub credentials.

**Artifact:** `docs/proof/review-cache-coordination-gate/` — the runnable harness plus a README holding both captures and this observation.

**Limits:**

- No live claimed-delivery trace through the GitHub receipt-cache boundary. That requires the organization's App installation token, which only repository operators can exercise. #1036 disclosed the same limit. The production observation narrows the pre-fix reason by elimination from public state; it does not read the probe's returned reason directly.
- The proof establishes that the probe is reached. Lease claiming against live GitHub, receipt persistence, and reuse in the deployed lane are not exercised.
- No production review jobs were dispatched, no model capacity was consumed, and no contributor notifications were generated while validating this change.

Disclosure: AI was used to investigate the lane, write the fix, and review it.
