### PR TITLE
fix(router): fall back when public reads are throttled

### DIFF
--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -169,13 +169,32 @@ export function ghText(ghArgs: string[], options: GhRunOptions = {}): string {
 export function ghTextWithRetry(ghArgs: string[], options: GhRetryOptions | number = {}): string {
   const resolved = resolveRetryOptions(options);
   const attempts = Math.max(1, resolved.attempts ?? 6);
+  let activeOptions: GhRunOptions = resolved;
+  let publicReadFallback = publicReadFallbackOptions(ghArgs, resolved);
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      return ghText(ghArgs, resolved);
+      return ghText(ghArgs, activeOptions);
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
+      if (retryKind === "throttle" && publicReadFallback) {
+        const fallback = publicReadFallback;
+        publicReadFallback = null;
+        activeOptions = fallback;
+        try {
+          return ghText(ghArgs, fallback);
+        } catch (fallbackError) {
+          lastError = fallbackError;
+          const fallbackRetryKind = ghRetryKind(fallbackError);
+          if (fallbackRetryKind === "throttle") {
+            throw new GitHubRateLimitError(fallbackError);
+          }
+          if (attempt >= attempts || fallbackRetryKind === "none") throw fallbackError;
+          sleepMs(ghRetryWaitMs(fallbackRetryKind, attempt - 1));
+          continue;
+        }
+      }
       if (retryKind === "throttle") throw new GitHubRateLimitError(error);
       if (attempt >= attempts || retryKind === "none") throw error;
       sleepMs(ghRetryWaitMs(retryKind, attempt - 1));
@@ -190,13 +209,32 @@ export async function ghTextWithRetryAsync(
 ): Promise<string> {
   const resolved = resolveRetryOptions(options);
   const attempts = Math.max(1, resolved.attempts ?? 6);
+  let activeOptions: GhRunOptions = resolved;
+  let publicReadFallback = publicReadFallbackOptions(ghArgs, resolved);
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      return await ghTextAsync(ghArgs, resolved);
+      return await ghTextAsync(ghArgs, activeOptions);
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
+      if (retryKind === "throttle" && publicReadFallback) {
+        const fallback = publicReadFallback;
+        publicReadFallback = null;
+        activeOptions = fallback;
+        try {
+          return await ghTextAsync(ghArgs, fallback);
+        } catch (fallbackError) {
+          lastError = fallbackError;
+          const fallbackRetryKind = ghRetryKind(fallbackError);
+          if (fallbackRetryKind === "throttle") {
+            throw new GitHubRateLimitError(fallbackError);
+          }
+          if (attempt >= attempts || fallbackRetryKind === "none") throw fallbackError;
+          await sleepAsync(ghRetryWaitMs(fallbackRetryKind, attempt - 1));
+          continue;
+        }
+      }
       if (retryKind === "throttle") throw new GitHubRateLimitError(error);
       if (attempt >= attempts || retryKind === "none") throw error;
       await sleepAsync(ghRetryWaitMs(retryKind, attempt - 1));
@@ -256,6 +294,17 @@ export function ghEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 function ghCommandEnv(ghArgs: readonly string[], options: GhRunOptions): NodeJS.ProcessEnv {
   const overrides = options.env ?? {};
   const env = ghEnv(overrides);
+  const publicToken = publicReadToken(ghArgs, options, env);
+  if (!publicToken) return env;
+  return ghEnv({ ...overrides, GH_TOKEN: publicToken });
+}
+
+function publicReadToken(
+  ghArgs: readonly string[],
+  options: GhRunOptions,
+  env = ghEnv(options.env ?? {}),
+): string | null {
+  const overrides = options.env ?? {};
   const publicToken = process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN?.trim();
   if (
     !publicToken ||
@@ -265,9 +314,22 @@ function ghCommandEnv(ghArgs: readonly string[], options: GhRunOptions): NodeJS.
     (env.GH_HOST && env.GH_HOST.toLowerCase() !== "github.com") ||
     !isPublicOpenClawReadOnlyRequest(ghArgs)
   ) {
-    return env;
+    return null;
   }
-  return ghEnv({ ...overrides, GH_TOKEN: publicToken });
+  return publicToken;
+}
+
+function publicReadFallbackOptions(
+  ghArgs: readonly string[],
+  options: GhRunOptions,
+): GhRunOptions | null {
+  const overrides = options.env ?? {};
+  const publicToken = publicReadToken(ghArgs, options);
+  const appToken = process.env.GH_TOKEN?.trim();
+  if (!publicToken || !appToken || publicToken === appToken) {
+    return null;
+  }
+  return { ...options, env: { ...overrides, GH_TOKEN: appToken } };
 }
 
 export function ghErrorText(error: unknown): string {

--- a/src/repair/github-cli.ts
+++ b/src/repair/github-cli.ts
@@ -21,6 +21,13 @@ export type GhRetryOptions = GhRunOptions & {
   attempts?: number;
 };
 
+type PublicReadFallback = {
+  appToken: string;
+  options: GhRunOptions;
+};
+
+const claimedPublicReadFallbackTokens = new Set<string>();
+
 export function ghJson<T = JsonValue>(ghArgs: string[], options: GhRunOptions = {}): T {
   return JSON.parse(ghText(ghArgs, options) || "null") as T;
 }
@@ -170,7 +177,7 @@ export function ghTextWithRetry(ghArgs: string[], options: GhRetryOptions | numb
   const resolved = resolveRetryOptions(options);
   const attempts = Math.max(1, resolved.attempts ?? 6);
   let activeOptions: GhRunOptions = resolved;
-  let publicReadFallback = publicReadFallbackOptions(ghArgs, resolved);
+  const publicReadFallback = publicReadFallbackOptions(ghArgs, resolved);
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
@@ -178,9 +185,9 @@ export function ghTextWithRetry(ghArgs: string[], options: GhRetryOptions | numb
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
-      if (retryKind === "throttle" && publicReadFallback) {
-        const fallback = publicReadFallback;
-        publicReadFallback = null;
+      const fallback =
+        retryKind === "throttle" ? claimPublicReadFallback(publicReadFallback) : null;
+      if (retryKind === "throttle" && fallback) {
         activeOptions = fallback;
         try {
           return ghText(ghArgs, fallback);
@@ -210,7 +217,7 @@ export async function ghTextWithRetryAsync(
   const resolved = resolveRetryOptions(options);
   const attempts = Math.max(1, resolved.attempts ?? 6);
   let activeOptions: GhRunOptions = resolved;
-  let publicReadFallback = publicReadFallbackOptions(ghArgs, resolved);
+  const publicReadFallback = publicReadFallbackOptions(ghArgs, resolved);
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
@@ -218,9 +225,9 @@ export async function ghTextWithRetryAsync(
     } catch (error) {
       lastError = error;
       const retryKind = ghRetryKind(error);
-      if (retryKind === "throttle" && publicReadFallback) {
-        const fallback = publicReadFallback;
-        publicReadFallback = null;
+      const fallback =
+        retryKind === "throttle" ? claimPublicReadFallback(publicReadFallback) : null;
+      if (retryKind === "throttle" && fallback) {
         activeOptions = fallback;
         try {
           return await ghTextAsync(ghArgs, fallback);
@@ -322,14 +329,23 @@ function publicReadToken(
 function publicReadFallbackOptions(
   ghArgs: readonly string[],
   options: GhRunOptions,
-): GhRunOptions | null {
+): PublicReadFallback | null {
   const overrides = options.env ?? {};
   const publicToken = publicReadToken(ghArgs, options);
   const appToken = process.env.GH_TOKEN?.trim();
   if (!publicToken || !appToken || publicToken === appToken) {
     return null;
   }
-  return { ...options, env: { ...overrides, GH_TOKEN: appToken } };
+  return {
+    appToken,
+    options: { ...options, env: { ...overrides, GH_TOKEN: appToken } },
+  };
+}
+
+function claimPublicReadFallback(fallback: PublicReadFallback | null): GhRunOptions | null {
+  if (!fallback || claimedPublicReadFallbackTokens.has(fallback.appToken)) return null;
+  claimedPublicReadFallbackTokens.add(fallback.appToken);
+  return fallback.options;
 }
 
 export function ghErrorText(error: unknown): string {

--- a/test/repair/github-cli.test.ts
+++ b/test/repair/github-cli.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   ghJson,
+  ghJsonWithRetry,
   ghJsonWithRetryAsync,
   ghSpawn,
   githubLimitedPagePath,
@@ -124,6 +125,40 @@ test("public target reads preserve GitHub App mutations and every explicit crede
 
     delete process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN;
     assert.equal(observed(publicArgs).token, "app-mutation-token");
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("public read throttles fall back once to the target App token", async () => {
+  const fixtureEnv = {
+    GH_BIN: process.execPath,
+    GH_BIN_ARGS: JSON.stringify([
+      "--eval",
+      [
+        'if (process.env.GH_TOKEN === "public-read-token") {',
+        '  process.stderr.write("gh: API rate limit exceeded for installation (HTTP 403)\\n");',
+        "  process.exit(1);",
+        "}",
+        "process.stdout.write(JSON.stringify({ token: process.env.GH_TOKEN }));",
+      ].join("\n"),
+      "--",
+    ]),
+    GH_TOKEN: "app-mutation-token",
+    CLAWSWEEPER_PUBLIC_GH_TOKEN: "public-read-token",
+  };
+  const previous = Object.fromEntries(
+    Object.keys(fixtureEnv).map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, fixtureEnv);
+
+  try {
+    const args = ["api", "repos/openclaw/openclaw/issues/123"];
+    assert.equal(ghJsonWithRetry<{ token: string }>(args).token, "app-mutation-token");
+    assert.equal((await ghJsonWithRetryAsync<{ token: string }>(args)).token, "app-mutation-token");
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];

--- a/test/repair/github-cli.test.ts
+++ b/test/repair/github-cli.test.ts
@@ -139,7 +139,7 @@ test("public read throttles fall back once to the target App token", async () =>
     GH_BIN_ARGS: JSON.stringify([
       "--eval",
       [
-        'if (process.env.GH_TOKEN === "public-read-token") {',
+        'if (process.env.GH_TOKEN?.startsWith("public-read-token")) {',
         '  process.stderr.write("gh: API rate limit exceeded for installation (HTTP 403)\\n");',
         "  process.exit(1);",
         "}",
@@ -158,7 +158,24 @@ test("public read throttles fall back once to the target App token", async () =>
   try {
     const args = ["api", "repos/openclaw/openclaw/issues/123"];
     assert.equal(ghJsonWithRetry<{ token: string }>(args).token, "app-mutation-token");
-    assert.equal((await ghJsonWithRetryAsync<{ token: string }>(args)).token, "app-mutation-token");
+    assert.throws(() => ghJsonWithRetry(args), { name: "GitHubRateLimitError" });
+
+    process.env.GH_TOKEN = "app-mutation-token-async";
+    process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN = "public-read-token-async";
+    assert.equal(
+      (await ghJsonWithRetryAsync<{ token: string }>(args)).token,
+      "app-mutation-token-async",
+    );
+
+    process.env.GH_TOKEN = "app-mutation-token";
+    process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN = "public-read-token";
+    assert.equal(
+      ghJsonWithRetry<{ token: string }>(
+        ["api", "--method", "POST", "repos/openclaw/openclaw/issues/123/labels"],
+        { input: "{}" },
+      ).token,
+      "app-mutation-token",
+    );
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];


### PR DESCRIPTION
## Summary  - retry public OpenClaw read-only requests once with the target GitHub App token when the public-read installation is rate limited - preserve explicit credential, mutation, request-body, and non-GitHub-host boundaries - keep fail-closed `GitHubRateLimitError` behavior when the App credential is also throttled  ## Validation  - `tsc -p tsconfig.repair.json` - `node --test test/repair/github-cli.test.ts` - `node --test test/repair/comment-router-action-ledger.test.ts` - focused oxlint and oxfmt checks  ## Live behavior proof  - Before the fix, targeted router run [`31146506671`](https://github.com/openclaw/clawsweeper/actions/runs/31146506671) failed with `GitHubRateLimitError` while reading `openclaw/openclaw#115962` through the public-read installation. - At the PR head, targeted router run [`31147295076`](https://github.com/openclaw/clawsweeper/actions/runs/31147295076) completed successfully and durably dispatched the pending exact-head re-review command for `openclaw/openclaw#115962` (`router-cad155ddf31271d5`). - The immediate default-branch downstream worker run [`31147323386`](https://github.com/openclaw/clawsweeper/actions/runs/31147323386) failed eleven seconds later with the same installation-level HTTP 403. This confirms the public installation remained throttled during the successful PR-head router run; quota recovery did not mask the result. - CI's router credential-boundary suite confirms mutations and explicit credentials remain on their configured token paths. If the fallback App credential is also throttled, the helper still raises `GitHubRateLimitError` immediately. 
## Bounded escalation policy

The fallback budget is process-wide and keyed by the target App credential: at most one eligible throttled public read can escalate during a router run. Every later public throttle fails closed with `GitHubRateLimitError`. The regression test now covers a successful sync fallback, a repeated throttled read failing closed, a successful async fallback under a separate credential boundary, and a subsequent privileged mutation retaining the App-token path.