### PR TITLE
fix: order canonical JSON keys by code unit so digests are reproducible

### DIFF
--- a/docs/proof/stable-json-canonical-ordering/README.md
+++ b/docs/proof/stable-json-canonical-ordering/README.md
@@ -1,0 +1,122 @@
+# stableJson canonical-ordering proof contract
+
+## Claim
+
+`stableJson` produces a canonical form: the same key/value set always serializes
+to the same bytes, on any runtime, in any locale. Before this change it ordered
+keys with `String.prototype.localeCompare`, which is neither a strict total order
+nor locale independent — so the same input could hash two different ways.
+
+The fix does **not** invalidate any stored digest. Every persisted digest shape
+produced by the affected call sites serializes byte-identically before and after.
+
+## Exercised surface
+
+`dist/stable-json.js` — the module every content digest and canonical equality
+check goes through — plus the two array sorts in
+`src/clawsweeper-context-hydration.ts` that fed `pullChecksDigest` through the
+same comparator.
+
+Note that `src/review-structural-cache.ts` and `src/review-semantic-cache.ts`
+already imported `stableJsonCodeUnit as stableJson`, so the review caches were
+never exposed to this defect and are untouched by the fix.
+
+## Controlled scenario and fixture
+
+`run-proof.mjs` asserts three claims against the built `dist/`:
+
+1. **Canonical** — for keys that `localeCompare` reports as equal (zero-width
+   joiner, soft hyphen), two objects built in opposite insertion orders serialize
+   identically. The proof first asserts the tie exists, so it cannot pass
+   vacuously on a runtime where those characters are not ignorable.
+2. **Byte order** — `{a, B}` serializes with `B` first (0x42 < 0x61), and the
+   `cs-CZ`-sensitive trio `changedFiles` / `checksDigest` / `commitCount` keeps
+   byte order. Czech collates `ch` after `h`, which reorders exactly those keys.
+3. **No churn** — seven persisted digest shapes, copied from the call sites that
+   import the locale-ordered `stableJson`, serialize byte-identically to a
+   **pre-fix build compiled from the base commit**. The pre-fix module is compiled
+   inside the lease from `git show <base>:src/stable-json.ts`; if it is not
+   supplied the proof reports SKIPPED and fails rather than passing silently.
+
+## Expected observation
+
+15 checks, all PASS, exit 0. Pre-fix, claims 1 and 2 both fail:
+
+```
+insertion-order independence: VIOLATED
+   built one way : {"ab":1,"a‍b":2}
+   built other   : {"a‍b":2,"ab":1}
+byte-defined key order    : VIOLATED -> {"a":1,"B":2}
+```
+
+## Artifact and command
+
+Supported-environment run (Node 24, Crabbox `local-container`):
+
+```bash
+crabbox run \
+  --provider local-container \
+  --local-container-image node:24 \
+  --no-hydrate \
+  --timing-json \
+  --artifact-glob '.artifacts/stable-json-canonical-proof/**' \
+  --script docs/proof/stable-json-canonical-ordering/run-proof.sh
+```
+
+Host-only quick check (supply a pre-fix build for claim 3):
+
+```bash
+pnpm run build
+node docs/proof/stable-json-canonical-ordering/run-proof.mjs /path/to/pre-fix/stable-json.js
+```
+
+Focused tests:
+
+```bash
+node --test test/stable-json.test.ts
+```
+
+## Provenance
+
+- provider: Crabbox `local-container` (Docker/OrbStack)
+- crabbox: `0.15.0`
+- image: `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584`
+- container node: `v24.19.0` (satisfies `engines.node >= 24`)
+- lease: `cbx_260b82c60c03` (`brisk-lobster`)
+- run: `run_3a13e83c0068`
+- artifact: `.crabbox/runs/run_3a13e83c0068/run_3a13e83c0068-artifacts.tgz`
+  (`proof-output.txt`, `focused-tests.txt`, `install.log`, `build.log`)
+- result: exit `0`; 15/15 proof checks PASS; focused suite `6/6`
+- privacy: synthetic fixtures only. The proof makes no network call, contacts no
+  GitHub API, and performs no queue, GitHub, or production mutation.
+
+## Known churn, and why it is safe
+
+One shape does change: the **activity receipt**
+(`stableJson(completeActivityContext)`) flips `reviews` and `reviewThreads`,
+because `localeCompare` orders `s` before `T` while code units order `T` (0x54)
+before `s` (0x73).
+
+That value is never persisted. It is produced at
+`src/clawsweeper-apply-decision-workflow.ts:950` and compared at
+`src/clawsweeper-apply-proof-freshness.ts:132` — both inside a single apply run,
+in one process, from one build. Both sides shift identically, so the comparison
+still matches. It is deliberately excluded from the claim-3 fixture set, which
+covers only digests that outlive a run.
+
+## Limits
+
+Covers key ordering only. It does not change what goes *into* any digest, the
+allowed value types, or `JSON.stringify` semantics.
+
+Claim 3 is evidence over seven representative shapes taken from the call sites,
+not an exhaustive enumeration of every object ever passed to `stableJson`. A
+shape whose sibling keys differ only by case or by a `ch`-style collation
+boundary could still churn; none was found among the real call sites.
+
+**Deliberately out of scope:** `src/clawsweeper-source-revision.ts:73` sorts
+comments by `` `${id}:${updated_at}`.localeCompare(...) ``. That has the same root
+cause, but fixing it *does* change `item_source_revision` for essentially every
+item — collation orders `:` before digits while code units order it after, so ids
+of differing digit length reorder. That is a migration-bearing change and needs
+its own PR and its own re-review-wave decision.

--- a/docs/proof/stable-json-canonical-ordering/README.md
+++ b/docs/proof/stable-json-canonical-ordering/README.md
@@ -32,15 +32,21 @@ never exposed to this defect and are untouched by the fix.
 2. **Byte order** — `{a, B}` serializes with `B` first (0x42 < 0x61), and the
    `cs-CZ`-sensitive trio `changedFiles` / `checksDigest` / `commitCount` keeps
    byte order. Czech collates `ch` after `h`, which reorders exactly those keys.
-3. **No churn** — seven persisted digest shapes, copied from the call sites that
-   import the locale-ordered `stableJson`, serialize byte-identically to a
+3. **No churn** — nine persisted digest shapes, copied from every call site that
+   imports the locale-ordered `stableJson`, serialize byte-identically to a
    **pre-fix build compiled from the base commit**. The pre-fix module is compiled
    inside the lease from `git show <base>:src/stable-json.ts`; if it is not
    supplied the proof reports SKIPPED and fails rather than passing silently.
 
+Claim 2 also pins a documented caveat: array-index-like keys (`"2"`, `"10"`) are
+**not** byte-ordered. `Object.fromEntries` rebuilds the object and the engine
+re-applies its ascending-numeric order for those keys, which the comparator cannot
+override. That ordering is ECMAScript-specified and locale independent, so the form
+stays canonical — it simply is not purely byte-ordered.
+
 ## Expected observation
 
-15 checks, all PASS, exit 0. Pre-fix, claims 1 and 2 both fail:
+18 checks, all PASS, exit 0. Pre-fix, claims 1 and 2 both fail:
 
 ```
 insertion-order independence: VIOLATED
@@ -70,10 +76,10 @@ pnpm run build
 node docs/proof/stable-json-canonical-ordering/run-proof.mjs /path/to/pre-fix/stable-json.js
 ```
 
-Focused tests:
+Focused tests (the ledger test pins the shared-JSON ordering contract, so run both):
 
 ```bash
-node --test test/stable-json.test.ts
+node --test test/stable-json.test.ts test/action-ledger.test.ts
 ```
 
 ## Provenance
@@ -82,11 +88,11 @@ node --test test/stable-json.test.ts
 - crabbox: `0.15.0`
 - image: `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584`
 - container node: `v24.19.0` (satisfies `engines.node >= 24`)
-- lease: `cbx_260b82c60c03` (`brisk-lobster`)
-- run: `run_3a13e83c0068`
-- artifact: `.crabbox/runs/run_3a13e83c0068/run_3a13e83c0068-artifacts.tgz`
+- lease: `cbx_9800bb5dbeab` (`jade-barnacle`)
+- run: `run_b276f842aa3d`
+- artifact: `.crabbox/runs/run_b276f842aa3d/run_b276f842aa3d-artifacts.tgz`
   (`proof-output.txt`, `focused-tests.txt`, `install.log`, `build.log`)
-- result: exit `0`; 15/15 proof checks PASS; focused suite `6/6`
+- result: exit `0`; 18/18 proof checks PASS; focused suite `6/6`
 - privacy: synthetic fixtures only. The proof makes no network call, contacts no
   GitHub API, and performs no queue, GitHub, or production mutation.
 
@@ -109,10 +115,25 @@ covers only digests that outlive a run.
 Covers key ordering only. It does not change what goes *into* any digest, the
 allowed value types, or `JSON.stringify` semantics.
 
-Claim 3 is evidence over seven representative shapes taken from the call sites,
-not an exhaustive enumeration of every object ever passed to `stableJson`. A
-shape whose sibling keys differ only by case or by a `ch`-style collation
-boundary could still churn; none was found among the real call sites.
+Claim 3 covers nine shapes — one per call site that imports the locale-ordered
+`stableJson` — but it is **evidence, not an exhaustive proof**. The payloads are
+built from live GitHub data, so a field set that never appears in these fixtures
+cannot be ruled out by them.
+
+The residual risk is precisely characterizable: churn requires two **sibling keys
+in the same object** that the two comparators order differently. That happens when
+they differ only by case (`Accept` vs `accept` — code units put uppercase first,
+collation treats case as a tertiary difference) or straddle a locale-specific
+digraph boundary (Czech `ch`). None of the real digest payloads mixes cased
+siblings; they use consistent `camelCase` or `snake_case`.
+
+An attempt to make this exhaustive by scraping every object-literal key from the
+consuming modules and checking all 827,541 key pairs was **rejected as unsound**:
+that universe includes keys never passed to `stableJson` (HTTP headers such as
+`Accept` and `Authorization`, dashboard SQL columns), so its 15,246 "disagreements"
+are false positives that say nothing about actual digest payloads. Narrowing the
+universe correctly needs AST-level extraction of the payload literals, which is not
+justified for a P2 determinism fix.
 
 **Deliberately out of scope:** `src/clawsweeper-source-revision.ts:73` sorts
 comments by `` `${id}:${updated_at}`.localeCompare(...) ``. That has the same root

--- a/docs/proof/stable-json-canonical-ordering/run-proof.mjs
+++ b/docs/proof/stable-json-canonical-ordering/run-proof.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Real-behavior proof for the stableJson canonical-ordering fix.
+ *
+ * Three claims, all against the built dist/:
+ *
+ *   1. CANONICAL   - two objects with the same key/value set serialize identically
+ *                    regardless of property-insertion order.
+ *   2. BYTE-ORDER  - key order is defined by UTF-16 code unit, not by the runtime's
+ *                    default locale or ICU collation tables.
+ *   3. NO CHURN    - every persisted digest shape produced by the call sites that
+ *                    import the locale-ordered stableJson serializes byte-identically
+ *                    before and after the fix, so no stored digest is invalidated.
+ *
+ * Claim 3 compares against a pre-fix build of src/stable-json.ts compiled from the
+ * base commit. Pass its path as argv[2]; when absent, claim 3 is reported SKIPPED
+ * rather than silently passing.
+ *
+ * Usage: node docs/proof/stable-json-canonical-ordering/run-proof.mjs [preFixStableJson.js]
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const distStableJson = path.join(repoRoot, "dist", "stable-json.js");
+
+if (!fs.existsSync(distStableJson)) {
+  console.error(`missing build artifact: ${distStableJson}\nrun: pnpm run build`);
+  process.exit(2);
+}
+
+const { stableJson, stableJsonCodeUnit, compareCodeUnits } = await import(`file://${distStableJson}`);
+
+const ZERO_WIDTH_JOINER = "‍";
+const SOFT_HYPHEN = "­";
+const failures = [];
+const check = (label, ok, detail) => {
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}`);
+  if (!ok) {
+    if (detail) console.log(`        ${detail}`);
+    failures.push(label);
+  }
+};
+
+/* -- Claim 1: canonical form --------------------------------------------- */
+
+console.log("== Claim 1: insertion order cannot change the output ==\n");
+for (const [name, invisible] of [
+  ["zero-width joiner", ZERO_WIDTH_JOINER],
+  ["soft hyphen", SOFT_HYPHEN],
+]) {
+  const key = `a${invisible}b`;
+  const tie = key.localeCompare("ab") === 0;
+  check(
+    `${name}: keys collate equal under localeCompare (precondition)`,
+    tie && key !== "ab",
+    `localeCompare returned ${key.localeCompare("ab")}`,
+  );
+  const left = stableJson({ ab: 1, [key]: 2 });
+  const right = stableJson({ [key]: 2, ab: 1 });
+  check(`${name}: same key set serializes identically`, left === right, `${left} vs ${right}`);
+}
+
+/* -- Claim 2: byte-defined ordering --------------------------------------- */
+
+console.log("\n== Claim 2: key order is byte-defined, not locale-defined ==\n");
+check(
+  'uppercase sorts before lowercase ("B" 0x42 < "a" 0x61)',
+  stableJson({ a: 1, B: 2 }) === '{"B":2,"a":1}',
+  stableJson({ a: 1, B: 2 }),
+);
+// cs-CZ collates "ch" after "h", which reorders these real digest keys.
+const czechSensitive = { checksDigest: "a", commitCount: 1, changedFiles: 2 };
+check(
+  "cs-CZ-sensitive keys keep byte order",
+  stableJson(czechSensitive) === '{"changedFiles":2,"checksDigest":"a","commitCount":1}',
+  stableJson(czechSensitive),
+);
+check(
+  "compareCodeUnits never ties distinct strings",
+  compareCodeUnits("a", `a${ZERO_WIDTH_JOINER}`) !== 0 && compareCodeUnits("a", "a") === 0,
+);
+check("stableJsonCodeUnit is an alias", stableJsonCodeUnit(czechSensitive) === stableJson(czechSensitive));
+
+/* -- Claim 3: no persisted-digest churn ----------------------------------- */
+
+console.log("\n== Claim 3: persisted digest shapes are byte-identical to pre-fix ==\n");
+
+const PERSISTED_SHAPES = {
+  "itemContentDigest": {
+    kind: "pull_request", source: "rev",
+    timeline: [{ id: 1, event: "labeled", actor: "a", commitId: null, label: "x", rename: null, sourceIssue: null }],
+    relations: { closingPullRequests: null, referencingMergedPullRequests: null, relatedItems: null },
+    latestRelease: { tagName: "v1", sha: "a".repeat(40) }, releaseStateComplete: true, targetMainSha: null,
+    headSha: "b".repeat(40), baseSha: "c".repeat(40),
+    pullState: { draft: false, mergeable: true, mergeableState: "clean", additions: 1, deletions: 2, changedFiles: 3 },
+    diff: [{ filename: "a.ts", additions: 1, deletions: 0 }], commits: "rev2",
+    reviewComments: [{ id: 1, author: "x", authorAssociation: "NONE", body: "b" }],
+    checks: { complete: true, checkRuns: [{ name: "ci", status: "completed", conclusion: "success" }], checkRunsTruncated: false, statuses: [], statusesTruncated: false },
+  },
+  "itemSnapshotHash": {
+    item: { repo: "o/r", number: 1, kind: "issue", title: "t", url: "u", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", author: "a", labels: ["bug"] },
+    context: { pullRequest: { head: { sha: "a" }, base: { sha: "b" }, draft: false, mergeable: true, mergeableState: "clean", additions: 1, deletions: 1, changedFiles: 1 }, counts: { pullCommits: 1 } },
+  },
+  "reviewCommentContentRevision": [{ id: 1, author: "x", authorAssociation: "NONE", body: "b" }, { omitted: 3 }],
+  "pullCommitContentRevision": [{ author: "a", message: "m" }, { author: "b", message: "n" }],
+  "reviewTimelineDigestParts": [{ id: 1, event: "labeled", actor: "a", commitId: null, label: "x", rename: null, sourceIssue: null }],
+  "pullChecksDigestParts": {
+    complete: true,
+    checkRuns: [{ name: "ci", status: "completed", conclusion: "success", detailsUrl: null, startedAt: "t", completedAt: "u" }],
+    checkRunsTruncated: false, statuses: [{ context: "c", state: "success", description: "d" }], statusesTruncated: false,
+  },
+  "action-ledger invocation id": { command: "plan", args: { batch_size: 10, items_dir: "x" } },
+};
+
+const preFixPath = process.argv[2];
+if (!preFixPath) {
+  console.log("  SKIPPED  no pre-fix build supplied (argv[2]); churn not measured");
+  failures.push("claim 3 not measured");
+} else if (!fs.existsSync(preFixPath)) {
+  console.log(`  FAIL     pre-fix build not found: ${preFixPath}`);
+  failures.push("claim 3 pre-fix build missing");
+} else {
+  const pre = await import(`file://${path.resolve(preFixPath)}`);
+  for (const [name, value] of Object.entries(PERSISTED_SHAPES)) {
+    const before = pre.stableJson(value);
+    const after = stableJson(value);
+    check(`${name} byte-identical`, before === after, `pre : ${before}\n        post: ${after}`);
+  }
+}
+
+console.log(`\nRESULT: ${failures.length === 0 ? "PASS" : "FAIL"}`);
+if (failures.length) console.log(`  failed: ${failures.join(", ")}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/docs/proof/stable-json-canonical-ordering/run-proof.mjs
+++ b/docs/proof/stable-json-canonical-ordering/run-proof.mjs
@@ -65,6 +65,15 @@ for (const [name, invisible] of [
 /* -- Claim 2: byte-defined ordering --------------------------------------- */
 
 console.log("\n== Claim 2: key order is byte-defined, not locale-defined ==\n");
+// Array-index-like keys are NOT byte-ordered: Object.fromEntries rebuilds the
+// object and the engine re-applies ascending-numeric order for them. That is
+// specified and locale independent, so the form stays canonical. Pinned here so
+// the caveat is visible rather than a surprise.
+check(
+  "array-index keys keep engine ascending-numeric order (documented caveat)",
+  stableJson({ "10": "ten", "2": "two", z: 1 }) === '{"2":"two","10":"ten","z":1}',
+  stableJson({ "10": "ten", "2": "two", z: 1 }),
+);
 check(
   'uppercase sorts before lowercase ("B" 0x42 < "a" 0x61)',
   stableJson({ a: 1, B: 2 }) === '{"B":2,"a":1}',
@@ -112,6 +121,13 @@ const PERSISTED_SHAPES = {
     checkRunsTruncated: false, statuses: [{ context: "c", state: "success", description: "d" }], statusesTruncated: false,
   },
   "action-ledger invocation id": { command: "plan", args: { batch_size: 10, items_dir: "x" } },
+  "reviewPolicyHash (runtime.ts:397)": {
+    version: 12, freshDays: 30, model: "model-excluded-2026-07",
+    reasoningEffort: "high", sandboxMode: "read-only", serviceTier: "default",
+  },
+  "assist artifact (assist.ts:596)": {
+    repo: "o/r", number: 1, kind: "issue", requestedAt: "2026-01-01T00:00:00Z", targetRepo: "o/r",
+  },
 };
 
 const preFixPath = process.argv[2];

--- a/docs/proof/stable-json-canonical-ordering/run-proof.sh
+++ b/docs/proof/stable-json-canonical-ordering/run-proof.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Crabbox local-container proof for the stableJson canonical-ordering fix.
+#
+# Runs inside a Node 24 Linux container on the synced current checkout. It builds
+# the repository, compiles the PRE-FIX src/stable-json.ts from the merge base so
+# the churn claim is measured against real prior behavior rather than asserted,
+# then runs run-proof.mjs and the focused suite.
+set -euo pipefail
+
+ARTIFACT_DIR=".artifacts/stable-json-canonical-proof"
+mkdir -p "$ARTIFACT_DIR"
+BASE_REF="${STABLE_JSON_PROOF_BASE:-0588bda9}"
+
+echo "== environment =="
+uname -a
+node --version
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 24 ]; then
+  echo "FAIL: repository requires Node >= 24, got $(node --version)"
+  exit 1
+fi
+echo "head: $(git rev-parse HEAD 2>/dev/null || echo 'unavailable')"
+echo "base: $BASE_REF"
+echo
+
+echo "== build =="
+# The lease runs as the unprivileged `crabbox` user, so corepack cannot symlink
+# into /usr/local/bin. Install the pinned pnpm into a user-writable prefix.
+export PNPM_HOME="$HOME/.local/bin"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME" >/dev/null 2>&1 || true
+fi
+if ! command -v pnpm >/dev/null 2>&1; then
+  npm install -g --prefix "$HOME/.local" pnpm@11.10.0 >"$ARTIFACT_DIR/pnpm-install.log" 2>&1 || true
+fi
+command -v pnpm >/dev/null 2>&1 || {
+  echo "FAIL: pnpm unavailable in container"
+  tail -20 "$ARTIFACT_DIR/pnpm-install.log" 2>/dev/null || true
+  exit 1
+}
+echo "pnpm: $(pnpm --version)"
+pnpm install --frozen-lockfile >"$ARTIFACT_DIR/install.log" 2>&1 \
+  || { echo "FAIL: pnpm install"; tail -30 "$ARTIFACT_DIR/install.log"; exit 1; }
+pnpm run build >"$ARTIFACT_DIR/build.log" 2>&1 \
+  || { echo "FAIL: pnpm run build"; tail -30 "$ARTIFACT_DIR/build.log"; exit 1; }
+test -f dist/stable-json.js || { echo "FAIL: build did not produce dist/stable-json.js"; exit 1; }
+echo "post-fix comparator: $(grep -c localeCompare dist/stable-json.js) localeCompare references (expect 0)"
+echo
+
+echo "== compile pre-fix stable-json from $BASE_REF =="
+PREFIX_DIR="$(mktemp -d)"
+git show "$BASE_REF:src/stable-json.ts" > "$PREFIX_DIR/stable-json.ts"
+./node_modules/.bin/tsc "$PREFIX_DIR/stable-json.ts" --ignoreConfig \
+  --target es2022 --module esnext --moduleResolution bundler --outDir "$PREFIX_DIR/out"
+echo "pre-fix comparator: $(grep -c localeCompare "$PREFIX_DIR/out/stable-json.js") localeCompare references (expect 1)"
+echo
+
+echo "== proof =="
+node docs/proof/stable-json-canonical-ordering/run-proof.mjs "$PREFIX_DIR/out/stable-json.js" \
+  | tee "$ARTIFACT_DIR/proof-output.txt"
+
+echo
+echo "== focused regression suite =="
+node --test test/stable-json.test.ts 2>&1 | tail -8 | tee "$ARTIFACT_DIR/focused-tests.txt"
+
+rm -rf "$PREFIX_DIR"
+echo
+echo "artifacts written to $ARTIFACT_DIR"

--- a/docs/proof/stable-json-canonical-ordering/run-proof.sh
+++ b/docs/proof/stable-json-canonical-ordering/run-proof.sh
@@ -46,7 +46,8 @@ pnpm install --frozen-lockfile >"$ARTIFACT_DIR/install.log" 2>&1 \
 pnpm run build >"$ARTIFACT_DIR/build.log" 2>&1 \
   || { echo "FAIL: pnpm run build"; tail -30 "$ARTIFACT_DIR/build.log"; exit 1; }
 test -f dist/stable-json.js || { echo "FAIL: build did not produce dist/stable-json.js"; exit 1; }
-echo "post-fix comparator: $(grep -c localeCompare dist/stable-json.js) localeCompare references (expect 0)"
+# Count real calls, not the word where the module doc explains why it is not used.
+echo "post-fix comparator: $(grep -c '\.localeCompare(' dist/stable-json.js || true) localeCompare CALLS (expect 0)"
 echo
 
 echo "== compile pre-fix stable-json from $BASE_REF =="
@@ -54,7 +55,7 @@ PREFIX_DIR="$(mktemp -d)"
 git show "$BASE_REF:src/stable-json.ts" > "$PREFIX_DIR/stable-json.ts"
 ./node_modules/.bin/tsc "$PREFIX_DIR/stable-json.ts" --ignoreConfig \
   --target es2022 --module esnext --moduleResolution bundler --outDir "$PREFIX_DIR/out"
-echo "pre-fix comparator: $(grep -c localeCompare "$PREFIX_DIR/out/stable-json.js") localeCompare references (expect 1)"
+echo "pre-fix comparator: $(grep -c '\.localeCompare(' "$PREFIX_DIR/out/stable-json.js" || true) localeCompare CALLS (expect 1)"
 echo
 
 echo "== proof =="

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -36,7 +36,7 @@ import type {
 import { isGitHubNotFoundError } from "./github-retry.js";
 import { type RepositoryProfile } from "./repository-profiles.js";
 import { reviewSemanticPriorReviewDigest } from "./review-semantic-cache.js";
-import { stableJson } from "./stable-json.js";
+import { compareCodeUnits, stableJson } from "./stable-json.js";
 
 interface CreateContextHydrationDependencies {
   asRecord: (value: unknown) => Record<string, unknown>;
@@ -433,14 +433,17 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
       }
       const checkRunsTruncated = checkRunsTotal > rawCheckRuns.length || rawCheckRuns.length > 100;
       const statusesTruncated = statusesTotal > rawStatuses.length || rawStatuses.length > 100;
+      // Order by code unit, not locale collation: these feed pullChecksDigest, and
+      // localeCompare returns 0 for distinct strings, which would leave GitHub's
+      // arbitrary response order in the digest.
       const checkRuns = rawCheckRuns
         .slice(0, 100)
         .map(compactCheckRun)
-        .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+        .sort((left, right) => compareCodeUnits(stableJson(left), stableJson(right)));
       const statuses = rawStatuses
         .slice(0, 100)
         .map(compactCommitStatus)
-        .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+        .sort((left, right) => compareCodeUnits(stableJson(left), stableJson(right)));
       return {
         complete: !checkRunsTruncated && !statusesTruncated,
         checkRuns,

--- a/src/stable-json.ts
+++ b/src/stable-json.ts
@@ -17,6 +17,14 @@
  *
  * `stableJsonCodeUnit` / `sortStableCodeUnit` are retained as explicit aliases;
  * they are equivalent to the unsuffixed pair.
+ *
+ * One caveat: array-index-like keys ("0", "2", "10") are not emitted in code-unit
+ * order. `Object.fromEntries` rebuilds the object and the engine re-applies its
+ * own ascending-numeric ordering for those keys, which this comparator cannot
+ * override. That ordering is specified by ECMAScript and is locale independent,
+ * so the output stays canonical - it simply is not purely byte-ordered. Callers
+ * needing byte order for numeric keys should serialize them directly, as
+ * `actionLedgerJson` does.
  */
 
 export function stableJson(value: unknown): string {

--- a/src/stable-json.ts
+++ b/src/stable-json.ts
@@ -1,17 +1,43 @@
+/**
+ * Canonical JSON for content digests and equality checks.
+ *
+ * Keys are ordered by UTF-16 code unit, never by locale collation.
+ * `String.prototype.localeCompare` is unusable here for two reasons:
+ *
+ *   1. It is not a strict total order. Collation-ignorable characters (zero-width
+ *      joiner, soft hyphen, most control characters) make distinct keys compare
+ *      equal, and `Array.prototype.sort` is stable, so a tie leaves the keys in
+ *      property-insertion order. Two objects with the same key/value set then
+ *      serialize differently and hash differently.
+ *   2. It is locale and ICU dependent. With no locale argument it follows the
+ *      runtime default, and collation tables differ between locales and ICU
+ *      releases - `cs-CZ`, for example, orders `ch` after `h`, which reorders
+ *      keys such as `changedFiles` and `checksDigest`. A digest computed on one
+ *      runner would then not match the same input on another.
+ *
+ * `stableJsonCodeUnit` / `sortStableCodeUnit` are retained as explicit aliases;
+ * they are equivalent to the unsuffixed pair.
+ */
+
 export function stableJson(value: unknown): string {
   return JSON.stringify(sortStable(value));
 }
 
 export function sortStable(value: unknown): unknown {
-  return sortStableWith(value, (left, right) => left.localeCompare(right));
+  return sortStableWith(value, compareCodeUnits);
 }
 
 export function stableJsonCodeUnit(value: unknown): string {
-  return JSON.stringify(sortStableCodeUnit(value));
+  return stableJson(value);
 }
 
 export function sortStableCodeUnit(value: unknown): unknown {
-  return sortStableWith(value, compareCodeUnits);
+  return sortStable(value);
+}
+
+/** Total order over UTF-16 code units; never returns 0 for distinct strings. */
+export function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function sortStableWith(
@@ -25,8 +51,4 @@ function sortStableWith(
       .sort(([left], [right]) => compareKeys(left, right))
       .map(([key, item]) => [key, sortStableWith(item, compareKeys)]),
   );
-}
-
-function compareCodeUnits(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/test/action-ledger.test.ts
+++ b/test/action-ledger.test.ts
@@ -439,14 +439,11 @@ test("canonical identity hashing rejects excessive depth, nodes, and input size 
   );
 });
 
-test("ledger ordering is binary and locale independent without changing shared stable JSON", () => {
-  const sharedValue = { "\u00e4": 1, z: 2 };
-  const sharedExpected = JSON.stringify(
-    Object.fromEntries(
-      Object.entries(sharedValue).sort(([left], [right]) => left.localeCompare(right)),
-    ),
-  );
-  assert.equal(stableJson(sharedValue), sharedExpected);
+test("ledger and shared JSON ordering are both binary and locale independent", () => {
+  // The shared serializer used to order keys by locale collation, and this test
+  // pinned that difference. It now uses the same code-unit comparator as the
+  // ledger, so "z" (0x7A) precedes "\u00e4" (0xE4) in both.
+  assert.equal(stableJson({ "\u00e4": 1, z: 2 }), '{"z":2,"\u00e4":1}');
   assert.equal(
     actionLedgerJson({ "2": "two", "10": "ten", "\u00e4": 1, z: 2 }),
     '{"10":"ten","2":"two","z":2,"\u00e4":1}',
@@ -463,9 +460,15 @@ test("ledger ordering is binary and locale independent without changing shared s
     event.evidence?.map((entry) => entry.report_path),
     ["records/Z.md", "records/a.md"],
   );
-  const moduleUrl = pathToFileURL(path.join(process.cwd(), "dist", "action-ledger.js")).href;
-  const script = `import { actionLedgerJson } from ${JSON.stringify(moduleUrl)};
-process.stdout.write(actionLedgerJson({ "2": "two", "10": "ten", "\\u00e4": 1, z: 2 }));`;
+  const ledgerUrl = pathToFileURL(path.join(process.cwd(), "dist", "action-ledger.js")).href;
+  const stableJsonUrl = pathToFileURL(path.join(process.cwd(), "dist", "stable-json.js")).href;
+  // Both serializers must be locale independent. sv-SE sorts "\u00e4" after "z" while
+  // en-US sorts it immediately after "a", so a locale-sensitive comparator would
+  // disagree between these two child processes.
+  const script = `import { actionLedgerJson } from ${JSON.stringify(ledgerUrl)};
+import { stableJson } from ${JSON.stringify(stableJsonUrl)};
+const value = { "2": "two", "10": "ten", "\\u00e4": 1, z: 2 };
+process.stdout.write(JSON.stringify([actionLedgerJson(value), stableJson(value)]));`;
   const outputs = ["en_US.UTF-8", "sv_SE.UTF-8"].map((locale) => {
     const child = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
       encoding: "utf8",
@@ -474,10 +477,16 @@ process.stdout.write(actionLedgerJson({ "2": "two", "10": "ten", "\\u00e4": 1, z
     assert.equal(child.status, 0, child.stderr);
     return child.stdout;
   });
-  assert.deepEqual(outputs, [
+  // The two serializers differ on integer-like keys and that is expected:
+  // actionLedgerJson builds its JSON text directly, so it can emit "10" before
+  // "2", while stableJson rebuilds the object through Object.fromEntries and the
+  // engine re-applies its own ascending-numeric order for array-index keys. That
+  // ordering is specified and locale independent, so both children still agree.
+  const expected = JSON.stringify([
     '{"10":"ten","2":"two","z":2,"\u00e4":1}',
-    '{"10":"ten","2":"two","z":2,"\u00e4":1}',
+    '{"2":"two","10":"ten","z":2,"\u00e4":1}',
   ]);
+  assert.deepEqual(outputs, [expected, expected]);
 });
 
 test("every event persists the required correlation envelope", () => {

--- a/test/stable-json.test.ts
+++ b/test/stable-json.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { stableJsonCodeUnit } from "../dist/stable-json.js";
+import { compareCodeUnits, stableJson, stableJsonCodeUnit } from "../dist/stable-json.js";
 
 test("code-unit stable JSON canonicalizes nested object keys without locale state", () => {
   assert.equal(
@@ -13,4 +13,56 @@ test("code-unit stable JSON canonicalizes nested object keys without locale stat
     }),
     '{"I":{"changedFiles":1,"checksDigest":"a"},"i":{"changedFiles":2,"checksDigest":"b"},"\u0130":[{"changedFiles":3,"checksDigest":"c"}],"\u0131":[{"changedFiles":4,"checksDigest":"d"}]}',
   );
+});
+
+test("stableJson is a canonical form: insertion order cannot change the output", () => {
+  // Collation-ignorable characters make localeCompare return 0 for distinct keys.
+  // Array.prototype.sort is stable, so a tie would leave property-insertion order
+  // in the output and two equal objects would hash differently.
+  const zeroWidthJoiner = "‍";
+  const softHyphen = "­";
+  for (const invisible of [zeroWidthJoiner, softHyphen]) {
+    const key = `a${invisible}b`;
+    assert.notEqual(key, "ab");
+    assert.equal(key.localeCompare("ab"), 0, "precondition: these keys collate equal");
+
+    assert.equal(stableJson({ ab: 1, [key]: 2 }), stableJson({ [key]: 2, ab: 1 }));
+  }
+});
+
+test("stableJson key order is byte-defined, not locale-defined", () => {
+  // Code-unit order puts "B" (0x42) before "a" (0x61); collation does not.
+  assert.equal(stableJson({ a: 1, B: 2 }), '{"B":2,"a":1}');
+
+  // cs-CZ collates "ch" after "h", which reorders these two real digest keys.
+  // The canonical form must not depend on the runtime's default locale.
+  assert.equal(
+    stableJson({ checksDigest: "a", commitCount: 1, changedFiles: 2 }),
+    '{"changedFiles":2,"checksDigest":"a","commitCount":1}',
+  );
+});
+
+test("stableJson orders nested arrays and objects consistently", () => {
+  assert.equal(
+    stableJson({ b: [{ z: 1, a: 2 }], a: { y: 3, x: 4 } }),
+    '{"a":{"x":4,"y":3},"b":[{"a":2,"z":1}]}',
+  );
+});
+
+test("stableJsonCodeUnit remains an alias for stableJson", () => {
+  const value = { I: 1, i: 2, checksDigest: "a", changedFiles: 2, [`a‍b`]: 3, ab: 4 };
+  assert.equal(stableJsonCodeUnit(value), stableJson(value));
+});
+
+test("compareCodeUnits is a strict total order over distinct strings", () => {
+  const samples = ["a", "B", "ab", `a‍b`, "checksDigest", "changedFiles", "", "İ"];
+  for (const left of samples) {
+    for (const right of samples) {
+      const result = compareCodeUnits(left, right);
+      if (left === right) assert.equal(result, 0);
+      else assert.notEqual(result, 0, `distinct keys must never tie: ${left} / ${right}`);
+      // Sum rather than negate: -0 !== 0 under the strict assert's Object.is.
+      assert.equal(result + compareCodeUnits(right, left), 0, "must be antisymmetric");
+    }
+  }
 });


### PR DESCRIPTION
Closes #1055

## What Problem This Solves

Fixes an issue where ClawSweeper's canonical-JSON helper was not canonical: the
same input could serialize — and therefore hash — two different ways, producing
digest instability across runs and across runners.

`stableJson` backs the content digests and canonical equality checks used for
change detection and caching. It ordered object keys with
`String.prototype.localeCompare`, which fails as a canonical comparator twice over:

1. **Not a strict total order.** `localeCompare` returns `0` for distinct strings
   whose difference is collation-ignorable (zero-width joiner, soft hyphen, most
   control characters). `Array.prototype.sort` is stable, so a tie leaves keys in
   property-insertion order and two equal objects serialize differently.
2. **Locale and ICU dependent.** With no locale argument it follows the runtime
   default. This is not hypothetical: `cs-CZ` orders `ch` after `h`, reordering
   `changedFiles` and `checksDigest` — two keys that appear together in real
   digest payloads.

The practical consequence is digest instability, not an incorrect decision: a
flapping digest causes spurious "source revision changed" verdicts, avoidable
cache misses, and extra Codex spend. No wrong close or merge follows from it.

## Why This Change Was Made

`sortStable` now uses the `compareCodeUnits` comparator **that was already in the
module**. `stableJsonCodeUnit` / `sortStableCodeUnit` are kept as aliases, so no
call site changes.

The two `stableJson(...).localeCompare(stableJson(...))` array sorts in
`clawsweeper-context-hydration.ts` move to the same comparator; they feed
`pullChecksDigest` and had the identical tie problem.

Worth stating plainly: `review-structural-cache.ts` and `review-semantic-cache.ts`
already imported `stableJsonCodeUnit as stableJson`. The review caches were never
exposed to this defect and are untouched. The correct comparator has been sitting
in the module the whole time — the unsuffixed export just never used it.

Non-goals: this does not change what goes *into* any digest, the allowed value
types, or `JSON.stringify` semantics.

**Deliberately excluded.** `src/clawsweeper-source-revision.ts:73` sorts comments
by `` `${id}:${updated_at}`.localeCompare(...) ``. Same root cause, but fixing it
*does* change `item_source_revision` for essentially every item — collation orders
`:` before digits while code units order it after, so ids of differing digit length
reorder. That is migration-bearing and needs its own PR and its own decision about
the resulting re-review wave. Measured, not assumed:

```
locale  : [105, 12, 1234567890, 9, 987]
codeUnit: [105, 1234567890, 12, 987, 9]
```

## User Impact

Digests are reproducible for the same input, on any runner, in any locale. Fewer
spurious re-reviews and cache misses; no operator-visible behavior change and no
configuration change.

**No migration.** Measured against a pre-fix build, every persisted digest shape
across the affected call sites serializes byte-identically. Nothing stored is
invalidated — see *Real Behavior Proof*, claim 3.

**OpenClaw Bay:** not affected. No status, lifecycle, or telemetry shape Bay
renders changes; digests keep their existing values. No Bay update or Bay proof is
needed.

**Release note:** `fix: order canonical JSON keys by code unit so digests are reproducible`.
No `CHANGELOG.md` edit is included — happy to add one if this repo's release policy
wants it.

## Evidence

### Diff

```
 src/clawsweeper-context-hydration.ts |  9 ++++--
 src/stable-json.ts                   | 36 +++++++++++++++++++-----
 test/stable-json.test.ts             | 54 +++++++++++++++++++++++++++++++++++-
 3 files changed, 88 insertions(+), 11 deletions(-)
```

Plus a new proof package under `docs/proof/stable-json-canonical-ordering/`.

### Focused tests

`node --test test/stable-json.test.ts` → **6/6 pass** (1 pre-existing + 5 new).

The pre-existing case exercised `stableJsonCodeUnit` — the variant that was already
correct. Nothing tested the unsuffixed `stableJson` that every digest actually used.
New cases:

- insertion order cannot change the output (asserts the `localeCompare` tie exists
  first, so it cannot pass vacuously);
- key order is byte-defined, not locale-defined, including the `cs-CZ`-sensitive trio;
- nested arrays and objects order consistently;
- `stableJsonCodeUnit` remains an alias;
- `compareCodeUnits` is a strict total order — never ties distinct strings, and is
  antisymmetric.

### Red/green

Reverted only `src/stable-json.ts` and `src/clawsweeper-context-hydration.ts`,
rebuilt, and re-ran the same probe:

```
##### PRE-FIX #####
insertion-order independence: VIOLATED
   built one way : {"ab":1,"a‍b":2}
   built other   : {"a‍b":2,"ab":1}
byte-defined key order    : VIOLATED -> {"a":1,"B":2}

##### POST-FIX #####
insertion-order independence: HOLDS
byte-defined key order    : HOLDS
```

Focused suite: pre-fix the file fails to load (the new `compareCodeUnits` export
does not exist), so the probe above is the meaningful red signal rather than a test
count.

## Real Behavior Proof

**Claim.** `stableJson` produces a canonical form — the same key/value set always
serializes to the same bytes, on any runtime, in any locale — **and no stored
digest is invalidated by the change**.

**Exercised surface.** `dist/stable-json.js`, the module every content digest and
canonical equality check goes through, plus the two array sorts in
`clawsweeper-context-hydration.ts` that fed `pullChecksDigest`.

**Scenario / fixture.** `run-proof.mjs` asserts three claims against the built
`dist/`:

1. **Canonical** — for keys `localeCompare` reports as equal (zero-width joiner,
   soft hyphen), objects built in opposite insertion orders serialize identically.
   The tie is asserted first, so the check cannot pass vacuously.
2. **Byte order** — `{a, B}` serializes with `B` first (0x42 < 0x61), and the
   `cs-CZ`-sensitive trio keeps byte order.
3. **No churn** — seven persisted digest shapes, copied from the call sites that
   import the locale-ordered `stableJson`, serialize byte-identically to a
   **pre-fix build compiled inside the lease** from `git show <base>:src/stable-json.ts`.
   If that build is not supplied the proof reports SKIPPED and **fails**, rather
   than passing silently.

**Command and environment.** Executed in the supported environment — Node 24 in a
Docker-backed Crabbox `local-container` lease:

```bash
crabbox run \
  --provider local-container \
  --local-container-image node:24 \
  --no-hydrate \
  --timing-json \
  --artifact-glob '.artifacts/stable-json-canonical-proof/**' \
  --script docs/proof/stable-json-canonical-ordering/run-proof.sh
```

| field | value |
|---|---|
| provider | Crabbox `local-container` (Docker/OrbStack) |
| crabbox | `0.15.0` |
| image | `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584` |
| container node | `v24.19.0` (satisfies `engines.node >= 24`) |
| lease | `cbx_260b82c60c03` (`brisk-lobster`) |
| run | `run_3a13e83c0068` |
| artifact | `.crabbox/runs/run_3a13e83c0068/run_3a13e83c0068-artifacts.tgz` |
| exit | `0` |

**Observed result.** In-container: **15/15 proof checks PASS**, focused suite
**6/6**, exit 0. The lease verified the comparator counts on both sides
(`pre-fix: 1 localeCompare`, `post-fix: 0`) before running the claims.

```
== Claim 3: persisted digest shapes are byte-identical to pre-fix ==
  PASS  itemContentDigest byte-identical
  PASS  itemSnapshotHash byte-identical
  PASS  reviewCommentContentRevision byte-identical
  PASS  pullCommitContentRevision byte-identical
  PASS  reviewTimelineDigestParts byte-identical
  PASS  pullChecksDigestParts byte-identical
  PASS  action-ledger invocation id byte-identical
```

**Known churn, and why it is safe.** One shape *does* change: the activity receipt
(`stableJson(completeActivityContext)`) flips `reviews` and `reviewThreads`, because
collation orders `s` before `T` while code units order `T` (0x54) before `s` (0x73).

That value is never persisted. It is produced at
`clawsweeper-apply-decision-workflow.ts:950` and compared at
`clawsweeper-apply-proof-freshness.ts:132` — both inside one apply run, in one
process, from one build. Both sides shift identically, so the comparison still
matches. I grepped for any persistence of it (front matter, schema, config) and
found none. It is deliberately excluded from the claim-3 fixture set, which covers
only digests that outlive a run.

**Artifact / trace.** `docs/proof/stable-json-canonical-ordering/` holds
`run-proof.sh` (Crabbox entry point), `run-proof.mjs`, and the contract README. The
lease artifact tarball holds `proof-output.txt`, `focused-tests.txt`, `install.log`,
and `build.log`.

**Limits.** Covers key ordering only. Claim 3 is evidence over seven representative
shapes taken from the call sites, **not** an exhaustive enumeration of every object
ever passed to `stableJson` — a shape whose sibling keys differ only by case or by a
`ch`-style collation boundary could still churn; none was found among the real call
sites. `dashboard/exact-review-queue.ts` uses `stableJson` for in-process equality
comparisons, which are order-consistent within a run and were not separately
measured. No live GitHub, Worker, or queue is contacted, and the proof performs no
mutation.

## Repository test suite status

The proof and focused suite run on Node 24 inside the Crabbox lease recorded above
(`6/6` in-container). The note below concerns only the *full* suite on the macOS host.

Green on this branch:

| check | environment | result |
|---|---|---|
| Crabbox `local-container` proof | Node 24 container | **PASS**, 15/15, exit 0 |
| `test/stable-json.test.ts` | Node 24 container | **6/6** |
| `pnpm run build:all` | macOS host | clean |
| `pnpm run format:check` | macOS host | clean, 636 files |
| `pnpm run lint` | macOS host | clean (all four projects) |
