### PR TITLE
fix: compare GitHub repository slugs case-insensitively

### DIFF
--- a/docs/proof/automerge-repo-case-sensitivity/README.md
+++ b/docs/proof/automerge-repo-case-sensitivity/README.md
@@ -1,0 +1,133 @@
+# Repository-slug case-sensitivity proof contract
+
+## Claim
+
+A parsed GitHub repository slug is matched case-insensitively, so a
+`canonical_pr` (or `source_prs` entry) that names the target repository with
+different casing resolves normally. Before this change the comparison was
+byte-exact, so `https://github.com/OpenClaw/OpenClaw/pull/83707` did not match
+the configured `openclaw/openclaw` and the reviewed head SHA was dropped.
+
+Matching stays bounded: a genuinely different repository is still rejected, so
+this cannot widen into cross-repository head borrowing.
+
+## Exercised surface
+
+`automergeOutcomeReviewedShaFromResult()` in `dist/repair/automerge-outcome.js`
+is the reported site and the one measured before/after.
+
+The same defect existed at every site that compared a slug returned by
+`parsePullRequestUrl` / `parseIssueOrPullRef`. Those parsers match with the `i`
+flag and return the slug **verbatim**, so a case-differing slug never equalled a
+configured one. All of them now use the shared `sameRepoSlug` comparator:
+
+- `automerge-outcome.ts`
+- `execute-fix-github.ts`
+- `execute-fix-artifact.ts`
+- `post-flight.ts`
+- `source-pr-checkout.ts`
+- `target-validation.ts`
+
+Claim 3 below re-derives that list from the built output rather than trusting the
+diff, so a site added later without the comparator fails the proof.
+
+## Controlled scenario and fixture
+
+`run-proof.mjs` asserts three claims against the built `dist/`:
+
+1. **Resolves** — `canonical_pr` in three casings (`OpenClaw/OpenClaw`,
+   `openclaw/OPENCLAW`, and a mixed-case `GitHub.com` host) each return the
+   reviewed head, alongside an exact-case control.
+2. **Bounded** — three genuinely different repositories are still rejected,
+   including the near-miss `openclaw/openclaw-state`. An absent slug never
+   satisfies a repository guard, so the comparator cannot degrade into
+   "empty matches everything".
+3. **Consistent** — the built output of all six consumer modules is scanned for a
+   parsed slug compared with `===`/`!==` instead of the shared comparator. Any
+   match fails the proof.
+
+The before/after contrast compiles the **pre-fix** `automerge-outcome.ts` and
+`github-ref.ts` from the base commit inside the lease (their runtime import
+closure is just those two files — `json-types` is type-only and erases). If that
+build is unavailable the proof reports SKIPPED and **fails**, rather than
+quietly asserting an unmeasured contrast.
+
+## Expected observation
+
+17 checks, all PASS, exit 0, plus the measured contrast:
+
+```
+https://github.com/OpenClaw/OpenClaw/pull/83707
+  pre-fix : null  (reviewed SHA dropped)
+  post-fix: 92dca8fde03aee8da56a84a011fa387b9c1640fe
+```
+
+Cross-repository rejection is asserted in **both** builds, showing the fix
+changed only the case dimension.
+
+## Artifact and command
+
+```bash
+crabbox run \
+  --provider local-container \
+  --local-container-image node:24 \
+  --no-hydrate \
+  --timing-json \
+  --artifact-glob '.artifacts/automerge-repo-case-proof/**' \
+  --script docs/proof/automerge-repo-case-sensitivity/run-proof.sh
+```
+
+The script runs `pnpm run build:node`, **not** `build:repair`: `test/helpers.ts`
+(used by `post-flight.test.ts`) imports `dist/clawsweeper.js` and
+`dist/review-activity-cursor.js` from the main build, so the repair lane alone
+leaves the focused suites unable to load. An earlier revision of this script made
+exactly that mistake and the lease failed on it.
+
+Host-only quick check (supply a pre-fix build directory for the contrast):
+
+```bash
+pnpm run build:node
+node docs/proof/automerge-repo-case-sensitivity/run-proof.mjs /path/to/pre-fix/dist/repair
+```
+
+Focused tests:
+
+```bash
+node --test test/repair/automerge-outcome.test.ts test/repair/execute-fix-github.test.ts \
+             test/repair/post-flight.test.ts test/repair/source-pr-checkout.test.ts
+```
+
+## Provenance
+
+- provider: Crabbox `local-container` (Docker/OrbStack)
+- crabbox: `0.15.0`
+- image: `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584`
+- container node: `v24.19.0` (satisfies `engines.node >= 24`)
+- lease: `cbx_fe1bec2bb1b0` (`amber-barnacle`)
+- run: `run_194358f6840f`
+- artifact: `.crabbox/runs/run_194358f6840f/run_194358f6840f-artifacts.tgz`
+  (`proof-output.txt`, `focused-tests.txt`, `install.log`, `build.log`,
+  `prefix-build.log`)
+- result: exit `0`; 17/17 proof checks PASS; focused suites `18/18`
+- privacy: synthetic fixtures and public repository slugs only. The proof makes no
+  network call, contacts no GitHub API, and performs no queue, GitHub, or
+  production mutation.
+
+## Limits
+
+Covers the repository-slug comparison only. It does not change URL parsing, the
+allowed host, item-number matching, or any other guard.
+
+The change is **one-directional**: it can only turn a "different repository"
+verdict into "same repository" when the two slugs differ solely by case. It can
+never cause a previously-matching slug to stop matching. That bounds the risk of
+touching the low-coverage `execute-fix-artifact.ts` mechanically.
+
+Claim 3 scans **built output** for the specific `parsed.repo === …` shape. A site
+that compares a parsed slug through a differently-named local variable would not
+be caught by that regex; the six modules listed were enumerated by hand from the
+`parsePullRequestUrl` / `parseIssueOrPullRef` call graph.
+
+The proof exercises no live GitHub redirect. That `github.com` serves
+case-differing slugs is GitHub's documented behavior, relied on here rather than
+demonstrated.

--- a/docs/proof/automerge-repo-case-sensitivity/run-proof.mjs
+++ b/docs/proof/automerge-repo-case-sensitivity/run-proof.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Real-behavior proof for the repository-slug case-sensitivity fix.
+ *
+ * Three claims, all against the built dist/:
+ *
+ *   1. RESOLVES  - automergeOutcomeReviewedShaFromResult() returns the reviewed
+ *                  head when canonical_pr names the same repository with
+ *                  different casing. Pre-fix it returned null.
+ *   2. BOUNDED   - a genuinely different repository is still rejected, so the
+ *                  fix cannot widen into cross-repository head borrowing. This
+ *                  must hold both before and after.
+ *   3. CONSISTENT- every module that compares a parsed repository slug now uses
+ *                  the shared comparator, so no equivalent site is left behind.
+ *
+ * Claim 1 compares against a pre-fix build when one is supplied as argv[2];
+ * without it, the before/after contrast is reported SKIPPED rather than assumed.
+ *
+ * Usage: node docs/proof/automerge-repo-case-sensitivity/run-proof.mjs [preFixDistRepairDir]
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const distRepair = path.join(repoRoot, "dist", "repair");
+const distOutcome = path.join(distRepair, "automerge-outcome.js");
+
+if (!fs.existsSync(distOutcome)) {
+  console.error(`missing build artifact: ${distOutcome}\nrun: pnpm run build:repair`);
+  process.exit(2);
+}
+
+const { automergeOutcomeReviewedShaFromResult } = await import(`file://${distOutcome}`);
+const { sameRepoSlug } = await import(`file://${path.join(distRepair, "github-ref.js")}`);
+
+const HEAD = "92dca8fde03aee8da56a84a011fa387b9c1640fe";
+const REPO = "openclaw/openclaw";
+const TARGET = 83707;
+const failures = [];
+const check = (label, ok, detail) => {
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}`);
+  if (!ok) {
+    if (detail) console.log(`        ${detail}`);
+    failures.push(label);
+  }
+};
+
+const resolve = (impl, canonicalPr) =>
+  impl({
+    repo: REPO,
+    target: TARGET,
+    result: { repo: REPO, canonical_pr: canonicalPr, fix_artifact: null },
+    targetView: { headRefOid: HEAD },
+  });
+
+/* -- Claim 1: case-differing slug resolves ------------------------------- */
+
+console.log("== Claim 1: a slug differing only by case resolves the reviewed head ==\n");
+const CASE_VARIANTS = [
+  `https://github.com/OpenClaw/OpenClaw/pull/${TARGET}`,
+  `https://github.com/openclaw/OPENCLAW/pull/${TARGET}`,
+  `https://GitHub.com/OpenClaw/openclaw/pull/${TARGET}`,
+];
+check(
+  "control: exact-case canonical_pr resolves",
+  resolve(automergeOutcomeReviewedShaFromResult, `https://github.com/${REPO}/pull/${TARGET}`) === HEAD,
+);
+for (const url of CASE_VARIANTS) {
+  check(`resolves ${url}`, resolve(automergeOutcomeReviewedShaFromResult, url) === HEAD);
+}
+
+/* -- Claim 2: cross-repository borrowing still rejected ------------------ */
+
+console.log("\n== Claim 2: a different repository is still rejected ==\n");
+for (const url of [
+  `https://github.com/openclaw/other-repo/pull/${TARGET}`,
+  `https://github.com/OtherOwner/OpenClaw/pull/${TARGET}`,
+  `https://github.com/openclaw/openclaw-state/pull/${TARGET}`,
+]) {
+  check(`rejects ${url}`, resolve(automergeOutcomeReviewedShaFromResult, url) === null);
+}
+check(
+  "an absent slug never satisfies a repository guard",
+  sameRepoSlug(undefined, undefined) === false && sameRepoSlug("", "") === false,
+);
+
+/* -- Claim 3: no equivalent comparison site left behind ------------------ */
+
+console.log("\n== Claim 3: every parsed-slug comparison uses the shared comparator ==\n");
+const CONSUMERS = [
+  "automerge-outcome.js",
+  "execute-fix-github.js",
+  "execute-fix-artifact.js",
+  "post-flight.js",
+  "source-pr-checkout.js",
+  "target-validation.js",
+];
+// A parsed slug compared with === / !== instead of sameRepoSlug is the defect.
+const LEFTOVER = /(?:parsed|canonicalPr|sourcePr)(?:\?)?\.repo\s*(?:===|!==)/;
+for (const file of CONSUMERS) {
+  const full = path.join(distRepair, file);
+  if (!fs.existsSync(full)) {
+    check(`${file} present`, false, "build artifact missing");
+    continue;
+  }
+  const src = fs.readFileSync(full, "utf8");
+  const leftover = src.match(new RegExp(LEFTOVER.source, "g")) ?? [];
+  check(
+    `${file}: no case-sensitive parsed-slug comparison`,
+    leftover.length === 0,
+    leftover.length ? `found: ${leftover.join(", ")}` : undefined,
+  );
+}
+
+/* -- Before/after contrast ------------------------------------------------ */
+
+console.log("\n== Before/after against a pre-fix build ==\n");
+const preFixDir = process.argv[2];
+if (!preFixDir) {
+  console.log("  SKIPPED  no pre-fix build supplied (argv[2]); contrast not measured");
+  failures.push("before/after not measured");
+} else {
+  const preOutcome = path.join(path.resolve(preFixDir), "automerge-outcome.js");
+  if (!fs.existsSync(preOutcome)) {
+    check("pre-fix build present", false, preOutcome);
+  } else {
+    const pre = await import(`file://${preOutcome}`);
+    const url = CASE_VARIANTS[0];
+    const before = resolve(pre.automergeOutcomeReviewedShaFromResult, url);
+    const after = resolve(automergeOutcomeReviewedShaFromResult, url);
+    console.log(`  ${url}`);
+    console.log(`    pre-fix : ${before === null ? "null  (reviewed SHA dropped)" : before}`);
+    console.log(`    post-fix: ${after}`);
+    check("pre-fix dropped the reviewed SHA", before === null);
+    check("post-fix resolves the reviewed SHA", after === HEAD);
+    // The bounded claim must hold in BOTH builds.
+    const crossRepo = `https://github.com/openclaw/other-repo/pull/${TARGET}`;
+    check(
+      "cross-repository rejection unchanged by the fix",
+      resolve(pre.automergeOutcomeReviewedShaFromResult, crossRepo) === null &&
+        resolve(automergeOutcomeReviewedShaFromResult, crossRepo) === null,
+    );
+  }
+}
+
+console.log(`\nRESULT: ${failures.length === 0 ? "PASS" : "FAIL"}`);
+if (failures.length) console.log(`  failed: ${failures.join(", ")}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/docs/proof/automerge-repo-case-sensitivity/run-proof.sh
+++ b/docs/proof/automerge-repo-case-sensitivity/run-proof.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Crabbox local-container proof for the repository-slug case-sensitivity fix.
+#
+# Runs inside a Node 24 Linux container on the synced current checkout. It builds
+# the repair lane, compiles the PRE-FIX repair modules from the merge base so the
+# before/after contrast is measured rather than asserted, then runs run-proof.mjs
+# and the focused suites.
+set -euo pipefail
+
+ARTIFACT_DIR=".artifacts/automerge-repo-case-proof"
+mkdir -p "$ARTIFACT_DIR"
+BASE_REF="${REPO_CASE_PROOF_BASE:-0588bda9}"
+
+echo "== environment =="
+uname -a
+node --version
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 24 ]; then
+  echo "FAIL: repository requires Node >= 24, got $(node --version)"
+  exit 1
+fi
+echo "head: $(git rev-parse HEAD 2>/dev/null || echo 'unavailable')"
+echo "base: $BASE_REF"
+echo
+
+echo "== build =="
+# The lease runs as the unprivileged `crabbox` user, so corepack cannot symlink
+# into /usr/local/bin. Install the pinned pnpm into a user-writable prefix.
+export PNPM_HOME="$HOME/.local/bin"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME" >/dev/null 2>&1 || true
+fi
+if ! command -v pnpm >/dev/null 2>&1; then
+  npm install -g --prefix "$HOME/.local" pnpm@11.10.0 >"$ARTIFACT_DIR/pnpm-install.log" 2>&1 || true
+fi
+command -v pnpm >/dev/null 2>&1 || {
+  echo "FAIL: pnpm unavailable in container"
+  tail -20 "$ARTIFACT_DIR/pnpm-install.log" 2>/dev/null || true
+  exit 1
+}
+echo "pnpm: $(pnpm --version)"
+pnpm install --frozen-lockfile >"$ARTIFACT_DIR/install.log" 2>&1 \
+  || { echo "FAIL: pnpm install"; tail -30 "$ARTIFACT_DIR/install.log"; exit 1; }
+# build:node, not build:repair: test/helpers.ts (used by post-flight.test.ts)
+# imports dist/clawsweeper.js and dist/review-activity-cursor.js from the MAIN
+# build, so the repair lane alone leaves the focused suites unable to load.
+pnpm run build:node >"$ARTIFACT_DIR/build.log" 2>&1 \
+  || { echo "FAIL: pnpm run build:node"; tail -30 "$ARTIFACT_DIR/build.log"; exit 1; }
+test -f dist/repair/automerge-outcome.js || { echo "FAIL: repair build artifact missing"; exit 1; }
+test -f dist/clawsweeper.js || { echo "FAIL: main build artifact missing"; exit 1; }
+echo "post-fix comparator: $(grep -c 'sameRepoSlug' dist/repair/automerge-outcome.js || true) sameRepoSlug references (expect >0)"
+echo
+
+echo "== compile pre-fix modules from $BASE_REF =="
+# automerge-outcome.ts's runtime import closure is just github-ref.ts (json-types
+# is type-only and erases), so the two files compile standalone. That is far more
+# robust inside a lease than reconstructing the whole repair lane.
+PREFIX_DIR="$(mktemp -d)"
+mkdir -p "$PREFIX_DIR/src"
+git show "$BASE_REF:src/repair/automerge-outcome.ts" > "$PREFIX_DIR/src/automerge-outcome.ts"
+git show "$BASE_REF:src/repair/github-ref.ts" > "$PREFIX_DIR/src/github-ref.ts"
+git show "$BASE_REF:src/repair/json-types.ts" > "$PREFIX_DIR/src/json-types.ts"
+./node_modules/.bin/tsc "$PREFIX_DIR/src/automerge-outcome.ts" --ignoreConfig \
+  --target es2022 --module esnext --moduleResolution bundler --outDir "$PREFIX_DIR/out" \
+  >"$ARTIFACT_DIR/prefix-build.log" 2>&1 || true
+PREFIX_REPAIR="$PREFIX_DIR/out"
+if [ ! -f "$PREFIX_REPAIR/automerge-outcome.js" ]; then
+  PREFIX_REPAIR=""
+  echo "pre-fix build: unavailable (before/after contrast reports SKIPPED and FAILS)"
+  tail -20 "$ARTIFACT_DIR/prefix-build.log" 2>/dev/null || true
+else
+  echo "pre-fix comparator: $(grep -c 'sameRepoSlug' "$PREFIX_REPAIR/automerge-outcome.js" || true) sameRepoSlug references (expect 0)"
+fi
+echo
+
+echo "== proof =="
+node docs/proof/automerge-repo-case-sensitivity/run-proof.mjs ${PREFIX_REPAIR:+"$PREFIX_REPAIR"} \
+  | tee "$ARTIFACT_DIR/proof-output.txt"
+
+echo
+echo "== focused regression suites =="
+node --test \
+  test/repair/automerge-outcome.test.ts \
+  test/repair/execute-fix-github.test.ts \
+  test/repair/post-flight.test.ts \
+  test/repair/source-pr-checkout.test.ts 2>&1 | tail -8 | tee "$ARTIFACT_DIR/focused-tests.txt"
+
+rm -rf "$PREFIX_DIR"
+echo
+echo "artifacts written to $ARTIFACT_DIR"

--- a/src/repair/automerge-outcome.ts
+++ b/src/repair/automerge-outcome.ts
@@ -1,5 +1,5 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
-import { parsePullRequestUrl } from "./github-ref.js";
+import { parsePullRequestUrl, sameRepoSlug } from "./github-ref.js";
 
 export function automergeOutcomeReviewedShaFromResult({
   result,
@@ -21,7 +21,7 @@ export function automergeOutcomeReviewedShaFromResult({
   if (direct) return direct;
 
   const canonicalPr = parsePullRequestUrl(result.canonical_pr);
-  if (!canonicalPr || canonicalPr.repo !== String(repo)) return null;
+  if (!canonicalPr || !sameRepoSlug(canonicalPr.repo, repo)) return null;
   if (target !== undefined && Number(canonicalPr.number) !== Number(target)) return null;
 
   return (

--- a/src/repair/execute-fix-artifact.ts
+++ b/src/repair/execute-fix-artifact.ts
@@ -54,7 +54,7 @@ import {
   automergePlanningHeadBlock,
 } from "./automerge-outcome.js";
 import { isCanonicalLandingNeedsHumanText } from "./comment-router-core.js";
-import { parsePullRequestUrl, pullRequestNumberFromUrl } from "./github-ref.js";
+import { parsePullRequestUrl, pullRequestNumberFromUrl, sameRepoSlug } from "./github-ref.js";
 import {
   clawsweeperGitUserEmail,
   clawsweeperGitUserName,
@@ -790,8 +790,8 @@ function shouldPromoteNeedsHumanReplacement(fixArtifact: LooseRecord, workerResu
   if (fixArtifact.repair_strategy !== "needs_human") return false;
   if (!Array.isArray(fixArtifact.source_prs) || fixArtifact.source_prs.length === 0) return false;
   if (
-    !fixArtifact.source_prs.every(
-      (source: JsonValue) => parsePullRequestUrl(source)?.repo === workerResult.repo,
+    !fixArtifact.source_prs.every((source: JsonValue) =>
+      sameRepoSlug(parsePullRequestUrl(source)?.repo, workerResult.repo),
     )
   )
     return false;
@@ -1382,7 +1382,7 @@ function openReplacementPrFromPreparedRepairCheckout({
   const supersededSourceActions: JsonValue[] = [];
   for (const source of supersededSources) {
     const parsed = parsePullRequestUrl(source);
-    if (!parsed || parsed.repo !== result.repo) continue;
+    if (!parsed || !sameRepoSlug(parsed.repo, result.repo)) continue;
     supersededSourceActions.push(
       closeSupersededSourcePrs
         ? closeSupersededSourcePr({
@@ -1838,7 +1838,7 @@ function executeReplacementBranch({
   if (supersededSources.length > 0) {
     for (const source of supersededSources) {
       const parsed = parsePullRequestUrl(source);
-      if (!parsed || parsed.repo !== result.repo) continue;
+      if (!parsed || !sameRepoSlug(parsed.repo, result.repo)) continue;
       supersededSourceActions.push(
         closeSupersededSourcePrs
           ? closeSupersededSourcePr({
@@ -1880,7 +1880,7 @@ function mergedReplacementSourcePr({ fixArtifact, sourcePr = null, targetDir }: 
   const sources = [...(sourcePr?.url ? [sourcePr.url] : []), ...(fixArtifact.source_prs ?? [])];
   for (const source of uniqueStrings(sources)) {
     const parsed = parsePullRequestUrl(source);
-    if (!parsed || parsed.repo !== result.repo) continue;
+    if (!parsed || !sameRepoSlug(parsed.repo, result.repo)) continue;
     const view = fetchSourcePullRequestView({
       repo: result.repo,
       number: parsed.number,
@@ -1991,7 +1991,7 @@ function replacementSourceLabelSets({ fixArtifact, targetDir }: LooseRecord) {
   const sourceLabelSets: string[][] = [];
   for (const source of fixArtifact.source_prs ?? []) {
     const parsed = parsePullRequestUrl(source);
-    if (!parsed || parsed.repo !== result.repo) continue;
+    if (!parsed || !sameRepoSlug(parsed.repo, result.repo)) continue;
     sourceLabelSets.push(sourcePullRequestLabels({ number: parsed.number, targetDir }));
   }
   return sourceLabelSets;
@@ -3593,7 +3593,7 @@ function jobMaintainerAttribution() {
 function firstSourcePullRequest(fixArtifact: LooseRecord) {
   for (const source of fixArtifact.source_prs ?? []) {
     const parsed = parsePullRequestUrl(source);
-    if (parsed && parsed.repo === result.repo) return parsed;
+    if (parsed && sameRepoSlug(parsed.repo, result.repo)) return parsed;
   }
   throw new Error("fix_artifact.source_prs must include a source PR in the target repo");
 }
@@ -4469,10 +4469,10 @@ function hasSuccessfulFixMutation(report: LooseRecord) {
 
 function automergeOutcomeTargetPrNumber() {
   const canonicalPr = parsePullRequestUrl(result.canonical_pr);
-  if (canonicalPr && canonicalPr.repo === result.repo) return canonicalPr.number;
+  if (canonicalPr && sameRepoSlug(canonicalPr.repo, result.repo)) return canonicalPr.number;
   for (const source of result.fix_artifact?.source_prs ?? []) {
     const parsed = parsePullRequestUrl(source);
-    if (parsed && parsed.repo === result.repo) return parsed.number;
+    if (parsed && sameRepoSlug(parsed.repo, result.repo)) return parsed.number;
   }
   for (const ref of job.frontmatter.canonical ?? []) {
     const match = String(ref).match(/^#(\d+)$/);

--- a/src/repair/execute-fix-github.ts
+++ b/src/repair/execute-fix-github.ts
@@ -1,7 +1,7 @@
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import { CLAWSWEEPER_CO_AUTHOR, coAuthorKey } from "./co-author-credit.js";
 import { runCommand as run } from "./command-runner.js";
-import { parsePullRequestUrl } from "./github-ref.js";
+import { parsePullRequestUrl, sameRepoSlug } from "./github-ref.js";
 import { repoRoot } from "./lib.js";
 import { repairGhEnv as ghEnv } from "./process-env.js";
 import { uniqueStrings } from "./validation-command-utils.js";
@@ -60,7 +60,7 @@ export function sourceClosingReferences({
   const references: string[] = [];
   for (const source of fixArtifact.source_prs ?? []) {
     const parsed = parsePullRequestUrl(source);
-    if (!parsed || parsed.repo !== repo) continue;
+    if (!parsed || !sameRepoSlug(parsed.repo, repo)) continue;
     const view = JSON.parse(
       run("gh", ["pr", "view", String(parsed.number), "--repo", repo, "--json", "body"], {
         cwd: targetDir,
@@ -85,7 +85,7 @@ export function sourceContributorCredits({
   const byLogin = new Map<string, LooseRecord>();
   for (const source of fixArtifact.source_prs ?? []) {
     const parsed = parsePullRequestUrl(source);
-    if (!parsed || parsed.repo !== repo) continue;
+    if (!parsed || !sameRepoSlug(parsed.repo, repo)) continue;
     const view = fetchSourcePullRequestView({ repo, number: parsed.number, targetDir });
     const login = String(view.author?.login ?? "").trim();
     if (!login || view.author?.is_bot || isBotLogin(login)) continue;
@@ -143,15 +143,15 @@ export function supersededReplacementSources({
     Array.isArray(fixArtifact.supersede_source_prs) &&
     fixArtifact.supersede_source_prs.length > 0
   ) {
-    return fixArtifact.supersede_source_prs.filter(
-      (source: JsonValue) => parsePullRequestUrl(source)?.repo === repo,
+    return fixArtifact.supersede_source_prs.filter((source: JsonValue) =>
+      sameRepoSlug(parsePullRequestUrl(source)?.repo, repo),
     );
   }
 
   const blockerText = (fixArtifact.branch_update_blockers ?? []).join("\n");
   const directUneditableSources = (fixArtifact.source_prs ?? []).filter((source: JsonValue) => {
     const parsed = parsePullRequestUrl(source);
-    if (!parsed || parsed.repo !== repo) return false;
+    if (!parsed || !sameRepoSlug(parsed.repo, repo)) return false;
     const sourcePattern = new RegExp(`(?:#|pull/)${parsed.number}(?!\\d)[\\s\\S]{0,220}`, "i");
     const sourceBlocker = blockerText.match(sourcePattern)?.[0] ?? "";
     return /maintainer_can_modify\s*=\s*false|uneditable|cannot safely update|branch is unsafe|mergeability unknown/i.test(

--- a/src/repair/github-ref.ts
+++ b/src/repair/github-ref.ts
@@ -4,6 +4,23 @@ export type GitHubRef = {
   url: string;
 };
 
+/**
+ * GitHub repository slugs are case-insensitive: `OpenClaw/OpenClaw` and
+ * `openclaw/openclaw` address the same repository, and github.com serves both.
+ * The URL parsers below match case-insensitively, so a slug they return may not
+ * be byte-equal to a configured slug that names the same repository. Compare
+ * with this rather than `===`.
+ */
+export function sameRepoSlug(left: unknown, right: unknown): boolean {
+  const a = String(left ?? "")
+    .trim()
+    .toLowerCase();
+  const b = String(right ?? "")
+    .trim()
+    .toLowerCase();
+  return a.length > 0 && a === b;
+}
+
 export function parsePullRequestUrl(value: unknown): GitHubRef | null {
   const match = String(value ?? "")
     .trim()

--- a/src/repair/post-flight.ts
+++ b/src/repair/post-flight.ts
@@ -17,7 +17,7 @@ import {
   ghJsonWithRetry as ghJson,
   ghTextWithRetry as ghWithRetry,
 } from "./github-cli.js";
-import { parsePullRequestUrl } from "./github-ref.js";
+import { parsePullRequestUrl, sameRepoSlug } from "./github-ref.js";
 import { sleepMs } from "./timing.js";
 import {
   CLAWSWEEPER_LABEL,
@@ -161,7 +161,7 @@ function finalizeFixPr(action: LooseRecord) {
   }
 
   const parsed = parsePullRequestUrl(action.pr_url ?? action.target);
-  if (!parsed || parsed.repo !== result.repo) {
+  if (!parsed || !sameRepoSlug(parsed.repo, result.repo)) {
     return { ...base, status: "blocked", reason: "fix PR URL is missing or outside target repo" };
   }
 

--- a/src/repair/source-pr-checkout.ts
+++ b/src/repair/source-pr-checkout.ts
@@ -1,6 +1,6 @@
 import { currentHead } from "./git-repo-utils.js";
 import type { GitHubRef } from "./github-ref.js";
-import { parsePullRequestUrl } from "./github-ref.js";
+import { parsePullRequestUrl, sameRepoSlug } from "./github-ref.js";
 import type { JsonValue } from "./json-types.js";
 import { runCommand as run } from "./command-runner.js";
 
@@ -26,7 +26,7 @@ export function firstTargetSourcePullRequest(
 ): GitHubRef | null {
   for (const source of sourcePrs) {
     const parsed = parsePullRequestUrl(source);
-    if (parsed?.repo === repo) return parsed;
+    if (sameRepoSlug(parsed?.repo, repo)) return parsed;
   }
   return null;
 }
@@ -49,7 +49,7 @@ export function checkoutSourcePullRequestHead({
   sourcePr: GitHubRef;
   pull: JsonValue;
 }): SourcePullRequestCheckout {
-  if (sourcePr.repo !== repo) {
+  if (!sameRepoSlug(sourcePr.repo, repo)) {
     throw new Error(`source PR ${sourcePr.url} is not in target repo ${repo}`);
   }
 

--- a/src/repair/target-validation.ts
+++ b/src/repair/target-validation.ts
@@ -11,7 +11,7 @@ import {
   gitLsFiles,
   isAncestor,
 } from "./git-repo-utils.js";
-import { parsePullRequestUrl } from "./github-ref.js";
+import { parsePullRequestUrl, sameRepoSlug } from "./github-ref.js";
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import {
   preparePinnedOpenClawValidationHelper,
@@ -1717,8 +1717,8 @@ export function preflightTargetValidationPlan(
   }
 
   const sourcePr =
-    (fixArtifact.source_prs ?? []).find(
-      (source: JsonValue) => parsePullRequestUrl(source)?.repo === options.targetRepo,
+    (fixArtifact.source_prs ?? []).find((source: JsonValue) =>
+      sameRepoSlug(parsePullRequestUrl(source)?.repo, options.targetRepo),
     ) ?? null;
   return {
     status: "blocked",

--- a/test/repair/automerge-outcome.test.ts
+++ b/test/repair/automerge-outcome.test.ts
@@ -61,3 +61,57 @@ test("automerge planning head binding accepts only the exact reviewed revision",
     /missing a valid reviewed head SHA/,
   );
 });
+
+test("automerge continuation matches a canonical PR whose slug differs only by case", () => {
+  // GitHub repository slugs are case-insensitive and github.com serves this URL.
+  // canonical_pr is model-authored and unconstrained by the result schema, so a
+  // model that echoes the repository's display casing must still resolve.
+  const headSha = "92dca8fde03aee8da56a84a011fa387b9c1640fe";
+  for (const canonicalPr of [
+    "https://github.com/OpenClaw/OpenClaw/pull/83707",
+    "https://github.com/openclaw/OPENCLAW/pull/83707",
+    "https://GitHub.com/OpenClaw/openclaw/pull/83707",
+  ]) {
+    assert.equal(
+      automergeOutcomeReviewedShaFromResult({
+        repo: "openclaw/openclaw",
+        target: 83707,
+        result: { repo: "openclaw/openclaw", canonical_pr: canonicalPr, fix_artifact: null },
+        targetView: { headRefOid: headSha },
+      }),
+      headSha,
+      `${canonicalPr} should resolve against openclaw/openclaw`,
+    );
+  }
+});
+
+test("automerge continuation still rejects a genuinely different repository", () => {
+  // Case-insensitive matching must not widen into cross-repository borrowing.
+  for (const canonicalPr of [
+    "https://github.com/openclaw/other-repo/pull/83707",
+    "https://github.com/OtherOwner/OpenClaw/pull/83707",
+  ]) {
+    assert.equal(
+      automergeOutcomeReviewedShaFromResult({
+        repo: "openclaw/openclaw",
+        target: 83707,
+        result: { repo: "openclaw/openclaw", canonical_pr: canonicalPr, fix_artifact: null },
+        targetView: { headRefOid: "92dca8fde03aee8da56a84a011fa387b9c1640fe" },
+      }),
+      null,
+      `${canonicalPr} must not borrow a head`,
+    );
+  }
+});
+
+test("sameRepoSlug compares case-insensitively without matching empty slugs", async () => {
+  const { sameRepoSlug } = await import("../../dist/repair/github-ref.js");
+  assert.equal(sameRepoSlug("OpenClaw/OpenClaw", "openclaw/openclaw"), true);
+  assert.equal(sameRepoSlug("  openclaw/openclaw  ", "openclaw/openclaw"), true);
+  assert.equal(sameRepoSlug("openclaw/openclaw", "openclaw/other"), false);
+  // An absent slug must never satisfy a repository guard.
+  assert.equal(sameRepoSlug(undefined, undefined), false);
+  assert.equal(sameRepoSlug("", ""), false);
+  assert.equal(sameRepoSlug(null, "openclaw/openclaw"), false);
+  assert.equal(sameRepoSlug("openclaw/openclaw", undefined), false);
+});


### PR DESCRIPTION

Closes #1057.

## What Problem This Solves

Fixes an issue where a repair result naming the target repository with different
casing — `https://github.com/OpenClaw/OpenClaw/pull/83707` instead of
`openclaw/openclaw` — failed every repository guard in the repair lane, even
though github.com serves both URLs and they address the same PR.

The clearest symptom is in automerge: the reviewed head SHA is dropped, and
`automergePlanningHeadBlock` then reports *"automerge planning result is missing a
valid reviewed head SHA"* — a diagnostic that blames the model's output rather
than the comparison. The failure is fail-closed, so it stalls the lane rather than
merging anything wrong.

**This is reachable, not theoretical.** `canonical_pr` is model-authored:
`prompts/repair/autonomous.md:93` tells Codex to emit it "with full URL when
known", and `schema/repair/codex-result.schema.json:180` types it as an
unconstrained `["string", "null"]` — no pattern, no normalization. A model echoing
a repository's display casing produces exactly this input.

## Why This Change Was Made

`parsePullRequestUrl` / `parseIssueOrPullRef` match with the `i` flag and return
the slug **verbatim**; every consumer compared it byte-exactly. A sibling helper in
the same file already got this right — `issueNumberFromRef` lowercases both sides.

This adds one shared comparator, `sameRepoSlug`, and routes all sixteen
comparison sites through it:

| module | comparisons |
|---|---|
| `automerge-outcome.ts` | 1 |
| `execute-fix-github.ts` | 4 |
| `execute-fix-artifact.ts` | 7 |
| `post-flight.ts` | 1 |
| `source-pr-checkout.ts` | 2 |
| `target-validation.ts` | 1 |

Fixing only the reported site would have left the identical defect in five other
modules, so they move together.

**On the risk of touching `execute-fix-artifact.ts` (≈13% covered):** the change is
**one-directional**. It can only turn a "different repository" verdict into "same
repository" when the two slugs differ solely by case; it can never make a
previously-matching slug stop matching. That bounds what a mechanical edit in a
low-coverage module can do.

`sameRepoSlug` also treats an empty or absent slug as **no match**, so the
comparator cannot degrade into "empty matches everything" — a real hazard when
swapping `===` for a helper.

Non-goals: no change to URL parsing, the allowed host, item-number matching, or any
other guard.

## User Impact

Automerge and repair lanes resolve a canonical or source PR whose slug differs only
by case, instead of stalling with a misleading "missing reviewed head SHA". No
configuration change, no migration, no data-contract change.

**OpenClaw Bay:** not affected. No status, lifecycle, or telemetry shape Bay renders
changes. No Bay update or Bay proof is needed.

**Release note:** `fix: compare GitHub repository slugs case-insensitively`.
No `CHANGELOG.md` edit is included — happy to add one if this repo's release policy
wants it.

## Evidence

### Diff

```
 src/repair/automerge-outcome.ts       |  4 +--
 src/repair/execute-fix-artifact.ts    | 20 ++++++-------
 src/repair/execute-fix-github.ts      | 12 ++++----
 src/repair/github-ref.ts              | 17 +++++++++++
 src/repair/post-flight.ts             |  4 +--
 src/repair/source-pr-checkout.ts      |  6 ++--
 src/repair/target-validation.ts       |  6 ++--
 test/repair/automerge-outcome.test.ts | 54 +++++++++++++++++++++++++++++++++++
 8 files changed, 97 insertions(+), 26 deletions(-)
```

Plus a new proof package under `docs/proof/automerge-repo-case-sensitivity/`.

### Focused tests

`node --test test/repair/automerge-outcome.test.ts test/repair/execute-fix-github.test.ts
test/repair/post-flight.test.ts test/repair/source-pr-checkout.test.ts` → **18/18 pass**.

Three new cases:

- a canonical PR whose slug differs only by case resolves (three casings, including
  a mixed-case `GitHub.com` host);
- a genuinely different repository is **still rejected** — a regression guard that
  passes both before and after, proving the fix did not widen into cross-repository
  head borrowing;
- `sameRepoSlug` compares case-insensitively and never matches an empty/absent slug.

### Red/green

Reverted only `src/repair/`, rebuilt, and re-ran:

| build | result |
|---|---|
| pre-fix | **2 fail**, 4 pass — the case-variant test and the comparator test |
| post-fix | **6 pass**, 0 fail |

The cross-repository rejection test passes in both directions, which is the point:
it is a guard, not a symptom.

## Real Behavior Proof

**Claim.** A parsed repository slug is matched case-insensitively, so a
case-differing `canonical_pr` resolves normally — while a genuinely different
repository is still rejected.

**Exercised surface.** `automergeOutcomeReviewedShaFromResult()` in
`dist/repair/automerge-outcome.js` (the reported site, measured before/after), plus
a scan of the built output of all six consumer modules.

**Scenario / fixture.** Three claims:

1. **Resolves** — three casings each return the reviewed head, alongside an
   exact-case control.
2. **Bounded** — three different repositories are rejected, including the near-miss
   `openclaw/openclaw-state`; an absent slug never satisfies a guard.
3. **Consistent** — the built output of all six modules is scanned for a parsed slug
   compared with `===`/`!==` instead of the comparator. Any match fails the proof, so
   a site added later without it is caught.

The contrast compiles the **pre-fix** `automerge-outcome.ts` + `github-ref.ts` from
the base commit inside the lease. If that build is unavailable the proof reports
SKIPPED and **fails**, rather than quietly asserting an unmeasured contrast.

**Command and environment.** Node 24 in a Docker-backed Crabbox `local-container`
lease:

```bash
crabbox run \
  --provider local-container \
  --local-container-image node:24 \
  --no-hydrate \
  --timing-json \
  --artifact-glob '.artifacts/automerge-repo-case-proof/**' \
  --script docs/proof/automerge-repo-case-sensitivity/run-proof.sh
```

| field | value |
|---|---|
| provider | Crabbox `local-container` (Docker/OrbStack) |
| crabbox | `0.15.0` |
| image | `node:24` @ `sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584` |
| container node | `v24.19.0` (satisfies `engines.node >= 24`) |
| lease | `cbx_fe1bec2bb1b0` (`amber-barnacle`) |
| run | `run_194358f6840f` |
| artifact | `.crabbox/runs/run_194358f6840f/run_194358f6840f-artifacts.tgz` |
| exit | `0` |

**Observed result.** In-container: **17/17 proof checks PASS**, focused suites
**18/18**, exit 0. The lease verified the comparator counts on both sides
(`post-fix: 2 sameRepoSlug`, `pre-fix: 0`) before running the claims.

```
https://github.com/OpenClaw/OpenClaw/pull/83707
  pre-fix : null  (reviewed SHA dropped)
  post-fix: 92dca8fde03aee8da56a84a011fa387b9c1640fe

PASS  cross-repository rejection unchanged by the fix
```

**A gap this proof caught in itself.** The first lease run **failed**:
`post-flight.test.ts` could not load, because the script ran `build:repair` while
`test/helpers.ts` imports `dist/clawsweeper.js` and `dist/review-activity-cursor.js`
from the **main** build. That was an environment gap in my proof script, not a code
defect — it passed on my host only because `dist/` was already fully built there.
The script now runs `build:node` and asserts both artifacts exist. Recording it
because a proof that only works on a pre-warmed host is not a proof.

**Artifact / trace.** `docs/proof/automerge-repo-case-sensitivity/` holds
`run-proof.sh`, `run-proof.mjs`, and the contract README. The lease artifact tarball
holds `proof-output.txt`, `focused-tests.txt`, `install.log`, `build.log`, and
`prefix-build.log`.

**Limits.** Covers the slug comparison only. Claim 3 scans built output for the
specific `parsed.repo === …` shape — a site comparing a parsed slug through a
differently-named local variable would not be caught by that regex; the six modules
were enumerated by hand from the parser call graph. The proof exercises no live
GitHub redirect: that github.com serves case-differing slugs is GitHub's documented
behavior, relied on here rather than demonstrated.

## Repository test suite status

The proof and focused suites run on Node 24 inside the Crabbox lease recorded above
(`18/18` in-container). The note below concerns only the *full* suite on the macOS host.

Host full suite on this branch: **22 distinct failures**. Three did not appear in the
clean-tree baseline — `comment webhook settles duplicate fast ack comments after
dispatch`, `webhook signature verification uses sha256 body hmac`, and `exact-review
queue durably coalesces concurrent unchanged pull request edits`. All three are
known flakes from earlier branches in this series, and I verified rather than assumed:

- `comment-webhook.test.ts` passes **25/25, three runs in a row** in isolation on this
  branch;
- a module-graph walk from `dist/repair/comment-webhook.js` shows **none** of the seven
  files this PR touches is reachable from it.

Green on this branch:

| check | environment | result |
|---|---|---|
| Crabbox `local-container` proof | Node 24 container | **PASS**, 17/17, exit 0 |
| focused repair suites | Node 24 container | **18/18** |
| `pnpm run build:all` | macOS host | clean |
| `pnpm run format:check` | macOS host | clean, 636 files |
| `pnpm run lint` | macOS host | clean (all four projects) |

