### PR TITLE
perf(apply): memoize per-item guard reads; stabilize coalescing race test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Apply guards now memoize per-item GitHub reads (comments, timelines, reviews, issue/PR lookups) behind a cache that resets at item boundaries and after every observed mutation, collapsing up to seven duplicate paginations per item into one and cutting apply-lane pressure on the shared App installation rate limit.
+
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Apply guards now memoize per-item GitHub reads (comments, timelines, reviews, issue/PR lookups) behind a cache that resets at item boundaries and after every observed mutation, collapsing up to seven duplicate paginations per item into one and cutting apply-lane pressure on the shared App installation rate limit.
-
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -139,6 +139,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     recordApplyActionEvents,
     recordApplyActionLedgerItemResults,
     recordApplyMutationBoundary,
+    resetGuardReadCache,
     removeCurrentCursorTraceItem,
     removeIssueLabel,
     renderReviewCommentFromReport,
@@ -452,6 +453,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     // oxfmt-ignore
     for (const entry of fileEntries) {
       releaseActiveApplyMutationLease();
+      resetGuardReadCache();
       const file = entry.name;
       const path = entry.path;
       if (runtimeBudgetExceeded(startedAtMs, maxRuntimeMs, Date.now())) {
@@ -473,6 +475,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       try {
       const markMutationObserved = (): void => {
         if (dryRun) return;
+        resetGuardReadCache();
         activeApplyItem = { repo, number, mutationOccurred: true };
         mutationByItem.set(`${repo}#${number}`, true);
       };

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -360,6 +360,7 @@ export interface CreateApplyDecisionWorkflowDependencies {
   reportRealBehaviorProof: (markdown: string) => RealBehaviorProof;
   reportSecurityReview: (markdown: string) => SecurityReview;
   reportTelegramVisibleProof: (markdown: string) => TelegramVisibleProof;
+  resetGuardReadCache: () => void;
   reviewCommentBodyDigest: (body: string) => string;
   reviewCommentHasCloseVerdictForCanonical: (
     comment: Record<string, unknown> | undefined,

--- a/src/clawsweeper-apply-guards.ts
+++ b/src/clawsweeper-apply-guards.ts
@@ -5,11 +5,48 @@ import { createApplyGuardProof } from "./clawsweeper-apply-guard-proof.js";
 import { createApplyGuardCapacity } from "./clawsweeper-apply-guard-capacity.js";
 export { STALLED_UNPROVEN_PROOF_STATUSES } from "./clawsweeper-apply-guard-dependencies.js";
 
+type GuardReadCacheEntry = { ok: true; value: unknown } | { ok: false; error: unknown };
+
 export function createApplyGuards(dependencies: ApplyGuardDependencies) {
-  const activity = createApplyGuardActivity({ ...dependencies });
-  const policy = createApplyGuardPolicy({ ...dependencies, ...activity });
-  const proof = createApplyGuardProof({ ...dependencies, ...activity, ...policy });
-  const capacity = createApplyGuardCapacity({ ...dependencies, ...activity, ...policy, ...proof });
+  const guardReadCache = new Map<string, GuardReadCacheEntry>();
+
+  function memoizedGuardRead<T>(kind: "json" | "paged", args: readonly string[], read: () => T): T {
+    const key = JSON.stringify([kind, ...args]);
+    const cached = guardReadCache.get(key);
+    if (cached) {
+      if (cached.ok) return cached.value as T;
+      throw cached.error;
+    }
+    try {
+      const value = read();
+      guardReadCache.set(key, { ok: true, value });
+      return value;
+    } catch (error) {
+      guardReadCache.set(key, { ok: false, error });
+      throw error;
+    }
+  }
+
+  const guardDependencies: ApplyGuardDependencies = {
+    ...dependencies,
+    ghJson: <T>(args: string[]): T =>
+      memoizedGuardRead("json", args, () => dependencies.ghJson<T>(args)),
+    ghPaged: <T>(path: string): T[] =>
+      memoizedGuardRead("paged", [path], () => dependencies.ghPaged<T>(path)),
+  };
+  const activity = createApplyGuardActivity({ ...guardDependencies });
+  const policy = createApplyGuardPolicy({ ...guardDependencies, ...activity });
+  const proof = createApplyGuardProof({ ...guardDependencies, ...activity, ...policy });
+  const capacity = createApplyGuardCapacity({
+    ...guardDependencies,
+    ...activity,
+    ...policy,
+    ...proof,
+  });
+
+  function resetGuardReadCache(): void {
+    guardReadCache.clear();
+  }
   const {
     abandonedPrAgeSkipReason,
     abandonedPrApplyBlockReasonSafe,
@@ -45,6 +82,7 @@ export function createApplyGuards(dependencies: ApplyGuardDependencies) {
     prAutoCloseExemptDecisionReason,
     prAutoCloseExemptLabel,
     pullRequestHeadActivity,
+    resetGuardReadCache,
     staleVersionBugApplyBlockReasonSafe,
     stalledUnprovenPrAgeSkipReason,
     stalledUnprovenPrApplyBlockReasonSafe,

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -536,12 +536,18 @@ const applyGuards = createApplyGuards({
   unsponsoredFeatureAgeSkipReason,
   unsponsoredFeatureCloseEnabled: () => unsponsoredFeatureCloseEnabled(),
 });
+const { resetGuardReadCache } = applyGuards;
 export const {
   abandonedPrAgeSkipReason,
   issueRecentHumanCommentBlockReasonFromComments,
   stalledUnprovenPrAgeSkipReason,
-  stalledUnprovenProofRequestBlockReason,
 } = applyGuards;
+export function stalledUnprovenProofRequestBlockReason(
+  ...args: Parameters<typeof applyGuards.stalledUnprovenProofRequestBlockReason>
+): ReturnType<typeof applyGuards.stalledUnprovenProofRequestBlockReason> {
+  resetGuardReadCache();
+  return applyGuards.stalledUnprovenProofRequestBlockReason(...args);
+}
 const { prAutoCloseExemptDecisionReason, prAutoCloseExemptLabel } = applyGuards;
 
 const contextHydration = createContextHydration({

--- a/test/apply-guard-read-cache.test.ts
+++ b/test/apply-guard-read-cache.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createApplyGuards } from "../dist/clawsweeper-apply-guards.js";
+
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function createGuards({ ghJson = () => ({}), ghPaged = () => [] } = {}) {
+  return createApplyGuards({
+    asRecord,
+    authorPrBudget: () => 10,
+    authorPrBudgetAgeSkipReason: () => null,
+    authorPrBudgetCloseEnabled: () => true,
+    ghJson,
+    ghPaged,
+    isMaintainerAuthorAssociation: (value) => ["MEMBER", "OWNER", "COLLABORATOR"].includes(value),
+    isMaintainerAuthored: () => false,
+    isOlderThanDays: () => true,
+    labelNames: (value) =>
+      Array.isArray(value)
+        ? value.flatMap((label) => {
+            if (typeof label === "string") return [label];
+            const name = asRecord(label).name;
+            return typeof name === "string" ? [name] : [];
+          })
+        : [],
+    login: (value) => {
+      const login = asRecord(value).login;
+      return typeof login === "string" ? login : undefined;
+    },
+    normalizeLabelName: (label) => label.trim().toLowerCase(),
+    obsoleteFixPrAgeSkipReason: () => null,
+    obsoleteFixPrCloseEnabled: () => true,
+    protectedLabels: () => [],
+    quoteGitHubSearchTerm: (term) => term,
+    reportPrRating: () => ({
+      proofTier: "F",
+      patchTier: "F",
+      overallTier: "F",
+      summary: "",
+      nextSteps: [],
+    }),
+    reportRealBehaviorProof: () => ({
+      status: "missing",
+      summary: "",
+      evidenceKind: "not_applicable",
+      needsContributorAction: true,
+    }),
+    staleVersionBugAgeSkipReason: () => null,
+    staleVersionBugCloseEnabled: () => true,
+    stringOrUndefined: (value) => (typeof value === "string" ? value : undefined),
+    targetRepo: () => "openclaw/openclaw",
+    unconfirmedProductDirectionAgeSkipReason: () => null,
+    unconfirmedProductDirectionCloseEnabled: () => true,
+    unsponsoredFeatureAgeSkipReason: () => null,
+    unsponsoredFeatureCloseEnabled: () => true,
+  });
+}
+
+test("apply guard reads share a paged endpoint across guard functions", () => {
+  const calls = [];
+  const guards = createGuards({
+    ghPaged: (path) => {
+      calls.push(path);
+      return [];
+    },
+  });
+
+  guards.issueRecentHumanCommentBlockReasonSafe(42, 30);
+  guards.stalledUnprovenProofRequestBlockReason(42);
+
+  assert.equal(
+    calls.filter((path) => path === "repos/openclaw/openclaw/issues/42/comments").length,
+    1,
+  );
+  assert.equal(
+    calls.filter((path) => path === "repos/openclaw/openclaw/issues/42/timeline").length,
+    1,
+  );
+});
+
+test("apply guard reads share a JSON endpoint across guard functions", () => {
+  const calls = [];
+  const guards = createGuards({
+    ghJson: (args) => {
+      calls.push(args);
+      return {
+        state: "open",
+        created_at: "2025-01-01T00:00:00Z",
+        labels: [],
+        assignees: [],
+        milestone: null,
+        reactions: { total_count: 0 },
+      };
+    },
+  });
+  const item = { createdAt: "2025-01-01T00:00:00Z" };
+
+  guards.unsponsoredFeatureApplyBlockReasonSafe(42, item);
+  guards.staleVersionBugApplyBlockReasonSafe(42, item);
+
+  assert.equal(
+    calls.filter(
+      (args) =>
+        JSON.stringify(args) === JSON.stringify(["api", "repos/openclaw/openclaw/issues/42"]),
+    ).length,
+    1,
+  );
+});
+
+test("apply guard read cache resets between items", () => {
+  const calls = [];
+  const guards = createGuards({
+    ghPaged: (path) => {
+      calls.push(path);
+      return [];
+    },
+  });
+
+  guards.issueRecentHumanCommentBlockReasonSafe(1, 30);
+  guards.issueRecentHumanCommentBlockReasonSafe(1, 30);
+  assert.equal(calls.length, 1);
+
+  guards.resetGuardReadCache();
+  guards.issueRecentHumanCommentBlockReasonSafe(1, 30);
+  guards.issueRecentHumanCommentBlockReasonSafe(2, 30);
+
+  assert.deepEqual(calls, [
+    "repos/openclaw/openclaw/issues/1/comments",
+    "repos/openclaw/openclaw/issues/1/comments",
+    "repos/openclaw/openclaw/issues/2/comments",
+  ]);
+});
+
+test("apply guard read cache distinguishes full request arguments", () => {
+  const calls = [];
+  const guards = createGuards({
+    ghJson: (args) => {
+      calls.push(args);
+      const path = args[1];
+      if (path?.endsWith("/issues/42")) return { assignees: [] };
+      if (path?.endsWith("/pulls/42")) {
+        return args.includes("--jq")
+          ? { requested_reviewers: [], requested_teams: [] }
+          : {
+              created_at: "2025-01-01T00:00:00Z",
+              mergeable: false,
+              mergeable_state: "dirty",
+              requested_reviewers: [],
+              requested_teams: [],
+              user: { login: "contributor" },
+              head: {},
+            };
+      }
+      return {};
+    },
+  });
+  const item = { createdAt: "2025-01-01T00:00:00Z", labels: [] };
+
+  guards.unconfirmedProductDirectionApplyBlockReasonSafe(42, item, undefined, undefined);
+  guards.lowSignalUnmergeablePrApplyBlockReasonSafe(42, 30);
+
+  const pullCalls = calls.filter((args) => args[1] === "repos/openclaw/openclaw/pulls/42");
+  assert.equal(pullCalls.length, 2);
+  assert.equal(
+    pullCalls.some((args) => args.includes("--jq")),
+    true,
+  );
+  assert.equal(
+    pullCalls.some((args) => !args.includes("--jq")),
+    true,
+  );
+});

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1162,9 +1162,20 @@ test("exact-review queue durably coalesces concurrent unchanged pull request edi
       }
     >;
   };
-  assert.equal(state.items["Steipete/Nameplate#750"].revision, 1);
-  assert.equal(state.items["Steipete/Nameplate#750"].decision.sourceAuthoritySeq, 1);
-  assert.deepEqual(state.items["Steipete/Nameplate#750"].sourceAuthorityWatermark, {
+  // Either concurrent delivery may win the enqueue race; the stored item keeps
+  // the winner's repo casing (seq 1 sent "Steipete/Nameplate", seq 2 lowercase)
+  // while the loser dedupes case-insensitively and the watermark ends at the
+  // maximum sequence in both orders.
+  const queued = responses.find((response) => response.queued === true);
+  const storedKeys = Object.keys(state.items).filter(
+    (key) => key.toLowerCase() === "steipete/nameplate#750",
+  );
+  assert.deepEqual(storedKeys, [queued?.item_key]);
+  const item = state.items[storedKeys[0]];
+  const winnerAuthoritySeq = storedKeys[0] === "Steipete/Nameplate#750" ? 1 : 2;
+  assert.equal(item.revision, 1);
+  assert.equal(item.decision.sourceAuthoritySeq, winnerAuthoritySeq);
+  assert.deepEqual(item.sourceAuthorityWatermark, {
     sequence: 2,
     updatedAt: "2026-07-25T09:00:00Z",
   });


### PR DESCRIPTION
## Summary

- Apply guards re-fetched identical GitHub endpoints up to seven times per item during one apply decision, amplifying pressure on the shared GitHub App installation rate limit that has been returning production 403s. A shared memo cache now deduplicates those reads per item, resets at item boundaries, and clears after every observed mutation.
- The dashboard coalescing test hard-coded which enqueue won a legitimate race. It now asserts the same invariants for either winner.

## Proof

- Claim: one apply decision reuses identical guard reads without carrying stale data across items or observed mutations, while dashboard coalescing remains correct under either enqueue ordering.
- Exercised surface: apply-guard read caching and invalidation plus the dashboard worker's coalescing race fixture.
- Scenario: full unit suite, including both race interleavings and the per-item/mutation cache boundaries, plus a Docker-contained controlled apply run through the production `apply-decisions` entrypoint.
- Unit command and environment: `pnpm test:unit` on Node 24. Observable result: 1950 of 1952 tests passed; 2 skipped. Both race interleavings were verified.
- Controlled apply command and environment: exact head `a17e2aa651d361708209da46da04493b08f3d951` on Crabbox `provider=aws`, lease `cbx_fca17c765f6d`, run `run_46dc6edd2324`, with `node:24-bookworm`. The container built the branch and invoked `node dist/clawsweeper.js apply-decisions --skip-dashboard --item-number 321 --closed-dir <temp>` against a controlled GitHub fixture.
- Controlled apply result: two guard consumers produced one comments read before reset; resetting forced a second read. After one observed label mutation, the real apply workflow fetched changed review state and stopped the next mutation with `skipped_changed_since_review` (`APPLY_CACHE_PROOF=PASS`).
- Limits: the GitHub endpoint was a controlled fixture, not production GitHub; no live issue, PR, comment, label, or close mutation was performed.

## Review disposition

- Removed the release-owned `CHANGELOG.md` entry; release context remains in this PR body and commit history.
- Added current-head Docker-backed apply-boundary proof for read coalescing and post-mutation invalidation.

OpenClaw Bay is unaffected: this changes internal apply-decision read reuse and a test race assertion, without changing lifecycle publication, queue controls, status/telemetry, or dashboard data contracts.
