### PR TITLE
fix(ledger): publish successful shard artifacts after workflow reruns

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4467,7 +4467,8 @@ jobs:
           pnpm run --silent publish-action-events -- \
             --source-root .clawsweeper-repair/action-ledger-download \
             --state-root . \
-            --expected-producer-job review |
+            --expected-producer-job review \
+            --expected-producer-max-run-attempt "$GITHUB_RUN_ATTEMPT" |
             jq -r '.paths[]?' >> .artifacts/action-ledger-paths.txt
           pnpm run --silent publish-action-events -- \
             --source-root "$CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT" \

--- a/src/action-ledger-runtime.ts
+++ b/src/action-ledger-runtime.ts
@@ -152,14 +152,16 @@ export type ActionEventShardImportResult = {
   paths: string[];
 };
 
-export type ExpectedActionEventProducer = {
+type ExpectedActionEventProducerIdentity = {
   repository: string;
   sha: string;
   workflow: string;
   job: string;
   runId: string;
-  runAttempt: number;
 };
+
+export type ExpectedActionEventProducer = ExpectedActionEventProducerIdentity &
+  ({ runAttempt: number; maxRunAttempt?: never } | { runAttempt?: never; maxRunAttempt: number });
 
 type ImportedActionEventShard = {
   relativePath: string;
@@ -1111,6 +1113,17 @@ function validateImportedActionEventProducer(
   shards: readonly ImportedActionEventShard[],
   expected: ExpectedActionEventProducer,
 ): void {
+  if (
+    (expected.runAttempt === undefined) === (expected.maxRunAttempt === undefined) ||
+    (expected.runAttempt !== undefined &&
+      (!Number.isSafeInteger(expected.runAttempt) || expected.runAttempt < 1)) ||
+    (expected.maxRunAttempt !== undefined &&
+      (!Number.isSafeInteger(expected.maxRunAttempt) || expected.maxRunAttempt < 1))
+  ) {
+    throw new Error(
+      "action event shard producer provenance requires one positive run attempt constraint",
+    );
+  }
   for (const shard of shards) {
     const actual = shard.identity;
     const mismatched = (
@@ -1120,12 +1133,21 @@ function validateImportedActionEventProducer(
         ["workflow", actual.workflow, expected.workflow],
         ["job", actual.job, expected.job],
         ["run_id", actual.runId, expected.runId],
-        ["run_attempt", actual.runAttempt, expected.runAttempt],
       ] as const
     ).find(([, value, expectedValue]) => value !== expectedValue);
     if (mismatched) {
       throw new Error(
         `action event shard producer provenance mismatch for ${mismatched[0]}: expected ${mismatched[2]}, got ${mismatched[1]}`,
+      );
+    }
+    if (expected.runAttempt !== undefined && actual.runAttempt !== expected.runAttempt) {
+      throw new Error(
+        `action event shard producer provenance mismatch for run_attempt: expected ${expected.runAttempt}, got ${actual.runAttempt}`,
+      );
+    }
+    if (expected.maxRunAttempt !== undefined && actual.runAttempt > expected.maxRunAttempt) {
+      throw new Error(
+        `action event shard producer provenance mismatch for run_attempt: expected at most ${expected.maxRunAttempt}, got ${actual.runAttempt}`,
       );
     }
   }

--- a/src/clawsweeper-action-commands.ts
+++ b/src/clawsweeper-action-commands.ts
@@ -34,12 +34,26 @@ export function createActionCommands(dependencies: CreateActionCommandsDependenc
       throw new UserFacingCommandError("--expected-producer-job is required");
     }
     const expectedProducerRunAttempt = optionalNumberArg(args.expected_producer_run_attempt);
+    const expectedProducerMaxRunAttempt = optionalNumberArg(args.expected_producer_max_run_attempt);
+    if (expectedProducerRunAttempt !== undefined && expectedProducerMaxRunAttempt !== undefined) {
+      throw new UserFacingCommandError(
+        "--expected-producer-run-attempt and --expected-producer-max-run-attempt are mutually exclusive",
+      );
+    }
     if (
       expectedProducerRunAttempt !== undefined &&
       (!Number.isInteger(expectedProducerRunAttempt) || expectedProducerRunAttempt < 1)
     ) {
       throw new UserFacingCommandError(
         "--expected-producer-run-attempt must be a positive integer",
+      );
+    }
+    if (
+      expectedProducerMaxRunAttempt !== undefined &&
+      (!Number.isInteger(expectedProducerMaxRunAttempt) || expectedProducerMaxRunAttempt < 1)
+    ) {
+      throw new UserFacingCommandError(
+        "--expected-producer-max-run-attempt must be a positive integer",
       );
     }
     const expectedProducerRunId = stringArg(args.expected_producer_run_id, "");
@@ -53,6 +67,10 @@ export function createActionCommands(dependencies: CreateActionCommandsDependenc
       throw new UserFacingCommandError("--expected-producer-sha must be a lowercase commit SHA");
     }
     const currentProducer = workflowActionProducer("action_event_publisher");
+    const expectedRunAttempt =
+      expectedProducerMaxRunAttempt === undefined
+        ? { runAttempt: expectedProducerRunAttempt ?? currentProducer.runAttempt }
+        : { maxRunAttempt: expectedProducerMaxRunAttempt };
     const result = importActionEventShards(sourceRoot, stateRoot, {
       expectedProducer: {
         repository: currentProducer.repository,
@@ -60,7 +78,7 @@ export function createActionCommands(dependencies: CreateActionCommandsDependenc
         workflow: currentProducer.workflow,
         job: expectedProducerJob,
         runId: expectedProducerRunId || currentProducer.runId,
-        runAttempt: expectedProducerRunAttempt ?? currentProducer.runAttempt,
+        ...expectedRunAttempt,
       },
     });
     console.log(JSON.stringify(result, null, 2));

--- a/test/action-ledger-runtime.test.ts
+++ b/test/action-ledger-runtime.test.ts
@@ -3934,6 +3934,64 @@ test("state shard imports reject producer provenance outside the authenticated w
   );
 });
 
+test("state shard imports accept retained prior attempts only through an explicit upper bound", async () => {
+  const root = tempRoot();
+  const source = trustedChildRoot(root, "source");
+  const destination = trustedChildRoot(root, "destination");
+  const attemptOneEnv = workflowEnv({ GITHUB_RUN_ATTEMPT: "1" });
+  const event = recordReview(root, attemptOneEnv);
+  assert.ok(event);
+  await flushWorkflowActionEvents(root, {
+    env: attemptOneEnv,
+    outputRoot: source,
+  });
+  const expectedIdentity = {
+    repository: event.producer.repository,
+    sha: event.producer.sha,
+    workflow: event.producer.workflow,
+    job: event.producer.job,
+    runId: event.producer.run_id,
+  };
+
+  assert.throws(
+    () =>
+      importActionEventShards(source, destination, {
+        expectedProducer: { ...expectedIdentity, runAttempt: 2 },
+      }),
+    /producer provenance mismatch for run_attempt: expected 2, got 1/,
+  );
+  assert.equal(
+    importActionEventShards(source, destination, {
+      expectedProducer: { ...expectedIdentity, maxRunAttempt: 2 },
+    }).created,
+    1,
+  );
+
+  const futureRoot = tempRoot();
+  const futureSource = trustedChildRoot(futureRoot, "source");
+  const futureDestination = trustedChildRoot(futureRoot, "destination");
+  const attemptThreeEnv = workflowEnv({ GITHUB_RUN_ATTEMPT: "3" });
+  recordReview(futureRoot, attemptThreeEnv);
+  await flushWorkflowActionEvents(futureRoot, {
+    env: attemptThreeEnv,
+    outputRoot: futureSource,
+  });
+  assert.throws(
+    () =>
+      importActionEventShards(futureSource, futureDestination, {
+        expectedProducer: { ...expectedIdentity, maxRunAttempt: 2 },
+      }),
+    /producer provenance mismatch for run_attempt: expected at most 2, got 3/,
+  );
+  assert.throws(
+    () =>
+      importActionEventShards(source, trustedChildRoot(root, "invalid-constraint"), {
+        expectedProducer: { ...expectedIdentity, maxRunAttempt: Number.NaN },
+      }),
+    /requires one positive run attempt constraint/,
+  );
+});
+
 test("state shard imports validate duplicate and causal integrity across shard parts", () => {
   const root = tempRoot();
   const event = recordReview(root);

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -102,6 +102,34 @@ test("action event import rejects an invalid expected producer run ID", async ()
   );
 });
 
+test("action event import rejects an invalid maximum producer run attempt", async () => {
+  await assert.rejects(
+    main([
+      "publish-action-events",
+      "--expected-producer-job",
+      "review",
+      "--expected-producer-max-run-attempt",
+      "0",
+    ]),
+    /expected-producer-max-run-attempt must be a positive integer/,
+  );
+});
+
+test("action event import keeps exact and maximum producer attempts mutually exclusive", async () => {
+  await assert.rejects(
+    main([
+      "publish-action-events",
+      "--expected-producer-job",
+      "review",
+      "--expected-producer-run-attempt",
+      "1",
+      "--expected-producer-max-run-attempt",
+      "2",
+    ]),
+    /expected-producer-run-attempt and --expected-producer-max-run-attempt are mutually exclusive/,
+  );
+});
+
 test("action event import rejects an invalid expected producer SHA", async () => {
   await assert.rejects(
     main([

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -5789,6 +5789,10 @@ test("every action-ledger publication authenticates the expected producer job", 
   assert.equal(commands.length, 7);
   assert.ok(commands.every((command) => command.includes("--expected-producer-job")));
   assert.match(workflow, /--expected-producer-job review/);
+  assert.match(
+    workflow,
+    /--expected-producer-job review \\\n\s+--expected-producer-max-run-attempt "\$GITHUB_RUN_ATTEMPT"/,
+  );
   assert.match(workflow, /--expected-producer-job apply-proof/);
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rerunning a partially failed ClawSweeper sweep could leave completed reviews unpublished. GitHub retains successful review-shard artifacts from the first attempt, but the attempt-2 publisher required every shard to claim `run_attempt=2`; it rejected the valid retained attempt-1 ledger before publication.

This was observed in [run 31223072940 attempt 2](https://github.com/openclaw/clawsweeper/actions/runs/31223072940/attempts/2), where [the publisher](https://github.com/openclaw/clawsweeper/actions/runs/31223072940/job/93015214709) reported `expected 2, got 1` even though [the review shard for openclaw/openclaw#120368](https://github.com/openclaw/clawsweeper/actions/runs/31223072940/job/93015215874) had completed and uploaded its review artifact.

## Why This Change Was Made

The ledger importer remains exact by default. It now also supports an explicit positive maximum-attempt provenance constraint, and only the sweep publisher's downloaded review-artifact handoff uses it. Repository, commit SHA, workflow, producer job, and workflow run ID must still match exactly; malformed constraints and artifacts from later attempts fail closed.

The sibling GitHub-read amplification exposed by the same incident was independently repaired and landed in [#1060](https://github.com/openclaw/clawsweeper/pull/1060). This PR is based on that commit and owns only the retained-artifact provenance defect.

## User Impact

Operators can rerun failed sweep jobs without losing successful reviews from earlier attempts of the same immutable workflow run. Exact command-manifest imports, current-job imports, and all other ledger provenance checks retain their previous strict behavior.

OpenClaw Bay is unaffected: this changes ledger import admission and one workflow caller, not dashboard or status data contracts.

## Evidence

- Source failure: [run 31223072940 attempt 2 / publisher job 93015214709](https://github.com/openclaw/clawsweeper/actions/runs/31223072940/job/93015214709) rejected attempt 1 against attempt 2, then the apply path exhausted GitHub App quota before replacing the placeholder.
- Focused regression: exact attempt 2 still rejects an attempt-1 shard; explicit maximum attempt 2 imports it; attempt 3 and malformed bounds are rejected.
- Focused commands passed on Node `v24.19.0`: all builds, the two ledger provenance tests, the two CLI validation tests, and the workflow provenance assertion.
- `git diff --check origin/main...HEAD` passed.
- Pre-commit dirty autoreview passed with no actionable findings (0.96 confidence).
- Committed branch autoreview against `origin/main` passed with no actionable findings (0.99 confidence).
- `pnpm run check` passed formatting, all three builds, all lint lanes, the changed coverage gate, and the changed ledger/workflow tests. Its full-suite tail hit seven unrelated `test/repair/target-validation.test.ts` fixture failures because their isolated package mirrors could not resolve pinned `pnpm@10.33.0`; exact-head hosted CI is the authoritative follow-up for that environment-only gap.

Production LOC: +46/-5 (net +41) | Tests: +90/-0. The production growth introduces the explicit bounded provenance contract, validates it fail-closed at the CLI/runtime boundary, and binds the sole retry-aware workflow consumer to it.

## Real Behavior Proof

- **Claim:** an attempt-2 publisher can import a retained successful attempt-1 review ledger from the same immutable workflow run without weakening exact provenance elsewhere.
- **Exercised surface:** a fresh PR checkout of current head, the built `dist/clawsweeper.js publish-action-events` command, and the real action-ledger shard writer/importer inside Docker-backed Crabbox.
- **Scenario:** a temporary Node 24 fixture generated a canonical review-completed shard with run ID `31223072940`, producer job `review`, and attempt 1. The built publisher then ran as job `publish`, attempt 2, first in exact mode and then with the new maximum-attempt constraint.
- **Command and environment:** local-container Crabbox `cbx_a2bd315ceba0` (`pearl-lobster`), image `node:24-bookworm`, Node `v24.19.0`, fresh PR checkout at `0e1dc0fe7fa9c0afaaf7379979061a27fa90fe9c`; no credentials or hydration. The uploaded proof script installed the frozen lockfile, built all TypeScript surfaces, ran the built CLI scenario, and ran the focused runtime/workflow tests.
- **Observed result:** exit 0 in 14.846 seconds total. Exact mode rejected attempt 1 against attempt 2; bounded mode created one shard; attempt 3 was rejected against maximum attempt 2. The two runtime provenance tests and workflow provenance assertion passed 3/3.
- **Artifact or trace:** the redacted stdout trace was:

```json
{
  "schema": "clawsweeper.rerun-ledger-proof",
  "schema_version": 1,
  "head": "0e1dc0fe7fa9c0afaaf7379979061a27fa90fe9c",
  "immutable_identity": {
    "repository": "openclaw/clawsweeper",
    "sha": "0e1dc0fe7fa9c0afaaf7379979061a27fa90fe9c",
    "workflow": "sweep.yml",
    "job": "review",
    "run_id": "31223072940"
  },
  "retained_attempt": {
    "producer_run_attempt": 1,
    "publisher_run_attempt": 2,
    "exact_mode": "rejected: expected 2, got 1",
    "bounded_mode": "accepted",
    "created_shards": 1
  },
  "future_attempt": {
    "producer_run_attempt": 3,
    "publisher_max_run_attempt": 2,
    "bounded_mode": "rejected: expected at most 2, got 3"
  }
}
```

- **Cleanup:** the lease reported `leaseStopped: true`; no container remains.
- **Limits:** this is a current-head Docker-backed built-CLI proof, not a deployed Actions rerun. The live canary is a safe retry/backfill after merge.

## Root Cause and Provenance

The authenticated importer compared every producer field for exact equality. That is correct for ordinary and manifest-bound imports, but the sweep publisher is a retry collector: GitHub reruns preserve successful artifacts from prior attempts under the same immutable run ID. The publisher supplied its current attempt as though it were the producer attempt, conflating collector generation with artifact generation.

The exact-attempt validation was introduced in `7ecb1fdc631ed17f9a9a20ae010ee1e087e3693c` as part of [#521](https://github.com/openclaw/clawsweeper/pull/521). Blame identifies @vincentkoc as code author and #521 merger; the defect became observable in the August 7 rerun above.

## Best-Fix Assessment

**Best-fix verdict:** best owner-boundary repair. The importer owns provenance semantics, while the workflow caller owns whether it is an exact producer handoff or a retry collector.

**Alternatives considered:** removing the attempt check would weaken all imports and was rejected; rewriting downloaded shards to the collector attempt would forge provenance and was rejected; rerunning every successful review shard would waste model work and still encode the wrong artifact-ownership contract.

**Remaining uncertainty:** no post-merge deployed rerun has exercised the new workflow source yet. The safe canary/backfill is tracked as the landing follow-up.
