### PR TITLE
perf(github): route sweep public reads off App tokens

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4168,6 +4168,7 @@ jobs:
         working-directory: clawsweeper
         env:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ needs.plan.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.codex-inspection-token.outputs.token }}
           ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.review_options.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1077,8 +1077,8 @@ jobs:
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' && steps.reserve-exact-review-lease.outputs.status == 'posted' }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
-          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}
+          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token }}
           ADDITIONAL_PROMPT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).additionalPrompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}
           EXACT_REVIEW_ITEM_KEY: ${{ steps.claim-exact-review-queue.outputs.item_key }}
@@ -1349,6 +1349,7 @@ jobs:
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}
           REPO_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
@@ -2333,6 +2334,7 @@ jobs:
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ steps.publication-context.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}
           REPO_TOKEN: ${{ github.token }}
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
@@ -2697,7 +2699,7 @@ jobs:
         id: confirm-terminal-item
         if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.release-terminal-review-leases.outcome == 'success' }}
         env:
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          GH_TOKEN: ${{ steps.publication-context.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-write-token.outputs.token }}
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
           ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
         run: |
@@ -4166,7 +4168,7 @@ jobs:
         working-directory: clawsweeper
         env:
           GH_TOKEN: ${{ steps.target-read-token.outputs.token || github.token }}
-          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.codex-inspection-token.outputs.token || github.token }}
+          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.codex-inspection-token.outputs.token }}
           ADDITIONAL_PROMPT: ${{ github.event.inputs.additional_prompt || github.event.client_payload.review_options.additional_prompt || github.event.client_payload.additional_prompt || '' }}
           EXACT_ITEM: ${{ github.event.client_payload.item_number || github.event.inputs.item_number || github.event.inputs.item_numbers || '' }}
           EXPECTED_SOURCE_REVISION: ${{ github.event.client_payload.expected_source_revision || '' }}
@@ -4768,6 +4770,7 @@ jobs:
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ needs.plan.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ needs.plan.outputs.target_repo }}
         run: |
@@ -5276,15 +5279,15 @@ jobs:
       - name: Select target read token
         id: target-token
         env:
-          APP_TOKEN: ${{ steps.target-read-token.outputs.token }}
-          FALLBACK_TOKEN: ${{ github.token }}
+          PRIMARY_TOKEN: ${{ github.token }}
+          APP_FALLBACK_TOKEN: ${{ steps.target-read-token.outputs.token }}
         run: |
-          if [ -n "$APP_TOKEN" ]; then
-            echo "Using ClawSweeper App token for audit reads."
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+          if [ -n "$PRIMARY_TOKEN" ]; then
+            echo "Using workflow token for public audit reads."
+            echo "token=$PRIMARY_TOKEN" >> "$GITHUB_OUTPUT"
           else
-            echo "Using workflow token fallback for public audit reads."
-            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "Using ClawSweeper App token fallback for audit reads."
+            echo "token=$APP_FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create state token
@@ -5416,8 +5419,12 @@ jobs:
             exit 1
           fi
           target_slug="$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g')"
+          target_owner="${target_repo%%/*}"
+          target_name="${target_repo#*/}"
           echo "target_repo=$target_repo" >> "$GITHUB_OUTPUT"
           echo "target_slug=$target_slug" >> "$GITHUB_OUTPUT"
+          echo "target_repo_owner=$target_owner" >> "$GITHUB_OUTPUT"
+          echo "target_repo_name=$target_name" >> "$GITHUB_OUTPUT"
 
       - name: Resolve proof artifact identity
         id: proof-artifact
@@ -5531,6 +5538,20 @@ jobs:
       - uses: ./.github/actions/setup-openclaw
         if: ${{ steps.proof-select.outputs.item_numbers != '' }}
 
+      - name: Create target proof inspection token
+        id: proof-inspection-token
+        if: ${{ steps.proof-select.outputs.item_numbers != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ steps.target.outputs.target_repo_owner }}
+          repositories: ${{ steps.target.outputs.target_repo_name }}
+          permission-contents: read
+          permission-issues: read
+          permission-pull-requests: read
+
       - name: Generate bound close coverage proofs
         id: generate-apply-proofs
         if: ${{ steps.proof-select.outputs.item_numbers != '' }}
@@ -5538,7 +5559,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_TOKEN: ${{ github.token }}
-          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ github.token }}
+          CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.proof-inspection-token.outputs.token }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
           set -euo pipefail
@@ -5806,7 +5827,7 @@ jobs:
         if: ${{ !(github.event_name == 'schedule' && github.event.schedule == '6,21,36,51 * * * *') && !(github.event_name == 'workflow_dispatch' && (github.event.inputs.apply_sync_comments_only == 'true' || github.event.inputs.apply_item_numbers == '__cursor__')) }}
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
-          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          GH_TOKEN: ${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-write-token.outputs.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
         run: |
@@ -5822,6 +5843,7 @@ jobs:
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_PUBLIC_GH_TOKEN: ${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}
           CLAWSWEEPER_APPLY_TOKEN_MINTED_AT_MS: ${{ steps.target-write-token.outputs.minted-at-ms }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}

--- a/src/clawsweeper-github-execution.ts
+++ b/src/clawsweeper-github-execution.ts
@@ -24,6 +24,7 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
   const { ROOT, gitHubRuntime, labelAlreadyExistsError } = dependencies;
   const {
     GitHubRuntimeBudgetError,
+    claimPublicReadFallback,
     ensureGitHubRetryFits,
     ensureGitHubRuntimeAvailable,
     gh,
@@ -38,14 +39,45 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
     attempts = configuredGitHubRetryAttempts(),
     options: GitHubRetryOptions = {},
   ): string {
+    let activeEnv: NodeJS.ProcessEnv | undefined;
     let lastError: unknown;
     for (let attempt = 0; attempt < attempts; attempt += 1) {
       try {
-        return options.request?.(args, attempt) ?? gh(args);
+        return (
+          options.request?.(args, attempt) ??
+          (activeEnv ? ghWithPreparedTimeout(args, githubCommandTimeoutMs(), activeEnv) : gh(args))
+        );
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         lastError = error;
         const retryKind = ghRetryKind(error);
+        const fallback =
+          retryKind === "throttle" && !options.request ? claimPublicReadFallback(args) : null;
+        if (retryKind === "throttle" && fallback) {
+          activeEnv = fallback;
+          try {
+            return ghWithPreparedTimeout(args, githubCommandTimeoutMs(), fallback);
+          } catch (fallbackError) {
+            if (fallbackError instanceof GitHubRuntimeBudgetError) throw fallbackError;
+            lastError = fallbackError;
+            const fallbackRetryKind = ghRetryKind(fallbackError);
+            if (fallbackRetryKind === "throttle") {
+              throw new GitHubRateLimitError(fallbackError);
+            }
+            ensureGitHubRuntimeAvailable("after GitHub operation");
+            if (fallbackRetryKind === "none" || attempt === attempts - 1) {
+              throw fallbackError;
+            }
+            const waitMs = ghRetryWaitMs(fallbackRetryKind, attempt);
+            ensureGitHubRetryFits(waitMs);
+            console.error(
+              `Transient GitHub API failure; retrying ${summarizeGhArgs(args)} in ${Math.round(waitMs / 1000)}s`,
+            );
+            if (options.sleepBeforeRetry) options.sleepBeforeRetry(waitMs);
+            else sleepBeforeGitHubRetry(waitMs);
+            continue;
+          }
+        }
         if (retryKind === "throttle") throw new GitHubRateLimitError(error);
         ensureGitHubRuntimeAvailable("after GitHub operation");
         if (retryKind === "none" || attempt === attempts - 1) throw error;

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -2,7 +2,10 @@ import { spawnSync } from "node:child_process";
 import type { GitHubRuntimeBudget } from "./clawsweeper-types.js";
 import { codexEnv } from "./codex-env.js";
 import { resolveCommand } from "./command.js";
-import { exactPublicationPublicReadToken } from "./github-public-read.js";
+import {
+  exactPublicationPublicReadToken,
+  isPublicOpenClawReadOnlyRequest,
+} from "./github-public-read.js";
 
 interface CreateGitHubRuntimeDependencies {
   ROOT: string;
@@ -13,6 +16,8 @@ interface CreateGitHubRuntimeDependencies {
   ) => string;
   targetRepo: () => string;
 }
+
+const claimedPublicReadFallbackTokens = new Set<string>();
 
 export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencies) {
   const { ROOT, run, targetRepo } = dependencies;
@@ -98,12 +103,67 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
     sleepMs(waitMs);
   }
 
-  function ghWithPreparedTimeout(args: string[], timeoutMs: number | undefined): string {
+  function publicReadToken(
+    args: readonly string[],
+    overrides: NodeJS.ProcessEnv = {},
+  ): string | null {
+    const publicToken = process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN?.trim();
+    const env = { ...process.env, ...overrides };
+    if (
+      !publicToken ||
+      Object.hasOwn(overrides, "GH_TOKEN") ||
+      Object.hasOwn(overrides, "GITHUB_TOKEN") ||
+      (env.GH_HOST && env.GH_HOST.toLowerCase() !== "github.com") ||
+      !isPublicOpenClawReadOnlyRequest(args)
+    ) {
+      return null;
+    }
+    return publicToken;
+  }
+
+  function preparedGitHubEnv(
+    args: readonly string[],
+    overrides: NodeJS.ProcessEnv = {},
+  ): NodeJS.ProcessEnv | undefined {
+    const hasExplicitToken =
+      Object.hasOwn(overrides, "GH_TOKEN") || Object.hasOwn(overrides, "GITHUB_TOKEN");
+    const token =
+      publicReadToken(args, overrides) ??
+      (hasExplicitToken
+        ? null
+        : exactPublicationPublicReadToken(args, targetRepo(), {
+            ...process.env,
+            ...overrides,
+          }));
+    if (token) return { ...overrides, GH_TOKEN: token };
+    return Object.keys(overrides).length > 0 ? overrides : undefined;
+  }
+
+  function claimPublicReadFallback(args: readonly string[]): NodeJS.ProcessEnv | null {
+    const publicToken = publicReadToken(args);
+    const appToken = process.env.GH_TOKEN?.trim();
+    if (
+      !publicToken ||
+      !appToken ||
+      publicToken === appToken ||
+      claimedPublicReadFallbackTokens.has(appToken)
+    ) {
+      return null;
+    }
+    claimedPublicReadFallbackTokens.add(appToken);
+    return { GH_TOKEN: appToken };
+  }
+
+  function ghWithPreparedTimeout(
+    args: string[],
+    timeoutMs: number | undefined,
+    env: NodeJS.ProcessEnv = {},
+  ): string {
     const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
-    const publicReadToken = exactPublicationPublicReadToken(resolvedArgs, targetRepo());
+    const preparedEnv = preparedGitHubEnv(resolvedArgs, env);
     return run("gh", resolvedArgs, {
       timeoutMs,
-      ...(publicReadToken ? { env: { GH_TOKEN: publicReadToken } } : {}),
+      ...(preparedEnv ? { env: preparedEnv } : {}),
     });
   }
 
@@ -113,11 +173,10 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
 
   function ghOnce(args: string[], timeoutMs: number): string {
     const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
-    const publicReadToken = exactPublicationPublicReadToken(resolvedArgs, targetRepo());
     const env = {
       ...process.env,
       GIT_OPTIONAL_LOCKS: "0",
-      ...(publicReadToken ? { GH_TOKEN: publicReadToken } : {}),
+      ...preparedGitHubEnv(resolvedArgs),
     };
     const command = resolveCommand("gh", resolvedArgs, env);
     const commandTimeoutMs = githubCommandTimeoutMs(timeoutMs) ?? timeoutMs;
@@ -181,6 +240,7 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
 
   return {
     GitHubRuntimeBudgetError,
+    claimPublicReadFallback,
     ensureGitHubRetryFits,
     ensureGitHubRuntimeAvailable,
     ensureRuntimeDelayFits,

--- a/src/github-public-read.ts
+++ b/src/github-public-read.ts
@@ -1,6 +1,7 @@
 export function isPublicOpenClawReadOnlyRequest(ghArgs: readonly string[]): boolean {
   if (ghArgs[0] !== "api") return false;
-  const endpoint = ghArgs[1] ?? "";
+  const endpointIndex = ghArgs[1] === "-i" ? 2 : 1;
+  const endpoint = ghArgs[endpointIndex] ?? "";
   const endpointPath = endpoint.split("?", 1)[0] ?? "";
   if (!/^repos\/openclaw\/openclaw\/(?:issues|pulls)(?:\/|$)/.test(endpointPath)) {
     return false;
@@ -13,7 +14,7 @@ export function isPublicOpenClawReadOnlyRequest(ghArgs: readonly string[]): bool
     return false;
   }
 
-  for (let index = 2; index < ghArgs.length; index += 1) {
+  for (let index = endpointIndex + 1; index < ghArgs.length; index += 1) {
     const flag = ghArgs[index];
     if (flag === "--paginate" || flag === "--slurp") continue;
     if ((flag === "--jq" || flag === "-q") && index + 1 < ghArgs.length) {

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2205,7 +2205,10 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(eventReviewBlock, /cancel-in-progress: false/);
-  assert.match(exactReviewStep, /GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/);
+  assert.match(
+    exactReviewStep,
+    /GH_TOKEN: \$\{\{ steps\.target\.outputs\.target_repo == 'openclaw\/openclaw' && github\.token \|\| steps\.target-read-token\.outputs\.token \}\}/,
+  );
   assert.match(exactReviewStep, /--readonly-openclaw/);
   assert.match(exactReviewStep, /--skip-start-comment/);
   assert.ok(claimIndex >= 0);

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -107,11 +107,12 @@ test("transient retries stay bounded while GitHub throttles defer immediately", 
   }
 });
 
-test("exact publication spends workflow credentials only on public target REST reads", () => {
+test("sweep runtime routes only public target REST reads onto the public token", () => {
   const fixtureEnv = {
     EXACT_EVENT_PUBLICATION: "true",
     GH_TOKEN: "target-app-token",
     REPO_TOKEN: "workflow-repository-token",
+    CLAWSWEEPER_PUBLIC_GH_TOKEN: "public-read-token",
     GH_BIN: process.execPath,
     GH_BIN_ARGS: JSON.stringify([
       "--eval",
@@ -145,8 +146,12 @@ test("exact publication spends workflow credentials only on public target REST r
     run,
     targetRepo: () => currentTarget,
   });
-  const observed = (args: string[], timeoutMs: number | undefined = 5_000) =>
-    JSON.parse(runtime.ghWithPreparedTimeout(args, timeoutMs)) as {
+  const observed = (
+    args: string[],
+    timeoutMs: number | undefined = 5_000,
+    env: NodeJS.ProcessEnv = {},
+  ) =>
+    JSON.parse(runtime.ghWithPreparedTimeout(args, timeoutMs, env)) as {
       token: string;
       args: string[];
       timeoutMs?: number;
@@ -159,13 +164,13 @@ test("exact publication spends workflow credentials only on public target REST r
       ["api", "repos/openclaw/openclaw/pulls/123/reviews?per_page=100", "--paginate", "--slurp"],
       ["api", "repos/openclaw/openclaw/pulls/123", "--jq", ".requested_reviewers"],
     ]) {
-      assert.equal(observed(args).token, "workflow-repository-token", args.join(" "));
+      assert.equal(observed(args).token, "public-read-token", args.join(" "));
     }
 
     const publicArgs = ["api", "repos/openclaw/openclaw/issues/comments/123"];
     assert.equal(observed(publicArgs, 1234).timeoutMs, 1234);
-    assert.equal(JSON.parse(runtime.gh(publicArgs)).token, "workflow-repository-token");
-    assert.equal(JSON.parse(runtime.ghOnce(publicArgs, 10_000)).token, "workflow-repository-token");
+    assert.equal(JSON.parse(runtime.gh(publicArgs)).token, "public-read-token");
+    assert.equal(JSON.parse(runtime.ghOnce(publicArgs, 10_000)).token, "public-read-token");
 
     const privateRequests = [
       ["api", "user"],
@@ -185,6 +190,14 @@ test("exact publication spends workflow credentials only on public target REST r
       assert.equal(observed(args).token, "target-app-token", args.join(" "));
     }
     assert.equal(JSON.parse(runtime.ghOnce(privateRequests[6]!, 10_000)).token, "target-app-token");
+    assert.equal(
+      observed(publicArgs, 5_000, { GH_TOKEN: "explicit-token" }).token,
+      "explicit-token",
+    );
+    assert.equal(
+      observed(publicArgs, 5_000, { GITHUB_TOKEN: "explicit-github-token" }).token,
+      "target-app-token",
+    );
 
     const execution = createGitHubExecution({
       ROOT: process.cwd(),
@@ -207,20 +220,81 @@ test("exact publication spends workflow credentials only on public target REST r
     );
 
     process.env.EXACT_EVENT_PUBLICATION = "false";
+    process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN = "   ";
     assert.equal(observed(publicArgs).token, "target-app-token");
+    delete process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN;
+    assert.equal(observed(publicArgs).token, "target-app-token");
+
     process.env.EXACT_EVENT_PUBLICATION = "true";
+    assert.equal(observed(publicArgs).token, "workflow-repository-token");
+
+    process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN = "public-read-token";
 
     currentTarget = "openclaw/private";
-    assert.equal(observed(publicArgs).token, "target-app-token");
+    assert.equal(observed(publicArgs).token, "public-read-token");
     currentTarget = "openclaw/openclaw";
 
     process.env.GH_HOST = "enterprise.example.invalid";
     assert.equal(observed(publicArgs).token, "target-app-token");
     delete process.env.GH_HOST;
 
+    delete process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN;
     delete process.env.REPO_TOKEN;
     assert.equal(observed(publicArgs).token, "target-app-token");
     assert.ok(requests.length > privateRequests.length);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("sweep public read throttles fall back once to the ambient App token", () => {
+  const fixtureEnv = {
+    GH_TOKEN: "sweep-fallback-app-token",
+    CLAWSWEEPER_PUBLIC_GH_TOKEN: "sweep-fallback-public-token",
+  };
+  const previous = Object.fromEntries(
+    Object.keys(fixtureEnv).map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, fixtureEnv);
+
+  const observedTokens: string[] = [];
+  const run = (
+    _command: string,
+    _args: string[],
+    options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeoutMs?: number },
+  ) => {
+    const token = options?.env?.GH_TOKEN ?? process.env.GH_TOKEN ?? "";
+    observedTokens.push(token);
+    if (token === fixtureEnv.CLAWSWEEPER_PUBLIC_GH_TOKEN) {
+      throw new Error("gh: API rate limit exceeded for installation (HTTP 403)");
+    }
+    return JSON.stringify({ token });
+  };
+  const runtime = createGitHubRuntime({
+    ROOT: process.cwd(),
+    run,
+    targetRepo: () => "openclaw/openclaw",
+  });
+  const execution = createGitHubExecution({
+    ROOT: process.cwd(),
+    gitHubRuntime: runtime,
+    labelAlreadyExistsError: () => false,
+  });
+
+  try {
+    const args = ["api", "repos/openclaw/openclaw/issues/123"];
+    assert.equal(JSON.parse(execution.ghWithRetry(args)).token, fixtureEnv.GH_TOKEN);
+    assert.deepEqual(observedTokens, [fixtureEnv.CLAWSWEEPER_PUBLIC_GH_TOKEN, fixtureEnv.GH_TOKEN]);
+
+    assert.throws(() => execution.ghWithRetry(args), { name: "GitHubRateLimitError" });
+    assert.deepEqual(observedTokens, [
+      fixtureEnv.CLAWSWEEPER_PUBLIC_GH_TOKEN,
+      fixtureEnv.GH_TOKEN,
+      fixtureEnv.CLAWSWEEPER_PUBLIC_GH_TOKEN,
+    ]);
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];
@@ -513,6 +587,7 @@ function githubRetryExecution(
     run: request,
     gitHubRuntime: {
       GitHubRuntimeBudgetError: TestGitHubRuntimeBudgetError,
+      claimPublicReadFallback: () => null,
       ensureGitHubRetryFits: () => undefined,
       ensureGitHubRuntimeAvailable: () => undefined,
       gh: request,

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -160,6 +160,7 @@ test("sweep runtime routes only public target REST reads onto the public token",
   try {
     for (const args of [
       ["api", "repos/openclaw/openclaw/issues/123"],
+      ["api", "-i", "repos/openclaw/openclaw/issues/123/timeline?per_page=100"],
       ["api", "repos/openclaw/openclaw/issues/123/comments?per_page=100", "--paginate", "--slurp"],
       ["api", "repos/openclaw/openclaw/pulls/123/reviews?per_page=100", "--paginate", "--slurp"],
       ["api", "repos/openclaw/openclaw/pulls/123", "--jq", ".requested_reviewers"],
@@ -184,6 +185,7 @@ test("sweep runtime routes only public target REST reads onto the public token",
       ["api", "repos/openclaw/openclaw/issues/123", "-f", "body=mutated"],
       ["api", "repos/openclaw/openclaw/issues/123", "--input", "payload.json"],
       ["api", "repos/openclaw/openclaw/issues/123", "--hostname", "example.invalid"],
+      ["api", "-i", "repos/openclaw/openclaw/issues/123", "--method", "PATCH"],
       ["pr", "view", "123"],
     ];
     for (const args of privateRequests) {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -4736,6 +4736,10 @@ test("public OpenClaw reads use workflow tokens without moving mutation identity
   const reviewShard = find("review", "Review shard");
   const applyProof = find("apply-proof", "Generate bound close coverage proofs");
   assert.equal(
+    reviewShard.env?.CLAWSWEEPER_PUBLIC_GH_TOKEN,
+    "${{ needs.plan.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}",
+  );
+  assert.equal(
     exactReview.env?.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
     "${{ steps.target-read-token.outputs.token }}",
   );

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -406,8 +406,9 @@ test("review workflow gives Codex a read-only inspection token", () => {
   assert.match(workflow, /CLAWSWEEPER_PROOF_INSPECTION_TOKEN/);
   assert.match(
     exactReviewStep,
-    /CLAWSWEEPER_PROOF_INSPECTION_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \|\| github\.token \}\}/,
+    /CLAWSWEEPER_PROOF_INSPECTION_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/,
   );
+  assert.doesNotMatch(workflow, /CLAWSWEEPER_PROOF_INSPECTION_TOKEN:.*github\.token/);
   assert.match(
     exactReviewStep,
     /report_path="artifacts\/event\/\$\{\{ steps\.target\.outputs\.item_number \}\}\.md"/,
@@ -449,7 +450,7 @@ test("review execution tokens can read check runs and commit statuses", () => {
   }
   assert.match(
     eventReviewJob,
-    /Review exact event item[\s\S]*GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/,
+    /Review exact event item[\s\S]*GH_TOKEN: \$\{\{ steps\.target\.outputs\.target_repo == 'openclaw\/openclaw' && github\.token \|\| steps\.target-read-token\.outputs\.token \}\}/,
   );
 });
 
@@ -599,6 +600,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.equal(
     step(reviewer, "Review exact event item").env?.GH_TOKEN,
+    "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}",
+  );
+  assert.equal(
+    step(reviewer, "Review exact event item").env?.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
     "${{ steps.target-read-token.outputs.token }}",
   );
   assert.equal(step(reviewer, "Review exact event item").env?.REPO_TOKEN, undefined);
@@ -4625,6 +4630,7 @@ test("sweep target tokens fall back when an org app installation is missing", ()
     "Create target write token",
     "Create target review token",
     "Create target Codex inspection token",
+    "Create target proof inspection token",
   ]) {
     const blocks = stepBlocks(name);
     assert.ok(blocks.length > 0, `missing workflow step: ${name}`);
@@ -4638,8 +4644,9 @@ test("sweep target tokens fall back when an org app installation is missing", ()
   );
   assert.match(
     workflow,
-    /CLAWSWEEPER_PROOF_INSPECTION_TOKEN: \$\{\{ steps\.codex-inspection-token\.outputs\.token \|\| github\.token \}\}/,
+    /CLAWSWEEPER_PROOF_INSPECTION_TOKEN: \$\{\{ steps\.codex-inspection-token\.outputs\.token \}\}/,
   );
+  assert.doesNotMatch(workflow, /CLAWSWEEPER_PROOF_INSPECTION_TOKEN:.*\|\| github\.token/);
   assert.ok(
     workflow.includes(
       "if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && needs.plan.outputs.hot_intake != 'true'",
@@ -4656,6 +4663,95 @@ test("sweep target tokens fall back when an org app installation is missing", ()
     ),
   );
   assert.doesNotMatch(workflow, new RegExp("OPENCLAW_" + "GH_TOKEN"));
+});
+
+test("public OpenClaw reads use workflow tokens without moving mutation identity", () => {
+  type Step = {
+    name?: string;
+    id?: string;
+    env?: Record<string, string>;
+    run?: string;
+    with?: Record<string, string>;
+  };
+  type Workflow = { jobs: Record<string, { steps: Step[] }> };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as Workflow;
+  const find = (job: string, name: string) => {
+    const selected = workflow.jobs[job]?.steps.find(
+      (candidate) => candidate.name === name || candidate.id === name,
+    );
+    assert.ok(selected, `${job}: ${name}`);
+    return selected;
+  };
+
+  const exactReview = find("event-review-apply", "Review exact event item");
+  assert.equal(
+    exactReview.env?.GH_TOKEN,
+    "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}",
+  );
+  assert.equal(
+    find("event-review-publish", "Confirm terminal item remains closed").env?.GH_TOKEN,
+    "${{ steps.publication-context.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-write-token.outputs.token }}",
+  );
+  assert.equal(
+    find("apply-existing", "Reconcile before apply preselect").env?.GH_TOKEN,
+    "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-write-token.outputs.token }}",
+  );
+
+  const auditSelection = find("audit-dashboard", "Select target read token");
+  assert.equal(auditSelection.env?.PRIMARY_TOKEN, "${{ github.token }}");
+  assert.equal(
+    auditSelection.env?.APP_FALLBACK_TOKEN,
+    "${{ steps.target-read-token.outputs.token }}",
+  );
+  assert.match(auditSelection.run ?? "", /Using workflow token for public audit reads/);
+  assert.match(auditSelection.run ?? "", /Using ClawSweeper App token fallback for audit reads/);
+
+  for (const [job, name, expression] of [
+    [
+      "event-review-apply",
+      "Deliver GitHub effects and prepare direct state mutation",
+      "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}",
+    ],
+    [
+      "event-review-publish",
+      "Publish event result and apply safe close",
+      "${{ steps.publication-context.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}",
+    ],
+    [
+      "publish",
+      "Sync selected review comments",
+      "${{ needs.plan.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}",
+    ],
+    [
+      "apply-existing",
+      "Apply unchanged proposed decisions with checkpoints",
+      "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || '' }}",
+    ],
+  ] as const) {
+    const selected = find(job, name);
+    assert.equal(selected.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
+    assert.equal(selected.env?.CLAWSWEEPER_PUBLIC_GH_TOKEN, expression);
+  }
+
+  const reviewShard = find("review", "Review shard");
+  const applyProof = find("apply-proof", "Generate bound close coverage proofs");
+  assert.equal(
+    exactReview.env?.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
+    "${{ steps.target-read-token.outputs.token }}",
+  );
+  assert.equal(
+    reviewShard.env?.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
+    "${{ steps.codex-inspection-token.outputs.token }}",
+  );
+  assert.equal(
+    applyProof.env?.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
+    "${{ steps.proof-inspection-token.outputs.token }}",
+  );
+  assert.equal(applyProof.env?.GH_TOKEN, "${{ github.token }}");
+  const proofInspectionToken = find("apply-proof", "Create target proof inspection token");
+  assert.equal(proofInspectionToken.with?.["permission-contents"], "read");
+  assert.equal(proofInspectionToken.with?.["permission-issues"], "read");
+  assert.equal(proofInspectionToken.with?.["permission-pull-requests"], "read");
 });
 
 test("sweep target review token can post pull request review leases", () => {


### PR DESCRIPTION
## Summary

The sweep lanes—scheduled and exact-event review, publication, comment sync, and apply—still performed target-repository reads on the shared GitHub App installation token. That installation has been exhausting its 15,000 requests/hour allowance and producing 403s in production.

This extends the incumbent `CLAWSWEEPER_PUBLIC_GH_TOKEN` convention from https://github.com/openclaw/clawsweeper/pull/1034, hardened by https://github.com/openclaw/clawsweeper/pull/1054, to the sweep runtime. It uses the same route classification and bounded once-per-run App-token throttle fallback.

It also flips the exact-event review runtime and two verified-read-only steps to the repository-conditional workflow-token pattern already used by the live-item probe, removes every `github.token` fallback from Codex proof-inspection tokens, and gives apply proof a dedicated read-only App inspection mint.

OpenClaw Bay is unaffected: this changes internal GitHub credential routing only, with no observer data-contract or action-surface change.

## Review finding disposition

- Resolved the header-read P1: the shared public-read classifier accepts the safe `gh api -i <endpoint>` form used by timeline hydration, while the same shape with `--method PATCH` remains on the App token.
- Resolved the scheduled-review P1: the regular `Review shard` now receives the repository-conditional workflow token in `CLAWSWEEPER_PUBLIC_GH_TOKEN`, while retaining its target App credential in `GH_TOKEN` for bounded fallback.

## Proof

- Claim: sweep public reads, including scheduled review and header-bearing timeline hydration, route away from the shared App token while mutations and bounded fallback behavior remain intact.
- Current head: `c8898f9d807bb5eed7b1bb872c22544b76e04505`.
- Exercised surface: compiled sweep GitHub runtime and execution boundary, scheduled and exact-event review routing, public-token throttle handling, App fallback, and the shared repair classifier.
- Scenario: `gh api -i repos/openclaw/openclaw/issues/123/timeline?per_page=100`; the public route is deterministically throttled, the App route succeeds once, and a second public throttle cannot claim the App fallback again.
- Environment: Docker `node:24-bookworm` inside Crabbox provider `aws`, lease `cbx_d72f87c5ebd6`, run `run_6b73750759b3`.
- Observable trace: `public,app,public`; first throttle result `app-fallback-success`; second throttle result `GitHubRateLimitError`; invariant `pass`.
- Exact assertions: scheduled workflow-token routing, header-read public routing, and once-per-run fallback all passed in the Docker-backed run (3 passed, 0 failed).
- Content binding: `.github/workflows/sweep.yml` SHA-256 `2bb0c3500f49d1a9e274f93afe04ed8790c941eaa6a5442e0bb9b9fbb8cdcbe8`; `src/github-public-read.ts` SHA-256 `88ac66a302a9f25331dd0be09b028fd78738aea812bd993725563d329dff7cb3`; `test/sweep-workflow.test.ts` SHA-256 `fd8d4e4483aa9393001c3827532fde72cfd27e91125717b43b4a119ea5e0c3a4`; `test/repair/exact-review-batch-workflow.test.ts` SHA-256 `ac93fb1779a198e38aeb4b7a396640a57dda7386bdddf070cbd4f62401b17120`.
- Full local gate: `pnpm run check` passed on Node 24 in 272 seconds: 3,196 tests, 3,187 passed, 9 skipped, 0 failed; all builds, lint, formatting, and coverage thresholds passed.
- Review: fresh pre-commit and committed-branch autoreviews reported no accepted/actionable findings.
- Limits: the 403 is injected deterministically through the real compiled runtime/subprocess boundary; production token exhaustion was not induced and no credential values were recorded.
