### PR TITLE
fix(recovery): rotate placeholder discovery cursors

### DIFF
--- a/.github/workflows/exact-review-reconcile.yml
+++ b/.github/workflows/exact-review-reconcile.yml
@@ -233,6 +233,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_WRITE_TOKEN: ${{ steps.target-write-token.outputs.token }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          REVIEW_PLACEHOLDER_CURSOR_STORE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           REVIEW_PLACEHOLDER_LOOKBACK_HOURS: ${{ vars.REVIEW_PLACEHOLDER_LOOKBACK_HOURS || '48' }}
           REVIEW_PLACEHOLDER_MAX_CHECKS: ${{ vars.REVIEW_PLACEHOLDER_MAX_CHECKS || '20' }}
           REVIEW_PLACEHOLDER_MAX_RECOVERIES: ${{ vars.REVIEW_PLACEHOLDER_MAX_RECOVERIES || '5' }}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -488,10 +488,16 @@ const EXACT_REVIEW_QUEUE_ROLLBACK_CLOCK_SKEW_MS = 5 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_LEGACY_GENERATION_PREFIX = "__clawsweeper_sql_generation:";
 const EXACT_REVIEW_QUEUE_STATE_KEY = "exact-review-queue";
 const EXACT_REVIEW_SOURCE_AUTHORITY_SEQUENCE_KEY = "exact-review-source-authority-sequence:v1";
-const TARGET_FANOUT_CURSOR_KEY_PREFIX = "target-fanout-cursor:v1:";
-type TargetFanoutMode = "hot-intake" | "normal-review" | "audit";
-type TargetFanoutCursor = {
-  mode: TargetFanoutMode;
+// Preserve the original key prefix so existing fanout cursors survive the
+// broader operational-cursor contract introduced for bounded recovery lanes.
+const OPERATIONAL_CURSOR_KEY_PREFIX = "target-fanout-cursor:v1:";
+type OperationalCursorMode =
+  | "hot-intake"
+  | "normal-review"
+  | "audit"
+  | `review-placeholder-${string}-${"open" | "closed"}`;
+type OperationalCursor = {
+  mode: OperationalCursorMode;
   nextCursor: number;
   revision: number;
   updatedAt: number;
@@ -629,12 +635,15 @@ export class ExactReviewQueue {
       this.reviewCoverageCache = null;
       return json({ ok: true, accepted: true }, 202);
     }
-    const targetFanoutMode = targetFanoutModeFromPath(url.pathname);
-    if (targetFanoutMode && request.method === "GET") {
-      return this.readTargetFanoutCursor(targetFanoutMode);
+    const operationalCursorMode = operationalCursorModeFromPath(url.pathname);
+    if (operationalCursorMode && request.method === "GET") {
+      return this.readOperationalCursor(operationalCursorMode);
     }
-    if (targetFanoutMode && request.method === "PUT") {
-      return this.writeTargetFanoutCursor(targetFanoutMode, await request.json().catch(() => null));
+    if (operationalCursorMode && request.method === "PUT") {
+      return this.writeOperationalCursor(
+        operationalCursorMode,
+        await request.json().catch(() => null),
+      );
     }
     if (request.method === "GET" && url.pathname === "/recent-durable-publication-events") {
       const events = this.recentDurablePublicationEvents(
@@ -3092,13 +3101,13 @@ export class ExactReviewQueue {
     return value;
   }
 
-  private readTargetFanoutCursor(mode: TargetFanoutMode) {
-    const stored = readTargetFanoutCursor(this.storage.kv.get(targetFanoutCursorKey(mode)), mode);
+  private readOperationalCursor(mode: OperationalCursorMode) {
+    const stored = readOperationalCursor(this.storage.kv.get(operationalCursorKey(mode)), mode);
     if (stored === "invalid") return json({ error: "fanout_cursor_store_invalid" }, 500);
-    return json(targetFanoutCursorJson(stored ?? emptyTargetFanoutCursor(mode)));
+    return json(operationalCursorJson(stored ?? emptyOperationalCursor(mode)));
   }
 
-  private writeTargetFanoutCursor(mode: TargetFanoutMode, value: unknown) {
+  private writeOperationalCursor(mode: OperationalCursorMode, value: unknown) {
     const body = objectValue(value);
     const nextCursor = Number(body.next_cursor);
     const expectedRevision = Number(body.expected_revision);
@@ -3112,25 +3121,22 @@ export class ExactReviewQueue {
     }
     try {
       const result = this.storage.transactionSync(() => {
-        const stored = readTargetFanoutCursor(
-          this.storage.kv.get(targetFanoutCursorKey(mode)),
-          mode,
-        );
+        const stored = readOperationalCursor(this.storage.kv.get(operationalCursorKey(mode)), mode);
         if (stored === "invalid") return { kind: "invalid" as const };
-        const current = stored ?? emptyTargetFanoutCursor(mode);
+        const current = stored ?? emptyOperationalCursor(mode);
         if (current.revision !== expectedRevision) {
           return { kind: "conflict" as const, current };
         }
         if (current.revision >= Number.MAX_SAFE_INTEGER) {
           return { kind: "invalid" as const };
         }
-        const next: TargetFanoutCursor = {
+        const next: OperationalCursor = {
           mode,
           nextCursor,
           revision: current.revision + 1,
           updatedAt: Date.now(),
         };
-        this.storage.kv.put(targetFanoutCursorKey(mode), next);
+        this.storage.kv.put(operationalCursorKey(mode), next);
         return { kind: "written" as const, cursor: next };
       });
       if (result.kind === "invalid") return json({ error: "fanout_cursor_store_invalid" }, 500);
@@ -3138,12 +3144,12 @@ export class ExactReviewQueue {
         return json(
           {
             error: "fanout_cursor_revision_conflict",
-            current: targetFanoutCursorJson(result.current),
+            current: operationalCursorJson(result.current),
           },
           409,
         );
       }
-      return json(targetFanoutCursorJson(result.cursor), 202);
+      return json(operationalCursorJson(result.cursor), 202);
     } catch (error) {
       console.error(`fanout cursor write failed: ${sanitizedServerError(error)}`);
       return json({ error: "fanout_cursor_store_unavailable" }, 503);
@@ -13659,23 +13665,26 @@ function objectValue(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
 }
 
-function targetFanoutModeFromPath(path: string): TargetFanoutMode | null {
-  const match = /^\/cursors\/(hot-intake|normal-review|audit)$/.exec(path);
-  return (match?.[1] as TargetFanoutMode | undefined) ?? null;
+function operationalCursorModeFromPath(path: string): OperationalCursorMode | null {
+  const match =
+    /^\/cursors\/(hot-intake|normal-review|audit|review-placeholder-[a-f0-9]{16}-(?:open|closed))$/.exec(
+      path,
+    );
+  return (match?.[1] as OperationalCursorMode | undefined) ?? null;
 }
 
-function targetFanoutCursorKey(mode: TargetFanoutMode): string {
-  return `${TARGET_FANOUT_CURSOR_KEY_PREFIX}${mode}`;
+function operationalCursorKey(mode: OperationalCursorMode): string {
+  return `${OPERATIONAL_CURSOR_KEY_PREFIX}${mode}`;
 }
 
-function emptyTargetFanoutCursor(mode: TargetFanoutMode): TargetFanoutCursor {
+function emptyOperationalCursor(mode: OperationalCursorMode): OperationalCursor {
   return { mode, nextCursor: 0, revision: 0, updatedAt: 0 };
 }
 
-function readTargetFanoutCursor(
+function readOperationalCursor(
   value: unknown,
-  mode: TargetFanoutMode,
-): TargetFanoutCursor | "invalid" | null {
+  mode: OperationalCursorMode,
+): OperationalCursor | "invalid" | null {
   if (value === undefined) return null;
   const cursor = objectValue(value);
   const nextCursor = Number(cursor.nextCursor);
@@ -13695,7 +13704,7 @@ function readTargetFanoutCursor(
   return { mode, nextCursor, revision, updatedAt };
 }
 
-function targetFanoutCursorJson(cursor: TargetFanoutCursor) {
+function operationalCursorJson(cursor: OperationalCursor) {
   return {
     ok: true,
     mode: cursor.mode,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -550,10 +550,11 @@ export default {
       return authenticatedExactReviewQueueRequest(request, env, "/source-authority");
     if (url.pathname === "/internal/review-coverage/inventory" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/review-coverage/inventory");
-    const fanoutCursorPath = /^\/internal\/state\/cursors\/(hot-intake|normal-review|audit)$/.exec(
-      url.pathname,
-    );
-    if (fanoutCursorPath && (request.method === "GET" || request.method === "PUT"))
+    const operationalCursorPath =
+      /^\/internal\/state\/cursors\/(hot-intake|normal-review|audit|review-placeholder-[a-f0-9]{16}-(?:open|closed))$/.exec(
+        url.pathname,
+      );
+    if (operationalCursorPath && (request.method === "GET" || request.method === "PUT"))
       return authenticatedExactReviewQueueCursorRequest(
         request,
         env,

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -318,9 +318,11 @@ and hot intake `14`. Existing repair lanes keep their
   the two most recently updated pages for sponsorship commands, then alternates
   newest/oldest created-order scans. Reaction-only revival can lag in very large
   archives; raise this override to scan deeper per run.
-- `REVIEW_PLACEHOLDER_MAX_CHECKS` overrides the number of open search candidates
-  examined by each 15-minute orphaned-placeholder recovery pass; the default is
-  20 and the maximum is 1000.
+- `REVIEW_PLACEHOLDER_MAX_CHECKS` overrides the number of search candidates
+  examined per open and closed state class by each 15-minute
+  orphaned-placeholder recovery pass; the default is 20 and the maximum is
+  1000. Independent durable cursors rotate both state classes so non-actionable
+  matches cannot permanently pin later placeholders behind the bounded pass.
 - `REVIEW_PLACEHOLDER_MIN_AGE_HOURS` overrides how old the latest ClawSweeper bot
   review-start placeholder must be before recovery; the default is 2 hours and
   the maximum is 720 hours.

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -8,7 +8,7 @@ operational paths that have not migrated yet.
 | Logical paths | Canonical owner | Git state status |
 | --- | --- | --- |
 | `records/**` | Durable Object record store with R2 snapshots | Never checked out or written |
-| fanout cursor per mode | ExactReviewQueue Durable Object KV | Never checked out or written |
+| fanout and placeholder-recovery cursors per mode | ExactReviewQueue Durable Object KV | Never checked out or written |
 | `ledger/v1/**` | R2 immutable blobs | Never checked out or written |
 | `assets/**` | R2 mutable blobs | Never checked out or written |
 | `jobs/**` | `clawsweeper-state` `state` branch | Retained until its own migration |
@@ -26,12 +26,12 @@ ordinary fetch/commit/push. The former Git lease refs, atomic multi-ref pushes,
 shallow-history deepening, remote-head rebuilds, record reconciliation, and
 immutable-ledger scratch branches no longer exist.
 
-Target fanout reads and updates `/internal/state/cursors/<mode>` with the same
-HMAC authentication as canonical record operations. Each record carries a
-monotonic revision so concurrent writers cannot silently overwrite one another.
-Cursor reads and writes are fail-open: an unavailable store emits a prominent
-warning, but repository dispatch continues so bookkeeping cannot block fleet
-coverage.
+Target fanout and bounded placeholder recovery read and update
+`/internal/state/cursors/<mode>` with the same HMAC authentication as canonical
+record operations. Each record carries a monotonic revision so concurrent
+writers cannot silently overwrite one another. Cursor reads and writes are
+fail-open: an unavailable store emits a prominent warning, but productive work
+continues and remains safe to retry.
 
 Git-backed reports, dashboard status, and post-dispatch cursors are best-effort
 after their productive side effect or canonical publication succeeds. Git

--- a/src/durable-cursor-store.ts
+++ b/src/durable-cursor-store.ts
@@ -1,0 +1,118 @@
+import { createHmac } from "node:crypto";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface DurableCursorSnapshot<Mode extends string = string> {
+  mode: Mode;
+  nextCursor: number;
+  revision: number;
+  updatedAt: string | null;
+}
+
+export type DurableCursorStoreOptions<Mode extends string = string> = {
+  baseUrl: string;
+  webhookSecret: string;
+  mode: Mode;
+  attempts?: number;
+  fetchImpl?: typeof globalThis.fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
+export async function fetchDurableCursor<Mode extends string>(
+  options: DurableCursorStoreOptions<Mode>,
+): Promise<DurableCursorSnapshot<Mode>> {
+  const payload = await durableCursorRequest(options, "GET", "");
+  if (payload.mode !== options.mode) throw new Error("durable cursor response mode mismatch");
+  return {
+    mode: options.mode,
+    nextCursor: nonNegativeNumber(payload.next_cursor, "durable cursor next_cursor"),
+    revision: nonNegativeNumber(payload.revision, "durable cursor revision"),
+    updatedAt:
+      payload.updated_at === null || typeof payload.updated_at === "string"
+        ? payload.updated_at
+        : null,
+  };
+}
+
+export async function putDurableCursor<Mode extends string>(
+  options: DurableCursorStoreOptions<Mode>,
+  nextCursor: number,
+  expectedRevision: number,
+): Promise<DurableCursorSnapshot<Mode>> {
+  const body = JSON.stringify({
+    next_cursor: nonNegativeNumber(nextCursor, "durable cursor next_cursor"),
+    expected_revision: nonNegativeNumber(expectedRevision, "durable cursor expected_revision"),
+  });
+  const payload = await durableCursorRequest(options, "PUT", body);
+  if (payload.mode !== options.mode) throw new Error("durable cursor response mode mismatch");
+  return {
+    mode: options.mode,
+    nextCursor: nonNegativeNumber(payload.next_cursor, "durable cursor next_cursor"),
+    revision: nonNegativeNumber(payload.revision, "durable cursor revision"),
+    updatedAt: typeof payload.updated_at === "string" ? payload.updated_at : null,
+  };
+}
+
+async function durableCursorRequest<Mode extends string>(
+  options: DurableCursorStoreOptions<Mode>,
+  method: "GET" | "PUT",
+  body: string,
+): Promise<JsonRecord> {
+  const baseUrl = options.baseUrl.replace(/\/$/, "");
+  if (!baseUrl.startsWith("https://")) throw new Error("durable cursor store URL must use HTTPS");
+  if (!options.webhookSecret) throw new Error("durable cursor webhook secret is required");
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
+  const attempts = Math.max(1, Math.min(5, Math.floor(options.attempts ?? 3)));
+  const request = options.fetchImpl ?? globalThis.fetch;
+  const sleep =
+    options.sleep ??
+    ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  let lastFailure = "durable cursor request failed";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const init: RequestInit = {
+        method,
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": signature,
+        },
+        signal: AbortSignal.timeout(5_000),
+      };
+      if (method === "PUT") init.body = body;
+      const response = await request(
+        `${baseUrl}/internal/state/cursors/${encodeURIComponent(options.mode)}`,
+        init,
+      );
+      const payload = record(await response.json().catch(() => ({})), "durable cursor response");
+      if (response.ok && payload.ok === true) return payload;
+      lastFailure =
+        typeof payload.error === "string" && payload.error
+          ? payload.error
+          : `http_${response.status}`;
+      if (response.status >= 400 && response.status < 500 && response.status !== 429) break;
+    } catch (error) {
+      lastFailure = errorMessage(error);
+    }
+    if (attempt < attempts) await sleep(attempt * 1_000);
+  }
+  throw new Error(`${method} durable cursor failed: ${lastFailure}`);
+}
+
+function nonNegativeNumber(value: unknown, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) throw new Error(`${label} must be non-negative`);
+  return parsed;
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonRecord;
+}
+
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error))
+    .replace(/[\r\n]+/g, " ")
+    .slice(0, 300);
+}

--- a/src/repair/target-fanout.ts
+++ b/src/repair/target-fanout.ts
@@ -5,6 +5,12 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveCommand } from "../command.js";
+import {
+  fetchDurableCursor,
+  putDurableCursor,
+  type DurableCursorSnapshot,
+  type DurableCursorStoreOptions,
+} from "../durable-cursor-store.js";
 import { fetchExactReviewQueuePressure } from "../queue-pressure.js";
 import { coverageTrackedCountsFromManifest } from "../review-coverage-manifest.js";
 import { parseArgs, repoRoot } from "./lib.js";
@@ -83,21 +89,8 @@ export interface ReviewFanoutRepository extends ReviewPlanningRepository {
   candidateCapacity: number;
 }
 
-export interface FanoutCursorSnapshot {
-  mode: FanoutMode;
-  nextCursor: number;
-  revision: number;
-  updatedAt: string | null;
-}
-
-export type FanoutCursorStoreOptions = {
-  baseUrl: string;
-  webhookSecret: string;
-  mode: FanoutMode;
-  attempts?: number;
-  fetchImpl?: typeof globalThis.fetch;
-  sleep?: (milliseconds: number) => Promise<void>;
-};
+export type FanoutCursorSnapshot = DurableCursorSnapshot<FanoutMode>;
+export type FanoutCursorStoreOptions = DurableCursorStoreOptions<FanoutMode>;
 
 interface FanoutOptions {
   mode: FanoutMode;
@@ -601,17 +594,7 @@ function workflowDispatchArgs(
 export async function fetchFanoutCursor(
   options: FanoutCursorStoreOptions,
 ): Promise<FanoutCursorSnapshot> {
-  const payload = await fanoutCursorRequest(options, "GET", "");
-  if (payload.mode !== options.mode) throw new Error("fanout cursor response mode mismatch");
-  return {
-    mode: options.mode,
-    nextCursor: nonNegativeNumber(payload.next_cursor, "fanout cursor next_cursor"),
-    revision: nonNegativeNumber(payload.revision, "fanout cursor revision"),
-    updatedAt:
-      payload.updated_at === null || typeof payload.updated_at === "string"
-        ? payload.updated_at
-        : null,
-  };
+  return fetchDurableCursor(options);
 }
 
 export async function putFanoutCursor(
@@ -619,18 +602,7 @@ export async function putFanoutCursor(
   nextCursor: number,
   expectedRevision: number,
 ): Promise<FanoutCursorSnapshot> {
-  const body = JSON.stringify({
-    next_cursor: nonNegativeNumber(nextCursor, "fanout cursor next_cursor"),
-    expected_revision: nonNegativeNumber(expectedRevision, "fanout cursor expected_revision"),
-  });
-  const payload = await fanoutCursorRequest(options, "PUT", body);
-  if (payload.mode !== options.mode) throw new Error("fanout cursor response mode mismatch");
-  return {
-    mode: options.mode,
-    nextCursor: nonNegativeNumber(payload.next_cursor, "fanout cursor next_cursor"),
-    revision: nonNegativeNumber(payload.revision, "fanout cursor revision"),
-    updatedAt: typeof payload.updated_at === "string" ? payload.updated_at : null,
-  };
+  return putDurableCursor(options, nextCursor, expectedRevision);
 }
 
 export async function loadFanoutCursor(
@@ -660,50 +632,6 @@ export async function persistFanoutCursorFailOpen(
     );
     return false;
   }
-}
-
-async function fanoutCursorRequest(
-  options: FanoutCursorStoreOptions,
-  method: "GET" | "PUT",
-  body: string,
-): Promise<JsonRecord> {
-  const baseUrl = options.baseUrl.replace(/\/$/, "");
-  if (!baseUrl.startsWith("https://")) {
-    throw new Error("fanout cursor store URL must use HTTPS");
-  }
-  if (!options.webhookSecret) throw new Error("fanout cursor webhook secret is required");
-  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
-  const attempts = Math.max(1, Math.min(5, Math.floor(options.attempts ?? 3)));
-  const request = options.fetchImpl ?? globalThis.fetch;
-  const sleep =
-    options.sleep ??
-    ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
-  let lastFailure = "fanout cursor request failed";
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      const init: RequestInit = {
-        method,
-        headers: {
-          "content-type": "application/json",
-          "x-clawsweeper-exact-review-signature": signature,
-        },
-        signal: AbortSignal.timeout(5_000),
-      };
-      if (method === "PUT") init.body = body;
-      const response = await request(
-        `${baseUrl}/internal/state/cursors/${encodeURIComponent(options.mode)}`,
-        init,
-      );
-      const payload = record(await response.json().catch(() => ({})), "fanout cursor response");
-      if (response.ok && payload.ok === true) return payload;
-      lastFailure = String(payload.error || `http_${response.status}`);
-      if (response.status >= 400 && response.status < 500 && response.status !== 429) break;
-    } catch (error) {
-      lastFailure = errorMessage(error);
-    }
-    if (attempt < attempts) await sleep(attempt * 1_000);
-  }
-  throw new Error(`${method} fanout cursor failed: ${lastFailure}`);
 }
 
 function runGh(args: readonly string[], env: NodeJS.ProcessEnv): string {

--- a/src/review-placeholder-recovery.ts
+++ b/src/review-placeholder-recovery.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  fetchDurableCursor,
+  putDurableCursor,
+  type DurableCursorSnapshot,
+  type DurableCursorStoreOptions,
+} from "./durable-cursor-store.js";
 import {
   REVIEW_RECOVERY_STUCK_LABEL,
   runReviewRecoveryLabelBackfill,
@@ -16,7 +22,7 @@ export const REVIEW_PLACEHOLDER_STUCK_LABEL = REVIEW_RECOVERY_STUCK_LABEL;
 export const DEFAULT_REVIEW_PLACEHOLDER_LOOKBACK_HOURS = 48;
 
 const SEARCH_PAGE_SIZE = 100;
-const SEARCH_MAX_PAGES = 2;
+const SEARCH_RESULT_LIMIT = 1_000;
 const COMMENT_PAGE_SIZE = 100;
 const COMMENT_MAX_PAGES = 5;
 const CLAWSWEEPER_BOT_LOGINS = new Set(["clawsweeper[bot]", "openclaw-clawsweeper[bot]"]);
@@ -47,6 +53,20 @@ export type ReviewPlaceholderRecoverySummary = {
   matched: number;
   remaining: number;
 };
+
+type ReviewPlaceholderState = "open" | "closed";
+type ReviewPlaceholderCursorMode = `review-placeholder-${string}-${ReviewPlaceholderState}`;
+
+export function reviewPlaceholderCursorMode(
+  repository: string,
+  state: ReviewPlaceholderState,
+): ReviewPlaceholderCursorMode {
+  const repositoryKey = createHash("sha256")
+    .update(repository.toLowerCase())
+    .digest("hex")
+    .slice(0, 16);
+  return `review-placeholder-${repositoryKey}-${state}`;
+}
 
 // The scheduled sweep should go red only when placeholders needed resolution
 // and the run resolved none of them; routine transient noise with nothing to
@@ -132,6 +152,11 @@ function candidateUpdatedAtMs(candidate: ReviewPlaceholderCandidate): number {
   return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }
 
+function candidateNumber(candidate: ReviewPlaceholderCandidate): number {
+  const number = Number(candidate.number);
+  return Number.isSafeInteger(number) && number > 0 ? number : Number.MAX_SAFE_INTEGER;
+}
+
 function candidateLabelNames(candidate: ReviewPlaceholderCandidate): string[] {
   if (!Array.isArray(candidate.labels)) return [];
   const names: string[] = [];
@@ -182,6 +207,7 @@ export async function runReviewPlaceholderRecovery(
   const targetBranch = env.TARGET_BRANCH ?? "main";
   const apiUrl = (env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
   const queueUrl = (env.QUEUE_URL ?? "").replace(/\/$/, "");
+  const cursorStoreUrl = (env.REVIEW_PLACEHOLDER_CURSOR_STORE_URL ?? "").replace(/\/$/, "");
   const maximumChecks = boundedPositiveInteger(
     env.REVIEW_PLACEHOLDER_MAX_CHECKS,
     DEFAULT_REVIEW_PLACEHOLDER_MAX_CHECKS,
@@ -219,6 +245,15 @@ export async function runReviewPlaceholderRecovery(
   let errors = 0;
   let actionFailures = 0;
   let matched = 0;
+
+  const cursorStore = (
+    state: ReviewPlaceholderState,
+  ): DurableCursorStoreOptions<ReviewPlaceholderCursorMode> => ({
+    baseUrl: cursorStoreUrl,
+    webhookSecret,
+    mode: reviewPlaceholderCursorMode(repo, state),
+    fetchImpl,
+  });
 
   const summary = (): ReviewPlaceholderRecoverySummary => {
     const remaining = Math.max(0, matched - checked);
@@ -407,56 +442,134 @@ export async function runReviewPlaceholderRecovery(
 
   const candidates = new Map<number, { candidate: ReviewPlaceholderCandidate; closed: boolean }>();
   const updatedSince = new Date(now.getTime() - lookbackHours * 60 * 60 * 1_000).toISOString();
-  // Each state class gets its own check budget; sharing one would let a
-  // backlog of open placeholders permanently starve closed-item cleanup.
-  const searchCandidates = async (stateQualifier: "is:open" | "is:closed"): Promise<void> => {
-    const query = `repo:${repo} "${REVIEW_PLACEHOLDER_MARKER}" in:comments updated:>=${updatedSince} ${stateQualifier}`;
-    const found: ReviewPlaceholderCandidate[] = [];
-    let total = 0;
-    for (let page = 1; page <= SEARCH_MAX_PAGES && found.length < maximumChecks; page += 1) {
-      const result = await github<{ items?: unknown; total_count?: unknown }>(
+  const cursors = new Map<
+    ReviewPlaceholderState,
+    DurableCursorSnapshot<ReviewPlaceholderCursorMode> & { loaded: boolean }
+  >();
+  const cursorUpdates = new Map<ReviewPlaceholderState, number>();
+  for (const state of ["open", "closed"] as const) {
+    if (!cursorStoreUrl) {
+      cursors.set(state, {
+        mode: reviewPlaceholderCursorMode(repo, state),
+        nextCursor: 0,
+        revision: 0,
+        updatedAt: null,
+        loaded: false,
+      });
+      continue;
+    }
+    try {
+      cursors.set(state, { ...(await fetchDurableCursor(cursorStore(state))), loaded: true });
+    } catch (error) {
+      errors += 1;
+      cursors.set(state, {
+        mode: reviewPlaceholderCursorMode(repo, state),
+        nextCursor: 0,
+        revision: 0,
+        updatedAt: null,
+        loaded: false,
+      });
+      console.warn(
+        `review-placeholder ${state} cursor unavailable; starting at 0 without advancing it: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  // Each state class gets its own check budget and durable offset. The cursor
+  // advances through every examined search slot, not only actionable rows, so
+  // a permanent false positive cannot pin later placeholders behind it.
+  const searchCandidates = async (state: ReviewPlaceholderState): Promise<void> => {
+    const query = `repo:${repo} "${REVIEW_PLACEHOLDER_MARKER}" in:comments updated:>=${updatedSince} is:${state}`;
+    const cursor = cursors.get(state)!;
+    const pages = new Map<number, { items: unknown[]; total: number; incomplete: boolean }>();
+    const fetchPage = async (page: number) => {
+      const cached = pages.get(page);
+      if (cached) return cached;
+      const result = await github<{
+        items?: unknown;
+        total_count?: unknown;
+        incomplete_results?: unknown;
+      }>(
         `/search/issues?q=${encodeURIComponent(query)}&sort=updated&order=asc&per_page=${SEARCH_PAGE_SIZE}&page=${page}`,
       );
+      const totalValue = Number(result.total_count);
       const items = Array.isArray(result.items) ? result.items : [];
-      if (page === 1 && typeof result.total_count === "number") {
-        total = Number.isFinite(result.total_count)
-          ? Math.max(0, Math.trunc(result.total_count))
-          : 0;
-      }
-      for (const value of items) {
-        if (!value || typeof value !== "object" || Array.isArray(value)) continue;
-        found.push(value as ReviewPlaceholderCandidate);
-      }
-      if (items.length < SEARCH_PAGE_SIZE) break;
+      const value = {
+        items,
+        total: Number.isFinite(totalValue)
+          ? Math.max(0, Math.trunc(totalValue), items.length)
+          : items.length,
+        incomplete: result.incomplete_results === true,
+      };
+      pages.set(page, value);
+      return value;
+    };
+
+    let start = cursor.nextCursor < SEARCH_RESULT_LIMIT ? cursor.nextCursor : 0;
+    let page = Math.floor(start / SEARCH_PAGE_SIZE) + 1;
+    let result = await fetchPage(page);
+    if (result.incomplete) throw new Error("GitHub returned incomplete search results");
+    let telemetryTotal = Math.max(result.total, result.items.length);
+    const pageOffset = start - (page - 1) * SEARCH_PAGE_SIZE;
+    if (start > 0 && pageOffset >= result.items.length) {
+      // Search counts lag comment mutations, so an empty/out-of-range page is
+      // the completion signal. Reset from live page contents, never total_count.
+      start = 0;
+      page = 1;
+      result = await fetchPage(page);
+      if (result.incomplete) throw new Error("GitHub returned incomplete search results");
+      telemetryTotal = Math.max(telemetryTotal, result.total, result.items.length);
     }
-    matched += Math.max(total, found.length);
-    const ranked = found.map((candidate, index) => ({
-      candidate,
-      index,
-      updatedAtMs: candidateUpdatedAtMs(candidate),
-    }));
-    ranked.sort((a, b) =>
-      a.updatedAtMs === b.updatedAtMs ? a.index - b.index : a.updatedAtMs - b.updatedAtMs,
-    );
-    let added = 0;
-    for (const entry of ranked) {
-      if (added >= maximumChecks) break;
-      const number = Number(entry.candidate.number);
-      if (!Number.isInteger(number) || number <= 0 || candidates.has(number)) continue;
-      candidates.set(number, {
-        candidate: entry.candidate,
-        closed: stateQualifier === "is:closed",
+    matched += telemetryTotal;
+
+    let remainingChecks = maximumChecks;
+    let nextCursor = start;
+    let reachedEnd = false;
+    while (remainingChecks > 0 && page * SEARCH_PAGE_SIZE <= SEARCH_RESULT_LIMIT) {
+      result = await fetchPage(page);
+      if (result.incomplete) throw new Error("GitHub returned incomplete search results");
+      const pageStart = (page - 1) * SEARCH_PAGE_SIZE;
+      const from = page === Math.floor(start / SEARCH_PAGE_SIZE) + 1 ? start - pageStart : 0;
+      const to = Math.min(result.items.length, from + remainingChecks);
+      const ranked = result.items.map((value, index) => {
+        const candidate =
+          value && typeof value === "object" && !Array.isArray(value)
+            ? (value as ReviewPlaceholderCandidate)
+            : null;
+        return {
+          candidate,
+          index,
+          number: candidate ? candidateNumber(candidate) : Number.MAX_SAFE_INTEGER,
+          updatedAtMs: candidate ? candidateUpdatedAtMs(candidate) : Number.POSITIVE_INFINITY,
+        };
       });
-      added += 1;
+      ranked.sort(
+        (a, b) => a.updatedAtMs - b.updatedAtMs || a.number - b.number || a.index - b.index,
+      );
+      for (const entry of ranked.slice(from, to)) {
+        if (!entry.candidate || entry.number === Number.MAX_SAFE_INTEGER) continue;
+        if (candidates.has(entry.number)) continue;
+        candidates.set(entry.number, { candidate: entry.candidate, closed: state === "closed" });
+      }
+      const consumed = Math.max(0, to - from);
+      remainingChecks -= consumed;
+      nextCursor = pageStart + to;
+      if (result.items.length < SEARCH_PAGE_SIZE) {
+        reachedEnd = to >= result.items.length;
+        break;
+      }
+      if (to < result.items.length) break;
+      page += 1;
     }
+    cursorUpdates.set(state, reachedEnd || nextCursor >= SEARCH_RESULT_LIMIT ? 0 : nextCursor);
   };
-  for (const stateQualifier of ["is:open", "is:closed"] as const) {
+  for (const state of ["open", "closed"] as const) {
     try {
-      await searchCandidates(stateQualifier);
+      await searchCandidates(state);
     } catch (error) {
       errors += 1;
       console.warn(
-        `review-placeholder discovery (${stateQualifier}) skipped: ${error instanceof Error ? error.message : String(error)}`,
+        `review-placeholder discovery (is:${state}) skipped: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
@@ -564,6 +677,22 @@ export async function runReviewPlaceholderRecovery(
           error instanceof Error ? error.message : String(error)
         }`,
       );
+    }
+  }
+  if (cursorStoreUrl) {
+    for (const state of ["open", "closed"] as const) {
+      const cursor = cursors.get(state)!;
+      const nextCursor = cursorUpdates.get(state);
+      if (!cursor.loaded || nextCursor === undefined || nextCursor === cursor.nextCursor) continue;
+      try {
+        await putDurableCursor(cursorStore(state), nextCursor, cursor.revision);
+        console.log(`review-placeholder ${state} cursor advanced to ${nextCursor}`);
+      } catch (error) {
+        errors += 1;
+        console.warn(
+          `review-placeholder ${state} cursor did not persist; attempted work remains idempotent: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
   }
   return summary();

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -5694,6 +5694,48 @@ test("authenticated fanout cursors round-trip through durable storage", async ()
   assert.deepEqual(await (await worker.fetch(request("GET"), env)).json(), written);
 });
 
+test("placeholder recovery cursor survives queue reconstruction", async () => {
+  const storage = new MemoryDurableStorage();
+  const secret = "placeholder-cursor-secret";
+  const mode = "review-placeholder-0123456789abcdef-closed";
+  const path = `/internal/state/cursors/${mode}`;
+  let queue = new ExactReviewQueue({ storage }, {});
+  let env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const request = (method: "GET" | "PUT", payload?: unknown) => {
+    const body = method === "PUT" ? JSON.stringify(payload) : "";
+    return new Request(`https://clawsweeper.openclaw.ai${path}`, {
+      method,
+      headers: {
+        "content-type": "application/json",
+        "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+      },
+      ...(method === "PUT" ? { body } : {}),
+    });
+  };
+
+  const written = await worker.fetch(
+    request("PUT", { next_cursor: 120, expected_revision: 0 }),
+    env,
+  );
+  assert.equal(written.status, 202);
+
+  queue = new ExactReviewQueue({ storage }, {});
+  env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  assert.deepEqual(await (await worker.fetch(request("GET"), env)).json(), {
+    ok: true,
+    mode,
+    next_cursor: 120,
+    revision: 1,
+    updated_at: (await written.clone().json()).updated_at,
+  });
+});
+
 test("Worker lifecycle projection permits one command acknowledgement after durable routing", async () => {
   const storage = new MemoryDurableStorage();
   const leased = leasedExactReviewPublicationItem(778, "7780");

--- a/test/review-placeholder-recovery.test.ts
+++ b/test/review-placeholder-recovery.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   isOrphanedReviewPlaceholder,
   REVIEW_PLACEHOLDER_MARKER,
+  reviewPlaceholderCursorMode,
   reviewPlaceholderRecoveryFailureReason,
   runReviewPlaceholderRecovery,
   selectReviewPlaceholderComment,
@@ -1092,6 +1093,296 @@ test("a large search count remains telemetry and does not fail the run", async (
     "summary line reports the discovery backlog",
   );
   assert.equal(reviewPlaceholderRecoveryFailureReason(summary), null);
+});
+
+test("durable discovery rotation reaches later open and closed candidates without bypassing age", async () => {
+  const openNumbers = Array.from({ length: 180 }, (_, index) => 1_001 + index);
+  const closedNumbers = Array.from({ length: 180 }, (_, index) => 2_001 + index);
+  const cursorModes = {
+    open: reviewPlaceholderCursorMode("openclaw/openclaw", "open"),
+    closed: reviewPlaceholderCursorMode("openclaw/openclaw", "closed"),
+  };
+  const stored = new Map(
+    Object.values(cursorModes).map((mode) => [
+      mode,
+      { next_cursor: 0, revision: 0, updated_at: null as string | null },
+    ]),
+  );
+  const checks = Array.from({ length: 4 }, () => ({
+    open: [] as number[],
+    closed: [] as number[],
+  }));
+  const enqueued: number[] = [];
+  const deleted: number[] = [];
+  let runIndex = 0;
+  let runNow = now;
+  let closedTargetDeleted = false;
+
+  const candidate = (number: number, index: number) => ({
+    number,
+    updated_at: new Date(Date.parse("2026-07-15T12:00:00.000Z") + index * 1_000).toISOString(),
+  });
+  const placeholder = (number: number, commentId: number, createdAt: string) => ({
+    id: commentId,
+    body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=${number} sha=abc v=1 -->`,
+    created_at: createdAt,
+    updated_at: createdAt,
+    user: bot,
+  });
+  const mockFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const cursorMatch = url.pathname.match(/\/internal\/state\/cursors\/([^/]+)$/);
+    if (cursorMatch) {
+      const mode = decodeURIComponent(cursorMatch[1]!);
+      const cursor = stored.get(mode);
+      assert.ok(cursor, `unexpected cursor mode ${mode}`);
+      if (init?.method === "PUT") {
+        const update = JSON.parse(String(init.body)) as {
+          next_cursor: number;
+          expected_revision: number;
+        };
+        assert.equal(update.expected_revision, cursor.revision);
+        cursor.next_cursor = update.next_cursor;
+        cursor.revision += 1;
+        cursor.updated_at = runNow.toISOString();
+      }
+      return Response.json({ ok: true, mode, ...cursor });
+    }
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      const state = query.includes("is:closed") ? "closed" : "open";
+      const numbers = state === "closed" ? closedNumbers : openNumbers;
+      const page = Number(url.searchParams.get("page"));
+      const pageStart = (page - 1) * 100;
+      return Response.json({
+        // Search count is intentionally stale for closed items; page contents
+        // remain the only completion authority for cursor advancement.
+        total_count: state === "closed" ? 1 : numbers.length,
+        incomplete_results: false,
+        items: numbers.slice(pageStart, pageStart + 100).map(candidate),
+      });
+    }
+    const commentsMatch = url.pathname.match(/\/issues\/(\d+)\/comments$/);
+    if (commentsMatch) {
+      const number = Number(commentsMatch[1]);
+      const state = number >= 2_000 ? "closed" : "open";
+      checks[runIndex]![state].push(number);
+      if (number === 1_001) {
+        return Response.json([placeholder(number, 91_001, "2026-07-17T11:00:00.000Z")]);
+      }
+      if (number === 2_144 && !closedTargetDeleted) {
+        return Response.json([placeholder(number, 92_144, "2026-07-17T06:00:00.000Z")]);
+      }
+      return Response.json([
+        {
+          body: "ClawSweeper review: keep open.",
+          created_at: "2026-07-17T06:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/2144") {
+      return Response.json({ state: "closed", locked: false });
+    }
+    if (
+      url.pathname === "/repos/openclaw/openclaw/issues/comments/92144" &&
+      init?.method === "DELETE"
+    ) {
+      deleted.push(92_144);
+      closedTargetDeleted = true;
+      return new Response(null, { status: 204 });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/comments/92144") {
+      return Response.json(placeholder(2_144, 92_144, "2026-07-17T06:00:00.000Z"));
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      const body = JSON.parse(String(init?.body)) as { decision: { itemNumber: number } };
+      enqueued.push(body.decision.itemNumber);
+      return Response.json({ ok: true, queued: true }, { status: 202 });
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  const run = async (index: number, at: Date) => {
+    runIndex = index;
+    runNow = at;
+    return runReviewPlaceholderRecovery({
+      env: {
+        GH_TOKEN: "read-token",
+        TARGET_WRITE_TOKEN: "write-token",
+        CLAWSWEEPER_WEBHOOK_SECRET: "cursor-secret",
+        GITHUB_API_URL: "https://api.github.test",
+        QUEUE_URL: "https://queue.test",
+        REVIEW_PLACEHOLDER_CURSOR_STORE_URL: "https://queue.test",
+        REVIEW_PLACEHOLDER_MAX_CHECKS: "60",
+        REVIEW_PLACEHOLDER_MAX_RECOVERIES: "5",
+        REVIEW_PLACEHOLDER_MIN_AGE_HOURS: "2",
+        TARGET_REPO: "openclaw/openclaw",
+        GITHUB_RUN_ID: String(10_000 + index),
+      },
+      fetchImpl: mockFetch as typeof fetch,
+      now: at,
+    });
+  };
+
+  const first = await run(0, now);
+  const second = await run(1, now);
+  const third = await run(2, now);
+  const fourth = await run(3, new Date("2026-07-17T14:00:00.000Z"));
+
+  assert.equal(first.cleaned, 0);
+  assert.equal(second.cleaned, 0);
+  assert.equal(third.cleaned, 1, "the rank-144 closed placeholder is reached on cycle three");
+  assert.equal(fourth.enqueued, 1, "the under-age open placeholder is retried after wrap");
+  assert.deepEqual(enqueued, [1_001]);
+  assert.deepEqual(deleted, [92_144]);
+  for (const [index, expected] of [
+    [0, [0, 60]],
+    [1, [60, 120]],
+    [2, [120, 180]],
+    [3, [0, 60]],
+  ] as const) {
+    assert.deepEqual(checks[index]!.open, openNumbers.slice(...expected));
+    assert.deepEqual(checks[index]!.closed, closedNumbers.slice(...expected));
+  }
+  assert.equal(stored.get(cursorModes.open)?.next_cursor, 60);
+  assert.equal(stored.get(cursorModes.closed)?.next_cursor, 60);
+});
+
+test("a stale discovery cursor resets inside the current result set", async () => {
+  const mode = reviewPlaceholderCursorMode("openclaw/openclaw", "open");
+  const closedMode = reviewPlaceholderCursorMode("openclaw/openclaw", "closed");
+  let stored = { next_cursor: 900, revision: 7, updated_at: now.toISOString() };
+  const checked: number[] = [];
+  const fetchImpl = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname.endsWith(`/${mode}`)) {
+      if (init?.method === "PUT") {
+        const update = JSON.parse(String(init.body)) as {
+          next_cursor: number;
+          expected_revision: number;
+        };
+        assert.equal(update.expected_revision, 7);
+        stored = { next_cursor: update.next_cursor, revision: 8, updated_at: now.toISOString() };
+      }
+      return Response.json({ ok: true, mode, ...stored });
+    }
+    if (url.pathname.endsWith(`/${closedMode}`)) {
+      return Response.json({
+        ok: true,
+        mode: closedMode,
+        next_cursor: 0,
+        revision: 0,
+        updated_at: null,
+      });
+    }
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ total_count: 0, items: [] });
+      if (url.searchParams.get("page") !== "1") {
+        return Response.json({ total_count: 1, items: [] });
+      }
+      return Response.json({ total_count: 1, items: [{ number: 7_001 }] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/7001/comments") {
+      checked.push(7_001);
+      return Response.json([]);
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+
+  await runReviewPlaceholderRecovery({
+    env: {
+      GH_TOKEN: "read-token",
+      CLAWSWEEPER_WEBHOOK_SECRET: "cursor-secret",
+      GITHUB_API_URL: "https://api.github.test",
+      QUEUE_URL: "https://queue.test",
+      REVIEW_PLACEHOLDER_CURSOR_STORE_URL: "https://queue.test",
+      TARGET_REPO: "openclaw/openclaw",
+    },
+    fetchImpl: fetchImpl as typeof fetch,
+    now,
+  });
+
+  assert.deepEqual(checked, [7_001]);
+  assert.equal(stored.next_cursor, 0);
+});
+
+test("cursor conflict repeats productive recovery safely after restart", async () => {
+  const modes = {
+    open: reviewPlaceholderCursorMode("openclaw/openclaw", "open"),
+    closed: reviewPlaceholderCursorMode("openclaw/openclaw", "closed"),
+  };
+  const checked: number[] = [];
+  const enqueued: number[] = [];
+  const fetchImpl = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    const cursorMode = Object.values(modes).find((mode) => url.pathname.endsWith(`/${mode}`));
+    if (cursorMode) {
+      if (init?.method === "PUT") {
+        return Response.json({ error: "fanout_cursor_revision_conflict" }, { status: 409 });
+      }
+      return Response.json({
+        ok: true,
+        mode: cursorMode,
+        next_cursor: 0,
+        revision: 0,
+        updated_at: null,
+      });
+    }
+    if (url.pathname === "/search/issues") {
+      const query = url.searchParams.get("q") ?? "";
+      if (query.includes("is:closed")) return Response.json({ total_count: 0, items: [] });
+      return Response.json({ total_count: 2, items: [{ number: 8_001 }, { number: 8_002 }] });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/issues/8001/comments") {
+      checked.push(8_001);
+      return Response.json([
+        {
+          body: `${REVIEW_PLACEHOLDER_MARKER}\n\n<!-- clawsweeper-review-status:started item=8001 sha=abc v=1 -->`,
+          created_at: "2026-07-17T06:00:00.000Z",
+          user: bot,
+        },
+      ]);
+    }
+    if (url.pathname === "/internal/exact-review/enqueue") {
+      enqueued.push(8_001);
+      return Response.json(
+        enqueued.length === 1 ? { ok: true, queued: true } : { ok: true, deduped: true },
+        { status: 202 },
+      );
+    }
+    throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+  };
+  const run = (runId: string) =>
+    runReviewPlaceholderRecovery({
+      env: {
+        GH_TOKEN: "read-token",
+        CLAWSWEEPER_WEBHOOK_SECRET: "cursor-secret",
+        GITHUB_API_URL: "https://api.github.test",
+        QUEUE_URL: "https://queue.test",
+        REVIEW_PLACEHOLDER_CURSOR_STORE_URL: "https://queue.test",
+        REVIEW_PLACEHOLDER_MAX_CHECKS: "1",
+        TARGET_REPO: "openclaw/openclaw",
+        GITHUB_RUN_ID: runId,
+      },
+      fetchImpl: fetchImpl as typeof fetch,
+      now,
+    });
+
+  assert.equal((await run("restart-1")).enqueued, 1);
+  assert.equal((await run("restart-2")).enqueued, 1);
+  assert.deepEqual(checked, [8_001, 8_001]);
+  assert.deepEqual(enqueued, [8_001, 8_001]);
 });
 
 test("placeholder refreshed recently by an active recovery is not orphaned", () => {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1769,6 +1769,10 @@ test("terminal exact-review runs reconcile through a signed isolated backstop", 
     sweepJob,
     /REVIEW_PLACEHOLDER_MAX_CHECKS: \$\{\{ vars\.REVIEW_PLACEHOLDER_MAX_CHECKS \|\| '20' \}\}/,
   );
+  assert.match(
+    sweepJob,
+    /REVIEW_PLACEHOLDER_CURSOR_STORE_URL: \$\{\{ vars\.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL \|\| 'https:\/\/clawsweeper\.openclaw\.ai' \}\}/,
+  );
   assert.doesNotMatch(sweepJob, /REVIEW_PLACEHOLDER_BACKLOG_ALERT/);
   assert.match(
     sweepJob,


### PR DESCRIPTION
## Summary

- persist independent open/closed placeholder-recovery offsets in the existing revision-CAS ExactReviewQueue cursor store
- rotate across GitHub Search pages after every bounded live-validation window instead of restarting at page 1
- preserve the two-hour activity guard and all destructive closed-comment rereads; cursor failures repeat work safely
- extract the existing signed cursor client so fanout and placeholder recovery share one transport contract

## Root cause

Run https://github.com/openclaw/clawsweeper/actions/runs/31230348601 reported `checked=120 cleaned=0 matched=718 remaining=598`. The stale placeholder on https://github.com/openclaw/openclaw/pull/120368 was rank 144 in the closed search, but every scheduled invocation rebuilt the same oldest-first query, selected only the first 60 closed rows, and discarded its position. Stable false positives at the front therefore starved every later candidate indefinitely.

GitHub remains authoritative for search, item state, comment identity, and age. The ExactReviewQueue Durable Object now owns only the fairness offset. Each state advances through all attempted search slots after live validation, including non-actionable and failed rows; a failed CAS leaves the old offset so the next run safely repeats queue-deduped or live-revalidated work.

## Real behavior proof

AWS Crabbox run https://crabbox.openclaw.ai/portal/runs/run_569b0ecfe10c (`cbx_769ecf9555a9`, `c7a.8xlarge`) ran the production TypeScript builds and recovery/Worker boundary suite inside a clean `node:24-bookworm` Docker container:

`docker run --rm -v "$PWD:/repo" -w /repo node:24-bookworm bash -lc "corepack enable && pnpm install --frozen-lockfile && pnpm run build:all && node --test test/review-placeholder-recovery.test.ts test/dashboard-worker.test.ts"`

Result: 342 passed, 0 failed. The redacted runtime trace showed independent open/closed cursor transitions `0 → 60 → 120 → 0`, no action while the open placeholder was below the two-hour guard, cleanup of the eligible closed placeholder at rank 144 in the third window, later recovery of the aged open placeholder after wrap, and an intentionally conflicted cursor write followed by a queue-deduped retry. The Worker boundary persisted `next_cursor=120, revision=1` across an ExactReviewQueue reconstruction. No credentials or live repository mutations were used.

OpenClaw Bay is unaffected. These cursors are authenticated control-plane fairness state only; they are not included in Bay lifecycle projections, cards, counts, timing, or public status payloads.

## Proof

- `pnpm run build:all`
- `node --test test/review-placeholder-recovery.test.ts test/repair/target-fanout.test.ts test/dashboard-worker.test.ts test/sweep-workflow.test.ts test/review-reliability-workflow.test.ts` — 478 passed
- exact #120368-shaped regression: 180 open + 180 closed matches, budget 60; fresh runs inspect 1–60, 61–120, then 121–180 and delete only the age-eligible rank-144 closed placeholder
- the same proof keeps an under-two-hour open placeholder untouched, wraps, and recovers it only after the age guard expires
- restart proof forces cursor CAS conflict after productive enqueue; the next invocation repeats safely and receives queue dedupe
- stale `total_count=1` does not truncate the 180-row closed rotation; live page contents remain completion authority
- Durable Object reconstruction retains the recovery cursor and existing fanout cursor compatibility tests remain green
- `pnpm run check` passed format, all builds, lint, focused coverage, and 3,190/3,200 full tests; its sole local failure is the unchanged `test/repair/process-env.test.ts` pnpmfile-hook assertion, reproduced alone on this base/environment. Base CI is green: https://github.com/openclaw/clawsweeper/actions/runs/31230058102
- pre-commit and committed-branch Codex autoreviews: clean, no accepted/actionable findings

## Production delta

The positive production delta adds the missing durable fairness owner and reusable cursor client. It removes the duplicate fanout transport implementation, preserves the existing KV key prefix, and does not change the ExactReviewQueue SQLite schema or version.
