### PR TITLE
fix(tokens): keep review hydration on the App bucket to balance read pools

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1077,7 +1077,10 @@ jobs:
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' && steps.reserve-exact-review-lease.outputs.status == 'posted' }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}
+          # Review hydration is the largest read stream (~30 calls/review); it
+          # stays on the App installation bucket so the per-repo Actions pool
+          # keeps headroom for the comment-router and support lanes.
+          GH_TOKEN: ${{ steps.target-read-token.outputs.token }}
           CLAWSWEEPER_PROOF_INSPECTION_TOKEN: ${{ steps.target-read-token.outputs.token }}
           ADDITIONAL_PROMPT: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).additionalPrompt || '' }}
           CLAWSWEEPER_RELATED_GITHUB_SEARCH: ${{ vars.CLAWSWEEPER_RELATED_GITHUB_SEARCH || '1' }}

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2205,10 +2205,7 @@ test("sweep workflow executes only durable queue leases without runner-side admi
   assert.match(legacyIntakeBlock, /statusCommentId: payload\.status_comment_id/);
   assert.match(legacyIntakeBlock, /additionalPrompt: payload\.additional_prompt/);
   assert.match(eventReviewBlock, /cancel-in-progress: false/);
-  assert.match(
-    exactReviewStep,
-    /GH_TOKEN: \$\{\{ steps\.target\.outputs\.target_repo == 'openclaw\/openclaw' && github\.token \|\| steps\.target-read-token\.outputs\.token \}\}/,
-  );
+  assert.match(exactReviewStep, /GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/);
   assert.match(exactReviewStep, /--readonly-openclaw/);
   assert.match(exactReviewStep, /--skip-start-comment/);
   assert.ok(claimIndex >= 0);

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -450,7 +450,7 @@ test("review execution tokens can read check runs and commit statuses", () => {
   }
   assert.match(
     eventReviewJob,
-    /Review exact event item[\s\S]*GH_TOKEN: \$\{\{ steps\.target\.outputs\.target_repo == 'openclaw\/openclaw' && github\.token \|\| steps\.target-read-token\.outputs\.token \}\}/,
+    /Review exact event item[\s\S]*GH_TOKEN: \$\{\{ steps\.target-read-token\.outputs\.token \}\}/,
   );
 });
 
@@ -600,7 +600,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.equal(
     step(reviewer, "Review exact event item").env?.GH_TOKEN,
-    "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}",
+    "${{ steps.target-read-token.outputs.token }}",
   );
   assert.equal(
     step(reviewer, "Review exact event item").env?.CLAWSWEEPER_PROOF_INSPECTION_TOKEN,
@@ -4684,10 +4684,7 @@ test("public OpenClaw reads use workflow tokens without moving mutation identity
   };
 
   const exactReview = find("event-review-apply", "Review exact event item");
-  assert.equal(
-    exactReview.env?.GH_TOKEN,
-    "${{ steps.target.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-read-token.outputs.token }}",
-  );
+  assert.equal(exactReview.env?.GH_TOKEN, "${{ steps.target-read-token.outputs.token }}");
   assert.equal(
     find("event-review-publish", "Confirm terminal item remains closed").env?.GH_TOKEN,
     "${{ steps.publication-context.outputs.target_repo == 'openclaw/openclaw' && github.token || steps.target-write-token.outputs.token }}",


### PR DESCRIPTION
## What Problem This Solves

PR #1062 moved the exact-event review runtime's GitHub reads (~30 calls per review, the largest single read stream) from the App installation bucket onto the per-repo Actions `GITHUB_TOKEN` pool. That pool is already shared by the comment-router public reads (#1034), dashboard CI, and every support lane in this repository. Concentrating both major read streams on one bucket exhausted it: after the merge at 00:20Z, queue telemetry shows review successes collapsing (184/hr → 40/hr by 01:21Z), throttle-retry backoff climbing past 95 items, and active `github_throttle` alerts doubling — while the App installation bucket idles.

## The Fix

One line: review hydration returns to the App read token. With apply-guard read memoization (#1060) and the router/public-read offload (#1034, #1062) in place, the two pools now each carry roughly half the read load instead of one carrying all of it:

- App installation bucket: review hydration (memoized), writes, leases.
- Actions pool: comment router, small read steps, dashboard CI, mixed-process public-read seams (each with the bounded App-token throttle fallback).

All other #1062 changes (runtime public-read seam, inspection-token hardening, small step flips) are unchanged.

## Proof

- Focused workflow test suites green: sweep-workflow 115/115, clawsweeper 77/77.
- Production telemetry cited above from `/api/exact-review-queue` (reservation-claim throttle alerts, review-lane flow rates).
