### PR TITLE
fix(review): let scheduled deliveries use the structural review cache

### DIFF
--- a/docs/review-cache.md
+++ b/docs/review-cache.md
@@ -27,7 +27,7 @@ A structural hit requires all of the following:
 - the complete hydrated PR state is unchanged, including head and base SHAs,
   draft and mergeability state, diff counts, and commit count; and
 - any item activity timestamp change is covered by the recorded ClawSweeper
-  comment or label synchronization boundary.
+  comment, label synchronization, or validated review-reservation boundary.
 
 Explicit reviews, maintainer prompts, close verdicts, failed reviews, legacy
 records, truncated metadata, malformed API responses, and probe failures always
@@ -41,11 +41,12 @@ timeline, review, and review-thread input; the final verdict probe must match
 that anchor again.
 
 Before carrying a structural hit, ClawSweeper acquires the normal durable review
-lease for the unchanged PR head or issue source revision. Missing coordination,
-an incomplete lease tuple, or a concurrent review always disables reuse.
-ClawSweeper then refreshes target and release state and repeats the bounded
-metadata and check-state probes under that lease; any intervening drift forces
-full hydration.
+lease for the unchanged PR head or issue source revision. Scheduled deliveries
+claim the lease already reserved by their workflow instead of posting a second
+lease comment. Missing coordination, an incomplete lease tuple, or a concurrent
+review always disables reuse. ClawSweeper then refreshes target and release state
+and repeats the bounded metadata and check-state probes under that lease; any
+intervening drift forces full hydration.
 
 ## Semantic Stage
 

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -43,6 +43,16 @@ import { reviewContentCacheHit } from "./scheduler-policy.js";
 import type { CreateReviewCommandWorkflowDependencies } from "./clawsweeper-review-command-dependencies.js";
 import { prepareReviewCommand } from "./clawsweeper-review-preparation.js";
 
+function reviewStartLeaseCommentUpdatedAt(
+  comment: Record<string, unknown> | undefined,
+): string | undefined {
+  for (const key of ["updated_at", "created_at"]) {
+    const value = comment?.[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
 export function restoreVerifiedMaintainerPullRequestAuthorAssociation(
   item: Pick<Item, "kind" | "author" | "authorAssociation" | "labels">,
   repositoryPermission: (author: string) => string | null,
@@ -178,6 +188,44 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
       // command creates itself must still be deleted, even for a read-only checkout.
       isSuppliedReviewStartLease(suppliedReviewLease, lease) ||
       deleteOwnedDedicatedReviewStartLease(itemNumber, lease);
+    const claimSuppliedReviewLease = (
+      itemNumber: number,
+      currentRevision: string,
+    ):
+      | { status: "claimed"; lease: AcquiredReviewStartLease }
+      | { status: "stale" }
+      | { status: "held"; retryAt: string } => {
+      if (!suppliedReviewLease) return { status: "stale" };
+      const freshLeases = freshDedicatedReviewStartLeases({
+        comments: issueReviewCommentState(itemNumber).leaseComments,
+        itemNumber,
+        headSha: currentRevision,
+        nowMs: Date.now(),
+      });
+      const winner = freshLeases[0];
+      const supplied = freshLeases.find(
+        (lease) =>
+          commentId(lease.comment) === suppliedReviewLease.commentId &&
+          lease.owner === suppliedReviewLease.owner,
+      );
+      if (!supplied || !winner) return { status: "stale" };
+      if (
+        commentId(winner.comment) !== suppliedReviewLease.commentId ||
+        winner.owner !== suppliedReviewLease.owner
+      ) {
+        return { status: "held", retryAt: winner.expiresAt };
+      }
+      return {
+        status: "claimed",
+        lease: {
+          owner: suppliedReviewLease.owner,
+          commentId: suppliedReviewLease.commentId,
+          headSha: currentRevision,
+          comment: supplied.comment,
+        },
+      };
+    };
+    const structuralCacheCoordinationEnabled = !skipStartComment || suppliedReviewLease !== null;
     let reviewLedger: ReviewActionLedger | null = null;
     let activeReviewItem: Item | null = null;
     let completed = 0;
@@ -361,7 +409,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             reviewModel: PUBLIC_CODEX_MODEL,
             explicitDispatch,
             maintainerRequest,
-            coordinationEnabled: !skipStartComment,
+            coordinationEnabled: structuralCacheCoordinationEnabled,
           });
           if (!structuralProbeDecision.hit) {
             structuralCacheReasons.set(
@@ -393,7 +441,11 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             }
             preHydrationStructuralRecord = structuralRecord;
             if (structuralRecord) item.updatedAt = structuralRecord.activityUpdatedAt;
-            const structuralDecision = reviewStructuralCacheDecision({
+            const leaseRevision =
+              item.kind === "pull_request"
+                ? structuralRecord?.pullHeadSha
+                : priorReview?.itemSourceRevision;
+            const structuralDecisionInput = {
               review: priorReview,
               priorRecord: priorReview?.structuralRecord ?? null,
               currentRecord: structuralRecord,
@@ -401,8 +453,29 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               reviewModel: PUBLIC_CODEX_MODEL,
               explicitDispatch,
               maintainerRequest,
-              coordinationEnabled: !skipStartComment,
-            });
+              coordinationEnabled: structuralCacheCoordinationEnabled,
+            };
+            let suppliedLeaseClaim: ReturnType<typeof claimSuppliedReviewLease> | null = null;
+            let ownedReservationUpdatedAt: string | undefined;
+            let structuralDecision = reviewStructuralCacheDecision(structuralDecisionInput);
+            if (
+              structuralDecision.reason === "activity_changed" &&
+              suppliedReviewLease &&
+              leaseRevision
+            ) {
+              suppliedLeaseClaim = claimSuppliedReviewLease(item.number, leaseRevision);
+              if (suppliedLeaseClaim.status === "claimed") {
+                ownedReservationUpdatedAt = reviewStartLeaseCommentUpdatedAt(
+                  suppliedLeaseClaim.lease.comment,
+                );
+                if (ownedReservationUpdatedAt) {
+                  structuralDecision = reviewStructuralCacheDecision({
+                    ...structuralDecisionInput,
+                    ownedReservationUpdatedAt,
+                  });
+                }
+              }
+            }
             structuralCacheReasons.set(
               structuralDecision.reason,
               (structuralCacheReasons.get(structuralDecision.reason) ?? 0) + 1,
@@ -410,33 +483,57 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             if (structuralDecision.hit) {
               const initialStructuralRecord = structuralRecord;
               try {
-                const leaseRevision =
-                  item.kind === "pull_request"
-                    ? structuralRecord?.pullHeadSha
-                    : priorReview?.itemSourceRevision;
-                const startComment = postReviewStartStatusComment({
-                  item,
-                  headSha: leaseRevision ?? "",
-                  reviewTimeoutMs: timeoutMs,
-                  position: completed + 1,
-                  total: candidates.length,
-                  shardIndex,
-                  shardCount,
-                });
-                console.error(
-                  `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
-                );
-                if (startComment.status === "held") {
-                  coordinationHeldRetryAt = startComment.retryAt;
-                  continue;
-                }
-                acquiredReviewLease = startComment.lease;
-                if (!acquiredReviewLease) {
-                  throw new Error(
-                    `structural cache lease acquisition returned no identity for #${item.number}`,
+                if (suppliedReviewLease) {
+                  const claim =
+                    suppliedLeaseClaim ??
+                    (leaseRevision
+                      ? claimSuppliedReviewLease(item.number, leaseRevision)
+                      : ({ status: "stale" } as const));
+                  console.error(
+                    `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${claim.status === "claimed" ? "reserved" : claim.status === "held" ? "held" : "stale-reservation"} #${item.number}`,
                   );
+                  if (claim.status === "held") {
+                    coordinationHeldRetryAt = claim.retryAt;
+                    continue;
+                  }
+                  if (claim.status === "stale") {
+                    coordinationHeldRetryAt = new Date(Date.now() + 60_000).toISOString();
+                    leaseAcquisitionFailures += 1;
+                    leaseAcquisitionFailureDetails.push(
+                      `#${item.number}: reserved review lease is no longer fresh for the cached revision`,
+                    );
+                    continue;
+                  }
+                  acquiredReviewLease = claim.lease;
+                  ownedReservationUpdatedAt ??= reviewStartLeaseCommentUpdatedAt(
+                    claim.lease.comment,
+                  );
+                  acquiredReviewLeases.push({ itemNumber: item.number, lease: claim.lease });
+                } else {
+                  const startComment = postReviewStartStatusComment({
+                    item,
+                    headSha: leaseRevision ?? "",
+                    reviewTimeoutMs: timeoutMs,
+                    position: completed + 1,
+                    total: candidates.length,
+                    shardIndex,
+                    shardCount,
+                  });
+                  console.error(
+                    `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} structural-cache-start-comment=${startComment.status} #${item.number}`,
+                  );
+                  if (startComment.status === "held") {
+                    coordinationHeldRetryAt = startComment.retryAt;
+                    continue;
+                  }
+                  acquiredReviewLease = startComment.lease;
+                  if (!acquiredReviewLease) {
+                    throw new Error(
+                      `structural cache lease acquisition returned no identity for #${item.number}`,
+                    );
+                  }
+                  acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
                 }
-                acquiredReviewLeases.push({ itemNumber: item.number, lease: acquiredReviewLease });
               } catch (error) {
                 leaseAcquisitionFailures += 1;
                 leaseAcquisitionFailureDetails.push(
@@ -478,12 +575,14 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                 structuralCacheRevalidationMs += Date.now() - structuralRevalidationStartedAt;
               }
               const revalidationDecision = reviewStructuralCacheDecision({
-                review: priorReview
+                // A lease posted by this command owns activity through now. A
+                // supplied reservation owns activity only through its recorded timestamp.
+                review: priorReview && !suppliedReviewLease
                   ? {
                       ...priorReview,
                       reviewCommentSyncedAt: new Date().toISOString(),
                     }
-                  : null,
+                  : priorReview,
                 priorRecord: initialStructuralRecord,
                 currentRecord: revalidatedStructuralRecord,
                 reviewPolicy,
@@ -491,6 +590,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                 explicitDispatch,
                 maintainerRequest,
                 coordinationEnabled: true,
+                ...(ownedReservationUpdatedAt ? { ownedReservationUpdatedAt } : {}),
               });
               const previousReviewIdentityMatches =
                 expectedPreviousReviewDigest !== null &&
@@ -655,19 +755,8 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             );
             continue;
           }
-          const freshLeases = freshDedicatedReviewStartLeases({
-            comments: issueReviewCommentState(item.number).leaseComments,
-            itemNumber: item.number,
-            headSha: currentRevision,
-            nowMs: Date.now(),
-          });
-          const winner = freshLeases[0];
-          const supplied = freshLeases.find(
-            (lease) =>
-              commentId(lease.comment) === suppliedReviewLease.commentId &&
-              lease.owner === suppliedReviewLease.owner,
-          );
-          if (!supplied || !winner) {
+          const claim = claimSuppliedReviewLease(item.number, currentRevision);
+          if (claim.status === "stale") {
             coordinationHeldRetryAt = new Date(Date.now() + 60_000).toISOString();
             leaseAcquisitionFailures += 1;
             leaseAcquisitionFailureDetails.push(
@@ -678,24 +767,15 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
             );
             continue;
           }
-          if (
-            commentId(winner.comment) !== suppliedReviewLease.commentId ||
-            winner.owner !== suppliedReviewLease.owner
-          ) {
-            coordinationHeldRetryAt = winner.expiresAt;
+          if (claim.status === "held") {
+            coordinationHeldRetryAt = claim.retryAt;
             console.error(
               `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start-comment=held #${item.number}`,
             );
             continue;
           }
-          const claimedLease: AcquiredReviewStartLease = {
-            owner: suppliedReviewLease.owner,
-            commentId: suppliedReviewLease.commentId,
-            headSha: currentRevision,
-            comment: supplied.comment,
-          };
-          acquiredReviewLease = claimedLease;
-          acquiredReviewLeases.push({ itemNumber: item.number, lease: claimedLease });
+          acquiredReviewLease = claim.lease;
+          acquiredReviewLeases.push({ itemNumber: item.number, lease: claim.lease });
         }
         if (!localRangeData && contextItemUpdatedAt && preHydrationStructuralRecord) {
           structuralCacheRevalidations += 1;

--- a/src/review-structural-cache.ts
+++ b/src/review-structural-cache.ts
@@ -159,6 +159,7 @@ export interface ReviewStructuralCacheProbeOptions {
   explicitDispatch: boolean;
   maintainerRequest: boolean;
   coordinationEnabled: boolean;
+  ownedReservationUpdatedAt?: string | undefined;
   now?: number;
 }
 
@@ -1189,6 +1190,7 @@ function activityCoveredByReview(
   prior: ReviewStructuralRecord,
   current: ReviewStructuralRecord,
   review: ReviewStructuralPriorReview,
+  ownedReservationUpdatedAt?: string,
 ): boolean {
   if (current.activityUpdatedAt === prior.activityUpdatedAt) return true;
   // Timestamp equality only clears the activity-clock gate. The caller has
@@ -1201,6 +1203,7 @@ function activityCoveredByReview(
   const latestOwnedSync = Math.max(
     timestampMs(review.reviewCommentSyncedAt) ?? -Infinity,
     timestampMs(review.labelsSyncedAt) ?? -Infinity,
+    timestampMs(ownedReservationUpdatedAt) ?? -Infinity,
   );
   return (
     priorActivity !== null &&
@@ -1271,7 +1274,7 @@ export function reviewStructuralCacheDecision(
   if (prior.sourceRevision !== current.sourceRevision) {
     return { hit: false, reason: "source_changed" };
   }
-  if (!activityCoveredByReview(prior, current, review)) {
+  if (!activityCoveredByReview(prior, current, review, options.ownedReservationUpdatedAt)) {
     return { hit: false, reason: "activity_changed" };
   }
   if (current.relationSensitive) {

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { parseArgs } from "../dist/clawsweeper-args.js";
+import { createReviewCommandWorkflow } from "../dist/clawsweeper-review-command-workflow.js";
+import {
+  isSuppliedReviewStartLease,
+  suppliedReviewStartLeaseFromArgs,
+} from "../dist/clawsweeper-review-lease.js";
+import { PUBLIC_CODEX_MODEL } from "../dist/codex-env.js";
+import {
+  createReviewStructuralRecord,
+  type ReviewStructuralSnapshot,
+} from "../dist/review-structural-cache.js";
+
+const POLICY = "scheduled-cache-proof-policy";
+const REPO = "openclaw/openclaw";
+const ITEM_NUMBER = 1052;
+const LEASE_OWNER = "github-run-123-1";
+const LEASE_COMMENT_ID = 456;
+const PRIOR_ACTIVITY_AT = "2026-08-07T10:00:00Z";
+const RESERVED_AT = "2026-08-07T10:05:00Z";
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function structuralRecord(activityUpdatedAt: string) {
+  const snapshot: ReviewStructuralSnapshot = {
+    repo: REPO,
+    number: ITEM_NUMBER,
+    kind: "issue",
+    nodeId: "I_scheduled_cache_proof",
+    author: "contributor",
+    authorAssociation: "CONTRIBUTOR",
+    titleDigest: digest("scheduled cache proof"),
+    bodyDigest: digest("unchanged body"),
+    state: "OPEN",
+    locked: false,
+    labels: ["bug"],
+    labelsTruncated: false,
+    activityUpdatedAt,
+    comments: [],
+    commentsTruncated: false,
+    timeline: [],
+    timelineTruncated: false,
+    relationSensitive: false,
+    targetHeadSha: "a".repeat(40),
+    latestReleaseTag: "v1.0.0",
+    latestReleaseSha: "a".repeat(40),
+    pull: null,
+  };
+  const record = createReviewStructuralRecord(snapshot, {
+    reviewPolicy: POLICY,
+    reviewModel: PUBLIC_CODEX_MODEL,
+  });
+  assert.ok(record);
+  return record;
+}
+
+test("scheduled delivery serves an unchanged item from the structural cache", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-scheduled-cache-"));
+  const artifactDir = join(root, "artifacts");
+  const itemsDir = join(root, "items");
+  const priorRecord = structuralRecord(PRIOR_ACTIVITY_AT);
+  const currentRecord = structuralRecord(RESERVED_AT);
+  const item = {
+    repo: REPO,
+    number: ITEM_NUMBER,
+    kind: "issue" as const,
+    title: "Scheduled cache proof",
+    url: `https://github.com/${REPO}/issues/${ITEM_NUMBER}`,
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: PRIOR_ACTIVITY_AT,
+    author: "contributor",
+    authorAssociation: "CONTRIBUTOR",
+    labels: ["bug"],
+  };
+  const leaseComment = {
+    id: LEASE_COMMENT_ID,
+    created_at: RESERVED_AT,
+    updated_at: RESERVED_AT,
+  };
+  const priorMarkdown = "---\ndecision: keep_open\nreview_status: complete\n---\nCached review\n";
+  let hydrationCalls = 0;
+  let generationCalls = 0;
+  let startCommentCalls = 0;
+  let structuralFetches = 0;
+  let cachedCompletions = 0;
+  let activeReviewMutationRunner = null;
+
+  const ledgerItem = {
+    item,
+    index: 0,
+    started: true,
+    startedAtMs: Date.now(),
+    startEventId: null,
+    lastEventId: null,
+    logPublication: false,
+    mutationAttemptCount: 0,
+    mutationObserved: false,
+    uncertainMutationObserved: false,
+    terminal: false,
+  };
+  const ledger = {
+    operationIdentity: {
+      repository: REPO,
+      reviewPolicy: POLICY,
+      shardIndex: 0,
+      shardCount: 1,
+      candidateSnapshots: [],
+    },
+    batchStartEventId: null,
+    items: new Map([[`${REPO}#${ITEM_NUMBER}`, ledgerItem]]),
+    nextPhaseSeq: 1,
+    mutationObserved: false,
+    uncertainMutationObserved: false,
+    startedAtMs: Date.now(),
+    terminal: false,
+  };
+
+  const dependencies = {
+    get activeReviewMutationRunner() {
+      return activeReviewMutationRunner;
+    },
+    set activeReviewMutationRunner(value: unknown) {
+      activeReviewMutationRunner = value;
+    },
+    actionLedgerFailureDisposition: () => ({
+      status: "failed",
+      reasonCode: "failed",
+      completionReason: "failed",
+    }),
+    actionLedgerItemKey: (value: { repo: string; number: number }) =>
+      `${value.repo}#${value.number}`,
+    asRecord: (value: unknown) => value as Record<string, unknown>,
+    bulkFilerPolicyInvalidatesCachedReview: () => false,
+    bulkFilerRepositoryPermission: () => null,
+    buildLocalRangeReview: () => {
+      throw new Error("local range must not run");
+    },
+    collectItemContext: () => {
+      hydrationCalls += 1;
+      throw new Error("scheduled structural cache hit must not hydrate");
+    },
+    commentId: (comment: Record<string, unknown> | undefined) =>
+      typeof comment?.id === "number" ? comment.id : null,
+    DEFAULT_PLAN_BATCH_SIZE: 3,
+    defaultItemsDir: () => itemsDir,
+    defaultLocalRangeArtifactDir: () => artifactDir,
+    defaultReviewArtifactDir: () => artifactDir,
+    deleteOwnedDedicatedReviewStartLease: () => {
+      throw new Error("the workflow-supplied lease is externally owned");
+    },
+    detectBulkFiler: () => ({ context: null, labelPending: false, labelApplied: false }),
+    ensureDir: (path: string) => mkdirSync(path, { recursive: true }),
+    existingReview: () => ({
+      path: join(itemsDir, `${ITEM_NUMBER}.md`),
+      markdown: priorMarkdown,
+      reviewedAt: PRIOR_ACTIVITY_AT,
+      itemUpdatedAt: PRIOR_ACTIVITY_AT,
+      automationItemUpdatedAt: undefined,
+      reviewCommentSyncedAt: "2026-08-07T10:01:00Z",
+      labelsSyncedAt: "2026-08-07T10:02:00Z",
+      decision: "keep_open",
+      reviewStatus: "complete",
+      reviewPolicy: POLICY,
+      reviewModel: PUBLIC_CODEX_MODEL,
+      itemSourceRevision: priorRecord.sourceRevision,
+      contentDigest: digest("content"),
+      lastFullReviewAt: new Date(Date.now() - 60_000).toISOString(),
+      lastFullReviewDecision: "keep_open",
+      structuralRecord: priorRecord,
+      semanticRecord: null,
+    }),
+    fetchReviewStructuralRecord: () => {
+      structuralFetches += 1;
+      return currentRecord;
+    },
+    finishReviewActionLedger: () => undefined,
+    finishReviewActionLedgerItem: (options: { completionReason?: string }) => {
+      if (options.completionReason === "structural_cache") cachedCompletions += 1;
+      return null;
+    },
+    freshDedicatedReviewStartLeases: (options: { headSha: string }) => {
+      assert.equal(options.headSha, priorRecord.sourceRevision);
+      return [
+        {
+          comment: leaseComment,
+          startedAt: RESERVED_AT,
+          expiresAt: "2026-08-07T11:05:00Z",
+          owner: LEASE_OWNER,
+          commentId: LEASE_COMMENT_ID,
+        },
+      ];
+    },
+    frontMatterValue: () => undefined,
+    gitInfo: () => ({
+      mainSha: "a".repeat(40),
+      releaseStateComplete: true,
+      latestRelease: null,
+    }),
+    isBulkFilerExemptAuthorAssociation: () => false,
+    isBulkFilerExemptRepositoryPermission: () => false,
+    issueReviewCommentState: () => ({
+      comments: [leaseComment],
+      reviewComment: undefined,
+      leaseComment,
+      leaseComments: [leaseComment],
+      dedicatedLeaseComment: leaseComment,
+      dedicatedLeaseComments: [leaseComment],
+    }),
+    isSuppliedReviewStartLease,
+    liveClawSweeperReviewDigest: () => "same-review",
+    localExactReviewItem: () => false,
+    makeTreeReadOnly: () => [],
+    postReviewStartStatusComment: () => {
+      startCommentCalls += 1;
+      throw new Error("scheduled delivery must not post a second lease");
+    },
+    previousClawSweeperReviewDigestFromReport: () => "same-review",
+    replaceFrontMatterValue: (markdown: string) => markdown,
+    repoFromArgs: () => ({ owner: "openclaw", repo: "openclaw" }),
+    reportFileName: () => `${ITEM_NUMBER}.md`,
+    reportReviewFindings: () => [],
+    resolveReviewCheckout: () => ({ openclawDir: root }),
+    restoreTreeModes: () => undefined,
+    reviewCodexForcedLoginMethod: () => "chatgpt",
+    reviewMutationRunner: () => null,
+    reviewPolicyHash: () => POLICY,
+    runCodex: () => {
+      generationCalls += 1;
+      throw new Error("scheduled structural cache hit must not generate a review");
+    },
+    selectCandidates: () => ({ candidates: [{ ...item }], scannedPages: 1 }),
+    startReviewActionLedger: () => ledger,
+    startReviewActionLedgerItem: () => null,
+    suppliedReviewStartLeaseFromArgs,
+    targetRepo: () => REPO,
+    updateBulkFilerDetectedFrontMatter: (markdown: string) => markdown,
+    updateReviewStructuralFrontMatter: (markdown: string) => markdown,
+  } as never;
+
+  try {
+    const { reviewCommand } = createReviewCommandWorkflow(dependencies);
+    reviewCommand(
+      parseArgs([
+        "--target-repo",
+        REPO,
+        "--artifact-dir",
+        artifactDir,
+        "--items-dir",
+        itemsDir,
+        "--item-numbers",
+        String(ITEM_NUMBER),
+        "--readonly-openclaw",
+        "--skip-start-comment",
+        "--review-lease-owner",
+        LEASE_OWNER,
+        "--review-lease-comment-id",
+        String(LEASE_COMMENT_ID),
+        "--review-source-action",
+        "scheduled_normal_backfill",
+      ]),
+    );
+
+    assert.equal(hydrationCalls, 0);
+    assert.equal(generationCalls, 0);
+    assert.equal(startCommentCalls, 0);
+    assert.equal(structuralFetches, 2);
+    assert.equal(cachedCompletions, 1);
+    assert.equal(existsSync(join(artifactDir, `${ITEM_NUMBER}.md`)), true);
+    const metrics = JSON.parse(
+      readFileSync(join(artifactDir, "review-cache-metrics.json"), "utf8"),
+    );
+    assert.equal(metrics.structural_cache_hits, 1);
+    assert.equal(metrics.hydrations, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/review-structural-cache.test.ts
+++ b/test/review-structural-cache.test.ts
@@ -617,6 +617,36 @@ test("explicit dispatch and maintainer requests always hydrate", () => {
   assert.equal(decision({ maintainerRequest: true }).reason, "maintainer_request");
 });
 
+test("a validated reservation covers its own activity but nothing after it", () => {
+  const reservedAt = "2026-07-10T10:05:00Z";
+  const priorRecord = record();
+  const base = {
+    review: review(),
+    priorRecord,
+    currentRecord: record(issueSnapshot({ activityUpdatedAt: reservedAt })),
+    reviewPolicy: "policy-1",
+    reviewModel: "gpt-5.6",
+    explicitDispatch: false,
+    maintainerRequest: false,
+    coordinationEnabled: true,
+    now: NOW,
+  };
+
+  assert.equal(reviewStructuralCacheDecision(base).reason, "activity_changed");
+  assert.deepEqual(
+    reviewStructuralCacheDecision({ ...base, ownedReservationUpdatedAt: reservedAt }),
+    { hit: true, reason: "hit" },
+  );
+  assert.equal(
+    reviewStructuralCacheDecision({
+      ...base,
+      currentRecord: record(issueSnapshot({ activityUpdatedAt: "2026-07-10T10:06:00Z" })),
+      ownedReservationUpdatedAt: reservedAt,
+    }).reason,
+    "activity_changed",
+  );
+});
+
 test("disabled coordination and missing lease revisions force hydration", () => {
   assert.equal(decision({ coordinationEnabled: false }).reason, "coordination_disabled");
   assert.equal(


### PR DESCRIPTION
## What Problem This Solves

Supersedes #1053 by @masatohoshino — same bug, smaller seam. Closes #1052.

Scheduled review deliveries run with `--skip-start-comment` because the exact-review queue reserves their lease before the runtime starts. That flag also disabled structural-cache coordination wholesale, so unchanged items were fully re-reviewed (Codex spend + API quota) every scheduled pass and could flip verdicts.

## The Fix

Instead of restructuring review preparation (+837 in #1053), the cache path learns to use the supplied scheduled-delivery lease: coordination is enabled when a supplied lease exists, the lease is validated and claimed inside the existing structural-cache flow, and the cache decision is re-evaluated against the reservation's own timestamp so owned-lease activity no longer reads as `activity_changed`. No preparation logic moves; the target-head cache policy is untouched. +463/−64 across 5 files, 285 of which are the workflow-level regression fixture.

## Proof

- Regression fixture drives the real review workflow with scheduled flags and fail-fast hydration/Codex sentinels: `cache-hit structural-unchanged skip-hydration-model #1052`, `structural_cache_hits=1 ... hydrations=0` (46/46 in the fixture file).
- Full `pnpm test:unit`: 1,961/1,963 pass (2 skipped), 0 fail.
- Coordinator autoreview clean (0.98).
- What only a live lane can additionally prove: Worker→Actions dispatch and real lease/comment persistence; the local fixture covers everything below that boundary.

Credit: commit carries `Co-authored-by: Masato Hoshino` — the diagnosis and test approach originate from #1053.
