### PR TITLE
fix(repair): suppress target pnpmfile via npm_config env spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Codex subprocess containment now actually suppresses target `.pnpmfile.cjs` execution: pnpm 11 only honors `npm_config_*` environment settings, so the previously used `PNPM_CONFIG_IGNORE_PNPMFILE` spelling was inert and a target repository's pnpmfile could run arbitrary code during repair installs.
 - Reconcile observers now start only for review titles they can classify, so queue-backed `Review exact item` and support runs no longer consume runner slots merely to report `skipped`; a new hourly janitor also cancels runs stuck in `queued` for over 24 hours before they decay into uncancellable zombies.
 - Deployment runs waiting for human approval no longer count as runner-queue congestion in operational health: a forgotten approval gate had pinned `oldest_queued_minutes` at eight-plus days and held work-execution status away from healthy; approval-gated runs now report separately (count and oldest age) in the API and the execution alert.
 - Terminal command acknowledgements whose status comment was deleted (or never existed) now complete as a durable `missing_status_comment` skip instead of requeueing the finalization driver forever every ~20 minutes.

--- a/src/repair/process-env.ts
+++ b/src/repair/process-env.ts
@@ -19,9 +19,11 @@ export function codexSubprocessEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     ...clawsweeperGitIdentityEnv(),
+    // pnpm 11 only honors npm_config_* env settings; keep PNPM_CONFIG_* for pnpm versions that read them.
     PNPM_CONFIG_IGNORE_SCRIPTS: "true",
     PNPM_CONFIG_IGNORE_PNPMFILE: "true",
     npm_config_ignore_scripts: "true",
+    npm_config_ignore_pnpmfile: "true",
   };
   const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
   const searchPath = env[pathKey];

--- a/test/repair/process-env.test.ts
+++ b/test/repair/process-env.test.ts
@@ -36,6 +36,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       PNPM_CONFIG_IGNORE_SCRIPTS: "false",
       PNPM_CONFIG_IGNORE_PNPMFILE: "false",
       npm_config_ignore_scripts: "false",
+      npm_config_ignore_pnpmfile: "false",
     },
     () => {
       const env = codexSubprocessEnv();
@@ -59,6 +60,7 @@ test("codexSubprocessEnv forces ClawSweeper git identity and strips tokens", () 
       assert.equal(env.PNPM_CONFIG_IGNORE_SCRIPTS, "true");
       assert.equal(env.PNPM_CONFIG_IGNORE_PNPMFILE, "true");
       assert.equal(env.npm_config_ignore_scripts, "true");
+      assert.equal(env.npm_config_ignore_pnpmfile, "true");
       assert.equal(internalCodexModel("internal"), "secret-model");
       assert.deepEqual(codexModelArgs("internal"), []);
       assert.deepEqual(codexModelArgs("secret-model"), []);
@@ -160,6 +162,7 @@ test("Codex subprocess prevents pnpm deploy from installing target Git hooks", (
     const unsafePnpmfile = deploy("unsafe-pnpmfile", {
       ...codexSubprocessEnv(),
       PNPM_CONFIG_IGNORE_PNPMFILE: "false",
+      npm_config_ignore_pnpmfile: "false",
     });
     assert.equal(unsafePnpmfile.status, 0, unsafePnpmfile.stderr || unsafePnpmfile.stdout);
     assert.equal(git("config", "--local", "--get", "core.hooksPath"), "git-hooks");


### PR DESCRIPTION
## Problem

`test/repair/process-env.test.ts` ("Codex subprocess prevents pnpm deploy from installing target Git hooks") fails reproducibly on current main: the pnpmfile leg of the containment test observes a target `.pnpmfile.cjs` executing and installing `core.hooksPath` despite `codexSubprocessEnv()` suppression.

This is not the `@pnpm/exe` mirror resolution issue — the fixture deploys a local workspace package with no registry access, and the deploy succeeds; the containment assertion afterwards is what fails.

## Root cause

pnpm 11.10.0 (the pinned version) does not honor `PNPM_CONFIG_*` environment settings at all — verified empirically for both `PNPM_CONFIG_IGNORE_PNPMFILE` and `PNPM_CONFIG_IGNORE_SCRIPTS` against `pnpm deploy`. Only `npm_config_*` spellings (case-insensitive) and CLI flags work.

Lifecycle-script suppression silently survived via the redundant `npm_config_ignore_scripts` key; pnpmfile suppression had no working spelling, so a target repository's `.pnpmfile.cjs` could run arbitrary code during Codex-driven installs.

## Fix

- `codexSubprocessEnv()` now also sets `npm_config_ignore_pnpmfile=true`; the `PNPM_CONFIG_*` keys stay as belt-and-braces for pnpm versions in target repos that may read them.
- The test asserts the new key survives an inherited `false`, and the unsafe-pnpmfile leg now disables the spelling pnpm actually reads.
- Changelog entry under 0.3.1 Unreleased.

## Proof

- `node --test test/repair/process-env.test.ts` — 7/7 pass (previously failing).
- Full repair suite: 1190 pass / 0 fail.
- `pnpm run check` — exit 0.
- Codex autoreview clean ("patch is correct (0.99)").
