### PR TITLE
fix(review): narrow stable maturity issue labels

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -254,19 +254,35 @@ Prefer `impact:ux-release-blocker` over `impact:ux-friction` when the same
 evidence supports both.
 
 Set `maturityLabels` for issues only; use `[]` for PRs or unsupported matches.
-`maturity:stable`: The issue's primary taxonomy surface is currently scored M4/M5.
+`maturity:stable`: The issue reports broken existing behavior whose primary
+taxonomy owner is currently scored M4/M5. M4/M5 ownership is necessary but is
+not enough by itself: this label is not a general description of the feature
+area's maturity.
 First run `node "$CLAWSWEEPER_PROOF_SCRATCH_DIR/maturity-stable-shortlist.mjs"`
 from the target checkout. Identify exactly one primary owner surface from the
-broken or missing product behavior and the source owner boundary. Shared
+broken product behavior and the source owner boundary. Shared
 Gateway/CLI transit, APIs, hosting, diagnostics, or implementation plumbing do
-not qualify an issue whose primary owner is below M4. A feature proposal does
-not qualify merely because implementing it would modify a stable surface.
-The helper lists both eligible M4+ surfaces and below-M4 exclusions. Read
+not qualify an issue whose primary owner is below M4.
+
+Before selecting the label, first decide whether current docs, tests, an API or
+CLI contract, or established shipped behavior define the expected behavior the
+issue says is broken. Prefer `[]` unless that existing contract and the M4/M5
+primary owner are both supported by current-source evidence. Use `[]` for a
+feature proposal, new capability, UX preference, new configuration or policy
+choice, docs/support request, cleanup, or unclear report even when it concerns
+an M4/M5 surface. `itemCategory: feature`, `skill`, `support`, `admin`,
+`docs`, `cleanup`, or `unclear`, or `requiresNewFeature: true` or
+`requiresNewConfigOption: true`, is a strong reason to use `[]`; do not
+relabel the request as a bug merely to make it eligible. If the
+existing-behavior contract or primary owner remains ambiguous after reading
+the relevant source, use `[]`.
+
+The helper lists M4+ candidate owner surfaces and below-M4 exclusions. Read
 `taxonomy.yaml`, the full checked-out `qa/maturity-scores.yaml`, or
 `docs/maturity/` when the primary owner or category is ambiguous. Select
-`maturity:stable` only when that primary surface is M4/M5. Cite the primary
-surface id/name/code and the matching category in `evidence` and
-`labelJustifications`.
+`maturity:stable` only when the broken existing contract's primary surface is
+M4/M5. Cite both the contract evidence and the primary surface id/name/code
+with its matching category in `evidence` and `labelJustifications`.
 Stable maturity supports priority, but does not automatically escalate it.
 
 Set `mergeRiskLabels` as PR-only ClawSweeper-owned GitHub labels for merge

--- a/schema/clawsweeper-decision.schema.json
+++ b/schema/clawsweeper-decision.schema.json
@@ -313,7 +313,7 @@
         "type": "string",
         "enum": ["maturity:stable"]
       },
-      "description": "Issue-only labels for mature taxonomy matches. Use [] for PRs. Select maturity:stable only when the issue's primary owner surface is currently M4/M5 in qa/maturity-scores.yaml; incidental Gateway/CLI transit or implementation plumbing does not qualify a lower-maturity surface."
+      "description": "Issue-only labels for broken existing behavior on a mature taxonomy surface. Use [] for PRs. M4/M5 primary ownership in qa/maturity-scores.yaml is necessary but not sufficient: select maturity:stable only when current docs, tests, API/CLI contracts, or established shipped behavior define the expected behavior that is broken. Use [] for feature proposals, new capabilities, UX preferences, new config or policy choices, docs/support work, cleanup, and unclear reports even when they concern an M4/M5 surface. Incidental Gateway/CLI transit or implementation plumbing does not qualify a lower-maturity surface. When the existing-behavior contract or primary owner remains ambiguous, use []."
     },
     "mergeRiskOptions": {
       "type": "array",

--- a/scripts/maturity-stable-shortlist.mjs
+++ b/scripts/maturity-stable-shortlist.mjs
@@ -19,9 +19,10 @@ function stableShortlist(text) {
   const nonStableRows = rows.filter((surface) => maturityCode(surface) < 4);
 
   return [
-    "Primary-surface rule: classify the issue by the product surface that owns the broken or missing behavior. Shared Gateway/CLI transit, APIs, hosting, or diagnostics do not make a lower-maturity owner eligible.",
+    "Conservative rule: maturity:stable is for broken existing behavior, not feature proposals, new capabilities, UX preferences, new config or policy choices, docs/support work, cleanup, or unclear reports. M4+ ownership is necessary but not sufficient; use no maturity label when the existing contract or primary owner is ambiguous.",
+    "Primary-surface rule: classify the issue by the product surface that owns the broken behavior. Shared Gateway/CLI transit, APIs, hosting, or diagnostics do not make a lower-maturity owner eligible.",
     "",
-    "M4+ primary surfaces (eligible for maturity:stable):",
+    "M4+ candidate primary owners (the issue must still report broken existing behavior):",
     ...(stableRows.length > 0
       ? stableRows.map((surface) => {
           const categories = surface.categories.length

--- a/src/clawsweeper-label-mutations.ts
+++ b/src/clawsweeper-label-mutations.ts
@@ -184,25 +184,21 @@ export function createLabelMutationOperations(
   function ensureMaturityLabel(name: MaturityLabelName, onMutation?: () => void): void {
     const definition = MATURITY_LABELS.find((label) => label.name === name);
     if (!definition) return;
-    try {
-      ghObservedMutationCommand({
-        identity: `label_create:${definition.name}`,
-        args: [
-          "label",
-          "create",
-          definition.name,
-          "--color",
-          definition.color,
-          "--description",
-          definition.description,
-        ],
-        attempts: 2,
-        onMutation,
-        knownNoMutation: labelAlreadyExistsError,
-      });
-    } catch (error) {
-      if (!labelAlreadyExistsError(error)) throw error;
-    }
+    ghObservedMutationCommand({
+      identity: `label_upsert:${definition.name}`,
+      args: [
+        "label",
+        "create",
+        definition.name,
+        "--force",
+        "--color",
+        definition.color,
+        "--description",
+        definition.description,
+      ],
+      attempts: 2,
+      onMutation,
+    });
   }
   function ensurePrRatingLabel(tier: PrRatingTier, onMutation?: () => void): void {
     const definition = ratingLabelForTier(tier);

--- a/src/clawsweeper-policy.ts
+++ b/src/clawsweeper-policy.ts
@@ -376,7 +376,7 @@ export const MATURITY_LABELS = [
   {
     name: "maturity:stable",
     color: "1F883D",
-    description: "Issue's primary taxonomy surface is currently scored M4/M5.",
+    description: "Broken existing behavior primarily owned by an M4/M5 scorecard surface.",
   },
 ] as const satisfies readonly {
   name: MaturityLabelName;

--- a/test/maturity-shortlist-script.test.ts
+++ b/test/maturity-shortlist-script.test.ts
@@ -38,8 +38,10 @@ test("maturity shortlist script distinguishes eligible primary surfaces from exc
       scorecard,
     ]).toString();
 
+    assert.match(output, /Conservative rule: maturity:stable is for broken existing behavior/);
+    assert.match(output, /M4\+ ownership is necessary but not sufficient/);
     assert.match(output, /Primary-surface rule:/);
-    assert.match(output, /M4\+ primary surfaces \(eligible for maturity:stable\):/);
+    assert.match(output, /M4\+ candidate primary owners/);
     assert.match(output, /gateway-runtime \| Gateway runtime \| M4 Stable \| q81 c89/);
     assert.match(output, /categories: HTTP APIs/);
     assert.match(output, /Below-M4 primary surfaces \(not eligible for maturity:stable\):/);

--- a/test/pr-label-policy.test.ts
+++ b/test/pr-label-policy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { createLabelSynchronization } from "../dist/clawsweeper-label-sync.js";
 import {
   featureShowcaseLabelsForTest,
   goodFirstIssueLabelOptedOutForTest,
@@ -733,13 +734,52 @@ test("ClawSweeper maturity labels remove stale owned labels and preserve unrelat
     {
       name: "maturity:stable",
       color: "1F883D",
-      description: "Issue's primary taxonomy surface is currently scored M4/M5.",
+      description: "Broken existing behavior primarily owned by an M4/M5 scorecard surface.",
     },
   ]);
   assert.deepEqual(maturityLabelsForTest(["bug"], ["maturity:stable"]), ["bug", "maturity:stable"]);
   assert.deepEqual(maturityLabelsForTest(["bug", "maturity:stable", "impact:security"], []), [
     "bug",
     "impact:security",
+  ]);
+});
+
+test("ClawSweeper updates managed maturity label metadata before applying it", () => {
+  const commands: string[][] = [];
+  const labels = createLabelSynchronization({
+    ghObservedMutationCommand: ({ args }: { args: string[] }) => {
+      commands.push(args);
+      return "";
+    },
+    hasNormalizedLabel: (current: readonly string[], label: string) =>
+      current.some((candidate) => candidate.toLowerCase() === label.toLowerCase()),
+    normalizeLabelName: (label: string) => label.toLowerCase(),
+    protectedLabels: () => [],
+    isBulkFilerExemptAuthorAssociation: () => false,
+    isBulkFilerExemptRepositoryPermission: () => false,
+    frontMatterValue: () => undefined,
+    frontMatterStringArray: () => [],
+    reportSecurityReview: () => ({ status: "not_applicable", evidence: [] }),
+    reviewSectionValue: () => "",
+    labelPolicy: {},
+  } as never);
+
+  labels.syncMaturityLabels({
+    number: 42,
+    labels: ["bug"],
+    maturityLabels: ["maturity:stable"],
+    dryRun: false,
+  });
+
+  assert.deepEqual(commands[0], [
+    "label",
+    "create",
+    "maturity:stable",
+    "--force",
+    "--color",
+    "1F883D",
+    "--description",
+    "Broken existing behavior primarily owned by an M4/M5 scorecard surface.",
   ]);
 });
 

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -513,7 +513,11 @@ test("review prompt uses token-light maturity shortlist helper", () => {
   assert.match(prompt, /maturity-stable-shortlist\.mjs/);
   assert.match(prompt, /Identify exactly one primary owner surface/);
   assert.match(prompt, /Shared\s+Gateway\/CLI transit/);
-  assert.match(prompt, /feature proposal does\s+not qualify/);
+  assert.match(prompt, /M4\/M5 ownership is necessary but is\s+not enough by itself/);
+  assert.match(prompt, /current docs, tests, an API or\s+CLI contract/);
+  assert.match(prompt, /feature proposal, new capability, UX preference/);
+  assert.match(prompt, /requiresNewFeature: true/);
+  assert.match(prompt, /existing-behavior\s+contract or primary owner remains ambiguous/);
   assert.match(
     runtimePrompt,
     /node "\$CLAWSWEEPER_PROOF_SCRATCH_DIR\/maturity-stable-shortlist\.mjs"/,


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper still applies `maturity:stable` to feature, documentation, and additive-capability requests when their area happens to map to an M4 surface. That makes the label too noisy to serve as a useful maintainer-attention or release signal.

## Why This Change Was Made

This narrows the model's guidance: M4/M5 ownership remains necessary, but the issue must also identify broken existing behavior backed by a current contract. Feature proposals, new capabilities, UX preferences, new configuration or policy choices, docs/support work, cleanup, and ambiguous reports should receive no maturity label.

The classifier remains model-driven. This does not add a deterministic category filter or post-processing rule. The only deterministic change is upserting the managed GitHub label's description when ClawSweeper applies it, so existing repository metadata converges on the same meaning.

OpenClaw Bay is unaffected; this changes review guidance and GitHub label metadata, not dashboard data contracts, queues, or publication lifecycle.

## User Impact

Maintainers should see fewer false-positive `maturity:stable` labels and can treat the remaining cohort as a more focused queue of defects in mature product surfaces.

## Evidence

- `pnpm run build`
- `node --test test/maturity-shortlist-script.test.ts test/pr-label-policy.test.ts test/review-prompt-policy.test.ts` — 79 passed, 0 failed
- `pnpm run format:check`
- `git diff --check`
- Fresh pre-commit and committed-range Codex reviews found no actionable defects.
- CI `pnpm check` passed. A concurrent local run passed static checks, all builds, lint, focused coverage, and the main coverage suite until eight unrelated `test/repair/target-validation.test.ts` environment cases could not resolve `pnpm@10.33.0` / `@pnpm/exe@10.33.0` from its configured package mirror; one deadline fixture reached `git check-attr` before its expected `corepack prepare` timeout.

## Real Behavior Proof

- Claim: a clear feature request on an M4 surface no longer receives `maturity:stable` solely because of that surface's score.
- Exercised surface: the built ClawSweeper local-only issue-review path using the revised prompt, schema, and maturity shortlist.
- Scenario: `openclaw/openclaw#118490`, an Android fullscreen chat-mode request that the current live review describes as a new presentation mode but labels stable because Android is M4.
- Command/environment: `pnpm run review -- --local-only --item-number 118490 --target-dir /Users/dallin/Documents/code/openclaw/openclaw.maturity-release-policy`; Node 26.3.0, pnpm 11.10.0, read-only local review.
- Observed result: complete/high-confidence review with `item_category: feature`, `requires_new_feature: true`, and `maturity_labels: []`. The evidence explicitly says Android is M4 but new features and UX preferences do not qualify.
- Artifact: local report `artifacts/local-review-118490/118490.md` at committed head `c8122a1824`.
- Limits: one representative known false positive was exercised; the run did not apply labels or mutate GitHub.

AI-assisted: yes.
