### PR TITLE
fix(review): attribute a finding to the patch before filing it

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -408,8 +408,10 @@ matching your confidence in the overall verdict.
 Establish patch attribution before you emit an actionable PR finding, and read
 it off the pull request diff first. That diff is computed against the merge
 base, so lines it shows as added or changed are this branch's work and lines it
-leaves as context are not. When the cited lines are visible there, that settles
-attribution.
+leaves as context are not. That settles who wrote the lines, which is not the
+whole test: a condition in untouched lines is still this patch's when the patch
+made it materially worse, newly made its bad path reachable, or claimed to cover
+it. Textual provenance answers authorship; the rules below answer attribution.
 
 The diff in this context is bounded — each file's patch is truncated and the
 file list is capped — so it will not always reach the cited lines. Then read the

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -405,6 +405,46 @@ correct` when the PR has no blocking correctness finding, and `not a patch` for
 issues and other non-PR reviews. Set `overallConfidenceScore` to a 0-1 number
 matching your confidence in the overall verdict.
 
+Establish patch attribution before you emit an actionable PR finding. The review
+context carries the pull request's `base.sha` and `head.sha`. Anchor every check
+on one snapshot — the merge base of those two commits — so the reads cannot
+disagree with each other. Read the base side of the affected file directly,
+`git show $(git merge-base <base-sha> <head-sha>):<file>`, instead of inferring
+provenance from the finding's line number or from the fact that a nearby line
+changed; and to see only what this branch changed use the three-dot form,
+`git diff <base-sha>...<head-sha> -- <file>`, which resolves to that same merge
+base, so base-branch commits made since the branch diverged are not read as this
+patch's work. When the patch renamed the file, its path does not exist on the
+base side: use the previous path for the base read, pass both paths to the diff,
+and do not read the missing path as evidence that the patch introduced the
+condition. For these comparisons do not anchor on `HEAD`, which is not guaranteed
+to be the PR head; `HEAD` remains correct where another instruction names it.
+
+A finding belongs in `reviewFindings` when this patch introduced the condition,
+made it materially worse, or newly made the bad path reachable. It also belongs
+there when covering the condition is part of the PR's own stated scope: a patch
+that claims to migrate every existing record but handles only new ones is
+incomplete against its own claim, even though the untouched records predate it.
+
+Otherwise — the condition is unchanged from the base, the patch neither worsens
+nor newly reaches it, and the PR never claimed to cover it — it is a pre-existing
+prerequisite rather than a defect this contributor created. Do not file it as a
+`reviewFinding` and do not let it set `overallCorrectness` to `patch is
+incorrect`; either would charge the contributor's patch quality for debt the
+branch did not create. Report it as the prerequisite it is: describe it in
+`risks`, name the next action in `bestSolution` or `workReason`, and — when it
+must be resolved before this PR can land — set `maintainerDecision.required:
+true` with the scope question, so automation pauses for the human choice instead
+of treating the PR as clear to land. Do not mark such an option
+`fix_before_merge` merely to signal a blocker: that category authorizes
+`automergeInstruction`, so it invites the repair lane to widen this PR into the
+pre-existing debt. If the base commit is unavailable or the comparison is
+inconclusive, treat the condition as patch-attributable and file the finding as
+usual — never drop a real defect on an unproven provenance claim. Whether a
+pre-existing prerequisite should be repaired inside this PR or tracked as
+explicit follow-up is the target repository's scope decision; report the
+prerequisite and let the target `AGENTS.md` policy govern the scope call.
+
 For PRs, apply re-review continuity. When the review context includes
 `previousClawSweeperReview`, this is a follow-up review cycle, not a first
 look: `previousClawSweeperReview.findings` lists the findings from the latest

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -405,20 +405,46 @@ correct` when the PR has no blocking correctness finding, and `not a patch` for
 issues and other non-PR reviews. Set `overallConfidenceScore` to a 0-1 number
 matching your confidence in the overall verdict.
 
-Establish patch attribution before you emit an actionable PR finding. The review
-context carries the pull request's `base.sha` and `head.sha`. Anchor every check
-on one snapshot — the merge base of those two commits — so the reads cannot
-disagree with each other. Read the base side of the affected file directly,
-`git show $(git merge-base <base-sha> <head-sha>):<file>`, instead of inferring
-provenance from the finding's line number or from the fact that a nearby line
-changed; and to see only what this branch changed use the three-dot form,
-`git diff <base-sha>...<head-sha> -- <file>`, which resolves to that same merge
-base, so base-branch commits made since the branch diverged are not read as this
-patch's work. When the patch renamed the file, its path does not exist on the
-base side: use the previous path for the base read, pass both paths to the diff,
-and do not read the missing path as evidence that the patch introduced the
-condition. For these comparisons do not anchor on `HEAD`, which is not guaranteed
-to be the PR head; `HEAD` remains correct where another instruction names it.
+Establish patch attribution before you emit an actionable PR finding, and read
+it off the pull request diff first. That diff is computed against the merge
+base, so lines it shows as added or changed are this branch's work and lines it
+leaves as context are not. When the cited lines are visible there, that settles
+attribution.
+
+The diff in this context is bounded — each file's patch is truncated and the
+file list is capped — so it will not always reach the cited lines. Then read the
+files directly. Both sides are available: `GIT_NO_LAZY_FETCH=1 git show
+<head-sha>:<file>` for the code as this branch leaves it, which is the read to
+use when a truncated patch hides the change you are reviewing, and
+`GIT_NO_LAZY_FETCH=1 git show <base-sha>:<file>` for the base side,
+using the file's `previous_filename` when the patch renamed it. For a renamed
+file, do not treat the new path's absence on the base side as evidence that the
+patch introduced the condition — read the previous path instead. That exception
+is for renames only: when the diff reports the file as added, absence is exactly
+what added means, and the patch owns what is in it. Keep that environment variable: the checkout is a blobless promisor
+clone and review hydration deliberately skips blobs over its size budget, so a
+plain `git show` would pull an oversized one back over the network. Let the read
+fail instead and fall through to the unresolved case below.
+Note what `base.sha` is: the base branch's current tip, not the merge base. If
+the branch is behind its base, that read cuts both ways and settles nothing on
+its own: a difference there may be the base branch's own work rather than this
+contributor's, and matching content there may be something the base branch
+introduced independently after the branch diverged rather than code the patch
+inherited. Unless the context positively shows the branch is not behind — an
+absent or unknown `mergeableState` is not that showing — use this fallback to
+raise doubt, never to clear the patch. Do not run `git merge-base`, and do not use the three-dot
+`git diff <a>...<b>` form: the review checkout can materialize the base and head
+commits with `--depth=1`, which leaves both trees present and their shared
+history absent, and both commands fail outright in that state.
+
+Blob hydration is best-effort — it is skipped for oversized or unresolvable
+files and only warns — so the base read can be unavailable for a condition that
+predates the branch. If neither the diff nor the base read settles provenance,
+keep the finding rather than dropping a real defect, but say in its body that
+provenance could not be established, and do not let an unestablished attribution
+by itself set `overallCorrectness` to `patch is incorrect`. A retained finding
+still counts as contributor work, so make both reads above a real attempt before
+falling back to this.
 
 A finding belongs in `reviewFindings` when this patch introduced the condition,
 made it materially worse, or newly made the bad path reachable. It also belongs
@@ -438,9 +464,7 @@ true` with the scope question, so automation pauses for the human choice instead
 of treating the PR as clear to land. Do not mark such an option
 `fix_before_merge` merely to signal a blocker: that category authorizes
 `automergeInstruction`, so it invites the repair lane to widen this PR into the
-pre-existing debt. If the base commit is unavailable or the comparison is
-inconclusive, treat the condition as patch-attributable and file the finding as
-usual — never drop a real defect on an unproven provenance claim. Whether a
+pre-existing debt. Whether a
 pre-existing prerequisite should be repaired inside this PR or tracked as
 explicit follow-up is the target repository's scope decision; report the
 prerequisite and let the target `AGENTS.md` policy govern the scope call.

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -266,3 +266,123 @@ test("review blob sizes use one bounded GraphQL metadata request", () => {
     /invalid bounded review blob metadata request/,
   );
 });
+
+// The review cache materializes a missing base or head with `--depth=1`
+// (`ensureReviewTreeCommit`), which leaves both trees present and their shared
+// history absent. The attribution rule in `prompts/review-item.md` is written
+// around that boundary, so this pins it: the operations the prompt names must
+// run offline after hydration, and the ones it forbids must be the ones that
+// cannot. Found by the first live ClawSweeper review of openclaw/clawsweeper#1075.
+function shallowReviewCacheFixture() {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-shallow-cache-"));
+  const origin = join(root, "origin.git");
+  const source = join(root, "source");
+  const target = join(root, "target");
+  mkdirSync(source);
+  git(root, "init", "--bare", "-q", origin);
+  git(origin, "config", "uploadpack.allowFilter", "true");
+  git(source, "init", "-q", "-b", "main");
+  git(source, "config", "user.name", "ClawSweeper Review Test");
+  git(source, "config", "user.email", "review-test@example.com");
+  git(source, "config", "commit.gpgsign", "false");
+  writeFileSync(join(source, "touched.txt"), "before\n");
+  writeFileSync(join(source, "moved.txt"), "pre-existing condition\n");
+  git(source, "add", ".");
+  git(source, "commit", "-qm", "base");
+  const baseSha = git(source, "rev-parse", "HEAD");
+  git(source, "remote", "add", "origin", origin);
+  git(source, "push", "-q", "origin", "main");
+
+  git(source, "checkout", "-qb", "feature");
+  writeFileSync(join(source, "touched.txt"), "after\n");
+  git(source, "mv", "moved.txt", "renamed.txt");
+  git(source, "add", ".");
+  git(source, "commit", "-qm", "feature");
+  const headSha = git(source, "rev-parse", "HEAD");
+  git(source, "push", "-q", "origin", "HEAD:refs/pull/991/head");
+
+  // Exactly what `ensureReviewTreeCommit` runs when neither commit is present.
+  git(target === "" ? root : root, "init", "-q", target);
+  git(target, "remote", "add", "origin", `file://${origin}`);
+  for (const [ref, destination] of [
+    ["refs/heads/main", "refs/clawsweeper/review-cache/base-991"],
+    ["refs/pull/991/head", "refs/clawsweeper/review-cache/head-991"],
+  ] as const) {
+    git(
+      target,
+      "fetch",
+      "--force",
+      "--filter=blob:none",
+      "origin",
+      `${ref}:${destination}`,
+      "--depth=1",
+    );
+  }
+  return { root, source, target, baseSha, headSha };
+}
+
+function gitStatusOffline(cwd: string, ...args: string[]): number {
+  return (
+    spawnSync("git", args, {
+      cwd,
+      env: { ...process.env, GIT_NO_LAZY_FETCH: "1" },
+      stdio: "ignore",
+    }).status ?? -1
+  );
+}
+
+test("attribution reads survive the depth-1 review cache that has no shared history", () => {
+  const fixture = shallowReviewCacheFixture();
+  try {
+    const result = hydratePullRequestReviewBlobs({
+      targetDir: fixture.target,
+      baseSha: fixture.baseSha,
+      headSha: fixture.headSha,
+      resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
+      files: [
+        { filename: "touched.txt", status: "modified" },
+        { filename: "renamed.txt", previous_filename: "moved.txt", status: "renamed" },
+      ],
+    });
+    assert.equal(result.hydrated, true);
+
+    // Both commits are present — the P1's premise, not a contradiction of it.
+    assert.equal(
+      gitStatusOffline(fixture.target, "cat-file", "-e", `${fixture.baseSha}^{commit}`),
+      0,
+    );
+    assert.equal(
+      gitStatusOffline(fixture.target, "cat-file", "-e", `${fixture.headSha}^{commit}`),
+      0,
+    );
+
+    // Ancestry is not. These are the two commands the prompt must never name.
+    assert.notEqual(
+      gitStatusOffline(fixture.target, "merge-base", fixture.baseSha, fixture.headSha),
+      0,
+    );
+    assert.notEqual(
+      gitStatusOffline(fixture.target, "diff", `${fixture.baseSha}...${fixture.headSha}`),
+      0,
+    );
+
+    // What the prompt does name works offline, including the renamed file read
+    // through its previous path. Cut the remote so a lazy fetch cannot rescue it.
+    git(fixture.target, "remote", "set-url", "origin", "https://invalid.invalid/offline.git");
+    assert.equal(git(fixture.target, "show", `${fixture.baseSha}:touched.txt`), "before");
+    assert.equal(
+      git(fixture.target, "show", `${fixture.baseSha}:moved.txt`),
+      "pre-existing condition",
+    );
+    assert.equal(
+      git(fixture.target, "show", `${fixture.headSha}:renamed.txt`),
+      "pre-existing condition",
+    );
+
+    // The rename trap: the head path does not exist on the base side, and that
+    // absence must never be read as "the patch introduced this file".
+    assert.notEqual(gitStatusOffline(fixture.target, "show", `${fixture.baseSha}:renamed.txt`), 0);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -479,6 +479,75 @@ test("decision schema keeps draft and protected workflow state out of PR rank", 
   );
 });
 
+test("review prompt requires base attribution before a finding is filed", () => {
+  const prompt = readFileSync("prompts/review-item.md", "utf8");
+
+  assert.match(prompt, /Establish patch attribution before you emit an actionable PR finding/);
+  assert.match(prompt, /carries the pull request's `base\.sha` and `head\.sha`/);
+  assert.match(prompt, /git show \$\(git merge-base <base-sha> <head-sha>\):<file>/);
+  // Both reads resolve to the same snapshot, or they can contradict each other.
+  assert.match(prompt, /Anchor every check\s+on one snapshot/);
+  assert.match(prompt, /instead of inferring\s+provenance from the finding's line number/);
+
+  // Three-dot against the PR head, not two-dot against HEAD: the two-dot form
+  // drags in base-branch commits made since the branch diverged, and HEAD is
+  // not guaranteed to be the PR head in every review lane.
+  assert.match(prompt, /git diff <base-sha>\.\.\.<head-sha> -- <file>/);
+  assert.match(prompt, /which resolves to that same merge\s+base/);
+  assert.match(prompt, /For these comparisons do not anchor on `HEAD`/);
+  // ...but the prohibition must stay scoped: the re-review paragraph below
+  // still requires `git diff <earlier-sha>..HEAD` for lateFinding.
+  assert.match(prompt, /`HEAD` remains correct where another instruction names it/);
+
+  // A renamed file has no base-side path under its new name; reading that as
+  // "introduced by the patch" would misattribute untouched code.
+  assert.match(
+    prompt,
+    /When the patch renamed the file, its path does not exist on the\s+base side/,
+  );
+  assert.match(prompt, /pass both paths to the diff/);
+  assert.match(prompt, /do not read the missing path as evidence/);
+  assert.doesNotMatch(prompt, /git diff <base-sha>\.\.HEAD/);
+  assert.match(
+    prompt,
+    /introduced the condition,\s+made it materially worse, or newly made the bad path reachable/,
+  );
+
+  // A patch that misses state it claimed to cover stays a finding: attribution
+  // must not become an escape hatch for anything that predates the branch.
+  assert.match(prompt, /covering the condition is part of the\s+PR's own stated scope/);
+  assert.match(prompt, /incomplete against its own claim/);
+
+  // A genuine pre-existing prerequisite is kept out of both channels that score
+  // the contributor's patch.
+  assert.match(prompt, /Do not file it as a\s+`reviewFinding`/);
+  assert.match(prompt, /do not let it set `overallCorrectness` to `patch is\s+incorrect`/);
+  assert.match(
+    prompt,
+    /charge the contributor's patch quality for debt the\s+branch did not create/,
+  );
+
+  // ...and routed to the field that actually pauses automated landing.
+  assert.match(prompt, /set `maintainerDecision\.required:\s+true` with the scope question/);
+  assert.match(prompt, /automation pauses for the human choice/);
+
+  // fix_before_merge is the wrong destination: it authorizes automergeInstruction.
+  assert.match(
+    prompt,
+    /Do not mark such an option\s+`fix_before_merge` merely to signal a blocker/,
+  );
+  assert.match(prompt, /invites the repair lane to widen this PR into the\s+pre-existing debt/);
+
+  // Fail closed: an unprovable provenance claim keeps the finding.
+  assert.match(
+    prompt,
+    /base commit is unavailable or the comparison is\s+inconclusive, treat the condition as patch-attributable/,
+  );
+
+  // Scope stays the target repository's call, not ClawSweeper's.
+  assert.match(prompt, /let the target `AGENTS\.md` policy govern the scope call/);
+});
+
 test("review finding schema requires every structured-output property", () => {
   const schema = JSON.parse(readFileSync("schema/clawsweeper-decision.schema.json", "utf8"));
   const finding = schema.properties.reviewFindings.items;

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -488,6 +488,10 @@ test("review prompt requires base attribution before a finding is filed", () => 
   // `base.sha` alone does not.
   assert.match(prompt, /read\s+it off the pull request diff first/);
   assert.match(prompt, /computed against the merge\s+base/);
+  // Line provenance is authorship, not attribution: a newly-reachable defect
+  // lives in untouched lines and must not be suppressed by the diff rule.
+  assert.match(prompt, /That settles who wrote the lines, which is not the\s+whole test/);
+  assert.match(prompt, /Textual provenance answers authorship; the rules below answer attribution/);
 
   // ...but that diff is bounded, so the fallback and its caveat are both stated.
   assert.match(prompt, /each file's patch is truncated and the\s+file list is capped/);

--- a/test/review-prompt-policy.test.ts
+++ b/test/review-prompt-policy.test.ts
@@ -483,68 +483,69 @@ test("review prompt requires base attribution before a finding is filed", () => 
   const prompt = readFileSync("prompts/review-item.md", "utf8");
 
   assert.match(prompt, /Establish patch attribution before you emit an actionable PR finding/);
-  assert.match(prompt, /carries the pull request's `base\.sha` and `head\.sha`/);
-  assert.match(prompt, /git show \$\(git merge-base <base-sha> <head-sha>\):<file>/);
-  // Both reads resolve to the same snapshot, or they can contradict each other.
-  assert.match(prompt, /Anchor every check\s+on one snapshot/);
-  assert.match(prompt, /instead of inferring\s+provenance from the finding's line number/);
 
-  // Three-dot against the PR head, not two-dot against HEAD: the two-dot form
-  // drags in base-branch commits made since the branch diverged, and HEAD is
-  // not guaranteed to be the PR head in every review lane.
-  assert.match(prompt, /git diff <base-sha>\.\.\.<head-sha> -- <file>/);
-  assert.match(prompt, /which resolves to that same merge\s+base/);
-  assert.match(prompt, /For these comparisons do not anchor on `HEAD`/);
-  // ...but the prohibition must stay scoped: the re-review paragraph below
-  // still requires `git diff <earlier-sha>..HEAD` for lateFinding.
-  assert.match(prompt, /`HEAD` remains correct where another instruction names it/);
+  // The PR diff is the primary source and carries merge-base semantics, which
+  // `base.sha` alone does not.
+  assert.match(prompt, /read\s+it off the pull request diff first/);
+  assert.match(prompt, /computed against the merge\s+base/);
+
+  // ...but that diff is bounded, so the fallback and its caveat are both stated.
+  assert.match(prompt, /each file's patch is truncated and the\s+file list is capped/);
+  assert.match(prompt, /GIT_NO_LAZY_FETCH=1 git show <base-sha>:<file>/);
+  // A truncated patch must not leave head-side code unreadable.
+  assert.match(prompt, /GIT_NO_LAZY_FETCH=1 git show\s+<head-sha>:<file>/);
+  assert.match(prompt, /when a truncated patch hides the change you are reviewing/);
+  // Hydration skips oversized blobs on purpose; a bare `git show` in a
+  // promisor clone would fetch them back and bypass that budget.
+  assert.match(prompt, /review hydration deliberately skips blobs over its size budget/);
+  assert.match(prompt, /Let the read\s+fail instead/);
+  assert.match(prompt, /the base branch's current tip, not the merge base/);
+  // The fallback is asymmetric on a stale branch: it may raise doubt, never
+  // clear the patch, or independent base-branch work reads as inherited code.
+  assert.match(prompt, /that read cuts both ways and settles nothing on\s+its own/);
+  assert.match(prompt, /introduced independently after the branch diverged/);
+  assert.match(prompt, /raise doubt, never to clear the patch/);
+  // Unknown staleness must default to the safe side, not to "not behind".
+  assert.match(prompt, /Unless the context positively shows the branch is not behind/);
+  assert.match(prompt, /an\s+absent or unknown `mergeableState` is not that showing/);
+
+  // Ancestry is unavailable in the depth-1 review cache, so the procedure may
+  // not name it. See review-blob-hydration.test.ts for the executable proof.
+  assert.match(prompt, /Do not run `git merge-base`/);
+  assert.match(prompt, /do not use the three-dot\s+`git diff <a>\.\.\.<b>` form/);
+  assert.match(prompt, /--depth=1/);
+  assert.doesNotMatch(prompt, /git show \$\(git merge-base/);
+  assert.doesNotMatch(prompt, /git diff <base-sha>\.\.\.<head-sha>/);
+  assert.doesNotMatch(prompt, /git diff <base-sha>\.\.HEAD/);
 
   // A renamed file has no base-side path under its new name; reading that as
   // "introduced by the patch" would misattribute untouched code.
+  assert.match(prompt, /`previous_filename` when the patch renamed it/);
+  assert.match(prompt, /do not treat the new path's absence on the base side as evidence/);
+  // ...but only for renames: an added file legitimately has no base side.
+  assert.match(prompt, /That exception\s+is for renames only/);
+  assert.match(prompt, /absence is exactly\s+what added means/);
+
+  // Hydration is best-effort, so unknown provenance keeps the finding without
+  // scoring the patch for it.
+  assert.match(prompt, /Blob hydration is best-effort/);
+  assert.match(prompt, /keep the finding rather than dropping a real defect/);
+  // Retention is deliberate and costly, so the prompt says so rather than
+  // implying the overallCorrectness guard makes it free.
+  assert.match(prompt, /A retained finding\s+still counts as contributor work/);
+  assert.match(prompt, /say in its body that\s+provenance could not be established/);
   assert.match(
     prompt,
-    /When the patch renamed the file, its path does not exist on the\s+base side/,
-  );
-  assert.match(prompt, /pass both paths to the diff/);
-  assert.match(prompt, /do not read the missing path as evidence/);
-  assert.doesNotMatch(prompt, /git diff <base-sha>\.\.HEAD/);
-  assert.match(
-    prompt,
-    /introduced the condition,\s+made it materially worse, or newly made the bad path reachable/,
+    /do not let an unestablished attribution\s+by itself set `overallCorrectness` to `patch is incorrect`/,
   );
 
-  // A patch that misses state it claimed to cover stays a finding: attribution
-  // must not become an escape hatch for anything that predates the branch.
-  assert.match(prompt, /covering the condition is part of the\s+PR's own stated scope/);
-  assert.match(prompt, /incomplete against its own claim/);
-
-  // A genuine pre-existing prerequisite is kept out of both channels that score
-  // the contributor's patch.
+  // A pre-existing prerequisite stays out of both channels that score the patch.
   assert.match(prompt, /Do not file it as a\s+`reviewFinding`/);
-  assert.match(prompt, /do not let it set `overallCorrectness` to `patch is\s+incorrect`/);
-  assert.match(
-    prompt,
-    /charge the contributor's patch quality for debt the\s+branch did not create/,
-  );
-
-  // ...and routed to the field that actually pauses automated landing.
   assert.match(prompt, /set `maintainerDecision\.required:\s+true` with the scope question/);
-  assert.match(prompt, /automation pauses for the human choice/);
-
-  // fix_before_merge is the wrong destination: it authorizes automergeInstruction.
   assert.match(
     prompt,
     /Do not mark such an option\s+`fix_before_merge` merely to signal a blocker/,
   );
-  assert.match(prompt, /invites the repair lane to widen this PR into the\s+pre-existing debt/);
-
-  // Fail closed: an unprovable provenance claim keeps the finding.
-  assert.match(
-    prompt,
-    /base commit is unavailable or the comparison is\s+inconclusive, treat the condition as patch-attributable/,
-  );
-
-  // Scope stays the target repository's call, not ClawSweeper's.
   assert.match(prompt, /let the target `AGENTS\.md` policy govern the scope call/);
 });
 


### PR DESCRIPTION
Closes #1074

## What Problem This Solves

Resolves a problem where a condition that already existed in the PR base can be
filed as a defect in the contributor's patch, turning it into contributor-facing
`Before merge` work.

The review prompt already states the rule twice — findings are defects
**introduced by the patch** — but it gives the reviewer no way to establish that.
Nothing in the prompt names the PR base, and the location guidance is only that
`the location should overlap the PR diff when possible`. Compare `lateFinding`,
the other provenance property in the same section: it gets a named verification
command, an instruction not to infer from a similar title or line location, and
an explicit fail-closed default.

That gap has a cost for contributors who follow OpenClaw's own rules.
`CONTRIBUTING.md` asks them to keep PRs focused (one thing per PR), and the root
`AGENTS.md` accepts a one-sided fix that records `explicit follow-up work`.
A contributor who does exactly that, stating the boundary and naming the
follow-up, can still have the untouched surface charged to their patch as
contributor-facing rework.

## Why This Change Was Made

The change is prose in the `reviewFindings` section of the review prompt, in the
same shape `lateFinding` already landed in: a named check, a stated rule, and a
fail-closed default. There is no schema change, no parser change, no rating
change, no second review pass, and no additional model call.

### What the first live review changed

The first ClawSweeper scan of this PR found a real defect in it, and the
procedure below is the repair. The original wording told the reviewer to run
`git merge-base` and a three-dot `git diff a...b`. ClawSweeper observed that the
review cache materializes a missing base or head with `--depth=1`
(`ensureReviewTreeCommit`), which leaves both trees present and their shared
history absent — so both commands fail there, the rule falls into its own
fail-closed branch, and it files the base-state finding it exists to prevent.

Reproduced against this PR's own refs, with the exact production fetches and
lazy fetching disabled:

Reproducible from the review comment on this PR, which names
`src/clawsweeper-context-hydration.ts` and the `--depth=1` fetch, and from the
harness below, which re-runs those exact fetches against this PR's own refs:

```text
git cat-file -e <base>^{commit}          rc=0     both commits present
git cat-file -e <head>^{commit}          rc=0
git merge-base <base> <head>             rc=1     no shared history
git diff <base>...<head> -- <file>       rc=128   "fatal: no merge base"
git show <base>:<file>                   rc=0     after blob hydration
```

The finding was accepted in full — the observed cache behaviour, the diagnosis,
and the conclusion that the procedure had to change. A separate recommendation
from a later local round was declined on the record; see the closeout. Nothing about the hydration is wrong: its contract is
the two commits plus the base-side and head-side blob of every changed file,
including a renamed file's previous path, and it keeps that contract exactly.
The prompt was asking for something outside it, so the prompt is what changed —
no production TypeScript, no new fetch, no widened cache.

### The procedure that replaced it

It now names only sources the review actually has, in the order it should trust
them.

1. **The pull request diff, first.** It arrives as data in the review context —
   `pullFiles[].patch`, fetched from the GitHub API during hydration — not as
   something the checkout computes. GitHub derives it against the merge base on
   its own side, where the full history exists, so the shallow cache cannot
   affect it: lines it shows as added or changed are this branch's work and
   lines it leaves as context are not. That settles *authorship*, which is not
   the whole test: a condition in untouched lines is still the patch's when the
   patch worsened it, newly made its bad path reachable, or claimed to cover it.
   The prompt says so explicitly, so the diff rule cannot suppress the
   newly-reachable case the scope preserves. This is also why the repair needs
   no local merge base at all.
2. **Both sides of the file, as a bounded fallback.** `GIT_NO_LAZY_FETCH=1 git
   show <head-sha>:<file>` for the code as the branch leaves it — the read to
   use when a truncated patch hides the change being reviewed — and
   `GIT_NO_LAZY_FETCH=1 git show <base-sha>:<file>` for the base side, using
   `previous_filename` when the patch renamed it. The environment variable is load-bearing: the
   checkout is a blobless promisor clone and hydration deliberately skips blobs
   over its size budget, so a plain `git show` would pull an oversized one back
   over the network and walk around the budget it depends on. Failing the read
   is the correct outcome — it falls through to the unresolved case. Needed because that diff is truncated per file and its file list is
   capped, so it does not always reach the cited lines. The prompt states plainly
   that `base.sha` is the base branch's current **tip**, not the merge base. On a
   branch behind its base that read cuts both ways: a difference may be the base
   branch's own work rather than the contributor's, and matching content may be
   something the base branch introduced independently after divergence rather
   than code the patch inherited. So the fallback may clear the patch only when
   the context positively shows the branch is not behind — an absent or unknown
   `mergeableState` is not that showing — and otherwise raises doubt only.
3. **`git merge-base` and the three-dot diff — forbidden**, with the `--depth=1`
   reason stated inline so the instruction cannot drift back.

Eight later review rounds sharpened each of those, and it is worth being
explicit that most of them pushed in the direction of *not* suppressing:
an unscoped rename exception would have cleared findings on added files,
base-side parity on a stale branch would have cleared findings the branch
actually introduced, and an unknown merge state would have defaulted to the
permissive reading. Each is now closed on the conservative side. Reading `base.sha` alone
carries no merge-base semantics: on a stale branch a fix that landed on main
after divergence is present at the base and absent from the head, which reads as
*the patch introduced it*. The in-context diff is not complete. And blob
hydration is best-effort — it skips oversized or unresolvable files and only
warns — so the base read can be missing for a condition that genuinely predates
the branch.

The stale-base problem also has two directions, and the first repair only closed
one: a difference at the base tip being read as the patch's work. The mirror —
matching content being read as inherited when the base branch added it
independently — would *suppress* a real finding, which is the worse direction,
and it is now closed too.

The hydration finding forced a distinction the earlier wording had collapsed. Keeping a
defect visible and scoring the contributor for it are separate acts. When
neither source settles provenance the finding stays, so no real defect is
dropped, but the reviewer must say provenance could not be established, and that
unestablished attribution may not by itself set `overallCorrectness` to
`patch is incorrect`.

The incremental cost of this change is zero network operations. Blob hydration
already runs on every PR review and is unchanged here; the procedure adds at
most one `git show` per side of the file being attributed, only when the bounded
diff does not already answer the question, and `GIT_NO_LAZY_FETCH=1` guarantees
those reads never fetch. When hydration skipped the blob the read fails rather
than reaching for it — that is the point of the flag, and the proof shows both
sides of it: the same read is rc=128 before hydration and rc=0 after.

**One review finding was not adopted, and it is worth naming.** A later round
argued that an unproven attribution should leave `reviewFindings` entirely and
live in `risks` plus a maintainer decision. Its factual half is right and is now
reflected in the prompt: `hasBlockingReviewFindings` counts any P0-P2 finding as
contributor work, so the `overallCorrectness` guard does not spare the
contributor a blocker, and the wording no longer implies it does. Its
recommendation is declined. Hydration skips a file because the file is large or
unresolvable, which is uncorrelated with whether the patch introduced the
defect — so routing on that signal would let real patch defects stop being
contributor work exactly when the evidence is thinnest. The defect itself is
established by reading the head; only its author is not. Keeping it costs the
contributor one reply, which the maintainer-decision route then resolves.
Whether ClawSweeper should prefer the opposite trade is a product call — which
is the same call the live review raised in its own decision packet.

The paragraph is one rule with the parts a rule needs: how to establish
provenance, what stays a finding, where a non-attributable prerequisite goes,
and what to do when the check cannot be completed. The exact decision sequence
is the diff itself, and the linked issue states it as an ordered rule.

Two things worth separating, since they are easy to conflate:

- **No code path changes.** This diff touches no landing, repair-lane or
  automerge logic. `maintainerDecision.required` already routes to a needs-human
  verdict today and `fix_before_merge` already authorises an automerge
  instruction today; neither contract is edited here.
- **Observable behaviour does change, and that is the point.** On a PR carrying
  a genuine pre-existing prerequisite, the same condition should now arrive as a
  maintainer decision rather than as contributor rework — so that PR gains a
  human-decision pause it might not have had, and loses a finding it should not
  have had. Fewer findings and more decision packets on that class of PR is the
  intended effect, not a side effect.

Deliberate boundaries:

- **Normal findings stay strict.** Introduced, materially worsened, and
  newly-reachable conditions all remain `reviewFindings`.
- **No escape hatch.** A patch that claims to migrate every existing record but
  handles only new ones is still incomplete against its own claim, even though
  the untouched records predate it. That case stays a finding.
- **Fails closed.** If the base commit is unavailable or the comparison is
  inconclusive, the condition is treated as patch-attributable and the finding is
  filed. Blob hydration is best-effort, so a fail-open rule would silently
  suppress real defects.
- **Routes to the field that actually pauses landing.** A genuine pre-existing
  prerequisite goes to `risks` plus `maintainerDecision.required`, not to
  `mergeRiskOptions`. Read off the current source rather than measured in a live
  run, so treat these three as maintainer verification points:
  `isRepairLoopPassReport` reads `reviewFindings.length` but no merge-risk
  field, so a prerequisite parked in merge risk alone still yields
  `clawsweeper-verdict:pass` on an automerge-labelled PR;
  `maintainerDecision` is not an input to `derivedPrRating` or
  `prStatusLabelKind`, so it cannot move patch quality; and `fix_before_merge`
  is the only category permitted to carry `automergeInstruction`. The prompt also warns against `fix_before_merge`
  specifically, because that is the only category permitted to carry
  `automergeInstruction` — it invites the repair lane to widen the PR into the
  pre-existing debt.
- **Scope stays the target repository's call.** Whether a prerequisite is
  repaired in the same PR or tracked as follow-up is left to the target
  `AGENTS.md`, per the root instruction that generic ClawSweeper prompts stay
  repo-agnostic.
- **The sibling prompt needs no matching change.** `prompts/review-commit.md`
  also emits findings, but its reviewed unit is one commit against the parent SHA
  the prompt is handed directly, so there is no base-tip-versus-merge-base
  question to get wrong and no `patchTier` for a misattributed finding to lower.
  The gap this fixes is specific to PR review.

## User Impact

When a prerequisite is *established* as pre-existing, it stops being contributor
patch debt and becomes a maintainer decision that pauses automated landing, so a
contributor who keeps the focused-PR shape OpenClaw asks for is not scored for
debt their branch did not create.

That qualifier is the honest part. Where provenance cannot be established — the
branch is behind its base, the patch is truncated past the cited lines, or the
base blob was skipped as oversized — the finding stays contributor-facing by
design. The change narrows when a contributor is charged; it does not promise
they never are.

No configuration, schema, or public interface changes. `patchTierFromReview`,
`hasBlockingReviewFindings`, `isReadyForMaintainerLook`, `parseReviewFinding`
and the decision schema are untouched — but that is a statement about their
implementation, not their output. They keep computing what they compute today;
what reaches them changes, which is the whole point, and their results move
accordingly on PRs carrying a pre-existing prerequisite.

**OpenClaw Bay: schema unchanged, distributions shift.** No decision-schema field is added, removed
or retyped, and the durable report and comment renderers are untouched, so Bay
reads exactly the fields it reads today and no data contract moves. Any view
that aggregates finding counts will see the distribution shift, which is the
intended effect of the change rather than a contract break.

## Evidence

Prompt prose plus two tests. **No production TypeScript** — the hydration path
is unchanged, because what it undertakes was never the problem.

What rests on what, since the claims have different strengths: the two tests are
durable and re-runnable, and carry the procedure's wording and the shallow-cache
behaviour. The Real Behavior Proof below is recorded output from a one-off local harness
run against this PR's live refs. The harness is not a shipped file, but every
git command it issues is quoted in that section, so the measurement can be
repeated by hand. The routing claims — that a prerequisite belongs in `risks` plus
`maintainerDecision.required` and not `fix_before_merge` — are read off current
source rather than exercised, and are flagged as maintainer verification points
rather than presented as measured.

### Root cause

The prompt states that findings are patch-introduced defects but
supplies no procedure for establishing it, so provenance is left to inference
from line numbers.

### Fix

This PR changes one paragraph pair in the `reviewFindings` section. It
names the base and head SHAs the review context already carries, names the two
commands that read the base side, keeps as findings every condition this patch
introduced, worsened, newly reached, or claimed to cover but did not, routes a
genuine pre-existing prerequisite to `risks` plus `maintainerDecision.required`,
warns off `fix_before_merge`, and fails closed.

### Tests added

Two, because a prompt assertion alone cannot speak for the review environment.

- `test/review-prompt-policy.test.ts` — pins every clause of the procedure in
  the file's existing `readFileSync` + `assert.match` idiom, and carries
  `doesNotMatch` assertions on all three superseded command forms (the
  merge-base read, the three-dot diff, and the older two-dot `HEAD` diff) so
  none of them can return. Reverting only the prompt paragraph fails exactly
  this test.
- `test/review-blob-hydration.test.ts` — a shallow-cache integration test that
  builds the review cache the way `ensureReviewTreeCommit` does (one
  `--depth=1 --filter=blob:none` fetch per side into the production ref names),
  runs the real `hydratePullRequestReviewBlobs`, points the remote at an
  invalid URL, and then asserts the boundary in both directions: both commits
  resolve, `git merge-base` and the three-dot diff do **not**, the instructed
  `git show` reads succeed including a renamed file through its previous path,
  and the head path is absent on the base side. The fixture is deliberately
  offline; it is a statement about hydration, not about the network.

The second test is not vacuous: building the same fixture without `--depth=1`
makes `git merge-base` and the three-dot diff succeed (rc=0 both), so the
assertions track the shallow boundary rather than git in general.

### Non-scope

This change is limited to the `reviewFindings` section of the
review prompt, its policy test, and one shallow-cache integration test in the
existing review-blob-hydration suite. It carries no rating redesign, no schema
change, no new label or status, no second review pass, and no change to
`patchTierFromReview`, `hasBlockingReviewFindings`, `isReadyForMaintainerLook`,
or `parseReviewFinding`.
Whether a prerequisite is repaired in the same PR or tracked as follow-up stays
the target repository's call.

### Limitations

This changes reviewer *behavior*, and nothing mechanically
enforces that the reviewer performs the check — the same level of assurance
`lateFinding` has today. The proof below shows the instruction is delivered and
executable; it does not and cannot show that the model will comply, which is only
observable from live review runs after this lands.

### Review closeout

Six findings changed this patch. Every one of them was a case where the
paragraph would have caused the misattribution it exists to prevent, which is
worth saying plainly rather than presenting the result as if it arrived clean.

**From the first live ClawSweeper scan** (the reason this PR moved):

- **Make merge-base available to the review checkout (P1).** The procedure named
  `git merge-base` and a three-dot diff; the review cache can materialize a
  missing base or head with `--depth=1`, leaving both trees present and their
  shared history absent, so both commands fail and the fail-closed branch files
  the base-state finding. **Accepted.** Reproduced against this PR's own refs
  with the production fetches (`merge-base` rc=1, three-dot rc=128, both commits
  rc=0), then repaired by removing ancestry from the procedure entirely rather
  than by widening the cache. Covered by a new shallow-cache integration test.

**From the local `codex review` rounds before submission:**

- `base.sha` is the base-branch tip rather than the merge base, and `HEAD` is not
  reliably the PR head, so the original two-dot `git diff <base-sha>..HEAD` could
  read base drift as the patch's work.
- A renamed file has no base-side content under its new path, so the base read
  must use `previous_filename` — otherwise the fail-closed rule charges untouched
  code to the contributor.
- The rename fix was initially half a fix: the diff pathspec still carried only
  the new name, so a renamed file diffed as wholly added.
- An unscoped "do not anchor on `HEAD`" contradicted the re-review paragraph in
  the same file, which legitimately requires `git diff <earlier-sha>..HEAD`.
- The direct read and the diff resolved to different commits, so on a branch
  behind its base the two checks could disagree about the same file.

The last four are now moot by construction rather than by instruction: with the
diff gone from the procedure, there is one git read against one snapshot, and
the only path question left is the rename, which the prompt and both tests
cover. The superseded command forms are all pinned absent.

## Real Behavior Proof

The previous version of this section proved only that the procedure reaches the
model's composed input. The first live ClawSweeper review was right that this was
not enough: delivery says nothing about whether the instructed commands can run.
This proof now carries both claims, and the second one is measured against this
PR's own refs on the real remote.

- **Claim 1 — delivery.** The attribution procedure reaches the review model's
  composed input through the production prompt-composition path, and the base SHA
  it refers to travels in the same payload.
- **Claim 2 — executability.** After the review cache materializes the base and
  head commits the way it actually does, every git operation the prompt instructs
  runs with lazy fetching disabled, and the two operations the prompt forbids are
  exactly the ones that cannot run there.
- **Surface:** for claim 1, the built head's `compactPullRequestForTest` and
  `reviewPromptForTest`, which calls the production `buildReviewPrompt` — nothing
  stubbed. For claim 2, a repository holding neither commit, then the exact fetch
  `ensureReviewTreeCommit` issues (`--force --filter=blob:none <src>:<dst>
  --depth=1`) per side into the production destination refs, against
  this repository's remote and this pull request's own head ref. Blob
  hydration then issues the same `fetch --filter=blob:none --stdin` that
  `hydratePullRequestReviewBlobs` issues for missing bounded blobs; every read is
  run with `GIT_NO_LAZY_FETCH=1` so nothing can be rescued by the network.
- **Command / environment:** Docker-backed Crabbox `local-container`, image
  `node:24-bookworm`, on a disposable container lease, Linux host, against
  committed head `9b52677592436dd2c7459f28b8ffe7f5717d8181`. The sandbox syncs the branch, builds it
  from source, and runs the harness. Crabbox's `--no-hydrate` below is its own
  sandbox-provisioning flag and is unrelated to review blob hydration.

  ```sh
  crabbox run --provider local-container --local-container-image node:24-bookworm \
    --no-hydrate --timing-json --shell -- \
    "corepack pnpm install --frozen-lockfile --store-dir .pnpm-store && \
     corepack pnpm run build && node attribution-proof.mjs"
  ```

- **Observed result:** exit `0`, command phase 6.511s.

  ```text
  CSW_ATTR_PROOF claim=1_delivery seam=reviewPromptForTest prompt_chars=102887
  CSW_ATTR_PROOF procedure_checks=27 missing=[]
  CSW_ATTR_PROOF forbidden_commands_present=[]
  CSW_ATTR_PROOF before_base_has_procedure=false
  CSW_ATTR_PROOF base_sha_in_same_payload=true
  CSW_ATTR_PROOF claim=2_executability pr=1075 base=36179dceb26f head=9b5267759243
  CSW_ATTR_PROOF cache_is_shallow=true base_commit_rc=0 head_commit_rc=0
  CSW_ATTR_PROOF instructed_git_show_rc_before_hydration=128 after_hydration=0
  CSW_ATTR_PROOF forbidden_merge_base_rc=1 forbidden_three_dot_rc=128
  CSW_ATTR_PROOF result=PASS
  ```

- **Read:** all twenty-seven clauses of the procedure are present in the prompt the
  production composer hands the model, none are present in the base copy, and
  none of the three superseded command forms survives. The cache really is
  shallow; both commits resolve; `git merge-base` and the three-dot diff fail
  there; and the instructed `git show` fails *before* blob hydration and succeeds
  *after* it — which is what makes it a statement about hydration rather than
  about network access. The SHAs in claim 1 are a synthetic PR fixture; the SHAs
  in claim 2 are this PR's real base and head.
- **Rename coverage:** carried by `test/review-blob-hydration.test.ts` rather
  than the harness, because it needs a rename to exist in the fixture. That test
  builds the same shallow cache, runs the real `hydratePullRequestReviewBlobs`,
  and proves offline that the base side reads through `previous_filename` while
  the head path is absent on the base side — the case where a naive reader would
  conclude the patch introduced the whole file.
- **Artifact / trace:** the durable fixtures are the two tests. The harness is a
  short local script rather than a shipped file, so the tests — not the harness —
  are what future readers re-run.
- **Freshness:** this proof and the review closeout describe commit
  `9b52677592436dd2c7459f28b8ffe7f5717d8181`. If the branch is rebased or gains a commit, both are
  regenerated against the new head rather than carried forward.
### Claim 3 — the structured review result (three behavioural examples)

The review asked for the changed structured outcome through the production
review path, which the earlier claims did not carry. Three controlled cases are
now measured. Read them as behavioural examples of what the procedure produces,
not as a reliability measurement.

**Path exercised.** `clawsweeper review --local-range` on this head:
`buildLocalRangeReview` synthesises the review item and its context from a local
git range →
`buildReviewPrompt` (the production composer, using this branch's
`prompts/review-item.md`) → `runCodex` → the decision schema → the production
parser and report writer. `--local-range` is the repository's own GitHub-free review mode: it scrubs
GitHub credentials, points `gh` at an empty config dir and skips the start
comment, so there are no public side effects. It is not offline in the model
sense — each case still invokes the configured reviewer session.

  **Coverage boundary.** These runs are limited to the production composition,
  model invocation, decision schema, parser and report writer. GitHub context
  hydration and publication are bypassed, so the inputs the procedure names —
  `pullFiles[].patch`, `base.sha`, `previous_filename`, merge state — reach the
  reviewer from the local range here rather than from GitHub. Claims 1 and 2
  cover those inputs; Claim 3 validates the routing decision the policy asks for;
  claims 1 and 2 validate that its inputs arrive and are readable. Reported
  runtime: `review_model: internal`, `review_reasoning_effort: high`, one model
  call per case — the ordinary review call, with no additional invocation added
  by the attribution procedure itself. The proof as a whole made three such
  calls, one per case.

**Case A — a pre-existing prerequisite, conclusive within the fixture.** Base
compares stored rows
against upstream text byte for byte. The patch is limited to adding a projection
match for rows the importer marked, leaving the unmarked path exactly as it was,
and the supplied PR body states that boundary and names the backfill as separate
follow-up work.

```text
reviewFindings            []
overallCorrectness        "patch is correct"
risks                     "Legacy rows without importedHistory remain on the failing
                           byte-equality path after upgrade …"
maintainerDecision.required  true
maintainerDecision.question  "Should this repair land with normalized matching limited
                              to import-marked rows, leaving pre-marker adopted sessions
                              on strict comparison until they are re-adopted?"
```

The prerequisite is visible, it pauses automation, and it is not charged to the
contributor's patch. That is the routing this PR exists to produce — shown for
this fixture, which is built so the answer is unambiguous. It is not a claim
that provenance is always establishable.

**Case B — a patch-introduced defect (control).** Same base; the patch adds a new
fork anchor with a real bug of its own.

```text
reviewFindings            2 × P1, both in the file the patch changed
                          "Preserve sessions with no imported rows" (src/fork.ts:4)
                          "Use the boundary's upstream offset" (src/fork.ts:5)
overallCorrectness        "patch is incorrect"
maintainerDecision.required  false
```

The control matters: the rule does not simply suppress findings, and a maintainer
decision is not substituted for a defect the patch introduced.

**Case C — a latent base defect the patch newly reaches.** An unchanged parsing
helper in the base converts its input with no guard; the patch routes an
operator-supplied value into it through the existing compaction entry point.

```text
reviewFindings            "Validate parsed retention before pruning rows" (P1)
                          body: the parsing helper "deliberately returns raw
                          `Number` values … validate or normalize this input
                          before" pruning
overallCorrectness        "patch is incorrect"
maintainerDecision.required  false
```

The defective lines are the base's and the finding is still the patch's, which is
the authorship-versus-attribution distinction stated above, executed.

- **Limits**, stated narrowly because the claims are narrow:
  - Claim 3 is **not Docker-backed**, and that is a real gap against what was
    asked. The model call needs this host's configured Codex session; putting
    those credentials inside a container is not something I will do for a proof.
    Claims 1 and 2 are container-run; claim 3 is host-run through the same
    production entrypoint. If a Docker-backed structured run matters, it needs
    to happen on infrastructure that already holds the reviewer credentials.
  - Three controlled cases with one run each show the procedure **can** produce
    the intended structured result. They do not measure how reliably a model
    obeys it across many runs; that is a separate question from whether the
    instruction is correct and executable.
  - Case fixtures are synthetic and small, chosen so each case is unambiguous.
    A real PR carries more signal and more noise than any of them.
  - Claim 2 measures the review cache as `ensureReviewTreeCommit` builds it when
    a commit is missing. When the commit is already present with full ancestry no
    shallow fetch happens, and the forbidden commands would work — the prompt
    still forbids them, because the instruction must hold in the worse state.
  - The before side of claim 1 compares against `upstream/main`'s copy of the
    prompt, not any particular PR's base. That shows the paragraph is new; it is
    not evidence about a specific review.
  - Blob hydration is best-effort and can report failure. That is why an
    unreadable base side keeps the finding instead of clearing it.

## Validation

- `node --test test/review-prompt-policy.test.ts` — exit `0`, 36/36 pass.
- `node --test test/review-blob-hydration.test.ts` — exit `0`, 6/6 pass, the
  sixth being the new shallow-cache case. It also runs inside `pnpm run check`;
  the local non-zero exit below comes from a different suite in that command's
  coverage phase, not from this test.
- The test has teeth: reverting only the prompt paragraph and re-running the same
  command leaves 35/36, failing exactly the new test and nothing else.
- `pnpm exec oxfmt --check test/review-prompt-policy.test.ts` — exit `0`.
- `pnpm run check` — **exits non-zero (1) on my machine.** Stating that plainly
  rather than burying it: `check:static`, `build:all` and all four `lint:*`
  targets pass, and the failure is entirely in the coverage test run, which
  reports **13 failures out of 3207**, all in
  `test/repair/target-validation.test.ts` (pinned-base git reproduction,
  replacement-branch plumbing, and dependency-setup process reaping under bun
  and npm).

  Those 13 are **pre-existing on this Linux host and not attributable to this
  change**, established mechanically rather than asserted: stashing the diff and
  re-running the same test file on an otherwise unmodified checkout reproduces
  the identical 13 failure names, and injecting one failure name that passes on
  the base tree correctly reports it as new. The visible causes are
  environmental — a coverage profile directory the sandboxed child cannot
  create, and a detached package-manager entry point it cannot resolve, with
  `bun` absent on this host entirely.

  I have not touched that suite: this PR is limited to the review prompt and its
  tests. **Upstream CI settles it.** The `pnpm check` job on this head — the same
  command, including the coverage phase that holds all 13 of those cases —
  passes:
  <https://github.com/openclaw/clawsweeper/actions/runs/31284806440/job/93171649120>.
  CodeQL (<https://github.com/openclaw/clawsweeper/runs/93171859965>) and the
  sparse repair build smoke
  (<https://github.com/openclaw/clawsweeper/actions/runs/31284806440/job/93171649127>)
  pass too. So the 13 failures are not reproduced in the upstream CI
  environment; treat them as local to my host, not as a property of the change
  or of the suite.
