### PR TITLE
fix(review): jitter throttled retry eligibility to break herd oscillation

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -198,6 +198,7 @@ export type ExactReviewQueueItem = {
   claimedAt?: number;
   parkedReason?: ExactReviewParkedReason;
   parkedRecoveryAttempts?: number;
+  parkedRecoveryAt?: number;
   dispatchFailureStatus?: number;
   dispatchFailureClass?: ExactReviewDispatchFailureClass;
   dispatchFailureAt?: number;
@@ -573,6 +574,7 @@ export class ExactReviewQueue {
   private stateWriterCoordinator;
   private lifecycleProjectionStore;
   private lifecycleTelemetryStore;
+  private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
   private recentDurablePublicationEventsCache = new Map<
@@ -580,10 +582,11 @@ export class ExactReviewQueue {
     { expiresAt: number; value: NonNullable<ReturnType<typeof recentDurablePublicationEvents>> }
   >();
 
-  constructor(state, env) {
+  constructor(state, env, random: () => number = Math.random) {
     this.state = state;
     this.storage = state.storage;
     this.env = env;
+    this.random = random;
     this.batchStore = new ExactReviewPublicationBatchStore(this.storage);
     this.directPublicationStore = new ExactReviewDirectPublicationStore(this.storage);
     this.recordSnapshotStore = new ExactReviewRecordSnapshotStore(
@@ -1872,6 +1875,7 @@ export class ExactReviewQueue {
                 requestedRetryAt ?? undefined,
                 requeueLatest,
                 retryKind,
+                this.random,
               ),
               retried: outcome !== "success",
               refreshed: false,
@@ -2819,6 +2823,10 @@ export class ExactReviewQueue {
           item,
           now,
           run.outcome,
+          0,
+          false,
+          undefined,
+          this.random,
         );
         reconciled += 1;
         if (parked) continue;
@@ -3628,10 +3636,7 @@ export class ExactReviewQueue {
         const failureAttempts = Number(item.reviewFailureAttempts || 0) + 1;
         item.reviewFailureAttempts = failureAttempts;
         if (failureAttempts >= EXACT_REVIEW_RETRY_LIMIT) {
-          item.state = "parked";
-          item.parkedReason = "review_retry_exhausted";
-          item.backoffReason = undefined;
-          item.updatedAt = checkedAt;
+          parkRecoverableExactReviewItem(item, "review_retry_exhausted", checkedAt, this.random);
           continue;
         }
         item.nextAttemptAt = Math.max(
@@ -3852,9 +3857,7 @@ export class ExactReviewQueue {
         item.backoffReason = "publication_retry";
         item.attempts = Number(item.attempts || 0) + 1;
       } else if (failure.attempted && failure.failure.scope === "item") {
-        item.state = "parked";
-        item.parkedReason = "dispatch_rejected";
-        item.backoffReason = undefined;
+        parkRecoverableExactReviewItem(item, "dispatch_rejected", completedAt, this.random);
       } else {
         item.state = "pending";
         item.nextAttemptAt = completedAt;
@@ -10736,6 +10739,7 @@ function finishExactReviewQueueItem(
   requestedRetryAt = 0,
   requeueLatest = false,
   retryKind?: ExactReviewRetryKind,
+  random: () => number = Math.random,
 ) {
   const retryingFailure = outcome !== "success";
   const hasNewerRevision = item.revision > Number(item.leaseRevision || 0);
@@ -10755,7 +10759,11 @@ function finishExactReviewQueueItem(
   item.state = "pending";
   if (typedDeferral) {
     const dispatcherAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
-    item.nextAttemptAt = Math.max(dispatcherAttemptAt, requestedRetryAt);
+    const deferredAttemptAt =
+      retryKind === "throttle"
+        ? now + exactReviewJitteredDelayMs(Math.max(0, requestedRetryAt - now), random)
+        : requestedRetryAt;
+    item.nextAttemptAt = Math.max(dispatcherAttemptAt, deferredAttemptAt);
     item.backoffReason =
       dispatcherAttemptAt >= item.nextAttemptAt
         ? "dispatcher_backoff"
@@ -10769,10 +10777,7 @@ function finishExactReviewQueueItem(
       const failureAttempts = Number(item.reviewFailureAttempts || 0) + 1;
       item.reviewFailureAttempts = failureAttempts;
       if (failureAttempts >= EXACT_REVIEW_RETRY_LIMIT) {
-        item.state = "parked";
-        item.parkedReason = "review_retry_exhausted";
-        item.backoffReason = undefined;
-        item.updatedAt = now;
+        parkRecoverableExactReviewItem(item, "review_retry_exhausted", now, random);
         return { requeued: false, parked: true };
       }
     }
@@ -10940,7 +10945,7 @@ function reclaimExpiredExactReviewLease(
   return true;
 }
 
-function exactReviewParkedRecoveryAt(item: ExactReviewQueueItem) {
+function exactReviewParkedRecoveryDelayMs(item: ExactReviewQueueItem) {
   if (
     item.state !== "parked" ||
     exactReviewQueueIsPublication(item) ||
@@ -10950,11 +10955,36 @@ function exactReviewParkedRecoveryAt(item: ExactReviewQueueItem) {
   }
   const recoveries = exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts);
   if (recoveries >= EXACT_REVIEW_PARKED_RECOVERY_LIMIT) return null;
-  const delay = Math.min(
+  return Math.min(
     EXACT_REVIEW_PARKED_RECOVERY_MAX_MS,
     EXACT_REVIEW_PARKED_RECOVERY_BASE_MS * 2 ** recoveries,
   );
-  return item.updatedAt + delay;
+}
+
+function parkRecoverableExactReviewItem(
+  item: ExactReviewQueueItem,
+  reason: Extract<ExactReviewParkedReason, "dispatch_rejected" | "review_retry_exhausted">,
+  now: number,
+  random: () => number,
+) {
+  item.state = "parked";
+  item.parkedReason = reason;
+  item.backoffReason = undefined;
+  item.updatedAt = now;
+  const delay = exactReviewParkedRecoveryDelayMs(item);
+  item.parkedRecoveryAt =
+    delay === null ? undefined : now + exactReviewJitteredDelayMs(delay, random);
+}
+
+function exactReviewParkedRecoveryAt(item: ExactReviewQueueItem) {
+  const delay = exactReviewParkedRecoveryDelayMs(item);
+  if (delay === null) return null;
+  const scheduled = Number(item.parkedRecoveryAt);
+  // Pre-jitter records did not persist their recovery timestamp. Preserve their
+  // established ladder for one final cycle instead of resampling on every read.
+  return Number.isSafeInteger(scheduled) && scheduled >= item.updatedAt
+    ? scheduled
+    : item.updatedAt + delay;
 }
 
 function recoverParkedExactReviewItems(state: ExactReviewQueueState, now: number) {
@@ -10964,6 +10994,7 @@ function recoverParkedExactReviewItems(state: ExactReviewQueueState, now: number
     if (retryAt === null || retryAt > now) continue;
     item.state = "pending";
     item.parkedReason = undefined;
+    item.parkedRecoveryAt = undefined;
     item.parkedRecoveryAttempts =
       exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts) + 1;
     item.nextAttemptAt = now;
@@ -10980,6 +11011,15 @@ function recoverParkedExactReviewItems(state: ExactReviewQueueState, now: number
 function exactReviewParkedRecoveryAttempts(value: unknown) {
   const attempts = Number(value || 0);
   return Number.isSafeInteger(attempts) && attempts > 0 ? attempts : 0;
+}
+
+export function exactReviewJitteredDelayMs(delayMs: number, random: () => number = Math.random) {
+  const delay = Math.max(0, delayMs);
+  const sample = random();
+  const unit = Number.isFinite(sample) ? Math.max(0, Math.min(1, sample)) : 0.5;
+  const minimum = Math.ceil(delay * 0.75);
+  const maximum = Math.floor(delay * 1.5);
+  return Math.max(minimum, Math.min(maximum, Math.round(delay * (0.75 + 0.75 * unit))));
 }
 
 function expireExactReviewPublicationItems(state: ExactReviewQueueState, now: number, env) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -57,6 +57,7 @@ import {
 export {
   ExactReviewQueue,
   exactReviewEffectiveLeaseExpiresAt,
+  exactReviewJitteredDelayMs,
   exactReviewPublicationCapacity,
   exactReviewPublicationCapacityForState,
   exactReviewQueueAdmittedItems,

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -66,14 +66,19 @@ Manual exact-item `workflow_dispatch` reviews use an exact-item concurrency
 group with the same single-pending policy, so newer revisions replace stale
 pending work instead of building a duplicate queue. Durable exact-review leases
 use lease-scoped workflow groups and remain owned by the Worker admission lane.
+Recoverable parked reviews use the nominal 5/10/20-minute retry ladder, but
+each item persists a schedule-time uniform jitter of 0.75-1.5x for every rung.
+GitHub throttle deferrals use the same per-item jitter band when the queue turns
+the reported cooldown into its next-attempt timestamp, preventing a parked
+cohort from becoming eligible in lockstep; coordination and ordinary failure
+retries keep their existing timing.
 Review publication and apply/comment sync use separate non-dropping queues.
 Exact-review publication starts at 24 concurrent publishers in the Durable
 Object and scales admission by ready backlog: every 250 ready publications adds
 8 slots, up to 48. Backoff work does not trigger expansion, and scaling down
 does not cancel publishers that already started. A GitHub 403/429 or explicit
 rate-limit failure halves the admission ceiling for 15 minutes; GitHub 5xx
-failures lower it by 8 for 5 minutes. Repeated pressure can reduce admission to
-4. After cooldown, every 50 successful
+failures lower it by 8 for 5 minutes. Repeated pressure can reduce admission to 4. After cooldown, every 50 successful
 publications restores 8 slots. Apply/comment sync remains per-target serialized.
 Tuple-aware state reconciliation prevents stale review snapshots from reviving
 closed records.

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -13,6 +13,7 @@ import worker, {
   automaticIssueWork,
   ExactReviewQueue,
   exactReviewEffectiveLeaseExpiresAt,
+  exactReviewJitteredDelayMs,
   exactReviewPublicationCapacity,
   exactReviewPublicationCapacityForState,
   exactReviewQueueAdmittedItems,
@@ -45,6 +46,36 @@ import { ExactReviewLifecycleTelemetryStore } from "../dashboard/exact-review-li
 import { LIVE_ACTIVITY_SOURCE_LIMIT, liveActivityBaySnapshot } from "../dashboard/live-activity.ts";
 import { captureCanonicalRecordBaseline } from "../dist/repair/canonical-record-baseline.js";
 import { publishMainWithStateAppend } from "../dist/repair/publish-main.js";
+
+function seededRandom(seed: number) {
+  let value = seed >>> 0;
+  return () => {
+    value += 0x6d2b79f5;
+    let mixed = value;
+    mixed = Math.imul(mixed ^ (mixed >>> 15), mixed | 1);
+    mixed ^= mixed + Math.imul(mixed ^ (mixed >>> 7), mixed | 61);
+    return ((mixed ^ (mixed >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+test("exact-review retry jitter stays within every parked recovery ladder band", () => {
+  const random = seededRandom(0xc1a05);
+  for (const delay of [5, 10, 20].map((minutes) => minutes * 60_000)) {
+    for (let sample = 0; sample < 1_000; sample += 1) {
+      const jittered = exactReviewJitteredDelayMs(delay, random);
+      assert.ok(jittered >= delay * 0.75);
+      assert.ok(jittered <= delay * 1.5);
+    }
+    assert.equal(
+      exactReviewJitteredDelayMs(delay, () => 0),
+      delay * 0.75,
+    );
+    assert.equal(
+      exactReviewJitteredDelayMs(delay, () => 1),
+      delay * 1.5,
+    );
+  }
+});
 
 test("exact-review queue defaults to all 128 global workers", () => {
   assert.equal(exactReviewQueueCapacity({}), 128);
@@ -15494,9 +15525,9 @@ test("exact-review review retries park at the attempt ceiling and recover after 
     );
 
     const due = (await storage.get("exact-review-queue")) as {
-      items: Record<string, { updatedAt: number }>;
+      items: Record<string, { parkedRecoveryAt?: number }>;
     };
-    due.items[itemKey].updatedAt = Date.now() - 6 * 60_000;
+    due.items[itemKey].parkedRecoveryAt = Date.now() - 1;
     await storage.put("exact-review-queue", due);
     await queue.alarm();
     assert.equal(dispatched.length, 9);
@@ -15507,6 +15538,56 @@ test("exact-review review retries park at the attempt ceiling and recover after 
     assert.equal(recovered.parkedRecoveryAttempts, 1);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("exact-review parking spreads a same-tick cohort across persisted recovery timestamps", async () => {
+  const originalNow = Date.now;
+  const now = Date.parse("2026-08-08T12:00:00.000Z");
+  Date.now = () => now;
+  try {
+    const storage = new MemoryDurableStorage();
+    const items = Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => {
+        const item = leasedExactReviewQueueItem(120_000 + index, `12000${index}`);
+        item.attempts = 7;
+        item.reviewFailureAttempts = 7;
+        return [item.key, item];
+      }),
+    );
+    await storage.put("exact-review-queue", { deliveries: {}, items });
+    const queue = new ExactReviewQueue({ storage }, {}, seededRandom(0x5eed));
+
+    for (const item of Object.values(items)) {
+      const response = await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/complete", {
+          method: "POST",
+          body: JSON.stringify({
+            lease_id: item.leaseId,
+            item_key: item.key,
+            lease_revision: item.leaseRevision,
+            claim_generation: item.claimGeneration,
+            run_id: item.claimedRunId,
+            run_attempt: item.claimedRunAttempt,
+            outcome: "failure",
+          }),
+        }),
+      );
+      assert.equal(response.status, 200);
+    }
+
+    const state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { state: string; parkedRecoveryAt?: number }>;
+    };
+    const recoveryTimes = Object.values(state.items).map((item) => {
+      assert.equal(item.state, "parked");
+      assert.ok(Number(item.parkedRecoveryAt) >= now + 3.75 * 60_000);
+      assert.ok(Number(item.parkedRecoveryAt) <= now + 7.5 * 60_000);
+      return Number(item.parkedRecoveryAt);
+    });
+    assert.ok(new Set(recoveryTimes).size > 1);
+  } finally {
+    Date.now = originalNow;
   }
 });
 
@@ -17204,9 +17285,12 @@ test("exact-review queue automatically retries a parked dispatch rejection after
 
     dispatchStatus = 204;
     const due = (await storage.get("exact-review-queue")) as {
-      items: Record<string, { updatedAt: number }>;
+      items: Record<string, { updatedAt: number; parkedRecoveryAt?: number }>;
     };
-    due.items["openclaw/gogcli#600"].updatedAt = Date.now() - 6 * 60_000;
+    const parked = due.items["openclaw/gogcli#600"];
+    assert.ok(Number(parked.parkedRecoveryAt) >= parked.updatedAt + 3.75 * 60_000);
+    assert.ok(Number(parked.parkedRecoveryAt) <= parked.updatedAt + 7.5 * 60_000);
+    parked.parkedRecoveryAt = Date.now() - 1;
     await storage.put("exact-review-queue", due);
     await queue.alarm();
     const recovered = (await storage.get("exact-review-queue")) as {
@@ -19395,46 +19479,56 @@ test("failed shard recovery replaces an expired recovery lease", async () => {
 
 for (const retryKind of ["coordination", "throttle"] as const) {
   test(`exact-review queue defers ${retryKind} without spending review attempts`, async () => {
-    const storage = new MemoryDurableStorage();
-    const retryAt = Date.now() + 45 * 60_000;
-    const item = leasedExactReviewQueueItem(711, "7110");
-    item.attempts = 3;
-    item.reviewFailureAttempts = 2;
-    await storage.put("exact-review-queue", {
-      deliveries: {},
-      items: {
-        "openclaw/openclaw#711": item,
-      },
-    });
-    const queue = new ExactReviewQueue({ storage }, {});
+    const originalNow = Date.now;
+    const now = Date.parse("2026-08-08T13:00:00.000Z");
+    Date.now = () => now;
+    try {
+      const storage = new MemoryDurableStorage();
+      const retryAt = now + 45 * 60_000;
+      const item = leasedExactReviewQueueItem(711, "7110");
+      item.attempts = 3;
+      item.reviewFailureAttempts = 2;
+      await storage.put("exact-review-queue", {
+        deliveries: {},
+        items: {
+          "openclaw/openclaw#711": item,
+        },
+      });
+      const queue = new ExactReviewQueue({ storage }, {}, () => 0);
 
-    const response = await queue.fetch(
-      new Request("https://clawsweeper-exact-review-queue/complete", {
-        method: "POST",
-        body: JSON.stringify({
-          lease_id: "lease-711",
-          item_key: "openclaw/openclaw#711",
-          lease_revision: 1,
-          claim_generation: 1,
-          run_id: "7110",
-          run_attempt: 1,
-          outcome: "failure",
-          retry_kind: retryKind,
-          retry_at: new Date(retryAt).toISOString(),
+      const response = await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/complete", {
+          method: "POST",
+          body: JSON.stringify({
+            lease_id: "lease-711",
+            item_key: "openclaw/openclaw#711",
+            lease_revision: 1,
+            claim_generation: 1,
+            run_id: "7110",
+            run_attempt: 1,
+            outcome: "failure",
+            retry_kind: retryKind,
+            retry_at: new Date(retryAt).toISOString(),
+          }),
         }),
-      }),
-    );
+      );
 
-    assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { ok: true, requeued: true });
-    const state = (await storage.get("exact-review-queue")) as {
-      items: Record<string, Record<string, unknown>>;
-    };
-    const deferred = state.items["openclaw/openclaw#711"];
-    assert.ok(Number(deferred.nextAttemptAt) >= retryAt);
-    assert.equal(deferred.attempts, 3);
-    assert.equal(deferred.reviewFailureAttempts, 2);
-    assert.equal(deferred.backoffReason, `${retryKind}_retry`);
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true, requeued: true });
+      const state = (await storage.get("exact-review-queue")) as {
+        items: Record<string, Record<string, unknown>>;
+      };
+      const deferred = state.items["openclaw/openclaw#711"];
+      assert.equal(
+        deferred.nextAttemptAt,
+        retryKind === "throttle" ? now + 33.75 * 60_000 : retryAt,
+      );
+      assert.equal(deferred.attempts, 3);
+      assert.equal(deferred.reviewFailureAttempts, 2);
+      assert.equal(deferred.backoffReason, `${retryKind}_retry`);
+    } finally {
+      Date.now = originalNow;
+    }
   });
 }
 
@@ -19471,6 +19565,7 @@ test("exact-review queue spends review attempts for an untyped retry deadline", 
   };
   assert.equal(state.items["openclaw/openclaw#711"].attempts, 1);
   assert.equal(state.items["openclaw/openclaw#711"].reviewFailureAttempts, 1);
+  assert.equal(state.items["openclaw/openclaw#711"].nextAttemptAt, retryAt);
 });
 
 test("exact-review queue does not carry an old coordination deadline to a newer revision", async () => {


### PR DESCRIPTION
## What Problem This Solves

Production telemetry on 2026-08-08 showed the review lane oscillating with a ~45-minute period across every token-routing configuration: successful-review rate swinging 12↔632/hr while `throttle_retry` backoff swung 19↔193. The retry schedule, not pool capacity, drives it — when throttling parks a cohort, the fixed 5/10/20-minute recovery ladder and fixed throttle-redispatch delays make the whole cohort eligible again simultaneously, recreating the herd that re-exhausts the rate-limit bucket.

## The Fix

Retry-eligibility timestamps for throttled/parked review items get per-item uniform jitter in a 0.75–1.5x band, sampled once at schedule time and persisted as `parkedRecoveryAt`. Randomness is injectable through the queue constructor (Math.random in production, seeded in tests). Legacy parked records honor their original fixed schedule for one final cycle. Coordination waits, ordinary failure retries, and the publication lane's separate (already-spread) retry machinery are untouched, as are token routing, feed rate, and leases.

## Proof

- Seeded-RNG tests: all ladder steps stay within the 0.75–1.5x band; a same-tick parked cohort receives spread timestamps; unjittered paths byte-identical.
- Dashboard worker suite 322/322; full `pnpm test:unit` 1,964 pass / 0 fail; `pnpm run check` green.
- Coordinator autoreview clean (0.98).

Deploys with the dashboard workflow on merge. Expected effect: flattened backoff peaks and shallower duty-cycle troughs at unchanged feed rate — measurable against the telemetry baseline recorded on 2026-08-08.
