### PR TITLE
fix(review): reduce first-feedback latency for newly opened PRs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -855,12 +855,6 @@ jobs:
           permission-pull-requests: write
           permission-statuses: read
 
-      - uses: ./.github/actions/setup-pnpm
-        id: setup-pnpm
-        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outcome == 'success' && steps.live-item.outputs.admission_retry != 'true' }}
-        with:
-          build-script: ${{ steps.live-item.outputs.proceed == 'true' && 'build:all' || 'build:repair' }}
-
       - name: React to target item review start
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}
         continue-on-error: true
@@ -889,6 +883,12 @@ jobs:
             rm -f "$err"
           }
           react "eyes"
+
+      - uses: ./.github/actions/setup-pnpm
+        id: setup-pnpm
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outcome == 'success' && steps.live-item.outputs.admission_retry != 'true' }}
+        with:
+          build-script: ${{ steps.live-item.outputs.proceed == 'true' && 'build:all' || 'build:repair' }}
 
       - uses: actions/cache@v6
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.live-item.outputs.proceed == 'true' }}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1312,7 +1312,7 @@ export class ExactReviewQueue {
             revision: this.nextExactReviewItemRevisionSync(key),
             createdAt: now,
             updatedAt: now,
-            ...exactReviewQueueDebouncedAttempt(state, decision, now, now, this.env),
+            ...exactReviewQueueDebouncedAttempt(state, decision, now, now, this.env, true),
             attempts: 0,
             ...(exactReviewSourceAuthorityWatermark(decision)
               ? { sourceAuthorityWatermark: exactReviewSourceAuthorityWatermark(decision)! }
@@ -11124,9 +11124,12 @@ function exactReviewQueueDebouncedAttempt(
   now: number,
   firstEnqueuedAt: number,
   env,
+  isFirstEvent = false,
 ) {
   const baseAttemptAt = exactReviewQueueEnqueueAttemptAt(state, now);
-  if (isImmediateExactReviewDecision(decision)) return exactReviewQueueEnqueueAttempt(state, now);
+  if (isImmediateExactReviewDecision(decision, isFirstEvent)) {
+    return exactReviewQueueEnqueueAttempt(state, now);
+  }
   const debounceAt = Math.min(
     now + exactReviewDispatchDebounceMs(env),
     firstEnqueuedAt + exactReviewDispatchDebounceMaxMs(env),
@@ -11143,9 +11146,14 @@ function exactReviewQueueDebouncedAttempt(
   };
 }
 
-function isImmediateExactReviewDecision(decision: ExactReviewDecision) {
+function isImmediateExactReviewDecision(decision: ExactReviewDecision, isFirstEvent = false) {
   return Boolean(
-    decision.commandStatusMarker || decision.publication || exactReviewScheduledLane(decision),
+    decision.commandStatusMarker ||
+    decision.publication ||
+    exactReviewScheduledLane(decision) ||
+    (isFirstEvent &&
+      decision.itemKind === "pull_request" &&
+      ["opened", "ready_for_review"].includes(decision.sourceAction)),
   );
 }
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1264,6 +1264,7 @@ async function githubWebhook(request, env, ctx) {
       ingress,
     });
     if (!queued) return json({ error: "exact_review_queue_not_configured" }, 503);
+    await acknowledgePullRequestEnqueue({ env, ctx, decision: exactReviewDecision });
     if (sourceAuthoritySeq !== null) {
       await completeExactReviewSourceAuthority(
         env,
@@ -2444,18 +2445,63 @@ async function enqueueExactReview({
   return body;
 }
 
-async function createFastAckComment({ token, repo, itemNumber, sourceCommentId }) {
-  const existingId = await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId });
+async function acknowledgePullRequestEnqueue({ env, ctx, decision }) {
+  if (
+    decision.itemKind !== "pull_request" ||
+    !["opened", "ready_for_review"].includes(decision.sourceAction)
+  ) {
+    return null;
+  }
+  const credentials = githubAppCredentials(env);
+  if (!credentials || !Number.isInteger(decision.installationId) || decision.installationId <= 0) {
+    return null;
+  }
+  const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
+  const token = await createGithubAppTokenFor({
+    appJwt,
+    installationId: decision.installationId,
+    label: decision.targetRepo,
+    repositories: [repoName(decision.targetRepo)],
+    permissions: { issues: "write", pull_requests: "read" },
+  });
+  const ackMarker = pullRequestFastAckMarker(decision.itemNumber, decision.sourceAction);
+  const statusCommentId = await createFastAckCommentOnce({
+    token,
+    repo: decision.targetRepo,
+    itemNumber: decision.itemNumber,
+    ackMarker,
+    ackBody: renderPullRequestFastAckComment(ackMarker),
+  });
+  settleFastAckComments({
+    token,
+    repo: decision.targetRepo,
+    itemNumber: decision.itemNumber,
+    ackMarker,
+    delaysMs: fastAckSettleDelaysMs(env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS),
+    waitUntil: ctx?.waitUntil?.bind(ctx),
+  });
+  return statusCommentId;
+}
+
+async function createFastAckComment({
+  token,
+  repo,
+  itemNumber,
+  sourceCommentId = undefined,
+  ackMarker = fastAckMarker(sourceCommentId),
+  ackBody = renderFastAckComment(sourceCommentId),
+}) {
+  const existingId = await pruneFastAckComments({ token, repo, itemNumber, ackMarker });
   if (existingId) return existingId;
   const payload = await githubTokenJson({
     token,
     path: `/repos/${repo}/issues/${itemNumber}/comments`,
     method: "POST",
-    body: { body: renderFastAckComment(sourceCommentId) },
+    body: { body: ackBody },
     errorLabel: "ClawSweeper ack comment",
   });
   return (
-    (await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId })) ||
+    (await pruneFastAckComments({ token, repo, itemNumber, ackMarker })) ||
     Number(payload.id) ||
     null
   );
@@ -2465,14 +2511,15 @@ function settleFastAckComments({
   token,
   repo,
   itemNumber,
-  sourceCommentId,
+  sourceCommentId = undefined,
+  ackMarker = fastAckMarker(sourceCommentId),
   delaysMs = DEFAULT_FAST_ACK_SETTLE_DELAYS_MS,
   waitUntil,
 }) {
   const cleanup = async () => {
     for (const delayMs of delaysMs) {
       await sleep(delayMs);
-      await pruneFastAckComments({ token, repo, itemNumber, sourceCommentId });
+      await pruneFastAckComments({ token, repo, itemNumber, ackMarker });
     }
   };
   const promise = cleanup().catch((error) => {
@@ -2489,19 +2536,26 @@ function fastAckSettleDelaysMs(value) {
   return delays.length > 0 ? delays : DEFAULT_FAST_ACK_SETTLE_DELAYS_MS;
 }
 
-async function createFastAckCommentOnce({ token, repo, itemNumber, sourceCommentId }) {
-  const key = fastAckKey({ repo, itemNumber, sourceCommentId });
+async function createFastAckCommentOnce({
+  token,
+  repo,
+  itemNumber,
+  sourceCommentId = undefined,
+  ackMarker = fastAckMarker(sourceCommentId),
+  ackBody = renderFastAckComment(sourceCommentId),
+}) {
+  const key = fastAckKey({ repo, itemNumber, ackMarker });
   const pending = inFlightFastAcks.get(key);
   if (pending) return pending;
-  const next = createFastAckComment({ token, repo, itemNumber, sourceCommentId }).finally(() => {
+  const next = createFastAckComment({ token, repo, itemNumber, ackMarker, ackBody }).finally(() => {
     inFlightFastAcks.delete(key);
   });
   inFlightFastAcks.set(key, next);
   return next;
 }
 
-function fastAckKey({ repo, itemNumber, sourceCommentId }) {
-  return `${String(repo).toLowerCase()}:${itemNumber}:${sourceCommentId}`;
+function fastAckKey({ repo, itemNumber, ackMarker }) {
+  return `${String(repo).toLowerCase()}:${itemNumber}:${ackMarker}`;
 }
 
 function sleep(delayMs) {
@@ -2511,8 +2565,14 @@ function sleep(delayMs) {
   });
 }
 
-async function pruneFastAckComments({ token, repo, itemNumber, sourceCommentId }) {
-  const comments = await listFastAckComments({ token, repo, itemNumber, sourceCommentId });
+async function pruneFastAckComments({
+  token,
+  repo,
+  itemNumber,
+  sourceCommentId = undefined,
+  ackMarker = fastAckMarker(sourceCommentId),
+}) {
+  const comments = await listFastAckComments({ token, repo, itemNumber, ackMarker });
   if (!comments.length) return null;
   const hasStatusComment = comments.some(isStatusBearingFastAckComment);
   comments.sort(compareFastAckKeepPriority);
@@ -2569,9 +2629,8 @@ function compareCommentsByCreatedAt(left, right) {
   );
 }
 
-async function listFastAckComments({ token, repo, itemNumber, sourceCommentId }) {
+async function listFastAckComments({ token, repo, itemNumber, ackMarker }) {
   const comments = [];
-  const marker = fastAckMarker(sourceCommentId);
   const since = encodeURIComponent(new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
   for (let page = 1; page <= 5; page += 1) {
     const payload = await githubTokenJson({
@@ -2584,7 +2643,7 @@ async function listFastAckComments({ token, repo, itemNumber, sourceCommentId })
     if (!Array.isArray(payload)) return comments;
     for (const comment of payload) {
       if (
-        String(objectValue(comment).body || "").includes(marker) &&
+        String(objectValue(comment).body || "").includes(ackMarker) &&
         isClawsweeperGithubWebhookSender(objectValue(objectValue(comment).user))
       ) {
         comments.push(comment);
@@ -2607,6 +2666,20 @@ function renderFastAckComment(sourceCommentId) {
 
 function fastAckMarker(sourceCommentId) {
   return `<!-- clawsweeper-command-ack:${sourceCommentId} -->`;
+}
+
+function pullRequestFastAckMarker(itemNumber, sourceAction) {
+  return `<!-- clawsweeper-pr-ack:${sourceAction} item=${itemNumber} -->`;
+}
+
+function renderPullRequestFastAckComment(ackMarker) {
+  return [
+    ackMarker,
+    "🦞👀",
+    "ClawSweeper picked this up.",
+    "",
+    "Pull request review queued. I will update this pull request when review starts.",
+  ].join("\n");
 }
 
 async function addIssueCommentReaction({ token, repo, commentId, content }) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -1727,6 +1727,50 @@ test("exact-review queue bypasses debounce for commands and publications", async
   }
 });
 
+test("exact-review queue bypasses debounce only for fresh pull request openings", async () => {
+  const originalNow = Date.now;
+  let now = 2_500_000;
+  Date.now = () => now;
+  try {
+    const storage = new MemoryDurableStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "90000",
+        EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS: "180000",
+      },
+    );
+    await queue.fetch(buildExactReviewQueueRequest("fresh-opened", 753, "opened", "pull_request"));
+    await queue.fetch(
+      buildExactReviewQueueRequest("fresh-ready", 754, "ready_for_review", "pull_request"),
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest("fresh-synchronize", 755, "synchronize", "pull_request"),
+    );
+    await queue.fetch(
+      buildExactReviewQueueRequest("scheduled-unchanged", 756, "scheduled_normal_backfill"),
+    );
+    await queue.fetch(buildExactReviewQueueRequest("existing-organic", 757, "opened"));
+
+    let state = (await storage.get("exact-review-queue")) as {
+      items: Record<string, { nextAttemptAt: number; revision: number }>;
+    };
+    assert.equal(state.items["openclaw/gogcli#753"].nextAttemptAt, now);
+    assert.equal(state.items["openclaw/gogcli#754"].nextAttemptAt, now);
+    assert.equal(state.items["openclaw/gogcli#755"].nextAttemptAt, now + 90_000);
+    assert.equal(state.items["openclaw/gogcli#756"].nextAttemptAt, now);
+    assert.equal(state.items["openclaw/gogcli#757"].nextAttemptAt, now + 90_000);
+
+    now += 1_000;
+    await queue.fetch(buildExactReviewQueueRequest("existing-coalesced", 757, "edited"));
+    state = (await storage.get("exact-review-queue")) as typeof state;
+    assert.equal(state.items["openclaw/gogcli#757"].revision, 2);
+    assert.equal(state.items["openclaw/gogcli#757"].nextAttemptAt, now + 90_000);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("replacing a queued command cannot inherit another command's delivery identity", async () => {
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
@@ -25857,6 +25901,157 @@ test("hosted webhook ignores removal of non-close-guard labels", async () => {
   });
 });
 
+test("hosted pull request openings post one fast ack across both ingress routes", async () => {
+  const originalFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  const comments: Array<{
+    id: number;
+    body: string;
+    created_at: string;
+    user: { login: string };
+  }> = [];
+  const waitUntilPromises: Promise<unknown>[] = [];
+  let fastAckPosts = 0;
+  const repository = {
+    full_name: "openclaw/gogcli",
+    default_branch: "trunk",
+    private: false,
+    archived: false,
+    fork: false,
+    has_issues: true,
+  };
+  const openedPullRequest = {
+    number: 597,
+    head: { sha: "a".repeat(40) },
+    updated_at: "2026-08-08T12:00:00Z",
+    body: "Ready for review.",
+  };
+  const fingerprint = createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: 1,
+        target_repo: "openclaw/gogcli",
+        item_number: 597,
+        action: "opened",
+        head_sha: "a".repeat(40),
+        updated_at: "2026-08-08T12:00:00Z",
+        body: "Ready for review.",
+        label: "",
+      }),
+    )
+    .digest("hex");
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/app/installations/123/access_tokens") {
+      return jsonResponse({ token: "target-token" });
+    }
+    if (/^\/repos\/openclaw\/gogcli\/pulls\/(597|598)$/.test(url.pathname)) {
+      return jsonResponse({
+        head: { sha: url.pathname.endsWith("597") ? "a".repeat(40) : "b".repeat(40) },
+      });
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "GET") {
+      return jsonResponse([...comments]);
+    }
+    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "POST") {
+      fastAckPosts += 1;
+      const body = JSON.parse(String(init.body || "{}"));
+      const comment = {
+        id: 9001,
+        body: String(body.body || ""),
+        created_at: "2026-08-08T12:00:01Z",
+        user: { login: "openclaw-clawsweeper[bot]" },
+      };
+      comments.push(comment);
+      return jsonResponse(comment);
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  const env = {
+    CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+    CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+    CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const context = {
+    waitUntil: (promise: Promise<unknown>) => waitUntilPromises.push(promise),
+  };
+  const send = (deliveryId: string, action: string, pullRequest = openedPullRequest) =>
+    worker.fetch(
+      signedGithubWebhookRequest({
+        event: "pull_request",
+        secret: "test-secret",
+        deliveryId,
+        payload: {
+          action,
+          repository,
+          pull_request: pullRequest,
+          installation: { id: 123 },
+        },
+      }),
+      env,
+      context,
+    );
+
+  try {
+    const fallback = await queue.fetch(
+      buildExactReviewQueueRequest(
+        "dispatcher-opened",
+        597,
+        "opened",
+        "pull_request",
+        "openclaw/gogcli",
+        { targetBranch: "trunk" },
+        { ingress: { route: "target_dispatcher", fingerprint } },
+      ),
+    );
+    assert.equal((await fallback.json()).queued, true);
+
+    assert.equal((await send("app-opened-1", "opened")).status, 202);
+    assert.equal((await send("app-opened-2", "opened")).status, 202);
+    assert.equal(fastAckPosts, 1);
+    assert.equal(comments.length, 1);
+    assert.equal(
+      comments[0]?.body,
+      [
+        "<!-- clawsweeper-pr-ack:opened item=597 -->",
+        "🦞👀",
+        "ClawSweeper picked this up.",
+        "",
+        "Pull request review queued. I will update this pull request when review starts.",
+      ].join("\n"),
+    );
+    assert.doesNotMatch(comments[0]?.body || "", /clawsweeper-command-ack:/);
+    assert.doesNotMatch(comments[0]?.body || "", /clawsweeper-review-status:started/);
+    assert.doesNotMatch(comments[0]?.body || "", /^ClawSweeper status: review started\./);
+
+    assert.equal(
+      (
+        await send("app-synchronize", "synchronize", {
+          number: 598,
+          head: { sha: "b".repeat(40) },
+          updated_at: "2026-08-08T12:01:00Z",
+          body: "Follow-up push.",
+        })
+      ).status,
+      202,
+    );
+    assert.equal(fastAckPosts, 1);
+    await Promise.all(waitUntilPromises);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("hosted webhook reuses existing fast ack comments on redelivery", async () => {
   const originalFetch = globalThis.fetch;
   const { privateKey } = generateKeyPairSync("rsa", {
@@ -26079,7 +26274,16 @@ test("hosted webhook coalesces concurrent duplicate fast ack comments", async ()
     assert.equal(fastAckPosts, 1);
     assert.equal(reactions, 2);
     assert.equal(comments.length, 1);
-    assert.match(comments[0]?.body || "", /clawsweeper-command-ack:456/);
+    assert.equal(
+      comments[0]?.body,
+      [
+        "<!-- clawsweeper-command-ack:456 -->",
+        "🦞👀",
+        "ClawSweeper picked this up.",
+        "",
+        "Command router queued. I will update this comment with the next step.",
+      ].join("\n"),
+    );
     assert.equal(dispatchBodies.length, 2);
     assert.deepEqual(
       dispatchBodies.map(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -24,6 +24,56 @@ test("sweep keeps optional media tooling out of review startup", () => {
   assert.doesNotMatch(workflow, /setup-media-proof-tools/);
 });
 
+test("exact event review exposes the token-only signal before runtime setup", () => {
+  type Step = {
+    name?: string;
+    uses?: string;
+    id?: string;
+    "continue-on-error"?: boolean;
+  };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: Step[] }>;
+  };
+  const steps = workflow.jobs["event-review-apply"]!.steps;
+  const index = (predicate: (step: Step) => boolean, label: string) => {
+    const value = steps.findIndex(predicate);
+    assert.notEqual(value, -1, label);
+    return value;
+  };
+  const ordered = [
+    [
+      "target write token",
+      index((step) => step.name === "Create target write token", "write token"),
+    ],
+    [
+      "eyes reaction",
+      index((step) => step.name === "React to target item review start", "reaction"),
+    ],
+    ["pnpm build", index((step) => step.uses === "./.github/actions/setup-pnpm", "pnpm")],
+    [
+      "target checkout",
+      index((step) => step.name === "Check out target repository", "target checkout"),
+    ],
+    ["Codex setup", index((step) => step.uses === "./.github/actions/setup-codex", "Codex setup")],
+    [
+      "OpenClaw setup",
+      index((step) => step.uses === "./.github/actions/setup-openclaw", "OpenClaw setup"),
+    ],
+    [
+      "review lease reservation",
+      index((step) => step.name === "Reserve exact review lease", "lease"),
+    ],
+  ] as const;
+  for (let position = 1; position < ordered.length; position += 1) {
+    assert.ok(
+      ordered[position - 1]![1] < ordered[position]![1],
+      `${ordered[position - 1]![0]} must precede ${ordered[position]![0]}`,
+    );
+  }
+  assert.equal(steps[ordered[1][1]]!["continue-on-error"], true);
+  assert.equal(steps[ordered[6][1]]!.id, "reserve-exact-review-lease");
+});
+
 test("automatic OpenClaw bug dispatch uses one gate across direct and deferred publication", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
     jobs: Record<


### PR DESCRIPTION
## What Problem This Solves

A newly opened PR on a target repo got no visible reaction for 4–9 minutes and no substantive review for 8–30. Three measured causes: the App-webhook ingress enqueued within seconds but posted no acknowledgment (fast-ack machinery was wired only to slash-commands); the 90-second dispatch debounce applied fully to an item's first-ever event, though there is nothing to coalesce on a brand-new PR (while scheduled backfill items skip the debounce entirely); and the eyes reaction ran only after checkout, pnpm build, and Codex/OpenClaw setup despite being a pure API write.

## The Fix

1. The webhook posts one action-scoped fast acknowledgment (marker `clawsweeper-pr-ack:<action>`) after a successful `opened`/`ready_for_review` enqueue, idempotent across duplicate deliveries via the existing prune/settle machinery. `synchronize` and metadata events stay silent.
2. Brand-new items from `opened`/`ready_for_review` bypass the dispatch debounce (extension of `isImmediateExactReviewDecision`, flag threaded only from the new-item creation path); existing-item coalescing, commands, publications, and scheduled lanes byte-identical.
3. The eyes reaction moved before the pnpm build in the event review job. The review-started placeholder deliberately stayed put: it invokes the built reserve-lease CLI and its outputs feed retry/publication/finalization steps.

Marker safety: the new marker cannot match numeric command-ack parsing or the `review-status:started` placeholder recovery marker; existing command ack text unchanged.

## Effect

First visible acknowledgment: webhook-time (~seconds) instead of 4–9 minutes. Review dispatch eligibility 90 seconds earlier. No queue priority, feed rate, token, or lease changes.

## Proof

Dashboard worker 325/325; full `pnpm test:unit` 1,971 pass / 0 fail; `pnpm run check` green; coordinator autoreview clean (0.96). New tests: single ack across duplicate deliveries, silent synchronize, first-event immediate scheduling vs preserved debounce, workflow step order.
