### PR TITLE
fix(review): acknowledge pull requests at webhook receipt

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1198,6 +1198,11 @@ async function githubWebhook(request, env, ctx) {
   if ("type" in decision && decision.type === "item") {
     const deliveryId = request.headers.get("x-github-delivery") || "";
     let itemDecision = decision as ExactReviewDecision & { installationId?: number };
+    if (itemDecision.itemKind === "pull_request") {
+      await acknowledgePullRequestReceipt({ env, ctx, decision: itemDecision }).catch(
+        () => undefined,
+      );
+    }
     itemDecision = await withPullRequestEditContentRevision({
       event,
       payload,
@@ -1264,7 +1269,6 @@ async function githubWebhook(request, env, ctx) {
       ingress,
     });
     if (!queued) return json({ error: "exact_review_queue_not_configured" }, 503);
-    await acknowledgePullRequestEnqueue({ env, ctx, decision: exactReviewDecision });
     if (sourceAuthoritySeq !== null) {
       await completeExactReviewSourceAuthority(
         env,
@@ -2445,7 +2449,7 @@ async function enqueueExactReview({
   return body;
 }
 
-async function acknowledgePullRequestEnqueue({ env, ctx, decision }) {
+async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
   if (
     decision.itemKind !== "pull_request" ||
     !["opened", "ready_for_review"].includes(decision.sourceAction)
@@ -2678,7 +2682,7 @@ function renderPullRequestFastAckComment(ackMarker) {
     "🦞👀",
     "ClawSweeper picked this up.",
     "",
-    "Pull request review queued. I will update this pull request when review starts.",
+    "Pull request received. I will update this pull request when review starts.",
   ].join("\n");
 }
 

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -25901,7 +25901,7 @@ test("hosted webhook ignores removal of non-close-guard labels", async () => {
   });
 });
 
-test("hosted pull request openings post one fast ack across both ingress routes", async () => {
+test("hosted pull request receipt fast acks precede verification and stay idempotent", async () => {
   const originalFetch = globalThis.fetch;
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
@@ -25910,14 +25910,15 @@ test("hosted pull request openings post one fast ack across both ingress routes"
   });
   const storage = new MemoryDurableStorage();
   const queue = new ExactReviewQueue({ storage }, {});
-  const comments: Array<{
+  type AckComment = {
     id: number;
     body: string;
     created_at: string;
     user: { login: string };
-  }> = [];
+  };
+  const comments = new Map<number, AckComment[]>();
   const waitUntilPromises: Promise<unknown>[] = [];
-  let fastAckPosts = 0;
+  const fastAckPostAttempts = new Map<number, number>();
   const repository = {
     full_name: "openclaw/gogcli",
     default_branch: "trunk",
@@ -25952,24 +25953,40 @@ test("hosted pull request openings post one fast ack across both ingress routes"
     if (url.pathname === "/app/installations/123/access_tokens") {
       return jsonResponse({ token: "target-token" });
     }
-    if (/^\/repos\/openclaw\/gogcli\/pulls\/(597|598)$/.test(url.pathname)) {
+    const pullMatch = /^\/repos\/openclaw\/gogcli\/pulls\/(\d+)$/.exec(url.pathname);
+    if (pullMatch) {
+      assert.equal(new Headers(init?.headers).get("authorization"), "Bearer verification-token");
+      const itemNumber = Number(pullMatch[1]);
+      if (itemNumber === 599) throw new Error("transient GitHub verification failure");
       return jsonResponse({
-        head: { sha: url.pathname.endsWith("597") ? "a".repeat(40) : "b".repeat(40) },
+        head: {
+          sha:
+            itemNumber === 597
+              ? "a".repeat(40)
+              : itemNumber === 598
+                ? "b".repeat(40)
+                : itemNumber === 600
+                  ? "e".repeat(40)
+                  : "f".repeat(40),
+        },
       });
     }
-    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "GET") {
-      return jsonResponse([...comments]);
+    const commentMatch = /^\/repos\/openclaw\/gogcli\/issues\/(\d+)\/comments$/.exec(url.pathname);
+    if (commentMatch && init?.method === "GET") {
+      return jsonResponse([...(comments.get(Number(commentMatch[1])) || [])]);
     }
-    if (url.pathname === "/repos/openclaw/gogcli/issues/597/comments" && init?.method === "POST") {
-      fastAckPosts += 1;
+    if (commentMatch && init?.method === "POST") {
+      const itemNumber = Number(commentMatch[1]);
+      fastAckPostAttempts.set(itemNumber, (fastAckPostAttempts.get(itemNumber) || 0) + 1);
+      if (itemNumber === 601) throw new Error("GitHub comment write failed");
       const body = JSON.parse(String(init.body || "{}"));
       const comment = {
-        id: 9001,
+        id: 9000 + itemNumber,
         body: String(body.body || ""),
         created_at: "2026-08-08T12:00:01Z",
         user: { login: "openclaw-clawsweeper[bot]" },
       };
-      comments.push(comment);
+      comments.set(itemNumber, [...(comments.get(itemNumber) || []), comment]);
       return jsonResponse(comment);
     }
     throw new Error(`unexpected fetch ${url}`);
@@ -25980,6 +25997,7 @@ test("hosted pull request openings post one fast ack across both ingress routes"
     CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
     CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
     CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
+    GITHUB_TOKEN: "verification-token",
     EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
   };
   const context = {
@@ -26018,21 +26036,24 @@ test("hosted pull request openings post one fast ack across both ingress routes"
 
     assert.equal((await send("app-opened-1", "opened")).status, 202);
     assert.equal((await send("app-opened-2", "opened")).status, 202);
-    assert.equal(fastAckPosts, 1);
-    assert.equal(comments.length, 1);
+    assert.equal(fastAckPostAttempts.get(597), 1);
+    assert.equal(comments.get(597)?.length, 1);
     assert.equal(
-      comments[0]?.body,
+      comments.get(597)?.[0]?.body,
       [
         "<!-- clawsweeper-pr-ack:opened item=597 -->",
         "🦞👀",
         "ClawSweeper picked this up.",
         "",
-        "Pull request review queued. I will update this pull request when review starts.",
+        "Pull request received. I will update this pull request when review starts.",
       ].join("\n"),
     );
-    assert.doesNotMatch(comments[0]?.body || "", /clawsweeper-command-ack:/);
-    assert.doesNotMatch(comments[0]?.body || "", /clawsweeper-review-status:started/);
-    assert.doesNotMatch(comments[0]?.body || "", /^ClawSweeper status: review started\./);
+    assert.doesNotMatch(comments.get(597)?.[0]?.body || "", /clawsweeper-command-ack:/);
+    assert.doesNotMatch(comments.get(597)?.[0]?.body || "", /clawsweeper-review-status:started/);
+    assert.doesNotMatch(
+      comments.get(597)?.[0]?.body || "",
+      /^ClawSweeper status: review started\./,
+    );
 
     assert.equal(
       (
@@ -26045,7 +26066,48 @@ test("hosted pull request openings post one fast ack across both ingress routes"
       ).status,
       202,
     );
-    assert.equal(fastAckPosts, 1);
+    assert.equal(fastAckPostAttempts.has(598), false);
+    assert.equal(comments.has(598), false);
+
+    const deferred = await send("app-opened-deferred", "opened", {
+      number: 599,
+      head: { sha: "c".repeat(40) },
+      updated_at: "2026-08-08T12:02:00Z",
+      body: "Verification will be retried.",
+    });
+    assert.deepEqual(await deferred.json(), {
+      ok: true,
+      accepted: true,
+      deferred: true,
+      reason: "pull request head verification deferred",
+    });
+    assert.equal(fastAckPostAttempts.get(599), 1);
+    assert.equal(comments.get(599)?.length, 1);
+
+    const stale = await send("app-ready-stale", "ready_for_review", {
+      number: 600,
+      head: { sha: "d".repeat(40) },
+      updated_at: "2026-08-08T12:03:00Z",
+      body: "The webhook head is already stale.",
+    });
+    assert.deepEqual(await stale.json(), {
+      ok: true,
+      accepted: false,
+      reason: "stale pull request head",
+    });
+    assert.equal(fastAckPostAttempts.get(600), 1);
+    assert.equal(comments.get(600)?.length, 1);
+    assert.match(comments.get(600)?.[0]?.body || "", /clawsweeper-pr-ack:ready_for_review/);
+
+    const ackFailure = await send("app-opened-ack-failure", "opened", {
+      number: 601,
+      head: { sha: "f".repeat(40) },
+      updated_at: "2026-08-08T12:04:00Z",
+      body: "The ack write fails, but enqueue continues.",
+    });
+    assert.equal(ackFailure.status, 202);
+    assert.equal((await ackFailure.json()).queued, true);
+    assert.equal(fastAckPostAttempts.get(601), 1);
     await Promise.all(waitUntilPromises);
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #1078, driven by a production miss: openclaw/openclaw#120874 (opened 04:15:08Z) received no fast acknowledgment. The #1078 ack ran only after a successful enqueue — below the "head verification deferred" catch (which a single throttled GitHub read triggers, and throttle cycles are routine) and the stale-head return. Any event taking those paths acknowledged nothing.

## The Fix

The acknowledgment moves to event receipt: posted immediately after webhook classification for `opened`/`ready_for_review`, before source-authority reservation, head verification, and enqueue. Semantics now match the copy — "Pull request received" — true regardless of what verification later decides. Same marker, idempotency, prune, and settle machinery; ack failures are caught so the webhook flow never degrades.

## Proof

- New tests: deferred-verification path posts exactly one ack; stale-head path acks before its response; failed ack write leaves enqueue untouched; happy-path, duplicate-delivery, and synchronize behavior unchanged from #1078.
- Dashboard worker 325/325; full `pnpm test:unit` 1,971 pass / 0 fail; `pnpm run check` 3,207 pass; coordinator autoreview clean (0.99).

Note: the #120874 event may also have suffered an ingress-delivery gap (no dispatcher run fired either — plausibly Actions-trigger suppression for a service-account author); the App webhook delivery log check is tracked separately. This change hardens the code path that is ours regardless.
