### PR TITLE
feat(dispatch): acknowledge pull request receipt from the target dispatcher

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -69,6 +69,70 @@ jobs:
           permission-issues: write
           permission-pull-requests: read
 
+      - name: Create target PR acknowledgement token
+        id: pr_ack_token
+        if: >-
+          ${{
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'ready_for_review' ||
+              (github.event.action == 'opened' && github.event.pull_request.draft == false)
+            ) &&
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'
+          }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+
+      - name: Acknowledge received pull request
+        if: >-
+          ${{
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'ready_for_review' ||
+              (github.event.action == 'opened' && github.event.pull_request.draft == false)
+            ) &&
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'
+          }}
+        continue-on-error: true
+        env:
+          ACK_TOKEN: ${{ steps.pr_ack_token.outputs.token }}
+          TARGET_REPO: ${{ github.repository }}
+          ITEM_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ACK_TOKEN" ]; then
+            echo "::notice::Skipping ClawSweeper pull request acknowledgement because no target credential is configured."
+            exit 0
+          fi
+          comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
+          if jq -e \
+            --arg marker_prefix "clawsweeper-pr-ack:" \
+            --arg marker_suffix " item=$ITEM_NUMBER -->" \
+            'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
+            <<< "$comments" >/dev/null; then
+            echo "ClawSweeper pull request acknowledgement already exists."
+            exit 0
+          fi
+          ack_body="$(printf '%s\n' \
+            "<!-- clawsweeper-pr-ack:$SOURCE_ACTION item=$ITEM_NUMBER -->" \
+            "🦞👀" \
+            "ClawSweeper picked this up." \
+            "" \
+            "Pull request received. I will update this pull request when review starts.")"
+          ack_payload="$(jq -nc --arg body "$ack_body" '{body:$body}')"
+          GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments" \
+            --method POST \
+            --input - <<< "$ack_payload"
+
       - name: Dispatch exact ClawSweeper review
         if: ${{ github.event_name != 'issue_comment' }}
         env:

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -114,6 +114,70 @@ jobs:
           permission-issues: write
           permission-pull-requests: read
 
+      - name: Create target PR acknowledgement token
+        id: pr_ack_token
+        if: >-
+          ${{
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'ready_for_review' ||
+              (github.event.action == 'opened' && github.event.pull_request.draft == false)
+            ) &&
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'
+          }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+
+      - name: Acknowledge received pull request
+        if: >-
+          ${{
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'ready_for_review' ||
+              (github.event.action == 'opened' && github.event.pull_request.draft == false)
+            ) &&
+            env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'
+          }}
+        continue-on-error: true
+        env:
+          ACK_TOKEN: ${{ steps.pr_ack_token.outputs.token }}
+          TARGET_REPO: ${{ github.repository }}
+          ITEM_NUMBER: ${{ github.event.pull_request.number }}
+          SOURCE_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ACK_TOKEN" ]; then
+            echo "::notice::Skipping ClawSweeper pull request acknowledgement because no target credential is configured."
+            exit 0
+          fi
+          comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
+          if jq -e \
+            --arg marker_prefix "clawsweeper-pr-ack:" \
+            --arg marker_suffix " item=$ITEM_NUMBER -->" \
+            'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
+            <<< "$comments" >/dev/null; then
+            echo "ClawSweeper pull request acknowledgement already exists."
+            exit 0
+          fi
+          ack_body="$(printf '%s\n' \
+            "<!-- clawsweeper-pr-ack:$SOURCE_ACTION item=$ITEM_NUMBER -->" \
+            "🦞👀" \
+            "ClawSweeper picked this up." \
+            "" \
+            "Pull request received. I will update this pull request when review starts.")"
+          ack_payload="$(jq -nc --arg body "$ack_body" '{body:$body}')"
+          GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments" \
+            --method POST \
+            --input - <<< "$ack_payload"
+
       - name: Dispatch exact ClawSweeper review
         if: ${{ github.event_name != 'issue_comment' }}
         env:

--- a/test/target-dispatcher-workflow.test.ts
+++ b/test/target-dispatcher-workflow.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { parse } from "yaml";
+
+const liveWorkflow = readFileSync(".github/workflows/clawsweeper-dispatch.yml", "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+const documentation = readFileSync("docs/target-dispatcher.md", "utf8").replace(/\r\n/g, "\n");
+const templateMatch = documentation.match(/```yaml\n(name: ClawSweeper Dispatch[\s\S]*?)\n```/);
+
+assert.ok(templateMatch, "target dispatcher workflow template is missing");
+const documentedWorkflow = `${templateMatch[1]}\n`;
+
+type WorkflowStep = {
+  name?: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string>;
+  "continue-on-error"?: boolean;
+};
+
+function dispatchSteps(source: string): WorkflowStep[] {
+  const workflow = parse(source) as {
+    jobs?: { dispatch?: { steps?: WorkflowStep[] } };
+  };
+  return workflow.jobs?.dispatch?.steps ?? [];
+}
+
+function namedStep(steps: WorkflowStep[], name: string): WorkflowStep {
+  const step = steps.find((candidate) => candidate.name === name);
+  assert.ok(step, `missing workflow step: ${name}`);
+  return step;
+}
+
+function normalizeWhitespace(value: string | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+test("documented target dispatcher template matches the live workflow", () => {
+  assert.equal(documentedWorkflow, liveWorkflow);
+});
+
+test("target dispatcher acknowledges non-draft PR receipts before review dispatch", () => {
+  for (const source of [liveWorkflow, documentedWorkflow]) {
+    const steps = dispatchSteps(source);
+    const tokenIndex = steps.findIndex(
+      (step) => step.name === "Create target PR acknowledgement token",
+    );
+    const acknowledgementIndex = steps.findIndex(
+      (step) => step.name === "Acknowledge received pull request",
+    );
+    const dispatchIndex = steps.findIndex(
+      (step) => step.name === "Dispatch exact ClawSweeper review",
+    );
+    assert.ok(tokenIndex >= 0 && tokenIndex < acknowledgementIndex);
+    assert.ok(acknowledgementIndex < dispatchIndex);
+
+    const token = namedStep(steps, "Create target PR acknowledgement token");
+    const acknowledgement = namedStep(steps, "Acknowledge received pull request");
+    const expectedGate = [
+      "${{",
+      "github.event_name == 'pull_request_target' &&",
+      "(",
+      "github.event.action == 'ready_for_review' ||",
+      "(github.event.action == 'opened' && github.event.pull_request.draft == false)",
+      ") &&",
+      "env.HAS_CLAWSWEEPER_APP_PRIVATE_KEY == 'true'",
+      "}}",
+    ].join(" ");
+
+    assert.equal(normalizeWhitespace(token.if), expectedGate);
+    assert.equal(normalizeWhitespace(acknowledgement.if), expectedGate);
+    assert.equal(token["continue-on-error"], true);
+    assert.equal(acknowledgement["continue-on-error"], true);
+    assert.deepEqual(
+      Object.keys(token.with ?? {}).filter((key) => key.startsWith("permission-")),
+      ["permission-issues"],
+    );
+    assert.equal(token.with?.["permission-issues"], "write");
+    assert.equal(acknowledgement.env?.ACK_TOKEN, "${{ steps.pr_ack_token.outputs.token }}");
+
+    const run = acknowledgement.run ?? "";
+    assert.match(run, /issues\/\$ITEM_NUMBER\/comments\?per_page=100/);
+    assert.match(run, /--arg marker_prefix "clawsweeper-pr-ack:"/);
+    assert.match(run, /--arg marker_suffix " item=\$ITEM_NUMBER -->"/);
+    assert.match(run, /"<!-- clawsweeper-pr-ack:\$SOURCE_ACTION item=\$ITEM_NUMBER -->"/);
+    assert.match(
+      run,
+      /"Pull request received\. I will update this pull request when review starts\."/,
+    );
+    assert.match(run, /issues\/\$ITEM_NUMBER\/comments"\s*\\\s*--method POST/);
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Production evidence (four consecutive organic PRs on openclaw/openclaw, post-#1079) shows the Worker-webhook fast-ack never fires for PR events — the GitHub App appears not to deliver pull_request webhooks (delivery-log verification tracked separately, needs App admin). Meanwhile the target-repo dispatcher workflow demonstrably fires within seconds of PR open. Contributors still see nothing until the review job's eyes reaction, minutes later.

## The Fix

The dispatcher posts the receipt acknowledgment itself: a new step in the clawsweeper-dispatch workflow (live copy and the canonical template in docs/target-dispatcher.md, byte-identical, with a test enforcing that), gated to non-draft `opened`/`ready_for_review`, minting a minimal issues:write App token, `continue-on-error`, placed before review dispatch. It posts the exact Worker marker (`clawsweeper-pr-ack:<action>`) and body, and skips if any marker comment already exists — idempotent against duplicate runs and against the webhook route whenever it comes back to life.

Target repos pick this up when their dispatcher copy is updated from the template (openclaw/openclaw propagation is a separate PR).

## Proof

Full `pnpm test:unit` 1,973 pass / 0 fail; `pnpm run check` 3,209 pass; coordinator autoreview clean (0.99). New tests: gating, marker/body exactness, placement, permissions, continue-on-error, live/template byte-parity.
