### PR TITLE
fix(review): keep runtime vocabulary out of persistent-data findings

### DIFF
--- a/src/clawsweeper-change-detection.ts
+++ b/src/clawsweeper-change-detection.ts
@@ -80,7 +80,10 @@ export function dataModelChangeFromContext(repo: string, context: ItemContext): 
     const previousPath =
       typeof file.previous_filename === "string" ? file.previous_filename.trim() : "";
     const candidates = [path, previousPath].filter(Boolean);
-    const likelyPath = candidates.find(isLikelyOpenClawDataModelPath) ?? "";
+    const productionCandidates = candidates.filter(
+      (candidate) => !isOpenClawDataModelTestPath(candidate),
+    );
+    const likelyPath = productionCandidates.find(isLikelyOpenClawDataModelPath) ?? "";
     const patch = typeof file.patch === "string" ? file.patch : null;
     const lines = patch === null ? [] : changedPatchLines(patch);
 
@@ -91,7 +94,7 @@ export function dataModelChangeFromContext(repo: string, context: ItemContext): 
       surfaces.add(dataModelSurfaceLabel(likelyPath, "unknown-data-model-change"));
     }
 
-    for (const candidate of candidates) {
+    for (const candidate of productionCandidates) {
       if (isDocsPath(candidate)) {
         if (patch !== null && !configSurfacePatchIsTruncated(patch)) {
           dataModelSurfacesFromPatch(candidate, lines, { docsOnly: true }).forEach((surface) =>
@@ -312,7 +315,7 @@ function dataModelSurfacesFromPatch(
   ) {
     add("database schema");
   }
-  if (/\b(?:migration|migrate|upgrade|backfill|doctor|repair|reindex|rehydrat\w*)\b/i.test(text)) {
+  if (/\b(?:migrations?|migrat(?:e|ed|es|ing)|backfill\w*)\b/i.test(text)) {
     add("migration/backfill/repair");
   }
   if (
@@ -322,22 +325,26 @@ function dataModelSurfacesFromPatch(
   ) {
     add("durable storage schema");
   }
-  if (
-    /\b(?:JSON\.(?:parse|stringify)|readFile|writeFile|localStorage|sessionStorage|workspaceState|globalState|serialized|persisted?|statePath)\b/i.test(
-      text,
-    )
-  ) {
+  const hasExplicitSerializedState =
+    /\b(?:localStorage|sessionStorage|workspaceState|globalState|statePath)\b/i.test(text);
+  const hasJsonFilePersistence = lines.some((_, index) => {
+    const operation = lines.slice(Math.max(0, index - 2), index + 3).join("\n");
+    return (
+      /\b(?:readFile|writeFile)\w*\b/i.test(operation) &&
+      /\bJSON\.(?:parse|stringify)\b/i.test(operation) &&
+      /\b(?:state|checkpoint|snapshot|cache|store|storage|record|session|history|queue|registry|cursor|profile|credential|memory|database|db)(?:[ _-]?(?:path|file|dir(?:ectory)?)){0,2}\b/i.test(
+        operation,
+      )
+    );
+  });
+  if (hasExplicitSerializedState || hasJsonFilePersistence) {
     add("serialized state");
   }
-  if (
-    /\b(?:cache(?:Key|Version|Schema|Namespace)?|cache[_-]?(?:key|version|schema|namespace)|ttl)\b/i.test(
-      text,
-    )
-  ) {
+  if (/\bcache[ _-]?(?:key|version|schema|namespace|ttl)\b/i.test(text)) {
     add("persistent cache schema");
   }
   if (
-    /\b(?:embedding|vector|collection|dimension|metadata|row[_-]?id|document[_-]?id|chunk[_-]?id|similarity[_-]?index)\b/i.test(
+    /\b(?:embedding[ _-]?dimension|vector[ _-]?dimension|collection[ _-]?name|row[ _-]?id|document[ _-]?id|chunk[ _-]?id|similarity[ _-]?index)\b/i.test(
       text,
     )
   ) {
@@ -358,6 +365,14 @@ function dataModelLineLooksSemantic(line: string, options: { docsOnly: boolean }
 function isLikelyOpenClawDataModelPath(path: string): boolean {
   if (!path || isDocsPath(path)) return false;
   return Boolean(dataModelPathHint(path)) || /\.(?:sql|sqlite|db|prisma)$/.test(path);
+}
+
+function isOpenClawDataModelTestPath(path: string): boolean {
+  return (
+    /(^|\/)(?:__tests__|test|tests|fixtures|__snapshots__)(?:\/|$)/i.test(path) ||
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/i.test(path) ||
+    /\.snap$/i.test(path)
+  );
 }
 
 function dataModelPathHint(path: string): string {
@@ -386,7 +401,7 @@ function dataModelPathHint(path: string): string {
     return "vector/embedding metadata";
   }
   if (
-    /(^|\/)(?:migrations?|backfill|doctor|repair|upgrade)(?:\/|[-_.])|(?:migration|backfill|doctor|repair|upgrade)\.(?:ts|js)$/i.test(
+    /(^|\/)(?:migrations?|backfill|doctor|repair|upgrade)(?:\/|[-_.])|(^|\/)(?:migration|backfill|doctor|repair|upgrade)\.(?:ts|js)$/i.test(
       path,
     )
   ) {

--- a/test/pr-surface-policy.test.ts
+++ b/test/pr-surface-policy.test.ts
@@ -294,6 +294,196 @@ test("data model detector ignores query-only and non-semantic docs changes", () 
   assert.deepEqual(detection, { change: false, surfaces: [] });
 });
 
+test("data model detector ignores workflow, test, and fixture vocabulary", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: ".github/workflows/release.yml",
+        patch:
+          '@@\n+          metadata=".artifacts/pkg/candidate.json"\n+          if [[ ! -f "$metadata" ]]; then',
+      },
+      {
+        filename: ".github/workflows/checks.yml",
+        patch: "@@\n+  vector-tests:\n+    runs-on: ubuntu-latest",
+      },
+      {
+        filename: "test/scripts/package-acceptance.test.ts",
+        patch: '@@\n+  assert.deepEqual(result.metadata, { name: "openclaw" });',
+      },
+      {
+        filename: "test/fixtures/layout.json",
+        patch: '@@\n+  "dimension": 24,',
+      },
+      {
+        filename: "test/fixtures/vector-schema.ts",
+        patch: "@@\n+  embeddingDimension: 24,",
+      },
+      {
+        filename: "src/talk/session-runtime.test.ts",
+        patch: "@@\n+  const parsed = JSON.parse(raw);",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, { change: false, surfaces: [] });
+});
+
+test("data model detector ignores runtime repair, telemetry, and cache vocabulary", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/agents/embedded-agent-runner/run/code-mode-tool-call-repair.ts",
+        patch: "@@\n+  return repairSmallModelToolCall(payload);",
+      },
+      {
+        filename: "src/agents/tool-search-telemetry.ts",
+        patch: "@@\n+  metadata: toolMetadata,\n+  cacheRead: usage.cacheRead,",
+      },
+      {
+        filename: "src/agents/code-mode-tool-input-repair.ts",
+        patch: "@@\n+  return JSON.parse(candidate);",
+      },
+      {
+        filename: "src/gateway/websocket.ts",
+        patch: '@@\n+  if (req.headers.upgrade !== "websocket") return;',
+      },
+      {
+        filename: "src/util/memo.ts",
+        patch: "@@\n+const cache = new Map<string, number>();\n+cache.set(key, value);",
+      },
+      {
+        filename: "docs/reference/full-release-validation.md",
+        patch: "@@\n+| Cross-OS | Tests: upgrade from the prior release |",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, { change: false, surfaces: [] });
+});
+
+test("data model detector keeps explicit repair and persistence surfaces", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/doctor/repair.ts",
+        patch: "@@\n+  await repair(database);",
+      },
+      {
+        filename: "src/cache/schema.ts",
+        patch: "@@\n+  entryFingerprint: string;",
+      },
+      {
+        filename: "src/runtime/checkpoint.ts",
+        patch:
+          "@@\n+  const raw = await readFile(checkpointPath, 'utf8');\n+  return JSON.parse(raw);",
+      },
+      {
+        filename: "scripts/config-fixture.ts",
+        patch:
+          "@@\n+  await writeFile(configPath, JSON.stringify(config));\n+  return readFile(resultPath, 'utf8');",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "migration/backfill/repair: src/doctor/repair.ts",
+      "persistent cache schema: src/cache/schema.ts",
+      "serialized state: src/runtime/checkpoint.ts",
+    ],
+  });
+});
+
+test("data model detector keeps production snapshot schemas", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/storage/snapshots/schema.sql",
+        patch: "@@\n+ALTER TABLE snapshots ADD COLUMN format_version INTEGER;",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: ["database schema: src/storage/snapshots/schema.sql"],
+  });
+});
+
+test("data model detector recognizes semantic prose forms", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "docs/storage.md",
+        patch:
+          "@@\n+The cache version changes when persisted entries become incompatible.\n+The embedding dimension remains part of stored vector metadata.",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "persistent cache schema: docs/storage.md",
+      "vector/embedding metadata: docs/storage.md",
+    ],
+  });
+});
+
+test("data model detector recognizes compound persisted path identifiers", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "src/runtime/load-checkpoint.ts",
+        patch:
+          "@@\n+  const raw = await readFile(checkpointFilePath, 'utf8');\n+  return JSON.parse(raw);",
+      },
+      {
+        filename: "src/runtime/load-state.ts",
+        patch:
+          "@@\n+  const raw = await readFile(state_file_path, 'utf8');\n+  return JSON.parse(raw);",
+      },
+      {
+        filename: "src/runtime/load-cache.ts",
+        patch:
+          "@@\n+  const raw = await readFile(cacheDirectoryPath, 'utf8');\n+  return JSON.parse(raw);",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "serialized state: src/runtime/load-cache.ts",
+      "serialized state: src/runtime/load-checkpoint.ts",
+      "serialized state: src/runtime/load-state.ts",
+    ],
+  });
+});
+
+test("data model detector keeps persistence outside the normal source tree", () => {
+  const detection = dataModelChangeFromPullFilesForTest({
+    pullFiles: [
+      {
+        filename: "migrations/0001-init.sql",
+        patch: "@@\n+CREATE TABLE sessions (id TEXT PRIMARY KEY);",
+      },
+      {
+        filename: "state/persisted-state.json",
+      },
+    ],
+  });
+
+  assert.deepEqual(detection, {
+    change: true,
+    surfaces: [
+      "database schema: migrations/0001-init.sql",
+      "unknown-data-model-change: state/persisted-state.json",
+    ],
+  });
+});
+
 test("data model detector flags path-hinted persisted field declarations", () => {
   const detection = dataModelChangeFromPullFilesForTest({
     pullFiles: [


### PR DESCRIPTION
Related: https://github.com/openclaw/clawsweeper/pull/983

## What Problem This Solves

Fixes an issue where OpenClaw pull requests that change no stored state are
publicly told to produce migration proof before merge.

`dataModelSurfacesFromPatch` joins every changed non-comment line into one blob
and runs its content regexes over that blob **without reference to the file
path**. Ordinary runtime, test, fixture, telemetry, docs, and GitHub Actions
vocabulary — `metadata`, `cache`, `upgrade`, `JSON.parse`, `vector`, `dimension`,
`repair` — is therefore enough to raise a persistent data-model surface.

A false hit is not cosmetic. It sets `data_model_change`, and
`dataModelSurfaceReviewRequired` then costs the PR **pass eligibility**
(`reviewAutomationMarkersFromReport` → `verdict:needs-human`), **repair-loop and
automerge eligibility** (`isRepairLoopPassReport`), and publishes *"Confirm
migration or upgrade compatibility proof before merge."* The only escape hatch,
`hasDataModelUpgradeProof`, asks the author to write migration proof for a
migration that does not exist.

Live carrier: https://github.com/openclaw/openclaw/pull/119762. Its ClawSweeper
comment https://github.com/openclaw/openclaw/pull/119762#issuecomment-5198139710,
at carrier head `0d5398a9`, reports a persistent data-model change on two
surfaces — the reusable live-and-e2e checks workflow, and a package-acceptance
test file. Both are files in `openclaw/openclaw`, both labelled `vector/embedding
metadata`, and the trigger in the workflow is a **bash variable named
`metadata`**.

## Why This Change Was Made

This **recuts the accepted persistent-data classifier boundary onto the active
post-#993 change-detection module.**

https://github.com/openclaw/clawsweeper/pull/983 fixed this exact root cause and
carries a recorded maintainer decision: *keep the narrower persistent-data
classifier boundary; ordinary runtime/test vocabulary must not create a
persistent-data merge gate.* It was **closed during queue cleanup, not rejected**
— *"nothing against the fix itself … reopen or recut against current main and it
will get a fast review."*

It went stale for a mechanical reason:
https://github.com/openclaw/clawsweeper/pull/993 (`9ab7ed402`) moved the detector
out of `src/clawsweeper.ts` into `src/clawsweeper-change-detection.ts`, so #983's
production hunk no longer applied. Its regressions still target
`test/pr-surface-policy.test.ts`, which is unchanged, so they port directly.

This PR changes `dataModelChangeFromContext` and `dataModelSurfacesFromPatch`,
porting #983's approved semantics:

- exclude test, fixture, and snapshot paths from the data-model candidate set;
- narrow the migration **content** regex to migration and backfill words, so bare
  `upgrade`, `doctor`, `repair`, `reindex`, `rehydrate` in changed text no longer
  trigger on their own (the `doctor/` and `migrations/` **path** hints are
  untouched, so `src/doctor/repair.ts` still signals);
- replace the bare `JSON.parse|readFile|serialized|persisted` serialized-state
  regex with explicit storage APIs **or** a proximity window (±2 changed lines
  around each changed line, so a 5-line span) requiring file I/O **and** JSON
  **and** a persistence noun;
- narrow the cache regex to `cache (key|version|schema|namespace|ttl)`;
- narrow the vector regex to compound persisted identifiers;
- anchor the migration **filename** branch of `dataModelPathHint` so a name merely
  ending in `-repair.ts` no longer reads as `repair.ts`; the basename must now be
  exactly one of `migration|backfill|doctor|repair|upgrade` + `.ts`/`.js`, and the
  directory branch of the same hint is unchanged.

**Boundaries.** `unknown-data-model-change`, `unknown-truncated-pull-files`,
truncation detection, and `pullFilesTruncated` fail-closed behavior are
untouched. Within `dataModelPathHint` only the migration *filename* branch is
anchored; every directory branch and the two-factor corroboration in
`dataModelTextMatchesPathHint` / `dataModelTextLooksLikePersistedShapeField` are
unchanged, so a strong path hint still establishes a persistent-data surface
outside the normal source tree. No new vocabulary, no
schema change, no consumer change: report front matter, orchestration readers,
renderer, and automation markers all consume `{change, surfaces}` unchanged.

**Rejected alternative, measured not assumed.** Gating the content branch behind
a `^(src|ui|packages|extensions)/` production-path predicate is the smaller
change, so it was implemented first and run against the same matrix. It **loses
2 approved positives** — `migrations/0001-init.sql` (persistence outside the
normal source tree) and #983's retained `docs/storage.md` prose — and leaves
**6 negatives still signalling**, every production-source case. Reproduce by
wrapping the compiled detector so content-derived surfaces are dropped on paths
failing that predicate, keeping `unknown-*` markers, and re-running the matrix
below.

`isOpenClawSourcePath` stays private in `src/pr-surface-stats.ts`: the accepted
shape needs a test-path predicate, not a production-source allowlist, and that
module's `isOpenClawTestPath` under-excludes here (misses nested `test/`
segments, `fixtures/`, `__snapshots__/`, `.snap`).

## Known waived trade-offs

Two review findings were raised against this branch. Both were waived as
properties of the boundary #983 established rather than defects introduced here,
and both residual costs are stated so they are trades, not hidden gaps.

1. **One-sided serialized-state detection.** When a hunk changes only the
   `JSON.parse` line and the `readFile` call stays in unchanged context,
   `changedPatchLines` never sees the I/O line, so no surface is raised. This
   cannot be separated from the required negative "API-response `JSON.parse`" —
   at the changed-lines level they are the same input, and #983 chose the
   negative. The two-factor `pathHint` route still covers persistence-located
   files. **Residuals:** a storage-path file whose only changed line carries no
   corroborating token — `src/storage/snapshot-loader.ts` with
   `return JSON.parse(raw) as SessionStateV3;` — goes clean; and so does
   on-disk **configuration** persistence such as `src/config/io.write.ts` writing
   `JSON.stringify(config)` to `configPath`, because `config` is deliberately
   absent from the persistence-noun list. That second one is not an oversight:
   #983 pinned it with a test this PR ports verbatim, which lists
   `scripts/config-fixture.ts` doing exactly that write and asserts it raises no
   surface.
2. **`upgrade`, `doctor`, `repair`, `reindex`, `rehydrate` dropped from the
   migration content regex.** #983 removed them; its PR body enumerates the
   preserved signal set without them. **Residuals:** a file inside `migrations/`
   whose only changed lines are `reindex(...)` / `rehydrateState(...)` goes
   clean, because the `pathHint` corroboration list does not carry those words
   either; and a generic production file such as `src/runtime/compat.ts` whose
   only changed line is `await upgrade(state);` goes clean, since neither its
   path nor its text now matches. The `doctor/`, `migrations/`, `backfill/`,
   `repair/` and `upgrade/` **path** hints are untouched, so
   `src/doctor/repair.ts` still signals.

Restoring either means re-widening the content regex (re-opening the class this
PR closes) or widening `pathHint` beyond #983. **Happy to add either if you want
the boundary moved** — I kept this PR to the shape you already approved.

Two further deltas, same origin, completing the list of four: bare `serialized` /
`persisted` prose no longer signals (#983 removed those words; its retained prose positives are `cache
version` and `embedding dimension`), and the migration filename branch now
requires the basename to be exactly one of `migration|backfill|doctor|repair|
upgrade` + `.ts`/`.js` (its directory branch still matches `migrations/`,
`backfill/`, `doctor/`, `repair/`, `upgrade/`).

## User Impact

Maintainers stop seeing migration-proof demands on PRs that touch only
workflows, tests, fixtures, docs, telemetry, or ordinary runtime code, and those
PRs regain `pass` plus automerge and repair-loop eligibility. Persistence
changes still gate across every case in the matrix below — schema, migrations,
durable storage, serialized state, cache versioning, vector metadata — except
for the four semantic deltas named above, which are #983's approved narrowing
rather than a change this PR introduces.

## Evidence

Tests added: 7 regressions in `test/pr-surface-policy.test.ts` — two negative
suites (workflow, test and fixture vocabulary; runtime repair, telemetry and
cache vocabulary) and five positive guards — four ported from #983, plus one new
case for persistence outside the normal source tree. `node --test test/pr-surface-policy.test.ts` →
30 subtests pass, 0 fail (23 pre-existing, unchanged).

**Teeth check.** Reverting only the production hunk and rebuilding fails 4 of the
7 added tests. Reverting *only* the candidate-path filter fails 1. The other 3
are positive-preservation guards: they pass before and after by design, and fail
if the narrowing overshoots.

**Detector matrix**, compiled `dataModelChangeFromPullFilesForTest`, before =
`upstream/main` `81c23bede7`, after = this branch:

| | before | after |
|---|---|---|
| negatives clean | 1/13 | **13/13** |
| positives signalling | 15/15 | **15/15** |
| positives with the exact expected surfaces | 13/15 | **15/15** |
| **lost positives** | — | **0** |

The 2 "before" positives that were not exact are the two false extras #983
removed: `serialized state: scripts/config-fixture.ts` and `serialized state:
docs/storage.md`.

Negatives, each a single changed file: workflow bash variable `metadata`;
workflow `vector-tests` job name; test `metadata` assertion; fixture
`"dimension": 24`; `test/fixtures/vector-schema.ts` with `embeddingDimension`;
telemetry `metadata` parameter; `req.headers['x-request-metadata']`; in-memory
`new Map()` cache; `req.headers.upgrade !== "websocket"`; API-response
`JSON.parse`; docs-only `upgrade`; a colocated `*.test.ts` with `JSON.parse`;
plus #983's own five-file false-positive set.

Positives, with the surfaces they must keep: `ALTER TABLE` → database schema;
`src/db/migrations/*.ts` → database schema; `writeFileSync(statePath,
JSON.stringify(...))` → serialized state; `state.storage.put` → durable storage
schema; `dimension`/`collection` under `src/memory/` → vector/embedding
metadata; `cacheVersion` under `src/cache/` → persistent cache schema;
`migrations/0001-init.sql` at repo root → database schema; `extensions/…` →
serialized state; #983's four semantic positives; and the fail-closed set
(missing patch, truncated patch, `pullFilesTruncated`) → the `unknown-*` markers.

**What is re-runnable from this diff, and what is not.** The added regressions in
`test/pr-surface-policy.test.ts` encode a representative subset of the matrix —
each is a `pullFiles` entry with its patch and its expected surfaces — so
`node --test test/pr-surface-policy.test.ts` re-runs that subset against your own
build. The rest of the matrix is **not** in the diff: the runtime
header-metadata negative, several single-file positives such as
`src/state/session-store.ts`, #983's full five-file negative set, and the
rejected production-path alternative all live in a scratch harness under
`.artifacts/`, which `AGENTS.md` keeps out of the tree. Every one of them is a
single call you can paste:

```js
const m = await import("./dist/clawsweeper-change-detection.js");
// negative: a bash variable named `metadata` in a workflow
m.dataModelChangeFromPullFilesForTest({
  repo: "openclaw/openclaw",
  pullFiles: [{
    filename: ".github/workflows/release.yml",
    patch: '@@\n+metadata=".artifacts/pkg/candidate.json"\n+if [[ ! -f "$metadata" ]]; then',
  }],
});
// before: { change: true, surfaces: ["vector/embedding metadata: .github/workflows/release.yml"] }
// after:  { change: false, surfaces: [] }

// positive: a persisted JSON state write still gates
m.dataModelChangeFromPullFilesForTest({
  repo: "openclaw/openclaw",
  pullFiles: [{
    filename: "src/state/session-store.ts",
    patch: "@@\n+  writeFileSync(statePath, JSON.stringify({ version: 3, turns }));",
  }],
});
// before and after: { change: true, surfaces: ["serialized state: src/state/session-store.ts"] }
```

The carrier A/B is **not** reproducible from this diff alone — it needs the live
payload and a build of the base as well as of this branch:

```bash
gh api "repos/openclaw/openclaw/pulls/119762/files?per_page=100" --paginate > files.json
git worktree add ../base 81c23bede7 && (cd ../base && pnpm install && pnpm run build)
pnpm run build
node --input-type=module -e '
  import { readFileSync } from "node:fs";
  const files = JSON.parse(readFileSync("files.json", "utf8"));
  const arms = [["before", "../base/dist"], ["after", "./dist"]];
  for (const arm of arms) {
    const m = await import(arm[1] + "/clawsweeper-change-detection.js");
    console.log(arm[0], JSON.stringify(
      m.dataModelChangeFromPullFilesForTest({ repo: "openclaw/openclaw", pullFiles: files })));
  }'
```

Feeding each result into `reviewAutomationMarkersFromReport` as `data_model_change`
and `data_model_surfaces` reproduces the marker flip shown below.

`pnpm run check` **exits non-zero.** Static checks, `format:check`, all three
`build:*` projects and all four `lint:*` lanes pass; 13 tests fail in
`test/repair/*` (git plumbing, dependency-setup process reaping, and a failure to
create a coverage profile directory under the system temp dir). Those 13 fail
**identically on a pristine `upstream/main` worktree** in the same sandbox —
baseline 3209 tests / 13 fail, this branch 3216 tests / 13 fail, same test names
— so none is attributable to this change. No `pr-surface-policy` or
change-detection test fails. **Upstream CI for this exact head is green**,
including its own `pnpm check` run, which independently confirms those 13
failures belong to the local sandbox rather than to the patch. CodeQL for this
exact head is green as well.

`git diff --check`: clean.

## Real Behavior Proof — Docker-backed Crabbox, current head

The repository-required production-path validation. **No code changed for this
follow-up** — the reviewed head is unchanged at `e23ba84401` and the branch
worktree has no modifications. `upstream/main` has advanced since this branch
was cut, but every commit since touches **neither** file in this PR — the blobs
for both are identical between the PR parent and current main — so the branch was
deliberately not rebased. (Inside the lease the checkout does carry untracked build output from
the two builds — the transcript reports 1 then 3 such paths — but the two tracked
files are checked back to head before the run ends and no commit was made.)

*Provenance note:* the two retained files below evidence everything inside the
lease. Two facts are host-side and independently checkable rather than part of
the artifact: that current `upstream/main` touches neither PR file, and that the
branch worktree has no modifications.

**Claim.** At the exact PR head, the compiled production classifier clears the
real false-positive carrier, while six sampled persistence positives — one per
surface the classifier can emit — and all three fail-closed cases still gate.
(The broader 15-positive boundary is covered by the detector matrix above and by
the committed regressions, not by this sample.)

**Exercised surface.** Compiled `dataModelChangeFromPullFilesForTest` from
`dist/clawsweeper-change-detection.js`, feeding the real
`reviewAutomationMarkersFromReport` and `renderReviewCommentFromReport` from
`dist/clawsweeper-runtime.js`. The classifier is not copied or reimplemented —
the harness imports the built artifact.

**Environment.** Every value below is traceable to one of two retained files:
the in-container transcript `crabbox-run.log`, or the host-side CLI capture
`crabbox-env.txt` (which holds `crabbox version`, `crabbox doctor`, the verbatim
`warmup` and `stop` output, and the artifact hash).

| Field | Value |
|---|---|
| Backend | Crabbox `local-container` (Docker-backed) |
| Crabbox | 0.40.0 |
| Image | `ubuntu:26.04` |
| Lease | `cbx_252483d2f160` |
| Container | hostname `crabbox-cs1081proof-138c0406` (docker id `b7de0b7f90a1` at provisioning) |
| Workdir | `/work/crabbox/cbx_252483d2f160/clawsweeper` |
| User | `uid=1001(crabbox)` — non-root; `docker_socket=false` |
| Docker engine | 29.4.2 |
| Kernel | `Linux 6.8.0-136-generic x86_64` |
| Resources | 8 vCPU, 46.9 GiB RAM, 381 GiB free |
| Node | v24.19.0 |
| pnpm | 11.10.0 |
| tsc | 7.0.2 |
| Git head in container | `e23ba84401cbfe7827badc9ae72e24f17916bb1d`. The transcript logs `git status : 1 modified paths` at run start and `restored to head : 3 modified paths` after the base rebuild; the two tracked files are checked back to head before the run ends, and no commit is made. |
| Base observed | `81c23bede7a805351bcbb1d5fde54ff278337535` (PR parent) |
| Lease expiry at provisioning | `2026-08-09T06:01:19Z` (30m idle timeout) |
| Proof run | 2026-08-09T05:37:03Z → 05:37:09Z, from the transcript (toolchain and deps provisioned earlier in the same lease) |

**Commands.**

```bash
crabbox doctor  --provider local-container   # retained capture is post-release,
                                             # showing leases=0
crabbox warmup  --provider local-container --slug cs1081proof
crabbox run     --provider local-container --id cs1081proof --no-hydrate \
                --artifact-glob '.artifacts/crabbox-proof/*' -- '<proof script>'
crabbox stop    --provider local-container --target linux --id cs1081proof
```

Inside the lease: `pnpm install --frozen-lockfile` → `pnpm run build` → fetch the
live carrier payload from the GitHub pull-files API → run the harness against the
built `dist`.

**Build attribution (teeth).** The `dist` under test is built in-container from
this head, not synced or stale:

```text
dist mtime   2026-08-09 05:37:04Z   sha256 74ef3b45b97cd891…  (head build)
base dist                            sha256 d2be75cc2aca1899…  (base build)
isOpenClawDataModelTestPath   head 2   base 0     # symbol added by this PR
hasJsonFilePersistence        head 2   base 0     # symbol added by this PR
reindex (old content regex)   head 0   base 1     # token removed by this PR
```

The base arm is produced in the same container by checking the two files back to
the parent commit, rebuilding, and restoring — so both arms come from the same
toolchain and differ only by this PR's diff.

### 1. Real false-positive carrier — openclaw/openclaw#119762

Payload fetched live inside the container (state `open`, head
`0d5398a9233014776b06d26252162cf5664535ca`, 7 files, sha256 `f056dd85a8ceca09…`).

```text
BEFORE (base 81c23bede7)          AFTER (head e23ba84401)
  data_model_change : true          data_model_change : false
  surfaces          : 5             surfaces          : 0
    migration/backfill/repair: docs/reference/full-release-validation.md
    persistent cache schema:   docs/reference/full-release-validation.md
    serialized state:          test/scripts/package-acceptance-workflow.test.ts
    vector/embedding metadata: .github/workflows/openclaw-live-and-e2e-checks-reusable.yml
    vector/embedding metadata: test/scripts/package-acceptance-workflow.test.ts
  downstream        : verdict:needs-human   downstream : verdict:pass
  stored-data section rendered : true       rendered   : false
  public warning    : "Persistent data-model change detected: …
                       Confirm migration or upgrade compatibility
                       proof before merge."                 : (none)
```

Workflow and test vocabulary no longer create persistent-data surfaces;
`data_model_change=false`; no migration-proof gate from this detector; the
detector-only downstream verdict becomes `pass`.

### 2. Retained true positives — 6/6 still gate

Each case goes through the compiled detector and then the real automation path
with **no upgrade proof recorded**. All are single changed files except the
migration case, which is two:

| Case | Surface produced | Downstream |
|---|---|---|
| SQL/DDL `ALTER TABLE … ADD COLUMN` | `database schema: src/db/schema.ts` | `verdict:needs-human` + warning |
| migration path + `backfill…(db)` | `migration/backfill/repair:` on both the `migrations/*.sql` and `src/doctor/backfill.ts` | `verdict:needs-human` + warning |
| serialized durable state `writeFileSync(statePath, JSON.stringify(…))` | `serialized state: src/state/session-store.ts` | `verdict:needs-human` + warning |
| durable object `state.storage.put` | `durable storage schema: src/gateway/worker/do.ts` | `verdict:needs-human` + warning |
| persistent cache `cacheVersion` | `persistent cache schema: src/cache/keys.ts` | `verdict:needs-human` + warning |
| persisted `embeddingDimension` / `document_id` | `vector/embedding metadata: src/memory/vector-store.ts` | `verdict:needs-human` + warning |

**6/6 in the AFTER arm and 6/6 in the BEFORE arm** — identical, so this PR loses
no positive.

### 3. Fail-closed — 3/3 still gate

| Case | Marker retained | Downstream |
|---|---|---|
| missing patch on a likely persistent path | `unknown-data-model-change: src/storage/session-state.ts` | `verdict:needs-human` |
| truncated patch | `unknown-data-model-change: packages/database/schema.ts` (plus `database schema`) | `verdict:needs-human` |
| `pullFilesTruncated` | `unknown-truncated-pull-files` | `verdict:needs-human` |

**3/3 in both arms.** No `unknown-*` case fails open.

Focused regressions at the same head, inside the same container: `node --test
test/pr-surface-policy.test.ts` → 30 subtests pass, 0 fail.

**Teeth.** Both arms run the same harness over the same inputs in the same
container; the only variable is which compiled artifact is loaded — the head
build or the parent build. Across that single variable, positives (6/6) and
fail-closed (3/3) are **identical**, and the carrier is the **only** observation
that moves. So the proof isolates exactly the behavior this PR changes rather
than exercising unrelated paths.

**Artifact.** `cbx_252483d2f160-artifacts.tgz`, sha256
`d8a19f20cca10db368e9d99b3968a60cb936e34e05b6bdb36fc7776413c35134` (21,879
bytes), collected via `--artifact-glob` to
`.crabbox/runs/cbx_252483d2f160/`. Contents and their hashes:

```text
e685eacf8b7667e8…  after.json          structured AFTER observations
a70feaa1c7cae6ba…  before.json         structured BEFORE observations
dab8e936553486374… harness.mjs         the harness itself
f056dd85a8ceca09…  pr119762-files.json live carrier payload as fetched
bcff3038d4819a7a…  proof.log           full transcript
```

Host-side Crabbox CLI output — `crabbox version`, the post-run `crabbox doctor`
showing `leases=0`, the verbatim `warmup` and `stop` lines, and this tarball's
sha256 — is retained beside it as `crabbox-env.txt`.

**Cleanup.** `crabbox stop --provider local-container --target linux --id
cs1081proof` → `deleted lease=cbx_252483d2f160 server=… name=crabbox-cs1081proof-138c0406`,
and a subsequent `crabbox doctor --provider local-container` reports `leases=0`.
Both lines are in `crabbox-env.txt`.

**Limits.** Egress is open in this lease, so the carrier payload was fetched
live; the run is therefore reproducible only while `#119762` remains open at that
head — the exact payload is retained in the artifact for replay. The lease is a
local Docker container on one host rather than an org-brokered backend, so this
proves classifier and automation behavior, not scheduling or distribution.
The downstream arm synthesises a report whose other gates (security cleared,
review complete) are held constant so the detector is the only variable; it does
not prove any PR becomes merge-ready.

---

## Earlier host A/B proof (retained)

**Claim.** On the live payload of https://github.com/openclaw/openclaw/pull/119762
the detector stops reporting persistent-data surfaces, and the false signal alone
no longer drives the report to `needs-human`.

**Exercised surface.** Compiled `dataModelChangeFromPullFilesForTest` from
`src/clawsweeper-change-detection.ts`, then the real
`reviewAutomationMarkersFromReport` and `renderReviewCommentFromReport`.

**Scenario / fixture.** The live 7-file pull-file payload of that PR from the
GitHub pull-files API at head `0d5398a9233014776b06d26252162cf5664535ca` —
3 workflow files, 1 docs page, 1 script, 2 test files, zero persistent production
code.

**Command and environment.** `pnpm run build` on Node 24 in two worktrees —
`upstream/main` at `81c23bede7` and this branch — then both compiled detectors
over the same payload, each result fed into the **same** downstream consumer, so
the detector is the only variable.

**Observed result.**

```
===== BEFORE (upstream/main 81c23bede7) =====
  data_model_change : true
  surfaces (5):
      - migration/backfill/repair: docs/reference/full-release-validation.md
      - persistent cache schema: docs/reference/full-release-validation.md
      - serialized state: test/scripts/[package-acceptance-workflow test]
      - vector/embedding metadata: .github/workflows/openclaw-live-and-e2e-checks-reusable.yml
      - vector/embedding metadata: test/scripts/[package-acceptance-workflow test]
  downstream markers: verdict:needs-human
  "Stored data model" section rendered: true

===== AFTER (this branch) =====
  data_model_change : false
  surfaces (0):
  downstream markers: verdict:pass
  "Stored data model" section rendered: false
  public warning   : (none)
```

The bracketed filename is elided only because it is an `openclaw/openclaw`
carrier path, not a file in this repository; the unedited text is in
ClawSweeper's own comment on the carrier.

The two surfaces ClawSweeper actually published on that PR — `vector/embedding
metadata` on the workflow and on the test file — both appear in the BEFORE arm,
so the reproduction is causally aligned with the live review rather than merely
similar.

**Freshness.** Captured at this branch head `e23ba84401`, cut from
`81c23bede7`. The other identifiers belong to the carrier, not to this PR:
`0d5398a9233014776b06d26252162cf5664535ca` is its head and `5198139710` is its
ClawSweeper comment.

**Limitations / what was not tested.** The BEFORE arm yields 3 surfaces the live
review does not show (the two `docs/…` ones and `serialized state` on the test
file); the docs patch is 41.7 KB and was almost certainly truncated out of the
live review context. This PR is scoped to the detector, and that gap does not
affect the two surfaces that do match. The A/B isolates the **detector-owned**
transition only: the synthesized report holds the other gates (security cleared,
proof sufficient, review complete) constant and favourable, so it proves the
false data-model signal alone flips `pass` → `needs-human` and back — **not**
that the carrier PR becomes merge-ready, which also depends on
`configSurfaceChangeFromContext`, the security assessment, the proof status, and
required CI, none of which this patch changes. This change is limited to the
boundary #983 established; intentionally out of scope is the read-and-write
context classifier redesign needed to narrow `metadata` in a telemetry signature
or `headers.upgrade` in the gateway any further.
