### PR TITLE
fix(webhook): grant pull request fast-ack tokens pull_requests write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`.
+- Scoped GitHub App tokens to their named repositories via the documented `repositories` parameter.
 - Legacy reports with canonical proof or rating keys outside the apparent leading front-matter block now fail closed, with a read-only workflow to inventory affected canonical records. (#1049)
 - Prevented model-authored report prose and body-shaped front matter from spoofing proof or rating sections, keeping unproven external pull requests in human review instead of routing them into automated repair. (#951)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`.
-- Scoped GitHub App tokens to their named repositories via the documented `repositories` parameter.
+- Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`. (#1082)
+- Scoped GitHub App tokens to their named repositories via the documented `repositories` parameter. (#1082)
 - Legacy reports with canonical proof or rating keys outside the apparent leading front-matter block now fail closed, with a read-only workflow to inventory affected canonical records. (#1049)
 - Prevented model-authored report prose and body-shaped front matter from spoofing proof or rating sections, keeping unproven external pull requests in human review instead of routing them into automated repair. (#951)
 

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -13093,7 +13093,7 @@ export async function createGithubAppTokenFor({
     {
       method: "POST",
       body: JSON.stringify({
-        repository_names: repositories.filter(Boolean),
+        repositories: repositories.filter(Boolean),
         permissions,
       }),
       errorLabel: `GitHub App token for ${label}`,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1199,9 +1199,10 @@ async function githubWebhook(request, env, ctx) {
     const deliveryId = request.headers.get("x-github-delivery") || "";
     let itemDecision = decision as ExactReviewDecision & { installationId?: number };
     if (itemDecision.itemKind === "pull_request") {
-      await acknowledgePullRequestReceipt({ env, ctx, decision: itemDecision }).catch(
-        () => undefined,
-      );
+      await acknowledgePullRequestReceipt({ env, ctx, decision: itemDecision }).catch((error) => {
+        console.error(`ClawSweeper pull request fast ack failed: ${error?.message || error}`);
+        return undefined;
+      });
     }
     itemDecision = await withPullRequestEditContentRevision({
       event,
@@ -2466,7 +2467,7 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
     installationId: decision.installationId,
     label: decision.targetRepo,
     repositories: [repoName(decision.targetRepo)],
-    permissions: { issues: "write", pull_requests: "read" },
+    permissions: { issues: "write", pull_requests: "write" },
   });
   const ackMarker = pullRequestFastAckMarker(decision.itemNumber, decision.sourceAction);
   const statusCommentId = await createFastAckCommentOnce({

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -466,7 +466,7 @@ async function createInstallationToken({
     path: `/app/installations/${installationId}/access_tokens`,
     method: "POST",
     body: {
-      repository_names: repositories.filter(Boolean),
+      repositories: repositories.filter(Boolean),
       permissions,
     },
     authScheme: "Bearer",

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -25951,6 +25951,10 @@ test("hosted pull request receipt fast acks precede verification and stay idempo
   globalThis.fetch = async (input, init) => {
     const url = new URL(String(input));
     if (url.pathname === "/app/installations/123/access_tokens") {
+      assert.deepEqual(JSON.parse(String(init?.body)), {
+        repositories: ["gogcli"],
+        permissions: { issues: "write", pull_requests: "write" },
+      });
       return jsonResponse({ token: "target-token" });
     }
     const pullMatch = /^\/repos\/openclaw\/gogcli\/pulls\/(\d+)$/.exec(url.pathname);
@@ -25978,7 +25982,12 @@ test("hosted pull request receipt fast acks precede verification and stay idempo
     if (commentMatch && init?.method === "POST") {
       const itemNumber = Number(commentMatch[1]);
       fastAckPostAttempts.set(itemNumber, (fastAckPostAttempts.get(itemNumber) || 0) + 1);
-      if (itemNumber === 601) throw new Error("GitHub comment write failed");
+      if (itemNumber === 601) {
+        return new Response(JSON.stringify({ message: "Resource not accessible by integration" }), {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        });
+      }
       const body = JSON.parse(String(init.body || "{}"));
       const comment = {
         id: 9000 + itemNumber,

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1709,7 +1709,7 @@ test("rollout dispatches one full batch workflow without admitting legacy publis
     if (url.pathname === "/app/installations/1000/access_tokens") {
       const body = JSON.parse(String(init?.body));
       assert.deepEqual(body, {
-        repository_names: ["openclaw"],
+        repositories: ["openclaw"],
         permissions: { issues: "read", pull_requests: "read" },
       });
       return new Response(JSON.stringify({ token: "target-token" }), {


### PR DESCRIPTION
## Problem

Since PR #1078 deployed (2026-08-09 04:10Z), every `pull_request` `opened`/`ready_for_review` webhook delivery to `clawsweeper.openclaw.ai` returned **HTTP 500** (Cloudflare 1101, Worker uncaught exception) until #1079 (04:53Z) moved the fast ack behind a bare `.catch(() => undefined)` — which stopped the 500s but left the receipt ack silently broken: no PR has received its 🦞👀 comment since.

## Root cause (verified live)

`acknowledgePullRequestReceipt` mints its App installation token with `permissions: { issues: "write", pull_requests: "read" }`. Posting a comment on a **pull request** via `POST /repos/{repo}/issues/{n}/comments` requires `pull_requests: write` for App tokens. GitHub answers **403 "Resource not accessible by integration"**, `githubTokenJson` throws. Replaying the worker's exact sequence (WebCrypto JWT replica included) from Actions with the production key reproduced it: every step 200/201 until the comment POST 403s with `pull_requests: read`; flipping to `write` posts successfully. The working comparison is the maintainer-command ack path, which has always minted `pull_requests: "write"`.

Bonus finding from the same replay: `createGithubAppTokenFor` sends `repository_names` in the mint body — a parameter the GitHub API does not have. It is silently ignored and tokens come back `repository_selection: "all"` (installation-wide) instead of scoped to the named repo. The documented parameter is `repositories` (verified: yields `"selected"`, 1 repo).

## Changes

- `acknowledgePullRequestReceipt`: mint `pull_requests: "write"` (matches the command-ack path).
- Webhook call site: log swallowed fast-ack failures (`console.error`) so the next regression shows up in `wrangler tail`; webhook still never fails on ack errors.
- `createGithubAppTokenFor` (dashboard queue) and `createInstallationToken` (`src/repair/comment-webhook.ts`): `repository_names` → `repositories`, restoring real repo scoping.
- Tests: mint-body assertions (`repositories` + `pull_requests: write`), and the ack-failure case now uses the production-shaped 403 response instead of a thrown mock error.

## Impact assessment of the incident

Delivery-log audit of the outage window (04:12:08–04:52:37Z): 500s hit only `opened`/`ready_for_review`; enqueue ran before the throw, and reconcile lanes absorbed the rest — every PR opened in the window is either already reviewed or pending in the queue. No redelivery batch needed.

## Proof

- `pnpm run check` green (coverage 81.34% lines / 74.05% branches / 87.37% functions).
- Targeted: `node --test test/dashboard-worker.test.ts test/exact-review-publication-batches.test.ts` — 386 pass, 0 fail; the 403 regression test logs `ClawSweeper pull request fast ack failed: ClawSweeper ack comment 403: …` and returns 202/queued.
- Live validation: Actions replay of the exact ack sequence with `pull_requests: write` posted the receipt comment on openclaw/openclaw#120874 (the PR whose lost delivery started this investigation).
