### PR TITLE
fix(dispatch): recheck pull request ack marker before posting

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -111,13 +111,27 @@ jobs:
             echo "::notice::Skipping ClawSweeper pull request acknowledgement because no target credential is configured."
             exit 0
           fi
+          has_ack_marker() {
+            jq -e \
+              --arg marker_prefix "clawsweeper-pr-ack:" \
+              --arg marker_suffix " item=$ITEM_NUMBER -->" \
+              'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
+              <<< "$1" >/dev/null
+          }
           comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
             "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
-          if jq -e \
-            --arg marker_prefix "clawsweeper-pr-ack:" \
-            --arg marker_suffix " item=$ITEM_NUMBER -->" \
-            'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
-            <<< "$comments" >/dev/null; then
+          if has_ack_marker "$comments"; then
+            echo "ClawSweeper pull request acknowledgement already exists."
+            exit 0
+          fi
+          # opened and ready_for_review can fire seconds apart for the same
+          # pull request, and both runs can list comments before either
+          # acknowledgement is visible. Wait, then recheck right before
+          # posting; a superseding run cancels this one while it sleeps.
+          sleep 15
+          comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
+          if has_ack_marker "$comments"; then
             echo "ClawSweeper pull request acknowledgement already exists."
             exit 0
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- The target dispatcher no longer double-posts pull request receipt acknowledgements when `opened` and `ready_for_review` fire seconds apart: the ack step now waits and rechecks for any existing marker immediately before posting.
 - Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`. (#1082)
 - Scoped GitHub App tokens to their named repositories via the documented `repositories` parameter. (#1082)
 - Legacy reports with canonical proof or rating keys outside the apparent leading front-matter block now fail closed, with a read-only workflow to inventory affected canonical records. (#1049)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- The target dispatcher no longer double-posts pull request receipt acknowledgements when `opened` and `ready_for_review` fire seconds apart: the ack step now waits and rechecks for any existing marker immediately before posting.
+- The target dispatcher no longer double-posts pull request receipt acknowledgements when `opened` and `ready_for_review` fire seconds apart: the ack step now waits and rechecks for any existing marker immediately before posting. (#1083)
 - Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`. (#1082)
 - Scoped GitHub App tokens to their named repositories via the documented `repositories` parameter. (#1082)
 - Legacy reports with canonical proof or rating keys outside the apparent leading front-matter block now fail closed, with a read-only workflow to inventory affected canonical records. (#1049)

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -156,13 +156,27 @@ jobs:
             echo "::notice::Skipping ClawSweeper pull request acknowledgement because no target credential is configured."
             exit 0
           fi
+          has_ack_marker() {
+            jq -e \
+              --arg marker_prefix "clawsweeper-pr-ack:" \
+              --arg marker_suffix " item=$ITEM_NUMBER -->" \
+              'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
+              <<< "$1" >/dev/null
+          }
           comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
             "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
-          if jq -e \
-            --arg marker_prefix "clawsweeper-pr-ack:" \
-            --arg marker_suffix " item=$ITEM_NUMBER -->" \
-            'any(.[]; (.body // "") as $body | ($body | contains($marker_prefix)) and ($body | contains($marker_suffix)))' \
-            <<< "$comments" >/dev/null; then
+          if has_ack_marker "$comments"; then
+            echo "ClawSweeper pull request acknowledgement already exists."
+            exit 0
+          fi
+          # opened and ready_for_review can fire seconds apart for the same
+          # pull request, and both runs can list comments before either
+          # acknowledgement is visible. Wait, then recheck right before
+          # posting; a superseding run cancels this one while it sleeps.
+          sleep 15
+          comments="$(GH_TOKEN="$ACK_TOKEN" gh api \
+            "repos/$TARGET_REPO/issues/$ITEM_NUMBER/comments?per_page=100")"
+          if has_ack_marker "$comments"; then
             echo "ClawSweeper pull request acknowledgement already exists."
             exit 0
           fi
@@ -310,6 +324,14 @@ jobs:
             --method POST \
             --input - <<< "$payload"
 ```
+
+Non-draft pull request receipts get one best-effort `clawsweeper-pr-ack`
+comment. `opened` and `ready_for_review` can fire seconds apart when a draft is
+marked ready immediately after creation, and both runs can list comments before
+either acknowledgement is visible. The acknowledgement step therefore matches
+any existing `clawsweeper-pr-ack` marker for the item, then waits and rechecks
+right before posting; when a superseding event arrives during that wait, the
+shared concurrency group cancels the sleeping run before it posts.
 
 Comments are a lightweight trigger only when the body contains a ClawSweeper
 command, and generated proof-nudge comments are explicitly ignored before command


### PR DESCRIPTION
## Problem

A PR created as draft and marked ready within seconds can receive two receipt acks from the target dispatcher. Observed on openclaw/openclaw#120974 (2026-08-09): `clawsweeper-pr-ack:opened` at 07:15:20Z and `clawsweeper-pr-ack:ready_for_review` at 07:15:29Z, despite the idempotency check.

## Root cause

The idempotency check already matches any `clawsweeper-pr-ack:` marker for the item, but it runs once at step start. The `opened` and `ready_for_review` runs can both list comments before either acknowledgement is visible (interleaved runs across the concurrency-group handoff, or comment-list read lag), so both proceed to POST.

## Fix

The "Acknowledge received pull request" step now rechecks immediately before posting: after a clean first check it sleeps 15s, re-lists, and exits if any marker appeared. This closes both race directions:

- a sibling ack posted in the meantime becomes visible before we POST;
- if a superseding `ready_for_review` event arrives while the `opened` run is sleeping, the existing concurrency group's cancel-in-progress cancels the sleeping run before it ever posts, leaving exactly one poster.

The step stays `continue-on-error` and the marker format is unchanged. `docs/target-dispatcher.md` template stays byte-identical to the live workflow (enforced by `test/target-dispatcher-workflow.test.ts`), plus a short prose note on the race guard.

## Proof

- `npx tsx --test test/clawsweeper.test.ts test/target-dispatcher-workflow.test.ts` — 79/79 pass, including the byte-identity assertion.
- `bash -n` on the extracted step script; `actionlint` clean; `pnpm run check:static` (incl. `format:check` over workflows) clean.
- Marker-function probe: existing `opened` marker dedupes; wrong-item / empty / null-body payloads still post.

Follow-up: propagating the fixed step byte-identically to openclaw/openclaw's customized dispatcher copy (step there matched the pre-fix canonical step exactly).
