### PR TITLE
fix(webhook): dedupe pull request receipts across opened and ready_for_review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Pull request 🦞👀 receipts now dedupe per pull request across `opened` and `ready_for_review`, so back-to-back webhook actions keep one receipt instead of posting near-identical duplicates.
 - Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`. (#1082)
 - Scoped GitHub App tokens to their named repositories via the documented `repositories` parameter. (#1082)
 - Legacy reports with canonical proof or rating keys outside the apparent leading front-matter block now fail closed, with a read-only workflow to inventory affected canonical records. (#1049)

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2470,11 +2470,14 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
     permissions: { issues: "write", pull_requests: "write" },
   });
   const ackMarker = pullRequestFastAckMarker(decision.itemNumber, decision.sourceAction);
+  const ackMatch = pullRequestFastAckMatch(decision.itemNumber);
   const statusCommentId = await createFastAckCommentOnce({
     token,
     repo: decision.targetRepo,
     itemNumber: decision.itemNumber,
     ackMarker,
+    ackMatch,
+    ackDedupeKey: "clawsweeper-pr-ack",
     ackBody: renderPullRequestFastAckComment(ackMarker),
   });
   settleFastAckComments({
@@ -2482,6 +2485,7 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
     repo: decision.targetRepo,
     itemNumber: decision.itemNumber,
     ackMarker,
+    ackMatch,
     delaysMs: fastAckSettleDelaysMs(env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS),
     waitUntil: ctx?.waitUntil?.bind(ctx),
   });
@@ -2494,9 +2498,10 @@ async function createFastAckComment({
   itemNumber,
   sourceCommentId = undefined,
   ackMarker = fastAckMarker(sourceCommentId),
+  ackMatch = undefined,
   ackBody = renderFastAckComment(sourceCommentId),
 }) {
-  const existingId = await pruneFastAckComments({ token, repo, itemNumber, ackMarker });
+  const existingId = await pruneFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch });
   if (existingId) return existingId;
   const payload = await githubTokenJson({
     token,
@@ -2506,7 +2511,7 @@ async function createFastAckComment({
     errorLabel: "ClawSweeper ack comment",
   });
   return (
-    (await pruneFastAckComments({ token, repo, itemNumber, ackMarker })) ||
+    (await pruneFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch })) ||
     Number(payload.id) ||
     null
   );
@@ -2518,13 +2523,14 @@ function settleFastAckComments({
   itemNumber,
   sourceCommentId = undefined,
   ackMarker = fastAckMarker(sourceCommentId),
+  ackMatch = undefined,
   delaysMs = DEFAULT_FAST_ACK_SETTLE_DELAYS_MS,
   waitUntil,
 }) {
   const cleanup = async () => {
     for (const delayMs of delaysMs) {
       await sleep(delayMs);
-      await pruneFastAckComments({ token, repo, itemNumber, ackMarker });
+      await pruneFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch });
     }
   };
   const promise = cleanup().catch((error) => {
@@ -2547,12 +2553,21 @@ async function createFastAckCommentOnce({
   itemNumber,
   sourceCommentId = undefined,
   ackMarker = fastAckMarker(sourceCommentId),
+  ackMatch = undefined,
+  ackDedupeKey = ackMarker,
   ackBody = renderFastAckComment(sourceCommentId),
 }) {
-  const key = fastAckKey({ repo, itemNumber, ackMarker });
+  const key = fastAckKey({ repo, itemNumber, ackMarker: ackDedupeKey });
   const pending = inFlightFastAcks.get(key);
   if (pending) return pending;
-  const next = createFastAckComment({ token, repo, itemNumber, ackMarker, ackBody }).finally(() => {
+  const next = createFastAckComment({
+    token,
+    repo,
+    itemNumber,
+    ackMarker,
+    ackMatch,
+    ackBody,
+  }).finally(() => {
     inFlightFastAcks.delete(key);
   });
   inFlightFastAcks.set(key, next);
@@ -2576,8 +2591,9 @@ async function pruneFastAckComments({
   itemNumber,
   sourceCommentId = undefined,
   ackMarker = fastAckMarker(sourceCommentId),
+  ackMatch = undefined,
 }) {
-  const comments = await listFastAckComments({ token, repo, itemNumber, ackMarker });
+  const comments = await listFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch });
   if (!comments.length) return null;
   const hasStatusComment = comments.some(isStatusBearingFastAckComment);
   comments.sort(compareFastAckKeepPriority);
@@ -2634,8 +2650,9 @@ function compareCommentsByCreatedAt(left, right) {
   );
 }
 
-async function listFastAckComments({ token, repo, itemNumber, ackMarker }) {
+async function listFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch = undefined }) {
   const comments = [];
+  const matchesAckBody = ackMatch || ((body) => body.includes(ackMarker));
   const since = encodeURIComponent(new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
   for (let page = 1; page <= 5; page += 1) {
     const payload = await githubTokenJson({
@@ -2648,7 +2665,7 @@ async function listFastAckComments({ token, repo, itemNumber, ackMarker }) {
     if (!Array.isArray(payload)) return comments;
     for (const comment of payload) {
       if (
-        String(objectValue(comment).body || "").includes(ackMarker) &&
+        matchesAckBody(String(objectValue(comment).body || "")) &&
         isClawsweeperGithubWebhookSender(objectValue(objectValue(comment).user))
       ) {
         comments.push(comment);
@@ -2675,6 +2692,14 @@ function fastAckMarker(sourceCommentId) {
 
 function pullRequestFastAckMarker(itemNumber, sourceAction) {
   return `<!-- clawsweeper-pr-ack:${sourceAction} item=${itemNumber} -->`;
+}
+
+// `opened` and `ready_for_review` can arrive seconds apart for one pull
+// request, so receipts dedupe per item across actions — the same
+// prefix+suffix identity the target dispatch workflow checks.
+function pullRequestFastAckMatch(itemNumber) {
+  const suffix = ` item=${itemNumber} -->`;
+  return (body) => body.includes("clawsweeper-pr-ack:") && body.includes(suffix);
 }
 
 function renderPullRequestFastAckComment(ackMarker) {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -26123,6 +26123,178 @@ test("hosted pull request receipt fast acks precede verification and stay idempo
   }
 });
 
+test("hosted pull request receipts dedupe across opened and ready_for_review", async () => {
+  const originalFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const storage = new MemoryDurableStorage();
+  const queue = new ExactReviewQueue({ storage }, {});
+  type AckComment = {
+    id: number;
+    body: string;
+    created_at: string;
+    user: { login: string };
+  };
+  const comments = new Map<number, AckComment[]>();
+  const waitUntilPromises: Promise<unknown>[] = [];
+  const fastAckPostAttempts = new Map<number, number>();
+  const deletedCommentIds: number[] = [];
+  const repository = {
+    full_name: "openclaw/gogcli",
+    default_branch: "trunk",
+    private: false,
+    archived: false,
+    fork: false,
+    has_issues: true,
+  };
+  const pullRequestFastAckBody = (itemNumber: number, sourceAction: string) =>
+    [
+      `<!-- clawsweeper-pr-ack:${sourceAction} item=${itemNumber} -->`,
+      "🦞👀",
+      "ClawSweeper picked this up.",
+      "",
+      "Pull request received. I will update this pull request when review starts.",
+    ].join("\n");
+
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/app/installations/123/access_tokens") {
+      return jsonResponse({ token: "target-token" });
+    }
+    const pullMatch = /^\/repos\/openclaw\/gogcli\/pulls\/(\d+)$/.exec(url.pathname);
+    if (pullMatch) {
+      return jsonResponse({
+        head: { sha: Number(pullMatch[1]) === 640 ? "9".repeat(40) : "8".repeat(40) },
+      });
+    }
+    const commentsMatch = /^\/repos\/openclaw\/gogcli\/issues\/(\d+)\/comments$/.exec(url.pathname);
+    if (commentsMatch && init?.method === "GET") {
+      return jsonResponse([...(comments.get(Number(commentsMatch[1])) || [])]);
+    }
+    if (commentsMatch && init?.method === "POST") {
+      const itemNumber = Number(commentsMatch[1]);
+      fastAckPostAttempts.set(itemNumber, (fastAckPostAttempts.get(itemNumber) || 0) + 1);
+      const body = JSON.parse(String(init.body || "{}"));
+      const comment = {
+        id: 9000 + itemNumber + (comments.get(itemNumber)?.length || 0),
+        body: String(body.body || ""),
+        created_at: "2026-08-09T12:00:01Z",
+        user: { login: "openclaw-clawsweeper[bot]" },
+      };
+      comments.set(itemNumber, [...(comments.get(itemNumber) || []), comment]);
+      return jsonResponse(comment);
+    }
+    const deleteMatch = /^\/repos\/openclaw\/gogcli\/issues\/comments\/(\d+)$/.exec(url.pathname);
+    if (deleteMatch && init?.method === "DELETE") {
+      const commentId = Number(deleteMatch[1]);
+      deletedCommentIds.push(commentId);
+      for (const [itemNumber, list] of comments) {
+        comments.set(
+          itemNumber,
+          list.filter((comment) => comment.id !== commentId),
+        );
+      }
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  const env = {
+    CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+    CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-secret",
+    CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS: "0",
+    GITHUB_TOKEN: "verification-token",
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const context = {
+    waitUntil: (promise: Promise<unknown>) => waitUntilPromises.push(promise),
+  };
+  const send = (
+    deliveryId: string,
+    action: string,
+    pullRequest: { number: number; head: { sha: string }; updated_at: string; body: string },
+  ) =>
+    worker.fetch(
+      signedGithubWebhookRequest({
+        event: "pull_request",
+        secret: "test-secret",
+        deliveryId,
+        payload: {
+          action,
+          repository,
+          pull_request: pullRequest,
+          installation: { id: 123 },
+        },
+      }),
+      env,
+      context,
+    );
+
+  try {
+    // A ready_for_review arriving seconds after opened must reuse the opened
+    // receipt instead of posting a second, action-suffixed duplicate.
+    const opened = {
+      number: 640,
+      head: { sha: "9".repeat(40) },
+      updated_at: "2026-08-09T12:00:00Z",
+      body: "Opened, then marked ready seconds later.",
+    };
+    assert.equal((await send("pr-ack-dual-opened", "opened", opened)).status, 202);
+    assert.equal(fastAckPostAttempts.get(640), 1);
+    assert.equal(
+      (
+        await send("pr-ack-dual-ready", "ready_for_review", {
+          ...opened,
+          updated_at: "2026-08-09T12:00:05Z",
+        })
+      ).status,
+      202,
+    );
+    assert.equal(fastAckPostAttempts.get(640), 1);
+    assert.equal(comments.get(640)?.length, 1);
+    assert.match(comments.get(640)?.[0]?.body || "", /clawsweeper-pr-ack:opened item=640/);
+
+    // A pair that already slipped through settles down to the earliest receipt.
+    comments.set(641, [
+      {
+        id: 9100,
+        body: pullRequestFastAckBody(641, "opened"),
+        created_at: "2026-08-09T12:01:01Z",
+        user: { login: "openclaw-clawsweeper[bot]" },
+      },
+      {
+        id: 9101,
+        body: pullRequestFastAckBody(641, "ready_for_review"),
+        created_at: "2026-08-09T12:01:03Z",
+        user: { login: "openclaw-clawsweeper[bot]" },
+      },
+    ]);
+    assert.equal(
+      (
+        await send("pr-ack-settle-ready", "ready_for_review", {
+          number: 641,
+          head: { sha: "8".repeat(40) },
+          updated_at: "2026-08-09T12:01:10Z",
+          body: "Duplicate receipts already exist.",
+        })
+      ).status,
+      202,
+    );
+    assert.equal(fastAckPostAttempts.has(641), false);
+    assert.deepEqual(deletedCommentIds, [9101]);
+    assert.equal(comments.get(641)?.length, 1);
+    assert.equal(comments.get(641)?.[0]?.id, 9100);
+    assert.match(comments.get(641)?.[0]?.body || "", /clawsweeper-pr-ack:opened item=641/);
+    await Promise.all(waitUntilPromises);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("hosted webhook reuses existing fast ack comments on redelivery", async () => {
   const originalFetch = globalThis.fetch;
   const { privateKey } = generateKeyPairSync("rsa", {


### PR DESCRIPTION
Fixes the double 🦞👀 receipt reported in openclaw/openclaw#120966: since #1082 restored fast-ack token permissions, PRs whose `opened` and `ready_for_review` webhooks arrive seconds apart got two nearly identical receipt comments, because `pullRequestFastAckMarker()` embeds the source action and the prune path only matched the exact marker.

## Decision

Keep the action in the marker; dedupe per pull request instead. The marker format is a deployed cross-repo contract: the synced `clawsweeper-dispatch.yml` in target repos both writes action-bearing markers and dedupes on the per-item prefix+suffix identity (`clawsweeper-pr-ack:` + ` item=N -->`). Dropping the action would break that workflow's existence check and orphan receipts already in the wild. The worker was the outlier; it now uses the same per-item identity.

## Changes

- `pullRequestFastAckMatch(itemNumber)` matches receipts for any action, mirroring the dispatch workflow's check.
- Optional `ackMatch` threaded through `createFastAckCommentOnce` → `createFastAckComment` → `pruneFastAckComments` → `listFastAckComments` and `settleFastAckComments`; defaults keep the comment-command ack path unchanged.
- PR acks dedupe in-flight per item (`ackDedupeKey`), so same-isolate `opened`/`ready_for_review` races collapse before any API call; cross-isolate stragglers are deleted by the settle passes, keeping the earliest receipt.

## Regression test

`hosted pull request receipts dedupe across opened and ready_for_review` covers both halves: a `ready_for_review` following `opened` reuses the existing receipt (one POST total), and a pre-seeded duplicate pair settles down to the earliest via DELETE. Fails with `2 !== 1` post attempts without the worker fix.

## Proof

- `tsc -p tsconfig.dashboard.json` clean
- `node --test test/dashboard-worker.test.ts`: 326 pass
- `node --test test/target-dispatcher-workflow.test.ts`: 2 pass
- Codex autoreview (gpt-5.6-sol, high): clean, no accepted findings
