### PR TITLE
fix(queue): preserve GitHub quota headroom

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -152,6 +152,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ITEM_KIND: ${{ github.event_name == 'pull_request_target' && 'pull_request' || 'issue' }}
           SOURCE_EVENT: ${{ github.event_name }}
@@ -199,13 +200,14 @@ jobs:
           )"
           payload="$(jq -nc \
             --arg target_repo "$TARGET_REPO" \
+            --arg target_branch "$TARGET_BRANCH" \
             --argjson item_number "$ITEM_NUMBER" \
             --arg item_kind "$ITEM_KIND" \
             --arg source_event "$SOURCE_EVENT" \
             --arg source_action "$SOURCE_ACTION" \
             --arg ingress_fingerprint "$ingress_fingerprint" \
             --argjson supersedes_in_progress "$SUPERSEDES_IN_PROGRESS" \
-            '{event_type:"clawsweeper_item",client_payload:({target_repo:$target_repo,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress} + (if $ingress_fingerprint != "" then {ingress_route:"target_dispatcher",ingress_fingerprint:$ingress_fingerprint} else {} end))}')"
+            '{event_type:"clawsweeper_item",client_payload:({target_repo:$target_repo,target_branch:$target_branch,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress} + (if $ingress_fingerprint != "" then {ingress_route:"target_dispatcher",ingress_fingerprint:$ingress_fingerprint} else {} end))}')"
           gh api repos/openclaw/clawsweeper/dispatches \
             --method POST \
             --input - <<< "$payload"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3840,7 +3840,7 @@ jobs:
             # The Durable Object turns every selected item into an independent exact-review
             # workflow. Direct schedules use current free queue capacity; target fanout may
             # request a smaller backlog-weighted share. The Worker remains the final owner of
-            # the fleet-wide 600/hour admission target and queue backpressure.
+            # the fleet-wide 300/hour admission target and queue backpressure.
             requested_batch_size="${{ github.event.client_payload.batch_size || '' }}"
             if ! [[ "$requested_batch_size" =~ ^[0-9]+$ ]] || [ "$requested_batch_size" -lt 1 ]; then
               requested_batch_size="$queue_candidate_capacity"

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1289,15 +1289,12 @@ export class ExactReviewQueue {
             );
             return { shed: true as const, reason: "backpressure" as const };
           }
-          if (
-            exactReviewScheduledLane(decision) &&
-            !this.takeScheduledReviewTokenSync(decision, now)
-          ) {
+          if (!this.takeScheduledReviewTokenSync(decision, now)) {
             state.shedSinceReset = exactReviewShedSinceReset(state) + 1;
             this.writeStateSync(state);
             this.incrementQueueMetricsSync({ reviewShed: 1, reviewShedScheduledRate: 1 });
             console.warn(
-              `exact-review admission shed: reason=scheduled_rate item=${key} lane=${exactReviewScheduledLane(decision)}`,
+              `exact-review admission shed: reason=scheduled_rate item=${key} lane=${exactReviewScheduledLane(decision) || "background"}`,
             );
             return { shed: true as const, reason: "scheduled_rate" as const };
           }
@@ -8016,13 +8013,15 @@ export class ExactReviewQueue {
 
   private takeScheduledReviewTokenSync(decision: ExactReviewDecision, now: number) {
     const lane = exactReviewScheduledLane(decision);
-    if (!lane) return true;
+    const lowPriority = isLowPriorityExactReviewDecision(decision);
+    if (!lane && !lowPriority) return true;
     const global = this.scheduledReviewBucketSync("global", now);
-    const bucket = this.scheduledReviewBucketSync(lane, now);
+    const bucket = lane ? this.scheduledReviewBucketSync(lane, now) : null;
     const admitted =
-      Number(global.throttleUntil || 0) <= now && global.tokens >= 1 && bucket.tokens >= 1;
+      Number(global.throttleUntil || 0) <= now &&
+      (lowPriority || (global.tokens >= 1 && Number(bucket?.tokens || 0) >= 1));
     this.storage.kv.put(exactReviewScheduledFeedKey("global"), {
-      tokens: admitted ? global.tokens - 1 : global.tokens,
+      tokens: admitted && lane ? global.tokens - 1 : global.tokens,
       updatedAt: now,
       ...(global.throttleObservedAt
         ? {
@@ -8032,10 +8031,12 @@ export class ExactReviewQueue {
           }
         : {}),
     });
-    this.storage.kv.put(exactReviewScheduledFeedKey(lane), {
-      tokens: admitted ? bucket.tokens - 1 : bucket.tokens,
-      updatedAt: now,
-    });
+    if (lane && bucket) {
+      this.storage.kv.put(exactReviewScheduledFeedKey(lane), {
+        tokens: admitted ? bucket.tokens - 1 : bucket.tokens,
+        updatedAt: now,
+      });
+    }
     return admitted;
   }
 
@@ -8087,10 +8088,13 @@ export class ExactReviewQueue {
       updatedAt: now,
       ratePerHour,
       burst,
-      ...(Number.isFinite(throttleObservedAt) && throttleObservedAt > 0
+      ...(Number.isFinite(throttleObservedAt) &&
+      throttleObservedAt > 0 &&
+      Number.isFinite(throttleUntil) &&
+      throttleUntil > now
         ? {
             throttleObservedAt,
-            throttleUntil: Number.isFinite(throttleUntil) ? throttleUntil : 0,
+            throttleUntil,
             throttleSource: String(stored.throttleSource || "unknown"),
           }
         : {}),

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -455,6 +455,7 @@ const DEFAULT_EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = 3 * 60_000;
 const DEFAULT_EXACT_REVIEW_PENDING_SOFT_LIMIT = 300;
 const DEFAULT_EXACT_REVIEW_TARGET_RATE_PER_HOUR = 200;
 const DEFAULT_EXACT_REVIEW_TARGET_BURST = 50;
+const EXACT_REVIEW_GITHUB_THROTTLE_ADMISSION_COOLDOWN_MS = 15 * 60 * 1000;
 const EXACT_REVIEW_SCHEDULED_FEED_KEY_PREFIX = "exact-review-scheduled-feed:v1";
 type ExactReviewScheduledLane = "hot_intake" | "normal_backfill";
 type ExactReviewScheduledBucket = ExactReviewScheduledLane | "global";
@@ -1955,6 +1956,9 @@ export class ExactReviewQueue {
         item.updatedAt = now;
       }
       const { requeued } = completionResult;
+      if (!publicationItem && retryKind === "throttle") {
+        this.deferScheduledReviewAdmissionForThrottleSync(now, requestedRetryAt ?? 0);
+      }
       // A successful workflow can still request requeue_latest after source
       // drift. That work did not leave its lane, so it must not improve the
       // operator-facing net speed until a later revision actually completes.
@@ -8015,10 +8019,18 @@ export class ExactReviewQueue {
     if (!lane) return true;
     const global = this.scheduledReviewBucketSync("global", now);
     const bucket = this.scheduledReviewBucketSync(lane, now);
-    const admitted = global.tokens >= 1 && bucket.tokens >= 1;
+    const admitted =
+      Number(global.throttleUntil || 0) <= now && global.tokens >= 1 && bucket.tokens >= 1;
     this.storage.kv.put(exactReviewScheduledFeedKey("global"), {
       tokens: admitted ? global.tokens - 1 : global.tokens,
       updatedAt: now,
+      ...(global.throttleObservedAt
+        ? {
+            throttleObservedAt: global.throttleObservedAt,
+            throttleUntil: global.throttleUntil,
+            throttleSource: global.throttleSource,
+          }
+        : {}),
     });
     this.storage.kv.put(exactReviewScheduledFeedKey(lane), {
       tokens: admitted ? bucket.tokens - 1 : bucket.tokens,
@@ -8032,6 +8044,29 @@ export class ExactReviewQueue {
     this.storage.kv.put(exactReviewScheduledFeedKey("global"), {
       tokens: Math.max(-global.burst, global.tokens - 1),
       updatedAt: now,
+      ...(global.throttleObservedAt
+        ? {
+            throttleObservedAt: global.throttleObservedAt,
+            throttleUntil: global.throttleUntil,
+            throttleSource: global.throttleSource,
+          }
+        : {}),
+    });
+  }
+
+  private deferScheduledReviewAdmissionForThrottleSync(now: number, requestedRetryAt: number) {
+    const global = this.scheduledReviewBucketSync("global", now);
+    const throttleUntil = Math.max(
+      now + EXACT_REVIEW_GITHUB_THROTTLE_ADMISSION_COOLDOWN_MS,
+      requestedRetryAt,
+      Number(global.throttleUntil || 0),
+    );
+    this.storage.kv.put(exactReviewScheduledFeedKey("global"), {
+      tokens: global.tokens,
+      updatedAt: now,
+      throttleObservedAt: now,
+      throttleUntil,
+      throttleSource: "review_completion",
     });
   }
 
@@ -8041,6 +8076,8 @@ export class ExactReviewQueue {
     const stored = objectValue(this.storage.kv.get(exactReviewScheduledFeedKey(lane)));
     const updatedAt = Number(stored.updatedAt);
     const storedTokens = Number(stored.tokens);
+    const throttleObservedAt = Number(stored.throttleObservedAt);
+    const throttleUntil = Number(stored.throttleUntil);
     if (!Number.isFinite(updatedAt) || !Number.isFinite(storedTokens)) {
       return { tokens: burst, updatedAt: now, ratePerHour, burst };
     }
@@ -8050,6 +8087,13 @@ export class ExactReviewQueue {
       updatedAt: now,
       ratePerHour,
       burst,
+      ...(Number.isFinite(throttleObservedAt) && throttleObservedAt > 0
+        ? {
+            throttleObservedAt,
+            throttleUntil: Number.isFinite(throttleUntil) ? throttleUntil : 0,
+            throttleSource: String(stored.throttleSource || "unknown"),
+          }
+        : {}),
     };
   }
 
@@ -8061,6 +8105,13 @@ export class ExactReviewQueue {
       target_rate_per_hour: global.ratePerHour,
       burst: global.burst,
       token_balance: Math.floor(global.tokens),
+      ...(global.throttleObservedAt
+        ? {
+            throttle_source: global.throttleSource,
+            throttle_observed_at: new Date(global.throttleObservedAt).toISOString(),
+            throttle_recovery_at: new Date(global.throttleUntil || 0).toISOString(),
+          }
+        : {}),
       lanes: {
         hot_intake: {
           target_rate_per_hour: hot.ratePerHour,

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -65,16 +65,14 @@ EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS = "60000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MS = "90000"
 EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS = "180000"
 EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"
-# 200/h only sustained ~14 concurrent reviews against a 128-slot pool; with the
-# review/publication lane split (#953) the queue drains to zero pending while
-# 3,306 items have never been reviewed at all (42.9% weekly coverage). Model
-# spend scales with this dial. 600/h saturated the GitHub App installation
-# token budget once the apply and comment-sync lanes resumed alongside reviews
-# (installation 122230863 rate-limit 403s, 2026-07-30 16:56Z): at ~30 API calls
-# per review, 450/h leaves the write lanes headroom inside the shared allowance
-# while still clearing the first-pass backlog in about a day.
-EXACT_REVIEW_TARGET_RATE_PER_HOUR = "450"
-EXACT_REVIEW_TARGET_BURST = "120"
+# A full review consumes about 30 GitHub requests. Keep scheduled review demand
+# at or below 9,000 requests/hour so the 15,000-request installation bucket has
+# explicit capacity for exact ingress, comment routing, apply proof, publication,
+# and support lanes. A 30-item burst bounds cold-start demand to roughly 900
+# requests instead of allowing a 3,600-request spike before the hourly limiter
+# takes effect. Interactive exact-event reviews keep their independent lane.
+EXACT_REVIEW_TARGET_RATE_PER_HOUR = "300"
+EXACT_REVIEW_TARGET_BURST = "30"
 # Keep each mutation lease at 8 while allowing four isolated workflows to prepare
 # concurrently. Final commits still cross the single state-writer coordinator.
 # A full-window publish moves ~2k paths and observed ~40 min; the drain lease

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -149,7 +149,7 @@ unset, empty, or invalid values use the defaults.
 | `CLAWSWEEPER_QUEUE_PRESSURE_HARD_AGE_MS`  | 7200000 |
 
 Only manual normal review and manual hot intake use this pressure
-multiplier. Scheduled review uses the queue's 600-item soft limit and 600/hour
+multiplier. Scheduled review uses the queue's 600-item soft limit and 300/hour
 admission target. Repair, assist, issue implementation, cluster repair, and
 exact-item review keep their existing priority budgets.
 
@@ -208,8 +208,8 @@ backlog cannot consume review admission capacity. Existing items, webhook
 events, commands, and publications remain admitted. The queue reports shed
 counts under `lanes.review.shed_reasons_since_reset` and the rolling flow by
 `backpressure` versus `scheduled_rate`; pre-migration totals remain
-`unattributed`. All newly queued review work debits a durable 600-review/hour
-budget with a 120-item burst. Organic work is always admitted and consumes the
+`unattributed`. All newly queued review work debits a durable 300-review/hour
+budget with a 30-item burst. Organic work is always admitted and consumes the
 budget first; scheduled work fills the remainder and is split 35% hot intake and
 65% normal backfill so hot churn cannot starve oldest-first coverage. Re-offering an item
 that is already pending, dispatching, or leased is a semantic dedupe: it does not

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -307,9 +307,9 @@ Current defaults:
 - scheduled hot intake and normal backfill: select up to 50 due items per target
   cycle, then enqueue each item through the durable exact-review queue; every
   admitted item receives its own parallel workflow
-- total review admission target: 600 items/hour across the fleet; organic work
+- total review admission target: 300 items/hour across the fleet; organic work
   consumes the budget first and scheduled backfill fills the remainder, split
-  35% hot intake and 65% normal backfill, with a 120-item burst
+  35% hot intake and 65% normal backfill, with a 30-item burst
 - review admission and pressure are computed independently from publication;
   top-level queue health describes reviews while `lanes.publication` retains
   publication backlog, retry, DLQ, and health telemetry
@@ -354,7 +354,7 @@ serializes per target repository, selects globally before sharding, and offers
 never-reviewed candidates before the oldest due tracked candidates to the
 durable queue. Queue admission is fleet-wide,
 so overlapping core and fanout cycles fill only the residual of the configured
-600/hour model-spend target after organic review demand.
+300/hour model-spend target after organic review demand.
 
 The manual quiet-system ceiling is not a promise that every operator run dispatches
 that many shards. The `mode` step checks active repair workers, exact-item sweep

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -384,7 +384,9 @@ run-summary funnel for selected, attempted, enqueued, deduped, shed, and deferre
 items. The queue exposes the configured rate, burst, and currently available
 token balance under `scheduled_feed` in `GET /api/exact-review-queue`. It also
 exposes backpressure and scheduled-rate shed counts separately so an operator
-can distinguish a full review queue from intentional 600/hour pacing.
+can distinguish a full review queue from intentional 300/hour pacing. The
+30-item burst bounds a cold-start cohort to roughly 900 GitHub requests at the
+observed planning average of 30 requests per completed review.
 The producer probes that field before its first enqueue and fails closed while
 an older Worker is still deployed, preventing a workflow-first rollout from
 bypassing the rate limiter.
@@ -393,11 +395,14 @@ Each hourly normal-fanout step can offer
 `50 items/target * 12 targets = 600 items/hour`. The direct five-minute hot and
 normal schedules can each offer `50 * 12 = 600 items/hour`, so either lane has
 enough candidates to keep its token bucket fed despite dedupe or uneven fleet
-distribution. At a 4.1-minute mean service time, 600/hour needs about
-`600 * 4.1 / 60 = 41` concurrent review workers, below the 120 per-target and
-128 global claim limits. The target rate, burst, and pending limit are explicit
-spend and GitHub API dials; lower them together when sustained traffic warrants
-more headroom.
+distribution. The queue admits at most 300 scheduled reviews/hour, which needs
+about `300 * 4.1 / 60 = 21` concurrent review workers at a 4.1-minute mean
+service time and budgets roughly 9,000 GitHub requests/hour. That leaves about
+6,000 requests in the shared 15,000-request installation allowance for exact
+ingress, routing, apply proof, publication, and support lanes. The target rate
+and burst are GitHub spend dials. The pending soft limit is a separate queue
+backpressure bound and should change only when queue-memory or latency evidence
+requires it, not automatically with the request budget.
 
 On saturated queues, normal planning reads the complete bounded open-item scan
 before selecting candidates. For the current largest repository this is about

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -197,6 +197,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ITEM_KIND: ${{ github.event_name == 'pull_request_target' && 'pull_request' || 'issue' }}
           SOURCE_EVENT: ${{ github.event_name }}
@@ -244,13 +245,14 @@ jobs:
           )"
           payload="$(jq -nc \
             --arg target_repo "$TARGET_REPO" \
+            --arg target_branch "$TARGET_BRANCH" \
             --argjson item_number "$ITEM_NUMBER" \
             --arg item_kind "$ITEM_KIND" \
             --arg source_event "$SOURCE_EVENT" \
             --arg source_action "$SOURCE_ACTION" \
             --arg ingress_fingerprint "$ingress_fingerprint" \
             --argjson supersedes_in_progress "$SUPERSEDES_IN_PROGRESS" \
-            '{event_type:"clawsweeper_item",client_payload:({target_repo:$target_repo,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress} + (if $ingress_fingerprint != "" then {ingress_route:"target_dispatcher",ingress_fingerprint:$ingress_fingerprint} else {} end))}')"
+            '{event_type:"clawsweeper_item",client_payload:({target_repo:$target_repo,target_branch:$target_branch,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress} + (if $ingress_fingerprint != "" then {ingress_route:"target_dispatcher",ingress_fingerprint:$ingress_fingerprint} else {} end))}')"
           gh api repos/openclaw/clawsweeper/dispatches \
             --method POST \
             --input - <<< "$payload"

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -19566,7 +19566,7 @@ test("failed shard recovery replaces an expired recovery lease", async () => {
 for (const retryKind of ["coordination", "throttle"] as const) {
   test(`exact-review queue defers ${retryKind} without spending review attempts`, async () => {
     const originalNow = Date.now;
-    const now = Date.parse("2026-08-08T13:00:00.000Z");
+    let now = Date.parse("2026-08-08T13:00:00.000Z");
     Date.now = () => now;
     try {
       const storage = new MemoryDurableStorage();
@@ -19651,6 +19651,61 @@ for (const retryKind of ["coordination", "throttle"] as const) {
               superseded_publications: 0,
             },
       );
+      for (const [index, sourceAction] of [
+        "failed_review_shard_recovery",
+        "artifact_retention_recovery",
+        "source_drift_requeue",
+      ].entries()) {
+        const background = await queue.fetch(
+          buildExactReviewQueueRequest(
+            `background-after-${retryKind}-${sourceAction}`,
+            713 + index,
+            sourceAction,
+          ),
+        );
+        assert.deepEqual(
+          await background.json(),
+          retryKind === "throttle"
+            ? { ok: true, shed: true, reason: "scheduled_rate" }
+            : {
+                ok: true,
+                queued: true,
+                item_key: `openclaw/gogcli#${713 + index}`,
+                superseded_publications: 0,
+              },
+        );
+      }
+      const interactive = await queue.fetch(
+        buildExactReviewQueueRequest(`interactive-after-${retryKind}`, 716, "opened"),
+      );
+      assert.deepEqual(await interactive.json(), {
+        ok: true,
+        queued: true,
+        item_key: "openclaw/gogcli#716",
+        superseded_publications: 0,
+      });
+      if (retryKind === "throttle") {
+        now += 91 * 60_000;
+        const recovered = await queue.fetch(
+          buildExactReviewQueueRequest(
+            "background-after-throttle-recovery",
+            717,
+            "source_drift_requeue",
+          ),
+        );
+        assert.deepEqual(await recovered.json(), {
+          ok: true,
+          queued: true,
+          item_key: "openclaw/gogcli#717",
+          superseded_publications: 0,
+        });
+        const recoveredStats = await (
+          await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+        ).json();
+        assert.equal("throttle_source" in recoveredStats.scheduled_feed, false);
+        assert.equal("throttle_observed_at" in recoveredStats.scheduled_feed, false);
+        assert.equal("throttle_recovery_at" in recoveredStats.scheduled_feed, false);
+      }
     } finally {
       Date.now = originalNow;
     }

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -203,8 +203,8 @@ test("production doubles exact review claims and canonical publication batches",
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"/);
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT = "8"/);
   assert.match(wrangler, /EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS = "5000"/);
-  assert.match(wrangler, /EXACT_REVIEW_TARGET_RATE_PER_HOUR = "450"/);
-  assert.match(wrangler, /EXACT_REVIEW_TARGET_BURST = "120"/);
+  assert.match(wrangler, /EXACT_REVIEW_TARGET_RATE_PER_HOUR = "300"/);
+  assert.match(wrangler, /EXACT_REVIEW_TARGET_BURST = "30"/);
   assert.match(wrangler, /EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"/);
 });
 
@@ -19580,6 +19580,15 @@ for (const retryKind of ["coordination", "throttle"] as const) {
           "openclaw/openclaw#711": item,
         },
       });
+      if (retryKind === "throttle") {
+        await storage.put("exact-review-scheduled-feed:v1:global", {
+          tokens: 1,
+          updatedAt: now,
+          throttleObservedAt: now - 60_000,
+          throttleUntil: now + 90 * 60_000,
+          throttleSource: "review_completion",
+        });
+      }
       const queue = new ExactReviewQueue({ storage }, {}, () => 0);
 
       const response = await queue.fetch(
@@ -19612,6 +19621,36 @@ for (const retryKind of ["coordination", "throttle"] as const) {
       assert.equal(deferred.attempts, 3);
       assert.equal(deferred.reviewFailureAttempts, 2);
       assert.equal(deferred.backoffReason, `${retryKind}_retry`);
+      if (retryKind === "throttle") {
+        const stats = await (
+          await queue.fetch(new Request("https://clawsweeper-exact-review-queue/stats"))
+        ).json();
+        assert.equal(stats.scheduled_feed.throttle_source, "review_completion");
+        assert.equal(stats.scheduled_feed.throttle_observed_at, new Date(now).toISOString());
+        assert.equal(
+          stats.scheduled_feed.throttle_recovery_at,
+          new Date(now + 90 * 60_000).toISOString(),
+        );
+        assert.ok(stats.scheduled_feed.token_balance >= 0);
+      }
+      const scheduled = await queue.fetch(
+        buildExactReviewQueueRequest(
+          `scheduled-after-${retryKind}`,
+          712,
+          "scheduled_normal_backfill",
+        ),
+      );
+      assert.deepEqual(
+        await scheduled.json(),
+        retryKind === "throttle"
+          ? { ok: true, shed: true, reason: "scheduled_rate" }
+          : {
+              ok: true,
+              queued: true,
+              item_key: "openclaw/gogcli#712",
+              superseded_publications: 0,
+            },
+      );
     } finally {
       Date.now = originalNow;
     }


### PR DESCRIPTION
## Summary

- reserve explicit GitHub App installation quota for ingress, routing, apply proof, publication, and support lanes by reducing scheduled exact-review admission from 450/hour with a 120-item burst to 300/hour with a 30-item burst
- turn typed GitHub throttle completions into a durable pause for scheduled/background admission while leaving interactive exact-event admission available
- include the event repository's default branch in target-dispatch payloads so ingress does not need a separate default-branch lookup

## Problem

Current `main` intermittently exhausts the shared GitHub App installation request bucket across otherwise independent consumers. Read-only investigation re-established primary quota failures in:

- [ingress durable enqueue run 31336100574](https://github.com/openclaw/clawsweeper/actions/runs/31336100574): default-branch lookup
- [scheduled comment router run 31335806816](https://github.com/openclaw/clawsweeper/actions/runs/31335806816): open autofix issue listing
- [exact comment router run 31335683131](https://github.com/openclaw/clawsweeper/actions/runs/31335683131): issue-comment pagination
- [read-only apply proof run 31335671451](https://github.com/openclaw/clawsweeper/actions/runs/31335671451): open issue listing

These were installation-token `403 API rate limit exceeded` responses interleaved with successful runs. Router-ledger finalize errors were secondary fallout after the primary quota failures. The current open issue/PR population is large enough that the repeated list and hydration paths amplify the shared pressure.

The structural over-capacity is the scheduled exact-review budget: the worker documents about 30 GitHub requests per full review, while 450 reviews/hour permits roughly 13,500 requests/hour and a 120-item cold-start burst permits roughly 3,600 requests before the hourly limiter dominates. That leaves insufficient room inside the 15,000-request installation allowance for all other lanes. This is independent of [#1085](https://github.com/openclaw/clawsweeper/pull/1085), whose exact-publication batching and guard behavior remain unchanged. The branch is rebased onto [#1087](https://github.com/openclaw/clawsweeper/pull/1087), which separately reduces only hot fleet target-fanout cadence from every 5 minutes to every 20 minutes. That containment lowers one producer's pressure but does not change core 5-minute intake, ClawHub, normal, or audit schedules and does not replace the shared admission/cooldown repair here.

## Implementation

- Scheduled review admission is bounded at 300/hour and burst 30, budgeting about 9,000 steady requests/hour and about 900 burst requests. Interactive exact-event work retains its independent admission path.
- A completion with typed `retryKind: throttle` pauses scheduled admission plus failed-shard recovery, artifact-retention recovery, and source-drift requeue admission. Interactive exact-event admission remains available. The durable deadline is the maximum of the existing deadline, the reported retry time, and a 15-minute minimum, so concurrent shorter reports cannot shrink an active cooldown.
- The scheduled-feed status includes optional source, observation, and recovery telemetry without token values or credentials.
- Target dispatchers propagate `github.event.repository.default_branch`; the legacy ingress fallback remains available for older senders.

No token pool was shuffled and no retry count was increased. Mutation leases, idempotence, publication guards, authorization, and destructive-close behavior are unchanged.

## Validation

- `corepack pnpm run build:all`
- `node --test test/dashboard-worker.test.ts` (326 passing)
- `node --test test/target-dispatcher-workflow.test.ts` (2 passing)
- `corepack pnpm exec oxlint dashboard/exact-review-queue.ts test/dashboard-worker.test.ts`
- `git diff --check`
- `corepack pnpm run check` reached repository-wide `format:check`; on this Windows checkout oxfmt reported all 648 files because of baseline line-ending behavior. The five changed files were formatted directly and scoped lint/diff checks passed. No repository-wide line-ending policy was changed.
- `actionlint` is not installed in this checkout. The changed workflow payload is covered by the dispatcher-template tests and exact-head Linux proof below.

### Review gates

- Dirty Codex review first found that the reported retry deadline was not honored; fixed and regression-tested.
- The repeated dirty review found that a concurrent shorter throttle could shrink an existing deadline; fixed and regression-tested.
- ClawSweeper found that three low-priority background sources bypassed the scheduled token path; fixed with per-source shedding and interactive control coverage.
- A follow-up dirty Codex review caught double charging of admitted background work; fixed by retaining the existing single shared-capacity charge.
- The first committed review caught stale throttle telemetry after recovery; fixed with expiry cleanup and recovery coverage.
- ClawSweeper found stale operator guidance for the former 600/hour policy; `docs/scheduler.md`, `docs/limits.md`, and the scheduler continuation comment now consistently document 300/hour, burst 30, request headroom, and the independent 600-item pending soft limit.
- Final dirty Codex review and final `codex review --base origin/main` on head `edf9eb74c01870212e6b2c3e65f88cf07e275cb4`: no actionable findings. The final read-only local ClawSweeper range review also completed with no blockers (`decision=keep_open`, confidence high, action `kept_open`).
- `corepack pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: one committed-range item, `decision=keep_open`, `confidence=high`, no blockers and no GitHub mutation.

## Real Behavior Proof

**Claim:** the exact head bounds scheduled request demand, durably sheds scheduled/background admission after a typed GitHub throttle without blocking interactive exact events, preserves the longest recovery deadline, and removes the ingress default-branch GET for current dispatcher events.

**Exercised surface:** production queue configuration, exact-review enqueue/completion/token-bucket/status paths, repeated and partial throttle reports, coordination retries, queue ordering and close-safety regressions, and the target-dispatch workflow/template payload.

**Scenario and fixture:** the complete dashboard worker suite (326 tests) plus dispatcher workflow suite (2 tests), including production limit assertions, scheduled/background-vs-interactive admission, supplied and concurrent throttle deadlines, fallback/partial-failure paths, ordering, idempotence, and close-safety coverage. A separate transport proof ran the built Worker through Wrangler/workerd HTTP routing and SQLite-backed Durable Object persistence: it seeded an isolated claimed lease, posted a typed throttle completion through `/internal/exact-review/complete`, sent signed enqueue traffic through `/internal/exact-review/enqueue`, read `/api/exact-review-queue`, advanced only the isolated proof deadline, and observed recovery.

**Command/environment:** Crabbox provider `local-container`, lease `cbx_c1798df48a65` (`golden-prawn`), Docker image `mcr.microsoft.com/playwright:v1.60.0-noble`. A fresh PR checkout and public branch clone asserted exact head `edf9eb74c01870212e6b2c3e65f88cf07e275cb4`, installed the frozen lockfile, built all targets, then ran Wrangler `4.107.0` locally with isolated persisted Durable Object state and an isolated proof-only webhook secret.

**Observed result:** exit 0 in 28.549s. The typed completion returned `{ok:true,requeued:true}`. Scheduled normal backfill and all three low-priority background sources returned `shed:true, reason:scheduled_rate`; interactive `opened` ingress queued. Active stats exposed redacted `review_completion` recovery telemetry. After the isolated deadline passed, source-drift recovery queued and all throttle fields disappeared. The script ended with `CSW110_WORKERD_PROOF=pass` and the asserted exact SHA. Separately, the full exact-head test suites passed 326 + 2 tests.

**Artifact/trace:** Crabbox local-container receipt for lease `cbx_c1798df48a65`, slug `golden-prawn`, exit 0 in 40.898s (command 29.934s), with `CSW110_WORKERD_PROOF=pass head=edf9eb74c01870212e6b2c3e65f88cf07e275cb4`. Two preceding local-container leases (`cbx_3a6c0490ed87`, `cbx_6509ab46b654`) stopped before command execution when raw-workspace rsync closed; the successful run used Crabbox fresh-PR checkout to bypass that transport failure without changing provider or image. This exact-head receipt is the authoritative result.

**Limits:** the transport proof uses the production Worker and Durable Object implementation but an isolated local workerd instance and a seeded claimed-lease fixture; it does not dispatch a GitHub workflow, mutate a live queue, or consume production GitHub state. Organic quota health can only be confirmed after merge and deployment. Current `main` therefore remains intermittently quota-constrained until the change is landed and deployed.

## Operational impact and rollback

- Scheduled first-pass review throughput decreases to preserve roughly 6,000 installation requests/hour for user- and operator-facing lanes. Interactive exact events are not rate-reduced by this change.
- The dashboard/Bay status surface gains optional scheduled-feed throttle telemetry; lifecycle stages, operator actions, and journey semantics do not change.
- Rollback is a normal revert. There is no data migration or queue rewrite; reverting restores the previous 450/120 admission and removes the completion-driven scheduled pause and branch hint, with the known risk of renewed quota exhaustion.
- This PR touches `.github/workflows/**`; GitHub OAuth workflow scope may require a maintainer-owned replacement branch or approval. No workflow was dispatched while developing or proving this patch.

## Risks

- The 30-request/review estimate is an observed planning average, not a hard per-review ceiling. Completion-driven cooldown provides a bounded second line of defense when real demand exceeds the planned envelope.
- Exact interactive demand can still consume shared installation capacity during an exceptional burst. This patch deliberately preserves interactive freshness instead of globally pausing ingress.
- No queues were replayed, cleared, or acknowledged; no gates, schedules, monitors, branch protections, production data, or workflow runs were mutated.
