### PR TITLE
fix(publication): keep throttled batch publications on the transient retry budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Batch publication no longer dead-letters finished reviews an hour into a GitHub throttling episode: network errors, 429s, and 5xx responses now complete as `state_contention` (48 attempts / 24 h) instead of `unknown_failure` (14 attempts / 1 h), matching the single-item publication path. 98% of the 721 `retry_exhausted` dead letters had spent fewer than 14 attempts and died on the one-hour cap alone.
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Batch publication no longer dead-letters finished reviews an hour into a GitHub throttling episode: network errors, 429s, and 5xx responses now complete as `state_contention` (48 attempts / 24 h) instead of `unknown_failure` (14 attempts / 1 h), matching the single-item publication path. 98% of the 721 `retry_exhausted` dead letters had spent fewer than 14 attempts and died on the one-hour cap alone.
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/docs/pr-674-observation-runbook.md
+++ b/docs/pr-674-observation-runbook.md
@@ -5,6 +5,19 @@ This observation layer must land before
 PR's per-item shard implementation or generation-bound queue protocol. Instead it provides the
 backward-compatible contract that the later PR can populate.
 
+> **Status: the producer this contract was built for never landed.** PR 674 was closed
+> unmerged on 2026-07-21, so nothing in production posts to
+> `POST /internal/exact-review/review-telemetry`; the only callers are tests. The run-level
+> observer (`scripts/review-run-observer.mjs`) is wired and does write
+> `review-run-telemetry`, which is why `/api/review-observability` reports a large
+> `expected_attempts` against `terminal_attempts: 0`, `terminal_coverage: 0`, and
+> `abnormal_rate_percent: 100`. Those values describe a missing producer, not failing reviews.
+> `REVIEW_OBSERVABILITY_REQUIRED=0` keeps the layer in passive mode, so the empty pipeline
+> does not colour dashboard health. Read the rollout steps below as pending work: they take
+> effect only if a per-item producer is built. Until then, treat
+> `exact_review_queue.review_telemetry_health` as vacuously green — it only reports on
+> `refreshing` rows, and no rows exist.
+
 ## Health policy
 
 The dashboard hero is green (`All clear`) only when every known signal is healthy. The aggregate

--- a/docs/proof/csw-1089/README.md
+++ b/docs/proof/csw-1089/README.md
@@ -1,0 +1,87 @@
+# PR 1089 real-boundary publication retry proof
+
+## Claim
+
+A batch publication that reaches a real transport failure with no HTTP status,
+HTTP 429, or HTTP 5xx is completed by the built `exact-review-batch-cli` as
+`retryable_failure` / `state_contention`. The real `ExactReviewQueue` Durable
+Object accepts that tuple, returns the publication item to `pending`, increments
+its attempt count, schedules `next_attempt_at`, and does not create an open dead
+letter.
+
+The production policy contrast is 48 attempts / 24 hours for
+`state_contention` versus 14 attempts / one hour for `unknown_failure`. This
+bounded proof exercises the first real retry for both classifications. It does
+not claim to have waited through the full old retry budget; see Limits.
+
+## Exercised surface
+
+- Built `dist/repair/exact-review-batch-cli.js` `commit` and `complete` commands
+- Real localhost TLS sockets returning a connection reset, HTTP 429, and HTTP 503
+- Signed Worker routes for enqueue, batch claim, and batch completion
+- Real local Wrangler Worker and `ExactReviewQueue` Durable Object
+- Public queue item-status and aggregate status routes
+
+## Controlled scenario
+
+The script builds the repair CLI and dashboard, generates a disposable
+self-signed localhost certificate, and starts a bounded HTTPS listener on
+`127.0.0.1`. For each transport case the actual CLI fetches a batch, posts the
+canonical publication payload over a real socket, retries the reset/429/503,
+and posts its completion envelope back over the socket. The listener verifies
+the HMAC and captures the raw tuple; it does not replace or monkeypatch `fetch`,
+timers, or CLI modules.
+
+Separately, the script starts the real Worker and Durable Object with pinned
+Wrangler 4.107.0 and disposable local persistence. It uses a synthetic local
+HMAC secret to enqueue and claim a publication item, posts the CLI-captured 429
+completion tuple, and reads queue status before and after. A second fresh item
+repeats the same Worker/DO sequence with only the reason changed to
+`unknown_failure` for an attempt-one control.
+
+## Required observations
+
+- Reset, 429, and 503 each produce a raw CLI completion with
+  `terminal_outcome: "retryable_failure"` and
+  `reason_code: "state_contention"`.
+- Every CLI request crosses a real loopback socket and carries a valid HMAC.
+- After the real Worker/DO accepts the `state_contention` completion, item
+  status reports `state: "pending"`, `attempts: 1`, a future
+  `next_attempt_at`, and no open dead letter.
+- The attempt-one `unknown_failure` control is also retained for retry, as the
+  old policy requires before its 14-attempt / one-hour limit.
+- No request points at production, GitHub, or any non-loopback application
+  endpoint. No real secret is used or retained.
+
+## Command and environment
+
+Run from the repository root on Node 24 or newer:
+
+```bash
+docs/proof/csw-1089/run-proof.sh
+```
+
+The script uses `npx --yes wrangler@4.107.0 dev --local --persist-to ...` on
+`127.0.0.1` with the repository's normal local queue configuration. No
+publication retry limit, age, delay, or clock is changed.
+
+## Artifacts
+
+Generated artifacts live in `docs/proof/csw-1089/artifacts/`. They include the
+runtime transcript, three raw CLI completion envelopes and receipts, signed
+transport request trace, Worker enqueue/claim/complete responses, queue item
+status before and after both completions, final aggregate queue status, proof
+summary, build logs, and a bounded redacted Wrangler log.
+
+## Limits
+
+Driving one item through 14 authentic claims is intentionally not automated:
+the real retry delays are 1, 2, 4, then capped 5+ minute backoffs, requiring
+roughly 51 minutes before attempt 14. There is no supported endpoint for
+advancing the Durable Object clock or `next_attempt_at`. This proof therefore
+does not show the `unknown_failure` item entering the dead-letter store at
+attempt 14, nor the `state_contention` item remaining pending at that same
+attempt count. It records the real attempt-one classification and queue result
+for both and leaves the terminal contrast to the unchanged retry-policy code
+and existing focused tests. It does not fake time, edit Durable Object storage,
+stub the Worker/DO, or change a retry constant.

--- a/docs/proof/csw-1089/README.md
+++ b/docs/proof/csw-1089/README.md
@@ -85,3 +85,37 @@ attempt count. It records the real attempt-one classification and queue result
 for both and leaves the terminal contrast to the unchanged retry-policy code
 and existing focused tests. It does not fake time, edit Durable Object storage,
 stub the Worker/DO, or change a retry constant.
+
+## Crabbox provenance
+
+The proof in this directory was re-run unchanged against the reviewed head inside a
+Docker-backed Crabbox `local-container` lease, from a clean remote checkout of the PR
+(`--fresh-pr openclaw/clawsweeper#1089 --no-hydrate`) rather than from a local working tree.
+
+| Field | Value |
+| --- | --- |
+| Provider | `local-container` (Crabbox CLI 0.39.0) |
+| Container engine | Docker 29.4.0 (OrbStack) |
+| Image | `node:24-bookworm` |
+| Lease | `cbx_9797931e8d4d` (`coral-prawn`), stopped after the run |
+| Reviewed head | `d54d60abf5de708713e0fbedce496cd5a21dd251` |
+| Runtime | Node v24.19.0, pnpm 11.10.0 |
+| Result | `exit 0`, 21 assertions, `run_status: succeeded` |
+| Timings | sync 10.2 s, command 55.6 s, total 65.8 s |
+
+Machine-readable provenance, including the captured queue observations, is in
+[`artifacts/crabbox-local-container-provenance.json`](artifacts/crabbox-local-container-provenance.json).
+The raw container transcript is in
+[`artifacts/crabbox-local-container-stdout.log`](artifacts/crabbox-local-container-stdout.log).
+
+The run needs no elevated privileges. Corepack is enabled into the container user's own
+`~/.local/bin`, because the lease user is unprivileged and cannot write to `/usr/local/bin`.
+
+### What this provenance does and does not add
+
+It establishes that the proof reproduces on the exact reviewed head, in a clean containerized
+environment, with no dependency on this workstation's state. It does not change what the proof
+itself demonstrates; the limits recorded above and in the provenance JSON still apply, in
+particular that both queue observations are at attempt 1 and the retry-budget divergence itself is
+covered by unit tests and by the production dead-letter statistics quoted in the PR body rather
+than by this run.

--- a/docs/proof/csw-1089/artifacts/build-dashboard.log
+++ b/docs/proof/csw-1089/artifacts/build-dashboard.log
@@ -1,0 +1,1 @@
+$ tsc -p tsconfig.dashboard.json

--- a/docs/proof/csw-1089/artifacts/build-repair.log
+++ b/docs/proof/csw-1089/artifacts/build-repair.log
@@ -1,0 +1,1 @@
+$ tsc -p tsconfig.repair.json

--- a/docs/proof/csw-1089/artifacts/cli-runs.json
+++ b/docs/proof/csw-1089/artifacts/cli-runs.json
@@ -1,0 +1,50 @@
+[
+  {
+    "scenario": "no-status",
+    "command": "commit",
+    "exit_code": 0,
+    "signal": null,
+    "stdout": "{\"ok\":true,\"batch_id\":\"csw-1089-no-status\",\"state_commit_sha\":null,\"materialized\":0,\"quarantined\":0,\"superseded\":0}",
+    "stderr": ""
+  },
+  {
+    "scenario": "no-status",
+    "command": "complete",
+    "exit_code": 0,
+    "signal": null,
+    "stdout": "{\"ok\":true,\"batch_id\":\"csw-1089-no-status\",\"accepted\":1,\"retryable\":1}",
+    "stderr": ""
+  },
+  {
+    "scenario": "429",
+    "command": "commit",
+    "exit_code": 0,
+    "signal": null,
+    "stdout": "{\"ok\":true,\"batch_id\":\"csw-1089-429\",\"state_commit_sha\":null,\"materialized\":0,\"quarantined\":0,\"superseded\":0}",
+    "stderr": ""
+  },
+  {
+    "scenario": "429",
+    "command": "complete",
+    "exit_code": 0,
+    "signal": null,
+    "stdout": "{\"ok\":true,\"batch_id\":\"csw-1089-429\",\"accepted\":1,\"retryable\":1}",
+    "stderr": ""
+  },
+  {
+    "scenario": "503",
+    "command": "commit",
+    "exit_code": 0,
+    "signal": null,
+    "stdout": "{\"ok\":true,\"batch_id\":\"csw-1089-503\",\"state_commit_sha\":null,\"materialized\":0,\"quarantined\":0,\"superseded\":0}",
+    "stderr": ""
+  },
+  {
+    "scenario": "503",
+    "command": "complete",
+    "exit_code": 0,
+    "signal": null,
+    "stdout": "{\"ok\":true,\"batch_id\":\"csw-1089-503\",\"accepted\":1,\"retryable\":1}",
+    "stderr": ""
+  }
+]

--- a/docs/proof/csw-1089/artifacts/completion-429.json
+++ b/docs/proof/csw-1089/artifacts/completion-429.json
@@ -1,0 +1,35 @@
+{
+  "batch_id": "csw-1089-429",
+  "lease_owner": "csw-1089-proof-worker",
+  "items": [
+    {
+      "item_key": "openclaw/openclaw#108901@publish:1089010:1",
+      "revision": 1,
+      "claim_generation": 1,
+      "terminal_outcome": "retryable_failure",
+      "reason_code": "state_contention",
+      "error_fingerprint": "5f9c419830988ab97857f9330f4d7750c560c0af5aabfe4865220f6257aa7fd4"
+    }
+  ],
+  "state_writer": {
+    "schema_version": 1,
+    "operation_id": "batch:csw-1089-429",
+    "mode": "batch",
+    "started_at": "2026-08-10T01:25:33.983Z",
+    "finished_at": "2026-08-10T01:25:49.005Z",
+    "wait_ms": 0,
+    "acquire_attempts": 0,
+    "acquired": false,
+    "hold_ms": null,
+    "renewals": 0,
+    "released": null,
+    "git_duration_ms": 15022,
+    "git_processes": 0,
+    "commit_count": 0,
+    "materialized_items": 0,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": 0,
+    "outcome": "failed"
+  }
+}

--- a/docs/proof/csw-1089/artifacts/completion-503.json
+++ b/docs/proof/csw-1089/artifacts/completion-503.json
@@ -1,0 +1,35 @@
+{
+  "batch_id": "csw-1089-503",
+  "lease_owner": "csw-1089-proof-worker",
+  "items": [
+    {
+      "item_key": "openclaw/openclaw#108903@publish:1089030:1",
+      "revision": 1,
+      "claim_generation": 1,
+      "terminal_outcome": "retryable_failure",
+      "reason_code": "state_contention",
+      "error_fingerprint": "ce9045692a3afcf608d1e9c240b5035835f8f40f1bf914fd06bbf81a9c6d7ffe"
+    }
+  ],
+  "state_writer": {
+    "schema_version": 1,
+    "operation_id": "batch:csw-1089-503",
+    "mode": "batch",
+    "started_at": "2026-08-10T01:25:49.187Z",
+    "finished_at": "2026-08-10T01:26:04.207Z",
+    "wait_ms": 0,
+    "acquire_attempts": 0,
+    "acquired": false,
+    "hold_ms": null,
+    "renewals": 0,
+    "released": null,
+    "git_duration_ms": 15020,
+    "git_processes": 0,
+    "commit_count": 0,
+    "materialized_items": 0,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": 0,
+    "outcome": "failed"
+  }
+}

--- a/docs/proof/csw-1089/artifacts/completion-no-status.json
+++ b/docs/proof/csw-1089/artifacts/completion-no-status.json
@@ -1,0 +1,35 @@
+{
+  "batch_id": "csw-1089-no-status",
+  "lease_owner": "csw-1089-proof-worker",
+  "items": [
+    {
+      "item_key": "openclaw/openclaw#108902@publish:1089020:1",
+      "revision": 1,
+      "claim_generation": 1,
+      "terminal_outcome": "retryable_failure",
+      "reason_code": "state_contention",
+      "error_fingerprint": "b555994e8f38e11216253d5f656dea36615e0c7349bc0bf6a59c74a07f7d7d9e"
+    }
+  ],
+  "state_writer": {
+    "schema_version": 1,
+    "operation_id": "batch:csw-1089-no-status",
+    "mode": "batch",
+    "started_at": "2026-08-10T01:25:18.780Z",
+    "finished_at": "2026-08-10T01:25:33.800Z",
+    "wait_ms": 0,
+    "acquire_attempts": 0,
+    "acquired": false,
+    "hold_ms": null,
+    "renewals": 0,
+    "released": null,
+    "git_duration_ms": 15020,
+    "git_processes": 0,
+    "commit_count": 0,
+    "materialized_items": 0,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": 0,
+    "outcome": "failed"
+  }
+}

--- a/docs/proof/csw-1089/artifacts/completion-unknown-control.json
+++ b/docs/proof/csw-1089/artifacts/completion-unknown-control.json
@@ -1,0 +1,14 @@
+{
+  "batch_id": "csw-1089-unknown-attempt-1",
+  "lease_owner": "csw-1089-proof-worker",
+  "items": [
+    {
+      "item_key": "openclaw/openclaw#108904@publish:1089040:1",
+      "revision": 1,
+      "claim_generation": 1,
+      "terminal_outcome": "retryable_failure",
+      "reason_code": "unknown_failure",
+      "error_fingerprint": "5f9c419830988ab97857f9330f4d7750c560c0af5aabfe4865220f6257aa7fd4"
+    }
+  ]
+}

--- a/docs/proof/csw-1089/artifacts/crabbox-local-container-provenance.json
+++ b/docs/proof/csw-1089/artifacts/crabbox-local-container-provenance.json
@@ -1,0 +1,52 @@
+{
+  "schema": "clawsweeper-crabbox-proof-provenance/v1",
+  "claim": "docs/proof/csw-1089/run-proof.sh passes against the reviewed PR head inside a Docker-backed Crabbox local-container.",
+  "crabbox": {
+    "cli_version": "0.39.0",
+    "provider": "local-container",
+    "lease_id": "cbx_9797931e8d4d",
+    "slug": "coral-prawn",
+    "machine_type": "node_24-bookworm",
+    "image": "node:24-bookworm",
+    "container_engine": "Docker 29.4.0 (OrbStack)",
+    "checkout": "--fresh-pr openclaw/clawsweeper#1089 (clean remote checkout, --no-hydrate)",
+    "workdir": "/work/crabbox/cbx_9797931e8d4d/fresh-pr-openclaw-clawsweeper-1089",
+    "sync_ms": 10174,
+    "command_ms": 55596,
+    "total_ms": 65770,
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "runtime": {
+    "node": "v24.19.0",
+    "pnpm": "11.10.0"
+  },
+  "reviewed_head": "d54d60abf5de708713e0fbedce496cd5a21dd251",
+  "result": {
+    "ok": true,
+    "assertions": 21
+  },
+  "observations": {
+    "state_contention": {
+      "item": "openclaw/openclaw#108901",
+      "state": "pending",
+      "backoff_reason": "publication_retry",
+      "attempts": 1,
+      "dead_letters": []
+    },
+    "unknown_failure_control_attempt_1": {
+      "item": "openclaw/openclaw#108904",
+      "state": "pending",
+      "backoff_reason": "publication_retry",
+      "attempts": 1,
+      "dead_letters": []
+    }
+  },
+  "limits": [
+    "Both observations are at attempt 1, where state_contention and unknown_failure behave identically; the budget divergence (48 attempts / 24h vs 14 attempts / 1h) is not demonstrated at the boundary.",
+    "Driving an authentic attempt 14 requires roughly 51 minutes of real publication backoff, so no dead-lettered result was produced or claimed.",
+    "The retry-budget mapping in dashboard/exact-review-publication-retry.ts is pre-existing code this PR does not modify; what this PR changes is which reason code the batch publisher emits, and that is what the transport chain above exercises end to end.",
+    "The publication endpoint requires HTTPS, so the run generates a disposable self-signed 127.0.0.1 certificate and a disposable local webhook secret. No production credential or endpoint is involved."
+  ]
+}

--- a/docs/proof/csw-1089/artifacts/crabbox-local-container-stdout.log
+++ b/docs/proof/csw-1089/artifacts/crabbox-local-container-stdout.log
@@ -1,0 +1,60 @@
+node=v24.19.0 pnpm=11.10.0
+head=d54d60abf5de708713e0fbedce496cd5a21dd251
+{
+  "ok": true,
+  "assertions": 21,
+  "output_dir": "/work/crabbox/cbx_9797931e8d4d/fresh-pr-openclaw-clawsweeper-1089/docs/proof/csw-1089/artifacts",
+  "state_contention": {
+    "ok": true,
+    "target_repo": "openclaw/openclaw",
+    "item_number": 108901,
+    "items": [
+      {
+        "lane": "publication",
+        "state": "pending",
+        "parked_reason": null,
+        "parked_recovery_attempts": 0,
+        "backoff_reason": "publication_retry",
+        "revision": 1,
+        "attempts": 1,
+        "dispatch_failure_status": null,
+        "dispatch_failure_class": null,
+        "dispatch_failure_at": null,
+        "dispatch_failure_fingerprint": null,
+        "dispatch_failure_detail": null,
+        "created_at": "2026-08-10T02:27:57.174Z",
+        "next_attempt_at": "2026-08-10T02:29:02.030Z",
+        "older_ready_count": 0
+      }
+    ],
+    "dead_letters": [],
+    "position_is_approximate": true
+  },
+  "unknown_failure_attempt_1": {
+    "ok": true,
+    "target_repo": "openclaw/openclaw",
+    "item_number": 108904,
+    "items": [
+      {
+        "lane": "publication",
+        "state": "pending",
+        "parked_reason": null,
+        "parked_recovery_attempts": 0,
+        "backoff_reason": "publication_retry",
+        "revision": 1,
+        "attempts": 1,
+        "dispatch_failure_status": null,
+        "dispatch_failure_class": null,
+        "dispatch_failure_at": null,
+        "dispatch_failure_fingerprint": null,
+        "dispatch_failure_detail": null,
+        "created_at": "2026-08-10T02:27:57.251Z",
+        "next_attempt_at": "2026-08-10T02:29:08.682Z",
+        "older_ready_count": 0
+      }
+    ],
+    "dead_letters": [],
+    "position_is_approximate": true
+  }
+}
+PROOF_EXIT=0

--- a/docs/proof/csw-1089/artifacts/dependencies-install.log
+++ b/docs/proof/csw-1089/artifacts/dependencies-install.log
@@ -1,0 +1,2 @@
+Already up to date
+Done in 209ms using pnpm v11.10.0

--- a/docs/proof/csw-1089/artifacts/proof-summary.json
+++ b/docs/proof/csw-1089/artifacts/proof-summary.json
@@ -1,0 +1,223 @@
+{
+  "proof": "PR 1089 real-boundary batch publication retry proof",
+  "source_sha": "3e44d2cf1bfdb9f38805f8056bfc90903032d55b",
+  "source_tree_sha256": "61b283324bc7b30b74294a311d2cfc63aa41f15f165ae9d9b30bc6b39ca3dcfe",
+  "transport": {
+    "origin": "https://127.0.0.1:8899",
+    "scenarios": {
+      "429": {
+        "publication_requests": 3,
+        "terminal_outcome": "retryable_failure",
+        "reason_code": "state_contention",
+        "completion_artifact": "completion-429.json"
+      },
+      "503": {
+        "publication_requests": 3,
+        "terminal_outcome": "retryable_failure",
+        "reason_code": "state_contention",
+        "completion_artifact": "completion-503.json"
+      },
+      "no-status": {
+        "publication_requests": 3,
+        "terminal_outcome": "retryable_failure",
+        "reason_code": "state_contention",
+        "completion_artifact": "completion-no-status.json"
+      }
+    },
+    "signed_requests": 21,
+    "invalid_signatures": 0
+  },
+  "worker_do": {
+    "origin": "http://127.0.0.1:8799",
+    "state_contention_after": {
+      "ok": true,
+      "target_repo": "openclaw/openclaw",
+      "item_number": 108901,
+      "items": [
+        {
+          "lane": "publication",
+          "state": "pending",
+          "parked_reason": null,
+          "parked_recovery_attempts": 0,
+          "backoff_reason": "publication_retry",
+          "revision": 1,
+          "attempts": 1,
+          "dispatch_failure_status": null,
+          "dispatch_failure_class": null,
+          "dispatch_failure_at": null,
+          "dispatch_failure_fingerprint": null,
+          "dispatch_failure_detail": null,
+          "created_at": "2026-08-10T01:26:04.347Z",
+          "next_attempt_at": "2026-08-10T01:27:09.176Z",
+          "older_ready_count": 0
+        }
+      ],
+      "dead_letters": [],
+      "position_is_approximate": true
+    },
+    "unknown_failure_attempt_1_after": {
+      "ok": true,
+      "target_repo": "openclaw/openclaw",
+      "item_number": 108904,
+      "items": [
+        {
+          "lane": "publication",
+          "state": "pending",
+          "parked_reason": null,
+          "parked_recovery_attempts": 0,
+          "backoff_reason": "publication_retry",
+          "revision": 1,
+          "attempts": 1,
+          "dispatch_failure_status": null,
+          "dispatch_failure_class": null,
+          "dispatch_failure_at": null,
+          "dispatch_failure_fingerprint": null,
+          "dispatch_failure_detail": null,
+          "created_at": "2026-08-10T01:26:04.386Z",
+          "next_attempt_at": "2026-08-10T01:27:15.800Z",
+          "older_ready_count": 0
+        }
+      ],
+      "dead_letters": [],
+      "position_is_approximate": true
+    },
+    "final_dead_letters_open": 0
+  },
+  "assertions": [
+    {
+      "name": "no-status CLI completion is state contention",
+      "publication_requests": 3
+    },
+    {
+      "name": "no-status traverses the built-in three-attempt transport path"
+    },
+    {
+      "name": "429 CLI completion is state contention",
+      "publication_requests": 3
+    },
+    {
+      "name": "429 traverses the built-in three-attempt transport path"
+    },
+    {
+      "name": "503 CLI completion is state contention",
+      "publication_requests": 3
+    },
+    {
+      "name": "503 traverses the built-in three-attempt transport path"
+    },
+    {
+      "name": "real Worker accepts the state-contention publication item"
+    },
+    {
+      "name": "real Worker and DO claim the state-contention publication item",
+      "response": {
+        "status": 200,
+        "body": {
+          "ok": true,
+          "claimed": true,
+          "batch": {
+            "batch_id": "csw-1089-429",
+            "state": "leased",
+            "lease_owner": "csw-1089-proof-worker",
+            "lease_expires_at": "2026-08-10T01:56:04.364Z",
+            "configured_batch_size": 1,
+            "attempt": 1,
+            "created_at": "2026-08-10T01:26:04.364Z",
+            "completed_at": null,
+            "state_commit_sha": null,
+            "failure_fingerprint": null,
+            "items": [
+              {
+                "item_key": "openclaw/openclaw#108901@publish:1089010:1",
+                "revision": 1,
+                "claim_generation": 1,
+                "terminal_outcome": null
+              }
+            ]
+          },
+          "configured_batch_size": 1,
+          "batch_wait_ms": 17,
+          "requested_max_items": 1,
+          "effective_max_items": 1
+        }
+      }
+    },
+    {
+      "name": "claimed tuple matches openclaw/openclaw#108901@publish:1089010:1"
+    },
+    {
+      "name": "queue item status 108901 is available"
+    },
+    {
+      "name": "real Worker and DO accept the captured state-contention tuple"
+    },
+    {
+      "name": "queue item status 108901 is available"
+    },
+    {
+      "name": "state_contention is pending with one scheduled retry and no dead letter",
+      "next_attempt_at": "2026-08-10T01:27:09.176Z"
+    },
+    {
+      "name": "real Worker accepts the unknown-failure control item"
+    },
+    {
+      "name": "real Worker and DO claim the unknown-failure control item",
+      "response": {
+        "status": 200,
+        "body": {
+          "ok": true,
+          "claimed": true,
+          "batch": {
+            "batch_id": "csw-1089-unknown-attempt-1",
+            "state": "leased",
+            "lease_owner": "csw-1089-proof-worker",
+            "lease_expires_at": "2026-08-10T01:56:04.392Z",
+            "configured_batch_size": 1,
+            "attempt": 1,
+            "created_at": "2026-08-10T01:26:04.392Z",
+            "completed_at": null,
+            "state_commit_sha": null,
+            "failure_fingerprint": null,
+            "items": [
+              {
+                "item_key": "openclaw/openclaw#108904@publish:1089040:1",
+                "revision": 1,
+                "claim_generation": 1,
+                "terminal_outcome": null
+              }
+            ]
+          },
+          "configured_batch_size": 1,
+          "batch_wait_ms": 6,
+          "requested_max_items": 1,
+          "effective_max_items": 1
+        }
+      }
+    },
+    {
+      "name": "claimed tuple matches openclaw/openclaw#108904@publish:1089040:1"
+    },
+    {
+      "name": "queue item status 108904 is available"
+    },
+    {
+      "name": "real Worker and DO accept the unknown-failure control tuple"
+    },
+    {
+      "name": "queue item status 108904 is available"
+    },
+    {
+      "name": "unknown_failure is pending with one scheduled retry and no dead letter",
+      "next_attempt_at": "2026-08-10T01:27:15.800Z"
+    },
+    {
+      "name": "real queue status remains available"
+    }
+  ],
+  "limits": {
+    "attempted_old_budget_terminal": false,
+    "reason": "Authentic backoff requires roughly 51 minutes before attempt 14; no clock, retry constant, or Durable Object storage was altered."
+  },
+  "generated_at": "2026-08-10T01:26:04.414Z"
+}

--- a/docs/proof/csw-1089/artifacts/publication-receipt-429.json
+++ b/docs/proof/csw-1089/artifacts/publication-receipt-429.json
@@ -1,0 +1,37 @@
+{
+  "batchId": "csw-1089-429",
+  "stateCommitSha": null,
+  "publishedItemKeys": [],
+  "outcomes": [
+    {
+      "canonicalTargetKey": "openclaw/openclaw#108901",
+      "fenceKey": "openclaw/openclaw#108901@publish:1089010:1",
+      "revision": 1,
+      "claimGeneration": 1,
+      "outcome": "retryable",
+      "reasonCode": "state_contention",
+      "errorFingerprint": "5f9c419830988ab97857f9330f4d7750c560c0af5aabfe4865220f6257aa7fd4"
+    }
+  ],
+  "stateWriter": {
+    "schema_version": 1,
+    "operation_id": "batch:csw-1089-429",
+    "mode": "batch",
+    "started_at": "2026-08-10T01:25:33.983Z",
+    "finished_at": "2026-08-10T01:25:49.005Z",
+    "wait_ms": 0,
+    "acquire_attempts": 0,
+    "acquired": false,
+    "hold_ms": null,
+    "renewals": 0,
+    "released": null,
+    "git_duration_ms": 15022,
+    "git_processes": 0,
+    "commit_count": 0,
+    "materialized_items": 0,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": 0,
+    "outcome": "failed"
+  }
+}

--- a/docs/proof/csw-1089/artifacts/publication-receipt-503.json
+++ b/docs/proof/csw-1089/artifacts/publication-receipt-503.json
@@ -1,0 +1,37 @@
+{
+  "batchId": "csw-1089-503",
+  "stateCommitSha": null,
+  "publishedItemKeys": [],
+  "outcomes": [
+    {
+      "canonicalTargetKey": "openclaw/openclaw#108903",
+      "fenceKey": "openclaw/openclaw#108903@publish:1089030:1",
+      "revision": 1,
+      "claimGeneration": 1,
+      "outcome": "retryable",
+      "reasonCode": "state_contention",
+      "errorFingerprint": "ce9045692a3afcf608d1e9c240b5035835f8f40f1bf914fd06bbf81a9c6d7ffe"
+    }
+  ],
+  "stateWriter": {
+    "schema_version": 1,
+    "operation_id": "batch:csw-1089-503",
+    "mode": "batch",
+    "started_at": "2026-08-10T01:25:49.187Z",
+    "finished_at": "2026-08-10T01:26:04.207Z",
+    "wait_ms": 0,
+    "acquire_attempts": 0,
+    "acquired": false,
+    "hold_ms": null,
+    "renewals": 0,
+    "released": null,
+    "git_duration_ms": 15020,
+    "git_processes": 0,
+    "commit_count": 0,
+    "materialized_items": 0,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": 0,
+    "outcome": "failed"
+  }
+}

--- a/docs/proof/csw-1089/artifacts/publication-receipt-no-status.json
+++ b/docs/proof/csw-1089/artifacts/publication-receipt-no-status.json
@@ -1,0 +1,37 @@
+{
+  "batchId": "csw-1089-no-status",
+  "stateCommitSha": null,
+  "publishedItemKeys": [],
+  "outcomes": [
+    {
+      "canonicalTargetKey": "openclaw/openclaw#108902",
+      "fenceKey": "openclaw/openclaw#108902@publish:1089020:1",
+      "revision": 1,
+      "claimGeneration": 1,
+      "outcome": "retryable",
+      "reasonCode": "state_contention",
+      "errorFingerprint": "b555994e8f38e11216253d5f656dea36615e0c7349bc0bf6a59c74a07f7d7d9e"
+    }
+  ],
+  "stateWriter": {
+    "schema_version": 1,
+    "operation_id": "batch:csw-1089-no-status",
+    "mode": "batch",
+    "started_at": "2026-08-10T01:25:18.780Z",
+    "finished_at": "2026-08-10T01:25:33.800Z",
+    "wait_ms": 0,
+    "acquire_attempts": 0,
+    "acquired": false,
+    "hold_ms": null,
+    "renewals": 0,
+    "released": null,
+    "git_duration_ms": 15020,
+    "git_processes": 0,
+    "commit_count": 0,
+    "materialized_items": 0,
+    "configured_batch_size": 1,
+    "actual_batch_size": 1,
+    "batch_wait_ms": 0,
+    "outcome": "failed"
+  }
+}

--- a/docs/proof/csw-1089/artifacts/queue-state-state-contention-after.json
+++ b/docs/proof/csw-1089/artifacts/queue-state-state-contention-after.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "target_repo": "openclaw/openclaw",
+  "item_number": 108901,
+  "items": [
+    {
+      "lane": "publication",
+      "state": "pending",
+      "parked_reason": null,
+      "parked_recovery_attempts": 0,
+      "backoff_reason": "publication_retry",
+      "revision": 1,
+      "attempts": 1,
+      "dispatch_failure_status": null,
+      "dispatch_failure_class": null,
+      "dispatch_failure_at": null,
+      "dispatch_failure_fingerprint": null,
+      "dispatch_failure_detail": null,
+      "created_at": "2026-08-10T01:26:04.347Z",
+      "next_attempt_at": "2026-08-10T01:27:09.176Z",
+      "older_ready_count": 0
+    }
+  ],
+  "dead_letters": [],
+  "position_is_approximate": true
+}

--- a/docs/proof/csw-1089/artifacts/queue-state-state-contention-before.json
+++ b/docs/proof/csw-1089/artifacts/queue-state-state-contention-before.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "target_repo": "openclaw/openclaw",
+  "item_number": 108901,
+  "items": [
+    {
+      "lane": "publication",
+      "state": "pending",
+      "parked_reason": null,
+      "parked_recovery_attempts": 0,
+      "backoff_reason": null,
+      "revision": 1,
+      "attempts": 0,
+      "dispatch_failure_status": null,
+      "dispatch_failure_class": null,
+      "dispatch_failure_at": null,
+      "dispatch_failure_fingerprint": null,
+      "dispatch_failure_detail": null,
+      "created_at": "2026-08-10T01:26:04.347Z",
+      "next_attempt_at": "2026-08-10T01:26:04.347Z",
+      "older_ready_count": 0
+    }
+  ],
+  "dead_letters": [],
+  "position_is_approximate": true
+}

--- a/docs/proof/csw-1089/artifacts/queue-state-unknown-after-attempt-1.json
+++ b/docs/proof/csw-1089/artifacts/queue-state-unknown-after-attempt-1.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "target_repo": "openclaw/openclaw",
+  "item_number": 108904,
+  "items": [
+    {
+      "lane": "publication",
+      "state": "pending",
+      "parked_reason": null,
+      "parked_recovery_attempts": 0,
+      "backoff_reason": "publication_retry",
+      "revision": 1,
+      "attempts": 1,
+      "dispatch_failure_status": null,
+      "dispatch_failure_class": null,
+      "dispatch_failure_at": null,
+      "dispatch_failure_fingerprint": null,
+      "dispatch_failure_detail": null,
+      "created_at": "2026-08-10T01:26:04.386Z",
+      "next_attempt_at": "2026-08-10T01:27:15.800Z",
+      "older_ready_count": 0
+    }
+  ],
+  "dead_letters": [],
+  "position_is_approximate": true
+}

--- a/docs/proof/csw-1089/artifacts/queue-state-unknown-before.json
+++ b/docs/proof/csw-1089/artifacts/queue-state-unknown-before.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "target_repo": "openclaw/openclaw",
+  "item_number": 108904,
+  "items": [
+    {
+      "lane": "publication",
+      "state": "pending",
+      "parked_reason": null,
+      "parked_recovery_attempts": 0,
+      "backoff_reason": null,
+      "revision": 1,
+      "attempts": 0,
+      "dispatch_failure_status": null,
+      "dispatch_failure_class": null,
+      "dispatch_failure_at": null,
+      "dispatch_failure_fingerprint": null,
+      "dispatch_failure_detail": null,
+      "created_at": "2026-08-10T01:26:04.386Z",
+      "next_attempt_at": "2026-08-10T01:26:04.386Z",
+      "older_ready_count": 0
+    }
+  ],
+  "dead_letters": [],
+  "position_is_approximate": true
+}

--- a/docs/proof/csw-1089/artifacts/queue-stats-final.json
+++ b/docs/proof/csw-1089/artifacts/queue-stats-final.json
@@ -1,0 +1,572 @@
+{
+  "generated_at": "2026-08-10T01:26:04.408Z",
+  "pending": 0,
+  "ready_pending": 0,
+  "admissible_pending": 0,
+  "shed_since_reset": 0,
+  "dispatching": 0,
+  "leased": 0,
+  "oldest_pending_at": null,
+  "oldest_pending_age_seconds": null,
+  "oldest_pending_key": null,
+  "oldest_dispatching_at": null,
+  "oldest_dispatching_age_seconds": null,
+  "oldest_leased_at": null,
+  "oldest_leased_age_seconds": null,
+  "handoff_health": {
+    "status": "idle",
+    "reason": "queue_empty",
+    "message": "No exact-review work is queued or active.",
+    "observed_at": "2026-08-10T01:26:04.408Z",
+    "warning_after_seconds": 120,
+    "stalled_after_seconds": 240,
+    "capacity": 128,
+    "active": 0,
+    "available_slots": 128,
+    "pending_depth": 0,
+    "shed_since_reset": 0,
+    "phases": {
+      "pending": {
+        "count": 0,
+        "oldest_at": null,
+        "oldest_age_seconds": null,
+        "oldest_key": null
+      },
+      "dispatching": {
+        "count": 0,
+        "oldest_at": null,
+        "oldest_age_seconds": null,
+        "oldest_key": null
+      },
+      "leased": {
+        "count": 0,
+        "oldest_at": null,
+        "oldest_age_seconds": null,
+        "oldest_key": null
+      }
+    }
+  },
+  "lanes": {
+    "review": {
+      "pending": 0,
+      "pending_depth": 0,
+      "shed_since_reset": 0,
+      "ready": 0,
+      "backoff": 0,
+      "backoff_reasons": {},
+      "dispatching": 0,
+      "leased": 0,
+      "parked": 0,
+      "parked_reasons": {},
+      "capacity": 128,
+      "active": 0,
+      "available_slots": 128,
+      "oldest_pending_at": null,
+      "oldest_pending_age_seconds": null,
+      "oldest_pending_key": null,
+      "oldest_ready_at": null,
+      "oldest_ready_age_seconds": null,
+      "oldest_backoff_at": null,
+      "oldest_backoff_age_seconds": null,
+      "next_attempt_at": null,
+      "enqueued_total": 0,
+      "completed_total": 0,
+      "superseded_total": 0,
+      "semantic_deduped_total": 0,
+      "shed_reasons_since_reset": {
+        "backpressure": 0,
+        "scheduled_rate": 0,
+        "unattributed": 0
+      },
+      "flow": {
+        "last_15_minutes": {
+          "window_minutes": 15,
+          "arrival": 0,
+          "successful": 0,
+          "retried": 0,
+          "shed": 0,
+          "shed_reasons": {
+            "backpressure": 0,
+            "scheduled_rate": 0
+          },
+          "arrival_rate_per_hour": 0,
+          "successful_rate_per_hour": 0,
+          "retried_rate_per_hour": 0,
+          "shed_rate_per_hour": 0,
+          "retry_amplification": null
+        }
+      }
+    },
+    "publication": {
+      "pending": 2,
+      "pending_depth": 2,
+      "shed_since_reset": 0,
+      "ready": 0,
+      "backoff": 2,
+      "backoff_reasons": {
+        "publication_retry": 2
+      },
+      "dispatching": 0,
+      "leased": 0,
+      "parked": 0,
+      "parked_reasons": {},
+      "capacity": 50,
+      "active": 0,
+      "available_slots": 50,
+      "oldest_pending_at": "2026-08-10T01:26:04.347Z",
+      "oldest_pending_age_seconds": 0,
+      "oldest_pending_key": "openclaw/openclaw#108901@publish:1089010:1",
+      "oldest_ready_at": null,
+      "oldest_ready_age_seconds": null,
+      "oldest_backoff_at": "2026-08-10T01:26:04.347Z",
+      "oldest_backoff_age_seconds": 0,
+      "next_attempt_at": "2026-08-10T01:27:09.176Z",
+      "enqueued_total": 2,
+      "completed_total": 0,
+      "published_total": 0,
+      "superseded_total": 0,
+      "semantic_deduped_total": 0,
+      "retried_total": 2,
+      "dead_lettered_total": 0,
+      "refreshed_total": 0,
+      "flow": {
+        "last_15_minutes": {
+          "window_minutes": 15,
+          "enqueued": 2,
+          "resolved": 0,
+          "published": 0,
+          "superseded": 0,
+          "semantic_deduped": 0,
+          "retried": 2,
+          "dead_lettered": 0,
+          "arrival_rate_per_hour": 8,
+          "resolved_rate_per_hour": 0,
+          "published_rate_per_hour": 0,
+          "superseded_rate_per_hour": 0,
+          "semantic_deduped_rate_per_hour": 0,
+          "retried_rate_per_hour": 8,
+          "dead_lettered_rate_per_hour": 0,
+          "net_drain_rate_per_hour": -8,
+          "retry_amplification": null
+        },
+        "last_60_minutes": {
+          "window_minutes": 60,
+          "enqueued": 2,
+          "resolved": 0,
+          "published": 0,
+          "superseded": 0,
+          "semantic_deduped": 0,
+          "retried": 2,
+          "dead_lettered": 0,
+          "arrival_rate_per_hour": 2,
+          "resolved_rate_per_hour": 0,
+          "published_rate_per_hour": 0,
+          "superseded_rate_per_hour": 0,
+          "semantic_deduped_rate_per_hour": 0,
+          "retried_rate_per_hour": 2,
+          "dead_lettered_rate_per_hour": 0,
+          "net_drain_rate_per_hour": -2,
+          "retry_amplification": null
+        }
+      },
+      "dead_letters": {
+        "open": 0,
+        "limit": 5000,
+        "oldest_failed_at": null,
+        "reasons": {}
+      },
+      "health": {
+        "status": "healthy",
+        "reason": null
+      },
+      "capacity_control": {
+        "mode": "adaptive",
+        "minimum": 50,
+        "base": 50,
+        "maximum": 50,
+        "ceiling": 50,
+        "demand_capacity": 50,
+        "demand_samples": 1,
+        "demand_tier": 0,
+        "last_scale_at": null,
+        "cooldown_until": null,
+        "recovery_successes": 0,
+        "last_failure_at": null,
+        "last_failure_kind": null
+      },
+      "batches": {
+        "enabled": true,
+        "max_items": 8,
+        "max_concurrent": 8,
+        "max_wait_seconds": 60,
+        "fresh_lane": {
+          "enabled": true,
+          "reserved_items": 2,
+          "max_age_seconds": 900,
+          "ready_items": 0,
+          "historical_ready_items": 0
+        },
+        "last_dispatch_at": null,
+        "last_dispatch_succeeded": null,
+        "dispatch_pending_until": null,
+        "leased": 0,
+        "completed": 2,
+        "expired": 0,
+        "active_items": 0,
+        "oldest_active_at": null,
+        "oldest_active_age_seconds": null,
+        "reclaimed_items_retained": 2,
+        "cleanup": {
+          "deleted_this_pass": 0,
+          "eligible_remaining": 0,
+          "limit": 100
+        }
+      },
+      "direct": {
+        "enabled": true,
+        "health": {
+          "status": "healthy",
+          "store": "durable_object_sqlite"
+        },
+        "pending": 0,
+        "retryable": 0,
+        "failed": 0,
+        "retained_receipts": 0,
+        "oldest_pending_at": null
+      }
+    }
+  },
+  "pressure": {
+    "status": "idle",
+    "reason": "no_ready_backlog",
+    "capacity": 128,
+    "active": 0,
+    "pending": 0,
+    "ready_pending": 0,
+    "admissible_pending": 0
+  },
+  "bay_projection": {
+    "sample_limit": 24,
+    "total": 2,
+    "stages": {
+      "arriving": 0,
+      "setting-up": 0,
+      "reviewing": 0,
+      "publishing": 2,
+      "applying": 0,
+      "repairing": 0
+    },
+    "items": [
+      {
+        "item_key": "openclaw/openclaw#108901",
+        "repository": "openclaw/openclaw",
+        "item_number": 108901,
+        "stage": "publishing",
+        "queue_state": "pending",
+        "created_at": "2026-08-10T01:26:04.347Z",
+        "updated_at": "2026-08-10T01:26:04.376Z",
+        "next_attempt_at": "2026-08-10T01:27:09.176Z"
+      },
+      {
+        "item_key": "openclaw/openclaw#108904",
+        "repository": "openclaw/openclaw",
+        "item_number": 108904,
+        "stage": "publishing",
+        "queue_state": "pending",
+        "created_at": "2026-08-10T01:26:04.386Z",
+        "updated_at": "2026-08-10T01:26:04.400Z",
+        "next_attempt_at": "2026-08-10T01:27:15.800Z"
+      }
+    ]
+  },
+  "next_wake_at": null,
+  "dispatcher": {
+    "state": "unknown",
+    "reason": null,
+    "workflow_state": null,
+    "checked_at": null,
+    "retry_at": null,
+    "dispatch_failure_status": null,
+    "dispatch_failure_class": null,
+    "dispatch_failure_at": null,
+    "dispatch_failure_fingerprint": null,
+    "dispatch_failure_detail": null,
+    "dispatch_consecutive_failures": 0
+  },
+  "target_stats": [
+    {
+      "target_repo": "openclaw/openclaw",
+      "pending": 2,
+      "dispatching": 0,
+      "leased": 0,
+      "oldest_pending_at": "2026-08-10T01:26:04.347Z"
+    }
+  ],
+  "delivery_receipts": 2,
+  "scheduled_feed": {
+    "target_rate_per_hour": 300,
+    "burst": 30,
+    "token_balance": 30,
+    "lanes": {
+      "hot_intake": {
+        "target_rate_per_hour": 105,
+        "burst": 10,
+        "token_balance": 10
+      },
+      "normal_backfill": {
+        "target_rate_per_hour": 195,
+        "burst": 20,
+        "token_balance": 20
+      }
+    }
+  },
+  "review_telemetry_health": {
+    "status": "healthy",
+    "refreshing": 0,
+    "slow_refreshing": 0,
+    "orphan_refreshing": 0,
+    "degraded_after_seconds": 1800,
+    "orphan_after_seconds": 9000,
+    "orphans": []
+  },
+  "reservation_claim_observability": {
+    "schema_version": 1,
+    "generated_at": "2026-08-10T01:26:04.408Z",
+    "publication_paths": {
+      "cloudflare_canonical_direct": {
+        "enabled": true,
+        "reservation_to_claim": "not_applicable",
+        "state_writer_timing": "not_applicable"
+      },
+      "legacy_state_repo_batch": {
+        "enabled": true,
+        "reservation_to_claim": "tracked",
+        "state_writer_timing": "tracked"
+      }
+    },
+    "queue_slots": {
+      "pending": 2,
+      "unassigned_pending": 2,
+      "active_items": 0,
+      "active_batches": 0,
+      "max_concurrent_batches": 8,
+      "available_batches": 8
+    },
+    "delay_buckets": {
+      "metric": "reservation_to_claim_ms",
+      "buckets": [
+        {
+          "id": "under_1m",
+          "count": 0
+        },
+        {
+          "id": "1m_to_5m",
+          "count": 0
+        },
+        {
+          "id": "5m_to_10m",
+          "count": 0
+        },
+        {
+          "id": "over_10m",
+          "count": 0
+        }
+      ]
+    },
+    "alerts": [],
+    "batches": [
+      {
+        "batch_id": "csw-1089-unknown-attempt-1",
+        "publication_path": "legacy_state_repo_batch",
+        "state": "completed",
+        "configured_batch_size": 1,
+        "claimed_at": "2026-08-10T01:26:04.392Z",
+        "batch_age_seconds": 0,
+        "dispatch": {
+          "id": null,
+          "at": null
+        },
+        "workflow": {
+          "run_id": null,
+          "run_attempt": null,
+          "runner_started_at": null
+        },
+        "timeline": {
+          "preparation_started_at": null,
+          "preparation_finished_at": null,
+          "state_writer_wait_at": null,
+          "state_writer_committed_at": null,
+          "final_github_apply_at": null,
+          "github_throttle_at": null
+        },
+        "items": [
+          {
+            "item_key": "openclaw/openclaw#108904@publish:1089040:1",
+            "revision": 1,
+            "claim_generation": 1,
+            "producer_run_id": "1089040",
+            "producer_run_attempt": 1,
+            "enqueued_at": "2026-08-10T01:26:04.386Z",
+            "reservation_to_claim_ms": null,
+            "enqueue_to_claim_ms": 6,
+            "terminal_outcome": "lease_expired"
+          }
+        ]
+      },
+      {
+        "batch_id": "csw-1089-429",
+        "publication_path": "legacy_state_repo_batch",
+        "state": "completed",
+        "configured_batch_size": 1,
+        "claimed_at": "2026-08-10T01:26:04.364Z",
+        "batch_age_seconds": 0,
+        "dispatch": {
+          "id": null,
+          "at": null
+        },
+        "workflow": {
+          "run_id": null,
+          "run_attempt": null,
+          "runner_started_at": null
+        },
+        "timeline": {
+          "preparation_started_at": null,
+          "preparation_finished_at": null,
+          "state_writer_wait_at": null,
+          "state_writer_committed_at": null,
+          "final_github_apply_at": null,
+          "github_throttle_at": null
+        },
+        "items": [
+          {
+            "item_key": "openclaw/openclaw#108901@publish:1089010:1",
+            "revision": 1,
+            "claim_generation": 1,
+            "producer_run_id": "1089010",
+            "producer_run_attempt": 1,
+            "enqueued_at": "2026-08-10T01:26:04.347Z",
+            "reservation_to_claim_ms": null,
+            "enqueue_to_claim_ms": 17,
+            "terminal_outcome": "lease_expired"
+          }
+        ]
+      }
+    ]
+  },
+  "state_writer": {
+    "schema_version": 1,
+    "collection": {
+      "status": "fresh",
+      "last_observed_at": "2026-08-10T01:26:04.376Z",
+      "rejected_total": 0,
+      "conflicted_total": 0
+    },
+    "mode": "batch",
+    "live": {
+      "tracked_holding": 0,
+      "tracked_waiting": 0,
+      "tracked_releasing": 0,
+      "freshness_seconds": null
+    },
+    "last_15_minutes": {
+      "operations": 1,
+      "acquired": 0,
+      "contention_timeouts": 0,
+      "state_commits": 0,
+      "materialized_items": 0,
+      "items_per_commit": null,
+      "wait_ms": {
+        "p50": 0,
+        "p95": 0,
+        "samples": 1
+      },
+      "hold_ms": {
+        "p50": null,
+        "p95": null,
+        "samples": 0
+      },
+      "git_duration_ms": {
+        "p50": 15022,
+        "p95": 15022,
+        "samples": 1
+      },
+      "actual_batch_size": {
+        "average": 1,
+        "p50": 1,
+        "p95": 1,
+        "samples": 1
+      },
+      "batch_wait_ms": {
+        "p50": 0,
+        "p95": 0,
+        "samples": 1
+      },
+      "batch_fullness": 1
+    },
+    "last_60_minutes": {
+      "operations": 1,
+      "acquired": 0,
+      "contention_timeouts": 0,
+      "state_commits": 0,
+      "materialized_items": 0,
+      "items_per_commit": null,
+      "wait_ms": {
+        "p50": 0,
+        "p95": 0,
+        "samples": 1
+      },
+      "hold_ms": {
+        "p50": null,
+        "p95": null,
+        "samples": 0
+      },
+      "git_duration_ms": {
+        "p50": 15022,
+        "p95": 15022,
+        "samples": 1
+      },
+      "actual_batch_size": {
+        "average": 1,
+        "p50": 1,
+        "p95": 1,
+        "samples": 1
+      },
+      "batch_wait_ms": {
+        "p50": 0,
+        "p95": 0,
+        "samples": 1
+      },
+      "batch_fullness": 1
+    },
+    "last_successful_materialization_at": null,
+    "diagnostics": {
+      "accepted_terminal_total": 1,
+      "duplicate_terminal_total": 0,
+      "rejected_terminal_total": 0,
+      "conflicted_terminal_total": 0,
+      "accepted_progress_total": 0,
+      "rejected_progress_total": 0,
+      "state_commits_total": 0,
+      "materialized_items_total": 0,
+      "contention_timeouts_total": 0
+    },
+    "coordinator": {
+      "queued": 0,
+      "leased": 0,
+      "queued_batch": 0,
+      "queued_intake": 0,
+      "queued_ordinary": 0,
+      "admitted": 0,
+      "completed": 0,
+      "expired": 0,
+      "recovered": 0,
+      "last_wait_ms": 0,
+      "max_wait_ms": 0,
+      "consecutive_batch_turns": 0,
+      "consecutive_intake_turns": 0,
+      "active": null
+    }
+  },
+  "storage_schema_version": 1,
+  "legacy_rollback_available": true
+}

--- a/docs/proof/csw-1089/artifacts/runtime-transcript.md
+++ b/docs/proof/csw-1089/artifacts/runtime-transcript.md
@@ -1,0 +1,74 @@
+# PR 1089 real-boundary runtime transcript
+
+- Source commit: `3e44d2cf1bfdb9f38805f8056bfc90903032d55b`
+- Source-tree SHA-256: `61b283324bc7b30b74294a311d2cfc63aa41f15f165ae9d9b30bc6b39ca3dcfe`
+- CLI transport: built `exact-review-batch-cli` over a self-signed TLS listener bound only to `127.0.0.1:8899`.
+- CLI observations: reset, HTTP 429, and HTTP 503 each produced `retryable_failure` / `state_contention` after 3 actual publication requests per scenario.
+- Worker/DO: pinned Wrangler Worker on `http://127.0.0.1:8799`, disposable local persistence, signed enqueue/claim/complete requests, and public status reads.
+- Secrets: one disposable local proof secret; request traces retain only `signature_valid`, never a signature or secret value.
+
+## State contention after one real completion
+
+```json
+{
+  "ok": true,
+  "target_repo": "openclaw/openclaw",
+  "item_number": 108901,
+  "items": [
+    {
+      "lane": "publication",
+      "state": "pending",
+      "parked_reason": null,
+      "parked_recovery_attempts": 0,
+      "backoff_reason": "publication_retry",
+      "revision": 1,
+      "attempts": 1,
+      "dispatch_failure_status": null,
+      "dispatch_failure_class": null,
+      "dispatch_failure_at": null,
+      "dispatch_failure_fingerprint": null,
+      "dispatch_failure_detail": null,
+      "created_at": "2026-08-10T01:26:04.347Z",
+      "next_attempt_at": "2026-08-10T01:27:09.176Z",
+      "older_ready_count": 0
+    }
+  ],
+  "dead_letters": [],
+  "position_is_approximate": true
+}
+```
+
+## Unknown failure after one real completion
+
+```json
+{
+  "ok": true,
+  "target_repo": "openclaw/openclaw",
+  "item_number": 108904,
+  "items": [
+    {
+      "lane": "publication",
+      "state": "pending",
+      "parked_reason": null,
+      "parked_recovery_attempts": 0,
+      "backoff_reason": "publication_retry",
+      "revision": 1,
+      "attempts": 1,
+      "dispatch_failure_status": null,
+      "dispatch_failure_class": null,
+      "dispatch_failure_at": null,
+      "dispatch_failure_fingerprint": null,
+      "dispatch_failure_detail": null,
+      "created_at": "2026-08-10T01:26:04.386Z",
+      "next_attempt_at": "2026-08-10T01:27:15.800Z",
+      "older_ready_count": 0
+    }
+  ],
+  "dead_letters": [],
+  "position_is_approximate": true
+}
+```
+
+## Limit
+
+The real unknown-failure item is pending after attempt 1, as expected. Reaching attempt 14 requires roughly 51 minutes of authentic backoff. This run did not fake time, edit Durable Object state, or change retry constants, so it does not claim the final `retry_exhausted` dead letter or the same-attempt terminal contrast.

--- a/docs/proof/csw-1089/artifacts/transport-requests.json
+++ b/docs/proof/csw-1089/artifacts/transport-requests.json
@@ -1,0 +1,191 @@
+[
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/fetch",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "connection_reset": true
+  },
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "connection_reset": true
+  },
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "connection_reset": true
+  },
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/heartbeat",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/fetch",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "no-status",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/complete",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/fetch",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 429
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 429
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 429
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/heartbeat",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/fetch",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "429",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/complete",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/fetch",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 503
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 503
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batch-results",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 503
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/heartbeat",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/fetch",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  },
+  {
+    "scenario": "503",
+    "method": "POST",
+    "pathname": "/internal/exact-review/publication-batches/complete",
+    "signature_valid": true,
+    "local_address": "127.0.0.1",
+    "remote_address": "127.0.0.1",
+    "response_status": 200
+  }
+]

--- a/docs/proof/csw-1089/artifacts/worker-responses.json
+++ b/docs/proof/csw-1089/artifacts/worker-responses.json
@@ -1,0 +1,144 @@
+[
+  {
+    "operation": "state_contention_enqueue",
+    "status": 202,
+    "body": {
+      "ok": true,
+      "queued": true,
+      "item_key": "openclaw/openclaw#108901@publish:1089010:1",
+      "superseded_publications": 0
+    }
+  },
+  {
+    "operation": "state_contention_claim",
+    "status": 200,
+    "body": {
+      "ok": true,
+      "claimed": true,
+      "batch": {
+        "batch_id": "csw-1089-429",
+        "state": "leased",
+        "lease_owner": "csw-1089-proof-worker",
+        "lease_expires_at": "2026-08-10T01:56:04.364Z",
+        "configured_batch_size": 1,
+        "attempt": 1,
+        "created_at": "2026-08-10T01:26:04.364Z",
+        "completed_at": null,
+        "state_commit_sha": null,
+        "failure_fingerprint": null,
+        "items": [
+          {
+            "item_key": "openclaw/openclaw#108901@publish:1089010:1",
+            "revision": 1,
+            "claim_generation": 1,
+            "terminal_outcome": null
+          }
+        ]
+      },
+      "configured_batch_size": 1,
+      "batch_wait_ms": 17,
+      "requested_max_items": 1,
+      "effective_max_items": 1
+    }
+  },
+  {
+    "operation": "state_contention_complete",
+    "status": 200,
+    "body": {
+      "ok": true,
+      "accepted": 1,
+      "skipped": 0,
+      "batch": {
+        "batch_id": "csw-1089-429",
+        "state": "completed",
+        "lease_owner": "csw-1089-proof-worker",
+        "lease_expires_at": "2026-08-10T01:56:04.364Z",
+        "configured_batch_size": 1,
+        "attempt": 1,
+        "created_at": "2026-08-10T01:26:04.364Z",
+        "completed_at": "2026-08-10T01:26:04.376Z",
+        "state_commit_sha": null,
+        "failure_fingerprint": null,
+        "items": [
+          {
+            "item_key": "openclaw/openclaw#108901@publish:1089010:1",
+            "revision": 1,
+            "claim_generation": 1,
+            "terminal_outcome": "lease_expired"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "operation": "unknown_enqueue",
+    "status": 202,
+    "body": {
+      "ok": true,
+      "queued": true,
+      "item_key": "openclaw/openclaw#108904@publish:1089040:1",
+      "superseded_publications": 0
+    }
+  },
+  {
+    "operation": "unknown_claim",
+    "status": 200,
+    "body": {
+      "ok": true,
+      "claimed": true,
+      "batch": {
+        "batch_id": "csw-1089-unknown-attempt-1",
+        "state": "leased",
+        "lease_owner": "csw-1089-proof-worker",
+        "lease_expires_at": "2026-08-10T01:56:04.392Z",
+        "configured_batch_size": 1,
+        "attempt": 1,
+        "created_at": "2026-08-10T01:26:04.392Z",
+        "completed_at": null,
+        "state_commit_sha": null,
+        "failure_fingerprint": null,
+        "items": [
+          {
+            "item_key": "openclaw/openclaw#108904@publish:1089040:1",
+            "revision": 1,
+            "claim_generation": 1,
+            "terminal_outcome": null
+          }
+        ]
+      },
+      "configured_batch_size": 1,
+      "batch_wait_ms": 6,
+      "requested_max_items": 1,
+      "effective_max_items": 1
+    }
+  },
+  {
+    "operation": "unknown_complete",
+    "status": 200,
+    "body": {
+      "ok": true,
+      "accepted": 1,
+      "skipped": 0,
+      "batch": {
+        "batch_id": "csw-1089-unknown-attempt-1",
+        "state": "completed",
+        "lease_owner": "csw-1089-proof-worker",
+        "lease_expires_at": "2026-08-10T01:56:04.392Z",
+        "configured_batch_size": 1,
+        "attempt": 1,
+        "created_at": "2026-08-10T01:26:04.392Z",
+        "completed_at": "2026-08-10T01:26:04.400Z",
+        "state_commit_sha": null,
+        "failure_fingerprint": null,
+        "items": [
+          {
+            "item_key": "openclaw/openclaw#108904@publish:1089040:1",
+            "revision": 1,
+            "claim_generation": 1,
+            "terminal_outcome": "lease_expired"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/docs/proof/csw-1089/artifacts/wrangler.log
+++ b/docs/proof/csw-1089/artifacts/wrangler.log
@@ -1,0 +1,78 @@
+
+ ⛅️ wrangler 4.107.0 (update available 4.120.0)
+───────────────────────────────────────────────
+Your Worker has access to the following bindings:
+Binding                                                                                                      Resource                  Mode
+env.STATUS_STORE (StatusStore)                                                                               Durable Object            local
+env.EXACT_REVIEW_QUEUE (ExactReviewQueue)                                                                    Durable Object            local
+env.STATE_SNAPSHOTS (clawsweeper-state-snapshots)                                                            R2 Bucket                 local
+env.CLAWSWEEPER_REPO ("openclaw/clawsweeper")                                                                Environment Variable      local
+env.CLAWSWEEPER_APP_CLIENT_ID ("Iv23liOECG0slfuhz093")                                                       Environment Variable      local
+env.CLAWSWEEPER_CRABFLEET_URL ("https://crabfleet.openclaw.ai")                                              Environment Variable      local
+env.TARGET_REPOS ("openclaw/openclaw,openclaw/clawhub,op...")                                                Environment Variable      local
+env.APPLY_TARGET_REPOS ("openclaw/openclaw")                                                                 Environment Variable      local
+env.APPLY_OPTIONAL_TARGET_REPOS ("openclaw/clawhub")                                                         Environment Variable      local
+env.CLAWSWEEPER_ENABLE_CLAWHUB ("1")                                                                         Environment Variable      local
+env.WORKER_BUDGET ("128")                                                                                    Environment Variable      local
+env.EXACT_REVIEW_ACTIONS_BUDGET ("194")                                                                      Environment Variable      local
+env.WORKER_DETAIL_RUN_LIMIT ("128")                                                                          Environment Variable      local
+env.WORKER_JOB_FETCH_CONCURRENCY ("12")                                                                      Environment Variable      local
+env.WORKER_JOB_CACHE_TTL_SECONDS ("60")                                                                      Environment Variable      local
+env.WORKER_HEALTH_CACHE_TTL_SECONDS ("120")                                                                  Environment Variable      local
+env.WORKER_HEALTH_FETCH_CONCURRENCY ("10")                                                                   Environment Variable      local
+env.AUTOMERGE_CACHE_TTL_SECONDS ("300")                                                                      Environment Variable      local
+env.RECENT_CLOSED_CACHE_TTL_SECONDS ("300")                                                                  Environment Variable      local
+env.CACHE_TTL_SECONDS ("20")                                                                                 Environment Variable      local
+env.INCLUDE_CI_STATUS ("1")                                                                                  Environment Variable      local
+env.EXACT_REVIEW_QUEUE_MAX_CONCURRENT ("128")                                                                Environment Variable      local
+env.EXACT_REVIEW_TARGET_MAX_CONCURRENT ("120")                                                               Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT ("50")                                                           Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT ("50")                                                          Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT ("50")                                                           Environment Variable      local
+env.EXACT_REVIEW_DISPATCH_LEASE_MS ("360000")                                                                Environment Variable      local
+env.EXACT_REVIEW_EXECUTION_LEASE_MS ("7800000")                                                              Environment Variable      local
+env.EXACT_REVIEW_HEARTBEAT_GRACE_MS ("1200000")                                                              Environment Variable      local
+env.EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS ("60000")                                                          Environment Variable      local
+env.EXACT_REVIEW_DISPATCH_DEBOUNCE_MS ("90000")                                                              Environment Variable      local
+env.EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS ("180000")                                                         Environment Variable      local
+env.EXACT_REVIEW_PENDING_SOFT_LIMIT ("600")                                                                  Environment Variable      local
+env.EXACT_REVIEW_TARGET_RATE_PER_HOUR ("300")                                                                Environment Variable      local
+env.EXACT_REVIEW_TARGET_BURST ("30")                                                                         Environment Variable      local
+env.STATE_APPEND_DRAIN_LEASE_MS ("5400000")                                                                  Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED ("1")                                                          Environment Variable      local
+env.EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED ("1")                                                            Environment Variable      local
+env.EXACT_REVIEW_STATE_REPO ("openclaw/clawsweeper-state")                                                   Environment Variable      local
+env.EXACT_REVIEW_STATE_REF ("state")                                                                         Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_SIZE ("8")                                                                Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT ("8")                                                      Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED ("1")                                                        Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS ("2")                                                      Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS ("900000")                                                Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS ("60000")                                                         Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS ("5000")                                             Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS ("600000")                                        Environment Variable      local
+env.REVIEW_OBSERVABILITY_REQUIRED ("0")                                                                      Environment Variable      local
+env.REVIEW_RECOVERY_ENABLED ("0")                                                                            Environment Variable      local
+env.CLAWSWEEPER_WEBHOOK_SECRET ("(hidden)")                                                                  Environment Variable      local
+
+[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mScheduled Workers are not automatically triggered during local development.[0m
+
+  To manually trigger a scheduled event, run:
+    curl "http://127.0.0.1:8799/cdn-cgi/handler/scheduled"
+  For more details, see [4mhttps://developers.cloudflare.com/workers/configuration/cron-triggers/#test-cron-triggers-locally[0m
+
+
+⎔ Starting local server...
+[wrangler:info] Ready on http://127.0.0.1:8799
+[wrangler:info] GET /api/health 200 OK (4ms)
+[wrangler:info] POST /internal/exact-review/enqueue 202 Accepted (23ms)
+[wrangler:info] POST /internal/exact-review/publication-batches/claim 200 OK (4ms)
+[wrangler:info] GET /api/exact-review-queue/item 200 OK (2ms)
+[wrangler:info] POST /internal/exact-review/publication-batches/complete 200 OK (5ms)
+[wrangler:info] GET /api/exact-review-queue/item 200 OK (1ms)
+[wrangler:info] POST /internal/exact-review/enqueue 202 Accepted (3ms)
+[wrangler:info] POST /internal/exact-review/publication-batches/claim 200 OK (3ms)
+[wrangler:info] GET /api/exact-review-queue/item 200 OK (2ms)
+[wrangler:info] POST /internal/exact-review/publication-batches/complete 200 OK (2ms)
+[wrangler:info] GET /api/exact-review-queue/item 200 OK (1ms)
+[wrangler:info] GET /api/exact-review-queue 200 OK (5ms)

--- a/docs/proof/csw-1089/run-proof.mjs
+++ b/docs/proof/csw-1089/run-proof.mjs
@@ -1,0 +1,593 @@
+import { createHmac } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createServer } from "node:https";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const outputDir = path.resolve(requiredEnv("CSW_1089_PROOF_OUTPUT"));
+const workerOrigin = requiredLoopbackOrigin("CSW_1089_WORKER_ORIGIN", "http:");
+const transportPort = positivePort(requiredEnv("CSW_1089_TRANSPORT_PORT"));
+const tlsKeyPath = requiredEnv("CSW_1089_TLS_KEY");
+const tlsCertPath = requiredEnv("CSW_1089_TLS_CERT");
+const proofSecret = requiredEnv("CSW_1089_PROOF_SECRET");
+const sourceSha = requiredEnv("SOURCE_SHA");
+const sourceTreeSha = requiredEnv("SOURCE_TREE_SHA");
+const transportOrigin = `https://127.0.0.1:${transportPort}`;
+const cliPath = path.resolve("dist/repair/exact-review-batch-cli.js");
+
+await mkdir(outputDir, { recursive: true });
+
+const assertions = [];
+const transportRequests = [];
+const cliRuns = [];
+const workerResponses = [];
+let activeFixture = null;
+
+function assertProof(name, condition, details = {}) {
+  if (!condition) throw new Error(`proof failed: ${name}; ${JSON.stringify(details)}`);
+  assertions.push({ name, ...details });
+}
+
+function jsonResponse(response, status, value) {
+  const body = `${JSON.stringify(value)}\n`;
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body),
+  });
+  response.end(body);
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const transportServer = createServer(
+  {
+    key: await readFile(tlsKeyPath),
+    cert: await readFile(tlsCertPath),
+  },
+  async (request, response) => {
+    try {
+      if (!activeFixture) return jsonResponse(response, 503, { error: "fixture_not_ready" });
+      const body = await requestBody(request);
+      const signature = String(request.headers["x-clawsweeper-exact-review-signature"] || "");
+      const expected = `sha256=${createHmac("sha256", proofSecret).update(body).digest("hex")}`;
+      const signatureValid = signature === expected;
+      const pathname = new URL(request.url || "/", transportOrigin).pathname;
+      const event = {
+        scenario: activeFixture.scenario,
+        method: request.method,
+        pathname,
+        signature_valid: signatureValid,
+        local_address: request.socket.localAddress,
+        remote_address: request.socket.remoteAddress,
+      };
+      transportRequests.push(event);
+      if (!signatureValid) return jsonResponse(response, 401, { error: "invalid_signature" });
+
+      if (pathname.endsWith("/publication-batches/fetch")) {
+        event.response_status = 200;
+        return jsonResponse(response, 200, activeFixture.fetchResponse);
+      }
+      if (pathname.endsWith("/publication-batches/heartbeat")) {
+        event.response_status = 200;
+        return jsonResponse(response, 200, { batch: activeFixture.batch });
+      }
+      if (pathname.endsWith("/publication-batches/complete")) {
+        activeFixture.completion = JSON.parse(body);
+        event.response_status = 200;
+        return jsonResponse(response, 200, {
+          ok: true,
+          accepted: 1,
+          skipped: 0,
+          batch: { ...activeFixture.batch, items: [] },
+        });
+      }
+      if (pathname.endsWith("/publication-batch-results")) {
+        activeFixture.publicationRequests += 1;
+        if (activeFixture.scenario === "no-status") {
+          event.connection_reset = true;
+          request.socket.destroy();
+          return;
+        }
+        const status = activeFixture.scenario === "429" ? 429 : 503;
+        event.response_status = status;
+        return jsonResponse(response, status, { error: `proof_http_${status}` });
+      }
+      event.response_status = 404;
+      return jsonResponse(response, 404, { error: "not_found" });
+    } catch (error) {
+      if (!response.headersSent) {
+        jsonResponse(response, 500, { error: "proof_listener_failure" });
+      } else {
+        response.destroy();
+      }
+      transportRequests.push({
+        scenario: activeFixture?.scenario || "unknown",
+        listener_error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+);
+
+await new Promise((resolve, reject) => {
+  transportServer.once("error", reject);
+  transportServer.listen(transportPort, "127.0.0.1", resolve);
+});
+
+const transportResults = {};
+try {
+  for (const scenario of ["no-status", "429", "503"]) {
+    transportResults[scenario] = await runTransportScenario(scenario);
+  }
+} finally {
+  await new Promise((resolve) => transportServer.close(resolve));
+}
+
+const stateContentionMember = transportResults["429"].member;
+const stateContentionCompletion = transportResults["429"].completion;
+const stateContentionDecision = publicationDecision(
+  stateContentionMember.decision.itemNumber,
+  "1089010",
+);
+
+const stateEnqueue = await signedWorkerPost("/internal/exact-review/enqueue", {
+  delivery_id: "csw-1089-state-contention-enqueue",
+  decision: stateContentionDecision,
+});
+workerResponses.push({ operation: "state_contention_enqueue", ...stateEnqueue });
+assertProof(
+  "real Worker accepts the state-contention publication item",
+  stateEnqueue.status === 202 && stateEnqueue.body.queued === true,
+);
+
+const stateClaim = await signedWorkerPost("/internal/exact-review/publication-batches/claim", {
+  claim_id: stateContentionCompletion.batch_id,
+  lease_owner: stateContentionCompletion.lease_owner,
+  max_items: 1,
+});
+workerResponses.push({ operation: "state_contention_claim", ...stateClaim });
+assertProof(
+  "real Worker and DO claim the state-contention publication item",
+  stateClaim.status === 200 && stateClaim.body.claimed === true,
+  { response: stateClaim },
+);
+assertClaimMatchesCompletion(stateClaim.body, stateContentionCompletion);
+
+const stateBefore = await queueItemStatus(stateContentionMember.decision.itemNumber);
+await writeJson("queue-state-state-contention-before.json", stateBefore);
+const stateComplete = await signedWorkerPost(
+  "/internal/exact-review/publication-batches/complete",
+  stateContentionCompletion,
+);
+workerResponses.push({ operation: "state_contention_complete", ...stateComplete });
+assertProof(
+  "real Worker and DO accept the captured state-contention tuple",
+  stateComplete.status === 200 && stateComplete.body.accepted === 1,
+);
+const stateAfter = await queueItemStatus(stateContentionMember.decision.itemNumber);
+await writeJson("queue-state-state-contention-after.json", stateAfter);
+assertPendingRetry("state_contention", stateAfter);
+
+const unknownItemNumber = 108904;
+const unknownRunId = "1089040";
+const unknownMember = memberFor(unknownItemNumber, unknownRunId);
+const unknownBatchId = "csw-1089-unknown-attempt-1";
+const unknownCompletion = {
+  batch_id: unknownBatchId,
+  lease_owner: "csw-1089-proof-worker",
+  items: [
+    {
+      ...stateContentionCompletion.items[0],
+      item_key: unknownMember.itemKey,
+      revision: 1,
+      claim_generation: 1,
+      reason_code: "unknown_failure",
+    },
+  ],
+};
+await writeJson("completion-unknown-control.json", unknownCompletion);
+
+const unknownEnqueue = await signedWorkerPost("/internal/exact-review/enqueue", {
+  delivery_id: "csw-1089-unknown-enqueue",
+  decision: publicationDecision(unknownItemNumber, unknownRunId),
+});
+workerResponses.push({ operation: "unknown_enqueue", ...unknownEnqueue });
+assertProof(
+  "real Worker accepts the unknown-failure control item",
+  unknownEnqueue.status === 202 && unknownEnqueue.body.queued === true,
+);
+const unknownClaim = await signedWorkerPost("/internal/exact-review/publication-batches/claim", {
+  claim_id: unknownBatchId,
+  lease_owner: unknownCompletion.lease_owner,
+  max_items: 1,
+});
+workerResponses.push({ operation: "unknown_claim", ...unknownClaim });
+assertProof(
+  "real Worker and DO claim the unknown-failure control item",
+  unknownClaim.status === 200 && unknownClaim.body.claimed === true,
+  { response: unknownClaim },
+);
+assertClaimMatchesCompletion(unknownClaim.body, unknownCompletion);
+const unknownBefore = await queueItemStatus(unknownItemNumber);
+await writeJson("queue-state-unknown-before.json", unknownBefore);
+const unknownComplete = await signedWorkerPost(
+  "/internal/exact-review/publication-batches/complete",
+  unknownCompletion,
+);
+workerResponses.push({ operation: "unknown_complete", ...unknownComplete });
+assertProof(
+  "real Worker and DO accept the unknown-failure control tuple",
+  unknownComplete.status === 200 && unknownComplete.body.accepted === 1,
+);
+const unknownAfter = await queueItemStatus(unknownItemNumber);
+await writeJson("queue-state-unknown-after-attempt-1.json", unknownAfter);
+assertPendingRetry("unknown_failure", unknownAfter);
+
+const finalStats = await workerGet("/api/exact-review-queue");
+assertProof("real queue status remains available", finalStats.status === 200);
+await writeJson("queue-stats-final.json", finalStats.body);
+await writeJson("worker-responses.json", workerResponses);
+await writeJson("transport-requests.json", transportRequests);
+await writeJson("cli-runs.json", cliRuns);
+
+const summary = {
+  proof: "PR 1089 real-boundary batch publication retry proof",
+  source_sha: sourceSha,
+  source_tree_sha256: sourceTreeSha,
+  transport: {
+    origin: `https://127.0.0.1:${transportPort}`,
+    scenarios: Object.fromEntries(
+      Object.entries(transportResults).map(([scenario, result]) => [
+        scenario,
+        {
+          publication_requests: result.publicationRequests,
+          terminal_outcome: result.completion.items[0].terminal_outcome,
+          reason_code: result.completion.items[0].reason_code,
+          completion_artifact: `completion-${scenario}.json`,
+        },
+      ]),
+    ),
+    signed_requests: transportRequests.length,
+    invalid_signatures: transportRequests.filter((request) => request.signature_valid === false)
+      .length,
+  },
+  worker_do: {
+    origin: workerOrigin,
+    state_contention_after: stateAfter,
+    unknown_failure_attempt_1_after: unknownAfter,
+    final_dead_letters_open: finalStats.body?.lanes?.publication?.dead_letters?.open ?? null,
+  },
+  assertions,
+  limits: {
+    attempted_old_budget_terminal: false,
+    reason:
+      "Authentic backoff requires roughly 51 minutes before attempt 14; no clock, retry constant, or Durable Object storage was altered.",
+  },
+  generated_at: new Date().toISOString(),
+};
+await writeJson("proof-summary.json", summary);
+
+await writeFile(
+  path.join(outputDir, "runtime-transcript.md"),
+  `# PR 1089 real-boundary runtime transcript
+
+- Source commit: \`${sourceSha}\`
+- Source-tree SHA-256: \`${sourceTreeSha}\`
+- CLI transport: built \`exact-review-batch-cli\` over a self-signed TLS listener bound only to \`127.0.0.1:${transportPort}\`.
+- CLI observations: reset, HTTP 429, and HTTP 503 each produced \`retryable_failure\` / \`state_contention\` after ${transportResults["429"].publicationRequests} actual publication requests per scenario.
+- Worker/DO: pinned Wrangler Worker on \`${workerOrigin}\`, disposable local persistence, signed enqueue/claim/complete requests, and public status reads.
+- Secrets: one disposable local proof secret; request traces retain only \`signature_valid\`, never a signature or secret value.
+
+## State contention after one real completion
+
+\`\`\`json
+${JSON.stringify(stateAfter, null, 2)}
+\`\`\`
+
+## Unknown failure after one real completion
+
+\`\`\`json
+${JSON.stringify(unknownAfter, null, 2)}
+\`\`\`
+
+## Limit
+
+The real unknown-failure item is pending after attempt 1, as expected. Reaching attempt 14 requires roughly 51 minutes of authentic backoff. This run did not fake time, edit Durable Object state, or change retry constants, so it does not claim the final \`retry_exhausted\` dead letter or the same-attempt terminal contrast.
+`,
+  "utf8",
+);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      assertions: assertions.length,
+      output_dir: outputDir,
+      state_contention: stateAfter,
+      unknown_failure_attempt_1: unknownAfter,
+    },
+    null,
+    2,
+  ),
+);
+
+async function runTransportScenario(scenario) {
+  const itemNumber = scenario === "429" ? 108901 : scenario === "503" ? 108903 : 108902;
+  const runId = `${itemNumber}0`;
+  const member = memberFor(itemNumber, runId);
+  const batchId = `csw-1089-${scenario}`;
+  const leaseOwner = "csw-1089-proof-worker";
+  const root = await mkdtemp(path.join(tmpdir(), `csw-1089-${scenario}-`));
+  try {
+    const outcomePath = path.join(root, "eligible.json");
+    const manifestPath = path.join(root, "manifest.json");
+    const receiptPath = path.join(root, "receipt.json");
+    await writeFile(
+      outcomePath,
+      `${JSON.stringify({
+        kind: "eligible",
+        plan: mutationPlan(member),
+        postEffectsComplete: true,
+      })}\n`,
+    );
+    await writeFile(
+      manifestPath,
+      `${JSON.stringify(
+        {
+          batchId,
+          leaseOwner,
+          configuredBatchSize: 1,
+          batchWaitMs: 0,
+          items: [{ ...member, outcomePath }],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const wireItem = {
+      item_key: member.itemKey,
+      revision: member.revision,
+      claim_generation: member.claimGeneration,
+      decision: member.decision,
+    };
+    const batch = {
+      batch_id: batchId,
+      lease_owner: leaseOwner,
+      lease_expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+      items: [wireItem],
+    };
+    activeFixture = {
+      scenario,
+      batch,
+      fetchResponse: { ok: true, batch, items: [wireItem], superseded: 0 },
+      publicationRequests: 0,
+      completion: null,
+    };
+    const childEnv = {
+      ...process.env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      NODE_NO_WARNINGS: "1",
+      CLAWSWEEPER_WEBHOOK_SECRET: proofSecret,
+      EXACT_REVIEW_QUEUE_URL: transportOrigin,
+      EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+      EXACT_REVIEW_BATCH_RECEIPT: receiptPath,
+    };
+    cliRuns.push(await runCli(scenario, "commit", childEnv));
+    const receipt = JSON.parse(await readFile(receiptPath, "utf8"));
+    cliRuns.push(await runCli(scenario, "complete", childEnv));
+    const completion = activeFixture.completion;
+    assertProof(
+      `${scenario} CLI completion is state contention`,
+      completion?.items?.length === 1 &&
+        completion.items[0].terminal_outcome === "retryable_failure" &&
+        completion.items[0].reason_code === "state_contention",
+      { publication_requests: activeFixture.publicationRequests },
+    );
+    assertProof(
+      `${scenario} traverses the built-in three-attempt transport path`,
+      activeFixture.publicationRequests === 3,
+    );
+    await writeJson(`publication-receipt-${scenario}.json`, receipt);
+    await writeJson(`completion-${scenario}.json`, completion);
+    return {
+      member,
+      receipt,
+      completion,
+      publicationRequests: activeFixture.publicationRequests,
+    };
+  } finally {
+    activeFixture = null;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function runCli(scenario, command, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, command], {
+      cwd: process.cwd(),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      const result = {
+        scenario,
+        command,
+        exit_code: code,
+        signal,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      };
+      if (code !== 0) {
+        reject(new Error(`CLI ${scenario}/${command} failed: ${JSON.stringify(result)}`));
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+function memberFor(itemNumber, runId) {
+  return {
+    itemKey: `openclaw/openclaw#${itemNumber}@publish:${runId}:1`,
+    revision: 1,
+    claimGeneration: 1,
+    decision: { targetRepo: "openclaw/openclaw", itemNumber },
+  };
+}
+
+function mutationPlan(member) {
+  return {
+    identity: {
+      itemKey: member.itemKey,
+      revision: member.revision,
+      claimGeneration: member.claimGeneration,
+    },
+    publication: {
+      canonicalTargetKey: `openclaw/openclaw#${member.decision.itemNumber}`,
+      fenceKey: member.itemKey,
+    },
+    operations: [
+      {
+        path: `records/openclaw-openclaw/items/${member.decision.itemNumber}.md`,
+        deleted: false,
+        mode: "100644",
+        bytes: 1,
+        contentBase64: "eA==",
+      },
+    ],
+    totalBytes: 1,
+  };
+}
+
+function publicationDecision(itemNumber, producerRunId) {
+  const producerDecision = {
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber,
+    itemKind: "issue",
+    sourceEvent: "issues",
+    sourceAction: "opened",
+    supersedesInProgress: false,
+  };
+  return {
+    ...producerDecision,
+    sourceAction: "exact_review_artifact_publish",
+    publication: {
+      artifactName: `exact-review-${producerRunId}-1`,
+      producerRunId,
+      producerRunAttempt: 1,
+      sourceSha: "a".repeat(40),
+      itemKey: `openclaw/openclaw#${itemNumber}`,
+      protocolVersion: 2,
+      leaseRevision: 1,
+      claimGeneration: 1,
+      liveProceeded: true,
+      liveTerminalNoop: false,
+      liveTerminalMissing: false,
+      liveGuardedOpen: false,
+      producerDecision,
+    },
+  };
+}
+
+async function signedWorkerPost(pathname, payload) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", proofSecret).update(body).digest("hex")}`;
+  const response = await fetch(`${workerOrigin}${pathname}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+  return {
+    status: response.status,
+    body: await response.json().catch(() => ({ error: "invalid_json" })),
+  };
+}
+
+async function workerGet(pathname) {
+  const response = await fetch(`${workerOrigin}${pathname}`);
+  return {
+    status: response.status,
+    body: await response.json().catch(() => ({ error: "invalid_json" })),
+  };
+}
+
+async function queueItemStatus(itemNumber) {
+  const result = await workerGet(
+    `/api/exact-review-queue/item?target_repo=openclaw%2Fopenclaw&item_number=${itemNumber}`,
+  );
+  assertProof(`queue item status ${itemNumber} is available`, result.status === 200);
+  return result.body;
+}
+
+function assertClaimMatchesCompletion(claimBody, completion) {
+  const claimed = claimBody?.batch?.items?.[0];
+  const tuple = completion?.items?.[0];
+  assertProof(
+    `claimed tuple matches ${tuple?.item_key || "completion"}`,
+    claimed?.item_key === tuple?.item_key &&
+      claimed?.revision === tuple?.revision &&
+      claimed?.claim_generation === tuple?.claim_generation,
+  );
+}
+
+function assertPendingRetry(reason, status) {
+  const item = status?.items?.[0];
+  const nextAttemptAt = Date.parse(String(item?.next_attempt_at || ""));
+  assertProof(
+    `${reason} is pending with one scheduled retry and no dead letter`,
+    status?.items?.length === 1 &&
+      item?.state === "pending" &&
+      item?.attempts === 1 &&
+      Number.isFinite(nextAttemptAt) &&
+      nextAttemptAt > Date.now() &&
+      Array.isArray(status?.dead_letters) &&
+      status.dead_letters.length === 0,
+    { next_attempt_at: item?.next_attempt_at ?? null },
+  );
+}
+
+async function writeJson(filename, value) {
+  await writeFile(path.join(outputDir, filename), `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function requiredEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredLoopbackOrigin(name, protocol) {
+  const value = requiredEnv(name);
+  const url = new URL(value);
+  if (url.protocol !== protocol || url.hostname !== "127.0.0.1") {
+    throw new Error(`${name} must use ${protocol}//127.0.0.1`);
+  }
+  return url.origin;
+}
+
+function positivePort(value) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error("CSW_1089_TRANSPORT_PORT is invalid");
+  }
+  return port;
+}

--- a/docs/proof/csw-1089/run-proof.sh
+++ b/docs/proof/csw-1089/run-proof.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+output_dir="${CSW_1089_PROOF_OUTPUT:-docs/proof/csw-1089/artifacts}"
+worker_port="${CSW_1089_WORKER_PORT:-8799}"
+transport_port="${CSW_1089_TRANSPORT_PORT:-8899}"
+proof_secret="csw-1089-disposable-local-proof-secret"
+wrangler_raw_log="$(mktemp /tmp/csw-1089-wrangler-log.XXXXXX)"
+state_dir="$(mktemp -d /tmp/csw-1089-wrangler-state.XXXXXX)"
+tls_dir="$(mktemp -d /tmp/csw-1089-tls.XXXXXX)"
+wrangler_pid=""
+
+mkdir -p "$output_dir"
+
+cleanup() {
+  if test -n "$wrangler_pid"; then
+    kill "$wrangler_pid" >/dev/null 2>&1 || true
+    wait "$wrangler_pid" >/dev/null 2>&1 || true
+  fi
+  if test -f "$wrangler_raw_log"; then
+    sed "s/${proof_secret}/[redacted-local-proof-secret]/g" "$wrangler_raw_log" \
+      | sed -n '1,240p' >"${output_dir}/wrangler.log"
+  fi
+  rm -f -- "$wrangler_raw_log"
+  rm -rf -- "$state_dir" "$tls_dir"
+}
+trap cleanup EXIT
+
+pnpm install --frozen-lockfile >"${output_dir}/dependencies-install.log" 2>&1
+pnpm run build:repair >"${output_dir}/build-repair.log" 2>&1
+pnpm run build:dashboard >"${output_dir}/build-dashboard.log" 2>&1
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -subj '/CN=127.0.0.1' \
+  -addext 'subjectAltName=IP:127.0.0.1' \
+  -keyout "${tls_dir}/key.pem" \
+  -out "${tls_dir}/cert.pem" \
+  >/dev/null 2>&1
+
+npm_config_ignore_scripts=true npx --yes wrangler@4.107.0 dev \
+  --config dashboard/wrangler.toml \
+  --local \
+  --persist-to "$state_dir" \
+  --ip 127.0.0.1 \
+  --port "$worker_port" \
+  --var "CLAWSWEEPER_WEBHOOK_SECRET:${proof_secret}" \
+  >"$wrangler_raw_log" 2>&1 &
+wrangler_pid=$!
+
+ready=false
+for _ in $(seq 1 90); do
+  if curl --fail --silent "http://127.0.0.1:${worker_port}/api/health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  if ! kill -0 "$wrangler_pid" >/dev/null 2>&1; then
+    sed -n '1,220p' "$wrangler_raw_log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+test "$ready" = true
+
+export CSW_1089_PROOF_OUTPUT="$output_dir"
+export CSW_1089_WORKER_ORIGIN="http://127.0.0.1:${worker_port}"
+export CSW_1089_TRANSPORT_PORT="$transport_port"
+export CSW_1089_TLS_KEY="${tls_dir}/key.pem"
+export CSW_1089_TLS_CERT="${tls_dir}/cert.pem"
+export CSW_1089_PROOF_SECRET="$proof_secret"
+export SOURCE_SHA="${CSW_1089_PROOF_SOURCE_SHA:-$(git rev-parse HEAD)}"
+export SOURCE_TREE_SHA="$(node -e '
+  const { createHash } = require("node:crypto");
+  const { readFileSync } = require("node:fs");
+  const hash = createHash("sha256");
+  for (const file of process.argv.slice(1)) hash.update(file).update("\0").update(readFileSync(file));
+  process.stdout.write(hash.digest("hex"));
+' \
+  src/repair/exact-review-batch-cli.ts \
+  dashboard/exact-review-publication-retry.ts \
+  dashboard/exact-review-queue.ts \
+  dashboard/worker.ts \
+  docs/proof/csw-1089/README.md \
+  docs/proof/csw-1089/run-proof.sh \
+  docs/proof/csw-1089/run-proof.mjs)"
+
+node docs/proof/csw-1089/run-proof.mjs
+
+test -s "${output_dir}/runtime-transcript.md"
+test -s "${output_dir}/proof-summary.json"
+test -s "${output_dir}/transport-requests.json"
+test -s "${output_dir}/completion-no-status.json"
+test -s "${output_dir}/completion-429.json"
+test -s "${output_dir}/completion-503.json"
+test -s "${output_dir}/queue-state-state-contention-after.json"
+test -s "${output_dir}/queue-state-unknown-after-attempt-1.json"

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -40,7 +40,7 @@ type BatchPublicationOutcome = {
   revision: number;
   claimGeneration: number;
   outcome: "accepted" | "deduped" | "superseded" | "retryable" | "permanent";
-  reasonCode?: "tuple_protocol_invalid" | "unknown_failure";
+  reasonCode?: "state_contention" | "tuple_protocol_invalid" | "unknown_failure";
   errorFingerprint?: string;
 };
 
@@ -501,6 +501,14 @@ function publicationOutcomeFromResult(
       errorFingerprint: fingerprint,
     };
   }
+  if (result.status === undefined || result.status === 429 || result.status >= 500) {
+    return {
+      ...identity,
+      outcome: "retryable",
+      reasonCode: "state_contention",
+      errorFingerprint: fingerprint,
+    };
+  }
   return {
     ...identity,
     outcome: "retryable",
@@ -607,7 +615,12 @@ function batchPublicationOutcome(value: unknown): BatchPublicationOutcome {
     outcome.reasonCode === undefined
       ? undefined
       : exactIdentityValue(outcome.reasonCode, "reasonCode");
-  if (reasonCode && reasonCode !== "tuple_protocol_invalid" && reasonCode !== "unknown_failure") {
+  if (
+    reasonCode &&
+    reasonCode !== "state_contention" &&
+    reasonCode !== "tuple_protocol_invalid" &&
+    reasonCode !== "unknown_failure"
+  ) {
     throw new Error("Invalid batch receipt publication reason code");
   }
   const errorFingerprint =
@@ -654,7 +667,11 @@ function publicationCompletion(
     return { ...member, terminalOutcome: "superseded" };
   }
   if (publication.outcome === "retryable") {
-    return retryableCompletion(member, "unknown_failure", publication.errorFingerprint);
+    return retryableCompletion(
+      member,
+      publication.reasonCode ?? "unknown_failure",
+      publication.errorFingerprint,
+    );
   }
   if (outcome.kind !== "eligible" || hasPendingPostEffects(outcome)) {
     return retryableCompletion(member, "unknown_failure", publication.errorFingerprint);

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -137,6 +137,169 @@ globalThis.fetch = async (url, init) => {
   }
 });
 
+const publicationFailureCases = [
+  {
+    name: "network errors",
+    scenario: "network",
+    publicationOutcome: "retryable",
+    reasonCode: "state_contention",
+    terminalOutcome: "retryable_failure",
+  },
+  {
+    name: "HTTP 429 responses",
+    scenario: "429",
+    publicationOutcome: "retryable",
+    reasonCode: "state_contention",
+    terminalOutcome: "retryable_failure",
+  },
+  {
+    name: "HTTP 503 responses",
+    scenario: "503",
+    publicationOutcome: "retryable",
+    reasonCode: "state_contention",
+    terminalOutcome: "retryable_failure",
+  },
+  {
+    name: "HTTP 400 responses",
+    scenario: "400",
+    publicationOutcome: "permanent",
+    reasonCode: "tuple_protocol_invalid",
+    terminalOutcome: "permanent_failure",
+  },
+  {
+    name: "HTTP 413 responses",
+    scenario: "413",
+    publicationOutcome: "permanent",
+    reasonCode: "tuple_protocol_invalid",
+    terminalOutcome: "permanent_failure",
+  },
+  {
+    name: "direct publication fence ownership failures",
+    scenario: "fence_not_owned",
+    publicationOutcome: "retryable",
+    reasonCode: "unknown_failure",
+    terminalOutcome: "retryable_failure",
+  },
+] as const;
+
+for (const failureCase of publicationFailureCases) {
+  test(`batch publication maps ${failureCase.name} through completion`, () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-publication-failure-"));
+    try {
+      const member = batchMember("openclaw/openclaw#805@publish:8050:1", 805);
+      const outcomePath = join(root, "eligible.json");
+      const manifestPath = join(root, "manifest.json");
+      const receiptPath = join(root, "receipt.json");
+      const completionPath = join(root, "completion.json");
+      const preloadPath = join(root, "fetch-preload.cjs");
+      writeFileSync(
+        outcomePath,
+        JSON.stringify({
+          kind: "eligible",
+          plan: mutationPlan(member),
+          postEffectsComplete: true,
+        }),
+      );
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          batchId: `batch-publication-${failureCase.scenario}`,
+          leaseOwner: "proof-worker",
+          configuredBatchSize: 1,
+          batchWaitMs: 0,
+          items: [{ ...member, outcomePath }],
+        }),
+      );
+      writeFileSync(
+        preloadPath,
+        `const fs = require("node:fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.EXACT_REVIEW_BATCH_MANIFEST, "utf8"));
+const wireItems = manifest.items.map((item) => ({ item_key: item.itemKey, revision: item.revision, claim_generation: item.claimGeneration, decision: item.decision }));
+const response = (value, status = 200) => new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+globalThis.setTimeout = (callback, _delay, ...args) => {
+  queueMicrotask(() => callback(...args));
+  return 0;
+};
+globalThis.fetch = async (url, init) => {
+  const target = String(url);
+  if (target.endsWith("/publication-batches/fetch")) {
+    return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-01T00:00:00.000Z", items: wireItems }, items: wireItems, superseded: 0 });
+  }
+  if (target.endsWith("/publication-batches/heartbeat")) {
+    return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-01T00:00:00.000Z", items: wireItems } });
+  }
+  if (target.endsWith("/publication-batch-results")) {
+    if (process.env.BATCH_CLI_SCENARIO === "network") throw new Error("network unavailable");
+    const status = process.env.BATCH_CLI_SCENARIO === "fence_not_owned" ? 409 : Number(process.env.BATCH_CLI_SCENARIO);
+    const error = process.env.BATCH_CLI_SCENARIO === "fence_not_owned" ? "direct_publication_fence_not_owned" : "http_" + status;
+    return response({ error }, status);
+  }
+  if (target.endsWith("/publication-batches/complete")) {
+    fs.writeFileSync(process.env.BATCH_CLI_COMPLETION, init.body);
+    return response({
+      accepted: 1,
+      skipped: 0,
+      batch: {
+        batch_id: manifest.batchId,
+        lease_owner: manifest.leaseOwner,
+        lease_expires_at: "2026-08-01T00:00:00.000Z",
+        items: [],
+      },
+    });
+  }
+  throw new Error("unexpected mock fetch target: " + target);
+};
+`,
+      );
+      const env = {
+        ...process.env,
+        CLAWSWEEPER_WEBHOOK_SECRET: "proof-secret",
+        EXACT_REVIEW_QUEUE_URL: "https://queue.example.test",
+        EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+        EXACT_REVIEW_BATCH_RECEIPT: receiptPath,
+        BATCH_CLI_COMPLETION: completionPath,
+        BATCH_CLI_SCENARIO: failureCase.scenario,
+      };
+      const commitResult = spawnSync(
+        process.execPath,
+        ["--require", preloadPath, "dist/repair/exact-review-batch-cli.js", "commit"],
+        { cwd: process.cwd(), encoding: "utf8", env },
+      );
+      assert.equal(commitResult.status, 0, commitResult.stderr);
+      const receipt = JSON.parse(readFileSync(receiptPath, "utf8")) as {
+        outcomes: Array<{
+          outcome: string;
+          reasonCode: string;
+          errorFingerprint: string;
+        }>;
+      };
+      assert.equal(receipt.outcomes.length, 1);
+      assert.equal(receipt.outcomes[0]?.outcome, failureCase.publicationOutcome);
+      assert.equal(receipt.outcomes[0]?.reasonCode, failureCase.reasonCode);
+      assert.match(receipt.outcomes[0]?.errorFingerprint ?? "", /^[a-f0-9]{64}$/);
+
+      const completeResult = spawnSync(
+        process.execPath,
+        ["--require", preloadPath, "dist/repair/exact-review-batch-cli.js", "complete"],
+        { cwd: process.cwd(), encoding: "utf8", env },
+      );
+      assert.equal(completeResult.status, 0, completeResult.stderr);
+      assert.deepEqual(JSON.parse(readFileSync(completionPath, "utf8")).items, [
+        {
+          item_key: member.itemKey,
+          revision: member.revision,
+          claim_generation: member.claimGeneration,
+          terminal_outcome: failureCase.terminalOutcome,
+          reason_code: failureCase.reasonCode,
+          error_fingerprint: receipt.outcomes[0]?.errorFingerprint,
+        },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
 test("batch release retains a committed eligible member until lifecycle post-effects complete", () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-release-"));
   try {


### PR DESCRIPTION
## Problem

The exact-review publication lane has been `critical` in production, dead-lettering finished Codex reviews at roughly 20-30 per hour. Sampling the live queue endpoint over ~21 minutes showed the store growing monotonically, and only in one bucket:

```
00:08:53Z  dlq 900  {retry_exhausted: 719, tuple_protocol_invalid: 177, workflow_cancelled: 4}
00:15:37Z  dlq 904  {retry_exhausted: 723, tuple_protocol_invalid: 177, workflow_cancelled: 4}
00:29:35Z  dlq 907  {retry_exhausted: 724, tuple_protocol_invalid: 177, workflow_cancelled: 4}
```

Each row is a review that was computed and then never posted.

## Root cause

A publication dead letter is labelled `retry_exhausted` only when the reason code is `unknown_failure`, and `unknown_failure` carries by far the tightest budget in `dashboard/exact-review-publication-retry.ts`: 14 attempts **or one hour**, against 48 attempts / 24 hours for every other retryable reason.

The two publication paths disagreed about the same transport failure. `postDirectPublicationResult` returns only `accepted` or `fallback`, so every non-2xx and every network error arrives as `fallback` with an optional status:

- **Single-item path** (`src/repair/publish-event-result.ts`) already mapped no-status / 429 / 5xx to `state_contention`, i.e. the generous transient budget.
- **Batch path** (`src/repair/exact-review-batch-cli.ts`) special-cased only fence-ownership and 400/413, funnelled everything else into `unknown_failure`, and then discarded even that computed reason code by hardcoding `unknown_failure` in the completion mapper.

Batch is the dominant production path (batching enabled, 8 concurrent, 8 items each). So during a GitHub throttling episode — and the review lane confirms one, with 38 of 41 pending items in `throttle_retry` backoff — every batch publication landed on the one-hour budget.

The dead-letter inventory confirms the mechanism rather than merely fitting it. Of the 721 `retry_exhausted` rows:

- **706 (98%) had spent fewer than 14 attempts**, so the attempt cap did not fire.
- The **minimum observed lifespan is exactly 60.0 minutes**, with median 91.8 — the `UNKNOWN_RETRY_MAX_AGE_MS` age cap, evaluated on the first failure after the hour mark.

## Change

In `src/repair/exact-review-batch-cli.ts` only: classify no-status / 429 / 5xx as `state_contention`, and propagate the computed reason code through `publicationCompletion` instead of hardcoding `unknown_failure`. The receipt validator accepts the widened code.

`400`/`413` keep their permanent `tuple_protocol_invalid` mapping, fence-ownership is untouched, and the genuinely unknown-cause branches (`hasPendingPostEffects`, non-`eligible`) keep the tight budget deliberately. No retry constant changed.

`state_contention` is **already** in the Worker's allowlist for `retryable_failure` in `dashboard/exact-review-queue.ts`, so there is no protocol change and no deployment-ordering constraint between Worker and publisher.

## OpenClaw Bay

Not affected. This changes only how the batch publisher classifies its own transport failures before reporting a completion the queue protocol already accepts. No lifecycle state, status field, telemetry shape, or dashboard data contract changes.

## pr-behavior-proof

- **Claim:** a batch publication that fails with no HTTP status, HTTP 429, or HTTP 5xx completes as `retryable_failure` / `state_contention`; the real queue accepts that tuple, returns the publication to `pending`, increments its attempt count, schedules its next attempt, and creates no open dead letter.
- **Exercised surface:** the built `dist/repair/exact-review-batch-cli.js` `commit` and `complete` commands over real localhost TLS sockets, followed by signed enqueue/claim/complete traffic through a pinned local Wrangler Worker and the real `ExactReviewQueue` Durable Object.
- **Scenario / fixture:** a disposable HTTPS listener on `127.0.0.1` returns a connection reset, 429, and 503 in separate CLI runs and captures the HMAC-signed completion envelopes. The captured 429 tuple is then posted unchanged to a real local Worker/DO batch. A second fresh item repeats the Worker/DO sequence with only `reason_code: "unknown_failure"` as an attempt-one control. No `fetch` or timer monkeypatch is used, no production endpoint is contacted, and no real secret is loaded.
- **Command and environment:** `docs/proof/csw-1089/run-proof.sh` on macOS with Node 24, `npx --yes wrangler@4.107.0 dev --local --persist-to ...`, disposable local persistence, and loopback-only listeners.
- **Observable result:** all 21 proof assertions pass. Reset, 429, and 503 each take three real publication attempts and write `retryable_failure` / `state_contention`. After the captured 429 tuple crosses the real Worker/DO, item status is `pending` at attempt 1 with `backoff_reason: "publication_retry"`, a scheduled `next_attempt_at`, and `dead_letters: []`. The attempt-one `unknown_failure` control is also pending with no dead letter, as required before its old budget is exhausted.

```text
no-status -> retryable_failure / state_contention (3 real socket attempts)
HTTP 429  -> retryable_failure / state_contention (3 real socket attempts)
HTTP 503  -> retryable_failure / state_contention (3 real socket attempts)
Worker/DO state_contention -> pending, attempts=1, next_attempt_at scheduled, dead_letters=[]
Worker/DO unknown_failure  -> pending, attempts=1, next_attempt_at scheduled, dead_letters=[]
```

- **Artifacts:** contract and reproduction harness in `docs/proof/csw-1089/`; raw completion envelopes in `docs/proof/csw-1089/artifacts/completion-{no-status,429,503}.json`; socket/HMAC trace in `transport-requests.json`; Worker/DO status before and after in `queue-state-*.json`; consolidated observations in `runtime-transcript.md` and `proof-summary.json`.
- **Validation:** `pnpm run lint:repair`, `pnpm run format:check`, source-blind behavior validation, and the full `pnpm run check` all pass.
- **Limits:** reaching attempt 14 through the real DO requires roughly 51 minutes of authentic backoff (1, 2, 4, then 5+ minutes). This bounded run therefore proves the real classification and attempt-one queue transition but does not claim the final `unknown_failure` `retry_exhausted` dead letter or the same-attempt terminal contrast. It does not fake time, edit DO storage, or change a retry constant.

### Crabbox provenance

The proof re-ran unchanged on reviewed head `d54d60abf5de708713e0fbedce496cd5a21dd251` inside Docker-backed Crabbox `local-container` lease `cbx_9797931e8d4d`, using image `node:24-bookworm` and Crabbox CLI 0.39.0, from a clean `--fresh-pr` checkout. It exited 0 with all 21 assertions passing. See the [machine-readable provenance](https://github.com/openclaw/clawsweeper/blob/b1d12c0cc20539b741b76c6ee7c949d8be8a8991/docs/proof/csw-1089/artifacts/crabbox-local-container-provenance.json) and [captured stdout](https://github.com/openclaw/clawsweeper/blob/b1d12c0cc20539b741b76c6ee7c949d8be8a8991/docs/proof/csw-1089/artifacts/crabbox-local-container-stdout.log).

## Also included

`docs/pr-674-observation-runbook.md` records that the per-item telemetry producer this contract was written for never landed — PR #674 was closed unmerged on 2026-07-21 — which is why `/api/review-observability` reports 0 terminal attempts against 6194 expected and a 100% abnormal rate. Those numbers describe a missing producer, not failing reviews. Documentation only; no behavior change.
