### PR TITLE
fix: surface direct publication rejection detail

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -2631,11 +2631,13 @@ export class ExactReviewQueue {
           202,
         );
       } catch (error) {
-        console.warn(`direct publication plan rejected: ${sanitizedServerError(error)}`);
+        const detail = sanitizedServerError(error);
+        console.warn(`direct publication plan rejected: ${detail}`);
         return json(
           {
             error: "invalid_direct_publication_plan",
             fallback_required: true,
+            detail,
           },
           400,
         );

--- a/docs/proof/direct-publication-reject-detail/README.md
+++ b/docs/proof/direct-publication-reject-detail/README.md
@@ -1,0 +1,36 @@
+# Direct publication rejection detail proof
+
+This proof exercises the built dashboard Worker and `ExactReviewQueue` Durable Object through real
+HTTP using local Wrangler persistence. It verifies the diagnosability-only response change for
+invalid direct publication plans.
+
+The behavior contract is:
+
+- the real Durable Object initializes before any rejection claim is made;
+- a deliberately invalid revision returns HTTP 400 with
+  `error: "invalid_direct_publication_plan"`, `fallback_required: true`, and a non-empty `detail`
+  naming the invalid revision;
+- a structurally different plan whose operation targets the wrong item returns the same unchanged
+  error classification with a non-empty path-specific `detail`;
+- the two validation failures produce different detail values.
+
+The script boots the Worker, drives `/api/exact-review-queue`, terminates the full Wrangler process
+tree, and inspects Wrangler's persisted SQLite database for the direct-publication table. Only that
+schema observation allows the proof to restart the Worker and make the signed HTTP assertions. The
+restart check waits for the health endpoint to stop answering so a surviving `workerd` child cannot
+turn the second boot into a false positive.
+
+Run from the repository root on Node 24 or newer:
+
+```bash
+bash docs/proof/direct-publication-reject-detail/run-proof.sh
+```
+
+Set `DIRECT_PUBLICATION_REJECT_DETAIL_PROOF_OUTPUT` to keep generated artifacts outside the
+repository. The default ignored artifact directory contains the captured HTTP responses, runtime
+transcript, build/install logs, and a redacted Wrangler log.
+
+This proof does not change or test retry/permanence policy, does not identify or fix the underlying
+CodexBar rejection, and does not deploy or mutate production. OpenClaw Bay is unaffected: the
+change enriches an internal publication rejection and its downstream diagnostic fingerprint, with
+no Bay observer data or control surface change.

--- a/docs/proof/direct-publication-reject-detail/assert-durable-object.mjs
+++ b/docs/proof/direct-publication-reject-detail/assert-durable-object.mjs
@@ -1,0 +1,16 @@
+import { DatabaseSync } from "node:sqlite";
+
+const [databasePath] = process.argv.slice(2);
+if (!databasePath) throw new Error("usage: assert-durable-object.mjs <database-path>");
+
+const database = new DatabaseSync(databasePath);
+try {
+  const row = database
+    .prepare(
+      "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'exact_review_direct_publication_plans'",
+    )
+    .get();
+  console.log(row.count);
+} finally {
+  database.close();
+}

--- a/docs/proof/direct-publication-reject-detail/run-proof.sh
+++ b/docs/proof/direct-publication-reject-detail/run-proof.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+output_dir="${DIRECT_PUBLICATION_REJECT_DETAIL_PROOF_OUTPUT:-docs/proof/direct-publication-reject-detail/artifacts}"
+worker_port="${DIRECT_PUBLICATION_REJECT_DETAIL_PROOF_PORT:-8797}"
+proof_secret="direct-publication-reject-detail-disposable-local-secret"
+sqlite_helper="docs/proof/direct-publication-reject-detail/assert-durable-object.mjs"
+state_dir="$(mktemp -d /tmp/direct-publication-reject-detail-state.XXXXXX)"
+wrangler_raw_log="$(mktemp /tmp/direct-publication-reject-detail-wrangler.XXXXXX)"
+wrangler_pid=""
+queue_db=""
+
+mkdir -p "$output_dir"
+
+stop_worker() {
+  if test -n "$wrangler_pid"; then
+    local -a worker_pids=("$wrangler_pid")
+    local child_pid
+    while IFS= read -r child_pid; do
+      worker_pids+=("$child_pid")
+    done < <(
+      ps -eo pid=,ppid= | awk -v root="$wrangler_pid" '
+        { parent[$1] = $2 }
+        END {
+          for (pid in parent) {
+            current = pid
+            for (depth = 0; depth < 100 && current in parent; depth++) {
+              current = parent[current]
+              if (current == root) {
+                print pid
+                break
+              }
+            }
+          }
+        }
+      '
+    )
+    kill "${worker_pids[@]}" >/dev/null 2>&1 || true
+    wait "$wrangler_pid" >/dev/null 2>&1 || true
+    wrangler_pid=""
+
+    local stopped=false
+    for _ in $(seq 1 50); do
+      if ! curl --silent --max-time 1 "http://127.0.0.1:${worker_port}/api/health" \
+        >/dev/null 2>&1; then
+        stopped=true
+        break
+      fi
+      sleep 0.1
+    done
+    if test "$stopped" != true; then
+      echo "failed to stop the Wrangler process tree before restart" >&2
+      exit 1
+    fi
+  fi
+}
+
+cleanup() {
+  stop_worker
+  sed "s/${proof_secret}/[redacted-local-proof-secret]/g" "$wrangler_raw_log" \
+    >"${output_dir}/wrangler.log"
+  rm -f -- "$wrangler_raw_log"
+  rm -rf -- "$state_dir"
+}
+trap cleanup EXIT
+
+start_worker() {
+  npm_config_ignore_scripts=true npx --yes wrangler@4.107.0 dev \
+    --config dashboard/wrangler.toml \
+    --local \
+    --persist-to "$state_dir" \
+    --ip 127.0.0.1 \
+    --port "$worker_port" \
+    --var "CLAWSWEEPER_WEBHOOK_SECRET:${proof_secret}" \
+    >>"$wrangler_raw_log" 2>&1 &
+  wrangler_pid=$!
+
+  local ready=false
+  for _ in $(seq 1 90); do
+    if curl --fail --silent "http://127.0.0.1:${worker_port}/api/health" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    if ! kill -0 "$wrangler_pid" >/dev/null 2>&1; then
+      sed -n '1,240p' "$wrangler_raw_log" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  test "$ready" = true
+}
+
+http_status() {
+  local output_file="$1"
+  shift
+  curl --silent --show-error --max-time 90 --output "$output_file" --write-out '%{http_code}' "$@"
+}
+
+signed_post() {
+  local body_file="$1"
+  local output_file="$2"
+  local signature
+  signature="$(openssl dgst -sha256 -hmac "$proof_secret" -hex <"$body_file" | awk '{print $NF}')"
+  http_status "$output_file" \
+    -X POST \
+    -H "content-type: application/json" \
+    -H "x-clawsweeper-exact-review-signature: sha256=${signature}" \
+    --data-binary "@${body_file}" \
+    "http://127.0.0.1:${worker_port}/internal/exact-review/publication-results"
+}
+
+pnpm install --frozen-lockfile >"${output_dir}/dependencies-install.log" 2>&1
+pnpm run build:dashboard >"${output_dir}/build-dashboard.log" 2>&1
+
+# Force the real Durable Object to initialize, then stop the entire Wrangler
+# process tree before inspecting its persisted schema.
+start_worker
+initial_queue_status="$(http_status "${output_dir}/initial-queue.json" \
+  "http://127.0.0.1:${worker_port}/api/exact-review-queue")"
+test "$initial_queue_status" = "200"
+stop_worker
+
+while IFS= read -r candidate; do
+  if test "$(node "$sqlite_helper" "$candidate")" = "1"; then
+    queue_db="$candidate"
+    break
+  fi
+done < <(find "$state_dir" -type f -name '*.sqlite' -print)
+if test -z "$queue_db"; then
+  echo "Durable Object did not initialize: direct publication table is absent" >&2
+  exit 1
+fi
+
+node -e '
+  const fs = require("node:fs");
+  const base = {
+    canonicalTargetKey: "steipete/CodexBar#2797",
+    fenceKey: "steipete/CodexBar#2797",
+    sourceSha: "a".repeat(40),
+    operations: [{
+      path: "records/steipete-CodexBar/items/2797.md",
+      deleted: false,
+      mode: "100644",
+      bytes: 1,
+      contentBase64: "eA==",
+    }],
+    totalBytes: 1,
+    lifecycle: { kind: "policy_noop" },
+  };
+  const invalidRevision = {
+    ...base,
+    revision: 0,
+    identity: {
+      canonicalTargetKey: base.canonicalTargetKey,
+      fenceKey: base.fenceKey,
+      revision: 0,
+      claimGeneration: 1,
+    },
+  };
+  const outsidePath = {
+    ...base,
+    revision: 1,
+    identity: {
+      canonicalTargetKey: base.canonicalTargetKey,
+      fenceKey: base.fenceKey,
+      revision: 1,
+      claimGeneration: 1,
+    },
+    operations: [{ ...base.operations[0], path: "records/steipete-CodexBar/items/2798.md" }],
+  };
+  fs.writeFileSync(process.argv[1], JSON.stringify(invalidRevision));
+  fs.writeFileSync(process.argv[2], JSON.stringify(outsidePath));
+' "${output_dir}/invalid-revision-request.json" "${output_dir}/outside-path-request.json"
+
+start_worker
+revision_status="$(signed_post \
+  "${output_dir}/invalid-revision-request.json" \
+  "${output_dir}/invalid-revision-response.json")"
+path_status="$(signed_post \
+  "${output_dir}/outside-path-request.json" \
+  "${output_dir}/outside-path-response.json")"
+test "$revision_status" = "400"
+test "$path_status" = "400"
+
+REVISION_STATUS="$revision_status" PATH_STATUS="$path_status" node -e '
+  const assert = require("node:assert/strict");
+  const fs = require("node:fs");
+  const revision = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const outsidePath = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+  for (const body of [revision, outsidePath]) {
+    assert.equal(body.error, "invalid_direct_publication_plan");
+    assert.equal(body.fallback_required, true);
+    assert.equal(typeof body.detail, "string");
+    assert.ok(body.detail.length > 0);
+  }
+  assert.match(revision.detail, /invalid direct publication revision/);
+  assert.match(outsidePath.detail, /direct publication path is outside steipete-CodexBar#2797/);
+  assert.notEqual(revision.detail, outsidePath.detail);
+  const lines = [
+    "Durable Object initialized: exact_review_direct_publication_plans table present",
+    "invalid revision: HTTP " + process.env.REVISION_STATUS + "; error=" + revision.error + "; fallback_required=" + revision.fallback_required + "; detail=" + revision.detail,
+    "outside path: HTTP " + process.env.PATH_STATUS + "; error=" + outsidePath.error + "; fallback_required=" + outsidePath.fallback_required + "; detail=" + outsidePath.detail,
+    "distinct validation details: true",
+  ];
+  fs.writeFileSync(process.argv[3], lines.join("\n") + "\n");
+' \
+  "${output_dir}/invalid-revision-response.json" \
+  "${output_dir}/outside-path-response.json" \
+  "${output_dir}/runtime-transcript.txt"
+
+test -s "${output_dir}/runtime-transcript.txt"
+cat "${output_dir}/runtime-transcript.txt"

--- a/src/repair/exact-review-direct-publication.ts
+++ b/src/repair/exact-review-direct-publication.ts
@@ -122,7 +122,9 @@ export async function postDirectPublicationResult(options: {
       ) {
         return { kind: "accepted", attempts: attempt, response: payload };
       }
-      lastReason = String(payload.error || `http_${response.status}`);
+      const reason = String(payload.error || `http_${response.status}`);
+      const detail = typeof payload.detail === "string" ? payload.detail.trim() : "";
+      lastReason = detail ? `${reason}: ${detail}` : reason;
       if (
         response.status === 413 ||
         (response.status >= 400 && response.status < 500 && response.status !== 429)

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3753,6 +3753,32 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     error: "direct_publication_source_sha_required",
     fallback_required: true,
   });
+  const urlCredentials = ["alice", "hunter2"].join(":");
+  const credentialPath = `https://${urlCredentials}@example.invalid/GITHUB_TOKEN=ghp_${"a".repeat(24)}`;
+  const invalidPlanBody = JSON.stringify({
+    ...payload,
+    operations: [{ ...payload.operations[0], path: credentialPath }],
+  });
+  const invalidPlanSignature = `sha256=${createHmac("sha256", "test-secret").update(invalidPlanBody).digest("hex")}`;
+  const invalidPlan = await worker.fetch(
+    new Request(url, {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": invalidPlanSignature },
+      body: invalidPlanBody,
+    }),
+    env,
+  );
+  assert.equal(invalidPlan.status, 400);
+  const invalidPlanResponse = (await invalidPlan.json()) as {
+    error: string;
+    fallback_required: boolean;
+    detail: string;
+  };
+  assert.equal(invalidPlanResponse.error, "invalid_direct_publication_plan");
+  assert.equal(invalidPlanResponse.fallback_required, true);
+  assert.match(invalidPlanResponse.detail, /^invalid bounded state mutation path: /);
+  assert.match(invalidPlanResponse.detail, /\[REDACTED\]/);
+  assert.doesNotMatch(invalidPlanResponse.detail, /alice|hunter2|ghp_[A-Za-z0-9_]+/);
   for (const expected of [
     { accepted: true, deduped: false },
     { accepted: false, deduped: true },

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -300,6 +300,95 @@ globalThis.fetch = async (url, init) => {
   });
 }
 
+test("batch publication fingerprints distinct direct-plan rejection details separately", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-publication-details-"));
+  try {
+    const member = batchMember("openclaw/openclaw#806@publish:8060:1", 806);
+    const outcomePath = join(root, "eligible.json");
+    const manifestPath = join(root, "manifest.json");
+    const preloadPath = join(root, "fetch-preload.cjs");
+    writeFileSync(
+      outcomePath,
+      JSON.stringify({
+        kind: "eligible",
+        plan: mutationPlan(member),
+        postEffectsComplete: true,
+      }),
+    );
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        batchId: "batch-publication-rejection-details",
+        leaseOwner: "proof-worker",
+        configuredBatchSize: 1,
+        batchWaitMs: 0,
+        items: [{ ...member, outcomePath }],
+      }),
+    );
+    writeFileSync(
+      preloadPath,
+      `const fs = require("node:fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.EXACT_REVIEW_BATCH_MANIFEST, "utf8"));
+const wireItems = manifest.items.map((item) => ({ item_key: item.itemKey, revision: item.revision, claim_generation: item.claimGeneration, decision: item.decision }));
+const response = (value, status = 200) => new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+globalThis.setTimeout = (callback, _delay, ...args) => {
+  queueMicrotask(() => callback(...args));
+  return 0;
+};
+globalThis.fetch = async (url) => {
+  const target = String(url);
+  if (target.endsWith("/publication-batches/fetch")) {
+    return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-01T00:00:00.000Z", items: wireItems }, items: wireItems, superseded: 0 });
+  }
+  if (target.endsWith("/publication-batches/heartbeat")) {
+    return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-01T00:00:00.000Z", items: wireItems } });
+  }
+  if (target.endsWith("/publication-batch-results")) {
+    return response({ error: "invalid_direct_publication_plan", fallback_required: true, detail: process.env.BATCH_CLI_DETAIL }, 400);
+  }
+  throw new Error("unexpected mock fetch target: " + target);
+};
+`,
+    );
+
+    const fingerprintFor = (detail: string, suffix: string) => {
+      const receiptPath = join(root, `receipt-${suffix}.json`);
+      const result = spawnSync(
+        process.execPath,
+        ["--require", preloadPath, "dist/repair/exact-review-batch-cli.js", "commit"],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            CLAWSWEEPER_WEBHOOK_SECRET: "proof-secret",
+            EXACT_REVIEW_QUEUE_URL: "https://queue.example.test",
+            EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+            EXACT_REVIEW_BATCH_RECEIPT: receiptPath,
+            BATCH_CLI_DETAIL: detail,
+          },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      const receipt = JSON.parse(readFileSync(receiptPath, "utf8")) as {
+        outcomes: Array<{ errorFingerprint: string }>;
+      };
+      const fingerprint = receipt.outcomes[0]?.errorFingerprint ?? "";
+      assert.match(fingerprint, /^[a-f0-9]{64}$/);
+      return fingerprint;
+    };
+
+    const invalidRevision = fingerprintFor("invalid direct publication revision", "revision");
+    const outsidePath = fingerprintFor(
+      "direct publication path is outside openclaw-openclaw#806",
+      "path",
+    );
+    assert.notEqual(invalidRevision, outsidePath);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("batch release retains a committed eligible member until lifecycle post-effects complete", () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-release-"));
   try {

--- a/test/repair/exact-review-batch-publisher.test.ts
+++ b/test/repair/exact-review-batch-publisher.test.ts
@@ -112,6 +112,29 @@ test("direct producer treats structured 413 as immediate legacy fallback", async
   assert.equal(result.status, 413);
 });
 
+test("direct producer includes a structured rejection detail in its fallback reason", async () => {
+  const result = await postDirectPublicationResult({
+    baseUrl: "https://clawsweeper.openclaw.ai",
+    webhookSecret: "test-secret",
+    payload: directPayload(),
+    fetch: async () =>
+      new Response(
+        JSON.stringify({
+          error: "invalid_direct_publication_plan",
+          fallback_required: true,
+          detail: "invalid direct publication revision",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+  });
+  assert.deepEqual(result, {
+    kind: "fallback",
+    attempts: 1,
+    reason: "invalid_direct_publication_plan: invalid direct publication revision",
+    status: 400,
+  });
+});
+
 test("direct publication flag defaults through workflow wiring while explicit off stays legacy", () => {
   assert.equal(exactReviewDirectPublicationEnabled("1"), true);
   assert.equal(exactReviewDirectPublicationEnabled("true"), true);


### PR DESCRIPTION
## Summary

- return the existing sanitized direct-publication validation reason as `detail` while preserving `error: "invalid_direct_publication_plan"`, `fallback_required: true`, HTTP 400, and every acceptance/classification branch
- append `detail` to the client-visible fallback reason so workflow logs identify the actual validation failure and batch dead-letter fingerprints split by that failure
- cover Worker redaction, client surfacing, downstream SHA-256 fingerprint separation, and the real local Worker/Durable Object HTTP contract

This is diagnosability-only. It does not change retry/permanence classification, which plans are accepted or rejected, or attempt to fix the underlying CodexBar rejection.

## Measured production evidence

`tuple_protocol_invalid` grew from 177 to 191 over about six hours. Of 189 reconciler inventory rows, 178 shared fingerprint `18100482292fa5b48fd215110a0be3a7d261257e337fdd57b748bee5482efac9`, exactly `sha256("Error:invalid_direct_publication_plan")`; 170 belonged to the legitimate generic-fallback target `steipete/CodexBar`. `steipete/CodexBar#2797` failed three times at batch revision 14 on the same morning. Workflow run https://github.com/openclaw/clawsweeper/actions/runs/31357238996 shows review publication succeeded and only canonical record publication failed with the opaque code.

## OpenClaw Bay impact

No Bay change is needed. This enriches an internal publication rejection response and its downstream diagnostic fingerprint. It does not alter Bay's public observer data contract, lifecycle state, or controls.

## pr-behavior-proof

**Claim:** The real Worker and `ExactReviewQueue` Durable Object preserve the existing HTTP 400 classification while returning a sanitized validation-specific `detail`; structurally different invalid plans return different details.

**Exercised surface:** Built dashboard Worker, signed `/internal/exact-review/publication-results` HTTP route, real local Wrangler runtime, real `ExactReviewQueue` Durable Object, and persisted local SQLite initialization.

**Scenario/fixture:** The proof first initializes the Durable Object, kills Wrangler's full process tree, verifies the persisted `exact_review_direct_publication_plans` table, and restarts. It then posts one plan with revision zero and one plan whose canonical record path targets the wrong item.

**Command/environment:** Node 24.19.0 and Wrangler 4.107.0 on macOS: `bash docs/proof/direct-publication-reject-detail/run-proof.sh`.

**Observable result:** `PROOF_RC=0`. Both requests returned HTTP 400 with `error=invalid_direct_publication_plan` and `fallback_required=true`. Details were `invalid direct publication revision` and `direct publication path is outside steipete-CodexBar#2797: records/steipete-CodexBar/items/2798.md`; the proof asserted they differ.

**Container reproduction:** Passed against pushed head `9bf0f83c5f35620580fc15c20354011adc624323` from the clean `--fresh-pr openclaw/clawsweeper#1091` checkout. Crabbox 0.39.0 used provider `local-container`, image/type `node:24-bookworm` / `node_24-bookworm`, and OrbStack-backed Docker 29.4.0. Lease `cbx_9840d67674b6` (`amber-prawn-86a1`) completed with verbatim `PROOF_RC=0`, exit 0, sync 17.849s, command 16.946s, total 34.796s, and `leaseStopped: true`.

**Artifacts/trace:** The proof harness is in `docs/proof/direct-publication-reject-detail/`; its ignored local artifact directory captures both request/response bodies, a runtime transcript, build/install logs, and a redacted Wrangler log.

**Limits:** Local-only synthetic plans and a disposable HMAC secret; no production deployment or mutation. This proves rejection diagnosability, not the underlying CodexBar cause, retry budget behavior, or production traffic volume.

## Validation

- `pnpm run build:all`
- `pnpm run test:no-build`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:dashboard-queue-boundary`
- focused Worker/client/batch tests: 338 passed
- pre-commit local autoreview: clean, no accepted/actionable findings
- committed branch autoreview against `origin/main`: clean, no accepted/actionable findings
