### PR TITLE
docs: align operations guidance with current runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,10 @@ gh api repos/openclaw/clawsweeper/readme --jq '.content' | base64 --decode
 gh api graphql -f query='query { repository(owner:"openclaw", name:"openclaw") { issues(states: OPEN) { totalCount } pullRequests(states: OPEN) { totalCount } } }'
 ```
 
-For throughput/default tuning, inspect and update both `src/clawsweeper.ts` and
-`.github/workflows/sweep.yml`; continuation paths can otherwise keep stale
-defaults.
+For throughput/default tuning, start with `config/automation-limits.json` and
+[`docs/limits.md`](docs/limits.md). `scripts/check-limits.ts` identifies the
+derived docs, Worker values, and the `workflow_dispatch` literals that must stay
+aligned. Effective exact-review admission, publication, and batching overrides
+live in `dashboard/wrangler.toml`; owning fallback behavior lives in
+`dashboard/exact-review-queue.ts`. Update `.github/workflows/sweep.yml` or
+`src/clawsweeper.ts` only when the changed contract is actually owned there.

--- a/README.md
+++ b/README.md
@@ -432,9 +432,10 @@ handles only the selected item, uploads a hash-bound GitHub Actions artifact,
 enqueues a separate durable publication lease, and then releases its review
 lease without checking out or pushing the state repository. The queue retries
 publication independently, so a cancelled publisher does not rerun Codex. The
-source fallback uses a 24-to-48 adaptive publisher range; production pins the
-lane at 50 and enables direct publication plus up to eight concurrent size-8
-batches. The Durable Object validates each artifact's workflow run, queue tuple,
+source fallback uses a 24-to-48 adaptive publisher range; production overrides
+that range with an adaptive minimum/base/maximum of 8/32/40 and enables direct
+publication plus up to eight concurrent size-8 batches. The Durable Object
+validates each artifact's workflow run, queue tuple,
 target, decision digest, file inventory, sizes, and SHA-256 hashes before a
 publisher receives write tokens.
 Publication leases reserve the bounded publisher lane's maximum queue wait;
@@ -720,8 +721,9 @@ yield when priority work is active. Exact-item runs use a durable Worker queue
 that coalesces item deliveries, leases at most 128 concurrent reviews, and admits
 up to 120 active exact reviews per target repository. Other lanes retain the
 checked-in 128-worker scheduling model. A separate 194-slot exact-review
-Actions budget preserves 50 deterministic publication slots plus a 16-slot
-reserve even when all 128 review leases are active.
+Actions budget supports the production maximum of 40 publisher slots, the
+enforced 16-slot control-plane reserve, and 10 additional slots of current
+configuration headroom even when all 128 review leases are active.
 Use `workers.max` first when turning total Codex usage up or down; use
 `lanes.repair.cluster_max_live_runs` to tune the imported legacy cluster-repair
 lane separately, and individual environment overrides only for temporary

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ ClawSweeper is the conservative maintenance bot for OpenClaw repositories. It
 keeps the backlog reviewed, keeps maintainer-visible GitHub comments tidy, and
 turns narrow trusted findings into guarded repair or automerge work.
 
-The current production targets are `openclaw/openclaw`, `openclaw/clawhub`, and
-self-review for `openclaw/clawsweeper`.
+The dashboard Worker's explicit production targets are `openclaw/openclaw`,
+`openclaw/clawhub`, `openclaw/clawsweeper`, and `openclaw/fs-safe`. Additional
+public `openclaw/*` and `steipete/*` repositories can use configured profiles or
+conservative generic fallback review through event dispatch and scheduled
+fanout.
 
 Project vision and boundaries: [`VISION.md`](VISION.md)
 
@@ -37,7 +40,8 @@ At a high level ClawSweeper:
 - automatically opens guarded implementation PRs for viable reviewed issues in
   eligible public `openclaw/*` and `steipete/*` projects outside
   `openclaw/openclaw` and `openclaw/clawhub`
-- can manually review selected code-bearing commits on target `main` branches
+- can review local branch ranges with repository and GitHub access kept local
+  while Codex connects to the configured model service
 - publishes canonical review records to the Cloudflare Worker, action ledgers
   and assets to R2, and the remaining operational state to
   `openclaw/clawsweeper-state`
@@ -340,7 +344,7 @@ maintainer engagement. See
 
 ## How It Works
 
-ClawSweeper is split into four operational lanes:
+ClawSweeper is split into three operational lanes:
 
 - review lane: scheduled and event-driven issue/PR reviews, durable reports, and
   public review comment sync
@@ -427,10 +431,12 @@ Exact event runs skip the bulk planner and shard matrix. The read-only reviewer
 handles only the selected item, uploads a hash-bound GitHub Actions artifact,
 enqueues a separate durable publication lease, and then releases its review
 lease without checking out or pushing the state repository. The queue retries
-publication independently, so a cancelled publisher does not rerun Codex. A
-Durable Object-bounded publisher lane (24 base, adaptively capped at 48)
-validates each artifact's workflow run, queue tuple, target, decision digest,
-file inventory, sizes, and SHA-256 hashes before it receives write tokens.
+publication independently, so a cancelled publisher does not rerun Codex. The
+source fallback uses a 24-to-48 adaptive publisher range; production pins the
+lane at 50 and enables direct publication plus up to eight concurrent size-8
+batches. The Durable Object validates each artifact's workflow run, queue tuple,
+target, decision digest, file inventory, sizes, and SHA-256 hashes before a
+publisher receives write tokens.
 Publication leases reserve the bounded publisher lane's maximum queue wait;
 terminal-run reconciliation releases dead dispatches early. The publisher then
 uses the same review and apply paths with only the
@@ -536,14 +542,13 @@ see [docs/commit-sweeper.md](docs/commit-sweeper.md).
 - Codex runs without GitHub write tokens.
 - Issue/PR event jobs create target write and report-push credentials only after
   Codex exits.
-- Commit review workers give Codex only a read-scoped target token as `GH_TOKEN`
-  so it can inspect mentioned issues, PRs, workflow runs, and commit metadata.
-- Commit write/check credentials are created only after Codex exits.
+- The retired hosted commit-review lane no longer mints target credentials;
+  `pnpm local-review` operates on the local branch range without GitHub writes.
 - CI makes the target checkout read-only for reviews.
 - Reviews fail if Codex leaves tracked or untracked changes behind.
 - Snapshot changes block apply unless the only change is the bot’s own review
   comment.
-- Commit Check Runs are optional and disabled by default.
+- The retired hosted commit-review lane no longer publishes Commit Check Runs.
 
 ### Audit
 
@@ -783,9 +788,8 @@ Token flow:
   context.
 - Apply mode uses the same app token for review comments and closes, so GitHub
   attributes mutations to the app bot account instead of a PAT user.
-- Commit review passes Codex only a read-scoped target token as `GH_TOKEN` for
-  issue/PR/workflow/commit hydration, then creates write/check credentials only
-  after Codex exits.
+- Offline `pnpm local-review` does not mint target write/check credentials or
+  publish hosted commit-review results.
 - The ClawSweeper GitHub App commits only the remaining operational paths to
   `openclaw/clawsweeper-state`; reports publish to the canonical Worker store.
 
@@ -828,6 +832,3 @@ Target repository setup:
 - install the issue/PR dispatcher from
   [docs/target-dispatcher.md](docs/target-dispatcher.md) for exact item event
   reviews
-- optionally set `CLAWSWEEPER_COMMIT_REVIEW_SETTLE_SECONDS=0` for manual
-  backfills where the target commit range is already settled; the default is
-  `60`

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ handles only the selected item, uploads a hash-bound GitHub Actions artifact,
 enqueues a separate durable publication lease, and then releases its review
 lease without checking out or pushing the state repository. The queue retries
 publication independently, so a cancelled publisher does not rerun Codex. The
-source fallback uses a 24-to-48 adaptive publisher range; production overrides
-that range with an adaptive minimum/base/maximum of 8/32/40 and enables direct
+source fallback uses adaptive minimum/base/maximum values of 4/24/48; production
+overrides them with 8/32/40 and enables direct
 publication plus up to eight concurrent size-8 batches. The Durable Object
 validates each artifact's workflow run, queue tuple,
 target, decision digest, file inventory, sizes, and SHA-256 hashes before a

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ weakening the strict bug gate.
 ### Commit Reviews (retired)
 
 The push/manual commit-review lane was retired in July 2026. Use
-`pnpm local-review` for offline branch reviews.
+`pnpm local-review` for GitHub-isolated local branch reviews.
 
 ### Operations
 
@@ -524,8 +524,8 @@ local-container, CI, and Crabbox harness in
 ### Commit Review Lane (retired)
 
 The hosted commit-review lane was retired in July 2026 (zero successful runs in
-its final month). The offline review engine survives as `pnpm local-review`;
-see [docs/commit-sweeper.md](docs/commit-sweeper.md).
+its final month). The local, GitHub-isolated review engine survives as
+`pnpm local-review`; see [docs/commit-sweeper.md](docs/commit-sweeper.md).
 
 ### Safety Model
 
@@ -788,8 +788,9 @@ Token flow:
   context.
 - Apply mode uses the same app token for review comments and closes, so GitHub
   attributes mutations to the app bot account instead of a PAT user.
-- Offline `pnpm local-review` does not mint target write/check credentials or
-  publish hosted commit-review results.
+- GitHub-isolated `pnpm local-review` does not mint target write/check
+  credentials or publish hosted commit-review results; Codex still connects to
+  the configured model service.
 - The ClawSweeper GitHub App commits only the remaining operational paths to
   `openclaw/clawsweeper-state`; reports publish to the canonical Worker store.
 

--- a/docs/commit-sweeper.md
+++ b/docs/commit-sweeper.md
@@ -2,12 +2,11 @@
 
 The hosted commit-review lane (per-commit main reviews, GitHub Checks, and
 commit-finding dispatch) was retired in July 2026 after producing zero
-successful runs in its final month. What remains is the offline review engine
-in `src/commit-sweeper.ts`, used two ways:
+successful runs in its final month. What remains is the local, GitHub-isolated
+review engine in `src/commit-sweeper.ts`, used two ways:
 
-- `pnpm local-review`: a manual, offline pre-PR self-review of the current
-  branch.
-- `clawsweeper review --local-range`: the main sweeper reuses the same offline
+- `pnpm local-review`: a manual pre-PR self-review of the current branch.
+- `clawsweeper review --local-range`: the main sweeper reuses the same local
   envelope for committed-range reviews.
 
 ## Usage
@@ -19,14 +18,16 @@ pnpm local-review -- --base main
 # writes ~/.clawsweeper-local-reviews/run-<sha>-<ts>-<pid>/local-review.md
 ```
 
-It is offline by contract and never contacts GitHub: it requires a clean checkout,
-uses a unique per-run output directory, withholds all GitHub token env vars, skips
-the `gh`-api commit-metadata hydration, points `GH_CONFIG_DIR` at an empty directory,
-disables Codex web search, and explicitly forbids network lookups. Repositories
-without a configured profile are rejected (no foreign-profile fallback). It never
-writes to GitHub — the local Markdown report is the only output.
+It is GitHub-isolated by contract, not air-gapped: it still calls the configured
+Codex model service and requires model authentication and network connectivity.
+The review requires a clean checkout, uses a unique per-run output directory,
+withholds all GitHub token env vars, skips `gh` API commit-metadata hydration,
+points `GH_CONFIG_DIR` at an empty directory, disables Codex web search, and
+forbids other review-time network lookups. Repositories without a configured
+profile are rejected (no foreign-profile fallback). It never writes to GitHub;
+the local Markdown report is the only output.
 
 ## Related Files
 
-- `src/commit-sweeper.ts`: offline review engine and `local-review` CLI
+- `src/commit-sweeper.ts`: local review engine and `local-review` CLI
 - `prompts/review-commit.md`: Codex review prompt

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -61,7 +61,7 @@ The mental model:
 | `workers.minimum_background`               |      16 | Target floor for background progress when enough global capacity is available.        |
 | `lanes.exact_review.max_concurrent`        |     128 | Maximum concurrent exact-item review workflow runs admitted to Codex.                 |
 | `lanes.exact_review.target_max_concurrent` |     120 | Maximum concurrent exact-item review workflow runs one target repository may consume. |
-| `lanes.exact_review.actions_budget`        |     194 | Review plus publication Actions budget; preserves 50 publishers and 16 reserve slots at 128 reviews. |
+| `lanes.exact_review.actions_budget`        |     194 | At 128 reviews and 40 publishers, preserves the 16-slot hard reserve plus 10 slots of headroom.       |
 | `lanes.assist.max`                         |      10 | Maximum concurrent lightweight assist jobs.                                           |
 | `lanes.repair.cluster_max_live_runs`       |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.            |
 
@@ -180,10 +180,11 @@ those priority workers start, normal and hot-intake planners
 count them and reduce their next background wave.
 
 `EXACT_REVIEW_ACTIONS_BUDGET` is deliberately separate from the 128-slot Codex
-worker budget. Its production value is 194: 128 exact reviews, 50 deterministic
-publication members, and 16 control-plane reserve slots. Full review admission
-therefore cannot reduce verdict publication to zero, while repair and broad
-review derivations remain anchored to `workers.max = 128`.
+worker budget. Its production value is 194: 128 exact reviews, up to 40
+publisher slots, the enforced 16-slot control-plane reserve, and 10 slots of
+headroom under the current publication maximum. Full review admission therefore
+cannot reduce verdict publication to zero, while repair and broad review
+derivations remain anchored to `workers.max = 128`.
 
 Fresh webhook work waits for `EXACT_REVIEW_DISPATCH_DEBOUNCE_MS` (90 seconds by
 default) so rapid edits and pushes coalesce before dispatch. Repeated pending
@@ -216,12 +217,13 @@ that is already pending, dispatching, or leased is a semantic dedupe: it does no
 advance the queue revision, revoke a lease, or count as new work.
 
 Exact-review result publication has a separate adaptive Actions lane. Source
-fallbacks start at 24 and rise in steps of 8 up to 48; production currently
-pins minimum, base, and maximum at 50. The controller still records GitHub
-pressure, cooldown, and recovery telemetry, but the equal production minimum
-and maximum keep effective capacity fixed at 50; rate-limit feedback can lower
-the wider source fallback range. Admission leaves 16 slots inside
-`EXACT_REVIEW_ACTIONS_BUDGET` after 128 active exact reviews and 50 publishers.
+fallbacks start at 24 and rise in steps of 8 up to 48; production overrides
+minimum, base, and maximum to 8, 32, and 40. The controller records GitHub
+pressure, cooldown, recovery, and demand telemetry, and can scale within that
+production range. Admission enforces a 16-slot control-plane reserve inside
+`EXACT_REVIEW_ACTIONS_BUDGET`; with 128 active exact reviews and the current
+production maximum of 40 publisher slots, another 10 slots remain as configuration
+headroom rather than protected reserve.
 Its checkout, artifact handling, comment sync, and result routing are
 deterministic control-plane work: they consume GitHub runners, but not Codex
 slots. The comment router and the singleton lease reconciler follow the same

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -217,13 +217,15 @@ advance the queue revision, revoke a lease, or count as new work.
 
 Exact-review result publication has a separate adaptive Actions lane. Source
 fallbacks start at 24 and rise in steps of 8 up to 48; production currently
-pins minimum, base, and maximum at 50. GitHub rate limits still lower the
-adaptive ceiling, and admission leaves 16 slots inside
-`WORKER_BUDGET` after active exact reviews. Its checkout, artifact handling,
-comment sync, and result routing are deterministic
-control-plane work: they consume GitHub runners, but not Codex slots. The
-comment router and the singleton lease reconciler follow the same accounting
-rule. Dashboard Codex capacity therefore counts only jobs whose steps execute
+pins minimum, base, and maximum at 50. The controller still records GitHub
+pressure, cooldown, and recovery telemetry, but the equal production minimum
+and maximum keep effective capacity fixed at 50; rate-limit feedback can lower
+the wider source fallback range. Admission leaves 16 slots inside
+`EXACT_REVIEW_ACTIONS_BUDGET` after 128 active exact reviews and 50 publishers.
+Its checkout, artifact handling, comment sync, and result routing are
+deterministic control-plane work: they consume GitHub runners, but not Codex
+slots. The comment router and the singleton lease reconciler follow the same
+accounting rule. Dashboard Codex capacity therefore counts only jobs whose steps execute
 Codex and does not deduct these control-plane workflows from `workers.max`.
 
 Legacy state-repository publication once limited exact-review preparation to

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -217,8 +217,8 @@ that is already pending, dispatching, or leased is a semantic dedupe: it does no
 advance the queue revision, revoke a lease, or count as new work.
 
 Exact-review result publication has a separate adaptive Actions lane. Source
-fallbacks start at 24 and rise in steps of 8 up to 48; production overrides
-minimum, base, and maximum to 8, 32, and 40. The controller records GitHub
+fallback minimum, base, and maximum are 4, 24, and 48; production overrides
+them to 8, 32, and 40. The controller records GitHub
 pressure, cooldown, recovery, and demand telemetry, and can scale within that
 production range. Admission enforces a 16-slot control-plane reserve inside
 `EXACT_REVIEW_ACTIONS_BUDGET`; with 128 active exact reviews and the current

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -338,10 +338,10 @@ recovery progress, and last classified GitHub pressure failure. `/api/status` re
 `control_plane` compatibility field, but the dashboard no longer renders that
 low-actionability section.
 
-Production pins publication minimum, base, and maximum capacity at 50 even
-though the source fallback remains adaptive from 24 to 48. The controller still
-records failure, cooldown, and recovery telemetry, but the equal production
-minimum and maximum keep its effective capacity fixed. The publication lane also
+Production overrides publication minimum, base, and maximum capacity to 8, 32,
+and 40, while the source fallback remains adaptive from 24 to 48. The controller
+records failure, cooldown, recovery, and demand telemetry and scales within the
+production range. The publication lane also
 exposes `batches` and `direct`: production enables up to eight concurrent size-8
 batches, reserves two fresh-lane members per batch, and enables direct
 publication with retry/batch fallback. Document effective production values from

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -338,6 +338,16 @@ recovery progress, and last classified GitHub pressure failure. `/api/status` re
 `control_plane` compatibility field, but the dashboard no longer renders that
 low-actionability section.
 
+Production pins publication minimum, base, and maximum capacity at 50 even
+though the source fallback remains adaptive from 24 to 48. The controller still
+records failure, cooldown, and recovery telemetry, but the equal production
+minimum and maximum keep its effective capacity fixed. The publication lane also
+exposes `batches` and `direct`: production enables up to eight concurrent size-8
+batches, reserves two fresh-lane members per batch, and enables direct
+publication with retry/batch fallback. Document effective production values from
+`dashboard/wrangler.toml`, not only fallback constants in
+`dashboard/exact-review-queue.ts`.
+
 The standalone **State writer** panel separates the repo-wide serialization
 boundary from exact-review materialization telemetry. After the coordinator
 cutover, `state_writer.coordinator` is authoritative for the active writer,

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -339,8 +339,8 @@ recovery progress, and last classified GitHub pressure failure. `/api/status` re
 low-actionability section.
 
 Production overrides publication minimum, base, and maximum capacity to 8, 32,
-and 40, while the source fallback remains adaptive from 24 to 48. The controller
-records failure, cooldown, recovery, and demand telemetry and scales within the
+and 40, while source fallback values are 4, 24, and 48. The controller records
+failure, cooldown, recovery, and demand telemetry and scales within the
 production range. The publication lane also
 exposes `batches` and `direct`: production enables up to eight concurrent size-8
 batches, reserves two fresh-lane members per batch, and enables direct

--- a/docs/openclaw-bay-demo.md
+++ b/docs/openclaw-bay-demo.md
@@ -30,13 +30,14 @@ design.
 
 ## What It Shows
 
-The five active lanes group the current worker state into:
+The six active lanes group the current worker and durable queue state into:
 
 - Arriving
 - Setting up
 - Reviewing
-- Repairing
-- Applying
+- Publishing
+- Repair cove
+- Applying & writing
 
 An item that advances raises a ready flag before the master sweeper moves it to
 the next reported lane. Any observed new run for the same GitHub item is
@@ -59,6 +60,19 @@ browser animation and does not mutate stored state.
 Repository filters and **Where's my crustacean?** operate entirely on the
 current snapshot. Selecting a crustacean opens the same GitHub and workflow-run
 links exposed by the source worker data.
+
+The exact-review control board above the shoreline separates review admission
+from result publication. It shows current lane totals, bounded 6-hour, 24-hour,
+or 7-day history, and the durable handoff between them. A separate state-writer
+card reports the coordinator that serializes remaining Git-backed operational
+writes. These cards are observational: they expose no queue, recovery, deploy,
+or rollback controls.
+
+Lane totals may exceed the individually rendered crustaceans. The public queue
+projection intentionally bounds its item-reference sample; the overflow drawer
+shows known references and explains when additional counted items fall outside
+that sample. It never invents identities or performs a browser-side GitHub
+lookup to fill the gap.
 
 ## Data And GitHub API Load
 

--- a/docs/queue-service-split-runbook.md
+++ b/docs/queue-service-split-runbook.md
@@ -1,5 +1,12 @@
 # Exact-review queue Worker split runbook
 
+- Status: proposed; not approved for production execution
+- Owner: ClawSweeper maintainers and the designated Cloudflare operator
+- Source of truth: `dashboard/wrangler.toml`,
+  `dashboard/exact-review-queue.ts`, and the deployed Worker settings
+- Last verified:
+  `openclaw/clawsweeper@2cc2c0df8d533677c5ff82cf3b86a148dd869554`
+
 This runbook moves the existing SQLite-backed `ExactReviewQueue` Durable Object
 namespace from the `clawsweeper-status` Worker script to a dedicated Worker
 script. It is a future operational plan only. Do not change either production
@@ -47,6 +54,20 @@ Copy these queue-runtime values to the destination without changing them:
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MS`
 - `EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS`
 - `EXACT_REVIEW_PENDING_SOFT_LIMIT`
+- `EXACT_REVIEW_TARGET_RATE_PER_HOUR`
+- `EXACT_REVIEW_TARGET_BURST`
+- `EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED`
+- `EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED`
+- `EXACT_REVIEW_STATE_REPO`
+- `EXACT_REVIEW_STATE_REF`
+- `EXACT_REVIEW_PUBLICATION_BATCH_SIZE`
+- `EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT`
+- `EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED`
+- `EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS`
+- `EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS`
+- `EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS`
+- `EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS`
+- `EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS`
 - `CLAWSWEEPER_ENABLE_CLAWHUB`, when set in the deployed environment
 - GitHub App identity used for Actions reads and dispatch:
   `CLAWSWEEPER_APP_ID` or `CLAWSWEEPER_APP_CLIENT_ID`, optional
@@ -55,6 +76,10 @@ Copy these queue-runtime values to the destination without changing them:
 
 Keep `STATUS_STORE`, dashboard cache/telemetry variables, assets, dashboard
 cron, custom domain, and `INGEST_TOKEN` on `clawsweeper-status`.
+`STATE_APPEND_DRAIN_LEASE_MS` remains in the checked-in Wrangler configuration,
+but current main no longer reads it after state-append retirement. Do not copy
+that obsolete override to the destination; remove it from the source only in a
+separately reviewed configuration cleanup.
 `CLAWSWEEPER_WEBHOOK_SECRET` can remain on the source while the source router
 authenticates queue writes. If the public queue endpoints move later, copy that
 secret in a separately reviewed route cutover; never print it while comparing

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -266,8 +266,9 @@ ten automatic ClawSweeper-triggered repair iterations. The per-PR cap is total
 across all head SHAs and stops the automatic review/repair loop even when every
 iteration produces a new commit.
 
-Runs for the same job path and mode share the `repair-cluster-worker.yml` concurrency
-group, so repeated dispatches queue instead of racing the same branch.
+Ordinary runs for the same job path share the `repair-cluster-worker.yml`
+concurrency group across modes, so repeated dispatches queue instead of racing
+the same branch. Explicit requeues use a dedicated run-specific group.
 
 For automerge activation and scheduled label sweeps, a dirty or behind merge
 state is enough to dispatch repair. That lets Codex rebase or resolve conflicts

--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -1,16 +1,20 @@
-# Repair containment validation TODO
+# Repair containment validation history
 
 ## Purpose
 
-Move Linux repair-containment failures left from live repair jobs into
-deterministic local tests and a non-mutating production-runner smoke check.
-Live workers should confirm a fix after merge, not be the first place that an
-unsupported syscall or runner capability is discovered.
+This historical handoff records how Linux repair-containment failures were moved
+from live repair jobs into deterministic local tests and a non-mutating
+production-runner smoke check. The work completed in July 2026; active
+containment behavior belongs in the implementation, tests, and repair operations
+documentation rather than this record.
 
-This document is a handoff for a follow-up session. It does not authorize live
-apply/close operations or changes to external pull-request branches.
+This document does not authorize live apply/close operations or changes to
+external pull-request branches.
 
 ## Current status
+
+Completed. PRs #596, #598, #599, and #602 are merged. The checked items below
+are retained as decision history, not outstanding work.
 
 - PR [openclaw/clawsweeper#596](https://github.com/openclaw/clawsweeper/pull/596)
   fixed exact-review lease contention handling and added a legacy readonly
@@ -35,10 +39,9 @@ apply/close operations or changes to external pull-request branches.
   - [run 29423502149](https://github.com/openclaw/clawsweeper/actions/runs/29423502149)
   - [run 29423499463](https://github.com/openclaw/clawsweeper/actions/runs/29423499463)
 
-## Two-PR execution plan
+## Completed two-PR execution plan
 
-This file is the durable cross-session handoff. Keep completion boxes and live
-evidence current as each PR progresses.
+This section preserves the executed cross-session plan and its evidence.
 
 ### PR 1: deterministic policy and one compiled preflight
 
@@ -63,11 +66,9 @@ live repair mutations.
 ### PR 2: production-runner smoke workflow
 
 Status: [PR openclaw/clawsweeper#602](https://github.com/openclaw/clawsweeper/pull/602)
-is open from `agent/containment-blacksmith-smoke`. Full local `pnpm run check`
-and autoreview pass with no actionable findings. The repository's existing
-Crabbox hydration workflow does not contain a Blacksmith Testbox action, so
-delegated Testbox validation stops before lease allocation; the pull request's
-own two-sample workflow is the authoritative remote Blacksmith proof for this PR.
+merged as `cd68a14528558cbc26932629c4bce49f314269b0` on 2026-07-15. Its pull-request
+workflow supplied the authoritative two-sample Blacksmith proof because the
+Crabbox hydration workflow did not contain a Blacksmith Testbox action.
 
 Remote proof for code commit `53304c7ce452e6accc2e0edc866c8131d7900c19`:
 [Actions run 29432924949](https://github.com/openclaw/clawsweeper/actions/runs/29432924949)
@@ -118,7 +119,7 @@ syscall 442 and syscall 444 surfaced as the same generic `[Errno 38] Function
 not implemented` message. PR 1 replaced that with validated stage, syscall, and
 errno fields.
 
-## Required work
+## Completed work
 
 ### P0: deterministic fallback tests
 

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -156,8 +156,10 @@ The cluster worker has two jobs:
    - labels ClawSweeper targets
    - uploads final artifacts
 
-The workflow concurrency group is based on job path and mode, so repeat
-dispatches of the same job queue instead of racing each other.
+The ordinary workflow concurrency group is based on job path only, so repeat
+dispatches and different modes for the same job queue behind its active run.
+Explicit requeues use a dedicated run-specific group so they can replace a
+stale-head worker without cancelling the active run's gate cleanup.
 
 ## Creating Implementation PRs
 

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -2,7 +2,7 @@
 
 For the internal feature map across job creation, PR generation, comment
 commands, finalizers, self-heal, gates, and ledgers, see
-[`docs/INTERNAL_FEATURES.md`](INTERNAL_FEATURES.md).
+[`internal-features.md`](internal-features.md).
 
 For the trusted ClawSweeper-to-ClawSweeper PR repair loop, see
 [`docs/repair/auto-update-prs.md`](auto-update-prs.md).
@@ -72,7 +72,8 @@ pnpm run status -- \
 
 ## Manual Fix PR From Issue or PR Refs
 
-Use `scripts/create-job.ts` when ClawSweeper or a maintainer has identified a
+Use `pnpm run repair:create-job` (implemented by
+`src/repair/create-job.ts`) when ClawSweeper or a maintainer has identified a
 valid issue/PR cluster that should get one implementation PR. It writes one
 idempotent job file and checks for an existing open PR or branch before creating
 another job.
@@ -118,22 +119,12 @@ Keep `CLAWSWEEPER_ALLOW_MERGE=0` unless a human explicitly opens the merge gate.
 
 ## Manual Fix PR From Commit Finding
 
-Use the `commit finding intake` workflow for a ClawSweeper commit report:
-
-```bash
-gh workflow run repair-commit-finding-intake.yml \
-  --repo openclaw/clawsweeper \
-  -f target_repo=openclaw/openclaw \
-  -f commit_sha=<sha> \
-  -f report_repo=openclaw/clawsweeper \
-  -f report_path=records/openclaw-openclaw/commits/<sha>.md
-```
-
-The workflow is idempotent for the commit SHA. It updates the same audit file,
-job file, branch, and PR path on rerun.
-
-If latest `main` no longer needs a fix, the generated artifact allows a clean
-no-PR outcome and the audit file records the skip.
+The hosted commit-review and commit-finding intake workflows were retired in
+July 2026. Do not dispatch `repair-commit-finding-intake.yml`; that workflow no
+longer exists. Existing durable jobs with `job_intent: commit_finding` remain
+executable through the ordinary cluster worker for compatibility. New work
+should start from current issue/PR references or an explicitly prepared manual
+repair job after verifying the finding still applies to current `main`.
 
 ## Security Boundary
 
@@ -306,7 +297,11 @@ Runs for the same job path and mode share a concurrency group. Different cluster
 
 Live preflight hydrates job-provided refs by default and records linked refs without expanding them. Set repo variables `CLAWSWEEPER_MAX_LINKED_REFS` above `0` only for small clusters that need first-hop context and `CLAWSWEEPER_HYDRATE_COMMENTS=1` when comment bodies are necessary evidence; normal scale runs use issue/PR metadata, body excerpts, PR files, and PR checks.
 
-Exact-review producers normally deliver GitHub effects and submit prepared state mutations directly to the dashboard Worker. The legacy exact-review batch publisher remains enabled only to drain already-enqueued and direct-publication fallback items; it is scheduled for removal after that queue stays empty through the migration window.
+Exact-review producers normally deliver GitHub effects and submit prepared state
+mutations directly to the dashboard Worker. Production also keeps batch
+publication enabled for queued and direct-publication fallback items. Treat that
+as an active recovery path: do not remove or bypass it without a separately
+approved retirement plan, an empty-queue observation window, and rollback proof.
 
 ## Maintainer Comment Routing
 

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -293,7 +293,9 @@ This avoids failing on GitHub's "No commits between" response when the repair is
 already represented on `main` or the resumed replacement branch collapsed to an
 empty diff after rebase.
 
-Runs for the same job path and mode share a concurrency group. Different cluster jobs can still run in parallel.
+Ordinary runs for the same job path share one concurrency group across modes.
+Different job paths can still run in parallel, and explicit requeues use a
+dedicated run-specific group.
 
 Live preflight hydrates job-provided refs by default and records linked refs without expanding them. Set repo variables `CLAWSWEEPER_MAX_LINKED_REFS` above `0` only for small clusters that need first-hop context and `CLAWSWEEPER_HYDRATE_COMMENTS=1` when comment bodies are necessary evidence; normal scale runs use issue/PR metadata, body excerpts, PR files, and PR checks.
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -74,12 +74,12 @@ cohort from becoming eligible in lockstep; coordination and ordinary failure
 retries keep their existing timing.
 Review publication and apply/comment sync use separate non-dropping queues.
 The source fallback starts exact-review publication at 24 concurrent publishers
-and can scale to 48, but production pins minimum, base, and maximum capacity at
-50. The adaptive controller still classifies GitHub pressure: a 403/429 or
+and can scale to 48, but production overrides minimum, base, and maximum
+capacity to 8, 32, and 40. The adaptive controller classifies GitHub pressure:
+a 403/429 or
 explicit rate-limit failure records a 15-minute cooldown, while GitHub 5xx
-failures record a 5-minute cooldown. Because production sets the minimum and
-maximum to the same value, those signals do not lower effective capacity below
-50; the source fallback can lower its wider adaptive range. Production batch
+failures record a 5-minute cooldown. Demand and recovery signals scale effective
+capacity within the production range. Production batch
 preparation is enabled for up to eight concurrent size-8 batches, including two
 fresh-lane members per batch. Direct publication is also enabled and falls back
 to the retry/batch path when the direct result is retryable. Apply/comment sync

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -73,13 +73,18 @@ the reported cooldown into its next-attempt timestamp, preventing a parked
 cohort from becoming eligible in lockstep; coordination and ordinary failure
 retries keep their existing timing.
 Review publication and apply/comment sync use separate non-dropping queues.
-Exact-review publication starts at 24 concurrent publishers in the Durable
-Object and scales admission by ready backlog: every 250 ready publications adds
-8 slots, up to 48. Backoff work does not trigger expansion, and scaling down
-does not cancel publishers that already started. A GitHub 403/429 or explicit
-rate-limit failure halves the admission ceiling for 15 minutes; GitHub 5xx
-failures lower it by 8 for 5 minutes. Repeated pressure can reduce admission to 4. After cooldown, every 50 successful
-publications restores 8 slots. Apply/comment sync remains per-target serialized.
+The source fallback starts exact-review publication at 24 concurrent publishers
+and can scale to 48, but production pins minimum, base, and maximum capacity at
+50. The adaptive controller still classifies GitHub pressure: a 403/429 or
+explicit rate-limit failure records a 15-minute cooldown, while GitHub 5xx
+failures record a 5-minute cooldown. Because production sets the minimum and
+maximum to the same value, those signals do not lower effective capacity below
+50; the source fallback can lower its wider adaptive range. Production batch
+preparation is enabled for up to eight concurrent size-8 batches, including two
+fresh-lane members per batch. Direct publication is also enabled and falls back
+to the retry/batch path when the direct result is retryable. Apply/comment sync
+remains per-target serialized. See [`docs/limits.md`](limits.md) for effective values and
+[`docs/live-dashboard.md`](live-dashboard.md) for the public lane telemetry.
 Tuple-aware state reconciliation prevents stale review snapshots from reviving
 closed records.
 
@@ -117,8 +122,7 @@ Failed Codex review backstop:
 
 - exact event review: enabled through the target repository dispatcher
 - scheduled review/apply/audit: not enabled yet
-- issues are review/comment-only; PRs may auto-close only when already
-  implemented on `main`
+- issues and PRs may auto-close only when already implemented on `main`
 
 Generic `openclaw/*` and `steipete/*` repositories:
 
@@ -126,9 +130,9 @@ Generic `openclaw/*` and `steipete/*` repositories:
   the target dispatcher and GitHub App installation are present
 - scheduled review/audit: target fanout dispatches small cursor-based batches
   from `target_inventory.owners`
-- generic OpenClaw issues are review/comment-only; generic OpenClaw PRs may
-  auto-close only when already implemented on the default branch or age-gated
-  mostly implemented there
+- generic OpenClaw issues may auto-close only when already implemented on the
+  default branch; generic OpenClaw PRs may additionally use age-gated mostly
+  implemented there
 - generic `steipete/*` repositories are review/comment-only for issues and PRs
 
 Manual `workflow_dispatch` can override `target_repo`, `item_number`,

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -73,9 +73,9 @@ the reported cooldown into its next-attempt timestamp, preventing a parked
 cohort from becoming eligible in lockstep; coordination and ordinary failure
 retries keep their existing timing.
 Review publication and apply/comment sync use separate non-dropping queues.
-The source fallback starts exact-review publication at 24 concurrent publishers
-and can scale to 48, but production overrides minimum, base, and maximum
-capacity to 8, 32, and 40. The adaptive controller classifies GitHub pressure:
+The source fallback publication minimum, base, and maximum are 4, 24, and 48,
+but production overrides them to 8, 32, and 40. The adaptive controller
+classifies GitHub pressure:
 a 403/429 or
 explicit rate-limit failure records a 15-minute cooldown, while GitHub 5xx
 failures record a 5-minute cooldown. Demand and recovery signals scale effective

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -23,9 +23,11 @@ For issue and PR dispatch, copy this workflow into each target repository as
 Target repositories no longer need a TypeScript profile before exact event
 review can run. Any installed `openclaw/*` repository that is not denied in
 `config/target-repositories.json` uses the conservative generic profile:
-issues stay open, and PRs can auto-close only when already implemented on
-`main`. Add a config entry only when the repo should appear in the dashboard or
-needs repo-specific review guidance.
+issues can auto-close only when already implemented on the default branch, and
+PRs can also use the age-gated `mostly_implemented_on_main` rule. Add a config
+entry only when the repo needs explicit review guidance, toolchain settings, or
+different close rules. Dashboard and scheduled-fanout membership are configured
+separately.
 
 Exact event reviews enable related issue GitHub Search by default so newly
 opened issues get stronger duplicate and adjacent-report context. Set repository

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -6,14 +6,22 @@ failures.
 
 ClawSweeper has two target-repository paths:
 
-- configured dashboard targets in `config/target-repositories.json`
+- configured runtime profiles in `config/target-repositories.json`
 - conservative generic fallbacks for exact event/manual reviews of configured
   owner inventories such as `openclaw/*` and `steipete/*`
 
 `openclaw/openclaw` remains a built-in profile because it has broader
-auto-close policy. Other configured targets default to safer repo-local rules:
-issues are review/comment-only, and PRs may auto-close only when the same
-change is certainly already implemented on `main`.
+auto-close policy. Every other configured profile declares its own issue and PR
+close rules in `apply_close_rules`; do not infer those rules from whether the
+repository appears in the dashboard or receives scheduled work. The current
+configured profiles allow `implemented_on_main` for issues and PRs, and some
+profiles additionally allow age-gated `mostly_implemented_on_main` for PRs.
+
+Dashboard targets are configured separately with `TARGET_REPOS` in
+`dashboard/wrangler.toml`. Scheduled target selection comes from
+`target_inventory`, and apply-enabled targets use the dashboard's
+`APPLY_TARGET_REPOS` and `APPLY_OPTIONAL_TARGET_REPOS`. A runtime profile alone
+does not enable any of those surfaces.
 
 ## Generic Fallbacks
 
@@ -25,8 +33,9 @@ without a TypeScript change. It is intentionally narrow:
 - denied repositories are rejected
 - scheduled fanout is public-only unless a private state publication path exists
 - auto-close policy comes from that owner fallback
-- `openclaw/*` issues cannot be auto-closed; PRs can auto-close only for
-  `implemented_on_main` or age-gated `mostly_implemented_on_main`
+- generic `openclaw/*` issues can auto-close only for
+  `implemented_on_main`; PRs can auto-close for `implemented_on_main` or
+  age-gated `mostly_implemented_on_main`
 - `steipete/*` starts review/comment-only for issues and PRs
 - scheduled dashboard/backfill rows are added only through target fanout
 
@@ -46,10 +55,11 @@ workflow and GitHub App installation.
    `https://github.com/openclaw/clawsweeper/actions`.
 6. Confirm the target item gets one durable ClawSweeper review comment.
 
-For a repo that should appear in the README dashboard or scheduled queues, add
-it to `config/target-repositories.json` with an explicit prompt note and
-close-policy block. Keep the default policy unless the repo has a documented
-reason to allow broader issue closes.
+Add a `config/target-repositories.json` entry when a repository needs explicit
+review guidance, toolchain configuration, or close rules. Dashboard and
+scheduled-queue membership are separate changes; update their owning
+configuration only when that rollout is intended. Keep close rules narrow
+unless the repository has a documented reason for broader policy.
 
 ## Add Many Repositories
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -487,7 +487,7 @@ function landingHero(rootPrefix) {
         <div class="hero-text">
           <p class="eyebrow">OpenClaw - maintenance bot</p>
           <h1>Sideways through the <em>backlog</em>.<br>Sweep what's safe.<br>Leave the rest.</h1>
-          <p class="lede">ClawSweeper is the conservative maintenance bot for OpenClaw. It reviews issues, pull requests, and code-bearing commits; keeps one durable public comment per item; and turns narrow trusted findings into guarded repair or automerge work.</p>
+          <p class="lede">ClawSweeper is the conservative maintenance bot for OpenClaw. It reviews issues and pull requests, can inspect a committed local branch range before submission, keeps one durable public comment per GitHub item, and turns narrow trusted findings into guarded repair or automerge work.</p>
           <div class="cta">
             <a class="cta-primary" href="${rootPrefix}scheduler.html">Read the docs</a>
             <a class="cta-secondary" href="${repoUrl}" rel="noopener">View on GitHub</a>
@@ -518,13 +518,13 @@ function landingBody() {
       "shield",
     ],
     [
-      "Four operational lanes",
-      "Review, apply, repair, and commit review run as separate lanes. Each lane has its own state, gates, and GitHub Actions path.",
+      "Three hosted operational lanes",
+      "Review, apply, and repair run as separate hosted lanes. Local branch review is a pre-submission tool, not a hosted workflow lane.",
       "lanes",
     ],
     [
       "Targeted dispatch",
-      "Target repos forward <code>repository_dispatch</code> for low-latency single-item review or commit-range review without polling.",
+      "Target repos forward <code>repository_dispatch</code> for low-latency single-item review without polling.",
       "bolt",
     ],
     [
@@ -559,7 +559,7 @@ function landingBody() {
     {
       name: "Local Branch Review",
       href: "commit-sweeper.html",
-      desc: "Offline pre-PR self-review of a branch's committed range. Never contacts GitHub.",
+      desc: "Pre-PR review of a committed local branch range. GitHub context stays local while Codex connects to its configured model service.",
     },
   ];
   const laneCards = lanes
@@ -591,7 +591,7 @@ function landingBody() {
 <span class="comment"># guarded close/comment mutations only after live re-fetch</span></code></pre>
         </section>
         <section class="lanes-row" aria-label="The lanes">
-          <h2>Four lanes, one engine</h2>
+          <h2>Three hosted lanes, plus local review</h2>
           <div class="lanes">${laneCards}</div>
         </section>
         <section class="rules" aria-label="Guardrails">

--- a/test/docs-site-theme.test.ts
+++ b/test/docs-site-theme.test.ts
@@ -24,4 +24,9 @@ test("docs site emits an early persistent theme switcher", () => {
   assert.match(html, /themeQuery\?\.addEventListener\('change'/);
   assert.match(html, /setAttribute\('aria-pressed',selected\?'true':'false'\)/);
   assert.match(html, /setAttribute\("content", themeColor\[active\]\)/);
+  assert.match(html, /Three hosted operational lanes/);
+  assert.match(html, /Three hosted lanes, plus local review/);
+  assert.match(html, /GitHub context stays local while Codex connects/);
+  assert.doesNotMatch(html, /Four operational lanes|Four lanes, one engine/);
+  assert.doesNotMatch(html, /commit-range review without polling/);
 });


### PR DESCRIPTION
## Summary

- align target-repository close-policy docs with current profile and fallback rules
- correct scheduler, publication, Bay, and dashboard guidance against current main
- replace broken or retired repair instructions with current commands and status
- correct generated documentation-site landing and local-review network wording

## Problem

ClawSweeper's documentation had drifted from runtime behavior in operator-sensitive
places: target close policy, effective publication capacity, batching/direct
publication, Bay lanes, retired commit review, repair paths, and concurrency.

## Implementation

- distinguish runtime profiles, generic fallbacks, dashboard inventory, scheduled
  fanout, and apply-enabled targets
- document the current production adaptive publication range of 8/32/40, distinct
  4/24/48 source fallbacks, size-8 batching, and direct-publication fallback
- document the 194-slot Actions budget as 128 review slots, up to 40 publisher
  slots, a hard 16-slot control-plane reserve, and 10 slots of current headroom
- update Bay lane names, exact-review controls, state writer, and bounded public
  queue projections
- mark containment validation as history and queue-service split as unapproved
- fix repair links/commands and make retired hosted commit review non-runnable
- align repair concurrency with job-path-only ordinary groups and explicit requeue
- update generated-site landing assertions for three hosted lanes plus local review

## Current-main reconciliation

This branch was rebased from `2cc2c0df8d53` onto current main
`dde38ecb4c74a2b1da1e9e5d607136fd10e0bf65`. No changed file conflicted, but the
source-of-truth audit found that #1094 had replaced the earlier fixed publication
capacity of 50 with adaptive production values 8/32/40. The affected README,
limits, scheduler, and dashboard text was corrected before the rebased branch was
pushed. No runtime, configuration, workflow, queue, or deployment change is in
this PR.

## Validation

At exact head `4664a888ceb33c85d01313c367b78282ba1063a8`:

- `corepack pnpm install --frozen-lockfile` — pass
- `corepack pnpm run check:limits` — pass
- `corepack pnpm run build` — pass
- `node --test test/repository-profiles.test.ts` — pass, 10/10
- `node scripts/build-docs-site.mjs` — pass, 53 pages
- `node --test test/docs-site-theme.test.ts` — pass, 1/1
- `git diff --check origin/main...HEAD` — pass
- thread-aware GitHub review scan — no review threads

Inspectable terminal trace from that head:

```text
HEAD=4664a888ceb33c85d01313c367b78282ba1063a8
source fallback: minimum=4 base=24 maximum=48
production override: minimum=8 base=32 maximum=40
check:limits: PASS
build: PASS
repository profiles: 10/10 PASS
generated docs: 53 pages
docs-site focused test: 1/1 PASS
live queue at 2026-08-10T11:39:07.687Z:
  minimum=8 base=32 maximum=40 capacity=40
  batching=true max_items=8 max_concurrent=8 fresh_reserved=2 direct=true
git diff --check: PASS
```

## Real Behavior Proof

- **Claim:** canonical Markdown and generated landing output describe the current
  target policy, hosted lanes, local-review boundary, and effective production
  publication controls.
- **Exercised surface:** the complete docs-site generator, focused generated-output
  assertions, limits synchronizer, repository-profile tests, current Wrangler
  configuration, queue implementation, and the public read-only queue endpoint.
- **Scenario/environment:** Node 24.13.0 and pnpm 11.10.0 on the exact rebased head;
  read-only `GET /api/exact-review-queue` at `2026-08-10T11:39:07.687Z`.
- **Observed result:** 53 pages generated; focused site test passed 1/1; profile
  tests passed 10/10; the live endpoint reported adaptive publication minimum 8,
  base 32, maximum/capacity 40, batching enabled, size 8, eight concurrent batch
  workers, two fresh members, and direct publication enabled.
- **Artifact/trace:** commands and results above; generated output is reproducible
  from `dist/docs-site/index.html`; fallback constants are in
  `dashboard/exact-review-queue.ts`, and production overrides are in
  `dashboard/wrangler.toml`.
- **Limits:** no Pages deploy, Worker mutation, workflow dispatch, queue mutation,
  gate change, secret access, or production write was performed. Configured
  Crabbox `provider=aws` attempts did not execute repository code: run
  `run_d054cc10128d` / lease `cbx_4803e6c923c4` failed during rsync, and
  `run_9d16fa2a689b` / lease `cbx_a01fbceb8de6` failed SSH during fresh-PR
  checkout. They are transport diagnostics, not claimed proof.

## Review closeout

The rebase review found and corrected two related capacity-wording defects:

- distinguish the enforced 16-slot reserve from 10 slots of configuration headroom
- describe the 40-unit maximum as publisher slots rather than publication members

The current-head ClawSweeper review then found one additional P2: the source
fallback range had omitted its minimum floor. All four affected surfaces now say
`4/24/48`, matching `dashboard/exact-review-queue.ts`; the production override
remains `8/32/40`. The inspectable terminal trace requested by that review is in
the main body above.

Focused validation was rerun after each fix. Final dirty-patch review reported the
values and 194-slot arithmetic consistent with current configuration. Final
committed review at `4664a888ceb33c85d01313c367b78282ba1063a8` against
`origin/main` reported no actionable correctness issues and confirmed alignment
with repository profiles, production Wrangler overrides, publication controller
defaults, and repair workflow concurrency behavior.

## Risks and rollout

- Future changes to `dashboard/wrangler.toml` can drift from prose until the
  follow-on deterministic checker lands.
- Documentation-only change; no rollback or production-state action is required.

## Related work

- CSW-114 documentation audit
- stacked follow-ons: #1095 and #1096
