### PR TITLE
docs: add canonical navigation and ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,6 @@ aligned. Effective exact-review admission, publication, and batching overrides
 live in `dashboard/wrangler.toml`; owning fallback behavior lives in
 `dashboard/exact-review-queue.ts`. Update `.github/workflows/sweep.yml` or
 `src/clawsweeper.ts` only when the changed contract is actually owned there.
+
+Use [`docs/README.md`](docs/README.md) for the documentation map, lifecycle
+states, role ownership, and cross-surface update triggers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 ClawSweeper is the conservative maintenance bot for OpenClaw repositories. This
 guide is for people and coding agents preparing or updating a ClawSweeper pull
 request. It complements the repository's [README](README.md) and
-[AGENTS.md](AGENTS.md); the latter is the binding instruction file for agents.
+[documentation index](docs/README.md). [AGENTS.md](AGENTS.md) is the binding
+instruction file for agents.
 
 ## Before You Start
 
@@ -30,12 +31,20 @@ pnpm run build
 pnpm run check
 ```
 
+Corepack reads the pinned `pnpm@11.10.0` version from `package.json`; do not
+replace it with an unpinned global pnpm command in canonical examples.
+
 Use the narrowest meaningful validation for the changed surface first. For a
 docs-only change, run `git diff --check` and verify the changed links and
 commands. For code, test, workflow, queue, API, UI, package, or integration
 changes, follow `AGENTS.md`: satisfy the real-behavior proof contract and
 mandatory Codex review loop before opening even a draft PR or updating one.
 Only Martin may expressly approve an evidence-in-progress exception.
+
+Documentation-only changes should also classify new pages as active, proposed,
+compatibility-only, or historical. Active runbooks need a role owner, owning
+source, last-verified revision, and concrete update triggers; see the
+[documentation index](docs/README.md#document-lifecycle).
 
 ## Create or Update a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,17 @@ fanout.
 
 Project vision and boundaries: [`VISION.md`](VISION.md)
 
+Documentation by task and audience: [`docs/README.md`](docs/README.md)
+
 ## Contributing
 
 For local setup, PR scope, main-body proof, and the author-owned review loop,
 read [CONTRIBUTING.md](CONTRIBUTING.md) before opening or updating a pull
-request. The guide explains when to use `@clawsweeper re-review`, why a changed
-head or PR body needs fresh evidence, and why readiness is not merge authority.
+request. Use the [documentation index](docs/README.md) to reach architecture,
+configuration, dashboard, policy, and operator references without scanning this
+entire README. The contributing guide explains when to use
+`@clawsweeper re-review`, why a changed head or PR body needs fresh evidence,
+and why readiness is not merge authority.
 
 The OpenClaw-hosted ClawSweeper instance is not a public review service and does
 not provide free reviews for third-party repositories. If you want ClawSweeper

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,159 @@
+# ClawSweeper documentation
+
+- Status: active documentation index
+- Owner: ClawSweeper maintainers
+- Source of truth: the linked repository files and their owning code,
+  configuration, workflows, and tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: a document is added, retired, moved, changes lifecycle, or gains a
+  new canonical owner
+
+ClawSweeper reviews GitHub issues and pull requests, publishes durable results,
+and applies or repairs only through guarded maintainer-controlled paths. Start
+with the task or audience below; this page is a map, not another operator
+manual.
+
+## Start here
+
+| Goal | First page | Next step |
+| --- | --- | --- |
+| Understand the product boundary | [Project vision](../VISION.md) | [Orchestration](orchestration.md) |
+| Set up a development checkout | [Contributing](../CONTRIBUTING.md) | [Local run](../README.md#local-run) |
+| Understand review and scheduling | [Scheduler](scheduler.md) | [Automation limits](limits.md) |
+| Add or operate a target repository | [Target repositories](target-repositories.md) | [Target dispatcher](target-dispatcher.md) |
+| Inspect production without mutation | [Live dashboard](live-dashboard.md) | [OpenClaw Bay](openclaw-bay-demo.md) |
+| Operate repair or automerge | [Repair entry point](repair/README.md) | [Repair operations](repair/operations.md) |
+| Prepare proof for a change | [Contributing](../CONTRIBUTING.md) | [Agent instructions](../AGENTS.md) |
+| Review a local committed range | [Local branch review](commit-sweeper.md) | `pnpm local-review -- --base origin/main` |
+
+Production mutation commands are intentionally not repeated here. Follow the
+linked runbook, confirm its status and source of truth, and keep all execution,
+fix, merge, automerge, deployment, and queue gates closed unless the current
+operator has explicit authority to open them.
+
+## Document lifecycle
+
+Every evergreen page belongs to one of these states:
+
+- **active**: current guidance for a supported surface
+- **proposed**: a future design or runbook that grants no execution approval
+- **compatibility-only**: retained for still-readable state or a supported
+  migration boundary, but not for creating new work
+- **historical**: completed proof or decision history, not current procedure
+
+Active runbooks and volatile configuration references should begin with status,
+role owner, owning source, last-verified revision, and update triggers. “Owner”
+is a responsibility role until maintainers approve a stable GitHub CODEOWNERS
+individual or team. Generated or checked values should name their checker;
+everything else requires human comparison with current main.
+
+## Concepts and architecture
+
+- [Project vision](../VISION.md) — active; product goals and boundaries
+- [Orchestration](orchestration.md) — active; planner, review, publish, apply,
+  and repair shape
+- [Scheduler](scheduler.md) — active and volatile; scheduled and exact-event
+  execution behavior
+- [State storage](state-storage.md) — active; Worker, R2, and Git-backed state
+  ownership
+- [Action ledger](action-ledger.md) — active; mutation receipts and replay
+  boundaries
+- [Work lane](work-lane.md) — active; bounded workflow admission
+- [Review cache](review-cache.md) — active; reusable review-state contract
+
+## Configuration and repository onboarding
+
+- [Automation limits](limits.md) — active; validated by
+  `pnpm run check:limits`
+- [Target repositories](target-repositories.md) — active; profiles, generic
+  fallbacks, inventory, and apply membership
+- [Target dispatcher](target-dispatcher.md) — active; exact-event integration
+- [OpenClaw event hooks](openclaw-event-hooks.md) — active; event routes
+- [Local branch review](commit-sweeper.md) — active local/GitHub-isolated
+  replacement for hosted commit review
+
+## Operations and runbooks
+
+- [Live dashboard](live-dashboard.md) — active; public observer surface and
+  operator diagnostics
+- [Queue-service split runbook](queue-service-split-runbook.md) — proposed;
+  unapproved production migration plan
+- [Repair operations](repair/operations.md) — active; canonical repair operator
+  procedures, trust checks, gates, and token boundaries
+- [Local ClawSweeper skill](local-clawsweeper-skill.md) — active; read-only
+  local exact-item or committed-range review
+
+## Dashboards and observability
+
+- [Live dashboard](live-dashboard.md) — active; Worker status and operational
+  telemetry
+- [OpenClaw Bay](openclaw-bay-demo.md) — active; public six-lane visualization
+- [Triage dashboard](triage-dashboard.md) — active; cached issue triage
+- [PR proof triage](pr-proof-triage-dashboard.md) — active; maintainer proof
+  inspection
+
+## Contributor, review, and proof guidance
+
+- [Contributing](../CONTRIBUTING.md) — active; setup, scope, PR evidence, and
+  author-owned review loop
+- [Agent instructions](../AGENTS.md) — active and binding for coding agents
+- [PR review comments](pr-review-comments.md) — active; review-thread handling
+- [Related issue discovery](related-issue-discovery.md) — active; duplicate and
+  adjacent-report context
+
+`docs/proof/**` contains inspectable artifacts for specific changes. Those
+files support their recorded claim but do not override current runbooks.
+
+## Repair and automerge
+
+- [Repair entry point](repair/README.md) — active; concepts, task map, and local
+  command reference
+- [Repair operations](repair/operations.md) — active; canonical operator
+  procedures
+- [Internal feature map](repair/internal-features.md) — active implementation
+  reference, not an operator runbook
+- [Steerable repair architecture](steerable-repair-automation.md) — active;
+  end-to-end protocol and control boundaries
+- [Trusted PR repair](repair/auto-update-prs.md) — active; autofix/automerge
+  contract
+- [Automatic issue PRs](repair/automatic-issue-prs.md) — active; guarded issue
+  implementation intake
+- [Automerge flow](repair/automerge-flow.md) — active; state machine
+- [Automerge proof](repair/automerge-e2e.md) — active; controlled proof harness
+- [Containment validation history](repair/containment-validation-todo.md) —
+  historical; completed July 2026 work
+
+## Close policy
+
+- [Obsolescence policies](obsolescence-close-policies.md) — active policy map
+- [Unsponsored feature policy](unsponsored-feature-close-policy.md) — active
+- [Product direction policy](product-direction-close-policy.md) — active
+- [Author PR budget policy](author-pr-budget-close-policy.md) — active
+- [Stalled PR policies](stalled-pr-close-policies.md) — active
+
+## Security and special-purpose surfaces
+
+- [Spam scanner](spam-scanner.md) — active; trust and classification boundary
+- Security-sensitive work must use maintainer security handling rather than a
+  normal public PR or public documentation page.
+
+## Update triggers
+
+Review the relevant pages in the same change when any of these surfaces move:
+
+- `config/automation-limits.json` or workflow limit literals: automation limits
+  and scheduler
+- `config/target-repositories.json`, repository profiles, target inventory, or
+  apply membership: target-repository and dispatcher docs
+- exact-review queue schema, retry classification, publication capacity,
+  batching, direct publication, or state writing: scheduler, limits, dashboard,
+  Bay, and queue runbooks
+- dashboard route, projection, or public-field changes: dashboard and Bay docs
+- mutation, close, proof, repair, or merge policy changes: policy pages,
+  CONTRIBUTING, AGENTS, and repair operations
+- workflow retirement or replacement: every command example and compatibility
+  page that names the workflow
+
+The current index and lifecycle labels are human-reviewed. Follow-on automated
+checks validate links, documented commands, and selected configuration-derived
+claims; they do not decide policy or production ownership.

--- a/docs/commit-sweeper.md
+++ b/docs/commit-sweeper.md
@@ -1,5 +1,14 @@
 # Local Branch Review (`local-review`)
 
+- Status: active local/GitHub-isolated review reference; hosted commit review is
+  retired
+- Owner: ClawSweeper maintainers
+- Source of truth: `src/commit-sweeper.ts`, `prompts/review-commit.md`, package
+  scripts, and local-review tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: local range selection, network/token isolation, model-service
+  requirements, output artifacts, or the retired hosted boundary changes
+
 The hosted commit-review lane (per-commit main reviews, GitHub Checks, and
 commit-finding dispatch) was retired in July 2026 after producing zero
 successful runs in its final month. What remains is the local, GitHub-isolated

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1,5 +1,13 @@
 # Automation Limits
 
+- Status: active generated/validated configuration reference
+- Owner: ClawSweeper maintainers
+- Source of truth: `config/automation-limits.json`, Worker overrides, and
+  `scripts/check-limits.ts`
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: worker budgets, lane ratios, workflow literals, or production
+  capacity overrides change; run `pnpm run check:limits`
+
 Read when changing ClawSweeper throughput, Codex fan-out,
 or repair dispatch capacity.
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -1,5 +1,13 @@
 # Live Dashboard
 
+- Status: active observer and operator reference
+- Owner: ClawSweeper maintainers and the designated Cloudflare operator
+- Source of truth: `dashboard/worker.ts`, `dashboard/exact-review-queue.ts`,
+  `dashboard/wrangler.toml`, dashboard tests, and deployed read-only endpoints
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: routes, public fields, queue projections, capacity, alerts,
+  deployment, or state-writer telemetry changes
+
 Read when changing the Cloudflare status dashboard, status ingest contract, or
 operator-facing ClawSweeper observability.
 

--- a/docs/openclaw-bay-demo.md
+++ b/docs/openclaw-bay-demo.md
@@ -1,5 +1,13 @@
 # OpenClaw Bay
 
+- Status: active public observer guide
+- Owner: ClawSweeper maintainers
+- Source of truth: `dashboard/bay-page.ts`, Worker queue projections, Bay tests,
+  and the read-only `/bay-demo` route
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: lane names, stage mapping, projection bounds, control cards,
+  routes, or navigation changes
+
 OpenClaw Bay is a public, indexable, read-only visualisation of the live
 ClawSweeper pipeline. It lives at `/bay-demo` on the existing dashboard Worker
 and turns active work into animated crustaceans moving across a shoreline. It

--- a/docs/queue-service-split-runbook.md
+++ b/docs/queue-service-split-runbook.md
@@ -6,6 +6,8 @@
   `dashboard/exact-review-queue.ts`, and the deployed Worker settings
 - Last verified:
   `openclaw/clawsweeper@2cc2c0df8d533677c5ff82cf3b86a148dd869554`
+- Update when: queue bindings, migrations, runtime variables, routes,
+  publication/state writing, verification, rollback, or approval changes
 
 This runbook moves the existing SQLite-backed `ExactReviewQueue` Durable Object
 namespace from the `clawsweeper-status` Worker script to a dedicated Worker

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -2,6 +2,29 @@
 
 # 🐠 ClawSweeper
 
+- Status: active repair entry point and local command reference
+- Owner: ClawSweeper maintainers
+- Source of truth: repair source, workflows, `package.json`, and focused repair
+  tests; [operations](operations.md) is canonical for live procedures
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: repair modes, command entry points, job/result shape, or linked
+  canonical guides change
+
+## Use the right repair document
+
+| Need | Canonical page |
+| --- | --- |
+| Understand repair concepts, modes, artifacts, or local CLI entry points | This page |
+| Run or recover live repair work | [Operations](operations.md) |
+| Change implementation objects, stages, ledgers, or extension points | [Internal feature map](internal-features.md) |
+| Change trusted PR autofix/automerge behavior | [Auto-updating PRs](auto-update-prs.md) |
+| Understand the end-to-end steerable session protocol | [Steerable repair automation](../steerable-repair-automation.md) |
+
+The operations runbook is the single source for live command trust, mutation
+gates, runner selection, token boundaries, routing, recovery, and promotion.
+This entry point keeps the conceptual model and local command catalog. It does
+not grant authority to open an execution or merge gate.
+
 ClawSweeper is a conservative OpenClaw maintainer tool for one-cluster issue and PR cleanup.
 
 It takes a curated GitHub issue/PR cluster, asks a Codex worker to classify the items, and applies only narrow, auditable cleanup actions when the evidence is strong. It shares the same ClawSweeper repo and GitHub App as the backlog sweeper, but runs as a separate repair lane with stricter mutation gates.
@@ -143,108 +166,39 @@ Full worker prompts, Codex transcripts, and raw artifacts stay in GitHub Actions
 - `autonomous`: adds live cluster preflight and fix-artifact generation. It may recommend and drive a canonical fix path; direct mutation still goes through the fix executor and applicator gates.
 - `route_security`: quarantines true security-sensitive refs without poisoning unrelated cluster work.
 - `needs_human`: only product-direction, trust-boundary, canonical-choice, merge-path, or contributor-credit decisions that remain unclear after the hydrated artifact and single-item review/check/decide pass.
-- Automated reviewer feedback must be cleared during autonomous PR work. Greptile, Codex, Asile, CodeRabbit, Copilot, and similar bot comments must be addressed, proven non-actionable, or escalated before any merge or post-merge closeout recommendation.
-- Merge preflight: no PR can merge until `CLAWSWEEPER_ALLOW_MERGE=1`, security issues are cleared, comments are resolved, review findings are addressed, changed-surface validation is clean, and the pushed head passes exact-head ClawSweeper review plus GitHub checks. With the merge gate closed, ClawSweeper Repair labels merge-ready targets for human review instead of merging.
-- Final base sync: every inner edit, validation, and review attempt stays pinned to one captured base SHA. Before push, ClawSweeper fetches latest `origin/main` exactly once. If main moved, the worker reconciles once, then runs one validation and Codex review against that synchronized base/tree before publication. Validation failures confined to base-identical files outside the repair delta stop as external base blockers instead of consuming repair attempts. The fresh exact-head ClawSweeper review and GitHub checks still gate merge.
-- Repair ladder: make the useful contributor PR mergeable when its branch is writable; same-repo PRs are writable by the GitHub App contents permission even when the raw maintainer-edit flag is false. If a fork push is rejected because the rebase would create or update workflow files without effective workflow permission, publish the already-prepared repair as a base-repo replacement PR instead of rerunning Codex. Otherwise replace draft, stale, unmergeable, uneditable, or unsafe branches with a narrow credited fix PR. When fix PR mode is enabled, "wait or replace" is already answered: replace, preserve credit and labels, then supersede only the source PR that could not be safely updated.
+
+Reviewer-feedback, base-sync, repair-ladder, exact-head, and merge requirements
+are canonical in [Auto-Updating ClawSweeper PRs](auto-update-prs.md). Live gate
+handling and runner/token procedure are canonical in [Operations](operations.md).
 
 ## Maintainer Comment Commands
 
-ClawSweeper can route maintainer comments from target repositories back into the
-cloud repair workflow. It recognizes both command styles:
+ClawSweeper routes trusted review, status, issue implementation, PR repair,
+autofix, automerge, approval, explanation, and stop requests through its
+maintainer comment router. The command matrix, accepted authors and mentions,
+idempotency behavior, execution switch, and recovery procedure are canonical in
+[Operations: Maintainer Comment Routing](operations.md#maintainer-comment-routing).
+The trusted PR state contract and label behavior are canonical in
+[Auto-Updating ClawSweeper PRs](auto-update-prs.md#maintainer-commands).
 
-```text
-/clawsweeper status
-@openclaw-clawsweeper status
-@clawsweeper status
-```
+Keep these boundaries visible from the entry point:
 
-Accepted mentions are `@clawsweeper`, `@clawsweeper[bot]`,
-`@openclaw-clawsweeper`, or `@openclaw-clawsweeper[bot]`.
-
-Only maintainers can trigger it. The router checks GitHub `author_association`
-and accepts `OWNER`, `MEMBER`, and `COLLABORATOR` by default. Contributor and
-unknown comments are ignored without a reply.
-
-Supported commands:
-
-```text
-/review
-/clawsweeper status
-/clawsweeper re-review
-/clawsweeper re-run
-/clawsweeper implement
-/clawsweeper build
-/clawsweeper fix ci
-/clawsweeper address review
-/clawsweeper rebase
-/clawsweeper autofix
-/clawsweeper automerge
-/clawsweeper auto merge
-/clawsweeper approve
-/clawsweeper explain
-/clawsweeper stop
-@clawsweeper re-review
-@clawsweeper re-run
-@clawsweeper review
-@clawsweeper implement
-@clawsweeper fix
-@clawsweeper build
-@clawsweeper create pr
-@clawsweeper fix issue
-@openclaw-clawsweeper fix ci
-@clawsweeper why did automerge stop here?
-```
-
-`status` and `explain` post a short status reply. `review`, `re-review`, and
-`re-run` dispatch ClawSweeper review again for an open issue or PR. Issue and PR
-authors may use only these read-only review commands on their own open item.
-`fix ci`, `address review`,
-and `rebase` dispatch the normal `repair-cluster-worker.yml` repair path, but only for
-existing ClawSweeper PRs identified by the `clawsweeper/*` branch.
-`implement`, `fix`, `build`, `create pr`, and `fix issue` work only on open issues.
-The router creates or reuses one durable `issue-<repo>-<number>` job and
-dispatches the normal repair worker to verify the issue on latest `main` and
-open or update one narrow implementation PR. This lane never merges or closes
-the issue; broad, underspecified, security-sensitive, or already-fixed issues
-become a blocked repair result instead of a public PR.
-Outside `openclaw/openclaw` and `openclaw/clawhub`, the normal review publisher
-also dispatches this same worker for newly reviewed issues and bounded backfill
-from existing open issue reports when automatic issue implementation is
-enabled. Codex discovers the implementation and validation from the
-repository; deterministic intake still blocks protected/security signals,
-opt-outs, stale issue state, queued issue jobs, and duplicate or linked PRs.
-Generated PRs receive `clawsweeper:autogenerated` plus
-`clawsweeper:autofix`, continue through exact-head review/fix/re-review, and
-remain open for manual merge.
-Freeform maintainer mentions such as `@clawsweeper why did automerge stop here?`
-dispatch a read-only assist review. The answer lands in the next ClawSweeper
-comment; action-looking prose can only become existing structured
-recommendations and still passes the normal deterministic gates.
-`autofix` opts an open PR into the bounded review/fix loop and never merges.
-`automerge` opts an open PR into the bounded review/fix/merge loop, but draft
-PRs stay fix-only until GitHub marks them ready for review. `approve` is
-maintainer-only exact-head approval after a human-review pause; it clears pause
-labels and merges only when the normal automerge readiness checks and merge
-gate pass. A later trusted pass for the exact current head also clears stale
-pause labels before continuing automerge. `stop` labels the item for human review.
-It also removes repair-loop labels, so older automerge/autofix commands and
-trusted pass markers cannot continue the loop after the stop.
-
-The router writes an idempotency marker into each reply and records processed
-comments in `results/comment-router.json`. The scheduled workflow is dry by
-default; set `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1` to let scheduled runs post
-replies and dispatch workers.
-
-Scheduled runs also sweep open PRs with `clawsweeper:autofix` or
-`clawsweeper:automerge` labels. When a labelled PR is stale, failing checks, or
-dirty/behind its base branch, the router can synthesize an internal trusted
-repair-loop command and re-enter the normal repair path without waiting for a
-new GitHub comment. `clawsweeper:human-review` still pauses that path.
+- item authors may request read-only review of their own open item; repair and
+  mutation commands require maintainer trust
+- `autofix` never merges, and `automerge` still requires every exact-head,
+  proof, review, check, mergeability, security, and global merge gate
+- issue implementation never merges or closes the source issue
+- `stop` pauses repair and removes continuation labels
+- freeform questions are read-only and cannot bypass structured command gates
 
 ## Local Run
 
 Requires Node 24.
+
+Validation, rendering, dry-run, and artifact-building commands below are local
+development surfaces. Commands that dispatch workflows, pass `--execute`, open
+gates, alter labels, or publish live state are operator-only; use
+[Operations](operations.md) for their authority, preflight, and recovery steps.
 
 ```bash
 # Validate all job files.
@@ -382,6 +336,10 @@ git diff --check
 ```
 
 ## GitHub Actions Setup
+
+This section is the canonical inventory of repair Actions configuration. It
+does not authorize changing a live variable or secret. Gate-window and token
+procedures remain canonical in [Operations](operations.md).
 
 The workflow needs:
 

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -1,5 +1,13 @@
 # Auto-Updating ClawSweeper PRs
 
+- Status: active trusted PR repair/automerge contract
+- Owner: ClawSweeper maintainers
+- Source of truth: comment router, repair worker/executor, finalizers, labels,
+  merge gates, and focused automerge tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: command trust, adoption, repair budgets, labels, validation,
+  exact-head review, merge, or stop/resume behavior changes
+
 Read when: changing ClawSweeper PR repair automation, ClawSweeper review
 integration, comment routing, duplicate dispatch guards, or generated-PR
 marking.

--- a/docs/repair/containment-validation-todo.md
+++ b/docs/repair/containment-validation-todo.md
@@ -1,5 +1,13 @@
 # Repair containment validation history
 
+- Status: historical; completed July 2026
+- Owner: ClawSweeper maintainers
+- Source of truth: the linked merged PRs, workflow runs, containment tests, and
+  current repair operations reference
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: only to correct this historical record or point to a superseding
+  active containment reference
+
 ## Purpose
 
 This historical handoff records how Linux repair-containment failures were moved

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -1,5 +1,13 @@
 # ClawSweeper Internal Feature Map
 
+- Status: active implementation reference; not an operator runbook
+- Owner: ClawSweeper maintainers
+- Source of truth: `src/repair/**`, repair workflows, job/result schemas, and
+  focused repair tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: internal objects, execution stages, routing, ledgers, gates, or
+  extension points change
+
 Read when: changing ClawSweeper automation, debugging a generated PR, wiring
 comment commands, or deciding where a new lane belongs.
 

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -1,5 +1,18 @@
 # Operations
 
+- Status: active canonical repair operator runbook
+- Owner: ClawSweeper maintainers and the authorized repair operator
+- Source of truth: repair workflows/source, current gates, focused tests, and
+  live read-only GitHub state where needed
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: commands, trust checks, gates, tokens, runners, routing,
+  publication, recovery, or promotion rules change
+
+This is the canonical live-operations page. Use the
+[repair entry point](README.md) for concepts and the local CLI catalog, the
+[internal feature map](internal-features.md) for implementation structure, and
+[auto-update PRs](auto-update-prs.md) for the trusted PR state contract.
+
 For the internal feature map across job creation, PR generation, comment
 commands, finalizers, self-heal, gates, and ledgers, see
 [`internal-features.md`](internal-features.md).

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,5 +1,13 @@
 # Issue and PR Scheduler
 
+- Status: active, volatile architecture and operations reference
+- Owner: ClawSweeper maintainers
+- Source of truth: `.github/workflows/sweep.yml`, planner/runtime source,
+  `config/automation-limits.json`, and focused scheduler tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: cadence, fanout, admission, retry, publication, apply, or
+  state-writing behavior changes
+
 Read when changing `.github/workflows/sweep.yml`, `src/clawsweeper.ts` planner
 selection, review cadence, dashboard capacity fields, or GitHub Actions
 concurrency for issue/PR review and apply.

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -1,5 +1,13 @@
 # Steerable Repair Automation
 
+- Status: active end-to-end architecture reference; not a routine runbook
+- Owner: ClawSweeper maintainers
+- Source of truth: repair source/workflows, CrabFleet integration, dashboard
+  telemetry, and controlled behavior proof
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: session lifecycle, steering, runner/auth boundary, capacity,
+  proof, dashboard, or recovery protocol changes
+
 Read this guide to understand how ClawSweeper turns GitHub work into bounded,
 observable, steerable Codex sessions. It covers issue-to-PR work, PR repair,
 GitCrawl cluster intake, GitHub App authentication, durable session resumption,

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -1,5 +1,13 @@
 # Target Repository Dispatcher
 
+- Status: active integration reference
+- Owner: ClawSweeper maintainers and target-repository maintainers
+- Source of truth: the embedded dispatcher workflow, receiver workflow,
+  repository profiles, and dispatcher tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: forwarded events, authentication, payloads, permissions, close
+  authority, or installation steps change
+
 `openclaw/clawsweeper` cannot receive native `issues` or `pull_request` events
 from sibling repositories directly. Target repositories should forward those
 events with `repository_dispatch` so ClawSweeper can run a single-job exact

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -1,5 +1,13 @@
 # Target Repositories
 
+- Status: active configuration and onboarding reference
+- Owner: ClawSweeper maintainers
+- Source of truth: `config/target-repositories.json`, repository profiles,
+  target inventory, dashboard/apply configuration, and profile tests
+- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Update when: profile policy, supported owners, inventory, dashboard targets,
+  apply membership, or onboarding requirements change
+
 Read when enabling ClawSweeper for another OpenClaw repository, changing
 `config/target-repositories.json`, or debugging `Unsupported target repo`
 failures.

--- a/docs/work-lane.md
+++ b/docs/work-lane.md
@@ -195,10 +195,13 @@ lists the opt-out labels. The live dashboard groups those lifecycle events by
 source issue and shows the issue title, current phase, active worker, run, and
 generated PR.
 
-Promote a candidate from this checkout:
+### Operator-only promotion
+
+This is a production mutation path, not developer setup. Follow
+[Repair operations](repair/operations.md), confirm the execution window and
+authority, and run from the repository root:
 
 ```bash
-cd ~/Projects/clawsweeper
 pnpm run repair:create-job -- \
   --from-report records/openclaw-openclaw/items/123.md
 pnpm run repair:validate-job -- jobs/openclaw/inbox/clawsweeper-openclaw-openclaw-123.md

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -11,7 +11,7 @@ const repoEditBase = `${repoUrl}/edit/main/docs`;
 const customDomain = "clawsweeper.bot";
 
 const sections = [
-  ["Start", ["scheduler.md", "work-lane.md"]],
+  ["Start", ["README.md", "scheduler.md", "work-lane.md"]],
   [
     "Lanes",
     [
@@ -173,7 +173,7 @@ function allMarkdown(dir) {
 }
 
 function outPath(rel) {
-  if (rel === "README.md") return "index.html";
+  if (rel === "README.md") return "documentation.html";
   if (rel.endsWith("/README.md")) return rel.replace(/README\.md$/, "index.html");
   return rel.replace(/\.md$/, ".html");
 }
@@ -349,6 +349,10 @@ function rewriteHref(href, currentRel) {
   if (!raw.endsWith(".md")) return href;
   const from = path.posix.dirname(currentRel);
   const target = path.posix.normalize(path.posix.join(from, raw));
+  if (target.startsWith("../")) {
+    const sourcePath = target.replace(/^\.\.\//, "");
+    return `${repoUrl}/blob/main/${sourcePath}${hash ? `#${hash}` : ""}`;
+  }
   let rewritten = outPath(target);
   const currentOut = outPath(currentRel);
   rewritten = path.posix.relative(path.posix.dirname(currentOut), rewritten) || "index.html";

--- a/test/docs-site-theme.test.ts
+++ b/test/docs-site-theme.test.ts
@@ -3,13 +3,14 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-test("docs site emits an early persistent theme switcher", () => {
+test("docs site preserves the landing, documentation hub, and theme controls", () => {
   execFileSync(process.execPath, ["scripts/build-docs-site.mjs"], {
     cwd: process.cwd(),
     stdio: "pipe",
   });
 
   const html = readFileSync("dist/docs-site/index.html", "utf8");
+  const documentationHtml = readFileSync("dist/docs-site/documentation.html", "utf8");
   const themeInit = html.indexOf('const key = "clawsweeper-theme"');
   const styles = html.indexOf("<style>");
 
@@ -29,4 +30,12 @@ test("docs site emits an early persistent theme switcher", () => {
   assert.match(html, /GitHub context stays local while Codex connects/);
   assert.doesNotMatch(html, /Four operational lanes|Four lanes, one engine/);
   assert.doesNotMatch(html, /commit-range review without polling/);
+  assert.match(documentationHtml, /ClawSweeper documentation/);
+  assert.match(documentationHtml, /Start here/);
+  assert.match(documentationHtml, /Document lifecycle/);
+  assert.match(
+    documentationHtml,
+    /github\.com\/openclaw\/clawsweeper\/blob\/main\/CONTRIBUTING\.md/,
+  );
+  assert.doesNotMatch(documentationHtml, /\.\.\/(?:VISION|CONTRIBUTING|AGENTS)\.html/);
 });


### PR DESCRIPTION
## Summary

- add a canonical documentation hub organized by audience, task, category, and lifecycle
- add role ownership, source-of-truth, last-verified, and update-trigger metadata to volatile references
- make repair documentation roles explicit and remove duplicated command-routing and merge-policy prose
- preserve the generated site landing while publishing the new hub at `documentation.html`

## Problem

The repository had no documentation index, so contributors and operators had to infer the right page from a large README and several overlapping repair guides. Volatile runbooks rarely named an owner, source, verification revision, or update trigger. The repair entry point repeated the comment command matrix, trust rules, merge gates, repair ladder, and routing behavior already maintained in the operator and autofix/automerge references.

Adding `docs/README.md` also exposed two generated-site routing assumptions: `docs/README.md` mapped to the same `index.html` as the synthetic landing, and links to root-level Markdown were rewritten to nonexistent escaped `.html` paths.

## Implementation

- create `docs/README.md` with start-here routes, lifecycle definitions, category navigation, update triggers, and explicit historical/proposed boundaries
- link the hub from README, CONTRIBUTING, and AGENTS; document Node 24 plus pinned `pnpm@11.10.0`
- add lightweight metadata to scheduler, limits, dashboard, Bay, target, queue, local-review, containment, and repair references
- assign canonical roles to repair entry, operations, internal feature, steerable architecture, and auto-update documents
- replace duplicated repair comment/gate details with short invariant summaries and canonical links
- separate local development commands from operator-only mutation paths and remove the personal checkout path
- route `docs/README.md` to `documentation.html`, retain the synthetic landing at `index.html`, and rewrite links outside `docs/` to repository source URLs

## Current-main reconciliation

After #1092 merged, this PR's single information-architecture commit was replayed onto current main `9c32c14c65b0551b43a10c2086c0031338ae41e7`. The rebase was conflict-free. Fourteen active-page `Last verified` fields were refreshed from the former stacked head to that merged baseline; the proposed queue-service split runbook retains its own older explicit verification revision. No runtime, configuration, workflow, queue, deployment, or production-state change is included.

## Validation

At exact head `8842fb82e4ab124d10b8b01325e9e33b188b1f72`:

- `corepack pnpm run check:limits` — pass
- `corepack pnpm run build` — pass
- `node scripts/build-docs-site.mjs` — pass, 54 pages
- `node --test test/docs-site-theme.test.ts` — pass, 1/1
- repository-wide relative Markdown link sweep — pass, 74 tracked Markdown files
- evergreen index coverage — pass, all 34 non-proof documentation pages linked
- canonical personal-path scan — pass
- `git diff --check origin/main...HEAD` — pass

Inspectable exact-head trace:

```text
HEAD=8842fb82e4ab124d10b8b01325e9e33b188b1f72
check:limits: PASS
build: PASS
built docs site: dist/docs-site (54 pages)
docs-site focused test: 1/1 PASS
relative Markdown links: PASS (74 files)
evergreen index coverage: PASS (34 pages)
canonical personal-path scan: PASS
git diff --check: PASS
```

## Review closeout

- dirty-patch review of the post-rebase metadata refresh found no functional, accuracy, or maintainability issue
- focused validation was rerun after the refresh
- final committed review against `origin/main` found the documentation reorganization and docs-site routing internally consistent, the synthetic landing preserved, and repository-root Markdown links correctly routed to GitHub; no actionable correctness issues

## Real Behavior Proof

- **Claim:** the static docs build keeps the existing landing at `/`, publishes the new canonical hub at `/documentation.html`, and emits valid links for root-level repository guidance.
- **Exercised surface:** exact-head docs-site generation, focused generated-output assertions, repository-wide relative-link validation, and complete evergreen-index coverage.
- **Scenario/environment:** Node 24.13.0 and pnpm 11.10.0 on exact head `8842fb82e4ab124d10b8b01325e9e33b188b1f72` after replay onto merged main.
- **Observed result:** 54 pages generated; focused test passed 1/1; `index.html` retained the three-hosted-lane landing; `documentation.html` contained the canonical hub and repository-source link for `CONTRIBUTING.md`; all 74 tracked Markdown files passed relative-link validation and all 34 non-proof docs pages were indexed.
- **Artifact/trace:** reproducible generated output in `dist/docs-site/index.html` and `dist/docs-site/documentation.html`; exact terminal trace above.
- **Limits:** documentation and deterministic static-output behavior only. No Pages deploy, Worker mutation, workflow dispatch, queue mutation, gate change, secret access, or production write was performed. An earlier public-PR proof on pre-rebase head `e3614fe3542c711399aaf9000d93a4f1c683b12d` also passed in Crabbox `local-container` run/lease `cbx_120dd6652601` (`crimson-shrimp`) with the Playwright noble image, but that historical run is not substituted for the exact-head trace above.

## Ownership decision

This PR uses the responsibility role “ClawSweeper maintainers.” It deliberately does not add `.github/CODEOWNERS`: repository team discovery was unavailable to the current token, and the inspected organization examples established security/release teams but no approved general-documentation owner. A maintainer should provide the stable individual or team slug before a CODEOWNERS rule is added.

## Risks and rollout

- lifecycle and owner metadata are human-reviewed; PR #1096 adds deterministic checks for links, documented commands, and selected configuration-derived claims, not policy ownership
- repair detail was removed only where a canonical operator or autofix/automerge page already owns it
- documentation/static-site change only; rollback is the squash commit

## Related work

- merged baseline: #1092
- CSW-114 PR C: #1096 deterministic documentation drift checks
