### PR TITLE
docs: add deterministic drift checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ Documentation-only changes should also classify new pages as active, proposed,
 compatibility-only, or historical. Active runbooks need a role owner, owning
 source, last-verified revision, and concrete update triggers; see the
 [documentation index](docs/README.md#document-lifecycle).
+Run `pnpm run check:docs` while editing documentation; the full `pnpm run check`
+gate runs it again through the static-check path.
 
 ## Create or Update a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ lease without checking out or pushing the state repository. The queue retries
 publication independently, so a cancelled publisher does not rerun Codex. The
 source fallback uses adaptive minimum/base/maximum values of 4/24/48; production
 overrides them with 8/32/40 and enables direct
-publication plus up to eight concurrent size-8 batches. The Durable Object
-validates each artifact's workflow run, queue tuple,
+publication plus up to 8 concurrent size-8 batches. The Durable Object validates
+each artifact's workflow run, queue tuple,
 target, decision digest, file inventory, sizes, and SHA-256 hashes before a
 publisher receives write tokens.
 Publication leases reserve the bounded publisher lane's maximum queue wait;

--- a/config/documentation-sync.json
+++ b/config/documentation-sync.json
@@ -1,0 +1,81 @@
+{
+  "version": 1,
+  "sources": [
+    {
+      "path": "dashboard/wrangler.toml",
+      "expect": {
+        "EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT": "8",
+        "EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT": "32",
+        "EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT": "40",
+        "EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED": "1",
+        "EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED": "1",
+        "EXACT_REVIEW_PUBLICATION_BATCH_SIZE": "8",
+        "EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT": "8",
+        "EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED": "1",
+        "EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS": "2",
+        "EXACT_REVIEW_TARGET_RATE_PER_HOUR": "300",
+        "EXACT_REVIEW_TARGET_BURST": "30"
+      },
+      "claims": [
+        {
+          "document": "README.md",
+          "text": "production overrides them with {{EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT}}/{{EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT}}/{{EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT}} and enables direct publication plus up to {{EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT}} concurrent size-{{EXACT_REVIEW_PUBLICATION_BATCH_SIZE}}"
+        },
+        {
+          "document": "docs/scheduler.md",
+          "text": "production overrides them to {{EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT}}, {{EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT}}, and {{EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT}}"
+        },
+        {
+          "document": "docs/scheduler.md",
+          "text": "preparation is enabled for up to {{EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT}} concurrent size-{{EXACT_REVIEW_PUBLICATION_BATCH_SIZE}} batches"
+        },
+        {
+          "document": "docs/scheduler.md",
+          "text": "including {{EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS}} fresh-lane members per batch"
+        },
+        {
+          "document": "docs/live-dashboard.md",
+          "text": "Production overrides publication minimum, base, and maximum capacity to {{EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT}}, {{EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT}}, and {{EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT}}"
+        },
+        {
+          "document": "docs/live-dashboard.md",
+          "text": "production enables up to {{EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT}} concurrent size-{{EXACT_REVIEW_PUBLICATION_BATCH_SIZE}} batches"
+        },
+        {
+          "document": "docs/limits.md",
+          "text": "production overrides them to {{EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT}}, {{EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT}}, and {{EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT}}"
+        },
+        {
+          "document": "docs/limits.md",
+          "text": "production now admits {{EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT}} preparation batches"
+        },
+        {
+          "document": "docs/limits.md",
+          "text": "durable {{EXACT_REVIEW_TARGET_RATE_PER_HOUR}}-review/hour budget with a {{EXACT_REVIEW_TARGET_BURST}}-item burst"
+        },
+        {
+          "document": "docs/scheduler.md",
+          "text": "total review admission target: {{EXACT_REVIEW_TARGET_RATE_PER_HOUR}} items/hour across the fleet"
+        },
+        {
+          "document": "docs/scheduler.md",
+          "text": "with a {{EXACT_REVIEW_TARGET_BURST}}-item burst"
+        }
+      ]
+    },
+    {
+      "path": "config/target-repositories.json",
+      "expect": {
+        "generic_fallbacks.0.apply_close_rules.issue.0": "implemented_on_main",
+        "generic_fallbacks.0.apply_close_rules.pull_request.0": "implemented_on_main",
+        "generic_fallbacks.0.apply_close_rules.pull_request.1": "mostly_implemented_on_main"
+      },
+      "claims": [
+        {
+          "document": "docs/target-repositories.md",
+          "text": "generic `openclaw/*` issues can auto-close only for `{{generic_fallbacks.0.apply_close_rules.issue.0}}`; PRs can auto-close for `{{generic_fallbacks.0.apply_close_rules.pull_request.0}}` or age-gated `{{generic_fallbacks.0.apply_close_rules.pull_request.1}}`"
+        }
+      ]
+    }
+  ]
+}

--- a/dashboard/wrangler.toml
+++ b/dashboard/wrangler.toml
@@ -73,7 +73,7 @@ EXACT_REVIEW_PENDING_SOFT_LIMIT = "600"
 # takes effect. Interactive exact-event reviews keep their independent lane.
 EXACT_REVIEW_TARGET_RATE_PER_HOUR = "300"
 EXACT_REVIEW_TARGET_BURST = "30"
-# Keep each mutation lease at 8 while allowing four isolated workflows to prepare
+# Keep each mutation lease at 8 while allowing eight isolated workflows to prepare
 # concurrently. Final commits still cross the single state-writer coordinator.
 # A full-window publish moves ~2k paths and observed ~40 min; the drain lease
 # must outlive it or the ack lands after expiry and the cycle makes no progress.
@@ -84,8 +84,8 @@ EXACT_REVIEW_STATE_REPO = "openclaw/clawsweeper-state"
 EXACT_REVIEW_STATE_REF = "state"
 EXACT_REVIEW_PUBLICATION_BATCH_SIZE = "8"
 EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT = "8"
-# Reserve two members for recent protocol-v2 tuples that still match the
-# queue's current source revision. The other six members keep draining FIFO.
+# Reserve 2 members for recent protocol-v2 tuples that still match the
+# queue's current source revision. The other 6 members keep draining FIFO.
 EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED = "1"
 EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS = "2"
 EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS = "900000"

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,6 +154,18 @@ Review the relevant pages in the same change when any of these surfaces move:
 - workflow retirement or replacement: every command example and compatibility
   page that names the workflow
 
-The current index and lifecycle labels are human-reviewed. Follow-on automated
-checks validate links, documented commands, and selected configuration-derived
-claims; they do not decide policy or production ownership.
+## Automated drift checks
+
+`pnpm run check:docs` validates exact-case relative links and Markdown anchors,
+documented package scripts, workflow files, repository source paths, and the
+selected configuration-derived claims in
+`config/documentation-sync.json`. It runs through the existing static check and
+CI path. Add a manifest claim when volatile production configuration is quoted
+as a concrete value in prose. Stage newly added files before running the check
+so its repository inventory matches the proposed commit rather than unrelated
+untracked workspace contents.
+
+The check deliberately does not crawl external URLs, infer policy, assign
+ownership, or treat historical proof commands and paths as current contracts.
+The index, lifecycle labels, and whether a configuration claim should become
+policy remain human-reviewed.

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -240,7 +240,7 @@ Codex and does not deduct these control-plane workflows from `workers.max`.
 
 Legacy state-repository publication once limited exact-review preparation to
 four concurrent size-8 batches. Canonical Worker publication removes that
-shared Git writer constraint, so production now admits eight preparation
+shared Git writer constraint, so production now admits 8 preparation
 batches (up to 64 publication members) while retaining the Durable Object's
 transactional SQLite ownership boundaries.
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -350,7 +350,7 @@ Production overrides publication minimum, base, and maximum capacity to 8, 32,
 and 40, while source fallback values are 4, 24, and 48. The controller records
 failure, cooldown, recovery, and demand telemetry and scales within the
 production range. The publication lane also
-exposes `batches` and `direct`: production enables up to eight concurrent size-8
+exposes `batches` and `direct`: production enables up to 8 concurrent size-8
 batches, reserves two fresh-lane members per batch, and enables direct
 publication with retry/batch fallback. Document effective production values from
 `dashboard/wrangler.toml`, not only fallback constants in

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -136,8 +136,8 @@ Each cluster job:
 4. Runs Codex with repo-local policy prompts and JSON output schema in a read-only sandbox when a planning pass is needed. Adopted automerge/autofix PR repairs skip this read-only model pass after live hydration and emit a generic fix artifact directly.
 5. Writes structured run artifacts under `.clawsweeper-repair/runs/`.
 6. Reviews the worker artifact with deterministic safety checks.
-7. Executes credited fix artifacts through `scripts/execute-fix-artifact.ts` when the fix gate is open: repair a writable contributor branch first, treating same-repo head branches as writable even when GitHub reports `maintainer_can_modify=false`; otherwise raise a narrow replacement PR, copy source labels, add non-bot source PR authors as replacement co-authors, and close the uneditable source PR after the replacement push succeeds.
-8. Applies guarded close/comment and explicit merge actions through `scripts/apply-result.ts`.
+7. Executes credited fix artifacts through `src/repair/execute-fix-artifact.ts` when the fix gate is open: repair a writable contributor branch first, treating same-repo head branches as writable even when GitHub reports `maintainer_can_modify=false`; otherwise raise a narrow replacement PR, copy source labels, add non-bot source PR authors as replacement co-authors, and close the uneditable source PR after the replacement push succeeds.
+8. Applies guarded close/comment and explicit merge actions through `src/repair/apply-result.ts`.
 9. Publishes a sanitized result ledger back to `openclaw/clawsweeper-state`
    under `results/`, `jobs/openclaw/closed/`, `repair-apply-report.json`, and
    `notifications/`; the external dashboard and Discord notification dedupe
@@ -179,7 +179,7 @@ maintainer comment router. The command matrix, accepted authors and mentions,
 idempotency behavior, execution switch, and recovery procedure are canonical in
 [Operations: Maintainer Comment Routing](operations.md#maintainer-comment-routing).
 The trusted PR state contract and label behavior are canonical in
-[Auto-Updating ClawSweeper PRs](auto-update-prs.md#maintainer-commands).
+[Auto-Updating ClawSweeper PRs](auto-update-prs.md).
 
 Keep these boundaries visible from the entry point:
 

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -56,7 +56,7 @@ job. That is the primary duplicate-PR guard.
 
 Path: `.clawsweeper-repair/runs/<run>/cluster-plan.json`
 
-Created by `scripts/plan-cluster.ts`. It hydrates the listed GitHub refs,
+Created by `src/repair/plan-cluster.ts`. It hydrates the listed GitHub refs,
 linked refs, labels, bodies, comments, PR files, PR reviews, PR review
 comments, checks, and current `main` state. The Codex worker receives this as
 its live evidence bundle.
@@ -65,11 +65,11 @@ its live evidence bundle.
 
 Path: `.clawsweeper-repair/runs/<run>/result.json`
 
-Created by `scripts/run-worker.ts` via `codex exec` using
+Created by `src/repair/run-worker.ts` via `codex exec` using
 `schema/repair/codex-result.schema.json`. The worker can recommend actions and fix
 artifacts, but it must not mutate GitHub directly.
 
-`scripts/review-results.ts` validates the result before any follow-up lane
+`src/repair/review-results.ts` validates the result before any follow-up lane
 trusts it.
 
 Long Codex calls emit periodic `[clawsweeper repair] ... still running` log
@@ -171,7 +171,7 @@ stale-head worker without cancelling the active run's gate cleanup.
 
 ## Creating Implementation PRs
 
-Script: `scripts/execute-fix-artifact.ts`
+Script: `src/repair/execute-fix-artifact.ts`
 
 This is the PR creation and branch repair engine.
 
@@ -215,7 +215,7 @@ Generated ClawSweeper PRs are marked by:
 - branch prefix: `clawsweeper/`
 - committed repair job metadata for the branch cluster id
 
-The `clawsweeper` label is a reporting hint from `scripts/tag-clawsweeper-targets.ts`,
+The `clawsweeper` label is a reporting hint from `src/repair/tag-clawsweeper-targets.ts`,
 not a PR identity boundary.
 
 Current operational gotcha: OpenClaw's PR queue policy can close PRs when the
@@ -307,7 +307,7 @@ label.
 
 ## Applying Comments, Closures, And Merges
 
-Script: `scripts/apply-result.ts`
+Script: `src/repair/apply-result.ts`
 
 This script owns safe GitHub mutations from reviewed worker results.
 
@@ -341,7 +341,7 @@ instead of merging.
 
 ## Post-Flight Finalization
 
-Script: `scripts/post-flight.ts`
+Script: `src/repair/post-flight.ts`
 
 Post-flight watches the PRs that `execute-fix-artifact` opened or repaired.
 It waits for merge readiness, validates merge preflight, and either:
@@ -532,7 +532,7 @@ instead of leaving duplicate crustacean notes.
 
 ## Label Backfill
 
-Script: `scripts/tag-clawsweeper-targets.ts`
+Script: `src/repair/tag-clawsweeper-targets.ts`
 
 This script labels ClawSweeper-created or ClawSweeper-tracked PRs/issues in the
 target repo. It helps downstream tools and maintainers distinguish generated
@@ -549,9 +549,9 @@ truth.
 
 Scripts:
 
-- `scripts/sweep-openclaw-jobs.ts`
-- `scripts/promote-stuck-jobs.ts`
-- `scripts/requeue-job.ts`
+- `src/repair/sweep-openclaw-jobs.ts`
+- `src/repair/promote-stuck-jobs.ts`
+- `src/repair/requeue-job.ts`
 
 These scripts manage the ClawSweeper backlog:
 
@@ -565,8 +565,8 @@ inventory and dispatch pressure.
 
 ## Dashboard Publishing
 
-Workflow: `.github/workflows/publish-results.yml`
-Script: `scripts/publish-result.ts`
+Workflow: `.github/workflows/repair-publish-results.yml`
+Script: `src/repair/publish-result.ts`
 
 Publishing turns raw run artifacts into durable, sanitized summaries. It updates
 the README dashboard, per-cluster markdown reports, and aggregate JSON ledgers.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -88,7 +88,7 @@ a 403/429 or
 explicit rate-limit failure records a 15-minute cooldown, while GitHub 5xx
 failures record a 5-minute cooldown. Demand and recovery signals scale effective
 capacity within the production range. Production batch
-preparation is enabled for up to eight concurrent size-8 batches, including two
+preparation is enabled for up to 8 concurrent size-8 batches, including 2
 fresh-lane members per batch. Direct publication is also enabled and falls back
 to the retry/batch path when the direct result is retryable. Apply/comment sync
 remains per-target serialized. See [`docs/limits.md`](limits.md) for effective values and

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "test:coverage:changed:no-build": "node scripts/run-node-tests.mjs fix-prompt-builder -- --experimental-test-coverage --test-coverage-include='dist/repair/fix-prompt-builder.js' --test-coverage-lines=85 --test-coverage-branches=85 --test-coverage-functions=85",
     "check:active-surface": "node scripts/check-active-surface.ts",
     "check:dashboard-queue-boundary": "node scripts/check-dashboard-queue-boundary.ts",
+    "check:docs": "node scripts/check-docs.mjs",
     "check:limits": "node scripts/check-limits.ts",
     "lint": "pnpm run \"/^lint:.*/\"",
     "lint:src": "oxlint src --ignore-pattern \"src/repair/**\" --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness",
@@ -108,7 +109,7 @@
     "format:check": "oxfmt --check src scripts test dashboard package.json tsconfig.json tsconfig.repair.json tsconfig.dashboard.json .oxfmtrc.json config schema .github/actions .github/workflows",
     "oxformat": "pnpm run format",
     "oxformat:check": "pnpm run format:check",
-    "check:static": "pnpm run \"/^(check:active-surface|check:dashboard-queue-boundary|check:limits|format:check)$/\"",
+    "check:static": "pnpm run \"/^(check:active-surface|check:dashboard-queue-boundary|check:docs|check:limits|format:check)$/\"",
     "check:parallel": "pnpm run check:static && pnpm run build:all && pnpm run lint && pnpm run test:coverage:changed:no-build && pnpm run test:coverage:no-build",
     "check": "pnpm run check:parallel",
     "check:changed": "pnpm run check",
@@ -125,6 +126,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
+    "markdown-it": "^15.0.0",
     "oxfmt": "^0.58.0",
     "oxlint": "^1.73.0",
     "oxlint-tsgolint": "0.24.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      markdown-it:
+        specifier: ^15.0.0
+        version: 15.0.0
       oxfmt:
         specifier: ^0.58.0
         version: 0.58.0
@@ -427,6 +430,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  argparse@3.0.0:
+    resolution: {integrity: sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
+  markdown-it@15.0.0:
+    resolution: {integrity: sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==}
+    hasBin: true
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
+
   oxfmt@0.58.0:
     resolution: {integrity: sha512-8feG/7NVEHDVwc1OUpP6Pks+TnaDFUw2jLLFIMi5bcmmwxAX2wBQvjSzj62RRTYBf2Op1Wt8xbkmagmPTR5ETg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -457,6 +477,10 @@ packages:
       vite-plus:
         optional: true
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -465,6 +489,9 @@ packages:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -672,6 +699,25 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  argparse@3.0.0: {}
+
+  entities@8.0.0: {}
+
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
+  markdown-it@15.0.0:
+    dependencies:
+      argparse: 3.0.0
+      entities: 8.0.0
+      linkify-it: 6.1.0
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 3.0.0
+
+  mdurl@2.1.0: {}
+
   oxfmt@0.58.0:
     dependencies:
       tinypool: 2.1.0
@@ -728,6 +774,8 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.73.0
       oxlint-tsgolint: 0.24.0
 
+  punycode.js@2.3.1: {}
+
   tinypool@2.1.0: {}
 
   typescript@7.0.2:
@@ -752,6 +800,8 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
+
+  uc.micro@3.0.0: {}
 
   undici-types@8.3.0: {}
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -301,7 +301,6 @@ function inlineText(token) {
 
 function githubSlug(value) {
   return value
-    .replace(/<[^>]+>/g, "")
     .replace(/[`*~]/g, "")
     .toLowerCase()
     .replace(/[^\p{L}\p{N}\s_-]/gu, "")

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,0 +1,568 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import MarkdownIt from "markdown-it";
+
+const markdown = new MarkdownIt({ html: true });
+
+const MARKDOWN_ROOTS = [
+  "README.md",
+  "CONTRIBUTING.md",
+  "AGENTS.md",
+  "VISION.md",
+  "docs",
+  "instructions",
+  ".github/pull_request_template.md",
+];
+const REPOSITORY_PATH_PREFIXES = [
+  ".github/",
+  "config/",
+  "dashboard/",
+  "docs/",
+  "instructions/",
+  "scripts/",
+  "src/",
+  "test/",
+];
+const PNPM_BUILT_INS = new Set([
+  "add",
+  "approve-builds",
+  "audit",
+  "bin",
+  "cache",
+  "cat-file",
+  "cat-index",
+  "clean",
+  "config",
+  "create",
+  "dedupe",
+  "deploy",
+  "dlx",
+  "env",
+  "exec",
+  "fetch",
+  "find-hash",
+  "i",
+  "ignored-builds",
+  "import",
+  "init",
+  "install",
+  "licenses",
+  "link",
+  "list",
+  "ln",
+  "ls",
+  "outdated",
+  "pack",
+  "patch",
+  "patch-commit",
+  "patch-remove",
+  "prune",
+  "publish",
+  "rb",
+  "rebuild",
+  "remove",
+  "rm",
+  "root",
+  "rt",
+  "runtime",
+  "self-update",
+  "stage",
+  "store",
+  "unlink",
+  "up",
+  "update",
+  "why",
+]);
+
+export function checkDocumentation(root = process.cwd()) {
+  const inventory = buildInventory(root);
+  const packageJson = readJson(path.join(root, "package.json"));
+  const packageScripts = new Set(Object.keys(packageJson.scripts ?? {}));
+  const markdownFiles = collectMarkdownFiles(root, inventory);
+  const findings = [];
+
+  for (const relativeFile of markdownFiles) {
+    const text = fs.readFileSync(path.join(root, relativeFile), "utf8");
+    checkLinks({ root, relativeFile, text, inventory, findings });
+    if (!relativeFile.startsWith("docs/proof/")) {
+      checkDocumentedCommands({ relativeFile, text, packageScripts, inventory, findings });
+    }
+  }
+
+  checkConfiguredClaims({ root, inventory, findings });
+  return findings.sort(compareFindings);
+}
+
+function buildInventory(root) {
+  const exact = new Set();
+  const lower = new Map();
+
+  try {
+    const tracked = execFileSync("git", ["ls-files", "-z", "--cached"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    for (const relative of tracked.split("\0").filter(Boolean)) {
+      if (!fs.existsSync(path.join(root, relative))) continue;
+      addInventoryEntry(relative.replace(/\\/g, "/"));
+    }
+    return { exact, lower };
+  } catch {
+    // Standalone fixture directories are intentionally supported by tests.
+  }
+
+  function visit(absolute, relative = "") {
+    for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+      if (entry.name === ".git" || entry.name === "node_modules" || entry.name === "dist") {
+        continue;
+      }
+      const childRelative = relative ? `${relative}/${entry.name}` : entry.name;
+      addInventoryEntry(childRelative);
+      if (entry.isDirectory()) visit(path.join(absolute, entry.name), childRelative);
+    }
+  }
+
+  visit(root);
+  return { exact, lower };
+
+  function addInventoryEntry(relative) {
+    let entry = relative;
+    while (entry) {
+      exact.add(entry);
+      const folded = entry.toLowerCase();
+      if (!lower.has(folded)) lower.set(folded, entry);
+      entry = path.posix.dirname(entry);
+      if (entry === ".") break;
+    }
+  }
+}
+
+function collectMarkdownFiles(root, inventory) {
+  return [...inventory.exact]
+    .filter(
+      (entry) =>
+        entry.endsWith(".md") &&
+        MARKDOWN_ROOTS.some(
+          (markdownRoot) => entry === markdownRoot || entry.startsWith(`${markdownRoot}/`),
+        ) &&
+        fs.statSync(path.join(root, entry)).isFile(),
+    )
+    .sort();
+}
+
+function checkLinks({ root, relativeFile, text, inventory, findings }) {
+  const environment = {};
+  const tokens = markdown.parse(text, environment);
+  const renderedTargets = new Set();
+  for (const token of tokens) {
+    if (token.type !== "inline") continue;
+    let line = (token.map?.[0] ?? 0) + 1;
+    for (const child of token.children ?? []) {
+      if (child.type === "softbreak" || child.type === "hardbreak") {
+        line += 1;
+        continue;
+      }
+      const attribute = child.type === "image" ? "src" : child.type === "link_open" ? "href" : null;
+      if (!attribute) continue;
+      const target = child.attrGet(attribute);
+      if (!target) continue;
+      renderedTargets.add(target);
+      checkLinkTarget(target, line);
+    }
+  }
+  const referenceLines = referenceDefinitionLines(text);
+  for (const [label, reference] of Object.entries(environment.references ?? {})) {
+    if (!renderedTargets.has(reference.href)) {
+      checkLinkTarget(reference.href, referenceLines.get(label) ?? 1);
+    }
+  }
+
+  function checkLinkTarget(rawTarget, line) {
+    let target = rawTarget.trim().replace(/\\([()\\ ])/g, "$1");
+    if (target.startsWith("<") && target.includes(">"))
+      target = target.slice(1, target.indexOf(">"));
+    else target = target.split(/\s+["']/)[0];
+    if (!target || /^(?:[a-z]+:|\/\/)/i.test(target)) return;
+
+    const [rawPath, rawAnchor] = target.split("#", 2);
+    let decodedPath;
+    try {
+      decodedPath = decodeURIComponent(rawPath.split("?", 1)[0]);
+    } catch {
+      addFinding(findings, relativeFile, line, "link", `malformed percent-encoding: ${target}`);
+      return;
+    }
+    const resolved = decodedPath
+      ? decodedPath.startsWith("/")
+        ? normalizeRelative(decodedPath.slice(1))
+        : normalizeRelative(path.posix.join(path.posix.dirname(relativeFile), decodedPath))
+      : relativeFile;
+
+    if (!inventory.exact.has(resolved)) {
+      const actual = inventory.lower.get(resolved.toLowerCase());
+      addFinding(
+        findings,
+        relativeFile,
+        line,
+        "link",
+        actual
+          ? `target case does not match repository entry: ${resolved} (actual: ${actual})`
+          : `target does not exist: ${resolved}`,
+      );
+      return;
+    }
+
+    const anchorDocument = resolved.endsWith(".md")
+      ? resolved
+      : inventory.exact.has(`${resolved}/README.md`)
+        ? `${resolved}/README.md`
+        : null;
+    if (rawAnchor && anchorDocument) {
+      const targetText = fs.readFileSync(path.join(root, anchorDocument), "utf8");
+      const anchors = markdownAnchors(targetText);
+      let anchor;
+      try {
+        anchor = decodeURIComponent(rawAnchor);
+      } catch {
+        addFinding(
+          findings,
+          relativeFile,
+          line,
+          "anchor",
+          `malformed percent-encoding: #${rawAnchor}`,
+        );
+        return;
+      }
+      if (!anchors.has(anchor)) {
+        addFinding(
+          findings,
+          relativeFile,
+          line,
+          "anchor",
+          `#${rawAnchor} does not exist in ${anchorDocument}`,
+        );
+      }
+    }
+  }
+}
+
+function referenceDefinitionLines(text) {
+  const lines = new Map();
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
+    const definition = line.match(/^\s{0,3}\[([^\]]+)\]:/);
+    if (!definition) continue;
+    lines.set(markdown.utils.normalizeReference(definition[1]), index + 1);
+  }
+  return lines;
+}
+
+function markdownAnchors(text) {
+  const anchors = new Set();
+  const occurrences = new Map();
+  const tokens = markdown.parse(text, {});
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.type === "inline" && tokens[index - 1]?.type === "heading_open") {
+      const base = githubSlug(inlineText(token));
+      const count = occurrences.get(base) ?? 0;
+      occurrences.set(base, count + 1);
+      anchors.add(count === 0 ? base : `${base}-${count}`);
+    }
+    const htmlTokens = [token, ...(token.children ?? [])].filter((item) =>
+      ["html_block", "html_inline"].includes(item.type),
+    );
+    for (const htmlToken of htmlTokens) {
+      for (const match of htmlToken.content.matchAll(
+        /<a\s+(?:[^>]*\s)?(?:id|name)=["']([^"']+)["']/gi,
+      )) {
+        anchors.add(match[1]);
+      }
+    }
+  }
+  return anchors;
+}
+
+function inlineText(token) {
+  return (token.children ?? [])
+    .map((child) => {
+      if (child.type === "text" || child.type === "code_inline" || child.type === "image") {
+        return child.content;
+      }
+      if (child.type === "softbreak" || child.type === "hardbreak") return " ";
+      return "";
+    })
+    .join("");
+}
+
+function githubSlug(value) {
+  return value
+    .replace(/<[^>]+>/g, "")
+    .replace(/[`*~]/g, "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
+    .trim()
+    .replace(/\s/g, "-");
+}
+
+function checkDocumentedCommands({ relativeFile, text, packageScripts, inventory, findings }) {
+  const codeText = markdownCodeOnly(text);
+  const pnpmPattern = /\bpnpm\b(?!@)([^\r\n;|&~]*)/g;
+  for (const match of codeText.matchAll(pnpmPattern)) {
+    const script = documentedPnpmScript(match[1]);
+    if (!script) continue;
+    if (
+      PNPM_BUILT_INS.has(script) ||
+      packageScripts.has(script) ||
+      (script === "start" && inventory.exact.has("server.js"))
+    ) {
+      continue;
+    }
+    addFinding(
+      findings,
+      relativeFile,
+      lineNumber(codeText, match.index),
+      "pnpm-script",
+      `package.json has no script named ${script}`,
+    );
+  }
+
+  const workflowPattern = /\bgh\s+workflow\s+(?:run|view)\s+(["']?)([^\s"']+\.ya?ml)\1/g;
+  for (const match of codeText.matchAll(workflowPattern)) {
+    const workflow = `.github/workflows/${path.posix.basename(match[2])}`;
+    checkInventoryReference({
+      relativeFile,
+      text: codeText,
+      index: match.index,
+      value: workflow,
+      inventory,
+      findings,
+      kind: "workflow",
+    });
+  }
+
+  const codePattern = /`([^`\r\n]+)`/g;
+  for (const match of text.matchAll(codePattern)) {
+    const value = match[1].replace(/\\/g, "/").replace(/[),.;:]$/, "");
+    if (!REPOSITORY_PATH_PREFIXES.some((prefix) => value.startsWith(prefix))) continue;
+    if (/[*{}<>]|\.\.\//.test(value) || value.includes(" ")) continue;
+    const reference = normalizeRelative(value.split(/[?#]/, 1)[0]);
+    if (!path.posix.extname(reference) && !inventory.exact.has(reference)) continue;
+    checkInventoryReference({
+      relativeFile,
+      text,
+      index: match.index,
+      value: reference,
+      inventory,
+      findings,
+      kind: "path",
+    });
+  }
+}
+
+function documentedPnpmScript(commandTail) {
+  const tokens = commandTail
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/^['"]|['"),.;:]$/g, ""))
+    .filter(Boolean);
+  const scopedOptions = new Set(["--dir", "--filter", "-C", "-F"]);
+  const valuedOptions = new Set([...scopedOptions, "--config", "--reporter"]);
+
+  function consumeOptions() {
+    while (tokens[0]?.startsWith("-")) {
+      const option = tokens.shift();
+      const optionName = option.split("=", 1)[0];
+      if (scopedOptions.has(optionName)) return false;
+      if (valuedOptions.has(optionName) && !option.includes("=")) tokens.shift();
+    }
+    return true;
+  }
+
+  if (!consumeOptions()) return null;
+  if (tokens[0] === "run") tokens.shift();
+  if (!consumeOptions()) return null;
+  const command = tokens[0]?.replace(/[.,;:]$/, "") ?? null;
+  if (command === "t" || command === "it" || command === "install-test") return "test";
+  return command;
+}
+
+function checkInventoryReference({ relativeFile, text, index, value, inventory, findings, kind }) {
+  if (inventory.exact.has(value)) return;
+  const actual = inventory.lower.get(value.toLowerCase());
+  addFinding(
+    findings,
+    relativeFile,
+    lineNumber(text, index),
+    kind,
+    actual
+      ? `reference case does not match repository entry: ${value} (actual: ${actual})`
+      : `repository entry does not exist: ${value}`,
+  );
+}
+
+function checkConfiguredClaims({ root, inventory, findings }) {
+  const manifestPath = "config/documentation-sync.json";
+  if (!inventory.exact.has(manifestPath)) return;
+  const manifest = readJson(path.join(root, manifestPath));
+  for (const source of manifest.sources ?? []) {
+    if (!inventory.exact.has(source.path)) {
+      addFinding(
+        findings,
+        manifestPath,
+        1,
+        "config-claim",
+        `source does not exist: ${source.path}`,
+      );
+      continue;
+    }
+    const values = sourceValues(path.join(root, source.path));
+    for (const [key, expected] of Object.entries(source.expect ?? {})) {
+      if (values.get(key) === String(expected)) continue;
+      addFinding(
+        findings,
+        manifestPath,
+        1,
+        "config-claim",
+        `${source.path} ${key} is ${values.get(key) ?? "undefined"}; expected ${expected}`,
+      );
+    }
+    for (const claim of source.claims ?? []) {
+      if (!inventory.exact.has(claim.document)) {
+        addFinding(
+          findings,
+          manifestPath,
+          1,
+          "config-claim",
+          `document does not exist: ${claim.document}`,
+        );
+        continue;
+      }
+      const missing = [];
+      const expected = claim.text.replace(/{{([^}]+)}}/g, (_match, key) => {
+        if (values.has(key)) return values.get(key);
+        missing.push(key);
+        return `{{${key}}}`;
+      });
+      if (missing.length > 0) {
+        addFinding(
+          findings,
+          manifestPath,
+          1,
+          "config-claim",
+          `${source.path} does not define ${missing.join(", ")}`,
+        );
+        continue;
+      }
+      const documentText = fs.readFileSync(path.join(root, claim.document), "utf8");
+      if (!normalizeWhitespace(documentText).includes(normalizeWhitespace(expected))) {
+        addFinding(
+          findings,
+          claim.document,
+          1,
+          "config-claim",
+          `does not match ${source.path}: ${expected}`,
+        );
+      }
+    }
+  }
+}
+
+function parseTomlStrings(text) {
+  const values = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([A-Z0-9_]+)\s*=\s*"([^"]*)"\s*$/);
+    if (match) values.set(match[1], match[2]);
+  }
+  return values;
+}
+
+function sourceValues(file) {
+  if (file.endsWith(".json")) {
+    const values = new Map();
+    flattenJson(readJson(file), "", values);
+    return values;
+  }
+  return parseTomlStrings(fs.readFileSync(file, "utf8"));
+}
+
+function flattenJson(value, prefix, values) {
+  if (value !== null && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      flattenJson(child, prefix ? `${prefix}.${key}` : key, values);
+    }
+    return;
+  }
+  values.set(prefix, String(value));
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function normalizeRelative(value) {
+  return value.replace(/^\.\//, "").replace(/\/$/, "");
+}
+
+function markdownCodeOnly(text) {
+  const output = text.split(/\r?\n/).map(() => "");
+  for (const token of markdown.parse(text, {})) {
+    if ((token.type === "fence" || token.type === "code_block") && token.map) {
+      const start = token.map[0] + (token.type === "fence" ? 1 : 0);
+      for (const [offset, content] of token.content.split(/\r?\n/).entries()) {
+        if (content && start + offset < output.length) output[start + offset] += content;
+      }
+      continue;
+    }
+    if (token.type !== "inline") continue;
+    let line = token.map?.[0] ?? 0;
+    for (const child of token.children ?? []) {
+      if (child.type === "softbreak" || child.type === "hardbreak") {
+        line += 1;
+        continue;
+      }
+      if (child.type === "code_inline") output[line] += `; ${child.content}`;
+    }
+  }
+  return output.join("\n");
+}
+
+function normalizeWhitespace(value) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function lineNumber(text, index) {
+  return text.slice(0, index).split(/\r?\n/).length;
+}
+
+function addFinding(findings, file, line, kind, message) {
+  findings.push({ file, line, kind, message });
+}
+
+function compareFindings(left, right) {
+  return (
+    left.file.localeCompare(right.file) ||
+    left.line - right.line ||
+    left.kind.localeCompare(right.kind) ||
+    left.message.localeCompare(right.message)
+  );
+}
+
+function runCli() {
+  const findings = checkDocumentation();
+  if (findings.length === 0) {
+    console.log("Documentation checks passed.");
+    return;
+  }
+  console.error(`Documentation checks failed (${findings.length}):`);
+  for (const finding of findings) {
+    console.error(`- ${finding.file}:${finding.line} [${finding.kind}] ${finding.message}`);
+  }
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) runCli();

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -187,7 +187,7 @@ function checkLinks({ root, relativeFile, text, inventory, findings }) {
     if (target.startsWith("<") && target.includes(">"))
       target = target.slice(1, target.indexOf(">"));
     else target = target.split(/\s+["']/)[0];
-    if (!target || /^(?:[a-z]+:|\/\/)/i.test(target)) return;
+    if (!target || /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(target)) return;
 
     const [rawPath, rawAnchor] = target.split("#", 2);
     let decodedPath;

--- a/test/check-docs.test.ts
+++ b/test/check-docs.test.ts
@@ -23,6 +23,7 @@ function fixture(): string {
       "[Underscore heading](docs/guide.md#stalled_unproven_pr)",
       "[Directory heading](docs/#documentation-home)",
       "[Explicit anchor](docs/guide.md#MixedCase)",
+      "[Escaped HTML-like heading](docs/guide.md#inline-span-html)",
       "`[Literal](docs/missing.md)`",
       "``[Literal `tick`](docs/missing.md)``",
       "```markdown",
@@ -46,7 +47,7 @@ function fixture(): string {
       "`gh workflow run ci.yml`",
     ].join("\n"),
     "docs/guide.md":
-      '# Operation\n\n<a id="MixedCase"></a>\n\n[Root](/README.md)\n\n## Foo & Bar\n\n## [Linked Operations](#operation)\n\n## `stalled_unproven_pr`\n\nSetext Operation\ncontinuation\n----------------\n\n~~~markdown\n## Example Only\n~~~\n\nCapacity is 50.\n\n# implemented\n',
+      '# Operation\n\n<a id="MixedCase"></a>\n\n[Root](/README.md)\n\n## Foo & Bar\n\n## [Linked Operations](#operation)\n\n## `stalled_unproven_pr`\n\n## Inline &lt;span&gt; HTML\n\nSetext Operation\ncontinuation\n----------------\n\n~~~markdown\n## Example Only\n~~~\n\nCapacity is 50.\n\n# implemented\n',
     "docs/README.md": "# Documentation Home\n",
     "docs/API_(legacy).md": "# Legacy API\n",
     "scripts/example.mjs": "export {};\n",

--- a/test/check-docs.test.ts
+++ b/test/check-docs.test.ts
@@ -24,6 +24,8 @@ function fixture(): string {
       "[Directory heading](docs/#documentation-home)",
       "[Explicit anchor](docs/guide.md#MixedCase)",
       "[Escaped HTML-like heading](docs/guide.md#inline-span-html)",
+      "[Custom URI scheme](web+clawsweeper://review/123)",
+      "[Hyphenated URI scheme](x-devonthink-item:ABC123)",
       "`[Literal](docs/missing.md)`",
       "``[Literal `tick`](docs/missing.md)``",
       "```markdown",
@@ -88,6 +90,16 @@ function withFixture(run: (root: string) => void): void {
 
 test("accepts synchronized documentation references", () => {
   withFixture((root) => assert.deepEqual(checkDocumentation(root), []));
+});
+
+test("accepts the full URI scheme syntax for external links", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "[Plus](web+clawsweeper://review/123)\n[Dot](x.dev-item:ABC123)\n[Hyphen](x-devonthink-item:ABC123)\n",
+    );
+    assert.deepEqual(checkDocumentation(root), []);
+  });
 });
 
 test("reports wrong-case links and missing anchors", () => {

--- a/test/check-docs.test.ts
+++ b/test/check-docs.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { checkDocumentation } from "../scripts/check-docs.mjs";
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-docs-"));
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({ scripts: { check: "node check.js" } }),
+    "README.md": [
+      "# Home",
+      "",
+      "[Guide](docs/guide.md#operation)",
+      "[Punctuation](docs/guide.md#foo--bar)",
+      "[Reference][guide-ref]",
+      "[guide-ref]: docs/guide.md#foo--bar",
+      "[Parentheses](docs/API_(legacy).md)",
+      "[Rendered heading](docs/guide.md#linked-operations)",
+      "[Setext heading](docs/guide.md#setext-operation-continuation)",
+      "[Underscore heading](docs/guide.md#stalled_unproven_pr)",
+      "[Directory heading](docs/#documentation-home)",
+      "[Explicit anchor](docs/guide.md#MixedCase)",
+      "`[Literal](docs/missing.md)`",
+      "``[Literal `tick`](docs/missing.md)``",
+      "```markdown",
+      "[Example][missing]",
+      "[missing]: docs/missing.md",
+      "```",
+      "",
+      "    [Indented example](docs/missing.md)",
+      "",
+      "`pnpm run check`",
+      "`pnpm --silent run check`",
+      "`pnpm --filter dashboard run build`",
+      "`pnpm -C dashboard test`",
+      "`pnpm audit`",
+      "`pnpm env use --global 24`",
+      "`pnpm outdated`",
+      "`pnpm prune`",
+      "",
+      "`scripts/example.mjs`",
+      "",
+      "`gh workflow run ci.yml`",
+    ].join("\n"),
+    "docs/guide.md":
+      '# Operation\n\n<a id="MixedCase"></a>\n\n[Root](/README.md)\n\n## Foo & Bar\n\n## [Linked Operations](#operation)\n\n## `stalled_unproven_pr`\n\nSetext Operation\ncontinuation\n----------------\n\n~~~markdown\n## Example Only\n~~~\n\nCapacity is 50.\n\n# implemented\n',
+    "docs/README.md": "# Documentation Home\n",
+    "docs/API_(legacy).md": "# Legacy API\n",
+    "scripts/example.mjs": "export {};\n",
+    ".github/workflows/ci.yml": "name: CI\n",
+    "dashboard/wrangler.toml": 'CAPACITY = "50"\n',
+    "config/targets.json": JSON.stringify({ close: { issue: "implemented" } }),
+    "config/documentation-sync.json": JSON.stringify({
+      version: 1,
+      sources: [
+        {
+          path: "dashboard/wrangler.toml",
+          expect: { CAPACITY: "50" },
+          claims: [{ document: "docs/guide.md", text: "Capacity is {{CAPACITY}}." }],
+        },
+        {
+          path: "config/targets.json",
+          claims: [{ document: "docs/guide.md", text: "# {{close.issue}}" }],
+        },
+      ],
+    }),
+  };
+  for (const [relative, contents] of Object.entries(files)) {
+    const absolute = join(root, relative);
+    mkdirSync(join(absolute, ".."), { recursive: true });
+    writeFileSync(absolute, contents);
+  }
+  return root;
+}
+
+function withFixture(run: (root: string) => void): void {
+  const root = fixture();
+  try {
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("accepts synchronized documentation references", () => {
+  withFixture((root) => assert.deepEqual(checkDocumentation(root), []));
+});
+
+test("reports wrong-case links and missing anchors", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "[Case](docs/Guide.md)\n[Anchor](docs/guide.md#missing)\n[Anchor case](docs/guide.md#Operation)\n[Fence](docs/guide.md#example-only)\n",
+    );
+    const findings = checkDocumentation(root);
+    assert.ok(
+      findings.some(
+        (finding) => finding.kind === "link" && finding.message.includes("actual: docs/guide.md"),
+      ),
+    );
+    assert.ok(
+      findings.some((finding) => finding.kind === "anchor" && finding.message.includes("#missing")),
+    );
+    assert.ok(
+      findings.some(
+        (finding) => finding.kind === "anchor" && finding.message.includes("#example-only"),
+      ),
+    );
+  });
+});
+
+test("reports multiline links and unused definitions at their source lines", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "Paragraph text\n[Case](docs/Guide.md)\n\nMore text\n\n[unused]: docs/missing.md\n",
+    );
+    const findings = checkDocumentation(root).filter((finding) => finding.kind === "link");
+    assert.deepEqual(
+      findings.map((finding) => finding.line),
+      [2, 6],
+    );
+  });
+});
+
+test("does not create Setext anchors from non-paragraph blocks", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "[List](docs/guide.md#list-item)\n[Quote](docs/guide.md#quote)\n[Code](docs/guide.md#code)\n[HTML](docs/guide.md#not-a-heading)\n",
+    );
+    writeFileSync(
+      join(root, "docs/guide.md"),
+      "- List item\n---\n\n> Quote\n===\n\n    Code\n---\n\n<div>\nNot a heading\n---\n</div>\n",
+    );
+    const findings = checkDocumentation(root).filter((finding) => finding.kind === "anchor");
+    assert.equal(findings.length, 4);
+  });
+});
+
+test("reports wrong-case reference definitions and encoded missing targets", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "[Case][guide]\n\n[guide]: docs/Guide.md\n[Escape](docs/100%-coverage.md)\n",
+    );
+    const findings = checkDocumentation(root);
+    assert.ok(
+      findings.some(
+        (finding) => finding.kind === "link" && finding.message.includes("actual: docs/guide.md"),
+      ),
+    );
+    assert.ok(
+      findings.some(
+        (finding) => finding.kind === "link" && finding.message.includes("100%-coverage.md"),
+      ),
+    );
+  });
+});
+
+test("resumes link validation after a closed code fence", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "```markdown\n[Ignored](docs/missing.md)\n```\n[After](docs/Guide.md)\n",
+    );
+    const findings = checkDocumentation(root);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].kind, "link");
+    assert.match(findings[0].message, /actual: docs\/guide\.md/);
+  });
+});
+
+test("preserves UTF-16 offsets around inline code", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "🦞 `[Ignored](docs/missing.md)` [After](docs/Guide.md)\n",
+    );
+    const findings = checkDocumentation(root);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].kind, "link");
+    assert.match(findings[0].message, /actual: docs\/guide\.md/);
+  });
+});
+
+test("reports nonexistent scripts, workflows, and repository paths", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "`pnpm run missing`\n``pnpm run missing-double `option` ``\n`gh workflow run absent.yml`\n`scripts/absent.mjs`\n~~~sh\npnpm run missing-tilde\n~~~\n\n    pnpm run missing-indented\n",
+    );
+    const kinds = new Set(checkDocumentation(root).map((finding) => finding.kind));
+    assert.ok(kinds.has("pnpm-script"));
+    assert.ok(kinds.has("workflow"));
+    assert.ok(kinds.has("path"));
+  });
+});
+
+test("keeps pnpm lifecycle aliases subject to script validation", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "README.md"),
+      "`pnpm start`\n`pnpm test`\n`pnpm t`\n`pnpm it`\n`pnpm install-test`\n",
+    );
+    const findings = checkDocumentation(root).filter((finding) => finding.kind === "pnpm-script");
+    assert.equal(findings.length, 5);
+    assert.match(findings[0].message, /start/);
+    assert.ok(findings.slice(1).every((finding) => finding.message.includes("test")));
+  });
+});
+
+test("does not accept unrelated untracked files as repository paths", () => {
+  withFixture((root) => {
+    execFileSync("git", ["init", "--quiet"], { cwd: root });
+    execFileSync("git", ["add", "."], { cwd: root });
+    writeFileSync(join(root, "scripts/untracked.mjs"), "export {};\n");
+    writeFileSync(join(root, "docs/untracked.md"), "[Broken](missing.md)\n");
+    writeFileSync(join(root, "README.md"), "`scripts/untracked.mjs`\n");
+    const findings = checkDocumentation(root);
+    assert.ok(
+      findings.some(
+        (finding) => finding.kind === "path" && finding.message.includes("untracked.mjs"),
+      ),
+    );
+  });
+});
+
+test("reports config-derived prose that no longer matches its source", () => {
+  withFixture((root) => {
+    writeFileSync(join(root, "dashboard/wrangler.toml"), 'CAPACITY = "51"\n');
+    const findings = checkDocumentation(root);
+    assert.ok(
+      findings.some(
+        (finding) => finding.kind === "config-claim" && finding.message.includes("Capacity is 51."),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a deterministic, read-only documentation drift checker
- validate local links and GitHub-style anchors through parsed Markdown
- validate documented pnpm commands, workflow names, and repository paths
- bind high-risk production prose to selected Wrangler and target-repository config values
- run the checker in the existing static-check lane with focused fixtures

## Problem

CSW-114 found that documentation drift was being caught only by manual audits. The repository had no deterministic gate for case-sensitive paths, stale commands, missing anchors, renamed workflows, or selected production configuration claims. That allowed confirmed stale statements to persist across scheduler, publication, repair, and contributor documentation.

## Implementation

- `scripts/check-docs.mjs` inventories tracked/staged repository paths and checks evergreen Markdown without treating unrelated untracked files as valid targets
- `markdown-it` supplies CommonMark-aware tokens for links, images, reference definitions, headings, inline code, fenced code, and indented code
- `config/documentation-sync.json` declares selected source-to-prose contracts for production publication settings and target close policy
- `test/check-docs.test.ts` proves passing and failing fixtures for path case, anchors, directory READMEs, multiline locations, code spans/blocks, pnpm commands, workflows, untracked files, config claims, escaped heading text, and full URI-scheme syntax
- `check:docs` is included in the existing `check:static` CI path
- confirmed drift exposed by the checker is corrected in the same PR

## Current-main reconciliation

After #1095 merged, the two original drift-check commits were replayed onto current main `2f547841c459886f78c5e3d3d28ebf781f2d78be`. Conflicts were limited to publication prose changed by #1092/#1094. Resolution preserved source fallback values 4/24/48 and production values 8/32/40, and updated the new sync manifest from obsolete fixed-50 expectations to current minimum/base/maximum 8/32/40 claims. No workflow file, gate, queue, deployment, or production-state change is included.

## Validation

At exact head `9ee3ce44a1aa43e6165ca886b729e3ac5873fe1b`:

- `corepack pnpm install --frozen-lockfile` — pass, pnpm 11.10.0
- `corepack pnpm run check:docs` — pass; `Documentation checks passed.`
- `node --test test/check-docs.test.ts` — pass, 12/12
- changed-file `oxfmt --check` — pass
- changed-file `oxlint` — pass
- `corepack pnpm run check:active-surface` — pass
- `corepack pnpm run check:dashboard-queue-boundary` — pass
- `corepack pnpm run check:limits` — pass
- `corepack pnpm run build` — pass
- docs generation and focused site test — pass; 54 pages, 1/1
- `git diff --check origin/main...HEAD` — pass

The aggregate local `check:static` reaches the existing Windows checkout CRLF formatter baseline across hundreds of untouched files; all changed files format cleanly. Hosted Linux CI is the authoritative aggregate static/check run for this exact head.

## Real Behavior Proof

- **Claim:** the new mandatory static check reads the actual repository, exits cleanly when documentation and selected config claims agree, and deterministically rejects representative drift.
- **Exercised surface:** exact public-PR checkout, frozen dependency installation, `pnpm run check:docs`, tracked/staged inventory, parsed Markdown validation, command/path validation, current 8/32/40 config manifest, and all focused fixtures.
- **Scenario/fixture:** the current repository plus isolated temporary repositories covering valid and invalid links, anchors, code syntax, commands, workflows, paths, URI schemes, and config claims.
- **Command/environment:** Crabbox `provider=aws`, run `run_ea6fde619f0a`, lease `cbx_20eb68741e5a` (`swift-hermit-f818`), `c7a.8xlarge`, Ubuntu 26.04 target; exact public-PR checkout via `--fresh-pr 1096`; no secrets.
- **Observed result:** exact head asserted; frozen install passed; the repository check printed `Documentation checks passed.`; focused tests passed 12/12; Crabbox exited 0 and stopped the lease.
- **Artifact/trace:** focused fixtures are committed in `test/check-docs.test.ts`; exact trace:

```text
CRABBOX_PHASE:assert-head
PROOF_HEAD=9ee3ce44a1aa43e6165ca886b729e3ac5873fe1b
CRABBOX_PHASE:install
Done in 1.8s using pnpm v11.10.0
CRABBOX_PHASE:docs-check
Documentation checks passed.
CRABBOX_PHASE:fixture-suite
tests 12 | pass 12 | fail 0
CRABBOX_PHASE:assert
PROOF_RESULT=PASS
provider=aws run=run_ea6fde619f0a lease=cbx_20eb68741e5a slug=swift-hermit-f818 exit=0
```

- **Limits:** no external URL crawl, production-secret access, workflow dispatch, queue mutation, deployment, or production-state change. The manifest intentionally covers selected high-risk config claims rather than inferring policy or ownership. The one provider-qualified proof used the repository-resolved Crabbox provider; no alternate backend was selected.

## Review closeout

Rebase review found one actionable P2: external URI schemes containing RFC-valid `+`, `.`, or `-` characters could be misclassified as repository-relative links. The scheme matcher now accepts `[a-z][a-z0-9+.-]*:` and a dedicated fixture covers all three characters. Focused proof was rerun at 12/12.

Dirty-patch review confirmed the URI fix and coverage. Final committed review against `origin/main` reported the checker, configuration manifest, tests, and documentation updates internally consistent with no actionable correctness regressions.

## OpenClaw Bay impact

No Bay behavior or contract changes. This PR adds a read-only repository checker and binds existing publication/dashboard prose to current configuration; it does not change the Bay route, six-lane projection, stage mapping, public fields, navigation, or observer-only control boundary. No Bay code, documentation, screenshot, or runtime proof update is required.

## Risks and rollout

- the checker is read-only, but adding it to `check:static` intentionally blocks future CI when covered docs drift
- **Maintainer decision:** Martin explicitly approved integrating the CSW-114 stack in the current conversation, including this narrow mandatory gate; its selected documentation/configuration drift failures are intended and accepted
- diagnostics include file, line, kind, and target/reason
- `markdown-it` is a new development-only dependency used by the static checker
- no workflow files, gates, queues, deployment, or production state are changed

## Related work

- merged documentation baseline: #1092
- merged information architecture: #1095
- CSW-114 durable remediation plan is maintained locally by the coordinator lane
