### PR TITLE
docs: correct scheduler fallback arithmetic

### DIFF
--- a/config/documentation-sync.json
+++ b/config/documentation-sync.json
@@ -54,6 +54,10 @@
           "text": "durable {{EXACT_REVIEW_TARGET_RATE_PER_HOUR}}-review/hour budget with a {{EXACT_REVIEW_TARGET_BURST}}-item burst"
         },
         {
+          "document": "docs/limits.md",
+          "text": "a single-target scheduled plan falls back to offering up to 50 candidates to the durable {{EXACT_REVIEW_TARGET_RATE_PER_HOUR}}-review/hour admission target with a {{EXACT_REVIEW_TARGET_BURST}}-item burst"
+        },
+        {
           "document": "docs/scheduler.md",
           "text": "total review admission target: {{EXACT_REVIEW_TARGET_RATE_PER_HOUR}} items/hour across the fleet"
         },

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -291,8 +291,10 @@ Examples with the current config:
 
 - Quiet system: manual normal review can request 89 shards, with 104 background
   slots available after reserving 16 for interactive work and 8 for matrix
-  expansion. Scheduled plans offer up to 20 candidates to the 200/hour durable
-  admission budget instead of starting matrix shards.
+  expansion. When the queue capacity probe is unavailable, a single-target
+  scheduled plan falls back to offering up to 50 candidates to the durable
+  300-review/hour admission target with a 30-item burst instead of starting
+  matrix shards.
 - 4 active repair workers and 96 active background workers: normal review gets
   4 because `128 - 16 interactive reserve - 8 expansion reserve - 4 priority
   - 96 background = 4`.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -403,11 +403,17 @@ The producer probes that field before its first enqueue and fails closed while
 an older Worker is still deployed, preventing a workflow-first rollout from
 bypassing the rate limiter.
 
-Each hourly normal-fanout step can offer
-`50 items/target * 12 targets = 600 items/hour`. The direct five-minute hot and
-normal schedules can each offer `50 * 12 = 600 items/hour`, so either lane has
-enough candidates to keep its token bucket fed despite dedupe or uneven fleet
-distribution. The queue admits at most 300 scheduled reviews/hour, which needs
+Normal fanout ordinarily divides one live queue-advertised candidate-capacity
+budget across the selected repositories; it does not grant 50 candidates to
+each target. If that capacity probe is unavailable, the bounded fallback for a
+10-minute cycle is `50 items/target * 12 targets = 600 items/cycle`. Six cycles
+per hour make that fallback's theoretical pre-filter ceiling 3,600 offers/hour
+before due filtering, planner capacity clamping, dedupe, and Worker admission.
+A direct five-minute schedule for one target also uses live advertised capacity;
+its fallback can offer `50 items/cycle * 12 cycles/hour = 600 items/hour` before
+the same bounds. These paths therefore have enough candidates to keep the
+shared token bucket fed despite dedupe or uneven fleet distribution. The queue
+admits at most 300 scheduled reviews/hour, which needs
 about `300 * 4.1 / 60 = 21` concurrent review workers at a 4.1-minute mean
 service time and budgets roughly 9,000 GitHub requests/hour. That leaves about
 6,000 requests in the shared 15,000-request installation allowance for exact

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -316,9 +316,13 @@ Current defaults:
 
 - exact event review: 1 shard, 1 item
 - exact manual hot intake: 1 shard, 1 item
-- scheduled hot intake and normal backfill: select up to 50 due items per target
-  cycle, then enqueue each item through the durable exact-review queue; every
-  admitted item receives its own parallel workflow
+- scheduled hot intake and normal backfill: size candidate selection from live
+  queue-advertised capacity, with normal fanout sharing that budget across its
+  selected targets. If the capacity probe is unavailable, a direct single-target
+  schedule falls back to 50 candidates; normal fanout creates a pool of 50
+  candidates per selected target and apportions that pool by backlog. Each
+  selected item enters the durable exact-review queue, and every admitted item
+  receives its own parallel workflow
 - total review admission target: 300 items/hour across the fleet; organic work
   consumes the budget first and scheduled backfill fills the remainder, split
   35% hot intake and 65% normal backfill, with a 30-item burst


### PR DESCRIPTION
## Summary

- correct the stale quiet-system scheduler example from 20 candidates / 200 reviews per hour to the current bounded fallback of 50 candidates and production admission target of 300 reviews per hour with a 30-item burst
- distinguish the live shared candidate-capacity budget from the bounded queue-probe fallback
- correct the fallback cadence arithmetic: 600 offers per 10-minute normal-fanout cycle, 3,600 offers per hour across six fallback cycles, and 600 offers per hour for a five-minute single-target fallback
- extend the existing documentation-sync manifest so the affected limits example tracks the production admission target and burst

## What Problem This Solves

`docs/limits.md` still described the pre-current fallback and admission values. `docs/scheduler.md` called `50 × 12 = 600` an hourly normal-fanout value even though normal fanout runs every 10 minutes.

Source inspection also found an important qualification: the 50-per-target multiplication is not the ordinary live-capacity path. Normal fanout ordinarily divides one queue-advertised candidate-capacity budget across selected repositories. `50 × 12` is the bounded fallback only when the queue-capacity probe is unavailable.

## Why This Change Was Made

The corrected wording follows current source and workflow behavior:

- `src/repair/target-fanout.ts` defines `SCHEDULED_REVIEW_PLAN_BATCH_SIZE = 50`.
- Normal fanout uses the live queue's `availableCandidateCapacity` when present and divides that shared budget across selected repositories.
- If the capacity probe is unavailable, fallback capacity is `50 × min(12, selected repositories)`.
- `.github/workflows/sweep.yml` runs normal fanout at `41/10 * * * *` with a 12-target limit.
- Direct schedules run every five minutes and default an unavailable queue-capacity probe to 50 candidates for the single target.
- `dashboard/wrangler.toml` configures `EXACT_REVIEW_TARGET_RATE_PER_HOUR = 300` and `EXACT_REVIEW_TARGET_BURST = 30`.

The offer ceilings are upstream candidate ceilings, not admitted review throughput. Due filtering, planner capacity clamping, dedupe, queue backpressure, and Worker admission can all reduce them; the Worker admits at most 300 scheduled reviews per hour.

## User Impact

Operators and maintainers get source-aligned scheduler capacity examples. Runtime behavior is unchanged.

## Validation

- `pnpm run check:docs` — passed
- `pnpm run check:limits` — passed
- `pnpm run build` — passed
- `git diff --check origin/main..HEAD` — passed
- `pnpm run codex:local:check` — passed

## Review Proof

- Dirty-patch Codex review initially found that the proposed 3,600/hour wording incorrectly described the fallback as ordinary per-target capacity. The finding was accepted, the wording was corrected to distinguish the live shared budget from fallback behavior, validation was rerun, and the repeat dirty review found no actionable defects.
- Durable ClawSweeper review on the first PR head found that the earlier `Current defaults` bullet still described 50 items per target without distinguishing live shared capacity from fallback behavior. The finding was accepted. During the required committed-base review, the first wording fix was further corrected to avoid presenting 50 as a per-repository allocation cap: direct single-target fallback is 50 candidates, while normal fanout creates a pooled `50 × selected target count` fallback and apportions it by backlog.
- Final dirty-patch and committed-base Codex reviews: clean, no actionable findings.
- Exact-head local ClawSweeper committed-range review: `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main` — `review_status: complete`, high confidence, patch correct, no findings; reviewed main `0559e03857fa9a9a6de28c984ed495287ec3b9cc` and head `d8a47bc68a380bb5ebf8a3830963b7dda170512a`. The local generic classifier marked proof missing because `config/documentation-sync.json` is outside `docs/`; repository policy and the live review apply the docs-only proof exception to this documentation-sync manifest change, with the executable checks above as proof.

## Real Behavior Proof

Not applicable. Every changed surface is documentation or documentation-sync configuration; no runtime, workflow, queue, API, UI, package, or integration behavior changes. The focused executable proof is `pnpm run check:docs`, `pnpm run check:limits`, and the build.

## Overlap and Landing Order

Draft PR #1097 also touches `docs/limits.md`, `docs/scheduler.md`, and `config/documentation-sync.json`, but for the separate production publication-capacity rollback (`8/32/40` versus `50/50/50`). This PR does not change publication policy, Goal B rate limiting, queues, workflows, config values, gates, or production state.

Either PR may land first because their semantic changes are independent. The second PR must rebase onto current `main`, preserve both sets of documentation changes, rerun the docs/build/diff checks, and repeat the required review gate before its next push. Neither branch should overwrite the other's prose or manifest claims.

## Risks and Rollback

Risk is limited to documentation accuracy and a deterministic docs-sync claim. Revert commits `d8a47bc68a380bb5ebf8a3830963b7dda170512a` and `52f76a07fa55843f7907f2b01775bf601de4d95b` to roll back. No production state or configuration rollback is involved.

## Non-goals

- changing production publication capacity (`8/32/40` or `50/50/50`)
- changing the 300/hour admission target, burst, Goal B behavior, queues, workflow cadence, scheduler code, gates, or production state
- broadening the documentation audit beyond these two derived examples

Related: #1097
