### PR TITLE
fix: accept mixed-case publication slugs

### DIFF
--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1425,6 +1425,7 @@ export async function validateCanonicalRecordTupleMutation(
     if (!tuple || !repositoryNamesEqual(tuple.repoSlug, repoSlug) || tuple.itemId !== itemId) {
       throw new Error(`canonical tuple path is outside ${inputKey}: ${String(operation.path)}`);
     }
+    const storagePath = canonicalTupleStoragePath(repoSlug, tuple.section, tuple.itemId);
     if (sections.has(tuple.section)) {
       throw new Error(`canonical tuple repeats section ${tuple.section}`);
     }
@@ -1436,11 +1437,13 @@ export async function validateCanonicalRecordTupleMutation(
     expectedDigests.set(tuple.section, expectedDigest);
     if (operation.contentBase64 === undefined) {
       operations.push({
-        path: operation.path,
+        path: storagePath,
         deleted: true,
         mode: "100644",
         bytes: 0,
-        ...tuple,
+        repoSlug,
+        section: tuple.section,
+        itemId: tuple.itemId,
         content: null,
         digest: null,
       });
@@ -1465,12 +1468,14 @@ export async function validateCanonicalRecordTupleMutation(
       throw new Error(`canonical tuple content is not UTF-8: ${operation.path}`);
     }
     operations.push({
-      path: operation.path,
+      path: storagePath,
       deleted: false,
       mode: "100644",
       bytes: bytes.byteLength,
       contentBase64: operation.contentBase64,
-      ...tuple,
+      repoSlug,
+      section: tuple.section,
+      itemId: tuple.itemId,
       content,
       digest: await sha256Hex(bytes),
     });
@@ -1588,35 +1593,51 @@ export async function validateDirectPublicationPlan(
   if (plan.operations.length > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES) {
     throw new Error("a direct publication plan exceeds the exact-review tuple file limit");
   }
-  const repoSlug = `${itemIdentity[1]}-${itemIdentity[2]}`;
+  const inputRepoSlug = `${itemIdentity[1]}-${itemIdentity[2]}`;
+  const repoSlug = inputRepoSlug.toLowerCase();
   const itemId = Number(itemIdentity[3]);
   const paths = new Set<string>();
   let totalBytes = 0;
   const operations: CanonicalDirectPublicationOperation[] = [];
   for (const raw of plan.operations) {
     const operation = raw && typeof raw === "object" ? raw : ({} as DirectPublicationOperation);
-    const path = canonicalPath(operation.path);
-    if (path !== operation.path || paths.has(path)) {
+    const inputPath = canonicalPath(operation.path);
+    if (inputPath !== operation.path) {
+      throw new Error(`invalid or repeated direct publication path: ${String(operation.path)}`);
+    }
+    const tuple = canonicalTuplePath(inputPath);
+    if (!tuple || !repositoryNamesEqual(tuple.repoSlug, inputRepoSlug) || tuple.itemId !== itemId) {
+      throw new Error(
+        `direct publication path is outside ${inputRepoSlug}#${itemId}: ${inputPath}`,
+      );
+    }
+    const path = canonicalTupleStoragePath(repoSlug, tuple.section, tuple.itemId);
+    if (paths.has(path)) {
       throw new Error(`invalid or repeated direct publication path: ${String(operation.path)}`);
     }
     paths.add(path);
-    const tuple = canonicalTuplePath(path);
-    if (!tuple || !repositoryNamesEqual(tuple.repoSlug, repoSlug) || tuple.itemId !== itemId) {
-      throw new Error(`direct publication path is outside ${repoSlug}#${itemId}: ${path}`);
-    }
-    if (operation.mode !== "100644") throw new Error(`invalid mutation mode for ${path}`);
+    if (operation.mode !== "100644") throw new Error(`invalid mutation mode for ${inputPath}`);
     if (
       !Number.isSafeInteger(operation.bytes) ||
       operation.bytes < 0 ||
       operation.bytes > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES
     ) {
-      throw new Error(`invalid mutation byte count for ${path}`);
+      throw new Error(`invalid mutation byte count for ${inputPath}`);
     }
     if (operation.deleted === true) {
       if (operation.bytes !== 0 || operation.contentBase64 !== undefined) {
-        throw new Error(`deleted mutation paths must not carry content: ${path}`);
+        throw new Error(`deleted mutation paths must not carry content: ${inputPath}`);
       }
-      operations.push({ ...operation, path, ...tuple, content: null, digest: null, bytes: 0 });
+      operations.push({
+        ...operation,
+        path,
+        repoSlug,
+        section: tuple.section,
+        itemId: tuple.itemId,
+        content: null,
+        digest: null,
+        bytes: 0,
+      });
       continue;
     }
     const contentBase64 = operation.contentBase64;
@@ -1624,21 +1645,30 @@ export async function validateDirectPublicationPlan(
       typeof contentBase64 !== "string" ||
       !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(contentBase64)
     ) {
-      throw new Error(`missing or invalid mutation content for ${path}`);
+      throw new Error(`missing or invalid mutation content for ${inputPath}`);
     }
     const bytes = base64Bytes(contentBase64);
     if (bytes.byteLength !== operation.bytes) {
-      throw new Error(`mutation byte count does not match content for ${path}`);
+      throw new Error(`mutation byte count does not match content for ${inputPath}`);
     }
     let content: string;
     try {
       content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
     } catch {
-      throw new Error(`canonical record content is not UTF-8: ${path}`);
+      throw new Error(`canonical record content is not UTF-8: ${inputPath}`);
     }
     const digest = await sha256Hex(bytes);
     totalBytes += bytes.byteLength;
-    operations.push({ ...operation, path, ...tuple, contentBase64, content, digest });
+    operations.push({
+      ...operation,
+      path,
+      repoSlug,
+      section: tuple.section,
+      itemId: tuple.itemId,
+      contentBase64,
+      content,
+      digest,
+    });
   }
   if (!Number.isSafeInteger(plan.totalBytes) || plan.totalBytes !== totalBytes) {
     throw new Error("direct publication total does not match its operations");
@@ -1791,6 +1821,15 @@ function canonicalTuplePath(path: string) {
   const section = match[2] as ExactReviewTupleRecordSection;
   if ((section === "decision-packets") !== (match[4] === "json")) return null;
   return { repoSlug: match[1]!, section, itemId: Number(match[3]) };
+}
+
+function canonicalTupleStoragePath(
+  repoSlug: string,
+  section: ExactReviewTupleRecordSection,
+  itemId: number,
+) {
+  const extension = section === "decision-packets" ? "json" : "md";
+  return `records/${repoSlug}/${section}/${itemId}.${extension}`;
 }
 
 function repositoryNamesEqual(left: string, right: string) {

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1405,7 +1405,8 @@ export async function validateCanonicalRecordTupleMutation(
   }
   const inputKey = String(mutation.key || "").trim();
   const keyMatch = /^([A-Za-z0-9][A-Za-z0-9_.-]{0,199})\/([1-9]\d*)$/.exec(inputKey);
-  const repoSlug = validateRepoSlug(keyMatch?.[1])?.toLowerCase() ?? null;
+  const inputRepoSlug = validateRepoSlug(keyMatch?.[1]);
+  const repoSlug = inputRepoSlug?.toLowerCase() ?? null;
   const itemId = Number(keyMatch?.[2]);
   if (!repoSlug || !Number.isSafeInteger(itemId) || itemId < 1) {
     throw new Error("invalid canonical tuple key");
@@ -1421,8 +1422,8 @@ export async function validateCanonicalRecordTupleMutation(
     const operation =
       raw && typeof raw === "object" ? raw : ({} as CanonicalRecordTupleMutationOperation);
     const tuple = canonicalTuplePath(String(operation.path || ""));
-    if (!tuple || tuple.repoSlug !== repoSlug || tuple.itemId !== itemId) {
-      throw new Error(`canonical tuple path is outside ${key}: ${String(operation.path)}`);
+    if (!tuple || !repositoryNamesEqual(tuple.repoSlug, repoSlug) || tuple.itemId !== itemId) {
+      throw new Error(`canonical tuple path is outside ${inputKey}: ${String(operation.path)}`);
     }
     if (sections.has(tuple.section)) {
       throw new Error(`canonical tuple repeats section ${tuple.section}`);
@@ -1545,7 +1546,7 @@ function validateCanonicalTuplePacketReference(
     }
     return;
   }
-  if (digest !== packet.digest || pointer !== packet.path) {
+  if (digest !== packet.digest || !recordPathsEqualIgnoringRepositoryCase(pointer, packet.path)) {
     throw new Error(`canonical tuple decision packet reference is inconsistent: ${key}`);
   }
 }
@@ -1587,7 +1588,7 @@ export async function validateDirectPublicationPlan(
   if (plan.operations.length > EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILES) {
     throw new Error("a direct publication plan exceeds the exact-review tuple file limit");
   }
-  const repoSlug = `${itemIdentity[1]}-${itemIdentity[2]}`.toLowerCase();
+  const repoSlug = `${itemIdentity[1]}-${itemIdentity[2]}`;
   const itemId = Number(itemIdentity[3]);
   const paths = new Set<string>();
   let totalBytes = 0;
@@ -1600,7 +1601,7 @@ export async function validateDirectPublicationPlan(
     }
     paths.add(path);
     const tuple = canonicalTuplePath(path);
-    if (!tuple || tuple.repoSlug !== repoSlug || tuple.itemId !== itemId) {
+    if (!tuple || !repositoryNamesEqual(tuple.repoSlug, repoSlug) || tuple.itemId !== itemId) {
       throw new Error(`direct publication path is outside ${repoSlug}#${itemId}: ${path}`);
     }
     if (operation.mode !== "100644") throw new Error(`invalid mutation mode for ${path}`);
@@ -1790,6 +1791,23 @@ function canonicalTuplePath(path: string) {
   const section = match[2] as ExactReviewTupleRecordSection;
   if ((section === "decision-packets") !== (match[4] === "json")) return null;
   return { repoSlug: match[1]!, section, itemId: Number(match[3]) };
+}
+
+function repositoryNamesEqual(left: string, right: string) {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function recordPathsEqualIgnoringRepositoryCase(left: string | undefined, right: string) {
+  if (left === undefined) return false;
+  const leftTuple = canonicalTuplePath(left);
+  const rightTuple = canonicalTuplePath(right);
+  return Boolean(
+    leftTuple &&
+    rightTuple &&
+    repositoryNamesEqual(leftTuple.repoSlug, rightTuple.repoSlug) &&
+    leftTuple.section === rightTuple.section &&
+    leftTuple.itemId === rightTuple.itemId,
+  );
 }
 
 function boundedItemKey(value: unknown) {

--- a/docs/proof/mixed-case-publication-slugs/README.md
+++ b/docs/proof/mixed-case-publication-slugs/README.md
@@ -7,8 +7,10 @@ direct exact-review publication while repository identity remains contained.
 The behavior contract is:
 
 - the real Durable Object initializes before any publication claim is made;
-- a signed plan for `steipete/CodexBar#2516` whose operation uses the lowercase
-  `records/steipete-codexbar/...` path returns HTTP 202 with an accepted or deduped receipt;
+- a signed plan for `steipete/CodexBar#2516` whose operation uses the mixed-case
+  `records/steipete-CodexBar/...` path returns HTTP 202 with an accepted or deduped receipt;
+- the real Worker export surface serves that record only from `steipete-codexbar`, and the
+  persisted Durable Object SQLite contains no `steipete-CodexBar` canonical or export row;
 - a signed plan whose operation names `steipete-other` returns the detailed HTTP 400
   `invalid_direct_publication_plan` response;
 - a signed all-lowercase `openclaw/openclaw` plan still returns HTTP 202 with an accepted or
@@ -17,7 +19,9 @@ The behavior contract is:
 The script boots the Worker, drives `/api/exact-review-queue`, terminates the full Wrangler process
 tree, and inspects Wrangler's persisted SQLite database for the direct-publication table. Only
 after that assertion does it seed disposable pending fences, restart the Worker, and submit the
-three signed plans. Pending fences let the real Worker accept and persist the valid plans without
+three signed plans. It then reads the accepted mixed-case plan through the signed record-export
+route, stops the Worker, and verifies the canonical, export-index, and stored receipt namespaces
+directly in SQLite. Pending fences let the real Worker accept and persist the valid plans without
 mocking the publication store or bypassing HTTP validation.
 
 Run from the repository root on Node 24 or newer:

--- a/docs/proof/mixed-case-publication-slugs/README.md
+++ b/docs/proof/mixed-case-publication-slugs/README.md
@@ -1,0 +1,35 @@
+# Mixed-case publication slug proof
+
+This proof exercises the built dashboard Worker and `ExactReviewQueue` Durable Object through real
+HTTP using local Wrangler persistence. It verifies that GitHub repository casing does not block
+direct exact-review publication while repository identity remains contained.
+
+The behavior contract is:
+
+- the real Durable Object initializes before any publication claim is made;
+- a signed plan for `steipete/CodexBar#2516` whose operation uses the lowercase
+  `records/steipete-codexbar/...` path returns HTTP 202 with an accepted or deduped receipt;
+- a signed plan whose operation names `steipete-other` returns the detailed HTTP 400
+  `invalid_direct_publication_plan` response;
+- a signed all-lowercase `openclaw/openclaw` plan still returns HTTP 202 with an accepted or
+  deduped receipt.
+
+The script boots the Worker, drives `/api/exact-review-queue`, terminates the full Wrangler process
+tree, and inspects Wrangler's persisted SQLite database for the direct-publication table. Only
+after that assertion does it seed disposable pending fences, restart the Worker, and submit the
+three signed plans. Pending fences let the real Worker accept and persist the valid plans without
+mocking the publication store or bypassing HTTP validation.
+
+Run from the repository root on Node 24 or newer:
+
+```bash
+bash docs/proof/mixed-case-publication-slugs/run-proof.sh
+```
+
+Set `MIXED_CASE_PUBLICATION_SLUGS_PROOF_OUTPUT` to keep generated artifacts outside the repository.
+The default artifact directory contains the signed request/response bodies, runtime transcript,
+build/install logs, and a redacted Wrangler log.
+
+This proof does not change retry or permanence classification, migrate stored records, deploy, or
+mutate production. OpenClaw Bay is unaffected: the change only relaxes repository-name casing at
+internal publication validation boundaries and does not change Bay data or controls.

--- a/docs/proof/mixed-case-publication-slugs/assert-durable-object.mjs
+++ b/docs/proof/mixed-case-publication-slugs/assert-durable-object.mjs
@@ -1,0 +1,16 @@
+import { DatabaseSync } from "node:sqlite";
+
+const [databasePath] = process.argv.slice(2);
+if (!databasePath) throw new Error("usage: assert-durable-object.mjs <database-path>");
+
+const database = new DatabaseSync(databasePath);
+try {
+  const row = database
+    .prepare(
+      "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'exact_review_direct_publication_plans'",
+    )
+    .get();
+  console.log(row.count);
+} finally {
+  database.close();
+}

--- a/docs/proof/mixed-case-publication-slugs/assert-durable-object.mjs
+++ b/docs/proof/mixed-case-publication-slugs/assert-durable-object.mjs
@@ -1,16 +1,83 @@
+import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 
-const [databasePath] = process.argv.slice(2);
-if (!databasePath) throw new Error("usage: assert-durable-object.mjs <database-path>");
+const [databasePath, command = "table-present"] = process.argv.slice(2);
+if (!databasePath) {
+  throw new Error(
+    "usage: assert-durable-object.mjs <database-path> [table-present|canonical-namespace]",
+  );
+}
 
 const database = new DatabaseSync(databasePath);
 try {
-  const row = database
-    .prepare(
-      "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'exact_review_direct_publication_plans'",
-    )
-    .get();
-  console.log(row.count);
+  if (command === "table-present") {
+    const row = database
+      .prepare(
+        "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'exact_review_direct_publication_plans'",
+      )
+      .get();
+    console.log(row.count);
+  } else if (command === "canonical-namespace") {
+    const lowerSlug = "steipete-codexbar";
+    const upperSlug = "steipete-CodexBar";
+    const itemId = 2516;
+    const canonical = database
+      .prepare(
+        `SELECT content, deleted FROM exact_review_canonical_records
+          WHERE repo_slug = ? AND section = 'items' AND item_id = ?`,
+      )
+      .get(lowerSlug, itemId);
+    const counts = database
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM exact_review_canonical_records
+             WHERE repo_slug = ?) AS lower_canonical_count,
+           (SELECT COUNT(*) FROM exact_review_record_export_index
+             WHERE repo_slug = ?) AS lower_export_count,
+           (SELECT COUNT(*) FROM exact_review_canonical_records
+             WHERE repo_slug = ?) AS upper_canonical_count,
+           (SELECT COUNT(*) FROM exact_review_record_export_index
+             WHERE repo_slug = ?) AS upper_export_count`,
+      )
+      .get(lowerSlug, lowerSlug, upperSlug, upperSlug);
+    const receipt = database
+      .prepare(
+        `SELECT operations_json FROM exact_review_direct_publication_plans
+          WHERE canonical_target_key = 'steipete/CodexBar#2516' AND revision = 1`,
+      )
+      .get();
+    const operations = JSON.parse(String(receipt?.operations_json || "[]"));
+
+    assert.equal(canonical?.content, "x");
+    assert.equal(canonical?.deleted, 0);
+    assert.ok(Number(counts.lower_canonical_count) > 0);
+    assert.ok(Number(counts.lower_export_count) > 0);
+    assert.equal(counts.upper_canonical_count, 0);
+    assert.equal(counts.upper_export_count, 0);
+    assert.equal(operations[0]?.path, "records/steipete-codexbar/items/2516.md");
+    assert.equal(
+      operations.some((operation) => operation.path.includes("steipete-CodexBar")),
+      false,
+    );
+    console.log(
+      JSON.stringify(
+        {
+          lowerSlug,
+          lowerCanonicalRead: canonical.content,
+          lowerCanonicalCount: Number(counts.lower_canonical_count),
+          lowerExportCount: Number(counts.lower_export_count),
+          upperSlug,
+          upperCanonicalCount: Number(counts.upper_canonical_count),
+          upperExportCount: Number(counts.upper_export_count),
+          receiptPath: operations[0].path,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    throw new Error(`unknown assertion command: ${command}`);
+  }
 } finally {
   database.close();
 }

--- a/docs/proof/mixed-case-publication-slugs/run-proof.sh
+++ b/docs/proof/mixed-case-publication-slugs/run-proof.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+output_dir="${MIXED_CASE_PUBLICATION_SLUGS_PROOF_OUTPUT:-docs/proof/mixed-case-publication-slugs/artifacts}"
+worker_port="${MIXED_CASE_PUBLICATION_SLUGS_PROOF_PORT:-8798}"
+proof_secret="mixed-case-publication-slugs-disposable-local-secret"
+proof_dir="docs/proof/mixed-case-publication-slugs"
+state_dir="$(mktemp -d /tmp/mixed-case-publication-slugs-state.XXXXXX)"
+wrangler_raw_log="$(mktemp /tmp/mixed-case-publication-slugs-wrangler.XXXXXX)"
+wrangler_pid=""
+queue_db=""
+
+mkdir -p "$output_dir"
+
+stop_worker() {
+  if test -n "$wrangler_pid"; then
+    local -a worker_pids=("$wrangler_pid")
+    local child_pid
+    while IFS= read -r child_pid; do
+      worker_pids+=("$child_pid")
+    done < <(
+      ps -eo pid=,ppid= | awk -v root="$wrangler_pid" '
+        { parent[$1] = $2 }
+        END {
+          for (pid in parent) {
+            current = pid
+            for (depth = 0; depth < 100 && current in parent; depth++) {
+              current = parent[current]
+              if (current == root) {
+                print pid
+                break
+              }
+            }
+          }
+        }
+      '
+    )
+    kill "${worker_pids[@]}" >/dev/null 2>&1 || true
+    wait "$wrangler_pid" >/dev/null 2>&1 || true
+    wrangler_pid=""
+
+    local stopped=false
+    for _ in $(seq 1 50); do
+      if ! curl --silent --max-time 1 "http://127.0.0.1:${worker_port}/api/health" \
+        >/dev/null 2>&1; then
+        stopped=true
+        break
+      fi
+      sleep 0.1
+    done
+    if test "$stopped" != true; then
+      echo "failed to stop the Wrangler process tree before restart" >&2
+      exit 1
+    fi
+  fi
+}
+
+cleanup() {
+  stop_worker
+  sed "s/${proof_secret}/[redacted-local-proof-secret]/g" "$wrangler_raw_log" \
+    >"${output_dir}/wrangler.log"
+  rm -f -- "$wrangler_raw_log"
+  rm -rf -- "$state_dir"
+}
+trap cleanup EXIT
+
+start_worker() {
+  npm_config_ignore_scripts=true npx --yes wrangler@4.107.0 dev \
+    --config dashboard/wrangler.toml \
+    --local \
+    --persist-to "$state_dir" \
+    --ip 127.0.0.1 \
+    --port "$worker_port" \
+    --var "CLAWSWEEPER_WEBHOOK_SECRET:${proof_secret}" \
+    >>"$wrangler_raw_log" 2>&1 &
+  wrangler_pid=$!
+
+  local ready=false
+  for _ in $(seq 1 90); do
+    if curl --fail --silent "http://127.0.0.1:${worker_port}/api/health" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    if ! kill -0 "$wrangler_pid" >/dev/null 2>&1; then
+      sed -n '1,240p' "$wrangler_raw_log" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  test "$ready" = true
+}
+
+http_status() {
+  local output_file="$1"
+  shift
+  curl --silent --show-error --max-time 90 --output "$output_file" --write-out '%{http_code}' "$@"
+}
+
+signed_post() {
+  local body_file="$1"
+  local output_file="$2"
+  local signature
+  signature="$(openssl dgst -sha256 -hmac "$proof_secret" -hex <"$body_file" | awk '{print $NF}')"
+  http_status "$output_file" \
+    -X POST \
+    -H "content-type: application/json" \
+    -H "x-clawsweeper-exact-review-signature: sha256=${signature}" \
+    --data-binary "@${body_file}" \
+    "http://127.0.0.1:${worker_port}/internal/exact-review/publication-results"
+}
+
+pnpm install --frozen-lockfile >"${output_dir}/dependencies-install.log" 2>&1
+pnpm run build:dashboard >"${output_dir}/build-dashboard.log" 2>&1
+
+start_worker
+initial_queue_status="$(http_status "${output_dir}/initial-queue.json" \
+  "http://127.0.0.1:${worker_port}/api/exact-review-queue")"
+test "$initial_queue_status" = "200"
+stop_worker
+
+while IFS= read -r candidate; do
+  if test "$(node "${proof_dir}/assert-durable-object.mjs" "$candidate")" = "1"; then
+    queue_db="$candidate"
+    break
+  fi
+done < <(find "$state_dir" -type f -name '*.sqlite' -print)
+if test -z "$queue_db"; then
+  echo "Durable Object did not initialize: direct publication table is absent" >&2
+  exit 1
+fi
+node "${proof_dir}/seed-publication-fences.mjs" "$queue_db"
+
+node -e '
+  const fs = require("node:fs");
+  const plan = (key, path) => ({
+    canonicalTargetKey: key,
+    fenceKey: key,
+    sourceSha: "a".repeat(40),
+    revision: 1,
+    identity: {
+      canonicalTargetKey: key,
+      fenceKey: key,
+      revision: 1,
+      claimGeneration: 1,
+    },
+    operations: [{
+      path,
+      deleted: false,
+      mode: "100644",
+      bytes: 1,
+      contentBase64: "eA==",
+    }],
+    totalBytes: 1,
+    lifecycle: { kind: "policy_noop" },
+  });
+  fs.writeFileSync(
+    process.argv[1],
+    JSON.stringify(plan("steipete/CodexBar#2516", "records/steipete-codexbar/items/2516.md")),
+  );
+  fs.writeFileSync(
+    process.argv[2],
+    JSON.stringify(plan("steipete/CodexBar#2517", "records/steipete-other/items/2517.md")),
+  );
+  fs.writeFileSync(
+    process.argv[3],
+    JSON.stringify(plan("openclaw/openclaw#806", "records/openclaw-openclaw/items/806.md")),
+  );
+' \
+  "${output_dir}/mixed-case-request.json" \
+  "${output_dir}/different-repository-request.json" \
+  "${output_dir}/lowercase-request.json"
+
+start_worker
+mixed_status="$(signed_post \
+  "${output_dir}/mixed-case-request.json" \
+  "${output_dir}/mixed-case-response.json")"
+different_status="$(signed_post \
+  "${output_dir}/different-repository-request.json" \
+  "${output_dir}/different-repository-response.json")"
+lowercase_status="$(signed_post \
+  "${output_dir}/lowercase-request.json" \
+  "${output_dir}/lowercase-response.json")"
+test "$mixed_status" = "202"
+test "$different_status" = "400"
+test "$lowercase_status" = "202"
+
+MIXED_STATUS="$mixed_status" DIFFERENT_STATUS="$different_status" LOWERCASE_STATUS="$lowercase_status" \
+  node -e '
+    const assert = require("node:assert/strict");
+    const fs = require("node:fs");
+    const mixed = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const different = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+    const lowercase = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+    for (const body of [mixed, lowercase]) {
+      assert.equal(body.ok, true);
+      assert.equal(body.accepted || body.deduped, true);
+    }
+    assert.equal(mixed.canonical_target_key, "steipete/CodexBar#2516");
+    assert.equal(lowercase.canonical_target_key, "openclaw/openclaw#806");
+    assert.equal(different.error, "invalid_direct_publication_plan");
+    assert.equal(different.fallback_required, true);
+    assert.match(
+      different.detail,
+      /direct publication path is outside steipete-CodexBar#2517: records\/steipete-other\/items\/2517\.md/,
+    );
+    const lines = [
+      "Durable Object initialized: exact_review_direct_publication_plans table present",
+      "mixed-case repository with lowercase path: HTTP " + process.env.MIXED_STATUS + "; accepted=" + mixed.accepted + "; deduped=" + mixed.deduped + "; canonical_target_key=" + mixed.canonical_target_key,
+      "different repository: HTTP " + process.env.DIFFERENT_STATUS + "; error=" + different.error + "; fallback_required=" + different.fallback_required + "; detail=" + different.detail,
+      "lowercase repository: HTTP " + process.env.LOWERCASE_STATUS + "; accepted=" + lowercase.accepted + "; deduped=" + lowercase.deduped + "; canonical_target_key=" + lowercase.canonical_target_key,
+    ];
+    fs.writeFileSync(process.argv[4], lines.join("\n") + "\n");
+  ' \
+  "${output_dir}/mixed-case-response.json" \
+  "${output_dir}/different-repository-response.json" \
+  "${output_dir}/lowercase-response.json" \
+  "${output_dir}/runtime-transcript.txt"
+
+test -s "${output_dir}/runtime-transcript.txt"
+cat "${output_dir}/runtime-transcript.txt"

--- a/docs/proof/mixed-case-publication-slugs/run-proof.sh
+++ b/docs/proof/mixed-case-publication-slugs/run-proof.sh
@@ -102,6 +102,7 @@ http_status() {
 signed_post() {
   local body_file="$1"
   local output_file="$2"
+  local endpoint="${3:-/internal/exact-review/publication-results}"
   local signature
   signature="$(openssl dgst -sha256 -hmac "$proof_secret" -hex <"$body_file" | awk '{print $NF}')"
   http_status "$output_file" \
@@ -109,7 +110,7 @@ signed_post() {
     -H "content-type: application/json" \
     -H "x-clawsweeper-exact-review-signature: sha256=${signature}" \
     --data-binary "@${body_file}" \
-    "http://127.0.0.1:${worker_port}/internal/exact-review/publication-results"
+    "http://127.0.0.1:${worker_port}${endpoint}"
 }
 
 pnpm install --frozen-lockfile >"${output_dir}/dependencies-install.log" 2>&1
@@ -158,7 +159,7 @@ node -e '
   });
   fs.writeFileSync(
     process.argv[1],
-    JSON.stringify(plan("steipete/CodexBar#2516", "records/steipete-codexbar/items/2516.md")),
+    JSON.stringify(plan("steipete/CodexBar#2516", "records/steipete-CodexBar/items/2516.md")),
   );
   fs.writeFileSync(
     process.argv[2],
@@ -168,10 +169,32 @@ node -e '
     process.argv[3],
     JSON.stringify(plan("openclaw/openclaw#806", "records/openclaw-openclaw/items/806.md")),
   );
+  fs.writeFileSync(
+    process.argv[4],
+    JSON.stringify({
+      repoSlug: "steipete-codexbar",
+      sections: ["items"],
+      sinceRevision: 0,
+      cursor: 0,
+      limit: 100,
+    }),
+  );
+  fs.writeFileSync(
+    process.argv[5],
+    JSON.stringify({
+      repoSlug: "steipete-CodexBar",
+      sections: ["items"],
+      sinceRevision: 0,
+      cursor: 0,
+      limit: 100,
+    }),
+  );
 ' \
   "${output_dir}/mixed-case-request.json" \
   "${output_dir}/different-repository-request.json" \
-  "${output_dir}/lowercase-request.json"
+  "${output_dir}/lowercase-request.json" \
+  "${output_dir}/lowercase-export-request.json" \
+  "${output_dir}/uppercase-export-request.json"
 
 start_worker
 mixed_status="$(signed_post \
@@ -183,23 +206,43 @@ different_status="$(signed_post \
 lowercase_status="$(signed_post \
   "${output_dir}/lowercase-request.json" \
   "${output_dir}/lowercase-response.json")"
+lowercase_export_status="$(signed_post \
+  "${output_dir}/lowercase-export-request.json" \
+  "${output_dir}/lowercase-export-response.json" \
+  "/internal/state/records/export")"
+uppercase_export_status="$(signed_post \
+  "${output_dir}/uppercase-export-request.json" \
+  "${output_dir}/uppercase-export-response.json" \
+  "/internal/state/records/export")"
 test "$mixed_status" = "202"
 test "$different_status" = "400"
 test "$lowercase_status" = "202"
+test "$lowercase_export_status" = "200"
+test "$uppercase_export_status" = "200"
 
 MIXED_STATUS="$mixed_status" DIFFERENT_STATUS="$different_status" LOWERCASE_STATUS="$lowercase_status" \
+  LOWERCASE_EXPORT_STATUS="$lowercase_export_status" UPPERCASE_EXPORT_STATUS="$uppercase_export_status" \
   node -e '
     const assert = require("node:assert/strict");
     const fs = require("node:fs");
     const mixed = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
     const different = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
     const lowercase = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+    const lowercaseExport = JSON.parse(fs.readFileSync(process.argv[4], "utf8"));
+    const uppercaseExport = JSON.parse(fs.readFileSync(process.argv[5], "utf8"));
     for (const body of [mixed, lowercase]) {
       assert.equal(body.ok, true);
       assert.equal(body.accepted || body.deduped, true);
     }
     assert.equal(mixed.canonical_target_key, "steipete/CodexBar#2516");
     assert.equal(lowercase.canonical_target_key, "openclaw/openclaw#806");
+    assert.equal(lowercaseExport.repoSlug, "steipete-codexbar");
+    assert.equal(lowercaseExport.records.length, 1);
+    assert.equal(lowercaseExport.records[0].section, "items");
+    assert.equal(lowercaseExport.records[0].id, "2516");
+    assert.equal(lowercaseExport.records[0].content, "x");
+    assert.equal(uppercaseExport.repoSlug, "steipete-CodexBar");
+    assert.deepEqual(uppercaseExport.records, []);
     assert.equal(different.error, "invalid_direct_publication_plan");
     assert.equal(different.fallback_required, true);
     assert.match(
@@ -208,16 +251,25 @@ MIXED_STATUS="$mixed_status" DIFFERENT_STATUS="$different_status" LOWERCASE_STAT
     );
     const lines = [
       "Durable Object initialized: exact_review_direct_publication_plans table present",
-      "mixed-case repository with lowercase path: HTTP " + process.env.MIXED_STATUS + "; accepted=" + mixed.accepted + "; deduped=" + mixed.deduped + "; canonical_target_key=" + mixed.canonical_target_key,
+      "mixed-case repository with uppercase path: HTTP " + process.env.MIXED_STATUS + "; accepted=" + mixed.accepted + "; deduped=" + mixed.deduped + "; canonical_target_key=" + mixed.canonical_target_key,
       "different repository: HTTP " + process.env.DIFFERENT_STATUS + "; error=" + different.error + "; fallback_required=" + different.fallback_required + "; detail=" + different.detail,
       "lowercase repository: HTTP " + process.env.LOWERCASE_STATUS + "; accepted=" + lowercase.accepted + "; deduped=" + lowercase.deduped + "; canonical_target_key=" + lowercase.canonical_target_key,
+      "lowercase namespace export: HTTP " + process.env.LOWERCASE_EXPORT_STATUS + "; records=" + lowercaseExport.records.length + "; content=" + lowercaseExport.records[0].content,
+      "uppercase namespace export: HTTP " + process.env.UPPERCASE_EXPORT_STATUS + "; records=" + uppercaseExport.records.length,
     ];
-    fs.writeFileSync(process.argv[4], lines.join("\n") + "\n");
+    fs.writeFileSync(process.argv[6], lines.join("\n") + "\n");
   ' \
   "${output_dir}/mixed-case-response.json" \
   "${output_dir}/different-repository-response.json" \
   "${output_dir}/lowercase-response.json" \
+  "${output_dir}/lowercase-export-response.json" \
+  "${output_dir}/uppercase-export-response.json" \
   "${output_dir}/runtime-transcript.txt"
+
+stop_worker
+node "${proof_dir}/assert-durable-object.mjs" "$queue_db" canonical-namespace \
+  >"${output_dir}/namespace-storage.json"
+cat "${output_dir}/namespace-storage.json" >>"${output_dir}/runtime-transcript.txt"
 
 test -s "${output_dir}/runtime-transcript.txt"
 cat "${output_dir}/runtime-transcript.txt"

--- a/docs/proof/mixed-case-publication-slugs/seed-publication-fences.mjs
+++ b/docs/proof/mixed-case-publication-slugs/seed-publication-fences.mjs
@@ -1,0 +1,40 @@
+import { createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+
+const [databasePath] = process.argv.slice(2);
+if (!databasePath) throw new Error("usage: seed-publication-fences.mjs <database-path>");
+
+const publications = [
+  {
+    key: "steipete/CodexBar#2516",
+    path: "records/steipete-codexbar/items/2516.md",
+  },
+  {
+    key: "openclaw/openclaw#806",
+    path: "records/openclaw-openclaw/items/806.md",
+  },
+];
+const digest = createHash("sha256").update("x").digest("hex");
+const database = new DatabaseSync(databasePath);
+try {
+  const insert = database.prepare(`
+    INSERT INTO exact_review_direct_publication_plans
+      (item_key, canonical_target_key, fence_key, revision, identity_item_key,
+       identity_revision, claim_generation, operations_json, lifecycle_json,
+       total_bytes, file_count, state, attempts, created_at, updated_at,
+       next_attempt_at, commit_sha, failure_reason)
+    VALUES (?, ?, ?, 1, ?, 1, 1, ?, ?, 1, 1, 'pending', 0, 1, 1, 1, NULL, NULL)
+  `);
+  for (const publication of publications) {
+    insert.run(
+      publication.key,
+      publication.key,
+      publication.key,
+      publication.key,
+      JSON.stringify([{ path: publication.path, bytes: 1, digest, deleted: false }]),
+      JSON.stringify({ kind: "policy_noop" }),
+    );
+  }
+} finally {
+  database.close();
+}

--- a/src/repair/record-tuple.ts
+++ b/src/repair/record-tuple.ts
@@ -494,7 +494,7 @@ function validatePacketReference(
     }
     return;
   }
-  if (pointer !== tuple.paths.packet) {
+  if (!recordPathsEqualIgnoringRepositoryCase(pointer, tuple.paths.packet)) {
     throw tupleError(tuple.paths, `${label} points to unexpected packet path ${pointer}`);
   }
   if (!/^[a-f0-9]{64}$/.test(digest)) {
@@ -536,12 +536,12 @@ function validatePacketSemantics(
     throw tupleError(tuple.paths, `${label} decision packet has malformed subject identity`);
   }
   if (
-    subject.repo.replace("/", "-") !== tuple.paths.repository ||
+    !repositoryNamesEqual(subject.repo.replace("/", "-"), tuple.paths.repository) ||
     String(subject.number) !== tuple.paths.number
   ) {
     throw tupleError(tuple.paths, `${label} decision packet belongs to another subject`);
   }
-  if (!source || source.reportPath !== primaryPath) {
+  if (!source || !recordPathsEqualIgnoringRepositoryCase(source.reportPath, primaryPath)) {
     throw tupleError(tuple.paths, `${label} decision packet points to another primary record`);
   }
   const primaryNumber = frontMatter.get("number");
@@ -549,9 +549,23 @@ function validatePacketSemantics(
   if (primaryNumber !== undefined && primaryNumber !== tuple.paths.number) {
     throw tupleError(tuple.paths, `${label} primary record has mismatched number`);
   }
-  if (primaryRepository !== undefined && primaryRepository !== subject.repo) {
+  if (primaryRepository !== undefined && !repositoryNamesEqual(primaryRepository, subject.repo)) {
     throw tupleError(tuple.paths, `${label} primary record has mismatched repository`);
   }
+}
+
+function repositoryNamesEqual(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function recordPathsEqualIgnoringRepositoryCase(left: unknown, right: string): boolean {
+  if (typeof left !== "string") return false;
+  const normalize = (value: string) =>
+    value.replace(
+      /^records\/([^/]+)\//,
+      (_match, repository: string) => `records/${repository.toLowerCase()}/`,
+    );
+  return normalize(left) === normalize(right);
 }
 
 function parseFrontMatter(markdown: string): Map<string, string> {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -4219,8 +4219,18 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
 
 test("direct publication keeps GitHub casing while using lowercase canonical record slugs", async () => {
   const fixtures = [
-    { targetRepo: "steipete/CodexBar", repoSlug: "steipete-codexbar", itemNumber: 2831 },
-    { targetRepo: "openclaw/Peekaboo", repoSlug: "openclaw-peekaboo", itemNumber: 364 },
+    {
+      targetRepo: "steipete/CodexBar",
+      inputRepoSlug: "steipete-CodexBar",
+      repoSlug: "steipete-codexbar",
+      itemNumber: 2831,
+    },
+    {
+      targetRepo: "openclaw/Peekaboo",
+      inputRepoSlug: "openclaw-peekaboo",
+      repoSlug: "openclaw-peekaboo",
+      itemNumber: 364,
+    },
   ] as const;
   const storage = new MemoryDurableStorage();
   const items: Record<string, ReturnType<typeof leasedExactReviewQueueItem>> = {};
@@ -4259,7 +4269,7 @@ test("direct publication keeps GitHub casing while using lowercase canonical rec
       },
       operations: [
         {
-          path: `records/${fixture.repoSlug}/items/${fixture.itemNumber}.md`,
+          path: `records/${fixture.inputRepoSlug}/items/${fixture.itemNumber}.md`,
           deleted: false,
           mode: "100644",
           bytes: Buffer.byteLength(content),
@@ -4304,43 +4314,32 @@ test("direct publication keeps GitHub casing while using lowercase canonical rec
     ).json();
     assert.equal(canonical.content, content);
     assert.equal(canonical.revision, 4);
+    if (fixture.inputRepoSlug !== fixture.repoSlug) {
+      assert.equal(
+        (
+          await queue.fetch(
+            new Request(
+              `https://queue/records/${fixture.inputRepoSlug}/items/${fixture.itemNumber}`,
+              { method: "GET" },
+            ),
+          )
+        ).status,
+        404,
+      );
+    }
   }
 
-  const uppercasePathPayload = {
-    canonicalTargetKey: "steipete/CodexBar#2831",
-    fenceKey: "steipete/CodexBar#2831",
-    revision: 4,
-    sourceSha: "c".repeat(40),
-    identity: {
-      canonicalTargetKey: "steipete/CodexBar#2831",
-      fenceKey: "steipete/CodexBar#2831",
-      revision: 4,
-      claimGeneration: 2,
-    },
-    operations: [
-      {
-        path: "records/steipete-CodexBar/items/2831.md",
-        deleted: false,
-        mode: "100644",
-        bytes: 1,
-        contentBase64: "eA==",
-      },
-    ],
-    totalBytes: 1,
-    lifecycle: { kind: "router" },
-  };
-  const uppercaseBody = JSON.stringify(uppercasePathPayload);
-  const uppercaseSignature = `sha256=${createHmac("sha256", env.CLAWSWEEPER_WEBHOOK_SECRET).update(uppercaseBody).digest("hex")}`;
-  const uppercase = await worker.fetch(
-    new Request(url, {
-      method: "POST",
-      headers: { "x-clawsweeper-exact-review-signature": uppercaseSignature },
-      body: uppercaseBody,
-    }),
-    env,
+  const [parallelNamespaceRows] = Array.from(
+    storage.sql.exec(
+      `SELECT
+         (SELECT COUNT(*) FROM exact_review_canonical_records
+           WHERE repo_slug = 'steipete-CodexBar') AS canonical_count,
+         (SELECT COUNT(*) FROM exact_review_record_export_index
+           WHERE repo_slug = 'steipete-CodexBar') AS export_count`,
+    ),
   );
-  assert.equal(uppercase.status, 400);
-  assert.equal((await uppercase.json()).error, "invalid_direct_publication_plan");
+  assert.equal(parallelNamespaceRows?.canonical_count, 0);
+  assert.equal(parallelNamespaceRows?.export_count, 0);
 });
 
 test("fetching a stale publication batch records a durable superseded telemetry outcome", async () => {
@@ -16603,12 +16602,54 @@ test("fallback tuple publication normalizes mixed-case keys onto existing lowerc
     ...operation,
     path: operation.path.replace("steipete-codexbar", "steipete-CodexBar"),
   }));
-  const casingQueue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const casingStorage = new MemoryDurableStorage();
+  const casingQueue = new ExactReviewQueue({ storage: casingStorage }, {});
   const uppercaseAccepted = await casingQueue.fetch(
     stateAppendQueueRequest("/records/tuples", uppercasePaths),
   );
   assert.equal(uppercaseAccepted.status, 202);
   assert.equal((await uppercaseAccepted.json()).accepted, true);
+
+  const lowercasePathRetry = structuredClone(uppercasePaths);
+  lowercasePathRetry.operations = lowercasePathRetry.operations.map((operation) => ({
+    ...operation,
+    path: operation.path.replace("steipete-CodexBar", "steipete-codexbar"),
+  }));
+  const casingDeduped = await casingQueue.fetch(
+    stateAppendQueueRequest("/records/tuples", lowercasePathRetry),
+  );
+  assert.equal(casingDeduped.status, 202);
+  assert.deepEqual(await casingDeduped.json(), {
+    ok: true,
+    accepted: false,
+    deduped: true,
+    revision: 1,
+  });
+
+  const lowercaseCanonical = await casingQueue.fetch(
+    new Request("https://queue/records/steipete-codexbar/items/2831", { method: "GET" }),
+  );
+  assert.equal(lowercaseCanonical.status, 200);
+  assert.equal((await lowercaseCanonical.json()).content, item);
+  assert.equal(
+    (
+      await casingQueue.fetch(
+        new Request("https://queue/records/steipete-CodexBar/items/2831", { method: "GET" }),
+      )
+    ).status,
+    404,
+  );
+  const [uppercaseNamespaceRows] = Array.from(
+    casingStorage.sql.exec(
+      `SELECT
+         (SELECT COUNT(*) FROM exact_review_canonical_records
+           WHERE repo_slug = 'steipete-CodexBar') AS canonical_count,
+         (SELECT COUNT(*) FROM exact_review_record_export_index
+           WHERE repo_slug = 'steipete-CodexBar') AS export_count`,
+    ),
+  );
+  assert.equal(uppercaseNamespaceRows?.canonical_count, 0);
+  assert.equal(uppercaseNamespaceRows?.export_count, 0);
 
   const differentRepository = structuredClone(mutation);
   differentRepository.deliveryId = "record-tuple:mixed-case:2831:different-repository";

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -16603,7 +16603,22 @@ test("fallback tuple publication normalizes mixed-case keys onto existing lowerc
     ...operation,
     path: operation.path.replace("steipete-codexbar", "steipete-CodexBar"),
   }));
-  const rejected = await queue.fetch(stateAppendQueueRequest("/records/tuples", uppercasePaths));
+  const casingQueue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const uppercaseAccepted = await casingQueue.fetch(
+    stateAppendQueueRequest("/records/tuples", uppercasePaths),
+  );
+  assert.equal(uppercaseAccepted.status, 202);
+  assert.equal((await uppercaseAccepted.json()).accepted, true);
+
+  const differentRepository = structuredClone(mutation);
+  differentRepository.deliveryId = "record-tuple:mixed-case:2831:different-repository";
+  differentRepository.operations = differentRepository.operations.map((operation) => ({
+    ...operation,
+    path: operation.path.replace("steipete-codexbar", "steipete-other"),
+  }));
+  const rejected = await casingQueue.fetch(
+    stateAppendQueueRequest("/records/tuples", differentRepository),
+  );
   assert.equal(rejected.status, 400);
   assert.deepEqual(await rejected.json(), { error: "invalid_canonical_record_tuple" });
 });

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHmac, generateKeyPairSync } from "node:crypto";
+import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
@@ -9,6 +9,7 @@ import {
   EXACT_REVIEW_DIRECT_PUBLICATION_RETENTION_MS,
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   ExactReviewDirectPublicationStore,
+  validateCanonicalRecordTupleMutation,
   validateDirectPublicationPlan,
   type DirectPublicationPlan,
 } from "../dashboard/exact-review-direct-publication.ts";
@@ -431,6 +432,92 @@ test("direct publication validates tuple and per-file size caps", async () => {
   });
   await assert.rejects(validateDirectPublicationPlan(invalidPath), /outside openclaw-openclaw#8/);
   assert.equal(EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES, 4 * 1024 * 1024);
+});
+
+test("direct publication accepts repository-only path casing differences", async () => {
+  const mixedCase = directPlan("steipete/CodexBar#2516", 1, {
+    path: "records/steipete-codexbar/items/2516.md",
+  });
+  const accepted = await validateDirectPublicationPlan(mixedCase);
+  assert.equal(accepted.operations[0]?.path, "records/steipete-codexbar/items/2516.md");
+  assert.equal(accepted.operations[0]?.repoSlug, "steipete-codexbar");
+  assert.equal(
+    accepted.operations[0]?.digest,
+    createHash("sha256").update(Buffer.from("result-1")).digest("hex"),
+  );
+
+  const differentRepository = structuredClone(mixedCase);
+  differentRepository.operations[0]!.path = "records/steipete-other/items/2516.md";
+  await assert.rejects(
+    validateDirectPublicationPlan(differentRepository),
+    /direct publication path is outside steipete-CodexBar#2516/,
+  );
+
+  const invalidMode = structuredClone(mixedCase);
+  invalidMode.operations[0]!.mode = "100755" as "100644";
+  await assert.rejects(validateDirectPublicationPlan(invalidMode), /invalid mutation mode/);
+
+  const invalidBytes = structuredClone(mixedCase);
+  invalidBytes.operations[0]!.bytes += 1;
+  await assert.rejects(
+    validateDirectPublicationPlan(invalidBytes),
+    /mutation byte count does not match content/,
+  );
+});
+
+test("lowercase direct publication preserves operation bytes exactly", async () => {
+  const input = directPlan("openclaw/openclaw#806", 1);
+  const accepted = await validateDirectPublicationPlan(input);
+  assert.equal(accepted.operations[0]?.path, input.operations[0]?.path);
+  assert.equal(accepted.operations[0]?.mode, input.operations[0]?.mode);
+  assert.equal(accepted.operations[0]?.bytes, input.operations[0]?.bytes);
+  assert.equal(accepted.operations[0]?.contentBase64, input.operations[0]?.contentBase64);
+  assert.deepEqual(
+    Buffer.from(accepted.operations[0]!.contentBase64!, "base64"),
+    Buffer.from(input.operations[0]!.contentBase64!, "base64"),
+  );
+});
+
+test("canonical tuple packet references ignore only repository casing", async () => {
+  const packet = JSON.stringify({ decision: "keep-open" });
+  const packetDigest = createHash("sha256").update(packet).digest("hex");
+  const item = [
+    "---",
+    `decision_packet_sha256: ${packetDigest}`,
+    "decision_packet_path: records/steipete-CodexBar/decision-packets/2516.json",
+    "---",
+    "",
+    "review",
+  ].join("\n");
+  const mutation = {
+    deliveryId: "record-tuple:mixed-packet-path:2516",
+    key: "steipete-CodexBar/2516",
+    operations: [
+      {
+        path: "records/steipete-codexbar/items/2516.md",
+        expectedDigest: null,
+        contentBase64: Buffer.from(item).toString("base64"),
+      },
+      { path: "records/steipete-codexbar/closed/2516.md", expectedDigest: null },
+      { path: "records/steipete-codexbar/plans/2516.md", expectedDigest: null },
+      {
+        path: "records/steipete-codexbar/decision-packets/2516.json",
+        expectedDigest: null,
+        contentBase64: Buffer.from(packet).toString("base64"),
+      },
+    ],
+  };
+
+  await assert.doesNotReject(validateCanonicalRecordTupleMutation(mutation));
+
+  const wrongDigest = structuredClone(mutation);
+  wrongDigest.operations[0]!.contentBase64 = Buffer.from(
+    item.replace(packetDigest, "0".repeat(64)),
+  ).toString("base64");
+  await assert.rejects(
+    validateCanonicalRecordTupleMutation(wrongDigest),
+    /decision packet reference is inconsistent/,
+  );
 });
 
 test("publication batches atomically select ready items without duplicate active ownership", () => {

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -436,7 +436,7 @@ test("direct publication validates tuple and per-file size caps", async () => {
 
 test("direct publication accepts repository-only path casing differences", async () => {
   const mixedCase = directPlan("steipete/CodexBar#2516", 1, {
-    path: "records/steipete-codexbar/items/2516.md",
+    path: "records/steipete-CodexBar/items/2516.md",
   });
   const accepted = await validateDirectPublicationPlan(mixedCase);
   assert.equal(accepted.operations[0]?.path, "records/steipete-codexbar/items/2516.md");
@@ -445,6 +445,42 @@ test("direct publication accepts repository-only path casing differences", async
     accepted.operations[0]?.digest,
     createHash("sha256").update(Buffer.from("result-1")).digest("hex"),
   );
+
+  const storage = new TestStorage();
+  const store = new ExactReviewDirectPublicationStore(storage);
+  store.ensureSchemaSync();
+  assert.equal(store.accept(accepted, 1_000).outcome, "accepted");
+  const normalizedRetry = await validateDirectPublicationPlan(
+    directPlan("steipete/CodexBar#2516", 1, {
+      path: "records/steipete-codexbar/items/2516.md",
+    }),
+  );
+  assert.equal(store.accept(normalizedRetry, 1_001).outcome, "deduped");
+  assert.equal(store.list().length, 1);
+  assert.equal(store.readCanonical("steipete-codexbar", "items", 2516)?.content, "result-1");
+  assert.equal(store.readCanonical("steipete-CodexBar", "items", 2516), null);
+  assert.equal(
+    storage.scalar(
+      `SELECT COUNT(*) AS value FROM exact_review_canonical_records
+        WHERE repo_slug = 'steipete-CodexBar'`,
+    ),
+    0,
+  );
+  assert.equal(
+    storage.scalar(
+      `SELECT COUNT(*) AS value FROM exact_review_record_export_index
+        WHERE repo_slug = 'steipete-CodexBar'`,
+    ),
+    0,
+  );
+  assert.deepEqual(store.get(accepted.fenceKey, accepted.revision)?.operations, [
+    {
+      path: "records/steipete-codexbar/items/2516.md",
+      bytes: Buffer.byteLength("result-1"),
+      digest: createHash("sha256").update(Buffer.from("result-1")).digest("hex"),
+      deleted: false,
+    },
+  ]);
 
   const differentRepository = structuredClone(mixedCase);
   differentRepository.operations[0]!.path = "records/steipete-other/items/2516.md";
@@ -455,7 +491,10 @@ test("direct publication accepts repository-only path casing differences", async
 
   const invalidMode = structuredClone(mixedCase);
   invalidMode.operations[0]!.mode = "100755" as "100644";
-  await assert.rejects(validateDirectPublicationPlan(invalidMode), /invalid mutation mode/);
+  await assert.rejects(
+    validateDirectPublicationPlan(invalidMode),
+    /invalid mutation mode for records\/steipete-CodexBar\/items\/2516\.md/,
+  );
 
   const invalidBytes = structuredClone(mixedCase);
   invalidBytes.operations[0]!.bytes += 1;

--- a/test/repair/record-tuple.test.ts
+++ b/test/repair/record-tuple.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  recordTuplePaths,
+  validateRecordTuple,
+  type RecordTupleContents,
+} from "../../src/repair/record-tuple.ts";
+
+function mixedCaseTuple(subjectRepository = "steipete/CodexBar"): RecordTupleContents {
+  const number = "2516";
+  const paths = recordTuplePaths({ repository: "steipete-codexbar", number });
+  const packet = JSON.stringify({
+    version: 1,
+    subject: { repo: subjectRepository, number: Number(number) },
+    source: { reportPath: "records/steipete-CodexBar/items/2516.md" },
+  });
+  const digest = createHash("sha256").update(packet).digest("hex");
+  const item = [
+    "---",
+    "repository: steipete/CodexBar",
+    `number: ${number}`,
+    "reviewed_at: 2026-08-10T09:02:00.000Z",
+    `decision_packet_sha256: ${digest}`,
+    "decision_packet_path: records/steipete-CodexBar/decision-packets/2516.json",
+    "---",
+    "",
+    "review",
+    "",
+  ].join("\n");
+  return { paths, item, closed: null, plan: null, packet };
+}
+
+test("record tuple validation accepts repository-only casing differences", () => {
+  assert.doesNotThrow(() => validateRecordTuple(mixedCaseTuple()));
+});
+
+test("record tuple validation still rejects a genuinely different repository", () => {
+  assert.throws(
+    () => validateRecordTuple(mixedCaseTuple("steipete/Other")),
+    /decision packet belongs to another subject/,
+  );
+});


### PR DESCRIPTION
## Summary

- compare GitHub repository slugs case-insensitively at both direct-publication Worker containment boundaries while canonicalizing accepted record paths and storage slugs to lowercase
- preserve original GitHub target/fence casing and error input while converging canonical records, export rows, tuple receipts, and direct-publication receipts on one lowercase record namespace
- apply the same repository-only normalization to decision-packet path and subject validation on the Worker and client mirror
- add focused regression coverage plus a real local Wrangler/Durable Object HTTP and persisted-SQLite proof

## Validation

- `pnpm run build:all`
- `pnpm run test:no-build` — 3,274 tests; 3,265 passed, 9 skipped, 0 failed
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:dashboard-queue-boundary`
- pre-commit and committed-branch autoreview: clean, no accepted/actionable findings

## pr-behavior-proof

- **Claim:** A signed direct-publication plan for `steipete/CodexBar#2516` with an uppercase `records/steipete-CodexBar/...` operation is accepted but persisted and served only from `records/steipete-codexbar/...`; a truly different repository remains rejected, and an all-lowercase repository remains byte-identical.
- **Exercised surface:** Built dashboard Worker, signed `/internal/exact-review/publication-results` and `/internal/state/records/export` HTTP routes, the real `ExactReviewQueue` Durable Object with local Wrangler persistence, and its persisted canonical, export-index, and publication-receipt SQLite rows.
- **Scenario/fixture:** The harness boots the Worker, instantiates the Durable Object, stops the full Wrangler process tree, asserts the direct-publication table in persisted SQLite, seeds disposable pending fences, reboots, and sends uppercase-path, different-repository, and lowercase signed plans. It exports both lowercase and uppercase namespaces through the Worker, stops Wrangler, then inspects persisted SQLite.
- **Command/environment:** Node 24 on macOS with `MIXED_CASE_PUBLICATION_SLUGS_PROOF_OUTPUT=<temp-dir> bash docs/proof/mixed-case-publication-slugs/run-proof.sh`; then fresh PR head `ff1c1c7432a6341b6117afba405caed39e2b9da5` in Crabbox `provider=local-container`, image `node:24-bookworm`, lease `cbx_10e79c7cd9e6`, using `bash docs/proof/mixed-case-publication-slugs/run-proof.sh`.
- **Observable result:** The uppercase-path plan returned HTTP 202 with `accepted=true`; lowercase export returned one item with content `x`; uppercase export returned zero records; persisted SQLite contained 3 lowercase canonical rows, 3 lowercase export rows, zero uppercase canonical/export rows, and receipt path `records/steipete-codexbar/items/2516.md`. The different repository returned HTTP 400 `invalid_direct_publication_plan` with the original-case detail `direct publication path is outside steipete-CodexBar#2517: records/steipete-other/items/2517.md`; the all-lowercase plan returned HTTP 202 with `accepted=true`.
- **Artifact/trace:** `docs/proof/mixed-case-publication-slugs/` contains the reusable harness and contract. The disposable local artifact directory captured signed requests/responses, both export responses, a runtime transcript, namespace-storage JSON, build/install logs, and a redacted Wrangler log. The container run reported `PROOF_RC=0` and `leaseStopped=true`.
- **Limits:** Local Wrangler and the Docker-backed fresh-PR container prove the built Worker/DO path without production mutation, production Cloudflare deployment, or replaying live dead letters.

## OpenClaw Bay impact

No Bay change is needed. This only normalizes repository-name casing at internal publication validation and persistence boundaries; it does not change observer data, status projections, or any Bay control surface.

## Aftermath

The roughly 191 `tuple_protocol_invalid` dead letters are all `fresh_recovery.eligible`. After this deploys, the scheduled dead-letter reconciler will re-run them and they should publish without manual replay. The `CodexBar` re-review loop stops once those publications finally persist.
