### PR TITLE
fix: exclude zombie runs from operational health

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -68,6 +68,7 @@ import {
 import { ExactReviewLifecycleTelemetryStore } from "./exact-review-lifecycle-telemetry.ts";
 import { recentDurablePublicationEvents } from "./recent-durable-publication-events.ts";
 import { sanitizedServerError } from "./error-safety.ts";
+import { githubApiUrl } from "./github-api.ts";
 
 const RECENT_DURABLE_PUBLICATION_EVENTS_CACHE_MS = 60_000;
 
@@ -3314,6 +3315,7 @@ export class ExactReviewQueue {
       try {
         const token = await exactReviewDispatchToken(this.env);
         await dispatchExactReviewBatchWorkflow({
+          env: this.env,
           token,
           dispatchId: batchDispatchId,
           dispatchedAt: new Date(batchDispatchRecordedAt).toISOString(),
@@ -3366,7 +3368,11 @@ export class ExactReviewQueue {
     };
     try {
       const token = await exactReviewDispatchToken(this.env);
-      preflight = { ok: true, token, workflowState: await exactReviewWorkflowState(token) };
+      preflight = {
+        ok: true,
+        token,
+        workflowState: await exactReviewWorkflowState(token, this.env),
+      };
     } catch {
       preflight = { ok: false };
     }
@@ -3486,7 +3492,7 @@ export class ExactReviewQueue {
           const token = await targetTokenFor(candidate.decision.targetRepo);
           return {
             ...candidate,
-            state: await exactReviewTargetItemState(token, candidate.decision),
+            state: await exactReviewTargetItemState(token, candidate.decision, this.env),
           };
         } catch (error) {
           const failure = exactReviewAdmissionFailure(error);
@@ -3516,7 +3522,7 @@ export class ExactReviewQueue {
           const token = await targetTokenFor(candidate.decision.targetRepo);
           return {
             ...candidate,
-            state: await exactReviewTargetItemState(token, candidate.decision),
+            state: await exactReviewTargetItemState(token, candidate.decision, this.env),
           };
         } catch (error) {
           // Do not convert a target-read failure into a terminal result or a
@@ -3780,6 +3786,7 @@ export class ExactReviewQueue {
       }
       try {
         await dispatchClawsweeperItem({
+          env: this.env,
           token: preflight.token,
           decision: item.leaseDecision || item.decision,
           itemKey: item.key,
@@ -3908,7 +3915,7 @@ export class ExactReviewQueue {
           const token = await targetTokenFor(candidate.decision.targetRepo);
           return {
             ...candidate,
-            state: await exactReviewTargetItemState(token, candidate.decision),
+            state: await exactReviewTargetItemState(token, candidate.decision, this.env),
           };
         } catch (error) {
           // Keep the established publication behavior on a target-read failure:
@@ -4006,11 +4013,15 @@ export class ExactReviewQueue {
         const publication = candidate.decision.publication;
         if (!publication) return null;
         try {
-          const terminal = await exactReviewTerminalRun(token, {
-            runId: publication.producerRunId,
-            runAttempt: publication.producerRunAttempt,
-            claimGeneration: publication.claimGeneration ?? 0,
-          });
+          const terminal = await exactReviewTerminalRun(
+            token,
+            {
+              runId: publication.producerRunId,
+              runAttempt: publication.producerRunAttempt,
+              claimGeneration: publication.claimGeneration ?? 0,
+            },
+            this.env,
+          );
           // A terminal target makes this ordinary delivery unnecessary, but do
           // not race an in-flight or failed producer lifecycle. A later bounded
           // pass can retry a temporarily unavailable run lookup.
@@ -12507,6 +12518,7 @@ async function exactReviewSourceAuthorityLiveHead(
   if (!credentials) throw new Error("github app is not configured");
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
   const token = await createGithubAppTokenFor({
+    env,
     appJwt,
     installationId: reservation.installationId,
     label: reservation.decision.targetRepo,
@@ -12514,6 +12526,7 @@ async function exactReviewSourceAuthorityLiveHead(
     permissions: { pull_requests: "read" },
   });
   const pull = await githubTokenJson({
+    env,
     token,
     path: `/repos/${reservation.decision.targetRepo}/pulls/${reservation.decision.itemNumber}`,
     method: "GET",
@@ -12529,8 +12542,9 @@ async function exactReviewTargetReadToken(env, targetRepo: string) {
   const credentials = githubAppCredentials(env);
   if (!credentials) throw new Error("github app is not configured");
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
-  const installationId = await githubAppInstallationId(appJwt, targetRepo);
+  const installationId = await githubAppInstallationId(appJwt, targetRepo, env);
   return createGithubAppTokenFor({
+    env,
     appJwt,
     installationId,
     label: targetRepo,
@@ -12547,12 +12561,14 @@ type ExactReviewTargetItemState =
 async function exactReviewTargetItemState(
   token: string,
   decision: ExactReviewDecision,
+  env = {},
 ): Promise<Exclude<ExactReviewTargetItemState, { state: "unavailable" }>> {
   try {
     const isPullRequest = decision.itemKind === "pull_request";
     const queuedHeadSha = String(decision.sourceHeadSha || "").toLowerCase();
     const readPullHead = isPullRequest && /^[0-9a-f]{40}$/.test(queuedHeadSha);
     const item = await githubTokenJson({
+      env,
       token,
       path: `/repos/${decision.targetRepo}/${readPullHead ? "pulls" : "issues"}/${decision.itemNumber}`,
       method: "GET",
@@ -12578,6 +12594,7 @@ async function exactReviewTargetItemState(
       // GitHub masks inaccessible private repositories as 404. Treat the item
       // as missing only when this token can still read its repository.
       await githubTokenJson({
+        env,
         token,
         path: `/repos/${decision.targetRepo}`,
         method: "GET",
@@ -12598,8 +12615,9 @@ async function exactReviewRepositoryToken(env, permissions) {
   const credentials = githubAppCredentials(env);
   if (!credentials) throw new Error("github app is not configured");
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
-  const installationId = await githubAppInstallationId(appJwt, CLAWSWEEPER_REVIEW_REPO);
+  const installationId = await githubAppInstallationId(appJwt, CLAWSWEEPER_REVIEW_REPO, env);
   return createGithubAppTokenFor({
+    env,
     appJwt,
     installationId,
     label: CLAWSWEEPER_REVIEW_REPO,
@@ -12608,8 +12626,9 @@ async function exactReviewRepositoryToken(env, permissions) {
   });
 }
 
-async function exactReviewWorkflowState(token: string) {
+async function exactReviewWorkflowState(token: string, env = {}) {
   const payload = await githubTokenJson({
+    env,
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/workflows/sweep.yml`,
     method: "GET",
@@ -12624,20 +12643,23 @@ async function exactReviewWorkflowState(token: string) {
 export async function exactReviewTerminalRun(
   token: string,
   candidate: ExactReviewClaimedRun & { requestedRunAttempt?: number },
+  env = {},
 ) {
   const latest = await githubTokenJson({
+    env,
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/runs/${candidate.runId}`,
     method: "GET",
     body: undefined,
     errorLabel: "ClawSweeper run status",
   });
-  return exactReviewTerminalRunFromSummary(token, candidate, latest);
+  return exactReviewTerminalRunFromSummary(token, candidate, latest, env);
 }
 
 export async function exactReviewTerminalRunsFromBatch(
   token: string,
   candidates: Array<ExactReviewClaimedRun & { requestedRunAttempt?: number }>,
+  env = {},
 ) {
   const runsById = new Map<string, Record<string, unknown>>();
   const unresolved = new Set(candidates.map((candidate) => candidate.runId));
@@ -12645,6 +12667,7 @@ export async function exactReviewTerminalRunsFromBatch(
     let payload;
     try {
       payload = await githubTokenJson({
+        env,
         token,
         path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/workflows/sweep.yml/runs?event=repository_dispatch&per_page=100&page=${page}`,
         method: "GET",
@@ -12668,8 +12691,8 @@ export async function exactReviewTerminalRunsFromBatch(
     const summary = runsById.get(candidate.runId);
     try {
       return summary
-        ? await exactReviewTerminalRunFromSummary(token, candidate, summary)
-        : await exactReviewTerminalRun(token, candidate);
+        ? await exactReviewTerminalRunFromSummary(token, candidate, summary, env)
+        : await exactReviewTerminalRun(token, candidate, env);
     } catch {
       return undefined;
     }
@@ -12680,6 +12703,7 @@ async function exactReviewTerminalRunFromSummary(
   token: string,
   candidate: ExactReviewClaimedRun & { requestedRunAttempt?: number },
   latest: Record<string, unknown>,
+  env = {},
 ) {
   const expectedRunAttempt = candidate.requestedRunAttempt ?? candidate.runAttempt;
   if (String(latest.id || "") !== candidate.runId) {
@@ -12693,6 +12717,7 @@ async function exactReviewTerminalRunFromSummary(
   if (String(latest.status || "") !== "completed") return null;
 
   const payload = await githubTokenJson({
+    env,
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/runs/${candidate.runId}/attempts/${latestRunAttempt}`,
     method: "GET",
@@ -12725,6 +12750,7 @@ async function exactReviewTerminalRunFromSummary(
 }
 
 export async function createGithubAppTokenFor({
+  env = {},
   appJwt,
   installationId,
   label,
@@ -12742,6 +12768,7 @@ export async function createGithubAppTokenFor({
       }),
       errorLabel: `GitHub App token for ${label}`,
     },
+    env,
   );
   const token = String(payload.token || "");
   if (!token) throw new Error(`GitHub App token response missing token for ${label}`);
@@ -12749,6 +12776,7 @@ export async function createGithubAppTokenFor({
 }
 
 async function dispatchClawsweeperItem({
+  env,
   token,
   decision,
   itemKey,
@@ -12756,6 +12784,7 @@ async function dispatchClawsweeperItem({
   leaseRevision,
   terminalFinalization,
 }: {
+  env: Record<string, unknown>;
   token: string;
   decision: ExactReviewDecision;
   itemKey: string;
@@ -12779,6 +12808,7 @@ async function dispatchClawsweeperItem({
     ...(decision.publication ? { publication: decision.publication } : {}),
   };
   await githubTokenJson({
+    env,
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/dispatches`,
     method: "POST",
@@ -12923,15 +12953,18 @@ function exactReviewDispatchGlobalRetryDelayMs(
 }
 
 async function dispatchExactReviewBatchWorkflow({
+  env,
   token,
   dispatchId,
   dispatchedAt,
 }: {
+  env: Record<string, unknown>;
   token: string;
   dispatchId: string;
   dispatchedAt: string;
 }) {
   await githubTokenJson({
+    env,
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/actions/workflows/exact-review-batch-publish.yml/dispatches`,
     method: "POST",
@@ -12943,7 +12976,7 @@ async function dispatchExactReviewBatchWorkflow({
   });
 }
 
-async function githubTokenJson({ token, path, method = "GET", body, errorLabel }) {
+async function githubTokenJson({ env = {}, token, path, method = "GET", body, errorLabel }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
   const init: RequestInit = {
@@ -12959,7 +12992,7 @@ async function githubTokenJson({ token, path, method = "GET", body, errorLabel }
   if (body !== undefined) init.body = JSON.stringify(body);
   let response: Response;
   try {
-    response = await fetch(`https://api.github.com${path}`, init);
+    response = await fetch(githubApiUrl(env, path), init);
   } catch (error) {
     const timedOut =
       controller.signal.aborted ||
@@ -13442,11 +13475,14 @@ function githubAppCredentials(env) {
   };
 }
 
-async function githubAppInstallationId(appJwt, repo) {
+async function githubAppInstallationId(appJwt, repo, env = {}) {
   if (!repo || !repo.includes("/")) throw new Error("GitHub App installation repo is required");
-  const payload = await githubAppJson(`/repos/${repo}/installation`, appJwt, {
-    errorLabel: "GitHub App installation",
-  });
+  const payload = await githubAppJson(
+    `/repos/${repo}/installation`,
+    appJwt,
+    { errorLabel: "GitHub App installation" },
+    env,
+  );
   const installationId = Number(payload.id);
   if (!Number.isInteger(installationId) || installationId <= 0) {
     throw new Error(`GitHub App installation response missing id for ${repo}`);
@@ -13454,12 +13490,12 @@ async function githubAppInstallationId(appJwt, repo) {
   return String(installationId);
 }
 
-async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}) {
+async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}, env = {}) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await fetch(`https://api.github.com${path}`, {
+    response = await fetch(githubApiUrl(env, path), {
       method: options.method || "GET",
       signal: controller.signal,
       headers: {

--- a/dashboard/github-api.ts
+++ b/dashboard/github-api.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_GITHUB_API_URL = "https://api.github.com";
+
+type GithubApiEnv = Record<string, unknown>;
+
+export function githubApiBaseUrl(env: GithubApiEnv = {}): string {
+  const configured = env.GITHUB_API_URL;
+  if (configured === undefined || configured === null || configured === "") {
+    return DEFAULT_GITHUB_API_URL;
+  }
+  if (typeof configured !== "string") throw invalidGithubApiUrl();
+
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw invalidGithubApiUrl();
+  }
+  const isHttps = url.protocol === "https:";
+  const isLoopbackHttp =
+    url.protocol === "http:" &&
+    (url.hostname === "127.0.0.1" || url.hostname === "localhost") &&
+    Boolean(url.port);
+  if (
+    (!isHttps && !isLoopbackHttp) ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash ||
+    url.origin !== configured
+  ) {
+    throw invalidGithubApiUrl();
+  }
+  return url.origin;
+}
+
+export function githubApiUrl(env: GithubApiEnv, path: string): string {
+  const normalizedPath = String(path);
+  if (!normalizedPath.startsWith("/")) throw new Error("GitHub API path must start with /");
+  return `${githubApiBaseUrl(env)}${normalizedPath}`;
+}
+
+function invalidGithubApiUrl(): Error {
+  return new Error(
+    "invalid GITHUB_API_URL: expected an https origin or an http://127.0.0.1:<port> / http://localhost:<port> origin",
+  );
+}

--- a/dashboard/github-api.ts
+++ b/dashboard/github-api.ts
@@ -15,13 +15,13 @@ export function githubApiBaseUrl(env: GithubApiEnv = {}): string {
   } catch {
     throw invalidGithubApiUrl();
   }
-  const isHttps = url.protocol === "https:";
+  const isDefaultGithubOrigin = configured === DEFAULT_GITHUB_API_URL;
   const isLoopbackHttp =
     url.protocol === "http:" &&
     (url.hostname === "127.0.0.1" || url.hostname === "localhost") &&
     Boolean(url.port);
   if (
-    (!isHttps && !isLoopbackHttp) ||
+    (!isDefaultGithubOrigin && !isLoopbackHttp) ||
     url.username ||
     url.password ||
     url.pathname !== "/" ||
@@ -42,6 +42,6 @@ export function githubApiUrl(env: GithubApiEnv, path: string): string {
 
 function invalidGithubApiUrl(): Error {
   return new Error(
-    "invalid GITHUB_API_URL: expected an https origin or an http://127.0.0.1:<port> / http://localhost:<port> origin",
+    "invalid GITHUB_API_URL: expected https://api.github.com or an http://127.0.0.1:<port> / http://localhost:<port> origin",
   );
 }

--- a/dashboard/operational-health.ts
+++ b/dashboard/operational-health.ts
@@ -1,4 +1,5 @@
 export const OPERATIONAL_QUEUE_DEGRADED_MS = 30 * 60 * 1000;
+export const OPERATIONAL_QUEUE_ZOMBIE_MS = 24 * 60 * 60 * 1000;
 export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;
 export const HEALTH_HISTORY_SAMPLE_MS = 5 * 60 * 1000;
 export const HEALTH_HISTORY_RETENTION_DAYS = 7;
@@ -24,6 +25,8 @@ export type OperationalHealth = {
   queued_over_threshold: number;
   queued_threshold_minutes: number;
   oldest_queued_minutes: number;
+  zombie_queued_runs: number;
+  oldest_zombie_queued_minutes: number;
   approval_gated_runs: number;
   oldest_approval_gated_minutes: number;
   running_runs: number;
@@ -94,11 +97,18 @@ export function summarizeOperationalHealth(
     // the authoritative execution timestamp is present.
     .map((run) => ageMs(run.run_started_at || run.created_at, now));
   const validQueuedAges = queuedAges.filter((age): age is number => age !== null);
+  // Normal queue waits are measured in minutes. Seventeen production runs are
+  // stranded past 24 hours (three from Jul 13/17 and fourteen from one Aug 7
+  // incident), and both cancel and force-cancel return HTTP 500 for every one.
+  // Excluding those unremediable zombies is the only way to keep live queue
+  // pressure observable without pinning operational health indefinitely.
+  const zombieQueuedAges = validQueuedAges.filter((age) => age > OPERATIONAL_QUEUE_ZOMBIE_MS);
+  const liveQueuedAges = validQueuedAges.filter((age) => age <= OPERATIONAL_QUEUE_ZOMBIE_MS);
   const validRunningAges = runningAges.filter((age): age is number => age !== null);
   const hasCompleteAges =
     validQueuedAges.length === queuedRuns.length && validRunningAges.length === runningRuns.length;
   const complete = telemetryComplete && hasCompleteAges;
-  const queuedOverThreshold = validQueuedAges.filter(
+  const queuedOverThreshold = liveQueuedAges.filter(
     (age) => age >= OPERATIONAL_QUEUE_DEGRADED_MS,
   ).length;
   const runningOverThreshold = validRunningAges.filter(
@@ -118,7 +128,9 @@ export function summarizeOperationalHealth(
     queued_runs: queuedRuns.length,
     queued_over_threshold: queuedOverThreshold,
     queued_threshold_minutes: OPERATIONAL_QUEUE_DEGRADED_MS / 60_000,
-    oldest_queued_minutes: oldestMinutes(validQueuedAges),
+    oldest_queued_minutes: oldestMinutes(liveQueuedAges),
+    zombie_queued_runs: zombieQueuedAges.length,
+    oldest_zombie_queued_minutes: oldestMinutes(zombieQueuedAges),
     approval_gated_runs: approvalGatedRuns.length,
     oldest_approval_gated_minutes: oldestMinutes(
       approvalGatedRuns

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -6,6 +6,7 @@ import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-l
 import { bayHtml } from "./bay-page.ts";
 import { liveActivityBaySnapshot } from "./live-activity.ts";
 import { summarizeDashboardHealth } from "./dashboard-health.ts";
+import { githubApiUrl } from "./github-api.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
   exactReviewHistorySample,
@@ -1290,8 +1291,9 @@ async function githubWebhook(request, env, ctx) {
   if (!credentials) return json({ error: "github_app_not_configured" }, 503);
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
   const dispatchToken = await createGithubAppTokenFor({
+    env,
     appJwt,
-    installationId: await githubAppInstallationId(appJwt, CLAWSWEEPER_REVIEW_REPO),
+    installationId: await githubAppInstallationId(appJwt, CLAWSWEEPER_REVIEW_REPO, env),
     label: CLAWSWEEPER_REVIEW_REPO,
     repositories: [repoName(CLAWSWEEPER_REVIEW_REPO)],
     permissions: { contents: "write" },
@@ -1299,6 +1301,7 @@ async function githubWebhook(request, env, ctx) {
 
   const commentDecision = decision as any;
   const targetToken = await createGithubAppTokenFor({
+    env,
     appJwt,
     installationId: commentDecision.installationId,
     label: commentDecision.targetRepo,
@@ -1309,24 +1312,28 @@ async function githubWebhook(request, env, ctx) {
     },
   });
   const statusCommentId = await createFastAckCommentOnce({
+    env,
     token: targetToken,
     repo: commentDecision.targetRepo,
     itemNumber: commentDecision.itemNumber,
     sourceCommentId: commentDecision.commentId,
   });
   await addIssueCommentReaction({
+    env,
     token: targetToken,
     repo: commentDecision.targetRepo,
     commentId: commentDecision.commentId,
     content: "eyes",
   });
   await dispatchClawsweeperComment({
+    env,
     token: dispatchToken,
     decision: commentDecision,
     statusCommentId,
     sourceDeliveryId: trigger?.source_delivery_id,
   });
   settleFastAckComments({
+    env,
     token: targetToken,
     repo: commentDecision.targetRepo,
     itemNumber: commentDecision.itemNumber,
@@ -1646,6 +1653,7 @@ async function bindLivePullRequestHeadAuthority({
     }
     const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
     token = await createGithubAppTokenFor({
+      env,
       appJwt,
       installationId: decision.installationId!,
       label: decision.targetRepo,
@@ -1654,6 +1662,7 @@ async function bindLivePullRequestHeadAuthority({
     });
   }
   const pull = await githubTokenJson({
+    env,
     token,
     path: `/repos/${decision.targetRepo}/pulls/${decision.itemNumber}`,
     body: undefined,
@@ -2367,13 +2376,13 @@ async function authenticatedExactReviewReconcile(request, env) {
     return json({ error: "github_run_status_unavailable" }, 502);
   }
   const checked = includeAllClaimed
-    ? await exactReviewTerminalRunsFromBatch(token, candidates)
+    ? await exactReviewTerminalRunsFromBatch(token, candidates, env)
     : await mapWithConcurrency(
         candidates,
         EXACT_REVIEW_RECONCILE_CONCURRENCY,
         async (candidate) => {
           try {
-            return await exactReviewTerminalRun(token, candidate);
+            return await exactReviewTerminalRun(token, candidate, env);
           } catch {
             return undefined;
           }
@@ -2461,6 +2470,7 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
   }
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
   const token = await createGithubAppTokenFor({
+    env,
     appJwt,
     installationId: decision.installationId,
     label: decision.targetRepo,
@@ -2470,6 +2480,7 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
   const ackMarker = pullRequestFastAckMarker(decision.itemNumber, decision.sourceAction);
   const ackMatch = pullRequestFastAckMatch(decision.itemNumber);
   const statusCommentId = await createFastAckCommentOnce({
+    env,
     token,
     repo: decision.targetRepo,
     itemNumber: decision.itemNumber,
@@ -2479,6 +2490,7 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
     ackBody: renderPullRequestFastAckComment(ackMarker),
   });
   settleFastAckComments({
+    env,
     token,
     repo: decision.targetRepo,
     itemNumber: decision.itemNumber,
@@ -2491,6 +2503,7 @@ async function acknowledgePullRequestReceipt({ env, ctx, decision }) {
 }
 
 async function createFastAckComment({
+  env,
   token,
   repo,
   itemNumber,
@@ -2499,9 +2512,17 @@ async function createFastAckComment({
   ackMatch = undefined,
   ackBody = renderFastAckComment(sourceCommentId),
 }) {
-  const existingId = await pruneFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch });
+  const existingId = await pruneFastAckComments({
+    env,
+    token,
+    repo,
+    itemNumber,
+    ackMarker,
+    ackMatch,
+  });
   if (existingId) return existingId;
   const payload = await githubTokenJson({
+    env,
     token,
     path: `/repos/${repo}/issues/${itemNumber}/comments`,
     method: "POST",
@@ -2509,13 +2530,14 @@ async function createFastAckComment({
     errorLabel: "ClawSweeper ack comment",
   });
   return (
-    (await pruneFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch })) ||
+    (await pruneFastAckComments({ env, token, repo, itemNumber, ackMarker, ackMatch })) ||
     Number(payload.id) ||
     null
   );
 }
 
 function settleFastAckComments({
+  env,
   token,
   repo,
   itemNumber,
@@ -2528,7 +2550,7 @@ function settleFastAckComments({
   const cleanup = async () => {
     for (const delayMs of delaysMs) {
       await sleep(delayMs);
-      await pruneFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch });
+      await pruneFastAckComments({ env, token, repo, itemNumber, ackMarker, ackMatch });
     }
   };
   const promise = cleanup().catch((error) => {
@@ -2546,6 +2568,7 @@ function fastAckSettleDelaysMs(value) {
 }
 
 async function createFastAckCommentOnce({
+  env,
   token,
   repo,
   itemNumber,
@@ -2559,6 +2582,7 @@ async function createFastAckCommentOnce({
   const pending = inFlightFastAcks.get(key);
   if (pending) return pending;
   const next = createFastAckComment({
+    env,
     token,
     repo,
     itemNumber,
@@ -2584,6 +2608,7 @@ function sleep(delayMs) {
 }
 
 async function pruneFastAckComments({
+  env,
   token,
   repo,
   itemNumber,
@@ -2591,7 +2616,14 @@ async function pruneFastAckComments({
   ackMarker = fastAckMarker(sourceCommentId),
   ackMatch = undefined,
 }) {
-  const comments = await listFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch });
+  const comments = await listFastAckComments({
+    env,
+    token,
+    repo,
+    itemNumber,
+    ackMarker,
+    ackMatch,
+  });
   if (!comments.length) return null;
   const hasStatusComment = comments.some(isStatusBearingFastAckComment);
   comments.sort(compareFastAckKeepPriority);
@@ -2601,6 +2633,7 @@ async function pruneFastAckComments({
     if (id <= 0 || id === keepId) continue;
     if (hasStatusComment && isStatusBearingFastAckComment(comment)) continue;
     await githubTokenJson({
+      env,
       token,
       path: `/repos/${repo}/issues/comments/${id}`,
       method: "DELETE",
@@ -2648,12 +2681,20 @@ function compareCommentsByCreatedAt(left, right) {
   );
 }
 
-async function listFastAckComments({ token, repo, itemNumber, ackMarker, ackMatch = undefined }) {
+async function listFastAckComments({
+  env,
+  token,
+  repo,
+  itemNumber,
+  ackMarker,
+  ackMatch = undefined,
+}) {
   const comments = [];
   const matchesAckBody = ackMatch || ((body) => body.includes(ackMarker));
   const since = encodeURIComponent(new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
   for (let page = 1; page <= 5; page += 1) {
     const payload = await githubTokenJson({
+      env,
       token,
       path: `/repos/${repo}/issues/${itemNumber}/comments?per_page=100&page=${page}&since=${since}`,
       method: "GET",
@@ -2710,8 +2751,9 @@ function renderPullRequestFastAckComment(ackMarker) {
   ].join("\n");
 }
 
-async function addIssueCommentReaction({ token, repo, commentId, content }) {
+async function addIssueCommentReaction({ env, token, repo, commentId, content }) {
   await githubTokenJson({
+    env,
     token,
     path: `/repos/${repo}/issues/comments/${commentId}/reactions`,
     method: "POST",
@@ -2725,7 +2767,13 @@ async function addIssueCommentReaction({ token, repo, commentId, content }) {
   });
 }
 
-async function dispatchClawsweeperComment({ token, decision, statusCommentId, sourceDeliveryId }) {
+async function dispatchClawsweeperComment({
+  env,
+  token,
+  decision,
+  statusCommentId,
+  sourceDeliveryId,
+}) {
   const exactVersion =
     decision.commentUpdatedAt && typeof decision.commentBody === "string"
       ? {
@@ -2735,6 +2783,7 @@ async function dispatchClawsweeperComment({ token, decision, statusCommentId, so
         }
       : {};
   await githubTokenJson({
+    env,
     token,
     path: `/repos/${CLAWSWEEPER_REVIEW_REPO}/dispatches`,
     method: "POST",
@@ -2761,7 +2810,7 @@ async function sha256Text(value) {
   return hexEncode(new Uint8Array(digest));
 }
 
-async function githubTokenJson({ token, path, method = "GET", body, errorLabel }) {
+async function githubTokenJson({ env = {}, token, path, method = "GET", body, errorLabel }) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
   const init: RequestInit = {
@@ -2775,9 +2824,7 @@ async function githubTokenJson({ token, path, method = "GET", body, errorLabel }
     },
   };
   if (body !== undefined) init.body = JSON.stringify(body);
-  const response = await fetch(`https://api.github.com${path}`, init).finally(() =>
-    clearTimeout(timeout),
-  );
+  const response = await fetch(githubApiUrl(env, path), init).finally(() => clearTimeout(timeout));
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     throw new Error(
@@ -6765,7 +6812,7 @@ async function githubJson(env, path) {
   const token = await githubAuthToken(env);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
-  const response = await fetch(`https://api.github.com${path}`, {
+  const response = await fetch(githubApiUrl(env, path), {
     signal: controller.signal,
     headers: {
       Accept: "application/vnd.github+json",
@@ -6782,7 +6829,7 @@ async function githubGraphql(env, query, variables) {
   if (!token) throw new Error("GitHub auth is required for GraphQL");
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort("timeout"), OPTIONAL_SECTION_TIMEOUT_MS);
-  const response = await fetch("https://api.github.com/graphql", {
+  const response = await fetch(githubApiUrl(env, "/graphql"), {
     method: "POST",
     signal: controller.signal,
     headers: {
@@ -6863,7 +6910,7 @@ function githubAppCredentials(env) {
 async function createGithubAppInstallationToken(env, credentials, repos) {
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
   const installationId =
-    credentials.installationId || (await githubAppInstallationId(appJwt, repos[0]));
+    credentials.installationId || (await githubAppInstallationId(appJwt, repos[0], env));
   const payload = await githubAppJson(
     `/app/installations/${installationId}/access_tokens`,
     appJwt,
@@ -6880,6 +6927,7 @@ async function createGithubAppInstallationToken(env, credentials, repos) {
       }),
       errorLabel: "GitHub App token",
     },
+    env,
   );
   const token = String(payload.token || "");
   if (!token) throw new Error("GitHub App token response missing token");
@@ -6889,11 +6937,14 @@ async function createGithubAppInstallationToken(env, credentials, repos) {
   return { token, expiresAtMs };
 }
 
-async function githubAppInstallationId(appJwt, repo) {
+async function githubAppInstallationId(appJwt, repo, env = {}) {
   if (!repo || !repo.includes("/")) throw new Error("GitHub App installation repo is required");
-  const payload = await githubAppJson(`/repos/${repo}/installation`, appJwt, {
-    errorLabel: "GitHub App installation",
-  });
+  const payload = await githubAppJson(
+    `/repos/${repo}/installation`,
+    appJwt,
+    { errorLabel: "GitHub App installation" },
+    env,
+  );
   const installationId = Number(payload.id);
   if (!Number.isInteger(installationId) || installationId <= 0) {
     throw new Error(`GitHub App installation response missing id for ${repo}`);
@@ -6901,10 +6952,10 @@ async function githubAppInstallationId(appJwt, repo) {
   return String(installationId);
 }
 
-async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}) {
+async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}, env = {}) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
-  const response = await fetch(`https://api.github.com${path}`, {
+  const response = await fetch(githubApiUrl(env, path), {
     method: options.method || "GET",
     signal: controller.signal,
     headers: {

--- a/docs/proof/operational-health-zombie-runs/README.md
+++ b/docs/proof/operational-health-zombie-runs/README.md
@@ -4,7 +4,7 @@
 
 The real dashboard Worker excludes queued workflow runs older than 24 hours from queue-pressure health while retaining them in `queued_runs` and surfacing them through `zombie_queued_runs` and `oldest_zombie_queued_minutes`. A non-zombie run queued for 31 minutes still degrades operational health exactly as before.
 
-The GitHub base-URL binding is dependency injection for testability. Production behavior is unchanged by default: when `GITHUB_API_URL` is unset, every dashboard GitHub REST and GraphQL request still uses `https://api.github.com`.
+The GitHub base-URL binding is dependency injection for testability. Production behavior is unchanged by default: when `GITHUB_API_URL` is unset, every dashboard GitHub REST and GraphQL request still uses `https://api.github.com`. Other HTTPS origins are rejected by design so credentialed requests cannot be redirected away from GitHub; only explicit-port HTTP loopback origins are accepted for local proof stubs.
 
 ## Exercised surface
 

--- a/docs/proof/operational-health-zombie-runs/README.md
+++ b/docs/proof/operational-health-zombie-runs/README.md
@@ -19,7 +19,7 @@ The proof boots three fresh Workers. Each boot gets a disposable Wrangler persis
 
 1. The GitHub stub returns one queued run aged 25 hours. `/api/status` must report `queued_runs: 1`, `zombie_queued_runs: 1`, `queued_over_threshold: 0`, operational status `healthy`, and no `workflow_execution_degraded` dashboard reason.
 2. The stub adds a second run aged 31 minutes. `/api/status` must report one zombie plus one over-threshold live queued run, operational status `degraded`, and the `workflow_execution_degraded` dashboard reason.
-3. `GITHUB_API_URL` is unset and no GitHub credential is provided. The resulting status payload and its local-sandbox GitHub error shape are retained to demonstrate that the default-origin path remains active without sending credentials.
+3. `GITHUB_API_URL` is unset and no GitHub credential is provided. The resulting status payload and its public GitHub response or local-sandbox error shape are retained to demonstrate that the default-origin path remains active without sending credentials.
 
 ## Command and environment
 

--- a/docs/proof/operational-health-zombie-runs/README.md
+++ b/docs/proof/operational-health-zombie-runs/README.md
@@ -1,0 +1,40 @@
+# Operational-health zombie workflow-run proof
+
+## Claim
+
+The real dashboard Worker excludes queued workflow runs older than 24 hours from queue-pressure health while retaining them in `queued_runs` and surfacing them through `zombie_queued_runs` and `oldest_zombie_queued_minutes`. A non-zombie run queued for 31 minutes still degrades operational health exactly as before.
+
+The GitHub base-URL binding is dependency injection for testability. Production behavior is unchanged by default: when `GITHUB_API_URL` is unset, every dashboard GitHub REST and GraphQL request still uses `https://api.github.com`.
+
+## Exercised surface
+
+- Real `wrangler dev --local` dashboard Worker and `/api/status` route
+- Real HTTP requests from the Worker to a loopback GitHub REST stub
+- The production operational-health and dashboard-health summaries
+- The default-origin path with `GITHUB_API_URL` unset and no GitHub credentials
+
+## Controlled scenarios and required observations
+
+The proof boots three fresh Workers. Each boot gets a disposable Wrangler persistence directory, and the entire Worker process group is stopped before the next boot.
+
+1. The GitHub stub returns one queued run aged 25 hours. `/api/status` must report `queued_runs: 1`, `zombie_queued_runs: 1`, `queued_over_threshold: 0`, operational status `healthy`, and no `workflow_execution_degraded` dashboard reason.
+2. The stub adds a second run aged 31 minutes. `/api/status` must report one zombie plus one over-threshold live queued run, operational status `degraded`, and the `workflow_execution_degraded` dashboard reason.
+3. `GITHUB_API_URL` is unset and no GitHub credential is provided. The resulting status payload and its local-sandbox GitHub error shape are retained to demonstrate that the default-origin path remains active without sending credentials.
+
+## Command and environment
+
+Run from the repository root on Node 24 or newer:
+
+```bash
+docs/proof/operational-health-zombie-runs/run-proof.sh
+```
+
+The proof uses pinned Wrangler 4.107.0, loopback HTTP only for the injected stub, and a synthetic webhook secret. Generated payloads, request traces, logs, and `proof-summary.json` are written to `.artifacts/operational-health-zombie-runs/` by default.
+
+## Limits
+
+The stub implements the GitHub REST response shapes consumed by `/api/status`; it does not emulate GitHub authentication, GraphQL, rate limiting, cancellation, or the production scheduler. Unit tests cover the strict 24-hour boundary and URL validation. The live production population and the failed cancel/force-cancel attempts are prior coordinator measurements, not repeated by this proof.
+
+## OpenClaw Bay impact
+
+No Bay contract or implementation changes. Bay remains an observer-only projection of workflow and review journeys. This change affects only the dashboard status payload and its derived health reason; it adds no queue, workflow, GitHub, recovery, deploy, or rollback action.

--- a/docs/proof/operational-health-zombie-runs/run-proof.mjs
+++ b/docs/proof/operational-health-zombie-runs/run-proof.mjs
@@ -109,6 +109,8 @@ async function runDefaultScenario() {
     assert.ok(payload.operational_health);
     return {
       scenario: "default-origin-unset",
+      github_api_url_binding: "unset",
+      github_credentials_forwarded: false,
       operational_health: payload.operational_health,
       dashboard_health: payload.dashboard_health,
       diagnostic_errors: payload.diagnostics.errors,

--- a/docs/proof/operational-health-zombie-runs/run-proof.mjs
+++ b/docs/proof/operational-health-zombie-runs/run-proof.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const outputDir = path.resolve(
+  process.env.PROOF_OUTPUT || ".artifacts/operational-health-zombie-runs",
+);
+const workerPort = Number(process.env.PROOF_WORKER_PORT || 8793);
+const stubPort = Number(process.env.PROOF_STUB_PORT || 8794);
+const sourceSha = process.env.PROOF_SOURCE_SHA || (await gitHead());
+const sourceTreeSha = await treeHash([
+  "dashboard/github-api.ts",
+  "dashboard/operational-health.ts",
+  "dashboard/worker.ts",
+  "dashboard/exact-review-queue.ts",
+  "test/dashboard-github-api.test.ts",
+  "test/dashboard-operational-health.test.ts",
+  "test/dashboard-worker.test.ts",
+  "docs/proof/operational-health-zombie-runs/README.md",
+  "docs/proof/operational-health-zombie-runs/run-proof.mjs",
+  "docs/proof/operational-health-zombie-runs/run-proof.sh",
+  "docs/proof/operational-health-zombie-runs/stub-github.mjs",
+]);
+await mkdir(outputDir, { recursive: true });
+
+const observations = [];
+try {
+  observations.push(await runStubbedScenario("zombie-only"));
+  observations.push(await runStubbedScenario("fresh-backlog"));
+  observations.push(await runDefaultScenario());
+
+  const summary = {
+    claim:
+      "queued runs older than 24 hours remain visible as zombies without degrading operational health, while a 31-minute queued run still degrades it",
+    source_sha: sourceSha,
+    source_tree_sha: sourceTreeSha,
+    generated_at: new Date().toISOString(),
+    observations,
+    assertions: 21,
+    run_status: "succeeded",
+  };
+  await writeJson("proof-summary.json", summary);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+} catch (error) {
+  await writeJson("proof-failure.json", {
+    source_sha: sourceSha,
+    source_tree_sha: sourceTreeSha,
+    generated_at: new Date().toISOString(),
+    error: error instanceof Error ? error.stack : String(error),
+    observations,
+    run_status: "failed",
+  });
+  throw error;
+}
+
+async function runStubbedScenario(mode) {
+  const tracePath = path.join(outputDir, `${mode}-github-requests.jsonl`);
+  await writeFile(tracePath, "");
+  const stub = startProcess(
+    process.execPath,
+    [
+      "docs/proof/operational-health-zombie-runs/stub-github.mjs",
+      mode,
+      String(stubPort),
+      tracePath,
+    ],
+    `${mode}-stub.log`,
+  );
+  await waitForText(path.join(outputDir, `${mode}-stub.log`), "stub-ready");
+  const worker = await startWorker(mode, `http://127.0.0.1:${stubPort}`);
+  try {
+    const payload = await statusPayload();
+    await writeJson(`${mode}-status.json`, payload);
+    const health = payload.operational_health;
+    assert.equal(health.queued_runs, mode === "fresh-backlog" ? 2 : 1);
+    assert.equal(health.zombie_queued_runs, 1);
+    assert.ok(health.oldest_zombie_queued_minutes >= 1_499);
+    assert.ok(health.oldest_zombie_queued_minutes <= 1_502);
+    assert.equal(health.queued_over_threshold, mode === "fresh-backlog" ? 1 : 0);
+    assert.equal(health.oldest_queued_minutes, mode === "fresh-backlog" ? 31 : 0);
+    assert.equal(health.status, mode === "fresh-backlog" ? "degraded" : "healthy");
+    assert.equal(
+      payload.dashboard_health.reasons.includes("workflow_execution_degraded"),
+      mode === "fresh-backlog",
+    );
+    return {
+      scenario: mode,
+      operational_health: health,
+      dashboard_health: payload.dashboard_health,
+      github_requests: (await readFile(tracePath, "utf8")).trim().split("\n").length,
+    };
+  } finally {
+    await stopProcessTree(worker);
+    await stopProcessTree(stub);
+  }
+}
+
+async function runDefaultScenario() {
+  const worker = await startWorker("default-origin", null);
+  try {
+    const payload = await statusPayload();
+    await writeJson("default-origin-status.json", payload);
+    assert.ok(Array.isArray(payload.diagnostics?.errors));
+    assert.ok(payload.operational_health);
+    return {
+      scenario: "default-origin-unset",
+      operational_health: payload.operational_health,
+      dashboard_health: payload.dashboard_health,
+      diagnostic_errors: payload.diagnostics.errors,
+    };
+  } finally {
+    await stopProcessTree(worker);
+  }
+}
+
+async function startWorker(name, githubApiUrl) {
+  const persistence = await mkdtemp(path.join(os.tmpdir(), `clawsweeper-zombie-${name}-`));
+  const args = [
+    "--yes",
+    "wrangler@4.107.0",
+    "dev",
+    "--config",
+    "dashboard/wrangler.toml",
+    "--local",
+    "--persist-to",
+    persistence,
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(workerPort),
+    "--var",
+    "CLAWSWEEPER_WEBHOOK_SECRET:operational-health-zombie-proof",
+    "--var",
+    "CACHE_TTL_SECONDS:0",
+    "--var",
+    "TARGET_REPOS:openclaw/openclaw",
+    "--log-level",
+    "warn",
+  ];
+  if (githubApiUrl) args.push("--var", `GITHUB_API_URL:${githubApiUrl}`);
+  const child = startProcess("npx", args, `${name}-wrangler.log`);
+  child.persistence = persistence;
+  try {
+    await waitForHttp(`http://127.0.0.1:${workerPort}/api/health`);
+    return child;
+  } catch (error) {
+    await stopProcessTree(child);
+    throw error;
+  }
+}
+
+function startProcess(command, args, logName) {
+  const stream = createWriteStream(path.join(outputDir, logName), { flags: "w" });
+  const child = spawn(command, args, {
+    cwd: process.cwd(),
+    detached: process.platform !== "win32",
+    env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.pipe(stream);
+  child.stderr.pipe(stream);
+  child.logStream = stream;
+  return child;
+}
+
+async function stopProcessTree(child) {
+  if (!child) return;
+  if (child.exitCode === null && child.signalCode === null) {
+    try {
+      process.kill(process.platform === "win32" ? child.pid : -child.pid, "SIGTERM");
+    } catch (error) {
+      if (error.code !== "ESRCH") throw error;
+    }
+    await Promise.race([onceExit(child), delay(5_000)]);
+  }
+  if (child.exitCode === null && child.signalCode === null) {
+    try {
+      process.kill(process.platform === "win32" ? child.pid : -child.pid, "SIGKILL");
+    } catch (error) {
+      if (error.code !== "ESRCH") throw error;
+    }
+    await onceExit(child);
+  }
+  child.logStream?.end();
+  if (child.persistence) await rm(child.persistence, { recursive: true, force: true });
+  await waitForPortRelease();
+}
+
+async function statusPayload() {
+  const response = await fetch(`http://127.0.0.1:${workerPort}/api/status`, {
+    signal: AbortSignal.timeout(60_000),
+  });
+  assert.equal(response.status, 200);
+  return response.json();
+}
+
+async function waitForHttp(url) {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) return;
+    } catch {}
+    await delay(250);
+  }
+  throw new Error(`timed out waiting for ${url}`);
+}
+
+async function waitForText(file, expected) {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const text = await readFile(file, "utf8").catch(() => "");
+    if (text.includes(expected)) return;
+    await delay(100);
+  }
+  throw new Error(`timed out waiting for ${expected} in ${file}`);
+}
+
+async function waitForPortRelease() {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      await fetch(`http://127.0.0.1:${workerPort}/api/health`, {
+        signal: AbortSignal.timeout(100),
+      });
+    } catch {
+      return;
+    }
+    await delay(100);
+  }
+  throw new Error(`worker port ${workerPort} remained occupied after process-tree stop`);
+}
+
+function onceExit(child) {
+  return child.exitCode !== null || child.signalCode !== null
+    ? Promise.resolve()
+    : new Promise((resolve) => child.once("exit", resolve));
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function writeJson(name, value) {
+  await writeFile(path.join(outputDir, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function gitHead() {
+  const child = spawn("git", ["rev-parse", "HEAD"], { stdio: ["ignore", "pipe", "inherit"] });
+  let output = "";
+  child.stdout.on("data", (chunk) => (output += chunk));
+  await onceExit(child);
+  return output.trim() || "unknown";
+}
+
+async function treeHash(files) {
+  const hash = createHash("sha256");
+  for (const file of files) {
+    hash
+      .update(file)
+      .update("\0")
+      .update(await readFile(file))
+      .update("\0");
+  }
+  return hash.digest("hex");
+}

--- a/docs/proof/operational-health-zombie-runs/run-proof.sh
+++ b/docs/proof/operational-health-zombie-runs/run-proof.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+pnpm install --frozen-lockfile
+pnpm run build:dashboard
+node docs/proof/operational-health-zombie-runs/run-proof.mjs

--- a/docs/proof/operational-health-zombie-runs/stub-github.mjs
+++ b/docs/proof/operational-health-zombie-runs/stub-github.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { appendFile, mkdir } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+
+const mode = process.argv[2];
+const port = Number(process.argv[3]);
+const tracePath = process.argv[4];
+if (!new Set(["zombie-only", "fresh-backlog"]).has(mode) || !Number.isInteger(port)) {
+  throw new Error("usage: stub-github.mjs <zombie-only|fresh-backlog> <port> <trace-path>");
+}
+
+await mkdir(path.dirname(tracePath), { recursive: true });
+
+const now = Date.now();
+const workflowRuns = [workflowRun(7001, "queued", now - 25 * 60 * 60 * 1000)];
+if (mode === "fresh-backlog") {
+  workflowRuns.push(workflowRun(7002, "queued", now - 31 * 60 * 1000));
+}
+
+const server = http.createServer(async (request, response) => {
+  const url = new URL(request.url || "/", `http://127.0.0.1:${port}`);
+  await appendFile(
+    tracePath,
+    `${JSON.stringify({ at: new Date().toISOString(), method: request.method, url: url.href })}\n`,
+  );
+
+  let payload;
+  if (/\/repos\/openclaw\/clawsweeper\/actions\/runs$/.test(url.pathname)) {
+    const status = url.searchParams.get("status");
+    payload = {
+      total_count: status === "queued" || status === null ? workflowRuns.length : 0,
+      workflow_runs: status === "queued" || status === null ? workflowRuns : [],
+    };
+  } else if (/\/actions\/runs\/\d+\/jobs$/.test(url.pathname)) {
+    payload = { total_count: 0, jobs: [] };
+  } else if (/\/actions\/workflows\/[^/]+\/runs$/.test(url.pathname)) {
+    payload = { total_count: 0, workflow_runs: [] };
+  } else if (/\/actions\/workflows$/.test(url.pathname)) {
+    payload = { total_count: 0, workflows: [] };
+  } else if (/\/commits\/[^/]+\/check-runs$/.test(url.pathname)) {
+    payload = { total_count: 0, check_runs: [] };
+  } else if (/\/(issues|pulls)$/.test(url.pathname)) {
+    payload = [];
+  } else if (url.pathname === "/rate_limit") {
+    payload = {
+      resources: { core: { limit: 5_000, remaining: 5_000, reset: Math.floor(now / 1000) + 3600 } },
+    };
+  } else {
+    payload = {};
+  }
+
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify(payload));
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`stub-ready mode=${mode} port=${port}\n`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}
+
+function workflowRun(id, status, createdAtMs) {
+  return {
+    id,
+    name: "ClawSweeper",
+    display_title: `proof run ${id}`,
+    status,
+    conclusion: null,
+    event: "workflow_dispatch",
+    html_url: `https://github.com/openclaw/clawsweeper/actions/runs/${id}`,
+    created_at: new Date(createdAtMs).toISOString(),
+    updated_at: new Date(createdAtMs).toISOString(),
+  };
+}

--- a/test/dashboard-github-api.test.ts
+++ b/test/dashboard-github-api.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DEFAULT_GITHUB_API_URL, githubApiBaseUrl, githubApiUrl } from "../dashboard/github-api.ts";
+
+test("GitHub API URL uses the production origin by default", () => {
+  assert.equal(githubApiBaseUrl({}), DEFAULT_GITHUB_API_URL);
+  assert.equal(githubApiUrl({}, "/graphql"), "https://api.github.com/graphql");
+});
+
+test("GitHub API URL honors a validated loopback override", () => {
+  const env = { GITHUB_API_URL: "http://127.0.0.1:8788" };
+  assert.equal(githubApiBaseUrl(env), "http://127.0.0.1:8788");
+  assert.equal(
+    githubApiUrl(env, "/repos/openclaw/clawsweeper"),
+    "http://127.0.0.1:8788/repos/openclaw/clawsweeper",
+  );
+});
+
+test("GitHub API URL rejects insecure or non-origin overrides", () => {
+  for (const value of [
+    "http://github.example.test",
+    "http://localhost",
+    "http://127.0.0.1:8788/api",
+    "https://api.github.test/v3",
+    "https://user@example.test",
+  ]) {
+    assert.throws(() => githubApiBaseUrl({ GITHUB_API_URL: value }), /invalid GITHUB_API_URL/);
+  }
+  assert.equal(
+    githubApiBaseUrl({ GITHUB_API_URL: "https://api.github.test" }),
+    "https://api.github.test",
+  );
+  assert.equal(
+    githubApiBaseUrl({ GITHUB_API_URL: "http://localhost:8788" }),
+    "http://localhost:8788",
+  );
+});

--- a/test/dashboard-github-api.test.ts
+++ b/test/dashboard-github-api.test.ts
@@ -5,6 +5,10 @@ import { DEFAULT_GITHUB_API_URL, githubApiBaseUrl, githubApiUrl } from "../dashb
 
 test("GitHub API URL uses the production origin by default", () => {
   assert.equal(githubApiBaseUrl({}), DEFAULT_GITHUB_API_URL);
+  assert.equal(
+    githubApiBaseUrl({ GITHUB_API_URL: "https://api.github.com" }),
+    DEFAULT_GITHUB_API_URL,
+  );
   assert.equal(githubApiUrl({}, "/graphql"), "https://api.github.com/graphql");
 });
 
@@ -15,24 +19,23 @@ test("GitHub API URL honors a validated loopback override", () => {
     githubApiUrl(env, "/repos/openclaw/clawsweeper"),
     "http://127.0.0.1:8788/repos/openclaw/clawsweeper",
   );
-});
-
-test("GitHub API URL rejects insecure or non-origin overrides", () => {
-  for (const value of [
-    "http://github.example.test",
-    "http://localhost",
-    "http://127.0.0.1:8788/api",
-    "https://api.github.test/v3",
-    "https://user@example.test",
-  ]) {
-    assert.throws(() => githubApiBaseUrl({ GITHUB_API_URL: value }), /invalid GITHUB_API_URL/);
-  }
-  assert.equal(
-    githubApiBaseUrl({ GITHUB_API_URL: "https://api.github.test" }),
-    "https://api.github.test",
-  );
   assert.equal(
     githubApiBaseUrl({ GITHUB_API_URL: "http://localhost:8788" }),
     "http://localhost:8788",
   );
+});
+
+test("GitHub API URL rejects non-default remote or non-origin overrides", () => {
+  for (const value of [
+    "http://github.example.test",
+    "http://localhost",
+    "http://127.0.0.1",
+    "http://127.0.0.1:8788/api",
+    "https://api.github.test/v3",
+    "https://user@example.test",
+    "https://evil.example",
+    "https://api.github.com:8443",
+  ]) {
+    assert.throws(() => githubApiBaseUrl({ GITHUB_API_URL: value }), /invalid GITHUB_API_URL/);
+  }
 });

--- a/test/dashboard-operational-health.test.ts
+++ b/test/dashboard-operational-health.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  OPERATIONAL_QUEUE_ZOMBIE_MS,
   exactReviewHistorySample,
   mergeHealthHistorySample,
   normalizeHealthHistorySample,
@@ -71,6 +72,44 @@ test("operational health reports approval-gated runs outside queue congestion", 
   assert.equal(health.oldest_queued_minutes, 5);
   assert.equal(health.approval_gated_runs, 1);
   assert.equal(health.oldest_approval_gated_minutes, 7 * 24 * 60);
+});
+
+test("operational health surfaces zombie queue entries without degrading", () => {
+  const health = summarizeOperationalHealth(
+    [run("queued", "2026-07-14T13:00:00Z")],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(health.status, "healthy");
+  assert.equal(health.queued_runs, 1);
+  assert.equal(health.queued_over_threshold, 0);
+  assert.equal(health.oldest_queued_minutes, 0);
+  assert.equal(health.zombie_queued_runs, 1);
+  assert.equal(health.oldest_zombie_queued_minutes, 25 * 60);
+});
+
+test("operational health keeps fresh queue pressure alongside zombies", () => {
+  const health = summarizeOperationalHealth(
+    [run("queued", "2026-07-14T13:00:00Z"), run("queued", "2026-07-15T13:29:00Z")],
+    CHECKED_AT,
+    true,
+  );
+  assert.equal(health.status, "degraded");
+  assert.equal(health.queued_runs, 2);
+  assert.equal(health.queued_over_threshold, 1);
+  assert.equal(health.oldest_queued_minutes, 31);
+  assert.equal(health.zombie_queued_runs, 1);
+  assert.equal(health.oldest_zombie_queued_minutes, 25 * 60);
+});
+
+test("operational health treats exactly 24 hours as live queue pressure", () => {
+  const boundary = new Date(Date.parse(CHECKED_AT) - OPERATIONAL_QUEUE_ZOMBIE_MS).toISOString();
+  const health = summarizeOperationalHealth([run("queued", boundary)], CHECKED_AT, true);
+  assert.equal(health.status, "degraded");
+  assert.equal(health.queued_over_threshold, 1);
+  assert.equal(health.oldest_queued_minutes, 24 * 60);
+  assert.equal(health.zombie_queued_runs, 0);
+  assert.equal(health.oldest_zombie_queued_minutes, 0);
 });
 
 test("operational health fails closed when active-run telemetry is incomplete", () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -24091,7 +24091,7 @@ test("dashboard counts active runs that are older than the latest unfiltered pag
   }
 });
 
-test("dashboard hides stale queue ghosts without suppressing queue health", async () => {
+test("dashboard surfaces stale queue ghosts as zombies without active cards", async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;
   Object.defineProperty(globalThis, "caches", {
@@ -24156,8 +24156,11 @@ test("dashboard hides stale queue ghosts without suppressing queue health", asyn
     assert.equal(status.fleet.active_workflow_runs, 1);
     assert.equal(status.fleet.queued_workflow_runs, 1);
     assert.equal(status.operational_health.queued_runs, 2);
-    assert.equal(status.operational_health.queued_over_threshold, 1);
-    assert.equal(status.operational_health.status, "degraded");
+    assert.equal(status.operational_health.queued_over_threshold, 0);
+    assert.equal(status.operational_health.oldest_queued_minutes, 10);
+    assert.equal(status.operational_health.zombie_queued_runs, 1);
+    assert.equal(status.operational_health.oldest_zombie_queued_minutes, 7 * 24 * 60);
+    assert.equal(status.operational_health.status, "healthy");
     assert.deepEqual(
       status.pipeline.map((row: { id: number }) => row.id),
       [2],


### PR DESCRIPTION
## Summary

- Treat queued workflow runs older than 24 hours as surfaced zombies: keep them in `queued_runs`, report `zombie_queued_runs` and `oldest_zombie_queued_minutes`, but exclude them from `queued_over_threshold`, `oldest_queued_minutes`, and degraded/stalled computation.
- Preserve the existing 30-minute queue and 150-minute running thresholds for non-zombie runs. Exactly 24 hours remains ordinary queue pressure; approval-gated `waiting` runs were already outside degraded computation and remain unchanged.
- Add a validated `GITHUB_API_URL` Worker binding across every dashboard GitHub REST and GraphQL fetch site. Production behavior is unchanged by default and still uses the byte-identical origin `https://api.github.com` when unset.

## Security repair

The accepted P1 review finding is fixed at `fe4b9e226a021b06dcf25917a62c4b0d876b48b1`. A configured `GITHUB_API_URL` may now be only the exact production origin `https://api.github.com` or an explicit-port loopback HTTP origin on `127.0.0.1` / `localhost`. Arbitrary HTTPS origins, alternate ports on `api.github.com`, loopback without an explicit port, credentials, paths, queries, fragments, and non-origin forms are rejected before any credentialed request can be constructed. This keeps local proof injection without allowing an environment misconfiguration to forward Bearer tokens or GitHub App JWTs to another origin.

## Production evidence

Measured live payload before the change:

`{"status":"degraded","queued_runs":17,"queued_over_threshold":16,"oldest_queued_minutes":41086}` — 28.5 days.

The zombie population was verified with `gh run list --status queued --limit 100`: runs 29219675461, 29219804812 (Jul 13), 29591086714 (Jul 17), plus 14 runs created 2026-08-07T09:08-09:09. All 17 returned HTTP 500 from both `POST .../runs/{id}/cancel` and `POST .../runs/{id}/force-cancel`.

## GitHub fetch coverage

All six hardcoded dashboard fetch sites now use the shared validated origin:

- `dashboard/worker.ts`: webhook token REST helper, status REST helper, status GraphQL helper (`/graphql` remains correct), and GitHub App REST helper.
- `dashboard/exact-review-queue.ts`: token REST helper and GitHub App REST helper.

Accepted configured origins are exactly `https://api.github.com`, `http://127.0.0.1:<port>`, or `http://localhost:<port>`.

## pr-behavior-proof

**Claim:** The real dashboard Worker surfaces a queued run older than 24 hours without letting it degrade queue health, while an additional 31-minute queued run still degrades health exactly as before. The unset binding retains the production GitHub origin, and configured remote HTTPS overrides are rejected before credentials can be forwarded.

**Exercised surface:** Real `wrangler dev --local`, real `/api/status` HTTP requests, real loopback HTTP GitHub REST dependency, production operational-health summary, production dashboard-health reason derivation, and the shared GitHub API origin validator.

**Scenario/fixture:** Three fresh Worker boots with full process-group shutdown between boots: zombie-only, zombie plus a 31-minute queued run, and `GITHUB_API_URL` unset. Each boot uses disposable Wrangler persistence. The first two use a Node HTTP stub that implements the GitHub REST shapes consumed by `/api/status`; the third sends no GitHub credential. Focused unit coverage exercises the accepted production origin, rejected arbitrary HTTPS and alternate-port GitHub origins, accepted explicit-port loopback origins, rejected portless loopback origins, and the unset default.

**Command/environment:** Node 24, pinned Wrangler 4.107.0, `docs/proof/operational-health-zombie-runs/run-proof.sh`. Reviewed head `fe4b9e226a021b06dcf25917a62c4b0d876b48b1`; source-tree SHA-256 `c4a8005d8ad7b65d8c10947ff2caaf66434a6a2c2c8524402d0310d0661157f2`.

**Observable result:** Local `PROOF_RC=0`, 21 assertions. Zombie-only returned `healthy`, `queued_runs: 1`, `zombie_queued_runs: 1`, `queued_over_threshold: 0`, `oldest_queued_minutes: 0`, `oldest_zombie_queued_minutes: 1500`, and no `workflow_execution_degraded` reason. Adding the 31-minute run returned `degraded`, `queued_runs: 2`, `zombie_queued_runs: 1`, `queued_over_threshold: 1`, `oldest_queued_minutes: 31`, and added `workflow_execution_degraded`. With the override unset and no credentials, the retained payload carried unauthenticated public-GitHub HTTP 403 diagnostics.

**Artifacts/trace:** The proof writes `proof-summary.json`, all three `/api/status` payloads, GitHub request JSONL traces, and bounded Wrangler/stub logs under `.artifacts/operational-health-zombie-runs/`.

**Limits:** The stub does not emulate authentication, GraphQL, rate limiting, cancellation, or the production scheduler. Unit tests cover URL validation and the exact 24-hour boundary. External HTTPS overrides are rejected by design; only the production GitHub origin and explicit-port HTTP loopback proof origins are supported. The production population and cancel/force-cancel failures above are coordinator measurements, not repeated by this proof.

## Validation

- `pnpm run build:all` — pass
- `pnpm run test:no-build` — pass (`3275` tests, `3266` passed, `9` skipped, `0` failed/cancelled)
- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run check:dashboard-queue-boundary` — pass
- Pre-commit and final committed-branch Codex autoreview — clean, no accepted/actionable findings

## OpenClaw Bay impact

No Bay contract or implementation change is needed. Bay remains a public, indexable, observer-only projection and gains no queue, workflow, GitHub, DLQ, recovery, deploy, or rollback action. The security repair changes only outbound dashboard GitHub origin validation; the zombie-run change affects only the dashboard status payload and the existing derived `workflow_execution_degraded` reason.

## Container proof

The unchanged proof passed from a clean GitHub PR checkout through Docker-backed Crabbox after the security fix was pushed:

- Invocation: explicit `--provider local-container`, `--fresh-pr openclaw/clawsweeper#1101`, `--no-hydrate`, image `node:24-bookworm`, and Crabbox `--script` transport. Corepack was enabled into `$HOME/.local/bin` for the unprivileged lease user.
- Actual provider/runtime: `local-container`, Docker-backed Node 24 Bookworm.
- Lease: `cbx_285108492329` (`crimson-barnacle`), stopped automatically after the run.
- Reviewed head: `fe4b9e226a021b06dcf25917a62c4b0d876b48b1`.
- Verbatim result: `PROOF_RC=0`; Crabbox `exitCode: 0`, `runStatus: succeeded`; 21 proof assertions.
- Timing: sync 9.982s, command 16.780s, total 26.762s.
