### PR TITLE
fix: collapse exact publication on GitHub quota

### DIFF
--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -44,6 +44,8 @@ jobs:
       EXACT_REVIEW_BATCH_DISPATCH_ID: ${{ inputs.dispatch_id }}
       EXACT_REVIEW_BATCH_DISPATCHED_AT: ${{ inputs.dispatched_at }}
       EXACT_REVIEW_BATCH_MANIFEST: .artifacts/exact-review-batch/manifest.json
+      CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: .artifacts/exact-review-batch/github-rate-limits.jsonl
+      CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: .artifacts/exact-review-batch/github-request-metrics.jsonl
       # Scan the full queue window so owner filtering can still fill the 32-item lease cap.
       EXACT_REVIEW_BATCH_MAX_ITEMS: "50"
       EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY: "1"
@@ -204,9 +206,11 @@ jobs:
             target_branch="$(jq -r '.decision.targetBranch' <<<"$item")"
             item_number="$(jq -r '.decision.itemNumber' <<<"$item")"
             source_action="$(jq -r '.decision.publication.producerDecision.sourceAction' <<<"$item")"
+            repeat_revision="$(jq -r '.repeatRevision == true' <<<"$item")"
             fence_key="$(jq -r '.itemKey' <<<"$item")"
             revision="$(jq -r '.revision' <<<"$item")"
             export TARGET_REPO="$target_repo" ITEM_NUMBER="$item_number" FENCE_KEY="$fence_key" REVISION="$revision"
+            export EXACT_REVIEW_GITHUB_REQUEST_REPEAT="$repeat_revision"
             lifecycle_terminal=""
             lifecycle_router_outcome=""
             lifecycle_deferred_coverage="false"
@@ -262,12 +266,21 @@ jobs:
                 -f lookback_minutes="$CLAWSWEEPER_COMMENT_LOOKBACK_MINUTES" \
                 -f max_comments="$CLAWSWEEPER_COMMENT_MAX_COMMENTS" \
                 2>"$github_apply_error"; then
+                EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE=repository_actions \
+                  EXACT_REVIEW_GITHUB_REQUEST_OUTCOME=success \
+                  pnpm run --silent repair:exact-review-batch request-metric
                 rm -f "$github_apply_error"
               else
                 github_apply_status=$?
-                if grep -Eqi 'rate limit|HTTP 429' "$github_apply_error"; then
+                if grep -Eqi 'rate limit|abuse detection|was submitted too quickly|HTTP 429' "$github_apply_error"; then
+                  EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE=repository_actions \
+                    pnpm run --silent repair:exact-review-batch rate-limit || true
                   EXACT_REVIEW_BATCH_OBSERVATION=github_throttle \
                     pnpm run --silent repair:exact-review-batch observe || true
+                else
+                  EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE=repository_actions \
+                    EXACT_REVIEW_GITHUB_REQUEST_OUTCOME=error \
+                    pnpm run --silent repair:exact-review-batch request-metric || true
                 fi
                 cat "$github_apply_error" >&2
                 rm -f "$github_apply_error"

--- a/dashboard/bay-page.ts
+++ b/dashboard/bay-page.ts
@@ -385,8 +385,22 @@ dialog{border:0;padding:0;margin:0 0 0 auto;width:min(580px,94vw);height:100vh;m
       '<div class="bay-control-rate ',historyGap||historyStale?"collecting":"",'">',esc(mode+" · "+(historyGap?"history gap · awaiting current sample":historyStale?"history stale":terminal)),'</div></section>'
     ].join("");
   }
+  function renderBayPublicationQuotaContext(board,queue){
+    var lane=queue.lanes&&queue.lanes.publication||{};
+    var circuits=Array.isArray(lane.credential_circuits)?lane.credential_circuits:[];
+    var counters=lane.github_request_metrics&&lane.github_request_metrics.counters||{};
+    var throttleCount=Object.keys(counters).filter(function(key){return key.indexOf(":throttle:")>=0;}).reduce(function(total,key){return total+Math.max(0,Number(counters[key])||0);},0);
+    if(!circuits.length&&!Object.keys(counters).length)return;
+    var active=circuits.filter(function(circuit){return circuit&&circuit.active===true;});
+    var details=circuits.map(function(circuit){var owner=circuit.target_owner?" · "+circuit.target_owner:"";var reset=circuit.reset_source?" · "+circuit.reset_source:"";var authority=circuit.authoritative===true?" · authoritative":" · estimated";var affected=Number(circuit.affected_pending||0);return String(circuit.pool||circuit.scope||"credential")+owner+" · "+(circuit.active===true?"blocked until "+bayFormatTime(circuit.blocked_until):"recovered")+reset+authority+" · "+affected+" pending";}).join("; ");
+    var card=board.querySelectorAll(".bay-control-card")[1];
+    if(!card)return;
+    var summary=card.querySelector(".bay-control-summary span");
+    if(active.length&&summary)summary.textContent+=(summary.textContent?" · ":"")+active.length+" credential-blocked";
+    card.insertAdjacentHTML("beforeend",'<div class="bay-control-rate '+(active.length?"rising":"")+'">'+esc(active.length?active.length+" credential circuit"+(active.length===1?"":"s")+" active":"Credential circuits recovered")+(throttleCount?" · "+esc(throttleCount)+" GitHub throttles observed":"")+'</div><div class="bay-control-empty">'+esc(details||"No circuit detail")+'</div>');
+  }
   var renderBayControlBeforeStateWriter=renderBayControl;
-  renderBayControl=function(){renderBayControlBeforeStateWriter();var queue=state.data&&state.data.exact_review_queue;var board=document.getElementById("bay-control-board");if(queue&&board)board.insertAdjacentHTML("beforeend",bayStateWriterCard());};
+  renderBayControl=function(){renderBayControlBeforeStateWriter();var queue=state.data&&state.data.exact_review_queue;var board=document.getElementById("bay-control-board");if(queue&&board){renderBayPublicationQuotaContext(board,queue);board.insertAdjacentHTML("beforeend",bayStateWriterCard());}};
 })();
 </script>
 </body>

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -248,9 +248,44 @@ type ExactReviewPublicationCompletion = {
   kind: ExactReviewPublicationCompletionKind;
   reasonCode: ExactReviewPublicationReasonCode;
   errorFingerprint?: string;
+  attempted?: boolean;
 };
 type ExactReviewPublicationBatchCompletion = PublicationBatchCompletion & {
   publicationCompletion?: ExactReviewPublicationCompletion;
+  requestedRetryAt?: number;
+};
+type ExactReviewGithubCredentialScope = "repository_actions" | "target_app";
+type ExactReviewGithubRateLimitProvenance =
+  | "retry_after"
+  | "rate_limit_reset"
+  | "rate_limit_status"
+  | "fallback";
+type ExactReviewGithubRateLimitObservation = {
+  scope: ExactReviewGithubCredentialScope;
+  targetOwner?: string;
+  observedAt: number;
+  retryAt: number;
+  provenance: ExactReviewGithubRateLimitProvenance;
+  authoritative: boolean;
+};
+type ExactReviewGithubCredentialCircuit = ExactReviewGithubRateLimitObservation & {
+  poolKey: string;
+};
+type ExactReviewGithubRequestMetric = {
+  scope: ExactReviewGithubCredentialScope;
+  category:
+    | "artifact_download"
+    | "rate_status"
+    | "comments"
+    | "labels"
+    | "reviews"
+    | "workflow_dispatch"
+    | "item_metadata"
+    | "other";
+  mode: "read" | "mutation_or_private_read";
+  outcome: "success" | "throttle" | "transient" | "error" | "skipped_by_circuit";
+  repeatRevision: boolean;
+  count: number;
 };
 type ExactReviewPublicationFeedback = {
   at: number;
@@ -269,6 +304,7 @@ type ExactReviewPublicationControl = {
   lastScaleAt: number;
   lastFailureAt?: number;
   lastFailureKind?: ExactReviewPublicationFailureKind;
+  githubFeedbackReceipts: Record<string, number>;
 };
 export type ExactReviewClaimedRun = {
   runId: string;
@@ -307,6 +343,11 @@ export type ExactReviewQueueState = {
     // terminal-probed immediately before its dispatch. The marker is cleared
     // when that departure is consumed, fails, or expires.
     publicationBatchTerminalProbe?: string;
+    githubCredentialCircuits?: Record<string, ExactReviewGithubCredentialCircuit>;
+    githubRequestMetrics?: {
+      updatedAt: number;
+      counters: Record<string, number>;
+    };
   };
 };
 type LegacyExactReviewQueueState = ExactReviewQueueState & {
@@ -512,7 +553,9 @@ const EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE = "exact_review_queue_supersessions"
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
 const EXACT_REVIEW_PUBLICATION_HEAD_TABLE = "exact_review_publication_heads";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
+const EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE = "exact_review_github_telemetry_receipts";
 const REVIEW_RUN_TELEMETRY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE = "exact_review_state_writer_operations";
 const EXACT_REVIEW_STATE_WRITER_LIVE_TABLE = "exact_review_state_writer_live";
 const EXACT_REVIEW_STATE_WRITER_DIAGNOSTICS_TABLE = "exact_review_state_writer_diagnostics";
@@ -2979,6 +3022,13 @@ export class ExactReviewQueue {
             dead_letters: deadLetters,
             health: publicationHealth,
             capacity_control: exactReviewPublicationControlStatus(this.env, publicationControl),
+            credential_circuits: exactReviewGithubCredentialCircuitStatus(state, now),
+            github_request_metrics: {
+              updated_at: state.dispatcher?.githubRequestMetrics?.updatedAt
+                ? new Date(state.dispatcher.githubRequestMetrics.updatedAt).toISOString()
+                : null,
+              counters: state.dispatcher?.githubRequestMetrics?.counters || {},
+            },
             batches: {
               enabled: exactReviewPublicationBatchingEnabled(this.env),
               max_items: exactReviewPublicationBatchSize(this.env),
@@ -3222,7 +3272,11 @@ export class ExactReviewQueue {
       (snapshot.dispatcher?.state === "paused" || snapshot.dispatcher?.state === "blocked") &&
       Number(snapshot.dispatcher?.retryAt || 0) > startedAt;
     let batchTerminalPreflightReady = false;
-    if (snapshotBatchDeparture?.due && !snapshotDispatcherBackoffActive) {
+    if (
+      snapshotBatchDeparture?.due &&
+      snapshotBatchCandidates.length > 0 &&
+      !snapshotDispatcherBackoffActive
+    ) {
       const batchTerminalProbe = exactReviewPublicationBatchCandidateProbe(snapshotBatchCandidates);
       await this.terminalizePublicationCandidates(
         snapshotBatchCandidates.map((item) => ({
@@ -3284,6 +3338,7 @@ export class ExactReviewQueue {
         Number(snapshot.dispatcher?.retryAt || 0) > recheckedAt;
       batchTerminalPreflightReady =
         snapshotBatchDeparture?.due === true &&
+        snapshotBatchCandidates.length > 0 &&
         !snapshotDispatcherBackoffActive &&
         exactReviewPublicationBatchCandidateProbe(snapshotBatchCandidates) === batchTerminalProbe;
     }
@@ -5020,6 +5075,9 @@ export class ExactReviewQueue {
       if (exactReviewQueueIsPublication(item) && !exactReviewQueueIsBatchablePublication(item)) {
         excludedItemKeys.add(item.key);
       }
+      if (exactReviewGithubCircuitBlocksItem(state, item, now)) {
+        excludedItemKeys.add(item.key);
+      }
       const revision = exactReviewPublicationRevision(item.decision);
       if (
         revision &&
@@ -5373,6 +5431,7 @@ export class ExactReviewQueue {
           revision: membership.revision,
           claim_generation: membership.claimGeneration,
           decision: item.decision,
+          repeat_revision: Number(item.publicationFailureAttempts || 0) > 0,
         },
       ];
     });
@@ -5444,12 +5503,26 @@ export class ExactReviewQueue {
     const batchId = exactReviewPublicationBatchId(body.batch_id);
     const leaseOwner = exactReviewPublicationBatchOwner(body.lease_owner);
     const completions = exactReviewPublicationBatchCompletions(body.items);
+    const rateLimitObservations = exactReviewGithubRateLimitObservations(
+      body.github_rate_limit_observations,
+    );
+    const requestMetrics = exactReviewGithubRequestMetrics(body.github_request_metrics);
+    const telemetryId = String(body.github_telemetry_id || "").trim();
     const stateWriter =
       body.state_writer === undefined
         ? undefined
         : normalizeStateWriterOperation(body.state_writer);
     if (!batchId || !leaseOwner) return json({ error: "invalid_batch_identity" }, 400);
     if (!completions) return json({ error: "invalid_batch_completions" }, 400);
+    if (body.github_rate_limit_observations !== undefined && !rateLimitObservations) {
+      return json({ error: "invalid_github_rate_limit_observations" }, 400);
+    }
+    if (body.github_request_metrics !== undefined && !requestMetrics) {
+      return json({ error: "invalid_github_request_metrics" }, 400);
+    }
+    if (body.github_telemetry_id !== undefined && !/^[0-9a-f]{64}$/i.test(telemetryId)) {
+      return json({ error: "invalid_github_telemetry_id" }, 400);
+    }
     if (body.state_writer !== undefined && !stateWriter) {
       this.incrementStateWriterDiagnosticSafely("rejected_terminal_total");
       return json({ error: "invalid_batch_state_writer" }, 400);
@@ -5571,6 +5644,7 @@ export class ExactReviewQueue {
               now,
               completion: requested.publicationCompletion,
               ownedRevision: completion.revision,
+              requestedRetryAt: requested.requestedRetryAt,
               deadLetterCapacityAvailable: this.deadLetterCapacityAvailableSync(
                 exactReviewDeadLetterId(item, completion.revision),
               ),
@@ -5660,6 +5734,7 @@ export class ExactReviewQueue {
             now,
             completion: publicationCompletion,
             ownedRevision: completion.revision,
+            requestedRetryAt: requested.requestedRetryAt,
             deadLetterCapacityAvailable: true,
             env: this.env,
           });
@@ -5729,19 +5804,56 @@ export class ExactReviewQueue {
           Date.parse(stateWriter.finished_at),
         ) ?? batch;
     }
+    const telemetrySubmitted = Boolean(rateLimitObservations?.length || requestMetrics?.length);
+    let telemetryApplied = false;
+    if (telemetrySubmitted) {
+      const state = this.readStateSync();
+      const telemetryReceipt =
+        telemetryId ||
+        (await sha256Hex(
+          new TextEncoder().encode(
+            stableJson({ batchId, leaseOwner, rateLimitObservations, requestMetrics }),
+          ),
+        ));
+      telemetryApplied = this.applyGithubTelemetrySync(
+        state,
+        telemetryReceipt,
+        rateLimitObservations || [],
+        requestMetrics || [],
+        now,
+      );
+      if (rateLimitObservations?.length) {
+        const control = this.publicationControlSync();
+        const feedbackAt = Math.max(
+          ...rateLimitObservations.map((observation) => observation.observedAt),
+        );
+        this.applyPublicationFeedbackSync(
+          {
+            at: feedbackAt,
+            capacity: control.capacityCeiling,
+            outcome: "failure",
+            failureKind: "github_rate_limit",
+          },
+          telemetryReceipt,
+        );
+      }
+    }
     if (
-      completions.some(
-        (completion) => completion.publicationCompletion?.reasonCode === "github_rate_limit",
-      )
+      (acceptedCount || telemetryApplied) &&
+      (rateLimitObservations?.length ||
+        completions.some(
+          (completion) => completion.publicationCompletion?.reasonCode === "github_rate_limit",
+        ))
     ) {
       batch = this.batchStore.recordGithubThrottle(batchId, leaseOwner, now) ?? batch;
     }
     this.recordStateWriterOperationSafely(stateWriter, false, now);
-    if (acceptedCount) await this.scheduleNext(this.readStateSync(), now);
+    if (acceptedCount || telemetryApplied) await this.scheduleNext(this.readStateSync(), now);
     return json({
       ok: true,
       accepted: acceptedCount,
       skipped: completions.length - acceptedCount,
+      ...(telemetrySubmitted ? { telemetry_accepted: true } : {}),
       batch: exactReviewPublicationBatchJson(batch),
     });
   }
@@ -7249,6 +7361,16 @@ export class ExactReviewQueue {
          (trigger_lane, target_repo, completed_at, workflow_outcome)`,
     );
     this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE} (
+         receipt TEXT PRIMARY KEY,
+         observed_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_github_telemetry_receipts_observed
+         ON ${EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE} (observed_at)`,
+    );
+    this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_STATE_WRITER_OPERATION_TABLE} (
          operation_id TEXT PRIMARY KEY,
          observed_at INTEGER NOT NULL,
@@ -7731,10 +7853,16 @@ export class ExactReviewQueue {
     return next;
   }
 
-  private applyPublicationFeedbackSync(feedback: ExactReviewPublicationFeedback) {
+  private applyPublicationFeedbackSync(feedback: ExactReviewPublicationFeedback, receipt?: string) {
     const current = this.publicationControlSync();
+    if (receipt && Object.hasOwn(current.githubFeedbackReceipts, receipt)) return;
     const next = exactReviewPublicationControlAfterFeedback(this.env, current, feedback);
-    this.storage.kv.put(EXACT_REVIEW_PUBLICATION_CONTROL_KEY, next);
+    this.storage.kv.put(EXACT_REVIEW_PUBLICATION_CONTROL_KEY, {
+      ...next,
+      githubFeedbackReceipts: receipt
+        ? { ...current.githubFeedbackReceipts, [receipt]: Date.now() }
+        : current.githubFeedbackReceipts,
+    });
   }
 
   private queueMetricTotalsSync(): ExactReviewQueueMetricTotals {
@@ -8196,6 +8324,41 @@ export class ExactReviewQueue {
       `DELETE FROM ${EXACT_REVIEW_STATE_WRITER_LIVE_TABLE} WHERE observed_at < ?`,
       now - EXACT_REVIEW_STATE_WRITER_LIVE_MS,
     );
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE} WHERE observed_at < ?`,
+      now - EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_RETENTION_MS,
+    );
+  }
+
+  private applyGithubTelemetrySync(
+    state: ExactReviewQueueState,
+    receipt: string,
+    rateLimitObservations: readonly ExactReviewGithubRateLimitObservation[],
+    requestMetrics: readonly ExactReviewGithubRequestMetric[],
+    now: number,
+  ): boolean {
+    return this.storage.transactionSync(() => {
+      const existing = Array.from(
+        this.storage.sql.exec(
+          `SELECT 1 FROM ${EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE} WHERE receipt = ? LIMIT 1`,
+          receipt,
+        ),
+      );
+      if (existing.length) return false;
+      if (rateLimitObservations.length) {
+        applyExactReviewGithubCredentialCircuits(state, rateLimitObservations);
+      }
+      if (requestMetrics.length) {
+        applyExactReviewGithubRequestMetrics(state, requestMetrics, now);
+      }
+      this.writeStateSync(state);
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE} (receipt, observed_at) VALUES (?, ?)`,
+        receipt,
+        now,
+      );
+      return true;
+    });
   }
 
   private recordStateWriterOperationSafely(
@@ -8999,11 +9162,13 @@ export class ExactReviewQueue {
       this.freshPublicationItemKeysSync(state, now),
     );
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
+    const credentialCircuitNext = exactReviewGithubCircuitNextWakeAt(state, now);
     const next = [
       queueNext,
       batchOwnership.nextLeaseExpiresAt,
       batchDeparture?.dueAt ?? null,
       sourceAuthorityNext,
+      credentialCircuitNext,
     ]
       .filter((candidate): candidate is number => candidate !== null)
       .reduce<number | null>(
@@ -10268,6 +10433,29 @@ function finishExactReviewPublicationQueueItem({
     };
   }
 
+  if (
+    completion.kind === "retryable_failure" &&
+    completion.reasonCode === "github_rate_limit" &&
+    completion.attempted === false
+  ) {
+    clearExactReviewLease(item);
+    item.state = "pending";
+    item.parkedReason = undefined;
+    item.nextAttemptAt = Math.max(
+      exactReviewQueueEnqueueAttemptAt(state, now),
+      requestedRetryAt + exactReviewCredentialRecoveryJitterMs(item.key),
+    );
+    item.backoffReason = "publication_retry";
+    item.lastFailureReason = "github_rate_limit";
+    item.updatedAt = now;
+    return {
+      requeued: true,
+      retried: false,
+      refreshed: false,
+      parked: false,
+    };
+  }
+
   // Dispatch failures and publisher results have independent budgets. A runner
   // handoff failure must not make the first deterministic artifact failure look
   // like its third confirmation attempt.
@@ -10334,6 +10522,15 @@ function finishExactReviewPublicationQueueItem({
       : "publication_retry";
   item.updatedAt = now;
   return { requeued: true, retried: true, refreshed: false, parked: false };
+}
+
+function exactReviewCredentialRecoveryJitterMs(itemKey: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < itemKey.length; index += 1) {
+    hash ^= itemKey.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0) % 30_001;
 }
 
 function exactReviewDeadLetterId(item: ExactReviewQueueItem, ownedRevision?: number) {
@@ -11274,6 +11471,7 @@ export function exactReviewQueueAdmittedItems(
   for (const item of pendingReviews) {
     if (admittedReviews.length >= reviewSlots) break;
     const target = item.decision.targetRepo;
+    if (exactReviewGithubTargetAppCircuitRetryAt(state, target, now) > now) continue;
     const active = activeTargets.get(target) || 0;
     if (active >= targetCapacity) continue;
     activeTargets.set(target, active + 1);
@@ -11685,6 +11883,7 @@ export function exactReviewQueueNextWakeAt(
         return [Math.max(item.nextAttemptAt, blockedUntil)];
       }
       const target = item.decision.targetRepo;
+      const credentialBlockedUntil = exactReviewGithubTargetAppCircuitRetryAt(state, target, now);
       const capacityBlockedUntil = [
         ...(activeReviews.length >= capacity && activeReviewWakeAt.length
           ? [Math.min(...activeReviewWakeAt)]
@@ -11698,6 +11897,7 @@ export function exactReviewQueueNextWakeAt(
         Math.max(
           item.nextAttemptAt,
           reviewAdmissionBlockedUntil ?? item.nextAttemptAt,
+          credentialBlockedUntil,
           capacityBlockedUntil.length ? Math.min(...capacityBlockedUntil) : item.nextAttemptAt,
         ),
       ];
@@ -11827,6 +12027,17 @@ function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicat
   const rawRecoverySuccesses = Number(control.recoverySuccesses);
   const rawLastFailureAt = Number(control.lastFailureAt);
   const lastFailureKind = exactReviewPublicationFailureKind(control.lastFailureKind);
+  const feedbackReceiptCutoff = Date.now() - EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_RETENTION_MS;
+  const githubFeedbackReceipts = Object.fromEntries(
+    Object.entries(objectValue(control.githubFeedbackReceipts))
+      .filter(
+        ([receipt, recordedAt]) =>
+          /^[0-9a-f]{64}$/i.test(receipt) &&
+          Number.isFinite(Number(recordedAt)) &&
+          Number(recordedAt) >= feedbackReceiptCutoff,
+      )
+      .map(([receipt, recordedAt]) => [receipt, Number(recordedAt)] as const),
+  );
   // A fixed higher-capacity policy persists both values above a later policy's
   // maximum (for example the temporary 50/50/50 override). On downgrade, the
   // ceiling may retain the new maximum, but demand must restart at the new base
@@ -11854,6 +12065,7 @@ function exactReviewPublicationControl(env, value: unknown): ExactReviewPublicat
     demandTier: Math.max(0, Number(control.demandTier) || 0),
     lastDemandSampleAt: Math.max(0, Number(control.lastDemandSampleAt) || 0),
     lastScaleAt: Math.max(0, Number(control.lastScaleAt) || 0),
+    githubFeedbackReceipts,
     ...(Number.isSafeInteger(rawLastFailureAt) && rawLastFailureAt > 0
       ? { lastFailureAt: rawLastFailureAt }
       : {}),
@@ -12190,7 +12402,8 @@ function exactReviewPublicationBatchDeparture(
           exactReviewQueueIsBatchablePublication(item) &&
           item.state === "pending" &&
           !item.terminalFinalization &&
-          !ownedItemKeys.has(item.key),
+          !ownedItemKeys.has(item.key) &&
+          !exactReviewGithubCircuitBlocksItem(state, item, now),
       )
       .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key)),
     freshItemKeys,
@@ -12253,6 +12466,12 @@ function exactReviewPublicationBatchDeparture(
 
 function exactReviewBatchDispatcherFields(dispatcher: ExactReviewQueueState["dispatcher"]) {
   return {
+    ...(dispatcher?.githubCredentialCircuits
+      ? { githubCredentialCircuits: dispatcher.githubCredentialCircuits }
+      : {}),
+    ...(dispatcher?.githubRequestMetrics
+      ? { githubRequestMetrics: dispatcher.githubRequestMetrics }
+      : {}),
     ...(dispatcher?.publicationBatchDispatchId
       ? { publicationBatchDispatchId: dispatcher.publicationBatchDispatchId }
       : {}),
@@ -12997,6 +13216,217 @@ function exactReviewPublicationBatchOwner(value) {
   return /^[A-Za-z0-9._:@/-]{1,200}$/.test(text) ? text : "";
 }
 
+function exactReviewGithubCredentialPoolKey(
+  scope: ExactReviewGithubCredentialScope,
+  targetOwner?: string,
+) {
+  return scope === "repository_actions"
+    ? "actions:openclaw/clawsweeper"
+    : `target_app:${String(targetOwner || "").toLowerCase()}`;
+}
+
+function exactReviewGithubRateLimitObservations(
+  value,
+): ExactReviewGithubRateLimitObservation[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 8) return null;
+  const now = Date.now();
+  const observations: ExactReviewGithubRateLimitObservation[] = [];
+  for (const raw of value) {
+    const item = objectValue(raw);
+    const scope = String(item.scope || "");
+    const targetOwner = String(item.target_owner || "")
+      .trim()
+      .toLowerCase();
+    const observedAt = Date.parse(String(item.observed_at || ""));
+    const retryAt = Date.parse(String(item.retry_at || ""));
+    const provenance = String(item.provenance || "");
+    if (
+      (scope !== "repository_actions" && scope !== "target_app") ||
+      (scope === "target_app" && !/^[a-z0-9_.-]{1,100}$/.test(targetOwner)) ||
+      !Number.isFinite(observedAt) ||
+      observedAt < now - 24 * 60 * 60 * 1000 ||
+      observedAt > now + 5 * 60_000 ||
+      !Number.isFinite(retryAt) ||
+      retryAt < observedAt ||
+      retryAt > now + EXACT_REVIEW_COMPLETION_RETRY_MAX_MS ||
+      !["retry_after", "rate_limit_reset", "rate_limit_status", "fallback"].includes(provenance) ||
+      typeof item.authoritative !== "boolean"
+    ) {
+      return null;
+    }
+    observations.push({
+      scope,
+      ...(targetOwner ? { targetOwner } : {}),
+      observedAt,
+      retryAt,
+      provenance: provenance as ExactReviewGithubRateLimitProvenance,
+      authoritative: item.authoritative,
+    });
+  }
+  return observations;
+}
+
+function exactReviewGithubRequestMetrics(value): ExactReviewGithubRequestMetric[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 128) return null;
+  const metrics: ExactReviewGithubRequestMetric[] = [];
+  for (const raw of value) {
+    const item = objectValue(raw);
+    const scope = String(item.scope || "");
+    const category = String(item.category || "");
+    const mode = String(item.mode || "");
+    const outcome = String(item.outcome || "");
+    const count = Number(item.count);
+    if (
+      !["repository_actions", "target_app"].includes(scope) ||
+      ![
+        "artifact_download",
+        "rate_status",
+        "comments",
+        "labels",
+        "reviews",
+        "workflow_dispatch",
+        "item_metadata",
+        "other",
+      ].includes(category) ||
+      !["read", "mutation_or_private_read"].includes(mode) ||
+      !["success", "throttle", "transient", "error", "skipped_by_circuit"].includes(outcome) ||
+      typeof item.repeat_revision !== "boolean" ||
+      !Number.isInteger(count) ||
+      count < 1 ||
+      count > 10_000
+    ) {
+      return null;
+    }
+    metrics.push({
+      scope: scope as ExactReviewGithubCredentialScope,
+      category: category as ExactReviewGithubRequestMetric["category"],
+      mode: mode as ExactReviewGithubRequestMetric["mode"],
+      outcome: outcome as ExactReviewGithubRequestMetric["outcome"],
+      repeatRevision: item.repeat_revision,
+      count,
+    });
+  }
+  return metrics;
+}
+
+function applyExactReviewGithubCredentialCircuits(
+  state: ExactReviewQueueState,
+  observations: readonly ExactReviewGithubRateLimitObservation[],
+) {
+  const dispatcher = state.dispatcher ?? { state: "unknown" as const, checkedAt: Date.now() };
+  const circuits = { ...dispatcher.githubCredentialCircuits };
+  for (const observation of observations) {
+    const poolKey = exactReviewGithubCredentialPoolKey(observation.scope, observation.targetOwner);
+    const previous = circuits[poolKey];
+    if (!previous || observation.retryAt > previous.retryAt) {
+      circuits[poolKey] = { ...observation, poolKey };
+    }
+  }
+  state.dispatcher = { ...dispatcher, githubCredentialCircuits: circuits };
+}
+
+function applyExactReviewGithubRequestMetrics(
+  state: ExactReviewQueueState,
+  metrics: readonly ExactReviewGithubRequestMetric[],
+  now: number,
+) {
+  const dispatcher = state.dispatcher ?? { state: "unknown" as const, checkedAt: now };
+  const counters = { ...dispatcher.githubRequestMetrics?.counters };
+  for (const metric of metrics) {
+    const key = [
+      metric.scope,
+      metric.category,
+      metric.mode,
+      metric.outcome,
+      metric.repeatRevision ? "repeat" : "first",
+    ].join(":");
+    counters[key] = Math.max(0, Number(counters[key] || 0)) + metric.count;
+  }
+  state.dispatcher = {
+    ...dispatcher,
+    githubRequestMetrics: { updatedAt: now, counters },
+  };
+}
+
+function exactReviewGithubCredentialCircuits(
+  state: ExactReviewQueueState,
+): ExactReviewGithubCredentialCircuit[] {
+  return Object.values(state.dispatcher?.githubCredentialCircuits || {}).filter(
+    (circuit) =>
+      circuit &&
+      (circuit.scope === "repository_actions" || circuit.scope === "target_app") &&
+      Number.isFinite(circuit.retryAt),
+  );
+}
+
+function exactReviewGithubCircuitBlocksItem(
+  state: ExactReviewQueueState,
+  item: ExactReviewQueueItem,
+  now: number,
+) {
+  const owner = item.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
+  return exactReviewGithubCredentialCircuits(state).some(
+    (circuit) =>
+      circuit.retryAt > now &&
+      (circuit.scope === "repository_actions" || circuit.targetOwner === owner),
+  );
+}
+
+function exactReviewGithubTargetAppCircuitRetryAt(
+  state: ExactReviewQueueState,
+  targetRepo: string,
+  now: number,
+) {
+  const owner = targetRepo.split("/", 1)[0]?.toLowerCase();
+  return exactReviewGithubCredentialCircuits(state).reduce(
+    (retryAt, circuit) =>
+      circuit.scope === "target_app" && circuit.targetOwner === owner && circuit.retryAt > now
+        ? Math.max(retryAt, circuit.retryAt)
+        : retryAt,
+    0,
+  );
+}
+
+function exactReviewGithubCircuitNextWakeAt(state: ExactReviewQueueState, now: number) {
+  return exactReviewGithubCredentialCircuits(state).reduce<number | null>(
+    (next, circuit) =>
+      circuit.retryAt <= now
+        ? next
+        : next === null
+          ? circuit.retryAt
+          : Math.min(next, circuit.retryAt),
+    null,
+  );
+}
+
+function exactReviewGithubCredentialCircuitStatus(state: ExactReviewQueueState, now: number) {
+  return exactReviewGithubCredentialCircuits(state)
+    .map((circuit) => {
+      const affectedPending = Object.values(state.items).filter((item) => {
+        if (!exactReviewQueueIsBatchablePublication(item) || item.state !== "pending") return false;
+        if (circuit.scope === "repository_actions") return true;
+        return item.decision.targetRepo.split("/", 1)[0]?.toLowerCase() === circuit.targetOwner;
+      }).length;
+      return {
+        pool: circuit.poolKey,
+        scope: circuit.scope,
+        target_owner: circuit.targetOwner || null,
+        observed_at: new Date(circuit.observedAt).toISOString(),
+        blocked_until: new Date(circuit.retryAt).toISOString(),
+        reset_source: circuit.provenance,
+        authoritative: circuit.authoritative,
+        active: circuit.retryAt > now,
+        affected_pending: affectedPending,
+      };
+    })
+    .sort(
+      (left, right) =>
+        Number(right.active) - Number(left.active) || left.pool.localeCompare(right.pool),
+    );
+}
+
 function exactReviewPublicationBatchCompletions(
   value,
 ): ExactReviewPublicationBatchCompletion[] | null {
@@ -13017,6 +13447,11 @@ function exactReviewPublicationBatchCompletions(
             item.reason_code,
             item.error_fingerprint,
           );
+    const requestedRetryAt = exactReviewCompletionRetryAt(item.retry_at, Date.now());
+    const attempted = item.attempted === undefined ? undefined : item.attempted === true;
+    if (publicationCompletion && attempted !== undefined) {
+      publicationCompletion.attempted = attempted;
+    }
     if (
       !itemKey ||
       itemKey.length > 500 ||
@@ -13030,7 +13465,11 @@ function exactReviewPublicationBatchCompletions(
         !publicationCompletion) ||
       publicationCompletion?.kind === "published" ||
       publicationCompletion?.kind === "superseded" ||
-      publicationCompletion?.kind === "deferred"
+      publicationCompletion?.kind === "deferred" ||
+      (item.retry_at !== undefined && requestedRetryAt === null) ||
+      (item.attempted !== undefined && typeof item.attempted !== "boolean") ||
+      (attempted === false &&
+        (publicationCompletion?.reasonCode !== "github_rate_limit" || requestedRetryAt === null))
     ) {
       return null;
     }
@@ -13044,6 +13483,7 @@ function exactReviewPublicationBatchCompletions(
           ? terminalOutcome
           : "lease_expired",
       ...(publicationCompletion ? { publicationCompletion } : {}),
+      ...(requestedRetryAt !== null ? { requestedRetryAt } : {}),
     });
   }
   return completions;

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -61,17 +61,17 @@ The mental model:
 
 ## Worker Budget
 
-| Name                                       | Current | Meaning                                                                               |
-| ------------------------------------------ | ------: | ------------------------------------------------------------------------------------- |
-| `workers.max`                              |     128 | Maximum global Codex worker budget used to derive lane limits.                        |
-| `workers.reserve_for_interactive`          |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                |
-| `workers.expansion_reserve`                |       8 | Extra slots background lanes leave open for independently planned matrix expansion.   |
-| `workers.minimum_background`               |      16 | Target floor for background progress when enough global capacity is available.        |
-| `lanes.exact_review.max_concurrent`        |     128 | Maximum concurrent exact-item review workflow runs admitted to Codex.                 |
-| `lanes.exact_review.target_max_concurrent` |     120 | Maximum concurrent exact-item review workflow runs one target repository may consume. |
-| `lanes.exact_review.actions_budget`        |     194 | At 128 reviews and 40 publishers, preserves the 16-slot hard reserve plus 10 slots of headroom.       |
-| `lanes.assist.max`                         |      10 | Maximum concurrent lightweight assist jobs.                                           |
-| `lanes.repair.cluster_max_live_runs`       |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.            |
+| Name                                       | Current | Meaning                                                                                         |
+| ------------------------------------------ | ------: | ----------------------------------------------------------------------------------------------- |
+| `workers.max`                              |     128 | Maximum global Codex worker budget used to derive lane limits.                                  |
+| `workers.reserve_for_interactive`          |      16 | Worker slots background lanes leave open for exact/manual/urgent work.                          |
+| `workers.expansion_reserve`                |       8 | Extra slots background lanes leave open for independently planned matrix expansion.             |
+| `workers.minimum_background`               |      16 | Target floor for background progress when enough global capacity is available.                  |
+| `lanes.exact_review.max_concurrent`        |     128 | Maximum concurrent exact-item review workflow runs admitted to Codex.                           |
+| `lanes.exact_review.target_max_concurrent` |     120 | Maximum concurrent exact-item review workflow runs one target repository may consume.           |
+| `lanes.exact_review.actions_budget`        |     194 | At 128 reviews and 40 publishers, preserves the 16-slot hard reserve plus 10 slots of headroom. |
+| `lanes.assist.max`                         |      10 | Maximum concurrent lightweight assist jobs.                                                     |
+| `lanes.repair.cluster_max_live_runs`       |       2 | Default live repair workflow cap for imported gitcrawl cluster dispatches.                      |
 
 ## Derived Limits
 
@@ -244,6 +244,34 @@ shared Git writer constraint, so production now admits 8 preparation
 batches (up to 64 publication members) while retaining the Durable Object's
 transactional SQLite ownership boundaries.
 
+Publication batching also owns reset-aware GitHub credential circuits. The
+repository Actions pool is identified only as `actions:openclaw/clawsweeper`;
+target App pools are identified by the non-secret target owner. A primary or
+secondary rate-limit observation persists its reset deadline in the queue
+dispatcher, suppresses new batch dispatch for only the affected pool, and adds
+that deadline to the next alarm wake-up. A later observation may extend but
+cannot shorten an open circuit. When `gh` omits response headers, the publisher
+performs at most one same-credential `/rate_limit` lookup; the one-minute
+fallback is used only when no authoritative reset is available.
+
+The first quota failure in a preparation batch stops later members before
+artifact download. The observing member records a normal retryable failure;
+members that never made a GitHub request are requeued after the shared reset
+with deterministic 0-30 second recovery jitter and do not consume their
+individual publication retry or dead-letter budgets. A classifier-approved
+public `openclaw/openclaw` read may make one bounded fallback from the exhausted
+Actions token to the already-authorized target App token. That success does not
+close the Actions circuit, and mutations, private reads, and unsupported routes
+never use the repository token.
+
+`lanes.publication.github_request_metrics` measures the successful and failed
+request budget by redacted credential scope, endpoint category, public-read
+versus App-operation class, first versus repeated revision, and outcome. It
+contains counts only: no repository item number, URL, content, token, token
+hash, authorization header, or filesystem path is retained. Use these counters
+to justify later cache or metadata-read consolidation; live freshness and
+pre-mutation guards remain mandatory.
+
 Each dispatched workflow claims its opaque lease before checkout. Protocol v2
 binds claim and completion to the item key, lease revision, run attempt, claim
 generation, source head (for pull requests), and an immutable decision snapshot.
@@ -334,8 +362,7 @@ and hot intake `14`. Existing repair lanes keep their
   archives; raise this override to scan deeper per run.
 - `REVIEW_PLACEHOLDER_MAX_CHECKS` overrides the number of search candidates
   examined per open and closed state class by each 15-minute
-  orphaned-placeholder recovery pass; the default is 20 and the maximum is
-  1000. Independent durable cursors rotate both state classes so non-actionable
+  orphaned-placeholder recovery pass; the default is 20 and the maximum is 1000. Independent durable cursors rotate both state classes so non-actionable
   matches cannot permanently pin later placeholders behind the bounded pass.
 - `REVIEW_PLACEHOLDER_MIN_AGE_HOURS` overrides how old the latest ClawSweeper bot
   review-start placeholder must be before recovery; the default is 2 hours and

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -356,6 +356,22 @@ publication with retry/batch fallback. Document effective production values from
 `dashboard/wrangler.toml`, not only fallback constants in
 `dashboard/exact-review-queue.ts`.
 
+The publication lane exposes two additional observer-only surfaces:
+
+- `credential_circuits` lists the redacted pool class, optional target owner,
+  observation time, `blocked_until`, reset source, authority flag, active state,
+  and affected pending count. `active: true` with free publication slots means
+  credential-blocked, not capacity-starved or healthy-idle.
+- `github_request_metrics` contains cumulative redacted counters keyed by pool
+  class, endpoint category, operation class, outcome, and whether the item
+  revision was already retried. These counters are for request-budget analysis;
+  they never contain raw URLs, item content, credentials, or local paths.
+
+Bay renders these fields as health context only. It has no circuit reset,
+workflow dispatch, queue retry, replay, acknowledgement, or gate control.
+Expired circuit observations remain visible as `active: false` for diagnosis;
+new work resumes automatically after the deadline and bounded item jitter.
+
 The standalone **State writer** panel separates the repo-wide serialization
 boundary from exact-review materialization telemetry. After the coordinator
 cutover, `state_writer.coordinator` is authoritative for the active writer,

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -96,6 +96,27 @@ remains per-target serialized. See [`docs/limits.md`](limits.md) for effective v
 Tuple-aware state reconciliation prevents stale review snapshots from reviving
 closed records.
 
+Batch admission is additionally gated by persisted GitHub credential circuits.
+Every batch needs the `actions:openclaw/clawsweeper` pool for producer artifact
+download, while target App circuits are owner-scoped so one exhausted
+installation does not stop healthy owners. A blocked pool prevents workflow
+dispatch, state hydration, and artifact download until its reported reset; the
+alarm wakes at the earliest circuit deadline. The current batch collapses after
+the first pool failure, and unattempted members return without advancing their
+retry budget. Reset recovery is spread by deterministic item jitter.
+An owner-scoped target App circuit also defers new exact-review admission for
+that owner, because review and publication share the installation quota; other
+owners remain admissible.
+
+Exact publication routes only classifier-approved public reads through the
+repository Actions token. If that pool is exhausted after the current member's
+artifact is already present, the member may use the ambient target App once;
+later members still stop because they require the blocked Actions pool. The
+workflow also records a typed repository-pool observation if its final comment
+router dispatch encounters quota pressure. All typed observations and request
+counters are acknowledged with the same fenced batch completion, so a delayed
+cleanup is idempotent and cannot duplicate accounting.
+
 ## Schedules
 
 `openclaw/openclaw`:

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -3,8 +3,11 @@ import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
 import {
   cpSync,
+  closeSync,
   existsSync,
+  appendFileSync,
   mkdirSync,
+  openSync,
   readdirSync,
   readFileSync,
   rmSync,
@@ -73,14 +76,52 @@ async function controller() {
     process.env.EXACT_REVIEW_BATCH_HEARTBEAT_FAILURE_PATH ||
       ".artifacts/exact-review-batch/heartbeat-failed",
   );
+  const rateLimitObservationPath = resolve(
+    workspace,
+    process.env.CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH ||
+      ".artifacts/exact-review-batch/github-rate-limits.jsonl",
+  );
+  const requestMetricsPath = resolve(
+    workspace,
+    process.env.CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH ||
+      ".artifacts/exact-review-batch/github-request-metrics.jsonl",
+  );
   rmSync(workersRoot, { recursive: true, force: true });
   mkdirSync(workersRoot, { recursive: true });
+  mkdirSync(dirname(rateLimitObservationPath), { recursive: true });
+  rmSync(rateLimitObservationPath, { force: true });
+  rmSync(`${rateLimitObservationPath}.lookup-repository_actions.lock`, { force: true });
+  rmSync(`${rateLimitObservationPath}.lookup-target_app.lock`, { force: true });
+  rmSync(`${rateLimitObservationPath}.fallback-target_app.lock`, { force: true });
+  rmSync(requestMetricsPath, { force: true });
   let cleanupFailures = 0;
   const durations = [];
   let timeouts = 0;
   let admitted = 0;
+  let collapsed = 0;
+  let activeCircuit = null;
   const { peak } = await runBoundedPool(items, concurrency, async (item, index) => {
     const outcomePath = checkedOutcomePath(workspace, item.outcomePath);
+    activeCircuit = activeCircuit || latestActiveRateLimitObservation(rateLimitObservationPath);
+    if (activeCircuit) {
+      collapsed += 1;
+      appendRequestMetric(requestMetricsPath, {
+        scope: activeCircuit.scope,
+        category: "artifact_download",
+        mode: "read",
+        outcome: "skipped_by_circuit",
+        repeat_revision: item.repeatRevision === true,
+        count: 1,
+      });
+      writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
+        retryAt: activeCircuit.retry_at,
+        rateLimitScope: activeCircuit.scope,
+        rateLimitProvenance: activeCircuit.provenance,
+        rateLimitAuthoritative: activeCircuit.authoritative === true,
+        attempted: false,
+      });
+      return { kind: "circuit_deferred", durationMs: 0 };
+    }
     if (existsSync(heartbeatFailurePath) || Date.now() >= deadline) {
       writeFailure(outcomePath, "retryable_failure", "unknown_failure");
       return { kind: "not_admitted", durationMs: 0 };
@@ -118,6 +159,7 @@ async function controller() {
       }
       console.error(`Failed to prepare batch member ${item.itemKey} during ${failureStage}`);
     } finally {
+      activeCircuit = activeCircuit || latestActiveRateLimitObservation(rateLimitObservationPath);
       durations.push(Date.now() - workerStartedAt);
       try {
         rmSync(root, { recursive: true, force: true });
@@ -136,6 +178,7 @@ async function controller() {
     workerMaximumMs: sortedDurations.at(-1) || 0,
     workerP95Ms: percentile(sortedDurations, 0.95),
     admitted,
+    collapsed,
     completedOutcomes: items.filter((item) =>
       existsSync(checkedOutcomePath(workspace, item.outcomePath)),
     ).length,
@@ -174,6 +217,17 @@ async function worker(itemPath, root, workspace) {
   mkdirSync(eventArtifacts, { recursive: true });
   mkdirSync(dirname(outcomePath), { recursive: true });
 
+  const rateLimitObservationPath = resolve(
+    workspace,
+    process.env.CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH ||
+      ".artifacts/exact-review-batch/github-rate-limits.jsonl",
+  );
+  const requestMetricsPath = resolve(
+    workspace,
+    process.env.CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH ||
+      ".artifacts/exact-review-batch/github-request-metrics.jsonl",
+  );
+  const repositoryToken = env("REPO_TOKEN");
   let result = await run(
     "gh",
     [
@@ -187,8 +241,32 @@ async function worker(itemPath, root, workspace) {
       "--dir",
       bundleDir,
     ],
-    { env: { ...process.env, GH_TOKEN: env("REPO_TOKEN") } },
+    { env: { ...process.env, GH_TOKEN: repositoryToken }, capture: true },
   );
+  appendRequestMetric(requestMetricsPath, {
+    scope: "repository_actions",
+    category: "artifact_download",
+    mode: "read",
+    outcome:
+      result.code === 0 ? "success" : githubThrottleText(result.stderr) ? "throttle" : "error",
+    repeat_revision: item.repeatRevision === true,
+    count: 1,
+  });
+  if (result.code !== 0 && githubThrottleText(result.stderr)) {
+    const observation = await resolveRateLimitObservation(
+      repositoryToken,
+      requestMetricsPath,
+      rateLimitObservationPath,
+    );
+    appendJsonLine(rateLimitObservationPath, observation);
+    return writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
+      retryAt: observation.retry_at,
+      rateLimitScope: observation.scope,
+      rateLimitProvenance: observation.provenance,
+      rateLimitAuthoritative: observation.authoritative,
+      attempted: true,
+    });
+  }
   if (result.code !== 0)
     return writeFailure(outcomePath, "retryable_failure", "artifact_unavailable");
   const artifactBytes = directoryBytes(bundleDir);
@@ -255,6 +333,9 @@ async function worker(itemPath, root, workspace) {
       EXACT_REVIEW_BATCH_REVISION: String(item.revision),
       EXACT_REVIEW_BATCH_CLAIM_GENERATION: String(item.claimGeneration),
       EXACT_REVIEW_BATCH_MUTATION_OUTPUT: outcomePath,
+      CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: rateLimitObservationPath,
+      CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: requestMetricsPath,
+      CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(item.repeatRevision === true),
     },
   });
   if (result.code !== 0 && !existsSync(outcomePath)) {
@@ -271,9 +352,93 @@ function checkedOutcomePath(workspace, path) {
   return candidate;
 }
 
-function writeFailure(path, kind, reasonCode) {
+function writeFailure(path, kind, reasonCode, details = {}) {
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify({ kind, reasonCode })}\n`, "utf8");
+  writeFileSync(path, `${JSON.stringify({ kind, reasonCode, ...details })}\n`, "utf8");
+}
+
+function githubThrottleText(value) {
+  return /api rate limit exceeded|secondary rate limit|abuse detection|http\s*429|rate limited|was submitted too quickly/i.test(
+    String(value || ""),
+  );
+}
+
+async function resolveRateLimitObservation(token, requestMetricsPath, observationPath) {
+  const now = Date.now();
+  try {
+    closeSync(openSync(`${observationPath}.lookup-repository_actions.lock`, "wx"));
+  } catch {
+    return {
+      scope: "repository_actions",
+      observed_at: new Date(now).toISOString(),
+      retry_at: new Date(now + 60_000).toISOString(),
+      provenance: "fallback",
+      authoritative: false,
+    };
+  }
+  const status = await run(
+    "gh",
+    [
+      "api",
+      "rate_limit",
+      "--jq",
+      "{remaining:.resources.core.remaining,reset:.resources.core.reset}",
+    ],
+    { env: { ...process.env, GH_TOKEN: token }, capture: true },
+  );
+  appendRequestMetric(requestMetricsPath, {
+    scope: "repository_actions",
+    category: "rate_status",
+    mode: "read",
+    outcome:
+      status.code === 0 ? "success" : githubThrottleText(status.stderr) ? "throttle" : "error",
+    repeat_revision: false,
+    count: 1,
+  });
+  let resetAt = 0;
+  if (status.code === 0) {
+    try {
+      const parsed = JSON.parse(status.stdout || "null");
+      if (Number(parsed?.remaining) <= 0 && Number.isSafeInteger(Number(parsed?.reset))) {
+        resetAt = Number(parsed.reset) * 1_000;
+      }
+    } catch {
+      // The shared circuit still uses the conservative fallback below.
+    }
+  }
+  return {
+    scope: "repository_actions",
+    observed_at: new Date(now).toISOString(),
+    retry_at: new Date(Math.max(now + 60_000, resetAt)).toISOString(),
+    provenance: resetAt ? "rate_limit_status" : "fallback",
+    authoritative: resetAt > 0,
+  };
+}
+
+function appendJsonLine(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function appendRequestMetric(path, value) {
+  appendJsonLine(path, value);
+}
+
+function latestActiveRateLimitObservation(path) {
+  if (!existsSync(path)) return null;
+  let latest = null;
+  for (const line of readFileSync(path, "utf8").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const value = JSON.parse(line);
+      const retryAt = Date.parse(String(value.retry_at || ""));
+      if (retryAt > Date.now() && (!latest || retryAt > Date.parse(latest.retry_at)))
+        latest = value;
+    } catch {
+      // A partial observation cannot open a circuit; the publisher outcome remains authoritative.
+    }
+  }
+  return latest;
 }
 
 function legacyTupleless(markdown) {
@@ -326,8 +491,21 @@ export function run(command, args, options = {}) {
       cwd: options.cwd,
       detached: Boolean(options.timeoutMs),
       env: options.env || process.env,
-      stdio: "inherit",
+      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
     });
+    let stdout = "";
+    let stderr = "";
+    if (options.capture) {
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderr += chunk;
+        process.stderr.write(chunk);
+      });
+    }
     let timedOut = false;
     let forceTimer = null;
     const terminate = (signal) => {
@@ -348,7 +526,7 @@ export function run(command, args, options = {}) {
     child.once("exit", (code, signal) => {
       if (timer) clearTimeout(timer);
       if (forceTimer) clearTimeout(forceTimer);
-      resolvePromise({ code: code ?? 1, signal, timedOut });
+      resolvePromise({ code: code ?? 1, signal, timedOut, stdout, stderr });
     });
   });
 }

--- a/src/clawsweeper-github-execution.ts
+++ b/src/clawsweeper-github-execution.ts
@@ -31,9 +31,12 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
     ghOnce,
     ghWithPreparedTimeout,
     githubCommandTimeoutMs,
+    githubRateLimitError: runtimeGithubRateLimitError,
     githubRuntimeBudgetError,
     sleepBeforeGitHubRetry,
   } = gitHubRuntime;
+  const githubRateLimitError =
+    runtimeGithubRateLimitError ?? ((cause: unknown) => new GitHubRateLimitError(cause));
   function ghWithRetry(
     args: string[],
     attempts = configuredGitHubRetryAttempts(),
@@ -51,6 +54,12 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
         if (error instanceof GitHubRuntimeBudgetError) throw error;
         lastError = error;
         const retryKind = ghRetryKind(error);
+        // Preserve the exhausted credential observation even when the current
+        // public read can finish through the bounded App-token fallback. That
+        // fallback is deliberately one-shot; later batch members must collapse
+        // instead of probing the same exhausted credential again.
+        const rateLimitError =
+          retryKind === "throttle" ? githubRateLimitError(error, args, activeEnv ?? {}) : null;
         const fallback =
           retryKind === "throttle" && !options.request ? claimPublicReadFallback(args) : null;
         if (retryKind === "throttle" && fallback) {
@@ -62,7 +71,7 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
             lastError = fallbackError;
             const fallbackRetryKind = ghRetryKind(fallbackError);
             if (fallbackRetryKind === "throttle") {
-              throw new GitHubRateLimitError(fallbackError);
+              throw githubRateLimitError(fallbackError, args, fallback);
             }
             ensureGitHubRuntimeAvailable("after GitHub operation");
             if (fallbackRetryKind === "none" || attempt === attempts - 1) {
@@ -78,7 +87,7 @@ export function createGitHubExecution(dependencies: CreateGitHubExecutionDepende
             continue;
           }
         }
-        if (retryKind === "throttle") throw new GitHubRateLimitError(error);
+        if (rateLimitError) throw rateLimitError;
         ensureGitHubRuntimeAvailable("after GitHub operation");
         if (retryKind === "none" || attempt === attempts - 1) throw error;
         const waitMs = ghRetryWaitMs(retryKind, attempt);

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { appendFileSync, closeSync, openSync } from "node:fs";
 import type { GitHubRuntimeBudget } from "./clawsweeper-types.js";
 import { codexEnv } from "./codex-env.js";
 import { resolveCommand } from "./command.js";
@@ -6,6 +7,7 @@ import {
   exactPublicationPublicReadToken,
   isPublicOpenClawReadOnlyRequest,
 } from "./github-public-read.js";
+import { GitHubRateLimitError, ghRetryKind, type GitHubCredentialScope } from "./github-retry.js";
 
 interface CreateGitHubRuntimeDependencies {
   ROOT: string;
@@ -18,9 +20,11 @@ interface CreateGitHubRuntimeDependencies {
 }
 
 const claimedPublicReadFallbackTokens = new Set<string>();
+const RATE_LIMIT_LOOKUP_TIMEOUT_MS = 20_000;
 
 export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencies) {
   const { ROOT, run, targetRepo } = dependencies;
+  const inspectedRateLimitScopes = new Set<GitHubCredentialScope>();
 
   const GITHUB_RUNTIME_REPORT_FLUSH_RESERVE_MS = 1_000;
 
@@ -139,8 +143,149 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
     return Object.keys(overrides).length > 0 ? overrides : undefined;
   }
 
+  function githubRequestScope(
+    args: readonly string[],
+    overrides: NodeJS.ProcessEnv = {},
+  ): GitHubCredentialScope {
+    const publicToken =
+      publicReadToken(args, overrides) ??
+      exactPublicationPublicReadToken(args, targetRepo(), {
+        ...process.env,
+        ...overrides,
+      });
+    const selectedToken =
+      overrides.GH_TOKEN?.trim() ||
+      overrides.GITHUB_TOKEN?.trim() ||
+      publicToken ||
+      process.env.GH_TOKEN?.trim() ||
+      process.env.GITHUB_TOKEN?.trim() ||
+      "";
+    const repositoryTokens = [
+      process.env.CLAWSWEEPER_PUBLIC_GH_TOKEN?.trim(),
+      process.env.REPO_TOKEN?.trim(),
+      process.env.GITHUB_TOKEN?.trim(),
+    ].filter((token): token is string => Boolean(token));
+    return repositoryTokens.includes(selectedToken) ? "repository_actions" : "target_app";
+  }
+
+  function rateLimitObservationPath(): string | null {
+    return process.env.CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH?.trim() || null;
+  }
+
+  function githubRequestMetricsPath(): string | null {
+    return process.env.CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH?.trim() || null;
+  }
+
+  function appendJsonLine(path: string | null, value: Record<string, unknown>): void {
+    if (!path) return;
+    appendFileSync(path, `${JSON.stringify(value)}\n`, "utf8");
+  }
+
+  function githubEndpointCategory(args: readonly string[]): string {
+    const text = args.join(" ").toLowerCase();
+    if (/\brate_limit\b/.test(text)) return "rate_status";
+    if (/\brun download\b/.test(text)) return "artifact_download";
+    if (/\/comments(?:\?|\s|$)/.test(text)) return "comments";
+    if (/\/labels(?:\?|\s|$)/.test(text)) return "labels";
+    if (/\/reviews(?:\?|\s|$)/.test(text)) return "reviews";
+    if (/\bworkflow run\b/.test(text)) return "workflow_dispatch";
+    if (/\/issues\/\d+|\/pulls\/\d+/.test(text)) return "item_metadata";
+    return "other";
+  }
+
+  function recordGitHubRequest(
+    args: readonly string[],
+    scope: GitHubCredentialScope,
+    outcome: "success" | "throttle" | "transient" | "error",
+  ): void {
+    appendJsonLine(githubRequestMetricsPath(), {
+      scope,
+      category: githubEndpointCategory(args),
+      mode: isPublicOpenClawReadOnlyRequest(args) ? "read" : "mutation_or_private_read",
+      outcome,
+      repeat_revision: process.env.CLAWSWEEPER_GITHUB_REQUEST_REPEAT === "true",
+      count: 1,
+    });
+  }
+
+  function rateLimitStatusRetryAt(scope: GitHubCredentialScope, token: string): number | null {
+    if (!rateLimitObservationPath() || inspectedRateLimitScopes.has(scope) || !token) return null;
+    inspectedRateLimitScopes.add(scope);
+    try {
+      closeSync(openSync(`${rateLimitObservationPath()}.lookup-${scope}.lock`, "wx"));
+    } catch {
+      return null;
+    }
+    try {
+      const raw = run(
+        "gh",
+        [
+          "api",
+          "rate_limit",
+          "--jq",
+          "{remaining:.resources.core.remaining,reset:.resources.core.reset}",
+        ],
+        {
+          timeoutMs: RATE_LIMIT_LOOKUP_TIMEOUT_MS,
+          env: { ...process.env, GH_TOKEN: token },
+        },
+      );
+      recordGitHubRequest(["api", "rate_limit"], scope, "success");
+      const status = JSON.parse(raw) as { remaining?: unknown; reset?: unknown };
+      const remaining = Number(status.remaining);
+      const reset = Number(status.reset);
+      return remaining <= 0 && Number.isSafeInteger(reset) && reset > 0 ? reset * 1_000 : null;
+    } catch (error) {
+      const kind = ghRetryKind(error);
+      recordGitHubRequest(
+        ["api", "rate_limit"],
+        scope,
+        kind === "throttle" ? "throttle" : kind === "transient" ? "transient" : "error",
+      );
+      return null;
+    }
+  }
+
+  function githubRateLimitError(
+    cause: unknown,
+    args: readonly string[],
+    overrides: NodeJS.ProcessEnv = {},
+  ): GitHubRateLimitError {
+    const scope = githubRequestScope(args, overrides);
+    const prepared = preparedGitHubEnv(args, overrides) ?? overrides;
+    const token =
+      prepared.GH_TOKEN?.trim() ||
+      prepared.GITHUB_TOKEN?.trim() ||
+      process.env.GH_TOKEN?.trim() ||
+      process.env.GITHUB_TOKEN?.trim() ||
+      "";
+    const hinted = new GitHubRateLimitError(cause, Date.now(), { scope });
+    const statusRetryAt = hinted.authoritative ? null : rateLimitStatusRetryAt(scope, token);
+    const error = statusRetryAt
+      ? new GitHubRateLimitError(cause, Date.now(), {
+          scope,
+          retryAt: statusRetryAt,
+          provenance: "rate_limit_status",
+          authoritative: true,
+        })
+      : hinted;
+    appendJsonLine(rateLimitObservationPath(), {
+      scope: error.scope,
+      ...(error.scope === "target_app"
+        ? { target_owner: targetRepo().split("/", 1)[0]?.toLowerCase() }
+        : {}),
+      observed_at: new Date().toISOString(),
+      retry_at: error.retryAt,
+      provenance: error.provenance,
+      authoritative: error.authoritative,
+    });
+    recordGitHubRequest(args, scope, "throttle");
+    return error;
+  }
+
   function claimPublicReadFallback(args: readonly string[]): NodeJS.ProcessEnv | null {
-    const publicToken = publicReadToken(args);
+    const publicToken =
+      publicReadToken(args) ?? exactPublicationPublicReadToken(args, targetRepo(), process.env);
     const appToken = process.env.GH_TOKEN?.trim();
     if (
       !publicToken ||
@@ -149,6 +294,14 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
       claimedPublicReadFallbackTokens.has(appToken)
     ) {
       return null;
+    }
+    const observationPath = rateLimitObservationPath();
+    if (observationPath) {
+      try {
+        closeSync(openSync(`${observationPath}.fallback-target_app.lock`, "wx"));
+      } catch {
+        return null;
+      }
     }
     claimedPublicReadFallbackTokens.add(appToken);
     return { GH_TOKEN: appToken };
@@ -161,10 +314,21 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
   ): string {
     const resolvedArgs = args[0] === "api" ? args : ["--repo", targetRepo(), ...args];
     const preparedEnv = preparedGitHubEnv(resolvedArgs, env);
-    return run("gh", resolvedArgs, {
-      timeoutMs,
-      ...(preparedEnv ? { env: preparedEnv } : {}),
-    });
+    const scope = githubRequestScope(resolvedArgs, env);
+    try {
+      const result = run("gh", resolvedArgs, {
+        timeoutMs,
+        ...(preparedEnv ? { env: preparedEnv } : {}),
+      });
+      recordGitHubRequest(resolvedArgs, scope, "success");
+      return result;
+    } catch (error) {
+      const retryKind = ghRetryKind(error);
+      if (retryKind !== "throttle") {
+        recordGitHubRequest(resolvedArgs, scope, retryKind === "transient" ? "transient" : "error");
+      }
+      throw error;
+    }
   }
 
   function gh(args: string[]): string {
@@ -247,6 +411,7 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
     gh,
     ghOnce,
     ghWithPreparedTimeout,
+    githubRateLimitError,
     githubCommandTimeoutMs,
     githubRuntimeBudgetError,
     sleepBeforeGitHubRetry,

--- a/src/github-retry.ts
+++ b/src/github-retry.ts
@@ -1,31 +1,82 @@
 export type GhRetryKind = "none" | "throttle" | "transient";
 
+export type GitHubCredentialScope = "repository_actions" | "target_app";
+export type GitHubRateLimitProvenance =
+  | "retry_after"
+  | "rate_limit_reset"
+  | "rate_limit_status"
+  | "fallback";
+
+type GitHubRateLimitOptions = {
+  scope?: GitHubCredentialScope;
+  retryAt?: string | number;
+  provenance?: GitHubRateLimitProvenance;
+  authoritative?: boolean;
+};
+
 export class GitHubRateLimitError extends Error {
   readonly retryAt: string;
+  readonly scope: GitHubCredentialScope;
+  readonly provenance: GitHubRateLimitProvenance;
+  readonly authoritative: boolean;
 
-  constructor(cause: unknown, now = Date.now()) {
+  constructor(cause: unknown, now = Date.now(), options: GitHubRateLimitOptions = {}) {
     const message = ghErrorText(cause);
-    // gh normally omits response headers; defer safely without probing GitHub,
-    // but preserve any reset hints already present in the observed error.
     const retryAfter = message.match(/\bretry-after\s*[:=]\s*(\d+)\b/i)?.[1];
     const reset = message.match(/\bx-ratelimit-reset\s*[:=]\s*(\d+)\b/i)?.[1];
     const propagated = message.match(/\brate limited until\s+(\d{4}-\d{2}-\d{2}T[\d:.]+Z)/i)?.[1];
-    const retryAt = new Date(
-      Math.max(
-        now + 60_000,
-        retryAfter ? now + Number(retryAfter) * 1_000 : 0,
-        reset ? Number(reset) * 1_000 : 0,
-        propagated ? Date.parse(propagated) || 0 : 0,
-      ),
-    ).toISOString();
-    super(`GitHub API rate limited until ${retryAt}: ${message}`, { cause });
+    const propagatedScope = message.match(/\bcredential scope\s+([a-z_]+)\b/i)?.[1];
+    const propagatedProvenance = message.match(/\breset source\s+([a-z_]+)\b/i)?.[1];
+    const carriedProvenance = [
+      "retry_after",
+      "rate_limit_reset",
+      "rate_limit_status",
+      "fallback",
+    ].includes(propagatedProvenance || "")
+      ? (propagatedProvenance as GitHubRateLimitProvenance)
+      : null;
+    const explicitRetryAt =
+      typeof options.retryAt === "number"
+        ? options.retryAt
+        : Date.parse(options.retryAt || "") || 0;
+    const propagatedRetryAt = propagated ? Date.parse(propagated) || 0 : 0;
+    const hintedRetryAt = retryAfter
+      ? now + Number(retryAfter) * 1_000
+      : reset
+        ? Number(reset) * 1_000
+        : propagatedRetryAt;
+    const provenance =
+      options.provenance ??
+      (retryAfter ? "retry_after" : reset ? "rate_limit_reset" : carriedProvenance || "fallback");
+    const scope =
+      options.scope ??
+      (propagatedScope === "repository_actions" || propagatedScope === "target_app"
+        ? propagatedScope
+        : "target_app");
+    const retryFloor = propagatedRetryAt > now ? now : now + 60_000;
+    const retryAt = new Date(Math.max(retryFloor, explicitRetryAt, hintedRetryAt)).toISOString();
+    super(
+      `GitHub API rate limited until ${retryAt}; credential scope ${scope}; reset source ${provenance}: ${message}`,
+      { cause },
+    );
     this.name = "GitHubRateLimitError";
     this.retryAt = retryAt;
+    this.scope = scope;
+    this.provenance = provenance;
+    this.authoritative =
+      options.authoritative ??
+      Boolean(
+        retryAfter ||
+        reset ||
+        provenance === "rate_limit_status" ||
+        (propagated && carriedProvenance && carriedProvenance !== "fallback"),
+      );
   }
 }
 
 const GH_THROTTLE_PATTERNS = [
   /was submitted too quickly/i,
+  /abuse detection/i,
   /secondary rate/i,
   /API rate limit exceeded/i,
   /rate limit/i,

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import type { ExactReviewBatchCompletion } from "./exact-review-batch-publisher.js";
 import {
   ExactReviewBatchQueueClient,
+  type ExactReviewGithubRateLimitObservation,
+  type ExactReviewGithubRequestMetric,
   type ExactReviewBatchQueueItem,
 } from "./exact-review-batch-queue-client.js";
 import { exactReviewBatchStateWriterProgressReporter } from "./exact-review-batch-state-writer-progress.js";
@@ -47,10 +50,19 @@ type BatchPublicationOutcome = {
 const command = process.argv[2];
 if (
   !command ||
-  !["claim", "heartbeat", "observe", "commit", "complete", "release"].includes(command)
+  ![
+    "claim",
+    "heartbeat",
+    "observe",
+    "commit",
+    "complete",
+    "release",
+    "rate-limit",
+    "request-metric",
+  ].includes(command)
 ) {
   throw new Error(
-    "usage: exact-review-batch-cli.ts <claim|heartbeat|observe|commit|complete|release>",
+    "usage: exact-review-batch-cli.ts <claim|heartbeat|observe|commit|complete|release|rate-limit|request-metric>",
   );
 }
 
@@ -67,7 +79,111 @@ else if (command === "heartbeat") await heartbeat();
 else if (command === "observe") await observe();
 else if (command === "commit") await commit();
 else if (command === "complete") await complete();
-else await release();
+else if (command === "release") await release();
+else if (command === "rate-limit") recordRateLimit();
+else recordRequestMetric();
+
+function recordRateLimit() {
+  const scope = env("EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE");
+  const targetOwner = process.env.EXACT_REVIEW_GITHUB_RATE_LIMIT_TARGET_OWNER?.trim().toLowerCase();
+  if (scope !== "repository_actions" && scope !== "target_app") {
+    throw new Error("EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE is invalid");
+  }
+  if (scope === "target_app" && !/^[a-z0-9_.-]{1,100}$/.test(targetOwner || "")) {
+    throw new Error("EXACT_REVIEW_GITHUB_RATE_LIMIT_TARGET_OWNER is invalid");
+  }
+  const now = Date.now();
+  const status = spawnSync(
+    "gh",
+    [
+      "api",
+      "rate_limit",
+      "--jq",
+      "{remaining:.resources.core.remaining,reset:.resources.core.reset}",
+    ],
+    {
+      encoding: "utf8",
+      env: process.env,
+      timeout: 20_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let resetAt = 0;
+  if (status.status === 0) {
+    try {
+      const parsed = JSON.parse(status.stdout || "null") as {
+        remaining?: unknown;
+        reset?: unknown;
+      };
+      if (Number(parsed.remaining) <= 0 && Number.isSafeInteger(Number(parsed.reset))) {
+        resetAt = Number(parsed.reset) * 1_000;
+      }
+    } catch {
+      // The conservative circuit below still prevents same-pool fanout.
+    }
+  }
+  const observation = {
+    scope,
+    ...(targetOwner ? { target_owner: targetOwner } : {}),
+    observed_at: new Date(now).toISOString(),
+    retry_at: new Date(Math.max(now + 60_000, resetAt)).toISOString(),
+    provenance: resetAt ? "rate_limit_status" : "fallback",
+    authoritative: resetAt > 0,
+  };
+  mkdirSync(dirname(rateLimitObservationPath()), { recursive: true });
+  mkdirSync(dirname(requestMetricsPath()), { recursive: true });
+  appendFileSync(rateLimitObservationPath(), `${JSON.stringify(observation)}\n`, "utf8");
+  appendRouterDispatchMetric(scope, "throttle");
+  appendFileSync(
+    requestMetricsPath(),
+    `${JSON.stringify({
+      scope,
+      category: "rate_status",
+      mode: "read",
+      outcome: status.status === 0 ? "success" : "error",
+      repeat_revision: false,
+      count: 1,
+    })}\n`,
+    "utf8",
+  );
+  console.log(JSON.stringify({ ok: true, observation }));
+}
+
+function recordRequestMetric() {
+  const scope = env("EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE");
+  const outcome = env("EXACT_REVIEW_GITHUB_REQUEST_OUTCOME");
+  if (scope !== "repository_actions" && scope !== "target_app") {
+    throw new Error("EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE is invalid");
+  }
+  if (outcome !== "success" && outcome !== "error") {
+    throw new Error("EXACT_REVIEW_GITHUB_REQUEST_OUTCOME is invalid");
+  }
+  mkdirSync(dirname(requestMetricsPath()), { recursive: true });
+  appendRouterDispatchMetric(scope, outcome);
+  console.log(JSON.stringify({ ok: true, scope, outcome }));
+}
+
+function appendRouterDispatchMetric(
+  scope: "repository_actions" | "target_app",
+  outcome: "success" | "throttle" | "error",
+) {
+  appendFileSync(
+    requestMetricsPath(),
+    `${JSON.stringify({
+      scope,
+      category: "workflow_dispatch",
+      mode: "mutation_or_private_read",
+      outcome,
+      repeat_revision: requestRepeatRevision(),
+      count: 1,
+    })}\n`,
+    "utf8",
+  );
+}
+
+function requestRepeatRevision(): boolean {
+  return process.env.EXACT_REVIEW_GITHUB_REQUEST_REPEAT?.trim().toLowerCase() === "true";
+}
 
 async function claim() {
   const leaseOwner = env("EXACT_REVIEW_BATCH_LEASE_OWNER");
@@ -321,7 +437,12 @@ async function complete() {
     const current = active.get(manifestItem.itemKey);
     if (!current) continue;
     if (!existsSync(manifestItem.outcomePath)) {
-      completions.push(retryableCompletion(current, "unknown_failure"));
+      const circuit = latestRateLimitObservation();
+      completions.push(
+        circuit
+          ? retryableCompletion(current, "github_rate_limit", undefined, circuit.retryAt, false)
+          : retryableCompletion(current, "unknown_failure"),
+      );
       continue;
     }
     const outcome = objectValue(JSON.parse(readFileSync(manifestItem.outcomePath, "utf8")));
@@ -355,6 +476,7 @@ async function complete() {
     receipt.stateCommitSha,
     undefined,
     receipt.stateWriter,
+    true,
   );
   const retryable = completions.filter(
     (completion) =>
@@ -398,7 +520,10 @@ async function release() {
         return { ...member, terminalOutcome: "published" };
       }
     }
-    return retryableCompletion(member, "workflow_cancelled");
+    const circuit = latestRateLimitObservation();
+    return circuit
+      ? retryableCompletion(member, "github_rate_limit", undefined, circuit.retryAt, false)
+      : retryableCompletion(member, "workflow_cancelled");
   });
   const result = await acknowledge(
     manifest,
@@ -406,6 +531,7 @@ async function release() {
     receipt?.stateCommitSha,
     undefined,
     receipt?.stateWriter,
+    true,
   );
   console.log(
     JSON.stringify({
@@ -422,16 +548,71 @@ async function acknowledge(
   stateCommitSha?: string,
   failure?: string,
   stateWriter?: StateWriterOperation,
+  includeTelemetry = false,
 ) {
-  if (!completions.length && !stateWriter) return null;
-  return client.complete({
+  const acknowledged = readTelemetryAcknowledgement();
+  const rateLimitEnd = telemetryFileSize(rateLimitObservationPath());
+  const requestMetricsEnd = telemetryFileSize(requestMetricsPath());
+  const rateLimitObservations = includeTelemetry
+    ? readRateLimitObservations(acknowledged.rateLimitBytes, rateLimitEnd)
+    : [];
+  const requestMetrics = includeTelemetry
+    ? readRequestMetrics(acknowledged.requestMetricBytes, requestMetricsEnd)
+    : [];
+  const telemetrySubmitted = rateLimitObservations.length > 0 || requestMetrics.length > 0;
+  const telemetryId = telemetrySubmitted
+    ? telemetrySubmissionId(acknowledged, rateLimitEnd, requestMetricsEnd)
+    : undefined;
+  if (
+    !completions.length &&
+    !stateWriter &&
+    !rateLimitObservations.length &&
+    !requestMetrics.length
+  )
+    return null;
+  const result = await client.complete({
     batchId: manifest.batchId,
     leaseOwner: manifest.leaseOwner,
     items: completions,
     ...(stateCommitSha ? { stateCommitSha } : {}),
     ...(failure ? { failureFingerprint: failure } : {}),
     ...(stateWriter ? { stateWriter } : {}),
+    ...(rateLimitObservations.length ? { rateLimitObservations } : {}),
+    ...(requestMetrics.length ? { requestMetrics } : {}),
+    ...(telemetryId ? { telemetryId } : {}),
   });
+  if (includeTelemetry && (!telemetrySubmitted || result.telemetryAccepted)) {
+    mkdirSync(dirname(telemetryAcknowledgedPath()), { recursive: true });
+    writeFileSync(
+      telemetryAcknowledgedPath(),
+      `${JSON.stringify({ rateLimitBytes: rateLimitEnd, requestMetricBytes: requestMetricsEnd })}\n`,
+      "utf8",
+    );
+  }
+  return result;
+}
+
+function telemetrySubmissionId(
+  acknowledged: { rateLimitBytes: number; requestMetricBytes: number },
+  rateLimitEnd: number,
+  requestMetricEnd: number,
+): string {
+  const producer = [
+    process.env.GITHUB_RUN_ID || "local",
+    process.env.GITHUB_RUN_ATTEMPT || "0",
+    dirname(env("EXACT_REVIEW_BATCH_MANIFEST")),
+  ].join(":");
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        producer,
+        rateLimitStart: acknowledged.rateLimitBytes,
+        rateLimitEnd,
+        requestMetricStart: acknowledged.requestMetricBytes,
+        requestMetricEnd,
+      }),
+    )
+    .digest("hex");
 }
 
 function failureCompletion(
@@ -452,11 +633,18 @@ function failureCompletion(
     typeof outcome.errorFingerprint === "string" && outcome.errorFingerprint
       ? outcome.errorFingerprint
       : undefined;
+  const retryAt =
+    typeof outcome.retryAt === "string" && Number.isFinite(Date.parse(outcome.retryAt))
+      ? new Date(Date.parse(outcome.retryAt)).toISOString()
+      : undefined;
+  const attempted = outcome.attempted === false ? false : undefined;
   return {
     ...member,
     terminalOutcome,
     reasonCode,
     ...(errorFingerprint ? { errorFingerprint } : {}),
+    ...(retryAt ? { retryAt } : {}),
+    ...(attempted !== undefined ? { attempted } : {}),
   };
 }
 
@@ -464,13 +652,176 @@ function retryableCompletion(
   member: ExactReviewBatchQueueItem,
   reasonCode: string,
   errorFingerprint?: string,
+  retryAt?: string,
+  attempted?: boolean,
 ): ExactReviewBatchCompletion {
   return {
     ...member,
     terminalOutcome: "retryable_failure",
     reasonCode,
     ...(errorFingerprint ? { errorFingerprint } : {}),
+    ...(retryAt ? { retryAt } : {}),
+    ...(attempted !== undefined ? { attempted } : {}),
   };
+}
+
+function telemetryAcknowledgedPath(): string {
+  return join(dirname(env("EXACT_REVIEW_BATCH_MANIFEST")), "github-telemetry-acknowledged");
+}
+
+function readTelemetryAcknowledgement(): {
+  rateLimitBytes: number;
+  requestMetricBytes: number;
+} {
+  const path = telemetryAcknowledgedPath();
+  if (!existsSync(path)) return { rateLimitBytes: 0, requestMetricBytes: 0 };
+  try {
+    const value = objectValue(JSON.parse(readFileSync(path, "utf8")));
+    const rateLimitBytes = Number(value.rateLimitBytes);
+    const requestMetricBytes = Number(value.requestMetricBytes);
+    if (
+      Number.isSafeInteger(rateLimitBytes) &&
+      rateLimitBytes >= 0 &&
+      Number.isSafeInteger(requestMetricBytes) &&
+      requestMetricBytes >= 0
+    ) {
+      return { rateLimitBytes, requestMetricBytes };
+    }
+  } catch {
+    // A malformed acknowledgement is safe to replay; the queue aggregates telemetry.
+  }
+  return { rateLimitBytes: 0, requestMetricBytes: 0 };
+}
+
+function telemetryFileSize(path: string): number {
+  return existsSync(path) ? readFileSync(path).byteLength : 0;
+}
+
+function readTelemetrySlice(path: string, start: number, end: number): string {
+  if (!existsSync(path) || end <= start) return "";
+  const contents = readFileSync(path);
+  return contents
+    .subarray(Math.min(start, contents.byteLength), Math.min(end, contents.byteLength))
+    .toString("utf8");
+}
+
+function rateLimitObservationPath(): string {
+  return (
+    process.env.CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH ||
+    join(dirname(env("EXACT_REVIEW_BATCH_MANIFEST")), "github-rate-limits.jsonl")
+  );
+}
+
+function requestMetricsPath(): string {
+  return (
+    process.env.CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH ||
+    join(dirname(env("EXACT_REVIEW_BATCH_MANIFEST")), "github-request-metrics.jsonl")
+  );
+}
+
+function readRateLimitObservations(
+  start = 0,
+  end = telemetryFileSize(rateLimitObservationPath()),
+): ExactReviewGithubRateLimitObservation[] {
+  const path = rateLimitObservationPath();
+  if (!existsSync(path)) return [];
+  const byPool = new Map<string, ExactReviewGithubRateLimitObservation>();
+  for (const line of readTelemetrySlice(path, start, end).split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const value = objectValue(JSON.parse(line));
+      const scope = String(value.scope || "");
+      const targetOwner = String(value.target_owner || "")
+        .trim()
+        .toLowerCase();
+      const observedAt = new Date(String(value.observed_at || "")).toISOString();
+      const retryAt = new Date(String(value.retry_at || "")).toISOString();
+      const provenance = String(value.provenance || "");
+      if (
+        (scope !== "repository_actions" && scope !== "target_app") ||
+        (scope === "target_app" && !/^[a-z0-9_.-]{1,100}$/.test(targetOwner)) ||
+        !["retry_after", "rate_limit_reset", "rate_limit_status", "fallback"].includes(provenance)
+      ) {
+        continue;
+      }
+      const observation: ExactReviewGithubRateLimitObservation = {
+        scope,
+        ...(targetOwner ? { targetOwner } : {}),
+        observedAt,
+        retryAt,
+        provenance: provenance as ExactReviewGithubRateLimitObservation["provenance"],
+        authoritative: value.authoritative === true,
+      };
+      const key = `${scope}:${targetOwner}`;
+      const prior = byPool.get(key);
+      if (!prior || Date.parse(prior.retryAt) < Date.parse(retryAt)) byPool.set(key, observation);
+    } catch {
+      // A partial JSONL tail cannot influence a durable circuit.
+    }
+  }
+  return [...byPool.values()];
+}
+
+function latestRateLimitObservation(): ExactReviewGithubRateLimitObservation | null {
+  return (
+    readRateLimitObservations()
+      .filter((observation) => Date.parse(observation.retryAt) > Date.now())
+      .sort((left, right) => Date.parse(right.retryAt) - Date.parse(left.retryAt))[0] ?? null
+  );
+}
+
+function readRequestMetrics(
+  start = 0,
+  end = telemetryFileSize(requestMetricsPath()),
+): ExactReviewGithubRequestMetric[] {
+  const path = requestMetricsPath();
+  if (!existsSync(path)) return [];
+  const counts = new Map<string, ExactReviewGithubRequestMetric>();
+  for (const line of readTelemetrySlice(path, start, end).split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const value = objectValue(JSON.parse(line));
+      const scope = String(value.scope || "");
+      const category = String(value.category || "");
+      const mode = String(value.mode || "");
+      const outcome = String(value.outcome || "");
+      const repeatRevision = value.repeat_revision === true;
+      const count = Number(value.count);
+      if (
+        !["repository_actions", "target_app"].includes(scope) ||
+        ![
+          "artifact_download",
+          "rate_status",
+          "comments",
+          "labels",
+          "reviews",
+          "workflow_dispatch",
+          "item_metadata",
+          "other",
+        ].includes(category) ||
+        !["read", "mutation_or_private_read"].includes(mode) ||
+        !["success", "throttle", "transient", "error", "skipped_by_circuit"].includes(outcome) ||
+        !Number.isInteger(count) ||
+        count < 1 ||
+        count > 10_000
+      ) {
+        continue;
+      }
+      const key = [scope, category, mode, outcome, String(repeatRevision)].join(":");
+      const prior = counts.get(key);
+      counts.set(key, {
+        scope: scope as ExactReviewGithubRequestMetric["scope"],
+        category: category as ExactReviewGithubRequestMetric["category"],
+        mode: mode as ExactReviewGithubRequestMetric["mode"],
+        outcome: outcome as ExactReviewGithubRequestMetric["outcome"],
+        repeatRevision,
+        count: (prior?.count || 0) + count,
+      });
+    } catch {
+      // Invalid metrics are dropped instead of widening the status contract.
+    }
+  }
+  return [...counts.values()];
 }
 
 function publicationOutcomeFromResult(

--- a/src/repair/exact-review-batch-publisher.ts
+++ b/src/repair/exact-review-batch-publisher.ts
@@ -17,6 +17,8 @@ export type ExactReviewBatchCompletion = ExactReviewBatchMember & {
   terminalOutcome: ExactReviewBatchTerminalOutcome;
   reasonCode?: string;
   errorFingerprint?: string;
+  retryAt?: string;
+  attempted?: boolean;
 };
 
 export type ExactReviewBatchItemResult =

--- a/src/repair/exact-review-batch-queue-client.ts
+++ b/src/repair/exact-review-batch-queue-client.ts
@@ -6,7 +6,36 @@ import type {
 } from "./exact-review-batch-publisher.js";
 import type { StateWriterOperation, StateWriterProgress } from "../state-writer-telemetry.js";
 
-export type ExactReviewBatchQueueItem = ExactReviewBatchMember & { decision: unknown };
+export type ExactReviewBatchQueueItem = ExactReviewBatchMember & {
+  decision: unknown;
+  repeatRevision?: boolean;
+};
+
+export type ExactReviewGithubRateLimitObservation = {
+  scope: "repository_actions" | "target_app";
+  targetOwner?: string;
+  observedAt: string;
+  retryAt: string;
+  provenance: "retry_after" | "rate_limit_reset" | "rate_limit_status" | "fallback";
+  authoritative: boolean;
+};
+
+export type ExactReviewGithubRequestMetric = {
+  scope: "repository_actions" | "target_app";
+  category:
+    | "artifact_download"
+    | "rate_status"
+    | "comments"
+    | "labels"
+    | "reviews"
+    | "workflow_dispatch"
+    | "item_metadata"
+    | "other";
+  mode: "read" | "mutation_or_private_read";
+  outcome: "success" | "throttle" | "transient" | "error" | "skipped_by_circuit";
+  repeatRevision: boolean;
+  count: number;
+};
 
 export type ExactReviewBatchLease = {
   batchId: string;
@@ -82,7 +111,15 @@ export interface ExactReviewBatchQueue {
     stateCommitSha?: string;
     failureFingerprint?: string;
     stateWriter?: StateWriterOperation;
-  }): Promise<{ accepted: number; skipped: number; batch: ExactReviewBatchLease }>;
+    rateLimitObservations?: readonly ExactReviewGithubRateLimitObservation[];
+    requestMetrics?: readonly ExactReviewGithubRequestMetric[];
+    telemetryId?: string;
+  }): Promise<{
+    accepted: number;
+    skipped: number;
+    telemetryAccepted: boolean;
+    batch: ExactReviewBatchLease;
+  }>;
 }
 
 type QueueClientOptions = {
@@ -278,6 +315,9 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
     stateCommitSha?: string;
     failureFingerprint?: string;
     stateWriter?: StateWriterOperation;
+    rateLimitObservations?: readonly ExactReviewGithubRateLimitObservation[];
+    requestMetrics?: readonly ExactReviewGithubRequestMetric[];
+    telemetryId?: string;
   }) {
     const response = await this.post("complete", {
       batch_id: input.batchId,
@@ -289,14 +329,42 @@ export class ExactReviewBatchQueueClient implements ExactReviewBatchQueue {
         terminal_outcome: item.terminalOutcome,
         ...(item.reasonCode ? { reason_code: item.reasonCode } : {}),
         ...(item.errorFingerprint ? { error_fingerprint: item.errorFingerprint } : {}),
+        ...(item.retryAt ? { retry_at: item.retryAt } : {}),
+        ...(item.attempted !== undefined ? { attempted: item.attempted } : {}),
       })),
       ...(input.stateCommitSha ? { state_commit_sha: input.stateCommitSha } : {}),
       ...(input.failureFingerprint ? { failure_fingerprint: input.failureFingerprint } : {}),
       ...(input.stateWriter ? { state_writer: input.stateWriter } : {}),
+      ...(input.rateLimitObservations?.length
+        ? {
+            github_rate_limit_observations: input.rateLimitObservations.map((observation) => ({
+              scope: observation.scope,
+              ...(observation.targetOwner ? { target_owner: observation.targetOwner } : {}),
+              observed_at: observation.observedAt,
+              retry_at: observation.retryAt,
+              provenance: observation.provenance,
+              authoritative: observation.authoritative,
+            })),
+          }
+        : {}),
+      ...(input.requestMetrics?.length
+        ? {
+            github_request_metrics: input.requestMetrics.map((metric) => ({
+              scope: metric.scope,
+              category: metric.category,
+              mode: metric.mode,
+              outcome: metric.outcome,
+              repeat_revision: metric.repeatRevision,
+              count: metric.count,
+            })),
+          }
+        : {}),
+      ...(input.telemetryId ? { github_telemetry_id: input.telemetryId } : {}),
     });
     return {
       accepted: nonNegativeInteger(response.accepted, "accepted"),
       skipped: nonNegativeInteger(response.skipped, "skipped"),
+      telemetryAccepted: response.telemetry_accepted === true,
       batch: parseLease(response.batch),
     };
   }
@@ -353,7 +421,11 @@ export function verifyExactReviewBatchSignature(
 
 function parseQueueItem(value: unknown): ExactReviewBatchQueueItem {
   const item = objectValue(value);
-  return { ...parseMember(item), decision: item.decision };
+  return {
+    ...parseMember(item),
+    decision: item.decision,
+    ...(item.repeat_revision === true ? { repeatRevision: true } : {}),
+  };
 }
 
 function parseLease(value: unknown): ExactReviewBatchLease {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -117,6 +117,15 @@ try {
       kind: completionKind,
       reasonCode,
       errorFingerprint: fingerprint,
+      ...(error instanceof GitHubRateLimitError
+        ? {
+            retryAt: error.retryAt,
+            rateLimitScope: error.scope,
+            rateLimitProvenance: error.provenance,
+            rateLimitAuthoritative: error.authoritative,
+            attempted: true,
+          }
+        : {}),
     });
   }
   writePublicationCompletionOutputs(

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -3243,6 +3243,10 @@ test("GitHub retry classifier distinguishes throttle and transient failures", ()
   assert.equal(ghRetryKind(throttled), "throttle");
   assert.equal(shouldRetryGh(throttled), true);
   assert.equal(ghRetryKind(new Error("gh: HTTP 429: Too Many Requests")), "throttle");
+  assert.equal(
+    ghRetryKind(new Error("You have triggered an abuse detection mechanism")),
+    "throttle",
+  );
   assert.equal(ghRetryWaitMs("throttle", 0), 30_000);
   assert.equal(ghRetryWaitMs("throttle", 3), 60_000);
   assert.equal(ghRetryWaitMs("transient", 0), 2_000);
@@ -3314,17 +3318,36 @@ test("GitHub rate-limit deferrals preserve available reset hints and safe defaul
     now,
   );
   assert.equal(retryAfter.retryAt, "2026-08-05T10:02:00.000Z");
+  assert.equal(retryAfter.provenance, "retry_after");
+  assert.equal(retryAfter.authoritative, true);
+
+  const secondaryWithBothHints = new GitHubRateLimitError(
+    new Error(
+      `HTTP 403: secondary rate limit\nRetry-After: 30\nx-ratelimit-reset: ${now / 1_000 + 300}`,
+    ),
+    now,
+  );
+  assert.equal(secondaryWithBothHints.retryAt, "2026-08-05T10:01:00.000Z");
+  assert.equal(secondaryWithBothHints.provenance, "retry_after");
 
   const reset = new GitHubRateLimitError(
     new Error(`HTTP 403: API rate limit exceeded\nx-ratelimit-reset: ${now / 1_000 + 300}`),
     now,
   );
   assert.equal(reset.retryAt, "2026-08-05T10:05:00.000Z");
+  assert.equal(reset.provenance, "rate_limit_reset");
   assert.equal(new GitHubRateLimitError(reset, now + 1_000).retryAt, reset.retryAt);
-  assert.equal(
-    new GitHubRateLimitError(new Error("HTTP 429: rate limit reached"), now).retryAt,
-    "2026-08-05T10:01:00.000Z",
-  );
+  const fallback = new GitHubRateLimitError(new Error("HTTP 429: rate limit reached"), now);
+  const wrappedFallback = new GitHubRateLimitError(fallback, now + 1_000);
+  assert.equal(fallback.authoritative, false);
+  assert.equal(wrappedFallback.retryAt, fallback.retryAt);
+  assert.equal(wrappedFallback.provenance, "fallback");
+  assert.equal(wrappedFallback.authoritative, false);
+  assert.equal(fallback.retryAt, "2026-08-05T10:01:00.000Z");
+  const wrappedExpiredFallback = new GitHubRateLimitError(fallback, now + 61_000);
+  assert.equal(wrappedExpiredFallback.retryAt, "2026-08-05T10:02:01.000Z");
+  assert.equal(wrappedExpiredFallback.provenance, "fallback");
+  assert.equal(wrappedExpiredFallback.authoritative, false);
 });
 
 test("closing pull request references preserve fork repository identity", () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -9732,6 +9732,10 @@ test("OpenClaw Bay is a public, indexable, hardened route", async () => {
   assert.match(body, /id="bay-control-board"/);
   assert.match(body, /Review admission/);
   assert.match(body, /Result publication/);
+  assert.match(body, /renderBayPublicationQuotaContext/);
+  assert.match(body, /credential_circuits/);
+  assert.match(body, /github_request_metrics/);
+  assert.match(body, /credential-blocked/);
   assert.match(body, /State writer/);
   assert.match(body, /Queue handoff/);
   assert.doesNotMatch(body, /Recent durable events/);

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -31,9 +31,14 @@ class SqlCursor<T extends Record<string, unknown>> implements Iterable<T> {
 class TestStorage {
   private readonly database = new DatabaseSync(":memory:");
   private readonly values = new Map<string, unknown>();
+  private failSqlPattern: RegExp | null = null;
   private alarmAt: number | null = null;
   readonly sql = {
     exec: (query: string, ...bindings: unknown[]) => {
+      if (this.failSqlPattern?.test(query)) {
+        this.failSqlPattern = null;
+        throw new Error("injected telemetry state write failure");
+      }
       const statement = this.database.prepare(query);
       if (/^\s*(?:SELECT|WITH)\b/i.test(query) || /\bRETURNING\b/i.test(query)) {
         return new SqlCursor(statement.all(...bindings) as Record<string, unknown>[]);
@@ -42,6 +47,10 @@ class TestStorage {
       return new SqlCursor<Record<string, unknown>>([]);
     },
   };
+
+  failNextSqlMatching(pattern: RegExp) {
+    this.failSqlPattern = pattern;
+  }
   readonly kv = {
     get: (key: string) => this.values.get(key),
     put: (key: string, value: unknown) => this.values.set(key, structuredClone(value)),
@@ -3256,6 +3265,423 @@ test("retryable batch completion releases ownership and preserves queue retry po
       )
     ).json();
     assert.equal(fetchedReplacement.items.length, 1);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("credential circuits persist, preserve healthy owners, and defer unattempted members without retry charge", async () => {
+  const originalNow = Date.now;
+  let now = Date.parse("2026-08-10T14:00:00.000Z");
+  Date.now = () => now;
+  try {
+    const storage = new TestStorage();
+    let queue = new ExactReviewQueue(
+      { storage },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    for (let index = 0; index < 52; index += 1) {
+      await queue.fetch(
+        publicationRequest(`owner-a-${index}`, 201 + index, String(1201 + index), "aaa/repo"),
+      );
+    }
+    await queue.fetch(publicationRequest("owner-b", 300, "1300", "bbb/repo"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-owner-a",
+          lease_owner: "worker-a",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    const member = claim.batch.items[0];
+    assert.match(member.item_key, /^aaa\/repo#/);
+    const malformedUnattempted = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-a",
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "github_rate_limit",
+            attempted: false,
+          },
+        ],
+      }),
+    );
+    assert.equal(malformedUnattempted.status, 400);
+    assert.deepEqual(await malformedUnattempted.json(), { error: "invalid_batch_completions" });
+    const longerReset = now + 120_000;
+    const completion = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          batch_id: claim.batch.batch_id,
+          lease_owner: "worker-a",
+          github_rate_limit_observations: [
+            {
+              scope: "target_app",
+              target_owner: "aaa",
+              observed_at: new Date(now).toISOString(),
+              retry_at: new Date(longerReset).toISOString(),
+              provenance: "rate_limit_status",
+              authoritative: true,
+            },
+            {
+              scope: "target_app",
+              target_owner: "aaa",
+              observed_at: new Date(now + 1).toISOString(),
+              retry_at: new Date(now + 60_000).toISOString(),
+              provenance: "fallback",
+              authoritative: false,
+            },
+          ],
+          github_request_metrics: [
+            {
+              scope: "target_app",
+              category: "item_metadata",
+              mode: "read",
+              outcome: "throttle",
+              repeat_revision: false,
+              count: 1,
+            },
+          ],
+          items: [
+            {
+              item_key: member.item_key,
+              revision: member.revision,
+              claim_generation: member.claim_generation,
+              terminal_outcome: "retryable_failure",
+              reason_code: "github_rate_limit",
+              retry_at: new Date(longerReset).toISOString(),
+              attempted: false,
+            },
+          ],
+        }),
+      )
+    ).json();
+    assert.equal(completion.accepted, 1, JSON.stringify(completion));
+
+    let stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.retried_total, 0);
+    assert.equal(stats.lanes.publication.credential_circuits.length, 1);
+    assert.deepEqual(stats.lanes.publication.credential_circuits[0], {
+      pool: "target_app:aaa",
+      scope: "target_app",
+      target_owner: "aaa",
+      observed_at: new Date(now).toISOString(),
+      blocked_until: new Date(longerReset).toISOString(),
+      reset_source: "rate_limit_status",
+      authoritative: true,
+      active: true,
+      affected_pending: 52,
+    });
+    assert.equal(
+      stats.lanes.publication.github_request_metrics.counters[
+        "target_app:item_metadata:read:throttle:first"
+      ],
+      1,
+    );
+    assert.equal(stats.lanes.publication.capacity_control.last_failure_kind, "github_rate_limit");
+
+    const lateReset = now + 180_000;
+    const lateTelemetry = {
+      batch_id: claim.batch.batch_id,
+      lease_owner: "worker-a",
+      github_telemetry_id: "a".repeat(64),
+      github_rate_limit_observations: [
+        {
+          scope: "target_app",
+          target_owner: "aaa",
+          observed_at: new Date(now + 2).toISOString(),
+          retry_at: new Date(lateReset).toISOString(),
+          provenance: "retry_after",
+          authoritative: true,
+        },
+      ],
+      github_request_metrics: [
+        {
+          scope: "target_app",
+          category: "workflow_dispatch",
+          mode: "mutation_or_private_read",
+          outcome: "throttle",
+          repeat_revision: true,
+          count: 1,
+        },
+      ],
+      items: [],
+    };
+    storage.failNextSqlMatching(/UPDATE exact_review_queue_meta/);
+    await assert.rejects(
+      queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry)),
+      /injected telemetry state write failure/,
+    );
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(
+      stats.lanes.publication.github_request_metrics.counters[
+        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+      ],
+      undefined,
+    );
+    assert.equal(
+      stats.lanes.publication.credential_circuits[0].blocked_until,
+      new Date(longerReset).toISOString(),
+    );
+    const late = await (
+      await queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry))
+    ).json();
+    assert.equal(late.accepted, 0);
+    assert.equal(late.telemetry_accepted, true);
+    const duplicate = await (
+      await queue.fetch(batchRequest("/publication-batches/complete", lateTelemetry))
+    ).json();
+    assert.equal(duplicate.telemetry_accepted, true);
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(
+      stats.lanes.publication.credential_circuits[0].blocked_until,
+      new Date(lateReset).toISOString(),
+    );
+    assert.equal(
+      stats.lanes.publication.github_request_metrics.counters[
+        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+      ],
+      1,
+    );
+    assert.equal(stats.lanes.publication.capacity_control.ceiling, 12);
+    queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" });
+    const healthyOwner = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-owner-b",
+          lease_owner: "worker-b",
+          max_items: 50,
+        }),
+      )
+    ).json();
+    assert.equal(healthyOwner.claimed, true, JSON.stringify(healthyOwner));
+    assert.match(healthyOwner.batch.items[0].item_key, /^bbb\/repo#/);
+    const replacementLeaseDuplicate = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          ...lateTelemetry,
+          batch_id: healthyOwner.batch.batch_id,
+          lease_owner: "worker-b",
+        }),
+      )
+    ).json();
+    assert.equal(replacementLeaseDuplicate.telemetry_accepted, true);
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(
+      stats.lanes.publication.github_request_metrics.counters[
+        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+      ],
+      1,
+    );
+    const independentTelemetry = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/complete", {
+          ...lateTelemetry,
+          batch_id: healthyOwner.batch.batch_id,
+          lease_owner: "worker-b",
+          github_telemetry_id: "b".repeat(64),
+        }),
+      )
+    ).json();
+    assert.equal(independentTelemetry.telemetry_accepted, true);
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(
+      stats.lanes.publication.github_request_metrics.counters[
+        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+      ],
+      2,
+    );
+    assert.equal(stats.lanes.publication.capacity_control.ceiling, 6);
+    const retainedReceiptPayloads: Record<string, unknown>[] = [];
+    for (let index = 0; index < 201; index += 1) {
+      const payload = {
+        batch_id: healthyOwner.batch.batch_id,
+        lease_owner: "worker-b",
+        github_telemetry_id: index.toString(16).padStart(64, "0"),
+        github_request_metrics: lateTelemetry.github_request_metrics,
+        items: [],
+      };
+      retainedReceiptPayloads.push(payload);
+      const recorded = await (
+        await queue.fetch(batchRequest("/publication-batches/complete", payload))
+      ).json();
+      assert.equal(recorded.telemetry_accepted, true);
+    }
+    const delayedDuplicate = await (
+      await queue.fetch(batchRequest("/publication-batches/complete", retainedReceiptPayloads[0]))
+    ).json();
+    assert.equal(delayedDuplicate.telemetry_accepted, true);
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(
+      stats.lanes.publication.github_request_metrics.counters[
+        "target_app:workflow_dispatch:mutation_or_private_read:throttle:repeat"
+      ],
+      203,
+    );
+
+    const receiptFailureReset = lateReset + 60_000;
+    const receiptFailureTelemetry = {
+      batch_id: healthyOwner.batch.batch_id,
+      lease_owner: "worker-b",
+      github_telemetry_id: "c".repeat(64),
+      github_rate_limit_observations: [
+        {
+          scope: "target_app",
+          target_owner: "aaa",
+          observed_at: new Date(now + 3).toISOString(),
+          retry_at: new Date(receiptFailureReset).toISOString(),
+          provenance: "retry_after",
+          authoritative: true,
+        },
+      ],
+      items: [],
+    };
+    storage.failNextSqlMatching(/INSERT INTO exact_review_github_telemetry_receipts/);
+    await assert.rejects(
+      queue.fetch(batchRequest("/publication-batches/complete", receiptFailureTelemetry)),
+      /injected telemetry state write failure/,
+    );
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.capacity_control.ceiling, 6);
+    assert.equal(
+      stats.lanes.publication.credential_circuits[0].blocked_until,
+      new Date(lateReset).toISOString(),
+    );
+    const receiptReplay = await (
+      await queue.fetch(batchRequest("/publication-batches/complete", receiptFailureTelemetry))
+    ).json();
+    assert.equal(receiptReplay.telemetry_accepted, true);
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.capacity_control.ceiling, 4);
+    assert.equal(
+      stats.lanes.publication.credential_circuits[0].blocked_until,
+      new Date(receiptFailureReset).toISOString(),
+    );
+
+    const healthyMember = healthyOwner.batch.items[0];
+    const healthyCompletion = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: healthyOwner.batch.batch_id,
+        lease_owner: "worker-b",
+        items: [
+          {
+            item_key: healthyMember.item_key,
+            revision: healthyMember.revision,
+            claim_generation: healthyMember.claim_generation,
+            terminal_outcome: "superseded",
+          },
+        ],
+      }),
+    );
+    assert.equal(
+      healthyCompletion.status,
+      200,
+      JSON.stringify(await healthyCompletion.clone().json()),
+    );
+
+    now = receiptFailureReset + 16 * 60_000;
+    stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(stats.lanes.publication.credential_circuits[0].active, false);
+    const recoveredOwner = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-owner-a-recovered",
+          lease_owner: "worker-c",
+          max_items: 50,
+        }),
+      )
+    ).json();
+    assert.equal(recoveredOwner.claimed, true, JSON.stringify(recoveredOwner));
+    assert.match(recoveredOwner.batch.items[0].item_key, /^aaa\/repo#/);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("repository Actions circuit blocks every publication batch until reset", async () => {
+  const originalNow = Date.now;
+  let now = Date.parse("2026-08-10T14:00:00.000Z");
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      { EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1" },
+    );
+    await queue.fetch(publicationRequest("actions-a", 211, "1211", "aaa/repo"));
+    await queue.fetch(publicationRequest("actions-b", 212, "1212", "bbb/repo"));
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-actions-a",
+          lease_owner: "worker-a",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    const member = claim.batch.items[0];
+    const resetAt = now + 90_000;
+    const completed = await queue.fetch(
+      batchRequest("/publication-batches/complete", {
+        batch_id: claim.batch.batch_id,
+        lease_owner: "worker-a",
+        github_rate_limit_observations: [
+          {
+            scope: "repository_actions",
+            observed_at: new Date(now).toISOString(),
+            retry_at: new Date(resetAt).toISOString(),
+            provenance: "rate_limit_status",
+            authoritative: true,
+          },
+        ],
+        items: [
+          {
+            item_key: member.item_key,
+            revision: member.revision,
+            claim_generation: member.claim_generation,
+            terminal_outcome: "retryable_failure",
+            reason_code: "github_rate_limit",
+            retry_at: new Date(resetAt).toISOString(),
+            attempted: false,
+          },
+        ],
+      }),
+    );
+    assert.equal(completed.status, 200, JSON.stringify(await completed.clone().json()));
+    const blocked = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-actions-blocked",
+          lease_owner: "worker-b",
+          max_items: 2,
+        }),
+      )
+    ).json();
+    assert.equal(blocked.claimed, false, JSON.stringify(blocked));
+    const stats = await (await queue.fetch(new Request("https://queue/stats"))).json();
+    assert.equal(
+      stats.lanes.publication.credential_circuits[0].pool,
+      "actions:openclaw/clawsweeper",
+    );
+    assert.equal(stats.lanes.publication.credential_circuits[0].affected_pending, 2);
+
+    now = resetAt + 31_000;
+    const recovered = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-actions-recovered",
+          lease_owner: "worker-c",
+          max_items: 2,
+        }),
+      )
+    ).json();
+    assert.equal(recovered.claimed, true, JSON.stringify(recovered));
   } finally {
     Date.now = originalNow;
   }

--- a/test/repair/exact-review-batch-cli.test.ts
+++ b/test/repair/exact-review-batch-cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -384,6 +384,307 @@ globalThis.fetch = async (url) => {
       "path",
     );
     assert.notEqual(invalidRevision, outsidePath);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("batch completion forwards one quota circuit and marks collapsed members unattempted", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-quota-"));
+  try {
+    const attempted = batchMember("openclaw/openclaw#811@publish:8110:1", 811);
+    const collapsed = batchMember("openclaw/openclaw#812@publish:8120:1", 812);
+    const attemptedOutcome = join(root, "attempted.json");
+    const collapsedOutcome = join(root, "collapsed.json");
+    const manifestPath = join(root, "manifest.json");
+    const receiptPath = join(root, "receipt.json");
+    const completionPath = join(root, "completion.json");
+    const observationsPath = join(root, "github-rate-limits.jsonl");
+    const metricsPath = join(root, "github-request-metrics.jsonl");
+    const preloadPath = join(root, "fetch-preload.cjs");
+    const retryAt = "2026-08-10T15:00:00.000Z";
+    writeFileSync(
+      attemptedOutcome,
+      JSON.stringify({
+        kind: "retryable_failure",
+        reasonCode: "github_rate_limit",
+        retryAt,
+        attempted: true,
+      }),
+    );
+    writeFileSync(
+      collapsedOutcome,
+      JSON.stringify({
+        kind: "retryable_failure",
+        reasonCode: "github_rate_limit",
+        retryAt,
+        attempted: false,
+      }),
+    );
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        batchId: "batch-quota-collapse",
+        leaseOwner: "proof-worker",
+        configuredBatchSize: 2,
+        batchWaitMs: 0,
+        items: [
+          { ...attempted, outcomePath: attemptedOutcome },
+          { ...collapsed, outcomePath: collapsedOutcome },
+        ],
+      }),
+    );
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({
+        batchId: "batch-quota-collapse",
+        publishedItemKeys: [],
+        outcomes: [],
+      }),
+    );
+    writeFileSync(
+      observationsPath,
+      `${JSON.stringify({
+        scope: "repository_actions",
+        observed_at: "2026-08-10T14:50:00.000Z",
+        retry_at: retryAt,
+        provenance: "rate_limit_status",
+        authoritative: true,
+      })}\n`,
+    );
+    writeFileSync(
+      metricsPath,
+      `${JSON.stringify({
+        scope: "repository_actions",
+        category: "item_metadata",
+        mode: "read",
+        outcome: "throttle",
+        repeat_revision: false,
+        count: 1,
+      })}\n`,
+    );
+    writeFileSync(
+      preloadPath,
+      `const fs = require("node:fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.EXACT_REVIEW_BATCH_MANIFEST, "utf8"));
+const wireItems = manifest.items.map((item) => ({ item_key: item.itemKey, revision: item.revision, claim_generation: item.claimGeneration, decision: item.decision }));
+globalThis.fetch = async (url, init) => {
+  const target = String(url);
+  const response = (value) => new Response(JSON.stringify(value), { status: 200, headers: { "content-type": "application/json" } });
+  if (target.endsWith("/publication-batches/fetch")) return response({ batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-10T16:00:00.000Z", items: wireItems }, items: wireItems, superseded: 0 });
+  if (target.endsWith("/publication-batches/complete")) {
+    fs.writeFileSync(process.env.BATCH_CLI_COMPLETION, init.body);
+    return response({ accepted: 2, skipped: 0, telemetry_accepted: true, batch: { batch_id: manifest.batchId, lease_owner: manifest.leaseOwner, lease_expires_at: "2026-08-10T16:00:00.000Z", items: [] } });
+  }
+  throw new Error("unexpected mock fetch target: " + target);
+};
+`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      ["--require", preloadPath, "dist/repair/exact-review-batch-cli.js", "complete"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAWSWEEPER_WEBHOOK_SECRET: "proof-secret",
+          EXACT_REVIEW_QUEUE_URL: "https://queue.example.test",
+          EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+          EXACT_REVIEW_BATCH_RECEIPT: receiptPath,
+          CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: observationsPath,
+          CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: metricsPath,
+          BATCH_CLI_COMPLETION: completionPath,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const completion = JSON.parse(readFileSync(completionPath, "utf8"));
+    assert.deepEqual(completion.items, [
+      {
+        item_key: attempted.itemKey,
+        revision: attempted.revision,
+        claim_generation: attempted.claimGeneration,
+        terminal_outcome: "retryable_failure",
+        reason_code: "github_rate_limit",
+        retry_at: retryAt,
+      },
+      {
+        item_key: collapsed.itemKey,
+        revision: collapsed.revision,
+        claim_generation: collapsed.claimGeneration,
+        terminal_outcome: "retryable_failure",
+        reason_code: "github_rate_limit",
+        retry_at: retryAt,
+        attempted: false,
+      },
+    ]);
+    assert.equal(completion.github_rate_limit_observations.length, 1);
+    assert.deepEqual(completion.github_request_metrics, [
+      {
+        scope: "repository_actions",
+        category: "item_metadata",
+        mode: "read",
+        outcome: "throttle",
+        repeat_revision: false,
+        count: 1,
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("batch completion forwards telemetry appended after an earlier acknowledgement", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-late-telemetry-"));
+  try {
+    const member = batchMember("openclaw/openclaw#813@publish:8130:1", 813);
+    const outcomePath = join(root, "outcome.json");
+    const manifestPath = join(root, "manifest.json");
+    const receiptPath = join(root, "receipt.json");
+    const completionPath = join(root, "completion.jsonl");
+    const observationsPath = join(root, "github-rate-limits.jsonl");
+    const metricsPath = join(root, "github-request-metrics.jsonl");
+    const preloadPath = join(root, "fetch-preload.cjs");
+    const firstRetryAt = "2026-08-10T15:00:00.000Z";
+    const lateRetryAt = "2026-08-10T15:30:00.000Z";
+    writeFileSync(
+      outcomePath,
+      JSON.stringify({
+        kind: "retryable_failure",
+        reasonCode: "github_rate_limit",
+        retryAt: firstRetryAt,
+      }),
+    );
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        batchId: "batch-late-telemetry",
+        leaseOwner: "proof-worker",
+        configuredBatchSize: 1,
+        batchWaitMs: 0,
+        items: [{ ...member, outcomePath }],
+      }),
+    );
+    writeFileSync(
+      receiptPath,
+      JSON.stringify({ batchId: "batch-late-telemetry", publishedItemKeys: [], outcomes: [] }),
+    );
+    writeFileSync(
+      observationsPath,
+      `${JSON.stringify({ scope: "repository_actions", observed_at: "2026-08-10T14:50:00.000Z", retry_at: firstRetryAt, provenance: "rate_limit_status", authoritative: true })}\n`,
+    );
+    writeFileSync(
+      metricsPath,
+      `${JSON.stringify({ scope: "repository_actions", category: "artifact_download", mode: "read", outcome: "throttle", repeat_revision: false, count: 1 })}\n`,
+    );
+    writeFileSync(
+      preloadPath,
+      `const fs = require("node:fs");
+globalThis.fetch = async (url, init) => {
+  if (String(url).endsWith("/publication-batches/fetch")) {
+    return new Response(JSON.stringify({ batch: { batch_id: "batch-late-telemetry", lease_owner: "proof-worker", lease_expires_at: "2026-08-10T16:00:00.000Z", items: [] }, items: [], superseded: 0 }), { status: 200, headers: { "content-type": "application/json" } });
+  }
+  if (!String(url).endsWith("/publication-batches/complete")) throw new Error("unexpected mock fetch target: " + url);
+  fs.appendFileSync(process.env.BATCH_CLI_COMPLETION, init.body + "\\n");
+  return new Response(JSON.stringify({ accepted: 1, skipped: 0, telemetry_accepted: true, batch: { batch_id: "batch-late-telemetry", lease_owner: "proof-worker", lease_expires_at: "2026-08-10T16:00:00.000Z", items: [] } }), { status: 200, headers: { "content-type": "application/json" } });
+};
+`,
+    );
+    const runCompletion = () =>
+      spawnSync(
+        process.execPath,
+        ["--require", preloadPath, "dist/repair/exact-review-batch-cli.js", "complete"],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            CLAWSWEEPER_WEBHOOK_SECRET: "proof-secret",
+            EXACT_REVIEW_QUEUE_URL: "https://queue.example.test",
+            EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+            EXACT_REVIEW_BATCH_RECEIPT: receiptPath,
+            CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: observationsPath,
+            CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: metricsPath,
+            BATCH_CLI_COMPLETION: completionPath,
+          },
+        },
+      );
+    const first = runCompletion();
+    assert.equal(first.status, 0, first.stderr);
+    appendFileSync(
+      observationsPath,
+      `${JSON.stringify({ scope: "target_app", target_owner: "late-owner", observed_at: "2026-08-10T15:05:00.000Z", retry_at: lateRetryAt, provenance: "retry_after", authoritative: true })}\n`,
+    );
+    appendFileSync(
+      metricsPath,
+      `${JSON.stringify({ scope: "target_app", category: "workflow_dispatch", mode: "mutation_or_private_read", outcome: "throttle", repeat_revision: false, count: 1 })}\n`,
+    );
+    const second = runCompletion();
+    assert.equal(second.status, 0, second.stderr);
+    const completions = readFileSync(completionPath, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    assert.equal(completions.length, 2);
+    assert.deepEqual(completions[1].github_rate_limit_observations, [
+      {
+        scope: "target_app",
+        target_owner: "late-owner",
+        observed_at: "2026-08-10T15:05:00.000Z",
+        retry_at: lateRetryAt,
+        provenance: "retry_after",
+        authoritative: true,
+      },
+    ]);
+    assert.deepEqual(completions[1].github_request_metrics, [
+      {
+        scope: "target_app",
+        category: "workflow_dispatch",
+        mode: "mutation_or_private_read",
+        outcome: "throttle",
+        repeat_revision: false,
+        count: 1,
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("router request metrics retain successful repeated-revision state", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-batch-cli-router-metric-"));
+  try {
+    const manifestPath = join(root, "manifest.json");
+    const metricsPath = join(root, "github-request-metrics.jsonl");
+    writeFileSync(manifestPath, "{}");
+    const result = spawnSync(
+      process.execPath,
+      ["dist/repair/exact-review-batch-cli.js", "request-metric"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAWSWEEPER_WEBHOOK_SECRET: "proof-secret",
+          EXACT_REVIEW_QUEUE_URL: "https://queue.example.test",
+          EXACT_REVIEW_BATCH_MANIFEST: manifestPath,
+          CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: metricsPath,
+          EXACT_REVIEW_GITHUB_RATE_LIMIT_SCOPE: "repository_actions",
+          EXACT_REVIEW_GITHUB_REQUEST_OUTCOME: "success",
+          EXACT_REVIEW_GITHUB_REQUEST_REPEAT: "true",
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(readFileSync(metricsPath, "utf8")), {
+      scope: "repository_actions",
+      category: "workflow_dispatch",
+      mode: "mutation_or_private_read",
+      outcome: "success",
+      repeat_revision: true,
+      count: 1,
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import YAML from "yaml";
 
@@ -305,6 +307,144 @@ test("sweep public read throttles fall back once to the ambient App token", () =
   }
 });
 
+test("exact publication records the Actions reset before one bounded App fallback", () => {
+  const observationPath = join(
+    tmpdir(),
+    `clawsweeper-rate-limit-${process.pid}-${Date.now()}.jsonl`,
+  );
+  const fixtureEnv = {
+    EXACT_EVENT_PUBLICATION: "true",
+    GH_TOKEN: "exact-fallback-app-token",
+    REPO_TOKEN: "exact-actions-token",
+    CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: observationPath,
+  };
+  const previous = Object.fromEntries(
+    Object.keys(fixtureEnv).map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, fixtureEnv);
+  const observed: Array<{ token: string; args: string[] }> = [];
+  const reset = Math.floor(Date.now() / 1_000) + 600;
+  const run = (_command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+    const token = options?.env?.GH_TOKEN ?? process.env.GH_TOKEN ?? "";
+    observed.push({ token, args });
+    if (args[0] === "api" && args[1] === "rate_limit") {
+      return JSON.stringify({ remaining: 0, reset });
+    }
+    if (token === fixtureEnv.REPO_TOKEN) {
+      throw new Error("gh: API rate limit exceeded for repository token (HTTP 403)");
+    }
+    return JSON.stringify({ token });
+  };
+  const runtime = createGitHubRuntime({
+    ROOT: process.cwd(),
+    run,
+    targetRepo: () => "openclaw/openclaw",
+  });
+  const execution = createGitHubExecution({
+    ROOT: process.cwd(),
+    gitHubRuntime: runtime,
+    labelAlreadyExistsError: () => false,
+  });
+  try {
+    const result = JSON.parse(execution.ghWithRetry(["api", "repos/openclaw/openclaw/issues/123"]));
+    assert.equal(result.token, fixtureEnv.GH_TOKEN);
+    assert.deepEqual(
+      observed.map(({ token }) => token),
+      [fixtureEnv.REPO_TOKEN, fixtureEnv.REPO_TOKEN, fixtureEnv.GH_TOKEN],
+    );
+    const observations = readFileSync(observationPath, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(observations, [
+      {
+        scope: "repository_actions",
+        observed_at: observations[0].observed_at,
+        retry_at: new Date(reset * 1_000).toISOString(),
+        provenance: "rate_limit_status",
+        authoritative: true,
+      },
+    ]);
+  } finally {
+    rmSync(observationPath, { force: true });
+    rmSync(`${observationPath}.lookup-repository_actions.lock`, { force: true });
+    rmSync(`${observationPath}.fallback-target_app.lock`, { force: true });
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("inherited GitHub Actions credentials open the repository quota circuit", () => {
+  const observationPath = join(
+    tmpdir(),
+    `clawsweeper-inherited-actions-rate-limit-${process.pid}-${Date.now()}.jsonl`,
+  );
+  const fixtureEnv = {
+    GITHUB_TOKEN: "inherited-actions-token",
+    CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: observationPath,
+  };
+  const clearedKeys = ["GH_TOKEN", "REPO_TOKEN", "CLAWSWEEPER_PUBLIC_GH_TOKEN"];
+  const previous = Object.fromEntries(
+    [...Object.keys(fixtureEnv), ...clearedKeys].map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, fixtureEnv);
+  for (const key of clearedKeys) delete process.env[key];
+  const observedTokens: string[] = [];
+  const reset = Math.floor(Date.now() / 1_000) + 300;
+  const run = (_command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+    const token =
+      options?.env?.GH_TOKEN ??
+      options?.env?.GITHUB_TOKEN ??
+      process.env.GH_TOKEN ??
+      process.env.GITHUB_TOKEN ??
+      "";
+    observedTokens.push(token);
+    if (args[0] === "api" && args[1] === "rate_limit") {
+      return JSON.stringify({ remaining: 0, reset });
+    }
+    throw new Error("gh: API rate limit exceeded for GITHUB_TOKEN (HTTP 403)");
+  };
+  const runtime = createGitHubRuntime({
+    ROOT: process.cwd(),
+    run,
+    targetRepo: () => "openclaw/openclaw",
+  });
+  const execution = createGitHubExecution({
+    ROOT: process.cwd(),
+    gitHubRuntime: runtime,
+    labelAlreadyExistsError: () => false,
+  });
+  try {
+    assert.throws(
+      () => execution.ghWithRetry(["api", "repos/openclaw/openclaw/issues/123/comments"]),
+      { name: "GitHubRateLimitError" },
+    );
+    assert.deepEqual(observedTokens, [fixtureEnv.GITHUB_TOKEN, fixtureEnv.GITHUB_TOKEN]);
+    const observations = readFileSync(observationPath, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line));
+    assert.deepEqual(observations, [
+      {
+        scope: "repository_actions",
+        observed_at: observations[0].observed_at,
+        retry_at: new Date(reset * 1_000).toISOString(),
+        provenance: "rate_limit_status",
+        authoritative: true,
+      },
+    ]);
+  } finally {
+    rmSync(observationPath, { force: true });
+    rmSync(`${observationPath}.lookup-repository_actions.lock`, { force: true });
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
 test("batch workflow signs queue ownership, isolates item failures, and commits once", () => {
   assert.match(source, /repair:exact-review-batch claim/);
   assert.match(source, /repair:exact-review-batch heartbeat/);
@@ -332,8 +472,24 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
   // Keep the fixture from looking like an embedded credential while still
   // proving that artifact downloads use the owner-scoped repository token.
   const ghToken = ["GH", "TOKEN"].join("_");
-  assert.match(prepareSource, new RegExp(`${ghToken}: env\\("REPO_TOKEN"\\)`));
+  assert.match(prepareSource, new RegExp(`${ghToken}: repositoryToken`));
+  assert.match(prepareSource, /activeCircuit[\s\S]*?attempted: false/);
+  assert.match(
+    prepareSource,
+    /githubThrottleText\(result\.stderr\)[\s\S]*?resolveRateLimitObservation/,
+  );
+  assert.match(prepareSource, /was submitted too quickly/);
   assert.match(source, /gh workflow run repair-comment-router\.yml/);
+  assert.match(source, /EXACT_REVIEW_GITHUB_REQUEST_REPEAT="\$repeat_revision"/);
+  assert.match(
+    source,
+    /EXACT_REVIEW_GITHUB_REQUEST_OUTCOME=success[\s\S]*?repair:exact-review-batch request-metric/,
+  );
+  assert.match(source, /was submitted too quickly[\s\S]*?repair:exact-review-batch rate-limit/);
+  assert.match(
+    source,
+    /EXACT_REVIEW_GITHUB_REQUEST_OUTCOME=error[\s\S]*?repair:exact-review-batch request-metric/,
+  );
   assert.match(
     source,
     /AUTO_IMPLEMENT_ISSUES: \$\{\{ vars\.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES \}\}/,
@@ -398,7 +554,7 @@ test("batch workflow signs queue ownership, isolates item failures, and commits 
   assert.match(source, /Record batch preparation finish/);
   assert.match(source, /EXACT_REVIEW_BATCH_OBSERVATION=final_github_apply/);
   assert.match(source, /EXACT_REVIEW_BATCH_OBSERVATION=github_throttle/);
-  assert.match(source, /rate limit\|HTTP 429/);
+  assert.match(source, /rate limit\|abuse detection\|was submitted too quickly\|HTTP 429/);
   assert.match(cliSource, /"observe"/);
   assert.match(cliSource, /optionalDispatchTelemetry/);
   assert.match(cliSource, /optionalRunnerTelemetry/);


### PR DESCRIPTION
## Summary

Contain exact-review publication when GitHub throttles a shared credential pool, instead of rotating queued items through the same exhausted quota. This combines the six CSW-117 remediation items in one stack: reset-aware errors, durable scoped circuits, first-failure batch collapse, bounded public-read fallback, adaptive feedback/operator telemetry, and successful-path request accounting.

Related: #1097 remains separate and unchanged.

## Problem

The 2026-08-10 production observation showed a publication backlog while publisher capacity was idle. In the retained sample, 31 throttled batches made 187 member attempts for only 63 unique revisions; 124 attempts (66%) repeated a revision already attempted in a throttled batch. Eight consecutive full batches expired all 64 members. This is shared GitHub quota amplification, not a shortage of publication workers.

The previous path could lose the authoritative reset boundary, retry after a short fallback, and rotate other ready items through the same credential. Artifact preparation also began before the first batch throttle could stop later members, and batch throttle outcomes were not feeding current publication control.

## Implementation

1. **Reset-aware quota signals**
   - Carries redacted credential scope, retry/reset provenance, and whether the deadline is authoritative.
   - Gives `retry-after` precedence, preserves `x-ratelimit-reset`, and applies a stable conservative future deadline when headers are absent or stale.

2. **Durable credential-scoped circuits**
   - Persists repository Actions and owner/App circuits without storing token-derived identifiers.
   - Never shortens an existing circuit, excludes blocked owners before bounded admission, preserves healthy owners, schedules recovery, and adds bounded recovery jitter.

3. **First-failure batch collapse**
   - Stops later preparation work after the first same-pool artifact or GitHub quota outcome.
   - Releases unattempted members without consuming their retry budget and records byte-offset telemetry so late terminal observations are not lost.

4. **Bounded public-read fallback**
   - Keeps approved public reads on the repository credential when healthy and permits one batch-wide target-App fallback when it is not.
   - Retains the repository-pool throttle observation even if that one fallback succeeds; private reads and mutations never cross credentials.

5. **Adaptive feedback and operator telemetry**
   - Feeds idempotent throttle receipts into publication control and distinguishes credential blocking from worker-capacity pressure.
   - Projects observer-only circuit/request telemetry through `/api/status` and Bay; no operational controls are added.

6. **Measured request demand and safe early reductions**
   - Records redacted request category/outcome counters with stable producer/byte-range identities and durable seven-day receipts.
   - Checks durable circuits before admission/setup work and prevents same-window duplicate feedback without weakening live mutation guards.

Receipt insertion, dispatcher state, and counters are committed atomically. Fault-injection coverage proves failed state or receipt writes do not leave partial acknowledgement.

## Validation

Current base: `75ac66b2b3b7dbf9def8007c52f5f05fac616c3d`  
Current head: `8d387089c30fbc84bd628f6b56ff629dbb875879`

- `pnpm run build:all`
- `pnpm run lint`
- `pnpm run check:docs`
- `pnpm run check:limits`
- `git diff --check`
- `node --test test/exact-review-publication-batches.test.ts` — 63/63 passed
- Focused CLI, workflow, GitHub retry, and Bay tests passed on the host.
- Docker-backed Linux proof below — 123/123 passed.

`actionlint` parsed the changed workflow. It reports five existing/intentional SC2016 informational notices for literal GitHub expressions in single-quoted shell text. A repository-wide run also reports unrelated current-main errors in `repair-comment-router.yml` and unsupported `queue` keys in `sweep.yml`; this patch does not alter those surfaces. The changed Bash path passed its Linux workflow tests.

On native Windows, the workflow test that invokes `/bin/bash` cannot execute because that path is not a Windows surface. The same path passed in the required Linux container proof.

## Real Behavior Proof

**Claim:** An exhausted GitHub credential pool opens one durable reset-aware circuit, collapses later same-pool work, preserves healthy owners/pools, and resumes after reset with bounded jitter without weakening exact-review fencing, freshness, idempotency, or mutation authorization.

**Exercised surface:** rate-limit parsing and propagation; exact-review preparation/outcomes; durable queue persistence, admission, alarm, recovery, and status; public-read routing; adaptive control; Bay/status telemetry; receipt atomicity and retention.

**Scenario/fixture:** deterministic primary/secondary/missing-header throttles; repository exhausted/App healthy; App exhausted/repository healthy; both exhausted; 8-member first-failure collapse; concurrency-in-flight bound; Durable Object restart; 52 blocked owners ahead of a healthy owner; reset recovery; duplicate and late telemetry; receipt/state write fault injection; private/mutating route rejection.

**Command/environment:** Docker-backed Crabbox `local-container`, image `node:24-bookworm`, read-only source bind copied to disposable `/tmp/proof`, frozen install, build, and focused Node/workflow suites.

**Observed result:** 123 tests passed with zero failures. No later member was admitted after a shared failure beyond already-in-flight work; unattempted releases did not spend retry budget; the healthy owner beyond the scan limit was admitted; persisted circuits survived restart and recovered after the deadline; duplicate feedback remained idempotent; injected transactional failures left no partial receipt/acknowledgement.

**Artifact/trace:** provider `local-container`; lease `cbx_8aa5ded88ca0`; run slug `golden-shrimp`; exact head `8d387089c30fbc84bd628f6b56ff629dbb875879`; total 32.822s (command 32.714s). The lease auto-stopped normally.

**Limits:** The proof uses local GitHub-boundary fixtures and does not exhaust a real credential or mutate production. Organic behavior still needs read-only observation across subsequent quota windows. Containing amplification does not prove that all legitimate successful-path demand fits every GitHub pool.

## Review closeout

- Final dirty-patch Codex review: clean; specifically verified pre-admission blocked-owner exclusion and healthy-owner recovery coverage.
- Final committed-base Codex review: clean; verified scoped propagation, no retry-budget charge for circuit deferral, and telemetry idempotency.
- Local ClawSweeper committed-range review: complete, `Overall correctness: patch is correct`, no findings. Artifact: `C:\clawsweeper-work\repos\clawsweeper\.git\worktrees\csw-117-github-quota-circuit\clawsweeper\reviews\local-range-1786377440411-17960\0.md`.
- Accepted findings from earlier review passes were fixed and proof/reviews rerun, including late telemetry forwarding, inherited `GITHUB_TOKEN`, full secondary-limit patterns, repeat revision propagation, stable fallback deadlines, cross-lease identity, bounded receipt retention, fallback observation semantics, transactional receipt/state updates, and blocked-owner scan saturation.

## Risks and rollout

- A misclassified credential scope could defer too much or too little work. Scope tests cover repository-vs-owner isolation and status exposes only redacted classes.
- Recovery jitter deliberately adds up to 30 seconds after reset to prevent a herd.
- The workflow change carries the normal GitHub OAuth/workflow-scope review risk.
- Post-merge verification should observe at least two complete quota windows: no same-pool dispatch before reset, no repeated revision amplification, healthy-owner progress, positive backlog drain, and no dead-letter increase.
- Ordinary revert is available; no queue rewrite, replay, clear, or manual circuit reset is required.

## Documentation

Updated limits, scheduler, and live-dashboard guidance alongside the status/Bay contract. The mandatory documentation/config drift checks pass. `CHANGELOG.md` is intentionally untouched because release notes are release-owned.

## Non-goals

- Raising publication concurrency or GitHub quota.
- Adding credentials or installations to evade limits.
- Removing live freshness/mutation guards.
- Live queue/DLQ replay, acknowledgement, workflow dispatch/rerun, gate changes, deployment, or production mutation.
- Changing #1097 or restoring fixed 50/50/50 capacity in this PR.
