### PR TITLE
docs: enforce current documentation lifecycle

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "docs/**"
+      - "config/documentation-site.json"
       - "scripts/build-docs-site.mjs"
       - ".github/workflows/pages.yml"
   workflow_dispatch:

--- a/config/documentation-site.json
+++ b/config/documentation-site.json
@@ -1,0 +1,70 @@
+{
+  "version": 1,
+  "sections": [
+    {
+      "name": "Start",
+      "pages": ["README.md", "orchestration.md", "scheduler.md", "work-lane.md"]
+    },
+    {
+      "name": "Review and policy",
+      "pages": [
+        "commit-sweeper.md",
+        "review-cache.md",
+        "pr-review-comments.md",
+        "pr-proof-triage-dashboard.md",
+        "author-pr-budget-close-policy.md",
+        "obsolescence-close-policies.md",
+        "product-direction-close-policy.md",
+        "stalled-pr-close-policies.md",
+        "unsponsored-feature-close-policy.md"
+      ]
+    },
+    {
+      "name": "Operations",
+      "pages": [
+        "limits.md",
+        "live-dashboard.md",
+        "openclaw-bay-demo.md",
+        "openclaw-event-hooks.md",
+        "state-storage.md",
+        "action-ledger.md",
+        "target-dispatcher.md",
+        "target-repositories.md",
+        "triage-dashboard.md",
+        "related-issue-discovery.md",
+        "spam-scanner.md",
+        "local-clawsweeper-skill.md"
+      ]
+    },
+    {
+      "name": "Repair",
+      "pages": [
+        "steerable-repair-automation.md",
+        "repair/README.md",
+        "repair/operations.md",
+        "repair/automatic-issue-prs.md",
+        "repair/auto-update-prs.md",
+        "repair/automerge-flow.md",
+        "repair/automerge-e2e.md",
+        "repair/internal-features.md"
+      ]
+    }
+  ],
+  "noncanonical": [
+    {
+      "path": "queue-service-split-runbook.md",
+      "lifecycle": "proposed",
+      "banner": "This is an unapproved proposal, not current operator guidance."
+    },
+    {
+      "path": "repair/containment-validation-todo.md",
+      "lifecycle": "historical",
+      "banner": "This is historical decision evidence, not current operator guidance."
+    },
+    {
+      "prefix": "proof/",
+      "lifecycle": "historical proof",
+      "banner": "This immutable proof records behavior at its stated revision and does not override current documentation."
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,3 +169,10 @@ The check deliberately does not crawl external URLs, infer policy, assign
 ownership, or treat historical proof commands and paths as current contracts.
 The index, lifecycle labels, and whether a configuration claim should become
 policy remain human-reviewed.
+
+The public documentation build reads `config/documentation-site.json` as its
+exhaustive lifecycle manifest. Active pages appear in navigation, search, the
+sitemap, and `llms.txt`. Proposed, historical, and proof pages remain available
+at stable generated paths for evidence links, but carry a visible lifecycle
+banner and `noindex` metadata and are excluded from canonical discovery. The
+documentation check fails when a page is unclassified or classified twice.

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -127,9 +127,10 @@ is absent or a cache event lands in another Cloudflare colo.
 - a budget-sized capacity rail plus lane filters for issue-to-PR, PR repair,
   review, repair, commit, assist, and other workers
 - queued/waiting run count
-- operational health derived from queue age and running age: queued runs become
-  degraded after 30 minutes, and in-progress runs become stalled after 150
-  minutes
+- operational health derived from queue age and running age: queued runs from
+  30 through 1440 minutes old degrade operational health; queued runs older
+  than 1440 minutes are reported separately as zombies; approval-gated runs are
+  also reported separately; in-progress runs become stalled after 150 minutes
 - 24-hour and seven-day health trends for total queue depth, over-age queue
   depth, and the oldest queued/running ages
 - job-level worker attempt error rate, recovery rate, and unresolved failures,
@@ -232,16 +233,23 @@ rate appears about five minutes after deployment.
 Operational health remains a current-snapshot alert rather than a historical
 chart. `/api/status` classifies the already-fetched active workflow runs as:
 
-- `healthy`: complete telemetry and no over-age runs;
-- `degraded`: at least one queued run is 30 minutes old;
+- `healthy`: complete telemetry and no non-zombie over-age runs;
+- `degraded`: at least one queued run is from 30 through 1440 minutes old;
 - `stalled`: at least one in-progress run is 150 minutes old;
 - `unknown`: one or more actionable-status reads failed.
 
-Healthy status stays hidden. A queued run over 30 minutes, an in-progress run
-over 150 minutes, or incomplete Actions telemetry opens the expandable “Work
-execution needs attention” alert. This live diagnostic reuses the status
-snapshot's Actions reads; the history cron no longer stores queue pressure or
-oldest-run values.
+Healthy status stays hidden. A non-zombie queued run over 30 minutes, an
+in-progress run over 150 minutes, or incomplete Actions telemetry opens the
+expandable “Work execution needs attention” alert. This live diagnostic reuses
+the status snapshot's Actions reads; the history cron no longer stores queue
+pressure or oldest-run values.
+
+Queued runs older than 1440 minutes are reported separately as zombies and do
+not contribute to `queued_over_threshold` or `oldest_queued_minutes`; they
+therefore do not make an otherwise healthy snapshot degraded. The API exposes
+them as `zombie_queued_runs` and `oldest_zombie_queued_minutes`. Runs waiting on
+deployment approval are also excluded from queue pressure and exposed as
+`approval_gated_runs` and `oldest_approval_gated_minutes`.
 
 ## Boundaries
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -238,8 +238,8 @@ chart. `/api/status` classifies the already-fetched active workflow runs as:
 - `stalled`: at least one in-progress run is 150 minutes old;
 - `unknown`: one or more actionable-status reads failed.
 
-Healthy status stays hidden. A non-zombie queued run over 30 minutes, an
-in-progress run over 150 minutes, or incomplete Actions telemetry opens the
+Healthy status stays hidden. A non-zombie queued run at least 30 minutes old, an
+in-progress run at least 150 minutes old, or incomplete Actions telemetry opens the
 expandable “Work execution needs attention” alert. This live diagnostic reuses
 the status snapshot's Actions reads; the history cron no longer stores queue
 pressure or oldest-run values.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -9,30 +9,9 @@ const outDir = path.join(root, "dist", "docs-site");
 const repoUrl = "https://github.com/openclaw/clawsweeper";
 const repoEditBase = `${repoUrl}/edit/main/docs`;
 const customDomain = "clawsweeper.bot";
-
-const sections = [
-  ["Start", ["README.md", "scheduler.md", "work-lane.md"]],
-  [
-    "Lanes",
-    [
-      "commit-sweeper.md",
-      "target-dispatcher.md",
-      "pr-review-comments.md",
-      "openclaw-event-hooks.md",
-    ],
-  ],
-  [
-    "Repair",
-    [
-      "repair/README.md",
-      "repair/operations.md",
-      "repair/automatic-issue-prs.md",
-      "repair/auto-update-prs.md",
-      "repair/automerge-flow.md",
-      "repair/internal-features.md",
-    ],
-  ],
-];
+const siteManifest = JSON.parse(
+  fs.readFileSync(path.join(root, "config", "documentation-site.json"), "utf8"),
+);
 
 fs.rmSync(outDir, { recursive: true, force: true });
 fs.mkdirSync(outDir, { recursive: true });
@@ -41,7 +20,15 @@ const pages = allMarkdown(docsDir).map((file) => {
   const rel = path.relative(docsDir, file).replaceAll(path.sep, "/");
   const markdown = fs.readFileSync(file, "utf8");
   const title = firstHeading(markdown) || titleize(path.basename(rel, ".md"));
-  return { file, rel, title, outRel: outPath(rel), markdown, synthetic: false };
+  return {
+    file,
+    rel,
+    title,
+    outRel: outPath(rel),
+    markdown,
+    synthetic: false,
+    lifecycle: lifecycleFor(rel),
+  };
 });
 
 const homePage = {
@@ -51,14 +38,15 @@ const homePage = {
   outRel: "index.html",
   markdown: "",
   synthetic: true,
+  lifecycle: { canonical: true, name: "active" },
 };
 pages.unshift(homePage);
 
 const pageMap = new Map(pages.map((page) => [page.rel, page]));
-const nav = sections
-  .map(([name, rels]) => ({
-    name,
-    pages: rels.map((rel) => pageMap.get(rel)).filter(Boolean),
+const nav = siteManifest.sections
+  .map((section) => ({
+    name: section.name,
+    pages: section.pages.map((rel) => pageMap.get(rel)).filter(Boolean),
   }))
   .filter((section) => section.pages.length);
 
@@ -66,6 +54,7 @@ const sectionByRel = new Map();
 for (const section of nav)
   for (const page of section.pages) sectionByRel.set(page.rel, section.name);
 const orderedPages = [homePage, ...nav.flatMap((s) => s.pages)];
+const canonicalPages = orderedPages;
 
 for (const page of pages) {
   const html = page.synthetic ? "" : markdownToHtml(page.markdown, page.rel);
@@ -89,7 +78,7 @@ fs.writeFileSync(
   `User-agent: *\nAllow: /\nSitemap: https://${customDomain}/sitemap.xml\n`,
   "utf8",
 );
-fs.writeFileSync(path.join(outDir, "sitemap.xml"), sitemap(orderedPages), "utf8");
+fs.writeFileSync(path.join(outDir, "sitemap.xml"), sitemap(canonicalPages), "utf8");
 fs.writeFileSync(path.join(outDir, "llms.txt"), llmsTxt(), "utf8");
 console.log(`built docs site: ${path.relative(root, outDir)} (${pages.length} pages)`);
 
@@ -120,11 +109,22 @@ function llmsTxt() {
 }
 
 function docsLlmsPages() {
-  const seen = new Set();
-  const ordered = typeof orderedPages !== "undefined" ? orderedPages : [];
-  return [...ordered, ...pages].filter(
-    (page) => page.outRel && !seen.has(page.outRel) && seen.add(page.outRel),
+  return canonicalPages;
+}
+
+function lifecycleFor(rel) {
+  const canonical = siteManifest.sections.some((section) => section.pages.includes(rel));
+  const matches = siteManifest.noncanonical.filter(
+    (entry) => entry.path === rel || (entry.prefix && rel.startsWith(entry.prefix)),
   );
+  if (canonical && matches.length)
+    throw new Error(`documentation page has conflicting lifecycle: ${rel}`);
+  if (canonical) return { canonical: true, name: "active" };
+  if (matches.length === 1)
+    return { canonical: false, name: matches[0].lifecycle, banner: matches[0].banner };
+  if (matches.length > 1)
+    throw new Error(`documentation page has multiple lifecycle matches: ${rel}`);
+  throw new Error(`documentation page is not classified in config/documentation-site.json: ${rel}`);
 }
 
 function docsOrigin() {
@@ -409,6 +409,7 @@ function layout({ page, html, toc, prev, next, sectionName }) {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(page.title)}${isHome ? " - Conservative maintenance bot" : " - ClawSweeper Docs"}</title>
   <meta name="description" content="${escapeAttr(description)}">
+  ${page.lifecycle.canonical ? "" : '<meta name="robots" content="noindex, follow">'}
   <meta name="theme-color" content="#f4ead7">
   <meta property="og:title" content="${escapeAttr(page.title)}${isHome ? " - ClawSweeper" : " - ClawSweeper docs"}">
   <meta property="og:description" content="${escapeAttr(description)}">
@@ -483,7 +484,11 @@ function standardHero(page, sectionName, editUrl) {
           <a class="repo" href="${repoUrl}" rel="noopener">GitHub</a>
           <a class="edit" href="${escapeAttr(editUrl)}" rel="noopener">Edit page</a>
         </div>
-      </header>`;
+      </header>${
+        page.lifecycle.canonical
+          ? ""
+          : `<aside class="lifecycle-banner" role="note"><strong>${escapeHtml(page.lifecycle.name)}</strong>: ${escapeHtml(page.lifecycle.banner)}</aside>`
+      }`;
 }
 
 function landingHero(rootPrefix) {

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -94,7 +94,93 @@ export function checkDocumentation(root = process.cwd()) {
   }
 
   checkConfiguredClaims({ root, inventory, findings });
+  checkDocumentationSiteManifest({ root, inventory, findings });
+  checkOperationalHealthDocumentation({ root, findings });
   return findings.sort(compareFindings);
+}
+
+function checkDocumentationSiteManifest({ root, inventory, findings }) {
+  const manifestPath = "config/documentation-site.json";
+  const manifest = readJson(path.join(root, manifestPath));
+  const canonical = new Set();
+  for (const section of manifest.sections ?? []) {
+    for (const page of section.pages ?? []) {
+      if (canonical.has(page)) {
+        addFinding(
+          findings,
+          manifestPath,
+          1,
+          "docs-lifecycle",
+          `duplicates canonical page ${page}`,
+        );
+      }
+      canonical.add(page);
+      if (!inventory.exact.has(`docs/${page}`)) {
+        addFinding(
+          findings,
+          manifestPath,
+          1,
+          "docs-lifecycle",
+          `references missing page docs/${page}`,
+        );
+      }
+    }
+  }
+
+  const docsPages = [...inventory.exact]
+    .filter((file) => file.startsWith("docs/") && file.endsWith(".md"))
+    .map((file) => file.slice("docs/".length));
+  for (const page of docsPages) {
+    const matches = (manifest.noncanonical ?? []).filter(
+      (entry) => entry.path === page || (entry.prefix && page.startsWith(entry.prefix)),
+    );
+    const classifications = Number(canonical.has(page)) + matches.length;
+    if (classifications !== 1) {
+      addFinding(
+        findings,
+        manifestPath,
+        1,
+        "docs-lifecycle",
+        `${page} has ${classifications === 0 ? "no" : "multiple"} lifecycle classifications`,
+      );
+    }
+  }
+}
+
+function checkOperationalHealthDocumentation({ root, findings }) {
+  const sourcePath = "dashboard/operational-health.ts";
+  const documentPath = "docs/live-dashboard.md";
+  const source = fs.readFileSync(path.join(root, sourcePath), "utf8");
+  const document = normalizeWhitespace(fs.readFileSync(path.join(root, documentPath), "utf8"));
+  const minutes = (name) => {
+    const expression = source.match(new RegExp(`export const ${name} = ([0-9 *]+);`))?.[1];
+    if (!expression) return null;
+    return (
+      expression
+        .split("*")
+        .map(Number)
+        .reduce((total, value) => total * value, 1) / 60_000
+    );
+  };
+  const expected = [
+    `queued runs from ${minutes("OPERATIONAL_QUEUE_DEGRADED_MS")} through ${minutes("OPERATIONAL_QUEUE_ZOMBIE_MS")} minutes old degrade operational health`,
+    `queued runs older than ${minutes("OPERATIONAL_QUEUE_ZOMBIE_MS")} minutes are reported separately as zombies`,
+    `in-progress runs become stalled after ${minutes("OPERATIONAL_RUNNING_STALLED_MS")} minutes`,
+    "zombie_queued_runs",
+    "oldest_zombie_queued_minutes",
+    "approval_gated_runs",
+  ];
+  for (const claim of expected) {
+    if (!document.includes(claim)) {
+      addFinding(
+        findings,
+        documentPath,
+        1,
+        "operational-health-claim",
+        `missing source-derived claim: ${claim}`,
+      );
+    }
+  }
 }
 
 function buildInventory(root) {

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -162,14 +162,34 @@ function checkOperationalHealthDocumentation({ root, findings }) {
         .reduce((total, value) => total * value, 1) / 60_000
     );
   };
-  const expected = [
-    `queued runs from ${minutes("OPERATIONAL_QUEUE_DEGRADED_MS")} through ${minutes("OPERATIONAL_QUEUE_ZOMBIE_MS")} minutes old degrade operational health`,
-    `queued runs older than ${minutes("OPERATIONAL_QUEUE_ZOMBIE_MS")} minutes are reported separately as zombies`,
-    `in-progress runs become stalled after ${minutes("OPERATIONAL_RUNNING_STALLED_MS")} minutes`,
+  const documentedFields = [
     "zombie_queued_runs",
     "oldest_zombie_queued_minutes",
     "approval_gated_runs",
     "oldest_approval_gated_minutes",
+  ];
+  const operationalHealthType = source.match(
+    /export type OperationalHealth = \{([\s\S]*?)\n\};/,
+  )?.[1];
+  for (const field of documentedFields) {
+    if (
+      !operationalHealthType ||
+      !new RegExp(`^\\s*${field}\\s*:`, "m").test(operationalHealthType)
+    ) {
+      addFinding(
+        findings,
+        sourcePath,
+        1,
+        "operational-health-source",
+        `documented field is missing from OperationalHealth: ${field}`,
+      );
+    }
+  }
+  const expected = [
+    `queued runs from ${minutes("OPERATIONAL_QUEUE_DEGRADED_MS")} through ${minutes("OPERATIONAL_QUEUE_ZOMBIE_MS")} minutes old degrade operational health`,
+    `queued runs older than ${minutes("OPERATIONAL_QUEUE_ZOMBIE_MS")} minutes are reported separately as zombies`,
+    `in-progress runs become stalled after ${minutes("OPERATIONAL_RUNNING_STALLED_MS")} minutes`,
+    ...documentedFields,
   ];
   for (const claim of expected) {
     if (!document.includes(claim)) {

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -169,6 +169,7 @@ function checkOperationalHealthDocumentation({ root, findings }) {
     "zombie_queued_runs",
     "oldest_zombie_queued_minutes",
     "approval_gated_runs",
+    "oldest_approval_gated_minutes",
   ];
   for (const claim of expected) {
     if (!document.includes(claim)) {

--- a/test/check-docs.test.ts
+++ b/test/check-docs.test.ts
@@ -53,7 +53,7 @@ function fixture(): string {
     "docs/README.md": "# Documentation Home\n",
     "docs/API_(legacy).md": "# Legacy API\n",
     "docs/live-dashboard.md":
-      "# Dashboard\n\nqueued runs from 30 through 1440 minutes old degrade operational health. queued runs older than 1440 minutes are reported separately as zombies. in-progress runs become stalled after 150 minutes. `zombie_queued_runs` `oldest_zombie_queued_minutes` `approval_gated_runs`\n",
+      "# Dashboard\n\nqueued runs from 30 through 1440 minutes old degrade operational health. queued runs older than 1440 minutes are reported separately as zombies. in-progress runs become stalled after 150 minutes. `zombie_queued_runs` `oldest_zombie_queued_minutes` `approval_gated_runs` `oldest_approval_gated_minutes`\n",
     "scripts/example.mjs": "export {};\n",
     ".github/workflows/ci.yml": "name: CI\n",
     "dashboard/wrangler.toml": 'CAPACITY = "50"\n',

--- a/test/check-docs.test.ts
+++ b/test/check-docs.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -52,9 +52,16 @@ function fixture(): string {
       '# Operation\n\n<a id="MixedCase"></a>\n\n[Root](/README.md)\n\n## Foo & Bar\n\n## [Linked Operations](#operation)\n\n## `stalled_unproven_pr`\n\n## Inline &lt;span&gt; HTML\n\nSetext Operation\ncontinuation\n----------------\n\n~~~markdown\n## Example Only\n~~~\n\nCapacity is 50.\n\n# implemented\n',
     "docs/README.md": "# Documentation Home\n",
     "docs/API_(legacy).md": "# Legacy API\n",
+    "docs/live-dashboard.md":
+      "# Dashboard\n\nqueued runs from 30 through 1440 minutes old degrade operational health. queued runs older than 1440 minutes are reported separately as zombies. in-progress runs become stalled after 150 minutes. `zombie_queued_runs` `oldest_zombie_queued_minutes` `approval_gated_runs`\n",
     "scripts/example.mjs": "export {};\n",
     ".github/workflows/ci.yml": "name: CI\n",
     "dashboard/wrangler.toml": 'CAPACITY = "50"\n',
+    "dashboard/operational-health.ts": [
+      "export const OPERATIONAL_QUEUE_DEGRADED_MS = 30 * 60 * 1000;",
+      "export const OPERATIONAL_QUEUE_ZOMBIE_MS = 24 * 60 * 60 * 1000;",
+      "export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;",
+    ].join("\n"),
     "config/targets.json": JSON.stringify({ close: { issue: "implemented" } }),
     "config/documentation-sync.json": JSON.stringify({
       version: 1,
@@ -69,6 +76,16 @@ function fixture(): string {
           claims: [{ document: "docs/guide.md", text: "# {{close.issue}}" }],
         },
       ],
+    }),
+    "config/documentation-site.json": JSON.stringify({
+      version: 1,
+      sections: [
+        {
+          name: "Docs",
+          pages: ["README.md", "API_(legacy).md", "guide.md", "live-dashboard.md"],
+        },
+      ],
+      noncanonical: [],
     }),
   };
   for (const [relative, contents] of Object.entries(files)) {
@@ -90,6 +107,35 @@ function withFixture(run: (root: string) => void): void {
 
 test("accepts synchronized documentation references", () => {
   withFixture((root) => assert.deepEqual(checkDocumentation(root), []));
+});
+
+test("reports unclassified and multiply classified documentation pages", () => {
+  withFixture((root) => {
+    writeFileSync(join(root, "docs/unclassified.md"), "# Unclassified\n");
+    const manifest = JSON.parse(String(readFileSync(join(root, "config/documentation-site.json"))));
+    manifest.noncanonical.push({ path: "guide.md", lifecycle: "historical", banner: "Old" });
+    writeFileSync(join(root, "config/documentation-site.json"), JSON.stringify(manifest));
+    const findings = checkDocumentation(root).filter(
+      (finding) => finding.kind === "docs-lifecycle",
+    );
+    assert.ok(findings.some((finding) => finding.message.includes("unclassified.md has no")));
+    assert.ok(findings.some((finding) => finding.message.includes("guide.md has multiple")));
+  });
+});
+
+test("reports operational health documentation drift", () => {
+  withFixture((root) => {
+    writeFileSync(
+      join(root, "dashboard/operational-health.ts"),
+      [
+        "export const OPERATIONAL_QUEUE_DEGRADED_MS = 31 * 60 * 1000;",
+        "export const OPERATIONAL_QUEUE_ZOMBIE_MS = 24 * 60 * 60 * 1000;",
+        "export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;",
+      ].join("\n"),
+    );
+    const findings = checkDocumentation(root);
+    assert.ok(findings.some((finding) => finding.kind === "operational-health-claim"));
+  });
 });
 
 test("accepts the full URI scheme syntax for external links", () => {

--- a/test/check-docs.test.ts
+++ b/test/check-docs.test.ts
@@ -61,6 +61,12 @@ function fixture(): string {
       "export const OPERATIONAL_QUEUE_DEGRADED_MS = 30 * 60 * 1000;",
       "export const OPERATIONAL_QUEUE_ZOMBIE_MS = 24 * 60 * 60 * 1000;",
       "export const OPERATIONAL_RUNNING_STALLED_MS = 150 * 60 * 1000;",
+      "export type OperationalHealth = {",
+      "  zombie_queued_runs: number;",
+      "  oldest_zombie_queued_minutes: number;",
+      "  approval_gated_runs: number;",
+      "  oldest_approval_gated_minutes: number;",
+      "};",
     ].join("\n"),
     "config/targets.json": JSON.stringify({ close: { issue: "implemented" } }),
     "config/documentation-sync.json": JSON.stringify({
@@ -135,6 +141,24 @@ test("reports operational health documentation drift", () => {
     );
     const findings = checkDocumentation(root);
     assert.ok(findings.some((finding) => finding.kind === "operational-health-claim"));
+  });
+});
+
+test("reports documented operational health fields missing from the runtime type", () => {
+  withFixture((root) => {
+    const sourcePath = join(root, "dashboard/operational-health.ts");
+    writeFileSync(
+      sourcePath,
+      String(readFileSync(sourcePath)).replace("  oldest_approval_gated_minutes: number;\n", ""),
+    );
+    const findings = checkDocumentation(root);
+    assert.ok(
+      findings.some(
+        (finding) =>
+          finding.kind === "operational-health-source" &&
+          finding.message.includes("oldest_approval_gated_minutes"),
+      ),
+    );
   });
 });
 

--- a/test/docs-site-theme.test.ts
+++ b/test/docs-site-theme.test.ts
@@ -39,3 +39,33 @@ test("docs site preserves the landing, documentation hub, and theme controls", (
   );
   assert.doesNotMatch(documentationHtml, /\.\.\/(?:VISION|CONTRIBUTING|AGENTS)\.html/);
 });
+
+test("docs site keeps non-current evidence out of canonical discovery", () => {
+  execFileSync(process.execPath, ["scripts/build-docs-site.mjs"], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+
+  const llms = readFileSync("dist/docs-site/llms.txt", "utf8");
+  const sitemap = readFileSync("dist/docs-site/sitemap.xml", "utf8");
+  const proposal = readFileSync("dist/docs-site/queue-service-split-runbook.html", "utf8");
+  const historical = readFileSync("dist/docs-site/repair/containment-validation-todo.html", "utf8");
+  const proof = readFileSync(
+    "dist/docs-site/proof/operational-health-zombie-runs/index.html",
+    "utf8",
+  );
+
+  for (const output of [llms, sitemap]) {
+    assert.doesNotMatch(output, /queue-service-split-runbook/);
+    assert.doesNotMatch(output, /containment-validation-todo/);
+    assert.doesNotMatch(output, /proof\/operational-health-zombie-runs/);
+  }
+  assert.match(llms, /live-dashboard\.html/);
+  for (const html of [proposal, historical, proof]) {
+    assert.match(html, /<meta name="robots" content="noindex, follow">/);
+    assert.match(html, /class="lifecycle-banner"/);
+  }
+  assert.match(proposal, /unapproved proposal, not current operator guidance/);
+  assert.match(historical, /historical decision evidence, not current operator guidance/);
+  assert.match(proof, /does not override current documentation/);
+});


### PR DESCRIPTION
## Summary

- Introduce one exhaustive lifecycle manifest for generated documentation.
- Keep proposed and historical proof pages intact, but remove them from canonical/indexable discovery and render clear lifecycle warnings.
- Correct active dashboard guidance for the current operational-health zombie-run semantics introduced by #1101.
- Add deterministic checks and negative fixtures for lifecycle and health-contract drift.
- Rebuild Pages when the lifecycle manifest changes.
- State the 30- and 150-minute alert boundaries inclusively and pin the complete approval-gated field pair.

## What Problem This Solves

The CSW-122 audit found that the generated site's `llms.txt` called immutable proof and an unapproved queue-split proposal “Canonical documentation.” Those pages were also rendered without lifecycle warnings. Separately, the active dashboard runbook still said every queued run older than 30 minutes degrades health, while #1101 excludes runs older than 24 hours as separately reported zombies.

These conflicts can make agents follow historical or proposed material and can make operators misread a healthy dashboard snapshot.

## Why This Change Was Made

`config/documentation-site.json` is now the exhaustive lifecycle source for the public docs build. The generator derives navigation, search, sitemap, and `llms.txt` from the active allowlist. Historical proof, the historical containment handoff, and the unapproved queue-split proposal keep their stable generated URLs, but receive visible lifecycle banners, `noindex, follow`, and no canonical discovery entry.

`check:docs` rejects unclassified or multiply classified pages and ties the documented operational-health thresholds/fields to `dashboard/operational-health.ts`.

## User Impact

Readers and agents see only current documentation in canonical discovery. Preserved evidence remains linkable but cannot be mistaken for current operator guidance. Dashboard operators now see the exact 30-minute-to-24-hour queue window, >24-hour zombie behavior, approval-gated counters, and 150-minute running threshold.

## Validation

- `node --test test/check-docs.test.ts test/docs-site-theme.test.ts` — 17/17 passed
- `pnpm run check:docs` — passed
- `pnpm run check:limits` — passed
- `pnpm run build:all` — passed
- `pnpm run check:active-surface` — passed
- `pnpm run check:dashboard-queue-boundary` — passed
- focused `oxfmt --check` — passed
- `git diff --check` — passed
- dirty-patch Codex review — no actionable findings
- committed Codex review against `origin/main` — no actionable findings
- local ClawSweeper `review --local-range` against `origin/main` — `keep_open`, high confidence, no GitHub mutation

## Real Behavior Proof

**Claim:** The real generated documentation output preserves non-current pages while excluding them from canonical discovery, labels them visibly and with `noindex`, and retains active current pages. The health documentation remains tied to the runtime constants and public field names.

**Exercised surface:** Exact pushed head `f6fcd47d3736ffcbf527680a17dfdfd9a883d536`; the production docs generator; Pages path trigger; generated navigation, sitemap, `llms.txt`, proposal/historical/proof HTML; `check:docs`; focused checker/site tests.

**Scenario:** A clean GitHub clone of the pushed branch was built inside Docker-backed Crabbox. The proof asserted that `live-dashboard.html` remains canonical; queue split, containment history, and proof URLs are absent from canonical discovery; preserved pages contain `noindex, follow` and lifecycle banners; all focused negative and positive tests pass.

**Command/environment:** Crabbox `0.40.0`, explicit repository-required `provider=local-container`, image `node:24-bookworm`, `--no-hydrate --no-sync`; the script cloned the exact pushed public branch because two normal sync attempts failed before execution with rsync protocol code 12.

**Observed result:** `CSW122_PR1_HEAD=f6fcd47d3736ffcbf527680a17dfdfd9a883d536`, 17/17 tests passed, `Documentation checks passed`, manifest path trigger present, `CSW122_PR1_PROOF=PASS`, exit 0.

**Artifact/trace:** Lease `cbx_cf906987454d` (`pearl-hermit`), provider `local-container`, image `node:24-bookworm`, `runStatus=succeeded`, command 18.302s, lease stopped. Local harness: `C:\clawsweeper-work\notes\csw-122-pr1-proof.sh`.

**Review disposition:** Accepted the Pages-trigger finding, the inclusive 30/150-minute wording finding, the request to pin `oldest_approval_gated_minutes`, and the request to bind all four documented health fields to the exported runtime type with a removed-field negative test. All are implemented at this head; no finding was rejected.

**Limits:** This proves exact-head generation and lifecycle/contract assertions in a real Linux container. It does not deploy the site, mutate Cloudflare, change runtime health classification, or test search-engine recrawl timing.

## OpenClaw Bay Impact

No Bay runtime, data contract, artwork, or controls change. The dashboard documentation now explains status fields already emitted by #1101. Bay remains observer-only.

## Risks and Rollback

- Risk: a current page omitted from the manifest now fails generation/checks instead of silently appearing. This is intentional fail-closed behavior.
- Risk: non-current pages remain directly reachable, but are visibly classified and excluded from canonical discovery.
- Rollback: revert this PR as one unit; there is no data, queue, deployment, or runtime migration.

## Non-goals

- No historical proof content is rewritten.
- No queue-split proposal is approved.
- No runtime, route, deployment logic, gate, queue, or state behavior changes; the only workflow change is the Pages input path trigger.
- Remaining CSW-122 operator API/config/governance gaps are reserved for a stacked follow-up PR.

## Stack / Order

This is PR 1 of the CSW-122 remediation. PR 2 will stack on this lifecycle manifest and will avoid the current #1105 limits/scheduler/target-dispatcher overlap. Merge this PR first.

## Related

- CSW-122 audit ledger: local maintainer artifact, not part of this repository
- #1092, #1095, #1096, #1098
- #1101
