### PR TITLE
fix(queue): reconcile parked review items

### DIFF
--- a/.github/workflows/exact-review-dead-letter-reconcile.yml
+++ b/.github/workflows/exact-review-dead-letter-reconcile.yml
@@ -38,6 +38,11 @@ jobs:
     env:
       EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
     steps:
+      - name: Establish reconciliation deadline
+        run: |
+          deadline_ms="$(( $(date +%s) * 1000 + 13 * 60 * 1000 ))"
+          echo "EXACT_REVIEW_RECONCILE_DEADLINE_MS=$deadline_ms" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: main

--- a/.github/workflows/exact-review-dead-letter-reconcile.yml
+++ b/.github/workflows/exact-review-dead-letter-reconcile.yml
@@ -49,13 +49,7 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Reconcile closed, duplicate, and recoverable dead letters
-        env:
-          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}
-          GITHUB_TOKEN: ${{ github.token }}
-          MAX_TARGETS: ${{ github.event.inputs.max_targets || '100' }}
-          MAX_RECOVERIES: ${{ github.event.inputs.max_recoveries || '10' }}
-          EXECUTE: ${{ github.event_name == 'schedule' && 'true' || github.event.inputs.execute }}
+      - name: Verify live recovery guards
         run: |
           set -euo pipefail
           expected_deploy_sha="$(git rev-parse HEAD)"
@@ -73,6 +67,16 @@ jobs:
               exit 1
             fi
           fi
+
+      - name: Reconcile closed, duplicate, and recoverable dead letters
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}
+          GITHUB_TOKEN: ${{ github.token }}
+          MAX_TARGETS: ${{ github.event.inputs.max_targets || '100' }}
+          MAX_RECOVERIES: ${{ github.event.inputs.max_recoveries || '10' }}
+          EXECUTE: ${{ github.event_name == 'schedule' && 'true' || github.event.inputs.execute }}
+        run: |
+          set -euo pipefail
           args=(
             --action reconcile
             --max-targets "$MAX_TARGETS"
@@ -84,12 +88,33 @@ jobs:
           fi
           node scripts/exact-review-dead-letter-operator.mjs "${args[@]}"
 
+      - name: Reconcile terminal and open parked reviews
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}
+          GITHUB_TOKEN: ${{ github.token }}
+          MAX_TARGETS: ${{ github.event.inputs.max_targets || '100' }}
+          EXECUTE: ${{ github.event_name == 'schedule' && 'true' || github.event.inputs.execute }}
+        run: |
+          set -euo pipefail
+          args=(
+            --action reconcile-parked
+            --max-targets "$MAX_TARGETS"
+            --max-recoveries 5
+            --output .artifacts/exact-review-dlq/parked-reviews.json
+          )
+          if [[ "$EXECUTE" == "true" ]]; then
+            args+=(--execute)
+          fi
+          node scripts/exact-review-dead-letter-operator.mjs "${args[@]}"
+
       - name: Upload sanitized inventory
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: exact-review-dlq-reconcile-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .artifacts/exact-review-dlq/inventory.json
+          path: |
+            .artifacts/exact-review-dlq/inventory.json
+            .artifacts/exact-review-dlq/parked-reviews.json
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 14

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -555,6 +555,7 @@ const EXACT_REVIEW_QUEUE_METRICS_TABLE = "exact_review_queue_metrics";
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TABLE = "exact_review_queue_metric_buckets";
 const EXACT_REVIEW_QUEUE_SUPERSESSION_TABLE = "exact_review_queue_supersessions";
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_TABLE = "exact_review_queue_dead_letters";
+const EXACT_REVIEW_QUEUE_PARKED_ACTION_TABLE = "exact_review_queue_parked_actions";
 const EXACT_REVIEW_PUBLICATION_HEAD_TABLE = "exact_review_publication_heads";
 const EXACT_REVIEW_RUN_TELEMETRY_TABLE = "exact_review_run_telemetry";
 const EXACT_REVIEW_GITHUB_TELEMETRY_RECEIPT_TABLE = "exact_review_github_telemetry_receipts";
@@ -568,6 +569,10 @@ const EXACT_REVIEW_STATE_WRITER_LIVE_MS = 90 * 1000;
 const REVIEW_OBSERVABILITY_SCAN_LIMIT = 10_000;
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_LIMIT = 5_000;
 const EXACT_REVIEW_QUEUE_DEAD_LETTER_RESOLVED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_QUEUE_PARKED_ACTION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const EXACT_REVIEW_PARKED_LIST_MAX_LIMIT = 50;
+const EXACT_REVIEW_PARKED_RESOLVE_MAX_ITEMS = 20;
+const EXACT_REVIEW_PARKED_RECOVER_MAX_ITEMS = 5;
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_MS = 5 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_METRIC_BUCKET_TTL_MS = 48 * 60 * 60 * 1000;
 const EXACT_REVIEW_QUEUE_SUPERSESSION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
@@ -2168,6 +2173,18 @@ export class ExactReviewQueue {
 
     if (request.method === "POST" && url.pathname === "/dead-letters/resolve") {
       return this.resolveDeadLetters(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/parked-reviews/list") {
+      return this.listParkedReviews(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/parked-reviews/resolve") {
+      return this.resolveParkedReviews(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/parked-reviews/recover-fresh") {
+      return this.recoverParkedReviewsFresh(await request.json().catch(() => null));
     }
 
     if (request.method === "POST" && url.pathname === "/publications/list") {
@@ -4543,6 +4560,207 @@ export class ExactReviewQueue {
       }
     });
     return json({ ok: true, resolved, skipped: ids.length - resolved, unparked });
+  }
+
+  private listParkedReviews(value: unknown) {
+    const body = objectValue(value);
+    const limit = body.limit === undefined ? 20 : Number(body.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > EXACT_REVIEW_PARKED_LIST_MAX_LIMIT) {
+      return json({ error: "invalid_limit" }, 400);
+    }
+    const cursor = String(body.cursor || "");
+    if (cursor && cursor.length > 500) return json({ error: "invalid_cursor" }, 400);
+    const rows = Object.values(this.readStateSync().items)
+      .filter(
+        (item) =>
+          item.state === "parked" &&
+          !exactReviewQueueIsPublication(item) &&
+          item.key.localeCompare(cursor) > 0,
+      )
+      .sort((left, right) => left.key.localeCompare(right.key))
+      .slice(0, limit + 1);
+    const page = rows.slice(0, limit);
+    return json({
+      ok: true,
+      parked_reviews: page.map((item) => ({
+        item_key: item.key,
+        target_repo: item.decision.targetRepo,
+        item_number: item.decision.itemNumber,
+        item_kind: item.decision.itemKind,
+        parked_reason: item.parkedReason || null,
+        parked_recovery_attempts: exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts),
+        first_failed_at: item.firstFailureAt
+          ? new Date(item.firstFailureAt).toISOString()
+          : item.dispatchFailureAt
+            ? new Date(item.dispatchFailureAt).toISOString()
+            : null,
+        last_failure_reason:
+          item.lastFailureReason || item.dispatchFailureClass || item.parkedReason || null,
+        updated_at: new Date(item.updatedAt).toISOString(),
+        updated_at_ms: item.updatedAt,
+      })),
+      next_cursor: rows.length > limit ? page.at(-1)?.key || null : null,
+    });
+  }
+
+  private resolveParkedReviews(value: unknown) {
+    const body = objectValue(value);
+    const items = exactReviewParkedOperatorItems(body.items, EXACT_REVIEW_PARKED_RESOLVE_MAX_ITEMS);
+    const note = String(body.note || "").trim();
+    if (!items) return json({ error: "invalid_parked_review_items" }, 400);
+    if (!note || note.length > 500) return json({ error: "invalid_resolution_note" }, 400);
+    const now = Date.now();
+    const result = this.storage.transactionSync(() => {
+      this.pruneParkedReviewActionsSync(now);
+      const state = this.readStateSync();
+      let resolved = 0;
+      let skipped = 0;
+      for (const expected of items) {
+        const item = state.items[expected.itemKey];
+        if (
+          !item ||
+          item.state !== "parked" ||
+          exactReviewQueueIsPublication(item) ||
+          item.updatedAt !== expected.updatedAt
+        ) {
+          skipped += 1;
+          continue;
+        }
+        delete state.items[item.key];
+        this.recordParkedReviewActionSync({
+          itemKey: item.key,
+          action: "resolved",
+          actionKey: null,
+          note,
+          sourceUpdatedAt: expected.updatedAt,
+          actedAt: now,
+        });
+        resolved += 1;
+      }
+      if (resolved) this.writeStateSync(state);
+      else this.syncLegacyCompatibilitySync(state);
+      return { resolved, skipped };
+    });
+    return json({ ok: true, ...result });
+  }
+
+  private async recoverParkedReviewsFresh(value: unknown) {
+    const body = objectValue(value);
+    const items = exactReviewParkedOperatorItems(body.items, EXACT_REVIEW_PARKED_RECOVER_MAX_ITEMS);
+    const recoveryKey = String(body.idempotency_key || "").trim();
+    if (!items) return json({ error: "invalid_parked_review_items" }, 400);
+    if (!/^[A-Za-z0-9:._-]{1,200}$/.test(recoveryKey)) {
+      return json({ error: "invalid_idempotency_key" }, 400);
+    }
+    const now = Date.now();
+    const result = this.storage.transactionSync(() => {
+      this.pruneParkedReviewActionsSync(now);
+      const state = this.readStateSync();
+      let recovered = 0;
+      let deduped = 0;
+      let skipped = 0;
+      for (const expected of items) {
+        const previous = Array.from(
+          this.storage.sql.exec(
+            `SELECT action, action_key, source_updated_at
+               FROM ${EXACT_REVIEW_QUEUE_PARKED_ACTION_TABLE}
+              WHERE item_key = ?`,
+            expected.itemKey,
+          ),
+        )[0] as { action?: string; action_key?: string; source_updated_at?: number } | undefined;
+        if (
+          previous?.action === "recovered_fresh" &&
+          previous.action_key === recoveryKey &&
+          Number(previous.source_updated_at) === expected.updatedAt
+        ) {
+          deduped += 1;
+          continue;
+        }
+        const item = state.items[expected.itemKey];
+        if (
+          !item ||
+          item.state !== "parked" ||
+          exactReviewQueueIsPublication(item) ||
+          item.updatedAt !== expected.updatedAt ||
+          exactReviewQueueActiveReviewCount(state) >= exactReviewQueueCapacity(this.env)
+        ) {
+          skipped += 1;
+          continue;
+        }
+        clearExactReviewLease(item);
+        item.state = "pending";
+        item.revision = Math.max(item.revision + 1, this.nextExactReviewItemRevisionSync(item.key));
+        item.admissionDeliveryId = `parked-recovery:${recoveryKey}:${item.key}`;
+        item.createdAt = now;
+        item.updatedAt = now;
+        item.parkedReason = undefined;
+        item.parkedRecoveryAttempts = 0;
+        item.parkedRecoveryAt = undefined;
+        item.attempts = 0;
+        item.publicationFailureAttempts = 0;
+        item.reviewFailureAttempts = 0;
+        item.firstFailureAt = undefined;
+        item.lastFailureReason = undefined;
+        clearExactReviewDispatchFailure(item);
+        Object.assign(
+          item,
+          exactReviewQueueDebouncedAttempt(state, item.decision, now, now, this.env),
+        );
+        this.recordParkedReviewActionSync({
+          itemKey: item.key,
+          action: "recovered_fresh",
+          actionKey: recoveryKey,
+          note: "recovered_fresh",
+          sourceUpdatedAt: expected.updatedAt,
+          actedAt: now,
+        });
+        recovered += 1;
+      }
+      if (recovered) this.writeStateSync(state);
+      else this.syncLegacyCompatibilitySync(state);
+      return { state, recovered, deduped, skipped };
+    });
+    if (result.recovered) await this.scheduleNext(result.state, now);
+    return json({
+      ok: true,
+      recovered: result.recovered,
+      deduped: result.deduped,
+      skipped: result.skipped,
+    });
+  }
+
+  private recordParkedReviewActionSync(input: {
+    itemKey: string;
+    action: "resolved" | "recovered_fresh";
+    actionKey: string | null;
+    note: string;
+    sourceUpdatedAt: number;
+    actedAt: number;
+  }) {
+    this.storage.sql.exec(
+      `INSERT INTO ${EXACT_REVIEW_QUEUE_PARKED_ACTION_TABLE}
+       (item_key, action, action_key, note, source_updated_at, acted_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(item_key) DO UPDATE SET
+         action = excluded.action,
+         action_key = excluded.action_key,
+         note = excluded.note,
+         source_updated_at = excluded.source_updated_at,
+         acted_at = excluded.acted_at`,
+      input.itemKey,
+      input.action,
+      input.actionKey,
+      input.note,
+      input.sourceUpdatedAt,
+      input.actedAt,
+    );
+  }
+
+  private pruneParkedReviewActionsSync(now: number) {
+    this.storage.sql.exec(
+      `DELETE FROM ${EXACT_REVIEW_QUEUE_PARKED_ACTION_TABLE} WHERE acted_at <= ?`,
+      now - EXACT_REVIEW_QUEUE_PARKED_ACTION_TTL_MS,
+    );
   }
 
   private listPublicationCandidates(value: unknown) {
@@ -7398,6 +7616,20 @@ export class ExactReviewQueue {
          (status, last_failed_at, dead_letter_id)`,
     );
     this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_QUEUE_PARKED_ACTION_TABLE} (
+         item_key TEXT PRIMARY KEY,
+         action TEXT NOT NULL CHECK (action IN ('resolved', 'recovered_fresh')),
+         action_key TEXT,
+         note TEXT NOT NULL,
+         source_updated_at INTEGER NOT NULL,
+         acted_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_queue_parked_actions_acted
+         ON ${EXACT_REVIEW_QUEUE_PARKED_ACTION_TABLE} (acted_at, item_key)`,
+    );
+    this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_RUN_TELEMETRY_TABLE} (
          run_id TEXT NOT NULL,
          run_attempt INTEGER NOT NULL CHECK (run_attempt >= 1),
@@ -10154,6 +10386,31 @@ function exactReviewDeadLetterIds(value): string[] | null {
   const ids = value.map((entry) => String(entry || "").trim());
   if (ids.some((id) => !id || id.length > 500) || new Set(ids).size !== ids.length) return null;
   return ids;
+}
+
+function exactReviewParkedOperatorItems(
+  value: unknown,
+  maximum: number,
+): Array<{ itemKey: string; updatedAt: number }> | null {
+  if (!Array.isArray(value) || value.length < 1 || value.length > maximum) return null;
+  const items: Array<{ itemKey: string; updatedAt: number }> = [];
+  const keys = new Set<string>();
+  for (const raw of value) {
+    const item = objectValue(raw);
+    const itemKey = String(item.item_key || "").trim();
+    const updatedAt = Number(item.updated_at_ms);
+    if (
+      !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
+      keys.has(itemKey.toLowerCase()) ||
+      !Number.isSafeInteger(updatedAt) ||
+      updatedAt < 1
+    ) {
+      return null;
+    }
+    keys.add(itemKey.toLowerCase());
+    items.push({ itemKey, updatedAt });
+  }
+  return items;
 }
 
 function exactReviewRecoveryAliases(

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -4572,12 +4572,7 @@ export class ExactReviewQueue {
     if (cursor && cursor.length > 500) return json({ error: "invalid_cursor" }, 400);
     const rows = Object.values(this.readStateSync().items)
       .filter(
-        (item) =>
-          item.state === "parked" &&
-          !exactReviewQueueIsPublication(item) &&
-          exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts) >=
-            EXACT_REVIEW_PARKED_RECOVERY_LIMIT &&
-          item.key.localeCompare(cursor) > 0,
+        (item) => exactReviewParkedOperatorEligible(item) && item.key.localeCompare(cursor) > 0,
       )
       .sort((left, right) => left.key.localeCompare(right.key))
       .slice(0, limit + 1);
@@ -4622,8 +4617,7 @@ export class ExactReviewQueue {
         const item = state.items[expected.itemKey];
         if (
           !item ||
-          item.state !== "parked" ||
-          exactReviewQueueIsPublication(item) ||
+          !exactReviewParkedOperatorEligible(item) ||
           item.revision !== expected.revision
         ) {
           skipped += 1;
@@ -4682,8 +4676,7 @@ export class ExactReviewQueue {
         const item = state.items[expected.itemKey];
         if (
           !item ||
-          item.state !== "parked" ||
-          exactReviewQueueIsPublication(item) ||
+          !exactReviewParkedOperatorEligible(item) ||
           item.revision !== expected.revision ||
           exactReviewQueueActiveReviewCount(state) >= exactReviewQueueCapacity(this.env)
         ) {
@@ -11166,15 +11159,18 @@ function exactReviewParkedRecoveryAttempts(value: unknown) {
   return Number.isSafeInteger(attempts) && attempts > 0 ? attempts : 0;
 }
 
-function exactReviewParkedTerminalCheckAt(item: ExactReviewQueueItem) {
-  if (
-    item.state !== "parked" ||
-    exactReviewQueueIsPublication(item) ||
-    exactReviewQueueHasCommandContext(item) ||
-    (item.parkedReason !== "review_retry_exhausted" && item.parkedReason !== "dispatch_rejected") ||
-    exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts) <
+function exactReviewParkedOperatorEligible(item: ExactReviewQueueItem) {
+  return (
+    item.state === "parked" &&
+    !exactReviewQueueIsPublication(item) &&
+    (item.parkedReason === "dispatch_rejected" || item.parkedReason === "review_retry_exhausted") &&
+    exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts) >=
       EXACT_REVIEW_PARKED_RECOVERY_LIMIT
-  ) {
+  );
+}
+
+function exactReviewParkedTerminalCheckAt(item: ExactReviewQueueItem) {
+  if (!exactReviewParkedOperatorEligible(item) || exactReviewQueueHasCommandContext(item)) {
     return null;
   }
   return Number(item.parkedTerminalCheckedAt || 0) + EXACT_REVIEW_PARKED_TERMINAL_CHECK_INTERVAL_MS;

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -4585,6 +4585,7 @@ export class ExactReviewQueue {
         target_repo: item.decision.targetRepo,
         item_number: item.decision.itemNumber,
         item_kind: item.decision.itemKind,
+        ...(exactReviewQueueHasCommandContext(item) ? { excluded_reason: "command_context" } : {}),
         parked_reason: item.parkedReason || null,
         parked_recovery_attempts: exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts),
         first_failed_at: item.firstFailureAt
@@ -4618,6 +4619,7 @@ export class ExactReviewQueue {
         if (
           !item ||
           !exactReviewParkedOperatorEligible(item) ||
+          exactReviewQueueHasCommandContext(item) ||
           item.revision !== expected.revision
         ) {
           skipped += 1;
@@ -4677,6 +4679,7 @@ export class ExactReviewQueue {
         if (
           !item ||
           !exactReviewParkedOperatorEligible(item) ||
+          exactReviewQueueHasCommandContext(item) ||
           item.revision !== expected.revision ||
           exactReviewQueueActiveReviewCount(state) >= exactReviewQueueCapacity(this.env)
         ) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -4575,6 +4575,8 @@ export class ExactReviewQueue {
         (item) =>
           item.state === "parked" &&
           !exactReviewQueueIsPublication(item) &&
+          exactReviewParkedRecoveryAttempts(item.parkedRecoveryAttempts) >=
+            EXACT_REVIEW_PARKED_RECOVERY_LIMIT &&
           item.key.localeCompare(cursor) > 0,
       )
       .sort((left, right) => left.key.localeCompare(right.key))
@@ -4584,6 +4586,7 @@ export class ExactReviewQueue {
       ok: true,
       parked_reviews: page.map((item) => ({
         item_key: item.key,
+        revision: item.revision,
         target_repo: item.decision.targetRepo,
         item_number: item.decision.itemNumber,
         item_kind: item.decision.itemKind,
@@ -4621,7 +4624,7 @@ export class ExactReviewQueue {
           !item ||
           item.state !== "parked" ||
           exactReviewQueueIsPublication(item) ||
-          item.updatedAt !== expected.updatedAt
+          item.revision !== expected.revision
         ) {
           skipped += 1;
           continue;
@@ -4681,7 +4684,7 @@ export class ExactReviewQueue {
           !item ||
           item.state !== "parked" ||
           exactReviewQueueIsPublication(item) ||
-          item.updatedAt !== expected.updatedAt ||
+          item.revision !== expected.revision ||
           exactReviewQueueActiveReviewCount(state) >= exactReviewQueueCapacity(this.env)
         ) {
           skipped += 1;
@@ -10391,24 +10394,27 @@ function exactReviewDeadLetterIds(value): string[] | null {
 function exactReviewParkedOperatorItems(
   value: unknown,
   maximum: number,
-): Array<{ itemKey: string; updatedAt: number }> | null {
+): Array<{ itemKey: string; revision: number; updatedAt: number }> | null {
   if (!Array.isArray(value) || value.length < 1 || value.length > maximum) return null;
-  const items: Array<{ itemKey: string; updatedAt: number }> = [];
+  const items: Array<{ itemKey: string; revision: number; updatedAt: number }> = [];
   const keys = new Set<string>();
   for (const raw of value) {
     const item = objectValue(raw);
     const itemKey = String(item.item_key || "").trim();
+    const revision = Number(item.revision);
     const updatedAt = Number(item.updated_at_ms);
     if (
       !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
       keys.has(itemKey.toLowerCase()) ||
+      !Number.isSafeInteger(revision) ||
+      revision < 1 ||
       !Number.isSafeInteger(updatedAt) ||
       updatedAt < 1
     ) {
       return null;
     }
     keys.add(itemKey.toLowerCase());
-    items.push({ itemKey, updatedAt });
+    items.push({ itemKey, revision, updatedAt });
   }
   return items;
 }

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -650,6 +650,18 @@ export default {
       return authenticatedExactReviewOperatorRequest(request, env, "/dead-letters/recover-fresh");
     if (url.pathname === "/internal/exact-review/dead-letters/resolve" && request.method === "POST")
       return authenticatedExactReviewOperatorRequest(request, env, "/dead-letters/resolve");
+    if (url.pathname === "/internal/exact-review/parked-reviews/list" && request.method === "POST")
+      return authenticatedExactReviewOperatorRequest(request, env, "/parked-reviews/list");
+    if (
+      url.pathname === "/internal/exact-review/parked-reviews/resolve" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewOperatorRequest(request, env, "/parked-reviews/resolve");
+    if (
+      url.pathname === "/internal/exact-review/parked-reviews/recover-fresh" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewOperatorRequest(request, env, "/parked-reviews/recover-fresh");
     if (url.pathname === "/internal/exact-review/publications/list" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/publications/list");
     if (

--- a/docs/proof/parked-review-reconcile/README.md
+++ b/docs/proof/parked-review-reconcile/README.md
@@ -5,7 +5,8 @@
 The real local dashboard Worker and `ExactReviewQueue` Durable Object expose a bounded, signed
 inventory for parked reviews. After the existing automatic recovery budget is genuinely exhausted,
 the parked-review operator resolves a terminal target and re-enqueues an open target as a fresh
-pending review with a reset recovery budget.
+pending review with a reset recovery budget, while leaving a command-context target parked for its
+maintainer-command obligations.
 
 ## Exercised surface
 
@@ -20,18 +21,26 @@ pending review with a reset recovery budget.
 
 ## Controlled scenario
 
-Two synthetic open issues are enqueued through the signed Worker route. The loopback GitHub stub
+Two ordinary open issues and one command-context review are enqueued through the signed Worker
+route. The command uses the real legacy command intake shape: a pull-request item with
+`sourceAction: "legacy_dispatch"`, command status marker, status comment id, and additional prompt.
+`exactReviewQueueHasCommandContext` recognizes that stored decision. The loopback GitHub stub
 returns the single-field HTTP 422 validation response that the production dispatcher classifies as
 `permanent_rejection`, parking each item as `dispatch_rejected`. Wrangler alarms perform all three
 automatic recoveries; every recovered item reaches the same real dispatch path and parks again.
-The proof waits until both inventory rows report `parked_recovery_attempts: 3`.
+The proof waits until all three inventory rows report `parked_recovery_attempts: 3` and the command
+row reports `excluded_reason: "command_context"`.
 
 The Worker process tree is then stopped. The proof opens Wrangler's disposable SQLite database only
 to assert that the `exact_review_queue_parked_actions` table was instantiated; it never inserts,
 updates, or deletes queue state. The Worker restarts against the same persistence with its normal
-90-second enqueue debounce. The stub marks one target closed and accepts dispatches. The real
+90-second enqueue debounce. The stub marks the ordinary terminal target and the command-context
+target closed, then accepts dispatches. The real
 operator classifies the targets, resolves the closed row with an audit note, fresh-recovers the open
-row, and the proof observes that row as `pending` with `parked_recovery_attempts: 0`.
+ordinary row, and skips the command-context row before GitHub inspection. Direct signed resolve and
+recover requests for that command row both report one skipped mutation. The proof observes the
+ordinary recovered row as `pending` with `parked_recovery_attempts: 0` and the command-context row
+unchanged as `parked` with `parked_recovery_attempts: 3`.
 
 ## Command and timing
 
@@ -49,16 +58,22 @@ take 26.25-52.5 minutes; the script has a 60-minute hard deadline. Generated evi
 ## Required observations
 
 - The Durable Object is instantiated and the parked action-receipt table exists.
-- Both rows are visible through the signed list route after exactly three automatic recoveries.
+- All three rows are visible through the signed list route after exactly three automatic recoveries.
+- The command-context row is flagged with `excluded_reason: "command_context"`.
 - The operator inspects two targets, resolves one terminal target, and recovers one open target.
+- The operator counts the excluded command-context target as skipped without inspecting it.
+- Signed resolve and fresh-recover requests both refuse the command-context row.
 - The terminal target has no queue item after reconciliation.
 - The open target is pending with attempts and parked recovery attempts reset to zero.
-- The final parked inventory is empty.
+- The final parked inventory contains only the unchanged command-context target.
 
 ## Limits and Bay impact
 
 The GitHub service is a loopback behavioral stub; no production GitHub repository, Worker, secret,
 comment, or workflow is contacted or mutated. The proof covers the real Worker/DO state machine,
 HTTP signing, alarms, operator process, and persistence boundary, not GitHub's hosted implementation.
+It exercises the initial command-review dispatch-rejection route. Terminal-finalization command
+acknowledgements use their separate pending retry path and are intentionally outside this parking
+scenario.
 OpenClaw Bay is unaffected: it remains a public observer-only surface and gains no recovery, DLQ,
 queue, workflow, deploy, or rollback action.

--- a/docs/proof/parked-review-reconcile/README.md
+++ b/docs/proof/parked-review-reconcile/README.md
@@ -1,0 +1,64 @@
+# Parked review reconciliation proof
+
+## Claim
+
+The real local dashboard Worker and `ExactReviewQueue` Durable Object expose a bounded, signed
+inventory for parked reviews. After the existing automatic recovery budget is genuinely exhausted,
+the parked-review operator resolves a terminal target and re-enqueues an open target as a fresh
+pending review with a reset recovery budget.
+
+## Exercised surface
+
+- Real `wrangler dev --local` Worker and Durable Object with disposable persistence
+- Signed exact-review enqueue and parked-review operator routes
+- The unchanged three-rung parked recovery alarm path (5/10/20 minutes, persisted 0.75-1.5x jitter)
+- Built `scripts/exact-review-dead-letter-operator.mjs --action reconcile-parked --execute`
+- A loopback GitHub stub for App installation tokens, live issue state, workflow state, and
+  repository-dispatch rejection
+- Full Wrangler process-tree stops, restart from the same Durable Object persistence, and a
+  read-only DO schema-instantiation assertion
+
+## Controlled scenario
+
+Two synthetic open issues are enqueued through the signed Worker route. The loopback GitHub stub
+returns the single-field HTTP 422 validation response that the production dispatcher classifies as
+`permanent_rejection`, parking each item as `dispatch_rejected`. Wrangler alarms perform all three
+automatic recoveries; every recovered item reaches the same real dispatch path and parks again.
+The proof waits until both inventory rows report `parked_recovery_attempts: 3`.
+
+The Worker process tree is then stopped. The proof opens Wrangler's disposable SQLite database only
+to assert that the `exact_review_queue_parked_actions` table was instantiated; it never inserts,
+updates, or deletes queue state. The Worker restarts against the same persistence with its normal
+90-second enqueue debounce. The stub marks one target closed and accepts dispatches. The real
+operator classifies the targets, resolves the closed row with an audit note, fresh-recovers the open
+row, and the proof observes that row as `pending` with `parked_recovery_attempts: 0`.
+
+## Command and timing
+
+Run from the repository root on Node 24 or newer with Docker/OrbStack available:
+
+```bash
+bash docs/proof/parked-review-reconcile/run-proof.sh
+```
+
+The recovery ladder is deliberately not shortened or faked. Its persisted jitter makes exhaustion
+take 26.25-52.5 minutes; the script has a 60-minute hard deadline. Generated evidence is written to
+`docs/proof/parked-review-reconcile/artifacts/` unless
+`PARKED_REVIEW_RECONCILE_PROOF_OUTPUT` overrides it.
+
+## Required observations
+
+- The Durable Object is instantiated and the parked action-receipt table exists.
+- Both rows are visible through the signed list route after exactly three automatic recoveries.
+- The operator inspects two targets, resolves one terminal target, and recovers one open target.
+- The terminal target has no queue item after reconciliation.
+- The open target is pending with attempts and parked recovery attempts reset to zero.
+- The final parked inventory is empty.
+
+## Limits and Bay impact
+
+The GitHub service is a loopback behavioral stub; no production GitHub repository, Worker, secret,
+comment, or workflow is contacted or mutated. The proof covers the real Worker/DO state machine,
+HTTP signing, alarms, operator process, and persistence boundary, not GitHub's hosted implementation.
+OpenClaw Bay is unaffected: it remains a public observer-only surface and gains no recovery, DLQ,
+queue, workflow, deploy, or rollback action.

--- a/docs/proof/parked-review-reconcile/assert-durable-object.mjs
+++ b/docs/proof/parked-review-reconcile/assert-durable-object.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { DatabaseSync } from "node:sqlite";
+
+const databasePath = process.argv[2];
+if (!databasePath) throw new Error("usage: assert-durable-object.mjs <sqlite-path>");
+
+const database = new DatabaseSync(databasePath, { readOnly: true });
+try {
+  const row = database
+    .prepare("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get("exact_review_queue_parked_actions");
+  process.stdout.write(String(Number(row?.count || 0)));
+} finally {
+  database.close();
+}

--- a/docs/proof/parked-review-reconcile/run-proof.mjs
+++ b/docs/proof/parked-review-reconcile/run-proof.mjs
@@ -22,7 +22,8 @@ if (phase === "exhaust") await exhaustRecoveryBudget();
 else await reconcileParkedReviews();
 
 async function exhaustRecoveryBudget() {
-  for (const number of [114100, 114101]) {
+  for (const number of [114100, 114101, 114102]) {
+    const commandContext = number === 114102;
     const result = await signedPost(
       "/internal/exact-review/enqueue",
       {
@@ -31,10 +32,18 @@ async function exhaustRecoveryBudget() {
           targetRepo: "openclaw/openclaw",
           targetBranch: "main",
           itemNumber: number,
-          itemKind: "issue",
+          itemKind: commandContext ? "pull_request" : "issue",
           sourceEvent: "issues",
-          sourceAction: "opened",
+          sourceAction: commandContext ? "legacy_dispatch" : "opened",
           supersedesInProgress: false,
+          ...(commandContext
+            ? {
+                commandStatusMarker:
+                  "<!-- clawsweeper-command-status:114102:re_review:0123456789abcdef0123456789abcdef01234567 -->",
+                statusCommentId: 114102,
+                additionalPrompt: "Check the maintainer-requested regression path.",
+              }
+            : {}),
         },
       },
       webhookSecret,
@@ -64,10 +73,12 @@ async function exhaustRecoveryBudget() {
       prior = progress;
     }
     if (
-      rows.length === 2 &&
+      rows.length === 3 &&
       rows.every(
         (row) => row.parked_reason === "dispatch_rejected" && row.parked_recovery_attempts === 3,
-      )
+      ) &&
+      rows.find((row) => row.item_key === "openclaw/openclaw#114102")?.excluded_reason ===
+        "command_context"
     ) {
       await writeJson("parked-inventory-exhausted.json", inventory.body);
       await writeJson("exhaustion-summary.json", {
@@ -89,7 +100,11 @@ async function reconcileParkedReviews() {
   const control = await fetch(`${githubOrigin}/__proof/control`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ reject_dispatch: false, issue_114101_state: "closed" }),
+    body: JSON.stringify({
+      reject_dispatch: false,
+      issue_114101_state: "closed",
+      issue_114102_state: "closed",
+    }),
   });
   assert.equal(control.status, 200);
 
@@ -117,7 +132,7 @@ async function reconcileParkedReviews() {
       resolved_targets: 1,
       open_targets: 1,
       recovered_targets: 1,
-      skipped_targets: 0,
+      skipped_targets: 1,
     },
   );
 
@@ -127,6 +142,9 @@ async function reconcileParkedReviews() {
   const terminal = await getJson(
     "/api/exact-review-queue/item?target_repo=openclaw%2Fopenclaw&item_number=114101",
   );
+  const commandContext = await getJson(
+    "/api/exact-review-queue/item?target_repo=openclaw%2Fopenclaw&item_number=114102",
+  );
   const finalInventory = await signedPost(
     "/internal/exact-review/parked-reviews/list",
     { limit: 50 },
@@ -134,6 +152,7 @@ async function reconcileParkedReviews() {
   );
   await writeJson("open-target-after.json", open.body);
   await writeJson("terminal-target-after.json", terminal.body);
+  await writeJson("command-context-target-after.json", commandContext.body);
   await writeJson("parked-inventory-final.json", finalInventory.body);
   assert.equal(open.status, 200);
   assert.equal(open.body.items.length, 1);
@@ -142,8 +161,52 @@ async function reconcileParkedReviews() {
   assert.equal(open.body.items[0].parked_recovery_attempts, 0);
   assert.equal(terminal.status, 200);
   assert.equal(terminal.body.items.length, 0);
+  assert.equal(commandContext.status, 200);
+  assert.equal(commandContext.body.items.length, 1);
+  assert.equal(commandContext.body.items[0].state, "parked");
+  assert.equal(commandContext.body.items[0].attempts, 0);
+  assert.equal(commandContext.body.items[0].parked_recovery_attempts, 3);
   assert.equal(finalInventory.status, 200);
-  assert.deepEqual(finalInventory.body.parked_reviews, []);
+  assert.equal(finalInventory.body.parked_reviews.length, 1);
+  const commandRow = finalInventory.body.parked_reviews[0];
+  assert.equal(commandRow.item_key, "openclaw/openclaw#114102");
+  assert.equal(commandRow.excluded_reason, "command_context");
+  const commandMutation = {
+    item_key: commandRow.item_key,
+    revision: commandRow.revision,
+    updated_at_ms: commandRow.updated_at_ms,
+  };
+  const refusedResolve = await signedPost(
+    "/internal/exact-review/parked-reviews/resolve",
+    {
+      items: [commandMutation],
+      note: "proof: command-context record must retain its acknowledgement obligation",
+    },
+    operatorSecret,
+  );
+  const refusedRecover = await signedPost(
+    "/internal/exact-review/parked-reviews/recover-fresh",
+    {
+      items: [commandMutation],
+      idempotency_key: "parked-proof:command-context-refusal",
+    },
+    operatorSecret,
+  );
+  await writeJson("command-context-resolve-refusal.json", refusedResolve.body);
+  await writeJson("command-context-recover-refusal.json", refusedRecover.body);
+  assert.equal(refusedResolve.status, 200);
+  assert.deepEqual(refusedResolve.body, { ok: true, resolved: 0, skipped: 1 });
+  assert.equal(refusedRecover.status, 200);
+  assert.deepEqual(refusedRecover.body, {
+    ok: true,
+    recovered: 0,
+    deduped: 0,
+    skipped: 1,
+  });
+  const commandAfterRefusals = await getJson(
+    "/api/exact-review-queue/item?target_repo=openclaw%2Fopenclaw&item_number=114102",
+  );
+  assert.deepEqual(commandAfterRefusals.body, commandContext.body);
 
   const proofSummary = {
     proof: "parked review inventory and reconcile",
@@ -154,7 +217,9 @@ async function reconcileParkedReviews() {
       automatic_recovery_attempts_exhausted: 3,
       terminal_target_resolved: true,
       open_target_recovered_pending: true,
-      final_parked_inventory_rows: 0,
+      command_context_target_untouched: true,
+      command_context_mutations_refused: true,
+      final_parked_inventory_rows: 1,
     },
     operator: result,
   };

--- a/docs/proof/parked-review-reconcile/run-proof.mjs
+++ b/docs/proof/parked-review-reconcile/run-proof.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const phase = process.argv[2];
+if (!new Set(["exhaust", "reconcile"]).has(phase)) {
+  throw new Error("usage: run-proof.mjs <exhaust|reconcile>");
+}
+
+const outputDir = path.resolve(required("PARKED_REVIEW_RECONCILE_PROOF_OUTPUT"));
+const workerOrigin = loopbackOrigin(required("PARKED_REVIEW_RECONCILE_WORKER_ORIGIN"));
+const githubOrigin = loopbackOrigin(required("PARKED_REVIEW_RECONCILE_GITHUB_ORIGIN"));
+const webhookSecret = required("PARKED_REVIEW_RECONCILE_WEBHOOK_SECRET");
+const operatorSecret = required("PARKED_REVIEW_RECONCILE_OPERATOR_SECRET");
+await mkdir(outputDir, { recursive: true });
+
+if (phase === "exhaust") await exhaustRecoveryBudget();
+else await reconcileParkedReviews();
+
+async function exhaustRecoveryBudget() {
+  for (const number of [114100, 114101]) {
+    const result = await signedPost(
+      "/internal/exact-review/enqueue",
+      {
+        delivery_id: `parked-review-proof-${number}`,
+        decision: {
+          targetRepo: "openclaw/openclaw",
+          targetBranch: "main",
+          itemNumber: number,
+          itemKind: "issue",
+          sourceEvent: "issues",
+          sourceAction: "opened",
+          supersedesInProgress: false,
+        },
+      },
+      webhookSecret,
+    );
+    assert.equal(result.status, 202);
+    assert.equal(result.body.queued, true);
+  }
+
+  const deadline = Date.now() + 60 * 60_000;
+  let prior = "";
+  for (;;) {
+    const inventory = await signedPost(
+      "/internal/exact-review/parked-reviews/list",
+      { limit: 50 },
+      operatorSecret,
+    );
+    assert.equal(inventory.status, 200);
+    const rows = inventory.body.parked_reviews || [];
+    const progress = rows
+      .map((row) => `${row.item_key}:${row.parked_recovery_attempts}`)
+      .sort()
+      .join(",");
+    if (progress !== prior) {
+      process.stdout.write(
+        `parked recovery progress ${new Date().toISOString()} ${progress || "none"}\n`,
+      );
+      prior = progress;
+    }
+    if (
+      rows.length === 2 &&
+      rows.every(
+        (row) => row.parked_reason === "dispatch_rejected" && row.parked_recovery_attempts === 3,
+      )
+    ) {
+      await writeJson("parked-inventory-exhausted.json", inventory.body);
+      await writeJson("exhaustion-summary.json", {
+        exhausted_at: new Date().toISOString(),
+        rows: rows.map((row) => ({
+          item_key: row.item_key,
+          parked_reason: row.parked_reason,
+          parked_recovery_attempts: row.parked_recovery_attempts,
+        })),
+      });
+      return;
+    }
+    if (Date.now() >= deadline) throw new Error("parked recovery budget did not exhaust in 60m");
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+}
+
+async function reconcileParkedReviews() {
+  const control = await fetch(`${githubOrigin}/__proof/control`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ reject_dispatch: false, issue_114101_state: "closed" }),
+  });
+  assert.equal(control.status, 200);
+
+  const operator = await runOperator();
+  await writeFile(path.join(outputDir, "operator.stdout.log"), operator.stdout);
+  await writeFile(path.join(outputDir, "operator.stderr.log"), operator.stderr);
+  assert.equal(operator.code, 0, operator.stderr);
+  const result = JSON.parse(operator.stdout);
+  assert.deepEqual(
+    {
+      action: result.action,
+      dry_run: result.dry_run,
+      inspected_targets: result.inspected_targets,
+      terminal_targets: result.terminal_targets,
+      resolved_targets: result.resolved_targets,
+      open_targets: result.open_targets,
+      recovered_targets: result.recovered_targets,
+      skipped_targets: result.skipped_targets,
+    },
+    {
+      action: "reconcile-parked",
+      dry_run: false,
+      inspected_targets: 2,
+      terminal_targets: 1,
+      resolved_targets: 1,
+      open_targets: 1,
+      recovered_targets: 1,
+      skipped_targets: 0,
+    },
+  );
+
+  const open = await getJson(
+    "/api/exact-review-queue/item?target_repo=openclaw%2Fopenclaw&item_number=114100",
+  );
+  const terminal = await getJson(
+    "/api/exact-review-queue/item?target_repo=openclaw%2Fopenclaw&item_number=114101",
+  );
+  const finalInventory = await signedPost(
+    "/internal/exact-review/parked-reviews/list",
+    { limit: 50 },
+    operatorSecret,
+  );
+  await writeJson("open-target-after.json", open.body);
+  await writeJson("terminal-target-after.json", terminal.body);
+  await writeJson("parked-inventory-final.json", finalInventory.body);
+  assert.equal(open.status, 200);
+  assert.equal(open.body.items.length, 1);
+  assert.equal(open.body.items[0].state, "pending");
+  assert.equal(open.body.items[0].attempts, 0);
+  assert.equal(open.body.items[0].parked_recovery_attempts, 0);
+  assert.equal(terminal.status, 200);
+  assert.equal(terminal.body.items.length, 0);
+  assert.equal(finalInventory.status, 200);
+  assert.deepEqual(finalInventory.body.parked_reviews, []);
+
+  const proofSummary = {
+    proof: "parked review inventory and reconcile",
+    source_sha: process.env.SOURCE_SHA || null,
+    completed_at: new Date().toISOString(),
+    assertions: {
+      durable_object_instantiated: true,
+      automatic_recovery_attempts_exhausted: 3,
+      terminal_target_resolved: true,
+      open_target_recovered_pending: true,
+      final_parked_inventory_rows: 0,
+    },
+    operator: result,
+  };
+  await writeJson("proof-summary.json", proofSummary);
+  process.stdout.write(`${JSON.stringify(proofSummary)}\n`);
+}
+
+function runOperator() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "scripts/exact-review-dead-letter-operator.mjs",
+        "--action",
+        "reconcile-parked",
+        "--max-targets",
+        "100",
+        "--max-recoveries",
+        "5",
+        "--execute",
+        "--output",
+        path.join(outputDir, "parked-operator-inventory.json"),
+      ],
+      {
+        env: {
+          ...process.env,
+          EXACT_REVIEW_QUEUE_URL: workerOrigin,
+          CLAWSWEEPER_WEBHOOK_SECRET: operatorSecret,
+          GITHUB_API_URL: githubOrigin,
+          GITHUB_TOKEN: "loopback-proof-token",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
+    child.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function signedPost(pathname, payload, secret) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  const response = await fetch(`${workerOrigin}${pathname}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+async function getJson(pathname) {
+  const response = await fetch(`${workerOrigin}${pathname}`);
+  return { status: response.status, body: await response.json() };
+}
+
+async function writeJson(name, value) {
+  await writeFile(path.join(outputDir, name), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function required(name) {
+  const value = String(process.env[name] || "");
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function loopbackOrigin(value) {
+  const url = new URL(value);
+  if (
+    url.protocol !== "http:" ||
+    url.hostname !== "127.0.0.1" ||
+    !url.port ||
+    url.pathname !== "/"
+  ) {
+    throw new Error(`proof origin must be explicit-port loopback HTTP: ${value}`);
+  }
+  return url.origin;
+}

--- a/docs/proof/parked-review-reconcile/run-proof.sh
+++ b/docs/proof/parked-review-reconcile/run-proof.sh
@@ -168,5 +168,8 @@ node docs/proof/parked-review-reconcile/run-proof.mjs reconcile \
 test -s "${output_dir}/proof-summary.json"
 test -s "${output_dir}/parked-inventory-exhausted.json"
 test -s "${output_dir}/parked-operator-inventory.json"
+test -s "${output_dir}/command-context-target-after.json"
+test -s "${output_dir}/command-context-resolve-refusal.json"
+test -s "${output_dir}/command-context-recover-refusal.json"
 test -s "${output_dir}/durable-object-assertion.txt"
 echo "PROOF_RC=0"

--- a/docs/proof/parked-review-reconcile/run-proof.sh
+++ b/docs/proof/parked-review-reconcile/run-proof.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+export PATH="$HOME/.local/bin:$PATH"
+
+output_dir="${PARKED_REVIEW_RECONCILE_PROOF_OUTPUT:-docs/proof/parked-review-reconcile/artifacts}"
+worker_port="${PARKED_REVIEW_RECONCILE_WORKER_PORT:-8798}"
+github_port="${PARKED_REVIEW_RECONCILE_GITHUB_PORT:-8898}"
+webhook_secret="parked-review-reconcile-local-webhook-secret"
+operator_secret="parked-review-reconcile-local-operator-secret"
+state_dir="$(mktemp -d /tmp/parked-review-reconcile-state.XXXXXX)"
+key_dir="$(mktemp -d /tmp/parked-review-reconcile-key.XXXXXX)"
+wrangler_raw_log="$(mktemp /tmp/parked-review-reconcile-wrangler.XXXXXX)"
+stub_log="$(mktemp /tmp/parked-review-reconcile-stub.XXXXXX)"
+worker_pid=""
+stub_pid=""
+queue_db=""
+
+mkdir -p "$output_dir" "$HOME/.local/bin"
+corepack enable --install-directory "$HOME/.local/bin"
+
+stop_tree() {
+  local root_pid="$1"
+  if test -z "$root_pid" || ! kill -0 "$root_pid" >/dev/null 2>&1; then
+    return
+  fi
+  local -a process_ids=("$root_pid")
+  local child_pid
+  while IFS= read -r child_pid; do
+    process_ids+=("$child_pid")
+  done < <(
+    ps -eo pid=,ppid= | awk -v root="$root_pid" '
+      { parent[$1] = $2 }
+      END {
+        for (pid in parent) {
+          current = pid
+          for (depth = 0; depth < 100 && current in parent; depth++) {
+            current = parent[current]
+            if (current == root) { print pid; break }
+          }
+        }
+      }
+    '
+  )
+  kill "${process_ids[@]}" >/dev/null 2>&1 || true
+  wait "$root_pid" >/dev/null 2>&1 || true
+}
+
+stop_worker() {
+  if test -n "$worker_pid"; then
+    stop_tree "$worker_pid"
+    worker_pid=""
+    local stopped=false
+    for _ in $(seq 1 50); do
+      if ! curl --silent --max-time 1 "http://127.0.0.1:${worker_port}/api/health" >/dev/null 2>&1; then
+        stopped=true
+        break
+      fi
+      sleep 0.1
+    done
+    test "$stopped" = true
+  fi
+}
+
+cleanup() {
+  stop_worker
+  if test -n "$stub_pid"; then
+    stop_tree "$stub_pid"
+  fi
+  sed -e "s/${webhook_secret}/[redacted-local-webhook-secret]/g" \
+    -e "s/${operator_secret}/[redacted-local-operator-secret]/g" \
+    "$wrangler_raw_log" >"${output_dir}/wrangler.log"
+  cp "$stub_log" "${output_dir}/stub.log"
+  rm -f -- "$wrangler_raw_log" "$stub_log"
+  rm -rf -- "$state_dir" "$key_dir"
+}
+trap cleanup EXIT
+
+start_worker() {
+  local fast_debounce="$1"
+  local -a debounce_args=()
+  if test "$fast_debounce" = true; then
+    debounce_args=(
+      --var "EXACT_REVIEW_DISPATCH_DEBOUNCE_MS:0"
+      --var "EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS:0"
+    )
+  fi
+  local app_private_key
+  app_private_key="$(<"${key_dir}/app-private.pem")"
+  npm_config_ignore_scripts=true npx --yes wrangler@4.107.0 dev \
+    --config dashboard/wrangler.toml \
+    --local \
+    --persist-to "$state_dir" \
+    --ip 127.0.0.1 \
+    --port "$worker_port" \
+    --var "CLAWSWEEPER_WEBHOOK_SECRET:${webhook_secret}" \
+    --var "EXACT_REVIEW_OPERATOR_SECRET:${operator_secret}" \
+    --var "GITHUB_API_URL:http://127.0.0.1:${github_port}" \
+    --var "CLAWSWEEPER_APP_CLIENT_ID:parked-proof-app" \
+    --var "CLAWSWEEPER_APP_PRIVATE_KEY:${app_private_key}" \
+    "${debounce_args[@]}" \
+    >>"$wrangler_raw_log" 2>&1 &
+  worker_pid=$!
+  local ready=false
+  for _ in $(seq 1 90); do
+    if curl --fail --silent "http://127.0.0.1:${worker_port}/api/health" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    if ! kill -0 "$worker_pid" >/dev/null 2>&1; then
+      sed -n '1,240p' "$wrangler_raw_log" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  test "$ready" = true
+}
+
+pnpm install --frozen-lockfile >"${output_dir}/dependencies-install.log" 2>&1
+pnpm run build:dashboard >"${output_dir}/build-dashboard.log" 2>&1
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+  -out "${key_dir}/app-private.pem" >/dev/null 2>&1
+
+node docs/proof/parked-review-reconcile/stub-github.mjs \
+  "$github_port" "${output_dir}/github-trace.jsonl" >"$stub_log" 2>&1 &
+stub_pid=$!
+stub_ready=false
+for _ in $(seq 1 50); do
+  if curl --fail --silent "http://127.0.0.1:${github_port}/__proof/status" >/dev/null 2>&1; then
+    stub_ready=true
+    break
+  fi
+  sleep 0.2
+done
+test "$stub_ready" = true
+
+export PARKED_REVIEW_RECONCILE_PROOF_OUTPUT="$output_dir"
+export PARKED_REVIEW_RECONCILE_WORKER_ORIGIN="http://127.0.0.1:${worker_port}"
+export PARKED_REVIEW_RECONCILE_GITHUB_ORIGIN="http://127.0.0.1:${github_port}"
+export PARKED_REVIEW_RECONCILE_WEBHOOK_SECRET="$webhook_secret"
+export PARKED_REVIEW_RECONCILE_OPERATOR_SECRET="$operator_secret"
+export SOURCE_SHA="$(git rev-parse HEAD)"
+
+start_worker true
+node docs/proof/parked-review-reconcile/run-proof.mjs exhaust \
+  | tee "${output_dir}/exhaustion-transcript.log"
+stop_worker
+
+while IFS= read -r candidate; do
+  if test "$(node docs/proof/parked-review-reconcile/assert-durable-object.mjs "$candidate")" = "1"; then
+    queue_db="$candidate"
+    break
+  fi
+done < <(find "$state_dir" -type f -name '*.sqlite' -print)
+if test -z "$queue_db"; then
+  echo "Durable Object did not initialize the parked action table" >&2
+  exit 1
+fi
+printf '%s\n' "Durable Object instantiated: exact_review_queue_parked_actions table present" \
+  >"${output_dir}/durable-object-assertion.txt"
+
+start_worker false
+node docs/proof/parked-review-reconcile/run-proof.mjs reconcile \
+  | tee "${output_dir}/reconcile-transcript.log"
+
+test -s "${output_dir}/proof-summary.json"
+test -s "${output_dir}/parked-inventory-exhausted.json"
+test -s "${output_dir}/parked-operator-inventory.json"
+test -s "${output_dir}/durable-object-assertion.txt"
+echo "PROOF_RC=0"

--- a/docs/proof/parked-review-reconcile/stub-github.mjs
+++ b/docs/proof/parked-review-reconcile/stub-github.mjs
@@ -16,6 +16,7 @@ await writeFile(tracePath, "");
 const issueStates = new Map([
   [114100, "open"],
   [114101, "open"],
+  [114102, "open"],
 ]);
 let rejectDispatch = true;
 let dispatches = 0;
@@ -47,6 +48,9 @@ const server = http.createServer(async (request, response) => {
     if (command.issue_114101_state) {
       issueStates.set(114101, String(command.issue_114101_state));
     }
+    if (command.issue_114102_state) {
+      issueStates.set(114102, String(command.issue_114102_state));
+    }
     return json(response, 200, { ok: true });
   }
   if (/^\/repos\/openclaw\/(?:openclaw|clawsweeper)\/installation$/.test(url.pathname)) {
@@ -58,7 +62,7 @@ const server = http.createServer(async (request, response) => {
   if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
     return json(response, 200, { state: "active" });
   }
-  const issueMatch = /^\/repos\/openclaw\/openclaw\/issues\/(11410[01])$/.exec(url.pathname);
+  const issueMatch = /^\/repos\/openclaw\/openclaw\/issues\/(11410[0-2])$/.exec(url.pathname);
   if (issueMatch) {
     const number = Number(issueMatch[1]);
     return json(response, 200, {

--- a/docs/proof/parked-review-reconcile/stub-github.mjs
+++ b/docs/proof/parked-review-reconcile/stub-github.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+
+const port = Number(process.argv[2]);
+const tracePath = process.argv[3];
+if (!Number.isInteger(port) || !tracePath) {
+  throw new Error("usage: stub-github.mjs <port> <trace-path>");
+}
+
+await mkdir(path.dirname(tracePath), { recursive: true });
+await writeFile(tracePath, "");
+
+const issueStates = new Map([
+  [114100, "open"],
+  [114101, "open"],
+]);
+let rejectDispatch = true;
+let dispatches = 0;
+
+const server = http.createServer(async (request, response) => {
+  const url = new URL(request.url || "/", `http://127.0.0.1:${port}`);
+  const body = await requestBody(request);
+  await appendFile(
+    tracePath,
+    `${JSON.stringify({
+      at: new Date().toISOString(),
+      method: request.method,
+      pathname: url.pathname,
+      reject_dispatch: rejectDispatch,
+    })}\n`,
+  );
+
+  if (url.pathname === "/__proof/status") {
+    return json(response, 200, {
+      ok: true,
+      reject_dispatch: rejectDispatch,
+      dispatches,
+      issues: Object.fromEntries(issueStates),
+    });
+  }
+  if (url.pathname === "/__proof/control" && request.method === "POST") {
+    const command = JSON.parse(body || "{}");
+    if (command.reject_dispatch !== undefined) rejectDispatch = command.reject_dispatch === true;
+    if (command.issue_114101_state) {
+      issueStates.set(114101, String(command.issue_114101_state));
+    }
+    return json(response, 200, { ok: true });
+  }
+  if (/^\/repos\/openclaw\/(?:openclaw|clawsweeper)\/installation$/.test(url.pathname)) {
+    return json(response, 200, { id: 999 });
+  }
+  if (url.pathname === "/app/installations/999/access_tokens" && request.method === "POST") {
+    return json(response, 201, { token: "parked-proof-installation-token" });
+  }
+  if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
+    return json(response, 200, { state: "active" });
+  }
+  const issueMatch = /^\/repos\/openclaw\/openclaw\/issues\/(11410[01])$/.exec(url.pathname);
+  if (issueMatch) {
+    const number = Number(issueMatch[1]);
+    return json(response, 200, {
+      node_id: `ISSUE_${number}`,
+      number,
+      state: issueStates.get(number),
+      repository_url: "https://api.github.com/repos/openclaw/openclaw",
+    });
+  }
+  if (url.pathname === "/repos/openclaw/clawsweeper/dispatches" && request.method === "POST") {
+    dispatches += 1;
+    if (!rejectDispatch) {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    return json(response, 422, {
+      message: "Validation Failed",
+      errors: [{ resource: "RepositoryDispatch", field: "client_payload", code: "invalid" }],
+    });
+  }
+  return json(response, 404, { message: "Not Found" });
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`stub-ready port=${port}\n`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(`${JSON.stringify(value)}\n`);
+}

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -83,6 +83,9 @@ resolves terminal or repository-gone targets with an audit note, and can queue
 at most five fresh reviews with replay-safe recovery keys. Manual runs remain
 read-only unless `execute` is enabled; scheduled runs execute. Their sanitized
 parked inventory is uploaded beside the publication dead-letter inventory.
+Parked records carrying maintainer-command context remain visible with an
+exclusion reason but cannot be resolved or fresh-recovered by this background
+reconciliation path.
 This drains the existing queue state and does not add a dashboard health input
 or an OpenClaw Bay action: Bay remains observer-only.
 GitHub throttle deferrals use the same per-item jitter band when the queue turns

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -76,6 +76,15 @@ pending work instead of building a duplicate queue. Durable exact-review leases
 use lease-scoped workflow groups and remain owned by the Worker admission lane.
 Recoverable parked reviews use the nominal 5/10/20-minute retry ladder, but
 each item persists a schedule-time uniform jitter of 0.75-1.5x for every rung.
+After the third automatic recovery, operator-only HMAC-signed routes provide a
+bounded parked-review inventory and guarded resolution/fresh-recovery path. The
+five-minute dead-letter reconcile workflow inspects at most 100 parked targets,
+resolves terminal or repository-gone targets with an audit note, and can queue
+at most five fresh reviews with replay-safe recovery keys. Manual runs remain
+read-only unless `execute` is enabled; scheduled runs execute. Their sanitized
+parked inventory is uploaded beside the publication dead-letter inventory.
+This drains the existing queue state and does not add a dashboard health input
+or an OpenClaw Bay action: Bay remains observer-only.
 GitHub throttle deferrals use the same per-item jitter band when the queue turns
 the reported cooldown into its next-attempt timestamp, preventing a parked
 cohort from becoming eligible in lockstep; coordination and ordinary failure

--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -19,6 +19,8 @@ const MAX_RECONCILE_INVENTORY_REFRESHES = 2;
 const GRAPHQL_IDENTITY_BATCH_SIZE = 40;
 const ACTIVE_RECOVERY_REASONS = new Set(["fresh_review_already_active", "publication_item_active"]);
 const IDEMPOTENCY_KEY = /^[A-Za-z0-9:._-]{1,200}$/;
+const OPERATOR_REQUEST_TIMEOUT_MS = 20_000;
+const OPERATOR_DEADLINE_SETTLE_MS = 25;
 
 class DeadLetterInventoryChangedError extends Error {
   constructor(summary, rowIds, targetKeys, blockedGroups) {
@@ -62,14 +64,16 @@ async function main(argv) {
   }
 
   if (args.action === "reconcile-parked") {
+    const deadlineAt = parkedReconcileDeadlineAt();
     const inventory = await loadParkedReviewInventory({
       queueUrl,
       secret,
       maxRows: args.maxTargets,
+      deadlineAt,
     });
     await mkdir(dirname(resolve(args.output)), { recursive: true });
     await writeFile(args.output, `${JSON.stringify(inventory, null, 2)}\n`, "utf8");
-    await reconcileParkedReviews({ inventory, queueUrl, secret, args });
+    await reconcileParkedReviews({ inventory, queueUrl, secret, args, deadlineAt });
     return;
   }
 
@@ -668,8 +672,10 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
   printResult(summary);
 }
 
-async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
-  const pressure = await readQueuePressure(queueUrl);
+async function reconcileParkedReviews({ inventory, queueUrl, secret, args, deadlineAt }) {
+  const pressure = parkedReconcileDeadlineReached(deadlineAt)
+    ? { status: "unknown", availableSlots: 0 }
+    : await readQueuePressure(queueUrl, deadlineAt);
   const summary = {
     action: "reconcile-parked",
     dry_run: !args.execute,
@@ -683,14 +689,32 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
     recovered_targets: 0,
     skipped_targets: 0,
   };
+  const stopForDeadline = (skippedTargets) => {
+    summary.deadline_reached = true;
+    summary.skipped_targets += skippedTargets;
+    printResult(summary);
+  };
   const terminal = [];
   const recoverable = [];
-  for (const row of inventory.parked_reviews.slice(0, args.maxTargets)) {
+  const selectedRows = inventory.parked_reviews.slice(0, args.maxTargets);
+  if (inventory.deadline_reached || parkedReconcileDeadlineReached(deadlineAt)) {
+    stopForDeadline(selectedRows.length);
+    return;
+  }
+  for (const [index, row] of selectedRows.entries()) {
+    if (parkedReconcileDeadlineReached(deadlineAt)) {
+      stopForDeadline(selectedRows.length - index + terminal.length + recoverable.length);
+      return;
+    }
     summary.inspected_targets += 1;
     let target;
     try {
-      target = await inspectParkedReviewTarget(`${row.target_repo}#${row.item_number}`);
+      target = await inspectParkedReviewTarget(`${row.target_repo}#${row.item_number}`, deadlineAt);
     } catch {
+      if (parkedReconcileDeadlineReached(deadlineAt)) {
+        stopForDeadline(selectedRows.length - index + terminal.length + recoverable.length);
+        return;
+      }
       summary.skipped_targets += 1;
       continue;
     }
@@ -707,15 +731,23 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
     }
   }
 
-  for (const candidate of terminal) {
+  for (const [index, candidate] of terminal.entries()) {
+    if (parkedReconcileDeadlineReached(deadlineAt)) {
+      stopForDeadline(terminal.length - index + recoverable.length);
+      return;
+    }
     if (!args.execute) {
       summary.resolved_targets += 1;
       continue;
     }
     let current;
     try {
-      current = await inspectParkedReviewTarget(candidate.target.requested_target);
+      current = await inspectParkedReviewTarget(candidate.target.requested_target, deadlineAt);
     } catch {
+      if (parkedReconcileDeadlineReached(deadlineAt)) {
+        stopForDeadline(terminal.length - index + recoverable.length);
+        return;
+      }
       summary.skipped_targets += 1;
       continue;
     }
@@ -723,18 +755,28 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
       summary.skipped_targets += 1;
       continue;
     }
-    const result = await signedPost({
-      queueUrl,
-      secret,
-      path: "/internal/exact-review/parked-reviews/resolve",
-      payload: {
-        items: [parkedMutationItem(candidate.row)],
-        note:
-          current.state === "repository_gone"
-            ? `automatic reconciliation: repository for ${current.requested_target} no longer exists`
-            : `automatic reconciliation: GitHub target ${current.canonical_target} is terminal`,
-      },
-    });
+    let result;
+    try {
+      result = await signedPost({
+        queueUrl,
+        secret,
+        path: "/internal/exact-review/parked-reviews/resolve",
+        payload: {
+          items: [parkedMutationItem(candidate.row)],
+          note:
+            current.state === "repository_gone"
+              ? `automatic reconciliation: repository for ${current.requested_target} no longer exists`
+              : `automatic reconciliation: GitHub target ${current.canonical_target} is terminal`,
+        },
+        deadlineAt,
+      });
+    } catch (error) {
+      if (parkedReconcileDeadlineReached(deadlineAt)) {
+        stopForDeadline(terminal.length - index + recoverable.length);
+        return;
+      }
+      throw error;
+    }
     summary.resolved_targets += requiredCount(result, "resolved");
     summary.skipped_targets += requiredCount(result, "skipped");
   }
@@ -742,11 +784,21 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
   if (recoverable.length && pressure.status === "idle") {
     const available = Math.min(args.maxRecoveries, pressure.availableSlots);
     const admitted = [];
-    for (const candidate of recoverable.slice(0, available)) {
+    const selectedRecoveries = recoverable.slice(0, available);
+    summary.skipped_targets += recoverable.length - selectedRecoveries.length;
+    for (const [index, candidate] of selectedRecoveries.entries()) {
+      if (parkedReconcileDeadlineReached(deadlineAt)) {
+        stopForDeadline(admitted.length + selectedRecoveries.length - index);
+        return;
+      }
       let current;
       try {
-        current = await inspectParkedReviewTarget(candidate.target.requested_target);
+        current = await inspectParkedReviewTarget(candidate.target.requested_target, deadlineAt);
       } catch {
+        if (parkedReconcileDeadlineReached(deadlineAt)) {
+          stopForDeadline(admitted.length + selectedRecoveries.length - index);
+          return;
+        }
         summary.skipped_targets += 1;
         continue;
       }
@@ -756,23 +808,36 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
       }
       admitted.push(candidate.row);
     }
-    summary.skipped_targets += recoverable.length - Math.min(recoverable.length, available);
     if (!args.execute) {
       summary.recovered_targets += admitted.length;
     } else if (admitted.length) {
+      if (parkedReconcileDeadlineReached(deadlineAt)) {
+        stopForDeadline(admitted.length);
+        return;
+      }
       const identity = admitted
         .map((row) => `${row.item_key}:${row.revision}:${row.updated_at_ms}`)
         .sort()
         .join("\n");
-      const result = await signedPost({
-        queueUrl,
-        secret,
-        path: "/internal/exact-review/parked-reviews/recover-fresh",
-        payload: {
-          items: admitted.map(parkedMutationItem),
-          idempotency_key: `parked-reconcile:${createHash("sha256").update(identity).digest("hex")}`,
-        },
-      });
+      let result;
+      try {
+        result = await signedPost({
+          queueUrl,
+          secret,
+          path: "/internal/exact-review/parked-reviews/recover-fresh",
+          payload: {
+            items: admitted.map(parkedMutationItem),
+            idempotency_key: `parked-reconcile:${createHash("sha256").update(identity).digest("hex")}`,
+          },
+          deadlineAt,
+        });
+      } catch (error) {
+        if (parkedReconcileDeadlineReached(deadlineAt)) {
+          stopForDeadline(admitted.length);
+          return;
+        }
+        throw error;
+      }
       summary.recovered_targets +=
         requiredCount(result, "recovered") + requiredCount(result, "deduped");
       summary.skipped_targets += requiredCount(result, "skipped");
@@ -783,18 +848,31 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
   printResult(summary);
 }
 
-async function loadParkedReviewInventory({ queueUrl, secret, maxRows }) {
+async function loadParkedReviewInventory({ queueUrl, secret, maxRows, deadlineAt }) {
   const rows = [];
   let cursor = "";
   let complete = false;
+  let deadlineReached = false;
   while (rows.length < maxRows) {
+    if (parkedReconcileDeadlineReached(deadlineAt)) {
+      deadlineReached = true;
+      break;
+    }
     const limit = Math.min(MAX_PARKED_INVENTORY_PAGE_SIZE, maxRows - rows.length);
-    const page = await signedPost({
-      queueUrl,
-      secret,
-      path: "/internal/exact-review/parked-reviews/list",
-      payload: { limit, ...(cursor ? { cursor } : {}) },
-    });
+    let page;
+    try {
+      page = await signedPost({
+        queueUrl,
+        secret,
+        path: "/internal/exact-review/parked-reviews/list",
+        payload: { limit, ...(cursor ? { cursor } : {}) },
+        deadlineAt,
+      });
+    } catch (error) {
+      if (!parkedReconcileDeadlineReached(deadlineAt)) throw error;
+      deadlineReached = true;
+      break;
+    }
     const pageRows = Array.isArray(page.parked_reviews) ? page.parked_reviews : [];
     rows.push(...pageRows.map(sanitizeParkedReviewRow));
     cursor = String(page.next_cursor || "");
@@ -807,6 +885,7 @@ async function loadParkedReviewInventory({ queueUrl, secret, maxRows }) {
   return {
     generated_at: new Date().toISOString(),
     complete,
+    ...(deadlineReached ? { deadline_reached: true } : {}),
     next_cursor: complete ? null : cursor,
     summary: {
       rows: rows.length,
@@ -854,7 +933,31 @@ function parkedMutationItem(row) {
   return { item_key: row.item_key, revision: row.revision, updated_at_ms: row.updated_at_ms };
 }
 
-async function inspectParkedReviewTarget(target) {
+function parkedReconcileDeadlineAt() {
+  const raw = String(process.env.EXACT_REVIEW_RECONCILE_DEADLINE_MS || "").trim();
+  if (!raw) return Number.POSITIVE_INFINITY;
+  const deadlineAt = Number(raw);
+  if (!Number.isSafeInteger(deadlineAt) || deadlineAt < 1) {
+    throw new Error("EXACT_REVIEW_RECONCILE_DEADLINE_MS must be a positive epoch millisecond");
+  }
+  return deadlineAt;
+}
+
+function parkedReconcileDeadlineReached(deadlineAt) {
+  return Number.isFinite(deadlineAt) && Date.now() + OPERATOR_DEADLINE_SETTLE_MS >= deadlineAt;
+}
+
+function operatorRequestSignal(deadlineAt = Number.POSITIVE_INFINITY) {
+  if (parkedReconcileDeadlineReached(deadlineAt)) {
+    throw new Error("exact-review reconciliation deadline reached");
+  }
+  const remaining = Number.isFinite(deadlineAt)
+    ? Math.max(1, deadlineAt - Date.now())
+    : OPERATOR_REQUEST_TIMEOUT_MS;
+  return AbortSignal.timeout(Math.min(OPERATOR_REQUEST_TIMEOUT_MS, remaining));
+}
+
+async function inspectParkedReviewTarget(target, deadlineAt = Number.POSITIVE_INFINITY) {
   const apiUrl = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
   const token = String(process.env.GITHUB_TOKEN || "");
   const match = /^([^/]+)\/([^#]+)#([1-9]\d*)$/.exec(target);
@@ -867,12 +970,12 @@ async function inspectParkedReviewTarget(target) {
   };
   const response = await fetch(
     `${apiUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${number}`,
-    { headers, signal: AbortSignal.timeout(20_000) },
+    { headers, signal: operatorRequestSignal(deadlineAt) },
   );
   if (response.status === 404) {
     const repository = await fetch(
       `${apiUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
-      { headers, signal: AbortSignal.timeout(20_000) },
+      { headers, signal: operatorRequestSignal(deadlineAt) },
     );
     if (repository.status === 404) {
       return {
@@ -901,11 +1004,11 @@ async function inspectParkedReviewTarget(target) {
   };
 }
 
-async function readQueuePressure(queueUrl) {
+async function readQueuePressure(queueUrl, deadlineAt = Number.POSITIVE_INFINITY) {
   try {
     const response = await fetch(`${queueUrl}/api/exact-review-queue`, {
       cache: "no-store",
-      signal: AbortSignal.timeout(20_000),
+      signal: operatorRequestSignal(deadlineAt),
     });
     if (!response.ok || response.headers.get("x-clawsweeper-cache") === "stale") {
       return { status: "unknown", availableSlots: 0 };
@@ -1165,7 +1268,13 @@ function countBy(rows, keyFor) {
   );
 }
 
-async function signedPost({ queueUrl, secret, path, payload }) {
+async function signedPost({
+  queueUrl,
+  secret,
+  path,
+  payload,
+  deadlineAt = Number.POSITIVE_INFINITY,
+}) {
   const body = JSON.stringify(payload);
   const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
   const response = await fetch(`${queueUrl}${path}`, {
@@ -1175,7 +1284,7 @@ async function signedPost({ queueUrl, secret, path, payload }) {
       "x-clawsweeper-exact-review-signature": signature,
     },
     body,
-    signal: AbortSignal.timeout(20_000),
+    signal: operatorRequestSignal(deadlineAt),
   });
   const text = await response.text();
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);

--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -761,7 +761,7 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
       summary.recovered_targets += admitted.length;
     } else if (admitted.length) {
       const identity = admitted
-        .map((row) => `${row.item_key}:${row.updated_at_ms}`)
+        .map((row) => `${row.item_key}:${row.revision}:${row.updated_at_ms}`)
         .sort()
         .join("\n");
       const result = await signedPost({
@@ -819,11 +819,14 @@ async function loadParkedReviewInventory({ queueUrl, secret, maxRows }) {
 function sanitizeParkedReviewRow(row) {
   const value = row && typeof row === "object" ? row : {};
   const itemKey = String(value.item_key || "");
+  const revision = Number(value.revision);
   const targetRepo = String(value.target_repo || "");
   const itemNumber = Number(value.item_number);
   const updatedAtMs = Number(value.updated_at_ms);
   if (
     !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
+    !Number.isSafeInteger(revision) ||
+    revision < 1 ||
     !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
     !Number.isSafeInteger(itemNumber) ||
     itemNumber < 1 ||
@@ -834,6 +837,7 @@ function sanitizeParkedReviewRow(row) {
   }
   return {
     item_key: itemKey,
+    revision,
     target_repo: targetRepo,
     item_number: itemNumber,
     item_kind: String(value.item_kind || ""),
@@ -847,7 +851,7 @@ function sanitizeParkedReviewRow(row) {
 }
 
 function parkedMutationItem(row) {
-  return { item_key: row.item_key, updated_at_ms: row.updated_at_ms };
+  return { item_key: row.item_key, revision: row.revision, updated_at_ms: row.updated_at_ms };
 }
 
 async function inspectParkedReviewTarget(target) {

--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -9,6 +9,8 @@ const DEFAULT_OUTPUT = ".artifacts/exact-review-dlq/inventory.json";
 const MAX_SELECTED_IDS = 2;
 const MAX_RECONCILE_TARGETS = 100;
 const MAX_RECONCILE_RECOVERIES = 10;
+const MAX_PARKED_RECONCILE_RECOVERIES = 5;
+const MAX_PARKED_INVENTORY_PAGE_SIZE = 50;
 const MAX_TERMINAL_TARGET_RECHECKS = 10;
 const MAX_RESOLUTION_IDS = 20;
 const MAX_INVENTORY_ROWS = 10_000;
@@ -30,7 +32,7 @@ class DeadLetterInventoryChangedError extends Error {
 }
 
 const HELP = `Usage:
-  node scripts/exact-review-dead-letter-operator.mjs --action <inventory|recover-fresh|resolve|reconcile> [options]
+  node scripts/exact-review-dead-letter-operator.mjs --action <inventory|recover-fresh|resolve|reconcile|reconcile-parked> [options]
 
 Options:
   --action <action>             Required operator action
@@ -38,7 +40,7 @@ Options:
   --idempotency-key <key>       Required for recover-fresh
   --note <text>                 Required for resolve
   --max-targets <count>         Reconcile at most 1-100 canonical targets (default 100)
-  --max-recoveries <count>      Queue at most 0-10 fresh reviews (default 10)
+  --max-recoveries <count>      Queue at most 0-10 DLQ or 0-5 parked reviews (default 10)
   --execute                     Apply the selected mutation; otherwise preview only
   --output <path>               Inventory artifact path
   -h, --help                    Show this help
@@ -57,6 +59,18 @@ async function main(argv) {
   const secret = String(process.env.CLAWSWEEPER_WEBHOOK_SECRET || "");
   if (!queueUrl || !secret) {
     throw new Error("EXACT_REVIEW_QUEUE_URL and CLAWSWEEPER_WEBHOOK_SECRET are required");
+  }
+
+  if (args.action === "reconcile-parked") {
+    const inventory = await loadParkedReviewInventory({
+      queueUrl,
+      secret,
+      maxRows: args.maxTargets,
+    });
+    await mkdir(dirname(resolve(args.output)), { recursive: true });
+    await writeFile(args.output, `${JSON.stringify(inventory, null, 2)}\n`, "utf8");
+    await reconcileParkedReviews({ inventory, queueUrl, secret, args });
+    return;
   }
 
   let inventory = await loadInventory({
@@ -215,6 +229,7 @@ function parseArgs(argv) {
     execute: false,
     maxTargets: MAX_RECONCILE_TARGETS,
     maxRecoveries: MAX_RECONCILE_RECOVERIES,
+    maxRecoveriesProvided: false,
     output: DEFAULT_OUTPUT,
     help: false,
   };
@@ -234,6 +249,7 @@ function parseArgs(argv) {
     else if (value === "--max-targets") {
       args.maxTargets = boundedInteger(argv[++index], "--max-targets", 1, MAX_RECONCILE_TARGETS);
     } else if (value === "--max-recoveries") {
+      args.maxRecoveriesProvided = true;
       args.maxRecoveries = boundedInteger(
         argv[++index],
         "--max-recoveries",
@@ -244,11 +260,29 @@ function parseArgs(argv) {
     else throw new Error(`unknown option ${value}; use --help`);
   }
   if (args.help) return args;
-  if (!["inventory", "recover-fresh", "resolve", "reconcile"].includes(args.action)) {
-    throw new Error("--action must be inventory, recover-fresh, resolve, or reconcile");
+  if (
+    !["inventory", "recover-fresh", "resolve", "reconcile", "reconcile-parked"].includes(
+      args.action,
+    )
+  ) {
+    throw new Error(
+      "--action must be inventory, recover-fresh, resolve, reconcile, or reconcile-parked",
+    );
   }
   if (!args.output) throw new Error("--output is required");
-  if (args.action !== "inventory" && args.action !== "reconcile") {
+  if (args.action === "reconcile-parked" && !args.maxRecoveriesProvided) {
+    args.maxRecoveries = MAX_PARKED_RECONCILE_RECOVERIES;
+  }
+  if (args.action === "reconcile-parked" && args.maxRecoveries > MAX_PARKED_RECONCILE_RECOVERIES) {
+    throw new Error(
+      `--max-recoveries must be between 0 and ${MAX_PARKED_RECONCILE_RECOVERIES} for reconcile-parked`,
+    );
+  }
+  if (
+    args.action !== "inventory" &&
+    args.action !== "reconcile" &&
+    args.action !== "reconcile-parked"
+  ) {
     if (args.ids.length < 1 || args.ids.length > MAX_SELECTED_IDS) {
       throw new Error(`mutation actions require between 1 and ${MAX_SELECTED_IDS} --ids`);
     }
@@ -632,6 +666,235 @@ async function reconcileDeadLetters({ inventory, queueUrl, secret, args, progres
     }
   }
   printResult(summary);
+}
+
+async function reconcileParkedReviews({ inventory, queueUrl, secret, args }) {
+  const pressure = await readQueuePressure(queueUrl);
+  const summary = {
+    action: "reconcile-parked",
+    dry_run: !args.execute,
+    inventory_complete: inventory.complete,
+    queue_pressure: pressure.status,
+    inspected_targets: 0,
+    terminal_targets: 0,
+    repository_gone_targets: 0,
+    resolved_targets: 0,
+    open_targets: 0,
+    recovered_targets: 0,
+    skipped_targets: 0,
+  };
+  const terminal = [];
+  const recoverable = [];
+  for (const row of inventory.parked_reviews.slice(0, args.maxTargets)) {
+    summary.inspected_targets += 1;
+    let target;
+    try {
+      target = await inspectParkedReviewTarget(`${row.target_repo}#${row.item_number}`);
+    } catch {
+      summary.skipped_targets += 1;
+      continue;
+    }
+    if (target.state === "closed" || target.state === "repository_gone") {
+      terminal.push({ row, target });
+      summary.terminal_targets += 1;
+      if (target.state === "repository_gone") summary.repository_gone_targets += 1;
+    } else if (target.state === "open") {
+      summary.open_targets += 1;
+      if (recoverable.length < args.maxRecoveries) recoverable.push({ row, target });
+      else summary.skipped_targets += 1;
+    } else {
+      summary.skipped_targets += 1;
+    }
+  }
+
+  for (const candidate of terminal) {
+    if (!args.execute) {
+      summary.resolved_targets += 1;
+      continue;
+    }
+    let current;
+    try {
+      current = await inspectParkedReviewTarget(candidate.target.requested_target);
+    } catch {
+      summary.skipped_targets += 1;
+      continue;
+    }
+    if (current.state !== candidate.target.state) {
+      summary.skipped_targets += 1;
+      continue;
+    }
+    const result = await signedPost({
+      queueUrl,
+      secret,
+      path: "/internal/exact-review/parked-reviews/resolve",
+      payload: {
+        items: [parkedMutationItem(candidate.row)],
+        note:
+          current.state === "repository_gone"
+            ? `automatic reconciliation: repository for ${current.requested_target} no longer exists`
+            : `automatic reconciliation: GitHub target ${current.canonical_target} is terminal`,
+      },
+    });
+    summary.resolved_targets += requiredCount(result, "resolved");
+    summary.skipped_targets += requiredCount(result, "skipped");
+  }
+
+  if (recoverable.length && pressure.status === "idle") {
+    const available = Math.min(args.maxRecoveries, pressure.availableSlots);
+    const admitted = [];
+    for (const candidate of recoverable.slice(0, available)) {
+      let current;
+      try {
+        current = await inspectParkedReviewTarget(candidate.target.requested_target);
+      } catch {
+        summary.skipped_targets += 1;
+        continue;
+      }
+      if (current.state !== "open" || current.node_id !== candidate.target.node_id) {
+        summary.skipped_targets += 1;
+        continue;
+      }
+      admitted.push(candidate.row);
+    }
+    summary.skipped_targets += recoverable.length - Math.min(recoverable.length, available);
+    if (!args.execute) {
+      summary.recovered_targets += admitted.length;
+    } else if (admitted.length) {
+      const identity = admitted
+        .map((row) => `${row.item_key}:${row.updated_at_ms}`)
+        .sort()
+        .join("\n");
+      const result = await signedPost({
+        queueUrl,
+        secret,
+        path: "/internal/exact-review/parked-reviews/recover-fresh",
+        payload: {
+          items: admitted.map(parkedMutationItem),
+          idempotency_key: `parked-reconcile:${createHash("sha256").update(identity).digest("hex")}`,
+        },
+      });
+      summary.recovered_targets +=
+        requiredCount(result, "recovered") + requiredCount(result, "deduped");
+      summary.skipped_targets += requiredCount(result, "skipped");
+    }
+  } else {
+    summary.skipped_targets += recoverable.length;
+  }
+  printResult(summary);
+}
+
+async function loadParkedReviewInventory({ queueUrl, secret, maxRows }) {
+  const rows = [];
+  let cursor = "";
+  let complete = false;
+  while (rows.length < maxRows) {
+    const limit = Math.min(MAX_PARKED_INVENTORY_PAGE_SIZE, maxRows - rows.length);
+    const page = await signedPost({
+      queueUrl,
+      secret,
+      path: "/internal/exact-review/parked-reviews/list",
+      payload: { limit, ...(cursor ? { cursor } : {}) },
+    });
+    const pageRows = Array.isArray(page.parked_reviews) ? page.parked_reviews : [];
+    rows.push(...pageRows.map(sanitizeParkedReviewRow));
+    cursor = String(page.next_cursor || "");
+    if (!cursor) {
+      complete = true;
+      break;
+    }
+    if (!pageRows.length) throw new Error("parked review inventory cursor did not advance");
+  }
+  return {
+    generated_at: new Date().toISOString(),
+    complete,
+    next_cursor: complete ? null : cursor,
+    summary: {
+      rows: rows.length,
+      by_reason: countBy(rows, (row) => row.parked_reason || "unknown"),
+    },
+    parked_reviews: rows,
+  };
+}
+
+function sanitizeParkedReviewRow(row) {
+  const value = row && typeof row === "object" ? row : {};
+  const itemKey = String(value.item_key || "");
+  const targetRepo = String(value.target_repo || "");
+  const itemNumber = Number(value.item_number);
+  const updatedAtMs = Number(value.updated_at_ms);
+  if (
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
+    !Number.isSafeInteger(itemNumber) ||
+    itemNumber < 1 ||
+    !Number.isSafeInteger(updatedAtMs) ||
+    updatedAtMs < 1
+  ) {
+    throw new Error("parked review inventory returned an invalid row");
+  }
+  return {
+    item_key: itemKey,
+    target_repo: targetRepo,
+    item_number: itemNumber,
+    item_kind: String(value.item_kind || ""),
+    parked_reason: String(value.parked_reason || "") || null,
+    parked_recovery_attempts: Number(value.parked_recovery_attempts || 0),
+    first_failed_at: value.first_failed_at ? String(value.first_failed_at) : null,
+    last_failure_reason: String(value.last_failure_reason || "") || null,
+    updated_at: String(value.updated_at || ""),
+    updated_at_ms: updatedAtMs,
+  };
+}
+
+function parkedMutationItem(row) {
+  return { item_key: row.item_key, updated_at_ms: row.updated_at_ms };
+}
+
+async function inspectParkedReviewTarget(target) {
+  const apiUrl = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
+  const token = String(process.env.GITHUB_TOKEN || "");
+  const match = /^([^/]+)\/([^#]+)#([1-9]\d*)$/.exec(target);
+  if (!match) throw new Error(`invalid parked review target: ${target}`);
+  const [, owner, repo, number] = match;
+  const headers = {
+    accept: "application/vnd.github+json",
+    "user-agent": "clawsweeper-parked-review-operator",
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+  const response = await fetch(
+    `${apiUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${number}`,
+    { headers, signal: AbortSignal.timeout(20_000) },
+  );
+  if (response.status === 404) {
+    const repository = await fetch(
+      `${apiUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+      { headers, signal: AbortSignal.timeout(20_000) },
+    );
+    if (repository.status === 404) {
+      return {
+        state: "repository_gone",
+        requested_target: normalizeRecoveryTargetKey(target),
+        canonical_target: normalizeRecoveryTargetKey(target),
+        node_id: null,
+      };
+    }
+    throw new Error(`parked review target is missing from an existing repository: ${target}`);
+  }
+  if (!response.ok) throw new Error(`parked review target check failed for ${target}`);
+  const item = await response.json();
+  if (
+    typeof item?.node_id !== "string" ||
+    !item.node_id ||
+    !["open", "closed"].includes(String(item.state || "").toLowerCase())
+  ) {
+    throw new Error(`parked review target check returned an invalid identity for ${target}`);
+  }
+  return {
+    state: String(item.state).toLowerCase(),
+    requested_target: normalizeRecoveryTargetKey(target),
+    canonical_target: canonicalGitHubTarget(item, target),
+    node_id: item.node_id,
+  };
 }
 
 async function readQueuePressure(queueUrl) {

--- a/scripts/exact-review-dead-letter-operator.mjs
+++ b/scripts/exact-review-dead-letter-operator.mjs
@@ -702,6 +702,10 @@ async function reconcileParkedReviews({ inventory, queueUrl, secret, args, deadl
     return;
   }
   for (const [index, row] of selectedRows.entries()) {
+    if (row.excluded_reason) {
+      summary.skipped_targets += 1;
+      continue;
+    }
     if (parkedReconcileDeadlineReached(deadlineAt)) {
       stopForDeadline(selectedRows.length - index + terminal.length + recoverable.length);
       return;
@@ -902,6 +906,8 @@ function sanitizeParkedReviewRow(row) {
   const targetRepo = String(value.target_repo || "");
   const itemNumber = Number(value.item_number);
   const updatedAtMs = Number(value.updated_at_ms);
+  const excludedReason =
+    value.excluded_reason === undefined ? null : String(value.excluded_reason || "");
   if (
     !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[1-9]\d*$/.test(itemKey) ||
     !Number.isSafeInteger(revision) ||
@@ -910,7 +916,8 @@ function sanitizeParkedReviewRow(row) {
     !Number.isSafeInteger(itemNumber) ||
     itemNumber < 1 ||
     !Number.isSafeInteger(updatedAtMs) ||
-    updatedAtMs < 1
+    updatedAtMs < 1 ||
+    (excludedReason !== null && excludedReason !== "command_context")
   ) {
     throw new Error("parked review inventory returned an invalid row");
   }
@@ -920,6 +927,7 @@ function sanitizeParkedReviewRow(row) {
     target_repo: targetRepo,
     item_number: itemNumber,
     item_kind: String(value.item_kind || ""),
+    excluded_reason: excludedReason,
     parked_reason: String(value.parked_reason || "") || null,
     parked_recovery_attempts: Number(value.parked_recovery_attempts || 0),
     first_failed_at: value.first_failed_at ? String(value.first_failed_at) : null,

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3342,7 +3342,7 @@ test("scheduled review feed is lane-paced and exposes its configured target", as
 test("scheduled untracked reviews are ready and claimable within one tick when 122 slots are free", async () => {
   const storage = new MemoryDurableStorage();
   const active = Object.fromEntries(
-    Array.from({ length: 7 }, (_, index) => {
+    Array.from({ length: 6 }, (_, index) => {
       const item = leasedExactReviewQueueItem(120_000 + index, String(120_000 + index));
       return [item.key, item];
     }),

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3776,6 +3776,65 @@ test("fresh dead-letter recovery is available only through the signed internal r
   });
 });
 
+test("parked review inventory and mutations require the operator signature", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: "test-token-placeholder",
+    EXACT_REVIEW_OPERATOR_SECRET: "operator-token-placeholder",
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const requests = [
+    { path: "list", payload: { limit: 5 } },
+    {
+      path: "resolve",
+      payload: {
+        items: [{ item_key: "openclaw/gogcli#1", updated_at_ms: 1 }],
+        note: "terminal target",
+      },
+    },
+    {
+      path: "recover-fresh",
+      payload: {
+        items: [{ item_key: "openclaw/gogcli#1", updated_at_ms: 1 }],
+        idempotency_key: "parked-reconcile:test",
+      },
+    },
+  ];
+  for (const { path, payload } of requests) {
+    const body = JSON.stringify(payload);
+    const url = `https://clawsweeper.openclaw.ai/internal/exact-review/parked-reviews/${path}`;
+    assert.equal((await worker.fetch(new Request(url, { method: "POST", body }), env)).status, 401);
+    const sharedSignature = `sha256=${createHmac("sha256", "test-token-placeholder").update(body).digest("hex")}`;
+    assert.equal(
+      (
+        await worker.fetch(
+          new Request(url, {
+            method: "POST",
+            headers: { "x-clawsweeper-exact-review-signature": sharedSignature },
+            body,
+          }),
+          env,
+        )
+      ).status,
+      401,
+    );
+    const operatorSignature = `sha256=${createHmac("sha256", "operator-token-placeholder").update(body).digest("hex")}`;
+    assert.equal(
+      (
+        await worker.fetch(
+          new Request(url, {
+            method: "POST",
+            headers: { "x-clawsweeper-exact-review-signature": operatorSignature },
+            body,
+          }),
+          env,
+        )
+      ).status,
+      200,
+    );
+  }
+});
+
 test("direct publication endpoint authenticates, dedupes, and returns a structured 413", async () => {
   const storage = new MemoryDurableStorage();
   const leased = leasedExactReviewQueueItem(701, "7010");
@@ -16205,6 +16264,176 @@ test("exact-review queue removes a terminal dispatch rejection after parked reco
   } finally {
     harness.restore();
   }
+});
+
+test("parked review operator routes paginate, resolve, and recover idempotently within caps", async () => {
+  const storage = new MemoryDurableStorage();
+  const now = Date.parse("2026-08-10T12:00:00.000Z");
+  const items = Object.fromEntries(
+    Array.from({ length: 6 }, (_, index) => {
+      const item = leasedExactReviewQueueItem(114_000 + index, `91400${index}`);
+      item.state = "parked";
+      item.parkedReason = "review_retry_exhausted";
+      item.parkedRecoveryAttempts = 3;
+      item.parkedRecoveryAt = undefined;
+      item.attempts = 8;
+      item.reviewFailureAttempts = 8;
+      item.firstFailureAt = now - 60_000;
+      item.updatedAt = now + index;
+      return [item.key, item];
+    }),
+  );
+  await storage.put("exact-review-queue", { deliveries: {}, items });
+  const queue = new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0", EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "10" },
+  );
+
+  const first = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/parked-reviews/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 2 }),
+      }),
+    )
+  ).json();
+  assert.equal(first.parked_reviews.length, 2);
+  assert.equal(first.parked_reviews[0].item_key, "openclaw/openclaw#114000");
+  assert.deepEqual(
+    Object.keys(first.parked_reviews[0]).sort(),
+    [
+      "first_failed_at",
+      "item_key",
+      "item_kind",
+      "last_failure_reason",
+      "parked_reason",
+      "parked_recovery_attempts",
+      "target_repo",
+      "item_number",
+      "updated_at",
+      "updated_at_ms",
+    ].sort(),
+  );
+  assert.equal(first.parked_reviews[0].parked_recovery_attempts, 3);
+  assert.equal(first.parked_reviews[0].last_failure_reason, "review_retry_exhausted");
+  assert.equal(first.next_cursor, "openclaw/openclaw#114001");
+
+  const second = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/parked-reviews/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 2, cursor: first.next_cursor }),
+      }),
+    )
+  ).json();
+  assert.deepEqual(
+    second.parked_reviews.map((item) => item.item_key),
+    ["openclaw/openclaw#114002", "openclaw/openclaw#114003"],
+  );
+
+  const terminal = first.parked_reviews[0];
+  const resolved = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/parked-reviews/resolve", {
+      method: "POST",
+      body: JSON.stringify({
+        items: [{ item_key: terminal.item_key, updated_at_ms: terminal.updated_at_ms }],
+        note: "automatic reconciliation: terminal test target",
+      }),
+    }),
+  );
+  assert.deepEqual(await resolved.json(), { ok: true, resolved: 1, skipped: 0 });
+
+  const recoverable = first.parked_reviews[1];
+  const recoveryPayload = {
+    items: [{ item_key: recoverable.item_key, updated_at_ms: recoverable.updated_at_ms }],
+    idempotency_key: "parked-reconcile:test:114001",
+  };
+  const recover = () =>
+    queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/parked-reviews/recover-fresh", {
+        method: "POST",
+        body: JSON.stringify(recoveryPayload),
+      }),
+    );
+  assert.deepEqual(await (await recover()).json(), {
+    ok: true,
+    recovered: 1,
+    deduped: 0,
+    skipped: 0,
+  });
+  assert.deepEqual(await (await recover()).json(), {
+    ok: true,
+    recovered: 0,
+    deduped: 1,
+    skipped: 0,
+  });
+  const state = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      {
+        state: string;
+        attempts: number;
+        reviewFailureAttempts?: number;
+        parkedReason?: string;
+        parkedRecoveryAttempts?: number;
+      }
+    >;
+  };
+  assert.equal(state.items[terminal.item_key], undefined);
+  assert.equal(state.items[recoverable.item_key].state, "pending");
+  assert.equal(state.items[recoverable.item_key].attempts, 0);
+  assert.equal(state.items[recoverable.item_key].reviewFailureAttempts, 0);
+  assert.equal(state.items[recoverable.item_key].parkedReason, undefined);
+  assert.equal(state.items[recoverable.item_key].parkedRecoveryAttempts, 0);
+
+  assert.equal(
+    (
+      await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/parked-reviews/list", {
+          method: "POST",
+          body: JSON.stringify({ limit: 51 }),
+        }),
+      )
+    ).status,
+    400,
+  );
+  assert.equal(
+    (
+      await queue.fetch(
+        new Request("https://clawsweeper-exact-review-queue/parked-reviews/recover-fresh", {
+          method: "POST",
+          body: JSON.stringify({
+            items: second.parked_reviews
+              .concat([
+                {
+                  ...second.parked_reviews[0],
+                  item_key: "openclaw/openclaw#114004",
+                  updated_at_ms: now + 4,
+                },
+                {
+                  ...second.parked_reviews[0],
+                  item_key: "openclaw/openclaw#114005",
+                  updated_at_ms: now + 5,
+                },
+                {
+                  ...second.parked_reviews[0],
+                  item_key: "openclaw/openclaw#114006",
+                  updated_at_ms: now + 6,
+                },
+                {
+                  ...second.parked_reviews[0],
+                  item_key: "openclaw/openclaw#114007",
+                  updated_at_ms: now + 7,
+                },
+              ])
+              .map((item) => ({ item_key: item.item_key, updated_at_ms: item.updated_at_ms })),
+            idempotency_key: "parked-reconcile:over-cap",
+          }),
+        }),
+      )
+    ).status,
+    400,
+  );
 });
 
 test("exact-review admission requeue_latest resets failures instead of parking at the review ceiling", async () => {

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -16513,6 +16513,135 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
   );
 });
 
+test("parked review operator routes flag and refuse both command-context variants", async () => {
+  const storage = new MemoryDurableStorage();
+  const now = Date.parse("2026-08-10T12:30:00.000Z");
+  const ordinary = leasedExactReviewQueueItem(114_020, "914020");
+  const markerOnly = leasedExactReviewQueueItem(114_021, "914021");
+  const commentOnly = leasedExactReviewQueueItem(114_022, "914022");
+  for (const item of [ordinary, markerOnly, commentOnly]) {
+    item.state = "parked";
+    item.parkedReason = "review_retry_exhausted";
+    item.parkedRecoveryAttempts = 3;
+    item.parkedRecoveryAt = undefined;
+    item.attempts = 8;
+    item.reviewFailureAttempts = 8;
+    item.updatedAt = now;
+  }
+  markerOnly.decision.commandStatusMarker =
+    "<!-- clawsweeper-command-status:114021:re_review:parked -->";
+  commentOnly.decision.statusCommentId = 914_022;
+  await storage.put("exact-review-queue", {
+    deliveries: {},
+    items: {
+      [ordinary.key]: ordinary,
+      [markerOnly.key]: markerOnly,
+      [commentOnly.key]: commentOnly,
+    },
+  });
+  const queue = new ExactReviewQueue({ storage }, { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0" });
+
+  const inventory = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/parked-reviews/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 50 }),
+      }),
+    )
+  ).json();
+  assert.equal(inventory.parked_reviews.length, 3);
+  const ordinaryRow = inventory.parked_reviews.find((row) => row.item_key === ordinary.key);
+  const commandRows = [markerOnly, commentOnly].map((command) =>
+    inventory.parked_reviews.find((row) => row.item_key === command.key),
+  );
+  assert.equal(ordinaryRow.excluded_reason, undefined);
+  assert.deepEqual(
+    commandRows.map((row) => row.excluded_reason),
+    ["command_context", "command_context"],
+  );
+  const commandMutations = commandRows.map((row) => ({
+    item_key: row.item_key,
+    revision: row.revision,
+    updated_at_ms: row.updated_at_ms,
+  }));
+
+  const resolve = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/parked-reviews/resolve", {
+      method: "POST",
+      body: JSON.stringify({
+        items: commandMutations,
+        note: "must remain parked for command acknowledgement",
+      }),
+    }),
+  );
+  assert.deepEqual(await resolve.json(), { ok: true, resolved: 0, skipped: 2 });
+  const recover = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/parked-reviews/recover-fresh", {
+      method: "POST",
+      body: JSON.stringify({
+        items: commandMutations,
+        idempotency_key: "parked-reconcile:command-context",
+      }),
+    }),
+  );
+  assert.deepEqual(await recover.json(), {
+    ok: true,
+    recovered: 0,
+    deduped: 0,
+    skipped: 2,
+  });
+
+  const ordinaryRecover = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/parked-reviews/recover-fresh", {
+      method: "POST",
+      body: JSON.stringify({
+        items: [
+          {
+            item_key: ordinaryRow.item_key,
+            revision: ordinaryRow.revision,
+            updated_at_ms: ordinaryRow.updated_at_ms,
+          },
+        ],
+        idempotency_key: "parked-reconcile:ordinary",
+      }),
+    }),
+  );
+  assert.deepEqual(await ordinaryRecover.json(), {
+    ok: true,
+    recovered: 1,
+    deduped: 0,
+    skipped: 0,
+  });
+
+  const after = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      {
+        state: string;
+        revision: number;
+        attempts: number;
+        parkedReason?: string;
+        parkedRecoveryAttempts?: number;
+        decision: { commandStatusMarker?: string; statusCommentId?: number };
+      }
+    >;
+  };
+  assert.equal(after.items[ordinary.key].state, "pending");
+  assert.equal(after.items[ordinary.key].parkedRecoveryAttempts, 0);
+  for (const [index, command] of [markerOnly, commentOnly].entries()) {
+    assert.equal(after.items[command.key].state, "parked");
+    assert.equal(after.items[command.key].revision, commandRows[index].revision);
+    assert.equal(after.items[command.key].attempts, 8);
+    assert.equal(after.items[command.key].parkedReason, "review_retry_exhausted");
+    assert.equal(after.items[command.key].parkedRecoveryAttempts, 3);
+  }
+  assert.equal(
+    after.items[markerOnly.key].decision.commandStatusMarker,
+    "<!-- clawsweeper-command-status:114021:re_review:parked -->",
+  );
+  assert.equal(after.items[commentOnly.key].decision.statusCommentId, 914_022);
+});
+
 test("exact-review admission requeue_latest resets failures instead of parking at the review ceiling", async () => {
   const storage = new MemoryDurableStorage();
   const review = leasedExactReviewQueueItem(113_342, "9130");

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -16270,10 +16270,10 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
   const storage = new MemoryDurableStorage();
   const now = Date.parse("2026-08-10T12:00:00.000Z");
   const items = Object.fromEntries(
-    Array.from({ length: 6 }, (_, index) => {
+    Array.from({ length: 8 }, (_, index) => {
       const item = leasedExactReviewQueueItem(114_000 + index, `91400${index}`);
       item.state = "parked";
-      item.parkedReason = "review_retry_exhausted";
+      item.parkedReason = index === 7 ? "dead_letter_capacity" : "review_retry_exhausted";
       item.parkedRecoveryAttempts = index === 6 ? 2 : 3;
       item.parkedRecoveryAt = undefined;
       item.attempts = 8;
@@ -16311,6 +16311,10 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
     all.parked_reviews.some((item) => item.item_key === "openclaw/openclaw#114006"),
     false,
   );
+  assert.equal(
+    all.parked_reviews.some((item) => item.item_key === "openclaw/openclaw#114007"),
+    false,
+  );
   assert.equal(first.parked_reviews[0].item_key, "openclaw/openclaw#114000");
   assert.deepEqual(
     Object.keys(first.parked_reviews[0]).sort(),
@@ -16344,6 +16348,44 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
     second.parked_reviews.map((item) => item.item_key),
     ["openclaw/openclaw#114002", "openclaw/openclaw#114003"],
   );
+
+  const ineligible = [6, 7].map((index) => ({
+    item_key: `openclaw/openclaw#${114_000 + index}`,
+    revision: 1,
+    updated_at_ms: now + index,
+  }));
+  const earlyResolve = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/parked-reviews/resolve", {
+      method: "POST",
+      body: JSON.stringify({ items: ineligible, note: "must remain parked" }),
+    }),
+  );
+  assert.deepEqual(await earlyResolve.json(), { ok: true, resolved: 0, skipped: 2 });
+  const earlyRecover = await queue.fetch(
+    new Request("https://clawsweeper-exact-review-queue/parked-reviews/recover-fresh", {
+      method: "POST",
+      body: JSON.stringify({
+        items: ineligible,
+        idempotency_key: "parked-reconcile:ineligible",
+      }),
+    }),
+  );
+  assert.deepEqual(await earlyRecover.json(), {
+    ok: true,
+    recovered: 0,
+    deduped: 0,
+    skipped: 2,
+  });
+  const guarded = (await storage.get("exact-review-queue")) as {
+    items: Record<
+      string,
+      { state: string; parkedRecoveryAttempts?: number; parkedReason?: string }
+    >;
+  };
+  assert.equal(guarded.items["openclaw/openclaw#114006"].state, "parked");
+  assert.equal(guarded.items["openclaw/openclaw#114006"].parkedRecoveryAttempts, 2);
+  assert.equal(guarded.items["openclaw/openclaw#114007"].state, "parked");
+  assert.equal(guarded.items["openclaw/openclaw#114007"].parkedReason, "dead_letter_capacity");
 
   const terminal = first.parked_reviews[0];
   const resolved = await queue.fetch(

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -3342,7 +3342,7 @@ test("scheduled review feed is lane-paced and exposes its configured target", as
 test("scheduled untracked reviews are ready and claimable within one tick when 122 slots are free", async () => {
   const storage = new MemoryDurableStorage();
   const active = Object.fromEntries(
-    Array.from({ length: 6 }, (_, index) => {
+    Array.from({ length: 7 }, (_, index) => {
       const item = leasedExactReviewQueueItem(120_000 + index, String(120_000 + index));
       return [item.key, item];
     }),
@@ -3788,14 +3788,14 @@ test("parked review inventory and mutations require the operator signature", asy
     {
       path: "resolve",
       payload: {
-        items: [{ item_key: "openclaw/gogcli#1", updated_at_ms: 1 }],
+        items: [{ item_key: "openclaw/gogcli#1", revision: 1, updated_at_ms: 1 }],
         note: "terminal target",
       },
     },
     {
       path: "recover-fresh",
       payload: {
-        items: [{ item_key: "openclaw/gogcli#1", updated_at_ms: 1 }],
+        items: [{ item_key: "openclaw/gogcli#1", revision: 1, updated_at_ms: 1 }],
         idempotency_key: "parked-reconcile:test",
       },
     },
@@ -16274,7 +16274,7 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
       const item = leasedExactReviewQueueItem(114_000 + index, `91400${index}`);
       item.state = "parked";
       item.parkedReason = "review_retry_exhausted";
-      item.parkedRecoveryAttempts = 3;
+      item.parkedRecoveryAttempts = index === 6 ? 2 : 3;
       item.parkedRecoveryAt = undefined;
       item.attempts = 8;
       item.reviewFailureAttempts = 8;
@@ -16298,6 +16298,19 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
     )
   ).json();
   assert.equal(first.parked_reviews.length, 2);
+  const all = await (
+    await queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/parked-reviews/list", {
+        method: "POST",
+        body: JSON.stringify({ limit: 50 }),
+      }),
+    )
+  ).json();
+  assert.equal(all.parked_reviews.length, 6);
+  assert.equal(
+    all.parked_reviews.some((item) => item.item_key === "openclaw/openclaw#114006"),
+    false,
+  );
   assert.equal(first.parked_reviews[0].item_key, "openclaw/openclaw#114000");
   assert.deepEqual(
     Object.keys(first.parked_reviews[0]).sort(),
@@ -16308,6 +16321,7 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
       "last_failure_reason",
       "parked_reason",
       "parked_recovery_attempts",
+      "revision",
       "target_repo",
       "item_number",
       "updated_at",
@@ -16336,7 +16350,13 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
     new Request("https://clawsweeper-exact-review-queue/parked-reviews/resolve", {
       method: "POST",
       body: JSON.stringify({
-        items: [{ item_key: terminal.item_key, updated_at_ms: terminal.updated_at_ms }],
+        items: [
+          {
+            item_key: terminal.item_key,
+            revision: terminal.revision,
+            updated_at_ms: terminal.updated_at_ms,
+          },
+        ],
         note: "automatic reconciliation: terminal test target",
       }),
     }),
@@ -16345,9 +16365,20 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
 
   const recoverable = first.parked_reviews[1];
   const recoveryPayload = {
-    items: [{ item_key: recoverable.item_key, updated_at_ms: recoverable.updated_at_ms }],
+    items: [
+      {
+        item_key: recoverable.item_key,
+        revision: recoverable.revision,
+        updated_at_ms: recoverable.updated_at_ms,
+      },
+    ],
     idempotency_key: "parked-reconcile:test:114001",
   };
+  const observed = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { updatedAt: number }>;
+  };
+  observed.items[recoverable.item_key].updatedAt += 5 * 60_000;
+  await storage.put("exact-review-queue", observed);
   const recover = () =>
     queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/parked-reviews/recover-fresh", {
@@ -16426,7 +16457,11 @@ test("parked review operator routes paginate, resolve, and recover idempotently 
                   updated_at_ms: now + 7,
                 },
               ])
-              .map((item) => ({ item_key: item.item_key, updated_at_ms: item.updated_at_ms })),
+              .map((item) => ({
+                item_key: item.item_key,
+                revision: item.revision,
+                updated_at_ms: item.updated_at_ms,
+              })),
             idempotency_key: "parked-reconcile:over-cap",
           }),
         }),

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -221,7 +221,7 @@ test("parked review reconciliation plans by default and executes terminal resolv
     assert.equal(mutations.filter((entry) => entry.url?.endsWith("/resolve")).length, 2);
     const recovery = mutations.find((entry) => entry.url?.endsWith("/recover-fresh"));
     assert.deepEqual(recovery.payload.items, [
-      { item_key: "openclaw/repo#1", updated_at_ms: 1_000 },
+      { item_key: "openclaw/repo#1", revision: 1, updated_at_ms: 1_000 },
     ]);
     assert.match(recovery.payload.idempotency_key, /^parked-reconcile:[a-f0-9]{64}$/);
     const artifact = JSON.parse(await readFile(join(directory, "executed.json"), "utf8"));
@@ -2760,6 +2760,7 @@ function row(
 function parkedRow(itemKey, targetRepo, itemNumber, updatedAtMs) {
   return {
     item_key: itemKey,
+    revision: 1,
     target_repo: targetRepo,
     item_number: itemNumber,
     item_kind: "issue",

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -60,6 +60,18 @@ test("automatic dead-letter reconciliation is scheduled, bounded, and least priv
   assert.equal(scheduled.on.workflow_dispatch.inputs.execute.default, false);
   assert.equal(scheduled.on.workflow_dispatch.inputs.max_targets.default, "100");
   assert.equal(scheduled.on.workflow_dispatch.inputs.max_recoveries.default, "10");
+  const deadline = scheduled.jobs.reconcile.steps.find(
+    (candidate) => candidate.name === "Establish reconciliation deadline",
+  );
+  assert.match(deadline.run, /EXACT_REVIEW_RECONCILE_DEADLINE_MS/);
+  assert.match(deadline.run, /13 \* 60 \* 1000/);
+  assert.match(deadline.run, /GITHUB_ENV/);
+  assert.ok(
+    scheduled.jobs.reconcile.steps.indexOf(deadline) <
+      scheduled.jobs.reconcile.steps.findIndex((candidate) =>
+        candidate.uses?.startsWith("actions/checkout@"),
+      ),
+  );
   const step = scheduled.jobs.reconcile.steps.find(
     (candidate) => candidate.name === "Reconcile closed, duplicate, and recoverable dead letters",
   );
@@ -238,6 +250,85 @@ test("parked review reconciliation plans by default and executes terminal resolv
     );
     assert.equal(overCap.code, 1);
     assert.match(overCap.stderr, /between 0 and 5 for reconcile-parked/);
+  } finally {
+    server.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("parked review reconciliation stops safely at the workflow deadline", async () => {
+  const secret = "test-parked-review-deadline";
+  const parkedRows = [
+    parkedRow("openclaw/repo#1", "openclaw/repo", 1, 1_000),
+    parkedRow("openclaw/repo#2", "openclaw/repo", 2, 2_000),
+    parkedRow("openclaw/repo#3", "openclaw/repo", 3, 3_000),
+  ];
+  let mutations = 0;
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    if (request.url === "/api/exact-review-queue") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ pressure: { status: "idle", active: 0, capacity: 128 } }));
+      return;
+    }
+    if (request.url?.startsWith("/repos/openclaw/repo/issues/")) {
+      const timer = setTimeout(() => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ node_id: "ISSUE_DELAYED", state: "open", number: 1 }));
+      }, 5_000);
+      response.once("close", () => clearTimeout(timer));
+      return;
+    }
+    const body = Buffer.concat(chunks).toString("utf8");
+    const expected = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+    assert.equal(request.headers["x-clawsweeper-exact-review-signature"], expected);
+    if (request.url?.endsWith("/parked-reviews/list")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, parked_reviews: parkedRows, next_cursor: null }));
+      return;
+    }
+    mutations += 1;
+    response.writeHead(500, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "unexpected_mutation" }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const directory = await mkdtemp(join(tmpdir(), "clawsweeper-parked-deadline-"));
+  try {
+    const startedAt = Date.now();
+    const result = await runOperator(
+      [
+        "--action",
+        "reconcile-parked",
+        "--execute",
+        "--max-targets",
+        "100",
+        "--output",
+        join(directory, "deadline.json"),
+      ],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+      { EXACT_REVIEW_RECONCILE_DEADLINE_MS: String(Date.now() + 1_000) },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.ok(Date.now() - startedAt < 2_500);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      action: "reconcile-parked",
+      dry_run: false,
+      inventory_complete: true,
+      queue_pressure: "idle",
+      inspected_targets: 1,
+      terminal_targets: 0,
+      repository_gone_targets: 0,
+      resolved_targets: 0,
+      open_targets: 0,
+      recovered_targets: 0,
+      skipped_targets: 3,
+      deadline_reached: true,
+    });
+    assert.equal(mutations, 0);
   } finally {
     server.close();
     await rm(directory, { recursive: true, force: true });
@@ -2773,7 +2864,7 @@ function parkedRow(itemKey, targetRepo, itemNumber, updatedAtMs) {
   };
 }
 
-function runOperator(args, queueUrl, secret) {
+function runOperator(args, queueUrl, secret, extraEnv = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(
       process.execPath,
@@ -2785,6 +2876,7 @@ function runOperator(args, queueUrl, secret) {
           CLAWSWEEPER_WEBHOOK_SECRET: secret,
           GITHUB_API_URL: queueUrl,
           GITHUB_TOKEN: "test-github-token",
+          ...extraEnv,
         },
         stdio: ["ignore", "pipe", "pipe"],
       },

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -67,13 +67,181 @@ test("automatic dead-letter reconciliation is scheduled, bounded, and least priv
   assert.equal(scheduled.jobs.reconcile.env.CLAWSWEEPER_WEBHOOK_SECRET, undefined);
   assert.match(step.run, /--max-targets "\$MAX_TARGETS"/);
   assert.match(step.run, /--max-recoveries "\$MAX_RECOVERIES"/);
-  assert.match(step.run, /\/api\/health/);
-  assert.match(step.run, /\.deployment_sha/);
-  assert.match(step.run, /live_deploy_sha.*expected_deploy_sha/);
-  assert.match(step.run, /git fetch --no-tags --depth=1 origin "\$live_deploy_sha"/);
-  assert.match(step.run, /dashboard\/exact-review-queue\.ts/);
-  assert.match(step.run, /live_guard_blob.*expected_guard_blob/);
+  const guard = scheduled.jobs.reconcile.steps.find(
+    (candidate) => candidate.name === "Verify live recovery guards",
+  );
+  assert.match(guard.run, /\/api\/health/);
+  assert.match(guard.run, /\.deployment_sha/);
+  assert.match(guard.run, /live_deploy_sha.*expected_deploy_sha/);
+  assert.match(guard.run, /git fetch --no-tags --depth=1 origin "\$live_deploy_sha"/);
+  assert.match(guard.run, /dashboard\/exact-review-queue\.ts/);
+  assert.match(guard.run, /live_guard_blob.*expected_guard_blob/);
+  const parked = scheduled.jobs.reconcile.steps.find(
+    (candidate) => candidate.name === "Reconcile terminal and open parked reviews",
+  );
+  assert.equal(
+    parked.env.CLAWSWEEPER_WEBHOOK_SECRET,
+    "${{ secrets.EXACT_REVIEW_OPERATOR_SECRET }}",
+  );
+  assert.equal(parked.env.GITHUB_TOKEN, "${{ github.token }}");
+  assert.match(parked.run, /--action reconcile-parked/);
+  assert.match(parked.run, /--max-targets "\$MAX_TARGETS"/);
+  assert.match(parked.run, /--max-recoveries 5/);
+  assert.match(parked.run, /parked-reviews\.json/);
+  const upload = scheduled.jobs.reconcile.steps.find(
+    (candidate) => candidate.name === "Upload sanitized inventory",
+  );
+  assert.match(upload.with.path, /inventory\.json/);
+  assert.match(upload.with.path, /parked-reviews\.json/);
   assert.doesNotMatch(source, /dead-letters\/replay/);
+});
+
+test("parked review reconciliation plans by default and executes terminal resolve plus open recovery", async () => {
+  const secret = "test-parked-review-reconcile";
+  const mutations = [];
+  const parkedRows = [
+    parkedRow("openclaw/repo#1", "openclaw/repo", 1, 1_000),
+    parkedRow("openclaw/repo#2", "openclaw/repo", 2, 2_000),
+    parkedRow("gone/repo#3", "gone/repo", 3, 3_000),
+  ];
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    if (request.url === "/api/exact-review-queue") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ pressure: { status: "idle", active: 0, capacity: 128 } }));
+      return;
+    }
+    if (request.url === "/repos/openclaw/repo/issues/1") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          node_id: "ISSUE_1",
+          state: "open",
+          number: 1,
+          repository_url: "https://api.github.com/repos/openclaw/repo",
+        }),
+      );
+      return;
+    }
+    if (request.url === "/repos/openclaw/repo/issues/2") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          node_id: "ISSUE_2",
+          state: "closed",
+          number: 2,
+          repository_url: "https://api.github.com/repos/openclaw/repo",
+        }),
+      );
+      return;
+    }
+    if (request.url === "/repos/gone/repo/issues/3" || request.url === "/repos/gone/repo") {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ message: "Not Found" }));
+      return;
+    }
+    const body = Buffer.concat(chunks).toString("utf8");
+    const expected = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+    assert.equal(request.headers["x-clawsweeper-exact-review-signature"], expected);
+    const payload = JSON.parse(body);
+    if (request.url?.endsWith("/parked-reviews/list")) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, parked_reviews: parkedRows, next_cursor: null }));
+      return;
+    }
+    mutations.push({ url: request.url, payload });
+    response.writeHead(200, { "content-type": "application/json" });
+    if (request.url?.endsWith("/recover-fresh")) {
+      response.end(
+        JSON.stringify({
+          ok: true,
+          recovered: payload.items.length,
+          deduped: 0,
+          skipped: 0,
+        }),
+      );
+    } else {
+      response.end(JSON.stringify({ ok: true, resolved: payload.items.length, skipped: 0 }));
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const directory = await mkdtemp(join(tmpdir(), "clawsweeper-parked-reconcile-"));
+  try {
+    const common = [
+      "--action",
+      "reconcile-parked",
+      "--max-targets",
+      "100",
+      "--max-recoveries",
+      "5",
+    ];
+    const planned = await runOperator(
+      [...common, "--output", join(directory, "planned.json")],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(planned.code, 0, planned.stderr);
+    assert.deepEqual(JSON.parse(planned.stdout), {
+      action: "reconcile-parked",
+      dry_run: true,
+      inventory_complete: true,
+      queue_pressure: "idle",
+      inspected_targets: 3,
+      terminal_targets: 2,
+      repository_gone_targets: 1,
+      resolved_targets: 2,
+      open_targets: 1,
+      recovered_targets: 1,
+      skipped_targets: 0,
+    });
+    assert.equal(mutations.length, 0);
+
+    const executed = await runOperator(
+      [...common, "--execute", "--output", join(directory, "executed.json")],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(executed.code, 0, executed.stderr);
+    assert.deepEqual(JSON.parse(executed.stdout), {
+      action: "reconcile-parked",
+      dry_run: false,
+      inventory_complete: true,
+      queue_pressure: "idle",
+      inspected_targets: 3,
+      terminal_targets: 2,
+      repository_gone_targets: 1,
+      resolved_targets: 2,
+      open_targets: 1,
+      recovered_targets: 1,
+      skipped_targets: 0,
+    });
+    assert.equal(mutations.filter((entry) => entry.url?.endsWith("/resolve")).length, 2);
+    const recovery = mutations.find((entry) => entry.url?.endsWith("/recover-fresh"));
+    assert.deepEqual(recovery.payload.items, [
+      { item_key: "openclaw/repo#1", updated_at_ms: 1_000 },
+    ]);
+    assert.match(recovery.payload.idempotency_key, /^parked-reconcile:[a-f0-9]{64}$/);
+    const artifact = JSON.parse(await readFile(join(directory, "executed.json"), "utf8"));
+    assert.deepEqual(artifact.summary, {
+      rows: 3,
+      by_reason: { review_retry_exhausted: 3 },
+    });
+    assert.equal(JSON.stringify(artifact).includes("test-parked-review-reconcile"), false);
+
+    const overCap = await runOperator(
+      ["--action", "reconcile-parked", "--max-recoveries", "6"],
+      `http://127.0.0.1:${address.port}`,
+      secret,
+    );
+    assert.equal(overCap.code, 1);
+    assert.match(overCap.stderr, /between 0 and 5 for reconcile-parked/);
+  } finally {
+    server.close();
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("automatic reconciliation resolves terminal rows and recovers one fresh review per target", async () => {
@@ -2586,6 +2754,21 @@ function row(
       reason: recoveryReason,
       item_key: recoveryItemKey,
     },
+  };
+}
+
+function parkedRow(itemKey, targetRepo, itemNumber, updatedAtMs) {
+  return {
+    item_key: itemKey,
+    target_repo: targetRepo,
+    item_number: itemNumber,
+    item_kind: "issue",
+    parked_reason: "review_retry_exhausted",
+    parked_recovery_attempts: 3,
+    first_failed_at: "2026-08-09T00:00:00.000Z",
+    last_failure_reason: "review_retry_exhausted",
+    updated_at: new Date(updatedAtMs).toISOString(),
+    updated_at_ms: updatedAtMs,
   };
 }
 

--- a/test/exact-review-dead-letter-operator.test.ts
+++ b/test/exact-review-dead-letter-operator.test.ts
@@ -115,6 +115,10 @@ test("parked review reconciliation plans by default and executes terminal resolv
     parkedRow("openclaw/repo#1", "openclaw/repo", 1, 1_000),
     parkedRow("openclaw/repo#2", "openclaw/repo", 2, 2_000),
     parkedRow("gone/repo#3", "gone/repo", 3, 3_000),
+    {
+      ...parkedRow("openclaw/repo#4", "openclaw/repo", 4, 4_000),
+      excluded_reason: "command_context",
+    },
   ];
   const server = createServer(async (request, response) => {
     const chunks = [];
@@ -207,7 +211,7 @@ test("parked review reconciliation plans by default and executes terminal resolv
       resolved_targets: 2,
       open_targets: 1,
       recovered_targets: 1,
-      skipped_targets: 0,
+      skipped_targets: 1,
     });
     assert.equal(mutations.length, 0);
 
@@ -228,7 +232,7 @@ test("parked review reconciliation plans by default and executes terminal resolv
       resolved_targets: 2,
       open_targets: 1,
       recovered_targets: 1,
-      skipped_targets: 0,
+      skipped_targets: 1,
     });
     assert.equal(mutations.filter((entry) => entry.url?.endsWith("/resolve")).length, 2);
     const recovery = mutations.find((entry) => entry.url?.endsWith("/recover-fresh"));
@@ -238,9 +242,13 @@ test("parked review reconciliation plans by default and executes terminal resolv
     assert.match(recovery.payload.idempotency_key, /^parked-reconcile:[a-f0-9]{64}$/);
     const artifact = JSON.parse(await readFile(join(directory, "executed.json"), "utf8"));
     assert.deepEqual(artifact.summary, {
-      rows: 3,
-      by_reason: { review_retry_exhausted: 3 },
+      rows: 4,
+      by_reason: { review_retry_exhausted: 4 },
     });
+    assert.equal(
+      artifact.parked_reviews.find((row) => row.item_key === "openclaw/repo#4").excluded_reason,
+      "command_context",
+    );
     assert.equal(JSON.stringify(artifact).includes("test-parked-review-reconcile"), false);
 
     const overCap = await runOperator(


### PR DESCRIPTION
## Summary

- add a bounded, operator-signed inventory and reconciliation path for terminal or still-open reviews parked after the automatic recovery budget is exhausted
- resolve terminal parked rows and re-enqueue open rows as fresh pending reviews with revision-fenced, idempotent mutations
- keep command-context records visible but excluded from operator inspection, terminal resolution, and fresh recovery
- run the guarded reconciliation from the existing scheduled dead-letter workflow and retain a sanitized artifact

## Command-context route diagnosis

Command-context review items can genuinely reach `parked` through real routes; this exclusion is not only defense-in-depth. The legacy command dispatcher emits a `clawsweeper_item` with a command status marker and optional status comment id in `src/repair/comment-router.ts`. The legacy intake in `.github/workflows/sweep.yml` turns that event into a signed queue enqueue. A permanent per-item repository-dispatch rejection reaches `parkRecoverableExactReviewItem(..., "dispatch_rejected")` in `dashboard/exact-review-queue.ts`, without excluding command context. Claimed non-publication command reviews can likewise reach `review_retry_exhausted` through the normal completion retry ceiling.

The command-specific exception is a terminal-finalization acknowledgement driver: dispatch failure keeps that driver pending with publication retry backoff rather than parking it. That separate branch does not apply to the initial command review exercised here.

## Off-by-one diagnosis

Diagnosis: **(c) rebase/integration drift**, not intended admission semantics and not a reconcile counting bug.

The post-rebase integration commit `64ac9773bb` accidentally changed `test/dashboard-worker.test.ts:3345` from six leased fixture rows to seven. The fixture helper marks every row `state: "leased"` at `test/dashboard-worker.test.ts:28245`. Lane stats count `dispatchingItems.length + leasedItems.length` as active at `dashboard/exact-review-queue.ts:12070` and calculate `available_slots` as `capacity - active` at `dashboard/exact-review-queue.ts:12109`. The test config sets the queue cap to 128 at `test/dashboard-worker.test.ts:3355`, so the accidental fixture produced `128 - 7 = 121`.

This is independent of parked recovery: parked rows are collected separately and are not included in `active`; the operator endpoints are not invoked by this test. The isolated Node 24 run at `64ac9773bb` reproduced `121 !== 122`. Commit `0f5c8d3b71` restored the mainline fixture to six leased rows, making `128 - 6 = 122`; the same isolated test then passed without changing the expectation or runtime admission semantics.

## pr-behavior-proof

**Claim:** after the unchanged three-rung parked recovery ladder genuinely exhausts, the real local Worker and Durable Object expose eligible parked rows through signed operator inventory; reconciliation resolves a terminal ordinary target and re-enqueues an open ordinary target as fresh pending work, while a real command-context target remains flagged and unchanged and both mutation routes refuse it.

**Exercised surface:** real `wrangler dev --local` Worker, `ExactReviewQueue` Durable Object, signed enqueue/operator HTTP routes, persisted 5/10/20-minute recovery alarms with production jitter, built dead-letter operator CLI, Worker restart against the same disposable persistence, and a loopback GitHub behavioral stub.

**Scenario and environment:** two ordinary issues and one realistic legacy command review enter through the signed Worker route. The command uses the pull-request/legacy-dispatch event shape with a command status marker, status comment id, and additional prompt. The GitHub stub returns the production-classified single-field HTTP 422 rejection until all three rows exhaust. Reconciliation then skips the flagged command row before inspection; direct signed resolve and fresh-recover requests also return one skipped mutation.

**Local proof:** `bash docs/proof/parked-review-reconcile/run-proof.sh` on the uncommitted final patch over `0ded7ef34b7a62ee51daf67190ed4e0a68b9163b` completed at `2026-08-11T00:00:34.302Z` with all assertions true.

`PROOF_RC=0`

**Fresh-PR container proof:** pushed head `2f2d4fc8d5ec0b2a628f227c8c6c7bf228d3cf8d`, Crabbox `--fresh-pr openclaw/clawsweeper#1111`, `provider=local-container`, lease `cbx_3d30da7d1f76`, image/type `node:24-bookworm`. Corepack and checksum-verified jq 1.8.1 were installed into `$HOME/.local/bin`. The proof completed at `2026-08-11T00:46:59.402Z`.

`PROOF_RC=0`

Crabbox reported `exitCode=0`, `runStatus=succeeded`, and `leaseStopped=true` after 44m34.718s of command time (44m45.231s end-to-end).

**Observable result:** all three rows reached `parked_recovery_attempts: 3`; inventory flagged the command row with `excluded_reason: "command_context"`; the operator inspected only the two ordinary targets, resolved one terminal row, recovered one open row to pending, and counted the command row as skipped. Direct resolve and fresh-recover requests both refused the command row, which remained parked and unchanged.

**Artifact/trace:** each harness run generated the exhaustion inventory, operator inventory, final inventory, command mutation refusal responses, proof summary, Worker/stub logs, and reconciliation transcript under its disposable checkout. The container summary binds the proof to source SHA `2f2d4fc8d5ec0b2a628f227c8c6c7bf228d3cf8d`.

**Limits:** GitHub was a loopback behavioral stub. No production GitHub repository, Worker, secret, comment, workflow, or queue was contacted or mutated. The proof covers the real Worker/DO state machine, signing, alarms, operator process, and persistence boundary, not GitHub's hosted implementation. It covers the initial command-review dispatch-rejection route, not the separate terminal-finalization acknowledgement retry path.

## Validation

- `pnpm run build:all` — pass
- `pnpm run test:no-build` — pass: 3,291 tests; 3,282 passed, 0 failed, 9 skipped
- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run check:dashboard-queue-boundary` — pass
- `pnpm run check:active-surface` — pass
- `pnpm run check:limits` — pass
- `pnpm run check` — pass
- pre-commit Codex autoreview of the uncommitted patch — clean, no accepted/actionable findings
- committed Codex autoreview against current `origin/main` — clean, no accepted/actionable findings

## OpenClaw Bay

OpenClaw Bay is unaffected. It remains public and observer-only and gains no recovery, DLQ, queue, workflow, GitHub, deploy, or rollback action.
