### PR TITLE
feat(dashboard): prioritize operational telemetry

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9396,7 +9396,26 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
 .health-chip.ok { border-color: color-mix(in srgb, var(--green) 28%, var(--line)); }
 .health-chip.amber { border-color: color-mix(in srgb, var(--amber) 35%, var(--line)); }
 .health-chip.red { border-color: color-mix(in srgb, var(--red) 35%, var(--line)); }
-.review-coverage { margin-top: 6px; }
+.review-coverage { margin-top: 28px; }
+.review-coverage > summary {
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+}
+.coverage-summary-content {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  width: calc(100% - 24px);
+  margin-left: 8px;
+}
+.review-coverage > summary:hover h2 { color: var(--claw); }
+.review-coverage > summary:focus-visible { outline: 2px solid var(--claw); outline-offset: 4px; }
+.review-coverage > summary h2 { display: inline; margin: 0; }
+.review-coverage > summary .muted { text-align: right; }
+.review-coverage[open] > summary { margin-bottom: 14px; }
 .coverage-fleets { display: grid; gap: 10px; margin-top: 14px; }
 .coverage-fleet {
   display: grid;
@@ -9465,6 +9484,8 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   .worker-toolbar { align-items: stretch; flex-direction: column; }
   .coverage-fleet { grid-template-columns: 1fr; gap: 9px; }
   .coverage-value { justify-items: start; }
+  .coverage-summary-content { align-items: flex-start; flex-direction: column; gap: 6px; }
+  .review-coverage > summary .muted { padding-left: 24px; text-align: left; }
 }
 @media (max-width: 560px) {
   main { width: min(100vw - 24px, 1280px); padding-top: 18px; }
@@ -9507,13 +9528,6 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     <div class="health-strip" id="health-strip" aria-label="Subsystem health at a glance"></div>
   </section>
   <section class="grid" id="metrics"></section>
-  <section class="review-coverage" aria-labelledby="review-coverage-title">
-    <div class="overview-head">
-      <h2 id="review-coverage-title">Fleet Review Coverage</h2>
-      <span class="muted" id="review-coverage-note">Open items reviewed in the trailing 7 days</span>
-    </div>
-    <div id="review-coverage-body" aria-live="polite"><div class="empty">Loading review coverage…</div></div>
-  </section>
   <section class="overview-shell" aria-labelledby="system-overview-title">
     <div class="overview-head">
       <h2 id="system-overview-title">System Overview</h2>
@@ -9568,6 +9582,15 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     </div>
     <div id="workers"></div>
   </section>
+  <details class="review-coverage">
+    <summary>
+      <span class="coverage-summary-content">
+        <h2 id="review-coverage-title">Fleet Review Coverage</h2>
+        <span class="muted" id="review-coverage-note">Open items reviewed in the trailing 7 days</span>
+      </span>
+    </summary>
+    <div id="review-coverage-body" aria-live="polite" aria-labelledby="review-coverage-title"><div class="empty">Loading review coverage…</div></div>
+  </details>
   <section class="automerge-health" aria-labelledby="automerge-product-title">
     <div class="automerge-health-head">
       <h2 id="automerge-product-title">Automerge Product Health</h2>

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -9411,9 +9411,9 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
   width: calc(100% - 24px);
   margin-left: 8px;
 }
-.review-coverage > summary:hover h2 { color: var(--claw); }
+.review-coverage > summary:hover .coverage-summary-label { color: var(--claw); }
 .review-coverage > summary:focus-visible { outline: 2px solid var(--claw); outline-offset: 4px; }
-.review-coverage > summary h2 { display: inline; margin: 0; }
+.coverage-summary-label { color: var(--ink); font-family: var(--font-heading); font-size: 18px; font-weight: 800; }
 .review-coverage > summary .muted { text-align: right; }
 .review-coverage[open] > summary { margin-bottom: 14px; }
 .coverage-fleets { display: grid; gap: 10px; margin-top: 14px; }
@@ -9582,10 +9582,11 @@ a.pill:hover { color: var(--claw); text-decoration: none; }
     </div>
     <div id="workers"></div>
   </section>
+  <h2 id="review-coverage-title">Fleet Review Coverage</h2>
   <details class="review-coverage">
     <summary>
       <span class="coverage-summary-content">
-        <h2 id="review-coverage-title">Fleet Review Coverage</h2>
+        <span class="coverage-summary-label">Explore repository coverage</span>
         <span class="muted" id="review-coverage-note">Open items reviewed in the trailing 7 days</span>
       </span>
     </summary>

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -21625,7 +21625,15 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /Fleet Review Coverage/);
   assert.match(html, /id="review-coverage-body"/);
   assert.match(html, /\/api\/review-coverage/);
-  assert.ok(html.indexOf('id="review-coverage-body"') < html.indexOf("System Overview"));
+  assert.ok(html.indexOf("System Overview") < html.indexOf('id="review-coverage-body"'));
+  assert.match(html, /<details class="review-coverage">/);
+  assert.match(
+    html,
+    /<summary>\s*<span class="coverage-summary-content">\s*<h2 id="review-coverage-title">Fleet Review Coverage<\/h2>/,
+  );
+  assert.doesNotMatch(html, /\.review-coverage > summary \{[^}]*display: flex/);
+  assert.doesNotMatch(html, /<details class="review-coverage" open>/);
+  assert.match(html, /aria-labelledby="review-coverage-title"/);
   assert.match(html, /\/api\/apply-observability\?range=/);
   assert.match(html, /data-trend-range="6h"/);
   assert.match(html, /<details class="execution-alert">/);

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -21629,8 +21629,13 @@ test("dashboard HTML preserves UTF-8 emoji labels", async () => {
   assert.match(html, /<details class="review-coverage">/);
   assert.match(
     html,
-    /<summary>\s*<span class="coverage-summary-content">\s*<h2 id="review-coverage-title">Fleet Review Coverage<\/h2>/,
+    /<h2 id="review-coverage-title">Fleet Review Coverage<\/h2>\s*<details class="review-coverage">/,
   );
+  assert.match(
+    html,
+    /<summary>\s*<span class="coverage-summary-content">\s*<span class="coverage-summary-label">Explore repository coverage<\/span>/,
+  );
+  assert.doesNotMatch(html, /<summary>(?:(?!<\/summary>)[\s\S])*<h2/);
   assert.doesNotMatch(html, /\.review-coverage > summary \{[^}]*display: flex/);
   assert.doesNotMatch(html, /<details class="review-coverage" open>/);
   assert.match(html, /aria-labelledby="review-coverage-title"/);


### PR DESCRIPTION
## Summary

- Put decision-useful operational telemetry first on the dashboard overview.
- Move the full Fleet Review Coverage inventory below telemetry into a collapsed native disclosure.
- Preserve repository counts, flags, links, loading/empty/error behavior, and the degraded coverage signal in the always-visible health hero.

## Problem

The overview opened with a long repository inventory. On production-sized data that inventory consumed the initial viewport and pushed queue, throughput, capacity, and incident telemetry far below the fold. Operators had to scroll past coverage detail before they could answer the page's primary questions: whether the system is healthy, whether work is flowing, and where intervention is needed.

## Implementation

- Reordered the existing overview so `System Overview` and its operational cards precede repository coverage in document order.
- Wrapped the unchanged repository exploration UI in semantic native `<details>/<summary>`, collapsed by default.
- Kept the coverage health indicator in the hero so stale/degraded coverage is never hidden by progressive disclosure.
- Added responsive disclosure styling, visible keyboard focus, and native disclosure affordance using the existing ClawSweeper visual language.
- Added deterministic rendering assertions for order, collapsed-default behavior, preserved loading/error/repository content, and accessibility semantics.

## Validation

Exact head: `6f3571adf1fe028483f94e934db067419286f66d`  
Tree: `7b1150e2ecbd5994be97da99984e95792df44263`  
Recorded base: `91272a65e6ffbf1eafddf520639c9acbd339e1bf`

User-authorized direct local Docker proof used pinned image:

`mcr.microsoft.com/playwright@sha256:9bd26ad900bb5e0f4dee75839e957a89ae89c2b7ab1e76050e559790e946b948`

The container materialized the exact commit with `git archive` from read-only Git objects, asserted commit/tree/manifest identity, then ran:

```text
pnpm install --frozen-lockfile
pnpm run build:all
pnpm run check:static
pnpm run format:check
pnpm run lint
node --test test/dashboard-github-api.test.ts test/dashboard-health.test.ts test/dashboard-operational-health.test.ts test/dashboard-smoke.test.ts test/dashboard-worker.test.ts test/worker-records-request.test.ts test/worker-state-blobs.test.ts
pnpm run test:coverage:changed:no-build
```

Results:

- Relevant dashboard/Worker tests: 375/375 passed.
- Changed coverage tests: 12/12 passed; 100% lines, 100% functions, 88.61% branches.
- Build, static checks, formatting, and every lint lane passed.
- `git diff --check` passed and the host worktree remained clean at the exact head.

## Real Behavior Proof

**Claim:** the dashboard's initial desktop viewport prioritizes operational health and telemetry while keeping complete repository exploration reachable and accessible.

**Exercised surface:** the exact archived Worker/dashboard build was served with Wrangler inside the pinned Linux container and exercised with real Chromium/Playwright.

**Scenario/fixture:** deterministic healthy/degraded operational data plus two repository coverage fixtures, including per-repository flags and explicit loading and error responses.

**Observed result:**

- Desktop 1440×900: `System Overview` began at y=422.56 (above fold); repository coverage began at y=2849.91 and followed it in heading/document order.
- Narrow 390×844: page scroll width remained 390 with no horizontal overflow.
- Coverage was collapsed by default.
- Keyboard Enter opened the native disclosure and focus remained on its summary.
- Both repository fixtures and their flags rendered after expansion.
- Loading and error semantics remained intact.
- The hero continued to show the degraded signal `7d coverage 50% · 3 stale` while the inventory was collapsed.

Artifacts retained outside the worktree under `C:\clawsweeper-work\artifacts\csw-125\direct-docker-6f3571adf1` include the browser report, test transcripts, archive/manifest hashes, exit code, and screenshots. Container `csw-125-direct-proof-6f3571adf1` (`ec6244f6616e954aa3e1b61ce354f9198caf723ffa57ce67918bc2151172fe26`) ran from `2026-08-10T21:15:14Z` to `21:16:04Z` and exited 0:

- `overview-desktop-1440x900.png`
- `overview-narrow-390x844.png`
- `repository-coverage-open.png`
- `repository-coverage-narrow-open.png`
- `repository-coverage-summary-focus.png`

The successful proof container exited 0 and was removed by its exact task-owned name after its ID, inspection, log, and Docker events were recorded. Other task containers were not modified.

**Proof boundary:** this is Martin-authorized direct-Docker evidence, not a Crabbox lease/run receipt. Earlier Crabbox local-container/AWS transport failures are retained as infrastructure diagnostics; they did not weaken or replace this unchanged exact-head proof contract. No production mutation or deployment was performed.

## Review closeout

- Dirty Codex review found and prompted restoration of the native disclosure marker; the fix was tested and the repeat review was clean.
- Committed Codex range review found an undefined color token; the fix was tested and the review was clean.
- ClawSweeper's PR review then identified an invalid heading nested in `<summary>`. The heading was moved immediately before `<details>`, the toggle was made phrasing-only, and structural tests were updated.
- Post-fix dirty and committed Codex reviews found no actionable defects.
- Post-fix local ClawSweeper range review against the recorded base returned `keep_open` with high confidence.

## Accessibility and responsive checks

- Semantic heading order is telemetry first, coverage second.
- Native `<details>/<summary>` provides keyboard and assistive-technology disclosure semantics.
- Summary has a visible `:focus-visible` treatment and retains focus when toggled.
- Urgent/degraded coverage status remains outside the collapsed region.
- Desktop and narrow layouts have no horizontal overflow.

## Compatibility and overlap

- PR #1112 (CSW-124 Bay route/header) overlaps both touched files. Land/rebase #1112 first if it is preferred; this PR is deliberately limited to overview section ordering/disclosure and its assertions, so conflict resolution should preserve CSW-124 header/navigation changes and reapply this telemetry-first body ordering.
- PR #1111 also touches the dashboard Worker/test; rebase whichever lands second and preserve its queue semantics.
- PR #1105 merged as `91272a65e6ffbf1eafddf520639c9acbd339e1bf` and is the exact proof base. `git range-diff` confirmed this PR's two commits replayed unchanged above its branch-authority, Worker, and test changes.
- PR #1110 and #1108 have no direct behavioral overlap with this two-file overview change; #1107 is no longer open.

## Risks and rollback

Risk is limited to overview presentation and discoverability: operators accustomed to the expanded inventory need one disclosure action. Counts and degraded status remain visible before expansion, and native disclosure behavior avoids custom state machinery. Rollback is a single-commit revert; no data, API, polling, queue, runtime, route, or deployment migration is involved.

## Non-goals

- No new route or broad brand redesign.
- No changes to telemetry meaning, data sources, polling cadence, queue/runtime behavior, gates, or production state.
- No deployment or production mutation.
