### PR TITLE
refactor(repair): consolidate duplicated helpers

### DIFF
--- a/docs/proof/repair-duplication-merges/README.md
+++ b/docs/proof/repair-duplication-merges/README.md
@@ -1,8 +1,11 @@
 # Repair duplication merges proof
 
 The four numbered directories contain the old-versus-new equivalence harnesses
-and JSON artifacts. Merge 1 proves the intentional one-shot-to-retry change
-with an unchanged idempotency key; merges 2–4 prove byte-identical behavior.
+and JSON artifacts. Merge 1 proves the intentional one-shot-to-retry change by
+running the old CLI and current production notifier function over a real
+loopback HTTP socket with an unchanged idempotency key. Merge 2 proves resolver
+equivalence with real SQLite files and both production importer entry points.
+Merges 3–4 prove byte-identical behavior.
 
 Docker proof used Crabbox `0.38.3-5-g2a79805d`, `provider=local-container`,
 lease `cbx_182ee21fa80c` (`quick-krill-f6cc`), `node:24-bookworm`, and Docker

--- a/docs/proof/repair-duplication-merges/README.md
+++ b/docs/proof/repair-duplication-merges/README.md
@@ -7,18 +7,23 @@ loopback HTTP socket with an unchanged idempotency key. Merge 2 proves resolver
 equivalence with real SQLite files and both production importer entry points.
 Merges 3–4 prove byte-identical behavior.
 
-Docker proof used Crabbox `0.38.3-5-g2a79805d`, `provider=local-container`,
-lease `cbx_182ee21fa80c` (`quick-krill-f6cc`), `node:24-bookworm`, and Docker
+Docker proof used Crabbox 0.41.1, `provider=local-container`, lease
+`cbx_5b0de8cbba98` (`silver-barnacle-695f`), `node:24-bookworm`, and Docker
 29.4.0. A clean `--fresh-pr openclaw/clawsweeper#1114` checkout at
-`1b53811246d6bf5a001f8db6d1de81db280c2015` reported 3,307 tests: 3,296 passed,
-8 skipped, and only the three known blob-hydration failures. Exact merge-base
-`51ac499c741b7b4b9b2bd1b7d78686055f8f3738` reproduced those same three and no
-others: 3,304 tests, 3,293 passed, 8 skipped. The focused baseline verifier
-exited zero with `BASELINE_RESULT=known_environmental_3`.
+`e94c0fbfe043545bebae5c3bf11fb961ef98a72a` built all targets, ran all four
+proof scripts with `PROOF_RC=0`, and passed `format:check`. The final
+provenance-only follow-up changes this README and its machine-readable
+provenance artifact, not the exercised harnesses.
 
 Corepack installed pinned pnpm 11.10.0. jq 1.8.1 was installed under
-`$HOME/.local/bin` and verified against SHA-256
-`020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d`.
-Fresh-PR timings were 9,217 ms sync, 83,295 ms command, 92,512 ms total. The
-lease was deleted. OpenClaw Bay is unaffected because no lifecycle, queue,
-telemetry, or dashboard contract changed.
+`$HOME/.local/bin`; its `jq-linux-arm64` SHA-256
+`6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4` was
+verified against the release's published checksum file before execution.
+Fresh-PR timings were 14,128 ms sync, 9,870 ms command, and 24,023 ms total.
+The lease stopped automatically. The full `test:no-build` gate ran locally on
+Node 24.19.0: 3,307 tests, 3,298 passed, 9 skipped, and 0 failed. The container
+run did not repeat the full suite, so no blob-hydration baseline was needed.
+
+Machine-readable provenance is in `container-provenance.json`. OpenClaw Bay is
+unaffected because no lifecycle, queue, telemetry, or dashboard contract
+changed.

--- a/docs/proof/repair-duplication-merges/README.md
+++ b/docs/proof/repair-duplication-merges/README.md
@@ -1,0 +1,21 @@
+# Repair duplication merges proof
+
+The four numbered directories contain the old-versus-new equivalence harnesses
+and JSON artifacts. Merge 1 proves the intentional one-shot-to-retry change
+with an unchanged idempotency key; merges 2–4 prove byte-identical behavior.
+
+Docker proof used Crabbox `0.38.3-5-g2a79805d`, `provider=local-container`,
+lease `cbx_182ee21fa80c` (`quick-krill-f6cc`), `node:24-bookworm`, and Docker
+29.4.0. A clean `--fresh-pr openclaw/clawsweeper#1114` checkout at
+`1b53811246d6bf5a001f8db6d1de81db280c2015` reported 3,307 tests: 3,296 passed,
+8 skipped, and only the three known blob-hydration failures. Exact merge-base
+`51ac499c741b7b4b9b2bd1b7d78686055f8f3738` reproduced those same three and no
+others: 3,304 tests, 3,293 passed, 8 skipped. The focused baseline verifier
+exited zero with `BASELINE_RESULT=known_environmental_3`.
+
+Corepack installed pinned pnpm 11.10.0. jq 1.8.1 was installed under
+`$HOME/.local/bin` and verified against SHA-256
+`020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d`.
+Fresh-PR timings were 9,217 ms sync, 83,295 ms command, 92,512 ms total. The
+lease was deleted. OpenClaw Bay is unaffected because no lifecycle, queue,
+telemetry, or dashboard contract changed.

--- a/docs/proof/repair-duplication-merges/container-provenance.json
+++ b/docs/proof/repair-duplication-merges/container-provenance.json
@@ -1,0 +1,59 @@
+{
+  "schema": "clawsweeper-real-boundary-proof-provenance/v1",
+  "claim": "The committed repair-duplication proof harnesses pass over real loopback HTTP sockets and real SQLite files in a clean Docker-backed Crabbox checkout of PR 1114.",
+  "reviewed_head": "e94c0fbfe043545bebae5c3bf11fb961ef98a72a",
+  "crabbox": {
+    "cli_version": "0.41.1",
+    "provider": "local-container",
+    "lease_id": "cbx_5b0de8cbba98",
+    "slug": "silver-barnacle-695f",
+    "run_id": "run_535154e728dc",
+    "machine_type": "node_24-bookworm",
+    "image": "node:24-bookworm",
+    "container_engine": "Docker 29.4.0",
+    "checkout": "--fresh-pr openclaw/clawsweeper#1114 --no-hydrate",
+    "sync_ms": 14128,
+    "command_ms": 9870,
+    "total_ms": 24023,
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "runtime": {
+    "node": "v24.19.0",
+    "pnpm": "11.10.0",
+    "jq": "jq-1.8.1",
+    "jq_asset": "jq-linux-arm64",
+    "jq_sha256": "6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4",
+    "jq_checksum_source": "https://github.com/jqlang/jq/releases/download/jq-1.8.1/sha256sum.txt",
+    "jq_checksum_verified": true
+  },
+  "result": {
+    "proof_rc": 0,
+    "proof_scripts": 4,
+    "build_all": "passed",
+    "format_check": "passed"
+  },
+  "local_gate": {
+    "proof_rc": 0,
+    "test_no_build": {
+      "tests": 3307,
+      "passed": 3298,
+      "skipped": 9,
+      "failed": 0
+    }
+  },
+  "discarded_attempt": {
+    "lease_id": "cbx_862ce6fd7912",
+    "slug": "amber-crab-c0bb",
+    "image": "ubuntu:26.04",
+    "exit_code": 127,
+    "reason": "generic image had no Node/Corepack; no proof command ran",
+    "lease_stopped": true
+  },
+  "limits": [
+    "The loopback hook listener uses a disposable local token and does not contact OpenClaw or Discord.",
+    "The SQLite fixtures and node:sqlite CLI adapter are disposable local files and do not contact Gitcrawl or production storage.",
+    "The container run did not repeat the full test:no-build suite; that gate passed locally with zero failures."
+  ]
+}

--- a/docs/proof/repair-duplication-merges/merge-1/README.md
+++ b/docs/proof/repair-duplication-merges/merge-1/README.md
@@ -1,14 +1,20 @@
 # Merge notifier hook-client proof
 
-This proof compares the one-shot hook poster extracted from
-`origin/main:src/repair/notify-merge.ts` with the shared OpenClaw hook client now
-used by the merge notifier.
+This proof builds the complete pre-change tree from `origin/main` and runs its
+production `dist/repair/notify-merge.js` entry point. It invokes the current
+built `runMergeNotifier` function with the same arguments used by that CLI's
+`main`. Both receive their normal hook configuration through the
+`CLAWSWEEPER_OPENCLAW_*` environment variables and post through Node's real
+`fetch` implementation to one HTTP server bound to an ephemeral
+`127.0.0.1:<port>` socket.
 
-The representative transient `502` scenario demonstrates the intentional
-behavior change: the old path makes one request and gives up, while the shared
-client retries and succeeds. Both new attempts carry the same merge
-idempotency key. The proof also verifies the three existing sibling notifiers
-that already use the shared client: `notify-events.ts`,
+The listener returns `503` to the first request for each path and `200` to a
+second request. The old process makes one request, records a failed delivery,
+and exits 1 under `--strict`. The current process retries over the socket,
+receives `200`, records a sent delivery, and exits 0. The transport trace
+captures a timestamp, socket addresses, response status, and the identical
+idempotency-key header and JSON field for every request. The proof also verifies
+the three existing sibling notifiers that already use the shared client: `notify-events.ts`,
 `notify-github-activity.ts`, and `notify-maintainer-report.ts`.
 
 Run after `pnpm run build:repair`:
@@ -18,5 +24,6 @@ node docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
 ```
 
 The checked-in result is in `artifacts/retry-adoption.json`. This is a local,
-credential-free HTTP-stub proof; it does not contact OpenClaw, Discord, GitHub,
-or any production service.
+credential-free real-transport proof. It uses a disposable token and a
+loopback-only listener; it does not contact OpenClaw, Discord, GitHub, or any
+production service.

--- a/docs/proof/repair-duplication-merges/merge-1/README.md
+++ b/docs/proof/repair-duplication-merges/merge-1/README.md
@@ -1,0 +1,22 @@
+# Merge notifier hook-client proof
+
+This proof compares the one-shot hook poster extracted from
+`origin/main:src/repair/notify-merge.ts` with the shared OpenClaw hook client now
+used by the merge notifier.
+
+The representative transient `502` scenario demonstrates the intentional
+behavior change: the old path makes one request and gives up, while the shared
+client retries and succeeds. Both new attempts carry the same merge
+idempotency key. The proof also verifies the three existing sibling notifiers
+that already use the shared client: `notify-events.ts`,
+`notify-github-activity.ts`, and `notify-maintainer-report.ts`.
+
+Run after `pnpm run build:repair`:
+
+```sh
+node docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
+```
+
+The checked-in result is in `artifacts/retry-adoption.json`. This is a local,
+credential-free HTTP-stub proof; it does not contact OpenClaw, Discord, GitHub,
+or any production service.

--- a/docs/proof/repair-duplication-merges/merge-1/artifacts/retry-adoption.json
+++ b/docs/proof/repair-duplication-merges/merge-1/artifacts/retry-adoption.json
@@ -1,0 +1,25 @@
+{
+  "base_ref": "origin/main",
+  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "extracted_source": "src/repair/notify-merge.ts",
+  "extracted_source_sha256": "123375f0a5b6c20cfd49f38620edf781f849fabf31d23bebc9a4cd6bd08a801b",
+  "scenario": "first hook response is transient HTTP 502",
+  "old": {
+    "requests": 1,
+    "outcome": "failed"
+  },
+  "new": {
+    "requests": 2,
+    "idempotency_keys": [
+      "merge:openclaw/openclaw#123:merge_canonical:abc123",
+      "merge:openclaw/openclaw#123:merge_canonical:abc123"
+    ],
+    "outcome": "succeeded",
+    "run_id": "proof-run"
+  },
+  "sibling_notifier_precedent": [
+    "src/repair/notify-events.ts",
+    "src/repair/notify-github-activity.ts",
+    "src/repair/notify-maintainer-report.ts"
+  ]
+}

--- a/docs/proof/repair-duplication-merges/merge-1/artifacts/retry-adoption.json
+++ b/docs/proof/repair-duplication-merges/merge-1/artifacts/retry-adoption.json
@@ -1,21 +1,75 @@
 {
   "base_ref": "origin/main",
-  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
-  "extracted_source": "src/repair/notify-merge.ts",
-  "extracted_source_sha256": "123375f0a5b6c20cfd49f38620edf781f849fabf31d23bebc9a4cd6bd08a801b",
-  "scenario": "first hook response is transient HTTP 502",
+  "base_sha": "765644804756d5f6b1dc1e940d62c50711e398d8",
+  "source": {
+    "baseline": {
+      "path": "src/repair/notify-merge.ts",
+      "sha256": "d9869572aca5538f5814412b95756087f768aaa3682080deb54956ec518d8574",
+      "cli_sha256": "9ab0c94991e801c5a6f3d2ef95d8bfa2d457ac41969459fc17168f281ca4d4ec"
+    },
+    "current": {
+      "path": "src/repair/notify-merge.ts",
+      "sha256": "90ab3b4a0e9df39551d6ea7f3fd49a2e2a2146954dd310d573024f28d7129065",
+      "cli_sha256": "c3471fff7ac23c60f8d6246a4cb6c4ec1f91a4167c0922cc8094246b038861b1"
+    }
+  },
+  "transport": {
+    "kind": "real loopback HTTP socket",
+    "bound_address": "127.0.0.1:50840",
+    "requests": [
+      {
+        "scenario": "old",
+        "attempt": 1,
+        "received_at": "2026-08-11T01:08:59.863Z",
+        "method": "POST",
+        "pathname": "/old/agent",
+        "idempotency_key": "merge:openclaw/openclaw#123:merge_canonical:abc123",
+        "body_idempotency_key": "merge:openclaw/openclaw#123:merge_canonical:abc123",
+        "local_address": "127.0.0.1",
+        "remote_address": "127.0.0.1",
+        "response_status": 503
+      },
+      {
+        "scenario": "new",
+        "attempt": 1,
+        "received_at": "2026-08-11T01:08:59.881Z",
+        "method": "POST",
+        "pathname": "/new/agent",
+        "idempotency_key": "merge:openclaw/openclaw#123:merge_canonical:abc123",
+        "body_idempotency_key": "merge:openclaw/openclaw#123:merge_canonical:abc123",
+        "local_address": "127.0.0.1",
+        "remote_address": "127.0.0.1",
+        "response_status": 503
+      },
+      {
+        "scenario": "new",
+        "attempt": 2,
+        "received_at": "2026-08-11T01:09:00.887Z",
+        "method": "POST",
+        "pathname": "/new/agent",
+        "idempotency_key": "merge:openclaw/openclaw#123:merge_canonical:abc123",
+        "body_idempotency_key": "merge:openclaw/openclaw#123:merge_canonical:abc123",
+        "local_address": "127.0.0.1",
+        "remote_address": "127.0.0.1",
+        "response_status": 200
+      }
+    ]
+  },
   "old": {
+    "entrypoint": "baseline dist/repair/notify-merge.js",
+    "exit_code": 1,
+    "outcome": "failed after one HTTP 503",
     "requests": 1,
-    "outcome": "failed"
+    "stdout": "{\n  \"status\": \"ok\",\n  \"considered\": 1,\n  \"pending\": 1,\n  \"sent\": 0,\n  \"failed\": 1,\n  \"skipped\": 0,\n  \"exitCode\": 1,\n  \"reason\": null\n}",
+    "stderr": ""
   },
   "new": {
+    "entrypoint": "runMergeNotifier (the function invoked by dist/repair/notify-merge.js main)",
+    "exit_code": 0,
+    "outcome": "succeeded after HTTP 503 then HTTP 200",
     "requests": 2,
-    "idempotency_keys": [
-      "merge:openclaw/openclaw#123:merge_canonical:abc123",
-      "merge:openclaw/openclaw#123:merge_canonical:abc123"
-    ],
-    "outcome": "succeeded",
-    "run_id": "proof-run"
+    "stdout": "{\n  \"status\": \"ok\",\n  \"considered\": 1,\n  \"pending\": 1,\n  \"sent\": 1,\n  \"failed\": 0,\n  \"skipped\": 0,\n  \"exitCode\": 0,\n  \"reason\": null\n}",
+    "stderr": ""
   },
   "sibling_notifier_precedent": [
     "src/repair/notify-events.ts",

--- a/docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+import { postOpenClawAgentHook } from "../../../../dist/repair/openclaw-hook.js";
+
+const root = process.cwd();
+const baseRef = process.env.PROOF_BASE_REF || "origin/main";
+const sourcePath = "src/repair/notify-merge.ts";
+const baseSource = gitShow(sourcePath);
+const oldFunction = extractBetween(
+  baseSource,
+  "async function postHookNotification(",
+  "\nfunction readHookRunId(",
+);
+const oldPostHookNotification = compileOldFunction(oldFunction);
+const idempotencyKey = "merge:openclaw/openclaw#123:merge_canonical:abc123";
+const config = {
+  hookUrl: "https://claw.example/hooks/agent",
+  token: "proof-token",
+  agentId: "clawsweeper",
+  channel: "discord",
+  discordTarget: "channel:123",
+  thinking: "low",
+  timeoutSeconds: 1,
+};
+const notification = {
+  idempotencyKey,
+  repo: "openclaw/openclaw",
+  target: "#123",
+};
+
+const oldCalls = [];
+await assert.rejects(
+  oldPostHookNotification({
+    config,
+    notification,
+    fetcher: async (_input, init) => {
+      oldCalls.push(new Headers(init?.headers).get("idempotency-key"));
+      return new Response("transient", { status: 502 });
+    },
+  }),
+  /OpenClaw hook returned 502/,
+);
+
+const newCalls = [];
+const result = await postOpenClawAgentHook({
+  config: { ...config, retryAttempts: 2 },
+  fetcher: async (_input, init) => {
+    newCalls.push(new Headers(init?.headers).get("idempotency-key"));
+    return newCalls.length === 1
+      ? new Response("transient", { status: 502 })
+      : new Response(JSON.stringify({ runId: "proof-run" }), { status: 200 });
+  },
+  post: {
+    name: "ClawSweeper merged openclaw/openclaw#123",
+    message: "proof message",
+    idempotencyKey,
+    deliver: true,
+  },
+  retryDelaysMs: [0],
+});
+
+assert.equal(oldCalls.length, 1);
+assert.deepEqual(newCalls, [idempotencyKey, idempotencyKey]);
+assert.equal(result.runId, "proof-run");
+
+const siblingNotifiers = [
+  "src/repair/notify-events.ts",
+  "src/repair/notify-github-activity.ts",
+  "src/repair/notify-maintainer-report.ts",
+].map((file) => {
+  const source = fs.readFileSync(path.join(root, file), "utf8");
+  assert.match(source, /postOpenClawAgentHook/);
+  assert.match(source, /resolveOpenClawHookConfig/);
+  return file;
+});
+
+const artifact = {
+  base_ref: baseRef,
+  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
+  extracted_source: sourcePath,
+  extracted_source_sha256: createHash("sha256").update(oldFunction).digest("hex"),
+  scenario: "first hook response is transient HTTP 502",
+  old: { requests: oldCalls.length, outcome: "failed" },
+  new: {
+    requests: newCalls.length,
+    idempotency_keys: newCalls,
+    outcome: "succeeded",
+    run_id: result.runId,
+  },
+  sibling_notifier_precedent: siblingNotifiers,
+};
+
+const outputPath = path.join(
+  root,
+  "docs/proof/repair-duplication-merges/merge-1/artifacts/retry-adoption.json",
+);
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(JSON.stringify(artifact, null, 2));
+
+function gitShow(file) {
+  return execFileSync("git", ["show", `${baseRef}:${file}`], { encoding: "utf8" });
+}
+
+function extractBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  assert(startIndex >= 0 && endIndex > startIndex, `could not extract ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function compileOldFunction(source) {
+  const compiled = source.replace(/}: \{[\s\S]*?\}\): Promise<HookPostResult> \{/, "}) {");
+  const context = {
+    exports: {},
+    AbortController,
+    clearTimeout,
+    console,
+    JSON,
+    renderNotificationMessage: () => "proof message",
+    setTimeout,
+  };
+  vm.runInNewContext(`${compiled}\nexports.proof = postHookNotification;`, context);
+  return context.exports.proof;
+}

--- a/docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
@@ -1,130 +1,360 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { createServer } from "node:http";
 import { execFileSync } from "node:child_process";
-import fs from "node:fs";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import vm from "node:vm";
 
-import { postOpenClawAgentHook } from "../../../../dist/repair/openclaw-hook.js";
+import { runMergeNotifier } from "../../../../dist/repair/notify-merge.js";
 
 const root = process.cwd();
 const baseRef = process.env.PROOF_BASE_REF || "origin/main";
 const sourcePath = "src/repair/notify-merge.ts";
-const baseSource = gitShow(sourcePath);
-const oldFunction = extractBetween(
-  baseSource,
-  "async function postHookNotification(",
-  "\nfunction readHookRunId(",
-);
-const oldPostHookNotification = compileOldFunction(oldFunction);
-const idempotencyKey = "merge:openclaw/openclaw#123:merge_canonical:abc123";
-const config = {
-  hookUrl: "https://claw.example/hooks/agent",
-  token: "proof-token",
-  agentId: "clawsweeper",
-  channel: "discord",
-  discordTarget: "channel:123",
-  thinking: "low",
-  timeoutSeconds: 1,
-};
-const notification = {
-  idempotencyKey,
-  repo: "openclaw/openclaw",
-  target: "#123",
-};
-
-const oldCalls = [];
-await assert.rejects(
-  oldPostHookNotification({
-    config,
-    notification,
-    fetcher: async (_input, init) => {
-      oldCalls.push(new Headers(init?.headers).get("idempotency-key"));
-      return new Response("transient", { status: 502 });
-    },
-  }),
-  /OpenClaw hook returned 502/,
-);
-
-const newCalls = [];
-const result = await postOpenClawAgentHook({
-  config: { ...config, retryAttempts: 2 },
-  fetcher: async (_input, init) => {
-    newCalls.push(new Headers(init?.headers).get("idempotency-key"));
-    return newCalls.length === 1
-      ? new Response("transient", { status: 502 })
-      : new Response(JSON.stringify({ runId: "proof-run" }), { status: 200 });
-  },
-  post: {
-    name: "ClawSweeper merged openclaw/openclaw#123",
-    message: "proof message",
-    idempotencyKey,
-    deliver: true,
-  },
-  retryDelaysMs: [0],
-});
-
-assert.equal(oldCalls.length, 1);
-assert.deepEqual(newCalls, [idempotencyKey, idempotencyKey]);
-assert.equal(result.runId, "proof-run");
-
-const siblingNotifiers = [
-  "src/repair/notify-events.ts",
-  "src/repair/notify-github-activity.ts",
-  "src/repair/notify-maintainer-report.ts",
-].map((file) => {
-  const source = fs.readFileSync(path.join(root, file), "utf8");
-  assert.match(source, /postOpenClawAgentHook/);
-  assert.match(source, /resolveOpenClawHookConfig/);
-  return file;
-});
-
-const artifact = {
-  base_ref: baseRef,
-  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
-  extracted_source: sourcePath,
-  extracted_source_sha256: createHash("sha256").update(oldFunction).digest("hex"),
-  scenario: "first hook response is transient HTTP 502",
-  old: { requests: oldCalls.length, outcome: "failed" },
-  new: {
-    requests: newCalls.length,
-    idempotency_keys: newCalls,
-    outcome: "succeeded",
-    run_id: result.runId,
-  },
-  sibling_notifier_precedent: siblingNotifiers,
-};
-
-const outputPath = path.join(
+const currentCli = path.join(root, "dist/repair/notify-merge.js");
+const artifactPath = path.join(
   root,
   "docs/proof/repair-duplication-merges/merge-1/artifacts/retry-adoption.json",
 );
-fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-fs.writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+const idempotencyKey = "merge:openclaw/openclaw#123:merge_canonical:abc123";
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "clawsweeper-notify-merge-proof-"));
+const requests = [];
+const scenarioAttempts = new Map();
+
+assert.equal(
+  await fileExists(currentCli),
+  true,
+  "build the repair CLI before running this proof",
+);
+
+const server = createServer(async (request, response) => {
+  const receivedAt = new Date().toISOString();
+  const pathname = new URL(request.url || "/", "http://127.0.0.1").pathname;
+  const scenario = pathname.startsWith("/old/") ? "old" : pathname.startsWith("/new/") ? "new" : "unknown";
+  const attempt = (scenarioAttempts.get(scenario) ?? 0) + 1;
+  scenarioAttempts.set(scenario, attempt);
+  const body = await readRequestBody(request);
+  const status = attempt === 1 ? 503 : 200;
+  const event = {
+    scenario,
+    attempt,
+    received_at: receivedAt,
+    method: request.method,
+    pathname,
+    idempotency_key: String(request.headers["idempotency-key"] ?? ""),
+    body_idempotency_key: parseBodyIdempotencyKey(body),
+    local_address: request.socket.localAddress,
+    remote_address: request.socket.remoteAddress,
+    response_status: status,
+  };
+  requests.push(event);
+  const responseBody =
+    status === 503
+      ? JSON.stringify({ error: "proof_transient_503" })
+      : JSON.stringify({ runId: "proof-run" });
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(responseBody),
+  });
+  response.end(responseBody);
+});
+
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+debug("listener ready");
+
+let artifact;
+try {
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const origin = `http://127.0.0.1:${address.port}`;
+  const baselineRoot = path.join(tempRoot, "baseline");
+  await mkdir(baselineRoot, { recursive: true });
+  await extractGitTree(baseRef, baselineRoot);
+  debug("baseline extracted");
+  await symlink(path.join(root, "node_modules"), path.join(baselineRoot, "node_modules"), "dir");
+  const baselineBuild = await runProcess(
+    process.execPath,
+    [path.join(root, "node_modules/typescript/bin/tsc"), "-p", path.join(baselineRoot, "tsconfig.repair.json")],
+    { cwd: baselineRoot },
+  );
+  assert.equal(baselineBuild.exitCode, 0, baselineBuild.stderr || baselineBuild.stdout);
+  debug("baseline built");
+
+  const inputPath = path.join(tempRoot, "repair-apply-report.json");
+  await writeFile(
+    inputPath,
+    `${JSON.stringify([
+      {
+        action: "merge_canonical",
+        status: "executed",
+        repo: "openclaw/openclaw",
+        target: "#123",
+        title: "Real socket proof",
+        reason: "proof fixture",
+        merge_commit_sha: "abc123",
+        merged_at: "2026-08-10T00:00:00.000Z",
+      },
+    ], null, 2)}\n`,
+  );
+
+  const baselineCli = path.join(baselineRoot, "dist/repair/notify-merge.js");
+  const oldRun = await runNotifier({
+    cli: baselineCli,
+    root: baselineRoot,
+    scenario: "old",
+    origin,
+    inputPath,
+  });
+  debug("old notifier complete");
+  const newRun = await runCurrentNotifier({
+    scenario: "new",
+    origin,
+    inputPath,
+  });
+  debug("new notifier complete");
+
+  const oldRequests = requests.filter((request) => request.scenario === "old");
+  const newRequests = requests.filter((request) => request.scenario === "new");
+  debug(`old run ${JSON.stringify(oldRun)}`);
+  debug(`new run ${JSON.stringify(newRun)}`);
+  assert.equal(oldRun.exitCode, 1, oldRun.stdout);
+  assert.equal(oldRequests.length, 1);
+  assert.equal(oldRequests[0].response_status, 503);
+  assert.equal(newRun.exitCode, 0, newRun.stderr);
+  assert.equal(newRequests.length, 2);
+  assert.deepEqual(
+    newRequests.map((request) => request.response_status),
+    [503, 200],
+  );
+  assert.deepEqual(
+    newRequests.map((request) => request.idempotency_key),
+    [idempotencyKey, idempotencyKey],
+  );
+  assert(requests.every((request) => request.local_address === "127.0.0.1"));
+  assert(requests.every((request) => request.remote_address === "127.0.0.1"));
+  assert(requests.every((request) => request.idempotency_key === idempotencyKey));
+  assert(requests.every((request) => request.body_idempotency_key === idempotencyKey));
+
+  const oldReport = JSON.parse(await readFile(oldRun.reportPath, "utf8"));
+  const newReport = JSON.parse(await readFile(newRun.reportPath, "utf8"));
+  assert.equal(oldReport.failed, 1);
+  assert.equal(oldReport.sent, 0);
+  assert.equal(newReport.failed, 0);
+  assert.equal(newReport.sent, 1);
+
+  const siblingNotifiers = [
+    "src/repair/notify-events.ts",
+    "src/repair/notify-github-activity.ts",
+    "src/repair/notify-maintainer-report.ts",
+  ];
+  for (const file of siblingNotifiers) {
+    const source = await readFile(path.join(root, file), "utf8");
+    assert.match(source, /postOpenClawAgentHook/);
+    assert.match(source, /resolveOpenClawHookConfig/);
+  }
+
+  artifact = {
+    base_ref: baseRef,
+    base_sha: git("rev-parse", baseRef),
+    source: {
+      baseline: {
+        path: sourcePath,
+        sha256: sha256(await readFile(path.join(baselineRoot, sourcePath))),
+        cli_sha256: sha256(await readFile(baselineCli)),
+      },
+      current: {
+        path: sourcePath,
+        sha256: sha256(await readFile(path.join(root, sourcePath))),
+        cli_sha256: sha256(await readFile(currentCli)),
+      },
+    },
+    transport: {
+      kind: "real loopback HTTP socket",
+      bound_address: `127.0.0.1:${address.port}`,
+      requests,
+    },
+    old: {
+      entrypoint: "baseline dist/repair/notify-merge.js",
+      exit_code: oldRun.exitCode,
+      outcome: "failed after one HTTP 503",
+      requests: oldRequests.length,
+      stdout: oldRun.stdout.trim(),
+      stderr: oldRun.stderr.trim(),
+    },
+    new: {
+      entrypoint: "runMergeNotifier (the function invoked by dist/repair/notify-merge.js main)",
+      exit_code: newRun.exitCode,
+      outcome: "succeeded after HTTP 503 then HTTP 200",
+      requests: newRequests.length,
+      stdout: newRun.stdout.trim(),
+      stderr: newRun.stderr.trim(),
+    },
+    sibling_notifier_precedent: siblingNotifiers,
+  };
+  debug("artifact assembled");
+} finally {
+  debug("cleanup start");
+  await closeServer(server);
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+await mkdir(path.dirname(artifactPath), { recursive: true });
+await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
 console.log(JSON.stringify(artifact, null, 2));
 
-function gitShow(file) {
-  return execFileSync("git", ["show", `${baseRef}:${file}`], { encoding: "utf8" });
-}
-
-function extractBetween(source, start, end) {
-  const startIndex = source.indexOf(start);
-  const endIndex = source.indexOf(end, startIndex);
-  assert(startIndex >= 0 && endIndex > startIndex, `could not extract ${start}`);
-  return source.slice(startIndex, endIndex);
-}
-
-function compileOldFunction(source) {
-  const compiled = source.replace(/}: \{[\s\S]*?\}\): Promise<HookPostResult> \{/, "}) {");
-  const context = {
-    exports: {},
-    AbortController,
-    clearTimeout,
-    console,
-    JSON,
-    renderNotificationMessage: () => "proof message",
-    setTimeout,
+async function runNotifier({ cli, root: notifierRoot, scenario, origin, inputPath }) {
+  const scenarioRoot = path.join(tempRoot, scenario);
+  const ledgerPath = path.join(scenarioRoot, "ledger.json");
+  const reportPath = path.join(scenarioRoot, "report.json");
+  await mkdir(scenarioRoot, { recursive: true });
+  const env = {
+    ...process.env,
+    CLAWSWEEPER_DISCORD_TARGET: "channel:proof",
+    CLAWSWEEPER_MERGE_NOTIFY_STRICT: "1",
+    CLAWSWEEPER_OPENCLAW_HOOK_RETRY_ATTEMPTS: "2",
+    CLAWSWEEPER_OPENCLAW_HOOK_TIMEOUT_SECONDS: "1",
+    CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "disposable-local-proof-token",
+    CLAWSWEEPER_OPENCLAW_HOOK_URL: `${origin}/${scenario}`,
   };
-  vm.runInNewContext(`${compiled}\nexports.proof = postHookNotification;`, context);
-  return context.exports.proof;
+  const result = await runProcess(
+    process.execPath,
+    [
+      await realpath(cli),
+      "--input",
+      inputPath,
+      "--ledger",
+      ledgerPath,
+      "--report",
+      reportPath,
+      "--strict",
+    ],
+    { cwd: notifierRoot, env },
+  );
+  return { ...result, reportPath };
+}
+
+async function runCurrentNotifier({ scenario, origin, inputPath }) {
+  const scenarioRoot = path.join(tempRoot, scenario);
+  const ledgerPath = path.join(scenarioRoot, "ledger.json");
+  const reportPath = path.join(scenarioRoot, "report.json");
+  await mkdir(scenarioRoot, { recursive: true });
+  const proofEnv = {
+    CLAWSWEEPER_DISCORD_TARGET: "channel:proof",
+    CLAWSWEEPER_MERGE_NOTIFY_STRICT: "1",
+    CLAWSWEEPER_OPENCLAW_HOOK_RETRY_ATTEMPTS: "2",
+    CLAWSWEEPER_OPENCLAW_HOOK_TIMEOUT_SECONDS: "1",
+    CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "disposable-local-proof-token",
+    CLAWSWEEPER_OPENCLAW_HOOK_URL: `${origin}/${scenario}`,
+  };
+  const previous = new Map(Object.keys(proofEnv).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, proofEnv);
+  const logs = [];
+  try {
+    const summary = await runMergeNotifier(
+      [
+        "--input",
+        inputPath,
+        "--ledger",
+        ledgerPath,
+        "--report",
+        reportPath,
+        "--strict",
+      ],
+      { log: (line) => logs.push(line) },
+    );
+    return {
+      exitCode: summary.exitCode,
+      signal: null,
+      stdout: logs.join("\n"),
+      stderr: "",
+      reportPath,
+    };
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function extractGitTree(ref, destination) {
+  const archivePath = path.join(tempRoot, "baseline.tar");
+  execFileSync("git", ["archive", "--format=tar", "-o", archivePath, ref], { cwd: root });
+  execFileSync("tar", ["-x", "-f", archivePath, "-C", destination]);
+  await rm(archivePath);
+}
+
+function runProcess(command, args, options = {}) {
+  return collectProcess(
+    spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+}
+
+function collectProcess(child) {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => (stdout += chunk));
+    child.stderr?.on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) => resolve({ exitCode, signal, stdout, stderr }));
+  });
+}
+
+async function readRequestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseBodyIdempotencyKey(body) {
+  try {
+    return JSON.parse(body).idempotencyKey ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fileExists(file) {
+  try {
+    await readFile(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function git(...args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function closeServer(httpServer) {
+  httpServer.close();
+  httpServer.closeAllConnections?.();
+}
+
+function debug(message) {
+  if (process.env.PROOF_DEBUG === "1") console.error(`[proof-debug] ${message}`);
 }

--- a/docs/proof/repair-duplication-merges/merge-2/README.md
+++ b/docs/proof/repair-duplication-merges/merge-2/README.md
@@ -1,0 +1,17 @@
+# Gitcrawl store resolver equivalence proof
+
+This proof extracts both repair-side resolver copies from `origin/main`, runs
+representative repository normalization, explicit override, environment
+override, portable-store priority, and legacy-fallback scenarios through both
+old copies and the new shared resolver, and requires identical path outputs.
+
+Run after `pnpm run build:repair`:
+
+```sh
+node docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
+```
+
+The checked-in result is in `artifacts/equivalence.json`. The harness also
+records that the callers retain their intentionally different `sqliteJson`
+buffer limits. It uses virtual file-existence probes and performs no database,
+network, GitHub, or production mutation.

--- a/docs/proof/repair-duplication-merges/merge-2/README.md
+++ b/docs/proof/repair-duplication-merges/merge-2/README.md
@@ -1,9 +1,18 @@
 # Gitcrawl store resolver equivalence proof
 
-This proof extracts both repair-side resolver copies from `origin/main`, runs
-representative repository normalization, explicit override, environment
-override, portable-store priority, and legacy-fallback scenarios through both
-old copies and the new shared resolver, and requires identical path outputs.
+This proof creates isolated repository/home layouts containing actual SQLite
+databases. It covers a sibling portable store, portable-store absence with a
+legacy fallback, and an environment override that wins over both competing
+files. Both resolver copies extracted from `origin/main` and the shared current
+resolver inspect those same files through real `fs.existsSync` calls and must
+return identical paths.
+
+For every layout, the proof also runs both built production entry points:
+`dist/repair/import-gitcrawl-clusters.js` and
+`dist/repair/import-gitcrawl-low-signal-prs.js`. They query the selected file
+through a proof-local `sqlite3`-compatible CLI backed by Node's real
+`node:sqlite` engine. Its trace captures the database path each importer opened,
+and marker rows in each database prove that competing files were not read.
 
 Run after `pnpm run build:repair`:
 
@@ -13,5 +22,5 @@ node docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
 
 The checked-in result is in `artifacts/equivalence.json`. The harness also
 records that the callers retain their intentionally different `sqliteJson`
-buffer limits. It uses virtual file-existence probes and performs no database,
+buffer limits. All fixtures are disposable local files; the proof performs no
 network, GitHub, or production mutation.

--- a/docs/proof/repair-duplication-merges/merge-2/artifacts/equivalence.json
+++ b/docs/proof/repair-duplication-merges/merge-2/artifacts/equivalence.json
@@ -1,0 +1,71 @@
+{
+  "base_ref": "origin/main",
+  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "extractions": [
+    {
+      "file": "src/repair/import-gitcrawl-clusters.ts",
+      "sha256": "4e79d6ac9cdc0244afbfc544a9a76b7f61bc6b67d61dd5c47161507b31a8a5cc"
+    },
+    {
+      "file": "src/repair/import-gitcrawl-low-signal-prs.ts",
+      "sha256": "4e79d6ac9cdc0244afbfc544a9a76b7f61bc6b67d61dd5c47161507b31a8a5cc"
+    }
+  ],
+  "results": [
+    {
+      "scenario": "explicit override wins",
+      "old": [
+        "/proof/explicit.db",
+        "/proof/explicit.db"
+      ],
+      "current": "/proof/explicit.db",
+      "identical": true
+    },
+    {
+      "scenario": "environment override",
+      "old": [
+        "/proof/configured.db",
+        "/proof/configured.db"
+      ],
+      "current": "/proof/configured.db",
+      "identical": true
+    },
+    {
+      "scenario": "sibling portable store precedes user store",
+      "old": [
+        "/proof/gitcrawl-store/data/openclaw__openclaw.sync.db",
+        "/proof/gitcrawl-store/data/openclaw__openclaw.sync.db"
+      ],
+      "current": "/proof/gitcrawl-store/data/openclaw__openclaw.sync.db",
+      "identical": true
+    },
+    {
+      "scenario": "user portable store precedes legacy store",
+      "old": [
+        "/proof/home/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db",
+        "/proof/home/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db"
+      ],
+      "current": "/proof/home/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db",
+      "identical": true
+    },
+    {
+      "scenario": "missing stores fall back to legacy path",
+      "old": [
+        "/proof/home/.config/gitcrawl/gitcrawl.db",
+        "/proof/home/.config/gitcrawl/gitcrawl.db"
+      ],
+      "current": "/proof/home/.config/gitcrawl/gitcrawl.db",
+      "identical": true
+    }
+  ],
+  "caller_local_sqlite_buffers": [
+    {
+      "file": "src/repair/import-gitcrawl-clusters.ts",
+      "max_buffer_expression": "256 * 1024 * 1024"
+    },
+    {
+      "file": "src/repair/import-gitcrawl-low-signal-prs.ts",
+      "max_buffer_expression": "64 * 1024 * 1024"
+    }
+  ]
+}

--- a/docs/proof/repair-duplication-merges/merge-2/artifacts/equivalence.json
+++ b/docs/proof/repair-duplication-merges/merge-2/artifacts/equivalence.json
@@ -1,6 +1,11 @@
 {
   "base_ref": "origin/main",
-  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "base_sha": "765644804756d5f6b1dc1e940d62c50711e398d8",
+  "fixtures": {
+    "storage": "real SQLite files created with node:sqlite DatabaseSync",
+    "query_boundary": "both built importer entry points spawn a proof-local sqlite3-compatible CLI backed by node:sqlite",
+    "path_observation": "the SQLite CLI trace records the database path opened by each importer"
+  },
   "extractions": [
     {
       "file": "src/repair/import-gitcrawl-clusters.ts",
@@ -13,49 +18,173 @@
   ],
   "results": [
     {
-      "scenario": "explicit override wins",
-      "old": [
-        "/proof/explicit.db",
-        "/proof/explicit.db"
+      "scenario": "portable-store present",
+      "resolved_store_path": "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+      "old_resolver_paths": [
+        "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+        "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db"
       ],
-      "current": "/proof/explicit.db",
-      "identical": true
+      "identical": true,
+      "real_file": {
+        "exists": true,
+        "sha256": "f960d92f768f33598c9ee038b717561d431164d6c25341b44496a678adb05f3a"
+      },
+      "importer_entry_points": [
+        {
+          "cli": "dist/repair/import-gitcrawl-clusters.js",
+          "exit_code": 0,
+          "opened_store_paths": [
+            "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db"
+          ],
+          "observed_fixture_marker": "portable-store"
+        },
+        {
+          "cli": "dist/repair/import-gitcrawl-low-signal-prs.js",
+          "exit_code": 0,
+          "opened_store_paths": [
+            "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db"
+          ],
+          "observed_fixture_marker": "portable-store"
+        }
+      ],
+      "sqlite_queries": [
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+          "sql_sha256": "65c2784b0b87e91c8f4d94b6edd2aea215d91d1c94700cceb7bfa0802eaecdf4"
+        },
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+          "sql_sha256": "ba1ab8b2a5f3327d0f3d3bf1119ac652c9ccf97446493c13806e0b1c19908eb5"
+        },
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+          "sql_sha256": "e328946aa69d0f7880d5fde58bbae2ea7aa3316b614184cbfb65cfa7d8cd6406"
+        },
+        {
+          "json": true,
+          "db_path": "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+          "sql_sha256": "8d21b6a2e7d30e76df0864c345fe39008dcc4c4aa21f31d90702f0e4c0efecd3"
+        },
+        {
+          "json": true,
+          "db_path": "$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db",
+          "sql_sha256": "8ea6cf3705e94d0aa6019a5c91ba967db6ae4020d9c6b821433135c3d4248dad"
+        }
+      ]
     },
     {
-      "scenario": "environment override",
-      "old": [
-        "/proof/configured.db",
-        "/proof/configured.db"
+      "scenario": "portable absent -> legacy fallback",
+      "resolved_store_path": "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db",
+      "old_resolver_paths": [
+        "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db",
+        "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db"
       ],
-      "current": "/proof/configured.db",
-      "identical": true
+      "identical": true,
+      "real_file": {
+        "exists": true,
+        "sha256": "3cc19212a3b669375d62f0b442981d020377920ec9a79b237216c964098a180c"
+      },
+      "importer_entry_points": [
+        {
+          "cli": "dist/repair/import-gitcrawl-clusters.js",
+          "exit_code": 0,
+          "opened_store_paths": [
+            "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db"
+          ],
+          "observed_fixture_marker": "legacy-fallback"
+        },
+        {
+          "cli": "dist/repair/import-gitcrawl-low-signal-prs.js",
+          "exit_code": 0,
+          "opened_store_paths": [
+            "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db"
+          ],
+          "observed_fixture_marker": "legacy-fallback"
+        }
+      ],
+      "sqlite_queries": [
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db",
+          "sql_sha256": "65c2784b0b87e91c8f4d94b6edd2aea215d91d1c94700cceb7bfa0802eaecdf4"
+        },
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db",
+          "sql_sha256": "223a7c70eb993ab6d0ee2510f541ab8051b384a06ea9704b43e7c7181aa76297"
+        },
+        {
+          "json": true,
+          "db_path": "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db",
+          "sql_sha256": "8dbfcc0a807ca6a57ae14b8bcf02b00569e384ac28d0aa22fb688d936fd4d79b"
+        },
+        {
+          "json": true,
+          "db_path": "$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db",
+          "sql_sha256": "8ea6cf3705e94d0aa6019a5c91ba967db6ae4020d9c6b821433135c3d4248dad"
+        }
+      ]
     },
     {
-      "scenario": "sibling portable store precedes user store",
-      "old": [
-        "/proof/gitcrawl-store/data/openclaw__openclaw.sync.db",
-        "/proof/gitcrawl-store/data/openclaw__openclaw.sync.db"
+      "scenario": "env override set",
+      "resolved_store_path": "$FIXTURE_ROOT/override/configured.db",
+      "old_resolver_paths": [
+        "$FIXTURE_ROOT/override/configured.db",
+        "$FIXTURE_ROOT/override/configured.db"
       ],
-      "current": "/proof/gitcrawl-store/data/openclaw__openclaw.sync.db",
-      "identical": true
-    },
-    {
-      "scenario": "user portable store precedes legacy store",
-      "old": [
-        "/proof/home/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db",
-        "/proof/home/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db"
+      "identical": true,
+      "real_file": {
+        "exists": true,
+        "sha256": "f7c60943afba268dda999fbc5c2e1d73c5abfba61944cbc7fce8446922e4c5b4"
+      },
+      "importer_entry_points": [
+        {
+          "cli": "dist/repair/import-gitcrawl-clusters.js",
+          "exit_code": 0,
+          "opened_store_paths": [
+            "$FIXTURE_ROOT/override/configured.db"
+          ],
+          "observed_fixture_marker": "env-override"
+        },
+        {
+          "cli": "dist/repair/import-gitcrawl-low-signal-prs.js",
+          "exit_code": 0,
+          "opened_store_paths": [
+            "$FIXTURE_ROOT/override/configured.db"
+          ],
+          "observed_fixture_marker": "env-override"
+        }
       ],
-      "current": "/proof/home/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db",
-      "identical": true
-    },
-    {
-      "scenario": "missing stores fall back to legacy path",
-      "old": [
-        "/proof/home/.config/gitcrawl/gitcrawl.db",
-        "/proof/home/.config/gitcrawl/gitcrawl.db"
-      ],
-      "current": "/proof/home/.config/gitcrawl/gitcrawl.db",
-      "identical": true
+      "sqlite_queries": [
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/override/configured.db",
+          "sql_sha256": "65c2784b0b87e91c8f4d94b6edd2aea215d91d1c94700cceb7bfa0802eaecdf4"
+        },
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/override/configured.db",
+          "sql_sha256": "ba1ab8b2a5f3327d0f3d3bf1119ac652c9ccf97446493c13806e0b1c19908eb5"
+        },
+        {
+          "json": false,
+          "db_path": "$FIXTURE_ROOT/override/configured.db",
+          "sql_sha256": "e328946aa69d0f7880d5fde58bbae2ea7aa3316b614184cbfb65cfa7d8cd6406"
+        },
+        {
+          "json": true,
+          "db_path": "$FIXTURE_ROOT/override/configured.db",
+          "sql_sha256": "8d21b6a2e7d30e76df0864c345fe39008dcc4c4aa21f31d90702f0e4c0efecd3"
+        },
+        {
+          "json": true,
+          "db_path": "$FIXTURE_ROOT/override/configured.db",
+          "sql_sha256": "8ea6cf3705e94d0aa6019a5c91ba967db6ae4020d9c6b821433135c3d4248dad"
+        }
+      ]
     }
   ],
   "caller_local_sqlite_buffers": [

--- a/docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import vm from "node:vm";
+
+import { resolveGitcrawlDbPath } from "../../../../dist/repair/gitcrawl-store.js";
+
+const root = process.cwd();
+const baseRef = process.env.PROOF_BASE_REF || "origin/main";
+const files = [
+  "src/repair/import-gitcrawl-clusters.ts",
+  "src/repair/import-gitcrawl-low-signal-prs.ts",
+];
+const oldResolvers = files.map((file) => {
+  const source = gitShow(file);
+  const endMarker = file.endsWith("clusters.ts") ? "\nfs.mkdirSync" : "\nconst candidates";
+  const extracted = extractBetween(source, "function gitcrawlStoreDbFileName(", endMarker);
+  return { file, source, extracted, resolve: compileResolver(extracted) };
+});
+
+const proofRoot = path.resolve("/proof/clawsweeper");
+const proofHome = path.resolve("/proof/home");
+const storeFile = "openclaw__openclaw.sync.db";
+const siblingStore = path.join(proofRoot, "..", "gitcrawl-store", "data", storeFile);
+const userStore = path.join(
+  proofHome,
+  ".config",
+  "gitcrawl",
+  "stores",
+  "gitcrawl-store",
+  "data",
+  storeFile,
+);
+const cases = [
+  {
+    name: "explicit override wins",
+    repo: " OpenClaw/OpenClaw ",
+    explicitDb: " ./explicit.db ",
+    env: { CLAWSWEEPER_GITCRAWL_DB: "/ignored.db" },
+    existing: [],
+  },
+  {
+    name: "environment override",
+    repo: "OpenClaw/OpenClaw",
+    env: { CLAWSWEEPER_GITCRAWL_DB: " ./configured.db " },
+    existing: [],
+  },
+  {
+    name: "sibling portable store precedes user store",
+    repo: "OpenClaw/OpenClaw",
+    env: {},
+    existing: [siblingStore, userStore],
+  },
+  {
+    name: "user portable store precedes legacy store",
+    repo: "OpenClaw/OpenClaw",
+    env: {},
+    existing: [userStore, path.join(proofHome, ".config", "gitcrawl", "gitcrawl.db")],
+  },
+  {
+    name: "missing stores fall back to legacy path",
+    repo: "OpenClaw/OpenClaw",
+    env: {},
+    existing: [],
+  },
+];
+
+const results = cases.map((scenario) => {
+  const existing = new Set(scenario.existing);
+  const old = oldResolvers.map(({ resolve }) =>
+    resolve(scenario.repo, scenario.explicitDb, {
+      env: scenario.env,
+      existing,
+      root: proofRoot,
+      homeDir: proofHome,
+    }),
+  );
+  const current = resolveGitcrawlDbPath(scenario.repo, scenario.explicitDb, {
+    env: scenario.env,
+    root: proofRoot,
+    homeDir: proofHome,
+    existsSync: (candidate) => existing.has(candidate),
+  });
+  assert.deepEqual(old, [current, current]);
+  return { scenario: scenario.name, old, current, identical: true };
+});
+
+const artifact = {
+  base_ref: baseRef,
+  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
+  extractions: oldResolvers.map(({ file, extracted }) => ({
+    file,
+    sha256: createHash("sha256").update(extracted).digest("hex"),
+  })),
+  results,
+  caller_local_sqlite_buffers: oldResolvers.map(({ file, source }) => ({
+    file,
+    max_buffer_expression: extractSqliteBuffer(source),
+  })),
+};
+
+const outputPath = path.join(
+  root,
+  "docs/proof/repair-duplication-merges/merge-2/artifacts/equivalence.json",
+);
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(JSON.stringify(artifact, null, 2));
+
+function gitShow(file) {
+  return execFileSync("git", ["show", `${baseRef}:${file}`], { encoding: "utf8" });
+}
+
+function extractBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  assert(startIndex >= 0 && endIndex > startIndex, `could not extract ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function compileResolver(source) {
+  const javascript = source
+    .replaceAll("repoFullName: string", "repoFullName")
+    .replaceAll("explicitDb?: string", "explicitDb")
+    .replaceAll("): string", ")")
+    .replaceAll("at(-1)!", "at(-1)");
+  return (repo, explicitDb, runtime) => {
+    const context = {
+      exports: {},
+      fs: { existsSync: (candidate) => runtime.existing.has(candidate) },
+      os: { homedir: () => runtime.homeDir },
+      path,
+      process: { env: runtime.env },
+      repoRoot: () => runtime.root,
+    };
+    vm.runInNewContext(`${javascript}\nexports.proof = resolveGitcrawlDbPath;`, context);
+    return context.exports.proof(repo, explicitDb);
+  };
+}
+
+function extractSqliteBuffer(source) {
+  const sqliteJson = extractBetween(source, "function sqliteJson(", "\nfunction ");
+  const match = sqliteJson.match(/maxBuffer:\s*([^,\n]+)/);
+  assert(match?.[1], "sqliteJson maxBuffer not found");
+  return match[1].trim();
+}

--- a/docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
@@ -38,14 +38,14 @@ const cases = [
   {
     name: "explicit override wins",
     repo: " OpenClaw/OpenClaw ",
-    explicitDb: " ./explicit.db ",
+    explicitDb: " /proof/explicit.db ",
     env: { CLAWSWEEPER_GITCRAWL_DB: "/ignored.db" },
     existing: [],
   },
   {
     name: "environment override",
     repo: "OpenClaw/OpenClaw",
-    env: { CLAWSWEEPER_GITCRAWL_DB: " ./configured.db " },
+    env: { CLAWSWEEPER_GITCRAWL_DB: " /proof/configured.db " },
     existing: [],
   },
   {

--- a/docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
@@ -1,99 +1,80 @@
 import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import {
+  chmod,
+  cp,
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import vm from "node:vm";
+import { DatabaseSync } from "node:sqlite";
 
 import { resolveGitcrawlDbPath } from "../../../../dist/repair/gitcrawl-store.js";
 
 const root = process.cwd();
 const baseRef = process.env.PROOF_BASE_REF || "origin/main";
-const files = [
+const repo = "openclaw/openclaw";
+const storeFile = "openclaw__openclaw.sync.db";
+const importerFiles = [
   "src/repair/import-gitcrawl-clusters.ts",
   "src/repair/import-gitcrawl-low-signal-prs.ts",
 ];
-const oldResolvers = files.map((file) => {
+const oldResolvers = importerFiles.map((file) => {
   const source = gitShow(file);
   const endMarker = file.endsWith("clusters.ts") ? "\nfs.mkdirSync" : "\nconst candidates";
   const extracted = extractBetween(source, "function gitcrawlStoreDbFileName(", endMarker);
   return { file, source, extracted, resolve: compileResolver(extracted) };
 });
-
-const proofRoot = path.resolve("/proof/clawsweeper");
-const proofHome = path.resolve("/proof/home");
-const storeFile = "openclaw__openclaw.sync.db";
-const siblingStore = path.join(proofRoot, "..", "gitcrawl-store", "data", storeFile);
-const userStore = path.join(
-  proofHome,
-  ".config",
-  "gitcrawl",
-  "stores",
-  "gitcrawl-store",
-  "data",
-  storeFile,
+const tempRoot = await realpath(
+  await mkdtemp(path.join(os.tmpdir(), "clawsweeper-gitcrawl-store-proof-")),
 );
-const cases = [
-  {
-    name: "explicit override wins",
-    repo: " OpenClaw/OpenClaw ",
-    explicitDb: " /proof/explicit.db ",
-    env: { CLAWSWEEPER_GITCRAWL_DB: "/ignored.db" },
-    existing: [],
-  },
-  {
-    name: "environment override",
-    repo: "OpenClaw/OpenClaw",
-    env: { CLAWSWEEPER_GITCRAWL_DB: " /proof/configured.db " },
-    existing: [],
-  },
-  {
-    name: "sibling portable store precedes user store",
-    repo: "OpenClaw/OpenClaw",
-    env: {},
-    existing: [siblingStore, userStore],
-  },
-  {
-    name: "user portable store precedes legacy store",
-    repo: "OpenClaw/OpenClaw",
-    env: {},
-    existing: [userStore, path.join(proofHome, ".config", "gitcrawl", "gitcrawl.db")],
-  },
-  {
-    name: "missing stores fall back to legacy path",
-    repo: "OpenClaw/OpenClaw",
-    env: {},
-    existing: [],
-  },
-];
+const adapterDir = path.join(tempRoot, "sqlite-adapter");
+const adapterPath = path.join(adapterDir, "sqlite3");
+const results = [];
 
-const results = cases.map((scenario) => {
-  const existing = new Set(scenario.existing);
-  const old = oldResolvers.map(({ resolve }) =>
-    resolve(scenario.repo, scenario.explicitDb, {
-      env: scenario.env,
-      existing,
-      root: proofRoot,
-      homeDir: proofHome,
-    }),
-  );
-  const current = resolveGitcrawlDbPath(scenario.repo, scenario.explicitDb, {
-    env: scenario.env,
-    root: proofRoot,
-    homeDir: proofHome,
-    existsSync: (candidate) => existing.has(candidate),
-  });
-  assert.deepEqual(old, [current, current]);
-  return { scenario: scenario.name, old, current, identical: true };
-});
+assert.equal(
+  fs.existsSync(path.join(root, "dist/repair/import-gitcrawl-clusters.js")),
+  true,
+  "build the repair CLIs before running this proof",
+);
+
+await mkdir(adapterDir, { recursive: true });
+await writeFile(adapterPath, sqliteAdapterSource(), { mode: 0o755 });
+await chmod(adapterPath, 0o755);
+
+try {
+  for (const scenario of [
+    { name: "portable-store present", selected: "portable" },
+    { name: "portable absent -> legacy fallback", selected: "legacy" },
+    { name: "env override set", selected: "override" },
+  ]) {
+    results.push(await runScenario(scenario));
+  }
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
 
 const artifact = {
   base_ref: baseRef,
-  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
+  base_sha: execFileSync("git", ["rev-parse", baseRef], { cwd: root, encoding: "utf8" }).trim(),
+  fixtures: {
+    storage: "real SQLite files created with node:sqlite DatabaseSync",
+    query_boundary:
+      "both built importer entry points spawn a proof-local sqlite3-compatible CLI backed by node:sqlite",
+    path_observation: "the SQLite CLI trace records the database path opened by each importer",
+  },
   extractions: oldResolvers.map(({ file, extracted }) => ({
     file,
-    sha256: createHash("sha256").update(extracted).digest("hex"),
+    sha256: sha256(extracted),
   })),
   results,
   caller_local_sqlite_buffers: oldResolvers.map(({ file, source }) => ({
@@ -106,12 +87,238 @@ const outputPath = path.join(
   root,
   "docs/proof/repair-duplication-merges/merge-2/artifacts/equivalence.json",
 );
-fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-fs.writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+await mkdir(path.dirname(outputPath), { recursive: true });
+await writeFile(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
 console.log(JSON.stringify(artifact, null, 2));
 
+async function runScenario(scenario) {
+  const scenarioSlug = scenario.name.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
+  const scenarioRoot = path.join(tempRoot, scenarioSlug);
+  const runtimeRoot = path.join(scenarioRoot, "clawsweeper");
+  const homeDir = path.join(scenarioRoot, "home");
+  const portablePath = path.join(scenarioRoot, "gitcrawl-store", "data", storeFile);
+  const legacyPath = path.join(homeDir, ".config", "gitcrawl", "gitcrawl.db");
+  const overridePath = path.join(scenarioRoot, "override", "configured.db");
+  const tracePath = path.join(scenarioRoot, "sqlite-path-trace.jsonl");
+  await mkdir(runtimeRoot, { recursive: true });
+  await cp(path.join(root, "dist"), path.join(runtimeRoot, "dist"), { recursive: true });
+  await cp(path.join(root, "config"), path.join(runtimeRoot, "config"), { recursive: true });
+  await writeFile(path.join(runtimeRoot, "package.json"), '{"type":"module"}\n');
+
+  if (scenario.selected === "portable") {
+    createFixtureDatabase(portablePath, "portable-store", "portable");
+    createFixtureDatabase(legacyPath, "competing-legacy", "legacy");
+  } else if (scenario.selected === "legacy") {
+    createFixtureDatabase(legacyPath, "legacy-fallback", "legacy");
+  } else {
+    createFixtureDatabase(portablePath, "competing-portable", "portable");
+    createFixtureDatabase(legacyPath, "competing-legacy", "legacy");
+    createFixtureDatabase(overridePath, "env-override", "portable");
+  }
+
+  const resolverEnv =
+    scenario.selected === "override" ? { CLAWSWEEPER_GITCRAWL_DB: overridePath } : {};
+  const expectedPath =
+    scenario.selected === "portable"
+      ? portablePath
+      : scenario.selected === "legacy"
+        ? legacyPath
+        : overridePath;
+  const current = resolveGitcrawlDbPath(repo, undefined, {
+    env: resolverEnv,
+    root: runtimeRoot,
+    homeDir,
+  });
+  const old = oldResolvers.map(({ resolve }) =>
+    resolve(repo, undefined, { env: resolverEnv, root: runtimeRoot, homeDir }),
+  );
+  assert.equal(current, expectedPath);
+  assert.deepEqual(old, [expectedPath, expectedPath]);
+
+  const childEnv = {
+    ...process.env,
+    HOME: homeDir,
+    NODE_NO_WARNINGS: "1",
+    PATH: `${adapterDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    PROOF_SQLITE_TRACE: tracePath,
+  };
+  if (scenario.selected === "override") {
+    childEnv.CLAWSWEEPER_GITCRAWL_DB = overridePath;
+  } else {
+    delete childEnv.CLAWSWEEPER_GITCRAWL_DB;
+  }
+
+  const clusterOut = path.join(scenarioRoot, "cluster-out");
+  const clusterRun = await runProcess(
+    process.execPath,
+    [
+      path.join(runtimeRoot, "dist/repair/import-gitcrawl-clusters.js"),
+      "1",
+      "--repo",
+      repo,
+      "--out",
+      clusterOut,
+      "--skip-existing",
+      "false",
+    ],
+    { cwd: runtimeRoot, env: childEnv },
+  );
+  assert.equal(clusterRun.exitCode, 0, clusterRun.stderr);
+  const clusterFiles = await readdir(clusterOut);
+  assert.equal(clusterFiles.length, 1);
+  const clusterOutput = await readFile(path.join(clusterOut, clusterFiles[0]), "utf8");
+
+  const lowSignalRun = await runProcess(
+    process.execPath,
+    [
+      path.join(runtimeRoot, "dist/repair/import-gitcrawl-low-signal-prs.js"),
+      "--repo",
+      repo,
+      "--out",
+      path.join(scenarioRoot, "low-signal-out"),
+      "--skip-existing",
+      "false",
+      "--dry-run",
+      "--json",
+      "--min-score",
+      "1",
+    ],
+    { cwd: runtimeRoot, env: childEnv },
+  );
+  assert.equal(lowSignalRun.exitCode, 0, lowSignalRun.stderr);
+  const lowSignalOutput = JSON.parse(lowSignalRun.stdout);
+  const expectedMarker =
+    scenario.selected === "portable"
+      ? "portable-store"
+      : scenario.selected === "legacy"
+        ? "legacy-fallback"
+        : "env-override";
+  assert.match(clusterOutput, new RegExp(expectedMarker));
+  assert.match(lowSignalOutput.candidates[0].title, new RegExp(expectedMarker));
+
+  const trace = (await readFile(tracePath, "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  assert(trace.length >= 4);
+  assert(trace.every((entry) => entry.db_path === expectedPath));
+
+  return {
+    scenario: scenario.name,
+    resolved_store_path: displayPath(scenarioRoot, current),
+    old_resolver_paths: old.map((candidate) => displayPath(scenarioRoot, candidate)),
+    identical: true,
+    real_file: {
+      exists: fs.existsSync(current),
+      sha256: sha256(await readFile(current)),
+    },
+    importer_entry_points: [
+      {
+        cli: "dist/repair/import-gitcrawl-clusters.js",
+        exit_code: clusterRun.exitCode,
+        opened_store_paths: unique(
+          trace.slice(0, trace.length - 1).map((entry) => displayPath(scenarioRoot, entry.db_path)),
+        ),
+        observed_fixture_marker: expectedMarker,
+      },
+      {
+        cli: "dist/repair/import-gitcrawl-low-signal-prs.js",
+        exit_code: lowSignalRun.exitCode,
+        opened_store_paths: unique(
+          trace.map((entry) => displayPath(scenarioRoot, entry.db_path)),
+        ),
+        observed_fixture_marker: expectedMarker,
+      },
+    ],
+    sqlite_queries: trace.map((entry) => ({
+      json: entry.json,
+      db_path: displayPath(scenarioRoot, entry.db_path),
+      sql_sha256: entry.sql_sha256,
+    })),
+  };
+}
+
+function createFixtureDatabase(file, marker, clusterKind) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const database = new DatabaseSync(file);
+  try {
+    database.exec(`
+      create table repositories (id integer primary key, owner text, name text);
+      create table threads (
+        id integer primary key,
+        repo_id integer,
+        number integer,
+        kind text,
+        state text,
+        title text,
+        body text,
+        body_excerpt text,
+        author_login text,
+        author_type text,
+        labels_json text,
+        assignees_json text,
+        raw_json text,
+        is_draft integer,
+        created_at_gh text,
+        updated_at_gh text,
+        last_pulled_at text,
+        closed_at_local text,
+        updated_at text
+      );
+      create table thread_revisions (id integer primary key, thread_id integer);
+      create table thread_code_snapshots (id integer primary key, thread_revision_id integer);
+      create table thread_changed_files (snapshot_id integer, path text);
+      insert into repositories values (1, 'openclaw', 'openclaw');
+      insert into threads values (
+        1, 1, 9001, 'pull_request', 'open', 'docs: ${marker}',
+        'Small documentation cleanup.', 'Small documentation cleanup.', 'proof-author', 'User',
+        '[]', '[]', '{"author_association":"NONE"}', 0,
+        '2026-08-01T00:00:00.000Z', '2026-08-02T00:00:00.000Z',
+        '2026-08-02T00:00:00.000Z', null, '2026-08-02T00:00:00.000Z'
+      );
+      insert into thread_revisions values (1, 1);
+      insert into thread_code_snapshots values (1, 1);
+      insert into thread_changed_files values (1, 'docs/proof.md');
+    `);
+    if (clusterKind === "portable") {
+      database.exec(`
+        create table cluster_groups (
+          id integer primary key,
+          created_at text,
+          closed_at text,
+          status text,
+          representative_thread_id integer
+        );
+        create table cluster_memberships (cluster_id integer, thread_id integer, state text);
+        insert into cluster_groups values (1, '2026-08-01T00:00:00.000Z', null, 'active', 1);
+        insert into cluster_memberships values (1, 1, 'active');
+      `);
+    } else {
+      database.exec(`
+        create table clusters (
+          id integer primary key,
+          member_count integer,
+          created_at text,
+          closed_at_local text,
+          close_reason_local text,
+          representative_thread_id integer
+        );
+        create table cluster_members (cluster_id integer, thread_id integer);
+        insert into clusters values (1, 1, '2026-08-01T00:00:00.000Z', null, null, 1);
+        insert into cluster_members values (1, 1);
+      `);
+    }
+  } finally {
+    database.close();
+  }
+}
+
 function gitShow(file) {
-  return execFileSync("git", ["show", `${baseRef}:${file}`], { encoding: "utf8" });
+  return execFileSync("git", ["show", `${baseRef}:${file}`], {
+    cwd: root,
+    encoding: "utf8",
+  });
 }
 
 function extractBetween(source, start, end) {
@@ -127,17 +334,17 @@ function compileResolver(source) {
     .replaceAll("explicitDb?: string", "explicitDb")
     .replaceAll("): string", ")")
     .replaceAll("at(-1)!", "at(-1)");
-  return (repo, explicitDb, runtime) => {
+  return (repoFullName, explicitDb, runtime) => {
     const context = {
       exports: {},
-      fs: { existsSync: (candidate) => runtime.existing.has(candidate) },
+      fs,
       os: { homedir: () => runtime.homeDir },
       path,
       process: { env: runtime.env },
       repoRoot: () => runtime.root,
     };
     vm.runInNewContext(`${javascript}\nexports.proof = resolveGitcrawlDbPath;`, context);
-    return context.exports.proof(repo, explicitDb);
+    return context.exports.proof(repoFullName, explicitDb);
   };
 }
 
@@ -146,4 +353,68 @@ function extractSqliteBuffer(source) {
   const match = sqliteJson.match(/maxBuffer:\s*([^,\n]+)/);
   assert(match?.[1], "sqliteJson maxBuffer not found");
   return match[1].trim();
+}
+
+function sqliteAdapterSource() {
+  return `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+
+const args = process.argv.slice(2);
+const json = args[0] === "-json";
+if (json) args.shift();
+const [dbPath, sql] = args;
+if (!dbPath || !sql) throw new Error("usage: sqlite3 [-json] <database> <sql>");
+const database = new DatabaseSync(dbPath, { readOnly: true });
+try {
+  const statement = database.prepare(sql);
+  const rows = statement.all();
+  if (json) {
+    process.stdout.write(JSON.stringify(rows));
+  } else if (rows.length > 0) {
+    process.stdout.write(String(Object.values(rows[0])[0] ?? ""));
+  }
+  appendFileSync(
+    process.env.PROOF_SQLITE_TRACE,
+    JSON.stringify({
+      json,
+      db_path: dbPath,
+      sql_sha256: createHash("sha256").update(sql).digest("hex"),
+    }) + "\\n",
+  );
+} finally {
+  database.close();
+}
+`;
+}
+
+function runProcess(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) => resolve({ exitCode, signal, stdout, stderr }));
+  });
+}
+
+function displayPath(scenarioRoot, candidate) {
+  return `$FIXTURE_ROOT/${path.relative(scenarioRoot, candidate).split(path.sep).join("/")}`;
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
 }

--- a/docs/proof/repair-duplication-merges/merge-3/README.md
+++ b/docs/proof/repair-duplication-merges/merge-3/README.md
@@ -1,0 +1,15 @@
+# Error-fingerprint wire-format equivalence proof
+
+This proof extracts `failureFingerprint` and `errorFingerprint` from their two
+`origin/main` callers, evaluates representative `Error` and string inputs, and
+compares them with the new shared digest primitive and its two named wrappers.
+
+Run after `pnpm run build:repair`:
+
+```sh
+node docs/proof/repair-duplication-merges/merge-3/run-proof.mjs
+```
+
+The checked-in result is in `artifacts/equivalence.json`. It pins the bare
+64-character hex batch format separately from the `sha256:`-prefixed event
+format. The proof is deterministic and performs no network or production I/O.

--- a/docs/proof/repair-duplication-merges/merge-3/artifacts/equivalence.json
+++ b/docs/proof/repair-duplication-merges/merge-3/artifacts/equivalence.json
@@ -1,0 +1,33 @@
+{
+  "base_ref": "origin/main",
+  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "extractions": [
+    {
+      "file": "src/repair/exact-review-batch-cli.ts",
+      "function": "failureFingerprint",
+      "sha256": "f4e334c4170f8b8b3bd5462c63ddecb92e9e0658acf0f7fa7a81252d9dbbd090"
+    },
+    {
+      "file": "src/repair/publish-event-result.ts",
+      "function": "errorFingerprint",
+      "sha256": "c6b354a7ad68128fe9b1fbdf6f8a6ed75f54a441dc6f03b60b7eeece4ff467f2"
+    }
+  ],
+  "inputs": [
+    {
+      "kind": "Error",
+      "text": "Error:boom",
+      "digest": "dd3599487ed91066c703b33178b719dcc9b548de8576047b95b06482bab7eaf6",
+      "failure": "dd3599487ed91066c703b33178b719dcc9b548de8576047b95b06482bab7eaf6",
+      "event": "sha256:dd3599487ed91066c703b33178b719dcc9b548de8576047b95b06482bab7eaf6"
+    },
+    {
+      "kind": "string",
+      "text": "plain failure",
+      "digest": "7cf7a70958727c4bec91d869f22ed253c020dc0e193cd67c432e9a3016777003",
+      "failure": "7cf7a70958727c4bec91d869f22ed253c020dc0e193cd67c432e9a3016777003",
+      "event": "sha256:7cf7a70958727c4bec91d869f22ed253c020dc0e193cd67c432e9a3016777003"
+    }
+  ],
+  "identical": true
+}

--- a/docs/proof/repair-duplication-merges/merge-3/artifacts/equivalence.json
+++ b/docs/proof/repair-duplication-merges/merge-3/artifacts/equivalence.json
@@ -1,6 +1,6 @@
 {
   "base_ref": "origin/main",
-  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "base_sha": "765644804756d5f6b1dc1e940d62c50711e398d8",
   "extractions": [
     {
       "file": "src/repair/exact-review-batch-cli.ts",

--- a/docs/proof/repair-duplication-merges/merge-3/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-3/run-proof.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+import {
+  errorFingerprint,
+  errorFingerprintDigest,
+  failureFingerprint,
+} from "../../../../dist/repair/error-fingerprint.js";
+
+const root = process.cwd();
+const baseRef = process.env.PROOF_BASE_REF || "origin/main";
+const extractions = [
+  {
+    file: "src/repair/exact-review-batch-cli.ts",
+    functionName: "failureFingerprint",
+    end: "\n\nfunction env(",
+  },
+  {
+    file: "src/repair/publish-event-result.ts",
+    functionName: "errorFingerprint",
+    end: "\n\nfunction validateTargetRepo(",
+  },
+].map((entry) => {
+  const source = gitShow(entry.file);
+  const extracted = extractBetween(source, `function ${entry.functionName}(`, entry.end);
+  return { ...entry, extracted, outputs: evaluateOld(extracted, entry.functionName) };
+});
+
+const inputs = [
+  {
+    kind: "Error",
+    text: "Error:boom",
+    digest: errorFingerprintDigest(new Error("boom")),
+    failure: failureFingerprint(new Error("boom")),
+    event: errorFingerprint(new Error("boom")),
+  },
+  {
+    kind: "string",
+    text: "plain failure",
+    digest: errorFingerprintDigest("plain failure"),
+    failure: failureFingerprint("plain failure"),
+    event: errorFingerprint("plain failure"),
+  },
+];
+
+assert.deepEqual(
+  extractions[0].outputs,
+  inputs.map((input) => input.failure),
+);
+assert.deepEqual(
+  extractions[1].outputs,
+  inputs.map((input) => input.event),
+);
+for (const input of inputs) {
+  assert.equal(input.failure, input.digest);
+  assert.equal(input.event, `sha256:${input.digest}`);
+}
+
+const artifact = {
+  base_ref: baseRef,
+  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
+  extractions: extractions.map(({ file, functionName, extracted }) => ({
+    file,
+    function: functionName,
+    sha256: createHash("sha256").update(extracted).digest("hex"),
+  })),
+  inputs,
+  identical: true,
+};
+
+const outputPath = path.join(
+  root,
+  "docs/proof/repair-duplication-merges/merge-3/artifacts/equivalence.json",
+);
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(JSON.stringify(artifact, null, 2));
+
+function gitShow(file) {
+  return execFileSync("git", ["show", `${baseRef}:${file}`], { encoding: "utf8" });
+}
+
+function extractBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  assert(startIndex >= 0 && endIndex > startIndex, `could not extract ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function evaluateOld(source, functionName) {
+  const javascript = source.replaceAll("error: unknown", "error").replaceAll("): string", ")");
+  const context = { exports: {}, createHash };
+  vm.runInNewContext(
+    `${javascript}\nexports.outputs = [${functionName}(new Error("boom")), ${functionName}("plain failure")];`,
+    context,
+  );
+  return Array.from(context.exports.outputs);
+}

--- a/docs/proof/repair-duplication-merges/merge-4/README.md
+++ b/docs/proof/repair-duplication-merges/merge-4/README.md
@@ -1,0 +1,17 @@
+# Command-ack convergence equivalence proof
+
+This proof extracts the command-ack parsing and convergence implementations
+from `origin/main` in `update-command-status.ts`, `comment-router-core.ts`, and
+`comment-router.ts`. Representative marker, status-scope, status-priority,
+updated-time, created-time, and numeric-id tie cases are evaluated against the
+new shared helper.
+
+Run after `pnpm run build:repair`:
+
+```sh
+node docs/proof/repair-duplication-merges/merge-4/run-proof.mjs
+```
+
+The checked-in result is in `artifacts/equivalence.json`. The harness is
+deterministic and performs no GitHub, network, queue, workflow, or production
+mutation.

--- a/docs/proof/repair-duplication-merges/merge-4/artifacts/equivalence.json
+++ b/docs/proof/repair-duplication-merges/merge-4/artifacts/equivalence.json
@@ -1,0 +1,136 @@
+{
+  "base_ref": "origin/main",
+  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "extractions": [
+    {
+      "name": "update",
+      "sha256": "309ac59e2d664a683771a24ad30f07ed74fc235c1157f1d6aae1b74df51076c9"
+    },
+    {
+      "name": "core",
+      "sha256": "72d2283100a842535c23e16213c9451d696440fc536b726afd3e5ac63d683f4e"
+    },
+    {
+      "name": "router",
+      "sha256": "92beb23aedc35449f30c05f35db9a8749177394c0965470f708a812f0ff90f1b"
+    }
+  ],
+  "representative_inputs": {
+    "markerInputs": [
+      "<!-- clawsweeper-command-ack:456 -->",
+      "prefix <!--   clawsweeper-command-ack:456   --> suffix",
+      "<!-- clawsweeper-command-ack:not-a-number -->",
+      null
+    ],
+    "statusInputs": [
+      "<!-- clawsweeper-command-status:81564:re_review:new -->",
+      "prefix <!-- clawsweeper-command-status:81564:re_review:old --> suffix",
+      "status-free",
+      null
+    ],
+    "comments": [
+      {
+        "id": 101,
+        "created_at": "2026-05-29T10:00:00Z",
+        "updated_at": "2026-05-29T10:01:00Z",
+        "body": "<!-- clawsweeper-command-status:81564:re_review:old -->\n<!-- clawsweeper-command-ack:456 -->"
+      },
+      {
+        "id": 102,
+        "created_at": "2026-05-29T10:02:00Z",
+        "updated_at": "2026-05-29T10:02:00Z",
+        "body": "<!-- clawsweeper-command-ack:456 -->"
+      },
+      {
+        "id": 103,
+        "created_at": "2026-05-29T10:03:00Z",
+        "updated_at": "2026-05-29T10:05:00Z",
+        "body": "<!-- clawsweeper-command-status:81564:re_review:new -->\n<!--   clawsweeper-command-ack:456   -->"
+      },
+      {
+        "id": 104,
+        "created_at": "2026-05-29T10:04:00Z",
+        "updated_at": "2026-05-29T10:04:00Z",
+        "body": "<!-- clawsweeper-command-ack:456 -->"
+      }
+    ],
+    "bareTie": [
+      {
+        "id": 12,
+        "created_at": "2026-05-29T10:00:00Z",
+        "body": "bare"
+      },
+      {
+        "id": 11,
+        "created_at": "2026-05-29T10:00:00Z",
+        "body": "bare"
+      },
+      {
+        "id": 13,
+        "created_at": "2026-05-29T10:01:00Z",
+        "body": "bare"
+      }
+    ]
+  },
+  "old": {
+    "updateAckMarkers": [
+      "<!-- clawsweeper-command-ack:456 -->",
+      "<!--   clawsweeper-command-ack:456   -->",
+      null,
+      null
+    ],
+    "routerAckMarkers": [
+      "<!-- clawsweeper-command-ack:456 -->",
+      "<!--   clawsweeper-command-ack:456   -->",
+      null,
+      null
+    ],
+    "updateStatusMarkers": [
+      "<!-- clawsweeper-command-status:81564:re_review:new -->",
+      "<!-- clawsweeper-command-status:81564:re_review:old -->",
+      null,
+      null
+    ],
+    "coreStatusMarkers": [
+      "<!-- clawsweeper-command-status:81564:re_review:new -->",
+      "<!-- clawsweeper-command-status:81564:re_review:old -->",
+      null,
+      null
+    ],
+    "corePlan": {
+      "keep": 103,
+      "prunable": [
+        102,
+        104
+      ]
+    },
+    "updateStatusKeeper": 103,
+    "coreStatusKeeper": 103,
+    "updateBareKeeper": 11,
+    "coreBareKeeper": 11
+  },
+  "current": {
+    "ackMarkers": [
+      "<!-- clawsweeper-command-ack:456 -->",
+      "<!--   clawsweeper-command-ack:456   -->",
+      null,
+      null
+    ],
+    "statusMarkers": [
+      "<!-- clawsweeper-command-status:81564:re_review:new -->",
+      "<!-- clawsweeper-command-status:81564:re_review:old -->",
+      null,
+      null
+    ],
+    "plan": {
+      "keep": 103,
+      "prunable": [
+        102,
+        104
+      ]
+    },
+    "statusKeeper": 103,
+    "bareKeeper": 11
+  },
+  "identical": true
+}

--- a/docs/proof/repair-duplication-merges/merge-4/artifacts/equivalence.json
+++ b/docs/proof/repair-duplication-merges/merge-4/artifacts/equivalence.json
@@ -1,6 +1,6 @@
 {
   "base_ref": "origin/main",
-  "base_sha": "51ac499c741b7b4b9b2bd1b7d78686055f8f3738",
+  "base_sha": "765644804756d5f6b1dc1e940d62c50711e398d8",
   "extractions": [
     {
       "name": "update",

--- a/docs/proof/repair-duplication-merges/merge-4/run-proof.mjs
+++ b/docs/proof/repair-duplication-merges/merge-4/run-proof.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+import {
+  commandAckMarkerFromBody,
+  commandStatusMarkerFromBody,
+  planCommandAckConvergence,
+  selectCommandAckKeeper,
+} from "../../../../dist/repair/command-ack-convergence.js";
+
+const root = process.cwd();
+const baseRef = process.env.PROOF_BASE_REF || "origin/main";
+const sources = {
+  update: extract(
+    "src/repair/update-command-status.ts",
+    "function commandAckMarkerFromBody(",
+    "\nexport function mergeCommandProgressSection(",
+  ),
+  core: extract(
+    "src/repair/comment-router-core.ts",
+    "export function commandStatusMarkerFromBody(",
+    "\nexport function commandResponseMarker(",
+  ),
+  router: extract(
+    "src/repair/comment-router.ts",
+    "function commandAckMarkerFromBody(",
+    "\nfunction automergeTimelineEvents(",
+  ),
+};
+const oldUpdate = compile(sources.update, [
+  "commandAckMarkerFromBody",
+  "commandStatusMarkerFromBody",
+  "selectCommandAckKeeper",
+]);
+const oldCore = compile(sources.core, [
+  "commandStatusMarkerFromBody",
+  "planCommandAckConvergence",
+  "selectCommandAckKeeper",
+]);
+const oldRouter = compile(sources.router, ["commandAckMarkerFromBody"]);
+
+const requestedStatus = "<!-- clawsweeper-command-status:81564:re_review:new -->";
+const otherStatus = "<!-- clawsweeper-command-status:81564:re_review:old -->";
+const comments = [
+  {
+    id: 101,
+    created_at: "2026-05-29T10:00:00Z",
+    updated_at: "2026-05-29T10:01:00Z",
+    body: `${otherStatus}\n<!-- clawsweeper-command-ack:456 -->`,
+  },
+  {
+    id: 102,
+    created_at: "2026-05-29T10:02:00Z",
+    updated_at: "2026-05-29T10:02:00Z",
+    body: "<!-- clawsweeper-command-ack:456 -->",
+  },
+  {
+    id: 103,
+    created_at: "2026-05-29T10:03:00Z",
+    updated_at: "2026-05-29T10:05:00Z",
+    body: `${requestedStatus}\n<!--   clawsweeper-command-ack:456   -->`,
+  },
+  {
+    id: 104,
+    created_at: "2026-05-29T10:04:00Z",
+    updated_at: "2026-05-29T10:04:00Z",
+    body: "<!-- clawsweeper-command-ack:456 -->",
+  },
+];
+const bareTie = [
+  { id: 12, created_at: "2026-05-29T10:00:00Z", body: "bare" },
+  { id: 11, created_at: "2026-05-29T10:00:00Z", body: "bare" },
+  { id: 13, created_at: "2026-05-29T10:01:00Z", body: "bare" },
+];
+const markerInputs = [
+  "<!-- clawsweeper-command-ack:456 -->",
+  "prefix <!--   clawsweeper-command-ack:456   --> suffix",
+  "<!-- clawsweeper-command-ack:not-a-number -->",
+  null,
+];
+const statusInputs = [requestedStatus, `prefix ${otherStatus} suffix`, "status-free", null];
+
+const current = {
+  ackMarkers: markerInputs.map(commandAckMarkerFromBody),
+  statusMarkers: statusInputs.map(commandStatusMarkerFromBody),
+  plan: simplifyPlan(planCommandAckConvergence(comments, requestedStatus)),
+  statusKeeper: selectCommandAckKeeper(comments.filter((comment) => !comment.body.includes("old")))
+    ?.id,
+  bareKeeper: selectCommandAckKeeper(bareTie)?.id,
+};
+const old = {
+  updateAckMarkers: markerInputs.map(oldUpdate.commandAckMarkerFromBody),
+  routerAckMarkers: markerInputs.map(oldRouter.commandAckMarkerFromBody),
+  updateStatusMarkers: statusInputs.map(oldUpdate.commandStatusMarkerFromBody),
+  coreStatusMarkers: statusInputs.map(oldCore.commandStatusMarkerFromBody),
+  corePlan: simplifyPlan(oldCore.planCommandAckConvergence(comments, requestedStatus)),
+  updateStatusKeeper: oldUpdate.selectCommandAckKeeper(
+    comments.filter((comment) => !comment.body.includes("old")),
+  )?.id,
+  coreStatusKeeper: oldCore.selectCommandAckKeeper(
+    comments.filter((comment) => !comment.body.includes("old")),
+  )?.id,
+  updateBareKeeper: oldUpdate.selectCommandAckKeeper(bareTie)?.id,
+  coreBareKeeper: oldCore.selectCommandAckKeeper(bareTie)?.id,
+};
+
+assert.deepEqual(old.updateAckMarkers, current.ackMarkers);
+assert.deepEqual(old.routerAckMarkers, current.ackMarkers);
+assert.deepEqual(old.updateStatusMarkers, current.statusMarkers);
+assert.deepEqual(old.coreStatusMarkers, current.statusMarkers);
+assert.deepEqual(old.corePlan, current.plan);
+assert.equal(old.updateStatusKeeper, current.statusKeeper);
+assert.equal(old.coreStatusKeeper, current.statusKeeper);
+assert.equal(old.updateBareKeeper, current.bareKeeper);
+assert.equal(old.coreBareKeeper, current.bareKeeper);
+
+const artifact = {
+  base_ref: baseRef,
+  base_sha: execFileSync("git", ["rev-parse", baseRef], { encoding: "utf8" }).trim(),
+  extractions: Object.entries(sources).map(([name, source]) => ({
+    name,
+    sha256: createHash("sha256").update(source).digest("hex"),
+  })),
+  representative_inputs: { markerInputs, statusInputs, comments, bareTie },
+  old,
+  current,
+  identical: true,
+};
+
+const outputPath = path.join(
+  root,
+  "docs/proof/repair-duplication-merges/merge-4/artifacts/equivalence.json",
+);
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(JSON.stringify(artifact, null, 2));
+
+function gitShow(file) {
+  return execFileSync("git", ["show", `${baseRef}:${file}`], { encoding: "utf8" });
+}
+
+function extract(file, start, end) {
+  const source = gitShow(file);
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  assert(startIndex >= 0 && endIndex > startIndex, `could not extract ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function compile(source, names) {
+  const javascript = source
+    .replaceAll("export ", "")
+    .replace(/\): \{ keep: LooseRecord \| null; prunable: LooseRecord\[\] \} \{/g, ") {")
+    .replace(/: JsonValue/g, "")
+    .replace(/: LooseRecord\[\]/g, "")
+    .replace(/: LooseRecord/g, "")
+    .replace(/: string/g, "");
+  const assignments = names.map((name) => `exports.${name} = ${name};`).join("\n");
+  const context = {
+    exports: {},
+    PROGRESS_START: "<!-- clawsweeper-command-progress:start -->",
+  };
+  vm.runInNewContext(`${javascript}\n${assignments}`, context);
+  return context.exports;
+}
+
+function simplifyPlan(plan) {
+  return {
+    keep: plan.keep?.id ?? null,
+    prunable: Array.from(plan.prunable, (comment) => comment.id),
+  };
+}

--- a/src/repair/command-ack-convergence.ts
+++ b/src/repair/command-ack-convergence.ts
@@ -1,0 +1,83 @@
+import type { JsonValue, LooseRecord } from "./json-types.js";
+
+export const COMMAND_PROGRESS_START = "<!-- clawsweeper-command-progress:start -->";
+
+export function commandAckMarkerFromBody(body: JsonValue): string | null {
+  return String(body ?? "").match(/<!--\s*clawsweeper-command-ack:\d+\s*-->/)?.[0] ?? null;
+}
+
+export function commandStatusMarkerFromBody(body: JsonValue): string | null {
+  return (
+    String(body ?? "").match(new RegExp("<!--\\s*clawsweeper-command-status:[^>]+-->"))?.[0] ?? null
+  );
+}
+
+export function statusMarkerDiffersFromRequested(
+  body: JsonValue,
+  requestedStatusMarker: string,
+): boolean {
+  const statusMarker = commandStatusMarkerFromBody(body);
+  return Boolean(requestedStatusMarker && statusMarker && statusMarker !== requestedStatusMarker);
+}
+
+export function isPrunableCommandAckDuplicate(
+  comment: LooseRecord,
+  requestedStatusMarker: string,
+): boolean {
+  const statusMarker = commandStatusMarkerFromBody(comment.body);
+  return !statusMarker || statusMarker === requestedStatusMarker;
+}
+
+export function selectCommandAckKeeper(comments: LooseRecord[]): LooseRecord | null {
+  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
+}
+
+export function planCommandAckConvergence(
+  comments: LooseRecord[],
+  requestedStatusMarker: string,
+): { keep: LooseRecord | null; prunable: LooseRecord[] } {
+  const scoped = comments.filter((comment) =>
+    isPrunableCommandAckDuplicate(comment, requestedStatusMarker),
+  );
+  const keep = selectCommandAckKeeper(scoped);
+  if (!keep) return { keep: null, prunable: [] };
+  const keepId = Number(keep.id ?? 0) || 0;
+  return {
+    keep,
+    prunable: scoped.filter((comment) => {
+      const id = Number(comment.id ?? 0) || 0;
+      return id > 0 && id !== keepId;
+    }),
+  };
+}
+
+export function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord): number {
+  const leftCreated = String(left.created_at ?? "");
+  const rightCreated = String(right.created_at ?? "");
+  return (
+    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
+  );
+}
+
+function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord): number {
+  const leftStatus = commandAckStatusScore(left);
+  const rightStatus = commandAckStatusScore(right);
+  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
+  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
+  return compareCommentsByCreatedAt(left, right);
+}
+
+function commandAckStatusScore(comment: LooseRecord): number {
+  const body = String(comment.body ?? "");
+  return body.includes("clawsweeper-command-status:") || body.includes(COMMAND_PROGRESS_START)
+    ? 1
+    : 0;
+}
+
+function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord): number {
+  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
+  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
+  return (
+    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
+  );
+}

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -20,6 +20,10 @@ export {
   HUMAN_REVIEW_LABEL,
   MANUAL_ONLY_LABEL,
 } from "./exact-review-guard-labels.js";
+export {
+  commandStatusMarkerFromBody,
+  planCommandAckConvergence,
+} from "./command-ack-convergence.js";
 import {
   isAutoCloseAllowed,
   repositoryProfileFor,
@@ -2932,68 +2936,6 @@ export function commandStatusMarker(command: LooseRecord) {
 
 export function commandStatusMarkerPrefix(command: LooseRecord) {
   return `<!-- clawsweeper-command-status:${command.issue_number ?? "unknown"}:${command.intent}:`;
-}
-
-export function commandStatusMarkerFromBody(body: JsonValue) {
-  return (
-    String(body ?? "").match(new RegExp("<!--\\s*clawsweeper-command-status:[^>]+-->"))?.[0] ?? null
-  );
-}
-
-export function planCommandAckConvergence(
-  comments: LooseRecord[],
-  requestedStatusMarker: string,
-): { keep: LooseRecord | null; prunable: LooseRecord[] } {
-  const scoped = comments.filter((comment) => {
-    const statusMarker = commandStatusMarkerFromBody(comment.body);
-    return !statusMarker || statusMarker === requestedStatusMarker;
-  });
-  const keep = selectCommandAckKeeper(scoped);
-  if (!keep) return { keep: null, prunable: [] };
-  const keepId = Number(keep.id ?? 0) || 0;
-  return {
-    keep,
-    prunable: scoped.filter((comment) => {
-      const id = Number(comment.id ?? 0) || 0;
-      return id > 0 && id !== keepId;
-    }),
-  };
-}
-
-function selectCommandAckKeeper(comments: LooseRecord[]) {
-  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
-}
-
-function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord) {
-  const leftStatus = commandAckStatusScore(left);
-  const rightStatus = commandAckStatusScore(right);
-  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
-  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
-  return compareCommentsByCreatedAt(left, right);
-}
-
-function commandAckStatusScore(comment: LooseRecord) {
-  const body = String(comment.body ?? "");
-  return body.includes("clawsweeper-command-status:") ||
-    body.includes("<!-- clawsweeper-command-progress:start -->")
-    ? 1
-    : 0;
-}
-
-function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
-  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
-  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
-  return (
-    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
-  );
-}
-
-function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord) {
-  const leftCreated = String(left.created_at ?? "");
-  const rightCreated = String(right.created_at ?? "");
-  return (
-    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
-  );
 }
 
 export function commandResponseMarker({ commentId, intent, headSha = "na" }: LooseRecord): string {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -42,7 +42,6 @@ import {
   buildAutomergeSquashMessage,
   commandHasAction,
   commandResponseMarker,
-  commandStatusMarkerFromBody,
   createCachedIssueCommentsLookup,
   createCachedIssueCommentsLookupAsync,
   createCachedLabelNumberLookup,
@@ -65,7 +64,6 @@ import {
   maintainerAutomergeOptInApprovesNeedsHuman as maintainerAutomergeOptInApprovesNeedsHumanReason,
   latestRepairLoopResumeTime,
   parseRoutedCommentCommand,
-  planCommandAckConvergence,
   pausedModeStatusBlocksReplay,
   parseTrustedAutomation,
   repairableCheckBlockers,
@@ -91,6 +89,11 @@ import {
   trustedCloseBlockReason,
   usesSharedAutomergeStatus,
 } from "./comment-router-core.js";
+import {
+  commandAckMarkerFromBody,
+  commandStatusMarkerFromBody,
+  planCommandAckConvergence,
+} from "./command-ack-convergence.js";
 import { mergeAutomergeTimelineSection } from "./automerge-status-timeline.js";
 import {
   automergeSessionId,
@@ -5048,10 +5051,6 @@ function convergePrecreatedCommandAckCommentsInner(command: LooseRecord) {
 
 function commandAckMarkerForCommentId(commentId: JsonValue) {
   return `<!-- clawsweeper-command-ack:${commentId} -->`;
-}
-
-function commandAckMarkerFromBody(body: JsonValue) {
-  return String(body ?? "").match(/<!--\s*clawsweeper-command-ack:\d+\s*-->/)?.[0] ?? null;
 }
 
 function automergeTimelineEvents(command: LooseRecord, body: string) {

--- a/src/repair/error-fingerprint.ts
+++ b/src/repair/error-fingerprint.ts
@@ -1,0 +1,14 @@
+import { createHash } from "node:crypto";
+
+export function errorFingerprintDigest(error: unknown): string {
+  const message = error instanceof Error ? `${error.name}:${error.message}` : String(error);
+  return createHash("sha256").update(message).digest("hex");
+}
+
+export function failureFingerprint(error: unknown): string {
+  return errorFingerprintDigest(error);
+}
+
+export function errorFingerprint(error: unknown): string {
+  return `sha256:${errorFingerprintDigest(error)}`;
+}

--- a/src/repair/exact-review-batch-cli.ts
+++ b/src/repair/exact-review-batch-cli.ts
@@ -13,6 +13,7 @@ import {
 } from "./exact-review-batch-queue-client.js";
 import { exactReviewBatchStateWriterProgressReporter } from "./exact-review-batch-state-writer-progress.js";
 import { postDirectPublicationResult } from "./exact-review-direct-publication.js";
+import { failureFingerprint } from "./error-fingerprint.js";
 import { StateWriterTelemetryRecorder } from "./state-writer-telemetry-recorder.js";
 import { normalizeRepo, slugForRepo } from "../repository-profiles.js";
 import type { StateWriterOperation } from "../state-writer-telemetry.js";
@@ -1121,11 +1122,6 @@ function output(name: string, value: string) {
   const path = process.env.GITHUB_OUTPUT;
   if (path) writeFileSync(path, `${name}=${value}\n`, { encoding: "utf8", flag: "a" });
   else console.log(`${name}=${value}`);
-}
-
-function failureFingerprint(error: unknown): string {
-  const detail = error instanceof Error ? `${error.name}:${error.message}` : String(error);
-  return createHash("sha256").update(detail).digest("hex");
 }
 
 function env(name: string): string {

--- a/src/repair/gitcrawl-store.ts
+++ b/src/repair/gitcrawl-store.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { repoRoot } from "./lib.js";
+
+type GitcrawlStoreRuntime = {
+  env?: NodeJS.ProcessEnv;
+  root?: string;
+  homeDir?: string;
+  existsSync?: (candidate: string) => boolean;
+};
+
+export function gitcrawlStoreDbFileName(repoFullName: string): string {
+  return `${repoFullName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
+}
+
+export function resolveGitcrawlDbPath(
+  repoFullName: string,
+  explicitDb?: string,
+  runtime: GitcrawlStoreRuntime = {},
+): string {
+  const env = runtime.env ?? process.env;
+  const configured = explicitDb?.trim() || env.CLAWSWEEPER_GITCRAWL_DB?.trim();
+  if (configured) return path.resolve(configured);
+  const storeDbFileName = gitcrawlStoreDbFileName(repoFullName);
+  const root = runtime.root ?? repoRoot();
+  const homeDir = runtime.homeDir ?? os.homedir();
+  const existsSync = runtime.existsSync ?? fs.existsSync;
+  const candidates = [
+    path.join(root, "..", "gitcrawl-store", "data", storeDbFileName),
+    path.join(homeDir, ".config", "gitcrawl", "stores", "gitcrawl-store", "data", storeDbFileName),
+    path.join(homeDir, ".config", "gitcrawl", "gitcrawl.db"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates.at(-1)!;
+}

--- a/src/repair/import-gitcrawl-clusters.ts
+++ b/src/repair/import-gitcrawl-clusters.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { parseArgs, repoRoot } from "./lib.js";
@@ -10,6 +9,7 @@ import {
   existingGitcrawlClusterIds,
   existingGitcrawlMemberRefs,
 } from "./gitcrawl-cluster-history.js";
+import { resolveGitcrawlDbPath } from "./gitcrawl-store.js";
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
@@ -48,33 +48,6 @@ if (clusterIds.length === 0) {
   );
   process.exit(2);
 }
-function gitcrawlStoreDbFileName(repoFullName: string): string {
-  return `${repoFullName
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
-}
-
-function resolveGitcrawlDbPath(repoFullName: string, explicitDb?: string): string {
-  const configured = explicitDb?.trim() || process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
-  if (configured) return path.resolve(configured);
-  const storeDbFileName = gitcrawlStoreDbFileName(repoFullName);
-  const candidates = [
-    path.join(repoRoot(), "..", "gitcrawl-store", "data", storeDbFileName),
-    path.join(
-      os.homedir(),
-      ".config",
-      "gitcrawl",
-      "stores",
-      "gitcrawl-store",
-      "data",
-      storeDbFileName,
-    ),
-    path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db"),
-  ];
-  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates.at(-1)!;
-}
-
 fs.mkdirSync(outDir, { recursive: true });
 
 const historyRoots = [

--- a/src/repair/import-gitcrawl-low-signal-prs.ts
+++ b/src/repair/import-gitcrawl-low-signal-prs.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import type { JsonValue, LooseRecord } from "./json-types.js";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { hasSecuritySignalText, parseArgs, repoRoot } from "./lib.js";
 import { renderJobIntentFrontmatter } from "./job-intent.js";
+import { resolveGitcrawlDbPath } from "./gitcrawl-store.js";
 
 const args = parseArgs(process.argv.slice(2));
 const repo = String(args.repo ?? "openclaw/openclaw");
@@ -31,33 +31,6 @@ if (!["stale", "recent", "score"].includes(sort)) {
   console.error("sort must be stale, recent, or score");
   process.exit(2);
 }
-function gitcrawlStoreDbFileName(repoFullName: string): string {
-  return `${repoFullName
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_.-]+/g, "__")}.sync.db`;
-}
-
-function resolveGitcrawlDbPath(repoFullName: string, explicitDb?: string): string {
-  const configured = explicitDb?.trim() || process.env.CLAWSWEEPER_GITCRAWL_DB?.trim();
-  if (configured) return path.resolve(configured);
-  const storeDbFileName = gitcrawlStoreDbFileName(repoFullName);
-  const candidates = [
-    path.join(repoRoot(), "..", "gitcrawl-store", "data", storeDbFileName),
-    path.join(
-      os.homedir(),
-      ".config",
-      "gitcrawl",
-      "stores",
-      "gitcrawl-store",
-      "data",
-      storeDbFileName,
-    ),
-    path.join(os.homedir(), ".config", "gitcrawl", "gitcrawl.db"),
-  ];
-  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates.at(-1)!;
-}
-
 const candidates = selectCandidates();
 const batches: JsonValue[] = [];
 for (let i = 0; i < candidates.length; i += batchSize) {

--- a/src/repair/notify-merge.ts
+++ b/src/repair/notify-merge.ts
@@ -3,9 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { JsonObject, JsonValue } from "./json-types.js";
-import { asJsonObject, isJsonObject } from "./json-types.js";
+import { asJsonObject } from "./json-types.js";
 import { parseArgs, repoRoot } from "./lib.js";
 import { readJsonFile } from "./json-file.js";
+import { errorText, postOpenClawAgentHook, resolveOpenClawHookConfig } from "./openclaw-hook.js";
 import type {
   CollectionResult,
   MergeLedgerEntry,
@@ -14,6 +15,7 @@ import type {
   MergeNotifierRuntime,
   MergeNotifierSummary,
 } from "./notify-merge-types.js";
+export { resolveHookAgentUrl } from "./openclaw-hook.js";
 
 export type {
   CollectionResult,
@@ -28,25 +30,6 @@ const MERGE_ACTIONS = new Set(["merge_candidate", "merge_canonical"]);
 const DEFAULT_LEDGER_PATH = "notifications/clawsweeper-merge-ledger.json";
 const DEFAULT_REPORT_PATH = "notifications/clawsweeper-merge-report.json";
 const DEFAULT_INPUT_PATH = "repair-apply-report.json";
-const DEFAULT_AGENT_ID = "clawsweeper";
-const DEFAULT_CHANNEL = "discord";
-const DEFAULT_THINKING = "low";
-const DEFAULT_TIMEOUT_SECONDS = 60;
-
-type NotifierConfig = {
-  hookUrl: string;
-  token: string;
-  agentId: string;
-  channel: string;
-  discordTarget: string;
-  thinking: string;
-  timeoutSeconds: number;
-};
-
-type HookPostResult = {
-  runId: string | null;
-};
-
 export function normalizeLedger(value: JsonValue): MergeNotificationLedger {
   const object = asJsonObject(value);
   const notifications = Array.isArray(object.notifications)
@@ -155,17 +138,6 @@ export function addLedgerEntry(
   };
 }
 
-export function resolveHookAgentUrl(raw: string): string {
-  const url = new URL(raw);
-  const trimmed = url.pathname.replace(/\/+$/, "");
-  if (trimmed.endsWith("/agent")) {
-    url.pathname = trimmed;
-  } else {
-    url.pathname = `${trimmed || ""}/agent`;
-  }
-  return url.toString();
-}
-
 export function renderNotificationMessage(notification: MergeNotification): string {
   return [
     "Send one concise Discord notification. Do not include a markdown table.",
@@ -208,7 +180,7 @@ export async function runMergeNotifier(
 
   const ledger = readLedger(ledgerPath);
   const collected = collectMergeNotifications(readJsonFile(inputPath), ledger, { runId });
-  const config = resolveConfig(env);
+  const config = resolveOpenClawHookConfig(env);
   if (!config) {
     const summary = summaryRow(
       "skipped",
@@ -238,7 +210,16 @@ export async function runMergeNotifier(
       continue;
     }
     try {
-      const result = await postHookNotification({ config, fetcher, notification });
+      const result = await postOpenClawAgentHook({
+        config,
+        fetcher,
+        post: {
+          name: `ClawSweeper merged ${notification.repo}${notification.target}`,
+          message: renderNotificationMessage(notification),
+          idempotencyKey: notification.idempotencyKey,
+          deliver: true,
+        },
+      });
       const notifiedAt = now().toISOString();
       nextLedger = addLedgerEntry(nextLedger, notification, {
         notifiedAt,
@@ -349,77 +330,6 @@ function normalizeLedgerEntry(row: JsonObject): MergeLedgerEntry | null {
   };
 }
 
-function resolveConfig(env: NodeJS.ProcessEnv): NotifierConfig | null {
-  const hookUrl = normalizeString(env.CLAWSWEEPER_OPENCLAW_HOOK_URL);
-  const token = normalizeString(env.CLAWSWEEPER_OPENCLAW_HOOK_TOKEN);
-  const discordTarget = normalizeString(env.CLAWSWEEPER_DISCORD_TARGET);
-  if (!hookUrl || !token || !discordTarget) return null;
-  return {
-    hookUrl: resolveHookAgentUrl(hookUrl),
-    token,
-    agentId: normalizeString(env.CLAWSWEEPER_OPENCLAW_AGENT_ID) ?? DEFAULT_AGENT_ID,
-    channel: normalizeString(env.CLAWSWEEPER_OPENCLAW_HOOK_CHANNEL) ?? DEFAULT_CHANNEL,
-    discordTarget,
-    thinking: normalizeString(env.CLAWSWEEPER_OPENCLAW_HOOK_THINKING) ?? DEFAULT_THINKING,
-    timeoutSeconds: positiveInt(
-      env.CLAWSWEEPER_OPENCLAW_HOOK_TIMEOUT_SECONDS,
-      DEFAULT_TIMEOUT_SECONDS,
-    ),
-  };
-}
-
-async function postHookNotification({
-  config,
-  fetcher,
-  notification,
-}: {
-  config: NotifierConfig;
-  fetcher: typeof fetch;
-  notification: MergeNotification;
-}): Promise<HookPostResult> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), (config.timeoutSeconds + 15) * 1000);
-  try {
-    const response = await fetcher(config.hookUrl, {
-      method: "POST",
-      signal: controller.signal,
-      headers: {
-        authorization: `Bearer ${config.token}`,
-        "content-type": "application/json",
-        "idempotency-key": notification.idempotencyKey,
-      },
-      body: JSON.stringify({
-        name: `ClawSweeper merged ${notification.repo}${notification.target}`,
-        agentId: config.agentId,
-        deliver: true,
-        channel: config.channel,
-        to: config.discordTarget,
-        idempotencyKey: notification.idempotencyKey,
-        thinking: config.thinking,
-        timeoutSeconds: config.timeoutSeconds,
-        message: renderNotificationMessage(notification),
-      }),
-    });
-    const body = await response.text();
-    if (!response.ok) {
-      throw new Error(`OpenClaw hook returned ${response.status}: ${body.slice(0, 500)}`);
-    }
-    return { runId: readHookRunId(body) };
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function readHookRunId(body: string): string | null {
-  try {
-    const parsed = JSON.parse(body);
-    if (!isJsonObject(parsed)) return null;
-    return stringOrNull(parsed.runId) ?? stringOrNull(parsed.run_id);
-  } catch {
-    return null;
-  }
-}
-
 function reportRow(
   notification: MergeNotification,
   status: "failed" | "planned" | "sent",
@@ -464,15 +374,6 @@ function stringOrNull(value: JsonValue): string | null {
 
 function normalizeString(value: string | undefined): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function positiveInt(value: string | undefined, fallback: number): number {
-  const parsed = Number.parseInt(value ?? "", 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
+import { errorFingerprint } from "./error-fingerprint.js";
 import {
   applyEventSnapshot,
   applyEventSnapshotIfCurrent,
@@ -796,11 +796,6 @@ function writePublicationCompletionOutputs(
     ].join("\n"),
     "utf8",
   );
-}
-
-function errorFingerprint(error: unknown): string {
-  const message = error instanceof Error ? `${error.name}:${error.message}` : String(error);
-  return `sha256:${createHash("sha256").update(message).digest("hex")}`;
 }
 
 function validateTargetRepo(targetRepo: string): void {

--- a/src/repair/update-command-status.ts
+++ b/src/repair/update-command-status.ts
@@ -20,8 +20,16 @@ import {
   runCommandLifecycleMutation,
   type CommandLifecycleInput,
 } from "./command-action-ledger.js";
+import {
+  COMMAND_PROGRESS_START as PROGRESS_START,
+  commandAckMarkerFromBody,
+  commandStatusMarkerFromBody,
+  compareCommentsByCreatedAt,
+  isPrunableCommandAckDuplicate,
+  selectCommandAckKeeper,
+  statusMarkerDiffersFromRequested,
+} from "./command-ack-convergence.js";
 
-const PROGRESS_START = "<!-- clawsweeper-command-progress:start -->";
 const PROGRESS_END = "<!-- clawsweeper-command-progress:end -->";
 
 type Options = {
@@ -412,59 +420,6 @@ function commandAckComments(comments: LooseRecord[], marker: string, trustedBots
         commandAckMarkerFromBody(comment.body) === marker,
     )
     .sort(compareCommentsByCreatedAt);
-}
-
-function commandAckMarkerFromBody(body: JsonValue) {
-  return String(body ?? "").match(/<!--\s*clawsweeper-command-ack:\d+\s*-->/)?.[0] ?? null;
-}
-
-function commandStatusMarkerFromBody(body: JsonValue) {
-  return (
-    String(body ?? "").match(new RegExp("<!--\\s*clawsweeper-command-status:[^>]+-->"))?.[0] ?? null
-  );
-}
-
-function statusMarkerDiffersFromRequested(body: JsonValue, requestedStatusMarker: string) {
-  const statusMarker = commandStatusMarkerFromBody(body);
-  return Boolean(requestedStatusMarker && statusMarker && statusMarker !== requestedStatusMarker);
-}
-
-function isPrunableCommandAckDuplicate(comment: LooseRecord, requestedStatusMarker: string) {
-  const statusMarker = commandStatusMarkerFromBody(comment.body);
-  return !statusMarker || statusMarker === requestedStatusMarker;
-}
-
-function selectCommandAckKeeper(comments: LooseRecord[]) {
-  return [...comments].sort(compareCommandAckKeepPriority)[0] ?? null;
-}
-
-function compareCommandAckKeepPriority(left: LooseRecord, right: LooseRecord) {
-  const leftStatus = commandAckStatusScore(left);
-  const rightStatus = commandAckStatusScore(right);
-  if (leftStatus !== rightStatus) return rightStatus - leftStatus;
-  if (leftStatus > 0) return compareCommentsByUpdatedAtDesc(left, right);
-  return compareCommentsByCreatedAt(left, right);
-}
-
-function commandAckStatusScore(comment: LooseRecord) {
-  const body = String(comment.body ?? "");
-  return body.includes("clawsweeper-command-status:") || body.includes(PROGRESS_START) ? 1 : 0;
-}
-
-function compareCommentsByUpdatedAtDesc(left: LooseRecord, right: LooseRecord) {
-  const leftUpdated = String(left.updated_at ?? left.created_at ?? "");
-  const rightUpdated = String(right.updated_at ?? right.created_at ?? "");
-  return (
-    rightUpdated.localeCompare(leftUpdated) || (Number(right.id) || 0) - (Number(left.id) || 0)
-  );
-}
-
-function compareCommentsByCreatedAt(left: LooseRecord, right: LooseRecord) {
-  const leftCreated = String(left.created_at ?? "");
-  const rightCreated = String(right.created_at ?? "");
-  return (
-    leftCreated.localeCompare(rightCreated) || (Number(left.id) || 0) - (Number(right.id) || 0)
-  );
 }
 
 export function mergeCommandProgressSection(

--- a/test/repair/command-ack-convergence.test.ts
+++ b/test/repair/command-ack-convergence.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  commandAckMarkerFromBody,
+  commandStatusMarkerFromBody,
+  planCommandAckConvergence,
+} from "../../dist/repair/command-ack-convergence.js";
+
+test("command acknowledgement convergence preserves parsing and keeper priority", () => {
+  const requestedStatus = "<!-- clawsweeper-command-status:81564:re_review:new -->";
+  const otherStatus = "<!-- clawsweeper-command-status:81564:re_review:old -->";
+  const comments = [
+    {
+      id: 101,
+      created_at: "2026-05-29T10:00:00Z",
+      updated_at: "2026-05-29T10:01:00Z",
+      body: `${otherStatus}\n<!-- clawsweeper-command-ack:456 -->`,
+    },
+    {
+      id: 102,
+      created_at: "2026-05-29T10:02:00Z",
+      updated_at: "2026-05-29T10:02:00Z",
+      body: "<!-- clawsweeper-command-ack:456 -->",
+    },
+    {
+      id: 103,
+      created_at: "2026-05-29T10:03:00Z",
+      updated_at: "2026-05-29T10:05:00Z",
+      body: `${requestedStatus}\n<!--   clawsweeper-command-ack:456   -->`,
+    },
+    {
+      id: 104,
+      created_at: "2026-05-29T10:04:00Z",
+      updated_at: "2026-05-29T10:04:00Z",
+      body: "<!-- clawsweeper-command-ack:456 -->",
+    },
+  ];
+
+  assert.equal(
+    commandAckMarkerFromBody(comments[2].body),
+    "<!--   clawsweeper-command-ack:456   -->",
+  );
+  assert.equal(commandStatusMarkerFromBody(comments[0].body), otherStatus);
+  const plan = planCommandAckConvergence(comments, requestedStatus);
+  assert.equal(plan.keep?.id, 103);
+  assert.deepEqual(
+    plan.prunable.map((comment) => comment.id),
+    [102, 104],
+  );
+});
+
+test("bare acknowledgement ties keep the earliest creation and lowest id", () => {
+  const plan = planCommandAckConvergence(
+    [
+      { id: 12, created_at: "2026-05-29T10:00:00Z", body: "bare" },
+      { id: 11, created_at: "2026-05-29T10:00:00Z", body: "bare" },
+      { id: 13, created_at: "2026-05-29T10:01:00Z", body: "bare" },
+    ],
+    "<!-- clawsweeper-command-status:81564:re_review:new -->",
+  );
+  assert.equal(plan.keep?.id, 11);
+});

--- a/test/repair/error-fingerprint.test.ts
+++ b/test/repair/error-fingerprint.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  errorFingerprint,
+  errorFingerprintDigest,
+  failureFingerprint,
+} from "../../dist/repair/error-fingerprint.js";
+
+test("error fingerprint wrappers preserve their distinct wire formats", () => {
+  const digest = "dd3599487ed91066c703b33178b719dcc9b548de8576047b95b06482bab7eaf6";
+  const error = new Error("boom");
+
+  assert.equal(errorFingerprintDigest(error), digest);
+  assert.equal(failureFingerprint(error), digest);
+  assert.equal(errorFingerprint(error), `sha256:${digest}`);
+});

--- a/test/repair/gitcrawl-store.test.ts
+++ b/test/repair/gitcrawl-store.test.ts
@@ -1,21 +1,52 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 
-test("gitcrawl readers prefer portable gitcrawl-store before legacy local DB", () => {
-  const sources = [
-    readFileSync("src/clawsweeper-related-context.ts", "utf8"),
-    readFileSync("src/repair/import-gitcrawl-clusters.ts", "utf8"),
-    readFileSync("src/repair/import-gitcrawl-low-signal-prs.ts", "utf8"),
-  ];
+import {
+  gitcrawlStoreDbFileName,
+  resolveGitcrawlDbPath,
+} from "../../dist/repair/gitcrawl-store.js";
 
-  for (const source of sources) {
-    assert.match(source, /CLAWSWEEPER_GITCRAWL_DB/);
-    assert.match(source, /gitcrawl-store/);
-    assert.match(source, /\.sync\.db/);
-    assert.match(source, /replace\(/);
-    assert(source.indexOf("gitcrawl-store") < source.indexOf('.config", "gitcrawl", "gitcrawl.db'));
-  }
+test("gitcrawl store resolver normalizes repositories and preserves path priority", () => {
+  const root = path.resolve("/proof/clawsweeper");
+  const homeDir = path.resolve("/proof/home");
+  const fileName = "openclaw__openclaw.sync.db";
+  const siblingStore = path.resolve(root, "../gitcrawl-store/data", fileName);
+  const userStore = path.resolve(homeDir, ".config/gitcrawl/stores/gitcrawl-store/data", fileName);
+  const legacyStore = path.resolve(homeDir, ".config/gitcrawl/gitcrawl.db");
+
+  assert.equal(gitcrawlStoreDbFileName(" OpenClaw/OpenClaw "), fileName);
+  assert.equal(
+    resolveGitcrawlDbPath("openclaw/openclaw", " ./explicit.db ", {
+      env: { CLAWSWEEPER_GITCRAWL_DB: "/ignored.db" },
+    }),
+    path.resolve("./explicit.db"),
+  );
+  assert.equal(
+    resolveGitcrawlDbPath("openclaw/openclaw", undefined, {
+      env: { CLAWSWEEPER_GITCRAWL_DB: " ./configured.db " },
+    }),
+    path.resolve("./configured.db"),
+  );
+  assert.equal(
+    resolveGitcrawlDbPath("openclaw/openclaw", undefined, {
+      env: {},
+      root,
+      homeDir,
+      existsSync: (candidate) => candidate === siblingStore || candidate === userStore,
+    }),
+    siblingStore,
+  );
+  assert.equal(
+    resolveGitcrawlDbPath("openclaw/openclaw", undefined, {
+      env: {},
+      root,
+      homeDir,
+      existsSync: () => false,
+    }),
+    legacyStore,
+  );
 });
 
 test("gitcrawl docs describe external store freshness instead of per-run crawling", () => {

--- a/test/repair/notify-merge.test.ts
+++ b/test/repair/notify-merge.test.ts
@@ -277,7 +277,7 @@ test("runMergeNotifier returns a strict failure when the hook rejects", async ()
 
   const summary = await runMergeNotifier(["--run-id", "987", "--strict"], {
     root,
-    fetch: (async () => new Response("bad", { status: 500 })) as typeof fetch,
+    fetch: (async () => new Response("denied", { status: 401 })) as typeof fetch,
     log: () => undefined,
     env: {
       CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks/agent",


### PR DESCRIPTION
## What Problem This Solves

Four repair-side behaviors had drift-prone duplicate implementations: merge notifications bypassed the shared OpenClaw hook client, two Gitcrawl importers independently resolved the same store paths, two publication paths independently hashed the same error detail, and three command-ack paths independently parsed and ranked the same markers.

## Why This Change Was Made

This makes each behavior have one owner while retaining the caller-specific wire contracts and limits.

1. `notify-merge` now uses the shared OpenClaw hook client already used by the three sibling notifiers. This intentionally changes transient-failure behavior from one-shot delivery to the shared retry policy. Every retry uses the same existing merge idempotency key.
2. Both repair Gitcrawl importers now use `gitcrawl-store.ts`; their intentionally different `sqliteJson` buffer limits remain local and unchanged.
3. Both error-fingerprint formats share one SHA-256 digest primitive while preserving the bare-hex batch contract and `sha256:`-prefixed event contract byte-for-byte.
4. Command-ack marker parsing, status scoring, ordering, and tie-breaking now live in `command-ack-convergence.ts`, consumed by all three prior owners with byte-identical behavior.

No compatibility shim or old duplicate path remains. `CHANGELOG.md` and `dashboard/` are untouched.

## User Impact

There is no user-visible behavior change except that the standalone merge notifier now retries transient OpenClaw hook failures using the same idempotency key, matching the existing sibling notifier behavior.

## Real Behavior Proof

Claim: each consolidation preserves its prior observable result, except for the explicitly intended merge-notifier retry adoption.

Exercised surface: the old built merge-notifier CLI and current production notifier function over native loopback HTTP, both built Gitcrawl importer CLIs over real on-disk SQLite stores, error-fingerprint wire formatting, and command-ack convergence.

Scenario and observable result:

- Merge notifier old control: the complete `origin/main` tree is built and its production `dist/repair/notify-merge.js` runs with normal hook environment configuration. A real server bound to `127.0.0.1:<ephemeral>` receives one POST at `2026-08-11T01:08:59.863Z`, returns HTTP 503, and the old process records one failed delivery and exits 1 under `--strict`.
- Merge notifier current path: the built `runMergeNotifier` function invoked by the CLI runs with the same arguments and normal hook environment configuration. The same real listener receives POST attempt 1 at `2026-08-11T01:08:59.881Z` and returns 503, then receives attempt 2 at `2026-08-11T01:09:00.887Z` and returns 200. Both socket requests carry `merge:openclaw/openclaw#123:merge_canonical:abc123` in the `idempotency-key` header and JSON body. The notifier report records one sent delivery and the process exits 0.
- Gitcrawl portable store: both old resolver copies, the shared resolver, and both built importer CLIs select `$FIXTURE_ROOT/gitcrawl-store/data/openclaw__openclaw.sync.db`; both importers exit 0 and read the `portable-store` marker from that real SQLite file.
- Gitcrawl legacy fallback: with the portable store absent, all resolvers and both importer CLIs select `$FIXTURE_ROOT/home/.config/gitcrawl/gitcrawl.db`; both importers exit 0 and read the `legacy-fallback` marker.
- Gitcrawl environment override: with competing portable and legacy files present, all resolvers and both importer CLIs select `$FIXTURE_ROOT/override/configured.db`; both importers exit 0 and read the `env-override` marker.
- Error fingerprints and command acknowledgements: the existing extracted-old-versus-shared-helper harnesses remain byte-identical across their committed cases.

Commands:

```text
pnpm run build:all
node docs/proof/repair-duplication-merges/merge-1/run-proof.mjs
node docs/proof/repair-duplication-merges/merge-2/run-proof.mjs
node docs/proof/repair-duplication-merges/merge-3/run-proof.mjs
node docs/proof/repair-duplication-merges/merge-4/run-proof.mjs
pnpm run format:check
pnpm run test:no-build
```

Local proof on Node 24.19.0 exited `PROOF_RC=0`. The full no-build suite reported 3,307 tests: 3,298 passed, 9 skipped, 0 failed. `format:check` passed.

Docker-backed proof used Crabbox 0.41.1, `provider=local-container`, lease `cbx_5b0de8cbba98` (`silver-barnacle-695f`), image `node:24-bookworm`, Docker 29.4.0, and a clean `--fresh-pr openclaw/clawsweeper#1114 --no-hydrate` checkout at `e94c0fbfe043545bebae5c3bf11fb961ef98a72a`. Corepack installed pinned pnpm 11.10.0. jq 1.8.1 was checksum-verified before use. All four proof scripts exited `PROOF_RC=0`; `build:all` and `format:check` passed. The lease stopped automatically. Final head `48009d55171e6ebee4c3212a9f55bc1db55189dc` adds only the committed README and machine-readable container provenance for that run.

Artifacts, source-extraction hashes, real socket timestamps/statuses, normalized resolved paths, real SQLite hashes, importer path traces, and machine-readable Crabbox provenance are committed under `docs/proof/repair-duplication-merges/`.

Limits: the proof is deterministic and credential-free. The HTTP endpoint is a loopback-only listener with a disposable token. SQLite fixtures are disposable local files queried by the real importer entry points through a `node:sqlite`-backed CLI adapter. No live OpenClaw, Discord, GitHub mutation, workflow, queue, or production service is exercised. The current container run did not repeat the full suite because that gate passed locally with zero failures; therefore the three previously known container blob-hydration failures did not need a new baseline run.

## Validation

- `build:all`: passed locally and in Docker-backed Crabbox
- all four committed proof scripts: `PROOF_RC=0` locally and in Docker-backed Crabbox
- `test:no-build`: passed locally — 3,307 tests, 3,298 passed, 9 skipped, 0 failed
- `format:check`: passed locally and in Docker-backed Crabbox
- pre-commit structured review: clean, no accepted/actionable findings
- provenance-only follow-up review: clean, no accepted/actionable findings

## OpenClaw Bay

No impact. These changes do not alter lifecycle/review publication, queue/workflow ownership, status/telemetry contracts, or dashboard data. Bay remains observer-only and requires no update.
