### PR TITLE
refactor(dashboard): unify GitHub App authentication

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -68,11 +68,22 @@ import {
 import { ExactReviewLifecycleTelemetryStore } from "./exact-review-lifecycle-telemetry.ts";
 import { recentDurablePublicationEvents } from "./recent-durable-publication-events.ts";
 import { sanitizedServerError } from "./error-safety.ts";
-import { githubApiUrl } from "./github-api.ts";
+import {
+  GitHubRequestError,
+  githubApiUrl,
+  githubAppCredentials,
+  githubAppInstallationId,
+  githubAppJson,
+  githubResponseRateLimitHint,
+  githubResponseRateLimited,
+  githubResponseValidationDetail,
+  signGithubAppJwt,
+  type GitHubRateLimitHint,
+  type GitHubRequestValidationDetail,
+} from "./github-api.ts";
 
 const RECENT_DURABLE_PUBLICATION_EVENTS_CACHE_MS = 60_000;
 
-type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
 const GITHUB_TIMEOUT_MS = 4500;
 const CLAWSWEEPER_REVIEW_REPO = "openclaw/clawsweeper";
 
@@ -13789,42 +13800,7 @@ type ExactReviewDispatchFailure = {
   detail?: ExactReviewDispatchFailureDetail;
 };
 
-type ExactReviewDispatchFailureDetail = {
-  validationFields: string[];
-  validationCodes: string[];
-};
-
-type GitHubRateLimitHint = {
-  observedAt: number;
-  retryAt: number;
-  provenance: ExactReviewGithubRateLimitProvenance;
-  authoritative: boolean;
-};
-
-class GitHubRequestError extends Error {
-  readonly status?: number;
-  readonly timedOut: boolean;
-  readonly rateLimited: boolean;
-  readonly validationDetail?: ExactReviewDispatchFailureDetail;
-  readonly rateLimitHint?: GitHubRateLimitHint;
-
-  constructor(
-    message: string,
-    status?: number,
-    timedOut = false,
-    rateLimited = false,
-    validationDetail?: ExactReviewDispatchFailureDetail,
-    rateLimitHint?: GitHubRateLimitHint,
-  ) {
-    super(message);
-    this.name = "GitHubRequestError";
-    this.status = status;
-    this.timedOut = timedOut;
-    this.rateLimited = rateLimited;
-    this.validationDetail = validationDetail;
-    this.rateLimitHint = rateLimitHint;
-  }
-}
+type ExactReviewDispatchFailureDetail = GitHubRequestValidationDetail;
 
 function exactReviewDispatchFailure(error: unknown): ExactReviewDispatchFailure {
   const requestError = error instanceof GitHubRequestError ? error : null;
@@ -14660,118 +14636,6 @@ async function mapWithConcurrency<Item, Result>(
   return results;
 }
 
-function githubAppCredentials(env) {
-  const issuer = stringEnv(env.CLAWSWEEPER_APP_ID) || stringEnv(env.CLAWSWEEPER_APP_CLIENT_ID);
-  const privateKey = normalizePrivateKey(env.CLAWSWEEPER_APP_PRIVATE_KEY);
-  if (!issuer || !privateKey) return null;
-  return {
-    issuer,
-    privateKey,
-    installationId: stringEnv(env.CLAWSWEEPER_APP_INSTALLATION_ID),
-  };
-}
-
-async function githubAppInstallationId(appJwt, repo, env = {}) {
-  if (!repo || !repo.includes("/")) throw new Error("GitHub App installation repo is required");
-  const payload = await githubAppJson(
-    `/repos/${repo}/installation`,
-    appJwt,
-    { errorLabel: "GitHub App installation" },
-    env,
-  );
-  const installationId = Number(payload.id);
-  if (!Number.isInteger(installationId) || installationId <= 0) {
-    throw new Error(`GitHub App installation response missing id for ${repo}`);
-  }
-  return String(installationId);
-}
-
-async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}, env = {}) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
-  let response: Response;
-  try {
-    response = await fetch(githubApiUrl(env, path), {
-      method: options.method || "GET",
-      signal: controller.signal,
-      headers: {
-        Accept: "application/vnd.github+json",
-        "Content-Type": "application/json",
-        "User-Agent": "openclaw-clawsweeper-status",
-        Authorization: `Bearer ${appJwt}`,
-      },
-      body: options.body,
-    });
-  } catch (error) {
-    const timedOut =
-      controller.signal.aborted ||
-      (error instanceof Error && (error.name === "AbortError" || error.message === "timeout"));
-    throw new GitHubRequestError(
-      `${options.errorLabel || "GitHub App"} ${timedOut ? "timed out" : "network failure"}`,
-      undefined,
-      timedOut,
-    );
-  } finally {
-    clearTimeout(timeout);
-  }
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    const rateLimited = githubResponseRateLimited(response, text);
-    throw new GitHubRequestError(
-      `${options.errorLabel || "GitHub App"} ${response.status}`,
-      response.status,
-      false,
-      rateLimited,
-      githubResponseValidationDetail(response.status, text),
-      rateLimited ? githubResponseRateLimitHint(response, Date.now()) : undefined,
-    );
-  }
-  return response.json();
-}
-
-function githubResponseRateLimited(response: Response, text: string) {
-  return (
-    response.status === 429 ||
-    response.headers.has("retry-after") ||
-    response.headers.get("x-ratelimit-remaining") === "0" ||
-    /(?:secondary )?rate limit|api rate limit|abuse detection/i.test(text)
-  );
-}
-
-function githubResponseRateLimitHint(response: Response, observedAt: number): GitHubRateLimitHint {
-  const maxRetryAt = observedAt + EXACT_REVIEW_COMPLETION_RETRY_MAX_MS;
-  const retryAfter = String(response.headers.get("retry-after") || "").trim();
-  if (retryAfter) {
-    const seconds = Number(retryAfter);
-    const parsed = Number.isFinite(seconds)
-      ? observedAt + Math.max(0, seconds) * 1_000
-      : Date.parse(retryAfter);
-    if (Number.isFinite(parsed)) {
-      return {
-        observedAt,
-        retryAt: Math.max(observedAt + 1_000, Math.min(maxRetryAt, parsed)),
-        provenance: "retry_after",
-        authoritative: true,
-      };
-    }
-  }
-  const resetSeconds = Number(response.headers.get("x-ratelimit-reset"));
-  if (Number.isFinite(resetSeconds) && resetSeconds > 0) {
-    return {
-      observedAt,
-      retryAt: Math.max(observedAt + 1_000, Math.min(maxRetryAt, resetSeconds * 1_000)),
-      provenance: "rate_limit_reset",
-      authoritative: true,
-    };
-  }
-  return {
-    observedAt,
-    retryAt: observedAt + EXACT_REVIEW_GITHUB_THROTTLE_ADMISSION_COOLDOWN_MS,
-    provenance: "fallback",
-    authoritative: false,
-  };
-}
-
 function exactReviewGithubTargetAppObservation(
   error: unknown,
   targetRepo: string,
@@ -14796,133 +14660,6 @@ function exactReviewGithubTargetAppObservation(
     provenance: hint.provenance,
     authoritative: hint.authoritative,
   };
-}
-
-function githubResponseValidationDetail(status: number, text: string) {
-  if (status !== 422 || text.length > 16_384) return undefined;
-  let payload: unknown;
-  try {
-    payload = JSON.parse(text);
-  } catch {
-    return undefined;
-  }
-  const errors = Array.isArray(objectValue(payload).errors) ? objectValue(payload).errors : [];
-  const validationFields = new Set<string>();
-  const validationCodes = new Set<string>();
-  for (const error of errors.slice(0, 8)) {
-    const value = objectValue(error);
-    const field = githubValidationToken(value.field);
-    const code = githubValidationToken(value.code);
-    if (field) validationFields.add(field);
-    if (code) validationCodes.add(code);
-  }
-  if (!validationFields.size && !validationCodes.size) return undefined;
-  return {
-    validationFields: [...validationFields].sort().slice(0, 4),
-    validationCodes: [...validationCodes].sort().slice(0, 4),
-  };
-}
-
-function githubValidationToken(value: unknown) {
-  const token =
-    String(value || "")
-      .match(/^[A-Za-z_][A-Za-z0-9_]*/)?.[0]
-      ?.toLowerCase() || "";
-  return token.length <= 64 ? token : "";
-}
-
-async function signGithubAppJwt(issuer, privateKey) {
-  const now = Math.floor(Date.now() / 1000);
-  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
-  const payload = base64UrlEncode(JSON.stringify({ iat: now - 60, exp: now + 540, iss: issuer }));
-  const input = `${header}.${payload}`;
-  const key = await crypto.subtle.importKey(
-    "pkcs8",
-    pemToPkcs8(privateKey),
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const signature = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    key,
-    new TextEncoder().encode(input),
-  );
-  return `${input}.${base64UrlEncode(new Uint8Array(signature))}`;
-}
-
-function normalizePrivateKey(value) {
-  return stringEnv(value)?.replace(/\\n/g, "\n") || "";
-}
-
-function pemToPkcs8(pem) {
-  const pkcs8 = pemBody(pem, "PRIVATE KEY");
-  if (pkcs8) return pkcs8;
-  const pkcs1 = pemBody(pem, "RSA PRIVATE KEY");
-  if (!pkcs1) throw new Error("GitHub App private key must be PEM encoded");
-  return wrapPkcs1PrivateKey(pkcs1);
-}
-
-function pemBody(pem, label) {
-  const pattern = new RegExp(`-----BEGIN ${label}-----([\\s\\S]+?)-----END ${label}-----`, "m");
-  const match = String(pem).match(pattern);
-  if (!match) return null;
-  const binary = atob(match[1].replace(/\s+/g, ""));
-  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
-}
-
-function wrapPkcs1PrivateKey(pkcs1) {
-  const version = new Uint8Array([0x02, 0x01, 0x00]);
-  const algorithm = new Uint8Array([
-    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
-  ]);
-  const octetString = derElement(0x04, pkcs1);
-  return derElement(0x30, concatBytes(version, algorithm, octetString));
-}
-
-function derElement(tag, value) {
-  return concatBytes(new Uint8Array([tag]), derLength(value.length), value);
-}
-
-function derLength(length) {
-  if (length < 0x80) return new Uint8Array([length]);
-  const bytes = [];
-  let value = length;
-  while (value > 0) {
-    bytes.unshift(value & 0xff);
-    value >>= 8;
-  }
-  return new Uint8Array([0x80 | bytes.length, ...bytes]);
-}
-
-function concatBytes(...parts) {
-  const total = parts.reduce((sum, part) => sum + part.length, 0);
-  const output = new Uint8Array(total);
-  let offset = 0;
-  for (const part of parts) {
-    output.set(part, offset);
-    offset += part.length;
-  }
-  return output;
-}
-
-function base64UrlEncode(value) {
-  const bytes =
-    typeof value === "string"
-      ? new TextEncoder().encode(value)
-      : value instanceof Uint8Array
-        ? value
-        : new Uint8Array(value);
-  let binary = "";
-  for (let index = 0; index < bytes.length; index += 1) {
-    binary += String.fromCharCode(bytes[index]);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
-}
-
-function stringEnv(value) {
-  const text = String(value || "").trim();
-  return text ? text : "";
 }
 
 function numberFrom(value, fallback) {

--- a/dashboard/github-api.ts
+++ b/dashboard/github-api.ts
@@ -1,6 +1,47 @@
 export const DEFAULT_GITHUB_API_URL = "https://api.github.com";
 
+const GITHUB_APP_TIMEOUT_MS = 4500;
+const GITHUB_RATE_LIMIT_FALLBACK_MS = 15 * 60 * 1000;
+const GITHUB_RATE_LIMIT_MAX_RETRY_MS = 2 * 60 * 60 * 1000;
+
 type GithubApiEnv = Record<string, unknown>;
+
+export type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
+export type GitHubRequestValidationDetail = {
+  validationFields: string[];
+  validationCodes: string[];
+};
+export type GitHubRateLimitHint = {
+  observedAt: number;
+  retryAt: number;
+  provenance: "retry_after" | "rate_limit_reset" | "rate_limit_status" | "fallback";
+  authoritative: boolean;
+};
+
+export class GitHubRequestError extends Error {
+  readonly status?: number;
+  readonly timedOut: boolean;
+  readonly rateLimited: boolean;
+  readonly validationDetail?: GitHubRequestValidationDetail;
+  readonly rateLimitHint?: GitHubRateLimitHint;
+
+  constructor(
+    message: string,
+    status?: number,
+    timedOut = false,
+    rateLimited = false,
+    validationDetail?: GitHubRequestValidationDetail,
+    rateLimitHint?: GitHubRateLimitHint,
+  ) {
+    super(message);
+    this.name = "GitHubRequestError";
+    this.status = status;
+    this.timedOut = timedOut;
+    this.rateLimited = rateLimited;
+    this.validationDetail = validationDetail;
+    this.rateLimitHint = rateLimitHint;
+  }
+}
 
 export function githubApiBaseUrl(env: GithubApiEnv = {}): string {
   const configured = env.GITHUB_API_URL;
@@ -44,4 +85,279 @@ function invalidGithubApiUrl(): Error {
   return new Error(
     "invalid GITHUB_API_URL: expected https://api.github.com or an http://127.0.0.1:<port> / http://localhost:<port> origin",
   );
+}
+
+export function githubAppCredentials(env) {
+  const issuer = stringEnv(env.CLAWSWEEPER_APP_ID) || stringEnv(env.CLAWSWEEPER_APP_CLIENT_ID);
+  const privateKey = normalizePrivateKey(env.CLAWSWEEPER_APP_PRIVATE_KEY);
+  if (!issuer || !privateKey) return null;
+  return {
+    issuer,
+    privateKey,
+    installationId: stringEnv(env.CLAWSWEEPER_APP_INSTALLATION_ID),
+  };
+}
+
+export async function githubAppInstallationId(appJwt, repo, env = {}) {
+  if (!repo || !repo.includes("/")) throw new Error("GitHub App installation repo is required");
+  const payload = await githubAppJson(
+    `/repos/${repo}/installation`,
+    appJwt,
+    { errorLabel: "GitHub App installation" },
+    env,
+  );
+  const installationId = Number(payload.id);
+  if (!Number.isInteger(installationId) || installationId <= 0) {
+    throw new Error(`GitHub App installation response missing id for ${repo}`);
+  }
+  return String(installationId);
+}
+
+export async function githubAppInstallationIdAsPlainError(appJwt, repo, env = {}) {
+  try {
+    return await githubAppInstallationId(appJwt, repo, env);
+  } catch (error) {
+    throwPlainGitHubRequestError(error);
+  }
+}
+
+export async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}, env = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_APP_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(githubApiUrl(env, path), {
+      method: options.method || "GET",
+      signal: controller.signal,
+      headers: {
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "User-Agent": "openclaw-clawsweeper-status",
+        Authorization: `Bearer ${appJwt}`,
+      },
+      body: options.body,
+    });
+  } catch (error) {
+    const timedOut =
+      controller.signal.aborted ||
+      (error instanceof Error && (error.name === "AbortError" || error.message === "timeout"));
+    throw new GitHubRequestError(
+      `${options.errorLabel || "GitHub App"} ${timedOut ? "timed out" : "network failure"}`,
+      undefined,
+      timedOut,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    const rateLimited = githubResponseRateLimited(response, text);
+    throw new GitHubRequestError(
+      `${options.errorLabel || "GitHub App"} ${response.status}`,
+      response.status,
+      false,
+      rateLimited,
+      githubResponseValidationDetail(response.status, text),
+      rateLimited ? githubResponseRateLimitHint(response, Date.now()) : undefined,
+    );
+  }
+  return response.json();
+}
+
+export async function githubAppJsonAsPlainError(
+  path,
+  appJwt,
+  options: GithubAppJsonOptions = {},
+  env = {},
+) {
+  try {
+    return await githubAppJson(path, appJwt, options, env);
+  } catch (error) {
+    throwPlainGitHubRequestError(error);
+  }
+}
+
+function throwPlainGitHubRequestError(error: unknown): never {
+  if (error instanceof GitHubRequestError) throw new Error(error.message);
+  throw error;
+}
+
+export function githubResponseRateLimited(response: Response, text: string) {
+  return (
+    response.status === 429 ||
+    response.headers.has("retry-after") ||
+    response.headers.get("x-ratelimit-remaining") === "0" ||
+    /(?:secondary )?rate limit|api rate limit|abuse detection/i.test(text)
+  );
+}
+
+export function githubResponseRateLimitHint(
+  response: Response,
+  observedAt: number,
+): GitHubRateLimitHint {
+  const maxRetryAt = observedAt + GITHUB_RATE_LIMIT_MAX_RETRY_MS;
+  const retryAfter = String(response.headers.get("retry-after") || "").trim();
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    const parsed = Number.isFinite(seconds)
+      ? observedAt + Math.max(0, seconds) * 1_000
+      : Date.parse(retryAfter);
+    if (Number.isFinite(parsed)) {
+      return {
+        observedAt,
+        retryAt: Math.max(observedAt + 1_000, Math.min(maxRetryAt, parsed)),
+        provenance: "retry_after",
+        authoritative: true,
+      };
+    }
+  }
+  const resetSeconds = Number(response.headers.get("x-ratelimit-reset"));
+  if (Number.isFinite(resetSeconds) && resetSeconds > 0) {
+    return {
+      observedAt,
+      retryAt: Math.max(observedAt + 1_000, Math.min(maxRetryAt, resetSeconds * 1_000)),
+      provenance: "rate_limit_reset",
+      authoritative: true,
+    };
+  }
+  return {
+    observedAt,
+    retryAt: observedAt + GITHUB_RATE_LIMIT_FALLBACK_MS,
+    provenance: "fallback",
+    authoritative: false,
+  };
+}
+
+export function githubResponseValidationDetail(status: number, text: string) {
+  if (status !== 422 || text.length > 16_384) return undefined;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  const record = objectValue(payload);
+  const errors = Array.isArray(record.errors) ? record.errors : [];
+  const validationFields = new Set<string>();
+  const validationCodes = new Set<string>();
+  for (const error of errors.slice(0, 8)) {
+    const value = objectValue(error);
+    const field = githubValidationToken(value.field);
+    const code = githubValidationToken(value.code);
+    if (field) validationFields.add(field);
+    if (code) validationCodes.add(code);
+  }
+  if (!validationFields.size && !validationCodes.size) return undefined;
+  return {
+    validationFields: [...validationFields].sort().slice(0, 4),
+    validationCodes: [...validationCodes].sort().slice(0, 4),
+  };
+}
+
+function githubValidationToken(value: unknown) {
+  const token =
+    String(value || "")
+      .match(/^[A-Za-z_][A-Za-z0-9_]*/)?.[0]
+      ?.toLowerCase() || "";
+  return token.length <= 64 ? token : "";
+}
+
+export async function signGithubAppJwt(issuer, privateKey) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64UrlEncode(JSON.stringify({ iat: now - 60, exp: now + 540, iss: issuer }));
+  const input = `${header}.${payload}`;
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToPkcs8(privateKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(input),
+  );
+  return `${input}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+export function normalizePrivateKey(value) {
+  return stringEnv(value)?.replace(/\\n/g, "\n") || "";
+}
+
+export function pemToPkcs8(pem) {
+  const pkcs8 = pemBody(pem, "PRIVATE KEY");
+  if (pkcs8) return pkcs8;
+  const pkcs1 = pemBody(pem, "RSA PRIVATE KEY");
+  if (!pkcs1) throw new Error("GitHub App private key must be PEM encoded");
+  return wrapPkcs1PrivateKey(pkcs1);
+}
+
+export function pemBody(pem, label) {
+  const pattern = new RegExp(`-----BEGIN ${label}-----([\\s\\S]+?)-----END ${label}-----`, "m");
+  const match = String(pem).match(pattern);
+  if (!match) return null;
+  const binary = atob(match[1].replace(/\s+/g, ""));
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+export function wrapPkcs1PrivateKey(pkcs1) {
+  const version = new Uint8Array([0x02, 0x01, 0x00]);
+  const algorithm = new Uint8Array([
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
+  ]);
+  const octetString = derElement(0x04, pkcs1);
+  return derElement(0x30, concatBytes(version, algorithm, octetString));
+}
+
+export function derElement(tag, value) {
+  return concatBytes(new Uint8Array([tag]), derLength(value.length), value);
+}
+
+export function derLength(length) {
+  if (length < 0x80) return new Uint8Array([length]);
+  const bytes = [];
+  let value = length;
+  while (value > 0) {
+    bytes.unshift(value & 0xff);
+    value >>= 8;
+  }
+  return new Uint8Array([0x80 | bytes.length, ...bytes]);
+}
+
+export function concatBytes(...parts) {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+export function base64UrlEncode(value) {
+  const bytes =
+    typeof value === "string"
+      ? new TextEncoder().encode(value)
+      : value instanceof Uint8Array
+        ? value
+        : new Uint8Array(value);
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringEnv(value) {
+  const text = String(value || "").trim();
+  return text ? text : "";
 }

--- a/dashboard/github-api.ts
+++ b/dashboard/github-api.ts
@@ -3,6 +3,7 @@ export const DEFAULT_GITHUB_API_URL = "https://api.github.com";
 const GITHUB_APP_TIMEOUT_MS = 4500;
 const GITHUB_RATE_LIMIT_FALLBACK_MS = 15 * 60 * 1000;
 const GITHUB_RATE_LIMIT_MAX_RETRY_MS = 2 * 60 * 60 * 1000;
+const workerTransportErrors = new WeakMap<GitHubRequestError, unknown>();
 
 type GithubApiEnv = Record<string, unknown>;
 
@@ -141,11 +142,13 @@ export async function githubAppJson(path, appJwt, options: GithubAppJsonOptions 
     const timedOut =
       controller.signal.aborted ||
       (error instanceof Error && (error.name === "AbortError" || error.message === "timeout"));
-    throw new GitHubRequestError(
+    const requestError = new GitHubRequestError(
       `${options.errorLabel || "GitHub App"} ${timedOut ? "timed out" : "network failure"}`,
       undefined,
       timedOut,
     );
+    if (!controller.signal.aborted) workerTransportErrors.set(requestError, error);
+    throw requestError;
   } finally {
     clearTimeout(timeout);
   }
@@ -178,7 +181,10 @@ export async function githubAppJsonAsPlainError(
 }
 
 function throwPlainGitHubRequestError(error: unknown): never {
-  if (error instanceof GitHubRequestError) throw new Error(error.message);
+  if (error instanceof GitHubRequestError) {
+    if (workerTransportErrors.has(error)) throw workerTransportErrors.get(error);
+    throw new Error(error.message);
+  }
   throw error;
 }
 

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -6,7 +6,13 @@ import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-l
 import { bayHtml } from "./bay-page.ts";
 import { liveActivityBaySnapshot } from "./live-activity.ts";
 import { summarizeDashboardHealth } from "./dashboard-health.ts";
-import { githubApiUrl } from "./github-api.ts";
+import {
+  githubApiUrl,
+  githubAppCredentials,
+  githubAppInstallationIdAsPlainError as githubAppInstallationId,
+  githubAppJsonAsPlainError as githubAppJson,
+  signGithubAppJwt,
+} from "./github-api.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
   exactReviewHistorySample,
@@ -70,7 +76,6 @@ const ACTIVE_RUN_STATUSES = new Set(["queued", "in_progress", "waiting", "reques
 const QUEUED_RUN_STATUSES = new Set(["queued", "waiting", "requested", "pending"]);
 type DashboardEnv = Record<string, unknown>;
 type DashboardContext = { waitUntil?: (promise: Promise<unknown>) => void };
-type GithubAppJsonOptions = { method?: string; body?: BodyInit; errorLabel?: string };
 type GithubJsonReader = (path: string) => ReturnType<typeof githubJson>;
 type StoredValue = { value: string; expires_at?: number };
 type WorkflowRunSummary = {
@@ -6914,17 +6919,6 @@ async function githubAuthToken(env) {
   return promise;
 }
 
-function githubAppCredentials(env) {
-  const issuer = stringEnv(env.CLAWSWEEPER_APP_ID) || stringEnv(env.CLAWSWEEPER_APP_CLIENT_ID);
-  const privateKey = normalizePrivateKey(env.CLAWSWEEPER_APP_PRIVATE_KEY);
-  if (!issuer || !privateKey) return null;
-  return {
-    issuer,
-    privateKey,
-    installationId: stringEnv(env.CLAWSWEEPER_APP_INSTALLATION_ID),
-  };
-}
-
 async function createGithubAppInstallationToken(env, credentials, repos) {
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
   const installationId =
@@ -6953,128 +6947,6 @@ async function createGithubAppInstallationToken(env, credentials, repos) {
     ? Date.parse(payload.expires_at)
     : Date.now() + GITHUB_APP_TOKEN_DEFAULT_TTL_MS;
   return { token, expiresAtMs };
-}
-
-async function githubAppInstallationId(appJwt, repo, env = {}) {
-  if (!repo || !repo.includes("/")) throw new Error("GitHub App installation repo is required");
-  const payload = await githubAppJson(
-    `/repos/${repo}/installation`,
-    appJwt,
-    { errorLabel: "GitHub App installation" },
-    env,
-  );
-  const installationId = Number(payload.id);
-  if (!Number.isInteger(installationId) || installationId <= 0) {
-    throw new Error(`GitHub App installation response missing id for ${repo}`);
-  }
-  return String(installationId);
-}
-
-async function githubAppJson(path, appJwt, options: GithubAppJsonOptions = {}, env = {}) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort("timeout"), GITHUB_TIMEOUT_MS);
-  const response = await fetch(githubApiUrl(env, path), {
-    method: options.method || "GET",
-    signal: controller.signal,
-    headers: {
-      Accept: "application/vnd.github+json",
-      "Content-Type": "application/json",
-      "User-Agent": "openclaw-clawsweeper-status",
-      Authorization: `Bearer ${appJwt}`,
-    },
-    body: options.body,
-  }).finally(() => clearTimeout(timeout));
-  if (!response.ok) throw new Error(`${options.errorLabel || "GitHub App"} ${response.status}`);
-  return response.json();
-}
-
-async function signGithubAppJwt(issuer, privateKey) {
-  const now = Math.floor(Date.now() / 1000);
-  const header = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
-  const payload = base64UrlEncode(JSON.stringify({ iat: now - 60, exp: now + 540, iss: issuer }));
-  const input = `${header}.${payload}`;
-  const key = await crypto.subtle.importKey(
-    "pkcs8",
-    pemToPkcs8(privateKey),
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const signature = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    key,
-    new TextEncoder().encode(input),
-  );
-  return `${input}.${base64UrlEncode(new Uint8Array(signature))}`;
-}
-
-function normalizePrivateKey(value) {
-  return stringEnv(value)?.replace(/\\n/g, "\n") || "";
-}
-
-function pemToPkcs8(pem) {
-  const pkcs8 = pemBody(pem, "PRIVATE KEY");
-  if (pkcs8) return pkcs8;
-  const pkcs1 = pemBody(pem, "RSA PRIVATE KEY");
-  if (!pkcs1) throw new Error("GitHub App private key must be PEM encoded");
-  return wrapPkcs1PrivateKey(pkcs1);
-}
-
-function pemBody(pem, label) {
-  const pattern = new RegExp(`-----BEGIN ${label}-----([\\s\\S]+?)-----END ${label}-----`, "m");
-  const match = String(pem).match(pattern);
-  if (!match) return null;
-  const binary = atob(match[1].replace(/\s+/g, ""));
-  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
-}
-
-function wrapPkcs1PrivateKey(pkcs1) {
-  const version = new Uint8Array([0x02, 0x01, 0x00]);
-  const algorithm = new Uint8Array([
-    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
-  ]);
-  const octetString = derElement(0x04, pkcs1);
-  return derElement(0x30, concatBytes(version, algorithm, octetString));
-}
-
-function derElement(tag, value) {
-  return concatBytes(new Uint8Array([tag]), derLength(value.length), value);
-}
-
-function derLength(length) {
-  if (length < 0x80) return new Uint8Array([length]);
-  const bytes = [];
-  let value = length;
-  while (value > 0) {
-    bytes.unshift(value & 0xff);
-    value >>= 8;
-  }
-  return new Uint8Array([0x80 | bytes.length, ...bytes]);
-}
-
-function concatBytes(...parts) {
-  const total = parts.reduce((sum, part) => sum + part.length, 0);
-  const output = new Uint8Array(total);
-  let offset = 0;
-  for (const part of parts) {
-    output.set(part, offset);
-    offset += part.length;
-  }
-  return output;
-}
-
-function base64UrlEncode(value) {
-  const bytes =
-    typeof value === "string"
-      ? new TextEncoder().encode(value)
-      : value instanceof Uint8Array
-        ? value
-        : new Uint8Array(value);
-  let binary = "";
-  for (let index = 0; index < bytes.length; index += 1) {
-    binary += String.fromCharCode(bytes[index]);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 function stringEnv(value) {

--- a/docs/proof/unify-github-app-auth/README.md
+++ b/docs/proof/unify-github-app-auth/README.md
@@ -44,6 +44,15 @@ docs/proof/unify-github-app-auth/run-proof.sh
 Artifacts are written under `docs/proof/unify-github-app-auth/artifacts/` by default. Set
 `UNIFY_GITHUB_APP_AUTH_PROOF_OUTPUT` to use another directory.
 
+## Local observation
+
+The committed local run exercised code commit `007544716b06d9b9189ac846c903bac2df7e155c` on
+Node 24.19.0 and completed with `PROOF_RC=0`. The real Worker returned `202` with status comment
+`777`; the real queue Durable Object returned `202`, resolved `openclaw/gogcli#598`, and made no
+unexpected loopback requests. The two entry points' App JWTs and canonical App-auth header bytes
+were identical. See [`artifacts/proof-summary.json`](artifacts/proof-summary.json) and the
+[`redacted request trace`](artifacts/github-requests.redacted.json).
+
 ## Limits
 
 This proves both production entry points, the local Worker/DO boundary, cryptographic signing, and

--- a/docs/proof/unify-github-app-auth/README.md
+++ b/docs/proof/unify-github-app-auth/README.md
@@ -53,6 +53,23 @@ unexpected loopback requests. The two entry points' App JWTs and canonical App-a
 were identical. See [`artifacts/proof-summary.json`](artifacts/proof-summary.json) and the
 [`redacted request trace`](artifacts/github-requests.redacted.json).
 
+## Crabbox container observation
+
+The same proof passed from a clean `--fresh-pr openclaw/clawsweeper#1115 --no-hydrate` checkout at
+head `075bcf0494864fb1d8fd4475d211b5b9f741c173` inside Docker-backed Crabbox
+`provider=local-container`, image `node:24-bookworm`, lease `cbx_585f04f5feea`
+(`violet-prawn-a71c`). Corepack supplied pnpm 11.10.0, and jq 1.8.1 printed
+`jq-linux-amd64: OK` before installation. The runtime proof completed with `PROOF_RC=0` and
+`CONTAINER_PROOF_RC=0`; Crabbox exited 0 and stopped the lease automatically.
+
+The same container first checked current `origin/main` at
+`765644804756d5f6b1dc1e940d62c50711e398d8`. Its targeted baseline produced the three known
+blob-hydration environmental failures. The PR full suite then ran 3,312 tests: 3,301 passed, 8
+skipped, and exactly those same 3 failed. The harness recorded `CONTAINER_DELTA_FAILURES=0`.
+[`artifacts/crabbox-local-container-provenance.json`](artifacts/crabbox-local-container-provenance.json)
+and [`artifacts/crabbox-local-container-summary.log`](artifacts/crabbox-local-container-summary.log)
+retain the provider, lease, timing, baseline, and verbatim result markers.
+
 ## Limits
 
 This proves both production entry points, the local Worker/DO boundary, cryptographic signing, and

--- a/docs/proof/unify-github-app-auth/README.md
+++ b/docs/proof/unify-github-app-auth/README.md
@@ -1,0 +1,57 @@
+# GitHub App authentication unification proof
+
+## Claim
+
+The dashboard Worker and exact-review queue Durable Object use one canonical GitHub App signer and
+request implementation without changing either entry point's observable behavior. Their signed
+routes emit byte-identical JWTs and canonical App-auth request headers for the same synthetic App
+identity, while their route-specific methods, paths, and bodies remain distinct.
+
+## Exercised surface
+
+- Real `wrangler dev --local` Worker HTTP routing and GitHub webhook signature verification
+- Real SQLite-backed `ExactReviewQueue` Durable Object routing, storage, and alarm processing
+- The production GitHub App credential parser, RS256 signer, PKCS8 importer, and HTTP client
+- The worker's plain-error adapter and the queue's classified-error implementation
+- Loopback-only `GITHUB_API_URL` transport over a real HTTP socket
+
+## Controlled scenario
+
+The harness starts one local Worker/DO runtime and one loopback GitHub HTTP server. It concurrently
+sends:
+
+1. a signed maintainer `issue_comment` webhook through `/github/webhook`, which exercises the
+   dashboard Worker App-auth path; and
+2. a signed branchless review request through `/internal/exact-review/branch-authority`, which is
+   forwarded to the real queue Durable Object and resolved by its alarm through App auth.
+
+The loopback server holds the Worker's installation lookup and the queue's installation-token
+request until both are present. The harness then requires their complete JWT strings and their
+canonical `Accept`, `Content-Type`, `User-Agent`, and `Authorization` header bytes to be identical.
+It also verifies the route-specific request methods, paths, and bodies, the Worker's successful
+command acknowledgement, the queue's resolved target branch, and the absence of unexpected HTTP
+requests. Committed traces contain hashes and redacted authorization values, never the private key,
+JWT, or installation tokens.
+
+## Command
+
+Run on Node 24 or newer from the repository root:
+
+```bash
+docs/proof/unify-github-app-auth/run-proof.sh
+```
+
+Artifacts are written under `docs/proof/unify-github-app-auth/artifacts/` by default. Set
+`UNIFY_GITHUB_APP_AUTH_PROOF_OUTPUT` to use another directory.
+
+## Limits
+
+This proves both production entry points, the local Worker/DO boundary, cryptographic signing, and
+real socket transport with synthetic credentials. The controlled loopback endpoint is not GitHub
+production, and the proof performs no production GitHub write, workflow dispatch, deployment, or
+queue mutation.
+
+## OpenClaw Bay impact
+
+None. This is an internal authentication ownership consolidation. It changes no Bay data contract,
+status projection, lifecycle semantics, controls, or observer-only boundary.

--- a/docs/proof/unify-github-app-auth/artifacts/build-dashboard.log
+++ b/docs/proof/unify-github-app-auth/artifacts/build-dashboard.log
@@ -1,0 +1,1 @@
+$ tsc -p tsconfig.dashboard.json

--- a/docs/proof/unify-github-app-auth/artifacts/crabbox-local-container-provenance.json
+++ b/docs/proof/unify-github-app-auth/artifacts/crabbox-local-container-provenance.json
@@ -1,0 +1,63 @@
+{
+  "schema": "clawsweeper-crabbox-proof-provenance/v1",
+  "generated_at": "2026-08-11T01:22:00Z",
+  "claim": "The pushed PR emits identical GitHub App JWT and canonical request-header bytes from the real signed Worker and Durable Object routes, with no container test failures beyond the current-main blob-hydration baseline.",
+  "crabbox": {
+    "cli_version": "0.38.3-5-g2a79805d",
+    "provider": "local-container",
+    "lease_id": "cbx_585f04f5feea",
+    "slug": "violet-prawn-a71c",
+    "machine_type": "node_24-bookworm",
+    "image": "node:24-bookworm",
+    "container_engine": "Docker 29.4.0",
+    "checkout": "--fresh-pr openclaw/clawsweeper#1115 --no-hydrate",
+    "sync_ms": 10154,
+    "command_ms": 104251,
+    "total_ms": 114406,
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "runtime": {
+    "node": "v24.19.0",
+    "pnpm": "11.10.0",
+    "jq": "1.8.1",
+    "git": "2.39.5"
+  },
+  "tool_verification": {
+    "corepack_enabled": true,
+    "jq_binary_sha256": "passed"
+  },
+  "reviewed_head": "075bcf0494864fb1d8fd4475d211b5b9f741c173",
+  "baseline": {
+    "head": "765644804756d5f6b1dc1e940d62c50711e398d8",
+    "selected_tests": 3,
+    "passed": 0,
+    "failed": 3,
+    "exit_code": 1,
+    "failures": [
+      "restricted PR review can inspect changed blobs from a genuine blobless clone offline",
+      "missing partial-clone objects are fetched in one bounded network request",
+      "review hydration enforces per-review byte limits without fetching oversized blobs"
+    ]
+  },
+  "result": {
+    "proof_rc": 0,
+    "full_suite_tests": 3312,
+    "full_suite_passed": 3301,
+    "full_suite_failed": 3,
+    "full_suite_skipped": 8,
+    "full_suite_exit_code": 1,
+    "failure_delta_vs_baseline": 0,
+    "container_proof_rc": 0
+  },
+  "setup_attempts": [
+    {
+      "lease_id": "cbx_0c3ea7d6f3e1",
+      "slug": "swift-krill-2dae",
+      "exit_code": 1,
+      "reason": "The baseline behaved as expected, but the harness parser initially retained Node test-duration suffixes when comparing the three titles.",
+      "lease_stopped": true
+    }
+  ]
+}

--- a/docs/proof/unify-github-app-auth/artifacts/crabbox-local-container-summary.log
+++ b/docs/proof/unify-github-app-auth/artifacts/crabbox-local-container-summary.log
@@ -1,0 +1,21 @@
+jq-linux-amd64: OK
+v24.19.0
+11.10.0
+jq-1.8.1
+git version 2.39.5
+PR_HEAD=075bcf0494864fb1d8fd4475d211b5b9f741c173
+BASELINE_HEAD=765644804756d5f6b1dc1e940d62c50711e398d8
+ℹ tests 3
+ℹ pass 0
+ℹ fail 3
+ℹ skipped 0
+BASELINE_TEST_RC=1
+PROOF_RC=0
+ℹ tests 3312
+ℹ pass 3301
+ℹ fail 3
+ℹ skipped 8
+PR_FULL_SUITE_RC=1
+CONTAINER_DELTA_FAILURES=0
+CONTAINER_PROOF_RC=0
+{"provider":"local-container","leaseId":"cbx_585f04f5feea","slug":"violet-prawn-a71c","syncMs":10154,"syncPhases":[{"name":"ssh","ms":60},{"name":"git_seed","ms":10094}],"syncSkipped":false,"commandMs":104251,"commandPhases":[{"name":"user-command","ms":1146},{"name":"baseline","ms":4916},{"name":"proof","ms":12515},{"name":"full-suite","ms":85673}],"totalMs":114406,"exitCode":0,"runStatus":"succeeded","machineType":"node_24-bookworm","repoPath":"/Users/steipete/Projects/clawsweeper-unify-github-app-auth","workdir":"/work/crabbox/cbx_585f04f5feea/fresh-pr-openclaw-clawsweeper-1115","stopCommand":"crabbox stop --provider local-container --target linux --id violet-prawn-a71c","idleTimeout":"30m0s","leaseStopped":true}

--- a/docs/proof/unify-github-app-auth/artifacts/dependencies-install.log
+++ b/docs/proof/unify-github-app-auth/artifacts/dependencies-install.log
@@ -1,0 +1,2 @@
+Already up to date
+Done in 193ms using pnpm v11.10.0

--- a/docs/proof/unify-github-app-auth/artifacts/github-requests.redacted.json
+++ b/docs/proof/unify-github-app-auth/artifacts/github-requests.redacted.json
@@ -1,0 +1,66 @@
+[
+  {
+    "at": "2026-08-11T01:12:25.105Z",
+    "method": "GET",
+    "path": "/repos/openclaw/clawsweeper/installation",
+    "request_body_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "authorization": "Bearer <redacted-app-jwt>",
+    "response_status": 200
+  },
+  {
+    "at": "2026-08-11T01:12:25.114Z",
+    "method": "POST",
+    "path": "/app/installations/456/access_tokens",
+    "request_body_sha256": "0b74cbb0206b276baf033ece187e7608c7cfd90fe4eccbc12f0fa0e7cd441de8",
+    "authorization": "Bearer <redacted-app-jwt>",
+    "response_status": 201
+  },
+  {
+    "at": "2026-08-11T01:12:25.115Z",
+    "method": "POST",
+    "path": "/app/installations/999/access_tokens",
+    "request_body_sha256": "72426a4661188f9473dbc964adacfe7fe19190d733344d173cb10a2963ba26da",
+    "authorization": "Bearer <redacted-app-jwt>",
+    "response_status": 201
+  },
+  {
+    "at": "2026-08-11T01:12:25.115Z",
+    "method": "GET",
+    "path": "/repos/openclaw/gogcli",
+    "request_body_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "authorization": "Bearer <redacted-installation-token>",
+    "response_status": 200
+  },
+  {
+    "at": "2026-08-11T01:12:25.116Z",
+    "method": "POST",
+    "path": "/app/installations/123/access_tokens",
+    "request_body_sha256": "acd29e10171bdf3e4038bbb242a50af40f9a9536c90e82cb550897a8779769fa",
+    "authorization": "Bearer <redacted-app-jwt>",
+    "response_status": 201
+  },
+  {
+    "at": "2026-08-11T01:12:25.125Z",
+    "method": "GET",
+    "path": "/repos/openclaw/gogcli/issues/597/comments",
+    "request_body_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "authorization": "Bearer <redacted-installation-token>",
+    "response_status": 200
+  },
+  {
+    "at": "2026-08-11T01:12:25.126Z",
+    "method": "POST",
+    "path": "/repos/openclaw/gogcli/issues/comments/456/reactions",
+    "request_body_sha256": "4c489d9e198b786d3bad13c48fccf07ccb226ac6bfa4085b4d4132642d3c8263",
+    "authorization": "Bearer <redacted-installation-token>",
+    "response_status": 200
+  },
+  {
+    "at": "2026-08-11T01:12:25.126Z",
+    "method": "POST",
+    "path": "/repos/openclaw/clawsweeper/dispatches",
+    "request_body_sha256": "a8db560d4d816b8385c6b65b06d0c6a2203bcb35f67b59139b6ac83141e2e236",
+    "authorization": "Bearer <redacted-installation-token>",
+    "response_status": 204
+  }
+]

--- a/docs/proof/unify-github-app-auth/artifacts/proof-summary.json
+++ b/docs/proof/unify-github-app-auth/artifacts/proof-summary.json
@@ -1,0 +1,31 @@
+{
+  "schema": "clawsweeper-unified-github-app-auth-proof/v1",
+  "generated_at": "2026-08-11T01:12:25.139Z",
+  "source_sha": "007544716b06d9b9189ac846c903bac2df7e155c",
+  "source_tree_sha": "908b5ec6daa8370f7605bacf6fa7e0922200ce511232027fbe49cf3af69b0598",
+  "runtime": "wrangler dev --local with SQLite-backed ExactReviewQueue",
+  "transport": "real loopback HTTP sockets (Worker 51507, GitHub 51508)",
+  "routes": {
+    "worker": "/github/webhook (signed issue_comment)",
+    "queue": "/internal/exact-review/branch-authority (signed request forwarded to Durable Object)"
+  },
+  "observations": {
+    "worker_status": 202,
+    "worker_status_comment_id": 777,
+    "queue_status": 202,
+    "queue_item_resolved": true,
+    "jwt_byte_identical": true,
+    "canonical_app_auth_headers_byte_identical": true,
+    "app_jwt_sha256": "009141f7b93e6b042d98e5884386d880f473db0ef90db8ec281cdf07a131d62c",
+    "canonical_app_auth_headers_sha256": "097756715c5629ced5dc6ec0e70aa455f317d5dc0e7dc8e811671f833074ac90",
+    "queue_token_request_body_sha256": "0b74cbb0206b276baf033ece187e7608c7cfd90fe4eccbc12f0fa0e7cd441de8",
+    "unexpected_loopback_requests": 0
+  },
+  "redactions": [
+    "App private key",
+    "App JWT",
+    "installation tokens"
+  ],
+  "production_mutations": 0,
+  "run_status": "succeeded"
+}

--- a/docs/proof/unify-github-app-auth/artifacts/wrangler-local.log
+++ b/docs/proof/unify-github-app-auth/artifacts/wrangler-local.log
@@ -1,0 +1,73 @@
+
+ ⛅️ wrangler 4.107.0 (update available 4.120.1)
+───────────────────────────────────────────────
+Your Worker has access to the following bindings:
+Binding                                                                                           Resource                  Mode
+env.STATUS_STORE (StatusStore)                                                                    Durable Object            local
+env.EXACT_REVIEW_QUEUE (ExactReviewQueue)                                                         Durable Object            local
+env.STATE_SNAPSHOTS (clawsweeper-state-snapshots)                                                 R2 Bucket                 local
+env.CLAWSWEEPER_REPO ("openclaw/clawsweeper")                                                     Environment Variable      local
+env.CLAWSWEEPER_APP_CLIENT_ID ("(hidden)")                                                        Environment Variable      local
+env.CLAWSWEEPER_CRABFLEET_URL ("https://crabfleet.openclaw.ai")                                   Environment Variable      local
+env.TARGET_REPOS ("(hidden)")                                                                     Environment Variable      local
+env.APPLY_TARGET_REPOS ("openclaw/openclaw")                                                      Environment Variable      local
+env.APPLY_OPTIONAL_TARGET_REPOS ("openclaw/clawhub")                                              Environment Variable      local
+env.CLAWSWEEPER_ENABLE_CLAWHUB ("1")                                                              Environment Variable      local
+env.WORKER_BUDGET ("128")                                                                         Environment Variable      local
+env.EXACT_REVIEW_ACTIONS_BUDGET ("194")                                                           Environment Variable      local
+env.WORKER_DETAIL_RUN_LIMIT ("128")                                                               Environment Variable      local
+env.WORKER_JOB_FETCH_CONCURRENCY ("12")                                                           Environment Variable      local
+env.WORKER_JOB_CACHE_TTL_SECONDS ("60")                                                           Environment Variable      local
+env.WORKER_HEALTH_CACHE_TTL_SECONDS ("120")                                                       Environment Variable      local
+env.WORKER_HEALTH_FETCH_CONCURRENCY ("10")                                                        Environment Variable      local
+env.AUTOMERGE_CACHE_TTL_SECONDS ("300")                                                           Environment Variable      local
+env.RECENT_CLOSED_CACHE_TTL_SECONDS ("300")                                                       Environment Variable      local
+env.CACHE_TTL_SECONDS ("20")                                                                      Environment Variable      local
+env.INCLUDE_CI_STATUS ("1")                                                                       Environment Variable      local
+env.EXACT_REVIEW_QUEUE_MAX_CONCURRENT ("128")                                                     Environment Variable      local
+env.EXACT_REVIEW_TARGET_MAX_CONCURRENT ("120")                                                    Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_MIN_CONCURRENT ("8")                                                 Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BASE_CONCURRENT ("32")                                               Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_MAX_CONCURRENT ("40")                                                Environment Variable      local
+env.EXACT_REVIEW_DISPATCH_LEASE_MS ("360000")                                                     Environment Variable      local
+env.EXACT_REVIEW_EXECUTION_LEASE_MS ("7800000")                                                   Environment Variable      local
+env.EXACT_REVIEW_HEARTBEAT_GRACE_MS ("1200000")                                                   Environment Variable      local
+env.EXACT_REVIEW_WORKFLOW_PAUSED_RETRY_MS ("60000")                                               Environment Variable      local
+env.EXACT_REVIEW_DISPATCH_DEBOUNCE_MS ("(hidden)")                                                Environment Variable      local
+env.EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS ("180000")                                              Environment Variable      local
+env.EXACT_REVIEW_PENDING_SOFT_LIMIT ("600")                                                       Environment Variable      local
+env.EXACT_REVIEW_TARGET_RATE_PER_HOUR ("300")                                                     Environment Variable      local
+env.EXACT_REVIEW_TARGET_BURST ("30")                                                              Environment Variable      local
+env.STATE_APPEND_DRAIN_LEASE_MS ("5400000")                                                       Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED ("1")                                               Environment Variable      local
+env.EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED ("1")                                                 Environment Variable      local
+env.EXACT_REVIEW_STATE_REPO ("openclaw/clawsweeper-state")                                        Environment Variable      local
+env.EXACT_REVIEW_STATE_REF ("state")                                                              Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_SIZE ("8")                                                     Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_MAX_CONCURRENT ("8")                                           Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED ("1")                                             Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS ("2")                                           Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS ("900000")                                     Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS ("60000")                                              Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_COOLDOWN_MS ("5000")                                  Environment Variable      local
+env.EXACT_REVIEW_PUBLICATION_BATCH_DISPATCH_RESERVATION_MS ("600000")                             Environment Variable      local
+env.REVIEW_OBSERVABILITY_REQUIRED ("0")                                                           Environment Variable      local
+env.REVIEW_RECOVERY_ENABLED ("0")                                                                 Environment Variable      local
+env.CLAWSWEEPER_WEBHOOK_SECRET ("(hidden)")                                                       Environment Variable      local
+env.CLAWSWEEPER_APP_PRIVATE_KEY ("(hidden)")                                                      Environment Variable      local
+env.GITHUB_API_URL ("(hidden)")                                                                   Environment Variable      local
+env.CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS ("(hidden)")                                            Environment Variable      local
+
+[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mScheduled Workers are not automatically triggered during local development.[0m
+
+  To manually trigger a scheduled event, run:
+    curl "http://127.0.0.1:51507/cdn-cgi/handler/scheduled"
+  For more details, see [4mhttps://developers.cloudflare.com/workers/configuration/cron-triggers/#test-cron-triggers-locally[0m
+
+
+⎔ Starting local server...
+[wrangler:info] Ready on http://127.0.0.1:51507
+[wrangler:info] GET /api/health 200 OK (216ms)
+[wrangler:info] POST /internal/exact-review/branch-authority 202 Accepted (59ms)
+[wrangler:info] POST /github/webhook 202 Accepted (112ms)
+[wrangler:info] GET /api/exact-review-queue 200 OK (4ms)

--- a/docs/proof/unify-github-app-auth/run-proof.mjs
+++ b/docs/proof/unify-github-app-auth/run-proof.mjs
@@ -1,0 +1,460 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const outputDir = path.resolve(
+  process.env.UNIFY_GITHUB_APP_AUTH_PROOF_OUTPUT || "docs/proof/unify-github-app-auth/artifacts",
+);
+const webhookSecret = "unify-github-app-auth-proof";
+const appIssuer = "Iv23unifiedproof";
+const persistence = await mkdtemp(path.join(os.tmpdir(), "clawsweeper-unified-app-auth-"));
+const workerPort = await availablePort();
+const githubPort = await availablePort();
+const workerOrigin = `http://127.0.0.1:${workerPort}`;
+const githubOrigin = `http://127.0.0.1:${githubPort}`;
+const { privateKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+const sourceSha = await git("rev-parse", "HEAD");
+const sourceTreeSha = await sourceTreeHash([
+  "dashboard/github-api.ts",
+  "dashboard/exact-review-queue.ts",
+  "dashboard/worker.ts",
+  "test/github-api.test.ts",
+  "docs/proof/unify-github-app-auth/README.md",
+  "docs/proof/unify-github-app-auth/run-proof.mjs",
+  "docs/proof/unify-github-app-auth/run-proof.sh",
+]);
+
+await mkdir(outputDir, { recursive: true });
+const github = await startGithubServer();
+let worker;
+
+try {
+  worker = await startWorker();
+  await waitForWorker();
+  await alignNearSecondStart();
+
+  const workerPayload = {
+    action: "created",
+    repository: {
+      full_name: "openclaw/gogcli",
+      default_branch: "trunk",
+      private: false,
+      archived: false,
+      fork: false,
+      has_issues: true,
+    },
+    issue: { number: 597, user: { login: "steipete" } },
+    installation: { id: 123 },
+    comment: {
+      id: 456,
+      body: "@clawsweeper review",
+      updated_at: "2026-08-10T12:00:00Z",
+      author_association: "OWNER",
+      user: { login: "steipete" },
+    },
+  };
+  const queuePayload = {
+    delivery_id: "unify-app-auth-queue-598",
+    installation_id: 456,
+    decision: {
+      targetRepo: "openclaw/gogcli",
+      itemNumber: 598,
+      itemKind: "issue",
+      sourceEvent: "issues",
+      sourceAction: "legacy_dispatch",
+      supersedesInProgress: false,
+    },
+  };
+
+  const [workerResponse, queueResponse] = await Promise.all([
+    signedRequest("/github/webhook", workerPayload, {
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "unify-app-auth-worker-597",
+      "x-hub-signature-256": githubSignature(JSON.stringify(workerPayload)),
+    }),
+    signedRequest("/internal/exact-review/branch-authority", queuePayload, {
+      "x-clawsweeper-exact-review-signature": githubSignature(JSON.stringify(queuePayload)),
+    }),
+  ]);
+
+  assert.equal(workerResponse.status, 202);
+  assert.deepEqual(await workerResponse.json(), { ok: true, status_comment_id: 777 });
+  assert.equal(queueResponse.status, 202);
+  assert.deepEqual(await queueResponse.json(), { ok: true, branch_authority_pending: true });
+
+  await waitFor(() => github.count("GET", "/repos/openclaw/gogcli") === 1);
+  const queueSnapshot = await waitForQueue((snapshot) =>
+    JSON.stringify(snapshot).includes("openclaw/gogcli#598"),
+  );
+
+  const workerAuthRequest = github.request("GET", "/repos/openclaw/clawsweeper/installation");
+  const queueAuthRequest = github.request("POST", "/app/installations/456/access_tokens");
+  assert(workerAuthRequest, "worker App-auth request was not observed");
+  assert(queueAuthRequest, "queue App-auth request was not observed");
+  assert.equal(workerAuthRequest.authorization, queueAuthRequest.authorization);
+  assert.equal(workerAuthRequest.canonicalHeaders, queueAuthRequest.canonicalHeaders);
+  assert.equal(workerAuthRequest.authorization.split(".").length, 3);
+  assert.deepEqual(decodeJwt(workerAuthRequest.authorization), {
+    header: { alg: "RS256", typ: "JWT" },
+    payload: {
+      iat: decodeJwt(workerAuthRequest.authorization).payload.iat,
+      exp: decodeJwt(workerAuthRequest.authorization).payload.iat + 600,
+      iss: appIssuer,
+    },
+  });
+  assert.deepEqual(JSON.parse(queueAuthRequest.body), {
+    repositories: ["gogcli"],
+    permissions: { issues: "read", pull_requests: "read" },
+  });
+  assert.equal(github.unexpectedRequests(), 0);
+
+  const jwtSha256 = sha256(workerAuthRequest.authorization);
+  const canonicalHeaderSha256 = sha256(workerAuthRequest.canonicalHeaders);
+  const redactedTrace = github.trace.map((entry) => ({
+    at: entry.at,
+    method: entry.method,
+    path: entry.path,
+    request_body_sha256: sha256(entry.body),
+    authorization: entry.authorization
+      ? entry.authorization.startsWith("proof-installation-")
+        ? "Bearer <redacted-installation-token>"
+        : "Bearer <redacted-app-jwt>"
+      : null,
+    response_status: entry.responseStatus,
+  }));
+  await writeJson("github-requests.redacted.json", redactedTrace);
+  const summary = {
+    schema: "clawsweeper-unified-github-app-auth-proof/v1",
+    generated_at: new Date().toISOString(),
+    source_sha: sourceSha,
+    source_tree_sha: sourceTreeSha,
+    runtime: "wrangler dev --local with SQLite-backed ExactReviewQueue",
+    transport: `real loopback HTTP sockets (Worker ${workerPort}, GitHub ${githubPort})`,
+    routes: {
+      worker: "/github/webhook (signed issue_comment)",
+      queue: "/internal/exact-review/branch-authority (signed request forwarded to Durable Object)",
+    },
+    observations: {
+      worker_status: 202,
+      worker_status_comment_id: 777,
+      queue_status: 202,
+      queue_item_resolved: JSON.stringify(queueSnapshot).includes("openclaw/gogcli#598"),
+      jwt_byte_identical: true,
+      canonical_app_auth_headers_byte_identical: true,
+      app_jwt_sha256: jwtSha256,
+      canonical_app_auth_headers_sha256: canonicalHeaderSha256,
+      queue_token_request_body_sha256: sha256(queueAuthRequest.body),
+      unexpected_loopback_requests: 0,
+    },
+    redactions: ["App private key", "App JWT", "installation tokens"],
+    production_mutations: 0,
+    run_status: "succeeded",
+  };
+  await writeJson("proof-summary.json", summary);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+} catch (error) {
+  await writeJson("proof-failure.json", {
+    generated_at: new Date().toISOString(),
+    source_sha: sourceSha,
+    source_tree_sha: sourceTreeSha,
+    error: error instanceof Error ? error.stack : String(error),
+    github_requests: github.trace.map((entry) => ({
+      method: entry.method,
+      path: entry.path,
+      response_status: entry.responseStatus,
+    })),
+    run_status: "failed",
+  });
+  throw error;
+} finally {
+  await stopProcessTree(worker);
+  await github.close();
+  await rm(persistence, { recursive: true, force: true });
+}
+
+async function startGithubServer() {
+  const trace = [];
+  const heldAuthResponses = [];
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url || "/", githubOrigin);
+    const method = request.method || "GET";
+    const body = await readBody(request);
+    const authorizationHeader = String(request.headers.authorization || "");
+    const authorization = authorizationHeader.startsWith("Bearer ")
+      ? authorizationHeader.slice("Bearer ".length)
+      : "";
+    const canonicalHeaders = JSON.stringify({
+      accept: request.headers.accept || "",
+      authorization: authorizationHeader,
+      contentType: request.headers["content-type"] || "",
+      userAgent: request.headers["user-agent"] || "",
+    });
+    const entry = {
+      at: new Date().toISOString(),
+      method,
+      path: url.pathname,
+      body,
+      authorization,
+      canonicalHeaders,
+      responseStatus: 0,
+    };
+    trace.push(entry);
+
+    if (
+      (method === "GET" && url.pathname === "/repos/openclaw/clawsweeper/installation") ||
+      (method === "POST" && url.pathname === "/app/installations/456/access_tokens")
+    ) {
+      heldAuthResponses.push({ request, response, entry, url });
+      if (heldAuthResponses.length === 2) {
+        for (const held of heldAuthResponses.splice(0)) {
+          if (held.url.pathname.endsWith("/installation")) {
+            sendJson(held.response, held.entry, 200, { id: 999 });
+          } else {
+            sendJson(held.response, held.entry, 201, { token: "proof-installation-queue" });
+          }
+        }
+      }
+      return;
+    }
+    if (method === "POST" && url.pathname === "/app/installations/999/access_tokens") {
+      return sendJson(response, entry, 201, { token: "proof-installation-dispatch" });
+    }
+    if (method === "POST" && url.pathname === "/app/installations/123/access_tokens") {
+      return sendJson(response, entry, 201, { token: "proof-installation-target" });
+    }
+    if (method === "GET" && url.pathname === "/repos/openclaw/gogcli/issues/597/comments") {
+      return sendJson(response, entry, 200, [
+        {
+          id: 777,
+          body: "<!-- clawsweeper-command-ack:456 -->\nClawSweeper picked this up.",
+          user: { login: "openclaw-clawsweeper[bot]" },
+        },
+      ]);
+    }
+    if (
+      method === "POST" &&
+      url.pathname === "/repos/openclaw/gogcli/issues/comments/456/reactions"
+    ) {
+      return sendJson(response, entry, 200, {});
+    }
+    if (method === "POST" && url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      entry.responseStatus = 204;
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    if (method === "GET" && url.pathname === "/repos/openclaw/gogcli") {
+      return sendJson(response, entry, 200, { default_branch: "trunk" });
+    }
+    return sendJson(response, entry, 501, { message: "unexpected proof request" });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(githubPort, "127.0.0.1", resolve);
+  });
+  return {
+    trace,
+    count(method, requestPath) {
+      return trace.filter((entry) => entry.method === method && entry.path === requestPath).length;
+    },
+    request(method, requestPath) {
+      return trace.find((entry) => entry.method === method && entry.path === requestPath);
+    },
+    unexpectedRequests() {
+      return trace.filter((entry) => entry.responseStatus === 501).length;
+    },
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function startWorker() {
+  const log = createWriteStream(path.join(outputDir, "wrangler-local.log"), { flags: "w" });
+  const args = [
+    "--yes",
+    "wrangler@4.107.0",
+    "dev",
+    "--config",
+    "dashboard/wrangler.toml",
+    "--local",
+    "--persist-to",
+    persistence,
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(workerPort),
+    "--var",
+    `CLAWSWEEPER_WEBHOOK_SECRET:${webhookSecret}`,
+    "--var",
+    `CLAWSWEEPER_APP_CLIENT_ID:${appIssuer}`,
+    "--var",
+    `CLAWSWEEPER_APP_PRIVATE_KEY:${privateKey.replace(/\n/g, "\\n")}`,
+    "--var",
+    `GITHUB_API_URL:${githubOrigin}`,
+    "--var",
+    "TARGET_REPOS:openclaw/gogcli",
+    "--var",
+    "EXACT_REVIEW_DISPATCH_DEBOUNCE_MS:600000",
+    "--var",
+    "CLAWSWEEPER_FAST_ACK_SETTLE_DELAYS_MS:600000",
+  ];
+  const child = spawn("npx", args, {
+    cwd: process.cwd(),
+    env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.pipe(log);
+  child.stderr.pipe(log);
+  child.once("exit", () => log.end());
+  return child;
+}
+
+async function waitForWorker() {
+  await waitFor(async () => {
+    try {
+      return (await fetch(`${workerOrigin}/api/health`)).ok;
+    } catch {
+      return false;
+    }
+  }, 30_000);
+}
+
+async function signedRequest(requestPath, payload, extraHeaders) {
+  const body = JSON.stringify(payload);
+  return fetch(`${workerOrigin}${requestPath}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...extraHeaders },
+    body,
+  });
+}
+
+async function waitForQueue(predicate) {
+  let last;
+  await waitFor(async () => {
+    const response = await fetch(`${workerOrigin}/api/exact-review-queue`);
+    if (!response.ok) return false;
+    last = await response.json();
+    return predicate(last);
+  }, 30_000);
+  return last;
+}
+
+function githubSignature(body) {
+  return `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+}
+
+function decodeJwt(jwt) {
+  const [header, payload] = jwt.split(".");
+  return {
+    header: JSON.parse(Buffer.from(header, "base64url").toString("utf8")),
+    payload: JSON.parse(Buffer.from(payload, "base64url").toString("utf8")),
+  };
+}
+
+function sendJson(response, entry, status, payload) {
+  entry.responseStatus = status;
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(payload));
+}
+
+async function readBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function availablePort() {
+  const server = http.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function alignNearSecondStart() {
+  const remainder = Date.now() % 1_000;
+  if (remainder > 150) await sleep(1_010 - remainder);
+}
+
+async function waitFor(predicate, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const result = await predicate();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(100);
+  }
+  if (lastError) throw lastError;
+  throw new Error(`proof condition timed out after ${timeoutMs}ms`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function stopProcessTree(child) {
+  if (!child || child.exitCode !== null) return;
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-child.pid, "SIGTERM");
+    } catch {}
+  } else {
+    child.kill("SIGTERM");
+  }
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    sleep(5_000).then(() => {
+      if (child.exitCode === null) child.kill("SIGKILL");
+    }),
+  ]);
+}
+
+async function sourceTreeHash(files) {
+  const hash = createHash("sha256");
+  for (const file of files.sort()) {
+    hash.update(`${file}\0`);
+    hash.update(await readFile(file));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+async function git(...args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("exit", (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(stderr.trim() || `git ${args.join(" ")} failed`));
+    });
+  });
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function writeJson(name, value) {
+  await writeFile(path.join(outputDir, name), `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/docs/proof/unify-github-app-auth/run-proof.sh
+++ b/docs/proof/unify-github-app-auth/run-proof.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$proof_dir" rev-parse --show-toplevel)"
+artifact_dir="${UNIFY_GITHUB_APP_AUTH_PROOF_OUTPUT:-$proof_dir/artifacts}"
+
+finish() {
+  local proof_rc=$?
+  echo "PROOF_RC=$proof_rc"
+}
+trap finish EXIT
+
+cd "$repo_root"
+mkdir -p "$artifact_dir"
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/bin}"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME"
+fi
+
+echo "node=$(node --version)"
+echo "pnpm=$(pnpm --version)"
+echo "head=$(git rev-parse HEAD)"
+
+pnpm install --frozen-lockfile >"$artifact_dir/dependencies-install.log" 2>&1
+pnpm run build:dashboard >"$artifact_dir/build-dashboard.log" 2>&1
+UNIFY_GITHUB_APP_AUTH_PROOF_OUTPUT="$artifact_dir" \
+  node "$proof_dir/run-proof.mjs"

--- a/test/github-api.test.ts
+++ b/test/github-api.test.ts
@@ -71,18 +71,42 @@ test("canonical GitHub App signer converts PKCS1 private keys to PKCS8", async (
 
 test("worker GitHub App call sites preserve plain error messages", async () => {
   const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
     publicKeyEncoding: { type: "spki", format: "pem" },
   });
+  const fetchFailure = new TypeError("fetch failed");
+  const abortFailure = new DOMException("request aborted", "AbortError");
   const failures = [
     {
-      fetch: async () => {
-        throw new DOMException("request aborted", "AbortError");
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        assert.equal(init?.signal?.aborted, true);
+        throw new DOMException("request timed out", "AbortError");
       },
+      setTimeout: ((callback: TimerHandler) => {
+        if (typeof callback === "function") callback();
+        return 0;
+      }) as typeof globalThis.setTimeout,
       message: "GitHub App installation timed out",
       constructor: Error,
+    },
+    {
+      fetch: async () => {
+        throw fetchFailure;
+      },
+      message: "fetch failed",
+      constructor: TypeError,
+      original: fetchFailure,
+    },
+    {
+      fetch: async () => {
+        throw abortFailure;
+      },
+      message: "request aborted",
+      constructor: DOMException,
+      original: abortFailure,
     },
     {
       fetch: async () =>
@@ -100,6 +124,7 @@ test("worker GitHub App call sites preserve plain error messages", async () => {
   try {
     for (const failure of failures) {
       globalThis.fetch = failure.fetch;
+      globalThis.setTimeout = failure.setTimeout || originalSetTimeout;
       await assert.rejects(
         worker.fetch(workerGithubWebhookRequest(), {
           CLAWSWEEPER_APP_CLIENT_ID: "Iv23worker-errors",
@@ -109,12 +134,14 @@ test("worker GitHub App call sites preserve plain error messages", async () => {
         (error: Error) => {
           assert.equal(error.constructor, failure.constructor);
           assert.equal(error.message, failure.message);
+          if (failure.original) assert.equal(error, failure.original);
           return true;
         },
       );
     }
   } finally {
     globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
   }
 });
 

--- a/test/github-api.test.ts
+++ b/test/github-api.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import {
+  createHmac,
+  createPrivateKey,
+  generateKeyPairSync,
+  verify as verifySignature,
+} from "node:crypto";
+import test from "node:test";
+
+import { pemToPkcs8, signGithubAppJwt } from "../dashboard/github-api.ts";
+import worker from "../dashboard/worker.ts";
+
+test("canonical GitHub App signer emits a verifiable RS256 JWT", async () => {
+  const originalNow = Date.now;
+  const now = 1_800_000_000_000;
+  Date.now = () => now;
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+
+  try {
+    const jwt = await signGithubAppJwt("Iv23canonical", privateKey);
+    const [encodedHeader, encodedPayload, encodedSignature] = jwt.split(".");
+    assert.deepEqual(decodeJwtPart(encodedHeader), { alg: "RS256", typ: "JWT" });
+    assert.deepEqual(decodeJwtPart(encodedPayload), {
+      iat: now / 1_000 - 60,
+      exp: now / 1_000 + 540,
+      iss: "Iv23canonical",
+    });
+    assert.equal(
+      verifySignature(
+        "RSA-SHA256",
+        `${encodedHeader}.${encodedPayload}`,
+        publicKey,
+        Buffer.from(encodedSignature, "base64url"),
+      ),
+      true,
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("canonical GitHub App signer converts PKCS1 private keys to PKCS8", async () => {
+  const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pkcs1Pem = keyPair.privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  const expectedPkcs8 = keyPair.privateKey.export({ type: "pkcs8", format: "der" });
+
+  assert.deepEqual(Buffer.from(pemToPkcs8(pkcs1Pem)), expectedPkcs8);
+  const jwt = await signGithubAppJwt("Iv23pkcs1", pkcs1Pem);
+  const [header, payload, signature] = jwt.split(".");
+  assert.equal(
+    verifySignature(
+      "RSA-SHA256",
+      `${header}.${payload}`,
+      keyPair.publicKey,
+      Buffer.from(signature, "base64url"),
+    ),
+    true,
+  );
+
+  const imported = createPrivateKey({
+    key: Buffer.from(pemToPkcs8(pkcs1Pem)),
+    format: "der",
+    type: "pkcs8",
+  });
+  assert.equal(imported.asymmetricKeyType, "rsa");
+});
+
+test("worker GitHub App call sites preserve plain error messages", async () => {
+  const originalFetch = globalThis.fetch;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const failures = [
+    {
+      fetch: async () => {
+        throw new DOMException("request aborted", "AbortError");
+      },
+      message: "GitHub App installation timed out",
+      constructor: Error,
+    },
+    {
+      fetch: async () =>
+        new Response(JSON.stringify({ message: "upstream unavailable" }), { status: 503 }),
+      message: "GitHub App installation 503",
+      constructor: Error,
+    },
+    {
+      fetch: async () => new Response("not-json", { status: 200 }),
+      message: `Unexpected token 'o', "not-json" is not valid JSON`,
+      constructor: SyntaxError,
+    },
+  ];
+
+  try {
+    for (const failure of failures) {
+      globalThis.fetch = failure.fetch;
+      await assert.rejects(
+        worker.fetch(workerGithubWebhookRequest(), {
+          CLAWSWEEPER_APP_CLIENT_ID: "Iv23worker-errors",
+          CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+          CLAWSWEEPER_WEBHOOK_SECRET: "worker-error-test",
+        }),
+        (error: Error) => {
+          assert.equal(error.constructor, failure.constructor);
+          assert.equal(error.message, failure.message);
+          return true;
+        },
+      );
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+function decodeJwtPart(value: string) {
+  return JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+}
+
+function workerGithubWebhookRequest() {
+  const payload = {
+    action: "created",
+    repository: {
+      full_name: "openclaw/gogcli",
+      default_branch: "trunk",
+      private: false,
+      archived: false,
+      fork: false,
+      has_issues: true,
+    },
+    issue: { number: 597, user: { login: "steipete" } },
+    installation: { id: 123 },
+    comment: {
+      id: 456,
+      body: "@clawsweeper review",
+      author_association: "OWNER",
+      user: { login: "steipete" },
+    },
+  };
+  const body = JSON.stringify(payload);
+  const signature = createHmac("sha256", "worker-error-test").update(body).digest("hex");
+  return new Request("https://clawsweeper.openclaw.ai/github/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "worker-error-shape",
+      "x-hub-signature-256": `sha256=${signature}`,
+    },
+    body,
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper had two independent copies of its GitHub App authentication stack in the dashboard
Worker and exact-review queue. Eleven functions were byte-identical, while `githubAppJson` had
already drifted: the queue classified timeout, network, rate-limit, validation, and response-body
failures with `GitHubRequestError`; the Worker exposed plain errors. Keeping two cryptographic and
request implementations made future auth drift likely while making a mechanical consolidation
unsafe without an explicit error-boundary decision.

## Why This Change Was Made

`dashboard/github-api.ts` is now the single canonical owner of all 12 functions and uses the
queue's richer classified implementation. The queue imports that implementation directly. The
Worker imports thin wrapper exports that preserve its former observable error surface: classified
timeout and HTTP failures become plain `Error` values with the same message, response-body errors
pass through, and non-timeout fetch rejections rethrow the original rejection object unchanged.

The shared module privately associates a classified request failure with its original transport
rejection. That preserves the queue's `GitHubRequestError` contract without exposing new fields or
changing its constructor, while allowing only the Worker adapter to restore the merge-base
behavior. A controller-owned timeout remains distinct from an independent `AbortError` rejection.

## User Impact

No intended observable behavior change. GitHub App signing, key normalization, installation
lookup, token requests, and queue classification now have one implementation. Every Worker
failure shape pinned from the merge-base implementation remains unchanged.

## Drift Evidence

Before this change, the two monoliths contained duplicate implementations of credentials parsing,
installation lookup, JSON requests, JWT signing, private-key normalization, PKCS1-to-PKCS8
conversion, PEM decoding, DER wrapping, DER element/length encoding, byte concatenation, and
base64url encoding. The only implementation drift was `githubAppJson`: the queue had the richer
classified error behavior and the Worker used plain errors. This PR resolves that drift by the
coordinator decision above rather than choosing one surface implicitly.

Production code changes remain a net reduction. The complete PR is larger because it commits the
required reusable real-runtime proof and redacted evidence.

## Accepted Finding Disposition

The P2 transport-compatibility finding is resolved at current head
`cdf2a6ead92276bd467bdda1e42d1f51880b6caf`. At the merge base, the Worker awaited `fetch(...).finally(...)`
without a catch, so a fetch rejection propagated unchanged. The adapter now rethrows the original
non-controller transport rejection object. The focused test pins both `TypeError("fetch failed")`
and `DOMException("request aborted", "AbortError")` by object identity, constructor, and message,
while separately pinning the controller-owned timeout path.

## Real Behavior Proof

- Claim: the signed Worker and exact-review queue routes use the same canonical App-auth bytes
  while preserving their entry-point behavior.
- Exercised surface: a real local Wrangler Worker, its SQLite-backed `ExactReviewQueue` Durable
  Object, both signed HTTP routes, the production App signer/request client, and a real loopback
  `GITHUB_API_URL` HTTP listener.
- Scenario: the proof concurrently sends a signed maintainer `issue_comment` webhook and a signed
  branch-authority request. The loopback server holds both initial App-auth requests until they are
  present, then compares the complete JWT and canonical auth-header bytes before allowing both
  workflows to finish.
- Local command/environment: `docs/proof/unify-github-app-auth/run-proof.sh`; Node 24.19.0,
  Wrangler 4.107.0, real loopback sockets.
- Observable result at current head: `PROOF_RC=0`; Worker status `202` with status comment `777`;
  queue status `202`; `openclaw/gogcli#598` resolved through the Durable Object; byte-identical JWT
  and canonical App-auth header bytes; zero unexpected loopback requests.
- Artifacts: committed proof README, redacted HTTP trace, Wrangler log, and machine-readable proof
  summary under `docs/proof/unify-github-app-auth/`; current-head reruns used isolated temporary
  output so historical committed artifacts remain immutable.
- Limits: the GitHub endpoint uses synthetic credentials and controlled responses. No production
  GitHub write, workflow dispatch, deployment, or live queue mutation occurs.

Docker-backed Crabbox proof used a clean
`--fresh-pr openclaw/clawsweeper#1115 --no-hydrate` checkout at
`cdf2a6ead92276bd467bdda1e42d1f51880b6caf`, Corepack with pnpm 11.10.0, and a
checksum-verified jq 1.8.1 (`jq-linux-amd64: OK`). The local-container runtime proof printed
`PROOF_RC=0` and `CONTAINER_PROOF_RC=0`. Provider `local-container`, image
`node:24-bookworm`, lease `cbx_b2244ab2ed15` (`jade-barnacle-ceda`); Crabbox exited 0 and reports
`leaseStopped=true`.

The same container baselined current `origin/main` at
`1ee584328f2f07e8dde61dc70124c26da6c28af2`: its targeted run produced exactly the three known
blob-hydration environmental failures. The PR full suite ran 3,312 tests—3,301 passed, 8 skipped,
and the same 3 failed—so `CONTAINER_DELTA_FAILURES=0`.

## Worker Error-Shape Evidence

`test/github-api.test.ts` drives the actual signed Worker route and pins the full representative
surface:

- controller-owned timeout: `GitHub App installation timed out` as plain `Error`
- fetch rejection: `fetch failed` as the original `TypeError` object
- independent abort rejection: `request aborted` as the original `DOMException` with name
  `AbortError`
- non-2xx: `GitHub App installation 503` as plain `Error`
- invalid body: `Unexpected token 'o', "not-json" is not valid JSON` as `SyntaxError`

The same focused file also verifies a canonical RS256 JWT and the PKCS1-to-PKCS8 conversion against
Node's cryptographic implementation.

## Validation

- `pnpm run format:check` — passed
- `pnpm run check:limits` — passed
- `pnpm run build:all` — passed
- `pnpm run test:no-build` — 3,312 tests; 3,303 passed; 9 skipped; 0 failed
- `pnpm run lint` — passed
- `pnpm run check:active-surface` — passed
- `pnpm run check:dashboard-queue-boundary` — passed
- focused signer/error test — 3 passed, 0 failed
- local committed runtime proof — `PROOF_RC=0`
- Docker-backed current-head Crabbox proof — `PROOF_RC=0`, `CONTAINER_PROOF_RC=0`, no failure delta
- pre-commit Codex autoreview — clean, no accepted/actionable findings
- committed branch Codex autoreview against `origin/main` — clean, no accepted/actionable findings

## OpenClaw Bay Impact

None. This is an internal authentication ownership consolidation and error-boundary compatibility
repair. It changes no lifecycle or review-publication contract, queue semantics, status/telemetry
shape, Bay data contract, control, or observer-only boundary.

## Documentation Lifecycle

The proof package is historical evidence tied to the recorded source SHA and re-runnable harness;
it is not an active operator runbook. No active documentation lifecycle changes.
