### PR TITLE
fix(review): hydrate PR blobs with older Git clients

### DIFF
--- a/docs/proof/blob-hydration-env/README.md
+++ b/docs/proof/blob-hydration-env/README.md
@@ -14,14 +14,28 @@ isolated genuine blobless clone showed why: `GIT_NO_LAZY_FETCH=1 git cat-file --
 exited 128 with zero output rather than emitting a `missing` row for the unavailable promised blob.
 
 Git's [2.45.0 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.45.0.adoc)
-place the correct client-side `--no-lazy-fetch` behavior in that release. The replacement probe,
-`git rev-list --objects --missing=print --no-walk=unsorted`, was exercised against the same
-Git 2.39.5 partial clone and reported the unavailable object as `?<oid>` without fetching it.
+place the correct client-side `--no-lazy-fetch` behavior in that release. The first replacement
+probe incorrectly retained `--no-walk=unsorted`. On Git 2.39.5, its path-limiting fallback spawned
+an implicit promisor fetch; the integration test counted that fetch without proving it was the
+production path's explicit bounded fetch. That masked the missing traversal and let the old proof
+appear green.
+
+The repaired probe starts from the exact tree objects instead:
+
+```text
+git rev-list --objects --missing=print <base>^{tree} <head>^{tree} -- <bounded-paths>
+```
+
+Tree recursion emits the selected blobs while commit-history traversal is impossible. A fixture
+with an earlier history-only blob and a separately fetched unrelated ref proved that neither was
+observed. The same real blobless-clone scenario passed on Git 2.39.5 and Git 2.55.0: all four
+expected blob IDs were observed, two were reported missing, no fetch ran under the probe, and the
+later explicit `--stdin` fetch ran exactly once.
 
 ## Chosen option
 
 This is the production-path fix from option 1 of the work order, not a test skip. Hydration now
-uses `rev-list` to classify the object IDs reached from the exact base/head commits and bounded
+uses `rev-list` to classify the object IDs reached from the exact base/head trees and bounded
 changed paths. `cat-file` receives only IDs already proven local. Existing GraphQL size resolution,
 the 4 MiB aggregate limit, explicit one-request fetch, unsafe-path rejection, and fail-closed
 behavior remain unchanged.
@@ -33,7 +47,27 @@ Hosted production does not currently depend on this compatibility path. Recent
 records Git 2.54.0. The fix matters for older self-hosted and container deployments and lets the
 Bookworm proof suite exercise real behavior instead of carrying three environmental failures.
 
-## Scenario and command
+## Tree-traversal repair proof
+
+The after-fix traversal trace used a genuine local filter-capable bare origin, a `blob:none` main
+clone, a depth-one PR-head fetch, and a depth-one unrelated-ref fetch. The selected base and head
+trees contained four distinct review blobs; two head-side blobs were absent locally before
+hydration. The probe reported every expected blob ID without fetching, excluded both the
+history-only and unrelated-ref blobs, and the production hydration function then completed its
+single explicit bounded fetch.
+
+The current-Git trace is retained in
+[`artifacts/current-git-tree-traversal.log`](artifacts/current-git-tree-traversal.log). The matching
+Git 2.39.5 trace is retained in
+[`artifacts/git-2.39.5-tree-traversal.log`](artifacts/git-2.39.5-tree-traversal.log). The latter ran
+inside `node:24-bookworm` through Crabbox provider `aws`, lease `cbx_7e3080158c5c`
+(`coral-lobster-9594`), run `run_0a87aaf605e6`; Crabbox reported exit 0 and `leaseStopped=true`.
+
+The strengthened integration test now separately asserts that the probe output includes every
+known blob ID, that production invokes the two `^{tree}` roots without `--no-walk`, that no nested
+promisor fetch occurs, and that the one counted fetch is the explicit `--stdin` fetch.
+
+## Original full-suite scenario and command
 
 Crabbox checked out pushed PR
 [`openclaw/clawsweeper#1118`](https://github.com/openclaw/clawsweeper/pull/1118) at code head
@@ -55,7 +89,7 @@ pnpm run format:check
 pnpm run check:active-surface
 ```
 
-## Observed result
+## Original observed result
 
 Every gate passed. The full suite reported 3,318 tests, 3,310 passes, 8 platform skips, and zero
 failures. All three named blob-hydration tests passed on Git 2.39.5 rather than being skipped. The
@@ -64,7 +98,9 @@ verbatim retained result is in
 runtime/tool checks are in [`artifacts/gates.txt`](artifacts/gates.txt) and
 [`artifacts/runtime.txt`](artifacts/runtime.txt).
 
-Crabbox reported provider `local-container`, lease `cbx_553522239697` (`quick-crab-969a`), command
+This original run predates the tree-traversal repair and is retained only as regression history; it
+does not establish the repaired behavior. Crabbox reported provider `local-container`, lease
+`cbx_553522239697` (`quick-crab-969a`), command
 time 375,055 ms, total time 401,893 ms, exit 0, and automatic lease cleanup. Full machine-readable
 details are in [`artifacts/crabbox-provenance.json`](artifacts/crabbox-provenance.json); the
 captured remote streams and generated proof receipt are retained alongside it.

--- a/docs/proof/blob-hydration-env/README.md
+++ b/docs/proof/blob-hydration-env/README.md
@@ -1,0 +1,82 @@
+# Blob-hydration old-Git compatibility proof
+
+## Claim
+
+Restricted PR review hydration detects missing promisor blobs without an implicit lazy fetch on
+Git 2.39.5, resolves their sizes through the existing bounded metadata callback, explicitly fetches
+only blobs within the per-review byte limit, and leaves the repository usable offline afterward.
+
+## Root-cause verification
+
+On unmodified `origin/main` (`ae04c61896effe1fb7795ef021c4feac99ddaea3`), the focused test file
+inside `node:24-bookworm` reported Git 2.39.5, 2 passes, and the three expected failures. An
+isolated genuine blobless clone showed why: `GIT_NO_LAZY_FETCH=1 git cat-file --batch-check`
+exited 128 with zero output rather than emitting a `missing` row for the unavailable promised blob.
+
+Git's [2.45.0 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.45.0.adoc)
+place the correct client-side `--no-lazy-fetch` behavior in that release. The replacement probe,
+`git rev-list --objects --missing=print --no-walk=unsorted`, was exercised against the same
+Git 2.39.5 partial clone and reported the unavailable object as `?<oid>` without fetching it.
+
+## Chosen option
+
+This is the production-path fix from option 1 of the work order, not a test skip. Hydration now
+uses `rev-list` to classify the object IDs reached from the exact base/head commits and bounded
+changed paths. `cat-file` receives only IDs already proven local. Existing GraphQL size resolution,
+the 4 MiB aggregate limit, explicit one-request fetch, unsafe-path rejection, and fail-closed
+behavior remain unchanged.
+
+Hosted production does not currently depend on this compatibility path. Recent
+[run 31466811047](https://github.com/openclaw/clawsweeper/actions/runs/31466811047) records Ubuntu
+24.04 runner image `20260720.247`; its
+[software manifest](https://github.com/actions/runner-images/blob/ubuntu24/20260720.247/images/ubuntu/Ubuntu2404-Readme.md)
+records Git 2.54.0. The fix matters for older self-hosted and container deployments and lets the
+Bookworm proof suite exercise real behavior instead of carrying three environmental failures.
+
+## Scenario and command
+
+Crabbox checked out pushed PR
+[`openclaw/clawsweeper#1118`](https://github.com/openclaw/clawsweeper/pull/1118) at code head
+`964d9d8d88b7e0a2394f7d555fa9b6d5cf0f923e` with `--fresh-pr` inside a Docker-backed
+`local-container` using `node:24-bookworm`. The unprivileged lease installed Corepack shims under
+`$HOME/.local/bin`; jq 1.8.1 was downloaded from its official release and verified against the
+published SHA-256 checksum before installation in the same directory.
+The retained `worktree_changes=1` is the uploaded `.crabbox/scripts/` proof harness; the remote PR
+checkout itself was clean before Crabbox installed that harness.
+
+The proof ran these gates in order:
+
+```text
+pnpm install --frozen-lockfile
+pnpm run build:all
+pnpm run test:no-build
+pnpm run lint
+pnpm run format:check
+pnpm run check:active-surface
+```
+
+## Observed result
+
+Every gate passed. The full suite reported 3,318 tests, 3,310 passes, 8 platform skips, and zero
+failures. All three named blob-hydration tests passed on Git 2.39.5 rather than being skipped. The
+verbatim retained result is in
+[`artifacts/full-suite-result.log`](artifacts/full-suite-result.log), and the gate markers and
+runtime/tool checks are in [`artifacts/gates.txt`](artifacts/gates.txt) and
+[`artifacts/runtime.txt`](artifacts/runtime.txt).
+
+Crabbox reported provider `local-container`, lease `cbx_553522239697` (`quick-crab-969a`), command
+time 375,055 ms, total time 401,893 ms, exit 0, and automatic lease cleanup. Full machine-readable
+details are in [`artifacts/crabbox-provenance.json`](artifacts/crabbox-provenance.json); the
+captured remote streams and generated proof receipt are retained alongside it.
+
+## Limits
+
+The proof uses genuine partial clones and real local Git transport, but the fixture's bounded size
+callback reads blob sizes from its source repository rather than GitHub GraphQL. Existing metadata
+request tests cover the one-request GraphQL mapping. The run does not mutate GitHub items, queues,
+production state, or deployment configuration.
+
+## OpenClaw Bay
+
+No Bay change is needed. This is local review-context Git compatibility; lifecycle, publication,
+queue, telemetry, dashboard data contracts, and the observer-only action boundary are unchanged.

--- a/docs/proof/blob-hydration-env/artifacts/crabbox-provenance.json
+++ b/docs/proof/blob-hydration-env/artifacts/crabbox-provenance.json
@@ -1,0 +1,53 @@
+{
+  "schema": "clawsweeper-crabbox-proof-provenance/v1",
+  "generated_at": "2026-08-11T07:20:06Z",
+  "claim": "The pushed PR hydrates genuine blobless-clone review objects on Git 2.39.5 and completes the full ClawSweeper gate suite with zero failures.",
+  "crabbox": {
+    "cli_version": "0.38.3-5-g2a79805d",
+    "provider": "local-container",
+    "lease_id": "cbx_553522239697",
+    "slug": "quick-crab-969a",
+    "run_id": null,
+    "machine_type": "node_24-bookworm",
+    "image": "node:24-bookworm",
+    "container_engine": "Docker 29.4.0",
+    "checkout": "--fresh-pr openclaw/clawsweeper#1118 (clean remote checkout, --no-hydrate)",
+    "workdir": "/work/crabbox/cbx_553522239697/fresh-pr-openclaw-clawsweeper-1118",
+    "sync_ms": 26760,
+    "command_ms": 375055,
+    "total_ms": 401893,
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "runtime": {
+    "node": "v24.19.0",
+    "git": "2.39.5",
+    "pnpm": "11.10.0",
+    "jq": "1.8.1"
+  },
+  "tool_verification": {
+    "jq_release": "https://github.com/jqlang/jq/releases/tag/jq-1.8.1",
+    "jq_linux_amd64_sha256": "020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d",
+    "jq_checksum": "passed",
+    "corepack_install_directory": "$HOME/.local/bin"
+  },
+  "pull_request": {
+    "url": "https://github.com/openclaw/clawsweeper/pull/1118",
+    "base_sha": "ae04c61896effe1fb7795ef021c4feac99ddaea3",
+    "reviewed_head": "964d9d8d88b7e0a2394f7d555fa9b6d5cf0f923e"
+  },
+  "result": {
+    "build_all": "passed",
+    "test_no_build": "passed",
+    "lint": "passed",
+    "format_check": "passed",
+    "check_active_surface": "passed",
+    "tests": 3318,
+    "passed": 3310,
+    "failed": 0,
+    "skipped": 8,
+    "target_blob_hydration_tests": "3 passed, 0 skipped"
+  },
+  "limits": "Fixture blob sizes use the local source repository; the production GitHub GraphQL transport is covered separately. No live GitHub mutation or deployment was exercised."
+}

--- a/docs/proof/blob-hydration-env/artifacts/crabbox-remote-stderr.log
+++ b/docs/proof/blob-hydration-env/artifacts/crabbox-remote-stderr.log
@@ -1,0 +1,1 @@
+! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.10.0.tgz

--- a/docs/proof/blob-hydration-env/artifacts/crabbox-remote-stdout.log
+++ b/docs/proof/blob-hydration-env/artifacts/crabbox-remote-stdout.log
@@ -1,0 +1,45 @@
+jq-linux-amd64: OK
+install=running
+install=passed
+build-all=running
+build-all=passed
+test-no-build=running
+test-no-build=passed
+lint=running
+lint=passed
+format-check=running
+format-check=passed
+check-active-surface=running
+check-active-surface=passed
+VERBATIM_CONTAINER_RESULT_BEGIN
+head=964d9d8d88b7e0a2394f7d555fa9b6d5cf0f923e
+branch=crabbox-pr-1118
+worktree_changes=1
+node=v24.19.0
+git=git version 2.39.5
+pnpm=11.10.0
+jq=jq-1.8.1
+jq_sha256=020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d
+jq_checksum=passed
+install=passed
+build-all=passed
+test-no-build=passed
+lint=passed
+format-check=passed
+check-active-surface=passed
+✔ restricted PR review can inspect changed blobs from a genuine blobless clone offline (838.357619ms)
+✔ missing partial-clone objects are fetched in one bounded network request (293.252076ms)
+✔ review hydration enforces per-review byte limits without fetching oversized blobs (593.233113ms)
+✔ multipart uploads stream fixed-size parts and enforce immutability at completion (6.799337ms)
+✔ chunked downloads retry transient 5xx responses and reject invalid ranges (762.054403ms)
+✔ blob listing pages with cursors and validates prefixes (8.336888ms)
+✔ materialize refuses partial trees only when the whole store is empty (8.439056ms)
+ℹ tests 3318
+ℹ suites 0
+ℹ pass 3310
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 8
+ℹ todo 0
+ℹ duration_ms 362873.722424
+VERBATIM_CONTAINER_RESULT_END

--- a/docs/proof/blob-hydration-env/artifacts/current-git-tree-traversal.log
+++ b/docs/proof/blob-hydration-env/artifacts/current-git-tree-traversal.log
@@ -1,0 +1,18 @@
+git=git version 2.55.0
+clone_filter=blob:none
+probe_form=git rev-list --objects --missing=print <base>^{tree} <head>^{tree} -- <bounded-paths>
+base_tree=6a5196dc8edf30d42048cf566da0a7fa31a60535
+head_tree=2d6015cbc21622dea89021ef0a191435adaae224
+expected.size=4
+observed.size=4
+observed.complete=true
+missing.size=2
+history_commit_objects_observed=false
+unrelated_history_blob_observed=false
+unrelated_ref_blob_observed=false
+probe_nested_fetches=0
+bounded_fetches=1
+bounded_fetch_uses_stdin=true
+hydrated=true
+hydrated_blobs=4
+offline_objects_complete=true

--- a/docs/proof/blob-hydration-env/artifacts/full-suite-result.log
+++ b/docs/proof/blob-hydration-env/artifacts/full-suite-result.log
@@ -1,0 +1,15 @@
+✔ restricted PR review can inspect changed blobs from a genuine blobless clone offline (838.357619ms)
+✔ missing partial-clone objects are fetched in one bounded network request (293.252076ms)
+✔ review hydration enforces per-review byte limits without fetching oversized blobs (593.233113ms)
+✔ multipart uploads stream fixed-size parts and enforce immutability at completion (6.799337ms)
+✔ chunked downloads retry transient 5xx responses and reject invalid ranges (762.054403ms)
+✔ blob listing pages with cursors and validates prefixes (8.336888ms)
+✔ materialize refuses partial trees only when the whole store is empty (8.439056ms)
+ℹ tests 3318
+ℹ suites 0
+ℹ pass 3310
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 8
+ℹ todo 0
+ℹ duration_ms 362873.722424

--- a/docs/proof/blob-hydration-env/artifacts/gates.txt
+++ b/docs/proof/blob-hydration-env/artifacts/gates.txt
@@ -1,0 +1,6 @@
+install=passed
+build-all=passed
+test-no-build=passed
+lint=passed
+format-check=passed
+check-active-surface=passed

--- a/docs/proof/blob-hydration-env/artifacts/git-2.39.5-tree-traversal.log
+++ b/docs/proof/blob-hydration-env/artifacts/git-2.39.5-tree-traversal.log
@@ -1,0 +1,18 @@
+git=git version 2.39.5
+clone_filter=blob:none
+probe_form=git rev-list --objects --missing=print <base>^{tree} <head>^{tree} -- <bounded-paths>
+base_tree=6a5196dc8edf30d42048cf566da0a7fa31a60535
+head_tree=2d6015cbc21622dea89021ef0a191435adaae224
+expected.size=4
+observed.size=4
+observed.complete=true
+missing.size=2
+history_commit_objects_observed=false
+unrelated_history_blob_observed=false
+unrelated_ref_blob_observed=false
+probe_nested_fetches=0
+bounded_fetches=1
+bounded_fetch_uses_stdin=true
+hydrated=true
+hydrated_blobs=4
+offline_objects_complete=true

--- a/docs/proof/blob-hydration-env/artifacts/runtime.txt
+++ b/docs/proof/blob-hydration-env/artifacts/runtime.txt
@@ -1,0 +1,9 @@
+head=964d9d8d88b7e0a2394f7d555fa9b6d5cf0f923e
+branch=crabbox-pr-1118
+worktree_changes=1
+node=v24.19.0
+git=git version 2.39.5
+pnpm=11.10.0
+jq=jq-1.8.1
+jq_sha256=020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d
+jq_checksum=passed

--- a/docs/proof/blob-hydration-env/artifacts/tree-traversal-provenance.json
+++ b/docs/proof/blob-hydration-env/artifacts/tree-traversal-provenance.json
@@ -1,0 +1,37 @@
+{
+  "schema": "clawsweeper-tree-traversal-proof/v1",
+  "generated_at": "2026-08-11T08:23:30Z",
+  "claim": "The availability probe traverses only the exact base and head trees, emits every selected blob ID without an implicit fetch, and leaves hydration to one explicit bounded fetch.",
+  "source": {
+    "branch": "steipete/blob-hydration-env-gate",
+    "base_head": "72936cc72849554c72a1cdfd433a283b194d136b",
+    "state": "after-fix working tree before the repair commit"
+  },
+  "crabbox": {
+    "cli_version": "0.38.3-5-g2a79805d",
+    "provider": "aws",
+    "lease_id": "cbx_7e3080158c5c",
+    "slug": "coral-lobster-9594",
+    "run_id": "run_0a87aaf605e6",
+    "machine_type": "c7a.8xlarge",
+    "container_image": "node:24-bookworm",
+    "container_git": "2.39.5",
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "result": {
+    "expected_blob_ids": 4,
+    "observed_blob_ids": 4,
+    "missing_blob_ids": 2,
+    "probe_nested_fetches": 0,
+    "bounded_fetches": 1,
+    "bounded_fetch_uses_stdin": true,
+    "hydrated": true,
+    "hydrated_blobs": 4,
+    "history_commit_objects_observed": false,
+    "unrelated_history_blob_observed": false,
+    "unrelated_ref_blob_observed": false
+  },
+  "limits": "The fixture uses a real local filter-capable origin and blobless clone. Remote size resolution is supplied by the fixture source repository rather than GitHub GraphQL."
+}

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -76,30 +76,65 @@ export function hydratePullRequestReviewBlobs({
   }
 
   if (objectIds.size === 0) return { hydrated: true, blobs: 0 };
-  const objectInput = `${[...objectIds].join("\n")}\n`;
-  const localObjects = spawnSync(
+  // Git before 2.45 exits without batch output when GIT_NO_LAZY_FETCH blocks a promisor fetch.
+  // rev-list's missing-object mode suppresses lazy fetches and reports them on older clients too.
+  const objectAvailability = spawnSync(
     "git",
-    ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+    [
+      "--literal-pathspecs",
+      "rev-list",
+      "--objects",
+      "--missing=print",
+      "--no-walk=unsorted",
+      baseSha,
+      headSha,
+      "--",
+      ...new Set([...basePaths, ...headPaths]),
+    ],
     {
       cwd: targetDir,
       encoding: "utf8",
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0", GIT_NO_LAZY_FETCH: "1" },
-      input: objectInput,
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
       maxBuffer: MAX_GIT_OUTPUT_BYTES,
     },
   );
-  if (localObjects.error || localObjects.status !== 0) return { hydrated: false, blobs: 0 };
-  const found = localObjects.stdout.trim().split("\n");
-  if (found.length !== objectIds.size) return { hydrated: false, blobs: 0 };
-  const sizes = new Map<string, number>();
+  if (objectAvailability.error || objectAvailability.status !== 0) {
+    return { hydrated: false, blobs: 0 };
+  }
+  const observed = new Set<string>();
   const missing = new Set<string>();
-  for (const entry of found) {
-    const [objectId, type, size] = entry.split(" ");
-    if (!objectId || !objectIds.has(objectId) || (type !== "blob" && type !== "missing")) {
-      return { hydrated: false, blobs: 0 };
+  for (const entry of objectAvailability.stdout.split("\n")) {
+    const match = entry.match(/^(\??)([0-9a-f]{40,64})(?: |$)/i);
+    if (!match || !objectIds.has(match[2]!)) continue;
+    observed.add(match[2]!);
+    if (match[1] === "?") missing.add(match[2]!);
+  }
+  if (observed.size !== objectIds.size) return { hydrated: false, blobs: 0 };
+
+  const sizes = new Map<string, number>();
+  const localObjectIds = [...objectIds].filter((objectId) => !missing.has(objectId));
+  if (localObjectIds.length > 0) {
+    const localObjects = spawnSync(
+      "git",
+      ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+      {
+        cwd: targetDir,
+        encoding: "utf8",
+        env: { ...process.env, GIT_OPTIONAL_LOCKS: "0", GIT_NO_LAZY_FETCH: "1" },
+        input: `${localObjectIds.join("\n")}\n`,
+        maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      },
+    );
+    if (localObjects.error || localObjects.status !== 0) return { hydrated: false, blobs: 0 };
+    const found = localObjects.stdout.trim().split("\n");
+    if (found.length !== localObjectIds.length) return { hydrated: false, blobs: 0 };
+    for (const entry of found) {
+      const [objectId, type, size] = entry.split(" ");
+      if (!objectId || !objectIds.has(objectId) || type !== "blob") {
+        return { hydrated: false, blobs: 0 };
+      }
+      sizes.set(objectId, Number(size));
     }
-    if (type === "missing") missing.add(objectId);
-    else sizes.set(objectId, Number(size));
   }
   if (missing.size > 0) {
     if (!resolveBlobSizes) return { hydrated: false, blobs: 0 };

--- a/src/clawsweeper-review-blobs.ts
+++ b/src/clawsweeper-review-blobs.ts
@@ -77,6 +77,7 @@ export function hydratePullRequestReviewBlobs({
 
   if (objectIds.size === 0) return { hydrated: true, blobs: 0 };
   // Git before 2.45 exits without batch output when GIT_NO_LAZY_FETCH blocks a promisor fetch.
+  // Traverse only the two commit trees: this emits their blobs without walking either history.
   // rev-list's missing-object mode suppresses lazy fetches and reports them on older clients too.
   const objectAvailability = spawnSync(
     "git",
@@ -85,9 +86,8 @@ export function hydratePullRequestReviewBlobs({
       "rev-list",
       "--objects",
       "--missing=print",
-      "--no-walk=unsorted",
-      baseSha,
-      headSha,
+      `${baseSha}^{tree}`,
+      `${headSha}^{tree}`,
       "--",
       ...new Set([...basePaths, ...headPaths]),
     ],

--- a/test/review-blob-hydration.test.ts
+++ b/test/review-blob-hydration.test.ts
@@ -179,16 +179,35 @@ test("missing partial-clone objects are fetched in one bounded network request",
   const previousTrace = process.env.GIT_TRACE2_EVENT;
   const trace = join(fixture.root, "git-trace.jsonl");
   try {
+    const paths = Array.from({ length: 12 }, (_, index) => `additional-${index}.txt`);
+    const expectedBlobIds = paths.map((path) => git(fixture.source, "rev-parse", `HEAD:${path}`));
+    const probeOutput = git(
+      fixture.target,
+      "--literal-pathspecs",
+      "rev-list",
+      "--objects",
+      "--missing=print",
+      `${fixture.baseSha}^{tree}`,
+      `${fixture.headSha}^{tree}`,
+      "--",
+      ...paths,
+    );
+    const probedObjectIds = new Set(
+      probeOutput.split("\n").map((entry) => entry.match(/^\??([0-9a-f]{40,64})(?: |$)/i)?.[1]),
+    );
+    assert.deepEqual(
+      expectedBlobIds.filter((objectId) => !probedObjectIds.has(objectId)),
+      [],
+      "availability probe must emit every blob ID reached from the bounded commit trees",
+    );
+
     process.env.GIT_TRACE2_EVENT = trace;
     const result = hydratePullRequestReviewBlobs({
       targetDir: fixture.target,
       baseSha: fixture.baseSha,
       headSha: fixture.headSha,
       resolveBlobSizes: resolveFixtureBlobSizes(fixture.source),
-      files: Array.from({ length: 12 }, (_, index) => ({
-        filename: `additional-${index}.txt`,
-        status: "added",
-      })),
+      files: paths.map((filename) => ({ filename, status: "added" })),
     });
     if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
     else process.env.GIT_TRACE2_EVENT = previousTrace;
@@ -197,11 +216,26 @@ test("missing partial-clone objects are fetched in one bounded network request",
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as { event: string; argv?: string[] });
-    const fetches = traceEvents.filter(
+    const revLists = traceEvents.filter(
+      (event) => event.event === "start" && event.argv?.includes("rev-list"),
+    );
+    const nestedFetches = traceEvents.filter(
+      (event) => event.event === "child_start" && event.argv?.includes("fetch"),
+    );
+    const explicitFetches = traceEvents.filter(
       (event) => event.event === "start" && event.argv?.includes("fetch"),
     );
     assert.deepEqual(result, { hydrated: true, blobs: 12 });
-    assert.equal(fetches.length, 1);
+    assert.equal(revLists.length, 1);
+    assert.ok(revLists[0]!.argv?.includes(`${fixture.baseSha}^{tree}`));
+    assert.ok(revLists[0]!.argv?.includes(`${fixture.headSha}^{tree}`));
+    assert.equal(
+      revLists[0]!.argv?.some((argument) => argument.startsWith("--no-walk")),
+      false,
+    );
+    assert.equal(nestedFetches.length, 0, "availability probe must not lazy-fetch blobs");
+    assert.equal(explicitFetches.length, 1, "hydration must perform one explicit bounded fetch");
+    assert.ok(explicitFetches[0]!.argv?.includes("--stdin"));
   } finally {
     if (previousTrace === undefined) delete process.env.GIT_TRACE2_EVENT;
     else process.env.GIT_TRACE2_EVENT = previousTrace;


### PR DESCRIPTION
## What Problem This Solves

Restricted PR review hydration needed an old-Git-compatible way to classify missing promisor blobs. The first repair used `rev-list --objects --missing=print --no-walk=unsorted`, but `--no-walk` prevented the required tree traversal on Git 2.39.5, so the parser could not observe the selected blob IDs and hydration failed closed before its bounded fetch.

## Root Cause and Masking Path

The old integration assertion counted any Git fetch. On Git 2.39.5, the path-limited `rev-list` path could spawn an implicit promisor fetch while resolving paths; that fallback fetch satisfied the test's count even though the production code's explicit bounded `--stdin` fetch did not run. The proof therefore looked green without proving the intended path.

## Fix

The availability probe now starts from the two exact tree objects:

```text
git rev-list --objects --missing=print <base>^{tree} <head>^{tree} -- <bounded-paths>
```

This recurses through the selected base/head trees, emits their blob IDs, and cannot walk either commit history. It also avoids the incorrect `--not --all` shape, so other refs cannot suppress objects that belong to the reviewed trees.

The strengthened test now:

- asserts that probe output includes every expected blob ID;
- requires both `^{tree}` roots and rejects `--no-walk`;
- rejects a fetch nested under the probe; and
- requires exactly one later explicit fetch using `--stdin`.

Path safety, the 4 MiB review limit, GraphQL size resolution, one-request fetching, and fail-closed behavior are unchanged.

## Real Behavior Proof

- Claim: Git 2.39.5 and current Git traverse only the two reviewed trees, observe every selected blob, perform no implicit probe fetch, and hydrate missing blobs with one explicit bounded fetch.
- Surface: `hydratePullRequestReviewBlobs` plus a genuine filter-capable bare origin and real `blob:none` partial clone.
- Scenario: base/head trees contain four selected blobs; two head blobs begin missing; an earlier history-only blob and a separately fetched unrelated-ref blob must remain unobserved.
- Result on Git 2.39.5 and Git 2.55.0: `expected.size=4`, `observed.size=4`, `observed.complete=true`, `missing.size=2`, `probe_nested_fetches=0`, `bounded_fetches=1`, `bounded_fetch_uses_stdin=true`, `hydrated=true`, and offline objects complete.
- Committed traces: [`docs/proof/blob-hydration-env/artifacts/git-2.39.5-tree-traversal.log`](https://github.com/openclaw/clawsweeper/blob/2439d7190c74/docs/proof/blob-hydration-env/artifacts/git-2.39.5-tree-traversal.log) and [`current-git-tree-traversal.log`](https://github.com/openclaw/clawsweeper/blob/2439d7190c74/docs/proof/blob-hydration-env/artifacts/current-git-tree-traversal.log).
- Git 2.39.5 trace provenance: Crabbox provider `aws`, lease `cbx_7e3080158c5c` (`coral-lobster-9594`), run `run_0a87aaf605e6`, `node:24-bookworm`, exit 0, lease stopped.
- Limits: the fixture uses real Git transport and partial-clone behavior, while the bounded size callback reads from its local source repository rather than GitHub GraphQL.

## Exact Pushed-Head Container Gates

Crabbox checked out the exact pushed PR head with `--fresh-pr openclaw/clawsweeper#1118` and no local patch. Provider `local-container`, lease `cbx_36c3ecd5d6d6` (`swift-shrimp-1a40`), image `node:24-bookworm`, exit 0, `leaseStopped=true`.

```text
head=2439d7190c74dc39a76b0947f28db3bb4dc621d8
branch=crabbox-pr-1118
worktree_changes=1
node=v24.19.0
git=git version 2.39.5
pnpm=11.10.0
jq=jq-1.8.1
jq_checksum=passed
build-all=passed
tests=3318
pass=3310
fail=0
cancelled=0
skipped=8
test-no-build=passed
lint=passed
format-check=passed
check-active-surface=passed
```

`worktree_changes=1` is the proof harness uploaded under `.crabbox/scripts/` after the clean fresh-PR checkout; no patch was applied to the pushed head.

Pre-commit Codex autoreview and the committed branch review against current `origin/main` both completed cleanly with no accepted/actionable findings.

## OpenClaw Bay Impact

None. This changes only local review-context Git object availability detection. It does not change lifecycle, publication, queue, status, telemetry, dashboard contracts, or Bay's observer-only boundary.
