### PR TITLE
perf(queue): reuse alarm state snapshots across synchronous sections

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -3323,12 +3323,13 @@ export class ExactReviewQueue {
     await this.storage.deleteAlarm();
     await this.processBranchAuthorityReservations(startedAt);
     await this.processSourceAuthorityReservations(startedAt);
-    this.storage.transactionSync(() => {
+    let snapshot = this.storage.transactionSync(() => {
       this.pruneDeliveryReceiptsSync(startedAt);
       this.directPublicationStore.pruneTerminalSync(startedAt);
-      this.syncLegacyCompatibilitySync(this.readStateSync());
+      const current = this.readStateSync();
+      this.syncLegacyCompatibilitySync(current);
+      return current;
     });
-    let snapshot = this.readStateSync();
     let snapshotBatchOwnership = this.batchStore.activeLeaseSnapshot(startedAt);
     const reclaimedSnapshot = reclaimExpiredExactReviewLeases(
       snapshot,
@@ -3477,7 +3478,7 @@ export class ExactReviewQueue {
       batchDispatchAttempted = true;
       batchDispatchRecordedAt = Date.now();
       batchDispatchId = `publication-batch-dispatch:${crypto.randomUUID()}`;
-      const reserved = this.readStateSync();
+      const reserved = snapshot;
       const reservedDispatcher = reserved.dispatcher ?? {
         state: "unknown",
         checkedAt: startedAt,

--- a/docs/proof/alarm-hydration-dedup/README.md
+++ b/docs/proof/alarm-hydration-dedup/README.md
@@ -1,0 +1,52 @@
+# Alarm hydration deduplication proof
+
+## Claim
+
+The real dashboard Worker and `ExactReviewQueue` Durable Object produce byte-identical normalized
+public queue state for the same populated batch-publication alarm scenario, while two redundant
+full item-table hydrations are removed from that alarm execution.
+
+## Exercised surface
+
+- Merge-base and candidate source trees, each installed and built independently on Node 24+
+- Real `wrangler dev --local` Workers and SQLite-backed `ExactReviewQueue` Durable Objects
+- Eight publication records seeded through the signed `/internal/exact-review/enqueue` route
+- Automatic Durable Object alarms and a loopback GitHub App/API stub that accepts the real batch
+  workflow dispatch
+- Public `/api/exact-review-queue` snapshots immediately after seeding and after batch dispatch
+- The existing test-only SQLite adapter around each revision's actual queue class, counting the
+  full `SELECT item_key, item_json FROM exact_review_queue_items` hydration query
+
+Only volatile clock-derived fields, request IDs, and UUIDs are normalized. The harness requires
+the normalized merge-base and candidate JSON bytes to match both before and after the alarm.
+
+## Eliminated reads
+
+| Reused hydration | Why the second read cannot differ |
+| --- | --- |
+| Alarm housekeeping transaction snapshot | Between the legacy compatibility mirror and the former next-line read, the callback only returns and the synchronous transaction closes; neither path writes the normalized item table or dispatcher. |
+| Post-terminal-preflight snapshot used for batch reservation | Between the recheck and reservation, the code performs only synchronous capacity, admission, candidate, and backoff calculations; there is no `await` or normalized-state mutation. |
+
+Every later alarm read remains because an external await or a possible queue-state write intervenes.
+
+## Run
+
+From the repository root on Node 24 or newer:
+
+```bash
+docs/proof/alarm-hydration-dedup/run-proof.sh
+```
+
+Generated evidence is written under `docs/proof/alarm-hydration-dedup/artifacts/`, including exact
+base/head provenance, raw and normalized queue snapshots, an empty normalized diff, Worker logs,
+GitHub-stub requests, scan-count test logs, and `proof-summary.json`.
+
+## Limits and OpenClaw Bay impact
+
+The GitHub service is a loopback behavioral stub; no production repository, Worker, secret,
+comment, workflow, or queue is contacted or mutated. SQL scan counts come from the existing
+test-only storage adapter, because Wrangler does not expose per-query counts without production
+instrumentation. This is state-equivalence and query-count proof, not a CPU benchmark.
+
+OpenClaw Bay is unaffected. The change alters neither queue/lifecycle data nor any public observer
+schema or control boundary.

--- a/docs/proof/alarm-hydration-dedup/run-proof.mjs
+++ b/docs/proof/alarm-hydration-dedup/run-proof.mjs
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const proofDir = path.join(repoRoot, "docs/proof/alarm-hydration-dedup");
+const artifactDir = path.join(proofDir, "artifacts");
+const scratch = await mkdtemp(path.join(tmpdir(), "alarm-hydration-dedup-"));
+const baseRoot = path.join(scratch, "merge-base");
+const archivePath = path.join(scratch, "merge-base.tar");
+const proofSecret = "alarm-hydration-dedup-local-secret";
+const targetRepo = "openclaw/alarm-hydration-proof";
+const workers = [];
+const stubRequests = [];
+let activeScenario = "setup";
+
+await mkdir(artifactDir, { recursive: true });
+await Promise.all(
+  [
+    "failure.json",
+    "proof-summary.json",
+    "normalized.diff",
+    "stub-requests.json",
+    "scan-counts.json",
+  ].map((name) => rm(path.join(artifactDir, name), { force: true })),
+);
+
+const mergeBase = (await command("git", ["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
+const headSha = (await command("git", ["rev-parse", "HEAD"], repoRoot)).trim();
+await mkdir(baseRoot, { recursive: true });
+await command("git", ["archive", "--format=tar", "-o", archivePath, mergeBase], repoRoot);
+await command("tar", ["-xf", archivePath, "-C", baseRoot], repoRoot);
+
+const { privateKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+const stubPort = await availablePort();
+const dispatches = new Map();
+const stub = createHttpServer(async (request, response) => {
+  const url = new URL(request.url || "/", `http://127.0.0.1:${stubPort}`);
+  const body = await requestBody(request);
+  const scenario = activeScenario;
+  stubRequests.push({ scenario, method: request.method, pathname: url.pathname });
+  if (/^\/repos\/[^/]+\/[^/]+\/installation$/.test(url.pathname)) {
+    return json(response, 200, { id: 999 });
+  }
+  if (url.pathname === "/app/installations/999/access_tokens" && request.method === "POST") {
+    return json(response, 201, { token: "loopback-proof-token" });
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(url.pathname)) {
+    return json(response, 200, { state: "open" });
+  }
+  if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
+    return json(response, 200, { state: "active" });
+  }
+  if (
+    url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/exact-review-batch-publish.yml/dispatches" &&
+    request.method === "POST"
+  ) {
+    dispatches.set(scenario, (dispatches.get(scenario) || 0) + 1);
+    return empty(response, 204);
+  }
+  return json(response, 404, { error: "proof_stub_not_found", body_bytes: body.length });
+});
+await new Promise((resolve, reject) => {
+  stub.once("error", reject);
+  stub.listen(stubPort, "127.0.0.1", resolve);
+});
+
+try {
+  await prepareRevision(baseRoot, "base");
+  await prepareRevision(repoRoot, "head");
+  const scanCounts = await measureScanCounts(baseRoot, repoRoot);
+  const base = await runScenario("base", baseRoot);
+  const head = await runScenario("head", repoRoot);
+
+  const normalized = {
+    base: { before: normalizeVolatile(base.before), after: normalizeVolatile(base.after) },
+    head: { before: normalizeVolatile(head.before), after: normalizeVolatile(head.after) },
+  };
+  const baseBeforeBytes = stableJson(normalized.base.before);
+  const headBeforeBytes = stableJson(normalized.head.before);
+  const baseAfterBytes = stableJson(normalized.base.after);
+  const headAfterBytes = stableJson(normalized.head.after);
+  assert.equal(headBeforeBytes, baseBeforeBytes, "normalized pre-alarm queue state changed");
+  assert.equal(headAfterBytes, baseAfterBytes, "normalized post-alarm queue state changed");
+  assert.deepEqual(scanCounts, { base: 7, head: 5 });
+
+  await Promise.all([
+    writeJson("base-before.json", base.before),
+    writeJson("base-after.json", base.after),
+    writeJson("head-before.json", head.before),
+    writeJson("head-after.json", head.after),
+    writeJson("base-before.normalized.json", normalized.base.before),
+    writeJson("base-after.normalized.json", normalized.base.after),
+    writeJson("head-before.normalized.json", normalized.head.before),
+    writeJson("head-after.normalized.json", normalized.head.after),
+    writeJson("scan-counts.json", scanCounts),
+    writeJson("stub-requests.json", stubRequests),
+    writeFile(path.join(artifactDir, "normalized.diff"), "", "utf8"),
+  ]);
+  const summary = {
+    proof: "alarm hydration deduplication",
+    merge_base: mergeBase,
+    head: headSha,
+    scenarios: {
+      seeded_publications: 8,
+      base_batch_dispatches: dispatches.get("base") || 0,
+      head_batch_dispatches: dispatches.get("head") || 0,
+    },
+    normalized_queue_state: {
+      before_equal: true,
+      after_equal: true,
+      before_sha256: sha256(baseBeforeBytes),
+      after_sha256: sha256(baseAfterBytes),
+    },
+    full_item_table_scans_per_alarm: scanCounts,
+    normalization: "clock-derived keys, request/dispatch identifiers, UUIDs",
+    openclaw_bay: "none",
+    limits: "loopback GitHub API; SQL counts use the existing test-only storage adapter",
+  };
+  await writeJson("proof-summary.json", summary);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+} catch (error) {
+  await writeJson("failure.json", {
+    error: error instanceof Error ? error.stack || error.message : String(error),
+    merge_base: mergeBase,
+    head: headSha,
+  });
+  throw error;
+} finally {
+  await Promise.all(workers.map(stopWorker));
+  await new Promise((resolve) => stub.close(resolve));
+  await rm(scratch, { recursive: true, force: true });
+}
+
+async function prepareRevision(root, label) {
+  await loggedCommand("corepack", ["enable"], root, `${label}-corepack.log`);
+  await loggedCommand("pnpm", ["install", "--frozen-lockfile"], root, `${label}-install.log`);
+  await loggedCommand("pnpm", ["run", "build:all"], root, `${label}-build.log`);
+}
+
+async function measureScanCounts(base, head) {
+  const testPath = "test/dashboard-worker.test.ts";
+  const headTest = await readFile(path.join(head, testPath), "utf8");
+  const assertion = "assert.equal(fullStateReads, 5);";
+  assert.equal(headTest.split(assertion).length, 2, "scan-count assertion marker changed");
+  await writeFile(path.join(base, testPath), headTest.replace(assertion, "assert.equal(fullStateReads, 7);"));
+  const pattern = "redundant full queue hydrations";
+  await loggedCommand(
+    "node",
+    ["--test", `--test-name-pattern=${pattern}`, testPath],
+    base,
+    "base-scan-count.log",
+  );
+  await loggedCommand(
+    "node",
+    ["--test", `--test-name-pattern=${pattern}`, testPath],
+    head,
+    "head-scan-count.log",
+  );
+  return { base: 7, head: 5 };
+}
+
+async function runScenario(label, root) {
+  activeScenario = label;
+  const port = await availablePort();
+  const stateDir = await mkdtemp(path.join(tmpdir(), `alarm-hydration-${label}-state-`));
+  const logPath = path.join(artifactDir, `${label}-worker.log`);
+  const log = createWriteStream(logPath);
+  await new Promise((resolve, reject) => {
+    log.once("open", resolve);
+    log.once("error", reject);
+  });
+  const args = [
+    "--yes",
+    "wrangler@4.107.0",
+    "dev",
+    "--config",
+    "dashboard/wrangler.toml",
+    "--local",
+    "--persist-to",
+    stateDir,
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(port),
+    "--var",
+    `CLAWSWEEPER_WEBHOOK_SECRET:${proofSecret}`,
+    "--var",
+    "CLAWSWEEPER_APP_CLIENT_ID:Iv23alarmproof",
+    "--var",
+    `CLAWSWEEPER_APP_PRIVATE_KEY:${privateKey}`,
+    "--var",
+    `GITHUB_API_URL:http://127.0.0.1:${stubPort}`,
+    "--var",
+    "EXACT_REVIEW_DISPATCH_DEBOUNCE_MS:3000",
+    "--var",
+    "EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS:3000",
+    "--var",
+    "EXACT_REVIEW_PUBLICATION_BATCH_SIZE:8",
+    "--var",
+    "EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS:1000",
+  ];
+  const child = spawn("npx", args, {
+    cwd: root,
+    detached: true,
+    env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+    stdio: ["ignore", log, log],
+  });
+  const worker = { child, log, stateDir };
+  workers.push(worker);
+  const origin = `http://127.0.0.1:${port}`;
+  await waitForWorker(origin, child, logPath);
+
+  for (let index = 0; index < 8; index += 1) {
+    const itemNumber = 77100 + index;
+    const response = await signedPost(origin, {
+      delivery_id: `alarm-proof-${index}`,
+      decision: publicationDecision(itemNumber, String(771000 + index)),
+    });
+    assert.equal(response.status, 202, `${label} enqueue ${index} failed: ${response.text}`);
+  }
+  const before = await getJson(`${origin}/api/exact-review-queue`);
+  await waitFor(async () => {
+    const state = await getJson(`${origin}/api/exact-review-queue`);
+    return state.lanes?.publication?.batches?.last_dispatch_succeeded === true ? state : null;
+  }, 30_000, `${label} batch alarm`);
+  const after = await getJson(`${origin}/api/exact-review-queue`);
+  assert.equal(dispatches.get(label), 1, `${label} did not issue exactly one batch dispatch`);
+  await stopWorker(worker);
+  workers.splice(workers.indexOf(worker), 1);
+  return { before, after };
+}
+
+function publicationDecision(itemNumber, producerRunId) {
+  const producerDecision = {
+    targetRepo,
+    targetBranch: "main",
+    itemNumber,
+    itemKind: "issue",
+    sourceEvent: "issues",
+    sourceAction: "opened",
+    supersedesInProgress: false,
+  };
+  return {
+    ...producerDecision,
+    sourceAction: "exact_review_artifact_publish",
+    publication: {
+      artifactName: `exact-review-${producerRunId}-1`,
+      producerRunId,
+      producerRunAttempt: 1,
+      sourceSha: "a".repeat(40),
+      itemKey: `${targetRepo}#${itemNumber}`,
+      protocolVersion: 2,
+      leaseRevision: 1,
+      claimGeneration: 1,
+      liveProceeded: true,
+      liveTerminalNoop: false,
+      liveTerminalMissing: false,
+      liveGuardedOpen: false,
+      producerDecision,
+    },
+  };
+}
+
+async function signedPost(origin, payload) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", proofSecret).update(body).digest("hex")}`;
+  const response = await fetch(`${origin}/internal/exact-review/enqueue`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+  return { status: response.status, text: await response.text() };
+}
+
+function normalizeVolatile(value) {
+  if (Array.isArray(value)) return value.map((entry) => normalizeVolatile(entry));
+  if (!value || typeof value !== "object") {
+    if (typeof value === "string" && /^\d{4}-\d\d-\d\dT/.test(value)) return "<time>";
+    if (typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f-]{27}$/i.test(value)) return "<uuid>";
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([childKey, child]) => [
+      childKey,
+      /(?:_at|_until|_age_seconds|_wait_seconds|request_id|dispatch_id|departure_id|batch_id|lease_id)$/.test(
+        childKey,
+      )
+        ? `<volatile:${childKey}>`
+        : normalizeVolatile(child, childKey),
+    ]),
+  );
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (!value || typeof value !== "object") return JSON.stringify(value);
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+    .join(",")}}`;
+}
+
+async function getJson(url) {
+  const response = await fetch(url);
+  const text = await response.text();
+  assert.equal(response.status, 200, `${url} returned ${response.status}: ${text}`);
+  return JSON.parse(text);
+}
+
+async function waitForWorker(origin, child, logPath) {
+  await waitFor(async () => {
+    if (child.exitCode !== null) {
+      throw new Error(`Worker exited early:\n${await readFile(logPath, "utf8")}`);
+    }
+    try {
+      const response = await fetch(`${origin}/api/health`);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }, 90_000, `Worker ${origin}`);
+}
+
+async function waitFor(probe, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await probe();
+    if (result) return result;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`${label} timed out after ${timeoutMs}ms`);
+}
+
+async function stopWorker(worker) {
+  if (!worker || worker.child.exitCode !== null) return;
+  try {
+    process.kill(-worker.child.pid, "SIGTERM");
+  } catch {
+    worker.child.kill("SIGTERM");
+  }
+  await new Promise((resolve) => {
+    const timer = setTimeout(resolve, 5_000);
+    worker.child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+  worker.log.end();
+  await rm(worker.stateDir, { recursive: true, force: true });
+}
+
+async function loggedCommand(executable, args, cwd, logName) {
+  const result = await command(executable, args, cwd);
+  await writeFile(path.join(artifactDir, logName), result, "utf8");
+}
+
+async function command(executable, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, { cwd, env: process.env });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      const output = Buffer.concat([...stdout, ...stderr]).toString("utf8");
+      if (code === 0) resolve(output);
+      else reject(new Error(`${executable} ${args.join(" ")} failed (${code}):\n${output}`));
+    });
+  });
+}
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function json(response, status, value) {
+  const body = `${JSON.stringify(value)}\n`;
+  response.writeHead(status, { "content-type": "application/json", "content-length": Buffer.byteLength(body) });
+  response.end(body);
+}
+
+function empty(response, status) {
+  response.writeHead(status);
+  response.end();
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function writeJson(name, value) {
+  await writeFile(path.join(artifactDir, name), `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/docs/proof/alarm-hydration-dedup/run-proof.sh
+++ b/docs/proof/alarm-hydration-dedup/run-proof.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+corepack enable
+exec node docs/proof/alarm-hydration-dedup/run-proof.mjs

--- a/test/dashboard-worker.test.ts
+++ b/test/dashboard-worker.test.ts
@@ -14358,6 +14358,40 @@ test("exact-review batch terminal probe resets for a later departure", async () 
   }
 });
 
+test("exact-review batch alarm avoids redundant full queue hydrations", async () => {
+  const harness = createExactReviewAdmissionHarness(() => jsonResponse({ state: "open" }), {
+    publicationBatching: true,
+    captureBatchDispatch: true,
+  });
+  try {
+    const enqueue = buildExactReviewQueueRequest(
+      "hydration-count",
+      9232,
+      "exact_review_artifact_publish",
+      "issue",
+      "openclaw/gogcli",
+      exactReviewPublicationOverrides(9232, "92320"),
+    );
+    assert.equal((await harness.queue.fetch(enqueue)).status, 202);
+
+    const exec = harness.storage.sql.exec.bind(harness.storage.sql);
+    let fullStateReads = 0;
+    harness.storage.sql.exec = (query: string, ...bindings: unknown[]) => {
+      if (/\bSELECT item_key, item_json FROM exact_review_queue_items\b/.test(query)) {
+        fullStateReads += 1;
+      }
+      return exec(query, ...bindings);
+    };
+
+    await harness.queue.alarm();
+
+    assert.equal(harness.batchDispatches, 1);
+    assert.equal(fullStateReads, 5);
+  } finally {
+    harness.restore();
+  }
+});
+
 test("exact-review batch claims keep a newer departure fence when an older workflow arrives", async () => {
   const originalNow = Date.now;
   let now = Date.parse("2026-07-25T13:00:00.000Z");


### PR DESCRIPTION
## Summary

Reuse already-hydrated `ExactReviewQueue` alarm state across two synchronous sections instead of scanning the normalized item table again.

## Why each reuse is safe

| Reused snapshot | Why it cannot be stale |
| --- | --- |
| Alarm housekeeping transaction result | Between the legacy compatibility mirror and the former next-line read, the callback only returns and the synchronous transaction closes; neither path writes the normalized item table or dispatcher. |
| Post-terminal-preflight snapshot used for batch reservation | Between the recheck and reservation, the code performs only synchronous capacity, admission, candidate, and backoff calculations; there is no `await` or normalized-state mutation. |

Every later alarm read remains because an external await or a possible queue-state write intervenes.

## Behavior proof

Claim: the real dashboard Worker and `ExactReviewQueue` Durable Object preserve the public queue state for the same populated batch-publication alarm while eliminating two redundant full item-table hydrations.

- Current head: `44b847da52`
- Exercised surface: independently built merge-base and candidate trees, real local Wrangler Workers, SQLite-backed Durable Objects, eight signed publication enqueues, automatic alarm execution, and a loopback GitHub App/API stub accepting the real batch workflow dispatch.
- Observable result: full normalized item-table scans per alarm decreased from **7 to 5**.
- State result: normalized public queue snapshots were byte-identical before and after the alarm at merge-base and head.
- Focused regression: `exact-review batch alarm avoids redundant full queue hydrations` passed at both revisions with the expected 7/5 assertions.
- Full local suite: 3,313 passed, 0 failed, 9 skipped, serially on Node 24.
- Static gates: lint, format check, dashboard queue boundary, active surface, and limits all passed.
- Reproduction and retained evidence: `docs/proof/alarm-hydration-dedup/README.md` and `docs/proof/alarm-hydration-dedup/run-proof.sh`.

### Exact pushed-head container proof

Crabbox checked out PR 1121 with `--fresh-pr` at exact pushed head
`44b847da529590d9f4e895045c312d1aaf326bbb`, with no local patch. The final run used
`provider=aws`, lease `cbx_1e632a851089` (`harbor-shrimp-945d`), run
`run_ce35bb320c92`, Docker 29.7.1, and `node:24-bookworm`. Corepack supplied pnpm 11.10.0;
jq 1.8.1 was installed only after `jq-linux-amd64: OK` against the official checksum manifest.

The container result was fully green: 3,322 tests, 3,314 passed, 0 failed, 0 cancelled, and 8
platform skips. Build, lint, format check, dashboard queue boundary, active surface, and limits all
passed. The container then ran the real behavior proof: scans decreased 7→5, normalized before and
after states were byte-identical, and Bay impact remained `none`.

Limits: the GitHub service is a loopback behavioral stub; no production repository, Worker, secret, comment, workflow, or queue is contacted. SQL scan counts use the existing test-only storage adapter because Wrangler does not expose per-query counts without production instrumentation. This proves state equivalence and query count, not CPU time.

Proof: sufficient.

## OpenClaw Bay

None. This changes internal alarm hydration reuse only; it does not alter queue/lifecycle data, the public observer schema, or any control boundary.
