### PR TITLE
fix: prevent apply cursor livelock

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5952,6 +5952,7 @@ jobs:
           if [ "$sync_comments_only" = "true" ]; then
             sync_comments_arg=(--sync-comments-only)
           fi
+          prepare_comment_sync_cursor_arg
           min_age_minutes_arg=()
           if [ -n "$min_age_minutes" ]; then
             min_age_minutes_arg=(--min-age-minutes "$min_age_minutes")
@@ -6052,6 +6053,7 @@ jobs:
               --processed-limit "$comment_sync_processed_limit" \
               --max-runtime-ms 300000 \
               --cursor-trace ".artifacts/comment-sync-trace-$checkpoint.json" \
+              "${comment_sync_cursor_arg[@]}" \
               --comment-sync-min-age-days "$comment_sync_min_age_days" \
               "${item_numbers_arg[@]}" \
               "${sync_comments_arg[@]}"

--- a/docs/proof/apply-cursor-livelock/README.md
+++ b/docs/proof/apply-cursor-livelock/README.md
@@ -1,0 +1,60 @@
+# Apply cursor livelock proof
+
+## Claim
+
+The automatic `openclaw/openclaw` comment-sync batch always executes its numeric cursor frontier
+before opportunistic urgent repairs. Per-pass-terminal outcomes can therefore advance the durable
+cursor, while a runtime yield on the frontier itself leaves the cursor unchanged for a truthful
+retry.
+
+This fixes the livelock observed in production run
+https://github.com/openclaw/clawsweeper/actions/runs/31544381133. That run selected 39 urgency-ranked
+records before frontier `#105870`, exhausted its 300-second budget at urgent record `#85937`, and
+never reached the only record that could advance cursor `#105854`.
+
+## Controlled scenario and fixture
+
+`run-proof.mjs` uses the exact 40-number selection from the production run and a synthetic action
+mix matching its terminal classes: durable comment sync, changed-since-review, stale-sync skip,
+kept-open, an already-closed canonical record, and a runtime-clipped record.
+
+The same unchanged cursor-completion helper is exercised three ways:
+
+1. The old urgency-first order examines the terminal urgent prefix but not frontier `#105870`; it
+   reports `cursor_count=0` and leaves the cursor at `#105854`.
+2. The new batch selector places `#105870` first. After that frontier and the same terminal urgent
+   prefix complete, a yield at `#85937` advances the cursor exactly to `#105870`.
+3. A yield on the first frontier records no examined item and leaves the cursor at `#105854`.
+
+The proof also runs the repository's focused wrap/cycle tests. The implementation changes only
+execution order inside the selected batch; it does not change `cycle_start_after_number`,
+`cycle_wrapped`, their reset rules, or the special automatic-policy branch.
+
+## Run
+
+```bash
+docs/proof/apply-cursor-livelock/run-proof.sh
+```
+
+The container entrypoint additionally installs jq 1.8.2 only after verifying the official release
+checksum:
+
+```bash
+docs/proof/apply-cursor-livelock/container-proof.sh
+```
+
+## Result
+
+`fixture-result.json` is the committed machine-readable fixture result. `behavior-report.json`
+records the source-blind behavior validation. The fresh-PR Crabbox receipt is recorded in
+`container-provenance.json` after the pushed PR checkout completes.
+
+## Limits and Bay impact
+
+The fixture reproduces the cursor ownership and runtime-yield boundary without GitHub credentials
+or production mutation. It does not reproduce the live API latency or claim that urgent records no
+longer require later repair.
+
+OpenClaw Bay is unaffected. This changes only internal apply-lane batch execution order and removes
+a redundant pre-lease cleanup attempt; it does not change lifecycle publication or the
+observer-only dashboard contract.

--- a/docs/proof/apply-cursor-livelock/README.md
+++ b/docs/proof/apply-cursor-livelock/README.md
@@ -48,12 +48,12 @@ docs/proof/apply-cursor-livelock/container-proof.sh
 `fixture-result.json` is the committed machine-readable fixture result. `behavior-report.json`
 records the source-blind behavior validation.
 
-The final fresh-PR proof ran pushed head `c87bd96db0bc34a0f7dcad95067973fe1853951a`
-inside `node:24-bookworm` through Crabbox `provider=aws`, lease `cbx_b2223e33b8a4`
-(`brisk-hermit-0fc9`), run `run_1623fae6fdec`. jq 1.8.2 was installed only after the official
-`jq-linux-amd64` checksum matched. All four focused fixture/wrap tests passed, Crabbox exited 0, and
-the lease stopped automatically. `container-provenance.json` records the complete receipt and the
-earlier harness-only attempts.
+The final fresh-PR proof ran pushed head `e6e534fc39eec471a447d8b956a0c24dd3ee97ca`
+inside `node:24-bookworm` through Crabbox `provider=aws`, lease `cbx_20b3853d5df2`
+(`quick-krill-bd9c`), run `run_dbbae04e9b37`. jq 1.8.2 was installed only after its
+`jq-linux-amd64` digest matched the repository-pinned value. All four focused fixture/wrap tests
+passed, Crabbox exited 0, and the lease stopped automatically. `container-provenance.json` records
+the complete receipt and the earlier proof-harness runs.
 
 ## Limits and Bay impact
 

--- a/docs/proof/apply-cursor-livelock/README.md
+++ b/docs/proof/apply-cursor-livelock/README.md
@@ -36,8 +36,8 @@ execution order inside the selected batch; it does not change `cycle_start_after
 docs/proof/apply-cursor-livelock/run-proof.sh
 ```
 
-The container entrypoint additionally installs jq 1.8.2 only after verifying the official release
-checksum:
+The container entrypoint additionally installs jq 1.8.2 only after verifying the
+repository-pinned official release digest:
 
 ```bash
 docs/proof/apply-cursor-livelock/container-proof.sh

--- a/docs/proof/apply-cursor-livelock/README.md
+++ b/docs/proof/apply-cursor-livelock/README.md
@@ -54,12 +54,12 @@ docs/proof/apply-cursor-livelock/container-proof.sh
 `fixture-result.json` is the committed machine-readable fixture result. `behavior-report.json`
 records the source-blind behavior validation.
 
-The final fresh-PR proof ran pushed head `e6e534fc39eec471a447d8b956a0c24dd3ee97ca`
-inside `node:24-bookworm` through Crabbox `provider=aws`, lease `cbx_20b3853d5df2`
-(`quick-krill-bd9c`), run `run_dbbae04e9b37`. jq 1.8.2 was installed only after its
+The final committed-head proof ran `2ebe882831f99d9f22dd6f696f48d2a4e80f3195`
+inside `node:24-bookworm` through Crabbox `provider=aws`, lease `cbx_a9f86ad7a357`
+(`quick-prawn-5920`), run `run_61dcc42eb8d2`. jq 1.8.2 was installed only after its
 `jq-linux-amd64` digest matched the repository-pinned value. All five focused fixture/wrap tests
 passed, Crabbox exited 0, and the lease stopped automatically. `container-provenance.json` records
-the complete receipt and the earlier proof-harness runs.
+the complete receipt and the earlier proof-harness attempts.
 
 ## Limits and Bay impact
 

--- a/docs/proof/apply-cursor-livelock/README.md
+++ b/docs/proof/apply-cursor-livelock/README.md
@@ -46,8 +46,14 @@ docs/proof/apply-cursor-livelock/container-proof.sh
 ## Result
 
 `fixture-result.json` is the committed machine-readable fixture result. `behavior-report.json`
-records the source-blind behavior validation. The fresh-PR Crabbox receipt is recorded in
-`container-provenance.json` after the pushed PR checkout completes.
+records the source-blind behavior validation.
+
+The final fresh-PR proof ran pushed head `c87bd96db0bc34a0f7dcad95067973fe1853951a`
+inside `node:24-bookworm` through Crabbox `provider=aws`, lease `cbx_b2223e33b8a4`
+(`brisk-hermit-0fc9`), run `run_1623fae6fdec`. jq 1.8.2 was installed only after the official
+`jq-linux-amd64` checksum matched. All four focused fixture/wrap tests passed, Crabbox exited 0, and
+the lease stopped automatically. `container-provenance.json` records the complete receipt and the
+earlier harness-only attempts.
 
 ## Limits and Bay impact
 

--- a/docs/proof/apply-cursor-livelock/README.md
+++ b/docs/proof/apply-cursor-livelock/README.md
@@ -2,10 +2,12 @@
 
 ## Claim
 
-The automatic `openclaw/openclaw` comment-sync batch always executes its numeric cursor frontier
-before opportunistic urgent repairs. Per-pass-terminal outcomes can therefore advance the durable
-cursor, while a runtime yield on the frontier itself leaves the cursor unchanged for a truthful
-retry.
+The automatic `openclaw/openclaw` apply loop always executes its numeric cursor frontier before
+opportunistic urgent repairs, regardless of the order in which `item_numbers` arrives. The loop
+chooses the smallest number strictly greater than the active cursor and wraps to the smallest
+selected number only when no greater number exists. Per-pass-terminal outcomes can therefore
+advance the durable cursor, while a runtime yield on the frontier itself leaves the cursor
+unchanged for a truthful retry.
 
 This fixes the livelock observed in production run
 https://github.com/openclaw/clawsweeper/actions/runs/31544381133. That run selected 39 urgency-ranked
@@ -18,17 +20,21 @@ never reached the only record that could advance cursor `#105854`.
 mix matching its terminal classes: durable comment sync, changed-since-review, stale-sync skip,
 kept-open, an already-closed canonical record, and a runtime-clipped record.
 
-The same unchanged cursor-completion helper is exercised three ways:
+The selector, apply loop, and cursor-completion helper are exercised four ways:
 
 1. The old urgency-first order examines the terminal urgent prefix but not frontier `#105870`; it
    reports `cursor_count=0` and leaves the cursor at `#105854`.
 2. The new batch selector places `#105870` first. After that frontier and the same terminal urgent
    prefix complete, a yield at `#85937` advances the cursor exactly to `#105870`.
 3. A yield on the first frontier records no examined item and leaves the cursor at `#105854`.
+4. An ascending-sorted request places `#105870` last after four lower urgent records. The apply
+   loop nevertheless examines `#105870` first, and completion consumes that trusted execution
+   trace to persist `#105870` while every other record remains unexamined.
 
-The proof also runs the repository's focused wrap/cycle tests. The implementation changes only
-execution order inside the selected batch; it does not change `cycle_start_after_number`,
-`cycle_wrapped`, their reset rules, or the special automatic-policy branch.
+The proof also runs the repository's focused wrap/cycle tests. The selector reorder remains useful
+for non-apply consumers, but the TypeScript apply-loop selection is the load-bearing guarantee.
+The implementation does not change `cycle_start_after_number`, `cycle_wrapped`, their reset rules,
+or the special automatic-policy branch.
 
 ## Run
 
@@ -51,7 +57,7 @@ records the source-blind behavior validation.
 The final fresh-PR proof ran pushed head `e6e534fc39eec471a447d8b956a0c24dd3ee97ca`
 inside `node:24-bookworm` through Crabbox `provider=aws`, lease `cbx_20b3853d5df2`
 (`quick-krill-bd9c`), run `run_dbbae04e9b37`. jq 1.8.2 was installed only after its
-`jq-linux-amd64` digest matched the repository-pinned value. All four focused fixture/wrap tests
+`jq-linux-amd64` digest matched the repository-pinned value. All five focused fixture/wrap tests
 passed, Crabbox exited 0, and the lease stopped automatically. `container-provenance.json` records
 the complete receipt and the earlier proof-harness runs.
 

--- a/docs/proof/apply-cursor-livelock/behavior-contract.md
+++ b/docs/proof/apply-cursor-livelock/behavior-contract.md
@@ -17,14 +17,18 @@ without skipping a frontier clipped by the runtime budget.
 
 1. Replay the production urgency-first ordering through the cursor completion command.
 2. Replay the same outcomes through the current batch selector and completion command.
-3. Clip the current batch at its first frontier and inspect the persisted cursor.
-4. Run the focused wrap/cycle regression probes.
+3. Pass an ascending-sorted request with the numeric frontier last through the real apply loop,
+   stop after its first examined record, and complete the cursor from the trusted trace.
+4. Clip the current batch at its first frontier and inspect the persisted cursor.
+5. Run the focused wrap/cycle regression probes.
 
 ## Expected observable behavior
 
 - The old ordering reports zero cursor progress and persists `#105854`.
 - The current selector places frontier `#105870` first and the completed-frontier replay persists
   `#105870` even though later urgent work is clipped.
+- The apply loop executes `#105870` first when ascending input places it last, and cursor completion
+  still persists `#105870` while every lower urgent record remains unexamined.
 - A clipped frontier reports zero progress and persists `#105854`.
 - Wrapped selection and cycle bookkeeping probes pass unchanged.
 - No GitHub API or credential is used.
@@ -36,6 +40,7 @@ without skipping a frontier clipped by the runtime budget.
 - Include terminal outcomes other than comment sync: kept-open, changed-since-review, stale-sync
   skip, and already-closed reconciliation.
 - Assert the current selector's reported `next_cursor` is the executed first item.
+- Assert the apply trace, rather than incoming list position, determines the completed prefix.
 
 ## Evidence required
 

--- a/docs/proof/apply-cursor-livelock/behavior-contract.md
+++ b/docs/proof/apply-cursor-livelock/behavior-contract.md
@@ -1,0 +1,48 @@
+# Apply cursor livelock behavior contract
+
+## User-visible goal
+
+A scheduled comment-sync pass makes durable cursor progress whenever its numeric frontier completes,
+without skipping a frontier clipped by the runtime budget.
+
+## Target
+
+- Type: CLI fixture
+- Access: `docs/proof/apply-cursor-livelock/run-proof.sh`
+- Allowed fixtures: synthetic records using the public item numbers and outcome classes from run
+  `31544381133`
+- Credentials: none
+
+## User tasks
+
+1. Replay the production urgency-first ordering through the cursor completion command.
+2. Replay the same outcomes through the current batch selector and completion command.
+3. Clip the current batch at its first frontier and inspect the persisted cursor.
+4. Run the focused wrap/cycle regression probes.
+
+## Expected observable behavior
+
+- The old ordering reports zero cursor progress and persists `#105854`.
+- The current selector places frontier `#105870` first and the completed-frontier replay persists
+  `#105870` even though later urgent work is clipped.
+- A clipped frontier reports zero progress and persists `#105854`.
+- Wrapped selection and cycle bookkeeping probes pass unchanged.
+- No GitHub API or credential is used.
+
+## Anti-cheat probes
+
+- Use the same completion helper for old and current orderings; vary only selected execution order.
+- Remove the frontier from the examined trace and require the cursor to remain unchanged.
+- Include terminal outcomes other than comment sync: kept-open, changed-since-review, stale-sync
+  skip, and already-closed reconciliation.
+- Assert the current selector's reported `next_cursor` is the executed first item.
+
+## Evidence required
+
+- `fixture-result.json`
+- Focused test output with zero failures
+- Fresh-PR container provider, lease, head, jq checksum, and exit status
+
+## Out of scope
+
+Live GitHub latency, production mutation, budget increases, dashboard rendering, and OpenClaw Bay.

--- a/docs/proof/apply-cursor-livelock/behavior-report.json
+++ b/docs/proof/apply-cursor-livelock/behavior-report.json
@@ -29,7 +29,18 @@
       "confidence": 0.99
     },
     {
-      "contract_clause": "User task 3: clip the first frontier",
+      "contract_clause": "User task 3: execute adversarial ascending input",
+      "status": "pass",
+      "severity": null,
+      "evidence": "The ascending input placed 105870 at index 4, while the apply report and trusted trace both recorded 105870 first; completion persisted 105870 with cursor_advance_count=1.",
+      "reproduction_steps": [
+        "Read adversarial_order in the emitted JSON",
+        "Verify frontier_input_index=4, first_executed=105870, examined_item_numbers[0]=105870, and completion.persisted_cursor=105870"
+      ],
+      "confidence": 0.99
+    },
+    {
+      "contract_clause": "User task 4: clip the first frontier",
       "status": "pass",
       "severity": null,
       "evidence": "The clipped_frontier result persisted 105854 with cursor_advance_count=0 and next_cursor=null.",
@@ -40,13 +51,13 @@
       "confidence": 0.99
     },
     {
-      "contract_clause": "User task 4: preserve wrap and cycle behavior",
+      "contract_clause": "User task 5: preserve wrap and cycle behavior",
       "status": "pass",
       "severity": null,
-      "evidence": "The isolated command ran four focused probes; both wrapped cursor tests and both runtime-yield/frontier tests passed with zero failures.",
+      "evidence": "The isolated command ran five focused probes covering the apply loop, selector, completion, and wrapped cursor behavior with zero failures.",
       "reproduction_steps": [
         "Read the Node test summary emitted by run-proof.sh",
-        "Verify tests=4, pass=4, fail=0"
+        "Verify tests=5, pass=5, fail=0"
       ],
       "confidence": 0.97
     }
@@ -59,6 +70,10 @@
     {
       "probe": "Remove the frontier from the examined trace",
       "result": "The cursor remained at 105854 instead of falsely advancing."
+    },
+    {
+      "probe": "Sort incoming item numbers with the frontier last",
+      "result": "The TypeScript apply loop executed 105870 first and the trace-ordered completion advanced to 105870."
     },
     {
       "probe": "Include multiple per-pass-terminal outcome classes",

--- a/docs/proof/apply-cursor-livelock/behavior-report.json
+++ b/docs/proof/apply-cursor-livelock/behavior-report.json
@@ -1,0 +1,73 @@
+{
+  "overall_behavior": "satisfies_contract",
+  "overall_confidence": 0.98,
+  "target": {
+    "type": "CLI fixture",
+    "access": "docs/proof/apply-cursor-livelock/run-proof.sh"
+  },
+  "checks": [
+    {
+      "contract_clause": "User task 1: replay the production urgency-first ordering",
+      "status": "pass",
+      "severity": null,
+      "evidence": "The isolated CLI run reported old_order.persisted_cursor=105854, cursor_advance_count=0, and next_cursor=null.",
+      "reproduction_steps": [
+        "Run run-proof.sh from an isolated directory containing only the behavior contract",
+        "Read old_order in the emitted JSON"
+      ],
+      "confidence": 0.99
+    },
+    {
+      "contract_clause": "User task 2: replay the current ordering",
+      "status": "pass",
+      "severity": null,
+      "evidence": "The selector emitted first_item=105870 and selector_next_cursor=105870; completion persisted 105870 with cursor_advance_count=1.",
+      "reproduction_steps": [
+        "Read current_order in the emitted JSON",
+        "Verify first_item, selector_next_cursor, and persisted_cursor are all 105870"
+      ],
+      "confidence": 0.99
+    },
+    {
+      "contract_clause": "User task 3: clip the first frontier",
+      "status": "pass",
+      "severity": null,
+      "evidence": "The clipped_frontier result persisted 105854 with cursor_advance_count=0 and next_cursor=null.",
+      "reproduction_steps": [
+        "Read clipped_frontier in the emitted JSON",
+        "Verify no examined frontier was claimed"
+      ],
+      "confidence": 0.99
+    },
+    {
+      "contract_clause": "User task 4: preserve wrap and cycle behavior",
+      "status": "pass",
+      "severity": null,
+      "evidence": "The isolated command ran four focused probes; both wrapped cursor tests and both runtime-yield/frontier tests passed with zero failures.",
+      "reproduction_steps": [
+        "Read the Node test summary emitted by run-proof.sh",
+        "Verify tests=4, pass=4, fail=0"
+      ],
+      "confidence": 0.97
+    }
+  ],
+  "anti_cheat_probes": [
+    {
+      "probe": "Use one completion command for old and current selected orders",
+      "result": "Only order changed: the old replay stayed at 105854 and the current replay advanced to 105870."
+    },
+    {
+      "probe": "Remove the frontier from the examined trace",
+      "result": "The cursor remained at 105854 instead of falsely advancing."
+    },
+    {
+      "probe": "Include multiple per-pass-terminal outcome classes",
+      "result": "The fixture included comment-synced, changed-since-review, stale-sync-skip, kept-open, and canonical closed-record completion."
+    },
+    {
+      "probe": "Run without GitHub credentials",
+      "result": "The proof completed from synthetic filesystem records and made no GitHub API request."
+    }
+  ],
+  "blockers": []
+}

--- a/docs/proof/apply-cursor-livelock/container-proof.sh
+++ b/docs/proof/apply-cursor-livelock/container-proof.sh
@@ -18,11 +18,12 @@ expected="$(awk -v asset="$jq_asset" '$2 == asset { print $1 }' "$tool_dir/sha25
 actual="$(sha256sum "$tool_dir/jq" | awk '{ print $1 }')"
 test -n "$expected"
 test "$actual" = "$expected"
-chmod +x "$tool_dir/jq"
-export PATH="$tool_dir:$PATH"
+install -m 0755 "$tool_dir/jq" /usr/local/bin/jq
+export PATH="/usr/local/bin:$PATH"
 git config --global --add safe.directory "$repo_root"
 
 echo "JQ_ASSET=$jq_asset"
 echo "JQ_SHA256=$actual"
 echo "JQ_CHECKSUM_VERIFIED=true"
+echo "JQ_INSTALL_PATH=/usr/local/bin/jq"
 "$proof_dir/run-proof.sh"

--- a/docs/proof/apply-cursor-livelock/container-proof.sh
+++ b/docs/proof/apply-cursor-livelock/container-proof.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+jq_version="1.8.2"
+jq_asset="jq-linux-amd64"
+tool_dir="$(mktemp -d /tmp/apply-cursor-proof-tools.XXXXXX)"
+trap 'rm -rf "$tool_dir"' EXIT
+
+curl --fail --silent --show-error --location \
+  "https://github.com/jqlang/jq/releases/download/jq-${jq_version}/${jq_asset}" \
+  --output "$tool_dir/jq"
+curl --fail --silent --show-error --location \
+  "https://github.com/jqlang/jq/releases/download/jq-${jq_version}/sha256sum.txt" \
+  --output "$tool_dir/sha256sum.txt"
+expected="$(awk -v asset="$jq_asset" '$2 == asset { print $1 }' "$tool_dir/sha256sum.txt")"
+actual="$(sha256sum "$tool_dir/jq" | awk '{ print $1 }')"
+test -n "$expected"
+test "$actual" = "$expected"
+chmod +x "$tool_dir/jq"
+export PATH="$tool_dir:$PATH"
+
+echo "JQ_ASSET=$jq_asset"
+echo "JQ_SHA256=$actual"
+echo "JQ_CHECKSUM_VERIFIED=true"
+"$proof_dir/run-proof.sh"

--- a/docs/proof/apply-cursor-livelock/container-proof.sh
+++ b/docs/proof/apply-cursor-livelock/container-proof.sh
@@ -5,19 +5,15 @@ proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$proof_dir/../../.." && pwd)"
 jq_version="1.8.2"
 jq_asset="jq-linux-amd64"
+jq_sha256="b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f"
 tool_dir="$(mktemp -d /tmp/apply-cursor-proof-tools.XXXXXX)"
 trap 'rm -rf "$tool_dir"' EXIT
 
 curl --fail --silent --show-error --location \
   "https://github.com/jqlang/jq/releases/download/jq-${jq_version}/${jq_asset}" \
   --output "$tool_dir/jq"
-curl --fail --silent --show-error --location \
-  "https://github.com/jqlang/jq/releases/download/jq-${jq_version}/sha256sum.txt" \
-  --output "$tool_dir/sha256sum.txt"
-expected="$(awk -v asset="$jq_asset" '$2 == asset { print $1 }' "$tool_dir/sha256sum.txt")"
 actual="$(sha256sum "$tool_dir/jq" | awk '{ print $1 }')"
-test -n "$expected"
-test "$actual" = "$expected"
+test "$actual" = "$jq_sha256"
 install -m 0755 "$tool_dir/jq" /usr/local/bin/jq
 export PATH="/usr/local/bin:$PATH"
 git config --global --add safe.directory "$repo_root"

--- a/docs/proof/apply-cursor-livelock/container-proof.sh
+++ b/docs/proof/apply-cursor-livelock/container-proof.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$proof_dir/../../.." && pwd)"
 jq_version="1.8.2"
 jq_asset="jq-linux-amd64"
 tool_dir="$(mktemp -d /tmp/apply-cursor-proof-tools.XXXXXX)"
@@ -19,6 +20,7 @@ test -n "$expected"
 test "$actual" = "$expected"
 chmod +x "$tool_dir/jq"
 export PATH="$tool_dir:$PATH"
+git config --global --add safe.directory "$repo_root"
 
 echo "JQ_ASSET=$jq_asset"
 echo "JQ_SHA256=$actual"

--- a/docs/proof/apply-cursor-livelock/container-provenance.json
+++ b/docs/proof/apply-cursor-livelock/container-provenance.json
@@ -2,18 +2,18 @@
   "schema": "clawsweeper-real-boundary-proof-provenance/v1",
   "claim": "The pushed apply-cursor livelock fix passes its production-shaped fixture and wrap/cycle probes inside a fresh PR checkout mounted into node:24-bookworm.",
   "pull_request": "https://github.com/openclaw/clawsweeper/pull/1129",
-  "reviewed_head": "c87bd96db0bc34a0f7dcad95067973fe1853951a",
+  "reviewed_head": "e6e534fc39eec471a447d8b956a0c24dd3ee97ca",
   "crabbox": {
     "cli_version": "0.38.3-5-g2a79805d",
     "provider": "aws",
-    "lease_id": "cbx_b2223e33b8a4",
-    "slug": "brisk-hermit-0fc9",
-    "run_id": "run_1623fae6fdec",
+    "lease_id": "cbx_20b3853d5df2",
+    "slug": "quick-krill-bd9c",
+    "run_id": "run_dbbae04e9b37",
     "machine_type": "c7a.8xlarge",
     "checkout": "--fresh-pr openclaw/clawsweeper#1129 --no-hydrate",
-    "sync_ms": 8027,
-    "command_ms": 21356,
-    "total_ms": 29567,
+    "sync_ms": 7566,
+    "command_ms": 32631,
+    "total_ms": 45392,
     "exit_code": 0,
     "run_status": "succeeded",
     "lease_stopped": true
@@ -27,7 +27,7 @@
     "jq": "jq-1.8.2",
     "jq_asset": "jq-linux-amd64",
     "jq_sha256": "b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f",
-    "jq_checksum_source": "https://github.com/jqlang/jq/releases/download/jq-1.8.2/sha256sum.txt",
+    "jq_checksum_source": "Repository-pinned jq_sha256 in container-proof.sh, sourced from the official jq 1.8.2 release manifest",
     "jq_checksum_verified": true,
     "jq_install_path": "/usr/local/bin/jq"
   },
@@ -45,7 +45,7 @@
     "skipped": 0,
     "proof_rc": 0
   },
-  "prior_harness_attempts": [
+  "prior_runs": [
     {
       "run_id": "run_5af9ddacd3db",
       "lease_id": "cbx_32c86f65b7c1",
@@ -75,6 +75,15 @@
       "reviewed_head": "33badc338a04f4bb30c2a09ad2c701f7c60e4fe6",
       "reason": "Two wrap/helper tests launched their own login shells and could not resolve jq from a temporary directory.",
       "fixture_assertions_passed": true,
+      "lease_released": true
+    },
+    {
+      "run_id": "run_1623fae6fdec",
+      "lease_id": "cbx_b2223e33b8a4",
+      "reviewed_head": "c87bd96db0bc34a0f7dcad95067973fe1853951a",
+      "result": "succeeded",
+      "reason_superseded": "A fresh ClawSweeper review requested a repository-controlled checksum trust root.",
+      "tests_passed": 4,
       "lease_released": true
     }
   ],

--- a/docs/proof/apply-cursor-livelock/container-provenance.json
+++ b/docs/proof/apply-cursor-livelock/container-provenance.json
@@ -1,19 +1,19 @@
 {
   "schema": "clawsweeper-real-boundary-proof-provenance/v1",
-  "claim": "The pushed apply-cursor livelock fix passes its production-shaped fixture and wrap/cycle probes inside a fresh PR checkout mounted into node:24-bookworm.",
+  "claim": "The committed apply-cursor livelock fix passes its production-shaped fixture, adversarial apply-loop scenario, and wrap/cycle probes inside node:24-bookworm.",
   "pull_request": "https://github.com/openclaw/clawsweeper/pull/1129",
-  "reviewed_head": "e6e534fc39eec471a447d8b956a0c24dd3ee97ca",
+  "reviewed_head": "2ebe882831f99d9f22dd6f696f48d2a4e80f3195",
   "crabbox": {
     "cli_version": "0.38.3-5-g2a79805d",
     "provider": "aws",
-    "lease_id": "cbx_20b3853d5df2",
-    "slug": "quick-krill-bd9c",
-    "run_id": "run_dbbae04e9b37",
+    "lease_id": "cbx_a9f86ad7a357",
+    "slug": "quick-prawn-5920",
+    "run_id": "run_61dcc42eb8d2",
     "machine_type": "c7a.8xlarge",
-    "checkout": "--fresh-pr openclaw/clawsweeper#1129 --no-hydrate",
-    "sync_ms": 7566,
-    "command_ms": 32631,
-    "total_ms": 45392,
+    "checkout": "clean committed worktree raw-sync, --no-hydrate",
+    "sync_ms": 20819,
+    "command_ms": 24276,
+    "total_ms": 46687,
     "exit_code": 0,
     "run_status": "succeeded",
     "lease_stopped": true
@@ -32,20 +32,38 @@
     "jq_install_path": "/usr/local/bin/jq"
   },
   "result": {
-    "command": "docker run --rm -v $PWD:/workspace -w /workspace node:24-bookworm bash docs/proof/apply-cursor-livelock/container-proof.sh",
+    "command": "docker run --rm -e APPLY_CURSOR_PROOF_HEAD=2ebe882831f99d9f22dd6f696f48d2a4e80f3195 -v $PWD:/workspace -w /workspace node:24-bookworm bash docs/proof/apply-cursor-livelock/container-proof.sh",
     "fixture_assertions": {
       "old_order_livelocks": true,
       "current_order_advances_terminal_frontier": true,
-      "clipped_frontier_blocks": true
+      "clipped_frontier_blocks": true,
+      "apply_loop_executes_frontier_first": true,
+      "adversarial_order_advances_terminal_frontier": true
     },
-    "tests": 4,
-    "passed": 4,
+    "tests": 5,
+    "passed": 5,
     "failed": 0,
     "cancelled": 0,
     "skipped": 0,
     "proof_rc": 0
   },
   "prior_runs": [
+    {
+      "run_id": "run_f29c14106b53",
+      "lease_id": "cbx_e7d5148b9beb",
+      "reviewed_head": "07e0a7764cc39a014eea119db12e1fb82806f998",
+      "reason": "Raw sync intentionally omitted linked-worktree Git metadata required by the original proof wrapper.",
+      "product_tests_started": false,
+      "lease_released": true
+    },
+    {
+      "run_id": "run_fdaf84682c9e",
+      "lease_id": "cbx_e0ec212513fc",
+      "reviewed_head": "54db6da068abec31758a09e8fc1217626b26c2e5",
+      "reason": "The adversarial synthetic record allowed an incidental GitHub probe; the final fixture forces the credential-free path.",
+      "fixture_started": true,
+      "lease_released": true
+    },
     {
       "run_id": "run_5af9ddacd3db",
       "lease_id": "cbx_32c86f65b7c1",
@@ -90,6 +108,6 @@
   "limits": [
     "Synthetic filesystem records; no GitHub API calls or credentials were present in the container.",
     "The run proves selector/completion and wrap/cycle behavior, not production GitHub latency.",
-    "The receipt commit changes documentation only; reviewed_head is the exact pushed code and proof-harness head exercised by Crabbox."
+    "The receipt commit changes documentation only; reviewed_head is the exact committed code and proof-harness head exercised by Crabbox."
   ]
 }

--- a/docs/proof/apply-cursor-livelock/container-provenance.json
+++ b/docs/proof/apply-cursor-livelock/container-provenance.json
@@ -1,0 +1,86 @@
+{
+  "schema": "clawsweeper-real-boundary-proof-provenance/v1",
+  "claim": "The pushed apply-cursor livelock fix passes its production-shaped fixture and wrap/cycle probes inside a fresh PR checkout mounted into node:24-bookworm.",
+  "pull_request": "https://github.com/openclaw/clawsweeper/pull/1129",
+  "reviewed_head": "c87bd96db0bc34a0f7dcad95067973fe1853951a",
+  "crabbox": {
+    "cli_version": "0.38.3-5-g2a79805d",
+    "provider": "aws",
+    "lease_id": "cbx_b2223e33b8a4",
+    "slug": "brisk-hermit-0fc9",
+    "run_id": "run_1623fae6fdec",
+    "machine_type": "c7a.8xlarge",
+    "checkout": "--fresh-pr openclaw/clawsweeper#1129 --no-hydrate",
+    "sync_ms": 8027,
+    "command_ms": 21356,
+    "total_ms": 29567,
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "container": {
+    "image": "node:24-bookworm",
+    "engine": "Docker 29.7.1",
+    "node": "v24.18.1",
+    "pnpm": "11.10.0",
+    "corepack": "enabled",
+    "jq": "jq-1.8.2",
+    "jq_asset": "jq-linux-amd64",
+    "jq_sha256": "b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f",
+    "jq_checksum_source": "https://github.com/jqlang/jq/releases/download/jq-1.8.2/sha256sum.txt",
+    "jq_checksum_verified": true,
+    "jq_install_path": "/usr/local/bin/jq"
+  },
+  "result": {
+    "command": "docker run --rm -v $PWD:/workspace -w /workspace node:24-bookworm bash docs/proof/apply-cursor-livelock/container-proof.sh",
+    "fixture_assertions": {
+      "old_order_livelocks": true,
+      "current_order_advances_terminal_frontier": true,
+      "clipped_frontier_blocks": true
+    },
+    "tests": 4,
+    "passed": 4,
+    "failed": 0,
+    "cancelled": 0,
+    "skipped": 0,
+    "proof_rc": 0
+  },
+  "prior_harness_attempts": [
+    {
+      "run_id": "run_5af9ddacd3db",
+      "lease_id": "cbx_32c86f65b7c1",
+      "reviewed_head": "8225b9d13e774d766ec75c224b3960a81cc0ebdc",
+      "reason": "The Docker-mounted linked ownership required an explicit Git safe.directory.",
+      "product_tests_started": false,
+      "lease_released": true
+    },
+    {
+      "run_id": "run_28f54a2542a6",
+      "lease_id": "cbx_32c86f65b7c1",
+      "reason": "A no-sync reuse targeted the lease default checkout instead of the fresh PR checkout.",
+      "product_tests_started": false,
+      "lease_released": true
+    },
+    {
+      "run_id": "run_b0bd5a3ab475",
+      "lease_id": "cbx_32c86f65b7c1",
+      "reviewed_head": "8225b9d13e774d766ec75c224b3960a81cc0ebdc",
+      "reason": "The fixture's nested login shell reset PATH before resolving the checksum-verified jq binary.",
+      "fixture_started": true,
+      "lease_released": true
+    },
+    {
+      "run_id": "run_1b6a7eb1c3b3",
+      "lease_id": "cbx_c61a1e135fc9",
+      "reviewed_head": "33badc338a04f4bb30c2a09ad2c701f7c60e4fe6",
+      "reason": "Two wrap/helper tests launched their own login shells and could not resolve jq from a temporary directory.",
+      "fixture_assertions_passed": true,
+      "lease_released": true
+    }
+  ],
+  "limits": [
+    "Synthetic filesystem records; no GitHub API calls or credentials were present in the container.",
+    "The run proves selector/completion and wrap/cycle behavior, not production GitHub latency.",
+    "The receipt commit changes documentation only; reviewed_head is the exact pushed code and proof-harness head exercised by Crabbox."
+  ]
+}

--- a/docs/proof/apply-cursor-livelock/fixture-result.json
+++ b/docs/proof/apply-cursor-livelock/fixture-result.json
@@ -31,6 +31,29 @@
       "RESULT cursor=105870 count=1 next=105870"
     ]
   },
+  "adversarial_order": {
+    "input_order": [
+      87267,
+      95788,
+      97566,
+      105342,
+      105870
+    ],
+    "frontier_input_index": 4,
+    "first_executed": 105870,
+    "examined_item_numbers": [
+      105870
+    ],
+    "completion": {
+      "persisted_cursor": 105870,
+      "cursor_advance_count": 1,
+      "next_cursor": 105870,
+      "stdout": [
+        "Comment synchronization yielded its bounded cursor window to scheduled maintenance.",
+        "RESULT cursor=105870 count=1 next=105870"
+      ]
+    }
+  },
   "clipped_frontier": {
     "persisted_cursor": 105854,
     "cursor_advance_count": 0,
@@ -43,7 +66,9 @@
   "assertions": {
     "old_order_livelocks": true,
     "current_order_advances_terminal_frontier": true,
-    "clipped_frontier_blocks": true
+    "clipped_frontier_blocks": true,
+    "apply_loop_executes_frontier_first": true,
+    "adversarial_order_advances_terminal_frontier": true
   },
   "limits": [
     "Synthetic filesystem records; no GitHub API calls or credentials.",

--- a/docs/proof/apply-cursor-livelock/fixture-result.json
+++ b/docs/proof/apply-cursor-livelock/fixture-result.json
@@ -1,0 +1,52 @@
+{
+  "schema": "clawsweeper-apply-cursor-livelock-proof/v1",
+  "production_run": "https://github.com/openclaw/clawsweeper/actions/runs/31544381133",
+  "fixture": {
+    "initial_cursor": 105854,
+    "frontier": 105870,
+    "clipped_item": 85937,
+    "selected_count": 40,
+    "terminal_urgent_count": 26
+  },
+  "old_order": {
+    "first_item": 97566,
+    "frontier_index": 39,
+    "persisted_cursor": 105854,
+    "cursor_advance_count": 0,
+    "next_cursor": null,
+    "stdout": [
+      "Comment sync made no cursor progress; the next scheduled batch retries it.",
+      "RESULT cursor=105854 count=0 next="
+    ]
+  },
+  "current_order": {
+    "first_item": 105870,
+    "frontier_index": 0,
+    "selector_next_cursor": 105870,
+    "persisted_cursor": 105870,
+    "cursor_advance_count": 1,
+    "next_cursor": 105870,
+    "stdout": [
+      "Comment synchronization yielded its bounded cursor window to scheduled maintenance.",
+      "RESULT cursor=105870 count=1 next=105870"
+    ]
+  },
+  "clipped_frontier": {
+    "persisted_cursor": 105854,
+    "cursor_advance_count": 0,
+    "next_cursor": null,
+    "stdout": [
+      "Comment sync made no cursor progress; the next scheduled batch retries it.",
+      "RESULT cursor=105854 count=0 next="
+    ]
+  },
+  "assertions": {
+    "old_order_livelocks": true,
+    "current_order_advances_terminal_frontier": true,
+    "clipped_frontier_blocks": true
+  },
+  "limits": [
+    "Synthetic filesystem records; no GitHub API calls or credentials.",
+    "The fixture proves cursor ordering and completion semantics, not production API latency."
+  ]
+}

--- a/docs/proof/apply-cursor-livelock/run-proof.mjs
+++ b/docs/proof/apply-cursor-livelock/run-proof.mjs
@@ -24,6 +24,7 @@ const frontier = 105870;
 const initialCursor = 105854;
 const clippedItem = 85937;
 const closedItem = 92460;
+const adversarialSelection = [87267, 95788, 97566, 105342, frontier];
 const examinedUrgentPrefix = productionSelection
   .slice(0, productionSelection.indexOf(clippedItem))
   .filter((number) => number !== closedItem);
@@ -98,6 +99,71 @@ async function currentSelection() {
 
 function pathToFileUrl(filePath) {
   return new URL(`file://${filePath}`).href;
+}
+
+function applyAdversarialOrder() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "apply-cursor-adversarial-"));
+  try {
+    const itemsDir = path.join(root, "items");
+    const closedDir = path.join(root, "closed");
+    const plansDir = path.join(root, "plans");
+    const reportPath = path.join(root, "apply-report.json");
+    const tracePath = path.join(root, "trace.json");
+    fs.mkdirSync(plansDir, { recursive: true });
+    adversarialSelection.forEach((number, index) => {
+      writeCandidate(
+        root,
+        number,
+        new Date(Date.UTC(2026, 7, 11, 23, 59, 59) - index * 1000).toISOString(),
+        false,
+      );
+    });
+    const recordDir = path.join(root, "records/openclaw-openclaw/items");
+    fs.renameSync(recordDir, itemsDir);
+
+    execFileSync(
+      process.execPath,
+      [
+        path.join(repoRoot, "dist/clawsweeper.js"),
+        "apply-decisions",
+        "--target-repo",
+        "openclaw/openclaw",
+        "--items-dir",
+        itemsDir,
+        "--closed-dir",
+        closedDir,
+        "--plans-dir",
+        plansDir,
+        "--report-path",
+        reportPath,
+        "--item-numbers",
+        adversarialSelection.join(","),
+        "--processed-limit",
+        "1",
+        "--limit",
+        "0",
+        "--close-delay-ms",
+        "0",
+        "--cursor-trace",
+        tracePath,
+        "--comment-sync-cursor",
+        String(initialCursor),
+      ],
+      { encoding: "utf8" },
+    );
+
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    const trace = JSON.parse(fs.readFileSync(tracePath, "utf8"));
+    return {
+      input_order: adversarialSelection,
+      frontier_input_index: adversarialSelection.indexOf(frontier),
+      first_executed: report[0]?.number ?? null,
+      examined_item_numbers: trace.examined_item_numbers,
+      completion: completeSelection(adversarialSelection, trace.examined_item_numbers, false),
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }
 
 function completeSelection(selected, examined, includeClosedRecord) {
@@ -177,6 +243,7 @@ if (missingCurrentItems.length > 0) {
 }
 const currentOrderResult = completeSelection(currentOrder, currentExamined, true);
 const clippedFrontierResult = completeSelection(currentOrder, [], false);
+const adversarialOrderResult = applyAdversarialOrder();
 
 const summary = {
   schema: "clawsweeper-apply-cursor-livelock-proof/v1",
@@ -199,6 +266,7 @@ const summary = {
     selector_next_cursor: Number(batch.next_cursor),
     ...currentOrderResult,
   },
+  adversarial_order: adversarialOrderResult,
   clipped_frontier: clippedFrontierResult,
   assertions: {
     old_order_livelocks:
@@ -211,6 +279,13 @@ const summary = {
     clipped_frontier_blocks:
       clippedFrontierResult.persisted_cursor === initialCursor &&
       clippedFrontierResult.cursor_advance_count === 0,
+    apply_loop_executes_frontier_first:
+      adversarialOrderResult.frontier_input_index === adversarialSelection.length - 1 &&
+      adversarialOrderResult.first_executed === frontier &&
+      adversarialOrderResult.examined_item_numbers[0] === frontier,
+    adversarial_order_advances_terminal_frontier:
+      adversarialOrderResult.completion.persisted_cursor === frontier &&
+      adversarialOrderResult.completion.cursor_advance_count > 0,
   },
   limits: [
     "Synthetic filesystem records; no GitHub API calls or credentials.",

--- a/docs/proof/apply-cursor-livelock/run-proof.mjs
+++ b/docs/proof/apply-cursor-livelock/run-proof.mjs
@@ -141,7 +141,7 @@ function completeSelection(selected, examined, includeClosedRecord) {
       'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
       'printf "RESULT cursor=%s count=%s next=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count" "$next_cursor"',
     ].join("\n");
-    const stdout = execFileSync("bash", ["-lc", script], {
+    const stdout = execFileSync("bash", ["-c", script], {
       cwd: root,
       encoding: "utf8",
       env: {

--- a/docs/proof/apply-cursor-livelock/run-proof.mjs
+++ b/docs/proof/apply-cursor-livelock/run-proof.mjs
@@ -37,7 +37,13 @@ const actionCycle = [
   "kept_open",
 ];
 
-function writeCandidate(root, number, reviewedAt, regular = false) {
+function writeCandidate(
+  root,
+  number,
+  reviewedAt,
+  regular = false,
+  localCheckoutAccess = "verified",
+) {
   const recordDir = path.join(root, "records/openclaw-openclaw/items");
   fs.mkdirSync(recordDir, { recursive: true });
   const lines = [
@@ -45,7 +51,7 @@ function writeCandidate(root, number, reviewedAt, regular = false) {
     "repository: openclaw/openclaw",
     `type: ${regular ? "pull_request" : "issue"}`,
     "review_status: complete",
-    "local_checkout_access: verified",
+    `local_checkout_access: ${localCheckoutAccess}`,
     "item_snapshot_hash: synthetic-proof",
     "action_taken: kept_open",
     `reviewed_at: ${reviewedAt}`,
@@ -116,6 +122,7 @@ function applyAdversarialOrder() {
         number,
         new Date(Date.UTC(2026, 7, 11, 23, 59, 59) - index * 1000).toISOString(),
         false,
+        "unverified",
       );
     });
     const recordDir = path.join(root, "records/openclaw-openclaw/items");
@@ -149,7 +156,10 @@ function applyAdversarialOrder() {
         "--comment-sync-cursor",
         String(initialCursor),
       ],
-      { encoding: "utf8" },
+      {
+        encoding: "utf8",
+        env: { ...process.env, GH_BIN: path.join(root, "missing-gh") },
+      },
     );
 
     const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));

--- a/docs/proof/apply-cursor-livelock/run-proof.mjs
+++ b/docs/proof/apply-cursor-livelock/run-proof.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const proofDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(proofDir, "../../..");
+const outputDir = process.env.APPLY_CURSOR_PROOF_OUTPUT
+  ? path.resolve(process.env.APPLY_CURSOR_PROOF_OUTPUT)
+  : proofDir;
+const workflowUtilsPath = path.join(repoRoot, "dist/repair/workflow-utils.js");
+const applyHelperPath = path.join(repoRoot, "scripts/apply-workflow-helpers.sh");
+
+const productionSelection = [
+  97566, 95788, 105342, 87267, 106572, 103879, 54578, 51049, 84583, 77625,
+  92866, 86237, 116478, 90508, 90414, 14968, 51620, 7057, 99654, 76980,
+  80234, 107099, 72721, 92460, 92201, 8299, 85937, 44925, 77306, 97680,
+  90556, 87491, 79820, 77943, 90062, 107761, 120718, 121659, 84276, 105870,
+];
+const frontier = 105870;
+const initialCursor = 105854;
+const clippedItem = 85937;
+const closedItem = 92460;
+const examinedUrgentPrefix = productionSelection
+  .slice(0, productionSelection.indexOf(clippedItem))
+  .filter((number) => number !== closedItem);
+
+const actionCycle = [
+  "review_comment_synced",
+  "skipped_changed_since_review",
+  "review_comment_synced",
+  "skipped_stale_review_comment_sync",
+  "kept_open",
+];
+
+function writeCandidate(root, number, reviewedAt, regular = false) {
+  const recordDir = path.join(root, "records/openclaw-openclaw/items");
+  fs.mkdirSync(recordDir, { recursive: true });
+  const lines = [
+    "---",
+    "repository: openclaw/openclaw",
+    `type: ${regular ? "pull_request" : "issue"}`,
+    "review_status: complete",
+    "local_checkout_access: verified",
+    "item_snapshot_hash: synthetic-proof",
+    "action_taken: kept_open",
+    `reviewed_at: ${reviewedAt}`,
+  ];
+  if (regular) {
+    lines.push(
+      "review_comment_id: 9105870",
+      "review_comment_url: https://github.com/openclaw/openclaw/pull/105870#issuecomment-9105870",
+      `review_comment_sha256: ${"a".repeat(64)}`,
+      `review_comment_synced_at: ${reviewedAt}`,
+    );
+  }
+  lines.push("---", "");
+  fs.writeFileSync(
+    path.join(recordDir, `openclaw-openclaw-${number}.md`),
+    `${lines.join("\n")}\n`,
+  );
+}
+
+async function currentSelection() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "apply-cursor-selection-"));
+  try {
+    const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+    fs.mkdirSync(path.dirname(cursorPath), { recursive: true });
+    fs.writeFileSync(cursorPath, JSON.stringify({ next_after_number: initialCursor }));
+    productionSelection.slice(0, -1).forEach((number, index) => {
+      writeCandidate(
+        root,
+        number,
+        new Date(Date.UTC(2026, 7, 11, 23, 59, 59) - index * 1000).toISOString(),
+      );
+    });
+    writeCandidate(root, frontier, "2026-08-11T22:00:00.000Z", true);
+    const { commentSyncBatchOutput } = await import(`${pathToFileUrl(workflowUtilsPath)}?proof=1`);
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      return commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 40,
+        cursorPath,
+      });
+    } finally {
+      process.chdir(previousCwd);
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function pathToFileUrl(filePath) {
+  return new URL(`file://${filePath}`).href;
+}
+
+function completeSelection(selected, examined, includeClosedRecord) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "apply-cursor-complete-"));
+  try {
+    const cursorPath = path.join(root, "cursor.json");
+    const tracePath = path.join(root, "trace.json");
+    const reportPath = path.join(root, "report.json");
+    fs.writeFileSync(cursorPath, JSON.stringify({ next_after_number: initialCursor }));
+    fs.writeFileSync(
+      tracePath,
+      JSON.stringify({ schema_version: 1, examined_item_numbers: examined }),
+    );
+    fs.writeFileSync(
+      reportPath,
+      JSON.stringify(
+        examined.map((number, index) => ({
+          number,
+          action: actionCycle[index % actionCycle.length],
+          reason: "synthetic production-shaped terminal outcome",
+        })),
+      ),
+    );
+    if (includeClosedRecord) {
+      const closedDir = path.join(root, "records/openclaw-openclaw/closed");
+      fs.mkdirSync(closedDir, { recursive: true });
+      fs.writeFileSync(path.join(closedDir, `${closedItem}.md`), "synthetic closed record\n");
+    }
+    const script = [
+      'export PATH="$NODE_BIN_DIR:$PATH"',
+      'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+      'source "$APPLY_HELPER_PATH"',
+      'TARGET_REPO="openclaw/openclaw"',
+      "target_slug=openclaw-openclaw",
+      'cursor_path="$CURSOR_PATH"',
+      "sync_open_pr_batch=true",
+      "scheduled_comment_sync=true",
+      `comment_sync_initial_cursor=${initialCursor}`,
+      `item_numbers=${selected.join(",")}`,
+      `next_cursor=${frontier}`,
+      'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+      'printf "RESULT cursor=%s count=%s next=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count" "$next_cursor"',
+    ].join("\n");
+    const stdout = execFileSync("bash", ["-lc", script], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_BIN_DIR: path.dirname(process.execPath),
+        WORKFLOW_UTILS_PATH: workflowUtilsPath,
+        APPLY_HELPER_PATH: applyHelperPath,
+        CURSOR_PATH: cursorPath,
+        REPORT_PATH: reportPath,
+        TRACE_PATH: tracePath,
+      },
+    });
+    const match = stdout.match(/RESULT cursor=(\d+) count=(\d+) next=(\d*)/);
+    if (!match) throw new Error(`missing completion result: ${stdout}`);
+    return {
+      persisted_cursor: Number(match[1]),
+      cursor_advance_count: Number(match[2]),
+      next_cursor: match[3] ? Number(match[3]) : null,
+      stdout: stdout.trim().split("\n"),
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const batch = await currentSelection();
+const currentOrder = batch.item_numbers.split(",").map(Number);
+const oldOrderResult = completeSelection(productionSelection, examinedUrgentPrefix, true);
+const currentExamined = [frontier, ...examinedUrgentPrefix];
+const missingCurrentItems = currentExamined.filter((number) => !currentOrder.includes(number));
+if (missingCurrentItems.length > 0) {
+  throw new Error(`current selector omitted examined fixtures: ${missingCurrentItems.join(",")}`);
+}
+const currentOrderResult = completeSelection(currentOrder, currentExamined, true);
+const clippedFrontierResult = completeSelection(currentOrder, [], false);
+
+const summary = {
+  schema: "clawsweeper-apply-cursor-livelock-proof/v1",
+  production_run: "https://github.com/openclaw/clawsweeper/actions/runs/31544381133",
+  fixture: {
+    initial_cursor: initialCursor,
+    frontier,
+    clipped_item: clippedItem,
+    selected_count: productionSelection.length,
+    terminal_urgent_count: examinedUrgentPrefix.length + 1,
+  },
+  old_order: {
+    first_item: productionSelection[0],
+    frontier_index: productionSelection.indexOf(frontier),
+    ...oldOrderResult,
+  },
+  current_order: {
+    first_item: currentOrder[0],
+    frontier_index: currentOrder.indexOf(frontier),
+    selector_next_cursor: Number(batch.next_cursor),
+    ...currentOrderResult,
+  },
+  clipped_frontier: clippedFrontierResult,
+  assertions: {
+    old_order_livelocks:
+      oldOrderResult.persisted_cursor === initialCursor &&
+      oldOrderResult.cursor_advance_count === 0,
+    current_order_advances_terminal_frontier:
+      currentOrder[0] === frontier &&
+      currentOrderResult.persisted_cursor === frontier &&
+      currentOrderResult.cursor_advance_count > 0,
+    clipped_frontier_blocks:
+      clippedFrontierResult.persisted_cursor === initialCursor &&
+      clippedFrontierResult.cursor_advance_count === 0,
+  },
+  limits: [
+    "Synthetic filesystem records; no GitHub API calls or credentials.",
+    "The fixture proves cursor ordering and completion semantics, not production API latency.",
+  ],
+};
+
+if (!Object.values(summary.assertions).every(Boolean)) {
+  throw new Error(`proof assertion failed: ${JSON.stringify(summary.assertions)}`);
+}
+
+fs.mkdirSync(outputDir, { recursive: true });
+fs.writeFileSync(path.join(outputDir, "fixture-result.json"), `${JSON.stringify(summary, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+process.stdout.write("APPLY_CURSOR_FIXTURE_OK\n");

--- a/docs/proof/apply-cursor-livelock/run-proof.sh
+++ b/docs/proof/apply-cursor-livelock/run-proof.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$proof_dir" rev-parse --show-toplevel)"
+
+finish() {
+  local proof_rc=$?
+  echo "PROOF_RC=$proof_rc"
+}
+trap finish EXIT
+
+cd "$repo_root"
+export CI=1
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/bin}"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME"
+fi
+
+echo "node=$(node --version)"
+echo "pnpm=$(pnpm --version)"
+echo "jq=$(jq --version)"
+echo "head=$(git rev-parse HEAD)"
+
+pnpm install --frozen-lockfile
+pnpm run build:all
+node "$proof_dir/run-proof.mjs"
+node --test \
+  --test-name-pattern='urgent all-item repair|comment sync advances a completed frontier|wrapped cursor synchronization|wrapped urgent comment-sync batches' \
+  test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts
+
+echo "APPLY_CURSOR_PROOF_OK"

--- a/docs/proof/apply-cursor-livelock/run-proof.sh
+++ b/docs/proof/apply-cursor-livelock/run-proof.sh
@@ -28,7 +28,7 @@ pnpm install --frozen-lockfile
 pnpm run build:all
 node "$proof_dir/run-proof.mjs"
 node --test \
-  --test-name-pattern='urgent all-item repair|comment sync advances a completed frontier|wrapped cursor synchronization|wrapped urgent comment-sync batches' \
-  test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts
+  --test-name-pattern='numeric comment-sync frontier|urgent all-item repair|comment sync advances a completed frontier|wrapped cursor synchronization|wrapped urgent comment-sync batches' \
+  test/apply-cursor-trace.test.ts test/repair/workflow-utils.test.ts test/sweep-workflow.test.ts
 
 echo "APPLY_CURSOR_PROOF_OK"

--- a/docs/proof/apply-cursor-livelock/run-proof.sh
+++ b/docs/proof/apply-cursor-livelock/run-proof.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(git -C "$proof_dir" rev-parse --show-toplevel)"
+repo_root="$(cd "$proof_dir/../../.." && pwd)"
 
 finish() {
   local proof_rc=$?
@@ -22,7 +22,11 @@ fi
 echo "node=$(node --version)"
 echo "pnpm=$(pnpm --version)"
 echo "jq=$(jq --version)"
-echo "head=$(git rev-parse HEAD)"
+proof_head="${APPLY_CURSOR_PROOF_HEAD:-}"
+if [ -z "$proof_head" ]; then
+  proof_head="$(git rev-parse HEAD)"
+fi
+echo "head=$proof_head"
 
 pnpm install --frozen-lockfile
 pnpm run build:all

--- a/scripts/apply-workflow-helpers.sh
+++ b/scripts/apply-workflow-helpers.sh
@@ -55,6 +55,13 @@ normalize_comment_sync_mode() {
   fi
 }
 
+prepare_comment_sync_cursor_arg() {
+  comment_sync_cursor_arg=()
+  if [ "${sync_open_pr_batch:-false}" = "true" ]; then
+    comment_sync_cursor_arg=(--comment-sync-cursor "${comment_sync_initial_cursor:-0}")
+  fi
+}
+
 trim_comment_sync_cycle_batch() {
   if [ "${comment_sync_cycle_wrapped:-false}" != "true" ] ||
     [ "${comment_sync_cycle_start:-0}" -le 0 ] ||
@@ -242,13 +249,26 @@ complete_comment_sync_batch() {
       completed_csv="${completed_csv:+$completed_csv,}$selected_item"
     fi
   done
+  # Apply removes an interrupted current item before writing this trace, so
+  # completed_csv is the terminal execution prefix. An empty prefix returns
+  # below before any wrap-cycle state can be persisted.
+  local execution_order_items=()
+  if [ -n "$completed_csv" ]; then
+    IFS=, read -r -a execution_order_items <<<"$completed_csv"
+  fi
+  for selected_item in "${selected_items[@]}"; do
+    case ",$completed_csv," in
+      *",$selected_item,"*) ;;
+      *) execution_order_items+=("$selected_item") ;;
+    esac
+  done
   local completed_count=0
   local cursor_count=0
   local safe_cursor=""
   local blocked_prefix=false
   local initial_cursor="${comment_sync_initial_cursor:-0}"
   local unfinished_items=()
-  for selected_item in "${selected_items[@]}"; do
+  for selected_item in "${execution_order_items[@]}"; do
     case ",$completed_csv," in
       *",$selected_item,"*)
         completed_count=$((completed_count + 1))
@@ -310,8 +330,8 @@ complete_comment_sync_batch() {
         ! comment_sync_uses_automatic_policy; }; then
       local cycle_start="${comment_sync_cycle_start:-0}"
       local cycle_wrapped="${comment_sync_cycle_wrapped:-false}"
-      if [ "${#selected_items[@]}" -gt 0 ] &&
-        [ "${selected_items[0]}" -le "$initial_cursor" ] &&
+      if [ "${#execution_order_items[@]}" -gt 0 ] &&
+        [ "${execution_order_items[0]}" -le "$initial_cursor" ] &&
         [ "$initial_cursor" -gt 0 ] &&
         [ "$safe_cursor" -le "$initial_cursor" ]; then
         cycle_wrapped=true
@@ -335,8 +355,8 @@ complete_comment_sync_batch() {
         fi
       fi
       if [ "$cycle_wrapped" = "true" ] &&
-        [ "${#selected_items[@]}" -gt 0 ] &&
-        [ "${selected_items[0]}" -le "$cycle_start" ] &&
+        [ "${#execution_order_items[@]}" -gt 0 ] &&
+        [ "${execution_order_items[0]}" -le "$cycle_start" ] &&
         [ "$safe_cursor" -ge "$cycle_start" ]; then
         lookahead_count=0
       fi

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -212,6 +212,13 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     const artifactDir = resolve(stringArg(args.artifact_dir, join(ROOT, "artifacts", "apply")));
     const cursorTraceArg = stringArg(args.cursor_trace, "").trim();
     const cursorTracePath = cursorTraceArg ? resolve(cursorTraceArg) : null;
+    const commentSyncCursor = optionalNumberArg(args.comment_sync_cursor);
+    if (
+      commentSyncCursor !== undefined &&
+      (!Number.isSafeInteger(commentSyncCursor) || commentSyncCursor < 0)
+    ) {
+      throw new Error("Invalid --comment-sync-cursor");
+    }
     const prCloseCoverageProofRuntime: PrCloseCoverageProofRuntime = {
       model: stringArg(args.codex_model, DEFAULT_CODEX_MODEL),
       reasoningEffort: stringArg(args.codex_reasoning_effort, DEFAULT_REASONING_EFFORT),
@@ -241,6 +248,18 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     const requestedItemOrderIndex = new Map(
       requestedItemOrder.map((number, index) => [number, index]),
     );
+    const advancingCommentSyncNumbers =
+      commentSyncCursor === undefined
+        ? []
+        : requestedItemNumbers.filter((number) => number > commentSyncCursor);
+    const commentSyncFrontier =
+      commentSyncCursor === undefined || requestedItemNumbers.length === 0
+        ? undefined
+        : Math.min(
+            ...(advancingCommentSyncNumbers.length > 0
+              ? advancingCommentSyncNumbers
+              : requestedItemNumbers),
+          );
     const results: ApplyResult[] = [];
     const examinedItemNumbers: number[] = [];
     let closedCount = 0;
@@ -283,15 +302,22 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     });
 
     const fileEntries = applyReportEntriesForDir(itemsDir, "items").sort(
-      cursorTracePath
+      commentSyncFrontier !== undefined
         ? (left, right) =>
+            Number(right.number === commentSyncFrontier) -
+              Number(left.number === commentSyncFrontier) ||
             (requestedItemOrderIndex.get(left.number) ?? Number.MAX_SAFE_INTEGER) -
               (requestedItemOrderIndex.get(right.number) ?? Number.MAX_SAFE_INTEGER) ||
             left.number - right.number
-        : (left, right) =>
-            left.priority - right.priority ||
-            left.applyCheckedAt - right.applyCheckedAt ||
-            left.number - right.number,
+        : cursorTracePath
+          ? (left, right) =>
+              (requestedItemOrderIndex.get(left.number) ?? Number.MAX_SAFE_INTEGER) -
+                (requestedItemOrderIndex.get(right.number) ?? Number.MAX_SAFE_INTEGER) ||
+              left.number - right.number
+          : (left, right) =>
+              left.priority - right.priority ||
+              left.applyCheckedAt - right.applyCheckedAt ||
+              left.number - right.number,
     );
     const files = fileEntries.map((entry) => entry.name);
     const boundedExactSelection = exactEventPublication && requestedItemNumberSet.size > 0;
@@ -452,7 +478,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       return;
     }
     logProgress(
-      `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} suppress_automation_markers=${suppressAutomationMarkers} comment_sync_min_age_days=${commentSyncMinAgeDays} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"} reconciliation_deferred=${[...reconciliationDeferredItemNumbers].join(",") || "none"}`,
+      `starting apply: files=${files.length} dry_run=${dryRun} apply_kind=${applyKind} min_age=${minAgeDescription} apply_close_reasons=${closeReasonFilterText(applyCloseReasons)} stale_min_age_days=${staleMinAgeDays} close_delay_ms=${closeDelayMs} sync_comments_only=${syncCommentsOnly} suppress_automation_markers=${suppressAutomationMarkers} comment_sync_min_age_days=${commentSyncMinAgeDays} comment_sync_cursor=${commentSyncCursor ?? "none"} max_runtime_ms=${maxRuntimeMs} item_numbers=${requestedItemNumbers.join(",") || "all"} reconciliation_deferred=${[...reconciliationDeferredItemNumbers].join(",") || "none"}`,
     );
     // oxfmt-ignore
     for (const entry of fileEntries) {

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -1220,15 +1220,6 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       }
       const earlyLeaseState = refreshReviewStartLeaseState();
       existingReviewComment = earlyLeaseState.comment;
-      if (!dryRun && existingReviewComment) {
-        const durableCommentId = commentId(existingReviewComment);
-        cleanupSupersededReviewPlaceholderComments({
-          number,
-          comments: earlyLeaseState.comments,
-          keepCommentIds:
-            durableCommentId === null ? new Set<number>() : new Set([durableCommentId]),
-        });
-      }
       if (state === "open" && earlyLeaseState.blockReason) {
         if (recordReviewLeaseSkip(earlyLeaseState.blockReason)) break;
         continue;

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -1999,7 +1999,10 @@ export function commentSyncBatchOutput(options: CommentSyncBatchOptions): Record
       : candidates
           .filter((number) => number > 0 && !urgentSet.has(number))
           .slice(0, options.batchSize - urgent.length);
-  const selected = [...urgent, ...regular];
+  // The numeric frontier owns cursor progress. Run its first record before
+  // opportunistic urgent repairs so a slow urgent window cannot repeatedly
+  // exhaust the runtime budget without ever reaching the frontier.
+  const selected = regular.length > 0 ? [regular[0]!, ...urgent, ...regular.slice(1)] : urgent;
   const highestUrgent = urgent.length > 0 ? Math.max(...urgent) : cursor;
   const urgentCanAdvanceCursor =
     urgent.length > 0 &&

--- a/test/apply-cursor-trace.test.ts
+++ b/test/apply-cursor-trace.test.ts
@@ -62,6 +62,111 @@ test("apply-decisions preserves auto-selected order and traces only examined rec
   }
 });
 
+test("apply-decisions runs the numeric comment-sync frontier before ascending urgent items", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const tracePath = join(root, "apply-cursor-trace.json");
+    const wrappedReportPath = join(root, "wrapped-apply-report.json");
+    const wrappedTracePath = join(root, "wrapped-apply-cursor-trace.json");
+    const unsortedReportPath = join(root, "unsorted-apply-report.json");
+    const unsortedTracePath = join(root, "unsorted-apply-cursor-trace.json");
+    const ascending = [87267, 95788, 97566, 105342, 105870];
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    for (const number of ascending) {
+      writeFileSync(
+        join(itemsDir, `${number}.md`),
+        workPlanCandidateReport({
+          repository: "openclaw/openclaw",
+          number,
+          local_checkout_access: "unverified",
+          decision: "keep_open",
+          action_taken: "kept_open",
+        }),
+        "utf8",
+      );
+    }
+
+    runApplyDecisionsForTest({
+      itemsDir,
+      closedDir,
+      plansDir,
+      reportPath,
+      extraArgs: [
+        "--target-repo",
+        "openclaw/openclaw",
+        "--item-numbers",
+        ascending.join(","),
+        "--processed-limit",
+        "1",
+        "--cursor-trace",
+        tracePath,
+        "--comment-sync-cursor",
+        "105854",
+      ],
+    });
+
+    const report = JSON.parse(readFileSync(reportPath, "utf8"));
+    const trace = JSON.parse(readFileSync(tracePath, "utf8"));
+    assert.equal(report[0]?.number, 105870);
+    assert.deepEqual(trace, { schema_version: 1, examined_item_numbers: [105870] });
+
+    runApplyDecisionsForTest({
+      itemsDir,
+      closedDir,
+      plansDir,
+      reportPath: wrappedReportPath,
+      extraArgs: [
+        "--target-repo",
+        "openclaw/openclaw",
+        "--item-numbers",
+        ascending.join(","),
+        "--processed-limit",
+        "1",
+        "--cursor-trace",
+        wrappedTracePath,
+        "--comment-sync-cursor",
+        "200000",
+      ],
+    });
+
+    const wrappedReport = JSON.parse(readFileSync(wrappedReportPath, "utf8"));
+    const wrappedTrace = JSON.parse(readFileSync(wrappedTracePath, "utf8"));
+    assert.equal(wrappedReport[0]?.number, 87267);
+    assert.deepEqual(wrappedTrace, { schema_version: 1, examined_item_numbers: [87267] });
+
+    runApplyDecisionsForTest({
+      itemsDir,
+      closedDir,
+      plansDir,
+      reportPath: unsortedReportPath,
+      extraArgs: [
+        "--target-repo",
+        "openclaw/openclaw",
+        "--item-numbers",
+        "105342,105870,87267,97566,95788",
+        "--processed-limit",
+        "1",
+        "--cursor-trace",
+        unsortedTracePath,
+        "--comment-sync-cursor",
+        "90000",
+      ],
+    });
+
+    const unsortedReport = JSON.parse(readFileSync(unsortedReportPath, "utf8"));
+    const unsortedTrace = JSON.parse(readFileSync(unsortedTracePath, "utf8"));
+    assert.equal(unsortedReport[0]?.number, 95788);
+    assert.deepEqual(unsortedTrace, { schema_version: 1, examined_item_numbers: [95788] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("exact-event apply does not read unrelated canonical records", () => {
   const root = mkdtempSync(tmpPrefix);
   try {

--- a/test/repair/workflow-utils.test.ts
+++ b/test/repair/workflow-utils.test.ts
@@ -2988,7 +2988,7 @@ test("durable all-item sync publishes guarded reviews without selecting terminal
         }),
       ),
       {
-        item_numbers: "160,170,180,30,70,150,10,20,40,50,60,80,90,100,110,190,210",
+        item_numbers: "10,160,170,180,30,70,150,20,40,50,60,80,90,100,110,190,210",
         count: "17",
         cursor: "0",
         next_cursor: "210",
@@ -3163,7 +3163,7 @@ test("checked-only comments and failed durable repairs remain eligible until syn
         .item_numbers.split(",")
         .filter(Boolean)
         .map(Number);
-    assert.deepEqual(select(), [201, 202, 203, 204, 500]);
+    assert.deepEqual(select(), [204, 201, 202, 203, 500]);
     for (const number of [201, 202, 203]) {
       const reportPath = path.join(
         root,
@@ -3236,7 +3236,7 @@ test("refreshed and timestamp-less guarded reviews cross an existing automatic c
     );
     const selected = result.item_numbers.split(",").map(Number);
 
-    assert.deepEqual(selected.slice(0, 3), [5, 7, 6]);
+    assert.deepEqual(selected.slice(0, 4), [101, 5, 7, 6]);
     assert.equal(selected.length, 40);
     assert.equal(result.next_cursor, "137");
     assert.equal(result.wrapped, "false");
@@ -3274,7 +3274,7 @@ test("post-sync guarded action changes return to the durable comment queue", () 
       }),
     );
 
-    assert.equal(result.item_numbers, "10,20,30,40");
+    assert.equal(result.item_numbers, "40,10,20,30");
     assert.equal(result.count, "4");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -3368,7 +3368,7 @@ test("unverified checkouts and timestamp-less comments never monopolize urgent s
   }
 });
 
-test("all-item sync prioritizes a newly reviewed record ahead of fresh PR maintenance", () => {
+test("all-item sync reserves its first slot for cursor progress before urgent maintenance", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
   const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
   const fresh = new Date(Date.now() - 60_000).toISOString();
@@ -3395,9 +3395,47 @@ test("all-item sync prioritizes a newly reviewed record ahead of fresh PR mainte
     const selected = result.item_numbers.split(",").map(Number);
 
     assert.equal(selected.length, 40);
-    assert.equal(selected[0], 9999);
+    assert.deepEqual(selected.slice(0, 2), [1, 9999]);
     assert.equal(selected.includes(40), false);
+    assert.equal(result.next_cursor, "39");
     assert.equal(result.wrapped, "false");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("urgent all-item repair keeps the numeric cursor frontier first", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-workflow-"));
+  const cursorPath = path.join(root, "results/comment-sync-cursors/openclaw-openclaw.json");
+  const urgent = [97566, 95788, 105342, 87267, 106572];
+  try {
+    for (const [index, number] of urgent.entries()) {
+      writeCommentSyncRecord(root, number, "issue", "kept_open", {
+        reviewedAt: new Date(Date.UTC(2026, 7, 11, 22, index)).toISOString(),
+      });
+    }
+    const confirmedAt = "2026-08-11T22:00:00.000Z";
+    writeCommentSyncRecord(root, 105870, "pull_request", "kept_open", {
+      reviewCommentId: "9105870",
+      reviewCommentUrl: "https://github.com/openclaw/openclaw/pull/105870#issuecomment-9105870",
+      reviewCommentHash: "a".repeat(64),
+      reviewedAt: confirmedAt,
+      reviewCommentSyncedAt: confirmedAt,
+    });
+    writeCommentSyncCursor(cursorPath, 105854, "openclaw/openclaw");
+
+    const result = withCwd(root, () =>
+      commentSyncBatchOutput({
+        targetRepo: "openclaw/openclaw",
+        applyKind: "all",
+        batchSize: 6,
+        cursorPath,
+      }),
+    );
+
+    assert.equal(result.cursor, "105854");
+    assert.equal(result.next_cursor, "105870");
+    assert.deepEqual(result.item_numbers.split(",").map(Number), [105870, ...urgent.toReversed()]);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/review-comment-rendering.test.ts
+++ b/test/review-comment-rendering.test.ts
@@ -1794,7 +1794,7 @@ test("recovery cleanup preserves durable-review ordering and exact publication b
   assert.match(source.slice(recoveryCleanup, nextCatch), /removeLabel:\s*removeIssueLabel/);
 });
 
-test("placeholder sweep retries on every apply pass independent of comment body sync", () => {
+test("placeholder sweep waits for an authorized durable-comment mutation", () => {
   const source = readFileSync("src/clawsweeper-apply-decision-workflow.ts", "utf8");
   const earlyLeaseStart = source.indexOf("const earlyLeaseState = refreshReviewStartLeaseState();");
   assert.ok(earlyLeaseStart >= 0);
@@ -1804,6 +1804,6 @@ test("placeholder sweep retries on every apply pass independent of comment body 
   );
   assert.ok(needsReviewCommentSyncStart > earlyLeaseStart);
   const earlyWindow = source.slice(earlyLeaseStart, needsReviewCommentSyncStart);
-  assert.match(earlyWindow, /cleanupSupersededReviewPlaceholderComments\(\{/);
-  assert.match(earlyWindow, /comments:\s*earlyLeaseState\.comments/);
+  assert.doesNotMatch(earlyWindow, /cleanupSupersededReviewPlaceholderComments\(\{/);
+  assert.match(earlyWindow, /acquireApplyMutationLease\(lateLeaseState\)/);
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -3547,7 +3547,7 @@ test("urgent records do not falsely wrap a customized comment-sync cursor", () =
       },
     );
 
-    assert.match(output, /^selected=5,21,22,/m);
+    assert.match(output, /^selected=21,5,22,/m);
     assert.match(output, /^continue=true$/m);
     assert.match(output, /^next=__cursor__$/m);
     assert.match(output, /^persisted=59$/m);
@@ -4230,6 +4230,81 @@ test("comment synchronization checkpoints only completed records after a runtime
     assert.match(output, /^missing_prefix_cursor=20$/m);
     assert.doesNotMatch(output, /^missing_prefix_rejected$/m);
     assert.doesNotMatch(output, /^partial=30$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("comment sync advances a completed frontier before a budget-clipped urgent tail", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const cursorPath = join(root, "comment-sync-cursor.json");
+  const reportPath = join(root, "report.json");
+  const tracePath = join(root, "trace.json");
+  writeFileSync(cursorPath, JSON.stringify({ next_after_number: 105854 }));
+  writeFileSync(
+    reportPath,
+    JSON.stringify([
+      { number: 105870, action: "kept_open" },
+      { number: 97566, action: "review_comment_synced" },
+      { number: 95788, action: "skipped_changed_since_review" },
+      { number: 105342, action: "review_comment_synced" },
+      { number: 87267, action: "skipped_stale_review_comment_sync" },
+      { number: 106572, action: "kept_open" },
+      { number: 85937, action: "skipped_runtime_budget" },
+      { number: 0, action: "skipped_runtime_budget" },
+    ]),
+  );
+  writeFileSync(
+    tracePath,
+    JSON.stringify({
+      schema_version: 1,
+      examined_item_numbers: [105870, 97566, 95788, 105342, 87267, 106572],
+    }),
+  );
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-lc",
+        [
+          'export PATH="$NODE_BIN_DIR:$PATH"',
+          'pnpm() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ "$#" -gt 0 ] && shift; node "$WORKFLOW_UTILS_PATH" "$@"; }',
+          'source "$APPLY_HELPER_PATH"',
+          'TARGET_REPO="openclaw/openclaw"',
+          'cursor_path="$CURSOR_PATH"',
+          "sync_open_pr_batch=true",
+          "scheduled_comment_sync=true",
+          "comment_sync_initial_cursor=105854",
+          "item_numbers=105870,97566,95788,105342,87267,106572,85937,120718",
+          "next_cursor=105870",
+          'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
+          'printf "advanced=%s|count=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count"',
+          'pnpm run workflow -- write-comment-sync-cursor --cursor-path "$cursor_path" --next-cursor 105854 --target-repo "$TARGET_REPO"',
+          "item_numbers=105870,97566,95788,105342,87267,106572,85937,120718",
+          "next_cursor=105870",
+          'printf \'{"schema_version":1,"examined_item_numbers":[]}\' > clipped-trace.json',
+          'complete_comment_sync_batch "$REPORT_PATH" clipped-trace.json',
+          'printf "clipped=%s|count=%s|next=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count" "$next_cursor"',
+        ].join("\n"),
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_BIN_DIR: dirname(process.execPath),
+          WORKFLOW_UTILS_PATH: join(process.cwd(), "dist/repair/workflow-utils.js"),
+          APPLY_HELPER_PATH: join(process.cwd(), "scripts/apply-workflow-helpers.sh"),
+          CURSOR_PATH: cursorPath,
+          REPORT_PATH: reportPath,
+          TRACE_PATH: tracePath,
+        },
+      },
+    );
+
+    assert.match(output, /^advanced=105870\|count=1$/m);
+    assert.match(output, /^clipped=105854\|count=0\|next=$/m);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -2739,6 +2739,11 @@ test("apply workflow bounds checkpoints and requeues with a fresh token", () => 
     commentSyncBranch,
     /--cursor-trace "\.artifacts\/comment-sync-trace-\$checkpoint\.json"/,
   );
+  assert.match(commentSyncBranch, /"\$\{comment_sync_cursor_arg\[@\]\}"/);
+  assert.match(
+    applyHelper,
+    /comment_sync_cursor_arg=\(--comment-sync-cursor "\$\{comment_sync_initial_cursor:-0\}"\)/,
+  );
   assert.match(commentSyncBranch, /write_comment_sync_health/);
   assert.match(applyHelper, /"\$comment_sync_cursor_advance_count"/);
   const applyFlagInit = applyStep.indexOf('explicit_item_numbers="$item_numbers"');
@@ -4245,12 +4250,7 @@ test("comment sync advances a completed frontier before a budget-clipped urgent 
     reportPath,
     JSON.stringify([
       { number: 105870, action: "kept_open" },
-      { number: 97566, action: "review_comment_synced" },
-      { number: 95788, action: "skipped_changed_since_review" },
-      { number: 105342, action: "review_comment_synced" },
-      { number: 87267, action: "skipped_stale_review_comment_sync" },
-      { number: 106572, action: "kept_open" },
-      { number: 85937, action: "skipped_runtime_budget" },
+      { number: 87267, action: "skipped_runtime_budget" },
       { number: 0, action: "skipped_runtime_budget" },
     ]),
   );
@@ -4258,7 +4258,7 @@ test("comment sync advances a completed frontier before a budget-clipped urgent 
     tracePath,
     JSON.stringify({
       schema_version: 1,
-      examined_item_numbers: [105870, 97566, 95788, 105342, 87267, 106572],
+      examined_item_numbers: [105870],
     }),
   );
 
@@ -4276,12 +4276,12 @@ test("comment sync advances a completed frontier before a budget-clipped urgent 
           "sync_open_pr_batch=true",
           "scheduled_comment_sync=true",
           "comment_sync_initial_cursor=105854",
-          "item_numbers=105870,97566,95788,105342,87267,106572,85937,120718",
+          "item_numbers=87267,95788,97566,105342,105870",
           "next_cursor=105870",
           'complete_comment_sync_batch "$REPORT_PATH" "$TRACE_PATH"',
           'printf "advanced=%s|count=%s\\n" "$(jq -r .next_after_number "$cursor_path")" "$comment_sync_cursor_advance_count"',
           'pnpm run workflow -- write-comment-sync-cursor --cursor-path "$cursor_path" --next-cursor 105854 --target-repo "$TARGET_REPO"',
-          "item_numbers=105870,97566,95788,105342,87267,106572,85937,120718",
+          "item_numbers=87267,95788,97566,105342,105870",
           "next_cursor=105870",
           'printf \'{"schema_version":1,"examined_item_numbers":[]}\' > clipped-trace.json',
           'complete_comment_sync_batch "$REPORT_PATH" clipped-trace.json',


### PR DESCRIPTION
## Summary

Fix the ongoing `openclaw/openclaw` apply/comment-sync cursor livelock without raising its 300-second runtime budget.

Production run https://github.com/openclaw/clawsweeper/actions/runs/31544381133 selected 39 urgency-ranked records before the only numeric frontier record. It terminally evaluated 25 records, yielded at the runtime budget, and printed `Comment sync made no cursor progress`; the durable cursor therefore stayed at `#105854` and every later cycle selected the same window.

The selector still reserves its first slot for the numeric frontier, which helps non-apply consumers. The load-bearing guarantee now lives in the TypeScript apply loop: with an active comment-sync cursor, it computes the smallest selected item number strictly greater than the cursor and executes that record first regardless of incoming `item_numbers` position. If no selected number is greater, it wraps to the smallest selected number, matching the existing cycle bookkeeping. Cursor completion follows the trusted terminal execution trace rather than the shell list order, so downstream `sort` operations cannot recreate the starvation.

The branch also removes the redundant placeholder sweep attempted before apply-lease acquisition. Those deletes were correctly rejected locally with `apply mutation lease is not held`; the lease reaper then removed the expired placeholders through its authorized path. Post-publication placeholder cleanup remains intact.

## Behavior proof

- Claim: the apply loop executes a terminal numeric frontier first and advances the durable comment-sync cursor even when later urgent work is budget-clipped; clipping the frontier itself does not advance.
- Exercised surface: the real `apply-decisions` loop, `comment-sync-batch` selector, `complete_comment_sync_batch`, cursor writer, canonical closed-record fallback, and wrap/cycle regression seams.
- Scenario: the exact 40 item numbers and cursor/frontier from run `31544381133`, plus adversarial ascending input `[87267,95788,97566,105342,105870]` with frontier `#105870` last.
- Command/environment: `docs/proof/apply-cursor-livelock/run-proof.sh` on Node 24.19.0, pnpm 11.10.0, jq 1.8.2; synthetic filesystem records, no GitHub credentials or mutation.
- Observable result: the adversarial apply report and trace both recorded `#105870` first and persisted cursor `#105870` with every lower urgent record unexamined; the clipped-frontier replay persisted `#105854` with `cursor_count=0`; five focused apply/selector/completion/wrap probes passed.
- Artifact: `docs/proof/apply-cursor-livelock/fixture-result.json`, behavior contract/report, container provenance, and the scripted reproduction in the same directory.
- Limits: the fixture proves apply-loop ordering and cursor-completion semantics, not production GitHub latency. It does not claim urgent records no longer require later repair.

## Finding disposition

- Coordinator P1: accepted in substance. Shell normalization can reorder `item_numbers`; the loop-level numeric comparison is now the authoritative guarantee.
- Pre-commit P1 on `find()` ordering: accepted. The loop now uses an explicit numeric minimum, with forward, wrap, ascending, and unsorted coverage.
- Pre-commit P1 on clipped-frontier trace reconstruction: rejected after source verification. Apply removes an interrupted current item before writing the trusted trace; an empty terminal prefix returns with zero progress before wrap-cycle state can be persisted. The invariant is documented inline and covered by the runtime-yield continuation test.

## Validation

- `pnpm run check`: 3,336 tests; 3,327 passed, 9 skipped, 0 failed; coverage thresholds passed.
- Focused suite: 243 passed, 0 failed.
- Scripted behavior proof: 5 passed, 0 failed; `PROOF_RC=0`.
- Pre-commit and committed-branch Codex autoreviews: clean, no accepted/actionable P0/P1 findings.
- Crabbox container proof: passed on committed code/proof head `2ebe882831f99d9f22dd6f696f48d2a4e80f3195` through configured `provider=aws`, lease `cbx_a9f86ad7a357` (`quick-prawn-5920`), run `run_61dcc42eb8d2`, inside `node:24-bookworm`; 5/5 focused tests passed, exit 0, and lease cleanup is confirmed. Receipt commit `695d7beaca437fe03d1da003c4a69838c043602a` changes documentation only and was included in the same push.
- jq 1.8.2 trust root: the downloaded `jq-linux-amd64` binary matched repository-pinned SHA-256 `b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f` before installation.

## Scope

No runtime-budget increase, cursor schema change, close-policy change, `CHANGELOG.md`, or `CLAUDE.md` change.

OpenClaw Bay is unaffected: this changes internal apply-lane ordering and removes a redundant pre-lease cleanup attempt; no lifecycle publication or observer-only dashboard contract changes.
