### PR TITLE
improve: build queue status from one census

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -156,7 +156,7 @@ import {
   exactReviewQueueActiveReviewCount,
   exactReviewQueueAdmittedItems,
   exactReviewQueueBackoffReason,
-  exactReviewQueueBayProjection,
+  exactReviewQueueBayProjectionFromStats,
   exactReviewQueueBayPriorityKeys,
   exactReviewQueueCapacity as exactReviewQueueCapacityFromReadModel,
   exactReviewQueueLane,
@@ -3092,13 +3092,14 @@ export class ExactReviewQueue {
         legacyStateRepoBatchEnabled: exactReviewPublicationBatchingEnabled(this.env),
         maxConcurrentBatches: exactReviewPublicationBatchMaxConcurrent(this.env),
       });
+      const bayProjection = exactReviewQueueBayProjectionFromStats(
+        stats,
+        bayPriorityKeys,
+        batchByItemKey,
+      );
       return json({
         ...stats,
-        bay_projection: exactReviewQueueBayProjection(
-          Object.values(state.items),
-          bayPriorityKeys,
-          batchByItemKey,
-        ),
+        bay_projection: bayProjection,
         lanes: {
           review: {
             ...stats.lanes.review,

--- a/dashboard/exact-review-read-model.ts
+++ b/dashboard/exact-review-read-model.ts
@@ -1,7 +1,4 @@
-import {
-  summarizeExactReviewHandoff,
-  summarizeExactReviewPressure,
-} from "./exact-review-health.ts";
+import { summarizeExactReviewPressure } from "./exact-review-health.ts";
 import {
   exactReviewQueueHasCommandContext,
   exactReviewQueueIsBatchablePublication,
@@ -188,6 +185,78 @@ type ExactReviewBayProjectionItem = {
   batch_created_at?: string;
 };
 
+type ExactReviewQueueLaneCensus = {
+  pending: number;
+  ready: number;
+  backoff: number;
+  dispatching: number;
+  leased: number;
+  parked: number;
+  oldestPendingAt: number | null;
+  oldestPendingKey: string | null;
+  oldestReadyAt: number | null;
+  oldestBackoffAt: number | null;
+  nextAttemptAt: number | null;
+  backoffReasons: Record<string, number>;
+  parkedReasons: Record<string, number>;
+};
+
+type ExactReviewHandoffPhaseCensus = {
+  count: number;
+  oldestAt: number | null;
+  oldestKey: string | null;
+};
+
+type ExactReviewBayCensusCandidate = {
+  item: ExactReviewQueueItem;
+  itemKey: string;
+  repository: string;
+  itemNumber: number;
+  updatedAt: number;
+};
+
+type ExactReviewQueueCensus = {
+  items: ExactReviewQueueItem[];
+  review: ExactReviewQueueLaneCensus;
+  publication: ExactReviewQueueLaneCensus;
+  all: ExactReviewQueueLaneCensus;
+  activeReviews: number;
+  activePublishers: number;
+  activeReviewWakeAt: number[];
+  activePublisherWakeAt: number[];
+  activeTargetCounts: Map<string, number>;
+  activeTargetWakeAt: Map<string, number>;
+  activeWithoutLeaseOrExpired: boolean;
+  dispatcherAdmissionPaused: boolean;
+  pendingReviews: ExactReviewQueueItem[];
+  pendingPublications: ExactReviewQueueItem[];
+  readyReviews: ExactReviewQueueItem[];
+  readyPublications: ExactReviewQueueItem[];
+  parkedWakeCandidates: Array<{ recoveryAt: number | null; terminalCheckAt: number | null }>;
+  parkedTerminalLastCheckedAt: number;
+  targetAppRetryAtByOwner: Map<string, number>;
+  targets: Map<
+    string,
+    {
+      target_repo: string;
+      pending: number;
+      dispatching: number;
+      leased: number;
+      parked: number;
+      oldest_pending_at: number | null;
+    }
+  >;
+  handoffItemCount: number;
+  handoffPhases: Record<"pending" | "dispatching" | "leased", ExactReviewHandoffPhaseCensus>;
+  bayCandidates: Map<string, ExactReviewBayCensusCandidate[]>;
+};
+
+const EXACT_REVIEW_STATS_CENSUS = Symbol("exact-review-stats-census");
+
+type ExactReviewQueueStatsWithCensus = ReturnType<typeof exactReviewQueueStats> & {
+  [EXACT_REVIEW_STATS_CENSUS]?: ExactReviewQueueCensus;
+};
+
 export type ExactReviewBayBatchOwner = {
   batchId: string;
 };
@@ -225,67 +294,347 @@ export function exactReviewQueueBayPriorityKeys(values: string[]) {
   return [...unique];
 }
 
+function emptyExactReviewQueueLaneCensus(): ExactReviewQueueLaneCensus {
+  return {
+    pending: 0,
+    ready: 0,
+    backoff: 0,
+    dispatching: 0,
+    leased: 0,
+    parked: 0,
+    oldestPendingAt: null,
+    oldestPendingKey: null,
+    oldestReadyAt: null,
+    oldestBackoffAt: null,
+    nextAttemptAt: null,
+    backoffReasons: {},
+    parkedReasons: {},
+  };
+}
+
+function observeExactReviewQueueLane(
+  lane: ExactReviewQueueLaneCensus,
+  item: ExactReviewQueueItem,
+  state: ExactReviewQueueState,
+  now: number,
+) {
+  if (item.state === "pending") {
+    lane.pending += 1;
+    if (
+      lane.oldestPendingAt === null ||
+      item.createdAt < lane.oldestPendingAt ||
+      (item.createdAt === lane.oldestPendingAt &&
+        (lane.oldestPendingKey === null || item.key.localeCompare(lane.oldestPendingKey) < 0))
+    ) {
+      lane.oldestPendingAt = item.createdAt;
+      lane.oldestPendingKey = item.key;
+    }
+    lane.nextAttemptAt =
+      lane.nextAttemptAt === null
+        ? item.nextAttemptAt
+        : Math.min(lane.nextAttemptAt, item.nextAttemptAt);
+    if (item.nextAttemptAt <= now) {
+      lane.ready += 1;
+      lane.oldestReadyAt =
+        lane.oldestReadyAt === null ? item.createdAt : Math.min(lane.oldestReadyAt, item.createdAt);
+    } else {
+      lane.backoff += 1;
+      lane.oldestBackoffAt =
+        lane.oldestBackoffAt === null
+          ? item.createdAt
+          : Math.min(lane.oldestBackoffAt, item.createdAt);
+      incrementExactReviewReason(
+        lane.backoffReasons,
+        exactReviewQueueBackoffReason(item, state, now),
+      );
+    }
+    return;
+  }
+  if (item.state === "dispatching") {
+    lane.dispatching += 1;
+    return;
+  }
+  if (item.state === "leased") {
+    lane.leased += 1;
+    return;
+  }
+  lane.parked += 1;
+  incrementExactReviewReason(lane.parkedReasons, item.parkedReason || "unknown");
+}
+
+function incrementExactReviewReason(counts: Record<string, number>, reason: string) {
+  counts[reason] = (counts[reason] || 0) + 1;
+}
+
+function exactReviewQueueItemOrder(left: ExactReviewQueueItem, right: ExactReviewQueueItem) {
+  return left.createdAt - right.createdAt || left.key.localeCompare(right.key);
+}
+
+function exactReviewTargetAppRetryAtByOwner(state: ExactReviewQueueState, now: number) {
+  const retryAtByOwner = new Map<string, number>();
+  for (const circuit of exactReviewGithubCredentialCircuits(state)) {
+    if (circuit.scope !== "target_app" || circuit.retryAt <= now) continue;
+    const current = retryAtByOwner.get(circuit.targetOwner) || 0;
+    retryAtByOwner.set(circuit.targetOwner, Math.max(current, circuit.retryAt));
+  }
+  return retryAtByOwner;
+}
+
+function exactReviewTargetAppRetryAt(census: ExactReviewQueueCensus, targetRepo: string) {
+  return census.targetAppRetryAtByOwner.get(targetRepo.split("/", 1)[0]?.toLowerCase()) || 0;
+}
+
+function buildExactReviewQueueCensus(
+  items: ExactReviewQueueItem[],
+  {
+    state,
+    now,
+    dispatchLeaseMs = DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS,
+    executionLeaseMs = DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS,
+    publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+    heartbeatGraceMs = DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
+    excludedItemKeys = new Set<string>(),
+    collectBay = true,
+  }: {
+    state: ExactReviewQueueState;
+    now: number;
+    dispatchLeaseMs?: number;
+    executionLeaseMs?: number;
+    publicationDispatchLeaseMs?: number;
+    heartbeatGraceMs?: number;
+    excludedItemKeys?: ReadonlySet<string>;
+    collectBay?: boolean;
+  },
+): ExactReviewQueueCensus {
+  const review = emptyExactReviewQueueLaneCensus();
+  const publication = emptyExactReviewQueueLaneCensus();
+  const all = emptyExactReviewQueueLaneCensus();
+  const census: ExactReviewQueueCensus = {
+    items,
+    review,
+    publication,
+    all,
+    activeReviews: 0,
+    activePublishers: 0,
+    activeReviewWakeAt: [],
+    activePublisherWakeAt: [],
+    activeTargetCounts: new Map(),
+    activeTargetWakeAt: new Map(),
+    activeWithoutLeaseOrExpired: false,
+    dispatcherAdmissionPaused:
+      (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
+      Number(state.dispatcher?.retryAt || 0) > now,
+    pendingReviews: [],
+    pendingPublications: [],
+    readyReviews: [],
+    readyPublications: [],
+    parkedWakeCandidates: [],
+    parkedTerminalLastCheckedAt: Number(state.dispatcher?.parkedTerminalCheckedAt || 0),
+    targetAppRetryAtByOwner: exactReviewTargetAppRetryAtByOwner(state, now),
+    targets: new Map(),
+    handoffItemCount: 0,
+    handoffPhases: {
+      pending: { count: 0, oldestAt: null, oldestKey: null },
+      dispatching: { count: 0, oldestAt: null, oldestKey: null },
+      leased: { count: 0, oldestAt: null, oldestKey: null },
+    },
+    bayCandidates: new Map(),
+  };
+
+  const handoffNow = finiteExactReviewTimestamp(now, Date.now());
+  const safeDispatchLeaseMs = Math.max(
+    1_000,
+    finiteExactReviewNumber(dispatchLeaseMs, 10 * 60_000),
+  );
+  const safeExecutionLeaseMs = Math.max(
+    1_000,
+    finiteExactReviewNumber(executionLeaseMs, 130 * 60_000),
+  );
+
+  for (const item of items) {
+    const isPublication = exactReviewQueueIsPublication(item);
+    const lane = isPublication ? publication : review;
+    observeExactReviewQueueLane(lane, item, state, now);
+    observeExactReviewQueueLane(all, item, state, now);
+
+    const targetRepo = item.decision.targetRepo;
+    const target = census.targets.get(targetRepo) ?? {
+      target_repo: targetRepo,
+      pending: 0,
+      dispatching: 0,
+      leased: 0,
+      parked: 0,
+      oldest_pending_at: null,
+    };
+    if (item.state === "pending") {
+      target.pending += 1;
+      target.oldest_pending_at =
+        target.oldest_pending_at === null
+          ? item.createdAt
+          : Math.min(target.oldest_pending_at, item.createdAt);
+      if (!excludedItemKeys.has(item.key)) {
+        const pendingItems = isPublication ? census.pendingPublications : census.pendingReviews;
+        pendingItems.push(item);
+        if (item.nextAttemptAt <= now) {
+          const readyItems = isPublication ? census.readyPublications : census.readyReviews;
+          readyItems.push(item);
+        }
+      }
+    } else if (item.state === "dispatching") {
+      target.dispatching += 1;
+    } else if (item.state === "leased") {
+      target.leased += 1;
+    } else {
+      target.parked += 1;
+      census.parkedWakeCandidates.push({
+        recoveryAt: exactReviewParkedRecoveryAt(item),
+        terminalCheckAt: exactReviewParkedTerminalCheckAt(item),
+      });
+    }
+    census.targets.set(targetRepo, target);
+    census.parkedTerminalLastCheckedAt = Math.max(
+      census.parkedTerminalLastCheckedAt,
+      Number(item.parkedTerminalCheckedAt || 0),
+    );
+
+    if (item.state === "dispatching" || item.state === "leased") {
+      const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(
+        item,
+        publicationDispatchLeaseMs,
+        heartbeatGraceMs,
+      );
+      if (!item.leaseExpiresAt || leaseExpiresAt <= now) census.activeWithoutLeaseOrExpired = true;
+      if (isPublication) {
+        census.activePublishers += 1;
+        if (leaseExpiresAt && leaseExpiresAt > now) {
+          census.activePublisherWakeAt.push(leaseExpiresAt);
+        }
+      } else {
+        census.activeReviews += 1;
+        if (leaseExpiresAt && leaseExpiresAt > now) census.activeReviewWakeAt.push(leaseExpiresAt);
+        const targetCount = census.activeTargetCounts.get(targetRepo) || 0;
+        census.activeTargetCounts.set(targetRepo, targetCount + 1);
+        if (leaseExpiresAt > now) {
+          const targetWakeAt = census.activeTargetWakeAt.get(targetRepo);
+          census.activeTargetWakeAt.set(
+            targetRepo,
+            targetWakeAt === undefined ? leaseExpiresAt : Math.min(targetWakeAt, leaseExpiresAt),
+          );
+        }
+      }
+    }
+
+    if (!isPublication && item.state !== "parked") {
+      census.handoffItemCount += 1;
+      const phase = census.handoffPhases[item.state];
+      const startedAt = exactReviewHandoffPhaseStartedAt(
+        item,
+        handoffNow,
+        safeDispatchLeaseMs,
+        safeExecutionLeaseMs,
+      );
+      const key = item.key?.trim() || null;
+      phase.count += 1;
+      if (
+        phase.oldestAt === null ||
+        startedAt < phase.oldestAt ||
+        (startedAt === phase.oldestAt &&
+          key !== null &&
+          (phase.oldestKey === null || key < phase.oldestKey))
+      ) {
+        phase.oldestAt = startedAt;
+        phase.oldestKey = key;
+      }
+    }
+
+    if (collectBay) observeExactReviewBayCandidate(census.bayCandidates, item);
+  }
+
+  census.pendingReviews.sort(exactReviewQueueItemOrder);
+  census.pendingPublications.sort(exactReviewQueueItemOrder);
+  census.readyReviews.sort(exactReviewQueueItemOrder);
+  census.readyPublications.sort(exactReviewQueueItemOrder);
+  return census;
+}
+
+function observeExactReviewBayCandidate(
+  projected: Map<string, ExactReviewBayCensusCandidate[]>,
+  item: ExactReviewQueueItem,
+) {
+  const repository = String(item.decision.targetRepo || "").trim();
+  const itemNumber = Number(item.decision.itemNumber);
+  if (!repository || !Number.isSafeInteger(itemNumber) || itemNumber <= 0) return;
+  const itemKey = `${repository}#${itemNumber}`;
+  const updatedAt = Date.parse(new Date(item.updatedAt).toISOString());
+  const candidate = { item, itemKey, repository, itemNumber, updatedAt };
+  const previous = projected.get(itemKey);
+  if (!previous || updatedAt > previous[0].updatedAt) {
+    projected.set(itemKey, [candidate]);
+  } else if (updatedAt === previous[0].updatedAt) {
+    previous.push(candidate);
+  }
+}
+
 export function exactReviewQueueBayProjection(
   items: ExactReviewQueueItem[],
   priorityItemKeys: string[] = [],
   batchByItemKey: ReadonlyMap<string, ExactReviewBayBatchOwner> = new Map(),
 ) {
+  const census = buildExactReviewQueueCensus(items, {
+    state: { items: {} },
+    now: 0,
+  });
+  return exactReviewQueueBayProjectionFromCensus(census, priorityItemKeys, batchByItemKey);
+}
+
+function exactReviewQueueBayProjectionFromCensus(
+  census: ExactReviewQueueCensus,
+  priorityItemKeys: string[] = [],
+  batchByItemKey: ReadonlyMap<string, ExactReviewBayBatchOwner> = new Map(),
+) {
   const projected = new Map<string, ExactReviewBayProjectionItem>();
-  for (const item of items) {
-    // Parked records are not terminal outcomes: they remain bounded durable
-    // queue work that needs recovery. Keep their already-scrubbed identity in
-    // the projection so Bay shows the exception rather than a false empty lane.
-    const repository = String(item.decision.targetRepo || "").trim();
-    const itemNumber = Number(item.decision.itemNumber);
-    if (!repository || !Number.isSafeInteger(itemNumber) || itemNumber <= 0) continue;
-    const batch = batchByItemKey.get(item.key);
-    const candidate: ExactReviewBayProjectionItem = {
-      item_key: `${repository}#${itemNumber}`,
-      repository,
-      item_number: itemNumber,
-      stage: exactReviewQueueBayStage(item, batchByItemKey),
-      queue_state: item.state,
-      created_at: new Date(item.createdAt).toISOString(),
-      updated_at: new Date(item.updatedAt).toISOString(),
-      next_attempt_at: new Date(item.nextAttemptAt).toISOString(),
-      ...(batch
-        ? {
-            batch_id: batch.batchId,
-          }
-        : {}),
-    };
-    const previous = projected.get(candidate.item_key);
-    const candidateUpdatedAt = Date.parse(candidate.updated_at);
-    const previousUpdatedAt = previous ? Date.parse(previous.updated_at) : Number.NEGATIVE_INFINITY;
-    if (
-      !previous ||
-      candidateUpdatedAt > previousUpdatedAt ||
-      (candidateUpdatedAt === previousUpdatedAt &&
-        exactReviewQueueBayStagePriority(candidate.stage) >
-          exactReviewQueueBayStagePriority(previous.stage))
-    ) {
-      projected.set(candidate.item_key, candidate);
-    }
-  }
-  const rows = [...projected.values()];
-  const stages = Object.fromEntries(
-    EXACT_REVIEW_BAY_STAGES.map((stage) => [
-      stage,
-      rows.filter((item) => item.stage === stage).length,
-    ]),
-  ) as Record<ExactReviewBayStage, number>;
+  const stages = Object.fromEntries(EXACT_REVIEW_BAY_STAGES.map((stage) => [stage, 0])) as Record<
+    ExactReviewBayStage,
+    number
+  >;
   const rowsByStage = Object.fromEntries(
-    EXACT_REVIEW_BAY_STAGES.map((stage) => [
-      stage,
-      rows
-        .filter((item) => item.stage === stage)
-        .sort(
-          (left, right) =>
-            Date.parse(left.created_at) - Date.parse(right.created_at) ||
-            left.item_key.localeCompare(right.item_key),
-        ),
-    ]),
+    EXACT_REVIEW_BAY_STAGES.map((stage) => [stage, []]),
   ) as Record<ExactReviewBayStage, ExactReviewBayProjectionItem[]>;
+  for (const candidates of census.bayCandidates.values()) {
+    let selected = candidates[0];
+    let selectedStage = exactReviewQueueBayStage(selected.item, batchByItemKey);
+    for (const candidate of candidates.slice(1)) {
+      const stage = exactReviewQueueBayStage(candidate.item, batchByItemKey);
+      if (
+        exactReviewQueueBayStagePriority(stage) > exactReviewQueueBayStagePriority(selectedStage)
+      ) {
+        selected = candidate;
+        selectedStage = stage;
+      }
+    }
+    const batch = batchByItemKey.get(selected.item.key);
+    const row: ExactReviewBayProjectionItem = {
+      item_key: selected.itemKey,
+      repository: selected.repository,
+      item_number: selected.itemNumber,
+      stage: selectedStage,
+      queue_state: selected.item.state,
+      created_at: new Date(selected.item.createdAt).toISOString(),
+      updated_at: new Date(selected.item.updatedAt).toISOString(),
+      next_attempt_at: new Date(selected.item.nextAttemptAt).toISOString(),
+      ...(batch ? { batch_id: batch.batchId } : {}),
+    };
+    projected.set(row.item_key, row);
+    stages[row.stage] += 1;
+    rowsByStage[row.stage].push(row);
+  }
+  for (const stage of EXACT_REVIEW_BAY_STAGES) {
+    rowsByStage[stage].sort(
+      (left, right) =>
+        Date.parse(left.created_at) - Date.parse(right.created_at) ||
+        left.item_key.localeCompare(right.item_key),
+    );
+  }
   const priorityRows = exactReviewQueueBayPriorityKeys(priorityItemKeys)
     .map((itemKey) => projected.get(itemKey))
     .filter((item): item is ExactReviewBayProjectionItem => Boolean(item))
@@ -309,26 +658,29 @@ export function exactReviewQueueBayProjection(
   }
   return {
     sample_limit: EXACT_REVIEW_BAY_SAMPLE_LIMIT,
-    total: rows.length,
+    total: projected.size,
     stages,
     items: sample,
   };
 }
 
 export function exactReviewQueueActiveReviewCount(state: ExactReviewQueueState) {
-  return Object.values(state.items).filter(
-    (item) =>
-      !exactReviewQueueIsPublication(item) &&
-      (item.state === "dispatching" || item.state === "leased"),
-  ).length;
+  return exactReviewQueueActiveCounts(state).review;
 }
 
 export function exactReviewQueueActivePublicationCount(state: ExactReviewQueueState) {
-  return Object.values(state.items).filter(
-    (item) =>
-      exactReviewQueueIsPublication(item) &&
-      (item.state === "dispatching" || item.state === "leased"),
-  ).length;
+  return exactReviewQueueActiveCounts(state).publication;
+}
+
+function exactReviewQueueActiveCounts(state: ExactReviewQueueState) {
+  let review = 0;
+  let publication = 0;
+  for (const item of Object.values(state.items)) {
+    if (item.state !== "dispatching" && item.state !== "leased") continue;
+    if (exactReviewQueueIsPublication(item)) publication += 1;
+    else review += 1;
+  }
+  return { review, publication };
 }
 
 export function exactReviewPrioritizePublicationItems(
@@ -337,9 +689,12 @@ export function exactReviewPrioritizePublicationItems(
   freshReserve: number,
 ) {
   if (!freshReserve || !freshItemKeys.size) return items;
-  const fresh = items.filter((item) => freshItemKeys.has(item.key));
+  const fresh: ExactReviewQueueItem[] = [];
+  const historical: ExactReviewQueueItem[] = [];
+  for (const item of items) {
+    (freshItemKeys.has(item.key) ? fresh : historical).push(item);
+  }
   if (!fresh.length) return items;
-  const historical = items.filter((item) => !freshItemKeys.has(item.key));
   if (!historical.length) return items;
   const reservedFresh = fresh.slice(0, freshReserve);
   return [...reservedFresh, ...historical, ...fresh.slice(reservedFresh.length)];
@@ -364,35 +719,50 @@ export function exactReviewQueueAdmittedItems(
   ) {
     return [];
   }
-  const reviewSlots = Math.max(0, capacity - exactReviewQueueActiveReviewCount(state));
-  const activeTargets = new Map<string, number>();
-  let activePublishers = 0;
-  for (const item of Object.values(state.items)) {
-    if (item.state !== "dispatching" && item.state !== "leased") continue;
-    if (exactReviewQueueIsPublication(item)) {
-      activePublishers += 1;
-      continue;
-    }
-    const target = item.decision.targetRepo;
-    activeTargets.set(target, (activeTargets.get(target) || 0) + 1);
-  }
-  const pending = Object.values(state.items)
-    .filter(
-      (item) =>
-        item.state === "pending" && item.nextAttemptAt <= now && !excludedItemKeys.has(item.key),
-    )
-    .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
-  const pendingReviews = pending.filter((item) => !exactReviewQueueIsPublication(item));
+  const census = buildExactReviewQueueCensus(Object.values(state.items), {
+    state,
+    now,
+    excludedItemKeys,
+    collectBay: false,
+  });
+  return exactReviewQueueAdmittedItemsFromCensus(
+    census,
+    now,
+    capacity,
+    targetCapacity,
+    publicationCapacity,
+    publicationAdmissionBlocked,
+    uniquePublicationItems,
+    freshPublicationItemKeys,
+    freshPublicationReserve,
+  );
+}
+
+function exactReviewQueueAdmittedItemsFromCensus(
+  census: ExactReviewQueueCensus,
+  now: number,
+  capacity: number,
+  targetCapacity: number,
+  publicationCapacity: number,
+  publicationAdmissionBlocked: boolean,
+  uniquePublicationItems: boolean,
+  freshPublicationItemKeys: ReadonlySet<string>,
+  freshPublicationReserve: number,
+) {
+  if (census.dispatcherAdmissionPaused) return [];
+  const reviewSlots = Math.max(0, capacity - census.activeReviews);
+  const activeTargets = new Map(census.activeTargetCounts);
+  let activePublishers = census.activePublishers;
   const pendingPublications = exactReviewPrioritizePublicationItems(
-    pending.filter(exactReviewQueueIsPublication),
+    census.readyPublications,
     freshPublicationItemKeys,
     freshPublicationReserve,
   );
   const admittedReviews: ExactReviewQueueItem[] = [];
-  for (const item of pendingReviews) {
+  for (const item of census.readyReviews) {
     if (admittedReviews.length >= reviewSlots) break;
     const target = item.decision.targetRepo;
-    if (exactReviewGithubTargetAppCircuitRetryAt(state, target, now) > now) continue;
+    if (exactReviewTargetAppRetryAt(census, target) > now) continue;
     const active = activeTargets.get(target) || 0;
     if (active >= targetCapacity) continue;
     activeTargets.set(target, active + 1);
@@ -449,6 +819,111 @@ export function percentileFor(rows: Array<Record<string, number | string | null>
   return { p50: at(0.5), p95: at(0.95), samples: values.length };
 }
 
+function exactReviewHandoffFromCensus(
+  census: ExactReviewQueueCensus,
+  state: ExactReviewQueueState,
+  now: number,
+  capacity: number,
+  dispatchLeaseMs: number,
+) {
+  const safeNow = finiteExactReviewTimestamp(now, Date.now());
+  const safeCapacity = Math.max(0, Math.floor(finiteExactReviewNumber(capacity, 0)));
+  const safeShedSinceReset = Math.max(
+    0,
+    Math.floor(finiteExactReviewNumber(exactReviewShedSinceReset(state), 0)),
+  );
+  const safeLeaseMs = Math.max(1_000, finiteExactReviewNumber(dispatchLeaseMs, 10 * 60_000));
+  const warningMs = Math.min(2 * 60_000, Math.max(30_000, Math.floor(safeLeaseMs / 3)));
+  const stalledMs = Math.min(
+    5 * 60_000,
+    Math.max(warningMs + 1_000, Math.floor((safeLeaseMs * 2) / 3)),
+  );
+  const phases = Object.fromEntries(
+    (["pending", "dispatching", "leased"] as const).map((phaseName) => {
+      const phase = census.handoffPhases[phaseName];
+      return [
+        phaseName,
+        {
+          count: phase.count,
+          oldest_at: phase.oldestAt === null ? null : new Date(phase.oldestAt).toISOString(),
+          oldest_age_seconds:
+            phase.oldestAt === null
+              ? null
+              : Math.max(0, Math.floor((safeNow - phase.oldestAt) / 1_000)),
+          oldest_key: phase.oldestKey,
+        },
+      ];
+    }),
+  ) as Record<
+    "pending" | "dispatching" | "leased",
+    {
+      count: number;
+      oldest_at: string | null;
+      oldest_age_seconds: number | null;
+      oldest_key: string | null;
+    }
+  >;
+  const active = phases.dispatching.count + phases.leased.count;
+  const common = {
+    observed_at: new Date(safeNow).toISOString(),
+    warning_after_seconds: Math.floor(warningMs / 1_000),
+    stalled_after_seconds: Math.floor(stalledMs / 1_000),
+    capacity: safeCapacity,
+    active,
+    available_slots: Math.max(0, safeCapacity - active),
+    pending_depth: phases.pending.count,
+    shed_since_reset: safeShedSinceReset,
+    phases,
+  };
+  if (census.handoffItemCount === 0) {
+    return {
+      status: "idle" as const,
+      reason: "queue_empty" as const,
+      message: "No exact-review work is queued or active.",
+      ...common,
+    };
+  }
+  const dispatchingAgeMs = (phases.dispatching.oldest_age_seconds || 0) * 1_000;
+  if (dispatchingAgeMs >= stalledMs) {
+    return {
+      status: "stalled" as const,
+      reason: "claim_stalled" as const,
+      message: "A dispatched review has not been claimed within the expected handoff window.",
+      ...common,
+    };
+  }
+  if (state.dispatcher?.state === "blocked" && phases.pending.count > 0) {
+    return {
+      status: "stalled" as const,
+      reason: "dispatcher_blocked" as const,
+      message: "The dispatcher cannot verify workflow availability while reviews are pending.",
+      ...common,
+    };
+  }
+  if (state.dispatcher?.state === "paused" && phases.pending.count > 0) {
+    return {
+      status: "degraded" as const,
+      reason: "dispatcher_paused" as const,
+      message: "The exact-review workflow is paused while reviews are pending.",
+      ...common,
+    };
+  }
+  if (dispatchingAgeMs >= warningMs) {
+    return {
+      status: "degraded" as const,
+      reason: "claim_delayed" as const,
+      message: "A dispatched review is taking longer than expected to claim.",
+      ...common,
+    };
+  }
+  return {
+    status: "healthy" as const,
+    reason: "handoff_current" as const,
+    message: "Dispatch-to-claim handoffs are within the expected window.",
+    ...common,
+  };
+}
+
 export function exactReviewQueueStats(
   state: ExactReviewQueueState,
   now = Date.now(),
@@ -463,58 +938,17 @@ export function exactReviewQueueStats(
   publicationBlockedUntil: number | null = null,
 ) {
   const items = Object.values(state.items);
-  const handoffItems = items.filter(
-    (item): item is ExactReviewQueueItem & { state: "pending" | "dispatching" | "leased" } =>
-      item.state !== "parked" && !exactReviewQueueIsPublication(item),
-  );
-  const handoffHealth = summarizeExactReviewHandoff({
-    // Parked poison items are reported by publication health and cannot take a
-    // handoff lease, so they must not be mislabeled as an unknown handoff phase.
-    items: handoffItems,
-    dispatcher: state.dispatcher,
-    shedSinceReset: exactReviewShedSinceReset(state),
+  const census = buildExactReviewQueueCensus(items, {
+    state,
     now,
-    capacity,
     dispatchLeaseMs,
     executionLeaseMs,
+    publicationDispatchLeaseMs,
+    heartbeatGraceMs,
+    excludedItemKeys,
   });
-  const targets = new Map<
-    string,
-    {
-      target_repo: string;
-      pending: number;
-      dispatching: number;
-      leased: number;
-      parked: number;
-      oldest_pending_at: number | null;
-    }
-  >();
-  for (const item of items) {
-    const targetRepo = item.decision.targetRepo;
-    const current = targets.get(targetRepo) ?? {
-      target_repo: targetRepo,
-      pending: 0,
-      dispatching: 0,
-      leased: 0,
-      parked: 0,
-      oldest_pending_at: null,
-    };
-    if (item.state === "pending") {
-      current.pending += 1;
-      current.oldest_pending_at =
-        current.oldest_pending_at === null
-          ? item.createdAt
-          : Math.min(current.oldest_pending_at, item.createdAt);
-    } else if (item.state === "dispatching") {
-      current.dispatching += 1;
-    } else if (item.state === "leased") {
-      current.leased += 1;
-    } else {
-      current.parked += 1;
-    }
-    targets.set(targetRepo, current);
-  }
-  const targetStats = [...targets.values()]
+  const handoffHealth = exactReviewHandoffFromCensus(census, state, now, capacity, dispatchLeaseMs);
+  const targetStats = [...census.targets.values()]
     .map((target) => ({
       target_repo: target.target_repo,
       pending: target.pending,
@@ -529,48 +963,47 @@ export function exactReviewQueueStats(
         right.dispatching + right.leased - (left.dispatching + left.leased) ||
         left.target_repo.localeCompare(right.target_repo),
     );
-  const nextWakeAt = exactReviewQueueNextWakeAt(
+  const nextWakeAt = exactReviewQueueNextWakeAtFromCensus(
+    census,
     state,
     now,
     capacity,
     targetCapacity,
     publicationCapacity,
-    publicationDispatchLeaseMs,
-    heartbeatGraceMs,
-    excludedItemKeys,
     publicationBlockedUntil,
     Number(state.dispatcher?.reviewAdmissionNextAt || 0) > now
       ? Number(state.dispatcher?.reviewAdmissionNextAt)
       : null,
   );
   const lanes = {
-    review: exactReviewQueueLaneStats(
-      items.filter((item) => !exactReviewQueueIsPublication(item)),
+    review: exactReviewQueueLaneStatsFromCensus(
+      census.review,
       now,
       capacity,
       exactReviewShedSinceReset(state),
-      state,
     ),
-    publication: exactReviewQueueLaneStats(
-      items.filter(exactReviewQueueIsPublication),
+    publication: exactReviewQueueLaneStatsFromCensus(
+      census.publication,
       now,
       publicationCapacity,
       0,
-      state,
     ),
   };
-  const admissibleItems = exactReviewQueueAdmittedItems(
-    state,
+  const admissibleItems = exactReviewQueueAdmittedItemsFromCensus(
+    census,
     now,
     Number.MAX_SAFE_INTEGER,
     targetCapacity,
     publicationCapacity,
-    excludedItemKeys,
     publicationBlockedUntil !== null && publicationBlockedUntil > now,
+    false,
+    new Set(),
+    0,
   );
-  const reviewAdmissiblePending = admissibleItems.filter(
-    (item) => !exactReviewQueueIsPublication(item),
-  ).length;
+  let reviewAdmissiblePending = 0;
+  for (const item of admissibleItems) {
+    if (!exactReviewQueueIsPublication(item)) reviewAdmissiblePending += 1;
+  }
   const pressure = summarizeExactReviewPressure({
     pending: lanes.review.pending,
     readyPending: lanes.review.ready,
@@ -581,7 +1014,7 @@ export function exactReviewQueueStats(
     dispatcherState: state.dispatcher?.state,
     handoffStatus: handoffHealth.status,
   });
-  return {
+  const stats = {
     generated_at: handoffHealth.observed_at,
     pending: lanes.review.pending,
     ready_pending: lanes.review.ready,
@@ -599,7 +1032,9 @@ export function exactReviewQueueStats(
     handoff_health: handoffHealth,
     lanes,
     pressure,
-    bay_projection: exactReviewQueueBayProjection(items),
+    bay_projection: undefined as unknown as ReturnType<
+      typeof exactReviewQueueBayProjectionFromCensus
+    >,
     next_wake_at: nextWakeAt === null ? null : new Date(nextWakeAt).toISOString(),
     dispatcher: {
       state: state.dispatcher?.state || "unknown",
@@ -622,6 +1057,37 @@ export function exactReviewQueueStats(
     },
     target_stats: targetStats,
   };
+  let bayProjection: ReturnType<typeof exactReviewQueueBayProjectionFromCensus> | undefined;
+  Object.defineProperty(stats, "bay_projection", {
+    enumerable: true,
+    configurable: true,
+    get() {
+      bayProjection ??= exactReviewQueueBayProjectionFromCensus(census);
+      return bayProjection;
+    },
+  });
+  Object.defineProperty(stats, EXACT_REVIEW_STATS_CENSUS, { value: census });
+  return stats;
+}
+
+export function exactReviewQueueBayProjectionFromStats(
+  stats: ExactReviewQueueStatsWithCensus,
+  priorityItemKeys: string[] = [],
+  batchByItemKey: ReadonlyMap<string, ExactReviewBayBatchOwner> = new Map(),
+) {
+  const census = stats[EXACT_REVIEW_STATS_CENSUS];
+  if (!census) throw new Error("exact-review queue stats are missing their census");
+  const projection = exactReviewQueueBayProjectionFromCensus(
+    census,
+    priorityItemKeys,
+    batchByItemKey,
+  );
+  Object.defineProperty(stats, "bay_projection", {
+    value: projection,
+    enumerable: true,
+    configurable: true,
+  });
+  return projection;
 }
 
 export function exactReviewQueueLaneStats(
@@ -631,63 +1097,52 @@ export function exactReviewQueueLaneStats(
   shedSinceReset = 0,
   state: ExactReviewQueueState = { items: {} },
 ) {
-  const pendingItems = items.filter((item) => item.state === "pending");
-  const readyItems = pendingItems.filter((item) => item.nextAttemptAt <= now);
-  const backoffItems = pendingItems.filter((item) => item.nextAttemptAt > now);
-  const dispatchingItems = items.filter((item) => item.state === "dispatching");
-  const leasedItems = items.filter((item) => item.state === "leased");
-  const parkedItems = items.filter((item) => item.state === "parked");
-  const active = dispatchingItems.length + leasedItems.length;
-  const oldestPendingAt = pendingItems.reduce<number | null>(
-    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
-    null,
-  );
-  const oldestPendingKey = pendingItems
-    .slice()
-    .sort(
-      (left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key),
-    )[0]?.key;
-  const oldestReadyAt = readyItems.reduce<number | null>(
-    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
-    null,
-  );
-  const oldestBackoffAt = backoffItems.reduce<number | null>(
-    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
-    null,
-  );
-  const nextAttemptAt = pendingItems.reduce<number | null>(
-    (next, item) => (next === null ? item.nextAttemptAt : Math.min(next, item.nextAttemptAt)),
-    null,
-  );
+  const census = buildExactReviewQueueCensus(items, { state, now, collectBay: false });
+  return exactReviewQueueLaneStatsFromCensus(census.all, now, capacity, shedSinceReset);
+}
+
+function exactReviewQueueLaneStatsFromCensus(
+  lane: ExactReviewQueueLaneCensus,
+  now: number,
+  capacity: number,
+  shedSinceReset = 0,
+) {
+  const active = lane.dispatching + lane.leased;
   return {
-    pending: pendingItems.length,
-    pending_depth: pendingItems.length,
+    pending: lane.pending,
+    pending_depth: lane.pending,
     shed_since_reset: shedSinceReset,
-    ready: readyItems.length,
-    backoff: backoffItems.length,
-    backoff_reasons: exactReviewQueueReasonCounts(
-      backoffItems.map((item) => exactReviewQueueBackoffReason(item, state, now)),
-    ),
-    dispatching: dispatchingItems.length,
-    leased: leasedItems.length,
-    parked: parkedItems.length,
-    parked_reasons: exactReviewQueueReasonCounts(
-      parkedItems.map((item) => item.parkedReason || "unknown"),
-    ),
+    ready: lane.ready,
+    backoff: lane.backoff,
+    backoff_reasons: lane.backoffReasons,
+    dispatching: lane.dispatching,
+    leased: lane.leased,
+    parked: lane.parked,
+    parked_reasons: lane.parkedReasons,
     capacity,
     active,
     available_slots: Math.max(0, capacity - active),
-    oldest_pending_at: oldestPendingAt === null ? null : new Date(oldestPendingAt).toISOString(),
+    oldest_pending_at:
+      lane.oldestPendingAt === null ? null : new Date(lane.oldestPendingAt).toISOString(),
     oldest_pending_age_seconds:
-      oldestPendingAt === null ? null : Math.max(0, Math.floor((now - oldestPendingAt) / 1_000)),
-    oldest_pending_key: oldestPendingKey ?? null,
-    oldest_ready_at: oldestReadyAt === null ? null : new Date(oldestReadyAt).toISOString(),
+      lane.oldestPendingAt === null
+        ? null
+        : Math.max(0, Math.floor((now - lane.oldestPendingAt) / 1_000)),
+    oldest_pending_key: lane.oldestPendingKey,
+    oldest_ready_at:
+      lane.oldestReadyAt === null ? null : new Date(lane.oldestReadyAt).toISOString(),
     oldest_ready_age_seconds:
-      oldestReadyAt === null ? null : Math.max(0, Math.floor((now - oldestReadyAt) / 1_000)),
-    oldest_backoff_at: oldestBackoffAt === null ? null : new Date(oldestBackoffAt).toISOString(),
+      lane.oldestReadyAt === null
+        ? null
+        : Math.max(0, Math.floor((now - lane.oldestReadyAt) / 1_000)),
+    oldest_backoff_at:
+      lane.oldestBackoffAt === null ? null : new Date(lane.oldestBackoffAt).toISOString(),
     oldest_backoff_age_seconds:
-      oldestBackoffAt === null ? null : Math.max(0, Math.floor((now - oldestBackoffAt) / 1_000)),
-    next_attempt_at: nextAttemptAt === null ? null : new Date(nextAttemptAt).toISOString(),
+      lane.oldestBackoffAt === null
+        ? null
+        : Math.max(0, Math.floor((now - lane.oldestBackoffAt) / 1_000)),
+    next_attempt_at:
+      lane.nextAttemptAt === null ? null : new Date(lane.nextAttemptAt).toISOString(),
   };
 }
 
@@ -732,121 +1187,171 @@ export function exactReviewQueueNextWakeAt(
   reviewAdmissionBlockedUntil: number | null = null,
 ) {
   const items = Object.values(state.items);
-  if (!items.length) return null;
-  const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
-  const dispatcherPaused =
-    (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
-    dispatcherRetryAt > now;
-  const activeItems = items.filter(
-    (item) => item.state === "dispatching" || item.state === "leased",
+  const census = buildExactReviewQueueCensus(items, {
+    state,
+    now,
+    publicationDispatchLeaseMs,
+    heartbeatGraceMs,
+    excludedItemKeys,
+    collectBay: false,
+  });
+  return exactReviewQueueNextWakeAtFromCensus(
+    census,
+    state,
+    now,
+    capacity,
+    targetCapacity,
+    publicationCapacity,
+    publicationBlockedUntil,
+    reviewAdmissionBlockedUntil,
   );
-  if (
-    activeItems.some(
-      (item) =>
-        !item.leaseExpiresAt ||
-        exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs, heartbeatGraceMs) <=
-          now,
-    )
-  ) {
-    return now + 1_000;
-  }
-  const activeReviews = activeItems.filter((item) => !exactReviewQueueIsPublication(item));
-  const activePublishers = activeItems.filter(exactReviewQueueIsPublication);
-  const activeReviewWakeAt = activeReviews
-    .map((item) =>
-      exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs, heartbeatGraceMs),
-    )
-    .filter((value): value is number => Boolean(value && value > now));
-  const activePublisherWakeAt = activePublishers
-    .map((item) =>
-      exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs, heartbeatGraceMs),
-    )
-    .filter((value): value is number => Boolean(value && value > now));
-  const activeTargetWakeAt = new Map<string, number>();
-  const activeTargetCounts = new Map<string, number>();
-  for (const item of activeReviews) {
-    const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(
-      item,
-      publicationDispatchLeaseMs,
-      heartbeatGraceMs,
-    );
-    if (leaseExpiresAt > now) {
-      const target = item.decision.targetRepo;
-      activeTargetCounts.set(target, (activeTargetCounts.get(target) || 0) + 1);
-      const current = activeTargetWakeAt.get(item.decision.targetRepo);
-      activeTargetWakeAt.set(
-        target,
-        current === undefined ? leaseExpiresAt : Math.min(current, leaseExpiresAt),
-      );
+}
+
+function exactReviewQueueNextWakeAtFromCensus(
+  census: ExactReviewQueueCensus,
+  state: ExactReviewQueueState,
+  now: number,
+  capacity: number,
+  targetCapacity: number,
+  publicationCapacity: number,
+  publicationBlockedUntil: number | null,
+  reviewAdmissionBlockedUntil: number | null,
+) {
+  if (!census.items.length) return null;
+  const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
+  if (census.activeWithoutLeaseOrExpired) return now + 1_000;
+  let earliest: number | null = null;
+  const include = (candidate: number) => {
+    earliest = earliest === null ? candidate : Math.min(earliest, candidate);
+  };
+
+  if (census.dispatcherAdmissionPaused) {
+    if (census.pendingReviews.length || census.pendingPublications.length)
+      include(dispatcherRetryAt);
+  } else {
+    let publicationCapacityWakeAt: number | null = null;
+    if (census.activePublishers >= publicationCapacity) {
+      const capacityWakeAt =
+        publicationCapacity <= 0
+          ? [...census.activePublisherWakeAt, ...census.activeReviewWakeAt]
+          : census.activePublisherWakeAt;
+      publicationCapacityWakeAt = capacityWakeAt.length
+        ? Math.min(...capacityWakeAt)
+        : now + DEFAULT_EXACT_REVIEW_RETRY_MS;
     }
-  }
-  const parkedTerminalGlobalCheckAt = exactReviewParkedTerminalGlobalCheckAt(state);
-  const times = items.flatMap((item) => {
-    if (item.state === "pending") {
-      if (excludedItemKeys.has(item.key)) return [];
-      if (dispatcherPaused) return [dispatcherRetryAt];
-      if (exactReviewQueueIsPublication(item)) {
-        if (publicationBlockedUntil !== null && publicationBlockedUntil > now) {
-          return [Math.max(item.nextAttemptAt, publicationBlockedUntil)];
-        }
-        let blockedUntil = item.nextAttemptAt;
-        if (activePublishers.length >= publicationCapacity) {
-          const capacityWakeAt = [...activePublisherWakeAt];
-          if (publicationCapacity <= 0) {
-            // A zero publication budget is normally caused by active reviews
-            // consuming the shared worker budget. Their leases, rather than a
-            // one-second alarm loop, determine when a slot can become available.
-            capacityWakeAt.push(...activeReviewWakeAt);
-          }
-          blockedUntil = capacityWakeAt.length
-            ? Math.min(...capacityWakeAt)
-            : now + DEFAULT_EXACT_REVIEW_RETRY_MS;
-        }
-        return [Math.max(item.nextAttemptAt, blockedUntil)];
+    for (const item of census.pendingPublications) {
+      if (publicationBlockedUntil !== null && publicationBlockedUntil > now) {
+        include(Math.max(item.nextAttemptAt, publicationBlockedUntil));
+      } else {
+        include(
+          Math.max(
+            item.nextAttemptAt,
+            publicationCapacityWakeAt === null ? item.nextAttemptAt : publicationCapacityWakeAt,
+          ),
+        );
       }
+    }
+
+    const reviewCapacityWakeAt =
+      census.activeReviews >= capacity && census.activeReviewWakeAt.length
+        ? Math.min(...census.activeReviewWakeAt)
+        : null;
+    for (const item of census.pendingReviews) {
       const target = item.decision.targetRepo;
-      const credentialBlockedUntil = exactReviewGithubTargetAppCircuitRetryAt(state, target, now);
-      const capacityBlockedUntil = [
-        ...(activeReviews.length >= capacity && activeReviewWakeAt.length
-          ? [Math.min(...activeReviewWakeAt)]
-          : []),
-        ...((activeTargetCounts.get(target) || 0) >= targetCapacity &&
-        activeTargetWakeAt.has(target)
-          ? [activeTargetWakeAt.get(target) as number]
-          : []),
-      ];
-      return [
+      const targetCapacityWakeAt =
+        (census.activeTargetCounts.get(target) || 0) >= targetCapacity &&
+        census.activeTargetWakeAt.has(target)
+          ? (census.activeTargetWakeAt.get(target) as number)
+          : null;
+      const capacityWakeAt =
+        reviewCapacityWakeAt === null
+          ? targetCapacityWakeAt
+          : targetCapacityWakeAt === null
+            ? reviewCapacityWakeAt
+            : Math.min(reviewCapacityWakeAt, targetCapacityWakeAt);
+      include(
         Math.max(
           item.nextAttemptAt,
           reviewAdmissionBlockedUntil ?? item.nextAttemptAt,
-          credentialBlockedUntil,
-          capacityBlockedUntil.length ? Math.min(...capacityBlockedUntil) : item.nextAttemptAt,
+          exactReviewTargetAppRetryAt(census, target),
+          capacityWakeAt ?? item.nextAttemptAt,
         ),
-      ];
+      );
     }
-    if (item.state === "parked") {
-      const recoveryAt = exactReviewParkedRecoveryAt(item);
-      const terminalCheckAt = exactReviewParkedTerminalCheckAt(item);
-      return [
-        recoveryAt,
-        terminalCheckAt === null
-          ? null
-          : Math.max(
-              terminalCheckAt,
-              parkedTerminalGlobalCheckAt,
-              dispatcherPaused ? dispatcherRetryAt : 0,
-            ),
-      ].filter((value): value is number => value !== null);
+  }
+
+  const parkedTerminalGlobalCheckAt =
+    census.parkedTerminalLastCheckedAt + EXACT_REVIEW_PARKED_TERMINAL_CHECK_INTERVAL_MS;
+  for (const candidate of census.parkedWakeCandidates) {
+    if (candidate.recoveryAt !== null) include(candidate.recoveryAt);
+    if (candidate.terminalCheckAt !== null) {
+      include(
+        Math.max(
+          candidate.terminalCheckAt,
+          parkedTerminalGlobalCheckAt,
+          census.dispatcherAdmissionPaused ? dispatcherRetryAt : 0,
+        ),
+      );
     }
-    const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(
-      item,
-      publicationDispatchLeaseMs,
-      heartbeatGraceMs,
-    );
-    return leaseExpiresAt ? [leaseExpiresAt] : [];
-  });
-  if (!times.length) return null;
-  return Math.max(now + 1_000, Math.min(...times));
+  }
+  for (const candidate of census.activeReviewWakeAt) include(candidate);
+  for (const candidate of census.activePublisherWakeAt) include(candidate);
+  return earliest === null ? null : Math.max(now + 1_000, earliest);
+}
+
+function exactReviewHandoffPhaseStartedAt(
+  item: ExactReviewQueueItem,
+  now: number,
+  dispatchLeaseMs: number,
+  executionLeaseMs: number,
+) {
+  if (item.state === "dispatching") {
+    const dispatchedAt = validExactReviewTimestamp(item.dispatchedAt);
+    const leaseExpiresAt = validExactReviewTimestamp(item.leaseExpiresAt);
+    const leaseStartedAt =
+      leaseExpiresAt === null ? null : timestampAtOrBefore(leaseExpiresAt - dispatchLeaseMs, now);
+    return newestExactReviewTimestamp(dispatchedAt, leaseStartedAt) ?? now;
+  }
+  if (item.state === "leased") {
+    const claimedAt = validExactReviewTimestamp(item.claimedAt);
+    const leaseExpiresAt = validExactReviewTimestamp(item.leaseExpiresAt);
+    const leaseStartedAt =
+      leaseExpiresAt === null ? null : validExactReviewTimestamp(leaseExpiresAt - executionLeaseMs);
+    return newestExactReviewTimestamp(claimedAt, leaseStartedAt) ?? now;
+  }
+  return finiteExactReviewTimestamp(
+    item.createdAt,
+    finiteExactReviewTimestamp(item.updatedAt, now),
+  );
+}
+
+function newestExactReviewTimestamp(...values: Array<number | null>) {
+  let newest: number | null = null;
+  for (const value of values) {
+    if (value === null) continue;
+    newest = newest === null ? value : Math.max(newest, value);
+  }
+  return newest;
+}
+
+function validExactReviewTimestamp(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 && number <= 8_640_000_000_000_000 ? number : null;
+}
+
+function timestampAtOrBefore(value: unknown, maximum: number): number | null {
+  const timestamp = validExactReviewTimestamp(value);
+  return timestamp !== null && timestamp <= maximum ? timestamp : null;
+}
+
+function finiteExactReviewTimestamp(value: unknown, fallback: number) {
+  return validExactReviewTimestamp(value) ?? fallback;
+}
+
+function finiteExactReviewNumber(value: unknown, fallback: number) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
 }
 
 export function exactReviewQueueCapacity(env, DEFAULT_EXACT_REVIEW_ACTIONS_BUDGET: number) {

--- a/docs/proof/single-census-read-model/README.md
+++ b/docs/proof/single-census-read-model/README.md
@@ -1,0 +1,54 @@
+# Single-census queue read-model proof
+
+## Claim
+
+The exact-review queue read model builds one census of durable queue items per
+request and preserves the normalized response bytes from the pre-refactor
+merge-base for both `/api/exact-review-queue` and `/api/status`.
+
+## Exercised surface
+
+`run-proof.mjs` archives the merge-base and starts its real local Wrangler
+Worker beside the candidate Worker. Independent SQLite-backed Durable Object
+stores receive the same fixed-seed populations through the signed enqueue
+route. The two public API responses are normalized only for volatile time,
+request, and lease fields, then compared with insertion order intact.
+
+The same proof instruments array traversals in the merge-base and candidate
+read-model modules over a 1,200-item synthetic state. Instrumentation exists
+only in the proof process: production code has no counters or timing hooks.
+
+## Run
+
+From a clean committed checkout on Node 24 or newer:
+
+```bash
+docs/proof/single-census-read-model/run-proof.sh
+```
+
+Artifacts are written below the ignored
+`.artifacts/single-census-read-model/` directory. The receipt is `COMMITTED`
+only when `HEAD` is a real commit and tracked files are clean before the run.
+
+## Expected observation
+
+- all fixed-seed populations return byte-identical normalized responses for
+  both routes;
+- the candidate records one full census traversal and one `Object.values`
+  materialization for `/stats` plus its customized Bay projection;
+- the merge-base performs multiple full or partial queue passes and repeats
+  `Object.values` materialization;
+- the proof exits zero and writes `proof-summary.json` with the exact counts,
+  response hashes, merge-base, candidate head, and `COMMITTED` receipt.
+
+## OpenClaw Bay and limits
+
+OpenClaw Bay is unaffected. Its public projection is byte-identical and remains
+observer-only; this change adds no queue, workflow, recovery, deploy, or
+rollback action.
+
+The Worker scenario uses synthetic pending reviews and a deterministic loopback
+GitHub error stub. It does not contact GitHub, acquire review leases, publish
+records, or mutate production. Randomized leased, parked, publication, Bay,
+capacity, and next-wake combinations are covered by the separate fixed-seed
+property-equivalence unit test.

--- a/docs/proof/single-census-read-model/run-proof.mjs
+++ b/docs/proof/single-census-read-model/run-proof.mjs
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.cwd();
+const artifactDir = path.join(repoRoot, ".artifacts/single-census-read-model");
+const scratch = await mkdtemp(path.join(tmpdir(), "single-census-proof-"));
+const baseRoot = path.join(scratch, "merge-base");
+const archivePath = path.join(scratch, "merge-base.tar");
+const proofSecret = "single-census-local-proof-secret";
+const populations = [0, 24, 96];
+const seed = 0x5eedc0de;
+const workers = [];
+const githubStubPort = await availablePort();
+const githubStub = createHttpServer((_request, response) => {
+  const body = `${JSON.stringify({ message: "proof GitHub stub" })}\n`;
+  response.writeHead(403, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body),
+  });
+  response.end(body);
+});
+await new Promise((resolve, reject) => {
+  githubStub.once("error", reject);
+  githubStub.listen(githubStubPort, "127.0.0.1", resolve);
+});
+
+await mkdir(artifactDir, { recursive: true });
+const mergeBase = (await command("git", ["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
+const headSha = (await command("git", ["rev-parse", "HEAD"], repoRoot)).trim();
+const trackedDirty = (await command("git", ["status", "--porcelain", "--untracked-files=no"], repoRoot)).trim();
+if (process.env.SINGLE_CENSUS_PROOF_ALLOW_DIRTY !== "1") {
+  assert.equal(trackedDirty, "", "proof requires a clean committed checkout");
+}
+const receipt = trackedDirty ? "DIRTY-DEVELOPMENT-RUN" : "COMMITTED";
+await mkdir(baseRoot, { recursive: true });
+await command("git", ["archive", "--format=tar", "-o", archivePath, mergeBase], repoRoot);
+await command("tar", ["-xf", archivePath, "-C", baseRoot], repoRoot);
+await symlink(path.join(repoRoot, "node_modules"), path.join(baseRoot, "node_modules"));
+
+try {
+  const comparisons = [];
+  for (const population of populations) {
+    const before = await runWorkerScenario("merge-base", baseRoot, population, seed);
+    const after = await runWorkerScenario("candidate", repoRoot, population, seed);
+    for (const route of ["/api/exact-review-queue", "/api/status"]) {
+      const beforeBytes = JSON.stringify(normalizeVolatile(before[route]));
+      const afterBytes = JSON.stringify(normalizeVolatile(after[route]));
+      assert.equal(afterBytes, beforeBytes, `normalized response changed for ${route} n=${population}`);
+      comparisons.push({
+        population,
+        route,
+        byte_identical: true,
+        normalized_bytes: Buffer.byteLength(beforeBytes),
+        normalized_sha256: sha256(beforeBytes),
+      });
+    }
+  }
+
+  const traversals = await measureTraversals(baseRoot, repoRoot);
+  assert.equal(traversals.candidate.full_queue_traversals, 1);
+  assert.equal(traversals.candidate.object_values_materializations, 1);
+  assert.ok(
+    traversals.candidate.equivalent_queue_passes < traversals.merge_base.equivalent_queue_passes,
+    "candidate did not reduce measured queue passes",
+  );
+  const summary = {
+    schema: "single-census-read-model-proof/v1",
+    receipt,
+    merge_base: mergeBase,
+    candidate_head: headSha,
+    worker: "wrangler dev --local",
+    durable_object: "SQLite-backed ExactReviewQueue",
+    seed,
+    populations,
+    responses: comparisons,
+    all_normalized_responses_byte_identical: true,
+    traversal_measurement: traversals,
+    production_mutations: 0,
+    openclaw_bay_affected: false,
+    limits:
+      "Synthetic pending reviews and loopback GitHub error stub; no GitHub, lease, publication, or production mutation.",
+  };
+  await writeFile(
+    path.join(artifactDir, "proof-summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+    "utf8",
+  );
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+} finally {
+  await Promise.all(workers.map(stopWorker));
+  await new Promise((resolve) => githubStub.close(resolve));
+  await rm(scratch, { recursive: true, force: true });
+}
+
+async function runWorkerScenario(label, root, population, populationSeed) {
+  const port = await availablePort();
+  const stateDir = await mkdtemp(path.join(tmpdir(), `single-census-${label}-${population}-`));
+  const logPath = path.join(artifactDir, `${label}-${population}-worker.log`);
+  const log = createWriteStream(logPath);
+  await new Promise((resolve, reject) => {
+    log.once("open", resolve);
+    log.once("error", reject);
+  });
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      "wrangler@4.107.0",
+      "dev",
+      "--config",
+      "dashboard/wrangler.toml",
+      "--local",
+      "--persist-to",
+      stateDir,
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--var",
+      `CLAWSWEEPER_WEBHOOK_SECRET:${proofSecret}`,
+      "--var",
+      `GITHUB_API_URL:http://127.0.0.1:${githubStubPort}`,
+      "--var",
+      "EXACT_REVIEW_DISPATCH_DEBOUNCE_MS:600000",
+      "--var",
+      "EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS:600000",
+    ],
+    {
+      cwd: root,
+      detached: true,
+      env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+      stdio: ["ignore", log, log],
+    },
+  );
+  const worker = { child, log, stateDir };
+  workers.push(worker);
+  const origin = `http://127.0.0.1:${port}`;
+  await waitForWorker(origin, child, logPath);
+  const random = seededRandom(populationSeed);
+  for (let index = 0; index < population; index += 1) {
+    const itemNumber = 90_000 + index;
+    const targetRepo = random() % 2 === 0 ? "openclaw/openclaw" : "openclaw/clawhub";
+    const body = {
+      delivery_id: `single-census-${populationSeed}-${population}-${index}`,
+      decision: {
+        targetRepo,
+        targetBranch: "main",
+        itemNumber,
+        itemKind: "issue",
+        sourceEvent: "issues",
+        sourceAction: random() % 3 === 0 ? "edited" : "opened",
+        supersedesInProgress: false,
+        sourceUpdatedAt: new Date(Date.UTC(2026, 7, 11, 12, 0, index)).toISOString(),
+      },
+    };
+    const response = await signedPost(origin, body);
+    assert.equal(response.status, 202, `${label} seed ${index} failed: ${response.text}`);
+  }
+  const responses = {
+    "/api/exact-review-queue": await getJson(`${origin}/api/exact-review-queue`),
+    "/api/status": await getJson(`${origin}/api/status`),
+  };
+  assert.equal(responses["/api/exact-review-queue"].pending, population);
+  await stopWorker(worker);
+  workers.splice(workers.indexOf(worker), 1);
+  return responses;
+}
+
+async function measureTraversals(base, candidate) {
+  const baseModule = await import(
+    `${pathToFileURL(path.join(base, "dashboard/exact-review-read-model.ts")).href}?proof=base`
+  );
+  const candidateModule = await import(
+    `${pathToFileURL(path.join(candidate, "dashboard/exact-review-read-model.ts")).href}?proof=head`
+  );
+  return {
+    merge_base: instrumentReadModel(baseModule, false),
+    candidate: instrumentReadModel(candidateModule, true),
+  };
+}
+
+function instrumentReadModel(module, hasSharedBayCensus) {
+  const population = 1_200;
+  const now = Date.parse("2026-08-11T18:00:00.000Z");
+  let itemReads = 0;
+  let fullQueueTraversals = 0;
+  let equivalentElements = 0;
+  const items = {};
+  const batchByItemKey = new Map();
+  for (let index = 0; index < population; index += 1) {
+    const publication = index % 5 === 0;
+    const state = ["pending", "dispatching", "leased", "parked"][index % 4];
+    const targetRepo = index % 3 === 0 ? "openclaw/clawhub" : "openclaw/openclaw";
+    const itemNumber = 100_000 + index;
+    const key = `${targetRepo}#${itemNumber}${publication ? `@publish:${index}` : ""}`;
+    const item = {
+      __singleCensusProofItem: true,
+      key,
+      decision: {
+        targetRepo,
+        targetBranch: "main",
+        itemNumber,
+        itemKind: "issue",
+        sourceEvent: "issues",
+        sourceAction: publication ? "exact_review_artifact_publish" : "opened",
+        supersedesInProgress: false,
+        ...(publication ? { publication: {} } : {}),
+      },
+      state,
+      revision: 1,
+      createdAt: now - index * 1_000,
+      updatedAt: now - index * 500,
+      nextAttemptAt: now + (index % 3) * 30_000,
+      attempts: 0,
+      ...(state === "dispatching" || state === "leased"
+        ? {
+            leaseExpiresAt: now + 30 * 60_000 + index,
+            dispatchedAt: now - 30_000,
+            claimedAt: now - 60_000,
+          }
+        : {}),
+      ...(state === "parked"
+        ? { parkedReason: "review_retry_exhausted", parkedRecoveryAttempts: 1 }
+        : {}),
+    };
+    Object.defineProperty(items, key, {
+      enumerable: true,
+      get() {
+        itemReads += 1;
+        return item;
+      },
+    });
+    if (index % 17 === 0) batchByItemKey.set(key, { batchId: `batch-${index}` });
+  }
+  const state = { items, dispatcher: { state: "active", checkedAt: now } };
+  const methods = ["filter", "map", "reduce", "sort", "flatMap", "some"];
+  const originals = new Map();
+  const iterator = Array.prototype[Symbol.iterator];
+  const observe = (array) => {
+    if (!array.length || !array[0]?.__singleCensusProofItem) return;
+    equivalentElements += array.length;
+    if (array.length === population) fullQueueTraversals += 1;
+  };
+  for (const name of methods) {
+    const original = Array.prototype[name];
+    originals.set(name, original);
+    Array.prototype[name] = function (...args) {
+      observe(this);
+      return Reflect.apply(original, this, args);
+    };
+  }
+  Array.prototype[Symbol.iterator] = function () {
+    observe(this);
+    return Reflect.apply(iterator, this, []);
+  };
+  try {
+    const stats = module.exactReviewQueueStats(
+      state,
+      now,
+      128,
+      16,
+      24,
+      6 * 60_000,
+      130 * 60_000,
+      15 * 60_000,
+      20 * 60_000,
+      new Set(),
+      null,
+    );
+    const bay = hasSharedBayCensus
+      ? module.exactReviewQueueBayProjectionFromStats(stats, [], batchByItemKey)
+      : module.exactReviewQueueBayProjection(Object.values(state.items), [], batchByItemKey);
+    JSON.stringify({ ...stats, bay_projection: bay });
+  } finally {
+    for (const [name, original] of originals) Array.prototype[name] = original;
+    Array.prototype[Symbol.iterator] = iterator;
+  }
+  return {
+    population,
+    full_queue_traversals: fullQueueTraversals,
+    object_values_materializations: itemReads / population,
+    equivalent_queue_passes: Number((equivalentElements / population).toFixed(3)),
+  };
+}
+
+function normalizeVolatile(value, key = "") {
+  if (Array.isArray(value)) {
+    const normalized = value.map((entry) => normalizeVolatile(entry, key));
+    return key === "errors" && normalized.every((entry) => typeof entry === "string")
+      ? normalized.toSorted()
+      : normalized;
+  }
+  if (!value || typeof value !== "object") {
+    if (typeof value === "string" && /^\d{4}-\d\d-\d\dT/.test(value)) return "<time>";
+    return volatileKey(key) ? `<volatile:${key}>` : value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([childKey, child]) => [
+      childKey,
+      volatileKey(childKey) ? `<volatile:${childKey}>` : normalizeVolatile(child, childKey),
+    ]),
+  );
+}
+
+function volatileKey(key) {
+  return /(?:^generated_at$|_at$|_until$|_age_seconds$|_wait_seconds$|_ms$|request_id$|lease_id$)/.test(
+    key,
+  );
+}
+
+function seededRandom(initial) {
+  let value = initial >>> 0;
+  return () => {
+    value ^= value << 13;
+    value ^= value >>> 17;
+    value ^= value << 5;
+    return value >>> 0;
+  };
+}
+
+async function signedPost(origin, payload) {
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", proofSecret).update(body).digest("hex")}`;
+  const response = await fetch(`${origin}/internal/exact-review/enqueue`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+  return { status: response.status, text: await response.text() };
+}
+
+async function getJson(url) {
+  const response = await fetch(url);
+  const text = await response.text();
+  assert.equal(response.status, 200, `${url} returned ${response.status}: ${text}`);
+  return JSON.parse(text);
+}
+
+async function waitForWorker(origin, child, logPath) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`Worker exited early:\n${await readFile(logPath, "utf8")}`);
+    try {
+      const response = await fetch(`${origin}/api/health`);
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Worker did not become ready: ${origin}`);
+}
+
+async function stopWorker(worker) {
+  if (!worker || worker.child.exitCode !== null) return;
+  try {
+    process.kill(-worker.child.pid, "SIGTERM");
+  } catch {
+    worker.child.kill("SIGTERM");
+  }
+  await new Promise((resolve) => {
+    const timer = setTimeout(resolve, 5_000);
+    worker.child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+  worker.log.end();
+  await rm(worker.stateDir, { recursive: true, force: true });
+}
+
+async function command(executable, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, { cwd, env: process.env });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      const output = Buffer.concat([...stdout, ...stderr]).toString("utf8");
+      if (code === 0) resolve(output);
+      else reject(new Error(`${executable} ${args.join(" ")} failed (${code}):\n${output}`));
+    });
+  });
+}
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/docs/proof/single-census-read-model/run-proof.sh
+++ b/docs/proof/single-census-read-model/run-proof.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+proof_rc=0
+trap 'proof_rc=$?; echo "PROOF_RC=$proof_rc"' EXIT
+
+test -z "$(git status --porcelain --untracked-files=no)"
+git cat-file -e HEAD^{commit}
+echo "PROOF_RECEIPT=COMMITTED"
+echo "PROOF_HEAD=$(git rev-parse HEAD)"
+
+corepack enable
+pnpm install --frozen-lockfile
+node docs/proof/single-census-read-model/run-proof.mjs

--- a/test/exact-review-read-model-equivalence.test.ts
+++ b/test/exact-review-read-model-equivalence.test.ts
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  exactReviewPrioritizePublicationItems,
+  exactReviewQueueActivePublicationCount,
+  exactReviewQueueActiveReviewCount,
+  exactReviewQueueAdmittedItems,
+  exactReviewQueueBayProjection,
+  exactReviewQueueLaneStats,
+  exactReviewQueueNextWakeAt,
+  exactReviewQueueStats,
+  type ExactReviewBayBatchOwner,
+} from "../dashboard/exact-review-read-model.ts";
+import type {
+  ExactReviewQueueItem,
+  ExactReviewQueueState,
+} from "../dashboard/exact-review-queue.ts";
+import {
+  oldExactReviewPrioritizePublicationItems,
+  oldExactReviewQueueActivePublicationCount,
+  oldExactReviewQueueActiveReviewCount,
+  oldExactReviewQueueAdmittedItems,
+  oldExactReviewQueueBayProjection,
+  oldExactReviewQueueLaneStats,
+  oldExactReviewQueueNextWakeAt,
+  oldExactReviewQueueStats,
+} from "./fixtures/exact-review-read-model-old.ts";
+
+const NOW = Date.parse("2026-08-11T18:00:00.000Z");
+const SEEDS = [0x1, 0x2a, 0x1234abcd, 0x5eedc0de, 0x7fffffff, 0xdeadbeef];
+
+test("single-census read model is property-equivalent to the extracted implementation", () => {
+  for (const seed of SEEDS) {
+    const random = seededRandom(seed);
+    for (let population = 0; population < 12; population += 1) {
+      const state = randomQueueState(random, population === 0 ? 0 : 1 + random.int(120));
+      const items = Object.values(state.items);
+      const excluded = new Set(items.filter((_, index) => index % 7 === 0).map((item) => item.key));
+      const fresh = new Set(items.filter((_, index) => index % 5 === 0).map((item) => item.key));
+      const batchByItemKey = new Map<string, ExactReviewBayBatchOwner>(
+        items
+          .filter((_, index) => index % 11 === 0)
+          .map((item, index) => [item.key, { batchId: `batch-${seed}-${index}` }]),
+      );
+      const priorityKeys = items
+        .filter((_, index) => index % 9 === 0)
+        .map((item) => `${item.decision.targetRepo}#${item.decision.itemNumber}`);
+      const capacity = random.int(9);
+      const targetCapacity = random.int(4);
+      const publicationCapacity = random.int(7);
+      const publicationBlockedUntil = random.bool() ? NOW + random.int(90_000) : null;
+      const reviewAdmissionBlockedUntil = random.bool() ? NOW + random.int(45_000) : null;
+
+      const oldStats = oldExactReviewQueueStats(
+        state,
+        NOW,
+        capacity,
+        targetCapacity,
+        publicationCapacity,
+        6 * 60_000,
+        130 * 60_000,
+        15 * 60_000,
+        20 * 60_000,
+        excluded,
+        publicationBlockedUntil,
+      );
+      const newStats = exactReviewQueueStats(
+        state,
+        NOW,
+        capacity,
+        targetCapacity,
+        publicationCapacity,
+        6 * 60_000,
+        130 * 60_000,
+        15 * 60_000,
+        20 * 60_000,
+        excluded,
+        publicationBlockedUntil,
+      );
+      assert.deepEqual(newStats, oldStats, `stats seed=${seed} population=${population}`);
+      assert.equal(
+        JSON.stringify(newStats),
+        JSON.stringify(oldStats),
+        `stats bytes seed=${seed} population=${population}`,
+      );
+      assert.deepEqual(
+        exactReviewQueueBayProjection(items, priorityKeys, batchByItemKey),
+        oldExactReviewQueueBayProjection(items, priorityKeys, batchByItemKey),
+        `Bay seed=${seed} population=${population}`,
+      );
+      assert.deepEqual(
+        exactReviewQueueLaneStats(items, NOW, capacity, state.shedSinceReset, state),
+        oldExactReviewQueueLaneStats(items, NOW, capacity, state.shedSinceReset, state),
+        `lane seed=${seed} population=${population}`,
+      );
+      const publicationAdmissionBlocked = random.bool();
+      const uniquePublicationItems = random.bool();
+      const freshPublicationReserve = random.int(4);
+      assert.deepEqual(
+        exactReviewQueueAdmittedItems(
+          state,
+          NOW,
+          capacity,
+          targetCapacity,
+          publicationCapacity,
+          excluded,
+          publicationAdmissionBlocked,
+          uniquePublicationItems,
+          fresh,
+          freshPublicationReserve,
+        ).map((item) => item.key),
+        oldExactReviewQueueAdmittedItems(
+          state,
+          NOW,
+          capacity,
+          targetCapacity,
+          publicationCapacity,
+          excluded,
+          publicationAdmissionBlocked,
+          uniquePublicationItems,
+          fresh,
+          freshPublicationReserve,
+        ).map((item) => item.key),
+        `admission seed=${seed} population=${population}`,
+      );
+      assert.equal(
+        exactReviewQueueNextWakeAt(
+          state,
+          NOW,
+          capacity,
+          targetCapacity,
+          publicationCapacity,
+          15 * 60_000,
+          20 * 60_000,
+          excluded,
+          publicationBlockedUntil,
+          reviewAdmissionBlockedUntil,
+        ),
+        oldExactReviewQueueNextWakeAt(
+          state,
+          NOW,
+          capacity,
+          targetCapacity,
+          publicationCapacity,
+          15 * 60_000,
+          20 * 60_000,
+          excluded,
+          publicationBlockedUntil,
+          reviewAdmissionBlockedUntil,
+        ),
+        `wake seed=${seed} population=${population}`,
+      );
+      assert.equal(
+        exactReviewQueueActiveReviewCount(state),
+        oldExactReviewQueueActiveReviewCount(state),
+      );
+      assert.equal(
+        exactReviewQueueActivePublicationCount(state),
+        oldExactReviewQueueActivePublicationCount(state),
+      );
+      const publications = items.filter((item) => item.decision.publication);
+      const reserve = random.int(5);
+      assert.deepEqual(
+        exactReviewPrioritizePublicationItems(publications, fresh, reserve).map((item) => item.key),
+        oldExactReviewPrioritizePublicationItems(publications, fresh, reserve).map(
+          (item) => item.key,
+        ),
+      );
+    }
+  }
+});
+
+function randomQueueState(random: SeededRandom, size: number): ExactReviewQueueState {
+  const states = ["pending", "dispatching", "leased", "parked"] as const;
+  const targets = ["openclaw/openclaw", "openclaw/clawhub", "openclaw/clawsweeper"];
+  const items: Record<string, ExactReviewQueueItem> = {};
+  for (let index = 0; index < size; index += 1) {
+    const state = states[random.int(states.length)];
+    const publication = random.int(4) === 0;
+    const targetRepo = targets[random.int(targets.length)];
+    const itemNumber = 10_000 + random.int(Math.max(1, Math.floor(size / 3) + 1));
+    const createdAt = NOW - random.int(8 * 60 * 60_000);
+    const updatedAt = createdAt + random.int(Math.max(1, NOW - createdAt + 1));
+    const nextAttemptAt = NOW - 60_000 + random.int(4 * 60_000);
+    const key = `${targetRepo}#${itemNumber}${publication ? `@publish:${index}` : `@review:${index}`}`;
+    const sourceAction = publication
+      ? "exact_review_artifact_publish"
+      : random.int(5) === 0
+        ? "source_drift_requeue"
+        : "opened";
+    const decision = {
+      targetRepo,
+      targetBranch: "main",
+      itemNumber,
+      itemKind: random.bool() ? "issue" : "pull_request",
+      sourceEvent: random.bool() ? "issues" : "pull_request",
+      sourceAction,
+      supersedesInProgress: false,
+      ...(publication
+        ? {
+            publication: {
+              artifactName: `artifact-${index}`,
+              producerRunId: String(1000 + index),
+              producerRunAttempt: 1,
+              sourceSha: `${index}`.padStart(40, "a"),
+              itemKey: `${targetRepo}#${itemNumber}`,
+              protocolVersion: 2 as const,
+              leaseRevision: index,
+              claimGeneration: index,
+              liveProceeded: true,
+              liveTerminalNoop: false,
+              liveTerminalMissing: false,
+              liveGuardedOpen: false,
+              producerDecision: {
+                targetRepo,
+                targetBranch: "main",
+                itemNumber,
+                itemKind: "issue" as const,
+                sourceEvent: "issues" as const,
+                sourceAction: "opened",
+                supersedesInProgress: false,
+              },
+            },
+          }
+        : {}),
+    } as ExactReviewQueueItem["decision"];
+    const leaseExpiresAt = NOW + 1_000 + random.int(3 * 60 * 60_000);
+    items[key] = {
+      key,
+      decision,
+      state,
+      revision: 1 + random.int(5),
+      createdAt,
+      updatedAt,
+      nextAttemptAt,
+      attempts: random.int(4),
+      ...(state === "dispatching" || state === "leased"
+        ? {
+            leaseExpiresAt: random.int(12) === 0 ? undefined : leaseExpiresAt,
+            dispatchedAt: state === "dispatching" ? NOW - random.int(10 * 60_000) : undefined,
+            claimedAt: state === "leased" ? NOW - random.int(90 * 60_000) : undefined,
+            leaseHeartbeatAt: state === "leased" ? NOW - random.int(25 * 60_000) : undefined,
+            leasePhase: random.int(6) === 0 ? ("finalizing" as const) : ("review" as const),
+          }
+        : {}),
+      ...(state === "parked"
+        ? {
+            parkedReason: random.bool() ? "dispatch_rejected" : "review_retry_exhausted",
+            parkedRecoveryAttempts: random.int(5),
+            parkedRecoveryAt: random.bool() ? NOW + random.int(30 * 60_000) : undefined,
+            parkedTerminalCheckedAt: NOW - random.int(20 * 60_000),
+          }
+        : {}),
+      ...(state === "pending" && nextAttemptAt > NOW && random.bool()
+        ? {
+            backoffReason: publication
+              ? ("publication_retry" as const)
+              : ("retry_backoff" as const),
+          }
+        : {}),
+      ...(publication && random.bool() ? { publicationFailureAttempts: 1 + random.int(3) } : {}),
+      ...(!publication && random.bool() ? { reviewFailureAttempts: random.int(3) } : {}),
+    };
+  }
+  const dispatcherState = ["active", "paused", "blocked", "unknown"] as const;
+  const selectedDispatcherState = dispatcherState[random.int(dispatcherState.length)];
+  return {
+    items,
+    shedSinceReset: random.int(20),
+    dispatcher: {
+      state: selectedDispatcherState,
+      checkedAt: NOW - random.int(60_000),
+      retryAt:
+        selectedDispatcherState === "paused" || selectedDispatcherState === "blocked"
+          ? NOW - 30_000 + random.int(120_000)
+          : undefined,
+      reviewAdmissionNextAt: random.bool() ? NOW + random.int(90_000) : undefined,
+      parkedTerminalCheckedAt: NOW - random.int(15 * 60_000),
+      githubCredentialCircuits: {
+        openclaw: {
+          poolKey: "target_app:openclaw",
+          scope: "target_app",
+          targetOwner: "openclaw",
+          observedAt: NOW - 1_000,
+          retryAt: NOW - 30_000 + random.int(120_000),
+          provenance: "fallback",
+          authoritative: false,
+        },
+      },
+    },
+  };
+}
+
+type SeededRandom = ReturnType<typeof seededRandom>;
+
+function seededRandom(seed: number) {
+  let value = seed >>> 0;
+  const next = () => {
+    value ^= value << 13;
+    value ^= value >>> 17;
+    value ^= value << 5;
+    return value >>> 0;
+  };
+  return {
+    int(limit: number) {
+      return next() % limit;
+    },
+    bool() {
+      return (next() & 1) === 1;
+    },
+  };
+}

--- a/test/fixtures/exact-review-read-model-old.ts
+++ b/test/fixtures/exact-review-read-model-old.ts
@@ -1,0 +1,592 @@
+// TEST-ONLY SNAPSHOT: the queue read-model algorithms from origin/main at
+// 9c7445bdca92d05b5a38317b498d7f41fc19bc2b. Keep these deliberately
+// straightforward multi-pass implementations so randomized tests compare the
+// single-census refactor against the behavior it replaced.
+import {
+  summarizeExactReviewHandoff,
+  summarizeExactReviewPressure,
+} from "../../dashboard/exact-review-health.ts";
+import {
+  exactReviewQueueIsBatchablePublication,
+  exactReviewQueueIsPublication,
+} from "../../dashboard/exact-review-decision.ts";
+import {
+  DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS,
+  DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS,
+  DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
+  DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+  DEFAULT_EXACT_REVIEW_RETRY_MS,
+  exactReviewDispatchFailureDetailJson,
+  exactReviewEffectiveLeaseExpiresAt,
+  exactReviewGithubTargetAppCircuitRetryAt,
+  exactReviewParkedRecoveryAt,
+  exactReviewParkedTerminalCheckAt,
+  exactReviewParkedTerminalGlobalCheckAt,
+  exactReviewQueueBackoffReason,
+  exactReviewQueueBayPriorityKeys,
+  exactReviewQueueBayStage,
+  exactReviewQueueBayStagePriority,
+  exactReviewShedSinceReset,
+  type ExactReviewBayBatchOwner,
+} from "../../dashboard/exact-review-read-model.ts";
+import type {
+  ExactReviewQueueItem,
+  ExactReviewQueueState,
+} from "../../dashboard/exact-review-queue.ts";
+
+const OLD_BAY_SAMPLE_LIMIT = 24;
+const OLD_BAY_STAGES = [
+  "arriving",
+  "setting-up",
+  "reviewing",
+  "publishing",
+  "applying",
+  "repairing",
+] as const;
+type OldBayStage = (typeof OLD_BAY_STAGES)[number];
+type OldBayItem = {
+  item_key: string;
+  repository: string;
+  item_number: number;
+  stage: OldBayStage;
+  queue_state: ExactReviewQueueItem["state"];
+  created_at: string;
+  updated_at: string;
+  next_attempt_at: string;
+  batch_id?: string;
+};
+
+export function oldExactReviewQueueBayProjection(
+  items: ExactReviewQueueItem[],
+  priorityItemKeys: string[] = [],
+  batchByItemKey: ReadonlyMap<string, ExactReviewBayBatchOwner> = new Map(),
+) {
+  const projected = new Map<string, OldBayItem>();
+  for (const item of items) {
+    const repository = String(item.decision.targetRepo || "").trim();
+    const itemNumber = Number(item.decision.itemNumber);
+    if (!repository || !Number.isSafeInteger(itemNumber) || itemNumber <= 0) continue;
+    const batch = batchByItemKey.get(item.key);
+    const candidate: OldBayItem = {
+      item_key: `${repository}#${itemNumber}`,
+      repository,
+      item_number: itemNumber,
+      stage: exactReviewQueueBayStage(item, batchByItemKey),
+      queue_state: item.state,
+      created_at: new Date(item.createdAt).toISOString(),
+      updated_at: new Date(item.updatedAt).toISOString(),
+      next_attempt_at: new Date(item.nextAttemptAt).toISOString(),
+      ...(batch ? { batch_id: batch.batchId } : {}),
+    };
+    const previous = projected.get(candidate.item_key);
+    const candidateUpdatedAt = Date.parse(candidate.updated_at);
+    const previousUpdatedAt = previous ? Date.parse(previous.updated_at) : Number.NEGATIVE_INFINITY;
+    if (
+      !previous ||
+      candidateUpdatedAt > previousUpdatedAt ||
+      (candidateUpdatedAt === previousUpdatedAt &&
+        exactReviewQueueBayStagePriority(candidate.stage) >
+          exactReviewQueueBayStagePriority(previous.stage))
+    ) {
+      projected.set(candidate.item_key, candidate);
+    }
+  }
+  const rows = [...projected.values()];
+  const stages = Object.fromEntries(
+    OLD_BAY_STAGES.map((stage) => [stage, rows.filter((item) => item.stage === stage).length]),
+  ) as Record<OldBayStage, number>;
+  const rowsByStage = Object.fromEntries(
+    OLD_BAY_STAGES.map((stage) => [
+      stage,
+      rows
+        .filter((item) => item.stage === stage)
+        .sort(
+          (left, right) =>
+            Date.parse(left.created_at) - Date.parse(right.created_at) ||
+            left.item_key.localeCompare(right.item_key),
+        ),
+    ]),
+  ) as Record<OldBayStage, OldBayItem[]>;
+  const priorityRows = exactReviewQueueBayPriorityKeys(priorityItemKeys)
+    .map((itemKey) => projected.get(itemKey))
+    .filter((item): item is OldBayItem => Boolean(item))
+    .slice(0, OLD_BAY_SAMPLE_LIMIT);
+  const priorityKeys = new Set(priorityRows.map((item) => item.item_key));
+  const sample = [...priorityRows];
+  const longestStage = Math.max(...OLD_BAY_STAGES.map((stage) => rowsByStage[stage].length));
+  for (let index = 0; sample.length < OLD_BAY_SAMPLE_LIMIT && index < longestStage; index += 1) {
+    for (const stage of OLD_BAY_STAGES) {
+      const item = rowsByStage[stage][index];
+      if (!item || priorityKeys.has(item.item_key)) continue;
+      sample.push(item);
+      if (sample.length === OLD_BAY_SAMPLE_LIMIT) break;
+    }
+  }
+  return { sample_limit: OLD_BAY_SAMPLE_LIMIT, total: rows.length, stages, items: sample };
+}
+
+export function oldExactReviewQueueLaneStats(
+  items: ExactReviewQueueItem[],
+  now: number,
+  capacity: number,
+  shedSinceReset = 0,
+  state: ExactReviewQueueState = { items: {} },
+) {
+  const pendingItems = items.filter((item) => item.state === "pending");
+  const readyItems = pendingItems.filter((item) => item.nextAttemptAt <= now);
+  const backoffItems = pendingItems.filter((item) => item.nextAttemptAt > now);
+  const dispatchingItems = items.filter((item) => item.state === "dispatching");
+  const leasedItems = items.filter((item) => item.state === "leased");
+  const parkedItems = items.filter((item) => item.state === "parked");
+  const active = dispatchingItems.length + leasedItems.length;
+  const oldestPendingAt = pendingItems.reduce<number | null>(
+    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
+    null,
+  );
+  const oldestPendingKey = pendingItems
+    .slice()
+    .sort(
+      (left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key),
+    )[0]?.key;
+  const oldestReadyAt = readyItems.reduce<number | null>(
+    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
+    null,
+  );
+  const oldestBackoffAt = backoffItems.reduce<number | null>(
+    (oldest, item) => (oldest === null ? item.createdAt : Math.min(oldest, item.createdAt)),
+    null,
+  );
+  const nextAttemptAt = pendingItems.reduce<number | null>(
+    (next, item) => (next === null ? item.nextAttemptAt : Math.min(next, item.nextAttemptAt)),
+    null,
+  );
+  const reasonCounts = (reasons: string[]) =>
+    reasons.reduce<Record<string, number>>((counts, reason) => {
+      counts[reason] = (counts[reason] || 0) + 1;
+      return counts;
+    }, {});
+  return {
+    pending: pendingItems.length,
+    pending_depth: pendingItems.length,
+    shed_since_reset: shedSinceReset,
+    ready: readyItems.length,
+    backoff: backoffItems.length,
+    backoff_reasons: reasonCounts(
+      backoffItems.map((item) => exactReviewQueueBackoffReason(item, state, now)),
+    ),
+    dispatching: dispatchingItems.length,
+    leased: leasedItems.length,
+    parked: parkedItems.length,
+    parked_reasons: reasonCounts(parkedItems.map((item) => item.parkedReason || "unknown")),
+    capacity,
+    active,
+    available_slots: Math.max(0, capacity - active),
+    oldest_pending_at: oldestPendingAt === null ? null : new Date(oldestPendingAt).toISOString(),
+    oldest_pending_age_seconds:
+      oldestPendingAt === null ? null : Math.max(0, Math.floor((now - oldestPendingAt) / 1_000)),
+    oldest_pending_key: oldestPendingKey ?? null,
+    oldest_ready_at: oldestReadyAt === null ? null : new Date(oldestReadyAt).toISOString(),
+    oldest_ready_age_seconds:
+      oldestReadyAt === null ? null : Math.max(0, Math.floor((now - oldestReadyAt) / 1_000)),
+    oldest_backoff_at: oldestBackoffAt === null ? null : new Date(oldestBackoffAt).toISOString(),
+    oldest_backoff_age_seconds:
+      oldestBackoffAt === null ? null : Math.max(0, Math.floor((now - oldestBackoffAt) / 1_000)),
+    next_attempt_at: nextAttemptAt === null ? null : new Date(nextAttemptAt).toISOString(),
+  };
+}
+
+export function oldExactReviewQueueActiveReviewCount(state: ExactReviewQueueState) {
+  return Object.values(state.items).filter(
+    (item) =>
+      !exactReviewQueueIsPublication(item) &&
+      (item.state === "dispatching" || item.state === "leased"),
+  ).length;
+}
+
+export function oldExactReviewQueueActivePublicationCount(state: ExactReviewQueueState) {
+  return Object.values(state.items).filter(
+    (item) =>
+      exactReviewQueueIsPublication(item) &&
+      (item.state === "dispatching" || item.state === "leased"),
+  ).length;
+}
+
+export function oldExactReviewPrioritizePublicationItems(
+  items: ExactReviewQueueItem[],
+  freshItemKeys: ReadonlySet<string>,
+  freshReserve: number,
+) {
+  if (!freshReserve || !freshItemKeys.size) return items;
+  const fresh = items.filter((item) => freshItemKeys.has(item.key));
+  if (!fresh.length) return items;
+  const historical = items.filter((item) => !freshItemKeys.has(item.key));
+  if (!historical.length) return items;
+  const reservedFresh = fresh.slice(0, freshReserve);
+  return [...reservedFresh, ...historical, ...fresh.slice(reservedFresh.length)];
+}
+
+export function oldExactReviewQueueAdmittedItems(
+  state: ExactReviewQueueState,
+  now: number,
+  capacity: number,
+  targetCapacity: number,
+  publicationCapacity: number,
+  excludedItemKeys: ReadonlySet<string> = new Set(),
+  publicationAdmissionBlocked = false,
+  uniquePublicationItems = false,
+  freshPublicationItemKeys: ReadonlySet<string> = new Set(),
+  freshPublicationReserve = 0,
+) {
+  const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
+  if (
+    (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
+    dispatcherRetryAt > now
+  ) {
+    return [];
+  }
+  const reviewSlots = Math.max(0, capacity - oldExactReviewQueueActiveReviewCount(state));
+  const activeTargets = new Map<string, number>();
+  let activePublishers = 0;
+  for (const item of Object.values(state.items)) {
+    if (item.state !== "dispatching" && item.state !== "leased") continue;
+    if (exactReviewQueueIsPublication(item)) {
+      activePublishers += 1;
+      continue;
+    }
+    const target = item.decision.targetRepo;
+    activeTargets.set(target, (activeTargets.get(target) || 0) + 1);
+  }
+  const pending = Object.values(state.items)
+    .filter(
+      (item) =>
+        item.state === "pending" && item.nextAttemptAt <= now && !excludedItemKeys.has(item.key),
+    )
+    .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key));
+  const pendingReviews = pending.filter((item) => !exactReviewQueueIsPublication(item));
+  const pendingPublications = oldExactReviewPrioritizePublicationItems(
+    pending.filter(exactReviewQueueIsPublication),
+    freshPublicationItemKeys,
+    freshPublicationReserve,
+  );
+  const admittedReviews: ExactReviewQueueItem[] = [];
+  for (const item of pendingReviews) {
+    if (admittedReviews.length >= reviewSlots) break;
+    const target = item.decision.targetRepo;
+    if (exactReviewGithubTargetAppCircuitRetryAt(state, target, now) > now) continue;
+    const active = activeTargets.get(target) || 0;
+    if (active >= targetCapacity) continue;
+    activeTargets.set(target, active + 1);
+    admittedReviews.push(item);
+  }
+  const admittedPublications: ExactReviewQueueItem[] = [];
+  const admittedPublicationItems = new Set<string>();
+  for (const item of pendingPublications) {
+    if (
+      publicationAdmissionBlocked &&
+      !item.terminalFinalization &&
+      exactReviewQueueIsBatchablePublication(item)
+    ) {
+      continue;
+    }
+    if (activePublishers >= publicationCapacity) break;
+    const publicationItem = uniquePublicationItems
+      ? `${item.decision.targetRepo.toLowerCase()}#${item.decision.itemNumber}`
+      : "";
+    if (uniquePublicationItems && admittedPublicationItems.has(publicationItem)) continue;
+    activePublishers += 1;
+    if (uniquePublicationItems) admittedPublicationItems.add(publicationItem);
+    admittedPublications.push(item);
+  }
+  return [...admittedReviews, ...admittedPublications];
+}
+
+export function oldExactReviewQueueNextWakeAt(
+  state: ExactReviewQueueState,
+  now: number,
+  capacity = Number.POSITIVE_INFINITY,
+  targetCapacity = Number.POSITIVE_INFINITY,
+  publicationCapacity = Number.POSITIVE_INFINITY,
+  publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+  heartbeatGraceMs = DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
+  excludedItemKeys: ReadonlySet<string> = new Set(),
+  publicationBlockedUntil: number | null = null,
+  reviewAdmissionBlockedUntil: number | null = null,
+) {
+  const items = Object.values(state.items);
+  if (!items.length) return null;
+  const dispatcherRetryAt = Number(state.dispatcher?.retryAt || 0);
+  const dispatcherPaused =
+    (state.dispatcher?.state === "paused" || state.dispatcher?.state === "blocked") &&
+    dispatcherRetryAt > now;
+  const activeItems = items.filter(
+    (item) => item.state === "dispatching" || item.state === "leased",
+  );
+  if (
+    activeItems.some(
+      (item) =>
+        !item.leaseExpiresAt ||
+        exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs, heartbeatGraceMs) <=
+          now,
+    )
+  ) {
+    return now + 1_000;
+  }
+  const activeReviews = activeItems.filter((item) => !exactReviewQueueIsPublication(item));
+  const activePublishers = activeItems.filter(exactReviewQueueIsPublication);
+  const activeReviewWakeAt = activeReviews
+    .map((item) =>
+      exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs, heartbeatGraceMs),
+    )
+    .filter((value): value is number => Boolean(value && value > now));
+  const activePublisherWakeAt = activePublishers
+    .map((item) =>
+      exactReviewEffectiveLeaseExpiresAt(item, publicationDispatchLeaseMs, heartbeatGraceMs),
+    )
+    .filter((value): value is number => Boolean(value && value > now));
+  const activeTargetWakeAt = new Map<string, number>();
+  const activeTargetCounts = new Map<string, number>();
+  for (const item of activeReviews) {
+    const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(
+      item,
+      publicationDispatchLeaseMs,
+      heartbeatGraceMs,
+    );
+    if (leaseExpiresAt > now) {
+      const target = item.decision.targetRepo;
+      activeTargetCounts.set(target, (activeTargetCounts.get(target) || 0) + 1);
+      const current = activeTargetWakeAt.get(target);
+      activeTargetWakeAt.set(
+        target,
+        current === undefined ? leaseExpiresAt : Math.min(current, leaseExpiresAt),
+      );
+    }
+  }
+  const parkedTerminalGlobalCheckAt = exactReviewParkedTerminalGlobalCheckAt(state);
+  const times = items.flatMap((item) => {
+    if (item.state === "pending") {
+      if (excludedItemKeys.has(item.key)) return [];
+      if (dispatcherPaused) return [dispatcherRetryAt];
+      if (exactReviewQueueIsPublication(item)) {
+        if (publicationBlockedUntil !== null && publicationBlockedUntil > now) {
+          return [Math.max(item.nextAttemptAt, publicationBlockedUntil)];
+        }
+        let blockedUntil = item.nextAttemptAt;
+        if (activePublishers.length >= publicationCapacity) {
+          const capacityWakeAt = [...activePublisherWakeAt];
+          if (publicationCapacity <= 0) capacityWakeAt.push(...activeReviewWakeAt);
+          blockedUntil = capacityWakeAt.length
+            ? Math.min(...capacityWakeAt)
+            : now + DEFAULT_EXACT_REVIEW_RETRY_MS;
+        }
+        return [Math.max(item.nextAttemptAt, blockedUntil)];
+      }
+      const target = item.decision.targetRepo;
+      const credentialBlockedUntil = exactReviewGithubTargetAppCircuitRetryAt(state, target, now);
+      const capacityBlockedUntil = [
+        ...(activeReviews.length >= capacity && activeReviewWakeAt.length
+          ? [Math.min(...activeReviewWakeAt)]
+          : []),
+        ...((activeTargetCounts.get(target) || 0) >= targetCapacity &&
+        activeTargetWakeAt.has(target)
+          ? [activeTargetWakeAt.get(target) as number]
+          : []),
+      ];
+      return [
+        Math.max(
+          item.nextAttemptAt,
+          reviewAdmissionBlockedUntil ?? item.nextAttemptAt,
+          credentialBlockedUntil,
+          capacityBlockedUntil.length ? Math.min(...capacityBlockedUntil) : item.nextAttemptAt,
+        ),
+      ];
+    }
+    if (item.state === "parked") {
+      const recoveryAt = exactReviewParkedRecoveryAt(item);
+      const terminalCheckAt = exactReviewParkedTerminalCheckAt(item);
+      return [
+        recoveryAt,
+        terminalCheckAt === null
+          ? null
+          : Math.max(
+              terminalCheckAt,
+              parkedTerminalGlobalCheckAt,
+              dispatcherPaused ? dispatcherRetryAt : 0,
+            ),
+      ].filter((value): value is number => value !== null);
+    }
+    const leaseExpiresAt = exactReviewEffectiveLeaseExpiresAt(
+      item,
+      publicationDispatchLeaseMs,
+      heartbeatGraceMs,
+    );
+    return leaseExpiresAt ? [leaseExpiresAt] : [];
+  });
+  if (!times.length) return null;
+  return Math.max(now + 1_000, Math.min(...times));
+}
+
+export function oldExactReviewQueueStats(
+  state: ExactReviewQueueState,
+  now = Date.now(),
+  capacity = Number.POSITIVE_INFINITY,
+  targetCapacity = Number.POSITIVE_INFINITY,
+  publicationCapacity = Number.POSITIVE_INFINITY,
+  dispatchLeaseMs = DEFAULT_EXACT_REVIEW_DISPATCH_LEASE_MS,
+  executionLeaseMs = DEFAULT_EXACT_REVIEW_EXECUTION_LEASE_MS,
+  publicationDispatchLeaseMs = DEFAULT_EXACT_REVIEW_PUBLICATION_DISPATCH_LEASE_MS,
+  heartbeatGraceMs = DEFAULT_EXACT_REVIEW_HEARTBEAT_GRACE_MS,
+  excludedItemKeys: ReadonlySet<string> = new Set(),
+  publicationBlockedUntil: number | null = null,
+) {
+  const items = Object.values(state.items);
+  const handoffItems = items.filter(
+    (item): item is ExactReviewQueueItem & { state: "pending" | "dispatching" | "leased" } =>
+      item.state !== "parked" && !exactReviewQueueIsPublication(item),
+  );
+  const handoffHealth = summarizeExactReviewHandoff({
+    items: handoffItems,
+    dispatcher: state.dispatcher,
+    shedSinceReset: exactReviewShedSinceReset(state),
+    now,
+    capacity,
+    dispatchLeaseMs,
+    executionLeaseMs,
+  });
+  const targets = new Map<
+    string,
+    {
+      target_repo: string;
+      pending: number;
+      dispatching: number;
+      leased: number;
+      oldest_pending_at: number | null;
+    }
+  >();
+  for (const item of items) {
+    const targetRepo = item.decision.targetRepo;
+    const current = targets.get(targetRepo) ?? {
+      target_repo: targetRepo,
+      pending: 0,
+      dispatching: 0,
+      leased: 0,
+      oldest_pending_at: null,
+    };
+    if (item.state === "pending") {
+      current.pending += 1;
+      current.oldest_pending_at =
+        current.oldest_pending_at === null
+          ? item.createdAt
+          : Math.min(current.oldest_pending_at, item.createdAt);
+    } else if (item.state === "dispatching") current.dispatching += 1;
+    else if (item.state === "leased") current.leased += 1;
+    targets.set(targetRepo, current);
+  }
+  const targetStats = [...targets.values()]
+    .map((target) => ({
+      target_repo: target.target_repo,
+      pending: target.pending,
+      dispatching: target.dispatching,
+      leased: target.leased,
+      oldest_pending_at:
+        target.oldest_pending_at === null ? null : new Date(target.oldest_pending_at).toISOString(),
+    }))
+    .sort(
+      (left, right) =>
+        right.pending - left.pending ||
+        right.dispatching + right.leased - (left.dispatching + left.leased) ||
+        left.target_repo.localeCompare(right.target_repo),
+    );
+  const nextWakeAt = oldExactReviewQueueNextWakeAt(
+    state,
+    now,
+    capacity,
+    targetCapacity,
+    publicationCapacity,
+    publicationDispatchLeaseMs,
+    heartbeatGraceMs,
+    excludedItemKeys,
+    publicationBlockedUntil,
+    Number(state.dispatcher?.reviewAdmissionNextAt || 0) > now
+      ? Number(state.dispatcher?.reviewAdmissionNextAt)
+      : null,
+  );
+  const lanes = {
+    review: oldExactReviewQueueLaneStats(
+      items.filter((item) => !exactReviewQueueIsPublication(item)),
+      now,
+      capacity,
+      exactReviewShedSinceReset(state),
+      state,
+    ),
+    publication: oldExactReviewQueueLaneStats(
+      items.filter(exactReviewQueueIsPublication),
+      now,
+      publicationCapacity,
+      0,
+      state,
+    ),
+  };
+  const admissibleItems = oldExactReviewQueueAdmittedItems(
+    state,
+    now,
+    Number.MAX_SAFE_INTEGER,
+    targetCapacity,
+    publicationCapacity,
+    excludedItemKeys,
+    publicationBlockedUntil !== null && publicationBlockedUntil > now,
+  );
+  const reviewAdmissiblePending = admissibleItems.filter(
+    (item) => !exactReviewQueueIsPublication(item),
+  ).length;
+  const pressure = summarizeExactReviewPressure({
+    pending: lanes.review.pending,
+    readyPending: lanes.review.ready,
+    admissiblePending: reviewAdmissiblePending,
+    dispatching: lanes.review.dispatching,
+    leased: lanes.review.leased,
+    capacity: lanes.review.capacity,
+    dispatcherState: state.dispatcher?.state,
+    handoffStatus: handoffHealth.status,
+  });
+  return {
+    generated_at: handoffHealth.observed_at,
+    pending: lanes.review.pending,
+    ready_pending: lanes.review.ready,
+    admissible_pending: reviewAdmissiblePending,
+    shed_since_reset: exactReviewShedSinceReset(state),
+    dispatching: handoffHealth.phases.dispatching.count,
+    leased: handoffHealth.phases.leased.count,
+    oldest_pending_at: handoffHealth.phases.pending.oldest_at,
+    oldest_pending_age_seconds: handoffHealth.phases.pending.oldest_age_seconds,
+    oldest_pending_key: handoffHealth.phases.pending.oldest_key,
+    oldest_dispatching_at: handoffHealth.phases.dispatching.oldest_at,
+    oldest_dispatching_age_seconds: handoffHealth.phases.dispatching.oldest_age_seconds,
+    oldest_leased_at: handoffHealth.phases.leased.oldest_at,
+    oldest_leased_age_seconds: handoffHealth.phases.leased.oldest_age_seconds,
+    handoff_health: handoffHealth,
+    lanes,
+    pressure,
+    bay_projection: oldExactReviewQueueBayProjection(items),
+    next_wake_at: nextWakeAt === null ? null : new Date(nextWakeAt).toISOString(),
+    dispatcher: {
+      state: state.dispatcher?.state || "unknown",
+      reason: state.dispatcher?.reason || null,
+      workflow_state: state.dispatcher?.workflowState || null,
+      checked_at: state.dispatcher?.checkedAt
+        ? new Date(state.dispatcher.checkedAt).toISOString()
+        : null,
+      retry_at: state.dispatcher?.retryAt ? new Date(state.dispatcher.retryAt).toISOString() : null,
+      dispatch_failure_status: state.dispatcher?.dispatchFailureStatus ?? null,
+      dispatch_failure_class: state.dispatcher?.dispatchFailureClass || null,
+      dispatch_failure_at: state.dispatcher?.dispatchFailureAt
+        ? new Date(state.dispatcher.dispatchFailureAt).toISOString()
+        : null,
+      dispatch_failure_fingerprint: state.dispatcher?.dispatchFailureFingerprint || null,
+      dispatch_failure_detail: exactReviewDispatchFailureDetailJson(
+        state.dispatcher?.dispatchFailureDetail,
+      ),
+      dispatch_consecutive_failures: state.dispatcher?.dispatchConsecutiveFailures || 0,
+    },
+    target_stats: targetStats,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

The frequently polled exact-review queue status path repeatedly scanned and materialized the full durable queue to produce counts, lane health, admission, wake timing, and the public Bay projection. `/stats` also built the Bay projection twice.

## Why This Change Was Made

One queue traversal now builds an internal census containing lane/state counts, oldest records, active targets, ready work, wake inputs, and Bay candidates. Existing public read-model functions consume that census without changing their signatures, and the Durable Object reuses the stats census for its priority/batch-aware Bay projection.

## User Impact

There is no user-visible behavior change. Operators receive byte-identical queue and status responses with substantially less queue-size-dependent read work.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. The real-Worker proof shows its queue projection remains byte-identical, and the observer-only Bay boundary gains no queue, workflow, GitHub, recovery, deploy, or rollback action.

## Documentation Lifecycle

The new proof package is historical verification evidence bound to commit `e94f3ca1eccfd88f497ea1934e7378ea20957c8f`; it is not an active runbook. No documentation lifecycle or ownership contract changes.

## Evidence

- `pnpm run check`: 3,337 tests passed, 9 skipped, 0 failed; static checks, all builds, lint, formatting, and coverage thresholds passed.
- Fixed-seed property equivalence: 72 randomized queue states matched the test-only pre-refactor implementation for stats JSON bytes, lane stats, Bay projection, admission, active counts, and next wake.
- Measured 1,200-item `/stats` + customized Bay path: 12 → 1 full queue traversals, 7 → 1 `Object.values` materializations, and 21.250 → 1.667 equivalent queue passes.
- Pre-commit and committed-branch Codex autoreviews both returned clean with no accepted/actionable findings.

## Real Behavior Proof

**Claim:** Merge-base and candidate Workers return byte-identical normalized `/api/exact-review-queue` and `/api/status` responses while the candidate performs a single full census traversal.

**Exercised surface:** Real `wrangler dev --local` Worker and SQLite-backed `ExactReviewQueue` Durable Object at merge-base `9c7445bdca92d05b5a38317b498d7f41fc19bc2b` and candidate `e94f3ca1eccfd88f497ea1934e7378ea20957c8f`.

**Scenario and fixture:** Fixed seed `1592639710`; independent 0, 24, and 96-item queue populations submitted through the signed enqueue route; public responses normalized only for volatile timestamps, request/lease identifiers, and nondeterministic diagnostic error ordering. Traversal instrumentation ran only in the proof over a separate 1,200-item state.

**Command and environment:** Crabbox provider `aws`, lease `cbx_4650d7912abb` (`amber-prawn-e3e1`), run `run_8fc3339ec3bc`; `node:24-bookworm` Docker container; proof command `docs/proof/single-census-read-model/run-proof.sh` from an independent clone of the pushed branch.

**Observable result:** `PROOF_RECEIPT=COMMITTED`, `PROOF_HEAD=e94f3ca1eccfd88f497ea1934e7378ea20957c8f`, all six route/population comparisons byte-identical, `PROOF_RC=0`, Crabbox `runStatus=succeeded`, exit `0`.

**Artifact or trace:** Crabbox artifact `run_8fc3339ec3bc-artifacts.tgz` contains `proof-summary.json`; the reproducible harness and contract are in `docs/proof/single-census-read-model/`.

**Limits:** Synthetic pending reviews and a deterministic loopback GitHub error stub only. The proof does not contact GitHub, acquire review leases, publish records, or mutate production. Randomized active, parked, publication, capacity, circuit, and wake combinations are covered by the property test.
