### PR TITLE
refactor(dashboard): type webhook ingress decisions

### DIFF
--- a/dashboard/webhook-ingress.type-test.ts
+++ b/dashboard/webhook-ingress.type-test.ts
@@ -1,0 +1,17 @@
+import type { GithubWebhookClassifier } from "./worker.ts";
+
+declare const classifyGithubWebhook: GithubWebhookClassifier;
+
+classifyGithubWebhook({ event: "issue_comment", payload: {} });
+classifyGithubWebhook({ event: "issues", payload: {} });
+classifyGithubWebhook({ event: "pull_request", payload: {} });
+classifyGithubWebhook({ event: "future_event", payload: {} });
+
+// @ts-expect-error GitHub event names are strings.
+classifyGithubWebhook({ event: 7, payload: {} });
+
+// @ts-expect-error The classifier requires the correctly spelled payload property.
+classifyGithubWebhook({ event: "issues", paylod: {} });
+
+// @ts-expect-error Pull request fields do not belong to an issues delivery.
+classifyGithubWebhook({ event: "issues", payload: { pull_request: {} } });

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -89,6 +89,111 @@ const QUEUED_RUN_STATUSES = new Set(["queued", "waiting", "requested", "pending"
 type DashboardContext = { waitUntil?: (promise: Promise<unknown>) => void };
 type GithubJsonReader = (path: string) => ReturnType<typeof githubJson>;
 type StoredValue = { value: string; expires_at?: number };
+type GithubWebhookDeliveryHeaders = {
+  readonly event: string;
+  readonly deliveryId: string | null;
+  readonly signature: string;
+};
+type GithubWebhookRepositoryPayload = {
+  readonly full_name?: unknown;
+  readonly default_branch?: unknown;
+  readonly private?: unknown;
+  readonly archived?: unknown;
+  readonly fork?: unknown;
+  readonly has_issues?: unknown;
+};
+type GithubWebhookInstallationPayload = { readonly id?: unknown };
+type GithubWebhookLabelPayload = { readonly name?: unknown };
+type GithubWebhookUserPayload = { readonly login?: unknown };
+type GithubWebhookIssuePayload = {
+  readonly number?: unknown;
+  readonly user?: GithubWebhookUserPayload | null;
+};
+type GithubWebhookCommentPayload = {
+  readonly id?: unknown;
+  readonly body?: unknown;
+  readonly author_association?: unknown;
+  readonly user?: GithubWebhookUserPayload | null;
+  readonly created_at?: unknown;
+  readonly updated_at?: unknown;
+};
+type GithubWebhookPullRequestPayload = {
+  readonly number?: unknown;
+  readonly head?: { readonly sha?: unknown } | null;
+  readonly base?: { readonly sha?: unknown } | null;
+  readonly draft?: unknown;
+  readonly title?: unknown;
+  readonly body?: unknown;
+  readonly updated_at?: unknown;
+};
+type GithubWebhookBasePayload = {
+  readonly action?: unknown;
+  readonly repository?: GithubWebhookRepositoryPayload | null;
+  readonly installation?: GithubWebhookInstallationPayload | null;
+  readonly label?: GithubWebhookLabelPayload | null;
+};
+type GithubIssueCommentWebhookPayload = GithubWebhookBasePayload & {
+  readonly comment?: GithubWebhookCommentPayload | null;
+  readonly issue?: GithubWebhookIssuePayload | null;
+};
+type GithubIssueWebhookPayload = GithubWebhookBasePayload & {
+  readonly issue?: GithubWebhookIssuePayload | null;
+};
+type GithubPullRequestWebhookPayload = GithubWebhookBasePayload & {
+  readonly pull_request?: GithubWebhookPullRequestPayload | null;
+};
+type GithubWebhookPayload = GithubIssueCommentWebhookPayload &
+  GithubIssueWebhookPayload &
+  GithubPullRequestWebhookPayload;
+type GithubWebhookClassifierRuntimeInput = {
+  readonly event: string;
+  readonly payload: GithubWebhookPayload;
+};
+
+export type GithubWebhookClassifierInput<Event extends string = string> =
+  Event extends "issue_comment"
+    ? { readonly event: Event; readonly payload: GithubIssueCommentWebhookPayload }
+    : Event extends "issues"
+      ? { readonly event: Event; readonly payload: GithubIssueWebhookPayload }
+      : Event extends "pull_request"
+        ? { readonly event: Event; readonly payload: GithubPullRequestWebhookPayload }
+        : { readonly event: Event; readonly payload: GithubWebhookBasePayload };
+
+type GithubWebhookRejectedClassification = {
+  readonly accepted: false;
+  readonly reason: string;
+};
+export type GithubWebhookIssueCommentClassification = {
+  readonly accepted: true;
+  readonly type: "issue_comment";
+  readonly targetRepo: string;
+  readonly targetBranch: string;
+  readonly itemNumber: number;
+  readonly commentId: number;
+  readonly installationId: number;
+  readonly sourceAction: string;
+  readonly commentUpdatedAt?: string;
+  readonly commentBody?: string;
+};
+type GithubWebhookIssueClassification = ExactReviewDecision & {
+  readonly accepted: true;
+  readonly type: "item";
+  readonly installationId: number;
+  readonly itemKind: "issue";
+  readonly sourceEvent: "issues";
+};
+type GithubWebhookPullRequestClassification = ExactReviewDecision & {
+  readonly accepted: true;
+  readonly type: "item";
+  readonly installationId: number;
+  readonly itemKind: "pull_request";
+  readonly sourceEvent: "pull_request";
+};
+export type GithubWebhookClassification =
+  | GithubWebhookRejectedClassification
+  | GithubWebhookIssueCommentClassification
+  | GithubWebhookIssueClassification
+  | GithubWebhookPullRequestClassification;
 type WorkflowRunSummary = {
   id: number | string;
   name?: string;
@@ -1332,11 +1437,19 @@ async function githubWebhook(request, env, ctx) {
   if (!secret) return json({ error: "webhook_not_configured" }, 503);
 
   const bodyText = await request.text();
-  const signature = request.headers.get("x-hub-signature-256") || "";
-  const signatureOk = await verifyGithubWebhookSignature({ secret, signature, bodyText });
+  const deliveryHeaders: GithubWebhookDeliveryHeaders = {
+    event: request.headers.get("x-github-event") || "",
+    deliveryId: request.headers.get("x-github-delivery"),
+    signature: request.headers.get("x-hub-signature-256") || "",
+  };
+  const signatureOk = await verifyGithubWebhookSignature({
+    secret,
+    signature: deliveryHeaders.signature,
+    bodyText,
+  });
   if (!signatureOk) return json({ error: "invalid_signature" }, 401);
 
-  const event = request.headers.get("x-github-event") || "";
+  const event = deliveryHeaders.event;
   const payload = parseJsonObject(bodyText);
   if (!payload) return json({ error: "invalid_json" }, 400);
   if (event === "ping") {
@@ -1344,7 +1457,7 @@ async function githubWebhook(request, env, ctx) {
       {
         ok: true,
         event: "ping",
-        delivery: request.headers.get("x-github-delivery") || null,
+        delivery: deliveryHeaders.deliveryId || null,
       },
       202,
     );
@@ -1383,13 +1496,13 @@ async function githubWebhook(request, env, ctx) {
   }
 
   const decision = classifyGithubWebhook({ event, payload });
-  if (!decision.accepted) {
+  if (decision.accepted === false) {
     return json({ ok: true, accepted: false, reason: decision.reason }, 202);
   }
 
   if ("type" in decision && decision.type === "item") {
-    const deliveryId = request.headers.get("x-github-delivery") || "";
-    let itemDecision = decision as ExactReviewDecision & { installationId?: number };
+    const deliveryId = deliveryHeaders.deliveryId || "";
+    let itemDecision: ExactReviewDecision & { installationId: number } = decision;
     if (itemDecision.itemKind === "pull_request") {
       await acknowledgePullRequestReceipt({ env, ctx, decision: itemDecision }).catch((error) => {
         console.error(`ClawSweeper pull request fast ack failed: ${error?.message || error}`);
@@ -1476,7 +1589,7 @@ async function githubWebhook(request, env, ctx) {
   const trigger = bayJourneyTriggerFromGithubWebhook({
     decision,
     payload,
-    deliveryId: request.headers.get("x-github-delivery"),
+    deliveryId: deliveryHeaders.deliveryId,
   });
   if (trigger) await recordBayJourneyTelemetry(env, ctx, [trigger], []);
 
@@ -1492,7 +1605,7 @@ async function githubWebhook(request, env, ctx) {
     permissions: { contents: "write" },
   });
 
-  const commentDecision = decision as any;
+  const commentDecision = decision;
   const targetToken = await createGithubAppTokenFor({
     env,
     appJwt,
@@ -1549,7 +1662,15 @@ async function recordBayJourneyTelemetry(env, ctx, triggers, completions) {
   await write;
 }
 
-function bayJourneyTriggerFromGithubWebhook({ decision, payload, deliveryId }) {
+function bayJourneyTriggerFromGithubWebhook({
+  decision,
+  payload,
+  deliveryId,
+}: {
+  readonly decision: GithubWebhookClassification;
+  readonly payload: GithubIssueCommentWebhookPayload;
+  readonly deliveryId: string | null;
+}) {
   if (!decision?.accepted || decision?.type !== "issue_comment") return null;
   const comment = objectValue(payload?.comment);
   const commandText = commandTextForClawSweeperFastAck(String(comment.body || ""));
@@ -1643,13 +1764,26 @@ function lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env 
   };
 }
 
-function classifyGithubWebhook({ event, payload }) {
+function classifyGithubWebhook<const Event extends string>(
+  input: GithubWebhookClassifierInput<Event>,
+): GithubWebhookClassification;
+function classifyGithubWebhook({
+  event,
+  payload,
+}: GithubWebhookClassifierRuntimeInput): GithubWebhookClassification {
   const comment = classifyGithubIssueCommentWebhook({ event, payload });
-  if (comment.accepted || comment.reason !== "not issue_comment") return comment;
+  if (comment.accepted === true) return comment;
+  if (comment.reason !== "not issue_comment") return comment;
   return classifyGithubItemWebhook({ event, payload });
 }
+export type GithubWebhookClassifier = typeof classifyGithubWebhook;
 
-function classifyGithubIssueCommentWebhook({ event, payload }) {
+function classifyGithubIssueCommentWebhook({
+  event,
+  payload,
+}: GithubWebhookClassifierRuntimeInput):
+  | GithubWebhookRejectedClassification
+  | GithubWebhookIssueCommentClassification {
   if (event !== "issue_comment") return { accepted: false, reason: "not issue_comment" };
   const action = String(payload.action || "");
   if (!["created", "edited"].includes(action))
@@ -1705,12 +1839,20 @@ function classifyGithubIssueCommentWebhook({ event, payload }) {
   };
 }
 
-function exactWebhookTimestamp(value) {
+function exactWebhookTimestamp(value: unknown): string | null {
   const text = String(value || "").trim();
   return text && Number.isFinite(Date.parse(text)) ? text : null;
 }
 
-async function withPullRequestEditContentRevision({ event, payload, decision }) {
+async function withPullRequestEditContentRevision({
+  event,
+  payload,
+  decision,
+}: {
+  readonly event: string;
+  readonly payload: GithubPullRequestWebhookPayload;
+  readonly decision: ExactReviewDecision & { readonly installationId: number };
+}): Promise<ExactReviewDecision & { installationId: number }> {
   if (
     event !== "pull_request" ||
     decision.itemKind !== "pull_request" ||
@@ -1733,7 +1875,13 @@ async function withPullRequestEditContentRevision({ event, payload, decision }) 
   };
 }
 
-function classifyGithubItemWebhook({ event, payload }) {
+function classifyGithubItemWebhook({
+  event,
+  payload,
+}: GithubWebhookClassifierRuntimeInput):
+  | GithubWebhookRejectedClassification
+  | GithubWebhookIssueClassification
+  | GithubWebhookPullRequestClassification {
   const action = String(payload.action || "");
   const repo = objectValue(payload.repository);
   if (!isEligibleGithubWebhookRepository(repo)) {
@@ -1869,7 +2017,15 @@ async function bindLivePullRequestHeadAuthority({
     : null;
 }
 
-async function exactReviewPullRequestIngress({ event, payload, decision }) {
+async function exactReviewPullRequestIngress({
+  event,
+  payload,
+  decision,
+}: {
+  readonly event: string;
+  readonly payload: GithubPullRequestWebhookPayload;
+  readonly decision: ExactReviewDecision;
+}): Promise<ExactReviewIngress | undefined> {
   if (event !== "pull_request" || decision.itemKind !== "pull_request") return undefined;
   const pullRequest = objectValue(payload.pull_request);
   const headSha = String(objectValue(pullRequest.head).sha || "")
@@ -2958,6 +3114,12 @@ async function dispatchClawsweeperComment({
   decision,
   statusCommentId,
   sourceDeliveryId,
+}: {
+  readonly env: DashboardEnv;
+  readonly token: string;
+  readonly decision: GithubWebhookIssueCommentClassification;
+  readonly statusCommentId: number | null;
+  readonly sourceDeliveryId?: string;
 }) {
   const exactVersion =
     decision.commentUpdatedAt && typeof decision.commentBody === "string"

--- a/docs/proof/typed-webhook-ingress/README.md
+++ b/docs/proof/typed-webhook-ingress/README.md
@@ -30,6 +30,17 @@ A successful run writes `behavior-report.json` with the merge-base/head comparis
 evidence commit also records the required Docker-backed Crabbox `local-container` run against the
 committed implementation head in `container-receipt.json`.
 
+## Result
+
+The committed comparison covers merge-base `408c28329c188c15e2d3dbefe98a2393cbca4989`
+and implementation head `896513f31ce3279a69f34dff9425809d55f9d782`. All four status/body
+pairs are identical; see `behavior-report.json`.
+
+Docker-backed Crabbox `provider=local-container` ran the same proof in `node:24-bookworm` on
+lease `cbx_ceccf5f1e95d` (`crimson-crayfish-21d5`). The dashboard build and all four Worker
+comparisons passed, Crabbox exited 0, and the lease stopped automatically. Full provenance and
+three disclosed setup-only attempts are in `container-receipt.json`.
+
 ## OpenClaw Bay impact
 
 None. The classifier's runtime objects, lifecycle calls, Bay journey inputs, queue decisions, and

--- a/docs/proof/typed-webhook-ingress/README.md
+++ b/docs/proof/typed-webhook-ingress/README.md
@@ -1,0 +1,43 @@
+# Typed webhook ingress proof
+
+## Claim
+
+Phase 1 types the GitHub webhook classifier as an event-to-payload discriminated input and a
+rejected/comment/issue/pull-request result union without changing hosted webhook behavior.
+
+## Exercised surface
+
+`run-proof.mjs` extracts the merge-base into a disposable directory and starts two real
+`wrangler dev --local` Workers over loopback HTTP: one from merge-base and one from the current
+head. It sends the same HMAC-signed `issue_comment`, `issues`, `pull_request`, and unsupported-event
+deliveries to both production `/github/webhook` routes and requires every HTTP status and JSON body
+to compare deeply equal.
+
+The `issue_comment` fixture reaches the accepted comment path and stops at absent synthetic GitHub
+App configuration. The issue fixture exercises local queue admission. The pull-request fixture
+exercises local receipt/source-authority handling and the deferred live-head path. The unsupported
+fixture exercises the terminal rejected result.
+
+## Run
+
+From the repository root on Node 24 or newer:
+
+```bash
+docs/proof/typed-webhook-ingress/run-proof.sh
+```
+
+A successful run writes `behavior-report.json` with the merge-base/head comparison. The final
+evidence commit also records the required Docker-backed Crabbox `local-container` run against the
+committed implementation head in `container-receipt.json`.
+
+## OpenClaw Bay impact
+
+None. The classifier's runtime objects, lifecycle calls, Bay journey inputs, queue decisions, and
+observer contracts are unchanged. The patch adds TypeScript annotations and narrowing only; it
+does not add a Bay action or alter its observer-only boundary.
+
+## Limits
+
+The fixtures and webhook secret are synthetic. The proof exercises real local Worker routing,
+signature verification, payload parsing, classification, and local Durable Objects, but it does
+not call the live GitHub API, deploy a Worker, or mutate production state.

--- a/docs/proof/typed-webhook-ingress/README.md
+++ b/docs/proof/typed-webhook-ingress/README.md
@@ -34,14 +34,17 @@ Docker-backed Crabbox `local-container` run against the committed implementation
 
 ## Result
 
-The committed comparison covers merge-base `408c28329c188c15e2d3dbefe98a2393cbca4989`
-and implementation head `896513f31ce3279a69f34dff9425809d55f9d782`. All four status/body
-pairs are identical; see `behavior-report.json`.
+The frozen committed comparison covers merge-base `408c28329c188c15e2d3dbefe98a2393cbca4989`
+and implementation head `896513f31ce3279a69f34dff9425809d55f9d782`; all four status/body
+pairs are identical. The current-head container receipt separately covers source and launcher head
+`a7e4e37adb18c939bd3b57e9d9f6ffc4610a9bd6` without replacing that review-time report.
 
-Docker-backed Crabbox `provider=local-container` ran the same proof in `node:24-bookworm` on
-lease `cbx_ceccf5f1e95d` (`crimson-crayfish-21d5`). The dashboard build and all four Worker
-comparisons passed, Crabbox exited 0, and the lease stopped automatically. Full provenance and
-three disclosed setup-only attempts are in `container-receipt.json`.
+Docker-backed Crabbox `provider=local-container` used `--fresh-pr openclaw/clawsweeper#1132` in
+`node:24-bookworm` on lease `cbx_dda9e37f1731` (`crimson-hermit-cceb`), run
+`run_686d05277f14`. Two consecutive dashboard builds and Worker comparisons passed with all four
+outcomes identical in each run. The generated report stayed under `.artifacts/`, and
+`git status --porcelain` was empty before, between, and after the runs. Crabbox exited 0 and stopped
+the lease automatically; full provenance is in `container-receipt.json`.
 
 ## OpenClaw Bay impact
 

--- a/docs/proof/typed-webhook-ingress/README.md
+++ b/docs/proof/typed-webhook-ingress/README.md
@@ -26,9 +26,11 @@ From the repository root on Node 24 or newer:
 docs/proof/typed-webhook-ingress/run-proof.sh
 ```
 
-A successful run writes `behavior-report.json` with the merge-base/head comparison. The final
-evidence commit also records the required Docker-backed Crabbox `local-container` run against the
-committed implementation head in `container-receipt.json`.
+A successful re-run writes the merge-base/head comparison to
+`.artifacts/typed-webhook-ingress/behavior-report.json`. The committed `behavior-report.json`
+remains the frozen review-time copy. The final evidence commit also records the required
+Docker-backed Crabbox `local-container` run against the committed implementation head in
+`container-receipt.json`.
 
 ## Result
 

--- a/docs/proof/typed-webhook-ingress/behavior-report.json
+++ b/docs/proof/typed-webhook-ingress/behavior-report.json
@@ -1,0 +1,104 @@
+{
+  "schema": "clawsweeper-typed-webhook-ingress-proof/v1",
+  "generated_at": "2026-08-12T05:04:23.338Z",
+  "merge_base": "408c28329c188c15e2d3dbefe98a2393cbca4989",
+  "head": "896513f31ce3279a69f34dff9425809d55f9d782",
+  "runtime": "two real wrangler dev --local Workers over loopback HTTP",
+  "fixtures": [
+    {
+      "name": "issue_comment",
+      "event": "issue_comment",
+      "merge_base": {
+        "status": 503,
+        "body": {
+          "error": "github_app_not_configured"
+        }
+      },
+      "head": {
+        "status": 503,
+        "body": {
+          "error": "github_app_not_configured"
+        }
+      },
+      "identical": true
+    },
+    {
+      "name": "issues",
+      "event": "issues",
+      "merge_base": {
+        "status": 202,
+        "body": {
+          "ok": true,
+          "queued": true,
+          "item_key": "openclaw/gogcli#1129",
+          "superseded_publications": 0
+        }
+      },
+      "head": {
+        "status": 202,
+        "body": {
+          "ok": true,
+          "queued": true,
+          "item_key": "openclaw/gogcli#1129",
+          "superseded_publications": 0
+        }
+      },
+      "identical": true
+    },
+    {
+      "name": "pull_request",
+      "event": "pull_request",
+      "merge_base": {
+        "status": 202,
+        "body": {
+          "ok": true,
+          "accepted": true,
+          "deferred": true,
+          "reason": "pull request head verification deferred"
+        }
+      },
+      "head": {
+        "status": 202,
+        "body": {
+          "ok": true,
+          "accepted": true,
+          "deferred": true,
+          "reason": "pull request head verification deferred"
+        }
+      },
+      "identical": true
+    },
+    {
+      "name": "unsupported_event",
+      "event": "future_event",
+      "merge_base": {
+        "status": 202,
+        "body": {
+          "ok": true,
+          "accepted": false,
+          "reason": "unsupported event"
+        }
+      },
+      "head": {
+        "status": 202,
+        "body": {
+          "ok": true,
+          "accepted": false,
+          "reason": "unsupported event"
+        }
+      },
+      "identical": true
+    }
+  ],
+  "result": {
+    "compared": 4,
+    "identical": 4,
+    "different": 0,
+    "status": "succeeded"
+  },
+  "limits": [
+    "Fixtures use synthetic payloads and credentials.",
+    "The proof exercises signed Worker intake and local Durable Objects but no live GitHub API or production state.",
+    "The issue_comment fixture stops at missing synthetic App configuration; the item fixtures exercise local queue admission."
+  ]
+}

--- a/docs/proof/typed-webhook-ingress/container-receipt.json
+++ b/docs/proof/typed-webhook-ingress/container-receipt.json
@@ -1,0 +1,78 @@
+{
+  "schema": "clawsweeper-real-worker-proof-provenance/v1",
+  "tested_commit": "896513f31ce3279a69f34dff9425809d55f9d782",
+  "merge_base": "408c28329c188c15e2d3dbefe98a2393cbca4989",
+  "crabbox": {
+    "cli_version": "0.38.3-5-g2a79805d",
+    "provider": "local-container",
+    "lease_id": "cbx_ceccf5f1e95d",
+    "lease_slug": "crimson-crayfish-21d5",
+    "run_id": null,
+    "machine_type": "node_24-bookworm",
+    "container_image": "node:24-bookworm",
+    "checkout": "fresh single-branch clone of origin/steipete/typed-webhook-ingress with explicit origin/main remote-tracking fetch",
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true
+  },
+  "runtime": {
+    "node": "v24.19.0",
+    "pnpm": "11.10.0",
+    "wrangler": "4.107.0"
+  },
+  "timing_ms": {
+    "sync": 24313,
+    "command": 28493,
+    "total": 52820,
+    "phases": {
+      "user_command": 13732,
+      "build": 569,
+      "worker_proof": 14192
+    }
+  },
+  "result": {
+    "dashboard_build": "passed",
+    "worker_fixtures_compared": 4,
+    "worker_fixtures_identical": 4,
+    "worker_fixture_differences": 0,
+    "proof_marker": "TYPED_WEBHOOK_INGRESS_PROOF_RC=0",
+    "stdout": {
+      "bytes": 3396,
+      "sha256": "bafb9cb9243bbf72f05a0fcab4f3dbbdfcd276ddc83d53ef277ea9fb081ff03b"
+    },
+    "stderr": {
+      "bytes": 3510,
+      "sha256": "655d7525d9dd882506a09b26ac88a4c22d9f85449e05079d86fc020151e83bd0"
+    }
+  },
+  "discarded_setup_attempts": [
+    {
+      "lease_id": "cbx_b6a661e59ce4",
+      "lease_slug": "brisk-lobster-9d4d",
+      "exit_code": 128,
+      "reason": "Raw linked-worktree sync intentionally omitted Git metadata, so the proof could not resolve the repository root.",
+      "lease_stopped": true
+    },
+    {
+      "lease_id": "cbx_2fed7ec8325c",
+      "lease_slug": "silver-prawn-b49b",
+      "tested_commit": "623cfae508573d2927539008b65bfaebd46d405a",
+      "exit_code": 1,
+      "reason": "The initial proof wrapper asked unprivileged Corepack to create /usr/local/bin/pnpm; the wrapper now uses a user-local PNPM_HOME.",
+      "lease_stopped": true
+    },
+    {
+      "lease_id": "cbx_547b3d225d57",
+      "lease_slug": "violet-shrimp-d152",
+      "tested_commit": "896513f31ce3279a69f34dff9425809d55f9d782",
+      "exit_code": 1,
+      "reason": "The single-branch launcher's main fetch populated FETCH_HEAD but not refs/remotes/origin/main; the successful launcher fetched the explicit remote-tracking ref.",
+      "lease_stopped": true
+    }
+  ],
+  "limits": [
+    "Fixtures and webhook credentials were synthetic.",
+    "The proof exercised real local Worker routing, signature verification, classification, and local Durable Objects without live GitHub API calls or production mutation.",
+    "The evidence commit containing this receipt was not part of the tested source commit; it changes proof artifacts only."
+  ]
+}

--- a/docs/proof/typed-webhook-ingress/container-receipt.json
+++ b/docs/proof/typed-webhook-ingress/container-receipt.json
@@ -1,16 +1,16 @@
 {
   "schema": "clawsweeper-real-worker-proof-provenance/v1",
-  "tested_commit": "896513f31ce3279a69f34dff9425809d55f9d782",
+  "tested_commit": "a7e4e37adb18c939bd3b57e9d9f6ffc4610a9bd6",
   "merge_base": "408c28329c188c15e2d3dbefe98a2393cbca4989",
   "crabbox": {
     "cli_version": "0.38.3-5-g2a79805d",
     "provider": "local-container",
-    "lease_id": "cbx_ceccf5f1e95d",
-    "lease_slug": "crimson-crayfish-21d5",
-    "run_id": null,
+    "lease_id": "cbx_dda9e37f1731",
+    "lease_slug": "crimson-hermit-cceb",
+    "run_id": "run_686d05277f14",
     "machine_type": "node_24-bookworm",
     "container_image": "node:24-bookworm",
-    "checkout": "fresh single-branch clone of origin/steipete/typed-webhook-ingress with explicit origin/main remote-tracking fetch",
+    "checkout": "--fresh-pr openclaw/clawsweeper#1132 with explicit origin/main remote-tracking fetch",
     "exit_code": 0,
     "run_status": "succeeded",
     "lease_stopped": true
@@ -18,61 +18,69 @@
   "runtime": {
     "node": "v24.19.0",
     "pnpm": "11.10.0",
-    "wrangler": "4.107.0"
+    "wrangler": "4.107.0",
+    "jq": "jq-1.8.1",
+    "jq_asset": "jq-linux-arm64",
+    "jq_sha256": "6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4"
   },
   "timing_ms": {
-    "sync": 24313,
-    "command": 28493,
-    "total": 52820,
-    "phases": {
-      "user_command": 13732,
-      "build": 569,
-      "worker_proof": 14192
-    }
+    "lease": 14809,
+    "bootstrap": 78,
+    "sync": 14962,
+    "command": 32529,
+    "total": 47542,
+    "end_to_end": 62362,
+    "command_phases": [
+      { "name": "user-command", "ms": 7052 },
+      { "name": "build", "ms": 396 },
+      { "name": "worker-proof", "ms": 16184 },
+      { "name": "build", "ms": 396 },
+      { "name": "worker-proof", "ms": 8499 }
+    ]
   },
   "result": {
-    "dashboard_build": "passed",
-    "worker_fixtures_compared": 4,
-    "worker_fixtures_identical": 4,
-    "worker_fixture_differences": 0,
-    "proof_marker": "TYPED_WEBHOOK_INGRESS_PROOF_RC=0",
+    "dashboard_build_runs": 2,
+    "dashboard_builds_passed": 2,
+    "worker_proof_runs": 2,
+    "worker_fixtures_compared_per_run": 4,
+    "worker_fixtures_identical_per_run": 4,
+    "worker_fixture_differences_per_run": 0,
+    "output_path": ".artifacts/typed-webhook-ingress/behavior-report.json",
+    "checkout_clean_before": true,
+    "checkout_clean_after_first_run": true,
+    "checkout_clean_after_second_run": true,
+    "proof_marker": "TYPED_WEBHOOK_INGRESS_CURRENT_HEAD_PROOF_RC=0",
+    "report": {
+      "bytes_per_run": 2580,
+      "first_run_generated_at": "2026-08-12T05:29:02.294Z",
+      "first_run_sha256": "ea09db2adfea2bfe912b1b544429bd4be06c24f7a563c5552cdc16d6d307d452",
+      "second_run_generated_at": "2026-08-12T05:29:11.661Z",
+      "second_run_sha256": "7242f444bab6f0f9ba65d6fdbeea77542668417f10274df6927c35b11706c274"
+    },
     "stdout": {
-      "bytes": 3396,
-      "sha256": "bafb9cb9243bbf72f05a0fcab4f3dbbdfcd276ddc83d53ef277ea9fb081ff03b"
+      "bytes": 6639,
+      "sha256": "07748fdf35543cd980c144973d6b1ab1b8b0db7bf8356a618b3e01226d6ab799"
     },
     "stderr": {
-      "bytes": 3510,
-      "sha256": "655d7525d9dd882506a09b26ac88a4c22d9f85449e05079d86fc020151e83bd0"
+      "bytes": 149,
+      "sha256": "4f119d7539454d9dcfc031557c85a91c2360b479e577737a8365125abf66b730"
     }
   },
   "discarded_setup_attempts": [
     {
-      "lease_id": "cbx_b6a661e59ce4",
-      "lease_slug": "brisk-lobster-9d4d",
-      "exit_code": 128,
-      "reason": "Raw linked-worktree sync intentionally omitted Git metadata, so the proof could not resolve the repository root.",
-      "lease_stopped": true
-    },
-    {
-      "lease_id": "cbx_2fed7ec8325c",
-      "lease_slug": "silver-prawn-b49b",
-      "tested_commit": "623cfae508573d2927539008b65bfaebd46d405a",
+      "lease_id": "cbx_c3f6213ec43c",
+      "lease_slug": "coral-crayfish-2f12",
+      "run_id": "run_e052ec43551b",
+      "tested_commit": "a7e4e37adb18c939bd3b57e9d9f6ffc4610a9bd6",
       "exit_code": 1,
-      "reason": "The initial proof wrapper asked unprivileged Corepack to create /usr/local/bin/pnpm; the wrapper now uses a user-local PNPM_HOME.",
-      "lease_stopped": true
-    },
-    {
-      "lease_id": "cbx_547b3d225d57",
-      "lease_slug": "violet-shrimp-d152",
-      "tested_commit": "896513f31ce3279a69f34dff9425809d55f9d782",
-      "exit_code": 1,
-      "reason": "The single-branch launcher's main fetch populated FETCH_HEAD but not refs/remotes/origin/main; the successful launcher fetched the explicit remote-tracking ref.",
+      "reason": "The fresh-pr uploaded-script transport created an untracked .crabbox directory before the baseline cleanliness assertion; the successful temporary launcher removed that transport residue before observing proof behavior.",
       "lease_stopped": true
     }
   ],
   "limits": [
     "Fixtures and webhook credentials were synthetic.",
     "The proof exercised real local Worker routing, signature verification, classification, and local Durable Objects without live GitHub API calls or production mutation.",
-    "The evidence commit containing this receipt was not part of the tested source commit; it changes proof artifacts only."
+    "The current-head proof ran twice to verify that routine output remains under the ignored .artifacts directory and leaves git status --porcelain empty.",
+    "The evidence commit containing this refreshed receipt was not part of the tested source commit; it changes this receipt and its README summary only, not the proof launcher or runtime source."
   ]
 }

--- a/docs/proof/typed-webhook-ingress/run-proof.mjs
+++ b/docs/proof/typed-webhook-ingress/run-proof.mjs
@@ -16,7 +16,8 @@ const repoRoot = (await git(["rev-parse", "--show-toplevel"], proofDir)).trim();
 const head = (await git(["rev-parse", "HEAD"], repoRoot)).trim();
 const mergeBase = (await git(["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
 const outputPath = path.resolve(
-  process.env.TYPED_WEBHOOK_INGRESS_PROOF_OUTPUT || path.join(proofDir, "behavior-report.json"),
+  process.env.TYPED_WEBHOOK_INGRESS_PROOF_OUTPUT ||
+    path.join(repoRoot, ".artifacts/typed-webhook-ingress/behavior-report.json"),
 );
 const scratch = await mkdtemp(path.join(os.tmpdir(), "clawsweeper-typed-webhook-ingress-"));
 const baseRoot = path.join(scratch, "merge-base");

--- a/docs/proof/typed-webhook-ingress/run-proof.mjs
+++ b/docs/proof/typed-webhook-ingress/run-proof.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { execFile as execFileCallback } from "node:child_process";
+
+const execFile = promisify(execFileCallback);
+const proofDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = (await git(["rev-parse", "--show-toplevel"], proofDir)).trim();
+const head = (await git(["rev-parse", "HEAD"], repoRoot)).trim();
+const mergeBase = (await git(["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
+const outputPath = path.resolve(
+  process.env.TYPED_WEBHOOK_INGRESS_PROOF_OUTPUT || path.join(proofDir, "behavior-report.json"),
+);
+const scratch = await mkdtemp(path.join(os.tmpdir(), "clawsweeper-typed-webhook-ingress-"));
+const baseRoot = path.join(scratch, "merge-base");
+const webhookSecret = "typed-webhook-ingress-proof";
+
+const repository = {
+  full_name: "openclaw/gogcli",
+  default_branch: "trunk",
+  private: false,
+  archived: false,
+  fork: false,
+  has_issues: true,
+};
+const fixtures = [
+  {
+    name: "issue_comment",
+    event: "issue_comment",
+    payload: {
+      action: "created",
+      repository,
+      issue: { number: 1128, user: { login: "steipete" } },
+      installation: { id: 123 },
+      comment: {
+        id: 456,
+        body: "@clawsweeper review",
+        author_association: "OWNER",
+        user: { login: "steipete" },
+      },
+    },
+  },
+  {
+    name: "issues",
+    event: "issues",
+    payload: {
+      action: "opened",
+      repository,
+      issue: { number: 1129 },
+      installation: { id: 123 },
+    },
+  },
+  {
+    name: "pull_request",
+    event: "pull_request",
+    payload: {
+      action: "opened",
+      repository,
+      pull_request: {
+        number: 1130,
+        head: { sha: "a".repeat(40) },
+        base: { sha: "b".repeat(40) },
+        draft: false,
+        title: "Typed webhook ingress proof",
+        body: "Synthetic proof fixture.",
+        updated_at: "2026-08-11T20:00:00Z",
+      },
+      installation: { id: 123 },
+    },
+  },
+  {
+    name: "unsupported_event",
+    event: "future_event",
+    payload: { action: "opened", repository, installation: { id: 123 } },
+  },
+];
+
+await mkdir(baseRoot, { recursive: true });
+await extractRevision(mergeBase, baseRoot);
+
+let baseWorker;
+let headWorker;
+try {
+  baseWorker = await startWorker(baseRoot, "merge-base");
+  headWorker = await startWorker(repoRoot, "head");
+  const before = await runFixtures(baseWorker.origin);
+  const after = await runFixtures(headWorker.origin);
+  assert.deepEqual(after, before);
+
+  const report = {
+    schema: "clawsweeper-typed-webhook-ingress-proof/v1",
+    generated_at: new Date().toISOString(),
+    merge_base: mergeBase,
+    head,
+    runtime: "two real wrangler dev --local Workers over loopback HTTP",
+    fixtures: fixtures.map((fixture, index) => ({
+      name: fixture.name,
+      event: fixture.event,
+      merge_base: before[index],
+      head: after[index],
+      identical: true,
+    })),
+    result: {
+      compared: fixtures.length,
+      identical: fixtures.length,
+      different: 0,
+      status: "succeeded",
+    },
+    limits: [
+      "Fixtures use synthetic payloads and credentials.",
+      "The proof exercises signed Worker intake and local Durable Objects but no live GitHub API or production state.",
+      "The issue_comment fixture stops at missing synthetic App configuration; the item fixtures exercise local queue admission.",
+    ],
+  };
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write("TYPED_WEBHOOK_INGRESS_PROOF_RC=0\n");
+} finally {
+  await Promise.all([stopWorker(baseWorker), stopWorker(headWorker)]);
+  await rm(scratch, { recursive: true, force: true });
+}
+
+async function runFixtures(origin) {
+  const outcomes = [];
+  for (const fixture of fixtures) {
+    const body = JSON.stringify(fixture.payload);
+    const response = await fetch(`${origin}/github/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": fixture.event,
+        "x-github-delivery": `typed-webhook-${fixture.name}`,
+        "x-hub-signature-256": signature(body),
+      },
+      body,
+    });
+    outcomes.push({ status: response.status, body: await response.json() });
+  }
+  return outcomes;
+}
+
+async function startWorker(sourceRoot, label) {
+  const port = await availablePort();
+  const persistence = path.join(scratch, `${label}-state`);
+  const logs = [];
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      "wrangler@4.107.0",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      persistence,
+      "--config",
+      path.join(sourceRoot, "dashboard/wrangler.toml"),
+      "--var",
+      `CLAWSWEEPER_WEBHOOK_SECRET:${webhookSecret}`,
+    ],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+    },
+  );
+  child.stdout.on("data", (chunk) => logs.push(String(chunk)));
+  child.stderr.on("data", (chunk) => logs.push(String(chunk)));
+  const origin = `http://127.0.0.1:${port}`;
+  try {
+    await waitForWorker(origin, child, logs);
+  } catch (error) {
+    await stopWorker({ child });
+    throw error;
+  }
+  return { child, origin };
+}
+
+async function waitForWorker(origin, child, logs) {
+  const body = "{}";
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`Wrangler exited early (${child.exitCode}):\n${logs.join("")}`);
+    }
+    try {
+      const response = await fetch(`${origin}/github/webhook`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "ping",
+          "x-hub-signature-256": signature(body),
+        },
+        body,
+      });
+      if (response.status === 202) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Wrangler did not become ready:\n${logs.join("")}`);
+}
+
+async function stopWorker(worker) {
+  if (!worker?.child || worker.child.exitCode !== null) return;
+  const signalTarget = process.platform === "win32" ? worker.child.pid : -worker.child.pid;
+  try {
+    process.kill(signalTarget, "SIGTERM");
+  } catch {}
+  await Promise.race([
+    new Promise((resolve) => worker.child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 5000)),
+  ]);
+  if (worker.child.exitCode === null) {
+    try {
+      process.kill(signalTarget, "SIGKILL");
+    } catch {}
+  }
+}
+
+async function extractRevision(revision, destination) {
+  await new Promise((resolve, reject) => {
+    const archive = spawn("git", ["archive", revision], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const extract = spawn("tar", ["-x", "-C", destination], { stdio: ["pipe", "ignore", "pipe"] });
+    archive.stdout.pipe(extract.stdin);
+    const errors = [];
+    archive.stderr.on("data", (chunk) => errors.push(String(chunk)));
+    extract.stderr.on("data", (chunk) => errors.push(String(chunk)));
+    let archiveCode;
+    let extractCode;
+    const finish = () => {
+      if (archiveCode === undefined || extractCode === undefined) return;
+      if (archiveCode === 0 && extractCode === 0) resolve();
+      else reject(new Error(`revision extraction failed:\n${errors.join("")}`));
+    };
+    archive.on("exit", (code) => {
+      archiveCode = code;
+      finish();
+    });
+    extract.on("exit", (code) => {
+      extractCode = code;
+      finish();
+    });
+  });
+}
+
+function signature(body) {
+  return `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+}
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+async function git(args, cwd) {
+  return (await execFile("git", args, { cwd, maxBuffer: 10 * 1024 * 1024 })).stdout;
+}

--- a/docs/proof/typed-webhook-ingress/run-proof.sh
+++ b/docs/proof/typed-webhook-ingress/run-proof.sh
@@ -7,8 +7,13 @@ cd "$repo_root"
 
 export CI=1
 export WRANGLER_SEND_METRICS=false
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/bin}"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
 
-corepack enable
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME"
+fi
 pnpm install --frozen-lockfile
 printf 'PROOF_HEAD=%s\n' "$(git rev-parse HEAD)"
 printf 'PROOF_NODE=%s\n' "$(node --version)"

--- a/docs/proof/typed-webhook-ingress/run-proof.sh
+++ b/docs/proof/typed-webhook-ingress/run-proof.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+proof_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$proof_dir" rev-parse --show-toplevel)"
+cd "$repo_root"
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+corepack enable
+pnpm install --frozen-lockfile
+printf 'PROOF_HEAD=%s\n' "$(git rev-parse HEAD)"
+printf 'PROOF_NODE=%s\n' "$(node --version)"
+printf 'PROOF_PNPM=%s\n' "$(pnpm --version)"
+printf 'CRABBOX_PHASE:build\n'
+pnpm run build:dashboard
+printf 'CRABBOX_PHASE:worker-proof\n'
+node "$proof_dir/run-proof.mjs"


### PR DESCRIPTION
## Scope

Phase 1 only of https://github.com/openclaw/clawsweeper/issues/1128.

This PR types the hosted GitHub webhook classification path. It does not enable strict compiler
flags, add a per-file strict allowlist, change classification policy, or begin Phase 2.

## Union shape

The classifier input maps string event literals to readonly consumed-field payload shapes:

- `issue_comment` -> repository, installation, issue, comment, action fields read by the path
- `issues` -> repository, installation, issue, label, action fields read by the path
- `pull_request` -> repository, installation, pull request, label, action fields read by the path
- other string event names -> the common repository/installation/label/action shape

The result union has four classification kinds: rejected, accepted issue comment, accepted issue
item, and accepted pull-request item. Existing runtime discriminants remain the source of truth:
`accepted`, then `type`, `itemKind`, and `sourceEvent`. The accepted comment member now flows into
`dispatchClawsweeperComment` without `as any`.

## Typing-forced code motion

No classification branch or returned object changed. Typing forced only these adjacent edits:

1. The three delivery-header reads are collected once in a readonly typed object and the same raw
   values are reused.
2. `!decision.accepted` is spelled `decision.accepted === false` so the relaxed dashboard compiler
   narrows the rejected member.
3. The classifier's compound accepted/reason guard is split into two guards for the same narrowing.
4. The accepted item local uses a type annotation instead of its previous assertion.
5. Existing timestamp, pull-request revision/ingress, Bay-trigger, and comment-dispatch parameters
   receive annotations needed to carry the narrowed members end to end.

The dedicated expect-error fixture rejects the issue's malformed `{ event: 7, paylod: {} }` shape,
the misspelled payload property by itself, and pull-request-only fields on an `issues` delivery.

## `pr-behavior-proof`

- Claim: Type annotations and union narrowing do not change hosted webhook classification outcomes.
- Exercised surface: real `wrangler dev --local` Worker HTTP intake, HMAC verification, JSON parsing,
  classifier branches, local issue queue admission, pull-request source-authority deferral, and the
  unsupported-event terminal result.
- Scenario: identical signed `issue_comment`, `issues`, `pull_request`, and future-event deliveries
  are sent to merge-base and implementation-head Workers twice from a fresh PR checkout.
- Command/environment: `docs/proof/typed-webhook-ingress/run-proof.sh`; Node 24, pinned pnpm,
  Wrangler 4.107.0. Required proof used Docker-backed Crabbox `provider=local-container`,
  `--fresh-pr openclaw/clawsweeper#1132`, image `node:24-bookworm`, checksum-verified jq 1.8.1,
  lease `cbx_dda9e37f1731` (`crimson-hermit-cceb`), run `run_686d05277f14`.
- Observable result: source and launcher head `a7e4e37adb18c939bd3b57e9d9f6ffc4610a9bd6` produced four
  deeply equal HTTP status/JSON body pairs in each of two consecutive runs; both dashboard builds
  passed; `git status --porcelain` was empty before, between, and after the runs; Crabbox exited 0
  and stopped the lease automatically. Final branch head `afa21cd96c4731da327b051535a6ec3381c26e88`
  adds only the refreshed receipt and this README summary, leaving the tested launcher unchanged.
- Artifacts: frozen review-time `docs/proof/typed-webhook-ingress/behavior-report.json`, current-head
  `docs/proof/typed-webhook-ingress/container-receipt.json`, and ignored rerun output under
  `.artifacts/typed-webhook-ingress/`.
- Limits: fixtures and credentials are synthetic; no live GitHub call, Worker deployment, or
  production mutation occurs.

## Validation

- `pnpm run build:dashboard`
- `node --test test/dashboard-worker-webhook-ingress.test.ts` — 25 passed, 0 failed
- `pnpm run check` — 3,346 tests; 3,337 passed, 9 skipped, 0 failed
- current source/launcher head Worker proof, run twice — 4 identical outcomes per run, 0 differences
- Docker-backed Crabbox proof — exit 0, lease stopped, checkout clean after both runs
- `pnpm run format:check`
- implementation pre-commit and committed-branch autoreview, plus receipt-refresh pre-commit
  autoreview — no accepted/actionable findings
- proof re-runs default to `.artifacts/typed-webhook-ingress/`, preserving the frozen committed report

Net delta is +731 lines overall (+748/-17): +179 net for production typing and its compile-time
fixture, plus +552 lines of committed proof harness, documentation, report, and receipt.

OpenClaw Bay: none. The runtime decision objects, lifecycle calls, journey inputs, queue behavior,
and observer-only boundary are unchanged.
