### PR TITLE
fix(review): preserve history across local reruns

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,16 @@ This mode withholds GitHub token variables, points `gh` at an empty config
 directory inside the run artifacts, disables Codex web search, skips host-side
 URL/media preprocessing, and makes no GitHub reads or writes. It is not
 air-gapped: the Codex model invocation still uses its configured network
-service. Reports use a unique
+service. Repeated local reviews preserve the latest local result in the same
+bounded review-history format used by hosted review. The next run receives the
+previous findings and dispositions so it can verify fixes and avoid re-raising
+resolved findings. Exact-item history stays in the selected artifact directory.
+Committed-range history stays under `.git/clawsweeper/reviews/` and is reused
+only for the same target repository and resolved base when its reviewed commit
+is an ancestor of the current `HEAD`; changing the base or switching to an
+unrelated branch starts a fresh history.
+
+Reports use a unique
 `.git/clawsweeper/reviews/local-range-<time>-<pid>/` directory so the default
 run leaves the checkout clean. `--artifact-dir` overrides that location.
 
@@ -740,7 +749,6 @@ The dispatcher sends `repository_dispatch` events to this repository with the
 target repo and exact item number; ClawSweeper then runs one event job that
 reviews, comments, and checks immediate safe apply instead of waiting for the
 next hot-intake cron or bulk publish lane.
-
 
 ## Checks
 

--- a/src/clawsweeper-context-hydration.ts
+++ b/src/clawsweeper-context-hydration.ts
@@ -18,6 +18,7 @@ import {
   filterReviewComments,
   latestClawSweeperReview,
   latestClawSweeperReviewFromHydration,
+  previousClawSweeperReviewFromComment,
   timestampValueMs,
 } from "./clawsweeper-review-comments.js";
 import { truncateText } from "./clawsweeper-text.js";
@@ -229,6 +230,10 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
     number: number,
   ): PreviousClawSweeperReview | null {
     return latestClawSweeperReview(comments, number, reviewCommentContext);
+  }
+
+  function extractClawSweeperReviewCommentBody(body: string): PreviousClawSweeperReview {
+    return previousClawSweeperReviewFromComment({ body }, reviewCommentContext);
   }
 
   function filterReviewContextCommentsForTest(
@@ -1116,6 +1121,7 @@ export function createContextHydration(dependencies: CreateContextHydrationDepen
     detectBulkFiler,
     detectBulkFilerForTest,
     extractLatestClawSweeperReview,
+    extractClawSweeperReviewCommentBody,
     extractLatestClawSweeperReviewForTest,
     extractLatestClawSweeperReviewFromHydration,
     extractLatestClawSweeperReviewFromHydrationForTest,

--- a/src/clawsweeper-review-command-dependencies.ts
+++ b/src/clawsweeper-review-command-dependencies.ts
@@ -108,6 +108,7 @@ export interface CreateReviewCommandWorkflowDependencies {
   DEFAULT_PLAN_BATCH_SIZE: 3;
   defaultItemsDir: (profile?: RepositoryProfile) => string;
   defaultLocalRangeArtifactDir: (targetDir: string) => string;
+  defaultLocalRangeHistoryPath: (targetDir: string, repo: string, baseSha: string) => string;
   defaultReviewArtifactDir: (
     localOnly: boolean,
     itemNumber: number | undefined,
@@ -127,6 +128,7 @@ export interface CreateReviewCommandWorkflowDependencies {
     itemNumber: number | undefined,
     shardIndex: number,
   ) => UserFacingCommandError;
+  extractClawSweeperReviewCommentBody: (body: string) => PreviousClawSweeperReview;
   existingReview: (item: Pick<Item, "number" | "repo">, itemsDir: string) => ExistingReview | null;
   extractLatestClawSweeperReview: (
     comments: readonly unknown[],
@@ -198,6 +200,12 @@ export interface CreateReviewCommandWorkflowDependencies {
     itemNumber: number | undefined,
     itemNumbers: number[] | undefined,
   ) => itemNumber is number;
+  localRangeHistoryApplies: (
+    targetDir: string,
+    reviewedSha: string | null,
+    headSha: string,
+  ) => boolean;
+  localExactReviewHistoryPath: (artifactDir: string, repo: string, itemNumber: number) => string;
   makeTreeReadOnly: (path: string, snapshots?: FileModeSnapshot[]) => FileModeSnapshot[];
   markdownFor: (options: {
     item: Item;
@@ -242,6 +250,11 @@ export interface CreateReviewCommandWorkflowDependencies {
   }) => ActionEvent | null;
   refreshRelatedItemsContext: (item: Item, context: ItemContext) => unknown[];
   replaceFrontMatterValue: (markdown: string, key: string, value: string) => string;
+  renderReviewCommentFromReport: (
+    markdown: string,
+    reason: "none",
+    options?: { previousReviewCommentBody?: string },
+  ) => string;
   repoFromArgs: (args: Args) => RepositoryProfile;
   reportFileName: (repo: string, number: number) => string;
   reportReviewFindings: (markdown: string) => ReviewFinding[];

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -1468,20 +1468,22 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                   reviewLeaseCommentId: acquiredReviewLease.commentId,
                 }
               : {}),
-          });
+        });
         writeFileSync(reportPath, reportMarkdown, "utf8");
         if (itemLocalReviewHistoryPath) {
-          writeFileSync(
-            itemLocalReviewHistoryPath,
-            renderReviewCommentFromReport(
-              reportMarkdown,
-              "none",
-              previousLocalReviewCommentBody
-                ? { previousReviewCommentBody: previousLocalReviewCommentBody }
-                : undefined,
-            ),
-            "utf8",
-          );
+          const nextLocalReviewCommentBody =
+            frontMatterValue(reportMarkdown, "review_status") === "complete"
+              ? renderReviewCommentFromReport(
+                  reportMarkdown,
+                  "none",
+                  previousLocalReviewCommentBody
+                    ? { previousReviewCommentBody: previousLocalReviewCommentBody }
+                    : undefined,
+                )
+              : previousLocalReviewCommentBody;
+          if (nextLocalReviewCommentBody) {
+            writeFileSync(itemLocalReviewHistoryPath, nextLocalReviewCommentBody, "utf8");
+          }
         }
         recordReviewLogPublication({
           ledger: reviewLedger,

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ACTION_EVENT_REASON_CODES, ACTION_EVENT_STATUSES } from "./action-ledger.js";
 import type { Args } from "./clawsweeper-args.js";
@@ -100,6 +100,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
     displayPath,
     enforceExpectedIssueSourceRevision,
     exactLocalReviewNoCandidateError,
+    extractClawSweeperReviewCommentBody,
     existingReview,
     extractLatestClawSweeperReview,
     fetchIssueReviewComments,
@@ -115,6 +116,8 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
     itemContentDigest,
     itemSnapshotHash,
     liveClawSweeperReviewDigest,
+    localExactReviewHistoryPath,
+    localRangeHistoryApplies,
     makeTreeReadOnly,
     markdownFor,
     postReviewStartStatusComment,
@@ -125,6 +128,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
     recordReviewLogPublication,
     refreshRelatedItemsContext,
     replaceFrontMatterValue,
+    renderReviewCommentFromReport,
     reportFileName,
     reportReviewFindings,
     restoreTreeModes,
@@ -163,6 +167,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
       expectedSourceRevision,
       allowClosed,
       localRangeData,
+      localReviewHistoryPath,
       coordinationHeldPath,
       shardIndex,
       shardCount,
@@ -347,6 +352,26 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         } else {
           console.error(
             `[review] ${new Date().toISOString()} shard=${shardIndex}/${shardCount} start #${item.number} (${completed + 1}/${candidates.length})`,
+          );
+        }
+        const itemLocalReviewHistoryPath = localRangeData
+          ? localReviewHistoryPath
+          : localOnly
+            ? localExactReviewHistoryPath(artifactDir, item.repo, item.number)
+            : null;
+        let previousLocalReviewCommentBody =
+          itemLocalReviewHistoryPath && existsSync(itemLocalReviewHistoryPath)
+            ? readFileSync(itemLocalReviewHistoryPath, "utf8")
+            : "";
+        if (
+          !previousLocalReviewCommentBody &&
+          localOnly &&
+          !localRangeData &&
+          existsSync(join(artifactDir, reportFileName(item.repo, item.number)))
+        ) {
+          previousLocalReviewCommentBody = renderReviewCommentFromReport(
+            readFileSync(join(artifactDir, reportFileName(item.repo, item.number)), "utf8"),
+            "none",
           );
         }
         const existingPriorReview = localRangeData ? null : existingReview(item, itemsDir);
@@ -735,6 +760,26 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
               reviewCacheDigest: true,
               reviewCacheGitDir: openclawDir,
             });
+        if (previousLocalReviewCommentBody) {
+          const previousLocalReview = extractClawSweeperReviewCommentBody(
+            previousLocalReviewCommentBody,
+          );
+          const hasCompletedLocalReview =
+            previousLocalReview.completedReviewCycles > 0 &&
+            /^[0-9a-f]{40}$/iu.test(previousLocalReview.reviewedSha ?? "");
+          const appliesToRange =
+            !localRangeData ||
+            localRangeHistoryApplies(
+              openclawDir,
+              previousLocalReview?.reviewedSha ?? null,
+              localRangeData.headSha,
+            );
+          if (hasCompletedLocalReview && appliesToRange) {
+            context.previousClawSweeperReview = previousLocalReview;
+          } else {
+            previousLocalReviewCommentBody = "";
+          }
+        }
         if (bulkFilerDetection.context) context.bulkFiler = bulkFilerDetection.context;
         const contextElapsedMs = Date.now() - contextStartedAt;
         const contextItemUpdatedAt = stringOrUndefined(asRecord(context.issue).updatedAt);
@@ -1383,9 +1428,7 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         const action = reviewActionForDecision({ item, decision, git, runtime });
         structuralRecord = refreshStructuralRecordForVerdict();
         const reportPath = join(artifactDir, reportFileName(item.repo, item.number));
-        writeFileSync(
-          reportPath,
-          markdownFor({
+        const reportMarkdown = markdownFor({
             item,
             context,
             decision,
@@ -1404,9 +1447,21 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
                   reviewLeaseCommentId: acquiredReviewLease.commentId,
                 }
               : {}),
-          }),
-          "utf8",
-        );
+          });
+        writeFileSync(reportPath, reportMarkdown, "utf8");
+        if (itemLocalReviewHistoryPath) {
+          writeFileSync(
+            itemLocalReviewHistoryPath,
+            renderReviewCommentFromReport(
+              reportMarkdown,
+              "none",
+              previousLocalReviewCommentBody
+                ? { previousReviewCommentBody: previousLocalReviewCommentBody }
+                : undefined,
+            ),
+            "utf8",
+          );
+        }
         recordReviewLogPublication({
           ledger: reviewLedger,
           item,

--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -53,6 +53,21 @@ function reviewStartLeaseCommentUpdatedAt(
   return undefined;
 }
 
+export function localExactBootstrapReviewCommentBody(
+  markdown: string,
+  item: Pick<Item, "repo" | "number">,
+  frontMatterValue: (markdown: string, key: string) => string | undefined,
+  renderReviewCommentFromReport: (markdown: string, reason: "none") => string,
+): string {
+  if (
+    frontMatterValue(markdown, "repository")?.toLowerCase() !== item.repo.toLowerCase() ||
+    frontMatterValue(markdown, "number") !== String(item.number)
+  ) {
+    return "";
+  }
+  return renderReviewCommentFromReport(markdown, "none");
+}
+
 export function restoreVerifiedMaintainerPullRequestAuthorAssociation(
   item: Pick<Item, "kind" | "author" | "authorAssociation" | "labels">,
   repositoryPermission: (author: string) => string | null,
@@ -369,9 +384,15 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
           !localRangeData &&
           existsSync(join(artifactDir, reportFileName(item.repo, item.number)))
         ) {
-          previousLocalReviewCommentBody = renderReviewCommentFromReport(
-            readFileSync(join(artifactDir, reportFileName(item.repo, item.number)), "utf8"),
-            "none",
+          const bootstrapReport = readFileSync(
+            join(artifactDir, reportFileName(item.repo, item.number)),
+            "utf8",
+          );
+          previousLocalReviewCommentBody = localExactBootstrapReviewCommentBody(
+            bootstrapReport,
+            item,
+            frontMatterValue,
+            renderReviewCommentFromReport,
           );
         }
         const existingPriorReview = localRangeData ? null : existingReview(item, itemsDir);

--- a/src/clawsweeper-review-comments.ts
+++ b/src/clawsweeper-review-comments.ts
@@ -109,8 +109,15 @@ export function latestClawSweeperReview(
     .filter((comment) => isDurableReviewComment(comment, number, context))
     .sort((left, right) => commentTimestampMs(right) - commentTimestampMs(left))[0];
   if (!latest) return null;
-  const comment = asRecord(latest);
-  const body = rawCommentBody(latest);
+  return previousClawSweeperReviewFromComment(latest, context);
+}
+
+export function previousClawSweeperReviewFromComment(
+  value: unknown,
+  context: ReviewCommentContext,
+): PreviousClawSweeperReview {
+  const comment = asRecord(value);
+  const body = rawCommentBody(value);
   const verdictMarker = htmlMarkerWithPrefix(body, "clawsweeper-verdict:");
   const actionMarker = htmlMarkerWithPrefix(body, "clawsweeper-action:");
   const history = parseReviewHistory(body);

--- a/src/clawsweeper-review-preparation.ts
+++ b/src/clawsweeper-review-preparation.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { boolArg, itemNumbersArg, numberArg, stringArg } from "./clawsweeper-args.js";
 import {
   DEFAULT_CODEX_MODEL,
@@ -38,6 +38,7 @@ export function prepareReviewCommand(
     DEFAULT_PLAN_BATCH_SIZE,
     defaultItemsDir,
     defaultLocalRangeArtifactDir,
+    defaultLocalRangeHistoryPath,
     defaultReviewArtifactDir,
     ensureDir,
     gitInfo,
@@ -127,6 +128,10 @@ export function prepareReviewCommand(
     ? buildLocalRangeReview(openclawDir, targetRepo(), stringArg(args.base, ""))
     : undefined;
   ensureDir(artifactDir);
+  const localReviewHistoryPath = localRangeData
+    ? defaultLocalRangeHistoryPath(openclawDir, targetRepo(), localRangeData.baseSha)
+    : null;
+  if (localReviewHistoryPath) ensureDir(dirname(localReviewHistoryPath));
   const coordinationHeldPath = join(artifactDir, "coordination-held.json");
   if (existsSync(coordinationHeldPath)) unlinkSync(coordinationHeldPath);
   if (localRangeData) {
@@ -197,6 +202,7 @@ export function prepareReviewCommand(
     additionalPrompt,
     allowClosed,
     localRangeData,
+    localReviewHistoryPath,
     coordinationHeldPath,
     shardIndex,
     shardCount,

--- a/src/clawsweeper-review-runtime.ts
+++ b/src/clawsweeper-review-runtime.ts
@@ -216,6 +216,42 @@ export function createReviewRuntime({
     return resolve(targetDir, gitArtifactRoot, `local-range-${Date.now()}-${process.pid}`);
   }
 
+  function defaultLocalRangeHistoryPath(targetDir: string, repo: string, baseSha: string): string {
+    const gitArtifactRoot = run("git", ["rev-parse", "--git-path", "clawsweeper/reviews"], {
+      cwd: targetDir,
+    }).trim();
+    return resolve(
+      targetDir,
+      gitArtifactRoot,
+      `local-range-review-history-${repositoryProfileFor(repo).slug}-${baseSha}.md`,
+    );
+  }
+
+  function localExactReviewHistoryPath(
+    artifactDir: string,
+    repo: string,
+    itemNumber: number,
+  ): string {
+    return join(
+      artifactDir,
+      `local-review-history-${repositoryProfileFor(repo).slug}-${itemNumber}.md`,
+    );
+  }
+
+  function localRangeHistoryApplies(
+    targetDir: string,
+    reviewedSha: string | null,
+    headSha: string,
+  ): boolean {
+    if (!reviewedSha || !/^[0-9a-f]{40}$/i.test(reviewedSha)) return false;
+    try {
+      run("git", ["merge-base", "--is-ancestor", reviewedSha, headSha], { cwd: targetDir });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   function resolveReviewCheckout(options: {
     args: Args;
     artifactDir: string;
@@ -353,6 +389,14 @@ export function createReviewRuntime({
     itemNumbers: number[] | undefined,
   ): string {
     return defaultReviewArtifactDir(localOnly, itemNumber, itemNumbers);
+  }
+
+  function localExactReviewHistoryPathForTest(
+    artifactDir: string,
+    repo: string,
+    itemNumber: number,
+  ): string {
+    return localExactReviewHistoryPath(artifactDir, repo, itemNumber);
   }
 
   function prepareManagedLocalReviewCheckoutForTest(
@@ -1083,6 +1127,7 @@ ${extra}
     codexFailureLogKindForTest,
     codexReviewFailureRetryableForTest,
     defaultReviewArtifactDirForTest,
+    localExactReviewHistoryPathForTest,
     makeTreeReadOnlyForTest,
     prepareManagedLocalReviewCheckoutForTest,
     restoreTreeModesForTest,
@@ -1099,12 +1144,15 @@ ${extra}
     codexFailureReason,
     codexReviewFailureRetryable,
     defaultLocalRangeArtifactDir,
+    defaultLocalRangeHistoryPath,
     defaultReviewArtifactDir,
     displayDurationMs,
     displayPath,
     gitInfo,
     isSafeGitBranchName,
     localExactReviewItem,
+    localExactReviewHistoryPath,
+    localRangeHistoryApplies,
     makeTreeReadOnly,
     prCloseCoverageProofPromptTemplate,
     resolveReviewCheckout,

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -741,6 +741,7 @@ export const {
   codexFailureLogKindForTest,
   codexReviewFailureRetryableForTest,
   defaultReviewArtifactDirForTest,
+  localExactReviewHistoryPathForTest,
   makeTreeReadOnlyForTest,
   prepareManagedLocalReviewCheckoutForTest,
   restoreTreeModesForTest,

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -19,6 +19,7 @@ import {
   exactEventReviewLeaseDispositionForTest,
   itemSourceRevisionSha256ForTest,
   isSuppliedReviewStartLeaseForTest,
+  localExactReviewHistoryPathForTest,
   prepareManagedLocalReviewCheckoutForTest,
   reviewPolicyHashForTest,
   reviewLeaseStillMatchesContextForTest,
@@ -98,6 +99,18 @@ test("local exact reviews default to item-specific artifacts", () => {
   assert.equal(defaultReviewArtifactDirForTest(true, 357, undefined), "artifacts/local-review-357");
   assert.equal(defaultReviewArtifactDirForTest(true, 357, [357]), "artifacts/reviews");
   assert.equal(defaultReviewArtifactDirForTest(false, 357, undefined), "artifacts/reviews");
+});
+
+test("local exact review history is keyed by repository and item", () => {
+  const artifactDir = join("artifacts", "reviews");
+  const first = localExactReviewHistoryPathForTest(artifactDir, "openclaw/openclaw", 357);
+  const second = localExactReviewHistoryPathForTest(artifactDir, "openclaw/openclaw", 358);
+  const otherRepo = localExactReviewHistoryPathForTest(artifactDir, "openclaw/clawsweeper", 357);
+
+  assert.equal(first, join(artifactDir, "local-review-history-openclaw-openclaw-357.md"));
+  assert.equal(second, join(artifactDir, "local-review-history-openclaw-openclaw-358.md"));
+  assert.notEqual(first, second);
+  assert.notEqual(first, otherRepo);
 });
 
 test("CSW-088 scheduled hot planning suppresses #117063, observes an in-flight update, and leaves explicit re-review eligible", () => {

--- a/test/local-range-review.test.ts
+++ b/test/local-range-review.test.ts
@@ -502,8 +502,13 @@ const captures = fs.existsSync(process.env.LOCAL_REVIEW_CAPTURE)
 captures.push({
   hasPreviousReview: prompt.includes('"previousClawSweeperReview"'),
   hasPriorFinding: prompt.includes(${JSON.stringify(priorFindingTitle)}),
+  previousReviewedSha: prompt.match(/"reviewedSha":\\s*"([0-9a-f]{40})"/)?.[1] ?? null,
 });
 fs.writeFileSync(process.env.LOCAL_REVIEW_CAPTURE, JSON.stringify(captures));
+if (process.env.LOCAL_REVIEW_FAIL === "1") {
+  process.stderr.write("deterministic local review failure\\n");
+  process.exit(1);
+}
 fs.writeFileSync(outputPath, fs.readFileSync(process.env.LOCAL_REVIEW_DECISION));
 process.stdout.write(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1 } }) + "\\n");
 `,
@@ -516,7 +521,7 @@ process.stdout.write(JSON.stringify({ type: "turn.completed", usage: { input_tok
     });
   }
 
-  function runReview(artifactDir: string, base = "base-ref"): void {
+  function runReview(artifactDir: string, base = "base-ref", shouldFail = false): void {
     const result = spawnSync(
       process.execPath,
       [
@@ -542,11 +547,16 @@ process.stdout.write(JSON.stringify({ type: "turn.completed", usage: { input_tok
           CODEX_BIN: fakeCodex,
           LOCAL_REVIEW_CAPTURE: capturePath,
           LOCAL_REVIEW_DECISION: decisionPath,
+          LOCAL_REVIEW_FAIL: shouldFail ? "1" : "0",
         },
         timeout: 60000,
       },
     );
-    assert.equal(result.status, 0, `${result.stderr ?? ""}${result.stdout ?? ""}`);
+    if (shouldFail) {
+      assert.notEqual(result.status, 0, "deterministic Codex failure must fail the review run");
+    } else {
+      assert.equal(result.status, 0, `${result.stderr ?? ""}${result.stdout ?? ""}`);
+    }
   }
 
   try {
@@ -564,7 +574,9 @@ process.stdout.write(JSON.stringify({ type: "turn.completed", usage: { input_tok
     writeFileSync(join(dir, "feature.txt"), "first\nsecond\n");
     git(dir, "add", "feature.txt");
     git(dir, "commit", "-q", "-m", "fix: follow up on local review");
-    runReview(join(harness, "run-2"));
+    const failedHead = git(dir, "rev-parse", "HEAD");
+    runReview(join(harness, "run-2-failed"), "base-ref", true);
+    runReview(join(harness, "run-3"));
 
     const historyPath = resolve(
       dir,
@@ -576,24 +588,27 @@ process.stdout.write(JSON.stringify({ type: "turn.completed", usage: { input_tok
     assert.match(relatedHistory, new RegExp(firstHead));
 
     git(dir, "branch", "alternate-base", firstHead);
-    runReview(join(harness, "run-3"), "alternate-base");
+    runReview(join(harness, "run-4"), "alternate-base");
 
     git(dir, "checkout", "-q", "-b", "unrelated", "base-ref");
     writeFileSync(join(dir, "unrelated.txt"), "different branch\n");
     git(dir, "add", "unrelated.txt");
     git(dir, "commit", "-q", "-m", "feat: unrelated local range");
-    runReview(join(harness, "run-4"));
+    runReview(join(harness, "run-5"));
 
     const captures = JSON.parse(readFileSync(capturePath, "utf8")) as Array<{
       hasPreviousReview: boolean;
       hasPriorFinding: boolean;
+      previousReviewedSha: string | null;
     }>;
     assert.deepEqual(captures, [
-      { hasPreviousReview: false, hasPriorFinding: false },
-      { hasPreviousReview: true, hasPriorFinding: true },
-      { hasPreviousReview: false, hasPriorFinding: false },
-      { hasPreviousReview: false, hasPriorFinding: false },
+      { hasPreviousReview: false, hasPriorFinding: false, previousReviewedSha: null },
+      { hasPreviousReview: true, hasPriorFinding: true, previousReviewedSha: firstHead },
+      { hasPreviousReview: true, hasPriorFinding: true, previousReviewedSha: firstHead },
+      { hasPreviousReview: false, hasPriorFinding: false, previousReviewedSha: null },
+      { hasPreviousReview: false, hasPriorFinding: false, previousReviewedSha: null },
     ]);
+    assert.doesNotMatch(JSON.stringify(captures[2]), new RegExp(failedHead));
     assert.doesNotMatch(readFileSync(historyPath, "utf8"), /Review history \(/);
     assert.equal(git(dir, "status", "--porcelain"), "");
   } finally {

--- a/test/local-range-review.test.ts
+++ b/test/local-range-review.test.ts
@@ -16,6 +16,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { buildLocalRangeReviewForTest } from "../dist/clawsweeper.js";
+import { changelogReviewDecision, reviewFinding } from "./helpers.ts";
 
 const CLI = fileURLToPath(new URL("../dist/clawsweeper.js", import.meta.url));
 
@@ -455,6 +456,148 @@ test("--local-range does not host-download proof video URLs from the body", asyn
       server.close((error) => (error ? reject(error) : resolve())),
     );
     rmSync(codexDir, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--local-range carries hosted-shaped review history across related local iterations", () => {
+  const dir = initRepo();
+  const harness = mkdtempSync(join(tmpdir(), "lrr-history-"));
+  const fakeCodexScript = join(harness, "fake-codex.mjs");
+  const fakeCodex =
+    process.platform === "win32" ? join(harness, "fake-codex.cmd") : join(harness, "fake-codex");
+  const capturePath = join(harness, "captures.json");
+  const decisionPath = join(harness, "decision.json");
+  const priorFindingTitle = "Preserve earlier local finding";
+  writeFileSync(
+    decisionPath,
+    JSON.stringify(
+      changelogReviewDecision({
+        summary: "The deterministic local review found one history-sensitive defect.",
+        bestSolution: "Preserve earlier local review context on the next iteration.",
+        reviewFindings: [
+          reviewFinding({
+            title: priorFindingTitle,
+            body: "A follow-up local review must see this earlier finding.",
+            file: "feature.txt",
+            lineStart: 1,
+            lineEnd: 1,
+          }),
+        ],
+        workReason: "Preserve earlier local review context.",
+        workPrompt: "Carry the previous local review into the follow-up prompt.",
+        workLikelyFiles: ["feature.txt"],
+      }),
+    ),
+  );
+  writeFileSync(
+    fakeCodexScript,
+    `import fs from "node:fs";
+const args = process.argv.slice(2);
+const outputPath = args[args.indexOf("--output-last-message") + 1];
+const prompt = fs.readFileSync(0, "utf8");
+const captures = fs.existsSync(process.env.LOCAL_REVIEW_CAPTURE)
+  ? JSON.parse(fs.readFileSync(process.env.LOCAL_REVIEW_CAPTURE, "utf8"))
+  : [];
+captures.push({
+  hasPreviousReview: prompt.includes('"previousClawSweeperReview"'),
+  hasPriorFinding: prompt.includes(${JSON.stringify(priorFindingTitle)}),
+});
+fs.writeFileSync(process.env.LOCAL_REVIEW_CAPTURE, JSON.stringify(captures));
+fs.writeFileSync(outputPath, fs.readFileSync(process.env.LOCAL_REVIEW_DECISION));
+process.stdout.write(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 1 } }) + "\\n");
+`,
+  );
+  if (process.platform === "win32") {
+    writeFileSync(fakeCodex, `@echo off\r\n"${process.execPath}" "${fakeCodexScript}" %*\r\n`);
+  } else {
+    writeFileSync(fakeCodex, `#!/bin/sh\nexec "${process.execPath}" "${fakeCodexScript}" "$@"\n`, {
+      mode: 0o755,
+    });
+  }
+
+  function runReview(artifactDir: string, base = "base-ref"): void {
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "review",
+        "--local-range",
+        "--base",
+        base,
+        "--target-repo",
+        "openclaw/clawsweeper",
+        "--target-dir",
+        dir,
+        "--artifact-dir",
+        artifactDir,
+        "--codex-timeout-ms",
+        "60000",
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAWSWEEPER_CODEX_REVIEW_ATTEMPTS: "1",
+          CODEX_BIN: fakeCodex,
+          LOCAL_REVIEW_CAPTURE: capturePath,
+          LOCAL_REVIEW_DECISION: decisionPath,
+        },
+        timeout: 60000,
+      },
+    );
+    assert.equal(result.status, 0, `${result.stderr ?? ""}${result.stdout ?? ""}`);
+  }
+
+  try {
+    writeFileSync(join(dir, "base.txt"), "base\n");
+    git(dir, "add", "base.txt");
+    git(dir, "commit", "-q", "-m", "init");
+    git(dir, "branch", "base-ref");
+    const baseSha = git(dir, "rev-parse", "base-ref");
+    writeFileSync(join(dir, "feature.txt"), "first\n");
+    git(dir, "add", "feature.txt");
+    git(dir, "commit", "-q", "-m", "feat: first local review");
+    const firstHead = git(dir, "rev-parse", "HEAD");
+
+    runReview(join(harness, "run-1"));
+    writeFileSync(join(dir, "feature.txt"), "first\nsecond\n");
+    git(dir, "add", "feature.txt");
+    git(dir, "commit", "-q", "-m", "fix: follow up on local review");
+    runReview(join(harness, "run-2"));
+
+    const historyPath = resolve(
+      dir,
+      git(dir, "rev-parse", "--git-path", "clawsweeper/reviews"),
+      `local-range-review-history-openclaw-clawsweeper-${baseSha}.md`,
+    );
+    const relatedHistory = readFileSync(historyPath, "utf8");
+    assert.match(relatedHistory, /Review history \(1 earlier review cycle\)/);
+    assert.match(relatedHistory, new RegExp(firstHead));
+
+    git(dir, "branch", "alternate-base", firstHead);
+    runReview(join(harness, "run-3"), "alternate-base");
+
+    git(dir, "checkout", "-q", "-b", "unrelated", "base-ref");
+    writeFileSync(join(dir, "unrelated.txt"), "different branch\n");
+    git(dir, "add", "unrelated.txt");
+    git(dir, "commit", "-q", "-m", "feat: unrelated local range");
+    runReview(join(harness, "run-4"));
+
+    const captures = JSON.parse(readFileSync(capturePath, "utf8")) as Array<{
+      hasPreviousReview: boolean;
+      hasPriorFinding: boolean;
+    }>;
+    assert.deepEqual(captures, [
+      { hasPreviousReview: false, hasPriorFinding: false },
+      { hasPreviousReview: true, hasPriorFinding: true },
+      { hasPreviousReview: false, hasPriorFinding: false },
+      { hasPreviousReview: false, hasPriorFinding: false },
+    ]);
+    assert.doesNotMatch(readFileSync(historyPath, "utf8"), /Review history \(/);
+    assert.equal(git(dir, "status", "--porcelain"), "");
+  } finally {
+    rmSync(harness, { recursive: true, force: true });
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/review-command-workflow.test.ts
+++ b/test/review-command-workflow.test.ts
@@ -6,7 +6,10 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { parseArgs } from "../dist/clawsweeper-args.js";
-import { createReviewCommandWorkflow } from "../dist/clawsweeper-review-command-workflow.js";
+import {
+  createReviewCommandWorkflow,
+  localExactBootstrapReviewCommentBody,
+} from "../dist/clawsweeper-review-command-workflow.js";
 import {
   isSuppliedReviewStartLease,
   suppliedReviewStartLeaseFromArgs,
@@ -61,6 +64,53 @@ function structuralRecord(activityUpdatedAt: string) {
   assert.ok(record);
   return record;
 }
+
+test("exact local bootstrap rejects a same-number report from another repository", () => {
+  const report = [
+    "---",
+    `number: ${ITEM_NUMBER}`,
+    "repository: openclaw/clawsweeper",
+    "review_status: complete",
+    "---",
+    "Foreign report",
+  ].join("\n");
+  const frontMatterValue = (markdown: string, key: string): string | undefined =>
+    markdown.match(new RegExp(`^${key}:\\s*(.+)$`, "m"))?.[1]?.trim();
+  let renderCalls = 0;
+  const render = () => {
+    renderCalls += 1;
+    return "rendered review history";
+  };
+
+  assert.equal(
+    localExactBootstrapReviewCommentBody(
+      report,
+      { repo: "openclaw/clawsweeper", number: ITEM_NUMBER },
+      frontMatterValue,
+      render,
+    ),
+    "rendered review history",
+  );
+  assert.equal(
+    localExactBootstrapReviewCommentBody(
+      report,
+      { repo: "openclaw/openclaw", number: ITEM_NUMBER },
+      frontMatterValue,
+      render,
+    ),
+    "",
+  );
+  assert.equal(
+    localExactBootstrapReviewCommentBody(
+      report,
+      { repo: "openclaw/clawsweeper", number: ITEM_NUMBER + 1 },
+      frontMatterValue,
+      render,
+    ),
+    "",
+  );
+  assert.equal(renderCalls, 1);
+});
 
 test("scheduled delivery serves an unchanged item from the structural cache", () => {
   const root = mkdtempSync(join(tmpdir(), "clawsweeper-scheduled-cache-"));


### PR DESCRIPTION
## Summary

- preserve bounded prior-review context across repeated local ClawSweeper runs, mirroring hosted review history
- scope exact-item history by repository and item, and committed-range history by repository, resolved base, and ancestry
- retain the last completed review through failed reruns so an unreviewed head is never promoted as reviewed
- keep the existing severity, proof, readiness, freshness, and stopping criteria unchanged

## Problem

Hosted review carries the latest durable ClawSweeper result into the next review as `previousClawSweeperReview`. Local review did not: `--local-range` started without prior review state, and exact `--local-only` runs did not reuse earlier local results. Repeated local runs were independent reviews, so they could not reliably reconcile fixed findings, earlier dispositions, or genuinely late findings.

The implementation now reuses the same bounded hosted representation and parser. History is reconciliation context only; every prompt still requires an independent full inspection.

## Implementation

- render each completed local report into the hosted durable-comment/history format, including the existing eight-cycle bound
- parse subsequent local runs through the hosted structured previous-review parser
- key exact-item history by canonical repository slug and item number
- validate legacy numeric-report bootstrap front matter against both repository and item before reuse
- key committed-range history by canonical repository slug and resolved merge-base SHA
- require the prior reviewed SHA to be an ancestor of the current committed-range head
- advance persisted history only for `review_status: complete`; a failed rerun retains the prior completed body
- document persistence and invalidation rules

## ClawSweeper feedback disposition

- **Accepted P2 — cross-repository exact bootstrap:** a same-number numeric report from another repository could seed prior findings. Fixed by validating repository and item front matter before rendering bootstrap history; focused matching, cross-repository, and cross-item assertions added.
- **Accepted P2 — failed-head attribution:** a failed local rerun could replace completed history with current-head markers plus older findings. Fixed by advancing history only after a completed report; success → failure → success coverage proves the recovery prompt retains the last completed SHA.
- **Rank-up proof move:** completed with current-head Docker-backed Crabbox focused behavior and broad `pnpm check` receipts below.
- **Rejected findings:** none.

## Validation

Current head: `98280ac678bc997d8a62d396605ae0e2df76ce63`  
Base: `a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`

- `pnpm run build:all`
- `node --test --test-name-pattern="local exact review history is keyed by repository and item" test/command.test.ts`
- `node --test --test-name-pattern="exact local bootstrap rejects" test/review-command-workflow.test.ts`
- `node --test --test-name-pattern="carries hosted-shaped review history" test/local-range-review.test.ts`
- `node --test test/review-prompt-context.test.ts test/context.test.ts` — 30/30 passed
- `pnpm run lint:src`
- `pnpm run lint:scripts`
- focused `oxfmt --check` on all changed files
- `git diff --check origin/main..HEAD`
- `pnpm run check` in Docker-backed Crabbox — static checks, all builds, all lint lanes, changed coverage, and 248-file full coverage passed

The success → failure → success regression was also run with only the persistence guard temporarily reverted to the prior behavior: it failed because the third prompt received the failed head. Restoring the committed guard made the same regression pass; the worktree was clean afterward.

## Real Behavior Proof

- **Claim:** a repeated local review receives only compatible completed prior state in the hosted bounded representation; failed or unrelated runs cannot advance or contaminate that state.
- **Exercised surface:** production exact `--local-only` bootstrap decision; production `review --local-range` CLI, Git-backed history discovery, prompt construction, hosted rendering/parsing, base/ancestry invalidation, failure retention, and clean-checkout behavior.
- **Scenario:** deterministic local-range runs cover initial success, a descendant Codex failure, recovery success, changed base, and unrelated branch. The recovery prompt retains the first completed SHA and finding, not the failed head. Exact-item assertions cover matching identity plus same-number cross-repository and cross-item rejection.
- **Focused environment:** exact head `98280ac678bc997d8a62d396605ae0e2df76ce63`; Node `v24.15.0`; `provider=local-container`; image `mcr.microsoft.com/playwright:v1.60.0-noble`; lease `cbx_d31caedc3ba6` (stopped).
- **Focused result:** exact history identity 1/1, bootstrap identity 1/1, success/failure/recovery lifecycle 1/1, prompt/context 30/30, `build:all`, source/script lint, and focused formatting all passed; 14.060 s total.
- **Broad environment:** same exact head/provider/image; lease `cbx_20ece4f25f1f` (stopped).
- **Broad result:** `pnpm run check` passed, including static checks, all builds, all lint lanes, changed coverage, and 248-file full coverage; 261.755 s total.
- **Limits:** the deterministic Codex boundary proves state transitions, target isolation, prompt admission, and failure recovery. It does not promise a fixed live-model convergence rate; model output remains nondeterministic. No GitHub write, hosted queue, gate, deployment, or production mutation was used for proof.
- **Staleness:** earlier proof receipts for head `e969dbba2f...` are superseded. Only the two current-head leases above support this revision.

## Review closeout

- final dirty `codex review --uncommitted`: clean after each accepted fix
- final `codex review --base origin/main`: no actionable correctness defects
- final local `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: `review_status: complete`, patch correct, confidence 0.89, no findings; it identified only the then-missing current-head proof, now supplied above
- Codex's read-only Windows sandbox could not open the TypeScript shim (`EPERM`); the same builds and tests passed directly and in the exact-head Linux containers above

## Risks, rollback, and OpenClaw Bay impact

- Prior findings can anchor a model, so the prompt continues to require full independent inspection; history is not a finding allowlist.
- History remains bounded to eight cycles, and malformed, cross-item, cross-repository, changed-base, unrelated-branch, and incomplete-run state is excluded.
- Rollback is a normal revert of this PR's commits; no migration or hosted-state cleanup is required.
- OpenClaw Bay impact: none. This changes only local review persistence under local artifact/Git paths; hosted publication, queues, workflows, gates, deployments, and Bay behavior are unchanged.
- Maintainer decision: no product or rollout decision is required; ordinary code-review judgment remains.
- Release note: repeated local reviews now remember compatible completed earlier results, making fix verification and late-finding classification align with hosted review more closely.
