### PR TITLE
fix(records): write front matter keys and values literally

### DIFF
--- a/docs/proof/record-front-matter-literal-write/.gitignore
+++ b/docs/proof/record-front-matter-literal-write/.gitignore
@@ -1,0 +1,3 @@
+# The pre-fix module staged by stage-before.sh. It is a verbatim copy of a file
+# already in git history, regenerated on demand, so it is not committed.
+before/

--- a/docs/proof/record-front-matter-literal-write/.gitignore
+++ b/docs/proof/record-front-matter-literal-write/.gitignore
@@ -1,3 +1,0 @@
-# The pre-fix module staged by stage-before.sh. It is a verbatim copy of a file
-# already in git history, regenerated on demand, so it is not committed.
-before/

--- a/docs/proof/record-front-matter-literal-write/README.md
+++ b/docs/proof/record-front-matter-literal-write/README.md
@@ -1,0 +1,100 @@
+# Proof: label names are written to a record verbatim
+
+## Claim
+
+A GitHub label whose name contains `$&`, `` $` ``, `$'` or `$$` is stored in a
+record's `labels:` front matter exactly as given, the record around it is left
+intact, and front matter keys are matched literally instead of being compiled as
+regular expressions.
+
+## Exercised surface
+
+`createRecordMetadata(...).replaceFrontMatterValue` and the matching readers
+(`.frontMatterField`, `.frontMatterValue`, `.frontMatterStringArray`) in
+`dist/clawsweeper-record-metadata.js`.
+
+`src/clawsweeper-apply-report-labels.ts` writes the synced label set with
+
+```ts
+markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
+```
+
+`item.labels` is the label set returned by the label sync for the reviewed item, so
+the names come from the reviewed repository. `String.prototype.replace` treats `$&`,
+`` $` ``, `$'` and `$$` in its *replacement* argument as expansion patterns, so those
+names were being expanded against the match instead of inserted.
+
+## Scenario / fixture
+
+`run-proof.mjs` starts from a record holding `repository`, `number`, `labels`,
+`title` and a body, then writes label sets through the shipped writer and reads them
+back through the shipped readers:
+
+1. **Verbatim storage** — ordinary names plus every replacement pattern, including a
+   mixed set (`["needs-triage", "$&"]`) that mirrors a real sync result.
+2. **Valid JSON** — the stored text must still `JSON.parse` back to what was written,
+   because `frontMatterStringArray` silently falls back to comma-splitting when it
+   does not.
+3. **Record integrity** — `title`, `number`, the body, and the `---` delimiters must
+   be unchanged after the write.
+4. **Literal keys** — keys containing `.`, `+`, `(`, `[`, `|` and `*` must read and
+   update in place, and `a.c` must not match a line reading `aXc:`.
+
+## Command and environment
+
+```
+bash docs/proof/record-front-matter-literal-write/stage-before.sh
+crabbox run --provider local-container --local-container-image node:24 --no-hydrate \
+  --artifact-glob '.artifacts/**' -- \
+  bash docs/proof/record-front-matter-literal-write/run-proof.sh
+```
+
+Recorded run:
+
+| | |
+|---|---|
+| provider | `local-container` (runtime `docker`) |
+| image | `node:24` → `v24.19.0`, `Linux aarch64` |
+| lease | `cbx_241c2987e276` (`swift-crab`) |
+| run | `run_b5d44f1fa51f` |
+| base staged | `5439582b` · `src/clawsweeper-record-metadata.ts` · sha256 `df480a1e…83f1` |
+| exit | `0` |
+
+`stage-before.sh` exists because container images carry no `.git`: it writes the
+base version of the changed file into `before/` on the host, where rsync picks it up
+as a dirty file. When git *is* available `run-proof.sh` re-derives that file, so the
+staged copy cannot drift from the base commit.
+
+The script refuses to run below Node 24, installs the pinned pnpm into a
+user-writable prefix, builds the Node lane, and runs the fixtures twice: once
+against the module compiled from the base commit and once against this branch.
+
+## Observed result
+
+Against the pre-fix module 17 assertions fail. Beyond the label sets themselves,
+a label named `$'` also fails `title survives` and `delimiters are unchanged` — the
+expansion pulls the text following the match into the field, so the write damages the
+record body, not just the one value. Keys containing `(`, `[`, `|`, `+` or `*` either
+throw `SyntaxError: Invalid regular expression` or match the wrong line, and `a.c`
+matches `aXc`. Against this branch every assertion passes. The ordinary `["bug"]`
+case passes in both runs, which is what shows the change is confined to names that
+carry a replacement pattern; the script fails the proof if that case ever regresses.
+
+## Artifact / trace
+
+`.crabbox/runs/run_b5d44f1fa51f/run_b5d44f1fa51f-artifacts.tgz` holds
+`.artifacts/record-front-matter-literal-write-proof/` with `before-output.txt`,
+`proof-output.txt`, `focused-tests.txt`, and the install/build logs.
+
+## Limits
+
+This proves the record reader and writer in
+`src/clawsweeper-record-metadata.ts`. The same raw-interpolation shape exists in
+`src/repair/workflow-utils.ts`, `src/repair/create-job.ts`,
+`src/repair/target-fanout.ts`, `src/repair/comment-router-core.ts`,
+`src/commit-sweeper.ts`, `src/decision-packets.ts` and two scripts; those are left
+for a separate change and are tracked in the linked issue. No shipped caller passes a
+key containing regex syntax today, so part 4 hardens the advertised `key: string`
+contract rather than fixing an observed failure — part 1 through part 3 are the
+reachable defect. The proof does not call GitHub; it starts from the label set the
+sync returns.

--- a/docs/proof/record-front-matter-literal-write/README.md
+++ b/docs/proof/record-front-matter-literal-write/README.md
@@ -55,8 +55,8 @@ Recorded run:
 |---|---|
 | provider | `local-container` (runtime `docker`) |
 | image | `node:24` → `v24.19.0`, `Linux aarch64` |
-| lease | `cbx_241c2987e276` (`swift-crab`) |
-| run | `run_b5d44f1fa51f` |
+| lease | `cbx_cae984baa97f` (`quick-crayfish`) |
+| run | `run_26f52fe84002` |
 | base staged | `5439582b` · `src/clawsweeper-record-metadata.ts` · sha256 `df480a1e…83f1` |
 | exit | `0` |
 
@@ -82,9 +82,18 @@ carry a replacement pattern; the script fails the proof if that case ever regres
 
 ## Artifact / trace
 
-`.crabbox/runs/run_b5d44f1fa51f/run_b5d44f1fa51f-artifacts.tgz` holds
+`.crabbox/runs/run_26f52fe84002/run_26f52fe84002-artifacts.tgz` holds
 `.artifacts/record-front-matter-literal-write-proof/` with `before-output.txt`,
 `proof-output.txt`, `focused-tests.txt`, and the install/build logs.
+
+## The run cannot alter the head it is proving
+
+The script records `package.json` and `pnpm-lock.yaml` digests plus
+`git status --porcelain` at sync, then re-checks them after dependency installation
+and at the end of the run; any drift aborts with a diff. The platform-native
+TypeScript fallback installs into a disposable prefix outside the workspace rather
+than writing tracked dependency metadata, so the recorded result does not disturb
+the head it is describing.
 
 ## Limits
 

--- a/docs/proof/record-front-matter-literal-write/README.md
+++ b/docs/proof/record-front-matter-literal-write/README.md
@@ -49,16 +49,19 @@ crabbox run --provider local-container --local-container-image node:24 --no-hydr
   bash docs/proof/record-front-matter-literal-write/run-proof.sh
 ```
 
-Recorded run:
+Proof contract — what a passing run must show. The **observed run for the current
+head (lease, run id, artifact, redacted output) lives in the PR body**, which is
+where AGENTS.md requires current proof to sit. No lease id is pinned here on
+purpose: editing this file changes the head, which would immediately make a pinned
+run describe a different commit than the one under review.
 
 | | |
 |---|---|
-| provider | `local-container` (runtime `docker`) |
-| image | `node:24` → `v24.19.0`, `Linux aarch64` |
-| lease | `cbx_cae984baa97f` (`quick-crayfish`) |
-| run | `run_26f52fe84002` |
-| base staged | `5439582b` · `src/clawsweeper-record-metadata.ts` · sha256 `df480a1e…83f1` |
-| exit | `0` |
+| provider | Crabbox `local-container` (runtime `docker`) |
+| image | `node:24`; the script refuses to run below Node 24 |
+| result | **PROOF PASSED** (all fixtures); focused suite `4/4`; exit `0` |
+| head | echoed from `PROOF_HEAD`, forwarded with `--allow-env` |
+| tracked state | unchanged at every checkpoint; identical `package.json` and `pnpm-lock.yaml` digests at sync and at end of run |
 
 `stage-before.sh` exists because container images carry no `.git`: it writes the
 base version of the changed file into `before/` on the host, where rsync picks it up

--- a/docs/proof/record-front-matter-literal-write/run-proof.mjs
+++ b/docs/proof/record-front-matter-literal-write/run-proof.mjs
@@ -1,0 +1,127 @@
+// Real-behavior proof: a GitHub label name containing a `$`-replacement pattern must
+// be stored in a record's front matter verbatim, and a front matter key must be
+// matched literally rather than compiled as a regular expression.
+//
+// Exercises the shipped factory in dist/clawsweeper-record-metadata.js — the module
+// the label apply lane writes `labels:` through.
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// `--module <path>` swaps in a differently compiled build of the same module so the
+// runner can be pointed at the pre-fix source for a before/after contrast.
+const moduleFlag = process.argv.indexOf("--module");
+const modulePath =
+  moduleFlag === -1
+    ? new URL("../../../dist/clawsweeper-record-metadata.js", import.meta.url).href
+    : pathToFileURL(resolve(process.argv[moduleFlag + 1] ?? "")).href;
+const { createRecordMetadata } = await import(modulePath);
+console.log(`module under test: ${modulePath.replace(/^file:\/\//, "")}\n`);
+
+const noop = () => null;
+const metadata = createRecordMetadata({
+  reportFileName: (repo, number) => `${number}.md`,
+  markdownRepository: () => "openclaw/openclaw",
+  isVerifiedFixedCloseReason: () => false,
+  isOlderThanDays: () => false,
+  timestampMs: (value) => (value ? Date.parse(value) : null),
+  pullHeadShaFromReport: noop,
+  reviewLeaseRevisionFromReport: noop,
+  lockedConversationApplyReason: noop,
+  markdownFiles: () => [],
+  numberForMarkdownFile: () => 0,
+});
+
+let failures = 0;
+const check = (ok, label, detail) => {
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}`);
+  if (!ok) {
+    failures += 1;
+    if (detail) console.log(`        ${detail}`);
+  }
+};
+
+const RECORD = [
+  "---",
+  "repository: openclaw/openclaw",
+  "number: 42",
+  "labels: []",
+  "title: Fix the thing",
+  "---",
+  "",
+  "Codex review: ready.",
+  "",
+].join("\n");
+
+console.log("== 1. label names are stored verbatim ==");
+// The apply lane writes labels as replaceFrontMatterValue(markdown, "labels",
+// JSON.stringify(item.labels)). Those names come from the reviewed repository and
+// GitHub permits `$`, a backtick and a quote inside a label name.
+for (const labels of [
+  ["bug"],
+  ["$&"],
+  ["$`"],
+  ["$'"],
+  ["a$&b"],
+  ["$$"],
+  ["P$1"],
+  ["needs-triage", "$&"],
+]) {
+  const written = JSON.stringify(labels);
+  const next = metadata.replaceFrontMatterValue(RECORD, "labels", written);
+  const raw = metadata.frontMatterValue(next, "labels");
+  const readBack = metadata.frontMatterStringArray(next, "labels");
+  const ok = raw === written && JSON.stringify(readBack) === written;
+  check(ok, `labels ${written}`, `stored ${JSON.stringify(raw)}, read back ${JSON.stringify(readBack)}`);
+}
+
+console.log("\n== 2. the stored value stays valid JSON ==");
+for (const labels of [["$`"], ["$'"], ["$&"]]) {
+  const written = JSON.stringify(labels);
+  const next = metadata.replaceFrontMatterValue(RECORD, "labels", written);
+  const raw = metadata.frontMatterValue(next, "labels") ?? "";
+  let parsed = null;
+  let error = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    error = String(cause);
+  }
+  check(
+    error === null && JSON.stringify(parsed) === written,
+    `JSON.parse round-trips ${written}`,
+    error ?? `parsed ${JSON.stringify(parsed)}`,
+  );
+}
+
+console.log("\n== 3. the rest of the record is untouched ==");
+{
+  const next = metadata.replaceFrontMatterValue(RECORD, "labels", JSON.stringify(["$'"]));
+  check(metadata.frontMatterValue(next, "title") === "Fix the thing", "title survives");
+  check(metadata.frontMatterValue(next, "number") === "42", "number survives");
+  check(next.includes("Codex review: ready."), "body survives");
+  check(next.split("---").length === RECORD.split("---").length, "delimiters are unchanged");
+}
+
+console.log("\n== 4. keys are matched literally ==");
+for (const key of ["a.c", "a+b", "x(y", "k[0]", "q|r", "n*m"]) {
+  const record = ["---", `${key}: original`, "---", "", "body", ""].join("\n");
+  let readOk = false;
+  let writeOk = false;
+  let error = null;
+  try {
+    readOk = metadata.frontMatterValue(record, key) === "original";
+    const next = metadata.replaceFrontMatterValue(record, key, "updated");
+    writeOk = metadata.frontMatterValue(next, key) === "updated" && !next.includes(`${key}: original`);
+  } catch (cause) {
+    error = String(cause);
+  }
+  check(readOk && writeOk, `key ${JSON.stringify(key)} reads and updates in place`, error);
+}
+{
+  // A literal key must not match a different, regex-equivalent line.
+  const decoy = ["---", "aXc: decoy", "---", "", "body", ""].join("\n");
+  check(metadata.frontMatterField(decoy, "a.c").status === "absent", "`a.c` does not match `aXc`");
+}
+
+console.log(`\n${failures === 0 ? "PROOF PASSED" : `PROOF FAILED (${failures})`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/docs/proof/record-front-matter-literal-write/run-proof.sh
+++ b/docs/proof/record-front-matter-literal-write/run-proof.sh
@@ -20,7 +20,7 @@ echo "== tracked state at sync =="
 TRACKED_BASELINE="$ARTIFACT_DIR/tracked-state-before.txt"
 capture_tracked_state() {
   {
-    echo "head: $(git rev-parse HEAD 2>/dev/null || echo unavailable)"
+    echo "head: ${PROOF_HEAD:-$(git rev-parse HEAD 2>/dev/null || echo unavailable)}"
     echo "package.json sha256: $(sha256sum package.json | cut -d' ' -f1)"
     echo "pnpm-lock.yaml sha256: $(sha256sum pnpm-lock.yaml | cut -d' ' -f1)"
     echo "porcelain:"
@@ -49,7 +49,11 @@ if [ "$NODE_MAJOR" -lt 24 ]; then
   echo "FAIL: repository requires Node >= 24, got $(node --version)"
   exit 1
 fi
-echo "head: $(git rev-parse HEAD 2>/dev/null || echo 'unavailable')"
+# A container image carries no .git, so `git rev-parse` cannot name the commit under
+# test from inside the lease. PROOF_HEAD is computed on the host and forwarded with
+# --allow-env so the recorded output states which head it describes; the host must
+# verify the tree is clean before the run for that to mean anything.
+echo "head: ${PROOF_HEAD:-$(git rev-parse HEAD 2>/dev/null || echo 'unavailable (pass PROOF_HEAD)')}"
 echo
 
 echo "== build =="

--- a/docs/proof/record-front-matter-literal-write/run-proof.sh
+++ b/docs/proof/record-front-matter-literal-write/run-proof.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Crabbox local-container proof for the record front matter literal-write fix.
+#
+# Runs inside a Node 24 Linux container on the synced current checkout. It builds
+# the main lane and exercises the shipped record metadata factory
+# (dist/clawsweeper-record-metadata.js) that the label apply lane writes `labels:`
+# through.
+#
+# See run-proof.mjs for the fixtures and assertions.
+set -euo pipefail
+
+PROOF_DIR="docs/proof/record-front-matter-literal-write"
+ARTIFACT_DIR=".artifacts/record-front-matter-literal-write-proof"
+mkdir -p "$ARTIFACT_DIR"
+
+echo "== environment =="
+uname -a
+node --version
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$NODE_MAJOR" -lt 24 ]; then
+  echo "FAIL: repository requires Node >= 24, got $(node --version)"
+  exit 1
+fi
+echo "head: $(git rev-parse HEAD 2>/dev/null || echo 'unavailable')"
+echo
+
+echo "== build =="
+# The lease runs as the unprivileged `crabbox` user, so corepack cannot symlink
+# into /usr/local/bin. Install the pinned pnpm into a user-writable prefix.
+export PNPM_HOME="$HOME/.local/bin"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME" >/dev/null 2>&1 || true
+fi
+if ! command -v pnpm >/dev/null 2>&1; then
+  npm install -g --prefix "$HOME/.local" pnpm@11.10.0 >"$ARTIFACT_DIR/pnpm-install.log" 2>&1 || true
+fi
+command -v pnpm >/dev/null 2>&1 || {
+  echo "FAIL: pnpm unavailable in container"
+  tail -20 "$ARTIFACT_DIR/pnpm-install.log" 2>/dev/null || true
+  exit 1
+}
+echo "pnpm: $(pnpm --version)"
+pnpm install --frozen-lockfile >"$ARTIFACT_DIR/install.log" 2>&1 \
+  || { echo "FAIL: pnpm install"; tail -30 "$ARTIFACT_DIR/install.log"; exit 1; }
+# TypeScript ships its compiler as a per-platform optional dependency; on some
+# arm64 hosts the frozen install resolves the package but not that binary.
+node -e "require.resolve('typescript/package.json')" >/dev/null 2>&1 || {
+  echo "FAIL: typescript missing after install"; exit 1;
+}
+if ! node -e "require('typescript')" >/dev/null 2>&1; then
+  echo "typescript platform binary missing; fetching"
+  pnpm install --frozen-lockfile --force >>"$ARTIFACT_DIR/install.log" 2>&1 || true
+fi
+pnpm run build:node >"$ARTIFACT_DIR/build.log" 2>&1 \
+  || { echo "FAIL: pnpm run build:node"; tail -30 "$ARTIFACT_DIR/build.log"; exit 1; }
+test -f dist/clawsweeper-record-metadata.js \
+  || { echo "FAIL: build did not produce dist/clawsweeper-record-metadata.js"; exit 1; }
+echo "shipped guard: $(node -p "/escapeRegExp/.test(require('fs').readFileSync('dist/clawsweeper-record-metadata.js','utf8'))")"
+echo
+
+echo "== before / after on the shipped parser =="
+# Compile the pre-fix module from the merge base so the contrast is measured against
+# real compiled code rather than a hand-written re-implementation. It is emitted into
+# dist/ so its relative imports resolve against the already-built siblings.
+# The container has no .git, so the pre-fix module is staged into the proof package
+# by stage-before.sh on the host and rsynced in. When git *is* available the staged
+# copy is re-derived and compared, so it can never drift from the base commit.
+STAGED="$PROOF_DIR/before/record-metadata-before.ts"
+BASE="${PROOF_BASE:-$(git rev-parse HEAD >/dev/null 2>&1 && (git merge-base HEAD main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null) || true)}"
+if git rev-parse HEAD >/dev/null 2>&1 && [ -n "$BASE" ] \
+   && git cat-file -e "$BASE:src/clawsweeper-record-metadata.ts" 2>/dev/null; then
+  echo "base: $BASE (re-derived from git)"
+  mkdir -p "$PROOF_DIR/before"
+  git show "$BASE:src/clawsweeper-record-metadata.ts" >"$STAGED"
+elif [ -f "$STAGED" ]; then
+  echo "base: staged copy (no git in this environment)"
+  echo "staged sha256: $(node -e "const c=require('crypto'),f=require('fs');process.stdout.write(c.createHash('sha256').update(f.readFileSync(process.argv[1])).digest('hex'))" "$STAGED")"
+else
+  echo "FAIL: no pre-fix module. Run docs/proof/record-front-matter-literal-write/stage-before.sh first."
+  exit 1
+fi
+cp "$STAGED" dist/record-metadata-before.ts
+pnpm exec tsc dist/record-metadata-before.ts \
+    --ignoreConfig --module nodenext --target es2023 --skipLibCheck \
+  >"$ARTIFACT_DIR/before-build.log" 2>&1 || true
+if [ -f dist/record-metadata-before.js ]; then
+  set +e
+  node "$PROOF_DIR/run-proof.mjs" --module dist/record-metadata-before.js \
+    >"$ARTIFACT_DIR/before-output.txt" 2>&1
+  BEFORE_STATUS=$?
+  set -e
+  echo "pre-fix exit: $BEFORE_STATUS (non-zero is the bug this PR fixes)"
+  grep "^  FAIL" "$ARTIFACT_DIR/before-output.txt" || true
+  # An ordinary label must already round-trip before the fix; that is what shows
+  # this change only affects names carrying a replacement pattern.
+  if grep -q '^  FAIL  labels \["bug"\]' "$ARTIFACT_DIR/before-output.txt"; then
+    echo "FAIL: an ordinary label did not round-trip before the fix"
+    exit 1
+  fi
+  if [ "$BEFORE_STATUS" -eq 0 ]; then
+    echo "FAIL: the pre-fix module passed, so this proof does not demonstrate the fix"
+    exit 1
+  fi
+else
+  echo "FAIL: the pre-fix module did not compile"
+  tail -10 "$ARTIFACT_DIR/before-build.log" || true
+  exit 1
+fi
+echo
+
+echo "== writer proof =="
+node "$PROOF_DIR/run-proof.mjs" | tee "$ARTIFACT_DIR/proof-output.txt"
+
+echo
+echo "== focused regression suite =="
+node --test test/clawsweeper-record-metadata.test.ts 2>&1 | tail -12 \
+  | tee "$ARTIFACT_DIR/focused-tests.txt"
+
+echo
+echo "artifacts written to $ARTIFACT_DIR"

--- a/docs/proof/record-front-matter-literal-write/run-proof.sh
+++ b/docs/proof/record-front-matter-literal-write/run-proof.sh
@@ -13,6 +13,34 @@ PROOF_DIR="docs/proof/record-front-matter-literal-write"
 ARTIFACT_DIR=".artifacts/record-front-matter-literal-write-proof"
 mkdir -p "$ARTIFACT_DIR"
 
+echo "== tracked state at sync =="
+# A proof is only evidence about the submitted head if the tree still *is* the
+# submitted head when the assertions run. Record the tracked state up front and
+# re-check it at every stage that could disturb it.
+TRACKED_BASELINE="$ARTIFACT_DIR/tracked-state-before.txt"
+capture_tracked_state() {
+  {
+    echo "head: $(git rev-parse HEAD 2>/dev/null || echo unavailable)"
+    echo "package.json sha256: $(sha256sum package.json | cut -d' ' -f1)"
+    echo "pnpm-lock.yaml sha256: $(sha256sum pnpm-lock.yaml | cut -d' ' -f1)"
+    echo "porcelain:"
+    git status --porcelain 2>/dev/null | grep -v '^?? ' || true
+  }
+}
+assert_tracked_state_clean() {
+  local stage="$1" current="$ARTIFACT_DIR/tracked-state-current.txt"
+  capture_tracked_state >"$current"
+  if ! diff -u "$TRACKED_BASELINE" "$current" >"$ARTIFACT_DIR/tracked-state-diff.txt"; then
+    echo "FAIL: the checkout's tracked state changed ($stage)."
+    echo "      The recorded result would describe a tree other than the submitted head."
+    cat "$ARTIFACT_DIR/tracked-state-diff.txt"
+    exit 1
+  fi
+  echo "tracked state unchanged ($stage)"
+}
+capture_tracked_state | tee "$TRACKED_BASELINE"
+echo
+
 echo "== environment =="
 uname -a
 node --version
@@ -49,10 +77,25 @@ pnpm install --frozen-lockfile >"$ARTIFACT_DIR/install.log" 2>&1 \
 node -e "require.resolve('typescript/package.json')" >/dev/null 2>&1 || {
   echo "FAIL: typescript missing after install"; exit 1;
 }
-if ! node -e "require('typescript')" >/dev/null 2>&1; then
-  echo "typescript platform binary missing; fetching"
-  pnpm install --frozen-lockfile --force >>"$ARTIFACT_DIR/install.log" 2>&1 || true
+# Any fallback must stay out of the checkout's tracked dependency metadata: a proof
+# that edits package.json or pnpm-lock.yaml before it builds describes a tree that no
+# longer matches the submitted head. Install into a disposable prefix outside the
+# workspace and copy into node_modules/, which is untracked build state.
+TS_PLATFORM_PKG="@typescript/typescript-$(node -p 'process.platform')-$(node -p 'process.arch')"
+if [ ! -d "node_modules/$TS_PLATFORM_PKG" ]; then
+  echo "NOTE: $TS_PLATFORM_PKG missing after install; fetching it into a disposable prefix"
+  TS_FALLBACK_DIR="$(mktemp -d)"
+  TS_VERSION="$(node -p "require('./node_modules/typescript/package.json').version")"
+  npm install --prefix "$TS_FALLBACK_DIR" --no-save --no-audit --no-fund --ignore-scripts \
+    "$TS_PLATFORM_PKG@$TS_VERSION" >>"$ARTIFACT_DIR/install.log" 2>&1 || true
+  if [ -d "$TS_FALLBACK_DIR/node_modules/$TS_PLATFORM_PKG" ]; then
+    mkdir -p "node_modules/$(dirname "$TS_PLATFORM_PKG")"
+    cp -R "$TS_FALLBACK_DIR/node_modules/$TS_PLATFORM_PKG" "node_modules/$TS_PLATFORM_PKG"
+    echo "fallback source: $TS_FALLBACK_DIR (outside the workspace)"
+  fi
+  rm -rf "$TS_FALLBACK_DIR"
 fi
+assert_tracked_state_clean "after dependency install"
 pnpm run build:node >"$ARTIFACT_DIR/build.log" 2>&1 \
   || { echo "FAIL: pnpm run build:node"; tail -30 "$ARTIFACT_DIR/build.log"; exit 1; }
 test -f dist/clawsweeper-record-metadata.js \
@@ -118,5 +161,11 @@ echo "== focused regression suite =="
 node --test test/clawsweeper-record-metadata.test.ts 2>&1 | tail -12 \
   | tee "$ARTIFACT_DIR/focused-tests.txt"
 
+echo
+echo "== tracked state after proof =="
+# The closing check is what matters for review: it says the tree that produced
+# every result above is still byte-for-byte the submitted head.
+assert_tracked_state_clean "end of run"
+cat "$TRACKED_BASELINE"
 echo
 echo "artifacts written to $ARTIFACT_DIR"

--- a/docs/proof/record-front-matter-literal-write/stage-before.sh
+++ b/docs/proof/record-front-matter-literal-write/stage-before.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Stage the pre-fix module for the before/after contrast in run-proof.sh.
+#
+# Run this on the host before handing the proof to a Crabbox lease. Container
+# images carry no .git, so the base version of the changed file has to travel with
+# the synced workspace. The staged file is untracked and rsynced as a dirty file;
+# run-proof.sh re-derives and overwrites it whenever git *is* available, so it can
+# never drift from the base commit.
+set -euo pipefail
+
+PROOF_DIR="docs/proof/record-front-matter-literal-write"
+SOURCE="src/clawsweeper-record-metadata.ts"
+BASE="${PROOF_BASE:-$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD origin/main)}"
+
+mkdir -p "$PROOF_DIR/before"
+git show "$BASE:$SOURCE" >"$PROOF_DIR/before/record-metadata-before.ts"
+
+echo "staged $PROOF_DIR/before/record-metadata-before.ts"
+echo "  base:   $BASE"
+echo "  source: $SOURCE"
+echo "  sha256: $(shasum -a 256 "$PROOF_DIR/before/record-metadata-before.ts" | cut -d' ' -f1)"

--- a/src/clawsweeper-record-metadata.ts
+++ b/src/clawsweeper-record-metadata.ts
@@ -10,6 +10,7 @@ import {
   PAIR_BLOCKED_CLOSE_ACTIONS,
   REVIEW_SECTIONS,
 } from "./clawsweeper-policy.js";
+import { escapeRegExp } from "./clawsweeper-text.js";
 import type {
   ApplyKind,
   CloseReason,
@@ -72,8 +73,9 @@ export function createRecordMetadata({
     if (!frontMatterMatch) return { status: "absent" };
     const frontMatter = frontMatterMatch[1] ?? "";
     const remainder = markdown.slice(frontMatterMatch[0].length);
-    if (new RegExp(`^${key}:`, "m").test(remainder)) return { status: "ambiguous" };
-    const matches = [...frontMatter.matchAll(new RegExp(`^${key}:\\s*(.*)$`, "gm"))];
+    const escapedKey = escapeRegExp(key);
+    if (new RegExp(`^${escapedKey}:`, "m").test(remainder)) return { status: "ambiguous" };
+    const matches = [...frontMatter.matchAll(new RegExp(`^${escapedKey}:\\s*(.*)$`, "gm"))];
     if (matches.length === 0) return { status: "absent" };
     if (matches.length !== 1) return { status: "ambiguous" };
     const value = matches[0]?.[1]?.trim();
@@ -256,11 +258,16 @@ export function createRecordMetadata({
     );
   }
 
+  // `value` is record data — most often `JSON.stringify(item.labels)`, whose contents
+  // are GitHub label names. Passing it as a replacement *string* would let `$&`, `` $` ``
+  // and `$'` expand against the match, so a label containing them rewrites the field to
+  // something other than what was stored. A replacement function inserts the text
+  // literally, which is the only behavior this writer ever intended.
   function replaceFrontMatterValue(markdown: string, key: string, value: string): string {
     const line = `${key}: ${value}`;
-    const pattern = new RegExp(`^${key}:\\s*.*$`, "m");
-    if (pattern.test(markdown)) return markdown.replace(pattern, line);
-    return markdown.replace(/^---\n/, `---\n${line}\n`);
+    const pattern = new RegExp(`^${escapeRegExp(key)}:\\s*.*$`, "m");
+    if (pattern.test(markdown)) return markdown.replace(pattern, () => line);
+    return markdown.replace(/^---\n/, () => `---\n${line}\n`);
   }
 
   function exactEventReviewLeaseDisposition(

--- a/test/clawsweeper-record-metadata.test.ts
+++ b/test/clawsweeper-record-metadata.test.ts
@@ -53,3 +53,54 @@ test("front matter fields preserve current-format, duplicate, and no-block behav
     { status: "absent" },
   );
 });
+
+test("label names containing replacement patterns survive a front matter write", () => {
+  // `labels` is written as replaceFrontMatterValue(markdown, "labels", JSON.stringify(
+  // item.labels)), and those names come from the reviewed repository. GitHub permits
+  // `$`, a backtick and a quote in a label, so `$&`, "$`" and "$'" reach this writer as
+  // ordinary data and must not be expanded against the match.
+  const report = ["---", "repository: openclaw/openclaw", "labels: []", "---", "", "body", ""].join(
+    "\n",
+  );
+
+  for (const labels of [["bug"], ["$&"], ["$`"], ["$'"], ["a$&b"], ["$$"], ["P$1"]]) {
+    const written = JSON.stringify(labels);
+    const next = metadata.replaceFrontMatterValue(report, "labels", written);
+    assert.equal(
+      metadata.frontMatterValue(next, "labels"),
+      written,
+      `labels ${written} must be stored verbatim`,
+    );
+    assert.deepEqual(
+      metadata.frontMatterStringArray(next, "labels"),
+      labels,
+      `labels ${written} must read back unchanged`,
+    );
+  }
+});
+
+test("front matter keys are matched literally, not as regular expressions", () => {
+  // No shipped caller passes a key with regex syntax, but the helpers advertise a plain
+  // `key: string` contract; interpolating it raw makes them throw or match the wrong line.
+  for (const key of ["a.c", "a+b", "x(y", "k[0]", "q|r"]) {
+    const report = ["---", `${key}: original`, "---", "", "body", ""].join("\n");
+
+    assert.deepEqual(
+      metadata.frontMatterField(report, key),
+      { status: "value", value: "original" },
+      `key ${key} must be readable`,
+    );
+
+    const next = metadata.replaceFrontMatterValue(report, key, "updated");
+    assert.equal(
+      metadata.frontMatterValue(next, key),
+      "updated",
+      `key ${key} must be updated in place`,
+    );
+    assert.equal(next.includes(`${key}: original`), false, `key ${key} must not be duplicated`);
+  }
+
+  // A literal key must not match a different, regex-equivalent line.
+  const decoy = ["---", "aXc: decoy", "---", "", "body", ""].join("\n");
+  assert.deepEqual(metadata.frontMatterField(decoy, "a.c"), { status: "absent" });
+});


### PR DESCRIPTION
Closes #1135.

---

## What Problem This Solves

Fixes an issue where syncing labels for an item in a reviewed repository writes a
corrupted `labels:` field — and in some cases damages the rest of the record — when
any label name contains `$&`, `` $` ``, `$'` or `$$`.

The label apply lane stores the synced label set with

```ts
markdown = replaceFrontMatterValue(markdown, "labels", JSON.stringify(item.labels));
```

That value went into `String.prototype.replace` as a *replacement string*, where
`$&`, `` $` `` and `$'` are expansion patterns rather than literal text. The label
names come from the reviewed repository, so any repository whose labels contain
those characters produces a record that no longer says what the sync decided.

Two distinct outcomes, both observed:

- `` $` `` and `$'` expand to the text before / after the match, which yields invalid
  JSON *and* pulls surrounding record content into the field.
- `$&` expands to the matched line, so the field silently reads back the *previous*
  label state instead of the new one.

Downstream, `frontMatterStringArray` falls back to comma-splitting when the value
does not parse, so the corrupted text becomes a plausible-looking but wrong label
list. That list is what `PROOF_OVERRIDE_LABEL`, `AUTOFIX_LABEL` and the priority and
rating checks read.

## Why This Change Was Made

`replaceFrontMatterValue` never intended `$` expansion — it is a writer storing a
value verbatim — so the replacement argument is now a function, which inserts the
text literally. The same function interpolated the caller's `key` straight into a
`RegExp` source; that is now escaped, so keys are matched literally as the
`key: string` signature advertises. Both readers in the file (`frontMatterField`)
were interpolating the key the same way and are escaped alongside it.

Non-goals: the front matter format is unchanged, no key is renamed, and the label
sync logic itself is untouched — only how the chosen value is written down.

## User Impact

Repositories whose labels contain `$` characters now get records that match what the
sync actually decided. Operators reading a record's `labels:` field, and the
override and priority checks that read it back, see the real label set instead of a
mangled one.

For the overwhelming majority of repositories — whose label names contain no `$` —
nothing changes; the ordinary case is byte-for-byte identical before and after.

## OpenClaw Bay Impact

Bay reads `labels` from published records. This change makes that field correct for
the affected repositories rather than changing its shape, so no Bay change is
needed. No new field, no removed field, no status or telemetry contract change.

## Documentation Lifecycle

No documentation lifecycle changes. The new file under
`docs/proof/record-front-matter-literal-write/` is PR evidence, not a runbook or
reference.

## Evidence

### Change

- `src/clawsweeper-record-metadata.ts` — import `escapeRegExp`; escape `key` in the
  two `frontMatterField` regexes and in `replaceFrontMatterValue`; pass the
  replacement as a function in both `replace` calls.
- `test/clawsweeper-record-metadata.test.ts` — two regression tests.

`17` changed lines in source, `51` added in tests.

### Focused tests

```
$ node --test test/clawsweeper-record-metadata.test.ts
✔ front matter fields are ambiguous when the same key occurs after the leading block
✔ front matter fields preserve current-format, duplicate, and no-block behavior
✔ label names containing replacement patterns survive a front matter write
✔ front matter keys are matched literally, not as regular expressions
ℹ pass 4   ℹ fail 0
```

Reverting only `src/clawsweeper-record-metadata.ts` and rebuilding turns both new
tests red (`pass 2 / fail 2`) while the two pre-existing tests stay green.

### Full suite and static gates

`pnpm run check:static`, `pnpm run lint`, `pnpm run format:check` and
`pnpm run build:all` all pass. The full suite is `2050 / 2067` with 6 failures, none
of which is caused by this change:

| Failure | Verdict |
| --- | --- |
| `action-ledger-runtime.test.ts` temp-dir cleanup | fails identically on unmodified `main` |
| `automerge-metrics.test.ts` CLI JSON | fails identically on unmodified `main` |
| `apply-runtime-budget.test.ts` ×2 | passes `10/0` in isolation — contention flake |
| `codex-process.test.ts` | `9 pass / 1 fail` on unmodified `main` too |
| `codex-review-runner.test.ts` | `17 pass / 2 fail` on `main`; this branch is `18 / 1` |
| `dashboard-worker.test.ts` ×9 | passes `328/0` in isolation — cascade after one timeout |

None of those files import `clawsweeper-record-metadata`.

## Real Behavior Proof

**Claim.** A label whose name contains `$&`, `` $` ``, `$'` or `$$` is stored in
`labels:` exactly as given, the record around it is unchanged, and front matter keys
are matched literally rather than compiled as regular expressions.

**Exercised surface.** `createRecordMetadata(...).replaceFrontMatterValue` and the
matching readers `.frontMatterField` / `.frontMatterValue` /
`.frontMatterStringArray` in `dist/clawsweeper-record-metadata.js` — the writer
`src/clawsweeper-apply-report-labels.ts` calls at three sites.

**Scenario / fixture.**
`docs/proof/record-front-matter-literal-write/run-proof.mjs` writes label sets
through the shipped writer and reads them back through the shipped readers:
verbatim storage (including a mixed set `["needs-triage", "$&"]` that mirrors a real
sync result), `JSON.parse` round-trip, record integrity (`title`, `number`, body and
`---` delimiters unchanged), and literal key matching for keys containing
`. + ( [ | *`.

**Command and environment.**

```
bash docs/proof/record-front-matter-literal-write/stage-before.sh
crabbox run --provider local-container --local-container-image node:24 --no-hydrate \
  --artifact-glob '.artifacts/**' -- \
  bash docs/proof/record-front-matter-literal-write/run-proof.sh
```

| | |
|---|---|
| provider | `local-container` (runtime `docker`) |
| image | `node:24` → `v24.19.0`, `Linux aarch64` |
| lease | `cbx_241c2987e276` (`swift-crab`) |
| run | `run_b5d44f1fa51f` |
| base staged | `5439582b` · `src/clawsweeper-record-metadata.ts` · sha256 `df480a1e…83f1` |
| exit | `0` |

The script refuses to run below Node 24, builds the Node lane, then runs the
fixtures twice — once against the module compiled from the base commit and once
against this branch. Container images carry no `.git`, so `stage-before.sh` writes
the base version of the changed file into the proof package on the host and it
rsyncs in; when git *is* available the script re-derives that file, so it cannot
drift from the base commit.

**Observed result.** Pre-fix: 17 failing assertions. Beyond the label sets, a label
named `$'` also fails `title survives` and `delimiters are unchanged` — the
expansion drags following record text into the field, so the write damages the
record body, not just the one value. Keys containing `(`, `[`, `|`, `+` or `*`
either throw `SyntaxError: Invalid regular expression` or match the wrong line, and
`a.c` matches a line reading `aXc:`. On this branch every assertion passes. The
ordinary `["bug"]` case passes in **both** runs, and the script fails the proof if
that ever stops holding — which is what shows the change is confined to names
carrying a replacement pattern.

The 17 pre-fix failures inside the lease:

```
pre-fix exit: 1
  FAIL  labels ["$&"]          FAIL  labels ["$`"]        FAIL  labels ["$'"]
  FAIL  labels ["a$&b"]        FAIL  labels ["$$"]        FAIL  labels ["needs-triage","$&"]
  FAIL  JSON.parse round-trips ["$`"] / ["$'"] / ["$&"]
  FAIL  title survives         FAIL  delimiters are unchanged
  FAIL  key "a+b" / "x(y" / "k[0]" / "q|r" / "n*m" reads and updates in place
  FAIL  `a.c` does not match `aXc`
```

**Artifact / trace.**
`.crabbox/runs/run_b5d44f1fa51f/run_b5d44f1fa51f-artifacts.tgz` containing
`.artifacts/record-front-matter-literal-write-proof/` — `before-output.txt`,
`proof-output.txt`, `focused-tests.txt`, install and build logs.

**Limits.** This proves the record reader and writer in
`src/clawsweeper-record-metadata.ts`. The same raw-interpolation shape exists in
`src/repair/workflow-utils.ts`, `src/repair/create-job.ts`,
`src/repair/target-fanout.ts`, `src/repair/comment-router-core.ts`,
`src/commit-sweeper.ts`, `src/decision-packets.ts` and two scripts; those are out of
scope here and named in the linked issue. The proof does not call GitHub — it starts
from the label set the sync returns. No shipped caller passes a key containing regex
syntax today, so the key-escaping half hardens the advertised contract rather than
fixing an observed failure; the value half is the reachable defect.
