### PR TITLE
feat(telemetry): observe GitHub publication egress

### DIFF
--- a/.github/actions/setup-github-egress-observer/action.yml
+++ b/.github/actions/setup-github-egress-observer/action.yml
@@ -1,0 +1,71 @@
+name: Set up GitHub egress observer
+description: Install the fail-open Phase 0 gh transport observation seam
+
+inputs:
+  metrics-path:
+    description: Repository-relative JSONL path for bounded egress metrics
+    required: true
+  rate-limit-path:
+    description: Repository-relative JSONL path for sanitized 403/429 details
+    required: true
+  pool-class:
+    description: Default credential pool class for direct gh calls
+    required: true
+  stage:
+    description: Publication lifecycle stage for direct gh calls
+    required: true
+  source-action:
+    description: Durable source action; normalized to a closed telemetry class
+    required: false
+    default: ""
+  claim-generation:
+    description: Durable claim generation for first/repeat attribution
+    required: false
+    default: ""
+  repeat-revision:
+    description: Whether this durable item revision has a prior publication failure
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install observer shim
+      shell: bash
+      env:
+        METRICS_PATH: ${{ inputs.metrics-path }}
+        RATE_LIMIT_PATH: ${{ inputs.rate-limit-path }}
+        POOL_CLASS: ${{ inputs.pool-class }}
+        STAGE: ${{ inputs.stage }}
+        SOURCE_ACTION: ${{ inputs.source-action }}
+        CLAIM_GENERATION: ${{ inputs.claim-generation }}
+        REPEAT_REVISION: ${{ inputs.repeat-revision }}
+      run: |
+        set -euo pipefail
+        [[ "$METRICS_PATH" =~ ^\.artifacts/[A-Za-z0-9._/-]+\.jsonl$ ]]
+        [[ "$RATE_LIMIT_PATH" =~ ^\.artifacts/[A-Za-z0-9._/-]+\.jsonl$ ]]
+        [[ "$POOL_CLASS" =~ ^(repository_actions|target_app|public_read_fallback)$ ]]
+        [[ "$STAGE" =~ ^(publication_prepare|publication_apply|publication_router|publication_recovery)$ ]]
+        [[ -z "$SOURCE_ACTION" || "$SOURCE_ACTION" =~ ^[A-Za-z0-9_.:-]{1,80}$ ]] || SOURCE_ACTION=""
+        [[ -z "$CLAIM_GENERATION" || "$CLAIM_GENERATION" =~ ^[0-9]{1,9}$ ]] || CLAIM_GENERATION=""
+        [[ -z "$REPEAT_REVISION" || "$REPEAT_REVISION" =~ ^(true|false)$ ]] || REPEAT_REVISION=""
+        real_gh="$(command -v gh)"
+        test -x "$real_gh"
+        observer_bin="$RUNNER_TEMP/clawsweeper-github-egress-observer"
+        rm -rf "$observer_bin"
+        mkdir -p "$observer_bin"
+        cp "$GITHUB_WORKSPACE/scripts/github-egress-observer.sh" "$observer_bin/gh"
+        chmod 0755 "$observer_bin/gh"
+        {
+          echo "CLAWSWEEPER_REAL_GH_BIN=$real_gh"
+          echo "CLAWSWEEPER_GITHUB_OBSERVER_ROOT=$GITHUB_WORKSPACE"
+          echo "CLAWSWEEPER_DEPLOYMENT_REVISION=$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+          echo "CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH=$METRICS_PATH"
+          echo "CLAWSWEEPER_GITHUB_RATE_LIMIT_DETAILS_PATH=$RATE_LIMIT_PATH"
+          echo "CLAWSWEEPER_GITHUB_POOL_CLASS=$POOL_CLASS"
+          echo "CLAWSWEEPER_GITHUB_STAGE=$STAGE"
+          echo "CLAWSWEEPER_GITHUB_SOURCE_ACTION=$SOURCE_ACTION"
+          echo "CLAWSWEEPER_GITHUB_CLAIM_GENERATION=$CLAIM_GENERATION"
+          echo "CLAWSWEEPER_GITHUB_REQUEST_REPEAT=$REPEAT_REVISION"
+        } >> "$GITHUB_ENV"
+        echo "$observer_bin" >> "$GITHUB_PATH"

--- a/.github/workflows/exact-review-batch-publish.yml
+++ b/.github/workflows/exact-review-batch-publish.yml
@@ -66,6 +66,16 @@ jobs:
         with:
           build-script: build:all
 
+      - uses: ./.github/actions/setup-github-egress-observer
+        id: github-egress-observer
+        continue-on-error: true
+        with:
+          metrics-path: .artifacts/exact-review-batch/github-egress-v2.jsonl
+          rate-limit-path: .artifacts/exact-review-batch/github-rate-limit-details-v2.jsonl
+          pool-class: repository_actions
+          stage: publication_prepare
+          source-action: exact_review_artifact_publish
+
       - name: Claim one durable publication batch
         id: batch
         env:
@@ -207,10 +217,16 @@ jobs:
             item_number="$(jq -r '.decision.itemNumber' <<<"$item")"
             source_action="$(jq -r '.decision.publication.producerDecision.sourceAction' <<<"$item")"
             repeat_revision="$(jq -r '.repeatRevision == true' <<<"$item")"
+            claim_generation="$(jq -r '.claimGeneration' <<<"$item")"
             fence_key="$(jq -r '.itemKey' <<<"$item")"
             revision="$(jq -r '.revision' <<<"$item")"
             export TARGET_REPO="$target_repo" ITEM_NUMBER="$item_number" FENCE_KEY="$fence_key" REVISION="$revision"
             export EXACT_REVIEW_GITHUB_REQUEST_REPEAT="$repeat_revision"
+            export CLAWSWEEPER_GITHUB_POOL_CLASS=repository_actions
+            export CLAWSWEEPER_GITHUB_STAGE=publication_router
+            export CLAWSWEEPER_GITHUB_SOURCE_ACTION="$source_action"
+            export CLAWSWEEPER_GITHUB_CLAIM_GENERATION="$claim_generation"
+            export CLAWSWEEPER_GITHUB_REQUEST_REPEAT="$repeat_revision"
             lifecycle_terminal=""
             lifecycle_router_outcome=""
             lifecycle_deferred_coverage="false"
@@ -387,6 +403,13 @@ jobs:
           EXACT_REVIEW_BATCH_OBSERVATION=final_github_apply \
             pnpm run --silent repair:exact-review-batch observe || true
           pnpm run --silent repair:exact-review-batch complete
+
+      - name: Submit batch GitHub egress telemetry
+        if: ${{ always() && steps.github-egress-observer.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run --silent repair:github-egress-telemetry submit
 
       - name: Release unfinished batch members
         if: ${{ always() && steps.batch.outputs.claimed == 'true' && steps.batch.outputs.item_count != '0' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -577,6 +577,7 @@ jobs:
                           process.env.QUEUE_LEASE_REVISION,
                       );
                 const claimGeneration = Number(response.claim_generation);
+                const repeatRevision = response.repeat_revision;
                 if (
                   !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo) ||
                   !Number.isInteger(itemNumber) ||
@@ -597,7 +598,8 @@ jobs:
                     response.item_key !== requestedItemKey ||
                     response.lease_revision !== requestedLeaseRevision ||
                     !Number.isInteger(claimGeneration) ||
-                    claimGeneration < 1)
+                    claimGeneration < 1 ||
+                    typeof repeatRevision !== "boolean")
                 ) {
                   process.exit(1);
                 }
@@ -607,6 +609,7 @@ jobs:
                   `item_key=${itemKey}`,
                   `lease_revision=${Number.isInteger(leaseRevision) ? leaseRevision : ""}`,
                   `claim_generation=${responseProtocol === 2 ? claimGeneration : ""}`,
+                  `repeat_revision=${responseProtocol === 2 ? repeatRevision : false}`,
                   `protocol_version=${responseProtocol}`,
                   `decision=${JSON.stringify(decision)}`,
                 ];
@@ -1388,6 +1391,26 @@ jobs:
           hydrate-git-state: "false"
           hydrate-state-blobs: "false"
 
+      - uses: ./.github/actions/setup-github-egress-observer
+        id: direct-github-egress-observer
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-setup-state.outcome == 'success' }}
+        continue-on-error: true
+        with:
+          metrics-path: .artifacts/direct-publication/github-egress-v2.jsonl
+          rate-limit-path: .artifacts/direct-publication/github-rate-limit-details-v2.jsonl
+          pool-class: target_app
+          stage: publication_apply
+          source-action: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).sourceAction }}
+          claim-generation: ${{ steps.claim-exact-review-queue.outputs.claim_generation }}
+          repeat-revision: ${{ steps.claim-exact-review-queue.outputs.repeat_revision }}
+
+      - name: Record direct-publication member
+        if: ${{ steps.direct-github-egress-observer.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+        run: node dist/github-egress-observer-cli.js record-member
+
       - name: Deliver GitHub effects and prepare direct state mutation
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-setup-state.outcome == 'success' }}
         id: prepare-direct-exact-review-publication
@@ -1426,6 +1449,8 @@ jobs:
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-exact-review-publication.outputs.accepted == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          CLAWSWEEPER_GITHUB_POOL_CLASS: repository_actions
+          CLAWSWEEPER_GITHUB_STAGE: publication_router
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
           TARGET_BRANCH: ${{ steps.target.outputs.target_branch }}
           ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
@@ -1891,6 +1916,14 @@ jobs:
           done
           exit 1
 
+      - name: Submit direct GitHub egress telemetry
+        if: ${{ always() && steps.direct-github-egress-observer.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run --silent repair:github-egress-telemetry submit
+
       - name: Fail unsuccessful exact review generation
         # A held review lease is a successful deferral only after the durable queue
         # accepts retry ownership; queue completion failures must remain visible.
@@ -2005,6 +2038,7 @@ jobs:
                 const producerDecision = publication?.producerDecision;
                 const leaseRevision = Number(response.lease_revision);
                 const claimGeneration = Number(response.claim_generation);
+                const repeatRevision = response.repeat_revision;
                 const publicationLeaseRevision = Number(publication?.leaseRevision);
                 const directItemKey = `${decision?.targetRepo}#${decision?.itemNumber}`;
                 const expectedDeferredItemKey = `${directItemKey}@publish:${publication?.producerRunId}:${publication?.producerRunAttempt}`;
@@ -2045,6 +2079,7 @@ jobs:
                 if (
                   response.claimed !== true ||
                   response.protocol_version !== 2 ||
+                  typeof repeatRevision !== "boolean" ||
                   response.item_key !== process.env.ITEM_KEY ||
                   (!deferredPublication && !directLifecycleRecovery) ||
                   decision?.sourceAction !== "exact_review_artifact_publish" ||
@@ -2088,6 +2123,7 @@ jobs:
                   publisher_item_key: response.item_key,
                   publisher_lease_revision: leaseRevision,
                   publisher_claim_generation: claimGeneration,
+                  repeat_revision: repeatRevision,
                   direct_lifecycle_recovery: directLifecycleRecoveryReady,
                   direct_lifecycle_plan: directLifecycleRecoveryReady
                     ? JSON.stringify(directLifecyclePlan)
@@ -2274,6 +2310,26 @@ jobs:
         with:
           build-script: build:all
 
+      - uses: ./.github/actions/setup-github-egress-observer
+        id: artifact-github-egress-observer
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.setup-publish-pnpm.outcome == 'success' }}
+        continue-on-error: true
+        with:
+          metrics-path: .artifacts/artifact-publication/github-egress-v2.jsonl
+          rate-limit-path: .artifacts/artifact-publication/github-rate-limit-details-v2.jsonl
+          pool-class: target_app
+          stage: publication_apply
+          source-action: ${{ fromJSON(steps.publication-context.outputs.decision).sourceAction }}
+          claim-generation: ${{ steps.publication-context.outputs.publisher_claim_generation }}
+          repeat-revision: ${{ steps.publication-context.outputs.repeat_revision }}
+
+      - name: Record artifact-publication member
+        if: ${{ steps.artifact-github-egress-observer.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+        run: node dist/github-egress-observer-cli.js record-member
+
       - name: Download exact review artifact bundle
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' }}
         id: download-exact-review-bundle
@@ -2285,6 +2341,14 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           path: .artifacts/exact-review-bundle
+
+      - name: Record artifact download transport boundary
+        if: ${{ always() && steps.artifact-github-egress-observer.outcome == 'success' && steps.download-exact-review-bundle.outcome != 'skipped' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_GITHUB_POOL_CLASS: repository_actions
+          CLAWSWEEPER_GITHUB_STAGE: publication_prepare
+        run: node dist/github-egress-observer-cli.js record-unobserved -- run download
 
       - name: Validate exact review artifact bundle
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.download-exact-review-bundle.outcome == 'success' }}
@@ -2558,6 +2622,8 @@ jobs:
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && fromJSON(steps.publication-context.outputs.decision).sourceAction != 'failed_review_shard_recovery' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.routing_deferred == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          CLAWSWEEPER_GITHUB_POOL_CLASS: repository_actions
+          CLAWSWEEPER_GITHUB_STAGE: publication_router
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
           TARGET_BRANCH: ${{ steps.publication-context.outputs.target_branch }}
           ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
@@ -3071,6 +3137,14 @@ jobs:
             --state "Waiting" \
             --detail "Another same-revision review is active; durable publication will retry after its lease expires." \
             --run-url "$RUN_URL"
+
+      - name: Submit artifact-publication GitHub egress telemetry
+        if: ${{ always() && steps.artifact-github-egress-observer.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: pnpm run --silent repair:github-egress-telemetry submit
 
       - name: Fail unsuccessful exact review publication
         if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && (steps.exact-review-publication-result.outputs.outcome != 'success' || steps.complete-exact-review-publication.outcome != 'success') }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1405,7 +1405,7 @@ jobs:
           repeat-revision: ${{ steps.claim-exact-review-queue.outputs.repeat_revision }}
 
       - name: Record direct-publication member
-        if: ${{ steps.direct-github-egress-observer.outcome == 'success' }}
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-github-egress-observer.outcome == 'success' }}
         continue-on-error: true
         env:
           TARGET_REPO: ${{ steps.target.outputs.target_repo }}
@@ -1917,7 +1917,7 @@ jobs:
           exit 1
 
       - name: Submit direct GitHub egress telemetry
-        if: ${{ always() && steps.direct-github-egress-observer.outcome == 'success' }}
+        if: ${{ always() && steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.direct-github-egress-observer.outcome == 'success' }}
         continue-on-error: true
         env:
           EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
@@ -2324,7 +2324,7 @@ jobs:
           repeat-revision: ${{ steps.publication-context.outputs.repeat_revision }}
 
       - name: Record artifact-publication member
-        if: ${{ steps.artifact-github-egress-observer.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.artifact-github-egress-observer.outcome == 'success' }}
         continue-on-error: true
         env:
           TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
@@ -2343,7 +2343,7 @@ jobs:
           path: .artifacts/exact-review-bundle
 
       - name: Record artifact download transport boundary
-        if: ${{ always() && steps.artifact-github-egress-observer.outcome == 'success' && steps.download-exact-review-bundle.outcome != 'skipped' }}
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.artifact-github-egress-observer.outcome == 'success' && steps.download-exact-review-bundle.outcome != 'skipped' }}
         continue-on-error: true
         env:
           CLAWSWEEPER_GITHUB_POOL_CLASS: repository_actions
@@ -3139,7 +3139,7 @@ jobs:
             --run-url "$RUN_URL"
 
       - name: Submit artifact-publication GitHub egress telemetry
-        if: ${{ always() && steps.artifact-github-egress-observer.outcome == 'success' }}
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.artifact-github-egress-observer.outcome == 'success' }}
         continue-on-error: true
         env:
           EXACT_REVIEW_QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}

--- a/config/documentation-site.json
+++ b/config/documentation-site.json
@@ -24,6 +24,7 @@
       "pages": [
         "limits.md",
         "public-api.md",
+        "github-egress-telemetry.md",
         "operator-configuration.md",
         "live-dashboard.md",
         "openclaw-bay-demo.md",

--- a/config/operator-documentation.json
+++ b/config/operator-documentation.json
@@ -9,6 +9,7 @@
     { "path": "/api/exact-review-queue/item", "method": "GET" },
     { "path": "/api/exact-review-queue/reviews", "method": "GET" },
     { "path": "/api/review-observability", "method": "GET" },
+    { "path": "/api/github-egress-observability", "method": "GET" },
     { "path": "/api/review-coverage", "method": "GET" },
     { "path": "/api/apply-observability", "method": "GET" },
     { "path": "/api/health-history", "method": "GET" },

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -60,6 +60,7 @@ import {
   type LifecycleTerminalDisposition,
 } from "./exact-review-lifecycle.ts";
 import { ExactReviewLifecycleTelemetryStore } from "./exact-review-lifecycle-telemetry.ts";
+import { GithubEgressTelemetryStore } from "./github-egress-telemetry.ts";
 import { recentDurablePublicationEvents } from "./recent-durable-publication-events.ts";
 import { sanitizedServerError } from "./error-safety.ts";
 import {
@@ -637,6 +638,7 @@ export class ExactReviewQueue {
   private stateWriterCoordinator;
   private lifecycleProjectionStore;
   private lifecycleTelemetryStore;
+  private githubEgressTelemetryStore;
   private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
@@ -660,6 +662,7 @@ export class ExactReviewQueue {
     this.stateWriterCoordinator = new StateWriterCoordinator(this.storage);
     this.lifecycleProjectionStore = new ExactReviewLifecycleProjectionStore(this.storage);
     this.lifecycleTelemetryStore = new ExactReviewLifecycleTelemetryStore(this.storage);
+    this.githubEgressTelemetryStore = new GithubEgressTelemetryStore(this.storage);
     // Direct in-process users retain the established eager setup behavior.
     // A real Durable Object has blockConcurrencyWhile; defer that setup until a
     // non-Bay request so constructing it for the public pure reader cannot
@@ -682,6 +685,16 @@ export class ExactReviewQueue {
     }
     await this.ensureReady();
     this.cleanupLegacyCompatibilitySync();
+    if (request.method === "POST" && url.pathname === "/github-egress-telemetry") {
+      const result = this.githubEgressTelemetryStore.ingest(await request.json().catch(() => null));
+      return result.ok ? json({ ok: true, ...result }, 202) : json({ error: result.error }, 400);
+    }
+    if (request.method === "GET" && url.pathname === "/github-egress-observability") {
+      const result = this.githubEgressTelemetryStore.publicObservability(
+        Number(url.searchParams.get("hours") || "6"),
+      );
+      return result ? json(result) : json({ error: "invalid_github_egress_window" }, 400);
+    }
     if (request.method === "POST" && url.pathname === "/review-coverage/inventory") {
       const inventory = normalizeReviewCoverageInventory(await request.json().catch(() => null));
       if (!inventory) return json({ error: "invalid_review_coverage_inventory" }, 400);
@@ -3145,6 +3158,7 @@ export class ExactReviewQueue {
                 : null,
               counters: state.dispatcher?.githubRequestMetrics?.counters || {},
             },
+            github_egress_metrics_v2: this.githubEgressTelemetryStore.publicSummary(now),
             batches: {
               enabled: exactReviewPublicationBatchingEnabled(this.env),
               max_items: exactReviewPublicationBatchSize(this.env),
@@ -7285,6 +7299,7 @@ export class ExactReviewQueue {
     this.stateWriterCoordinator.ensureSchemaSync();
     this.lifecycleProjectionStore.ensureSchemaSync();
     this.lifecycleTelemetryStore.ensureSchemaSync();
+    this.githubEgressTelemetryStore.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
     const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as
@@ -9754,6 +9769,9 @@ function exactReviewClaimResponse(
     ...(protocolVersion === 1 ? { revision: item.leaseRevision } : {}),
     lease_revision: item.leaseRevision,
     claim_generation: claimGeneration,
+    ...(protocolVersion === 2
+      ? { repeat_revision: Number(item.publicationFailureAttempts || 0) > 0 }
+      : {}),
     decision: item.leaseDecision,
     ...(item.terminalFinalization
       ? {

--- a/dashboard/github-egress-telemetry.ts
+++ b/dashboard/github-egress-telemetry.ts
@@ -28,6 +28,11 @@ const MAX_METRICS_PER_SUBMISSION = 128;
 const MAX_RATE_LIMITS_PER_SUBMISSION = 16;
 const MAX_RATE_LIMIT_INTEGER = 10_000_000_000;
 
+function alignedBucketStart(bucketKind: "five_minute" | "hour", timestamp: number) {
+  const bucketMs = bucketKind === "five_minute" ? 300_000 : 3_600_000;
+  return Math.floor(timestamp / bucketMs) * bucketMs;
+}
+
 export class GithubEgressTelemetryStore {
   private readonly storage;
 
@@ -233,8 +238,9 @@ export class GithubEgressTelemetryStore {
   }
 
   publicSummary(now = Date.now()) {
-    const start = now - 6 * 60 * 60 * 1000;
-    const completeness = this.completenessSince("five_minute", start);
+    const windowStart = now - 6 * 60 * 60 * 1000;
+    const bucketStart = alignedBucketStart("five_minute", windowStart);
+    const completeness = this.completenessSince("five_minute", bucketStart);
     const diagnostics = this.diagnostics();
     return {
       version: 2,
@@ -248,8 +254,9 @@ export class GithubEgressTelemetryStore {
         hourly_days: 30,
         evicted_rollup_rows_total: Number(diagnostics.evicted_rollup_rows || 0),
         evicted_rate_limit_rows_total: Number(diagnostics.evicted_rate_limit_rows || 0),
-        rollup_window_complete: Number(diagnostics.last_rollup_evicted_at || 0) < start,
-        rate_limit_window_complete: Number(diagnostics.last_rate_limit_evicted_at || 0) < start,
+        rollup_window_complete: Number(diagnostics.last_rollup_evicted_at || 0) < bucketStart,
+        rate_limit_window_complete:
+          Number(diagnostics.last_rate_limit_evicted_at || 0) < windowStart,
       },
     };
   }
@@ -292,7 +299,8 @@ export class GithubEgressTelemetryStore {
     const boundedHours = hours === 1 || hours === 6 || hours === 24 ? hours : null;
     if (!boundedHours) return null;
     const bucketKind = boundedHours <= 6 ? "five_minute" : "hour";
-    const start = now - boundedHours * 60 * 60 * 1000;
+    const windowStart = now - boundedHours * 60 * 60 * 1000;
+    const bucketStart = alignedBucketStart(bucketKind, windowStart);
     const rows = Array.from(
       this.storage.sql.exec(
         `SELECT bucket_start, deployment_revision, config_revision, pool_class,
@@ -310,7 +318,7 @@ export class GithubEgressTelemetryStore {
           ORDER BY bucket_start ASC, pool_class, stage, operation, unit
           LIMIT ?`,
         bucketKind,
-        start,
+        bucketStart,
         MAX_PUBLIC_ROWS + 1,
       ),
     ) as Array<Record<string, unknown>>;
@@ -349,15 +357,16 @@ export class GithubEgressTelemetryStore {
           WHERE observed_at >= ?
           ORDER BY observed_at DESC
           LIMIT 257`,
-        Math.max(start, now - RATE_LIMIT_RETENTION_MS),
+        Math.max(windowStart, now - RATE_LIMIT_RETENTION_MS),
       ),
     ) as Array<Record<string, unknown>>;
     const rateLimitTruncated = rateLimitRows.length > 256;
     const rateLimits = rateLimitRows.slice(0, 256).map(publicRateLimitRow);
-    const completeness = this.completenessSince(bucketKind, start);
+    const completeness = this.completenessSince(bucketKind, bucketStart);
     const diagnostics = this.diagnostics();
-    const rollupWindowComplete = Number(diagnostics.last_rollup_evicted_at || 0) < start;
-    const rateLimitWindowComplete = Number(diagnostics.last_rate_limit_evicted_at || 0) < start;
+    const rollupWindowComplete = Number(diagnostics.last_rollup_evicted_at || 0) < bucketStart;
+    const rateLimitWindowComplete =
+      Number(diagnostics.last_rate_limit_evicted_at || 0) < windowStart;
     return {
       version: 2,
       generated_at: new Date(now).toISOString(),

--- a/dashboard/github-egress-telemetry.ts
+++ b/dashboard/github-egress-telemetry.ts
@@ -1,0 +1,723 @@
+import {
+  GITHUB_EGRESS_CLAIM_GENERATION_BUCKETS,
+  GITHUB_EGRESS_LATENCY_BUCKETS,
+  GITHUB_EGRESS_METHODS,
+  GITHUB_EGRESS_OPERATIONS,
+  GITHUB_EGRESS_OUTCOMES,
+  GITHUB_EGRESS_PAGE_BUCKETS,
+  GITHUB_EGRESS_POOL_CLASSES,
+  GITHUB_EGRESS_ROUTE_TEMPLATES,
+  GITHUB_EGRESS_SOURCE_ACTIONS,
+  GITHUB_EGRESS_STAGES,
+  GITHUB_EGRESS_STATUS_BUCKETS,
+  GITHUB_EGRESS_UNITS,
+} from "../src/github-egress-telemetry-contract.ts";
+
+const ROLLUP_TABLE = "exact_review_github_egress_rollups_v2";
+const RATE_LIMIT_TABLE = "exact_review_github_rate_limits_v2";
+const RECEIPT_TABLE = "exact_review_github_egress_receipts_v2";
+const DIAGNOSTICS_TABLE = "exact_review_github_egress_diagnostics_v2";
+const FIVE_MINUTE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const HOURLY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const RATE_LIMIT_RETENTION_MS = 24 * 60 * 60 * 1000;
+const RECEIPT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_ROLLUP_ROWS = 50_000;
+const MAX_RATE_LIMIT_ROWS = 10_000;
+const MAX_PUBLIC_ROWS = 2_000;
+const MAX_METRICS_PER_SUBMISSION = 128;
+const MAX_RATE_LIMITS_PER_SUBMISSION = 16;
+const MAX_RATE_LIMIT_INTEGER = 10_000_000_000;
+
+export class GithubEgressTelemetryStore {
+  private readonly storage;
+
+  constructor(storage) {
+    this.storage = storage;
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${ROLLUP_TABLE} (
+         bucket_kind TEXT NOT NULL CHECK (bucket_kind IN ('five_minute', 'hour')),
+         bucket_start INTEGER NOT NULL,
+         deployment_revision TEXT NOT NULL,
+         config_revision TEXT NOT NULL,
+         pool_class TEXT NOT NULL,
+         pool_identity TEXT NOT NULL,
+         stage TEXT NOT NULL,
+         source_action TEXT NOT NULL,
+         operation TEXT NOT NULL,
+         method TEXT NOT NULL,
+         route_template TEXT NOT NULL,
+         page_bucket TEXT NOT NULL,
+         unit TEXT NOT NULL,
+         outcome TEXT NOT NULL,
+         status_bucket TEXT NOT NULL,
+         latency_bucket TEXT NOT NULL,
+         claim_generation_bucket TEXT NOT NULL,
+         first_repeat TEXT NOT NULL,
+         attempted INTEGER NOT NULL CHECK (attempted IN (0, 1)),
+         telemetry_complete INTEGER NOT NULL CHECK (telemetry_complete IN (0, 1)),
+         count INTEGER NOT NULL CHECK (count >= 1),
+         PRIMARY KEY (
+           bucket_kind, bucket_start, deployment_revision, config_revision,
+           pool_class, pool_identity, stage, source_action, operation, method,
+           route_template, page_bucket, unit, outcome, status_bucket,
+           latency_bucket, claim_generation_bucket, first_repeat, attempted,
+           telemetry_complete
+         )
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_github_egress_rollups_window_v2
+         ON ${ROLLUP_TABLE} (bucket_kind, bucket_start, pool_class, operation)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${RATE_LIMIT_TABLE} (
+         event_id TEXT PRIMARY KEY,
+         observed_at INTEGER NOT NULL,
+         deployment_revision TEXT NOT NULL,
+         config_revision TEXT NOT NULL,
+         pool_class TEXT NOT NULL,
+         pool_identity TEXT NOT NULL,
+         stage TEXT NOT NULL,
+         source_action TEXT NOT NULL,
+         operation TEXT NOT NULL,
+         method TEXT NOT NULL,
+         route_template TEXT NOT NULL,
+         page_bucket TEXT NOT NULL,
+         status INTEGER NOT NULL CHECK (status IN (403, 429)),
+         retry_after_present INTEGER NOT NULL CHECK (retry_after_present IN (0, 1)),
+         retry_after_seconds INTEGER,
+         limit_present INTEGER NOT NULL CHECK (limit_present IN (0, 1)),
+         rate_limit INTEGER,
+         remaining_present INTEGER NOT NULL CHECK (remaining_present IN (0, 1)),
+         remaining INTEGER,
+         used_present INTEGER NOT NULL CHECK (used_present IN (0, 1)),
+         used INTEGER,
+         reset_present INTEGER NOT NULL CHECK (reset_present IN (0, 1)),
+         reset_epoch_seconds INTEGER,
+         resource_present INTEGER NOT NULL CHECK (resource_present IN (0, 1)),
+         resource TEXT,
+         reset_authority_candidate TEXT NOT NULL,
+         telemetry_complete INTEGER NOT NULL CHECK (telemetry_complete IN (0, 1))
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_github_rate_limits_observed_v2
+         ON ${RATE_LIMIT_TABLE} (observed_at, pool_class, operation)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${RECEIPT_TABLE} (
+         receipt_id TEXT PRIMARY KEY,
+         observed_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${DIAGNOSTICS_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         accepted_submissions INTEGER NOT NULL DEFAULT 0,
+         deduped_submissions INTEGER NOT NULL DEFAULT 0,
+         rejected_submissions INTEGER NOT NULL DEFAULT 0,
+         accepted_metrics INTEGER NOT NULL DEFAULT 0,
+         accepted_rate_limits INTEGER NOT NULL DEFAULT 0,
+         incomplete_count INTEGER NOT NULL DEFAULT 0,
+         evicted_rollup_rows INTEGER NOT NULL DEFAULT 0,
+         evicted_rate_limit_rows INTEGER NOT NULL DEFAULT 0,
+         last_rollup_evicted_at INTEGER,
+         last_rate_limit_evicted_at INTEGER,
+         last_observed_at INTEGER
+       ) STRICT`,
+    );
+    this.storage.sql.exec(`INSERT OR IGNORE INTO ${DIAGNOSTICS_TABLE} (singleton_id) VALUES (1)`);
+  }
+
+  ingest(value: unknown, now = Date.now()) {
+    const submission = githubEgressSubmission(value, now);
+    if (!submission) {
+      this.storage.sql.exec(
+        `UPDATE ${DIAGNOSTICS_TABLE}
+            SET rejected_submissions = rejected_submissions + 1,
+                last_observed_at = ?
+          WHERE singleton_id = 1`,
+        now,
+      );
+      return { ok: false as const, error: "invalid_github_egress_telemetry" };
+    }
+    return this.storage.transactionSync(() => {
+      const existing = Array.from(
+        this.storage.sql.exec(
+          `SELECT 1 FROM ${RECEIPT_TABLE} WHERE receipt_id = ? LIMIT 1`,
+          submission.receiptId,
+        ),
+      );
+      if (existing.length) {
+        this.storage.sql.exec(
+          `UPDATE ${DIAGNOSTICS_TABLE}
+              SET deduped_submissions = deduped_submissions + 1,
+                  last_observed_at = ?
+            WHERE singleton_id = 1`,
+          now,
+        );
+        return { ok: true as const, accepted: false, deduped: true };
+      }
+      this.pruneSync(now);
+      let incomplete = 0;
+      for (const metric of submission.metrics) {
+        this.upsertMetric("five_minute", metric.bucketStart, metric);
+        this.upsertMetric("hour", Math.floor(metric.bucketStart / 3_600_000) * 3_600_000, metric);
+        if (!metric.telemetryComplete) incomplete += metric.count;
+      }
+      for (const [index, observation] of submission.rateLimitObservations.entries()) {
+        this.storage.sql.exec(
+          `INSERT OR IGNORE INTO ${RATE_LIMIT_TABLE} (
+             event_id, observed_at, deployment_revision, config_revision,
+             pool_class, pool_identity, stage, source_action, operation, method,
+             route_template, page_bucket, status, retry_after_present,
+             retry_after_seconds, limit_present, rate_limit, remaining_present,
+             remaining, used_present, used, reset_present, reset_epoch_seconds,
+             resource_present, resource, reset_authority_candidate,
+             telemetry_complete
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `${submission.receiptId}:${index}`,
+          observation.observedAt,
+          observation.deploymentRevision,
+          observation.configRevision,
+          observation.poolClass,
+          observation.poolIdentity,
+          observation.stage,
+          observation.sourceAction,
+          observation.operation,
+          observation.method,
+          observation.routeTemplate,
+          observation.pageBucket,
+          observation.status,
+          observation.headers.retryAfterPresent ? 1 : 0,
+          observation.headers.retryAfterSeconds,
+          observation.headers.limitPresent ? 1 : 0,
+          observation.headers.limit,
+          observation.headers.remainingPresent ? 1 : 0,
+          observation.headers.remaining,
+          observation.headers.usedPresent ? 1 : 0,
+          observation.headers.used,
+          observation.headers.resetPresent ? 1 : 0,
+          observation.headers.resetEpochSeconds,
+          observation.headers.resourcePresent ? 1 : 0,
+          observation.headers.resource,
+          observation.resetAuthorityCandidate,
+          observation.telemetryComplete ? 1 : 0,
+        );
+        if (!observation.telemetryComplete) incomplete += 1;
+      }
+      this.storage.sql.exec(
+        `INSERT INTO ${RECEIPT_TABLE} (receipt_id, observed_at) VALUES (?, ?)`,
+        submission.receiptId,
+        now,
+      );
+      this.enforceCapsSync(now);
+      this.storage.sql.exec(
+        `UPDATE ${DIAGNOSTICS_TABLE}
+            SET accepted_submissions = accepted_submissions + 1,
+                accepted_metrics = accepted_metrics + ?,
+                accepted_rate_limits = accepted_rate_limits + ?,
+                incomplete_count = incomplete_count + ?,
+                last_observed_at = ?
+          WHERE singleton_id = 1`,
+        submission.metrics.reduce((total, metric) => total + metric.count, 0),
+        submission.rateLimitObservations.length,
+        incomplete,
+        now,
+      );
+      return { ok: true as const, accepted: true, deduped: false };
+    });
+  }
+
+  publicSummary(now = Date.now()) {
+    const start = now - 6 * 60 * 60 * 1000;
+    const completeness = this.completenessSince("five_minute", start);
+    const diagnostics = this.diagnostics();
+    return {
+      version: 2,
+      window: "6h",
+      generated_at: new Date(now).toISOString(),
+      units: completeness.byUnit,
+      completeness: completeness.result,
+      retention: {
+        detail_hours: 24,
+        five_minute_days: 7,
+        hourly_days: 30,
+        evicted_rollup_rows_total: Number(diagnostics.evicted_rollup_rows || 0),
+        evicted_rate_limit_rows_total: Number(diagnostics.evicted_rate_limit_rows || 0),
+        rollup_window_complete: Number(diagnostics.last_rollup_evicted_at || 0) < start,
+        rate_limit_window_complete: Number(diagnostics.last_rate_limit_evicted_at || 0) < start,
+      },
+    };
+  }
+
+  private completenessSince(bucketKind: "five_minute" | "hour", start: number) {
+    const totals = Array.from(
+      this.storage.sql.exec(
+        `SELECT unit, telemetry_complete, SUM(count) AS count
+           FROM ${ROLLUP_TABLE}
+          WHERE bucket_kind = ? AND bucket_start >= ?
+          GROUP BY unit, telemetry_complete`,
+        bucketKind,
+        start,
+      ),
+    ) as Array<Record<string, unknown>>;
+    const byUnit = { invocation: 0, wire_attempt: 0, member: 0 };
+    let complete = 0;
+    let incomplete = 0;
+    for (const row of totals) {
+      const count = Number(row.count || 0);
+      const unit = String(row.unit || "");
+      if (unit === "invocation" || unit === "wire_attempt" || unit === "member") {
+        byUnit[unit] += count;
+      }
+      if (Number(row.telemetry_complete) === 1) complete += count;
+      else incomplete += count;
+    }
+    return {
+      byUnit,
+      result: {
+        complete,
+        incomplete,
+        observed: complete + incomplete > 0,
+        telemetry_complete: complete > 0 && incomplete === 0,
+      },
+    };
+  }
+
+  publicObservability(hours: number, now = Date.now()) {
+    const boundedHours = hours === 1 || hours === 6 || hours === 24 ? hours : null;
+    if (!boundedHours) return null;
+    const bucketKind = boundedHours <= 6 ? "five_minute" : "hour";
+    const start = now - boundedHours * 60 * 60 * 1000;
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT bucket_start, deployment_revision, config_revision, pool_class,
+                stage, source_action, operation, method, route_template,
+                page_bucket, unit, outcome, status_bucket, latency_bucket,
+                claim_generation_bucket, first_repeat, attempted,
+                telemetry_complete, SUM(count) AS count
+           FROM ${ROLLUP_TABLE}
+          WHERE bucket_kind = ? AND bucket_start >= ?
+          GROUP BY bucket_start, deployment_revision, config_revision,
+                   pool_class, stage, source_action, operation, method,
+                   route_template, page_bucket, unit, outcome, status_bucket,
+                   latency_bucket, claim_generation_bucket, first_repeat,
+                   attempted, telemetry_complete
+          ORDER BY bucket_start ASC, pool_class, stage, operation, unit
+          LIMIT ?`,
+        bucketKind,
+        start,
+        MAX_PUBLIC_ROWS + 1,
+      ),
+    ) as Array<Record<string, unknown>>;
+    const truncated = rows.length > MAX_PUBLIC_ROWS;
+    const publicRows = rows.slice(0, MAX_PUBLIC_ROWS).map((row) => ({
+      bucket_start: new Date(Number(row.bucket_start)).toISOString(),
+      deployment_revision: row.deployment_revision,
+      config_revision: row.config_revision,
+      pool_class: row.pool_class,
+      stage: row.stage,
+      source_action: row.source_action,
+      operation: row.operation,
+      method: row.method,
+      route_template: row.route_template,
+      page_bucket: row.page_bucket,
+      unit: row.unit,
+      outcome: row.outcome,
+      status_bucket: row.status_bucket,
+      latency_bucket: row.latency_bucket,
+      claim_generation_bucket: row.claim_generation_bucket,
+      first_repeat: row.first_repeat,
+      attempted: Number(row.attempted) === 1,
+      telemetry_complete: Number(row.telemetry_complete) === 1,
+      count: Number(row.count),
+    }));
+    const rateLimitRows = Array.from(
+      this.storage.sql.exec(
+        `SELECT observed_at, deployment_revision, config_revision, pool_class,
+                stage, source_action, operation, method, route_template,
+                page_bucket, status, retry_after_present, retry_after_seconds,
+                limit_present, rate_limit, remaining_present, remaining,
+                used_present, used, reset_present, reset_epoch_seconds,
+                resource_present, resource, reset_authority_candidate,
+                telemetry_complete
+           FROM ${RATE_LIMIT_TABLE}
+          WHERE observed_at >= ?
+          ORDER BY observed_at DESC
+          LIMIT 257`,
+        Math.max(start, now - RATE_LIMIT_RETENTION_MS),
+      ),
+    ) as Array<Record<string, unknown>>;
+    const rateLimitTruncated = rateLimitRows.length > 256;
+    const rateLimits = rateLimitRows.slice(0, 256).map(publicRateLimitRow);
+    const completeness = this.completenessSince(bucketKind, start);
+    const diagnostics = this.diagnostics();
+    const rollupWindowComplete = Number(diagnostics.last_rollup_evicted_at || 0) < start;
+    const rateLimitWindowComplete = Number(diagnostics.last_rate_limit_evicted_at || 0) < start;
+    return {
+      version: 2,
+      generated_at: new Date(now).toISOString(),
+      window: { hours: boundedHours, bucket_minutes: bucketKind === "five_minute" ? 5 : 60 },
+      units: completeness.byUnit,
+      rows: publicRows,
+      rate_limit_observations: rateLimits,
+      completeness: {
+        ...completeness.result,
+        rows_truncated: truncated,
+        rate_limit_rows_truncated: rateLimitTruncated,
+        rollup_window_complete: rollupWindowComplete,
+        rate_limit_window_complete: rateLimitWindowComplete,
+        query_complete:
+          !truncated && !rateLimitTruncated && rollupWindowComplete && rateLimitWindowComplete,
+      },
+      privacy: {
+        pool_identity: "withheld",
+        raw_identifiers: false,
+        closed_dimensions: true,
+      },
+    };
+  }
+
+  private upsertMetric(bucketKind: "five_minute" | "hour", bucketStart: number, metric) {
+    this.storage.sql.exec(
+      `INSERT INTO ${ROLLUP_TABLE} (
+         bucket_kind, bucket_start, deployment_revision, config_revision,
+         pool_class, pool_identity, stage, source_action, operation, method,
+         route_template, page_bucket, unit, outcome, status_bucket,
+         latency_bucket, claim_generation_bucket, first_repeat, attempted,
+         telemetry_complete, count
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT DO UPDATE SET count = count + excluded.count`,
+      bucketKind,
+      bucketStart,
+      metric.deploymentRevision,
+      metric.configRevision,
+      metric.poolClass,
+      metric.poolIdentity,
+      metric.stage,
+      metric.sourceAction,
+      metric.operation,
+      metric.method,
+      metric.routeTemplate,
+      metric.pageBucket,
+      metric.unit,
+      metric.outcome,
+      metric.statusBucket,
+      metric.latencyBucket,
+      metric.claimGenerationBucket,
+      metric.firstRepeat,
+      metric.attempted ? 1 : 0,
+      metric.telemetryComplete ? 1 : 0,
+      metric.count,
+    );
+  }
+
+  private pruneSync(now: number) {
+    this.storage.sql.exec(
+      `DELETE FROM ${ROLLUP_TABLE}
+        WHERE (bucket_kind = 'five_minute' AND bucket_start < ?)
+           OR (bucket_kind = 'hour' AND bucket_start < ?)`,
+      now - FIVE_MINUTE_RETENTION_MS,
+      now - HOURLY_RETENTION_MS,
+    );
+    this.storage.sql.exec(
+      `DELETE FROM ${RATE_LIMIT_TABLE} WHERE observed_at < ?`,
+      now - RATE_LIMIT_RETENTION_MS,
+    );
+    this.storage.sql.exec(
+      `DELETE FROM ${RECEIPT_TABLE} WHERE observed_at < ?`,
+      now - RECEIPT_RETENTION_MS,
+    );
+  }
+
+  private enforceCapsSync(now: number) {
+    const rollupRows = Array.from(
+      this.storage.sql.exec(`SELECT COUNT(*) AS count FROM ${ROLLUP_TABLE}`),
+    ) as Array<Record<string, unknown>>;
+    const rollupCount = Number(rollupRows[0]?.count || 0);
+    const rollupOverflow = Math.max(0, rollupCount - MAX_ROLLUP_ROWS);
+    if (rollupOverflow) {
+      this.storage.sql.exec(
+        `DELETE FROM ${ROLLUP_TABLE}
+          WHERE rowid IN (
+            SELECT rowid FROM ${ROLLUP_TABLE}
+             ORDER BY bucket_start ASC LIMIT ?
+          )`,
+        rollupOverflow,
+      );
+      this.storage.sql.exec(
+        `UPDATE ${DIAGNOSTICS_TABLE}
+            SET evicted_rollup_rows = evicted_rollup_rows + ?,
+                last_rollup_evicted_at = ?
+          WHERE singleton_id = 1`,
+        rollupOverflow,
+        now,
+      );
+    }
+    const rateRows = Array.from(
+      this.storage.sql.exec(`SELECT COUNT(*) AS count FROM ${RATE_LIMIT_TABLE}`),
+    ) as Array<Record<string, unknown>>;
+    const rateCount = Number(rateRows[0]?.count || 0);
+    const rateOverflow = Math.max(0, rateCount - MAX_RATE_LIMIT_ROWS);
+    if (rateOverflow) {
+      this.storage.sql.exec(
+        `DELETE FROM ${RATE_LIMIT_TABLE}
+          WHERE event_id IN (
+            SELECT event_id FROM ${RATE_LIMIT_TABLE}
+             ORDER BY observed_at ASC LIMIT ?
+          )`,
+        rateOverflow,
+      );
+      this.storage.sql.exec(
+        `UPDATE ${DIAGNOSTICS_TABLE}
+            SET evicted_rate_limit_rows = evicted_rate_limit_rows + ?,
+                last_rate_limit_evicted_at = ?
+          WHERE singleton_id = 1`,
+        rateOverflow,
+        now,
+      );
+    }
+  }
+
+  private diagnostics(): Record<string, unknown> {
+    const rows = Array.from(
+      this.storage.sql.exec(`SELECT * FROM ${DIAGNOSTICS_TABLE} LIMIT 1`),
+    ) as Array<Record<string, unknown>>;
+    return rows[0] || {};
+  }
+}
+
+function githubEgressSubmission(value: unknown, now: number) {
+  const body = objectValue(value);
+  const receiptId = String(body.receipt_id || "");
+  if (
+    body.version !== 2 ||
+    !/^[0-9a-f]{64}$/.test(receiptId) ||
+    !Array.isArray(body.metrics) ||
+    body.metrics.length > MAX_METRICS_PER_SUBMISSION ||
+    !Array.isArray(body.rate_limit_observations) ||
+    body.rate_limit_observations.length > MAX_RATE_LIMITS_PER_SUBMISSION ||
+    (!body.metrics.length && !body.rate_limit_observations.length)
+  ) {
+    return null;
+  }
+  const metrics = body.metrics.map((metric) => githubEgressMetric(metric, now));
+  const rateLimitObservations = body.rate_limit_observations.map((observation) =>
+    githubRateLimitObservation(observation, now),
+  );
+  if (metrics.some((metric) => !metric) || rateLimitObservations.some((item) => !item)) return null;
+  return { receiptId, metrics, rateLimitObservations };
+}
+
+function githubEgressMetric(value: unknown, now: number) {
+  const metric = objectValue(value);
+  const bucketStart = Date.parse(String(metric.bucket_start || ""));
+  const count = Number(metric.count);
+  if (
+    !Number.isFinite(bucketStart) ||
+    bucketStart % 300_000 !== 0 ||
+    bucketStart < now - 24 * 60 * 60 * 1000 ||
+    bucketStart > now + 5 * 60_000 ||
+    !digest(metric.deployment_revision, 16) ||
+    !digest(metric.config_revision, 16) ||
+    !digest(metric.pool_identity, 24) ||
+    !member(GITHUB_EGRESS_POOL_CLASSES, metric.pool_class) ||
+    !member(GITHUB_EGRESS_STAGES, metric.stage) ||
+    !member(GITHUB_EGRESS_SOURCE_ACTIONS, metric.source_action) ||
+    !member(GITHUB_EGRESS_OPERATIONS, metric.operation) ||
+    !member(GITHUB_EGRESS_METHODS, metric.method) ||
+    !member(GITHUB_EGRESS_ROUTE_TEMPLATES, metric.route_template) ||
+    !member(GITHUB_EGRESS_PAGE_BUCKETS, metric.page_bucket) ||
+    !member(GITHUB_EGRESS_UNITS, metric.unit) ||
+    !member(GITHUB_EGRESS_OUTCOMES, metric.outcome) ||
+    !member(GITHUB_EGRESS_STATUS_BUCKETS, metric.status_bucket) ||
+    !member(GITHUB_EGRESS_LATENCY_BUCKETS, metric.latency_bucket) ||
+    !member(GITHUB_EGRESS_CLAIM_GENERATION_BUCKETS, metric.claim_generation_bucket) ||
+    !member(["first", "repeat", "unknown"], metric.first_repeat) ||
+    typeof metric.attempted !== "boolean" ||
+    typeof metric.telemetry_complete !== "boolean" ||
+    !Number.isSafeInteger(count) ||
+    count < 1 ||
+    count > 1_000_000
+  ) {
+    return null;
+  }
+  return {
+    bucketStart,
+    deploymentRevision: metric.deployment_revision,
+    configRevision: metric.config_revision,
+    poolClass: metric.pool_class,
+    poolIdentity: metric.pool_identity,
+    stage: metric.stage,
+    sourceAction: metric.source_action,
+    operation: metric.operation,
+    method: metric.method,
+    routeTemplate: metric.route_template,
+    pageBucket: metric.page_bucket,
+    unit: metric.unit,
+    outcome: metric.outcome,
+    statusBucket: metric.status_bucket,
+    latencyBucket: metric.latency_bucket,
+    claimGenerationBucket: metric.claim_generation_bucket,
+    firstRepeat: metric.first_repeat,
+    attempted: metric.attempted,
+    telemetryComplete: metric.telemetry_complete,
+    count,
+  };
+}
+
+function githubRateLimitObservation(value: unknown, now: number) {
+  const observation = objectValue(value);
+  const headers = objectValue(observation.headers);
+  const observedAt = Date.parse(String(observation.observed_at || ""));
+  if (
+    !Number.isFinite(observedAt) ||
+    observedAt < now - 24 * 60 * 60 * 1000 ||
+    observedAt > now + 5 * 60_000 ||
+    !digest(observation.deployment_revision, 16) ||
+    !digest(observation.config_revision, 16) ||
+    !digest(observation.pool_identity, 24) ||
+    !member(GITHUB_EGRESS_POOL_CLASSES, observation.pool_class) ||
+    !member(GITHUB_EGRESS_STAGES, observation.stage) ||
+    !member(GITHUB_EGRESS_SOURCE_ACTIONS, observation.source_action) ||
+    !member(GITHUB_EGRESS_OPERATIONS, observation.operation) ||
+    !member(GITHUB_EGRESS_METHODS, observation.method) ||
+    !member(GITHUB_EGRESS_ROUTE_TEMPLATES, observation.route_template) ||
+    !member(GITHUB_EGRESS_PAGE_BUCKETS, observation.page_bucket) ||
+    ![403, 429].includes(Number(observation.status)) ||
+    !headers ||
+    !member(
+      ["retry_after", "rate_limit_reset", "absent", "invalid"],
+      observation.reset_authority_candidate,
+    ) ||
+    typeof observation.telemetry_complete !== "boolean"
+  ) {
+    return null;
+  }
+  const parsedHeaders = rateLimitHeaders(headers);
+  if (!parsedHeaders) return null;
+  if (observation.reset_authority_candidate !== resetAuthorityCandidate(parsedHeaders)) return null;
+  return {
+    observedAt,
+    deploymentRevision: observation.deployment_revision,
+    configRevision: observation.config_revision,
+    poolClass: observation.pool_class,
+    poolIdentity: observation.pool_identity,
+    stage: observation.stage,
+    sourceAction: observation.source_action,
+    operation: observation.operation,
+    method: observation.method,
+    routeTemplate: observation.route_template,
+    pageBucket: observation.page_bucket,
+    status: Number(observation.status),
+    headers: parsedHeaders,
+    resetAuthorityCandidate: observation.reset_authority_candidate,
+    telemetryComplete: observation.telemetry_complete,
+  };
+}
+
+function rateLimitHeaders(headers: Record<string, unknown>) {
+  const presence = [
+    "retryAfterPresent",
+    "limitPresent",
+    "remainingPresent",
+    "usedPresent",
+    "resetPresent",
+    "resourcePresent",
+  ];
+  if (presence.some((key) => typeof headers[key] !== "boolean")) return null;
+  const numericKeys = ["retryAfterSeconds", "limit", "remaining", "used", "resetEpochSeconds"];
+  if (
+    numericKeys.some((key) => {
+      const value = headers[key];
+      return (
+        value !== null &&
+        (!Number.isSafeInteger(value) ||
+          Number(value) < 0 ||
+          Number(value) > MAX_RATE_LIMIT_INTEGER)
+      );
+    }) ||
+    !member(
+      ["core", "graphql", "search", "integration_manifest", "unknown", null],
+      headers.resource,
+    )
+  ) {
+    return null;
+  }
+  if (
+    (!headers.retryAfterPresent && headers.retryAfterSeconds !== null) ||
+    (!headers.limitPresent && headers.limit !== null) ||
+    (!headers.remainingPresent && headers.remaining !== null) ||
+    (!headers.usedPresent && headers.used !== null) ||
+    (!headers.resetPresent && headers.resetEpochSeconds !== null) ||
+    (!headers.resourcePresent && headers.resource !== null) ||
+    (headers.resourcePresent && headers.resource === null)
+  ) {
+    return null;
+  }
+  return headers;
+}
+
+function resetAuthorityCandidate(headers: Record<string, unknown>) {
+  if (headers.retryAfterPresent) {
+    return headers.retryAfterSeconds === null ? "invalid" : "retry_after";
+  }
+  if (headers.resetPresent) {
+    return headers.resetEpochSeconds === null ? "invalid" : "rate_limit_reset";
+  }
+  return "absent";
+}
+
+function publicRateLimitRow(row) {
+  return {
+    observed_at: new Date(Number(row.observed_at)).toISOString(),
+    deployment_revision: row.deployment_revision,
+    config_revision: row.config_revision,
+    pool_class: row.pool_class,
+    stage: row.stage,
+    source_action: row.source_action,
+    operation: row.operation,
+    method: row.method,
+    route_template: row.route_template,
+    page_bucket: row.page_bucket,
+    status: Number(row.status),
+    headers: {
+      retry_after_present: Number(row.retry_after_present) === 1,
+      retry_after_seconds: nullableNumber(row.retry_after_seconds),
+      limit_present: Number(row.limit_present) === 1,
+      limit: nullableNumber(row.rate_limit),
+      remaining_present: Number(row.remaining_present) === 1,
+      remaining: nullableNumber(row.remaining),
+      used_present: Number(row.used_present) === 1,
+      used: nullableNumber(row.used),
+      reset_present: Number(row.reset_present) === 1,
+      reset_epoch_seconds: nullableNumber(row.reset_epoch_seconds),
+      resource_present: Number(row.resource_present) === 1,
+      resource: row.resource || null,
+    },
+    reset_authority_candidate: row.reset_authority_candidate,
+    telemetry_complete: Number(row.telemetry_complete) === 1,
+  };
+}
+
+function nullableNumber(value: unknown) {
+  return value === null || value === undefined ? null : Number(value);
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function digest(value: unknown, length: number) {
+  return typeof value === "string" && new RegExp(`^[0-9a-f]{${length}}$`).test(value);
+}
+
+function member(values: readonly unknown[], value: unknown) {
+  return values.includes(value);
+}

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -927,6 +927,11 @@ export default {
       request.method === "POST"
     )
       return authenticatedExactReviewQueueRequest(request, env, "/publication-batches/complete");
+    if (
+      url.pathname === "/internal/exact-review/github-egress-telemetry" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/github-egress-telemetry");
     if (url.pathname === "/internal/apply-observability" && request.method === "POST")
       return authenticatedApplyObservability(request, env);
     if (url.pathname === "/internal/exact-review/reconcile" && request.method === "POST")
@@ -950,6 +955,11 @@ export default {
       return emptyPerItemReviewsJson(url.searchParams);
     if (url.pathname === "/api/review-observability" && request.method === "GET")
       return exactReviewQueueRequest(env, `/review-observability?${url.searchParams.toString()}`);
+    if (url.pathname === "/api/github-egress-observability" && request.method === "GET")
+      return exactReviewQueueRequest(
+        env,
+        `/github-egress-observability?${url.searchParams.toString()}`,
+      );
     if (url.pathname === "/api/review-coverage" && request.method === "GET")
       return exactReviewQueueRequest(env, "/review-coverage");
     if (url.pathname === "/api/apply-observability" && request.method === "GET")

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: the linked repository files and their owning code,
   configuration, workflows, and tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
 - Update when: a document is added, retired, moved, changes lifecycle, or gains a
   new canonical owner
 
@@ -88,6 +88,8 @@ everything else requires human comparison with current main.
 
 - [Live dashboard](live-dashboard.md) — active; Worker status and operational
   telemetry
+- [GitHub publication egress telemetry](github-egress-telemetry.md) — active;
+  wire denominator, credential attribution, completeness, and retention
 - [OpenClaw Bay](openclaw-bay-demo.md) — active; public six-lane visualization
 - [Triage dashboard](triage-dashboard.md) — active; cached issue triage
 - [PR proof triage](pr-proof-triage-dashboard.md) — active; maintainer proof
@@ -163,6 +165,8 @@ Review the relevant pages in the same change when any of these surfaces move:
   batching, direct publication, or state writing: scheduler, limits, dashboard,
   Bay, and queue runbooks
 - dashboard route, projection, or public-field changes: dashboard and Bay docs
+- publication GitHub request paths, credential selection, or egress fields:
+  GitHub egress telemetry and public API docs
 - mutation, close, proof, repair, or merge policy changes: policy pages,
   CONTRIBUTING, AGENTS, and repair operations
 - workflow retirement or replacement: every command example and compatibility

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -159,8 +159,10 @@ per-route breakdown.
 
 The `gh` wrapper preserves the command's stdout, cleaned non-debug stderr, and
 exit status. Observation and upload failures do not fail publication. This
-fail-open rule means a completely missing upload cannot report its own absence;
-use stage conservation against durable publication starts and workflow results
+fail-open rule means an uploader that finds no readable metric records sends
+one bounded, incomplete, unattempted invocation marker; it never invents a wire
+attempt or member count. A completely missing uploader still cannot report its
+own absence, so use stage conservation against durable publication starts and workflow results
 to detect that case.
 
 Known incomplete boundaries are explicit:

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -141,8 +141,12 @@ method/status, and response receive time. Unsafe parsing emits or uploads an
 incomplete bounded marker. It never uploads a partially parsed raw frame.
 
 Completeness is computed independently for each requested one-, six-, or
-24-hour window. `rows_truncated` and `rate_limit_rows_truncated` identify a
-bounded public response, while `rollup_window_complete` and
+24-hour window. Rollup queries include the complete five-minute or hourly
+bucket that overlaps the window's lower boundary, so totals can include at
+most one bucket of observations immediately before the exact cutoff. Raw
+rate-limit observations use the exact cutoff. `rows_truncated` and
+`rate_limit_rows_truncated` identify a bounded public response, while
+`rollup_window_complete` and
 `rate_limit_window_complete` identify any cap eviction during the requested
 window. `query_complete` is true only when neither condition applies. These
 query bounds are separate from transport `telemetry_complete`.

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -1,0 +1,205 @@
+# GitHub publication egress telemetry
+
+- Status: active operator reference
+- Owner: ClawSweeper publication and dashboard maintainers
+- Source of truth: `src/github-egress-observer.ts`,
+  `src/github-egress-telemetry-contract.ts`,
+  `dashboard/github-egress-telemetry.ts`, and the publication workflows
+- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
+- Update when: a publication request path, credential selection rule, telemetry
+  dimension, retention limit, or public response changes
+- Checked by: focused telemetry tests plus `pnpm run check:docs`
+
+ClawSweeper records bounded observations of GitHub requests made while publishing
+exact reviews. The observer is diagnostic only: it does not admit, defer, retry,
+cancel, or reprioritize work, and it does not open or close a credential circuit.
+Existing version-1 request and circuit metrics continue in parallel during the
+version-2 observation period.
+
+## Read the six-hour view
+
+Use the public, read-only endpoint for time-aligned diagnosis:
+
+```bash
+curl --fail --silent --show-error \
+  'https://clawsweeper.openclaw.ai/api/github-egress-observability?hours=6'
+```
+
+`hours` accepts only `1`, `6`, or `24`. The response contains closed aggregate
+dimensions and sanitized rate-limit observations. It never contains private
+pool identities, repository or item identifiers, branches, raw SHAs, paths,
+queries, cursors, URLs, request IDs, ETags, bodies, tokens, or installation IDs.
+
+The exact-review queue status also includes a compact six-hour
+`publication.github_egress_metrics_v2` summary. Use the dedicated endpoint when
+the operation, route, page, outcome, or rate-limit-header breakdown is needed.
+
+## Counting units
+
+Do not add unlike units. Each row declares one of these units:
+
+| Unit           | What one count means                                                                             |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| `member`       | One durable publication member entering a direct, artifact, or batch publication boundary.       |
+| `invocation`   | One `gh` command invocation, including a pre-wire failure or an opaque artifact download action. |
+| `wire_attempt` | One HTTP request observed in a safe `GH_DEBUG=api` transport frame; each pagination page counts. |
+
+A paginated invocation therefore contributes one `invocation` and N
+`wire_attempt` rows. An artifact download whose binary redirect is unsafe to
+debug contributes an incomplete `invocation` but no invented wire count.
+`attempted=false` is emitted only for a directly observed pre-wire condition or
+an existing batch circuit skip. Phase 0 does not manufacture requests that a
+future coordinator might have avoided.
+
+Use the unit totals as a conservation check:
+
+1. Compare `member` counts with durable direct, artifact, and batch publication
+   starts for the same window.
+2. Compare `invocation` with `wire_attempt` by stage and operation. A larger wire
+   count is expected for pagination; an incomplete opaque invocation has no wire
+   denominator.
+3. Compare attempted and non-attempted members with the existing publication
+   completion, retry, and circuit-skip counters. A gap indicates missing or
+   incomplete telemetry, not zero demand.
+
+## `first` and `repeat`
+
+`first_repeat` is fixed when the durable item is claimed for publication:
+
+- `first` means `publicationFailureAttempts` is zero for that exact durable item
+  revision at claim time.
+- `repeat` means the same durable item revision already has at least one charged
+  publication failure at claim time.
+- `unknown` means the workflow could not safely bind this command to that
+  durable fact; the row is incomplete.
+
+This dimension does not mean a second HTTP request, another pagination page,
+another member in the same batch, or every later claim generation. Every GitHub
+invocation and wire request performed for one claim inherits the same
+first/repeat value. `claim_generation_bucket` separately records the bounded
+claim generation (`1`, `2`, `3_5`, `6_10`, `11_32`, or `33_plus`).
+
+## Credential and request dimensions
+
+Pool attribution follows the token actually selected at the call site. It is
+never inferred from GitHub's generic error text.
+
+| `pool_class`           | Meaning                                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `repository_actions`   | The ClawSweeper repository Actions credential used for artifacts, workflow dispatch, or explicit calls. |
+| `target_app`           | The target owner's GitHub App installation credential.                                                  |
+| `public_read_fallback` | A public target read deliberately moved to the repository Actions credential after pool selection.      |
+| `other`                | Attribution was unsafe; the row is incomplete.                                                          |
+
+The private pool identity is a one-way, versioned fingerprint of the real
+credential boundary: ClawSweeper repository Actions or target owner. It is
+retained only inside the Durable Object and is omitted from public rows.
+
+The remaining dimensions are closed allowlists:
+
+- `stage`: preparation, apply, router, or recovery;
+- `source_action`: exact event, command, scheduled hot, scheduled normal,
+  repair, or publication retry;
+- `operation`: artifact download, item metadata, comments, reviews, labels,
+  reactions, checks, contents, authorization, GraphQL, workflow dispatch, rate
+  status, or other;
+- `method`: an allowlisted HTTP method or `UNKNOWN`;
+- `route_template`: a normalized route family such as `issue_comments` or
+  `actions_workflow_dispatch`;
+- `page_bucket`, `status_bucket`, and `latency_bucket`: bounded buckets rather
+  than raw values.
+
+`deployment_revision` is a one-way 16-hex fingerprint derived from the exact
+checked-out deployment SHA. `config_revision` is a separate 16-hex fingerprint
+of a versioned allowlist of non-secret egress controls. Operators can correlate
+a known SHA or configuration locally without publishing a raw SHA or control
+payload.
+
+## Rate-limit observations
+
+Only HTTP 403 and 429 responses produce detail rows. The observer records the
+approximate response receive time (request timestamp plus measured duration),
+status, closed request dimensions, and presence plus bounded numeric values for:
+
+- `Retry-After`;
+- `X-RateLimit-Limit`;
+- `X-RateLimit-Remaining`;
+- `X-RateLimit-Used`;
+- `X-RateLimit-Reset`;
+- the allowlisted `X-RateLimit-Resource` value.
+
+`reset_authority_candidate` reports `retry_after`, `rate_limit_reset`, `absent`,
+or `invalid`. It does not choose a shared `blocked_until`, authorize a probe, or
+alter retry behavior. A present but non-numeric authority remains present and is
+classified `invalid`.
+
+## Completeness and safe failure
+
+`telemetry_complete=true` requires a known credential boundary, stage, source
+class, durable claim generation, first/repeat fact, safe route template, parsed
+method/status, and response receive time. Unsafe parsing emits or uploads an
+incomplete bounded marker. It never uploads a partially parsed raw frame.
+
+Completeness is computed independently for each requested one-, six-, or
+24-hour window. `rows_truncated` and `rate_limit_rows_truncated` identify a
+bounded public response, while `rollup_window_complete` and
+`rate_limit_window_complete` identify any cap eviction during the requested
+window. `query_complete` is true only when neither condition applies. These
+query bounds are separate from transport `telemetry_complete`.
+
+The public view also returns full-window `units` totals for members,
+invocations, and wire attempts. These conservation denominators remain exact
+when the bounded dimensional `rows` array is truncated; operators must still
+treat `completeness.query_complete=false` as insufficient for a complete
+per-route breakdown.
+
+The `gh` wrapper preserves the command's stdout, cleaned non-debug stderr, and
+exit status. Observation and upload failures do not fail publication. This
+fail-open rule means a completely missing upload cannot report its own absence;
+use stage conservation against durable publication starts and workflow results
+to detect that case.
+
+Known incomplete boundaries are explicit:
+
+- `gh run download` and `actions/download-artifact` remain opaque because debug
+  output can include redirected archive bytes;
+- direct-lifecycle replay performed before the repaired implementation checkout
+  is not observed;
+- calls outside the direct, artifact, and batch publication paths are outside
+  this Phase 0 denominator;
+- public views expose pool class, not the private owner-sharded pool identity;
+- a closed route family cannot separate endpoint variants that are not in the
+  allowlist.
+
+## Retention and cardinality
+
+| Boundary                         | Limit                                  |
+| -------------------------------- | -------------------------------------- |
+| Workflow JSONL input             | 2,000 lines per file                   |
+| Signed upload                    | 128 metrics and 16 rate rows per chunk |
+| Five-minute rollups              | 7 days                                 |
+| Hourly rollups                   | 30 days                                |
+| Sanitized 403/429 detail         | 24 hours                               |
+| Deduplication receipts           | 7 days                                 |
+| Durable rollup rows              | 50,000                                 |
+| Durable rate-limit detail rows   | 10,000                                 |
+| Public aggregate rows per query  | 2,000 plus a truncation flag           |
+| Public rate-limit rows per query | 256                                    |
+
+The Durable Object validates every enum, digest length, timestamp window,
+numeric header, count, and chunk limit before committing a receipt. It stores
+both five-minute and hourly rollups transactionally and deduplicates upload
+retries by producer-run-scoped, content-derived receipt ID. Cap evictions are
+cumulative diagnostics and mark affected public windows incomplete.
+
+## Rollback and Phase 1 boundary
+
+Rollback removes the workflow setup and upload steps and the public route. The
+version-2 tables are additive and may remain dormant; version-1 metrics and
+publication behavior continue unchanged. No queue drain, schedule change,
+credential change, or state migration is required.
+
+Phase 1 may use this denominator to justify a shared credential-pool
+coordinator. Epochs, permits, blocked-until decisions, probes, ramps, shared
+backoff, enforcement kill switches, and coordinator-derived avoided requests
+are deliberately absent here.

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers and the designated Cloudflare operator
 - Source of truth: `dashboard/worker.ts`, `dashboard/exact-review-queue.ts`,
   `dashboard/wrangler.toml`, dashboard tests, and deployed read-only endpoints
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
 - Update when: routes, public fields, queue projections, capacity, alerts,
   deployment, or state-writer telemetry changes
 
@@ -374,6 +374,15 @@ The publication lane exposes two additional observer-only surfaces:
   class, endpoint category, operation class, outcome, and whether the item
   revision was already retried. These counters are for request-budget analysis;
   they never contain raw URLs, item content, credentials, or local paths.
+
+`GET /api/github-egress-observability?hours=6` adds the publication transport
+denominator without changing those version-1 fields. It separates durable
+members, `gh` invocations, and observed HTTP wire attempts; attributes the
+selected credential pool, method, normalized route, page, source, stage, claim
+generation, and first/repeat revision; and includes sanitized 403/429 reset
+header observations. See
+[GitHub publication egress telemetry](github-egress-telemetry.md) for exact
+semantics, retention, privacy, and known opaque boundaries.
 
 Bay renders these fields as health context only. It has no circuit reset,
 workflow dispatch, queue retry, replay, acknowledgement, or gate control.

--- a/docs/proof/github-egress-telemetry/README.md
+++ b/docs/proof/github-egress-telemetry/README.md
@@ -1,0 +1,74 @@
+# GitHub publication egress telemetry real-boundary proof
+
+## Claim
+
+Phase 0 observes the real publication `gh` transport without changing command
+stdout, cleaned ordinary stderr, or exit status. A paginated invocation records
+one invocation and one wire attempt per page. Credential pool, normalized
+method/route, first/repeat, claim generation, response status/latency, and
+sanitized 403/429 reset headers remain bounded. Unsafe classification fails
+open with `telemetry_complete=false` and no raw request data.
+
+The resulting aggregate uploads through the production HMAC serializer to a
+real local Worker and SQLite-backed `ExactReviewQueue` Durable Object. Stored
+rows survive a Worker restart and an identical producer receipt is deduplicated.
+
+## Exercised surface
+
+- The production `scripts/github-egress-observer.sh` wrapper and built observer
+  parser/CLI
+- A real GitHub CLI binary over loopback TLS, including three REST pagination
+  pages, an opaque artifact archive download, and an HTTP 403 with
+  `Retry-After` and `X-RateLimit-*` headers
+- `repository_actions`, `target_app`, and `public_read_fallback` call-site
+  attribution
+- A real signed telemetry upload and public query through `wrangler dev --local`
+- The real SQLite Durable Object storage, receipt deduplication, and restart
+  persistence
+- Sentinel scans across workflow JSONL and public output
+- Twelve baseline and twelve observed loopback invocations for bounded observer
+  overhead measurement
+
+## Run
+
+From a clean repository root on Node 24 or later:
+
+```bash
+docs/proof/github-egress-telemetry/run-proof.sh
+```
+
+The script uses pinned Wrangler 4.107.0 and a disposable self-signed loopback
+certificate. If `gh` is unavailable, it downloads GitHub CLI 2.88.1 into the
+disposable proof directory. It uses only synthetic credentials and loopback
+application endpoints. It does not call GitHub APIs, mutate production, or
+touch queue, schedule, gate, deployment, or credential state.
+
+## Required result
+
+- 18 invocations conserve to 19 observed wire attempts and one durable member;
+  one artifact invocation is explicitly opaque and invents no wire count.
+- The paginated invocation accounts for exactly three page attempts.
+- The authoritative 403 produces exactly one sanitized reset observation.
+- Public-read fallback and target-App each retain their actual selected pool.
+- The unrecognized route is incomplete but preserves command behavior.
+- A missing observer parser preserves the original throttled command's stderr,
+  stdout, and exit status while stripping unsafe debug frames.
+- Public output withholds pool identity and all raw sentinels.
+- Worker restart preserves rows and replaying the same receipt is deduplicated.
+- Median loopback observer overhead remains below the proof's one-second safety
+  ceiling; the measured value is reported, not treated as a production latency
+  forecast.
+
+## Artifacts and limits
+
+Generated evidence is written to `.artifacts/github-egress-telemetry-proof/`:
+a machine-readable summary, the bounded public observability response,
+build/install logs, and a secret-redacted Wrangler log. The generated evidence
+is intentionally outside the committed proof package; exact-head provenance is
+recorded in the pull request.
+
+The GitHub responses are deterministic loopback fixtures, not live quota
+consumption. Artifact downloads remain deliberately opaque because GitHub CLI
+debug output can cross a binary redirect; deterministic tests cover their
+incomplete invocation accounting. This is observation proof only and makes no
+claim about Phase 1 admission, circuit, permit, probe, or ramp behavior.

--- a/docs/proof/github-egress-telemetry/README.md
+++ b/docs/proof/github-egress-telemetry/README.md
@@ -47,8 +47,10 @@ schedule, gate, deployment, or credential state.
 
 ## Required result
 
-- 18 invocations conserve to 19 observed wire attempts and one durable member;
-  one artifact invocation is explicitly opaque and invents no wire count.
+- 18 transport invocations conserve to 19 observed wire attempts and one
+  durable member; one artifact invocation is explicitly opaque and invents no
+  wire count. A separate missing-sink fixture contributes exactly one
+  incomplete, unattempted invocation marker and no invented wire/member count.
 - The paginated invocation accounts for exactly three page attempts.
 - The authoritative 403 produces exactly one sanitized reset observation.
 - Public-read fallback and target-App each retain their actual selected pool.

--- a/docs/proof/github-egress-telemetry/README.md
+++ b/docs/proof/github-egress-telemetry/README.md
@@ -39,9 +39,11 @@ docs/proof/github-egress-telemetry/run-proof.sh
 
 The script uses pinned Wrangler 4.107.0 and a disposable self-signed loopback
 certificate. If `gh` is unavailable, it downloads GitHub CLI 2.88.1 into the
-disposable proof directory. It uses only synthetic credentials and loopback
-application endpoints. It does not call GitHub APIs, mutate production, or
-touch queue, schedule, gate, deployment, or credential state.
+disposable proof directory and verifies the Linux AMD64 archive against the
+committed SHA-256 from the official release checksum manifest before
+extraction. It uses only synthetic credentials and loopback application
+endpoints. It does not call GitHub APIs, mutate production, or touch queue,
+schedule, gate, deployment, or credential state.
 
 ## Required result
 

--- a/docs/proof/github-egress-telemetry/run-proof.mjs
+++ b/docs/proof/github-egress-telemetry/run-proof.mjs
@@ -234,6 +234,16 @@ exit 73
     receiptScope: "github-egress-proof:1:loopback",
   });
   assert.equal(submissions.length, 1);
+  const emptySinkSubmissions = githubEgressTelemetrySubmissions({
+    metricsPath: path.join(scratch, "missing-egress.jsonl"),
+    rateLimitPath: path.join(scratch, "missing-rate-limits.jsonl"),
+    receiptScope: "github-egress-proof:1:missing-sink",
+  });
+  assert.equal(emptySinkSubmissions.length, 1);
+  assert.equal(emptySinkSubmissions[0].metrics.length, 1);
+  assert.equal(emptySinkSubmissions[0].metrics[0].unit, "invocation");
+  assert.equal(emptySinkSubmissions[0].metrics[0].attempted, false);
+  assert.equal(emptySinkSubmissions[0].metrics[0].telemetryComplete, false);
 
   const workerPort = await availablePort();
   let worker = await startWorker(workerPort, persistPath, workerLogPath);
@@ -246,6 +256,13 @@ exit 73
     fetch: rewriteFetch(worker.origin),
   });
   assert.deepEqual(firstUpload, { accepted: true, deduped: false });
+  const emptySinkUpload = await submitGitHubEgressTelemetry({
+    baseUrl: "https://proof.invalid",
+    webhookSecret: proofSecret,
+    submission: emptySinkSubmissions[0],
+    fetch: rewriteFetch(worker.origin),
+  });
+  assert.deepEqual(emptySinkUpload, { accepted: true, deduped: false });
   const beforeRestart = await getJson(`${worker.origin}/api/github-egress-observability?hours=1`);
   assertPublicView(beforeRestart);
 
@@ -298,6 +315,7 @@ exit 73
       public_read_fallback_wire_attempts: 1,
       target_app_wire_attempts: 1,
       incomplete_unknown_route_wire_attempts: 1,
+      empty_sink_incomplete_invocations: 1,
       restart_rows_preserved: true,
       duplicate_upload_deduped: true,
       output_and_exit_preserved: true,
@@ -559,7 +577,7 @@ function assertPublicView(view) {
   assert.equal(view.rate_limit_observations.length, 1);
   assert.equal(view.privacy.pool_identity, "withheld");
   const totals = countBy(view.rows, "unit");
-  assert.deepEqual(totals, { invocation: 18, member: 1, wire_attempt: 19 });
+  assert.deepEqual(totals, { invocation: 19, member: 1, wire_attempt: 19 });
 }
 
 function privacyScan(serialized) {

--- a/docs/proof/github-egress-telemetry/run-proof.mjs
+++ b/docs/proof/github-egress-telemetry/run-proof.mjs
@@ -1,0 +1,624 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createServer as createHttpsServer } from "node:https";
+import { createWriteStream, readFileSync } from "node:fs";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
+import path from "node:path";
+
+import {
+  githubEgressTelemetrySubmissions,
+  submitGitHubEgressTelemetry,
+} from "../../../dist/repair/github-egress-telemetry-client.js";
+
+const repoRoot = process.cwd();
+const outputDir = required("GITHUB_EGRESS_PROOF_OUTPUT");
+const scratch = required("GITHUB_EGRESS_PROOF_SCRATCH");
+const tlsKey = required("GITHUB_EGRESS_PROOF_TLS_KEY");
+const tlsCert = required("GITHUB_EGRESS_PROOF_TLS_CERT");
+const realGh = required("GITHUB_EGRESS_PROOF_REAL_GH");
+const wrapper = path.join(repoRoot, "scripts/github-egress-observer.sh");
+const metricsPath = path.join(scratch, "github-egress.jsonl");
+const rateLimitPath = path.join(scratch, "github-rate-limits.jsonl");
+const persistPath = path.join(scratch, "wrangler-state");
+const workerLogPath = path.join(scratch, "wrangler.log");
+const proofSecret = "disposable-github-egress-proof-secret";
+const workers = [];
+const requestSummary = new Map();
+const candidateHead = process.env.GITHUB_EGRESS_PROOF_SOURCE_SHA || (await gitHead());
+
+await mkdir(outputDir, { recursive: true });
+await Promise.all(
+  ["proof-summary.json", "public-observability.json", "wrangler.log"].map((name) =>
+    rm(path.join(outputDir, name), { force: true }),
+  ),
+);
+
+const github = createHttpsServer(
+  { key: readFileSync(tlsKey), cert: readFileSync(tlsCert) },
+  githubRequest,
+);
+await new Promise((resolve) => github.listen(0, "127.0.0.1", resolve));
+const githubAddress = github.address();
+assert.ok(githubAddress && typeof githubAddress !== "string");
+const githubHost = `127.0.0.1:${githubAddress.port}`;
+
+const commonEnv = {
+  ...process.env,
+  GH_HOST: githubHost,
+  GH_ENTERPRISE_TOKEN: "disposable-loopback-token",
+  SSL_CERT_FILE: tlsCert,
+  CLAWSWEEPER_REAL_GH_BIN: realGh,
+  CLAWSWEEPER_GITHUB_OBSERVER_ROOT: repoRoot,
+  CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH: metricsPath,
+  CLAWSWEEPER_GITHUB_RATE_LIMIT_DETAILS_PATH: rateLimitPath,
+  CLAWSWEEPER_GITHUB_STAGE: "publication_prepare",
+  CLAWSWEEPER_GITHUB_SOURCE_ACTION: "scheduled_hot_intake",
+  CLAWSWEEPER_GITHUB_CLAIM_GENERATION: "2",
+  CLAWSWEEPER_GITHUB_REQUEST_REPEAT: "false",
+  CLAWSWEEPER_DEPLOYMENT_REVISION: candidateHead,
+  GITHUB_REPOSITORY: "openclaw/clawsweeper",
+  TARGET_REPO: "proof-owner/proof-repo",
+  EXACT_REVIEW_BATCH_MAX_ITEMS: "8",
+  EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY: "1",
+};
+
+try {
+  const paginationArgs = [
+    "api",
+    "repos/proof-owner/proof-repo/issues/42/comments?per_page=1",
+    "--paginate",
+    "--slurp",
+  ];
+  await assertBehaviorPreserved(paginationArgs, "repository_actions", true);
+  await assertBehaviorPreserved(
+    ["api", "repos/proof-owner/proof-repo/issues/43/comments"],
+    "repository_actions",
+    false,
+  );
+  const parserFailureArgs = ["api", "repos/proof-owner/proof-repo/issues/43/comments"];
+  const parserFailureDirect = await command(
+    realGh,
+    parserFailureArgs,
+    { ...commonEnv, GH_DEBUG: "" },
+    true,
+  );
+  const parserFailureObserved = await command(
+    "bash",
+    [wrapper, ...parserFailureArgs],
+    {
+      ...commonEnv,
+      CLAWSWEEPER_GITHUB_OBSERVER_ROOT: path.join(scratch, "missing-observer"),
+      CLAWSWEEPER_GITHUB_POOL_CLASS: "repository_actions",
+    },
+    true,
+  );
+  assert.equal(parserFailureObserved.status, parserFailureDirect.status);
+  assert.deepEqual(parserFailureObserved.stdout, parserFailureDirect.stdout);
+  assert.deepEqual(parserFailureObserved.stderr, parserFailureDirect.stderr);
+  const noNewlineGh = path.join(scratch, "gh-no-newline");
+  await writeFile(
+    noNewlineGh,
+    `#!/usr/bin/env bash
+printf '%s\n' '* Request at 2026-08-12T12:00:00Z' '> GET /repos/proof/private HTTP/1.1' '* Request took 1ms' >&2
+printf '%s' 'ordinary-error-without-newline' >&2
+exit 73
+`,
+  );
+  await chmod(noNewlineGh, 0o755);
+  const noNewlineObserved = await command(
+    "bash",
+    [wrapper, "api", "repos/proof/private"],
+    {
+      ...commonEnv,
+      CLAWSWEEPER_REAL_GH_BIN: noNewlineGh,
+      CLAWSWEEPER_GITHUB_OBSERVER_ROOT: path.join(scratch, "missing-observer"),
+      CLAWSWEEPER_GITHUB_POOL_CLASS: "repository_actions",
+    },
+    true,
+  );
+  assert.equal(noNewlineObserved.status, 73);
+  assert.deepEqual(noNewlineObserved.stdout, Buffer.alloc(0));
+  assert.deepEqual(noNewlineObserved.stderr, Buffer.from("ordinary-error-without-newline"));
+  await observedGh(
+    ["api", "repos/proof-owner/proof-repo/issues/44/comments"],
+    "public_read_fallback",
+  );
+  await observedGh(["api", "repos/proof-owner/proof-repo/issues/45/comments"], "target_app");
+  await assertBehaviorPreserved(
+    ["api", "repos/proof-owner/proof-repo/mystery/private"],
+    "repository_actions",
+    true,
+  );
+  const directArtifactDir = path.join(scratch, "direct-artifact");
+  const observedArtifactDir = path.join(scratch, "observed-artifact");
+  await mkdir(directArtifactDir, { recursive: true });
+  await mkdir(observedArtifactDir, { recursive: true });
+  const directArtifact = await command(
+    realGh,
+    [
+      "run",
+      "download",
+      "46",
+      "--repo",
+      "proof-owner/proof-repo",
+      "--name",
+      "proof-artifact",
+      "--dir",
+      directArtifactDir,
+    ],
+    { ...commonEnv, GH_DEBUG: "" },
+  );
+  const observedArtifact = await observedGh(
+    [
+      "run",
+      "download",
+      "46",
+      "--repo",
+      "proof-owner/proof-repo",
+      "--name",
+      "proof-artifact",
+      "--dir",
+      observedArtifactDir,
+    ],
+    "repository_actions",
+  );
+  assert.equal(observedArtifact.status, directArtifact.status);
+  assert.deepEqual(observedArtifact.stdout, directArtifact.stdout);
+  assert.deepEqual(observedArtifact.stderr, directArtifact.stderr);
+  await command(process.execPath, ["dist/github-egress-observer-cli.js", "record-member"], {
+    ...commonEnv,
+    CLAWSWEEPER_GITHUB_POOL_CLASS: "repository_actions",
+  });
+
+  const baselineSamples = [];
+  const observedSamples = [];
+  for (let index = 0; index < 12; index += 1) {
+    baselineSamples.push(
+      (
+        await command(realGh, ["api", "repos/proof-owner/proof-repo/issues/44/comments"], {
+          ...commonEnv,
+          GH_DEBUG: "",
+        })
+      ).elapsedMs,
+    );
+  }
+  for (let index = 0; index < 12; index += 1) {
+    observedSamples.push(
+      (
+        await observedGh(
+          ["api", "repos/proof-owner/proof-repo/issues/44/comments"],
+          "repository_actions",
+        )
+      ).elapsedMs,
+    );
+  }
+
+  const metrics = jsonLines(await readFile(metricsPath, "utf8"));
+  const rateLimits = jsonLines(await readFile(rateLimitPath, "utf8"));
+  const totals = countBy(metrics, "unit");
+  assert.deepEqual(totals, { invocation: 18, member: 1, wire_attempt: 19 });
+  assert.equal(rateLimits.length, 1);
+  assert.equal(rateLimits[0].status, 403);
+  assert.equal(rateLimits[0].headers.retryAfterPresent, true);
+  assert.equal(rateLimits[0].headers.retryAfterSeconds, 120);
+  assert.equal(rateLimits[0].headers.resetPresent, true);
+  assert.equal(rateLimits[0].resetAuthorityCandidate, "retry_after");
+  assert.equal(
+    sum(
+      metrics.filter(
+        (metric) => metric.unit === "wire_attempt" && metric.poolClass === "public_read_fallback",
+      ),
+    ),
+    1,
+  );
+  assert.equal(
+    sum(
+      metrics.filter(
+        (metric) => metric.unit === "wire_attempt" && metric.poolClass === "target_app",
+      ),
+    ),
+    1,
+  );
+  const incompleteWire = metrics.filter(
+    (metric) => metric.unit === "wire_attempt" && metric.telemetryComplete === false,
+  );
+  assert.equal(sum(incompleteWire), 1, JSON.stringify(incompleteWire));
+
+  privacyScan(`${JSON.stringify(metrics)}\n${JSON.stringify(rateLimits)}`);
+  const submissions = githubEgressTelemetrySubmissions({
+    metricsPath,
+    rateLimitPath,
+    receiptScope: "github-egress-proof:1:loopback",
+  });
+  assert.equal(submissions.length, 1);
+
+  const workerPort = await availablePort();
+  let worker = await startWorker(workerPort, persistPath, workerLogPath);
+  workers.push(worker);
+  await waitForWorker(worker.origin);
+  const firstUpload = await submitGitHubEgressTelemetry({
+    baseUrl: "https://proof.invalid",
+    webhookSecret: proofSecret,
+    submission: submissions[0],
+    fetch: rewriteFetch(worker.origin),
+  });
+  assert.deepEqual(firstUpload, { accepted: true, deduped: false });
+  const beforeRestart = await getJson(`${worker.origin}/api/github-egress-observability?hours=1`);
+  assertPublicView(beforeRestart);
+
+  await stopWorker(worker);
+  workers.splice(workers.indexOf(worker), 1);
+  worker = await startWorker(workerPort, persistPath, workerLogPath, true);
+  workers.push(worker);
+  await waitForWorker(worker.origin);
+  const afterRestart = await getJson(`${worker.origin}/api/github-egress-observability?hours=1`);
+  assert.deepEqual(afterRestart.rows, beforeRestart.rows);
+  assert.deepEqual(afterRestart.rate_limit_observations, beforeRestart.rate_limit_observations);
+  const duplicateUpload = await submitGitHubEgressTelemetry({
+    baseUrl: "https://proof.invalid",
+    webhookSecret: proofSecret,
+    submission: submissions[0],
+    fetch: rewriteFetch(worker.origin),
+  });
+  assert.deepEqual(duplicateUpload, { accepted: false, deduped: true });
+  const afterDuplicate = await getJson(`${worker.origin}/api/github-egress-observability?hours=1`);
+  assert.deepEqual(afterDuplicate.rows, beforeRestart.rows);
+
+  privacyScan(JSON.stringify(afterDuplicate));
+  const baselineMedianMs = median(baselineSamples);
+  const observedMedianMs = median(observedSamples);
+  const addedMedianMs = observedMedianMs - baselineMedianMs;
+  assert.ok(addedMedianMs < 1_000, `observer median overhead was ${addedMedianMs}ms`);
+
+  const summary = {
+    schema: "github-egress-telemetry-proof/v1",
+    generated_at: new Date().toISOString(),
+    candidate_head: candidateHead,
+    runtime: {
+      node: process.version,
+      gh: (await command(realGh, ["--version"], commonEnv)).stdout.toString("utf8").split("\n")[0],
+      worker: "wrangler 4.107.0 dev --local",
+      durable_object: "SQLite-backed ExactReviewQueue",
+      transport: "real loopback TLS GitHub CLI and HTTP Worker sockets",
+    },
+    assertions: {
+      wire_attempts: totals.wire_attempt,
+      invocations: totals.invocation,
+      members: totals.member,
+      pagination_pages: 3,
+      rate_limit_observations: rateLimits.length,
+      repository_actions_wire_attempts: sum(
+        metrics.filter(
+          (metric) => metric.unit === "wire_attempt" && metric.poolClass === "repository_actions",
+        ),
+      ),
+      public_read_fallback_wire_attempts: 1,
+      target_app_wire_attempts: 1,
+      incomplete_unknown_route_wire_attempts: 1,
+      restart_rows_preserved: true,
+      duplicate_upload_deduped: true,
+      output_and_exit_preserved: true,
+      parser_failure_error_preserved: true,
+      sentinel_privacy_scan_passed: true,
+    },
+    request_summary: Object.fromEntries([...requestSummary].sort()),
+    overhead: {
+      samples_per_lane: 12,
+      baseline_median_ms: baselineMedianMs,
+      observed_median_ms: observedMedianMs,
+      added_median_ms: addedMedianMs,
+      note: "Loopback process-launch timing; not a production latency benchmark.",
+    },
+    production_mutations: 0,
+    openclaw_bay_affected: false,
+    run_status: "succeeded",
+    limits: [
+      "Synthetic loopback GitHub responses, not live GitHub quota consumption.",
+      "The artifact invocation is real, but its internal inventory and archive wire count remains deliberately opaque.",
+      "The proof observes telemetry only; it does not exercise Phase 1 admission or circuit behavior.",
+    ],
+  };
+  await writeFile(
+    path.join(outputDir, "public-observability.json"),
+    `${JSON.stringify(afterDuplicate, null, 2)}\n`,
+  );
+  await writeFile(
+    path.join(outputDir, "proof-summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+} finally {
+  await Promise.all(workers.map(stopWorker));
+  await new Promise((resolve) => github.close(resolve));
+  const workerLog = await readFile(workerLogPath, "utf8").catch(() => "");
+  await writeFile(
+    path.join(outputDir, "wrangler.log"),
+    workerLog.replaceAll(proofSecret, "[redacted-local-proof-secret]").slice(0, 32_000),
+  );
+}
+
+function githubRequest(request, response) {
+  const url = new URL(request.url || "/", "https://loopback.invalid");
+  const pathKey = routeKey(url.pathname);
+  const key = `${request.method || "UNKNOWN"} ${pathKey}`;
+  requestSummary.set(key, (requestSummary.get(key) || 0) + 1);
+  const commonHeaders = {
+    "content-type": "application/json",
+    etag: '"synthetic-etag-secret"',
+    "x-github-request-id": "synthetic-request-id-secret",
+    "x-ratelimit-limit": "5000",
+    "x-ratelimit-resource": "core",
+  };
+  if (url.pathname.endsWith("/actions/runs/46/artifacts")) {
+    response.writeHead(200, commonHeaders);
+    response.end(
+      JSON.stringify({
+        total_count: 1,
+        artifacts: [
+          {
+            id: 9001,
+            name: "proof-artifact",
+            size_in_bytes: 22,
+            archive_download_url: `https://${request.headers.host}/api/v3/repos/proof-owner/proof-repo/actions/artifacts/9001/zip`,
+            expired: false,
+            created_at: "2026-08-12T10:00:00Z",
+            updated_at: "2026-08-12T10:00:00Z",
+            expires_at: "2026-08-13T10:00:00Z",
+            workflow_run: { id: 46 },
+          },
+        ],
+      }),
+    );
+    return;
+  }
+  if (url.pathname.endsWith("/actions/artifacts/9001/zip")) {
+    response.writeHead(200, { "content-type": "application/zip" });
+    response.end(Buffer.from("UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==", "base64"));
+    return;
+  }
+  if (url.pathname.endsWith("/issues/43/comments")) {
+    response.writeHead(403, {
+      ...commonHeaders,
+      "retry-after": "120",
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-used": "5000",
+      "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 120),
+    });
+    response.end(JSON.stringify({ message: "synthetic rate limit body secret" }));
+    return;
+  }
+  if (url.pathname.endsWith("/issues/42/comments")) {
+    const page = Number(url.searchParams.get("page") || "1");
+    const headers = {
+      ...commonHeaders,
+      "x-ratelimit-remaining": "100",
+      "x-ratelimit-used": "4900",
+      "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+    };
+    if (page < 3) {
+      headers.link = `<https://${request.headers.host}${url.pathname}?per_page=1&page=${page + 1}>; rel="next"`;
+    }
+    response.writeHead(200, headers);
+    response.end(JSON.stringify([{ id: page, body: "synthetic page body secret" }]));
+    return;
+  }
+  response.writeHead(200, {
+    ...commonHeaders,
+    "x-ratelimit-remaining": "100",
+    "x-ratelimit-used": "4900",
+    "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+  });
+  response.end(JSON.stringify([{ id: 1, body: "synthetic body secret" }]));
+}
+
+function routeKey(pathname) {
+  if (pathname.endsWith("/issues/42/comments")) return "issue_comments_paginated";
+  if (pathname.endsWith("/issues/43/comments")) return "issue_comments_throttled";
+  if (pathname.endsWith("/issues/44/comments")) return "issue_comments_control";
+  if (pathname.endsWith("/issues/45/comments")) return "issue_comments_target_app";
+  if (pathname.endsWith("/actions/runs/46/artifacts")) return "artifact_inventory";
+  if (pathname.endsWith("/actions/artifacts/9001/zip")) return "artifact_archive";
+  return "unknown_route";
+}
+
+async function assertBehaviorPreserved(args, poolClass, expectSuccess) {
+  const direct = await command(realGh, args, { ...commonEnv, GH_DEBUG: "" }, true);
+  const observed = await observedGh(args, poolClass, true);
+  assert.equal(observed.status, direct.status);
+  assert.deepEqual(observed.stdout, direct.stdout);
+  assert.deepEqual(observed.stderr, direct.stderr);
+  assert.equal(observed.status === 0, expectSuccess);
+}
+
+function observedGh(args, poolClass, allowFailure = false) {
+  return command(
+    "bash",
+    [wrapper, ...args],
+    { ...commonEnv, CLAWSWEEPER_GITHUB_POOL_CLASS: poolClass },
+    allowFailure,
+  );
+}
+
+function command(executable, args, env, allowFailure = false) {
+  return new Promise((resolve, reject) => {
+    const started = process.hrtime.bigint();
+    const child = spawn(executable, args, {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      const result = {
+        status: status ?? 128,
+        signal,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+        elapsedMs: Number(process.hrtime.bigint() - started) / 1_000_000,
+      };
+      if (!allowFailure && (status !== 0 || signal)) {
+        reject(
+          new Error(
+            `${executable} ${args.join(" ")} failed (${status}/${signal}): ${result.stderr.toString("utf8")}`,
+          ),
+        );
+      } else resolve(result);
+    });
+  });
+}
+
+async function startWorker(port, persist, logPath, append = false) {
+  const log = createWriteStream(logPath, { flags: append ? "a" : "w" });
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      "wrangler@4.107.0",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      persist,
+      "--config",
+      "dashboard/wrangler.toml",
+      "--var",
+      `CLAWSWEEPER_WEBHOOK_SECRET:${proofSecret}`,
+    ],
+    {
+      cwd: repoRoot,
+      detached: process.platform !== "win32",
+      env: { ...process.env, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.stdout.pipe(log);
+  child.stderr.pipe(log);
+  return { child, log, origin: `http://127.0.0.1:${port}` };
+}
+
+async function waitForWorker(origin) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${origin}/api/health`);
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Worker did not become ready: ${origin}`);
+}
+
+async function stopWorker(worker) {
+  if (!worker?.child) return;
+  signalProcessTree(worker.child, "SIGTERM");
+  if (worker.child.exitCode === null) {
+    await Promise.race([
+      new Promise((resolve) => worker.child.once("exit", resolve)),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+  }
+  signalProcessTree(worker.child, "SIGKILL");
+  await new Promise((resolve) => worker.log.end(resolve));
+}
+
+function signalProcessTree(child, signal) {
+  try {
+    if (process.platform === "win32") child.kill(signal);
+    else if (child.pid) process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+function rewriteFetch(origin) {
+  return (input, init) => fetch(String(input).replace("https://proof.invalid", origin), init);
+}
+
+async function getJson(url) {
+  const response = await fetch(url);
+  const text = await response.text();
+  assert.equal(response.status, 200, text);
+  return JSON.parse(text);
+}
+
+function assertPublicView(view) {
+  assert.equal(view.version, 2);
+  assert.equal(view.completeness.rows_truncated, false);
+  assert.equal(view.completeness.rate_limit_rows_truncated, false);
+  assert.equal(view.completeness.query_complete, true);
+  assert.equal(view.rate_limit_observations.length, 1);
+  assert.equal(view.privacy.pool_identity, "withheld");
+  const totals = countBy(view.rows, "unit");
+  assert.deepEqual(totals, { invocation: 18, member: 1, wire_attempt: 19 });
+}
+
+function privacyScan(serialized) {
+  for (const sentinel of [
+    "proof-owner",
+    "proof-repo",
+    "synthetic-etag-secret",
+    "synthetic-request-id-secret",
+    "synthetic page body secret",
+    "synthetic rate limit body secret",
+    "disposable-loopback-token",
+    "/issues/",
+    "https://127.0.0.1",
+  ]) {
+    assert.equal(serialized.includes(sentinel), false, `privacy sentinel: ${sentinel}`);
+  }
+}
+
+function jsonLines(text) {
+  return text
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function countBy(rows, key) {
+  return Object.fromEntries(
+    [...new Set(rows.map((row) => row[key]))]
+      .sort()
+      .map((value) => [value, sum(rows.filter((row) => row[key] === value))]),
+  );
+}
+
+function sum(rows) {
+  return rows.reduce((total, row) => total + Number(row.count || 0), 0);
+}
+
+function median(values) {
+  const ordered = [...values].sort((left, right) => left - right);
+  const midpoint = Math.floor(ordered.length / 2);
+  return ordered.length % 2 ? ordered[midpoint] : (ordered[midpoint - 1] + ordered[midpoint]) / 2;
+}
+
+async function availablePort() {
+  const server = createNetServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  await new Promise((resolve) => server.close(resolve));
+  return address.port;
+}
+
+async function gitHead() {
+  const result = await command("git", ["rev-parse", "HEAD"], process.env);
+  return result.stdout.toString("utf8").trim();
+}
+
+function required(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/docs/proof/github-egress-telemetry/run-proof.sh
+++ b/docs/proof/github-egress-telemetry/run-proof.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+output_dir="${GITHUB_EGRESS_PROOF_OUTPUT:-.artifacts/github-egress-telemetry-proof}"
+scratch="$(mktemp -d /tmp/clawsweeper-github-egress-proof.XXXXXX)"
+tls_dir="$scratch/tls"
+mkdir -p "$output_dir" "$tls_dir"
+
+cleanup() {
+  rm -rf -- "$scratch"
+}
+trap cleanup EXIT
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  mkdir -p "$scratch/bin"
+  corepack enable --install-directory "$scratch/bin"
+  export PATH="$scratch/bin:$PATH"
+fi
+
+pnpm install --frozen-lockfile >"$output_dir/dependencies-install.log" 2>&1
+pnpm run build:all >"$output_dir/build.log" 2>&1
+
+real_gh="$(command -v gh || true)"
+if test -z "$real_gh"; then
+  gh_version="2.88.1"
+  gh_archive="$scratch/gh.tar.gz"
+  curl --fail --silent --show-error --location \
+    "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \
+    --output "$gh_archive"
+  tar -xzf "$gh_archive" -C "$scratch"
+  real_gh="$scratch/gh_${gh_version}_linux_amd64/bin/gh"
+fi
+test -x "$real_gh"
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -subj '/CN=127.0.0.1' \
+  -addext 'subjectAltName=IP:127.0.0.1' \
+  -keyout "$tls_dir/key.pem" \
+  -out "$tls_dir/cert.pem" \
+  >/dev/null 2>&1
+
+export GITHUB_EGRESS_PROOF_OUTPUT="$output_dir"
+export GITHUB_EGRESS_PROOF_SCRATCH="$scratch"
+export GITHUB_EGRESS_PROOF_TLS_KEY="$tls_dir/key.pem"
+export GITHUB_EGRESS_PROOF_TLS_CERT="$tls_dir/cert.pem"
+export GITHUB_EGRESS_PROOF_REAL_GH="$real_gh"
+node docs/proof/github-egress-telemetry/run-proof.mjs
+
+test -s "$output_dir/proof-summary.json"
+test -s "$output_dir/public-observability.json"
+test -s "$output_dir/wrangler.log"

--- a/docs/proof/github-egress-telemetry/run-proof.sh
+++ b/docs/proof/github-egress-telemetry/run-proof.sh
@@ -26,10 +26,12 @@ pnpm run build:all >"$output_dir/build.log" 2>&1
 real_gh="$(command -v gh || true)"
 if test -z "$real_gh"; then
   gh_version="2.88.1"
+  gh_linux_amd64_sha256="36352a993b97e9758793cdb87f9ba674bd6d88c914488e122be78a1962203803"
   gh_archive="$scratch/gh.tar.gz"
   curl --fail --silent --show-error --location \
     "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz" \
     --output "$gh_archive"
+  printf '%s  %s\n' "$gh_linux_amd64_sha256" "$gh_archive" | sha256sum --check --status
   tar -xzf "$gh_archive" -C "$scratch"
   real_gh="$scratch/gh_${gh_version}_linux_amd64/bin/gh"
 fi

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -3,7 +3,7 @@
 - Status: active operator reference
 - Owner: ClawSweeper dashboard maintainers
 - Source of truth: `dashboard/worker.ts` request routing and its focused tests
-- Last verified: `openclaw/clawsweeper@2b5b345063efe1690e1d802fb1a738aa6a408707`
+- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
 - Update when: a public observer route, method, query parameter, response source, or authentication boundary changes
 - Checked by: `pnpm run check:docs`
 
@@ -24,6 +24,7 @@ branch, not a promise that every method will remain supported.
 | `/api/exact-review-queue/item`           | `GET`  | One queue item's status; forwards query parameters.                                         |
 | `/api/exact-review-queue/reviews`        | `GET`  | Per-item review lookup used by observer surfaces.                                           |
 | `/api/review-observability`              | `GET`  | Review observability from the queue Durable Object; forwards query parameters.              |
+| `/api/github-egress-observability`        | `GET`  | Sanitized publication GitHub egress rollups for `hours=1`, `6`, or `24`.                     |
 | `/api/review-coverage`                   | `GET`  | Review coverage from the queue Durable Object.                                              |
 | `/api/apply-observability`               | `GET`  | Apply-lane observability from `applyObservabilityJson`.                                     |
 | `/api/health-history`                    | `GET`  | Historical health from `healthHistoryJson`.                                                 |
@@ -37,5 +38,7 @@ removing a literal observer route in `dashboard/worker.ts` requires updating
 that manifest and this table. The checker excludes `/api/events`, because it is
 an ingest mutation rather than an observer route.
 
-For field interpretation, use [Live dashboard](live-dashboard.md). For the
-rendered lane model, use [OpenClaw Bay](openclaw-bay-demo.md).
+For egress field interpretation, use
+[GitHub publication egress telemetry](github-egress-telemetry.md). For other
+fields, use [Live dashboard](live-dashboard.md). For the rendered lane model,
+use [OpenClaw Bay](openclaw-bay-demo.md).

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "repair:scheduled-review-enqueue": "node dist/repair/scheduled-review-enqueue.js",
     "repair:exact-review-dead-letters": "node scripts/exact-review-dead-letter-operator.mjs",
     "repair:exact-review-batch": "node dist/repair/exact-review-batch-cli.js",
+    "repair:github-egress-telemetry": "node dist/repair/github-egress-telemetry-cli.js",
     "repair:exact-review-direct-publication": "node dist/repair/exact-review-direct-publication.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",

--- a/scripts/github-egress-observer.sh
+++ b/scripts/github-egress-observer.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -u
+
+real_gh="${CLAWSWEEPER_REAL_GH_BIN:-}"
+if [[ -z "$real_gh" || ! -x "$real_gh" ]]; then
+  echo "ClawSweeper GitHub observer: CLAWSWEEPER_REAL_GH_BIN is unavailable" >&2
+  exit 127
+fi
+
+metrics_path="${CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH:-}"
+observer_root="${CLAWSWEEPER_GITHUB_OBSERVER_ROOT:-${GITHUB_WORKSPACE:-.}}"
+if [[ -z "$metrics_path" ]]; then
+  exec "$real_gh" "$@"
+fi
+
+descriptor=true
+previous=""
+for argument in "$@"; do
+  if [[ "$previous" == "run" && "$argument" == "download" ]]; then
+    descriptor=false
+    break
+  fi
+  previous="$argument"
+done
+
+stderr_file="$(mktemp "${RUNNER_TEMP:-/tmp}/clawsweeper-gh-stderr.XXXXXX")"
+clean_stderr_file="$(mktemp "${RUNNER_TEMP:-/tmp}/clawsweeper-gh-clean-stderr.XXXXXX")"
+gh_pid=""
+cleanup() {
+  rm -f "$stderr_file" "$clean_stderr_file"
+}
+forward_signal() {
+  local signal="$1"
+  local status="$2"
+  if [[ -n "$gh_pid" ]]; then
+    kill -s "$signal" "$gh_pid" 2>/dev/null || true
+    wait "$gh_pid" 2>/dev/null || true
+  fi
+  exit "$status"
+}
+sanitize_debug_fallback() {
+  # Preserve ordinary gh stderr while suppressing complete or partial GH_DEBUG
+  # frames if the richer observer is unavailable. Latin-1 is a byte-preserving
+  # mapping, including an ordinary final record without a newline.
+  node -e '
+    const fs = require("node:fs");
+    const input = fs.readFileSync(0);
+    const text = input.toString("latin1");
+    const clean = [];
+    let cursor = 0;
+    const startPattern = /^\* Request at [^\r\n]*(?:\r?\n|$)/gm;
+    for (;;) {
+      startPattern.lastIndex = cursor;
+      const start = startPattern.exec(text);
+      if (!start) {
+        clean.push(text.slice(cursor));
+        break;
+      }
+      clean.push(text.slice(cursor, start.index));
+      const endPattern = /^\* Request (?:took|failed after) [^\r\n]*(?:\r?\n|$)/gm;
+      endPattern.lastIndex = start.index + start[0].length;
+      const end = endPattern.exec(text);
+      if (!end) break;
+      cursor = end.index + end[0].length;
+    }
+    process.stdout.write(Buffer.from(clean.join(""), "latin1"));
+  ' <"$stderr_file"
+}
+trap cleanup EXIT
+trap 'forward_signal TERM 143' TERM
+trap 'forward_signal INT 130' INT
+trap 'forward_signal HUP 129' HUP
+
+if [[ "$descriptor" == "true" ]]; then
+  CLAWSWEEPER_GITHUB_DEBUG_ENABLED=true GH_DEBUG=api "$real_gh" "$@" 2>"$stderr_file" &
+else
+  CLAWSWEEPER_GITHUB_DEBUG_ENABLED=false env -u GH_DEBUG "$real_gh" "$@" 2>"$stderr_file" &
+fi
+gh_pid=$!
+set +e
+wait "$gh_pid"
+status=$?
+set -e
+gh_pid=""
+
+if ! CLAWSWEEPER_GITHUB_DEBUG_ENABLED="$descriptor" \
+  node "$observer_root/dist/github-egress-observer-cli.js" -- "$@" \
+  <"$stderr_file" >"$clean_stderr_file" 2>/dev/null; then
+  # Never leak a raw GH_DEBUG frame or suppress the original gh error text when
+  # observation itself fails. Conservation detects the missing upload.
+  sanitize_debug_fallback >"$clean_stderr_file"
+fi
+cat "$clean_stderr_file" >&2
+exit "$status"

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -16,6 +16,10 @@ import {
 } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  appendLegacyAvoidedGithubEgressMember,
+  recordGithubEgressMember,
+} from "../dist/github-egress-observer.js";
 
 const DEFAULT_CONCURRENCY = 4;
 const MAX_CONCURRENCY = 4;
@@ -113,6 +117,16 @@ async function controller() {
         repeat_revision: item.repeatRevision === true,
         count: 1,
       });
+      appendLegacyAvoidedGithubEgressMember({
+        env: { ...process.env, TARGET_REPO: String(item.decision?.targetRepo || "") },
+        poolClass:
+          activeCircuit.scope === "repository_actions" ? "repository_actions" : "target_app",
+        stage: "publication_prepare",
+        sourceAction: item.decision?.publication?.producerDecision?.sourceAction,
+        operation: "artifact_download",
+        claimGeneration: item.claimGeneration,
+        repeatRevision: item.repeatRevision === true,
+      });
       writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
         retryAt: activeCircuit.retry_at,
         rateLimitScope: activeCircuit.scope,
@@ -123,10 +137,30 @@ async function controller() {
       return { kind: "circuit_deferred", durationMs: 0 };
     }
     if (existsSync(heartbeatFailurePath) || Date.now() >= deadline) {
+      recordGithubEgressMember({
+        env: { ...process.env, TARGET_REPO: String(item.decision?.targetRepo || "") },
+        poolClass: "repository_actions",
+        stage: "publication_prepare",
+        sourceAction: item.decision?.publication?.producerDecision?.sourceAction,
+        claimGeneration: item.claimGeneration,
+        repeatRevision: item.repeatRevision === true,
+        attempted: false,
+        outcome: "pre_wire_failure",
+      });
       writeFailure(outcomePath, "retryable_failure", "unknown_failure");
       return { kind: "not_admitted", durationMs: 0 };
     }
     admitted += 1;
+    recordGithubEgressMember({
+      env: { ...process.env, TARGET_REPO: String(item.decision?.targetRepo || "") },
+      poolClass: "repository_actions",
+      stage: "publication_prepare",
+      sourceAction: item.decision?.publication?.producerDecision?.sourceAction,
+      claimGeneration: item.claimGeneration,
+      repeatRevision: item.repeatRevision === true,
+      attempted: true,
+      outcome: "attempted",
+    });
     const identity = createHash("sha256")
       .update(`${item.itemKey}:${item.revision}:${item.claimGeneration}`)
       .digest("hex")
@@ -228,6 +262,14 @@ async function worker(itemPath, root, workspace) {
       ".artifacts/exact-review-batch/github-request-metrics.jsonl",
   );
   const repositoryToken = env("REPO_TOKEN");
+  const itemEgressEnv = {
+    TARGET_REPO: targetRepo,
+    CLAWSWEEPER_GITHUB_POOL_CLASS: "repository_actions",
+    CLAWSWEEPER_GITHUB_STAGE: "publication_prepare",
+    CLAWSWEEPER_GITHUB_SOURCE_ACTION: String(producer.sourceAction || ""),
+    CLAWSWEEPER_GITHUB_CLAIM_GENERATION: String(item.claimGeneration),
+    CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(item.repeatRevision === true),
+  };
   let result = await run(
     "gh",
     [
@@ -241,7 +283,14 @@ async function worker(itemPath, root, workspace) {
       "--dir",
       bundleDir,
     ],
-    { env: { ...process.env, GH_TOKEN: repositoryToken }, capture: true },
+    {
+      env: {
+        ...process.env,
+        GH_TOKEN: repositoryToken,
+        ...itemEgressEnv,
+      },
+      capture: true,
+    },
   );
   appendRequestMetric(requestMetricsPath, {
     scope: "repository_actions",
@@ -257,6 +306,7 @@ async function worker(itemPath, root, workspace) {
       repositoryToken,
       requestMetricsPath,
       rateLimitObservationPath,
+      itemEgressEnv,
     );
     appendJsonLine(rateLimitObservationPath, observation);
     return writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
@@ -335,6 +385,8 @@ async function worker(itemPath, root, workspace) {
       EXACT_REVIEW_BATCH_MUTATION_OUTPUT: outcomePath,
       CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: rateLimitObservationPath,
       CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: requestMetricsPath,
+      CLAWSWEEPER_GITHUB_STAGE: "publication_apply",
+      CLAWSWEEPER_GITHUB_SOURCE_ACTION: String(producer.sourceAction || ""),
       CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(item.repeatRevision === true),
     },
   });
@@ -363,7 +415,12 @@ function githubThrottleText(value) {
   );
 }
 
-async function resolveRateLimitObservation(token, requestMetricsPath, observationPath) {
+async function resolveRateLimitObservation(
+  token,
+  requestMetricsPath,
+  observationPath,
+  telemetryEnv,
+) {
   const now = Date.now();
   try {
     closeSync(openSync(`${observationPath}.lookup-repository_actions.lock`, "wx"));
@@ -384,7 +441,7 @@ async function resolveRateLimitObservation(token, requestMetricsPath, observatio
       "--jq",
       "{remaining:.resources.core.remaining,reset:.resources.core.reset}",
     ],
-    { env: { ...process.env, GH_TOKEN: token }, capture: true },
+    { env: { ...process.env, GH_TOKEN: token, ...telemetryEnv }, capture: true },
   );
   appendRequestMetric(requestMetricsPath, {
     scope: "repository_actions",

--- a/src/clawsweeper-github-runtime.ts
+++ b/src/clawsweeper-github-runtime.ts
@@ -139,8 +139,41 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
             ...process.env,
             ...overrides,
           }));
-    if (token) return { ...overrides, GH_TOKEN: token };
-    return Object.keys(overrides).length > 0 ? overrides : undefined;
+    const selected = token ? { ...overrides, GH_TOKEN: token } : overrides;
+    const telemetryEnv = githubEgressEnvironment(
+      args,
+      selected,
+      token ? "public_read_fallback" : undefined,
+    );
+    if (token) return { ...selected, ...telemetryEnv };
+    return Object.keys(selected).length > 0 || telemetryEnv
+      ? { ...selected, ...telemetryEnv }
+      : undefined;
+  }
+
+  function githubEgressEnvironment(
+    args: readonly string[],
+    overrides: NodeJS.ProcessEnv = {},
+    selectedPoolClass?: "public_read_fallback",
+  ): NodeJS.ProcessEnv | undefined {
+    if (!process.env.CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH?.trim()) return undefined;
+    const scope = githubRequestScope(args, overrides);
+    return {
+      CLAWSWEEPER_GITHUB_POOL_CLASS:
+        selectedPoolClass ?? (scope === "repository_actions" ? "repository_actions" : "target_app"),
+      CLAWSWEEPER_GITHUB_STAGE:
+        process.env.CLAWSWEEPER_GITHUB_STAGE ||
+        (process.env.EXACT_EVENT_PUBLICATION === "true"
+          ? "publication_apply"
+          : "publication_recovery"),
+      CLAWSWEEPER_GITHUB_SOURCE_ACTION: process.env.CLAWSWEEPER_GITHUB_SOURCE_ACTION || "",
+      CLAWSWEEPER_GITHUB_CLAIM_GENERATION:
+        process.env.CLAWSWEEPER_GITHUB_CLAIM_GENERATION ||
+        process.env.EXACT_REVIEW_BATCH_CLAIM_GENERATION ||
+        process.env.EXACT_REVIEW_CLAIM_GENERATION ||
+        "",
+      CLAWSWEEPER_GITHUB_REQUEST_REPEAT: process.env.CLAWSWEEPER_GITHUB_REQUEST_REPEAT || "",
+    };
   }
 
   function githubRequestScope(
@@ -227,7 +260,11 @@ export function createGitHubRuntime(dependencies: CreateGitHubRuntimeDependencie
         ],
         {
           timeoutMs: RATE_LIMIT_LOOKUP_TIMEOUT_MS,
-          env: { ...process.env, GH_TOKEN: token },
+          env: {
+            ...process.env,
+            GH_TOKEN: token,
+            ...githubEgressEnvironment(["api", "rate_limit"], { GH_TOKEN: token }),
+          },
         },
       );
       recordGitHubRequest(["api", "rate_limit"], scope, "success");

--- a/src/github-egress-descriptor.ts
+++ b/src/github-egress-descriptor.ts
@@ -1,0 +1,220 @@
+import type {
+  GitHubEgressMethod,
+  GitHubEgressOperation,
+  GitHubEgressRouteTemplate,
+} from "./github-egress-telemetry-contract.js";
+
+export type GitHubEgressCommandDescriptor = {
+  operation: GitHubEgressOperation;
+  method: GitHubEgressMethod;
+  routeTemplate: GitHubEgressRouteTemplate;
+  wireSafe: boolean;
+};
+
+export function githubEgressCommandDescriptor(
+  args: readonly string[],
+): GitHubEgressCommandDescriptor {
+  const command = args[0] === "--repo" ? args[2] : args[0];
+  if (command === "run" && args.includes("download")) {
+    return {
+      operation: "artifact_download",
+      method: "GET",
+      routeTemplate: "actions_run_artifacts",
+      // GH_DEBUG can render the redirected archive body. Retain invocation
+      // accounting but do not expose that binary path to the debug parser.
+      wireSafe: false,
+    };
+  }
+  if (command === "workflow" && args.includes("run")) {
+    return {
+      operation: "workflow_dispatch",
+      method: "POST",
+      routeTemplate: "actions_workflow_dispatch",
+      wireSafe: true,
+    };
+  }
+  const apiIndex = args.indexOf("api");
+  if (apiIndex < 0) return unknownDescriptor();
+  const endpoint = apiEndpoint(args, apiIndex);
+  const method = apiMethod(args, apiIndex);
+  const routeTemplate = githubEgressRouteTemplate(endpoint);
+  return {
+    operation: githubEgressOperation(routeTemplate),
+    method,
+    routeTemplate,
+    wireSafe: routeTemplate !== "unknown",
+  };
+}
+
+export function githubEgressRouteTemplate(value: string): GitHubEgressRouteTemplate {
+  let path = value.trim();
+  try {
+    path = new URL(path, "https://api.github.invalid").pathname;
+  } catch {
+    return "unknown";
+  }
+  path = path.replace(/^\/api\/v3/i, "");
+  if (path === "/rate_limit" || path === "rate_limit") return "rate_limit";
+  if (path === "/graphql" || path === "graphql") return "graphql";
+  if (path === "/user" || path === "user") return "authenticated_user";
+  if (path === "/search/issues" || path === "search/issues") return "search_issues";
+  if (/^\/repos\/[^/]+\/[^/]+\/?$/.test(path)) return "repository_metadata";
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/?$/.test(path)) return "issues_collection";
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/?$/.test(path)) return "issue_metadata";
+  if (/^\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/?$/.test(path)) return "pull_metadata";
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/comments\/?$/.test(path)) {
+    return "issue_comments";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/comments\/\d+\/?$/.test(path)) {
+    return "issue_comment";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/reviews\/?$/.test(path)) {
+    return "pull_reviews";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/comments\/?$/.test(path)) {
+    return "pull_comments";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/files\/?$/.test(path)) {
+    return "pull_files";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/pulls\/\d+\/commits\/?$/.test(path)) {
+    return "pull_commits";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/timeline\/?$/.test(path)) {
+    return "issue_timeline";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/labels(?:\/[^/]+)?\/?$/.test(path)) {
+    return "issue_labels";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/reactions\/?$/.test(path)) {
+    return "issue_reactions";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/issues\/\d+\/reactions\/\d+\/?$/.test(path)) {
+    return "issue_reactions";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/labels(?:\/[^/]+)?\/?$/.test(path)) {
+    return "repository_labels";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/collaborators\/[^/]+\/permission\/?$/.test(path)) {
+    return "collaborator_permission";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/contents(?:\/.*)?$/.test(path)) {
+    return "repository_contents";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/commits\/?$/.test(path)) return "commits_collection";
+  if (/^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/check-runs\/?$/.test(path)) {
+    return "commit_check_runs";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/status\/?$/.test(path)) {
+    return "commit_status";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/pulls\/?$/.test(path)) {
+    return "commit_pulls";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/commits\/[^/]+\/?$/.test(path)) {
+    return "commit_metadata";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/actions\/runs\/?$/.test(path)) return "actions_runs";
+  if (/^\/repos\/[^/]+\/[^/]+\/actions\/runs\/\d+\/artifacts\/?$/.test(path)) {
+    return "actions_run_artifacts";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/actions\/artifacts\/\d+\/(?:zip|tar)\/?$/.test(path)) {
+    return "actions_artifact_archive";
+  }
+  if (/^\/repos\/[^/]+\/[^/]+\/actions\/workflows\/[^/]+\/dispatches\/?$/.test(path)) {
+    return "actions_workflow_dispatch";
+  }
+  return "unknown";
+}
+
+function apiEndpoint(args: readonly string[], apiIndex: number): string {
+  for (let index = apiIndex + 1; index < args.length; index += 1) {
+    const value = args[index] || "";
+    if (!value.startsWith("-")) return value;
+    if (
+      [
+        "-X",
+        "--method",
+        "-H",
+        "--header",
+        "-f",
+        "--raw-field",
+        "-F",
+        "--field",
+        "-q",
+        "--jq",
+        "--hostname",
+        "--input",
+        "-t",
+        "--template",
+      ].includes(value)
+    ) {
+      index += 1;
+    }
+  }
+  return "";
+}
+
+function apiMethod(args: readonly string[], apiIndex: number): GitHubEgressMethod {
+  for (let index = apiIndex + 1; index < args.length; index += 1) {
+    const value = args[index];
+    if (value === "-X" || value === "--method") {
+      const method = String(args[index + 1] || "").toUpperCase();
+      return githubEgressMethod(method);
+    }
+  }
+  return args
+    .slice(apiIndex + 1)
+    .some((value) => ["-f", "--raw-field", "-F", "--field"].includes(value))
+    ? "POST"
+    : "GET";
+}
+
+function githubEgressMethod(value: string): GitHubEgressMethod {
+  return ["GET", "POST", "PATCH", "PUT", "DELETE", "HEAD"].includes(value)
+    ? (value as GitHubEgressMethod)
+    : "UNKNOWN";
+}
+
+export function githubEgressOperation(route: GitHubEgressRouteTemplate): GitHubEgressOperation {
+  if (route === "rate_limit") return "rate_status";
+  if (
+    route === "actions_run_artifacts" ||
+    route === "actions_artifact_archive" ||
+    route === "external_artifact_blob"
+  )
+    return "artifact_download";
+  if (route === "actions_workflow_dispatch") return "workflow_dispatch";
+  if (route === "graphql") return "graphql";
+  if (
+    route === "issue_metadata" ||
+    route === "pull_metadata" ||
+    route === "repository_metadata" ||
+    route === "issues_collection" ||
+    route === "issue_timeline" ||
+    route === "pull_files" ||
+    route === "pull_commits" ||
+    route === "commits_collection" ||
+    route === "commit_metadata" ||
+    route === "commit_pulls" ||
+    route === "actions_runs" ||
+    route === "search_issues"
+  )
+    return "item_metadata";
+  if (route === "issue_comments" || route === "issue_comment" || route === "pull_comments") {
+    return "comments";
+  }
+  if (route === "pull_reviews") return "reviews";
+  if (route === "issue_labels" || route === "repository_labels") return "labels";
+  if (route === "issue_reactions") return "reactions";
+  if (route === "commit_status" || route === "commit_check_runs") return "checks";
+  if (route === "repository_contents") return "contents";
+  if (route === "collaborator_permission" || route === "authenticated_user") {
+    return "authorization";
+  }
+  return "other";
+}
+
+function unknownDescriptor(): GitHubEgressCommandDescriptor {
+  return { operation: "other", method: "UNKNOWN", routeTemplate: "unknown", wireSafe: false };
+}

--- a/src/github-egress-observer-cli.ts
+++ b/src/github-egress-observer-cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import {
+  observeGitHubDebugStderr,
+  recordGithubEgressMember,
+  recordUnobservedGitHubInvocation,
+} from "./github-egress-observer.js";
+
+const mode = process.argv[2];
+const separator = process.argv.indexOf("--");
+const args = separator >= 0 ? process.argv.slice(separator + 1) : process.argv.slice(2);
+if (mode === "record-member") {
+  recordGithubEgressMember();
+} else if (mode === "record-unobserved") {
+  recordUnobservedGitHubInvocation(args);
+} else {
+  const stderr = readFileSync(0);
+  const debugEnabled = process.env.CLAWSWEEPER_GITHUB_DEBUG_ENABLED === "true";
+  const clean = debugEnabled
+    ? observeGitHubDebugStderr(stderr, args)
+    : (recordUnobservedGitHubInvocation(args), stderr);
+  process.stdout.write(clean);
+}

--- a/src/github-egress-observer.ts
+++ b/src/github-egress-observer.ts
@@ -1,0 +1,591 @@
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  githubEgressCommandDescriptor,
+  githubEgressOperation,
+  githubEgressRouteTemplate,
+} from "./github-egress-descriptor.js";
+import {
+  GITHUB_EGRESS_METHODS,
+  GITHUB_EGRESS_POOL_CLASSES,
+  GITHUB_EGRESS_STAGES,
+  GITHUB_EGRESS_TELEMETRY_VERSION,
+  githubEgressClaimGenerationBucket,
+  githubEgressFiveMinuteBucket,
+  githubEgressLatencyBucket,
+  githubEgressPageBucket,
+  githubEgressSourceAction,
+  githubEgressStatusBucket,
+  type GitHubEgressMethod,
+  type GitHubEgressMetricV2,
+  type GitHubEgressOutcome,
+  type GitHubEgressPageBucket,
+  type GitHubEgressPoolClass,
+  type GitHubEgressRouteTemplate,
+  type GitHubEgressStage,
+  type GitHubRateLimitHeadersV2,
+  type GitHubRateLimitObservationV2,
+} from "./github-egress-telemetry-contract.js";
+
+type ParsedWireAttempt = {
+  method: GitHubEgressMethod;
+  routeTemplate: GitHubEgressRouteTemplate;
+  pageBucket: GitHubEgressPageBucket;
+  status: number | null;
+  latencyMs: number | null;
+  receivedAtMs: number | null;
+  headers: GitHubRateLimitHeadersV2;
+  complete: boolean;
+};
+
+type GitHubEgressContext = {
+  deploymentRevision: string;
+  configRevision: string;
+  poolClass: GitHubEgressPoolClass;
+  poolIdentity: string;
+  poolIdentityComplete: boolean;
+  stage: GitHubEgressStage;
+  sourceAction: ReturnType<typeof githubEgressSourceAction>;
+  claimGeneration: number | null;
+  firstRepeat: "first" | "repeat" | "unknown";
+  descriptor: ReturnType<typeof githubEgressCommandDescriptor>;
+  complete: boolean;
+};
+
+const SAFE_RATE_LIMIT_RESOURCES = new Set(["core", "graphql", "search", "integration_manifest"]);
+const CONFIG_KEYS = [
+  "CLAWSWEEPER_GH_RETRY_ATTEMPTS",
+  "EXACT_REVIEW_BATCH_MAX_ITEMS",
+  "EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY",
+  "EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED",
+] as const;
+const MAX_RATE_LIMIT_INTEGER = 10_000_000_000;
+
+export function observeGitHubDebugStderr(
+  stderr: Buffer,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  nowMs = Date.now(),
+): Buffer {
+  try {
+    const context = githubEgressContext(args, env);
+    const parsed = parseGitHubDebugStderr(stderr, githubEgressAllowedHosts(env));
+    const complete = context.complete && parsed.complete;
+    for (const [index, attempt] of parsed.attempts.entries()) {
+      const routeTemplate = attempt.routeTemplate;
+      const observedAtMs = attempt.receivedAtMs ?? nowMs;
+      const pageBucket =
+        attempt.pageBucket === "none" && parsed.attempts.length > 1
+          ? githubEgressPageBucket(index + 1)
+          : attempt.pageBucket;
+      const operation =
+        routeTemplate === "unknown"
+          ? context.descriptor.operation
+          : githubEgressOperation(routeTemplate);
+      const attemptComplete =
+        complete &&
+        attempt.complete &&
+        attempt.receivedAtMs !== null &&
+        routeTemplate !== "unknown";
+      appendGithubEgressMetric(env, {
+        ...metricBase(context, observedAtMs),
+        operation,
+        method: attempt.method,
+        routeTemplate,
+        pageBucket,
+        unit: "wire_attempt",
+        outcome: wireOutcome(attempt.status, attempt.headers),
+        statusBucket: githubEgressStatusBucket(attempt.status),
+        latencyBucket: githubEgressLatencyBucket(attempt.latencyMs),
+        attempted: true,
+        telemetryComplete: attemptComplete,
+        count: 1,
+      });
+      if (attempt.status === 403 || attempt.status === 429) {
+        appendRateLimitObservation(env, {
+          version: GITHUB_EGRESS_TELEMETRY_VERSION,
+          observedAt: new Date(observedAtMs).toISOString(),
+          deploymentRevision: context.deploymentRevision,
+          configRevision: context.configRevision,
+          poolClass: context.poolClass,
+          poolIdentity: context.poolIdentity,
+          stage: context.stage,
+          sourceAction: context.sourceAction,
+          operation,
+          method: attempt.method,
+          routeTemplate,
+          pageBucket,
+          status: attempt.status,
+          headers: attempt.headers,
+          resetAuthorityCandidate: resetAuthorityCandidate(attempt.headers),
+          telemetryComplete: attemptComplete,
+        });
+      }
+    }
+    const last = parsed.attempts.at(-1);
+    const invocationDescriptor = observedInvocationDescriptor(context, parsed.attempts);
+    appendGithubEgressMetric(env, {
+      ...metricBase(context, nowMs),
+      operation: invocationDescriptor.operation,
+      method: invocationDescriptor.method,
+      routeTemplate: invocationDescriptor.routeTemplate,
+      pageBucket: "none",
+      unit: "invocation",
+      outcome:
+        parsed.attempts.length === 0
+          ? "pre_wire_failure"
+          : wireOutcome(last?.status ?? null, last?.headers ?? emptyRateLimitHeaders()),
+      statusBucket: githubEgressStatusBucket(last?.status ?? null),
+      latencyBucket: "unknown",
+      attempted: parsed.attempts.length > 0,
+      telemetryComplete: complete && parsed.attempts.length > 0 && invocationDescriptor.complete,
+      count: 1,
+    });
+    return parsed.cleanStderr;
+  } catch {
+    // Observation is deliberately fail-open for command behavior. Never put a
+    // raw diagnostic frame back on stderr: it may contain response bodies,
+    // query strings, ETags, URLs, or request identifiers.
+    return conservativeStripGitHubDebug(stderr);
+  }
+}
+
+function observedInvocationDescriptor(
+  context: GitHubEgressContext,
+  attempts: readonly ParsedWireAttempt[],
+): {
+  operation: GitHubEgressMetricV2["operation"];
+  method: GitHubEgressMethod;
+  routeTemplate: GitHubEgressRouteTemplate;
+  complete: boolean;
+} {
+  if (context.descriptor.routeTemplate !== "unknown") {
+    return { ...context.descriptor, complete: context.descriptor.operation !== "other" };
+  }
+  const completeAttempts = attempts.filter((attempt) => attempt.complete);
+  if (completeAttempts.length !== attempts.length || completeAttempts.length === 0) {
+    return { operation: "other", method: "UNKNOWN", routeTemplate: "unknown", complete: false };
+  }
+  const routes = new Set(completeAttempts.map((attempt) => attempt.routeTemplate));
+  const methods = new Set(completeAttempts.map((attempt) => attempt.method));
+  if (routes.size === 1) {
+    const routeTemplate = completeAttempts[0]!.routeTemplate;
+    return {
+      operation: githubEgressOperation(routeTemplate),
+      method: methods.size === 1 ? completeAttempts[0]!.method : "UNKNOWN",
+      routeTemplate,
+      complete: true,
+    };
+  }
+  return { operation: "other", method: "UNKNOWN", routeTemplate: "multiple", complete: true };
+}
+
+export function recordUnobservedGitHubInvocation(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  nowMs = Date.now(),
+): void {
+  try {
+    const context = githubEgressContext(args, env);
+    appendGithubEgressMetric(env, {
+      ...metricBase(context, nowMs),
+      operation: context.descriptor.operation,
+      method: context.descriptor.method,
+      routeTemplate: context.descriptor.routeTemplate,
+      pageBucket: "none",
+      unit: "invocation",
+      outcome: "ambiguous",
+      statusBucket: "none",
+      latencyBucket: "unknown",
+      attempted: true,
+      telemetryComplete: false,
+      count: 1,
+    });
+  } catch {
+    // A missing or unwritable telemetry sink must not affect GitHub egress.
+  }
+}
+
+export function appendLegacyAvoidedGithubEgressMember(options: {
+  env?: NodeJS.ProcessEnv;
+  poolClass: GitHubEgressPoolClass;
+  stage: GitHubEgressStage;
+  sourceAction?: string;
+  operation: GitHubEgressMetricV2["operation"];
+  claimGeneration: number;
+  repeatRevision: boolean;
+  nowMs?: number;
+}): void {
+  recordGithubEgressMember({
+    ...options,
+    attempted: false,
+    outcome: "legacy_avoided",
+  });
+}
+
+export function recordGithubEgressMember(
+  options: {
+    env?: NodeJS.ProcessEnv;
+    poolClass?: GitHubEgressPoolClass;
+    stage?: GitHubEgressStage;
+    sourceAction?: string;
+    operation?: GitHubEgressMetricV2["operation"];
+    claimGeneration?: number;
+    repeatRevision?: boolean;
+    attempted?: boolean;
+    outcome?: GitHubEgressOutcome;
+    nowMs?: number;
+  } = {},
+): void {
+  const env = options.env ?? process.env;
+  const nowMs = options.nowMs ?? Date.now();
+  try {
+    const context = githubEgressContext([], {
+      ...env,
+      ...(options.poolClass ? { CLAWSWEEPER_GITHUB_POOL_CLASS: options.poolClass } : {}),
+      ...(options.stage ? { CLAWSWEEPER_GITHUB_STAGE: options.stage } : {}),
+      ...(options.sourceAction !== undefined
+        ? { CLAWSWEEPER_GITHUB_SOURCE_ACTION: options.sourceAction }
+        : {}),
+      ...(options.claimGeneration
+        ? { CLAWSWEEPER_GITHUB_CLAIM_GENERATION: String(options.claimGeneration) }
+        : {}),
+      ...(typeof options.repeatRevision === "boolean"
+        ? { CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(options.repeatRevision) }
+        : {}),
+    });
+    const operation = options.operation ?? "other";
+    appendGithubEgressMetric(env, {
+      ...metricBase(context, nowMs),
+      operation,
+      method: "UNKNOWN",
+      routeTemplate: operation === "artifact_download" ? "actions_run_artifacts" : "unknown",
+      pageBucket: "none",
+      unit: "member",
+      outcome: options.outcome ?? "attempted",
+      statusBucket: "none",
+      latencyBucket: "unknown",
+      attempted: options.attempted ?? true,
+      telemetryComplete:
+        context.poolClass !== "other" &&
+        context.poolIdentityComplete &&
+        context.stage !== "unknown" &&
+        context.sourceAction !== "unknown" &&
+        context.claimGeneration !== null &&
+        context.firstRepeat !== "unknown",
+      count: 1,
+    });
+  } catch {
+    // Observation remains fail-open.
+  }
+}
+
+export function parseGitHubDebugStderr(
+  stderr: Buffer,
+  allowedHosts: ReadonlySet<string> = new Set(["api.github.com", "github.com"]),
+): {
+  cleanStderr: Buffer;
+  attempts: ParsedWireAttempt[];
+  complete: boolean;
+} {
+  const text = stderr.toString("latin1");
+  const attempts: ParsedWireAttempt[] = [];
+  const clean: string[] = [];
+  let cursor = 0;
+  let complete = true;
+  const startPattern = /^\* Request at [^\r\n]*(?:\r?\n|$)/gm;
+  while (true) {
+    startPattern.lastIndex = cursor;
+    const start = startPattern.exec(text);
+    if (!start) {
+      clean.push(text.slice(cursor));
+      break;
+    }
+    clean.push(text.slice(cursor, start.index));
+    const endPattern = /^\* Request (?:took|failed after) [^\r\n]*(?:\r?\n|$)/gm;
+    endPattern.lastIndex = start.index + start[0].length;
+    const end = endPattern.exec(text);
+    if (!end) {
+      complete = false;
+      // Never forward a partial diagnostic block: it can contain response
+      // bodies, query strings, ETags, or request identifiers.
+      cursor = text.length;
+      break;
+    }
+    const blockEnd = end.index + end[0].length;
+    attempts.push(parseDebugBlock(text.slice(start.index, blockEnd), allowedHosts));
+    cursor = blockEnd;
+  }
+  return {
+    cleanStderr: Buffer.from(clean.join(""), "latin1"),
+    attempts,
+    complete,
+  };
+}
+
+function conservativeStripGitHubDebug(stderr: Buffer): Buffer {
+  const text = stderr.toString("latin1");
+  const first = text.search(/^\* Request at [^\r\n]*(?:\r?\n|$)/m);
+  return first < 0 ? stderr : Buffer.from(text.slice(0, first), "latin1");
+}
+
+function parseDebugBlock(block: string, allowedHosts: ReadonlySet<string>): ParsedWireAttempt {
+  const request = /^> (GET|POST|PATCH|PUT|DELETE|HEAD) ([^\s]+) HTTP\/[^\r\n]+$/m.exec(block);
+  const response = /^< HTTP\/[^\s]+ (\d{3})(?:\s|$)/m.exec(block);
+  const requestTo = /^\* Request to (\S+)$/m.exec(block)?.[1] || "";
+  const method = request?.[1] as GitHubEgressMethod | undefined;
+  const requestTarget = request?.[2] || "";
+  let routeTemplate: GitHubEgressRouteTemplate = "unknown";
+  let page: number | null = null;
+  try {
+    const url = new URL(requestTarget, requestTo || "https://api.github.invalid");
+    const host = url.hostname.toLowerCase();
+    if (allowedHosts.has(host)) {
+      routeTemplate = githubEgressRouteTemplate(url.pathname);
+    } else if (host.endsWith(".blob.core.windows.net")) {
+      routeTemplate = "external_artifact_blob";
+    }
+    const rawPage = url.searchParams.get("page");
+    page = rawPage && /^\d+$/.test(rawPage) ? Number(rawPage) : null;
+  } catch {
+    routeTemplate = "unknown";
+  }
+  const status = response ? Number(response[1]) : null;
+  const latencyMs = parseLatency(block);
+  const requestedAt = /^\* Request at ([^\r\n]+)$/m.exec(block)?.[1]?.trim() || "";
+  const requestedAtMs = Date.parse(requestedAt.replace(/\s+m=[+-][^\s]+$/, ""));
+  const receivedAtMs =
+    Number.isFinite(requestedAtMs) && latencyMs !== null ? requestedAtMs + latencyMs : null;
+  const headers = responseHeaders(block);
+  return {
+    method: method && GITHUB_EGRESS_METHODS.includes(method) ? method : "UNKNOWN",
+    routeTemplate,
+    pageBucket: githubEgressPageBucket(page),
+    status: Number.isSafeInteger(status) ? status : null,
+    latencyMs,
+    receivedAtMs,
+    headers,
+    complete: Boolean(
+      request && response && method && routeTemplate !== "unknown" && receivedAtMs !== null,
+    ),
+  };
+}
+
+function githubEgressAllowedHosts(env: NodeJS.ProcessEnv): ReadonlySet<string> {
+  const hosts = new Set(["api.github.com", "github.com"]);
+  const configured = String(env.GH_HOST || "").trim();
+  if (configured) {
+    try {
+      hosts.add(new URL(`https://${configured}`).hostname.toLowerCase());
+    } catch {
+      // An invalid GH_HOST cannot expand the safe parser boundary.
+    }
+  }
+  return hosts;
+}
+
+function responseHeaders(block: string): GitHubRateLimitHeadersV2 {
+  const values = new Map<string, string>();
+  for (const match of block.matchAll(/^< ([^:\r\n]+):\s*([^\r\n]*)$/gm)) {
+    values.set(String(match[1]).toLowerCase(), String(match[2]).trim());
+  }
+  const numeric = (name: string) => boundedIntegerHeader(values.get(name));
+  const retryAfter = numeric("retry-after");
+  const limit = numeric("x-ratelimit-limit");
+  const remaining = numeric("x-ratelimit-remaining");
+  const used = numeric("x-ratelimit-used");
+  const reset = numeric("x-ratelimit-reset");
+  const rawResource = values.get("x-ratelimit-resource");
+  const resource = rawResource
+    ? SAFE_RATE_LIMIT_RESOURCES.has(rawResource.toLowerCase())
+      ? (rawResource.toLowerCase() as NonNullable<GitHubRateLimitHeadersV2["resource"]>)
+      : "unknown"
+    : null;
+  return {
+    retryAfterPresent: values.has("retry-after"),
+    retryAfterSeconds: retryAfter,
+    limitPresent: values.has("x-ratelimit-limit"),
+    limit,
+    remainingPresent: values.has("x-ratelimit-remaining"),
+    remaining,
+    usedPresent: values.has("x-ratelimit-used"),
+    used,
+    resetPresent: values.has("x-ratelimit-reset"),
+    resetEpochSeconds: reset,
+    resourcePresent: values.has("x-ratelimit-resource"),
+    resource,
+  };
+}
+
+function githubEgressContext(args: readonly string[], env: NodeJS.ProcessEnv): GitHubEgressContext {
+  const rawPool = String(env.CLAWSWEEPER_GITHUB_POOL_CLASS || "");
+  const poolClass = GITHUB_EGRESS_POOL_CLASSES.includes(rawPool as GitHubEgressPoolClass)
+    ? (rawPool as GitHubEgressPoolClass)
+    : "other";
+  const rawStage = String(env.CLAWSWEEPER_GITHUB_STAGE || "");
+  const stage = GITHUB_EGRESS_STAGES.includes(rawStage as GitHubEgressStage)
+    ? (rawStage as GitHubEgressStage)
+    : "unknown";
+  const claimGenerationText =
+    env.CLAWSWEEPER_GITHUB_CLAIM_GENERATION ||
+    env.EXACT_REVIEW_BATCH_CLAIM_GENERATION ||
+    env.EXACT_REVIEW_CLAIM_GENERATION ||
+    "";
+  const claimGeneration = /^\d+$/.test(claimGenerationText) ? Number(claimGenerationText) : null;
+  const repeat = env.CLAWSWEEPER_GITHUB_REQUEST_REPEAT;
+  const firstRepeat = repeat === "true" ? "repeat" : repeat === "false" ? "first" : "unknown";
+  const deploymentSource =
+    env.CLAWSWEEPER_DEPLOYMENT_REVISION || env.GITHUB_SHA || "unknown-deployment";
+  const deploymentRevision = digest(`deployment:v1:${deploymentSource}`, 16);
+  const configRevision = digest(
+    JSON.stringify({
+      version: 1,
+      values: Object.fromEntries(CONFIG_KEYS.map((key) => [key, env[key] || ""])),
+    }),
+    16,
+  );
+  const targetOwner = /^([A-Za-z0-9_.-]+)\/[A-Za-z0-9_.-]+$/.exec(
+    String(env.TARGET_REPO || ""),
+  )?.[1];
+  const repository = String(env.GITHUB_REPOSITORY || "").toLowerCase();
+  const poolIdentityComplete =
+    poolClass === "target_app"
+      ? Boolean(targetOwner)
+      : poolClass === "repository_actions" || poolClass === "public_read_fallback"
+        ? /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(repository)
+        : false;
+  const poolSource =
+    poolClass === "target_app"
+      ? `target_app:${targetOwner?.toLowerCase() || "unknown"}`
+      : poolClass === "repository_actions" || poolClass === "public_read_fallback"
+        ? `repository_actions:${repository || "unknown"}`
+        : "other";
+  const descriptor = githubEgressCommandDescriptor(args);
+  return {
+    deploymentRevision,
+    configRevision,
+    poolClass,
+    poolIdentity: digest(`pool:v1:${poolSource}`, 24),
+    poolIdentityComplete,
+    stage,
+    sourceAction: githubEgressSourceAction(env.CLAWSWEEPER_GITHUB_SOURCE_ACTION),
+    claimGeneration,
+    firstRepeat,
+    descriptor,
+    complete:
+      poolClass !== "other" &&
+      poolIdentityComplete &&
+      stage !== "unknown" &&
+      githubEgressSourceAction(env.CLAWSWEEPER_GITHUB_SOURCE_ACTION) !== "unknown" &&
+      firstRepeat !== "unknown" &&
+      claimGeneration !== null &&
+      githubEgressClaimGenerationBucket(claimGeneration) !== "unknown",
+  };
+}
+
+function metricBase(context: GitHubEgressContext, nowMs: number) {
+  return {
+    version: GITHUB_EGRESS_TELEMETRY_VERSION,
+    bucketStart: githubEgressFiveMinuteBucket(nowMs),
+    deploymentRevision: context.deploymentRevision,
+    configRevision: context.configRevision,
+    poolClass: context.poolClass,
+    poolIdentity: context.poolIdentity,
+    stage: context.stage,
+    sourceAction: context.sourceAction,
+    claimGenerationBucket: githubEgressClaimGenerationBucket(context.claimGeneration),
+    firstRepeat: context.firstRepeat,
+  } as const;
+}
+
+function appendGithubEgressMetric(env: NodeJS.ProcessEnv, metric: GitHubEgressMetricV2): void {
+  const path = githubEgressMetricsPath(env);
+  if (!path) return;
+  appendJsonLine(path, metric);
+}
+
+function appendRateLimitObservation(
+  env: NodeJS.ProcessEnv,
+  observation: GitHubRateLimitObservationV2,
+): void {
+  const path = env.CLAWSWEEPER_GITHUB_RATE_LIMIT_DETAILS_PATH?.trim();
+  if (!path) return;
+  appendJsonLine(path, observation);
+}
+
+function appendJsonLine(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function githubEgressMetricsPath(env: NodeJS.ProcessEnv): string | null {
+  return env.CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH?.trim() || null;
+}
+
+function wireOutcome(
+  status: number | null,
+  headers: GitHubRateLimitHeadersV2,
+): GitHubEgressOutcome {
+  if (status === null) return "ambiguous";
+  if (
+    status === 429 ||
+    (status === 403 && (headers.remaining === 0 || headers.retryAfterPresent))
+  ) {
+    return "throttle";
+  }
+  if (status >= 200 && status < 400) return "success";
+  if (status >= 500) return "transient";
+  return "error";
+}
+
+function resetAuthorityCandidate(
+  headers: GitHubRateLimitHeadersV2,
+): GitHubRateLimitObservationV2["resetAuthorityCandidate"] {
+  if (headers.retryAfterPresent) {
+    return headers.retryAfterSeconds === null ? "invalid" : "retry_after";
+  }
+  if (headers.resetPresent) {
+    return headers.resetEpochSeconds === null ? "invalid" : "rate_limit_reset";
+  }
+  return "absent";
+}
+
+function boundedIntegerHeader(value: string | undefined): number | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= MAX_RATE_LIMIT_INTEGER
+    ? parsed
+    : null;
+}
+
+function parseLatency(block: string): number | null {
+  const match = /^\* Request took ([\d.]+)(Â?µs|ms|s)$/m.exec(block);
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value < 0) return null;
+  if (match[2]?.endsWith("µs")) return value / 1_000;
+  if (match[2] === "s") return value * 1_000;
+  return value;
+}
+
+function emptyRateLimitHeaders(): GitHubRateLimitHeadersV2 {
+  return {
+    retryAfterPresent: false,
+    retryAfterSeconds: null,
+    limitPresent: false,
+    limit: null,
+    remainingPresent: false,
+    remaining: null,
+    usedPresent: false,
+    used: null,
+    resetPresent: false,
+    resetEpochSeconds: null,
+    resourcePresent: false,
+    resource: null,
+  };
+}
+
+function digest(value: string, length: number): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, length);
+}

--- a/src/github-egress-telemetry-contract.ts
+++ b/src/github-egress-telemetry-contract.ts
@@ -1,0 +1,284 @@
+export const GITHUB_EGRESS_TELEMETRY_VERSION = 2 as const;
+
+export const GITHUB_EGRESS_POOL_CLASSES = [
+  "repository_actions",
+  "target_app",
+  "public_read_fallback",
+  "other",
+] as const;
+export type GitHubEgressPoolClass = (typeof GITHUB_EGRESS_POOL_CLASSES)[number];
+
+export const GITHUB_EGRESS_STAGES = [
+  "publication_prepare",
+  "publication_apply",
+  "publication_router",
+  "publication_recovery",
+  "unknown",
+] as const;
+export type GitHubEgressStage = (typeof GITHUB_EGRESS_STAGES)[number];
+
+export const GITHUB_EGRESS_SOURCE_ACTIONS = [
+  "exact_event",
+  "command",
+  "scheduled_hot",
+  "scheduled_normal",
+  "repair",
+  "publication_retry",
+  "unknown",
+] as const;
+export type GitHubEgressSourceAction = (typeof GITHUB_EGRESS_SOURCE_ACTIONS)[number];
+
+export const GITHUB_EGRESS_OPERATIONS = [
+  "artifact_download",
+  "item_metadata",
+  "comments",
+  "reviews",
+  "labels",
+  "reactions",
+  "checks",
+  "contents",
+  "authorization",
+  "graphql",
+  "workflow_dispatch",
+  "rate_status",
+  "other",
+] as const;
+export type GitHubEgressOperation = (typeof GITHUB_EGRESS_OPERATIONS)[number];
+
+export const GITHUB_EGRESS_METHODS = [
+  "GET",
+  "POST",
+  "PATCH",
+  "PUT",
+  "DELETE",
+  "HEAD",
+  "UNKNOWN",
+] as const;
+export type GitHubEgressMethod = (typeof GITHUB_EGRESS_METHODS)[number];
+
+export const GITHUB_EGRESS_ROUTE_TEMPLATES = [
+  "actions_artifact_archive",
+  "actions_runs",
+  "actions_run_artifacts",
+  "actions_workflow_dispatch",
+  "authenticated_user",
+  "collaborator_permission",
+  "commit_check_runs",
+  "commit_metadata",
+  "commit_pulls",
+  "commit_status",
+  "commits_collection",
+  "external_artifact_blob",
+  "graphql",
+  "issue_comments",
+  "issue_comment",
+  "issue_labels",
+  "issue_metadata",
+  "issue_reactions",
+  "issue_timeline",
+  "issues_collection",
+  "multiple",
+  "pull_comments",
+  "pull_commits",
+  "pull_files",
+  "pull_metadata",
+  "pull_reviews",
+  "rate_limit",
+  "repository_contents",
+  "repository_labels",
+  "repository_metadata",
+  "search_issues",
+  "unknown",
+] as const;
+export type GitHubEgressRouteTemplate = (typeof GITHUB_EGRESS_ROUTE_TEMPLATES)[number];
+
+export const GITHUB_EGRESS_PAGE_BUCKETS = [
+  "none",
+  "1",
+  "2",
+  "3_5",
+  "6_10",
+  "11_plus",
+  "unknown",
+] as const;
+export type GitHubEgressPageBucket = (typeof GITHUB_EGRESS_PAGE_BUCKETS)[number];
+
+export const GITHUB_EGRESS_UNITS = ["invocation", "wire_attempt", "member"] as const;
+export type GitHubEgressUnit = (typeof GITHUB_EGRESS_UNITS)[number];
+
+export const GITHUB_EGRESS_OUTCOMES = [
+  "attempted",
+  "success",
+  "throttle",
+  "transient",
+  "error",
+  "ambiguous",
+  "pre_wire_failure",
+  "legacy_avoided",
+] as const;
+export type GitHubEgressOutcome = (typeof GITHUB_EGRESS_OUTCOMES)[number];
+
+export const GITHUB_EGRESS_STATUS_BUCKETS = [
+  "none",
+  "2xx",
+  "3xx",
+  "403",
+  "429",
+  "4xx_other",
+  "5xx",
+  "other",
+] as const;
+export type GitHubEgressStatusBucket = (typeof GITHUB_EGRESS_STATUS_BUCKETS)[number];
+
+export const GITHUB_EGRESS_LATENCY_BUCKETS = [
+  "unknown",
+  "lt_100ms",
+  "100_249ms",
+  "250_499ms",
+  "500_999ms",
+  "1_2s",
+  "2_5s",
+  "5s_plus",
+] as const;
+export type GitHubEgressLatencyBucket = (typeof GITHUB_EGRESS_LATENCY_BUCKETS)[number];
+
+export const GITHUB_EGRESS_CLAIM_GENERATION_BUCKETS = [
+  "none",
+  "1",
+  "2",
+  "3_5",
+  "6_10",
+  "11_32",
+  "33_plus",
+  "unknown",
+] as const;
+export type GitHubEgressClaimGenerationBucket =
+  (typeof GITHUB_EGRESS_CLAIM_GENERATION_BUCKETS)[number];
+
+export type GitHubEgressMetricV2 = {
+  version: typeof GITHUB_EGRESS_TELEMETRY_VERSION;
+  bucketStart: string;
+  deploymentRevision: string;
+  configRevision: string;
+  poolClass: GitHubEgressPoolClass;
+  poolIdentity: string;
+  stage: GitHubEgressStage;
+  sourceAction: GitHubEgressSourceAction;
+  operation: GitHubEgressOperation;
+  method: GitHubEgressMethod;
+  routeTemplate: GitHubEgressRouteTemplate;
+  pageBucket: GitHubEgressPageBucket;
+  unit: GitHubEgressUnit;
+  outcome: GitHubEgressOutcome;
+  statusBucket: GitHubEgressStatusBucket;
+  latencyBucket: GitHubEgressLatencyBucket;
+  claimGenerationBucket: GitHubEgressClaimGenerationBucket;
+  firstRepeat: "first" | "repeat" | "unknown";
+  attempted: boolean;
+  telemetryComplete: boolean;
+  count: number;
+};
+
+export type GitHubRateLimitHeadersV2 = {
+  retryAfterPresent: boolean;
+  retryAfterSeconds: number | null;
+  limitPresent: boolean;
+  limit: number | null;
+  remainingPresent: boolean;
+  remaining: number | null;
+  usedPresent: boolean;
+  used: number | null;
+  resetPresent: boolean;
+  resetEpochSeconds: number | null;
+  resourcePresent: boolean;
+  resource: "core" | "graphql" | "search" | "integration_manifest" | "unknown" | null;
+};
+
+export type GitHubRateLimitObservationV2 = {
+  version: typeof GITHUB_EGRESS_TELEMETRY_VERSION;
+  observedAt: string;
+  deploymentRevision: string;
+  configRevision: string;
+  poolClass: GitHubEgressPoolClass;
+  poolIdentity: string;
+  stage: GitHubEgressStage;
+  sourceAction: GitHubEgressSourceAction;
+  operation: GitHubEgressOperation;
+  method: GitHubEgressMethod;
+  routeTemplate: GitHubEgressRouteTemplate;
+  pageBucket: GitHubEgressPageBucket;
+  status: 403 | 429;
+  headers: GitHubRateLimitHeadersV2;
+  resetAuthorityCandidate: "retry_after" | "rate_limit_reset" | "absent" | "invalid";
+  telemetryComplete: boolean;
+};
+
+export function githubEgressSourceAction(value: string | undefined): GitHubEgressSourceAction {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "scheduled_hot_intake") return "scheduled_hot";
+  if (normalized === "scheduled_normal_backfill") return "scheduled_normal";
+  if (
+    normalized === "failed_review_shard_recovery" ||
+    normalized.includes("repair") ||
+    normalized.includes("recovery")
+  ) {
+    return "repair";
+  }
+  if (normalized === "source_drift_requeue" || normalized === "exact_review_artifact_publish") {
+    return "publication_retry";
+  }
+  if (normalized.includes("command") || normalized.includes("comment")) return "command";
+  if (normalized) return "exact_event";
+  return "unknown";
+}
+
+export function githubEgressPageBucket(value: number | null): GitHubEgressPageBucket {
+  if (value === null) return "none";
+  if (!Number.isSafeInteger(value) || value < 1) return "unknown";
+  if (value === 1) return "1";
+  if (value === 2) return "2";
+  if (value <= 5) return "3_5";
+  if (value <= 10) return "6_10";
+  return "11_plus";
+}
+
+export function githubEgressClaimGenerationBucket(
+  value: number | null,
+): GitHubEgressClaimGenerationBucket {
+  if (value === null) return "none";
+  if (!Number.isSafeInteger(value) || value < 1) return "unknown";
+  if (value === 1) return "1";
+  if (value === 2) return "2";
+  if (value <= 5) return "3_5";
+  if (value <= 10) return "6_10";
+  if (value <= 32) return "11_32";
+  return "33_plus";
+}
+
+export function githubEgressStatusBucket(status: number | null): GitHubEgressStatusBucket {
+  if (status === null) return "none";
+  if (status >= 200 && status < 300) return "2xx";
+  if (status >= 300 && status < 400) return "3xx";
+  if (status === 403) return "403";
+  if (status === 429) return "429";
+  if (status >= 400 && status < 500) return "4xx_other";
+  if (status >= 500 && status < 600) return "5xx";
+  return "other";
+}
+
+export function githubEgressLatencyBucket(milliseconds: number | null): GitHubEgressLatencyBucket {
+  if (milliseconds === null || !Number.isFinite(milliseconds) || milliseconds < 0) return "unknown";
+  if (milliseconds < 100) return "lt_100ms";
+  if (milliseconds < 250) return "100_249ms";
+  if (milliseconds < 500) return "250_499ms";
+  if (milliseconds < 1_000) return "500_999ms";
+  if (milliseconds < 2_000) return "1_2s";
+  if (milliseconds < 5_000) return "2_5s";
+  return "5s_plus";
+}
+
+export function githubEgressFiveMinuteBucket(timestampMs: number): string {
+  return new Date(Math.floor(timestampMs / 300_000) * 300_000).toISOString();
+}

--- a/src/repair/github-egress-telemetry-cli.ts
+++ b/src/repair/github-egress-telemetry-cli.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { join } from "node:path";
+import {
+  githubEgressTelemetrySubmissions,
+  submitGitHubEgressTelemetry,
+} from "./github-egress-telemetry-client.js";
+
+if (process.argv[2] !== "submit") {
+  throw new Error("usage: github-egress-telemetry-cli.ts submit");
+}
+
+const root = process.env.GITHUB_WORKSPACE || process.cwd();
+const metricsPath =
+  process.env.CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH ||
+  join(root, ".artifacts/github-egress/metrics-v2.jsonl");
+const rateLimitPath =
+  process.env.CLAWSWEEPER_GITHUB_RATE_LIMIT_DETAILS_PATH ||
+  join(root, ".artifacts/github-egress/rate-limits-v2.jsonl");
+const submissions = githubEgressTelemetrySubmissions({ metricsPath, rateLimitPath });
+let accepted = 0;
+let deduped = 0;
+for (const submission of submissions) {
+  const result = await submitGitHubEgressTelemetry({
+    baseUrl: env("EXACT_REVIEW_QUEUE_URL"),
+    webhookSecret: env("CLAWSWEEPER_WEBHOOK_SECRET"),
+    submission,
+  });
+  if (result.accepted) accepted += 1;
+  if (result.deduped) deduped += 1;
+}
+console.log(JSON.stringify({ ok: true, submissions: submissions.length, accepted, deduped }));
+
+function env(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/src/repair/github-egress-telemetry-client.ts
+++ b/src/repair/github-egress-telemetry-client.ts
@@ -1,0 +1,471 @@
+import { createHash, createHmac } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import {
+  GITHUB_EGRESS_CLAIM_GENERATION_BUCKETS,
+  GITHUB_EGRESS_LATENCY_BUCKETS,
+  GITHUB_EGRESS_METHODS,
+  GITHUB_EGRESS_OPERATIONS,
+  GITHUB_EGRESS_OUTCOMES,
+  GITHUB_EGRESS_PAGE_BUCKETS,
+  GITHUB_EGRESS_POOL_CLASSES,
+  GITHUB_EGRESS_ROUTE_TEMPLATES,
+  GITHUB_EGRESS_SOURCE_ACTIONS,
+  GITHUB_EGRESS_STAGES,
+  GITHUB_EGRESS_STATUS_BUCKETS,
+  GITHUB_EGRESS_TELEMETRY_VERSION,
+  GITHUB_EGRESS_UNITS,
+  githubEgressFiveMinuteBucket,
+  type GitHubEgressMetricV2,
+  type GitHubRateLimitObservationV2,
+} from "../github-egress-telemetry-contract.js";
+
+const MAX_METRICS_PER_SUBMISSION = 128;
+const MAX_RATE_LIMITS_PER_SUBMISSION = 16;
+const MAX_INPUT_LINES = 2_000;
+const MAX_COUNT = 1_000_000;
+const MAX_RATE_LIMIT_INTEGER = 10_000_000_000;
+
+export type GitHubEgressTelemetrySubmission = {
+  receiptId: string;
+  metrics: GitHubEgressMetricV2[];
+  rateLimitObservations: GitHubRateLimitObservationV2[];
+};
+
+export function githubEgressTelemetrySubmissions(options: {
+  metricsPath: string;
+  rateLimitPath: string;
+  receiptScope?: string;
+}): GitHubEgressTelemetrySubmission[] {
+  const metricInput = readJsonLines(options.metricsPath);
+  const rateLimitInput = readJsonLines(options.rateLimitPath);
+  const metricResult = aggregateMetrics(metricInput.values);
+  const metrics = metricResult.metrics;
+  const rateLimitObservations: GitHubRateLimitObservationV2[] = [];
+  let invalidRateLimits = 0;
+  for (const value of rateLimitInput.values) {
+    const observation = githubRateLimitObservation(value);
+    if (observation) rateLimitObservations.push(observation);
+    else invalidRateLimits += 1;
+  }
+  const invalid =
+    metricInput.invalid + metricResult.invalid + rateLimitInput.invalid + invalidRateLimits;
+  if (invalid > 0) {
+    const exemplar = metrics[0] ?? incompleteMetric();
+    metrics.push({
+      ...exemplar,
+      operation: "other",
+      method: "UNKNOWN",
+      routeTemplate: "unknown",
+      pageBucket: "unknown",
+      unit: "invocation",
+      outcome: "ambiguous",
+      statusBucket: "none",
+      latencyBucket: "unknown",
+      attempted: false,
+      telemetryComplete: false,
+      count: Math.min(MAX_COUNT, invalid),
+    });
+  }
+  const submissions: GitHubEgressTelemetrySubmission[] = [];
+  const receiptScope =
+    options.receiptScope ||
+    [
+      process.env.GITHUB_RUN_ID || "local",
+      process.env.GITHUB_RUN_ATTEMPT || "1",
+      process.env.GITHUB_JOB || "unknown-job",
+      createHash("sha256")
+        .update(`${options.metricsPath}\0${options.rateLimitPath}`)
+        .digest("hex")
+        .slice(0, 16),
+    ].join(":");
+  const chunks = Math.max(
+    Math.ceil(metrics.length / MAX_METRICS_PER_SUBMISSION),
+    Math.ceil(rateLimitObservations.length / MAX_RATE_LIMITS_PER_SUBMISSION),
+  );
+  for (let index = 0; index < chunks; index += 1) {
+    const metricChunk = metrics.slice(
+      index * MAX_METRICS_PER_SUBMISSION,
+      (index + 1) * MAX_METRICS_PER_SUBMISSION,
+    );
+    const rateChunk = rateLimitObservations.slice(
+      index * MAX_RATE_LIMITS_PER_SUBMISSION,
+      (index + 1) * MAX_RATE_LIMITS_PER_SUBMISSION,
+    );
+    const body = JSON.stringify({
+      version: 2,
+      metrics: metricChunk,
+      rateLimitObservations: rateChunk,
+    });
+    submissions.push({
+      receiptId: createHash("sha256")
+        .update(`github-egress-v2:${receiptScope}:${index}:${body}`)
+        .digest("hex"),
+      metrics: metricChunk,
+      rateLimitObservations: rateChunk,
+    });
+  }
+  return submissions;
+}
+
+export async function submitGitHubEgressTelemetry(options: {
+  baseUrl: string;
+  webhookSecret: string;
+  submission: GitHubEgressTelemetrySubmission;
+  fetch?: typeof globalThis.fetch;
+}): Promise<{ accepted: boolean; deduped: boolean }> {
+  const baseUrl = options.baseUrl.replace(/\/$/, "");
+  if (!baseUrl.startsWith("https://"))
+    throw new Error("GitHub egress telemetry URL must use HTTPS");
+  if (!options.webhookSecret) throw new Error("GitHub egress telemetry secret is required");
+  const body = JSON.stringify({
+    version: GITHUB_EGRESS_TELEMETRY_VERSION,
+    receipt_id: options.submission.receiptId,
+    metrics: options.submission.metrics.map(metricPayload),
+    rate_limit_observations: options.submission.rateLimitObservations.map(rateLimitPayload),
+  });
+  const signature = `sha256=${createHmac("sha256", options.webhookSecret).update(body).digest("hex")}`;
+  const response = await (options.fetch ?? globalThis.fetch)(
+    `${baseUrl}/internal/exact-review/github-egress-telemetry`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-clawsweeper-exact-review-signature": signature,
+      },
+      body,
+      signal: AbortSignal.timeout(20_000),
+    },
+  );
+  const text = await response.text();
+  let result: Record<string, unknown>;
+  try {
+    result = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new Error(`GitHub egress telemetry returned invalid JSON (HTTP ${response.status})`);
+  }
+  if (!response.ok || result.ok !== true) {
+    throw new Error(
+      `GitHub egress telemetry failed (HTTP ${response.status}): ${String(result.error || "unknown")}`,
+    );
+  }
+  return { accepted: result.accepted === true, deduped: result.deduped === true };
+}
+
+function readJsonLines(path: string): { values: unknown[]; invalid: number } {
+  if (!existsSync(path)) return { values: [], invalid: 0 };
+  const lines = readFileSync(path, "utf8").split(/\r?\n/);
+  const values: unknown[] = [];
+  let invalid = 0;
+  for (const line of lines.slice(0, MAX_INPUT_LINES)) {
+    if (!line.trim()) continue;
+    try {
+      values.push(JSON.parse(line));
+    } catch {
+      invalid += 1;
+    }
+  }
+  if (lines.length > MAX_INPUT_LINES) invalid += lines.length - MAX_INPUT_LINES;
+  return { values, invalid };
+}
+
+function aggregateMetrics(values: readonly unknown[]): {
+  metrics: GitHubEgressMetricV2[];
+  invalid: number;
+} {
+  const metrics = new Map<string, GitHubEgressMetricV2>();
+  let invalid = 0;
+  for (const value of values) {
+    const metric = githubEgressMetric(value);
+    if (!metric) {
+      invalid += 1;
+      continue;
+    }
+    const key = JSON.stringify({ ...metric, count: 0 });
+    const prior = metrics.get(key);
+    metrics.set(key, { ...metric, count: Math.min(MAX_COUNT, (prior?.count || 0) + metric.count) });
+  }
+  return { metrics: [...metrics.values()], invalid };
+}
+
+function incompleteMetric(nowMs = Date.now()): GitHubEgressMetricV2 {
+  const digest = (value: string, length: number) =>
+    createHash("sha256").update(value).digest("hex").slice(0, length);
+  return {
+    version: GITHUB_EGRESS_TELEMETRY_VERSION,
+    bucketStart: githubEgressFiveMinuteBucket(nowMs),
+    deploymentRevision: digest(
+      `deployment:v1:${process.env.CLAWSWEEPER_DEPLOYMENT_REVISION || process.env.GITHUB_SHA || "unknown"}`,
+      16,
+    ),
+    configRevision: digest("config:v1:invalid-input", 16),
+    poolClass: "other",
+    poolIdentity: digest("pool:v1:other", 24),
+    stage: "unknown",
+    sourceAction: "unknown",
+    operation: "other",
+    method: "UNKNOWN",
+    routeTemplate: "unknown",
+    pageBucket: "unknown",
+    unit: "invocation",
+    outcome: "ambiguous",
+    statusBucket: "none",
+    latencyBucket: "unknown",
+    claimGenerationBucket: "unknown",
+    firstRepeat: "unknown",
+    attempted: false,
+    telemetryComplete: false,
+    count: 1,
+  };
+}
+
+function githubEgressMetric(value: unknown): GitHubEgressMetricV2 | null {
+  const item = objectValue(value);
+  if (!item || item.version !== GITHUB_EGRESS_TELEMETRY_VERSION) return null;
+  const bucketStart = safeTimestamp(item.bucketStart);
+  const deploymentRevision = safeDigest(item.deploymentRevision, 16);
+  const configRevision = safeDigest(item.configRevision, 16);
+  const poolIdentity = safeDigest(item.poolIdentity, 24);
+  const count = Number(item.count);
+  if (
+    !bucketStart ||
+    !deploymentRevision ||
+    !configRevision ||
+    !poolIdentity ||
+    !member(GITHUB_EGRESS_POOL_CLASSES, item.poolClass) ||
+    !member(GITHUB_EGRESS_STAGES, item.stage) ||
+    !member(GITHUB_EGRESS_SOURCE_ACTIONS, item.sourceAction) ||
+    !member(GITHUB_EGRESS_OPERATIONS, item.operation) ||
+    !member(GITHUB_EGRESS_METHODS, item.method) ||
+    !member(GITHUB_EGRESS_ROUTE_TEMPLATES, item.routeTemplate) ||
+    !member(GITHUB_EGRESS_PAGE_BUCKETS, item.pageBucket) ||
+    !member(GITHUB_EGRESS_UNITS, item.unit) ||
+    !member(GITHUB_EGRESS_OUTCOMES, item.outcome) ||
+    !member(GITHUB_EGRESS_STATUS_BUCKETS, item.statusBucket) ||
+    !member(GITHUB_EGRESS_LATENCY_BUCKETS, item.latencyBucket) ||
+    !member(GITHUB_EGRESS_CLAIM_GENERATION_BUCKETS, item.claimGenerationBucket) ||
+    !member(["first", "repeat", "unknown"] as const, item.firstRepeat) ||
+    typeof item.attempted !== "boolean" ||
+    typeof item.telemetryComplete !== "boolean" ||
+    !Number.isSafeInteger(count) ||
+    count < 1 ||
+    count > MAX_COUNT
+  ) {
+    return null;
+  }
+  return {
+    version: GITHUB_EGRESS_TELEMETRY_VERSION,
+    bucketStart,
+    deploymentRevision,
+    configRevision,
+    poolClass: item.poolClass,
+    poolIdentity,
+    stage: item.stage,
+    sourceAction: item.sourceAction,
+    operation: item.operation,
+    method: item.method,
+    routeTemplate: item.routeTemplate,
+    pageBucket: item.pageBucket,
+    unit: item.unit,
+    outcome: item.outcome,
+    statusBucket: item.statusBucket,
+    latencyBucket: item.latencyBucket,
+    claimGenerationBucket: item.claimGenerationBucket,
+    firstRepeat: item.firstRepeat,
+    attempted: item.attempted,
+    telemetryComplete: item.telemetryComplete,
+    count,
+  };
+}
+
+function githubRateLimitObservation(value: unknown): GitHubRateLimitObservationV2 | null {
+  const item = objectValue(value);
+  const headers = objectValue(item?.headers);
+  if (!item || !headers || item.version !== GITHUB_EGRESS_TELEMETRY_VERSION) return null;
+  const observedAt = safeTimestamp(item.observedAt);
+  const deploymentRevision = safeDigest(item.deploymentRevision, 16);
+  const configRevision = safeDigest(item.configRevision, 16);
+  const poolIdentity = safeDigest(item.poolIdentity, 24);
+  if (
+    !observedAt ||
+    !deploymentRevision ||
+    !configRevision ||
+    !poolIdentity ||
+    !member(GITHUB_EGRESS_POOL_CLASSES, item.poolClass) ||
+    !member(GITHUB_EGRESS_STAGES, item.stage) ||
+    !member(GITHUB_EGRESS_SOURCE_ACTIONS, item.sourceAction) ||
+    !member(GITHUB_EGRESS_OPERATIONS, item.operation) ||
+    !member(GITHUB_EGRESS_METHODS, item.method) ||
+    !member(GITHUB_EGRESS_ROUTE_TEMPLATES, item.routeTemplate) ||
+    !member(GITHUB_EGRESS_PAGE_BUCKETS, item.pageBucket) ||
+    (item.status !== 403 && item.status !== 429) ||
+    !member(
+      ["retry_after", "rate_limit_reset", "absent", "invalid"] as const,
+      item.resetAuthorityCandidate,
+    ) ||
+    typeof item.telemetryComplete !== "boolean"
+  ) {
+    return null;
+  }
+  const parsedHeaders = rateLimitHeaders(headers);
+  if (!parsedHeaders) return null;
+  if (item.resetAuthorityCandidate !== resetAuthorityCandidate(parsedHeaders)) return null;
+  return {
+    version: GITHUB_EGRESS_TELEMETRY_VERSION,
+    observedAt,
+    deploymentRevision,
+    configRevision,
+    poolClass: item.poolClass,
+    poolIdentity,
+    stage: item.stage,
+    sourceAction: item.sourceAction,
+    operation: item.operation,
+    method: item.method,
+    routeTemplate: item.routeTemplate,
+    pageBucket: item.pageBucket,
+    status: item.status,
+    headers: parsedHeaders,
+    resetAuthorityCandidate: item.resetAuthorityCandidate,
+    telemetryComplete: item.telemetryComplete,
+  };
+}
+
+function rateLimitHeaders(
+  value: Record<string, unknown>,
+): GitHubRateLimitObservationV2["headers"] | null {
+  const numeric = (name: string) => {
+    const candidate = value[name];
+    return candidate === null ||
+      (Number.isSafeInteger(candidate) &&
+        Number(candidate) >= 0 &&
+        Number(candidate) <= MAX_RATE_LIMIT_INTEGER)
+      ? (candidate as number | null)
+      : undefined;
+  };
+  const retryAfterSeconds = numeric("retryAfterSeconds");
+  const limit = numeric("limit");
+  const remaining = numeric("remaining");
+  const used = numeric("used");
+  const resetEpochSeconds = numeric("resetEpochSeconds");
+  const resource = value.resource;
+  if (
+    [
+      "retryAfterPresent",
+      "limitPresent",
+      "remainingPresent",
+      "usedPresent",
+      "resetPresent",
+      "resourcePresent",
+    ].some((name) => typeof value[name] !== "boolean") ||
+    [retryAfterSeconds, limit, remaining, used, resetEpochSeconds].includes(undefined) ||
+    !(
+      resource === null ||
+      member(["core", "graphql", "search", "integration_manifest", "unknown"] as const, resource)
+    )
+  ) {
+    return null;
+  }
+  if (
+    (!value.retryAfterPresent && retryAfterSeconds !== null) ||
+    (!value.limitPresent && limit !== null) ||
+    (!value.remainingPresent && remaining !== null) ||
+    (!value.usedPresent && used !== null) ||
+    (!value.resetPresent && resetEpochSeconds !== null) ||
+    (!value.resourcePresent && resource !== null) ||
+    (value.resourcePresent && resource === null)
+  ) {
+    return null;
+  }
+  return {
+    retryAfterPresent: value.retryAfterPresent as boolean,
+    retryAfterSeconds: retryAfterSeconds!,
+    limitPresent: value.limitPresent as boolean,
+    limit: limit!,
+    remainingPresent: value.remainingPresent as boolean,
+    remaining: remaining!,
+    usedPresent: value.usedPresent as boolean,
+    used: used!,
+    resetPresent: value.resetPresent as boolean,
+    resetEpochSeconds: resetEpochSeconds!,
+    resourcePresent: value.resourcePresent as boolean,
+    resource: resource as GitHubRateLimitObservationV2["headers"]["resource"],
+  };
+}
+
+function resetAuthorityCandidate(
+  headers: GitHubRateLimitObservationV2["headers"],
+): GitHubRateLimitObservationV2["resetAuthorityCandidate"] {
+  if (headers.retryAfterPresent) {
+    return headers.retryAfterSeconds === null ? "invalid" : "retry_after";
+  }
+  if (headers.resetPresent) {
+    return headers.resetEpochSeconds === null ? "invalid" : "rate_limit_reset";
+  }
+  return "absent";
+}
+
+function metricPayload(metric: GitHubEgressMetricV2) {
+  return {
+    bucket_start: metric.bucketStart,
+    deployment_revision: metric.deploymentRevision,
+    config_revision: metric.configRevision,
+    pool_class: metric.poolClass,
+    pool_identity: metric.poolIdentity,
+    stage: metric.stage,
+    source_action: metric.sourceAction,
+    operation: metric.operation,
+    method: metric.method,
+    route_template: metric.routeTemplate,
+    page_bucket: metric.pageBucket,
+    unit: metric.unit,
+    outcome: metric.outcome,
+    status_bucket: metric.statusBucket,
+    latency_bucket: metric.latencyBucket,
+    claim_generation_bucket: metric.claimGenerationBucket,
+    first_repeat: metric.firstRepeat,
+    attempted: metric.attempted,
+    telemetry_complete: metric.telemetryComplete,
+    count: metric.count,
+  };
+}
+
+function rateLimitPayload(observation: GitHubRateLimitObservationV2) {
+  return {
+    observed_at: observation.observedAt,
+    deployment_revision: observation.deploymentRevision,
+    config_revision: observation.configRevision,
+    pool_class: observation.poolClass,
+    pool_identity: observation.poolIdentity,
+    stage: observation.stage,
+    source_action: observation.sourceAction,
+    operation: observation.operation,
+    method: observation.method,
+    route_template: observation.routeTemplate,
+    page_bucket: observation.pageBucket,
+    status: observation.status,
+    headers: observation.headers,
+    reset_authority_candidate: observation.resetAuthorityCandidate,
+    telemetry_complete: observation.telemetryComplete,
+  };
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function safeTimestamp(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function safeDigest(value: unknown, length: number): string | null {
+  return typeof value === "string" && new RegExp(`^[0-9a-f]{${length}}$`).test(value)
+    ? value
+    : null;
+}
+
+function member<const T extends readonly string[]>(values: T, value: unknown): value is T[number] {
+  return typeof value === "string" && (values as readonly string[]).includes(value);
+}

--- a/src/repair/github-egress-telemetry-client.ts
+++ b/src/repair/github-egress-telemetry-client.ts
@@ -66,6 +66,7 @@ export function githubEgressTelemetrySubmissions(options: {
       count: Math.min(MAX_COUNT, invalid),
     });
   }
+  if (metrics.length === 0) metrics.push(incompleteMetric("missing-input"));
   const submissions: GitHubEgressTelemetrySubmission[] = [];
   const receiptScope =
     options.receiptScope ||
@@ -187,7 +188,7 @@ function aggregateMetrics(values: readonly unknown[]): {
   return { metrics: [...metrics.values()], invalid };
 }
 
-function incompleteMetric(nowMs = Date.now()): GitHubEgressMetricV2 {
+function incompleteMetric(reason = "invalid-input", nowMs = Date.now()): GitHubEgressMetricV2 {
   const digest = (value: string, length: number) =>
     createHash("sha256").update(value).digest("hex").slice(0, length);
   return {
@@ -197,7 +198,7 @@ function incompleteMetric(nowMs = Date.now()): GitHubEgressMetricV2 {
       `deployment:v1:${process.env.CLAWSWEEPER_DEPLOYMENT_REVISION || process.env.GITHUB_SHA || "unknown"}`,
       16,
     ),
-    configRevision: digest("config:v1:invalid-input", 16),
+    configRevision: digest(`config:v1:${reason}`, 16),
     poolClass: "other",
     poolIdentity: digest("pool:v1:other", 24),
     stage: "unknown",

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -2896,6 +2896,7 @@ test("a newer exact-review enqueue revokes a claimed immutable decision", async 
     item_key: "openclaw/openclaw#620",
     lease_revision: 1,
     claim_generation: 1,
+    repeat_revision: false,
     decision: item.leaseDecision,
   });
 

--- a/test/github-egress-telemetry.test.ts
+++ b/test/github-egress-telemetry.test.ts
@@ -1,0 +1,602 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import YAML from "yaml";
+
+import { GithubEgressTelemetryStore } from "../dashboard/github-egress-telemetry.ts";
+import { createGitHubRuntime } from "../dist/clawsweeper-github-runtime.js";
+import {
+  githubEgressCommandDescriptor,
+  githubEgressRouteTemplate,
+} from "../dist/github-egress-descriptor.js";
+import {
+  observeGitHubDebugStderr,
+  recordGithubEgressMember,
+  recordUnobservedGitHubInvocation,
+} from "../dist/github-egress-observer.js";
+import {
+  githubEgressTelemetrySubmissions,
+  submitGitHubEgressTelemetry,
+} from "../dist/repair/github-egress-telemetry-client.js";
+import { MemoryDurableStorage } from "./dashboard-worker-harness.ts";
+
+const NOW = Date.parse("2026-08-12T12:00:00.000Z");
+
+test("GH_DEBUG observation counts paginated wire attempts and strips unsafe diagnostics", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-egress-observer-"));
+  try {
+    const metricsPath = join(root, "metrics.jsonl");
+    const rateLimitPath = join(root, "rate-limits.jsonl");
+    const env = observerEnv(metricsPath, rateLimitPath);
+    const stderr = Buffer.from(
+      [
+        "ordinary warning before",
+        debugFrame({ page: null, status: 200, at: "2026-08-12T11:59:58.000Z m=+0.000001" }),
+        debugFrame({ page: 2, status: 200, at: "2026-08-12T11:59:58.100Z" }),
+        debugFrame({
+          page: 3,
+          status: 403,
+          at: "2026-08-12T11:59:58.200Z",
+          duration: "900µs",
+        }),
+        "ordinary warning after",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const clean = observeGitHubDebugStderr(
+      stderr,
+      ["api", "repos/private-owner/private-repo/issues/991/comments", "--paginate"],
+      env,
+      NOW,
+    );
+    assert.equal(clean.toString("utf8"), "ordinary warning before\nordinary warning after\n");
+
+    const metrics = jsonLines(metricsPath);
+    const wire = metrics.filter((metric) => metric.unit === "wire_attempt");
+    assert.equal(wire.length, 3);
+    assert.deepEqual(
+      wire.map((metric) => metric.pageBucket),
+      ["1", "2", "3_5"],
+    );
+    assert.ok(wire.every((metric) => metric.poolClass === "repository_actions"));
+    assert.ok(wire.every((metric) => metric.operation === "comments"));
+    assert.ok(wire.every((metric) => metric.method === "GET"));
+    assert.ok(wire.every((metric) => metric.firstRepeat === "first"));
+    assert.ok(wire.every((metric) => metric.claimGenerationBucket === "2"));
+    assert.ok(wire.every((metric) => metric.telemetryComplete === true));
+    assert.equal(metrics.filter((metric) => metric.unit === "invocation").length, 1);
+
+    const observations = jsonLines(rateLimitPath);
+    assert.equal(observations.length, 1);
+    assert.equal(observations[0]?.status, 403);
+    assert.equal(observations[0]?.pageBucket, "3_5");
+    assert.equal(observations[0]?.resetAuthorityCandidate, "rate_limit_reset");
+    assert.deepEqual(observations[0]?.headers, {
+      retryAfterPresent: false,
+      retryAfterSeconds: null,
+      limitPresent: true,
+      limit: 5_000,
+      remainingPresent: true,
+      remaining: 0,
+      usedPresent: true,
+      used: 5_000,
+      resetPresent: true,
+      resetEpochSeconds: 1_786_533_900,
+      resourcePresent: true,
+      resource: "core",
+    });
+    const persisted = `${readFileSync(metricsPath, "utf8")}\n${readFileSync(rateLimitPath, "utf8")}`;
+    for (const sentinel of [
+      "private-owner",
+      "private-repo",
+      "991",
+      "cursor-secret",
+      "etag-secret",
+      "request-id-secret",
+      "body-secret",
+    ]) {
+      assert.equal(persisted.includes(sentinel), false, sentinel);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unsafe or unavailable wire parsing fails open with incomplete bounded metrics", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-egress-incomplete-"));
+  try {
+    const metricsPath = join(root, "metrics.jsonl");
+    const env = observerEnv(metricsPath, join(root, "rate.jsonl"));
+    const partial = Buffer.from(
+      "prefix preserved\n* Request at 2026-08-12T11:00:00Z\n* Request to https://api.github.com/repos/raw/secret\n> GET /repos/raw/secret?cursor=cursor-secret HTTP/1.1\nbody-secret",
+    );
+    assert.equal(
+      observeGitHubDebugStderr(partial, ["api", "repos/raw/secret"], env, NOW).toString(),
+      "prefix preserved\n",
+    );
+    const incomplete = jsonLines(metricsPath);
+    assert.equal(incomplete.length, 1);
+    assert.equal(incomplete[0]?.unit, "invocation");
+    assert.equal(incomplete[0]?.attempted, false);
+    assert.equal(incomplete[0]?.telemetryComplete, false);
+
+    recordUnobservedGitHubInvocation(["run", "download", "123", "--repo", "raw/secret"], env, NOW);
+    recordGithubEgressMember({ env, nowMs: NOW });
+    const recorded = jsonLines(metricsPath);
+    assert.equal(recorded[1]?.operation, "artifact_download");
+    assert.equal(recorded[1]?.unit, "invocation");
+    assert.equal(recorded[1]?.telemetryComplete, false);
+    assert.equal(recorded[2]?.unit, "member");
+    assert.equal(recorded[2]?.firstRepeat, "first");
+    assert.equal(recorded[2]?.telemetryComplete, true);
+    assert.equal(readFileSync(metricsPath, "utf8").includes("raw/secret"), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("descriptor exposes only closed method, operation, and route dimensions", () => {
+  assert.deepEqual(
+    githubEgressCommandDescriptor([
+      "api",
+      "repos/o/r/issues/4/comments?per_page=100&cursor=secret",
+      "--paginate",
+    ]),
+    { operation: "comments", method: "GET", routeTemplate: "issue_comments", wireSafe: true },
+  );
+  assert.deepEqual(githubEgressCommandDescriptor(["workflow", "run", "repair.yml"]), {
+    operation: "workflow_dispatch",
+    method: "POST",
+    routeTemplate: "actions_workflow_dispatch",
+    wireSafe: true,
+  });
+  assert.equal(githubEgressCommandDescriptor(["run", "download", "1"]).wireSafe, false);
+  assert.equal(githubEgressRouteTemplate("/repos/o/r/unknown/raw/path"), "unknown");
+  assert.deepEqual(
+    [
+      ["/graphql", "graphql"],
+      ["/user", "authenticated_user"],
+      ["/search/issues?q=private", "search_issues"],
+      ["/repos/o/r/issues", "issues_collection"],
+      ["/repos/o/r/issues/4/timeline", "issue_timeline"],
+      ["/repos/o/r/pulls/4/comments", "pull_comments"],
+      ["/repos/o/r/pulls/4/files", "pull_files"],
+      ["/repos/o/r/pulls/4/commits", "pull_commits"],
+      ["/repos/o/r/labels/name", "repository_labels"],
+      ["/repos/o/r/collaborators/person/permission", "collaborator_permission"],
+      ["/repos/o/r/contents/private/path", "repository_contents"],
+      ["/repos/o/r/commits", "commits_collection"],
+      ["/repos/o/r/commits/secret", "commit_metadata"],
+      ["/repos/o/r/commits/secret/status", "commit_status"],
+      ["/repos/o/r/commits/secret/check-runs", "commit_check_runs"],
+      ["/repos/o/r/commits/secret/pulls", "commit_pulls"],
+      ["/repos/o/r/actions/runs", "actions_runs"],
+    ].map(([route, expected]) => [githubEgressRouteTemplate(route!), expected]),
+    [
+      ["graphql", "graphql"],
+      ["authenticated_user", "authenticated_user"],
+      ["search_issues", "search_issues"],
+      ["issues_collection", "issues_collection"],
+      ["issue_timeline", "issue_timeline"],
+      ["pull_comments", "pull_comments"],
+      ["pull_files", "pull_files"],
+      ["pull_commits", "pull_commits"],
+      ["repository_labels", "repository_labels"],
+      ["collaborator_permission", "collaborator_permission"],
+      ["repository_contents", "repository_contents"],
+      ["commits_collection", "commits_collection"],
+      ["commit_metadata", "commit_metadata"],
+      ["commit_status", "commit_status"],
+      ["commit_check_runs", "commit_check_runs"],
+      ["commit_pulls", "commit_pulls"],
+      ["actions_runs", "actions_runs"],
+    ],
+  );
+});
+
+test("wire evidence completes high-level gh invocations without leaking their arguments", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-egress-high-level-"));
+  try {
+    const metricsPath = join(root, "metrics.jsonl");
+    const env = observerEnv(metricsPath, join(root, "rate.jsonl"));
+    observeGitHubDebugStderr(
+      Buffer.from(
+        debugFrame({
+          page: null,
+          status: 200,
+          at: "2026-08-12T11:59:58.000Z",
+          route: "/repos/private-owner/private-repo/issues/991",
+          method: "PATCH",
+        }),
+      ),
+      ["issue", "edit", "991", "--add-label", "private-label"],
+      env,
+      NOW,
+    );
+    const invocation = jsonLines(metricsPath).find((metric) => metric.unit === "invocation");
+    assert.deepEqual(
+      {
+        operation: invocation?.operation,
+        method: invocation?.method,
+        routeTemplate: invocation?.routeTemplate,
+        telemetryComplete: invocation?.telemetryComplete,
+      },
+      {
+        operation: "item_metadata",
+        method: "PATCH",
+        routeTemplate: "issue_metadata",
+        telemetryComplete: true,
+      },
+    );
+    assert.equal(readFileSync(metricsPath, "utf8").includes("private-label"), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runtime attribution follows the selected credential instead of throttle text", () => {
+  const keys = [
+    "CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH",
+    "CLAWSWEEPER_GITHUB_STAGE",
+    "CLAWSWEEPER_GITHUB_SOURCE_ACTION",
+    "CLAWSWEEPER_GITHUB_CLAIM_GENERATION",
+    "CLAWSWEEPER_GITHUB_REQUEST_REPEAT",
+    "CLAWSWEEPER_PUBLIC_GH_TOKEN",
+    "GH_TOKEN",
+    "REPO_TOKEN",
+    "GITHUB_REPOSITORY",
+  ];
+  const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  Object.assign(process.env, {
+    CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH: "metrics.jsonl",
+    CLAWSWEEPER_GITHUB_STAGE: "publication_apply",
+    CLAWSWEEPER_GITHUB_SOURCE_ACTION: "scheduled_hot_intake",
+    CLAWSWEEPER_GITHUB_CLAIM_GENERATION: "2",
+    CLAWSWEEPER_GITHUB_REQUEST_REPEAT: "true",
+    CLAWSWEEPER_PUBLIC_GH_TOKEN: "public-actions-token",
+    GH_TOKEN: "target-app-token",
+    REPO_TOKEN: "repository-actions-token",
+    GITHUB_REPOSITORY: "openclaw/clawsweeper",
+  });
+  const requests: Array<{ token: string; pool: string }> = [];
+  const runtime = createGitHubRuntime({
+    ROOT: process.cwd(),
+    targetRepo: () => "openclaw/openclaw",
+    run: (_command, _args, options) => {
+      requests.push({
+        token: String(options?.env?.GH_TOKEN || process.env.GH_TOKEN || ""),
+        pool: String(options?.env?.CLAWSWEEPER_GITHUB_POOL_CLASS || ""),
+      });
+      return "{}";
+    },
+  });
+  try {
+    runtime.ghWithPreparedTimeout(["api", "repos/openclaw/openclaw/issues/1"], 1_000);
+    runtime.ghWithPreparedTimeout(
+      ["api", "repos/openclaw/openclaw/issues/1", "--method", "PATCH"],
+      1_000,
+    );
+    runtime.ghWithPreparedTimeout(["api", "repos/openclaw/openclaw/issues/1"], 1_000, {
+      GH_TOKEN: "repository-actions-token",
+    });
+    assert.deepEqual(requests, [
+      { token: "public-actions-token", pool: "public_read_fallback" },
+      { token: "target-app-token", pool: "target_app" },
+      { token: "repository-actions-token", pool: "repository_actions" },
+    ]);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("publication workflows retain v1 metrics while wiring bounded v2 observation and upload", () => {
+  const batchSource = readFileSync(".github/workflows/exact-review-batch-publish.yml", "utf8");
+  const sweepSource = readFileSync(".github/workflows/sweep.yml", "utf8");
+  const batch = YAML.parse(batchSource) as {
+    jobs: { publish: { env: Record<string, string>; steps: Array<Record<string, unknown>> } };
+  };
+  const sweep = YAML.parse(sweepSource) as {
+    jobs: Record<string, { steps: Array<Record<string, unknown>> }>;
+  };
+  assert.ok(batch.jobs.publish.env.CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH);
+  assert.ok(batch.jobs.publish.env.CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH);
+  const batchSteps = batch.jobs.publish.steps;
+  assertStepOrder(batchSteps, [
+    "./.github/actions/setup-github-egress-observer",
+    "Prepare each item independently",
+    "Finalize healthy members under a fenced heartbeat",
+    "Submit batch GitHub egress telemetry",
+    "Release unfinished batch members",
+  ]);
+  assert.match(batchSource, /CLAWSWEEPER_GITHUB_POOL_CLASS=repository_actions/);
+  assert.match(batchSource, /CLAWSWEEPER_GITHUB_STAGE=publication_router/);
+  assert.equal(
+    batchSteps.find((step) => step.id === "github-egress-observer")?.["continue-on-error"],
+    true,
+  );
+
+  const direct = sweep.jobs["event-review-apply"]!.steps;
+  assertStepOrder(direct, [
+    "./.github/actions/setup-github-egress-observer",
+    "Record direct-publication member",
+    "Deliver GitHub effects and prepare direct state mutation",
+    "Finalize direct exact review lifecycle",
+    "Submit direct GitHub egress telemetry",
+    "Fail unsuccessful exact review generation",
+  ]);
+  assert.equal(
+    direct.find((step) => step.id === "direct-github-egress-observer")?.["continue-on-error"],
+    true,
+  );
+  assert.equal(
+    direct.find((step) => step.name === "Record direct-publication member")?.["continue-on-error"],
+    true,
+  );
+  assert.equal(
+    direct.find((step) => step.name === "Record direct-publication member")?.env?.TARGET_REPO,
+    "${{ steps.target.outputs.target_repo }}",
+  );
+  const artifact = sweep.jobs["event-review-publish"]!.steps;
+  assertStepOrder(artifact, [
+    "./.github/actions/setup-github-egress-observer",
+    "Record artifact-publication member",
+    "Download exact review artifact bundle",
+    "Record artifact download transport boundary",
+    "Publish event result and apply safe close",
+    "Queue deferred exact verdict router",
+    "Submit artifact-publication GitHub egress telemetry",
+    "Fail unsuccessful exact review publication",
+  ]);
+  assert.equal(
+    artifact.find((step) => step.id === "artifact-github-egress-observer")?.["continue-on-error"],
+    true,
+  );
+  assert.equal(
+    artifact.find((step) => step.name === "Record artifact-publication member")?.env?.TARGET_REPO,
+    "${{ steps.publication-context.outputs.target_repo }}",
+  );
+  assert.match(sweepSource, /CLAWSWEEPER_GITHUB_POOL_CLASS: repository_actions/);
+  assert.match(sweepSource, /CLAWSWEEPER_GITHUB_STAGE: publication_router/);
+  assert.match(
+    sweepSource,
+    /repeat_revision=\$\{responseProtocol === 2 \? repeatRevision : false\}/,
+  );
+});
+
+test("signed upload, SQLite restart, retention, cardinality, and public privacy are bounded", async () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-egress-upload-"));
+  try {
+    const metricsPath = join(root, "metrics.jsonl");
+    const rateLimitPath = join(root, "rate.jsonl");
+    const env = observerEnv(metricsPath, rateLimitPath);
+    recordGithubEgressMember({ env, nowMs: NOW });
+    recordUnobservedGitHubInvocation(["run", "download", "123"], env, NOW);
+    writeFileSync(metricsPath, '{"raw_repo":"private-owner/private-repo"}\nnot-json\n', {
+      flag: "a",
+    });
+    const submissions = githubEgressTelemetrySubmissions({
+      metricsPath,
+      rateLimitPath,
+      receiptScope: "test-run:1:test-job",
+    });
+    assert.equal(submissions.length, 1);
+    assert.ok(submissions[0]?.metrics.some((metric) => metric.telemetryComplete === false));
+    assert.equal(JSON.stringify(submissions).includes("private-owner"), false);
+    const otherRun = githubEgressTelemetrySubmissions({
+      metricsPath,
+      rateLimitPath,
+      receiptScope: "test-run:2:test-job",
+    });
+    assert.notEqual(otherRun[0]?.receiptId, submissions[0]?.receiptId);
+
+    const storage = new MemoryDurableStorage();
+    const store = new GithubEgressTelemetryStore(storage);
+    store.ensureSchemaSync();
+    assert.deepEqual(store.publicSummary(NOW).completeness, {
+      complete: 0,
+      incomplete: 0,
+      observed: false,
+      telemetry_complete: false,
+    });
+    let signature = "";
+    const fakeFetch: typeof fetch = async (_input, init) => {
+      signature = new Headers(init?.headers).get("x-clawsweeper-exact-review-signature") || "";
+      const result = store.ingest(JSON.parse(String(init?.body)), NOW);
+      return Response.json(result.ok ? { ok: true, ...result } : { error: result.error }, {
+        status: result.ok ? 202 : 400,
+      });
+    };
+    const first = await submitGitHubEgressTelemetry({
+      baseUrl: "https://clawsweeper.invalid",
+      webhookSecret: "test-secret",
+      submission: submissions[0]!,
+      fetch: fakeFetch,
+    });
+    assert.deepEqual(first, { accepted: true, deduped: false });
+    assert.match(signature, /^sha256=[0-9a-f]{64}$/);
+    const duplicate = await submitGitHubEgressTelemetry({
+      baseUrl: "https://clawsweeper.invalid",
+      webhookSecret: "test-secret",
+      submission: submissions[0]!,
+      fetch: fakeFetch,
+    });
+    assert.deepEqual(duplicate, { accepted: false, deduped: true });
+
+    const restarted = new GithubEgressTelemetryStore(storage);
+    restarted.ensureSchemaSync();
+    const publicView = restarted.publicObservability(6, NOW);
+    assert.ok(publicView);
+    assert.equal(publicView!.completeness.telemetry_complete, false);
+    assert.equal(publicView!.completeness.rows_truncated, false);
+    assert.equal(publicView!.completeness.rate_limit_rows_truncated, false);
+    assert.equal(publicView!.completeness.query_complete, true);
+    assert.deepEqual(publicView!.units, {
+      invocation: 3,
+      wire_attempt: 0,
+      member: 1,
+    });
+    assert.equal(publicView!.privacy.pool_identity, "withheld");
+    const serialized = JSON.stringify(publicView);
+    for (const sentinel of [
+      "private-owner",
+      "private-repo",
+      "pool:v1",
+      "item_key",
+      "branch",
+      "cursor",
+      "etag",
+      "request_id",
+    ]) {
+      assert.equal(serialized.includes(sentinel), false, sentinel);
+    }
+
+    const windowStorage = new MemoryDurableStorage();
+    const windowStore = new GithubEgressTelemetryStore(windowStorage);
+    windowStore.ensureSchemaSync();
+    const twoHoursAgo = NOW - 2 * 60 * 60 * 1_000;
+    assert.equal(
+      windowStore.ingest(telemetryBody("9".repeat(64), twoHoursAgo), twoHoursAgo).ok,
+      true,
+    );
+    assert.equal(windowStore.publicObservability(1, NOW)?.completeness.observed, false);
+    assert.equal(windowStore.publicObservability(6, NOW)?.completeness.observed, true);
+
+    const future = NOW + 8 * 24 * 60 * 60 * 1_000;
+    const futureBody = telemetryBody("f".repeat(64), future);
+    assert.equal(restarted.ingest(futureBody, future).ok, true);
+    const fiveMinuteRows = Array.from(
+      storage.sql.exec(
+        "SELECT bucket_start FROM exact_review_github_egress_rollups_v2 WHERE bucket_kind = 'five_minute' ORDER BY bucket_start",
+      ),
+    );
+    const hourlyRows = Array.from(
+      storage.sql.exec(
+        "SELECT bucket_start FROM exact_review_github_egress_rollups_v2 WHERE bucket_kind = 'hour' ORDER BY bucket_start",
+      ),
+    );
+    assert.deepEqual(
+      fiveMinuteRows.map((row) => row.bucket_start),
+      [future],
+    );
+    assert.equal(hourlyRows.length >= 2, true);
+
+    const invalidRoute = telemetryBody("e".repeat(64), future);
+    invalidRoute.metrics[0]!.route_template = "repos/raw/private";
+    assert.deepEqual(restarted.ingest(invalidRoute, future), {
+      ok: false,
+      error: "invalid_github_egress_telemetry",
+    });
+    const oversized = telemetryBody("d".repeat(64), future);
+    oversized.metrics = Array.from({ length: 129 }, () => structuredClone(oversized.metrics[0]!));
+    assert.equal(restarted.ingest(oversized, future).ok, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function observerEnv(metricsPath: string, rateLimitPath: string): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_GITHUB_EGRESS_METRICS_PATH: metricsPath,
+    CLAWSWEEPER_GITHUB_RATE_LIMIT_DETAILS_PATH: rateLimitPath,
+    CLAWSWEEPER_GITHUB_POOL_CLASS: "repository_actions",
+    CLAWSWEEPER_GITHUB_STAGE: "publication_prepare",
+    CLAWSWEEPER_GITHUB_SOURCE_ACTION: "scheduled_hot_intake",
+    CLAWSWEEPER_GITHUB_CLAIM_GENERATION: "2",
+    CLAWSWEEPER_GITHUB_REQUEST_REPEAT: "false",
+    CLAWSWEEPER_DEPLOYMENT_REVISION: "a".repeat(40),
+    GITHUB_REPOSITORY: "openclaw/clawsweeper",
+    EXACT_REVIEW_BATCH_MAX_ITEMS: "50",
+    EXACT_REVIEW_BATCH_PREPARE_CONCURRENCY: "1",
+  };
+}
+
+function debugFrame(options: {
+  page: number | null;
+  status: number;
+  at: string;
+  route?: string;
+  method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+  duration?: string;
+}) {
+  const route = options.route ?? "/repos/private-owner/private-repo/issues/991/comments";
+  const method = options.method ?? "GET";
+  const query =
+    options.page === null ? "?per_page=100&cursor=cursor-secret" : `?page=${options.page}`;
+  return [
+    `* Request at ${options.at}`,
+    `* Request to https://api.github.com${route}${query}`,
+    `> ${method} ${route}${query} HTTP/1.1`,
+    "> X-GitHub-Api-Version: 2022-11-28",
+    "< HTTP/2.0 " + options.status,
+    "< Etag: etag-secret",
+    "< X-Github-Request-Id: request-id-secret",
+    "< X-Ratelimit-Limit: 5000",
+    `< X-Ratelimit-Remaining: ${options.status === 403 ? 0 : 10}`,
+    `< X-Ratelimit-Used: ${options.status === 403 ? 5000 : 4990}`,
+    "< X-Ratelimit-Reset: 1786533900",
+    "< X-Ratelimit-Resource: core",
+    "body-secret",
+    `* Request took ${options.duration ?? "20ms"}`,
+  ].join("\n");
+}
+
+function jsonLines(path: string): Array<Record<string, unknown>> {
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function telemetryBody(receiptId: string, now: number) {
+  const bucket = new Date(Math.floor(now / 300_000) * 300_000).toISOString();
+  return {
+    version: 2,
+    receipt_id: receiptId,
+    metrics: [
+      {
+        bucket_start: bucket,
+        deployment_revision: "a".repeat(16),
+        config_revision: "b".repeat(16),
+        pool_class: "repository_actions",
+        pool_identity: "c".repeat(24),
+        stage: "publication_apply",
+        source_action: "scheduled_hot",
+        operation: "comments",
+        method: "GET",
+        route_template: "issue_comments",
+        page_bucket: "1",
+        unit: "wire_attempt",
+        outcome: "success",
+        status_bucket: "2xx",
+        latency_bucket: "100_249ms",
+        claim_generation_bucket: "1",
+        first_repeat: "first",
+        attempted: true,
+        telemetry_complete: true,
+        count: 1,
+      },
+    ],
+    rate_limit_observations: [],
+  };
+}
+
+function assertStepOrder(steps: Array<Record<string, unknown>>, labels: string[]) {
+  const indexes = labels.map((label) => {
+    const index = steps.findIndex((step) => step.name === label || step.uses === label);
+    assert.notEqual(index, -1, label);
+    return index;
+  });
+  for (let index = 1; index < indexes.length; index += 1) {
+    assert.ok(
+      indexes[index - 1]! < indexes[index]!,
+      `${labels[index - 1]} before ${labels[index]}`,
+    );
+  }
+}

--- a/test/github-egress-telemetry.test.ts
+++ b/test/github-egress-telemetry.test.ts
@@ -468,6 +468,26 @@ test("signed upload, SQLite restart, retention, cardinality, and public privacy 
     assert.equal(windowStore.publicObservability(1, NOW)?.completeness.observed, false);
     assert.equal(windowStore.publicObservability(6, NOW)?.completeness.observed, true);
 
+    const unalignedNow = NOW + 2 * 60 * 1_000;
+    const firstPartialBucket = unalignedNow - 60 * 60 * 1_000 + 30 * 1_000;
+    assert.equal(
+      windowStore.ingest(telemetryBody("8".repeat(64), firstPartialBucket), firstPartialBucket).ok,
+      true,
+    );
+    const oneHourView = windowStore.publicObservability(1, unalignedNow);
+    assert.equal(oneHourView?.completeness.observed, true);
+    assert.equal(oneHourView?.units.wire_attempt, 1);
+
+    const unalignedDayNow = NOW + 30 * 60 * 1_000;
+    const firstPartialHour = unalignedDayNow - 24 * 60 * 60 * 1_000 + 5 * 60 * 1_000;
+    assert.equal(
+      windowStore.ingest(telemetryBody("7".repeat(64), firstPartialHour), firstPartialHour).ok,
+      true,
+    );
+    const oneDayView = windowStore.publicObservability(24, unalignedDayNow);
+    assert.equal(oneDayView?.completeness.observed, true);
+    assert.equal(oneDayView?.units.wire_attempt, 3);
+
     const future = NOW + 8 * 24 * 60 * 60 * 1_000;
     const futureBody = telemetryBody("f".repeat(64), future);
     assert.equal(restarted.ingest(futureBody, future).ok, true);

--- a/test/github-egress-telemetry.test.ts
+++ b/test/github-egress-telemetry.test.ts
@@ -396,6 +396,31 @@ test("signed upload, SQLite restart, retention, cardinality, and public privacy 
     });
     assert.notEqual(otherRun[0]?.receiptId, submissions[0]?.receiptId);
 
+    const emptySink = githubEgressTelemetrySubmissions({
+      metricsPath: join(root, "missing-metrics.jsonl"),
+      rateLimitPath: join(root, "missing-rate-limits.jsonl"),
+      receiptScope: "test-run:3:missing-sink",
+    });
+    assert.equal(emptySink.length, 1);
+    assert.deepEqual(
+      emptySink[0]?.metrics.map((metric) => ({
+        unit: metric.unit,
+        attempted: metric.attempted,
+        outcome: metric.outcome,
+        telemetryComplete: metric.telemetryComplete,
+        count: metric.count,
+      })),
+      [
+        {
+          unit: "invocation",
+          attempted: false,
+          outcome: "ambiguous",
+          telemetryComplete: false,
+          count: 1,
+        },
+      ],
+    );
+
     const storage = new MemoryDurableStorage();
     const store = new GithubEgressTelemetryStore(storage);
     store.ensureSchemaSync();

--- a/tsconfig.repair.json
+++ b/tsconfig.repair.json
@@ -21,6 +21,9 @@
     "src/codex-output-capture.ts",
     "src/codex-spawn.ts",
     "src/codex-app-server-worker.ts",
-    "src/codex-process-worker.ts"
+    "src/codex-process-worker.ts",
+    "src/github-egress-descriptor.ts",
+    "src/github-egress-observer.ts",
+    "src/github-egress-telemetry-contract.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- add an observe-only GitHub publication-egress seam around the real `gh` transport while retaining the existing v1 request metrics
- attribute bounded v2 member, invocation, wire-attempt, pagination, credential-pool, route, latency, outcome, first/repeat, and reset-header facts
- retain sanitized aggregates in the existing SQLite Durable Object and expose bounded public 1h/6h/24h observability
- document exact semantics, privacy/cardinality/retention bounds, known incomplete boundaries, and the Phase 1 exclusion

Related: CSW-123. This is the separate Phase 0 dependency for the future pool-coordinator work. It intentionally does not implement coordinator bindings, epochs, permits, blocked-until decisions, probes, recovery ramps, or any admission/retry enforcement.

Maintainer authorization: Martin explicitly authorized merging and automatically deploying this separate observe-only Phase 0 telemetry PR on 2026-08-12. Phase 1 remains explicitly out of scope.

## Problem

Existing v1 metrics count logical request classes but cannot reliably distinguish one command from its paginated HTTP attempts, identify the credential pool actually selected, or preserve sanitized reset-authority evidence. That makes six-hour quota diagnosis underdetermined and leaves no trustworthy denominator for Phase 1.

## Implementation

- A fail-open PATH shim observes GitHub CLI debug frames for safe commands and records one wire attempt per real page. Opaque artifact downloads retain an explicit incomplete invocation without fabricating wire counts.
- Call sites declare closed descriptors for pool class, stage, source action, claim generation, and durable-revision first/repeat state. Pool identity is privately fingerprinted from the actual credential boundary; public responses expose only pool class.
- Runtime token selection propagates `repository_actions`, `target_app`, and `public_read_fallback` from the credential actually chosen, never from generic rate-limit prose.
- Only allowlisted method/operation/route/page/status/latency dimensions survive parsing. Raw repositories, owners, items, branches, SHAs, paths, queries, cursors, URLs, request IDs, ETags, bodies, tokens, and installation IDs are rejected or discarded.
- Sanitized 403/429 observations retain header presence, bounded numeric values, receive time, and `retry_after`/`rate_limit_reset`/`absent`/`invalid` candidate provenance. They do not choose a shared reset policy.
- Signed, receipt-deduplicated submissions aggregate into five-minute and hourly SQLite rollups with fixed row caps and retention. Public queries return truncation/completeness flags plus full-window member/invocation/wire-attempt conservation totals.
- Observer, parser, and upload failures remain non-fatal. The command's stdout, ordinary stderr, signals, and exit status are preserved; the byte-preserving fallback also protects existing throttle classification if the rich parser is unavailable. If the uploader finds no readable metric records, it emits one incomplete, unattempted invocation marker without inventing a wire attempt or member.
- Public rollup queries include the complete five-minute or hourly bucket overlapping the lower window boundary; raw rate-limit observations retain the exact cutoff.

`first_repeat` has one exact meaning: `first` when `publicationFailureAttempts == 0` for the claimed durable item revision, and `repeat` when that same revision already has at least one charged publication failure. It is not an HTTP retry, pagination page, batch membership, or claim-generation grouping.

## Validation

Current base: `f0dd69f75573e6ac592d5b8c218bbda245fc2b1a`  
Current head: `41bdd3bd2ad97475ce36d63f975ee4adc03b8a43`

- `pnpm run check:static`
- `pnpm run build:all`
- `pnpm run lint`
- `node --test test/github-egress-telemetry.test.ts` — 7/7
- `node --test --test-name-pattern="exact-review lease competition" test/sweep-workflow.test.ts` — 1/1
- `node --test --test-name-pattern="github egress|exact-review queue" test/dashboard-worker-queue-runtime.test.ts` — 45/45
- Linux container: telemetry, publication-batch, batch CLI/prepare/workflow, and state-writer suites — 113/113
- `git diff --check origin/main...HEAD`
- actionlint on the two touched workflows: no new diagnostic class versus current `origin/main`
- ShellCheck on `scripts/github-egress-observer.sh`: only SC2317 informational reports for trap-invoked functions
- dirty Codex review: accepted and fixed missing target-owner member attribution; final pass clean
- committed Codex review: accepted and fixed parser-failure stderr suppression, unterminated-record handling, partial-window bucket omission, and the empty-sink conservation blind spot; final `codex review --base origin/main` clean
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: `decision=keep_open confidence=high action=kept_open`; local-only, no GitHub mutation

The full native-Windows aggregate suite also reproduces current-main platform noise: hosted-Linux Bash tests cannot find WSL `/bin/bash`, and unrelated concurrent temporary-root cleanup tests can fail with `EPERM`. No platform-policy or unrelated test-harness changes are included; the affected Linux surfaces pass in the container lane above.

## Real Behavior Proof

### Claim

The production observation seam counts real GitHub CLI HTTP pages and attributes the actual selected credential pool without changing command behavior or exposing raw identifiers. Its signed aggregates survive Worker restart, dedupe replayed receipts, and fail open when parsing is unsafe or unavailable.

### Exercised surface

- exact head `41bdd3bd2ad97475ce36d63f975ee4adc03b8a43`
- Docker-backed Crabbox `provider=local-container`, lease `cbx_a8d87f6084a7`, Node 24 Bookworm, exit 0
- GitHub CLI 2.88.1 over an unmocked loopback TLS HTTP server
- production shell shim and built parser/CLI
- real Wrangler 4.107.0 local Worker and SQLite-backed `ExactReviewQueue` Durable Object
- signed upload, restart persistence, receipt replay, public query, and privacy sentinel scan

### Scenario and observed result

The fixture executed repository-Actions, target-App, and public-read-fallback calls; a three-page REST request; a 403 with `Retry-After` and `X-RateLimit-*`; an unknown route; and an opaque artifact download. It then removed the rich parser and repeated a throttled command, including an unterminated ordinary-stderr case, and exercised an absent telemetry sink.

- 18 invocations conserved to 19 observed wire attempts and 1 durable member
- pagination accounted for exactly 3 page attempts
- wire attempts: 17 `repository_actions`, 1 `target_app`, 1 `public_read_fallback`
- exactly 1 sanitized rate-limit observation with authoritative candidate data
- exactly 1 unknown-route wire attempt marked incomplete
- exactly 1 missing-sink incomplete invocation, unattempted and with no invented wire/member count
- stdout, ordinary stderr, and exit status matched direct CLI behavior
- missing-parser fallback preserved throttle text and unterminated stderr while stripping debug frames
- rows and rate-limit observations survived Worker restart
- duplicate receipt was deduplicated
- private/raw sentinels were absent from stored submissions and public output
- median added loopback observer overhead was 38.6 ms across 12 baseline and 12 observed samples (process-launch measurement, not a production latency forecast)
- production mutations: 0; OpenClaw Bay affected: false

Proof package: `docs/proof/github-egress-telemetry/README.md` and `run-proof.sh`. The exact-head run used a fresh clone of the pushed branch because Windows-to-local-container rsync failed before execution with code 12; Crabbox performed no local dirty-tree sync (`syncSkipped=true`) and verified the remote HEAD before running.

### Limits

- Responses are deterministic loopback fixtures; the proof does not consume or deliberately exhaust live GitHub quota.
- `gh run download` remains intentionally opaque because binary redirects cannot be safely parsed from debug output.
- This proves observation and conservation only, not Phase 1 admission, shared circuits, permits, probes, or ramp behavior.

## Risks and rollout

- The observer adds a process/parser boundary around publication `gh` calls; measured loopback overhead is bounded but production latency must be observed over six complete quota windows.
- An uploader with no readable metrics emits one bounded incomplete invocation, but an uploader that never starts still cannot report itself. Operators must compare member/invocation/wire conservation against existing durable lifecycle and workflow counters.
- Public detail is capped and explicitly marked truncated/incomplete; private pool identity remains internal.
- Existing v1 metrics continue in parallel, so current dashboards and retry behavior remain compatible.
- This PR touches workflow files and therefore carries GitHub OAuth/workflow-scope risk; a maintainer-owned replacement branch may be required by policy.

Bay impact is observe-only: no queue, gate, schedule, hot cadence, batch size/concurrency, retry budget, credential, or production-state setting changes. After merge/deployment, collect six complete quota windows before authorizing Phase 1.

Rollback is a commit revert: remove the observer setup/upload steps and public route. Existing v1 metrics and publication behavior continue; retained v2 tables become inert and require no queue drain or data migration.

## Release note

Internal operations telemetry only; no user-facing behavior change.
