### PR TITLE
fix(telemetry): add a 15-minute egress window

### DIFF
--- a/dashboard/github-egress-telemetry.ts
+++ b/dashboard/github-egress-telemetry.ts
@@ -296,7 +296,8 @@ export class GithubEgressTelemetryStore {
   }
 
   publicObservability(hours: number, now = Date.now()) {
-    const boundedHours = hours === 1 || hours === 6 || hours === 24 ? hours : null;
+    const boundedHours =
+      hours === 0.25 || hours === 1 || hours === 6 || hours === 24 ? hours : null;
     if (!boundedHours) return null;
     const bucketKind = boundedHours <= 6 ? "five_minute" : "hour";
     const windowStart = now - boundedHours * 60 * 60 * 1000;

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -25,7 +25,9 @@ curl --fail --silent --show-error \
   'https://clawsweeper.openclaw.ai/api/github-egress-observability?hours=6'
 ```
 
-`hours` accepts only `1`, `6`, or `24`. The response contains closed aggregate
+`hours` accepts only `0.25` (15 minutes), `1`, `6`, or `24`. Use the 15-minute
+view for periodic collection when a high-cardinality one-hour detail response
+would reach the public row cap. The response contains closed aggregate
 dimensions and sanitized rate-limit observations. It never contains private
 pool identities, repository or item identifiers, branches, raw SHAs, paths,
 queries, cursors, URLs, request IDs, ETags, bodies, tokens, or installation IDs.
@@ -140,9 +142,9 @@ class, durable claim generation, first/repeat fact, safe route template, parsed
 method/status, and response receive time. Unsafe parsing emits or uploads an
 incomplete bounded marker. It never uploads a partially parsed raw frame.
 
-Completeness is computed independently for each requested one-, six-, or
-24-hour window. Rollup queries include the complete five-minute or hourly
-bucket that overlaps the window's lower boundary, so totals can include at
+Completeness is computed independently for each requested 15-minute, one-,
+six-, or 24-hour window. Rollup queries include the complete five-minute or
+hourly bucket that overlaps the window's lower boundary, so totals can include at
 most one bucket of observations immediately before the exact cutoff. Raw
 rate-limit observations use the exact cutoff. `rows_truncated` and
 `rate_limit_rows_truncated` identify a bounded public response, while
@@ -197,6 +199,10 @@ numeric header, count, and chunk limit before committing a receipt. It stores
 both five-minute and hourly rollups transactionally and deduplicates upload
 retries by producer-run-scoped, content-derived receipt ID. Cap evictions are
 cumulative diagnostics and mark affected public windows incomplete.
+
+The 15-minute view does not raise or bypass the public row cap. A collector
+must preserve `rows_truncated` and `query_complete` and record a gap if even the
+smaller view exceeds the bound.
 
 ## Rollback and Phase 1 boundary
 

--- a/docs/proof/github-egress-telemetry/README.md
+++ b/docs/proof/github-egress-telemetry/README.md
@@ -23,6 +23,7 @@ rows survive a Worker restart and an identical producer receipt is deduplicated.
 - `repository_actions`, `target_app`, and `public_read_fallback` call-site
   attribution
 - A real signed telemetry upload and public query through `wrangler dev --local`
+- The 15-minute public detail query through the same Worker and Durable Object
 - The real SQLite Durable Object storage, receipt deduplication, and restart
   persistence
 - Sentinel scans across workflow JSONL and public output
@@ -58,6 +59,7 @@ schedule, gate, deployment, or credential state.
 - A missing observer parser preserves the original throttled command's stderr,
   stdout, and exit status while stripping unsafe debug frames.
 - Public output withholds pool identity and all raw sentinels.
+- The 15-minute view returns `window.hours=0.25` with a complete query.
 - Worker restart preserves rows and replaying the same receipt is deduplicated.
 - Median loopback observer overhead remains below the proof's one-second safety
   ceiling; the measured value is reported, not treated as a production latency

--- a/docs/proof/github-egress-telemetry/run-proof.mjs
+++ b/docs/proof/github-egress-telemetry/run-proof.mjs
@@ -31,9 +31,12 @@ const candidateHead = process.env.GITHUB_EGRESS_PROOF_SOURCE_SHA || (await gitHe
 
 await mkdir(outputDir, { recursive: true });
 await Promise.all(
-  ["proof-summary.json", "public-observability.json", "wrangler.log"].map((name) =>
-    rm(path.join(outputDir, name), { force: true }),
-  ),
+  [
+    "proof-summary.json",
+    "public-observability.json",
+    "public-observability-15m.json",
+    "wrangler.log",
+  ].map((name) => rm(path.join(outputDir, name), { force: true })),
 );
 
 const github = createHttpsServer(
@@ -283,8 +286,14 @@ exit 73
   assert.deepEqual(duplicateUpload, { accepted: false, deduped: true });
   const afterDuplicate = await getJson(`${worker.origin}/api/github-egress-observability?hours=1`);
   assert.deepEqual(afterDuplicate.rows, beforeRestart.rows);
+  const fifteenMinuteView = await getJson(
+    `${worker.origin}/api/github-egress-observability?hours=0.25`,
+  );
+  assert.equal(fifteenMinuteView.window.hours, 0.25);
+  assertPublicView(fifteenMinuteView);
 
   privacyScan(JSON.stringify(afterDuplicate));
+  privacyScan(JSON.stringify(fifteenMinuteView));
   const baselineMedianMs = median(baselineSamples);
   const observedMedianMs = median(observedSamples);
   const addedMedianMs = observedMedianMs - baselineMedianMs;
@@ -318,6 +327,7 @@ exit 73
       empty_sink_incomplete_invocations: 1,
       restart_rows_preserved: true,
       duplicate_upload_deduped: true,
+      fifteen_minute_public_query_complete: fifteenMinuteView.completeness.query_complete,
       output_and_exit_preserved: true,
       parser_failure_error_preserved: true,
       sentinel_privacy_scan_passed: true,
@@ -342,6 +352,10 @@ exit 73
   await writeFile(
     path.join(outputDir, "public-observability.json"),
     `${JSON.stringify(afterDuplicate, null, 2)}\n`,
+  );
+  await writeFile(
+    path.join(outputDir, "public-observability-15m.json"),
+    `${JSON.stringify(fifteenMinuteView, null, 2)}\n`,
   );
   await writeFile(
     path.join(outputDir, "proof-summary.json"),

--- a/docs/proof/github-egress-telemetry/run-proof.sh
+++ b/docs/proof/github-egress-telemetry/run-proof.sh
@@ -53,4 +53,5 @@ node docs/proof/github-egress-telemetry/run-proof.mjs
 
 test -s "$output_dir/proof-summary.json"
 test -s "$output_dir/public-observability.json"
+test -s "$output_dir/public-observability-15m.json"
 test -s "$output_dir/wrangler.log"

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -24,7 +24,7 @@ branch, not a promise that every method will remain supported.
 | `/api/exact-review-queue/item`           | `GET`  | One queue item's status; forwards query parameters.                                         |
 | `/api/exact-review-queue/reviews`        | `GET`  | Per-item review lookup used by observer surfaces.                                           |
 | `/api/review-observability`              | `GET`  | Review observability from the queue Durable Object; forwards query parameters.              |
-| `/api/github-egress-observability`        | `GET`  | Sanitized publication GitHub egress rollups for `hours=1`, `6`, or `24`.                     |
+| `/api/github-egress-observability`        | `GET`  | Sanitized publication GitHub egress rollups for `hours=0.25`, `1`, `6`, or `24`.              |
 | `/api/review-coverage`                   | `GET`  | Review coverage from the queue Durable Object.                                              |
 | `/api/apply-observability`               | `GET`  | Apply-lane observability from `applyObservabilityJson`.                                     |
 | `/api/health-history`                    | `GET`  | Historical health from `healthHistoryJson`.                                                 |

--- a/test/github-egress-telemetry.test.ts
+++ b/test/github-egress-telemetry.test.ts
@@ -492,6 +492,7 @@ test("signed upload, SQLite restart, retention, cardinality, and public privacy 
     );
     assert.equal(windowStore.publicObservability(1, NOW)?.completeness.observed, false);
     assert.equal(windowStore.publicObservability(6, NOW)?.completeness.observed, true);
+    assert.equal(windowStore.publicObservability(0.5, NOW), null);
 
     const unalignedNow = NOW + 2 * 60 * 1_000;
     const firstPartialBucket = unalignedNow - 60 * 60 * 1_000 + 30 * 1_000;
@@ -503,6 +504,18 @@ test("signed upload, SQLite restart, retention, cardinality, and public privacy 
     assert.equal(oneHourView?.completeness.observed, true);
     assert.equal(oneHourView?.units.wire_attempt, 1);
 
+    const fifteenMinutesAgo = unalignedNow - 15 * 60 * 1_000 + 30 * 1_000;
+    assert.equal(
+      windowStore.ingest(telemetryBody("6".repeat(64), fifteenMinutesAgo), fifteenMinutesAgo).ok,
+      true,
+    );
+    const fifteenMinuteView = windowStore.publicObservability(0.25, unalignedNow);
+    assert.equal(fifteenMinuteView?.window.hours, 0.25);
+    assert.equal(fifteenMinuteView?.window.bucket_minutes, 5);
+    assert.equal(fifteenMinuteView?.completeness.observed, true);
+    assert.equal(fifteenMinuteView?.completeness.query_complete, true);
+    assert.equal(fifteenMinuteView?.units.wire_attempt, 1);
+
     const unalignedDayNow = NOW + 30 * 60 * 1_000;
     const firstPartialHour = unalignedDayNow - 24 * 60 * 60 * 1_000 + 5 * 60 * 1_000;
     assert.equal(
@@ -511,7 +524,55 @@ test("signed upload, SQLite restart, retention, cardinality, and public privacy 
     );
     const oneDayView = windowStore.publicObservability(24, unalignedDayNow);
     assert.equal(oneDayView?.completeness.observed, true);
-    assert.equal(oneDayView?.units.wire_attempt, 3);
+    assert.equal(oneDayView?.units.wire_attempt, 4);
+
+    const highCardinalityStorage = new MemoryDurableStorage();
+    const highCardinalityStore = new GithubEgressTelemetryStore(highCardinalityStorage);
+    highCardinalityStore.ensureSchemaSync();
+    const insertRollup = (bucketStart: number, configRevision: string) =>
+      highCardinalityStorage.sql.exec(
+        `INSERT INTO exact_review_github_egress_rollups_v2 (
+           bucket_kind, bucket_start, deployment_revision, config_revision,
+           pool_class, pool_identity, stage, source_action, operation, method,
+           route_template, page_bucket, unit, outcome, status_bucket,
+           latency_bucket, claim_generation_bucket, first_repeat, attempted,
+           telemetry_complete, count
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        "five_minute",
+        bucketStart,
+        "a".repeat(16),
+        configRevision,
+        "repository_actions",
+        "private-pool",
+        "publication_apply",
+        "scheduled_normal",
+        "item_metadata",
+        "GET",
+        "issue_metadata",
+        "none",
+        "invocation",
+        "success",
+        "2xx",
+        "100_249ms",
+        "1",
+        "first",
+        1,
+        1,
+        1,
+      );
+    for (let index = 0; index < 2_001; index += 1) {
+      insertRollup(NOW - 50 * 60 * 1_000, index.toString(16).padStart(16, "0"));
+    }
+    insertRollup(NOW - 10 * 60 * 1_000, "f".repeat(16));
+    const truncatedHour = highCardinalityStore.publicObservability(1, NOW);
+    assert.equal(truncatedHour?.rows.length, 2_000);
+    assert.equal(truncatedHour?.completeness.rows_truncated, true);
+    assert.equal(truncatedHour?.completeness.query_complete, false);
+    const completeQuarterHour = highCardinalityStore.publicObservability(0.25, NOW);
+    assert.equal(completeQuarterHour?.rows.length, 1);
+    assert.equal(completeQuarterHour?.units.invocation, 1);
+    assert.equal(completeQuarterHour?.completeness.rows_truncated, false);
+    assert.equal(completeQuarterHour?.completeness.query_complete, true);
 
     const future = NOW + 8 * 24 * 60 * 60 * 1_000;
     const futureBody = telemetryBody("f".repeat(64), future);


### PR DESCRIPTION
## Summary

- add a read-only 15-minute (`hours=0.25`) GitHub-egress observability window
- preserve the existing 1h, 6h, and 24h response contract and 2,000-row cap
- extend deterministic and real-Worker proof to cover the smaller window

Related: CSW-127 and https://github.com/openclaw/clawsweeper/pull/1140.

This is a narrow Phase 0 follow-up. It does not implement Phase 1 coordination,
change publication scheduling, alter queue or retry behavior, increase the row
cap, or mutate credentials, gates, DLQs, or production state.

## Problem

Post-merge observation found that organic high-cardinality publication traffic
can fill the public 2,000-row detail cap even for `hours=1`. The full-window
member/invocation/wire totals and reset observations remain usable, but
`rows_truncated=true` makes the per-route and per-stage breakdown incomplete.
Because one hour was the smallest accepted window, a 15-minute monitor could
not collect a smaller complete slice for local aggregation.

## Implementation

- accept `hours=0.25` in the existing public observability store
- retain five-minute bucket alignment and every existing completeness/privacy
  field
- keep unsupported windows rejected and keep 1/6/24-hour behavior unchanged
- document that the smaller view does not bypass the public cap and must still
  preserve truthful truncation flags
- add a high-cardinality regression proving a one-hour query can truncate while
  the same store's 15-minute query remains complete
- extend the real Worker/SQLite proof to query and privacy-scan the new window

OpenClaw Bay is unaffected: its compact six-hour summary and observer-only UI do
not change. The new surface is an optional query value on the existing API.

## Validation

Exact base: `ac340908bf694c902f5a673374be1639ef9f220f`  
Exact head: `3c47cda57d9dae56479dc71dbcdaca93b7788553`

- `pnpm run build:all`
- `node --test test/github-egress-telemetry.test.ts` — 7/7
- `pnpm run lint`
- `pnpm run check:docs`
- `pnpm exec oxfmt --check dashboard/github-egress-telemetry.ts test/github-egress-telemetry.test.ts docs/proof/github-egress-telemetry/run-proof.mjs`
- `git diff --check origin/main...HEAD`
- `pnpm run codex:local:check`
- dirty-patch `codex review --uncommitted`: no actionable findings
- committed `codex review --base origin/main`: no actionable findings
- final committed `codex review --base origin/main` after proof-artifact assertion: no actionable findings
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: `decision=keep_open confidence=high action=kept_open`; local-only, no GitHub mutation

The repository-wide Windows `format:check` reports the existing CRLF formatting
baseline across hundreds of untouched files. The changed TypeScript/JavaScript
files pass focused `oxfmt --check`, and `git diff --check` is clean. No platform
policy or unrelated formatting change is included.

## Real Behavior Proof

### Claim

The production read-only API accepts `hours=0.25`, preserves the Phase 0
privacy and completeness contract, and gives a 15-minute monitor a smaller
bounded detail slice without altering publication behavior.

### Exercised surface

- exact head `3c47cda57d9dae56479dc71dbcdaca93b7788553`
- Crabbox `provider=local-container`, lease `cbx_ea87b5d56d48`, image
  `node:24-bookworm`, exit 0
- Node 24.19.0, GitHub CLI 2.88.1, Wrangler 4.107.0 local Worker
- SQLite-backed `ExactReviewQueue` Durable Object
- real loopback TLS GitHub CLI transport, signed upload, restart persistence,
  receipt deduplication, public query, and sentinel privacy scan

### Scenario and observed result

The deterministic high-cardinality fixture inserted 2,001 distinct older
five-minute dimension rows plus one recent row. Its one-hour response was capped
at 2,000 with `rows_truncated=true` and `query_complete=false`; its 15-minute
response contained only the recent row and returned `query_complete=true`.

The exact-head Crabbox proof then exercised the real public Worker route:

- `hours=0.25` returned `window.hours=0.25` and `query_complete=true`
- 18 invocations conserved to 19 wire attempts and one durable member
- pagination accounted for exactly three pages
- one sanitized rate-limit observation survived Worker restart
- duplicate receipt was deduplicated
- stdout, ordinary stderr, and exit behavior were preserved
- private/raw sentinel scan passed
- production mutations: 0; OpenClaw Bay affected: false

The initial Windows-to-local-container sync attempt failed before execution with
rsync code 12. The successful proof used Crabbox `--no-sync`, cloned the pushed
branch inside the container, and verified the exact head before running. This is
the same bounded workaround used by the original Phase 0 proof.

### Limits

- A sufficiently high-cardinality 15-minute burst can still reach the cap; the
  existing flags remain authoritative and the collector must record that gap.
- The proof uses deterministic loopback GitHub responses and does not consume
  or deliberately exhaust live quota.
- This does not add pagination/cursors or Phase 1 admission, permits, shared
  circuits, probes, recovery ramps, or retry enforcement.

## Risks and rollout

The change is additive and read-only. Existing callers using 1/6/24-hour
windows receive the same response shape and aggregation. The 2,000-row cap,
retention, privacy allowlists, and invalid-window behavior remain unchanged.

Rollback is a normal code revert removing `0.25` from the accepted window set
and its documentation/tests. It requires no queue drain, workflow change, gate
change, credential change, or state migration.

## Release note

Internal operator telemetry: add a 15-minute GitHub-egress detail window for
high-volume monitoring.
