### PR TITLE
feat(review): make re-review command intake durable

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -201,7 +201,7 @@ jobs:
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
           CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
           CLAWSWEEPER_ACTION_LEDGER_INVOCATION: initial
-          CLAWSWEEPER_INTERNAL_QUEUE_SECRET: ${{ secrets.CLAWSWEEPER_INTERNAL_QUEUE_SECRET || secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           CLAWSWEEPER_TARGET_INSTALLATION_ID: ${{ steps.app_token.outputs.installation-id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
@@ -361,7 +361,7 @@ jobs:
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
           CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
           CLAWSWEEPER_ACTION_LEDGER_INVOCATION: retry
-          CLAWSWEEPER_INTERNAL_QUEUE_SECRET: ${{ secrets.CLAWSWEEPER_INTERNAL_QUEUE_SECRET || secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
           CLAWSWEEPER_TARGET_INSTALLATION_ID: ${{ steps.app_token.outputs.installation-id }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |

--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -201,6 +201,9 @@ jobs:
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
           CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
           CLAWSWEEPER_ACTION_LEDGER_INVOCATION: initial
+          CLAWSWEEPER_INTERNAL_QUEUE_SECRET: ${{ secrets.CLAWSWEEPER_INTERNAL_QUEUE_SECRET || secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_TARGET_INSTALLATION_ID: ${{ steps.app_token.outputs.installation-id }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           target_repo="${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLAWSWEEPER_TARGET_REPO || 'openclaw/openclaw' }}"
@@ -358,6 +361,9 @@ jobs:
           CLAWSWEEPER_ALLOW_MERGE: ${{ vars.CLAWSWEEPER_ALLOW_MERGE || '0' }}
           CLAWSWEEPER_STATUS_INGEST_TOKEN: ${{ secrets.CLAWSWEEPER_STATUS_INGEST_TOKEN }}
           CLAWSWEEPER_ACTION_LEDGER_INVOCATION: retry
+          CLAWSWEEPER_INTERNAL_QUEUE_SECRET: ${{ secrets.CLAWSWEEPER_INTERNAL_QUEUE_SECRET || secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          CLAWSWEEPER_TARGET_INSTALLATION_ID: ${{ steps.app_token.outputs.installation-id }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
           target_repo="${{ github.event_name == 'workflow_dispatch' && inputs.target_repo || vars.CLAWSWEEPER_TARGET_REPO || 'openclaw/openclaw' }}"

--- a/README.md
+++ b/README.md
@@ -292,9 +292,11 @@ Users with repository write access and issue/PR authors may ask
 Other contributor commands are ignored without a reply. Scheduled comment routing is dry unless
 `CLAWSWEEPER_COMMENT_ROUTER_EXECUTE=1`; workflow dispatch with `execute=true`
 can be used for one-off live routing.
-For fast intake, the ClawSweeper GitHub App webhook can post the same queued
-status comment and enqueue exact `clawsweeper_comment` or `clawsweeper_item`
-work from eligible public `openclaw/*` and `steipete/*` repositories. Exact
+For fast intake, the ClawSweeper GitHub App webhook durably records eligible
+`review` and `re-review` comment versions before it acknowledges them. Other
+commands still enqueue exact `clawsweeper_comment` work, and item events enqueue
+`clawsweeper_item` work, from eligible public `openclaw/*` and `steipete/*`
+repositories. Exact
 item work is coalesced and leased by the dashboard Worker before it dispatches
 an executor, so webhook bursts do not create capacity-waiting Actions runners.
 The target-side dispatcher remains a scheduled-intake fallback until it adopts

--- a/dashboard/exact-review-command-intake.ts
+++ b/dashboard/exact-review-command-intake.ts
@@ -174,9 +174,15 @@ export class ExactReviewCommandIntakeStore {
            (source_comment_key, source_updated_at, command_version_id, body_digest)
          VALUES (?, ?, ?, ?)
          ON CONFLICT(source_comment_key) DO UPDATE SET
-           source_updated_at = excluded.source_updated_at,
-           command_version_id = excluded.command_version_id,
-           body_digest = excluded.body_digest`,
+           source_updated_at = CASE
+             WHEN excluded.source_updated_at > source_updated_at
+             THEN excluded.source_updated_at ELSE source_updated_at END,
+           command_version_id = CASE
+             WHEN excluded.source_updated_at > source_updated_at
+             THEN excluded.command_version_id ELSE command_version_id END,
+           body_digest = CASE
+             WHEN excluded.source_updated_at > source_updated_at
+             THEN excluded.body_digest ELSE body_digest END`,
         sourceCommentKey,
         sourceUpdatedAt,
         intake.commandVersionId,
@@ -224,9 +230,52 @@ export class ExactReviewCommandIntakeStore {
         commandSourceCommentKey(record.intake),
       ),
     );
+    const timestampMatches =
+      Number(watermark?.source_updated_at) === Date.parse(record.intake.sourceCommentUpdatedAt);
     return (
-      Number(watermark?.source_updated_at) === Date.parse(record.intake.sourceCommentUpdatedAt)
+      timestampMatches &&
+      (record.stage === "verify_pending" ||
+        watermark?.command_version_id === record.intake.commandVersionId)
     );
+  }
+
+  markVerified(record: ExactReviewCommandIntakeRecord, now: number) {
+    const sourceCommentKey = commandSourceCommentKey(record.intake);
+    const sourceUpdatedAt = Date.parse(record.intake.sourceCommentUpdatedAt);
+    return this.storage.transactionSync(() => {
+      const watermark = firstRow(
+        this.storage.sql.exec(
+          `SELECT source_updated_at FROM ${COMMAND_WATERMARK_TABLE}
+            WHERE source_comment_key = ?`,
+          sourceCommentKey,
+        ),
+      );
+      if (Number(watermark?.source_updated_at) > sourceUpdatedAt) return false;
+      this.storage.sql.exec(
+        `UPDATE ${COMMAND_WATERMARK_TABLE}
+            SET command_version_id = ?, body_digest = ?
+          WHERE source_comment_key = ? AND source_updated_at = ?`,
+        record.intake.commandVersionId,
+        record.intake.commandBodyDigest,
+        sourceCommentKey,
+        sourceUpdatedAt,
+      );
+      this.storage.sql.exec(
+        `UPDATE ${COMMAND_RECEIPT_TABLE}
+            SET outcome = 'superseded', observed_at = ?, detail = 'verified_sibling_version'
+          WHERE source_comment_key = ? AND command_version_id != ? AND outcome = 'pending'`,
+        now,
+        sourceCommentKey,
+        record.intake.commandVersionId,
+      );
+      this.storage.sql.exec(
+        `DELETE FROM ${COMMAND_INTAKE_TABLE}
+          WHERE source_comment_key = ? AND command_version_id != ?`,
+        sourceCommentKey,
+        record.intake.commandVersionId,
+      );
+      return true;
+    });
   }
 
   advance(

--- a/dashboard/exact-review-command-intake.ts
+++ b/dashboard/exact-review-command-intake.ts
@@ -1,0 +1,423 @@
+import {
+  validateDirectReReviewIntake,
+  type DirectReReviewDecision,
+  type DirectReReviewIntake,
+} from "../src/repair/direct-re-review-admission.ts";
+import { exactReviewBaseDecisionFrom } from "./exact-review-decision.ts";
+
+const COMMAND_INTAKE_TABLE = "exact_review_command_intakes";
+const COMMAND_WATERMARK_TABLE = "exact_review_command_watermarks";
+const COMMAND_RECEIPT_TABLE = "exact_review_command_receipts";
+const ITEM_REVISION_TABLE = "exact_review_item_revisions";
+const COMMAND_INTAKE_LIMIT = 16;
+const COMMAND_RETRY_BASE_MS = 15_000;
+const COMMAND_RETRY_MAX_MS = 15 * 60_000;
+export const EXACT_REVIEW_COMMAND_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+type SqlRow = Record<string, unknown>;
+type CommandIntakeStorage = {
+  sql: { exec: (query: string, ...bindings: unknown[]) => Iterable<SqlRow> };
+  transactionSync: <T>(callback: () => T) => T;
+};
+
+export type CommandIntakeStage = "verify_pending" | "enqueue_pending" | "effects_pending";
+
+export type ExactReviewCommandIntakeRecord = {
+  intake: DirectReReviewIntake;
+  stage: CommandIntakeStage;
+  attempts: number;
+  nextAttemptAt: number;
+  admittedAt: number;
+  verifiedDecision?: DirectReReviewDecision;
+};
+
+export type ExactReviewCommandAdmission =
+  | {
+      accepted: true;
+      deduped: boolean;
+      commandVersionId: string;
+    }
+  | {
+      accepted: false;
+      reason: string;
+      commandVersionId: string;
+    };
+
+export class ExactReviewCommandIntakeStore {
+  private readonly storage: CommandIntakeStorage;
+
+  constructor(storage: CommandIntakeStorage) {
+    this.storage = storage;
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${COMMAND_INTAKE_TABLE} (
+         command_version_id TEXT PRIMARY KEY,
+         source_comment_key TEXT NOT NULL,
+         source_updated_at INTEGER NOT NULL,
+         record_json TEXT NOT NULL,
+         next_attempt_at INTEGER NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_command_intakes_due
+         ON ${COMMAND_INTAKE_TABLE} (next_attempt_at, command_version_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${COMMAND_WATERMARK_TABLE} (
+         source_comment_key TEXT PRIMARY KEY,
+         source_updated_at INTEGER NOT NULL,
+         command_version_id TEXT NOT NULL,
+         body_digest TEXT NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${COMMAND_RECEIPT_TABLE} (
+         command_version_id TEXT PRIMARY KEY,
+         source_comment_key TEXT NOT NULL,
+         outcome TEXT NOT NULL CHECK (outcome IN ('pending', 'completed', 'rejected', 'superseded')),
+         observed_at INTEGER NOT NULL,
+         detail TEXT
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_command_receipts_terminal_observed
+         ON ${COMMAND_RECEIPT_TABLE} (outcome, observed_at, command_version_id)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${ITEM_REVISION_TABLE} (
+         item_key TEXT PRIMARY KEY,
+         last_revision INTEGER NOT NULL CHECK (last_revision >= 0)
+       ) STRICT`,
+    );
+  }
+
+  admit(value: unknown, now: number): ExactReviewCommandAdmission | null {
+    const intake = validateDirectReReviewIntake(value);
+    if (!intake || !exactReviewBaseDecisionFrom(intake.decision)) return null;
+    const sourceUpdatedAt = Date.parse(intake.sourceCommentUpdatedAt);
+    const sourceCommentKey = commandSourceCommentKey(intake);
+    return this.storage.transactionSync(() => {
+      const receipt = firstRow(
+        this.storage.sql.exec(
+          `SELECT outcome, detail FROM ${COMMAND_RECEIPT_TABLE} WHERE command_version_id = ?`,
+          intake.commandVersionId,
+        ),
+      );
+      if (receipt) {
+        const outcome = String(receipt.outcome || "");
+        if (outcome === "rejected" || outcome === "superseded") {
+          return {
+            accepted: false,
+            reason: String(receipt.detail || outcome),
+            commandVersionId: intake.commandVersionId,
+          };
+        }
+        return {
+          accepted: true,
+          deduped: true,
+          commandVersionId: intake.commandVersionId,
+        };
+      }
+
+      const watermark = firstRow(
+        this.storage.sql.exec(
+          `SELECT source_updated_at, command_version_id FROM ${COMMAND_WATERMARK_TABLE}
+            WHERE source_comment_key = ?`,
+          sourceCommentKey,
+        ),
+      );
+      const watermarkUpdatedAt = Number(watermark?.source_updated_at);
+      const sameWatermarkVersion =
+        watermark?.command_version_id === intake.commandVersionId &&
+        watermarkUpdatedAt === sourceUpdatedAt;
+      if (watermark && (watermarkUpdatedAt > sourceUpdatedAt || sameWatermarkVersion)) {
+        const reason = sameWatermarkVersion
+          ? "semantic command version already observed"
+          : "older comment version";
+        this.storage.sql.exec(
+          `INSERT OR IGNORE INTO ${COMMAND_RECEIPT_TABLE}
+             (command_version_id, source_comment_key, outcome, observed_at, detail)
+           VALUES (?, ?, 'rejected', ?, ?)`,
+          intake.commandVersionId,
+          sourceCommentKey,
+          now,
+          reason === "older comment version" ? "older_comment_version" : "already_observed",
+        );
+        return { accepted: false, reason, commandVersionId: intake.commandVersionId };
+      }
+
+      if (watermark && watermarkUpdatedAt < sourceUpdatedAt) {
+        this.storage.sql.exec(
+          `UPDATE ${COMMAND_RECEIPT_TABLE}
+              SET outcome = 'superseded', observed_at = ?, detail = 'newer_comment_version'
+            WHERE source_comment_key = ? AND outcome = 'pending'`,
+          now,
+          sourceCommentKey,
+        );
+        this.storage.sql.exec(
+          `DELETE FROM ${COMMAND_INTAKE_TABLE} WHERE source_comment_key = ?`,
+          sourceCommentKey,
+        );
+      }
+
+      const record: ExactReviewCommandIntakeRecord = {
+        intake,
+        stage: "verify_pending",
+        attempts: 0,
+        nextAttemptAt: now,
+        admittedAt: now,
+      };
+      this.storage.sql.exec(
+        `INSERT INTO ${COMMAND_WATERMARK_TABLE}
+           (source_comment_key, source_updated_at, command_version_id, body_digest)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(source_comment_key) DO UPDATE SET
+           source_updated_at = excluded.source_updated_at,
+           command_version_id = excluded.command_version_id,
+           body_digest = excluded.body_digest`,
+        sourceCommentKey,
+        sourceUpdatedAt,
+        intake.commandVersionId,
+        intake.commandBodyDigest,
+      );
+      this.storage.sql.exec(
+        `INSERT INTO ${COMMAND_RECEIPT_TABLE}
+           (command_version_id, source_comment_key, outcome, observed_at)
+         VALUES (?, ?, 'pending', ?)`,
+        intake.commandVersionId,
+        sourceCommentKey,
+        now,
+      );
+      this.storage.sql.exec(
+        `INSERT INTO ${COMMAND_INTAKE_TABLE}
+           (command_version_id, source_comment_key, source_updated_at, record_json, next_attempt_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        intake.commandVersionId,
+        sourceCommentKey,
+        sourceUpdatedAt,
+        JSON.stringify(record),
+        now,
+      );
+      return { accepted: true, deduped: false, commandVersionId: intake.commandVersionId };
+    });
+  }
+
+  due(now: number): ExactReviewCommandIntakeRecord[] {
+    return Array.from(
+      this.storage.sql.exec(
+        `SELECT record_json FROM ${COMMAND_INTAKE_TABLE}
+          WHERE next_attempt_at <= ? ORDER BY next_attempt_at, command_version_id
+          LIMIT ${COMMAND_INTAKE_LIMIT}`,
+        now,
+      ),
+      (row) => parseRecord(row.record_json),
+    ).filter((record): record is ExactReviewCommandIntakeRecord => record !== null);
+  }
+
+  isCurrent(record: ExactReviewCommandIntakeRecord) {
+    const watermark = firstRow(
+      this.storage.sql.exec(
+        `SELECT source_updated_at, command_version_id FROM ${COMMAND_WATERMARK_TABLE}
+          WHERE source_comment_key = ?`,
+        commandSourceCommentKey(record.intake),
+      ),
+    );
+    return (
+      Number(watermark?.source_updated_at) === Date.parse(record.intake.sourceCommentUpdatedAt)
+    );
+  }
+
+  advance(
+    commandVersionId: string,
+    stage: Exclude<CommandIntakeStage, "verify_pending">,
+    now: number,
+    verifiedDecision: DirectReReviewDecision,
+  ) {
+    this.storage.transactionSync(() => {
+      const current = this.read(commandVersionId);
+      if (!current) return;
+      const next: ExactReviewCommandIntakeRecord = {
+        ...current,
+        stage,
+        attempts: 0,
+        nextAttemptAt: now,
+        verifiedDecision,
+      };
+      this.write(next);
+    });
+  }
+
+  finish(
+    commandVersionId: string,
+    outcome: "completed" | "rejected" | "superseded",
+    now: number,
+    detail: string | null,
+  ) {
+    this.storage.transactionSync(() => {
+      this.storage.sql.exec(
+        `UPDATE ${COMMAND_RECEIPT_TABLE}
+            SET outcome = ?, observed_at = ?, detail = ? WHERE command_version_id = ?`,
+        outcome,
+        now,
+        detail,
+        commandVersionId,
+      );
+      this.storage.sql.exec(
+        `DELETE FROM ${COMMAND_INTAKE_TABLE} WHERE command_version_id = ?`,
+        commandVersionId,
+      );
+    });
+  }
+
+  defer(
+    record: ExactReviewCommandIntakeRecord,
+    now: number,
+    detail: string,
+    requestedRetryAt?: number,
+    incrementAttempts = true,
+  ) {
+    this.storage.transactionSync(() => {
+      const current = this.read(record.intake.commandVersionId) ?? record;
+      const attempts = incrementAttempts ? current.attempts + 1 : current.attempts;
+      const delay = Math.min(
+        COMMAND_RETRY_MAX_MS,
+        COMMAND_RETRY_BASE_MS * 2 ** Math.min(Math.max(0, attempts - 1), 8),
+      );
+      const boundedRequestedRetryAt = requestedRetryAt
+        ? Math.min(requestedRetryAt, now + COMMAND_RETRY_MAX_MS)
+        : 0;
+      const next = {
+        ...current,
+        attempts,
+        nextAttemptAt: Math.max(now + Math.max(1_000, delay), boundedRequestedRetryAt),
+      };
+      this.write(next);
+      this.storage.sql.exec(
+        `UPDATE ${COMMAND_RECEIPT_TABLE}
+            SET observed_at = ?, detail = ? WHERE command_version_id = ? AND outcome = 'pending'`,
+        now,
+        detail.slice(0, 500),
+        record.intake.commandVersionId,
+      );
+    });
+  }
+
+  retryVerification(record: ExactReviewCommandIntakeRecord, now: number, detail: string) {
+    this.storage.transactionSync(() => {
+      const current = this.read(record.intake.commandVersionId) ?? record;
+      const attempts = current.attempts + 1;
+      const delay = Math.min(
+        COMMAND_RETRY_MAX_MS,
+        COMMAND_RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 8),
+      );
+      const next: ExactReviewCommandIntakeRecord = {
+        ...current,
+        stage: "verify_pending",
+        attempts,
+        nextAttemptAt: now + delay,
+      };
+      delete next.verifiedDecision;
+      this.write(next);
+      this.storage.sql.exec(
+        `UPDATE ${COMMAND_RECEIPT_TABLE}
+            SET observed_at = ?, detail = ? WHERE command_version_id = ? AND outcome = 'pending'`,
+        now,
+        detail.slice(0, 500),
+        record.intake.commandVersionId,
+      );
+    });
+  }
+
+  nextAttemptAt(): number | null {
+    const row = firstRow(
+      this.storage.sql.exec(
+        `SELECT MIN(next_attempt_at) AS next_attempt_at FROM ${COMMAND_INTAKE_TABLE}`,
+      ),
+    );
+    const next = Number(row?.next_attempt_at || 0);
+    return next > 0 ? next : null;
+  }
+
+  pruneTerminalReceipts(now: number) {
+    this.storage.sql.exec(
+      `DELETE FROM ${COMMAND_RECEIPT_TABLE}
+        WHERE outcome != 'pending' AND observed_at <= ?`,
+      now - EXACT_REVIEW_COMMAND_RECEIPT_RETENTION_MS,
+    );
+  }
+
+  allocateItemRevision(
+    itemKey: string,
+    minimumRevision: number,
+    lifecycleRevision: number,
+    publicationRevision: number,
+  ) {
+    const canonicalKey = itemKey.split("@publish:")[0]!.toLowerCase();
+    const floor = Math.max(0, minimumRevision - 1, lifecycleRevision, publicationRevision);
+    this.storage.sql.exec(
+      `INSERT INTO ${ITEM_REVISION_TABLE} (item_key, last_revision)
+       VALUES (?, ?)
+       ON CONFLICT(item_key) DO UPDATE SET last_revision = MAX(last_revision, excluded.last_revision)`,
+      canonicalKey,
+      floor,
+    );
+    const row = firstRow(
+      this.storage.sql.exec(
+        `UPDATE ${ITEM_REVISION_TABLE}
+            SET last_revision = last_revision + 1 WHERE item_key = ?
+          RETURNING last_revision`,
+        canonicalKey,
+      ),
+    );
+    const revision = Number(row?.last_revision || 0);
+    if (!Number.isSafeInteger(revision) || revision < minimumRevision) {
+      throw new Error("exact-review item revision allocation failed");
+    }
+    return revision;
+  }
+
+  private read(commandVersionId: string) {
+    const row = firstRow(
+      this.storage.sql.exec(
+        `SELECT record_json FROM ${COMMAND_INTAKE_TABLE} WHERE command_version_id = ?`,
+        commandVersionId,
+      ),
+    );
+    return parseRecord(row?.record_json);
+  }
+
+  private write(record: ExactReviewCommandIntakeRecord) {
+    this.storage.sql.exec(
+      `UPDATE ${COMMAND_INTAKE_TABLE}
+          SET record_json = ?, next_attempt_at = ? WHERE command_version_id = ?`,
+      JSON.stringify(record),
+      record.nextAttemptAt,
+      record.intake.commandVersionId,
+    );
+  }
+}
+
+function parseRecord(value: unknown): ExactReviewCommandIntakeRecord | null {
+  try {
+    const parsed = JSON.parse(String(value || "")) as ExactReviewCommandIntakeRecord;
+    return validateDirectReReviewIntake(parsed.intake) &&
+      ["verify_pending", "enqueue_pending", "effects_pending"].includes(parsed.stage) &&
+      Number.isSafeInteger(parsed.attempts) &&
+      parsed.attempts >= 0 &&
+      Number.isFinite(parsed.nextAttemptAt)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function commandSourceCommentKey(intake: DirectReReviewIntake) {
+  return `${intake.decision.targetRepo.toLowerCase()}:${intake.sourceCommentId}`;
+}
+
+function firstRow(rows: Iterable<SqlRow>): SqlRow | undefined {
+  return Array.from(rows)[0];
+}

--- a/dashboard/exact-review-decision.ts
+++ b/dashboard/exact-review-decision.ts
@@ -46,6 +46,11 @@ export type ExactReviewBaseDecision = {
   commandStatusMarker?: string;
   statusCommentId?: number;
   additionalPrompt?: string;
+  sourceCommentId?: number;
+  sourceCommentUpdatedAt?: string;
+  commandBodyDigest?: string;
+  commandOrigin?: "hosted_webhook" | "comment_router";
+  sourceCommentVerified?: boolean;
 };
 export type ExactReviewPublication = {
   artifactName: string;
@@ -326,6 +331,21 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
   const statusCommentId = hasStatusCommentId ? Number(decision.statusCommentId) : undefined;
   const hasAdditionalPrompt = Object.hasOwn(decision, "additionalPrompt");
   const additionalPrompt = hasAdditionalPrompt ? decision.additionalPrompt : undefined;
+  const hasSourceCommentId = Object.hasOwn(decision, "sourceCommentId");
+  const sourceCommentId = hasSourceCommentId ? Number(decision.sourceCommentId) : undefined;
+  const hasSourceCommentUpdatedAt = Object.hasOwn(decision, "sourceCommentUpdatedAt");
+  const sourceCommentUpdatedAt = hasSourceCommentUpdatedAt
+    ? String(decision.sourceCommentUpdatedAt || "").trim()
+    : undefined;
+  const hasCommandBodyDigest = Object.hasOwn(decision, "commandBodyDigest");
+  const commandBodyDigest = hasCommandBodyDigest
+    ? String(decision.commandBodyDigest || "")
+        .trim()
+        .toLowerCase()
+    : undefined;
+  const hasCommandOrigin = Object.hasOwn(decision, "commandOrigin");
+  const commandOrigin = hasCommandOrigin ? String(decision.commandOrigin || "") : undefined;
+  const hasSourceCommentVerified = Object.hasOwn(decision, "sourceCommentVerified");
   if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(targetRepo)) return null;
   if (!/^[A-Za-z0-9_./-]+$/.test(targetBranch)) return null;
   if (!Number.isInteger(itemNumber) || itemNumber <= 0) return null;
@@ -373,6 +393,31 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
   ) {
     return null;
   }
+  if (
+    hasSourceCommentId &&
+    (!Number.isSafeInteger(sourceCommentId) || Number(sourceCommentId) <= 0)
+  ) {
+    return null;
+  }
+  if (hasSourceCommentUpdatedAt && !Number.isFinite(Date.parse(sourceCommentUpdatedAt || ""))) {
+    return null;
+  }
+  if (hasCommandBodyDigest && !/^[0-9a-f]{64}$/.test(commandBodyDigest || "")) return null;
+  if (
+    hasCommandOrigin &&
+    commandOrigin !== "hosted_webhook" &&
+    commandOrigin !== "comment_router"
+  ) {
+    return null;
+  }
+  if (hasSourceCommentVerified && typeof decision.sourceCommentVerified !== "boolean") return null;
+  const commandMetadataCount = [
+    hasSourceCommentId,
+    hasSourceCommentUpdatedAt,
+    hasCommandBodyDigest,
+    hasCommandOrigin,
+  ].filter(Boolean).length;
+  if (commandMetadataCount !== 0 && commandMetadataCount !== 4) return null;
   return {
     targetRepo,
     targetBranch,
@@ -402,6 +447,15 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
     ...(typeof commandStatusMarker === "string" ? { commandStatusMarker } : {}),
     ...(statusCommentId === undefined ? {} : { statusCommentId }),
     ...(typeof additionalPrompt === "string" ? { additionalPrompt } : {}),
+    ...(sourceCommentId === undefined ? {} : { sourceCommentId }),
+    ...(sourceCommentUpdatedAt === undefined ? {} : { sourceCommentUpdatedAt }),
+    ...(commandBodyDigest === undefined ? {} : { commandBodyDigest }),
+    ...(commandOrigin === "hosted_webhook" || commandOrigin === "comment_router"
+      ? { commandOrigin }
+      : {}),
+    ...(typeof decision.sourceCommentVerified === "boolean"
+      ? { sourceCommentVerified: decision.sourceCommentVerified }
+      : {}),
   };
 }
 
@@ -622,6 +676,22 @@ export function mergePendingExactReviewDecision(
   return merged;
 }
 
+export function exactReviewDecisionHasCommandContext(decision: ExactReviewDecision) {
+  return Boolean(decision.commandStatusMarker || decision.statusCommentId);
+}
+
+export function exactReviewCommandObligationSurvives(
+  current: ExactReviewDecision,
+  incoming: ExactReviewDecision,
+) {
+  if (!exactReviewDecisionHasCommandContext(current)) return true;
+  if (!exactReviewDecisionHasCommandContext(incoming)) return false;
+  return (
+    (current.commandStatusMarker ?? null) === (incoming.commandStatusMarker ?? null) &&
+    (current.statusCommentId ?? null) === (incoming.statusCommentId ?? null)
+  );
+}
+
 export function exactReviewDecisionAtLiveHead(decision: ExactReviewDecision, headSha: string) {
   const refreshed = {
     ...decision,
@@ -649,6 +719,25 @@ export function exactReviewDecisionCanSupersedeReview(
   incoming: ExactReviewDecision,
 ): boolean {
   const active = current.leaseDecision || current.decision;
+  if (
+    active.sourceCommentId &&
+    incoming.sourceCommentId &&
+    active.sourceCommentId === incoming.sourceCommentId
+  ) {
+    const activeCommentAt = Date.parse(String(active.sourceCommentUpdatedAt || ""));
+    const incomingCommentAt = Date.parse(String(incoming.sourceCommentUpdatedAt || ""));
+    if (Number.isFinite(activeCommentAt) && Number.isFinite(incomingCommentAt)) {
+      if (incomingCommentAt < activeCommentAt) return false;
+      if (
+        incomingCommentAt === activeCommentAt &&
+        active.commandBodyDigest &&
+        incoming.commandBodyDigest &&
+        active.commandBodyDigest !== incoming.commandBodyDigest
+      ) {
+        return incoming.sourceCommentVerified === true;
+      }
+    }
+  }
   if (active.itemKind !== "pull_request" || incoming.itemKind !== "pull_request") return true;
 
   const activeHead = String(active.sourceHeadSha || "").toLowerCase();
@@ -688,6 +777,29 @@ export function exactReviewDecisionCanSupersedeReview(
   }
 
   return incomingAuthoritySeq > activeSourceAuthoritySeq;
+}
+
+export function exactReviewCommandVersionIsOlder(
+  active: ExactReviewDecision,
+  incoming: ExactReviewDecision,
+) {
+  if (
+    !active.sourceCommentId ||
+    !incoming.sourceCommentId ||
+    active.sourceCommentId !== incoming.sourceCommentId
+  ) {
+    return false;
+  }
+  const activeAt = Date.parse(String(active.sourceCommentUpdatedAt || ""));
+  const incomingAt = Date.parse(String(incoming.sourceCommentUpdatedAt || ""));
+  if (!Number.isFinite(activeAt) || !Number.isFinite(incomingAt)) return false;
+  if (incomingAt !== activeAt) return incomingAt < activeAt;
+  return Boolean(
+    active.commandBodyDigest &&
+    incoming.commandBodyDigest &&
+    incoming.commandBodyDigest !== active.commandBodyDigest &&
+    incoming.sourceCommentVerified !== true,
+  );
 }
 
 export function exactReviewSourceAuthorityWatermark(

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -228,6 +228,15 @@ type ProjectionIdentity = {
   fenceKey: string;
   revision: number;
 };
+type LifecycleAdmissionInput = ProjectionIdentity & {
+  deliveryId: string;
+  sourceDeliveryId?: string;
+  sourceAction: string;
+  commandOriginated: boolean;
+  statusMarker: string | null;
+  statusCommentId: number | null;
+  observedAt: number;
+};
 
 export class ExactReviewLifecycleProjectionStore {
   private readonly storage: DurableStorage;
@@ -262,17 +271,11 @@ export class ExactReviewLifecycleProjectionStore {
     this.schemaReady = true;
   }
 
-  recordAdmission(
-    input: ProjectionIdentity & {
-      deliveryId: string;
-      sourceDeliveryId?: string;
-      sourceAction: string;
-      commandOriginated: boolean;
-      statusMarker: string | null;
-      statusCommentId: number | null;
-      observedAt: number;
-    },
-  ) {
+  recordAdmission(input: LifecycleAdmissionInput) {
+    return this.storage.transactionSync(() => this.recordAdmissionSync(input));
+  }
+
+  recordAdmissionSync(input: LifecycleAdmissionInput) {
     this.validateIdentity(input);
     if (!validText(input.deliveryId, 1, 300) || !validText(input.sourceAction, 1, 200)) {
       throw new Error("invalid lifecycle admission fact");
@@ -287,51 +290,49 @@ export class ExactReviewLifecycleProjectionStore {
       throw new Error("invalid lifecycle status comment id");
     }
     this.ensureSchemaSync();
-    return this.storage.transactionSync(() => {
-      const existing = this.readSync(input.canonicalTargetKey, input.fenceKey, input.revision);
-      if (existing) {
-        this.assertIdentity(existing, input);
-        const admission = existing.admission;
-        if (
-          admission.deliveryId !== input.deliveryId ||
-          admission.sourceDeliveryId !== input.sourceDeliveryId ||
-          admission.sourceAction !== input.sourceAction ||
-          admission.commandOriginated !== input.commandOriginated ||
-          admission.statusMarker !== input.statusMarker ||
-          admission.statusCommentId !== input.statusCommentId
-        ) {
-          throw new Error("conflicting lifecycle admission fact");
-        }
-        return existing;
+    const existing = this.readSync(input.canonicalTargetKey, input.fenceKey, input.revision);
+    if (existing) {
+      this.assertIdentity(existing, input);
+      const admission = existing.admission;
+      if (
+        admission.deliveryId !== input.deliveryId ||
+        admission.sourceDeliveryId !== input.sourceDeliveryId ||
+        admission.sourceAction !== input.sourceAction ||
+        admission.commandOriginated !== input.commandOriginated ||
+        admission.statusMarker !== input.statusMarker ||
+        admission.statusCommentId !== input.statusCommentId
+      ) {
+        throw new Error("conflicting lifecycle admission fact");
       }
-      const projection: ExactReviewLifecycleProjection = {
-        version: 1,
-        canonicalTargetKey: input.canonicalTargetKey,
-        fenceKey: input.fenceKey,
-        revision: input.revision,
-        admission: {
-          deliveryId: input.deliveryId,
-          ...(input.sourceDeliveryId ? { sourceDeliveryId: input.sourceDeliveryId } : {}),
-          sourceAction: input.sourceAction,
-          commandOriginated: input.commandOriginated,
-          statusMarker: input.statusMarker,
-          statusCommentId: input.statusCommentId,
-          admittedAt: input.observedAt,
-        },
-        claims: [],
-        reviewResults: [],
-        githubEffect: null,
-        canonicalReceipts: [],
-        routerReceipts: [],
-        routerReceipt: null,
-        acknowledgement: { required: input.commandOriginated, attempts: [], observed: null },
-        terminalDispositions: [],
-        terminalDisposition: null,
-        updatedAt: input.observedAt,
-      };
-      this.writeSync(projection);
-      return projection;
-    });
+      return existing;
+    }
+    const projection: ExactReviewLifecycleProjection = {
+      version: 1,
+      canonicalTargetKey: input.canonicalTargetKey,
+      fenceKey: input.fenceKey,
+      revision: input.revision,
+      admission: {
+        deliveryId: input.deliveryId,
+        ...(input.sourceDeliveryId ? { sourceDeliveryId: input.sourceDeliveryId } : {}),
+        sourceAction: input.sourceAction,
+        commandOriginated: input.commandOriginated,
+        statusMarker: input.statusMarker,
+        statusCommentId: input.statusCommentId,
+        admittedAt: input.observedAt,
+      },
+      claims: [],
+      reviewResults: [],
+      githubEffect: null,
+      canonicalReceipts: [],
+      routerReceipts: [],
+      routerReceipt: null,
+      acknowledgement: { required: input.commandOriginated, attempts: [], observed: null },
+      terminalDispositions: [],
+      terminalDisposition: null,
+      updatedAt: input.observedAt,
+    };
+    this.writeSync(projection);
+    return projection;
   }
 
   recordClaim(
@@ -484,25 +485,17 @@ export class ExactReviewLifecycleProjectionStore {
     },
   ) {
     this.validateIdentity(input);
-    return this.mutate(input, (projection) => {
-      const next = { kind: input.kind, observedAt: input.observedAt };
-      const current = projection.terminalDisposition;
-      if (!current) {
-        projection.terminalDispositions.push(next);
-        projection.terminalDisposition = next;
-        return projection;
-      }
-      if (current.kind === next.kind) return projection;
-      // A newer source can requeue a just-routed revision before its final
-      // queue completion lands. Requeue remains an immutable history fact and
-      // a later durable handoff may still complete the same admitted revision.
-      if (next.kind !== "requeue" && current.kind !== "requeue") {
-        throw new Error("conflicting lifecycle terminal disposition");
-      }
-      projection.terminalDispositions.push(next);
-      projection.terminalDisposition = next;
-      return projection;
-    });
+    return this.mutate(input, (projection) => applyTerminalDisposition(projection, input));
+  }
+
+  recordTerminalDispositionSync(
+    input: ProjectionIdentity & {
+      kind: LifecycleTerminalDisposition;
+      observedAt: number;
+    },
+  ) {
+    this.validateIdentity(input);
+    return this.mutateSync(input, (projection) => applyTerminalDisposition(projection, input));
   }
 
   authorizeCommandAcknowledgement(
@@ -767,6 +760,20 @@ export class ExactReviewLifecycleProjectionStore {
       return null;
     }
     return this.readSync(canonicalTargetKey, fenceKey, revision);
+  }
+
+  maxRevision(canonicalTargetKey: string) {
+    if (!validCanonicalTargetKey(canonicalTargetKey)) return 0;
+    const row = Array.from(
+      this.storage.sql.exec(
+        `SELECT MAX(revision) AS max_revision
+           FROM ${EXACT_REVIEW_LIFECYCLE_PROJECTION_TABLE}
+          WHERE canonical_target_key = ?`,
+        canonicalTargetKey,
+      ),
+    )[0] as { max_revision?: unknown } | undefined;
+    const revision = Number(row?.max_revision || 0);
+    return Number.isSafeInteger(revision) && revision >= 0 ? revision : 0;
   }
 
   /**
@@ -1133,18 +1140,24 @@ export class ExactReviewLifecycleProjectionStore {
     apply: (projection: ExactReviewLifecycleProjection) => T,
     writeResult = true,
   ): T {
+    return this.storage.transactionSync(() => this.mutateSync(input, apply, writeResult));
+  }
+
+  private mutateSync<T>(
+    input: ProjectionIdentity,
+    apply: (projection: ExactReviewLifecycleProjection) => T,
+    writeResult = true,
+  ): T {
     this.ensureSchemaSync();
-    return this.storage.transactionSync(() => {
-      const projection = this.readSync(input.canonicalTargetKey, input.fenceKey, input.revision);
-      if (!projection) throw new Error("missing lifecycle admission fact");
-      this.assertIdentity(projection, input);
-      const result = apply(projection);
-      if (writeResult) {
-        projection.updatedAt = Date.now();
-        this.writeSync(projection);
-      }
-      return result;
-    });
+    const projection = this.readSync(input.canonicalTargetKey, input.fenceKey, input.revision);
+    if (!projection) throw new Error("missing lifecycle admission fact");
+    this.assertIdentity(projection, input);
+    const result = apply(projection);
+    if (writeResult) {
+      projection.updatedAt = Date.now();
+      this.writeSync(projection);
+    }
+    return result;
   }
 
   private readSync(canonicalTargetKey: string, fenceKey: string, revision: number) {
@@ -1196,6 +1209,28 @@ export class ExactReviewLifecycleProjectionStore {
       throw new Error("conflicting lifecycle projection identity");
     }
   }
+}
+
+function applyTerminalDisposition(
+  projection: ExactReviewLifecycleProjection,
+  input: ProjectionIdentity & { kind: LifecycleTerminalDisposition; observedAt: number },
+) {
+  const next = { kind: input.kind, observedAt: input.observedAt };
+  const current = projection.terminalDisposition;
+  if (!current) {
+    projection.terminalDispositions.push(next);
+    projection.terminalDisposition = next;
+    return projection;
+  }
+  if (current.kind === next.kind) return projection;
+  // A newer source can requeue a just-routed revision before its final queue
+  // completion lands. Only a requeue may transition to another terminal fact.
+  if (next.kind !== "requeue" && current.kind !== "requeue") {
+    throw new Error("conflicting lifecycle terminal disposition");
+  }
+  projection.terminalDispositions.push(next);
+  projection.terminalDisposition = next;
+  return projection;
 }
 
 export function lifecycleState(projection: ExactReviewLifecycleProjection): LifecycleState {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -1,5 +1,11 @@
 import { stableJson } from "../src/stable-json.ts";
 import {
+  clawSweeperCommandAckMarker,
+  renderClawSweeperQueuedAcknowledgement,
+} from "../src/repair/comment-command-text.ts";
+import { planCommandAckConvergence } from "../src/repair/command-ack-convergence.ts";
+import type { DirectReReviewDecision } from "../src/repair/direct-re-review-admission.ts";
+import {
   normalizeStateWriterOperation,
   normalizeStateWriterProgress,
   payloadHash,
@@ -61,6 +67,10 @@ import {
 } from "./exact-review-lifecycle.ts";
 import { ExactReviewLifecycleTelemetryStore } from "./exact-review-lifecycle-telemetry.ts";
 import { GithubEgressTelemetryStore } from "./github-egress-telemetry.ts";
+import {
+  ExactReviewCommandIntakeStore,
+  type ExactReviewCommandIntakeRecord,
+} from "./exact-review-command-intake.ts";
 import { recentDurablePublicationEvents } from "./recent-durable-publication-events.ts";
 import { sanitizedServerError } from "./error-safety.ts";
 import {
@@ -91,6 +101,9 @@ import {
   exactReviewBranchAuthorityReservationKey,
   exactReviewDecisionAtLiveHead,
   exactReviewDecisionCanSupersedeReview,
+  exactReviewDecisionHasCommandContext,
+  exactReviewCommandObligationSurvives,
+  exactReviewCommandVersionIsOlder,
   exactReviewDecisionFrom,
   exactReviewDecisionWithoutSourceAuthority,
   exactReviewEditedSemanticInput,
@@ -639,6 +652,7 @@ export class ExactReviewQueue {
   private lifecycleProjectionStore;
   private lifecycleTelemetryStore;
   private githubEgressTelemetryStore;
+  private commandIntakeStore;
   private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
@@ -663,6 +677,7 @@ export class ExactReviewQueue {
     this.lifecycleProjectionStore = new ExactReviewLifecycleProjectionStore(this.storage);
     this.lifecycleTelemetryStore = new ExactReviewLifecycleTelemetryStore(this.storage);
     this.githubEgressTelemetryStore = new GithubEgressTelemetryStore(this.storage);
+    this.commandIntakeStore = new ExactReviewCommandIntakeStore(this.storage);
     // Direct in-process users retain the established eager setup behavior.
     // A real Durable Object has blockConcurrencyWhile; defer that setup until a
     // non-Bay request so constructing it for the public pure reader cannot
@@ -725,6 +740,21 @@ export class ExactReviewQueue {
       return events
         ? json({ recent_durable_publication_events: events })
         : json({ error: "invalid_window" }, 400);
+    }
+    if (request.method === "POST" && url.pathname === "/command-intake") {
+      const now = Date.now();
+      const admitted = this.commandIntakeStore.admit(await request.json().catch(() => null), now);
+      if (!admitted) return json({ error: "invalid_command_intake" }, 400);
+      if (admitted.accepted) await this.scheduleSourceAuthorityVerification(now);
+      return json(
+        {
+          ok: true,
+          accepted: admitted.accepted,
+          ...(admitted.accepted ? { deduped: admitted.deduped } : { reason: admitted.reason }),
+          command_version_id: admitted.commandVersionId,
+        },
+        202,
+      );
     }
     if (request.method === "POST" && url.pathname === "/branch-authority") {
       const body = objectValue(await request.json().catch(() => null));
@@ -1263,6 +1293,21 @@ export class ExactReviewQueue {
           // Ordinary source events retain normal replacement behavior, including the
           // command-context merge for pending items.
           if (!ignoredRecovery) {
+            if (
+              exactReviewCommandVersionIsOlder(current.leaseDecision || current.decision, decision)
+            ) {
+              this.storage.sql.exec(
+                `DELETE FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} WHERE delivery_id = ?`,
+                deliveryId,
+              );
+              this.writeStateSync(state);
+              return {
+                deduped: true as const,
+                staleCommand: true as const,
+                key,
+                state,
+              };
+            }
             const pendingTerminalFinalizer =
               Boolean(current.terminalFinalization) &&
               (current.state === "pending" || current.state === "parked");
@@ -1288,10 +1333,11 @@ export class ExactReviewQueue {
               // old publication or command marker.
               current.terminalFinalization = undefined;
             }
-            const nextRevision = Math.max(
-              current.revision + 1,
-              this.nextExactReviewItemRevisionSync(key),
-            );
+            const nextRevision =
+              exactReviewDecisionHasCommandContext(current.decision) ||
+              exactReviewDecisionHasCommandContext(decision)
+                ? this.nextExactReviewCommandRevisionSync(key, current.revision + 1)
+                : this.nextExactReviewItemRevisionSync(key, current.revision + 1);
             // Explicit commands arrive through repository_dispatch without a webhook authority
             // tuple. Bind them to the current verified decision via the merge below. An active
             // review keeps its lease and exposes the command as a follow-up revision on completion.
@@ -1314,6 +1360,12 @@ export class ExactReviewQueue {
               !attemptsReviewSupersession ||
               exactReviewDecisionCanSupersedeReview(current, decision);
             if (attemptsReviewSupersession && !sourceAuthorityIsNewer) {
+              if (decision.sourceCommentId) {
+                this.storage.sql.exec(
+                  `DELETE FROM ${EXACT_REVIEW_QUEUE_DELIVERY_TABLE} WHERE delivery_id = ?`,
+                  deliveryId,
+                );
+              }
               this.writeStateSync(state);
               return {
                 deduped: true as const,
@@ -1360,14 +1412,27 @@ export class ExactReviewQueue {
               exactReviewQueueIsPublication(current)
                 ? (current.decision.publication?.producerDecision ?? current.decision)
                 : current.decision;
-            current.decision = supersedesActiveReview
+            const nextDecision = supersedesActiveReview
               ? decision
               : mergeable || queuesCommandFollowUp
                 ? mergePendingExactReviewDecision(followUpMergeBase, decision)
                 : decision;
-            current.revision = nextRevision;
-            current.admissionDeliveryId = deliveryId;
-            current.updatedAt = now;
+            if (
+              exactReviewDecisionHasCommandContext(current.decision) ||
+              exactReviewDecisionHasCommandContext(nextDecision)
+            ) {
+              this.transitionCommandRevision(state, current, nextDecision, now, {
+                allocatedRevision: nextRevision,
+                admissionDeliveryId: deliveryId,
+                retainPriorLifecycle:
+                  queuesCommandFollowUp && current.revision === current.leaseRevision,
+              });
+            } else {
+              current.decision = nextDecision;
+              current.revision = nextRevision;
+              current.admissionDeliveryId = deliveryId;
+              current.updatedAt = now;
+            }
             // Immediacy must come from the merged decision: a pending explicit command
             // keeps its command marker through the merge, and a later plain webhook
             // event must not re-debounce it.
@@ -1443,7 +1508,9 @@ export class ExactReviewQueue {
             admissionDeliveryId: deliveryId,
             ...(ingress ? { ingressFingerprint: ingress.fingerprint } : {}),
             state: "pending",
-            revision: this.nextExactReviewItemRevisionSync(key),
+            revision: exactReviewDecisionHasCommandContext(decision)
+              ? this.nextExactReviewCommandRevisionSync(key, 1)
+              : this.nextExactReviewItemRevisionSync(key),
             createdAt: now,
             updatedAt: now,
             ...exactReviewQueueDebouncedAttempt(state, decision, now, now, this.env, true),
@@ -1452,6 +1519,7 @@ export class ExactReviewQueue {
               ? { sourceAuthorityWatermark: exactReviewSourceAuthorityWatermark(decision)! }
               : {}),
           };
+          this.recordCommandAdmission(state.items[key], decision, now);
           ingressAdmitted = true;
         }
         if (
@@ -1520,6 +1588,7 @@ export class ExactReviewQueue {
                 }
               : {}),
             ...("staleSource" in accepted && accepted.staleSource ? { stale_source: true } : {}),
+            ...("staleCommand" in accepted && accepted.staleCommand ? { stale_command: true } : {}),
             ...(accepted.superseded
               ? {
                   superseded: true,
@@ -3327,8 +3396,10 @@ export class ExactReviewQueue {
     await this.storage.deleteAlarm();
     await this.processBranchAuthorityReservations(startedAt);
     await this.processSourceAuthorityReservations(startedAt);
+    await this.processCommandIntakes(startedAt);
     let snapshot = this.storage.transactionSync(() => {
       this.pruneDeliveryReceiptsSync(startedAt);
+      this.commandIntakeStore.pruneTerminalReceipts(startedAt);
       this.directPublicationStore.pruneTerminalSync(startedAt);
       const current = this.readStateSync();
       this.syncLegacyCompatibilitySync(current);
@@ -4559,7 +4630,9 @@ export class ExactReviewQueue {
           key: canonicalKey,
           decision: canonicalDecision,
           state: "pending",
-          revision: this.nextExactReviewItemRevisionSync(canonicalKey),
+          revision: exactReviewDecisionHasCommandContext(canonicalDecision)
+            ? this.nextExactReviewCommandRevisionSync(canonicalKey, 1)
+            : this.nextExactReviewItemRevisionSync(canonicalKey),
           createdAt: now,
           updatedAt: now,
           ...exactReviewQueueDebouncedAttempt(state, canonicalDecision, now, now, this.env),
@@ -4799,7 +4872,7 @@ export class ExactReviewQueue {
         }
         clearExactReviewLease(item);
         item.state = "pending";
-        item.revision = Math.max(item.revision + 1, this.nextExactReviewItemRevisionSync(item.key));
+        item.revision = this.nextExactReviewItemRevisionSync(item.key, item.revision + 1);
         item.admissionDeliveryId = `parked-recovery:${recoveryKey}:${item.key}`;
         item.createdAt = now;
         item.updatedAt = now;
@@ -6241,6 +6314,91 @@ export class ExactReviewQueue {
     });
   }
 
+  private recordCommandAdmission(
+    item: ExactReviewQueueItem,
+    decision: ExactReviewDecision,
+    now: number,
+    revision = item.revision,
+  ) {
+    const commandDecision = decision.publication?.producerDecision ?? decision;
+    if (!exactReviewDecisionHasCommandContext(commandDecision)) return null;
+    const canonicalTargetKey = `${commandDecision.targetRepo}#${commandDecision.itemNumber}`;
+    const existing = this.lifecycleProjectionStore.read(canonicalTargetKey, item.key, revision);
+    if (existing) return existing;
+    return this.lifecycleProjectionStore.recordAdmissionSync({
+      canonicalTargetKey,
+      fenceKey: item.key,
+      revision,
+      deliveryId:
+        commandDecision.sourceDeliveryId ||
+        item.admissionDeliveryId ||
+        `command:${item.key}:${revision}`,
+      sourceAction: commandDecision.sourceAction,
+      commandOriginated: true,
+      statusMarker: commandDecision.commandStatusMarker ?? null,
+      statusCommentId: commandDecision.statusCommentId ?? null,
+      ...(commandDecision.sourceDeliveryId
+        ? { sourceDeliveryId: commandDecision.sourceDeliveryId }
+        : {}),
+      observedAt: now,
+    });
+  }
+
+  private transitionCommandRevision(
+    state: ExactReviewQueueState,
+    item: ExactReviewQueueItem,
+    decision: ExactReviewDecision,
+    now: number,
+    options: {
+      newItem?: boolean;
+      minimumRevision?: number;
+      allocatedRevision?: number;
+      admissionDeliveryId?: string;
+      retainPriorLifecycle?: boolean;
+    } = {},
+  ) {
+    if (!options.newItem) {
+      const prior = this.recordCommandAdmission(item, item.decision, now);
+      if (prior && !options.retainPriorLifecycle) {
+        const requestedKind = exactReviewCommandObligationSurvives(item.decision, decision)
+          ? "requeue"
+          : "superseded";
+        const committedKind = prior.terminalDisposition?.kind;
+        const terminal =
+          committedKind && committedKind !== "requeue"
+            ? prior
+            : this.lifecycleProjectionStore.recordTerminalDispositionSync({
+                canonicalTargetKey: prior.canonicalTargetKey,
+                fenceKey: prior.fenceKey,
+                revision: prior.revision,
+                kind: requestedKind,
+                observedAt: now,
+              });
+        const terminalKind = terminal.terminalDisposition?.kind;
+        if (terminalKind && terminalKind !== "requeue") {
+          this.ensureLifecycleTerminalFinalizationDriver({
+            state,
+            projection: terminal,
+            terminalDisposition: terminalKind,
+            now,
+          });
+        }
+      }
+    }
+    item.revision =
+      options.allocatedRevision ??
+      this.nextExactReviewCommandRevisionSync(
+        item.key,
+        Math.max(options.minimumRevision || 1, options.newItem ? 1 : item.revision + 1),
+      );
+    if (options.admissionDeliveryId) item.admissionDeliveryId = options.admissionDeliveryId;
+    item.decision = decision;
+    item.updatedAt = now;
+    state.items[item.key] = item;
+    this.recordCommandAdmission(item, decision, now);
+    return item;
+  }
+
   private recordLifecycleClaim(item: ExactReviewQueueItem, now: number) {
     if (!exactReviewQueueIsPublication(item) || item.terminalFinalization || !item.claimedRunId) {
       return;
@@ -7205,7 +7363,9 @@ export class ExactReviewQueue {
     item.admissionDeliveryId = `direct-lifecycle-requeue:${item.key}:${completedRevision}`;
     item.ingressFingerprint = undefined;
     item.state = "pending";
-    item.revision = Math.max(item.revision + 1, this.nextExactReviewItemRevisionSync(item.key));
+    item.revision = exactReviewDecisionHasCommandContext(decision)
+      ? this.nextExactReviewCommandRevisionSync(item.key, item.revision + 1)
+      : this.nextExactReviewItemRevisionSync(item.key, item.revision + 1);
     item.createdAt = now;
     item.updatedAt = now;
     item.parkedReason = undefined;
@@ -7238,8 +7398,18 @@ export class ExactReviewQueue {
     return Number(row?.source_revision || 0);
   }
 
-  private nextExactReviewItemRevisionSync(itemKey: string): number {
-    return this.publicationHeadRevisionSync(itemKey.toLowerCase()) + 1;
+  private nextExactReviewItemRevisionSync(itemKey: string, minimumRevision = 1): number {
+    return Math.max(minimumRevision, this.publicationHeadRevisionSync(itemKey.toLowerCase()) + 1);
+  }
+
+  private nextExactReviewCommandRevisionSync(itemKey: string, minimumRevision: number): number {
+    const canonicalKey = itemKey.split("@publish:")[0]!.toLowerCase();
+    return this.commandIntakeStore.allocateItemRevision(
+      canonicalKey,
+      minimumRevision,
+      this.lifecycleProjectionStore.maxRevision(canonicalKey),
+      this.publicationHeadRevisionSync(canonicalKey),
+    );
   }
 
   private freshPublicationItemKeysSync(state: ExactReviewQueueState, now: number) {
@@ -7293,6 +7463,7 @@ export class ExactReviewQueue {
 
   private async initializeStorage() {
     this.ensureStorageSchemaSync();
+    this.commandIntakeStore.ensureSchemaSync();
     this.batchStore.ensureSchemaSync();
     this.directPublicationStore.ensureSchemaSync();
     this.recordSnapshotStore.ensureSchemaSync();
@@ -9402,6 +9573,253 @@ export class ExactReviewQueue {
     this.storage.kv.delete(EXACT_REVIEW_QUEUE_STATE_KEY);
   }
 
+  private async processCommandIntakes(now: number) {
+    for (const record of this.commandIntakeStore.due(now)) {
+      if (!this.commandIntakeStore.isCurrent(record)) {
+        this.commandIntakeStore.finish(
+          record.intake.commandVersionId,
+          "superseded",
+          Date.now(),
+          "newer_comment_version",
+        );
+        continue;
+      }
+      const circuitRetryAt = exactReviewGithubTargetAppCircuitRetryAt(
+        this.readStateSync(),
+        record.intake.decision.targetRepo,
+        now,
+      );
+      if (circuitRetryAt > now) {
+        this.commandIntakeStore.defer(
+          record,
+          now,
+          "target GitHub credential circuit is open",
+          circuitRetryAt,
+          false,
+        );
+        continue;
+      }
+      let tokenPromise: Promise<string> | null = null;
+      const token = () => (tokenPromise ??= exactReviewCommandTargetToken(this.env, record.intake));
+      try {
+        let current = record;
+        if (current.stage === "verify_pending") {
+          const decision = await this.verifyCommandIntake(current, token());
+          if (!decision) continue;
+          this.commandIntakeStore.advance(
+            current.intake.commandVersionId,
+            "enqueue_pending",
+            Date.now(),
+            decision,
+          );
+          current = { ...current, stage: "enqueue_pending", verifiedDecision: decision };
+        }
+        if (current.stage === "enqueue_pending") {
+          const decision = current.verifiedDecision;
+          if (!decision) throw new Error("verified command decision is missing");
+          const response = await this.fetch(
+            new Request("https://clawsweeper-exact-review-queue/enqueue", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                delivery_id: current.intake.commandVersionId,
+                decision,
+              }),
+            }),
+          );
+          const result = objectValue(await response.json().catch(() => null));
+          if (!response.ok) {
+            throw new Error(`command queue admission failed: ${response.status}`);
+          }
+          if (result.stale_source === true || result.stale_command === true) {
+            this.commandIntakeStore.retryVerification(
+              current,
+              Date.now(),
+              result.stale_command === true ? "older_command_version" : "stale_source_authority",
+            );
+            continue;
+          }
+          if (result.queued !== true && result.deduped !== true) {
+            this.commandIntakeStore.finish(
+              current.intake.commandVersionId,
+              "rejected",
+              Date.now(),
+              String(result.reason || result.error || "queue_rejected"),
+            );
+            continue;
+          }
+          this.commandIntakeStore.advance(
+            current.intake.commandVersionId,
+            "effects_pending",
+            Date.now(),
+            decision,
+          );
+          current = { ...current, stage: "effects_pending" };
+        }
+        if (current.stage === "effects_pending") {
+          const decision = current.verifiedDecision;
+          if (!decision) throw new Error("command effects decision is missing");
+          await Promise.all([
+            convergeCommandAcknowledgement({
+              env: this.env,
+              token: token(),
+              decision,
+              sourceCommentId: current.intake.sourceCommentId,
+            }),
+            addCommandReaction({
+              env: this.env,
+              token: token(),
+              repo: decision.targetRepo,
+              commentId: current.intake.sourceCommentId,
+            }),
+          ]);
+          this.commandIntakeStore.finish(
+            current.intake.commandVersionId,
+            "completed",
+            Date.now(),
+            null,
+          );
+        }
+      } catch (error) {
+        const observedAt = Date.now();
+        const observation = exactReviewGithubTargetAppObservation(
+          error,
+          record.intake.decision.targetRepo,
+          observedAt,
+        );
+        this.recordAuthorityGithubOutcomeSync(
+          record.attempts > 0,
+          observation ? "throttle" : "error",
+          observedAt,
+          observation,
+        );
+        this.commandIntakeStore.defer(
+          record,
+          observedAt,
+          sanitizedServerError(error),
+          observation?.retryAt,
+        );
+      }
+    }
+  }
+
+  private async verifyCommandIntake(
+    record: ExactReviewCommandIntakeRecord,
+    token: Promise<string>,
+  ): Promise<DirectReReviewDecision | null> {
+    const intake = record.intake;
+    let sourceComment: Record<string, unknown>;
+    try {
+      sourceComment = objectValue(
+        await githubTokenJson({
+          env: this.env,
+          token: await token,
+          path: `/repos/${intake.decision.targetRepo}/issues/comments/${intake.sourceCommentId}`,
+          method: "GET",
+          body: undefined,
+          errorLabel: "direct re-review source comment",
+        }),
+      );
+    } catch (error) {
+      if (error instanceof GitHubRequestError && (error.status === 404 || error.status === 410)) {
+        this.commandIntakeStore.finish(
+          intake.commandVersionId,
+          "rejected",
+          Date.now(),
+          "source_comment_missing",
+        );
+        return null;
+      }
+      throw error;
+    }
+    const sourceIssueUrl = String(sourceComment.issue_url || "");
+    if (
+      !sourceIssueUrl.endsWith(
+        `/repos/${intake.decision.targetRepo}/issues/${intake.decision.itemNumber}`,
+      )
+    ) {
+      this.commandIntakeStore.finish(
+        intake.commandVersionId,
+        "rejected",
+        Date.now(),
+        "source_comment_item_mismatch",
+      );
+      return null;
+    }
+    const liveCommentUpdatedAt = Date.parse(String(sourceComment.updated_at || ""));
+    const admittedCommentUpdatedAt = Date.parse(intake.sourceCommentUpdatedAt);
+    const liveCommentDigest = await sha256Hex(
+      new TextEncoder().encode(String(sourceComment.body || "")),
+    );
+    if (!Number.isFinite(liveCommentUpdatedAt) || liveCommentUpdatedAt < admittedCommentUpdatedAt) {
+      throw new Error("live source comment version is not yet authoritative");
+    }
+    if (
+      liveCommentUpdatedAt > admittedCommentUpdatedAt ||
+      liveCommentDigest !== intake.commandBodyDigest
+    ) {
+      this.commandIntakeStore.finish(
+        intake.commandVersionId,
+        "rejected",
+        Date.now(),
+        "source_comment_changed",
+      );
+      return null;
+    }
+
+    let decision: DirectReReviewDecision = {
+      ...intake.decision,
+      sourceCommentVerified: true,
+    };
+    const itemPath = decision.itemKind === "pull_request" ? "pulls" : "issues";
+    const item = objectValue(
+      await githubTokenJson({
+        env: this.env,
+        token: await token,
+        path: `/repos/${decision.targetRepo}/${itemPath}/${decision.itemNumber}`,
+        method: "GET",
+        body: undefined,
+        errorLabel: "direct re-review item",
+      }),
+    );
+    if (String(item.state || "").toLowerCase() !== "open") {
+      this.commandIntakeStore.finish(
+        intake.commandVersionId,
+        "rejected",
+        Date.now(),
+        "target_not_open",
+      );
+      return null;
+    }
+    if (decision.itemKind === "pull_request") {
+      const headSha = String(objectValue(item.head).sha || "")
+        .trim()
+        .toLowerCase();
+      const sourceUpdatedAt = String(item.updated_at || "").trim();
+      if (!/^[0-9a-f]{40}$/.test(headSha)) {
+        throw new Error("live pull request head is invalid");
+      }
+      const sourceAuthoritySeq = this.storage.transactionSync(() => {
+        const stored = this.storage.kv.get(EXACT_REVIEW_SOURCE_AUTHORITY_SEQUENCE_KEY);
+        const current = stored === undefined ? 0 : Number(stored);
+        if (!Number.isSafeInteger(current) || current < 0 || current >= Number.MAX_SAFE_INTEGER) {
+          throw new Error("invalid exact-review source authority sequence");
+        }
+        const next = current + 1;
+        this.storage.kv.put(EXACT_REVIEW_SOURCE_AUTHORITY_SEQUENCE_KEY, next);
+        return next;
+      });
+      decision = {
+        ...decision,
+        sourceHeadSha: headSha,
+        sourceHeadVerified: true,
+        sourceAuthoritySeq,
+        ...(Number.isFinite(Date.parse(sourceUpdatedAt)) ? { sourceUpdatedAt } : {}),
+      };
+    }
+    return decision;
+  }
+
   private async processSourceAuthorityReservations(now: number) {
     const reservations = (await this.sourceAuthorityReservations())
       .filter((reservation) => reservation.nextAttemptAt <= now)
@@ -9728,12 +10146,14 @@ export class ExactReviewQueue {
       this.freshPublicationItemKeysSync(state, now),
     );
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
+    const commandIntakeNext = this.commandIntakeStore.nextAttemptAt();
     const credentialCircuitNext = exactReviewGithubCircuitNextWakeAt(state, now);
     const next = [
       queueNext,
       batchOwnership.nextLeaseExpiresAt,
       batchDeparture?.dueAt ?? null,
       sourceAuthorityNext,
+      commandIntakeNext,
       credentialCircuitNext,
     ]
       .filter((candidate): candidate is number => candidate !== null)
@@ -11974,6 +12394,108 @@ async function exactReviewSourceAuthorityLiveHead(
   return String(objectValue(objectValue(pull).head).sha || "")
     .trim()
     .toLowerCase();
+}
+
+async function exactReviewCommandTargetToken(
+  env,
+  intake: ExactReviewCommandIntakeRecord["intake"],
+) {
+  const credentials = githubAppCredentials(env);
+  if (!credentials) throw new Error("github app is not configured");
+  const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
+  return createGithubAppTokenFor({
+    env,
+    appJwt,
+    installationId: intake.installationId,
+    label: intake.decision.targetRepo,
+    repositories: [repoName(intake.decision.targetRepo)],
+    permissions: { issues: "write", pull_requests: "write" },
+  });
+}
+
+export async function convergeCommandAcknowledgement(options: {
+  env: Record<string, unknown>;
+  token: Promise<string>;
+  decision: DirectReReviewDecision;
+  sourceCommentId: number;
+}) {
+  const token = await options.token;
+  const ackMarker = clawSweeperCommandAckMarker(options.sourceCommentId);
+  const statusMarker = options.decision.commandStatusMarker;
+  const list = async () => {
+    const comments = await githubTokenJson({
+      env: options.env,
+      token,
+      path: `/repos/${options.decision.targetRepo}/issues/${options.decision.itemNumber}/comments?per_page=100`,
+      method: "GET",
+      body: undefined,
+      errorLabel: "direct command acknowledgement list",
+    });
+    return Array.isArray(comments)
+      ? comments
+          .map((comment) => objectValue(comment))
+          .filter((comment) => String(comment.body || "").includes(ackMarker))
+      : [];
+  };
+  let comments = await list();
+  let exact = comments.find((comment) => String(comment.body || "").includes(statusMarker));
+  if (!exact) {
+    const bare = comments.find(
+      (comment) => !String(comment.body || "").includes("clawsweeper-command-status:"),
+    );
+    const bareId = Number(bare?.id) || null;
+    const body = renderClawSweeperQueuedAcknowledgement(options.sourceCommentId, statusMarker);
+    exact = objectValue(
+      await githubTokenJson({
+        env: options.env,
+        token,
+        path: bareId
+          ? `/repos/${options.decision.targetRepo}/issues/comments/${bareId}`
+          : `/repos/${options.decision.targetRepo}/issues/${options.decision.itemNumber}/comments`,
+        method: bareId ? "PATCH" : "POST",
+        body: { body },
+        errorLabel: "direct command acknowledgement",
+      }),
+    );
+    comments = [
+      ...(await list()),
+      { ...exact, body, id: Number(exact.id || bareId), created_at: exact.created_at || "" },
+    ];
+  }
+  const convergence = planCommandAckConvergence(comments, statusMarker);
+  for (const duplicate of convergence.prunable.slice(0, 20)) {
+    const id = Number(duplicate.id);
+    if (!Number.isSafeInteger(id) || id <= 0) continue;
+    await githubTokenJson({
+      env: options.env,
+      token,
+      path: `/repos/${options.decision.targetRepo}/issues/comments/${id}`,
+      method: "DELETE",
+      body: undefined,
+      errorLabel: "duplicate command acknowledgement cleanup",
+    }).catch((error) => {
+      if (!(error instanceof GitHubRequestError && error.status === 404)) throw error;
+    });
+  }
+  return Number(convergence.keep?.id || exact.id) || null;
+}
+
+async function addCommandReaction(options: {
+  env: Record<string, unknown>;
+  token: Promise<string>;
+  repo: string;
+  commentId: number;
+}) {
+  await githubTokenJson({
+    env: options.env,
+    token: await options.token,
+    path: `/repos/${options.repo}/issues/comments/${options.commentId}/reactions`,
+    method: "POST",
+    body: { content: "eyes" },
+    errorLabel: "direct command reaction",
+  }).catch((error) => {
+    if (!(error instanceof GitHubRequestError && error.status === 422)) throw error;
+  });
 }
 
 async function exactReviewTargetReadToken(env, targetRepo: string, knownInstallationId?: number) {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -9606,6 +9606,15 @@ export class ExactReviewQueue {
         if (current.stage === "verify_pending") {
           const decision = await this.verifyCommandIntake(current, token());
           if (!decision) continue;
+          if (!this.commandIntakeStore.markVerified(current, Date.now())) {
+            this.commandIntakeStore.finish(
+              current.intake.commandVersionId,
+              "superseded",
+              Date.now(),
+              "newer_comment_version",
+            );
+            continue;
+          }
           this.commandIntakeStore.advance(
             current.intake.commandVersionId,
             "enqueue_pending",
@@ -9615,6 +9624,15 @@ export class ExactReviewQueue {
           current = { ...current, stage: "enqueue_pending", verifiedDecision: decision };
         }
         if (current.stage === "enqueue_pending") {
+          if (!this.commandIntakeStore.isCurrent(current)) {
+            this.commandIntakeStore.finish(
+              current.intake.commandVersionId,
+              "superseded",
+              Date.now(),
+              "newer_comment_version",
+            );
+            continue;
+          }
           const decision = current.verifiedDecision;
           if (!decision) throw new Error("verified command decision is missing");
           const response = await this.fetch(
@@ -9657,6 +9675,15 @@ export class ExactReviewQueue {
           current = { ...current, stage: "effects_pending" };
         }
         if (current.stage === "effects_pending") {
+          if (!this.commandIntakeStore.isCurrent(current)) {
+            this.commandIntakeStore.finish(
+              current.intake.commandVersionId,
+              "superseded",
+              Date.now(),
+              "newer_comment_version",
+            );
+            continue;
+          }
           const decision = current.verifiedDecision;
           if (!decision) throw new Error("command effects decision is missing");
           await Promise.all([

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -12422,22 +12422,66 @@ export async function convergeCommandAcknowledgement(options: {
   const token = await options.token;
   const ackMarker = clawSweeperCommandAckMarker(options.sourceCommentId);
   const statusMarker = options.decision.commandStatusMarker;
+  const trustedBotLogins = exactReviewCommandBotLogins(options.env);
+  const trustedAcknowledgement = (comment: Record<string, unknown>) =>
+    trustedBotLogins.has(
+      String(objectValue(comment.user).login || "")
+        .trim()
+        .toLowerCase(),
+    );
   const list = async () => {
-    const comments = await githubTokenJson({
-      env: options.env,
-      token,
-      path: `/repos/${options.decision.targetRepo}/issues/${options.decision.itemNumber}/comments?per_page=100`,
-      method: "GET",
-      body: undefined,
-      errorLabel: "direct command acknowledgement list",
-    });
-    return Array.isArray(comments)
-      ? comments
-          .map((comment) => objectValue(comment))
-          .filter((comment) => String(comment.body || "").includes(ackMarker))
-      : [];
+    const matching: Record<string, unknown>[] = [];
+    for (let page = 1; page <= 5; page += 1) {
+      const comments = await githubTokenJson({
+        env: options.env,
+        token,
+        path: `/repos/${options.decision.targetRepo}/issues/${options.decision.itemNumber}/comments?per_page=100&page=${page}`,
+        method: "GET",
+        body: undefined,
+        errorLabel: "direct command acknowledgement list",
+      });
+      if (!Array.isArray(comments)) break;
+      const records = comments.map((comment) => objectValue(comment));
+      matching.push(
+        ...records.filter(
+          (comment) =>
+            trustedAcknowledgement(comment) && String(comment.body || "").includes(ackMarker),
+        ),
+      );
+      if (records.length < 100) break;
+    }
+    return matching;
   };
   let comments = await list();
+  const suppliedStatusCommentId = Number(options.decision.statusCommentId) || null;
+  if (
+    suppliedStatusCommentId &&
+    !comments.some((comment) => Number(comment.id) === suppliedStatusCommentId)
+  ) {
+    const supplied = objectValue(
+      await githubTokenJson({
+        env: options.env,
+        token,
+        path: `/repos/${options.decision.targetRepo}/issues/comments/${suppliedStatusCommentId}`,
+        method: "GET",
+        body: undefined,
+        errorLabel: "direct command supplied acknowledgement",
+      }).catch((error) => {
+        if (error instanceof GitHubRequestError && error.status === 404) return null;
+        throw error;
+      }),
+    );
+    if (
+      Number(supplied.id) === suppliedStatusCommentId &&
+      trustedAcknowledgement(supplied) &&
+      String(supplied.body || "").includes(ackMarker) &&
+      String(supplied.issue_url || "").endsWith(
+        `/repos/${options.decision.targetRepo}/issues/${options.decision.itemNumber}`,
+      )
+    ) {
+      comments.push(supplied);
+    }
+  }
   let exact = comments.find((comment) => String(comment.body || "").includes(statusMarker));
   if (!exact) {
     const bare = comments.find(
@@ -12478,6 +12522,16 @@ export async function convergeCommandAcknowledgement(options: {
     });
   }
   return Number(convergence.keep?.id || exact.id) || null;
+}
+
+function exactReviewCommandBotLogins(env: Record<string, unknown>) {
+  const configured = String(env.CLAWSWEEPER_BOT_LOGINS || "")
+    .split(",")
+    .map((login) => login.trim().toLowerCase())
+    .filter(Boolean);
+  return new Set(
+    configured.length ? configured : ["clawsweeper[bot]", "openclaw-clawsweeper[bot]"],
+  );
 }
 
 async function addCommandReaction(options: {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1,7 +1,10 @@
 import {
   commandTextForClawSweeperFastAck,
+  directReReviewAdditionalPrompt,
   isClawSweeperReReviewCommandText,
+  reReviewContextFromClawSweeperComment,
 } from "../src/repair/comment-command-text.ts";
+import { directReReviewIntake } from "../src/repair/direct-re-review-admission.ts";
 import { isExactReviewCloseGuardLabel } from "../src/repair/exact-review-guard-labels.ts";
 import { bayHtml } from "./bay-page.ts";
 import {
@@ -108,6 +111,8 @@ type GithubWebhookUserPayload = { readonly login?: unknown };
 type GithubWebhookIssuePayload = {
   readonly number?: unknown;
   readonly user?: GithubWebhookUserPayload | null;
+  readonly state?: unknown;
+  readonly pull_request?: unknown;
 };
 type GithubWebhookCommentPayload = {
   readonly id?: unknown;
@@ -116,6 +121,7 @@ type GithubWebhookCommentPayload = {
   readonly user?: GithubWebhookUserPayload | null;
   readonly created_at?: unknown;
   readonly updated_at?: unknown;
+  readonly html_url?: unknown;
 };
 type GithubWebhookPullRequestPayload = {
   readonly number?: unknown;
@@ -169,11 +175,16 @@ export type GithubWebhookIssueCommentClassification = {
   readonly targetRepo: string;
   readonly targetBranch: string;
   readonly itemNumber: number;
+  readonly itemKind: "issue" | "pull_request";
+  readonly itemState: string;
   readonly commentId: number;
   readonly installationId: number;
   readonly sourceAction: string;
   readonly commentUpdatedAt?: string;
   readonly commentBody?: string;
+  readonly commentAuthor: string;
+  readonly commentUrl: string;
+  readonly maintainerAuthorized: boolean;
 };
 type GithubWebhookIssueClassification = ExactReviewDecision & {
   readonly accepted: true;
@@ -738,6 +749,8 @@ export default {
       return json({ ok: true, service: "clawsweeper-github-webhook" });
     if (url.pathname === "/github/webhook" && request.method === "POST")
       return githubWebhook(request, env, ctx);
+    if (url.pathname === "/internal/exact-review/command-intake" && request.method === "POST")
+      return authenticatedExactReviewQueueRequest(request, env, "/command-intake");
     if (url.pathname === "/internal/exact-review/enqueue" && request.method === "POST")
       return authenticatedExactReviewEnqueue(request, env);
     if (url.pathname === "/internal/exact-review/branch-authority" && request.method === "POST")
@@ -1603,6 +1616,41 @@ async function githubWebhook(request, env, ctx) {
   });
   if (trigger) await recordBayJourneyTelemetry(env, ctx, [trigger], []);
 
+  const commentDecision = decision;
+  if (
+    commentDecision.itemState === "open" &&
+    typeof commentDecision.commentBody === "string" &&
+    commentDecision.commentUpdatedAt &&
+    reReviewContextFromClawSweeperComment(commentDecision.commentBody) !== null
+  ) {
+    const intake = directReReviewIntake({
+      targetRepo: commentDecision.targetRepo,
+      targetBranch: commentDecision.targetBranch,
+      itemNumber: commentDecision.itemNumber,
+      itemKind: commentDecision.itemKind,
+      installationId: commentDecision.installationId,
+      sourceCommentId: commentDecision.commentId,
+      sourceCommentUpdatedAt: commentDecision.commentUpdatedAt,
+      commandBodyDigest: await sha256Text(commentDecision.commentBody),
+      commandOrigin: "hosted_webhook",
+      additionalPrompt: directReReviewAdditionalPrompt({
+        body: commentDecision.commentBody,
+        maintainerAuthorized: commentDecision.maintainerAuthorized,
+        author: commentDecision.commentAuthor,
+        commentUrl: commentDecision.commentUrl,
+      }),
+    });
+    const queue = exactReviewQueueStub(env);
+    if (!queue) return json({ error: "exact_review_queue_not_configured" }, 503);
+    return queue.fetch(
+      new Request("https://clawsweeper-exact-review-queue/command-intake", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(intake),
+      }),
+    );
+  }
+
   const credentials = githubAppCredentials(env);
   if (!credentials) return json({ error: "github_app_not_configured" }, 503);
   const appJwt = await signGithubAppJwt(credentials.issuer, credentials.privateKey);
@@ -1615,7 +1663,6 @@ async function githubWebhook(request, env, ctx) {
     permissions: { contents: "write" },
   });
 
-  const commentDecision = decision;
   const targetToken = await createGithubAppTokenFor({
     env,
     appJwt,
@@ -1837,9 +1884,14 @@ function classifyGithubIssueCommentWebhook({
     targetRepo,
     targetBranch,
     itemNumber,
+    itemKind: issue.pull_request ? "pull_request" : "issue",
+    itemState: String(issue.state || "").toLowerCase(),
     commentId,
     installationId,
     sourceAction: action,
+    commentAuthor: String(objectValue(comment.user).login || ""),
+    commentUrl: String(comment.html_url || ""),
+    maintainerAuthorized: CLAWSWEEPER_ALLOWED_ASSOCIATIONS.has(association),
     ...(commentUpdatedAt
       ? {
           commentUpdatedAt,

--- a/docs/pr-review-comments.md
+++ b/docs/pr-review-comments.md
@@ -36,6 +36,14 @@ shard posts a short status placeholder with the same durable identity marker.
 The placeholder is intentionally light and crustacean-friendly, then the final
 review sync edits that exact comment in place.
 
+Interactive re-review commands have a separate durable intake marker. The
+ExactReviewQueue records the exact source-comment version before creating or
+editing its acknowledgement, then converges on one status comment containing
+both `clawsweeper-command-ack:<source-comment-id>` and a version-specific
+`clawsweeper-command-status` marker. Retries may repeat GitHub reads and writes,
+but they must reuse the command receipt and must not enqueue the same comment
+version twice.
+
 After a newer source revision wins its lease, ClawSweeper may delete dedicated
 review-start placeholders for older revisions. The candidate comment snapshot
 is captured first, then the worker must still own the exact queue

--- a/docs/proof/durable-command-intake/behavior-contract.md
+++ b/docs/proof/durable-command-intake/behavior-contract.md
@@ -1,0 +1,52 @@
+# Durable command intake behavior contract
+
+## User-visible goal
+
+An eligible `@clawsweeper re-review` comment becomes durable before ClawSweeper
+acknowledges or dispatches it. Target GitHub App throttling may delay processing,
+but it must neither lose the command nor enqueue the same comment version twice.
+
+## Target
+
+- Type: Cloudflare Worker HTTP API and ExactReviewQueue Durable Object.
+- Launch: `wrangler dev --local` from both the pinned main baseline and candidate.
+- Fixtures: a signed pull-request `issue_comment` webhook and a loopback GitHub
+  API that accepts acknowledgement writes but throttles the old Actions dispatch
+  path and the candidate's deferred source verification.
+
+## User tasks
+
+1. Submit the same eligible re-review webhook to the main baseline.
+2. Submit it to the candidate Worker.
+3. Stop the complete Worker process group after each boot and inspect its local
+   Durable Object SQLite state.
+
+## Expected observable behavior
+
+- Baseline: the optimistic acknowledgement can be created before the throttled
+  repository dispatch fails, and no durable command-intake row exists.
+- Candidate: the webhook returns HTTP 202 without first writing an optimistic
+  acknowledgement; all four command tables exist and the throttled command
+  remains pending for retry.
+- Redelivery of the same version resolves through its existing receipt.
+
+## Anti-cheat probes
+
+- Use a real loopback HTTP listener through `GITHUB_API_URL`, not an in-process
+  fetch stub.
+- Boot a real local Worker twice with separate persistence roots.
+- Kill the full process group between boots so no Worker or alarm state leaks
+  from baseline to candidate.
+- Assert the ExactReviewQueue Durable Object was instantiated by finding its
+  command-intake SQLite schema and pending receipt.
+
+## Evidence required
+
+- Baseline and candidate commit SHAs, HTTP results, loopback request counts,
+  process-group termination results, SQLite table inventory, and receipt state.
+- Crabbox provider and lease id in the committed receipt.
+
+## Out of scope
+
+- Live GitHub credentials, production mutation, executor completion, and final
+  public review publication.

--- a/docs/proof/durable-command-intake/behavior-report.json
+++ b/docs/proof/durable-command-intake/behavior-report.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "contract": "docs/proof/durable-command-intake/behavior-contract.md",
+  "target": "pinned-main and candidate Cloudflare Workers via wrangler dev --local",
+  "summary": { "pass": 6, "fail": 0, "blocked": 0, "out_of_scope": 0 },
+  "clauses": [
+    {
+      "id": "baseline_failure",
+      "result": "pass",
+      "evidence": "HTTP 500 followed one acknowledgement, one reaction, and one throttled dispatch."
+    },
+    {
+      "id": "baseline_not_durable",
+      "result": "pass",
+      "evidence": "No command-intake schema or command row existed after the baseline process group stopped."
+    },
+    {
+      "id": "candidate_acceptance",
+      "result": "pass",
+      "evidence": "Candidate returned HTTP 202 accepted=true before any acknowledgement or dispatch."
+    },
+    {
+      "id": "candidate_retry_durability",
+      "result": "pass",
+      "evidence": "After one throttled source-comment read, one intake and one pending receipt remained."
+    },
+    {
+      "id": "durable_object_instantiation",
+      "result": "pass",
+      "evidence": "All four exact-review command tables were present in local Durable Object SQLite."
+    },
+    {
+      "id": "boot_isolation",
+      "result": "pass",
+      "evidence": "Both Wrangler process groups exited after SIGTERM before the next boot or inspection."
+    }
+  ],
+  "anti_cheat_probes": [
+    "real loopback GITHUB_API_URL listener",
+    "separate baseline and candidate persistence roots",
+    "full process-group termination between boots",
+    "post-stop SQLite schema and receipt inspection"
+  ],
+  "findings": [],
+  "limits": [
+    "No live GitHub credentials or production mutations.",
+    "Executor completion and final public review publication were not exercised."
+  ]
+}

--- a/docs/proof/durable-command-intake/receipt.md
+++ b/docs/proof/durable-command-intake/receipt.md
@@ -3,17 +3,16 @@
 The pinned-main/candidate comparison passed on the repository-resolved Crabbox
 backend.
 
-- Tested candidate: `10f574b39c62cbc99a972967bda4e529cb15784e`
+- Tested candidate: `ee949363f5c4cf755a431020b738f1bf06ae49b5`
 - Baseline: `bd869542a3a820c4d3d5fb44bcf2fc553f8f3468`
 - Provider: `aws`
-- Lease: `cbx_63aaf1aeefab` (`golden-shrimp-4f6a`)
-- Run: `run_ebdd0e751613`
+- Lease: `cbx_6b30d164d7dc` (`jade-barnacle-c01a`)
+- Run: `run_7cfa46ca99f9`
 - Machine: `c7a.8xlarge`, Linux (`ubuntu:26.04` resolved target)
 - Result: `comparison_pass=true`; exit code 0
 - Cleanup: both inner Wrangler process groups confirmed SIGTERM completion
-  before persistence inspection. Crabbox heartbeat trouble left the outer lease
-  visible after the successful command, so it was explicitly released and
-  verified absent from the owned-lease inventory.
+  before persistence inspection. Crabbox reported `leaseStopped=true`, and a
+  final provider list showed no owned live lease.
 
 The baseline wrote one optimistic acknowledgement and reaction, then returned
 HTTP 500 when its repository dispatch was throttled. It had no durable command
@@ -26,7 +25,7 @@ Command:
 
 ```sh
 PROOF_BASE_SHA=bd869542a3a820c4d3d5fb44bcf2fc553f8f3468 \
-PROOF_CANDIDATE_SHA=10f574b39c62cbc99a972967bda4e529cb15784e \
+PROOF_CANDIDATE_SHA=ee949363f5c4cf755a431020b738f1bf06ae49b5 \
 PROOF_OUTPUT=.artifacts/durable-command-intake \
 node docs/proof/durable-command-intake/run-proof.mjs
 ```

--- a/docs/proof/durable-command-intake/receipt.md
+++ b/docs/proof/durable-command-intake/receipt.md
@@ -1,0 +1,41 @@
+# Durable command intake proof receipt
+
+The pinned-main/candidate comparison passed on the repository-resolved Crabbox
+backend.
+
+- Tested candidate: `2483005e35204228ddf2f2ebf42c8a6c1c49c6b2`
+- Baseline: `bd869542a3a820c4d3d5fb44bcf2fc553f8f3468`
+- Provider: `aws`
+- Lease: `cbx_0af821d4195f` (`silver-shrimp`)
+- Run: `run_33bdb0af560e`
+- Machine: `c7a.8xlarge`, Linux (`ubuntu:26.04` resolved target)
+- Result: `comparison_pass=true`; exit code 0
+- Cleanup: Crabbox reported `leaseStopped=true`; a final provider list showed no
+  owned live lease. Both inner Wrangler process groups also confirmed SIGTERM
+  completion before persistence inspection.
+
+The baseline wrote one optimistic acknowledgement and reaction, then returned
+HTTP 500 when its repository dispatch was throttled. It had no durable command
+schema or intake row. The candidate returned HTTP 202 before acknowledgement,
+then retained one pending intake/receipt when its deferred source-comment read
+was throttled. SQLite inspection found all four required tables, which proves
+the ExactReviewQueue Durable Object was instantiated.
+
+Command:
+
+```sh
+PROOF_BASE_SHA=bd869542a3a820c4d3d5fb44bcf2fc553f8f3468 \
+PROOF_CANDIDATE_SHA=2483005e35204228ddf2f2ebf42c8a6c1c49c6b2 \
+PROOF_OUTPUT=.artifacts/durable-command-intake \
+node docs/proof/durable-command-intake/run-proof.mjs
+```
+
+The successful run used Crabbox `--no-hydrate` because this repository's pinned
+`pnpm/action-setup` step is not supported by the wrapper's local Actions
+hydrator. That workaround did not change provider selection; the proof script
+requires only the raw image's Node 24, Git, and npx toolchain.
+
+Limits: the GitHub API was a loopback synthetic listener, and no live credential
+or production mutation was used. The proof covers command acceptance, throttled
+retry durability, Worker boot isolation, and DO schema instantiation; it does
+not exercise executor completion or final public review publication.

--- a/docs/proof/durable-command-intake/receipt.md
+++ b/docs/proof/durable-command-intake/receipt.md
@@ -3,16 +3,17 @@
 The pinned-main/candidate comparison passed on the repository-resolved Crabbox
 backend.
 
-- Tested candidate: `2483005e35204228ddf2f2ebf42c8a6c1c49c6b2`
+- Tested candidate: `10f574b39c62cbc99a972967bda4e529cb15784e`
 - Baseline: `bd869542a3a820c4d3d5fb44bcf2fc553f8f3468`
 - Provider: `aws`
-- Lease: `cbx_0af821d4195f` (`silver-shrimp`)
-- Run: `run_33bdb0af560e`
+- Lease: `cbx_63aaf1aeefab` (`golden-shrimp-4f6a`)
+- Run: `run_ebdd0e751613`
 - Machine: `c7a.8xlarge`, Linux (`ubuntu:26.04` resolved target)
 - Result: `comparison_pass=true`; exit code 0
-- Cleanup: Crabbox reported `leaseStopped=true`; a final provider list showed no
-  owned live lease. Both inner Wrangler process groups also confirmed SIGTERM
-  completion before persistence inspection.
+- Cleanup: both inner Wrangler process groups confirmed SIGTERM completion
+  before persistence inspection. Crabbox heartbeat trouble left the outer lease
+  visible after the successful command, so it was explicitly released and
+  verified absent from the owned-lease inventory.
 
 The baseline wrote one optimistic acknowledgement and reaction, then returned
 HTTP 500 when its repository dispatch was throttled. It had no durable command
@@ -25,7 +26,7 @@ Command:
 
 ```sh
 PROOF_BASE_SHA=bd869542a3a820c4d3d5fb44bcf2fc553f8f3468 \
-PROOF_CANDIDATE_SHA=2483005e35204228ddf2f2ebf42c8a6c1c49c6b2 \
+PROOF_CANDIDATE_SHA=10f574b39c62cbc99a972967bda4e529cb15784e \
 PROOF_OUTPUT=.artifacts/durable-command-intake \
 node docs/proof/durable-command-intake/run-proof.mjs
 ```

--- a/docs/proof/durable-command-intake/result.json
+++ b/docs/proof/durable-command-intake/result.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-12T17:08:17.631Z",
+  "base_sha": "bd869542a3a820c4d3d5fb44bcf2fc553f8f3468",
+  "candidate_sha": "2483005e35204228ddf2f2ebf42c8a6c1c49c6b2",
+  "provider_environment": "Crabbox-selected provider; see receipt.md",
+  "comparison_pass": true,
+  "baseline": {
+    "response": { "status": 500 },
+    "github": {
+      "acknowledgements": 1,
+      "dispatchAttempts": 1,
+      "sourceCommentReads": 0,
+      "reactions": 1
+    },
+    "sqlite": {
+      "commandSchemaPresent": false,
+      "commandIntakes": 0,
+      "receiptOutcomes": []
+    },
+    "process_tree_kill": { "signal": "SIGTERM", "confirmed": true }
+  },
+  "candidate": {
+    "response": {
+      "status": 202,
+      "accepted": true,
+      "deduped": false,
+      "command_version_id": "command-9001-msqaw0kw-1e1d2457837dc1f6ead419e59d2cbfc1e3d0c416368765252799cd62e216cccc"
+    },
+    "github": {
+      "acknowledgements": 0,
+      "dispatchAttempts": 0,
+      "sourceCommentReads": 1,
+      "reactions": 0
+    },
+    "sqlite": {
+      "requiredTables": [
+        "exact_review_command_intakes",
+        "exact_review_command_receipts",
+        "exact_review_command_watermarks",
+        "exact_review_item_revisions"
+      ],
+      "commandIntakes": 1,
+      "receiptOutcomes": ["pending"]
+    },
+    "durable_object_instantiated": true,
+    "process_tree_kill": { "signal": "SIGTERM", "confirmed": true }
+  },
+  "limits": {
+    "github": "loopback synthetic API; no live credentials or production mutations",
+    "worker": "wrangler dev --local; executor completion and public publication not exercised"
+  }
+}

--- a/docs/proof/durable-command-intake/result.json
+++ b/docs/proof/durable-command-intake/result.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T17:32:05.572Z",
+  "generated_at": "2026-08-12T17:57:28.290Z",
   "base_sha": "bd869542a3a820c4d3d5fb44bcf2fc553f8f3468",
-  "candidate_sha": "10f574b39c62cbc99a972967bda4e529cb15784e",
+  "candidate_sha": "ee949363f5c4cf755a431020b738f1bf06ae49b5",
   "provider_environment": "Crabbox-selected provider; see receipt.md",
   "comparison_pass": true,
   "baseline": {

--- a/docs/proof/durable-command-intake/result.json
+++ b/docs/proof/durable-command-intake/result.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T17:08:17.631Z",
+  "generated_at": "2026-08-12T17:32:05.572Z",
   "base_sha": "bd869542a3a820c4d3d5fb44bcf2fc553f8f3468",
-  "candidate_sha": "2483005e35204228ddf2f2ebf42c8a6c1c49c6b2",
+  "candidate_sha": "10f574b39c62cbc99a972967bda4e529cb15784e",
   "provider_environment": "Crabbox-selected provider; see receipt.md",
   "comparison_pass": true,
   "baseline": {

--- a/docs/proof/durable-command-intake/run-proof.mjs
+++ b/docs/proof/durable-command-intake/run-proof.mjs
@@ -31,10 +31,20 @@ for (const directory of [baselineDir, candidateDir, baselinePersist, candidatePe
   fs.mkdirSync(directory, { recursive: true });
 }
 
-const baseSha = git(["rev-parse", baseRef]);
-const candidateSha = git(["rev-parse", "HEAD"]);
-archive(baseSha, baselineDir);
-archive(candidateSha, candidateDir);
+const hasGitMetadata = isGitRepository();
+const baseSha = /^[0-9a-f]{40}$/.test(baseRef) ? baseRef : git(["rev-parse", baseRef]);
+const candidateSha =
+  process.env.PROOF_CANDIDATE_SHA || (hasGitMetadata ? git(["rev-parse", "HEAD"]) : "");
+if (!/^[0-9a-f]{40}$/.test(candidateSha)) {
+  throw new Error("PROOF_CANDIDATE_SHA is required when Crabbox sync omits Git metadata");
+}
+if (hasGitMetadata) {
+  archive(baseSha, baselineDir);
+  archive(candidateSha, candidateDir);
+} else {
+  cloneBaseline(baseSha, baselineDir);
+  copyCandidateTree(candidateDir);
+}
 
 const { privateKey } = generateKeyPairSync("rsa", {
   modulusLength: 2048,
@@ -407,6 +417,53 @@ function archive(ref, destination) {
     maxBuffer: 256 * 1024 * 1024,
   });
   if (extracted.status !== 0) throw new Error(`tar extraction failed: ${extracted.stderr}`);
+}
+
+function cloneBaseline(ref, destination) {
+  const parent = path.dirname(destination);
+  const checkout = path.join(parent, "baseline-checkout");
+  const cloned = spawnSync(
+    "git",
+    [
+      "clone",
+      "--filter=blob:none",
+      "--no-checkout",
+      "https://github.com/openclaw/clawsweeper.git",
+      checkout,
+    ],
+    { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (cloned.status !== 0) throw new Error(`baseline clone failed: ${cloned.stderr}`);
+  const checkedOut = spawnSync("git", ["-C", checkout, "checkout", "--detach", ref], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (checkedOut.status !== 0) throw new Error(`baseline checkout failed: ${checkedOut.stderr}`);
+  fs.rmSync(destination, { recursive: true, force: true });
+  fs.renameSync(checkout, destination);
+}
+
+function copyCandidateTree(destination) {
+  const sourceRoot = process.cwd();
+  fs.cpSync(sourceRoot, destination, {
+    recursive: true,
+    filter: (source) => {
+      const relative = path.relative(sourceRoot, source);
+      if (!relative) return true;
+      const first = relative.split(path.sep)[0];
+      return ![".artifacts", ".crabbox", ".git", "coverage", "dist", "node_modules"].includes(
+        first,
+      );
+    },
+  });
+}
+
+function isGitRepository() {
+  return (
+    spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      encoding: "utf8",
+    }).status === 0
+  );
 }
 
 function git(args) {

--- a/docs/proof/durable-command-intake/run-proof.mjs
+++ b/docs/proof/durable-command-intake/run-proof.mjs
@@ -230,9 +230,10 @@ async function sendWebhook(port) {
     },
     body,
   });
+  const responseBody = await response.text();
   return {
     status: response.status,
-    body: await response.text(),
+    body: responseBody.slice(0, 500),
   };
 }
 
@@ -396,11 +397,11 @@ function writeDevVars(checkout, githubOrigin, key) {
   const values = {
     CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
     CLAWSWEEPER_APP_CLIENT_ID: "Iv23durable-command-intake-proof",
-    CLAWSWEEPER_APP_PRIVATE_KEY: key.replace(/\n/g, "\\n"),
+    CLAWSWEEPER_APP_PRIVATE_KEY: key,
     GITHUB_API_URL: githubOrigin,
   };
   const contents = `${Object.entries(values)
-    .map(([name, value]) => `${name}=${JSON.stringify(value)}`)
+    .map(([name, value]) => `${name}=${value.includes("\n") ? `"${value}"` : value}`)
     .join("\n")}\n`;
   fs.writeFileSync(path.join(checkout, ".dev.vars"), contents);
   fs.writeFileSync(path.join(checkout, "dashboard", ".dev.vars"), contents);

--- a/docs/proof/durable-command-intake/run-proof.mjs
+++ b/docs/proof/durable-command-intake/run-proof.mjs
@@ -1,0 +1,448 @@
+import { spawn, spawnSync } from "node:child_process";
+import { createHmac, generateKeyPairSync } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const outputDir = path.resolve(process.env.PROOF_OUTPUT || ".artifacts/durable-command-intake");
+const baseRef = process.env.PROOF_BASE_SHA || "origin/main";
+const commandBody = "@clawsweeper re-review\n\nPlease check the current head.";
+const commandUpdatedAt = "2026-08-12T16:25:26Z";
+const commandCommentId = 9_001;
+const itemNumber = 42;
+const headSha = "a".repeat(40);
+const webhookSecret = "durable-command-intake-proof-secret";
+const requiredTables = [
+  "exact_review_command_intakes",
+  "exact_review_command_receipts",
+  "exact_review_command_watermarks",
+  "exact_review_item_revisions",
+];
+
+fs.mkdirSync(outputDir, { recursive: true });
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "durable-command-intake-proof-"));
+const baselineDir = path.join(root, "baseline");
+const candidateDir = path.join(root, "candidate");
+const baselinePersist = path.join(root, "baseline-persist");
+const candidatePersist = path.join(root, "candidate-persist");
+for (const directory of [baselineDir, candidateDir, baselinePersist, candidatePersist]) {
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+const baseSha = git(["rev-parse", baseRef]);
+const candidateSha = git(["rev-parse", "HEAD"]);
+archive(baseSha, baselineDir);
+archive(candidateSha, candidateDir);
+
+const { privateKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+let activeBoot = "baseline";
+const observations = {
+  baseline: observation(),
+  candidate: observation(),
+};
+const github = await startGithubLoopback(() => observations[activeBoot]);
+
+try {
+  writeDevVars(baselineDir, github.origin, privateKey);
+  writeDevVars(candidateDir, github.origin, privateKey);
+
+  const baseline = await runWorkerBoot({
+    label: "baseline",
+    checkout: baselineDir,
+    persist: baselinePersist,
+    setActive: () => {
+      activeBoot = "baseline";
+    },
+  });
+  const candidate = await runWorkerBoot({
+    label: "candidate",
+    checkout: candidateDir,
+    persist: candidatePersist,
+    setActive: () => {
+      activeBoot = "candidate";
+    },
+  });
+
+  const baselineSql = inspectPersistence(baselinePersist);
+  const candidateSql = inspectPersistence(candidatePersist);
+  const baselineHasCommandSchema = requiredTables.some((table) =>
+    baselineSql.tables.includes(table),
+  );
+  const candidateHasCommandSchema = requiredTables.every((table) =>
+    candidateSql.tables.includes(table),
+  );
+  const comparisonPass =
+    baseline.response.status >= 500 &&
+    observations.baseline.acknowledgements >= 1 &&
+    observations.baseline.dispatchAttempts >= 1 &&
+    !baselineHasCommandSchema &&
+    candidate.response.status === 202 &&
+    observations.candidate.acknowledgements === 0 &&
+    candidateHasCommandSchema &&
+    candidateSql.commandIntakes === 1 &&
+    candidateSql.receiptOutcomes.includes("pending") &&
+    baseline.processTreeKill.confirmed &&
+    candidate.processTreeKill.confirmed;
+
+  const result = {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    base_sha: baseSha,
+    candidate_sha: candidateSha,
+    provider_environment: "Crabbox-selected provider; see receipt.md",
+    comparison_pass: comparisonPass,
+    baseline: {
+      response: baseline.response,
+      github: observations.baseline,
+      sqlite: baselineSql,
+      process_tree_kill: baseline.processTreeKill,
+    },
+    candidate: {
+      response: candidate.response,
+      github: observations.candidate,
+      sqlite: candidateSql,
+      durable_object_instantiated: candidateHasCommandSchema,
+      process_tree_kill: candidate.processTreeKill,
+    },
+    limits: {
+      github: "loopback synthetic API; no live credentials or production mutations",
+      worker: "wrangler dev --local; executor completion and public publication not exercised",
+    },
+  };
+  fs.writeFileSync(path.join(outputDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!comparisonPass) process.exitCode = 1;
+} finally {
+  await github.close();
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+function observation() {
+  return {
+    acknowledgements: 0,
+    dispatchAttempts: 0,
+    sourceCommentReads: 0,
+    reactions: 0,
+  };
+}
+
+async function runWorkerBoot({ label, checkout, persist, setActive }) {
+  setActive();
+  const port = await unusedPort();
+  const stdoutPath = path.join(outputDir, `${label}-wrangler.stdout.log`);
+  const stderrPath = path.join(outputDir, `${label}-wrangler.stderr.log`);
+  const stdout = fs.openSync(stdoutPath, "w");
+  const stderr = fs.openSync(stderrPath, "w");
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      "wrangler@4.107.0",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      persist,
+      "--config",
+      "dashboard/wrangler.toml",
+    ],
+    {
+      cwd: checkout,
+      detached: true,
+      stdio: ["ignore", stdout, stderr],
+      env: { ...process.env, NO_COLOR: "1" },
+    },
+  );
+  fs.closeSync(stdout);
+  fs.closeSync(stderr);
+  try {
+    await waitForHealth(port, child);
+    const response = await sendWebhook(port);
+    await delay(1_500);
+    return {
+      response,
+      processTreeKill: await stopProcessGroup(child),
+    };
+  } catch (error) {
+    const processTreeKill = await stopProcessGroup(child);
+    throw new Error(
+      `${label} worker proof failed: ${error instanceof Error ? error.message : String(error)}; process_tree_kill=${JSON.stringify(processTreeKill)}`,
+    );
+  }
+}
+
+async function sendWebhook(port) {
+  const body = JSON.stringify({
+    action: "created",
+    repository: {
+      full_name: "openclaw/openclaw",
+      default_branch: "main",
+      private: false,
+      archived: false,
+      fork: false,
+      has_issues: true,
+    },
+    installation: { id: 123 },
+    issue: {
+      number: itemNumber,
+      state: "open",
+      user: { login: "contributor" },
+      pull_request: { url: `https://api.github.com/repos/openclaw/openclaw/pulls/${itemNumber}` },
+    },
+    comment: {
+      id: commandCommentId,
+      body: commandBody,
+      author_association: "CONTRIBUTOR",
+      user: { login: "contributor" },
+      created_at: commandUpdatedAt,
+      updated_at: commandUpdatedAt,
+      html_url: `https://github.com/openclaw/openclaw/pull/${itemNumber}#issuecomment-${commandCommentId}`,
+    },
+  });
+  const signature = `sha256=${createHmac("sha256", webhookSecret).update(body).digest("hex")}`;
+  const response = await fetch(`http://127.0.0.1:${port}/github/webhook`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": "issue_comment",
+      "x-github-delivery": `proof-${port}`,
+      "x-hub-signature-256": signature,
+    },
+    body,
+  });
+  return {
+    status: response.status,
+    body: await response.text(),
+  };
+}
+
+async function startGithubLoopback(currentObservation) {
+  const acknowledgements = new Map();
+  let nextCommentId = 20_000;
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url || "/", "http://127.0.0.1");
+    const body = await readJson(request);
+    const observed = currentObservation();
+    if (url.pathname === `/repos/openclaw/openclaw/issues/comments/${commandCommentId}`) {
+      observed.sourceCommentReads += 1;
+      return sendJson(
+        response,
+        403,
+        {
+          message: "API rate limit exceeded for installation",
+        },
+        {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1_000) + 60),
+        },
+      );
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return sendJson(response, 200, { id: 777 });
+    }
+    if (/^\/app\/installations\/(?:123|777)\/access_tokens$/.test(url.pathname)) {
+      return sendJson(response, 201, { token: "synthetic-loopback-token" });
+    }
+    if (url.pathname === `/repos/openclaw/openclaw/issues/${itemNumber}/comments`) {
+      if (request.method === "GET") return sendJson(response, 200, [...acknowledgements.values()]);
+      if (request.method === "POST") {
+        const comment = {
+          id: nextCommentId++,
+          body: String(body.body || ""),
+          created_at: new Date().toISOString(),
+        };
+        acknowledgements.set(comment.id, comment);
+        observed.acknowledgements += 1;
+        return sendJson(response, 201, comment);
+      }
+    }
+    if (url.pathname === `/repos/openclaw/openclaw/issues/comments/${commandCommentId}/reactions`) {
+      observed.reactions += 1;
+      return sendJson(response, 201, { id: observed.reactions, content: "eyes" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      observed.dispatchAttempts += 1;
+      return sendJson(response, 403, { message: "API rate limit exceeded for installation" });
+    }
+    return sendJson(response, 404, { message: `unhandled ${request.method} ${url.pathname}` });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("loopback server missing address");
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}
+
+function inspectPersistence(rootDirectory) {
+  const tables = new Set();
+  const receiptOutcomes = [];
+  let commandIntakes = 0;
+  for (const file of walk(rootDirectory)) {
+    let database;
+    try {
+      database = new DatabaseSync(file, { readOnly: true });
+      const names = database
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all()
+        .map((row) => String(row.name));
+      names.forEach((name) => tables.add(name));
+      if (names.includes("exact_review_command_intakes")) {
+        commandIntakes += Number(
+          database.prepare("SELECT COUNT(*) AS count FROM exact_review_command_intakes").get()
+            ?.count || 0,
+        );
+      }
+      if (names.includes("exact_review_command_receipts")) {
+        receiptOutcomes.push(
+          ...database
+            .prepare(
+              "SELECT outcome FROM exact_review_command_receipts ORDER BY command_version_id",
+            )
+            .all()
+            .map((row) => String(row.outcome)),
+        );
+      }
+    } catch {
+      // Wrangler persistence contains metadata alongside SQLite files.
+    } finally {
+      database?.close();
+    }
+  }
+  return {
+    tables: [...tables].sort(),
+    commandIntakes,
+    receiptOutcomes,
+  };
+}
+
+function walk(directory) {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    return entry.isDirectory() ? walk(target) : [target];
+  });
+}
+
+async function stopProcessGroup(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { signal: child.signalCode || "exited", confirmed: true };
+  }
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+  const graceful = await waitForExit(child, 5_000);
+  if (graceful) return { signal: "SIGTERM", confirmed: true };
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+  return { signal: "SIGKILL", confirmed: await waitForExit(child, 5_000) };
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+async function waitForHealth(port, child) {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    if (child.exitCode !== null) throw new Error(`wrangler exited ${child.exitCode}`);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+      if (response.ok) return;
+    } catch {
+      // Worker is still compiling.
+    }
+    await delay(250);
+  }
+  throw new Error("wrangler health check timed out");
+}
+
+function writeDevVars(checkout, githubOrigin, key) {
+  const values = {
+    CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
+    CLAWSWEEPER_APP_CLIENT_ID: "Iv23durable-command-intake-proof",
+    CLAWSWEEPER_APP_PRIVATE_KEY: key.replace(/\n/g, "\\n"),
+    GITHUB_API_URL: githubOrigin,
+  };
+  const contents = `${Object.entries(values)
+    .map(([name, value]) => `${name}=${JSON.stringify(value)}`)
+    .join("\n")}\n`;
+  fs.writeFileSync(path.join(checkout, ".dev.vars"), contents);
+  fs.writeFileSync(path.join(checkout, "dashboard", ".dev.vars"), contents);
+}
+
+function archive(ref, destination) {
+  const result = spawnSync("git", ["archive", "--format=tar", ref], {
+    encoding: null,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (result.status !== 0) throw new Error(`git archive ${ref} failed: ${result.stderr}`);
+  const extracted = spawnSync("tar", ["-xf", "-", "-C", destination], {
+    input: result.stdout,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (extracted.status !== 0) throw new Error(`tar extraction failed: ${extracted.stderr}`);
+}
+
+function git(args) {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function unusedPort() {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("port probe missing address"));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? JSON.parse(text) : {};
+}
+
+function sendJson(response, status, value, headers = {}) {
+  response.writeHead(status, { "content-type": "application/json", ...headers });
+  response.end(JSON.stringify(value));
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -376,7 +376,12 @@ Supported triggers:
 @openclaw-clawsweeper fix ci
 ```
 
-`review` and `re-review` dispatch ClawSweeper review again for an open issue or PR.
+`review` and `re-review` admit the exact comment version to the durable review
+queue for an open issue or PR. The hosted webhook is the fast path; the
+five-minute router scan is the recovery producer. Both converge on the same
+comment-version receipt, so a throttled router cannot lose the command and a
+redelivery cannot start the same version twice. The queue verifies the source
+comment and current PR head before it creates the marker-backed acknowledgement.
 Issue implementation commands (`implement`, `fix`, `build`, `create pr`, `fix issue`)
 dispatch the repair worker for one open issue and ask it to create or update a
 single ClawSweeper implementation PR. The generated job uses

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -5,16 +5,17 @@ for review records, R2 is canonical for immutable action ledgers and published
 assets, and the `state` branch of `openclaw/clawsweeper-state` retains only the
 operational paths that have not migrated yet.
 
-| Logical paths | Canonical owner | Git state status |
-| --- | --- | --- |
-| `records/**` | Durable Object record store with R2 snapshots | Never checked out or written |
-| fanout and placeholder-recovery cursors per mode | ExactReviewQueue Durable Object KV | Never checked out or written |
-| `ledger/v1/**` | R2 immutable blobs | Never checked out or written |
-| `assets/**` | R2 mutable blobs | Never checked out or written |
-| `jobs/**` | `clawsweeper-state` `state` branch | Retained until its own migration |
-| `results/**` | `clawsweeper-state` `state` branch | Retained until its own migration |
-| `notifications/**` | `clawsweeper-state` `state` branch | Retained until its own migration |
-| `apply-report.json`, `repair-apply-report.json` | `clawsweeper-state` `state` branch | Retained until their own migration |
+| Logical paths                                                                         | Canonical owner                               | Git state status                   |
+| ------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------- |
+| `records/**`                                                                          | Durable Object record store with R2 snapshots | Never checked out or written       |
+| fanout and placeholder-recovery cursors per mode                                      | ExactReviewQueue Durable Object KV            | Never checked out or written       |
+| exact re-review command intakes, version watermarks, receipts, and per-item revisions | ExactReviewQueue Durable Object SQLite        | Never checked out or written       |
+| `ledger/v1/**`                                                                        | R2 immutable blobs                            | Never checked out or written       |
+| `assets/**`                                                                           | R2 mutable blobs                              | Never checked out or written       |
+| `jobs/**`                                                                             | `clawsweeper-state` `state` branch            | Retained until its own migration   |
+| `results/**`                                                                          | `clawsweeper-state` `state` branch            | Retained until its own migration   |
+| `notifications/**`                                                                    | `clawsweeper-state` `state` branch            | Retained until its own migration   |
+| `apply-report.json`, `repair-apply-report.json`                                       | `clawsweeper-state` `state` branch            | Retained until their own migration |
 
 `setup-state` always hydrates records from the Worker and ledger/assets from R2.
 Jobs that need operational Git state receive a sparse checkout containing only
@@ -32,6 +33,13 @@ record operations. Each record carries a monotonic revision so concurrent
 writers cannot silently overwrite one another. Cursor reads and writes are
 fail-open: an unavailable store emits a prominent warning, but productive work
 continues and remains safe to retry.
+
+Eligible `@clawsweeper re-review` comment versions cross the durable boundary
+before acknowledgement or Actions dispatch. The queue keeps one immutable
+identity per comment id, update timestamp, and body digest; a newer edit
+supersedes older pending work, while retries reuse the same receipt. Detailed
+terminal receipts use the same 30-day horizon as resolved dead letters, and the
+per-comment watermark remains after receipt compaction.
 
 Git-backed reports, dashboard status, and post-dispatch cursors are best-effort
 after their productive side effect or canonical publication succeeds. Git

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -352,19 +352,29 @@ right before posting; when a superseding event arrives during that wait, the
 shared concurrency group cancels the sleeping run before it posts.
 
 Comments are a lightweight trigger only when the body contains a ClawSweeper
-command, and generated proof-nudge comments are explicitly ignored before command
-matching. The target workflow reacts with `eyes` and creates one visible queued
-status comment for maintainer-authored commands when target write permission is
-available, but both acknowledgement writes are best-effort. It must still dispatch
-`clawsweeper_comment` to the comment router when acknowledgement or queued-comment
-creation gets a target-repository 403. The dispatch carries the exact source
-comment id and, when available, the queued status comment id. The router edits
-that queued comment in place instead of posting a second reply.
+command, and generated proof-nudge comments are explicitly ignored before
+command matching. Eligible open-item `review` and `re-review` command versions
+go directly into the ExactReviewQueue Durable Object before any acknowledgement
+or Actions dispatch. The identity binds the comment id, GitHub update timestamp,
+and body digest. The queue verifies that exact live comment, binds a live PR head,
+and retries GitHub dependencies with bounded 15-second-to-15-minute backoff.
+Only after durable admission does it converge the marker-backed status comment
+and `eyes` reaction. Redelivery is therefore idempotent, and App-token throttling
+cannot leave an optimistic “router queued” comment as the only record of intent.
+
+Other commands retain the comment-router path. The target workflow reacts with
+`eyes` and creates one visible queued status comment for maintainer-authored
+commands when target write permission is available, but both acknowledgement
+writes are best-effort. It must still dispatch `clawsweeper_comment` to the
+comment router when acknowledgement or queued-comment creation gets a
+target-repository 403. The dispatch carries the exact source comment id and,
+when available, the queued status comment id. The router edits that queued
+comment in place instead of posting a second reply.
 Exact comment dispatches scan only that comment and use a per-comment receiver
 concurrency group, so one maintainer command does not wait behind an unrelated
 command on the same repository. The scheduled sweep remains a five-minute
-fallback. Bot-authored label churn is also ignored. Human
-Label changes never directly trigger an exact review. Content-changing events
+fallback. Bot-authored label churn is also ignored. Label changes never
+directly trigger an exact review. Content-changing events
 such as issue edits and PR synchronizes update the desired review revision. The
 receiver coalesces by repository and item number, then dispatches only a leased
 executor for the newest revision.
@@ -377,7 +387,8 @@ endpoint is `/github/webhook`; the local equivalent is
 `steipete/*` `issue_comment`, `issues`, and `pull_request` events, mints a
 target installation token for acknowledgement/comment reactions, mints the
 `openclaw/clawsweeper` installation token for repository dispatch, and queues
-exact `clawsweeper_comment` or `clawsweeper_item` work. The durable Worker
+exact `clawsweeper_comment` or `clawsweeper_item` work. Re-review commands take
+the direct durable command-intake route described above. The durable Worker
 queue dispatches at most 128 leased exact-review executors, with up to 120 active
 reviews per target repository. Keep the Actions
 dispatcher installed as a compatibility fallback; its legacy dispatch is

--- a/scripts/check-dashboard-strict.mjs
+++ b/scripts/check-dashboard-strict.mjs
@@ -16,6 +16,7 @@ export const DASHBOARD_STRICT_BASELINE_FILES = Object.freeze([
   "dashboard/automerge-metrics.ts",
   "dashboard/dashboard-health.ts",
   "dashboard/error-safety.ts",
+  "dashboard/exact-review-command-intake.ts",
   "dashboard/exact-review-decision.ts",
   "dashboard/exact-review-publication-retry.ts",
   "dashboard/exact-review-queue-shared.ts",

--- a/src/repair/comment-command-text.ts
+++ b/src/repair/comment-command-text.ts
@@ -38,13 +38,16 @@ export function extractClawSweeperCommandLine(body: unknown): ClawSweeperCommand
   return null;
 }
 
-export function commandTextForClawSweeperFastAck(body: unknown) {
+export function normalizeClawSweeperCommandLine(body: unknown): ClawSweeperCommandLine | null {
   const command = extractClawSweeperCommandLine(body);
-  if (!command) return "";
-  if (command.trigger === "mention" && command.commandText === "status" && command.rest) {
-    return command.rest;
+  if (command?.trigger === "mention" && command.commandText === "status" && command.rest) {
+    return commandLine("mention", command.rest, "", false);
   }
-  return command.commandText;
+  return command;
+}
+
+export function commandTextForClawSweeperFastAck(body: unknown) {
+  return normalizeClawSweeperCommandLine(body)?.commandText ?? "";
 }
 
 export function isClawSweeperReReviewCommandText(commandText: unknown) {
@@ -73,6 +76,58 @@ export function reviewPromptFromClawSweeperCommandText(commandText: unknown) {
     .trim()
     .replace(RE_REVIEW_PROMPT_PREFIX_PATTERN, "")
     .trim();
+}
+
+export function reReviewContextFromClawSweeperComment(body: unknown) {
+  const command = normalizeClawSweeperCommandLine(body);
+  if (!command || !isClawSweeperReReviewCommandText(command.commandText)) return null;
+  return [
+    reviewPromptFromClawSweeperCommandText(command.commandText),
+    command.supportsContinuation ? command.rest : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export function directReReviewAdditionalPrompt(options: {
+  body: unknown;
+  maintainerAuthorized: boolean;
+  author: unknown;
+  commentUrl: unknown;
+}) {
+  if (!options.maintainerAuthorized) return "";
+  const context = reReviewContextFromClawSweeperComment(options.body);
+  if (!context) return "";
+  return [
+    "Maintainer context from an @clawsweeper re-review command.",
+    "",
+    `Author: ${String(options.author || "unknown")}`,
+    `Comment: ${String(options.commentUrl || "unknown")}`,
+    "",
+    "Requested focus:",
+    context.slice(0, 3000),
+    "",
+    "Use this only as read-only review context. Do not merge, close, label, or push code from the model.",
+  ].join("\n");
+}
+
+export const clawSweeperCommandAckMarker = (sourceCommentId: number) =>
+  `<!-- clawsweeper-command-ack:${sourceCommentId} -->`;
+
+export function renderClawSweeperQueuedAcknowledgement(
+  sourceCommentId: number,
+  statusMarker?: string,
+) {
+  const detail = statusMarker
+    ? [statusMarker, "🦞👀", "Exact review queued."]
+    : [
+        "🦞👀",
+        "ClawSweeper picked this up.",
+        "",
+        "Command router queued. I will update this comment with the next step.",
+      ];
+  return [clawSweeperCommandAckMarker(sourceCommentId), ...detail].join("\n");
 }
 
 function commandLine(

--- a/src/repair/comment-router-core.ts
+++ b/src/repair/comment-router-core.ts
@@ -2931,7 +2931,7 @@ function normalizeIntent(command: LooseRecord) {
 }
 
 export function commandStatusMarker(command: LooseRecord) {
-  return `<!-- clawsweeper-command-status:${command.issue_number ?? "unknown"}:${command.intent}:${command.target?.head_sha ?? "na"} -->`;
+  return `<!-- clawsweeper-command-status:${command.issue_number ?? "unknown"}:${command.intent}:${command.command_status_revision ?? command.target?.head_sha ?? "na"} -->`;
 }
 
 export function commandStatusMarkerPrefix(command: LooseRecord) {

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -159,6 +159,8 @@ import {
   decideReviewDispatchCoordination,
   type ReviewDispatchCoordinationDecision,
 } from "./review-dispatch-coordination.js";
+import { directReReviewIntake } from "./direct-re-review-admission.js";
+import { postExactReviewCommandIntakeSync } from "./exact-review-command-queue.js";
 
 const automergeMetricWrites: Promise<boolean>[] = [];
 
@@ -3321,9 +3323,8 @@ function trustedAutomationReviewLeaseBlockReason(
 }
 
 function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
-  const requiresCommandStatus = ["re_review", "autofix", "automerge"].includes(
-    String(command.intent ?? ""),
-  );
+  if (command.intent === "re_review") return enqueueClawSweeperReReview(command);
+  const requiresCommandStatus = ["autofix", "automerge"].includes(String(command.intent ?? ""));
   let dispatchKey = dispatchReceiptKey(command);
   const expectedTitle = `Review event item ${command.repo}#${command.issue_number} [${dispatchKey}]`;
   const claimed = claimedDispatchState({
@@ -3448,6 +3449,47 @@ function dispatchClawSweeperReview(command: LooseRecord): LooseRecord {
     repo: reviewRepo,
     item_number: command.issue_number,
     dispatch_key: dispatchKey,
+  };
+}
+
+function enqueueClawSweeperReReview(command: LooseRecord): LooseRecord {
+  const dispatchKey = dispatchReceiptKey(command);
+  const itemKind = command.target?.kind === "pull_request" ? "pull_request" : "issue";
+  const intake = directReReviewIntake({
+    targetRepo: command.repo,
+    targetBranch: command.target_branch || "main",
+    itemNumber: Number(command.issue_number),
+    itemKind,
+    installationId: Number(process.env.CLAWSWEEPER_TARGET_INSTALLATION_ID),
+    sourceCommentId: Number(command.comment_id),
+    sourceCommentUpdatedAt: String(command.comment_updated_at || ""),
+    commandBodyDigest: String(command.comment_body_sha256 || ""),
+    commandOrigin: "comment_router",
+    ...(command.status_comment_id ? { statusCommentId: Number(command.status_comment_id) } : {}),
+    additionalPrompt: freeformReviewPrompt(command),
+  });
+  command.command_status_revision = intake.commandVersionId;
+  const secret =
+    process.env.CLAWSWEEPER_INTERNAL_QUEUE_SECRET || process.env.CLAWSWEEPER_WEBHOOK_SECRET || "";
+  if (!secret) throw new Error("internal exact-review queue secret is required");
+  const result = runCommandMutation(command, {
+    kind: "review_queue_admission",
+    identity: intake,
+    operation: () =>
+      postExactReviewCommandIntakeSync({
+        queueUrl: process.env.QUEUE_URL || "https://clawsweeper.openclaw.ai",
+        secret,
+        intake,
+      }),
+  });
+  return {
+    workflow: reviewWorkflow,
+    event: "exact_review_queue",
+    repo: reviewRepo,
+    item_number: command.issue_number,
+    dispatch_key: dispatchKey,
+    command_version_id: intake.commandVersionId,
+    deduped: result.kind === "accepted" && result.deduped,
   };
 }
 

--- a/src/repair/comment-router.ts
+++ b/src/repair/comment-router.ts
@@ -3469,8 +3469,7 @@ function enqueueClawSweeperReReview(command: LooseRecord): LooseRecord {
     additionalPrompt: freeformReviewPrompt(command),
   });
   command.command_status_revision = intake.commandVersionId;
-  const secret =
-    process.env.CLAWSWEEPER_INTERNAL_QUEUE_SECRET || process.env.CLAWSWEEPER_WEBHOOK_SECRET || "";
+  const secret = process.env.CLAWSWEEPER_WEBHOOK_SECRET || "";
   if (!secret) throw new Error("internal exact-review queue secret is required");
   const result = runCommandMutation(command, {
     kind: "review_queue_admission",

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -162,10 +162,7 @@ export async function handleGitHubWebhook({
         process.env.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL ||
         process.env.QUEUE_URL ||
         "https://clawsweeper.openclaw.ai",
-      secret:
-        process.env.CLAWSWEEPER_INTERNAL_QUEUE_SECRET ||
-        process.env.CLAWSWEEPER_WEBHOOK_SECRET ||
-        "",
+      secret: process.env.CLAWSWEEPER_WEBHOOK_SECRET || "",
       intake,
     });
     return { statusCode: 202, body: { ok: true, ...result } };

--- a/src/repair/comment-webhook.ts
+++ b/src/repair/comment-webhook.ts
@@ -13,6 +13,12 @@ import {
 import { adaptiveReviewBudgetForPullRequest } from "./adaptive-review-budget.js";
 import { isExactReviewCloseGuardLabel } from "./exact-review-guard-labels.js";
 import { commentBodySha256 } from "./comment-router-utils.js";
+import {
+  directReReviewAdditionalPrompt,
+  reReviewContextFromClawSweeperComment,
+} from "./comment-command-text.js";
+import { directReReviewIntake } from "./direct-re-review-admission.js";
+import { postExactReviewCommandIntake } from "./exact-review-command-queue.js";
 
 const DEFAULT_PORT = 8787;
 const REVIEW_REPO = "openclaw/clawsweeper";
@@ -39,9 +45,15 @@ type AcceptedIssueCommentWebhook = {
   targetRepo: string;
   targetBranch: string;
   itemNumber: number;
+  itemKind: "issue" | "pull_request";
+  itemState: string;
   commentId: number;
   installationId: number;
   sourceAction: string;
+  commentBody: string;
+  commentAuthor: string;
+  commentUrl: string;
+  maintainerAuthorized: boolean;
   commentUpdatedAt?: string;
   commentBodySha256?: string;
 };
@@ -102,8 +114,13 @@ async function handleRequest(request: http.IncomingMessage, response: http.Serve
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`[clawsweeper webhook] ${message}`);
-    response.writeHead(400, { "content-type": "application/json" });
-    response.end(`${JSON.stringify({ ok: false, error: message })}\n`);
+    const retryable = /command intake failed \(HTTP (?:429|5\d\d)\)|aborted|timed out/i.test(
+      message,
+    );
+    response.writeHead(retryable ? 503 : 400, { "content-type": "application/json" });
+    response.end(
+      `${JSON.stringify(retryable ? { ok: false, retryable: true } : { ok: false, error: message })}\n`,
+    );
   }
 }
 
@@ -117,6 +134,42 @@ export async function handleGitHubWebhook({
   const decision = classifyWebhook({ event, payload });
   if (!decision.accepted) return { statusCode: 202, body: decision };
   const accepted = decision as AcceptedWebhook;
+
+  if (
+    accepted.type === "issue_comment" &&
+    accepted.itemState === "open" &&
+    reReviewContextFromClawSweeperComment(accepted.commentBody) !== null
+  ) {
+    const intake = directReReviewIntake({
+      targetRepo: accepted.targetRepo,
+      targetBranch: accepted.targetBranch,
+      itemNumber: accepted.itemNumber,
+      itemKind: accepted.itemKind,
+      installationId: accepted.installationId,
+      sourceCommentId: accepted.commentId,
+      sourceCommentUpdatedAt: accepted.commentUpdatedAt ?? "",
+      commandBodyDigest: accepted.commentBodySha256 ?? "",
+      commandOrigin: "hosted_webhook",
+      additionalPrompt: directReReviewAdditionalPrompt({
+        body: accepted.commentBody,
+        maintainerAuthorized: accepted.maintainerAuthorized,
+        author: accepted.commentAuthor,
+        commentUrl: accepted.commentUrl,
+      }),
+    });
+    const result = await postExactReviewCommandIntake({
+      queueUrl:
+        process.env.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL ||
+        process.env.QUEUE_URL ||
+        "https://clawsweeper.openclaw.ai",
+      secret:
+        process.env.CLAWSWEEPER_INTERNAL_QUEUE_SECRET ||
+        process.env.CLAWSWEEPER_WEBHOOK_SECRET ||
+        "",
+      intake,
+    });
+    return { statusCode: 202, body: { ok: true, ...result } };
+  }
 
   const appJwt = createAppJwt();
   const dispatchToken = await createReviewRepoDispatchToken({ appJwt });
@@ -244,9 +297,15 @@ export function classifyIssueCommentWebhook({
     targetRepo,
     targetBranch,
     itemNumber,
+    itemKind: issue.pull_request ? "pull_request" : "issue",
+    itemState: String(issue.state ?? "").toLowerCase(),
     commentId,
     installationId,
     sourceAction: String(payload.action ?? "created"),
+    commentBody: String(comment.body ?? ""),
+    commentAuthor: String(asRecord(comment.user).login ?? ""),
+    commentUrl: String(comment.html_url ?? ""),
+    maintainerAuthorized: ALLOWED_ASSOCIATIONS.has(association),
     ...(commentUpdatedAt
       ? {
           commentUpdatedAt,

--- a/src/repair/direct-re-review-admission.ts
+++ b/src/repair/direct-re-review-admission.ts
@@ -1,0 +1,181 @@
+export type DirectReReviewOrigin = "hosted_webhook" | "comment_router";
+
+export type DirectReReviewDecision = {
+  targetRepo: string;
+  targetBranch: string;
+  itemNumber: number;
+  itemKind: "issue" | "pull_request";
+  sourceEvent: "issues" | "pull_request";
+  sourceAction: "re_review";
+  supersedesInProgress: false;
+  sourceDeliveryId: string;
+  sourceCommentId: number;
+  sourceCommentUpdatedAt: string;
+  commandBodyDigest: string;
+  commandOrigin: DirectReReviewOrigin;
+  commandStatusMarker: string;
+  additionalPrompt: string;
+  statusCommentId?: number;
+  sourceHeadSha?: string;
+  sourceUpdatedAt?: string;
+  sourceHeadVerified?: boolean;
+  sourceCommentVerified?: boolean;
+  sourceAuthoritySeq?: number;
+};
+
+export type DirectReReviewIntake = {
+  protocolVersion: 1;
+  commandVersionId: string;
+  installationId: number;
+  sourceCommentId: number;
+  sourceCommentUpdatedAt: string;
+  commandBodyDigest: string;
+  commandOrigin: DirectReReviewOrigin;
+  decision: Omit<
+    DirectReReviewDecision,
+    "sourceAuthoritySeq" | "sourceCommentVerified" | "sourceHeadVerified" | "sourceUpdatedAt"
+  >;
+};
+
+export function reReviewCommandVersionIdentity(options: {
+  commentId: number;
+  updatedAt: string;
+  bodySha256: string;
+}) {
+  const timestamp = Date.parse(options.updatedAt);
+  const digest = options.bodySha256.trim().toLowerCase();
+  if (
+    !Number.isSafeInteger(options.commentId) ||
+    options.commentId < 1 ||
+    !Number.isFinite(timestamp) ||
+    !/^[0-9a-f]{64}$/.test(digest)
+  ) {
+    throw new Error("exact re-review command version is invalid");
+  }
+  return `command-${options.commentId}-${timestamp.toString(36)}-${digest}`;
+}
+
+export function directReReviewIntake(options: {
+  targetRepo: string;
+  targetBranch: string;
+  itemNumber: number;
+  itemKind: "issue" | "pull_request";
+  installationId: number;
+  sourceCommentId: number;
+  sourceCommentUpdatedAt: string;
+  commandBodyDigest: string;
+  commandOrigin: DirectReReviewOrigin;
+  additionalPrompt: string;
+  statusCommentId?: number;
+  candidateHeadSha?: string;
+}): DirectReReviewIntake {
+  const commandVersionId = reReviewCommandVersionIdentity({
+    commentId: options.sourceCommentId,
+    updatedAt: options.sourceCommentUpdatedAt,
+    bodySha256: options.commandBodyDigest,
+  });
+  if (!Number.isSafeInteger(options.installationId) || options.installationId < 1) {
+    throw new Error("exact re-review installation is invalid");
+  }
+  const decision: DirectReReviewIntake["decision"] = {
+    targetRepo: options.targetRepo,
+    targetBranch: options.targetBranch,
+    itemNumber: options.itemNumber,
+    itemKind: options.itemKind,
+    sourceEvent: options.itemKind === "pull_request" ? "pull_request" : "issues",
+    sourceAction: "re_review",
+    supersedesInProgress: false,
+    sourceDeliveryId: commandVersionId,
+    sourceCommentId: options.sourceCommentId,
+    sourceCommentUpdatedAt: options.sourceCommentUpdatedAt,
+    commandBodyDigest: options.commandBodyDigest,
+    commandOrigin: options.commandOrigin,
+    commandStatusMarker: directReReviewStatusMarker(options.itemNumber, commandVersionId),
+    additionalPrompt: options.additionalPrompt.slice(0, 5_000),
+    ...(options.statusCommentId ? { statusCommentId: options.statusCommentId } : {}),
+    ...(options.candidateHeadSha ? { sourceHeadSha: options.candidateHeadSha } : {}),
+  };
+  return {
+    protocolVersion: 1,
+    commandVersionId,
+    installationId: options.installationId,
+    sourceCommentId: options.sourceCommentId,
+    sourceCommentUpdatedAt: options.sourceCommentUpdatedAt,
+    commandBodyDigest: options.commandBodyDigest,
+    commandOrigin: options.commandOrigin,
+    decision,
+  };
+}
+
+export function validateDirectReReviewIntake(value: unknown): DirectReReviewIntake | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const intake = value as Partial<DirectReReviewIntake>;
+  const decision = intake.decision as Partial<DirectReReviewDecision> | undefined;
+  if (
+    intake.protocolVersion !== 1 ||
+    !decision ||
+    !Number.isSafeInteger(intake.installationId) ||
+    Number(intake.installationId) < 1 ||
+    !Number.isSafeInteger(intake.sourceCommentId) ||
+    Number(intake.sourceCommentId) < 1 ||
+    !Number.isFinite(Date.parse(String(intake.sourceCommentUpdatedAt || ""))) ||
+    !/^[0-9a-f]{64}$/.test(String(intake.commandBodyDigest || "")) ||
+    (intake.commandOrigin !== "hosted_webhook" && intake.commandOrigin !== "comment_router") ||
+    typeof intake.commandVersionId !== "string" ||
+    intake.commandVersionId !==
+      reReviewCommandVersionIdentity({
+        commentId: Number(intake.sourceCommentId),
+        updatedAt: String(intake.sourceCommentUpdatedAt),
+        bodySha256: String(intake.commandBodyDigest),
+      }) ||
+    decision.sourceDeliveryId !== intake.commandVersionId ||
+    decision.sourceCommentId !== intake.sourceCommentId ||
+    decision.sourceCommentUpdatedAt !== intake.sourceCommentUpdatedAt ||
+    decision.commandBodyDigest !== intake.commandBodyDigest ||
+    decision.commandOrigin !== intake.commandOrigin ||
+    typeof decision.targetRepo !== "string" ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(decision.targetRepo) ||
+    typeof decision.targetBranch !== "string" ||
+    !/^[A-Za-z0-9_./-]+$/.test(decision.targetBranch) ||
+    !Number.isSafeInteger(decision.itemNumber) ||
+    Number(decision.itemNumber) < 1 ||
+    (decision.itemKind !== "issue" && decision.itemKind !== "pull_request") ||
+    decision.sourceEvent !== (decision.itemKind === "pull_request" ? "pull_request" : "issues") ||
+    decision.sourceAction !== "re_review" ||
+    decision.supersedesInProgress !== false ||
+    decision.commandStatusMarker !==
+      directReReviewStatusMarker(Number(decision.itemNumber), intake.commandVersionId) ||
+    typeof decision.additionalPrompt !== "string" ||
+    decision.additionalPrompt.length > 5_000 ||
+    Object.hasOwn(decision, "sourceHeadVerified") ||
+    Object.hasOwn(decision, "sourceCommentVerified") ||
+    Object.hasOwn(decision, "sourceAuthoritySeq") ||
+    Object.hasOwn(decision, "sourceUpdatedAt")
+  ) {
+    return null;
+  }
+  if (
+    decision.statusCommentId !== undefined &&
+    (!Number.isSafeInteger(decision.statusCommentId) || Number(decision.statusCommentId) < 1)
+  ) {
+    return null;
+  }
+  if (
+    decision.sourceHeadSha !== undefined &&
+    !/^[0-9a-f]{40}$/.test(String(decision.sourceHeadSha).toLowerCase())
+  ) {
+    return null;
+  }
+  return intake as DirectReReviewIntake;
+}
+
+function directReReviewStatusMarker(itemNumber: number, commandVersionId: string) {
+  if (
+    !Number.isSafeInteger(itemNumber) ||
+    itemNumber < 1 ||
+    !/^command-[a-z0-9-]{1,120}$/.test(commandVersionId)
+  ) {
+    throw new Error("exact re-review command status marker is invalid");
+  }
+  return `<!-- clawsweeper-command-status:${itemNumber}:re_review:${commandVersionId} -->`;
+}

--- a/src/repair/exact-review-command-queue.ts
+++ b/src/repair/exact-review-command-queue.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import { createHmac } from "node:crypto";
+
+import type { DirectReReviewIntake } from "./direct-re-review-admission.js";
+
+const COMMAND_INTAKE_PATH = "/internal/exact-review/command-intake";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export type CommandIntakeAdmissionResult =
+  | { kind: "accepted"; deduped: boolean; commandVersionId: string }
+  | { kind: "stale"; reason: string; commandVersionId: string };
+
+export function signedExactReviewQueueRequest(options: {
+  queueUrl: string;
+  secret: string;
+  intake: DirectReReviewIntake;
+}) {
+  if (!options.secret) throw new Error("internal exact-review queue secret is required");
+  const body = JSON.stringify(options.intake);
+  return {
+    url: `${options.queueUrl.replace(/\/$/, "")}${COMMAND_INTAKE_PATH}`,
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", options.secret).update(body).digest("hex")}`,
+    },
+  };
+}
+
+export function postExactReviewCommandIntakeSync(options: {
+  queueUrl: string;
+  secret: string;
+  intake: DirectReReviewIntake;
+}) {
+  const request = signedExactReviewQueueRequest(options);
+  const headerArgs = Object.entries(request.headers).flatMap(([name, value]) => [
+    "--header",
+    `${name}: ${value}`,
+  ]);
+  const response = spawnSync(
+    "curl",
+    [
+      "--silent",
+      "--show-error",
+      "--fail-with-body",
+      "--max-time",
+      String(REQUEST_TIMEOUT_MS / 1_000),
+      ...headerArgs,
+      "--data-binary",
+      "@-",
+      request.url,
+    ],
+    { encoding: "utf8", input: request.body },
+  );
+  if (response.status !== 0) {
+    throw new Error(`exact re-review command intake failed: ${response.stderr || response.stdout}`);
+  }
+  return commandIntakeAdmissionResult(JSON.parse(response.stdout || "null"));
+}
+
+export async function postExactReviewCommandIntake(options: {
+  queueUrl: string;
+  secret: string;
+  intake: DirectReReviewIntake;
+  fetchImpl?: typeof fetch;
+}) {
+  const request = signedExactReviewQueueRequest(options);
+  const response = await (options.fetchImpl ?? fetch)(request.url, {
+    method: "POST",
+    headers: request.headers,
+    body: request.body,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const result = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(`exact-review command intake failed (HTTP ${response.status})`);
+  }
+  return commandIntakeAdmissionResult(result);
+}
+
+export function commandIntakeAdmissionResult(value: unknown): CommandIntakeAdmissionResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("exact-review command intake returned an invalid result");
+  }
+  const result = value as Record<string, unknown>;
+  const commandVersionId = String(result.command_version_id || "");
+  if (result.ok !== true || !commandVersionId) {
+    throw new Error("exact-review command intake was not accepted");
+  }
+  if (result.accepted === false && typeof result.reason === "string") {
+    return { kind: "stale", reason: result.reason, commandVersionId };
+  }
+  if (result.accepted === true && typeof result.deduped === "boolean") {
+    return {
+      kind: "accepted",
+      deduped: result.deduped,
+      commandVersionId,
+    };
+  }
+  throw new Error("exact-review command intake did not establish durable ownership");
+}

--- a/test/dashboard-worker-command-intake.test.ts
+++ b/test/dashboard-worker-command-intake.test.ts
@@ -71,6 +71,41 @@ test("command intake migrations, watermarks, receipts, and revisions stay idempo
   );
 });
 
+test("a verified same-timestamp edit fences an older receipt before enqueue effects", () => {
+  const storage = new MemoryDurableStorage();
+  const store = new ExactReviewCommandIntakeStore(storage);
+  store.ensureSchemaSync();
+  const now = Date.parse("2026-08-12T16:30:00Z");
+  const first = intakeFixture({ updatedAt: COMMAND_UPDATED_AT, body: COMMAND_BODY });
+  const edited = intakeFixture({
+    updatedAt: COMMAND_UPDATED_AT,
+    body: `${COMMAND_BODY}\nEdited in the same timestamp tick.`,
+  });
+  assert.equal(store.admit(first, now)?.accepted, true);
+  const firstRecord = store.due(now)[0]!;
+  assert.equal(store.markVerified(firstRecord, now + 1), true);
+  const verifiedFirst = {
+    ...first.decision,
+    sourceCommentVerified: true as const,
+    sourceHeadSha: HEAD_SHA,
+    sourceHeadVerified: true as const,
+    sourceAuthoritySeq: 1,
+  };
+  store.advance(first.commandVersionId, "enqueue_pending", now + 1, verifiedFirst);
+  assert.equal(store.admit(edited, now + 2)?.accepted, true);
+  const editedRecord = store
+    .due(now + 2)
+    .find((record) => record.intake.commandVersionId === edited.commandVersionId)!;
+  assert.equal(store.markVerified(editedRecord, now + 3), true);
+
+  assert.equal(receiptOutcome(storage, first.commandVersionId), "superseded");
+  assert.equal(store.isCurrent({ ...firstRecord, stage: "enqueue_pending" }), false);
+  assert.deepEqual(
+    store.due(now + 3).map((record) => record.intake.commandVersionId),
+    [edited.commandVersionId],
+  );
+});
+
 test("durable command intake survives target throttling before queue admission", async (t) => {
   const fixture = await startGithubLoopback();
   t.after(() => fixture.close());

--- a/test/dashboard-worker-command-intake.test.ts
+++ b/test/dashboard-worker-command-intake.test.ts
@@ -2,6 +2,7 @@ import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
 import http from "node:http";
 
 import { ExactReviewCommandIntakeStore } from "../dashboard/exact-review-command-intake.ts";
+import { convergeCommandAcknowledgement } from "../dashboard/exact-review-queue.ts";
 import { directReReviewIntake } from "../src/repair/direct-re-review-admission.ts";
 import {
   assert,
@@ -178,6 +179,44 @@ test("durable command intake survives target throttling before queue admission",
   assert.equal(fixture.acknowledgements.length, 1);
 });
 
+test("command acknowledgement ignores forged markers and paginates to the trusted receipt", async (t) => {
+  const fixture = await startGithubLoopback();
+  t.after(() => fixture.close());
+  const intake = intakeFixture({ updatedAt: COMMAND_UPDATED_AT, body: COMMAND_BODY });
+  const ackMarker = `<!-- clawsweeper-command-ack:${COMMAND_COMMENT_ID} -->`;
+  fixture.seedAcknowledgement({
+    id: 30_000,
+    body: `${ackMarker}\n${intake.decision.commandStatusMarker}`,
+    login: "contributor",
+  });
+  for (let index = 0; index < 99; index += 1) {
+    fixture.seedAcknowledgement({
+      id: 31_000 + index,
+      body: `unrelated comment ${index}`,
+      login: "contributor",
+    });
+  }
+  fixture.seedAcknowledgement({
+    id: 40_000,
+    body: `${ackMarker}\n${intake.decision.commandStatusMarker}\nExact review queued.`,
+    login: "clawsweeper[bot]",
+  });
+
+  const result = await convergeCommandAcknowledgement({
+    env: { GITHUB_API_URL: fixture.origin },
+    token: Promise.resolve("loopback-token"),
+    decision: intake.decision,
+    sourceCommentId: COMMAND_COMMENT_ID,
+  });
+
+  assert.equal(result, 40_000);
+  assert.equal(fixture.acknowledgements.length, 101);
+  assert.equal(
+    fixture.acknowledgements.some((comment) => comment.id === 30_000),
+    true,
+  );
+});
+
 async function mainEquivalentOldCommandPath(origin: string) {
   const acknowledgement = await fetch(
     `${origin}/repos/openclaw/openclaw/issues/${ITEM_NUMBER}/comments`,
@@ -270,7 +309,13 @@ function receiptOutcome(storage: MemoryDurableStorage, commandVersion: string) {
 }
 
 async function startGithubLoopback() {
-  const acknowledgements: Array<{ id: number; body: string; created_at: string }> = [];
+  const acknowledgements: Array<{
+    id: number;
+    body: string;
+    created_at: string;
+    issue_url: string;
+    user: { login: string };
+  }> = [];
   let nextCommentId = 20_000;
   const state = {
     acknowledgements,
@@ -317,12 +362,22 @@ async function startGithubLoopback() {
       return sendJson(response, 201, { token: "loopback-token" });
     }
     if (url.pathname === `/repos/openclaw/openclaw/issues/${ITEM_NUMBER}/comments`) {
-      if (request.method === "GET") return sendJson(response, 200, acknowledgements);
+      if (request.method === "GET") {
+        const page = Math.max(1, Number(url.searchParams.get("page") || 1));
+        const perPage = Math.max(1, Number(url.searchParams.get("per_page") || 100));
+        return sendJson(
+          response,
+          200,
+          acknowledgements.slice((page - 1) * perPage, page * perPage),
+        );
+      }
       if (request.method === "POST") {
         const comment = {
           id: nextCommentId++,
           body: String(body.body || ""),
           created_at: new Date().toISOString(),
+          issue_url: `https://api.github.com/repos/openclaw/openclaw/issues/${ITEM_NUMBER}`,
+          user: { login: "clawsweeper[bot]" },
         };
         acknowledgements.push(comment);
         return sendJson(response, 201, comment);
@@ -368,6 +423,15 @@ async function startGithubLoopback() {
   assert.ok(address && typeof address === "object");
   return Object.assign(state, {
     origin: `http://127.0.0.1:${address.port}`,
+    seedAcknowledgement: (comment: { id: number; body: string; login: string }) => {
+      acknowledgements.push({
+        id: comment.id,
+        body: comment.body,
+        created_at: new Date(comment.id).toISOString(),
+        issue_url: `https://api.github.com/repos/openclaw/openclaw/issues/${ITEM_NUMBER}`,
+        user: { login: comment.login },
+      });
+    },
     close: () =>
       new Promise<void>((resolve, reject) =>
         server.close((error) => (error ? reject(error) : resolve())),

--- a/test/dashboard-worker-command-intake.test.ts
+++ b/test/dashboard-worker-command-intake.test.ts
@@ -1,0 +1,388 @@
+import { createHash, createHmac, generateKeyPairSync } from "node:crypto";
+import http from "node:http";
+
+import { ExactReviewCommandIntakeStore } from "../dashboard/exact-review-command-intake.ts";
+import { directReReviewIntake } from "../src/repair/direct-re-review-admission.ts";
+import {
+  assert,
+  ExactReviewQueue,
+  MemoryDurableNamespace,
+  MemoryDurableStorage,
+  test,
+  worker,
+} from "./dashboard-worker-harness.ts";
+
+const COMMAND_BODY = "@clawsweeper re-review\n\nPlease check the current head.";
+const COMMAND_UPDATED_AT = "2026-08-12T16:25:26Z";
+const COMMAND_COMMENT_ID = 9_001;
+const ITEM_NUMBER = 42;
+const HEAD_SHA = "a".repeat(40);
+
+test("command intake migrations, watermarks, receipts, and revisions stay idempotent", () => {
+  const storage = new MemoryDurableStorage();
+  const store = new ExactReviewCommandIntakeStore(storage);
+  store.ensureSchemaSync();
+  const first = intakeFixture({ updatedAt: "2026-08-12T16:25:26Z", body: COMMAND_BODY });
+  const second = intakeFixture({
+    updatedAt: "2026-08-12T16:25:27Z",
+    body: `${COMMAND_BODY}\nOne more detail.`,
+  });
+  const now = Date.parse("2026-08-12T16:30:00Z");
+
+  assert.deepEqual(store.admit(first, now), {
+    accepted: true,
+    deduped: false,
+    commandVersionId: first.commandVersionId,
+  });
+  assert.deepEqual(store.admit(first, now + 1), {
+    accepted: true,
+    deduped: true,
+    commandVersionId: first.commandVersionId,
+  });
+  assert.equal(store.admit(second, now + 2)?.accepted, true);
+  assert.deepEqual(
+    store.due(now + 2).map((record) => record.intake.commandVersionId),
+    [second.commandVersionId],
+  );
+  assert.equal(receiptOutcome(storage, first.commandVersionId), "superseded");
+  assert.equal(receiptOutcome(storage, second.commandVersionId), "pending");
+
+  const due = store.due(now + 2)[0]!;
+  store.defer(due, now + 2, "rate_limited");
+  const nextAttemptAt = store.nextAttemptAt();
+  assert.ok(nextAttemptAt !== null && nextAttemptAt >= now + 2 + 15_000);
+  assert.ok(nextAttemptAt !== null && nextAttemptAt <= now + 2 + 15 * 60_000);
+  assert.equal(store.allocateItemRevision("openclaw/openclaw#42", 1, 0, 0), 1);
+  assert.equal(store.allocateItemRevision("openclaw/openclaw#42", 1, 0, 0), 2);
+  assert.deepEqual(
+    Array.from(
+      storage.sql.exec(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('exact_review_command_intakes', 'exact_review_command_receipts', 'exact_review_command_watermarks', 'exact_review_item_revisions') ORDER BY name",
+      ),
+      (row) => row.name,
+    ),
+    [
+      "exact_review_command_intakes",
+      "exact_review_command_receipts",
+      "exact_review_command_watermarks",
+      "exact_review_item_revisions",
+    ],
+  );
+});
+
+test("durable command intake survives target throttling before queue admission", async (t) => {
+  const fixture = await startGithubLoopback();
+  t.after(() => fixture.close());
+
+  await assert.rejects(
+    mainEquivalentOldCommandPath(fixture.origin),
+    /old command dispatch failed: 403/,
+  );
+  assert.equal(fixture.acknowledgements.length, 1);
+  assert.equal(fixture.durableIntakes, 0);
+
+  fixture.acknowledgements.length = 0;
+  const storage = new MemoryDurableStorage();
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const env = {
+    GITHUB_API_URL: fixture.origin,
+    CLAWSWEEPER_WEBHOOK_SECRET: "command-intake-test-secret",
+    CLAWSWEEPER_APP_CLIENT_ID: "Iv23command-intake-test",
+    CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+    EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
+  };
+  const queue = new ExactReviewQueue({ storage }, env);
+  const namespace = new MemoryDurableNamespace(queue);
+  const payload = commandWebhookPayload();
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", env.CLAWSWEEPER_WEBHOOK_SECRET)
+    .update(body)
+    .digest("hex")}`;
+
+  const accepted = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/github/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issue_comment",
+        "x-github-delivery": "delivery-command-1",
+        "x-hub-signature-256": signature,
+      },
+      body,
+    }),
+    { ...env, EXACT_REVIEW_QUEUE: namespace },
+    {},
+  );
+  assert.equal(accepted.status, 202);
+  assert.deepEqual(await accepted.json(), {
+    ok: true,
+    accepted: true,
+    deduped: false,
+    command_version_id: commandVersionId(),
+  });
+  assert.equal(fixture.acknowledgements.length, 0);
+
+  fixture.throttleSourceComment = true;
+  await queue.alarm();
+  assert.equal(fixture.sourceCommentReads, 1);
+  assert.equal(fixture.acknowledgements.length, 0);
+  assert.equal(commandReceiptOutcome(storage), "pending");
+
+  fixture.throttleSourceComment = false;
+  storage.sql.exec("UPDATE exact_review_command_intakes SET next_attempt_at = 0");
+  const state = (await storage.get("exact-review-queue")) as {
+    dispatcher?: { githubCredentialCircuits?: Record<string, { retryAt: number }> };
+  };
+  for (const circuit of Object.values(state.dispatcher?.githubCredentialCircuits || {})) {
+    circuit.retryAt = 0;
+  }
+  await storage.put("exact-review-queue", state);
+  await queue.alarm();
+
+  const queued = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { decision: Record<string, unknown> }>;
+  };
+  const item = queued.items[`openclaw/openclaw#${ITEM_NUMBER}`];
+  assert.ok(item, JSON.stringify({ queued, receipt: commandReceipt(storage) }));
+  assert.equal(item.decision.sourceDeliveryId, commandVersionId());
+  assert.equal(item.decision.sourceHeadSha, HEAD_SHA);
+  assert.equal(item.decision.sourceCommentVerified, true);
+  assert.equal(commandReceiptOutcome(storage), "completed");
+  assert.equal(fixture.acknowledgements.length, 1);
+  assert.match(
+    fixture.acknowledgements[0]!.body,
+    /clawsweeper-command-status:42:re_review:command-/,
+  );
+  assert.equal(fixture.reactions, 1);
+
+  const redelivery = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/github/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issue_comment",
+        "x-github-delivery": "delivery-command-1-redelivery",
+        "x-hub-signature-256": signature,
+      },
+      body,
+    }),
+    { ...env, EXACT_REVIEW_QUEUE: namespace },
+    {},
+  );
+  assert.equal(redelivery.status, 202);
+  assert.equal((await redelivery.json()).deduped, true);
+  assert.equal(fixture.acknowledgements.length, 1);
+});
+
+async function mainEquivalentOldCommandPath(origin: string) {
+  const acknowledgement = await fetch(
+    `${origin}/repos/openclaw/openclaw/issues/${ITEM_NUMBER}/comments`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: "<!-- clawsweeper-command-ack:9001 -->\nrouter queued" }),
+    },
+  );
+  assert.equal(acknowledgement.status, 201);
+  const dispatch = await fetch(`${origin}/repos/openclaw/clawsweeper/dispatches`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ event_type: "clawsweeper_comment" }),
+  });
+  if (!dispatch.ok) throw new Error(`old command dispatch failed: ${dispatch.status}`);
+}
+
+function commandWebhookPayload() {
+  return {
+    action: "created",
+    repository: {
+      full_name: "openclaw/openclaw",
+      default_branch: "main",
+      private: false,
+      archived: false,
+      fork: false,
+      has_issues: true,
+    },
+    installation: { id: 123 },
+    issue: {
+      number: ITEM_NUMBER,
+      state: "open",
+      user: { login: "contributor" },
+      pull_request: { url: `https://api.github.com/repos/openclaw/openclaw/pulls/${ITEM_NUMBER}` },
+    },
+    comment: {
+      id: COMMAND_COMMENT_ID,
+      body: COMMAND_BODY,
+      author_association: "CONTRIBUTOR",
+      user: { login: "contributor" },
+      created_at: COMMAND_UPDATED_AT,
+      updated_at: COMMAND_UPDATED_AT,
+      html_url: `https://github.com/openclaw/openclaw/pull/${ITEM_NUMBER}#issuecomment-${COMMAND_COMMENT_ID}`,
+    },
+  };
+}
+
+function commandVersionId() {
+  const bodyDigest = createHash("sha256").update(COMMAND_BODY).digest("hex");
+  return `command-${COMMAND_COMMENT_ID}-${Date.parse(COMMAND_UPDATED_AT).toString(36)}-${bodyDigest}`;
+}
+
+function intakeFixture(options: { updatedAt: string; body: string }) {
+  return directReReviewIntake({
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: ITEM_NUMBER,
+    itemKind: "pull_request",
+    installationId: 123,
+    sourceCommentId: COMMAND_COMMENT_ID,
+    sourceCommentUpdatedAt: options.updatedAt,
+    commandBodyDigest: createHash("sha256").update(options.body).digest("hex"),
+    commandOrigin: "hosted_webhook",
+    additionalPrompt: "",
+  });
+}
+
+function commandReceiptOutcome(storage: MemoryDurableStorage) {
+  return commandReceipt(storage)?.outcome;
+}
+
+function commandReceipt(storage: MemoryDurableStorage) {
+  const row = Array.from(
+    storage.sql.exec(
+      "SELECT outcome, detail FROM exact_review_command_receipts WHERE command_version_id = ?",
+      commandVersionId(),
+    ),
+  )[0];
+  return row;
+}
+
+function receiptOutcome(storage: MemoryDurableStorage, commandVersion: string) {
+  return Array.from(
+    storage.sql.exec(
+      "SELECT outcome FROM exact_review_command_receipts WHERE command_version_id = ?",
+      commandVersion,
+    ),
+  )[0]?.outcome;
+}
+
+async function startGithubLoopback() {
+  const acknowledgements: Array<{ id: number; body: string; created_at: string }> = [];
+  let nextCommentId = 20_000;
+  const state = {
+    acknowledgements,
+    durableIntakes: 0,
+    throttleSourceComment: false,
+    sourceCommentReads: 0,
+    reactions: 0,
+  };
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url || "/", "http://127.0.0.1");
+    const body = await readJson(request);
+    if (url.pathname === `/repos/openclaw/openclaw/issues/comments/${COMMAND_COMMENT_ID}`) {
+      state.sourceCommentReads += 1;
+      if (state.throttleSourceComment) {
+        response.writeHead(403, {
+          "content-type": "application/json",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 60),
+        });
+        response.end(JSON.stringify({ message: "API rate limit exceeded for installation" }));
+        return;
+      }
+      return sendJson(response, 200, {
+        id: COMMAND_COMMENT_ID,
+        body: COMMAND_BODY,
+        updated_at: COMMAND_UPDATED_AT,
+        issue_url: `https://api.github.com/repos/openclaw/openclaw/issues/${ITEM_NUMBER}`,
+      });
+    }
+    if (url.pathname === `/repos/openclaw/openclaw/pulls/${ITEM_NUMBER}`) {
+      return sendJson(response, 200, {
+        state: "open",
+        updated_at: COMMAND_UPDATED_AT,
+        head: { sha: HEAD_SHA },
+      });
+    }
+    if (url.pathname === "/repos/openclaw/openclaw/installation") {
+      return sendJson(response, 200, { id: 123 });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return sendJson(response, 200, { id: 777 });
+    }
+    if (/^\/app\/installations\/(?:123|777)\/access_tokens$/.test(url.pathname)) {
+      return sendJson(response, 201, { token: "loopback-token" });
+    }
+    if (url.pathname === `/repos/openclaw/openclaw/issues/${ITEM_NUMBER}/comments`) {
+      if (request.method === "GET") return sendJson(response, 200, acknowledgements);
+      if (request.method === "POST") {
+        const comment = {
+          id: nextCommentId++,
+          body: String(body.body || ""),
+          created_at: new Date().toISOString(),
+        };
+        acknowledgements.push(comment);
+        return sendJson(response, 201, comment);
+      }
+    }
+    const acknowledgement = url.pathname.match(
+      /^\/repos\/openclaw\/openclaw\/issues\/comments\/(\d+)$/,
+    );
+    if (acknowledgement) {
+      const id = Number(acknowledgement[1]);
+      const index = acknowledgements.findIndex((comment) => comment.id === id);
+      if (request.method === "PATCH" && index >= 0) {
+        acknowledgements[index] = { ...acknowledgements[index]!, body: String(body.body || "") };
+        return sendJson(response, 200, acknowledgements[index]);
+      }
+      if (request.method === "DELETE" && index >= 0) {
+        acknowledgements.splice(index, 1);
+        response.writeHead(204).end();
+        return;
+      }
+    }
+    if (
+      url.pathname === `/repos/openclaw/openclaw/issues/comments/${COMMAND_COMMENT_ID}/reactions`
+    ) {
+      state.reactions += 1;
+      return sendJson(response, 201, { id: state.reactions, content: "eyes" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/actions/workflows/sweep.yml") {
+      return sendJson(response, 200, { state: "active" });
+    }
+    if (url.pathname === "/repos/openclaw/clawsweeper/dispatches") {
+      if (request.headers.authorization) {
+        response.writeHead(204).end();
+      } else {
+        sendJson(response, 403, { message: "API rate limit exceeded for installation" });
+      }
+      return;
+    }
+    sendJson(response, 404, { message: `unhandled ${request.method} ${url.pathname}` });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return Object.assign(state, {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  });
+}
+
+async function readJson(request: http.IncomingMessage) {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  const body = Buffer.concat(chunks).toString("utf8");
+  return body ? (JSON.parse(body) as Record<string, unknown>) : {};
+}
+
+function sendJson(response: http.ServerResponse, status: number, value: unknown) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}

--- a/test/repair/comment-router-action-ledger.test.ts
+++ b/test/repair/comment-router-action-ledger.test.ts
@@ -114,6 +114,24 @@ test("comment router isolates public target reads from its GitHub App mutation i
   assert.match(publicReadSource, /repos\\\/openclaw\\\/openclaw\\\/\(\?:issues\|pulls\)/);
 });
 
+test("re-review recovery signs with the Worker-accepted webhook secret", () => {
+  const source = readText("src/repair/comment-router.ts");
+  const workflow = readText(".github/workflows/repair-comment-router.yml");
+  const intake = source.slice(
+    source.indexOf("function enqueueClawSweeperReReview"),
+    source.indexOf("function dispatchCompletedReviewVerdict"),
+  );
+
+  assert.match(intake, /process\.env\.CLAWSWEEPER_WEBHOOK_SECRET/);
+  assert.doesNotMatch(intake, /CLAWSWEEPER_INTERNAL_QUEUE_SECRET/);
+  assert.doesNotMatch(workflow, /CLAWSWEEPER_INTERNAL_QUEUE_SECRET/);
+  assert.equal(
+    workflow.match(/CLAWSWEEPER_WEBHOOK_SECRET: \$\{\{ secrets\.CLAWSWEEPER_WEBHOOK_SECRET \}\}/g)
+      ?.length,
+    5,
+  );
+});
+
 test("exact comment convergence classifies a missing comment as no mutation", () => {
   const source = readText("src/repair/comment-router.ts");
   const fastPath = source.slice(source.indexOf("function convergeExactCommentVersionFastPathAck"));

--- a/test/repair/comment-webhook.test.ts
+++ b/test/repair/comment-webhook.test.ts
@@ -34,9 +34,15 @@ test("comment webhook accepts maintainer ClawSweeper commands", () => {
     targetRepo: "openclaw/openclaw",
     targetBranch: "trunk",
     itemNumber: 71898,
+    itemKind: "issue",
+    itemState: "",
     commentId: 456,
     installationId: 123,
     sourceAction: "created",
+    commentBody: "@clawsweeper automerge",
+    commentAuthor: "",
+    commentUrl: "",
+    maintainerAuthorized: true,
   });
 });
 
@@ -187,9 +193,15 @@ test("comment webhook accepts author read-only re-review commands", () => {
     targetRepo: "openclaw/openclaw",
     targetBranch: "main",
     itemNumber: 76991,
+    itemKind: "issue",
+    itemState: "",
     commentId: 456,
     installationId: 123,
     sourceAction: "created",
+    commentBody: "@clawsweeper Re-run",
+    commentAuthor: "NickMOpen",
+    commentUrl: "",
+    maintainerAuthorized: false,
   });
 });
 
@@ -253,9 +265,15 @@ test("comment webhook still accepts post-close re-review commands for router res
     targetRepo: "openclaw/openclaw",
     targetBranch: "main",
     itemNumber: 76991,
+    itemKind: "pull_request",
+    itemState: "closed",
     commentId: 456,
     installationId: 123,
     sourceAction: "created",
+    commentBody: "@clawsweeper re-review",
+    commentAuthor: "user",
+    commentUrl: "",
+    maintainerAuthorized: true,
     commentUpdatedAt: "2026-05-19T05:03:00Z",
     commentBodySha256: crypto.createHash("sha256").update("@clawsweeper re-review").digest("hex"),
   });

--- a/tsconfig.dashboard-strict.json
+++ b/tsconfig.dashboard-strict.json
@@ -11,6 +11,7 @@
     "dashboard/automerge-metrics.ts",
     "dashboard/dashboard-health.ts",
     "dashboard/error-safety.ts",
+    "dashboard/exact-review-command-intake.ts",
     "dashboard/exact-review-decision.ts",
     "dashboard/exact-review-publication-retry.ts",
     "dashboard/exact-review-queue-shared.ts",


### PR DESCRIPTION
## What this fixes

An eligible `@clawsweeper re-review` command currently becomes durable only after a GitHub Actions comment-router run claims it. The hosted webhook first creates an optimistic acknowledgement and then dispatches that run. When the target GitHub App bucket is throttled, both the exact router run and its five-minute fallback can fail before the action ledger owns the command.

That happened in production on August 12: [openclaw/openclaw#116562's command](https://github.com/openclaw/openclaw/pull/116562#issuecomment-5269512824) received only “Command router queued”; [the exact router run](https://github.com/openclaw/clawsweeper/actions/runs/31617498103) and [the scheduled fallback](https://github.com/openclaw/clawsweeper/actions/runs/31617412341) both failed on installation rate limiting, and no sweep run for that item existed at investigation time.

This PR moves only re-review command intake ahead of acknowledgement and Actions dispatch. The Worker records an immutable comment-version identity in the ExactReviewQueue Durable Object, verifies the live source comment and PR head, enqueues once, and then converges the acknowledgement and reaction. The scheduled comment router remains a recovery producer, but it posts into the same receipt instead of creating a second dispatch path.

## Snapshot and supersession analysis

The source was abandoned WIP snapshot `4cad8dea21` (`codex/fix-command-review-publication`), based 58 commits behind main with 59 changed files. It was treated as design evidence, not applied as a patch.

Kept and rewritten:

- the four command/version tables, idempotent schema creation, 16-item intake bound, 15-second-to-15-minute retry ladder, and 30-day terminal-receipt horizon;
- exact comment-version identity, live source verification, PR-head authority, monotonic command revisions, and acknowledgement/reaction convergence;
- hosted-webhook fast intake plus comment-router recovery intake.

Dropped as already landed or structurally superseded:

- throttled retry jitter from #1076;
- durable placeholder cursors from #1077;
- quota headroom and publication retry-budget work from #1086 and #1089;
- the `branch_is_usable`/branch-authority work from #962;
- parked inventory and bounded reconciliation from #1111;
- shared command acknowledgement convergence from #1114;
- dashboard page extraction from #1116;
- queue decision/read-model/shared extraction from #1124;
- typed webhook ingress from #1132;
- the snapshot's generic internal-request script and broad cursor/recovery/workflow rewrites, which duplicate current owners.

The old 1,400-line `dashboard/exact-review-queue.ts` splice was not ported. The command tables and state transitions live in a new strict module, with narrow hooks into the current decision, lifecycle, Worker, and queue owners.

## Migration and behavior

The new SQLite tables are created idempotently during ExactReviewQueue initialization. No backfill is required: existing GitHub comments remain discoverable through the scheduled router, and new exact versions receive durable receipts on first observation. Detailed terminal receipts expire with resolved dead letters; per-comment watermarks remain to prevent an old version from restarting after compaction.

The processing fence is deliberately three-stage: verify, enqueue, effects. A crash after enqueue reuses the delivery receipt without rebinding authority; a crash during acknowledgement/reaction retries only idempotent effects.

OpenClaw Bay is unaffected. This changes no Bay field, data contract, control, or action surface; Bay remains observer-only.

## Review finding disposition

The first ClawSweeper review identified three actionable findings; all are resolved on the current head:

- **P1 signing contract:** the scheduled router and local receiver now sign only with `CLAWSWEEPER_WEBHOOK_SECRET`, exactly matching the Worker endpoint. The unsupported distinct-secret preference was removed from code and workflow environments.
- **P1 acknowledgement trust:** acknowledgement candidates are now restricted to the configured trusted ClawSweeper bot logins before any PATCH, retention, or duplicate cleanup decision.
- **P2 complete lookup:** the queue performs a bounded five-page marker search and independently fetches/verifies the persisted status-comment ID, including author, marker, and target-item ownership.

Focused regressions cover the signing source, a contributor-forged exact marker, and a trusted exact receipt on page two. The forged human comment remains untouched.

The second and final allowed ClawSweeper review identified one late P1 finding: same-timestamp edited comment bodies could both pass a timestamp-only currentness check. The final correction lets same-timestamp contenders reach live verification, atomically promotes only the full version identity whose digest matches GitHub, supersedes sibling intakes, and rechecks that identity before enqueue and acknowledgement effects. Its regression advances the older receipt beyond verification before the edited version wins.

## Proof

Claim: throttling before Actions dispatch can no longer lose or duplicate an eligible re-review command.

Exercised surface: real `wrangler dev --local` Worker boots, signed webhook HTTP, loopback `GITHUB_API_URL`, ExactReviewQueue DO SQLite, alarm retry, and full Wrangler process-tree shutdown.

Scenario: the pinned-main Worker and candidate received the same signed PR command. The loopback GitHub API accepted acknowledgement writes but throttled baseline repository dispatch and candidate source verification.

Observed result:

- baseline returned HTTP 500 after one optimistic acknowledgement/reaction and one throttled dispatch; no command schema or intake existed;
- candidate returned HTTP 202 before acknowledgement, attempted one deferred source read, and retained one pending intake/receipt across shutdown;
- all four command tables were present, proving DO instantiation;
- both Wrangler process groups confirmed SIGTERM completion between boots.

Crabbox proof was renewed after every code head. The committed receipt records final code head `ee949363f5c4cf755a431020b738f1bf06ae49b5` on AWS lease `cbx_6b30d164d7dc`, run `run_7cfa46ca99f9`. A second successful comparison exercised the exact final receipt head `9eb957ea6ae034d8aba003c47664b6bac2864e6e`: `provider=aws`, lease `cbx_72a05adbf287`, run `run_d2eb04c505d7`, `comparison_pass=true`, exit 0, `leaseStopped=true`. Receipt: [`docs/proof/durable-command-intake/receipt.md`](https://github.com/openclaw/clawsweeper/blob/steipete/durable-command-intake/docs/proof/durable-command-intake/receipt.md).

Provider note: `crabbox config show` resolves `provider=aws` for this repository and host. The applicable Crabbox workflow forbids silently overriding that resolved backend when the user did not request one. This host is macOS; the repository's local-container-only sentence is explicitly scoped to a Windows host. The proof therefore preserves the resolved AWS backend while running real `wrangler dev --local` Workers with isolated persistence.

Limits: the GitHub API was synthetic loopback; no live credentials or production mutations were used. Executor completion and final public review publication were not exercised by this proof.

## Validation

- `pnpm run check`: 7,056 passed, 13 skipped; coverage 81.34% lines, 73.93% branches, 87.25% functions
- `pnpm run check:dashboard-strict`
- focused queue/runtime/publication suite: 259 passed
- loopback command regression: red main-equivalent old path, green durable path
- pre-commit and committed-branch Codex reviews: clean
- source-blind behavior contract: 6 passed, 0 failed/blocked
