### PR TITLE
fix: reconcile reads canonical records with operator auth

### DIFF
--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -771,7 +771,7 @@ export default {
       );
     const canonicalRecordPath =
       request.method === "GET"
-        ? /^\/internal\/state\/records\/[^/]+\/(?:items|closed|plans|decision-packets)\/[1-9]\d*$/.exec(
+        ? /^\/internal\/state\/records\/[^/]+\/(items|closed|plans|decision-packets)\/[1-9]\d*$/.exec(
             url.pathname,
           )
         : null;
@@ -780,6 +780,7 @@ export default {
         request,
         env,
         url.pathname.slice("/internal/state".length),
+        canonicalRecordPath[1] === "items",
       );
     if (url.pathname === "/internal/state/records/slugs" && request.method === "POST")
       return authenticatedExactReviewQueueRequest(request, env, "/records/slugs");
@@ -2581,16 +2582,21 @@ async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
   );
 }
 
-async function authenticatedExactReviewQueueRead(request, env, path: string) {
+async function authenticatedExactReviewQueueRead(
+  request,
+  env,
+  path: string,
+  allowOperatorSecret: boolean,
+) {
   const webhookSecret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
-  const operatorSecret = stringEnv(env.EXACT_REVIEW_OPERATOR_SECRET);
+  const operatorSecret = allowOperatorSecret ? stringEnv(env.EXACT_REVIEW_OPERATOR_SECRET) : "";
   if (!webhookSecret && !operatorSecret) return json({ error: "webhook_not_configured" }, 503);
   const body = await request.text();
   const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
   let authenticated = webhookSecret
     ? await verifyGithubWebhookSignature({ secret: webhookSecret, signature, bodyText: body })
     : false;
-  // This read-only route may accept the operator credential because it already authorizes queue mutations.
+  // Reconciliation reads active items only; closed records, plans, and decision packets stay webhook-only.
   if (!authenticated && operatorSecret) {
     authenticated = await verifyGithubWebhookSignature({
       secret: operatorSecret,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -2582,11 +2582,23 @@ async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
 }
 
 async function authenticatedExactReviewQueueRead(request, env, path: string) {
-  const secret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
-  if (!secret) return json({ error: "webhook_not_configured" }, 503);
+  const webhookSecret = stringEnv(env.CLAWSWEEPER_WEBHOOK_SECRET);
+  const operatorSecret = stringEnv(env.EXACT_REVIEW_OPERATOR_SECRET);
+  if (!webhookSecret && !operatorSecret) return json({ error: "webhook_not_configured" }, 503);
   const body = await request.text();
   const signature = request.headers.get("x-clawsweeper-exact-review-signature") || "";
-  if (!(await verifyGithubWebhookSignature({ secret, signature, bodyText: body }))) {
+  let authenticated = webhookSecret
+    ? await verifyGithubWebhookSignature({ secret: webhookSecret, signature, bodyText: body })
+    : false;
+  // This read-only route may accept the operator credential because it already authorizes queue mutations.
+  if (!authenticated && operatorSecret) {
+    authenticated = await verifyGithubWebhookSignature({
+      secret: operatorSecret,
+      signature,
+      bodyText: body,
+    });
+  }
+  if (!authenticated) {
     return json({ error: "invalid_signature" }, 401);
   }
   return exactReviewQueueRequest(

--- a/docs/proof/operator-record-read-auth/README.md
+++ b/docs/proof/operator-record-read-auth/README.md
@@ -1,0 +1,17 @@
+# Operator canonical-record read authentication proof
+
+Production exact-review reconcile run `31651591787` at `2026-08-12T23:38Z` checked ten head-mismatch targets and received `401` from every canonical completed-review lookup. The operator signed the existing read-only record GET with `EXACT_REVIEW_OPERATOR_SECRET`, while the Worker accepted only `CLAWSWEEPER_WEBHOOK_SECRET`. The shared-secret test setup for [openclaw/clawsweeper#1148](https://github.com/openclaw/clawsweeper/pull/1148) hid that boundary mismatch.
+
+The fix keeps the route and signature shape unchanged. `GET /internal/state/records/<repo-slug>/(items|closed|plans|decision-packets)/<number>` verifies the webhook secret first and, only if that fails, verifies the operator secret. A missing configuration returns 503 only when neither secret exists. Accepting the operator credential on this read-only route is not a privilege escalation because it already authorizes the queue’s mutation endpoints. The operator script and workflows remain unchanged.
+
+The executable [behavior contract](behavior-contract.md) and [RED/GREEN record](red-green.md) close the shared-secret coverage gap. `run-proof.mjs` extracts the merge base, boots it with distinct secrets, publishes a synthetic record, and proves operator/webhook/garbage statuses of 401/200/401. It then kills the complete Wrangler process tree, confirms the health endpoint is down, boots the candidate on the same port with separate persistence, and proves 200/200/401. The router-level unit test independently covers the same candidate auth matrix plus missing configuration.
+
+Run the real-Worker comparison from a committed head with:
+
+```bash
+node docs/proof/operator-record-read-auth/run-proof.mjs "$(git rev-parse HEAD)"
+```
+
+The final Docker-backed Crabbox `local-container` receipt, captured transcript, behavior report, content hashes, and cleanup result are recorded beside this file after the implementation commit is frozen.
+
+OpenClaw Bay is unaffected: no queue lifecycle, telemetry, dashboard data contract, or observer/action boundary changes. The operational-cursor route is also unchanged because its only current consumer uses the webhook secret.

--- a/docs/proof/operator-record-read-auth/README.md
+++ b/docs/proof/operator-record-read-auth/README.md
@@ -14,6 +14,6 @@ node docs/proof/operator-record-read-auth/run-proof.mjs \
   "$(git merge-base HEAD origin/main)"
 ```
 
-The final Docker-backed Crabbox `local-container` receipt, captured transcript, behavior report, content hashes, and cleanup result are recorded beside this file after the implementation commit is frozen.
+Docker-backed Crabbox `provider=local-container` ran the frozen executable head `c2c81fcdb6861a1b15ae9f9b6531d76c776d433b` in `node:24-bookworm` on lease `cbx_c96e9586c6f8` (`quick-shrimp-ead6`). The router test passed, the real Worker produced the required 401→200 operator transition with webhook 200 and garbage 401, both process trees stopped cleanly, `check:dashboard-strict` passed without adding `worker.ts`, and the full gate passed 3,393 of 3,401 tests with eight platform skips and zero failures. Crabbox exited 0 and stopped the lease automatically. The frozen [behavior report](behavior-report.json), [receipt](receipt.json), captured transcript, and stderr are recorded beside this file.
 
 OpenClaw Bay is unaffected: no queue lifecycle, telemetry, dashboard data contract, or observer/action boundary changes. The operational-cursor route is also unchanged because its only current consumer uses the webhook secret.

--- a/docs/proof/operator-record-read-auth/README.md
+++ b/docs/proof/operator-record-read-auth/README.md
@@ -2,9 +2,9 @@
 
 Production exact-review reconcile run `31651591787` at `2026-08-12T23:38Z` checked ten head-mismatch targets and received `401` from every canonical completed-review lookup. The operator signed the existing read-only record GET with `EXACT_REVIEW_OPERATOR_SECRET`, while the Worker accepted only `CLAWSWEEPER_WEBHOOK_SECRET`. The shared-secret test setup for [openclaw/clawsweeper#1148](https://github.com/openclaw/clawsweeper/pull/1148) hid that boundary mismatch.
 
-The fix keeps the route and signature shape unchanged. `GET /internal/state/records/<repo-slug>/(items|closed|plans|decision-packets)/<number>` verifies the webhook secret first and, only if that fails, verifies the operator secret. A missing configuration returns 503 only when neither secret exists. Accepting the operator credential on this read-only route is not a privilege escalation because it already authorizes the queue’s mutation endpoints. The operator script and workflows remain unchanged.
+The fix keeps the route and signature shape unchanged. `GET /internal/state/records/<repo-slug>/items/<number>` verifies the webhook secret first and, only if that fails, verifies the operator secret because reconciliation reads active items only. The `closed`, `plans`, and `decision-packets` collections remain webhook-only. Existing 503 behavior remains unchanged for missing required credentials. The operator script and workflows remain unchanged.
 
-The executable [behavior contract](behavior-contract.md) and [RED/GREEN record](red-green.md) close the shared-secret coverage gap. `run-proof.mjs` extracts the merge base, boots it with distinct secrets, publishes a synthetic record, and proves operator/webhook/garbage statuses of 401/200/401. It then kills the complete Wrangler process tree, confirms the health endpoint is down, boots the candidate on the same port with separate persistence, and proves 200/200/401. The router-level unit test independently covers the same candidate auth matrix plus missing configuration.
+The executable [behavior contract](behavior-contract.md) and [RED/GREEN record](red-green.md) close the shared-secret coverage gap. `run-proof.mjs` extracts the merge base, boots it with distinct secrets, publishes all four synthetic records, and proves the full operator/webhook/garbage matrix. It then kills the complete Wrangler process tree, confirms the health endpoint is down, and boots the candidate on the same port with separate persistence. The router-level unit test independently covers the same candidate matrix plus missing configuration.
 
 Run the real-Worker comparison from a committed head with:
 
@@ -14,6 +14,6 @@ node docs/proof/operator-record-read-auth/run-proof.mjs \
   "$(git merge-base HEAD origin/main)"
 ```
 
-Docker-backed Crabbox `provider=local-container` ran the frozen executable head `c2c81fcdb6861a1b15ae9f9b6531d76c776d433b` in `node:24-bookworm` on lease `cbx_c96e9586c6f8` (`quick-shrimp-ead6`). The router test passed, the real Worker produced the required 401→200 operator transition with webhook 200 and garbage 401, both process trees stopped cleanly, `check:dashboard-strict` passed without adding `worker.ts`, and the full gate passed 3,393 of 3,401 tests with eight platform skips and zero failures. Crabbox exited 0 and stopped the lease automatically. The frozen [behavior report](behavior-report.json), [receipt](receipt.json), captured transcript, and stderr are recorded beside this file.
+The final Docker-backed Crabbox `provider=local-container` receipt, tested executable head, lease, full matrix, and gate totals are frozen in [receipt.json](receipt.json). The [behavior report](behavior-report.json), captured transcript, and stderr are recorded beside it.
 
 OpenClaw Bay is unaffected: no queue lifecycle, telemetry, dashboard data contract, or observer/action boundary changes. The operational-cursor route is also unchanged because its only current consumer uses the webhook secret.

--- a/docs/proof/operator-record-read-auth/README.md
+++ b/docs/proof/operator-record-read-auth/README.md
@@ -9,7 +9,9 @@ The executable [behavior contract](behavior-contract.md) and [RED/GREEN record](
 Run the real-Worker comparison from a committed head with:
 
 ```bash
-node docs/proof/operator-record-read-auth/run-proof.mjs "$(git rev-parse HEAD)"
+node docs/proof/operator-record-read-auth/run-proof.mjs \
+  "$(git rev-parse HEAD)" \
+  "$(git merge-base HEAD origin/main)"
 ```
 
 The final Docker-backed Crabbox `local-container` receipt, captured transcript, behavior report, content hashes, and cleanup result are recorded beside this file after the implementation commit is frozen.

--- a/docs/proof/operator-record-read-auth/behavior-contract.md
+++ b/docs/proof/operator-record-read-auth/behavior-contract.md
@@ -1,0 +1,24 @@
+# Operator canonical-record read authentication contract
+
+## Claim
+
+The canonical-record GET route accepts an HMAC made with either the webhook secret or the exact-review operator secret. The secrets remain distinct, invalid signatures remain unauthorized, and absent configuration remains unavailable only when neither secret exists.
+
+## Exercised surface
+
+The proof starts the production dashboard Worker with `wrangler dev --local`, publishes a synthetic canonical record through the signed tuple route, and reads that record through `GET /internal/state/records/openclaw-openclaw/items/1148`. It boots the merge-base Worker and candidate Worker sequentially on the same loopback port with different webhook and operator secret values. Between boots it terminates the complete Wrangler process tree and requires `/api/health` to stop responding.
+
+## Expected behavior
+
+| Revision   | Webhook signature | Operator signature | Garbage signature |
+| ---------- | ----------------: | -----------------: | ----------------: |
+| Merge base |               200 |                401 |               401 |
+| Candidate  |               200 |                200 |               401 |
+
+The router-level unit fixture repeats the candidate matrix with two distinct configured values and also requires `503 webhook_not_configured` when neither value exists.
+
+## Non-goals and limits
+
+The proof uses synthetic local credentials and state. It exercises the real Worker router, HMAC verification, and Durable Object record store over HTTP, but does not deploy, read production records, or mutate GitHub. The operational-cursor route is unchanged because its current client signs with the webhook secret and no operator-secret cursor consumer exists.
+
+OpenClaw Bay is unaffected. This is an internal authentication correction for an existing read-only queue route; it changes no observer data contract or action surface.

--- a/docs/proof/operator-record-read-auth/behavior-contract.md
+++ b/docs/proof/operator-record-read-auth/behavior-contract.md
@@ -2,20 +2,21 @@
 
 ## Claim
 
-The canonical-record GET route accepts an HMAC made with either the webhook secret or the exact-review operator secret. The secrets remain distinct, invalid signatures remain unauthorized, and absent configuration remains unavailable only when neither secret exists.
+The canonical-record GET route accepts the exact-review operator secret only for `items`, the sole collection read by reconciliation. The webhook secret retains access to `items`, `closed`, `plans`, and `decision-packets`; invalid signatures remain unauthorized; and missing required configuration remains unavailable.
 
 ## Exercised surface
 
-The proof starts the production dashboard Worker with `wrangler dev --local`, publishes a synthetic canonical record through the signed tuple route, and reads that record through `GET /internal/state/records/openclaw-openclaw/items/1148`. It boots the merge-base Worker and candidate Worker sequentially on the same loopback port with different webhook and operator secret values. Between boots it terminates the complete Wrangler process tree and requires `/api/health` to stop responding.
+The proof starts the production dashboard Worker with `wrangler dev --local`, publishes synthetic canonical records through the signed tuple route, and reads all four collections through `GET /internal/state/records/openclaw-openclaw/<collection>/1148`. It boots the merge-base Worker and candidate Worker sequentially on the same loopback port with different webhook and operator secret values. Between boots it terminates the complete Wrangler process tree and requires `/api/health` to stop responding.
 
 ## Expected behavior
 
-| Revision   | Webhook signature | Operator signature | Garbage signature |
-| ---------- | ----------------: | -----------------: | ----------------: |
-| Merge base |               200 |                401 |               401 |
-| Candidate  |               200 |                200 |               401 |
+| Revision  | Signature | Items | Closed | Plans | Decision packets |
+| --------- | --------- | ----: | -----: | ----: | ---------------: |
+| Candidate | Operator  |   200 |    401 |   401 |              401 |
+| Candidate | Webhook   |   200 |    200 |   200 |              200 |
+| Candidate | Garbage   |   401 |    401 |   401 |              401 |
 
-The router-level unit fixture repeats the candidate matrix with two distinct configured values and also requires `503 webhook_not_configured` when neither value exists.
+The merge base remains webhook-only for all four collections. The router-level unit fixture repeats the candidate matrix with two distinct configured values. It also requires `503 webhook_not_configured` when neither value exists and for an operator-only request to a webhook-only collection.
 
 ## Non-goals and limits
 

--- a/docs/proof/operator-record-read-auth/behavior-report.json
+++ b/docs/proof/operator-record-read-auth/behavior-report.json
@@ -1,8 +1,8 @@
 {
   "schema": "clawsweeper-operator-record-read-auth-proof/v1",
-  "generated_at": "2026-08-12T23:56:21.024Z",
+  "generated_at": "2026-08-13T00:18:03.379Z",
   "merge_base": "ae36d608d01701af7e06c313be96689068b5c890",
-  "head": "c2c81fcdb6861a1b15ae9f9b6531d76c776d433b",
+  "head": "1855dfbb0c0d0b66978a99b20756845e3d6fa131",
   "runtime": "sequential real wrangler dev --local Workers over loopback HTTP",
   "configuration": {
     "secrets_distinct": true,
@@ -13,52 +13,115 @@
     "baseline_source": "exact public GitHub commit"
   },
   "before": {
-    "webhook": {
-      "status": 200,
-      "body": {
-        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
-        "revision": 1,
-        "content_matches": true,
-        "updated_at_valid": true
-      }
-    },
     "operator": {
-      "status": 401,
-      "body": {
-        "error": "invalid_signature"
+      "items": { "status": 401, "body": { "error": "invalid_signature" } },
+      "closed": { "status": 401, "body": { "error": "invalid_signature" } },
+      "plans": { "status": 401, "body": { "error": "invalid_signature" } },
+      "decision-packets": { "status": 401, "body": { "error": "invalid_signature" } }
+    },
+    "webhook": {
+      "items": {
+        "status": 200,
+        "body": {
+          "digest": "6471d07455ff7a89b394dae08e7e693a6f79629db0e14e8f58115b9c90be986a",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "closed": {
+        "status": 200,
+        "body": {
+          "digest": "15f2f682df60c650c5f0e7f4235f410b2402460ac19e9dd6d14271013aa657c0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "plans": {
+        "status": 200,
+        "body": {
+          "digest": "b89ebbdc643dd7be0defe48e3d48ce7342c62a4cc150f9ef199dab2b7c26e129",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "decision-packets": {
+        "status": 200,
+        "body": {
+          "digest": "a24f6dd883067f6048feacf7c00c1c8c2572ef1a0b09690b7945855555e8ccc0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
       }
     },
     "garbage": {
-      "status": 401,
-      "body": {
-        "error": "invalid_signature"
-      }
+      "items": { "status": 401, "body": { "error": "invalid_signature" } },
+      "closed": { "status": 401, "body": { "error": "invalid_signature" } },
+      "plans": { "status": 401, "body": { "error": "invalid_signature" } },
+      "decision-packets": { "status": 401, "body": { "error": "invalid_signature" } }
     }
   },
   "after": {
-    "webhook": {
-      "status": 200,
-      "body": {
-        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
-        "revision": 1,
-        "content_matches": true,
-        "updated_at_valid": true
-      }
-    },
     "operator": {
-      "status": 200,
-      "body": {
-        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
-        "revision": 1,
-        "content_matches": true,
-        "updated_at_valid": true
+      "items": {
+        "status": 200,
+        "body": {
+          "digest": "6471d07455ff7a89b394dae08e7e693a6f79629db0e14e8f58115b9c90be986a",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "closed": { "status": 401, "body": { "error": "invalid_signature" } },
+      "plans": { "status": 401, "body": { "error": "invalid_signature" } },
+      "decision-packets": { "status": 401, "body": { "error": "invalid_signature" } }
+    },
+    "webhook": {
+      "items": {
+        "status": 200,
+        "body": {
+          "digest": "6471d07455ff7a89b394dae08e7e693a6f79629db0e14e8f58115b9c90be986a",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "closed": {
+        "status": 200,
+        "body": {
+          "digest": "15f2f682df60c650c5f0e7f4235f410b2402460ac19e9dd6d14271013aa657c0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "plans": {
+        "status": 200,
+        "body": {
+          "digest": "b89ebbdc643dd7be0defe48e3d48ce7342c62a4cc150f9ef199dab2b7c26e129",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "decision-packets": {
+        "status": 200,
+        "body": {
+          "digest": "a24f6dd883067f6048feacf7c00c1c8c2572ef1a0b09690b7945855555e8ccc0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
       }
     },
     "garbage": {
-      "status": 401,
-      "body": {
-        "error": "invalid_signature"
-      }
+      "items": { "status": 401, "body": { "error": "invalid_signature" } },
+      "closed": { "status": 401, "body": { "error": "invalid_signature" } },
+      "plans": { "status": 401, "body": { "error": "invalid_signature" } },
+      "decision-packets": { "status": 401, "body": { "error": "invalid_signature" } }
     }
   },
   "process_tree_shutdowns": [
@@ -76,10 +139,16 @@
     }
   ],
   "result": {
-    "merge_base_operator_status": 401,
-    "candidate_operator_status": 200,
-    "candidate_webhook_status": 200,
-    "candidate_garbage_status": 401,
+    "merge_base_statuses": {
+      "operator": { "items": 401, "closed": 401, "plans": 401, "decision-packets": 401 },
+      "webhook": { "items": 200, "closed": 200, "plans": 200, "decision-packets": 200 },
+      "garbage": { "items": 401, "closed": 401, "plans": 401, "decision-packets": 401 }
+    },
+    "candidate_statuses": {
+      "operator": { "items": 200, "closed": 401, "plans": 401, "decision-packets": 401 },
+      "webhook": { "items": 200, "closed": 200, "plans": 200, "decision-packets": 200 },
+      "garbage": { "items": 401, "closed": 401, "plans": 401, "decision-packets": 401 }
+    },
     "status": "succeeded"
   },
   "limits": [

--- a/docs/proof/operator-record-read-auth/behavior-report.json
+++ b/docs/proof/operator-record-read-auth/behavior-report.json
@@ -1,0 +1,90 @@
+{
+  "schema": "clawsweeper-operator-record-read-auth-proof/v1",
+  "generated_at": "2026-08-12T23:56:21.024Z",
+  "merge_base": "ae36d608d01701af7e06c313be96689068b5c890",
+  "head": "c2c81fcdb6861a1b15ae9f9b6531d76c776d433b",
+  "runtime": "sequential real wrangler dev --local Workers over loopback HTTP",
+  "configuration": {
+    "secrets_distinct": true,
+    "shared_secret_fixture": false,
+    "persisted_state_shared_between_boots": false,
+    "candidate_git_metadata": false,
+    "candidate_head_source": "explicit Crabbox argument",
+    "baseline_source": "exact public GitHub commit"
+  },
+  "before": {
+    "webhook": {
+      "status": 200,
+      "body": {
+        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
+        "revision": 1,
+        "content_matches": true,
+        "updated_at_valid": true
+      }
+    },
+    "operator": {
+      "status": 401,
+      "body": {
+        "error": "invalid_signature"
+      }
+    },
+    "garbage": {
+      "status": 401,
+      "body": {
+        "error": "invalid_signature"
+      }
+    }
+  },
+  "after": {
+    "webhook": {
+      "status": 200,
+      "body": {
+        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
+        "revision": 1,
+        "content_matches": true,
+        "updated_at_valid": true
+      }
+    },
+    "operator": {
+      "status": 200,
+      "body": {
+        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
+        "revision": 1,
+        "content_matches": true,
+        "updated_at_valid": true
+      }
+    },
+    "garbage": {
+      "status": 401,
+      "body": {
+        "error": "invalid_signature"
+      }
+    }
+  },
+  "process_tree_shutdowns": [
+    {
+      "label": "merge-base",
+      "method": "process_group_and_descendants",
+      "targeted_processes": 8,
+      "health_down": true
+    },
+    {
+      "label": "candidate",
+      "method": "process_group_and_descendants",
+      "targeted_processes": 8,
+      "health_down": true
+    }
+  ],
+  "result": {
+    "merge_base_operator_status": 401,
+    "candidate_operator_status": 200,
+    "candidate_webhook_status": 200,
+    "candidate_garbage_status": 401,
+    "status": "succeeded"
+  },
+  "limits": [
+    "Credentials and canonical content are synthetic local fixtures.",
+    "The proof exercises local Worker routing and Durable Object persistence, not production state or GitHub mutation.",
+    "The operational-cursor route is outside scope because it has no operator-secret consumer."
+  ]
+}

--- a/docs/proof/operator-record-read-auth/container-stderr.txt
+++ b/docs/proof/operator-record-read-auth/container-stderr.txt
@@ -1,0 +1,11 @@
+debconf: delaying package configuration, since apt-utils is not installed
+npm notice
+npm notice New major version of npm available! 11.17.0 -> 12.0.2
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v12.0.2
+npm notice To update run: npm install -g npm@12.0.2
+npm notice
+$ pnpm run build && pnpm run build:repair && pnpm run build:dashboard
+$ tsc -p tsconfig.json
+$ tsc -p tsconfig.repair.json
+$ tsc -p tsconfig.dashboard.json
+$ node scripts/check-dashboard-strict.mjs

--- a/docs/proof/operator-record-read-auth/container-transcript.txt
+++ b/docs/proof/operator-record-read-auth/container-transcript.txt
@@ -1,0 +1,169 @@
+PROOF_PHASE=environment
+provider=local-container
+image=node:24-bookworm
+head=c2c81fcdb6861a1b15ae9f9b6531d76c776d433b
+base=ae36d608d01701af7e06c313be96689068b5c890
+head_attestation=explicit_argument_with_content_hashes
+v24.19.0
+11.17.0
+jq-1.6
+PROOF_PHASE=corepack
+
+added 1 package in 274ms
+11.10.0
+PROOF_PHASE=install
+? Verifying lockfile against supply-chain policies (79 entries)...
+Lockfile is up to date, resolution step is skipped
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Packages: +19
++++++++++++++++++++
+
+   ╭───────────────────────────────────────────────╮
+   │                                               │
+   │     Update available! 11.10.0 → 11.21.0.      │
+   │     Changelog: https://pnpm.io/v/11.21.0      │
+   │   To update, run: corepack use pnpm@11.21.0   │
+   │                                               │
+   ╰───────────────────────────────────────────────╯
+
+✓ Lockfile passes supply-chain policies (79 entries in 528ms)
+Progress: resolved 19, reused 0, downloaded 17, added 17
+Progress: resolved 19, reused 0, downloaded 19, added 19, done
+
+dependencies:
++ typescript 7.0.2
++ yaml 2.9.0
+
+devDependencies:
++ @types/node 24.13.3
++ markdown-it 15.0.0
++ oxfmt 0.58.0
++ oxlint 1.73.0
++ oxlint-tsgolint 0.24.0
+
+Done in 1.8s using pnpm v11.10.0
+PROOF_PHASE=build
+PROOF_PHASE=focused-router-test
+✔ canonical record reads accept distinct webhook and operator secrets (20.805956ms)
+ℹ tests 1
+ℹ suites 0
+ℹ pass 1
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 164.649768
+PROOF_PHASE=real-worker
+{
+  "schema": "clawsweeper-operator-record-read-auth-proof/v1",
+  "generated_at": "2026-08-12T23:56:21.024Z",
+  "merge_base": "ae36d608d01701af7e06c313be96689068b5c890",
+  "head": "c2c81fcdb6861a1b15ae9f9b6531d76c776d433b",
+  "runtime": "sequential real wrangler dev --local Workers over loopback HTTP",
+  "configuration": {
+    "secrets_distinct": true,
+    "shared_secret_fixture": false,
+    "persisted_state_shared_between_boots": false,
+    "candidate_git_metadata": false,
+    "candidate_head_source": "explicit Crabbox argument",
+    "baseline_source": "exact public GitHub commit"
+  },
+  "before": {
+    "webhook": {
+      "status": 200,
+      "body": {
+        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
+        "revision": 1,
+        "content_matches": true,
+        "updated_at_valid": true
+      }
+    },
+    "operator": {
+      "status": 401,
+      "body": {
+        "error": "invalid_signature"
+      }
+    },
+    "garbage": {
+      "status": 401,
+      "body": {
+        "error": "invalid_signature"
+      }
+    }
+  },
+  "after": {
+    "webhook": {
+      "status": 200,
+      "body": {
+        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
+        "revision": 1,
+        "content_matches": true,
+        "updated_at_valid": true
+      }
+    },
+    "operator": {
+      "status": 200,
+      "body": {
+        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
+        "revision": 1,
+        "content_matches": true,
+        "updated_at_valid": true
+      }
+    },
+    "garbage": {
+      "status": 401,
+      "body": {
+        "error": "invalid_signature"
+      }
+    }
+  },
+  "process_tree_shutdowns": [
+    {
+      "label": "merge-base",
+      "method": "process_group_and_descendants",
+      "targeted_processes": 8,
+      "health_down": true
+    },
+    {
+      "label": "candidate",
+      "method": "process_group_and_descendants",
+      "targeted_processes": 8,
+      "health_down": true
+    }
+  ],
+  "result": {
+    "merge_base_operator_status": 401,
+    "candidate_operator_status": 200,
+    "candidate_webhook_status": 200,
+    "candidate_garbage_status": 401,
+    "status": "succeeded"
+  },
+  "limits": [
+    "Credentials and canonical content are synthetic local fixtures.",
+    "The proof exercises local Worker routing and Durable Object persistence, not production state or GitHub mutation.",
+    "The operational-cursor route is outside scope because it has no operator-secret consumer."
+  ]
+}
+OPERATOR_RECORD_READ_AUTH_PROOF_RC=0
+PROOF_PHASE=dashboard-strict
+PROOF_PHASE=full-gate
+. check:dashboard-queue-boundary: dashboard queue boundary check passed
+. check:docs: Documentation checks passed.
+. format:check: All matched files use the correct format.
+ℹ tests 12
+ℹ pass 12
+ℹ fail 0
+ℹ skipped 0
+ℹ tests 3401
+ℹ pass 3393
+ℹ fail 0
+ℹ skipped 8
+PROOF_PHASE=content
+ea6547649937116d24ee3ab187ca8e9835231584ac585bfc9addeded3b37c922  dashboard/worker.ts
+c0c1825dd97733ea09194da9554f805a9fb9404603e6c43d4a15e58bf4ec0525  docs/proof/operator-record-read-auth/behavior-contract.md
+4d54adab56e97ecb21fa9f6dea49313762d904a4704deae38e8d2e9f27923037  docs/proof/operator-record-read-auth/red-green.md
+521718fca6b486d29bd649d27f3628ce225903f4b3a9ff27def531268ec51c29  docs/proof/operator-record-read-auth/run-proof.mjs
+a8698271a34774193d753901386f71e14f696e4038678786467e3c40e07fe924  docs/proof/operator-record-read-auth/run-proof.sh
+8484d0e38125141f4388b9db1f5c5656b1e95cf7ae90da5c82f4dad1f852fb47  test/dashboard-worker-publication-lifecycle.test.ts
+source_status=git_metadata_unavailable_after_linked-worktree_sync
+PROOF_RESULT=pass

--- a/docs/proof/operator-record-read-auth/container-transcript.txt
+++ b/docs/proof/operator-record-read-auth/container-transcript.txt
@@ -1,7 +1,7 @@
 PROOF_PHASE=environment
 provider=local-container
 image=node:24-bookworm
-head=c2c81fcdb6861a1b15ae9f9b6531d76c776d433b
+head=1855dfbb0c0d0b66978a99b20756845e3d6fa131
 base=ae36d608d01701af7e06c313be96689068b5c890
 head_attestation=explicit_argument_with_content_hashes
 v24.19.0
@@ -9,7 +9,7 @@ v24.19.0
 jq-1.6
 PROOF_PHASE=corepack
 
-added 1 package in 274ms
+added 1 package in 337ms
 11.10.0
 PROOF_PHASE=install
 ? Verifying lockfile against supply-chain policies (79 entries)...
@@ -26,8 +26,8 @@ Packages: +19
    │                                               │
    ╰───────────────────────────────────────────────╯
 
-✓ Lockfile passes supply-chain policies (79 entries in 528ms)
-Progress: resolved 19, reused 0, downloaded 17, added 17
+✓ Lockfile passes supply-chain policies (79 entries in 464ms)
+Progress: resolved 19, reused 0, downloaded 16, added 16
 Progress: resolved 19, reused 0, downloaded 19, added 19, done
 
 dependencies:
@@ -41,10 +41,10 @@ devDependencies:
 + oxlint 1.73.0
 + oxlint-tsgolint 0.24.0
 
-Done in 1.8s using pnpm v11.10.0
+Done in 3.1s using pnpm v11.10.0
 PROOF_PHASE=build
 PROOF_PHASE=focused-router-test
-✔ canonical record reads accept distinct webhook and operator secrets (20.805956ms)
+✔ canonical record operator auth is scoped to items (29.007503ms)
 ℹ tests 1
 ℹ suites 0
 ℹ pass 1
@@ -52,13 +52,13 @@ PROOF_PHASE=focused-router-test
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 164.649768
+ℹ duration_ms 174.1721
 PROOF_PHASE=real-worker
 {
   "schema": "clawsweeper-operator-record-read-auth-proof/v1",
-  "generated_at": "2026-08-12T23:56:21.024Z",
+  "generated_at": "2026-08-13T00:18:03.379Z",
   "merge_base": "ae36d608d01701af7e06c313be96689068b5c890",
-  "head": "c2c81fcdb6861a1b15ae9f9b6531d76c776d433b",
+  "head": "1855dfbb0c0d0b66978a99b20756845e3d6fa131",
   "runtime": "sequential real wrangler dev --local Workers over loopback HTTP",
   "configuration": {
     "secrets_distinct": true,
@@ -69,51 +69,189 @@ PROOF_PHASE=real-worker
     "baseline_source": "exact public GitHub commit"
   },
   "before": {
-    "webhook": {
-      "status": 200,
-      "body": {
-        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
-        "revision": 1,
-        "content_matches": true,
-        "updated_at_valid": true
+    "operator": {
+      "items": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "closed": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "plans": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "decision-packets": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
       }
     },
-    "operator": {
-      "status": 401,
-      "body": {
-        "error": "invalid_signature"
+    "webhook": {
+      "items": {
+        "status": 200,
+        "body": {
+          "digest": "6471d07455ff7a89b394dae08e7e693a6f79629db0e14e8f58115b9c90be986a",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "closed": {
+        "status": 200,
+        "body": {
+          "digest": "15f2f682df60c650c5f0e7f4235f410b2402460ac19e9dd6d14271013aa657c0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "plans": {
+        "status": 200,
+        "body": {
+          "digest": "b89ebbdc643dd7be0defe48e3d48ce7342c62a4cc150f9ef199dab2b7c26e129",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "decision-packets": {
+        "status": 200,
+        "body": {
+          "digest": "a24f6dd883067f6048feacf7c00c1c8c2572ef1a0b09690b7945855555e8ccc0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
       }
     },
     "garbage": {
-      "status": 401,
-      "body": {
-        "error": "invalid_signature"
+      "items": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "closed": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "plans": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "decision-packets": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
       }
     }
   },
   "after": {
-    "webhook": {
-      "status": 200,
-      "body": {
-        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
-        "revision": 1,
-        "content_matches": true,
-        "updated_at_valid": true
+    "operator": {
+      "items": {
+        "status": 200,
+        "body": {
+          "digest": "6471d07455ff7a89b394dae08e7e693a6f79629db0e14e8f58115b9c90be986a",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "closed": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "plans": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "decision-packets": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
       }
     },
-    "operator": {
-      "status": 200,
-      "body": {
-        "digest": "0f26c70ecb4fcf26431384b70af9851d87404a8a497f363974a247080f8b9e11",
-        "revision": 1,
-        "content_matches": true,
-        "updated_at_valid": true
+    "webhook": {
+      "items": {
+        "status": 200,
+        "body": {
+          "digest": "6471d07455ff7a89b394dae08e7e693a6f79629db0e14e8f58115b9c90be986a",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "closed": {
+        "status": 200,
+        "body": {
+          "digest": "15f2f682df60c650c5f0e7f4235f410b2402460ac19e9dd6d14271013aa657c0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "plans": {
+        "status": 200,
+        "body": {
+          "digest": "b89ebbdc643dd7be0defe48e3d48ce7342c62a4cc150f9ef199dab2b7c26e129",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
+      },
+      "decision-packets": {
+        "status": 200,
+        "body": {
+          "digest": "a24f6dd883067f6048feacf7c00c1c8c2572ef1a0b09690b7945855555e8ccc0",
+          "revision": 1,
+          "content_matches": true,
+          "updated_at_valid": true
+        }
       }
     },
     "garbage": {
-      "status": 401,
-      "body": {
-        "error": "invalid_signature"
+      "items": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "closed": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "plans": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
+      },
+      "decision-packets": {
+        "status": 401,
+        "body": {
+          "error": "invalid_signature"
+        }
       }
     }
   },
@@ -132,10 +270,46 @@ PROOF_PHASE=real-worker
     }
   ],
   "result": {
-    "merge_base_operator_status": 401,
-    "candidate_operator_status": 200,
-    "candidate_webhook_status": 200,
-    "candidate_garbage_status": 401,
+    "merge_base_statuses": {
+      "operator": {
+        "items": 401,
+        "closed": 401,
+        "plans": 401,
+        "decision-packets": 401
+      },
+      "webhook": {
+        "items": 200,
+        "closed": 200,
+        "plans": 200,
+        "decision-packets": 200
+      },
+      "garbage": {
+        "items": 401,
+        "closed": 401,
+        "plans": 401,
+        "decision-packets": 401
+      }
+    },
+    "candidate_statuses": {
+      "operator": {
+        "items": 200,
+        "closed": 401,
+        "plans": 401,
+        "decision-packets": 401
+      },
+      "webhook": {
+        "items": 200,
+        "closed": 200,
+        "plans": 200,
+        "decision-packets": 200
+      },
+      "garbage": {
+        "items": 401,
+        "closed": 401,
+        "plans": 401,
+        "decision-packets": 401
+      }
+    },
     "status": "succeeded"
   },
   "limits": [
@@ -159,11 +333,11 @@ PROOF_PHASE=full-gate
 ℹ fail 0
 ℹ skipped 8
 PROOF_PHASE=content
-ea6547649937116d24ee3ab187ca8e9835231584ac585bfc9addeded3b37c922  dashboard/worker.ts
-c0c1825dd97733ea09194da9554f805a9fb9404603e6c43d4a15e58bf4ec0525  docs/proof/operator-record-read-auth/behavior-contract.md
-4d54adab56e97ecb21fa9f6dea49313762d904a4704deae38e8d2e9f27923037  docs/proof/operator-record-read-auth/red-green.md
-521718fca6b486d29bd649d27f3628ce225903f4b3a9ff27def531268ec51c29  docs/proof/operator-record-read-auth/run-proof.mjs
-a8698271a34774193d753901386f71e14f696e4038678786467e3c40e07fe924  docs/proof/operator-record-read-auth/run-proof.sh
-8484d0e38125141f4388b9db1f5c5656b1e95cf7ae90da5c82f4dad1f852fb47  test/dashboard-worker-publication-lifecycle.test.ts
+5508c1bfe6a685ba62b22d8ceada83c756b35f48c730a80b42cbd2bd10ec41bc  dashboard/worker.ts
+a950aa0ca94f2e6c396209140c055ac5994e7680cd0267f6fa5f230feb1ed786  docs/proof/operator-record-read-auth/behavior-contract.md
+7c60ddb812795928ba08d988fb351c269ca1760bf1ff75e9ad3175e955bade63  docs/proof/operator-record-read-auth/red-green.md
+f6b9f2e2261acaf105f50e55180e92dacaf3282fe2eca4df1605bd99992588a9  docs/proof/operator-record-read-auth/run-proof.mjs
+d085561567bd4ab3659d6aecb78ff419d745dfecc6c1c0ef0f8f3c2882eae2c4  docs/proof/operator-record-read-auth/run-proof.sh
+dbcce41ccc3ecb38620bea13d4c93d0eff9f317b24c8b569e9dfd1fe4bec0c93  test/dashboard-worker-publication-lifecycle.test.ts
 source_status=git_metadata_unavailable_after_linked-worktree_sync
 PROOF_RESULT=pass

--- a/docs/proof/operator-record-read-auth/receipt.json
+++ b/docs/proof/operator-record-read-auth/receipt.json
@@ -1,20 +1,20 @@
 {
   "schema_version": 1,
-  "recorded_at": "2026-08-12T23:58:40Z",
+  "recorded_at": "2026-08-13T00:22:47Z",
   "provider": "local-container",
-  "lease_id": "cbx_c96e9586c6f8",
-  "slug": "quick-shrimp-ead6",
+  "lease_id": "cbx_23906feb2769",
+  "slug": "pearl-shrimp-a24f",
   "container_runtime": "docker",
   "image": "node:24-bookworm",
   "machine_type": "node_24-bookworm",
-  "tested_head": "c2c81fcdb6861a1b15ae9f9b6531d76c776d433b",
+  "tested_head": "1855dfbb0c0d0b66978a99b20756845e3d6fa131",
   "base_head": "ae36d608d01701af7e06c313be96689068b5c890",
-  "command": "/Users/steipete/Projects/crabbox/bin/crabbox run --provider local-container --local-container-image node:24-bookworm --no-hydrate --preflight --timing-json --capture-stdout docs/proof/operator-record-read-auth/container-transcript.txt --capture-stderr docs/proof/operator-record-read-auth/container-stderr.txt --script docs/proof/operator-record-read-auth/run-proof.sh -- c2c81fcdb6861a1b15ae9f9b6531d76c776d433b ae36d608d01701af7e06c313be96689068b5c890",
+  "command": "/Users/steipete/Projects/crabbox/bin/crabbox run --provider local-container --local-container-image node:24-bookworm --no-hydrate --preflight --timing-json --capture-stdout docs/proof/operator-record-read-auth/container-transcript.txt --capture-stderr docs/proof/operator-record-read-auth/container-stderr.txt --script docs/proof/operator-record-read-auth/run-proof.sh -- 1855dfbb0c0d0b66978a99b20756845e3d6fa131 ae36d608d01701af7e06c313be96689068b5c890",
   "exit_code": 0,
   "lease_stopped": true,
-  "sync_ms": 1079,
-  "command_ms": 142192,
-  "total_ms": 143285,
+  "sync_ms": 1015,
+  "command_ms": 260400,
+  "total_ms": 261431,
   "node_version": "v24.19.0",
   "pnpm_version": "11.10.0",
   "jq_version": "jq-1.6",
@@ -24,10 +24,24 @@
     "failed": 0
   },
   "real_worker": {
-    "merge_base_operator_status": 401,
-    "candidate_operator_status": 200,
-    "candidate_webhook_status": 200,
-    "candidate_garbage_status": 401,
+    "operator": {
+      "items": 200,
+      "closed": 401,
+      "plans": 401,
+      "decision-packets": 401
+    },
+    "webhook": {
+      "items": 200,
+      "closed": 200,
+      "plans": 200,
+      "decision-packets": 200
+    },
+    "garbage": {
+      "items": 401,
+      "closed": 401,
+      "plans": 401,
+      "decision-packets": 401
+    },
     "full_process_tree_shutdowns": 2,
     "health_down_after_each_shutdown": true
   },
@@ -46,47 +60,42 @@
   },
   "pre_commit_autoreview": [
     {
-      "scope": "complete implementation bundle",
+      "scope": "round-two implementation and matrix",
       "exit_code": 0,
       "accepted_or_actionable_findings": 0,
       "result": "autoreview clean: no accepted/actionable findings reported"
     },
     {
-      "scope": "linked-worktree proof transport correction",
-      "exit_code": 0,
-      "accepted_or_actionable_findings": 0,
-      "result": "autoreview clean: no accepted/actionable findings reported"
-    },
-    {
-      "scope": "container gate prerequisite correction",
-      "exit_code": 0,
-      "accepted_or_actionable_findings": 0,
-      "result": "autoreview clean: no accepted/actionable findings reported"
+      "scope": "proof harness plus stale failed-run transcript",
+      "exit_code": 1,
+      "accepted_or_actionable_findings": 1,
+      "result": "accepted P1 resolved by this successful final-head container receipt"
     }
   ],
   "behavior_report": "docs/proof/operator-record-read-auth/behavior-report.json",
   "content_sha256": {
-    "dashboard/worker.ts": "ea6547649937116d24ee3ab187ca8e9835231584ac585bfc9addeded3b37c922",
-    "docs/proof/operator-record-read-auth/behavior-contract.md": "c0c1825dd97733ea09194da9554f805a9fb9404603e6c43d4a15e58bf4ec0525",
-    "docs/proof/operator-record-read-auth/red-green.md": "4d54adab56e97ecb21fa9f6dea49313762d904a4704deae38e8d2e9f27923037",
-    "docs/proof/operator-record-read-auth/run-proof.mjs": "521718fca6b486d29bd649d27f3628ce225903f4b3a9ff27def531268ec51c29",
-    "docs/proof/operator-record-read-auth/run-proof.sh": "a8698271a34774193d753901386f71e14f696e4038678786467e3c40e07fe924",
-    "test/dashboard-worker-publication-lifecycle.test.ts": "8484d0e38125141f4388b9db1f5c5656b1e95cf7ae90da5c82f4dad1f852fb47"
+    "dashboard/worker.ts": "5508c1bfe6a685ba62b22d8ceada83c756b35f48c730a80b42cbd2bd10ec41bc",
+    "docs/proof/operator-record-read-auth/behavior-contract.md": "a950aa0ca94f2e6c396209140c055ac5994e7680cd0267f6fa5f230feb1ed786",
+    "docs/proof/operator-record-read-auth/red-green.md": "7c60ddb812795928ba08d988fb351c269ca1760bf1ff75e9ad3175e955bade63",
+    "docs/proof/operator-record-read-auth/run-proof.mjs": "f6b9f2e2261acaf105f50e55180e92dacaf3282fe2eca4df1605bd99992588a9",
+    "docs/proof/operator-record-read-auth/run-proof.sh": "d085561567bd4ab3659d6aecb78ff419d745dfecc6c1c0ef0f8f3c2882eae2c4",
+    "test/dashboard-worker-publication-lifecycle.test.ts": "dbcce41ccc3ecb38620bea13d4c93d0eff9f317b24c8b569e9dfd1fe4bec0c93"
   },
-  "transcript_sha256": "46028317a5ca54ccc1f9f1856d7369f2c148c4e1c4d5920446ee037d579f92a5",
+  "transcript_sha256": "8e1da1d966baeccd428df56d89cf06701d60c5606fbc9ddcd53394c210664e90",
   "stderr_sha256": "f558a75380196784725021d1f644597a31a196bb0ccd1f16542c0b6fda2c7e39",
   "secret_scan": {
     "tool": "trufflehog 3.96.0",
     "command": "trufflehog filesystem --no-update --results=verified,unknown --fail --fail-on-scan-errors docs/proof/operator-record-read-auth/container-transcript.txt docs/proof/operator-record-read-auth/container-stderr.txt",
     "exit_code": 0,
     "chunks": 2,
-    "bytes": 5913,
+    "bytes": 9815,
     "verified_secrets": 0,
     "unknown_secrets": 0
   },
   "cleanup": {
-    "owned_lease_absent_from_local_container_list": true,
+    "owned_success_lease_absent_from_local_container_list": true,
+    "owned_failed_lease_absent_from_local_container_list": true,
     "unrelated_preexisting_exited_lease_untouched": true,
-    "failed_attempt_artifacts_moved_to_macos_trash": true
+    "failed_capture_moved_to_macos_trash": true
   }
 }

--- a/docs/proof/operator-record-read-auth/receipt.json
+++ b/docs/proof/operator-record-read-auth/receipt.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-08-12T23:58:40Z",
+  "provider": "local-container",
+  "lease_id": "cbx_c96e9586c6f8",
+  "slug": "quick-shrimp-ead6",
+  "container_runtime": "docker",
+  "image": "node:24-bookworm",
+  "machine_type": "node_24-bookworm",
+  "tested_head": "c2c81fcdb6861a1b15ae9f9b6531d76c776d433b",
+  "base_head": "ae36d608d01701af7e06c313be96689068b5c890",
+  "command": "/Users/steipete/Projects/crabbox/bin/crabbox run --provider local-container --local-container-image node:24-bookworm --no-hydrate --preflight --timing-json --capture-stdout docs/proof/operator-record-read-auth/container-transcript.txt --capture-stderr docs/proof/operator-record-read-auth/container-stderr.txt --script docs/proof/operator-record-read-auth/run-proof.sh -- c2c81fcdb6861a1b15ae9f9b6531d76c776d433b ae36d608d01701af7e06c313be96689068b5c890",
+  "exit_code": 0,
+  "lease_stopped": true,
+  "sync_ms": 1079,
+  "command_ms": 142192,
+  "total_ms": 143285,
+  "node_version": "v24.19.0",
+  "pnpm_version": "11.10.0",
+  "jq_version": "jq-1.6",
+  "focused_router_test": {
+    "total": 1,
+    "passed": 1,
+    "failed": 0
+  },
+  "real_worker": {
+    "merge_base_operator_status": 401,
+    "candidate_operator_status": 200,
+    "candidate_webhook_status": 200,
+    "candidate_garbage_status": 401,
+    "full_process_tree_shutdowns": 2,
+    "health_down_after_each_shutdown": true
+  },
+  "dashboard_strict": {
+    "command": "pnpm run check:dashboard-strict",
+    "exit_code": 0,
+    "worker_ts_added_to_strict_list": false
+  },
+  "full_gate": {
+    "command": "pnpm run check",
+    "exit_code": 0,
+    "tests": 3401,
+    "passed": 3393,
+    "failed": 0,
+    "skipped": 8
+  },
+  "pre_commit_autoreview": [
+    {
+      "scope": "complete implementation bundle",
+      "exit_code": 0,
+      "accepted_or_actionable_findings": 0,
+      "result": "autoreview clean: no accepted/actionable findings reported"
+    },
+    {
+      "scope": "linked-worktree proof transport correction",
+      "exit_code": 0,
+      "accepted_or_actionable_findings": 0,
+      "result": "autoreview clean: no accepted/actionable findings reported"
+    },
+    {
+      "scope": "container gate prerequisite correction",
+      "exit_code": 0,
+      "accepted_or_actionable_findings": 0,
+      "result": "autoreview clean: no accepted/actionable findings reported"
+    }
+  ],
+  "behavior_report": "docs/proof/operator-record-read-auth/behavior-report.json",
+  "content_sha256": {
+    "dashboard/worker.ts": "ea6547649937116d24ee3ab187ca8e9835231584ac585bfc9addeded3b37c922",
+    "docs/proof/operator-record-read-auth/behavior-contract.md": "c0c1825dd97733ea09194da9554f805a9fb9404603e6c43d4a15e58bf4ec0525",
+    "docs/proof/operator-record-read-auth/red-green.md": "4d54adab56e97ecb21fa9f6dea49313762d904a4704deae38e8d2e9f27923037",
+    "docs/proof/operator-record-read-auth/run-proof.mjs": "521718fca6b486d29bd649d27f3628ce225903f4b3a9ff27def531268ec51c29",
+    "docs/proof/operator-record-read-auth/run-proof.sh": "a8698271a34774193d753901386f71e14f696e4038678786467e3c40e07fe924",
+    "test/dashboard-worker-publication-lifecycle.test.ts": "8484d0e38125141f4388b9db1f5c5656b1e95cf7ae90da5c82f4dad1f852fb47"
+  },
+  "transcript_sha256": "46028317a5ca54ccc1f9f1856d7369f2c148c4e1c4d5920446ee037d579f92a5",
+  "stderr_sha256": "f558a75380196784725021d1f644597a31a196bb0ccd1f16542c0b6fda2c7e39",
+  "secret_scan": {
+    "tool": "trufflehog 3.96.0",
+    "command": "trufflehog filesystem --no-update --results=verified,unknown --fail --fail-on-scan-errors docs/proof/operator-record-read-auth/container-transcript.txt docs/proof/operator-record-read-auth/container-stderr.txt",
+    "exit_code": 0,
+    "chunks": 2,
+    "bytes": 5913,
+    "verified_secrets": 0,
+    "unknown_secrets": 0
+  },
+  "cleanup": {
+    "owned_lease_absent_from_local_container_list": true,
+    "unrelated_preexisting_exited_lease_untouched": true,
+    "failed_attempt_artifacts_moved_to_macos_trash": true
+  }
+}

--- a/docs/proof/operator-record-read-auth/red-green.md
+++ b/docs/proof/operator-record-read-auth/red-green.md
@@ -1,0 +1,14 @@
+# RED/GREEN record
+
+The RED router test ran from fresh `origin/main` at `ae36d608d01701af7e06c313be96689068b5c890` after adding the distinct-secret fixture and before changing production code. After the required full build, the operator-signed canonical-record GET returned `401` instead of the required `200`:
+
+```text
+tests 1
+pass 0
+fail 1
+AssertionError: 401 !== 200
+```
+
+The first direct test attempt also documented a fresh-worktree setup dependency: the dashboard harness imports built repair modules, so `pnpm run build:all` is required before the focused test. That setup-only failure is not counted as the behavior RED result above.
+
+GREEN requires the same router fixture to return 200 for distinct operator and webhook signatures, 401 for garbage, and 503 only when neither secret is configured. The real-Worker proof independently requires merge-base operator auth to remain 401 while the candidate returns 200, with full Wrangler process-tree shutdown between the two boots.

--- a/docs/proof/operator-record-read-auth/red-green.md
+++ b/docs/proof/operator-record-read-auth/red-green.md
@@ -11,4 +11,4 @@ AssertionError: 401 !== 200
 
 The first direct test attempt also documented a fresh-worktree setup dependency: the dashboard harness imports built repair modules, so `pnpm run build:all` is required before the focused test. That setup-only failure is not counted as the behavior RED result above.
 
-GREEN requires the same router fixture to return 200 for distinct operator and webhook signatures, 401 for garbage, and 503 only when neither secret is configured. The real-Worker proof independently requires merge-base operator auth to remain 401 while the candidate returns 200, with full Wrangler process-tree shutdown between the two boots.
+GREEN requires the same router fixture to return 200 for the operator only on `items`, 401 for the operator on `closed`, `plans`, and `decision-packets`, 200 for the webhook on all four collections, 401 for garbage on all four, and the existing 503 behavior when a required credential is not configured. The real-Worker proof independently requires merge-base operator auth to remain 401 everywhere while the candidate unlocks only `items`, with full Wrangler process-tree shutdown between the two boots.

--- a/docs/proof/operator-record-read-auth/run-proof.mjs
+++ b/docs/proof/operator-record-read-auth/run-proof.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFile as execFileCallback, spawn } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+const proofDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = (await git(["rev-parse", "--show-toplevel"], proofDir)).trim();
+const head = (await git(["rev-parse", "HEAD"], repoRoot)).trim();
+const expectedHead = process.argv[2] || "";
+if (expectedHead) assert.equal(head, expectedHead, "proof must run at the expected committed head");
+const mergeBase = (await git(["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
+const outputPath = path.resolve(
+  process.env.OPERATOR_RECORD_READ_AUTH_PROOF_OUTPUT ||
+    path.join(repoRoot, ".artifacts/operator-record-read-auth/behavior-report.json"),
+);
+const scratch = await mkdtemp(path.join(os.tmpdir(), "clawsweeper-operator-record-read-auth-"));
+const baseRoot = path.join(scratch, "merge-base");
+const workerPort = await availablePort();
+const webhookSecret = "synthetic-record-read-webhook-proof-secret";
+const operatorSecret = "synthetic-record-read-operator-proof-secret";
+const garbageSecret = "synthetic-record-read-garbage-proof-secret";
+const recordContent = [
+  "---",
+  "repository: openclaw/openclaw",
+  "number: 1148",
+  "type: pull_request",
+  "review_status: complete",
+  `pull_head_sha: ${"a".repeat(40)}`,
+  "---",
+  "",
+  "Synthetic canonical record for operator auth proof.",
+  "",
+].join("\n");
+const recordDigest = createHash("sha256").update(recordContent).digest("hex");
+const recordPath = "/internal/state/records/openclaw-openclaw/items/1148";
+const shutdowns = [];
+
+await mkdir(baseRoot, { recursive: true });
+await extractRevision(mergeBase, baseRoot);
+
+let worker;
+try {
+  worker = await startWorker(baseRoot, "merge-base");
+  await publishRecord(worker.origin, "merge-base");
+  const before = await readMatrix(worker.origin);
+  assert.equal(before.operator.status, 401);
+  assert.deepEqual(before.operator.body, { error: "invalid_signature" });
+  assertSuccessfulRecord(before.webhook);
+  assert.equal(before.garbage.status, 401);
+  assert.deepEqual(before.garbage.body, { error: "invalid_signature" });
+  shutdowns.push(await stopWorker(worker, "merge-base"));
+  worker = undefined;
+
+  worker = await startWorker(repoRoot, "candidate");
+  await publishRecord(worker.origin, "candidate");
+  const after = await readMatrix(worker.origin);
+  assertSuccessfulRecord(after.operator);
+  assertSuccessfulRecord(after.webhook);
+  assert.equal(after.garbage.status, 401);
+  assert.deepEqual(after.garbage.body, { error: "invalid_signature" });
+  shutdowns.push(await stopWorker(worker, "candidate"));
+  worker = undefined;
+
+  const report = {
+    schema: "clawsweeper-operator-record-read-auth-proof/v1",
+    generated_at: new Date().toISOString(),
+    merge_base: mergeBase,
+    head,
+    runtime: "sequential real wrangler dev --local Workers over loopback HTTP",
+    configuration: {
+      secrets_distinct: webhookSecret !== operatorSecret,
+      shared_secret_fixture: false,
+      persisted_state_shared_between_boots: false,
+    },
+    before: sanitizeMatrix(before),
+    after: sanitizeMatrix(after),
+    process_tree_shutdowns: shutdowns,
+    result: {
+      merge_base_operator_status: before.operator.status,
+      candidate_operator_status: after.operator.status,
+      candidate_webhook_status: after.webhook.status,
+      candidate_garbage_status: after.garbage.status,
+      status: "succeeded",
+    },
+    limits: [
+      "Credentials and canonical content are synthetic local fixtures.",
+      "The proof exercises local Worker routing and Durable Object persistence, not production state or GitHub mutation.",
+      "The operational-cursor route is outside scope because it has no operator-secret consumer.",
+    ],
+  };
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write("OPERATOR_RECORD_READ_AUTH_PROOF_RC=0\n");
+} finally {
+  if (worker) await stopWorker(worker, "cleanup");
+  await rm(scratch, { recursive: true, force: true });
+}
+
+async function publishRecord(origin, label) {
+  const body = JSON.stringify({
+    deliveryId: `operator-record-read-auth:${label}`,
+    key: "openclaw-openclaw/1148",
+    operations: [
+      {
+        path: "records/openclaw-openclaw/items/1148.md",
+        expectedDigest: null,
+        contentBase64: Buffer.from(recordContent).toString("base64"),
+      },
+      { path: "records/openclaw-openclaw/closed/1148.md", expectedDigest: null },
+      { path: "records/openclaw-openclaw/plans/1148.md", expectedDigest: null },
+      {
+        path: "records/openclaw-openclaw/decision-packets/1148.json",
+        expectedDigest: null,
+      },
+    ],
+  });
+  const response = await fetch(`${origin}/internal/state/records/tuples`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature(webhookSecret, body),
+    },
+    body,
+  });
+  assert.equal(response.status, 202, await response.text());
+}
+
+async function readMatrix(origin) {
+  return {
+    webhook: await readRecord(origin, webhookSecret),
+    operator: await readRecord(origin, operatorSecret),
+    garbage: await readRecord(origin, garbageSecret),
+  };
+}
+
+async function readRecord(origin, secret) {
+  const response = await fetch(`${origin}${recordPath}`, {
+    headers: { "x-clawsweeper-exact-review-signature": signature(secret, "") },
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+function assertSuccessfulRecord(outcome) {
+  assert.equal(outcome.status, 200);
+  assert.equal(outcome.body.content, recordContent);
+  assert.equal(outcome.body.digest, recordDigest);
+  assert.equal(outcome.body.revision, 1);
+  assert.equal(Number.isFinite(Date.parse(outcome.body.updatedAt)), true);
+}
+
+function sanitizeMatrix(matrix) {
+  return Object.fromEntries(
+    Object.entries(matrix).map(([name, outcome]) => [
+      name,
+      {
+        status: outcome.status,
+        body:
+          outcome.status === 200
+            ? {
+                digest: outcome.body.digest,
+                revision: outcome.body.revision,
+                content_matches: outcome.body.content === recordContent,
+                updated_at_valid: Number.isFinite(Date.parse(outcome.body.updatedAt)),
+              }
+            : outcome.body,
+      },
+    ]),
+  );
+}
+
+async function startWorker(sourceRoot, label) {
+  const logs = [];
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      "wrangler@4.107.0",
+      "dev",
+      "--config",
+      path.join(sourceRoot, "dashboard/wrangler.toml"),
+      "--local",
+      "--persist-to",
+      path.join(scratch, `${label}-state`),
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(workerPort),
+      "--var",
+      `CLAWSWEEPER_WEBHOOK_SECRET:${webhookSecret}`,
+      "--var",
+      `EXACT_REVIEW_OPERATOR_SECRET:${operatorSecret}`,
+    ],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, CI: "1", WRANGLER_SEND_METRICS: "false" },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+    },
+  );
+  child.stdout.on("data", (chunk) => logs.push(String(chunk)));
+  child.stderr.on("data", (chunk) => logs.push(String(chunk)));
+  const origin = `http://127.0.0.1:${workerPort}`;
+  try {
+    await waitForWorker(origin, child, logs);
+  } catch (error) {
+    await stopWorker({ child, origin }, `${label}-failed-start`);
+    throw error;
+  }
+  return { child, origin };
+}
+
+async function waitForWorker(origin, child, logs) {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`Wrangler exited early (${child.exitCode}):\n${logs.join("")}`);
+    }
+    try {
+      const response = await fetch(`${origin}/api/health`);
+      if (response.status === 200) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Wrangler did not become ready:\n${logs.join("")}`);
+}
+
+async function stopWorker(runningWorker, label) {
+  const rootPid = runningWorker?.child?.pid;
+  if (!rootPid) return { label, method: "not_started", health_down: true };
+  const pids = await processTreePids(rootPid);
+  signalProcessTree(rootPid, pids, "SIGTERM");
+  await Promise.race([
+    runningWorker.child.exitCode !== null
+      ? Promise.resolve()
+      : new Promise((resolve) => runningWorker.child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  let healthDown = await waitForHealthDown(runningWorker.origin, 30);
+  if (!healthDown) {
+    signalProcessTree(rootPid, await processTreePids(rootPid), "SIGKILL");
+    healthDown = await waitForHealthDown(runningWorker.origin, 30);
+  }
+  assert.equal(healthDown, true, `Wrangler process tree for ${label} retained the proof port`);
+  return {
+    label,
+    method: process.platform === "win32" ? "descendant_pid_tree" : "process_group_and_descendants",
+    targeted_processes: pids.length,
+    health_down: true,
+  };
+}
+
+function signalProcessTree(rootPid, pids, signal) {
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-rootPid, signal);
+    } catch {}
+  }
+  for (const pid of [...pids].reverse()) {
+    try {
+      process.kill(pid, signal);
+    } catch {}
+  }
+}
+
+async function processTreePids(rootPid) {
+  let stdout = "";
+  try {
+    stdout = (await execFile("ps", ["-eo", "pid=,ppid="])).stdout;
+  } catch {
+    return [rootPid];
+  }
+  const parents = new Map();
+  for (const line of stdout.split("\n")) {
+    const [pidText, parentText] = line.trim().split(/\s+/);
+    const pid = Number(pidText);
+    const parent = Number(parentText);
+    if (Number.isSafeInteger(pid) && Number.isSafeInteger(parent)) parents.set(pid, parent);
+  }
+  const tree = [rootPid];
+  for (const pid of parents.keys()) {
+    let current = pid;
+    for (let depth = 0; depth < 100 && parents.has(current); depth += 1) {
+      current = parents.get(current);
+      if (current === rootPid) {
+        tree.push(pid);
+        break;
+      }
+    }
+  }
+  return [...new Set(tree)];
+}
+
+async function waitForHealthDown(origin, attempts) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      await fetch(`${origin}/api/health`, { signal: AbortSignal.timeout(250) });
+    } catch {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+async function extractRevision(revision, destination) {
+  await new Promise((resolve, reject) => {
+    const archive = spawn("git", ["archive", revision], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const extract = spawn("tar", ["-x", "-C", destination], {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    archive.stdout.pipe(extract.stdin);
+    const errors = [];
+    archive.stderr.on("data", (chunk) => errors.push(String(chunk)));
+    extract.stderr.on("data", (chunk) => errors.push(String(chunk)));
+    let archiveCode;
+    let extractCode;
+    const finish = () => {
+      if (archiveCode === undefined || extractCode === undefined) return;
+      if (archiveCode === 0 && extractCode === 0) resolve();
+      else reject(new Error(`revision extraction failed:\n${errors.join("")}`));
+    };
+    archive.on("exit", (code) => {
+      archiveCode = code;
+      finish();
+    });
+    extract.on("exit", (code) => {
+      extractCode = code;
+      finish();
+    });
+  });
+}
+
+function signature(secret, body) {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+async function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+async function git(args, cwd) {
+  return (await execFile("git", args, { cwd, maxBuffer: 10 * 1024 * 1024 })).stdout;
+}

--- a/docs/proof/operator-record-read-auth/run-proof.mjs
+++ b/docs/proof/operator-record-read-auth/run-proof.mjs
@@ -11,11 +11,22 @@ import { promisify } from "node:util";
 
 const execFile = promisify(execFileCallback);
 const proofDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = (await git(["rev-parse", "--show-toplevel"], proofDir)).trim();
-const head = (await git(["rev-parse", "HEAD"], repoRoot)).trim();
+const repoRoot = path.resolve(proofDir, "../../..");
+const observedHead = (await optionalGit(["rev-parse", "HEAD"], repoRoot)).trim();
 const expectedHead = process.argv[2] || "";
-if (expectedHead) assert.equal(head, expectedHead, "proof must run at the expected committed head");
-const mergeBase = (await git(["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
+if (!observedHead && !expectedHead) {
+  throw new Error("expected committed head is required when synced source omits Git metadata");
+}
+if (expectedHead) {
+  assert.match(expectedHead, /^[0-9a-f]{40}$/);
+  if (observedHead)
+    assert.equal(observedHead, expectedHead, "proof must run at the expected committed head");
+}
+const head = observedHead || expectedHead;
+const expectedBase = process.argv[3] || "";
+if (expectedBase) assert.match(expectedBase, /^[0-9a-f]{40}$/);
+const mergeBase =
+  expectedBase || (await git(["merge-base", "HEAD", "origin/main"], repoRoot)).trim();
 const outputPath = path.resolve(
   process.env.OPERATOR_RECORD_READ_AUTH_PROOF_OUTPUT ||
     path.join(repoRoot, ".artifacts/operator-record-read-auth/behavior-report.json"),
@@ -42,8 +53,12 @@ const recordDigest = createHash("sha256").update(recordContent).digest("hex");
 const recordPath = "/internal/state/records/openclaw-openclaw/items/1148";
 const shutdowns = [];
 
-await mkdir(baseRoot, { recursive: true });
-await extractRevision(mergeBase, baseRoot);
+if (observedHead) {
+  await mkdir(baseRoot, { recursive: true });
+  await extractRevision(mergeBase, baseRoot);
+} else {
+  await cloneRevision(mergeBase, baseRoot);
+}
 
 let worker;
 try {
@@ -78,6 +93,9 @@ try {
       secrets_distinct: webhookSecret !== operatorSecret,
       shared_secret_fixture: false,
       persisted_state_shared_between_boots: false,
+      candidate_git_metadata: Boolean(observedHead),
+      candidate_head_source: observedHead ? "local git checkout" : "explicit Crabbox argument",
+      baseline_source: observedHead ? "local git archive" : "exact public GitHub commit",
     },
     before: sanitizeMatrix(before),
     after: sanitizeMatrix(after),
@@ -340,6 +358,24 @@ async function extractRevision(revision, destination) {
   });
 }
 
+async function cloneRevision(revision, destination) {
+  await mkdir(destination, { recursive: true });
+  await execFile("git", ["init", "--quiet"], { cwd: destination });
+  await execFile(
+    "git",
+    ["remote", "add", "origin", "https://github.com/openclaw/clawsweeper.git"],
+    { cwd: destination },
+  );
+  await execFile("git", ["fetch", "--quiet", "--depth", "1", "origin", revision], {
+    cwd: destination,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  await execFile("git", ["checkout", "--quiet", "--detach", "FETCH_HEAD"], {
+    cwd: destination,
+  });
+  assert.equal((await git(["rev-parse", "HEAD"], destination)).trim(), revision);
+}
+
 function signature(secret, body) {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
 }
@@ -358,4 +394,12 @@ async function availablePort() {
 
 async function git(args, cwd) {
   return (await execFile("git", args, { cwd, maxBuffer: 10 * 1024 * 1024 })).stdout;
+}
+
+async function optionalGit(args, cwd) {
+  try {
+    return await git(args, cwd);
+  } catch {
+    return "";
+  }
 }

--- a/docs/proof/operator-record-read-auth/run-proof.mjs
+++ b/docs/proof/operator-record-read-auth/run-proof.mjs
@@ -37,20 +37,31 @@ const workerPort = await availablePort();
 const webhookSecret = "synthetic-record-read-webhook-proof-secret";
 const operatorSecret = "synthetic-record-read-operator-proof-secret";
 const garbageSecret = "synthetic-record-read-garbage-proof-secret";
-const recordContent = [
+const packetContent = '{"version":1,"proof":"operator-record-read-auth"}\n';
+const packetDigest = createHash("sha256").update(packetContent).digest("hex");
+const itemContent = [
   "---",
   "repository: openclaw/openclaw",
   "number: 1148",
   "type: pull_request",
   "review_status: complete",
   `pull_head_sha: ${"a".repeat(40)}`,
+  `decision_packet_sha256: ${packetDigest}`,
+  "decision_packet_path: records/openclaw-openclaw/decision-packets/1148.json",
   "---",
   "",
   "Synthetic canonical record for operator auth proof.",
   "",
 ].join("\n");
-const recordDigest = createHash("sha256").update(recordContent).digest("hex");
 const collections = ["items", "closed", "plans", "decision-packets"];
+const collectionNumbers = { items: 1148, closed: 1149, plans: 1148, "decision-packets": 1148 };
+const collectionContent = {
+  items: itemContent,
+  closed:
+    "---\nrepository: openclaw/openclaw\nnumber: 1149\ndecision_packet_sha256: none\ndecision_packet_path: none\n---\n\nSynthetic closed record.\n",
+  plans: "---\nreviewed_at: 2026-08-12T23:38:00Z\n---\n\nSynthetic plan record.\n",
+  "decision-packets": packetContent,
+};
 const shutdowns = [];
 
 if (observedHead) {
@@ -63,7 +74,7 @@ if (observedHead) {
 let worker;
 try {
   worker = await startWorker(baseRoot, "merge-base");
-  await publishRecord(worker.origin, "merge-base");
+  await publishRecords(worker.origin, "merge-base");
   const before = await readMatrix(worker.origin);
   assertMatrix(before, { items: 401, closed: 401, plans: 401, "decision-packets": 401 });
   assertMatrix(before, { items: 200, closed: 200, plans: 200, "decision-packets": 200 }, "webhook");
@@ -72,7 +83,7 @@ try {
   worker = undefined;
 
   worker = await startWorker(repoRoot, "candidate");
-  await publishRecord(worker.origin, "candidate");
+  await publishRecords(worker.origin, "candidate");
   const after = await readMatrix(worker.origin);
   assertMatrix(after, { items: 200, closed: 401, plans: 401, "decision-packets": 401 });
   assertMatrix(after, { items: 200, closed: 200, plans: 200, "decision-packets": 200 }, "webhook");
@@ -117,18 +128,33 @@ try {
   await rm(scratch, { recursive: true, force: true });
 }
 
-async function publishRecord(origin, label) {
-  const body = JSON.stringify({
-    deliveryId: `operator-record-read-auth:${label}`,
+async function publishRecords(origin, label) {
+  await publishTuple(origin, {
+    deliveryId: `operator-record-read-auth:${label}:open`,
     key: "openclaw-openclaw/1148",
-    operations: [
-      ...collections.map((collection) => ({
-        path: `records/openclaw-openclaw/${collection}/1148.${collection === "decision-packets" ? "json" : "md"}`,
-        expectedDigest: null,
-        contentBase64: Buffer.from(recordContent).toString("base64"),
-      })),
-    ],
+    operations: collections.map((collection) => ({
+      path: `records/openclaw-openclaw/${collection}/1148.${collection === "decision-packets" ? "json" : "md"}`,
+      expectedDigest: null,
+      ...(collection === "closed"
+        ? {}
+        : { contentBase64: Buffer.from(collectionContent[collection]).toString("base64") }),
+    })),
   });
+  await publishTuple(origin, {
+    deliveryId: `operator-record-read-auth:${label}:closed`,
+    key: "openclaw-openclaw/1149",
+    operations: collections.map((collection) => ({
+      path: `records/openclaw-openclaw/${collection}/1149.${collection === "decision-packets" ? "json" : "md"}`,
+      expectedDigest: null,
+      ...(collection === "closed"
+        ? { contentBase64: Buffer.from(collectionContent.closed).toString("base64") }
+        : {}),
+    })),
+  });
+}
+
+async function publishTuple(origin, mutation) {
+  const body = JSON.stringify(mutation);
   const response = await fetch(`${origin}/internal/state/records/tuples`, {
     method: "POST",
     headers: {
@@ -153,7 +179,7 @@ async function readMatrix(origin) {
           await Promise.all(
             collections.map(async (collection) => [
               collection,
-              await readRecord(origin, collection, secret),
+              { ...(await readRecord(origin, collection, secret)), collection },
             ]),
           ),
         ),
@@ -164,7 +190,7 @@ async function readMatrix(origin) {
 
 async function readRecord(origin, collection, secret) {
   const response = await fetch(
-    `${origin}/internal/state/records/openclaw-openclaw/${collection}/1148`,
+    `${origin}/internal/state/records/openclaw-openclaw/${collection}/${collectionNumbers[collection]}`,
     {
       headers: { "x-clawsweeper-exact-review-signature": signature(secret, "") },
     },
@@ -194,8 +220,9 @@ function statusMatrix(matrix) {
 
 function assertSuccessfulRecord(outcome) {
   assert.equal(outcome.status, 200);
-  assert.equal(outcome.body.content, recordContent);
-  assert.equal(outcome.body.digest, recordDigest);
+  const expectedContent = collectionContent[outcome.collection];
+  assert.equal(outcome.body.content, expectedContent);
+  assert.equal(outcome.body.digest, createHash("sha256").update(expectedContent).digest("hex"));
   assert.equal(outcome.body.revision, 1);
   assert.equal(Number.isFinite(Date.parse(outcome.body.updatedAt)), true);
 }
@@ -214,7 +241,7 @@ function sanitizeMatrix(matrix) {
                 ? {
                     digest: outcome.body.digest,
                     revision: outcome.body.revision,
-                    content_matches: outcome.body.content === recordContent,
+                    content_matches: outcome.body.content === collectionContent[collection],
                     updated_at_valid: Number.isFinite(Date.parse(outcome.body.updatedAt)),
                   }
                 : outcome.body,

--- a/docs/proof/operator-record-read-auth/run-proof.mjs
+++ b/docs/proof/operator-record-read-auth/run-proof.mjs
@@ -50,7 +50,7 @@ const recordContent = [
   "",
 ].join("\n");
 const recordDigest = createHash("sha256").update(recordContent).digest("hex");
-const recordPath = "/internal/state/records/openclaw-openclaw/items/1148";
+const collections = ["items", "closed", "plans", "decision-packets"];
 const shutdowns = [];
 
 if (observedHead) {
@@ -65,21 +65,18 @@ try {
   worker = await startWorker(baseRoot, "merge-base");
   await publishRecord(worker.origin, "merge-base");
   const before = await readMatrix(worker.origin);
-  assert.equal(before.operator.status, 401);
-  assert.deepEqual(before.operator.body, { error: "invalid_signature" });
-  assertSuccessfulRecord(before.webhook);
-  assert.equal(before.garbage.status, 401);
-  assert.deepEqual(before.garbage.body, { error: "invalid_signature" });
+  assertMatrix(before, { items: 401, closed: 401, plans: 401, "decision-packets": 401 });
+  assertMatrix(before, { items: 200, closed: 200, plans: 200, "decision-packets": 200 }, "webhook");
+  assertMatrix(before, { items: 401, closed: 401, plans: 401, "decision-packets": 401 }, "garbage");
   shutdowns.push(await stopWorker(worker, "merge-base"));
   worker = undefined;
 
   worker = await startWorker(repoRoot, "candidate");
   await publishRecord(worker.origin, "candidate");
   const after = await readMatrix(worker.origin);
-  assertSuccessfulRecord(after.operator);
-  assertSuccessfulRecord(after.webhook);
-  assert.equal(after.garbage.status, 401);
-  assert.deepEqual(after.garbage.body, { error: "invalid_signature" });
+  assertMatrix(after, { items: 200, closed: 401, plans: 401, "decision-packets": 401 });
+  assertMatrix(after, { items: 200, closed: 200, plans: 200, "decision-packets": 200 }, "webhook");
+  assertMatrix(after, { items: 401, closed: 401, plans: 401, "decision-packets": 401 }, "garbage");
   shutdowns.push(await stopWorker(worker, "candidate"));
   worker = undefined;
 
@@ -101,10 +98,8 @@ try {
     after: sanitizeMatrix(after),
     process_tree_shutdowns: shutdowns,
     result: {
-      merge_base_operator_status: before.operator.status,
-      candidate_operator_status: after.operator.status,
-      candidate_webhook_status: after.webhook.status,
-      candidate_garbage_status: after.garbage.status,
+      merge_base_statuses: statusMatrix(before),
+      candidate_statuses: statusMatrix(after),
       status: "succeeded",
     },
     limits: [
@@ -127,17 +122,11 @@ async function publishRecord(origin, label) {
     deliveryId: `operator-record-read-auth:${label}`,
     key: "openclaw-openclaw/1148",
     operations: [
-      {
-        path: "records/openclaw-openclaw/items/1148.md",
+      ...collections.map((collection) => ({
+        path: `records/openclaw-openclaw/${collection}/1148.${collection === "decision-packets" ? "json" : "md"}`,
         expectedDigest: null,
         contentBase64: Buffer.from(recordContent).toString("base64"),
-      },
-      { path: "records/openclaw-openclaw/closed/1148.md", expectedDigest: null },
-      { path: "records/openclaw-openclaw/plans/1148.md", expectedDigest: null },
-      {
-        path: "records/openclaw-openclaw/decision-packets/1148.json",
-        expectedDigest: null,
-      },
+      })),
     ],
   });
   const response = await fetch(`${origin}/internal/state/records/tuples`, {
@@ -152,18 +141,55 @@ async function publishRecord(origin, label) {
 }
 
 async function readMatrix(origin) {
-  return {
-    webhook: await readRecord(origin, webhookSecret),
-    operator: await readRecord(origin, operatorSecret),
-    garbage: await readRecord(origin, garbageSecret),
-  };
+  return Object.fromEntries(
+    await Promise.all(
+      [
+        ["operator", operatorSecret],
+        ["webhook", webhookSecret],
+        ["garbage", garbageSecret],
+      ].map(async ([credential, secret]) => [
+        credential,
+        Object.fromEntries(
+          await Promise.all(
+            collections.map(async (collection) => [
+              collection,
+              await readRecord(origin, collection, secret),
+            ]),
+          ),
+        ),
+      ]),
+    ),
+  );
 }
 
-async function readRecord(origin, secret) {
-  const response = await fetch(`${origin}${recordPath}`, {
-    headers: { "x-clawsweeper-exact-review-signature": signature(secret, "") },
-  });
+async function readRecord(origin, collection, secret) {
+  const response = await fetch(
+    `${origin}/internal/state/records/openclaw-openclaw/${collection}/1148`,
+    {
+      headers: { "x-clawsweeper-exact-review-signature": signature(secret, "") },
+    },
+  );
   return { status: response.status, body: await response.json() };
+}
+
+function assertMatrix(matrix, expected, credential = "operator") {
+  for (const [collection, status] of Object.entries(expected)) {
+    const outcome = matrix[credential][collection];
+    assert.equal(outcome.status, status, `${credential}:${collection}`);
+    if (status === 200) assertSuccessfulRecord(outcome);
+    else assert.deepEqual(outcome.body, { error: "invalid_signature" });
+  }
+}
+
+function statusMatrix(matrix) {
+  return Object.fromEntries(
+    Object.entries(matrix).map(([credential, outcomes]) => [
+      credential,
+      Object.fromEntries(
+        Object.entries(outcomes).map(([collection, outcome]) => [collection, outcome.status]),
+      ),
+    ]),
+  );
 }
 
 function assertSuccessfulRecord(outcome) {
@@ -176,20 +202,25 @@ function assertSuccessfulRecord(outcome) {
 
 function sanitizeMatrix(matrix) {
   return Object.fromEntries(
-    Object.entries(matrix).map(([name, outcome]) => [
-      name,
-      {
-        status: outcome.status,
-        body:
-          outcome.status === 200
-            ? {
-                digest: outcome.body.digest,
-                revision: outcome.body.revision,
-                content_matches: outcome.body.content === recordContent,
-                updated_at_valid: Number.isFinite(Date.parse(outcome.body.updatedAt)),
-              }
-            : outcome.body,
-      },
+    Object.entries(matrix).map(([credential, outcomes]) => [
+      credential,
+      Object.fromEntries(
+        Object.entries(outcomes).map(([collection, outcome]) => [
+          collection,
+          {
+            status: outcome.status,
+            body:
+              outcome.status === 200
+                ? {
+                    digest: outcome.body.digest,
+                    revision: outcome.body.revision,
+                    content_matches: outcome.body.content === recordContent,
+                    updated_at_valid: Number.isFinite(Date.parse(outcome.body.updatedAt)),
+                  }
+                : outcome.body,
+          },
+        ]),
+      ),
     ]),
   );
 }

--- a/docs/proof/operator-record-read-auth/run-proof.sh
+++ b/docs/proof/operator-record-read-auth/run-proof.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_head=${1:?expected committed head argument is required}
+
+export PATH="$HOME/.local/bin:$PATH"
+mkdir -p "$HOME/.local/bin"
+
+echo "PROOF_PHASE=environment"
+echo "provider=local-container"
+echo "image=node:24-bookworm"
+echo "head=$expected_head"
+test "$(git rev-parse HEAD)" = "$expected_head"
+node --version
+npm --version
+
+echo "PROOF_PHASE=corepack"
+npm install --global --prefix "$HOME/.local" corepack@0.35.0
+corepack enable --install-directory "$HOME/.local/bin"
+corepack pnpm --version
+
+echo "PROOF_PHASE=install"
+corepack pnpm install --frozen-lockfile
+
+echo "PROOF_PHASE=build"
+corepack pnpm run build:all
+
+echo "PROOF_PHASE=focused-router-test"
+node --test \
+  --test-name-pattern='canonical record reads accept distinct webhook and operator secrets' \
+  test/dashboard-worker-publication-lifecycle.test.ts
+
+echo "PROOF_PHASE=real-worker"
+OPERATOR_RECORD_READ_AUTH_PROOF_OUTPUT=.artifacts/operator-record-read-auth/behavior-report.json \
+  node docs/proof/operator-record-read-auth/run-proof.mjs "$expected_head"
+
+echo "PROOF_PHASE=dashboard-strict"
+corepack pnpm run check:dashboard-strict
+
+echo "PROOF_PHASE=full-gate"
+corepack pnpm run check
+
+echo "PROOF_PHASE=content"
+sha256sum \
+  dashboard/worker.ts \
+  docs/proof/operator-record-read-auth/behavior-contract.md \
+  docs/proof/operator-record-read-auth/red-green.md \
+  docs/proof/operator-record-read-auth/run-proof.mjs \
+  docs/proof/operator-record-read-auth/run-proof.sh \
+  test/dashboard-worker-publication-lifecycle.test.ts
+test -z "$(git status --porcelain)"
+echo "PROOF_RESULT=pass"

--- a/docs/proof/operator-record-read-auth/run-proof.sh
+++ b/docs/proof/operator-record-read-auth/run-proof.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 expected_head=${1:?expected committed head argument is required}
+expected_base=${2:?expected origin/main base argument is required}
+[[ "$expected_head" =~ ^[0-9a-f]{40}$ ]]
+[[ "$expected_base" =~ ^[0-9a-f]{40}$ ]]
 
 export PATH="$HOME/.local/bin:$PATH"
 mkdir -p "$HOME/.local/bin"
@@ -10,7 +13,13 @@ echo "PROOF_PHASE=environment"
 echo "provider=local-container"
 echo "image=node:24-bookworm"
 echo "head=$expected_head"
-test "$(git rev-parse HEAD)" = "$expected_head"
+echo "base=$expected_base"
+if git rev-parse HEAD >/dev/null 2>&1; then
+  test "$(git rev-parse HEAD)" = "$expected_head"
+  echo "head_attestation=local_git"
+else
+  echo "head_attestation=explicit_argument_with_content_hashes"
+fi
 node --version
 npm --version
 
@@ -32,7 +41,7 @@ node --test \
 
 echo "PROOF_PHASE=real-worker"
 OPERATOR_RECORD_READ_AUTH_PROOF_OUTPUT=.artifacts/operator-record-read-auth/behavior-report.json \
-  node docs/proof/operator-record-read-auth/run-proof.mjs "$expected_head"
+  node docs/proof/operator-record-read-auth/run-proof.mjs "$expected_head" "$expected_base"
 
 echo "PROOF_PHASE=dashboard-strict"
 corepack pnpm run check:dashboard-strict
@@ -48,5 +57,9 @@ sha256sum \
   docs/proof/operator-record-read-auth/run-proof.mjs \
   docs/proof/operator-record-read-auth/run-proof.sh \
   test/dashboard-worker-publication-lifecycle.test.ts
-test -z "$(git status --porcelain)"
+if git rev-parse HEAD >/dev/null 2>&1; then
+  test -z "$(git status --porcelain)"
+else
+  echo "source_status=git_metadata_unavailable_after_linked-worktree_sync"
+fi
 echo "PROOF_RESULT=pass"

--- a/docs/proof/operator-record-read-auth/run-proof.sh
+++ b/docs/proof/operator-record-read-auth/run-proof.sh
@@ -22,6 +22,11 @@ else
 fi
 node --version
 npm --version
+if ! command -v jq >/dev/null 2>&1; then
+  sudo apt-get update >/dev/null
+  sudo apt-get install --yes jq >/dev/null
+fi
+jq --version
 
 echo "PROOF_PHASE=corepack"
 npm install --global --prefix "$HOME/.local" corepack@0.35.0
@@ -47,7 +52,13 @@ echo "PROOF_PHASE=dashboard-strict"
 corepack pnpm run check:dashboard-strict
 
 echo "PROOF_PHASE=full-gate"
-corepack pnpm run check
+proof_full_gate_log="$(mktemp)"
+if ! corepack pnpm run check >"$proof_full_gate_log" 2>&1; then
+  tail -n 240 "$proof_full_gate_log"
+  exit 1
+fi
+grep -E '^(ℹ (tests|pass|fail|skipped)|.*(dashboard queue boundary check passed|Documentation checks passed|All matched files use the correct format))' \
+  "$proof_full_gate_log" | tail -n 24
 
 echo "PROOF_PHASE=content"
 sha256sum \

--- a/docs/proof/operator-record-read-auth/run-proof.sh
+++ b/docs/proof/operator-record-read-auth/run-proof.sh
@@ -41,7 +41,7 @@ corepack pnpm run build:all
 
 echo "PROOF_PHASE=focused-router-test"
 node --test \
-  --test-name-pattern='canonical record reads accept distinct webhook and operator secrets' \
+  --test-name-pattern='canonical record operator auth is scoped to items' \
   test/dashboard-worker-publication-lifecycle.test.ts
 
 echo "PROOF_PHASE=real-worker"

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -24,11 +24,10 @@ import {
   type ExactReviewQueueItem,
 } from "./dashboard-worker-harness.ts";
 
-test("canonical record reads accept distinct webhook and operator secrets", async () => {
+test("canonical record operator auth is scoped to items", async () => {
   const webhookSecret = "record-read-webhook-secret";
   const operatorSecret = "record-read-operator-secret";
-  const recordUrl =
-    "https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/items/1148";
+  const collections = ["items", "closed", "plans", "decision-packets"];
   const record = {
     content: "canonical record",
     digest: createHash("sha256").update("canonical record").digest("hex"),
@@ -37,7 +36,10 @@ test("canonical record reads accept distinct webhook and operator secrets", asyn
   };
   const queue = {
     async fetch(request: Request) {
-      assert.equal(new URL(request.url).pathname, "/records/openclaw-openclaw/items/1148");
+      assert.match(
+        new URL(request.url).pathname,
+        /^\/records\/openclaw-openclaw\/(?:items|closed|plans|decision-packets)\/1148$/,
+      );
       assert.equal(request.method, "GET");
       return jsonResponse(record);
     },
@@ -47,26 +49,53 @@ test("canonical record reads accept distinct webhook and operator secrets", asyn
     EXACT_REVIEW_OPERATOR_SECRET: operatorSecret,
     EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
   };
-  const signedRequest = (secret: string) =>
-    new Request(recordUrl, {
-      headers: {
-        "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update("").digest("hex")}`,
+  const signedRequest = (secret: string, collection: string) =>
+    new Request(
+      `https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/${collection}/1148`,
+      {
+        headers: {
+          "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update("").digest("hex")}`,
+        },
       },
-    });
+    );
 
-  const operatorRead = await worker.fetch(signedRequest(operatorSecret), env);
-  assert.equal(operatorRead.status, 200);
-  assert.deepEqual(await operatorRead.json(), record);
+  for (const collection of collections) {
+    const operatorRead = await worker.fetch(signedRequest(operatorSecret, collection), env);
+    assert.equal(operatorRead.status, collection === "items" ? 200 : 401, collection);
+    assert.deepEqual(
+      await operatorRead.json(),
+      collection === "items" ? record : { error: "invalid_signature" },
+    );
 
-  const webhookRead = await worker.fetch(signedRequest(webhookSecret), env);
-  assert.equal(webhookRead.status, 200);
-  assert.deepEqual(await webhookRead.json(), record);
+    const webhookRead = await worker.fetch(signedRequest(webhookSecret, collection), env);
+    assert.equal(webhookRead.status, 200, collection);
+    assert.deepEqual(await webhookRead.json(), record);
 
-  const garbageRead = await worker.fetch(signedRequest("garbage-record-read-secret"), env);
-  assert.equal(garbageRead.status, 401);
-  assert.deepEqual(await garbageRead.json(), { error: "invalid_signature" });
+    const garbageRead = await worker.fetch(
+      signedRequest("garbage-record-read-secret", collection),
+      env,
+    );
+    assert.equal(garbageRead.status, 401, collection);
+    assert.deepEqual(await garbageRead.json(), { error: "invalid_signature" });
+  }
 
-  const unconfiguredRead = await worker.fetch(signedRequest(operatorSecret), {
+  const operatorOnlyEnv = {
+    EXACT_REVIEW_OPERATOR_SECRET: operatorSecret,
+    EXACT_REVIEW_QUEUE: env.EXACT_REVIEW_QUEUE,
+  };
+  const operatorOnlyItem = await worker.fetch(
+    signedRequest(operatorSecret, "items"),
+    operatorOnlyEnv,
+  );
+  assert.equal(operatorOnlyItem.status, 200);
+  const operatorOnlyClosed = await worker.fetch(
+    signedRequest(operatorSecret, "closed"),
+    operatorOnlyEnv,
+  );
+  assert.equal(operatorOnlyClosed.status, 503);
+  assert.deepEqual(await operatorOnlyClosed.json(), { error: "webhook_not_configured" });
+
+  const unconfiguredRead = await worker.fetch(signedRequest(operatorSecret, "items"), {
     EXACT_REVIEW_QUEUE: env.EXACT_REVIEW_QUEUE,
   });
   assert.equal(unconfiguredRead.status, 503);

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -24,6 +24,55 @@ import {
   type ExactReviewQueueItem,
 } from "./dashboard-worker-harness.ts";
 
+test("canonical record reads accept distinct webhook and operator secrets", async () => {
+  const webhookSecret = "record-read-webhook-secret";
+  const operatorSecret = "record-read-operator-secret";
+  const recordUrl =
+    "https://clawsweeper.openclaw.ai/internal/state/records/openclaw-openclaw/items/1148";
+  const record = {
+    content: "canonical record",
+    digest: createHash("sha256").update("canonical record").digest("hex"),
+    revision: 1,
+    updatedAt: "2026-08-12T23:38:00.000Z",
+  };
+  const queue = {
+    async fetch(request: Request) {
+      assert.equal(new URL(request.url).pathname, "/records/openclaw-openclaw/items/1148");
+      assert.equal(request.method, "GET");
+      return jsonResponse(record);
+    },
+  };
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
+    EXACT_REVIEW_OPERATOR_SECRET: operatorSecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const signedRequest = (secret: string) =>
+    new Request(recordUrl, {
+      headers: {
+        "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update("").digest("hex")}`,
+      },
+    });
+
+  const operatorRead = await worker.fetch(signedRequest(operatorSecret), env);
+  assert.equal(operatorRead.status, 200);
+  assert.deepEqual(await operatorRead.json(), record);
+
+  const webhookRead = await worker.fetch(signedRequest(webhookSecret), env);
+  assert.equal(webhookRead.status, 200);
+  assert.deepEqual(await webhookRead.json(), record);
+
+  const garbageRead = await worker.fetch(signedRequest("garbage-record-read-secret"), env);
+  assert.equal(garbageRead.status, 401);
+  assert.deepEqual(await garbageRead.json(), { error: "invalid_signature" });
+
+  const unconfiguredRead = await worker.fetch(signedRequest(operatorSecret), {
+    EXACT_REVIEW_QUEUE: env.EXACT_REVIEW_QUEUE,
+  });
+  assert.equal(unconfiguredRead.status, 503);
+  assert.deepEqual(await unconfiguredRead.json(), { error: "webhook_not_configured" });
+});
+
 test("direct publication endpoint authenticates, dedupes, and returns a structured 413", async () => {
   const storage = new MemoryDurableStorage();
   const leased = leasedExactReviewQueueItem(701, "7010");


### PR DESCRIPTION
Related: #1148

## What Problem This Solves

Fixes an issue where exact-review dead-letter reconciliation classified every checked head mismatch as unproven when it tried to read the completed canonical review with its operator credential. Production run 31651591787 hit this for all ten checked targets because the existing canonical-record GET accepted only the separately configured webhook credential.

## Why This Change Was Made

The existing read-only canonical-record route now verifies the webhook secret first and falls back to the exact-review operator secret only for the `items` collection, which is the sole collection read by reconciliation. `closed`, `plans`, and `decision-packets` remain webhook-secret-only. Missing required configuration still returns 503, invalid signatures still return 401, and the operator script and workflows remain unchanged.

The operational-cursor GET/PUT route remains webhook-only because its current client explicitly uses that credential and no operator-secret consumer exists.

## User Impact

Operators can reconcile stale head-mismatch dead letters using completed canonical-review evidence instead of receiving false 401 failures and leaving every checked target as `head_mismatch_unproven`, without gaining read access to unrelated canonical collections.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes authentication on one existing internal read-only route and does not alter queue lifecycle state, telemetry, dashboard data contracts, or Bay's observer-only boundary.

## Documentation Lifecycle

The `docs/proof/operator-record-read-auth/` package is historical, frozen evidence for this change. It is not an active runbook or operational source of truth.

## Finding Disposition

- **[P1] Limit operator fallback to active item records — resolved.** Operator fallback is now restricted to `items`; `closed`, `plans`, and `decision-packets` retain webhook-only authentication.
- **Rank-up move — applied.** Router and real-Worker coverage now prove denied operator access to the three webhook-only collections and retained webhook access to all four collections.

## Evidence

- Router-level distinct-secret regression test covers operator, webhook, and garbage signatures across all four collections, plus missing-configuration 503 behavior.
- Docker-backed Crabbox `provider=local-container` receipt: lease `cbx_23906feb2769` (`pearl-shrimp-a24f`), image `node:24-bookworm`, exit 0, lease auto-stopped.
- Real Worker candidate matrix: operator `items/closed/plans/decision-packets` = `200/401/401/401`; webhook = `200/200/200/200`; garbage = `401/401/401/401`.
- `pnpm run check:dashboard-strict` passed without adding `dashboard/worker.ts` to the strict list.
- `pnpm run check` passed in the same container: 3,401 tests, 3,393 passed, eight platform skips, zero failures.
- Final committed `autoreview --mode branch --base origin/main --max-priority P1`: no accepted/actionable findings.
- Final branch head: `06561bd4ee433cc3318a0ffd91d29ed29d9856d7`. The frozen receipt committed in that push exercises executable head `1855dfbb0c0d0b66978a99b20756845e3d6fa131`; the final commit only records the generated proof artifacts.

## Real Behavior Proof

**Claim:** The production canonical-record GET accepts the exact-review operator credential only for active item records, preserves webhook access to all four canonical collections, and rejects invalid credentials everywhere.

**Exercised surface:** Two sequential real `wrangler dev --local` Workers over loopback HTTP, using the production router and SQLite-backed ExactReviewQueue Durable Object.

**Scenario:** The proof publishes valid synthetic open and closed canonical tuples to merge-base and candidate Workers configured with distinct webhook and operator values. It signs GETs for `items`, `closed`, `plans`, and `decision-packets` with the operator value, webhook value, and garbage. Between boots it kills the complete Wrangler process tree, requires `/api/health` to stop responding, and reuses the same port with separate persistence.

**Command and environment:** Docker-backed Crabbox `provider=local-container`, image `node:24-bookworm`, lease `cbx_23906feb2769` (`pearl-shrimp-a24f`), tested executable head `1855dfbb0c0d0b66978a99b20756845e3d6fa131`, base `ae36d608d01701af7e06c313be96689068b5c890`. The exact command is frozen in `docs/proof/operator-record-read-auth/receipt.json`.

**Observable result:** The candidate returned operator `200/401/401/401`, webhook `200/200/200/200`, and garbage `401/401/401/401` for `items/closed/plans/decision-packets`. The merge base remained webhook-only. Both process-tree shutdown checks observed the health endpoint down. The focused router test, dashboard-strict gate, and full repository gate passed in the same lease. Crabbox exited 0 and reported `leaseStopped=true`.

**Artifact or trace:** `docs/proof/operator-record-read-auth/behavior-report.json`, `container-transcript.txt`, `container-stderr.txt`, and `receipt.json`. TruffleHog 3.96.0 found zero verified or unknown secrets in the captured logs.

**Limits:** Credentials and record content are synthetic. The proof exercises the real local Worker, router, HMAC verification, and Durable Object record store; it does not deploy, read production state, mutate GitHub beyond this PR update, or broaden cursor authentication.
