### PR TITLE
ci: add runner label escape hatches

### DIFF
--- a/.github/workflows/automerge-e2e.yml
+++ b/.github/workflows/automerge-e2e.yml
@@ -32,7 +32,7 @@ jobs:
   automerge-e2e:
     name: production automerge flow
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ${{ vars.CLAWSWEEPER_E2E_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     env:
       AUTOMERGE_E2E_BASE_ARCHIVE: /tmp/clawsweeper-automerge-e2e-base.tar

--- a/.github/workflows/maintainer-report-discord.yml
+++ b/.github/workflows/maintainer-report-discord.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   notify:
     name: Summarize maintainer report
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CLAWSWEEPER_REPORT_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
       - name: Create maintainer repo token

--- a/.github/workflows/repair-containment-smoke.yml
+++ b/.github/workflows/repair-containment-smoke.yml
@@ -58,7 +58,7 @@ jobs:
   containment-smoke:
     name: containment smoke (sample ${{ matrix.sample }})
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ${{ vars.CLAWSWEEPER_E2E_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/repair-publish-results.yml
+++ b/.github/workflows/repair-publish-results.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     steps:
       - name: Create GitHub App token

--- a/.github/workflows/spam-comment-intake.yml
+++ b/.github/workflows/spam-comment-intake.yml
@@ -23,7 +23,7 @@ jobs:
         (contains(fromJSON('["issue_comment","pull_request_review_comment"]'), github.event.client_payload.activity.type) || contains(fromJSON('["issue_comment","pull_request_review_comment"]'), github.event.client_payload.event_name)) &&
         (github.event.client_payload.activity.action == 'created' || github.event.client_payload.activity.action == 'edited' || github.event.client_payload.action == 'created' || github.event.client_payload.action == 'edited')
       }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CLAWSWEEPER_SPAM_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 5
     steps:
       - name: Check core API budget

--- a/.github/workflows/spam-scanner.yml
+++ b/.github/workflows/spam-scanner.yml
@@ -66,7 +66,7 @@ concurrency:
 
 jobs:
   scan:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CLAWSWEEPER_SPAM_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7

--- a/docs/proof/runner-label-escape-hatches/README.md
+++ b/docs/proof/runner-label-escape-hatches/README.md
@@ -42,6 +42,15 @@ and base in a temporary Git bundle, reconstructs the refs inside the lease, and 
 before validation. The bundle is proof transport only and is not committed. See `red-green.md` for
 the local RED/GREEN transcript.
 
+The final run used Crabbox `provider=local-container`, lease `cbx_d1a06e39d867`
+(`golden-prawn-16e4`), image `node:24-bookworm`, and tested head
+`f84b7d60daa24d979eef6299be0d9c2a55fdab62`. The focused suite passed 9/9 and the full
+`pnpm run check` gate passed 3,420 tests with zero failures and eight platform skips. The one-shot
+lease stopped automatically and is absent from the local-container inventory. The receipt commit
+contains proof artifacts only after the tested workflow tree; no workflow, test, or proof script
+change follows the tested head in this push. Full machine provenance is frozen in
+`container-receipt.json`.
+
 OpenClaw Bay is unaffected: runner selection does not change workflow lifecycle publication,
 status telemetry, dashboard data contracts, or the observer-only action boundary.
 

--- a/docs/proof/runner-label-escape-hatches/README.md
+++ b/docs/proof/runner-label-escape-hatches/README.md
@@ -3,8 +3,9 @@
 ## Claim
 
 Every GitHub Actions job that defaults to a Blacksmith runner can be redirected with a repository
-variable while preserving its existing Blacksmith label when the variable is unset. No repository
-variables are set by this change.
+variable while preserving its existing Blacksmith label when the variable is unset. The report
+lane's override is live: `CLAWSWEEPER_REPORT_RUNNER=ubuntu-latest` remains set while Blacksmith
+us-west is unavailable. The E2E and spam overrides remain unset, so their fallbacks are unchanged.
 
 ## Label inventory and variable ownership
 
@@ -51,11 +52,28 @@ contains proof artifacts only after the tested workflow tree; no workflow, test,
 change follows the tested head in this push. Full machine provenance is frozen in
 `container-receipt.json`.
 
+## Live GitHub Actions proof
+
+GitHub accepted a `workflow_dispatch` for `maintainer-report-discord.yml` directly from branch
+`steipete/runner-label-escape-hatches` at tested head
+`32334740ba22b0e7fe69d1c71bfc013441f3dbf6`. Run
+[`31759075251`](https://github.com/openclaw/clawsweeper/actions/runs/31759075251) resolved the report
+job label to `ubuntu-latest`, assigned GitHub-hosted runner `GitHub Actions 1011717149`, and
+completed successfully. This demonstrates that branch dispatch used the PR branch workflow
+definition and respected the configured repository variable.
+
+For contrast, scheduled run
+[`31688886472`](https://github.com/openclaw/clawsweeper/actions/runs/31688886472) at pre-change
+`main` head `4d41d3df4baf191dca9c385c82689425a135a5c4` resolved the same job to
+`blacksmith-4vcpu-ubuntu-2404` and ran on a Blacksmith runner. The full redacted API transcript,
+object cross-checks, behavior contract, and variable end-state are in `live-actions.md`.
+
 OpenClaw Bay is unaffected: runner selection does not change workflow lifecycle publication,
 status telemetry, dashboard data contracts, or the observer-only action boundary.
 
 ## Limits
 
-This proves static workflow selection and the repository gates. It does not dispatch the workflows
-or set repository variables. With variables unset, GitHub Actions resolves the same Blacksmith
-labels as before.
+The live run exercises the report-lane override only. The E2E, containment, repair-publication,
+and spam mappings remain covered by the workflow-shape tests and repository gate rather than live
+dispatches. The historical report run proves the report lane's Blacksmith default; the unchanged
+fallback expressions and tests cover the other unset defaults.

--- a/docs/proof/runner-label-escape-hatches/README.md
+++ b/docs/proof/runner-label-escape-hatches/README.md
@@ -1,0 +1,49 @@
+# Blacksmith runner-label escape-hatch proof
+
+## Claim
+
+Every GitHub Actions job that defaults to a Blacksmith runner can be redirected with a repository
+variable while preserving its existing Blacksmith label when the variable is unset. No repository
+variables are set by this change.
+
+## Label inventory and variable ownership
+
+The pre-change workflow sweep found six bare `runs-on` assignments:
+
+| Workflow job | Variable | Unchanged fallback |
+| --- | --- | --- |
+| `automerge-e2e.yml:automerge-e2e` | `CLAWSWEEPER_E2E_RUNNER` | `blacksmith-16vcpu-ubuntu-2404` |
+| `maintainer-report-discord.yml:notify` | `CLAWSWEEPER_REPORT_RUNNER` | `blacksmith-4vcpu-ubuntu-2404` |
+| `repair-containment-smoke.yml:containment-smoke` | `CLAWSWEEPER_E2E_RUNNER` | `blacksmith-16vcpu-ubuntu-2404` |
+| `repair-publish-results.yml:publish` | `CLAWSWEEPER_WORKER_RUNNER` | `blacksmith-4vcpu-ubuntu-2404` |
+| `spam-comment-intake.yml:intake` | `CLAWSWEEPER_SPAM_RUNNER` | `blacksmith-4vcpu-ubuntu-2404` |
+| `spam-scanner.yml:scan` | `CLAWSWEEPER_SPAM_RUNNER` | `blacksmith-4vcpu-ubuntu-2404` |
+
+The containment smoke reuses the E2E control because both jobs exercise the production
+container/containment surface on the same runner class. Repair result publication reuses the
+existing lightweight worker control. Spam intake and scanning share one spam-lane control rather
+than introducing two equivalent variables.
+
+Other Blacksmith strings in the workflow tree were already protected by repository-variable
+fallbacks or were `workflow_dispatch` input defaults, so they required no change.
+
+## Test and proof shape
+
+`test/workflow-runner-labels.test.ts` parses every workflow and rejects any Blacksmith `runs-on`
+assignment without a `vars.CLAWSWEEPER_*_RUNNER || 'blacksmith-*'` fallback. It also pins the six
+current job-to-variable mappings and fallback labels. Existing automerge and containment workflow
+shape tests assert their exact expressions.
+
+The committed `run-proof.sh` is the static `jq` recipe for the Docker-backed Crabbox run. It obtains
+the head commit, head tree, and base commit through `git rev-parse`, verifies all three objects with
+`git cat-file`, runs the focused workflow tests and `pnpm run check`, and validates its generated
+JSON receipt. See `red-green.md` for the local RED/GREEN transcript.
+
+OpenClaw Bay is unaffected: runner selection does not change workflow lifecycle publication,
+status telemetry, dashboard data contracts, or the observer-only action boundary.
+
+## Limits
+
+This proves static workflow selection and the repository gates. It does not dispatch the workflows
+or set repository variables. With variables unset, GitHub Actions resolves the same Blacksmith
+labels as before.

--- a/docs/proof/runner-label-escape-hatches/README.md
+++ b/docs/proof/runner-label-escape-hatches/README.md
@@ -37,7 +37,10 @@ shape tests assert their exact expressions.
 The committed `run-proof.sh` is the static `jq` recipe for the Docker-backed Crabbox run. It obtains
 the head commit, head tree, and base commit through `git rev-parse`, verifies all three objects with
 `git cat-file`, runs the focused workflow tests and `pnpm run check`, and validates its generated
-JSON receipt. See `red-green.md` for the local RED/GREEN transcript.
+JSON receipt. Raw Crabbox sync omits Git metadata, so the run transports the already-committed head
+and base in a temporary Git bundle, reconstructs the refs inside the lease, and removes the bundle
+before validation. The bundle is proof transport only and is not committed. See `red-green.md` for
+the local RED/GREEN transcript.
 
 OpenClaw Bay is unaffected: runner selection does not change workflow lifecycle publication,
 status telemetry, dashboard data contracts, or the observer-only action boundary.

--- a/docs/proof/runner-label-escape-hatches/container-receipt.json
+++ b/docs/proof/runner-label-escape-hatches/container-receipt.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "provider": "local-container",
+  "lease_id": "cbx_d1a06e39d867",
+  "lease_slug": "golden-prawn-16e4",
+  "machine_type": "node_24-bookworm",
+  "image": "node:24-bookworm",
+  "crabbox_cli": "0.38.3-5-g2a79805d",
+  "lease_stopped": true,
+  "cleanup": {
+    "owned_lease_absent_from_local_container_list": true,
+    "unrelated_preexisting_exited_lease_untouched": true
+  },
+  "tested_head_sha": "f84b7d60daa24d979eef6299be0d9c2a55fdab62",
+  "tested_head_tree": "7e7afa01638ca5940bb7c1aa4cdc6b43b63c61a4",
+  "base_sha": "dc738b3845655ad36f91ea9584d90abdd4df3ca3",
+  "cat_file_cross_check": {
+    "head_commit": true,
+    "head_tree": true,
+    "base_commit": true
+  },
+  "git_transport": "temporary bundle removed before validation and omitted from the receipt commit",
+  "runtime": {
+    "node": "v24.19.0",
+    "pnpm": "11.10.0"
+  },
+  "timing_ms": {
+    "sync": 2177,
+    "command": 132552,
+    "total": 134785
+  },
+  "command_phases_ms": {
+    "git_metadata_and_setup": 1759,
+    "tools": 1647,
+    "install": 2712,
+    "focused": 324,
+    "check": 126109
+  },
+  "focused_tests": {
+    "passed": 9,
+    "failed": 0
+  },
+  "full_gate": {
+    "command": "pnpm run check",
+    "passed": true,
+    "tests": 3428,
+    "passed_tests": 3420,
+    "failed_tests": 0,
+    "skipped_tests": 8
+  },
+  "runner_inventory": [
+    {
+      "file": ".github/workflows/assist.yml",
+      "job": "assist",
+      "runner": "${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/automerge-e2e.yml",
+      "job": "automerge-e2e",
+      "runner": "${{ vars.CLAWSWEEPER_E2E_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/maintainer-report-discord.yml",
+      "job": "notify",
+      "runner": "${{ vars.CLAWSWEEPER_REPORT_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/repair-cluster-intake.yml",
+      "job": "intake",
+      "runner": "${{ github.event.inputs.runner || vars.CLAWSWEEPER_CLUSTER_REPAIR_INTAKE_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/repair-conflict-self-heal.yml",
+      "job": "self-heal",
+      "runner": "${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/repair-containment-smoke.yml",
+      "job": "containment-smoke",
+      "runner": "${{ vars.CLAWSWEEPER_E2E_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/repair-publish-results.yml",
+      "job": "publish",
+      "runner": "${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/repair-self-heal.yml",
+      "job": "self-heal",
+      "runner": "${{ github.event_name == 'workflow_dispatch' && inputs.runner || vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/spam-comment-intake.yml",
+      "job": "intake",
+      "runner": "${{ vars.CLAWSWEEPER_SPAM_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    },
+    {
+      "file": ".github/workflows/spam-scanner.yml",
+      "job": "scan",
+      "runner": "${{ vars.CLAWSWEEPER_SPAM_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+    }
+  ],
+  "limits": [
+    "Static workflow parsing and repository validation only.",
+    "No workflow was dispatched and no repository variable was set.",
+    "The receipt commit adds proof artifacts only after the tested workflow tree."
+  ]
+}

--- a/docs/proof/runner-label-escape-hatches/live-actions.md
+++ b/docs/proof/runner-label-escape-hatches/live-actions.md
@@ -1,0 +1,142 @@
+# Live GitHub Actions runner override proof
+
+Captured 2026-08-14 UTC for
+[PR 1157](https://github.com/openclaw/clawsweeper/pull/1157).
+
+## Behavior contract
+
+With `CLAWSWEEPER_REPORT_RUNNER=ubuntu-latest`, dispatch the report workflow from the PR branch and
+observe through the GitHub Actions API that the job resolves the configured label, receives a
+GitHub-hosted runner, starts real steps, and completes. Compare that result with a prior run of the
+same workflow showing the Blacksmith fallback. Leave the report override set, and do not create the
+E2E or spam overrides.
+
+## Route
+
+The branch version of `maintainer-report-discord.yml` exposes `workflow_dispatch`, so the proof used
+the report lane directly. GitHub tied the run to the requested PR branch and exact PR head; no
+default-branch-definition fallback or precedent-only proof route was needed.
+
+## Committed-object cross-check
+
+The tested head, tree, and base were resolved by command substitution and checked with
+`git cat-file` before dispatch evidence was committed:
+
+```console
+$ proof_head=$(git rev-parse HEAD)
+$ proof_tree=$(git rev-parse 'HEAD^{tree}')
+$ proof_base=$(git rev-parse origin/main)
+$ printf 'proof_head=%s\nproof_tree=%s\nproof_base=%s\n' "$proof_head" "$proof_tree" "$proof_base"
+proof_head=32334740ba22b0e7fe69d1c71bfc013441f3dbf6
+proof_tree=8792b966061fe9aad1ba23ffe9d4a7704b9aa334
+proof_base=dc738b3845655ad36f91ea9584d90abdd4df3ca3
+$ printf 'proof_head_type=%s\n' "$(git cat-file -t "$proof_head")"
+proof_head_type=commit
+$ printf 'proof_tree_type=%s\n' "$(git cat-file -t "$proof_tree")"
+proof_tree_type=tree
+$ printf 'proof_base_type=%s\n' "$(git cat-file -t "$proof_base")"
+proof_base_type=commit
+```
+
+## Variable and dispatch
+
+```console
+$ gh variable set CLAWSWEEPER_REPORT_RUNNER --repo openclaw/clawsweeper --body ubuntu-latest
+$ gh variable get CLAWSWEEPER_REPORT_RUNNER --repo openclaw/clawsweeper
+ubuntu-latest
+$ gh workflow run 281699657 --repo openclaw/clawsweeper --ref steipete/runner-label-escape-hatches
+https://github.com/openclaw/clawsweeper/actions/runs/31759075251
+```
+
+The run identity reported by `gh run view 31759075251 --json ...` was:
+
+```json
+{
+  "conclusion": "success",
+  "createdAt": "2026-08-14T00:57:31Z",
+  "databaseId": 31759075251,
+  "event": "workflow_dispatch",
+  "headBranch": "steipete/runner-label-escape-hatches",
+  "headSha": "32334740ba22b0e7fe69d1c71bfc013441f3dbf6",
+  "name": "maintainer report to discord",
+  "startedAt": "2026-08-14T00:57:31Z",
+  "status": "completed",
+  "updatedAt": "2026-08-14T00:58:12Z",
+  "url": "https://github.com/openclaw/clawsweeper/actions/runs/31759075251",
+  "workflowDatabaseId": 281699657
+}
+```
+
+## Resolved label and runner pickup
+
+The attempt-specific Actions jobs API avoids a stale cached first response. The final response was:
+
+```console
+$ gh api 'repos/openclaw/clawsweeper/actions/runs/31759075251/attempts/1/jobs?filter=all&per_page=100&page=1' --jq '<job projection>'
+{
+  "id": 94641313387,
+  "name": "Summarize maintainer report",
+  "status": "completed",
+  "conclusion": "success",
+  "started_at": "2026-08-14T00:57:35Z",
+  "completed_at": "2026-08-14T00:58:12Z",
+  "runner_id": 1011717149,
+  "runner_name": "GitHub Actions 1011717149",
+  "runner_group_id": 0,
+  "runner_group_name": "GitHub Actions",
+  "labels": ["ubuntu-latest"],
+  "html_url": "https://github.com/openclaw/clawsweeper/actions/runs/31759075251/job/94641313387"
+}
+```
+
+The `Set up job` step ran from `00:57:37Z` to `00:57:38Z`, and every workflow step, including
+`Post report summary`, completed successfully. The non-null runner assignment plus completed setup
+and checkout steps demonstrate pickup rather than a queued label-only result.
+
+## Historical Blacksmith contrast
+
+The most recent scheduled report run before this PR used `main` head
+`4d41d3df4baf191dca9c385c82689425a135a5c4`:
+
+```console
+$ gh api repos/openclaw/clawsweeper/actions/runs/31688886472/attempts/1/jobs --jq '<job projection>'
+{
+  "id": 94411349909,
+  "name": "Summarize maintainer report",
+  "status": "completed",
+  "conclusion": "success",
+  "started_at": "2026-08-13T09:56:50Z",
+  "completed_at": "2026-08-13T09:57:26Z",
+  "runner_id": 12762319,
+  "runner_name": "blacksmith-scale2-01kzx8ttr5349w912nmq4jtwqd-4vcpu",
+  "runner_group_id": 5,
+  "runner_group_name": "blacksmith runners 01kwyrrg4m5049hqd9h5a6vf13",
+  "labels": ["blacksmith-4vcpu-ubuntu-2404"],
+  "html_url": "https://github.com/openclaw/clawsweeper/actions/runs/31688886472/job/94411349909"
+}
+```
+
+This is the same workflow and job, so it is a direct before/after contrast rather than evidence
+borrowed from another lane.
+
+## Variable end-state
+
+```console
+$ gh variable get CLAWSWEEPER_REPORT_RUNNER --repo openclaw/clawsweeper
+ubuntu-latest
+$ gh variable get CLAWSWEEPER_E2E_RUNNER --repo openclaw/clawsweeper
+variable CLAWSWEEPER_E2E_RUNNER was not found
+$ gh variable get CLAWSWEEPER_SPAM_RUNNER --repo openclaw/clawsweeper
+variable CLAWSWEEPER_SPAM_RUNNER was not found
+```
+
+Result: the report override remains set to `ubuntu-latest`; the E2E and spam fallbacks remain
+active because their variables are absent.
+
+## Limits
+
+This live proof exercises the report expression, runner assignment, and successful job execution.
+It does not dispatch the E2E, containment, repair-publication, or spam lanes. Their exact expression
+shapes remain covered by the committed workflow tests. No new Crabbox lease was needed for this
+round; the earlier container proof lease `cbx_d1a06e39d867` is stopped as recorded in
+`container-receipt.json`.

--- a/docs/proof/runner-label-escape-hatches/red-green.md
+++ b/docs/proof/runner-label-escape-hatches/red-green.md
@@ -39,3 +39,7 @@ tests 9
 pass 9
 fail 0
 ```
+
+Docker-backed Crabbox `provider=local-container` repeated the GREEN contract at committed head
+`f84b7d60daa24d979eef6299be0d9c2a55fdab62` on lease `cbx_d1a06e39d867`, then completed the full
+repository gate with 3,420 passed, zero failed, and eight skipped tests.

--- a/docs/proof/runner-label-escape-hatches/red-green.md
+++ b/docs/proof/runner-label-escape-hatches/red-green.md
@@ -1,0 +1,41 @@
+# Runner-label escape-hatch RED/GREEN transcript
+
+## RED
+
+The ratchet test was added before any workflow changed and run against fresh `origin/main` at
+`dc738b3845655ad36f91ea9584d90abdd4df3ca3`:
+
+```text
+$ node --test test/workflow-runner-labels.test.ts
+✖ Blacksmith runner assignments keep a repository-variable escape hatch
+AssertionError [ERR_ASSERTION]: .github/workflows/automerge-e2e.yml:automerge-e2e must keep its Blacksmith label behind a vars fallback
+actual: 'blacksmith-16vcpu-ubuntu-2404'
+expected pattern: vars.CLAWSWEEPER_*_RUNNER || 'blacksmith-*'
+tests 1
+pass 0
+fail 1
+```
+
+The first failing site is sufficient to establish the old tree violated the new invariant; the
+inventory in `README.md` records all six bare assignments found by the repository-wide sweep.
+
+## GREEN
+
+The same ratchet plus the existing automerge and containment workflow-shape tests passed after the
+mechanical replacements:
+
+```text
+$ node --test test/workflow-runner-labels.test.ts test/repair/automerge-e2e-workflow.test.ts test/repair/repair-containment-smoke-workflow.test.ts
+✔ automerge E2E uses the production containment runner and container entrypoint
+✔ automerge E2E builds its cached base from repository-controlled source
+✔ automerge E2E is read-only and excludes untrusted fork pull requests
+✔ automerge E2E uploads the container proof even when a scenario fails
+✔ containment smoke uses two production-class runner samples
+✔ containment smoke is read-only and excludes untrusted fork pull requests
+✔ containment changes trigger the smoke workflow
+✔ Blacksmith lanes keep their expected variable names and default labels
+✔ Blacksmith runner assignments keep a repository-variable escape hatch
+tests 9
+pass 9
+fail 0
+```

--- a/docs/proof/runner-label-escape-hatches/run-proof.sh
+++ b/docs/proof/runner-label-escape-hatches/run-proof.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  proof_bundle="docs/proof/runner-label-escape-hatches/proof-objects.bundle"
+  test -f "$proof_bundle"
+  git init --quiet
+  git fetch --quiet "$proof_bundle" \
+    HEAD:refs/heads/proof-head \
+    refs/remotes/origin/main:refs/remotes/origin/main
+  git symbolic-ref HEAD refs/heads/proof-head
+  git reset --mixed --quiet HEAD
+  rm -f "$proof_bundle"
+fi
+
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 output_dir="${RUNNER_LABEL_PROOF_OUTPUT:-.artifacts/runner-label-escape-hatches}"
@@ -50,7 +62,8 @@ EOF
 echo "CRABBOX_PHASE:check"
 pnpm run check | tee "$output_dir/full-gate.log"
 
-test -z "$(git status --porcelain)"
+git diff --quiet HEAD
+git diff --cached --quiet HEAD
 
 jq -n \
   --arg head_sha "$head_sha" \
@@ -71,6 +84,7 @@ jq -n \
       head_tree: true,
       base_commit: true
     },
+    git_transport: "temporary bundle removed before validation",
     runtime: {
       node: $node_version,
       pnpm: $pnpm_version

--- a/docs/proof/runner-label-escape-hatches/run-proof.sh
+++ b/docs/proof/runner-label-escape-hatches/run-proof.sh
@@ -31,6 +31,11 @@ export PATH="$PNPM_HOME:$PATH"
 if ! command -v pnpm >/dev/null 2>&1; then
   corepack enable --install-directory "$PNPM_HOME"
 fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "CRABBOX_PHASE:tools"
+  sudo apt-get update
+  sudo apt-get install --yes jq
+fi
 
 echo "CRABBOX_PHASE:install"
 pnpm install --frozen-lockfile

--- a/docs/proof/runner-label-escape-hatches/run-proof.sh
+++ b/docs/proof/runner-label-escape-hatches/run-proof.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+output_dir="${RUNNER_LABEL_PROOF_OUTPUT:-.artifacts/runner-label-escape-hatches}"
+mkdir -p "$output_dir"
+
+head_sha="$(git rev-parse HEAD)"
+head_tree="$(git rev-parse "${head_sha}^{tree}")"
+base_sha="$(git rev-parse origin/main)"
+git cat-file -e "${head_sha}^{commit}"
+git cat-file -e "${head_tree}^{tree}"
+git cat-file -e "${base_sha}^{commit}"
+
+export PNPM_HOME="$HOME/.local/bin"
+mkdir -p "$PNPM_HOME"
+export PATH="$PNPM_HOME:$PATH"
+if ! command -v pnpm >/dev/null 2>&1; then
+  corepack enable --install-directory "$PNPM_HOME"
+fi
+
+echo "CRABBOX_PHASE:install"
+pnpm install --frozen-lockfile
+
+echo "CRABBOX_PHASE:focused"
+node --test \
+  test/workflow-runner-labels.test.ts \
+  test/repair/automerge-e2e-workflow.test.ts \
+  test/repair/repair-containment-smoke-workflow.test.ts \
+  | tee "$output_dir/focused-tests.tap"
+
+node --input-type=module >"$output_dir/runner-inventory.json" <<'EOF'
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+const rows = [];
+for (const name of readdirSync(".github/workflows").filter((entry) => /\.ya?ml$/.test(entry))) {
+  const file = join(".github/workflows", name);
+  const workflow = parse(readFileSync(file, "utf8"));
+  for (const [job, definition] of Object.entries(workflow.jobs ?? {})) {
+    const runner = String(definition["runs-on"] ?? "");
+    if (runner.includes("blacksmith-")) rows.push({ file, job, runner });
+  }
+}
+process.stdout.write(`${JSON.stringify(rows.sort((a, b) => `${a.file}:${a.job}`.localeCompare(`${b.file}:${b.job}`)), null, 2)}\n`);
+EOF
+
+echo "CRABBOX_PHASE:check"
+pnpm run check | tee "$output_dir/full-gate.log"
+
+test -z "$(git status --porcelain)"
+
+jq -n \
+  --arg head_sha "$head_sha" \
+  --arg head_tree "$head_tree" \
+  --arg base_sha "$base_sha" \
+  --arg node_version "$(node --version)" \
+  --arg pnpm_version "$(pnpm --version)" \
+  --slurpfile inventory "$output_dir/runner-inventory.json" \
+  '{
+    schema_version: 1,
+    provider: "local-container",
+    image: "node:24-bookworm",
+    tested_head_sha: $head_sha,
+    tested_head_tree: $head_tree,
+    base_sha: $base_sha,
+    cat_file_cross_check: {
+      head_commit: true,
+      head_tree: true,
+      base_commit: true
+    },
+    runtime: {
+      node: $node_version,
+      pnpm: $pnpm_version
+    },
+    runner_inventory: $inventory[0],
+    focused_tests: {
+      passed: 9,
+      failed: 0
+    },
+    full_gate: "passed",
+    limits: [
+      "Static workflow parsing and repository validation only.",
+      "No workflow was dispatched and no repository variable was set.",
+      "The receipt commit may add proof artifacts after the tested workflow tree."
+    ]
+  }' >"$output_dir/container-receipt.json"
+
+jq -e '
+  .schema_version == 1 and
+  .provider == "local-container" and
+  .image == "node:24-bookworm" and
+  (.tested_head_sha | test("^[0-9a-f]{40}$")) and
+  (.tested_head_tree | test("^[0-9a-f]{40}$")) and
+  (.base_sha | test("^[0-9a-f]{40}$")) and
+  .cat_file_cross_check == {head_commit:true, head_tree:true, base_commit:true} and
+  (.runner_inventory | length) >= 6 and
+  all(.runner_inventory[]; .runner | test("vars\\.CLAWSWEEPER_[A-Z0-9_]*RUNNER.*\\|\\|.*blacksmith-")) and
+  .focused_tests == {passed:9, failed:0} and
+  .full_gate == "passed"
+' "$output_dir/container-receipt.json" >/dev/null
+
+cat "$output_dir/container-receipt.json"

--- a/test/repair/automerge-e2e-workflow.test.ts
+++ b/test/repair/automerge-e2e-workflow.test.ts
@@ -5,7 +5,10 @@ import test from "node:test";
 const workflow = fs.readFileSync(".github/workflows/automerge-e2e.yml", "utf8");
 
 test("automerge E2E uses the production containment runner and container entrypoint", () => {
-  assert.match(workflow, /runs-on: blacksmith-16vcpu-ubuntu-2404/);
+  assert.match(
+    workflow,
+    /runs-on: \$\{\{ vars\.CLAWSWEEPER_E2E_RUNNER \|\| 'blacksmith-16vcpu-ubuntu-2404' \}\}/,
+  );
   assert.match(workflow, /node scripts\/e2e\/automerge-container\.mjs/);
   assert.match(workflow, /--scenario all/);
   assert.match(workflow, /--fixture all/);

--- a/test/repair/repair-containment-smoke-workflow.test.ts
+++ b/test/repair/repair-containment-smoke-workflow.test.ts
@@ -5,7 +5,10 @@ import test from "node:test";
 const workflow = fs.readFileSync(".github/workflows/repair-containment-smoke.yml", "utf8");
 
 test("containment smoke uses two production-class runner samples", () => {
-  assert.match(workflow, /runs-on: blacksmith-16vcpu-ubuntu-2404/);
+  assert.match(
+    workflow,
+    /runs-on: \$\{\{ vars\.CLAWSWEEPER_E2E_RUNNER \|\| 'blacksmith-16vcpu-ubuntu-2404' \}\}/,
+  );
   assert.match(workflow, /max-parallel: 2/);
   assert.match(workflow, /sample: \[1, 2\]/);
   assert.match(workflow, /run: pnpm run repair:containment-smoke/);

--- a/test/workflow-runner-labels.test.ts
+++ b/test/workflow-runner-labels.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { parse } from "yaml";
+
+type WorkflowDocument = {
+  jobs?: Record<string, { "runs-on"?: string | string[] }>;
+};
+
+const workflowDirectory = ".github/workflows";
+const expectedRunnerByJob = new Map([
+  [
+    ".github/workflows/automerge-e2e.yml:automerge-e2e",
+    "${{ vars.CLAWSWEEPER_E2E_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}",
+  ],
+  [
+    ".github/workflows/maintainer-report-discord.yml:notify",
+    "${{ vars.CLAWSWEEPER_REPORT_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+  ],
+  [
+    ".github/workflows/repair-containment-smoke.yml:containment-smoke",
+    "${{ vars.CLAWSWEEPER_E2E_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}",
+  ],
+  [
+    ".github/workflows/repair-publish-results.yml:publish",
+    "${{ vars.CLAWSWEEPER_WORKER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+  ],
+  [
+    ".github/workflows/spam-comment-intake.yml:intake",
+    "${{ vars.CLAWSWEEPER_SPAM_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+  ],
+  [
+    ".github/workflows/spam-scanner.yml:scan",
+    "${{ vars.CLAWSWEEPER_SPAM_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+  ],
+]);
+
+test("Blacksmith lanes keep their expected variable names and default labels", () => {
+  for (const [site, expectedRunner] of expectedRunnerByJob) {
+    const separator = site.lastIndexOf(":");
+    const file = site.slice(0, separator);
+    const jobName = site.slice(separator + 1);
+    const workflow = parse(readFileSync(file, "utf8")) as WorkflowDocument;
+
+    assert.equal(workflow.jobs?.[jobName]?.["runs-on"], expectedRunner, site);
+  }
+});
+
+test("Blacksmith runner assignments keep a repository-variable escape hatch", () => {
+  for (const name of readdirSync(workflowDirectory).filter((entry) => /\.ya?ml$/.test(entry))) {
+    const file = join(workflowDirectory, name);
+    const workflow = parse(readFileSync(file, "utf8")) as WorkflowDocument;
+    for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
+      const runner = String(job["runs-on"] ?? "");
+      if (!runner.includes("blacksmith-")) continue;
+
+      assert.match(
+        runner,
+        /vars\.CLAWSWEEPER_[A-Z0-9_]*RUNNER\s*\|\|\s*'blacksmith-[a-z0-9-]+'/,
+        `${file}:${jobName} must keep its Blacksmith label behind a vars fallback`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

The 2026-08-13 Blacksmith us-west outage showed that review jobs could fail over through their existing repository-variable runner controls, while six jobs still had literal Blacksmith `runs-on` labels and could not start elsewhere. In particular, the automerge E2E smoke stayed permanently queued while [PR #1155](https://github.com/openclaw/clawsweeper/pull/1155) had to merge past it.

This change gives every Blacksmith-backed job a repository-variable escape hatch while preserving its current label as the fallback. Under the amended live-proof authority, `CLAWSWEEPER_REPORT_RUNNER=ubuntu-latest` is now set and intentionally remains set while Blacksmith us-west is unavailable. The E2E and spam variables remain unset, so their fallbacks are unchanged.

The six migrated jobs use:

- `CLAWSWEEPER_E2E_RUNNER` for automerge E2E and containment smoke
- `CLAWSWEEPER_REPORT_RUNNER` for the maintainer Discord report
- `CLAWSWEEPER_SPAM_RUNNER` for spam intake and scanning
- the existing `CLAWSWEEPER_WORKER_RUNNER` for repair result publication

## Validation

The new workflow-tree ratchet parses every job and rejects a Blacksmith runner assignment without a `vars.CLAWSWEEPER_*_RUNNER` fallback. It also pins the six current mappings and unchanged default labels. Existing automerge and containment workflow-shape tests assert the exact expressions.

- Live report-lane dispatch: [run 31759075251](https://github.com/openclaw/clawsweeper/actions/runs/31759075251), `workflow_dispatch` from `steipete/runner-label-escape-hatches` at `32334740ba22b0e7fe69d1c71bfc013441f3dbf6`
- Live resolved label: `ubuntu-latest`; assigned runner `GitHub Actions 1011717149`, runner group `GitHub Actions`; job completed successfully
- Historical same-job contrast: [run 31688886472](https://github.com/openclaw/clawsweeper/actions/runs/31688886472), label `blacksmith-4vcpu-ubuntu-2404`, Blacksmith runner/group
- Variable end-state: `CLAWSWEEPER_REPORT_RUNNER=ubuntu-latest`; `CLAWSWEEPER_E2E_RUNNER` and `CLAWSWEEPER_SPAM_RUNNER` absent
- Local focused RED/GREEN: 9 passed, 0 failed after a failing pre-change control
- Local full gate: `pnpm run check` passed, 3,419 passed / 0 failed / 9 skipped
- Docker-backed Crabbox: `provider=local-container`, image `node:24-bookworm`, lease `cbx_d1a06e39d867` (`golden-prawn-16e4`)
- Container-tested runtime head: `f84b7d60daa24d979eef6299be0d9c2a55fdab62`
- Live-Actions-tested head: `32334740ba22b0e7fe69d1c71bfc013441f3dbf6`
- Final proof head: `11117ec402f19bf3a51d64be512136ec55576599`
- Container focused tests: 9 passed / 0 failed
- Container full gate: 3,420 passed / 0 failed / 8 skipped
- Commit, tree, and base objects were resolved with `git rev-parse` and verified with `git cat-file`; the one-shot Crabbox lease stopped and is absent from the local-container inventory
- Fresh structured review before the proof commit and again on the committed branch: no accepted/actionable findings

The committed proof is under `docs/proof/runner-label-escape-hatches/`. `live-actions.md` contains the redacted Actions/API transcript, exact runner assignment, historical contrast, behavior contract, object cross-checks, and variable end-state. The directory also retains the RED/GREEN transcript, static `jq` recipe, and container receipt.

## Proof limits

The live run exercises the report-lane override expression, GitHub-hosted runner assignment and pickup, and successful report-job completion. It does not dispatch the E2E, containment, repair-publication, or spam lanes; those exact mappings and unchanged fallbacks remain covered by the workflow-shape tests and repository gate. The same-job historical run provides the report lane's pre-change Blacksmith contrast.

OpenClaw Bay is unaffected because this changes runner selection only, not workflow lifecycle publication, status telemetry, dashboard data contracts, or the observer-only action boundary.
