### PR TITLE
fix(apply): defer folder reconciliation on GitHub rate limit instead of failing the close lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Folder reconciliation now defers with a zero-mutation result when the open-state scan hits GitHub rate limiting, so throttled proof/apply/publish runs proceed to their close and publication work instead of failing before `Apply close proposals` can run.
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/src/clawsweeper-dashboard-audit.ts
+++ b/src/clawsweeper-dashboard-audit.ts
@@ -38,7 +38,7 @@ import type {
   WorkflowStatusSummary,
 } from "./clawsweeper-types.js";
 import { syncDecisionPacketRecord, type DecisionPacketSubjectState } from "./decision-packets.js";
-import { isGitHubNotFoundError } from "./github-retry.js";
+import { GitHubRateLimitError, isGitHubNotFoundError } from "./github-retry.js";
 import { captureCanonicalRecordBaseline } from "./repair/canonical-record-baseline.js";
 import {
   REPOSITORY_PROFILES,
@@ -403,17 +403,39 @@ export function createDashboardAudit(dependencies: CreateDashboardAuditDependenc
     if (scopedItemNumbers?.size === 0) {
       throw new Error("scoped reconciliation requires at least one item number");
     }
-    const { numbers: openNumbers, pagesScanned } = scopedItemNumbers
-      ? { numbers: new Set<number>(), pagesScanned: 0 }
-      : fetchOpenItemNumbers(maxPages);
-    for (const number of options.preserveItemNumbers ?? []) {
-      try {
-        const { state } = fetchItem(number);
-        if (state === "open") openNumbers.add(number);
-      } catch (error) {
-        if (!scopedItemNumbers || !isGitHubNotFoundError(error)) throw error;
-        ghJson<unknown>(["api", `repos/${targetRepo()}`]);
+    let openNumbers: Set<number>;
+    let pagesScanned: number;
+    try {
+      ({ numbers: openNumbers, pagesScanned } = scopedItemNumbers
+        ? { numbers: new Set<number>(), pagesScanned: 0 }
+        : fetchOpenItemNumbers(maxPages));
+      for (const number of options.preserveItemNumbers ?? []) {
+        try {
+          const { state } = fetchItem(number);
+          if (state === "open") openNumbers.add(number);
+        } catch (error) {
+          if (!scopedItemNumbers || !isGitHubNotFoundError(error)) throw error;
+          ghJson<unknown>(["api", `repos/${targetRepo()}`]);
+        }
       }
+    } catch (error) {
+      if (!(error instanceof GitHubRateLimitError)) throw error;
+      // The throttled open-state scan happens before any record mutation, so a
+      // deferral is guaranteed to leave every record untouched. Callers keep
+      // their fail-closed per-item live checks; the next scheduled pass
+      // retries folder placement after the reported reset.
+      console.error(`[reconcile] deferred: ${error.message}`);
+      return {
+        openItemsSeen: 0,
+        pagesScanned: 0,
+        movedToClosed: 0,
+        movedToItems: 0,
+        removedStaleClosedCopies: 0,
+        fetchedClosedAt: 0,
+        changedItemNumbers: [],
+        changedRecordFiles: [],
+        deferred: { reason: "github_rate_limited", retryAt: error.retryAt },
+      };
     }
     let movedToClosed = 0;
     let movedToItems = 0;

--- a/src/clawsweeper-types.ts
+++ b/src/clawsweeper-types.ts
@@ -953,6 +953,7 @@ export interface ReconcileResult {
   fetchedClosedAt: number;
   changedItemNumbers: number[];
   changedRecordFiles: string[];
+  deferred?: { reason: "github_rate_limited"; retryAt: string };
 }
 
 export type AuditRecordLocation = "items" | "closed";

--- a/test/reconcile.test.ts
+++ b/test/reconcile.test.ts
@@ -329,3 +329,55 @@ if (args[0] === "api" && args[1]?.includes("/issues?state=open")) {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("unscoped reconciliation defers without mutations when the open-state scan is rate limited", () => {
+  const root = mkdtempSync(tmpPrefix);
+  const itemsDir = join(root, "items");
+  const closedDir = join(root, "closed");
+  const plansDir = join(root, "plans");
+  for (const dir of [itemsDir, closedDir, plansDir]) mkdirSync(dir, { recursive: true });
+  const openReport = reportFrontMatter({ number: 11, current_state: "open" });
+  const closedReport = reportFrontMatter({ number: 12, current_state: "closed" });
+  writeFileSync(join(itemsDir, "11.md"), openReport);
+  writeFileSync(join(closedDir, "12.md"), closedReport);
+  const ghMock = `
+process.stderr.write("gh: API rate limit exceeded for installation. (HTTP 403)\\n");
+process.exit(1);
+`;
+
+  try {
+    let stdout = "";
+    withMockGh(root, ghMock, () => {
+      stdout = execFileSync(
+        process.execPath,
+        [
+          "dist/clawsweeper.js",
+          "reconcile",
+          "--target-repo",
+          "openclaw/openclaw",
+          "--items-dir",
+          itemsDir,
+          "--closed-dir",
+          closedDir,
+          "--plans-dir",
+          plansDir,
+          "--skip-closed-at",
+        ],
+        { encoding: "utf8" },
+      );
+    });
+
+    const result = JSON.parse(stdout);
+    assert.equal(result.deferred?.reason, "github_rate_limited");
+    assert.match(result.deferred?.retryAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(result.openItemsSeen, 0);
+    assert.equal(result.movedToClosed, 0);
+    assert.equal(result.movedToItems, 0);
+    assert.deepEqual(result.changedItemNumbers, []);
+    assert.deepEqual(result.changedRecordFiles, []);
+    assert.equal(readFileSync(join(itemsDir, "11.md"), "utf8"), openReport);
+    assert.equal(readFileSync(join(closedDir, "12.md"), "utf8"), closedReport);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Every scheduled `Apply close proposals` run has been dying before it could close anything. The `apply-proof` job's "Reconcile read-only proof inputs" step performs a full open-item scan; when the shared GitHub credential is rate limited, `ghWithRetry` deliberately throws `GitHubRateLimitError`, the `reconcile` CLI exits 1, the proof job fails before `proof_ready` is ever exported, and the downstream apply job is skipped. Observed on runs 31764392301 and 31763539358 (both failed at this exact step with `API rate limit exceeded for installation`), during a window where only 3 items were closed in 12 hours despite all six close reasons being enabled and thousands of eligible candidates.

## Why This Change Was Made

The open-state scan is the very first GitHub read in `reconcileFolders` and happens before any record mutation. Deferring the whole reconciliation at that boundary is therefore guaranteed zero-mutation: the emitted result truthfully reports no changed records (`publish_reconciled_records` validates and publishes nothing), and every downstream close still runs its own fail-closed live-state verification per item. The next scheduled pass retries folder placement after the reported reset. Reconciliation deferral is reported as a typed `deferred: { reason: "github_rate_limited", retryAt }` field on `ReconcileResult` and logged to stderr.

This also protects the other `pnpm run reconcile` call sites with the same throttle exposure: the review record publication step (which previously could fail record publication on a throttled reconcile) and the apply job's own "Reconcile before apply preselect" step.

Non-throttle errors still fail loudly; scoped reconciliation semantics are unchanged.

## Evidence

- New regression test: a rate-limited open-state scan yields exit 0, `deferred.reason === "github_rate_limited"`, zero moves, and byte-identical record files. All 5 reconcile tests pass.
- Full apply-lane suite: 250/250 tests pass (`node --test test/apply-*.test.ts`).
- Close-policy suites: 70/70 tests pass (`test/close-reasons.test.ts`, `test/review-close-policy.test.ts`).
- `pnpm run check:static` (including docs check) and `pnpm run lint` clean.
- Codex-backed autoreview: clean, no accepted/actionable findings (`patch is correct`, 0.99).
