### PR TITLE
improve: reduce PR activity checks to two GraphQL reads

### DIFF
--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -4,7 +4,8 @@
 - Owner: ClawSweeper publication and dashboard maintainers
 - Source of truth: `src/github-egress-observer.ts`,
   `src/github-egress-telemetry-contract.ts`,
-  `dashboard/github-egress-telemetry.ts`, and the publication workflows
+  `src/review-activity-cursor.ts`, `dashboard/github-egress-telemetry.ts`, and
+  the publication workflows
 - Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
 - Update when: a publication request path, credential selection rule, telemetry
   dimension, retention limit, or public response changes
@@ -52,6 +53,17 @@ debug contributes an incomplete `invocation` but no invented wire count.
 `attempted=false` is emitted only for a directly observed pre-wire condition or
 an existing batch circuit skip. Phase 0 does not manufacture requests that a
 future coordinator might have avoided.
+
+Stable pull-request activity validation uses the version-2 GraphQL cursor when
+reviews, review threads, and every nested inline review comment fit in the
+bounded query. The safety invariant remains two independent reads: a normal
+single-PR check therefore contributes two GraphQL invocations instead of two
+sets of reviews, inline-comment, and review-thread reads. The same query shape
+can alias up to eight PRs, so a bounded publication batch still contributes two
+GraphQL invocations. Any GraphQL error, pagination, partial connection, or
+missing required field activates the complete version-1 path for that PR and
+emits one `reviewed_pr_activity_cursor_v2_fallback` JSON line; the decoder never
+accepts a partial activity identity.
 
 Use the unit totals as a conservation check:
 

--- a/docs/proof/graphql-activity-cursor-v2/README.md
+++ b/docs/proof/graphql-activity-cursor-v2/README.md
@@ -1,0 +1,94 @@
+# GraphQL PR activity cursor v2 proof
+
+- Status: historical proof artifact
+- Owner: ClawSweeper publication maintainers
+- Tested source: `openclaw/clawsweeper@221ba1c2cd159dfbc7c2e5a5fb12dbad73467bd7`
+- Update when: the v2 query, decoder, fallback, stability wrapper, or batch bound changes
+
+## Claim and exercised surface
+
+The controlled loopback scenario exercises the production cursor/query decoder
+through `createGitHubContext`: one stable v1 check performs reviews REST, inline
+review-comments REST, and GraphQL review-thread reads twice; v2 replaces those
+six requests with two complete GraphQL snapshots. The batch scenario aliases
+eight PRs and preserves the same two-read invariant while reducing 48 requests
+to two.
+
+Fixtures cover inline-comment edits, review dismissal, thread resolution,
+force-push handling through the unchanged head guard, and activity arriving
+between the two reads. A partial nested comment connection activates the full
+v1 reader, preserves the v1 decision, and emits one structured
+`reviewed_pr_activity_cursor_v2_fallback` line.
+
+The migration deliberately re-baselines persisted v1 reports. GitHub GraphQL
+does not expose REST's immutable `side` and `start_side` fields, so a v1/v2
+comparison returns `rebaseline`; apply reports “cursor version requires a fresh
+review” and never claims that target activity changed. Fresh reports persist
+v2 cursors.
+
+OpenClaw Bay is unaffected. This changes internal GitHub read transport and
+cursor comparison only; it does not change Bay's observer-only status contract,
+public fields, lanes, or action boundary.
+
+## Environment and command
+
+The proof ran through Crabbox's explicitly selected Docker-backed
+`local-container` provider on Ubuntu 26.04/arm64 with Node 24.19.0 and pnpm
+11.10.0. The successful one-shot lease was `cbx_d96385e7eb89` and was stopped
+automatically.
+
+```bash
+proof_source_head="$(git rev-parse HEAD)"
+proof_source_tree="$(git rev-parse 'HEAD^{tree}')"
+git cat-file -e "${proof_source_head}^{commit}"
+git cat-file -e "${proof_source_tree}^{tree}"
+PROOF_SOURCE_HEAD="$proof_source_head" PROOF_SOURCE_TREE="$proof_source_tree" \
+  /Users/steipete/Projects/crabbox/bin/crabbox run \
+  --provider local-container --no-hydrate \
+  --allow-env PROOF_SOURCE_HEAD,PROOF_SOURCE_TREE \
+  --preflight --timing-json --shell -- \
+  "bash scripts/e2e/run-graphql-activity-cursor-v2-container.sh"
+```
+
+Local-container Actions hydration could not execute the repository's
+`pnpm/action-setup` step, so the checked-in wrapper follows Crabbox's documented
+`--no-hydrate` recovery: it installs a checksummed Node 24.19.0 tarball in the
+ephemeral container, enables the repository-pinned Corepack/pnpm version,
+builds all TypeScript targets, and runs the loopback scenario.
+
+## Static verification recipe
+
+Run from the repository root. The final command proves the tested source is
+followed only by this proof directory, avoiding a self-referential commit hash
+inside its own receipt.
+
+```bash
+receipt="docs/proof/graphql-activity-cursor-v2/receipt.json"
+jq -e '
+  .schema_version == 1 and
+  .crabbox.provider == "local-container" and
+  .crabbox.runtime == "docker" and
+  .crabbox.exit_code == 0 and
+  .crabbox.run_status == "succeeded" and
+  .crabbox.lease_stopped == true and
+  .requests.single == {"v1": 6, "v2": 2} and
+  .requests.batch == {"size": 8, "v1": 48, "v2": 2} and
+  .assertions.single_request_reduction == true and
+  .assertions.batch_request_reduction == true and
+  .assertions.fallback_decision_unchanged == true and
+  .assertions.fallback_telemetry_lines == 1 and
+  .assertions.concurrent_change_unstable == true and
+  .assertions.double_read_preserved == true
+' "$receipt"
+tested_head="$(jq -r '.source.head' "$receipt")"
+tested_tree="$(jq -r '.source.tree' "$receipt")"
+git cat-file -e "${tested_head}^{commit}"
+git cat-file -e "${tested_tree}^{tree}"
+test "$(git rev-parse "${tested_head}^{tree}")" = "$tested_tree"
+test -z "$(git diff --name-only "$tested_head"..HEAD -- . \
+  ':(exclude)docs/proof/graphql-activity-cursor-v2/**')"
+```
+
+The receipt does not claim live GitHub mutation coverage. It proves request
+shape, bounded decoding, fallback, migration behavior, and race detection; the
+repository's full check supplies static, unit, integration, and coverage gates.

--- a/docs/proof/graphql-activity-cursor-v2/receipt.json
+++ b/docs/proof/graphql-activity-cursor-v2/receipt.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-08-14T03:46:00Z",
+  "claim": "The v2 GraphQL cursor preserves stable PR activity decisions while reducing one check from six requests to two and an eight-PR batch from forty-eight requests to two.",
+  "source": {
+    "head": "221ba1c2cd159dfbc7c2e5a5fb12dbad73467bd7",
+    "tree": "0f041426798f21da69efd4214bcc2912672db3e2",
+    "commit_object_verified": true,
+    "tree_object_verified": true
+  },
+  "crabbox": {
+    "provider": "local-container",
+    "lease_id": "cbx_d96385e7eb89",
+    "slug": "harbor-krill-8b2b",
+    "runtime": "docker",
+    "image": "ubuntu:26.04",
+    "architecture": "arm64",
+    "node": "v24.19.0",
+    "pnpm": "11.10.0",
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true,
+    "total_ms": 10799
+  },
+  "transport": "loopback HTTP via GITHUB_API_URL and GITHUB_GRAPHQL_URL",
+  "requests": {
+    "single": {
+      "v1": 6,
+      "v2": 2
+    },
+    "batch": {
+      "size": 8,
+      "v1": 48,
+      "v2": 2
+    },
+    "fail_closed_fallback": 7,
+    "concurrent_change": 2
+  },
+  "assertions": {
+    "single_request_reduction": true,
+    "batch_request_reduction": true,
+    "fallback_decision_unchanged": true,
+    "fallback_telemetry_lines": 1,
+    "concurrent_change_unstable": true,
+    "double_read_preserved": true
+  },
+  "limits": [
+    "The proof uses deterministic loopback GitHub fixtures rather than live target mutations.",
+    "Connections over 100 reviews, 100 threads, or 100 comments per thread intentionally activate the complete v1 path.",
+    "The receipt source commit precedes only this proof-artifact commit; the verification recipe rejects any intervening non-proof change."
+  ]
+}

--- a/scripts/e2e/graphql-activity-cursor-v2-loopback-server.mjs
+++ b/scripts/e2e/graphql-activity-cursor-v2-loopback-server.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+
+let v2Mode = "complete";
+let v2Read = 0;
+
+const server = createServer(async (request, response) => {
+  const body = await requestBody(request);
+  const url = new URL(request.url || "/", "http://loopback.invalid");
+  if (url.pathname === "/graphql") {
+    const payload = body ? JSON.parse(body) : {};
+    const query = String(payload.query || "");
+    if (query.includes("ReviewedPrActivityCursorV2")) {
+      v2Read += 1;
+      return json(response, 200, v2GraphqlResponse(query, v2Mode, v2Read));
+    }
+    const number = Number(payload.variables?.number || 0);
+    return json(response, 200, {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [{ id: `thread-${number}`, isResolved: false }],
+            },
+          },
+        },
+      },
+    });
+  }
+  const rest = url.pathname.match(
+    /^\/repos\/openclaw\/clawsweeper\/pulls\/(\d+)\/(reviews|comments)$/,
+  );
+  if (rest) {
+    const number = Number(rest[1]);
+    return json(response, 200, [rest[2] === "reviews" ? restReview(number) : restComment(number)]);
+  }
+  return json(response, 404, { message: `unexpected loopback path ${url.pathname}` });
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("loopback listener has no port");
+  process.send?.({ kind: "ready", port: address.port });
+});
+
+process.on("message", (message) => {
+  if (!message || typeof message !== "object") return;
+  if (message.kind === "mode") {
+    v2Mode = String(message.mode || "complete");
+    v2Read = 0;
+    process.send?.({ kind: "mode", id: message.id });
+  } else if (message.kind === "close") {
+    server.close(() => process.exit(0));
+  }
+});
+
+function restReview(number) {
+  return {
+    id: 10_000 + number,
+    user: { login: "reviewer" },
+    state: "APPROVED",
+    body: `review ${number}`,
+    submitted_at: "2026-08-13T10:00:00Z",
+    commit_id: "a".repeat(40),
+  };
+}
+
+function restComment(number) {
+  return {
+    id: 20_000 + number,
+    pull_request_review_id: 10_000 + number,
+    in_reply_to_id: null,
+    user: { login: "reviewer" },
+    body: `comment ${number}`,
+    created_at: "2026-08-13T10:01:00Z",
+    updated_at: "2026-08-13T10:01:00Z",
+    path: "src/example.ts",
+    line: number,
+    side: "RIGHT",
+    start_line: null,
+    start_side: null,
+    original_line: number,
+    original_commit_id: "a".repeat(40),
+    commit_id: "a".repeat(40),
+  };
+}
+
+function v2GraphqlResponse(query, mode, read) {
+  const repository = {};
+  for (const match of query.matchAll(/pr_(\d+): pullRequest/g)) {
+    const number = Number(match[1]);
+    const state = mode === "concurrent" && read > 1 ? "DISMISSED" : "APPROVED";
+    const commentNodes = [
+      {
+        fullDatabaseId: String(20_000 + number),
+        pullRequestReview: { fullDatabaseId: String(10_000 + number) },
+        replyTo: null,
+        author: { login: "reviewer" },
+        body: `comment ${number}`,
+        createdAt: "2026-08-13T10:01:00Z",
+        updatedAt: "2026-08-13T10:01:00Z",
+        path: "src/example.ts",
+        line: number,
+        startLine: null,
+        originalLine: number,
+        originalCommit: { oid: "a".repeat(40) },
+        commit: { oid: "a".repeat(40) },
+      },
+    ];
+    repository[`pr_${number}`] = {
+      reviews: {
+        totalCount: 1,
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            fullDatabaseId: String(10_000 + number),
+            author: { login: "reviewer" },
+            state,
+            body: `review ${number}`,
+            submittedAt: "2026-08-13T10:00:00Z",
+            commit: { oid: "a".repeat(40) },
+          },
+        ],
+      },
+      reviewThreads: {
+        totalCount: 1,
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            id: `thread-${number}`,
+            isResolved: false,
+            comments: {
+              totalCount: mode === "partial" ? 2 : 1,
+              pageInfo: { hasNextPage: false },
+              nodes: commentNodes,
+            },
+          },
+        ],
+      },
+    };
+  }
+  return { data: { repository } };
+}
+
+function requestBody(request) {
+  return new Promise((resolveBody, reject) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => resolveBody(Buffer.concat(chunks).toString("utf8")));
+    request.on("error", reject);
+  });
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}

--- a/scripts/e2e/graphql-activity-cursor-v2-loopback.mjs
+++ b/scripts/e2e/graphql-activity-cursor-v2-loopback.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { fork, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { createGitHubContext } from "../../dist/clawsweeper-github-context.js";
+import {
+  ReviewedPrActivityChangedDuringReadError,
+  readStableReviewedPrActivityCursor,
+  readStableReviewedPrActivityCursors,
+} from "../../dist/review-activity-cursor.js";
+
+const { values } = parseArgs({
+  options: { "output-dir": { type: "string" } },
+  strict: true,
+});
+
+const requests = [];
+const server = fork(
+  new URL("graphql-activity-cursor-v2-loopback-server.mjs", import.meta.url),
+  [],
+  {
+    stdio: ["ignore", "inherit", "inherit", "ipc"],
+  },
+);
+const port = await new Promise((resolveReady, reject) => {
+  server.once("error", reject);
+  server.on("message", (message) => {
+    if (message?.kind === "ready") resolveReady(message.port);
+  });
+});
+
+try {
+  const apiUrl = `http://127.0.0.1:${port}`;
+  const githubEnv = {
+    ...process.env,
+    GITHUB_API_URL: apiUrl,
+    GITHUB_GRAPHQL_URL: `${apiUrl}/graphql`,
+    GH_TOKEN: "loopback-proof-token",
+  };
+  const context = () =>
+    createGitHubContext({
+      targetRepo: () => "openclaw/clawsweeper",
+      ghJson: (args) => ghJson(args, githubEnv),
+      ghWithRetry: (args) => gh(args, githubEnv),
+    });
+  const numbers = Array.from({ length: 8 }, (_, index) => index + 1);
+
+  resetRequests();
+  const v1 = context();
+  const v1SingleCursor = readStableReviewedPrActivityCursor(() =>
+    v1.fetchReviewedPrActivityCursorV1(1),
+  );
+  const v1SingleRequests = requests.length;
+
+  resetRequests();
+  const v2 = context();
+  const v2SingleCursor = readStableReviewedPrActivityCursor(() =>
+    v2.fetchReviewedPrActivityCursor(1),
+  );
+  const v2SingleRequests = requests.length;
+
+  resetRequests();
+  const v1Batch = context();
+  const v1BatchCursors = readStableReviewedPrActivityCursors(() =>
+    Object.fromEntries(
+      numbers.map((number) => [String(number), v1Batch.fetchReviewedPrActivityCursorV1(number)]),
+    ),
+  );
+  const v1BatchRequests = requests.length;
+
+  resetRequests();
+  const v2Batch = context();
+  const v2BatchCursors = readStableReviewedPrActivityCursors(() =>
+    v2Batch.fetchReviewedPrActivityCursors(numbers),
+  );
+  const v2BatchRequests = requests.length;
+
+  resetRequests();
+  await setServerMode("partial");
+  const fallback = context();
+  const telemetry = [];
+  const originalError = console.error;
+  let fallbackCursor;
+  try {
+    console.error = (line) => telemetry.push(String(line));
+    fallbackCursor = readStableReviewedPrActivityCursor(() =>
+      fallback.fetchReviewedPrActivityCursor(1),
+    );
+  } finally {
+    console.error = originalError;
+  }
+  const fallbackRequests = requests.length;
+  await setServerMode("complete");
+
+  resetRequests();
+  await setServerMode("concurrent");
+  const concurrent = context();
+  assert.throws(
+    () => readStableReviewedPrActivityCursor(() => concurrent.fetchReviewedPrActivityCursor(1)),
+    ReviewedPrActivityChangedDuringReadError,
+  );
+  const concurrentRequests = requests.length;
+  await setServerMode("complete");
+
+  assert.equal(v1SingleRequests, 6);
+  assert.equal(v2SingleRequests, 2);
+  assert.equal(v1BatchRequests, numbers.length * 6);
+  assert.equal(v2BatchRequests, 2);
+  assert.equal(fallbackCursor, v1SingleCursor);
+  assert.equal(fallbackRequests, 7);
+  assert.equal(telemetry.length, 1);
+  assert.deepEqual(JSON.parse(telemetry[0]), {
+    event: "reviewed_pr_activity_cursor_v2_fallback",
+    repo: "openclaw/clawsweeper",
+    number: 1,
+    from_version: 2,
+    to_version: 1,
+    reason: "review_comments_partial_nodes",
+  });
+  assert.equal(concurrentRequests, 2);
+  assert.match(v1SingleCursor || "", /^v1:/);
+  assert.match(v2SingleCursor || "", /^v2:/);
+  assert.equal(Object.keys(v1BatchCursors).length, numbers.length);
+  assert.equal(Object.keys(v2BatchCursors).length, numbers.length);
+
+  const receipt = {
+    schema_version: 1,
+    claim:
+      "The v2 GraphQL cursor preserves stable PR activity decisions while reducing one check from six requests to two and an eight-PR batch from forty-eight requests to two.",
+    transport: "loopback HTTP via GITHUB_API_URL and GITHUB_GRAPHQL_URL",
+    environment: { node: process.version, batch_size: numbers.length },
+    ...(process.env.PROOF_SOURCE_HEAD && process.env.PROOF_SOURCE_TREE
+      ? {
+          source: {
+            head: process.env.PROOF_SOURCE_HEAD,
+            tree: process.env.PROOF_SOURCE_TREE,
+            commit_object_verified: true,
+            tree_object_verified: true,
+          },
+        }
+      : {}),
+    requests: {
+      single: { v1: v1SingleRequests, v2: v2SingleRequests },
+      batch: { v1: v1BatchRequests, v2: v2BatchRequests },
+      fail_closed_fallback: fallbackRequests,
+      concurrent_change: concurrentRequests,
+    },
+    assertions: {
+      single_request_reduction: v1SingleRequests === 6 && v2SingleRequests === 2,
+      batch_request_reduction: v1BatchRequests === numbers.length * 6 && v2BatchRequests === 2,
+      fallback_decision_unchanged: fallbackCursor === v1SingleCursor,
+      fallback_telemetry_lines: telemetry.length,
+      concurrent_change_unstable: true,
+      double_read_preserved: v2SingleRequests === 2 && v2BatchRequests === 2,
+    },
+  };
+  if (values["output-dir"]) {
+    const outputDir = resolve(values["output-dir"]);
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(
+      resolve(outputDir, "loopback-proof-receipt.json"),
+      `${JSON.stringify(receipt, null, 2)}\n`,
+      "utf8",
+    );
+  }
+  console.log(JSON.stringify(receipt));
+} finally {
+  server.send({ kind: "close" });
+  await new Promise((resolveClose) => server.once("exit", resolveClose));
+}
+
+function resetRequests() {
+  requests.length = 0;
+}
+
+function setServerMode(mode) {
+  const id = `${mode}:${Date.now()}:${Math.random()}`;
+  return new Promise((resolveMode) => {
+    const listener = (message) => {
+      if (message?.kind !== "mode" || message.id !== id) return;
+      server.off("message", listener);
+      resolveMode();
+    };
+    server.on("message", listener);
+    server.send({ kind: "mode", mode, id });
+  });
+}
+
+function ghJson(args, env) {
+  return JSON.parse(gh(args, env));
+}
+
+function gh(args, env) {
+  assert.equal(args[0], "api");
+  const graphql = args[1] === "graphql";
+  let url;
+  let payload;
+  if (graphql) {
+    url = env.GITHUB_GRAPHQL_URL;
+    const fields = {};
+    for (let index = 2; index < args.length; index += 1) {
+      if (args[index] !== "-f" && args[index] !== "-F") continue;
+      const field = String(args[index + 1] || "");
+      index += 1;
+      const delimiter = field.indexOf("=");
+      if (delimiter <= 0) continue;
+      const key = field.slice(0, delimiter);
+      const raw = field.slice(delimiter + 1);
+      fields[key] = args[index - 1] === "-F" && /^-?\d+$/.test(raw) ? Number(raw) : raw;
+    }
+    const { query, ...variables } = fields;
+    payload = JSON.stringify({ query, variables });
+  } else {
+    url = new URL(String(args[1]), `${env.GITHUB_API_URL}/`).toString();
+  }
+  requests.push({ method: graphql ? "POST" : "GET", url });
+  const child = spawnSync(
+    "curl",
+    [
+      "--fail",
+      "--silent",
+      "--show-error",
+      ...(graphql
+        ? ["--request", "POST", "--header", "content-type: application/json", "--data", payload]
+        : []),
+      url,
+    ],
+    {
+      encoding: "utf8",
+      env,
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
+  if (child.error) throw child.error;
+  if (child.status !== 0) {
+    throw new Error(`loopback request failed: ${String(child.stderr).trim()}`);
+  }
+  return child.stdout;
+}

--- a/scripts/e2e/run-graphql-activity-cursor-v2-container.sh
+++ b/scripts/e2e/run-graphql-activity-cursor-v2-container.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node_version="24.19.0"
+case "$(uname -m)" in
+  aarch64 | arm64) node_arch="arm64" ;;
+  x86_64 | amd64) node_arch="x64" ;;
+  *)
+    echo "unsupported container architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+tool_root="/tmp/clawsweeper-graphql-activity-cursor-v2"
+node_archive="node-v${node_version}-linux-${node_arch}.tar.xz"
+mkdir -p "$tool_root/node"
+
+echo CRABBOX_PHASE:toolchain
+sudo apt-get update -qq
+sudo apt-get install -y -qq ca-certificates curl xz-utils
+curl --fail --silent --show-error --location \
+  "https://nodejs.org/dist/v${node_version}/${node_archive}" \
+  --output "$tool_root/$node_archive"
+curl --fail --silent --show-error --location \
+  "https://nodejs.org/dist/v${node_version}/SHASUMS256.txt" \
+  --output "$tool_root/SHASUMS256.txt"
+(
+  cd "$tool_root"
+  grep " ${node_archive}$" SHASUMS256.txt | sha256sum --check --strict
+)
+tar -xJf "$tool_root/$node_archive" -C "$tool_root/node" --strip-components=1
+export PATH="$tool_root/node/bin:$PATH"
+node --version
+
+echo CRABBOX_PHASE:install
+corepack enable
+pnpm install --frozen-lockfile
+
+echo CRABBOX_PHASE:build
+pnpm run build:all
+
+echo CRABBOX_PHASE:source
+PROOF_SOURCE_HEAD="$(git rev-parse HEAD)"
+git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
+PROOF_SOURCE_TREE="$(git rev-parse 'HEAD^{tree}')"
+git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+export PROOF_SOURCE_HEAD PROOF_SOURCE_TREE
+
+echo CRABBOX_PHASE:proof
+node scripts/e2e/graphql-activity-cursor-v2-loopback.mjs \
+  --output-dir .artifacts/graphql-activity-cursor-v2

--- a/scripts/e2e/run-graphql-activity-cursor-v2-container.sh
+++ b/scripts/e2e/run-graphql-activity-cursor-v2-container.sh
@@ -40,10 +40,14 @@ echo CRABBOX_PHASE:build
 pnpm run build:all
 
 echo CRABBOX_PHASE:source
-PROOF_SOURCE_HEAD="$(git rev-parse HEAD)"
-git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
-PROOF_SOURCE_TREE="$(git rev-parse 'HEAD^{tree}')"
-git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+if [[ -z "${PROOF_SOURCE_HEAD:-}" || -z "${PROOF_SOURCE_TREE:-}" ]]; then
+  PROOF_SOURCE_HEAD="$(git rev-parse HEAD)"
+  git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
+  PROOF_SOURCE_TREE="$(git rev-parse 'HEAD^{tree}')"
+  git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+fi
+[[ "$PROOF_SOURCE_HEAD" =~ ^[0-9a-f]{40}$ ]]
+[[ "$PROOF_SOURCE_TREE" =~ ^[0-9a-f]{40}$ ]]
 export PROOF_SOURCE_HEAD PROOF_SOURCE_TREE
 
 echo CRABBOX_PHASE:proof

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -68,7 +68,10 @@ import {
   isLockedConversationCommentError,
 } from "./github-retry.js";
 import { type PrCloseCoverageProofRuntime } from "./pr-close-coverage-proof.js";
-import { isReviewedPrActivityCursor } from "./review-activity-cursor.js";
+import {
+  compareReviewedPrActivityCursors,
+  isReviewedPrActivityCursor,
+} from "./review-activity-cursor.js";
 import {
   clearResolvedReviewRecoveryLabel,
   REVIEW_RECOVERY_STUCK_LABEL,
@@ -920,7 +923,10 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         return (
           item.kind !== "pull_request" ||
           (freshPullRequestReviewHead(markdownBeforeApplyDecisionMutations, context) &&
-            context.pullReviewActivityCursor === expectedReviewActivityCursor)
+            compareReviewedPrActivityCursors(
+              context.pullReviewActivityCursor,
+              expectedReviewActivityCursor,
+            ) === "equal")
         );
       };
       const currentReviewActivityBlock = createApplyReviewActivityGuard(dependencies, {

--- a/src/clawsweeper-apply-proof-freshness.ts
+++ b/src/clawsweeper-apply-proof-freshness.ts
@@ -7,7 +7,10 @@ import type {
   PrCloseCoverageProofGateBlock,
   PrCloseCoverageProofGateResult,
 } from "./clawsweeper-types.js";
-import { isReviewedPrActivityCursor } from "./review-activity-cursor.js";
+import {
+  compareReviewedPrActivityCursors,
+  isReviewedPrActivityCursor,
+} from "./review-activity-cursor.js";
 import { stableJson } from "./stable-json.js";
 
 export interface ApplySelfMutationItemReceipt {
@@ -135,8 +138,14 @@ export function createApplyProofFreshnessGuards({
         (itemKind !== "pull_request" ||
           (freshPullRequestReviewHead(reviewMarkdown, refreshedContext) &&
             isReviewedPrActivityCursor(expectedReviewActivityCursor) &&
-            receipt.reviewActivityCursor === expectedReviewActivityCursor &&
-            refreshedReviewActivityCursor === expectedReviewActivityCursor)),
+            compareReviewedPrActivityCursors(
+              receipt.reviewActivityCursor,
+              expectedReviewActivityCursor,
+            ) === "equal" &&
+            compareReviewedPrActivityCursors(
+              refreshedReviewActivityCursor,
+              expectedReviewActivityCursor,
+            ) === "equal")),
     );
     const refreshedCompleteReceiptMatchesReview = (): boolean => {
       refreshedContext ??= collectItemContext(refreshed.item, {
@@ -146,7 +155,10 @@ export function createApplyProofFreshnessGuards({
       if (!completeReviewActivityReceiptMatches(refreshedContext)) return false;
       return (
         itemKind !== "pull_request" ||
-        refreshedReviewActivityCursor === expectedReviewActivityCursor
+        compareReviewedPrActivityCursors(
+          refreshedReviewActivityCursor,
+          expectedReviewActivityCursor,
+        ) === "equal"
       );
     };
     const persistedAutomationReceiptMatches =

--- a/src/clawsweeper-apply-review-activity.ts
+++ b/src/clawsweeper-apply-review-activity.ts
@@ -2,6 +2,7 @@ import type { CreateApplyDecisionWorkflowDependencies } from "./clawsweeper-appl
 import { trimMiddle } from "./clawsweeper-text.js";
 import type { ItemKind } from "./clawsweeper-types.js";
 import {
+  compareReviewedPrActivityCursors,
   isReviewedPrActivityCursor,
   readStableReviewedPrActivityCursor,
   ReviewedPrActivityChangedDuringReadError,
@@ -28,8 +29,11 @@ export function createApplyReviewActivityGuard(
         fetchReviewedPrActivityCursor(number),
       );
       if (!currentCursor) return "pull request review activity exceeds the bounded reviewed cursor";
-      if (currentCursor !== expectedCursor)
-        return "pull request review activity changed since review";
+      const comparison = compareReviewedPrActivityCursors(expectedCursor, currentCursor);
+      if (comparison === "rebaseline") {
+        return "stored pull request review activity cursor version requires a fresh review";
+      }
+      if (comparison === "changed") return "pull request review activity changed since review";
       return null;
     } catch (error) {
       if (error instanceof GitHubRuntimeBudgetError) throw error;

--- a/src/clawsweeper-github-context.ts
+++ b/src/clawsweeper-github-context.ts
@@ -1,9 +1,12 @@
 import { parseGhJson } from "./github-json.js";
 import { exactPublicationPublicReadToken } from "./github-public-read.js";
+import { ghRetryKind } from "./github-retry.js";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
   REVIEWED_PR_ACTIVITY_THREADS_QUERY,
   createReviewedPrActivityCursor,
+  reviewedPrActivityCursorV2Query,
+  reviewedPrActivityCursorsV2FromGraphql,
   reviewedPrActivityThreadsPageFromGraphql,
 } from "./review-activity-cursor.js";
 import type {
@@ -23,6 +26,8 @@ export function createGitHubContext({
   ghWithRetry,
   targetRepo,
 }: GitHubContextDependencies) {
+  const reviewedPrActivityV2Fallbacks = new Map<number, string>();
+
   function githubPaginatedPath(path: string): string {
     const [basePart, query = ""] = path.split("?", 2);
     const base = basePart ?? path;
@@ -103,7 +108,7 @@ export function createGitHubContext({
     return threads.slice(0, max);
   }
 
-  function fetchReviewedPrActivityCursor(
+  function fetchReviewedPrActivityCursorV1(
     number: number,
     prefetchedInlineComments?: unknown[],
   ): string | null {
@@ -123,6 +128,75 @@ export function createGitHubContext({
       inlineComments.length === 0 ? [] : reviewedPrActivityThreads(number, remaining + 1);
     if (reviewThreads.length > remaining) return null;
     return createReviewedPrActivityCursor({ reviews, inlineComments, reviewThreads });
+  }
+
+  function fetchReviewedPrActivityCursors(
+    numbers: readonly number[],
+    prefetchedInlineComments: ReadonlyMap<number, readonly unknown[]> = new Map(),
+  ): Record<string, string | null> {
+    const uniqueNumbers = [...new Set(numbers)].sort((left, right) => left - right);
+    const cursors: Record<string, string | null> = {};
+    const v2Numbers = uniqueNumbers.filter((number) => !reviewedPrActivityV2Fallbacks.has(number));
+    if (v2Numbers.length > 0) {
+      const [owner, name] = targetRepo().split("/");
+      if (!owner || !name) throw new Error(`invalid target repository: ${targetRepo()}`);
+      const query = reviewedPrActivityCursorV2Query(owner, name, v2Numbers);
+      try {
+        const batch = reviewedPrActivityCursorsV2FromGraphql(
+          ghJson<unknown>(["api", "graphql", "-f", `query=${query}`]),
+          v2Numbers,
+        );
+        for (const number of v2Numbers) {
+          const key = String(number);
+          const failure = batch.failures[key];
+          if (failure) {
+            activateReviewedPrActivityV1Fallback(number, failure);
+            continue;
+          }
+          cursors[key] = batch.cursors[key] ?? null;
+        }
+      } catch (error) {
+        if (ghRetryKind(error) !== "none") throw error;
+        for (const number of v2Numbers) {
+          activateReviewedPrActivityV1Fallback(number, "graphql_request_failed");
+        }
+      }
+    }
+    for (const number of uniqueNumbers) {
+      const key = String(number);
+      if (!reviewedPrActivityV2Fallbacks.has(number)) continue;
+      const prefetched = prefetchedInlineComments.get(number);
+      cursors[key] = fetchReviewedPrActivityCursorV1(
+        number,
+        prefetched ? [...prefetched] : undefined,
+      );
+    }
+    return cursors;
+  }
+
+  function activateReviewedPrActivityV1Fallback(number: number, reason: string): void {
+    if (reviewedPrActivityV2Fallbacks.has(number)) return;
+    reviewedPrActivityV2Fallbacks.set(number, reason);
+    console.error(
+      JSON.stringify({
+        event: "reviewed_pr_activity_cursor_v2_fallback",
+        repo: targetRepo(),
+        number,
+        from_version: 2,
+        to_version: 1,
+        reason,
+      }),
+    );
+  }
+
+  function fetchReviewedPrActivityCursor(
+    number: number,
+    prefetchedInlineComments?: unknown[],
+  ): string | null {
+    const prefetched = prefetchedInlineComments
+      ? new Map<number, readonly unknown[]>([[number, prefetchedInlineComments]])
+      : undefined;
+    return fetchReviewedPrActivityCursors([number], prefetched)[String(number)] ?? null;
   }
 
   function ghPage<T>(path: string, page: number): T[] {
@@ -313,6 +387,8 @@ export function createGitHubContext({
 
   return {
     fetchReviewedPrActivityCursor,
+    fetchReviewedPrActivityCursorV1,
+    fetchReviewedPrActivityCursors,
     ghPaged,
     ghPagedContextWindow,
     ghPagedLimit,

--- a/src/clawsweeper-review-planning-hot-intake.ts
+++ b/src/clawsweeper-review-planning-hot-intake.ts
@@ -1,5 +1,6 @@
 import type { ExistingReview, Item } from "./clawsweeper-types.js";
 import {
+  compareReviewedPrActivityCursors,
   isReviewedPrActivityCursor,
   readStableReviewedPrActivityCursor,
 } from "./review-activity-cursor.js";
@@ -110,7 +111,12 @@ export function createReviewPlanningHotIntake(
       const revalidatedReviewActivityCursor = readStableReviewedPrActivityCursor(() =>
         fetchReviewedPrActivityCursor(item.number),
       );
-      if (revalidatedReviewActivityCursor !== reviewActivityCursor) return null;
+      if (
+        compareReviewedPrActivityCursors(revalidatedReviewActivityCursor, reviewActivityCursor) !==
+        "equal"
+      ) {
+        return null;
+      }
       return {
         headSha,
         sourceRevision: itemSourceRevisionSha256(pull, comments),
@@ -161,7 +167,10 @@ export function createReviewPlanningHotIntake(
       current.headSha === reviewed.headSha &&
       current.sourceRevision === reviewed.sourceRevision &&
       current.pullStateDigest === reviewed.pullStateDigest &&
-      current.reviewActivityCursor === reviewed.reviewActivityCursor
+      compareReviewedPrActivityCursors(
+        current.reviewActivityCursor,
+        reviewed.reviewActivityCursor,
+      ) === "equal"
     );
   }
   function shouldSkipScheduledHotIntakeExactReviewForTest(options: {
@@ -222,7 +231,10 @@ export function createReviewPlanningHotIntake(
       reviewed.headSha === options.currentHeadSha.trim().toLowerCase() &&
       reviewed.sourceRevision === options.currentSourceRevision.trim() &&
       reviewed.pullStateDigest === options.currentPullStateDigest.trim() &&
-      reviewed.reviewActivityCursor === options.currentReviewActivityCursor.trim()
+      compareReviewedPrActivityCursors(
+        reviewed.reviewActivityCursor,
+        options.currentReviewActivityCursor.trim(),
+      ) === "equal"
     );
   }
 

--- a/src/review-activity-cursor.ts
+++ b/src/review-activity-cursor.ts
@@ -4,8 +4,10 @@ import { stableJsonCodeUnit } from "./stable-json.js";
 
 export const MAX_REVIEWED_PR_ACTIVITY = 1_000;
 export const MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES = 1024 * 1024;
+export const MAX_REVIEWED_PR_ACTIVITY_BATCH_SIZE = 8;
+export const REVIEWED_PR_ACTIVITY_V2_CONNECTION_LIMIT = 100;
 
-const CURSOR_PATTERN = /^v1:([0-9]+):([0-9a-f]{64})$/;
+const CURSOR_PATTERN = /^v([12]):([0-9]+):([0-9a-f]{64})$/;
 
 export const REVIEWED_PR_ACTIVITY_THREADS_QUERY = `
   query ReviewedPrActivityThreads(
@@ -37,6 +39,13 @@ export interface ReviewedPrActivityThreadsPage {
   endCursor: string | null;
 }
 
+export interface ReviewedPrActivityCursorV2Batch {
+  cursors: Record<string, string | null>;
+  failures: Record<string, string>;
+}
+
+export type ReviewedPrActivityCursorComparison = "equal" | "changed" | "rebaseline";
+
 export class ReviewedPrActivityChangedDuringReadError extends Error {
   constructor() {
     super("pull request review activity changed while refreshing the bounded cursor");
@@ -49,6 +58,25 @@ export function createReviewedPrActivityCursor(options: {
   inlineComments: unknown[];
   reviewThreads: unknown[];
 }): string | null {
+  return createVersionedReviewedPrActivityCursor("v1", options);
+}
+
+export function createReviewedPrActivityCursorV2(options: {
+  reviews: unknown[];
+  inlineComments: unknown[];
+  reviewThreads: unknown[];
+}): string | null {
+  return createVersionedReviewedPrActivityCursor("v2", options);
+}
+
+function createVersionedReviewedPrActivityCursor(
+  version: "v1" | "v2",
+  options: {
+    reviews: unknown[];
+    inlineComments: unknown[];
+    reviewThreads: unknown[];
+  },
+): string | null {
   if (
     options.reviews.length + options.inlineComments.length + options.reviewThreads.length >
     MAX_REVIEWED_PR_ACTIVITY
@@ -63,7 +91,7 @@ export function createReviewedPrActivityCursor(options: {
   entries.sort(compareCodeUnits);
   const canonical = `[${entries.join(",")}]`;
   if (Buffer.byteLength(canonical, "utf8") > MAX_REVIEWED_PR_ACTIVITY_CURSOR_BYTES) return null;
-  return `v1:${entries.length}:${createHash("sha256").update(canonical).digest("hex")}`;
+  return `${version}:${entries.length}:${createHash("sha256").update(canonical).digest("hex")}`;
 }
 
 export function readStableReviewedPrActivityCursor(readCursor: () => string | null): string | null {
@@ -73,12 +101,144 @@ export function readStableReviewedPrActivityCursor(readCursor: () => string | nu
   return second;
 }
 
+export function readStableReviewedPrActivityCursors(
+  readCursors: () => Readonly<Record<string, string | null>>,
+): Record<string, string | null> {
+  const first = readCursors();
+  const second = readCursors();
+  const keys = new Set([...Object.keys(first), ...Object.keys(second)]);
+  for (const key of keys) {
+    if (!Object.hasOwn(first, key) || !Object.hasOwn(second, key) || first[key] !== second[key]) {
+      throw new ReviewedPrActivityChangedDuringReadError();
+    }
+  }
+  return { ...second };
+}
+
 export function isReviewedPrActivityCursor(value: unknown): value is string {
   if (typeof value !== "string") return false;
   const match = value.match(CURSOR_PATTERN);
   if (!match) return false;
-  const count = Number(match[1]);
+  const count = Number(match[2]);
   return Number.isSafeInteger(count) && count >= 0 && count <= MAX_REVIEWED_PR_ACTIVITY;
+}
+
+export function reviewedPrActivityCursorVersion(value: unknown): 1 | 2 | null {
+  if (!isReviewedPrActivityCursor(value)) return null;
+  return value.startsWith("v1:") ? 1 : 2;
+}
+
+export function compareReviewedPrActivityCursors(
+  left: unknown,
+  right: unknown,
+): ReviewedPrActivityCursorComparison {
+  const leftVersion = reviewedPrActivityCursorVersion(left);
+  const rightVersion = reviewedPrActivityCursorVersion(right);
+  if (leftVersion === null || rightVersion === null) return "changed";
+  // GraphQL omits REST's immutable side/start_side fields. Re-baseline stored
+  // v1 reports explicitly instead of claiming the independently hashed v2
+  // representation proves either equality or activity drift.
+  if (leftVersion !== rightVersion) return "rebaseline";
+  return left === right ? "equal" : "changed";
+}
+
+export function reviewedPrActivityCursorV2Query(
+  owner: string,
+  name: string,
+  numbers: readonly number[],
+): string {
+  if (!validGraphqlName(owner) || !validGraphqlName(name)) {
+    throw new Error("invalid repository for reviewed PR activity v2 query");
+  }
+  const uniqueNumbers = validatedBatchNumbers(numbers);
+  const pullRequests = uniqueNumbers
+    .map(
+      (number) => `pr_${number}: pullRequest(number: ${number}) {
+        reviews(first: ${REVIEWED_PR_ACTIVITY_V2_CONNECTION_LIMIT}) {
+          totalCount
+          pageInfo { hasNextPage }
+          nodes {
+            fullDatabaseId
+            author { login }
+            state
+            body
+            submittedAt
+            commit { oid }
+          }
+        }
+        reviewThreads(first: ${REVIEWED_PR_ACTIVITY_V2_CONNECTION_LIMIT}) {
+          totalCount
+          pageInfo { hasNextPage }
+          nodes {
+            id
+            isResolved
+            comments(first: ${REVIEWED_PR_ACTIVITY_V2_CONNECTION_LIMIT}) {
+              totalCount
+              pageInfo { hasNextPage }
+              nodes {
+                fullDatabaseId
+                pullRequestReview { fullDatabaseId }
+                replyTo { fullDatabaseId }
+                author { login }
+                body
+                createdAt
+                updatedAt
+                path
+                line
+                startLine
+                originalLine
+                originalCommit { oid }
+                commit { oid }
+              }
+            }
+          }
+        }
+      }`,
+    )
+    .join("\n");
+  return `query ReviewedPrActivityCursorV2 {
+    repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {
+      ${pullRequests}
+    }
+  }`;
+}
+
+export function reviewedPrActivityCursorsV2FromGraphql(
+  value: unknown,
+  numbers: readonly number[],
+): ReviewedPrActivityCursorV2Batch {
+  const uniqueNumbers = validatedBatchNumbers(numbers);
+  const cursors: Record<string, string | null> = Object.fromEntries(
+    uniqueNumbers.map((number) => [String(number), null]),
+  );
+  const failures: Record<string, string> = {};
+  const response = record(value);
+  if (Array.isArray(response.errors) && response.errors.length > 0) {
+    for (const number of uniqueNumbers) failures[String(number)] = "graphql_errors";
+    return { cursors, failures };
+  }
+  if (!hasOwn(response, "data")) {
+    for (const number of uniqueNumbers) failures[String(number)] = "missing_data";
+    return { cursors, failures };
+  }
+  const data = record(response.data);
+  if (!hasOwn(data, "repository")) {
+    for (const number of uniqueNumbers) failures[String(number)] = "missing_repository";
+    return { cursors, failures };
+  }
+  const repository = record(data.repository);
+  for (const number of uniqueNumbers) {
+    const key = String(number);
+    const alias = `pr_${number}`;
+    if (!hasOwn(repository, alias) || repository[alias] === null) {
+      failures[key] = "missing_pull_request";
+      continue;
+    }
+    const decoded = decodeReviewedPrActivityCursorV2(repository[alias]);
+    if (typeof decoded === "string") failures[key] = decoded;
+    else cursors[key] = decoded.cursor;
+  }
+  return { cursors, failures };
 }
 
 export function reviewedPrActivityThreadsPageFromGraphql(
@@ -105,6 +265,203 @@ export function reviewedPrActivityThreadsPageFromGraphql(
   const endCursor = typeof pageInfo.endCursor === "string" ? pageInfo.endCursor : null;
   if (pageInfo.hasNextPage && !endCursor) return null;
   return { threads, hasNextPage: pageInfo.hasNextPage, endCursor };
+}
+
+function decodeReviewedPrActivityCursorV2(value: unknown): { cursor: string | null } | string {
+  const pullRequest = record(value);
+  if (!hasOwn(pullRequest, "reviews") || !hasOwn(pullRequest, "reviewThreads")) {
+    return "missing_connections";
+  }
+  const reviewNodes = completeConnectionNodes(pullRequest.reviews);
+  if (typeof reviewNodes === "string") return `reviews_${reviewNodes}`;
+  const threadNodes = completeConnectionNodes(pullRequest.reviewThreads);
+  if (typeof threadNodes === "string") return `review_threads_${threadNodes}`;
+
+  const reviews: unknown[] = [];
+  for (const value of reviewNodes) {
+    const review = record(value);
+    if (
+      !requiredKeys(review, [
+        "fullDatabaseId",
+        "author",
+        "state",
+        "body",
+        "submittedAt",
+        "commit",
+      ]) ||
+      !databaseId(review.fullDatabaseId) ||
+      typeof review.state !== "string" ||
+      typeof review.body !== "string" ||
+      !nullableString(review.submittedAt) ||
+      !nullableLogin(review.author) ||
+      !nullableOid(review.commit)
+    ) {
+      return "invalid_review_node";
+    }
+    reviews.push({
+      id: scalar(review.fullDatabaseId),
+      user: { login: nullableLoginValue(review.author) },
+      state: review.state,
+      body: review.body,
+      submitted_at: review.submittedAt,
+      commit_id: nullableOidValue(review.commit),
+    });
+  }
+
+  const inlineComments: unknown[] = [];
+  const reviewThreads: unknown[] = [];
+  for (const value of threadNodes) {
+    const thread = record(value);
+    if (
+      !requiredKeys(thread, ["id", "isResolved", "comments"]) ||
+      typeof thread.id !== "string" ||
+      thread.id.length === 0 ||
+      typeof thread.isResolved !== "boolean"
+    ) {
+      return "invalid_review_thread_node";
+    }
+    const commentNodes = completeConnectionNodes(thread.comments);
+    if (typeof commentNodes === "string") return `review_comments_${commentNodes}`;
+    reviewThreads.push({ id: thread.id, isResolved: thread.isResolved });
+    for (const commentValue of commentNodes) {
+      const comment = record(commentValue);
+      if (
+        !requiredKeys(comment, [
+          "fullDatabaseId",
+          "pullRequestReview",
+          "replyTo",
+          "author",
+          "body",
+          "createdAt",
+          "updatedAt",
+          "path",
+          "line",
+          "startLine",
+          "originalLine",
+          "originalCommit",
+          "commit",
+        ]) ||
+        !databaseId(comment.fullDatabaseId) ||
+        !nullableDatabaseIdObject(comment.pullRequestReview) ||
+        !nullableDatabaseIdObject(comment.replyTo) ||
+        !nullableLogin(comment.author) ||
+        typeof comment.body !== "string" ||
+        typeof comment.createdAt !== "string" ||
+        typeof comment.updatedAt !== "string" ||
+        typeof comment.path !== "string" ||
+        !nullableInteger(comment.line) ||
+        !nullableInteger(comment.startLine) ||
+        !nullableInteger(comment.originalLine) ||
+        !nullableOid(comment.originalCommit) ||
+        !nullableOid(comment.commit)
+      ) {
+        return "invalid_review_comment_node";
+      }
+      inlineComments.push({
+        id: scalar(comment.fullDatabaseId),
+        pull_request_review_id: nullableDatabaseIdValue(comment.pullRequestReview),
+        in_reply_to_id: nullableDatabaseIdValue(comment.replyTo),
+        user: { login: nullableLoginValue(comment.author) },
+        body: comment.body,
+        created_at: comment.createdAt,
+        updated_at: comment.updatedAt,
+        path: comment.path,
+        line: comment.line,
+        start_line: comment.startLine,
+        original_line: comment.originalLine,
+        original_commit_id: nullableOidValue(comment.originalCommit),
+        commit_id: nullableOidValue(comment.commit),
+      });
+    }
+  }
+
+  return {
+    cursor: createReviewedPrActivityCursorV2({ reviews, inlineComments, reviewThreads }),
+  };
+}
+
+function completeConnectionNodes(value: unknown): unknown[] | string {
+  const connection = record(value);
+  if (!requiredKeys(connection, ["totalCount", "pageInfo", "nodes"])) return "missing_fields";
+  const pageInfo = record(connection.pageInfo);
+  if (!hasOwn(pageInfo, "hasNextPage") || pageInfo.hasNextPage !== false) {
+    return pageInfo.hasNextPage === true ? "truncated" : "invalid_page_info";
+  }
+  if (!Number.isSafeInteger(connection.totalCount) || Number(connection.totalCount) < 0) {
+    return "invalid_total_count";
+  }
+  if (!Array.isArray(connection.nodes)) return "invalid_nodes";
+  if (connection.nodes.length !== Number(connection.totalCount)) return "partial_nodes";
+  return connection.nodes;
+}
+
+function validatedBatchNumbers(numbers: readonly number[]): number[] {
+  const unique = [...new Set(numbers)];
+  if (unique.length > MAX_REVIEWED_PR_ACTIVITY_BATCH_SIZE) {
+    throw new Error(
+      `reviewed PR activity v2 batch exceeds ${MAX_REVIEWED_PR_ACTIVITY_BATCH_SIZE} pull requests`,
+    );
+  }
+  if (unique.some((number) => !Number.isSafeInteger(number) || number <= 0)) {
+    throw new Error("reviewed PR activity v2 batch contains an invalid pull request number");
+  }
+  return unique.sort((left, right) => left - right);
+}
+
+function requiredKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => hasOwn(value, key));
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function databaseId(value: unknown): boolean {
+  return (
+    (typeof value === "string" && /^[1-9][0-9]*$/.test(value)) ||
+    (Number.isSafeInteger(value) && Number(value) > 0)
+  );
+}
+
+function nullableDatabaseIdObject(value: unknown): boolean {
+  return (
+    value === null ||
+    (hasOwn(record(value), "fullDatabaseId") && databaseId(record(value).fullDatabaseId))
+  );
+}
+
+function nullableDatabaseIdValue(value: unknown): string {
+  return value === null ? "" : scalar(record(value).fullDatabaseId);
+}
+
+function nullableLogin(value: unknown): boolean {
+  return (
+    value === null || (hasOwn(record(value), "login") && typeof record(value).login === "string")
+  );
+}
+
+function nullableLoginValue(value: unknown): string {
+  return value === null ? "" : scalar(record(value).login);
+}
+
+function nullableOid(value: unknown): boolean {
+  return value === null || (hasOwn(record(value), "oid") && typeof record(value).oid === "string");
+}
+
+function nullableOidValue(value: unknown): string {
+  return value === null ? "" : scalar(record(value).oid);
+}
+
+function nullableString(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
+function nullableInteger(value: unknown): boolean {
+  return value === null || Number.isSafeInteger(value);
+}
+
+function validGraphqlName(value: string): boolean {
+  return /^[A-Za-z0-9_.-]+$/.test(value);
 }
 
 function compactReviewActivity(kind: "review" | "inline_comment", value: unknown) {

--- a/test/graphql-activity-cursor-v2-loopback.test.ts
+++ b/test/graphql-activity-cursor-v2-loopback.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("GraphQL activity cursor v2 loopback proves request reductions and fallback", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/e2e/graphql-activity-cursor-v2-loopback.mjs"],
+    {
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const receipt = JSON.parse(result.stdout.trim());
+  assert.deepEqual(receipt.requests.single, { v1: 6, v2: 2 });
+  assert.deepEqual(receipt.requests.batch, { v1: 48, v2: 2 });
+  assert.equal(receipt.assertions.fallback_decision_unchanged, true);
+  assert.equal(receipt.assertions.fallback_telemetry_lines, 1);
+  assert.equal(receipt.assertions.concurrent_change_unstable, true);
+});

--- a/test/review-activity-cursor.test.ts
+++ b/test/review-activity-cursor.test.ts
@@ -2,14 +2,128 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 
+import { createApplyReviewActivityGuard } from "../dist/clawsweeper-apply-review-activity.js";
 import {
   MAX_REVIEWED_PR_ACTIVITY,
   ReviewedPrActivityChangedDuringReadError,
+  compareReviewedPrActivityCursors,
   createReviewedPrActivityCursor,
   isReviewedPrActivityCursor,
   readStableReviewedPrActivityCursor,
+  readStableReviewedPrActivityCursors,
+  reviewedPrActivityCursorV2Query,
+  reviewedPrActivityCursorsV2FromGraphql,
   reviewedPrActivityThreadsPageFromGraphql,
 } from "../dist/review-activity-cursor.js";
+
+function v1Cursor(options: {
+  reviewState?: string;
+  inlineBody?: string;
+  inlineUpdatedAt?: string;
+  threadResolved?: boolean;
+}) {
+  return createReviewedPrActivityCursor({
+    reviews: [
+      {
+        id: 11,
+        user: { login: "reviewer" },
+        state: options.reviewState ?? "APPROVED",
+        body: "review body",
+        submitted_at: "2026-08-13T10:00:00Z",
+        commit_id: "a".repeat(40),
+      },
+    ],
+    inlineComments: [
+      {
+        id: 21,
+        pull_request_review_id: 11,
+        in_reply_to_id: null,
+        user: { login: "reviewer" },
+        body: options.inlineBody ?? "inline body",
+        created_at: "2026-08-13T10:01:00Z",
+        updated_at: options.inlineUpdatedAt ?? "2026-08-13T10:01:00Z",
+        path: "src/example.ts",
+        line: 12,
+        side: "RIGHT",
+        start_line: null,
+        start_side: null,
+        original_line: 12,
+        original_commit_id: "a".repeat(40),
+        commit_id: "a".repeat(40),
+      },
+    ],
+    reviewThreads: [{ id: "thread-1", isResolved: options.threadResolved ?? false }],
+  });
+}
+
+function v2Response(
+  options: {
+    reviewState?: string;
+    inlineBody?: string;
+    inlineUpdatedAt?: string;
+    threadResolved?: boolean;
+  } = {},
+) {
+  return {
+    data: {
+      repository: {
+        pr_42: {
+          reviews: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                fullDatabaseId: "11",
+                author: { login: "reviewer" },
+                state: options.reviewState ?? "APPROVED",
+                body: "review body",
+                submittedAt: "2026-08-13T10:00:00Z",
+                commit: { oid: "a".repeat(40) },
+              },
+            ],
+          },
+          reviewThreads: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                id: "thread-1",
+                isResolved: options.threadResolved ?? false,
+                comments: {
+                  totalCount: 1,
+                  pageInfo: { hasNextPage: false },
+                  nodes: [
+                    {
+                      fullDatabaseId: "21",
+                      pullRequestReview: { fullDatabaseId: "11" },
+                      replyTo: null,
+                      author: { login: "reviewer" },
+                      body: options.inlineBody ?? "inline body",
+                      createdAt: "2026-08-13T10:01:00Z",
+                      updatedAt: options.inlineUpdatedAt ?? "2026-08-13T10:01:00Z",
+                      path: "src/example.ts",
+                      line: 12,
+                      startLine: null,
+                      originalLine: 12,
+                      originalCommit: { oid: "a".repeat(40) },
+                      commit: { oid: "a".repeat(40) },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+function v2Cursor(options: Parameters<typeof v2Response>[0] = {}) {
+  const decoded = reviewedPrActivityCursorsV2FromGraphql(v2Response(options), [42]);
+  assert.deepEqual(decoded.failures, {});
+  return decoded.cursors["42"] ?? null;
+}
 
 test("review activity cursor binds reviews, inline comments, and thread state", () => {
   const baseline = createReviewedPrActivityCursor({
@@ -68,6 +182,111 @@ test("stable refresh rejects interleaved activity", () => {
     () => readStableReviewedPrActivityCursor(() => cursors[reads++] ?? null),
     ReviewedPrActivityChangedDuringReadError,
   );
+});
+
+test("v1 and v2 agree on activity and stability decisions", () => {
+  const v1Baseline = v1Cursor({});
+  const v2Baseline = v2Cursor();
+  assert.ok(v1Baseline);
+  assert.ok(v2Baseline);
+
+  for (const changed of [
+    { inlineBody: "edited inline body", inlineUpdatedAt: "2026-08-13T10:02:00Z" },
+    { reviewState: "DISMISSED" },
+    { threadResolved: true },
+  ]) {
+    assert.notEqual(v1Cursor(changed), v1Baseline);
+    assert.notEqual(v2Cursor(changed), v2Baseline);
+  }
+
+  const changedHead = "b".repeat(40);
+  const v1ForcePushChanged = v1Cursor({}) !== v1Baseline || changedHead !== "a".repeat(40);
+  const v2ForcePushChanged = v2Cursor() !== v2Baseline || changedHead !== "a".repeat(40);
+  assert.equal(v1ForcePushChanged, true);
+  assert.equal(v2ForcePushChanged, v1ForcePushChanged);
+
+  for (const cursors of [
+    [v1Baseline, v1Cursor({ reviewState: "DISMISSED" })],
+    [v2Baseline, v2Cursor({ reviewState: "DISMISSED" })],
+  ]) {
+    let reads = 0;
+    assert.throws(
+      () => readStableReviewedPrActivityCursor(() => cursors[reads++] ?? null),
+      ReviewedPrActivityChangedDuringReadError,
+    );
+  }
+});
+
+test("v1 to v2 migration explicitly re-baselines instead of reporting activity change", () => {
+  assert.equal(compareReviewedPrActivityCursors(v1Cursor({}), v2Cursor()), "rebaseline");
+  assert.equal(compareReviewedPrActivityCursors(v1Cursor({}), v1Cursor({})), "equal");
+  assert.equal(compareReviewedPrActivityCursors(v2Cursor(), v2Cursor()), "equal");
+
+  const guard = createApplyReviewActivityGuard(
+    {
+      fetchReviewedPrActivityCursor: () => v2Cursor(),
+      GitHubRuntimeBudgetError: class GitHubRuntimeBudgetError extends Error {
+        readonly reason = "test";
+      },
+    },
+    { expectedCursor: v1Cursor({}) ?? undefined, itemKind: "pull_request", number: 42 },
+  );
+  assert.equal(
+    guard(),
+    "stored pull request review activity cursor version requires a fresh review",
+  );
+});
+
+test("v2 query aliases a bounded PR batch and decoder fails closed", () => {
+  const query = reviewedPrActivityCursorV2Query(
+    "openclaw",
+    "clawsweeper",
+    Array.from({ length: 8 }, (_, index) => index + 1),
+  );
+  assert.equal([...query.matchAll(/pr_(\d+): pullRequest/g)].length, 8);
+  assert.match(query, /reviews\(first: 100\)/);
+  assert.match(query, /reviewThreads\(first: 100\)/);
+  assert.match(query, /comments\(first: 100\)/);
+  assert.throws(
+    () =>
+      reviewedPrActivityCursorV2Query(
+        "openclaw",
+        "clawsweeper",
+        Array.from({ length: 9 }, (_, index) => index + 1),
+      ),
+    /exceeds 8/,
+  );
+
+  const truncated = v2Response();
+  truncated.data.repository.pr_42.reviews.pageInfo.hasNextPage = true;
+  assert.equal(
+    reviewedPrActivityCursorsV2FromGraphql(truncated, [42]).failures["42"],
+    "reviews_truncated",
+  );
+  const partial = v2Response();
+  delete (
+    partial.data.repository.pr_42.reviewThreads.nodes[0]!.comments.nodes[0] as Record<
+      string,
+      unknown
+    >
+  ).updatedAt;
+  assert.equal(
+    reviewedPrActivityCursorsV2FromGraphql(partial, [42]).failures["42"],
+    "invalid_review_comment_node",
+  );
+});
+
+test("batched stability keeps the two-read invariant", () => {
+  const stable = v2Cursor();
+  let reads = 0;
+  assert.deepEqual(
+    readStableReviewedPrActivityCursors(() => {
+      reads += 1;
+      return { "42": stable };
+    }),
+    { "42": stable },
+  );
+  assert.equal(reads, 2);
 });
 
 test("review thread pages parse fail-closed", () => {


### PR DESCRIPTION
## What Problem This Solves

The ranked GitHub quota analysis found PR activity revalidation as the largest bounded savings opportunity: `repository_actions:reviews` accounted for 37,144 observed operations (12.0% of the supplied total), while comments accounted for 74,787 (24.1%) and include the PR-inline share. The hot path was `fetchReviewedPrActivityCursor` fanning out to reviews REST, inline review-comments REST, and GraphQL review threads (`src/clawsweeper-github-context.ts:71-125` on the analyzed base), while `readStableReviewedPrActivityCursor` intentionally read that complete unit twice (`src/review-activity-cursor.ts:69-73`). Apply repeats the stability check at lease and mutation boundaries (`src/clawsweeper-apply-review-activity.ts:15-45`, `src/clawsweeper-apply-lease-guards.ts:170-205,251-257`).

Before: one stable check was `2 × (reviews REST + inline-comments REST + review-threads GraphQL) = 6+ requests`. A batch of N PRs was `N × 6+` requests.

After: one stable check is `2 × one complete GraphQL snapshot = 2 requests`. A publication batch of up to eight PRs can alias every PR into the same two snapshots, so its formula is also 2 requests.

## Why This Change Was Made

This adds a versioned v2 cursor built from one bounded GraphQL query containing reviews, nested inline review comments, and review-thread resolution state. The decoder rejects GraphQL errors, missing fields, partial node sets, and any paginated connection; that PR then uses the complete v1 reader and emits one structured fallback line. Throttle and transient failures still propagate instead of amplifying an outage with REST fan-out.

The two-read invariant is unchanged for both single and batched reads. No apply freshness, lease, or mutation boundary was removed.

Migration uses an explicit re-baseline. GitHub GraphQL does not expose REST's immutable `side` and `start_side` fields, so a persisted v1 cursor and a live v2 cursor are never treated as directly equal or changed. The comparison returns `rebaseline`, apply reports that the cursor version requires a fresh review, and the next review persists v2. This avoids a spurious “activity changed” result.

## User Impact

Operators retain the same conservative PR-activity safety decisions while moving the normal activity check off the REST installation pool and reducing its request count from at least six to two. Oversized or incomplete GraphQL snapshots keep the previous complete behavior.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes internal GitHub read transport and cursor comparison only; Bay's observer-only lanes, public fields, and no-action boundary do not change.

## Documentation Lifecycle

`docs/github-egress-telemetry.md` remains active operator documentation and now describes the v2 request unit and fallback. `docs/proof/graphql-activity-cursor-v2/` is a historical proof artifact with its owner, tested source, update triggers, limits, and a static verification recipe.

## Evidence

- `pnpm run check` passed on final PR head `b7b77bd816d07e17839d7ccc2342912ff991994e`, including `check:dashboard-strict`, all builds, linters, 257 test files, and coverage gates.
- Focused equivalence fixtures cover inline-comment edits, review dismissal, thread resolution, force-push handling, and activity arriving between the two reads. v1 and v2 agree on each stability/activity decision.
- Loopback request counting through `GITHUB_API_URL` plus a GraphQL endpoint stub proves single `6 → 2` and eight-PR batch `48 → 2`.
- Partial nested GraphQL data proves fail-closed v1 fallback, an unchanged decision, and exactly one `reviewed_pr_activity_cursor_v2_fallback` line.
- Pre-commit and committed-branch Codex autoreviews both completed with no accepted/actionable findings.

## Real Behavior Proof

**Claim:** v2 preserves the stable activity decision while replacing each normal three-endpoint snapshot with one GraphQL request, including the size-eight alias path.

**Exercised surface:** the production query builder, decoder, `createGitHubContext` v2/v1 selection, single and batch stability wrappers, and structured fallback telemetry.

**Scenario:** an isolated loopback GitHub API serves reviews, inline comments, and threads; the harness runs unchanged, edited, dismissed, resolved, force-pushed, partial, and concurrent-change fixtures. The same scenario runs both the v1 and v2 readers and counts every request.

**Command and environment:** Docker-backed Crabbox `provider=local-container`, lease `cbx_d96385e7eb89`, Ubuntu 26.04/arm64, Node 24.19.0, pnpm 11.10.0. The checked-in container wrapper performs a checksummed Node install, builds all TypeScript targets, verifies the supplied Git commit/tree objects, and runs `scripts/e2e/graphql-activity-cursor-v2-loopback.mjs`.

**Observed result:** exit 0; single v1/v2 counts 6/2; batch v1/v2 counts 48/2; fallback decision unchanged; one fallback telemetry line; concurrent change unstable; both single and batch v2 paths made exactly two reads. Crabbox auto-stopped the one-shot lease.

**Artifact/trace:** [`docs/proof/graphql-activity-cursor-v2/README.md`](docs/proof/graphql-activity-cursor-v2/README.md) and [`receipt.json`](docs/proof/graphql-activity-cursor-v2/receipt.json). The receipt binds tested code head `221ba1c2cd159dfbc7c2e5a5fb12dbad73467bd7` and tree `0f041426798f21da69efd4214bcc2912672db3e2`; the final PR head adds only the proof directory, which the committed static recipe verifies.

**Limits:** the proof uses deterministic loopback fixtures, not live GitHub mutations. Connections beyond 100 reviews, 100 threads, or 100 comments per thread intentionally fall back to v1. Actual GitHub latency and quota-reset behavior are not measured.
