### PR TITLE
fix(apply): comment-only sync defers on GitHub rate limit instead of failing the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 ### Changed
 
 - Folder reconciliation now defers with a zero-mutation result when the open-state scan hits GitHub rate limiting, so throttled proof/apply/publish runs proceed to their close and publication work instead of failing before `Apply close proposals` can run.
+- Comment-only sync now defers its remaining batch as a runtime-budget-style yield when GitHub rate limits a live read, instead of failing the scheduled run; the next 15-minute cycle resumes the interrupted item, and close-mode apply keeps its loud failure.
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/src/clawsweeper-command-operations.ts
+++ b/src/clawsweeper-command-operations.ts
@@ -32,6 +32,7 @@ import type {
   ReviewStartStatusCommentResult,
 } from "./clawsweeper-types.js";
 import { UserFacingCommandError } from "./command.js";
+import { GitHubRateLimitError } from "./github-retry.js";
 import { syncDecisionPacketRecord } from "./decision-packets.js";
 import { captureCanonicalRecordBaseline } from "./repair/canonical-record-baseline.js";
 import { type RepositoryProfile } from "./repository-profiles.js";
@@ -567,6 +568,19 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
       } catch (error) {
         if (error instanceof GitHubRuntimeBudgetError && runtimeBudget.onYield) {
           runtimeBudget.onYield(error.reason);
+          return;
+        }
+        if (
+          error instanceof GitHubRateLimitError &&
+          boolArg(args.sync_comments_only) &&
+          runtimeBudget.onYield
+        ) {
+          // Comment sync is idempotent and re-runs on the next 15-minute tick,
+          // so an exhausted GitHub quota defers the remaining batch like a
+          // runtime-budget yield instead of recording a workflow failure.
+          runtimeBudget.onYield(
+            `GitHub rate limited until ${error.retryAt}; comment sync deferred to the next cycle`,
+          );
           return;
         }
         runtimeBudget.onFailure?.(error);

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -2877,3 +2877,91 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     }
   }
 });
+
+test("comment-only sync defers the remaining batch when GitHub is rate limited", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const originalReport = implementedCloseReport();
+    writeFileSync(join(itemsDir, "321.md"), originalReport, "utf8");
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.error("gh: API rate limit exceeded for installation. (HTTP 403)");
+  process.exit(1);
+}
+console.error("unexpected gh args", JSON.stringify(args));
+process.exit(1);
+`;
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: ["--sync-comments-only"],
+      });
+    });
+
+    const report = JSON.parse(readText(reportPath));
+    assert.deepEqual(
+      report.map((result) => ({ number: result.number, action: result.action })),
+      [
+        { number: 321, action: "skipped_runtime_budget" },
+        { number: 0, action: "skipped_runtime_budget" },
+      ],
+    );
+    for (const result of report) {
+      assert.match(result.reason, /rate limited until .*comment sync deferred/);
+    }
+    assert.equal(readText(join(itemsDir, "321.md")), originalReport);
+    assert.equal(existsSync(join(closedDir, "321.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("close-mode apply still fails loudly when GitHub is rate limited", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(join(itemsDir, "321.md"), implementedCloseReport(), "utf8");
+
+    const ghMock = `
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+const path = args[1] || "";
+if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
+  console.error("gh: API rate limit exceeded for installation. (HTTP 403)");
+  process.exit(1);
+}
+console.error("unexpected gh args", JSON.stringify(args));
+process.exit(1);
+`;
+    assert.throws(
+      () =>
+        withMockGh(root, ghMock, () => {
+          runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+        }),
+      /rate limit/i,
+    );
+
+    assert.ok(existsSync(join(itemsDir, "321.md")));
+    assert.equal(existsSync(join(closedDir, "321.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

The scheduled comment-sync variant of the apply lane (sweep.yml `6,21,36,51 * * * *`, `sync_open_pr_batch=true`) fails the entire run with an uncaught `GitHubRateLimitError` when a per-item live read hits an exhausted installation quota — observed at [run 31766800724](https://github.com/openclaw/clawsweeper/actions/runs/31766800724) (`liveIssueSourceRevision` → `gh api repos/openclaw/openclaw/issues/106670` → 403). Comment sync is idempotent and re-runs every 15 minutes, so these failures only pollute failure telemetry and burn a scheduled slot.

## Why This Change Was Made

The per-item loop already funnels every throttle throw to one catch that rethrows out of `applyDecisionsCommandInner`, and the outer `applyDecisionsCommand` wrapper already converts `GitHubRuntimeBudgetError` into a graceful `runtimeBudget.onYield` — which releases the mutation lease, returns the interrupted item to the cursor trace for the next cycle, records the dedup'd `skipped_runtime_budget` results, and finalizes apply events as a clean yield. This change routes `GitHubRateLimitError` onto that same rail, gated to `--sync-comments-only` runs with an available yield callback. Close-mode apply keeps its loud failure semantics unchanged, verified by a new regression test.

Follow-up to #1158, which fixed the equivalent hard-fail in the reconcile step that was skipping `Apply close proposals` entirely.

## Evidence

- New regression test: a rate-limited live read in `--sync-comments-only` mode exits 0, records `skipped_runtime_budget` results for the interrupted item plus the summary row with a "comment sync deferred" reason, and leaves the record file byte-identical.
- New counter-test: the same throttle in close mode still throws.
- Full apply + reconcile suites: 257/257 tests pass.
- `pnpm run lint` and `pnpm run check:static` (including docs check) clean.
- Codex-backed autoreview: clean, no accepted/actionable findings (`patch is correct`, 0.99).
