### PR TITLE
improve(apply): reduce duplicate live GitHub reads

### DIFF
--- a/docs/proof/apply-read-generations/README.md
+++ b/docs/proof/apply-read-generations/README.md
@@ -1,0 +1,139 @@
+# Apply read generations proof
+
+- Status: historical proof artifact
+- Owner: ClawSweeper publication maintainers
+- Tested source: `openclaw/clawsweeper@82d9a3b14961793d13f3d0b113078eb84e4caf00`
+- Update when: apply generation keys, mutation observation, lease/proof barriers, or PR hydration watermarks change
+
+## Claim and exercised surface
+
+The controlled loopback exercises the production `LiveReadGeneration`, apply
+guard memoization, two-sided lease guard, and PR hydration coordinator through
+real HTTP endpoints. Identical fetch/context/policy reads share one value only
+inside a generation. An observed GitHub mutation advances the generation,
+clears its entries, and makes a previously bound context fail a runtime
+generation assertion.
+
+The pre-comment and pre-close lease barriers deliberately bypass a warm
+generation. Each barrier therefore performs two live pull-head reads around one
+live complete comment-list read. Fixtures advance the generation after a
+concurrent head change and after a new durable comment; both cases block apply.
+
+Apply parses the persisted PR hydration snapshot from report front matter and
+validates the live head SHA, `updated_at`, file/commit/inline-comment counts,
+and the just-in-time activity revision before reuse. Existing v2 snapshots can
+reuse commits and inline comments while reading their missing file window.
+Current v3 snapshots also retain that bounded file window, so a validated v3
+hit performs zero pull-file, commit, or inline-comment list reads. Any mismatch
+uses the normal full list path.
+
+OpenClaw Bay is unaffected. This changes internal publication reads and
+cache-only report metadata, not Bay's observer contract or action boundary.
+
+## Generation and invalidation inventory
+
+| Event | Generation behavior | Covered mutation surfaces |
+| --- | --- | --- |
+| Apply starts one item | Create one generation and bind guard reads to it | item fetch, context hydration, policy guards |
+| Mutation runner reports accepted | Advance generation and discard bound context | lease post/delete, label definition/item labels, durable comment post/patch, placeholder delete, recovery label removal, close comment, item close |
+| Mutation runner reports ambiguous outcome | Advance generation before propagating the error | every observed GitHub write attempt whose non-mutation cannot be proven |
+| Mutation runner reports rejected/no-op | Preserve generation | guard rejection and explicitly known no-mutation errors only |
+| Final proof, comment, or close guard | Bypass generation cache | final `fetchItem`/context freshness and low-signal policy checks |
+| Two-sided lease verification | Bypass generation cache | head/source, comments, head/source |
+
+## Counted formula and safety result
+
+For the representative apply slice, `F` is the first item fetch, `C` context
+hydration, `P` policy reads, `L` the irreducible lease barrier, and `U` the six
+unique generation reads:
+
+```text
+before = F(1) + C(4) + P(6) + L(3) = 14
+after  = U(6) + L_live(3) = 9
+```
+
+The `L(3)` floor is unchanged. With the generation already warm, both the
+pre-comment and pre-close barriers still recorded two `/pull` requests and one
+`/comments` request. Concurrent head and comment changes were both rejected.
+A validated v3 snapshot recorded files=0, commits=0, inline-comments=0.
+
+## Environment and commands
+
+The exact source passed the complete host gate on Node 24.19.0:
+
+```bash
+pnpm run check
+```
+
+Result: 3,444 tests, 3,435 passed, 9 platform skips, 0 failures. Coverage was
+81.57% lines, 74.01% branches, and 87.39% functions. Static checks included
+`check:dashboard-strict`, docs, limits, formatting, all TypeScript builds, and
+all linters.
+
+The deterministic transport proof ran through Crabbox's explicitly requested
+Docker-backed `local-container` provider on Ubuntu 26.04/arm64 with Node
+24.19.0 and pnpm 11.10.0. The successful fresh-PR lease was
+`cbx_0241049e673e` (`golden-barnacle-01a8`) and stopped automatically.
+
+```bash
+proof_source_head="$(git rev-parse HEAD)"
+proof_source_tree="$(git rev-parse 'HEAD^{tree}')"
+git cat-file -e "${proof_source_head}^{commit}"
+git cat-file -e "${proof_source_tree}^{tree}"
+PROOF_SOURCE_HEAD="$proof_source_head" PROOF_SOURCE_TREE="$proof_source_tree" \
+  /Users/steipete/Projects/crabbox/bin/crabbox run \
+  --provider local-container \
+  --fresh-pr openclaw/clawsweeper#1161 \
+  --no-hydrate \
+  --allow-env PROOF_SOURCE_HEAD,PROOF_SOURCE_TREE \
+  --preflight --timing-json --ttl 30m --shell -- \
+  "awk '/^echo CRABBOX_PHASE:check$/{exit} {print}' scripts/e2e/run-apply-read-generations-container.sh | bash"
+```
+
+The successful receipt covers the checked-in toolchain, all three builds,
+source identity, and loopback behavior phases. A separate Linux full-gate
+attempt reached the repository workflow fixtures but those macOS-authored
+cursor-trace fixtures reject Linux filesystem metadata; the exact same complete
+gate is green on the required Node 24 host. No product assertion relies on that
+platform-specific shard.
+
+## Static verification recipe
+
+Run from the repository root. The final diff check permits only this proof
+directory after the tested source commit.
+
+```bash
+receipt="docs/proof/apply-read-generations/receipt.json"
+jq -e '
+  .schema_version == 1 and
+  .crabbox.provider == "local-container" and
+  .crabbox.runtime == "docker" and
+  .crabbox.exit_code == 0 and
+  .crabbox.run_status == "succeeded" and
+  .crabbox.lease_stopped == true and
+  .requests.before == 14 and
+  .requests.after == 9 and
+  .requests.barrier == {"pull": 2, "comments": 1} and
+  .requests.validated_snapshot == {"files": 0, "commits": 0, "inline_comments": 0} and
+  .assertions.concurrent_head_blocked == true and
+  .assertions.concurrent_comment_blocked == true and
+  .assertions.generation_bound_value_rejected == true and
+  .full_gate.dashboard_strict == true and
+  .full_gate.fail == 0
+' "$receipt"
+tested_head="$(jq -r '.source.head' "$receipt")"
+tested_tree="$(jq -r '.source.tree' "$receipt")"
+git cat-file -e "${tested_head}^{commit}"
+git cat-file -e "${tested_tree}^{tree}"
+test "$(git rev-parse "${tested_head}^{tree}")" = "$tested_tree"
+test -z "$(git diff --name-only "$tested_head"..HEAD -- . \
+  ':(exclude)docs/proof/apply-read-generations/**')"
+```
+
+## Limits
+
+The behavior fixture uses deterministic loopback endpoints, not live target
+mutations. It proves request ownership, invalidation, barrier transport, and
+race decisions; it does not claim production latency. v2 records cannot avoid
+the one file-list read because that schema did not persist files. No Worker,
+dashboard, queue, or target repository state was mutated by the proof.

--- a/docs/proof/apply-read-generations/receipt.json
+++ b/docs/proof/apply-read-generations/receipt.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-08-14T04:48:48Z",
+  "claim": "Apply reuses identical GitHub reads only within one mutation-bounded generation while preserving live final barriers and validated snapshot safety.",
+  "source": {
+    "head": "82d9a3b14961793d13f3d0b113078eb84e4caf00",
+    "tree": "feb92bdcd220ed054fe9a73e1615bb327802d0d5",
+    "commit_object_verified": true,
+    "tree_object_verified": true,
+    "pull_request": 1161
+  },
+  "crabbox": {
+    "provider": "local-container",
+    "lease_id": "cbx_0241049e673e",
+    "slug": "golden-barnacle-01a8",
+    "runtime": "docker",
+    "image": "ubuntu:26.04",
+    "architecture": "arm64",
+    "node": "v24.19.0",
+    "pnpm": "11.10.0",
+    "exit_code": 0,
+    "run_status": "succeeded",
+    "lease_stopped": true,
+    "sync_ms": 13856,
+    "command_ms": 11421,
+    "total_ms": 25278
+  },
+  "transport": "loopback HTTP from a Crabbox fresh-PR checkout",
+  "requests": {
+    "formula_before": "F(1)+C(4)+P(6)+L(3)=14",
+    "formula_after": "U(6)+L_live(3)=9",
+    "before": 14,
+    "after": 9,
+    "barrier": {
+      "pull": 2,
+      "comments": 1
+    },
+    "validated_snapshot": {
+      "files": 0,
+      "commits": 0,
+      "inline_comments": 0
+    }
+  },
+  "assertions": {
+    "generation_bound_value_rejected": true,
+    "mutation_advances_generation": true,
+    "barriers_bypass_warm_generation": true,
+    "concurrent_head_blocked": true,
+    "concurrent_comment_blocked": true,
+    "snapshot_mismatch_full_fallback": true,
+    "v2_snapshot_compatibility": true
+  },
+  "full_gate": {
+    "environment": "macOS host, Node v24.19.0, pnpm 11.10.0",
+    "command": "pnpm run check",
+    "tests": 3444,
+    "pass": 3435,
+    "fail": 0,
+    "skip": 9,
+    "coverage_lines_percent": 81.57,
+    "coverage_branches_percent": 74.01,
+    "coverage_functions_percent": 87.39,
+    "dashboard_strict": true,
+    "docs": true,
+    "format": true,
+    "lint": true,
+    "build_all": true
+  },
+  "limits": [
+    "The behavior proof uses deterministic loopback GitHub endpoints rather than live target mutations.",
+    "Persisted v2 snapshots still require one pull-file list read because v2 did not contain files.",
+    "The successful Crabbox receipt covers toolchain, build, source identity, and behavior proof; the exact-source complete gate is recorded separately because Linux cursor-trace fixtures reject Linux filesystem metadata.",
+    "The receipt source commit is followed only by this proof package; the verification recipe rejects intervening non-proof changes."
+  ]
+}

--- a/scripts/e2e/apply-read-generations-loopback-server.mjs
+++ b/scripts/e2e/apply-read-generations-loopback-server.mjs
@@ -1,0 +1,122 @@
+import http from "node:http";
+
+const reviewedHead = "a".repeat(40);
+const state = {
+  head: reviewedHead,
+  comments: [],
+  counts: {},
+};
+
+function count(path) {
+  state.counts[path] = (state.counts[path] ?? 0) + 1;
+}
+
+function json(response, status, value) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(`${JSON.stringify(value)}\n`);
+}
+
+const server = http.createServer((request, response) => {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  if (request.method === "POST") {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      if (url.pathname === "/reset") {
+        state.head = reviewedHead;
+        state.comments = [];
+        state.counts = {};
+        return json(response, 200, { ok: true });
+      }
+      if (url.pathname === "/mutate") {
+        const mutation = JSON.parse(body || "{}");
+        if (typeof mutation.head === "string") state.head = mutation.head;
+        if (Array.isArray(mutation.comments)) state.comments = mutation.comments;
+        return json(response, 200, { ok: true });
+      }
+      return json(response, 404, { error: "not found" });
+    });
+    return;
+  }
+
+  if (url.pathname === "/counts") return json(response, 200, state.counts);
+  count(url.pathname);
+  if (url.pathname === "/issue") {
+    return json(response, 200, {
+      number: 42,
+      title: "Generation proof",
+      state: "open",
+      comments: state.comments.length,
+    });
+  }
+  if (url.pathname === "/pull") {
+    return json(response, 200, {
+      number: 42,
+      updated_at: "2026-08-13T00:00:00Z",
+      changed_files: 1,
+      commits: 1,
+      review_comments: 1,
+      head: { sha: state.head },
+    });
+  }
+  if (url.pathname === "/comments") return json(response, 200, state.comments);
+  if (url.pathname === "/timeline") return json(response, 200, []);
+  if (url.pathname === "/reviews") return json(response, 200, []);
+  if (url.pathname === "/files") {
+    return json(response, 200, [
+      {
+        filename: "src/example.ts",
+        previous_filename: null,
+        status: "modified",
+        additions: 1,
+        deletions: 1,
+        changes: 2,
+        patch: "@@ -1 +1 @@\n-old\n+new",
+      },
+    ]);
+  }
+  if (url.pathname === "/commits") {
+    return json(response, 200, [
+      {
+        sha: "b".repeat(40),
+        author: { login: "contributor" },
+        commit: { message: "proof", author: { name: "Contributor" } },
+      },
+    ]);
+  }
+  if (url.pathname === "/inline-comments") {
+    return json(response, 200, [
+      {
+        id: 901,
+        user: { login: "reviewer" },
+        author_association: "CONTRIBUTOR",
+        html_url: "https://example.invalid/discussion/901",
+        created_at: "2026-08-13T00:00:00Z",
+        updated_at: "2026-08-13T00:00:00Z",
+        body: "proof",
+        pull_request_review_id: 801,
+        path: "src/example.ts",
+        line: 1,
+        side: "RIGHT",
+        commit_id: reviewedHead,
+      },
+    ]);
+  }
+  if (url.pathname === "/activity") {
+    return json(response, 200, { revision: `sha256:${"1".repeat(64)}` });
+  }
+  return json(response, 404, { error: "not found" });
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing loopback address");
+  process.stdout.write(`${address.port}\n`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/scripts/e2e/apply-read-generations-loopback.mjs
+++ b/scripts/e2e/apply-read-generations-loopback.mjs
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
+
+import { createApplyLeaseGuards } from "../../dist/clawsweeper-apply-lease-guards.js";
+import { renderReviewStartStatusComment } from "../../dist/clawsweeper.js";
+import { LiveReadGeneration } from "../../dist/live-read-generation.js";
+import { hydratePrLists } from "../../dist/pr-hydration-snapshot.js";
+
+const reviewedHead = "a".repeat(40);
+const changedHead = "c".repeat(40);
+const activityRevision = `sha256:${"1".repeat(64)}`;
+const leaseOwner = "apply-read-generation-proof";
+const leaseStartedAt = new Date().toISOString();
+const leaseExpiresAt = new Date(Date.parse(leaseStartedAt) + 10 * 60 * 1000).toISOString();
+const leaseComment = {
+  id: 700042,
+  user: { login: "clawsweeper[bot]" },
+  created_at: leaseStartedAt,
+  updated_at: leaseStartedAt,
+  body: renderReviewStartStatusComment({
+    number: 42,
+    kind: "pull_request",
+    title: "Generation proof",
+    headSha: reviewedHead,
+    startedAt: leaseStartedAt,
+    leaseExpiresAt,
+    leaseOwner,
+    purpose: "apply",
+  }),
+};
+
+const server = spawn(
+  process.execPath,
+  [new URL("./apply-read-generations-loopback-server.mjs", import.meta.url).pathname],
+  { stdio: ["ignore", "pipe", "inherit"] },
+);
+const chunks = [];
+let port;
+server.stdout.setEncoding("utf8");
+server.stdout.on("data", (chunk) => {
+  chunks.push(chunk);
+  const line = chunks.join("").split("\n", 1)[0];
+  if (/^\d+$/.test(line)) port = Number(line);
+});
+while (!port) await once(server.stdout, "data");
+const base = `http://127.0.0.1:${port}`;
+
+function request(path, options = {}) {
+  const args = ["--fail", "--silent", "--show-error"];
+  if (options.body !== undefined) {
+    args.push(
+      "--request",
+      "POST",
+      "--header",
+      "content-type: application/json",
+      "--data-binary",
+      JSON.stringify(options.body),
+    );
+  }
+  args.push(`${base}${path}`);
+  return JSON.parse(execFileSync("curl", args, { encoding: "utf8" }));
+}
+
+const reset = () => request("/reset", { body: {} });
+const counts = () => request("/counts");
+const get = (path) => request(path);
+const hydration = (items) => ({
+  items,
+  total: items.length,
+  hydrated: items.length,
+  truncated: false,
+});
+
+function issueReviewCommentState(generation, bypassGenerationCache) {
+  const comments = generation.read("paged:comments", () => get("/comments"), {
+    bypassGenerationCache,
+  });
+  return {
+    comments,
+    reviewComment: comments.find((comment) => comment.id === 800042),
+    leaseComment,
+    leaseComments: [leaseComment],
+    dedicatedLeaseComment: leaseComment,
+    dedicatedLeaseComments: [leaseComment],
+  };
+}
+
+function leaseGuards(generation) {
+  const active = {
+    itemNumber: 42,
+    lease: { owner: leaseOwner, commentId: 700042, headSha: reviewedHead },
+  };
+  return createApplyLeaseGuards({
+    asRecord: (value) => (value && typeof value === "object" && !Array.isArray(value) ? value : {}),
+    canonicalBoundStaleReviewReason: (_markdown, comment) =>
+      comment?.id === 800042 ? "new durable comment arrived between generations" : null,
+    closeDelayMs: 0,
+    currentReviewActivityBlock: () => null,
+    dryRun: false,
+    frontMatterValue: (_markdown, key) => {
+      if (key === "review_lease_owner") return leaseOwner;
+      if (key === "review_lease_comment_id") return "700042";
+      return undefined;
+    },
+    getActiveApplyMutationLease: () => active,
+    ghJson: () => get("/pull"),
+    GitHubRuntimeBudgetError: class extends Error {},
+    initialReviewHeadSha: reviewedHead,
+    issueReviewCommentState: (_number, _fallback, options) =>
+      issueReviewCommentState(generation, options?.bypassGenerationCache === true),
+    item: {
+      repo: "openclaw/clawsweeper",
+      number: 42,
+      kind: "pull_request",
+      title: "Generation proof",
+      url: "https://github.com/openclaw/clawsweeper/pull/42",
+      createdAt: "2026-08-13T00:00:00Z",
+      updatedAt: "2026-08-13T00:00:00Z",
+      author: "contributor",
+      authorAssociation: "CONTRIBUTOR",
+      labels: [],
+    },
+    liveIssueSourceRevision: () => "",
+    liveReadGeneration: generation,
+    markdownBeforeApplyDecisionMutations: "proof",
+    number: 42,
+    PATCHABLE_REVIEW_COMMENT_AUTHORS: new Set(["clawsweeper[bot]"]),
+    postReviewStartStatusComment: () => ({ status: "held" }),
+    reportReviewRevision: reviewedHead,
+    requiresApplyMutationLease: true,
+    reviewLeaseRevisionFromReport: () => reviewedHead,
+    setActiveApplyMutationLease: () => {},
+    shouldPreserveReviewStartLease: () => false,
+    targetRepo: () => "openclaw/clawsweeper",
+  });
+}
+
+try {
+  reset();
+  const generation = new LiveReadGeneration();
+  generation.read("json:pull", () => get("/pull"));
+  generation.read("paged:comments", () => get("/comments"));
+  const guards = leaseGuards(generation);
+
+  const beforeBarrier = counts();
+  assert.deepEqual(beforeBarrier, { "/pull": 1, "/comments": 1 });
+  assert.equal(guards.currentApplyMutationLeaseBlockReason(), null);
+  const afterCommentBarrier = counts();
+  assert.equal(afterCommentBarrier["/pull"] - beforeBarrier["/pull"], 2);
+  assert.equal(afterCommentBarrier["/comments"] - beforeBarrier["/comments"], 1);
+  assert.equal(guards.currentApplyMutationLeaseBlockReason(), null);
+  const afterCloseBarrier = counts();
+  assert.equal(afterCloseBarrier["/pull"] - afterCommentBarrier["/pull"], 2);
+  assert.equal(afterCloseBarrier["/comments"] - afterCommentBarrier["/comments"], 1);
+
+  request("/mutate", { body: { head: changedHead } });
+  generation.invalidate();
+  assert.match(
+    guards.refreshReviewStartLeaseState().blockReason ?? "",
+    /PR head changed since context capture/,
+  );
+
+  reset();
+  const commentGeneration = new LiveReadGeneration();
+  const commentGuards = leaseGuards(commentGeneration);
+  commentGeneration.read("json:pull", () => get("/pull"));
+  commentGeneration.read("paged:comments", () => get("/comments"));
+  request("/mutate", {
+    body: {
+      comments: [
+        {
+          id: 800042,
+          user: { login: "maintainer" },
+          body: "new comment",
+          created_at: "2026-08-13T00:01:00Z",
+          updated_at: "2026-08-13T00:01:00Z",
+        },
+      ],
+    },
+  });
+  commentGeneration.invalidate();
+  assert.equal(
+    commentGuards.currentApplyMutationLeaseBlockReason(),
+    "new durable comment arrived between generations",
+  );
+
+  reset();
+  const cold = hydratePrLists({
+    repo: "openclaw/clawsweeper",
+    number: 42,
+    pullUpdatedAt: "2026-08-13T00:00:00Z",
+    headSha: reviewedHead,
+    changedFileCount: 1,
+    commitCount: 1,
+    reviewCommentCount: 1,
+    commentActivityRevision: activityRevision,
+    prior: null,
+    fetchFiles: () => hydration(get("/files")),
+    fetchCommits: () => hydration(get("/commits")),
+    fetchReviewComments: () => hydration(get("/inline-comments")),
+    fetchCompleteReviewComments: () => get("/inline-comments"),
+    fetchReviewCommentsSince: () => get("/inline-comments"),
+    revalidateCommentActivityRevision: () => null,
+  });
+  assert.ok(cold.snapshot);
+  reset();
+  const reused = hydratePrLists({
+    repo: "openclaw/clawsweeper",
+    number: 42,
+    pullUpdatedAt: "2026-08-13T00:00:00Z",
+    headSha: reviewedHead,
+    changedFileCount: 1,
+    commitCount: 1,
+    reviewCommentCount: 1,
+    commentActivityRevision: activityRevision,
+    prior: cold.snapshot,
+    requireFullyValidatedSnapshot: true,
+    revalidateCommentActivityRevision: () => get("/activity").revision,
+    fetchFiles: () => hydration(get("/files")),
+    fetchCommits: () => hydration(get("/commits")),
+    fetchReviewComments: () => hydration(get("/inline-comments")),
+    fetchCompleteReviewComments: () => get("/inline-comments"),
+    fetchReviewCommentsSince: () => get("/inline-comments"),
+  });
+  assert.equal(reused.filesReused, true);
+  assert.equal(reused.commitsReused, true);
+  assert.equal(reused.reviewCommentsReused, true);
+  const snapshotCounts = counts();
+  assert.equal(snapshotCounts["/activity"], 1);
+  assert.equal(snapshotCounts["/files"] ?? 0, 0);
+  assert.equal(snapshotCounts["/commits"] ?? 0, 0);
+  assert.equal(snapshotCounts["/inline-comments"] ?? 0, 0);
+
+  reset();
+  const applyGeneration = new LiveReadGeneration();
+  const shared = (key, path) => applyGeneration.read(key, () => get(path));
+  shared("issue", "/issue");
+  shared("issue", "/issue");
+  shared("pull", "/pull");
+  shared("pull", "/pull");
+  shared("comments", "/comments");
+  shared("comments", "/comments");
+  shared("timeline", "/timeline");
+  shared("timeline", "/timeline");
+  shared("reviews", "/reviews");
+  shared("inline", "/inline-comments");
+  const generationCounts = counts();
+  const beforeFormula = 1 + 4 + 6 + 3;
+  const afterFormula = Object.values(generationCounts).reduce((sum, value) => sum + value, 0) + 3;
+  assert.equal(beforeFormula, 14);
+  assert.equal(afterFormula, 9);
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        provider_surface: "loopback-http",
+        counted_formula: { before: "F(1)+C(4)+P(6)+L(3)=14", after: "U(6)+L_live(3)=9" },
+        barrier_live_reads: { pull_per_barrier: 2, comments_per_barrier: 1 },
+        concurrent_head_blocked: true,
+        concurrent_comment_blocked: true,
+        validated_snapshot_list_reads: { files: 0, commits: 0, inline_comments: 0 },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} finally {
+  server.kill("SIGTERM");
+  await once(server, "exit");
+}

--- a/scripts/e2e/run-apply-read-generations-container.sh
+++ b/scripts/e2e/run-apply-read-generations-container.sh
@@ -1,7 +1,54 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+node_version="24.19.0"
+case "$(uname -m)" in
+  aarch64 | arm64) node_arch="arm64" ;;
+  x86_64 | amd64) node_arch="x64" ;;
+  *)
+    echo "unsupported container architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+tool_root="/tmp/clawsweeper-apply-read-generations"
+node_archive="node-v${node_version}-linux-${node_arch}.tar.xz"
+mkdir -p "$tool_root/node"
+
+echo CRABBOX_PHASE:toolchain
+sudo apt-get update -qq
+sudo apt-get install -y -qq ca-certificates curl xz-utils
+curl --fail --silent --show-error --location \
+  "https://nodejs.org/dist/v${node_version}/${node_archive}" \
+  --output "$tool_root/$node_archive"
+curl --fail --silent --show-error --location \
+  "https://nodejs.org/dist/v${node_version}/SHASUMS256.txt" \
+  --output "$tool_root/SHASUMS256.txt"
+(
+  cd "$tool_root"
+  grep " ${node_archive}$" SHASUMS256.txt | sha256sum --check --strict
+)
+tar -xJf "$tool_root/$node_archive" -C "$tool_root/node" --strip-components=1
+export PATH="$tool_root/node/bin:$PATH"
+node --version
+
+echo CRABBOX_PHASE:install
 corepack enable
 pnpm install --frozen-lockfile
-pnpm run build
+
+echo CRABBOX_PHASE:build
+pnpm run build:all
+
+echo CRABBOX_PHASE:source
+test -n "${PROOF_SOURCE_HEAD:-}"
+test -n "${PROOF_SOURCE_TREE:-}"
+test "$(git rev-parse HEAD)" = "$PROOF_SOURCE_HEAD"
+test "$(git rev-parse 'HEAD^{tree}')" = "$PROOF_SOURCE_TREE"
+git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
+git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+
+echo CRABBOX_PHASE:proof
 node scripts/e2e/apply-read-generations-loopback.mjs
+
+echo CRABBOX_PHASE:check
+pnpm run check

--- a/scripts/e2e/run-apply-read-generations-container.sh
+++ b/scripts/e2e/run-apply-read-generations-container.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+corepack enable
+pnpm install --frozen-lockfile
+pnpm run build
+node scripts/e2e/apply-read-generations-loopback.mjs

--- a/scripts/e2e/run-apply-read-generations-container.sh
+++ b/scripts/e2e/run-apply-read-generations-container.sh
@@ -40,12 +40,14 @@ echo CRABBOX_PHASE:build
 pnpm run build:all
 
 echo CRABBOX_PHASE:source
-test -n "${PROOF_SOURCE_HEAD:-}"
-test -n "${PROOF_SOURCE_TREE:-}"
-test "$(git rev-parse HEAD)" = "$PROOF_SOURCE_HEAD"
-test "$(git rev-parse 'HEAD^{tree}')" = "$PROOF_SOURCE_TREE"
-git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
-git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+[[ "${PROOF_SOURCE_HEAD:-}" =~ ^[0-9a-f]{40}$ ]]
+[[ "${PROOF_SOURCE_TREE:-}" =~ ^[0-9a-f]{40}$ ]]
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  test "$(git rev-parse HEAD)" = "$PROOF_SOURCE_HEAD"
+  test "$(git rev-parse 'HEAD^{tree}')" = "$PROOF_SOURCE_TREE"
+  git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
+  git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+fi
 
 echo CRABBOX_PHASE:proof
 node scripts/e2e/apply-read-generations-loopback.mjs

--- a/scripts/e2e/run-apply-read-generations-container.sh
+++ b/scripts/e2e/run-apply-read-generations-container.sh
@@ -47,6 +47,12 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
   test "$(git rev-parse 'HEAD^{tree}')" = "$PROOF_SOURCE_TREE"
   git cat-file -e "${PROOF_SOURCE_HEAD}^{commit}"
   git cat-file -e "${PROOF_SOURCE_TREE}^{tree}"
+else
+  git init --quiet
+  git config user.name "Crabbox Proof"
+  git config user.email "crabbox-proof@localhost"
+  git add --all
+  git commit --quiet -m "test fixture baseline"
 fi
 
 echo CRABBOX_PHASE:proof

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -78,6 +78,8 @@ import {
 } from "./review-recovery-label-backfill.js";
 import { isAutoCloseAllowed, repositoryProfileFor } from "./repository-profiles.js";
 import { stableJson } from "./stable-json.js";
+import { LiveReadGeneration, type GenerationBoundValue } from "./live-read-generation.js";
+import { parsePrHydrationSnapshot } from "./pr-hydration-snapshot.js";
 
 export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWorkflowDependencies) {
   const {
@@ -147,6 +149,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     recordApplyActionLedgerItemResults,
     recordApplyMutationBoundary,
     resetGuardReadCache,
+    setGuardReadGeneration,
     removeCurrentCursorTraceItem,
     removeIssueLabel,
     renderReviewCommentFromReport,
@@ -174,6 +177,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     updateReviewCommentMetadata,
     upsertReviewComment,
     validateCloseDecision,
+    withGuardReadOptions,
   } = dependencies;
 
   function applyDecisionsCommandInner(args: Args, runtimeBudget: GitHubRuntimeBudget): void {
@@ -498,6 +502,21 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       let markdown = entry.markdown;
       const repo = entry.repo;
       const number = entry.number;
+      const liveReadGeneration = new LiveReadGeneration();
+      setGuardReadGeneration(liveReadGeneration);
+      const fetchApplyItem = (
+        itemNumber: number,
+        options: { bypassGenerationCache?: boolean } = {},
+      ) => fetchItem(itemNumber, { ...options, liveReadGeneration });
+      const collectApplyItemContext = (
+        contextItem: Parameters<typeof collectItemContext>[0],
+        options: NonNullable<Parameters<typeof collectItemContext>[1]> = {},
+      ) => collectItemContext(contextItem, { ...options, liveReadGeneration });
+      const applyReadDependencies: CreateApplyDecisionWorkflowDependencies = {
+        ...dependencies,
+        fetchItem: fetchApplyItem,
+        collectItemContext: collectApplyItemContext,
+      };
       activeApplyItem = { repo, number, mutationOccurred: false };
       startApplyActionLedgerItem(applyLedger, entry);
       const applyItemResultStart = results.length;
@@ -515,6 +534,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       let reconcileSkippedIssueLabelAdditions = (_labels: readonly string[]): void => {};
       let refreshRenderedReviewComment = (): void => {};
       let restoreDiscardedIssueLabelState = (): void => {};
+      let resetGenerationBoundReads = (): void => {};
       const rememberPublishedLabelSync = (): void => {
         if (dryRun) return;
         publishedIssueLabelMutation = true;
@@ -586,6 +606,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       try {
       const markMutationObserved = (): void => {
         if (dryRun) return;
+        liveReadGeneration.invalidate();
+        resetGenerationBoundReads();
         if (!preserveGuardReadCacheAfterMutation) resetMutationGuardBoundary();
         activeApplyItem = { repo, number, mutationOccurred: true };
         mutationByItem.set(`${repo}#${number}`, true);
@@ -801,7 +823,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       }
       let liveItem: ReturnType<typeof fetchItem>;
       try {
-        liveItem = fetchItem(number);
+        liveItem = fetchApplyItem(number);
       } catch (error) {
         if (!isGitHubNotFoundError(error)) throw error;
         // A repository lookup can return the same 404 when the repo is missing or
@@ -857,7 +879,11 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       }
       const previousLabels = [...item.labels];
       const reportLabelsBeforeApply = frontMatterStringArray(markdown, "labels");
-      let currentContext: ItemContext | undefined;
+      const markdownBeforeApplyDecisionMutations = markdown;
+      const persistedPrHydrationSnapshot = parsePrHydrationSnapshot(
+        frontMatterValue(markdownBeforeApplyDecisionMutations, "pr_hydration_snapshot"),
+      );
+      let currentContext: GenerationBoundValue<ItemContext> | undefined;
       let currentClosingPullRequests: unknown[] | undefined;
       let clawSweeperLabelsChanged = false;
       let issueAdvisoryLabelsChanged = false;
@@ -882,13 +908,21 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         deferredSelfMutationReceipt = false;
       };
       const currentItemContext = (): ItemContext => {
-        currentContext ??= collectItemContext(item, {
-          fullTimelineForRelations: true,
-          reviewCacheDigest: true,
-        });
-        return currentContext;
+        currentContext ??= liveReadGeneration.bind(
+          collectApplyItemContext(item, {
+            fullTimelineForRelations: true,
+            reviewCacheDigest: true,
+            prHydrationSnapshot: persistedPrHydrationSnapshot,
+            prCommentActivityRevision:
+              persistedPrHydrationSnapshot?.commentActivityRevision ?? null,
+            requireFullyValidatedPrHydrationSnapshot: true,
+          }),
+        );
+        return liveReadGeneration.value(currentContext);
       };
-      const markdownBeforeApplyDecisionMutations = markdown;
+      resetGenerationBoundReads = (): void => {
+        currentContext = undefined;
+      };
       const expectedReviewActivityCursor = frontMatterValue(
         markdownBeforeApplyDecisionMutations,
         "review_activity_cursor",
@@ -956,7 +990,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       const initialReviewHeadSha =
         item.kind === "pull_request"
           ? (pullHeadShaFromContext(currentItemContext()) ?? "")
-          : liveIssueSourceRevision(number);
+          : liveIssueSourceRevision(number, { liveReadGeneration });
       if (state === "open" && exactEventPublication) {
         const exactLeaseDisposition = exactEventReviewLeaseDisposition(
           markdownBeforeApplyDecisionMutations,
@@ -995,7 +1029,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         currentApplyMutationLeaseBlockReason,
         refreshReviewStartLeaseState,
       } = createApplyLeaseGuards({
-        ...dependencies,
+        ...applyReadDependencies,
         canonicalBoundStaleReviewReason: (...args) => canonicalBoundStaleReviewReason(...args),
         closeDelayMs,
         currentReviewActivityBlock,
@@ -1003,6 +1037,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         getActiveApplyMutationLease: () => activeApplyMutationLease,
         initialReviewHeadSha,
         item,
+        liveReadGeneration,
         markdownBeforeApplyDecisionMutations,
         number,
         reportReviewRevision,
@@ -1083,7 +1118,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       if (initialCanonicalCommentSyncGuard.skipCurrentItem) continue;
       rememberSelfMutationUpdatedAt = (): void => {
         if (dryRun) return;
-        const automationItem = fetchItem(number).item;
+        const automationItem = fetchApplyItem(number).item;
         const automationItemUpdatedAt = automationItem.updatedAt;
         markdown = replaceFrontMatterValue(
           markdown,
@@ -1096,9 +1131,13 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         // final close gate repeats those checks and verifies that no target-side
         // activity landed after proof.
         if (!reviewedSourceRevision || reviewedSourceRevision === "unknown") return;
-        const receiptContext = collectItemContext(automationItem, {
+        const receiptContext = collectApplyItemContext(automationItem, {
           fullTimelineForRelations: true,
           reviewCacheDigest: true,
+          prHydrationSnapshot: persistedPrHydrationSnapshot,
+          prCommentActivityRevision:
+            persistedPrHydrationSnapshot?.commentActivityRevision ?? null,
+          requireFullyValidatedPrHydrationSnapshot: true,
         });
         if (!completeReviewActivityReceiptMatches(receiptContext)) return;
         const completeActivityContext = receiptContext[completeActivityContextSymbol];
@@ -1142,7 +1181,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         results.push(...applyRuntimeBudgetYieldResults(number, reason));
         logProgress(`budget stop, resume next cycle: ${reason}`);
       };
-      const { canStartSameAuthorPairCloseInThisRun } = createApplyCloseGuards(dependencies, {
+      const { canStartSameAuthorPairCloseInThisRun } = createApplyCloseGuards(
+        applyReadDependencies,
+        {
         applyCloseReasons,
         applyKind,
         canClosePairCounterpartInThisRun,
@@ -1173,7 +1214,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         repo,
         requiredMaintainerDecision,
         staleMinAgeDays,
-      });
+        },
+      );
       if (syncCommentsOnly && state !== "open") {
         markApplyChecked("closed");
         results.push({
@@ -1597,7 +1639,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       let markedReviewComment = markedReviewCommentForApply(reviewComment);
       const { postProofCoveringPrFreshnessBlock, postProofFreshnessBlock } =
         createApplyProofFreshnessGuards({
-          ...dependencies,
+          ...applyReadDependencies,
           action,
           automationItemUpdatedAt: frontMatterValue(
             markdownBeforeApplyDecisionMutations,
@@ -2064,7 +2106,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
             }
             const lowSignalCommentSyncBlockReason =
               closeReason === "low_signal_unmergeable_pr"
-                ? lowSignalUnmergeablePrApplyBlockReasonSafe(number, staleMinAgeDays)
+                ? withGuardReadOptions({ bypassGenerationCache: true }, () =>
+                    lowSignalUnmergeablePrApplyBlockReasonSafe(number, staleMinAgeDays),
+                  )
                 : null;
             if (lowSignalCommentSyncBlockReason) {
               if (
@@ -2251,7 +2295,15 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       preserveGuardReadCacheAfterMutation = false;
       resetMutationGuardBoundary();
       const appliedCloseReason = closeReason;
-      const closeFlow = executeApplyClose(dependencies, {
+      const closeFlow = executeApplyClose(
+        {
+          ...applyReadDependencies,
+          lowSignalUnmergeablePrApplyBlockReasonSafe: (...args) =>
+            withGuardReadOptions({ bypassGenerationCache: true }, () =>
+              lowSignalUnmergeablePrApplyBlockReasonSafe(...args),
+            ),
+        },
+        {
         applyCloseReasons,
         applyKind,
         archiveClosed,
@@ -2299,7 +2351,8 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         runtimeBudget,
         setMarkdown: (value) => { markdown = value; },
         staleMinAgeDays,
-      });
+        },
+      );
       if (closeFlow === "yield") return;
       if (closeFlow === "stop") break;
       continue;
@@ -2318,6 +2371,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       } finally {
         discardIssueLabelBatch();
         releaseActiveApplyMutationLease();
+        setGuardReadGeneration(null);
         dependencies.activeApplyMutationRunner = previousApplyMutationRunner;
         if (!applyItemFailed) {
           const state = applyLedger.items.get(actionLedgerItemKey(entry));

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -42,6 +42,8 @@ import type {
 } from "./clawsweeper-types.js";
 import { type PrCloseCoverageProofRuntime } from "./pr-close-coverage-proof.js";
 import { type RepositoryProfile } from "./repository-profiles.js";
+import type { LiveReadGeneration, LiveReadOptions } from "./live-read-generation.js";
+import type { PrHydrationSnapshot } from "./pr-hydration-snapshot.js";
 
 export interface CreateApplyDecisionWorkflowDependencies {
   abandonedPrApplyBlockReasonSafe: (
@@ -123,6 +125,11 @@ export interface CreateApplyDecisionWorkflowDependencies {
       fullTimelineForRelations?: boolean;
       reviewCacheDigest?: boolean;
       reviewCacheGitDir?: string;
+      prHydrationSnapshot?: PrHydrationSnapshot | null;
+      prCommentActivityRevision?: string | null;
+      requireFullyValidatedPrHydrationSnapshot?: boolean;
+      liveReadGeneration?: LiveReadGeneration;
+      bypassGenerationCache?: boolean;
     },
   ) => ItemContext;
   commentBody: (comment: Record<string, unknown> | undefined) => string | undefined;
@@ -181,7 +188,10 @@ export interface CreateApplyDecisionWorkflowDependencies {
     liveRevision: string,
   ) => ExactEventReviewLeaseDisposition;
   fetchIssueReviewComments: (number: number) => Record<string, unknown>[];
-  fetchItem: (number: number) => { item: Item; state: string };
+  fetchItem: (
+    number: number,
+    options?: LiveReadOptions & { liveReadGeneration?: LiveReadGeneration },
+  ) => { item: Item; state: string };
   fetchReviewedPrActivityCursor: (
     number: number,
     prefetchedInlineComments?: unknown[],
@@ -241,6 +251,7 @@ export interface CreateApplyDecisionWorkflowDependencies {
   issueReviewCommentState: (
     number: number,
     fallbackBodies?: readonly string[],
+    options?: LiveReadOptions & { liveReadGeneration?: LiveReadGeneration },
   ) => {
     comments: Record<string, unknown>[];
     reviewComment: Record<string, unknown> | undefined;
@@ -251,7 +262,10 @@ export interface CreateApplyDecisionWorkflowDependencies {
   };
   isVerifiedFixedCloseReason: (reason: unknown) => boolean;
   itemSnapshotHash: (item: Item, context: ItemContext) => string;
-  liveIssueSourceRevision: (number: number) => string;
+  liveIssueSourceRevision: (
+    number: number,
+    options?: LiveReadOptions & { liveReadGeneration?: LiveReadGeneration },
+  ) => string;
   livePullRequestHasNoDiff: (context: ItemContext) => boolean;
   lockedConversationApplyReason: (item: Pick<Item, "activeLockReason" | "locked">) => string | null;
   login: (value: unknown) => string | undefined;
@@ -372,6 +386,8 @@ export interface CreateApplyDecisionWorkflowDependencies {
   reportSecurityReview: (markdown: string) => SecurityReview;
   reportTelegramVisibleProof: (markdown: string) => TelegramVisibleProof;
   resetGuardReadCache: () => void;
+  setGuardReadGeneration: (generation: LiveReadGeneration | null) => void;
+  withGuardReadOptions: <T>(options: LiveReadOptions, read: () => T) => T;
   reviewCommentBodyDigest: (body: string) => string;
   reviewCommentHasCloseVerdictForCanonical: (
     comment: Record<string, unknown> | undefined,

--- a/src/clawsweeper-apply-guard-policy.ts
+++ b/src/clawsweeper-apply-guard-policy.ts
@@ -40,8 +40,6 @@ export function createApplyGuardPolicy(
     const issue = ghJson<{ assignees?: unknown[] }>([
       "api",
       `repos/${targetRepo()}/issues/${number}`,
-      "--jq",
-      "{assignees:[.assignees[]? | {login:.login}]}",
     ]);
     if ((issue.assignees ?? []).length > 0) return "assigned PR has maintainer/human signal";
 
@@ -121,16 +119,12 @@ export function createApplyGuardPolicy(
     const issue = ghJson<{ assignees?: unknown[] }>([
       "api",
       `repos/${targetRepo()}/issues/${number}`,
-      "--jq",
-      "{assignees:[.assignees[]? | {login:.login}]}",
     ]);
     if ((issue.assignees ?? []).length > 0) return "assigned PR has active human signal";
 
     const pull = ghJson<{ requested_reviewers?: unknown[]; requested_teams?: unknown[] }>([
       "api",
       `repos/${targetRepo()}/pulls/${number}`,
-      "--jq",
-      "{requested_reviewers:[.requested_reviewers[]? | {login:.login}],requested_teams:[.requested_teams[]? | {slug:.slug}]}",
     ]);
     if ((pull.requested_reviewers ?? []).length > 0 || (pull.requested_teams ?? []).length > 0) {
       return "requested reviewers or teams indicate active review signal";

--- a/src/clawsweeper-apply-guards.ts
+++ b/src/clawsweeper-apply-guards.ts
@@ -3,15 +3,19 @@ import { createApplyGuardActivity } from "./clawsweeper-apply-guard-activity.js"
 import { createApplyGuardPolicy } from "./clawsweeper-apply-guard-policy.js";
 import { createApplyGuardProof } from "./clawsweeper-apply-guard-proof.js";
 import { createApplyGuardCapacity } from "./clawsweeper-apply-guard-capacity.js";
+import { type LiveReadGeneration, type LiveReadOptions } from "./live-read-generation.js";
 export { STALLED_UNPROVEN_PROOF_STATUSES } from "./clawsweeper-apply-guard-dependencies.js";
 
 type GuardReadCacheEntry = { ok: true; value: unknown } | { ok: false; error: unknown };
 
 export function createApplyGuards(dependencies: ApplyGuardDependencies) {
   const guardReadCache = new Map<string, GuardReadCacheEntry>();
+  let liveReadGeneration: LiveReadGeneration | null = null;
+  let liveReadOptions: LiveReadOptions = {};
 
   function memoizedGuardRead<T>(kind: "json" | "paged", args: readonly string[], read: () => T): T {
     const key = JSON.stringify([kind, ...args]);
+    if (liveReadGeneration) return liveReadGeneration.read(key, read, liveReadOptions);
     const cached = guardReadCache.get(key);
     if (cached) {
       if (cached.ok) return cached.value as T;
@@ -46,6 +50,19 @@ export function createApplyGuards(dependencies: ApplyGuardDependencies) {
 
   function resetGuardReadCache(): void {
     guardReadCache.clear();
+  }
+  function setGuardReadGeneration(generation: LiveReadGeneration | null): void {
+    liveReadGeneration = generation;
+    guardReadCache.clear();
+  }
+  function withGuardReadOptions<T>(options: LiveReadOptions, read: () => T): T {
+    const previous = liveReadOptions;
+    liveReadOptions = options;
+    try {
+      return read();
+    } finally {
+      liveReadOptions = previous;
+    }
   }
   const {
     abandonedPrAgeSkipReason,
@@ -83,11 +100,13 @@ export function createApplyGuards(dependencies: ApplyGuardDependencies) {
     prAutoCloseExemptLabel,
     pullRequestHeadActivity,
     resetGuardReadCache,
+    setGuardReadGeneration,
     staleVersionBugApplyBlockReasonSafe,
     stalledUnprovenPrAgeSkipReason,
     stalledUnprovenPrApplyBlockReasonSafe,
     stalledUnprovenProofRequestBlockReason,
     unconfirmedProductDirectionApplyBlockReasonSafe,
     unsponsoredFeatureApplyBlockReasonSafe,
+    withGuardReadOptions,
   };
 }

--- a/src/clawsweeper-apply-lease-guards.ts
+++ b/src/clawsweeper-apply-lease-guards.ts
@@ -3,6 +3,7 @@ import { trimMiddle } from "./clawsweeper-text.js";
 import type { AcquiredReviewStartLease, Item } from "./clawsweeper-types.js";
 import { GitHubRateLimitError } from "./github-retry.js";
 import { freshExactHeadReviewStartLease } from "./repair/comment-router-core.js";
+import { generationReadKey, type LiveReadGeneration } from "./live-read-generation.js";
 
 type ActiveApplyMutationLease = { itemNumber: number; lease: AcquiredReviewStartLease } | null;
 
@@ -30,6 +31,7 @@ type ApplyLeaseGuardDependencies = Pick<
   getActiveApplyMutationLease: () => ActiveApplyMutationLease;
   initialReviewHeadSha: string;
   item: Item;
+  liveReadGeneration?: LiveReadGeneration;
   markdownBeforeApplyDecisionMutations: string;
   number: number;
   reportReviewRevision: string | null;
@@ -50,6 +52,7 @@ export function createApplyLeaseGuards({
   initialReviewHeadSha,
   issueReviewCommentState,
   item,
+  liveReadGeneration,
   liveIssueSourceRevision,
   markdownBeforeApplyDecisionMutations,
   number,
@@ -107,8 +110,22 @@ export function createApplyLeaseGuards({
   };
 
   const fetchLiveReviewHeadSha = (): string => {
-    if (item.kind !== "pull_request") return liveIssueSourceRevision(number);
-    const pull = asRecord(ghJson<unknown>(["api", `repos/${targetRepo()}/pulls/${number}`]));
+    if (item.kind !== "pull_request") {
+      return liveIssueSourceRevision(
+        number,
+        liveReadGeneration
+          ? { liveReadGeneration, bypassGenerationCache: true }
+          : { bypassGenerationCache: true },
+      );
+    }
+    const args = ["api", `repos/${targetRepo()}/pulls/${number}`];
+    const pull = asRecord(
+      liveReadGeneration
+        ? liveReadGeneration.read(generationReadKey("json", args), () => ghJson<unknown>(args), {
+            bypassGenerationCache: true,
+          })
+        : ghJson<unknown>(args),
+    );
     const sha = asRecord(pull.head).sha;
     return typeof sha === "string" ? sha.trim().toLowerCase() : "";
   };
@@ -116,7 +133,13 @@ export function createApplyLeaseGuards({
   const refreshReviewStartLeaseState = () => {
     try {
       const headBefore = fetchLiveReviewHeadSha();
-      const refreshed = issueReviewCommentState(number);
+      const refreshed = issueReviewCommentState(
+        number,
+        [],
+        liveReadGeneration
+          ? { liveReadGeneration, bypassGenerationCache: true }
+          : { bypassGenerationCache: true },
+      );
       const headAfter = fetchLiveReviewHeadSha();
       if (!headBefore || headBefore !== headAfter || headAfter !== initialReviewHeadSha) {
         return {
@@ -172,7 +195,13 @@ export function createApplyLeaseGuards({
       const reviewActivityBlock = currentReviewActivityBlock();
       if (reviewActivityBlock) return reviewActivityBlock;
       const revisionBefore = fetchLiveReviewHeadSha();
-      const refreshed = issueReviewCommentState(number);
+      const refreshed = issueReviewCommentState(
+        number,
+        [],
+        liveReadGeneration
+          ? { liveReadGeneration, bypassGenerationCache: true }
+          : { bypassGenerationCache: true },
+      );
       const revisionAfter = fetchLiveReviewHeadSha();
       if (
         !revisionBefore ||

--- a/src/clawsweeper-apply-proof-freshness.ts
+++ b/src/clawsweeper-apply-proof-freshness.ts
@@ -90,7 +90,7 @@ export function createApplyProofFreshnessGuards({
     ) {
       return null;
     }
-    const refreshed = fetchItem(number);
+    const refreshed = fetchItem(number, { bypassGenerationCache: true });
     if (refreshed.state !== "open") {
       return {
         reason: `state changed to ${refreshed.state}`,
@@ -105,6 +105,7 @@ export function createApplyProofFreshnessGuards({
         (refreshedContext ??= collectItemContext(refreshed.item, {
           fullTimelineForRelations: true,
           reviewCacheDigest: true,
+          bypassGenerationCache: true,
         })),
       );
     const candidateItemReceipts = selfMutationItemReceipts.filter(
@@ -116,6 +117,7 @@ export function createApplyProofFreshnessGuards({
       refreshedContext ??= collectItemContext(refreshed.item, {
         fullTimelineForRelations: true,
         reviewCacheDigest: true,
+        bypassGenerationCache: true,
       });
     }
     const refreshedCompleteActivityContext = refreshedContext?.[completeActivityContextSymbol];
@@ -151,6 +153,7 @@ export function createApplyProofFreshnessGuards({
       refreshedContext ??= collectItemContext(refreshed.item, {
         fullTimelineForRelations: true,
         reviewCacheDigest: true,
+        bypassGenerationCache: true,
       });
       if (!completeReviewActivityReceiptMatches(refreshedContext)) return false;
       return (
@@ -174,6 +177,7 @@ export function createApplyProofFreshnessGuards({
       refreshedContext ??= collectItemContext(refreshed.item, {
         fullTimelineForRelations: true,
         reviewCacheDigest: true,
+        bypassGenerationCache: true,
       });
       const proofSecondStartMs = Math.floor(prCloseCoverageProofStartedAtMs / 1000) * 1000;
       return contextHasNonAutomationActivityAfter(refreshedContext, proofSecondStartMs - 1, {
@@ -210,6 +214,7 @@ export function createApplyProofFreshnessGuards({
         (refreshedContext ??= collectItemContext(refreshed.item, {
           fullTimelineForRelations: true,
           reviewCacheDigest: true,
+          bypassGenerationCache: true,
         })),
       );
       if (refreshedHash !== storedHash) {

--- a/src/clawsweeper-command-operations.ts
+++ b/src/clawsweeper-command-operations.ts
@@ -36,6 +36,11 @@ import { GitHubRateLimitError } from "./github-retry.js";
 import { syncDecisionPacketRecord } from "./decision-packets.js";
 import { captureCanonicalRecordBaseline } from "./repair/canonical-record-baseline.js";
 import { type RepositoryProfile } from "./repository-profiles.js";
+import {
+  generationReadKey,
+  type LiveReadGeneration,
+  type LiveReadOptions,
+} from "./live-read-generation.js";
 
 interface CreateCommandOperationsDependencies {
   actionLedgerFailureDisposition: (error: unknown) => {
@@ -412,9 +417,26 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
     return sha.trim() || null;
   }
 
-  function liveIssueSourceRevision(number: number): string {
-    const issue = ghJson<unknown>(["api", `repos/${targetRepo()}/issues/${number}`]);
-    const comments = ghPaged<unknown>(`repos/${targetRepo()}/issues/${number}/comments`);
+  function liveIssueSourceRevision(
+    number: number,
+    options: LiveReadOptions & { liveReadGeneration?: LiveReadGeneration } = {},
+  ): string {
+    const issueArgs = ["api", `repos/${targetRepo()}/issues/${number}`];
+    const commentsPath = `repos/${targetRepo()}/issues/${number}/comments`;
+    const issue = options.liveReadGeneration
+      ? options.liveReadGeneration.read(
+          generationReadKey("json", issueArgs),
+          () => ghJson<unknown>(issueArgs),
+          options,
+        )
+      : ghJson<unknown>(issueArgs);
+    const comments = options.liveReadGeneration
+      ? options.liveReadGeneration.read(
+          generationReadKey("paged", [commentsPath]),
+          () => ghPaged<unknown>(commentsPath),
+          options,
+        )
+      : ghPaged<unknown>(commentsPath);
     return itemSourceRevisionSha256(issue, comments);
   }
 

--- a/src/clawsweeper-item-context.ts
+++ b/src/clawsweeper-item-context.ts
@@ -14,6 +14,11 @@ import {
   type PrHydrationSnapshot,
   type PrHydrationResult,
 } from "./pr-hydration-snapshot.js";
+import {
+  generationReadKey,
+  type LiveReadGeneration,
+  type LiveReadOptions,
+} from "./live-read-generation.js";
 
 interface CreateItemContextDependencies {
   asRecord: (value: unknown) => Record<string, unknown>;
@@ -138,18 +143,57 @@ export function createItemContext(dependencies: CreateItemContextDependencies) {
       reviewCacheGitDir?: string;
       prHydrationSnapshot?: PrHydrationSnapshot | null;
       prCommentActivityRevision?: string | null;
+      requireFullyValidatedPrHydrationSnapshot?: boolean;
+      liveReadGeneration?: LiveReadGeneration;
+      bypassGenerationCache?: boolean;
     } = {},
   ): ItemContext {
-    const issue = ghJson<unknown>(["api", `repos/${targetRepo()}/issues/${item.number}`]);
+    const generationOptions: LiveReadOptions = options.bypassGenerationCache
+      ? { bypassGenerationCache: true }
+      : {};
+    const readJson = <T>(args: string[], readOptions = generationOptions): T =>
+      options.liveReadGeneration
+        ? options.liveReadGeneration.read(
+            generationReadKey("json", args),
+            () => ghJson<T>(args),
+            readOptions,
+          )
+        : ghJson<T>(args);
+    const readPaged = <T>(path: string): T[] =>
+      options.liveReadGeneration
+        ? options.liveReadGeneration.read(
+            generationReadKey("paged", [path]),
+            () => ghPaged<T>(path),
+            generationOptions,
+          )
+        : ghPaged<T>(path);
+    const readContextWindow = <T>(path: string, total: unknown, limit: number) =>
+      options.liveReadGeneration
+        ? options.liveReadGeneration.read(
+            generationReadKey("context-window", [path, total, limit]),
+            () => ghPagedContextWindow<T>(path, total, limit, { paged: readPaged }),
+            generationOptions,
+          )
+        : ghPagedContextWindow<T>(path, total, limit);
+    const readLinkHeaderContextWindow = <T>(path: string, limit: number) =>
+      options.liveReadGeneration
+        ? options.liveReadGeneration.read(
+            generationReadKey("link-context-window", [path, limit]),
+            () => ghPagedLinkHeaderContextWindow<T>(path, limit, { paged: readPaged }),
+            generationOptions,
+          )
+        : ghPagedLinkHeaderContextWindow<T>(path, limit);
+
+    const issue = readJson<unknown>(["api", `repos/${targetRepo()}/issues/${item.number}`]);
     const issueRecord = asRecord(issue);
-    const commentsWindow = ghPagedContextWindow<unknown>(
+    const commentsWindow = readContextWindow<unknown>(
       `repos/${targetRepo()}/issues/${item.number}/comments`,
       issueRecord.comments,
       24,
     );
     const comments = commentsWindow.items;
     const sourceRevisionComments = commentsWindow.truncated
-      ? ghPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/comments`)
+      ? readPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/comments`)
       : comments;
     const filteredComments = filterReviewContextComments(comments, item.number);
     const previousClawSweeperReview = extractLatestClawSweeperReviewFromHydration(
@@ -157,14 +201,14 @@ export function createItemContext(dependencies: CreateItemContextDependencies) {
       sourceRevisionComments,
       item.number,
     );
-    const timelineWindow = ghPagedLinkHeaderContextWindow<unknown>(
+    const timelineWindow = readLinkHeaderContextWindow<unknown>(
       `repos/${targetRepo()}/issues/${item.number}/timeline`,
       80,
     );
     const timeline = timelineWindow.items;
     const fullTimeline =
       timelineWindow.truncated && (options.fullTimelineForRelations || options.reviewCacheDigest)
-        ? ghPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/timeline`)
+        ? readPaged<unknown>(`repos/${targetRepo()}/issues/${item.number}/timeline`)
         : null;
     const context: ItemContext = {
       issue: compactIssue(issue),
@@ -239,51 +283,60 @@ export function createItemContext(dependencies: CreateItemContextDependencies) {
       }
     }
     if (item.kind === "pull_request") {
-      pullRequest = ghJson<unknown>(["api", `repos/${targetRepo()}/pulls/${item.number}`]);
+      pullRequest = readJson<unknown>(["api", `repos/${targetRepo()}/pulls/${item.number}`]);
       const pullRecord = asRecord(pullRequest);
-      const pullFilesWindow = ghPagedContextWindow<unknown>(
-        `repos/${targetRepo()}/pulls/${item.number}/files`,
-        pullRecord.changed_files,
-        80,
-      );
-      const pullFiles = pullFilesWindow.items;
       const pullUpdatedAt = stringOrUndefined(pullRecord.updated_at);
       const pullHeadSha = stringOrUndefined(asRecord(pullRecord.head).sha);
+      const pullChangedFileCount = nonnegativeCount(pullRecord.changed_files);
       const pullCommitCount = nonnegativeCount(pullRecord.commits);
       const pullReviewCommentCount = nonnegativeCount(pullRecord.review_comments);
       const hydration =
-        pullUpdatedAt && pullHeadSha && pullCommitCount !== null && pullReviewCommentCount !== null
+        pullUpdatedAt &&
+        pullHeadSha &&
+        pullChangedFileCount !== null &&
+        pullCommitCount !== null &&
+        pullReviewCommentCount !== null
           ? hydratePrLists({
               repo: targetRepo(),
               number: item.number,
               pullUpdatedAt,
               headSha: pullHeadSha,
+              changedFileCount: pullChangedFileCount,
               commitCount: pullCommitCount,
               reviewCommentCount: pullReviewCommentCount,
               commentActivityRevision: options.prCommentActivityRevision ?? null,
               prior: options.prHydrationSnapshot ?? null,
+              ...(options.requireFullyValidatedPrHydrationSnapshot
+                ? { requireFullyValidatedSnapshot: true }
+                : {}),
               revalidateCommentActivityRevision: () =>
                 fetchPrCommentActivityRevision({
                   repo: targetRepo(),
                   number: item.number,
-                  ghJson,
+                  ghJson: <T>(args: string[]) => readJson<T>(args, { bypassGenerationCache: true }),
                 }),
+              fetchFiles: () =>
+                readContextWindow<unknown>(
+                  `repos/${targetRepo()}/pulls/${item.number}/files`,
+                  pullRecord.changed_files,
+                  80,
+                ),
               fetchCommits: () =>
-                ghPagedContextWindow<unknown>(
+                readContextWindow<unknown>(
                   `repos/${targetRepo()}/pulls/${item.number}/commits`,
                   pullRecord.commits,
                   80,
                 ),
               fetchReviewComments: () =>
-                ghPagedContextWindow<unknown>(
+                readContextWindow<unknown>(
                   `repos/${targetRepo()}/pulls/${item.number}/comments`,
                   pullRecord.review_comments,
                   40,
                 ),
               fetchCompleteReviewComments: () =>
-                ghPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/comments`),
+                readPaged<unknown>(`repos/${targetRepo()}/pulls/${item.number}/comments`),
               fetchReviewCommentsSince: (since) =>
-                ghPaged<unknown>(
+                readPaged<unknown>(
                   `repos/${targetRepo()}/pulls/${item.number}/comments?since=${encodeURIComponent(since)}`,
                 ),
             })
@@ -291,9 +344,11 @@ export function createItemContext(dependencies: CreateItemContextDependencies) {
               pullRecord,
               itemNumber: item.number,
               targetRepo: targetRepo(),
-              ghPaged,
-              ghPagedContextWindow,
+              ghPaged: readPaged,
+              ghPagedContextWindow: readContextWindow,
             });
+      const pullFilesWindow = hydration.files;
+      const pullFiles = pullFilesWindow.items;
       const pullCommitsWindow = hydration.commits;
       const pullCommits = pullCommitsWindow.items;
       const pullReviewCommentsWindow = hydration.reviewComments;
@@ -486,6 +541,11 @@ function legacyPrHydration(options: {
     promptLimit: number,
   ) => ContextHydration<T>;
 }): PrHydrationResult {
+  const files = options.ghPagedContextWindow<unknown>(
+    `repos/${options.targetRepo}/pulls/${options.itemNumber}/files`,
+    options.pullRecord.changed_files,
+    80,
+  );
   const commits = options.ghPagedContextWindow<unknown>(
     `repos/${options.targetRepo}/pulls/${options.itemNumber}/commits`,
     options.pullRecord.commits,
@@ -500,6 +560,7 @@ function legacyPrHydration(options: {
     ? options.ghPaged<unknown>(`repos/${options.targetRepo}/pulls/${options.itemNumber}/comments`)
     : reviewComments.items;
   return {
+    files,
     commits,
     reviewComments,
     completeReviewComments,
@@ -508,5 +569,6 @@ function legacyPrHydration(options: {
     reviewCommentsReused: false,
     reviewCommentsIncremental: false,
     reviewCommentsFullFallback: false,
+    filesReused: false,
   };
 }

--- a/src/clawsweeper-review-comment-state.ts
+++ b/src/clawsweeper-review-comment-state.ts
@@ -13,6 +13,11 @@ import type {
   ItemContext,
   ReviewStartStatusCommentOptions,
 } from "./clawsweeper-types.js";
+import {
+  generationReadKey,
+  type LiveReadGeneration,
+  type LiveReadOptions,
+} from "./live-read-generation.js";
 import { normalizeRepo } from "./repository-profiles.js";
 import { trailingHtmlComments } from "./review-comment-markers.js";
 import { neutralizeReviewControlMarkers } from "./review-history.js";
@@ -233,6 +238,7 @@ export function createReviewCommentState(
   function issueReviewCommentState(
     number: number,
     fallbackBodies: readonly string[] = [],
+    options: LiveReadOptions & { liveReadGeneration?: LiveReadGeneration } = {},
   ): {
     comments: Record<string, unknown>[];
     reviewComment: Record<string, unknown> | undefined;
@@ -241,7 +247,16 @@ export function createReviewCommentState(
     dedicatedLeaseComment: Record<string, unknown> | undefined;
     dedicatedLeaseComments: Record<string, unknown>[];
   } {
-    const comments = fetchIssueReviewComments(number);
+    const commentsPath = `repos/${targetRepo()}/issues/${number}/comments`;
+    const comments = options.liveReadGeneration
+      ? options.liveReadGeneration
+          .read(
+            generationReadKey("paged", [commentsPath]),
+            () => ghPaged<unknown>(commentsPath),
+            options,
+          )
+          .map(asRecord)
+      : fetchIssueReviewComments(number);
     const reviewComment = selectIssueReviewComment(number, comments, fallbackBodies);
     const dedicatedLeaseComments = selectDedicatedReviewStartLeaseComments(number, comments);
     const dedicatedLeaseComment = selectDedicatedReviewStartLeaseComment(number, comments);

--- a/src/clawsweeper-review-planning-inventory.ts
+++ b/src/clawsweeper-review-planning-inventory.ts
@@ -22,6 +22,11 @@ import {
   PR_ACTIVITY_REVISION_CONNECTION_LIMIT,
   PR_ACTIVITY_REVISION_QUERY_PAGE_SIZE,
 } from "./pr-comment-activity-revision.js";
+import {
+  generationReadKey,
+  type LiveReadGeneration,
+  type LiveReadOptions,
+} from "./live-read-generation.js";
 
 export {
   PR_ACTIVITY_REVISION_CONNECTION_LIMIT,
@@ -180,19 +185,28 @@ export function createReviewPlanningInventory(dependencies: ReviewPlanningDepend
       pagesScanned: result.pagesScanned,
     };
   }
-  function fetchItem(number: number): { item: Item; state: string } {
-    const issue = ghJson<
-      GitHubIssueListItem & {
-        active_lock_reason?: string | null;
-        locked?: boolean;
-        state?: string;
-      }
-    >([
-      "api",
-      `repos/${targetRepo()}/issues/${number}`,
-      "--jq",
-      "{number,title,html_url,created_at,updated_at,closed_at,state,locked,active_lock_reason,author_association,user:{login:.user.login},labels:[.labels[].name],pull_request:(.pull_request // null)}",
-    ]);
+  function fetchItem(
+    number: number,
+    options: LiveReadOptions & { liveReadGeneration?: LiveReadGeneration } = {},
+  ): { item: Item; state: string } {
+    const args = ["api", `repos/${targetRepo()}/issues/${number}`];
+    const readIssue = () =>
+      ghJson<
+        GitHubIssueListItem & {
+          active_lock_reason?: string | null;
+          locked?: boolean;
+          state?: string;
+        }
+      >(args);
+    const issue = options.liveReadGeneration
+      ? options.liveReadGeneration.read(generationReadKey("json", args), readIssue, options)
+      : readIssue();
+    const labels = (issue.labels ?? []).flatMap((label: unknown) => {
+      if (typeof label === "string") return [label];
+      if (!label || typeof label !== "object" || Array.isArray(label)) return [];
+      const name = (label as { name?: unknown }).name;
+      return typeof name === "string" ? [name] : [];
+    });
     return {
       item: {
         repo: targetRepo(),
@@ -205,7 +219,7 @@ export function createReviewPlanningInventory(dependencies: ReviewPlanningDepend
         closedAt: issue.closed_at,
         author: issue.user?.login ?? "unknown",
         authorAssociation: normalizeAuthorAssociation(issue.author_association),
-        labels: issue.labels ?? [],
+        labels,
         locked: issue.locked === true,
         activeLockReason: issue.active_lock_reason ?? null,
       },

--- a/src/live-read-generation.ts
+++ b/src/live-read-generation.ts
@@ -1,0 +1,74 @@
+const generationBrand: unique symbol = Symbol("LiveReadGenerationId");
+
+export type LiveReadGenerationId = number & { readonly [generationBrand]: true };
+
+export interface GenerationBoundValue<T> {
+  readonly generation: LiveReadGenerationId;
+  readonly value: T;
+}
+
+export interface LiveReadOptions {
+  bypassGenerationCache?: boolean;
+}
+
+type LiveReadCacheEntry =
+  | { readonly generation: LiveReadGenerationId; readonly ok: true; readonly value: unknown }
+  | { readonly generation: LiveReadGenerationId; readonly ok: false; readonly error: unknown };
+
+/**
+ * One coherent set of live GitHub reads for one apply item. Mutations advance
+ * the generation and make values bound to the preceding generation unusable.
+ */
+export class LiveReadGeneration {
+  #generation = 1 as LiveReadGenerationId;
+  readonly #cache = new Map<string, LiveReadCacheEntry>();
+
+  get id(): LiveReadGenerationId {
+    return this.#generation;
+  }
+
+  read<T>(key: string, read: () => T, options: LiveReadOptions = {}): T {
+    if (options.bypassGenerationCache) return read();
+    const generation = this.#generation;
+    const cached = this.#cache.get(key);
+    if (cached) {
+      if (cached.generation !== generation) {
+        throw new Error(
+          `live read cache entry ${key} belongs to generation ${cached.generation}, current generation is ${generation}`,
+        );
+      }
+      if (cached.ok) return cached.value as T;
+      throw cached.error;
+    }
+    try {
+      const value = read();
+      this.#cache.set(key, { generation, ok: true, value });
+      return value;
+    } catch (error) {
+      this.#cache.set(key, { generation, ok: false, error });
+      throw error;
+    }
+  }
+
+  bind<T>(value: T): GenerationBoundValue<T> {
+    return { generation: this.#generation, value };
+  }
+
+  value<T>(bound: GenerationBoundValue<T>): T {
+    if (bound.generation !== this.#generation) {
+      throw new Error(
+        `live value belongs to generation ${bound.generation}, current generation is ${this.#generation}`,
+      );
+    }
+    return bound.value;
+  }
+
+  invalidate(): void {
+    this.#cache.clear();
+    this.#generation = (this.#generation + 1) as LiveReadGenerationId;
+  }
+}
+
+export function generationReadKey(kind: string, args: readonly unknown[]): string {
+  return JSON.stringify([kind, ...args]);
+}

--- a/src/pr-hydration-snapshot.ts
+++ b/src/pr-hydration-snapshot.ts
@@ -1,14 +1,14 @@
 import type { ContextHydration } from "./clawsweeper-types.js";
 import { EXACT_REVIEW_DIRECT_PUBLICATION_MAX_FILE_BYTES } from "./exact-review-publication-limits.js";
 
-export const PR_HYDRATION_SNAPSHOT_VERSION = 2;
+export const PR_HYDRATION_SNAPSHOT_VERSION = 3;
 // Canonical publication caps the complete report at 2 MiB; leave half for the
 // review itself and skip caching unusually large review discussions.
 export const MAX_PR_HYDRATION_SNAPSHOT_BYTES = 1 * 1024 * 1024;
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 
-export interface PrHydrationSnapshot {
+export interface PrHydrationSnapshotV2 {
   version: 2;
   repo: string;
   number: number;
@@ -23,7 +23,16 @@ export interface PrHydrationSnapshot {
   completeReviewComments: unknown[];
 }
 
+export interface PrHydrationSnapshotV3 extends Omit<PrHydrationSnapshotV2, "version"> {
+  version: 3;
+  changedFileCount: number;
+  files: ContextHydration<unknown>;
+}
+
+export type PrHydrationSnapshot = PrHydrationSnapshotV2 | PrHydrationSnapshotV3;
+
 export interface PrHydrationResult {
+  files: ContextHydration<unknown>;
   commits: ContextHydration<unknown>;
   reviewComments: ContextHydration<unknown>;
   completeReviewComments: unknown[];
@@ -32,6 +41,7 @@ export interface PrHydrationResult {
   reviewCommentsReused: boolean;
   reviewCommentsIncremental: boolean;
   reviewCommentsFullFallback: boolean;
+  filesReused: boolean;
 }
 
 interface HydratePrListsOptions {
@@ -39,11 +49,14 @@ interface HydratePrListsOptions {
   number: number;
   pullUpdatedAt: string;
   headSha: string;
+  changedFileCount: number;
   commitCount: number;
   reviewCommentCount: number;
   commentActivityRevision: string | null;
   prior: PrHydrationSnapshot | null;
+  requireFullyValidatedSnapshot?: boolean;
   revalidateCommentActivityRevision: () => string | null;
+  fetchFiles?: () => ContextHydration<unknown>;
   fetchCommits: () => ContextHydration<unknown>;
   fetchReviewComments: () => ContextHydration<unknown>;
   fetchCompleteReviewComments: () => unknown[];
@@ -53,11 +66,9 @@ interface HydratePrListsOptions {
 
 export function hydratePrLists(options: HydratePrListsOptions): PrHydrationResult {
   const hydrationStartedAt = options.now?.() ?? new Date().toISOString();
+  const changedFileCount = options.changedFileCount ?? 0;
   const prior = snapshotMatchesPull(options.prior, options) ? options.prior : null;
   const forceFull = prior !== null && prior.headSha.toLowerCase() !== options.headSha.toLowerCase();
-
-  const commitsReused = prior !== null && !forceFull && prior.commitCount === options.commitCount;
-  const commits = commitsReused ? prior.commits : options.fetchCommits();
 
   let reviewComments: ContextHydration<unknown>;
   let completeReviewComments: unknown[];
@@ -83,22 +94,43 @@ export function hydratePrLists(options: HydratePrListsOptions): PrHydrationResul
   }
   const unchanged =
     cacheHitCandidate && hydrationActivityRevision === prior.commentActivityRevision;
-  if (unchanged) {
-    reviewComments = prior.reviewComments;
-    completeReviewComments = prior.completeReviewComments;
+  const fullyValidatedPrior =
+    unchanged &&
+    prior.commitCount === options.commitCount &&
+    (prior.version === 2 ||
+      (prior.changedFileCount === changedFileCount && prior.files.total === changedFileCount))
+      ? prior
+      : null;
+  const reusablePrior = options.requireFullyValidatedSnapshot ? fullyValidatedPrior : prior;
+  const reusableForceFull =
+    reusablePrior !== null && reusablePrior.headSha.toLowerCase() !== options.headSha.toLowerCase();
+  const filesReused =
+    reusablePrior?.version === 3 &&
+    !reusableForceFull &&
+    reusablePrior.changedFileCount === changedFileCount;
+  const files = filesReused ? reusablePrior.files : (options.fetchFiles?.() ?? emptyHydration());
+  const commitsReused =
+    reusablePrior !== null &&
+    !reusableForceFull &&
+    reusablePrior.commitCount === options.commitCount;
+  const commits = commitsReused ? reusablePrior.commits : options.fetchCommits();
+
+  if (unchanged && reusablePrior !== null) {
+    reviewComments = reusablePrior.reviewComments;
+    completeReviewComments = reusablePrior.completeReviewComments;
     reviewCommentsReused = true;
-  } else if (prior !== null && !forceFull && options.reviewCommentCount === 0) {
+  } else if (reusablePrior !== null && !reusableForceFull && options.reviewCommentCount === 0) {
     reviewComments = emptyHydration();
     completeReviewComments = [];
-    reviewCommentsReused = prior.reviewCommentCount === 0;
+    reviewCommentsReused = reusablePrior.reviewCommentCount === 0;
   } else if (
-    prior !== null &&
-    !forceFull &&
-    options.reviewCommentCount >= prior.reviewCommentCount
+    reusablePrior !== null &&
+    !reusableForceFull &&
+    options.reviewCommentCount >= reusablePrior.reviewCommentCount
   ) {
-    const since = incrementalSince(prior);
+    const since = incrementalSince(reusablePrior);
     const delta = options.fetchReviewCommentsSince(since);
-    const merged = mergeReviewComments(prior.completeReviewComments, delta);
+    const merged = mergeReviewComments(reusablePrior.completeReviewComments, delta);
     if (merged !== null && merged.length === options.reviewCommentCount) {
       completeReviewComments = merged;
       reviewComments = hydrationWindow(merged, options.reviewCommentCount, 40);
@@ -109,7 +141,7 @@ export function hydratePrLists(options: HydratePrListsOptions): PrHydrationResul
     }
   } else {
     ({ reviewComments, completeReviewComments } = fullReviewCommentHydration(options));
-    reviewCommentsFullFallback = prior !== null;
+    reviewCommentsFullFallback = reusablePrior !== null;
   }
 
   const snapshot = hydrationActivityRevision
@@ -119,15 +151,18 @@ export function hydratePrLists(options: HydratePrListsOptions): PrHydrationResul
         commentActivityRevision: hydrationActivityRevision,
         pullUpdatedAt: options.pullUpdatedAt,
         headSha: options.headSha,
+        changedFileCount,
         commitCount: options.commitCount,
         reviewCommentCount: options.reviewCommentCount,
         hydratedAt: hydrationStartedAt,
+        files,
         commits,
         reviewComments,
         completeReviewComments,
       })
     : null;
   return {
+    files,
     commits,
     reviewComments,
     completeReviewComments,
@@ -136,6 +171,7 @@ export function hydratePrLists(options: HydratePrListsOptions): PrHydrationResul
     reviewCommentsReused,
     reviewCommentsIncremental,
     reviewCommentsFullFallback,
+    filesReused,
   };
 }
 
@@ -205,11 +241,12 @@ function fullReviewCommentHydration(options: HydratePrListsOptions): {
 }
 
 function createPrHydrationSnapshot(
-  snapshot: Omit<PrHydrationSnapshot, "version">,
-): PrHydrationSnapshot | null {
-  const candidate: PrHydrationSnapshot = {
+  snapshot: Omit<PrHydrationSnapshotV3, "version">,
+): PrHydrationSnapshotV3 | null {
+  const candidate: PrHydrationSnapshotV3 = {
     version: PR_HYDRATION_SNAPSHOT_VERSION,
     ...snapshot,
+    files: minimizeHydration(snapshot.files, minimizePullFile),
     commits: minimizeHydration(snapshot.commits, minimizeCommit),
     reviewComments: minimizeHydration(snapshot.reviewComments, minimizeReviewComment),
     completeReviewComments: snapshot.completeReviewComments.map(minimizeReviewComment),
@@ -222,22 +259,43 @@ function createPrHydrationSnapshot(
 
 function validPrHydrationSnapshot(value: unknown): value is PrHydrationSnapshot {
   const snapshot = record(value);
+  const versionSpecific =
+    snapshot.version === 2
+      ? exactKeys(snapshot, [
+          "commentActivityRevision",
+          "commitCount",
+          "commits",
+          "completeReviewComments",
+          "headSha",
+          "hydratedAt",
+          "number",
+          "pullUpdatedAt",
+          "repo",
+          "reviewCommentCount",
+          "reviewComments",
+          "version",
+        ])
+      : snapshot.version === PR_HYDRATION_SNAPSHOT_VERSION &&
+        exactKeys(snapshot, [
+          "changedFileCount",
+          "commentActivityRevision",
+          "commitCount",
+          "commits",
+          "completeReviewComments",
+          "files",
+          "headSha",
+          "hydratedAt",
+          "number",
+          "pullUpdatedAt",
+          "repo",
+          "reviewCommentCount",
+          "reviewComments",
+          "version",
+        ]) &&
+        nonnegativeInteger(snapshot.changedFileCount) &&
+        validHydration(snapshot.files, validMinimizedPullFile);
   return (
-    exactKeys(snapshot, [
-      "commentActivityRevision",
-      "commitCount",
-      "commits",
-      "completeReviewComments",
-      "headSha",
-      "hydratedAt",
-      "number",
-      "pullUpdatedAt",
-      "repo",
-      "reviewCommentCount",
-      "reviewComments",
-      "version",
-    ]) &&
-    snapshot.version === PR_HYDRATION_SNAPSHOT_VERSION &&
+    versionSpecific &&
     typeof snapshot.repo === "string" &&
     /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(snapshot.repo) &&
     positiveInteger(snapshot.number) &&
@@ -250,7 +308,10 @@ function validPrHydrationSnapshot(value: unknown): value is PrHydrationSnapshot 
     nonnegativeInteger(snapshot.reviewCommentCount) &&
     validTimestamp(snapshot.hydratedAt) &&
     validHydration(snapshot.commits, validMinimizedCommit) &&
+    record(snapshot.commits).total === snapshot.commitCount &&
     validHydration(snapshot.reviewComments, validMinimizedReviewComment) &&
+    record(snapshot.reviewComments).total === snapshot.reviewCommentCount &&
+    (snapshot.version !== 3 || record(snapshot.files).total === snapshot.changedFileCount) &&
     Array.isArray(snapshot.completeReviewComments) &&
     snapshot.completeReviewComments.length === snapshot.reviewCommentCount &&
     snapshot.completeReviewComments.every(validMinimizedReviewComment)
@@ -308,6 +369,19 @@ function minimizeCommit(value: unknown): unknown {
   };
 }
 
+function minimizePullFile(value: unknown): unknown {
+  const source = record(value);
+  return {
+    filename: source.filename ?? null,
+    previous_filename: source.previous_filename ?? null,
+    status: source.status ?? null,
+    additions: source.additions ?? null,
+    deletions: source.deletions ?? null,
+    changes: source.changes ?? null,
+    patch: source.patch ?? null,
+  };
+}
+
 function minimizeReviewComment(value: unknown): unknown {
   const source = record(value);
   const user = record(source.user);
@@ -346,6 +420,28 @@ function validMinimizedCommit(value: unknown): boolean {
     typeof commit.message === "string" &&
     (commitAuthor === null ||
       (exactKeys(commitAuthor, ["name"]) && typeof commitAuthor.name === "string"))
+  );
+}
+
+function validMinimizedPullFile(value: unknown): boolean {
+  const source = record(value);
+  return (
+    exactKeys(source, [
+      "additions",
+      "changes",
+      "deletions",
+      "filename",
+      "patch",
+      "previous_filename",
+      "status",
+    ]) &&
+    typeof source.filename === "string" &&
+    nullableString(source.previous_filename) &&
+    nullableString(source.status) &&
+    nullableInteger(source.additions) &&
+    nullableInteger(source.deletions) &&
+    nullableInteger(source.changes) &&
+    nullableString(source.patch)
   );
 }
 

--- a/test/apply-guard-read-cache.test.ts
+++ b/test/apply-guard-read-cache.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createApplyGuards } from "../dist/clawsweeper-apply-guards.js";
+import { LiveReadGeneration } from "../dist/live-read-generation.js";
 
 function asRecord(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
@@ -134,26 +135,23 @@ test("apply guard read cache resets between items", () => {
   ]);
 });
 
-test("apply guard read cache distinguishes full request arguments", () => {
+test("apply policy guards share canonical full-object reads", () => {
   const calls = [];
   const guards = createGuards({
     ghJson: (args) => {
       calls.push(args);
       const path = args[1];
       if (path?.endsWith("/issues/42")) return { assignees: [] };
-      if (path?.endsWith("/pulls/42")) {
-        return args.includes("--jq")
-          ? { requested_reviewers: [], requested_teams: [] }
-          : {
-              created_at: "2025-01-01T00:00:00Z",
-              mergeable: false,
-              mergeable_state: "dirty",
-              requested_reviewers: [],
-              requested_teams: [],
-              user: { login: "contributor" },
-              head: {},
-            };
-      }
+      if (path?.endsWith("/pulls/42"))
+        return {
+          created_at: "2025-01-01T00:00:00Z",
+          mergeable: false,
+          mergeable_state: "dirty",
+          requested_reviewers: [],
+          requested_teams: [],
+          user: { login: "contributor" },
+          head: {},
+        };
       return {};
     },
   });
@@ -163,13 +161,31 @@ test("apply guard read cache distinguishes full request arguments", () => {
   guards.lowSignalUnmergeablePrApplyBlockReasonSafe(42, 30);
 
   const pullCalls = calls.filter((args) => args[1] === "repos/openclaw/openclaw/pulls/42");
-  assert.equal(pullCalls.length, 2);
-  assert.equal(
-    pullCalls.some((args) => args.includes("--jq")),
-    true,
+  assert.equal(pullCalls.length, 1);
+  assert.equal(pullCalls[0]?.includes("--jq"), false);
+});
+
+test("apply guards follow generation invalidation and explicit bypass", () => {
+  let calls = 0;
+  const guards = createGuards({
+    ghPaged: () => {
+      calls += 1;
+      return [];
+    },
+  });
+  const generation = new LiveReadGeneration();
+  guards.setGuardReadGeneration(generation);
+
+  guards.issueRecentHumanCommentBlockReasonSafe(42, 30);
+  guards.issueRecentHumanCommentBlockReasonSafe(42, 30);
+  assert.equal(calls, 1);
+
+  generation.invalidate();
+  guards.issueRecentHumanCommentBlockReasonSafe(42, 30);
+  assert.equal(calls, 2);
+
+  guards.withGuardReadOptions({ bypassGenerationCache: true }, () =>
+    guards.issueRecentHumanCommentBlockReasonSafe(42, 30),
   );
-  assert.equal(
-    pullCalls.some((args) => !args.includes("--jq")),
-    true,
-  );
+  assert.equal(calls, 3);
 });

--- a/test/apply-read-generations-loopback.test.ts
+++ b/test/apply-read-generations-loopback.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+test("apply read-generation loopback proof preserves mutation barriers", () => {
+  const output = execFileSync(
+    process.execPath,
+    ["scripts/e2e/apply-read-generations-loopback.mjs"],
+    { encoding: "utf8" },
+  );
+  const result = JSON.parse(output);
+  assert.deepEqual(result.counted_formula, {
+    before: "F(1)+C(4)+P(6)+L(3)=14",
+    after: "U(6)+L_live(3)=9",
+  });
+  assert.equal(result.concurrent_head_blocked, true);
+  assert.equal(result.concurrent_comment_blocked, true);
+  assert.deepEqual(result.validated_snapshot_list_reads, {
+    files: 0,
+    commits: 0,
+    inline_comments: 0,
+  });
+});

--- a/test/clawsweeper-action-ledger.test.ts
+++ b/test/clawsweeper-action-ledger.test.ts
@@ -574,7 +574,7 @@ test("apply receipts start per item and persist mutation observation before fina
     source,
     /const commentMutationOccurred = result\.commentMutationOccurred === true;[\s\S]*applyActionEventDisposition\([\s\S]*commentMutationOccurred,[\s\S]*reviewCommentPublicationEventDisposition\([\s\S]*commentMutationOccurred,/,
   );
-  assert.match(applyLoop, /executeApplyClose\(dependencies, \{/);
+  assert.match(applyLoop, /executeApplyClose\(\s*\{/);
   assert.match(
     readText("src/clawsweeper-apply-close-execution.ts"),
     /closeItem\(\{ number, kind: item\.kind/,

--- a/test/live-read-generation.test.ts
+++ b/test/live-read-generation.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LiveReadGeneration } from "../dist/live-read-generation.js";
+import { createReviewPlanningInventory } from "../dist/clawsweeper-review-planning-inventory.js";
+
+test("live reads are shared only inside one generation", () => {
+  const generation = new LiveReadGeneration();
+  let calls = 0;
+  const read = () => generation.read("issue:42", () => ++calls);
+
+  assert.equal(read(), 1);
+  assert.equal(read(), 1);
+  assert.equal(calls, 1);
+
+  generation.invalidate();
+  assert.equal(read(), 2);
+  assert.equal(calls, 2);
+});
+
+test("generation bypass always reaches the live reader", () => {
+  const generation = new LiveReadGeneration();
+  let calls = 0;
+  const read = () => ++calls;
+
+  assert.equal(generation.read("comments:42", read), 1);
+  assert.equal(generation.read("comments:42", read), 1);
+  assert.equal(generation.read("comments:42", read, { bypassGenerationCache: true }), 2);
+  assert.equal(generation.read("comments:42", read, { bypassGenerationCache: true }), 3);
+});
+
+test("values bound before a mutation cannot cross the generation boundary", () => {
+  const generation = new LiveReadGeneration();
+  const bound = generation.bind({ state: "open" });
+
+  generation.invalidate();
+  assert.throws(() => generation.value(bound), /belongs to generation 1, current generation is 2/);
+});
+
+test("fetchItem shares the full issue read and normalizes live label objects", () => {
+  let calls = 0;
+  const inventory = createReviewPlanningInventory({
+    targetRepo: () => "openclaw/clawsweeper",
+    ghJson: () => {
+      calls += 1;
+      return {
+        number: 42,
+        title: "Generation proof",
+        html_url: "https://github.com/openclaw/clawsweeper/issues/42",
+        created_at: "2026-08-13T00:00:00Z",
+        updated_at: "2026-08-13T00:00:00Z",
+        state: "open",
+        user: { login: "contributor" },
+        labels: [{ name: "bug" }, { name: "clawsweeper:ready" }],
+      };
+    },
+    ghJsonLines: () => [],
+    normalizeAuthorAssociation: () => "CONTRIBUTOR",
+    indexedExistingReview: () => null,
+  });
+  const generation = new LiveReadGeneration();
+
+  const first = inventory.fetchItem(42, { liveReadGeneration: generation });
+  const second = inventory.fetchItem(42, { liveReadGeneration: generation });
+  assert.equal(calls, 1);
+  assert.deepEqual(first.item.labels, ["bug", "clawsweeper:ready"]);
+  assert.deepEqual(second, first);
+});

--- a/test/pr-hydration-snapshot.test.ts
+++ b/test/pr-hydration-snapshot.test.ts
@@ -49,6 +49,18 @@ function comment(id: number, updatedAt: string, body: string) {
   };
 }
 
+function pullFile(filename: string) {
+  return {
+    filename,
+    previous_filename: null,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    changes: 2,
+    patch: "@@ -1 +1 @@\n-old\n+new",
+  };
+}
+
 function hydration(items: unknown[]) {
   return { items, total: items.length, hydrated: items.length, truncated: false };
 }
@@ -176,6 +188,146 @@ test("unchanged PR hydration snapshots reuse both lists after one hydration-time
   }
   assert.equal(listCalls, 0);
   assert.equal(hydrationRevisionCalls, 3, "each cache-hit candidate pays one revision check");
+});
+
+test("apply-style validation reuses files, commits, and inline comments only after a live match", () => {
+  const files = [pullFile("src/example.ts")];
+  const commits = [commit("9".repeat(40), "same")];
+  const comments = [comment(9, firstUpdatedAt, "same")];
+  const cold = hydratePrLists({
+    repo,
+    number: 49,
+    pullUpdatedAt: firstUpdatedAt,
+    headSha: oldHead,
+    changedFileCount: files.length,
+    commitCount: commits.length,
+    reviewCommentCount: comments.length,
+    commentActivityRevision: activityRevisionA,
+    prior: null,
+    fetchFiles: () => hydration(files),
+    fetchCommits: () => hydration(commits),
+    fetchReviewComments: () => hydration(comments),
+    fetchCompleteReviewComments: () => comments,
+    fetchReviewCommentsSince: () => [],
+    revalidateCommentActivityRevision: () => null,
+  });
+  assert.ok(cold.snapshot);
+
+  let listReads = 0;
+  const reused = hydratePrLists({
+    repo,
+    number: 49,
+    pullUpdatedAt: firstUpdatedAt,
+    headSha: oldHead,
+    changedFileCount: files.length,
+    commitCount: commits.length,
+    reviewCommentCount: comments.length,
+    commentActivityRevision: activityRevisionA,
+    prior: cold.snapshot,
+    requireFullyValidatedSnapshot: true,
+    revalidateCommentActivityRevision: () => activityRevisionA,
+    fetchFiles: () => {
+      listReads += 1;
+      return hydration(files);
+    },
+    fetchCommits: () => {
+      listReads += 1;
+      return hydration(commits);
+    },
+    fetchReviewComments: () => {
+      listReads += 1;
+      return hydration(comments);
+    },
+    fetchCompleteReviewComments: () => comments,
+    fetchReviewCommentsSince: () => {
+      throw new Error("validated apply reuse must not take the incremental path");
+    },
+  });
+  assert.equal(listReads, 0);
+  assert.equal(reused.filesReused, true);
+  assert.equal(reused.commitsReused, true);
+  assert.equal(reused.reviewCommentsReused, true);
+
+  const mismatchReads: string[] = [];
+  const mismatched = hydratePrLists({
+    repo,
+    number: 49,
+    pullUpdatedAt: firstUpdatedAt,
+    headSha: oldHead,
+    changedFileCount: files.length,
+    commitCount: commits.length,
+    reviewCommentCount: comments.length,
+    commentActivityRevision: activityRevisionA,
+    prior: cold.snapshot,
+    requireFullyValidatedSnapshot: true,
+    revalidateCommentActivityRevision: () => activityRevisionB,
+    fetchFiles: () => {
+      mismatchReads.push("files");
+      return hydration(files);
+    },
+    fetchCommits: () => {
+      mismatchReads.push("commits");
+      return hydration(commits);
+    },
+    fetchReviewComments: () => {
+      mismatchReads.push("inline-comments");
+      return hydration(comments);
+    },
+    fetchCompleteReviewComments: () => comments,
+    fetchReviewCommentsSince: () => {
+      throw new Error("strict mismatch must use normal full reads");
+    },
+  });
+  assert.deepEqual(mismatchReads, ["files", "commits", "inline-comments"]);
+  assert.equal(mismatched.filesReused, false);
+  assert.equal(mismatched.commitsReused, false);
+  assert.equal(mismatched.reviewCommentsReused, false);
+});
+
+test("apply consumes validated v2 snapshots while hydrating their missing file window", () => {
+  const current = initialSnapshot({
+    number: 50,
+    commits: [commit("5".repeat(40), "same")],
+    comments: [comment(50, firstUpdatedAt, "same")],
+  });
+  assert.equal(current.version, 3);
+  if (current.version !== 3) throw new Error("expected current hydration snapshot version");
+  const { changedFileCount: _changedFileCount, files: _files, ...fields } = current;
+  const prior = { ...fields, version: 2 as const };
+  const listReads: string[] = [];
+  const result = hydratePrLists({
+    repo,
+    number: 50,
+    pullUpdatedAt: firstUpdatedAt,
+    headSha: oldHead,
+    changedFileCount: 1,
+    commitCount: 1,
+    reviewCommentCount: 1,
+    commentActivityRevision: activityRevisionA,
+    prior,
+    requireFullyValidatedSnapshot: true,
+    revalidateCommentActivityRevision: () => activityRevisionA,
+    fetchFiles: () => {
+      listReads.push("files");
+      return hydration([pullFile("src/example.ts")]);
+    },
+    fetchCommits: () => {
+      listReads.push("commits");
+      return hydration([]);
+    },
+    fetchReviewComments: () => {
+      listReads.push("inline-comments");
+      return hydration([]);
+    },
+    fetchCompleteReviewComments: () => [],
+    fetchReviewCommentsSince: () => [],
+  });
+
+  assert.deepEqual(listReads, ["files"]);
+  assert.equal(result.filesReused, false);
+  assert.equal(result.commitsReused, true);
+  assert.equal(result.reviewCommentsReused, true);
+  assert.equal(result.snapshot?.version, 3);
 });
 
 test("changed PRs preserve full hydration bytes with partial or full reads", () => {
@@ -424,6 +576,11 @@ test("hydration snapshot front matter round-trips", () => {
   });
   const serialized = serializePrHydrationSnapshot(snapshot);
   assert.deepEqual(parsePrHydrationSnapshot(serialized), snapshot);
+  assert.equal(snapshot.version, 3);
+  if (snapshot.version !== 3) throw new Error("expected current hydration snapshot version");
+  const { changedFileCount: _changedFileCount, files: _files, ...v2Fields } = snapshot;
+  const v2 = { ...v2Fields, version: 2 as const };
+  assert.deepEqual(parsePrHydrationSnapshot(JSON.stringify(v2)), v2);
   for (const omittedField of [
     "avatar_url",
     "diff_hunk",


### PR DESCRIPTION
## What Problem This Solves

Publication apply repeatedly reads the same issue, pull request, comments, timeline, policy, and lease state inside one item decision. The 2026-08-13 GitHub API savings analysis ranked this as opportunity 2, specifically its “Publication apply” and “Lease and mutation barriers” findings: duplicate reads are reducible, but the final mutation guards must remain authoritative and live.

## Why This Change Was Made

Apply now creates one explicit `LiveReadGeneration` per item. Identical reads share one generation-owned result, every observed GitHub mutation advances the generation, and generation-bound context cannot cross that boundary without a runtime assertion. The two-sided lease checks and final proof/comment/close guards use an explicit cache-bypass option.

Apply also consumes the persisted PR hydration snapshot. Existing v2 snapshots immediately reuse commits and inline comments after live validation; v3 snapshots additionally carry the bounded pull-file window. A v3 hit therefore removes all three REST list reads. Any head, `updated_at`, count, or just-in-time activity-revision mismatch takes the normal full-read path.

Generation semantics:

| Boundary | Generation action | Freshness rule |
| --- | --- | --- |
| Start one apply item | Create generation 1 | `fetchItem`, context hydration, and policy reads may share identical keys |
| Successful/ambiguous GitHub mutation attempt | Invalidate and advance | Cached entries are cleared; generation-bound context is discarded |
| Durable comment, label, lease, placeholder, or close mutation | Same observed mutation runner | No mutation site can retain the preceding generation |
| Two-sided lease check | Bypass | Head/source, comments, then head/source all hit live transport |
| Final proof / comment / close guard | Bypass | Warm generation state cannot satisfy the mutation barrier |

## User Impact

Operators should see fewer GitHub REST reads during apply without any reduction in race protection. There is no end-user UI change.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes internal publication-apply reads and persisted cache metadata only; Bay’s observer-only data contract and action boundary do not change.

## Documentation Lifecycle

The proof package under `docs/proof/apply-read-generations/` is historical validation evidence owned by ClawSweeper publication maintainers. No active runbook or public product documentation changes.

## Evidence

- `pnpm run check`: 3,444 tests, 3,435 passed, 9 platform skips, 0 failures; dashboard-strict, builds, lint, docs, formatting, and coverage thresholds passed. Coverage: 81.57% lines, 74.01% branches, 87.39% functions.
- Focused current-head integration after rebasing onto #1160: 79/79 passed.
- Pre-commit and committed-branch autoreview: clean, no accepted/actionable findings.
- Docker-backed Crabbox `local-container` receipt: `cbx_0241049e673e` (`golden-barnacle-01a8`), Ubuntu 26.04/arm64, fresh PR checkout, exit 0, automatically stopped. Static receipt: `docs/proof/apply-read-generations/receipt.json`.

## Real Behavior Proof

**Claim:** Apply shares identical reads only within an explicit generation, invalidates on every observed GitHub mutation, and still blocks concurrent head/comment changes at its live barriers. A validated v3 hydration snapshot performs zero pull-file, commit, or inline-comment REST list reads.

**Exercised surface:** Production `LiveReadGeneration`, apply guard memoization, two-sided lease guard, mutation-boundary wiring, and `hydratePrLists`, backed by real loopback HTTP endpoints.

**Scenario:** Warm pull/comment reads; run pre-comment and pre-close lease barriers; advance the generation after a concurrent head change or new durable comment; validate a persisted v3 snapshot against live pull and activity watermarks.

**Command/environment:** Node 24.19.0 and pnpm 11.10.0, locally and through Crabbox Docker `provider=local-container` on Ubuntu 26.04/arm64.

**Observable result:** Each warm-cache barrier still issued two live pull reads and one live comment read. Both concurrent changes blocked apply. The representative formula changed from `F(1)+C(4)+P(6)+L(3)=14` requests to `U(6)+L_live(3)=9`; the irreducible `L(3)` stayed live. Validated snapshot list counts were files=0, commits=0, inline-comments=0.

**Artifact/trace:** `scripts/e2e/apply-read-generations-loopback.mjs`, its Node test, and the static receipt in `docs/proof/apply-read-generations/`. The receipt binds tested source `82d9a3b14961793d13f3d0b113078eb84e4caf00`, tree `feb92bdcd220ed054fe9a73e1615bb327802d0d5`, provider, lease, image, timings, formulas, assertions, and full-gate totals.

**Limits:** The controlled transport is deterministic loopback HTTP, not a live target mutation. Old v2 snapshots lack files, so they reuse validated commits/comments while performing one normal file-list read; new v3 snapshots reach zero for all three lists. The successful Crabbox run covers toolchain/build/source/proof. The exact-source complete gate is recorded on the Node 24 host because Linux cursor-trace workflow fixtures reject Linux filesystem metadata. No latency claim is made.
