### PR TITLE
fix(review): enable hosted Linux sandbox

### DIFF
--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -52,6 +52,28 @@ runs:
         fi
         codex --version
 
+    - name: Enable Linux user namespaces for bubblewrap
+      if: ${{ runner.os == 'Linux' && runner.environment == 'github-hosted' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Codex read-only reviews use bubblewrap. Newer Ubuntu images otherwise
+        # reject its loopback setup before the first repository command runs.
+        current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+        if [[ -n "$current_userns" && "$current_userns" != "1" ]]; then
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+        fi
+
+        current_apparmor="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+        if [[ -n "$current_apparmor" && "$current_apparmor" != "0" ]]; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
+
+        # Exercise the same read-only, network-isolated backend used by reviews.
+        # A sandbox regression must stop the job before it can publish a verdict.
+        codex sandbox --permission-profile :read-only -C "$GITHUB_WORKSPACE" -- /bin/true
+
     - name: Resolve Codex home
       shell: bash
       run: |

--- a/test/clawsweeper.test.ts
+++ b/test/clawsweeper.test.ts
@@ -2346,6 +2346,13 @@ test("agent workflows install pinned CLI releases and keep runner models secret"
   assert.doesNotMatch(localCheck, /gpt-5\.5/);
   assert.match(action, /env -u OPENAI_API_KEY[\s\S]*-u CLAWSWEEPER_INTERNAL_MODEL/);
   assert.equal(action.match(/--ignore-scripts/g)?.length, 2);
+  assert.match(action, /runner\.os == 'Linux' && runner\.environment == 'github-hosted'/);
+  assert.match(action, /kernel\.unprivileged_userns_clone=1/);
+  assert.match(action, /kernel\.apparmor_restrict_unprivileged_userns=0/);
+  assert.match(
+    action,
+    /codex sandbox --permission-profile :read-only -C "\$GITHUB_WORKSPACE" -- \/bin\/true/,
+  );
   for (const workflow of workflows) {
     assert.match(workflow, /CLAWSWEEPER_MODEL: internal/);
     assert.match(workflow, /CLAWSWEEPER_INTERNAL_MODEL: \$\{\{ secrets\.CLAWSWEEPER_MODEL \}\}/);


### PR DESCRIPTION
## Summary

- enable the Linux user-namespace settings required by the hosted review sandbox
- verify the real read-only, network-isolated sandbox before authentication or review execution
- fail the setup step instead of publishing a verdict when sandbox startup is broken

## Root cause

The hosted Ubuntu runner allowed the review process to start, but AppArmor rejected bubblewrap while it configured loopback inside the isolated network namespace. Every repository command failed before execution, yet the degraded report could still reach publication.

The setup action now applies the same hosted-Linux preparation used by the upstream action, then exercises the exact review permission profile with `/bin/true`. Self-hosted and non-Linux runners are unchanged.

## Behavior

Before: a review could publish after every checkout command failed with `RTM_NEWADDR: Operation not permitted`.

After: hosted Linux must enter the read-only, network-isolated sandbox successfully before the review starts. A sandbox regression stops the workflow before a verdict can be produced.

## Proof

- action contract: 77/77 tests passed
- formatting: clean
- diff check: clean
- independent pre-commit review: no findings
- independent post-commit review: no findings
- hosted proof: [run 31771166758](https://github.com/openclaw/clawsweeper/actions/runs/31771166758), exact branch `fad063b7e6d9`
  - the hosted Ubuntu setup action and its exact `:read-only` sandbox smoke passed
  - the target checkout then completed successfully, with no bubblewrap or `RTM_NEWADDR` failure
  - the later target review lease stopped on a separate GitHub installation rate limit before repository review; no degraded verdict was published

## Scope

- workflow code: +22/-0
- tests: +7/-0
- no dashboard, status-record, review-schema, or target-repository behavior changes
- self-hosted runners are intentionally excluded from the hosted-runner kernel preparation
