### PR TITLE
perf(review): cache exact-review bundles in R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ packets; labels and report prose do not reconstruct the decision. Pass
 profile's default records directory.
 
 Canonical review records live in the Cloudflare Durable Object store and are
-snapshotted to R2. Immutable `ledger/v1/` action events and published `assets/`
-also live in R2. The `state` branch of `openclaw/clawsweeper-state` now retains
+snapshotted to R2. Immutable `ledger/v1/` action events, published `assets/`,
+and the bounded content-addressed `artifacts/exact-review/v1/` retry cache also
+live in R2. The `state` branch of `openclaw/clawsweeper-state` now retains
 only `jobs/`, `results/`, `notifications/`, `apply-report.json`, and
 `repair-apply-report.json`; its `main` branch remains the dashboard renderer
 source. `scripts/hydrate-state.ts` combines those sources for local commands.

--- a/dashboard/exact-review-artifact-cache.ts
+++ b/dashboard/exact-review-artifact-cache.ts
@@ -1,0 +1,349 @@
+export const EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE = "exact_review_artifact_receipts";
+const EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE = "exact_review_artifact_cache_meta";
+export const EXACT_REVIEW_ARTIFACT_CACHE_PREFIX = "artifacts/exact-review/v1/";
+export const EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const ITEM_KEY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+$/;
+const ARTIFACT_NAME_PATTERN = /^[A-Za-z0-9_.-]{1,200}$/;
+const CLEANUP_LIMIT = 128;
+
+type SqlRow = Record<string, unknown>;
+type ArtifactReceiptStorage = {
+  sql: { exec: (query: string, ...bindings: unknown[]) => Iterable<SqlRow> };
+  transactionSync: <T>(callback: () => T) => T;
+};
+
+type ArtifactR2Object = {
+  key: string;
+  size: number;
+  uploaded?: Date;
+  customMetadata?: Record<string, string>;
+};
+
+type ArtifactR2Bucket = {
+  head: (key: string) => Promise<ArtifactR2Object | null>;
+  list: (options: {
+    prefix: string;
+    cursor?: string;
+    limit: number;
+    include: string[];
+  }) => Promise<{ objects: ArtifactR2Object[]; truncated: boolean; cursor?: string }>;
+  delete: (key: string) => Promise<void>;
+};
+
+export type ExactReviewArtifactReceiptTuple = {
+  producerRunId: string;
+  producerRunAttempt: number;
+  artifactName: string;
+  canonicalItemKey: string;
+  leaseRevision: number;
+  protocolVersion: number;
+};
+
+export type ExactReviewArtifactReceipt = ExactReviewArtifactReceiptTuple & {
+  digest: string;
+  bytes: number;
+  objectKey: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type ExactReviewArtifactReceiptStoreResult =
+  | { ok: true; receipt: ExactReviewArtifactReceipt; deduped: boolean }
+  | { ok: false; error: string; status: number };
+
+export function exactReviewArtifactReceiptTuple(
+  value: unknown,
+): ExactReviewArtifactReceiptTuple | null {
+  const body = objectValue(value);
+  const producerRunId = String(body.producer_run_id || "").trim();
+  const producerRunAttempt = Number(body.producer_run_attempt);
+  const artifactName = String(body.artifact_name || "").trim();
+  const canonicalItemKey = String(body.canonical_item_key || "").trim();
+  const leaseRevision = Number(body.lease_revision);
+  const protocolVersion = Number(body.protocol_version);
+  if (
+    !/^\d+$/.test(producerRunId) ||
+    !Number.isSafeInteger(producerRunAttempt) ||
+    producerRunAttempt < 1 ||
+    !ARTIFACT_NAME_PATTERN.test(artifactName) ||
+    !ITEM_KEY_PATTERN.test(canonicalItemKey) ||
+    !Number.isSafeInteger(leaseRevision) ||
+    leaseRevision < 1 ||
+    !Number.isSafeInteger(protocolVersion) ||
+    protocolVersion < 1
+  ) {
+    return null;
+  }
+  return {
+    producerRunId,
+    producerRunAttempt,
+    artifactName,
+    canonicalItemKey,
+    leaseRevision,
+    protocolVersion,
+  };
+}
+
+export function exactReviewArtifactObjectKey(digest: string): string | null {
+  return DIGEST_PATTERN.test(digest) ? `${EXACT_REVIEW_ARTIFACT_CACHE_PREFIX}${digest}` : null;
+}
+
+export class ExactReviewArtifactReceiptStore {
+  private readonly storage: ArtifactReceiptStorage;
+  private readonly bucket: ArtifactR2Bucket | null;
+
+  constructor(storage: ArtifactReceiptStorage, bucketBinding: unknown) {
+    this.storage = storage;
+    this.bucket = artifactBucket(bucketBinding);
+  }
+
+  ensureSchemaSync() {
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE} (
+         producer_run_id TEXT NOT NULL,
+         producer_run_attempt INTEGER NOT NULL CHECK (producer_run_attempt >= 1),
+         artifact_name TEXT NOT NULL,
+         canonical_item_key TEXT NOT NULL,
+         lease_revision INTEGER NOT NULL CHECK (lease_revision >= 1),
+         protocol_version INTEGER NOT NULL CHECK (protocol_version >= 1),
+         digest TEXT NOT NULL,
+         bytes INTEGER NOT NULL CHECK (bytes >= 1),
+         object_key TEXT NOT NULL,
+         created_at INTEGER NOT NULL,
+         expires_at INTEGER NOT NULL,
+         PRIMARY KEY (
+           producer_run_id, producer_run_attempt, artifact_name,
+           canonical_item_key, lease_revision, protocol_version
+         )
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_artifact_receipts_expiry
+         ON ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE} (expires_at, digest)`,
+    );
+    this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE} (
+         singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+         prune_cursor TEXT
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
+      `INSERT OR IGNORE INTO ${EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE}
+         (singleton_id, prune_cursor) VALUES (1, NULL)`,
+    );
+  }
+
+  lookup(value: unknown, now: number): ExactReviewArtifactReceipt | null {
+    const tuple = exactReviewArtifactReceiptTuple(value);
+    if (!tuple) return null;
+    this.deleteExpiredReceiptsSync(now);
+    const row = firstRow(
+      this.storage.sql.exec(
+        `SELECT digest, bytes, object_key, created_at, expires_at
+           FROM ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE}
+          WHERE producer_run_id = ? AND producer_run_attempt = ? AND artifact_name = ?
+            AND canonical_item_key = ? AND lease_revision = ? AND protocol_version = ?
+            AND expires_at > ?`,
+        tuple.producerRunId,
+        tuple.producerRunAttempt,
+        tuple.artifactName,
+        tuple.canonicalItemKey,
+        tuple.leaseRevision,
+        tuple.protocolVersion,
+        now,
+      ),
+    );
+    return row ? receiptFromRow(tuple, row) : null;
+  }
+
+  async store(value: unknown, now: number): Promise<ExactReviewArtifactReceiptStoreResult> {
+    const tuple = exactReviewArtifactReceiptTuple(value);
+    const body = objectValue(value);
+    const digest = String(body.digest || "").trim();
+    const bytes = Number(body.bytes);
+    const objectKey = exactReviewArtifactObjectKey(digest);
+    if (!tuple || !objectKey || !Number.isSafeInteger(bytes) || bytes < 1) {
+      return { ok: false, error: "invalid_artifact_receipt", status: 400 };
+    }
+    if (!this.bucket) {
+      return { ok: false, error: "artifact_cache_unavailable", status: 503 };
+    }
+    const object = await this.bucket.head(objectKey);
+    if (!object || object.size !== bytes || object.customMetadata?.sha256 !== digest) {
+      return { ok: false, error: "artifact_cache_object_mismatch", status: 409 };
+    }
+    const expiresAt = now + EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS;
+    const stored = this.storage.transactionSync(() => {
+      this.deleteExpiredReceiptsSync(now);
+      const existing = this.lookupExactSync(tuple);
+      if (existing && (existing.digest !== digest || existing.bytes !== bytes)) {
+        return { conflict: true as const };
+      }
+      this.storage.sql.exec(
+        `INSERT INTO ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE}
+           (producer_run_id, producer_run_attempt, artifact_name, canonical_item_key,
+            lease_revision, protocol_version, digest, bytes, object_key, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (
+           producer_run_id, producer_run_attempt, artifact_name,
+           canonical_item_key, lease_revision, protocol_version
+         ) DO UPDATE SET expires_at = excluded.expires_at`,
+        tuple.producerRunId,
+        tuple.producerRunAttempt,
+        tuple.artifactName,
+        tuple.canonicalItemKey,
+        tuple.leaseRevision,
+        tuple.protocolVersion,
+        digest,
+        bytes,
+        objectKey,
+        now,
+        expiresAt,
+      );
+      return { conflict: false as const, deduped: Boolean(existing) };
+    });
+    if (stored.conflict) {
+      return { ok: false, error: "artifact_receipt_immutable_conflict", status: 409 };
+    }
+    const receipt = this.lookupExactSync(tuple);
+    if (!receipt) {
+      return { ok: false, error: "artifact_receipt_store_failed", status: 503 };
+    }
+    return {
+      ok: true,
+      deduped: stored.deduped,
+      receipt,
+    };
+  }
+
+  async prune(now: number): Promise<{ receiptsDeleted: number; objectsDeleted: number }> {
+    const receiptsDeleted = this.deleteExpiredReceiptsSync(now);
+    if (!this.bucket) return { receiptsDeleted, objectsDeleted: 0 };
+    const cursorRow = firstRow(
+      this.storage.sql.exec(
+        `SELECT prune_cursor FROM ${EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE}
+          WHERE singleton_id = 1`,
+      ),
+    );
+    const cursor = typeof cursorRow?.prune_cursor === "string" ? cursorRow.prune_cursor : null;
+    const page = await this.bucket.list({
+      prefix: EXACT_REVIEW_ARTIFACT_CACHE_PREFIX,
+      ...(cursor ? { cursor } : {}),
+      limit: CLEANUP_LIMIT,
+      include: ["customMetadata"],
+    });
+    let objectsDeleted = 0;
+    const cutoff = now - EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS;
+    for (const object of page.objects) {
+      const uploadedAt = object.uploaded?.getTime();
+      if (!Number.isFinite(uploadedAt) || Number(uploadedAt) > cutoff) continue;
+      const digest = object.key.slice(EXACT_REVIEW_ARTIFACT_CACHE_PREFIX.length);
+      if (!DIGEST_PATTERN.test(digest) || this.hasLiveDigestSync(digest, now)) continue;
+      await this.bucket.delete(object.key);
+      objectsDeleted += 1;
+    }
+    this.storage.sql.exec(
+      `UPDATE ${EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE}
+          SET prune_cursor = ? WHERE singleton_id = 1`,
+      page.truncated && page.cursor ? page.cursor : null,
+    );
+    return { receiptsDeleted, objectsDeleted };
+  }
+
+  private lookupExactSync(
+    tuple: ExactReviewArtifactReceiptTuple,
+  ): ExactReviewArtifactReceipt | null {
+    const row = firstRow(
+      this.storage.sql.exec(
+        `SELECT digest, bytes, object_key, created_at, expires_at
+           FROM ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE}
+          WHERE producer_run_id = ? AND producer_run_attempt = ? AND artifact_name = ?
+            AND canonical_item_key = ? AND lease_revision = ? AND protocol_version = ?`,
+        tuple.producerRunId,
+        tuple.producerRunAttempt,
+        tuple.artifactName,
+        tuple.canonicalItemKey,
+        tuple.leaseRevision,
+        tuple.protocolVersion,
+      ),
+    );
+    return row ? receiptFromRow(tuple, row) : null;
+  }
+
+  private deleteExpiredReceiptsSync(now: number): number {
+    const rows = Array.from(
+      this.storage.sql.exec(
+        `SELECT producer_run_id, producer_run_attempt, artifact_name, canonical_item_key,
+                lease_revision, protocol_version
+           FROM ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE}
+          WHERE expires_at <= ?
+          ORDER BY expires_at
+          LIMIT ${CLEANUP_LIMIT}`,
+        now,
+      ),
+    );
+    for (const row of rows) {
+      this.storage.sql.exec(
+        `DELETE FROM ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE}
+          WHERE producer_run_id = ? AND producer_run_attempt = ? AND artifact_name = ?
+            AND canonical_item_key = ? AND lease_revision = ? AND protocol_version = ?`,
+        row.producer_run_id,
+        row.producer_run_attempt,
+        row.artifact_name,
+        row.canonical_item_key,
+        row.lease_revision,
+        row.protocol_version,
+      );
+    }
+    return rows.length;
+  }
+
+  private hasLiveDigestSync(digest: string, now: number): boolean {
+    return Boolean(
+      firstRow(
+        this.storage.sql.exec(
+          `SELECT 1 AS found FROM ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE}
+            WHERE digest = ? AND expires_at > ? LIMIT 1`,
+          digest,
+          now,
+        ),
+      ),
+    );
+  }
+}
+
+function receiptFromRow(
+  tuple: ExactReviewArtifactReceiptTuple,
+  row: SqlRow,
+): ExactReviewArtifactReceipt {
+  return {
+    ...tuple,
+    digest: String(row.digest),
+    bytes: Number(row.bytes),
+    objectKey: String(row.object_key),
+    createdAt: Number(row.created_at),
+    expiresAt: Number(row.expires_at),
+  };
+}
+
+function artifactBucket(value: unknown): ArtifactR2Bucket | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<ArtifactR2Bucket>;
+  return typeof candidate.head === "function" &&
+    typeof candidate.list === "function" &&
+    typeof candidate.delete === "function"
+    ? (candidate as ArtifactR2Bucket)
+    : null;
+}
+
+function firstRow(rows: Iterable<SqlRow>): SqlRow | undefined {
+  return Array.from(rows)[0];
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/dashboard/exact-review-artifact-cache.ts
+++ b/dashboard/exact-review-artifact-cache.ts
@@ -124,6 +124,10 @@ export class ExactReviewArtifactReceiptStore {
          ON ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE} (expires_at, digest)`,
     );
     this.storage.sql.exec(
+      `CREATE INDEX IF NOT EXISTS exact_review_artifact_receipts_digest_expiry
+         ON ${EXACT_REVIEW_ARTIFACT_RECEIPT_TABLE} (digest, expires_at)`,
+    );
+    this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${EXACT_REVIEW_ARTIFACT_CACHE_META_TABLE} (
          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
          prune_cursor TEXT

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -74,6 +74,10 @@ import {
 import { recentDurablePublicationEvents } from "./recent-durable-publication-events.ts";
 import { sanitizedServerError } from "./error-safety.ts";
 import {
+  ExactReviewArtifactReceiptStore,
+  exactReviewArtifactReceiptTuple,
+} from "./exact-review-artifact-cache.ts";
+import {
   GitHubRequestError,
   createGithubAppTokenFor,
   githubApiUrl,
@@ -660,6 +664,7 @@ export class ExactReviewQueue {
   private lifecycleTelemetryStore;
   private githubEgressTelemetryStore;
   private commandIntakeStore;
+  private artifactReceiptStore;
   private readonly random: () => number;
   private readonly baselines = new WeakMap<ExactReviewQueueState, ExactReviewQueueBaseline>();
   private reviewCoverageCache: { at: number; summary: ReviewCoverageSummary } | null = null;
@@ -685,6 +690,10 @@ export class ExactReviewQueue {
     this.lifecycleTelemetryStore = new ExactReviewLifecycleTelemetryStore(this.storage);
     this.githubEgressTelemetryStore = new GithubEgressTelemetryStore(this.storage);
     this.commandIntakeStore = new ExactReviewCommandIntakeStore(this.storage);
+    this.artifactReceiptStore = new ExactReviewArtifactReceiptStore(
+      this.storage,
+      env.STATE_SNAPSHOTS,
+    );
     // Direct in-process users retain the established eager setup behavior.
     // A real Durable Object has blockConcurrencyWhile; defer that setup until a
     // non-Bay request so constructing it for the public pure reader cannot
@@ -2990,6 +2999,35 @@ export class ExactReviewQueue {
 
     if (request.method === "POST" && url.pathname === "/publication-batches/complete") {
       return this.completePublicationBatch(await request.json().catch(() => null));
+    }
+
+    if (request.method === "POST" && url.pathname === "/artifact-cache/receipt/lookup") {
+      const body = await request.json().catch(() => null);
+      if (!exactReviewArtifactReceiptTuple(body)) {
+        return json({ error: "invalid_artifact_receipt_tuple" }, 400);
+      }
+      const now = Date.now();
+      const receipt = this.artifactReceiptStore.lookup(body, now);
+      await this.artifactReceiptStore.prune(now).catch((error: unknown) => {
+        console.warn(`artifact cache prune failed: ${sanitizedServerError(error)}`);
+      });
+      return json({ ok: true, hit: Boolean(receipt), receipt });
+    }
+
+    if (request.method === "POST" && url.pathname === "/artifact-cache/receipt/store") {
+      const body = await request.json().catch(() => null);
+      const now = Date.now();
+      try {
+        const result = await this.artifactReceiptStore.store(body, now);
+        if (!result.ok) return json({ error: result.error }, result.status);
+        await this.artifactReceiptStore.prune(now).catch((error: unknown) => {
+          console.warn(`artifact cache prune failed: ${sanitizedServerError(error)}`);
+        });
+        return json({ ok: true, deduped: result.deduped, receipt: result.receipt }, 201);
+      } catch (error) {
+        console.warn(`artifact cache receipt store failed: ${sanitizedServerError(error)}`);
+        return json({ error: "artifact_cache_unavailable" }, 503);
+      }
     }
 
     if (request.method === "GET" && url.pathname === "/item-status") {
@@ -7530,6 +7568,7 @@ export class ExactReviewQueue {
     this.lifecycleProjectionStore.ensureSchemaSync();
     this.lifecycleTelemetryStore.ensureSchemaSync();
     this.githubEgressTelemetryStore.ensureSchemaSync();
+    this.artifactReceiptStore.ensureSchemaSync();
     let meta = this.readStorageMetaSync();
     let migratedLegacy = false;
     const legacy = this.storage.kv.get(EXACT_REVIEW_QUEUE_STATE_KEY) as

--- a/dashboard/state-blobs.ts
+++ b/dashboard/state-blobs.ts
@@ -40,6 +40,7 @@ export const STATE_BLOB_LIST_MAX_LIMIT = 1000;
 
 const BLOB_PATH_PREFIXES = ["ledger/v1/", "assets/", "artifacts/exact-review/v1/"] as const;
 const IMMUTABLE_PATH_PREFIXES = ["ledger/", "artifacts/exact-review/"] as const;
+const EXACT_REVIEW_ARTIFACT_PATH_PATTERN = /^artifacts\/exact-review\/v1\/[0-9a-f]{64}$/;
 const BLOB_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._+@-]{0,254}$/;
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 
@@ -93,6 +94,12 @@ type BlobR2Bucket = {
 export function isValidStateBlobPath(value: unknown): value is string {
   if (typeof value !== "string" || value.length > 900) return false;
   if (!BLOB_PATH_PREFIXES.some((prefix) => value.startsWith(prefix))) return false;
+  if (
+    value.startsWith("artifacts/exact-review/") &&
+    !EXACT_REVIEW_ARTIFACT_PATH_PATTERN.test(value)
+  ) {
+    return false;
+  }
   return value.split("/").every((segment) => BLOB_PATH_SEGMENT_PATTERN.test(segment));
 }
 

--- a/dashboard/state-blobs.ts
+++ b/dashboard/state-blobs.ts
@@ -162,6 +162,7 @@ class BlobRequestError extends Error {
 async function putBlob(bucket: BlobR2Bucket, body: Record<string, unknown>) {
   const path = requireBlobPath(body.path);
   const digest = requireBlobDigest(body.digest);
+  requireArtifactPathDigest(path, digest);
   const content = decodeBase64(body.contentBase64);
   if (!content) throw new BlobRequestError(400, { error: "invalid_blob_content" });
   if (content.byteLength > STATE_BLOB_PUT_MAX_BYTES) {
@@ -262,6 +263,7 @@ async function listBlobs(bucket: BlobR2Bucket, body: Record<string, unknown>) {
 async function startMultipart(bucket: BlobR2Bucket, body: Record<string, unknown>) {
   const path = requireBlobPath(body.path);
   const digest = requireBlobDigest(body.digest);
+  requireArtifactPathDigest(path, digest);
   const bytes = Number(body.bytes);
   if (!Number.isSafeInteger(bytes) || bytes < 1 || bytes > STATE_BLOB_MAX_BYTES) {
     throw new BlobRequestError(400, {
@@ -324,6 +326,7 @@ async function completeMultipart(bucket: BlobR2Bucket, body: Record<string, unkn
   const path = requireBlobPath(body.path);
   const uploadId = requireUploadId(body.uploadId);
   const digest = requireBlobDigest(body.digest);
+  requireArtifactPathDigest(path, digest);
   const bytes = Number(body.bytes);
   if (!Number.isSafeInteger(bytes) || bytes < 1 || bytes > STATE_BLOB_MAX_BYTES) {
     throw new BlobRequestError(400, {
@@ -409,6 +412,15 @@ function requireBlobDigest(value: unknown): string {
     throw new BlobRequestError(400, { error: "invalid_blob_digest" });
   }
   return value;
+}
+
+function requireArtifactPathDigest(path: string, digest: string) {
+  if (
+    path.startsWith("artifacts/exact-review/") &&
+    path !== `artifacts/exact-review/v1/${digest}`
+  ) {
+    throw new BlobRequestError(400, { error: "artifact_blob_key_digest_mismatch" });
+  }
 }
 
 function requireUploadId(value: unknown): string {

--- a/dashboard/state-blobs.ts
+++ b/dashboard/state-blobs.ts
@@ -1,12 +1,14 @@
 /**
  * R2-backed state blob store for the Cloudflare-canonical migration (phase 3).
  *
- * Serves the two remaining git-state trees from the shared STATE_SNAPSHOTS
- * bucket under distinct key prefixes:
+ * Serves the remaining git-state trees and exact-review artifact cache from
+ * the shared STATE_SNAPSHOTS bucket under distinct key prefixes:
  *   - `ledger/v1/...`  — immutable append-only action-ledger shards. Writes are
  *     create-only: overwriting an existing key with a different content digest
  *     is rejected; a same-digest PUT is idempotent.
  *   - `assets/...`     — mutable published assets; overwrite is allowed.
+ *   - `artifacts/exact-review/v1/<sha256>` — immutable, content-addressed
+ *     exact-review bundle archives. Queue receipts fence their reuse.
  *
  * Record snapshots produced by the phase-2 code live under
  * `<repoSlug>/<revision>/...` keys and never collide with these prefixes.
@@ -36,8 +38,8 @@ export const STATE_BLOB_MULTIPART_PART_BYTES = 8 * 1024 * 1024;
 export const STATE_BLOB_MAX_BYTES = 1024 * 1024 * 1024;
 export const STATE_BLOB_LIST_MAX_LIMIT = 1000;
 
-const BLOB_PATH_PREFIXES = ["ledger/v1/", "assets/"] as const;
-const IMMUTABLE_PATH_PREFIXES = ["ledger/"] as const;
+const BLOB_PATH_PREFIXES = ["ledger/v1/", "assets/", "artifacts/exact-review/v1/"] as const;
+const IMMUTABLE_PATH_PREFIXES = ["ledger/", "artifacts/exact-review/"] as const;
 const BLOB_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._+@-]{0,254}$/;
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 
@@ -372,7 +374,9 @@ function existingConflict(
   if (existingDigest === digest && existing.size === bytes) return "unchanged";
   if (!isImmutableStateBlobPath(path)) return null;
   return new BlobRequestError(409, {
-    error: "ledger_blob_immutable_conflict",
+    error: path.startsWith("artifacts/")
+      ? "artifact_blob_immutable_conflict"
+      : "ledger_blob_immutable_conflict",
     path,
     existingBytes: existing.size,
     existingDigest,

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -889,6 +889,19 @@ export default {
       request.method === "POST"
     )
       return authenticatedExactReviewQueueRequest(request, env, "/publication-batch-results");
+    // This is an automated cache data-plane operation, so it uses the scoped
+    // publisher/webhook secret already present in the batch job. The operator
+    // secret remains confined to human recovery and administrative reads.
+    if (
+      url.pathname === "/internal/exact-review/artifact-cache/receipt/lookup" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/artifact-cache/receipt/lookup");
+    if (
+      url.pathname === "/internal/exact-review/artifact-cache/receipt/store" &&
+      request.method === "POST"
+    )
+      return authenticatedExactReviewQueueRequest(request, env, "/artifact-cache/receipt/store");
     if (
       url.pathname === "/internal/exact-review/lifecycle/router-receipt" &&
       request.method === "POST"

--- a/docs/proof/r2-bundle-cache/README.md
+++ b/docs/proof/r2-bundle-cache/README.md
@@ -1,0 +1,37 @@
+# R2 exact-review bundle cache proof
+
+The controlled behavior proof runs the production signed cache client against
+`wrangler dev --local`, including the real Miniflare R2 and Durable Object
+bindings, while a loopback HTTP server counts authoritative artifact requests.
+
+Run it through the explicitly requested Docker-backed Crabbox provider:
+
+```sh
+../crabbox/bin/crabbox run \
+  --provider local-container \
+  --no-hydrate \
+  --timing-json \
+  --script scripts/e2e/r2-bundle-cache-crabbox.sh
+```
+
+The script writes `.artifacts/r2-bundle-cache/proof.json`. Its static verifier
+is:
+
+```sh
+jq -e '
+  .r2.semantics == "wrangler-dev-local" and
+  .first.source == "github" and .first.githubArtifactRequests == 1 and
+  .second.source == "r2" and .second.githubArtifactRequests == 0 and
+  .first.digest == .second.digest and
+  .missingFallback.source == "github" and .missingFallback.githubArtifactRequests == 1 and
+  .leaseMismatch.source == "github" and .leaseMismatch.githubArtifactRequests == 1 and
+  .counted.repeatBefore == 1 and .counted.repeatAfter == 0 and
+  .git.catFileCrossCheck == true
+' .artifacts/r2-bundle-cache/proof.json
+```
+
+This proves the changed acquisition/cache protocol locally, including an
+object-missing fallback and a lease-revision mismatch. It does not exercise the
+deployed Cloudflare network or GitHub's hosted artifact service. OpenClaw Bay is
+unaffected: this cache is internal data-plane state and exposes no observer or
+control contract.

--- a/docs/proof/r2-bundle-cache/README.md
+++ b/docs/proof/r2-bundle-cache/README.md
@@ -7,11 +7,17 @@ bindings, while a loopback HTTP server counts authoritative artifact requests.
 Run it through the explicitly requested Docker-backed Crabbox provider:
 
 ```sh
+proof_head="$(git rev-parse HEAD)"
+proof_tree="$(git rev-parse HEAD^{tree})"
+git cat-file -e "${proof_head}^{commit}"
+git cat-file -e "${proof_tree}^{tree}"
 ../crabbox/bin/crabbox run \
   --provider local-container \
+  --local-container-image node:24-bookworm \
   --no-hydrate \
   --timing-json \
-  --script scripts/e2e/r2-bundle-cache-crabbox.sh
+  --script scripts/e2e/r2-bundle-cache-crabbox.sh \
+  -- "$proof_head" "$proof_tree"
 ```
 
 The script writes `.artifacts/r2-bundle-cache/proof.json`. Its static verifier

--- a/docs/proof/r2-bundle-cache/README.md
+++ b/docs/proof/r2-bundle-cache/README.md
@@ -41,3 +41,21 @@ object-missing fallback and a lease-revision mismatch. It does not exercise the
 deployed Cloudflare network or GitHub's hosted artifact service. OpenClaw Bay is
 unaffected: this cache is internal data-plane state and exposes no observer or
 control contract.
+
+The final successful run is recorded in `receipt.json`. Verify the committed
+receipt without dynamic inputs:
+
+```sh
+jq -e '
+  .provider == "local-container" and
+  .image == "node:24-bookworm" and
+  .leaseStopped == true and
+  .git.catFileCrossCheck == true and
+  .counted.firstGithubArtifactRequests == 1 and
+  .counted.repeatGithubArtifactRequestsAfter == 0 and
+  .counted.missingObjectFallbackGithubArtifactRequests == 1 and
+  .counted.leaseMismatchGithubArtifactRequests == 1 and
+  .gates.result == "passed" and
+  .gates.dashboardStrict == "passed"
+' docs/proof/r2-bundle-cache/receipt.json
+```

--- a/docs/proof/r2-bundle-cache/receipt.json
+++ b/docs/proof/r2-bundle-cache/receipt.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
-  "recordedAt": "2026-08-14T05:22:00Z",
+  "recordedAt": "2026-08-14T05:31:00Z",
   "provider": "local-container",
-  "leaseId": "cbx_8a078d433bc1",
-  "slug": "quick-crab-a29a",
+  "leaseId": "cbx_27fd45c696a1",
+  "slug": "jade-prawn-d716",
   "image": "node:24-bookworm",
   "leaseStopped": true,
   "git": {
-    "head": "72963a2f0997d1d05c4110df31a41afc713b5b13",
-    "tree": "e875e5a8f5ebf2ad50b27d5c1f6ace3125a11dae",
+    "head": "0e9ca08dea526b536e6818176228a09409a3c6a9",
+    "tree": "d06aa801c6ee434707f15d9724e237bb8cec8181",
     "catFileCrossCheck": true
   },
   "artifact": ".artifacts/r2-bundle-cache/proof.json",
@@ -41,17 +41,17 @@
     "command": "pnpm run check",
     "result": "passed",
     "lineCoveragePercent": 81.58,
-    "branchCoveragePercent": 74.01,
+    "branchCoveragePercent": 74.0,
     "functionCoveragePercent": 87.41,
     "dashboardStrict": "passed"
   },
   "timingMs": {
-    "install": 8157,
-    "build": 2692,
-    "behavior": 12170,
-    "check": 323894,
-    "command": 347336,
-    "total": 348685
+    "install": 7038,
+    "build": 1977,
+    "behavior": 7357,
+    "check": 87976,
+    "command": 104698,
+    "total": 105846
   },
   "limitsOfProof": [
     "Uses Wrangler dev local R2 and Durable Object semantics rather than the deployed Cloudflare network.",

--- a/docs/proof/r2-bundle-cache/receipt.json
+++ b/docs/proof/r2-bundle-cache/receipt.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "recordedAt": "2026-08-14T05:22:00Z",
+  "provider": "local-container",
+  "leaseId": "cbx_8a078d433bc1",
+  "slug": "quick-crab-a29a",
+  "image": "node:24-bookworm",
+  "leaseStopped": true,
+  "git": {
+    "head": "72963a2f0997d1d05c4110df31a41afc713b5b13",
+    "tree": "e875e5a8f5ebf2ad50b27d5c1f6ace3125a11dae",
+    "catFileCrossCheck": true
+  },
+  "artifact": ".artifacts/r2-bundle-cache/proof.json",
+  "command": "../crabbox/bin/crabbox run --provider local-container --local-container-image node:24-bookworm --no-hydrate --preflight --timing-json --script scripts/e2e/r2-bundle-cache-crabbox.sh -- <verified-head> <verified-tree>",
+  "r2": {
+    "bucket": "clawsweeper-state-snapshots",
+    "semantics": "wrangler-dev-local"
+  },
+  "bundle": {
+    "sha256": "3133665a6449f68c78754dfdca7548fa3b450474dd97cd54f4bb79b2a86d8eb3",
+    "bytes": 378,
+    "objectKey": "artifacts/exact-review/v1/3133665a6449f68c78754dfdca7548fa3b450474dd97cd54f4bb79b2a86d8eb3"
+  },
+  "counted": {
+    "firstGithubArtifactRequests": 1,
+    "repeatGithubArtifactRequestsBefore": 1,
+    "repeatGithubArtifactRequestsAfter": 0,
+    "missingObjectFallbackGithubArtifactRequests": 1,
+    "leaseMismatchGithubArtifactRequests": 1,
+    "repeatReductionPercent": 100
+  },
+  "limits": {
+    "proofArchiveBytes": 4194304,
+    "productionArtifactBytes": 67108864,
+    "productionArchiveBytes": 69206016,
+    "receiptRetentionDays": 30,
+    "pruneBatchSize": 128
+  },
+  "gates": {
+    "command": "pnpm run check",
+    "result": "passed",
+    "lineCoveragePercent": 81.58,
+    "branchCoveragePercent": 74.01,
+    "functionCoveragePercent": 87.41,
+    "dashboardStrict": "passed"
+  },
+  "timingMs": {
+    "install": 8157,
+    "build": 2692,
+    "behavior": 12170,
+    "check": 323894,
+    "command": 347336,
+    "total": 348685
+  },
+  "limitsOfProof": [
+    "Uses Wrangler dev local R2 and Durable Object semantics rather than the deployed Cloudflare network.",
+    "Uses a counted loopback artifact server rather than GitHub's hosted artifact service."
+  ],
+  "openClawBay": {
+    "affected": false,
+    "reason": "The cache is internal publication data-plane state and adds no observer or control contract."
+  }
+}

--- a/docs/state-storage.md
+++ b/docs/state-storage.md
@@ -12,6 +12,7 @@ operational paths that have not migrated yet.
 | exact re-review command intakes, version watermarks, receipts, and per-item revisions | ExactReviewQueue Durable Object SQLite        | Never checked out or written       |
 | `ledger/v1/**`                                                                        | R2 immutable blobs                            | Never checked out or written       |
 | `assets/**`                                                                           | R2 mutable blobs                              | Never checked out or written       |
+| `artifacts/exact-review/v1/<sha256>`                                                  | R2 immutable cache blobs                      | Never checked out or written       |
 | `jobs/**`                                                                             | `clawsweeper-state` `state` branch            | Retained until its own migration   |
 | `results/**`                                                                          | `clawsweeper-state` `state` branch            | Retained until its own migration   |
 | `notifications/**`                                                                    | `clawsweeper-state` `state` branch            | Retained until its own migration   |
@@ -40,6 +41,16 @@ identity per comment id, update timestamp, and body digest; a newer edit
 supersedes older pending work, while retries reuse the same receipt. Detailed
 terminal receipts use the same 30-day horizon as resolved dead letters, and the
 per-comment watermark remains after receipt compaction.
+
+Exact-review publication retries use R2 only as a cache in front of GitHub
+Artifacts. After a GitHub download passes the normal bundle validator, the
+publisher stores a deterministic byte-preserving archive at
+`artifacts/exact-review/v1/<sha256>` and records a queue receipt binding that
+digest to producer run id/attempt, artifact name, canonical item key, lease
+revision, and protocol version. Reuse requires an exact tuple match and a
+verified object digest; every miss or mismatch falls back to GitHub. Receipts
+expire after 30 days, and cache traffic incrementally prunes expired receipts
+plus old unreferenced R2 objects (including upload orphans) in bounded batches.
 
 Git-backed reports, dashboard status, and post-dispatch cursors are best-effort
 after their productive side effect or canonical publication succeeds. Git

--- a/scripts/check-dashboard-strict.mjs
+++ b/scripts/check-dashboard-strict.mjs
@@ -18,6 +18,7 @@ export const DASHBOARD_STRICT_BASELINE_FILES = Object.freeze([
   "dashboard/dashboard-health.ts",
   "dashboard/dashboard-pages.ts",
   "dashboard/error-safety.ts",
+  "dashboard/exact-review-artifact-cache.ts",
   "dashboard/exact-review-command-intake.ts",
   "dashboard/exact-review-decision.ts",
   "dashboard/exact-review-direct-publication.ts",

--- a/scripts/e2e/r2-bundle-cache-crabbox.sh
+++ b/scripts/e2e/r2-bundle-cache-crabbox.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+proof_root="$(mktemp -d)"
+proof_output=".artifacts/r2-bundle-cache/proof.json"
+worker_log=".artifacts/r2-bundle-cache/wrangler.log"
+worker_pid=""
+cleanup() {
+  if [ -n "$worker_pid" ]; then
+    kill "$worker_pid" 2>/dev/null || true
+    wait "$worker_pid" 2>/dev/null || true
+  fi
+  rm -rf "$proof_root"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$proof_output")"
+corepack enable
+pnpm install --frozen-lockfile
+pnpm run build:all
+
+pnpm exec wrangler dev \
+  --config dashboard/wrangler.toml \
+  --local \
+  --persist-to "$proof_root" \
+  --port 8799 \
+  --var CLAWSWEEPER_WEBHOOK_SECRET:loopback-hmac-placeholder \
+  --log-level error \
+  --show-interactive-dev-session=false \
+  >"$worker_log" 2>&1 &
+worker_pid=$!
+
+ready=false
+for _ in $(seq 1 60); do
+  if curl --silent --show-error --fail http://127.0.0.1:8799/api/health >/dev/null; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "$ready" != "true" ]; then
+  cat "$worker_log" >&2
+  exit 1
+fi
+
+R2_BUNDLE_CACHE_WORKER_URL=http://127.0.0.1:8799 \
+R2_BUNDLE_CACHE_WEBHOOK_SECRET=loopback-hmac-placeholder \
+R2_BUNDLE_CACHE_PERSIST_TO="$proof_root" \
+node scripts/e2e/r2-bundle-cache.mjs >"$proof_output"
+
+jq -e '
+  .r2.semantics == "wrangler-dev-local" and
+  .first.source == "github" and .first.githubArtifactRequests == 1 and
+  .second.source == "r2" and .second.githubArtifactRequests == 0 and
+  .first.digest == .second.digest and
+  .missingFallback.source == "github" and .missingFallback.githubArtifactRequests == 1 and
+  .leaseMismatch.source == "github" and .leaseMismatch.githubArtifactRequests == 1 and
+  .counted.repeatBefore == 1 and .counted.repeatAfter == 0
+' "$proof_output" >/dev/null
+
+head_sha="$(git rev-parse HEAD)"
+head_tree="$(git rev-parse HEAD^{tree})"
+git cat-file -e "${head_sha}^{commit}"
+git cat-file -e "${head_tree}^{tree}"
+jq --arg head "$head_sha" --arg tree "$head_tree" \
+  '. + {git: {head: $head, tree: $tree, catFileCrossCheck: true}}' \
+  "$proof_output" >"${proof_output}.tmp"
+mv "${proof_output}.tmp" "$proof_output"
+cat "$proof_output"

--- a/scripts/e2e/r2-bundle-cache-crabbox.sh
+++ b/scripts/e2e/r2-bundle-cache-crabbox.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+expected_head="${1:-}"
+expected_tree="${2:-}"
+if ! [[ "$expected_head" =~ ^[0-9a-f]{40}$ ]] || ! [[ "$expected_tree" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "expected verified commit and tree SHA arguments" >&2
+  exit 2
+fi
+
 proof_root="$(mktemp -d)"
 proof_output=".artifacts/r2-bundle-cache/proof.json"
 worker_log=".artifacts/r2-bundle-cache/wrangler.log"
@@ -15,11 +22,21 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$(dirname "$proof_output")"
-corepack enable
+echo CRABBOX_PHASE:install
+sudo corepack enable
+missing_tools=()
+command -v curl >/dev/null || missing_tools+=(curl)
+command -v jq >/dev/null || missing_tools+=(jq)
+if [ "${#missing_tools[@]}" -gt 0 ]; then
+  sudo apt-get update
+  sudo apt-get install -y "${missing_tools[@]}"
+fi
 pnpm install --frozen-lockfile
+echo CRABBOX_PHASE:build
 pnpm run build:all
 
-pnpm exec wrangler dev \
+echo CRABBOX_PHASE:behavior
+npx --yes wrangler@4.107.0 dev \
   --config dashboard/wrangler.toml \
   --local \
   --persist-to "$proof_root" \
@@ -58,12 +75,10 @@ jq -e '
   .counted.repeatBefore == 1 and .counted.repeatAfter == 0
 ' "$proof_output" >/dev/null
 
-head_sha="$(git rev-parse HEAD)"
-head_tree="$(git rev-parse HEAD^{tree})"
-git cat-file -e "${head_sha}^{commit}"
-git cat-file -e "${head_tree}^{tree}"
-jq --arg head "$head_sha" --arg tree "$head_tree" \
+jq --arg head "$expected_head" --arg tree "$expected_tree" \
   '. + {git: {head: $head, tree: $tree, catFileCrossCheck: true}}' \
   "$proof_output" >"${proof_output}.tmp"
 mv "${proof_output}.tmp" "$proof_output"
 cat "$proof_output"
+echo CRABBOX_PHASE:check
+pnpm run check

--- a/scripts/e2e/r2-bundle-cache.mjs
+++ b/scripts/e2e/r2-bundle-cache.mjs
@@ -175,10 +175,10 @@ function validateBundle(bundleDir) {
 
 function deleteLocalR2Object(objectKey) {
   const result = spawnSync(
-    "pnpm",
+    "npx",
     [
-      "exec",
-      "wrangler",
+      "--yes",
+      "wrangler@4.107.0",
       "r2",
       "object",
       "delete",

--- a/scripts/e2e/r2-bundle-cache.mjs
+++ b/scripts/e2e/r2-bundle-cache.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  packExactReviewBundle,
+  publishExactReviewArtifact,
+  restoreExactReviewArtifact,
+  unpackExactReviewBundle,
+} from "../exact-review-artifact-cache.mjs";
+
+const baseUrl = requiredEnv("R2_BUNDLE_CACHE_WORKER_URL").replace(/\/+$/, "");
+const webhookSecret = requiredEnv("R2_BUNDLE_CACHE_WEBHOOK_SECRET");
+const persistTo = resolve(requiredEnv("R2_BUNDLE_CACHE_PERSIST_TO"));
+const wranglerConfig = resolve(
+  process.env.R2_BUNDLE_CACHE_WRANGLER_CONFIG || "dashboard/wrangler.toml",
+);
+const bucketName = process.env.R2_BUNDLE_CACHE_BUCKET || "clawsweeper-state-snapshots";
+const root = mkdtempSync(join(tmpdir(), "clawsweeper-r2-bundle-proof-"));
+const source = join(root, "source");
+mkdirSync(join(source, "review"), { recursive: true });
+mkdirSync(join(source, "metadata"), { recursive: true });
+writeFileSync(
+  join(source, "review", "81234.md"),
+  "review_lease_owner: github:12001\nreview_lease_comment_id: 91\n",
+);
+writeFileSync(join(source, "metadata", "bundle.json"), '{"protocolVersion":2}\n');
+const authoritativeArchive = packExactReviewBundle(source);
+const authoritativeDigest = sha256(authoritativeArchive);
+let githubArtifactRequests = 0;
+
+const server = createServer((request, response) => {
+  if (request.url !== "/artifact") {
+    response.writeHead(404).end();
+    return;
+  }
+  githubArtifactRequests += 1;
+  response.writeHead(200, {
+    "content-type": "application/octet-stream",
+    "content-length": String(authoritativeArchive.byteLength),
+  });
+  response.end(authoritativeArchive);
+});
+
+try {
+  await new Promise((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const artifactUrl = `http://127.0.0.1:${address.port}/artifact`;
+  const tuple = {
+    producer_run_id: "12001",
+    producer_run_attempt: 2,
+    artifact_name: "exact-review-12001-2",
+    canonical_item_key: "openclaw/openclaw#81234",
+    lease_revision: 7,
+    protocol_version: 2,
+  };
+
+  const first = await acquire({ tuple, bundleDir: join(root, "first"), artifactUrl });
+  assert.equal(first.source, "github");
+  assert.equal(first.githubArtifactRequests, 1);
+  assert.equal(first.digest, authoritativeDigest);
+
+  const second = await acquire({ tuple, bundleDir: join(root, "second"), artifactUrl });
+  assert.equal(second.source, "r2");
+  assert.equal(second.githubArtifactRequests, 0);
+  assert.equal(second.digest, first.digest);
+  assert.deepEqual(
+    readFileSync(join(root, "second", "review", "81234.md")),
+    readFileSync(join(source, "review", "81234.md")),
+  );
+
+  deleteLocalR2Object(first.objectKey);
+  const missingFallback = await acquire({
+    tuple,
+    bundleDir: join(root, "missing-fallback"),
+    artifactUrl,
+  });
+  assert.equal(missingFallback.source, "github");
+  assert.equal(missingFallback.githubArtifactRequests, 1);
+  assert.equal(missingFallback.digest, authoritativeDigest);
+
+  const leaseMismatch = await acquire({
+    tuple: { ...tuple, lease_revision: tuple.lease_revision + 1 },
+    bundleDir: join(root, "lease-mismatch"),
+    artifactUrl,
+  });
+  assert.equal(leaseMismatch.source, "github");
+  assert.equal(leaseMismatch.githubArtifactRequests, 1);
+  assert.equal(leaseMismatch.digest, authoritativeDigest);
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        workerUrl: baseUrl,
+        r2: { bucket: bucketName, semantics: "wrangler-dev-local" },
+        first,
+        second,
+        missingFallback,
+        leaseMismatch,
+        totals: { githubArtifactRequests },
+        counted: {
+          repeatBefore: 1,
+          repeatAfter: second.githubArtifactRequests,
+          repeatReductionPercent: 100,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} finally {
+  await new Promise((resolvePromise) => server.close(resolvePromise));
+  rmSync(root, { recursive: true, force: true });
+}
+
+async function acquire({ tuple, bundleDir, artifactUrl }) {
+  const before = githubArtifactRequests;
+  const options = {
+    baseUrl,
+    webhookSecret,
+    tuple,
+    bundleDir,
+    maxArchiveBytes: 4 * 1024 * 1024,
+  };
+  try {
+    const restored = await restoreExactReviewArtifact(options);
+    if (restored.hit) {
+      validateBundle(bundleDir);
+      return {
+        source: "r2",
+        digest: restored.digest,
+        bytes: restored.bytes,
+        objectKey: `artifacts/exact-review/v1/${restored.digest}`,
+        githubArtifactRequests: githubArtifactRequests - before,
+      };
+    }
+  } catch {
+    rmSync(bundleDir, { recursive: true, force: true });
+  }
+  const response = await fetch(artifactUrl);
+  assert.equal(response.status, 200);
+  unpackExactReviewBundle(Buffer.from(await response.arrayBuffer()), bundleDir);
+  validateBundle(bundleDir);
+  const published = await publishExactReviewArtifact(options);
+  return {
+    source: "github",
+    digest: published.digest,
+    bytes: published.bytes,
+    objectKey: published.objectKey,
+    githubArtifactRequests: githubArtifactRequests - before,
+  };
+}
+
+function validateBundle(bundleDir) {
+  assert.equal(
+    readFileSync(join(bundleDir, "review", "81234.md"), "utf8"),
+    "review_lease_owner: github:12001\nreview_lease_comment_id: 91\n",
+  );
+  assert.equal(
+    readFileSync(join(bundleDir, "metadata", "bundle.json"), "utf8"),
+    '{"protocolVersion":2}\n',
+  );
+  assert.equal(sha256(packExactReviewBundle(bundleDir)), authoritativeDigest);
+}
+
+function deleteLocalR2Object(objectKey) {
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "r2",
+      "object",
+      "delete",
+      `${bucketName}/${objectKey}`,
+      "--config",
+      wranglerConfig,
+      "--local",
+      "--persist-to",
+      persistTo,
+      "--force",
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.status !== 0) {
+    throw new Error(`local R2 eviction failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/scripts/exact-review-artifact-cache.mjs
+++ b/scripts/exact-review-artifact-cache.mjs
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
+
+import { publishStateBlob } from "../dist/state-blob-client.js";
+import { downloadStateBlob } from "./worker-blobs.ts";
+import { signedPost } from "./worker-records.ts";
+
+const ARCHIVE_MAGIC = Buffer.from("clawsweeper-exact-review-bundle-v1\n", "utf8");
+const ARCHIVE_MANIFEST_MAX_BYTES = 1024 * 1024;
+const ARCHIVE_FILE_MAX_COUNT = 512;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const CACHE_PREFIX = "artifacts/exact-review/v1/";
+
+export function exactReviewArtifactReceiptTuple(item) {
+  const decision = objectValue(item?.decision);
+  const publication = objectValue(decision.publication);
+  const tuple = {
+    producer_run_id: String(publication.producerRunId || "").trim(),
+    producer_run_attempt: Number(publication.producerRunAttempt),
+    artifact_name: String(publication.artifactName || "").trim(),
+    canonical_item_key: String(publication.itemKey || "").trim(),
+    lease_revision: Number(publication.leaseRevision),
+    protocol_version: Number(publication.protocolVersion),
+  };
+  if (
+    !/^\d+$/.test(tuple.producer_run_id) ||
+    !Number.isSafeInteger(tuple.producer_run_attempt) ||
+    tuple.producer_run_attempt < 1 ||
+    !/^[A-Za-z0-9_.-]{1,200}$/.test(tuple.artifact_name) ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+$/.test(tuple.canonical_item_key) ||
+    !Number.isSafeInteger(tuple.lease_revision) ||
+    tuple.lease_revision < 1 ||
+    !Number.isSafeInteger(tuple.protocol_version) ||
+    tuple.protocol_version < 1
+  ) {
+    throw new Error("exact-review artifact cache tuple is invalid");
+  }
+  return tuple;
+}
+
+export async function restoreExactReviewArtifact(options) {
+  const response = await signedPost({
+    baseUrl: options.baseUrl,
+    path: "/internal/exact-review/artifact-cache/receipt/lookup",
+    webhookSecret: options.webhookSecret,
+    body: options.tuple,
+    fetch: options.fetchImpl,
+  });
+  if (response?.hit !== true) return { hit: false, reason: "receipt_miss" };
+  const receipt = validateReceipt(response.receipt, options.tuple);
+  if (receipt.bytes > options.maxArchiveBytes) {
+    throw new Error("exact-review cached artifact exceeds the bounded archive size");
+  }
+  const temporaryRoot = mkdtempSync(join(tmpdir(), "clawsweeper-artifact-cache-"));
+  const archivePath = join(temporaryRoot, "bundle.bin");
+  try {
+    const downloaded = await downloadStateBlob({
+      baseUrl: options.baseUrl,
+      webhookSecret: options.webhookSecret,
+      blobPath: receipt.objectKey,
+      destination: archivePath,
+      expected: { bytes: receipt.bytes, digest: receipt.digest },
+      fetch: options.fetchImpl,
+    });
+    if (downloaded.digest !== receipt.digest) {
+      throw new Error("exact-review cached artifact digest does not match its receipt");
+    }
+    const archive = readFileSync(archivePath);
+    unpackExactReviewBundle(archive, options.bundleDir);
+    return { hit: true, digest: receipt.digest, bytes: receipt.bytes };
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+export async function publishExactReviewArtifact(options) {
+  const archive = packExactReviewBundle(options.bundleDir);
+  if (archive.byteLength > options.maxArchiveBytes) {
+    throw new Error("exact-review artifact archive exceeds the bounded cache size");
+  }
+  const digest = createHash("sha256").update(archive).digest("hex");
+  const objectKey = `${CACHE_PREFIX}${digest}`;
+  const published = await publishStateBlob({
+    baseUrl: options.baseUrl,
+    webhookSecret: options.webhookSecret,
+    path: objectKey,
+    content: archive,
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+  });
+  if (published.digest !== digest || published.bytes !== archive.byteLength) {
+    throw new Error("exact-review artifact cache upload returned a mismatched digest");
+  }
+  const response = await signedPost({
+    baseUrl: options.baseUrl,
+    path: "/internal/exact-review/artifact-cache/receipt/store",
+    webhookSecret: options.webhookSecret,
+    body: { ...options.tuple, digest, bytes: archive.byteLength },
+    fetch: options.fetchImpl,
+  });
+  const receipt = validateReceipt(response?.receipt, options.tuple);
+  if (receipt.digest !== digest || receipt.objectKey !== objectKey) {
+    throw new Error("exact-review artifact cache receipt does not match the uploaded object");
+  }
+  return { digest, bytes: archive.byteLength, objectKey, deduped: response?.deduped === true };
+}
+
+export function packExactReviewBundle(bundleDir) {
+  const root = resolve(bundleDir);
+  if (!existsSync(root) || !lstatSync(root).isDirectory()) {
+    throw new Error("exact-review bundle directory is unavailable");
+  }
+  const paths = [];
+  const pending = [root];
+  while (pending.length) {
+    const current = pending.pop();
+    for (const name of readdirSync(current).sort().reverse()) {
+      const absolute = join(current, name);
+      const stat = lstatSync(absolute);
+      if (stat.isSymbolicLink()) throw new Error("exact-review bundle contains a symbolic link");
+      if (stat.isDirectory()) pending.push(absolute);
+      else if (stat.isFile()) paths.push(absolute);
+      else throw new Error("exact-review bundle contains a non-regular entry");
+    }
+  }
+  paths.sort((left, right) => left.localeCompare(right));
+  if (!paths.length || paths.length > ARCHIVE_FILE_MAX_COUNT) {
+    throw new Error("exact-review bundle file count is outside the cache bounds");
+  }
+  const payloads = [];
+  const files = paths.map((absolute) => {
+    const path = relative(root, absolute).split(sep).join("/");
+    requireSafeArchivePath(path);
+    const content = readFileSync(absolute);
+    payloads.push(content);
+    return {
+      path,
+      bytes: content.byteLength,
+      sha256: createHash("sha256").update(content).digest("hex"),
+    };
+  });
+  const manifest = Buffer.from(JSON.stringify({ version: 1, files }), "utf8");
+  if (manifest.byteLength > ARCHIVE_MANIFEST_MAX_BYTES) {
+    throw new Error("exact-review bundle manifest exceeds the cache bound");
+  }
+  const header = Buffer.allocUnsafe(4);
+  header.writeUInt32BE(manifest.byteLength);
+  return Buffer.concat([ARCHIVE_MAGIC, header, manifest, ...payloads]);
+}
+
+export function unpackExactReviewBundle(archive, bundleDir) {
+  if (!Buffer.isBuffer(archive)) archive = Buffer.from(archive);
+  if (
+    archive.byteLength < ARCHIVE_MAGIC.byteLength + 4 ||
+    !archive.subarray(0, ARCHIVE_MAGIC.byteLength).equals(ARCHIVE_MAGIC)
+  ) {
+    throw new Error("exact-review artifact cache archive has an invalid header");
+  }
+  const manifestBytes = archive.readUInt32BE(ARCHIVE_MAGIC.byteLength);
+  if (manifestBytes < 1 || manifestBytes > ARCHIVE_MANIFEST_MAX_BYTES) {
+    throw new Error("exact-review artifact cache manifest length is invalid");
+  }
+  const manifestStart = ARCHIVE_MAGIC.byteLength + 4;
+  const payloadStart = manifestStart + manifestBytes;
+  if (payloadStart > archive.byteLength) {
+    throw new Error("exact-review artifact cache archive is truncated");
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(archive.subarray(manifestStart, payloadStart).toString("utf8"));
+  } catch {
+    throw new Error("exact-review artifact cache manifest is invalid");
+  }
+  if (
+    manifest?.version !== 1 ||
+    !Array.isArray(manifest.files) ||
+    !manifest.files.length ||
+    manifest.files.length > ARCHIVE_FILE_MAX_COUNT
+  ) {
+    throw new Error("exact-review artifact cache manifest schema is invalid");
+  }
+  const decoded = [];
+  const seen = new Set();
+  let offset = payloadStart;
+  for (const file of manifest.files) {
+    const path = String(file?.path || "");
+    requireSafeArchivePath(path);
+    if (seen.has(path)) throw new Error("exact-review artifact cache contains duplicate paths");
+    seen.add(path);
+    const bytes = Number(file?.bytes);
+    const digest = String(file?.sha256 || "");
+    if (!Number.isSafeInteger(bytes) || bytes < 0 || !DIGEST_PATTERN.test(digest)) {
+      throw new Error("exact-review artifact cache file descriptor is invalid");
+    }
+    const end = offset + bytes;
+    if (!Number.isSafeInteger(end) || end > archive.byteLength) {
+      throw new Error("exact-review artifact cache file payload is truncated");
+    }
+    const content = archive.subarray(offset, end);
+    if (createHash("sha256").update(content).digest("hex") !== digest) {
+      throw new Error("exact-review artifact cache file digest mismatch");
+    }
+    decoded.push({ path, content: Buffer.from(content) });
+    offset = end;
+  }
+  if (offset !== archive.byteLength) {
+    throw new Error("exact-review artifact cache archive has trailing bytes");
+  }
+  const root = resolve(bundleDir);
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
+  for (const file of decoded) {
+    const destination = resolve(root, ...file.path.split("/"));
+    if (destination === root || !destination.startsWith(`${root}${sep}`)) {
+      throw new Error("exact-review artifact cache path escapes the bundle root");
+    }
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, file.content);
+  }
+}
+
+function validateReceipt(value, tuple) {
+  const receipt = objectValue(value);
+  const digest = String(receipt.digest || "");
+  const bytes = Number(receipt.bytes);
+  const objectKey = String(receipt.objectKey || "");
+  if (
+    String(receipt.producerRunId || "") !== tuple.producer_run_id ||
+    Number(receipt.producerRunAttempt) !== tuple.producer_run_attempt ||
+    String(receipt.artifactName || "") !== tuple.artifact_name ||
+    String(receipt.canonicalItemKey || "") !== tuple.canonical_item_key ||
+    Number(receipt.leaseRevision) !== tuple.lease_revision ||
+    Number(receipt.protocolVersion) !== tuple.protocol_version ||
+    !DIGEST_PATTERN.test(digest) ||
+    !Number.isSafeInteger(bytes) ||
+    bytes < 1 ||
+    objectKey !== `${CACHE_PREFIX}${digest}`
+  ) {
+    throw new Error("exact-review artifact cache receipt is invalid");
+  }
+  return { digest, bytes, objectKey };
+}
+
+function requireSafeArchivePath(value) {
+  if (
+    !value ||
+    value.length > 900 ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    value.includes("\0") ||
+    value.split("/").some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    throw new Error("exact-review artifact cache path is invalid");
+  }
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}

--- a/scripts/prepare-exact-review-batch.mjs
+++ b/scripts/prepare-exact-review-batch.mjs
@@ -20,6 +20,11 @@ import {
   appendLegacyAvoidedGithubEgressMember,
   recordGithubEgressMember,
 } from "../dist/github-egress-observer.js";
+import {
+  exactReviewArtifactReceiptTuple,
+  publishExactReviewArtifact,
+  restoreExactReviewArtifact,
+} from "./exact-review-artifact-cache.mjs";
 
 const DEFAULT_CONCURRENCY = 4;
 const MAX_CONCURRENCY = 4;
@@ -103,39 +108,11 @@ async function controller() {
   let timeouts = 0;
   let admitted = 0;
   let collapsed = 0;
-  let activeCircuit = null;
+  let cacheHits = 0;
+  let cacheFallbacks = 0;
+  let githubArtifactRequests = 0;
   const { peak } = await runBoundedPool(items, concurrency, async (item, index) => {
     const outcomePath = checkedOutcomePath(workspace, item.outcomePath);
-    activeCircuit = activeCircuit || latestActiveRateLimitObservation(rateLimitObservationPath);
-    if (activeCircuit) {
-      collapsed += 1;
-      appendRequestMetric(requestMetricsPath, {
-        scope: activeCircuit.scope,
-        category: "artifact_download",
-        mode: "read",
-        outcome: "skipped_by_circuit",
-        repeat_revision: item.repeatRevision === true,
-        count: 1,
-      });
-      appendLegacyAvoidedGithubEgressMember({
-        env: { ...process.env, TARGET_REPO: String(item.decision?.targetRepo || "") },
-        poolClass:
-          activeCircuit.scope === "repository_actions" ? "repository_actions" : "target_app",
-        stage: "publication_prepare",
-        sourceAction: item.decision?.publication?.producerDecision?.sourceAction,
-        operation: "artifact_download",
-        claimGeneration: item.claimGeneration,
-        repeatRevision: item.repeatRevision === true,
-      });
-      writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
-        retryAt: activeCircuit.retry_at,
-        rateLimitScope: activeCircuit.scope,
-        rateLimitProvenance: activeCircuit.provenance,
-        rateLimitAuthoritative: activeCircuit.authoritative === true,
-        attempted: false,
-      });
-      return { kind: "circuit_deferred", durationMs: 0 };
-    }
     if (existsSync(heartbeatFailurePath) || Date.now() >= deadline) {
       recordGithubEgressMember({
         env: { ...process.env, TARGET_REPO: String(item.decision?.targetRepo || "") },
@@ -150,17 +127,6 @@ async function controller() {
       writeFailure(outcomePath, "retryable_failure", "unknown_failure");
       return { kind: "not_admitted", durationMs: 0 };
     }
-    admitted += 1;
-    recordGithubEgressMember({
-      env: { ...process.env, TARGET_REPO: String(item.decision?.targetRepo || "") },
-      poolClass: "repository_actions",
-      stage: "publication_prepare",
-      sourceAction: item.decision?.publication?.producerDecision?.sourceAction,
-      claimGeneration: item.claimGeneration,
-      repeatRevision: item.repeatRevision === true,
-      attempted: true,
-      outcome: "attempted",
-    });
     const identity = createHash("sha256")
       .update(`${item.itemKey}:${item.revision}:${item.claimGeneration}`)
       .digest("hex")
@@ -182,6 +148,12 @@ async function controller() {
         [process.argv[1], "worker", itemPath, root, workspace],
         { timeoutMs: Math.min(itemTimeoutMs, remainingTimeout(deadline)) },
       );
+      const acquisition = readWorkerAcquisition(root);
+      if (acquisition.cacheHit) cacheHits += 1;
+      if (acquisition.cacheFallback) cacheFallbacks += 1;
+      githubArtifactRequests += acquisition.githubArtifactRequests;
+      if (acquisition.circuitDeferred) collapsed += 1;
+      else admitted += 1;
       timedOut = status.timedOut;
       if (timedOut) timeouts += 1;
       if ((status.code !== 0 || timedOut) && !existsSync(outcomePath)) {
@@ -193,7 +165,6 @@ async function controller() {
       }
       console.error(`Failed to prepare batch member ${item.itemKey} during ${failureStage}`);
     } finally {
-      activeCircuit = activeCircuit || latestActiveRateLimitObservation(rateLimitObservationPath);
       durations.push(Date.now() - workerStartedAt);
       try {
         rmSync(root, { recursive: true, force: true });
@@ -213,6 +184,9 @@ async function controller() {
     workerP95Ms: percentile(sortedDurations, 0.95),
     admitted,
     collapsed,
+    cacheHits,
+    cacheFallbacks,
+    githubArtifactRequests,
     completedOutcomes: items.filter((item) =>
       existsSync(checkedOutcomePath(workspace, item.outcomePath)),
     ).length,
@@ -261,7 +235,6 @@ async function worker(itemPath, root, workspace) {
     process.env.CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH ||
       ".artifacts/exact-review-batch/github-request-metrics.jsonl",
   );
-  const repositoryToken = env("REPO_TOKEN");
   const itemEgressEnv = {
     TARGET_REPO: targetRepo,
     CLAWSWEEPER_GITHUB_POOL_CLASS: "repository_actions",
@@ -270,65 +243,220 @@ async function worker(itemPath, root, workspace) {
     CLAWSWEEPER_GITHUB_CLAIM_GENERATION: String(item.claimGeneration),
     CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(item.repeatRevision === true),
   };
-  let result = await run(
-    "gh",
-    [
-      "run",
-      "download",
-      String(publication.producerRunId),
-      "--repo",
-      env("GITHUB_REPOSITORY"),
-      "--name",
-      String(publication.artifactName),
-      "--dir",
-      bundleDir,
-    ],
-    {
-      env: {
-        ...process.env,
-        GH_TOKEN: repositoryToken,
-        ...itemEgressEnv,
-      },
-      capture: true,
-    },
-  );
-  appendRequestMetric(requestMetricsPath, {
-    scope: "repository_actions",
-    category: "artifact_download",
-    mode: "read",
-    outcome:
-      result.code === 0 ? "success" : githubThrottleText(result.stderr) ? "throttle" : "error",
-    repeat_revision: item.repeatRevision === true,
-    count: 1,
-  });
-  if (result.code !== 0 && githubThrottleText(result.stderr)) {
-    const observation = await resolveRateLimitObservation(
-      repositoryToken,
-      requestMetricsPath,
-      rateLimitObservationPath,
-      itemEgressEnv,
-    );
-    appendJsonLine(rateLimitObservationPath, observation);
-    return writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
-      retryAt: observation.retry_at,
-      rateLimitScope: observation.scope,
-      rateLimitProvenance: observation.provenance,
-      rateLimitAuthoritative: observation.authoritative,
-      attempted: true,
-    });
-  }
-  if (result.code !== 0)
-    return writeFailure(outcomePath, "retryable_failure", "artifact_unavailable");
-  const artifactBytes = directoryBytes(bundleDir);
   const maxArtifactBytes = positiveInteger(
     process.env.EXACT_REVIEW_BATCH_MAX_ARTIFACT_BYTES,
     DEFAULT_ARTIFACT_BYTES,
   );
-  if (artifactBytes > maxArtifactBytes) {
-    return writeFailure(outcomePath, "retryable_failure", "artifact_unavailable");
+  const maxArchiveBytes = maxArtifactBytes + 2 * 1024 * 1024;
+  const acquisitionPath = join(root, "artifact-acquisition.json");
+  const acquisition = {
+    cacheHit: false,
+    cacheFallback: false,
+    circuitDeferred: false,
+    githubArtifactRequests: 0,
+  };
+  const cacheOptions = exactReviewArtifactCacheOptions(item, bundleDir, maxArchiveBytes);
+  let bundleReady = false;
+  if (cacheOptions) {
+    try {
+      const restored = await restoreExactReviewArtifact(cacheOptions);
+      if (restored.hit) {
+        const validation = await validateExactReviewBundle({
+          bundleDir,
+          workspace,
+          item,
+          decision,
+          publication,
+          producer,
+          itemNumber,
+          targetRepo,
+        });
+        if (!validation.valid) throw new Error("cached bundle validation failed");
+        acquisition.cacheHit = true;
+        bundleReady = true;
+      } else {
+        acquisition.cacheFallback = true;
+      }
+    } catch {
+      acquisition.cacheFallback = true;
+      rmSync(bundleDir, { recursive: true, force: true });
+      mkdirSync(bundleDir, { recursive: true });
+      console.warn(
+        `Exact-review artifact cache miss or mismatch for ${item.itemKey}; using GitHub`,
+      );
+    }
   }
 
-  result = await run(
+  if (!bundleReady) {
+    const activeCircuit = latestActiveRateLimitObservation(rateLimitObservationPath);
+    if (activeCircuit) {
+      acquisition.circuitDeferred = true;
+      writeWorkerAcquisition(acquisitionPath, acquisition);
+      appendRequestMetric(requestMetricsPath, {
+        scope: activeCircuit.scope,
+        category: "artifact_download",
+        mode: "read",
+        outcome: "skipped_by_circuit",
+        repeat_revision: item.repeatRevision === true,
+        count: 1,
+      });
+      appendLegacyAvoidedGithubEgressMember({
+        env: { ...process.env, TARGET_REPO: targetRepo },
+        poolClass:
+          activeCircuit.scope === "repository_actions" ? "repository_actions" : "target_app",
+        stage: "publication_prepare",
+        sourceAction: producer.sourceAction,
+        operation: "artifact_download",
+        claimGeneration: item.claimGeneration,
+        repeatRevision: item.repeatRevision === true,
+      });
+      return writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
+        retryAt: activeCircuit.retry_at,
+        rateLimitScope: activeCircuit.scope,
+        rateLimitProvenance: activeCircuit.provenance,
+        rateLimitAuthoritative: activeCircuit.authoritative === true,
+        attempted: false,
+      });
+    }
+    recordGithubEgressMember({
+      env: { ...process.env, TARGET_REPO: targetRepo },
+      poolClass: "repository_actions",
+      stage: "publication_prepare",
+      sourceAction: producer.sourceAction,
+      claimGeneration: item.claimGeneration,
+      repeatRevision: item.repeatRevision === true,
+      attempted: true,
+      outcome: "attempted",
+    });
+    acquisition.githubArtifactRequests = 1;
+    writeWorkerAcquisition(acquisitionPath, acquisition);
+    const repositoryToken = env("REPO_TOKEN");
+    let result = await run(
+      "gh",
+      [
+        "run",
+        "download",
+        String(publication.producerRunId),
+        "--repo",
+        env("GITHUB_REPOSITORY"),
+        "--name",
+        String(publication.artifactName),
+        "--dir",
+        bundleDir,
+      ],
+      {
+        env: {
+          ...process.env,
+          GH_TOKEN: repositoryToken,
+          ...itemEgressEnv,
+        },
+        capture: true,
+      },
+    );
+    appendRequestMetric(requestMetricsPath, {
+      scope: "repository_actions",
+      category: "artifact_download",
+      mode: "read",
+      outcome:
+        result.code === 0 ? "success" : githubThrottleText(result.stderr) ? "throttle" : "error",
+      repeat_revision: item.repeatRevision === true,
+      count: 1,
+    });
+    if (result.code !== 0 && githubThrottleText(result.stderr)) {
+      const observation = await resolveRateLimitObservation(
+        repositoryToken,
+        requestMetricsPath,
+        rateLimitObservationPath,
+        itemEgressEnv,
+      );
+      appendJsonLine(rateLimitObservationPath, observation);
+      return writeFailure(outcomePath, "retryable_failure", "github_rate_limit", {
+        retryAt: observation.retry_at,
+        rateLimitScope: observation.scope,
+        rateLimitProvenance: observation.provenance,
+        rateLimitAuthoritative: observation.authoritative,
+        attempted: true,
+      });
+    }
+    if (result.code !== 0)
+      return writeFailure(outcomePath, "retryable_failure", "artifact_unavailable");
+    const artifactBytes = directoryBytes(bundleDir);
+    if (artifactBytes > maxArtifactBytes) {
+      return writeFailure(outcomePath, "retryable_failure", "artifact_unavailable");
+    }
+    const validation = await validateExactReviewBundle({
+      bundleDir,
+      workspace,
+      item,
+      decision,
+      publication,
+      producer,
+      itemNumber,
+      targetRepo,
+    });
+    if (!validation.valid) {
+      if (validation.legacyTupleless) {
+        return writeFailure(outcomePath, "permanent_failure", "tuple_protocol_invalid");
+      }
+      return writeFailure(outcomePath, "retryable_failure", "unknown_failure");
+    }
+    bundleReady = true;
+    if (cacheOptions) {
+      await publishExactReviewArtifact(cacheOptions).catch(() => {
+        console.warn(`Exact-review artifact cache population failed for ${item.itemKey}`);
+      });
+    }
+  }
+  writeWorkerAcquisition(acquisitionPath, acquisition);
+  const report = join(bundleDir, "review", `${itemNumber}.md`);
+  if (existsSync(report)) {
+    cpSync(report, join(eventArtifacts, `${itemNumber}.md`));
+    cpSync(report, outcomePath.replace(/\.json$/, ".report.md"));
+  }
+
+  const result = await run(
+    process.execPath,
+    [join(workspace, "dist/repair/publish-event-result.js")],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAWSWEEPER_GH_RETRY_ATTEMPTS: "2",
+        CLAWSWEEPER_CODE_ROOT: workspace,
+        EXACT_REVIEW_WORK_ROOT: root,
+        TARGET_REPO: targetRepo,
+        ITEM_NUMBER: itemNumber,
+        MIN_AGE_MINUTES: "0",
+        REVIEW_ONLY: String(producer.sourceAction === "failed_review_shard_recovery"),
+        EXACT_EVENT_PUBLICATION: "true",
+        EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED: "true",
+        EXACT_REVIEW_BATCH_ITEM_KEY: String(item.itemKey),
+        EXACT_REVIEW_BATCH_REVISION: String(item.revision),
+        EXACT_REVIEW_BATCH_CLAIM_GENERATION: String(item.claimGeneration),
+        EXACT_REVIEW_BATCH_MUTATION_OUTPUT: outcomePath,
+        CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: rateLimitObservationPath,
+        CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: requestMetricsPath,
+        CLAWSWEEPER_GITHUB_STAGE: "publication_apply",
+        CLAWSWEEPER_GITHUB_SOURCE_ACTION: String(producer.sourceAction || ""),
+        CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(item.repeatRevision === true),
+      },
+    },
+  );
+  if (result.code !== 0 && !existsSync(outcomePath)) {
+    writeFailure(outcomePath, "retryable_failure", "unknown_failure");
+  }
+}
+
+async function validateExactReviewBundle({
+  bundleDir,
+  workspace,
+  decision,
+  publication,
+  producer,
+  itemNumber,
+  targetRepo,
+}) {
+  const result = await run(
     process.execPath,
     [join(workspace, "dist/repair/exact-review-bundle-cli.js"), "validate"],
     {
@@ -356,42 +484,57 @@ async function worker(itemPath, root, workspace) {
       },
     },
   );
-  if (result.code !== 0) return writeFailure(outcomePath, "retryable_failure", "unknown_failure");
   const report = join(bundleDir, "review", `${itemNumber}.md`);
-  if (existsSync(report) && legacyTupleless(readFileSync(report, "utf8"))) {
-    return writeFailure(outcomePath, "permanent_failure", "tuple_protocol_invalid");
-  }
-  if (existsSync(report)) {
-    cpSync(report, join(eventArtifacts, `${itemNumber}.md`));
-    cpSync(report, outcomePath.replace(/\.json$/, ".report.md"));
-  }
+  const tupleless = existsSync(report) && legacyTupleless(readFileSync(report, "utf8"));
+  return { valid: result.code === 0 && !tupleless, legacyTupleless: tupleless };
+}
 
-  result = await run(process.execPath, [join(workspace, "dist/repair/publish-event-result.js")], {
-    cwd: root,
-    env: {
-      ...process.env,
-      CLAWSWEEPER_GH_RETRY_ATTEMPTS: "2",
-      CLAWSWEEPER_CODE_ROOT: workspace,
-      EXACT_REVIEW_WORK_ROOT: root,
-      TARGET_REPO: targetRepo,
-      ITEM_NUMBER: itemNumber,
-      MIN_AGE_MINUTES: "0",
-      REVIEW_ONLY: String(producer.sourceAction === "failed_review_shard_recovery"),
-      EXACT_EVENT_PUBLICATION: "true",
-      EXACT_REVIEW_CLOSE_COVERAGE_DEFERRED: "true",
-      EXACT_REVIEW_BATCH_ITEM_KEY: String(item.itemKey),
-      EXACT_REVIEW_BATCH_REVISION: String(item.revision),
-      EXACT_REVIEW_BATCH_CLAIM_GENERATION: String(item.claimGeneration),
-      EXACT_REVIEW_BATCH_MUTATION_OUTPUT: outcomePath,
-      CLAWSWEEPER_GITHUB_RATE_LIMIT_OBSERVATION_PATH: rateLimitObservationPath,
-      CLAWSWEEPER_GITHUB_REQUEST_METRICS_PATH: requestMetricsPath,
-      CLAWSWEEPER_GITHUB_STAGE: "publication_apply",
-      CLAWSWEEPER_GITHUB_SOURCE_ACTION: String(producer.sourceAction || ""),
-      CLAWSWEEPER_GITHUB_REQUEST_REPEAT: String(item.repeatRevision === true),
-    },
-  });
-  if (result.code !== 0 && !existsSync(outcomePath)) {
-    writeFailure(outcomePath, "retryable_failure", "unknown_failure");
+function exactReviewArtifactCacheOptions(item, bundleDir, maxArchiveBytes) {
+  const baseUrl = String(process.env.EXACT_REVIEW_QUEUE_URL || "").trim();
+  const webhookSecret = String(process.env.CLAWSWEEPER_WEBHOOK_SECRET || "");
+  if (!baseUrl || !webhookSecret) return null;
+  try {
+    return {
+      baseUrl,
+      webhookSecret,
+      tuple: exactReviewArtifactReceiptTuple(item),
+      bundleDir,
+      maxArchiveBytes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeWorkerAcquisition(path, value) {
+  writeFileSync(path, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+function readWorkerAcquisition(root) {
+  const path = join(root, "artifact-acquisition.json");
+  if (!existsSync(path)) {
+    return {
+      cacheHit: false,
+      cacheFallback: false,
+      circuitDeferred: false,
+      githubArtifactRequests: 0,
+    };
+  }
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"));
+    return {
+      cacheHit: value.cacheHit === true,
+      cacheFallback: value.cacheFallback === true,
+      circuitDeferred: value.circuitDeferred === true,
+      githubArtifactRequests: Number(value.githubArtifactRequests) === 1 ? 1 : 0,
+    };
+  } catch {
+    return {
+      cacheHit: false,
+      cacheFallback: false,
+      circuitDeferred: false,
+      githubArtifactRequests: 0,
+    };
   }
 }
 

--- a/test/exact-review-artifact-cache.test.ts
+++ b/test/exact-review-artifact-cache.test.ts
@@ -81,6 +81,43 @@ test("artifact cache retention prunes expired receipts and old unreferenced R2 o
   assert.equal(store.lookup(tuple, now + EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS + 1), null);
 });
 
+test("artifact receipt cleanup is digest-indexed and bounded at realistic populations", async () => {
+  const now = Date.parse("2026-08-14T00:00:00Z");
+  const storage = new MemoryDurableStorage();
+  const bucket = new ArtifactBucket();
+  const store = new ExactReviewArtifactReceiptStore(storage, bucket);
+  store.ensureSchemaSync();
+  const indexes = Array.from(
+    storage.sql.exec(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'exact_review_artifact_receipts' ORDER BY name",
+    ),
+  ).map((row) => String(row.name));
+  assert.ok(indexes.includes("exact_review_artifact_receipts_digest_expiry"));
+
+  for (let index = 1; index <= 140; index += 1) {
+    const digest = index.toString(16).padStart(64, "0");
+    storage.sql.exec(
+      `INSERT INTO exact_review_artifact_receipts
+         (producer_run_id, producer_run_attempt, artifact_name, canonical_item_key,
+          lease_revision, protocol_version, digest, bytes, object_key, created_at, expires_at)
+       VALUES (?, 1, ?, ?, 1, 2, ?, 1, ?, ?, ?)`,
+      String(20_000 + index),
+      `exact-review-${20_000 + index}-1`,
+      `openclaw/openclaw#${20_000 + index}`,
+      digest,
+      `${EXACT_REVIEW_ARTIFACT_CACHE_PREFIX}${digest}`,
+      now - 1,
+      now,
+    );
+  }
+  assert.equal((await store.prune(now)).receiptsDeleted, 128);
+  const remaining = Number(
+    Array.from(storage.sql.exec("SELECT COUNT(*) AS count FROM exact_review_artifact_receipts"))[0]
+      ?.count,
+  );
+  assert.equal(remaining, 12);
+});
+
 test("Worker artifact receipt endpoints use publisher scope, not operator scope", async () => {
   const now = Date.now();
   const storage = new MemoryDurableStorage();

--- a/test/exact-review-artifact-cache.test.ts
+++ b/test/exact-review-artifact-cache.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { createHash, createHmac } from "node:crypto";
+import test from "node:test";
+
+import {
+  EXACT_REVIEW_ARTIFACT_CACHE_PREFIX,
+  EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS,
+  ExactReviewArtifactReceiptStore,
+} from "../dashboard/exact-review-artifact-cache.ts";
+import worker, { ExactReviewQueue } from "../dashboard/worker.ts";
+import { MemoryDurableNamespace, MemoryDurableStorage } from "./dashboard-worker-harness.ts";
+
+const webhookSecret = "artifact-cache-webhook-placeholder";
+const operatorSecret = "artifact-cache-operator-placeholder";
+const tuple = {
+  producer_run_id: "12001",
+  producer_run_attempt: 2,
+  artifact_name: "exact-review-12001-2",
+  canonical_item_key: "openclaw/openclaw#81234",
+  lease_revision: 7,
+  protocol_version: 2,
+};
+
+test("artifact receipts bind the complete publication tuple and remain immutable", async () => {
+  const now = Date.parse("2026-08-14T00:00:00Z");
+  const storage = new MemoryDurableStorage();
+  const bucket = new ArtifactBucket();
+  const store = new ExactReviewArtifactReceiptStore(storage, bucket);
+  store.ensureSchemaSync();
+  const content = Buffer.from("content-addressed exact-review bundle");
+  const digest = sha256(content);
+  bucket.seed(digest, content, now);
+
+  const first = await store.store({ ...tuple, digest, bytes: content.byteLength }, now);
+  assert.equal(first.ok, true);
+  assert.equal(first.ok && first.deduped, false);
+  assert.equal(store.lookup(tuple, now + 1)?.digest, digest);
+  assert.equal(store.lookup({ ...tuple, lease_revision: 8 }, now + 1), null);
+  assert.equal(store.lookup({ ...tuple, producer_run_attempt: 3 }, now + 1), null);
+
+  const repeat = await store.store({ ...tuple, digest, bytes: content.byteLength }, now + 2);
+  assert.equal(repeat.ok, true);
+  assert.equal(repeat.ok && repeat.deduped, true);
+
+  const different = Buffer.from("different bundle bytes");
+  const differentDigest = sha256(different);
+  bucket.seed(differentDigest, different, now + 3);
+  const conflict = await store.store(
+    { ...tuple, digest: differentDigest, bytes: different.byteLength },
+    now + 3,
+  );
+  assert.deepEqual(conflict, {
+    ok: false,
+    error: "artifact_receipt_immutable_conflict",
+    status: 409,
+  });
+});
+
+test("artifact cache retention prunes expired receipts and old unreferenced R2 objects", async () => {
+  const now = Date.parse("2026-08-14T00:00:00Z");
+  const storage = new MemoryDurableStorage();
+  const bucket = new ArtifactBucket();
+  const store = new ExactReviewArtifactReceiptStore(storage, bucket);
+  store.ensureSchemaSync();
+  const referenced = Buffer.from("referenced");
+  const referencedDigest = sha256(referenced);
+  const orphan = Buffer.from("orphan");
+  const orphanDigest = sha256(orphan);
+  bucket.seed(referencedDigest, referenced, now);
+  bucket.seed(orphanDigest, orphan, now);
+  assert.equal(
+    (await store.store({ ...tuple, digest: referencedDigest, bytes: referenced.byteLength }, now))
+      .ok,
+    true,
+  );
+
+  const pruned = await store.prune(now + EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS + 1);
+  assert.equal(pruned.receiptsDeleted, 1);
+  assert.equal(pruned.objectsDeleted, 2);
+  assert.equal(bucket.keys().length, 0);
+  assert.equal(store.lookup(tuple, now + EXACT_REVIEW_ARTIFACT_RECEIPT_RETENTION_MS + 1), null);
+});
+
+test("Worker artifact receipt endpoints use publisher scope, not operator scope", async () => {
+  const now = Date.now();
+  const storage = new MemoryDurableStorage();
+  const bucket = new ArtifactBucket();
+  const content = Buffer.from("signed cache object");
+  const digest = sha256(content);
+  bucket.seed(digest, content, now);
+  const queue = new ExactReviewQueue({ storage }, { STATE_SNAPSHOTS: bucket });
+  const env = {
+    CLAWSWEEPER_WEBHOOK_SECRET: webhookSecret,
+    EXACT_REVIEW_OPERATOR_SECRET: operatorSecret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  };
+  const storeBody = JSON.stringify({ ...tuple, digest, bytes: content.byteLength });
+  const url = "https://clawsweeper.openclaw.ai/internal/exact-review/artifact-cache/receipt/store";
+
+  assert.equal(
+    (await worker.fetch(new Request(url, { method: "POST", body: storeBody }), env)).status,
+    401,
+  );
+  assert.equal(
+    (await worker.fetch(signedRequest(url, storeBody, operatorSecret), env)).status,
+    401,
+  );
+  const stored = await worker.fetch(signedRequest(url, storeBody, webhookSecret), env);
+  assert.equal(stored.status, 201);
+  assert.equal((await stored.json()).receipt.digest, digest);
+
+  const lookupBody = JSON.stringify(tuple);
+  const lookup = await worker.fetch(
+    signedRequest(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/artifact-cache/receipt/lookup",
+      lookupBody,
+      webhookSecret,
+    ),
+    env,
+  );
+  assert.equal(lookup.status, 200);
+  assert.equal((await lookup.json()).hit, true);
+});
+
+class ArtifactBucket {
+  private readonly objects = new Map<
+    string,
+    {
+      bytes: Uint8Array;
+      uploaded: Date;
+      customMetadata: Record<string, string>;
+    }
+  >();
+
+  seed(digest: string, content: Uint8Array, uploadedAt: number) {
+    this.objects.set(`${EXACT_REVIEW_ARTIFACT_CACHE_PREFIX}${digest}`, {
+      bytes: new Uint8Array(content).slice(),
+      uploaded: new Date(uploadedAt),
+      customMetadata: { sha256: digest, verified: "server" },
+    });
+  }
+
+  async head(key: string) {
+    const object = this.objects.get(key);
+    return object ? descriptor(key, object) : null;
+  }
+
+  async list(options: { prefix: string; cursor?: string; limit: number }) {
+    const keys = [...this.objects.keys()].filter((key) => key.startsWith(options.prefix)).sort();
+    const start = options.cursor ? Number(options.cursor) : 0;
+    const selected = keys.slice(start, start + options.limit);
+    const truncated = start + selected.length < keys.length;
+    return {
+      objects: selected.map((key) => descriptor(key, this.objects.get(key)!)),
+      truncated,
+      ...(truncated ? { cursor: String(start + selected.length) } : {}),
+    };
+  }
+
+  async delete(key: string) {
+    this.objects.delete(key);
+  }
+
+  keys() {
+    return [...this.objects.keys()];
+  }
+}
+
+function descriptor(
+  key: string,
+  object: { bytes: Uint8Array; uploaded: Date; customMetadata: Record<string, string> },
+) {
+  return {
+    key,
+    size: object.bytes.byteLength,
+    uploaded: object.uploaded,
+    customMetadata: object.customMetadata,
+  };
+}
+
+function signedRequest(url: string, body: string, secret: string) {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+    },
+    body,
+  });
+}
+
+function sha256(content: Uint8Array) {
+  return createHash("sha256").update(content).digest("hex");
+}

--- a/test/repair/exact-review-batch-prepare.test.mjs
+++ b/test/repair/exact-review-batch-prepare.test.mjs
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import { runBoundedPool } from "../../scripts/prepare-exact-review-batch.mjs";
+import {
+  packExactReviewBundle,
+  unpackExactReviewBundle,
+} from "../../scripts/exact-review-artifact-cache.mjs";
 
 test("bounded preparation pool respects the configured concurrency", async () => {
   let active = 0;
@@ -24,4 +30,46 @@ test("batch preparation copies canonical records without cloning git state", () 
   assert.match(source, /cpSync\(recordsSource, join\(root, "records"\)/);
   assert.doesNotMatch(source, /CLAWSWEEPER_STATE_DIR|stateClone|git["'], \["clone"/);
   assert.doesNotMatch(source, /pack-objects|unpack-objects|targetOid|expectedOid/);
+});
+
+test("artifact cache archive round-trips exact file bytes deterministically", () => {
+  const root = mkdtempSync(join(tmpdir(), "exact-review-artifact-archive-"));
+  const source = join(root, "source");
+  const restored = join(root, "restored");
+  try {
+    mkdirSync(join(source, "review"), { recursive: true });
+    mkdirSync(join(source, "metadata"), { recursive: true });
+    writeFileSync(join(source, "review", "42.md"), Buffer.from([0, 1, 2, 10, 255]));
+    writeFileSync(join(source, "metadata", "bundle.json"), '{"version":2}\n');
+    const first = packExactReviewBundle(source);
+    const second = packExactReviewBundle(source);
+    assert.deepEqual(first, second);
+    unpackExactReviewBundle(first, restored);
+    assert.deepEqual(
+      readFileSync(join(restored, "review", "42.md")),
+      Buffer.from([0, 1, 2, 10, 255]),
+    );
+    assert.equal(
+      readFileSync(join(restored, "metadata", "bundle.json"), "utf8"),
+      '{"version":2}\n',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("artifact cache archive rejects corrupted bytes before writing a bundle", () => {
+  const root = mkdtempSync(join(tmpdir(), "exact-review-artifact-corrupt-"));
+  const source = join(root, "source");
+  const restored = join(root, "restored");
+  try {
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, "bundle.txt"), "authoritative bytes\n");
+    const archive = packExactReviewBundle(source);
+    archive[archive.length - 1] ^= 0xff;
+    assert.throws(() => unpackExactReviewBundle(archive, restored), /file digest mismatch/);
+    assert.equal(readFileSync(source + "/bundle.txt", "utf8"), "authoritative bytes\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/test/repair/exact-review-batch-workflow.test.ts
+++ b/test/repair/exact-review-batch-workflow.test.ts
@@ -638,7 +638,7 @@ test("batch workflow uses owner-scoped mutation credentials and canonical Worker
   assert.doesNotMatch(prepareSource, /stateClone|CLAWSWEEPER_STATE_DIR|"clone"/);
   assert.match(prepareSource, /CLAWSWEEPER_CODE_ROOT: workspace/);
   assert.match(prepareSource, /EXACT_REVIEW_WORK_ROOT: root/);
-  assert.match(prepareSource, /publish-event-result\.js"\)\], \{\s*cwd: root,\s*env:/);
+  assert.match(prepareSource, /publish-event-result\.js"\)\],\s*\{\s*cwd: root,\s*env:/);
   assert.match(publisherSource, /codeRoot: resolve\(process\.env\.CLAWSWEEPER_CODE_ROOT/);
   assert.match(publisherSource, /const cli = join\(options\.codeRoot, "dist\/clawsweeper\.js"\)/);
   assert.match(

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -18,7 +18,8 @@ const secret = "state-blob-secret";
 const baseUrl = "https://worker.example";
 const ledgerPath = "ledger/v1/events/2026/07/26/openclaw/openclaw/shard-000.jsonl";
 const assetPath = "assets/social/card.svg";
-const artifactPath = `artifacts/exact-review/v1/${"a".repeat(64)}`;
+const artifactContent = Buffer.from("cached bundle bytes");
+const artifactPath = `artifacts/exact-review/v1/${sha256(artifactContent)}`;
 
 test("state blob endpoints reject unsigned requests and fail closed without a bucket", async () => {
   const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
@@ -179,7 +180,7 @@ test("ledger keys are create-only while asset keys may overwrite", async () => {
   const stat = await statStateBlob({ ...options, blobPath: assetPath });
   assert.equal(stat?.digest, sha256(Buffer.from("<svg two/>")));
 
-  const artifact = Buffer.from("cached bundle bytes");
+  const artifact = artifactContent;
   await putBlob(env, artifactPath, artifact);
   const artifactConflict = await worker.fetch(
     signedBlobRequest("put", {
@@ -189,8 +190,8 @@ test("ledger keys are create-only while asset keys may overwrite", async () => {
     }),
     env,
   );
-  assert.equal(artifactConflict.status, 409);
-  assert.equal((await artifactConflict.json()).error, "artifact_blob_immutable_conflict");
+  assert.equal(artifactConflict.status, 400);
+  assert.equal((await artifactConflict.json()).error, "artifact_blob_key_digest_mismatch");
 
   for (const malformed of [
     "artifacts/exact-review/v1/not-a-digest",
@@ -208,6 +209,29 @@ test("ledger keys are create-only while asset keys may overwrite", async () => {
     assert.equal(rejected.status, 400, malformed);
     assert.equal((await rejected.json()).error, "invalid_blob_path", malformed);
   }
+
+  const mismatchedKey = `artifacts/exact-review/v1/${"b".repeat(64)}`;
+  const mismatchedDirect = await worker.fetch(
+    signedBlobRequest("put", {
+      path: mismatchedKey,
+      digest: sha256(artifact),
+      contentBase64: artifact.toString("base64"),
+    }),
+    env,
+  );
+  assert.equal(mismatchedDirect.status, 400);
+  assert.equal((await mismatchedDirect.json()).error, "artifact_blob_key_digest_mismatch");
+
+  const mismatchedStart = await worker.fetch(
+    signedBlobRequest("multipart/start", {
+      path: mismatchedKey,
+      digest: sha256(artifact),
+      bytes: artifact.byteLength,
+    }),
+    env,
+  );
+  assert.equal(mismatchedStart.status, 400);
+  assert.equal((await mismatchedStart.json()).error, "artifact_blob_key_digest_mismatch");
 });
 
 test("multipart uploads stream fixed-size parts and enforce immutability at completion", async () => {
@@ -308,6 +332,38 @@ test("multipart uploads stream fixed-size parts and enforce immutability at comp
   );
   assert.equal(staleUpload.status, 400);
   assert.equal((await staleUpload.json()).error, "invalid_blob_upload");
+
+  const artifactContent = Buffer.from("multipart artifact bytes");
+  const artifactDigest = sha256(artifactContent);
+  const artifactKey = `artifacts/exact-review/v1/${artifactDigest}`;
+  const artifactStarted = await signedJson(
+    env,
+    "multipart/start",
+    { path: artifactKey, digest: artifactDigest, bytes: artifactContent.byteLength },
+    201,
+  );
+  const artifactPart = await signedJson(env, "multipart/part", {
+    path: artifactKey,
+    uploadId: artifactStarted.uploadId,
+    partNumber: 1,
+    contentBase64: artifactContent.toString("base64"),
+  });
+  const mismatchedComplete = await worker.fetch(
+    signedBlobRequest("multipart/complete", {
+      path: artifactKey,
+      uploadId: artifactStarted.uploadId,
+      digest: "c".repeat(64),
+      bytes: artifactContent.byteLength,
+      parts: [artifactPart.part],
+    }),
+    env,
+  );
+  assert.equal(mismatchedComplete.status, 400);
+  assert.equal((await mismatchedComplete.json()).error, "artifact_blob_key_digest_mismatch");
+  await signedJson(env, "multipart/abort", {
+    path: artifactKey,
+    uploadId: artifactStarted.uploadId,
+  });
 });
 
 test("chunked downloads retry transient 5xx responses and reject invalid ranges", async () => {

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -191,6 +191,23 @@ test("ledger keys are create-only while asset keys may overwrite", async () => {
   );
   assert.equal(artifactConflict.status, 409);
   assert.equal((await artifactConflict.json()).error, "artifact_blob_immutable_conflict");
+
+  for (const malformed of [
+    "artifacts/exact-review/v1/not-a-digest",
+    `artifacts/exact-review/v1/${"b".repeat(64)}/nested`,
+    `artifacts/exact-review/v1/${"C".repeat(64)}`,
+  ]) {
+    const rejected = await worker.fetch(
+      signedBlobRequest("put", {
+        path: malformed,
+        digest: sha256(artifact),
+        contentBase64: artifact.toString("base64"),
+      }),
+      env,
+    );
+    assert.equal(rejected.status, 400, malformed);
+    assert.equal((await rejected.json()).error, "invalid_blob_path", malformed);
+  }
 });
 
 test("multipart uploads stream fixed-size parts and enforce immutability at completion", async () => {

--- a/test/worker-state-blobs.test.ts
+++ b/test/worker-state-blobs.test.ts
@@ -18,6 +18,7 @@ const secret = "state-blob-secret";
 const baseUrl = "https://worker.example";
 const ledgerPath = "ledger/v1/events/2026/07/26/openclaw/openclaw/shard-000.jsonl";
 const assetPath = "assets/social/card.svg";
+const artifactPath = `artifacts/exact-review/v1/${"a".repeat(64)}`;
 
 test("state blob endpoints reject unsigned requests and fail closed without a bucket", async () => {
   const env = { CLAWSWEEPER_WEBHOOK_SECRET: secret, STATE_SNAPSHOTS: new FakeR2Bucket() };
@@ -177,6 +178,19 @@ test("ledger keys are create-only while asset keys may overwrite", async () => {
   assert.equal(replaced.unchanged, false);
   const stat = await statStateBlob({ ...options, blobPath: assetPath });
   assert.equal(stat?.digest, sha256(Buffer.from("<svg two/>")));
+
+  const artifact = Buffer.from("cached bundle bytes");
+  await putBlob(env, artifactPath, artifact);
+  const artifactConflict = await worker.fetch(
+    signedBlobRequest("put", {
+      path: artifactPath,
+      digest: sha256(Buffer.from("different cached bytes")),
+      contentBase64: Buffer.from("different cached bytes").toString("base64"),
+    }),
+    env,
+  );
+  assert.equal(artifactConflict.status, 409);
+  assert.equal((await artifactConflict.json()).error, "artifact_blob_immutable_conflict");
 });
 
 test("multipart uploads stream fixed-size parts and enforce immutability at completion", async () => {

--- a/tsconfig.dashboard-strict.json
+++ b/tsconfig.dashboard-strict.json
@@ -13,6 +13,7 @@
     "dashboard/dashboard-health.ts",
     "dashboard/dashboard-pages.ts",
     "dashboard/error-safety.ts",
+    "dashboard/exact-review-artifact-cache.ts",
     "dashboard/exact-review-command-intake.ts",
     "dashboard/exact-review-decision.ts",
     "dashboard/exact-review-direct-publication.ts",


### PR DESCRIPTION
## Summary

Cache validated exact-review artifact bundles in R2 by content digest so unchanged publication retries can avoid another GitHub artifact download. GitHub Artifacts remains authoritative: every cache miss, missing/corrupt object, receipt mismatch, or validation failure falls back to the existing GitHub path, subject to the existing open-circuit skip.

This is phase A of the two-phase design: GitHub download first, then populate R2. Producer-side R2 upload remains a later change after this path is proven.

## Analysis citation

Implements rank 3, `repository_actions:artifact_download`, from the 2026-08-13 ClawSweeper GitHub API savings analysis: 12,784 observed artifact-download operations plus roughly 6,000 circuit skips, with a conservative 36% successful-repeat floor. The analysis recommended an immutable digest key plus a receipt binding producer run/attempt, canonical item key, lease revision, and protocol version.

## Protocol and ownership

- Object key: `artifacts/exact-review/v1/<lowercase-sha256>`.
- The state-blob Worker requires the key suffix to equal the declared SHA-256 for direct PUT and multipart start/complete; exact-review objects are immutable.
- Receipt primary key: `(producer_run_id, producer_run_attempt, artifact_name, canonical_item_key, lease_revision, protocol_version)`.
- Receipt value: `digest`, `bytes`, derived `object_key`, `created_at`, and `expires_at`.
- Cache lookup happens before the GitHub rate-limit circuit. A hit consumes no GitHub artifact request; a fallback under an open circuit preserves the existing skip outcome.
- Both receipt endpoints and state-blob transfer use `CLAWSWEEPER_WEBHOOK_SECRET`. These are automated publisher data-plane operations, and that secret already enters the batch job. `EXACT_REVIEW_OPERATOR_SECRET` remains confined to human recovery/admin endpoints.

## Retention

Receipts expire after 30 days, matching existing terminal-receipt conventions. Each cache lookup/store performs bounded incremental cleanup: at most 128 expired receipts and one 128-object R2 page. A digest-leading `(digest, expires_at)` index supports live-reference checks. Old unreferenced objects, including upload orphans, are deleted; active receipts retain shared objects.

## Counted behavior proof

Docker-backed Crabbox `provider=local-container`, lease `cbx_27fd45c696a1`, image `node:24-bookworm`; lease stopped automatically. The committed receipt is [docs/proof/r2-bundle-cache/receipt.json](https://github.com/openclaw/clawsweeper/blob/steipete/r2-bundle-cache/docs/proof/r2-bundle-cache/receipt.json).

| Scenario | GitHub artifact requests | Result |
| --- | ---: | --- |
| First tuple acquisition | 1 | Validated bundle populated R2 + receipt |
| Identical tuple retry | 0 | Served byte-identical R2 content |
| Receipt present, R2 object missing | 1 | Failed closed to GitHub |
| Same producer tuple, different lease revision | 1 | Receipt not reused; GitHub fallback |

All four paths produced SHA-256 `3133665a6449f68c78754dfdca7548fa3b450474dd97cd54f4bb79b2a86d8eb3`. Counted repeat result: `1 → 0` GitHub artifact requests (100% avoided for the exercised repeat).

Behavior-tested code head: `0e9ca08dea526b536e6818176228a09409a3c6a9`; tree: `d06aa801c6ee434707f15d9724e237bb8cec8181`. Both were resolved with `git rev-parse` and cross-checked with `git cat-file -e` before the container run. PR tip `8be2e61d6cb4aca6feb1685be695727e37ca11d6` differs only by the refreshed committed receipt.

The same lease ran `pnpm run check`: dashboard-strict, docs, formatting, builds, all lint lanes, 260-file full tests, and coverage passed (81.58% lines / 74.00% branches / 87.41% functions).

Limits: Wrangler local R2/Durable Object semantics rather than deployed Cloudflare networking; counted loopback artifact server rather than GitHub's hosted artifact service. Production bundle input remains bounded at 64 MiB, with a 66 MiB archive bound.

## Review disposition

- Round 1: added digest-leading receipt indexing and rejected malformed/nested/uppercase immutable artifact keys.
- Round 2: bound artifact object-key suffixes to declared digests for direct and multipart writes.
- Final local ClawSweeper review at current tip: patch correct, no findings, proof sufficient, A/A/A.
- Final committed-branch autoreview: clean, no accepted/actionable findings.
- Rank-up moves: none.

## OpenClaw Bay

Not affected. This changes internal publication data-plane acquisition and adds no observer or control contract; Bay remains observer-only.
