### PR TITLE
fix(apply): close-mode apply yields on GitHub rate limit instead of failing mid-scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Folder reconciliation now defers with a zero-mutation result when the open-state scan hits GitHub rate limiting, so throttled proof/apply/publish runs proceed to their close and publication work instead of failing before `Apply close proposals` can run.
 - Comment-only sync now defers its remaining batch as a runtime-budget-style yield when GitHub rate limits a live read, instead of failing the scheduled run; the next 15-minute cycle resumes the interrupted item, and close-mode apply keeps its loud failure.
+- Close-mode apply now takes the same rate-limit yield as comment sync: a throttled live read mid-scan defers the remaining window to the next cycle instead of failing the run, after production runs kept losing 600-record scan windows to mid-run 403s.
 - Increased the AWS Crabbox root volume from 160 GB to 400 GB so trusted checks can provision with the repository's current dependency and build footprint.
 - GitHub-throttled terminal status updates no longer fail the finalization run; the requeue step already re-arms the acknowledgement for after the rate window.
 

--- a/src/clawsweeper-command-operations.ts
+++ b/src/clawsweeper-command-operations.ts
@@ -592,16 +592,14 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
           runtimeBudget.onYield(error.reason);
           return;
         }
-        if (
-          error instanceof GitHubRateLimitError &&
-          boolArg(args.sync_comments_only) &&
-          runtimeBudget.onYield
-        ) {
-          // Comment sync is idempotent and re-runs on the next 15-minute tick,
-          // so an exhausted GitHub quota defers the remaining batch like a
-          // runtime-budget yield instead of recording a workflow failure.
+        if (error instanceof GitHubRateLimitError && runtimeBudget.onYield) {
+          // Quota exhaustion is the same "out of resource, resume next cycle"
+          // situation as a runtime-budget stop: closes are per-item verified
+          // and checkpointed, comment sync is idempotent, and the cursor trace
+          // returns the interrupted item to the next scheduled window. Failing
+          // loudly here only discarded the rest of the scan window.
           runtimeBudget.onYield(
-            `GitHub rate limited until ${error.retryAt}; comment sync deferred to the next cycle`,
+            `GitHub rate limited until ${error.retryAt}; apply resumes next cycle`,
           );
           return;
         }

--- a/test/apply-live-state.test.ts
+++ b/test/apply-live-state.test.ts
@@ -2920,7 +2920,7 @@ process.exit(1);
       ],
     );
     for (const result of report) {
-      assert.match(result.reason, /rate limited until .*comment sync deferred/);
+      assert.match(result.reason, /rate limited until .*apply resumes next cycle/);
     }
     assert.equal(readText(join(itemsDir, "321.md")), originalReport);
     assert.equal(existsSync(join(closedDir, "321.md")), false);
@@ -2929,7 +2929,7 @@ process.exit(1);
   }
 });
 
-test("close-mode apply still fails loudly when GitHub is rate limited", () => {
+test("close-mode apply defers the remaining scan window when GitHub is rate limited", () => {
   const root = mkdtempSync(tmpPrefix);
   try {
     const itemsDir = join(root, "items");
@@ -2938,7 +2938,8 @@ test("close-mode apply still fails loudly when GitHub is rate limited", () => {
     const reportPath = join(root, "apply-report.json");
     mkdirSync(itemsDir, { recursive: true });
     mkdirSync(plansDir, { recursive: true });
-    writeFileSync(join(itemsDir, "321.md"), implementedCloseReport(), "utf8");
+    const originalReport = implementedCloseReport();
+    writeFileSync(join(itemsDir, "321.md"), originalReport, "utf8");
 
     const ghMock = `
 const rawArgs = process.argv.slice(2);
@@ -2951,15 +2952,22 @@ if (args[0] === "api" && /\\/issues\\/321$/.test(path)) {
 console.error("unexpected gh args", JSON.stringify(args));
 process.exit(1);
 `;
-    assert.throws(
-      () =>
-        withMockGh(root, ghMock, () => {
-          runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
-        }),
-      /rate limit/i,
-    );
+    withMockGh(root, ghMock, () => {
+      runApplyDecisionsForTest({ itemsDir, closedDir, plansDir, reportPath });
+    });
 
-    assert.ok(existsSync(join(itemsDir, "321.md")));
+    const report = JSON.parse(readText(reportPath));
+    assert.deepEqual(
+      report.map((result) => ({ number: result.number, action: result.action })),
+      [
+        { number: 321, action: "skipped_runtime_budget" },
+        { number: 0, action: "skipped_runtime_budget" },
+      ],
+    );
+    for (const result of report) {
+      assert.match(result.reason, /rate limited until .*apply resumes next cycle/);
+    }
+    assert.equal(readText(join(itemsDir, "321.md")), originalReport);
     assert.equal(existsSync(join(closedDir, "321.md")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What Problem This Solves

After #1158 and #1160, close-mode apply runs start reliably and comment sync yields cleanly — but the close-mode scan itself still fails loudly on a mid-run throttle. [Run 31780550963](https://github.com/openclaw/clawsweeper/actions/runs/31780550963) scanned for 17 minutes, then lost the rest of its 600-record window to an uncaught `GitHubRateLimitError` during per-item comment pagination (`LiveReadGeneration.read` → `ghPagedContextWindow`). Under sustained installation-quota pressure this repeats every cycle, which is why real closes were running at ~4/hour despite ~1,500 policy-eligible candidates.

## Why This Change Was Made

#1160 deliberately scoped the yield to `--sync-comments-only` and kept close mode loud. Production evidence says that split was wrong: `GitHubRuntimeBudgetError` already yields gracefully in **every** apply mode, and quota exhaustion is the same "out of resource, resume next cycle" situation. Nothing about close mode makes a loud failure safer — closes are per-item live-verified and checkpointed, the cursor trace advances only through examined records and returns the interrupted item to the next window, and apply events finalize as a clean yield either way. The only effect of the loud failure was discarding the remaining scan window and recording `workflow_failure` telemetry for routine quota weather.

This drops the `sync_comments_only` gate so `GitHubRateLimitError` takes the same yield rail in all apply modes.

## Evidence

- Updated regression tests: both comment-sync and close-mode rate-limited runs now exit 0 with `skipped_runtime_budget` results (`apply resumes next cycle`) and byte-identical record files; 259/259 apply+reconcile tests pass.
- `pnpm run lint` and `pnpm run check:static` clean.
- Codex-backed autoreview: clean, no accepted/actionable findings (`patch is correct`, 0.98).
