### PR TITLE
fix(automerge): preserve quota retry classification

### DIFF
--- a/docs/proof/fix-automerge-quota-fixture/README.md
+++ b/docs/proof/fix-automerge-quota-fixture/README.md
@@ -1,0 +1,11 @@
+# Automerge quota publication proof
+
+The automerge quota fixture already observed the intended one-request fail-fast behavior, but exact-event publication misclassified the clean apply yield introduced by #1166. A GitHub 403 or 429 became two `skipped_runtime_budget` apply records (the interrupted item and continuation sentinel); `publish-event-result` did not recognize that proof and converted it into `permanent_failure/unknown_failure`.
+
+The fix preserves the structured rate-limit metadata in the apply-yield reason and reconstructs the quota error at the exact-publication boundary. Both HTTP cases must make one authenticated GET, make no DELETE request, exit the publisher honestly, and record `retryable_failure/github_rate_limit` in the workflow outputs and durable batch result.
+
+`run-proof.sh` obtains the commit, tree, and merge-base objects programmatically, cross-checks all three with `git cat-file`, runs the real GitHub CLI over the fixture's owned Unix-socket HTTP server, validates the generated summary with static `jq`, and runs the full repository gate.
+
+OpenClaw Bay is unaffected because this restores an internal exact-publication failure classification; no queue, workflow, status, telemetry, dashboard, or public observer contract changes.
+
+Limits: GitHub traffic is deterministic loopback traffic using synthetic credentials. The proof does not mutate production GitHub, Worker, queue, comment, label, close, merge, deployment, or workflow state. The receipt commit adds proof metadata only after the tested runtime commit.

--- a/docs/proof/fix-automerge-quota-fixture/container-receipt.json
+++ b/docs/proof/fix-automerge-quota-fixture/container-receipt.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-08-14T10:42:27Z",
+  "provider": "local-container",
+  "lease_id": "cbx_c6ed44beacf2",
+  "lease_slug": "crimson-prawn-01cd",
+  "container_runtime": "docker",
+  "image": "clawsweeper-automerge-e2e-base:quota-fixture",
+  "machine_type": "clawsweeper-automerge-e2e-base_quota-fixture",
+  "lease_stopped": true,
+  "tested_head_sha": "e1b0e27e5fd8045ce65da1fdcdcfc6c145d1e8d0",
+  "tested_head_tree": "d9fc824102d7521547b062b5152d8f6cd3d193a0",
+  "base_sha": "bf762f3f6f9e8ee89fc31a260053dabe257a7103",
+  "cat_file_cross_check": {
+    "head_commit": true,
+    "head_tree": true,
+    "base_commit": true
+  },
+  "runtime": {
+    "architecture": "arm64",
+    "node": "v24.15.0",
+    "pnpm": "11.10.0",
+    "transport": "actual gh HTTP over an owned Unix socket"
+  },
+  "timing_ms": {
+    "sync": 937,
+    "command": 116171,
+    "total": 117144,
+    "install": 2471,
+    "build": 1511,
+    "quota_fixture": 716,
+    "full_gate": 107917,
+    "receipt": 351
+  },
+  "quota_fixture": {
+    "statuses": [403, 429],
+    "requests": [1, 1],
+    "publisher_exits": [1, 1],
+    "completion_kinds": ["retryable_failure", "retryable_failure"],
+    "failure_kinds": ["github_rate_limit", "github_rate_limit"],
+    "batch_kinds": ["retryable_failure", "retryable_failure"],
+    "cleanup_deletes": [0, 0],
+    "static_jq": true
+  },
+  "full_gate": {
+    "command": "pnpm run check",
+    "exit_code": 0,
+    "tests": 3463,
+    "passed": 3455,
+    "failed": 0,
+    "skipped": 8
+  },
+  "pre_commit_autoreview": {
+    "command": "autoreview --mode local --stream-engine-output --parallel-tests 'pnpm run check'",
+    "exit_code": 0,
+    "accepted_or_actionable_findings": 0,
+    "result": "autoreview clean: no accepted/actionable findings reported"
+  },
+  "limits": [
+    "The GitHub API was a deterministic Unix-socket loopback fixture with synthetic credentials.",
+    "No production GitHub, Worker, queue, deployment, or workflow state was mutated.",
+    "The receipt commit adds proof metadata only after the tested runtime tree."
+  ],
+  "cleanup": {
+    "successful_lease_absent_from_local_container_list": true,
+    "failed_owned_leases_absent_from_local_container_list": true,
+    "unrelated_preexisting_exited_lease_untouched": true
+  }
+}

--- a/docs/proof/fix-automerge-quota-fixture/run-proof.sh
+++ b/docs/proof/fix-automerge-quota-fixture/run-proof.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_head="${1:?expected head is required}"
+expected_base="${2:?expected merge base is required}"
+output_dir="${AUTOMERGE_QUOTA_PROOF_OUTPUT:-.artifacts/fix-automerge-quota-fixture}"
+
+actual_head="$(git rev-parse HEAD)"
+head_tree="$(git rev-parse "${actual_head}^{tree}")"
+merge_base="$(git merge-base HEAD origin/main)"
+
+test "$actual_head" = "$expected_head"
+test "$merge_base" = "$expected_base"
+git cat-file -e "${actual_head}^{commit}"
+git cat-file -e "${head_tree}^{tree}"
+git cat-file -e "${merge_base}^{commit}"
+
+echo CRABBOX_PHASE:install
+corepack prepare pnpm@11.10.0 --activate
+pnpm install --frozen-lockfile
+
+echo CRABBOX_PHASE:build
+pnpm run build:node
+
+echo CRABBOX_PHASE:quota_fixture
+mkdir -p "$output_dir"
+node scripts/e2e/automerge.mjs \
+  --scenario github-api-quota-fail-fast \
+  --fixture tiny \
+  --output "$output_dir/automerge"
+
+summary="$output_dir/automerge/tiny/github-api-quota-fail-fast/summary.json"
+jq -e '
+  .status == "passed" and
+  .fixture == "tiny" and
+  .scenario == "github-api-quota-fail-fast" and
+  .container == true and
+  .transport == "actual gh HTTP over an owned Unix socket" and
+  [.results[].http_status] == [403, 429] and
+  (.results | all(
+    .requests == 1 and
+    .request.method == "GET" and
+    (.request.path | endswith("/repos/openclaw/openclaw/issues/42")) and
+    .request.authenticated == true and
+    .publisher_exit == 1 and
+    .completion_kind == "retryable_failure" and
+    .failure_kind == "github_rate_limit" and
+    .batch_kind == "retryable_failure" and
+    .cleanup_deletes == 0
+  ))
+' "$summary" >/dev/null
+
+echo CRABBOX_PHASE:full_gate
+pnpm run check
+
+echo CRABBOX_PHASE:receipt
+jq -n \
+  --arg head_sha "$actual_head" \
+  --arg head_tree "$head_tree" \
+  --arg base_sha "$merge_base" \
+  --arg node_version "$(node --version)" \
+  --arg pnpm_version "$(pnpm --version)" \
+  --slurpfile result "$summary" \
+  '{
+    schema_version: 1,
+    tested_head_sha: $head_sha,
+    tested_head_tree: $head_tree,
+    base_sha: $base_sha,
+    cat_file_cross_check: {
+      head_commit: true,
+      head_tree: true,
+      base_commit: true
+    },
+    runtime: {
+      node: $node_version,
+      pnpm: $pnpm_version,
+      transport: $result[0].transport
+    },
+    quota_fixture: {
+      statuses: [$result[0].results[].http_status],
+      requests: [$result[0].results[].requests],
+      publisher_exits: [$result[0].results[].publisher_exit],
+      completion_kinds: [$result[0].results[].completion_kind],
+      failure_kinds: [$result[0].results[].failure_kind],
+      batch_kinds: [$result[0].results[].batch_kind],
+      cleanup_deletes: [$result[0].results[].cleanup_deletes]
+    },
+    full_gate: {
+      command: "pnpm run check",
+      exit_code: 0
+    },
+    limits: [
+      "The GitHub API was a deterministic Unix-socket loopback fixture with synthetic credentials.",
+      "No production GitHub, Worker, queue, deployment, or workflow state was mutated.",
+      "The receipt commit adds proof metadata only after the tested runtime tree."
+    ]
+  }' > "$output_dir/container-receipt.json"
+
+jq -e '
+  .schema_version == 1 and
+  (.tested_head_sha | test("^[0-9a-f]{40}$")) and
+  (.tested_head_tree | test("^[0-9a-f]{40}$")) and
+  (.base_sha | test("^[0-9a-f]{40}$")) and
+  .cat_file_cross_check == {head_commit:true, head_tree:true, base_commit:true} and
+  .quota_fixture.statuses == [403, 429] and
+  .quota_fixture.requests == [1, 1] and
+  .quota_fixture.publisher_exits == [1, 1] and
+  .quota_fixture.completion_kinds == ["retryable_failure", "retryable_failure"] and
+  .quota_fixture.failure_kinds == ["github_rate_limit", "github_rate_limit"] and
+  .quota_fixture.batch_kinds == ["retryable_failure", "retryable_failure"] and
+  .quota_fixture.cleanup_deletes == [0, 0] and
+  .full_gate.exit_code == 0
+' "$output_dir/container-receipt.json" >/dev/null
+
+cat "$output_dir/container-receipt.json"
+echo "AUTOMERGE_QUOTA_FIXTURE_PROOF_OK head=$actual_head base=$merge_base"

--- a/src/clawsweeper-command-operations.ts
+++ b/src/clawsweeper-command-operations.ts
@@ -599,7 +599,7 @@ export function createCommandOperations(dependencies: CreateCommandOperationsDep
           // returns the interrupted item to the next scheduled window. Failing
           // loudly here only discarded the rest of the scan window.
           runtimeBudget.onYield(
-            `GitHub rate limited until ${error.retryAt}; apply resumes next cycle`,
+            `GitHub rate limited until ${error.retryAt}; credential scope ${error.scope}; reset source ${error.provenance}; apply resumes next cycle`,
           );
           return;
         }

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -229,6 +229,14 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     exactEventPublication: options.exactEventPublication,
     legacyTuplelessReviewLease,
   });
+  const rateLimitYield = exactActions.find(
+    (action) =>
+      action.action === "skipped_runtime_budget" &&
+      /GitHub(?: API)? rate limited until/i.test(action.reason),
+  );
+  if (rateLimitYield) {
+    throw new GitHubRateLimitError(new Error(rateLimitYield.reason));
+  }
   if (options.exactEventPublication && legacyTuplelessReviewLease) {
     console.log(
       `Requeueing ${options.targetRepo}#${options.itemNumber}: legacy exact artifact lacks its durable review lease tuple`,


### PR DESCRIPTION
## What broke

The inherited failure in [automerge e2e run 31791711359](https://github.com/openclaw/clawsweeper/actions/runs/31791711359) is a production classification regression, not a stale request-count fixture.

[PR #1166](https://github.com/openclaw/clawsweeper/pull/1166) correctly changed close-mode quota exhaustion from a thrown error into a clean apply yield. The exact-event apply now records two `skipped_runtime_budget` actions: one for item `42` and one continuation sentinel for item `0`. `publish-event-result` did not recognize that clean-yield proof, threw an untyped error, and converted the intended retry into `permanent_failure/unknown_failure`.

The request-count assertion was already correct. In the red 403 case it expected 1 request and observed 1 request, with 0 DELETEs; the failing assertion was `retryable_failure` expected versus `permanent_failure` actual. The 429 case was unreachable after that first assertion aborted. After the fix, 403 and 429 each observe exactly 1 authenticated GET and 0 DELETEs.

## Fix

The apply yield now preserves the bounded retry deadline plus credential scope and reset provenance. The exact-publication boundary recognizes a rate-limit-backed `skipped_runtime_budget` result and reconstructs the existing `GitHubRateLimitError`, so the established completion path emits `retryable_failure/github_rate_limit` to both workflow outputs and the durable batch result.

No fixture count was changed. `CHANGELOG.md` was intentionally left untouched per the work order.

## Behavior proof

- Claim: an exact-event 403 or 429 quota response remains a durable retryable quota result after the clean apply yield.
- Exercised surface: the production `publish-event-result` CLI and real GitHub CLI HTTP transport over the fixture's owned Unix socket.
- Scenario: HTTP 403 and 429, one issue read each, synthetic credentials, no DELETE request.
- Command/environment: Docker-backed Crabbox `provider=local-container`; committed `docs/proof/fix-automerge-quota-fixture/run-proof.sh` at runtime head `e1b0e27e5fd8045ce65da1fdcdcfc6c145d1e8d0`.
- Observable result: statuses `[403,429]`, requests `[1,1]`, publisher exits `[1,1]`, completion kinds `retryable_failure` twice, failure kinds `github_rate_limit` twice, durable batch kinds `retryable_failure` twice, cleanup deletes `[0,0]`.
- Receipt: `docs/proof/fix-automerge-quota-fixture/container-receipt.json`; lease `cbx_c6ed44beacf2` (`crimson-prawn-01cd`), stopped and absent from the provider list.
- SHA proof: commit, tree, and merge base were resolved programmatically and cross-checked with `git cat-file`; static `jq` validated the receipt.
- Limits: deterministic loopback GitHub traffic only; no production GitHub, Worker, queue, deployment, or workflow state was mutated.

OpenClaw Bay is unaffected because this restores an internal exact-publication failure classification; no lifecycle, queue, status, telemetry, dashboard, or public observer contract changes.

## Validation

- Focused apply/publication tests: 50 passed, 0 failed.
- Quota E2E: 403 and 429 green with the counts above.
- `pnpm run check`: 3,463 tests; 3,455 passed, 8 skipped, 0 failed.
- Pre-commit Codex autoreview: clean, no accepted/actionable findings.
- Committed branch Codex autoreview against `origin/main`: clean, no accepted/actionable findings.

Proof is sufficient for the claimed loopback publication behavior. No review finding is unresolved.
