### PR TITLE
fix(bay): correlate direct re-review completions

### DIFF
--- a/dashboard/exact-review-command-intake.ts
+++ b/dashboard/exact-review-command-intake.ts
@@ -8,6 +8,7 @@ import { exactReviewBaseDecisionFrom } from "./exact-review-decision.ts";
 const COMMAND_INTAKE_TABLE = "exact_review_command_intakes";
 const COMMAND_WATERMARK_TABLE = "exact_review_command_watermarks";
 const COMMAND_RECEIPT_TABLE = "exact_review_command_receipts";
+const COMMAND_BAY_JOURNEY_TABLE = "exact_review_command_bay_journeys";
 const ITEM_REVISION_TABLE = "exact_review_item_revisions";
 const COMMAND_INTAKE_LIMIT = 16;
 const COMMAND_RETRY_BASE_MS = 15_000;
@@ -36,6 +37,7 @@ export type ExactReviewCommandAdmission =
       accepted: true;
       deduped: boolean;
       commandVersionId: string;
+      bayJourneyDeliveryId?: string;
     }
   | {
       accepted: false;
@@ -86,6 +88,12 @@ export class ExactReviewCommandIntakeStore {
          ON ${COMMAND_RECEIPT_TABLE} (outcome, observed_at, command_version_id)`,
     );
     this.storage.sql.exec(
+      `CREATE TABLE IF NOT EXISTS ${COMMAND_BAY_JOURNEY_TABLE} (
+         command_version_id TEXT PRIMARY KEY,
+         bay_journey_delivery_id TEXT NOT NULL
+       ) STRICT`,
+    );
+    this.storage.sql.exec(
       `CREATE TABLE IF NOT EXISTS ${ITEM_REVISION_TABLE} (
          item_key TEXT PRIMARY KEY,
          last_revision INTEGER NOT NULL CHECK (last_revision >= 0)
@@ -101,7 +109,11 @@ export class ExactReviewCommandIntakeStore {
     return this.storage.transactionSync(() => {
       const receipt = firstRow(
         this.storage.sql.exec(
-          `SELECT outcome, detail FROM ${COMMAND_RECEIPT_TABLE} WHERE command_version_id = ?`,
+          `SELECT receipt.outcome, receipt.detail, journey.bay_journey_delivery_id
+             FROM ${COMMAND_RECEIPT_TABLE} receipt
+             LEFT JOIN ${COMMAND_BAY_JOURNEY_TABLE} journey
+               ON journey.command_version_id = receipt.command_version_id
+            WHERE receipt.command_version_id = ?`,
           intake.commandVersionId,
         ),
       );
@@ -118,6 +130,9 @@ export class ExactReviewCommandIntakeStore {
           accepted: true,
           deduped: true,
           commandVersionId: intake.commandVersionId,
+          ...(typeof receipt.bay_journey_delivery_id === "string"
+            ? { bayJourneyDeliveryId: receipt.bay_journey_delivery_id }
+            : {}),
         };
       }
 
@@ -196,6 +211,15 @@ export class ExactReviewCommandIntakeStore {
         sourceCommentKey,
         now,
       );
+      if (intake.decision.bayJourneyDeliveryId) {
+        this.storage.sql.exec(
+          `INSERT INTO ${COMMAND_BAY_JOURNEY_TABLE}
+             (command_version_id, bay_journey_delivery_id)
+           VALUES (?, ?)`,
+          intake.commandVersionId,
+          intake.decision.bayJourneyDeliveryId,
+        );
+      }
       this.storage.sql.exec(
         `INSERT INTO ${COMMAND_INTAKE_TABLE}
            (command_version_id, source_comment_key, source_updated_at, record_json, next_attempt_at)
@@ -206,7 +230,14 @@ export class ExactReviewCommandIntakeStore {
         JSON.stringify(record),
         now,
       );
-      return { accepted: true, deduped: false, commandVersionId: intake.commandVersionId };
+      return {
+        accepted: true,
+        deduped: false,
+        commandVersionId: intake.commandVersionId,
+        ...(intake.decision.bayJourneyDeliveryId
+          ? { bayJourneyDeliveryId: intake.decision.bayJourneyDeliveryId }
+          : {}),
+      };
     });
   }
 
@@ -394,6 +425,10 @@ export class ExactReviewCommandIntakeStore {
       `DELETE FROM ${COMMAND_RECEIPT_TABLE}
         WHERE outcome != 'pending' AND observed_at <= ?`,
       now - EXACT_REVIEW_COMMAND_RECEIPT_RETENTION_MS,
+    );
+    this.storage.sql.exec(
+      `DELETE FROM ${COMMAND_BAY_JOURNEY_TABLE}
+        WHERE command_version_id NOT IN (SELECT command_version_id FROM ${COMMAND_RECEIPT_TABLE})`,
     );
   }
 

--- a/dashboard/exact-review-decision.ts
+++ b/dashboard/exact-review-decision.ts
@@ -41,6 +41,7 @@ export type ExactReviewBaseDecision = {
   sourceAuthoritySeq?: number;
   sourceUpdatedAt?: string;
   sourceDeliveryId?: string;
+  bayJourneyDeliveryId?: string;
   codexTimeoutMs?: number;
   mediaProofTimeoutMs?: number;
   commandStatusMarker?: string;
@@ -325,6 +326,8 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
     : undefined;
   const hasSourceDeliveryId = Object.hasOwn(decision, "sourceDeliveryId");
   const sourceDeliveryId = hasSourceDeliveryId ? decision.sourceDeliveryId : undefined;
+  const hasBayJourneyDeliveryId = Object.hasOwn(decision, "bayJourneyDeliveryId");
+  const bayJourneyDeliveryId = hasBayJourneyDeliveryId ? decision.bayJourneyDeliveryId : undefined;
   const hasCommandStatusMarker = Object.hasOwn(decision, "commandStatusMarker");
   const commandStatusMarker = hasCommandStatusMarker ? decision.commandStatusMarker : undefined;
   const hasStatusCommentId = Object.hasOwn(decision, "statusCommentId");
@@ -369,6 +372,13 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
   if (
     hasSourceDeliveryId &&
     (typeof sourceDeliveryId !== "string" || !/^[A-Za-z0-9_.:-]{1,200}$/.test(sourceDeliveryId))
+  ) {
+    return null;
+  }
+  if (
+    hasBayJourneyDeliveryId &&
+    (typeof bayJourneyDeliveryId !== "string" ||
+      !/^[A-Za-z0-9_.:-]{1,200}$/.test(bayJourneyDeliveryId))
   ) {
     return null;
   }
@@ -438,6 +448,7 @@ export function exactReviewBaseDecisionFrom(value: unknown): ExactReviewBaseDeci
     ...(sourceAuthoritySeq === undefined ? {} : { sourceAuthoritySeq }),
     ...(sourceUpdatedAt === undefined ? {} : { sourceUpdatedAt }),
     ...(typeof sourceDeliveryId === "string" ? { sourceDeliveryId } : {}),
+    ...(typeof bayJourneyDeliveryId === "string" ? { bayJourneyDeliveryId } : {}),
     ...(Number.isFinite(Number(decision.codexTimeoutMs))
       ? { codexTimeoutMs: Number(decision.codexTimeoutMs) }
       : {}),

--- a/dashboard/exact-review-lifecycle.ts
+++ b/dashboard/exact-review-lifecycle.ts
@@ -173,6 +173,7 @@ export type ExactReviewLifecycleProjection = {
   admission: {
     deliveryId: string;
     sourceDeliveryId?: string;
+    bayJourneyDeliveryId?: string;
     sourceAction: string;
     commandOriginated: boolean;
     statusMarker: string | null;
@@ -231,6 +232,7 @@ type ProjectionIdentity = {
 type LifecycleAdmissionInput = ProjectionIdentity & {
   deliveryId: string;
   sourceDeliveryId?: string;
+  bayJourneyDeliveryId?: string;
   sourceAction: string;
   commandOriginated: boolean;
   statusMarker: string | null;
@@ -283,6 +285,12 @@ export class ExactReviewLifecycleProjectionStore {
     if (input.sourceDeliveryId !== undefined && !validText(input.sourceDeliveryId, 1, 200)) {
       throw new Error("invalid lifecycle source delivery identity");
     }
+    if (
+      input.bayJourneyDeliveryId !== undefined &&
+      !validText(input.bayJourneyDeliveryId, 1, 200)
+    ) {
+      throw new Error("invalid lifecycle Bay journey delivery identity");
+    }
     if (input.statusMarker !== null && !validText(input.statusMarker, 1, 300)) {
       throw new Error("invalid lifecycle status marker");
     }
@@ -297,6 +305,7 @@ export class ExactReviewLifecycleProjectionStore {
       if (
         admission.deliveryId !== input.deliveryId ||
         admission.sourceDeliveryId !== input.sourceDeliveryId ||
+        admission.bayJourneyDeliveryId !== input.bayJourneyDeliveryId ||
         admission.sourceAction !== input.sourceAction ||
         admission.commandOriginated !== input.commandOriginated ||
         admission.statusMarker !== input.statusMarker ||
@@ -314,6 +323,7 @@ export class ExactReviewLifecycleProjectionStore {
       admission: {
         deliveryId: input.deliveryId,
         ...(input.sourceDeliveryId ? { sourceDeliveryId: input.sourceDeliveryId } : {}),
+        ...(input.bayJourneyDeliveryId ? { bayJourneyDeliveryId: input.bayJourneyDeliveryId } : {}),
         sourceAction: input.sourceAction,
         commandOriginated: input.commandOriginated,
         statusMarker: input.statusMarker,
@@ -1557,6 +1567,8 @@ function validDurableLifecycleBayProjection(value: ExactReviewLifecycleProjectio
     !validText(value.admission.deliveryId, 1, 300) ||
     (value.admission.sourceDeliveryId !== undefined &&
       !validText(value.admission.sourceDeliveryId, 1, 200)) ||
+    (value.admission.bayJourneyDeliveryId !== undefined &&
+      !validText(value.admission.bayJourneyDeliveryId, 1, 200)) ||
     !validText(value.admission.sourceAction, 1, 200) ||
     (value.admission.statusMarker !== null && !validText(value.admission.statusMarker, 1, 300)) ||
     (value.admission.statusCommentId !== null &&

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -840,6 +840,9 @@ export class ExactReviewQueue {
           accepted: admitted.accepted,
           ...(admitted.accepted ? { deduped: admitted.deduped } : { reason: admitted.reason }),
           command_version_id: admitted.commandVersionId,
+          ...(admitted.accepted && admitted.bayJourneyDeliveryId
+            ? { bay_journey_delivery_id: admitted.bayJourneyDeliveryId }
+            : {}),
         },
         202,
       );
@@ -6749,6 +6752,9 @@ export class ExactReviewQueue {
       ...(commandDecision.sourceDeliveryId
         ? { sourceDeliveryId: commandDecision.sourceDeliveryId }
         : {}),
+      ...(commandDecision.bayJourneyDeliveryId
+        ? { bayJourneyDeliveryId: commandDecision.bayJourneyDeliveryId }
+        : {}),
       observedAt: now,
     });
   }
@@ -7652,6 +7658,10 @@ export class ExactReviewQueue {
         ...((fenceKey !== undefined || includeDeliveryIdentity === true) &&
         result.projection?.admission.sourceDeliveryId
           ? { source_delivery_id: result.projection.admission.sourceDeliveryId }
+          : {}),
+        ...((fenceKey !== undefined || includeDeliveryIdentity === true) &&
+        result.projection?.admission.bayJourneyDeliveryId
+          ? { bay_journey_delivery_id: result.projection.admission.bayJourneyDeliveryId }
           : {}),
       });
     } catch (error) {

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1694,8 +1694,12 @@ async function githubWebhook(request, env, ctx) {
       ctx,
       [],
       [
-        acknowledgement.sourceDeliveryId
-          ? { ...completion, source_delivery_id: acknowledgement.sourceDeliveryId }
+        acknowledgement.bayJourneyDeliveryId || acknowledgement.sourceDeliveryId
+          ? {
+              ...completion,
+              source_delivery_id:
+                acknowledgement.bayJourneyDeliveryId ?? acknowledgement.sourceDeliveryId,
+            }
           : completion,
       ],
     );
@@ -1820,7 +1824,6 @@ async function githubWebhook(request, env, ctx) {
     payload,
     deliveryId: deliveryHeaders.deliveryId,
   });
-  if (trigger) await recordBayJourneyTelemetry(env, ctx, [trigger], []);
 
   const commentDecision = decision;
   if (
@@ -1839,6 +1842,7 @@ async function githubWebhook(request, env, ctx) {
       sourceCommentUpdatedAt: commentDecision.commentUpdatedAt,
       commandBodyDigest: await sha256Text(commentDecision.commentBody),
       commandOrigin: "hosted_webhook",
+      ...(trigger?.source_delivery_id ? { bayJourneyDeliveryId: trigger.source_delivery_id } : {}),
       additionalPrompt: directReReviewAdditionalPrompt({
         body: commentDecision.commentBody,
         maintainerAuthorized: commentDecision.maintainerAuthorized,
@@ -1848,14 +1852,32 @@ async function githubWebhook(request, env, ctx) {
     });
     const queue = exactReviewQueueStub(env);
     if (!queue) return json({ error: "exact_review_queue_not_configured" }, 503);
-    return queue.fetch(
+    const intakeResponse = await queue.fetch(
       new Request("https://clawsweeper-exact-review-queue/command-intake", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(intake),
       }),
     );
+    const intakeResult = objectValue(
+      await intakeResponse
+        .clone()
+        .json()
+        .catch(() => null),
+    );
+    const bayJourneyDeliveryId = nullableString(intakeResult.bay_journey_delivery_id);
+    if (trigger && intakeResult.accepted === true && bayJourneyDeliveryId) {
+      await recordBayJourneyTelemetry(
+        env,
+        ctx,
+        [{ ...trigger, source_delivery_id: bayJourneyDeliveryId }],
+        [],
+      );
+    }
+    return intakeResponse;
   }
+
+  if (trigger) await recordBayJourneyTelemetry(env, ctx, [trigger], []);
 
   const credentials = githubAppCredentials(env);
   if (!credentials) return json({ error: "github_app_not_configured" }, 503);
@@ -2663,7 +2685,7 @@ function exactReviewQueueStub(env): DurableObjectStub | null {
 
 async function recordLifecycleCommandAcknowledgement(env, completion) {
   const queue = exactReviewQueueStub(env);
-  if (!queue) return { accepted: true, sourceDeliveryId: null };
+  if (!queue) return { accepted: true, sourceDeliveryId: null, bayJourneyDeliveryId: null };
   const observedAt = Date.parse(String(completion.completed_at || ""));
   const response = await queue.fetch(
     new Request("https://clawsweeper-exact-review-queue/lifecycle/command-ack/observed", {
@@ -2685,6 +2707,7 @@ async function recordLifecycleCommandAcknowledgement(env, completion) {
   return {
     accepted: result.accepted !== false,
     sourceDeliveryId: nullableString(result.source_delivery_id),
+    bayJourneyDeliveryId: nullableString(result.bay_journey_delivery_id),
   };
 }
 
@@ -3065,8 +3088,13 @@ async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
               repository: target[1],
               number: Number(target[2]),
               source_comment_id: Number(receipt.command_comment_id),
-              ...(nullableString(result.source_delivery_id)
-                ? { source_delivery_id: nullableString(result.source_delivery_id) }
+              ...(nullableString(result.bay_journey_delivery_id) ||
+              nullableString(result.source_delivery_id)
+                ? {
+                    source_delivery_id:
+                      nullableString(result.bay_journey_delivery_id) ??
+                      nullableString(result.source_delivery_id),
+                  }
                 : {}),
               completed_at: completedAt,
               completion_kind: "final_command_status",

--- a/src/repair/direct-re-review-admission.ts
+++ b/src/repair/direct-re-review-admission.ts
@@ -9,6 +9,7 @@ export type DirectReReviewDecision = {
   sourceAction: "re_review";
   supersedesInProgress: false;
   sourceDeliveryId: string;
+  bayJourneyDeliveryId?: string;
   sourceCommentId: number;
   sourceCommentUpdatedAt: string;
   commandBodyDigest: string;
@@ -68,6 +69,7 @@ export function directReReviewIntake(options: {
   additionalPrompt: string;
   statusCommentId?: number;
   candidateHeadSha?: string;
+  bayJourneyDeliveryId?: string;
 }): DirectReReviewIntake {
   const commandVersionId = reReviewCommandVersionIdentity({
     commentId: options.sourceCommentId,
@@ -86,6 +88,7 @@ export function directReReviewIntake(options: {
     sourceAction: "re_review",
     supersedesInProgress: false,
     sourceDeliveryId: commandVersionId,
+    ...(options.bayJourneyDeliveryId ? { bayJourneyDeliveryId: options.bayJourneyDeliveryId } : {}),
     sourceCommentId: options.sourceCommentId,
     sourceCommentUpdatedAt: options.sourceCommentUpdatedAt,
     commandBodyDigest: options.commandBodyDigest,
@@ -129,6 +132,9 @@ export function validateDirectReReviewIntake(value: unknown): DirectReReviewInta
         bodySha256: String(intake.commandBodyDigest),
       }) ||
     decision.sourceDeliveryId !== intake.commandVersionId ||
+    (decision.bayJourneyDeliveryId !== undefined &&
+      (typeof decision.bayJourneyDeliveryId !== "string" ||
+        !/^[A-Za-z0-9_.:-]{1,200}$/.test(decision.bayJourneyDeliveryId))) ||
     decision.sourceCommentId !== intake.sourceCommentId ||
     decision.sourceCommentUpdatedAt !== intake.sourceCommentUpdatedAt ||
     decision.commandBodyDigest !== intake.commandBodyDigest ||

--- a/test/dashboard-worker-command-intake.test.ts
+++ b/test/dashboard-worker-command-intake.test.ts
@@ -7,9 +7,12 @@ import { directReReviewIntake } from "../src/repair/direct-re-review-admission.t
 import {
   assert,
   ExactReviewQueue,
+  ExactReviewLifecycleProjectionStore,
+  MemoryKv,
   MemoryDurableNamespace,
   MemoryDurableStorage,
   test,
+  summarizeBayJourneyTimings,
   worker,
 } from "./dashboard-worker-harness.ts";
 
@@ -159,6 +162,7 @@ test("durable command intake survives target throttling before queue admission",
     accepted: true,
     deduped: false,
     command_version_id: commandVersionId(),
+    bay_journey_delivery_id: "delivery-command-1",
   });
   assert.equal(fixture.acknowledgements.length, 0);
 
@@ -227,6 +231,238 @@ test("durable command intake survives target throttling before queue admission",
   assert.equal(redelivery.status, 202);
   assert.equal((await redelivery.json()).deduped, true);
   assert.equal(fixture.acknowledgements.length, 1);
+});
+
+test("hosted durable command intake keeps the GitHub delivery identity for Bay journey completion", async (t) => {
+  const fixture = await startGithubLoopback();
+  t.after(() => fixture.close());
+  const storage = new MemoryDurableStorage();
+  const statusStore = new MemoryKv();
+  const lifecycle = new ExactReviewLifecycleProjectionStore(storage);
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const env = {
+    GITHUB_API_URL: fixture.origin,
+    CLAWSWEEPER_WEBHOOK_SECRET: "bay-journey-command-intake-test-secret",
+    CLAWSWEEPER_APP_CLIENT_ID: "Iv23bay-journey-command-intake-test",
+    CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+    EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0",
+    STATUS_STORE: statusStore,
+  };
+  const queue = new ExactReviewQueue({ storage }, env);
+  const namespace = new MemoryDurableNamespace(queue);
+  const payload = commandWebhookPayload();
+  const commandAt = new Date(Date.now() - 120_000).toISOString();
+  payload.comment.created_at = commandAt;
+  payload.comment.updated_at = commandAt;
+  const body = JSON.stringify(payload);
+  const signature = `sha256=${createHmac("sha256", env.CLAWSWEEPER_WEBHOOK_SECRET)
+    .update(body)
+    .digest("hex")}`;
+  const commandDeliveryId = "github-command-delivery-1";
+  const { STATUS_STORE: _statusStore, ...envWithoutStatusStore } = env;
+
+  const accepted = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/github/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issue_comment",
+        "x-github-delivery": commandDeliveryId,
+        "x-hub-signature-256": signature,
+      },
+      body,
+    }),
+    { ...envWithoutStatusStore, EXACT_REVIEW_QUEUE: namespace },
+    {},
+  );
+  assert.equal(accepted.status, 202);
+  const redelivery = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/github/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issue_comment",
+        "x-github-delivery": "github-command-delivery-1-redelivery",
+        "x-hub-signature-256": signature,
+      },
+      body,
+    }),
+    { ...env, EXACT_REVIEW_QUEUE: namespace },
+    {},
+  );
+  assert.equal(redelivery.status, 202);
+  const redeliveryResult = await redelivery.json();
+  assert.equal(redeliveryResult.deduped, true);
+  assert.equal(redeliveryResult.bay_journey_delivery_id, commandDeliveryId);
+  const stateAfterRedelivery = JSON.parse(
+    (await statusStore.get("openclaw-bay:journey-state:v1")) || "{}",
+  );
+  assert.equal(stateAfterRedelivery.journeys.length, 1);
+  assert.equal(stateAfterRedelivery.journeys[0]?.source_delivery_id, commandDeliveryId);
+  const intake = directReReviewIntake({
+    targetRepo: "openclaw/openclaw",
+    targetBranch: "main",
+    itemNumber: ITEM_NUMBER,
+    itemKind: "pull_request",
+    installationId: 123,
+    sourceCommentId: COMMAND_COMMENT_ID,
+    sourceCommentUpdatedAt: commandAt,
+    commandBodyDigest: createHash("sha256").update(COMMAND_BODY).digest("hex"),
+    commandOrigin: "hosted_webhook",
+    additionalPrompt: "",
+    bayJourneyDeliveryId: commandDeliveryId,
+  });
+  assert.equal(
+    new ExactReviewCommandIntakeStore(storage).read(intake.commandVersionId)?.intake.decision
+      .bayJourneyDeliveryId,
+    commandDeliveryId,
+  );
+
+  fixture.sourceCommentUpdatedAt = commandAt;
+  await queue.alarm();
+  await queue.alarm();
+  const queueState = (await storage.get("exact-review-queue")) as {
+    items: Record<string, { key: string; revision: number }>;
+  };
+  const item = queueState.items[`openclaw/openclaw#${ITEM_NUMBER}`];
+  assert.ok(item);
+  const identity = {
+    canonicalTargetKey: `openclaw/openclaw#${ITEM_NUMBER}`,
+    fenceKey: item.key,
+    revision: item.revision,
+  };
+  const projection = lifecycle.read(
+    identity.canonicalTargetKey,
+    identity.fenceKey,
+    identity.revision,
+  );
+  assert.equal(projection?.admission.bayJourneyDeliveryId, commandDeliveryId);
+  const completionCommentId = 90_002;
+  lifecycle.recordCanonicalReceipt({
+    ...identity,
+    outcome: "accepted",
+    receiptId: "canonical:fixture",
+    observedAt: Date.parse(commandAt) + 1,
+  });
+  lifecycle.recordRouterReceipt({
+    ...identity,
+    outcome: "durable",
+    receiptId: "router:fixture",
+    observedAt: Date.parse(commandAt) + 2,
+  });
+  lifecycle.recordTerminalDisposition({
+    ...identity,
+    kind: "review_completed_routed",
+    observedAt: Date.parse(commandAt) + 3,
+  });
+  const authorized = lifecycle.authorizeCommandAcknowledgement({
+    ...identity,
+    statusMarker: intake.decision.commandStatusMarker,
+    statusCommentId: projection?.admission.statusCommentId ?? null,
+    observedAt: Date.parse(commandAt) + 4,
+  });
+  assert.equal(authorized.allowed, true);
+
+  const completedAt = new Date(Date.now() - 60_000).toISOString();
+  const acknowledgementBody = JSON.stringify({
+    canonical_target_key: identity.canonicalTargetKey,
+    fence_key: identity.fenceKey,
+    revision: identity.revision,
+    status_marker: intake.decision.commandStatusMarker,
+    ...(projection?.admission.statusCommentId
+      ? { status_comment_id: projection.admission.statusCommentId }
+      : {}),
+    command_comment_id: COMMAND_COMMENT_ID,
+    completion_comment_id: completionCommentId,
+    completed_at: completedAt,
+    observed_at: Date.now(),
+  });
+  const acknowledgementSignature = `sha256=${createHmac("sha256", env.CLAWSWEEPER_WEBHOOK_SECRET)
+    .update(acknowledgementBody)
+    .digest("hex")}`;
+  const acknowledgement = await worker.fetch(
+    new Request(
+      "https://clawsweeper.openclaw.ai/internal/exact-review/lifecycle/command-ack/observed",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-clawsweeper-exact-review-signature": acknowledgementSignature,
+        },
+        body: acknowledgementBody,
+      },
+    ),
+    { ...env, EXACT_REVIEW_QUEUE: namespace },
+    {},
+  );
+  assert.equal(acknowledgement.status, 200);
+  assert.equal((await acknowledgement.json()).bay_journey_delivery_id, commandDeliveryId);
+  const stateAfterAcknowledgement = JSON.parse(
+    (await statusStore.get("openclaw-bay:journey-state:v1")) || "{}",
+  );
+  assert.equal(stateAfterAcknowledgement.journeys.length, 1);
+  assert.equal(stateAfterAcknowledgement.journeys[0]?.source_delivery_id, commandDeliveryId);
+  assert.equal(
+    summarizeBayJourneyTimings(stateAfterAcknowledgement.journeys, new Date().toISOString()).overall
+      .samples,
+    1,
+  );
+
+  const completionBody = JSON.stringify({
+    action: "edited",
+    repository: payload.repository,
+    issue: payload.issue,
+    comment: {
+      id: completionCommentId,
+      body: [
+        `<!-- clawsweeper-command-ack:${COMMAND_COMMENT_ID} -->`,
+        intake.decision.commandStatusMarker,
+        "<!-- clawsweeper-command-progress:start -->",
+        "- State: Complete",
+        "<!-- clawsweeper-command-progress:end -->",
+      ].join("\n"),
+      created_at: completedAt,
+      updated_at: completedAt,
+      user: { login: "clawsweeper[bot]" },
+    },
+  });
+  const completionSignature = `sha256=${createHmac("sha256", env.CLAWSWEEPER_WEBHOOK_SECRET)
+    .update(completionBody)
+    .digest("hex")}`;
+  const completion = await worker.fetch(
+    new Request("https://clawsweeper.openclaw.ai/github/webhook", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issue_comment",
+        "x-github-delivery": "github-completion-delivery-1",
+        "x-hub-signature-256": completionSignature,
+      },
+      body: completionBody,
+    }),
+    { ...env, EXACT_REVIEW_QUEUE: namespace },
+    {},
+  );
+  assert.equal(completion.status, 202);
+  assert.deepEqual(await completion.json(), {
+    ok: true,
+    accepted: false,
+    reason: "recorded Bay journey completion",
+  });
+
+  const state = JSON.parse((await statusStore.get("openclaw-bay:journey-state:v1")) || "{}");
+  assert.equal(state.journeys.length, 1);
+  assert.equal(state.journeys[0]?.source_delivery_id, commandDeliveryId);
+  assert.ok(state.journeys[0]?.triggered_at);
+  assert.ok(state.journeys[0]?.completed_at);
+  assert.equal(
+    summarizeBayJourneyTimings(state.journeys, new Date().toISOString()).overall.samples,
+    1,
+  );
 });
 
 test("command acknowledgement ignores forged markers and paginates to the trusted receipt", async (t) => {
@@ -372,6 +608,7 @@ async function startGithubLoopback() {
     durableIntakes: 0,
     throttleSourceComment: false,
     sourceCommentReads: 0,
+    sourceCommentUpdatedAt: COMMAND_UPDATED_AT,
     reactions: 0,
   };
   const server = http.createServer(async (request, response) => {
@@ -391,7 +628,7 @@ async function startGithubLoopback() {
       return sendJson(response, 200, {
         id: COMMAND_COMMENT_ID,
         body: COMMAND_BODY,
-        updated_at: COMMAND_UPDATED_AT,
+        updated_at: state.sourceCommentUpdatedAt,
         issue_url: `https://api.github.com/repos/openclaw/openclaw/issues/${ITEM_NUMBER}`,
       });
     }


### PR DESCRIPTION
## Summary

Restores OpenClaw Bay completed-journey correlation for hosted direct `@clawsweeper re-review` commands without undoing PR #1143's command-version fencing.

## Problem

PR #1143 deliberately changed direct re-review `sourceDeliveryId` from the GitHub webhook delivery (`G`) to a deterministic command-version identity (`C`). Bay records the trigger under `G`, but lifecycle acknowledgement emitted the completion under `C`; Bay therefore created separate partial records and the tide summary had zero completed samples.

## Implementation

- Preserve the original signed GitHub delivery ID as the additive `bayJourneyDeliveryId` alongside #1143's command-version `sourceDeliveryId`.
- Persist and validate it through direct command intake and the durable lifecycle projection.
- Retain that identity in a small command-version keyed durable table, so a redelivery can retry Bay telemetry with the original `G` if the first Bay write was unavailable.
- Return it from fenced lifecycle acknowledgement receipts.
- Prefer it for both the GitHub-terminal-webhook and signed workflow-acknowledgement Bay completion paths, falling back to the existing identity for older projections.

This is additive durable state. Existing projections without the field remain valid and use legacy behaviour; no migration or cache invalidation is required. Historical partial journeys cannot be deterministically repaired by this code alone, but new completions after deployment join their live triggers.

## Validation

- `pnpm run build:all`
- `pnpm run lint:dashboard`
- `node --test --test-concurrency=1 test/dashboard-worker-command-intake.test.ts test/dashboard-worker-bay-records-routes.test.ts` — 46 passed, 0 failed.
- `git diff --check`
- Codex dirty-patch review: clean, no actionable findings.
- Codex committed-range review against `origin/main` (`9fb6d6bfe562611ba5c40e60521ba4a726bac926`): clean, no actionable findings.
- Read-only local ClawSweeper committed-range review: completed with no actionable code finding (`decision=keep_open`, `action=kept_open`).
- Hosted ClawSweeper re-review on exact head `c272176e9bdc85ff1d36648c218c31c6afd54773`: no actionable findings; `proof: sufficient` and `status: 👀 ready for maintainer look` applied.
- Hosted CI `pnpm check`, both CodeQL analyses, and the hermetic automerge-flow test: successful.

`pnpm run check` is blocked by the existing repository formatting baseline: `oxfmt --check` reports 719 unrelated files. The touched files were formatted and the focused build/tests pass.

## Real Behavior Proof

Claim: A signed hosted direct re-review retains its raw GitHub delivery identity through durable intake and lifecycle acknowledgement, allowing Bay to produce one completed in-window journey even when only the normal workflow acknowledgement arrives.

Exercised surface: Worker GitHub webhook, direct intake, actual in-memory Durable Object queue admission/alarm, lifecycle projection, signed internal lifecycle acknowledgement endpoint, and Bay journey state.

Scenario: The regression test sends a real HMAC-signed command webhook with delivery `G` while Bay storage is unavailable. Its GitHub redelivery is command-deduplicated but returns the durable original `G`, allowing Bay telemetry to recover exactly one journey. It then drives the queue alarm, records terminal lifecycle facts, and sends the signed workflow acknowledgement without relying on a terminal GitHub webhook. The endpoint returns `bay_journey_delivery_id=G`; Bay contains exactly one joined journey and one timing sample. A subsequent terminal webhook remains idempotent.

Command/environment: the focused Node test command above on this checkout at `c272176e9b`.

Direct-Docker runtime proof: coordinator-authorized fallback after CRA-001 Crabbox transport failure. At exact head `c272176e9bdc85ff1d36648c218c31c6afd54773` / tree `94b50bdd94a30c5d88222cc6230c83006ea56259`, a clean read-only source mount was copied into disposable container `clawsweeper-proof:node24-jq@sha256:b9ddc0c04722a87ff36948964d93942a316689de01063798032328772a36aeee`. The container ran `wrangler@4.107.0 dev --local` against the current Worker with fresh persisted local SQLite Durable Objects. A redacted loopback GitHub server supplied only fixture data; the proof exercised actual HTTP Worker routes and the DO alarm rather than the in-memory test harness. The redelivery was command-deduplicated and explicitly required to return the original Bay delivery identity. Observed result:

```json
{"proof":"csw130-direct-docker-wrangler-do","command_status":202,"command_accepted":true,"redelivery_status":202,"redelivery_deduped":true,"github_delivery_id":"csw130-direct-docker-delivery","durable_source_comment_reads":1,"durable_status_comments":1,"lifecycle_acknowledgement_accepted":true,"lifecycle_bay_journey_delivery_id":"csw130-direct-docker-delivery","bay_completed_journey_samples":1,"status_marker_present":true}
```

This proves a real local Worker/DO admission, a deduplicated redelivery retaining `G`, and one joined, in-window Bay timing sample on the current head. Docker Engine was 29.5.2. Crabbox itself remains unavailable for this tree because two local-container attempts (`cbx_ba0806abf103`, `cbx_1307edd2fb1b`) and configured AWS run `run_2dbd1a63208b` / lease `cbx_2794c92c5e43` each failed before execution during rsync handshake with code 12; no Crabbox result is claimed.

## Risks / rollout / rollback

The change only adds optional durable identity and preserves legacy fallback. Roll out normally with the Worker/dashboard deployment, then verify Bay reports a completed sample after the next hosted re-review completes. Existing records are not rewritten; a redelivery can recover a missed trigger during receipt retention. If needed, revert this one commit; no state rollback is needed.

Related: CSW-130; regression introduced by #1143.
