### PR TITLE
Fix canonical Bay redirect smoke

### DIFF
--- a/docs/proof/openclaw-bay/README.md
+++ b/docs/proof/openclaw-bay/README.md
@@ -136,5 +136,5 @@ private payloads.
 
 This is deterministic interaction proof, not a claim that synthetic state is
 live operational evidence. The separate deployment smoke covers the canonical
-`/bay` route, the query-preserving legacy redirect, response headers, shared
+`/bay` route, the query-stripping legacy redirect, response headers, shared
 schema, and static assets.

--- a/scripts/dashboard-smoke.mjs
+++ b/scripts/dashboard-smoke.mjs
@@ -107,11 +107,8 @@ async function main() {
   const legacyBay = await fetch(`${baseUrl}/bay-demo?repo=openclaw%2Fopenclaw&q=proof`, {
     redirect: "manual",
   });
-  if (
-    legacyBay.status !== 308 ||
-    legacyBay.headers.get("location") !== `${baseUrl}/bay?repo=openclaw%2Fopenclaw&q=proof`
-  ) {
-    throw new Error("legacy Bay route did not preserve its query in a permanent redirect");
+  if (!isCanonicalLegacyBayRedirect(legacyBay, baseUrl)) {
+    throw new Error("legacy Bay route did not strip its query in a permanent redirect");
   }
 
   const bayAssets = {};
@@ -214,6 +211,10 @@ async function fetchText(url) {
 
 export function containsDirectGitHubApiUrl(html) {
   return /(?:^|[^a-z0-9.-])api\.github\.com\.?(?=$|[^a-z0-9.-])/iu.test(html);
+}
+
+export function isCanonicalLegacyBayRedirect(response, baseUrl) {
+  return response.status === 308 && response.headers.get("location") === `${baseUrl}/bay`;
 }
 
 function positiveInteger(value, fallback) {

--- a/test/dashboard-smoke.test.ts
+++ b/test/dashboard-smoke.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   containsDirectGitHubApiUrl,
+  isCanonicalLegacyBayRedirect,
   waitForDashboardDeployment,
 } from "../scripts/dashboard-smoke.mjs";
 
@@ -46,6 +47,28 @@ test("dashboard smoke requires Bay's public indexability and overview navigation
   assert.match(source, /public: true/);
   assert.match(source, /indexable: true/);
   assert.doesNotMatch(source, /unlisted: true/);
+});
+
+test("dashboard smoke requires the legacy Bay redirect to strip query data", () => {
+  const baseUrl = "https://clawsweeper.example";
+
+  assert.equal(
+    isCanonicalLegacyBayRedirect(
+      new Response(null, { status: 308, headers: { location: `${baseUrl}/bay` } }),
+      baseUrl,
+    ),
+    true,
+  );
+  assert.equal(
+    isCanonicalLegacyBayRedirect(
+      new Response(null, {
+        status: 308,
+        headers: { location: `${baseUrl}/bay?repo=public%2Frepository&q=proof` },
+      }),
+      baseUrl,
+    ),
+    false,
+  );
 });
 
 test("dashboard smoke waits for the exact deployed revision", async () => {


### PR DESCRIPTION
## Summary

Align the live dashboard smoke test with the canonical privacy-preserving Bay
redirect that landed in #1180. A request to the legacy Bay route may contain a
query, but its permanent redirect must point to the queryless `/bay` route.

## Problem

The Worker correctly deployed #1180 and stripped the legacy query. The automatic
dashboard smoke still expected the older query-preserving redirect, so the
deployment run failed after the Worker deployment and all earlier live checks
had succeeded.

Failed deployment-smoke evidence:
https://github.com/openclaw/clawsweeper/actions/runs/32004437979

## Implementation

- centralize the canonical legacy redirect assertion in a small exported smoke
  helper;
- require status 308 and an exact queryless `/bay` location;
- add a regression that accepts the canonical redirect and rejects the former
  query-preserving location.

No Worker behavior, API response, public data projection, credentials, queue
state, or production configuration changes.

## Validation

- `pnpm run build:all`
- `node --test --test-concurrency=1 test/dashboard-smoke.test.ts test/dashboard-worker-bay-records-routes.test.ts`
  — 52 passed, 0 failed
- `pnpm run check:docs`
- `pnpm exec oxfmt --check scripts/dashboard-smoke.mjs test/dashboard-smoke.test.ts docs/proof/openclaw-bay/README.md`
- `pnpm exec oxlint --deny-warnings scripts/dashboard-smoke.mjs test/dashboard-smoke.test.ts`
- `git diff --check`
- dirty Codex reviews before both commits — no actionable findings
- committed Codex review against `origin/main` at the exact final head — no
  actionable finding; its optional `tsx` probe was unavailable, while the
  repository's actual Node test command and the controlled proof below passed
- local ClawSweeper committed-range review at the exact final head — patch
  correct, confidence 0.95, no code or security finding; its requested real
  smoke evidence is supplied below

## Review finding disposition

- **Accepted:** hosted ClawSweeper identified stale proof wording that still
  described the legacy redirect as query-preserving. The documentation now
  says query-stripping and the exact-head regression rejects the old contract.
- **Resolved by proof:** both hosted and local ClawSweeper requested a
  current-head Docker-backed behavior receipt. The Crabbox local-container
  execution below proves the exact committed files and redirect oracle, while
  the read-only live run proves the complete deployed Worker smoke path.

## Real Behavior Proof

**Claim:** the corrected smoke accepts the deployed canonical query-stripping
redirect while preserving the rest of the dashboard deployment contract.

**Exercised surface:** the exact committed smoke oracle in Crabbox's
Docker-backed local-container provider, plus the committed smoke script against
the live Worker already deployed from squash
`68a6dfcfc5564acddc788a746d9399e44ac00969`.

**Scenario:** send the legacy route a query-bearing read-only request with manual
redirect handling, require an exact queryless `/bay` location, then continue the
existing health, status, queue, Bay HTML, CSP, no-browser-GitHub, and asset checks.

**Command/environment — exact-head controlled proof:** Crabbox provider
`local-container`; lease `cbx_34215d350dc3`; run `run_22f628223302`; image
`mcr.microsoft.com/playwright:v1.60.0-noble` at digest
`sha256:9bd26ad900bb5e0f4dee75839e957a89ae89c2b7ab1e76050e559790e946b948`;
Node 24.15.0; repository hydration disabled; clean raw-workspace sync. The
content-hashed proof script ran the committed redirect tests and direct helper
assertions without production access.

**Command/environment — read-only live proof:**

```powershell
$env:CLAWSWEEPER_EXPECTED_DEPLOY_SHA = '68a6dfcfc5564acddc788a746d9399e44ac00969'
pnpm run dashboard:smoke -- 'https://clawsweeper.openclaw.ai'
```

**Observed result:** Crabbox exit 0 with 6 passed, 0 failed; all three changed
files matched the hashes from the clean committed tree; the queryless redirect
was accepted, the former query-preserving redirect was rejected, and the proof
documentation was current. The disposable lease stopped automatically. The
read-only live smoke also exited 0, matched the expected deployed revision,
accepted the canonical redirect, completed every subsequent live assertion, and
reported zero direct browser-to-GitHub requests.

**Inspectable redacted terminal receipt:**

```text
provider=local-container
lease=cbx_34215d350dc3
run=run_22f628223302
image=mcr.microsoft.com/playwright:v1.60.0-noble
node=v24.15.0
sync_candidate_files=1235
sync_bytes=24.5 MiB
tests=6
pass=6
fail=0
exact_head=true
exact_tree=true
exact_changed_files=true
queryless_redirect_accepted=true
query_preserving_redirect_rejected=true
documentation_current=true
stderr_bytes=0
exit=0
lease_stopped=true
```

The separate read-only live terminal completed the repository's full
`dashboard:smoke` command with the expected deployment revision, canonical
redirect, health/status/queue/Bay/CSP/assets checks, and
`direct_github_requests=0`; exit was 0. No response bodies, credentials, private
repository data, or production mutations are included in this receipt.

**Artifact/trace:** exact patch head
`298b1da03a7bef67a1766c669b8d044430b5c5bc`; tree
`2e999b3b3c66abf40ef1da5c3620fa90c23822c4`. Crabbox proof-script SHA-256
`c6b74ac880428846dfcd9b3676487ef5fe8dc3d21d8e0b6f17b81c7d4eaf2e91`;
stdout SHA-256
`5579adf2149872c491bc8a6d7c1a2dfbb068b75181f562fe190c1568980fed07`;
empty-stderr SHA-256
`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
Final local ClawSweeper artifact SHA-256
`4d37e2d7597d736d39cda8185b993b3989d86d717db250fc58c636997bb9ccc0`.

**Limits:** this is a read-only smoke-oracle correction. It proves behavior
against the already deployed Worker and does not deploy, mutate queues, call a
workflow action, or change production state.

## Risk and rollout

Low risk: three files, no runtime Worker change. The automatic dashboard workflow
will exercise the same smoke after merge. Revert this commit if the oracle causes
an unexpected compatibility issue; reverting #1180 would instead restore the
privacy regression and is not recommended.
