### PR TITLE
fix(live-proof): dispatch from the exact-event lane and enable live tests everywhere

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1433,6 +1433,49 @@ jobs:
           EXACT_REVIEW_BATCH_MUTATION_OUTPUT: .artifacts/direct-publication-outcome.json
         run: pnpm run --silent repair:publish-event-result
 
+      - name: Create live-proof dispatch token
+        id: live-proof-dispatch-token
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.prepare-direct-exact-review-publication.outcome == 'success' }}
+        continue-on-error: true
+        uses: ./.github/actions/create-target-write-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repository: clawsweeper
+
+      - name: Dispatch recommended live proofs
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.prepare-direct-exact-review-publication.outcome == 'success' && steps.live-proof-dispatch-token.outcome == 'success' && steps.live-proof-dispatch-token.outputs.token != '' }}
+        env:
+          GH_TOKEN: ${{ steps.live-proof-dispatch-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+        run: |
+          set -euo pipefail
+          item_numbers="$ITEM_NUMBER"
+          ITEM_NUMBERS="$item_numbers" RECORDS_ROOT=records pnpm run --silent repair:live-proof-candidates > /tmp/live-proof-candidates.jsonl
+          if [ ! -s /tmp/live-proof-candidates.jsonl ]; then
+            echo "No published review requested an enabled live proof."
+            exit 0
+          fi
+          while IFS= read -r candidate; do
+            item="$(jq -r '.item' <<<"$candidate")"
+            plan="$(jq -c '.plan' <<<"$candidate")"
+            jq -n \
+              --arg repo "$TARGET_REPO" \
+              --arg item "$item" \
+              --argjson plan "$plan" \
+              '{
+                event_type: "clawsweeper_live_proof",
+                client_payload: {
+                  repo: $repo,
+                  item: $item,
+                  live_proof_plan: $plan
+                }
+              }' | gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches" --input -
+            echo "Dispatched live proof for $TARGET_REPO#$item."
+          done < /tmp/live-proof-candidates.jsonl
+
       - name: Post direct exact review publication result
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.prepare-direct-exact-review-publication.outcome == 'success' }}
         id: direct-exact-review-publication
@@ -4753,28 +4796,7 @@ jobs:
         run: |
           set -euo pipefail
           item_numbers="$(pnpm run --silent workflow -- artifact-item-numbers --artifact-dir artifacts)"
-          TARGET_REPO="$TARGET_REPO" ITEM_NUMBERS="$item_numbers" node --input-type=module <<'NODE' > /tmp/live-proof-candidates.jsonl
-          import { readFileSync } from "node:fs";
-          import { reportLiveProofPlan } from "./dist/clawsweeper.js";
-          import { repositoryProfileFor } from "./dist/repository-profiles.js";
-
-          const repo = process.env.TARGET_REPO || "";
-          const profile = repositoryProfileFor(repo);
-          if (!profile.liveTest?.enabled) process.exit(0);
-          for (const item of (process.env.ITEM_NUMBERS || "").split(",").filter(Boolean)) {
-            const path = "records/" + profile.slug + "/items/" + item + ".md";
-            let markdown;
-            try {
-              markdown = readFileSync(path, "utf8");
-            } catch {
-              continue;
-            }
-            const plan = reportLiveProofPlan(markdown);
-            if (plan.status === "recommended") {
-              process.stdout.write(JSON.stringify({ item: Number(item), plan }) + "\n");
-            }
-          }
-          NODE
+          ITEM_NUMBERS="$item_numbers" RECORDS_ROOT=records pnpm run --silent repair:live-proof-candidates > /tmp/live-proof-candidates.jsonl
           if [ ! -s /tmp/live-proof-candidates.jsonl ]; then
             echo "No published review requested an enabled live proof."
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Exact-event reviews now dispatch recommended live proofs with host-repository credentials, while generic and configured OpenClaw and steipete profiles opt into browser or terminal proof as appropriate.
 - Hosted webhook 🦞👀 receipts now dedupe per pull request across `opened` and `ready_for_review`, so back-to-back webhook actions keep one receipt instead of posting near-identical duplicates. (#1084)
 - The target dispatcher no longer double-posts pull request receipt acknowledgements when `opened` and `ready_for_review` fire seconds apart: the ack step now waits and rechecks for any existing marker immediately before posting. (#1083)
 - Restored pull request 🦞👀 receipt comments by granting fast-ack tokens `pull_requests: write`. (#1082)

--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -13,7 +13,16 @@
       },
       "package_manager": "bun",
       "validation_commands": ["bun run check"],
-      "changed_gate": null
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "browser",
+        "setup": ["bun install"],
+        "start": "bun run dev",
+        "url": "http://127.0.0.1:3000",
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
     },
     {
       "target_repo": "openclaw/clawsweeper",
@@ -51,7 +60,14 @@
       },
       "package_manager": "pnpm",
       "validation_commands": ["pnpm typecheck", "pnpm test", "pnpm build"],
-      "changed_gate": null
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": ["pnpm install --frozen-lockfile"],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
     },
     {
       "target_repo": "openclaw/fs-safe",
@@ -64,7 +80,14 @@
       },
       "package_manager": "pnpm",
       "validation_commands": [],
-      "changed_gate": null
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": ["pnpm install --frozen-lockfile"],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
     }
   ],
   "generic_fallbacks": [
@@ -79,7 +102,14 @@
       },
       "package_manager": "pnpm",
       "validation_commands": [],
-      "changed_gate": null
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": ["pnpm install --frozen-lockfile"],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
     },
     {
       "owner": "steipete",
@@ -92,7 +122,14 @@
       },
       "package_manager": "pnpm",
       "validation_commands": [],
-      "changed_gate": null
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": ["pnpm install --frozen-lockfile"],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
     }
   ],
   "core_target_overrides": {

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -12,12 +12,14 @@ recording of user-visible browser or terminal behavior. Classification remains
 part of the existing read-only review. It records only a typed plan in the
 durable report; it never executes pull request code and never publishes a URL.
 
-After the report is published, `sweep.yml` dispatches
-`live-proof.yml` only when the plan status is `recommended` and the target's
-repository profile has `live_test.enabled: true`. The command then applies four
-ordered gates: `CLAWSWEEPER_LIVE_PROOF_ENABLED=1`, repository opt-in, a
-recommended plan, and a still-open pull request. Every failed gate is a logged
-successful skip.
+After the report is published, both scheduled publication and exact-event
+direct delivery in `sweep.yml` dispatch `live-proof.yml` only when the plan
+status is `recommended` and the target's repository profile has
+`live_test.enabled: true`. The command then applies ordered gates for
+`CLAWSWEEPER_LIVE_PROOF_ENABLED=1`, repository opt-in, a recommended plan, a
+runnable configured surface, and a still-open pull request. Every failed gate
+is a logged successful skip, including a browser recommendation for a
+terminal-only repository that has no configured server or URL.
 
 ## Execute and attach
 

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -48,6 +48,9 @@ without a TypeScript change. It is intentionally narrow:
 - denied repositories are rejected
 - scheduled fanout is public-only unless a private state publication path exists
 - auto-close policy comes from that owner fallback
+- `live_test`, when present, supplies the default live-proof configuration to
+  matching built-in, configured, and generic profiles; an explicit repository
+  block can override it
 - generic `openclaw/*` issues can auto-close only for
   `implemented_on_main`; PRs can auto-close for `implemented_on_main` or
   age-gated `mostly_implemented_on_main`

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "repair:github-egress-telemetry": "node dist/repair/github-egress-telemetry-cli.js",
     "repair:exact-review-direct-publication": "node dist/repair/exact-review-direct-publication.js",
     "repair:publish-event-result": "node dist/repair/publish-event-result.js",
+    "repair:live-proof-candidates": "node dist/repair/live-proof-dispatch-candidates.js",
     "repair:update-command-status": "node dist/repair/update-command-status.js",
     "workflow": "node dist/repair/workflow-utils.js",
     "repair:promote-stuck-jobs": "node dist/repair/promote-stuck-jobs.js",

--- a/src/clawsweeper-report-parser.ts
+++ b/src/clawsweeper-report-parser.ts
@@ -3,6 +3,7 @@ import {
   normalizePrRating,
   normalizeRealBehaviorProof,
 } from "./clawsweeper-rating.js";
+import { createDecisionParser } from "./clawsweeper-decision-parser.js";
 import {
   AGENTS_POLICY_STATUSES,
   AUTO_IMPLEMENTATION_CANDIDATES,
@@ -79,7 +80,6 @@ interface ReportParsingDependencies {
   markdownRepository: (markdown: string, file?: string) => string;
   parseBoldListHeading: (line: string) => { label: string; detail: string } | null;
   parseLabelJustification: (value: unknown, path: string) => LabelJustification;
-  parseLiveProofPlan: (value: unknown, path: string) => LiveProofPlan;
   parseMergeRiskOption: (value: unknown, path: string) => MergeRiskOption;
   parseReviewFindingHeading: (line: string) => {
     priority: ReviewFinding["priority"];
@@ -111,6 +111,106 @@ interface ReportParsingDependencies {
   splitFileAndLine: (file: string) => { file: string; line?: number };
 }
 
+const LIVE_PROOF_SECTION_HEADING = REVIEW_SECTIONS.liveProof;
+const LIVE_PROOF_OWNED_HEADINGS = new Set(
+  Object.values(REVIEW_SECTIONS).map((heading) => heading.toLowerCase()),
+);
+const parseRecordedLiveProofPlan = createDecisionParser({
+  isMaintainerAuthorAssociation: () => false,
+  neutralizeOwnedSectionSpoofing: neutralizeLiveProofText,
+  sanitizeArchitectureDiagram: (value) => value,
+}).parseLiveProofPlan;
+
+export function reportLiveProofPlan(markdown: string): LiveProofPlan {
+  const section = reportSectionValue(markdown, LIVE_PROOF_SECTION_HEADING);
+  const rawSteps = reportSectionList(section, "Steps");
+  try {
+    return parseRecordedLiveProofPlan(
+      {
+        status: reportSectionLineValue(section, "Status"),
+        surface: reportSectionLineValue(section, "Surface"),
+        reason: reportSectionLineValue(section, "Reason"),
+        entry: reportSectionLineValue(section, "Entry") ?? "",
+        steps: rawSteps.map((step) => JSON.parse(step) as unknown),
+      },
+      "report.liveProofPlan",
+    );
+  } catch {
+    return {
+      status: "not_applicable",
+      surface: "none",
+      reason: "No live-proof plan was recorded in this report.",
+      entry: "",
+      steps: [],
+    };
+  }
+}
+
+function reportSectionValue(markdown: string, heading: string): string {
+  const match = markdown.match(
+    new RegExp(`(?:^|\\n)## ${heading}\\n\\n([\\s\\S]*?)(?=\\n## |\\n?$)`),
+  );
+  return match?.[1]?.trim() ?? "";
+}
+
+function reportSectionLineValue(section: string, label: string): string | undefined {
+  const prefix = `${label}:`;
+  for (const line of section.split("\n")) {
+    if (!line.startsWith(prefix)) continue;
+    const value = line.slice(prefix.length).trim();
+    return value || undefined;
+  }
+  return undefined;
+}
+
+function reportSectionList(section: string, label: string): string[] {
+  const lines = section.split("\n");
+  const start = lines.findIndex((line) => line.trim() === `${label}:`);
+  if (start === -1) return [];
+  const values: string[] = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (/^[A-Z][A-Za-z -]+:/.test(line)) break;
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith("- ")) continue;
+    const item = trimmed.slice(2).trim();
+    if (item) values.push(item);
+  }
+  return values;
+}
+
+function neutralizeLiveProofText(value: string): string {
+  return value
+    .replace(/\r\n?|[\u2028\u2029]/g, "\n")
+    .split("\n")
+    .map((line) => {
+      const containerPrefix =
+        line.match(/^[ \t]*(?:(?:>|(?:[-*+]|\d+[.)])[ \t])[ \t]*)*/)?.[0] ?? "";
+      const content = line.slice(containerPrefix.length).replace(/<(?!br\s*\/?>)/gi, "&lt;");
+      const trimmed = content.trim();
+      if (/^#{1,6}\s+\S/.test(trimmed)) {
+        return `${containerPrefix}${content.replace("#", "\\#")}`;
+      }
+      if (/^\*\*[^*\n]+\*\*:?\s*$/.test(trimmed)) {
+        return `${containerPrefix}${content.replace("**", "\\*\\*")}`;
+      }
+      if (/^(?:```|~~~)/.test(trimmed)) {
+        return `${containerPrefix}${content.replace(/[`~]/, "\\$&")}`;
+      }
+      if (/^(?:=+|-+)[ \t]*$/.test(trimmed)) {
+        return `${containerPrefix}${content.replace(/[=-]/, "\\$&")}`;
+      }
+      if (
+        trimmed.endsWith(":") &&
+        LIVE_PROOF_OWNED_HEADINGS.has(trimmed.slice(0, -1).trim().toLowerCase())
+      ) {
+        return `${containerPrefix}${content.trimEnd().slice(0, -1)}&#58;`;
+      }
+      return `${containerPrefix}${content}`;
+    })
+    .join("\n");
+}
+
 export function createReportParser({
   agentsPolicyStatusLine,
   defaultRootCauseCluster,
@@ -124,7 +224,6 @@ export function createReportParser({
   markdownRepository,
   parseBoldListHeading,
   parseLabelJustification,
-  parseLiveProofPlan,
   parseMergeRiskOption,
   parseReviewFindingHeading,
   parseRootCauseCluster,
@@ -524,35 +623,6 @@ export function createReportParser({
         sectionLineValue(section, "Summary") ??
         "No Telegram visible-proof assessment was recorded in this report.",
     };
-  }
-
-  function defaultLiveProofPlan(): LiveProofPlan {
-    return {
-      status: "not_applicable",
-      surface: "none",
-      reason: "No live-proof plan was recorded in this report.",
-      entry: "",
-      steps: [],
-    };
-  }
-
-  function reportLiveProofPlan(markdown: string): LiveProofPlan {
-    const section = reviewSectionValue(markdown, "liveProof");
-    const rawSteps = sectionList(section, "Steps");
-    try {
-      return parseLiveProofPlan(
-        {
-          status: sectionLineValue(section, "Status"),
-          surface: sectionLineValue(section, "Surface"),
-          reason: sectionLineValue(section, "Reason"),
-          entry: sectionLineValue(section, "Entry") ?? "",
-          steps: rawSteps.map((step) => JSON.parse(step) as unknown),
-        },
-        "report.liveProofPlan",
-      );
-    } catch {
-      return defaultLiveProofPlan();
-    }
   }
 
   function reportLiveProofRecordingBlock(markdown: string): string {

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -63,6 +63,12 @@ export async function executeLiveProof(
   if (plan.surface === "none") {
     throw new Error("recommended live proof plan is missing a browser or terminal surface");
   }
+  if (plan.surface === "browser" && (!liveTest.start || !liveTest.url)) {
+    log(
+      `[live-proof] skip: browser plan cannot run for ${profile.targetRepo} because live_test.start and live_test.url are not configured`,
+    );
+    return;
+  }
 
   const checkout = resolve(options.checkoutPath ?? process.cwd());
   let headSha: string;
@@ -85,9 +91,6 @@ export async function executeLiveProof(
     headSha = item.headSha.toLowerCase();
   }
 
-  if (plan.surface === "browser" && (!liveTest.start || !liveTest.url)) {
-    throw new Error("browser live proof requires live_test.start and live_test.url");
-  }
   const outputDir = resolve(options.outputDir);
   mkdirSync(outputDir, { recursive: true });
   const rawVideoPath = join(outputDir, "live-proof.raw.webm");

--- a/src/repair/live-proof-dispatch-candidates.ts
+++ b/src/repair/live-proof-dispatch-candidates.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { reportLiveProofPlan } from "../clawsweeper-report-parser.js";
+import { repositoryProfileFor } from "../repository-profiles.js";
+
+export interface LiveProofDispatchCandidateOptions {
+  targetRepo: string;
+  itemNumbers: readonly string[];
+  recordsRoot: string;
+}
+
+export function liveProofDispatchCandidates(
+  options: LiveProofDispatchCandidateOptions,
+): Array<{ item: number; plan: ReturnType<typeof reportLiveProofPlan> }> {
+  const profile = repositoryProfileFor(options.targetRepo);
+  if (!profile.liveTest?.enabled) return [];
+
+  const candidates: Array<{ item: number; plan: ReturnType<typeof reportLiveProofPlan> }> = [];
+  for (const rawItem of options.itemNumbers) {
+    const item = Number(rawItem);
+    if (!Number.isSafeInteger(item) || item < 1) continue;
+    let markdown: string;
+    try {
+      markdown = readFileSync(
+        join(options.recordsRoot, profile.slug, "items", `${item}.md`),
+        "utf8",
+      );
+    } catch {
+      continue;
+    }
+    const plan = reportLiveProofPlan(markdown);
+    if (plan.status === "recommended") candidates.push({ item, plan });
+  }
+  return candidates;
+}
+
+function main(): void {
+  const targetRepo = String(process.env.TARGET_REPO ?? "").trim();
+  if (!targetRepo) throw new Error("TARGET_REPO is required");
+  const itemNumbers = String(process.env.ITEM_NUMBERS ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const recordsRoot = resolve(process.env.RECORDS_ROOT || "records");
+  for (const candidate of liveProofDispatchCandidates({ targetRepo, itemNumbers, recordsRoot })) {
+    process.stdout.write(`${JSON.stringify(candidate)}\n`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -69,6 +69,7 @@ interface GenericFallbackConfig {
   allowRepoNamePattern: RegExp;
   promptNote: string;
   applyCloseRules: Partial<Record<RepositoryItemKind, readonly RepositoryCloseReason[]>>;
+  liveTest?: RepositoryLiveTestConfig;
 }
 
 const OPENCLAW_CLOSE_REASONS: readonly RepositoryCloseReason[] = [
@@ -121,7 +122,7 @@ const CORE_OPENCLAW_PROFILE: RepositoryProfile = {
 const TARGET_REPOSITORY_CONFIG = readTargetRepositoryConfig();
 
 export const REPOSITORY_PROFILES: RepositoryProfile[] = [
-  CORE_OPENCLAW_PROFILE,
+  repositoryProfileWithFallbackLiveTest(CORE_OPENCLAW_PROFILE),
   ...TARGET_REPOSITORY_CONFIG.repositories.map(configuredRepositoryProfile),
 ];
 
@@ -173,22 +174,25 @@ function configuredRepositoryProfile(profile: ConfiguredRepositoryProfile): Repo
   };
   if (profile.docsUrl) result.docsUrl = profile.docsUrl;
   if (profile.communityUrl) result.communityUrl = profile.communityUrl;
-  if (profile.liveTest) result.liveTest = profile.liveTest;
+  const liveTest = profile.liveTest ?? genericFallbackConfigFor(targetRepo)?.liveTest;
+  if (liveTest) result.liveTest = liveTest;
   return result;
+}
+
+function repositoryProfileWithFallbackLiveTest(profile: RepositoryProfile): RepositoryProfile {
+  if (profile.liveTest) return profile;
+  const liveTest = genericFallbackConfigFor(profile.targetRepo)?.liveTest;
+  return liveTest ? { ...profile, liveTest } : profile;
 }
 
 function fallbackRepositoryProfile(normalizedTargetRepo: string): RepositoryProfile | undefined {
   const [owner, repoName] = normalizedTargetRepo.split("/");
   if (!owner || !repoName) return undefined;
 
-  const fallback = TARGET_REPOSITORY_CONFIG.genericFallbacks.find(
-    (candidate) => candidate.owner === owner,
-  );
+  const fallback = genericFallbackConfigFor(normalizedTargetRepo);
   if (!fallback) return undefined;
-  if (fallback.denyRepositories.includes(normalizedTargetRepo)) return undefined;
-  if (!fallback.allowRepoNamePattern.test(repoName)) return undefined;
 
-  return {
+  const result: RepositoryProfile = {
     targetRepo: normalizedTargetRepo,
     slug: slugForRepo(normalizedTargetRepo),
     displayName: repoName,
@@ -198,6 +202,20 @@ function fallbackRepositoryProfile(normalizedTargetRepo: string): RepositoryProf
       .replaceAll("{repo_name}", repoName),
     applyCloseRules: fallback.applyCloseRules,
   };
+  if (fallback.liveTest) result.liveTest = fallback.liveTest;
+  return result;
+}
+
+function genericFallbackConfigFor(normalizedTargetRepo: string): GenericFallbackConfig | undefined {
+  const [owner, repoName] = normalizedTargetRepo.split("/");
+  if (!owner || !repoName) return undefined;
+  const fallback = TARGET_REPOSITORY_CONFIG.genericFallbacks.find(
+    (candidate) => candidate.owner === owner,
+  );
+  if (!fallback) return undefined;
+  if (fallback.denyRepositories.includes(normalizedTargetRepo)) return undefined;
+  if (!fallback.allowRepoNamePattern.test(repoName)) return undefined;
+  return fallback;
 }
 
 function fallbackDescription(): string {
@@ -236,7 +254,11 @@ function validateTargetRepositoryConfig(value: unknown): TargetRepositoryConfig 
   const genericFallbacks =
     config.generic_fallbacks !== undefined
       ? arrayValue(config.generic_fallbacks, "generic_fallbacks").map((entry, index) =>
-          validateGenericFallbackConfig(entry, `generic_fallbacks[${index}]`),
+          validateGenericFallbackConfig(
+            entry,
+            `generic_fallbacks[${index}]`,
+            schemaVersion as 1 | 2,
+          ),
         )
       : [];
   const result: TargetRepositoryConfig = {
@@ -247,7 +269,11 @@ function validateTargetRepositoryConfig(value: unknown): TargetRepositoryConfig 
   if (config.openclaw_fallback !== undefined) {
     result.genericFallbacks = [
       ...result.genericFallbacks,
-      validateGenericFallbackConfig(config.openclaw_fallback, "openclaw_fallback"),
+      validateGenericFallbackConfig(
+        config.openclaw_fallback,
+        "openclaw_fallback",
+        schemaVersion as 1 | 2,
+      ),
     ];
   }
   return result;
@@ -333,10 +359,14 @@ export function validateTargetRepositoryConfigForTest(value: unknown): TargetRep
   return validateTargetRepositoryConfig(value);
 }
 
-function validateGenericFallbackConfig(value: unknown, label: string): GenericFallbackConfig {
+function validateGenericFallbackConfig(
+  value: unknown,
+  label: string,
+  schemaVersion: 1 | 2,
+): GenericFallbackConfig {
   const fallback = record(value, label);
   const pattern = stringValue(fallback.allow_repo_name_pattern, `${label}.allow_repo_name_pattern`);
-  return {
+  const result: GenericFallbackConfig = {
     owner: stringValue(fallback.owner, `${label}.owner`).toLowerCase(),
     denyRepositories: arrayValue(fallback.deny_repositories, `${label}.deny_repositories`).map(
       (entry, index) => normalizeRepo(repoValue(entry, `${label}.deny_repositories[${index}]`)),
@@ -345,6 +375,11 @@ function validateGenericFallbackConfig(value: unknown, label: string): GenericFa
     promptNote: stringValue(fallback.prompt_note, `${label}.prompt_note`),
     applyCloseRules: closeRulesValue(fallback.apply_close_rules, `${label}.apply_close_rules`),
   };
+  if (fallback.live_test !== undefined) {
+    if (schemaVersion !== 2) throw new Error(`${label}.live_test requires schema_version 2`);
+    result.liveTest = liveTestValue(fallback.live_test, `${label}.live_test`);
+  }
+  return result;
 }
 
 function closeRulesValue(

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -101,6 +101,24 @@ test("live-proof gates skip in order with a successful result", async (t) => {
       expectedFetches: 0,
     },
     {
+      name: "browser plan on terminal-only profile",
+      env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+      targetProfile: {
+        ...profile(),
+        liveTest: {
+          enabled: true,
+          surfaceDefault: "terminal",
+          setup: [],
+          readyTimeoutSeconds: 5,
+          maxRecordingSeconds: 90,
+        },
+      },
+      plan: recommendedPlan("browser"),
+      pull: { kind: "pull_request", state: "open", headSha: HEAD },
+      expected: /browser plan cannot run .* live_test\.start and live_test\.url are not configured/,
+      expectedFetches: 0,
+    },
+    {
       name: "item kind",
       env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
       targetProfile: profile(),
@@ -319,8 +337,63 @@ test("live-proof workflow keeps execute secretless and attach trusted", () => {
   assert.match(source, /--record \.\.\/live-proof-report\.md/);
   assert.doesNotMatch(source, /--plan \.\.\/live-proof/);
   const sweep = readFileSync(".github/workflows/sweep.yml", "utf8");
-  assert.match(sweep, /event_type: "clawsweeper_live_proof"/);
-  assert.match(sweep, /profile\.liveTest\?\.enabled/);
+  const sweepWorkflow = YAML.parse(sweep) as {
+    jobs: Record<
+      string,
+      {
+        steps: Array<{
+          name?: string;
+          id?: string;
+          if?: string;
+          env?: Record<string, string>;
+          run?: string;
+          uses?: string;
+          with?: Record<string, string>;
+        }>;
+      }
+    >;
+  };
+  const directSteps = sweepWorkflow.jobs["event-review-apply"]?.steps ?? [];
+  const directDeliveryIndex = directSteps.findIndex(
+    (step) => step.name === "Deliver GitHub effects and prepare direct state mutation",
+  );
+  const directDispatchIndex = directSteps.findIndex(
+    (step) => step.name === "Dispatch recommended live proofs",
+  );
+  const directDispatch = directSteps[directDispatchIndex];
+  const dispatchToken = directSteps.find((step) => step.id === "live-proof-dispatch-token");
+  assert.ok(directDeliveryIndex >= 0);
+  assert.ok(directDispatchIndex > directDeliveryIndex);
+  assert.equal(dispatchToken?.uses, "./.github/actions/create-target-write-token");
+  assert.equal(dispatchToken?.with?.owner, "openclaw");
+  assert.equal(dispatchToken?.with?.repository, "clawsweeper");
+  assert.match(
+    directDispatch?.if ?? "",
+    /prepare-direct-exact-review-publication\.outcome == 'success'/,
+  );
+  assert.equal(
+    directDispatch?.env?.GH_TOKEN,
+    "${{ steps.live-proof-dispatch-token.outputs.token }}",
+  );
+  assert.equal(directDispatch?.env?.ITEM_NUMBER, "${{ steps.target.outputs.item_number }}");
+  assert.match(
+    directDispatch?.run ?? "",
+    /ITEM_NUMBERS="\$item_numbers" RECORDS_ROOT=records pnpm run --silent repair:live-proof-candidates/,
+  );
+  assert.doesNotMatch(directDispatch?.run ?? "", /dist\/clawsweeper\.js/);
+  assert.match(directDispatch?.run ?? "", /event_type: "clawsweeper_live_proof"/);
+  assert.match(directDispatch?.run ?? "", /repos\/\$GITHUB_REPOSITORY\/dispatches/);
+  assert.equal(
+    Object.values(sweepWorkflow.jobs)
+      .flatMap((job) => job.steps)
+      .filter((step) => step.name === "Dispatch recommended live proofs").length,
+    2,
+  );
+  assert.equal(sweep.match(/pnpm run --silent repair:live-proof-candidates/g)?.length, 2);
+  assert.doesNotMatch(sweep, /node --input-type=module <<'NODE' > \/tmp\/live-proof-candidates/);
+  const candidateSource = readFileSync("src/repair/live-proof-dispatch-candidates.ts", "utf8");
+  assert.match(candidateSource, /profile\.liveTest\?\.enabled/);
+  assert.match(candidateSource, /plan\.status === "recommended"/);
 });
 
 function validManifest() {

--- a/test/repair/live-proof-dispatch-candidates.test.ts
+++ b/test/repair/live-proof-dispatch-candidates.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+test("live-proof dispatch candidate CLI emits recommended enabled records as JSONL", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-candidates-"));
+  const items = join(root, "openclaw-clawsweeper", "items");
+  mkdirSync(items, { recursive: true });
+  writeFileSync(
+    join(items, "42.md"),
+    `## Live Proof
+
+Status: recommended
+
+Surface: browser
+
+Reason: The changed settings confirmation is visible in the browser.
+
+Entry: /settings
+
+Steps:
+
+- {"action":"goto","path":"/settings"}
+- {"action":"expect_text","text":"Saved"}
+`,
+    "utf8",
+  );
+  writeFileSync(
+    join(items, "43.md"),
+    `## Live Proof
+
+Status: not_applicable
+
+Surface: none
+
+Reason: This change has no visible behavior.
+
+Entry:
+
+Steps:
+`,
+    "utf8",
+  );
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      [resolve("dist/repair/live-proof-dispatch-candidates.js")],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          TARGET_REPO: "openclaw/clawsweeper",
+          ITEM_NUMBERS: "42,43,44",
+          RECORDS_ROOT: root,
+        },
+      },
+    );
+    assert.deepEqual(output.trim().split("\n").map(JSON.parse), [
+      {
+        item: 42,
+        plan: {
+          status: "recommended",
+          surface: "browser",
+          reason: "The changed settings confirmation is visible in the browser.",
+          entry: "/settings",
+          steps: [
+            { action: "goto", path: "/settings" },
+            { action: "expect_text", text: "Saved" },
+          ],
+        },
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -24,6 +24,31 @@ function targetRepositoryConfig(liveTest: Record<string, unknown>, schemaVersion
   };
 }
 
+function fallbackRepositoryConfig(liveTest: Record<string, unknown>, schemaVersion = 2) {
+  return {
+    schema_version: schemaVersion,
+    repositories: [],
+    generic_fallbacks: [
+      {
+        owner: "example",
+        deny_repositories: [],
+        allow_repo_name_pattern: "^[A-Za-z0-9_.-]+$",
+        prompt_note: "Review {target_repo}.",
+        apply_close_rules: { issue: [], pull_request: [] },
+        live_test: liveTest,
+      },
+    ],
+  };
+}
+
+const TERMINAL_LIVE_TEST = {
+  enabled: true,
+  surfaceDefault: "terminal",
+  setup: ["pnpm install --frozen-lockfile"],
+  readyTimeoutSeconds: 240,
+  maxRecordingSeconds: 90,
+} as const;
+
 test("OpenClaw allows unsponsored feature closes for issues only", () => {
   const profile = repositoryProfileFor("openclaw/openclaw");
   assert.equal(profile.applyCloseRules.issue?.includes("unsponsored_feature_request"), true);
@@ -86,6 +111,7 @@ test("generic OpenClaw fallback supports conservative event-only onboarding", ()
     "implemented_on_main",
     "mostly_implemented_on_main",
   ]);
+  assert.deepEqual(profile.liveTest, TERMINAL_LIVE_TEST);
 });
 
 test("generic steipete fallback starts review-only", () => {
@@ -98,6 +124,7 @@ test("generic steipete fallback starts review-only", () => {
   assert.match(profile.promptNote, /generic personal-repository onboarding profile/);
   assert.deepEqual(profile.applyCloseRules.issue, []);
   assert.deepEqual(profile.applyCloseRules.pull_request, []);
+  assert.deepEqual(profile.liveTest, TERMINAL_LIVE_TEST);
 });
 
 test("generic OpenClaw fallback keeps denied repositories unsupported", () => {
@@ -188,6 +215,50 @@ test("terminal live_test profiles may omit browser start and URL fields", () => 
     surfaceDefault: "terminal",
     setup: ["pnpm install", "pnpm build"],
     readyTimeoutSeconds: 120,
+    maxRecordingSeconds: 90,
+  });
+});
+
+test("schema v2 generic fallbacks strictly validate and inherit optional live_test config", () => {
+  const liveTest = {
+    enabled: true,
+    surface_default: "terminal",
+    setup: ["pnpm install"],
+    ready_timeout_seconds: 120,
+    max_recording_seconds: 90,
+  };
+  const parsed = validateTargetRepositoryConfigForTest(fallbackRepositoryConfig(liveTest));
+  assert.deepEqual(parsed.genericFallbacks[0]?.liveTest, {
+    enabled: true,
+    surfaceDefault: "terminal",
+    setup: ["pnpm install"],
+    readyTimeoutSeconds: 120,
+    maxRecordingSeconds: 90,
+  });
+  assert.throws(
+    () =>
+      validateTargetRepositoryConfigForTest(
+        fallbackRepositoryConfig({ ...liveTest, surprise: true }),
+      ),
+    /generic_fallbacks\[0\]\.live_test has unexpected keys: surprise/,
+  );
+  assert.throws(
+    () => validateTargetRepositoryConfigForTest(fallbackRepositoryConfig(liveTest, 1)),
+    /generic_fallbacks\[0\]\.live_test requires schema_version 2/,
+  );
+});
+
+test("configured and fallback-owned repositories expose their enabled live-proof surfaces", () => {
+  assert.deepEqual(repositoryProfileFor("openclaw/openclaw").liveTest, TERMINAL_LIVE_TEST);
+  assert.deepEqual(repositoryProfileFor("openclaw/openclaw-facetime").liveTest, TERMINAL_LIVE_TEST);
+  assert.deepEqual(repositoryProfileFor("openclaw/fs-safe").liveTest, TERMINAL_LIVE_TEST);
+  assert.deepEqual(repositoryProfileFor("openclaw/clawhub").liveTest, {
+    enabled: true,
+    surfaceDefault: "browser",
+    setup: ["bun install"],
+    start: "bun run dev",
+    url: "http://127.0.0.1:3000",
+    readyTimeoutSeconds: 240,
     maxRecordingSeconds: 90,
   });
 });


### PR DESCRIPTION
## Summary

Production verification of the live-proof lane (#1181) on openclaw/clawsweeper#1182 exposed a lane gap: the exact-event review path delivers GitHub effects directly and skips the artifact publication job, so its recommended live proofs never dispatched (run 32002395638 reviewed #1182 with every publish job skipped). Both lanes now extract dispatch candidates through one repair-built CLI — `repair:live-proof-candidates`, emitted by every branch of the job's conditional build-script, satisfying the static workflow assertion — and POST the `clawsweeper_live_proof` dispatch with a host-repo app token that works regardless of which target repository was reviewed.

Per maintainer direction, live tests are also enabled everywhere: `live_test` is now inherited from generic fallback profiles, giving every `openclaw/*` and `steipete/*` target (including openclaw/openclaw via the fallback) terminal-surface live proofs with install-only setup, plus explicit browser configs for ClawHub (vite dev server) and the ClawSweeper bay demo, and terminal configs for openclaw-facetime and fs-safe. A recommended browser plan for a repository without a configured dev server is now a logged skip instead of an execution error.

## Validation

- `pnpm build` and `pnpm run build:repair` clean.
- Unit suite: 2,286 passed, 0 failed, 2 platform skips.
- The previously failing static assertion ("every workflow job that runs the main bundle directly obtains it") passes.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted findings, "patch is correct (0.93)".
- Remaining `pnpm check` failures are the known environmental repair fixtures that need a network package mirror.
