### PR TITLE
fix(live-proof): wait for display and recorder readiness in the terminal driver

### DIFF
--- a/.github/workflows/live-proof.yml
+++ b/.github/workflows/live-proof.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install deterministic recording tools
         run: |
           sudo apt-get update
-          sudo apt-get install --yes ffmpeg tmux xvfb xterm
+          sudo apt-get install --yes ffmpeg tmux x11-utils xvfb xterm
 
       - name: Check out the public PR head
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.
 - Routed every durable review-record publication lane through one shared, host-authenticated live-proof dispatcher, including queued exact-review batches grouped per target repository.
 - Exact-event reviews now dispatch recommended live proofs with host-repository credentials, while generic and configured OpenClaw and steipete profiles opt into browser or terminal proof as appropriate.
 - Hosted webhook 🦞👀 receipts now dedupe per pull request across `opened` and `ready_for_review`, so back-to-back webhook actions keep one receipt instead of posting near-identical duplicates. (#1084)

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -21,6 +21,16 @@ export interface LiveProofDriveResult {
   rawVideoPath: string;
 }
 
+const DISPLAY_READY_TIMEOUT_SECONDS = 30;
+const RECORDER_READY_TIMEOUT_SECONDS = 15;
+const RECORDER_FINALIZE_TIMEOUT_SECONDS = 20;
+
+type TerminalCommandInvocation = {
+  command: string;
+  args: string[];
+  waitAfter?: "display" | "recorder";
+};
+
 export function generatePlaywrightScript(steps: readonly LiveProofBrowserStep[]): string {
   const serializedSteps = JSON.stringify(JSON.stringify(steps))
     .replaceAll("\u2028", "\\u2028")
@@ -149,7 +159,7 @@ export function terminalCommandPlan(options: {
   entry: string;
   maxRecordingSeconds: number;
   rawVideoPath: string;
-}): Array<{ command: string; args: string[] }> {
+}): TerminalCommandInvocation[] {
   const terminalSession = `${options.sessionPrefix}-terminal`;
   const displaySession = `${options.sessionPrefix}-display`;
   const recorderSession = `${options.sessionPrefix}-recorder`;
@@ -160,11 +170,19 @@ export function terminalCommandPlan(options: {
     },
     {
       command: "tmux",
+      args: ["new-session", "-d", "-s", displaySession],
+    },
+    {
+      command: "tmux",
+      args: ["set-option", "-w", "-t", `${displaySession}:0`, "remain-on-exit", "on"],
+    },
+    {
+      command: "tmux",
       args: [
-        "new-session",
-        "-d",
-        "-s",
-        displaySession,
+        "respawn-pane",
+        "-k",
+        "-t",
+        `${displaySession}:0.0`,
         "xvfb-run",
         "--server-num=99",
         "--server-args=-screen 0 1280x800x24",
@@ -178,15 +196,23 @@ export function terminalCommandPlan(options: {
         "-t",
         terminalSession,
       ],
+      waitAfter: "display",
     },
-    { command: "sleep", args: ["1"] },
+    {
+      command: "tmux",
+      args: ["new-session", "-d", "-s", recorderSession],
+    },
+    {
+      command: "tmux",
+      args: ["set-option", "-w", "-t", `${recorderSession}:0`, "remain-on-exit", "on"],
+    },
     {
       command: "tmux",
       args: [
-        "new-session",
-        "-d",
-        "-s",
-        recorderSession,
+        "respawn-pane",
+        "-k",
+        "-t",
+        `${recorderSession}:0.0`,
         "timeout",
         `${options.maxRecordingSeconds}s`,
         "ffmpeg",
@@ -204,6 +230,7 @@ export function terminalCommandPlan(options: {
         "libvpx-vp9",
         options.rawVideoPath,
       ],
+      waitAfter: "recorder",
     },
     {
       command: "tmux",
@@ -229,6 +256,7 @@ export function driveTerminal(options: {
   const recorderSession = `${sessionPrefix}-recorder`;
   const log: LiveProofStepLogEntry[] = [];
   let failed = false;
+  let thrown: Error | undefined;
   try {
     for (const invocation of terminalCommandPlan({
       sessionPrefix,
@@ -241,8 +269,12 @@ export function driveTerminal(options: {
         invocation.args,
         options.runner(invocation.command, invocation.args, { cwd: options.checkout }),
       );
+      if (invocation.waitAfter === "display") {
+        waitForDisplay(options.runner, options.checkout);
+      } else if (invocation.waitAfter === "recorder") {
+        waitForRecorder(options.runner, options.checkout, recorderSession, options.rawVideoPath);
+      }
     }
-    requireSuccess("sleep", ["1"], options.runner("sleep", ["1"]));
     for (const step of options.plan.steps as LiveProofTerminalStep[]) {
       try {
         runTerminalStep(step, terminalSession, options.runner, options.checkout);
@@ -257,20 +289,150 @@ export function driveTerminal(options: {
         break;
       }
     }
+    finalizeRecorder(options.runner, options.checkout, recorderSession);
+    requireRecording(options.runner, options.checkout, options.rawVideoPath);
+  } catch (error) {
+    thrown = terminalErrorWithDiagnostics(error, options.runner, options.checkout, {
+      terminal: terminalSession,
+      display: displaySession,
+      recorder: recorderSession,
+    });
   } finally {
-    options.runner("tmux", ["send-keys", "-t", `${recorderSession}:0.0`, "q"]);
-    options.runner("sleep", ["1"]);
     options.runner("tmux", ["kill-session", "-t", recorderSession]);
     options.runner("tmux", ["kill-session", "-t", displaySession]);
     options.runner("tmux", ["kill-session", "-t", terminalSession]);
   }
-  if (!existsSync(options.rawVideoPath))
-    throw new Error("terminal driver did not finalize a recording");
+  if (thrown) throw thrown;
   return {
     status: failed ? (log.length > 1 ? "partial" : "failed") : "completed",
     steps: log,
     rawVideoPath: options.rawVideoPath,
   };
+}
+
+function waitForDisplay(runner: MediaProofCommandRunner, checkout: string): void {
+  let lastResult: ReturnType<MediaProofCommandRunner> | undefined;
+  for (let elapsed = 0; elapsed <= DISPLAY_READY_TIMEOUT_SECONDS; elapsed += 1) {
+    lastResult = runner("xdpyinfo", ["-display", ":99"], { cwd: checkout });
+    if (lastResult.status === 0) return;
+    if (elapsed < DISPLAY_READY_TIMEOUT_SECONDS) pollSleep(runner);
+  }
+  throw new Error(
+    `X display :99 was not ready after ${DISPLAY_READY_TIMEOUT_SECONDS} seconds: ${mediaProofSpawnDetail(lastResult!)}`,
+  );
+}
+
+function waitForRecorder(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  recorderSession: string,
+  rawVideoPath: string,
+): void {
+  let previousSize: number | undefined;
+  for (let elapsed = 0; elapsed <= RECORDER_READY_TIMEOUT_SECONDS; elapsed += 1) {
+    const size = recordingSize(runner, checkout, rawVideoPath);
+    if (recorderExited(runner, checkout, recorderSession)) {
+      throw new Error("recorder session exited before the raw WebM began growing");
+    }
+    if (size !== undefined) {
+      if (previousSize !== undefined && size > previousSize) return;
+      previousSize = size;
+    }
+    if (elapsed < RECORDER_READY_TIMEOUT_SECONDS) pollSleep(runner);
+  }
+  throw new Error(
+    `raw WebM did not begin growing within ${RECORDER_READY_TIMEOUT_SECONDS} seconds`,
+  );
+}
+
+function finalizeRecorder(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  recorderSession: string,
+): void {
+  if (recorderExited(runner, checkout, recorderSession)) {
+    throw new Error("recorder session exited before finalization");
+  }
+  const target = `${recorderSession}:0.0`;
+  requireSuccess(
+    "tmux",
+    ["send-keys", "-t", target, "q"],
+    runner("tmux", ["send-keys", "-t", target, "q"], { cwd: checkout }),
+  );
+  for (let elapsed = 0; elapsed <= RECORDER_FINALIZE_TIMEOUT_SECONDS; elapsed += 1) {
+    if (recorderExited(runner, checkout, recorderSession)) return;
+    if (elapsed < RECORDER_FINALIZE_TIMEOUT_SECONDS) pollSleep(runner);
+  }
+  throw new Error(
+    `recorder session did not exit within ${RECORDER_FINALIZE_TIMEOUT_SECONDS} seconds after ffmpeg received q`,
+  );
+}
+
+function recorderExited(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  recorderSession: string,
+): boolean {
+  const result = runner(
+    "tmux",
+    ["display-message", "-p", "-t", `${recorderSession}:0.0`, "#{pane_dead}"],
+    { cwd: checkout },
+  );
+  return result.status !== 0 || String(result.stdout ?? "").trim() === "1";
+}
+
+function recordingSize(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  rawVideoPath: string,
+): number | undefined {
+  const result = runner("wc", ["-c", "--", rawVideoPath], { cwd: checkout });
+  if (result.status !== 0) return undefined;
+  const size = Number.parseInt(String(result.stdout ?? "").trim(), 10);
+  return Number.isSafeInteger(size) && size >= 0 ? size : undefined;
+}
+
+function requireRecording(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  rawVideoPath: string,
+): void {
+  const size = recordingSize(runner, checkout, rawVideoPath);
+  if (size === undefined || size === 0) {
+    throw new Error("terminal driver did not finalize a recording");
+  }
+}
+
+function pollSleep(runner: MediaProofCommandRunner): void {
+  requireSuccess("sleep", ["1"], runner("sleep", ["1"]));
+}
+
+function terminalErrorWithDiagnostics(
+  error: unknown,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  sessions: Record<"terminal" | "display" | "recorder", string>,
+): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  const diagnostics = (Object.entries(sessions) as Array<[keyof typeof sessions, string]>).map(
+    ([label, session]) => {
+      const result = runner("tmux", ["capture-pane", "-p", "-t", `${session}:0.0`, "-S", "-40"], {
+        cwd: checkout,
+      });
+      const output =
+        result.status === 0
+          ? lastLines(String(result.stdout ?? ""), 40) || "<empty>"
+          : `<capture failed: ${mediaProofSpawnDetail(result)}>`;
+      return `[${label}: ${session}]\n${output}`;
+    },
+  );
+  return new Error(
+    `${message}\n\nTerminal session diagnostics (last 40 lines):\n\n${diagnostics.join("\n\n")}`,
+  );
+}
+
+function lastLines(value: string, count: number): string {
+  return value.trimEnd().split("\n").slice(-count).join("\n");
 }
 
 function runTerminalStep(

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -10,7 +10,11 @@ import { REVIEW_SECTIONS } from "../dist/clawsweeper-policy.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
 import type { RepositoryProfile } from "../dist/repository-profiles.js";
 import { attachLiveProof } from "../dist/live-proof/attach.js";
-import { generatePlaywrightScript, terminalCommandPlan } from "../dist/live-proof/drivers.js";
+import {
+  driveTerminal,
+  generatePlaywrightScript,
+  terminalCommandPlan,
+} from "../dist/live-proof/drivers.js";
 import { executeLiveProof } from "../dist/live-proof/execute.js";
 import { parseLiveProofManifest } from "../dist/live-proof/manifest.js";
 
@@ -203,14 +207,16 @@ test("terminal driver composes tmux, xvfb-run, and bounded ffmpeg x11grab", () =
     command: "tmux",
     args: ["new-session", "-d", "-s", "proof-terminal", "-x", "160", "-y", "50"],
   });
-  assert.deepEqual(commands[1]?.args.slice(4, 8), [
+  const display = commands.find((invocation) => invocation.args.includes("xvfb-run"));
+  const recorder = commands.find((invocation) => invocation.args.includes("ffmpeg"));
+  assert.deepEqual(display?.args.slice(4, 8), [
     "xvfb-run",
     "--server-num=99",
     "--server-args=-screen 0 1280x800x24",
     "xterm",
   ]);
-  assert.deepEqual(commands[2], { command: "sleep", args: ["1"] });
-  assert.deepEqual(commands[3]?.args.slice(4, 13), [
+  assert.equal(display?.waitAfter, "display");
+  assert.deepEqual(recorder?.args.slice(4, 13), [
     "timeout",
     "90s",
     "ffmpeg",
@@ -221,7 +227,91 @@ test("terminal driver composes tmux, xvfb-run, and bounded ffmpeg x11grab", () =
     "-video_size",
     "1280x800",
   ]);
+  assert.equal(recorder?.waitAfter, "recorder");
+  assert.equal(
+    commands.some((invocation) => invocation.command === "sleep"),
+    false,
+  );
   assert.deepEqual(commands.at(-2)?.args.slice(-2), ["--", "pnpm cli --help"]);
+});
+
+test("terminal driver reports display readiness timeout with all pane diagnostics", () => {
+  const calls: string[] = [];
+  const runner = terminalLifecycleRunner(calls, {
+    displayReadyAfter: Number.POSITIVE_INFINITY,
+    paneOutput: {
+      terminal: "terminal pane waiting",
+      display: "display pane cold",
+      recorder: "recorder pane absent",
+    },
+  });
+  assert.throws(
+    () => runTerminalFixture(runner),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /X display :99 was not ready after 30 seconds/);
+      assert.match(error.message, /\[terminal: .*\]\nterminal pane waiting/);
+      assert.match(error.message, /\[display: .*\]\ndisplay pane cold/);
+      assert.match(error.message, /\[recorder: .*\]\nrecorder pane absent/);
+      return true;
+    },
+  );
+  assert.equal(calls.filter((call) => call === "xdpyinfo -display :99").length, 31);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 30);
+});
+
+test("terminal driver accepts a recorder file that appears and grows late", () => {
+  const calls: string[] = [];
+  const result = runTerminalFixture(
+    terminalLifecycleRunner(calls, {
+      recorderSizes: [undefined, undefined, 7, 7, 11],
+    }),
+  );
+  assert.equal(result.status, "completed");
+  assert.equal(calls.filter((call) => call.startsWith("wc -c -- ")).length, 6);
+  assert.ok(calls.some((call) => /tmux send-keys .* q$/.test(call)));
+});
+
+test("terminal driver reports a dead recorder with its pane diagnostics", () => {
+  const calls: string[] = [];
+  const runner = terminalLifecycleRunner(calls, {
+    recorderDiesAtProbe: 0,
+    recorderSizes: [undefined],
+    paneOutput: {
+      terminal: "terminal pane ready",
+      display: "display pane ready",
+      recorder: "ffmpeg: cannot open display :99",
+    },
+  });
+  assert.throws(
+    () => runTerminalFixture(runner),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /recorder session exited before the raw WebM began growing/);
+      assert.match(error.message, /\[recorder: .*\]\nffmpeg: cannot open display :99/);
+      return true;
+    },
+  );
+});
+
+test("terminal driver waits for the recorder session to exit after sending q", () => {
+  const calls: string[] = [];
+  runTerminalFixture(
+    terminalLifecycleRunner(calls, {
+      recorderSizes: [1, 2],
+      finalizeExitAfter: 3,
+    }),
+  );
+  const sentQ = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
+  assert.notEqual(sentQ, -1);
+  const finalizeCalls = calls.slice(sentQ + 1);
+  assert.equal(finalizeCalls.filter((call) => call === "sleep 1").length, 3);
+  assert.equal(
+    finalizeCalls.filter(
+      (call) => call.includes("tmux display-message") && call.includes("pane_dead"),
+    ).length,
+    4,
+  );
 });
 
 test("live proof manifest is metadata-only and rejects URL-bearing extensions", () => {
@@ -334,6 +424,7 @@ test("live-proof workflow keeps execute secretless and attach trusted", () => {
   assert.match(source, /uses: \.\/\.github\/actions\/create-target-write-token/);
   assert.match(source, /CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT: \$\{\{ secrets\./);
   assert.match(source, /setsid timeout --kill-after=30s 1500s/);
+  assert.match(source, /apt-get install --yes ffmpeg tmux x11-utils xvfb xterm/);
   assert.match(source, /--record \.\.\/live-proof-report\.md/);
   assert.doesNotMatch(source, /--plan \.\.\/live-proof/);
 
@@ -608,6 +699,74 @@ function mediaRunner(commands: string[]): MediaProofCommandRunner {
           format: image ? {} : { duration: "4.000" },
         }),
       };
+    }
+    return { status: 0 };
+  };
+}
+
+function runTerminalFixture(runner: MediaProofCommandRunner) {
+  return driveTerminal({
+    plan: { ...recommendedPlan("terminal"), steps: [] },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    runner,
+  });
+}
+
+function terminalLifecycleRunner(
+  calls: string[],
+  options: {
+    displayReadyAfter?: number;
+    recorderSizes?: Array<number | undefined>;
+    recorderDiesAtProbe?: number;
+    finalizeExitAfter?: number;
+    paneOutput?: Record<"terminal" | "display" | "recorder", string>;
+  } = {},
+): MediaProofCommandRunner {
+  let displayProbe = 0;
+  let recorderSizeProbe = 0;
+  let recorderPaneProbe = 0;
+  let finalizeProbe = 0;
+  let finalizing = false;
+  const recorderSizes = options.recorderSizes ?? [1, 2];
+  return (command, args) => {
+    const rendered = [command, ...args].join(" ");
+    calls.push(rendered);
+    if (command === "xdpyinfo") {
+      const ready = displayProbe >= (options.displayReadyAfter ?? 0);
+      displayProbe += 1;
+      return ready ? { status: 0 } : { status: 1, stderr: "unable to open display :99" };
+    }
+    if (command === "wc") {
+      const size = recorderSizes[Math.min(recorderSizeProbe, recorderSizes.length - 1)];
+      recorderSizeProbe += 1;
+      return size === undefined
+        ? { status: 1, stderr: "No such file" }
+        : { status: 0, stdout: `${size} /tmp/live-proof.raw.webm\n` };
+    }
+    if (command === "tmux" && args[0] === "send-keys" && args.at(-1) === "q") {
+      finalizing = true;
+      return { status: 0 };
+    }
+    if (command === "tmux" && args[0] === "display-message") {
+      if (finalizing) {
+        const exited = finalizeProbe >= (options.finalizeExitAfter ?? 0);
+        finalizeProbe += 1;
+        return { status: 0, stdout: exited ? "1\n" : "0\n" };
+      }
+      const exited = recorderPaneProbe >= (options.recorderDiesAtProbe ?? Number.POSITIVE_INFINITY);
+      recorderPaneProbe += 1;
+      return { status: 0, stdout: exited ? "1\n" : "0\n" };
+    }
+    if (command === "tmux" && args[0] === "capture-pane") {
+      const target = String(args[args.indexOf("-t") + 1] ?? "");
+      const label = target.includes("-display")
+        ? "display"
+        : target.includes("-recorder")
+          ? "recorder"
+          : "terminal";
+      return { status: 0, stdout: `${options.paneOutput?.[label] ?? `${label} pane`}\n` };
     }
     return { status: 0 };
   };

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -31,7 +31,7 @@ test("every state hydration uses the canonical Worker with an explicit git-state
     }
   }
 
-  assert.equal(setups.length, 21, "setup-state site count is an audited invariant");
+  assert.equal(setups.length, 22, "setup-state site count is an audited invariant");
   for (const { site, step } of setups) {
     assert.equal(step.with?.["records-url"], workerUrl, site);
     assert.equal(step.with?.["records-secret"], workerSecret, site);
@@ -45,6 +45,7 @@ test("every state hydration uses the canonical Worker with an explicit git-state
       .map(({ site }) => site),
     [
       ".github/workflows/exact-review-batch-publish.yml:publish",
+      ".github/workflows/exact-review-batch-publish.yml:dispatch-live-proofs",
       ".github/workflows/live-proof.yml:attach",
       ".github/workflows/sweep.yml:event-review-apply",
       ".github/workflows/sweep.yml:event-review-publish",
@@ -69,6 +70,7 @@ test("per-target state hydration is slug-scoped while fleet lanes retain discove
       .map(({ site }) => site),
     [
       ".github/workflows/exact-review-batch-publish.yml:publish",
+      ".github/workflows/exact-review-batch-publish.yml:dispatch-live-proofs",
       ".github/workflows/live-proof.yml:attach",
       ".github/workflows/repair-cluster-intake.yml:intake",
       ".github/workflows/repair-cluster-worker.yml:cluster",


### PR DESCRIPTION
## Summary

The first production terminal live proof (openclaw/crabbox#1379, run 32017763576 — an organic, model-recommended dispatch from a fallback-profiled repo) failed with "terminal driver did not finalize a recording": ffmpeg launched against the xvfb display after a fixed one-second sleep, before Xvfb accepted connections, and died silently inside its detached tmux session.

The terminal driver now polls readiness at every boundary — `xdpyinfo` until the display accepts connections (30s bound), recorder output existence and growth (15s), and recorder exit after finalize (20s) — and attaches `tmux capture-pane` diagnostics from all three sessions to any failure. `x11-utils` joins the workflow's recording tools. All polling goes through the injected runner with tests covering slow display, late-appearing recorder files, dead recorders, and finalize waits.

Also registers the batch-publish dispatch lane's `setup-state` site in the state-writer audits — those two audits have been red on main since #1185 (the site itself met every invariant; only the audited inventory was missing the entry).

## Validation

- `pnpm build` clean; full unit suite 2,291 passed, 0 failed.
- state-writer audits 8/8 (previously 6/8 on main).
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.99)".
