### PR TITLE
feat(live-proof): record OpenClaw browser proofs against the mock control UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- OpenClaw browser live proofs run against the repository's mock control-UI dev server.
 - Folder reconciliation now defers with a zero-mutation result when the open-state scan hits GitHub rate limiting, so throttled proof/apply/publish runs proceed to their close and publication work instead of failing before `Apply close proposals` can run.
 - Comment-only sync now defers its remaining batch as a runtime-budget-style yield when GitHub rate limits a live read, instead of failing the scheduled run; the next 15-minute cycle resumes the interrupted item, and close-mode apply keeps its loud failure.
 - Close-mode apply now takes the same rate-limit yield as comment sync: a throttled live read mid-scan defers the remaining window to the next cycle instead of failing the run, after production runs kept losing 600-record scan windows to mid-run 403s.

--- a/src/repository-profiles.ts
+++ b/src/repository-profiles.ts
@@ -117,6 +117,17 @@ const CORE_OPENCLAW_PROFILE: RepositoryProfile = {
         reason !== "stale_version_bug",
     ),
   },
+  // Browser live proofs run against the repository's self-contained mock
+  // control-UI dev server, which needs no gateway, accounts, or credentials.
+  liveTest: {
+    enabled: true,
+    surfaceDefault: "browser",
+    setup: ["pnpm install --frozen-lockfile", "pnpm ui:install"],
+    start: "pnpm dev:ui:mock",
+    url: "http://127.0.0.1:5187",
+    readyTimeoutSeconds: 300,
+    maxRecordingSeconds: 90,
+  },
 };
 
 const TARGET_REPOSITORY_CONFIG = readTargetRepositoryConfig();

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -249,7 +249,15 @@ test("schema v2 generic fallbacks strictly validate and inherit optional live_te
 });
 
 test("configured and fallback-owned repositories expose their enabled live-proof surfaces", () => {
-  assert.deepEqual(repositoryProfileFor("openclaw/openclaw").liveTest, TERMINAL_LIVE_TEST);
+  assert.deepEqual(repositoryProfileFor("openclaw/openclaw").liveTest, {
+    enabled: true,
+    surfaceDefault: "browser",
+    setup: ["pnpm install --frozen-lockfile", "pnpm ui:install"],
+    start: "pnpm dev:ui:mock",
+    url: "http://127.0.0.1:5187",
+    readyTimeoutSeconds: 300,
+    maxRecordingSeconds: 90,
+  });
   assert.deepEqual(repositoryProfileFor("openclaw/openclaw-facetime").liveTest, TERMINAL_LIVE_TEST);
   assert.deepEqual(repositoryProfileFor("openclaw/fs-safe").liveTest, TERMINAL_LIVE_TEST);
   assert.deepEqual(repositoryProfileFor("openclaw/clawhub").liveTest, {


### PR DESCRIPTION
## Summary

Production live-proof telemetry shows OpenClaw reviews recommending browser demonstrations of its control UI (e.g. openclaw/openclaw#123507), which the terminal-only fallback profile safely skips. The OpenClaw core profile now runs browser live proofs against the repository's own mock control-UI dev server (`pnpm dev:ui:mock`, 127.0.0.1:5187) — self-contained, no gateway, no accounts, no credentials, matching the secretless execute-job invariant.

## Validation

- `pnpm build` clean; full unit suite green in parallel with review (exit 0, 209s).
- repository-profiles suite 15/15 with the surface-inventory expectation updated.
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.98)".
