### PR TITLE
fix(live-proof): serve the terminal display without X authorization

### DIFF
--- a/.github/workflows/live-proof.yml
+++ b/.github/workflows/live-proof.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install deterministic recording tools
         run: |
           sudo apt-get update
-          sudo apt-get install --yes ffmpeg tmux x11-utils xvfb xterm
+          sudo apt-get install --yes ffmpeg tmux x11-utils xfonts-base xvfb xterm
 
       - name: Check out the public PR head
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.
 - Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.
 - Routed every durable review-record publication lane through one shared, host-authenticated live-proof dispatcher, including queued exact-review batches grouped per target repository.
 - Exact-event reviews now dispatch recommended live proofs with host-repository credentials, while generic and configured OpenClaw and steipete profiles opt into browser or terminal proof as appropriate.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -30,7 +30,8 @@ contains no model call. Browser plans are serialized as JSON data into a
 generated plain `playwright-core` script; plan values are never inserted as
 source code. The script uses installed Chrome, a 1280x800 recorded context, and
 falls back to Playwright Chromium only when Chrome cannot launch. Terminal
-plans use tmux, `xvfb-run`, a fullscreen xterm, and ffmpeg `x11grab`; typed
+plans use tmux, an unauthenticated local Xvfb display with its TCP listener
+disabled, a fullscreen xterm, and ffmpeg `x11grab`; typed
 `run`, `wait`, and `expect_output` steps are replayed through the tmux pane.
 
 Both drivers finalize the recording after a mid-plan failure and record the

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -162,6 +162,7 @@ export function terminalCommandPlan(options: {
 }): TerminalCommandInvocation[] {
   const terminalSession = `${options.sessionPrefix}-terminal`;
   const displaySession = `${options.sessionPrefix}-display`;
+  const xtermSession = `${options.sessionPrefix}-xterm`;
   const recorderSession = `${options.sessionPrefix}-recorder`;
   return [
     {
@@ -183,9 +184,25 @@ export function terminalCommandPlan(options: {
         "-k",
         "-t",
         `${displaySession}:0.0`,
-        "xvfb-run",
-        "--server-num=99",
-        "--server-args=-screen 0 1280x800x24",
+        "Xvfb",
+        ":99",
+        "-screen",
+        "0",
+        "1280x800x24",
+        "-nolisten",
+        "tcp",
+      ],
+      waitAfter: "display",
+    },
+    {
+      command: "tmux",
+      args: [
+        "new-session",
+        "-d",
+        "-s",
+        xtermSession,
+        "env",
+        "DISPLAY=:99",
         "xterm",
         "-fullscreen",
         "-geometry",
@@ -196,7 +213,6 @@ export function terminalCommandPlan(options: {
         "-t",
         terminalSession,
       ],
-      waitAfter: "display",
     },
     {
       command: "tmux",
@@ -253,6 +269,7 @@ export function driveTerminal(options: {
   const sessionPrefix = `clawsweeper-live-proof-${process.pid}`;
   const terminalSession = `${sessionPrefix}-terminal`;
   const displaySession = `${sessionPrefix}-display`;
+  const xtermSession = `${sessionPrefix}-xterm`;
   const recorderSession = `${sessionPrefix}-recorder`;
   const log: LiveProofStepLogEntry[] = [];
   let failed = false;
@@ -295,10 +312,12 @@ export function driveTerminal(options: {
     thrown = terminalErrorWithDiagnostics(error, options.runner, options.checkout, {
       terminal: terminalSession,
       display: displaySession,
+      xterm: xtermSession,
       recorder: recorderSession,
     });
   } finally {
     options.runner("tmux", ["kill-session", "-t", recorderSession]);
+    options.runner("tmux", ["kill-session", "-t", xtermSession]);
     options.runner("tmux", ["kill-session", "-t", displaySession]);
     options.runner("tmux", ["kill-session", "-t", terminalSession]);
   }
@@ -411,7 +430,7 @@ function terminalErrorWithDiagnostics(
   error: unknown,
   runner: MediaProofCommandRunner,
   checkout: string,
-  sessions: Record<"terminal" | "display" | "recorder", string>,
+  sessions: Record<"terminal" | "display" | "xterm" | "recorder", string>,
 ): Error {
   const message = error instanceof Error ? error.message : String(error);
   const diagnostics = (Object.entries(sessions) as Array<[keyof typeof sessions, string]>).map(

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -196,7 +196,7 @@ test("Playwright generation keeps quotes, backticks, and newlines inside JSON da
   assert.equal(checked.status, 0, checked.stderr);
 });
 
-test("terminal driver composes tmux, xvfb-run, and bounded ffmpeg x11grab", () => {
+test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions", () => {
   const commands = terminalCommandPlan({
     sessionPrefix: "proof",
     entry: "pnpm cli --help",
@@ -207,15 +207,43 @@ test("terminal driver composes tmux, xvfb-run, and bounded ffmpeg x11grab", () =
     command: "tmux",
     args: ["new-session", "-d", "-s", "proof-terminal", "-x", "160", "-y", "50"],
   });
-  const display = commands.find((invocation) => invocation.args.includes("xvfb-run"));
+  const display = commands.find((invocation) => invocation.args.includes("Xvfb"));
+  const xterm = commands.find((invocation) => invocation.args.includes("xterm"));
   const recorder = commands.find((invocation) => invocation.args.includes("ffmpeg"));
-  assert.deepEqual(display?.args.slice(4, 8), [
-    "xvfb-run",
-    "--server-num=99",
-    "--server-args=-screen 0 1280x800x24",
-    "xterm",
+  assert.deepEqual(display?.args.slice(4), [
+    "Xvfb",
+    ":99",
+    "-screen",
+    "0",
+    "1280x800x24",
+    "-nolisten",
+    "tcp",
   ]);
   assert.equal(display?.waitAfter, "display");
+  assert.deepEqual(xterm, {
+    command: "tmux",
+    args: [
+      "new-session",
+      "-d",
+      "-s",
+      "proof-xterm",
+      "env",
+      "DISPLAY=:99",
+      "xterm",
+      "-fullscreen",
+      "-geometry",
+      "160x50+0+0",
+      "-e",
+      "tmux",
+      "attach-session",
+      "-t",
+      "proof-terminal",
+    ],
+  });
+  assert.equal(
+    commands.some((invocation) => invocation.args.includes("xvfb-run")),
+    false,
+  );
   assert.deepEqual(recorder?.args.slice(4, 13), [
     "timeout",
     "90s",
@@ -242,6 +270,7 @@ test("terminal driver reports display readiness timeout with all pane diagnostic
     paneOutput: {
       terminal: "terminal pane waiting",
       display: "display pane cold",
+      xterm: "xterm pane absent",
       recorder: "recorder pane absent",
     },
   });
@@ -252,12 +281,14 @@ test("terminal driver reports display readiness timeout with all pane diagnostic
       assert.match(error.message, /X display :99 was not ready after 30 seconds/);
       assert.match(error.message, /\[terminal: .*\]\nterminal pane waiting/);
       assert.match(error.message, /\[display: .*\]\ndisplay pane cold/);
+      assert.match(error.message, /\[xterm: .*\]\nxterm pane absent/);
       assert.match(error.message, /\[recorder: .*\]\nrecorder pane absent/);
       return true;
     },
   );
   assert.equal(calls.filter((call) => call === "xdpyinfo -display :99").length, 31);
   assert.equal(calls.filter((call) => call === "sleep 1").length, 30);
+  assert.ok(calls.some((call) => /tmux kill-session -t .*-xterm$/.test(call)));
 });
 
 test("terminal driver accepts a recorder file that appears and grows late", () => {
@@ -280,6 +311,7 @@ test("terminal driver reports a dead recorder with its pane diagnostics", () => 
     paneOutput: {
       terminal: "terminal pane ready",
       display: "display pane ready",
+      xterm: "xterm pane ready",
       recorder: "ffmpeg: cannot open display :99",
     },
   });
@@ -288,6 +320,7 @@ test("terminal driver reports a dead recorder with its pane diagnostics", () => 
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /recorder session exited before the raw WebM began growing/);
+      assert.match(error.message, /\[xterm: .*\]\nxterm pane ready/);
       assert.match(error.message, /\[recorder: .*\]\nffmpeg: cannot open display :99/);
       return true;
     },
@@ -721,7 +754,7 @@ function terminalLifecycleRunner(
     recorderSizes?: Array<number | undefined>;
     recorderDiesAtProbe?: number;
     finalizeExitAfter?: number;
-    paneOutput?: Record<"terminal" | "display" | "recorder", string>;
+    paneOutput?: Record<"terminal" | "display" | "xterm" | "recorder", string>;
   } = {},
 ): MediaProofCommandRunner {
   let displayProbe = 0;
@@ -763,9 +796,11 @@ function terminalLifecycleRunner(
       const target = String(args[args.indexOf("-t") + 1] ?? "");
       const label = target.includes("-display")
         ? "display"
-        : target.includes("-recorder")
-          ? "recorder"
-          : "terminal";
+        : target.includes("-xterm")
+          ? "xterm"
+          : target.includes("-recorder")
+            ? "recorder"
+            : "terminal";
       return { status: 0, stdout: `${options.paneOutput?.[label] ?? `${label} pane`}\n` };
     }
     return { status: 0 };


### PR DESCRIPTION
## Summary

Production diagnostics (openclaw/crabbox#1380 run 32022049214 and subsequent terminal dispatches) show the readiness probe and ffmpeg recorder refused by the display with "Authorization required, but no authorization protocol specified": `xvfb-run` protects Xvfb with an xauth cookie that processes outside its wrapper cannot present. The same diagnostics surfaced a missing default xterm bitmap font on hosted runners.

The terminal driver now starts `Xvfb :99 -screen 0 1280x800x24 -nolisten tcp` directly — an auth-less local display is safe here: the execute job is secretless by construction, the runner VM is ephemeral, and no TCP listener is bound — with xterm in its own tmux session pointed at the display via env, and the workflow installs `xfonts-base`. The readiness/finalize polling and three-pane diagnostics from #1186 are unchanged (they are what surfaced this root cause).

## Validation

- `pnpm build` clean; focused live-proof suite 18/18; full unit suite 2,291 passed, 0 failed.
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.98)".
