### PR TITLE
fix(workflow): publish hot-intake review comments

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4915,7 +4915,7 @@ jobs:
 
       - name: Sync selected review comments
         id: sync-selected-review-comments
-        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '') }}
+        if: ${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '' || needs.plan.outputs.hot_intake == 'true') }}
         timeout-minutes: 15
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -16,7 +16,14 @@ import test from "node:test";
 import YAML from "yaml";
 
 import { makeTreeReadOnlyForTest, restoreTreeModesForTest } from "../dist/clawsweeper.js";
-import { readText, tmpPrefix } from "./helpers.ts";
+import {
+  readText,
+  reportWithSyncedReviewComment,
+  runApplyDecisionsForTest,
+  tmpPrefix,
+  withMockGh,
+  workPlanCandidateReport,
+} from "./helpers.ts";
 import { scheduledReviewSemanticSourceRevision } from "../scripts/classify-scheduled-review-noop.ts";
 
 test("sweep keeps optional media tooling out of review startup", () => {
@@ -5476,6 +5483,155 @@ test("review publication routes hot intake once without changing other producers
       1,
       `${name}: exactly one terminal-publication route`,
     );
+  }
+
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const itemsDir = join(root, "items");
+    const closedDir = join(root, "closed");
+    const plansDir = join(root, "plans");
+    const reportPath = join(root, "apply-report.json");
+    const statePath = join(root, "comments.json");
+    const logPath = join(root, "gh.log");
+    const number = 125204;
+    const reviewedAt = "2026-08-17T10:30:00.000Z";
+    mkdirSync(itemsDir, { recursive: true });
+    mkdirSync(plansDir, { recursive: true });
+    const review = reportWithSyncedReviewComment(
+      workPlanCandidateReport({
+        repository: "openclaw/openclaw",
+        number,
+        title: "Hot intake publication regression",
+        reviewed_at: reviewedAt,
+        item_created_at: "2026-08-17T10:08:36.000Z",
+        item_updated_at: reviewedAt,
+        item_snapshot_hash: "reviewed-snapshot-125204",
+        labels: JSON.stringify([]),
+      }),
+      number,
+    );
+    writeFileSync(
+      join(itemsDir, `${number}.md`),
+      review.report.replaceAll(
+        `https://github.com/openclaw/clawsweeper/issues/${number}`,
+        `https://github.com/openclaw/openclaw/issues/${number}`,
+      ),
+      "utf8",
+    );
+    writeFileSync(
+      statePath,
+      JSON.stringify([
+        {
+          id: 9000 + number,
+          html_url: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${9000 + number}`,
+          created_at: "2026-08-17T10:31:00.000Z",
+          updated_at: "2026-08-17T10:31:00.000Z",
+          user: { login: "clawsweeper[bot]" },
+          body: review.comment.replace("queue_fix_pr", "stale_publication"),
+        },
+      ]),
+      "utf8",
+    );
+    writeFileSync(logPath, "", "utf8");
+
+    const ghMock = `
+const { appendFileSync, readFileSync, writeFileSync } = require("fs");
+const logPath = ${JSON.stringify(logPath)};
+const statePath = ${JSON.stringify(statePath)};
+const rawArgs = process.argv.slice(2);
+const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const path = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+const comments = JSON.parse(readFileSync(statePath, "utf8"));
+if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
+  console.log(JSON.stringify({
+    number: ${number},
+    title: "Hot intake publication regression",
+    body: "A recently created issue needs a review.",
+    html_url: "https://github.com/openclaw/openclaw/issues/${number}",
+    created_at: "2026-08-17T10:08:36.000Z",
+    updated_at: ${JSON.stringify(reviewedAt)},
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: [],
+    comments: comments.length,
+    pull_request: null
+  }));
+} else if (args[0] === "api" && /\\/issues\\/${number}\\/timeline(?:\\?|$)/.test(path)) {
+  console.log(JSON.stringify(args.includes("--slurp") ? [[]] : []));
+} else if (args[0] === "api" && /\\/issues\\/${number}\\/comments(?:\\?|$)/.test(path)) {
+  if (args.includes("--method") && args.includes("POST")) {
+    const input = args[args.indexOf("--input") + 1];
+    const body = JSON.parse(readFileSync(input, "utf8")).body;
+    const comment = {
+      id: 5315045852,
+      html_url: "https://github.com/openclaw/openclaw/issues/${number}#issuecomment-5315045852",
+      created_at: "2026-08-17T10:47:02.000Z",
+      updated_at: "2026-08-17T10:47:02.000Z",
+      user: { login: "clawsweeper[bot]" },
+      body
+    };
+    writeFileSync(statePath, JSON.stringify([comment]), "utf8");
+    console.log(JSON.stringify(comment));
+  } else {
+    console.log(JSON.stringify(args.includes("--slurp") ? [comments] : comments));
+  }
+} else if (args[0] === "api" && /\\/issues\\/comments\\/${9000 + number}$/.test(path) && args.includes("PATCH")) {
+  const input = args[args.indexOf("--input") + 1];
+  const body = JSON.parse(readFileSync(input, "utf8")).body;
+  const comment = { ...comments[0], body, updated_at: "2026-08-17T10:47:02.000Z" };
+  writeFileSync(statePath, JSON.stringify([comment]), "utf8");
+  console.log(JSON.stringify(comment));
+} else if (args[0] === "issue" && args[1] === "view") {
+  console.log(JSON.stringify({ closedByPullRequestsReferences: [] }));
+} else if (args[0] === "api" && /\\/collaborators\\/reporter\\/permission$/.test(path)) {
+  console.log(JSON.stringify({ permission: "read", role_name: "read" }));
+} else if (args[0] === "label" && args[1] === "create") {
+  console.log(JSON.stringify({ name: args[2] }));
+} else if (args[0] === "issue" && args[1] === "edit") {
+  console.log("");
+} else {
+  console.error("unexpected gh args", JSON.stringify(args));
+  process.exit(1);
+}
+`;
+    const broadHotRoute = routes({ event: "workflow_dispatch", hot: true });
+    assert.equal(broadHotRoute.selected, true);
+    assert.equal(broadHotRoute.background, false);
+    withMockGh(root, ghMock, () => {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        runApplyDecisionsForTest({
+          targetRepo: "openclaw/openclaw",
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--sync-comments-only", "--item-numbers", String(number)],
+        });
+      }
+    });
+
+    const calls = readFileSync(logPath, "utf8")
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as string[]);
+    const publications = calls.filter(
+      (args) => args[0] === "api" && (args.includes("POST") || args.includes("PATCH")),
+    );
+    assert.equal(
+      publications.length,
+      1,
+      `selected sync publishes once across a replay: ${readFileSync(reportPath, "utf8")}`,
+    );
+    const [published] = JSON.parse(readFileSync(statePath, "utf8")) as Array<{ body: string }>;
+    assert.match(published?.body ?? "", /clawsweeper-review item=125204/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 
   // Selected publication keeps using the existing exact artifact set and

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -5397,6 +5397,104 @@ test("target hot sweep dispatches honor shard cap payload", () => {
   assert.match(modeBlock, /shard_count="\$hot_intake_shards"/);
 });
 
+test("review publication routes hot intake once without changing other producers", () => {
+  type PublishStep = { name?: string; if?: string; run?: string };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: PublishStep[] }>;
+  };
+  const publishSteps = workflow.jobs.publish!.steps;
+  const step = (name: string) => {
+    const value = publishSteps.find((candidate) => candidate.name === name);
+    assert.ok(value, name);
+    return value;
+  };
+  const background = step("Dispatch background review comment sync");
+  const selected = step("Sync selected review comments");
+
+  assert.equal(
+    background.if,
+    "${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && needs.plan.outputs.hot_intake != 'true' && (github.event_name != 'repository_dispatch' || github.event.action == 'clawsweeper_target_sweep') && (github.event_name != 'workflow_dispatch' || (github.event.inputs.item_number == '' && github.event.inputs.item_numbers == '')) }}",
+  );
+  assert.equal(
+    selected.if,
+    "${{ always() && !cancelled() && steps.commit-review-records.outputs.records_published == 'true' && steps.target-write-token.outputs.token != '' && ((github.event_name == 'repository_dispatch' && github.event.action != 'clawsweeper_target_sweep') || github.event.inputs.item_number != '' || github.event.inputs.item_numbers != '' || needs.plan.outputs.hot_intake == 'true') }}",
+  );
+
+  type RouteInput = {
+    event: "workflow_dispatch" | "repository_dispatch" | "schedule";
+    action?: string;
+    hot: boolean;
+    itemNumber?: string;
+    itemNumbers?: string;
+  };
+  const routes = ({ event, action = "", hot, itemNumber = "", itemNumbers = "" }: RouteInput) => ({
+    background:
+      !hot &&
+      (event !== "repository_dispatch" || action === "clawsweeper_target_sweep") &&
+      (event !== "workflow_dispatch" || (itemNumber === "" && itemNumbers === "")),
+    selected:
+      (event === "repository_dispatch" && action !== "clawsweeper_target_sweep") ||
+      itemNumber !== "" ||
+      itemNumbers !== "" ||
+      hot,
+  });
+  const scenarios: Array<[string, RouteInput, "background" | "selected"]> = [
+    ["broad hot workflow dispatch", { event: "workflow_dispatch", hot: true }, "selected"],
+    ["normal workflow dispatch", { event: "workflow_dispatch", hot: false }, "background"],
+    [
+      "explicit item workflow dispatch",
+      { event: "workflow_dispatch", hot: false, itemNumber: "125204" },
+      "selected",
+    ],
+    [
+      "explicit items workflow dispatch",
+      { event: "workflow_dispatch", hot: false, itemNumbers: "125204,125205" },
+      "selected",
+    ],
+    [
+      "hot target repository dispatch",
+      { event: "repository_dispatch", action: "clawsweeper_target_sweep", hot: true },
+      "selected",
+    ],
+    [
+      "normal target repository dispatch",
+      { event: "repository_dispatch", action: "clawsweeper_target_sweep", hot: false },
+      "background",
+    ],
+    [
+      "exact repository dispatch",
+      { event: "repository_dispatch", action: "clawsweeper_exact_review", hot: false },
+      "selected",
+    ],
+    ["scheduled background review", { event: "schedule", hot: false }, "background"],
+  ];
+  for (const [name, input, expected] of scenarios) {
+    const result = routes(input);
+    assert.equal(result[expected], true, `${name}: expected ${expected}`);
+    assert.equal(
+      Number(result.background) + Number(result.selected),
+      1,
+      `${name}: exactly one terminal-publication route`,
+    );
+  }
+
+  // Selected publication keeps using the existing exact artifact set and
+  // canonical mutation path, so the fix does not bypass its lease/fencing and
+  // idempotent comment-update behavior or its immutable action ledger.
+  assert.match(selected.run ?? "", /begin_canonical_record_mutation/);
+  assert.match(selected.run ?? "", /artifact-item-numbers --artifact-dir artifacts/);
+  assert.match(selected.run ?? "", /--item-numbers "\$item_numbers"/);
+  assert.match(selected.run ?? "", /--sync-comments-only/);
+  assert.match(
+    step("Finalize selected review comment action ledger").if ?? "",
+    /steps\.sync-selected-review-comments\.outcome != 'skipped'/,
+  );
+  assert.match(
+    step("Publish selected review comment action ledger").run ?? "",
+    /publish-action-events/,
+  );
+});
+
 test("scheduled reviews feed the durable queue instead of one-item matrix workers", () => {
   const workflow = readText(".github/workflows/sweep.yml");
   const modeBlock = workflow.slice(


### PR DESCRIPTION
## Summary

- route broad hot-intake review results through the existing selected-comment publication path
- keep the background comment-sync route exclusive to non-hot broad work
- add a production-shaped routing and publication regression covering hot intake, explicit items, repository dispatch, scheduled/background producers, and replay idempotency

## Problem

The broad `workflow_dispatch` hot-intake path has no `item_number` or `item_numbers` input. After its review artifacts were committed, `Dispatch background review comment sync` excluded hot intake while `Sync selected review comments` required an explicit item or a non-target repository dispatch. Both terminal-comment routes therefore evaluated false.

This was observed on [openclaw/openclaw#125204](https://github.com/openclaw/openclaw/issues/125204): intake and the model/artifact run completed, but the broad hot workflow skipped both comment-sync steps. Its valid start lease then delayed the exact worker until expiry; the terminal response was eventually published roughly 38 minutes after issue creation.

## Implementation

`Sync selected review comments` now also selects `needs.plan.outputs.hot_intake == 'true'`. It reuses the existing target-write token, sync implementation, canonical state publication, action ledger, fencing, retry, and idempotency behavior. No queue, lease, credential, or publication implementation changes are introduced.

The regression asserts exactly one terminal sync route for:

- broad workflow-dispatch hot intake
- normal broad workflow dispatch
- explicit item and item-list dispatches
- hot and normal target repository dispatches
- exact-item repository dispatch
- scheduled background review

It also executes the real `apply-decisions --sync-comments-only` boundary twice against controlled GitHub state: the first pass publishes the final ClawSweeper comment and the replay is a no-op. Existing lease/fencing and immutable-ledger suites remain unchanged and pass.

## Validation

- `pnpm run build:all`
- focused Node test: `review publication routes hot intake once without changing other producers`
- `node --test --test-concurrency=1 test/sweep-workflow.test.ts` — 121/121 passed on Linux
- focused apply-label lease/fencing suite — 4/4 passed
- focused action-ledger idempotency suite — 2/2 passed
- `pnpm exec oxfmt --check .github/workflows/sweep.yml test/sweep-workflow.test.ts`
- YAML parse of `.github/workflows/sweep.yml`
- actionlint v1.7.12, pinned release archive SHA-256 and repository config
- `git diff --check origin/main...HEAD`

## Real Behavior Proof

**Claim:** A no-item broad hot-intake run selects the synchronous terminal-comment route exactly once; it does not select the background route. Other producer routes retain their prior ownership.

**Exercised surface:** exact committed `.github/workflows/sweep.yml`, its parsed GitHub Actions conditions, the real selected `apply-decisions --sync-comments-only` publication boundary, and the existing lease/fencing/idempotency suites.

**Scenario/fixture:** the routing matrix evaluates production event/input shapes for hot and normal workflow dispatch, explicit items, target and exact repository dispatch, and schedule. A controlled openclaw/openclaw#125204-shaped record begins with a stale bot comment; the selected sync runs twice through the real apply entry point against a stateful `gh` boundary.

**Command/environment:** AWS Crabbox Linux (`c7a.8xlarge`), provider `aws`, run `run_89cc583b9849`, lease `cbx_c29a3f86d9f1`, exact head `4c4deccf2a6beff08c7d5f1478ea1fc2ac0f5b0c`, base `69adf7592803cc1440162b049fbf572be66fdd12`. Both changed files were SHA-256 checked against their committed blobs before execution.

**Observed result:** before: broad hot intake `selected=false`, `background=false`; after: `selected=true`, `background=false`. The first real apply pass performed one final-comment mutation; the replay performed none, leaving exactly one terminal ClawSweeper comment. All 121 workflow tests, four lease/fencing tests, two ledger idempotency tests, formatting, YAML parse, pinned actionlint, and exact-content checks passed.

**Artifact/trace:** [Crabbox run `run_89cc583b9849`](https://crabbox.openclaw.ai/portal/runs/run_89cc583b9849), lease `cbx_c29a3f86d9f1`; terminal proof line: `CSW-132 Linux hot-intake publication boundary proof: PASS`.

**Live GitHub Actions proof:** With Martin's explicit authorization, one bounded real `workflow_dispatch` ran on this PR branch and exact head: [run `32035557210`](https://github.com/openclaw/clawsweeper/actions/runs/32035557210). Inputs were `hot_intake=true`, `target_repo=openclaw/slacrawl`, `batch_size=2`, `shard_count=1`, no `item_number` or `item_numbers`, and `apply_existing=false` / `apply_after_review=false`. The planner selected only [openclaw/slacrawl#152](https://github.com/openclaw/slacrawl/pull/152), reported planned count 1 below its effective capacity 44, and therefore skipped continuation. Its model review completed, artifact publication succeeded, `Dispatch background review comment sync` was skipped, and the fixed `Sync selected review comments` succeeded. The real `apply-decisions --sync-comments-only` result was exactly `review_comment_synced: 1`; it updated the existing durable ClawSweeper comment on #152 at 2026-08-17T13:35:41Z. No close/apply operation ran, no issue-implementation candidate existed, and the optional live-proof dispatcher found no enabled proof request.

**Limits:** The live proof deliberately used a single public PR outside openclaw/openclaw to avoid the enabled issue-implementation producer. It proves the actual GitHub Actions condition, branch-loaded workflow, target token, canonical record path, callback, and final comment publication once. The deterministic matrix supplies the replay/no-double-publish guarantee. The optional `pr-behavior-proof` skill named by workspace policy was unavailable in this session, so its contract is reproduced explicitly here.

**Current review infrastructure status:** The current-head `@clawsweeper re-review` command was accepted after this proof, but its normal comment-router run failed before a verdict when GitHub returned HTTP 503 to its authenticated `gh api user` check. A direct authenticated API check from the operator host reproduced the same 503, while the PR remains `CLEAN` at the exact head above. This is an infrastructure-only review blocker, not a patch finding. No duplicate review command, manual workflow rerun, queue action, deployment, or production control change will be made; the next step is the normal current-head/current-body re-review after GitHub API recovery.

## Reviews

- dirty Codex review: clean after the production-shaped apply/replay regression was added
- committed Codex review against exact base `69adf7592803cc1440162b049fbf572be66fdd12`: clean; confirmed the selected route, mutually exclusive background route, and replay idempotency
- local ClawSweeper committed-range review: `decision=keep_open`, `confidence=high`, `action=kept_open`; no GitHub mutation

## Risks and rollout

Risk is limited to broad hot-intake result publication. A successful hot run can now perform the same bounded selected-comment sync already used by exact/explicit producers. The matrix guards against double publication and unintended changes to target, exact, scheduled, and normal broad routes.

Rollback is a one-line revert removing the hot-intake disjunct from the selected-sync condition. No state migration or queue repair is required.

This PR changes a GitHub Actions workflow and therefore requires maintainer credentials with workflow scope to update. It does not address the separate OpenClaw Bay projection timeout/fail-closed behavior or the durable-lifecycle over-cap condition.

## Related

- CSW-132 missing-review and Bay incident investigation
- [openclaw/openclaw#125204](https://github.com/openclaw/openclaw/issues/125204)
