### PR TITLE
fix(live-proof): fall back to a single poster frame for short recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Short live-proof recordings fall back to a single poster frame when the contact-sheet tile cannot emit one.
 - Terminal recorders flush WebM packets immediately and treat a live ffmpeg session as healthy while the muxer buffers.
 - Terminal live-proof recordings tune VP9 for realtime capture and accept the recorder once any payload is written, matching the encoder's bursty muxer output.
 - OpenClaw browser live proofs run against the repository's mock control-UI dev server.

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -147,8 +147,20 @@ export async function executeLiveProof(
         `live proof recording exceeds configured ${liveTest.maxRecordingSeconds}-second cap`,
       );
     }
-    const poster = createVideoContactSheet(mp4Path, posterPath, runner);
-    requireSuccess("ffmpeg", ["contact-sheet", mp4Path], poster);
+    // The contact-sheet tile needs ~100 seconds of sampled video before some
+    // ffmpeg builds emit a frame, so short recordings fall back to a single
+    // poster frame near the start of the demonstration.
+    createVideoContactSheet(mp4Path, posterPath, runner);
+    if (!existsSync(posterPath)) {
+      for (const offset of ["1", "0"]) {
+        const frame = runner(
+          "ffmpeg",
+          ["-hide_banner", "-y", "-ss", offset, "-i", mp4Path, "-frames:v", "1", "-vf", "scale=640:-1", posterPath],
+          { cwd: checkout },
+        );
+        if (frame.status === 0 && existsSync(posterPath)) break;
+      }
+    }
     if (!existsSync(posterPath)) throw new Error("ffmpeg did not create poster.jpg");
 
     writeFileSync(stepsLogPath, `${JSON.stringify(drive.steps, null, 2)}\n`, "utf8");


### PR DESCRIPTION
## Summary

With the recorder fixed (#1191), terminal live proofs progressed to poster generation and failed there: the contact-sheet filter (`fps=1/5,tile=5x4`) needs ~100 seconds of sampled video before hosted ffmpeg builds emit a tile, and short demonstrations produced no poster at all (openclaw/openclaw#110714, run 32028028690; local ffmpeg 7 flushes a partial tile, runner ffmpeg 6 does not). Short recordings now fall back to a single scaled frame near the start of the demonstration, keeping the strict existence check.

## Validation

- `pnpm build` clean; live-proof suite 18/18.
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.98)".
