### PR TITLE
Restore live-proof formatting checks

### DIFF
--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -369,9 +369,7 @@ function waitForRecorder(
     if (elapsed >= RECORDER_READY_TIMEOUT_SECONDS) return;
     pollSleep(runner);
   }
-  throw new Error(
-    `raw WebM was not written within ${RECORDER_READY_TIMEOUT_SECONDS} seconds`,
-  );
+  throw new Error(`raw WebM was not written within ${RECORDER_READY_TIMEOUT_SECONDS} seconds`);
 }
 
 function finalizeRecorder(

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -155,7 +155,19 @@ export async function executeLiveProof(
       for (const offset of ["1", "0"]) {
         const frame = runner(
           "ffmpeg",
-          ["-hide_banner", "-y", "-ss", offset, "-i", mp4Path, "-frames:v", "1", "-vf", "scale=640:-1", posterPath],
+          [
+            "-hide_banner",
+            "-y",
+            "-ss",
+            offset,
+            "-i",
+            mp4Path,
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=640:-1",
+            posterPath,
+          ],
           { cwd: checkout },
         );
         if (frame.status === 0 && existsSync(posterPath)) break;


### PR DESCRIPTION
Two recently merged live-proof changes no longer match the repository formatter, leaving `main` red and blocking otherwise unrelated PRs. This PR applies the configured formatter to those two files; runtime behavior is unchanged.

## Proof

- `pnpm run format:check` passes across all 741 matched files.
- The net diff is formatter-only: one wrapped error expression and one expanded `ffmpeg` argument list.
- `pnpm run check` reached coverage tests, then the local host exhausted temporary coverage space (`ENOSPC`). GitHub CI provides the clean-runner result.

OpenClaw Bay is unaffected because this changes formatting only; no lifecycle, queue, status, telemetry, or dashboard contract changes.