### PR TITLE
fix(live-proof): retry canonical publication conflicts before syncing the comment

### DIFF
--- a/.github/workflows/live-proof.yml
+++ b/.github/workflows/live-proof.yml
@@ -205,10 +205,8 @@ jobs:
         run: |
           set -euo pipefail
           record="records/${{ needs.execute.outputs.repo_slug }}/items/${{ needs.execute.outputs.item }}.md"
-          node dist/clawsweeper.js live-proof-attach \
+          node dist/clawsweeper.js live-proof-attach-publish \
             --bundle live-proof-bundle \
-            --record "$record"
-          pnpm run repair:publish-main -- \
-            --message "chore: attach live proof" \
-            --path "$record" \
-            --rebase-strategy normal
+            --record "$record" \
+            --repo-slug "${{ needs.execute.outputs.repo_slug }}" \
+            --item "${{ needs.execute.outputs.item }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Live-proof attachment now retries canonical publication conflicts from fresh single-record state and updates the public review comment only after the record lands.
 - Short live-proof recordings fall back to a single poster frame when the contact-sheet tile cannot emit one.
 - Terminal recorders flush WebM packets immediately and treat a live ffmpeg session as healthy while the muxer buffers.
 - Terminal live-proof recordings tune VP9 for realtime capture and accept the recorder once any payload is written, matching the encoder's bursty muxer output.

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -67,6 +67,10 @@ import {
 } from "./clawsweeper-item-policy.js";
 import { createLabelPolicy } from "./clawsweeper-label-policy.js";
 import { createLiveProofCommands } from "./live-proof/commands.js";
+import {
+  isCanonicalPublicationConflict,
+  publishLiveProofAttachment,
+} from "./live-proof/publication.js";
 import { createRepositoryLinks } from "./clawsweeper-links.js";
 import { createLocalRangeReviewer } from "./clawsweeper-local-review.js";
 import { createPlanCommand } from "./clawsweeper-plan-command.js";
@@ -1477,7 +1481,6 @@ const liveProofCommands = createLiveProofCommands({
     renderReviewCommentFromReport: reportOrchestration.renderReviewCommentFromReport,
     markedReviewCommentBody: reviewCommentWorkflow.markedReviewCommentBody,
     upsertReviewComment: reviewCommentWorkflow.upsertReviewComment,
-    updateReviewCommentMetadata: reviewCommentWorkflow.updateReviewCommentMetadata,
   },
 });
 
@@ -1493,6 +1496,68 @@ async function liveProofAttachCommand(args: Args): Promise<void> {
   await liveProofCommands.liveProofAttachCommand(args);
 }
 
+async function liveProofAttachPublishCommand(args: Args): Promise<void> {
+  const recordPath = stringArg(args.record, "");
+  const repoSlug = stringArg(args.repo_slug, "").trim();
+  const itemText = stringArg(args.item ?? args.item_number, "").trim();
+  const item = Number(itemText);
+  if (!recordPath) throw new Error("--record is required");
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(repoSlug)) {
+    throw new Error("--repo-slug is required and must be a canonical repository slug");
+  }
+  if (!/^\d+$/.test(itemText) || !Number.isSafeInteger(item) || item < 1) {
+    throw new Error("--item requires a positive safe integer");
+  }
+  const recordsUrl = process.env.QUEUE_URL?.trim() || "https://clawsweeper.openclaw.ai";
+
+  await publishLiveProofAttachment({
+    hydrateRecord: () => {
+      runText(
+        process.execPath,
+        [
+          join(ROOT, "scripts", "hydrate-state.ts"),
+          "--worktree",
+          ROOT,
+          "--records-url",
+          recordsUrl,
+          "--records-repo-slugs",
+          repoSlug,
+          "--records-item-number",
+          String(item),
+          "--skip-state-blobs",
+          "--skip-git-state",
+        ],
+        { cwd: ROOT, trim: "none" },
+      );
+    },
+    attachRecord: async () => {
+      const markdown = readFileSync(resolve(recordPath), "utf8");
+      const repo = frontMatterValue(markdown, "repository");
+      if (repo) setTargetRepo(repo);
+      return liveProofCommands.liveProofAttachCommand(args);
+    },
+    publishRecord: () => {
+      runText(
+        "pnpm",
+        [
+          "run",
+          "repair:publish-main",
+          "--",
+          "--message",
+          "chore: attach live proof",
+          "--path",
+          recordPath,
+          "--rebase-strategy",
+          "normal",
+        ],
+        { cwd: ROOT, trim: "none" },
+      );
+    },
+    syncComment: () => liveProofCommands.liveProofCommentCommand(args),
+    isCanonicalConflict: isCanonicalPublicationConflict,
+  });
+}
+
 const COMMAND_HANDLERS: Readonly<Record<string, CommandHandler<Args>>> = {
   plan: planCommand,
   "reserve-review-lease": reserveReviewLeaseCommand,
@@ -1501,6 +1566,7 @@ const COMMAND_HANDLERS: Readonly<Record<string, CommandHandler<Args>>> = {
   "apply-artifacts": applyArtifactsCommand,
   "live-proof": liveProofCommand,
   "live-proof-attach": liveProofAttachCommand,
+  "live-proof-attach-publish": liveProofAttachPublishCommand,
   "apply-decisions": applyDecisionsCommand,
   "publish-action-events": publishActionEventsCommand,
   "publish-action-event-paths": publishActionEventPathsCommand,

--- a/src/live-proof/attach.ts
+++ b/src/live-proof/attach.ts
@@ -27,18 +27,15 @@ export interface LiveProofAttachDependencies {
   renderReviewCommentFromReport: (markdown: string, closeReason: CloseReason) => string;
   markedReviewCommentBody: (number: number, body: string) => string;
   upsertReviewComment: (number: number, body: string) => Record<string, unknown> | undefined;
-  updateReviewCommentMetadata: (
-    markdown: string,
-    comment: Record<string, unknown> | undefined,
-    body: string,
-  ) => string;
   log?: (message: string) => void;
 }
+
+export type LiveProofAttachResult = "attached" | "skipped" | "dry-run";
 
 export async function attachLiveProof(
   options: LiveProofAttachOptions,
   dependencies: LiveProofAttachDependencies,
-): Promise<void> {
+): Promise<LiveProofAttachResult> {
   const env = dependencies.env ?? process.env;
   const runner = dependencies.runner ?? mediaProofCommandRunner;
   const log = dependencies.log ?? console.log;
@@ -64,7 +61,7 @@ export async function attachLiveProof(
       log(
         `[live-proof-attach] skip: ${manifest.repo}#${manifest.item} is not an open pull request`,
       );
-      return;
+      return "skipped";
     }
     liveHead = pull.headSha?.toLowerCase() ?? "";
   }
@@ -72,7 +69,7 @@ export async function attachLiveProof(
     log(
       `[live-proof-attach] skip: stale proof head ${manifest.head_sha} does not match live head ${liveHead || "unknown"}`,
     );
-    return;
+    return "skipped";
   }
 
   const upload = trustedUploadConfiguration(env, manifest);
@@ -107,7 +104,7 @@ export async function attachLiveProof(
     log(
       `[live-proof-attach] dry-run: upsert marker-backed review comment for ${manifest.repo}#${manifest.item}:\n${markedComment}`,
     );
-    return;
+    return "dry-run";
   }
 
   for (const candidate of uploads) {
@@ -117,15 +114,38 @@ export async function attachLiveProof(
       throw new Error(`aws s3 cp failed: ${mediaProofSpawnDetail(result)}`);
     }
   }
-  const publishedComment = dependencies.upsertReviewComment(manifest.item, markedComment);
-  updatedReport = dependencies.updateReviewCommentMetadata(
-    updatedReport,
-    publishedComment,
-    markedComment,
-  );
   writeFileSync(recordPath, updatedReport, "utf8");
   log(
-    `[live-proof-attach] attached ${manifest.surface} proof for ${manifest.repo}#${manifest.item} at ${manifest.head_sha}`,
+    `[live-proof-attach] prepared ${manifest.surface} proof for ${manifest.repo}#${manifest.item} at ${manifest.head_sha}`,
+  );
+  return "attached";
+}
+
+export function syncLiveProofComment(
+  options: Pick<LiveProofAttachOptions, "bundleDir" | "recordPath">,
+  dependencies: LiveProofAttachDependencies,
+): void {
+  const bundleDir = resolve(options.bundleDir);
+  const recordPath = resolve(options.recordPath);
+  const manifest = parseLiveProofManifest(
+    JSON.parse(readFileSync(join(bundleDir, "live-proof-manifest.json"), "utf8")) as unknown,
+  );
+  const report = readFileSync(recordPath, "utf8");
+  validateReportIdentity(report, manifest, dependencies.frontMatterValue);
+  if (
+    !dependencies
+      .sectionValue(report, dependencies.reviewSections.liveProof)
+      .includes(LIVE_PROOF_RECORDING_MARKER)
+  ) {
+    throw new Error("record is missing the attached Live Proof recording");
+  }
+  const closeReason = (dependencies.frontMatterValue(report, "close_reason") ??
+    "none") as CloseReason;
+  const comment = dependencies.renderReviewCommentFromReport(report, closeReason);
+  const markedComment = dependencies.markedReviewCommentBody(manifest.item, comment);
+  dependencies.upsertReviewComment(manifest.item, markedComment);
+  (dependencies.log ?? console.log)(
+    `[live-proof-attach] synced marker-backed review comment for ${manifest.repo}#${manifest.item}`,
   );
 }
 

--- a/src/live-proof/commands.ts
+++ b/src/live-proof/commands.ts
@@ -1,7 +1,11 @@
 import { boolArg, stringArg, type Args } from "../clawsweeper-args.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../clawsweeper-types.js";
 import type { RepositoryProfile } from "../repository-profiles.js";
-import { attachLiveProof, type LiveProofAttachDependencies } from "./attach.js";
+import {
+  attachLiveProof,
+  syncLiveProofComment,
+  type LiveProofAttachDependencies,
+} from "./attach.js";
 import {
   executeLiveProof,
   type LiveProofExecuteDependencies,
@@ -51,10 +55,10 @@ export function createLiveProofCommands(dependencies: LiveProofCommandDependenci
     );
   }
 
-  async function liveProofAttachCommand(args: Args): Promise<void> {
+  async function liveProofAttachCommand(args: Args) {
     const bundleDir = requiredArg(args.bundle, "--bundle");
     const recordPath = requiredArg(args.record, "--record");
-    await attachLiveProof(
+    return attachLiveProof(
       {
         bundleDir,
         recordPath,
@@ -70,7 +74,22 @@ export function createLiveProofCommands(dependencies: LiveProofCommandDependenci
     );
   }
 
-  return { liveProofCommand, liveProofAttachCommand };
+  function liveProofCommentCommand(args: Args): void {
+    const bundleDir = requiredArg(args.bundle, "--bundle");
+    const recordPath = requiredArg(args.record, "--record");
+    syncLiveProofComment(
+      { bundleDir, recordPath },
+      {
+        ...dependencies.attach,
+        fetchPullRequest,
+        ...(dependencies.runner ? { runner: dependencies.runner } : {}),
+        ...(dependencies.env ? { env: dependencies.env } : {}),
+        ...(dependencies.log ? { log: dependencies.log } : {}),
+      },
+    );
+  }
+
+  return { liveProofCommand, liveProofAttachCommand, liveProofCommentCommand };
 }
 
 export async function fetchGitHubPullRequest(

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -369,9 +369,7 @@ function waitForRecorder(
     if (elapsed >= RECORDER_READY_TIMEOUT_SECONDS) return;
     pollSleep(runner);
   }
-  throw new Error(
-    `raw WebM was not written within ${RECORDER_READY_TIMEOUT_SECONDS} seconds`,
-  );
+  throw new Error(`raw WebM was not written within ${RECORDER_READY_TIMEOUT_SECONDS} seconds`);
 }
 
 function finalizeRecorder(

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -155,7 +155,19 @@ export async function executeLiveProof(
       for (const offset of ["1", "0"]) {
         const frame = runner(
           "ffmpeg",
-          ["-hide_banner", "-y", "-ss", offset, "-i", mp4Path, "-frames:v", "1", "-vf", "scale=640:-1", posterPath],
+          [
+            "-hide_banner",
+            "-y",
+            "-ss",
+            offset,
+            "-i",
+            mp4Path,
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=640:-1",
+            posterPath,
+          ],
           { cwd: checkout },
         );
         if (frame.status === 0 && existsSync(posterPath)) break;

--- a/src/live-proof/publication.ts
+++ b/src/live-proof/publication.ts
@@ -1,0 +1,63 @@
+import type { LiveProofAttachResult } from "./attach.js";
+
+export const LIVE_PROOF_PUBLICATION_ATTEMPTS = 3;
+export const LIVE_PROOF_PUBLICATION_BACKOFF_MS = 1_000;
+
+export interface LiveProofPublicationDependencies {
+  hydrateRecord: () => Promise<void> | void;
+  attachRecord: () => Promise<LiveProofAttachResult>;
+  publishRecord: () => Promise<void> | void;
+  syncComment: () => Promise<void> | void;
+  isCanonicalConflict: (error: unknown) => boolean;
+  delay?: (milliseconds: number) => Promise<void>;
+  log?: (message: string) => void;
+}
+
+export async function publishLiveProofAttachment(
+  dependencies: LiveProofPublicationDependencies,
+): Promise<LiveProofAttachResult> {
+  const delay =
+    dependencies.delay ??
+    ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  const log = dependencies.log ?? console.log;
+
+  for (let attempt = 1; attempt <= LIVE_PROOF_PUBLICATION_ATTEMPTS; attempt += 1) {
+    await dependencies.hydrateRecord();
+    const outcome = await dependencies.attachRecord();
+    if (outcome !== "attached") return outcome;
+
+    try {
+      await dependencies.publishRecord();
+    } catch (error) {
+      if (!dependencies.isCanonicalConflict(error) || attempt === LIVE_PROOF_PUBLICATION_ATTEMPTS) {
+        throw error;
+      }
+      log(
+        `[live-proof-attach] canonical publication conflicted on attempt ${attempt}/${LIVE_PROOF_PUBLICATION_ATTEMPTS}; rehydrating before retry`,
+      );
+      await delay(LIVE_PROOF_PUBLICATION_BACKOFF_MS * attempt);
+      continue;
+    }
+
+    await dependencies.syncComment();
+    return outcome;
+  }
+
+  throw new Error("live proof publication exhausted its retry loop");
+}
+
+export function isCanonicalPublicationConflict(error: unknown): boolean {
+  return errorText(error).includes("Canonical publication conflicted for all");
+}
+
+function errorText(error: unknown): string {
+  if (!error || typeof error !== "object") return String(error);
+  const candidate = error as { message?: unknown; stdout?: unknown; stderr?: unknown };
+  return [candidate.message, candidate.stdout, candidate.stderr].map(commandOutputText).join("\n");
+}
+
+function commandOutputText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString("utf8");
+  return "";
+}

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -9,7 +9,7 @@ import YAML from "yaml";
 import { REVIEW_SECTIONS } from "../dist/clawsweeper-policy.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
 import type { RepositoryProfile } from "../dist/repository-profiles.js";
-import { attachLiveProof } from "../dist/live-proof/attach.js";
+import { attachLiveProof, syncLiveProofComment } from "../dist/live-proof/attach.js";
 import {
   driveTerminal,
   generatePlaywrightScript,
@@ -17,6 +17,10 @@ import {
 } from "../dist/live-proof/drivers.js";
 import { executeLiveProof } from "../dist/live-proof/execute.js";
 import { parseLiveProofManifest } from "../dist/live-proof/manifest.js";
+import {
+  isCanonicalPublicationConflict,
+  publishLiveProofAttachment,
+} from "../dist/live-proof/publication.js";
 
 const HEAD = "0123456789abcdef0123456789abcdef01234567";
 
@@ -386,7 +390,7 @@ test("live-proof attach refuses stale heads before upload or publication", async
   assert.match(fixture.logs.join("\n"), /skip: stale proof head/);
 });
 
-test("live-proof attach constructs trusted URLs, uploads, rewrites the report, and re-upserts", async () => {
+test("live-proof attach publishes the record before syncing its marker-backed comment", async () => {
   const fixture = attachmentFixture();
   const commands: string[] = [];
   let publishedBody = "";
@@ -412,9 +416,96 @@ test("live-proof attach constructs trusted URLs, uploads, rewrites the report, a
   const report = readFileSync(fixture.recordPath, "utf8");
   assert.match(report, /<!-- clawsweeper-live-proof-recording -->/);
   assert.match(report, /https:\/\/media\.example\.test\/live-proof\/example-repo\/42\//);
-  assert.match(report, /<!-- comment metadata updated -->/);
+  assert.equal(publishedBody, "");
+  syncLiveProofComment(
+    { bundleDir: fixture.bundleDir, recordPath: fixture.recordPath },
+    attachDependencies({
+      runner: mediaRunner(commands),
+      fetchPullRequest: async () => ({ kind: "pull_request", state: "open", headSha: HEAD }),
+      upsertReviewComment: (_number, body) => {
+        publishedBody = body;
+        return { id: 99, html_url: "https://github.com/example/repo/pull/42#issuecomment-99" };
+      },
+      logs: fixture.logs,
+    }),
+  );
   assert.match(publishedBody, /### Live Proof/);
   assert.match(publishedBody, /<!-- clawsweeper-review item=42 -->/);
+});
+
+test("live-proof publication rehydrates and retries a canonical conflict without duplicate comment upserts", async () => {
+  const calls: string[] = [];
+  let publications = 0;
+  let commentUpserts = 0;
+  const result = await publishLiveProofAttachment({
+    hydrateRecord: () => calls.push("hydrate"),
+    attachRecord: async () => {
+      calls.push("attach");
+      return "attached";
+    },
+    publishRecord: () => {
+      calls.push("publish");
+      publications += 1;
+      if (publications === 1) throw canonicalPublicationConflict();
+    },
+    syncComment: () => {
+      calls.push("comment");
+      commentUpserts += 1;
+    },
+    isCanonicalConflict: isCanonicalPublicationConflict,
+    delay: async () => undefined,
+    log: () => undefined,
+  });
+
+  assert.equal(result, "attached");
+  assert.deepEqual(calls, [
+    "hydrate",
+    "attach",
+    "publish",
+    "hydrate",
+    "attach",
+    "publish",
+    "comment",
+  ]);
+  assert.equal(commentUpserts, 1);
+});
+
+test("live-proof publication fails loudly after three canonical conflicts", async () => {
+  let hydrations = 0;
+  let attachments = 0;
+  let publications = 0;
+  let commentUpserts = 0;
+
+  await assert.rejects(
+    publishLiveProofAttachment({
+      hydrateRecord: () => {
+        hydrations += 1;
+      },
+      attachRecord: async () => {
+        attachments += 1;
+        return "attached";
+      },
+      publishRecord: () => {
+        publications += 1;
+        throw canonicalPublicationConflict();
+      },
+      syncComment: () => {
+        commentUpserts += 1;
+      },
+      isCanonicalConflict: isCanonicalPublicationConflict,
+      delay: async () => undefined,
+      log: () => undefined,
+    }),
+    (error) =>
+      typeof error === "object" &&
+      error !== null &&
+      "stderr" in error &&
+      String(error.stderr).includes("Canonical publication conflicted for all 1 item(s)"),
+  );
+  assert.equal(hydrations, 3);
+  assert.equal(attachments, 3);
+  assert.equal(publications, 3);
+  assert.equal(commentUpserts, 0);
 });
 
 test("live-proof attach dry-run prints exact uploads and mutations without performing them", async () => {
@@ -460,6 +551,8 @@ test("live-proof workflow keeps execute secretless and attach trusted", () => {
   assert.match(source, /apt-get install --yes ffmpeg tmux x11-utils xfonts-base xvfb xterm/);
   assert.match(source, /--record \.\.\/live-proof-report\.md/);
   assert.doesNotMatch(source, /--plan \.\.\/live-proof/);
+  assert.match(source, /live-proof-attach-publish/);
+  assert.match(source, /--repo-slug "\$\{\{ needs\.execute\.outputs\.repo_slug \}\}"/);
 
   const dispatchActionSource = readFileSync(
     ".github/actions/dispatch-live-proofs/action.yml",
@@ -834,10 +927,14 @@ function attachDependencies(options: {
     markedReviewCommentBody: (number: number, body: string) =>
       `${body}\n\n<!-- clawsweeper-review item=${number} -->`,
     upsertReviewComment: options.upsertReviewComment,
-    updateReviewCommentMetadata: (markdown: string) =>
-      `${markdown.trimEnd()}\n\n<!-- comment metadata updated -->\n`,
     log: (message: string) => options.logs.push(message),
   };
+}
+
+function canonicalPublicationConflict(): Error & { stderr: string } {
+  return Object.assign(new Error("publish-main failed"), {
+    stderr: "Canonical publication conflicted for all 1 item(s); see per-item warnings above",
+  });
 }
 
 function frontMatterValue(markdown: string, key: string): string | undefined {

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -154,6 +154,7 @@ test("setup-state checks out only the remaining operational git tree", () => {
 test("all remaining git publishers join setup-state and receive a step-scoped coordinator secret", () => {
   const patterns = [
     /repair:publish-main\b/,
+    /live-proof-attach-publish\b/,
     /repair:publish-cluster-intake\b/,
     /repair:conflict-self-heal\b(?![^\n]*--verify-job-head)/,
     /\b(?:persist_reconciliation|publish_changes|publish_status)\b/,


### PR DESCRIPTION
## Summary

With the recorder fully repaired, production attach jobs fail only on the canonical publication revision fence when high-churn items get re-reviewed mid-attach (openclaw/openclaw#110714 run 32028578967, plus two organic follow-ups on #122581 and #112797 whose execute jobs succeeded end to end). Attach now rehydrates the single record and reapplies the attachment for up to three attempts with short backoff — the fence stays strict and the final conflict remains fatal — and the marker-backed comment upsert moves after canonical publication succeeds so the public comment can never diverge from the durable record.

## Validation

- `pnpm build` clean; affected suites 43/43; full unit suite 2,309 passed, 0 failed (ran in parallel with review, exit 0).
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.93)".
