### PR TITLE
fix(review): raise checkout inspection ls-files buffer for large repos

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -83,11 +83,14 @@ export function runAgentCheckoutInspection(options: {
   timeoutMs: number;
 }): CodexProcessResult {
   const env = { ...options.env, GIT_OPTIONAL_LOCKS: "0" };
+  // Large repositories list tens of thousands of tracked paths (openclaw/openclaw
+  // exceeds 3 MB); the 1 MB spawnSync default returns ENOBUFS and fails inspection.
   const trackedFiles = spawnSync("git", ["ls-files", "--stage", "-z"], {
     cwd: options.cwd,
     encoding: "utf8",
     env,
     timeout: options.timeoutMs,
+    maxBuffer: 64 * 1024 * 1024,
   });
   if (trackedFiles.error || trackedFiles.status !== 0) return spawnResult(trackedFiles);
   const candidates = (trackedFiles.stdout ?? "").split("\0").flatMap((entry) => {

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -261,3 +261,40 @@ test("OpenClaw checkout inspection reports challenge setup failures", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("checkout inspection lists tracked files beyond the 1 MB spawn default", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-agent-runner-large-index-test-"));
+  try {
+    execFileSync("git", ["init", "-q"], { cwd: root });
+    const blob = execFileSync("git", ["hash-object", "-w", "--stdin"], {
+      cwd: root,
+      input: "tracked checkout content\n",
+      encoding: "utf8",
+    }).trim();
+    // Index-only entries: ~6000 x 220-byte paths push `git ls-files --stage -z` past 1 MB.
+    const indexInfo = Array.from(
+      { length: 6000 },
+      (_, index) => `100644 blob ${blob}\t${"deep/".repeat(40)}file-${index}.txt\n`,
+    ).join("");
+    execFileSync("git", ["update-index", "--index-info"], { cwd: root, input: indexInfo });
+    const listing = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    assert.ok(listing.length > 1024 * 1024, `listing is ${listing.length} bytes`);
+
+    const result = runAgentCheckoutInspection({
+      cwd: root,
+      env: {
+        ...process.env,
+        CLAWSWEEPER_RUNNER: "openclaw",
+        CLAWSWEEPER_OPENCLAW_MODEL: "openai/test",
+      },
+      timeoutMs: 30_000,
+    });
+    assert.notEqual(result.error?.code, "ENOBUFS", result.error?.message);
+    assert.match(result.error?.message ?? "", /could not select a tracked text line/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Since #1170, `runAgentCheckoutInspection` lists tracked files with `git ls-files --stage -z` under the 1 MB `spawnSync` default `maxBuffer`. openclaw/openclaw's stage listing is >3 MB, so every local review of an openclaw PR fails before Codex runs:

```
codex-failure classification=content_or_output
Read-only checkout inspection failed for #125278: ... spawnSync git ENOBUFS
```

Observed on `pnpm run review -- --local-only --target-repo openclaw/openclaw --item-number 125278` at clawsweeper `866506fb0f`.

## Fix

`src/agent-runner.ts`: `maxBuffer: 64 MiB` on the listing spawn, with a comment naming the measurement.

## pr-behavior-proof

- claim: checkout inspection no longer ENOBUFS on repositories whose `ls-files --stage -z` output exceeds 1 MB
- surface: `runAgentCheckoutInspection`
- fixture: `test/agent-runner.test.ts` — index-only repo with 6000 × 220-byte paths (>1 MB listing), OpenClaw runner
- result: pre-fix build → `spawnSync git ENOBUFS`; post-fix build → proceeds to challenge selection (`could not select a tracked text line`, the expected outcome for an index-only fixture)
- command: `node --test test/agent-runner.test.ts` → 8/8 pass post-fix, 7/8 pre-fix (new test fails with ENOBUFS)
- limits: not re-run against a live openclaw review from `main` yet; local review of openclaw #125278 with this build follows and will be linked here.

## Live proof with this build

Local review of openclaw/openclaw#125278 (head `14ddf72f`) with this branch built at `0617d19e`: checkout inspection passed and Codex completed (`decision=keep_open confidence=high`, `overallCorrectness: patch is correct`, 0 findings, security cleared). Same command on `main` (`866506fb0f`) failed with `Read-only checkout inspection failed ... ENOBUFS` in ~1s.

## OpenClaw Bay impact

None. This changes only the local pre-review checkout inspection command's output buffer; no publication, queue, status/telemetry, or dashboard data contract changes, so Bay needs no update.
