### PR TITLE
fix(review): bound checkout challenge discovery

### DIFF
--- a/src/agent-runner.ts
+++ b/src/agent-runner.ts
@@ -10,6 +10,8 @@ import {
 } from "./codex-process.js";
 import { runOpenclawProcess } from "./openclaw-process.js";
 
+const MAX_CHECKOUT_INDEX_BYTES = 8 * 1024 * 1024;
+
 export type AgentRunner = "codex" | "openclaw";
 
 export interface RunAgentProcessOptions {
@@ -87,8 +89,22 @@ export function runAgentCheckoutInspection(options: {
     cwd: options.cwd,
     encoding: "utf8",
     env,
+    // Large target repositories can exceed Node's 1 MiB subprocess default.
+    // Keep discovery bounded so attestation still fails closed on an unreasonable index.
+    maxBuffer: MAX_CHECKOUT_INDEX_BYTES,
     timeout: options.timeoutMs,
   });
+  const listingError = trackedFiles.error as NodeJS.ErrnoException | undefined;
+  if (listingError?.code === "ENOBUFS") {
+    return failedCheckoutInspection(
+      Object.assign(
+        new Error("Checkout inspection tracked-file index exceeded the 8 MiB limit.", {
+          cause: listingError,
+        }),
+        { code: listingError.code },
+      ),
+    );
+  }
   if (trackedFiles.error || trackedFiles.status !== 0) return spawnResult(trackedFiles);
   const candidates = (trackedFiles.stdout ?? "").split("\0").flatMap((entry) => {
     const separator = entry.indexOf("\t");

--- a/test/agent-runner.test.ts
+++ b/test/agent-runner.test.ts
@@ -12,6 +12,62 @@ import {
   runAgentProcess,
 } from "../dist/agent-runner.js";
 
+function writeFakeOpenClawCheckoutInspector(binary: string): void {
+  writeFileSync(
+    binary,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const prompt = fs.readFileSync(process.argv[process.argv.indexOf("--message-file") + 1], "utf8");
+const relativePath = JSON.parse(prompt.match(/^Path: (.+)$/m)[1]);
+const lineNumber = Number(prompt.match(/^Return exactly line (\\d+)/m)[1]);
+const challenged = fs.readFileSync(path.join(process.env.OPENCLAW_WORKSPACE_DIR, relativePath), "utf8").split(/\\r?\\n/)[lineNumber - 1].trim();
+const sessionId = process.argv[process.argv.indexOf("--session-id") + 1];
+const sessionFile = path.join(process.env.OPENCLAW_STATE_DIR, "agents", "main", "sessions", sessionId + ".jsonl");
+fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+if (process.env.OPENCLAW_TEST_NO_RECEIPT !== "1") {
+  const toolCallId = "read-checkout";
+  const readPath = process.env.OPENCLAW_TEST_DIFFERENT_PATH === "1" ? "different.txt" : relativePath;
+  const entries = [
+    { type: "message", message: { role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: readPath } }] } },
+    { type: "message", message: { role: "toolResult", toolCallId, toolName: "read", isError: false, content: [{ type: "text", text: challenged }] } },
+  ];
+  fs.writeFileSync(sessionFile, entries.map((entry) => JSON.stringify(entry)).join("\\n") + "\\n");
+}
+process.stdout.write(JSON.stringify({
+  payloads: [{ text: challenged }],
+  meta: { stopReason: "stop" },
+}));
+`,
+  );
+  chmodSync(binary, 0o755);
+}
+
+function populateSyntheticTrackedIndex(
+  root: string,
+  { count, pathPadding = "" }: { count: number; pathPadding?: string },
+): string {
+  const trackedPath = join(root, "tracked.txt");
+  writeFileSync(trackedPath, "tracked checkout content for a large repository\n");
+  const blob = execFileSync("git", ["hash-object", "-w", "tracked.txt"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  const indexEntries = [
+    `100644 ${blob}\ttracked.txt\0`,
+    ...Array.from(
+      { length: count },
+      (_, index) =>
+        `100644 ${blob}\tbulk/${String(index).padStart(5, "0")}-${pathPadding}tracked-checkout-challenge-candidate.txt\0`,
+    ),
+  ].join("");
+  execFileSync("git", ["update-index", "-z", "--index-info"], {
+    cwd: root,
+    input: indexEntries,
+  });
+  return trackedPath;
+}
+
 test("agent runner defaults to Codex and fails closed on unknown values", () => {
   assert.equal(agentRunner({}), "codex");
   assert.equal(agentRunner({ CLAWSWEEPER_RUNNER: "codex" }), "codex");
@@ -181,34 +237,7 @@ test("OpenClaw checkout inspection attests the exact tracked path without checko
     ],
     { cwd: root },
   );
-  writeFileSync(
-    binary,
-    `#!/usr/bin/env node
-const fs = require("node:fs");
-const path = require("node:path");
-const prompt = fs.readFileSync(process.argv[process.argv.indexOf("--message-file") + 1], "utf8");
-const relativePath = JSON.parse(prompt.match(/^Path: (.+)$/m)[1]);
-const lineNumber = Number(prompt.match(/^Return exactly line (\\d+)/m)[1]);
-const challenged = fs.readFileSync(path.join(process.env.OPENCLAW_WORKSPACE_DIR, relativePath), "utf8").split(/\\r?\\n/)[lineNumber - 1].trim();
-const sessionId = process.argv[process.argv.indexOf("--session-id") + 1];
-const sessionFile = path.join(process.env.OPENCLAW_STATE_DIR, "agents", "main", "sessions", sessionId + ".jsonl");
-fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-if (process.env.OPENCLAW_TEST_NO_RECEIPT !== "1") {
-  const toolCallId = "read-checkout";
-  const readPath = process.env.OPENCLAW_TEST_DIFFERENT_PATH === "1" ? "different.txt" : relativePath;
-  const entries = [
-    { type: "message", message: { role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: readPath } }] } },
-    { type: "message", message: { role: "toolResult", toolCallId, toolName: "read", isError: false, content: [{ type: "text", text: challenged }] } },
-  ];
-  fs.writeFileSync(sessionFile, entries.map((entry) => JSON.stringify(entry)).join("\\n") + "\\n");
-}
-process.stdout.write(JSON.stringify({
-  payloads: [{ text: challenged }],
-  meta: { stopReason: "stop" },
-}));
-`,
-  );
-  chmodSync(binary, 0o755);
+  writeFakeOpenClawCheckoutInspector(binary);
   const baseEnv = {
     ...process.env,
     CLAWSWEEPER_RUNNER: "openclaw",
@@ -243,16 +272,83 @@ process.stdout.write(JSON.stringify({
   }
 });
 
-test("OpenClaw checkout inspection reports challenge setup failures", () => {
-  const root = mkdtempSync(join(tmpdir(), "clawsweeper-agent-runner-missing-test-"));
+test("OpenClaw checkout inspection supports an OpenClaw-sized tracked index", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-agent-runner-large-index-test-"));
+  const binary = join(root, "fake-openclaw");
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  const trackedPath = populateSyntheticTrackedIndex(root, { count: 30_000 });
+  writeFakeOpenClawCheckoutInspector(binary);
+  const env = {
+    ...process.env,
+    CLAWSWEEPER_RUNNER: "openclaw",
+    CLAWSWEEPER_OPENCLAW_MODEL: "openai/test",
+    CLAWSWEEPER_OPENCLAW_BIN: binary,
+  };
   try {
+    const listingBytes = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      maxBuffer: 4 * 1024 * 1024,
+    }).byteLength;
+    assert.ok(listingBytes >= 2_878_984, `expected an OpenClaw-sized listing, got ${listingBytes}`);
+
+    chmodSync(trackedPath, 0o444);
+    chmodSync(root, 0o555);
+    const result = runAgentCheckoutInspection({ cwd: root, env, timeoutMs: 10_000 });
+    assert.equal(result.status, 0, result.error?.message);
+  } finally {
+    chmodSync(root, 0o755);
+    chmodSync(trackedPath, 0o644);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenClaw checkout inspection fails closed when the tracked index exceeds its bound", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-agent-runner-bounded-index-test-"));
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  populateSyntheticTrackedIndex(root, { count: 10_000, pathPadding: "x".repeat(800) });
+  try {
+    const listingBytes = execFileSync("git", ["ls-files", "--stage", "-z"], {
+      cwd: root,
+      maxBuffer: 16 * 1024 * 1024,
+    }).byteLength;
+    assert.ok(listingBytes > 8 * 1024 * 1024, `expected listing >8 MiB, got ${listingBytes}`);
+
     const result = runAgentCheckoutInspection({
-      cwd: join(root, "missing"),
+      cwd: root,
       env: {
         ...process.env,
         CLAWSWEEPER_RUNNER: "openclaw",
         CLAWSWEEPER_OPENCLAW_MODEL: "openai/test",
+        CLAWSWEEPER_OPENCLAW_BIN: join(root, "must-not-run"),
       },
+      timeoutMs: 10_000,
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.error?.message ?? "", /tracked-file index exceeded the 8 MiB limit/);
+    assert.equal((result.error as NodeJS.ErrnoException | undefined)?.code, "ENOBUFS");
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("OpenClaw checkout inspection reports challenge setup failures", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-agent-runner-missing-test-"));
+  const env = {
+    ...process.env,
+    CLAWSWEEPER_RUNNER: "openclaw",
+    CLAWSWEEPER_OPENCLAW_MODEL: "openai/test",
+  };
+  try {
+    const notRepository = runAgentCheckoutInspection({ cwd: root, env, timeoutMs: 10_000 });
+    assert.equal(notRepository.status, 128);
+    assert.equal(notRepository.error, undefined);
+    assert.match(notRepository.stderr, /not a git repository/);
+
+    const result = runAgentCheckoutInspection({
+      cwd: join(root, "missing"),
+      env,
       timeoutMs: 10_000,
     });
     assert.notEqual(result.status, 0);


### PR DESCRIPTION
## Summary

Large repositories could never reach exact review because checkout attestation buffered the full tracked-file index with Node's 1 MiB subprocess default. OpenClaw's current index is 2,878,984 bytes, so the preflight terminated with `ENOBUFS` before the review process started.

This change:

- gives the tracked-index read a purpose-specific 8 MiB hard bound;
- preserves fail-closed behavior above that bound with an actionable error;
- preserves native Git status and stderr for ordinary checkout failures;
- adds regressions at the real OpenClaw index scale and above the hard cap.

No fallback, truncation, network expansion, or sandbox weakening is introduced.

## Operator-visible behavior

Before:

```text
review_status: failed
local_checkout_access: unverified
output buffer overflow
```

After, against the actual OpenClaw checkout:

```text
target_sha=93d99bbb083b472f95951b7bb72f7494e5af5f82
listing_bytes=2878984
listing_entries=30353
inspection_status=0
checkout_status_unchanged=true
```

Indexes over 8 MiB still fail before the review runner launches.

## Proof

- TDD red: OpenClaw-sized fixture failed with `spawnSync git ENOBUFS`.
- Focused green: `node --test test/agent-runner.test.ts` — 9/9.
- Build: `tsc -p tsconfig.json`.
- Static: targeted oxfmt and oxlint clean; `git diff --check` clean.
- Fresh pre-commit and committed-head reviews: no actionable findings.
- Real preflight: exact OpenClaw tracked index inspected successfully; dirty-state hash unchanged before/after.
- Full `pnpm run check`: static, build, formatting, and lint stages passed. The repository-wide test stage could not complete locally because the machine's global Corepack first inherited a private npm mirror, then failed pnpm signature verification after the registry was corrected. CI is the authoritative full-gate proof.

## Dependency contract

Node's synchronous subprocess API buffers output and enforces `maxBuffer`; the default is too small for the current target index. The sandbox CLI's read-only command path was checked at exact v0.146.0: it runs the requested Git hash command with inherited stdio and does not own this parent-process buffer.

## Scope

Production: +16/-0 lines. Tests: +127/-31 lines.

OpenClaw Bay is unaffected. This changes only pre-model checkout attestation; no dashboard, public status, durable record, or Bay data contract changes.
