### PR TITLE
fix(live-proof): publish against an attempt-scoped hydrated baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
-- Live-proof attachment now retries canonical publication conflicts from fresh single-record state and updates the public review comment only after the record lands.
+- Live-proof attachment now captures each freshly hydrated canonical single-record revision as the publication baseline before retrying conflicts, then updates the public review comment only after the record lands.
 - Short live-proof recordings fall back to a single poster frame when the contact-sheet tile cannot emit one.
 - Terminal recorders flush WebM packets immediately and treat a live ffmpeg session as healthy while the muxer buffers.
 - Terminal live-proof recordings tune VP9 for realtime capture and accept the recorder once any payload is written, matching the encoder's bursty muxer output.

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -68,6 +68,7 @@ import {
 import { createLabelPolicy } from "./clawsweeper-label-policy.js";
 import { createLiveProofCommands } from "./live-proof/commands.js";
 import {
+  captureLiveProofCanonicalBaseline,
   isCanonicalPublicationConflict,
   publishLiveProofAttachment,
 } from "./live-proof/publication.js";
@@ -1509,9 +1510,10 @@ async function liveProofAttachPublishCommand(args: Args): Promise<void> {
     throw new Error("--item requires a positive safe integer");
   }
   const recordsUrl = process.env.QUEUE_URL?.trim() || "https://clawsweeper.openclaw.ai";
+  const canonicalBaselineRoots = new Map<number, string>();
 
   await publishLiveProofAttachment({
-    hydrateRecord: () => {
+    hydrateRecord: (attempt) => {
       runText(
         process.execPath,
         [
@@ -1529,6 +1531,15 @@ async function liveProofAttachPublishCommand(args: Args): Promise<void> {
         ],
         { cwd: ROOT, trim: "none" },
       );
+      canonicalBaselineRoots.set(
+        attempt,
+        captureLiveProofCanonicalBaseline({
+          root: ROOT,
+          repositorySlug: repoSlug,
+          itemNumber: item,
+          attempt,
+        }),
+      );
     },
     attachRecord: async () => {
       const markdown = readFileSync(resolve(recordPath), "utf8");
@@ -1536,7 +1547,11 @@ async function liveProofAttachPublishCommand(args: Args): Promise<void> {
       if (repo) setTargetRepo(repo);
       return liveProofCommands.liveProofAttachCommand(args);
     },
-    publishRecord: () => {
+    publishRecord: (attempt) => {
+      const canonicalBaselineRoot = canonicalBaselineRoots.get(attempt);
+      if (!canonicalBaselineRoot) {
+        throw new Error(`Missing canonical live-proof baseline for attempt ${attempt}`);
+      }
       runText(
         "pnpm",
         [
@@ -1550,7 +1565,13 @@ async function liveProofAttachPublishCommand(args: Args): Promise<void> {
           "--rebase-strategy",
           "normal",
         ],
-        { cwd: ROOT, trim: "none" },
+        {
+          cwd: ROOT,
+          env: {
+            CLAWSWEEPER_CANONICAL_RECORD_BASELINE_DIR: canonicalBaselineRoot,
+          },
+          trim: "none",
+        },
       );
     },
     syncComment: () => liveProofCommands.liveProofCommentCommand(args),

--- a/src/live-proof/publication.ts
+++ b/src/live-proof/publication.ts
@@ -1,12 +1,16 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+
+import { captureCanonicalRecordBaseline } from "../repair/canonical-record-baseline.js";
 import type { LiveProofAttachResult } from "./attach.js";
 
 export const LIVE_PROOF_PUBLICATION_ATTEMPTS = 3;
 export const LIVE_PROOF_PUBLICATION_BACKOFF_MS = 1_000;
 
 export interface LiveProofPublicationDependencies {
-  hydrateRecord: () => Promise<void> | void;
-  attachRecord: () => Promise<LiveProofAttachResult>;
-  publishRecord: () => Promise<void> | void;
+  hydrateRecord: (attempt: number) => Promise<void> | void;
+  attachRecord: (attempt: number) => Promise<LiveProofAttachResult>;
+  publishRecord: (attempt: number) => Promise<void> | void;
   syncComment: () => Promise<void> | void;
   isCanonicalConflict: (error: unknown) => boolean;
   delay?: (milliseconds: number) => Promise<void>;
@@ -22,12 +26,12 @@ export async function publishLiveProofAttachment(
   const log = dependencies.log ?? console.log;
 
   for (let attempt = 1; attempt <= LIVE_PROOF_PUBLICATION_ATTEMPTS; attempt += 1) {
-    await dependencies.hydrateRecord();
-    const outcome = await dependencies.attachRecord();
+    await dependencies.hydrateRecord(attempt);
+    const outcome = await dependencies.attachRecord(attempt);
     if (outcome !== "attached") return outcome;
 
     try {
-      await dependencies.publishRecord();
+      await dependencies.publishRecord(attempt);
     } catch (error) {
       if (!dependencies.isCanonicalConflict(error) || attempt === LIVE_PROOF_PUBLICATION_ATTEMPTS) {
         throw error;
@@ -44,6 +48,35 @@ export async function publishLiveProofAttachment(
   }
 
   throw new Error("live proof publication exhausted its retry loop");
+}
+
+export function captureLiveProofCanonicalBaseline(options: {
+  root: string;
+  repositorySlug: string;
+  itemNumber: number;
+  attempt: number;
+}): string {
+  const itemName = `${options.itemNumber}.md`;
+  const baselineParent = join(options.root, ".artifacts", "live-proof-canonical-baseline");
+  mkdirSync(baselineParent, { recursive: true });
+  const baselineRoot = mkdtempSync(join(baselineParent, `attempt-${options.attempt}-`));
+  const repositoryRoot = join(options.root, "records", options.repositorySlug);
+  captureCanonicalRecordBaseline({
+    baselineRoot,
+    repositorySlug: options.repositorySlug,
+    itemNumber: options.itemNumber,
+    sources: [
+      { section: "items", name: itemName, path: join(repositoryRoot, "items", itemName) },
+      { section: "closed", name: itemName, path: join(repositoryRoot, "closed", itemName) },
+      { section: "plans", name: itemName, path: join(repositoryRoot, "plans", itemName) },
+      {
+        section: "decision-packets",
+        name: `${options.itemNumber}.json`,
+        path: join(repositoryRoot, "decision-packets", `${options.itemNumber}.json`),
+      },
+    ],
+  });
+  return baselineRoot;
 }
 
 export function isCanonicalPublicationConflict(error: unknown): boolean {

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 import YAML from "yaml";
@@ -18,6 +18,7 @@ import {
 import { executeLiveProof } from "../dist/live-proof/execute.js";
 import { parseLiveProofManifest } from "../dist/live-proof/manifest.js";
 import {
+  captureLiveProofCanonicalBaseline,
   isCanonicalPublicationConflict,
   publishLiveProofAttachment,
 } from "../dist/live-proof/publication.js";
@@ -433,18 +434,23 @@ test("live-proof attach publishes the record before syncing its marker-backed co
   assert.match(publishedBody, /<!-- clawsweeper-review item=42 -->/);
 });
 
-test("live-proof publication rehydrates and retries a canonical conflict without duplicate comment upserts", async () => {
+test("live-proof publication retries from a lagged hydration and publishes the fresh canonical baseline", async () => {
   const calls: string[] = [];
+  const hydratedRevisions = ["revision-5", "revision-6"];
+  let hydratedRevision = "";
   let publications = 0;
   let commentUpserts = 0;
   const result = await publishLiveProofAttachment({
-    hydrateRecord: () => calls.push("hydrate"),
-    attachRecord: async () => {
-      calls.push("attach");
+    hydrateRecord: (attempt) => {
+      hydratedRevision = hydratedRevisions[attempt - 1] ?? "";
+      calls.push(`hydrate:${hydratedRevision}`);
+    },
+    attachRecord: async (attempt) => {
+      calls.push(`attach:${attempt}`);
       return "attached";
     },
-    publishRecord: () => {
-      calls.push("publish");
+    publishRecord: (attempt) => {
+      calls.push(`publish:${attempt}:${hydratedRevision}`);
       publications += 1;
       if (publications === 1) throw canonicalPublicationConflict();
     },
@@ -459,15 +465,46 @@ test("live-proof publication rehydrates and retries a canonical conflict without
 
   assert.equal(result, "attached");
   assert.deepEqual(calls, [
-    "hydrate",
-    "attach",
-    "publish",
-    "hydrate",
-    "attach",
-    "publish",
+    "hydrate:revision-5",
+    "attach:1",
+    "publish:1:revision-5",
+    "hydrate:revision-6",
+    "attach:2",
+    "publish:2:revision-6",
     "comment",
   ]);
   assert.equal(commentUpserts, 1);
+});
+
+test("live-proof publication captures each hydrated canonical revision in a fresh baseline", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-baseline-"));
+  const recordPath = join(root, "records", "openclaw-openclaw", "items", "42.md");
+  mkdirSync(dirname(recordPath), { recursive: true });
+  writeFileSync(recordPath, "canonical revision 5\n");
+
+  const first = captureLiveProofCanonicalBaseline({
+    root,
+    repositorySlug: "openclaw-openclaw",
+    itemNumber: 42,
+    attempt: 1,
+  });
+  writeFileSync(recordPath, "canonical revision 6\n");
+  const second = captureLiveProofCanonicalBaseline({
+    root,
+    repositorySlug: "openclaw-openclaw",
+    itemNumber: 42,
+    attempt: 2,
+  });
+
+  assert.notEqual(first, second);
+  assert.equal(
+    readFileSync(join(first, "records", "openclaw-openclaw", "items", "42.md"), "utf8"),
+    "canonical revision 5\n",
+  );
+  assert.equal(
+    readFileSync(join(second, "records", "openclaw-openclaw", "items", "42.md"), "utf8"),
+    "canonical revision 6\n",
+  );
 });
 
 test("live-proof publication fails loudly after three canonical conflicts", async () => {


### PR DESCRIPTION
## Summary

The attach conflict was systematic, not churn: openclaw/clawsweeper#1182 (a record with no concurrent writers) conflicted on all three retry attempts (run 32031655761). Investigation refuted the snapshot-lag hypothesis — focused hydration reads CURRENT straight from the Durable Object canonical store — and found the real cause: `repair:publish-main` fell back to the intentionally unhydrated `CLAWSWEEPER_STATE_DIR` for its three-way baseline, so the absent/stale expected digest made every publication look like a same-section concurrent edit.

Each retry attempt now captures the freshly hydrated record into an attempt-scoped baseline and supplies it explicitly to the unchanged strict publisher fence, matching exact review's capture-before-mutate idiom.

## Validation

- `pnpm build` clean; focused suites 38/38; publish-main suite 15/15; full unit 2,311 passed, 0 failed.
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.97)".
