### PR TITLE
fix(live-proof): only publish recordings that demonstrate a change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Live-proof recordings now wait for post-action command or page expectations, hold the final state on screen, and attach only when an initially absent expectation proves a semantic change.
 - Live-proof attachment now captures each freshly hydrated canonical single-record revision as the publication baseline before retrying conflicts, then updates the public review comment only after the record lands.
 - Short live-proof recordings fall back to a single poster frame when the contact-sheet tile cannot emit one.
 - Terminal recorders flush WebM packets immediately and treat a live ffmpeg session as healthy while the muxer buffers.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -34,10 +34,17 @@ plans use tmux, an unauthenticated local Xvfb display with its TCP listener
 disabled, a fullscreen xterm, and ffmpeg `x11grab`; typed
 `run`, `wait`, and `expect_output` steps are replayed through the tmux pane.
 
-Both drivers finalize the recording after a mid-plan failure and record the
-result as `drive_status`. The command transcodes to H.264 MP4, probes it with
-ffprobe, creates `poster.jpg`, enforces the repository's recording limit and a
-50 MB MP4 cap, and writes `steps-log.json` plus a metadata-only
+Both drivers hold the final state on screen. Terminal commands poll for output
+beyond the echoed command line; browser steps settle briefly and target steps
+scroll the changed region into the recorded viewport. Each expectation records
+whether its text was present at the start and whether the later check succeeded.
+A recording is eligible only when at least one expectation was absent initially
+and satisfied after the plan acted. A failed drive, a plan that demonstrates no
+such semantic change, or a recording shorter than three seconds is a logged
+successful skip and emits no manifest, so it cannot reach attachment. Eligible
+completed and partial drives are transcoded to H.264 MP4 and probed with
+ffprobe. The command creates `poster.jpg`, enforces the repository's recording
+limit and a 50 MB MP4 cap, and writes `steps-log.json` plus a metadata-only
 `live-proof-manifest.json`. The manifest contains no media URL. The bundle is
 retained as a GitHub Actions artifact for seven days.
 

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -445,9 +445,16 @@ internal plumbing. Use `surface: "browser"` for browser behavior and
 browser proof or a command for terminal proof. Emit at most ten deterministic,
 typed `steps`: browser plans may use `goto`, `click`, `fill`, `press`,
 `wait_for`, `wait`, and `expect_text`; terminal plans may use `run`, `wait`, and
-`expect_output`. The plan must be demonstrable from the PR head alone without
-external accounts, credentials, or third-party services. Step values must never
-contain secrets or tokens of any kind.
+`expect_output`. Every recommended plan must include at least one state-changing
+step (`goto`, `click`, `fill`, or `press` for browser plans; `run` for terminal
+plans) and at least one expectation whose text is absent before that action and
+appears only afterward. Never assert a static label, hint, heading, or the typed
+command itself: the expectation must prove that the action changed observable
+state. Targets for `click`, `fill`, and `wait_for` must be valid CSS or Playwright
+selectors, including `text=...` selectors when appropriate, never prose
+descriptions of state. The plan must be demonstrable from the PR head alone
+without external accounts, credentials, or third-party services. Step values
+must never contain secrets or tokens of any kind.
 
 Live proof recordings are published publicly. If the diff, or the
 demonstration it would require, reads environment variables or credential

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -9,11 +9,21 @@ import type {
 import { mediaProofSpawnDetail } from "../clawsweeper-media-proof.js";
 import type { LiveProofDriveStatus } from "./manifest.js";
 
-export interface LiveProofStepLogEntry {
+interface LiveProofBaseStepLogEntry {
   action: string;
   status: "completed" | "failed";
   detail: string;
 }
+
+export type LiveProofStepLogEntry =
+  | (LiveProofBaseStepLogEntry & {
+      action: "expect_text" | "expect_output";
+      presentAtStart: boolean;
+      satisfied: boolean;
+    })
+  | (LiveProofBaseStepLogEntry & {
+      action: Exclude<LiveProofStep["action"], "expect_text" | "expect_output">;
+    });
 
 export interface LiveProofDriveResult {
   status: LiveProofDriveStatus;
@@ -24,6 +34,11 @@ export interface LiveProofDriveResult {
 const DISPLAY_READY_TIMEOUT_SECONDS = 30;
 const RECORDER_READY_TIMEOUT_SECONDS = 15;
 const RECORDER_FINALIZE_TIMEOUT_SECONDS = 20;
+const TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS = 20;
+const TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS = 30;
+const STEP_SETTLE_MILLISECONDS = 700;
+const END_STATE_HOLD_MILLISECONDS = 3_000;
+const MINIMUM_RECORDING_MILLISECONDS = 6_000;
 
 type TerminalCommandInvocation = {
   command: string;
@@ -61,19 +76,28 @@ let context;
 let page;
 let video;
 let failed = false;
+let recordingStartedAt = 0;
 try {
   browser = await chromium.launch(useBundledChromium ? { headless } : { headless, channel: "chrome" });
   context = await browser.newContext({ viewport: { width: 1280, height: 800 }, recordVideo: { dir: output + ".videos", size: { width: 1280, height: 800 } } });
   page = await context.newPage();
   page.setDefaultTimeout(15_000);
   video = page.video();
+  recordingStartedAt = Date.now();
   await page.goto(new URL(entry, baseUrl).href);
-  for (const step of steps) {
+  const expectationPresentAtStart = new Map();
+  for (const [index, step] of steps.entries()) {
+    if (step.action !== "expect_text") continue;
+    const locator = page.getByText(step.text, { exact: false }).first();
+    expectationPresentAtStart.set(index, await locator.isVisible().catch(() => false));
+  }
+  for (const [index, step] of steps.entries()) {
     try {
       switch (step.action) {
         case "goto": await page.goto(new URL(step.path, baseUrl).href); break;
         case "click": {
           const locator = page.locator(step.target);
+          await locator.scrollIntoViewIfNeeded();
           // Fall back to a force click so continuously animated targets (whose
           // position never stabilizes) can still be demonstrated.
           try { await locator.click({ timeout: 5_000 }); }
@@ -82,18 +106,35 @@ try {
         }
         case "fill": await page.locator(step.target).fill(step.value); break;
         case "press": await page.keyboard.press(step.key); break;
-        case "wait_for": await page.locator(step.target).waitFor({ state: "visible" }); break;
+        case "wait_for": {
+          const locator = page.locator(step.target);
+          await locator.scrollIntoViewIfNeeded();
+          await locator.waitFor({ state: "visible" });
+          break;
+        }
         case "wait": await page.waitForTimeout(step.seconds * 1000); break;
-        case "expect_text": await page.getByText(step.text, { exact: false }).first().waitFor({ state: "visible" }); break;
+        case "expect_text": {
+          const locator = page.getByText(step.text, { exact: false }).first();
+          await locator.scrollIntoViewIfNeeded();
+          await locator.waitFor({ state: "visible" });
+          break;
+        }
         default: throw new Error("unsupported browser action");
       }
-      log.push({ action: step.action, status: "completed", detail: "ok" });
+      await page.waitForTimeout(${STEP_SETTLE_MILLISECONDS});
+      log.push(step.action === "expect_text"
+        ? { action: step.action, status: "completed", detail: "ok", presentAtStart: expectationPresentAtStart.get(index) === true, satisfied: true }
+        : { action: step.action, status: "completed", detail: "ok" });
     } catch (error) {
       failed = true;
-      log.push({ action: step.action, status: "failed", detail: error instanceof Error ? error.message : String(error) });
+      log.push(step.action === "expect_text"
+        ? { action: step.action, status: "failed", detail: error instanceof Error ? error.message : String(error), presentAtStart: expectationPresentAtStart.get(index) === true, satisfied: false }
+        : { action: step.action, status: "failed", detail: error instanceof Error ? error.message : String(error) });
       break;
     }
   }
+  const elapsed = Date.now() - recordingStartedAt;
+  await page.waitForTimeout(Math.max(${END_STATE_HOLD_MILLISECONDS}, ${MINIMUM_RECORDING_MILLISECONDS} - elapsed));
 } finally {
   if (context) await context.close().catch(() => undefined);
   if (video) {
@@ -156,7 +197,6 @@ export function driveBrowser(options: {
 
 export function terminalCommandPlan(options: {
   sessionPrefix: string;
-  entry: string;
   maxRecordingSeconds: number;
   rawVideoPath: string;
 }): TerminalCommandInvocation[] {
@@ -258,15 +298,11 @@ export function terminalCommandPlan(options: {
       ],
       waitAfter: "recorder",
     },
-    {
-      command: "tmux",
-      args: ["send-keys", "-t", `${terminalSession}:0.0`, "-l", "--", options.entry],
-    },
-    {
-      command: "tmux",
-      args: ["send-keys", "-t", `${terminalSession}:0.0`, "Enter"],
-    },
   ];
+}
+
+interface TerminalOutputWindow {
+  echoSnapshot: string;
 }
 
 export function driveTerminal(options: {
@@ -284,10 +320,12 @@ export function driveTerminal(options: {
   const log: LiveProofStepLogEntry[] = [];
   let failed = false;
   let thrown: Error | undefined;
+  let recordingStartedAt = 0;
+  let outputWindow: TerminalOutputWindow | undefined;
+  let initialPaneSnapshot = "";
   try {
     for (const invocation of terminalCommandPlan({
       sessionPrefix,
-      entry: options.plan.entry,
       maxRecordingSeconds: options.maxRecordingSeconds,
       rawVideoPath: options.rawVideoPath,
     })) {
@@ -300,22 +338,61 @@ export function driveTerminal(options: {
         waitForDisplay(options.runner, options.checkout);
       } else if (invocation.waitAfter === "recorder") {
         waitForRecorder(options.runner, options.checkout, recorderSession, options.rawVideoPath);
+        recordingStartedAt = Date.now();
       }
     }
+    initialPaneSnapshot = captureTerminalPane(
+      options.runner,
+      options.checkout,
+      `${terminalSession}:0.0`,
+    );
+    outputWindow = runTerminalCommand(
+      options.plan.entry,
+      terminalSession,
+      options.runner,
+      options.checkout,
+    );
     for (const step of options.plan.steps as LiveProofTerminalStep[]) {
       try {
-        runTerminalStep(step, terminalSession, options.runner, options.checkout);
-        log.push({ action: step.action, status: "completed", detail: "ok" });
+        outputWindow = runTerminalStep(
+          step,
+          terminalSession,
+          options.runner,
+          options.checkout,
+          outputWindow,
+        );
+        log.push(
+          step.action === "expect_output"
+            ? {
+                action: step.action,
+                status: "completed",
+                detail: "ok",
+                presentAtStart: initialPaneSnapshot.includes(step.text),
+                satisfied: true,
+              }
+            : { action: step.action, status: "completed", detail: "ok" },
+        );
       } catch (error) {
         failed = true;
-        log.push({
-          action: step.action,
-          status: "failed",
-          detail: error instanceof Error ? error.message : String(error),
-        });
+        log.push(
+          step.action === "expect_output"
+            ? {
+                action: step.action,
+                status: "failed",
+                detail: error instanceof Error ? error.message : String(error),
+                presentAtStart: initialPaneSnapshot.includes(step.text),
+                satisfied: false,
+              }
+            : {
+                action: step.action,
+                status: "failed",
+                detail: error instanceof Error ? error.message : String(error),
+              },
+        );
         break;
       }
     }
+    holdEndState(options.runner, recordingStartedAt);
     finalizeRecorder(options.runner, options.checkout, recorderSession);
     requireRecording(options.runner, options.checkout, options.rawVideoPath);
   } catch (error) {
@@ -467,35 +544,97 @@ function runTerminalStep(
   terminalSession: string,
   runner: MediaProofCommandRunner,
   checkout: string,
-): void {
-  const target = `${terminalSession}:0.0`;
+  outputWindow: TerminalOutputWindow | undefined,
+): TerminalOutputWindow | undefined {
   if (step.action === "run") {
-    requireSuccess(
-      "tmux",
-      ["send-keys", "-t", target, "-l", "--", step.command],
-      runner("tmux", ["send-keys", "-t", target, "-l", "--", step.command], {
-        cwd: checkout,
-      }),
-    );
-    requireSuccess(
-      "tmux",
-      ["send-keys", "-t", target, "Enter"],
-      runner("tmux", ["send-keys", "-t", target, "Enter"], { cwd: checkout }),
-    );
-    return;
+    return runTerminalCommand(step.command, terminalSession, runner, checkout);
   }
   if (step.action === "wait") {
     const seconds = String(step.seconds);
     requireSuccess("sleep", [seconds], runner("sleep", [seconds]));
-    return;
+    return outputWindow;
   }
-  const capture = runner("tmux", ["capture-pane", "-p", "-t", target, "-S", "-200"], {
-    cwd: checkout,
-  });
-  requireSuccess("tmux", ["capture-pane"], capture);
-  if (!String(capture.stdout ?? "").includes(step.text)) {
-    throw new Error(`expected terminal output was not visible: ${JSON.stringify(step.text)}`);
+  if (!outputWindow) {
+    throw new Error("expected terminal output without a preceding command");
   }
+  const target = `${terminalSession}:0.0`;
+  let capturedPane = "";
+  for (let elapsed = 0; elapsed <= TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
+    capturedPane = captureTerminalPane(runner, checkout, target);
+    const output = paneContentAfterSnapshot(outputWindow.echoSnapshot, capturedPane);
+    if (output.includes(step.text)) return outputWindow;
+    if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) pollSleep(runner);
+  }
+  throw new Error(
+    `expected terminal output was not visible within ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(step.text)}\n\nCaptured pane:\n${capturedPane || "<empty>"}`,
+  );
+}
+
+function runTerminalCommand(
+  command: string,
+  terminalSession: string,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+): TerminalOutputWindow {
+  const target = `${terminalSession}:0.0`;
+  captureTerminalPane(runner, checkout, target);
+  requireSuccess(
+    "tmux",
+    ["send-keys", "-t", target, "-l", "--", command],
+    runner("tmux", ["send-keys", "-t", target, "-l", "--", command], { cwd: checkout }),
+  );
+  const echoSnapshot = captureTerminalPane(runner, checkout, target);
+  requireSuccess(
+    "tmux",
+    ["send-keys", "-t", target, "Enter"],
+    runner("tmux", ["send-keys", "-t", target, "Enter"], { cwd: checkout }),
+  );
+  let capturedPane = echoSnapshot;
+  for (let elapsed = 0; elapsed <= TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
+    capturedPane = captureTerminalPane(runner, checkout, target);
+    if (paneContentAfterSnapshot(echoSnapshot, capturedPane).trim()) {
+      return { echoSnapshot };
+    }
+    if (elapsed < TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS) pollSleep(runner);
+  }
+  throw new Error(
+    `terminal command did not produce output within ${TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(command)}\n\nCaptured pane:\n${capturedPane || "<empty>"}`,
+  );
+}
+
+function captureTerminalPane(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  target: string,
+): string {
+  const args = ["capture-pane", "-p", "-t", target, "-S", "-200"];
+  const capture = runner("tmux", args, { cwd: checkout });
+  requireSuccess("tmux", args, capture);
+  return String(capture.stdout ?? "");
+}
+
+function paneContentAfterSnapshot(snapshot: string, current: string): string {
+  const before = snapshot.split("\n");
+  const after = current.split("\n");
+  let firstChangedLine = 0;
+  while (
+    firstChangedLine < before.length &&
+    firstChangedLine < after.length &&
+    before[firstChangedLine] === after[firstChangedLine]
+  ) {
+    firstChangedLine += 1;
+  }
+  return after.slice(firstChangedLine).join("\n");
+}
+
+function holdEndState(runner: MediaProofCommandRunner, recordingStartedAt: number): void {
+  const elapsed = Math.max(0, Date.now() - recordingStartedAt);
+  const holdMilliseconds = Math.max(
+    END_STATE_HOLD_MILLISECONDS,
+    MINIMUM_RECORDING_MILLISECONDS - elapsed,
+  );
+  const holdSeconds = String(Math.ceil(holdMilliseconds / 1000));
+  requireSuccess("sleep", [holdSeconds], runner("sleep", [holdSeconds]));
 }
 
 function readStepLog(path: string): LiveProofStepLogEntry[] {
@@ -509,7 +648,10 @@ function readStepLog(path: string): LiveProofStepLogEntry[] {
       return (
         typeof record.action === "string" &&
         (record.status === "completed" || record.status === "failed") &&
-        typeof record.detail === "string"
+        typeof record.detail === "string" &&
+        (record.action !== "expect_text" && record.action !== "expect_output"
+          ? true
+          : typeof record.presentAtStart === "boolean" && typeof record.satisfied === "boolean")
       );
     });
   } catch {

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 import {
   createVideoContactSheet,
@@ -7,7 +15,12 @@ import {
 } from "../clawsweeper-media-proof.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../clawsweeper-types.js";
 import type { RepositoryProfile } from "../repository-profiles.js";
-import { driveBrowser, driveTerminal, liveProofStepActions } from "./drivers.js";
+import {
+  driveBrowser,
+  driveTerminal,
+  type LiveProofStepLogEntry,
+  liveProofStepActions,
+} from "./drivers.js";
 import { LIVE_PROOF_MAX_MP4_BYTES, type LiveProofManifest, probeMedia } from "./manifest.js";
 
 export interface LiveProofPullRequestState {
@@ -99,6 +112,8 @@ export async function executeLiveProof(
   const stepsLogPath = join(outputDir, "steps-log.json");
   const scriptPath = join(outputDir, "live-proof-playwright.mjs");
   const serverPidPath = join(outputDir, "server.pid");
+  const manifestPath = join(outputDir, "live-proof-manifest.json");
+  rmSync(manifestPath, { force: true });
 
   for (const command of liveTest.setup) {
     requireSuccess("sh", ["-lc", command], runner("sh", ["-lc", command], { cwd: checkout }));
@@ -136,6 +151,17 @@ export async function executeLiveProof(
             runner,
           });
 
+    writeFileSync(stepsLogPath, `${JSON.stringify(drive.steps, null, 2)}\n`, "utf8");
+
+    if (drive.status === "failed") {
+      log("[live-proof] skip: demonstration did not complete");
+      return;
+    }
+    if (!demonstratedChange(drive.steps)) {
+      log("[live-proof] skip: plan verified nothing that changed");
+      return;
+    }
+
     transcodeToMp4(rawVideoPath, mp4Path, runner, checkout);
     enforceMp4SizeCap(mp4Path, runner, checkout);
     const media = probeMedia(mp4Path, runner);
@@ -146,6 +172,10 @@ export async function executeLiveProof(
       throw new Error(
         `live proof recording exceeds configured ${liveTest.maxRecordingSeconds}-second cap`,
       );
+    }
+    if (media.durationSeconds < 3) {
+      log("[live-proof] skip: recording is shorter than 3 seconds");
+      return;
     }
     // The contact-sheet tile needs ~100 seconds of sampled video before some
     // ffmpeg builds emit a frame, so short recordings fall back to a single
@@ -175,7 +205,6 @@ export async function executeLiveProof(
     }
     if (!existsSync(posterPath)) throw new Error("ffmpeg did not create poster.jpg");
 
-    writeFileSync(stepsLogPath, `${JSON.stringify(drive.steps, null, 2)}\n`, "utf8");
     const manifest: LiveProofManifest = {
       schema_version: 1,
       repo: profile.targetRepo,
@@ -189,17 +218,22 @@ export async function executeLiveProof(
       steps_executed: liveProofStepActions(plan.steps),
       recorded_at: (dependencies.now ?? (() => new Date()))().toISOString(),
     };
-    writeFileSync(
-      join(outputDir, "live-proof-manifest.json"),
-      `${JSON.stringify(manifest, null, 2)}\n`,
-      "utf8",
-    );
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
     log(
       `[live-proof] wrote ${plan.surface} proof bundle for ${profile.targetRepo}#${options.item} at ${headSha}`,
     );
   } finally {
     if (serverStarted) stopBackgroundServer(serverPidPath, runner, checkout);
   }
+}
+
+function demonstratedChange(steps: readonly LiveProofStepLogEntry[]): boolean {
+  return steps.some(
+    (step) =>
+      (step.action === "expect_text" || step.action === "expect_output") &&
+      !step.presentAtStart &&
+      step.satisfied,
+  );
 }
 
 function readPlan(

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -201,10 +201,36 @@ test("Playwright generation keeps quotes, backticks, and newlines inside JSON da
   assert.equal(checked.status, 0, checked.stderr);
 });
 
+test("Playwright steps scroll targets into view, settle, and hold a six-second minimum", () => {
+  const script = generatePlaywrightScript([
+    { action: "click", target: "#save" },
+    { action: "wait_for", target: "#result" },
+    { action: "expect_text", text: "Saved" },
+  ]);
+  assert.equal(script.match(/scrollIntoViewIfNeeded\(\)/g)?.length, 3);
+  assert.match(script, /await page\.waitForTimeout\(700\)/);
+  assert.match(script, /Math\.max\(3000, 6000 - elapsed\)/);
+});
+
+test("Playwright probes every expected text immediately after the initial navigation", () => {
+  const script = generatePlaywrightScript([
+    { action: "click", target: "#save" },
+    { action: "expect_text", text: "Saved" },
+  ]);
+  const goto = script.indexOf("await page.goto(new URL(entry, baseUrl).href)");
+  const probe = script.indexOf("const expectationPresentAtStart = new Map()", goto);
+  const loop = "for (const [index, step] of steps.entries()) {";
+  const probeLoop = script.indexOf(loop, probe);
+  const actionLoop = script.indexOf(loop, probeLoop + loop.length);
+  assert.ok(goto >= 0 && probe > goto && probeLoop > probe && actionLoop > probeLoop);
+  assert.match(script, /await locator\.isVisible\(\)\.catch\(\(\) => false\)/);
+  assert.match(script, /presentAtStart: expectationPresentAtStart\.get\(index\) === true/);
+  assert.match(script, /satisfied: true/);
+});
+
 test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions", () => {
   const commands = terminalCommandPlan({
     sessionPrefix: "proof",
-    entry: "pnpm cli --help",
     maxRecordingSeconds: 90,
     rawVideoPath: "/tmp/live-proof.raw.webm",
   });
@@ -265,7 +291,101 @@ test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions",
     commands.some((invocation) => invocation.command === "sleep"),
     false,
   );
-  assert.deepEqual(commands.at(-2)?.args.slice(-2), ["--", "pnpm cli --help"]);
+});
+
+test("terminal run waits for pane content beyond the echoed command", () => {
+  const calls: string[] = [];
+  const result = runTerminalFixture(
+    terminalLifecycleRunner(calls, {
+      terminalCaptures: [
+        "$ pnpm cli --help\n",
+        "$ pnpm cli --help\n",
+        "$ pnpm cli --help\nUsage\n",
+      ],
+    }),
+  );
+  assert.equal(result.status, "completed");
+  const enter = calls.findIndex((call) => /tmux send-keys .* Enter$/.test(call));
+  const hold = calls.findIndex((call, index) => index > enter && call === "sleep 6");
+  assert.notEqual(enter, -1);
+  assert.notEqual(hold, -1);
+  assert.equal(calls.slice(enter + 1, hold).filter((call) => call === "sleep 1").length, 2);
+});
+
+test("terminal expect_output polls until new command output appears", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: ["$ demo\nstarting\n", "$ demo\nstarting\n", "$ demo\nstarting\nReady\n"],
+    }),
+  });
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.status, "completed");
+  assert.equal(result.steps[0]?.presentAtStart, false);
+  assert.equal(result.steps[0]?.satisfied, true);
+  assert.ok(calls.includes("sleep 1"));
+});
+
+test("terminal expect_output records text already present in the plan-start snapshot", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    runner: terminalLifecycleRunner(calls, {
+      initialTerminalOutput: "$ Ready\n",
+      terminalCaptures: ["$ demo\nReady\n"],
+    }),
+  });
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.presentAtStart, true);
+  assert.equal(result.steps[0]?.satisfied, true);
+});
+
+test("terminal expect_output times out without matching the echoed command", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "show expected-token",
+      steps: [{ action: "expect_output", text: "expected-token" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: ["$ show expected-token\nworking\n"],
+    }),
+  });
+  assert.equal(result.status, "failed");
+  assert.equal(result.steps[0]?.status, "failed");
+  assert.equal(result.steps[0]?.presentAtStart, false);
+  assert.equal(result.steps[0]?.satisfied, false);
+  assert.match(result.steps[0]?.detail ?? "", /within 30 seconds/);
+  assert.match(result.steps[0]?.detail ?? "", /Captured pane:\n\$ show expected-token/);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 30);
+});
+
+test("terminal recording holds the end state and enforces its minimum before finalizing", () => {
+  const calls: string[] = [];
+  runTerminalFixture(terminalLifecycleRunner(calls));
+  const hold = calls.findIndex((call) => call === "sleep 6");
+  const finalize = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
+  assert.notEqual(hold, -1);
+  assert.ok(finalize > hold);
 });
 
 test("terminal driver reports display readiness timeout with all pane diagnostics", () => {
@@ -350,6 +470,55 @@ test("terminal driver waits for the recorder session to exit after sending q", (
     ).length,
     4,
   );
+});
+
+test("live-proof skips a failed drive without producing a manifest", async () => {
+  const fixture = executeFixture("failed");
+  mkdirSync(dirname(fixture.manifestPath), { recursive: true });
+  writeFileSync(fixture.manifestPath, "stale manifest", "utf8");
+  await fixture.run();
+  assert.equal(existsSync(fixture.manifestPath), false);
+  assert.match(fixture.logs.join("\n"), /skip: demonstration did not complete/);
+  assert.equal(
+    fixture.commands.some((command) => command.startsWith("ffmpeg ")),
+    false,
+  );
+});
+
+test("live-proof skips when every satisfied expectation was present at start", async () => {
+  const fixture = executeFixture("present-at-start");
+  await fixture.run();
+  assert.equal(existsSync(fixture.manifestPath), false);
+  assert.match(fixture.logs.join("\n"), /skip: plan verified nothing that changed/);
+  assert.equal(
+    fixture.commands.some((command) => command.startsWith("ffmpeg ")),
+    false,
+  );
+});
+
+test("live-proof emits a bundle when an initially absent expectation is satisfied", async () => {
+  const fixture = executeFixture("demonstrated-partial");
+  await fixture.run();
+  assert.equal(existsSync(fixture.manifestPath), true);
+  const manifest = parseLiveProofManifest(
+    JSON.parse(readFileSync(fixture.manifestPath, "utf8")) as unknown,
+  );
+  assert.equal(manifest.drive_status, "partial");
+  assert.match(fixture.logs.join("\n"), /wrote browser proof bundle/);
+});
+
+test("live-proof skips a plan with no expectation steps", async () => {
+  const fixture = executeFixture("no-expectation");
+  await fixture.run();
+  assert.equal(existsSync(fixture.manifestPath), false);
+  assert.match(fixture.logs.join("\n"), /skip: plan verified nothing that changed/);
+});
+
+test("live-proof skips a demonstrated recording shorter than three seconds", async () => {
+  const fixture = executeFixture("too-short");
+  await fixture.run();
+  assert.equal(existsSync(fixture.manifestPath), false);
+  assert.match(fixture.logs.join("\n"), /skip: recording is shorter than 3 seconds/);
 });
 
 test("live proof manifest is metadata-only and rejects URL-bearing extensions", () => {
@@ -885,6 +1054,8 @@ function terminalLifecycleRunner(
     recorderDiesAtProbe?: number;
     finalizeExitAfter?: number;
     paneOutput?: Record<"terminal" | "display" | "xterm" | "recorder", string>;
+    initialTerminalOutput?: string;
+    terminalCaptures?: string[];
   } = {},
 ): MediaProofCommandRunner {
   let displayProbe = 0;
@@ -892,6 +1063,9 @@ function terminalLifecycleRunner(
   let recorderPaneProbe = 0;
   let finalizeProbe = 0;
   let finalizing = false;
+  let typedCommand = "";
+  let commandRunning = false;
+  let terminalCaptureProbe = 0;
   const recorderSizes = options.recorderSizes ?? [1, 2];
   return (command, args) => {
     const rendered = [command, ...args].join(" ");
@@ -910,6 +1084,14 @@ function terminalLifecycleRunner(
     }
     if (command === "tmux" && args[0] === "send-keys" && args.at(-1) === "q") {
       finalizing = true;
+      return { status: 0 };
+    }
+    if (command === "tmux" && args[0] === "send-keys" && args.includes("-l")) {
+      typedCommand = String(args.at(-1) ?? "");
+      return { status: 0 };
+    }
+    if (command === "tmux" && args[0] === "send-keys" && args.at(-1) === "Enter") {
+      commandRunning = true;
       return { status: 0 };
     }
     if (command === "tmux" && args[0] === "display-message") {
@@ -931,9 +1113,146 @@ function terminalLifecycleRunner(
           : target.includes("-recorder")
             ? "recorder"
             : "terminal";
+      if (label === "terminal" && !options.paneOutput?.terminal) {
+        if (!typedCommand) {
+          return { status: 0, stdout: options.initialTerminalOutput ?? "$ \n" };
+        }
+        if (!commandRunning) return { status: 0, stdout: `$ ${typedCommand}\n` };
+        const captures = options.terminalCaptures ?? [`$ ${typedCommand}\ncommand output\n`];
+        const output = captures[Math.min(terminalCaptureProbe, captures.length - 1)] ?? "";
+        terminalCaptureProbe += 1;
+        return { status: 0, stdout: output };
+      }
       return { status: 0, stdout: `${options.paneOutput?.[label] ?? `${label} pane`}\n` };
     }
     return { status: 0 };
+  };
+}
+
+function executeFixture(
+  mode: "failed" | "present-at-start" | "demonstrated-partial" | "no-expectation" | "too-short",
+) {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-proof-execute-"));
+  const outputDir = join(directory, "output");
+  const planPath = join(directory, "plan.json");
+  const manifestPath = join(outputDir, "live-proof-manifest.json");
+  const mp4Path = join(outputDir, "live-proof.mp4");
+  const logs: string[] = [];
+  const commands: string[] = [];
+  const plan: LiveProofPlan = {
+    ...recommendedPlan("browser"),
+    steps:
+      mode === "demonstrated-partial"
+        ? [
+            { action: "click", target: "#save" },
+            { action: "expect_text", text: "Saved" },
+            { action: "wait_for", target: "#never" },
+          ]
+        : mode === "no-expectation"
+          ? [{ action: "click", target: "#save" }]
+          : [
+              { action: "click", target: "#save" },
+              { action: "expect_text", text: "Saved" },
+            ],
+  };
+  writeFileSync(planPath, JSON.stringify(plan), "utf8");
+
+  const runner: MediaProofCommandRunner = (command, args, options) => {
+    commands.push([command, ...args].join(" "));
+    if (command === "git") return { status: 0, stdout: `${HEAD}\n` };
+    if (command === "node") {
+      const env = options?.env ?? {};
+      writeFileSync(String(env.CLAWSWEEPER_LIVE_PROOF_RAW_VIDEO), "webm", "utf8");
+      const steps =
+        mode === "failed"
+          ? [
+              { action: "click", status: "failed", detail: "not visible" },
+              {
+                action: "expect_text",
+                status: "failed",
+                detail: "not visible",
+                presentAtStart: false,
+                satisfied: false,
+              },
+            ]
+          : mode === "demonstrated-partial"
+            ? [
+                { action: "click", status: "completed", detail: "ok" },
+                {
+                  action: "expect_text",
+                  status: "completed",
+                  detail: "ok",
+                  presentAtStart: false,
+                  satisfied: true,
+                },
+                { action: "wait_for", status: "failed", detail: "not visible" },
+              ]
+            : mode === "no-expectation"
+              ? [{ action: "click", status: "completed", detail: "ok" }]
+              : [
+                  { action: "click", status: "completed", detail: "ok" },
+                  {
+                    action: "expect_text",
+                    status: "completed",
+                    detail: "ok",
+                    presentAtStart: mode === "present-at-start",
+                    satisfied: true,
+                  },
+                ];
+      writeFileSync(
+        String(env.CLAWSWEEPER_LIVE_PROOF_STEPS_LOG),
+        `${JSON.stringify(steps)}\n`,
+        "utf8",
+      );
+      return {
+        status: mode === "failed" || mode === "demonstrated-partial" ? 1 : 0,
+        stderr: mode === "failed" ? "failed" : "",
+      };
+    }
+    if (command === "ffprobe") {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          streams: [{ codec_type: "video", width: 1280, height: 800 }],
+          format: { duration: mode === "too-short" ? "2.999" : "7.000" },
+        }),
+      };
+    }
+    if (command === "ffmpeg") {
+      const output = String(args.at(-1));
+      writeFileSync(output, output.endsWith(".jpg") ? "jpg" : "mp4", "utf8");
+      return { status: 0 };
+    }
+    return { status: 0 };
+  };
+
+  return {
+    commands,
+    logs,
+    manifestPath,
+    mp4Path,
+    run: () =>
+      executeLiveProof(
+        {
+          repo: "example/repo",
+          item: 42,
+          outputDir,
+          planPath,
+          checkoutPath: directory,
+        },
+        {
+          env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+          runner,
+          repositoryProfileFor: () => profile(),
+          reportLiveProofPlan: () => plan,
+          parseLiveProofPlan: () => plan,
+          fetchPullRequest: async () => {
+            throw new Error("local checkout must not fetch the pull request");
+          },
+          log: (message) => logs.push(message),
+          now: () => new Date("2026-08-17T12:00:00.000Z"),
+        },
+      ),
   };
 }
 


### PR DESCRIPTION
## Summary

Every live proof published so far was useless, and I only caught it by watching the videos rather than checking that the URLs resolved.

- Terminal clips were 0.9s: an empty prompt, the typed command, end — before any output rendered. `expect_output` captured the pane exactly once with no polling immediately after Enter, so it threw instantly; it also grepped the whole pane including the echoed command, so other plans could match the command the model had just typed.
- Browser clips ran 16s with every frame identical, because plans asserted static text already rendered at load (openclaw/clawsweeper#1182 asserted `"press /"`, the finder's own hint) and nothing scrolled the changed region into frame.
- Nothing gated attachment: `drive_status` was recorded but unused, so failed drives were uploaded and posted to public review comments.

Fixes: terminal `run` waits for real output and `expect_output` polls with a timeout against post-command content only; both drivers settle between steps, hold the end state, and honour a minimum length; browser steps scroll their target into view.

The substance gate is semantic, not pixel-based. Attachment now requires an expectation that was **absent at plan start and satisfied afterwards** — a demonstration that verifies nothing publishes nothing. Pixel-difference gating was implemented, measured against real artifacts, and rejected: the junk frozen-page recording scores SSIM 0.914 between first and last frame while a genuine blade-opening demo scores 0.980, because ambient page animation swamps any threshold. The review prompt now requires a state-changing action plus an assertion on content that is absent beforehand, and real selectors rather than prose.

## Validation

Run locally against the two real plans:
- the organic #1182 plan that produced the frozen video now logs `skip: plan verified nothing that changed` and writes no manifest — nothing would be attached;
- a plan asserting `"Found openclaw/clawsweeper#1178"` (absent at load) attaches, and its extracted frames show the input filling, the status flipping, and the toast appearing.

`pnpm build` clean; live-proof suite 33/33; full unit suite 2,326 passed / 0 failed (parallel with review, exit 0). Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.98)".

## Follow-up

The five PRs that received junk videos need cleanup once this lands: re-dispatching the same heads overwrites the head-scoped R2 objects and record block, and any plan that legitimately has nothing to show needs its stale Live Proof block stripped from the record.
