### PR TITLE
feat(live-proof): retract a published recording with detach mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 - Live-proof recordings now wait for post-action command or page expectations, hold the final state on screen, and attach only when an initially absent expectation proves a semantic change.
 - Live-proof attachment now captures each freshly hydrated canonical single-record revision as the publication baseline before retrying conflicts, then updates the public review comment only after the record lands.
+- Live-proof attachment now supports idempotently retracting a published recording while preserving its review plan and synchronizing the public comment after canonical publication.
 - Short live-proof recordings fall back to a single poster frame when the contact-sheet tile cannot emit one.
 - Terminal recorders flush WebM packets immediately and treat a live ffmpeg session as healthy while the muxer buffers.
 - Terminal live-proof recordings tune VP9 for realtime capture and accept the recorder once any payload is written, matching the encoder's bursty muxer output.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -122,6 +122,27 @@ node dist/clawsweeper.js live-proof-attach \
   --dry-run
 ```
 
+## Retracting a published recording
+
+Operators can retract a recording while preserving the legitimate Live Proof
+plan (status, surface, reason, entry, and steps). Detach mode needs no bundle
+and deliberately does not compare the record with the current PR head:
+
+```bash
+node dist/clawsweeper.js live-proof-attach \
+  --detach \
+  --record ./records/openclaw-openclaw/items/110714.md \
+  --repo-slug openclaw-openclaw \
+  --item 110714
+```
+
+The command hydrates the attempt-scoped canonical record, removes only the
+marker-backed recording block, publishes through the normal bounded-conflict
+path, and then re-renders the marker-backed GitHub comment. If the block is
+already absent, it exits successfully without publishing or updating the
+comment. Add `--dry-run` to print the report and comment mutations without
+hydrating, publishing, or changing any file.
+
 ## Security invariants
 
 - Classification is read-only and executes no target code.

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { flushWorkflowActionEvents } from "./action-ledger-runtime.js";
-import { parseArgs, stringArg, type Args } from "./clawsweeper-args.js";
+import { boolArg, parseArgs, stringArg, type Args } from "./clawsweeper-args.js";
 import { dispatchCommand, type CommandHandler } from "./clawsweeper-command-dispatch.js";
 import { createDecisionParser } from "./clawsweeper-decision-parser.js";
 import { runText } from "./command.js";
@@ -1494,6 +1494,10 @@ async function liveProofAttachCommand(args: Args): Promise<void> {
     const repo = frontMatterValue(markdown, "repository");
     if (repo) setTargetRepo(repo);
   }
+  if (boolArg(args.detach) && !boolArg(args.dry_run)) {
+    await liveProofAttachPublishCommand(args);
+    return;
+  }
   await liveProofCommands.liveProofAttachCommand(args);
 }
 
@@ -1509,6 +1513,11 @@ async function liveProofAttachPublishCommand(args: Args): Promise<void> {
   if (!/^\d+$/.test(itemText) || !Number.isSafeInteger(item) || item < 1) {
     throw new Error("--item requires a positive safe integer");
   }
+  if (boolArg(args.dry_run)) {
+    await liveProofCommands.liveProofAttachCommand(args);
+    return;
+  }
+  const detaching = boolArg(args.detach);
   const recordsUrl = process.env.QUEUE_URL?.trim() || "https://clawsweeper.openclaw.ai";
   const canonicalBaselineRoots = new Map<number, string>();
 
@@ -1559,7 +1568,7 @@ async function liveProofAttachPublishCommand(args: Args): Promise<void> {
           "repair:publish-main",
           "--",
           "--message",
-          "chore: attach live proof",
+          detaching ? "chore: detach live proof" : "chore: attach live proof",
           "--path",
           recordPath,
           "--rebase-strategy",

--- a/src/live-proof/attach.ts
+++ b/src/live-proof/attach.ts
@@ -16,6 +16,13 @@ export interface LiveProofAttachOptions {
   dryRun: boolean;
 }
 
+export interface LiveProofDetachOptions {
+  recordPath: string;
+  repositorySlug: string;
+  item: number;
+  dryRun: boolean;
+}
+
 export interface LiveProofAttachDependencies {
   env?: NodeJS.ProcessEnv;
   runner?: MediaProofCommandRunner;
@@ -30,7 +37,7 @@ export interface LiveProofAttachDependencies {
   log?: (message: string) => void;
 }
 
-export type LiveProofAttachResult = "attached" | "skipped" | "dry-run";
+export type LiveProofAttachResult = "attached" | "detached" | "unchanged" | "skipped" | "dry-run";
 
 export async function attachLiveProof(
   options: LiveProofAttachOptions,
@@ -121,6 +128,55 @@ export async function attachLiveProof(
   return "attached";
 }
 
+export function detachLiveProof(
+  options: LiveProofDetachOptions,
+  dependencies: LiveProofAttachDependencies,
+): LiveProofAttachResult {
+  const log = dependencies.log ?? console.log;
+  const recordPath = resolve(options.recordPath);
+  const report = readFileSync(recordPath, "utf8");
+  validateDetachedReportIdentity(
+    report,
+    options.repositorySlug,
+    options.item,
+    dependencies.frontMatterValue,
+  );
+  const section = dependencies.sectionValue(report, dependencies.reviewSections.liveProof);
+  const markerIndex = section.lastIndexOf(LIVE_PROOF_RECORDING_MARKER);
+  if (markerIndex < 0) {
+    log(
+      `[live-proof-attach] detach: ${options.repositorySlug}#${options.item} has no recording block; no changes needed`,
+    );
+    return "unchanged";
+  }
+
+  const liveProofSection = section.slice(0, markerIndex).trimEnd();
+  if (!liveProofSection) throw new Error("record is missing the Live Proof plan section");
+  const updatedReport = dependencies.replaceSectionValue(
+    report,
+    dependencies.reviewSections.liveProof,
+    liveProofSection,
+  );
+  const closeReason = (dependencies.frontMatterValue(updatedReport, "close_reason") ??
+    "none") as CloseReason;
+  const comment = dependencies.renderReviewCommentFromReport(updatedReport, closeReason);
+  const markedComment = dependencies.markedReviewCommentBody(options.item, comment);
+
+  if (options.dryRun) {
+    log(
+      `[live-proof-attach] dry-run: replace ## ${dependencies.reviewSections.liveProof} in ${recordPath} with:\n${liveProofSection}`,
+    );
+    log(
+      `[live-proof-attach] dry-run: publish ${recordPath}, then upsert marker-backed review comment for ${options.repositorySlug}#${options.item}:\n${markedComment}`,
+    );
+    return "dry-run";
+  }
+
+  writeFileSync(recordPath, updatedReport, "utf8");
+  log(`[live-proof-attach] detached recording from ${options.repositorySlug}#${options.item}`);
+  return "detached";
+}
+
 export function syncLiveProofComment(
   options: Pick<LiveProofAttachOptions, "bundleDir" | "recordPath">,
   dependencies: LiveProofAttachDependencies,
@@ -149,6 +205,35 @@ export function syncLiveProofComment(
   );
 }
 
+export function syncDetachedLiveProofComment(
+  options: Omit<LiveProofDetachOptions, "dryRun">,
+  dependencies: LiveProofAttachDependencies,
+): void {
+  const recordPath = resolve(options.recordPath);
+  const report = readFileSync(recordPath, "utf8");
+  validateDetachedReportIdentity(
+    report,
+    options.repositorySlug,
+    options.item,
+    dependencies.frontMatterValue,
+  );
+  if (
+    dependencies
+      .sectionValue(report, dependencies.reviewSections.liveProof)
+      .includes(LIVE_PROOF_RECORDING_MARKER)
+  ) {
+    throw new Error("record still contains the Live Proof recording");
+  }
+  const closeReason = (dependencies.frontMatterValue(report, "close_reason") ??
+    "none") as CloseReason;
+  const comment = dependencies.renderReviewCommentFromReport(report, closeReason);
+  const markedComment = dependencies.markedReviewCommentBody(options.item, comment);
+  dependencies.upsertReviewComment(options.item, markedComment);
+  (dependencies.log ?? console.log)(
+    `[live-proof-attach] synced retracted marker-backed review comment for ${options.repositorySlug}#${options.item}`,
+  );
+}
+
 function validateReportIdentity(
   report: string,
   manifest: LiveProofManifest,
@@ -165,6 +250,29 @@ function validateReportIdentity(
   }
   if (frontMatterValue(report, "pull_head_sha")?.toLowerCase() !== manifest.head_sha) {
     throw new Error("record pull_head_sha does not match the live proof manifest");
+  }
+}
+
+function validateDetachedReportIdentity(
+  report: string,
+  repositorySlug: string,
+  item: number,
+  frontMatterValue: (markdown: string, key: string) => string | undefined,
+): void {
+  const repository = frontMatterValue(report, "repository") ?? "";
+  const actualSlug = repository
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (actualSlug !== repositorySlug.toLowerCase()) {
+    throw new Error("record repository does not match --repo-slug");
+  }
+  if (Number(frontMatterValue(report, "number")) !== item) {
+    throw new Error("record item number does not match --item");
+  }
+  if (frontMatterValue(report, "type") !== "pull_request") {
+    throw new Error("live proof can only be detached from a pull request report");
   }
 }
 

--- a/src/live-proof/commands.ts
+++ b/src/live-proof/commands.ts
@@ -3,6 +3,8 @@ import type { LiveProofPlan, MediaProofCommandRunner } from "../clawsweeper-type
 import type { RepositoryProfile } from "../repository-profiles.js";
 import {
   attachLiveProof,
+  detachLiveProof,
+  syncDetachedLiveProofComment,
   syncLiveProofComment,
   type LiveProofAttachDependencies,
 } from "./attach.js";
@@ -56,8 +58,25 @@ export function createLiveProofCommands(dependencies: LiveProofCommandDependenci
   }
 
   async function liveProofAttachCommand(args: Args) {
-    const bundleDir = requiredArg(args.bundle, "--bundle");
     const recordPath = requiredArg(args.record, "--record");
+    if (boolArg(args.detach)) {
+      return detachLiveProof(
+        {
+          recordPath,
+          repositorySlug: requiredRepositorySlugArg(args.repo_slug),
+          item: positiveIntegerArg(args.item ?? args.item_number, "--item"),
+          dryRun: boolArg(args.dry_run),
+        },
+        {
+          ...dependencies.attach,
+          fetchPullRequest,
+          ...(dependencies.runner ? { runner: dependencies.runner } : {}),
+          ...(dependencies.env ? { env: dependencies.env } : {}),
+          ...(dependencies.log ? { log: dependencies.log } : {}),
+        },
+      );
+    }
+    const bundleDir = requiredArg(args.bundle, "--bundle");
     return attachLiveProof(
       {
         bundleDir,
@@ -75,8 +94,25 @@ export function createLiveProofCommands(dependencies: LiveProofCommandDependenci
   }
 
   function liveProofCommentCommand(args: Args): void {
-    const bundleDir = requiredArg(args.bundle, "--bundle");
     const recordPath = requiredArg(args.record, "--record");
+    if (boolArg(args.detach)) {
+      syncDetachedLiveProofComment(
+        {
+          recordPath,
+          repositorySlug: requiredRepositorySlugArg(args.repo_slug),
+          item: positiveIntegerArg(args.item ?? args.item_number, "--item"),
+        },
+        {
+          ...dependencies.attach,
+          fetchPullRequest,
+          ...(dependencies.runner ? { runner: dependencies.runner } : {}),
+          ...(dependencies.env ? { env: dependencies.env } : {}),
+          ...(dependencies.log ? { log: dependencies.log } : {}),
+        },
+      );
+      return;
+    }
+    const bundleDir = requiredArg(args.bundle, "--bundle");
     syncLiveProofComment(
       { bundleDir, recordPath },
       {
@@ -157,6 +193,14 @@ function positiveIntegerArg(value: ArgValue, label: string): number {
   const result = Number(requiredArg(value, label));
   if (!Number.isSafeInteger(result) || result <= 0) {
     throw new Error(`${label} must be a positive integer`);
+  }
+  return result;
+}
+
+function requiredRepositorySlugArg(value: ArgValue): string {
+  const result = requiredArg(value, "--repo-slug");
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(result)) {
+    throw new Error("--repo-slug must be a canonical repository slug");
   }
   return result;
 }

--- a/src/live-proof/publication.ts
+++ b/src/live-proof/publication.ts
@@ -28,7 +28,7 @@ export async function publishLiveProofAttachment(
   for (let attempt = 1; attempt <= LIVE_PROOF_PUBLICATION_ATTEMPTS; attempt += 1) {
     await dependencies.hydrateRecord(attempt);
     const outcome = await dependencies.attachRecord(attempt);
-    if (outcome !== "attached") return outcome;
+    if (outcome !== "attached" && outcome !== "detached") return outcome;
 
     try {
       await dependencies.publishRecord(attempt);

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -9,7 +9,13 @@ import YAML from "yaml";
 import { REVIEW_SECTIONS } from "../dist/clawsweeper-policy.js";
 import type { LiveProofPlan, MediaProofCommandRunner } from "../dist/clawsweeper-types.js";
 import type { RepositoryProfile } from "../dist/repository-profiles.js";
-import { attachLiveProof, syncLiveProofComment } from "../dist/live-proof/attach.js";
+import {
+  attachLiveProof,
+  detachLiveProof,
+  syncDetachedLiveProofComment,
+  syncLiveProofComment,
+} from "../dist/live-proof/attach.js";
+import { createLiveProofCommands } from "../dist/live-proof/commands.js";
 import {
   driveTerminal,
   generatePlaywrightScript,
@@ -603,6 +609,234 @@ test("live-proof attach publishes the record before syncing its marker-backed co
   assert.match(publishedBody, /<!-- clawsweeper-review item=42 -->/);
 });
 
+test("live-proof detach removes only the recording block", () => {
+  const fixture = recordedAttachmentFixture();
+  const before = readFileSync(fixture.recordPath, "utf8");
+  const result = detachLiveProof(
+    {
+      recordPath: fixture.recordPath,
+      repositorySlug: "example-repo",
+      item: 42,
+      dryRun: false,
+    },
+    attachDependencies({
+      runner: mediaRunner([]),
+      fetchPullRequest: async () => {
+        throw new Error("detach must not fetch the pull request");
+      },
+      upsertReviewComment: () => {
+        throw new Error("detach must not sync the comment before publication");
+      },
+      logs: fixture.logs,
+    }),
+  );
+
+  const after = readFileSync(fixture.recordPath, "utf8");
+  assert.equal(result, "detached");
+  assert.equal(
+    after,
+    before.replace(
+      /\n\n<!-- clawsweeper-live-proof-recording -->[\s\S]*?(?=\n## Work Candidate)/,
+      "\n",
+    ),
+  );
+  assert.match(after, /Status: recommended[\s\S]*- \{"action":"expect_text","text":"Saved"\}/);
+  assert.match(after, /## Work Candidate\n\nCandidate: none/);
+  assert.doesNotMatch(after, /clawsweeper-live-proof-recording|Live proof recording|Recorded live/);
+});
+
+test("live-proof detach is a clean no-op when the record has no recording block", () => {
+  const fixture = attachmentFixture();
+  const before = readFileSync(fixture.recordPath, "utf8");
+  const result = detachLiveProof(
+    {
+      recordPath: fixture.recordPath,
+      repositorySlug: "example-repo",
+      item: 42,
+      dryRun: false,
+    },
+    attachDependencies({
+      runner: mediaRunner([]),
+      fetchPullRequest: async () => {
+        throw new Error("detach must not fetch the pull request");
+      },
+      upsertReviewComment: () => ({}),
+      logs: fixture.logs,
+    }),
+  );
+
+  assert.equal(result, "unchanged");
+  assert.equal(readFileSync(fixture.recordPath, "utf8"), before);
+  assert.match(fixture.logs.join("\n"), /has no recording block; no changes needed/);
+});
+
+test("live-proof detach syncs the marker-backed comment only after publication", async () => {
+  const fixture = recordedAttachmentFixture();
+  const calls: string[] = [];
+  const result = await publishLiveProofAttachment({
+    hydrateRecord: () => calls.push("hydrate"),
+    attachRecord: async () => {
+      calls.push("detach");
+      return detachLiveProof(
+        {
+          recordPath: fixture.recordPath,
+          repositorySlug: "example-repo",
+          item: 42,
+          dryRun: false,
+        },
+        attachDependencies({
+          runner: mediaRunner([]),
+          fetchPullRequest: async () => {
+            throw new Error("detach must not fetch the pull request");
+          },
+          upsertReviewComment: () => ({}),
+          logs: fixture.logs,
+        }),
+      );
+    },
+    publishRecord: () => calls.push("publish"),
+    syncComment: () => {
+      calls.push("comment");
+      syncDetachedLiveProofComment(
+        { recordPath: fixture.recordPath, repositorySlug: "example-repo", item: 42 },
+        attachDependencies({
+          runner: mediaRunner([]),
+          fetchPullRequest: async () => {
+            throw new Error("detach must not fetch the pull request");
+          },
+          upsertReviewComment: (_number, body) => {
+            assert.doesNotMatch(body, /clawsweeper-live-proof-recording|Live proof recording/);
+            return {};
+          },
+          logs: fixture.logs,
+        }),
+      );
+    },
+    isCanonicalConflict: isCanonicalPublicationConflict,
+  });
+
+  assert.equal(result, "detached");
+  assert.deepEqual(calls, ["hydrate", "detach", "publish", "comment"]);
+});
+
+test("live-proof detach dry-run prints mutations without changing the record", () => {
+  const fixture = recordedAttachmentFixture();
+  const before = readFileSync(fixture.recordPath, "utf8");
+  const result = detachLiveProof(
+    {
+      recordPath: fixture.recordPath,
+      repositorySlug: "example-repo",
+      item: 42,
+      dryRun: true,
+    },
+    attachDependencies({
+      runner: mediaRunner([]),
+      fetchPullRequest: async () => {
+        throw new Error("detach dry-run must not fetch the pull request");
+      },
+      upsertReviewComment: () => {
+        throw new Error("detach dry-run must not sync the comment");
+      },
+      logs: fixture.logs,
+    }),
+  );
+
+  assert.equal(result, "dry-run");
+  assert.equal(readFileSync(fixture.recordPath, "utf8"), before);
+  const output = fixture.logs.join("\n");
+  assert.match(output, /dry-run: replace ## Live Proof/);
+  assert.match(output, /dry-run: publish .* then upsert marker-backed review comment/);
+  assert.doesNotMatch(output, /Live proof recording/);
+});
+
+test("live-proof attach command accepts detach without a bundle", async () => {
+  const fixture = recordedAttachmentFixture();
+  const dependencies = attachDependencies({
+    runner: mediaRunner([]),
+    fetchPullRequest: async () => {
+      throw new Error("detach must not fetch the pull request");
+    },
+    upsertReviewComment: () => ({}),
+    logs: fixture.logs,
+  });
+  const commands = createLiveProofCommands({
+    repositoryProfileFor: () => profile(),
+    reportLiveProofPlan: () => recommendedPlan(),
+    parseLiveProofPlan: () => recommendedPlan(),
+    attach: dependencies,
+    fetchPullRequest: dependencies.fetchPullRequest,
+    log: dependencies.log,
+  });
+
+  const result = await commands.liveProofAttachCommand({
+    _: ["live-proof-attach"],
+    detach: true,
+    record: fixture.recordPath,
+    repo_slug: "example-repo",
+    item: "42",
+    dry_run: true,
+  });
+
+  assert.equal(result, "dry-run");
+});
+
+test("live-proof detach rejects record identity mismatches without requiring a manifest", () => {
+  const fixture = recordedAttachmentFixture();
+  const dependencies = attachDependencies({
+    runner: mediaRunner([]),
+    fetchPullRequest: async () => {
+      throw new Error("detach must not fetch the pull request");
+    },
+    upsertReviewComment: () => ({}),
+    logs: fixture.logs,
+  });
+
+  assert.throws(
+    () =>
+      detachLiveProof(
+        {
+          recordPath: fixture.recordPath,
+          repositorySlug: "other-repo",
+          item: 42,
+          dryRun: false,
+        },
+        dependencies,
+      ),
+    /record repository does not match --repo-slug/,
+  );
+  assert.throws(
+    () =>
+      detachLiveProof(
+        {
+          recordPath: fixture.recordPath,
+          repositorySlug: "example-repo",
+          item: 41,
+          dryRun: false,
+        },
+        dependencies,
+      ),
+    /record item number does not match --item/,
+  );
+  writeFileSync(
+    fixture.recordPath,
+    readFileSync(fixture.recordPath, "utf8").replace("type: pull_request", "type: issue"),
+    "utf8",
+  );
+  assert.throws(
+    () =>
+      detachLiveProof(
+        {
+          recordPath: fixture.recordPath,
+          repositorySlug: "example-repo",
+          item: 42,
+          dryRun: false,
+        },
+        dependencies,
+      ),
+    /live proof can only be detached from a pull request report/,
+  );
+});
+
 test("live-proof publication retries from a lagged hydration and publishes the fresh canonical baseline", async () => {
   const calls: string[] = [];
   const hydratedRevisions = ["revision-5", "revision-6"];
@@ -1017,6 +1251,27 @@ Candidate: none
     "utf8",
   );
   return { bundleDir, recordPath, logs };
+}
+
+function recordedAttachmentFixture() {
+  const fixture = attachmentFixture();
+  const report = readFileSync(fixture.recordPath, "utf8");
+  writeFileSync(
+    fixture.recordPath,
+    report.replace(
+      "\n## Work Candidate",
+      `
+<!-- clawsweeper-live-proof-recording -->
+
+[![Live proof recording](https://media.example.test/poster.jpg)](https://media.example.test/proof.mp4)
+
+*Recorded live on the PR head (\`${HEAD.slice(0, 12)}\`), 4s, browser surface.*
+
+## Work Candidate`,
+    ),
+    "utf8",
+  );
+  return fixture;
 }
 
 function mediaRunner(commands: string[]): MediaProofCommandRunner {


### PR DESCRIPTION
## Summary

#1199 stopped the lane from publishing recordings that demonstrate nothing, but it cannot remove blocks already written to durable records — and because the marker-backed comment is re-rendered from the record, the junk persists indefinitely. Three PRs are in exactly that state today (openclaw/openclaw#110714, #122591 and openclaw/clawsweeper#1182 all correctly re-ran and skipped, leaving their old blocks in place).

`live-proof-attach --detach` retracts one. It removes only the recording block and keeps the plan (still legitimate review output), is a clean no-op when no block exists, works after the head has moved — a retraction must not require a matching manifest or SHA — and reuses the attach path's attempt-scoped hydrated baseline, bounded canonical-conflict retry, and comment-sync-after-publication so the record and the public comment lose the block together. `--dry-run` previews the mutations.

```bash
node dist/clawsweeper.js live-proof-attach --detach \
  --record ./records/openclaw-openclaw/items/110714.md \
  --repo-slug openclaw-openclaw --item 110714
```

## Validation

- `pnpm build` clean; live-proof suite 39/39; full unit suite 2,332 passed / 0 failed (parallel with review, exit 0).
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.96)".
