### PR TITLE
feat(live-proof): retract published recordings from workflow dispatch

### DIFF
--- a/.github/workflows/live-proof.yml
+++ b/.github/workflows/live-proof.yml
@@ -7,6 +7,14 @@ on:
     types: [clawsweeper_live_proof]
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Attach or retract a live-proof recording"
+        required: true
+        default: attach
+        type: choice
+        options:
+          - attach
+          - retract
       repo:
         description: "Target repository"
         required: true
@@ -22,6 +30,7 @@ env:
 
 jobs:
   execute:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'attach' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions: {}
@@ -148,7 +157,7 @@ jobs:
 
   attach:
     needs: execute
-    if: ${{ needs.execute.outputs.produced == 'true' }}
+    if: ${{ always() && !cancelled() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'retract') || needs.execute.outputs.produced == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -159,22 +168,42 @@ jobs:
           ref: main
           persist-credentials: false
 
+      - name: Resolve target
+        id: target
+        env:
+          EVENT_REPO: ${{ github.event.client_payload.repo || inputs.repo }}
+          EVENT_ITEM: ${{ github.event.client_payload.item || inputs.item }}
+        run: |
+          set -euo pipefail
+          repo="$(printf '%s' "$EVENT_REPO" | tr '[:upper:]' '[:lower:]')"
+          item="$EVENT_ITEM"
+          if ! [[ "$repo" =~ ^[a-z0-9_.-]+/[a-z0-9_.-]+$ ]] || ! [[ "$item" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid live-proof target: $repo#$item" >&2
+            exit 1
+          fi
+          {
+            echo "repo_owner=${repo%%/*}"
+            echo "repo_name=${repo#*/}"
+            echo "repo_slug=${repo//\//-}"
+            echo "item=$item"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create target write token
         id: target-write-token
         uses: ./.github/actions/create-target-write-token
         with:
           client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
-          owner: ${{ needs.execute.outputs.repo_owner }}
-          repository: ${{ needs.execute.outputs.repo_name }}
+          owner: ${{ steps.target.outputs.repo_owner }}
+          repository: ${{ steps.target.outputs.repo_name }}
 
       - uses: ./.github/actions/setup-state
         with:
           coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
-          records-repo-slugs: ${{ needs.execute.outputs.repo_slug }}
-          records-item-number: ${{ needs.execute.outputs.item }}
+          records-repo-slugs: ${{ steps.target.outputs.repo_slug }}
+          records-item-number: ${{ steps.target.outputs.item }}
           hydrate-git-state: "false"
           hydrate-state-blobs: "false"
 
@@ -183,17 +212,20 @@ jobs:
           build-script: build:all
 
       - name: Install media validators
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'attach' }}
         run: |
           sudo apt-get update
           sudo apt-get install --yes ffmpeg
 
       - uses: actions/download-artifact@v8
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'attach' }}
         with:
-          name: live-proof-${{ needs.execute.outputs.repo_slug }}-${{ needs.execute.outputs.item }}
+          name: live-proof-${{ steps.target.outputs.repo_slug }}-${{ steps.target.outputs.item }}
           path: live-proof-bundle
 
-      - name: Validate, upload, and attach live proof
+      - name: Publish live-proof change
         env:
+          MODE: ${{ inputs.mode || 'attach' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_AWS_SECRET_ACCESS_KEY }}
           CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT: ${{ secrets.CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT }}
@@ -204,9 +236,17 @@ jobs:
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
         run: |
           set -euo pipefail
-          record="records/${{ needs.execute.outputs.repo_slug }}/items/${{ needs.execute.outputs.item }}.md"
+          record="records/${{ steps.target.outputs.repo_slug }}/items/${{ steps.target.outputs.item }}.md"
+          if [ "$MODE" = "retract" ]; then
+            node dist/clawsweeper.js live-proof-attach \
+              --detach \
+              --record "$record" \
+              --repo-slug "${{ steps.target.outputs.repo_slug }}" \
+              --item "${{ steps.target.outputs.item }}"
+            exit 0
+          fi
           node dist/clawsweeper.js live-proof-attach-publish \
             --bundle live-proof-bundle \
             --record "$record" \
-            --repo-slug "${{ needs.execute.outputs.repo_slug }}" \
-            --item "${{ needs.execute.outputs.item }}"
+            --repo-slug "${{ steps.target.outputs.repo_slug }}" \
+            --item "${{ steps.target.outputs.item }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Live-proof recordings can now be retracted through a trusted manual workflow dispatch without rerunning target code or requiring an artifact, manifest, or matching head SHA.
 - Live-proof recordings now wait for post-action command or page expectations, hold the final state on screen, and attach only when an initially absent expectation proves a semantic change.
 - Live-proof attachment now captures each freshly hydrated canonical single-record revision as the publication baseline before retrying conflicts, then updates the public review comment only after the record lands.
 - Live-proof attachment now supports idempotently retracting a published recording while preserving its review plan and synchronizing the public comment after canonical publication.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -23,7 +23,9 @@ terminal-only repository that has no configured server or URL.
 
 ## Execute and attach
 
-The workflow has two jobs with different trust. `execute` has
+The workflow has two jobs with different trust. Manual dispatch defaults to
+`mode=attach`; `mode=retract` skips `execute` entirely and runs only the trusted
+publication path described below. `execute` has
 `permissions: {}`, receives no secret environment values, checks out the public
 PR head, and runs setup/start commands from the trusted repository profile. It
 contains no model call. Browser plans are serialized as JSON data into a
@@ -129,19 +131,22 @@ plan (status, surface, reason, entry, and steps). Detach mode needs no bundle
 and deliberately does not compare the record with the current PR head:
 
 ```bash
-node dist/clawsweeper.js live-proof-attach \
-  --detach \
-  --record ./records/openclaw-openclaw/items/110714.md \
-  --repo-slug openclaw-openclaw \
-  --item 110714
+gh workflow run live-proof.yml \
+  --repo openclaw/clawsweeper \
+  --ref main \
+  -f mode=retract \
+  -f repo=openclaw/openclaw \
+  -f item=110714
 ```
 
-The command hydrates the attempt-scoped canonical record, removes only the
+The trusted job validates the target, mints its target-scoped write token, and
+hydrates only that canonical Worker record using the same setup as attachment.
+It then invokes `live-proof-attach --detach`, which removes only the
 marker-backed recording block, publishes through the normal bounded-conflict
-path, and then re-renders the marker-backed GitHub comment. If the block is
-already absent, it exits successfully without publishing or updating the
-comment. Add `--dry-run` to print the report and comment mutations without
-hydrating, publishing, or changing any file.
+path, and re-renders the marker-backed GitHub comment. Retraction never
+downloads an artifact, reads a manifest, or compares a head SHA. If the block
+is already absent, it exits successfully without publishing or updating the
+comment.
 
 ## Security invariants
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -977,14 +977,40 @@ test("live-proof attach dry-run prints exact uploads and mutations without perfo
 test("live-proof workflow keeps execute secretless and attach trusted", () => {
   const source = readFileSync(".github/workflows/live-proof.yml", "utf8");
   const workflow = YAML.parse(source) as {
-    on: { workflow_dispatch: { inputs: Record<string, unknown> } };
+    on: {
+      workflow_dispatch: {
+        inputs: Record<string, { default?: string; options?: string[]; type?: string }>;
+      };
+    };
     env: Record<string, string>;
-    jobs: Record<string, Record<string, unknown>>;
+    jobs: Record<
+      string,
+      {
+        if?: string;
+        permissions?: Record<string, unknown>;
+        steps?: Array<{ name?: string; if?: string; run?: string; uses?: string }>;
+      }
+    >;
   };
-  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["repo", "item"]);
+  assert.deepEqual(Object.keys(workflow.on.workflow_dispatch.inputs), ["mode", "repo", "item"]);
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs.mode, {
+    description: "Attach or retract a live-proof recording",
+    required: true,
+    default: "attach",
+    type: "choice",
+    options: ["attach", "retract"],
+  });
   assert.equal(workflow.env.CLAWSWEEPER_APP_CLIENT_ID, "Iv23liOECG0slfuhz093");
   assert.deepEqual(workflow.jobs.execute?.permissions, {});
   assert.doesNotMatch(JSON.stringify(workflow.jobs.execute), /secrets\./);
+  assert.equal(
+    workflow.jobs.execute?.if,
+    "${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'attach' }}",
+  );
+  assert.equal(
+    workflow.jobs.attach?.if,
+    "${{ always() && !cancelled() && ((github.event_name == 'workflow_dispatch' && inputs.mode == 'retract') || needs.execute.outputs.produced == 'true') }}",
+  );
   assert.match(source, /uses: \.\/\.github\/actions\/create-target-write-token/);
   assert.match(source, /CLAWSWEEPER_LIVE_PROOF_S3_ENDPOINT: \$\{\{ secrets\./);
   assert.match(source, /setsid timeout --kill-after=30s 1500s/);
@@ -992,7 +1018,25 @@ test("live-proof workflow keeps execute secretless and attach trusted", () => {
   assert.match(source, /--record \.\.\/live-proof-report\.md/);
   assert.doesNotMatch(source, /--plan \.\.\/live-proof/);
   assert.match(source, /live-proof-attach-publish/);
-  assert.match(source, /--repo-slug "\$\{\{ needs\.execute\.outputs\.repo_slug \}\}"/);
+  assert.match(source, /--repo-slug "\$\{\{ steps\.target\.outputs\.repo_slug \}\}"/);
+
+  const attachSteps = workflow.jobs.attach?.steps ?? [];
+  const attachOnly = "${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'attach' }}";
+  assert.equal(
+    attachSteps.find((step) => step.name === "Install media validators")?.if,
+    attachOnly,
+  );
+  assert.equal(
+    attachSteps.find((step) => step.uses === "actions/download-artifact@v8")?.if,
+    attachOnly,
+  );
+  const publish = attachSteps.find((step) => step.name === "Publish live-proof change")?.run ?? "";
+  assert.match(publish, /if \[ "\$MODE" = "retract" \]; then/);
+  assert.match(publish, /live-proof-attach \\\n+\s+--detach \\\n+\s+--record "\$record"/);
+  assert.doesNotMatch(
+    publish.slice(0, publish.indexOf("exit 0")),
+    /--bundle|manifest|head[_-]sha/i,
+  );
 
   const dispatchActionSource = readFileSync(
     ".github/actions/dispatch-live-proofs/action.yml",


### PR DESCRIPTION
## Summary

`--detach` (#1200) exists only as a CLI, but retraction needs the records-Worker hydration and target write token that only a workflow job holds — so the stale recordings on public PRs could not actually be removed. Three PRs are in that state today (openclaw/openclaw#110714, openclaw/openclaw#122591, openclaw/clawsweeper#1182: all re-ran correctly under #1199 and skipped, so nothing overwrote their old blocks).

`live-proof.yml` gains a `mode` input (`attach` default, `retract`). Retraction skips the untrusted execute job entirely and reuses the existing trusted attach setup — no new `setup-state` site, so the audited inventory stays at 22 — and requires no artifact, manifest, or matching head SHA, since a retraction must work after the head has moved.

```bash
gh workflow run live-proof.yml --repo openclaw/clawsweeper --ref main \
  -f mode=retract -f repo=openclaw/openclaw -f item=110714
```

## Validation

- `pnpm build` clean; live-proof suite 39/39; state-writer audit 8/8 (setup-state count unchanged at 22); full unit suite 2,332 passed / 0 failed.
- Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.99)".
