### PR TITLE
fix(live-proof): scroll browser targets into view best effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Browser live proofs treat scroll-into-view as best effort so continuously animated targets stay clickable.
 - Live-proof recordings can now be retracted through a trusted manual workflow dispatch without rerunning target code or requiring an artifact, manifest, or matching head SHA.
 - Live-proof recordings now wait for post-action command or page expectations, hold the final state on screen, and attach only when an initially absent expectation proves a semantic change.
 - Live-proof attachment now captures each freshly hydrated canonical single-record revision as the publication baseline before retrying conflicts, then updates the public review comment only after the record lands.

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -97,7 +97,9 @@ try {
         case "goto": await page.goto(new URL(step.path, baseUrl).href); break;
         case "click": {
           const locator = page.locator(step.target);
-          await locator.scrollIntoViewIfNeeded();
+          // Best-effort framing only: continuously animated targets never
+          // settle, and a failed scroll must not defeat the force-click below.
+          await locator.scrollIntoViewIfNeeded({ timeout: 2_000 }).catch(() => undefined);
           // Fall back to a force click so continuously animated targets (whose
           // position never stabilizes) can still be demonstrated.
           try { await locator.click({ timeout: 5_000 }); }
@@ -108,14 +110,14 @@ try {
         case "press": await page.keyboard.press(step.key); break;
         case "wait_for": {
           const locator = page.locator(step.target);
-          await locator.scrollIntoViewIfNeeded();
+          await locator.scrollIntoViewIfNeeded({ timeout: 2_000 }).catch(() => undefined);
           await locator.waitFor({ state: "visible" });
           break;
         }
         case "wait": await page.waitForTimeout(step.seconds * 1000); break;
         case "expect_text": {
           const locator = page.getByText(step.text, { exact: false }).first();
-          await locator.scrollIntoViewIfNeeded();
+          await locator.scrollIntoViewIfNeeded({ timeout: 2_000 }).catch(() => undefined);
           await locator.waitFor({ state: "visible" });
           break;
         }

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -207,13 +207,19 @@ test("Playwright generation keeps quotes, backticks, and newlines inside JSON da
   assert.equal(checked.status, 0, checked.stderr);
 });
 
-test("Playwright steps scroll targets into view, settle, and hold a six-second minimum", () => {
+test("Playwright scrolls targets into view best effort, settles, and holds a six-second minimum", () => {
   const script = generatePlaywrightScript([
     { action: "click", target: "#save" },
     { action: "wait_for", target: "#result" },
     { action: "expect_text", text: "Saved" },
   ]);
-  assert.equal(script.match(/scrollIntoViewIfNeeded\(\)/g)?.length, 3);
+  // Scrolling is best effort: continuously animated targets never settle, and a
+  // failed scroll must not defeat the force-click fallback (openclaw/clawsweeper
+  // Bay critters made every click time out before this).
+  assert.equal(
+    script.match(/scrollIntoViewIfNeeded\(\{ timeout: 2_000 \}\)\.catch\(\(\) => undefined\)/g)?.length,
+    3,
+  );
   assert.match(script, /await page\.waitForTimeout\(700\)/);
   assert.match(script, /Math\.max\(3000, 6000 - elapsed\)/);
 });


### PR DESCRIPTION
## Summary

Browser live proofs could not demonstrate anything on animated pages. #1199 added `scrollIntoViewIfNeeded()` for framing, but it ran *before* the force-click fallback and threw after a 15s timeout on targets that never stop moving — the OpenClaw Bay shoreline critters are precisely that case. Every bay UI plan therefore failed at its first click and skipped with "plan verified nothing that changed", which looked like a plan-quality problem and was actually this regression.

Scrolling is now bounded (2s) and non-fatal; the click or visibility wait still decides whether the step succeeded, so the force-click fallback works again.

## Validation

Recorded locally against the seeded Bay demo after the fix: all 9 plan steps completed, 24.7s, and the frames show the detail blade opening with canonical links and ordered job steps, then the finder resolving a reference. Before the fix the identical plan skipped at step 2.

`pnpm build` clean; live-proof suite 39/39. Autoreview (Codex, gpt-5.6-sol, high): clean, "patch is correct (0.99)".
