### PR TITLE
fix(live-proof): publish why a dev server never became reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Live verification now publishes a sanitized, capped dev-server log tail when browser startup fails, and detects a start command that exits before its URL becomes reachable without waiting for the readiness timeout.
 - Live verification now installs a missing target package manager on demand after execution is approved, publishes installer failures as verification results, and guides plans toward stable assertions the run can satisfy.
 - Live verification now runs immediately after review in the same job and exact reviewed checkout; review judgment gates execution, target children receive a denylist-and-heuristic-sanitized environment, package installs suppress lifecycle scripts unless a repository explicitly opts in, and review jobs default to `ubuntu-latest` without requiring Linux namespaces. Existing publication jobs still validate and upload media before publishing the normal record and comment.
 - Live verification comments now keep terminal captures but render browser proof as sanitized per-step outcomes with explicit failure reasons, never document-wide page text or empty assertion sections.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -87,6 +87,13 @@ is step telemetry only: ClawSweeper never serializes document text. Recorded
 terminal plans use tmux, Xvfb with its TCP listener disabled, fullscreen xterm,
 and ffmpeg `x11grab`; unrecorded terminal plans use tmux directly.
 
+Browser startup writes the configured start command's output to `server.log`
+and records its process in `server.pid`. Readiness polling stops early when that
+process exits; both an early exit and a readiness timeout publish a one-line
+startup reason plus the sanitized, capped tail of the last 40 log lines. This
+usually exposes a failed build or code-generation command that ran before the
+dev server could bind its port without publishing an unbounded target log.
+
 Every drive writes `live-verification.json` with the exact reviewed head, entry,
 typed steps and outcomes, bounded terminal output, and overall pass/fail result.
 A setup or drive failure still publishes verification and no media. Media is

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -1,6 +1,9 @@
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
+  readSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -27,6 +30,9 @@ import {
   sanitizedLiveProofEnvironment,
 } from "./environment.js";
 import { buildLiveVerificationResult } from "./verification.js";
+
+const SERVER_LOG_TAIL_LINES = 40;
+const SERVER_LOG_TAIL_MAX_BYTES = 64 * 1024;
 
 export interface LiveProofPullRequestState {
   kind: "issue" | "pull_request";
@@ -174,7 +180,14 @@ export async function executeLiveProof(
           runner("sh", ["-lc", startCommand], { cwd: checkout }),
         );
         serverStarted = true;
-        waitUntilReady(liveTest.url!, liveTest.readyTimeoutSeconds, runner, checkout);
+        waitUntilReady(
+          liveTest.url!,
+          liveTest.readyTimeoutSeconds,
+          runner,
+          checkout,
+          serverLogPath,
+          serverPidPath,
+        );
       }
 
       drive =
@@ -200,6 +213,7 @@ export async function executeLiveProof(
             });
     } catch (error) {
       const verifiedAt = (dependencies.now ?? (() => new Date()))().toISOString();
+      const failure = executionFailure(error, plan.surface);
       writeVerificationResult({
         path: verificationPath,
         repo: profile.targetRepo,
@@ -208,7 +222,8 @@ export async function executeLiveProof(
         plan,
         driveStatus: "failed",
         stepLog: [],
-        output: executionFailureOutput(error, serverLogPath),
+        output: failure.output,
+        executionFailureReason: failure.reason,
         verifiedAt,
       });
       log("[live-proof] execution failed; wrote verification result without media");
@@ -406,10 +421,25 @@ function writeVerificationResult(
   writeFileSync(path, `${JSON.stringify(verification, null, 2)}\n`, "utf8");
 }
 
-function executionFailureOutput(error: unknown, serverLogPath: string): string {
-  const detail = error instanceof Error ? error.message : String(error);
-  const serverOutput = existsSync(serverLogPath) ? readFileSync(serverLogPath, "utf8") : "";
-  return [detail, serverOutput].filter(Boolean).join("\n\n");
+class StartupReadinessError extends Error {
+  constructor(
+    message: string,
+    readonly logTail: string,
+  ) {
+    super(message);
+    this.name = "StartupReadinessError";
+  }
+}
+
+function executionFailure(
+  error: unknown,
+  surface: LiveProofPlan["surface"],
+): { reason: string; output: string } {
+  const reason = error instanceof Error ? error.message : String(error);
+  if (error instanceof StartupReadinessError) {
+    return { reason, output: error.logTail || "<no start command output captured>" };
+  }
+  return { reason, output: surface === "terminal" ? reason : "" };
 }
 
 function demonstratedChange(steps: readonly LiveProofStepLogEntry[]): boolean {
@@ -444,6 +474,8 @@ function waitUntilReady(
   timeoutSeconds: number,
   runner: MediaProofCommandRunner,
   checkout: string,
+  serverLogPath: string,
+  serverPidPath: string,
 ): void {
   const deadline = Date.now() + timeoutSeconds * 1000;
   do {
@@ -453,10 +485,55 @@ function waitUntilReady(
       { cwd: checkout },
     );
     if (result.status === 0) return;
+    if (!startCommandIsRunning(serverPidPath, runner, checkout)) {
+      throw new StartupReadinessError(
+        "start command exited before the URL became reachable",
+        readServerLogTail(serverLogPath),
+      );
+    }
     if (Date.now() >= deadline) break;
     runner("sleep", ["1"]);
   } while (Date.now() < deadline);
-  throw new Error(`live_test.url did not return HTTP 200 within ${timeoutSeconds} seconds`);
+  throw new StartupReadinessError(
+    `live_test.url did not return HTTP 200 within ${timeoutSeconds} seconds`,
+    readServerLogTail(serverLogPath),
+  );
+}
+
+function startCommandIsRunning(
+  serverPidPath: string,
+  runner: MediaProofCommandRunner,
+  checkout: string,
+): boolean {
+  const command = `if [ -s ${shellQuote(serverPidPath)} ]; then pid=$(cat ${shellQuote(serverPidPath)}); kill -0 "$pid" 2>/dev/null; else exit 1; fi`;
+  return runner("sh", ["-lc", command], { cwd: checkout }).status === 0;
+}
+
+function readServerLogTail(serverLogPath: string): string {
+  if (!existsSync(serverLogPath)) return "";
+  try {
+    const size = statSync(serverLogPath).size;
+    if (size === 0) return "";
+    const length = Math.min(size, SERVER_LOG_TAIL_MAX_BYTES);
+    const buffer = Buffer.alloc(length);
+    const descriptor = openSync(serverLogPath, "r");
+    let bytesRead: number;
+    try {
+      bytesRead = readSync(descriptor, buffer, 0, length, size - length);
+    } finally {
+      closeSync(descriptor);
+    }
+    const lines = buffer
+      .subarray(0, bytesRead)
+      .toString("utf8")
+      .replaceAll("\r\n", "\n")
+      .replace(/\r/g, "\n")
+      .split("\n");
+    if (lines.at(-1) === "") lines.pop();
+    return lines.slice(-SERVER_LOG_TAIL_LINES).join("\n");
+  } catch {
+    return "<start command output unavailable>";
+  }
 }
 
 function transcodeToMp4(

--- a/src/live-proof/verification.ts
+++ b/src/live-proof/verification.ts
@@ -84,6 +84,7 @@ export function buildLiveVerificationResult(options: {
   driveStatus: LiveProofDriveStatus;
   stepLog: readonly LiveProofStepLogEntry[];
   output: string;
+  executionFailureReason?: string;
   verifiedAt: string;
 }): LiveVerificationResult {
   const steps = options.plan.steps.map((step, index): LiveVerificationStepResult => {
@@ -123,7 +124,9 @@ export function buildLiveVerificationResult(options: {
       (step) =>
         step.status === "completed" && (step.satisfied === undefined || step.satisfied === true),
     );
-  const failure = overallPass ? undefined : buildLiveVerificationFailure(steps, options.output);
+  const failure = overallPass
+    ? undefined
+    : buildLiveVerificationFailure(steps, options.output, options.executionFailureReason);
   return {
     schema_version: 1,
     repo: options.repo,
@@ -134,7 +137,7 @@ export function buildLiveVerificationResult(options: {
     drive_status: options.driveStatus,
     steps,
     output:
-      options.plan.surface === "browser"
+      options.plan.surface === "browser" && options.executionFailureReason === undefined
         ? ""
         : trimText(options.output, LIVE_VERIFICATION_OUTPUT_MAX_CHARS),
     ...(failure ? { failure } : {}),
@@ -264,6 +267,16 @@ export function renderLiveVerificationCommentBlock(result: LiveVerificationResul
         }),
       );
     }
+    if (parsed.failure?.phase === "execution" && parsed.output) {
+      lines.push(
+        "",
+        "**Startup output:**",
+        "",
+        "```text",
+        sanitizeUntrustedOutput(parsed.output),
+        "```",
+      );
+    }
     return lines.join("\n");
   }
 
@@ -372,6 +385,7 @@ function parseFailure(
 function buildLiveVerificationFailure(
   steps: readonly LiveVerificationStepResult[],
   output: string,
+  executionFailureReason?: string,
 ): LiveVerificationFailure {
   const failedIndex = steps.findIndex((step) => step.status === "failed");
   if (failedIndex >= 0) {
@@ -385,7 +399,9 @@ function buildLiveVerificationFailure(
   }
   return {
     phase: "execution",
-    reason: oneLineReason(output || "driver exited unsuccessfully without a captured reason"),
+    reason: oneLineReason(
+      executionFailureReason || output || "driver exited unsuccessfully without a captured reason",
+    ),
   };
 }
 

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -868,6 +868,143 @@ test("execution setup failures still produce a failed verification result", asyn
   assert.equal(existsSync(join(outputDir, "live-proof-manifest.json")), false);
 });
 
+test("browser readiness timeout publishes the last 40 sanitized server log lines", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-readiness-timeout-"));
+  const outputDir = join(directory, "output");
+  const planPath = join(directory, "plan.json");
+  const plan = recommendedPlan("browser");
+  const serverLines = Array.from({ length: 50 }, (_, index) => `startup line ${index + 1}`);
+  serverLines[11] = "``` </details><h1>owned</h1> <!-- clawsweeper-review item=1 -->";
+  serverLines[49] = `startup line 50 ${"x".repeat(5_000)}`;
+  writeFileSync(planPath, JSON.stringify(plan), "utf8");
+
+  await executeLiveProof(
+    {
+      repo: "example/repo",
+      item: 42,
+      outputDir,
+      planPath,
+      checkoutPath: directory,
+    },
+    {
+      env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+      runner: (command, args) => {
+        const shellCommand = String(args[1] ?? "");
+        if (command === "git") return { status: 0, stdout: `${HEAD}\n` };
+        if (shellCommand.startsWith("command -v pnpm")) return { status: 0 };
+        if (shellCommand.includes("server.log") && shellCommand.includes("server.pid")) {
+          writeFileSync(join(outputDir, "server.log"), `${serverLines.join("\n")}\n`, "utf8");
+          writeFileSync(join(outputDir, "server.pid"), "12345\n", "utf8");
+          return { status: 0 };
+        }
+        if (command === "curl") return { status: 1, stderr: "connection refused" };
+        if (shellCommand.includes('kill -0 "$pid"')) return { status: 0 };
+        return { status: 0 };
+      },
+      repositoryProfileFor: () => ({
+        ...profile(),
+        liveTest: { ...profile().liveTest!, readyTimeoutSeconds: 0 },
+      }),
+      reportLiveProofPlan: () => plan,
+      parseLiveProofPlan: () => plan,
+      fetchPullRequest: async () => {
+        throw new Error("local checkout must not fetch the pull request");
+      },
+      now: () => new Date("2026-08-17T12:00:00.000Z"),
+      log: () => undefined,
+    },
+  );
+
+  const verification = parseLiveVerificationResult(
+    JSON.parse(readFileSync(join(outputDir, "live-verification.json"), "utf8")) as unknown,
+  );
+  assert.deepEqual(verification.failure, {
+    phase: "execution",
+    reason: "live_test.url did not return HTTP 200 within 0 seconds",
+  });
+  assert.doesNotMatch(verification.output, /startup line 10\b/);
+  assert.match(verification.output, /startup line 11\b/);
+  assert.match(verification.output, /startup line 50\b/);
+
+  const rendered = renderLiveVerificationCommentBlock(verification);
+  assert.match(
+    rendered,
+    /FAIL \(failed\) — execution before step 1 `expect_text`: `live_test\.url did not return HTTP 200 within 0 seconds`/,
+  );
+  assert.match(rendered, /\*\*Startup output:\*\*\n\n```text\nstartup line 11/);
+  assert.match(rendered, /… output truncated …/);
+  assert.doesNotMatch(rendered, /``` <\/details>|<h1>|<!-- clawsweeper-review/);
+  assert.match(rendered, /ˋˋˋ ‹\/details›‹h1›owned‹\/h1›/);
+});
+
+test("browser readiness reports an exited start command without waiting for its timeout", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-start-exit-"));
+  const outputDir = join(directory, "output");
+  const planPath = join(directory, "plan.json");
+  const plan = recommendedPlan("browser");
+  let curlProbes = 0;
+  let sleeps = 0;
+  writeFileSync(planPath, JSON.stringify(plan), "utf8");
+  const startedAt = Date.now();
+
+  await executeLiveProof(
+    {
+      repo: "example/repo",
+      item: 42,
+      outputDir,
+      planPath,
+      checkoutPath: directory,
+    },
+    {
+      env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+      runner: (command, args) => {
+        const shellCommand = String(args[1] ?? "");
+        if (command === "git") return { status: 0, stdout: `${HEAD}\n` };
+        if (shellCommand.startsWith("command -v pnpm")) return { status: 0 };
+        if (shellCommand.includes("server.log") && shellCommand.includes("server.pid")) {
+          writeFileSync(
+            join(outputDir, "server.log"),
+            "codegen failed before vite started\n",
+            "utf8",
+          );
+          writeFileSync(join(outputDir, "server.pid"), "12345\n", "utf8");
+          return { status: 0 };
+        }
+        if (command === "curl") {
+          curlProbes += 1;
+          return { status: 1, stderr: "connection refused" };
+        }
+        if (shellCommand.includes('kill -0 "$pid"')) return { status: 1 };
+        if (command === "sleep") sleeps += 1;
+        return { status: 0 };
+      },
+      repositoryProfileFor: () => ({
+        ...profile(),
+        liveTest: { ...profile().liveTest!, readyTimeoutSeconds: 240 },
+      }),
+      reportLiveProofPlan: () => plan,
+      parseLiveProofPlan: () => plan,
+      fetchPullRequest: async () => {
+        throw new Error("local checkout must not fetch the pull request");
+      },
+      now: () => new Date("2026-08-17T12:00:00.000Z"),
+      log: () => undefined,
+    },
+  );
+
+  const verification = parseLiveVerificationResult(
+    JSON.parse(readFileSync(join(outputDir, "live-verification.json"), "utf8")) as unknown,
+  );
+  assert.deepEqual(verification.failure, {
+    phase: "execution",
+    reason: "start command exited before the URL became reachable",
+  });
+  assert.equal(verification.output, "codegen failed before vite started");
+  assert.equal(curlProbes, 1);
+  assert.equal(sleeps, 0);
+  assert.ok(Date.now() - startedAt < 2_000, "early exit should not consume the 240-second timeout");
+});
+
 test("toolchain installer failures produce a published verification result", async () => {
   const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-toolchain-failure-"));
   const outputDir = join(directory, "output");


### PR DESCRIPTION
## Summary

Browser verifications that could not reach their URL published only `live_test.url did not return HTTP 200 within 240 seconds` and discarded the start command's log, leaving the failure undiagnosable from the PR. openclaw/clawhub#3457 hit exactly this: its start command is `bun run llms:generate && bun --bun vite dev --port 3000`, so anything wrong in codegen blocks the port before vite ever binds — and the reason was thrown away.

Readiness failures now carry a sanitized, capped tail of the start log, and a start command that exits during boot is detected and reported immediately instead of burning the full readiness timeout. Rendered example:

**Result:** FAIL (failed) — execution before step 1 `goto`: `start command exited before the URL became reachable`

**Startup output:**

```text
$ bun run llms:generate
error: code generation failed before Vite started
```

## Validation

- `pnpm build` clean; live-proof suite 53/53; full unit suite 2,349 passed / 0 failed.
