### PR TITLE
docs: align operator guidance with current workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,14 +60,18 @@ data-contract changes, name the affected Bay surface and its proof. Otherwise,
 state why Bay is unaffected. See AGENTS.md.
 -->
 
-## Documentation Lifecycle
+## Documentation Impact
 
 <!--
-For new or changed documentation, classify it as active, proposed,
+For every code, configuration, workflow, API, UI, package, policy, or integration
+change, name the canonical documentation reviewed and summarize any required
+updates. If no documentation changes are needed, explain why the existing
+contract remains accurate.
+
+For new or changed documentation, also classify it as active, proposed,
 compatibility-only, or historical. Active runbooks and volatile references must
 name their role owner, source of truth, verified scope/revision, and update
-triggers. Otherwise state that no documentation lifecycle changes. See
-CONTRIBUTING.md.
+triggers. See CONTRIBUTING.md.
 -->
 
 ## Evidence

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: the linked repository files and their owning code,
   configuration, workflows, and tests
-- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: a document is added, retired, moved, changes lifecycle, or gains a
   new canonical owner
 

--- a/docs/commit-sweeper.md
+++ b/docs/commit-sweeper.md
@@ -5,7 +5,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: `src/commit-sweeper.ts`, `prompts/review-commit.md`, package
   scripts, and local-review tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: local range selection, network/token isolation, model-service
   requirements, output artifacts, or the retired hosted boundary changes
 

--- a/docs/github-egress-telemetry.md
+++ b/docs/github-egress-telemetry.md
@@ -6,7 +6,7 @@
   `src/github-egress-telemetry-contract.ts`,
   `src/review-activity-cursor.ts`, `dashboard/github-egress-telemetry.ts`, and
   the publication workflows
-- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: a publication request path, credential selection rule, telemetry
   dimension, retention limit, or public response changes
 - Checked by: focused telemetry tests plus `pnpm run check:docs`

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: `config/automation-limits.json`, Worker overrides, and
   `scripts/check-limits.ts`
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: worker budgets, lane ratios, workflow literals, or production
   capacity overrides change; run `pnpm run check:limits`
 

--- a/docs/live-dashboard.md
+++ b/docs/live-dashboard.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers and the designated Cloudflare operator
 - Source of truth: `dashboard/worker.ts`, `dashboard/exact-review-queue.ts`,
   `dashboard/wrangler.toml`, dashboard tests, and deployed read-only endpoints
-- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: routes, public fields, queue projections, capacity, alerts,
   deployment, or state-writer telemetry changes
 

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -5,6 +5,7 @@
 - Source of truth: `src/live-proof/`, `.github/workflows/sweep.yml`,
   `.github/workflows/exact-review-batch-publish.yml`, and repository `live_test`
   profiles
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: the plan schema, security boundary, execution gates, media
   limits, storage path, or comment rendering changes
 

--- a/docs/openclaw-bay-demo.md
+++ b/docs/openclaw-bay-demo.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: `dashboard/bay-page.ts`, public Worker and queue projectors,
   Bay tests, and the read-only `/bay` route
-- Last verified: `openclaw/clawsweeper@71b16d208511700bb241ea06276c94f71c977d89`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: lane names, stage mapping, public projection or completeness
   rules, private-state ownership, routes, or navigation changes
 

--- a/docs/openclaw-event-hooks.md
+++ b/docs/openclaw-event-hooks.md
@@ -1,5 +1,13 @@
 # OpenClaw Event Hooks
 
+- Status: active integration and operator reference
+- Owner: ClawSweeper notification and activity-stream maintainers
+- Source of truth: `.github/workflows/github-activity.yml`,
+  `.github/workflows/repair-publish-results.yml`, and `src/repair/*notify*`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
+- Update when: hook payloads, delivery policy, activity filtering, runtime setup,
+  notification ledgers, or workflow ownership changes
+
 ClawSweeper can forward important automation events to OpenClaw through the
 Gateway hook API. The pattern is generic: a deterministic ClawSweeper workflow
 detects an event, posts a small authenticated payload to OpenClaw, and OpenClaw
@@ -200,13 +208,11 @@ is intentionally lossy because it is not a source of truth. Exact review,
 repair, automerge, apply, and command-router workflows have separate
 concurrency groups and are not cancelled by this observer lane.
 
-The workflow intentionally uses the runner-provided Node runtime plus a lean
-uncached pnpm install instead of `actions/setup-node` or the shared cached pnpm
-action. This event stream can burst dozens of runs at once, and downloading
-extra setup/cache actions has proven slower and less reliable than a direct
-install/build path for the small notifier. The activity notifier is kept
-compatible with the runner's Node 20+ runtime even though the broader project
-gate still uses Node 24.
+The workflow pins Node 24 with `actions/setup-node`, enables the repository's
+pinned pnpm version, and caches the pnpm store before installing and building
+the repair notifier. The activity stream can burst dozens of runs at once, so
+its concurrency group remains lossy even though each admitted run uses the
+normal supported runtime and dependency cache.
 
 The activity prompt always treats GitHub titles, comments, review bodies, and
 issue text as untrusted data. It must not follow instructions embedded in those

--- a/docs/operator-configuration.md
+++ b/docs/operator-configuration.md
@@ -3,7 +3,7 @@
 - Status: active operator reference
 - Owner: ClawSweeper deployment and workflow maintainers
 - Source of truth: `dashboard/wrangler.toml` and `.github/workflows/`
-- Last verified: `openclaw/clawsweeper@2b5b345063efe1690e1d802fb1a738aa6a408707`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: an audited name is removed, renamed, or changes responsibility, or a source-verified ownership gap is added to this inventory
 - Checked by: `pnpm run check:docs`
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -3,7 +3,7 @@
 - Status: active operator reference
 - Owner: ClawSweeper dashboard maintainers
 - Source of truth: `dashboard/worker.ts` request routing and its focused tests
-- Last verified: `openclaw/clawsweeper@a1795973a9e6bb00b73cd6adc21a4ea02ca78ced`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: a public observer route, method, query parameter, response source, or authentication boundary changes
 - Checked by: `pnpm run check:docs`
 

--- a/docs/repair/README.md
+++ b/docs/repair/README.md
@@ -6,7 +6,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: repair source, workflows, `package.json`, and focused repair
   tests; [operations](operations.md) is canonical for live procedures
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: repair modes, command entry points, job/result shape, or linked
   canonical guides change
 

--- a/docs/repair/auto-update-prs.md
+++ b/docs/repair/auto-update-prs.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: comment router, repair worker/executor, finalizers, labels,
   merge gates, and focused automerge tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: command trust, adoption, repair budgets, labels, validation,
   exact-head review, merge, or stop/resume behavior changes
 

--- a/docs/repair/internal-features.md
+++ b/docs/repair/internal-features.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: `src/repair/**`, repair workflows, job/result schemas, and
   focused repair tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: internal objects, execution stages, routing, ledgers, gates, or
   extension points change
 

--- a/docs/repair/operations.md
+++ b/docs/repair/operations.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers and the authorized repair operator
 - Source of truth: repair workflows/source, current gates, focused tests, and
   live read-only GitHub state where needed
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: commands, trust checks, gates, tokens, runners, routing,
   publication, recovery, or promotion rules change
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: `.github/workflows/sweep.yml`, planner/runtime source,
   `config/automation-limits.json`, and focused scheduler tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: cadence, fanout, admission, retry, publication, apply, or
   state-writing behavior changes
 
@@ -104,6 +104,13 @@ the reported cooldown into its next-attempt timestamp, preventing a parked
 cohort from becoming eligible in lockstep; coordination and ordinary failure
 retries keep their existing timing.
 Review publication and apply/comment sync use separate non-dropping queues.
+Apply treats a typed GitHub installation or abuse-rate-limit response as a
+bounded yield, not a failed scan. It checkpoints completed item work, records
+the interrupted item as `skipped_runtime_budget`, returns that item to the
+cursor, and exits successfully so a later scheduled or continuation cycle can
+retry it. This applies to comment-only sync and close-mode apply. Folder
+reconciliation also defers before mutation when its open-item scan is
+rate-limited; ordinary non-rate-limit failures remain fatal.
 The source fallback publication minimum, base, and maximum are 4, 24, and 48,
 but production overrides them to 8, 32, and 40. The adaptive controller
 classifies GitHub pressure:

--- a/docs/spam-scanner.md
+++ b/docs/spam-scanner.md
@@ -1,5 +1,13 @@
 # Spam Scanner
 
+- Status: active trust-boundary and operator reference
+- Owner: ClawSweeper spam-intake maintainers
+- Source of truth: `.github/workflows/spam-comment-intake.yml`,
+  `.github/workflows/spam-scanner.yml`, and `src/repair/spam-*`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
+- Update when: event intake, candidate filtering, workflow inputs, model routing,
+  audit records, or mutation policy changes
+
 Read when changing ClawSweeper comment spam detection, audit records, or org
 blocking policy.
 
@@ -36,7 +44,6 @@ Inputs:
 - `max_comments`: cap for prioritized scanned comments
 - `comment_ids`: exact issue comment replay
 - `review_comment_ids`: exact PR review comment replay
-- `model`: public model alias, default `internal`
 - `force_reprocess`: ignore the processed-version ledger for replay
 
 The workflow checks out the live ClawSweeper repo plus hydrated generated state,
@@ -46,6 +53,14 @@ publishes the resulting files through `repair:publish-main`.
 The current scheduled workflow is active, but GitHub cron delivery can lag or
 drop a newly added workflow's first tick. Manual dispatch is the immediate
 verification path.
+
+New or edited issue and pull-request review comments also have an event-driven
+path. The GitHub activity workflow runs the deterministic spam intake filter;
+target repositories may forward the same normalized activity through
+`clawsweeper_spam_comment_intake`. Only comments with a qualifying deterministic
+signal dispatch `clawsweeper_spam_comment`, which invokes `spam-scanner.yml` for
+that exact comment with `max_comments=1`. The hourly scan remains the bounded
+catch-up path.
 
 ## Comment Sources
 
@@ -71,6 +86,7 @@ Protected authors are skipped before model spend:
 - `OWNER`
 - `MEMBER`
 - `COLLABORATOR`
+- `CONTRIBUTOR`
 - GitHub bot accounts
 - configured trusted bots
 
@@ -172,6 +188,5 @@ gh workflow run spam-scanner.yml \
   -f target_repo=openclaw/openclaw \
   -f lookback_minutes=180 \
   -f max_comments=100 \
-  -f model=internal \
   -f force_reprocess=false
 ```

--- a/docs/steerable-repair-automation.md
+++ b/docs/steerable-repair-automation.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: repair source/workflows, CrabFleet integration, dashboard
   telemetry, and controlled behavior proof
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: session lifecycle, steering, runner/auth boundary, capacity,
   proof, dashboard, or recovery protocol changes
 

--- a/docs/target-dispatcher.md
+++ b/docs/target-dispatcher.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers and target-repository maintainers
 - Source of truth: the embedded dispatcher workflow, receiver workflow,
   repository profiles, and dispatcher tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: forwarded events, authentication, payloads, permissions, close
   authority, or installation steps change
 

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -4,7 +4,7 @@
 - Owner: ClawSweeper maintainers
 - Source of truth: `config/target-repositories.json`, repository profiles,
   target inventory, dashboard/apply configuration, and profile tests
-- Last verified: `openclaw/clawsweeper@9c32c14c65b0551b43a10c2086c0031338ae41e7`
+- Last verified: `openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19`
 - Update when: profile policy, supported owners, inventory, dashboard targets,
   apply membership, or onboarding requirements change
 


### PR DESCRIPTION
## What Problem This Solves

Resolves documentation drift that left a broken spam-scanner dispatch example,
incorrect GitHub activity runtime guidance, incomplete apply-throttle behavior,
and stale or missing verification metadata. The PR template also did not require
behavior-bearing changes to state their documentation impact.

## Why This Change Was Made

Align the active documentation set to
`openclaw/clawsweeper@647503ec44b8e777dd172adf974a945367da0d19` and require
relevant PRs to explain their documentation impact. This is intentionally a
documentation/template-only change; it does not modify workflow behavior.

## User Impact

Operators get commands and runtime guidance that match current main, including
the event-driven spam path and resumable apply-throttling semantics.
Contributors are prompted to update or explicitly assess canonical
documentation whenever behavior-bearing surfaces change.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes documentation and the contributor PR
template only; it does not change Bay routes, projections, public fields, or
controls.

## Documentation Impact

The changed pages are active operator, integration, architecture, or
trust-boundary references. Their role owners, sources of truth, verification
revision, and update triggers are recorded at the top of each volatile page.
The activity and spam runbooks now match their current owners, and the scheduler
documents apply/comment-sync and folder-reconciliation throttle deferrals
without promising reset-aware retry timing.

## Evidence

- `git diff --check origin/main`: passed.
- `node scripts/check-docs.mjs`: passed.
- `node scripts/check-limits.ts`: passed.
- Exact docs-only head: `8653dcc5825c4e5a19ef5d6a73101f9edbd43b1f`.
- Native committed-range Codex review against `origin/main`: clean after the
  accepted wording correction below.
- No live workflow dispatch, GitHub apply/close operation, or production
  mutation was performed. Runtime proof is not applicable because the branch
  changes only Markdown and the PR template.

### Review disposition

- An early review found the protected-author list omitted `CONTRIBUTOR`; the
  spam-scanner documentation now includes it.
- The docs-only committed-range review found that scheduler wording promised a
  retry after GitHub's reported reset even though a continuation can run sooner.
  The text now states only that a later scheduled or continuation cycle retries
  the item.
- The final committed-range review found no actionable defects.
- No Rank-up moves were proposed.
