### PR TITLE
Add a review-only Awesome Claws profile

### DIFF
--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -25,6 +25,26 @@
       }
     },
     {
+      "target_repo": "giodl73-repo/awesome-claws",
+      "display_name": "Awesome Claws",
+      "checkout_dir": "awesome-claws",
+      "prompt_note": "Use the Awesome Claws source tree and current main branch. Read the repository AGENTS.md and contribution admission guide before reviewing starter proposals or pull requests. For a new Claw, use the repository similarity report and related GitHub items to compare the actual user, repeatable job, workflow, outputs, evidence model, and authority boundary. Similarity is advisory: never auto-close, auto-fix, or auto-merge a new-Claw proposal from title or lexical overlap. Route unresolved catalog admission to Patrick and Gio as a product decision.",
+      "apply_close_rules": {
+        "issue": [],
+        "pull_request": []
+      },
+      "package_manager": "npm",
+      "validation_commands": ["npm run check"],
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": ["npm ci"],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
+    },
+    {
       "target_repo": "openclaw/clawsweeper",
       "display_name": "ClawSweeper",
       "checkout_dir": "clawsweeper",

--- a/docs/target-repositories.md
+++ b/docs/target-repositories.md
@@ -24,6 +24,9 @@ close rules in `apply_close_rules`; do not infer those rules from whether the
 repository appears in the dashboard or receives scheduled work. The current
 configured profiles allow `implemented_on_main` for issues and PRs, and some
 profiles additionally allow age-gated `mostly_implemented_on_main` for PRs.
+The Awesome Claws contribution profile is deliberately review-only: similarity
+evidence can inform catalog admission, but only its maintainers decide whether
+a proposal is a new Claw, an improvement, a variant, or a product decision.
 
 Dashboard targets are configured separately with `TARGET_REPOS` in
 `dashboard/wrangler.toml`. Scheduled target selection comes from

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -99,6 +99,19 @@ test("repositoryProfileFor supports fs-safe event reviews", () => {
   ]);
 });
 
+test("Awesome Claws keeps contribution admission review-only", () => {
+  const profile = repositoryProfileFor("giodl73-repo/awesome-claws");
+
+  assert.equal(profile.slug, "giodl73-repo-awesome-claws");
+  assert.equal(profile.checkoutDir, "awesome-claws");
+  assert.equal(profile.packageManager, "npm");
+  assert.deepEqual(profile.applyCloseRules.issue, []);
+  assert.deepEqual(profile.applyCloseRules.pull_request, []);
+  assert.deepEqual(profile.liveTest?.setup, ["npm ci"]);
+  assert.match(profile.promptNote, /contribution admission guide/);
+  assert.match(profile.promptNote, /never auto-close, auto-fix, or auto-merge/);
+});
+
 test("generic OpenClaw fallback supports conservative event-only onboarding", () => {
   const profile = repositoryProfileFor("OpenClaw/example-tool");
 


### PR DESCRIPTION
## Summary

- add an explicit `giodl73-repo/awesome-claws` repository profile
- keep issue and pull-request close rules empty so contribution admission remains human-owned
- provide npm validation and contribution-specific review guidance
- document that similarity can inform, but never decide, catalog admission

Supports giodl73-repo/awesome-claws#27.

## Validation

- `pnpm run build`
- `node --test test/repository-profiles.test.ts` (17 tests)
- final code review clean

The repository is intentionally not added to scheduled inventory, dashboard, or apply membership.