### PR TITLE
fix: require verified provenance for main-implemented PR closes

### DIFF
--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -75,6 +75,13 @@ whether the fix is in the latest release or main-only, and whether a merged or
 open related PR now owns the work. When current `main` solves the issue with
 high-confidence source, history, and release/main-only evidence, prefer an
 `implemented_on_main` close even if the fix has not shipped in a release yet.
+For a pull request, source resemblance, an overlapping feature, or a current
+main commit alone is never sufficient to propose `implemented_on_main` or
+`mostly_implemented_on_main`. Require a GitHub-verified, merged fixing PR in
+the same repository, with an explicit connection to the requested behavior.
+If that connection is incomplete, ambiguous, cross-repository, or only
+inferred from filenames/commit text, keep the PR open and do not close any
+linked issue. A linked issue is not permission or proof to close either item.
 If a meaningful requested behavior remains missing, keep the item open or link
 the canonical remaining work.
 
@@ -632,6 +639,11 @@ Use reason-specific anchors:
   release tag/version. If it is only on current `main`, say that and include the
   commit timestamp. If you cannot establish either the shipped release or the
   main-only timestamp with high confidence, keep the item open.
+  For PR closure, additionally require a same-repository merged fixing PR that
+  GitHub formally identifies as closing the relevant issue or request; cite its
+  PR URL in the review and final closeout. A commit with no such PR, a PR that
+  only happens to touch nearby code, an unverified issue link, or an ambiguous
+  partial implementation is a keep-open result, not an automatic close.
 - For `cannot_reproduce`, distinguish missing reporter evidence from a report
   whose concrete mechanism is disproved. Search the complete current tree,
   source history, renamed paths, and shipped version when identified; trace the

--- a/src/clawsweeper-apply-close-execution.ts
+++ b/src/clawsweeper-apply-close-execution.ts
@@ -35,6 +35,7 @@ type ApplyCloseExecutionDependencies = Pick<
   | "implementedOnMainPullRequestProvenanceApplyBlock"
   | "issueRecentHumanCommentBlockReasonSafe"
   | "lowSignalUnmergeablePrApplyBlockReasonSafe"
+  | "mutationErrorMessage"
   | "normalizeLabelName"
   | "removeCurrentCursorTraceItem"
   | "replaceFrontMatterValue"
@@ -151,6 +152,7 @@ export function executeApplyClose(
     implementedOnMainPullRequestProvenanceApplyBlock,
     issueRecentHumanCommentBlockReasonSafe,
     lowSignalUnmergeablePrApplyBlockReasonSafe,
+    mutationErrorMessage,
     normalizeLabelName,
     removeCurrentCursorTraceItem,
     replaceFrontMatterValue,
@@ -321,17 +323,26 @@ export function executeApplyClose(
   const closeMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
   if (closeMutationLeaseBlockReason) return skipLease(closeMutationLeaseBlockReason);
   logProgress(`closing #${number}`);
-  const closeAppliedCommentReason =
-    item.kind === "pull_request"
-      ? ensureCloseAppliedComment({
-          number,
-          closeReason,
-          markdown: getMarkdown(),
-          itemUrl: item.url,
-          dryRun,
-        })
-      : null;
+  let closeAppliedCommentReason: string | null = null;
   if (dryRun) {
+    const finalImplementationProvenanceBlock = implementedOnMainPullRequestProvenanceApplyBlock(
+      getMarkdown(),
+      item,
+      closeReason,
+    );
+    if (finalImplementationProvenanceBlock) {
+      return skip("kept_open", finalImplementationProvenanceBlock);
+    }
+    closeAppliedCommentReason =
+      item.kind === "pull_request"
+        ? ensureCloseAppliedComment({
+            number,
+            closeReason,
+            markdown: getMarkdown(),
+            itemUrl: item.url,
+            dryRun,
+          })
+        : null;
     const stop = onClosed(
       {
         number,
@@ -361,7 +372,29 @@ export function executeApplyClose(
     }
   }
   // Preserve the archive label after an uncertain close; the revival watcher reconciles it.
+  // The earlier check avoids unnecessary apply work; this one closes the race with the mutation.
+  const finalImplementationProvenanceBlock = implementedOnMainPullRequestProvenanceApplyBlock(
+    getMarkdown(),
+    item,
+    closeReason,
+  );
+  if (finalImplementationProvenanceBlock) {
+    return skip("kept_open", finalImplementationProvenanceBlock);
+  }
   closeItem({ number, kind: item.kind, reason: closeReason });
+  if (item.kind === "pull_request") {
+    try {
+      closeAppliedCommentReason = ensureCloseAppliedComment({
+        number,
+        closeReason,
+        markdown: getMarkdown(),
+        itemUrl: item.url,
+        dryRun,
+      });
+    } catch (error) {
+      closeAppliedCommentReason = `close-applied comment failed after close: ${mutationErrorMessage(error)}`;
+    }
+  }
   let postCloseRuntimeYieldReason: string | null = null;
   try {
     ensureRuntimeDelayFits(closeDelayMs, "before close delay");

--- a/src/clawsweeper-apply-close-execution.ts
+++ b/src/clawsweeper-apply-close-execution.ts
@@ -18,6 +18,10 @@ import type {
 } from "./clawsweeper-types.js";
 import type { MaintainerDecision } from "./decision-packets.js";
 import { IDEA_ARCHIVE_LABEL } from "./idea-archive-revival.js";
+import {
+  isGitHubRequiresAuthenticationError,
+  isLockedConversationCommentError,
+} from "./github-retry.js";
 
 type ApplyCloseExecutionDependencies = Pick<
   CreateApplyDecisionWorkflowDependencies,
@@ -35,7 +39,6 @@ type ApplyCloseExecutionDependencies = Pick<
   | "implementedOnMainPullRequestProvenanceApplyBlock"
   | "issueRecentHumanCommentBlockReasonSafe"
   | "lowSignalUnmergeablePrApplyBlockReasonSafe"
-  | "mutationErrorMessage"
   | "normalizeLabelName"
   | "removeCurrentCursorTraceItem"
   | "replaceFrontMatterValue"
@@ -122,6 +125,9 @@ interface ApplyCloseExecutionOptions {
   proofResult: () => PrCloseCoverageProofGateResult | undefined;
   recordApplySkipped: (action: ActionTaken, reason: string) => boolean;
   recordMutation: (parentEventId?: string | null) => void;
+  rememberSelfMutationUpdatedAt: (options?: {
+    allowsPostReviewAutomationActivity?: boolean;
+  }) => void;
   recordReviewLeaseSkip: (reason: string, preserveLease?: boolean) => boolean;
   recordRuntimeBudgetYield: (reason: string) => void;
   repo: string;
@@ -152,7 +158,6 @@ export function executeApplyClose(
     implementedOnMainPullRequestProvenanceApplyBlock,
     issueRecentHumanCommentBlockReasonSafe,
     lowSignalUnmergeablePrApplyBlockReasonSafe,
-    mutationErrorMessage,
     normalizeLabelName,
     removeCurrentCursorTraceItem,
     replaceFrontMatterValue,
@@ -196,6 +201,7 @@ export function executeApplyClose(
     proofResult,
     recordApplySkipped,
     recordMutation,
+    rememberSelfMutationUpdatedAt,
     recordReviewLeaseSkip,
     recordRuntimeBudgetYield,
     repo,
@@ -362,14 +368,44 @@ export function executeApplyClose(
   const preCloseMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
   if (preCloseMutationLeaseBlockReason) return skipLease(preCloseMutationLeaseBlockReason);
   ensureRuntimeDelayFits(closeDelayMs, "before close");
-  if (closeReason === "unsponsored_feature_request") {
-    const needsIdeaArchiveLabel = !item.labels.map(normalizeLabelName).includes(IDEA_ARCHIVE_LABEL);
-    ensureIdeaArchiveLabel(recordMutation);
-    if (needsIdeaArchiveLabel) {
-      addIssueLabel(number, IDEA_ARCHIVE_LABEL, recordMutation);
-      item.labels.push(IDEA_ARCHIVE_LABEL);
-      setMarkdown(replaceFrontMatterValue(getMarkdown(), "labels", JSON.stringify(item.labels)));
+  try {
+    closeAppliedCommentReason =
+      item.kind === "pull_request"
+        ? ensureCloseAppliedComment({
+            number,
+            closeReason,
+            markdown: getMarkdown(),
+            itemUrl: item.url,
+            dryRun,
+          })
+        : null;
+  } catch (error) {
+    if (isGitHubRequiresAuthenticationError(error)) {
+      return skip(
+        "skipped_comment_auth",
+        "GitHub rejected closeout evidence comment write with Requires authentication",
+      );
     }
+    if (isLockedConversationCommentError(error)) {
+      return skip(
+        "skipped_locked_conversation",
+        "conversation was locked while recording closeout evidence",
+        true,
+      );
+    }
+    throw error;
+  }
+  if (/^(?:posted|updated) close-applied comment$/.test(closeAppliedCommentReason ?? "")) {
+    // The comment updates the PR's activity timestamp. Admit only this verified
+    // self-mutation before the final freshness guard; it still rejects any
+    // intervening contributor activity or source/head drift.
+    rememberSelfMutationUpdatedAt({ allowsPostReviewAutomationActivity: true });
+  }
+  const finalFreshnessBlock = postProofFreshnessBlock();
+  if (finalFreshnessBlock) return markChangedSinceReview(finalFreshnessBlock) ? "stop" : "next";
+  const finalCoveringPrFreshnessBlock = postProofCoveringPrFreshnessBlock();
+  if (finalCoveringPrFreshnessBlock) {
+    return skip(finalCoveringPrFreshnessBlock.actionTaken, finalCoveringPrFreshnessBlock.reason);
   }
   // Preserve the archive label after an uncertain close; the revival watcher reconciles it.
   // The earlier check avoids unnecessary apply work; this one closes the race with the mutation.
@@ -381,20 +417,18 @@ export function executeApplyClose(
   if (finalImplementationProvenanceBlock) {
     return skip("kept_open", finalImplementationProvenanceBlock);
   }
-  closeItem({ number, kind: item.kind, reason: closeReason });
-  if (item.kind === "pull_request") {
-    try {
-      closeAppliedCommentReason = ensureCloseAppliedComment({
-        number,
-        closeReason,
-        markdown: getMarkdown(),
-        itemUrl: item.url,
-        dryRun,
-      });
-    } catch (error) {
-      closeAppliedCommentReason = `close-applied comment failed after close: ${mutationErrorMessage(error)}`;
+  if (closeReason === "unsponsored_feature_request") {
+    const needsIdeaArchiveLabel = !item.labels.map(normalizeLabelName).includes(IDEA_ARCHIVE_LABEL);
+    ensureIdeaArchiveLabel(recordMutation);
+    if (needsIdeaArchiveLabel) {
+      addIssueLabel(number, IDEA_ARCHIVE_LABEL, recordMutation);
+      item.labels.push(IDEA_ARCHIVE_LABEL);
+      setMarkdown(replaceFrontMatterValue(getMarkdown(), "labels", JSON.stringify(item.labels)));
     }
   }
+  const finalCloseMutationLeaseBlockReason = currentApplyMutationLeaseBlockReason();
+  if (finalCloseMutationLeaseBlockReason) return skipLease(finalCloseMutationLeaseBlockReason);
+  closeItem({ number, kind: item.kind, reason: closeReason });
   let postCloseRuntimeYieldReason: string | null = null;
   try {
     ensureRuntimeDelayFits(closeDelayMs, "before close delay");

--- a/src/clawsweeper-apply-close-execution.ts
+++ b/src/clawsweeper-apply-close-execution.ts
@@ -32,6 +32,7 @@ type ApplyCloseExecutionDependencies = Pick<
   | "ensureIdeaArchiveLabel"
   | "ensureRuntimeDelayFits"
   | "GitHubRuntimeBudgetError"
+  | "implementedOnMainPullRequestProvenanceApplyBlock"
   | "issueRecentHumanCommentBlockReasonSafe"
   | "lowSignalUnmergeablePrApplyBlockReasonSafe"
   | "normalizeLabelName"
@@ -52,6 +53,42 @@ type ReviewFreshnessBlock = {
   currentUpdatedAt?: string;
   currentSnapshotHash?: string;
 };
+
+export function implementedOnMainCloseProvenanceBlock(
+  markdown: string,
+  itemKind: Item["kind"],
+  itemNumber: number,
+  closeReason: CloseReason,
+): string | null {
+  if (
+    itemKind !== "pull_request" ||
+    !["implemented_on_main", "mostly_implemented_on_main"].includes(closeReason)
+  ) {
+    return null;
+  }
+  const fixedPrUrl = markdown.match(/^fixed_pr_url: (.+)$/m)?.[1]?.trim();
+  const repository = markdown.match(/^repository: (.+)$/m)?.[1]?.trim();
+  const fixedPrNumber = markdown.match(/^fixed_pr_number: (\d+)$/m)?.[1]?.trim();
+  const fixedPrConfidence = markdown.match(/^fixed_pr_confidence: (.+)$/m)?.[1]?.trim();
+  const fixedPrSource = markdown.match(/^fixed_pr_source: (.+)$/m)?.[1]?.trim();
+  const fixedPrMergedAt = markdown.match(/^fixed_pr_merged_at: (.+)$/m)?.[1]?.trim();
+  if (
+    fixedPrUrl &&
+    repository &&
+    fixedPrNumber &&
+    fixedPrNumber !== String(itemNumber) &&
+    fixedPrUrl === `https://github.com/${repository}/pull/${fixedPrNumber}` &&
+    fixedPrConfidence === "high" &&
+    fixedPrSource &&
+    fixedPrSource !== "unknown" &&
+    fixedPrSource.includes("GitHub ") &&
+    fixedPrMergedAt &&
+    fixedPrMergedAt !== "unknown"
+  ) {
+    return null;
+  }
+  return "implemented-on-main close requires a GitHub-verified, same-repository merged fixing pull request";
+}
 
 interface ApplyCloseExecutionOptions {
   applyCloseReasons: ReadonlySet<CloseReason> | null;
@@ -111,6 +148,7 @@ export function executeApplyClose(
     ensureIdeaArchiveLabel,
     ensureRuntimeDelayFits,
     GitHubRuntimeBudgetError,
+    implementedOnMainPullRequestProvenanceApplyBlock,
     issueRecentHumanCommentBlockReasonSafe,
     lowSignalUnmergeablePrApplyBlockReasonSafe,
     normalizeLabelName,
@@ -191,6 +229,21 @@ export function executeApplyClose(
   }
   if (!closeReasonEnabled(closeReason, applyCloseReasons)) {
     return recordSkip("kept_open", `close reason ${closeReason} is not enabled for this apply run`);
+  }
+  const implementationProvenanceBlock = implementedOnMainCloseProvenanceBlock(
+    getMarkdown(),
+    item.kind,
+    item.number,
+    closeReason,
+  );
+  if (implementationProvenanceBlock) return skip("kept_open", implementationProvenanceBlock);
+  const currentImplementationProvenanceBlock = implementedOnMainPullRequestProvenanceApplyBlock(
+    getMarkdown(),
+    item,
+    closeReason,
+  );
+  if (currentImplementationProvenanceBlock) {
+    return skip("kept_open", currentImplementationProvenanceBlock);
   }
 
   const currentReportValidation = validateCloseDecision(

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -530,7 +530,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       let currentApplyMutationBoundaryBlockReason = (): string | null => null;
       let deferredSelfMutationReceipt = false;
       let publishedIssueLabelMutation = false;
-      let rememberSelfMutationUpdatedAt = (): void => {};
+      let rememberSelfMutationUpdatedAt = (
+        _options: { allowsPostReviewAutomationActivity?: boolean } = {},
+      ): void => {};
       let reconcileSkippedIssueLabelAdditions = (_labels: readonly string[]): void => {};
       let refreshRenderedReviewComment = (): void => {};
       let restoreDiscardedIssueLabelState = (): void => {};
@@ -1116,7 +1118,9 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       const initialCanonicalCommentSyncGuard = applyCanonicalCommentSyncGuard();
       if (initialCanonicalCommentSyncGuard.stopApply) break;
       if (initialCanonicalCommentSyncGuard.skipCurrentItem) continue;
-      rememberSelfMutationUpdatedAt = (): void => {
+      rememberSelfMutationUpdatedAt = (
+        options?: { allowsPostReviewAutomationActivity?: boolean },
+      ): void => {
         if (dryRun) return;
         const automationItem = fetchApplyItem(number).item;
         const automationItemUpdatedAt = automationItem.updatedAt;
@@ -1139,13 +1143,27 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
             persistedPrHydrationSnapshot?.commentActivityRevision ?? null,
           requireFullyValidatedPrHydrationSnapshot: true,
         });
-        if (!completeReviewActivityReceiptMatches(receiptContext)) return;
+        const allowsPostReviewAutomationActivity =
+          options?.allowsPostReviewAutomationActivity === true;
+        if (
+          !allowsPostReviewAutomationActivity &&
+          !completeReviewActivityReceiptMatches(receiptContext)
+        )
+          return;
+        if (
+          allowsPostReviewAutomationActivity &&
+          (receiptContext.sourceRevision !== reviewedSourceRevision ||
+            (item.kind === "pull_request" &&
+              !freshPullRequestReviewHead(markdownBeforeApplyDecisionMutations, receiptContext)))
+        )
+          return;
         const completeActivityContext = receiptContext[completeActivityContextSymbol];
         if (!completeActivityContext) return;
         selfMutationItemReceipts.push({
           updatedAt: automationItemUpdatedAt,
           sourceRevision: reviewedSourceRevision,
           activityReceipt: stableJson(completeActivityContext),
+          allowsPostReviewAutomationActivity,
           prHeadMatches:
             item.kind !== "pull_request" ||
             freshPullRequestReviewHead(markdownBeforeApplyDecisionMutations, receiptContext),
@@ -2343,6 +2361,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         proofResult: () => coverageProofState.cachedPrCloseCoverageProofGateResult,
         recordApplySkipped,
         recordMutation,
+        rememberSelfMutationUpdatedAt,
         recordReviewLeaseSkip,
         recordRuntimeBudgetYield,
         repo,

--- a/src/clawsweeper-apply-dependencies.ts
+++ b/src/clawsweeper-apply-dependencies.ts
@@ -226,6 +226,11 @@ export interface CreateApplyDecisionWorkflowDependencies {
   hasVerifiedLocalCheckoutAccess: (markdown: string) => boolean;
   impactLabelsFromReport: (markdown: string) => ImpactLabelName[];
   isApplyCloseCandidateReport: (markdown: string) => boolean;
+  implementedOnMainPullRequestProvenanceApplyBlock: (
+    markdown: string,
+    item: Item,
+    closeReason: Decision["closeReason"],
+  ) => string | null;
   isBulkFilerExemptAuthorAssociation: (value: unknown) => boolean;
   isExactEventSourceRevisionChange: (itemKind: Item["kind"], reason: string) => boolean;
   isGoodFirstIssue: (state: IssueAdvisoryLabelState, currentLabels: readonly string[]) => boolean;

--- a/src/clawsweeper-apply-proof-freshness.ts
+++ b/src/clawsweeper-apply-proof-freshness.ts
@@ -17,6 +17,7 @@ export interface ApplySelfMutationItemReceipt {
   updatedAt: string;
   sourceRevision: string;
   activityReceipt: string;
+  allowsPostReviewAutomationActivity?: boolean;
   prHeadMatches: boolean;
   reviewActivityCursor: string | null;
 }
@@ -131,24 +132,37 @@ export function createApplyProofFreshnessGuards({
         refreshed.item.updatedAt === storedUpdatedAt)
         ? fetchReviewedPrActivityCursor(number)
         : null;
-    const refreshedItemReceiptMatches = candidateItemReceipts.some(
-      (receipt) =>
-        refreshedContext?.sourceRevision === receipt.sourceRevision &&
-        refreshedActivityReceipt === receipt.activityReceipt &&
-        receipt.prHeadMatches &&
-        refreshedContext !== null &&
-        (itemKind !== "pull_request" ||
-          (freshPullRequestReviewHead(reviewMarkdown, refreshedContext) &&
-            isReviewedPrActivityCursor(expectedReviewActivityCursor) &&
-            compareReviewedPrActivityCursors(
-              receipt.reviewActivityCursor,
-              expectedReviewActivityCursor,
-            ) === "equal" &&
-            compareReviewedPrActivityCursors(
-              refreshedReviewActivityCursor,
-              expectedReviewActivityCursor,
-            ) === "equal")),
-    );
+    const refreshedItemReceiptMatches = candidateItemReceipts.some((receipt) => {
+      if (
+        refreshedContext?.sourceRevision !== receipt.sourceRevision ||
+        refreshedActivityReceipt !== receipt.activityReceipt ||
+        !receipt.prHeadMatches ||
+        refreshedContext === null
+      ) {
+        return false;
+      }
+      if (itemKind !== "pull_request") return true;
+      if (!freshPullRequestReviewHead(reviewMarkdown, refreshedContext)) return false;
+      if (!isReviewedPrActivityCursor(expectedReviewActivityCursor)) return false;
+      if (receipt.allowsPostReviewAutomationActivity) {
+        return (
+          compareReviewedPrActivityCursors(
+            receipt.reviewActivityCursor,
+            refreshedReviewActivityCursor,
+          ) === "equal"
+        );
+      }
+      return (
+        compareReviewedPrActivityCursors(
+          receipt.reviewActivityCursor,
+          expectedReviewActivityCursor,
+        ) === "equal" &&
+        compareReviewedPrActivityCursors(
+          refreshedReviewActivityCursor,
+          expectedReviewActivityCursor,
+        ) === "equal"
+      );
+    });
     const refreshedCompleteReceiptMatchesReview = (): boolean => {
       refreshedContext ??= collectItemContext(refreshed.item, {
         fullTimelineForRelations: true,

--- a/src/clawsweeper-close-decision.ts
+++ b/src/clawsweeper-close-decision.ts
@@ -63,6 +63,30 @@ export function createCloseDecisionWorkflow({
     );
   }
 
+  function verifiedImplementationPullRequestBlockReason(
+    item: Partial<Pick<Item, "repo" | "number">>,
+    decision: Decision,
+  ): string | null {
+    const pull = decision.fixedPullRequest;
+    const repo = item.repo ?? targetRepo();
+    if (!pull || pull.confidence !== "high") {
+      return "implemented-on-main close requires a GitHub-verified fixing pull request";
+    }
+    if (pull.repo !== repo) {
+      return "implemented-on-main fixing pull request must be in the reviewed repository";
+    }
+    if (item.number === pull.number) {
+      return "implemented-on-main fixing pull request cannot be the pull request being closed";
+    }
+    if (!pull.mergedAt || !pull.source.startsWith("GitHub ")) {
+      return "implemented-on-main fixing pull request must be GitHub-verified and merged";
+    }
+    if (pull.url !== `https://github.com/${repo}/pull/${pull.number}`) {
+      return "implemented-on-main fixing pull request URL does not match its GitHub identity";
+    }
+    return null;
+  }
+
   function canClose(decision: Decision): boolean {
     return (
       decision.decision === "close" &&
@@ -413,6 +437,19 @@ export function createCloseDecisionWorkflow({
         actionTaken: "skipped_invalid_decision",
         reason: `${decision.closeReason} requires evidence with file and sha`,
       };
+    }
+    if (item.kind === "pull_request" && isImplementationCloseReason(decision.closeReason)) {
+      const implementationPullRequestBlock = verifiedImplementationPullRequestBlockReason(
+        item,
+        decision,
+      );
+      if (implementationPullRequestBlock) {
+        return {
+          ok: false,
+          actionTaken: "skipped_invalid_decision",
+          reason: implementationPullRequestBlock,
+        };
+      }
     }
     if (isImplementationCloseReason(decision.closeReason) && !decision.fixedSha?.trim()) {
       return {

--- a/src/clawsweeper-review-comment-publication.ts
+++ b/src/clawsweeper-review-comment-publication.ts
@@ -246,9 +246,9 @@ export function createReviewCommentPublication(
   }): string {
     const coverageProofLine = closeAppliedCoverageProofLine(options.markdown);
     return [
-      "ClawSweeper applied the proposed close for this PR.",
+      "ClawSweeper recorded implementation evidence for this proposed close.",
       "",
-      "- Action: closed this PR.",
+      "- Action: close remains subject to final live verification.",
       `- Close reason: ${closeReasonText(options.closeReason)}.`,
       `- Implementation evidence: ${closeAppliedEvidenceLink(options.markdown, options.itemUrl)}.`,
       coverageProofLine,
@@ -278,24 +278,38 @@ export function createReviewCommentPublication(
     dryRun: boolean;
   }): string {
     const marker = closeAppliedCommentMarker(options.number);
-    if (issueCommentWithMarker(options.number, marker)) {
+    const body = renderCloseAppliedComment(options);
+    const existing = issueCommentWithMarker(options.number, marker);
+    if (existing?.body === body) {
       return "matching ClawSweeper close-applied comment already exists";
     }
-    const body = renderCloseAppliedComment(options);
     if (options.dryRun) return "dry-run: would post close-applied comment";
     const payload = writeCommentPayload(options.number, body);
+    const existingId = commentId(existing);
+    const updateExisting = existingId !== null && canPatchReviewComment(existing);
     ghObservedMutationCommand({
       identity: `close_applied_comment:${options.number}:${sha256(body)}`,
-      args: [
-        "api",
-        `repos/${targetRepo()}/issues/${options.number}/comments`,
-        "--method",
-        "POST",
-        "--input",
-        payload,
-      ],
+      args: updateExisting
+        ? [
+            "api",
+            `repos/${targetRepo()}/issues/comments/${existingId}`,
+            "--method",
+            "PATCH",
+            "--input",
+            payload,
+          ]
+        : [
+            "api",
+            `repos/${targetRepo()}/issues/${options.number}/comments`,
+            "--method",
+            "POST",
+            "--input",
+            payload,
+          ],
+      knownNoMutation: (error) =>
+        isGitHubRequiresAuthenticationError(error) || isLockedConversationCommentError(error),
     });
-    return "posted close-applied comment";
+    return updateExisting ? "updated close-applied comment" : "posted close-applied comment";
   }
 
   return {

--- a/src/clawsweeper-review-comment-publication.ts
+++ b/src/clawsweeper-review-comment-publication.ts
@@ -224,16 +224,16 @@ export function createReviewCommentPublication(
   }
 
   function closeAppliedEvidenceLink(markdown: string, itemUrl: string): string {
-    const reviewCommentUrl = frontMatterValue(markdown, "review_comment_url");
-    if (reviewCommentUrl && reviewCommentUrl !== "unknown") {
-      return markdownLink("durable ClawSweeper review", reviewCommentUrl);
-    }
     const fixedPrUrl = frontMatterValue(markdown, "fixed_pr_url");
     const fixedPrNumber = frontMatterValue(markdown, "fixed_pr_number");
     if (fixedPrUrl && fixedPrUrl !== "unknown") {
       const label =
         fixedPrNumber && fixedPrNumber !== "unknown" ? `fix PR #${fixedPrNumber}` : "fix PR";
       return markdownLink(label, fixedPrUrl);
+    }
+    const reviewCommentUrl = frontMatterValue(markdown, "review_comment_url");
+    if (reviewCommentUrl && reviewCommentUrl !== "unknown") {
+      return markdownLink("durable ClawSweeper review", reviewCommentUrl);
     }
     return markdownLink("closed PR", itemUrl);
   }
@@ -250,7 +250,7 @@ export function createReviewCommentPublication(
       "",
       "- Action: closed this PR.",
       `- Close reason: ${closeReasonText(options.closeReason)}.`,
-      `- Evidence: ${closeAppliedEvidenceLink(options.markdown, options.itemUrl)}.`,
+      `- Implementation evidence: ${closeAppliedEvidenceLink(options.markdown, options.itemUrl)}.`,
       coverageProofLine,
       "",
       closeAppliedCommentMarker(options.number),

--- a/src/clawsweeper-runtime.ts
+++ b/src/clawsweeper-runtime.ts
@@ -25,6 +25,7 @@ import { stableJson } from "./stable-json.js";
 
 import { createActionCommands } from "./clawsweeper-action-commands.js";
 import { createApplyDecisionWorkflow } from "./clawsweeper-apply-decision-workflow.js";
+import { implementedOnMainCloseProvenanceBlock } from "./clawsweeper-apply-close-execution.js";
 import { createApplyGuards } from "./clawsweeper-apply-guards.js";
 import { createAssistWorkflow } from "./clawsweeper-assist.js";
 import { isDocsPath } from "./clawsweeper-change-detection.js";
@@ -98,7 +99,12 @@ import { createReviewPlanning } from "./clawsweeper-review-planning.js";
 import { createReviewPresentation } from "./clawsweeper-review-presentation.js";
 import { createReviewRuntime } from "./clawsweeper-review-runtime.js";
 import { createSourceRevisionTools } from "./clawsweeper-source-revision.js";
-import { createStatusContext } from "./clawsweeper-status-context.js";
+import {
+  currentClosingPullRequestReferenceFromIssueTimeline,
+  createStatusContext,
+  linkedIssueNumbersForImplementationProvenance,
+  linkedIssueNumbersForPullRequestBody,
+} from "./clawsweeper-status-context.js";
 import { createSweepStatus } from "./clawsweeper-sweep-status.js";
 import type {
   Decision,
@@ -803,7 +809,18 @@ const statusContext = createStatusContext({
   recordOrUndefined,
 });
 export const { fixedPullRequestFromCommitPullsForTest } = statusContext;
-const { attachFixedPullRequest, displayTitle, readSweepStatusSummary } = statusContext;
+export {
+  currentClosingPullRequestReferenceFromIssueTimeline,
+  implementedOnMainCloseProvenanceBlock,
+  linkedIssueNumbersForPullRequestBody,
+  linkedIssueNumbersForImplementationProvenance,
+};
+const {
+  attachFixedPullRequest,
+  displayTitle,
+  implementedOnMainPullRequestProvenanceApplyBlock,
+  readSweepStatusSummary,
+} = statusContext;
 
 const regressionProvenanceVerifier = createRegressionProvenanceVerifier({
   fetchPull: (repo, number) =>
@@ -1320,6 +1337,7 @@ const { applyDecisionsCommandInner } = createApplyDecisionWorkflow({
   isBulkFilerExemptAuthorAssociation,
   ...sourceRevisionTools,
   isMaintainerAuthorAssociation,
+  implementedOnMainPullRequestProvenanceApplyBlock,
   isVerifiedFixedCloseReason,
   login,
   mutationErrorMessage,

--- a/src/clawsweeper-status-context.ts
+++ b/src/clawsweeper-status-context.ts
@@ -24,20 +24,62 @@ export function linkedIssueNumbersForPullRequestBody(
   body: string,
   targetRepo: string,
 ): readonly number[] | null {
+  let fence: { delimiter: "`" | "~"; length: number } | null = null;
+  const semanticBody = body
+    .split(/\r?\n/)
+    .filter((line) => {
+      const fenceMatch = line.match(/^[\t ]*(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        const marker = fenceMatch[1] ?? "";
+        const delimiter = marker[0] as "`" | "~" | undefined;
+        if (!delimiter) return false;
+        if (!fence) {
+          fence = { delimiter, length: marker.length };
+        } else if (fence.delimiter === delimiter && marker.length >= fence.length) {
+          fence = null;
+        }
+        return false;
+      }
+      return !fence && !/^[\t ]*>/.test(line) && !line.includes("`");
+    })
+    .join("\n");
   const escapedRepo = escapeRegExp(targetRepo);
-  const closingReference = new RegExp(
-    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\b[\\t ]*(?::[\\t ]*)?` +
-      `(?:#(\\d+)\\b|(${escapedRepo})#(\\d+)\\b|https?:\\/\\/github\\.com\\/(${escapedRepo})\\/issues\\/(\\d+)\\b|([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)#(\\d+)\\b|https?:\\/\\/github\\.com\\/([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)\\/issues\\/(\\d+)\\b)`,
-    "gi",
+  const closingVerb = "(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)";
+  const issueReference =
+    `(?:#(\\d+)\\b|(${escapedRepo})#(\\d+)\\b|https?:\\/\\/github\\.com\\/(${escapedRepo})\\/issues\\/(\\d+)\\b|` +
+    `([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)#(\\d+)\\b|https?:\\/\\/github\\.com\\/([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)\\/issues\\/(\\d+)\\b)`;
+  const closingDirective = new RegExp(
+    `^[\\t ]*(?:(?:[-*+][\\t ]+(?:\\[[ xX]\\][\\t ]+)?)|(?:\\d+[.)][\\t ]+))?` +
+      `${closingVerb}[\\t ]*(?::[\\t ]*)?(.*)$`,
+    "i",
+  );
+  const issueReferencePattern = new RegExp(issueReference, "gi");
+  const additionalReferenceSeparator = new RegExp(
+    `^[\\t ]*(?:,|\\band\\b)[\\t ]*(?:${closingVerb}[\\t ]*(?::[\\t ]*)?)?$`,
+    "i",
   );
   const issueNumbers = new Set<number>();
-  for (const match of body.matchAll(closingReference)) {
-    const linkedRepo = match[2] ?? match[4] ?? match[6] ?? match[8] ?? targetRepo;
-    if (linkedRepo.toLowerCase() !== targetRepo.toLowerCase()) return null;
-    const rawNumber = match[1] ?? match[3] ?? match[5] ?? match[7] ?? match[9];
-    const number = rawNumber ? Number(rawNumber) : NaN;
-    if (!Number.isSafeInteger(number) || number <= 0) return null;
-    issueNumbers.add(number);
+  for (const line of semanticBody.split(/\r?\n/)) {
+    const directive = line.match(closingDirective);
+    if (!directive) continue;
+    const referenceTail = directive[1] ?? "";
+    const references = [...referenceTail.matchAll(issueReferencePattern)];
+    const firstReference = references[0];
+    if (!firstReference || firstReference.index !== 0) return null;
+    for (const [index, match] of references.entries()) {
+      if (index > 0) {
+        const previous = references[index - 1];
+        if (!previous || previous.index === undefined || match.index === undefined) return null;
+        const separator = referenceTail.slice(previous.index + previous[0].length, match.index);
+        if (!additionalReferenceSeparator.test(separator)) return null;
+      }
+      const linkedRepo = match[2] ?? match[4] ?? match[6] ?? match[8] ?? targetRepo;
+      if (linkedRepo.toLowerCase() !== targetRepo.toLowerCase()) return null;
+      const rawNumber = match[1] ?? match[3] ?? match[5] ?? match[7] ?? match[9];
+      const number = rawNumber ? Number(rawNumber) : NaN;
+      if (!Number.isSafeInteger(number) || number <= 0) return null;
+      issueNumbers.add(number);
+    }
   }
   return issueNumbers.size > 0 ? [...issueNumbers].sort((left, right) => left - right) : null;
 }

--- a/src/clawsweeper-status-context.ts
+++ b/src/clawsweeper-status-context.ts
@@ -59,7 +59,8 @@ export function currentClosingPullRequestReferenceFromIssueTimeline(
   const data = (result as Record<string, unknown>).data;
   if (typeof data !== "object" || data === null || Array.isArray(data)) return null;
   const repository = (data as Record<string, unknown>).repository;
-  if (typeof repository !== "object" || repository === null || Array.isArray(repository)) return null;
+  if (typeof repository !== "object" || repository === null || Array.isArray(repository))
+    return null;
   const issue = (repository as Record<string, unknown>).issue;
   if (typeof issue !== "object" || issue === null || Array.isArray(issue)) return null;
   const issueRecord = issue as Record<string, unknown>;
@@ -78,7 +79,9 @@ export function currentClosingPullRequestReferenceFromIssueTimeline(
         typeof node === "object" &&
         node !== null &&
         !Array.isArray(node) &&
-        ["ClosedEvent", "ReopenedEvent"].includes(String((node as Record<string, unknown>).__typename)),
+        ["ClosedEvent", "ReopenedEvent"].includes(
+          String((node as Record<string, unknown>).__typename),
+        ),
     )
     .map((node) => ({
       node,
@@ -570,12 +573,7 @@ ${profileStatusEnd(profile)}`;
     }
     try {
       const pull = asRecord(
-        ghJson<unknown>([
-          "api",
-          `repos/${targetRepo()}/pulls/${item.number}`,
-          "--jq",
-          "{body}",
-        ]),
+        ghJson<unknown>(["api", `repos/${targetRepo()}/pulls/${item.number}`, "--jq", "{body}"]),
       );
       if (typeof pull.body !== "string") {
         return "implemented-on-main close could not revalidate the pull request's current issue linkage";

--- a/src/clawsweeper-status-context.ts
+++ b/src/clawsweeper-status-context.ts
@@ -15,8 +15,91 @@ import {
   isRegressionAssessment,
   isPublicRegressionProvenance,
 } from "./clawsweeper-regression-provenance.js";
-import { isGitHubNotFoundError } from "./github-retry.js";
+import { GitHubRateLimitError, isGitHubNotFoundError } from "./github-retry.js";
 import type { RepositoryProfile } from "./repository-profiles.js";
+
+export const MAX_IMPLEMENTATION_LINKED_ISSUE_REFERENCES = 5;
+
+export function linkedIssueNumbersForPullRequestBody(
+  body: string,
+  targetRepo: string,
+): readonly number[] | null {
+  const escapedRepo = escapeRegExp(targetRepo);
+  const closingReference = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\b[\\t ]*(?::[\\t ]*)?` +
+      `(?:#(\\d+)\\b|(${escapedRepo})#(\\d+)\\b|https?:\\/\\/github\\.com\\/(${escapedRepo})\\/issues\\/(\\d+)\\b|([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)#(\\d+)\\b|https?:\\/\\/github\\.com\\/([A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+)\\/issues\\/(\\d+)\\b)`,
+    "gi",
+  );
+  const issueNumbers = new Set<number>();
+  for (const match of body.matchAll(closingReference)) {
+    const linkedRepo = match[2] ?? match[4] ?? match[6] ?? match[8] ?? targetRepo;
+    if (linkedRepo.toLowerCase() !== targetRepo.toLowerCase()) return null;
+    const rawNumber = match[1] ?? match[3] ?? match[5] ?? match[7] ?? match[9];
+    const number = rawNumber ? Number(rawNumber) : NaN;
+    if (!Number.isSafeInteger(number) || number <= 0) return null;
+    issueNumbers.add(number);
+  }
+  return issueNumbers.size > 0 ? [...issueNumbers].sort((left, right) => left - right) : null;
+}
+
+export function linkedIssueNumbersForImplementationProvenance(
+  body: string,
+  targetRepo: string,
+): readonly number[] | null {
+  const issueNumbers = linkedIssueNumbersForPullRequestBody(body, targetRepo);
+  return issueNumbers && issueNumbers.length <= MAX_IMPLEMENTATION_LINKED_ISSUE_REFERENCES
+    ? issueNumbers
+    : null;
+}
+
+export function currentClosingPullRequestReferenceFromIssueTimeline(
+  result: unknown,
+): Record<string, unknown> | null {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) return null;
+  const data = (result as Record<string, unknown>).data;
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return null;
+  const repository = (data as Record<string, unknown>).repository;
+  if (typeof repository !== "object" || repository === null || Array.isArray(repository)) return null;
+  const issue = (repository as Record<string, unknown>).issue;
+  if (typeof issue !== "object" || issue === null || Array.isArray(issue)) return null;
+  const issueRecord = issue as Record<string, unknown>;
+  if (typeof issueRecord.state !== "string" || issueRecord.state.toUpperCase() !== "CLOSED") {
+    return null;
+  }
+  const timelineItems = issueRecord.timelineItems;
+  if (typeof timelineItems !== "object" || timelineItems === null || Array.isArray(timelineItems)) {
+    return null;
+  }
+  const nodes = (timelineItems as Record<string, unknown>).nodes;
+  if (!Array.isArray(nodes)) return null;
+  const lifecycleEvents = nodes
+    .filter(
+      (node): node is Record<string, unknown> =>
+        typeof node === "object" &&
+        node !== null &&
+        !Array.isArray(node) &&
+        ["ClosedEvent", "ReopenedEvent"].includes(String((node as Record<string, unknown>).__typename)),
+    )
+    .map((node) => ({
+      node,
+      createdAt: typeof node.createdAt === "string" ? Date.parse(node.createdAt) : NaN,
+    }))
+    .filter((event) => Number.isFinite(event.createdAt));
+  if (lifecycleEvents.length === 0) return null;
+  const latestCreatedAt = Math.max(...lifecycleEvents.map((event) => event.createdAt));
+  const latestEvents = lifecycleEvents.filter((event) => event.createdAt === latestCreatedAt);
+  if (
+    latestEvents.length !== 1 ||
+    latestEvents[0]?.node.__typename !== "ClosedEvent" ||
+    typeof latestEvents[0].node.closer !== "object" ||
+    latestEvents[0].node.closer === null ||
+    Array.isArray(latestEvents[0].node.closer)
+  ) {
+    return null;
+  }
+  const closer = latestEvents[0].node.closer as Record<string, unknown>;
+  return closer.__typename === "PullRequest" ? closer : null;
+}
 
 interface StatusContextDependencies {
   targetProfile: () => RepositoryProfile;
@@ -400,6 +483,120 @@ ${profileStatusEnd(profile)}`;
     return candidates[0] ?? null;
   }
 
+  function fixedPullRequestForLinkedIssue(issueNumber: number): FixedPullRequest | null {
+    try {
+      const [owner, name] = targetRepo().split("/");
+      if (!owner || !name) return null;
+      const timeline = ghJson<unknown>([
+        "api",
+        "graphql",
+        "-f",
+        "query=query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { issue(number: $number) { state timelineItems(last: 100, itemTypes: [CLOSED_EVENT, REOPENED_EVENT]) { nodes { __typename ... on ClosedEvent { createdAt closer { __typename ... on PullRequest { number url mergedAt repository { nameWithOwner } } } } ... on ReopenedEvent { createdAt } } } } } }",
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `name=${name}`,
+        "-F",
+        `number=${issueNumber}`,
+      ]);
+      const reference = currentClosingPullRequestReferenceFromIssueTimeline(timeline);
+      if (!reference) return null;
+      const record = asRecord(reference);
+      const number = record.number;
+      const repository = asRecord(record.repository);
+      if (
+        typeof number !== "number" ||
+        !Number.isInteger(number) ||
+        repository.nameWithOwner !== targetRepo()
+      ) {
+        return null;
+      }
+      const defaultBranch = defaultBranchForFixedSha();
+      if (!defaultBranch) return null;
+      const pull = ghJson<unknown>([
+        "api",
+        `repos/${targetRepo()}/pulls/${number}`,
+        "--jq",
+        "{number,title,state,html_url,merged,merged_at,merge_commit_sha,head:{sha:.head.sha},base:{ref:.base.ref}}",
+      ]);
+      return pullTargetsBranch(pull, defaultBranch)
+        ? fixedPullRequestFromUnknown(pull, "GitHub linked-issue current closing PR")
+        : null;
+    } catch (error) {
+      if (error instanceof GitHubRateLimitError) throw error;
+      // Missing or unreadable linkage must not turn into an inferred close.
+      return null;
+    }
+  }
+
+  function fixedPullRequestFromLinkedPullRequest(
+    item: Item,
+    context: ItemContext,
+    decision: Decision,
+  ): FixedPullRequest | null {
+    if (item.kind !== "pull_request") return null;
+    if (decision.decision !== "close" || decision.confidence !== "high") return null;
+    if (!["implemented_on_main", "mostly_implemented_on_main"].includes(decision.closeReason)) {
+      return null;
+    }
+    const body = asRecord(context.pullRequest).body;
+    if (typeof body !== "string") return null;
+    const issueNumbers = linkedIssueNumbersForImplementationProvenance(body, targetRepo());
+    if (!issueNumbers) return null;
+    let first: FixedPullRequest | null = null;
+    for (const issueNumber of issueNumbers) {
+      const pull = fixedPullRequestForLinkedIssue(issueNumber);
+      if (!pull || pull.number === item.number) return null;
+      if (first && pull.number !== first.number) return null;
+      first = pull;
+    }
+    return first;
+  }
+
+  function implementedOnMainPullRequestProvenanceApplyBlock(
+    markdown: string,
+    item: Item,
+    closeReason: Decision["closeReason"],
+  ): string | null {
+    if (
+      item.kind !== "pull_request" ||
+      !["implemented_on_main", "mostly_implemented_on_main"].includes(closeReason)
+    ) {
+      return null;
+    }
+    const expectedNumber = Number(frontMatterValue(markdown, "fixed_pr_number"));
+    if (!Number.isInteger(expectedNumber) || expectedNumber <= 0) {
+      return "implemented-on-main close requires current GitHub-verified fixing pull request provenance";
+    }
+    try {
+      const pull = asRecord(
+        ghJson<unknown>([
+          "api",
+          `repos/${targetRepo()}/pulls/${item.number}`,
+          "--jq",
+          "{body}",
+        ]),
+      );
+      if (typeof pull.body !== "string") {
+        return "implemented-on-main close could not revalidate the pull request's current issue linkage";
+      }
+      const issueNumbers = linkedIssueNumbersForImplementationProvenance(pull.body, targetRepo());
+      if (!issueNumbers) {
+        return "implemented-on-main close no longer has a current explicit same-repository issue link";
+      }
+      for (const issueNumber of issueNumbers) {
+        const fixedPullRequest = fixedPullRequestForLinkedIssue(issueNumber);
+        if (!fixedPullRequest || fixedPullRequest.number !== expectedNumber) {
+          return "implemented-on-main close no longer has current GitHub-verified fixing pull request provenance";
+        }
+      }
+      return null;
+    } catch (error) {
+      if (error instanceof GitHubRateLimitError) throw error;
+      return "implemented-on-main close could not revalidate current GitHub provenance";
+    }
+  }
+
   function fixedPullRequestFromCommitPulls(
     pulls: readonly unknown[],
     source: string,
@@ -589,11 +786,19 @@ ${profileStatusEnd(profile)}`;
     context: ItemContext,
     priorReviewMarkdown?: string,
   ): Decision {
+    if (
+      item.kind === "pull_request" &&
+      ["implemented_on_main", "mostly_implemented_on_main"].includes(decision.closeReason)
+    ) {
+      const fixedPullRequest = fixedPullRequestFromLinkedPullRequest(item, context, decision);
+      return { ...decision, fixedPullRequest };
+    }
     if (decision.fixedPullRequest) return decision;
     const fixedPullRequest =
       fixedPullRequestFromContext(item, context, decision) ??
       persistedFixedPullRequest(decision, priorReviewMarkdown) ??
-      (item.kind === "issue" ? fixedPullRequestFromCommitSha(decision, item.number) : null);
+      (item.kind === "issue" ? fixedPullRequestFromCommitSha(decision, item.number) : null) ??
+      fixedPullRequestFromLinkedPullRequest(item, context, decision);
     return fixedPullRequest ? { ...decision, fixedPullRequest } : decision;
   }
 
@@ -683,7 +888,9 @@ ${profileStatusEnd(profile)}`;
 
   return {
     fixedPullRequestFromCommitPullsForTest,
+    linkedIssueNumbersForPullRequestBodyForTest: linkedIssueNumbersForPullRequestBody,
     attachFixedPullRequest,
+    implementedOnMainPullRequestProvenanceApplyBlock,
     currentWorkflowStatusBlock,
     displayTitle,
     fixedInReportText,

--- a/test/apply-close-retry-policy.test.ts
+++ b/test/apply-close-retry-policy.test.ts
@@ -8,6 +8,7 @@ import {
   reportWithSyncedReviewComment,
   runApplyDecisionsForTest,
   tmpPrefix,
+  verifiedImplementationPullRequestReport,
   withMockGh,
 } from "./helpers.ts";
 
@@ -22,7 +23,7 @@ test("apply-decisions retries legacy fixed close skips", () => {
       const logPath = join(root, "gh.log");
       mkdirSync(itemsDir, { recursive: true });
       mkdirSync(plansDir, { recursive: true });
-      const closeReport = implementedCloseReport({
+      const closeReport = verifiedImplementationPullRequestReport({
         type: "pull_request",
         action_taken: actionTaken,
         author_association: "MEMBER",
@@ -42,6 +43,22 @@ const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const path = args[1] || "";
+if (args[0] === "api" && args[1] === "graphql") {
+  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
+  process.exit(0);
+}
+if (args[0] === "api" && path === "repos/openclaw/clawsweeper") {
+  console.log(JSON.stringify({ default_branch: "main" }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/900$/.test(path)) {
+  console.log(JSON.stringify({ number: 900, html_url: "https://github.com/openclaw/clawsweeper/pull/900", title: "Current implementation", merged: true, merged_at: "2026-05-01T02:00:00Z", merge_commit_sha: "fix-sha", head: { sha: "fix-sha" }, base: { ref: "main" } }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/321$/.test(path) && args.includes("--jq")) {
+  console.log(JSON.stringify({ body: "Fixes #320." }));
+  process.exit(0);
+}
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
@@ -137,7 +154,7 @@ test("apply-decisions retries legacy kept-open close reports", () => {
     const reportPath = join(root, "apply-report.json");
     mkdirSync(itemsDir, { recursive: true });
     mkdirSync(plansDir, { recursive: true });
-    const closeReport = implementedCloseReport({
+    const closeReport = verifiedImplementationPullRequestReport({
       type: "pull_request",
       action_taken: "kept_open",
     });
@@ -149,6 +166,22 @@ const comment = ${JSON.stringify(synced.comment)};
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 const path = args[1] || "";
+if (args[0] === "api" && args[1] === "graphql") {
+  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
+  process.exit(0);
+}
+if (args[0] === "api" && path === "repos/openclaw/clawsweeper") {
+  console.log(JSON.stringify({ default_branch: "main" }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/900$/.test(path)) {
+  console.log(JSON.stringify({ number: 900, html_url: "https://github.com/openclaw/clawsweeper/pull/900", title: "Current implementation", merged: true, merged_at: "2026-05-01T02:00:00Z", merge_commit_sha: "fix-sha", head: { sha: "fix-sha" }, base: { ref: "main" } }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/321$/.test(path) && args.includes("--jq")) {
+  console.log(JSON.stringify({ body: "Fixes #320." }));
+  process.exit(0);
+}
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
@@ -251,7 +284,7 @@ test("apply-decisions pair-closes issues blocked by closeable linked PRs", () =>
       "implemented_on_main",
     );
     const pullSynced = reportWithSyncedReviewComment(
-      implementedCloseReport({
+      verifiedImplementationPullRequestReport({
         repository: "openclaw/openclaw",
         number: 321,
         type: "pull_request",
@@ -273,6 +306,22 @@ const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 const path = args[1] || "";
 const issueNumber = (path.match(/\\/issues\\/(\\d+)/) || [])[1];
+if (args[0] === "api" && args[1] === "graphql") {
+  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, repository: { nameWithOwner: "openclaw/openclaw" } } }] } } } } }));
+  process.exit(0);
+}
+if (args[0] === "api" && path === "repos/openclaw/openclaw") {
+  console.log(JSON.stringify({ default_branch: "main" }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/900$/.test(path)) {
+  console.log(JSON.stringify({ number: 900, html_url: "https://github.com/openclaw/openclaw/pull/900", title: "Current implementation", merged: true, merged_at: "2026-05-01T02:00:00Z", merge_commit_sha: "fix-sha", head: { sha: "fix-sha" }, base: { ref: "main" } }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/321$/.test(path) && args.includes("--jq")) {
+  console.log(JSON.stringify({ body: "Fixes #320." }));
+  process.exit(0);
+}
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && /\\/issues\\/(320|321)\\/comments(?:\\?|$)/.test(path)) {
@@ -331,6 +380,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?
     title: "Obsolete linked PR",
     html_url: "https://github.com/openclaw/clawsweeper/pull/321",
     state: "open",
+    body: "Fixes #320.",
     changed_files: 0,
     commits: 0,
     review_comments: 0,

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 
 import {
   contextHasNonAutomationActivityAfterForTest,
+  implementedOnMainCloseProvenanceBlock,
   isExactEventSourceRevisionChange,
   itemSourceRevisionSha256ForTest,
   renderReviewStartStatusComment,
@@ -24,6 +25,39 @@ import {
   withMockGh,
   workPlanCandidateReport,
 } from "./helpers.ts";
+
+test("apply-time implementation provenance keeps incomplete PR closeout metadata open", () => {
+  const incomplete = `repository: openclaw/openclaw
+fixed_pr_url: unknown
+fixed_pr_number: unknown
+fixed_pr_confidence: unknown
+fixed_pr_source: unknown
+fixed_pr_merged_at: unknown`;
+  assert.equal(
+    implementedOnMainCloseProvenanceBlock(
+      incomplete,
+      "pull_request",
+      118679,
+      "implemented_on_main",
+    ),
+    "implemented-on-main close requires a GitHub-verified, same-repository merged fixing pull request",
+  );
+
+  const verified = `repository: openclaw/openclaw
+fixed_pr_url: https://github.com/openclaw/openclaw/pull/456
+fixed_pr_number: 456
+fixed_pr_confidence: high
+fixed_pr_source: GitHub linked-issue closing PR reference
+fixed_pr_merged_at: 2026-08-18T12:00:00Z`;
+  assert.equal(
+    implementedOnMainCloseProvenanceBlock(verified, "pull_request", 118679, "implemented_on_main"),
+    null,
+  );
+  assert.equal(
+    implementedOnMainCloseProvenanceBlock(verified, "pull_request", 456, "implemented_on_main"),
+    "implemented-on-main close requires a GitHub-verified, same-repository merged fixing pull request",
+  );
+});
 
 test("same-item comment payloads never overwrite an earlier pending mutation", () => {
   const root = mkdtempSync(tmpPrefix);
@@ -425,7 +459,6 @@ if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
         extraArgs: ["--sync-comments-only", "--item-numbers", String(number)],
       });
     });
-
     const calls = readFileSync(logPath, "utf8")
       .trim()
       .split("\n")
@@ -547,7 +580,6 @@ if (args[0] === "api" && /\\/issues\\/${number}$/.test(path)) {
         extraArgs: ["--sync-comments-only", "--item-numbers", String(number)],
       });
     });
-
     const calls = readFileSync(logPath, "utf8")
       .trim()
       .split("\n")
@@ -3583,6 +3615,8 @@ const path = args[1] || "";
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   const timeline = Array.from({ length: 100 }, (_, index) => ({ id: index + 1 }));
   console.log('HTTP/2 200\\nlink: <https://api.github.com/repos/openclaw/clawsweeper/issues/321/timeline?per_page=100&page=2>; rel="last"\\n\\n' + JSON.stringify(timeline));
+} else if (args[0] === "api" && args[1] === "graphql") {
+  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   console.log(JSON.stringify([[{
     id: 9321,
@@ -3687,6 +3721,9 @@ test("apply-decisions posts an explicit close-time note before closing PR propos
       reproduction_confidence: "high",
       fixed_pr_url: "https://github.com/openclaw/clawsweeper/pull/900",
       fixed_pr_number: "900",
+      fixed_pr_confidence: "high",
+      fixed_pr_source: "GitHub verified implementation landing",
+      fixed_pr_merged_at: "2026-05-01T02:00:00Z",
       fixed_sha: "1234567890abcdef1234567890abcdef12345678",
       fixed_at: "2026-05-01T02:00:00Z",
     })}\n\n## Evidence\n\n- **main fix:** git show confirms current main has the replacement implementation and it is not in the latest release yet\n  - file: [src/clawsweeper.ts](https://github.com/openclaw/clawsweeper/blob/1234567890abcdef1234567890abcdef12345678/src/clawsweeper.ts)\n  - sha: [1234567890ab](https://github.com/openclaw/clawsweeper/commit/1234567890abcdef1234567890abcdef12345678)\n\n## Close Comment\n\nClosing this PR because the fix is already on main.\n`;
@@ -3704,6 +3741,8 @@ appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const path = args[1] || "";
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
+} else if (args[0] === "api" && args[1] === "graphql") {
+  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, url: "https://github.com/openclaw/clawsweeper/pull/900", mergedAt: "2026-05-01T02:00:00Z", repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   if (args.includes("--method") && args.includes("POST")) {
     const input = args[args.indexOf("--input") + 1];
@@ -3741,6 +3780,20 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     comments: 1,
     pull_request: { url: "https://api.github.com/repos/openclaw/clawsweeper/pulls/321" }
   }));
+} else if (args[0] === "api" && path === "repos/openclaw/clawsweeper") {
+  console.log(JSON.stringify({ default_branch: "main" }));
+} else if (args[0] === "api" && /\\/pulls\\/900$/.test(path)) {
+  console.log(JSON.stringify({
+    number: 900,
+    title: "fix: rendered work plans",
+    html_url: "https://github.com/openclaw/clawsweeper/pull/900",
+    state: "closed",
+    merged: true,
+    merged_at: "2026-05-01T02:00:00Z",
+    merge_commit_sha: "fixed-sha",
+    head: { sha: "fixed-head" },
+    base: { ref: "main" }
+  }));
 } else if (args[0] === "api" && /\\/pulls\\/321$/.test(path)) {
   console.log(JSON.stringify({
     number: 321,
@@ -3749,6 +3802,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     changed_files: 0,
     commits: 0,
     review_comments: 0,
+    body: "Fixes #456",
     head: { sha: "head-sha", ref: "branch", repo: { full_name: "fork/clawsweeper" } },
     base: { sha: "base-sha", ref: "main", repo: { full_name: "openclaw/clawsweeper" } },
     user: { login: "reporter" }
@@ -3775,7 +3829,6 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
         extraArgs: ["--apply-kind", "all", "--processed-limit", "2"],
       });
     });
-
     const calls = readFileSync(logPath, "utf8")
       .trim()
       .split("\n")
@@ -3799,7 +3852,7 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
     assert.equal(postedBodies.length, 1);
     assert.match(postedBodies[0], /ClawSweeper applied the proposed close for this PR/);
     assert.match(postedBodies[0], /Close reason: already implemented on main/);
-    assert.match(postedBodies[0], /durable ClawSweeper review/);
+    assert.match(postedBodies[0], /Implementation evidence: \[fix PR #900\]/);
     assert.match(postedBodies[0], /clawsweeper-close-applied item=321/);
     assert.ok(existsSync(join(closedDir, "321.md")));
     assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -3698,12 +3698,10 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   }
 });
 
-test("apply-decisions posts an explicit close-time note after closing PR proposals", () => {
-  for (const { lifecycleDrift, closeAppliedCommentFails } of [
-    { lifecycleDrift: false, closeAppliedCommentFails: false },
-    { lifecycleDrift: true, closeAppliedCommentFails: false },
-    { lifecycleDrift: false, closeAppliedCommentFails: true },
-  ]) {
+test("apply-decisions verifies provenance after a closeout note and before closing PR proposals", () => {
+  for (const scenario of ["normal", "lifecycle_drift", "locked_closeout_comment"] as const) {
+    const lifecycleDrift = scenario === "lifecycle_drift";
+    const lockedCloseoutComment = scenario === "locked_closeout_comment";
     const root = mkdtempSync(tmpPrefix);
     try {
       const itemsDir = join(root, "items");
@@ -3746,7 +3744,7 @@ const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const path = args[1] || "";
 const lifecycleDrift = ${lifecycleDrift};
-const closeAppliedCommentFails = ${closeAppliedCommentFails};
+const lockedCloseoutComment = ${lockedCloseoutComment};
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && args[1] === "graphql") {
@@ -3756,8 +3754,8 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   console.log(JSON.stringify({ data: { repository: { issue: { state: currentState, timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, url: "https://github.com/openclaw/clawsweeper/pull/900", mergedAt: "2026-05-01T02:00:00Z", repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   if (args.includes("--method") && args.includes("POST")) {
-    if (closeAppliedCommentFails) {
-      console.error("simulated close-applied comment failure");
+    if (lockedCloseoutComment) {
+      console.error("gh: conversation is locked (HTTP 403)");
       process.exit(1);
     }
     const input = args[args.indexOf("--input") + 1];
@@ -3861,10 +3859,27 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
       const graphqlIndices = calls
         .map((args, index) => (args[0] === "api" && args[1] === "graphql" ? index : -1))
         .filter((index) => index >= 0);
+      if (lockedCloseoutComment) {
+        assert.equal(closeIndex, -1);
+        assert.equal(existsSync(join(closedDir, "321.md")), false);
+        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+          action: string;
+          reason: string;
+        }>;
+        assert.equal(
+          report.some(
+            (entry) =>
+              entry.action === "skipped_locked_conversation" &&
+              entry.reason === "conversation was locked while recording closeout evidence",
+          ),
+          true,
+        );
+        continue;
+      }
       assert.equal(graphqlIndices.length, 3);
       if (lifecycleDrift) {
         assert.equal(closeIndex, -1);
-        assert.equal(postIndex, -1);
+        assert.ok(postIndex >= 0);
         assert.equal(existsSync(join(closedDir, "321.md")), false);
         const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
           action: string;
@@ -3884,31 +3899,17 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
         );
         continue;
       }
+      assert.ok(postIndex < graphqlIndices[2]!);
       assert.ok(closeIndex > graphqlIndices[2]!);
-      assert.ok(postIndex > closeIndex);
-      if (closeAppliedCommentFails) {
-        assert.equal(existsSync(postedBodiesPath), false);
-        assert.ok(existsSync(join(closedDir, "321.md")));
-        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
-          action: string;
-          reason: string;
-        }>;
-        assert.equal(
-          report.some(
-            (entry) =>
-              entry.action === "closed" &&
-              entry.reason.includes("close-applied comment failed after close"),
-          ),
-          true,
-        );
-        continue;
-      }
       const postedBodies = readFileSync(postedBodiesPath, "utf8")
         .trim()
         .split("\n")
         .map((line) => JSON.parse(line) as string);
       assert.equal(postedBodies.length, 1);
-      assert.match(postedBodies[0], /ClawSweeper applied the proposed close for this PR/);
+      assert.match(
+        postedBodies[0],
+        /ClawSweeper recorded implementation evidence for this proposed close/,
+      );
       assert.match(postedBodies[0], /Close reason: already implemented on main/);
       assert.match(postedBodies[0], /Implementation evidence: \[fix PR #900\]/);
       assert.match(postedBodies[0], /clawsweeper-close-applied item=321/);

--- a/test/apply-label-sync.test.ts
+++ b/test/apply-label-sync.test.ts
@@ -3698,53 +3698,68 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   }
 });
 
-test("apply-decisions posts an explicit close-time note before closing PR proposals", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    const logPath = join(root, "gh.log");
-    const postedBodiesPath = join(root, "posted-bodies.jsonl");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
-    const closeReport = `${workPlanCandidateReport({
-      type: "pull_request",
-      decision: "close",
-      action_taken: "proposed_close",
-      close_reason: "implemented_on_main",
-      confidence: "high",
-      item_snapshot_hash: "reviewed-snapshot",
-      item_updated_at: "2026-05-01T00:00:00Z",
-      reproduction_status: "reproduced",
-      reproduction_confidence: "high",
-      fixed_pr_url: "https://github.com/openclaw/clawsweeper/pull/900",
-      fixed_pr_number: "900",
-      fixed_pr_confidence: "high",
-      fixed_pr_source: "GitHub verified implementation landing",
-      fixed_pr_merged_at: "2026-05-01T02:00:00Z",
-      fixed_sha: "1234567890abcdef1234567890abcdef12345678",
-      fixed_at: "2026-05-01T02:00:00Z",
-    })}\n\n## Evidence\n\n- **main fix:** git show confirms current main has the replacement implementation and it is not in the latest release yet\n  - file: [src/clawsweeper.ts](https://github.com/openclaw/clawsweeper/blob/1234567890abcdef1234567890abcdef12345678/src/clawsweeper.ts)\n  - sha: [1234567890ab](https://github.com/openclaw/clawsweeper/commit/1234567890abcdef1234567890abcdef12345678)\n\n## Close Comment\n\nClosing this PR because the fix is already on main.\n`;
-    const synced = reportWithSyncedReviewComment(closeReport, 321, "implemented_on_main");
-    writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
+test("apply-decisions posts an explicit close-time note after closing PR proposals", () => {
+  for (const { lifecycleDrift, closeAppliedCommentFails } of [
+    { lifecycleDrift: false, closeAppliedCommentFails: false },
+    { lifecycleDrift: true, closeAppliedCommentFails: false },
+    { lifecycleDrift: false, closeAppliedCommentFails: true },
+  ]) {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "items");
+      const closedDir = join(root, "closed");
+      const plansDir = join(root, "plans");
+      const reportPath = join(root, "apply-report.json");
+      const logPath = join(root, "gh.log");
+      const postedBodiesPath = join(root, "posted-bodies.jsonl");
+      mkdirSync(itemsDir, { recursive: true });
+      mkdirSync(plansDir, { recursive: true });
+      const closeReport = `${workPlanCandidateReport({
+        type: "pull_request",
+        decision: "close",
+        action_taken: "proposed_close",
+        close_reason: "implemented_on_main",
+        confidence: "high",
+        item_snapshot_hash: "reviewed-snapshot",
+        item_updated_at: "2026-05-01T00:00:00Z",
+        reproduction_status: "reproduced",
+        reproduction_confidence: "high",
+        fixed_pr_url: "https://github.com/openclaw/clawsweeper/pull/900",
+        fixed_pr_number: "900",
+        fixed_pr_confidence: "high",
+        fixed_pr_source: "GitHub verified implementation landing",
+        fixed_pr_merged_at: "2026-05-01T02:00:00Z",
+        fixed_sha: "1234567890abcdef1234567890abcdef12345678",
+        fixed_at: "2026-05-01T02:00:00Z",
+      })}\n\n## Evidence\n\n- **main fix:** git show confirms current main has the replacement implementation and it is not in the latest release yet\n  - file: [src/clawsweeper.ts](https://github.com/openclaw/clawsweeper/blob/1234567890abcdef1234567890abcdef12345678/src/clawsweeper.ts)\n  - sha: [1234567890ab](https://github.com/openclaw/clawsweeper/commit/1234567890abcdef1234567890abcdef12345678)\n\n## Close Comment\n\nClosing this PR because the fix is already on main.\n`;
+      const synced = reportWithSyncedReviewComment(closeReport, 321, "implemented_on_main");
+      writeFileSync(join(itemsDir, "321.md"), synced.report, "utf8");
 
-    const ghMock = `
-const { appendFileSync, readFileSync } = require("fs");
+      const ghMock = `
+const { appendFileSync, existsSync, readFileSync, writeFileSync } = require("fs");
 const logPath = ${JSON.stringify(logPath)};
 const postedBodiesPath = ${JSON.stringify(postedBodiesPath)};
+const graphqlStatePath = ${JSON.stringify(join(root, "graphql-reads"))};
 const comment = ${JSON.stringify(synced.comment)};
 const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const path = args[1] || "";
+const lifecycleDrift = ${lifecycleDrift};
+const closeAppliedCommentFails = ${closeAppliedCommentFails};
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && args[1] === "graphql") {
-  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, url: "https://github.com/openclaw/clawsweeper/pull/900", mergedAt: "2026-05-01T02:00:00Z", repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
+  const graphqlReads = existsSync(graphqlStatePath) ? Number(readFileSync(graphqlStatePath, "utf8")) : 0;
+  writeFileSync(graphqlStatePath, String(graphqlReads + 1), "utf8");
+  const currentState = lifecycleDrift && graphqlReads + 1 > 2 ? "OPEN" : "CLOSED";
+  console.log(JSON.stringify({ data: { repository: { issue: { state: currentState, timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, url: "https://github.com/openclaw/clawsweeper/pull/900", mergedAt: "2026-05-01T02:00:00Z", repository: { nameWithOwner: "openclaw/clawsweeper" } } }] } } } } }));
 } else if (args[0] === "api" && /\\/issues\\/321\\/comments(?:\\?|$)/.test(path)) {
   if (args.includes("--method") && args.includes("POST")) {
+    if (closeAppliedCommentFails) {
+      console.error("simulated close-applied comment failure");
+      process.exit(1);
+    }
     const input = args[args.indexOf("--input") + 1];
     const payload = JSON.parse(readFileSync(input, "utf8"));
     appendFileSync(postedBodiesPath, JSON.stringify(payload.body) + "\\n");
@@ -3820,55 +3835,99 @@ if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/321\\/timeline(?:\\?|$
   process.exit(1);
 }
 `;
-    withMockGh(root, ghMock, () => {
-      runApplyDecisionsForTest({
-        itemsDir,
-        closedDir,
-        plansDir,
-        reportPath,
-        extraArgs: ["--apply-kind", "all", "--processed-limit", "2"],
+      withMockGh(root, ghMock, () => {
+        runApplyDecisionsForTest({
+          itemsDir,
+          closedDir,
+          plansDir,
+          reportPath,
+          extraArgs: ["--apply-kind", "all", "--processed-limit", "2"],
+        });
       });
-    });
-    const calls = readFileSync(logPath, "utf8")
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as string[]);
-    const postIndex = calls.findIndex(
-      (args) =>
-        args[0] === "api" &&
-        (args[1] ?? "").endsWith("/issues/321/comments") &&
-        args.includes("POST"),
-    );
-    const closeIndex = calls.findIndex(
-      (args) => args[0] === "pr" && args[1] === "close" && args[2] === "321",
-    );
-    assert.ok(postIndex >= 0);
-    assert.ok(closeIndex > postIndex);
-    const postedBodies = readFileSync(postedBodiesPath, "utf8")
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line) as string);
-    assert.equal(postedBodies.length, 1);
-    assert.match(postedBodies[0], /ClawSweeper applied the proposed close for this PR/);
-    assert.match(postedBodies[0], /Close reason: already implemented on main/);
-    assert.match(postedBodies[0], /Implementation evidence: \[fix PR #900\]/);
-    assert.match(postedBodies[0], /clawsweeper-close-applied item=321/);
-    assert.ok(existsSync(join(closedDir, "321.md")));
-    assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
-      {
-        number: 321,
-        action: "review_comment_synced",
-        reason: "updated durable Codex review comment",
-      },
-      {
-        number: 321,
-        action: "closed",
-        reason: "already implemented on main; posted close-applied comment",
-      },
-    ]);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
+      const calls = readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as string[]);
+      const postIndex = calls.findIndex(
+        (args) =>
+          args[0] === "api" &&
+          (args[1] ?? "").endsWith("/issues/321/comments") &&
+          args.includes("POST"),
+      );
+      const closeIndex = calls.findIndex(
+        (args) => args[0] === "pr" && args[1] === "close" && args[2] === "321",
+      );
+      const graphqlIndices = calls
+        .map((args, index) => (args[0] === "api" && args[1] === "graphql" ? index : -1))
+        .filter((index) => index >= 0);
+      assert.equal(graphqlIndices.length, 3);
+      if (lifecycleDrift) {
+        assert.equal(closeIndex, -1);
+        assert.equal(postIndex, -1);
+        assert.equal(existsSync(join(closedDir, "321.md")), false);
+        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+          action: string;
+          reason: string;
+        }>;
+        assert.equal(
+          report.some((entry) => entry.action === "closed"),
+          false,
+        );
+        assert.equal(
+          report.some(
+            (entry) =>
+              entry.action === "kept_open" &&
+              entry.reason.includes("current GitHub-verified fixing pull request provenance"),
+          ),
+          true,
+        );
+        continue;
+      }
+      assert.ok(closeIndex > graphqlIndices[2]!);
+      assert.ok(postIndex > closeIndex);
+      if (closeAppliedCommentFails) {
+        assert.equal(existsSync(postedBodiesPath), false);
+        assert.ok(existsSync(join(closedDir, "321.md")));
+        const report = JSON.parse(readFileSync(reportPath, "utf8")) as Array<{
+          action: string;
+          reason: string;
+        }>;
+        assert.equal(
+          report.some(
+            (entry) =>
+              entry.action === "closed" &&
+              entry.reason.includes("close-applied comment failed after close"),
+          ),
+          true,
+        );
+        continue;
+      }
+      const postedBodies = readFileSync(postedBodiesPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string);
+      assert.equal(postedBodies.length, 1);
+      assert.match(postedBodies[0], /ClawSweeper applied the proposed close for this PR/);
+      assert.match(postedBodies[0], /Close reason: already implemented on main/);
+      assert.match(postedBodies[0], /Implementation evidence: \[fix PR #900\]/);
+      assert.match(postedBodies[0], /clawsweeper-close-applied item=321/);
+      assert.ok(existsSync(join(closedDir, "321.md")));
+      assert.deepEqual(JSON.parse(readFileSync(reportPath, "utf8")), [
+        {
+          number: 321,
+          action: "review_comment_synced",
+          reason: "updated durable Codex review comment",
+        },
+        {
+          number: 321,
+          action: "closed",
+          reason: "already implemented on main; posted close-applied comment",
+        },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   }
 });
 

--- a/test/apply-same-author-pair-close.test.ts
+++ b/test/apply-same-author-pair-close.test.ts
@@ -12,6 +12,7 @@ import {
   runApplyDecisionsForTest,
   tmpPrefix,
   withMockCodexProof,
+  verifiedImplementationPullRequestReport,
   withMockGh,
 } from "./helpers.ts";
 
@@ -37,7 +38,7 @@ test("apply-decisions starts same-author pair closes from the PR side", () => {
       "implemented_on_main",
     );
     const pullSynced = reportWithSyncedReviewComment(
-      implementedCloseReport({
+      verifiedImplementationPullRequestReport({
         repository: "openclaw/openclaw",
         number: 321,
         type: "pull_request",
@@ -60,6 +61,22 @@ const rawArgs = process.argv.slice(2);
 const args = rawArgs[0] === "--repo" ? rawArgs.slice(2) : rawArgs;
 const path = args[1] || "";
 const issueNumber = (path.match(/\\/issues\\/(\\d+)/) || [])[1];
+if (args[0] === "api" && args[1] === "graphql") {
+  console.log(JSON.stringify({ data: { repository: { issue: { state: "CLOSED", timelineItems: { nodes: [{ __typename: "ClosedEvent", createdAt: "2026-05-01T02:00:00Z", closer: { __typename: "PullRequest", number: 900, repository: { nameWithOwner: "openclaw/openclaw" } } }] } } } } }));
+  process.exit(0);
+}
+if (args[0] === "api" && path === "repos/openclaw/openclaw") {
+  console.log(JSON.stringify({ default_branch: "main" }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/900$/.test(path)) {
+  console.log(JSON.stringify({ number: 900, html_url: "https://github.com/openclaw/openclaw/pull/900", title: "Current implementation", merged: true, merged_at: "2026-05-01T02:00:00Z", merge_commit_sha: "fix-sha", head: { sha: "fix-sha" }, base: { ref: "main" } }));
+  process.exit(0);
+}
+if (args[0] === "api" && /\\/pulls\\/321$/.test(path) && args.includes("--jq")) {
+  console.log(JSON.stringify({ body: "Fixes #320." }));
+  process.exit(0);
+}
 if (args[0] === "api" && args[1] === "-i" && /\\/issues\\/(320|321)\\/timeline(?:\\?|$)/.test(args[2] || "")) {
   console.log("HTTP/2 200\\n\\n[]");
 } else if (args[0] === "api" && /\\/issues\\/(320|321)\\/comments(?:\\?|$)/.test(path)) {

--- a/test/close-reasons.test.ts
+++ b/test/close-reasons.test.ts
@@ -641,6 +641,16 @@ test("implemented-on-main closes require fix provenance", () => {
       summary: "Current main implements the useful part of this older PR.",
       closeComment:
         "Closing this older PR because current main already covers the useful change and the remaining branch diff is obsolete.",
+      fixedPullRequest: {
+        repo: "openclaw/openclaw",
+        number: 900,
+        url: "https://github.com/openclaw/openclaw/pull/900",
+        title: "Current implementation",
+        mergedAt: "2026-04-28T12:00:00Z",
+        sha: "abcdef1234567890",
+        confidence: "high",
+        source: "GitHub linked-issue current closing PR",
+      },
     }),
   );
   assert.equal(mostlyImplementedPr.ok, true);

--- a/test/fixed-sha-pull-resolution.test.ts
+++ b/test/fixed-sha-pull-resolution.test.ts
@@ -7,7 +7,11 @@ import { closeDecision, item, reportFrontMatter } from "./helpers.ts";
 
 function statusContextWithCalls(
   defaultBranch = "main",
-  options: { rateLimitOnApplyRead?: boolean; rateLimitOnIssueRead?: boolean; freshApplyBody?: boolean } = {},
+  options: {
+    rateLimitOnApplyRead?: boolean;
+    rateLimitOnIssueRead?: boolean;
+    freshApplyBody?: boolean;
+  } = {},
 ) {
   const calls: string[] = [];
   const recentPulls = [

--- a/test/fixed-sha-pull-resolution.test.ts
+++ b/test/fixed-sha-pull-resolution.test.ts
@@ -2,9 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createStatusContext } from "../dist/clawsweeper-status-context.js";
+import { GitHubRateLimitError } from "../dist/github-retry.js";
 import { closeDecision, item, reportFrontMatter } from "./helpers.ts";
 
-function statusContextWithCalls() {
+function statusContextWithCalls(
+  defaultBranch = "main",
+  options: { rateLimitOnApplyRead?: boolean; rateLimitOnIssueRead?: boolean; freshApplyBody?: boolean } = {},
+) {
   const calls: string[] = [];
   const recentPulls = [
     pull(701, "cold-list-a", 101),
@@ -34,8 +38,40 @@ function statusContextWithCalls() {
   const ghJson = <T>(args: string[]): T => {
     const path = args[1] ?? "";
     calls.push(path);
-    if (path === "repos/openclaw/openclaw") return { default_branch: "main" } as T;
+    if (path === "graphql") {
+      if (options.rateLimitOnIssueRead) throw new GitHubRateLimitError("API rate limit exceeded");
+      return {
+        data: {
+          repository: {
+            issue: {
+              state: "CLOSED",
+              timelineItems: {
+                nodes: [
+                  {
+                    __typename: "ClosedEvent",
+                    createdAt: "2026-08-19T12:00:00Z",
+                    closer: {
+                      __typename: "PullRequest",
+                      number: 900,
+                      repository: { nameWithOwner: "openclaw/openclaw" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as T;
+    }
+    if (path === "repos/openclaw/openclaw") return { default_branch: defaultBranch } as T;
     if (path.startsWith("repos/openclaw/openclaw/pulls?")) return recentPulls as T;
+    if (path === "repos/openclaw/openclaw/pulls/123") {
+      if (options.rateLimitOnApplyRead) throw new GitHubRateLimitError("API rate limit exceeded");
+      return { body: options.freshApplyBody ? "Fixes #456" : "No longer linked" } as T;
+    }
+    if (path === "repos/openclaw/openclaw/pulls/900") {
+      return { ...pull(900, "current", 456), base: { ref: defaultBranch } } as T;
+    }
     const fallback = path.match(/^repos\/openclaw\/openclaw\/commits\/([^/]+)\/pulls$/);
     if (fallback?.[1]) return (fallbackPulls.get(fallback[1]) ?? []) as T;
     const commit = path.match(/^repos\/openclaw\/openclaw\/commits\/([^/]+)$/);
@@ -199,4 +235,66 @@ test("a changed fixed SHA does not reuse a prior association", () => {
 
   assert.equal(resolved.fixedPullRequest?.number, 701);
   assert.equal(calls.filter((path) => path.includes("/pulls?state=all")).length, 1);
+});
+
+test("PR implementation closeout revalidates current issue linkage on the repository default branch", () => {
+  const { calls, context } = statusContextWithCalls("master");
+  const resolved = context.attachFixedPullRequest(
+    closeDecision({ fixedSha: "same-sha" }),
+    item({ number: 123, kind: "pull_request" }),
+    { pullRequest: { body: "Fixes #456" } },
+    persistedReview(123, "same-sha", 999),
+  );
+
+  assert.equal(resolved.fixedPullRequest?.number, 900);
+  assert.equal(resolved.fixedPullRequest?.source, "GitHub linked-issue current closing PR");
+  assert.deepEqual(calls, [
+    "graphql",
+    "repos/openclaw/openclaw",
+    "repos/openclaw/openclaw/pulls/900",
+  ]);
+});
+
+test("apply-time PR closeout rejects stale issue linkage", () => {
+  const { calls, context } = statusContextWithCalls();
+  const block = context.implementedOnMainPullRequestProvenanceApplyBlock(
+    reportFrontMatter({ fixed_pr_number: "900" }),
+    item({ number: 123, kind: "pull_request" }),
+    "implemented_on_main",
+  );
+
+  assert.equal(
+    block,
+    "implemented-on-main close no longer has a current explicit same-repository issue link",
+  );
+  assert.deepEqual(calls, ["repos/openclaw/openclaw/pulls/123"]);
+});
+
+test("apply-time PR closeout propagates GitHub rate limits", () => {
+  const { context } = statusContextWithCalls("main", { rateLimitOnApplyRead: true });
+  assert.throws(
+    () =>
+      context.implementedOnMainPullRequestProvenanceApplyBlock(
+        reportFrontMatter({ fixed_pr_number: "900" }),
+        item({ number: 123, kind: "pull_request" }),
+        "implemented_on_main",
+      ),
+    GitHubRateLimitError,
+  );
+});
+
+test("apply-time PR closeout propagates linked-issue GitHub rate limits", () => {
+  const { context } = statusContextWithCalls("main", {
+    freshApplyBody: true,
+    rateLimitOnIssueRead: true,
+  });
+  assert.throws(
+    () =>
+      context.implementedOnMainPullRequestProvenanceApplyBlock(
+        reportFrontMatter({ fixed_pr_number: "900" }),
+        item({ number: 123, kind: "pull_request" }),
+        "implemented_on_main",
+      ),
+    GitHubRateLimitError,
+  );
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -438,6 +438,20 @@ export function implementedCloseReport(overrides = {}) {
   })}\n\n## Evidence\n\n- **main fix:** git show confirms current main has the replacement implementation and it is not in the latest release yet\n  - file: [src/clawsweeper.ts](https://github.com/openclaw/clawsweeper/blob/1234567890abcdef1234567890abcdef12345678/src/clawsweeper.ts)\n  - sha: [1234567890ab](https://github.com/openclaw/clawsweeper/commit/1234567890abcdef1234567890abcdef12345678)\n\n## Close Comment\n\nClosing this because the requested behavior is already on main.\n`;
 }
 
+export function verifiedImplementationPullRequestReport(overrides = {}) {
+  const repository = String(
+    (overrides as { repository?: unknown }).repository ?? "openclaw/clawsweeper",
+  );
+  return implementedCloseReport({
+    fixed_pr_url: `https://github.com/${repository}/pull/900`,
+    fixed_pr_number: "900",
+    fixed_pr_merged_at: "2026-05-01T02:00:00Z",
+    fixed_pr_confidence: "high",
+    fixed_pr_source: "GitHub linked-issue current closing PR",
+    ...overrides,
+  });
+}
+
 export function stalePullRequestReport(overrides = {}) {
   return `${workPlanCandidateReport({
     repository: "openclaw/openclaw",

--- a/test/review-close-policy.test.ts
+++ b/test/review-close-policy.test.ts
@@ -527,6 +527,31 @@ test("PR implementation provenance accepts only explicit same-repository closing
     [118669, 118670],
   );
   assert.deepEqual(
+    linkedIssueNumbersForPullRequestBody("Fixes #118669.", "openclaw/openclaw"),
+    [118669],
+  );
+  assert.deepEqual(
+    linkedIssueNumbersForPullRequestBody(
+      "Fixes #118669, fixes #118670 and #118671.",
+      "openclaw/openclaw",
+    ),
+    [118669, 118670, 118671],
+  );
+  assert.deepEqual(
+    linkedIssueNumbersForPullRequestBody(
+      "- Fixes #118669 - carried with the current implementation.",
+      "openclaw/openclaw",
+    ),
+    [118669],
+  );
+  assert.deepEqual(
+    linkedIssueNumbersForPullRequestBody(
+      "1. Fixes #118669\n- [x] Fixes #118670",
+      "openclaw/openclaw",
+    ),
+    [118669, 118670],
+  );
+  assert.deepEqual(
     linkedIssueNumbersForPullRequestBody(
       "Resolves https://github.com/openclaw/openclaw/issues/118669",
       "openclaw/openclaw",
@@ -539,6 +564,13 @@ test("PR implementation provenance accepts only explicit same-repository closing
   );
   assert.equal(
     linkedIssueNumbersForPullRequestBody("Related to #118669", "openclaw/openclaw"),
+    null,
+  );
+  assert.equal(
+    linkedIssueNumbersForPullRequestBody(
+      "Do not write `Fixes #118669` in this explanation.\n\n> Fixes #118670\n\n```md\nFixes #118671\n```\n\n````md\n```\nFixes #118672\n````",
+      "openclaw/openclaw",
+    ),
     null,
   );
 });

--- a/test/review-close-policy.test.ts
+++ b/test/review-close-policy.test.ts
@@ -3,8 +3,11 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  currentClosingPullRequestReferenceFromIssueTimeline,
   fixedPullRequestFromCommitPullsForTest,
   isProtectedItem,
+  linkedIssueNumbersForPullRequestBody,
+  linkedIssueNumbersForImplementationProvenance,
   parseGhJson,
   parseGhJsonLines,
   parseGhJsonWithRetry,
@@ -43,6 +46,8 @@ test("review prompt documents gated backlog close policies", () => {
   assert.match(prompt, /extra duplicate scrutiny/);
   assert.match(prompt, /Never route it to proof-nudge or automated fix-dispatch work/);
   assert.match(prompt, /do not invent a bulk-filing close reason/);
+  assert.match(prompt, /GitHub-verified, merged fixing PR in\s+the same repository/);
+  assert.match(prompt, /linked issue is not permission or proof to close either item/);
   assert.ok(
     [...sweepWorkflow.matchAll(/CLAWSWEEPER_IDEA_REVIVAL_REACTIONS:.*\|\| '5'/g)].length >= 2,
   );
@@ -376,6 +381,7 @@ test("review actions only propose valid closes and never apply directly", () => 
   assert.match(action.closeComment, /Thanks for the context here/);
   assert.match(action.closeComment, /shell check/);
   assert.match(action.closeComment, /already implemented/);
+  assert.doesNotMatch(action.closeComment, /implementation landing is \[commit/);
   assert.match(action.closeComment, /<details>\n<summary>Review details<\/summary>/);
   assert.match(
     action.closeComment,
@@ -416,20 +422,23 @@ test("review actions render deterministic close comments when model close commen
 });
 
 test("close comments reference high-confidence merged fixing PRs", () => {
+  const fixingPullRequest = {
+    repo: "openclaw/openclaw",
+    number: 456,
+    url: "https://github.com/openclaw/openclaw/pull/456",
+    title: "fix: wire the shell check",
+    mergedAt: "2026-04-28T12:00:00Z",
+    sha: "fedcba9876543210",
+    confidence: "high" as const,
+    source: "GitHub closing PR reference",
+  };
+  assert.deepEqual(
+    validateCloseDecision(item(), closeDecision({ fixedPullRequest: fixingPullRequest })),
+    { ok: true },
+  );
   const action = reviewActionForDecision({
     item: item(),
-    decision: closeDecision({
-      fixedPullRequest: {
-        repo: "openclaw/openclaw",
-        number: 456,
-        url: "https://github.com/openclaw/openclaw/pull/456",
-        title: "fix: wire the shell check",
-        mergedAt: "2026-04-28T12:00:00Z",
-        sha: "fedcba9876543210",
-        confidence: "high",
-        source: "GitHub closing PR reference",
-      },
-    }),
+    decision: closeDecision({ fixedPullRequest: fixingPullRequest }),
     git,
     runtime: { model: "gpt-5.6-sol", reasoningEffort: "high" },
   });
@@ -442,6 +451,160 @@ test("close comments reference high-confidence merged fixing PRs", () => {
   assert.match(
     action.closeComment,
     /fix evidence: merged PR \[#456\]\(https:\/\/github\.com\/openclaw\/openclaw\/pull\/456\), commit/,
+  );
+});
+
+test("implemented-on-main closure fails closed without a GitHub-verified fixing PR", () => {
+  const pullRequest = item({
+    kind: "pull_request",
+    number: 118679,
+    url: "https://github.com/openclaw/openclaw/pull/118679",
+  });
+  const ambiguousCommit = closeDecision({
+    fixedSha: "c2de3206aabbccddeeff00112233445566778899",
+    fixedPullRequest: null,
+  });
+  const noProvenance = validateCloseDecision(pullRequest, ambiguousCommit);
+  assert.deepEqual(noProvenance, {
+    ok: false,
+    actionTaken: "skipped_invalid_decision",
+    reason: "implemented-on-main close requires a GitHub-verified fixing pull request",
+  });
+  assert.equal(
+    reviewActionForDecision({ item: pullRequest, decision: ambiguousCommit, git }).actionTaken,
+    "skipped_invalid_decision",
+  );
+
+  const crossRepository = validateCloseDecision(
+    pullRequest,
+    closeDecision({
+      fixedPullRequest: {
+        repo: "other/repository",
+        number: 125781,
+        url: "https://github.com/other/repository/pull/125781",
+        title: "unrelated implementation",
+        mergedAt: "2026-04-28T12:00:00Z",
+        sha: "c2de3206aabbccddeeff00112233445566778899",
+        confidence: "high",
+        source: "GitHub closing PR reference",
+      },
+    }),
+  );
+  assert.equal(crossRepository.ok, false);
+  assert.equal(
+    crossRepository.reason,
+    "implemented-on-main fixing pull request must be in the reviewed repository",
+  );
+
+  const selfReference = validateCloseDecision(
+    pullRequest,
+    closeDecision({
+      fixedPullRequest: {
+        repo: "openclaw/openclaw",
+        number: 118679,
+        url: "https://github.com/openclaw/openclaw/pull/118679",
+        title: "the PR being closed",
+        mergedAt: "2026-04-28T12:00:00Z",
+        sha: "c2de3206aabbccddeeff00112233445566778899",
+        confidence: "high",
+        source: "GitHub closing PR reference",
+      },
+    }),
+  );
+  assert.equal(selfReference.ok, false);
+  assert.equal(
+    selfReference.reason,
+    "implemented-on-main fixing pull request cannot be the pull request being closed",
+  );
+});
+
+test("PR implementation provenance accepts only explicit same-repository closing issues", () => {
+  assert.deepEqual(
+    linkedIssueNumbersForPullRequestBody(
+      "Fixes #118669\nResolves openclaw/openclaw#118670",
+      "openclaw/openclaw",
+    ),
+    [118669, 118670],
+  );
+  assert.deepEqual(
+    linkedIssueNumbersForPullRequestBody(
+      "Resolves https://github.com/openclaw/openclaw/issues/118669",
+      "openclaw/openclaw",
+    ),
+    [118669],
+  );
+  assert.equal(
+    linkedIssueNumbersForPullRequestBody("Fixes other/repository#118669", "openclaw/openclaw"),
+    null,
+  );
+  assert.equal(
+    linkedIssueNumbersForPullRequestBody("Related to #118669", "openclaw/openclaw"),
+    null,
+  );
+});
+
+test("PR implementation provenance caps linked issue references", () => {
+  assert.deepEqual(
+    linkedIssueNumbersForImplementationProvenance(
+      "Fixes #1\nFixes #2\nFixes #3\nFixes #4\nFixes #5",
+      "openclaw/openclaw",
+    ),
+    [1, 2, 3, 4, 5],
+  );
+  assert.equal(
+    linkedIssueNumbersForImplementationProvenance(
+      "Fixes #1\nFixes #2\nFixes #3\nFixes #4\nFixes #5\nFixes #6",
+      "openclaw/openclaw",
+    ),
+    null,
+  );
+});
+
+test("PR implementation provenance accepts only the current GitHub issue-closing PR", () => {
+  assert.equal(
+    currentClosingPullRequestReferenceFromIssueTimeline({
+      data: {
+        repository: {
+          issue: {
+            state: "CLOSED",
+            timelineItems: {
+              nodes: [
+                {
+                  __typename: "ClosedEvent",
+                  createdAt: "2026-08-19T12:00:00Z",
+                  closer: { __typename: "PullRequest", number: 125023 },
+                },
+                { __typename: "ReopenedEvent", createdAt: "2026-08-19T12:01:00Z" },
+                { __typename: "ClosedEvent", createdAt: "2026-08-19T12:02:00Z", closer: null },
+              ],
+            },
+          },
+        },
+      },
+    }),
+    null,
+  );
+  assert.deepEqual(
+    currentClosingPullRequestReferenceFromIssueTimeline({
+      data: {
+        repository: {
+          issue: {
+            state: "CLOSED",
+            timelineItems: {
+              nodes: [
+                { __typename: "ReopenedEvent", createdAt: "2026-08-19T12:01:00Z" },
+                {
+                  __typename: "ClosedEvent",
+                  createdAt: "2026-08-19T12:02:00Z",
+                  closer: { __typename: "PullRequest", number: 125023 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }),
+    { __typename: "PullRequest", number: 125023 },
   );
 });
 
@@ -745,7 +908,7 @@ test("skill-only OpenClaw PRs can close through ClawHub with upload guidance", (
   assert.match(action.closeComment, /installable ClawHub package/);
 });
 
-test("ClawHub policy allows main-implemented issue and PR close proposals", () => {
+test("ClawHub policy requires verified fixing provenance before main-implemented PR closure", () => {
   const implementedPr = validateCloseDecision(
     item({
       repo: "openclaw/clawhub",
@@ -754,7 +917,8 @@ test("ClawHub policy allows main-implemented issue and PR close proposals", () =
     }),
     closeDecision(),
   );
-  assert.equal(implementedPr.ok, true);
+  assert.equal(implementedPr.ok, false);
+  assert.equal(implementedPr.actionTaken, "skipped_invalid_decision");
 
   const implementedIssue = validateCloseDecision(
     item({
@@ -778,7 +942,7 @@ test("ClawHub policy allows main-implemented issue and PR close proposals", () =
   assert.equal(nonImplementedPr.actionTaken, "skipped_invalid_decision");
 });
 
-test("ClawSweeper policy allows self implemented-on-main issue and PR close proposals", () => {
+test("ClawSweeper policy requires verified fixing provenance before self PR closure", () => {
   const implementedPr = validateCloseDecision(
     item({
       repo: "openclaw/clawsweeper",
@@ -787,7 +951,8 @@ test("ClawSweeper policy allows self implemented-on-main issue and PR close prop
     }),
     closeDecision(),
   );
-  assert.equal(implementedPr.ok, true);
+  assert.equal(implementedPr.ok, false);
+  assert.equal(implementedPr.actionTaken, "skipped_invalid_decision");
 
   const implementedIssue = validateCloseDecision(
     item({


### PR DESCRIPTION
## Summary

- Require GitHub-verified, same-repository, merged fixing-PR provenance before ClawSweeper can close a pull request as already implemented on the default branch.
- Revalidate that provenance immediately before the close and post the concrete implementing pull-request link in the final closeout comment.
- Fail closed for missing, partial, ambiguous, stale, cross-repository, or rate-limited provenance.

## Problem and investigation

ClawSweeper closed [openclaw/openclaw#118679](https://github.com/openclaw/openclaw/pull/118679), which addresses [openclaw/openclaw#118669](https://github.com/openclaw/openclaw/issues/118669), as already implemented. Its cited commit `c2de3206` belongs to [openclaw/openclaw#125781](https://github.com/openclaw/openclaw/pull/125781), an external llama-server change that closes [openclaw/openclaw#116765](https://github.com/openclaw/openclaw/issues/116765). It does not implement the Workboard terminal-subagent reconciliation in #118679.

The superficial Workboard overlap in [openclaw/openclaw#125023](https://github.com/openclaw/openclaw/pull/125023) is not a formal fixing relationship or proof of behavioral equivalence. The close was therefore a false positive: #118679 has been reopened, while #118669 remains open because neither implementation equivalence nor an issue-close decision is proven here.

## Implementation

- Parse only explicit `Fixes` / `Closes` / `Resolves` references in the target pull-request body, accept only same-repository references, and cap the fan-out at five linked issues.
- For each linked issue, inspect GitHub's current lifecycle event and require its current closer to be one merged pull request targeting the repository's default branch. Historical closers, a reopened issue, a manual reclose, a commit-only association, and divergent multiple fixes all block automation.
- Discard persisted provenance unless it matches freshly resolved GitHub state at review time, then repeat the check at apply time before any mutation.
- Require the final closeout comment to contain the verified implementing PR. The implementation-close decision is rejected when that identity, URL, source, merge state, or repository is inconsistent.
- Recheck both target and covering-PR freshness, the apply lease, and implementation provenance after the evidence-comment mutation; replace stale bot-owned evidence rather than reusing it.
- Preserve rate-limit errors for retry handling; other unreadable or uncertain evidence produces a non-mutating skip.

This deliberately does not close linked issues automatically. A PR close is never treated as evidence that an issue should close; uncertain linkage, equivalence, policy, or authority remains a fail-closed manual-maintainer decision.

## Validation

- `pnpm run build:all`
- `pnpm run lint:src`
- `node --test test/fixed-sha-pull-resolution.test.ts test/review-close-policy.test.ts test/apply-close-retry-policy.test.ts test/apply-same-author-pair-close.test.ts test/close-reasons.test.ts test/apply-pr-coverage-proof-close.test.ts test/apply-unsponsored-feature-policy.test.ts` (112 passing tests)
- `node --test --test-name-pattern="verifies provenance after a closeout note" test/apply-label-sync.test.ts` (three deterministic paths: permitted close, provenance drift, and locked evidence comment)
- `pnpm exec oxfmt --check src/clawsweeper-apply-close-execution.ts src/clawsweeper-apply-decision-workflow.ts src/clawsweeper-apply-proof-freshness.ts src/clawsweeper-review-comment-publication.ts src/clawsweeper-status-context.ts test/apply-label-sync.test.ts test/review-close-policy.test.ts`
- `git diff --check`
- Final dirty-patch and committed-base Codex reviews: no actionable findings.
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: no code or security findings.

`pnpm run test:unit` did not complete within the local command window and exposed unrelated Windows-host runner noise, so it is not claimed as passing.

Hosted `pnpm check`, CodeQL, sparse repair build smoke, and Windows Codex launcher passed for `07dca54bb6c2261f7efa339e119a7d536b65ae0d`.

## Real Behavior Proof

**Claim:** an implementation-based PR close cannot proceed unless GitHub currently proves that the PR's explicit same-repository linked issue was closed by the same merged fixing PR; a permitted close cites that PR before the close mutation.

**Exercised surface and scenario:** an exact-head, isolated AWS Linux Crabbox lease built the repository and ran the built Node apply process. The focused apply scenario drives the full close path through its controlled GitHub CLI fixture: valid current issue provenance posts `fix PR #900` before the close action; lifecycle drift after that evidence comment prevents closure; and a locked evidence-comment surface also prevents closure. The provenance-policy tests cover commit-only evidence, no PR, partial/ambiguous evidence, multiple linked issues, cross-repository links, already-closed/reopened histories, self-reference, missing authority evidence, and retry-safe rate-limit propagation.

**Command/environment/result:** on exact head `07dca54bb6c2261f7efa339e119a7d536b65ae0d`, Crabbox `provider=aws`, Linux `ubuntu:26.04`, lease `cbx_2ad64ac24f8c` / run `run_3ff8610bd611`, executed `corepack enable && pnpm install --frozen-lockfile && pnpm run build:all && node --test --test-name-pattern='verifies provenance after a closeout note' test/apply-label-sync.test.ts`. It installed dependencies, built all targets, and passed the three-path proof (`1` selected test, `1` pass, `0` fail; `8.46s` test duration; `1m48s` total leased run).

**Artifact/limits:** the retained Crabbox control-plane event trace is `run_3ff8610bd611` (the local redacted copy is `C:\\clawsweeper-work\\docs\\csw-134-crabbox-run-events.json`). This is a real containerized build-and-apply-boundary execution, but the GitHub API behavior is deliberately controlled by the test fixture: it does not create comments or close any live GitHub item. Live mutation is intentionally out of scope for this repair; the run proves the deterministic closure contract and its fail-closed paths, not GitHub API availability or repository authorization.

## Risks and rollout

The change intentionally favors false negatives: valid implementation closes may require manual maintainer review if GitHub linkage is incomplete or unavailable. It adds no automatic issue closure and does not change OpenClaw Bay.

## Related records

- Incorrectly closed then reopened: [openclaw/openclaw#118679](https://github.com/openclaw/openclaw/pull/118679)
- Originating issue left open: [openclaw/openclaw#118669](https://github.com/openclaw/openclaw/issues/118669)
- Incorrectly cited landing: [openclaw/openclaw#125781](https://github.com/openclaw/openclaw/pull/125781) / [openclaw/openclaw#116765](https://github.com/openclaw/openclaw/issues/116765)
- Correction note: [#118679 comment](https://github.com/openclaw/openclaw/pull/118679#issuecomment-5346667712)

## Review closeout

The final Codex committed-range review found no actionable issue. The local ClawSweeper range review likewise found no code or security issue. A normal hosted ClawSweeper re-review is requested only after this current-head proof was added; retain draft status until that review and all remaining readiness gates are terminally clear.
