### PR TITLE
fix(live-proof): bound exact review tool installs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1354,14 +1354,14 @@ jobs:
       - name: Install exact live-proof terminal tools
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.requires_terminal == 'true' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes tmux
+          timeout --foreground 5m sudo apt-get update
+          timeout --foreground 5m sudo apt-get install --yes tmux
 
       - name: Install exact live-proof recording tools
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.record_media == 'true' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes ffmpeg x11-utils xfonts-base xvfb xterm
+          timeout --foreground 5m sudo apt-get update
+          timeout --foreground 5m sudo apt-get install --yes ffmpeg x11-utils xfonts-base xvfb xterm
 
       - name: Execute exact review live proof
         id: execute-exact-live-proof

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1354,14 +1354,98 @@ jobs:
       - name: Install exact live-proof terminal tools
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.requires_terminal == 'true' }}
         run: |
-          timeout --foreground 5m sudo apt-get update
-          timeout --foreground 5m sudo apt-get install --yes tmux
+          run_bounded_install() {
+            local install_timeout_seconds=300
+            local install_grace_seconds=5
+            local install_pid=""
+            local install_pgid=""
+            local watchdog_pid=""
+            terminate_install_group() {
+              [ -n "$install_pgid" ] || return 0
+              kill -TERM -- "-$install_pgid" 2>/dev/null || return 0
+              for ((grace_second = 0; grace_second < install_grace_seconds; grace_second += 1)); do
+                if ! kill -0 -- "-$install_pgid" 2>/dev/null; then
+                  return 0
+                fi
+                sleep 1
+              done
+              kill -KILL -- "-$install_pgid" 2>/dev/null || true
+            }
+            cleanup_install() {
+              [ -n "$watchdog_pid" ] && kill "$watchdog_pid" 2>/dev/null || true
+              [ -n "$watchdog_pid" ] && wait "$watchdog_pid" 2>/dev/null || true
+              terminate_install_group
+            }
+            trap cleanup_install EXIT INT TERM
+            setsid "$@" &
+            install_pid=$!
+            install_pgid=$install_pid
+            (
+              sleep "$install_timeout_seconds"
+              if kill -0 -- "-$install_pgid" 2>/dev/null; then
+                echo "::error::Exact live-proof package install exceeded ${install_timeout_seconds}s."
+                terminate_install_group
+              fi
+            ) &
+            watchdog_pid=$!
+            set +e
+            wait "$install_pid"
+            local install_exit_code=$?
+            set -e
+            cleanup_install
+            trap - EXIT INT TERM
+            return "$install_exit_code"
+          }
+          run_bounded_install sudo apt-get update
+          run_bounded_install sudo apt-get install --yes tmux
 
       - name: Install exact live-proof recording tools
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.record_media == 'true' }}
         run: |
-          timeout --foreground 5m sudo apt-get update
-          timeout --foreground 5m sudo apt-get install --yes ffmpeg x11-utils xfonts-base xvfb xterm
+          run_bounded_install() {
+            local install_timeout_seconds=300
+            local install_grace_seconds=5
+            local install_pid=""
+            local install_pgid=""
+            local watchdog_pid=""
+            terminate_install_group() {
+              [ -n "$install_pgid" ] || return 0
+              kill -TERM -- "-$install_pgid" 2>/dev/null || return 0
+              for ((grace_second = 0; grace_second < install_grace_seconds; grace_second += 1)); do
+                if ! kill -0 -- "-$install_pgid" 2>/dev/null; then
+                  return 0
+                fi
+                sleep 1
+              done
+              kill -KILL -- "-$install_pgid" 2>/dev/null || true
+            }
+            cleanup_install() {
+              [ -n "$watchdog_pid" ] && kill "$watchdog_pid" 2>/dev/null || true
+              [ -n "$watchdog_pid" ] && wait "$watchdog_pid" 2>/dev/null || true
+              terminate_install_group
+            }
+            trap cleanup_install EXIT INT TERM
+            setsid "$@" &
+            install_pid=$!
+            install_pgid=$install_pid
+            (
+              sleep "$install_timeout_seconds"
+              if kill -0 -- "-$install_pgid" 2>/dev/null; then
+                echo "::error::Exact live-proof package install exceeded ${install_timeout_seconds}s."
+                terminate_install_group
+              fi
+            ) &
+            watchdog_pid=$!
+            set +e
+            wait "$install_pid"
+            local install_exit_code=$?
+            set -e
+            cleanup_install
+            trap - EXIT INT TERM
+            return "$install_exit_code"
+          }
+          run_bounded_install sudo apt-get update
+          run_bounded_install sudo apt-get install --yes ffmpeg x11-utils xfonts-base xvfb xterm
 
       - name: Execute exact review live proof
         id: execute-exact-live-proof

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -777,8 +777,14 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     "Install exact live-proof recording tools",
   ]) {
     const install = step(reviewer, name).run ?? "";
-    assert.match(install, /timeout --foreground 5m sudo apt-get update/);
-    assert.match(install, /timeout --foreground 5m sudo apt-get install --yes/);
+    assert.match(install, /run_bounded_install\(\)/);
+    assert.match(install, /local install_timeout_seconds=300/);
+    assert.match(install, /setsid "\$@" &/);
+    assert.match(install, /kill -TERM -- "-\$install_pgid"/);
+    assert.match(install, /grace_second < install_grace_seconds/);
+    assert.match(install, /kill -KILL -- "-\$install_pgid"/);
+    assert.match(install, /run_bounded_install sudo apt-get update/);
+    assert.match(install, /run_bounded_install sudo apt-get install --yes/);
   }
   const reserveLease = step(reviewer, "Reserve exact review lease");
   assert.equal(reserveLease.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -772,6 +772,14 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
   assert.equal(step(reviewer, "Review exact event item").env?.REPO_TOKEN, undefined);
   assert.match(step(reviewer, "Review exact event item").run ?? "", /--skip-start-comment/);
+  for (const name of [
+    "Install exact live-proof terminal tools",
+    "Install exact live-proof recording tools",
+  ]) {
+    const install = step(reviewer, name).run ?? "";
+    assert.match(install, /timeout --foreground 5m sudo apt-get update/);
+    assert.match(install, /timeout --foreground 5m sudo apt-get install --yes/);
+  }
   const reserveLease = step(reviewer, "Reserve exact review lease");
   assert.equal(reserveLease.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
   assert.match(reserveLease.run ?? "", /pnpm run --silent reserve-review-lease/);


### PR DESCRIPTION
## Summary

Bound and reap package-install processes used only by the exact-review live-proof path.

## Problem

CSW-136 traced the apparent hour-plus review for openclaw/clawsweeper#1210 to a real runner stall: workflow run 32301592228 reached `Install exact live-proof terminal tools` at 2026-08-19T21:03:15Z and remained there. The job-level timeout was the only bound. Its review marker lease expired at 21:42Z, but that did not terminate the still-running workflow execution lease.

## Implementation

- Replace the first attempted foreground timeout with a five-minute, `setsid`-isolated install wrapper.
- The watchdog sends TERM to the whole install process group, waits up to five seconds, then sends KILL; it also cleans up on workflow-shell exit.
- Assert this contract for both conditional exact-review install steps.

The scope deliberately excludes shard-review and publication installs: the observed stall was the exact `event-review-apply` path.

## Validation

- `git diff --check`
- `pnpm exec oxfmt --write .github/workflows/sweep.yml test/sweep-workflow.test.ts`
- deterministic workflow contract: `exact-live-proof-install-process-group-contract=pass`
- `pnpm run build:all`
- Docker-backed Crabbox/Linux real-behavior proof: `run_8cfa41e7bd2f`, provider `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_1230797bab36`, current head `bf9e34ba632eded73e248f507f74448205ba04ad`; passed with `normal_completion_contract=pass` and `process_group_timeout_contract=pass exit=137 child=5433`.
- `codex review --uncommitted`: no actionable findings.
- `codex review --base origin/main`: no actionable findings.
- `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main`: no code correctness finding; it requested the real-behavior proof recorded below.

The Windows-host broad unit runner is not claimed as passing: this host has no WSL `/bin/bash`, and several unrelated fixture paths also return `EPERM`. The focused workflow assertions execute before that known host limitation. `actionlint` is unavailable on this host.

## Real Behavior Proof

**Claim:** A TERM-resistant exact-review live-proof install and its child cannot consume the whole job timeout or survive its timeout cleanup.

**Exercised surface:** The final `run_bounded_install` contract in `.github/workflows/sweep.yml`, job `event-review-apply`, used by both conditional live-proof install steps.

**Scenario/fixture:** On current head `bf9e34ba632eded73e248f507f74448205ba04ad`, a controlled Bash command starts a child `sleep`, ignores TERM in its parent, and waits for that child. The fixture reduces the production five-minute deadline and five-second grace to one second each, then verifies `kill -0 <child>` fails after cleanup.

**Command/environment:** `crabbox run --provider local-container --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble --no-sync --timing-json --script C:\clawsweeper-work\notes\csw-136-process-group-proof.sh`; Docker Desktop Linux provider `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_1230797bab36`, run `run_8cfa41e7bd2f`. `--no-sync` avoids an unrelated Crabbox Windows workspace-sync preflight stall; Crabbox uploaded and ran the standalone LF script. The proof itself requires only Bash, `setsid`, `kill`, and `sleep`.

**Observed result:** The ordinary command completed successfully (`normal_completion_contract=pass`). For the resistant fixture, the watchdog expired, the isolated process group was KILLed after its TERM grace, the child was absent, and the harness exited zero: `process_group_timeout_contract=pass exit=137 child=5433`.

**Artifact/trace:** Crabbox receipt `run_8cfa41e7bd2f` records provider `local-container`, Linux lease `cbx_1230797bab36`, script upload, `exitCode: 0`, and `syncSkipped: true`. Captured stdout contains both success markers. The earlier independent AWS receipt `run_3ab98f55555d` also passed the resistant-child scenario.

**Limits:** This is real Docker-backed Linux process behavior against the exact committed workflow contract, not a deliberately stalled real `apt-get` mirror. Hosted run `32315457866` independently exercised the normal exact-review install step to success in 9 seconds on this same head; the re-review now needs only to reconcile this added proof body.

## Risk / rollout

An unusually slow package mirror now fails the exact review after five minutes per package command and reaps its process group, allowing the existing failure/finalization path to take over instead of retaining the review until the job timeout. No queues, leases, schedules, deployments, or existing reviews were changed during this investigation.

**OpenClaw Bay impact:** Unaffected. This change only bounds package-install execution inside the exact-review worker. It does not change Bay deployment or projection code, public status schema, queue/lease records, or their lifecycle mapping; Bay will continue to show the durable queue state. The fix can reduce a future worker's time in the setup/review stages, but it does not mutate or reclassify any Bay item.

## Related

- CSW-136
- openclaw/clawsweeper#1210 (observed stalled review; no mutation to that review)
