### PR TITLE
fix(dashboard): count Bay lifecycle completions

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -3557,6 +3557,7 @@ jobs:
           COMMAND_COMMENT_ID: ${{ steps.update-final-command-status.outputs.command_comment_id }}
           COMPLETION_COMMENT_ID: ${{ steps.update-final-command-status.outputs.completion_comment_id }}
           COMPLETION_COMPLETED_AT: ${{ steps.update-final-command-status.outputs.completion_completed_at }}
+          STATUS_STATE: ${{ steps.finalization-context.outputs.status_state }}
           QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
         run: |
@@ -3569,6 +3570,7 @@ jobs:
             const commandCommentId = Number(process.env.COMMAND_COMMENT_ID);
             const completionCommentId = Number(process.env.COMPLETION_COMMENT_ID);
             const completedAt = process.env.COMPLETION_COMPLETED_AT || "";
+            const completionOutcome = process.env.STATUS_STATE === "Failed" ? "failure" : "success";
             if (
               !fenceKey || !Number.isSafeInteger(revision) || revision < 1 ||
               (!statusMarker && statusCommentId === null) ||
@@ -3586,6 +3588,7 @@ jobs:
               command_comment_id: commandCommentId,
               completion_comment_id: completionCommentId,
               completed_at: completedAt,
+              completion_outcome: completionOutcome,
               observed_at: Date.now(),
             }));
           ')"

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -691,6 +691,9 @@ export class StatusStore {
         body?.closed_items,
         generatedAt,
         body?.active_item_keys,
+        body?.completed_reviews,
+        body?.completed_reviews_authoritative,
+        body?.active_item_keys_authoritative,
       );
       if (
         currentValue &&
@@ -3895,6 +3898,7 @@ function lifecycleCommandAcknowledgementFromGithubWebhook({ event, payload, env 
     source_comment_id: sourceCommentId,
     completed_at: completedAt,
     completion_kind: "final_command_status",
+    completion_outcome: /^- State:\s*Failed\s*$/im.test(progress || "") ? "failure" : "success",
     completion_comment_id: Number(comment.id),
     status_marker: status?.[0] ?? null,
     ...(legacyCommand ? { require_exact_status_comment: true } : {}),
@@ -5254,6 +5258,7 @@ async function authenticatedLifecycleCommandAcknowledgement(request, env, ctx) {
                 : {}),
               completed_at: completedAt,
               completion_kind: "final_command_status",
+              completion_outcome: receipt.completion_outcome === "failure" ? "failure" : "success",
               completion_comment_id: completionCommentId,
             },
           ],
@@ -6208,19 +6213,23 @@ async function statusSnapshot(env) {
   ]);
   errors.push(...activeJobs.errors);
   errors.push(...workerHealth.errors);
+  const journeyBay = await readBayJourneyState(env).catch((error) => {
+    errors.push(`OpenClaw Bay journey state: ${error instanceof Error ? error.message : error}`);
+    return { journeys: [] };
+  });
+  const completedReviews = completedBayReviews(journeyBay.journeys);
   const terminalBay = await updateBayTerminalState(
     env,
     workerHealth.recent_attempts,
     closed.items,
     generatedAt,
     activeBayItemKeys(activeJobs.workers),
+    completedReviews,
+    completedReviews.length > 0,
+    activeJobs.complete,
   ).catch((error) => {
     errors.push(`OpenClaw Bay terminal state: ${error instanceof Error ? error.message : error}`);
     return emptyBayTerminalState(generatedAt);
-  });
-  const journeyBay = await readBayJourneyState(env).catch((error) => {
-    errors.push(`OpenClaw Bay journey state: ${error instanceof Error ? error.message : error}`);
-    return { journeys: [] };
   });
   const bay = {
     ...terminalBay,
@@ -7605,6 +7614,7 @@ function normalizeBayJourneyCompletion(value) {
   const completedAt = bayJourneyTimestamp(completion.completed_at);
   const completionKind = nullableString(completion.completion_kind);
   const completionCommentId = Number(completion.completion_comment_id);
+  const completionOutcome = nullableString(completion.completion_outcome);
   if (
     !repository ||
     !Number.isInteger(number) ||
@@ -7631,6 +7641,12 @@ function normalizeBayJourneyCompletion(value) {
     ...(sourceDeliveryId ? { source_delivery_id: sourceDeliveryId } : {}),
     completed_at: completedAt,
     completion_kind: completionKind || "final_command_status",
+    completion_outcome:
+      completionOutcome === "success" ||
+      completionOutcome === "failure" ||
+      completionOutcome === "cancelled"
+        ? completionOutcome
+        : null,
     completion_comment_id:
       Number.isSafeInteger(completionCommentId) && completionCommentId > 0
         ? completionCommentId
@@ -7657,6 +7673,7 @@ function normalizeBayJourneyRecord(value) {
     triggered_at: trigger?.triggered_at || null,
     completed_at: completion?.completed_at || null,
     completion_kind: completion?.completion_kind || null,
+    completion_outcome: completion?.completion_outcome || null,
     completion_comment_id: completion?.completion_comment_id || null,
     ...(completion?.source_delivery_id
       ? { completion_source_delivery_id: completion.source_delivery_id }
@@ -7876,6 +7893,7 @@ export function mergeBayJourneyState(previous, triggers, completions, generatedA
       ...record,
       completed_at: completedOrphan.completed_at,
       completion_kind: completedOrphan.completion_kind,
+      completion_outcome: completedOrphan.completion_outcome,
       completion_comment_id: completedOrphan.completion_comment_id,
       ...(completedOrphan.completion_source_delivery_id
         ? { completion_source_delivery_id: completedOrphan.completion_source_delivery_id }
@@ -8057,7 +8075,53 @@ export function activeBayItemKeys(workers, limits: { workers?: number; items?: n
   return [...keys];
 }
 
-async function updateBayTerminalState(env, attempts, closedItems, generatedAt, activeItemKeys) {
+export function completedBayReviews(journeys) {
+  return (Array.isArray(journeys) ? journeys : []).flatMap((journey) => {
+    const record = normalizeBayJourneyRecord(journey);
+    if (
+      !record?.triggered_at ||
+      !record.completed_at ||
+      !record.repository ||
+      !Number.isInteger(record.number) ||
+      !new Set(["success", "failure", "cancelled"]).has(String(record.completion_outcome || ""))
+    )
+      return [];
+    return [
+      {
+        event_id: [
+          "review",
+          record.repository,
+          record.number,
+          "completion",
+          record.completion_source_delivery_id || "legacy",
+          record.completion_comment_id || "status",
+          record.completed_at,
+        ].join(":"),
+        target: {
+          repository: record.repository,
+          number: record.number,
+          url: `https://github.com/${record.repository}/issues/${record.number}`,
+        },
+        revision: record.source_delivery_id || record.id,
+        outcome: record.completion_outcome,
+        trigger_kind: "review_journey",
+        triggered_at: record.triggered_at,
+        completed_at: record.completed_at,
+      },
+    ];
+  });
+}
+
+async function updateBayTerminalState(
+  env,
+  attempts,
+  closedItems,
+  generatedAt,
+  activeItemKeys,
+  completedReviews = [],
+  completedReviewsAuthoritative = false,
+  activeItemKeysAuthoritative = true,
+) {
   if (isDurableStatusStore(env.STATUS_STORE)) {
     const response = await durableStatusStoreStub(env.STATUS_STORE).fetch(
       statusStoreRequest(BAY_TERMINAL_STATE_KEY, "POST"),
@@ -8069,6 +8133,9 @@ async function updateBayTerminalState(env, attempts, closedItems, generatedAt, a
           generated_at: generatedAt,
           ttl_seconds: EVENT_STORE_TTL_SECONDS,
           active_item_keys: activeItemKeys,
+          completed_reviews: completedReviews,
+          completed_reviews_authoritative: completedReviewsAuthoritative,
+          active_item_keys_authoritative: activeItemKeysAuthoritative,
         }),
       },
     );
@@ -8076,7 +8143,16 @@ async function updateBayTerminalState(env, attempts, closedItems, generatedAt, a
     return publicBayTerminalState(await response.json());
   }
   const stored = await readStoredJson(env, BAY_TERMINAL_STATE_KEY);
-  const next = mergeBayTerminalState(stored, attempts, closedItems, generatedAt, activeItemKeys);
+  const next = mergeBayTerminalState(
+    stored,
+    attempts,
+    closedItems,
+    generatedAt,
+    activeItemKeys,
+    completedReviews,
+    completedReviewsAuthoritative,
+    activeItemKeysAuthoritative,
+  );
   if (!stored || bayTerminalStateSignature(stored) !== bayTerminalStateSignature(next)) {
     await writeStoredJson(env, BAY_TERMINAL_STATE_KEY, next, EVENT_STORE_TTL_SECONDS);
     return publicBayTerminalState(next);
@@ -8090,25 +8166,61 @@ export function mergeBayTerminalState(
   closedItems,
   generatedAt,
   activeItemKeys = [],
+  completedReviews = [],
+  completedReviewsAuthoritative = false,
+  activeItemKeysAuthoritative = true,
 ) {
   const now = Date.parse(generatedAt);
   const source = previous && previous.schema_version === 1 ? previous : {};
+  const lifecycleAvailable = completedReviewsAuthoritative === true;
+  // Journey telemetry is bounded and its writes are best-effort, so it can
+  // reconcile known fallback outcomes but cannot globally replace them.
+  const lifecycleAuthoritative = false;
   const storedWindowStartedAt = nullableString(source.terminal_window_started_at);
   const bootstrapWindowStartedAt = Number.isFinite(Date.parse(storedWindowStartedAt || ""))
     ? storedWindowStartedAt
     : bayTerminalBootstrapWindowStartedAt(now);
   const activeKeys = new Set(
-    (Array.isArray(activeItemKeys) ? activeItemKeys : []).map((value) => String(value)),
+    (activeItemKeysAuthoritative
+      ? activeItemKeys
+      : [...(source.active_item_keys || []), ...activeItemKeys]
+    )
+      .filter((value) => typeof value === "string")
+      .map((value) => String(value).toLowerCase()),
   );
-  const bootstrapBuffer = Array.isArray(source.terminal_buffer)
-    ? source.terminal_buffer.filter(
-        (item) =>
-          item?.event_id &&
-          item?.item_key &&
-          isBayTerminalAtOrAfterWindowStart(item, bootstrapWindowStartedAt) &&
-          !activeKeys.has(String(item.item_key)),
+  let pendingFallbackSuccesses = Array.isArray(source.pending_fallback_successes)
+    ? source.pending_fallback_successes.filter(
+        (item) => item?.event_id && item?.item_key && item?.source === "worker_attempt",
       )
     : [];
+  const sourceTerminalBuffer = Array.isArray(source.terminal_buffer) ? source.terminal_buffer : [];
+  for (const item of sourceTerminalBuffer) {
+    if (
+      item?.source === "worker_attempt" &&
+      item?.outcome === "success" &&
+      activeKeys.has(String(item.item_key).toLowerCase()) &&
+      !pendingFallbackSuccesses.some((pending) => pending.event_id === item.event_id)
+    ) {
+      pendingFallbackSuccesses.push(item);
+    }
+  }
+  const restoredFallbackSuccesses = pendingFallbackSuccesses.filter(
+    (item) => !activeKeys.has(String(item.item_key).toLowerCase()),
+  );
+  pendingFallbackSuccesses = pendingFallbackSuccesses.filter((item) =>
+    activeKeys.has(String(item.item_key).toLowerCase()),
+  );
+  const bufferInputs = [...sourceTerminalBuffer, ...restoredFallbackSuccesses].filter(
+    (item, index, items) =>
+      items.findIndex((candidate) => candidate.event_id === item.event_id) === index,
+  );
+  const bootstrapBuffer = bufferInputs.filter(
+    (item) =>
+      item?.event_id &&
+      item?.item_key &&
+      isBayTerminalAtOrAfterWindowStart(item, bootstrapWindowStartedAt) &&
+      (item.source === "completed_review" || !activeKeys.has(String(item.item_key).toLowerCase())),
+  );
   let terminalWindowStartedAt = bayTerminalWindowStartedAt(source, now, bootstrapBuffer);
   const buffer = bootstrapBuffer.filter((item) =>
     isBayTerminalAtOrAfterWindowStart(item, terminalWindowStartedAt),
@@ -8117,6 +8229,11 @@ export function mergeBayTerminalState(
     ? source.seen_events.filter((item) => item?.event_id)
     : [];
   const seenIds = new Set(seenEvents.map((item) => item.event_id));
+  const fallbackAttempts = bayFallbackTerminalAttempts([
+    ...sourceTerminalBuffer,
+    ...pendingFallbackSuccesses,
+    ...seenEvents,
+  ]);
   let terminalWindowEventIds = Array.isArray(source.terminal_window_event_ids)
     ? source.terminal_window_event_ids.map((eventId) => String(eventId)).filter(Boolean)
     : [];
@@ -8130,17 +8247,77 @@ export function mergeBayTerminalState(
   let washedAt = recentlyWashed.length ? source.washed_at || null : null;
   let tideGeneration = Math.max(0, Number(source.tide_generation) || 0);
   let lastTideAt = nullableString(source.last_tide_at);
+  let replacedWashedFallback = false;
 
-  for (const candidate of bayTerminalCandidates(attempts, closedItems)) {
-    if (activeKeys.has(candidate.item_key)) continue;
+  for (const candidate of bayTerminalCandidates(attempts, closedItems, completedReviews)) {
+    const itemKey = String(candidate.item_key).toLowerCase();
     if (
-      !isBayTerminalAfterWindowStart(candidate, terminalWindowStartedAt, terminalWindowEventIdSet)
+      lifecycleAuthoritative &&
+      candidate.source === "worker_attempt" &&
+      candidate.outcome === "success"
     )
       continue;
+    if (activeKeys.has(itemKey) && candidate.source === "worker_attempt") {
+      if (
+        !lifecycleAuthoritative &&
+        candidate.outcome === "success" &&
+        !pendingFallbackSuccesses.some((pending) => pending.event_id === candidate.event_id)
+      ) {
+        pendingFallbackSuccesses.push(candidate);
+      }
+      continue;
+    }
+    const withinTerminalWindow = isBayTerminalAfterWindowStart(
+      candidate,
+      terminalWindowStartedAt,
+      terminalWindowEventIdSet,
+    );
+    if (!withinTerminalWindow && candidate.source !== "completed_review") continue;
     if (seenIds.has(candidate.event_id)) continue;
+    if (candidate.source === "completed_review") {
+      const fallbackAttempt = takeMatchingBayFallbackAttempt(fallbackAttempts, candidate);
+      // A bounded lifecycle snapshot cannot introduce a completion from before
+      // the current tide window. It may still replace a known worker fallback,
+      // including one already washed, without counting it a second time.
+      if (!withinTerminalWindow && !fallbackAttempt) continue;
+      seenIds.add(candidate.event_id);
+      seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
+      if (fallbackAttempt) {
+        const existingIndex = buffer.findIndex(
+          (item) => item.event_id === fallbackAttempt.event_id,
+        );
+        if (existingIndex !== -1) buffer[existingIndex] = candidate;
+        else if (
+          pendingFallbackSuccesses.some((pending) => pending.event_id === fallbackAttempt.event_id)
+        )
+          buffer.push(candidate);
+        else replacedWashedFallback = true;
+        pendingFallbackSuccesses = pendingFallbackSuccesses.filter(
+          (pending) => pending.event_id !== fallbackAttempt.event_id,
+        );
+        continue;
+      }
+      buffer.push(candidate);
+      continue;
+    }
     seenIds.add(candidate.event_id);
     seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
-    const existingIndex = buffer.findIndex((item) => item.item_key === candidate.item_key);
+    if (candidate.source === "worker_attempt") {
+      const lifecycleIndex = buffer.findIndex(
+        (item) =>
+          item.source === "completed_review" &&
+          isLateBayWorkerFallbackForLifecycle(candidate, item),
+      );
+      if (lifecycleIndex !== -1) {
+        seenIds.add(candidate.event_id);
+        seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
+        continue;
+      }
+      fallbackAttempts.push(candidate);
+    }
+    const existingIndex = buffer.findIndex(
+      (item) => item.item_key === candidate.item_key && item.source !== "completed_review",
+    );
     if (existingIndex === -1) {
       buffer.push(candidate);
       continue;
@@ -8157,21 +8334,34 @@ export function mergeBayTerminalState(
   );
 
   let washed = recentlyWashed;
+  let newTides = 0;
   while (buffer.length >= BAY_TIDE_THRESHOLD) {
     washed = buffer.splice(0, BAY_TIDE_THRESHOLD);
     const tideCompletedAt = nullableString(washed.at(-1)?.completed_at) || generatedAt;
     washedAt = generatedAt;
-    lastTideAt = tideCompletedAt;
+    if (!lastTideAt || Date.parse(tideCompletedAt) >= Date.parse(String(lastTideAt || ""))) {
+      lastTideAt = tideCompletedAt;
+    }
     terminalWindowStartedAt = tideCompletedAt;
     terminalWindowEventIds = washed
       .filter((item) => item.completed_at === terminalWindowStartedAt)
       .map((item) => String(item.event_id));
     terminalWindowEventIdSet = new Set(terminalWindowEventIds);
     tideGeneration += 1;
+    newTides += 1;
+  }
+  if (replacedWashedFallback && newTides === 0) {
+    washed = [];
+    washedAt = null;
   }
 
   return {
     schema_version: 1,
+    source_kind: "completed_reviews_v1",
+    completed_reviews_authoritative: lifecycleAuthoritative,
+    completed_reviews_available: lifecycleAvailable,
+    active_item_keys: [...activeKeys],
+    pending_fallback_successes: pendingFallbackSuccesses.slice(-BAY_SEEN_EVENT_LIMIT),
     tide_threshold: BAY_TIDE_THRESHOLD,
     tide_generation: tideGeneration,
     last_tide_at: lastTideAt,
@@ -8189,6 +8379,11 @@ export function mergeBayTerminalState(
 function bayTerminalStateSignature(state) {
   return JSON.stringify({
     schema_version: state?.schema_version,
+    source_kind: state?.source_kind,
+    completed_reviews_authoritative: state?.completed_reviews_authoritative,
+    completed_reviews_available: state?.completed_reviews_available,
+    active_item_keys: state?.active_item_keys,
+    pending_fallback_successes: state?.pending_fallback_successes,
     tide_threshold: state?.tide_threshold,
     tide_generation: state?.tide_generation,
     last_tide_at: state?.last_tide_at,
@@ -8238,7 +8433,81 @@ function isBayTerminalAtOrAfterWindowStart(candidate, terminalWindowStartedAt) {
   return Number.isFinite(completedAt) && Number.isFinite(windowStart) && completedAt >= windowStart;
 }
 
-function bayTerminalCandidates(attempts, closedItems) {
+function bayFallbackTerminalAttempts(values) {
+  const attempts = [];
+  const seen = new Set<string>();
+  for (const value of Array.isArray(values) ? values : []) {
+    const eventId = String(value?.event_id || "");
+    if (!eventId || seen.has(eventId)) continue;
+    if (
+      value?.source === "worker_attempt" &&
+      new Set(["success", "failure", "cancelled"]).has(String(value?.outcome || ""))
+    ) {
+      attempts.push(value);
+      seen.add(eventId);
+      continue;
+    }
+    const match = /^worker:[^:]+:[^:]+:([^:]+#[0-9]+):(success|failure|cancelled):(.+)$/.exec(
+      eventId,
+    );
+    if (!match?.[1] || !match[2] || !match[3]) continue;
+    attempts.push({
+      event_id: eventId,
+      item_key: match[1],
+      completed_at: match[3],
+      source: "worker_attempt",
+      outcome: match[2],
+    });
+    seen.add(eventId);
+  }
+  return attempts;
+}
+
+function takeMatchingBayFallbackAttempt(fallbackAttempts, review) {
+  const reviewCompletedAt = Date.parse(String(review?.completed_at || ""));
+  const reviewTriggeredAt = Date.parse(String(review?.triggered_at || ""));
+  const itemKey = String(review?.item_key || "").toLowerCase();
+  if (!Number.isFinite(reviewCompletedAt) || !itemKey) return null;
+  let matchIndex = -1;
+  let latestCompletedAt = Number.NEGATIVE_INFINITY;
+  for (let index = 0; index < fallbackAttempts.length; index += 1) {
+    const fallback = fallbackAttempts[index];
+    const fallbackCompletedAt = Date.parse(String(fallback?.completed_at || ""));
+    if (
+      String(fallback?.item_key || "").toLowerCase() !== itemKey ||
+      !Number.isFinite(fallbackCompletedAt) ||
+      fallbackCompletedAt > reviewCompletedAt ||
+      (Number.isFinite(reviewTriggeredAt)
+        ? fallbackCompletedAt < reviewTriggeredAt
+        : fallbackCompletedAt !== reviewCompletedAt) ||
+      fallbackCompletedAt < latestCompletedAt
+    )
+      continue;
+    matchIndex = index;
+    latestCompletedAt = fallbackCompletedAt;
+  }
+  return matchIndex === -1 ? null : fallbackAttempts.splice(matchIndex, 1)[0];
+}
+
+function isLateBayWorkerFallbackForLifecycle(fallback, review) {
+  const itemKey = String(review?.item_key || "").toLowerCase();
+  const fallbackStartedAt = Date.parse(
+    String(fallback?.started_at || fallback?.completed_at || ""),
+  );
+  const reviewTriggeredAt = Date.parse(String(review?.triggered_at || ""));
+  const reviewCompletedAt = Date.parse(String(review?.completed_at || ""));
+  return (
+    !!itemKey &&
+    String(fallback?.item_key || "").toLowerCase() === itemKey &&
+    Number.isFinite(fallbackStartedAt) &&
+    Number.isFinite(reviewTriggeredAt) &&
+    Number.isFinite(reviewCompletedAt) &&
+    fallbackStartedAt >= reviewTriggeredAt &&
+    fallbackStartedAt <= reviewCompletedAt
+  );
+}
+
+function bayTerminalCandidates(attempts, closedItems, completedReviews = []) {
   const candidates = [];
   for (const attempt of Array.isArray(attempts) ? attempts : []) {
     const outcome = String(attempt?.terminal_outcome || "");
@@ -8296,6 +8565,33 @@ function bayTerminalCandidates(attempts, closedItems) {
       completed_at: completedAt,
       current_step: "Closed by ClawSweeper",
       source: "closed_item",
+    });
+  }
+  for (const review of Array.isArray(completedReviews) ? completedReviews : []) {
+    const target = objectValue(review?.target);
+    const repository = nullableString(target.repository || review?.repository)?.toLowerCase();
+    const number = Number(target.number || review?.number);
+    const completedAt = nullableString(review?.completed_at);
+    const eventId = nullableString(review?.event_id);
+    if (!repository || !Number.isInteger(number) || number <= 0 || !completedAt || !eventId)
+      continue;
+    const outcome = String(review?.outcome || "success");
+    if (!new Set(["success", "failure", "cancelled"]).has(outcome)) continue;
+    const itemKey = `${repository}#${number}`;
+    candidates.push({
+      event_id: eventId,
+      item_key: itemKey,
+      repository,
+      number,
+      outcome,
+      title: `Completed review ${itemKey}`,
+      item_url: nullableString(target.url) || `https://github.com/${repository}/issues/${number}`,
+      job_url: null,
+      run_id: null,
+      triggered_at: nullableString(review?.triggered_at),
+      completed_at: completedAt,
+      current_step: outcome === "success" ? "Review completed" : `Review ${outcome}`,
+      source: "completed_review",
     });
   }
   return candidates.sort(

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -8281,7 +8281,11 @@ export function mergeBayTerminalState(
       // including one already washed, without counting it a second time.
       if (!withinTerminalWindow && !fallbackAttempt) continue;
       seenIds.add(candidate.event_id);
-      seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
+      seenEvents.push({
+        event_id: candidate.event_id,
+        seen_at: candidate.completed_at,
+        started_at: candidate.started_at,
+      });
       if (fallbackAttempt) {
         const existingIndex = buffer.findIndex(
           (item) => item.event_id === fallbackAttempt.event_id,
@@ -8301,7 +8305,11 @@ export function mergeBayTerminalState(
       continue;
     }
     seenIds.add(candidate.event_id);
-    seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
+    seenEvents.push({
+      event_id: candidate.event_id,
+      seen_at: candidate.completed_at,
+      started_at: candidate.started_at,
+    });
     if (candidate.source === "worker_attempt") {
       const lifecycleIndex = buffer.findIndex(
         (item) =>
@@ -8310,7 +8318,11 @@ export function mergeBayTerminalState(
       );
       if (lifecycleIndex !== -1) {
         seenIds.add(candidate.event_id);
-        seenEvents.push({ event_id: candidate.event_id, seen_at: candidate.completed_at });
+        seenEvents.push({
+          event_id: candidate.event_id,
+          seen_at: candidate.completed_at,
+          started_at: candidate.started_at,
+        });
         continue;
       }
       fallbackAttempts.push(candidate);
@@ -8454,6 +8466,7 @@ function bayFallbackTerminalAttempts(values) {
     attempts.push({
       event_id: eventId,
       item_key: match[1],
+      started_at: nullableString(value?.started_at),
       completed_at: match[3],
       source: "worker_attempt",
       outcome: match[2],
@@ -8473,13 +8486,15 @@ function takeMatchingBayFallbackAttempt(fallbackAttempts, review) {
   for (let index = 0; index < fallbackAttempts.length; index += 1) {
     const fallback = fallbackAttempts[index];
     const fallbackCompletedAt = Date.parse(String(fallback?.completed_at || ""));
+    const fallbackStartedAt = Date.parse(String(fallback?.started_at || ""));
     if (
       String(fallback?.item_key || "").toLowerCase() !== itemKey ||
       !Number.isFinite(fallbackCompletedAt) ||
+      !Number.isFinite(fallbackStartedAt) ||
+      !Number.isFinite(reviewTriggeredAt) ||
       fallbackCompletedAt > reviewCompletedAt ||
-      (Number.isFinite(reviewTriggeredAt)
-        ? fallbackCompletedAt < reviewTriggeredAt
-        : fallbackCompletedAt !== reviewCompletedAt) ||
+      fallbackStartedAt < reviewTriggeredAt ||
+      fallbackStartedAt > reviewCompletedAt ||
       fallbackCompletedAt < latestCompletedAt
     )
       continue;

--- a/test/dashboard-worker-bay-records-routes.test.ts
+++ b/test/dashboard-worker-bay-records-routes.test.ts
@@ -4878,6 +4878,7 @@ test("OpenClaw Bay counts completed review revisions without replaying washed fa
     repository: "openclaw/openclaw",
     item_numbers: [600 + index],
     terminal_outcome: "success",
+    started_at: "2026-07-11T11:59:00.000Z",
     completed_at: `2026-07-11T12:00:${String(index).padStart(2, "0")}.000Z`,
   }));
   const fallbackTide = mergeBayTerminalState(null, attempts, [], "2026-07-11T12:00:20.000Z");
@@ -5335,6 +5336,40 @@ test("OpenClaw Bay replaces a matching failed worker attempt with its lifecycle 
   assert.equal(completed.terminal_buffer[0]?.outcome, "failure");
 });
 
+test("OpenClaw Bay keeps an earlier re-review worker completion beside the next lifecycle", () => {
+  const earlierWorkerFailure = {
+    run_id: 130,
+    job_id: 230,
+    repository: "openclaw/openclaw",
+    item_numbers: [7110],
+    terminal_outcome: "failure",
+    started_at: "2026-07-11T12:00:00.000Z",
+    completed_at: "2026-07-11T12:10:00.000Z",
+  };
+  const nextReview = {
+    event_id: "review:openclaw/openclaw:7110:completion:920:2026-07-11T12:11:00.000Z",
+    target: { repository: "openclaw/openclaw", number: 7110 },
+    triggered_at: "2026-07-11T12:08:00.000Z",
+    completed_at: "2026-07-11T12:11:00.000Z",
+  };
+
+  const completed = mergeBayTerminalState(
+    null,
+    [earlierWorkerFailure],
+    [],
+    "2026-07-11T12:11:01.000Z",
+    [],
+    [nextReview],
+    true,
+  );
+
+  assert.equal(completed.terminal_count, 2);
+  assert.deepEqual(
+    completed.terminal_buffer.map((item) => item.event_id),
+    ["worker:130:230:openclaw/openclaw#7110:failure:2026-07-11T12:10:00.000Z", nextReview.event_id],
+  );
+});
+
 test("OpenClaw Bay does not duplicate a worker that finishes after its lifecycle completion", () => {
   const workerSuccess = {
     run_id: 131,
@@ -5451,6 +5486,7 @@ test("OpenClaw Bay replaces an active pending fallback when its completion arriv
     repository: "openclaw/openclaw",
     item_numbers: [714],
     terminal_outcome: "success",
+    started_at: "2026-07-11T12:13:30.000Z",
     completed_at: "2026-07-11T12:14:00.000Z",
   };
   const pending = mergeBayTerminalState(null, [workerSuccess], [], "2026-07-11T12:14:01.000Z", [

--- a/test/dashboard-worker-bay-records-routes.test.ts
+++ b/test/dashboard-worker-bay-records-routes.test.ts
@@ -6007,9 +6007,11 @@ test("hosted webhook records an edited review command through its final command 
   });
 
   const originalCaches = globalThis.caches;
+  const originalFetch = globalThis.fetch;
   Object.assign(globalThis, {
     caches: { default: { match: async () => undefined, put: async () => undefined } },
   });
+  globalThis.fetch = async () => new Response("isolated status trace", { status: 503 });
   try {
     const status = await worker.fetch(
       new Request("https://clawsweeper.openclaw.ai/api/status"),
@@ -6021,5 +6023,6 @@ test("hosted webhook records an edited review command through its final command 
     assert.deepEqual(snapshot.bay.terminal_buffer, [{ outcome: "failure" }]);
   } finally {
     Object.assign(globalThis, { caches: originalCaches });
+    globalThis.fetch = originalFetch;
   }
 });

--- a/test/dashboard-worker-bay-records-routes.test.ts
+++ b/test/dashboard-worker-bay-records-routes.test.ts
@@ -9,6 +9,7 @@ import {
   gunzipSync,
   worker,
   ExactReviewQueue,
+  completedBayReviews,
   exactReviewQueueAdmittedItems,
   exactReviewQueueNextWakeAt,
   exactReviewQueueStatusSnapshot,
@@ -4870,6 +4871,654 @@ test("OpenClaw Bay shares a bounded 20-outcome tide buffer", () => {
   );
 });
 
+test("OpenClaw Bay counts completed review revisions without replaying washed fallback success", () => {
+  const attempts = Array.from({ length: 20 }, (_, index) => ({
+    run_id: 100 + index,
+    job_id: 200 + index,
+    repository: "openclaw/openclaw",
+    item_numbers: [600 + index],
+    terminal_outcome: "success",
+    completed_at: `2026-07-11T12:00:${String(index).padStart(2, "0")}.000Z`,
+  }));
+  const fallbackTide = mergeBayTerminalState(null, attempts, [], "2026-07-11T12:00:20.000Z");
+  const reviews = attempts.map((attempt, index) => ({
+    event_id: `review:openclaw/openclaw#${600 + index}:revision-${index + 1}`,
+    target: {
+      repository: "openclaw/openclaw",
+      number: 600 + index,
+      url: `https://github.com/openclaw/openclaw/issues/${600 + index}`,
+    },
+    triggered_at: "2026-07-11T11:59:00.000Z",
+    completed_at: attempt.completed_at,
+  }));
+
+  const promoted = mergeBayTerminalState(
+    fallbackTide,
+    attempts,
+    [],
+    "2026-07-11T12:00:21.000Z",
+    [],
+    reviews,
+    true,
+  );
+
+  assert.equal(promoted.tide_generation, 1);
+  assert.equal(promoted.terminal_count, 0);
+  assert.deepEqual(promoted.recently_washed, []);
+
+  const newRevision = {
+    ...reviews[0],
+    event_id: "review:openclaw/openclaw#600:revision-21",
+    triggered_at: "2026-07-11T12:00:20.000Z",
+    completed_at: "2026-07-11T12:00:21.000Z",
+  };
+  const next = mergeBayTerminalState(
+    promoted,
+    [],
+    [],
+    "2026-07-11T12:00:22.000Z",
+    [],
+    [newRevision],
+    true,
+  );
+  assert.equal(next.terminal_count, 1);
+  assert.equal(next.terminal_buffer[0]?.event_id, newRevision.event_id);
+});
+
+test("OpenClaw Bay retains an unrelated displayed tide when lifecycle telemetry first appears", () => {
+  const attempts = Array.from({ length: 20 }, (_, index) => ({
+    run_id: 300 + index,
+    job_id: 400 + index,
+    repository: "openclaw/openclaw",
+    item_numbers: [900 + index],
+    terminal_outcome: "success",
+    completed_at: `2026-07-11T12:20:${String(index).padStart(2, "0")}.000Z`,
+  }));
+  const tide = mergeBayTerminalState(null, attempts, [], "2026-07-11T12:20:20.000Z");
+  const next = mergeBayTerminalState(
+    tide,
+    [],
+    [],
+    "2026-07-11T12:20:21.000Z",
+    [],
+    [
+      {
+        event_id: "review:openclaw/openclaw:999:completion:99:2026-07-11T12:20:21.000Z",
+        target: { repository: "openclaw/openclaw", number: 999 },
+        triggered_at: "2026-07-11T12:19:00.000Z",
+        completed_at: "2026-07-11T12:20:21.000Z",
+        outcome: "success",
+      },
+    ],
+    true,
+  );
+
+  assert.equal(next.recently_washed.length, 20);
+  assert.equal(next.terminal_count, 1);
+});
+
+test("OpenClaw Bay keeps failure and cancelled outcomes during lifecycle promotion", () => {
+  const failure = {
+    run_id: 1,
+    job_id: 1,
+    repository: "openclaw/openclaw",
+    item_numbers: [701],
+    terminal_outcome: "failure",
+    completed_at: "2026-07-11T12:00:00.000Z",
+  };
+  const cancelled = {
+    ...failure,
+    run_id: 2,
+    job_id: 2,
+    item_numbers: [702],
+    terminal_outcome: "cancelled",
+    completed_at: "2026-07-11T12:01:00.000Z",
+  };
+  const fallback = mergeBayTerminalState(
+    null,
+    [failure, cancelled],
+    [],
+    "2026-07-11T12:01:01.000Z",
+  );
+  const completedReview = {
+    event_id: "review:openclaw/openclaw#703:revision-1",
+    target: {
+      repository: "openclaw/openclaw",
+      number: 703,
+      url: "https://github.com/openclaw/openclaw/issues/703",
+    },
+    completed_at: "2026-07-11T12:02:00.000Z",
+  };
+  const promoted = mergeBayTerminalState(
+    fallback,
+    [],
+    [],
+    "2026-07-11T12:02:01.000Z",
+    [],
+    [completedReview],
+    true,
+  );
+
+  assert.deepEqual(
+    promoted.terminal_buffer.map((item: { outcome: string }) => item.outcome).sort(),
+    ["cancelled", "failure", "success"],
+  );
+});
+
+test("OpenClaw Bay keeps worker successes until a completed lifecycle review is available", () => {
+  const success = {
+    run_id: 10,
+    job_id: 20,
+    repository: "openclaw/openclaw",
+    item_numbers: [704],
+    terminal_outcome: "success",
+    completed_at: "2026-07-11T12:03:00.000Z",
+  };
+  const state = mergeBayTerminalState(
+    null,
+    [success],
+    [],
+    "2026-07-11T12:03:01.000Z",
+    [],
+    [],
+    false,
+  );
+
+  assert.equal(state.completed_reviews_authoritative, false);
+  assert.equal(state.terminal_count, 1);
+  assert.equal(state.terminal_buffer[0]?.outcome, "success");
+});
+
+test("OpenClaw Bay does not reopen a cleared tide boundary during lifecycle reconciliation", () => {
+  const prior = {
+    schema_version: 1,
+    source_kind: "worker_attempts_v1",
+    tide_threshold: 20,
+    tide_generation: 1,
+    last_tide_at: "2026-07-11T12:00:00.000Z",
+    terminal_window_started_at: "2026-07-11T12:00:00.000Z",
+    terminal_window_event_ids: [],
+    terminal_count: 0,
+    terminal_buffer: [],
+    washed_at: "2026-07-11T12:00:01.000Z",
+    recently_washed: [],
+    seen_events: [],
+    updated_at: "2026-07-11T12:00:01.000Z",
+  };
+  const completedReview = {
+    event_id: "review:openclaw/openclaw#705:revision-1",
+    target: {
+      repository: "openclaw/openclaw",
+      number: 705,
+      url: "https://github.com/openclaw/openclaw/issues/705",
+    },
+    completed_at: "2026-07-11T11:00:00.000Z",
+  };
+  const reconciled = mergeBayTerminalState(
+    prior,
+    [],
+    [],
+    "2026-07-11T12:01:00.000Z",
+    [],
+    [completedReview],
+    true,
+  );
+  const staleFailure = {
+    run_id: 11,
+    job_id: 21,
+    repository: "openclaw/openclaw",
+    item_numbers: [706],
+    terminal_outcome: "failure",
+    completed_at: "2026-07-11T11:30:00.000Z",
+  };
+  const next = mergeBayTerminalState(reconciled, [staleFailure], [], "2026-07-11T12:01:01.000Z");
+
+  assert.equal(reconciled.terminal_window_started_at, "2026-07-11T12:00:00.000Z");
+  assert.equal(next.terminal_count, 0);
+});
+
+test("OpenClaw Bay does not wash retained lifecycle completions from before the tide boundary", () => {
+  const prior = {
+    schema_version: 1,
+    tide_generation: 1,
+    last_tide_at: "2026-07-11T12:00:00.000Z",
+    terminal_window_started_at: "2026-07-11T12:00:00.000Z",
+    terminal_window_event_ids: [],
+    terminal_count: 0,
+    terminal_buffer: [],
+    recently_washed: [],
+    seen_events: [],
+  };
+  const completedReviews = Array.from({ length: 20 }, (_, index) => ({
+    event_id: `review:openclaw/openclaw#${760 + index}:revision-1`,
+    target: { repository: "openclaw/openclaw", number: 760 + index },
+    triggered_at: "2026-07-11T10:00:00.000Z",
+    completed_at: `2026-07-11T11:${String(index).padStart(2, "0")}:00.000Z`,
+  }));
+  const reconciled = mergeBayTerminalState(
+    prior,
+    [],
+    [],
+    "2026-07-11T12:01:00.000Z",
+    [],
+    completedReviews,
+    true,
+  );
+
+  assert.equal(reconciled.tide_generation, 1);
+  assert.equal(reconciled.terminal_count, 0);
+  assert.deepEqual(reconciled.recently_washed, []);
+});
+
+test("OpenClaw Bay keeps completion IDs stable when an orphaned receipt gains its trigger", () => {
+  const completion = {
+    repository: "openclaw/openclaw",
+    number: 707,
+    source_comment_id: 77,
+    completed_at: "2026-07-11T12:05:00.000Z",
+    completion_kind: "final_command_status",
+    completion_outcome: "failure",
+    completion_comment_id: 88,
+  };
+  const orphaned = mergeBayJourneyState(null, [], [completion], "2026-07-11T12:05:01.000Z");
+  const correlated = mergeBayJourneyState(
+    orphaned,
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 707,
+        source_comment_id: 77,
+        source_delivery_id: "delivery-707",
+        triggered_at: "2026-07-11T12:00:00.000Z",
+      },
+    ],
+    [],
+    "2026-07-11T12:05:02.000Z",
+  );
+
+  assert.equal(completedBayReviews(orphaned.journeys).length, 0);
+  assert.equal(completedBayReviews(correlated.journeys)[0]?.outcome, "failure");
+});
+
+test("OpenClaw Bay preserves failed review completions", () => {
+  const journeys = mergeBayJourneyState(
+    null,
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 708,
+        source_comment_id: 78,
+        triggered_at: "2026-07-11T12:05:00.000Z",
+      },
+    ],
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 708,
+        source_comment_id: 78,
+        completed_at: "2026-07-11T12:06:00.000Z",
+        completion_kind: "final_command_status",
+        completion_outcome: "failure",
+        completion_comment_id: 89,
+      },
+    ],
+    "2026-07-11T12:06:01.000Z",
+  );
+  const state = mergeBayTerminalState(
+    null,
+    [],
+    [],
+    "2026-07-11T12:06:02.000Z",
+    [],
+    completedBayReviews(journeys.journeys),
+  );
+
+  assert.equal(state.terminal_buffer[0]?.outcome, "failure");
+});
+
+test("OpenClaw Bay excludes legacy completions with an unknown outcome", () => {
+  const journeys = mergeBayJourneyState(
+    null,
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 708,
+        source_comment_id: 78,
+        triggered_at: "2026-07-11T12:05:00.000Z",
+      },
+    ],
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 708,
+        source_comment_id: 78,
+        completed_at: "2026-07-11T12:06:00.000Z",
+        completion_kind: "final_command_status",
+        completion_comment_id: 89,
+      },
+    ],
+    "2026-07-11T12:06:01.000Z",
+  );
+
+  assert.deepEqual(completedBayReviews(journeys.journeys), []);
+});
+
+test("OpenClaw Bay keeps same-second delivery-fenced revisions distinct", () => {
+  const completedAt = "2026-07-11T12:07:00.000Z";
+  const journeys = mergeBayJourneyState(
+    null,
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 709,
+        source_comment_id: 79,
+        source_delivery_id: "delivery-709-a",
+        triggered_at: "2026-07-11T12:06:00.000Z",
+      },
+      {
+        repository: "openclaw/openclaw",
+        number: 709,
+        source_comment_id: 79,
+        source_delivery_id: "delivery-709-b",
+        triggered_at: "2026-07-11T12:06:00.000Z",
+      },
+    ],
+    [
+      {
+        repository: "openclaw/openclaw",
+        number: 709,
+        source_comment_id: 79,
+        source_delivery_id: "delivery-709-a",
+        completed_at: completedAt,
+        completion_kind: "final_command_status",
+        completion_outcome: "success",
+        completion_comment_id: 90,
+      },
+      {
+        repository: "openclaw/openclaw",
+        number: 709,
+        source_comment_id: 79,
+        source_delivery_id: "delivery-709-b",
+        completed_at: completedAt,
+        completion_kind: "final_command_status",
+        completion_outcome: "success",
+        completion_comment_id: 90,
+      },
+    ],
+    "2026-07-11T12:07:01.000Z",
+  );
+  const reviews = completedBayReviews(journeys.journeys);
+
+  assert.equal(reviews.length, 2);
+  assert.notEqual(reviews[0]?.event_id, reviews[1]?.event_id);
+});
+
+test("OpenClaw Bay replaces a matching worker fallback with its lifecycle completion", () => {
+  const previous = mergeBayTerminalState(
+    null,
+    [],
+    [],
+    "2026-07-11T12:08:00.000Z",
+    [],
+    [
+      {
+        event_id: "review:openclaw/openclaw:709:completion:90:2026-07-11T12:08:00.000Z",
+        target: { repository: "openclaw/openclaw", number: 709 },
+        triggered_at: "2026-07-11T12:07:00.000Z",
+        completed_at: "2026-07-11T12:08:00.000Z",
+      },
+    ],
+    true,
+  );
+  const workerSuccess = {
+    run_id: 12,
+    job_id: 22,
+    repository: "openclaw/openclaw",
+    item_numbers: [710],
+    terminal_outcome: "success",
+    started_at: "2026-07-11T12:09:00.000Z",
+    completed_at: "2026-07-11T12:10:00.000Z",
+  };
+  const review = {
+    event_id: "review:openclaw/openclaw:710:completion:91:2026-07-11T12:11:00.000Z",
+    target: { repository: "openclaw/openclaw", number: 710 },
+    triggered_at: "2026-07-11T12:08:30.000Z",
+    completed_at: "2026-07-11T12:11:00.000Z",
+  };
+  const next = mergeBayTerminalState(
+    previous,
+    [workerSuccess],
+    [],
+    "2026-07-11T12:11:01.000Z",
+    [],
+    [review],
+    true,
+  );
+
+  assert.equal(next.terminal_count, 2);
+  assert.equal(next.terminal_buffer.at(-1)?.event_id, review.event_id);
+  assert.equal(
+    next.terminal_buffer.filter((item) => item.item_key === "openclaw/openclaw#710").length,
+    1,
+  );
+});
+
+test("OpenClaw Bay replaces a matching failed worker attempt with its lifecycle completion", () => {
+  const workerFailure = {
+    run_id: 13,
+    job_id: 23,
+    repository: "openclaw/openclaw",
+    item_numbers: [711],
+    terminal_outcome: "failure",
+    started_at: "2026-07-11T12:09:00.000Z",
+    completed_at: "2026-07-11T12:10:00.000Z",
+  };
+  const review = {
+    event_id: "review:openclaw/openclaw:711:completion:92:2026-07-11T12:11:00.000Z",
+    target: { repository: "openclaw/openclaw", number: 711 },
+    triggered_at: "2026-07-11T12:08:30.000Z",
+    completed_at: "2026-07-11T12:11:00.000Z",
+    outcome: "failure",
+  };
+  const completed = mergeBayTerminalState(
+    null,
+    [workerFailure],
+    [],
+    "2026-07-11T12:11:01.000Z",
+    [],
+    [review],
+    true,
+  );
+
+  assert.equal(completed.terminal_count, 1);
+  assert.equal(completed.terminal_buffer[0]?.event_id, review.event_id);
+  assert.equal(completed.terminal_buffer[0]?.outcome, "failure");
+});
+
+test("OpenClaw Bay does not duplicate a worker that finishes after its lifecycle completion", () => {
+  const workerSuccess = {
+    run_id: 131,
+    job_id: 231,
+    repository: "openclaw/openclaw",
+    item_numbers: [7111],
+    terminal_outcome: "success",
+    started_at: "2026-07-11T12:09:00.000Z",
+    completed_at: "2026-07-11T12:12:00.000Z",
+  };
+  const review = {
+    event_id: "review:openclaw/openclaw:7111:completion:921:2026-07-11T12:10:00.000Z",
+    target: { repository: "openclaw/openclaw", number: 7111 },
+    triggered_at: "2026-07-11T12:08:30.000Z",
+    completed_at: "2026-07-11T12:10:00.000Z",
+  };
+
+  const completed = mergeBayTerminalState(
+    null,
+    [workerSuccess],
+    [],
+    "2026-07-11T12:12:01.000Z",
+    [],
+    [review],
+    true,
+  );
+
+  assert.equal(completed.terminal_count, 1);
+  assert.equal(completed.terminal_buffer[0]?.event_id, review.event_id);
+});
+
+test("OpenClaw Bay suppresses a failed worker attempt while its retry is active", () => {
+  const workerFailure = {
+    run_id: 132,
+    job_id: 232,
+    repository: "openclaw/openclaw",
+    item_numbers: [7112],
+    terminal_outcome: "failure",
+    completed_at: "2026-07-11T12:12:00.000Z",
+  };
+
+  const active = mergeBayTerminalState(null, [workerFailure], [], "2026-07-11T12:12:01.000Z", [
+    "openclaw/openclaw#7112",
+  ]);
+
+  assert.equal(active.terminal_count, 0);
+});
+
+test("OpenClaw Bay retains observed active keys during a partial census", () => {
+  const workerFailure = {
+    run_id: 133,
+    job_id: 233,
+    repository: "openclaw/openclaw",
+    item_numbers: [7113],
+    terminal_outcome: "failure",
+    completed_at: "2026-07-11T12:13:00.000Z",
+  };
+
+  const partial = mergeBayTerminalState(
+    { schema_version: 1, active_item_keys: ["openclaw/openclaw#7110"] },
+    [workerFailure],
+    [],
+    "2026-07-11T12:13:01.000Z",
+    ["openclaw/openclaw#7113"],
+    [],
+    false,
+    false,
+  );
+
+  assert.equal(partial.terminal_count, 0);
+  assert.deepEqual(partial.active_item_keys.sort(), [
+    "openclaw/openclaw#7110",
+    "openclaw/openclaw#7113",
+  ]);
+});
+
+test("OpenClaw Bay keeps unmatched worker successes during lifecycle promotion", () => {
+  const workerSuccess = {
+    run_id: 14,
+    job_id: 24,
+    repository: "openclaw/openclaw",
+    item_numbers: [712],
+    terminal_outcome: "success",
+    completed_at: "2026-07-11T12:12:00.000Z",
+  };
+  const fallback = mergeBayTerminalState(null, [workerSuccess], [], "2026-07-11T12:12:01.000Z");
+  const promoted = mergeBayTerminalState(
+    fallback,
+    [],
+    [],
+    "2026-07-11T12:13:01.000Z",
+    [],
+    [
+      {
+        event_id: "review:openclaw/openclaw:713:completion:93:2026-07-11T12:13:00.000Z",
+        target: { repository: "openclaw/openclaw", number: 713 },
+        triggered_at: "2026-07-11T12:12:30.000Z",
+        completed_at: "2026-07-11T12:13:00.000Z",
+      },
+    ],
+    true,
+  );
+
+  assert.deepEqual(promoted.terminal_buffer.map((item) => item.item_key).sort(), [
+    "openclaw/openclaw#712",
+    "openclaw/openclaw#713",
+  ]);
+});
+
+test("OpenClaw Bay replaces an active pending fallback when its completion arrives", () => {
+  const workerSuccess = {
+    run_id: 15,
+    job_id: 25,
+    repository: "openclaw/openclaw",
+    item_numbers: [714],
+    terminal_outcome: "success",
+    completed_at: "2026-07-11T12:14:00.000Z",
+  };
+  const pending = mergeBayTerminalState(null, [workerSuccess], [], "2026-07-11T12:14:01.000Z", [
+    "openclaw/openclaw#714",
+  ]);
+  const review = {
+    event_id: "review:openclaw/openclaw:714:completion:94:2026-07-11T12:15:00.000Z",
+    target: { repository: "openclaw/openclaw", number: 714 },
+    triggered_at: "2026-07-11T12:13:00.000Z",
+    completed_at: "2026-07-11T12:15:00.000Z",
+  };
+  const completed = mergeBayTerminalState(
+    pending,
+    [],
+    [],
+    "2026-07-11T12:15:01.000Z",
+    ["openclaw/openclaw#714"],
+    [review],
+    true,
+  );
+  const inactive = mergeBayTerminalState(
+    completed,
+    [],
+    [],
+    "2026-07-11T12:15:02.000Z",
+    [],
+    [],
+    true,
+  );
+
+  assert.equal(completed.pending_fallback_successes.length, 0);
+  assert.equal(inactive.terminal_count, 1);
+  assert.equal(inactive.terminal_buffer[0]?.event_id, review.event_id);
+});
+
+test("OpenClaw Bay does not match a prior revision's fallback to a later review", () => {
+  const prior = {
+    schema_version: 1,
+    terminal_window_started_at: "2026-07-11T11:00:00.000Z",
+    terminal_window_event_ids: [],
+    terminal_buffer: [],
+    seen_events: [
+      {
+        event_id: "worker:13:23:openclaw/openclaw#711:success:2026-07-11T11:30:00.000Z",
+        seen_at: "2026-07-11T11:30:00.000Z",
+      },
+    ],
+  };
+  const review = {
+    event_id: "review:openclaw/openclaw:711:completion:92:2026-07-11T12:31:00.000Z",
+    target: { repository: "openclaw/openclaw", number: 711 },
+    triggered_at: "2026-07-11T12:00:00.000Z",
+    completed_at: "2026-07-11T12:31:00.000Z",
+  };
+  const state = mergeBayTerminalState(
+    prior,
+    [],
+    [],
+    "2026-07-11T12:31:01.000Z",
+    [],
+    [review],
+    true,
+  );
+
+  assert.equal(state.terminal_count, 1);
+  assert.equal(state.terminal_buffer[0]?.event_id, review.event_id);
+});
+
 test("OpenClaw Bay averages completed trigger-to-summary journeys from the last hour", () => {
   const generatedAt = "2026-07-11T12:00:00.000Z";
   const journeys = mergeBayJourneyState(
@@ -5310,6 +5959,7 @@ test("hosted webhook records an edited review command through its final command 
       triggered_at: at(),
       completed_at: at(4_820_000),
       completion_kind: "final_command_status",
+      completion_outcome: "failure",
       completion_comment_id: 790,
     },
   ]);

--- a/test/dashboard-worker-bay-records-routes.test.ts
+++ b/test/dashboard-worker-bay-records-routes.test.ts
@@ -5969,4 +5969,21 @@ test("hosted webhook records an edited review command through its final command 
     median_ms: 4_820_000,
     samples: 1,
   });
+
+  const originalCaches = globalThis.caches;
+  Object.assign(globalThis, {
+    caches: { default: { match: async () => undefined, put: async () => undefined } },
+  });
+  try {
+    const status = await worker.fetch(
+      new Request("https://clawsweeper.openclaw.ai/api/status"),
+      env,
+    );
+    assert.equal(status.status, 200);
+    const snapshot = await status.json();
+    assert.equal(snapshot.bay.terminal_count, 1);
+    assert.deepEqual(snapshot.bay.terminal_buffer, [{ outcome: "failure" }]);
+  } finally {
+    Object.assign(globalThis, { caches: originalCaches });
+  }
 });

--- a/test/dashboard-worker-harness.ts
+++ b/test/dashboard-worker-harness.ts
@@ -12,6 +12,7 @@ import { gunzipSync } from "node:zlib";
 import worker, {
   automaticIssueWork,
   ExactReviewQueue,
+  completedBayReviews,
   exactReviewEffectiveLeaseExpiresAt,
   exactReviewJitteredDelayMs,
   exactReviewPublicationCapacity,
@@ -1022,6 +1023,7 @@ export {
   worker,
   automaticIssueWork,
   ExactReviewQueue,
+  completedBayReviews,
   exactReviewEffectiveLeaseExpiresAt,
   exactReviewJitteredDelayMs,
   exactReviewPublicationCapacity,


### PR DESCRIPTION
## Summary

Count completed exact-review lifecycle journeys in OpenClaw Bay so the dashboard is not limited to the bounded worker-run sample.

## Problem

Bay could undercount reviews that completed outside the recent worker-run sample, obscuring terminal-review throughput and delaying tide transitions.

## Implementation

- Persist signed terminal command acknowledgements as bounded Bay journey telemetry, including `success` and terminal `failure` outcomes.
- Merge completed lifecycle journeys with worker fallbacks without replaying old entries, duplicating late worker completions, or counting active retries.
- Keep an older re-review worker completion distinct from the next review revision by matching fallbacks only when their recorded start falls inside that review's lifecycle window.
- Preserve tide-window boundaries, delivery fencing, legacy-telemetry safety, and partial active-census observations.
- Pass the final workflow status into the signed lifecycle callback.

## Real Behavior Proof

Claim: a signed terminal lifecycle receipt is accepted by the Worker and projects exactly one redacted terminal outcome through `/api/status`; lifecycle and worker records remain distinct across overlapping re-review revisions.

- Surface: signed terminal-receipt webhook handling, durable status storage, lifecycle normalization, Bay terminal reconciliation, and public `/api/status` projection.
- Fixture/scenarios: a valid signed failure receipt is posted to the Worker, then `/api/status` is fetched from that Worker runtime; the suite also covers fallbacks, delayed completions, same-second delivery fences, legacy records without an outcome, cancellations, active retries, partial active-job censuses, and an earlier overlapping re-review completion.
- Command/environment: Docker-backed Crabbox local-container at rebased current head `81baafd4d5c33da9a2f85a9a788644df232a3b59` (base `e869bde55a75e87d8158e8cb59c0f2de2d59f37b`, including #1211): `crabbox run --provider local-container --local-container-image mcr.microsoft.com/playwright:v1.60.0-noble --no-hydrate --timing-json --script csw-133-final-head-runtime-proof.sh`. The script runs a frozen install, `pnpm run build:all`, then `node --test --test-name-pattern="hosted webhook records" test/dashboard-worker-bay-records-routes.test.ts`.
- Observed result: 1 passed, 0 failed; `hosted webhook records an edited review command through its final command update without GitHub reads` passed in 52ms. The status projection returned `terminal_count: 1` and `terminal_buffer: [{ outcome: "failure" }]` after the signed receipt.
- Artifact/trace: Crabbox run `run_b48c37eb450c`, lease `cbx_83d5cacdc4d6` (`swift-hermit-7fe8`), recorded `provider=local-container`, `machineType=mcr.microsoft.com/playwright:v1.60.0-noble`, `commandMs=11806`, `exitCode=0`; the redacted terminal trace is included here. Its only runtime diagnostics were four expected `github_read_model_ingest_failed` queue-unavailable fallbacks, followed by `github_read_model_degraded` with `fallback=live_poll`; the focused test passed.
- Limits: controlled in-memory Worker runtime with a signed input and real Worker route calls; outbound GitHub fetches are deliberately failed so unrelated live dashboard data cannot enter this single-outcome trace. The container run neither mutates GitHub nor deploys a Worker.

## Validation

- `node --test --test-name-pattern="hosted webhook records" test/dashboard-worker-bay-records-routes.test.ts` — 1 passed, 0 failed; signed receipt to `/api/status` runtime trace observed `terminal_count: 1` and redacted failure outcome.
- Docker-backed Crabbox current-head proof — provider `local-container`, image `mcr.microsoft.com/playwright:v1.60.0-noble`, lease `cbx_83d5cacdc4d6`, run `run_b48c37eb450c`: frozen install, `pnpm run build:all`, and the signed-receipt `/api/status` scenario all passed (1 passed, 0 failed; exit 0).
- `node --test test/dashboard-worker-bay-records-routes.test.ts` — 65 passed, 0 failed.
- Changed-file formatter proof: byte-for-byte `oxfmt --stdin-filepath` checks against both `origin/main` and the rebased head for every changed file passed. The Windows file-mode `oxfmt --check` falsely reported those same formatted files, so it is recorded as a host tool defect rather than a code-format change.
- `git diff --check origin/main...HEAD` — passed.
- Clean AWS Crabbox Linux workflow proof: `corepack enable && pnpm install --frozen-lockfile && pnpm run build:all && node --test test/sweep-workflow.test.ts` — 121 passed, 0 failed; provider `aws`, lease `cbx_432b90828da4`, run `run_7591f2760772`.
- Codex dirty-patch review: accepted and fixed four findings, including overlapping re-review fallback attribution; final review was clean.
- Codex committed-range review against `origin/main`: clean.
- Local ClawSweeper committed-range review: `pnpm run review -- --local-range --target-repo openclaw/clawsweeper --base origin/main` completed with `decision=keep_open`, `confidence=high`, `action=kept_open`; no GitHub mutation was performed.
- Hosted current-head CI: pending the rebased-head push; all substantive checks passed on the immediately preceding, semantically identical head.

The repository-wide `pnpm run format:check` remains host baseline noise (740 untouched files). The local Windows workflow suite is blocked by CRLF conversion in untouched Bash helpers. An AWS Crabbox Linux run on the earlier head (`run_6e1521eaa6bb`, lease `cbx_9b4d699fbc90`) exposed that live GitHub data could enter the runtime trace; this final commit isolates that egress. Docker Desktop's Linux engine was then recovered and the required rebased-head local-container proof above passed.

## Review closeout

Codex reviewed the dirty patch repeatedly. Accepted findings covered lifecycle/fallback double counts, active-retry suppression, partial active-census retention, and overlapping re-review attribution; each was fixed with a regression test and rerun focused proof. The rebased worktree was clean (no dirty patch remained to assess), and the exact committed-range review against current `origin/main` found no actionable correctness issue.

Final reviewed head: `81baafd4d5c33da9a2f85a9a788644df232a3b59` rebased onto `e869bde55a75e87d8158e8cb59c0f2de2d59f37b` (including #1211).

## Risk and rollout

This changes dashboard telemetry and the signed workflow receipt payload only; it does not change credentials, permissions, or deployment configuration. Existing legacy lifecycle records without an explicit terminal outcome are intentionally excluded rather than assumed successful.

## Attribution

This continues the original Roboclaw Teams investigation and preserves Martin Cleary (@brokemac79) as the commit author. The recovery work was reconstructed from the unpushed Roboclaw task state; no contributor work was discarded.
