### PR TITLE
fix(security): keep containment fixture data out of code

### DIFF
--- a/test/repair/command-runner.test.ts
+++ b/test/repair/command-runner.test.ts
@@ -17,6 +17,20 @@ import { resolveSpawnCommand } from "../../dist/command.js";
 import { runCommand, runContainedCommand } from "../../dist/repair/command-runner.js";
 import { mockCommandBinEnv } from "../helpers.ts";
 
+const WRITE_MARKER_AFTER_DELAY_SCRIPT = [
+  'const fs = require("node:fs");',
+  "const [marker, delay] = process.argv.slice(1);",
+  'setTimeout(() => fs.writeFileSync(marker, "escaped"), Number(delay));',
+].join(" ");
+
+const SPAWN_DETACHED_MARKER_SCRIPT = [
+  'const { spawn } = require("node:child_process");',
+  `const child = spawn(process.execPath, ["-e", ${JSON.stringify(WRITE_MARKER_AFTER_DELAY_SCRIPT)}, process.argv[1], "1000"], { detached: true, stdio: "ignore" });`,
+  "child.unref();",
+  'process.kill(process.ppid, "SIGKILL");',
+  "setInterval(() => {}, 1000);",
+].join(" ");
+
 test("runCommand handles validation output larger than Node's sync spawn default", () => {
   const output = runCommand(process.execPath, [
     "-e",
@@ -67,9 +81,11 @@ test(
                 'const fs = require("node:fs");',
                 'process.on("SIGTERM", () => {});',
                 'process.stdout.write("x".repeat(128 * 1024));',
-                `setTimeout(() => fs.writeFileSync(${JSON.stringify(marker)}, "escaped"), 750);`,
+                "const marker = process.argv[1];",
+                'setTimeout(() => fs.writeFileSync(marker, "escaped"), 750);',
                 "setInterval(() => {}, 1000);",
               ].join(" "),
+              marker,
             ],
             { maxBuffer: 1024, timeoutMs: 3_000 },
           ),
@@ -198,28 +214,15 @@ test(
     try {
       assert.throws(
         () =>
-          runContainedCommand(
-            process.execPath,
-            [
-              "-e",
-              [
-                'const { spawn } = require("node:child_process");',
-                `const child = spawn(process.execPath, ["-e", ${JSON.stringify(`setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(marker)}, "escaped"), 1000);`)}], { detached: true, stdio: "ignore" });`,
-                "child.unref();",
-                'process.kill(process.ppid, "SIGKILL");',
-                "setInterval(() => {}, 1000);",
-              ].join(" "),
-            ],
-            {
-              cwd: root,
-              env: {
-                ...process.env,
-                CLAWSWEEPER_TEST_FORCE_LINUX_CONTAINMENT: "1",
-              },
-              timeoutMs: 250,
-              writableRoots: [root],
+          runContainedCommand(process.execPath, ["-e", SPAWN_DETACHED_MARKER_SCRIPT, marker], {
+            cwd: root,
+            env: {
+              ...process.env,
+              CLAWSWEEPER_TEST_FORCE_LINUX_CONTAINMENT: "1",
             },
-          ),
+            timeoutMs: 250,
+            writableRoots: [root],
+          }),
         /command timed out after 250ms/,
       );
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1_250);

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -45,6 +45,20 @@ import {
 import { mockCommandBinEnv } from "../helpers.ts";
 
 const FAKE_TOOLCHAIN_TIMEOUT_MS = 15_000;
+const WRITE_NODE_MODULES_MARKER_AFTER_DELAY_SCRIPT = [
+  'const fs = require("node:fs");',
+  'const path = require("node:path");',
+  'const marker = path.join(process.cwd(), "node_modules", process.argv[1]);',
+  "setTimeout(() => {",
+  "  fs.mkdirSync(path.dirname(marker), { recursive: true });",
+  '  fs.writeFileSync(marker, "ran");',
+  "}, 750);",
+].join(" ");
+const SPAWN_DETACHED_NODE_MODULES_MARKER_SCRIPT = [
+  'const { spawn } = require("node:child_process");',
+  `const child = spawn(process.execPath, ["-e", ${JSON.stringify(WRITE_NODE_MODULES_MARKER_AFTER_DELAY_SCRIPT)}, process.argv[1]], { detached: true, stdio: "ignore" });`,
+  "child.unref();",
+].join(" ");
 
 test("OpenClaw repairs require changed-surface validation even when omitted", () => {
   const cwd = packageFixture({ "check:changed": "node check.js" });
@@ -3425,7 +3439,8 @@ test(
       return;
     }
     const cwd = gitBunPackageFixture({ check: 'node -e ""' });
-    const marker = path.join(cwd, "node_modules", "detached-bun-ran");
+    const markerName = "detached-bun-ran";
+    const marker = path.join(cwd, "node_modules", markerName);
     git(cwd, "add", ".");
     git(cwd, "commit", "-m", "initial");
     attachOrigin(cwd);
@@ -3439,8 +3454,8 @@ if (process.argv[2] === "--version") {
 } else if (process.argv[2] === "install") {
   const { spawn } = require("node:child_process");
   const child = spawn(process.execPath, ["-e", ${JSON.stringify(
-    `setTimeout(() => { require("node:fs").mkdirSync(${JSON.stringify(path.dirname(marker))}, { recursive: true }); require("node:fs").writeFileSync(${JSON.stringify(marker)}, "ran"); }, 750);`,
-  )}], { detached: true, stdio: "ignore" });
+    WRITE_NODE_MODULES_MARKER_AFTER_DELAY_SCRIPT,
+  )}, ${JSON.stringify(markerName)}], { detached: true, stdio: "ignore" });
   child.unref();
 }
 `,
@@ -3478,7 +3493,8 @@ test(
       return;
     }
     const cwd = gitPackageFixture({ check: 'node -e ""' });
-    const marker = path.join(cwd, "node_modules", "detached-npm-ran");
+    const markerName = "detached-npm-ran";
+    const marker = path.join(cwd, "node_modules", markerName);
     git(cwd, "add", ".");
     git(cwd, "commit", "-m", "initial");
     attachOrigin(cwd);
@@ -3489,8 +3505,8 @@ test(
       `#!/usr/bin/env node
 const { spawn } = require("node:child_process");
 const child = spawn(process.execPath, ["-e", ${JSON.stringify(
-        `setTimeout(() => { require("node:fs").mkdirSync(${JSON.stringify(path.dirname(marker))}, { recursive: true }); require("node:fs").writeFileSync(${JSON.stringify(marker)}, "ran"); }, 750);`,
-      )}], { detached: true, stdio: "ignore" });
+        WRITE_NODE_MODULES_MARKER_AFTER_DELAY_SCRIPT,
+      )}, ${JSON.stringify(markerName)}], { detached: true, stdio: "ignore" });
 child.unref();
 `,
     );
@@ -8189,24 +8205,20 @@ test(
       context.skip("runner does not provide delegated user namespaces and Landlock ABI 3+");
       return;
     }
-    const marker = path.join(
-      os.tmpdir(),
-      `clawsweeper-detached-validation-${process.pid}-${Date.now()}`,
-    );
     const cwd = gitPackageFixture({ verify: "node verify.js" });
+    const markerName = "detached-validation-ran";
+    const marker = path.join(cwd, "node_modules", markerName);
     git(cwd, "add", ".");
     git(cwd, "commit", "-m", "initial");
     attachOrigin(cwd);
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawsweeper-detached-pnpm-"));
     const pnpmPath = path.join(binDir, "pnpm.js");
-    const grandchild = `setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(marker)}, "escaped"), 800)`;
-    const intermediate = `const { spawn } = require("node:child_process"); const child = spawn(process.execPath, ["-e", ${JSON.stringify(
-      grandchild,
-    )}], { detached: true, stdio: "ignore" }); child.unref();`;
     fs.writeFileSync(
       pnpmPath,
       `const { spawn } = require("node:child_process");
-const child = spawn(process.execPath, ["-e", ${JSON.stringify(intermediate)}], {
+const child = spawn(process.execPath, ["-e", ${JSON.stringify(
+        SPAWN_DETACHED_NODE_MODULES_MARKER_SCRIPT,
+      )}, ${JSON.stringify(markerName)}], {
   detached: true,
   stdio: "ignore"
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves seven CodeQL alerts where Linux containment tests constructed executable JavaScript from fixture-specific marker paths. The tests were behaviorally safe, but the dynamic source shape obscured the code/data boundary and made the security contract harder to audit.

## Why This Change Was Made

The fixture programs are now static constants. Marker paths and marker names cross the process boundary only through `argv` or `cwd`, preserving the exact containment, timeout, detached-process, and cleanup scenarios without constructing code from runtime values.

## User Impact

No product behavior changes. Maintainers get clearer containment fixtures and CodeQL can verify that fixture data is not executable source.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes only test fixture construction; no dashboard, lifecycle, review-publication, queue, telemetry, or data contract changes.

## Documentation Impact

No documentation changes are needed. The containment behavior and operator contract remain unchanged.

## Real Behavior Proof

Claim: static fixture scripts still exercise the same marker creation and detached-process cleanup paths while keeping marker data outside executable source.

- Surface: `command-runner` overflow cleanup, Linux namespace-init containment, Bun/npm detached dependency setup, and immediate detached double-fork validation fixtures.
- Fixture/scenarios: marker paths and names are passed through `argv` or derived from `cwd`; the child scripts write the same marker values and preserve the same exit, timeout, and detached-process behavior.
- Command/environment: clean AWS Crabbox Linux run at head `26015f73ad1d7df857ca4cedabdb64e0d00aaceb`, using `build:node` followed by the focused Node test-name patterns.
- Observed result: the portable overflow cleanup case passed; four Linux kernel-capability cases were skipped because the runner did not expose delegated namespaces/Landlock. The run exited 0.
- Artifact/trace: AWS Crabbox run `run_2f08389683a6`, lease `cbx_547ab78f476f` (`harbor-shrimp-f8fd`), `c7a.8xlarge`, exit 0.
- Limits: the AWS runner lacked the delegated namespace/Landlock capabilities required by four existing tests. CodeQL CI is the authoritative proof that alerts 79-85 no longer reproduce.

## Evidence

- TypeScript compilation for the root and repair configurations passed.
- Focused local test: 1 passed, 4 capability-dependent skips.
- Focused AWS Crabbox Linux proof: 1 passed, 4 capability-dependent skips, exit 0.
- Changed-file lint, formatting, and `git diff --check` passed.
- Codex dirty-patch review: clean.
- Codex committed-range review against `origin/main`: clean.
- Signed commit: `26015f73ad1d7df857ca4cedabdb64e0d00aaceb`.

## Risk and Rollout

Test-only change. There is no production rollout or compatibility surface. Merge is gated on exact-head ClawSweeper review, hosted CI, and CodeQL closure for alerts 79-85.
