### PR TITLE
fix(security): stop exposing Worker rejection internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Replaced public Worker exception text with endpoint-owned error codes and bounded direct-publication rejection categories, preserving distinct operational fingerprints without exposing submitted values or stack traces.
 - Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.
 - Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.
 - Routed every durable review-record publication lane through one shared, host-authenticated live-proof dispatcher, including queued exact-review batches grouped per target repository.

--- a/dashboard/exact-review-direct-publication.ts
+++ b/dashboard/exact-review-direct-publication.ts
@@ -1696,6 +1696,80 @@ export async function validateDirectPublicationPlan(
   };
 }
 
+export function directPublicationRejectionDetail(error: unknown): string {
+  const message = error instanceof Error ? error.message : "";
+  switch (message) {
+    case "invalid direct publication canonical target key":
+      return "invalid direct publication canonical target key";
+    case "invalid direct publication fence key":
+      return "invalid direct publication fence key";
+    case "invalid direct publication source SHA":
+      return "invalid direct publication source SHA";
+    case "invalid direct publication revision":
+      return "invalid direct publication revision";
+    case "invalid direct publication lifecycle plan":
+      return "invalid direct publication lifecycle plan";
+    case "invalid direct publication identity":
+      return "invalid direct publication identity";
+    case "a direct publication plan must change a path":
+      return "a direct publication plan must change a path";
+    case "a direct publication plan exceeds the exact-review tuple file limit":
+      return "a direct publication plan exceeds the exact-review tuple file limit";
+    case "direct publication total does not match its operations":
+      return "direct publication total does not match its operations";
+    case "direct publication plan exceeds the per-POST byte limit":
+      return "direct publication plan exceeds the per-POST byte limit";
+    case "conflicting direct publication retry":
+      return "conflicting direct publication retry";
+    case "direct publication source run identity is unavailable":
+      return "direct publication source run identity is unavailable";
+    case "direct publication source SHA is unavailable":
+      return "direct publication source SHA is unavailable";
+  }
+  if (message.startsWith("invalid bounded state mutation path:")) {
+    return "invalid bounded state mutation path";
+  }
+  if (message.startsWith("invalid or repeated direct publication path:")) {
+    return "invalid or repeated direct publication path";
+  }
+  if (message.startsWith("direct publication path is outside ")) {
+    return "direct publication path is outside its target tuple";
+  }
+  if (message.startsWith("invalid mutation mode for ")) return "invalid mutation mode";
+  if (message.startsWith("invalid mutation byte count for ")) return "invalid mutation byte count";
+  if (message.startsWith("deleted mutation paths must not carry content:")) {
+    return "deleted mutation paths must not carry content";
+  }
+  if (message.startsWith("missing or invalid mutation content for ")) {
+    return "missing or invalid mutation content";
+  }
+  if (message.startsWith("mutation byte count does not match content for ")) {
+    return "mutation byte count does not match content";
+  }
+  if (message.startsWith("canonical record content is not UTF-8:")) {
+    return "canonical record content is not UTF-8";
+  }
+  if (message.startsWith("canonical tuple has invalid primary/sidecar structure:")) {
+    return "canonical tuple has invalid primary/sidecar structure";
+  }
+  if (message.startsWith("canonical closed tuple retains a work plan:")) {
+    return "canonical closed tuple retains a work plan";
+  }
+  if (message.startsWith("canonical tuple references a missing decision packet:")) {
+    return "canonical tuple references a missing decision packet";
+  }
+  if (message.startsWith("canonical tuple decision packet reference is inconsistent:")) {
+    return "canonical tuple decision packet reference is inconsistent";
+  }
+  if (message.startsWith("direct publication tuple writes both primary sections:")) {
+    return "direct publication tuple writes both primary sections";
+  }
+  if (message.startsWith("canonical record tuple exceeds its file limit:")) {
+    return "canonical record tuple exceeds its file limit";
+  }
+  return "direct publication request failed";
+}
+
 function storedOperationsFrom(
   operations: readonly CanonicalDirectPublicationOperation[],
 ): DirectPublicationStoredOperation[] {

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -27,6 +27,7 @@ import {
   EXACT_REVIEW_DIRECT_PUBLICATION_MAX_POST_BYTES,
   REVIEW_COVERAGE_INVENTORY_KEY,
   ExactReviewDirectPublicationStore,
+  directPublicationRejectionDetail,
   normalizeReviewCoverageInventory,
   sha256Hex,
   validateCanonicalRecordTupleMutation,
@@ -3044,7 +3045,7 @@ export class ExactReviewQueue {
           202,
         );
       } catch (error) {
-        const detail = sanitizedServerError(error);
+        const detail = directPublicationRejectionDetail(error);
         console.warn("direct_publication_plan_rejected");
         return json(
           {
@@ -3185,8 +3186,8 @@ export class ExactReviewQueue {
           this.githubWebhookReadModelStore.ingest(await request.json().catch(() => null)),
           202,
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_delivery" }, 400);
       }
     }
 
@@ -3256,8 +3257,8 @@ export class ExactReviewQueue {
           this.githubWebhookReadModelStore.repair(await request.json().catch(() => null)),
           202,
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_repair" }, 400);
       }
     }
 
@@ -3266,8 +3267,8 @@ export class ExactReviewQueue {
         return json(
           await this.githubWebhookReadModelStore.readItem(await request.json().catch(() => null)),
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_item_request" }, 400);
       }
     }
 
@@ -3278,8 +3279,8 @@ export class ExactReviewQueue {
             await request.json().catch(() => null),
           ),
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_comments_request" }, 400);
       }
     }
 
@@ -3290,8 +3291,8 @@ export class ExactReviewQueue {
             await request.json().catch(() => null),
           ),
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_activity_request" }, 400);
       }
     }
 
@@ -3302,8 +3303,8 @@ export class ExactReviewQueue {
             await request.json().catch(() => null),
           ),
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_workflows_request" }, 400);
       }
     }
 
@@ -3314,8 +3315,8 @@ export class ExactReviewQueue {
             await request.json().catch(() => null),
           ),
         );
-      } catch (error) {
-        return json({ error: sanitizedServerError(error) }, 400);
+      } catch {
+        return json({ error: "invalid_github_webhook_read_model_placeholders_request" }, 400);
       }
     }
 

--- a/docs/proof/direct-publication-reject-detail/README.md
+++ b/docs/proof/direct-publication-reject-detail/README.md
@@ -11,8 +11,9 @@ The behavior contract is:
   `error: "invalid_direct_publication_plan"`, `fallback_required: true`, and a non-empty `detail`
   naming the invalid revision;
 - a structurally different plan whose operation targets the wrong item returns the same unchanged
-  error classification with a non-empty path-specific `detail`;
-- the two validation failures produce different detail values.
+  error classification with a bounded `detail` that names the violated tuple invariant without
+  echoing the submitted path;
+- the two validation failures produce different bounded detail values.
 
 The script boots the Worker, drives `/api/exact-review-queue`, terminates the full Wrangler process
 tree, and inspects Wrangler's persisted SQLite database for the direct-publication table. Only that
@@ -32,5 +33,5 @@ transcript, build/install logs, and a redacted Wrangler log.
 
 This proof does not change or test retry/permanence policy, does not identify or fix the underlying
 CodexBar rejection, and does not deploy or mutate production. OpenClaw Bay is unaffected: the
-change enriches an internal publication rejection and its downstream diagnostic fingerprint, with
-no Bay observer data or control surface change.
+change keeps internal publication rejection fingerprints distinct without exposing submitted
+values, with no Bay observer data or control surface change.

--- a/docs/proof/direct-publication-reject-detail/run-proof.sh
+++ b/docs/proof/direct-publication-reject-detail/run-proof.sh
@@ -197,13 +197,13 @@ REVISION_STATUS="$revision_status" PATH_STATUS="$path_status" node -e '
     assert.ok(body.detail.length > 0);
   }
   assert.match(revision.detail, /invalid direct publication revision/);
-  assert.match(outsidePath.detail, /direct publication path is outside steipete-CodexBar#2797/);
+  assert.equal(outsidePath.detail, "direct publication path is outside its target tuple");
   assert.notEqual(revision.detail, outsidePath.detail);
   const lines = [
     "Durable Object initialized: exact_review_direct_publication_plans table present",
     "invalid revision: HTTP " + process.env.REVISION_STATUS + "; error=" + revision.error + "; fallback_required=" + revision.fallback_required + "; detail=" + revision.detail,
     "outside path: HTTP " + process.env.PATH_STATUS + "; error=" + outsidePath.error + "; fallback_required=" + outsidePath.fallback_required + "; detail=" + outsidePath.detail,
-    "distinct validation details: true",
+    "distinct bounded validation details: true",
   ];
   fs.writeFileSync(process.argv[3], lines.join("\n") + "\n");
 ' \

--- a/docs/proof/mixed-case-publication-slugs/README.md
+++ b/docs/proof/mixed-case-publication-slugs/README.md
@@ -11,8 +11,8 @@ The behavior contract is:
   `records/steipete-CodexBar/...` path returns HTTP 202 with an accepted or deduped receipt;
 - the real Worker export surface serves that record only from `steipete-codexbar`, and the
   persisted Durable Object SQLite contains no `steipete-CodexBar` canonical or export row;
-- a signed plan whose operation names `steipete-other` returns the detailed HTTP 400
-  `invalid_direct_publication_plan` response;
+- a signed plan whose operation names `steipete-other` returns the HTTP 400
+  `invalid_direct_publication_plan` response with a bounded tuple-invariant detail;
 - a signed all-lowercase `openclaw/openclaw` plan still returns HTTP 202 with an accepted or
   deduped receipt.
 

--- a/docs/proof/mixed-case-publication-slugs/run-proof.sh
+++ b/docs/proof/mixed-case-publication-slugs/run-proof.sh
@@ -245,10 +245,7 @@ MIXED_STATUS="$mixed_status" DIFFERENT_STATUS="$different_status" LOWERCASE_STAT
     assert.deepEqual(uppercaseExport.records, []);
     assert.equal(different.error, "invalid_direct_publication_plan");
     assert.equal(different.fallback_required, true);
-    assert.match(
-      different.detail,
-      /direct publication path is outside steipete-CodexBar#2517: records\/steipete-other\/items\/2517\.md/,
-    );
+    assert.equal(different.detail, "direct publication path is outside its target tuple");
     const lines = [
       "Durable Object initialized: exact_review_direct_publication_plans table present",
       "mixed-case repository with uppercase path: HTTP " + process.env.MIXED_STATUS + "; accepted=" + mixed.accepted + "; deduped=" + mixed.deduped + "; canonical_target_key=" + mixed.canonical_target_key,

--- a/test/dashboard-worker-publication-lifecycle.test.ts
+++ b/test/dashboard-worker-publication-lifecycle.test.ts
@@ -181,11 +181,37 @@ test("direct publication endpoint authenticates, dedupes, and returns a structur
     fallback_required: boolean;
     detail: string;
   };
-  assert.equal(invalidPlanResponse.error, "invalid_direct_publication_plan");
-  assert.equal(invalidPlanResponse.fallback_required, true);
-  assert.match(invalidPlanResponse.detail, /^invalid bounded state mutation path: /);
-  assert.match(invalidPlanResponse.detail, /\[REDACTED\]/);
-  assert.doesNotMatch(invalidPlanResponse.detail, /alice|hunter2|ghp_[A-Za-z0-9_]+/);
+  assert.deepEqual(invalidPlanResponse, {
+    error: "invalid_direct_publication_plan",
+    fallback_required: true,
+    detail: "invalid bounded state mutation path",
+  });
+  const dualPrimaryBody = JSON.stringify({
+    ...payload,
+    totalBytes: 2,
+    operations: [
+      payload.operations[0],
+      {
+        ...payload.operations[0],
+        path: "records/openclaw-openclaw/closed/701.md",
+      },
+    ],
+  });
+  const dualPrimarySignature = `sha256=${createHmac("sha256", "test-secret").update(dualPrimaryBody).digest("hex")}`;
+  const dualPrimary = await worker.fetch(
+    new Request(url, {
+      method: "POST",
+      headers: { "x-clawsweeper-exact-review-signature": dualPrimarySignature },
+      body: dualPrimaryBody,
+    }),
+    env,
+  );
+  assert.equal(dualPrimary.status, 400);
+  assert.deepEqual(await dualPrimary.json(), {
+    error: "invalid_direct_publication_plan",
+    fallback_required: true,
+    detail: "direct publication tuple writes both primary sections",
+  });
   for (const expected of [
     { accepted: true, deduped: false },
     { accepted: false, deduped: true },

--- a/test/github-webhook-read-model.test.ts
+++ b/test/github-webhook-read-model.test.ts
@@ -314,6 +314,30 @@ test("signed webhook loopback covers lifecycle, comments, reviews, checks, runs,
   assert.equal(afterDuplicate.watermark, workflows.watermark);
 });
 
+test("read-model failures expose only endpoint-owned error codes", async () => {
+  const queue = new ExactReviewQueue({ storage: new MemoryDurableStorage() }, {});
+  const cases = [
+    ["ingest", "invalid_github_webhook_read_model_delivery"],
+    ["repair", "invalid_github_webhook_read_model_repair"],
+    ["item", "invalid_github_webhook_read_model_item_request"],
+    ["comments", "invalid_github_webhook_read_model_comments_request"],
+    ["activity", "invalid_github_webhook_read_model_activity_request"],
+    ["workflows", "invalid_github_webhook_read_model_workflows_request"],
+    ["placeholders", "invalid_github_webhook_read_model_placeholders_request"],
+  ] as const;
+
+  for (const [operation, error] of cases) {
+    const response = await queue.fetch(
+      new Request(`https://queue/github-read-model/${operation}`, {
+        method: "POST",
+        body: JSON.stringify({ invalid: "private-path-marker" }),
+      }),
+    );
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error });
+  }
+});
+
 test("dashboard workflow snapshot preserves health decisions while removing run and job polls", async () => {
   const storage = new MemoryDurableStorage();
   const store = new GithubWebhookReadModelStore(storage);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where authenticated Worker clients could receive exception-derived rejection text from direct-publication and GitHub read-model endpoints. That text could include stack-derived or request-specific internal details and triggered CodeQL alert 76.

## Why This Change Was Made

Read-model endpoints now return fixed endpoint-owned error codes. Direct publication preserves useful operational fingerprints through an explicit bounded category allowlist, with a generic fallback for unexpected failures. This removes exception text from public responses without collapsing known rejection causes into one opaque error.

## User Impact

Operators keep distinct, stable direct-publication failure fingerprints for supported validation failures. Public Worker responses no longer echo paths, submitted values, stack-derived text, or unexpected exception messages.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. The change is limited to exact-review queue rejection responses and their internal publication client; it does not alter Bay data, controls, lifecycle projection, status telemetry, deployment, or rollback behavior.

## Documentation Impact

The active direct-publication rejection proof and mixed-case publication proof now assert bounded categories instead of path-specific error text. `CHANGELOG.md` records the security hardening. No public API documentation changes are required because these authenticated internal endpoints are not a public compatibility surface.

## Real Behavior Proof

Claim: the real Worker/queue runtime returns distinct bounded direct-publication categories without exposing submitted paths, while valid mixed-case canonical publication behavior remains unchanged.

- Surface: signed direct-publication Worker route, exact-review queue validation, canonical record storage, and response projection.
- Fixture/scenarios: invalid revision, out-of-tuple path, dual-primary tuple, valid uppercase repository path, invalid different-repository path, lowercase publication, and canonical export namespace counts.
- Command/environment: AWS Crabbox Linux run at exact rebased head `3a9cce5146cd2e7e05014e61e96d4e7ca01769da`, executing the direct-publication rejection and mixed-case publication proof scripts against the real Worker/Durable Object runtime.
- Observed result: invalid revision returned HTTP 400 with `invalid direct publication revision`; the submitted outside path returned HTTP 400 with `direct publication path is outside its target tuple`; the categories were distinct and contained no submitted path. Uppercase and lowercase valid publications returned HTTP 202, the different-repository request returned the bounded tuple category, exports selected the correct canonical casing, and SQLite namespace counts matched.
- Artifact/trace: AWS Crabbox run `run_6c65cc68e9bd`, lease `cbx_f4579c811b63` (`silver-lobster-4865`), `c7a.8xlarge`, exit 0, lease stopped.
- Limits: controlled signed requests against the real Worker/queue runtime with ephemeral storage; no production Worker deployment or GitHub mutation.

## Evidence

- 33 focused Worker/read-model tests passed.
- AWS Crabbox direct-publication and mixed-case runtime proofs passed, exit 0.
- Dashboard and repair TypeScript compilation passed.
- Changed-file lint, formatting, and `git diff --check` passed.
- Codex dirty-patch review: clean after preserving distinct failure fingerprints and updating proof contracts.
- Codex committed-range review against `origin/main`: clean.
- Prior exact-head ClawSweeper review's changelog-removal finding was not applied: its cited release-owned rule explicitly covers `openclaw/openclaw` target PRs, while this is an `openclaw/clawsweeper` security change and the repository's own `CHANGELOG.md` tracks notable fixes.
- Signed commit: `3a9cce5146cd2e7e05014e61e96d4e7ca01769da`.

## Risk and Rollout

Production TypeScript delta is `+90/-15`; the positive delta is the explicit security allowlist required to preserve established failure fingerprints without exposing exception text. Tests are `+55/-5`; documentation/proof contracts are `+11/-12`. Merge is gated on exact-head ClawSweeper review, hosted CI, and CodeQL closure for alert 76.
