### PR TITLE
fix(queue): restore scheduled feed capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Restored the public exact-review queue's bounded scheduled-feed capability signal without exposing private rate-limit state.
 - Replaced public Worker exception text with endpoint-owned error codes and bounded direct-publication rejection categories, preserving distinct operational fingerprints without exposing submitted values or stack traces.
 - Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.
 - Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
-- Restored the public exact-review queue's bounded scheduled-feed capability signal without exposing private rate-limit state.
 - Replaced public Worker exception text with endpoint-owned error codes and bounded direct-publication rejection categories, preserving distinct operational fingerprints without exposing submitted values or stack traces.
 - Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.
 - Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.

--- a/dashboard/dashboard-pages.ts
+++ b/dashboard/dashboard-pages.ts
@@ -1945,7 +1945,7 @@ const STATUS_CONTAINER_FIELDS = new Set([
   "comment_sync", "automerge", "automerge_reliability", "closed_items", "closed_stats",
   "operation_counts", "events", "reasons", "cursor", "exact_review_queue",
   "recent_durable_publication_events", "collection", "review", "publication", "handoff_health",
-  "phases", "pending", "dispatching", "leased", "pressure", "bay_projection", "activity", "queue_stages", "live_stages", "stages",
+  "phases", "pending", "dispatching", "leased", "pressure", "scheduled_feed", "bay_projection", "activity", "queue_stages", "live_stages", "stages",
   "active_stages", "window", "direct", "batch", "counts", "buckets", "provenance",
   "backoff_reasons", "parked_reasons", "recovery_reasons", "errors"
 ]);
@@ -2005,7 +2005,7 @@ const STATUS_NUMBER_FIELDS = new Set([
   "failure_rate_percent", "generated_count", "longest_duration_ms", "maximum_age_ms", "median_ms",
   "oldest_age_seconds", "oldest_dispatching_age_seconds", "oldest_leased_age_seconds",
   "oldest_pending_age_seconds", "omitted_count", "ready_pending", "admissible_pending",
-  "scheduled_interval_minutes", "terminal_count", "total_count", "total_duration_ms", "ttl_seconds",
+  "scheduled_interval_minutes", "target_rate_per_hour", "terminal_count", "total_count", "total_duration_ms", "ttl_seconds",
   "setting-up", "ready", "backoff", "parked", "oldest_ready_age_seconds",
   "oldest_backoff_age_seconds", "oldest_lease_age_seconds", "enqueued_total", "completed_total",
   "published_total", "superseded_total", "semantic_deduped_total", "retried_total",

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -1688,6 +1688,7 @@ const PUBLIC_STATUS_COUNT_FIELDS = new Set([
   "ready_pending",
   "admissible_pending",
   "scheduled_interval_minutes",
+  "target_rate_per_hour",
   "terminal_count",
   "total_count",
   "total_duration_ms",
@@ -1803,6 +1804,7 @@ const PUBLIC_STATUS_CONTAINER_FIELDS = new Set([
   "dispatching",
   "leased",
   "pressure",
+  "scheduled_feed",
   "bay_projection",
   "activity",
   "queue_stages",
@@ -4398,6 +4400,7 @@ async function exactReviewQueueRequest(env, path, request?: Request) {
 }
 
 const PUBLIC_QUEUE_COUNT_LIMIT = 1_000_000;
+const PUBLIC_SCHEDULED_FEED_RATE_LIMIT = 2_000;
 const PUBLIC_QUEUE_TOTAL_LIMIT = 1_000_000_000_000;
 const PUBLIC_QUEUE_BACKOFF_REASONS = [
   "dispatch_debounce",
@@ -4643,6 +4646,10 @@ export function publicExactReviewQueueProjection(
   const projectedHandoff = publicExactReviewHandoff(sourceHandoff);
   const sourcePressure = objectValue(source.pressure);
   const projectedPressure = publicExactReviewPressure(sourcePressure);
+  const scheduledTargetRate = publicQueueCount(
+    objectValue(source.scheduled_feed).target_rate_per_hour,
+    PUBLIC_SCHEDULED_FEED_RATE_LIMIT,
+  );
   const requiredCounts = [
     source.pending,
     source.ready_pending,
@@ -4740,6 +4747,10 @@ export function publicExactReviewQueueProjection(
     next_wake_at: publicQueueTimestamp(source.next_wake_at),
     handoff_health: projectedHandoff,
     pressure: projectedPressure,
+    scheduled_feed:
+      scheduledTargetRate !== null && scheduledTargetRate > 0
+        ? { target_rate_per_hour: scheduledTargetRate }
+        : null,
     lanes: {
       review: projectedReviewLane.value,
       publication: projectedPublicationLane.value,

--- a/test/dashboard-worker-dashboard-status.test.ts
+++ b/test/dashboard-worker-dashboard-status.test.ts
@@ -802,12 +802,18 @@ test("dashboard sanitizes stored status immediately and never renders transport 
     bay: {},
     recent: {},
     diagnostics: { errors: [marker], error_count: 0 },
+    exact_review_queue: {
+      scheduled_feed: { target_rate_per_hour: 300, token_balance: marker },
+    },
   });
   const withCache = await run(cached);
   assert.equal(withCache.removed, false);
   assert.ok(withCache.writes.length >= 1);
   assert.equal(withCache.writes[0].includes(marker), false);
   assert.match(withCache.writes[0], /telemetry_unavailable/);
+  assert.deepEqual(JSON.parse(withCache.writes[0]).exact_review_queue.scheduled_feed, {
+    target_rate_per_hour: 300,
+  });
   assert.doesNotMatch(JSON.stringify([...withCache.elements.values()]), new RegExp(marker, "i"));
 
   const withoutCache = await run(null);

--- a/test/dashboard-worker-status-privacy.test.ts
+++ b/test/dashboard-worker-status-privacy.test.ts
@@ -1066,6 +1066,14 @@ test("public queue projection retains only closed operational aggregates", () =>
       dispatch_failure_fingerprint: sentinel,
       dispatch_failure_detail: { workflow_title: sentinel },
     },
+    scheduled_feed: {
+      target_rate_per_hour: 300,
+      burst: 50,
+      token_balance: 42,
+      throttle_source: sentinel,
+      lanes: { normal_backfill: { target_rate_per_hour: 200 } },
+      sentinel,
+    },
     lanes: {
       review: {
         pending: 7,
@@ -1165,6 +1173,7 @@ test("public queue projection retains only closed operational aggregates", () =>
   assert.equal(projected.lanes.review.parked_reasons.unknown, 1);
   assert.equal(projected.handoff_health.status, "healthy");
   assert.equal(projected.pressure.status, "congested");
+  assert.deepEqual(projected.scheduled_feed, { target_rate_per_hour: 300 });
   assert.deepEqual(projected.bay_projection.activity, {
     complete: false,
     queue_stages: null,
@@ -1198,11 +1207,18 @@ test("public queue projection retains only closed operational aggregates", () =>
   assert.equal(JSON.stringify(statusProjected).includes(sentinel), false);
   assert.deepEqual(statusProjected.recent.closed_items, []);
   assert.deepEqual(statusProjected.exact_review_queue.collection, { state: "complete" });
+  assert.deepEqual(statusProjected.exact_review_queue.scheduled_feed, {
+    target_rate_per_hour: 300,
+  });
   assert.deepEqual(statusProjected.exact_review_queue.handoff_health.phases, {
     pending: { count: 7, oldest_at: null, oldest_age_seconds: null },
     dispatching: { count: 2, oldest_at: null, oldest_age_seconds: null },
     leased: { count: 1, oldest_at: null, oldest_age_seconds: null },
   });
+  assert.deepEqual(
+    strictPublicStatusProjection(statusProjected).exact_review_queue.scheduled_feed,
+    statusProjected.exact_review_queue.scheduled_feed,
+  );
 
   const highTotals = publicExactReviewQueueProjection({
     ...projected,
@@ -1217,6 +1233,21 @@ test("public queue projection retains only closed operational aggregates", () =>
   });
   assert.equal(highTotals.lanes.review.enqueued_total, 1_120_211);
   assert.equal(highTotals.lanes.review.completed_total, 1_120_299);
+
+  for (const scheduled_feed of [
+    undefined,
+    null,
+    {},
+    { target_rate_per_hour: 0 },
+    { target_rate_per_hour: 1.5 },
+    { target_rate_per_hour: 2_001 },
+    { target_rate_per_hour: "300" },
+  ]) {
+    assert.equal(
+      publicExactReviewQueueProjection({ ...source, scheduled_feed }).scheduled_feed,
+      null,
+    );
+  }
 
   const mismatches = [
     (value) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled ClawSweeper sweeps failed before queue admission because the public exact-review queue response omitted the queue's scheduled-feed pacing capability.

## Why This Change Was Made

The public queue projector now retains only the bounded `scheduled_feed.target_rate_per_hour` capability required by the existing fail-closed scheduler client. The same closed field survives `/api/status` and browser-cache sanitization; burst, token balance, lane splits, throttle state, and unknown fields remain private.

No scheduler policy, workflow, Durable Object state, queue capacity, retry behavior, or publication behavior changes.

## User Impact

Scheduled review sweeps can resume signed queue admission against a compatible Worker instead of failing with `exact-review queue does not advertise scheduled feed admission`.

## OpenClaw Bay Impact

Bay queue/status snapshots retain the bounded scheduled-feed target through server and browser sanitization. The visible Bay layout and lifecycle behavior are unchanged. Focused status-cache tests prove the capability survives while private rate-limit state is stripped.

## Documentation Impact

Reviewed `docs/scheduler.md` and `docs/live-dashboard.md`. Their existing contract already describes the scheduled-feed capability and `/api/status` queue snapshot, so no documentation text change is required. The release-owned changelog remains unchanged; operational context stays in this PR body and the commit message.

## Evidence

- Pre-commit Codex review found one `/api/status` sibling-path omission; it was repaired before the implementation commit.
- Exact committed-range Codex review at `a4d9287866dd71e98a07e046579d702caaf9e761`: no actionable finding.
- `node --test test/dashboard-worker-status-privacy.test.ts test/dashboard-worker-dashboard-status.test.ts`: 70 passed.
- `node --test test/repair/scheduled-review-enqueue.test.ts`: 5 passed.
- Focused queue pacing test: 1 passed.
- Dashboard typecheck, focused oxlint/oxfmt, dashboard queue-boundary check, strict dashboard check, docs check, and `git diff --check`: passed.
- Current-head Crabbox proof: provider `aws`, run `run_c9b208b3a296`, lease `cbx_43f938c8e687` (`swift-crayfish-d6ca`), image `ami-0461d919be7deb53c`, Node 24.18.1, exit `0`, lease stopped.
- Production delta: +11 lines in the Worker projector; browser allowlist replacements are net-neutral. Tests add 37 lines.

## Finding Dispositions

- **Release-owned changelog:** removed in `a4d9287866dd71e98a07e046579d702caaf9e761`. A local dirty-tree reviewer suggested restoring it, but that conflicts with the repository-specific ClawSweeper policy and the exact-head finding. Release context remains in this body and commit history.
- **Crabbox proof:** completed at the current head. `crabbox config show` resolved `provider=aws` from repo configuration on the current macOS host, so the run preserved that provider as required by the Crabbox skill. The `local-container` clause in `AGENTS.md` is explicitly conditional on a Windows host and did not apply to this Darwin host.

## Real Behavior Proof

**Claim:** A real Worker queue response exposes only the bounded scheduled-feed target, and the unchanged scheduled enqueue client can consume it and complete signed queue admission.

**Exercised surface:** `ExactReviewQueue` Durable Object -> Worker `/api/exact-review-queue?fresh=1` -> `enqueueScheduledReviewPlan` -> Worker authenticated enqueue route.

**Scenario:** An in-memory Worker/DO instance configured for 300 reviews/hour served the public capability, then accepted one scheduled issue through the production HMAC path.

**Command and environment:** Crabbox `0.45.0`, resolved provider `aws`, run `run_c9b208b3a296`, lease `cbx_43f938c8e687` (`swift-crayfish-d6ca`), machine `c7a.8xlarge`, promoted image `ami-0461d919be7deb53c`, fresh PR checkout at `a4d9287866dd71e98a07e046579d702caaf9e761`, Node 24.18.1. The script ran `pnpm install --frozen-lockfile`, `pnpm run build:all`, then the Worker/DO-to-signed-enqueue scenario.

**Observed result:**

```json
{"head_sha":"a4d9287866dd71e98a07e046579d702caaf9e761","public_status":200,"scheduled_feed":{"target_rate_per_hour":300},"private_fields_exposed":false,"enqueue":{"attempted":1,"queued":1}}
```

**Artifact or trace:** Required artifact `.artifacts/pr-1219/result.json` was collected in `run_c9b208b3a296-artifacts.tgz`; the redacted stdout/stderr transcript and Crabbox timing receipt recorded exit `0`, exact-head match, and `leaseStopped=true`. Focused tests cover direct projection, `/api/status`, browser cache reprojection, malformed bounds, and scheduler fail-closed behavior.

**Limits:** Synthetic fixture and in-memory Cloudflare bindings inside a fresh remote checkout. No production deployment, production queue mutation, credentials, or external GitHub calls.
