### PR TITLE
fix(live-proof): keep review module caches writable

### DIFF
--- a/src/live-proof/review-artifacts.ts
+++ b/src/live-proof/review-artifacts.ts
@@ -43,6 +43,11 @@ export interface ReviewLiveProofDependencies {
   repositoryProfileFor: (repo: string) => RepositoryProfile;
 }
 
+export const reviewLiveProofGoEnvironment = (environment: NodeJS.ProcessEnv, profile: string) => ({
+  GOFLAGS: [environment.GOFLAGS, "-modcacherw"].filter(Boolean).join(" "),
+  GOMODCACHE: join(profile, "go-mod-cache"),
+});
+
 export function inspectReviewLiveProofs(
   options: Pick<ReviewLiveProofOptions, "itemNumbers" | "recordsDir" | "repo">,
   dependencies: ReviewLiveProofDependencies,
@@ -123,6 +128,7 @@ function executeReviewLiveProof(
       CLAWSWEEPER_SANITIZED_LIVE_PROOF: "1",
       GIT_CONFIG_GLOBAL: "/dev/null",
       GIT_CONFIG_NOSYSTEM: "1",
+      ...reviewLiveProofGoEnvironment(environment, profile),
       HOME: profile,
       npm_config_cache: join(profile, "npm-cache"),
       PNPM_HOME: join(profile, "pnpm"),

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -6,8 +6,25 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 import type { LiveProofPlan } from "../dist/clawsweeper-types.js";
-import { executeReviewLiveProofs } from "../dist/live-proof/review-artifacts.js";
+import {
+  executeReviewLiveProofs,
+  reviewLiveProofGoEnvironment,
+} from "../dist/live-proof/review-artifacts.js";
 import { parseLiveVerificationResult } from "../dist/live-proof/verification.js";
+
+test("review live proof composes inherited Go environment settings", () => {
+  const profile = join("scratch", "profile");
+  const environment = reviewLiveProofGoEnvironment(
+    {
+      GOFLAGS: "-trimpath -modcacherw=false",
+      GOMODCACHE: join("shared", "go", "pkg", "mod"),
+    },
+    profile,
+  );
+
+  assert.equal(environment.GOFLAGS, "-trimpath -modcacherw=false -modcacherw");
+  assert.equal(environment.GOMODCACHE, join(profile, "go-mod-cache"));
+});
 
 test(
   "review live proof runs an unsandboxed static plan with a sanitized child environment",


### PR DESCRIPTION
## What Problem This Solves

Review live-proof jobs can finish successfully and then fail while removing their private `HOME` because Go creates read-only module-cache directories by default. The cleanup error masks the successful review, requeues the item, and repeats the review work.

## Why This Change Was Made

The private live-proof child environment now pins `GOMODCACHE` under its scratch profile and composes inherited flags with `[environment.GOFLAGS, "-modcacherw"].filter(Boolean).join(" ")`. Appending preserves existing flags and makes the final value authoritative when an inherited environment contains `-modcacherw=false`.

The environment composition lives in one focused producer helper so the exact inherited and replacement values can be tested without adding cleanup behavior.

This fixes the state at its producer. It does not add permission recovery, filesystem traversal, cleanup retries, ignored cleanup failures, or process/worktree lifecycle changes.

## User Impact

Successful Go-backed review proofs no longer create read-only module-cache directories under the private scratch profile, so ordinary recursive cleanup can complete without turning a successful review into a failed and requeued run.

## OpenClaw Bay Impact

Bay is unaffected. Queue state, durable records, publication payloads, comments, dashboard contracts, and cleanup ownership are unchanged.

## Documentation Impact

Reviewed the live-proof documentation and contributor workflow. No documentation update is needed because commands, output, flags, and operator workflow are unchanged.

## Evidence

Exact head: `e5c34566436448ad33dba6e0499f173ec8e39e55`

- Signed commit based directly on current `origin/main`.
- `node_modules/.bin/tsc -p tsconfig.json`
- `env -u TMUX -u TMUX_PANE TMUX_TMPDIR=<isolated> node --test test/live-proof-review-environment.test.ts` - 2 passed
- Same isolated environment with `test/live-proof.test.ts`, `test/review-blob-hydration.test.ts`, and `test/live-proof-review-environment.test.ts` - 62 passed
- Targeted `oxfmt`, type-aware `oxlint`, and `git diff --check`
- Real Go module-cache proof: default mode `0555`; inherited `-trimpath -modcacherw=false` followed by `-modcacherw` produced mode `0755`; recursive removal succeeded
- Committed `codex review --base origin/main` - no introduced defect

The linked worktree intentionally shares `node_modules`, so repository-level pnpm wrappers attempt to purge that symlink. Their focused exact-head constituents ran directly. Hosted CI provides the clean-install full-check proof.

## Real Behavior Proof

- **Claim:** inherited Go flags remain intact while the private review profile owns writable module-cache directories.
- **Exercised surface:** `executeReviewLiveProofs` child-environment construction and the real static-plan execution path.
- **Scenario:** the parent environment supplies `GOFLAGS=-trimpath -modcacherw=false` and a shared `GOMODCACHE`.
- **Command and environment:** focused Node live-proof execution on macOS plus real `go mod download` runs against separate default and appended-flag caches.
- **Observed result:** the environment producer returns `GOFLAGS=-trimpath -modcacherw=false -modcacherw`, replaces the shared module-cache path with its scratch-local cache, and the live-proof integration test completes. The real Go cache changes from mode `0555` by default to `0755` with the appended flag and is recursively removable.
- **Artifact or trace:** the focused test prints the successful sanitized live-proof receipt; the redacted Go probe records `default=555 writable=755` and `writable_cleanup=removed`.
- **Dependency contract:** Go applies repeated boolean flags in order, so the appended value wins.
- **Limits:** local proof ran on macOS with an isolated tmux socket; hosted CI covers the clean Linux runner.

## Prior Review Findings

This replaces the previous broad lifecycle rewrite entirely. The reviewed `lstat`/`chmod` race, detached-descendant concern, permission-recovery traversal, and cleanup retry behavior are absent from this head. The narrow producer fix leaves the existing cleanup and process ownership model untouched.

A pre-commit review also reproduced the separate existing-server tmux environment limitation. That is not accepted into this PR: fixing it requires the previously rejected process/socket lifecycle expansion, while the affected exact-review workflow runs the proof in a fresh hosted job. This PR deliberately keeps the reviewed producer-only scope.

## Diff

- Production: `+6/-0`
- Tests: `+18/-1`

The production delta creates one canonical, directly testable Go-environment producer and applies it at the existing child boundary.
