### PR TITLE
fix(router): let review commands inspect target checks

### DIFF
--- a/.github/workflows/repair-comment-router.yml
+++ b/.github/workflows/repair-comment-router.yml
@@ -150,9 +150,11 @@ jobs:
           owner: ${{ steps.target.outputs.target_repo_owner }}
           repositories: ${{ steps.target.outputs.target_repo_name }}
           permission-actions: write
+          permission-checks: read
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: read
 
       - name: Create central dispatch token
         id: dispatch-token

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -532,6 +532,26 @@ test("review execution tokens can read check runs and commit statuses", () => {
   );
 });
 
+test("comment router target token can inspect checks without widening dispatch authority", () => {
+  type TokenStep = {
+    id?: string;
+    with?: Record<string, string>;
+  };
+  const workflow = YAML.parse(readText(".github/workflows/repair-comment-router.yml")) as {
+    jobs: Record<string, { steps: TokenStep[] }>;
+  };
+  const steps = workflow.jobs["route-comments"]!.steps;
+  const targetToken = steps.find((step) => step.id === "app_token");
+  const dispatchToken = steps.find((step) => step.id === "dispatch-token");
+
+  assert.ok(targetToken?.with);
+  assert.equal(targetToken.with["permission-checks"], "read");
+  assert.equal(targetToken.with["permission-statuses"], "read");
+  assert.ok(dispatchToken?.with);
+  assert.equal("permission-checks" in dispatchToken.with, false);
+  assert.equal("permission-statuses" in dispatchToken.with, false);
+});
+
 test("exact event branch guard resolves empty and numeric claims to the repository default", () => {
   const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
     jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an authorized `@clawsweeper review` command could be acknowledged without producing a review when the target GitHub App token could not read the pull request's check rollup.

The observed failure was run `32552137513`, job `96980506957`: routing reached the target PR, then `statusCheckRollup` failed with `Resource not accessible by integration`, leaving the command with no actionable review artifact.

## Why This Change Was Made

The comment router's target-repository token now gets read-only Checks and commit-status permissions, matching the status surface it already queries. The central dispatch token remains unchanged and narrow.

## User Impact

Maintainer review commands can inspect target PR checks and complete routing instead of falsely finishing without a ClawSweeper review artifact.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes only the private target-token permission set used by the comment router; no public status, telemetry, dashboard contract, or navigation surface changes.

## Documentation Impact

Reviewed `AGENTS.md`, `CONTRIBUTING.md`, and the existing comment-router workflow contract. No documentation update is needed because the maintainer command surface and operator procedure are unchanged.

## Evidence

- Exact head: `2f98ff61881d839141e63597f44c28ca9defb794`
- `node --test test/sweep-workflow.test.ts`: 122 passed, 0 failed
- `actionlint -shellcheck= -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/*.yml`: passed
- `./node_modules/.bin/oxfmt --check .github/workflows/repair-comment-router.yml test/sweep-workflow.test.ts`: passed
- `git diff --check origin/main...HEAD`: passed

## Real Behavior Proof

**Claim:** the target App token can request the two read permissions needed by `statusCheckRollup`, without widening the central dispatch token.

**Exercised surface:** `.github/workflows/repair-comment-router.yml` token creation and the workflow contract test.

**Scenario:** parse the exact workflow YAML, locate both GitHub App token steps, and verify that only the target token requests `checks: read` and `statuses: read`.

**Command and environment:** Node `v26.5.0` on macOS, running `node --test test/sweep-workflow.test.ts` at exact head `2f98ff61881d839141e63597f44c28ca9defb794`.

**Observed result:** all 122 workflow contract tests passed, including the new target-token/dispatch-token boundary assertion. The canonical actionlint invocation also accepted the full workflow set.

**Trace:** the pre-fix live trace is `https://github.com/openclaw/clawsweeper/actions/runs/32552137513/job/96980506957`; it fails exactly at the missing target-token read authority.

**Limits:** GitHub issues installation tokens only inside Actions. The post-merge proof is a bounded replay of the single failed maintainer comment, verifying token creation, routing completion, and an exact-head review artifact.
