### PR TITLE
fix(publication): prevent aged owner starvation

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -3847,6 +3847,7 @@ export class ExactReviewQueue {
       new Set(snapshotBatchOwnership.itemKeys),
       snapshotBatchOwnership.activeBatches,
       this.freshPublicationItemKeysSync(snapshot, startedAt),
+      this.supersededPublicationItemKeysSync(snapshot),
     );
     let snapshotBatchCandidates = snapshotBatchDeparture?.due
       ? this.publicationBatchCandidates(
@@ -3912,6 +3913,7 @@ export class ExactReviewQueue {
         new Set(snapshotBatchOwnership.itemKeys),
         snapshotBatchOwnership.activeBatches,
         this.freshPublicationItemKeysSync(snapshot, recheckedAt),
+        this.supersededPublicationItemKeysSync(snapshot),
       );
       snapshotBatchCandidates = snapshotBatchDeparture?.due
         ? this.publicationBatchCandidates(
@@ -5929,7 +5931,10 @@ export class ExactReviewQueue {
     // shared helper counts candidate rows, so widen only its scan window by
     // requestedSize; passing +1 here would silently collapse every batch to one.
     const activePublishers = exactReviewQueueActivePublicationCount(state);
-    const excludedItemKeys = new Set<string>(batchOwnership.itemKeys);
+    const excludedItemKeys = new Set<string>([
+      ...batchOwnership.itemKeys,
+      ...this.supersededPublicationItemKeysSync(state),
+    ]);
     for (const item of Object.values(state.items)) {
       // Direct receipts and terminal acknowledgement drivers must remain on
       // the normal publisher. Exclude them before admission so they cannot
@@ -5938,13 +5943,6 @@ export class ExactReviewQueue {
         excludedItemKeys.add(item.key);
       }
       if (exactReviewGithubCircuitBlocksItem(state, item, now)) {
-        excludedItemKeys.add(item.key);
-      }
-      const revision = exactReviewPublicationRevision(item.decision);
-      if (
-        revision &&
-        revision.sourceRevision < this.publicationHeadRevisionSync(revision.targetKey)
-      ) {
         excludedItemKeys.add(item.key);
       }
     }
@@ -5968,14 +5966,7 @@ export class ExactReviewQueue {
             // immutable lifecycle plan must return through the fenced legacy
             // publisher, which is the only path that replays that plan.
             .filter(exactReviewQueueIsBatchablePublication)
-            .filter((item) => !item.terminalFinalization)
-            .filter((item) => {
-              const revision = exactReviewPublicationRevision(item.decision);
-              return (
-                !revision ||
-                revision.sourceRevision >= this.publicationHeadRevisionSync(revision.targetKey)
-              );
-            });
+            .filter((item) => !item.terminalFinalization);
     const selection = exactReviewPublicationBatchSelection(
       readyCandidates,
       freshItemKeys,
@@ -7856,6 +7847,20 @@ export class ExactReviewQueue {
       ),
     )[0] as { source_revision?: number } | undefined;
     return Number(row?.source_revision || 0);
+  }
+
+  private supersededPublicationItemKeysSync(state: ExactReviewQueueState) {
+    // Active batch ownership can preserve an older row after a newer head lands.
+    // Departure and claim must exclude that same row when ownership expires.
+    return new Set(
+      Object.values(state.items).flatMap((item) => {
+        const revision = exactReviewPublicationRevision(item.decision);
+        return revision &&
+          revision.sourceRevision < this.publicationHeadRevisionSync(revision.targetKey)
+          ? [item.key]
+          : [];
+      }),
+    );
   }
 
   private nextExactReviewItemRevisionSync(itemKey: string, minimumRevision = 1): number {
@@ -10859,6 +10864,7 @@ export class ExactReviewQueue {
       new Set(batchOwnership.itemKeys),
       batchOwnership.activeBatches,
       this.freshPublicationItemKeysSync(state, now),
+      this.supersededPublicationItemKeysSync(state),
     );
     const sourceAuthorityNext = await this.nextSourceAuthorityVerificationAt();
     const commandIntakeNext = this.commandIntakeStore.nextAttemptAt();
@@ -12964,6 +12970,7 @@ function exactReviewPublicationBatchDeparture(
   ownedItemKeys: ReadonlySet<string>,
   activeBatchCount: number,
   freshItemKeys: ReadonlySet<string> = new Set(),
+  supersededItemKeys: ReadonlySet<string> = new Set(),
 ) {
   if (
     !exactReviewPublicationBatchingEnabled(env) ||
@@ -12979,6 +12986,7 @@ function exactReviewPublicationBatchDeparture(
           item.state === "pending" &&
           !item.terminalFinalization &&
           !ownedItemKeys.has(item.key) &&
+          !supersededItemKeys.has(item.key) &&
           !exactReviewGithubCircuitBlocksItem(state, item, now),
       )
       .sort((left, right) => left.createdAt - right.createdAt || left.key.localeCompare(right.key)),

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -5948,6 +5948,7 @@ export class ExactReviewQueue {
         excludedItemKeys.add(item.key);
       }
     }
+    const freshItemKeys = this.freshPublicationItemKeysSync(state, now);
     const readyCandidates =
       activePublishers >= publicationCapacity
         ? []
@@ -5960,7 +5961,7 @@ export class ExactReviewQueue {
             excludedItemKeys,
             false, // batching replaces legacy publication blocking at this admission point
             true, // one durable item path per commit; later events remain FIFO candidates
-            this.freshPublicationItemKeysSync(state, now),
+            freshItemKeys,
             exactReviewPublicationFreshLaneMaxItems(this.env),
           )
             // A direct receipt has already committed its GitHub effect. Its
@@ -5975,13 +5976,17 @@ export class ExactReviewQueue {
                 revision.sourceRevision >= this.publicationHeadRevisionSync(revision.targetKey)
               );
             });
-    const firstOwner = readyCandidates[0]?.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
+    const selection = exactReviewPublicationBatchSelection(
+      readyCandidates,
+      freshItemKeys,
+      exactReviewPublicationBatchSize(this.env),
+      exactReviewPublicationBatchWaitMs(this.env),
+      now,
+    );
     // One GitHub App installation token is scoped to one owner. Keeping a batch
     // owner-homogeneous lets the workflow retain least privilege without serially
     // minting and exporting a different credential for every item.
-    return readyCandidates
-      .filter((item) => item.decision.targetRepo.split("/", 1)[0]?.toLowerCase() === firstOwner)
-      .slice(0, leaseSize);
+    return selection?.candidates.slice(0, leaseSize) ?? [];
   }
 
   private async claimPublicationBatch(value: unknown) {
@@ -12981,40 +12986,27 @@ function exactReviewPublicationBatchDeparture(
     exactReviewPublicationFreshLaneMaxItems(env),
   );
   const maxItems = exactReviewPublicationBatchSize(env);
+  const waitMs = exactReviewPublicationBatchWaitMs(env);
   const nextEligibilityAt = pending.reduce(
     (earliest, item) =>
       item.nextAttemptAt > now ? Math.min(earliest, item.nextAttemptAt) : earliest,
     Number.POSITIVE_INFINITY,
   );
   const candidates = pending.filter((item) => item.nextAttemptAt <= now);
-  const freshOwner = candidates
-    .find((item) => freshItemKeys.has(item.key))
-    ?.decision.targetRepo.split("/", 1)[0]
-    ?.toLowerCase();
-  const owner = freshOwner ?? candidates[0]?.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
-  if (!owner) {
+  const selection = exactReviewPublicationBatchSelection(
+    candidates,
+    freshItemKeys,
+    maxItems,
+    waitMs,
+    now,
+  );
+  if (!selection) {
     return Number.isFinite(nextEligibilityAt)
       ? { candidateCount: 0, maxItems, dueAt: nextEligibilityAt, due: false }
       : null;
   }
-  const candidatesByOwner = new Map<string, ExactReviewQueueItem[]>();
-  for (const item of candidates) {
-    const candidateOwner = item.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
-    if (!candidateOwner) continue;
-    const group = candidatesByOwner.get(candidateOwner) ?? [];
-    group.push(item);
-    candidatesByOwner.set(candidateOwner, group);
-  }
-  // Keep a fresh owner's bounded service even when another owner could fill a
-  // historical batch. Without fresh work, retain the existing full-owner choice.
-  const selectedOwner =
-    freshOwner ??
-    [...candidatesByOwner].find(([, group]) => group.length >= maxItems)?.[0] ??
-    owner;
-  const ownerCandidates = candidatesByOwner.get(selectedOwner)!;
-  const oldestAt = ownerCandidates[0]!.createdAt;
-  const fullAt = ownerCandidates.length >= maxItems ? now : Number.POSITIVE_INFINITY;
-  const ageAt = oldestAt + exactReviewPublicationBatchWaitMs(env);
+  const fullAt = selection.candidates.length >= maxItems ? now : Number.POSITIVE_INFINITY;
+  const ageAt = selection.oldestAt + waitMs;
   const lastAttemptAt = Number(state.dispatcher?.publicationBatchDispatchedAt || 0);
   const dispatchRetryMs = state.dispatcher?.publicationBatchDispatchSucceeded
     ? exactReviewPublicationBatchDispatchCooldownMs(env)
@@ -13028,10 +13020,60 @@ function exactReviewPublicationBatchDeparture(
   // so they must retain their own wake-up even when today's partial batch is older.
   const dueAt = Math.min(dispatchDueAt, nextEligibilityAt);
   return {
-    candidateCount: ownerCandidates.length,
+    candidateCount: selection.candidates.length,
     maxItems,
     dueAt,
     due: dueAt <= now,
+  };
+}
+
+function exactReviewPublicationBatchSelection(
+  candidates: ExactReviewQueueItem[],
+  freshItemKeys: ReadonlySet<string>,
+  maxItems: number,
+  waitMs: number,
+  now: number,
+) {
+  const candidatesByOwner = new Map<string, ExactReviewQueueItem[]>();
+  let oldest: ExactReviewQueueItem | undefined;
+  let oldestAged: ExactReviewQueueItem | undefined;
+  for (const item of candidates) {
+    const owner = item.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
+    if (!owner) continue;
+    const group = candidatesByOwner.get(owner) ?? [];
+    group.push(item);
+    candidatesByOwner.set(owner, group);
+    if (
+      !oldest ||
+      item.createdAt < oldest.createdAt ||
+      (item.createdAt === oldest.createdAt && item.key.localeCompare(oldest.key) < 0)
+    ) {
+      oldest = item;
+    }
+    if (
+      item.createdAt + waitMs <= now &&
+      (!oldestAged ||
+        item.createdAt < oldestAged.createdAt ||
+        (item.createdAt === oldestAged.createdAt && item.key.localeCompare(oldestAged.key) < 0))
+    ) {
+      oldestAged = item;
+    }
+  }
+  const ownerFor = (item: ExactReviewQueueItem | undefined) =>
+    item?.decision.targetRepo.split("/", 1)[0]?.toLowerCase();
+  // Departure and claim must choose the same installation owner. Once an
+  // owner's oldest work has waited a full batch window, cross-owner fresh/full
+  // optimization yields to that owner; ordering within the owner stays intact.
+  const selectedOwner =
+    ownerFor(oldestAged) ??
+    ownerFor(candidates.find((item) => freshItemKeys.has(item.key))) ??
+    [...candidatesByOwner].find(([, group]) => group.length >= maxItems)?.[0] ??
+    ownerFor(oldest);
+  const selected = selectedOwner ? candidatesByOwner.get(selectedOwner) : undefined;
+  if (!selected?.length) return null;
+  return {
+    candidates: selected,
+    oldestAt: oldest!.createdAt,
   };
 }
 

--- a/test/dashboard-worker-queue-runtime.test.ts
+++ b/test/dashboard-worker-queue-runtime.test.ts
@@ -1402,18 +1402,20 @@ test("exact-review batch preflight follows the publisher owner selection", async
 
     await harness.queue.alarm();
 
-    // Departure policy sees beta's full batch, while the publisher picks the
-    // oldest alpha owner. The preflight must inspect that publisher selection.
-    assert.deepEqual(checked, [["alpha/repo", 9221]]);
-    assert.equal(harness.batchDispatches, 0);
-    const terminal = await (
+    // The shared selector picks beta's full batch before either owner ages.
+    assert.deepEqual(checked, [
+      ["beta/repo", 9222],
+      ["beta/repo", 9223],
+    ]);
+    assert.equal(harness.batchDispatches, 1);
+    const alphaStatus = await (
       await harness.queue.fetch(
         new Request(
           "https://clawsweeper-exact-review-queue/item-status?target_repo=alpha%2Frepo&item_number=9221",
         ),
       )
     ).json();
-    assert.equal(terminal.items.length, 0);
+    assert.equal(alphaStatus.items.length, 1);
   } finally {
     harness.restore();
   }

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -2829,6 +2829,163 @@ test("batch ask widens owner scanning without exceeding the configured lease siz
   }
 });
 
+test("oldest publication aging deadline drives the alarm and then its owner claim", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalNow = Date.now;
+  let now = 1_900_000;
+  const agingDeadline = now + 300_000;
+  Date.now = () => now;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const dispatches: Array<{ inputs: Record<string, string> }> = [];
+  const checkedTargets: string[] = [];
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return new Response(JSON.stringify({ id: 999 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/repos/aged/repo/installation") {
+      return new Response(JSON.stringify({ id: 1000 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return new Response(JSON.stringify({ token: "dispatch-token" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/app/installations/1000/access_tokens") {
+      return new Response(JSON.stringify({ token: "aged-token" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/repos/aged/repo/issues/140") {
+      checkedTargets.push("aged/repo#140");
+      return new Response(JSON.stringify({ state: "open" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/exact-review-batch-publish.yml/dispatches"
+    ) {
+      dispatches.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "4",
+        EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "300000",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+      },
+    );
+    await queue.fetch(publicationRequest("owner-aged", 140, "1040", "aged/repo"));
+    now += 120_000;
+    await queue.fetch(publicationRequest("owner-fresh", 141, "1041", "fresh/repo"));
+
+    await queue.alarm();
+
+    assert.deepEqual(checkedTargets, []);
+    assert.equal(dispatches.length, 0);
+    assert.equal(storage.scheduledAlarm(), agingDeadline);
+
+    now = agingDeadline - 1;
+    await queue.fetch(publicationRequest("owner-fresh-replenished", 142, "1042", "fresh/repo"));
+    now = agingDeadline;
+    await queue.alarm();
+
+    assert.deepEqual(checkedTargets, ["aged/repo#140"]);
+    assert.equal(dispatches.length, 1);
+    const dispatch = dispatches[0]!;
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-aged-owner",
+          lease_owner: "worker-1",
+          max_items: 50,
+          dispatch_id: dispatch.inputs.dispatch_id,
+          dispatched_at: dispatch.inputs.dispatched_at,
+        }),
+      )
+    ).json();
+    assert.equal(claim.claimed, true, JSON.stringify(claim));
+    assert.deepEqual(
+      claim.batch.items.map((item: { item_key: string }) => item.item_key),
+      ["aged/repo#140@publish:1040:1"],
+    );
+    if (process.env.CLAWSWEEPER_EVIDENCE_TRANSCRIPT === "1") {
+      console.log(
+        `PUBLICATION_OWNER_AGING_PROOF=${JSON.stringify({
+          early_alarm_at: new Date(agingDeadline).toISOString(),
+          alarm_dispatched: dispatches.length === 1,
+          terminal_preflight: checkedTargets,
+          claimed_items: claim.batch.items.map((item: { item_key: string }) => item.item_key),
+        })}`,
+      );
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});
+
+test("fresh publication owner still wins when no owner's work has aged", async () => {
+  const originalNow = Date.now;
+  let now = 1_950_000;
+  Date.now = () => now;
+  try {
+    const queue = new ExactReviewQueue(
+      { storage: new TestStorage() },
+      {
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+        EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "300000",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+      },
+    );
+    await queue.fetch(publicationRequest("owner-full-1", 150, "1050", "full/repo"));
+    now += 1;
+    await queue.fetch(publicationRequest("owner-full-2", 151, "1051", "full/repo"));
+    now += 60_001;
+    await queue.fetch(publicationRequest("owner-fresh-only", 152, "1052", "fresh/repo"));
+
+    const claim = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-fresh-owner",
+          lease_owner: "worker-1",
+          max_items: 50,
+        }),
+      )
+    ).json();
+
+    assert.equal(claim.claimed, true, JSON.stringify(claim));
+    assert.deepEqual(
+      claim.batch.items.map((item: { item_key: string }) => item.item_key),
+      ["fresh/repo#152@publish:1052:1"],
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("fresh publication admission reserves bounded service and preserves historical FIFO", async () => {
   const originalNow = Date.now;
   let now = 2_000_000;
@@ -2876,15 +3033,14 @@ test("fresh publication admission reserves bounded service and preserves histori
         }),
       )
     ).json();
-    const keys = new Set(claim.batch.items.map((item: { item_key: string }) => item.item_key));
     assert.deepEqual(
-      keys,
-      new Set([
+      claim.batch.items.map((item: { item_key: string }) => item.item_key),
+      [
         "openclaw/openclaw#10@publish:7010:1",
         "openclaw/openclaw#11@publish:7011:1",
         "openclaw/openclaw#12@publish:7012:1",
         "openclaw/openclaw#90@publish:7190:1",
-      ]),
+      ],
     );
   } finally {
     Date.now = originalNow;

--- a/test/exact-review-publication-batches.test.ts
+++ b/test/exact-review-publication-batches.test.ts
@@ -2829,6 +2829,109 @@ test("batch ask widens owner scanning without exceeding the configured lease siz
   }
 });
 
+test("aged superseded publication does not dispatch a fresh owner before its deadline", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalNow = Date.now;
+  let now = 1_850_000;
+  const agedEnqueuedAt = now;
+  Date.now = () => now;
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const checkedTargets: string[] = [];
+  const dispatches: Array<{ inputs: Record<string, string> }> = [];
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/repos/openclaw/clawsweeper/installation") {
+      return new Response(JSON.stringify({ id: 999 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/repos/fresh/repo/installation") {
+      return new Response(JSON.stringify({ id: 1001 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/app/installations/999/access_tokens") {
+      return new Response(JSON.stringify({ token: "dispatch-token" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/app/installations/1001/access_tokens") {
+      return new Response(JSON.stringify({ token: "fresh-token" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/repos/fresh/repo/issues/161") {
+      checkedTargets.push("fresh/repo#161");
+      return new Response(JSON.stringify({ state: "open" }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      url.pathname ===
+      "/repos/openclaw/clawsweeper/actions/workflows/exact-review-batch-publish.yml/dispatches"
+    ) {
+      dispatches.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  try {
+    const storage = new TestStorage();
+    const queue = new ExactReviewQueue(
+      { storage },
+      {
+        CLAWSWEEPER_APP_CLIENT_ID: "Iv23test",
+        CLAWSWEEPER_APP_PRIVATE_KEY: privateKey,
+        EXACT_REVIEW_PUBLICATION_BATCHING_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_BATCH_SIZE: "2",
+        EXACT_REVIEW_PUBLICATION_BATCH_LEASE_MS: "60000",
+        EXACT_REVIEW_PUBLICATION_BATCH_WAIT_MS: "300000",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_ENABLED: "1",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_ITEMS: "1",
+        EXACT_REVIEW_PUBLICATION_FRESH_LANE_MAX_AGE_MS: "60000",
+      },
+    );
+    await queue.fetch(publicationRequest("superseded-aged-1", 160, "1060", "stale/repo", 1));
+    const owned = await (
+      await queue.fetch(
+        batchRequest("/publication-batches/claim", {
+          claim_id: "claim-superseded-aged",
+          lease_owner: "worker-1",
+          max_items: 1,
+        }),
+      )
+    ).json();
+    assert.equal(owned.claimed, true, JSON.stringify(owned));
+
+    now += 1;
+    await queue.fetch(publicationRequest("superseded-aged-2", 160, "1061", "stale/repo", 2));
+    const removedNewer = await (
+      await queue.fetch(
+        batchRequest("/publications/supersede", {
+          items: [{ item_key: "stale/repo#160@publish:1061:1", revision: 1 }],
+        }),
+      )
+    ).json();
+    assert.equal(removedNewer.superseded, 1);
+
+    now = agedEnqueuedAt + 300_001;
+    const freshEnqueuedAt = now;
+    await queue.fetch(publicationRequest("valid-fresh-owner", 161, "1062", "fresh/repo"));
+    await queue.alarm();
+
+    assert.deepEqual(checkedTargets, []);
+    assert.equal(dispatches.length, 0);
+    assert.equal(storage.scheduledAlarm(), freshEnqueuedAt + 300_000);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});
+
 test("oldest publication aging deadline drives the alarm and then its owner claim", async () => {
   const originalFetch = globalThis.fetch;
   const originalNow = Date.now;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an owner with aged publication work could remain queued while another owner's fresh or full batch kept winning departure selection. The alarm could also be scheduled from the selected fresh owner instead of the globally oldest eligible item, delaying the aged owner's next dispatch opportunity.

## Why This Change Was Made

Departure and claim now share one owner-selection rule: the globally oldest aged owner's owner wins before cross-owner fresh/full optimization, while batches remain owner-homogeneous and existing within-owner ordering is preserved. The global oldest eligible timestamp remains the alarm boundary even while a different fresh owner is temporarily selected.

Both paths also use the same superseded-revision exclusion. An expired batch can no longer leave an aged stale revision eligible for departure while claim rejects it, which previously allowed that stale owner to trigger an early dispatch of another owner's fresh work.

This does not change capacity, configuration, telemetry, read models, publication payloads, or queue storage.

## User Impact

Operators can expect aged publication work to receive a bounded dispatch opportunity instead of being indefinitely displaced by continuously arriving fresh work from another owner.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes internal publication batch owner selection and alarm timing only; Bay's observer-only projection, status fields, data contracts, and navigation remain unchanged.

## Documentation Impact

Reviewed `AGENTS.md` and `CONTRIBUTING.md`. No documentation update is required because this repair does not add or change a public API, configuration option, workflow input, status field, or operator procedure.

## Evidence

- `node --test --test-name-pattern='aged superseded publication|oldest publication aging deadline|fresh publication owner still wins' test/exact-review-publication-batches.test.ts` — 3/3 passed; covers the superseded lifecycle regression plus both owner-ordering contracts.
- `node --test --test-name-pattern='exact-review batch preflight follows the publisher owner selection' test/dashboard-worker-queue-runtime.test.ts` — 1/1 passed; preflight inspected beta items 9222/9223, dispatched one full beta batch, and left alpha queued.
- `node --test test/exact-review-publication-batches.test.ts` — 69/69 passed.
- Dashboard TypeScript build passed: `./node_modules/.bin/tsc -p tsconfig.dashboard.json --pretty false`.
- Dashboard queue-boundary and strict checks passed.
- Targeted dashboard/test lint passed.
- Targeted formatting and `git diff --check` passed.
- Current branch delta: production +96/-46; tests +271/-10. The exact-head follow-up is production +24/-16 and tests +103/-0.

## Real Behavior Proof

**Claim:** A real local Durable Object alarm preserves the globally oldest publication's aging deadline after an earlier wake, then departure preflight and the signed workflow claim agree on that aged owner despite a fresh competing owner.

**Runtime surface:** Exact head `e709b11798d4136077dc1101f6a12844fc47e5db` under `wrangler@4.107.0 dev --local`, using the repository's Worker entry point, persisted SQLite-backed `ExactReviewQueue`, automatic Durable Object alarms, signed internal enqueue/claim routes, GitHub App authentication, terminal preflight, and workflow dispatch code. The harness follows the existing `docs/proof/alarm-hydration-dedup/run-proof.mjs` Worker/alarm pattern and `docs/proof/csw-127-phase0-6/run-proof.mjs` signed claim pattern.

**Command and environment:**

```text
node .artifacts/pr-1225-publication-runtime-proof/run-proof.mjs
```

Node 26.5.0; Wrangler 4.107.0 local runtime; disposable local Durable Object persistence; generated synthetic RSA/HMAC credentials; loopback-only GitHub API/workflow receiver.

**Controlled scenario:**

- Enqueued aged owner `aged/proof#140`.
- Waited 61 seconds, then enqueued fresh owner `fresh/proof#141`.
- Enqueued `review/proof#300` to force an earlier real alarm/wake.
- Configured publication batch wait to 65 seconds and fresh max age to 60 seconds.
- Captured the real batch workflow dispatch, then called `/internal/exact-review/publication-batches/claim` through the Worker with a valid synthetic signature and the captured dispatch identity.

**Observable result:**

```text
old enqueue:               2026-08-22T09:03:33.965Z
early alarm/wake:          2026-08-22T09:04:36.416Z
old owner aging deadline:  2026-08-22T09:04:38.965Z
batch dispatch:            2026-08-22T09:04:39.130Z
dispatch from old enqueue: 65,165 ms
dispatch from fresh enqueue: 4,161 ms
time before fresh deadline: 60,839 ms
terminal preflight:        aged/proof#140
signed claim item:         aged/proof#140@publish:1040:1
```

The earlier review wake occurred 2,549 ms before the old owner's boundary. The subsequent real alarm dispatched 165 ms after that boundary, not at the fresh owner's later deadline. The loopback terminal preflight touched only the aged owner, the signed claim returned only the aged owner, and the persisted SQLite receipt contained one leased batch owned by `pr-1225-runtime-worker` with that exact member.

**Artifacts:** `.artifacts/pr-1225-publication-runtime-proof/runtime-summary.json` (local ignored evidence), SHA-256 `4d2cf94447e8127c48479c52f2aaa543789274f6521a825abe63858cadcf9aa4`; reproducible harness `run-proof.mjs`, SHA-256 `62e2c754f05a68bb27dc738c04766d4e3b18266d517880606ac976be0ef78c2a`. Supporting request trace and redacted Wrangler log are stored beside them.

**Limits:** GitHub App/API and workflow dispatch were terminated at a loopback receiver. No production Worker, GitHub repository, workflow, queue, secret, deployment, or live ClawSweeper state was contacted or mutated.
