### PR TITLE
fix(scripts): use build:node for test:repair so it emits dist/clawsweeper.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test": "pnpm run build:all && pnpm run test:no-build",
     "test:no-build": "node scripts/run-node-tests.mjs all",
     "test:unit": "node scripts/run-node-tests.mjs unit",
-    "test:repair": "pnpm run build:repair && pnpm run test:repair:no-build",
+    "test:repair": "pnpm run build:node && pnpm run test:repair:no-build",
     "test:repair:no-build": "node scripts/run-node-tests.mjs repair",
     "test:workflow-sparse-checkout": "node --test test/repair/workflow-sparse-checkout.smoke.ts",
     "test:coverage": "pnpm run build:all && pnpm run test:coverage:no-build",

--- a/prompts/review-item.md
+++ b/prompts/review-item.md
@@ -502,7 +502,12 @@ user-visible. Reserve `not_applicable` for a change with genuinely nothing to
 run, such as docs-only edits or generated assets in a repository with no
 meaningful runnable surface. Use `surface: "browser"` for browser behavior and
 `surface: "terminal"` for terminal behavior. The `entry` must be a URL path for
-browser verification or a command for terminal verification. Emit at most ten
+browser verification or a command for terminal verification. For terminal
+verification, prefer invoking a repository-defined `pnpm run` (or equivalent
+package-manager) script over hand-composing individual build/test commands
+whenever one already expresses the needed setup, so the plan does not need to
+independently reconstruct build or dependency sequencing that the script
+already encodes correctly. Emit at most ten
 deterministic, typed `steps`: browser plans may use `goto`, `click`, `fill`,
 `press`, `wait_for`, `wait`, and `expect_text`; terminal plans may use `run`,
 `wait`, and `expect_output`. Include at least one concrete expectation of real

--- a/test/run-node-tests.test.ts
+++ b/test/run-node-tests.test.ts
@@ -99,7 +99,7 @@ test("composed no-build scripts preserve standalone build contracts", () => {
   const scripts = packageJson.scripts as Record<string, string>;
 
   assert.match(scripts.test, /^pnpm run build:all && pnpm run test:no-build$/);
-  assert.match(scripts["test:repair"], /^pnpm run build:repair && pnpm run test:repair:no-build$/);
+  assert.match(scripts["test:repair"], /^pnpm run build:node && pnpm run test:repair:no-build$/);
   assert.match(scripts["test:coverage"], /^pnpm run build:all && pnpm run test:coverage:no-build$/);
   assert.match(
     scripts["test:coverage:changed"],


### PR DESCRIPTION
Closes #1229

## What Problem This Solves

`pnpm run test:repair`, the repo's own documented standalone test command, fails on a clean checkout before running a single test. Most files under `test/repair/` import `test/helpers.ts`, which imports `../dist/clawsweeper.js`, an output of the main build. `test:repair` only ran `build:repair` (`tsc -p tsconfig.repair.json`, which excludes `src/clawsweeper.ts` entirely), so on a fresh checkout with no prior build, `pnpm run test:repair` failed with `ERR_MODULE_NOT_FOUND` before loading nearly the entire repair suite, not just one file. This also produced a false negative in ClawSweeper's own live-verification of #1228, where the exact same error appeared on an unrelated, correct patch, because it hand-composed `pnpm run build:repair && node --test test/repair/target-validation.test.ts` instead of using the repo's own (broken) script.

## Why This Change Was Made

Two fixes, both recommended by ClawSweeper's review of #1229:

1. **`test:repair` script fix.** `build:node` (`pnpm run build && pnpm run build:repair`) already exists in `package.json` for exactly this defect class, added in #948 to fix two CI workflow jobs that invoked `dist/clawsweeper.js` directly without building it. That fix's own guard test (`test/repair/workflow-sparse-checkout.test.ts`) only audits GitHub Actions workflow job definitions for direct bundle invocations, not `package.json` scripts, so this call site slipped through as a distinct instance of the same underlying problem rather than being caught by that guard. This change points `test:repair` at the script that already does the right thing, and updates the existing contract test (`test/run-node-tests.test.ts`) that had locked in the old, broken composition.
2. **Review-prompt guidance fix.** `prompts/review-item.md`'s `liveProofPlan` instructions had no guidance steering a reviewer toward this repo's own defined scripts, so ClawSweeper's model reconstructed a build/test command from scratch and got it wrong in exactly the way (1) fixes. Added a sentence to that section: for terminal verification, prefer a repository-defined `pnpm run` script over hand-composing individual build/test commands when one already expresses the needed setup. This doesn't require the model to know this specific import-graph fact, it just needs to reach for an existing script instead of reinventing one.

## User Impact

Contributors and CI running `pnpm run test:repair` on a clean checkout now get a working test run instead of an immediate module-resolution crash. Future ClawSweeper live-verification passes on this repo are steered toward using existing correct scripts rather than re-deriving build sequencing per review, reducing the odds of the same false-negative class recurring on a different test file. No behavior change for anyone who already had a full `dist/` build present.

## OpenClaw Bay Impact

Not affected. This is a package script, its own contract test, and reviewer-prompt wording, not a lifecycle, queue, status/telemetry, or dashboard data-contract surface.

## Documentation Impact

None needed for `README.md`, its existing "Standalone `test`, `test:repair`, and coverage commands still build their required outputs" line already documents the intended contract; this change makes the code satisfy it. `prompts/review-item.md` itself is the documentation being updated as part of the fix.

## Evidence

**Real Behavior Proof**

Claim: `pnpm run test:repair` on a clean checkout (no prior build) builds and runs the repair test suite successfully instead of failing with `ERR_MODULE_NOT_FOUND` before any test loads.

Exercised surface: the `test:repair` script in `package.json`, its dependency on `test/helpers.ts` → `dist/clawsweeper.js`, and the `liveProofPlan` section of `prompts/review-item.md`.

Scenario/fixture: a fresh clone of `corvid-reads/clawsweeper` with `pnpm install` and no build step, before and after this patch.

Command and environment: local Node v26.7.0, pnpm 11.10.0.

Observed result:
- Before this patch (fresh clone, `build:repair` only): `pnpm run test:repair` throws `Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/clawsweeper.js' imported from .../test/helpers.ts`, failing to load nearly the entire repair suite.
- After this patch (fresh clone, `build:node`): `pnpm run test:repair` runs to completion, 1275 passing, 3 failing, 0 cancelled out of 1278. The 3 failures are pre-existing and unrelated: process-containment tests requiring kernel capabilities (delegated user namespaces, Landlock ABI 3+) not available in every environment, the same class of test the project's own Crabbox proof documentation already skips for the identical reason.
- Contract test: `test/run-node-tests.test.ts`'s `composed no-build scripts preserve standalone build contracts` test, updated to expect `build:node`, passes.
- `format:check`, `lint`, `build:node`: all clean.
- Full unit suite (`node scripts/run-node-tests.mjs unit`): 2405 passing, 1 failing, 1 skipped out of 2407, both runs (before and after this patch). The 1 failure is a pre-existing locale/number-formatting mismatch (`>2,000<` vs `>2 000<`), confirmed present identically on unmodified `upstream/main`, unrelated to this change.

Artifact/trace: command output captured directly above; no separate proof directory added, this is a small, directly reproducible before/after change.

Limits: the 3 containment-test failures and the 1 locale-test failure are both pre-existing environment limitations, confirmed unrelated to this change by reproducing them on unmodified `upstream/main`, not something this PR attempts to fix. The `prompts/review-item.md` change is a prompt-wording addition; its effect can only be observed in a future live ClawSweeper review, not exercised directly by a local test.
