### PR TITLE
feat(apply): requeue exact re-reviews for drift-blocked close proposals

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -6817,6 +6817,46 @@ jobs:
               -f codex_timeout_ms=1200000
           fi
 
+      - name: Requeue drift-blocked close reviews
+        if: ${{ always() && !cancelled() && steps.primary-apply-result.outputs.succeeded == 'true' && steps.target.outputs.target_repo == 'openclaw/openclaw' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${APPLY_NOOP:-false}" = "true" ] ||
+            [ "${APPLY_SYNC_COMMENTS_ONLY:-false}" = "true" ] ||
+            [ "${APPLY_AUTO_SELECTED_BATCH:-false}" != "true" ] ||
+            [ ! -f apply-report.json ]; then
+            echo "Not a default close-mode cursor run with a merged apply report; skipping drift requeue."
+            exit 0
+          fi
+          items="$(pnpm run --silent workflow -- apply-requeue-review-item-numbers --report apply-report.json --limit 5)"
+          if [ -z "$items" ]; then
+            echo "No source-drift or unverified-checkout close blocks to requeue."
+            exit 0
+          fi
+          target_branch="$(gh api "repos/${APPLY_TARGET_REPO}" --jq .default_branch)"
+          IFS=',' read -r -a requeue_items <<< "$items"
+          for item_number in "${requeue_items[@]}"; do
+            jq -n \
+              --arg target_repo "$APPLY_TARGET_REPO" \
+              --arg target_branch "$target_branch" \
+              --arg item_number "$item_number" \
+              '{
+                event_type: "clawsweeper_target_sweep",
+                client_payload: {
+                  target_repo: $target_repo,
+                  target_branch: $target_branch,
+                  item_number: $item_number,
+                  batch_size: "1",
+                  shard_count: "1",
+                  hot_intake: "false",
+                  codex_timeout_ms: "1200000"
+                }
+              }' | gh api --method POST "repos/${{ github.repository }}/dispatches" --input -
+            echo "::notice::Requeued exact review for ${APPLY_TARGET_REPO}#${item_number}: its close was blocked by source drift or an unverified-checkout review."
+          done
+
   publish-apply-observability:
     name: Publish apply telemetry
     needs: [apply-proof, publish-apply-proof-action-ledger, apply-existing]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Changed
 
+- Default close-mode apply runs now requeue up to five exact re-reviews for records whose close was blocked by source drift or an unverified-checkout review, so stale backlog records converge to closeable instead of being skipped by every cursor sweep.
 - Live verification now publishes a sanitized, capped dev-server log tail when browser startup fails, and detects a start command that exits before its URL becomes reachable without waiting for the readiness timeout.
 - Live verification now installs a missing target package manager on demand after execution is approved, publishes installer failures as verification results, and guides plans toward stable assertions the run can satisfy.
 - Live verification now runs immediately after review in the same job and exact reviewed checkout; review judgment gates execution, target children receive a denylist-and-heuristic-sanitized environment, package installs suppress lifecycle scripts unless a repository explicitly opts in, and review jobs default to `ubuntu-latest` without requiring Linux namespaces. Existing publication jobs still validate and upload media before publishing the normal record and comment.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -701,6 +701,15 @@ limits, live-state checks, or policy gates. Stalled-unproven and abandoned PR
 proposals are eligible for apply selection, where the executor re-checks their
 PR-only age, activity, proof, status, and human-engagement gates before closing.
 
+After a default close-mode cursor run for `openclaw/openclaw`, the apply job
+requeues up to five exact reviews for records whose close was blocked by
+source drift (`skipped_changed_since_review`) or by a stored review without
+verified local checkout access. Both blocks have the same cure: a fresh exact
+review re-verifies the close proposal at the current snapshot and writes a
+close-capable record, so the next apply pass can execute instead of skipping
+the same stale records every sweep. The per-run cap bounds review spend, and
+the exact-item queue's supersession semantics absorb repeat dispatches.
+
 Apply and comment-sync Actions run titles include the target repository. Before
 dispatching a default cursor-based apply continuation, the workflow checks
 recent active or queued same-target default cursor runs and treats one of those

--- a/src/repair/workflow-utils.ts
+++ b/src/repair/workflow-utils.ts
@@ -332,6 +332,11 @@ async function runCli(): Promise<void> {
     case "merge-apply-reports":
       mergeApplyReports(requiredString("dir"), requiredString("output"));
       break;
+    case "apply-requeue-review-item-numbers":
+      process.stdout.write(
+        applyRequeueReviewItemNumbers(requiredString("report"), numberArg("limit", 0)).join(","),
+      );
+      break;
     default:
       throw new Error(`unknown workflow utility command: ${command}`);
   }
@@ -552,6 +557,35 @@ export function artifactItemNumbers(artifactDir: string): number[] {
 export function countActions(reportPath: string, action: string): number {
   if (!action) return readApplyActions(reportPath).length;
   return readApplyActions(reportPath).filter((entry) => entry.action === action).length;
+}
+
+export const APPLY_REQUEUE_UNVERIFIED_CHECKOUT_REASON =
+  "review lacks verified local checkout access";
+
+// Close-mode apply cannot close a record whose source drifted since review or
+// whose stored review never verified local checkout access. Both blocks have
+// the same cure: a fresh exact review. Source-drift skips come first because
+// their close proposals are already confirmed and only need re-verification.
+export function applyRequeueReviewItemNumbers(reportPath: string, limit: number): number[] {
+  if (!Number.isInteger(limit) || limit <= 0) return [];
+  const actions = readApplyActions(reportPath);
+  const selected: number[] = [];
+  const seen = new Set<number>();
+  const push = (entry: ApplyAction): void => {
+    const number = entry.number;
+    if (number === undefined || seen.has(number) || selected.length >= limit) return;
+    seen.add(number);
+    selected.push(number);
+  };
+  for (const entry of actions) {
+    if (entry.action === "skipped_changed_since_review") push(entry);
+  }
+  for (const entry of actions) {
+    if (entry.action === "kept_open" && entry.reason === APPLY_REQUEUE_UNVERIFIED_CHECKOUT_REASON) {
+      push(entry);
+    }
+  }
+  return selected;
 }
 
 export function applyContinuationBlocker(

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -6680,3 +6680,79 @@ test("exact review publication enqueue accepts a superseded acknowledgement", ()
   assert.match(run, /jq -e '\.superseded == true'/);
   assert.match(run, /the newer publisher owns final delivery/);
 });
+
+test("apply drift requeue selects source-drift skips before unverified-checkout keeps", () => {
+  const root = mkdtempSync(tmpPrefix);
+  try {
+    const reportPath = join(root, "apply-report.json");
+    writeFileSync(
+      reportPath,
+      JSON.stringify([
+        { number: 101, action: "skipped_changed_since_review", reason: "updated_at changed" },
+        { number: 102, action: "kept_open", reason: "review lacks verified local checkout access" },
+        { number: 103, action: "kept_open", reason: "no close proposal" },
+        { number: 104, action: "skipped_changed_since_review", reason: "snapshot changed" },
+        { number: 101, action: "skipped_changed_since_review", reason: "updated_at changed" },
+        { number: 105, action: "kept_open", reason: "review lacks verified local checkout access" },
+        { number: 0, action: "skipped_runtime_budget", reason: "budget" },
+        { number: 106, action: "closed", reason: "implemented on main" },
+      ]),
+      "utf8",
+    );
+
+    const selected = execFileSync(
+      process.execPath,
+      [
+        "dist/repair/workflow-utils.js",
+        "apply-requeue-review-item-numbers",
+        "--report",
+        reportPath,
+        "--limit",
+        "3",
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(selected, "101,104,102");
+
+    const unlimited = execFileSync(
+      process.execPath,
+      [
+        "dist/repair/workflow-utils.js",
+        "apply-requeue-review-item-numbers",
+        "--report",
+        reportPath,
+        "--limit",
+        "10",
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(unlimited, "101,104,102,105");
+
+    const disabled = execFileSync(
+      process.execPath,
+      [
+        "dist/repair/workflow-utils.js",
+        "apply-requeue-review-item-numbers",
+        "--report",
+        reportPath,
+        "--limit",
+        "0",
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(disabled, "");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("apply job requeues drift-blocked close reviews only for default cursor runs", () => {
+  const workflow = readText(".github/workflows/sweep.yml");
+  const step = workflow.slice(workflow.indexOf("Requeue drift-blocked close reviews"));
+
+  assert.match(step, /apply-requeue-review-item-numbers --report apply-report\.json --limit 5/);
+  assert.match(step, /APPLY_SYNC_COMMENTS_ONLY:-false.*=.*"true"/s);
+  assert.match(step, /APPLY_AUTO_SELECTED_BATCH:-false.*!=.*"true"/s);
+  assert.match(step, /event_type: "clawsweeper_target_sweep"/);
+  assert.match(step, /shard_count: "1"/);
+});


### PR DESCRIPTION
## What Problem This Solves

Close-mode cursor sweeps close almost nothing from the standing backlog: successful apply runs on 2026-08-24 (e.g. runs 32690338216 and 32684664263) report `closed=0/40` on every checkpoint. The skip histogram from those runs shows two dominant vetoes: ~50% `skipped_changed_since_review` ("updated_at changed" — any third-party activity since the last review blocks the close until a fresh review confirms it) and ~35% `kept_open` with "review lacks verified local checkout access" (records whose stored review can never authorize a close). Old records accumulate drift faster than the weekly review cadence revisits them, so the same records are re-skipped by every sweep and the backlog only drains through the event-driven fresh-review path.

## Why This Change Was Made

Both vetoes have the same cure: a fresh exact review re-verifies the close proposal at the current snapshot and (since every modern review writes `local_checkout_access: verified`) produces a close-capable record. After each successful **default close-mode cursor run** for `openclaw/openclaw`, the apply job now dispatches up to five `clawsweeper_target_sweep` exact re-reviews for the blocked items — source-drift skips first, unverified-checkout keeps as filler — using the same repository-dispatch shape as the existing source-revision-drift requeue job.

Bounds and safety:

- At most 5 dispatches per run, only for successful, auto-selected (default cursor) close-mode runs — never comment-sync, explicit-item, or no-op runs.
- The exact-item planner's run-scoped concurrency group and the durable queue's supersession semantics absorb repeat dispatches for the same item.
- Review → proposal → apply gates are completely unchanged; this only refreshes the inputs the existing gates require.
- Selection logic lives in a tested `workflow` CLI subcommand (`apply-requeue-review-item-numbers`), consistent with the other apply-report helpers.

## Evidence

- New unit test: selection prefers drift skips, dedupes, respects the cap, returns empty at limit 0.
- New workflow-shape test: the step is gated to default cursor runs and dispatches `clawsweeper_target_sweep` with `shard_count: "1"`.
- 162/162 tests across `sweep-workflow`, `apply-live-state`, and `reconcile` suites; `pnpm run lint` and `pnpm run check:static` (docs check included) clean.
- Codex-backed autoreview on the rebased branch diff: clean, no accepted/actionable findings (`patch is correct`, 0.98).
