### PR TITLE
fix(live-proof): preserve successful terminal verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Terminal live verification preserves successful commands when a marker is not observed, reports that distinction truthfully, and still rejects real command failures and timeouts.
 - Replaced public Worker exception text with endpoint-owned error codes and bounded direct-publication rejection categories, preserving distinct operational fingerprints without exposing submitted values or stack traces.
 - Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.
 - Made terminal live-proof recording wait for Xvfb and ffmpeg readiness and clean finalization, with tmux pane diagnostics on failure.

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -128,10 +128,18 @@ existing comment-sync path upserts the marker-backed review comment.
 
 Browser comments contain sanitized per-step outcomes and a one-line failing-step
 reason, never page text. Terminal comments retain capped output and list
-assertions only when present. All untrusted fields are bounded and neutralized
-against Markdown fences, HTML, and ClawSweeper marker spoofing. OpenClaw Bay is
-unaffected: the durable report and comment contract is unchanged, and Bay remains
-an observer-only surface.
+assertions only when present. A terminal command with a confirmed successful exit
+still passes when its expected marker is absent from the captured pane; the
+assertion remains a completed, non-gating schema-v1 step, is explicitly labeled
+`NOT OBSERVED`, and cannot qualify a recording. Private command files and runner
+paths never enter published terminal output. Each entry or `run` action executes
+as a separately supervised Bash process in the same checkout, so plans should
+share state through files or one command rather than shell-local mutations.
+Nonzero exits, signals, command timeouts, and missing markers for still-running
+commands remain failures.
+All untrusted fields are bounded and neutralized against Markdown fences, HTML,
+and ClawSweeper marker spoofing. OpenClaw Bay is unaffected: the durable schema-v1
+passing-assertion invariant and observer ownership remain unchanged.
 
 ## Local simulation
 

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -885,11 +885,20 @@ function readTerminalPaneExitStatus(
     ],
     { cwd: checkout },
   );
-  if (result.status !== 0) return undefined;
-  const match = String(result.stdout ?? "")
-    .trim()
-    .match(/^([01]):(\d{0,3}):([A-Za-z0-9]*)$/);
-  if (!match || match[1] === "0") return undefined;
+  if (result.status !== 0) {
+    throw new Error(`tmux pane status probe failed: ${mediaProofSpawnDetail(result)}`);
+  }
+  const rawStatus = String(result.stdout ?? "").trim();
+  const match = rawStatus.match(/^([01]):(\d{0,3}):([A-Za-z0-9]*)$/);
+  if (!match) {
+    throw new Error(`tmux pane status probe returned invalid output: ${JSON.stringify(rawStatus)}`);
+  }
+  if (match[1] === "0") {
+    if (match[2] || match[3]) {
+      throw new Error(`tmux live pane unexpectedly reported an exit: ${JSON.stringify(rawStatus)}`);
+    }
+    return undefined;
+  }
   if (match[3]) {
     const numericSignal = /^\d+$/.test(match[3]) ? Number.parseInt(match[3], 10) : undefined;
     if (numericSignal !== undefined && numericSignal > 0 && numericSignal < 128) {

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -804,7 +804,22 @@ function runTerminalCommand(
       const failure = terminalCommandFailure(command, exitStatus, capturedOutput);
       throw new TerminalCommandExecutionError(failure.message, window);
     }
-    if (exitStatus === 0) return window;
+    if (exitStatus === 0) {
+      const settledStatus = observeTerminalCommandStatus(
+        runner,
+        checkout,
+        terminalSession,
+        window,
+        readCommandStatus,
+        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
+        true,
+      );
+      if (settledStatus !== undefined && settledStatus !== 0) {
+        const failure = terminalCommandFailure(command, settledStatus, window.output);
+        throw new TerminalCommandExecutionError(failure.message, window);
+      }
+      return window;
+    }
     if (capturedOutput.trim()) {
       // Output commonly precedes process exit; wait briefly for tmux to publish the
       // pane's final status before treating it as intentionally long-running.

--- a/src/live-proof/drivers.ts
+++ b/src/live-proof/drivers.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { constants as osConstants } from "node:os";
 import type {
   LiveProofBrowserStep,
   LiveProofPlan,
@@ -35,11 +36,15 @@ export interface LiveProofDriveResult {
 const DISPLAY_READY_TIMEOUT_SECONDS = 30;
 const RECORDER_READY_TIMEOUT_SECONDS = 15;
 const RECORDER_FINALIZE_TIMEOUT_SECONDS = 20;
-const TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS = 20;
+const TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS = 30;
 const TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS = 30;
+const TERMINAL_COMMAND_STATUS_GRACE_SECONDS = 2;
 const STEP_SETTLE_MILLISECONDS = 700;
 const END_STATE_HOLD_MILLISECONDS = 3_000;
 const MINIMUM_RECORDING_MILLISECONDS = 6_000;
+
+export const TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL =
+  "command exited successfully; expected output was not observed in the captured pane";
 
 type TerminalCommandInvocation = {
   command: string;
@@ -223,6 +228,10 @@ export function terminalCommandPlan(options: {
       command: "tmux",
       args: ["new-session", "-d", "-s", terminalSession, "-x", "160", "-y", "50"],
     },
+    {
+      command: "tmux",
+      args: ["set-option", "-w", "-t", `${terminalSession}:0`, "remain-on-exit", "on"],
+    },
   ];
   if (options.recordMedia === false) return commands;
   return [
@@ -321,6 +330,25 @@ export function terminalCommandPlan(options: {
 
 interface TerminalOutputWindow {
   echoSnapshot: string;
+  command: string;
+  commandPath: string;
+  output: string;
+}
+
+interface TerminalStepResult {
+  outputWindow: TerminalOutputWindow | undefined;
+  expectationSatisfied?: boolean;
+  detail?: string;
+}
+
+class TerminalCommandExecutionError extends Error {
+  constructor(
+    message: string,
+    readonly window: TerminalOutputWindow,
+  ) {
+    super(message);
+    this.name = "TerminalCommandExecutionError";
+  }
 }
 
 export function driveTerminal(options: {
@@ -330,6 +358,7 @@ export function driveTerminal(options: {
   maxRecordingSeconds: number;
   recordMedia?: boolean;
   runner: MediaProofCommandRunner;
+  readCommandStatus?: () => number | undefined;
 }): LiveProofDriveResult {
   const sessionPrefix = `clawsweeper-live-proof-${process.pid}`;
   const terminalSession = `${sessionPrefix}-terminal`;
@@ -344,6 +373,16 @@ export function driveTerminal(options: {
   let initialPaneSnapshot = "";
   let capturedOutput = "";
   const recordMedia = options.recordMedia !== false;
+  const commandPaths: string[] = [];
+  const commandWindows: TerminalOutputWindow[] = [];
+  const readCommandStatus =
+    options.readCommandStatus ??
+    (() => readTerminalPaneExitStatus(options.runner, options.checkout, terminalSession));
+  const nextCommandPath = () => {
+    const path = `${options.rawVideoPath}.command-${process.pid}-${commandPaths.length}`;
+    commandPaths.push(path);
+    return path;
+  };
   try {
     for (const invocation of terminalCommandPlan({
       sessionPrefix,
@@ -374,69 +413,121 @@ export function driveTerminal(options: {
         terminalSession,
         options.runner,
         options.checkout,
+        nextCommandPath(),
+        readCommandStatus,
       );
-    } catch {
+      commandWindows.push(outputWindow);
+    } catch (error) {
       failed = true;
+      if (error instanceof TerminalCommandExecutionError) {
+        outputWindow = error.window;
+        commandWindows.push(error.window);
+      }
+      capturedOutput = terminalPrivateErrorMessage(error, commandPaths);
     }
     if (!failed) {
       for (const step of options.plan.steps as LiveProofTerminalStep[]) {
         try {
-          outputWindow = runTerminalStep(
+          const result = runTerminalStep(
             step,
             terminalSession,
             options.runner,
             options.checkout,
             outputWindow,
+            nextCommandPath,
+            readCommandStatus,
           );
+          if (result.outputWindow && result.outputWindow !== outputWindow) {
+            commandWindows.push(result.outputWindow);
+          }
+          outputWindow = result.outputWindow;
           log.push(
             step.action === "expect_output"
               ? {
                   action: step.action,
                   status: "completed",
-                  detail: "ok",
+                  detail: result.detail ?? "ok",
                   presentAtStart: initialPaneSnapshot.includes(step.text),
-                  satisfied: true,
+                  satisfied: result.expectationSatisfied === true,
                 }
               : { action: step.action, status: "completed", detail: "ok" },
           );
         } catch (error) {
           failed = true;
+          if (error instanceof TerminalCommandExecutionError) {
+            outputWindow = error.window;
+            commandWindows.push(error.window);
+          }
           log.push(
             step.action === "expect_output"
               ? {
                   action: step.action,
                   status: "failed",
-                  detail: error instanceof Error ? error.message : String(error),
+                  detail: terminalPrivateErrorMessage(error, commandPaths),
                   presentAtStart: initialPaneSnapshot.includes(step.text),
                   satisfied: false,
                 }
               : {
                   action: step.action,
                   status: "failed",
-                  detail: error instanceof Error ? error.message : String(error),
+                  detail: terminalPrivateErrorMessage(error, commandPaths),
                 },
           );
           break;
         }
       }
     }
-    capturedOutput = captureTerminalPane(
-      options.runner,
-      options.checkout,
-      `${terminalSession}:0.0`,
-    );
+    if (outputWindow) {
+      captureCommandOutput(options.runner, options.checkout, terminalSession, outputWindow);
+    }
     if (recordMedia) {
       holdEndState(options.runner, recordingStartedAt);
       finalizeRecorder(options.runner, options.checkout, recorderSession);
       requireRecording(options.runner, options.checkout, options.rawVideoPath);
     }
+    if (outputWindow && !failed) {
+      captureCommandOutput(options.runner, options.checkout, terminalSession, outputWindow);
+      const exitStatus = observeTerminalCommandStatus(
+        options.runner,
+        options.checkout,
+        terminalSession,
+        outputWindow,
+        readCommandStatus,
+        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
+        true,
+      );
+      if (exitStatus !== undefined && exitStatus !== 0) {
+        failed = true;
+        const failure = terminalCommandFailure(
+          outputWindow.command,
+          exitStatus,
+          outputWindow.output,
+        );
+        const previousStep = log.at(-1);
+        if (previousStep) {
+          previousStep.status = "failed";
+          previousStep.detail = failure.message;
+          if (previousStep.action === "expect_output" || previousStep.action === "expect_text") {
+            previousStep.satisfied = false;
+          }
+        } else {
+          capturedOutput = failure.message;
+        }
+      }
+    }
+    const cleanOutput = commandWindows
+      .map((window) => window.output.trim())
+      .filter(Boolean)
+      .join("\n");
+    if (cleanOutput && (!failed || log.length > 0)) capturedOutput = cleanOutput;
   } catch (error) {
-    thrown = terminalErrorWithDiagnostics(error, options.runner, options.checkout, {
+    const diagnosticError = terminalErrorWithDiagnostics(error, options.runner, options.checkout, {
       terminal: terminalSession,
       display: displaySession,
       xterm: xtermSession,
       recorder: recorderSession,
     });
+    thrown = new Error(terminalPrivateErrorMessage(diagnosticError, commandPaths));
   } finally {
     if (recordMedia) {
       options.runner("tmux", ["kill-session", "-t", recorderSession]);
@@ -444,6 +535,9 @@ export function driveTerminal(options: {
       options.runner("tmux", ["kill-session", "-t", displaySession]);
     }
     options.runner("tmux", ["kill-session", "-t", terminalSession]);
+    for (const commandPath of commandPaths) {
+      rmSync(commandPath, { force: true });
+    }
   }
   if (thrown) throw thrown;
   return {
@@ -583,28 +677,89 @@ function runTerminalStep(
   runner: MediaProofCommandRunner,
   checkout: string,
   outputWindow: TerminalOutputWindow | undefined,
-): TerminalOutputWindow | undefined {
+  nextCommandPath: () => string,
+  readCommandStatus: () => number | undefined,
+): TerminalStepResult {
   if (step.action === "run") {
-    return runTerminalCommand(step.command, terminalSession, runner, checkout);
+    if (outputWindow) {
+      captureCommandOutput(runner, checkout, terminalSession, outputWindow);
+      const exitStatus = observeTerminalCommandStatus(
+        runner,
+        checkout,
+        terminalSession,
+        outputWindow,
+        readCommandStatus,
+        TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS,
+      );
+      if (exitStatus === undefined) {
+        throw new Error(
+          `previous terminal command was still running after ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(outputWindow.command)}`,
+        );
+      }
+      if (exitStatus !== 0) {
+        const failure = terminalCommandFailure(
+          outputWindow.command,
+          exitStatus,
+          outputWindow.output,
+        );
+        throw new Error(`terminal run was blocked by the previous command: ${failure.message}`);
+      }
+      rmSync(outputWindow.commandPath, { force: true });
+    }
+    return {
+      outputWindow: runTerminalCommand(
+        step.command,
+        terminalSession,
+        runner,
+        checkout,
+        nextCommandPath(),
+        readCommandStatus,
+      ),
+    };
   }
   if (step.action === "wait") {
     const seconds = String(step.seconds);
     requireSuccess("sleep", [seconds], runner("sleep", [seconds]));
-    return outputWindow;
+    return { outputWindow };
   }
   if (!outputWindow) {
     throw new Error("expected terminal output without a preceding command");
   }
-  const target = `${terminalSession}:0.0`;
-  let capturedPane = "";
+  let capturedOutput = "";
   for (let elapsed = 0; elapsed <= TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
-    capturedPane = captureTerminalPane(runner, checkout, target);
-    const output = paneContentAfterSnapshot(outputWindow.echoSnapshot, capturedPane);
-    if (output.includes(step.text)) return outputWindow;
+    capturedOutput = captureCommandOutput(runner, checkout, terminalSession, outputWindow);
+    const exitStatus = readCommandStatus();
+    if (exitStatus !== undefined && exitStatus !== 0) {
+      throw terminalCommandFailure(outputWindow.command, exitStatus, capturedOutput);
+    }
+    if (capturedOutput.includes(step.text)) return { outputWindow, expectationSatisfied: true };
+    if (exitStatus === 0) {
+      const settledStatus = observeTerminalCommandStatus(
+        runner,
+        checkout,
+        terminalSession,
+        outputWindow,
+        readCommandStatus,
+        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
+        true,
+      );
+      if (settledStatus !== undefined && settledStatus !== 0) {
+        throw terminalCommandFailure(outputWindow.command, settledStatus, outputWindow.output);
+      }
+      capturedOutput = outputWindow.output;
+      if (capturedOutput.includes(step.text)) {
+        return { outputWindow, expectationSatisfied: true };
+      }
+      return {
+        outputWindow,
+        expectationSatisfied: true,
+        detail: TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL,
+      };
+    }
     if (elapsed < TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS) pollSleep(runner);
   }
   throw new Error(
-    `expected terminal output was not visible within ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(step.text)}\n\nCaptured pane:\n${capturedPane || "<empty>"}`,
+    `expected terminal output was not visible within ${TERMINAL_EXPECT_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(step.text)}\n\nCaptured output:\n${capturedOutput || "<empty>"}`,
   );
 }
 
@@ -613,31 +768,158 @@ function runTerminalCommand(
   terminalSession: string,
   runner: MediaProofCommandRunner,
   checkout: string,
+  commandPath: string,
+  readCommandStatus: () => number | undefined,
 ): TerminalOutputWindow {
   const target = `${terminalSession}:0.0`;
-  captureTerminalPane(runner, checkout, target);
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  rmSync(commandPath, { force: true });
+  writeFileSync(commandPath, command.endsWith("\n") ? command : `${command}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  const clearHistoryArgs = ["clear-history", "-t", target];
+  requireSuccess("tmux", clearHistoryArgs, runner("tmux", clearHistoryArgs, { cwd: checkout }));
+  const commandRunner = `builtin printf '\\033[2J\\033[H'; exec /bin/bash --noprofile --norc "$1"`;
+  const shellCommand =
+    `/usr/bin/env -u TMUX -u TMUX_PANE /bin/bash --noprofile --norc -c ` +
+    `${quote(commandRunner)} clawsweeper ${quote(commandPath)}`;
   requireSuccess(
     "tmux",
-    ["send-keys", "-t", target, "-l", "--", command],
-    runner("tmux", ["send-keys", "-t", target, "-l", "--", command], { cwd: checkout }),
+    ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand],
+    runner("tmux", ["respawn-pane", "-k", "-t", target, "-c", checkout, shellCommand], {
+      cwd: checkout,
+    }),
   );
-  const echoSnapshot = captureTerminalPane(runner, checkout, target);
-  requireSuccess(
-    "tmux",
-    ["send-keys", "-t", target, "Enter"],
-    runner("tmux", ["send-keys", "-t", target, "Enter"], { cwd: checkout }),
-  );
-  let capturedPane = echoSnapshot;
+  const window: TerminalOutputWindow = {
+    echoSnapshot: "",
+    command,
+    commandPath,
+    output: "",
+  };
   for (let elapsed = 0; elapsed <= TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS; elapsed += 1) {
-    capturedPane = captureTerminalPane(runner, checkout, target);
-    if (paneContentAfterSnapshot(echoSnapshot, capturedPane).trim()) {
-      return { echoSnapshot };
+    const capturedOutput = captureCommandOutput(runner, checkout, terminalSession, window);
+    const exitStatus = readCommandStatus();
+    if (exitStatus !== undefined && exitStatus !== 0) {
+      const failure = terminalCommandFailure(command, exitStatus, capturedOutput);
+      throw new TerminalCommandExecutionError(failure.message, window);
+    }
+    if (exitStatus === 0) return window;
+    if (capturedOutput.trim()) {
+      // Output commonly precedes process exit; wait briefly for tmux to publish the
+      // pane's final status before treating it as intentionally long-running.
+      const observedStatus = observeTerminalCommandStatus(
+        runner,
+        checkout,
+        terminalSession,
+        window,
+        readCommandStatus,
+        TERMINAL_COMMAND_STATUS_GRACE_SECONDS,
+        true,
+      );
+      if (observedStatus !== undefined && observedStatus !== 0) {
+        const failure = terminalCommandFailure(command, observedStatus, window.output);
+        throw new TerminalCommandExecutionError(failure.message, window);
+      }
+      return window;
     }
     if (elapsed < TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS) pollSleep(runner);
   }
-  throw new Error(
-    `terminal command did not produce output within ${TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(command)}\n\nCaptured pane:\n${capturedPane || "<empty>"}`,
+  throw new TerminalCommandExecutionError(
+    `terminal command did not produce output or exit within ${TERMINAL_RUN_OUTPUT_TIMEOUT_SECONDS} seconds: ${JSON.stringify(command)}\n\nCaptured output:\n${window.output || "<empty>"}`,
+    window,
   );
+}
+
+function observeTerminalCommandStatus(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalSession: string,
+  window: TerminalOutputWindow,
+  readCommandStatus: () => number | undefined,
+  timeoutSeconds: number,
+  settleAfterSuccess = false,
+): number | undefined {
+  let exitStatus = readCommandStatus();
+  if (exitStatus !== undefined && (!settleAfterSuccess || exitStatus !== 0)) return exitStatus;
+  for (let elapsed = 0; elapsed < timeoutSeconds; elapsed += 1) {
+    pollSleep(runner);
+    captureCommandOutput(runner, checkout, terminalSession, window);
+    const observedStatus = readCommandStatus();
+    if (observedStatus !== undefined) {
+      exitStatus = observedStatus;
+      if (observedStatus !== 0 || !settleAfterSuccess) return observedStatus;
+    }
+  }
+  return exitStatus;
+}
+
+function captureCommandOutput(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalSession: string,
+  window: TerminalOutputWindow,
+): string {
+  const capturedPane = captureTerminalPane(runner, checkout, `${terminalSession}:0.0`);
+  window.output = capturedPane
+    .replaceAll(window.commandPath, "<private command>")
+    .split("\n")
+    .filter((line) => !/^Pane is dead \((?:status \d+|signal [^,]+),.+\)$/.test(line.trim()))
+    .join("\n");
+  return window.output;
+}
+
+function readTerminalPaneExitStatus(
+  runner: MediaProofCommandRunner,
+  checkout: string,
+  terminalSession: string,
+): number | undefined {
+  const result = runner(
+    "tmux",
+    [
+      "display-message",
+      "-p",
+      "-t",
+      `${terminalSession}:0.0`,
+      "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}",
+    ],
+    { cwd: checkout },
+  );
+  if (result.status !== 0) return undefined;
+  const match = String(result.stdout ?? "")
+    .trim()
+    .match(/^([01]):(\d{0,3}):([A-Za-z0-9]*)$/);
+  if (!match || match[1] === "0") return undefined;
+  if (match[3]) {
+    const numericSignal = /^\d+$/.test(match[3]) ? Number.parseInt(match[3], 10) : undefined;
+    if (numericSignal !== undefined && numericSignal > 0 && numericSignal < 128) {
+      return 128 + numericSignal;
+    }
+    const signal =
+      osConstants.signals[`SIG${match[3].toUpperCase()}` as keyof typeof osConstants.signals];
+    return 128 + (signal ?? 127);
+  }
+  if (!match[2]) return undefined;
+  const status = Number.parseInt(match[2], 10);
+  if (!Number.isSafeInteger(status) || status < 0 || status > 255) {
+    throw new Error(`terminal pane reported an invalid exit status: ${JSON.stringify(match[2])}`);
+  }
+  return status;
+}
+
+function terminalCommandFailure(command: string, status: number, capturedOutput: string): Error {
+  const detail = status === 124 ? "timed out" : status > 128 ? "terminated by a signal" : "failed";
+  return new Error(
+    `terminal command ${detail} with exit status ${status}: ${JSON.stringify(command)}\n\nCaptured output:\n${capturedOutput || "<empty>"}`,
+  );
+}
+
+function terminalPrivateErrorMessage(error: unknown, commandPaths: readonly string[]): string {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const commandPath of commandPaths) {
+    message = message.replaceAll(commandPath, "<private command>");
+  }
+  return message;
 }
 
 function captureTerminalPane(
@@ -649,20 +931,6 @@ function captureTerminalPane(
   const capture = runner("tmux", args, { cwd: checkout });
   requireSuccess("tmux", args, capture);
   return String(capture.stdout ?? "");
-}
-
-function paneContentAfterSnapshot(snapshot: string, current: string): string {
-  const before = snapshot.split("\n");
-  const after = current.split("\n");
-  let firstChangedLine = 0;
-  while (
-    firstChangedLine < before.length &&
-    firstChangedLine < after.length &&
-    before[firstChangedLine] === after[firstChangedLine]
-  ) {
-    firstChangedLine += 1;
-  }
-  return after.slice(firstChangedLine).join("\n");
 }
 
 function holdEndState(runner: MediaProofCommandRunner, recordingStartedAt: number): void {

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -21,6 +21,7 @@ import type { RepositoryProfile } from "../repository-profiles.js";
 import {
   driveBrowser,
   driveTerminal,
+  TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL,
   type LiveProofStepLogEntry,
   liveProofStepActions,
 } from "./drivers.js";
@@ -447,7 +448,8 @@ function demonstratedChange(steps: readonly LiveProofStepLogEntry[]): boolean {
     (step) =>
       (step.action === "expect_text" || step.action === "expect_output") &&
       !step.presentAtStart &&
-      step.satisfied,
+      step.satisfied &&
+      step.detail !== TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL,
   );
 }
 

--- a/src/live-proof/verification.ts
+++ b/src/live-proof/verification.ts
@@ -1,6 +1,6 @@
 import type { LiveProofPlan, LiveProofStep } from "../clawsweeper-types.js";
 import type { LiveProofDriveStatus } from "./manifest.js";
-import type { LiveProofStepLogEntry } from "./drivers.js";
+import { TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL, type LiveProofStepLogEntry } from "./drivers.js";
 
 export const LIVE_VERIFICATION_SCHEMA_VERSION = 1;
 export const LIVE_VERIFICATION_OUTPUT_MAX_CHARS = 16_000;
@@ -293,12 +293,31 @@ export function renderLiveVerificationCommentBlock(result: LiveVerificationResul
       "**Assertions:**",
       "",
       ...assertions.map((step) => {
-        const passed = step.status === "completed" && step.satisfied === true;
-        return `- ${passed ? "PASS" : "FAIL"} \`${sanitizeInline(step.action)}\`: ${sanitizeInline(step.assertion ?? "")}`;
+        const outcome =
+          step.status === "completed" && step.satisfied === true
+            ? terminalOutputWasNotObserved(parsed.surface, step)
+              ? "NOT OBSERVED"
+              : "PASS"
+            : "FAIL";
+        const detail = outcome === "NOT OBSERVED" ? ` — ${sanitizeInline(step.detail)}` : "";
+        return `- ${outcome} \`${sanitizeInline(step.action)}\`: ${sanitizeInline(step.assertion ?? "")}${detail}`;
       }),
     );
   }
   return lines.join("\n");
+}
+
+function terminalOutputWasNotObserved(
+  surface: LiveProofPlan["surface"],
+  step: LiveVerificationStepResult,
+): boolean {
+  return (
+    surface === "terminal" &&
+    step.action === "expect_output" &&
+    step.status === "completed" &&
+    step.satisfied === true &&
+    step.detail === TERMINAL_OUTPUT_NOT_OBSERVED_DETAIL
+  );
 }
 
 export function sanitizeUntrustedOutput(value: string): string {

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -767,6 +767,32 @@ test("terminal waits for tmux to publish a dead pane status", () => {
   assert.equal(result.steps[0]?.satisfied, true);
 });
 
+test("terminal status probe errors fail closed", () => {
+  for (const options of [
+    { terminalPaneProbeError: true },
+    { terminalPaneMalformed: "not-a-pane-status" },
+  ]) {
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: "demo",
+        steps: [{ action: "expect_output", text: "Ready" }],
+      },
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner: terminalLifecycleRunner([], {
+        ...options,
+        terminalCaptures: ["Ready\n"],
+      }),
+    });
+
+    assert.equal(result.status, "failed");
+    assert.match(result.output, /tmux pane status probe/);
+  }
+});
+
 test("terminal command failure after an observed marker is caught after the recording hold", () => {
   const calls: string[] = [];
   const result = driveTerminal({
@@ -2379,6 +2405,8 @@ function terminalLifecycleRunner(
     terminalPaneExitStatus?: number;
     terminalPaneSignal?: string;
     terminalPaneStates?: string[];
+    terminalPaneProbeError?: boolean;
+    terminalPaneMalformed?: string;
   } = {},
 ): MediaProofCommandRunner {
   let displayProbe = 0;
@@ -2424,6 +2452,12 @@ function terminalLifecycleRunner(
         target.includes("-terminal") &&
         args.at(-1) === "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}"
       ) {
+        if (options.terminalPaneProbeError) {
+          return { status: 1, stderr: "status probe failed" };
+        }
+        if (options.terminalPaneMalformed !== undefined) {
+          return { status: 0, stdout: `${options.terminalPaneMalformed}\n` };
+        }
         if (options.terminalPaneStates?.length) {
           const state =
             options.terminalPaneStates[

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -446,6 +446,10 @@ test("terminal driver composes direct Xvfb, xterm, and bounded ffmpeg sessions",
     command: "tmux",
     args: ["new-session", "-d", "-s", "proof-terminal", "-x", "160", "-y", "50"],
   });
+  assert.deepEqual(commands[1], {
+    command: "tmux",
+    args: ["set-option", "-w", "-t", "proof-terminal:0", "remain-on-exit", "on"],
+  });
   const display = commands.find((invocation) => invocation.args.includes("Xvfb"));
   const xterm = commands.find((invocation) => invocation.args.includes("xterm"));
   const recorder = commands.find((invocation) => invocation.args.includes("ffmpeg"));
@@ -513,11 +517,34 @@ test("terminal run waits for pane content beyond the echoed command", () => {
     }),
   );
   assert.equal(result.status, "completed");
-  const enter = calls.findIndex((call) => /tmux send-keys .* Enter$/.test(call));
-  const hold = calls.findIndex((call, index) => index > enter && call === "sleep 6");
-  assert.notEqual(enter, -1);
+  const respawn = calls.findIndex((call) => call.startsWith("tmux respawn-pane"));
+  const hold = calls.findIndex((call, index) => index > respawn && call === "sleep 6");
+  assert.notEqual(respawn, -1);
   assert.notEqual(hold, -1);
-  assert.equal(calls.slice(enter + 1, hold).filter((call) => call === "sleep 1").length, 2);
+  assert.equal(calls.slice(respawn + 1, hold).filter((call) => call === "sleep 1").length, 4);
+});
+
+test("terminal keeps silent commands eligible for the full expectation window", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => undefined,
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: [...Array.from({ length: 21 }, () => ""), "Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.satisfied, true);
+  assert.ok(calls.filter((call) => call === "sleep 1").length >= 21);
 });
 
 test("terminal expect_output polls until new command output appears", () => {
@@ -542,6 +569,27 @@ test("terminal expect_output polls until new command output appears", () => {
   assert.ok(calls.includes("sleep 1"));
 });
 
+test("terminal expect_output preserves leading and trailing marker whitespace", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "  indented result\n" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      commandExitStatus: 0,
+      terminalCaptures: ["  indented result\n"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.satisfied, true);
+});
+
 test("terminal expect_output records text already present in the plan-start snapshot", () => {
   const calls: string[] = [];
   const result = driveTerminal({
@@ -561,6 +609,464 @@ test("terminal expect_output records text already present in the plan-start snap
   assert.equal(result.status, "completed");
   assert.equal(result.steps[0]?.presentAtStart, true);
   assert.equal(result.steps[0]?.satisfied, true);
+});
+
+test("terminal command success is not overturned by an unobserved output marker", () => {
+  const calls: string[] = [];
+  let commandStatusProbes = 0;
+  const plan: LiveProofPlan = {
+    ...recommendedPlan("terminal"),
+    entry: "node scripts/run-vitest.mjs src/agents/code-mode.mcp.test.ts",
+    steps: [{ action: "expect_output", text: "Code Mode MCP namespace" }],
+  };
+  const result = driveTerminal({
+    plan,
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => (++commandStatusProbes >= 30 ? 0 : undefined),
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: [
+        "$ node scripts/run-vitest.mjs src/agents/code-mode.mcp.test.ts\nTests  10 passed (10)\nwrapper passed after 28.37 seconds\n",
+      ],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.status, "completed");
+  assert.equal(result.steps[0]?.satisfied, true);
+  assert.match(result.steps[0]?.detail ?? "", /not observed/);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 31);
+  assert.match(result.output, /Tests  10 passed \(10\)/);
+  assert.doesNotMatch(result.output, /\.command-\d+-\d+\.|printf '%s'|mv -f|\/tmp\//);
+
+  const verification = buildLiveVerificationResult({
+    repo: "example/repo",
+    item: 42,
+    headSha: HEAD,
+    plan,
+    driveStatus: result.status,
+    stepLog: result.steps,
+    output: result.output,
+    verifiedAt: "2026-08-23T12:00:00.000Z",
+  });
+  assert.equal(verification.overall_pass, true);
+  assert.equal(verification.steps[0]?.satisfied, true);
+  assert.deepEqual(parseLiveVerificationResult(verification), verification);
+  assert.throws(
+    () =>
+      parseLiveVerificationResult({
+        ...verification,
+        steps: [{ ...verification.steps[0], satisfied: false }],
+      }),
+    /overall_pass does not match/,
+  );
+  assert.match(renderLiveVerificationCommentBlock(verification), /\*\*Result:\*\* PASS/);
+  assert.match(
+    renderLiveVerificationCommentBlock(verification),
+    /NOT OBSERVED `expect_output`: Code Mode MCP namespace/,
+  );
+});
+
+test("terminal command timeout remains a failed output expectation", () => {
+  const calls: string[] = [];
+  let commandStatusProbes = 0;
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "timeout 5 demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => (++commandStatusProbes >= 6 ? 124 : undefined),
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: ["$ timeout 5 demo\nwaiting for the command\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.steps[0]?.status, "failed");
+  assert.equal(result.steps[0]?.satisfied, false);
+  assert.match(result.steps[0]?.detail ?? "", /timed out with exit status 124/);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 3);
+});
+
+test("terminal nonzero and signal exits fail even when the expected marker is present", () => {
+  for (const [exitStatus, reason] of [
+    [7, /failed with exit status 7/],
+    [143, /terminated by a signal with exit status 143/],
+  ] as const) {
+    let commandStatusProbes = 0;
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: "demo",
+        steps: [{ action: "expect_output", text: "Ready" }],
+      },
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      readCommandStatus: () => (++commandStatusProbes >= 5 ? exitStatus : undefined),
+      runner: terminalLifecycleRunner([], {
+        terminalCaptures: ["$ demo\nReady\n"],
+      }),
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.steps[0]?.status, "failed");
+    assert.match(result.steps[0]?.detail ?? "", reason);
+  }
+});
+
+test("terminal pane signals fail even when expected output is present", () => {
+  for (const signal of ["term", "15"]) {
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: "kill -TERM $$",
+        steps: [{ action: "expect_output", text: "Ready" }],
+      },
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner: terminalLifecycleRunner([], {
+        terminalPaneSignal: signal,
+        terminalCaptures: ["Ready\n"],
+      }),
+    });
+
+    assert.equal(result.status, "failed");
+    assert.match(result.output, /terminated by a signal with exit status 143/);
+  }
+});
+
+test("terminal waits for tmux to publish a dead pane status", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      terminalPaneStates: ["1::", "1:0:"],
+      terminalCaptures: ["Ready\n"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.satisfied, true);
+});
+
+test("terminal command failure after an observed marker is caught after the recording hold", () => {
+  const calls: string[] = [];
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    readCommandStatus: () => (calls.includes("sleep 6") ? 7 : undefined),
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: ["$ demo\nReady\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.steps[0]?.status, "failed");
+  assert.equal(result.steps[0]?.satisfied, false);
+  assert.match(result.steps[0]?.detail ?? "", /failed with exit status 7/);
+});
+
+test("terminal commands with no assertion or only a wait cannot hide a nonzero exit", () => {
+  for (const steps of [[], [{ action: "wait", seconds: 2 }]] as const) {
+    let commandStatusProbes = 0;
+    const result = driveTerminal({
+      plan: { ...recommendedPlan("terminal"), entry: "demo", steps: [...steps] },
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      readCommandStatus: () => (++commandStatusProbes >= 5 ? 143 : undefined),
+      runner: terminalLifecycleRunner([], {
+        terminalCaptures: ["$ demo\nworking\n"],
+      }),
+    });
+
+    assert.equal(result.status, "failed");
+    assert.match(
+      steps.length ? (result.steps[0]?.detail ?? "") : result.output,
+      /terminated by a signal with exit status 143/,
+    );
+  }
+});
+
+test("terminal post-output grace catches a prompt failure before cleanup", () => {
+  let commandStatusProbes = 0;
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "printf 'Ready\\n'; sleep 1; exit 7",
+      steps: [],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => (++commandStatusProbes >= 3 ? 7 : undefined),
+    runner: terminalLifecycleRunner([], {
+      terminalCaptures: ["$ printf 'Ready\\n'; sleep 1; exit 7\nReady\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /failed with exit status 7/);
+});
+
+test("terminal detects an active shell that exits before publishing prompt status", () => {
+  const result = driveTerminal({
+    plan: { ...recommendedPlan("terminal"), entry: "exit 7", steps: [] },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      terminalPaneExitStatus: 7,
+      terminalCaptures: ["$ exit 7\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /failed with exit status 7/);
+});
+
+test("terminal accepts a successful silent command", () => {
+  const result = driveTerminal({
+    plan: { ...recommendedPlan("terminal"), entry: "true", steps: [] },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      commandExitStatus: 0,
+      terminalCaptures: ["$ true\n"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.output, "");
+});
+
+test("terminal artifact errors redact private command paths", () => {
+  let commandPath = "";
+  const fixtureRunner = terminalLifecycleRunner([], {
+    terminalCaptures: ["$ demo\ncommand output\n"],
+  });
+  const runner: MediaProofCommandRunner = (tool, args, options) => {
+    if (tool === "tmux" && args[0] === "respawn-pane") {
+      commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1] ?? commandPath;
+    }
+    return fixtureRunner(tool, args, options);
+  };
+  const result = driveTerminal({
+    plan: { ...recommendedPlan("terminal"), entry: "demo", steps: [] },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => {
+      throw new Error(`EACCES: cannot read ${commandPath}`);
+    },
+    runner,
+  });
+
+  assert.equal(result.status, "failed");
+  assert.match(result.output, /<private command>/);
+  assert.doesNotMatch(result.output, /live-proof\.raw\.webm\.command-/);
+});
+
+test("terminal marker-present long-running commands remain successful without an exit status", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo-server",
+      steps: [{ action: "expect_output", text: "Ready" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => undefined,
+    runner: terminalLifecycleRunner([], {
+      terminalCaptures: ["$ demo-server\nReady\n"],
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.steps[0]?.satisfied, true);
+});
+
+test("terminal output aggregates clean evidence across the entry command and run steps", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "first-command",
+      steps: [
+        { action: "run", command: "second-command" },
+        { action: "expect_output", text: "second result" },
+      ],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([], {
+      commandExitStatus: 0,
+      terminalCapturesByCommand: {
+        "first-command": ["$ first-command\nfirst result\n"],
+        "second-command": ["$ second-command\nsecond result\n"],
+      },
+    }),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.output, "first result\nsecond result");
+  assert.doesNotMatch(result.output, /\.wrapper|\.command|\.status|\/tmp\//);
+});
+
+test("a previous terminal command failure blocks a following run step", () => {
+  const calls: string[] = [];
+  let commandStatusProbes = 0;
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "first-command",
+      steps: [{ action: "run", command: "second-command" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    readCommandStatus: () => (++commandStatusProbes >= 5 ? 7 : undefined),
+    runner: terminalLifecycleRunner(calls, {
+      terminalCaptures: ["$ first-command\nfirst result\n"],
+    }),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.steps[0]?.status, "failed");
+  assert.match(result.steps[0]?.detail ?? "", /blocked by the previous command/);
+  assert.match(result.steps[0]?.detail ?? "", /failed with exit status 7/);
+  assert.equal(calls.filter((call) => call.startsWith("tmux respawn-pane")).length, 1);
+});
+
+test("terminal commands preserve shell syntax in supervised command files", () => {
+  const cases = [
+    ["printf 'semicolon-ready\\n';", "semicolon-ready"],
+    ["printf 'background-ready\\n' &", "background-ready"],
+    ["printf 'comment-ready\\n' # keep the trailing comment", "comment-ready"],
+    ["cat <<'END_PROOF'\nheredoc-ready\nEND_PROOF", "heredoc-ready"],
+  ] as const;
+
+  for (const [command, expected] of cases) {
+    const supervisedCommands: string[] = [];
+    const fixtureRunner = terminalLifecycleRunner([], {
+      terminalCaptures: [`$ ${command}\n${expected}\n`],
+      commandExitStatus: 0,
+    });
+    const runner: MediaProofCommandRunner = (tool, args, options) => {
+      if (tool === "tmux" && args[0] === "respawn-pane") {
+        const commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1];
+        if (commandPath) supervisedCommands.push(readFileSync(commandPath, "utf8").trimEnd());
+      }
+      return fixtureRunner(tool, args, options);
+    };
+
+    const result = driveTerminal({
+      plan: {
+        ...recommendedPlan("terminal"),
+        entry: command,
+        steps: [{ action: "expect_output", text: expected }],
+      },
+      checkout: "/tmp/checkout",
+      rawVideoPath: "/tmp/live-proof.raw.webm",
+      maxRecordingSeconds: 90,
+      recordMedia: false,
+      runner,
+    });
+
+    assert.equal(result.status, "completed");
+    assert.deepEqual(supervisedCommands, [command]);
+    assert.match(result.output, new RegExp(expected));
+    assert.doesNotMatch(result.output, /\.command-|\/tmp\//);
+  }
+
+  const sequentialCalls: string[] = [];
+  const sequentialPaths: string[] = [];
+  const sequentialFixtureRunner = terminalLifecycleRunner(sequentialCalls, {
+    commandExitStatus: 0,
+    terminalCapturesByCommand: {
+      "printf 'first\\n'": ["first\n"],
+      "printf 'second\\n'": ["second\n"],
+    },
+  });
+  const sequentialRunner: MediaProofCommandRunner = (tool, args, options) => {
+    if (tool === "tmux" && args[0] === "respawn-pane") {
+      const commandPath = String(args.at(-1) ?? "").match(/'([^']+)'$/)?.[1];
+      if (sequentialPaths.length) assert.equal(existsSync(sequentialPaths.at(-1)!), false);
+      if (commandPath) sequentialPaths.push(commandPath);
+    }
+    return sequentialFixtureRunner(tool, args, options);
+  };
+  const sequential = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "printf 'first\\n'",
+      steps: [
+        { action: "run", command: "printf 'second\\n'" },
+        { action: "expect_output", text: "second" },
+      ],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: sequentialRunner,
+  });
+  assert.equal(sequential.status, "completed");
+  assert.equal(sequential.output, "first\nsecond");
+  assert.equal(sequentialCalls.filter((call) => call.startsWith("tmux respawn-pane")).length, 2);
+});
+
+test("terminal published output excludes private command paths", () => {
+  const result = driveTerminal({
+    plan: {
+      ...recommendedPlan("terminal"),
+      entry: "demo",
+      steps: [{ action: "expect_output", text: "command output" }],
+    },
+    checkout: "/tmp/checkout",
+    rawVideoPath: "/tmp/live-proof.raw.webm",
+    maxRecordingSeconds: 90,
+    recordMedia: false,
+    runner: terminalLifecycleRunner([]),
+  });
+
+  assert.equal(result.status, "completed");
+  assert.match(result.output, /command output/);
+  assert.doesNotMatch(result.output, /\.wrapper|\.command|\.status|printf|mv -f|\/tmp\//);
 });
 
 test("terminal expect_output times out without matching the echoed command", () => {
@@ -583,8 +1089,8 @@ test("terminal expect_output times out without matching the echoed command", () 
   assert.equal(result.steps[0]?.presentAtStart, false);
   assert.equal(result.steps[0]?.satisfied, false);
   assert.match(result.steps[0]?.detail ?? "", /within 30 seconds/);
-  assert.match(result.steps[0]?.detail ?? "", /Captured pane:\n\$ show expected-token/);
-  assert.equal(calls.filter((call) => call === "sleep 1").length, 30);
+  assert.match(result.steps[0]?.detail ?? "", /Captured output:\nworking/);
+  assert.equal(calls.filter((call) => call === "sleep 1").length, 32);
 });
 
 test("terminal recording holds the end state and enforces its minimum before finalizing", () => {
@@ -671,10 +1177,13 @@ test("terminal driver waits for the recorder session to exit after sending q", (
   const sentQ = calls.findIndex((call) => /tmux send-keys .* q$/.test(call));
   assert.notEqual(sentQ, -1);
   const finalizeCalls = calls.slice(sentQ + 1);
-  assert.equal(finalizeCalls.filter((call) => call === "sleep 1").length, 3);
+  assert.equal(finalizeCalls.filter((call) => call === "sleep 1").length, 5);
   assert.equal(
     finalizeCalls.filter(
-      (call) => call.includes("tmux display-message") && call.includes("pane_dead"),
+      (call) =>
+        call.includes("tmux display-message") &&
+        call.includes("-recorder") &&
+        call.includes("pane_dead"),
     ).length,
     4,
   );
@@ -811,6 +1320,72 @@ test("static-text terminal verification runs directly without recording tools", 
     false,
   );
   assert.match(logs.join("\n"), /verification bundle without media/);
+});
+
+test("an unobserved terminal marker cannot make a passing command eligible for recorded media", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "clawsweeper-live-unobserved-media-"));
+  const outputDir = join(directory, "output");
+  const planPath = join(directory, "plan.json");
+  const calls: string[] = [];
+  const logs: string[] = [];
+  const plan: LiveProofPlan = {
+    ...recommendedPlan("terminal"),
+    entry: "demo",
+    steps: [{ action: "expect_output", text: "missing-marker" }],
+  };
+  writeFileSync(planPath, JSON.stringify(plan), "utf8");
+  const terminalRunner = terminalLifecycleRunner(calls, {
+    commandExitStatus: 0,
+    terminalCaptures: ["$ demo\nall tests passed\n"],
+  });
+
+  await executeLiveProof(
+    {
+      repo: "example/repo",
+      item: 42,
+      outputDir,
+      planPath,
+      checkoutPath: directory,
+    },
+    {
+      env: { CLAWSWEEPER_LIVE_PROOF_ENABLED: "1" },
+      runner: (command, args, options) =>
+        command === "git"
+          ? { status: 0, stdout: `${HEAD}\n` }
+          : terminalRunner(command, args, options),
+      repositoryProfileFor: () => ({
+        ...profile(),
+        liveTest: {
+          enabled: true,
+          surfaceDefault: "terminal",
+          setup: [],
+          allowInstallScripts: false,
+          readyTimeoutSeconds: 5,
+          maxRecordingSeconds: 90,
+        },
+      }),
+      reportLiveProofPlan: () => plan,
+      parseLiveProofPlan: () => plan,
+      fetchPullRequest: async () => {
+        throw new Error("local checkout must not fetch the pull request");
+      },
+      log: (message) => logs.push(message),
+      now: () => new Date("2026-08-17T12:00:00.000Z"),
+    },
+  );
+
+  const verification = parseLiveVerificationResult(
+    JSON.parse(readFileSync(join(outputDir, "live-verification.json"), "utf8")) as unknown,
+  );
+  assert.equal(verification.overall_pass, true);
+  assert.equal(verification.steps[0]?.satisfied, true);
+  assert.match(verification.steps[0]?.detail ?? "", /not observed/);
+  assert.match(logs.join("\n"), /media skipped because no expectation changed/);
+  assert.equal(existsSync(join(outputDir, "live-proof-manifest.json")), false);
+  assert.equal(
+    calls.some((call) => call.startsWith("ffmpeg ")),
+    false,
+  );
 });
 
 test("execution setup failures still produce a failed verification result", async () => {
@@ -1799,11 +2374,17 @@ function terminalLifecycleRunner(
     paneOutput?: Record<"terminal" | "display" | "xterm" | "recorder", string>;
     initialTerminalOutput?: string;
     terminalCaptures?: string[];
+    terminalCapturesByCommand?: Record<string, string[]>;
+    commandExitStatus?: number;
+    terminalPaneExitStatus?: number;
+    terminalPaneSignal?: string;
+    terminalPaneStates?: string[];
   } = {},
 ): MediaProofCommandRunner {
   let displayProbe = 0;
   let recorderSizeProbe = 0;
   let recorderPaneProbe = 0;
+  let terminalPaneProbe = 0;
   let finalizeProbe = 0;
   let finalizing = false;
   let typedCommand = "";
@@ -1829,15 +2410,36 @@ function terminalLifecycleRunner(
       finalizing = true;
       return { status: 0 };
     }
-    if (command === "tmux" && args[0] === "send-keys" && args.includes("-l")) {
-      typedCommand = String(args.at(-1) ?? "");
-      return { status: 0 };
-    }
-    if (command === "tmux" && args[0] === "send-keys" && args.at(-1) === "Enter") {
+    if (command === "tmux" && args[0] === "respawn-pane") {
+      const shellCommand = String(args.at(-1) ?? "");
+      const commandPath = shellCommand.match(/'([^']+)'$/)?.[1];
+      typedCommand = commandPath ? readFileSync(commandPath, "utf8").trimEnd() : shellCommand;
       commandRunning = true;
+      terminalCaptureProbe = 0;
       return { status: 0 };
     }
     if (command === "tmux" && args[0] === "display-message") {
+      const target = String(args[args.indexOf("-t") + 1] ?? "");
+      if (
+        target.includes("-terminal") &&
+        args.at(-1) === "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}"
+      ) {
+        if (options.terminalPaneStates?.length) {
+          const state =
+            options.terminalPaneStates[
+              Math.min(terminalPaneProbe, options.terminalPaneStates.length - 1)
+            ] ?? "0::";
+          terminalPaneProbe += 1;
+          return { status: 0, stdout: `${state}\n` };
+        }
+        if (options.terminalPaneSignal) {
+          return { status: 0, stdout: `1::${options.terminalPaneSignal}\n` };
+        }
+        const exitStatus = options.terminalPaneExitStatus ?? options.commandExitStatus;
+        return exitStatus === undefined
+          ? { status: 0, stdout: "0::\n" }
+          : { status: 0, stdout: `1:${exitStatus}:\n` };
+      }
       if (finalizing) {
         const exited = finalizeProbe >= (options.finalizeExitAfter ?? 0);
         finalizeProbe += 1;
@@ -1857,14 +2459,13 @@ function terminalLifecycleRunner(
             ? "recorder"
             : "terminal";
       if (label === "terminal" && !options.paneOutput?.terminal) {
-        if (!typedCommand) {
-          return { status: 0, stdout: options.initialTerminalOutput ?? "$ \n" };
-        }
-        if (!commandRunning) return { status: 0, stdout: `$ ${typedCommand}\n` };
-        const captures = options.terminalCaptures ?? [`$ ${typedCommand}\ncommand output\n`];
+        if (!typedCommand) return { status: 0, stdout: options.initialTerminalOutput ?? "$ \n" };
+        if (!commandRunning) return { status: 0, stdout: "" };
+        const captures = options.terminalCapturesByCommand?.[typedCommand] ??
+          options.terminalCaptures ?? ["command output\n"];
         const output = captures[Math.min(terminalCaptureProbe, captures.length - 1)] ?? "";
         terminalCaptureProbe += 1;
-        return { status: 0, stdout: output };
+        return { status: 0, stdout: output.replace(/^\$ [^\n]*\n/, "") };
       }
       return { status: 0, stdout: `${options.paneOutput?.[label] ?? `${label} pane`}\n` };
     }


### PR DESCRIPTION
## Summary

Fix terminal live verification so a successful command is not reclassified as failed only because a requested marker was not visible in the captured pane.

- Run every terminal entry and `run` action as a tmux-supervised Bash process from an exact private command file.
- Treat tmux `pane_dead_status` and `pane_dead_signal` as the command completion authority, including transient status publication and fail-closed probe errors.
- Preserve the durable schema-v1 passing invariant while rendering a successful, absent marker as `NOT OBSERVED` and excluding it from recorded-proof eligibility.
- Keep nonzero exits, direct signals, exit 124 timeouts, still-running missing markers, malformed supervision state, and failed sequential commands as failures.
- Redact and promptly remove private command-file paths; aggregate clean output across ordered commands.

## Root cause

The 30-second `expect_output` loop owned only tmux pane visibility. It had no authoritative relationship to the command's completion status, so its timeout could override a command that had already completed successfully.

That happened in [ClawSweeper run 32405834950](https://github.com/openclaw/clawsweeper/actions/runs/32405834950): `node scripts/run-vitest.mjs src/agents/code-mode.mcp.test.ts` completed with 1 file and 10/10 tests passing, and the wrapper reported success after 28.37 seconds. The durable review comment nevertheless recorded a partial failure because `Code Mode MCP namespace` was not visible before the display wait expired: [openclaw/openclaw#126262 review](https://github.com/openclaw/openclaw/pull/126262#issuecomment-5340686462).

The fix moves completion ownership outside the measured shell. tmux now supervises the exact command process and reports its exit or signal independently of what appeared in the pane.

## Behavior proof

**Claim:** A terminal command that exits 0 remains a passing verification when its requested marker was not captured, while genuine failures and timeouts still fail.

**Exercised surface:** `src/live-proof/drivers.ts` through the real local tmux process boundary on current head `cb2128f8a1764041f80424dca09ddfc942161699`.

**Environment:** macOS, Node v24.19.0, tmux 3.7c, recording disabled.

**Scenarios and observable results:**

- Successful test-shaped command printed `Tests  10 passed (10)` and `wrapper passed after 28.37 seconds`; absent marker produced `completed` with `command exited successfully; expected output was not observed in the captured pane`.
- `timeout 1s ...` failed and was identified as exit status 124.
- `kill -TERM $$` failed and was identified as signal-derived exit status 143.
- Two ordered `run` actions completed with clean aggregated output `first\nsecond`.
- Focused regression suite: 73/73 passed.

**Trace:** The current-head JSON trace was captured session-locally and its complete scenario results are summarized above.

**Limits:** Local macOS proof, recording disabled, and synthetic commands matching the observed timing/result shape rather than rerunning the OpenClaw repository test itself.

## Validation

- `pnpm run check:static`
- `pnpm run build:all`
- `pnpm run lint`
- `node --test test/live-proof.test.ts` — 73 passed
- `node --test test/live-proof-review-environment.test.ts` — passed five consecutive reruns after the CI timing fix
- Current-head real tmux behavior proof described above
- Committed branch autoreview against `origin/main` — no accepted/actionable findings

A full `pnpm run check` was also attempted. Static checks, all builds, lint, the changed coverage gate, and 3,668 tests passed before 48 unrelated repair-fixture failures. Those fixtures construct temporary repositories where validation now reports `fatal: Not a valid object name origin/main`; 9 tests were skipped. The failures are outside the live-proof files changed here.

## Bay impact

OpenClaw Bay is unaffected. The durable live-verification schema remains version 1, and Bay remains an observer-only consumer.
