### PR TITLE
docs: propose material SQLite discussion checkpoint

### DIFF
--- a/config/documentation-site.json
+++ b/config/documentation-site.json
@@ -63,6 +63,11 @@
       "banner": "This is an unapproved proposal, not current operator guidance."
     },
     {
+      "path": "sqlite-change-policy-proposal.md",
+      "lifecycle": "proposed",
+      "banner": "This is an unapproved policy proposal; it grants no review, label, or merge authority."
+    },
+    {
       "path": "repair/containment-validation-todo.md",
       "lifecycle": "historical",
       "banner": "This is historical decision evidence, not current operator guidance."

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,8 @@ poster or WebP over accumulated before/after sets.
 - [Obsolescence policies](obsolescence-close-policies.md) — active policy map
 - [Unsponsored feature policy](unsponsored-feature-close-policy.md) — active
 - [Product direction policy](product-direction-close-policy.md) — active
+- [Material SQLite change discussion proposal](sqlite-change-policy-proposal.md)
+  — proposed; maintainer decision required before any enforcement
 - [Author PR budget policy](author-pr-budget-close-policy.md) — active
 - [Stalled PR policies](stalled-pr-close-policies.md) — active
 

--- a/docs/sqlite-change-policy-proposal.md
+++ b/docs/sqlite-change-policy-proposal.md
@@ -1,0 +1,80 @@
+# Material SQLite Change Discussion Proposal
+
+- Status: proposed; grants no execution or merge authority
+- Owner: OpenClaw maintainers for policy; ClawSweeper maintainers for any later advisory implementation
+- Source of truth: maintainer decision linked from [CSW-138](https://github.com/openclaw/clawsweeper/issues/1234)
+- Last verified: `openclaw/clawsweeper@ce250708c1ea10228f29fc5740cba95460dcdf74`
+- Update when: a maintainer accepts, rejects, or materially changes the proposal; or an approved implementation changes detection behavior
+
+This proposal defines a human discussion checkpoint for material SQLite and
+other durable-store changes in `openclaw/openclaw`. It is not current OpenClaw
+contributor policy, does not re-evaluate historical changes, and does not
+authorize ClawSweeper to block, label, close, or merge a pull request.
+
+## Proposed checkpoint
+
+Before maintainers consider a pull request for merge, its author would open or
+link a maintainer discussion when the pull request does any of the following:
+
+- adds a table, durable store, or persistent projection/cache that changes a
+  user-visible result;
+- adds an index with material write, read, or disk-space impact;
+- changes migration, downgrade or upgrade compatibility, backfill, repair,
+  retention, import/export, corruption handling, or recovery;
+- changes transactions, locking, writer ownership, reader consistency,
+  publication fencing, or cross-process lifecycle; or
+- changes what data is canonical or derived, retained or reconstructible, or
+  visible after restart.
+
+Several individually small changes also qualify when their combined data model
+or operational contract cannot be reviewed as an ordinary implementation
+detail.
+
+The discussion should record the owner and purpose, canonical-versus-derived
+classification, schema and compatibility plan, lifetime and retention, writer
+and reader contract, recovery behavior, performance budget, rollback plan, and
+the validation limits. It should also explain why an existing store is not the
+right owner.
+
+## Exclusions and exception route
+
+The checkpoint would not normally apply to a read-only query with unchanged
+semantics, a bounded query-plan improvement on an existing table, or generated
+types, schema baselines, tests, and documentation that only follow an already
+approved decision. A mechanical migration may cite the prior approval instead
+of reopening the design decision.
+
+For an urgent bug, security, or recovery fix, a maintainer could record a
+narrow exception containing the immediate risk, temporary scope, and required
+follow-up discussion. An exception is never inferred from urgency or from CI.
+
+## Proposed ClawSweeper role after approval
+
+If maintainers separately authorize implementation, ClawSweeper would only
+report high-confidence candidates. Candidate evidence may include changed SQL
+DDL, schema or migration files, Kysely/SQLite schema generation, and known
+durable-store entry points. A report would be advisory, non-blocking, and would
+state its evidence and confidence.
+
+The detector would suppress generated or schema-baseline-only changes when the
+functional change links an approval. It would permit a human `not material`
+disposition and recognize a recorded exception. It would not add labels,
+require a new label, alter merge authority, or treat a missing discussion as a
+defect in already-merged work.
+
+The existing `clawsweeper:needs-product-decision` and
+`clawsweeper:needs-maintainer-review` labels are the proposed human decision
+signals. This proposal does not create, apply, or automate either label.
+
+## Approval needed
+
+Before this page can become active policy or before any detector change starts:
+
+1. OpenClaw maintainers must confirm that the policy belongs in OpenClaw's
+   contributor/PR process.
+2. They must approve the material-change threshold and exception route.
+3. They must approve reuse of the existing decision labels rather than a broad
+   SQLite taxonomy label.
+4. They must separately authorize any ClawSweeper advisory implementation.
+
+Until all four decisions are recorded, normal review remains unchanged.


### PR DESCRIPTION
Closes https://github.com/openclaw/clawsweeper/issues/1234

## What Problem This Solves

OpenClaw needs an explicit, human-owned checkpoint before maintainers consider
material SQLite, schema, or persistent-store changes for merge. Without a
durable proposal, the boundary between routine storage maintenance and a new
persistence contract is difficult to discuss consistently.

## Why This Change Was Made

This draft records the CSW-138 policy proposal as a **proposed**, noncanonical
ClawSweeper documentation page and makes it discoverable from the documentation
index. It defines material triggers, exclusions, an exception route, and a
strictly advisory future role for ClawSweeper.

It does not change the persistent-data classifier, request review, add or
automate labels, change a workflow, alter merge authority, or re-evaluate any
historical OpenClaw PR. `openclaw/openclaw` maintainers remain the policy owner;
this page cannot become active policy or authorize detection until the four
listed approvals are recorded.

## User Impact

No current user, contributor, or automation behavior changes. Maintainers have
a concrete draft to approve, amend, or reject before any enforcement work is
started.

## Evidence

- `git diff --check` passed.
- `pnpm run check:docs` passed after staging the new page, validating Markdown
  links and the documentation lifecycle manifest.
- Codex pre-commit review: clean; no findings.
- Codex committed-range review against `origin/main`: clean; no findings.

## Risks and rollout

The only change is a noindex proposed documentation page. It grants no execute,
label, review, merge, or apply permission; OpenClaw Bay and production behavior
are unaffected.

## Proposed linked changes in `openclaw/openclaw`

After maintainers approve the policy threshold and exception route, a separate
docs-only OpenClaw PR should establish the canonical policy:

- `docs/reference/database-schemas.md`: add the complete material-change
  definition, required decision record, low-risk exclusions, and urgent
  bug/security/recovery exception route.
- `CONTRIBUTING.md`: add one concise **Before You PR** requirement to link the
  approved discussion for material SQLite or persistent-store changes.
- `AGENTS.md`: broaden the existing schema-version-bump discussion rule to
  cover material same-version additions such as new tables, projections,
  retention, concurrency, recovery, and user-visible persistence semantics,
  while linking to the canonical database-schema reference.

Do not initially change `.github/pull_request_template.md`; a repository-wide
checkbox would affect unrelated PRs and can be considered later if maintainers
want stronger visibility. The linked OpenClaw policy PR should not change
runtime code, schemas, labels, or `CHANGELOG.md`.

Once that OpenClaw policy lands, update this ClawSweeper proposal to cite the
canonical document. Any advisory detector remains a separate, explicitly
authorized implementation PR with its own false-positive controls, tests, and
behavior proof.

## Approval needed before any follow-up

1. Confirm that the policy belongs in the `openclaw/openclaw` contributor/PR
   process.
2. Approve the material-change threshold and exception route.
3. Approve use of the existing `clawsweeper:needs-product-decision` and
   `clawsweeper:needs-maintainer-review` labels without adding a broad SQLite
   label.
4. Separately authorize any advisory-only ClawSweeper detection implementation.
