### PR TITLE
fix(dashboard): normalize exact-review queue failures

### DIFF
--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -799,6 +799,14 @@ export class ExactReviewQueue {
   }
 
   async fetch(request: Request) {
+    try {
+      return await this.handleFetchRequest(request);
+    } catch (error) {
+      return json({ error: sanitizedServerError(error) }, 500);
+    }
+  }
+
+  private async handleFetchRequest(request: Request) {
     const url = new URL(request.url);
     // This is deliberately the only route that may observe lifecycle rows
     // before full queue initialization. Its constructor-managed schema barrier

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -799,14 +799,6 @@ export class ExactReviewQueue {
   }
 
   async fetch(request: Request) {
-    try {
-      return await this.handleFetchRequest(request);
-    } catch (error) {
-      return json({ error: sanitizedServerError(error) }, 500);
-    }
-  }
-
-  private async handleFetchRequest(request: Request) {
     const url = new URL(request.url);
     // This is deliberately the only route that may observe lifecycle rows
     // before full queue initialization. Its constructor-managed schema barrier

--- a/dashboard/worker.ts
+++ b/dashboard/worker.ts
@@ -28,6 +28,7 @@ import {
   githubAppJsonAsPlainError as githubAppJson,
   signGithubAppJwt,
 } from "./github-api.ts";
+import { sanitizedServerError } from "./error-safety.ts";
 import {
   HEALTH_HISTORY_RETENTION_DAYS,
   HEALTH_HISTORY_SAMPLE_MS,
@@ -4422,13 +4423,25 @@ async function exactReviewQueueRequest(env, path, request?: Request) {
   const queue = exactReviewQueueStub(env);
   if (!queue) return json({ error: "exact_review_queue_not_configured" }, 503);
   const body = request ? await request.text() : undefined;
-  return queue.fetch(
-    new Request(`https://clawsweeper-exact-review-queue${path}`, {
-      method: request?.method || "GET",
-      headers: body ? { "content-type": "application/json" } : undefined,
-      ...(body ? { body } : {}),
-    }),
-  );
+  try {
+    const response = await queue.fetch(
+      new Request(`https://clawsweeper-exact-review-queue${path}`, {
+        method: request?.method || "GET",
+        headers: body ? { "content-type": "application/json" } : undefined,
+        ...(body ? { body } : {}),
+      }),
+    );
+    if (response.status < 500) return response;
+    const responseBody = await response.clone().text();
+    try {
+      JSON.parse(responseBody);
+      return response;
+    } catch {
+      return json({ error: sanitizedServerError(responseBody) }, response.status);
+    }
+  } catch (error) {
+    return json({ error: sanitizedServerError(error) }, 500);
+  }
 }
 
 const PUBLIC_QUEUE_COUNT_LIMIT = 1_000_000;

--- a/docs/proof/exact-review-do-json-errors/README.md
+++ b/docs/proof/exact-review-do-json-errors/README.md
@@ -1,0 +1,43 @@
+# Exact-review Durable Object sanitized JSON error proof
+
+This proof starts the actual local Wrangler Worker and its ExactReviewQueue
+Durable Object, then drives the signed internal
+`/internal/exact-review/publications/list` route through the real Workers
+Durable Object boundary. A proof-only entry module re-exports the production
+`ExactReviewQueue` with its real SQLite `storage.sql.exec` wrapped so one
+marked request fails the `SELECT item_key, item_json` state read with an
+error message carrying a planted GitHub token. The production route code,
+worker forwarding, HMAC verification, storage initialization, and every other
+request run unmodified.
+
+The scenario sends three identical-shape signed requests: a baseline list
+(expect 200), the marked failing request, and a recovery list (expect 200).
+The script detects whether the checked-out tree contains the fix and asserts
+accordingly:
+
+- before (base tree): the injected failure escapes the unguarded Durable
+  Object `fetch`, and the client receives a non-JSON 500 with no sanitized
+  error contract; in the local dev runtime the error page also exposes the
+  planted token to the client.
+- after (fixed tree): the client receives HTTP 500 with
+  `content-type: application/json` and body
+  `{"error":"injected sqlite read failure exposing GH_TOKEN=[REDACTED]"}`;
+  the planted token never reaches the client.
+
+Run from the repository root of the tree under test:
+
+```bash
+crabbox run \
+  --provider local-container \
+  --local-container-image node:24-bookworm \
+  --no-hydrate \
+  --timing-json \
+  --script docs/proof/exact-review-do-json-errors/run-proof.sh \
+  --require-artifact '.artifacts/exact-review-do-json-errors/proof-summary.json' \
+  --artifact-glob '.artifacts/exact-review-do-json-errors/**'
+```
+
+Limits: the before-mode HTML error page is the local dev runtime's rendering
+of the escaped exception; deployed workerd returns its generic internal-error
+response instead. The invariant proven is the failure contract at the Durable
+Object boundary: unguarded escape versus sanitized JSON 500.

--- a/docs/proof/exact-review-do-json-errors/README.md
+++ b/docs/proof/exact-review-do-json-errors/README.md
@@ -1,4 +1,4 @@
-# Exact-review Durable Object sanitized JSON error proof
+# Exact-review Worker sanitized JSON error proof
 
 This proof starts the actual local Wrangler Worker and its ExactReviewQueue
 Durable Object, then drives the signed internal
@@ -15,11 +15,13 @@ The scenario sends three identical-shape signed requests: a baseline list
 The script detects whether the checked-out tree contains the fix and asserts
 accordingly:
 
-- before (base tree): the injected failure escapes the unguarded Durable
-  Object `fetch`, and the client receives a non-JSON 500 with no sanitized
-  error contract; in the local dev runtime the error page also exposes the
-  planted token to the client.
-- after (fixed tree): the client receives HTTP 500 with
+- before (base tree): the injected Durable Object failure escapes the Worker,
+  and the client receives a non-JSON 500 with no sanitized error contract; in
+  the local dev runtime the error page also exposes the planted token to the
+  client.
+- after (fixed tree): the Durable Object still rejects so its transaction
+  remains fail closed, while the Worker converts that rejected stub call into
+  HTTP 500 with
   `content-type: application/json` and body
   `{"error":"injected sqlite read failure exposing GH_TOKEN=[REDACTED]"}`;
   the planted token never reaches the client.
@@ -39,5 +41,6 @@ crabbox run \
 
 Limits: the before-mode HTML error page is the local dev runtime's rendering
 of the escaped exception; deployed workerd returns its generic internal-error
-response instead. The invariant proven is the failure contract at the Durable
-Object boundary: unguarded escape versus sanitized JSON 500.
+response instead. The invariant proven is the Worker-facing failure contract:
+an escaped Durable Object rejection becomes a sanitized JSON 500 without
+changing the Durable Object transaction boundary.

--- a/docs/proof/exact-review-do-json-errors/run-proof.sh
+++ b/docs/proof/exact-review-do-json-errors/run-proof.sh
@@ -19,7 +19,7 @@ if [ -e "$output_dir" ]; then
 fi
 mkdir -p "$output_dir"
 
-if grep -q "handleFetchRequest" dashboard/exact-review-queue.ts; then
+if grep -q 'sanitizedServerError(responseBody)' dashboard/worker.ts; then
   proof_mode=after
 else
   proof_mode=before
@@ -191,7 +191,9 @@ if (mode === "before") {
     token_leaked: tokenLeaked,
   });
 } else {
-  assertProof("sanitized_json_contract", jsonContract, { content_type: failing.contentType });
+  assertProof("worker_sanitized_json_contract", jsonContract, {
+    content_type: failing.contentType,
+  });
   assertProof("planted_token_redacted", !tokenLeaked && failing.text.includes("[REDACTED"), {
     response_body: redact(failing.text).slice(0, 300),
   });
@@ -218,7 +220,7 @@ await writeFile(
 await writeFile(
   path.join(outputDir, "transcript.md"),
   [
-    "# exact-review Durable Object JSON error proof",
+    "# exact-review Worker JSON error proof",
     `mode: ${mode}`,
     `head: ${headSha}`,
     "",

--- a/docs/proof/exact-review-do-json-errors/run-proof.sh
+++ b/docs/proof/exact-review-do-json-errors/run-proof.sh
@@ -13,6 +13,21 @@ wrangler_log="$runtime_dir/wrangler.log"
 proof_entry="dashboard/proof-entry-do-error.ts"
 proof_config="dashboard/wrangler.proof.toml"
 
+if [ -e "$proof_entry" ] || [ -e "$proof_config" ]; then
+  echo "Refusing to overwrite existing proof injection files" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [ -n "${wrangler_pid:-}" ]; then
+    kill "$wrangler_pid" >/dev/null 2>&1 || true
+    wait "$wrangler_pid" >/dev/null 2>&1 || true
+  fi
+  rm -f "$proof_entry" "$proof_config"
+  rm -rf "$runtime_dir"
+}
+trap cleanup EXIT
+
 if [ -e "$output_dir" ]; then
   echo "Refusing to overwrite existing proof output: $output_dir" >&2
   exit 1
@@ -240,16 +255,6 @@ await writeFile(
 );
 console.log(JSON.stringify({ mode, head: headSha, assertions }, null, 2));
 PROOF_DRIVER
-
-cleanup() {
-  if [ -n "${wrangler_pid:-}" ]; then
-    kill "$wrangler_pid" >/dev/null 2>&1 || true
-    wait "$wrangler_pid" >/dev/null 2>&1 || true
-  fi
-  rm -f "$proof_entry" "$proof_config"
-  rm -rf "$runtime_dir"
-}
-trap cleanup EXIT
 
 if [ "${EXACT_REVIEW_DO_PROOF_SKIP_INSTALL:-0}" != "1" ]; then
   corepack pnpm install --frozen-lockfile

--- a/docs/proof/exact-review-do-json-errors/run-proof.sh
+++ b/docs/proof/exact-review-do-json-errors/run-proof.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=1
+export WRANGLER_SEND_METRICS=false
+
+root_dir=$PWD
+output_dir="${EXACT_REVIEW_DO_PROOF_OUTPUT:-.artifacts/exact-review-do-json-errors}"
+port="${EXACT_REVIEW_DO_PROOF_PORT:-8794}"
+runtime_dir=$(mktemp -d "${TMPDIR:-/tmp}/clawsweeper-do-json-errors.XXXXXX")
+vars_file="$runtime_dir/.dev.vars"
+wrangler_log="$runtime_dir/wrangler.log"
+proof_entry="dashboard/proof-entry-do-error.ts"
+proof_config="dashboard/wrangler.proof.toml"
+
+if [ -e "$output_dir" ]; then
+  echo "Refusing to overwrite existing proof output: $output_dir" >&2
+  exit 1
+fi
+mkdir -p "$output_dir"
+
+if grep -q "handleFetchRequest" dashboard/exact-review-queue.ts; then
+  proof_mode=after
+else
+  proof_mode=before
+fi
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo unknown)
+
+secret=$(node --input-type=module -e 'import { randomBytes } from "node:crypto"; process.stdout.write(randomBytes(32).toString("hex"));')
+umask 077
+printf '%s\n' \
+  "CLAWSWEEPER_WEBHOOK_SECRET=$secret" \
+  "INGEST_TOKEN=$secret" \
+  "GITHUB_API_URL=http://127.0.0.1:9" \
+  "CACHE_TTL_SECONDS=0" \
+  "STALE_CACHE_TTL_SECONDS=0" \
+  "INCLUDE_CI_STATUS=0" \
+  "EXACT_REVIEW_DISPATCH_DEBOUNCE_MS=900000" \
+  "EXACT_REVIEW_DISPATCH_DEBOUNCE_MAX_MS=900000" \
+  >"$vars_file"
+
+cat >"$proof_entry" <<'PROOF_ENTRY'
+import baseWorker, {
+  StatusStore as WorkerStatusStore,
+  ExactReviewQueue as BaseExactReviewQueue,
+} from "./worker.ts";
+
+const PROOF_FAILURE_MESSAGE =
+  "injected sqlite read failure exposing GH_TOKEN=ghp_examplesecrettoken0123456789abcd";
+
+function bindingProxy(target: any, overrides: Record<PropertyKey, unknown>) {
+  return new Proxy(target, {
+    get(source, property) {
+      if (Object.prototype.hasOwnProperty.call(overrides, property)) return overrides[property];
+      const value = source[property];
+      return typeof value === "function" ? value.bind(source) : value;
+    },
+  });
+}
+
+export class ExactReviewQueue extends BaseExactReviewQueue {
+  constructor(state: any, env: any) {
+    let armedPattern: RegExp | null = null;
+    const realStorage = state.storage;
+    const sqlProxy = bindingProxy(realStorage.sql, {
+      exec: (query: string, ...args: unknown[]) => {
+        if (armedPattern && armedPattern.test(String(query))) {
+          armedPattern = null;
+          throw new Error(PROOF_FAILURE_MESSAGE);
+        }
+        return realStorage.sql.exec(query, ...args);
+      },
+    });
+    const storageProxy = bindingProxy(realStorage, { sql: sqlProxy });
+    const stateProxy = bindingProxy(state, { storage: storageProxy });
+    super(stateProxy, env);
+    Object.defineProperty(this, "armProofSqlFailure", {
+      value: (pattern: RegExp) => {
+        armedPattern = pattern;
+      },
+    });
+  }
+
+  async fetch(request: Request) {
+    if (request.method !== "POST") return super.fetch(request);
+    const bodyText = await request.text();
+    let marker: unknown = null;
+    try {
+      marker = (JSON.parse(bodyText) as { proof_fail_sql?: unknown }).proof_fail_sql;
+    } catch {
+      marker = null;
+    }
+    if (typeof marker === "string" && marker) {
+      (this as { armProofSqlFailure?: (pattern: RegExp) => void }).armProofSqlFailure?.(
+        new RegExp(marker),
+      );
+    }
+    return super.fetch(
+      new Request(request.url, { method: "POST", headers: request.headers, body: bodyText }),
+    );
+  }
+}
+
+export { WorkerStatusStore as StatusStore };
+export default baseWorker;
+PROOF_ENTRY
+
+sed 's|^main = "worker.ts"$|main = "proof-entry-do-error.ts"|' dashboard/wrangler.toml >"$proof_config"
+grep -q 'proof-entry-do-error.ts' "$proof_config"
+
+driver="$runtime_dir/drive-proof.mjs"
+cat >"$driver" <<'PROOF_DRIVER'
+import { createHmac } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const origin = String(process.env.EXACT_REVIEW_DO_PROOF_ORIGIN || "").replace(/\/+$/, "");
+const secret = String(process.env.EXACT_REVIEW_DO_PROOF_SECRET || "");
+const outputDir = path.resolve(
+  process.env.EXACT_REVIEW_DO_PROOF_OUTPUT || ".artifacts/exact-review-do-json-errors",
+);
+const mode = process.env.EXACT_REVIEW_DO_PROOF_MODE === "before" ? "before" : "after";
+const headSha = String(process.env.EXACT_REVIEW_DO_PROOF_HEAD || "unknown");
+if (!origin || !secret) throw new Error("proof origin and secret are required");
+
+const plantedToken = "ghp_examplesecrettoken0123456789abcd";
+const routePath = "/internal/exact-review/publications/list";
+const assertions = [];
+const transcript = [];
+
+function assertProof(name, condition, details = {}) {
+  if (!condition) throw new Error(`Proof assertion failed: ${name} ${JSON.stringify(details)}`);
+  assertions.push({ name, status: "PASS", ...details });
+}
+
+function redact(value) {
+  return String(value).split(plantedToken).join("ghp_[PLANTED_TOKEN_REDACTED]");
+}
+
+async function signedPost(label, value) {
+  const body = JSON.stringify(value);
+  const signature = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+  const response = await fetch(`${origin}${routePath}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": signature,
+    },
+    body,
+  });
+  const text = await response.text();
+  transcript.push({
+    label,
+    request_body: body,
+    status: response.status,
+    content_type: response.headers.get("content-type") || "",
+    response_body: redact(text),
+  });
+  return { status: response.status, contentType: response.headers.get("content-type") || "", text };
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const baseline = await signedPost("baseline-list", { limit: 100 });
+assertProof("baseline_list_ok", baseline.status === 200, { http_status: baseline.status });
+
+const failing = await signedPost("injected-storage-failure", {
+  limit: 100,
+  proof_fail_sql: "SELECT item_key, item_json",
+});
+
+const recovery = await signedPost("recovery-list", { limit: 100 });
+assertProof("recovery_list_ok", recovery.status === 200, { http_status: recovery.status });
+
+let parsedFailing = null;
+try {
+  parsedFailing = JSON.parse(failing.text);
+} catch {
+  parsedFailing = null;
+}
+const jsonContract =
+  failing.contentType.includes("application/json") &&
+  parsedFailing !== null &&
+  typeof parsedFailing.error === "string";
+const tokenLeaked = failing.text.includes(plantedToken);
+
+assertProof("failure_status_500", failing.status === 500, { http_status: failing.status });
+if (mode === "before") {
+  assertProof("broken_failure_contract_on_base", !jsonContract || tokenLeaked, {
+    json_contract: jsonContract,
+    token_leaked: tokenLeaked,
+  });
+} else {
+  assertProof("sanitized_json_contract", jsonContract, { content_type: failing.contentType });
+  assertProof("planted_token_redacted", !tokenLeaked && failing.text.includes("[REDACTED"), {
+    response_body: redact(failing.text).slice(0, 300),
+  });
+}
+
+const summary = {
+  mode,
+  head_sha: headSha,
+  route: routePath,
+  planted_token: "ghp_[PLANTED_TOKEN_REDACTED]",
+  failure_response: {
+    status: failing.status,
+    content_type: failing.contentType,
+    body: redact(failing.text).slice(0, 2000),
+    json_contract: jsonContract,
+    token_leaked: tokenLeaked,
+  },
+  assertions,
+};
+await writeFile(
+  path.join(outputDir, "proof-summary.json"),
+  `${JSON.stringify(summary, null, 2)}\n`,
+);
+await writeFile(
+  path.join(outputDir, "transcript.md"),
+  [
+    "# exact-review Durable Object JSON error proof",
+    `mode: ${mode}`,
+    `head: ${headSha}`,
+    "",
+    ...transcript.map((entry) =>
+      [
+        `## ${entry.label}`,
+        "```",
+        `POST ${routePath}`,
+        entry.request_body,
+        `-> ${entry.status} ${entry.content_type}`,
+        entry.response_body,
+        "```",
+        "",
+      ].join("\n"),
+    ),
+  ].join("\n"),
+);
+console.log(JSON.stringify({ mode, head: headSha, assertions }, null, 2));
+PROOF_DRIVER
+
+cleanup() {
+  if [ -n "${wrangler_pid:-}" ]; then
+    kill "$wrangler_pid" >/dev/null 2>&1 || true
+    wait "$wrangler_pid" >/dev/null 2>&1 || true
+  fi
+  rm -f "$proof_entry" "$proof_config"
+  rm -rf "$runtime_dir"
+}
+trap cleanup EXIT
+
+if [ "${EXACT_REVIEW_DO_PROOF_SKIP_INSTALL:-0}" != "1" ]; then
+  corepack pnpm install --frozen-lockfile
+fi
+npx --yes wrangler@4.107.0 dev --config "$proof_config" --local --ip 127.0.0.1 --port "$port" --env-file "$vars_file" --persist-to "$runtime_dir/state" >"$wrangler_log" 2>&1 &
+wrangler_pid=$!
+
+for _ in $(seq 1 120); do
+  if curl --fail --silent "http://127.0.0.1:${port}/api/health" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$wrangler_pid" >/dev/null 2>&1; then
+    tail -n 100 "$wrangler_log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+curl --fail --silent --show-error "http://127.0.0.1:${port}/api/health" >/dev/null
+EXACT_REVIEW_DO_PROOF_ORIGIN="http://127.0.0.1:${port}" \
+  EXACT_REVIEW_DO_PROOF_SECRET="$secret" \
+  EXACT_REVIEW_DO_PROOF_OUTPUT="$output_dir" \
+  EXACT_REVIEW_DO_PROOF_MODE="$proof_mode" \
+  EXACT_REVIEW_DO_PROOF_HEAD="$head_sha" \
+  node "$driver"
+
+test -s "$output_dir/proof-summary.json"

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -1,8 +1,11 @@
 import {
   assert,
+  createHmac,
   test,
   ExactReviewQueue,
   MemoryDurableStorage,
+  MemoryDurableNamespace,
+  worker,
 } from "./dashboard-worker-harness.ts";
 
 function publicationsListRequest(limit: number) {
@@ -20,7 +23,30 @@ function newQueue(storage: MemoryDurableStorage) {
   );
 }
 
-test("exact-review Durable Object returns a sanitized JSON error when a route throws", async () => {
+function signedPublicationsListRequest(body: string, secret: string) {
+  return new Request("https://clawsweeper.openclaw.ai/internal/exact-review/publications/list", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-clawsweeper-exact-review-signature": `sha256=${createHmac("sha256", secret)
+        .update(body)
+        .digest("hex")}`,
+    },
+    body,
+  });
+}
+
+test("exact-review Durable Object rejects storage failures directly", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = newQueue(storage);
+  assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
+
+  storage.failNextSql(/SELECT item_key, item_json/);
+  await assert.rejects(queue.fetch(publicationsListRequest(100)), /injected SQL failure/);
+  assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
+});
+
+test("exact-review Worker sanitizes rejected Durable Object calls", async () => {
   const storage = new MemoryDurableStorage();
   const queue = newQueue(storage);
   assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
@@ -31,22 +57,60 @@ test("exact-review Durable Object returns a sanitized JSON error when a route th
       "injected sqlite read failure exposing GH_TOKEN=ghp_examplesecrettoken0123456789abcd",
     ),
   );
-  const response = await queue.fetch(publicationsListRequest(100));
+  const secret = "test-webhook-secret";
+  const requestBody = JSON.stringify({ limit: 100 });
+  const response = await worker.fetch(signedPublicationsListRequest(requestBody, secret), {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace(queue),
+  });
 
   assert.equal(response.status, 500);
   assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
-  const body = (await response.json()) as { error?: unknown };
-  assert.equal(typeof body.error, "string");
-  assert.equal(JSON.stringify(body).includes("ghp_examplesecrettoken"), false);
+  const responseBody = (await response.json()) as { error?: unknown };
+  assert.equal(typeof responseBody.error, "string");
+  assert.equal(JSON.stringify(responseBody).includes("ghp_examplesecrettoken"), false);
 });
 
-test("exact-review Durable Object preserves intentional non-200 responses", async () => {
-  const storage = new MemoryDurableStorage();
-  const queue = newQueue(storage);
+test("exact-review Worker normalizes malformed Durable Object 5xx responses", async () => {
+  const plantedToken = "ghp_examplesecrettoken0123456789abcd";
+  const secret = "test-webhook-secret";
+  const body = JSON.stringify({ limit: 100 });
+  const response = await worker.fetch(signedPublicationsListRequest(body, secret), {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+      async fetch() {
+        return new Response(`upstream failure GH_TOKEN=${plantedToken}`, {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    }),
+  });
 
-  const response = await queue.fetch(publicationsListRequest(0));
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+  const responseBody = (await response.json()) as { error?: unknown };
+  assert.equal(typeof responseBody.error, "string");
+  assert.equal(JSON.stringify(responseBody).includes(plantedToken), false);
+  assert.match(String(responseBody.error), /\[REDACTED\]/);
+});
 
-  assert.equal(response.status, 400);
-  const body = (await response.json()) as { error?: unknown };
-  assert.equal(body.error, "invalid_limit");
+test("exact-review Worker preserves intentional non-JSON 4xx responses", async () => {
+  const secret = "test-webhook-secret";
+  const body = JSON.stringify({ limit: 0 });
+  const response = await worker.fetch(signedPublicationsListRequest(body, secret), {
+    CLAWSWEEPER_WEBHOOK_SECRET: secret,
+    EXACT_REVIEW_QUEUE: new MemoryDurableNamespace({
+      async fetch() {
+        return new Response("intentional conflict", {
+          status: 409,
+          headers: { "content-type": "text/plain" },
+        });
+      },
+    }),
+  });
+
+  assert.equal(response.status, 409);
+  assert.equal(response.headers.get("content-type"), "text/plain");
+  assert.equal(await response.text(), "intentional conflict");
 });

--- a/test/dashboard-worker-durable-object-error.test.ts
+++ b/test/dashboard-worker-durable-object-error.test.ts
@@ -1,0 +1,52 @@
+import {
+  assert,
+  test,
+  ExactReviewQueue,
+  MemoryDurableStorage,
+} from "./dashboard-worker-harness.ts";
+
+function publicationsListRequest(limit: number) {
+  return new Request("https://clawsweeper-exact-review-queue/publications/list", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ limit }),
+  });
+}
+
+function newQueue(storage: MemoryDurableStorage) {
+  return new ExactReviewQueue(
+    { storage },
+    { EXACT_REVIEW_DISPATCH_DEBOUNCE_MS: "0", EXACT_REVIEW_QUEUE_MAX_CONCURRENT: "1" },
+  );
+}
+
+test("exact-review Durable Object returns a sanitized JSON error when a route throws", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = newQueue(storage);
+  assert.equal((await queue.fetch(publicationsListRequest(100))).status, 200);
+
+  storage.failNextSql(
+    /SELECT item_key, item_json/,
+    new Error(
+      "injected sqlite read failure exposing GH_TOKEN=ghp_examplesecrettoken0123456789abcd",
+    ),
+  );
+  const response = await queue.fetch(publicationsListRequest(100));
+
+  assert.equal(response.status, 500);
+  assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+  const body = (await response.json()) as { error?: unknown };
+  assert.equal(typeof body.error, "string");
+  assert.equal(JSON.stringify(body).includes("ghp_examplesecrettoken"), false);
+});
+
+test("exact-review Durable Object preserves intentional non-200 responses", async () => {
+  const storage = new MemoryDurableStorage();
+  const queue = newQueue(storage);
+
+  const response = await queue.fetch(publicationsListRequest(0));
+
+  assert.equal(response.status, 400);
+  const body = (await response.json()) as { error?: unknown };
+  assert.equal(body.error, "invalid_limit");
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where signed exact-review Worker callers could receive an unparseable 500 response when the ExactReviewQueue Durable Object rejected or returned a malformed server-error body.

## Why This Change Was Made

The Durable Object remains fail closed: route and storage exceptions still reject directly, preserving SQLite and durable-storage rollback behavior. The dashboard Worker now owns the transport contract and converts rejected stub calls or malformed 5xx bodies into sanitized JSON while preserving intentional 4xx responses and already-valid JSON 5xx responses.

## User Impact

Exact-review queue clients receive parseable, redacted JSON for unexpected queue failures without weakening queue transaction semantics.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. Its queue projections already map non-OK responses to unavailable states; this change only makes the shared Worker-facing failure envelope parseable and sanitized.

## Documentation Impact

The active proof harness under `docs/proof/exact-review-do-json-errors/` now documents the Worker as the normalization owner and the Durable Object as the fail-closed transaction owner. No operator setup or public API documentation changes are required.

## Evidence

Current head: `0e6ef72c14bfbfe25d8a5ac247d95787563e82f5`

- TypeScript builds: `tsconfig.json`, `tsconfig.repair.json`, and `tsconfig.dashboard.json` passed.
- Focused Worker boundary tests: 4 passed.
  - direct Durable Object storage failure rejects;
  - rejected Durable Object call becomes sanitized JSON 500;
  - malformed 5xx becomes sanitized JSON with its status preserved;
  - intentional non-JSON 4xx is unchanged.
- Existing rollback regressions: all 6 previously failing tests passed.
  - completion and lane metrics roll back together;
  - receipt acceptance and queue mutation commit atomically;
  - divergent rollback shadow fails closed;
  - obsolete shadow cleanup failure rolls SQL back;
  - publication capacity state rolls back on storage failure;
  - credential telemetry state rolls back on SQL failure.
- Changed-file formatting, dashboard/test lint, dashboard queue-boundary check, dashboard strict check, documentation check, and `git diff --check` passed.
- Proof-file collision check: pre-existing `dashboard/proof-entry-do-error.ts` and `dashboard/wrangler.proof.toml` sentinels caused an immediate refusal and remained unchanged.

## Real Behavior Proof

**Claim:** a real Worker-to-Durable-Object storage rejection crosses the Worker boundary as sanitized JSON, while the Durable Object still rejects and a following request recovers.

**Surface:** local Wrangler dashboard Worker, ExactReviewQueue Durable Object, HMAC-authenticated `/internal/exact-review/publications/list`, and SQLite-backed Durable Object storage.

**Scenario:** a proof-only wrapper arms one marked `SELECT item_key, item_json` call to throw an error containing a planted GitHub token. Baseline and recovery requests use the unmodified production route.

**Command and environment:**

```bash
EXACT_REVIEW_DO_PROOF_SKIP_INSTALL=1 \
EXACT_REVIEW_DO_PROOF_OUTPUT=.artifacts/exact-review-do-json-errors-0e6ef72c \
bash docs/proof/exact-review-do-json-errors/run-proof.sh
```

Run on macOS with Node 26.7.0 and Wrangler 4.107.0 against exact head `0e6ef72c14bfbfe25d8a5ac247d95787563e82f5`.

**Observed result:**

```text
baseline_list_ok: PASS (HTTP 200)
failure_status_500: PASS (HTTP 500)
worker_sanitized_json_contract: PASS (application/json; charset=utf-8)
planted_token_redacted: PASS (GH_TOKEN=[REDACTED])
recovery_list_ok: PASS (HTTP 200)
```

**Before evidence:** on base `d61664303d1bcab286362c8386cc2b5cb77e2c7f`, the same marked request escaped the Worker as a non-JSON 500.

**Limits:** the Docker-backed Crabbox rerun was unavailable because the local Docker daemon was stopped. The exact-head proof above used the same committed Wrangler harness directly on the host. It proves the Worker/DO failure contract and recovery path, not a deployed Cloudflare revision.
