### PR TITLE
Review Endor remediation PRs until clean

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1569,8 +1569,41 @@ jobs:
           EXACT_REVIEW_BATCH_MUTATION_OUTPUT: .artifacts/direct-publication-outcome.json
         run: pnpm run --silent repair:publish-event-result
 
-      - name: Post direct exact review publication result
+      - name: Detect Endor review for durable publication
+        id: detect-direct-endor-review
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.prepare-direct-exact-review-publication.outcome == 'success' && fromJSON(steps.claim-exact-review-queue.outputs.decision).itemKind == 'pull_request' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.target.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.target.outputs.item_number }}
+          REVIEW_GENERATION: ${{ format('{0}:{1}', steps.claim-exact-review-queue.outputs.lease_id, steps.claim-exact-review-queue.outputs.lease_revision) }}
+          RECORD_PATH: artifacts/event/${{ steps.target.outputs.item_number }}.md
+          EVIDENCE_PATH: .artifacts/endor-remediation/direct-route-evidence.json
+        run: |
+          pnpm run --silent repair:notify-endor-remediation -- prepare \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --review-generation "$REVIEW_GENERATION" \
+            --record-path "$RECORD_PATH" \
+            --evidence-path "$EVIDENCE_PATH"
+
+      - name: Resolve direct exact review publication route
+        id: direct-publication-route
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.prepare-direct-exact-review-publication.outcome == 'success' }}
+        env:
+          ITEM_KIND: ${{ fromJSON(steps.claim-exact-review-queue.outputs.decision).itemKind }}
+          DETECTION_OUTCOME: ${{ steps.detect-direct-endor-review.outcome }}
+          ENDOR_ELIGIBLE: ${{ steps.detect-direct-endor-review.outputs.eligible }}
+        run: |
+          route=direct
+          if [ "$ITEM_KIND" = "pull_request" ] && { [ "$DETECTION_OUTCOME" != "success" ] || [ "$ENDOR_ELIGIBLE" = "true" ]; }; then
+            route=durable_publication
+          fi
+          echo "route=$route" >> "$GITHUB_OUTPUT"
+
+      - name: Post direct exact review publication result
+        if: ${{ steps.direct-publication-route.outputs.route == 'direct' }}
         id: direct-exact-review-publication
         env:
           EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED: ${{ vars.EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED || '1' }}
@@ -2880,6 +2913,234 @@ jobs:
             --data "$payload" \
             "$queue_url/internal/exact-review/lifecycle/router-receipt" >/dev/null
 
+      - name: Prepare Endor exact-head review
+        id: prepare-endor-review
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.publication-context.outputs.item_kind == 'pull_request' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.publish-event-result.outputs.requeue_latest != 'true' && steps.record-fallback-canonical-lifecycle-receipt.outcome == 'success' && (steps.publish-event-result.outputs.routing_deferred != 'true' || steps.queue-deferred-verdict-router.outcome == 'success') }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          TARGET_REPO: ${{ steps.publication-context.outputs.target_repo }}
+          ITEM_NUMBER: ${{ steps.publication-context.outputs.item_number }}
+          PUBLISHER_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
+          PUBLISHER_LEASE_REVISION: ${{ steps.publication-context.outputs.publisher_lease_revision }}
+          RECORD_PATH: artifacts/event/${{ steps.publication-context.outputs.item_number }}.md
+          EVIDENCE_PATH: .artifacts/endor-remediation/evidence.json
+        run: |
+          pnpm run --silent repair:notify-endor-remediation -- prepare \
+            --repo "$TARGET_REPO" \
+            --item-number "$ITEM_NUMBER" \
+            --review-generation "$PUBLISHER_LEASE_ID:$PUBLISHER_LEASE_REVISION" \
+            --record-path "$RECORD_PATH" \
+            --evidence-path "$EVIDENCE_PATH"
+
+      - name: Create Endor remediation state token
+        id: endor-state-token
+        if: ${{ steps.prepare-endor-review.outcome == 'success' && steps.prepare-endor-review.outputs.eligible == 'true' }}
+        continue-on-error: true
+        uses: ./.github/actions/create-state-token
+        with:
+          client-id: ${{ env.CLAWSWEEPER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-state
+        id: setup-endor-state
+        if: ${{ steps.prepare-endor-review.outcome == 'success' && steps.prepare-endor-review.outputs.eligible == 'true' && steps.endor-state-token.outcome == 'success' }}
+        continue-on-error: true
+        with:
+          token: ${{ steps.endor-state-token.outputs.token }}
+          coordinator-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-url: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          records-secret: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          records-repo-slugs: ${{ steps.publication-context.outputs.target_slug }}
+          records-item-number: ${{ steps.publication-context.outputs.item_number }}
+          hydrate-git-state: "true"
+          hydrate-state-blobs: "false"
+
+      - name: Advance Endor review-until-clean state
+        id: advance-endor-review
+        if: ${{ steps.setup-endor-state.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          pnpm run --silent repair:notify-endor-remediation -- advance \
+            --evidence-path .artifacts/endor-remediation/evidence.json \
+            --event-path .artifacts/endor-remediation/event.json
+
+      - name: Publish Endor review progress
+        id: publish-endor-review-progress
+        if: ${{ steps.advance-endor-review.outcome == 'success' && steps.advance-endor-review.outputs.action == 'requeue' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          GH_TOKEN: ${{ steps.endor-state-token.outputs.token }}
+        run: |
+          pnpm run --silent repair:publish-main -- \
+            --message "chore: advance Endor exact-head review" \
+            --path "${{ steps.advance-endor-review.outputs.state_path }}" \
+            --max-attempts 12 \
+            --push-attempts 4
+
+      - name: Queue next Endor exact-head review
+        id: queue-next-endor-review
+        if: ${{ steps.publish-endor-review-progress.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          CLAIM_DECISION: ${{ steps.publication-context.outputs.decision }}
+          REQUEUE_KEY: ${{ steps.advance-endor-review.outputs.requeue_key }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          payload="$(node <<'NODE'
+          const decision = JSON.parse(process.env.CLAIM_DECISION || "{}");
+          process.stdout.write(JSON.stringify({
+            delivery_id: process.env.REQUEUE_KEY,
+            decision: {
+              ...decision,
+              sourceAction: "endor_until_clean_rereview",
+              supersedesInProgress: false,
+            },
+          }));
+          NODE
+          )"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "x-clawsweeper-exact-review-signature: $signature" \
+            --data "$payload" \
+            "${QUEUE_URL%/}/internal/exact-review/enqueue")"
+          jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null
+
+      - name: Publish Endor terminal review state
+        id: publish-endor-terminal-state
+        if: ${{ steps.advance-endor-review.outcome == 'success' && steps.advance-endor-review.outputs.action == 'notify' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          GH_TOKEN: ${{ steps.endor-state-token.outputs.token }}
+        run: |
+          pnpm run --silent repair:publish-main -- \
+            --message "chore: publish Endor terminal review state" \
+            --path "${{ steps.advance-endor-review.outputs.state_path }}" \
+            --max-attempts 12 \
+            --push-attempts 4
+
+      - name: Deliver Endor remediation notification
+        id: deliver-endor-notification
+        if: ${{ steps.publish-endor-terminal-state.outcome == 'success' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
+          CLAWSWEEPER_HERMIT_URL: ${{ vars.CLAWSWEEPER_HERMIT_URL }}
+          CLAWSWEEPER_HERMIT_TOKEN: ${{ secrets.CLAWSWEEPER_HERMIT_TOKEN }}
+        run: pnpm run --silent repair:notify-endor-remediation -- deliver --event-path .artifacts/endor-remediation/event.json
+
+      - name: Queue current Endor head after delivery drift
+        id: queue-current-endor-head
+        if: ${{ steps.deliver-endor-notification.outcome == 'success' && steps.deliver-endor-notification.outputs.action == 'requeue' }}
+        continue-on-error: true
+        env:
+          CLAIM_DECISION: ${{ steps.publication-context.outputs.decision }}
+          CURRENT_HEAD_SHA: ${{ steps.deliver-endor-notification.outputs.requeue_head_sha }}
+          CURRENT_UPDATED_AT: ${{ steps.deliver-endor-notification.outputs.requeue_updated_at }}
+          REQUEUE_KEY: ${{ steps.deliver-endor-notification.outputs.requeue_key }}
+          QUEUE_URL: ${{ vars.CLAWSWEEPER_EXACT_REVIEW_QUEUE_URL || 'https://clawsweeper.openclaw.ai' }}
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          payload="$(node <<'NODE'
+          const original = JSON.parse(process.env.CLAIM_DECISION || "{}");
+          const {
+            sourceContentRevision: _sourceContentRevision,
+            sourceDeliveryId: _sourceDeliveryId,
+            sourceUpdatedAt: _sourceUpdatedAt,
+            ...decision
+          } = original;
+          if (!/^[0-9a-f]{40}$/.test(process.env.CURRENT_HEAD_SHA || "")) process.exit(1);
+          process.stdout.write(JSON.stringify({
+            delivery_id: process.env.REQUEUE_KEY,
+            decision: {
+              ...decision,
+              sourceAction: "endor_delivery_drift_rereview",
+              supersedesInProgress: true,
+              sourceHeadSha: process.env.CURRENT_HEAD_SHA,
+              sourceHeadVerified: true,
+              ...(process.env.CURRENT_UPDATED_AT
+                ? { sourceUpdatedAt: process.env.CURRENT_UPDATED_AT }
+                : {}),
+            },
+          }));
+          NODE
+          )"
+          signature="$(PAYLOAD="$payload" node -e 'const crypto=require("node:crypto"); process.stdout.write(`sha256=${crypto.createHmac("sha256", process.env.CLAWSWEEPER_WEBHOOK_SECRET).update(process.env.PAYLOAD).digest("hex")}`)')"
+          response="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "x-clawsweeper-exact-review-signature: $signature" \
+            --data "$payload" \
+            "${QUEUE_URL%/}/internal/exact-review/enqueue")"
+          jq -e '.ok == true and (.queued == true or .deduped == true)' <<< "$response" >/dev/null
+
+      - name: Publish Endor notification receipt
+        id: publish-endor-notification-receipt
+        if: ${{ steps.deliver-endor-notification.outcome == 'success' && steps.deliver-endor-notification.outputs.action == 'notify' }}
+        continue-on-error: true
+        env:
+          CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
+          GH_TOKEN: ${{ steps.endor-state-token.outputs.token }}
+        run: |
+          pnpm run --silent repair:publish-main -- \
+            --message "chore: publish Endor remediation notification" \
+            --path "${{ steps.deliver-endor-notification.outputs.ledger_path }}" \
+            --path "${{ steps.deliver-endor-notification.outputs.report_path }}" \
+            --max-attempts 12 \
+            --push-attempts 4
+
+      - name: Resolve Endor finalization readiness
+        id: endor-finalization-readiness
+        if: ${{ always() && steps.publication-context.outputs.claimed == 'true' }}
+        env:
+          PREPARE_OUTCOME: ${{ steps.prepare-endor-review.outcome }}
+          ELIGIBLE: ${{ steps.prepare-endor-review.outputs.eligible }}
+          ADVANCE_OUTCOME: ${{ steps.advance-endor-review.outcome }}
+          ACTION: ${{ steps.advance-endor-review.outputs.action }}
+          PROGRESS_PUBLICATION_OUTCOME: ${{ steps.publish-endor-review-progress.outcome }}
+          REQUEUE_OUTCOME: ${{ steps.queue-next-endor-review.outcome }}
+          TERMINAL_STATE_PUBLICATION_OUTCOME: ${{ steps.publish-endor-terminal-state.outcome }}
+          DELIVERY_OUTCOME: ${{ steps.deliver-endor-notification.outcome }}
+          DELIVERY_ACTION: ${{ steps.deliver-endor-notification.outputs.action }}
+          DELIVERY_REQUEUE_OUTCOME: ${{ steps.queue-current-endor-head.outcome }}
+          RECEIPT_PUBLICATION_OUTCOME: ${{ steps.publish-endor-notification-receipt.outcome }}
+        run: |
+          ready=false
+          if [ "$PREPARE_OUTCOME" = "skipped" ]; then
+            ready=true
+          elif [ "$PREPARE_OUTCOME" = "success" ] && [ "$ELIGIBLE" != "true" ]; then
+            ready=true
+          elif [ "$PREPARE_OUTCOME" = "success" ] && [ "$ELIGIBLE" = "true" ] && \
+            [ "$ADVANCE_OUTCOME" = "success" ] && [ "$ACTION" = "requeue" ] && \
+            [ "$PROGRESS_PUBLICATION_OUTCOME" = "success" ] && [ "$REQUEUE_OUTCOME" = "success" ]; then
+            ready=true
+          elif [ "$PREPARE_OUTCOME" = "success" ] && [ "$ELIGIBLE" = "true" ] && \
+            [ "$ADVANCE_OUTCOME" = "success" ] && [ "$ACTION" = "notify" ] && \
+            [ "$TERMINAL_STATE_PUBLICATION_OUTCOME" = "success" ] && \
+            [ "$DELIVERY_OUTCOME" = "success" ] && [ "$DELIVERY_ACTION" = "requeue" ] && \
+            [ "$DELIVERY_REQUEUE_OUTCOME" = "success" ]; then
+            ready=true
+          elif [ "$PREPARE_OUTCOME" = "success" ] && [ "$ELIGIBLE" = "true" ] && \
+            [ "$ADVANCE_OUTCOME" = "success" ] && [ "$ACTION" = "notify" ] && \
+            [ "$TERMINAL_STATE_PUBLICATION_OUTCOME" = "success" ] && \
+            [ "$DELIVERY_OUTCOME" = "success" ] && [ "$DELIVERY_ACTION" = "complete" ]; then
+            ready=true
+          elif [ "$PREPARE_OUTCOME" = "success" ] && [ "$ELIGIBLE" = "true" ] && \
+            [ "$ADVANCE_OUTCOME" = "success" ] && [ "$ACTION" = "notify" ] && \
+            [ "$TERMINAL_STATE_PUBLICATION_OUTCOME" = "success" ] && \
+            [ "$DELIVERY_OUTCOME" = "success" ] && [ "$DELIVERY_ACTION" = "notify" ] && \
+            [ "$RECEIPT_PUBLICATION_OUTCOME" = "success" ]; then
+            ready=true
+          fi
+          echo "ready=$ready" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch deferred high-confidence bug implementation
         if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publication-context.outputs.direct_lifecycle_recovery != 'true' && steps.publish-event-result.outcome == 'success' && steps.publish-event-result.outputs.remote_tuple_verified == 'true' && steps.record-fallback-canonical-lifecycle-receipt.outcome == 'success' && vars.CLAWSWEEPER_AUTO_IMPLEMENT_ISSUES == '1' && steps.publication-context.outputs.target_repo == 'openclaw/openclaw' && fromJSON(steps.publication-context.outputs.decision).itemKind == 'issue' && ((fromJSON(steps.publication-context.outputs.decision).sourceAction == 'failed_review_shard_recovery' && steps.record-no-router-lifecycle-receipt.outcome == 'success') || (fromJSON(steps.publication-context.outputs.decision).sourceAction != 'failed_review_shard_recovery' && (steps.publish-event-result.outputs.routing_deferred != 'true' || steps.queue-deferred-verdict-router.outcome == 'success'))) }}
         continue-on-error: true
@@ -3043,6 +3304,13 @@ jobs:
           PUBLISH_RETRY_AT: ${{ steps.publish-event-result.outputs.retry_at }}
           ERROR_FINGERPRINT: ${{ steps.publish-event-result.outputs.error_fingerprint }}
           STATE_WRITER_JSON: ${{ steps.publish-event-result.outputs.state_writer_json }}
+          ENDOR_FINALIZATION_READY: ${{ steps.endor-finalization-readiness.outputs.ready }}
+          ENDOR_PREPARE_OUTCOME: ${{ steps.prepare-endor-review.outcome }}
+          ENDOR_PREPARE_FAILURE_KIND: ${{ steps.prepare-endor-review.outputs.failure_kind }}
+          ENDOR_PREPARE_RETRY_AT: ${{ steps.prepare-endor-review.outputs.retry_at }}
+          ENDOR_DELIVERY_OUTCOME: ${{ steps.deliver-endor-notification.outcome }}
+          ENDOR_DELIVERY_FAILURE_KIND: ${{ steps.deliver-endor-notification.outputs.failure_kind }}
+          ENDOR_DELIVERY_RETRY_AT: ${{ steps.deliver-endor-notification.outputs.retry_at }}
           DIRECT_RECOVERY_OUTCOME: ${{ steps.replay-direct-lifecycle.outputs.outcome }}
           DIRECT_RECOVERY_COMPLETION_KIND: ${{ steps.replay-direct-lifecycle.outputs.completion_kind }}
           DIRECT_RECOVERY_REASON_CODE: ${{ steps.replay-direct-lifecycle.outputs.reason_code }}
@@ -3057,7 +3325,9 @@ jobs:
           retry_at=
           requeue_latest="$REQUEUE_LATEST"
           direct_requeue=false
-          if [ "$DIRECT_RECOVERY_OUTCOME" = "success" ]; then
+          if [ "$ENDOR_FINALIZATION_READY" != "true" ]; then
+            :
+          elif [ "$DIRECT_RECOVERY_OUTCOME" = "success" ]; then
             case "$DIRECT_RECOVERY_COMPLETION_KIND:$DIRECT_RECOVERY_REASON_CODE" in
               published:publication_applied|superseded:remote_newer_tuple) ;;
               *) exit 1 ;;
@@ -3113,6 +3383,15 @@ jobs:
               outcome=success
             fi
           fi
+          endor_failure_kind=
+          endor_retry_at=
+          if [ "$ENDOR_PREPARE_OUTCOME" = "failure" ]; then
+            endor_failure_kind="$ENDOR_PREPARE_FAILURE_KIND"
+            endor_retry_at="$ENDOR_PREPARE_RETRY_AT"
+          elif [ "$ENDOR_DELIVERY_OUTCOME" = "failure" ]; then
+            endor_failure_kind="$ENDOR_DELIVERY_FAILURE_KIND"
+            endor_retry_at="$ENDOR_DELIVERY_RETRY_AT"
+          fi
           if [ "$outcome" = "success" ] && [ "$completion_kind" != "superseded" ] && [ "$completion_kind" != "deferred" ] && [ "$completion_kind" != "refresh_required" ] && [ "$completion_kind" != "retryable_failure" ]; then
             if [ "$PUBLISH_COMPLETION_KIND" = "published" ] && [ "$PUBLISH_REASON_CODE" = "publication_applied" ]; then
               completion_kind=published
@@ -3121,6 +3400,10 @@ jobs:
               completion_kind=superseded
               reason_code=live_terminal
             fi
+          elif [ "$outcome" != "success" ] && { [ "$endor_failure_kind" = "github_rate_limit" ] || [ "$endor_failure_kind" = "github_transient" ] || [ "$endor_failure_kind" = "hermit_transient" ]; }; then
+            completion_kind=retryable_failure
+            reason_code="$endor_failure_kind"
+            retry_at="$endor_retry_at"
           elif [ "$outcome" != "success" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
             completion_kind=retryable_failure
             reason_code="$FAILURE_KIND"
@@ -3149,8 +3432,8 @@ jobs:
           if [ -n "$retry_at" ]; then
             echo "retry_at=$retry_at" >> "$GITHUB_OUTPUT"
           fi
-          if [ "$outcome" = "failure" ] && { [ "$FAILURE_KIND" = "github_rate_limit" ] || [ "$FAILURE_KIND" = "github_transient" ]; }; then
-            echo "failure_kind=$FAILURE_KIND" >> "$GITHUB_OUTPUT"
+          if [ "$outcome" = "failure" ] && { [ "$reason_code" = "github_rate_limit" ] || [ "$reason_code" = "github_transient" ]; }; then
+            echo "failure_kind=$reason_code" >> "$GITHUB_OUTPUT"
           fi
           if [ -n "$STATE_WRITER_JSON" ]; then
             echo "state_writer_json=$STATE_WRITER_JSON" >> "$GITHUB_OUTPUT"
@@ -3178,7 +3461,7 @@ jobs:
           TERMINAL_CLOSED: ${{ steps.publish-event-result.outputs.terminal_closed }}
           GUARDED_OPEN: ${{ steps.publish-event-result.outputs.guarded_open }}
           POLICY_NOOP: ${{ steps.publish-event-result.outputs.policy_noop }}
-          REQUEUE_LATEST: ${{ steps.publish-event-result.outputs.requeue_latest }}
+          REQUEUE_LATEST: ${{ steps.exact-review-publication-result.outputs.requeue_latest }}
           DIRECT_LIFECYCLE_REQUEUE: ${{ steps.exact-review-publication-result.outputs.direct_requeue }}
           LEGACY_TUPLELESS: ${{ steps.legacy-exact-artifact.outputs.legacy_tupleless }}
           QUEUE_LEASE_ID: ${{ steps.publication-context.outputs.publisher_lease_id }}
@@ -3204,7 +3487,7 @@ jobs:
             const completionKind = ["published", "superseded", "deferred", "retryable_failure", "refresh_required", "permanent_failure"].includes(process.env.COMPLETION_KIND)
               ? process.env.COMPLETION_KIND
               : undefined;
-            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "state_contention", "review_lease_active", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
+            const reasonCode = ["publication_applied", "remote_newer_tuple", "remote_closed", "live_terminal", "github_rate_limit", "github_transient", "hermit_transient", "state_contention", "review_lease_active", "workflow_cancelled", "artifact_unavailable", "artifact_expired", "close_coverage_retry", "close_coverage_deferred", "invalid_artifact", "missing_record_tuple", "tuple_protocol_invalid", "policy_invariant", "unknown_failure", "retry_exhausted"].includes(process.env.REASON_CODE)
               ? process.env.REASON_CODE
               : undefined;
             const errorFingerprint = /^[A-Za-z0-9:._-]{1,200}$/.test(process.env.ERROR_FINGERPRINT || "")

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1603,7 +1603,7 @@ jobs:
           echo "route=$route" >> "$GITHUB_OUTPUT"
 
       - name: Post direct exact review publication result
-        if: ${{ steps.direct-publication-route.outputs.route == 'direct' }}
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.prepare-direct-exact-review-publication.outcome == 'success' && steps.direct-publication-route.outputs.route == 'direct' }}
         id: direct-exact-review-publication
         env:
           EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED: ${{ vars.EXACT_REVIEW_DIRECT_PUBLICATION_ENABLED || '1' }}
@@ -2935,7 +2935,7 @@ jobs:
 
       - name: Create Endor remediation state token
         id: endor-state-token
-        if: ${{ steps.prepare-endor-review.outcome == 'success' && steps.prepare-endor-review.outputs.eligible == 'true' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.prepare-endor-review.outcome == 'success' && steps.prepare-endor-review.outputs.eligible == 'true' }}
         continue-on-error: true
         uses: ./.github/actions/create-state-token
         with:
@@ -2944,7 +2944,7 @@ jobs:
 
       - uses: ./.github/actions/setup-state
         id: setup-endor-state
-        if: ${{ steps.prepare-endor-review.outcome == 'success' && steps.prepare-endor-review.outputs.eligible == 'true' && steps.endor-state-token.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.prepare-endor-review.outcome == 'success' && steps.prepare-endor-review.outputs.eligible == 'true' && steps.endor-state-token.outcome == 'success' }}
         continue-on-error: true
         with:
           token: ${{ steps.endor-state-token.outputs.token }}
@@ -2958,7 +2958,7 @@ jobs:
 
       - name: Advance Endor review-until-clean state
         id: advance-endor-review
-        if: ${{ steps.setup-endor-state.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.setup-endor-state.outcome == 'success' }}
         continue-on-error: true
         run: |
           pnpm run --silent repair:notify-endor-remediation -- advance \
@@ -2967,7 +2967,7 @@ jobs:
 
       - name: Publish Endor review progress
         id: publish-endor-review-progress
-        if: ${{ steps.advance-endor-review.outcome == 'success' && steps.advance-endor-review.outputs.action == 'requeue' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.advance-endor-review.outcome == 'success' && steps.advance-endor-review.outputs.action == 'requeue' }}
         continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -2981,7 +2981,7 @@ jobs:
 
       - name: Queue next Endor exact-head review
         id: queue-next-endor-review
-        if: ${{ steps.publish-endor-review-progress.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publish-endor-review-progress.outcome == 'success' }}
         continue-on-error: true
         env:
           CLAIM_DECISION: ${{ steps.publication-context.outputs.decision }}
@@ -3013,7 +3013,7 @@ jobs:
 
       - name: Publish Endor terminal review state
         id: publish-endor-terminal-state
-        if: ${{ steps.advance-endor-review.outcome == 'success' && steps.advance-endor-review.outputs.action == 'notify' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.advance-endor-review.outcome == 'success' && steps.advance-endor-review.outputs.action == 'notify' }}
         continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}
@@ -3027,7 +3027,7 @@ jobs:
 
       - name: Deliver Endor remediation notification
         id: deliver-endor-notification
-        if: ${{ steps.publish-endor-terminal-state.outcome == 'success' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.publish-endor-terminal-state.outcome == 'success' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.target-write-token.outputs.token }}
@@ -3037,7 +3037,7 @@ jobs:
 
       - name: Queue current Endor head after delivery drift
         id: queue-current-endor-head
-        if: ${{ steps.deliver-endor-notification.outcome == 'success' && steps.deliver-endor-notification.outputs.action == 'requeue' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.deliver-endor-notification.outcome == 'success' && steps.deliver-endor-notification.outputs.action == 'requeue' }}
         continue-on-error: true
         env:
           CLAIM_DECISION: ${{ steps.publication-context.outputs.decision }}
@@ -3083,7 +3083,7 @@ jobs:
 
       - name: Publish Endor notification receipt
         id: publish-endor-notification-receipt
-        if: ${{ steps.deliver-endor-notification.outcome == 'success' && steps.deliver-endor-notification.outputs.action == 'notify' }}
+        if: ${{ steps.publication-context.outputs.claimed == 'true' && steps.deliver-endor-notification.outcome == 'success' && steps.deliver-endor-notification.outputs.action == 'notify' }}
         continue-on-error: true
         env:
           CLAWSWEEPER_WEBHOOK_SECRET: ${{ secrets.CLAWSWEEPER_WEBHOOK_SECRET }}

--- a/dashboard/exact-review-queue.ts
+++ b/dashboard/exact-review-queue.ts
@@ -317,6 +317,7 @@ type ExactReviewPublicationReasonCode =
   | "live_terminal"
   | "github_rate_limit"
   | "github_transient"
+  | "hermit_transient"
   | "state_contention"
   | "review_lease_active"
   | "workflow_cancelled"
@@ -11211,6 +11212,7 @@ function exactReviewPublicationReasonCode(value): ExactReviewPublicationReasonCo
     "live_terminal",
     "github_rate_limit",
     "github_transient",
+    "hermit_transient",
     "state_contention",
     "review_lease_active",
     "workflow_cancelled",
@@ -11247,6 +11249,7 @@ function exactReviewPublicationCompletion(
     retryable_failure: new Set([
       "github_rate_limit",
       "github_transient",
+      "hermit_transient",
       "state_contention",
       "review_lease_active",
       "workflow_cancelled",
@@ -11934,7 +11937,9 @@ function exactReviewPublicationRecoveryCause(
   if (completion.reasonCode === "github_rate_limit" && completion.attempted === false) {
     return "credential_circuit";
   }
-  if (["github_rate_limit", "github_transient"].includes(completion.reasonCode)) {
+  if (
+    ["github_rate_limit", "github_transient", "hermit_transient"].includes(completion.reasonCode)
+  ) {
     return "transient_retry";
   }
   if (completion.reasonCode === "state_contention") return "state_retry";

--- a/docs/openclaw-event-hooks.md
+++ b/docs/openclaw-event-hooks.md
@@ -178,6 +178,52 @@ These events use `deliver: true`, so OpenClaw can post the final answer to the
 Discord target. The prompt still permits `NO_REPLY` for an event that is clearly
 routine or not useful.
 
+## Endor Remediation Reviews
+
+Endor remediation reviews use the strict event class
+`clawsweeper.endor_remediation_reviewed`. After each durable exact-head review,
+ClawSweeper verifies the production `endor-labs-pro[bot]` App identity, the
+current 40-character PR head, and the published review-comment digest. Title,
+branch, and comment text alone cannot enter this path.
+
+The review state is stored in per-PR files under
+`notifications/endor-remediation/<owner>/<repo>/pulls/<number>/`. Delivery
+receipts are further separated by full reviewed head and normalized outcome, so
+concurrent PR publishers cannot replace each other's convergence or deduplication
+state. Three consecutive fresh clean reviews are required on one unchanged head.
+A finding or new head resets the clean count, ambiguous results never count, and
+the loop stops after six review cycles. ClawSweeper acknowledges the current
+publication only after the next exact review is durably queued or the terminal
+notification and receipt are durably published.
+
+The default direct exact-review path detects eligible Endor reviews after the
+durable GitHub comment is synchronized and diverts them to the publication job
+that owns convergence, state persistence, successor queueing, and notification.
+Non-Endor items retain direct publication.
+
+For a terminal review, ClawSweeper publishes the per-PR terminal state before
+calling Hermit, then checkpoints Hermit's Discord message receipt before completing
+the exact-review publication. Exhausted transient delivery attempts retain a
+dedicated retryable finalization reason, so they use the full transient recovery
+window and never create a receipt before acceptance.
+
+Immediately before delivery, ClawSweeper reads the PR head, checks, and merge
+state again. Head or readiness drift suppresses the stale notification and
+queues a fresh exact-head review; a closed or merged PR completes without a
+notification or another review, and transient GitHub failures remain retryable.
+
+Configure `CLAWSWEEPER_HERMIT_URL` and the shared
+`CLAWSWEEPER_HERMIT_TOKEN`. ClawSweeper sends the structured terminal event to
+Hermit; it cannot select a Discord target. Hermit validates the event, renders
+the ready, needs-attention, or unknown notification, and sends it only to its
+configured `CLAWSWEEPER_ENDOR_DISCORD_CHANNEL_ID`. Hermit combines a durable D1
+receipt with Discord's enforced nonce to deduplicate retries. The message directs
+maintainers to GitHub to comment `@clawsweeper automerge`.
+
+Hermit's Discord message receipt is the automated delivery boundary. OpenClaw Bay is unaffected:
+this internal security notification adds no public status, telemetry, navigation,
+data contract, or mutation control.
+
 ## GitHub Activity Stream
 
 The `github activity to openclaw` workflow feeds broader GitHub activity to the

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "repair:publish-main": "node dist/repair/publish-main.js",
     "repair:notify-merge": "node dist/repair/notify-merge.js",
     "repair:notify-events": "node dist/repair/notify-events.js",
+    "repair:notify-endor-remediation": "node dist/repair/notify-endor-remediation.js",
     "repair:notify-maintainer-report": "node dist/repair/notify-maintainer-report.js",
     "repair:notify-github-activity": "node dist/repair/notify-github-activity.js",
     "repair:spam-comment-intake": "node dist/repair/spam-comment-intake.js",

--- a/src/repair/hermit-notification.ts
+++ b/src/repair/hermit-notification.ts
@@ -1,0 +1,152 @@
+import { isJsonObject } from "./json-types.js";
+import { normalizeString, positiveInt, stringOrNull } from "./openclaw-hook.js";
+
+export type HermitNotificationConfig = {
+  endpoint: string;
+  token: string;
+  timeoutSeconds: number;
+  retryAttempts: number;
+};
+
+export type HermitNotificationResult = {
+  messageId: string;
+  duplicate: boolean;
+};
+
+const ENDOR_NOTIFICATION_PATH = "/api/clawsweeper/endor-remediation/reviewed";
+const DEFAULT_TIMEOUT_SECONDS = 30;
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAYS_MS = [1000, 4000];
+
+export function resolveHermitNotificationConfig(
+  env: NodeJS.ProcessEnv,
+): HermitNotificationConfig | null {
+  const url = normalizeString(env.CLAWSWEEPER_HERMIT_URL);
+  const token = normalizeString(env.CLAWSWEEPER_HERMIT_TOKEN);
+  if (!url || !token) return null;
+  return {
+    endpoint: resolveHermitEndorNotificationUrl(url),
+    token,
+    timeoutSeconds: positiveInt(env.CLAWSWEEPER_HERMIT_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS),
+    retryAttempts: positiveInt(env.CLAWSWEEPER_HERMIT_RETRY_ATTEMPTS, DEFAULT_RETRY_ATTEMPTS),
+  };
+}
+
+export function resolveHermitEndorNotificationUrl(raw: string): string {
+  const url = new URL(raw);
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Hermit URL must use HTTP or HTTPS");
+  }
+  url.pathname = ENDOR_NOTIFICATION_PATH;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+export async function postHermitEndorNotification({
+  config,
+  fetcher,
+  notification,
+  idempotencyKey,
+  retryDelaysMs = DEFAULT_RETRY_DELAYS_MS,
+  sleep = delay,
+}: {
+  config: HermitNotificationConfig;
+  fetcher: typeof fetch;
+  notification: object;
+  idempotencyKey: string;
+  retryDelaysMs?: number[];
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<HermitNotificationResult> {
+  const attempts = Math.max(1, Math.floor(config.retryAttempts));
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await postHermitEndorNotificationOnce({
+        config,
+        fetcher,
+        notification,
+        idempotencyKey,
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || !isTransientHermitNotificationError(error)) {
+        throw error;
+      }
+      await sleep(retryDelaysMs[Math.min(attempt - 1, retryDelaysMs.length - 1)] ?? 0);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function postHermitEndorNotificationOnce({
+  config,
+  fetcher,
+  notification,
+  idempotencyKey,
+}: {
+  config: HermitNotificationConfig;
+  fetcher: typeof fetch;
+  notification: object;
+  idempotencyKey: string;
+}): Promise<HermitNotificationResult> {
+  const response = await fetcher(config.endpoint, {
+    method: "POST",
+    signal: AbortSignal.timeout(config.timeoutSeconds * 1000),
+    headers: {
+      authorization: `Bearer ${config.token}`,
+      "content-type": "application/json",
+      "idempotency-key": idempotencyKey,
+    },
+    body: JSON.stringify(notification),
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new HermitNotificationHttpError(response.status, body);
+  }
+  const parsed = parseHermitNotificationResult(body);
+  if (!parsed) {
+    throw new Error("Hermit returned an invalid Endor notification receipt");
+  }
+  return parsed;
+}
+
+export class HermitNotificationHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`Hermit notification returned ${status}: ${body.slice(0, 500)}`);
+  }
+}
+
+export function isTransientHermitNotificationError(error: unknown): boolean {
+  if (error instanceof HermitNotificationHttpError) {
+    return [408, 425, 429, 500, 502, 503, 504].includes(error.status);
+  }
+  if (!(error instanceof Error)) return false;
+  if (error.name === "AbortError" || error.name === "TimeoutError") return true;
+  return /\b(ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed)\b/i.test(
+    error.message,
+  );
+}
+
+function parseHermitNotificationResult(body: string): HermitNotificationResult | null {
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (!isJsonObject(parsed) || parsed.delivered !== true) return null;
+    const messageId = stringOrNull(parsed.messageId);
+    if (!messageId) return null;
+    return { messageId, duplicate: parsed.duplicate === true };
+  } catch {
+    return null;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    timeout.unref?.();
+  });
+}

--- a/src/repair/notify-endor-remediation.ts
+++ b/src/repair/notify-endor-remediation.ts
@@ -1,0 +1,1207 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { GitHubRateLimitError, ghRetryKind } from "../github-retry.js";
+import { summarizeChecks } from "./comment-router-utils.js";
+import {
+  isTransientHermitNotificationError,
+  postHermitEndorNotification,
+  resolveHermitNotificationConfig,
+} from "./hermit-notification.js";
+import { asJsonObject, isJsonObject, type JsonObject } from "./json-types.js";
+import { errorText, stringOrNull } from "./openclaw-hook.js";
+
+const ENDOR_APP_USER_ID = 179191674;
+const ENDOR_APP_LOGIN = "endor-labs-pro[bot]";
+const ENDOR_APP_URL = "https://github.com/apps/endor-labs-pro";
+const EVENT_TYPE = "clawsweeper.endor_remediation_reviewed";
+const DEFAULT_MAX_CYCLES = 6;
+const REQUIRED_CLEAN_STREAK = 3;
+const ENDOR_STATE_ROOT = "notifications/endor-remediation";
+
+export type EndorReviewVerdict = "clean" | "has_findings" | "ambiguous";
+export type EndorNotificationOutcome = "ready" | "needs_attention" | "unknown";
+export type EndorCheckState = "passing" | "pending" | "failing" | "unknown";
+export type EndorMergeState = "clean" | "blocked" | "behind" | "unstable" | "unknown";
+export type EndorPreparationFailure = {
+  kind: "github_rate_limit" | "github_transient" | "permanent";
+  retryAt: string | null;
+};
+
+export type EndorReviewEvidence = {
+  version: 1;
+  repo: string;
+  prNumber: number;
+  prUrl: string;
+  title: string;
+  findingSummary: string;
+  reviewedHeadSha: string;
+  reviewDigest: string;
+  reviewGeneration: string;
+  verdict: EndorReviewVerdict;
+  reviewSummary: string;
+  reviewUrl: string;
+  checks: { state: EndorCheckState; total: number | null; summary: string };
+  mergeState: EndorMergeState;
+};
+
+export type EndorRemediationReviewedEvent = Omit<
+  EndorReviewEvidence,
+  "reviewDigest" | "reviewGeneration" | "verdict" | "version"
+> & {
+  version: 1;
+  type: typeof EVENT_TYPE;
+  outcome: EndorNotificationOutcome;
+  cycles: number;
+  cleanStreak: number;
+  idempotencyKey: string;
+};
+
+export type EndorPreparationInput = {
+  repo: string;
+  itemNumber: number;
+  reviewCommentId: number;
+  reviewCommentDigest: string;
+  reviewGeneration: string;
+};
+
+export type EndorPreparationResult =
+  | { status: "eligible"; evidence: EndorReviewEvidence }
+  | { status: "skipped"; reason: string };
+
+export type EndorAdvanceResult =
+  | {
+      action: "requeue";
+      cycles: number;
+      cleanStreak: number;
+      resetReason: "head_changed" | null;
+      requeueKey: string;
+    }
+  | {
+      action: "notify";
+      cycles: number;
+      cleanStreak: number;
+      resetReason: "head_changed" | null;
+      event: EndorRemediationReviewedEvent;
+    };
+
+export type EndorNotifierSummary = {
+  action: "notify" | "requeue" | "complete";
+  status: "ok" | "failed" | "skipped";
+  pending: number;
+  sent: number;
+  failed: number;
+  skipped: number;
+  exitCode: number;
+  reason: string | null;
+  requeueHeadSha: string | null;
+  requeueUpdatedAt: string | null;
+  requeueKey: string | null;
+  failureKind: "github_rate_limit" | "github_transient" | "hermit_transient" | null;
+  retryAt: string | null;
+};
+
+export type EndorRuntime = {
+  root?: string;
+  env?: NodeJS.ProcessEnv;
+  fetch?: typeof fetch;
+  now?: () => Date;
+  log?: (message: string) => void;
+};
+
+export function classifyEndorPreparationFailure(error: unknown): EndorPreparationFailure {
+  const retryKind = ghRetryKind(error);
+  if (retryKind === "throttle") {
+    return { kind: "github_rate_limit", retryAt: new GitHubRateLimitError(error).retryAt };
+  }
+  if (retryKind === "transient") return { kind: "github_transient", retryAt: null };
+  return { kind: "permanent", retryAt: null };
+}
+
+type ReviewStateEntry = {
+  repo: string;
+  prNumber: number;
+  reviewedHeadSha: string;
+  cycles: number;
+  cleanStreak: number;
+  reviewGenerations: string[];
+  lastVerdict: EndorReviewVerdict;
+  terminalOutcome: EndorNotificationOutcome | null;
+  stopReason: "finding" | "safety_cap" | null;
+  updatedAt: string;
+};
+
+type ReviewState = {
+  version: 1;
+  updated_at: string;
+  review: ReviewStateEntry;
+};
+
+type DeliveryLedgerEntry = EndorRemediationReviewedEvent & {
+  notifiedAt: string;
+  hermitMessageId: string;
+  deliveryProvider: "hermit";
+};
+
+type DeliveryLedger = {
+  version: 1;
+  notification: DeliveryLedgerEntry;
+};
+
+export function endorReviewStatePath(evidence: Pick<EndorReviewEvidence, "repo" | "prNumber">) {
+  return path.posix.join(endorPullStateRoot(evidence), "review-state.json");
+}
+
+export function endorDeliveryLedgerPath(
+  event: Pick<EndorRemediationReviewedEvent, "repo" | "prNumber" | "reviewedHeadSha" | "outcome">,
+) {
+  return path.posix.join(
+    endorPullStateRoot(event),
+    "notifications",
+    requiredSha(event.reviewedHeadSha, "event reviewed head"),
+    `${requiredOutcome(event.outcome)}.json`,
+  );
+}
+
+export function endorDeliveryReportPath(
+  event: Pick<EndorRemediationReviewedEvent, "repo" | "prNumber" | "reviewedHeadSha" | "outcome">,
+) {
+  return path.posix.join(
+    endorPullStateRoot(event),
+    "reports",
+    requiredSha(event.reviewedHeadSha, "event reviewed head"),
+    `${requiredOutcome(event.outcome)}.json`,
+  );
+}
+
+export async function prepareEndorRemediationReview(
+  input: EndorPreparationInput,
+  runtime: Pick<EndorRuntime, "env" | "fetch"> = {},
+): Promise<EndorPreparationResult> {
+  validatePreparationInput(input);
+  const env = runtime.env ?? process.env;
+  const fetcher = runtime.fetch ?? fetch;
+  const item = await githubJson({
+    env,
+    fetcher,
+    apiPath: `/repos/${input.repo}/issues/${input.itemNumber}`,
+    label: "GitHub item",
+  });
+  if (!isJsonObject(item.pull_request)) {
+    return { status: "skipped", reason: "reviewed item is not a pull request" };
+  }
+  const pull = await githubJson({
+    env,
+    fetcher,
+    apiPath: `/repos/${input.repo}/pulls/${input.itemNumber}`,
+    label: "pull request",
+  });
+  if (!isEndorAuthoredPull(pull)) {
+    return { status: "skipped", reason: "pull request is not Endor-authored" };
+  }
+  const inactiveReason = inactivePullReason(pull);
+  if (inactiveReason) return { status: "skipped", reason: inactiveReason };
+  const comment = await githubJson({
+    env,
+    fetcher,
+    apiPath: `/repos/${input.repo}/issues/comments/${input.reviewCommentId}`,
+    label: "durable review comment",
+  });
+  const commentBody = requiredString(comment.body, "durable review comment body");
+  if (sha256(commentBody.trim()) !== input.reviewCommentDigest) {
+    throw new Error("durable review comment digest mismatch");
+  }
+  const currentHeadSha = requiredSha(asJsonObject(pull.head).sha, "pull request head SHA");
+  const reviewedHead = reviewedHeadFromComment(commentBody);
+  if (!reviewedHead) {
+    return {
+      status: "skipped",
+      reason: "durable review does not contain one authoritative full-head marker",
+    };
+  }
+  if (currentHeadSha !== reviewedHead) {
+    return {
+      status: "skipped",
+      reason: "durable review does not cover the current pull request head",
+    };
+  }
+  const [checkRuns, combinedStatus] = await Promise.all([
+    optionalGithubJson({
+      env,
+      fetcher,
+      apiPath: `/repos/${input.repo}/commits/${currentHeadSha}/check-runs?per_page=100`,
+    }),
+    optionalGithubJson({
+      env,
+      fetcher,
+      apiPath: `/repos/${input.repo}/commits/${currentHeadSha}/status?per_page=100`,
+    }),
+  ]);
+  const review = reviewVerdictFromComment(commentBody);
+  const title = cleanInlineText(requiredString(pull.title, "pull request title"));
+  const prUrl = requiredString(pull.html_url, "pull request URL");
+  return {
+    status: "eligible",
+    evidence: {
+      version: 1,
+      repo: input.repo,
+      prNumber: input.itemNumber,
+      prUrl,
+      title: stripEndorTitlePrefix(title),
+      findingSummary: findingSummaryFromPull(title, stringOrNull(pull.body)),
+      reviewedHeadSha: currentHeadSha,
+      reviewDigest: input.reviewCommentDigest,
+      reviewGeneration: requiredReviewGeneration(input.reviewGeneration),
+      verdict: review.verdict,
+      reviewSummary: review.summary,
+      reviewUrl: stringOrNull(comment.html_url) ?? `${prUrl}#issuecomment-${input.reviewCommentId}`,
+      checks: summarizeGithubChecks(checkRuns, combinedStatus),
+      mergeState: normalizeMergeState(pull),
+    },
+  };
+}
+
+export function advanceEndorRemediationReview(
+  evidence: EndorReviewEvidence,
+  runtime: Pick<EndorRuntime, "root" | "now"> = {},
+): EndorAdvanceResult {
+  validateEvidence(evidence);
+  const root = runtime.root ?? process.cwd();
+  const now = (runtime.now ?? (() => new Date()))().toISOString();
+  const statePath = path.join(root, endorReviewStatePath(evidence));
+  const prior = readReviewState(statePath);
+  const headChanged = Boolean(prior && prior.reviewedHeadSha !== evidence.reviewedHeadSha);
+  let entry =
+    !prior || headChanged
+      ? newReviewStateEntry(evidence, now)
+      : { ...prior, reviewGenerations: [...prior.reviewGenerations] };
+  const replay = entry.reviewGenerations.includes(evidence.reviewGeneration);
+  if (!replay) {
+    entry.reviewGenerations.push(evidence.reviewGeneration);
+    entry.cycles = Math.min(DEFAULT_MAX_CYCLES, entry.cycles + 1);
+    entry.lastVerdict = evidence.verdict;
+    entry.updatedAt = now;
+    if (evidence.verdict === "clean") {
+      entry.cleanStreak = Math.min(REQUIRED_CLEAN_STREAK, entry.cleanStreak + 1);
+    } else {
+      entry.cleanStreak = 0;
+    }
+  }
+
+  const terminal =
+    prior?.stopReason && !headChanged
+      ? {
+          outcome: "needs_attention" as const,
+          summary:
+            prior.stopReason === "finding"
+              ? "The prior actionable finding still requires a new reviewed head."
+              : "The six-review safety cap was already reached for this head.",
+          stopReason: prior.stopReason,
+        }
+      : terminalOutcome(evidence, entry);
+  entry.terminalOutcome = terminal?.outcome ?? null;
+  entry.stopReason = terminal?.stopReason ?? null;
+  writeJsonFile(statePath, { version: 1, updated_at: now, review: entry } satisfies ReviewState);
+
+  const common = {
+    cycles: entry.cycles,
+    cleanStreak: entry.cleanStreak,
+    resetReason: headChanged ? ("head_changed" as const) : null,
+  };
+  if (!terminal) {
+    return {
+      action: "requeue",
+      ...common,
+      requeueKey: [
+        "endor-until-clean",
+        evidence.repo,
+        String(evidence.prNumber),
+        evidence.reviewedHeadSha,
+        evidence.reviewGeneration,
+      ].join(":"),
+    };
+  }
+  return {
+    action: "notify",
+    ...common,
+    event: eventFromEvidence(evidence, entry, terminal.outcome, terminal.summary),
+  };
+}
+
+export async function deliverEndorRemediationEvent(
+  event: EndorRemediationReviewedEvent,
+  runtime: EndorRuntime = {},
+): Promise<EndorNotifierSummary> {
+  validateEvent(event);
+  const root = runtime.root ?? process.cwd();
+  const env = runtime.env ?? process.env;
+  const fetcher = runtime.fetch ?? fetch;
+  const now = runtime.now ?? (() => new Date());
+  const log = runtime.log ?? console.log;
+  const ledgerPath = path.join(root, endorDeliveryLedgerPath(event));
+  const reportPath = path.join(root, endorDeliveryReportPath(event));
+  const receipt = readDeliveryLedger(ledgerPath);
+  if (receipt) {
+    if (receipt.notification.idempotencyKey !== event.idempotencyKey) {
+      throw new Error("Endor notification receipt path contains a different event");
+    }
+    const summary = notifierSummary("skipped", 0, 0, 0, 1, "notification already sent");
+    writeReport(reportPath, event, summary, null);
+    log(JSON.stringify(summary));
+    return summary;
+  }
+  let currentEvent: EndorRemediationReviewedEvent;
+  try {
+    const revalidation = await revalidateEndorRemediationEvent(event, { env, fetcher });
+    if (revalidation.action === "complete") {
+      const summary = notifierSummary("skipped", 0, 0, 0, 1, revalidation.reason, {
+        action: "complete",
+      });
+      writeReport(reportPath, event, summary, null);
+      log(JSON.stringify(summary));
+      return summary;
+    }
+    if (revalidation.action === "requeue") {
+      const summary = notifierSummary("skipped", 0, 0, 0, 1, revalidation.reason, {
+        action: "requeue",
+        requeueHeadSha: revalidation.headSha,
+        requeueUpdatedAt: revalidation.updatedAt,
+        requeueKey: [
+          "endor-delivery-refresh",
+          event.repo,
+          String(event.prNumber),
+          revalidation.headSha,
+        ].join(":"),
+      });
+      writeReport(reportPath, event, summary, null);
+      log(JSON.stringify(summary));
+      return summary;
+    }
+    currentEvent = revalidation.event;
+  } catch (error) {
+    const failure = classifyEndorPreparationFailure(error);
+    const summary = notifierSummary("failed", 1, 0, 1, 0, errorText(error), {
+      failureKind: failure.kind === "permanent" ? null : failure.kind,
+      retryAt: failure.retryAt,
+    });
+    writeReport(reportPath, event, summary, null);
+    log(JSON.stringify(summary));
+    return summary;
+  }
+  const config = resolveHermitNotificationConfig(env);
+  if (!config) {
+    const summary = notifierSummary(
+      "failed",
+      1,
+      0,
+      1,
+      0,
+      "CLAWSWEEPER_HERMIT_URL and CLAWSWEEPER_HERMIT_TOKEN are required",
+    );
+    writeReport(reportPath, event, summary, null);
+    log(JSON.stringify(summary));
+    return summary;
+  }
+  try {
+    const result = await postHermitEndorNotification({
+      config,
+      fetcher,
+      notification: currentEvent,
+      idempotencyKey: currentEvent.idempotencyKey,
+    });
+    const notifiedAt = now().toISOString();
+    writeJsonFile(ledgerPath, {
+      version: 1,
+      notification: {
+        ...currentEvent,
+        notifiedAt,
+        hermitMessageId: result.messageId,
+        deliveryProvider: "hermit",
+      },
+    } satisfies DeliveryLedger);
+    const summary = notifierSummary("ok", 0, 1, 0, 0, null);
+    writeReport(reportPath, currentEvent, summary, result.messageId);
+    log(JSON.stringify(summary));
+    return summary;
+  } catch (error) {
+    const summary = notifierSummary("failed", 1, 0, 1, 0, errorText(error), {
+      failureKind: isTransientHermitNotificationError(error) ? "hermit_transient" : null,
+    });
+    writeReport(reportPath, event, summary, null);
+    log(JSON.stringify(summary));
+    return summary;
+  }
+}
+
+async function revalidateEndorRemediationEvent(
+  event: EndorRemediationReviewedEvent,
+  runtime: { env: NodeJS.ProcessEnv; fetcher: typeof fetch },
+): Promise<
+  | { action: "notify"; event: EndorRemediationReviewedEvent }
+  | { action: "requeue"; headSha: string; updatedAt: string | null; reason: string }
+  | { action: "complete"; reason: string }
+> {
+  const pull = await githubJson({
+    env: runtime.env,
+    fetcher: runtime.fetcher,
+    apiPath: `/repos/${event.repo}/pulls/${event.prNumber}`,
+    label: "delivery-time pull request",
+  });
+  if (!isEndorAuthoredPull(pull))
+    throw new Error("delivery-time pull request is not Endor-authored");
+  const inactiveReason = inactivePullReason(pull);
+  if (inactiveReason) return { action: "complete", reason: inactiveReason };
+  const headSha = requiredSha(asJsonObject(pull.head).sha, "delivery-time pull request head SHA");
+  const updatedAt = stringOrNull(pull.updated_at);
+  if (headSha !== event.reviewedHeadSha) {
+    return {
+      action: "requeue",
+      headSha,
+      updatedAt,
+      reason: `pull request head moved from ${event.reviewedHeadSha} to ${headSha}`,
+    };
+  }
+  const [checkRuns, combinedStatus] = await Promise.all([
+    githubJson({
+      env: runtime.env,
+      fetcher: runtime.fetcher,
+      apiPath: `/repos/${event.repo}/commits/${headSha}/check-runs?per_page=100`,
+      label: "delivery-time check runs",
+    }),
+    githubJson({
+      env: runtime.env,
+      fetcher: runtime.fetcher,
+      apiPath: `/repos/${event.repo}/commits/${headSha}/status?per_page=100`,
+      label: "delivery-time commit status",
+    }),
+  ]);
+  const checks = summarizeGithubChecks(checkRuns, combinedStatus);
+  const mergeState = normalizeMergeState(pull);
+  const outcome = currentReadinessOutcome(event, checks.state, mergeState);
+  if (outcome !== event.outcome) {
+    return {
+      action: "requeue",
+      headSha,
+      updatedAt,
+      reason: `delivery-time readiness changed from ${event.outcome} to ${outcome}`,
+    };
+  }
+  return { action: "notify", event: { ...event, checks, mergeState } };
+}
+
+function currentReadinessOutcome(
+  event: EndorRemediationReviewedEvent,
+  checkState: EndorCheckState,
+  mergeState: EndorMergeState,
+): EndorNotificationOutcome {
+  if (event.cleanStreak < REQUIRED_CLEAN_STREAK) return event.outcome;
+  if (checkState === "failing" || mergeState === "blocked") return "needs_attention";
+  if (checkState !== "passing" || mergeState !== "clean") return "unknown";
+  return "ready";
+}
+
+function terminalOutcome(
+  evidence: EndorReviewEvidence,
+  entry: ReviewStateEntry,
+): {
+  outcome: EndorNotificationOutcome;
+  summary: string;
+  stopReason: ReviewStateEntry["stopReason"];
+} | null {
+  if (evidence.verdict === "has_findings") {
+    return { outcome: "needs_attention", summary: evidence.reviewSummary, stopReason: "finding" };
+  }
+  if (entry.cleanStreak >= REQUIRED_CLEAN_STREAK) {
+    if (evidence.checks.state === "failing" || evidence.mergeState === "blocked") {
+      return {
+        outcome: "needs_attention",
+        summary: `${REQUIRED_CLEAN_STREAK}/${REQUIRED_CLEAN_STREAK} clean reviews completed, but current GitHub readiness is blocked.`,
+        stopReason: null,
+      };
+    }
+    if (evidence.checks.state !== "passing" || evidence.mergeState !== "clean") {
+      return {
+        outcome: "unknown",
+        summary: `${REQUIRED_CLEAN_STREAK}/${REQUIRED_CLEAN_STREAK} clean reviews completed, but current checks or merge evidence is unknown.`,
+        stopReason: null,
+      };
+    }
+    return { outcome: "ready", summary: evidence.reviewSummary, stopReason: null };
+  }
+  if (entry.cycles >= DEFAULT_MAX_CYCLES) {
+    return {
+      outcome: "needs_attention",
+      summary: `Stopped at the six-review safety cap with ${entry.cleanStreak}/${REQUIRED_CLEAN_STREAK} consecutive clean reviews.`,
+      stopReason: "safety_cap",
+    };
+  }
+  return null;
+}
+
+function eventFromEvidence(
+  evidence: EndorReviewEvidence,
+  entry: ReviewStateEntry,
+  outcome: EndorNotificationOutcome,
+  reviewSummary: string,
+): EndorRemediationReviewedEvent {
+  const idempotencyKey = [
+    EVENT_TYPE,
+    evidence.repo,
+    String(evidence.prNumber),
+    evidence.reviewedHeadSha,
+    outcome,
+  ].join(":");
+  return {
+    version: 1,
+    type: EVENT_TYPE,
+    repo: evidence.repo,
+    prNumber: evidence.prNumber,
+    prUrl: evidence.prUrl,
+    title: evidence.title,
+    findingSummary: evidence.findingSummary,
+    reviewedHeadSha: evidence.reviewedHeadSha,
+    outcome,
+    reviewSummary,
+    reviewUrl: evidence.reviewUrl,
+    checks: evidence.checks,
+    mergeState: evidence.mergeState,
+    cycles: entry.cycles,
+    cleanStreak: entry.cleanStreak,
+    idempotencyKey,
+  };
+}
+
+function newReviewStateEntry(evidence: EndorReviewEvidence, now: string): ReviewStateEntry {
+  return {
+    repo: evidence.repo,
+    prNumber: evidence.prNumber,
+    reviewedHeadSha: evidence.reviewedHeadSha,
+    cycles: 0,
+    cleanStreak: 0,
+    reviewGenerations: [],
+    lastVerdict: "ambiguous",
+    terminalOutcome: null,
+    stopReason: null,
+    updatedAt: now,
+  };
+}
+
+function isEndorAuthoredPull(pull: JsonObject): boolean {
+  const author = asJsonObject(pull.user);
+  return (
+    author.id === ENDOR_APP_USER_ID &&
+    author.login === ENDOR_APP_LOGIN &&
+    author.type === "Bot" &&
+    author.html_url === ENDOR_APP_URL
+  );
+}
+
+function inactivePullReason(pull: JsonObject): string | null {
+  if (pull.merged === true || stringOrNull(pull.merged_at)) return "pull request is merged";
+  if (pull.state !== "open") return "pull request is not open";
+  return null;
+}
+
+function reviewedHeadFromComment(body: string): string | null {
+  const markers = [...body.matchAll(/<!--\s*clawsweeper-review-version\b([^>]*)-->/gi)];
+  if (markers.length !== 1) return null;
+  const attributes = markers[0]?.[1] ?? "";
+  const versions = [...attributes.matchAll(/(?:^|\s)v=([^\s>]+)(?=\s|$)/gi)];
+  const heads = [...attributes.matchAll(/(?:^|\s)sha=([^\s>]+)(?=\s|$)/gi)];
+  if (versions.length !== 1 || versions[0]?.[1] !== "1" || heads.length !== 1) return null;
+  const head = heads[0]?.[1]?.toLowerCase() ?? "";
+  return /^[0-9a-f]{40}$/.test(head) ? head : null;
+}
+
+function reviewVerdictFromComment(body: string): {
+  verdict: EndorReviewVerdict;
+  summary: string;
+} {
+  const heading = /^## Merge readiness\s*$/im.exec(body);
+  const tail = heading ? body.slice(heading.index + heading[0].length) : "";
+  const nextHeading = /^## /m.exec(tail);
+  const section = nextHeading ? tail.slice(0, nextHeading.index) : tail;
+  const lines = section
+    .split(/\r?\n/)
+    .map((line) => cleanInlineText(line))
+    .filter(Boolean);
+  const summary = lines.slice(0, 2).join(" ") || "Review evidence is unknown.";
+  if (/⚠️|⛔|needs? maintainer attention|items? remain|\bblocked\b/i.test(section)) {
+    return { verdict: "has_findings", summary };
+  }
+  if (/✅|\bReady for maintainer review\b/i.test(section)) {
+    return { verdict: "clean", summary };
+  }
+  return { verdict: "ambiguous", summary };
+}
+
+function summarizeGithubChecks(
+  checkRuns: JsonObject | null,
+  combinedStatus: JsonObject | null,
+): EndorReviewEvidence["checks"] {
+  const checks = [
+    ...(Array.isArray(checkRuns?.check_runs) ? checkRuns.check_runs.map(asJsonObject) : []),
+    ...(Array.isArray(combinedStatus?.statuses)
+      ? combinedStatus.statuses.map(asJsonObject).map(legacyStatusAsCheck)
+      : []),
+  ];
+  if (checks.length === 0) {
+    return { state: "unknown", total: null, summary: "no check result known" };
+  }
+  const summary = summarizeChecks(checks);
+  if (summary.terminalBlockers.length > 0) {
+    return {
+      state: "failing",
+      total: summary.gatingTotal,
+      summary: `${summary.terminalBlockers.length} failing or action-required check${summary.terminalBlockers.length === 1 ? "" : "s"}`,
+    };
+  }
+  if (summary.pending.length > 0) {
+    return {
+      state: "pending",
+      total: summary.gatingTotal,
+      summary: `${summary.pending.length} check${summary.pending.length === 1 ? "" : "s"} pending`,
+    };
+  }
+  if (summary.gatingTotal > 0) {
+    return {
+      state: "passing",
+      total: summary.gatingTotal,
+      summary: `${summary.gatingTotal} gating check${summary.gatingTotal === 1 ? "" : "s"} passed`,
+    };
+  }
+  return { state: "unknown", total: null, summary: "no gating check result known" };
+}
+
+function legacyStatusAsCheck(status: JsonObject): JsonObject {
+  const state = String(status.state ?? "").toUpperCase();
+  return {
+    name: stringOrNull(status.context) ?? "commit status",
+    status: state === "PENDING" ? "IN_PROGRESS" : "COMPLETED",
+    conclusion:
+      state === "SUCCESS" ? "SUCCESS" : state === "FAILURE" || state === "ERROR" ? "FAILURE" : null,
+  };
+}
+
+function normalizeMergeState(pull: JsonObject): EndorMergeState {
+  const state = String(pull.mergeable_state ?? "")
+    .trim()
+    .toLowerCase();
+  if (state === "clean" || state === "has_hooks") return "clean";
+  if (state === "dirty" || state === "blocked" || pull.mergeable === false) return "blocked";
+  if (state === "behind") return "behind";
+  if (state === "unstable") return "unstable";
+  return "unknown";
+}
+
+function findingSummaryFromPull(title: string, body: string | null): string {
+  const parts = [stripEndorTitlePrefix(title)];
+  if (!body) return parts[0]!;
+  const counts = new Map<string, number>();
+  for (const match of body.matchAll(
+    /^\|\s*[^\p{L}\p{N}|]*(Critical|High|Medium|Low)\s*\|\s*([0-9]+)\s*\|/gimu,
+  )) {
+    const severity = match[1];
+    const count = Number(match[2]);
+    if (severity && Number.isSafeInteger(count)) counts.set(severity, count);
+  }
+  if (counts.size > 0) {
+    parts.push(
+      `fixed findings: ${[...counts.entries()]
+        .map(([severity, count]) => `${severity}: ${count}`)
+        .join(", ")}`,
+    );
+  }
+  const advisories = [
+    ...new Set(body.match(/\b(?:GHSA-[a-z0-9-]+|CVE-[0-9]{4}-[0-9]+)\b/gi) ?? []),
+  ].slice(0, 5);
+  if (advisories.length > 0) parts.push(`advisories: ${advisories.join(", ")}`);
+  return parts.join("; ");
+}
+
+function stripEndorTitlePrefix(title: string): string {
+  return title.replace(/^Endor Labs Version Upgrade:\s*/i, "").trim();
+}
+
+function cleanInlineText(value: string): string {
+  return value
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/(?:✅|⚠️|⛔)/gu, "")
+    .replace(/[*_`]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 500);
+}
+
+async function githubJson({
+  env,
+  fetcher,
+  apiPath,
+  label,
+}: {
+  env: NodeJS.ProcessEnv;
+  fetcher: typeof fetch;
+  apiPath: string;
+  label: string;
+}): Promise<JsonObject> {
+  const baseUrl = (stringOrNull(env.GITHUB_API_URL) ?? "https://api.github.com").replace(
+    /\/+$/,
+    "",
+  );
+  const token = stringOrNull(env.GH_TOKEN) ?? stringOrNull(env.GITHUB_TOKEN);
+  const response = await fetcher(`${baseUrl}${apiPath}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`${label} returned HTTP ${response.status}: ${body.slice(0, 500)}`);
+  }
+  const parsed: unknown = JSON.parse(body);
+  if (!isJsonObject(parsed)) throw new Error(`${label} returned a non-object JSON response`);
+  return parsed;
+}
+
+async function optionalGithubJson(
+  options: Omit<Parameters<typeof githubJson>[0], "label">,
+): Promise<JsonObject | null> {
+  try {
+    return await githubJson({ ...options, label: "optional GitHub readiness read" });
+  } catch {
+    return null;
+  }
+}
+
+function readReviewState(filePath: string): ReviewStateEntry | null {
+  if (!fs.existsSync(filePath)) return null;
+  const object = asJsonObject(JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown);
+  if (object.version !== 1) throw new Error("invalid Endor review state version");
+  const review = normalizeReviewStateEntry(object.review);
+  if (!review) throw new Error("invalid Endor review state entry");
+  return review;
+}
+
+function normalizeReviewStateEntry(value: unknown): ReviewStateEntry | null {
+  try {
+    const object = asJsonObject(value);
+    const entry: ReviewStateEntry = {
+      repo: requiredRepo(object.repo),
+      prNumber: requiredPositiveInteger(object.prNumber, "state PR number"),
+      reviewedHeadSha: requiredSha(object.reviewedHeadSha, "state reviewed head"),
+      cycles: requiredNonNegativeInteger(object.cycles, "state cycles"),
+      cleanStreak: requiredNonNegativeInteger(object.cleanStreak, "state clean streak"),
+      reviewGenerations: Array.isArray(object.reviewGenerations)
+        ? object.reviewGenerations.filter(
+            (generation): generation is string =>
+              typeof generation === "string" && /^[0-9A-Za-z._:@/-]{1,256}$/.test(generation),
+          )
+        : [],
+      lastVerdict: requiredVerdict(object.lastVerdict),
+      terminalOutcome:
+        object.terminalOutcome === null ? null : requiredOutcome(object.terminalOutcome),
+      stopReason:
+        object.stopReason === "finding" || object.stopReason === "safety_cap"
+          ? object.stopReason
+          : null,
+      updatedAt: requiredString(object.updatedAt, "state updatedAt"),
+    };
+    if (entry.cycles > DEFAULT_MAX_CYCLES || entry.cleanStreak > REQUIRED_CLEAN_STREAK) return null;
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+function readDeliveryLedger(filePath: string): DeliveryLedger | null {
+  if (!fs.existsSync(filePath)) return null;
+  const object = asJsonObject(JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown);
+  if (object.version !== 1) throw new Error("invalid Endor notification receipt version");
+  const notification = normalizeDeliveryLedgerEntry(object.notification);
+  if (!notification) throw new Error("invalid Endor notification receipt");
+  return { version: 1, notification };
+}
+
+function normalizeDeliveryLedgerEntry(value: unknown): DeliveryLedgerEntry | null {
+  try {
+    const object = asJsonObject(value);
+    const event = normalizeEvent(object);
+    return {
+      ...event,
+      notifiedAt: requiredString(object.notifiedAt, "ledger notifiedAt"),
+      hermitMessageId: requiredString(object.hermitMessageId, "ledger Hermit message ID"),
+      deliveryProvider: requiredDeliveryProvider(object.deliveryProvider),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function validatePreparationInput(input: EndorPreparationInput): void {
+  requiredRepo(input.repo);
+  requiredPositiveInteger(input.itemNumber, "item number");
+  requiredPositiveInteger(input.reviewCommentId, "review comment ID");
+  if (!/^[0-9a-f]{64}$/.test(input.reviewCommentDigest)) {
+    throw new Error("review comment digest must be a lowercase SHA-256");
+  }
+  requiredReviewGeneration(input.reviewGeneration);
+}
+
+function validateEvidence(evidence: EndorReviewEvidence): void {
+  if (evidence.version !== 1) throw new Error("invalid Endor evidence version");
+  requiredRepo(evidence.repo);
+  requiredPositiveInteger(evidence.prNumber, "evidence PR number");
+  requiredSha(evidence.reviewedHeadSha, "evidence reviewed head");
+  if (!/^[0-9a-z-]{1,128}$/.test(evidence.reviewDigest)) {
+    throw new Error("invalid evidence review digest");
+  }
+  requiredReviewGeneration(evidence.reviewGeneration);
+  requiredVerdict(evidence.verdict);
+  requiredCheckState(evidence.checks.state);
+  requiredMergeState(evidence.mergeState);
+}
+
+function validateEvent(event: EndorRemediationReviewedEvent): void {
+  if (event.version !== 1 || event.type !== EVENT_TYPE) throw new Error("invalid Endor event type");
+  requiredRepo(event.repo);
+  requiredPositiveInteger(event.prNumber, "event PR number");
+  requiredSha(event.reviewedHeadSha, "event reviewed head");
+  requiredOutcome(event.outcome);
+  requiredCheckState(event.checks.state);
+  requiredMergeState(event.mergeState);
+  const expected = [
+    EVENT_TYPE,
+    event.repo,
+    String(event.prNumber),
+    event.reviewedHeadSha,
+    event.outcome,
+  ].join(":");
+  if (event.idempotencyKey !== expected) throw new Error("invalid Endor event idempotency key");
+}
+
+function normalizeEvent(value: unknown): EndorRemediationReviewedEvent {
+  const object = asJsonObject(value);
+  const checks = asJsonObject(object.checks);
+  const event: EndorRemediationReviewedEvent = {
+    version: 1,
+    type: EVENT_TYPE,
+    repo: requiredRepo(object.repo),
+    prNumber: requiredPositiveInteger(object.prNumber, "event PR number"),
+    prUrl: requiredString(object.prUrl, "event PR URL"),
+    title: requiredString(object.title, "event title"),
+    findingSummary: requiredString(object.findingSummary, "event finding summary"),
+    reviewedHeadSha: requiredSha(object.reviewedHeadSha, "event reviewed head"),
+    outcome: requiredOutcome(object.outcome),
+    reviewSummary: requiredString(object.reviewSummary, "event review summary"),
+    reviewUrl: requiredString(object.reviewUrl, "event review URL"),
+    checks: {
+      state: requiredCheckState(checks.state),
+      total:
+        checks.total === null
+          ? null
+          : requiredNonNegativeInteger(checks.total, "event check total"),
+      summary: requiredString(checks.summary, "event check summary"),
+    },
+    mergeState: requiredMergeState(object.mergeState),
+    cycles: requiredPositiveInteger(object.cycles, "event cycles"),
+    cleanStreak: requiredNonNegativeInteger(object.cleanStreak, "event clean streak"),
+    idempotencyKey: requiredString(object.idempotencyKey, "event idempotency key"),
+  };
+  validateEvent(event);
+  return event;
+}
+
+function requiredRepo(value: unknown): string {
+  const repo = requiredString(value, "repository");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) throw new Error("invalid repository");
+  return repo;
+}
+
+function requiredDeliveryProvider(value: unknown): "hermit" {
+  if (value !== "hermit") throw new Error("invalid ledger delivery provider");
+  return value;
+}
+
+function endorPullStateRoot(value: { repo: string; prNumber: number }): string {
+  const repo = requiredRepo(value.repo).toLowerCase();
+  const prNumber = requiredPositiveInteger(value.prNumber, "PR number");
+  return path.posix.join(ENDOR_STATE_ROOT, repo, "pulls", String(prNumber));
+}
+
+function requiredString(value: unknown, label: string): string {
+  const normalized = stringOrNull(value);
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function requiredReviewGeneration(value: unknown): string {
+  const generation = requiredString(value, "review generation");
+  if (!/^[0-9A-Za-z._:@/-]{1,256}$/.test(generation)) {
+    throw new Error("invalid review generation");
+  }
+  return generation;
+}
+
+function requiredPositiveInteger(value: unknown, label: string): number {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 1) throw new Error(`${label} must be positive`);
+  return number;
+}
+
+function requiredNonNegativeInteger(value: unknown, label: string): number {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) throw new Error(`${label} must be non-negative`);
+  return number;
+}
+
+function requiredSha(value: unknown, label: string): string {
+  const sha = requiredString(value, label).toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(sha)) throw new Error(`${label} must be a 40-character SHA`);
+  return sha;
+}
+
+function requiredVerdict(value: unknown): EndorReviewVerdict {
+  if (value === "clean" || value === "has_findings" || value === "ambiguous") return value;
+  throw new Error("invalid Endor review verdict");
+}
+
+function requiredOutcome(value: unknown): EndorNotificationOutcome {
+  if (value === "ready" || value === "needs_attention" || value === "unknown") return value;
+  throw new Error("invalid Endor notification outcome");
+}
+
+function requiredCheckState(value: unknown): EndorCheckState {
+  if (value === "passing" || value === "pending" || value === "failing" || value === "unknown") {
+    return value;
+  }
+  throw new Error("invalid Endor check state");
+}
+
+function requiredMergeState(value: unknown): EndorMergeState {
+  if (
+    value === "clean" ||
+    value === "blocked" ||
+    value === "behind" ||
+    value === "unstable" ||
+    value === "unknown"
+  ) {
+    return value;
+  }
+  throw new Error("invalid Endor merge state");
+}
+
+function notifierSummary(
+  status: EndorNotifierSummary["status"],
+  pending: number,
+  sent: number,
+  failed: number,
+  skipped: number,
+  reason: string | null,
+  details: Partial<
+    Pick<
+      EndorNotifierSummary,
+      "action" | "requeueHeadSha" | "requeueUpdatedAt" | "requeueKey" | "failureKind" | "retryAt"
+    >
+  > = {},
+): EndorNotifierSummary {
+  return {
+    action: details.action ?? "notify",
+    status,
+    pending,
+    sent,
+    failed,
+    skipped,
+    exitCode: failed > 0 ? 1 : 0,
+    reason,
+    requeueHeadSha: details.requeueHeadSha ?? null,
+    requeueUpdatedAt: details.requeueUpdatedAt ?? null,
+    requeueKey: details.requeueKey ?? null,
+    failureKind: details.failureKind ?? null,
+    retryAt: details.retryAt ?? null,
+  };
+}
+
+function writeReport(
+  reportPath: string,
+  event: EndorRemediationReviewedEvent,
+  summary: EndorNotifierSummary,
+  hermitMessageId: string | null,
+): void {
+  writeJsonFile(reportPath, {
+    version: 1,
+    event_type: EVENT_TYPE,
+    event_key: event.idempotencyKey,
+    repository: event.repo,
+    pr_number: event.prNumber,
+    reviewed_head_sha: event.reviewedHeadSha,
+    outcome: event.outcome,
+    status: summary.status,
+    reason: summary.reason,
+    action: summary.action,
+    hermit_message_id: hermitMessageId,
+  });
+}
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function reviewTupleFromRecord(recordPath: string): {
+  reviewCommentId: number;
+  reviewCommentDigest: string;
+} {
+  const markdown = fs.readFileSync(recordPath, "utf8");
+  const id = strictFrontMatterValue(markdown, "review_comment_id");
+  const digest = strictFrontMatterValue(markdown, "review_comment_sha256");
+  return {
+    reviewCommentId: requiredPositiveInteger(id, "review comment ID"),
+    reviewCommentDigest: requiredString(digest, "review comment digest"),
+  };
+}
+
+function strictFrontMatterValue(markdown: string, key: string): string {
+  const frontMatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(markdown)?.[1];
+  if (!frontMatter) throw new Error("review record is missing front matter");
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const matches = [...frontMatter.matchAll(new RegExp(`^${escaped}:\\s*(.*)$`, "gm"))];
+  if (matches.length !== 1 || !matches[0]?.[1]?.trim()) {
+    throw new Error(`review record has invalid ${key}`);
+  }
+  return matches[0][1].trim();
+}
+
+async function runCli(argv: string[]): Promise<number> {
+  const command = argv[0];
+  const options = parseCliOptions(argv.slice(1));
+  if (command === "prepare") {
+    try {
+      const evidencePath = requiredCliOption(options, "evidence-path");
+      const tuple = reviewTupleFromRecord(requiredCliOption(options, "record-path"));
+      const result = await prepareEndorRemediationReview({
+        repo: requiredCliOption(options, "repo"),
+        itemNumber: Number(requiredCliOption(options, "item-number")),
+        reviewGeneration: requiredCliOption(options, "review-generation"),
+        ...tuple,
+      });
+      if (result.status === "eligible") writeJsonFile(evidencePath, result.evidence);
+      else fs.rmSync(evidencePath, { force: true });
+      appendGithubOutput("eligible", String(result.status === "eligible"));
+      appendGithubOutput("reason", result.status === "eligible" ? "eligible" : result.reason);
+      console.log(JSON.stringify(result, null, 2));
+      return 0;
+    } catch (error) {
+      const failure = classifyEndorPreparationFailure(error);
+      appendGithubOutput("failure_kind", failure.kind);
+      appendGithubOutput("retry_at", failure.retryAt ?? "");
+      throw error;
+    }
+  }
+  if (command === "advance") {
+    const evidence = normalizeEvidence(
+      JSON.parse(fs.readFileSync(requiredCliOption(options, "evidence-path"), "utf8")) as unknown,
+    );
+    const result = advanceEndorRemediationReview(evidence);
+    const eventPath = requiredCliOption(options, "event-path");
+    if (result.action === "notify") writeJsonFile(eventPath, result.event);
+    else fs.rmSync(eventPath, { force: true });
+    appendGithubOutput("action", result.action);
+    appendGithubOutput("cycles", String(result.cycles));
+    appendGithubOutput("clean_streak", String(result.cleanStreak));
+    appendGithubOutput("requeue_key", result.action === "requeue" ? result.requeueKey : "");
+    appendGithubOutput("state_path", endorReviewStatePath(evidence));
+    console.log(JSON.stringify(result, null, 2));
+    return 0;
+  }
+  if (command === "deliver") {
+    const event = normalizeEvent(
+      JSON.parse(fs.readFileSync(requiredCliOption(options, "event-path"), "utf8")) as unknown,
+    );
+    appendGithubOutput("ledger_path", endorDeliveryLedgerPath(event));
+    appendGithubOutput("report_path", endorDeliveryReportPath(event));
+    const result = await deliverEndorRemediationEvent(event);
+    appendGithubOutput("action", result.action);
+    appendGithubOutput("requeue_head_sha", result.requeueHeadSha ?? "");
+    appendGithubOutput("requeue_updated_at", result.requeueUpdatedAt ?? "");
+    appendGithubOutput("requeue_key", result.requeueKey ?? "");
+    appendGithubOutput("failure_kind", result.failureKind ?? "");
+    appendGithubOutput("retry_at", result.retryAt ?? "");
+    return result.exitCode;
+  }
+  throw new Error("usage: notify-endor-remediation <prepare|advance|deliver> [options]");
+}
+
+function normalizeEvidence(value: unknown): EndorReviewEvidence {
+  const object = asJsonObject(value);
+  const checks = asJsonObject(object.checks);
+  const evidence: EndorReviewEvidence = {
+    version: 1,
+    repo: requiredRepo(object.repo),
+    prNumber: requiredPositiveInteger(object.prNumber, "evidence PR number"),
+    prUrl: requiredString(object.prUrl, "evidence PR URL"),
+    title: requiredString(object.title, "evidence title"),
+    findingSummary: requiredString(object.findingSummary, "evidence finding summary"),
+    reviewedHeadSha: requiredSha(object.reviewedHeadSha, "evidence reviewed head"),
+    reviewDigest: requiredString(object.reviewDigest, "evidence review digest"),
+    reviewGeneration: requiredReviewGeneration(object.reviewGeneration),
+    verdict: requiredVerdict(object.verdict),
+    reviewSummary: requiredString(object.reviewSummary, "evidence review summary"),
+    reviewUrl: requiredString(object.reviewUrl, "evidence review URL"),
+    checks: {
+      state: requiredCheckState(checks.state),
+      total:
+        checks.total === null
+          ? null
+          : requiredNonNegativeInteger(checks.total, "evidence check total"),
+      summary: requiredString(checks.summary, "evidence check summary"),
+    },
+    mergeState: requiredMergeState(object.mergeState),
+  };
+  validateEvidence(evidence);
+  return evidence;
+}
+
+function parseCliOptions(argv: string[]): Map<string, string> {
+  const options = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw new Error(`invalid CLI option near ${flag ?? "end of arguments"}`);
+    }
+    options.set(flag.slice(2), value);
+  }
+  return options;
+}
+
+function requiredCliOption(options: Map<string, string>, name: string): string {
+  const value = options.get(name)?.trim();
+  if (!value) throw new Error(`--${name} is required`);
+  return value;
+}
+
+function appendGithubOutput(name: string, value: string): void {
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) return;
+  fs.appendFileSync(output, `${name}=${value.replace(/[\r\n]+/g, " ")}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli(process.argv.slice(2))
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      console.error(errorText(error));
+      process.exitCode = 1;
+    });
+}

--- a/test/exact-review-publication-retry.test.ts
+++ b/test/exact-review-publication-retry.test.ts
@@ -8,7 +8,12 @@ import {
 const itemKey = "openclaw/openclaw#112030@publish:30795752045:1";
 
 test("ordinary publication failures retry within six minutes even after repeated failures", () => {
-  for (const reasonCode of ["github_transient", "state_contention", "unknown_failure"]) {
+  for (const reasonCode of [
+    "github_transient",
+    "hermit_transient",
+    "state_contention",
+    "unknown_failure",
+  ]) {
     for (const kind of ["retryable_failure", "permanent_failure"]) {
       for (const attempt of [1, 2, 3, 4, 8, 12]) {
         const delay = exactReviewPublicationRetryDelayMs(itemKey, { kind, reasonCode }, attempt);
@@ -63,6 +68,15 @@ test("publication retry exhaustion preserves transient, permanent, and unknown b
       now,
     ),
     true,
+  );
+  assert.equal(
+    exactReviewPublicationRetryExhausted(
+      { kind: "retryable_failure", reasonCode: "hermit_transient" },
+      47,
+      now,
+      now,
+    ),
+    false,
   );
   assert.equal(
     exactReviewPublicationRetryExhausted(
@@ -128,4 +142,5 @@ test("faster retries preserve the previous unknown and transient outage horizons
 
   assert.ok(elapsedUntilExhausted("unknown_failure") >= 50 * 60_000);
   assert.ok(elapsedUntilExhausted("github_transient") >= 210 * 60_000);
+  assert.ok(elapsedUntilExhausted("hermit_transient") >= 210 * 60_000);
 });

--- a/test/repair/endor-remediation-workflow.test.ts
+++ b/test/repair/endor-remediation-workflow.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parse } from "yaml";
+
+const workflow = fs.readFileSync(".github/workflows/sweep.yml", "utf8");
+const publishStart = workflow.indexOf("\n  event-review-publish:");
+const publishEnd = workflow.indexOf("\n  event-review-terminal-finalization:", publishStart);
+const publication = workflow.slice(publishStart, publishEnd);
+
+test("exact-review publication finalization fences Endor convergence and notification durability", () => {
+  assert.ok(publishStart > 0);
+  assert.ok(publishEnd > publishStart);
+  assert.match(publication, /name: Prepare Endor exact-head review/);
+  assert.match(
+    publication,
+    /--review-generation "\$PUBLISHER_LEASE_ID:\$PUBLISHER_LEASE_REVISION"/,
+  );
+  assert.match(publication, /name: Advance Endor review-until-clean state/);
+  assert.match(publication, /name: Queue next Endor exact-head review/);
+  assert.match(publication, /name: Deliver Endor remediation notification/);
+  assert.match(
+    publication,
+    /name: Deliver Endor remediation notification[\s\S]*?GH_TOKEN: \$\{\{ steps\.target-write-token\.outputs\.token \}\}/,
+  );
+  assert.match(publication, /name: Queue current Endor head after delivery drift/);
+  assert.match(publication, /CLAWSWEEPER_HERMIT_URL/);
+  assert.match(publication, /CLAWSWEEPER_HERMIT_TOKEN/);
+  assert.match(publication, /name: Publish Endor terminal review state/);
+  assert.match(publication, /name: Publish Endor notification receipt/);
+  assert.match(publication, /id: endor-finalization-readiness/);
+  assert.match(publication, /steps\.advance-endor-review\.outputs\.state_path/);
+  assert.match(publication, /steps\.deliver-endor-notification\.outputs\.ledger_path/);
+  assert.match(publication, /steps\.deliver-endor-notification\.outputs\.report_path/);
+  assert.doesNotMatch(publication, /endor-remediation-(?:review-state|ledger|report)\.json/);
+  assert.match(publication, /steps\.prepare-endor-review\.outputs\.failure_kind/);
+  assert.match(publication, /steps\.prepare-endor-review\.outputs\.retry_at/);
+  assert.match(publication, /steps\.deliver-endor-notification\.outputs\.failure_kind/);
+  assert.match(publication, /steps\.queue-current-endor-head\.outcome/);
+  assert.doesNotMatch(publication, /ENDOR_ACTION/);
+  assert.doesNotMatch(
+    publication,
+    /\[ "\$outcome" = "success" \] && \[ "\$ENDOR_ACTION" = "requeue" \]/,
+  );
+
+  const prepare = publication.indexOf("name: Prepare Endor exact-head review");
+  const publishTerminal = publication.indexOf("name: Publish Endor terminal review state");
+  const deliver = publication.indexOf("name: Deliver Endor remediation notification");
+  const publishReceipt = publication.indexOf("name: Publish Endor notification receipt");
+  const readiness = publication.indexOf("name: Resolve Endor finalization readiness");
+  const acknowledgement = publication.indexOf("name: Complete durable exact review publication");
+  assert.ok(prepare > 0);
+  assert.ok(publishTerminal > prepare);
+  assert.ok(deliver > publishTerminal);
+  assert.ok(publishReceipt > deliver);
+  assert.ok(readiness > publishReceipt);
+  assert.ok(acknowledgement > readiness);
+  assert.match(publication, /ENDOR_FINALIZATION_READY/);
+});
+
+test("Endor publication completion retires queued successors and retries transient preparation", () => {
+  const document = parse(workflow) as {
+    jobs: Record<
+      string,
+      { steps: Array<{ name?: string; run?: string; env?: Record<string, unknown> }> }
+    >;
+  };
+  const exportStep = document.jobs["event-review-publish"]?.steps.find(
+    (step) => step.name === "Export exact review publication result",
+  );
+  assert.ok(exportStep?.run);
+  const baseEnv = Object.fromEntries(Object.keys(exportStep.env ?? {}).map((name) => [name, ""]));
+  const run = (overrides: Record<string, string>) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "endor-publication-result-"));
+    const output = path.join(root, "github-output");
+    try {
+      execFileSync("bash", ["-c", exportStep.run!], {
+        env: { ...process.env, ...baseEnv, ...overrides, GITHUB_OUTPUT: output },
+      });
+      return Object.fromEntries(
+        fs
+          .readFileSync(output, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => {
+            const separator = line.indexOf("=");
+            return [line.slice(0, separator), line.slice(separator + 1)];
+          }),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  assert.deepEqual(
+    run({
+      ENDOR_FINALIZATION_READY: "false",
+      ENDOR_PREPARE_OUTCOME: "failure",
+      ENDOR_PREPARE_FAILURE_KIND: "github_transient",
+      REQUEUE_LATEST: "false",
+    }),
+    {
+      outcome: "failure",
+      completion_kind: "retryable_failure",
+      reason_code: "github_transient",
+      requeue_latest: "false",
+      direct_requeue: "false",
+      failure_kind: "github_transient",
+    },
+  );
+
+  const successor = run({
+    ENDOR_FINALIZATION_READY: "true",
+    ENDOR_PREPARE_OUTCOME: "success",
+    PRIOR_JOB_STATUS: "success",
+    PUBLISH_OUTCOME: "success",
+    PUBLISH_COMPLETION_KIND: "published",
+    PUBLISH_REASON_CODE: "publication_applied",
+    GUARDED_OPEN: "true",
+    REQUEUE_LATEST: "false",
+  });
+  assert.equal(successor.outcome, "success");
+  assert.equal(successor.completion_kind, "published");
+  assert.equal(successor.reason_code, "publication_applied");
+  assert.equal(successor.requeue_latest, "false");
+
+  const deliveryRetry = run({
+    ENDOR_FINALIZATION_READY: "false",
+    ENDOR_DELIVERY_OUTCOME: "failure",
+    ENDOR_DELIVERY_FAILURE_KIND: "github_transient",
+    REQUEUE_LATEST: "false",
+  });
+  assert.equal(deliveryRetry.completion_kind, "retryable_failure");
+  assert.equal(deliveryRetry.reason_code, "github_transient");
+  assert.equal(deliveryRetry.failure_kind, "github_transient");
+
+  const hermitRetry = run({
+    ENDOR_FINALIZATION_READY: "false",
+    ENDOR_DELIVERY_OUTCOME: "failure",
+    ENDOR_DELIVERY_FAILURE_KIND: "hermit_transient",
+    REQUEUE_LATEST: "false",
+  });
+  assert.equal(hermitRetry.completion_kind, "retryable_failure");
+  assert.equal(hermitRetry.reason_code, "hermit_transient");
+  assert.equal(hermitRetry.failure_kind, undefined);
+});
+
+test("delivery terminal races finalize without a receipt or another review", () => {
+  const document = parse(workflow) as {
+    jobs: Record<
+      string,
+      { steps: Array<{ name?: string; run?: string; env?: Record<string, unknown> }> }
+    >;
+  };
+  const readinessStep = document.jobs["event-review-publish"]?.steps.find(
+    (step) => step.name === "Resolve Endor finalization readiness",
+  );
+  assert.ok(readinessStep?.run);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "endor-terminal-readiness-"));
+  const output = path.join(root, "github-output");
+  try {
+    execFileSync("bash", ["-c", readinessStep.run], {
+      env: {
+        ...process.env,
+        ...Object.fromEntries(Object.keys(readinessStep.env ?? {}).map((name) => [name, ""])),
+        PREPARE_OUTCOME: "success",
+        ELIGIBLE: "true",
+        ADVANCE_OUTCOME: "success",
+        ACTION: "notify",
+        DELIVERY_OUTCOME: "success",
+        DELIVERY_ACTION: "complete",
+        TERMINAL_STATE_PUBLICATION_OUTCOME: "success",
+        GITHUB_OUTPUT: output,
+      },
+    });
+    assert.equal(fs.readFileSync(output, "utf8"), "ready=true\n");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the default direct path diverts eligible Endor reviews to durable publication", () => {
+  const document = parse(workflow) as {
+    jobs: Record<
+      string,
+      { steps: Array<{ name?: string; run?: string; env?: Record<string, unknown>; if?: string }> }
+    >;
+  };
+  const steps = document.jobs["event-review-apply"]?.steps ?? [];
+  const prepareIndex = steps.findIndex(
+    (step) => step.name === "Deliver GitHub effects and prepare direct state mutation",
+  );
+  const detectIndex = steps.findIndex(
+    (step) => step.name === "Detect Endor review for durable publication",
+  );
+  const routeIndex = steps.findIndex(
+    (step) => step.name === "Resolve direct exact review publication route",
+  );
+  const directIndex = steps.findIndex(
+    (step) => step.name === "Post direct exact review publication result",
+  );
+  assert.ok(prepareIndex >= 0 && detectIndex > prepareIndex);
+  assert.ok(routeIndex > detectIndex && directIndex > routeIndex);
+  assert.match(
+    steps[directIndex]?.if ?? "",
+    /direct-publication-route\.outputs\.route == 'direct'/,
+  );
+
+  const routeStep = steps[routeIndex];
+  assert.ok(routeStep?.run);
+  const run = (overrides: Record<string, string>) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "endor-direct-route-"));
+    const output = path.join(root, "github-output");
+    try {
+      execFileSync("bash", ["-c", routeStep.run!], {
+        env: {
+          ...process.env,
+          ITEM_KIND: "",
+          DETECTION_OUTCOME: "",
+          ENDOR_ELIGIBLE: "",
+          ...overrides,
+          GITHUB_OUTPUT: output,
+        },
+      });
+      return fs.readFileSync(output, "utf8").trim();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  assert.equal(run({ ITEM_KIND: "issue" }), "route=direct");
+  assert.equal(
+    run({ ITEM_KIND: "pull_request", DETECTION_OUTCOME: "success", ENDOR_ELIGIBLE: "false" }),
+    "route=direct",
+  );
+  assert.equal(
+    run({ ITEM_KIND: "pull_request", DETECTION_OUTCOME: "success", ENDOR_ELIGIBLE: "true" }),
+    "route=durable_publication",
+  );
+  assert.equal(
+    run({ ITEM_KIND: "pull_request", DETECTION_OUTCOME: "failure" }),
+    "route=durable_publication",
+  );
+});

--- a/test/repair/hermit-notification.test.ts
+++ b/test/repair/hermit-notification.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  HermitNotificationHttpError,
+  isTransientHermitNotificationError,
+  postHermitEndorNotification,
+  resolveHermitEndorNotificationUrl,
+  resolveHermitNotificationConfig,
+  type HermitNotificationConfig,
+} from "../../dist/repair/hermit-notification.js";
+
+const config: HermitNotificationConfig = {
+  endpoint: "https://hermit.example/api/clawsweeper/endor-remediation/reviewed",
+  token: "secret",
+  timeoutSeconds: 30,
+  retryAttempts: 3,
+};
+
+test("Hermit delivery retries transient failures with the same structured event", async () => {
+  const requests: Array<{ url: string; headers: Headers; body: string }> = [];
+  const delays: number[] = [];
+  const result = await postHermitEndorNotification({
+    config,
+    idempotencyKey: "event-key",
+    notification: { type: "event", value: 1 },
+    retryDelaysMs: [1, 4],
+    sleep: async (ms) => {
+      delays.push(ms);
+    },
+    fetcher: async (input, init) => {
+      requests.push({
+        url: String(input),
+        headers: new Headers(init?.headers),
+        body: String(init?.body),
+      });
+      if (requests.length === 1) return new Response("unavailable", { status: 503 });
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          delivered: true,
+          duplicate: true,
+          messageId: "discord-message-123",
+        }),
+        { status: 200 },
+      );
+    },
+  });
+
+  assert.deepEqual(result, { messageId: "discord-message-123", duplicate: true });
+  assert.equal(requests.length, 2);
+  assert.deepEqual(delays, [1]);
+  assert.equal(requests[0]?.url, config.endpoint);
+  assert.equal(requests[0]?.headers.get("authorization"), "Bearer secret");
+  assert.equal(requests[0]?.headers.get("idempotency-key"), "event-key");
+  assert.equal(requests[0]?.body, requests[1]?.body);
+});
+
+test("Hermit delivery does not retry permanent failures or invalid receipts", async () => {
+  let permanentCalls = 0;
+  await assert.rejects(
+    postHermitEndorNotification({
+      config,
+      idempotencyKey: "event-key",
+      notification: { type: "event" },
+      sleep: async () => undefined,
+      fetcher: async () => {
+        permanentCalls += 1;
+        return new Response("unauthorized", { status: 401 });
+      },
+    }),
+    /Hermit notification returned 401/,
+  );
+  assert.equal(permanentCalls, 1);
+
+  await assert.rejects(
+    postHermitEndorNotification({
+      config: { ...config, retryAttempts: 1 },
+      idempotencyKey: "event-key",
+      notification: { type: "event" },
+      fetcher: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    }),
+    /invalid Endor notification receipt/,
+  );
+});
+
+test("Hermit configuration resolves the fixed Endor route", () => {
+  assert.deepEqual(
+    resolveHermitNotificationConfig({
+      CLAWSWEEPER_HERMIT_URL: "https://hermit.example/some/old/path?unused=1",
+      CLAWSWEEPER_HERMIT_TOKEN: " secret ",
+      CLAWSWEEPER_HERMIT_TIMEOUT_SECONDS: "45",
+      CLAWSWEEPER_HERMIT_RETRY_ATTEMPTS: "4",
+    }),
+    {
+      endpoint: "https://hermit.example/api/clawsweeper/endor-remediation/reviewed",
+      token: "secret",
+      timeoutSeconds: 45,
+      retryAttempts: 4,
+    },
+  );
+  assert.equal(resolveHermitNotificationConfig({}), null);
+  assert.equal(
+    resolveHermitEndorNotificationUrl("https://hermit.example"),
+    "https://hermit.example/api/clawsweeper/endor-remediation/reviewed",
+  );
+  assert.throws(() => resolveHermitEndorNotificationUrl("file:///tmp/hermit"), /HTTP or HTTPS/);
+});
+
+test("Hermit transient classification covers retryable HTTP and network failures", () => {
+  assert.equal(
+    isTransientHermitNotificationError(new HermitNotificationHttpError(502, "bad")),
+    true,
+  );
+  assert.equal(
+    isTransientHermitNotificationError(new HermitNotificationHttpError(409, "bad")),
+    false,
+  );
+  assert.equal(isTransientHermitNotificationError(new Error("read ECONNRESET")), true);
+});

--- a/test/repair/notify-endor-remediation.test.ts
+++ b/test/repair/notify-endor-remediation.test.ts
@@ -386,7 +386,7 @@ test("delivery requeues the live PR head instead of notifying a stale reviewed h
     env: hermitEnv(),
     log: () => undefined,
     fetch: async (input, init) => {
-      if (String(input).includes("api.github.com")) {
+      if (new URL(String(input)).hostname === "api.github.com") {
         return jsonResponse({
           head: { sha: NEXT_HEAD },
           user: {
@@ -422,7 +422,7 @@ test("transient delivery-time GitHub failures remain retryable without notifying
     env: hermitEnv(),
     log: () => undefined,
     fetch: async (input, init) => {
-      if (String(input).includes("api.github.com")) {
+      if (new URL(String(input)).hostname === "api.github.com") {
         return new Response("temporarily unavailable", { status: 503 });
       }
       if (init?.method === "POST") hookRequests += 1;
@@ -702,9 +702,12 @@ function deliveryFixtureFetch({
   onHook: (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
 }): typeof fetch {
   return async (input, init) => {
-    const url = String(input);
-    if (url.includes("api.github.com")) onGithub(input, init);
-    if (/api\.github\.com\/repos\/[^/]+\/[^/]+\/pulls\/\d+$/.test(url)) {
+    const url = new URL(String(input));
+    if (url.hostname === "api.github.com") onGithub(input, init);
+    if (
+      url.hostname === "api.github.com" &&
+      /^\/repos\/[^/]+\/[^/]+\/pulls\/\d+$/.test(url.pathname)
+    ) {
       return jsonResponse({
         head: { sha: head() },
         user: {
@@ -721,7 +724,7 @@ function deliveryFixtureFetch({
         updated_at: "2026-08-24T00:03:00Z",
       });
     }
-    if (url.includes("/check-runs")) {
+    if (url.pathname.endsWith("/check-runs")) {
       return jsonResponse({
         check_runs: [
           { name: "build", status: "completed", conclusion: "success" },
@@ -729,7 +732,9 @@ function deliveryFixtureFetch({
         ],
       });
     }
-    if (url.endsWith("/status?per_page=100")) return jsonResponse({ statuses: [] });
+    if (url.pathname.endsWith("/status") && url.searchParams.get("per_page") === "100") {
+      return jsonResponse({ statuses: [] });
+    }
     return onHook(input, init);
   };
 }

--- a/test/repair/notify-endor-remediation.test.ts
+++ b/test/repair/notify-endor-remediation.test.ts
@@ -1,0 +1,751 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  advanceEndorRemediationReview,
+  classifyEndorPreparationFailure,
+  deliverEndorRemediationEvent,
+  endorDeliveryLedgerPath,
+  prepareEndorRemediationReview,
+  type EndorReviewEvidence,
+} from "../../dist/repair/notify-endor-remediation.js";
+
+const HEAD = "a".repeat(40);
+const NEXT_HEAD = "b".repeat(40);
+const ENDOR_BODY = `<h1>Endor Labs Automated Dependency Update</h1>
+
+## Summary
+
+| Dependency Name | Update Version (From ➡️ To) | Update Risk |
+|---|---|---|
+| \`example-package\` | \`1.0.0\` ➡️ \`1.0.1\` | \`LOW\` |
+
+## Security Impact
+
+| Severity | Count |
+|---|---|
+| High | 1 |
+
+GHSA-aaaa-bbbb-cccc is reachable.`;
+
+test("Endor preparation distinguishes retryable GitHub failures from invalid evidence", () => {
+  assert.deepEqual(
+    classifyEndorPreparationFailure(new Error("GitHub item returned HTTP 503: unavailable")),
+    { kind: "github_transient", retryAt: null },
+  );
+  const rateLimit = classifyEndorPreparationFailure(
+    new Error("GitHub item returned HTTP 429: retry-after: 60"),
+  );
+  assert.equal(rateLimit.kind, "github_rate_limit");
+  assert.match(rateLimit.retryAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
+  assert.deepEqual(classifyEndorPreparationFailure(new Error("invalid repository")), {
+    kind: "permanent",
+    retryAt: null,
+  });
+});
+
+test("only the authoritative Endor App PR with a current durable review qualifies", async () => {
+  const comment = reviewComment(HEAD, "clean", "review-1");
+  const prepared = await prepareEndorRemediationReview(preparationInput(comment), {
+    fetch: githubFixture({ comment }),
+  });
+
+  assert.equal(prepared.status, "eligible");
+  if (prepared.status !== "eligible") return;
+  assert.equal(prepared.evidence.reviewedHeadSha, HEAD);
+  assert.equal(prepared.evidence.verdict, "clean");
+  assert.match(prepared.evidence.findingSummary, /example-package/);
+  assert.match(prepared.evidence.findingSummary, /High: 1/);
+  assert.match(prepared.evidence.findingSummary, /GHSA-aaaa-bbbb-cccc/);
+
+  for (const spoof of [
+    { authorId: 99 },
+    { authorLogin: "endor-labs-pro" },
+    { authorType: "User" },
+    { authorUrl: "https://github.com/endor-labs-pro" },
+  ]) {
+    const rejected = await prepareEndorRemediationReview(preparationInput(comment), {
+      fetch: githubFixture({ comment, ...spoof }),
+    });
+    assert.deepEqual(rejected, {
+      status: "skipped",
+      reason: "pull request is not Endor-authored",
+    });
+  }
+
+  const issue = await prepareEndorRemediationReview(preparationInput(comment), {
+    fetch: githubFixture({ comment, isPullRequest: false }),
+  });
+  assert.deepEqual(issue, { status: "skipped", reason: "reviewed item is not a pull request" });
+
+  const closed = await prepareEndorRemediationReview(preparationInput(comment), {
+    fetch: githubFixture({ comment, state: "closed" }),
+  });
+  assert.deepEqual(closed, { status: "skipped", reason: "pull request is not open" });
+
+  const merged = await prepareEndorRemediationReview(preparationInput(comment), {
+    fetch: githubFixture({ comment, state: "closed", merged: true }),
+  });
+  assert.deepEqual(merged, { status: "skipped", reason: "pull request is merged" });
+});
+
+test("stale digests and reviewed-head mismatches cannot advance the streak", async () => {
+  const comment = reviewComment(HEAD, "clean", "review-1");
+  await assert.rejects(
+    prepareEndorRemediationReview(
+      { ...preparationInput(comment), reviewCommentDigest: "0".repeat(64) },
+      { fetch: githubFixture({ comment }) },
+    ),
+    /durable review comment digest mismatch/,
+  );
+
+  const stale = await prepareEndorRemediationReview(preparationInput(comment), {
+    fetch: githubFixture({ comment, headSha: NEXT_HEAD }),
+  });
+  assert.deepEqual(stale, {
+    status: "skipped",
+    reason: "durable review does not cover the current pull request head",
+  });
+
+  const visibleHeadOnly = comment.replace(/\n<!-- clawsweeper-review-version\b[^>]* -->/, "");
+  const incomplete = await prepareEndorRemediationReview(preparationInput(visibleHeadOnly), {
+    fetch: githubFixture({ comment: visibleHeadOnly }),
+  });
+  assert.deepEqual(incomplete, {
+    status: "skipped",
+    reason: "durable review does not contain one authoritative full-head marker",
+  });
+});
+
+test("three distinct clean reviews on one exact head are required", () => {
+  const root = temporaryRoot();
+  const first = advanceEndorRemediationReview(evidence("clean", HEAD, "review-1"), { root });
+  const second = advanceEndorRemediationReview(evidence("clean", HEAD, "review-2"), { root });
+  const replay = advanceEndorRemediationReview(evidence("clean", HEAD, "review-2"), { root });
+  const third = advanceEndorRemediationReview(evidence("clean", HEAD, "review-3"), { root });
+
+  assert.deepEqual(progress(first), { action: "requeue", cycles: 1, cleanStreak: 1 });
+  assert.deepEqual(progress(second), { action: "requeue", cycles: 2, cleanStreak: 2 });
+  assert.deepEqual(progress(replay), { action: "requeue", cycles: 2, cleanStreak: 2 });
+  assert.equal(third.action, "notify");
+  assert.equal(third.cycles, 3);
+  assert.equal(third.cleanStreak, 3);
+  assert.equal(third.event.outcome, "ready");
+  assert.equal(
+    third.event.idempotencyKey,
+    `clawsweeper.endor_remediation_reviewed:openclaw/openclaw:123:${HEAD}:ready`,
+  );
+});
+
+test("identical rendered reviews advance through distinct publication generations", () => {
+  const root = temporaryRoot();
+  const sameReview = evidence("clean", HEAD, "same-comment-digest");
+  const first = advanceEndorRemediationReview(
+    { ...sameReview, reviewGeneration: "lease-1:1" },
+    { root },
+  );
+  const second = advanceEndorRemediationReview(
+    { ...sameReview, reviewGeneration: "lease-2:1" },
+    { root },
+  );
+  const third = advanceEndorRemediationReview(
+    { ...sameReview, reviewGeneration: "lease-3:1" },
+    { root },
+  );
+
+  assert.deepEqual(progress(first), { action: "requeue", cycles: 1, cleanStreak: 1 });
+  assert.deepEqual(progress(second), { action: "requeue", cycles: 2, cleanStreak: 2 });
+  assert.equal(third.action, "notify");
+  assert.equal(third.cleanStreak, 3);
+});
+
+test("different Endor PRs persist convergence and delivery receipts in disjoint files", async () => {
+  const root = temporaryRoot();
+  const secondPrEvidence = (reviewDigest: string) => ({
+    ...evidence("clean", HEAD, reviewDigest),
+    prNumber: 124,
+    prUrl: "https://github.com/openclaw/openclaw/pull/124",
+    reviewUrl: "https://github.com/openclaw/openclaw/pull/124#issuecomment-457",
+  });
+
+  advanceEndorRemediationReview(evidence("clean", HEAD, "pr-123-review-1"), { root });
+  advanceEndorRemediationReview(secondPrEvidence("pr-124-review-1"), { root });
+
+  const firstPrRoot = path.join(
+    root,
+    "notifications/endor-remediation/openclaw/openclaw/pulls/123",
+  );
+  const secondPrRoot = path.join(
+    root,
+    "notifications/endor-remediation/openclaw/openclaw/pulls/124",
+  );
+  assert.equal(fs.existsSync(path.join(firstPrRoot, "review-state.json")), true);
+  assert.equal(fs.existsSync(path.join(secondPrRoot, "review-state.json")), true);
+
+  advanceEndorRemediationReview(evidence("clean", HEAD, "pr-123-review-2"), { root });
+  const firstEvent = advanceEndorRemediationReview(evidence("clean", HEAD, "pr-123-review-3"), {
+    root,
+  });
+  advanceEndorRemediationReview(secondPrEvidence("pr-124-review-2"), { root });
+  const secondEvent = advanceEndorRemediationReview(secondPrEvidence("pr-124-review-3"), {
+    root,
+  });
+  assert.equal(firstEvent.action, "notify");
+  assert.equal(secondEvent.action, "notify");
+  if (firstEvent.action !== "notify" || secondEvent.action !== "notify") return;
+
+  let requests = 0;
+  const runtime = {
+    root,
+    env: hermitEnv(),
+    log: () => undefined,
+    fetch: deliveryFixtureFetch({
+      onHook: async () => {
+        requests += 1;
+        return new Response(JSON.stringify({ delivered: true, messageId: `message-${requests}` }), {
+          status: 200,
+        });
+      },
+    }),
+  };
+  assert.equal((await deliverEndorRemediationEvent(firstEvent.event, runtime)).sent, 1);
+  assert.equal((await deliverEndorRemediationEvent(secondEvent.event, runtime)).sent, 1);
+  assert.equal(requests, 2);
+  assert.equal(fs.existsSync(path.join(firstPrRoot, `notifications/${HEAD}/ready.json`)), true);
+  assert.equal(fs.existsSync(path.join(secondPrRoot, `notifications/${HEAD}/ready.json`)), true);
+});
+
+test("findings and a new head reset clean progress", () => {
+  const root = temporaryRoot();
+  advanceEndorRemediationReview(evidence("clean", HEAD, "review-1"), { root });
+  advanceEndorRemediationReview(evidence("clean", HEAD, "review-2"), { root });
+
+  const finding = advanceEndorRemediationReview(evidence("has_findings", HEAD, "review-3"), {
+    root,
+  });
+  assert.equal(finding.action, "notify");
+  assert.equal(finding.cleanStreak, 0);
+  assert.equal(finding.event.outcome, "needs_attention");
+  assert.match(finding.event.reviewSummary, /lockfile contains an unrelated change/);
+
+  const unchangedHead = advanceEndorRemediationReview(
+    evidence("clean", HEAD, "review-after-finding"),
+    { root },
+  );
+  assert.equal(unchangedHead.action, "notify");
+  assert.equal(unchangedHead.event.outcome, "needs_attention");
+  assert.match(unchangedHead.event.reviewSummary, /requires a new reviewed head/);
+
+  const newHead = advanceEndorRemediationReview(evidence("clean", NEXT_HEAD, "review-4"), {
+    root,
+  });
+  assert.deepEqual(progress(newHead), { action: "requeue", cycles: 1, cleanStreak: 1 });
+  assert.equal(newHead.resetReason, "head_changed");
+});
+
+test("ambiguous reviews never count and stop honestly at six cycles", () => {
+  const root = temporaryRoot();
+  let result = advanceEndorRemediationReview(evidence("ambiguous", HEAD, "review-1"), { root });
+  assert.deepEqual(progress(result), { action: "requeue", cycles: 1, cleanStreak: 0 });
+  for (let cycle = 2; cycle <= 6; cycle += 1) {
+    result = advanceEndorRemediationReview(evidence("ambiguous", HEAD, `review-${cycle}`), {
+      root,
+    });
+  }
+  assert.equal(result.action, "notify");
+  assert.equal(result.cycles, 6);
+  assert.equal(result.cleanStreak, 0);
+  assert.equal(result.event.outcome, "needs_attention");
+  assert.match(result.event.reviewSummary, /six-review safety cap/i);
+});
+
+test("an ambiguous review breaks a consecutive clean streak", () => {
+  const root = temporaryRoot();
+  advanceEndorRemediationReview(evidence("clean", HEAD, "review-1"), { root });
+  const ambiguous = advanceEndorRemediationReview(evidence("ambiguous", HEAD, "review-2"), {
+    root,
+  });
+  const nextClean = advanceEndorRemediationReview(evidence("clean", HEAD, "review-3"), { root });
+  const secondClean = advanceEndorRemediationReview(evidence("clean", HEAD, "review-4"), {
+    root,
+  });
+  const thirdClean = advanceEndorRemediationReview(evidence("clean", HEAD, "review-5"), { root });
+
+  assert.equal(ambiguous.cleanStreak, 0);
+  assert.deepEqual(progress(nextClean), { action: "requeue", cycles: 3, cleanStreak: 1 });
+  assert.deepEqual(progress(secondClean), { action: "requeue", cycles: 4, cleanStreak: 2 });
+  assert.equal(thirdClean.action, "notify");
+  assert.equal(thirdClean.cleanStreak, 3);
+});
+
+test("ready, attention, and unknown outcomes retain the exact review evidence", () => {
+  const ready = advanceThreeClean({ checks: "passing", mergeState: "clean" });
+  const unknown = advanceThreeClean({ checks: "unknown", mergeState: "unknown" });
+  const attention = advanceEndorRemediationReview(evidence("has_findings", HEAD, "finding"), {
+    root: temporaryRoot(),
+  });
+  assert.equal(ready.event.outcome, "ready");
+  assert.equal(unknown.event.outcome, "unknown");
+  assert.equal(attention.event.outcome, "needs_attention");
+
+  for (const result of [ready, unknown, attention]) {
+    assert.equal(result.event.reviewedHeadSha, HEAD);
+    assert.equal(
+      result.event.reviewUrl,
+      "https://github.com/openclaw/openclaw/pull/123#issuecomment-456",
+    );
+    assert.equal(result.event.prUrl, "https://github.com/openclaw/openclaw/pull/123");
+  }
+});
+
+test("strict delivery sends the structured event to Hermit, deduplicates replay, and retries safely", async () => {
+  const root = temporaryRoot();
+  const event = advanceThreeClean({ root }).event;
+  const requests: Array<Record<string, unknown>> = [];
+  let liveHead = HEAD;
+  const runtime = {
+    root,
+    env: hermitEnv(),
+    log: () => undefined,
+    now: () => new Date("2026-08-21T00:00:00Z"),
+    fetch: deliveryFixtureFetch({
+      head: () => liveHead,
+      onHook: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+          JSON.stringify({ delivered: true, messageId: `message-${requests.length}` }),
+          { status: 200 },
+        );
+      },
+    }),
+  };
+  const first = await deliverEndorRemediationEvent(event, runtime);
+  const replay = await deliverEndorRemediationEvent(event, runtime);
+  assert.equal(first.sent, 1);
+  assert.equal(replay.skipped, 1);
+  assert.equal(requests.length, 1);
+  assert.deepEqual(requests[0], {
+    ...event,
+    checks: { state: "passing", total: 2, summary: "2 gating checks passed" },
+  });
+
+  const nextHeadEvent = advanceThreeClean({ head: NEXT_HEAD }).event;
+  liveHead = NEXT_HEAD;
+  const nextHead = await deliverEndorRemediationEvent(nextHeadEvent, runtime);
+  assert.equal(nextHead.sent, 1);
+  assert.equal(requests.length, 2);
+  assert.notEqual(event.idempotencyKey, nextHeadEvent.idempotencyKey);
+
+  const missing = await deliverEndorRemediationEvent(event, {
+    root: temporaryRoot(),
+    log: () => undefined,
+    env: {
+      CLAWSWEEPER_OPENCLAW_HOOK_URL: "https://claw.example/hooks",
+      CLAWSWEEPER_OPENCLAW_HOOK_TOKEN: "legacy-secret",
+    },
+    fetch: deliveryFixtureFetch({
+      onHook: async () => jsonResponse({ delivered: true, messageId: "must-not-send" }),
+    }),
+  });
+  assert.equal(missing.failed, 1);
+  assert.match(missing.reason ?? "", /CLAWSWEEPER_HERMIT_URL/);
+
+  const retryRoot = temporaryRoot();
+  const failed = await deliverEndorRemediationEvent(event, {
+    root: retryRoot,
+    log: () => undefined,
+    env: { ...hermitEnv(), CLAWSWEEPER_HERMIT_RETRY_ATTEMPTS: "1" },
+    fetch: deliveryFixtureFetch({
+      onHook: async () => new Response("unavailable", { status: 500 }),
+    }),
+  });
+  assert.equal(failed.failed, 1);
+  assert.equal(failed.failureKind, "hermit_transient");
+  assert.equal(fs.existsSync(path.join(retryRoot, endorDeliveryLedgerPath(event))), false);
+  const retried = await deliverEndorRemediationEvent(event, {
+    root: retryRoot,
+    log: () => undefined,
+    env: hermitEnv(),
+    fetch: deliveryFixtureFetch({
+      onHook: async () =>
+        new Response(JSON.stringify({ delivered: true, messageId: "retry-ok" }), { status: 200 }),
+    }),
+  });
+  assert.equal(retried.sent, 1);
+});
+
+test("delivery requeues the live PR head instead of notifying a stale reviewed head", async () => {
+  const event = advanceThreeClean().event;
+  let hookRequests = 0;
+  const result = await deliverEndorRemediationEvent(event, {
+    root: temporaryRoot(),
+    env: hermitEnv(),
+    log: () => undefined,
+    fetch: async (input, init) => {
+      if (String(input).includes("api.github.com")) {
+        return jsonResponse({
+          head: { sha: NEXT_HEAD },
+          user: {
+            id: 179191674,
+            login: "endor-labs-pro[bot]",
+            type: "Bot",
+            html_url: "https://github.com/apps/endor-labs-pro",
+          },
+          state: "open",
+          merged: false,
+          merged_at: null,
+          mergeable: true,
+          mergeable_state: "clean",
+          updated_at: "2026-08-24T00:03:00Z",
+        });
+      }
+      if (init?.method === "POST") hookRequests += 1;
+      return jsonResponse({ delivered: true, messageId: "must-not-send" });
+    },
+  });
+
+  assert.equal(result.action, "requeue");
+  assert.equal(result.sent, 0);
+  assert.equal(result.requeueHeadSha, NEXT_HEAD);
+  assert.equal(hookRequests, 0);
+});
+
+test("transient delivery-time GitHub failures remain retryable without notifying", async () => {
+  const event = advanceThreeClean().event;
+  let hookRequests = 0;
+  const result = await deliverEndorRemediationEvent(event, {
+    root: temporaryRoot(),
+    env: hermitEnv(),
+    log: () => undefined,
+    fetch: async (input, init) => {
+      if (String(input).includes("api.github.com")) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      if (init?.method === "POST") hookRequests += 1;
+      return jsonResponse({ delivered: true, messageId: "must-not-send" });
+    },
+  });
+
+  assert.equal(result.failed, 1);
+  assert.equal(result.failureKind, "github_transient");
+  assert.equal(result.sent, 0);
+  assert.equal(hookRequests, 0);
+});
+
+test("delivery-time GitHub revalidation uses the target token", async () => {
+  const event = advanceThreeClean().event;
+  const authorization: Array<string | null> = [];
+  const result = await deliverEndorRemediationEvent(event, {
+    root: temporaryRoot(),
+    env: { ...hermitEnv(), GH_TOKEN: "target-token" },
+    log: () => undefined,
+    fetch: deliveryFixtureFetch({
+      onGithub: (_input, init) => {
+        authorization.push(new Headers(init?.headers).get("authorization"));
+      },
+      onHook: async () => jsonResponse({ delivered: true, messageId: "authenticated-delivery" }),
+    }),
+  });
+
+  assert.equal(result.sent, 1);
+  assert.deepEqual(authorization, [
+    "Bearer target-token",
+    "Bearer target-token",
+    "Bearer target-token",
+  ]);
+});
+
+test("closed or merged PRs complete delivery without notifying or requeueing", async () => {
+  const event = advanceThreeClean().event;
+  for (const pull of [
+    { state: "closed", merged: false, reason: "pull request is not open" },
+    { state: "closed", merged: true, reason: "pull request is merged" },
+  ]) {
+    const root = temporaryRoot();
+    let hookRequests = 0;
+    const result = await deliverEndorRemediationEvent(event, {
+      root,
+      env: {},
+      log: () => undefined,
+      fetch: deliveryFixtureFetch({
+        state: () => pull.state,
+        merged: () => pull.merged,
+        onHook: async () => {
+          hookRequests += 1;
+          return jsonResponse({ delivered: true, messageId: "must-not-send" });
+        },
+      }),
+    });
+
+    assert.equal(result.action, "complete");
+    assert.equal(result.status, "skipped");
+    assert.equal(result.reason, pull.reason);
+    assert.equal(result.sent, 0);
+    assert.equal(result.requeueKey, null);
+    assert.equal(hookRequests, 0);
+    assert.equal(fs.existsSync(path.join(root, endorDeliveryLedgerPath(event))), false);
+  }
+});
+
+test(
+  "accepted delivery without a durable ledger remains failed and retryable",
+  { skip: process.platform === "win32" ? "requires POSIX write permissions" : false },
+  async () => {
+    const root = temporaryRoot();
+    const event = advanceThreeClean().event;
+    const ledgerPath = path.join(root, endorDeliveryLedgerPath(event));
+    const ledgerDirectory = path.dirname(ledgerPath);
+    fs.mkdirSync(ledgerDirectory, { recursive: true });
+    fs.chmodSync(ledgerDirectory, 0o555);
+    let requests = 0;
+    const runtime = {
+      root,
+      env: hermitEnv(),
+      log: () => undefined,
+      fetch: deliveryFixtureFetch({
+        onHook: async () => {
+          requests += 1;
+          return new Response(
+            JSON.stringify({ delivered: true, messageId: `message-${requests}` }),
+            { status: 200 },
+          );
+        },
+      }),
+    };
+
+    const failed = await deliverEndorRemediationEvent(event, runtime);
+    assert.equal(failed.failed, 1);
+    assert.match(failed.reason ?? "", /permission denied|EACCES/i);
+    assert.equal(requests, 1);
+    assert.equal(fs.existsSync(ledgerPath), false);
+
+    fs.chmodSync(ledgerDirectory, 0o755);
+    const retried = await deliverEndorRemediationEvent(event, runtime);
+    assert.equal(retried.sent, 1);
+    assert.equal(requests, 2);
+    assert.equal(
+      JSON.parse(fs.readFileSync(ledgerPath, "utf8")).notification.idempotencyKey,
+      event.idempotencyKey,
+    );
+  },
+);
+
+function preparationInput(comment: string) {
+  return {
+    repo: "openclaw/openclaw",
+    itemNumber: 123,
+    reviewCommentId: 456,
+    reviewCommentDigest: sha256(comment.trim()),
+    reviewGeneration: "publisher-lease:1",
+  };
+}
+
+function evidence(
+  verdict: EndorReviewEvidence["verdict"],
+  reviewedHeadSha: string,
+  reviewDigest: string,
+): EndorReviewEvidence {
+  return {
+    version: 1,
+    repo: "openclaw/openclaw",
+    prNumber: 123,
+    prUrl: "https://github.com/openclaw/openclaw/pull/123",
+    title: "Bump example-package from 1.0.0 to 1.0.1",
+    findingSummary: "example-package; fixed findings: High: 1; advisories: GHSA-aaaa-bbbb-cccc",
+    reviewedHeadSha,
+    reviewDigest,
+    reviewGeneration: reviewDigest,
+    verdict,
+    reviewSummary:
+      verdict === "has_findings"
+        ? "The lockfile contains an unrelated change."
+        : verdict === "clean"
+          ? "No actionable findings remain."
+          : "The review result was ambiguous.",
+    reviewUrl: "https://github.com/openclaw/openclaw/pull/123#issuecomment-456",
+    checks: { state: "passing", total: 2, summary: "2 gating checks passed" },
+    mergeState: "clean",
+  };
+}
+
+function advanceThreeClean({
+  root = temporaryRoot(),
+  head = HEAD,
+  checks = "passing",
+  mergeState = "clean",
+}: {
+  root?: string;
+  head?: string;
+  checks?: EndorReviewEvidence["checks"]["state"];
+  mergeState?: EndorReviewEvidence["mergeState"];
+} = {}) {
+  for (let cycle = 1; cycle < 3; cycle += 1) {
+    advanceEndorRemediationReview(evidence("clean", head, `review-${cycle}`), { root });
+  }
+  const finalEvidence = evidence("clean", head, "review-3");
+  finalEvidence.checks = {
+    state: checks,
+    total: checks === "passing" ? 2 : null,
+    summary: `${checks}`,
+  };
+  finalEvidence.mergeState = mergeState;
+  const result = advanceEndorRemediationReview(finalEvidence, { root });
+  assert.equal(result.action, "notify");
+  return result;
+}
+
+function progress(result: ReturnType<typeof advanceEndorRemediationReview>) {
+  return { action: result.action, cycles: result.cycles, cleanStreak: result.cleanStreak };
+}
+
+function reviewComment(head: string, verdict: "clean" | "attention" | "unknown", nonce: string) {
+  const readiness =
+    verdict === "clean"
+      ? "✅ **Ready for maintainer review**\n\nNo actionable findings remain."
+      : verdict === "attention"
+        ? "⚠️ **Needs maintainer attention - 1 item remains**\n\nThe lockfile contains an unrelated change."
+        : "Review result was published.";
+  return `# ClawSweeper review
+
+## Merge readiness
+
+${readiness}
+
+**Reviewed head:** \`${head.slice(0, 12)}\`
+
+<!-- clawsweeper-review-version item=123 reviewed_at=2026-08-24T00:00:00.000Z sha=${head} source_revision=source-${nonce} lease_owner=unknown lease_comment_id=unknown v=1 -->
+<!-- review-nonce:${nonce} -->`;
+}
+
+function githubFixture({
+  comment,
+  authorId = 179191674,
+  authorLogin = "endor-labs-pro[bot]",
+  authorType = "Bot",
+  authorUrl = "https://github.com/apps/endor-labs-pro",
+  headSha = HEAD,
+  isPullRequest = true,
+  state = "open",
+  merged = false,
+}: {
+  comment: string;
+  authorId?: number;
+  authorLogin?: string;
+  authorType?: string;
+  authorUrl?: string;
+  headSha?: string;
+  isPullRequest?: boolean;
+  state?: "open" | "closed";
+  merged?: boolean;
+}): typeof fetch {
+  return async (input) => {
+    const url = String(input);
+    if (url.endsWith("/issues/123")) {
+      return jsonResponse(isPullRequest ? { pull_request: { url: "pull" } } : {});
+    }
+    if (url.endsWith("/pulls/123")) {
+      return jsonResponse({
+        number: 123,
+        title: "Endor Labs Version Upgrade: Bump example-package from 1.0.0 to 1.0.1",
+        body: ENDOR_BODY,
+        html_url: "https://github.com/openclaw/openclaw/pull/123",
+        head: { sha: headSha },
+        user: { id: authorId, login: authorLogin, type: authorType, html_url: authorUrl },
+        state,
+        merged,
+        merged_at: merged ? "2026-08-24T00:04:00Z" : null,
+        mergeable: true,
+        mergeable_state: "clean",
+      });
+    }
+    if (url.endsWith("/issues/comments/456")) {
+      return jsonResponse({
+        body: comment,
+        html_url: "https://github.com/openclaw/openclaw/pull/123#issuecomment-456",
+      });
+    }
+    if (url.includes("/check-runs")) {
+      return jsonResponse({
+        check_runs: [
+          { name: "build", status: "completed", conclusion: "success" },
+          { name: "test", status: "completed", conclusion: "success" },
+        ],
+      });
+    }
+    if (url.endsWith("/status?per_page=100")) return jsonResponse({ statuses: [] });
+    return new Response("missing fixture", { status: 404 });
+  };
+}
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function deliveryFixtureFetch({
+  head = () => HEAD,
+  state = () => "open",
+  merged = () => false,
+  onGithub = () => undefined,
+  onHook,
+}: {
+  head?: () => string;
+  state?: () => string;
+  merged?: () => boolean;
+  onGithub?: (input: URL | RequestInfo, init?: RequestInit) => void;
+  onHook: (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
+}): typeof fetch {
+  return async (input, init) => {
+    const url = String(input);
+    if (url.includes("api.github.com")) onGithub(input, init);
+    if (/api\.github\.com\/repos\/[^/]+\/[^/]+\/pulls\/\d+$/.test(url)) {
+      return jsonResponse({
+        head: { sha: head() },
+        user: {
+          id: 179191674,
+          login: "endor-labs-pro[bot]",
+          type: "Bot",
+          html_url: "https://github.com/apps/endor-labs-pro",
+        },
+        state: state(),
+        merged: merged(),
+        merged_at: merged() ? "2026-08-24T00:04:00Z" : null,
+        mergeable: true,
+        mergeable_state: "clean",
+        updated_at: "2026-08-24T00:03:00Z",
+      });
+    }
+    if (url.includes("/check-runs")) {
+      return jsonResponse({
+        check_runs: [
+          { name: "build", status: "completed", conclusion: "success" },
+          { name: "test", status: "completed", conclusion: "success" },
+        ],
+      });
+    }
+    if (url.endsWith("/status?per_page=100")) return jsonResponse({ statuses: [] });
+    return onHook(input, init);
+  };
+}
+
+function hermitEnv(): NodeJS.ProcessEnv {
+  return {
+    CLAWSWEEPER_HERMIT_URL: "https://hermit.example",
+    CLAWSWEEPER_HERMIT_TOKEN: "secret",
+    CLAWSWEEPER_HERMIT_RETRY_ATTEMPTS: "1",
+  };
+}
+
+function temporaryRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "endor-remediation-"));
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/test/state-writer-workflow.test.ts
+++ b/test/state-writer-workflow.test.ts
@@ -31,7 +31,7 @@ test("every state hydration uses the canonical Worker with an explicit git-state
     }
   }
 
-  assert.equal(setups.length, 21, "setup-state site count is an audited invariant");
+  assert.equal(setups.length, 22, "setup-state site count is an audited invariant");
   for (const { site, step } of setups) {
     assert.equal(step.with?.["records-url"], workerUrl, site);
     assert.equal(step.with?.["records-secret"], workerSecret, site);
@@ -79,6 +79,7 @@ test("per-target state hydration is slug-scoped while fleet lanes retain discove
       ".github/workflows/repair-issue-implementation-intake.yml:intake",
       ".github/workflows/spam-scanner.yml:scan",
       ".github/workflows/sweep.yml:event-review-apply",
+      ".github/workflows/sweep.yml:event-review-publish",
       ".github/workflows/sweep.yml:event-review-publish",
       ".github/workflows/sweep.yml:plan",
       ".github/workflows/sweep.yml:publish",
@@ -172,7 +173,7 @@ test("all remaining git publishers join setup-state and receive a step-scoped co
       }
     }
   }
-  assert.equal(publishers, 21, "git publisher count is an audited invariant");
+  assert.equal(publishers, 24, "git publisher count is an audited invariant");
 });
 
 test("post-side-effect git bookkeeping is non-fatal while durability fences stay strict", () => {


### PR DESCRIPTION
Endor remediation PRs currently receive one normal ClawSweeper review, with no exact-head convergence loop or strict notification fence. A single result cannot prove that the same commit stays clean across fresh reviews, and a delivery failure is not tied to publication completion. This PR requires three consecutive clean reviews on one unchanged head, resets progress after findings or a new commit, and sends the terminal result through Hermit. ClawSweeper completes publication only after it has queued the next review or durably recorded the terminal state and delivery receipt.

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Implementation | 3 | +1,365 | -1 |
| Tests | 5 | +1,142 | -3 |
| Documentation | 1 | +46 | -0 |
| Workflow and tooling | 2 | +290 | -6 |
| **Total** | **11** | **+2,843** | **-10** |

## Proof

**Before: direct base**

```text
fresh Endor review -> ordinary publication completes
clean streak: not tracked
terminal Hermit receipt: not required
```

**After: PR**

```text
clean review 1, same head -> requeue, clean=1/3
clean review 2, same head -> requeue, clean=2/3
clean review 3, same head -> notify ready, clean=3/3
same terminal event replay -> skipped, existing receipt retained
new head or finding -> prior streak reset
ambiguous result -> never counted as clean
```

The controlled proof exercises the exact-review workflow, state files, head revalidation, Hermit request, retry classification, and durable delivery ledger. It does not run a live Endor tenant or send to production Discord because external configuration was deliberately left unchanged.

Linux proof passed 37/37 tests on AWS Crabbox lease `cbx_8b4077021265`. The exact rebased head also passes static checks, all builds, lint, and the 37 focused tests on Node 24.18.1.

## How to verify

1. Run `pnpm run check:static`, `pnpm run build:all`, and `pnpm run lint` on Node 24 or newer.
2. Run the focused Endor notification, workflow, retry, and state-writer tests.
3. Confirm transient Hermit failures produce `retryable_failure/hermit_transient` without a delivery receipt.

## Implementation notes

This depends on [openclaw/hermit#30](https://github.com/openclaw/hermit/pull/30), which must be deployed first. Then set `CLAWSWEEPER_HERMIT_URL` and `CLAWSWEEPER_HERMIT_TOKEN` in ClawSweeper. OpenClaw Bay is unaffected because this adds no public status, data contract, navigation, or controls.
