### PR TITLE
fix: run camsnap live proof without pnpm setup

### DIFF
--- a/config/target-repositories.json
+++ b/config/target-repositories.json
@@ -88,6 +88,26 @@
         "ready_timeout_seconds": 240,
         "max_recording_seconds": 90
       }
+    },
+    {
+      "target_repo": "steipete/camsnap",
+      "display_name": "camsnap",
+      "checkout_dir": "camsnap",
+      "prompt_note": "Use the camsnap source tree and current main branch. Review camera discovery, RTSP/ONVIF behavior, Go changes, and cross-platform build behavior conservatively. Keep issues and pull requests open for maintainer triage.",
+      "apply_close_rules": {
+        "issue": [],
+        "pull_request": []
+      },
+      "package_manager": "npm",
+      "validation_commands": [],
+      "changed_gate": null,
+      "live_test": {
+        "enabled": true,
+        "surface_default": "terminal",
+        "setup": [],
+        "ready_timeout_seconds": 240,
+        "max_recording_seconds": 90
+      }
     }
   ],
   "generic_fallbacks": [

--- a/src/live-proof/execute.ts
+++ b/src/live-proof/execute.ts
@@ -406,7 +406,9 @@ function addPackageManagerToPath(packageManager: string, environment: NodeJS.Pro
     packageManager === "bun"
       ? join(home, ".bun", "bin")
       : packageManager === "pnpm"
-        ? environment.PNPM_HOME?.trim() || join(home, ".local", "share", "pnpm")
+        ? environment.PNPM_HOME?.trim()
+          ? join(environment.PNPM_HOME.trim(), "bin")
+          : join(home, ".local", "share", "pnpm")
         : undefined;
   if (!directory) return;
   const path = environment.PATH ?? "";

--- a/test/live-proof.test.ts
+++ b/test/live-proof.test.ts
@@ -367,6 +367,42 @@ test("live-proof installs a missing Bun toolchain with the official installer", 
   assert.match(logs.join("\n"), /installed target package manager bun/);
 });
 
+test("live-proof resolves pnpm from the configured PNPM_HOME bin directory", () => {
+  const calls: Array<{ command: string; args: readonly string[]; path?: string }> = [];
+  const environment: NodeJS.ProcessEnv = {
+    HOME: "/tmp/live-proof-home",
+    PATH: "/usr/bin",
+    PNPM_HOME: "/tmp/live-proof-home/pnpm",
+  };
+  let probes = 0;
+  ensureLiveProofPackageManager(
+    "pnpm",
+    (command, args, options) => {
+      calls.push({ command, args, path: options?.env?.PATH ?? environment.PATH });
+      if (String(args[1]).startsWith("command -v pnpm")) {
+        probes += 1;
+        return { status: probes === 1 ? 1 : 0 };
+      }
+      return { status: 0 };
+    },
+    "/tmp/checkout",
+    environment,
+  );
+
+  assert.deepEqual(
+    calls.map(({ command, args }) => [command, ...args].join(" ")),
+    [
+      "sh -lc command -v pnpm >/dev/null 2>&1",
+      "sh -lc curl -fsSL https://get.pnpm.io/install.sh | sh -",
+      "sh -lc command -v pnpm >/dev/null 2>&1",
+    ],
+  );
+  assert.equal(
+    calls.every(({ path }) => path?.startsWith("/tmp/live-proof-home/pnpm/bin:")),
+    true,
+  );
+});
+
 test("live-proof reports an unsupported package manager clearly", () => {
   assert.throws(
     () =>

--- a/test/repair/target-validation.test.ts
+++ b/test/repair/target-validation.test.ts
@@ -8141,6 +8141,18 @@ test("resolveTargetRepoToolchain reads openclaw/clawhub from the real config wit
   }
 });
 
+test("resolveTargetRepoToolchain uses the explicit camsnap no-validation profile", () => {
+  __resetTargetRepoToolchainCache();
+  try {
+    const toolchain = resolveTargetRepoToolchain("steipete/camsnap");
+    assert.equal(toolchain.packageManager, "npm");
+    assert.deepEqual(toolchain.baseValidationCommands, []);
+    assert.equal(toolchain.changedGate, null);
+  } finally {
+    __resetTargetRepoToolchainCache();
+  }
+});
+
 test("resolveTargetRepoToolchain keeps the OpenClaw changed gate even without core_target_overrides", () => {
   // Regression guard for the earlier ordering bug: if core_target_overrides is
   // ever removed but a generic openclaw fallback is kept (changed_gate: null),

--- a/test/repository-profiles.test.ts
+++ b/test/repository-profiles.test.ts
@@ -130,6 +130,23 @@ test("generic steipete fallback starts review-only", () => {
   assert.deepEqual(profile.liveTest, TERMINAL_LIVE_TEST);
 });
 
+test("camsnap uses its Go-native review-only live-proof profile", () => {
+  const profile = repositoryProfileFor("Steipete/CamSnap");
+
+  assert.equal(profile.targetRepo, "steipete/camsnap");
+  assert.equal(profile.packageManager, "npm");
+  assert.deepEqual(profile.applyCloseRules.issue, []);
+  assert.deepEqual(profile.applyCloseRules.pull_request, []);
+  assert.deepEqual(profile.liveTest, {
+    enabled: true,
+    surfaceDefault: "terminal",
+    setup: [],
+    allowInstallScripts: false,
+    readyTimeoutSeconds: 240,
+    maxRecordingSeconds: 90,
+  });
+});
+
 test("generic OpenClaw fallback keeps denied repositories unsupported", () => {
   assert.throws(
     () => repositoryProfileFor("openclaw/clawsweeper-state"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where live proof for `steipete/camsnap` stopped before the requested Go command because the generic repository profile selected pnpm, and the pnpm installer placed its executable below a directory that was not added to `PATH`.

## Why This Change Was Made

The live-proof runner now follows pnpm's current `PNPM_HOME/bin` installer layout. Camsnap also has an explicit review-only Go repository profile that uses the runner's existing npm toolchain, skips package setup and validation commands, and preserves empty auto-close rules.

This deliberately does not add a package-manager enum, chmod/retry fallback, or validation policy for camsnap.

## User Impact

Camsnap review live proofs can reach their selected Go command instead of failing during unrelated pnpm setup. Review and close policy remains maintainer-only.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected. This changes target toolchain selection and live-proof executable resolution, not lifecycle publication, queue state, status telemetry, or dashboard contracts.

## Documentation Impact

Reviewed `docs/live-proof.md` and `docs/target-repositories.md`. Their contract remains accurate: repository-specific behavior is configured in `config/target-repositories.json`, and live proof installs or selects the configured package manager. No documentation update is needed.

## Evidence

Source revision: `932b03921191e286ed0f6f8eb584184bc9e57aaa`

- `node --test --test-name-pattern='live-proof resolves pnpm from the configured PNPM_HOME bin directory' test/live-proof.test.ts` — passed
- `node --test --test-name-pattern='camsnap uses its Go-native review-only live-proof profile' test/repository-profiles.test.ts` — passed
- `node --test --test-name-pattern='resolveTargetRepoToolchain uses the explicit camsnap no-validation profile' test/repair/target-validation.test.ts` — passed
- `node_modules/.bin/tsc -p tsconfig.json --pretty false` — passed
- `node_modules/.bin/tsc -p tsconfig.repair.json --pretty false` — passed
- targeted `oxfmt --check` and `git diff --check` — passed
- committed `codex review --base origin/main` — no actionable correctness issues
- full `test/repair/target-validation.test.ts` local run: 196 passed, 7 failed, 3 skipped; all seven failures were the existing offline package-mirror error resolving `pnpm@10.33.0`. The new camsnap test passed.
- local `pnpm check` was not run because this isolated GWT uses a managed `node_modules` symlink and pnpm attempted dependency reconciliation/removal. Hosted CI is the authoritative full check.

Production delta: +22/-1 lines. Tests: +65 lines. The production growth is the repository-owned camsnap profile; the shared runtime change is the two-line pnpm installer-path correction.

## Real Behavior Proof

**Claim:** live proof can resolve a freshly installed pnpm from its isolated profile, and the camsnap profile reaches a Go command without package setup.

**Exercised surface:** the official pnpm installer layout, repository profile resolution, sanitized Go live-proof environment, and command execution.

**Scenario or fixture:** two controlled temporary fixtures were used: an isolated pnpm profile and a generated local Go module selected through `repositoryProfileFor("steipete/camsnap")`. No contributor code was executed.

**Command and environment:** the official `https://get.pnpm.io/install.sh` ran with an isolated `HOME` and `PNPM_HOME`; the resulting `PNPM_HOME/bin` was prepended to `PATH`. The Go fixture then ran with the resolved camsnap profile and `reviewLiveProofGoEnvironment`.

**Observed result:** the installer created executable mode `755` commands under `PNPM_HOME/bin`; `command -v pnpm` resolved that isolated path and reported pnpm `11.10.0`. The camsnap profile resolved `package_manager=npm`, `setup=[]`, empty close rules, and `go run .` printed `camsnap-go-proof`. Neither run produced `EACCES`.

**Artifact or trace:** terminal traces recorded the resolved pnpm path/version/mode, exact camsnap profile fields, and `camsnap-go-proof`. Both temporary fixture roots were confirmed absent after cleanup.

**Limits:** a full local review-wrapper attempt reached a pre-existing macOS tmux pane-capture race (`no such window`); its `finally` cleanup removed the scratch tree. Hosted Linux CI and exact-head ClawSweeper review remain required before merge.
