### PR TITLE
fix(live-proof): provision candidate Go toolchains

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1364,27 +1364,49 @@ jobs:
           set -euo pipefail
           versions_file="$(mktemp)"
           trap 'rm -f "$versions_file"' EXIT
+          requires_automatic_toolchain=false
           while read -r item; do
             record="$RECORDS_DIR/$item.md"
             head_sha="$(sed -n 's/^pull_head_sha:[[:space:]]*//p' "$record" | head -n 1)"
             printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'
             if ! go_mod="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.mod" 2>/dev/null)"; then
+              requires_automatic_toolchain=true
               continue
             fi
-            go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_mod")"
-            toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_mod")"
-            printf '%s\n' "${go_version:-1.16}" >> "$versions_file"
+            if go_work="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.work" 2>/dev/null)"; then
+              go_config="$go_work"
+              default_go_version=1.18
+            else
+              go_config="$go_mod"
+              default_go_version=1.16
+            fi
+            while IFS= read -r -d '' path; do
+              case "$path" in
+                */go.mod | */go.work)
+                  requires_automatic_toolchain=true
+                  ;;
+              esac
+            done < <(git -C "$TARGET_CHECKOUT" ls-tree -rz --name-only "$head_sha")
+            go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_config")"
+            toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_config")"
+            printf '%s\n' "${go_version:-$default_go_version}" >> "$versions_file"
             if [ -n "$toolchain_version" ]; then
               printf '%s\n' "$toolchain_version" >> "$versions_file"
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATES")
+          echo "automatic=$requires_automatic_toolchain" >> "$GITHUB_OUTPUT"
           if [ ! -s "$versions_file" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          version="$(node - "$versions_file" <<'NODE'
+          minimum_go_version=1.14.0
+          if [ "$requires_automatic_toolchain" = "true" ]; then
+            minimum_go_version=1.21.0
+          fi
+          version="$(node - "$versions_file" "$minimum_go_version" <<'NODE'
           const fs = require("node:fs");
           const path = process.argv[2];
+          const minimum = process.argv[3];
           const versions = fs
             .readFileSync(path, "utf8")
             .trim()
@@ -1405,7 +1427,7 @@ jobs:
             return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
           };
           versions.sort(compare);
-          process.stdout.write(compare(versions.at(-1), "1.14.0") < 0 ? "1.14.0" : versions.at(-1));
+          process.stdout.write(compare(versions.at(-1), minimum) < 0 ? minimum : versions.at(-1));
           NODE
           )"
           mkdir -p "$(dirname "$VERSION_FILE")"
@@ -1422,6 +1444,10 @@ jobs:
         with:
           go-version-file: ${{ steps.resolve-exact-live-proof-go.outputs.path }}
           cache: "false"
+
+      - name: Enable exact live-proof automatic Go fallback
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.resolve-exact-live-proof-go.outputs.automatic == 'true' }}
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Install exact live-proof terminal tools
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.requires_terminal == 'true' }}
@@ -4600,33 +4626,53 @@ jobs:
           trap 'rm -f "$versions_file"' EXIT
           candidate_count="$(jq -r 'length' <<< "$CANDIDATES")"
           root_module_count=0
+          requires_automatic_toolchain=false
           while read -r item; do
             record="$RECORDS_DIR/$item.md"
             head_sha="$(sed -n 's/^pull_head_sha:[[:space:]]*//p' "$record" | head -n 1)"
             printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'
             if ! go_mod="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.mod" 2>/dev/null)"; then
+              requires_automatic_toolchain=true
               continue
             fi
             root_module_count=$((root_module_count + 1))
-            go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_mod")"
-            toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_mod")"
-            printf '%s\n' "${go_version:-1.16}" >> "$versions_file"
+            if go_work="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.work" 2>/dev/null)"; then
+              go_config="$go_work"
+              default_go_version=1.18
+            else
+              go_config="$go_mod"
+              default_go_version=1.16
+            fi
+            while IFS= read -r -d '' path; do
+              case "$path" in
+                */go.mod | */go.work)
+                  requires_automatic_toolchain=true
+                  ;;
+              esac
+            done < <(git -C "$TARGET_CHECKOUT" ls-tree -rz --name-only "$head_sha")
+            go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_config")"
+            toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_config")"
+            printf '%s\n' "${go_version:-$default_go_version}" >> "$versions_file"
             if [ -n "$toolchain_version" ]; then
               printf '%s\n' "$toolchain_version" >> "$versions_file"
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATES")
           if [ "$root_module_count" -ne "$candidate_count" ]; then
-            echo "::notice::Skipping job-wide Go setup because some candidates have no root go.mod; retaining automatic toolchain fallback."
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            requires_automatic_toolchain=true
           fi
+          echo "automatic=$requires_automatic_toolchain" >> "$GITHUB_OUTPUT"
           if [ ! -s "$versions_file" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          version="$(node - "$versions_file" <<'NODE'
+          minimum_go_version=1.14.0
+          if [ "$requires_automatic_toolchain" = "true" ]; then
+            minimum_go_version=1.21.0
+          fi
+          version="$(node - "$versions_file" "$minimum_go_version" <<'NODE'
           const fs = require("node:fs");
           const path = process.argv[2];
+          const minimum = process.argv[3];
           const versions = fs
             .readFileSync(path, "utf8")
             .trim()
@@ -4647,7 +4693,7 @@ jobs:
             return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
           };
           versions.sort(compare);
-          process.stdout.write(compare(versions.at(-1), "1.14.0") < 0 ? "1.14.0" : versions.at(-1));
+          process.stdout.write(compare(versions.at(-1), minimum) < 0 ? minimum : versions.at(-1));
           NODE
           )"
           mkdir -p "$(dirname "$VERSION_FILE")"
@@ -4664,6 +4710,10 @@ jobs:
         with:
           go-version-file: ${{ steps.resolve-shard-live-proof-go.outputs.path }}
           cache: "false"
+
+      - name: Enable review-shard live-proof automatic Go fallback
+        if: ${{ steps.resolve-shard-live-proof-go.outputs.automatic == 'true' }}
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Install review-shard terminal tools
         if: ${{ steps.inspect-shard-live-proofs.outputs.requires_terminal == 'true' }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1359,7 +1359,7 @@ jobs:
           CANDIDATES: ${{ steps.inspect-exact-live-proof.outputs.candidates }}
           RECORDS_DIR: artifacts/event
           TARGET_CHECKOUT: ${{ steps.target.outputs.target_checkout_dir }}
-          VERSION_FILE: .artifacts/exact-live-proof-go/.tool-versions
+          VERSION_FILE: .artifacts/exact-live-proof-go/.go-version
         run: |
           set -euo pipefail
           versions_file="$(mktemp)"
@@ -1409,7 +1409,7 @@ jobs:
           NODE
           )"
           mkdir -p "$(dirname "$VERSION_FILE")"
-          printf 'golang %s\n' "$version" > "$VERSION_FILE"
+          printf '%s\n' "$version" > "$VERSION_FILE"
           {
             echo "available=true"
             echo "path=$VERSION_FILE"
@@ -4593,7 +4593,7 @@ jobs:
           CANDIDATES: ${{ steps.inspect-shard-live-proofs.outputs.candidates }}
           RECORDS_DIR: review-artifacts/shard-${{ matrix.shard }}
           TARGET_CHECKOUT: ${{ needs.plan.outputs.target_checkout_dir }}
-          VERSION_FILE: review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.tool-versions
+          VERSION_FILE: review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.go-version
         run: |
           set -euo pipefail
           versions_file="$(mktemp)"
@@ -4643,7 +4643,7 @@ jobs:
           NODE
           )"
           mkdir -p "$(dirname "$VERSION_FILE")"
-          printf 'golang %s\n' "$version" > "$VERSION_FILE"
+          printf '%s\n' "$version" > "$VERSION_FILE"
           {
             echo "available=true"
             echo "path=$VERSION_FILE"

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -4598,6 +4598,8 @@ jobs:
           set -euo pipefail
           versions_file="$(mktemp)"
           trap 'rm -f "$versions_file"' EXIT
+          candidate_count="$(jq -r 'length' <<< "$CANDIDATES")"
+          root_module_count=0
           while read -r item; do
             record="$RECORDS_DIR/$item.md"
             head_sha="$(sed -n 's/^pull_head_sha:[[:space:]]*//p' "$record" | head -n 1)"
@@ -4605,6 +4607,7 @@ jobs:
             if ! go_mod="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.mod" 2>/dev/null)"; then
               continue
             fi
+            root_module_count=$((root_module_count + 1))
             go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_mod")"
             toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_mod")"
             printf '%s\n' "${go_version:-1.16}" >> "$versions_file"
@@ -4612,6 +4615,11 @@ jobs:
               printf '%s\n' "$toolchain_version" >> "$versions_file"
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATES")
+          if [ "$root_module_count" -ne "$candidate_count" ]; then
+            echo "::notice::Skipping job-wide Go setup because some candidates have no root go.mod; retaining automatic toolchain fallback."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ ! -s "$versions_file" ]; then
             echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1347,9 +1347,81 @@ jobs:
           echo "$summary"
           {
             echo "candidate_count=$(jq -r '.candidates | length' <<< "$summary")"
+            echo "candidates=$(jq -c '.candidates' <<< "$summary")"
             echo "record_media=$(jq -r '.recordMedia' <<< "$summary")"
             echo "requires_terminal=$(jq -r '.requiresTerminal' <<< "$summary")"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve exact live-proof Go version
+        id: resolve-exact-live-proof-go
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.candidate_count != '0' && steps.inspect-exact-live-proof.outcome == 'success' }}
+        env:
+          CANDIDATES: ${{ steps.inspect-exact-live-proof.outputs.candidates }}
+          RECORDS_DIR: artifacts/event
+          TARGET_CHECKOUT: ${{ steps.target.outputs.target_checkout_dir }}
+          VERSION_FILE: .artifacts/exact-live-proof-go/.tool-versions
+        run: |
+          set -euo pipefail
+          versions_file="$(mktemp)"
+          trap 'rm -f "$versions_file"' EXIT
+          while read -r item; do
+            record="$RECORDS_DIR/$item.md"
+            head_sha="$(sed -n 's/^pull_head_sha:[[:space:]]*//p' "$record" | head -n 1)"
+            printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'
+            if ! go_mod="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.mod" 2>/dev/null)"; then
+              continue
+            fi
+            go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_mod")"
+            toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_mod")"
+            printf '%s\n' "${go_version:-1.16}" >> "$versions_file"
+            if [ -n "$toolchain_version" ]; then
+              printf '%s\n' "$toolchain_version" >> "$versions_file"
+            fi
+          done < <(jq -r '.[]' <<< "$CANDIDATES")
+          if [ ! -s "$versions_file" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          version="$(node - "$versions_file" <<'NODE'
+          const fs = require("node:fs");
+          const path = process.argv[2];
+          const versions = fs
+            .readFileSync(path, "utf8")
+            .trim()
+            .split(/\s+/)
+            .map((version) => version.replace(/-.+$/, ""));
+          const key = (version) => {
+            const match = /^1\.(\d+)(?:(beta|rc)(\d+)|\.(\d+))?$/.exec(version);
+            if (!match) throw new Error(`unsupported Go version ${version}`);
+            const minor = Number(match[1]);
+            if (match[2] === "beta") return [minor, 0, Number(match[3])];
+            if (match[2] === "rc") return [minor, 1, Number(match[3])];
+            if (match[4] !== undefined) return [minor, 2, Number(match[4])];
+            return [minor, minor < 21 ? 2 : -1, 0];
+          };
+          const compare = (left, right) => {
+            const a = key(left);
+            const b = key(right);
+            return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+          };
+          versions.sort(compare);
+          process.stdout.write(compare(versions.at(-1), "1.14.0") < 0 ? "1.14.0" : versions.at(-1));
+          NODE
+          )"
+          mkdir -p "$(dirname "$VERSION_FILE")"
+          printf 'golang %s\n' "$version" > "$VERSION_FILE"
+          {
+            echo "available=true"
+            echo "path=$VERSION_FILE"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up exact live-proof Go toolchain
+        if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.resolve-exact-live-proof-go.outputs.available == 'true' && hashFiles(steps.resolve-exact-live-proof-go.outputs.path) != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: ${{ steps.resolve-exact-live-proof-go.outputs.path }}
+          cache: "false"
 
       - name: Install exact live-proof terminal tools
         if: ${{ steps.claim-exact-review-queue.outputs.claimed == 'true' && steps.inspect-exact-live-proof.outputs.requires_terminal == 'true' }}
@@ -4509,9 +4581,81 @@ jobs:
           echo "$summary"
           {
             echo "candidate_count=$(jq -r '.candidates | length' <<< "$summary")"
+            echo "candidates=$(jq -c '.candidates' <<< "$summary")"
             echo "record_media=$(jq -r '.recordMedia' <<< "$summary")"
             echo "requires_terminal=$(jq -r '.requiresTerminal' <<< "$summary")"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve review-shard live-proof Go version
+        id: resolve-shard-live-proof-go
+        if: ${{ steps.inspect-shard-live-proofs.outputs.candidate_count != '0' && steps.inspect-shard-live-proofs.outcome == 'success' }}
+        env:
+          CANDIDATES: ${{ steps.inspect-shard-live-proofs.outputs.candidates }}
+          RECORDS_DIR: review-artifacts/shard-${{ matrix.shard }}
+          TARGET_CHECKOUT: ${{ needs.plan.outputs.target_checkout_dir }}
+          VERSION_FILE: review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.tool-versions
+        run: |
+          set -euo pipefail
+          versions_file="$(mktemp)"
+          trap 'rm -f "$versions_file"' EXIT
+          while read -r item; do
+            record="$RECORDS_DIR/$item.md"
+            head_sha="$(sed -n 's/^pull_head_sha:[[:space:]]*//p' "$record" | head -n 1)"
+            printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'
+            if ! go_mod="$(git -C "$TARGET_CHECKOUT" show "$head_sha:go.mod" 2>/dev/null)"; then
+              continue
+            fi
+            go_version="$(awk '$1 == "go" { print $2; exit }' <<< "$go_mod")"
+            toolchain_version="$(awk '$1 == "toolchain" && $2 ~ /^go/ { sub(/^go/, "", $2); print $2; exit }' <<< "$go_mod")"
+            printf '%s\n' "${go_version:-1.16}" >> "$versions_file"
+            if [ -n "$toolchain_version" ]; then
+              printf '%s\n' "$toolchain_version" >> "$versions_file"
+            fi
+          done < <(jq -r '.[]' <<< "$CANDIDATES")
+          if [ ! -s "$versions_file" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          version="$(node - "$versions_file" <<'NODE'
+          const fs = require("node:fs");
+          const path = process.argv[2];
+          const versions = fs
+            .readFileSync(path, "utf8")
+            .trim()
+            .split(/\s+/)
+            .map((version) => version.replace(/-.+$/, ""));
+          const key = (version) => {
+            const match = /^1\.(\d+)(?:(beta|rc)(\d+)|\.(\d+))?$/.exec(version);
+            if (!match) throw new Error(`unsupported Go version ${version}`);
+            const minor = Number(match[1]);
+            if (match[2] === "beta") return [minor, 0, Number(match[3])];
+            if (match[2] === "rc") return [minor, 1, Number(match[3])];
+            if (match[4] !== undefined) return [minor, 2, Number(match[4])];
+            return [minor, minor < 21 ? 2 : -1, 0];
+          };
+          const compare = (left, right) => {
+            const a = key(left);
+            const b = key(right);
+            return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+          };
+          versions.sort(compare);
+          process.stdout.write(compare(versions.at(-1), "1.14.0") < 0 ? "1.14.0" : versions.at(-1));
+          NODE
+          )"
+          mkdir -p "$(dirname "$VERSION_FILE")"
+          printf 'golang %s\n' "$version" > "$VERSION_FILE"
+          {
+            echo "available=true"
+            echo "path=$VERSION_FILE"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up review-shard live-proof Go toolchain
+        if: ${{ steps.resolve-shard-live-proof-go.outputs.available == 'true' && hashFiles(steps.resolve-shard-live-proof-go.outputs.path) != '' }}
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: ${{ steps.resolve-shard-live-proof-go.outputs.path }}
+          cache: "false"
 
       - name: Install review-shard terminal tools
         if: ${{ steps.inspect-shard-live-proofs.outputs.requires_terminal == 'true' }}

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -38,16 +38,18 @@ After the review command returns, the job inspects the produced reports before
 installing tools. tmux is installed only when a terminal candidate exists. The
 recording toolchain (`ffmpeg`, Xvfb, xterm, and related X11 tools) is installed
 only when at least one recommended plan has a non-`static_text` payoff. Review
-jobs also read each candidate's exact reviewed-head root `go.mod` and provision
-the highest required Go version before execution. Targets without a root
-`go.mod`, mixed review shards where any candidate lacks a root `go.mod`, and
-reviews without a live-proof candidate do not run Go setup. Mixed shards retain
-the existing automatic toolchain fallback for every candidate. When setup runs,
-the action disables shared Go caching and exports `GOTOOLCHAIN=local`; the
-sanitized child keeps that setting while using its private writable module
-cache. Review job timeouts include the target installation and deterministic
-drive. Review jobs default to `ubuntu-latest`; `CLAWSWEEPER_REVIEW_RUNNER`
-remains an optional runner override.
+jobs use each candidate's exact reviewed-head root `go.mod` as the setup gate,
+then use a root `go.work` instead when present and provision the highest
+candidate baseline. A directive-less root workspace requires Go 1.18. Nested Go
+configuration and mixed shards with rootless candidates enable
+`GOTOOLCHAIN=auto` after setup so each proof can select a newer toolchain without
+letting nested fixtures choose the shared baseline. Automatic fallback baselines
+are floored at Go 1.21, the first release with toolchain switching. Root-only
+candidates retain the setup action's `GOTOOLCHAIN=local`; the sanitized child
+keeps the selected setting while using its private writable module cache. Review
+job timeouts include the target installation and deterministic drive. Review
+jobs default to `ubuntu-latest`; `CLAWSWEEPER_REVIEW_RUNNER` remains an optional
+runner override.
 
 For every candidate, trusted ClawSweeper code materializes the report's exact
 head SHA into a scratch worktree, then invokes the existing `live-proof`

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -40,12 +40,14 @@ recording toolchain (`ffmpeg`, Xvfb, xterm, and related X11 tools) is installed
 only when at least one recommended plan has a non-`static_text` payoff. Review
 jobs also read each candidate's exact reviewed-head root `go.mod` and provision
 the highest required Go version before execution. Targets without a root
-`go.mod`, and reviews without a live-proof candidate, do not run Go setup. The
-action disables shared Go caching and exports `GOTOOLCHAIN=local`; the sanitized
-child keeps that setting while using its private writable module cache. Review
-job timeouts include the target installation and deterministic drive. Review
-jobs default to `ubuntu-latest`; `CLAWSWEEPER_REVIEW_RUNNER` remains an optional
-runner override.
+`go.mod`, mixed review shards where any candidate lacks a root `go.mod`, and
+reviews without a live-proof candidate do not run Go setup. Mixed shards retain
+the existing automatic toolchain fallback for every candidate. When setup runs,
+the action disables shared Go caching and exports `GOTOOLCHAIN=local`; the
+sanitized child keeps that setting while using its private writable module
+cache. Review job timeouts include the target installation and deterministic
+drive. Review jobs default to `ubuntu-latest`; `CLAWSWEEPER_REVIEW_RUNNER`
+remains an optional runner override.
 
 For every candidate, trusted ClawSweeper code materializes the report's exact
 head SHA into a scratch worktree, then invokes the existing `live-proof`

--- a/docs/live-proof.md
+++ b/docs/live-proof.md
@@ -38,6 +38,11 @@ After the review command returns, the job inspects the produced reports before
 installing tools. tmux is installed only when a terminal candidate exists. The
 recording toolchain (`ffmpeg`, Xvfb, xterm, and related X11 tools) is installed
 only when at least one recommended plan has a non-`static_text` payoff. Review
+jobs also read each candidate's exact reviewed-head root `go.mod` and provision
+the highest required Go version before execution. Targets without a root
+`go.mod`, and reviews without a live-proof candidate, do not run Go setup. The
+action disables shared Go caching and exports `GOTOOLCHAIN=local`; the sanitized
+child keeps that setting while using its private writable module cache. Review
 job timeouts include the target installation and deterministic drive. Review
 jobs default to `ubuntu-latest`; `CLAWSWEEPER_REVIEW_RUNNER` remains an optional
 runner override.

--- a/test/live-proof-review-environment.test.ts
+++ b/test/live-proof-review-environment.test.ts
@@ -10,18 +10,21 @@ import {
   executeReviewLiveProofs,
   reviewLiveProofGoEnvironment,
 } from "../dist/live-proof/review-artifacts.js";
+import { sanitizedLiveProofEnvironment } from "../dist/live-proof/environment.js";
 import { parseLiveVerificationResult } from "../dist/live-proof/verification.js";
 
 test("review live proof composes inherited Go environment settings", () => {
   const profile = join("scratch", "profile");
-  const environment = reviewLiveProofGoEnvironment(
-    {
-      GOFLAGS: "-trimpath -modcacherw=false",
-      GOMODCACHE: join("shared", "go", "pkg", "mod"),
-    },
-    profile,
-  );
+  const environment = sanitizedLiveProofEnvironment({
+    GOFLAGS: "-trimpath -modcacherw=false",
+    GOMODCACHE: join("shared", "go", "pkg", "mod"),
+    GOTOOLCHAIN: "local",
+    GH_TOKEN: "must-not-cross",
+  });
+  Object.assign(environment, reviewLiveProofGoEnvironment(environment, profile));
 
+  assert.equal(environment.GOTOOLCHAIN, "local");
+  assert.equal(environment.GH_TOKEN, undefined);
   assert.equal(environment.GOFLAGS, "-trimpath -modcacherw=false -modcacherw");
   assert.equal(environment.GOMODCACHE, join(profile, "go-mod-cache"));
 });

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -806,6 +806,58 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     assert.match(install, /run_bounded_install sudo apt-get update/);
     assert.match(install, /run_bounded_install sudo apt-get install --yes/);
   }
+  const resolveExactLiveProofGo = step(reviewer, "Resolve exact live-proof Go version");
+  const setupExactLiveProofGo = step(reviewer, "Set up exact live-proof Go toolchain");
+  assert.match(
+    step(reviewer, "Inspect exact review live proof").run ?? "",
+    /echo "candidates=\$\(jq -c '\.candidates'/,
+  );
+  assert.match(
+    resolveExactLiveProofGo.if ?? "",
+    /inspect-exact-live-proof.*candidate_count != '0'/,
+  );
+  assert.match(resolveExactLiveProofGo.if ?? "", /inspect-exact-live-proof\.outcome == 'success'/);
+  assert.match(
+    resolveExactLiveProofGo.run ?? "",
+    /git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.mod"/,
+  );
+  assert.match(resolveExactLiveProofGo.run ?? "", /\$\{go_version:-1\.16\}/);
+  assert.match(resolveExactLiveProofGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
+  assert.match(resolveExactLiveProofGo.run ?? "", /minor < 21 \? 2 : -1/);
+  assert.match(resolveExactLiveProofGo.run ?? "", /compare\(versions\.at\(-1\), "1\.14\.0"\)/);
+  assert.match(resolveExactLiveProofGo.run ?? "", /printf 'golang %s\\n'/);
+  assert.equal(
+    setupExactLiveProofGo.uses,
+    "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16",
+  );
+  assert.equal(
+    setupExactLiveProofGo.with?.["go-version-file"],
+    "${{ steps.resolve-exact-live-proof-go.outputs.path }}",
+  );
+  assert.equal(setupExactLiveProofGo.with?.cache, "false");
+  assert.match(
+    setupExactLiveProofGo.if ?? "",
+    /claim-exact-review-queue\.outputs\.claimed == 'true'/,
+  );
+  assert.match(
+    setupExactLiveProofGo.if ?? "",
+    /resolve-exact-live-proof-go\.outputs\.available == 'true'/,
+  );
+  assert.match(
+    setupExactLiveProofGo.if ?? "",
+    /hashFiles\(steps\.resolve-exact-live-proof-go\.outputs\.path\) != ''/,
+  );
+  assert.ok(
+    reviewer.steps.indexOf(step(reviewer, "Inspect exact review live proof")) <
+      reviewer.steps.indexOf(resolveExactLiveProofGo),
+  );
+  assert.ok(
+    reviewer.steps.indexOf(resolveExactLiveProofGo) < reviewer.steps.indexOf(setupExactLiveProofGo),
+  );
+  assert.ok(
+    reviewer.steps.indexOf(setupExactLiveProofGo) <
+      reviewer.steps.indexOf(step(reviewer, "Execute exact review live proof")),
+  );
   const reserveLease = step(reviewer, "Reserve exact review lease");
   assert.equal(reserveLease.env?.GH_TOKEN, "${{ steps.target-write-token.outputs.token }}");
   assert.match(reserveLease.run ?? "", /pnpm run --silent reserve-review-lease/);
@@ -1498,6 +1550,54 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.ok(
     publisherSource.indexOf("eventSnapshotMatchesCurrent(paths)", completeStart) > completeStart,
   );
+});
+
+test("review shards provision Go only for inspected live-proof candidates with a root module", () => {
+  type Step = {
+    name?: string;
+    uses?: string;
+    if?: string;
+    run?: string;
+    with?: Record<string, string | number | boolean>;
+  };
+  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+    jobs: Record<string, { steps: Step[] }>;
+  };
+  const steps = workflow.jobs.review!.steps;
+  const step = (name: string) => {
+    const value = steps.find((candidate) => candidate.name === name);
+    assert.ok(value, `missing step: ${name}`);
+    return value;
+  };
+  const resolveGo = step("Resolve review-shard live-proof Go version");
+  const setupGo = step("Set up review-shard live-proof Go toolchain");
+
+  assert.match(
+    step("Inspect review-shard live proofs").run ?? "",
+    /echo "candidates=\$\(jq -c '\.candidates'/,
+  );
+  assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs.*candidate_count != '0'/);
+  assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs\.outcome == 'success'/);
+  assert.match(resolveGo.run ?? "", /git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.mod"/);
+  assert.match(resolveGo.run ?? "", /\$\{go_version:-1\.16\}/);
+  assert.match(resolveGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
+  assert.match(resolveGo.run ?? "", /minor < 21 \? 2 : -1/);
+  assert.match(resolveGo.run ?? "", /compare\(versions\.at\(-1\), "1\.14\.0"\)/);
+  assert.match(resolveGo.run ?? "", /printf 'golang %s\\n'/);
+  assert.equal(setupGo.uses, "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16");
+  assert.equal(
+    setupGo.with?.["go-version-file"],
+    "${{ steps.resolve-shard-live-proof-go.outputs.path }}",
+  );
+  assert.equal(setupGo.with?.cache, "false");
+  assert.match(setupGo.if ?? "", /resolve-shard-live-proof-go\.outputs\.available == 'true'/);
+  assert.match(
+    setupGo.if ?? "",
+    /hashFiles\(steps\.resolve-shard-live-proof-go\.outputs\.path\) != ''/,
+  );
+  assert.ok(steps.indexOf(step("Inspect review-shard live proofs")) < steps.indexOf(resolveGo));
+  assert.ok(steps.indexOf(resolveGo) < steps.indexOf(setupGo));
+  assert.ok(steps.indexOf(setupGo) < steps.indexOf(step("Execute review-shard live proofs")));
 });
 test("exact event publication derives lifecycle receipt and final command acknowledgement from the projection", () => {
   type Step = {

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -1556,7 +1556,7 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
 });
 
-test("review shards provision Go only for inspected live-proof candidates with a root module", () => {
+test("review shards provision Go only when every live-proof candidate has a root module", () => {
   type Step = {
     name?: string;
     uses?: string;
@@ -1583,6 +1583,11 @@ test("review shards provision Go only for inspected live-proof candidates with a
   assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs.*candidate_count != '0'/);
   assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs\.outcome == 'success'/);
   assert.match(resolveGo.run ?? "", /git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.mod"/);
+  assert.match(resolveGo.run ?? "", /candidate_count="\$\(jq -r 'length'/);
+  assert.match(resolveGo.run ?? "", /root_module_count=0/);
+  assert.match(resolveGo.run ?? "", /root_module_count=\$\(\(root_module_count \+ 1\)\)/);
+  assert.match(resolveGo.run ?? "", /if \[ "\$root_module_count" -ne "\$candidate_count" \]; then/);
+  assert.match(resolveGo.run ?? "", /retaining automatic toolchain fallback/);
   assert.match(resolveGo.run ?? "", /\$\{go_version:-1\.16\}/);
   assert.match(resolveGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
   assert.match(resolveGo.run ?? "", /minor < 21 \? 2 : -1/);
@@ -1592,6 +1597,10 @@ test("review shards provision Go only for inspected live-proof candidates with a
     "review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.go-version",
   );
   assert.match(resolveGo.run ?? "", /printf '%s\\n'/);
+  assert.ok(
+    (resolveGo.run ?? "").indexOf('if [ "$root_module_count" -ne "$candidate_count" ]; then') <
+      (resolveGo.run ?? "").indexOf('if [ ! -s "$versions_file" ]; then'),
+  );
   assert.equal(setupGo.uses, "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16");
   assert.equal(
     setupGo.with?.["go-version-file"],

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -821,10 +821,10 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
     resolveExactLiveProofGo.run ?? "",
     /git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.mod"/,
   );
-  assert.match(resolveExactLiveProofGo.run ?? "", /\$\{go_version:-1\.16\}/);
+  assert.match(resolveExactLiveProofGo.run ?? "", /\$\{go_version:-\$default_go_version\}/);
   assert.match(resolveExactLiveProofGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
   assert.match(resolveExactLiveProofGo.run ?? "", /minor < 21 \? 2 : -1/);
-  assert.match(resolveExactLiveProofGo.run ?? "", /compare\(versions\.at\(-1\), "1\.14\.0"\)/);
+  assert.match(resolveExactLiveProofGo.run ?? "", /compare\(versions\.at\(-1\), minimum\)/);
   assert.equal(
     resolveExactLiveProofGo.env?.VERSION_FILE,
     ".artifacts/exact-live-proof-go/.go-version",
@@ -1556,66 +1556,245 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   );
 });
 
-test("review shards provision Go only when every live-proof candidate has a root module", () => {
-  type Step = {
-    name?: string;
-    uses?: string;
-    if?: string;
-    run?: string;
-    with?: Record<string, string | number | boolean>;
-  };
-  const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
-    jobs: Record<string, { steps: Step[] }>;
-  };
-  const steps = workflow.jobs.review!.steps;
-  const step = (name: string) => {
-    const value = steps.find((candidate) => candidate.name === name);
-    assert.ok(value, `missing step: ${name}`);
-    return value;
-  };
-  const resolveGo = step("Resolve review-shard live-proof Go version");
-  const setupGo = step("Set up review-shard live-proof Go toolchain");
+test(
+  "review shards provision the highest candidate Go workspace version only for root modules",
+  { skip: process.platform === "win32" ? "requires Bash" : false },
+  () => {
+    type Step = {
+      name?: string;
+      uses?: string;
+      if?: string;
+      run?: string;
+      with?: Record<string, string | number | boolean>;
+    };
+    const workflow = YAML.parse(readText(".github/workflows/sweep.yml")) as {
+      jobs: Record<string, { steps: Step[] }>;
+    };
+    const steps = workflow.jobs.review!.steps;
+    const exactSteps = workflow.jobs["event-review-apply"]!.steps;
+    const step = (name: string) => {
+      const value = steps.find((candidate) => candidate.name === name);
+      assert.ok(value, `missing step: ${name}`);
+      return value;
+    };
+    const exactStep = (name: string) => {
+      const value = exactSteps.find((candidate) => candidate.name === name);
+      assert.ok(value, `missing exact step: ${name}`);
+      return value;
+    };
+    const resolveGo = step("Resolve review-shard live-proof Go version");
+    const setupGo = step("Set up review-shard live-proof Go toolchain");
+    const enableGoFallback = step("Enable review-shard live-proof automatic Go fallback");
+    const resolveExactGo = exactStep("Resolve exact live-proof Go version");
+    const enableExactGoFallback = exactStep("Enable exact live-proof automatic Go fallback");
 
-  assert.match(
-    step("Inspect review-shard live proofs").run ?? "",
-    /echo "candidates=\$\(jq -c '\.candidates'/,
-  );
-  assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs.*candidate_count != '0'/);
-  assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs\.outcome == 'success'/);
-  assert.match(resolveGo.run ?? "", /git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.mod"/);
-  assert.match(resolveGo.run ?? "", /candidate_count="\$\(jq -r 'length'/);
-  assert.match(resolveGo.run ?? "", /root_module_count=0/);
-  assert.match(resolveGo.run ?? "", /root_module_count=\$\(\(root_module_count \+ 1\)\)/);
-  assert.match(resolveGo.run ?? "", /if \[ "\$root_module_count" -ne "\$candidate_count" \]; then/);
-  assert.match(resolveGo.run ?? "", /retaining automatic toolchain fallback/);
-  assert.match(resolveGo.run ?? "", /\$\{go_version:-1\.16\}/);
-  assert.match(resolveGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
-  assert.match(resolveGo.run ?? "", /minor < 21 \? 2 : -1/);
-  assert.match(resolveGo.run ?? "", /compare\(versions\.at\(-1\), "1\.14\.0"\)/);
-  assert.equal(
-    resolveGo.env?.VERSION_FILE,
-    "review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.go-version",
-  );
-  assert.match(resolveGo.run ?? "", /printf '%s\\n'/);
-  assert.ok(
-    (resolveGo.run ?? "").indexOf('if [ "$root_module_count" -ne "$candidate_count" ]; then') <
-      (resolveGo.run ?? "").indexOf('if [ ! -s "$versions_file" ]; then'),
-  );
-  assert.equal(setupGo.uses, "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16");
-  assert.equal(
-    setupGo.with?.["go-version-file"],
-    "${{ steps.resolve-shard-live-proof-go.outputs.path }}",
-  );
-  assert.equal(setupGo.with?.cache, "false");
-  assert.match(setupGo.if ?? "", /resolve-shard-live-proof-go\.outputs\.available == 'true'/);
-  assert.match(
-    setupGo.if ?? "",
-    /hashFiles\(steps\.resolve-shard-live-proof-go\.outputs\.path\) != ''/,
-  );
-  assert.ok(steps.indexOf(step("Inspect review-shard live proofs")) < steps.indexOf(resolveGo));
-  assert.ok(steps.indexOf(resolveGo) < steps.indexOf(setupGo));
-  assert.ok(steps.indexOf(setupGo) < steps.indexOf(step("Execute review-shard live proofs")));
-});
+    assert.match(
+      step("Inspect review-shard live proofs").run ?? "",
+      /echo "candidates=\$\(jq -c '\.candidates'/,
+    );
+    assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs.*candidate_count != '0'/);
+    assert.match(resolveGo.if ?? "", /inspect-shard-live-proofs\.outcome == 'success'/);
+    assert.match(
+      resolveGo.run ?? "",
+      /go_mod="\$\(git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.mod"/,
+    );
+    assert.match(
+      resolveGo.run ?? "",
+      /go_work="\$\(git -C "\$TARGET_CHECKOUT" show "\$head_sha:go\.work"/,
+    );
+    assert.match(resolveGo.run ?? "", /go_config="\$go_work"/);
+    assert.match(resolveGo.run ?? "", /default_go_version=1\.18/);
+    assert.match(resolveGo.run ?? "", /go_config="\$go_mod"/);
+    assert.match(resolveGo.run ?? "", /default_go_version=1\.16/);
+    assert.match(resolveGo.run ?? "", /git -C "\$TARGET_CHECKOUT" ls-tree -rz --name-only/);
+    assert.match(resolveGo.run ?? "", /while IFS= read -r -d '' path/);
+    assert.match(resolveGo.run ?? "", /\*\/go\.mod \| \*\/go\.work\)/);
+    assert.match(resolveGo.run ?? "", /requires_automatic_toolchain=true/);
+    assert.match(resolveExactGo.run ?? "", /git -C "\$TARGET_CHECKOUT" ls-tree -rz --name-only/);
+    assert.match(resolveExactGo.run ?? "", /while IFS= read -r -d '' path/);
+    assert.match(resolveExactGo.run ?? "", /requires_automatic_toolchain=true/);
+    assert.match(resolveGo.run ?? "", /candidate_count="\$\(jq -r 'length'/);
+    assert.match(resolveGo.run ?? "", /root_module_count=0/);
+    assert.match(resolveGo.run ?? "", /root_module_count=\$\(\(root_module_count \+ 1\)\)/);
+    assert.match(resolveGo.run ?? "", /root_module_count" -ne "\$candidate_count"/);
+    assert.match(resolveGo.run ?? "", /automatic=\$requires_automatic_toolchain/);
+    assert.match(resolveGo.run ?? "", /\$\{go_version:-\$default_go_version\}/);
+    assert.match(resolveGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
+    assert.match(resolveGo.run ?? "", /minor < 21 \? 2 : -1/);
+    assert.match(resolveGo.run ?? "", /minimum_go_version=1\.14\.0/);
+    assert.match(resolveGo.run ?? "", /minimum_go_version=1\.21\.0/);
+    assert.match(resolveGo.run ?? "", /compare\(versions\.at\(-1\), minimum\)/);
+    assert.equal(
+      resolveGo.env?.VERSION_FILE,
+      "review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.go-version",
+    );
+    assert.match(resolveGo.run ?? "", /printf '%s\\n'/);
+    const rootlessGuard = (resolveGo.run ?? "").indexOf(
+      'if [ "$root_module_count" -ne "$candidate_count" ]; then',
+    );
+    const availabilityGuard = (resolveGo.run ?? "").indexOf('if [ ! -s "$versions_file" ]; then');
+    assert.notEqual(rootlessGuard, -1);
+    assert.notEqual(availabilityGuard, -1);
+    assert.ok(rootlessGuard < availabilityGuard);
+    assert.equal(setupGo.uses, "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16");
+    assert.equal(
+      setupGo.with?.["go-version-file"],
+      "${{ steps.resolve-shard-live-proof-go.outputs.path }}",
+    );
+    assert.equal(setupGo.with?.cache, "false");
+    assert.match(setupGo.if ?? "", /resolve-shard-live-proof-go\.outputs\.available == 'true'/);
+    assert.match(
+      setupGo.if ?? "",
+      /hashFiles\(steps\.resolve-shard-live-proof-go\.outputs\.path\) != ''/,
+    );
+    assert.match(enableGoFallback.if ?? "", /resolve-shard-live-proof-go\.outputs\.automatic/);
+    assert.match(enableGoFallback.run ?? "", /GOTOOLCHAIN=auto.*GITHUB_ENV/);
+    assert.match(enableExactGoFallback.if ?? "", /resolve-exact-live-proof-go\.outputs\.automatic/);
+    assert.match(enableExactGoFallback.run ?? "", /GOTOOLCHAIN=auto.*GITHUB_ENV/);
+    assert.ok(steps.indexOf(step("Inspect review-shard live proofs")) < steps.indexOf(resolveGo));
+    assert.ok(steps.indexOf(resolveGo) < steps.indexOf(setupGo));
+    assert.ok(steps.indexOf(setupGo) < steps.indexOf(enableGoFallback));
+    assert.ok(
+      steps.indexOf(enableGoFallback) < steps.indexOf(step("Execute review-shard live proofs")),
+    );
+
+    const root = mkdtempSync(`${tmpPrefix}go-workspace-resolver-`);
+    const target = join(root, "target");
+    const records = join(root, "records");
+    const runGit = (...args: string[]) =>
+      execFileSync("git", args, { cwd: target, encoding: "utf8" }).trim();
+    try {
+      mkdirSync(target);
+      mkdirSync(records);
+      runGit("init", "-b", "main");
+      runGit("config", "user.name", "ClawSweeper Test");
+      runGit("config", "user.email", "test@example.com");
+      runGit("config", "commit.gpgsign", "false");
+
+      writeFileSync(join(target, "go.mod"), "module example.com/root\n\ngo 1.26.0\n");
+      writeFileSync(join(target, "go.work"), "go 1.27.2\n\nuse .\n");
+      runGit("add", ".");
+      runGit("commit", "-m", "workspace");
+      const workspaceHead = runGit("rev-parse", "HEAD");
+
+      writeFileSync(join(target, "go.mod"), "module example.com/root\n\ngo 1.29.0\n");
+      writeFileSync(join(target, "go.work"), "go 1.27.0\n\nuse .\n");
+      runGit("add", ".");
+      runGit("commit", "-m", "workspace governs module");
+      const workspaceGovernedHead = runGit("rev-parse", "HEAD");
+
+      writeFileSync(join(target, "go.mod"), "module example.com/root\n\ngo 1.17\n");
+      writeFileSync(join(target, "go.work"), "use .\n");
+      runGit("add", ".");
+      runGit("commit", "-m", "implicit workspace version");
+      const implicitWorkspaceHead = runGit("rev-parse", "HEAD");
+
+      const nestedWorkspaceDir = join(target, "nested-\u00e9\nworkspace");
+      mkdirSync(nestedWorkspaceDir);
+      writeFileSync(
+        join(nestedWorkspaceDir, "go.mod"),
+        "module example.com/excluded\n\ngo 1.28.0\n",
+      );
+      runGit("add", ".");
+      runGit("commit", "-m", "excluded nested module");
+      const excludedNestedHead = runGit("rev-parse", "HEAD");
+
+      writeFileSync(join(nestedWorkspaceDir, "go.work"), "go 1.28.0\n");
+      runGit("add", ".");
+      runGit("commit", "-m", "nested workspace");
+      const nestedWorkspaceHead = runGit("rev-parse", "HEAD");
+
+      rmSync(nestedWorkspaceDir, { recursive: true });
+      rmSync(join(target, "go.work"));
+      writeFileSync(join(target, "go.mod"), "module example.com/root\n\ngo 1.25.0\n");
+      runGit("add", "-A");
+      runGit("commit", "-m", "root module");
+      const rootHead = runGit("rev-parse", "HEAD");
+
+      mkdirSync(join(target, "nested"));
+      writeFileSync(join(target, "nested", "go.mod"), "module example.com/nested\n\ngo 1.28.0\n");
+      runGit("add", "-A");
+      runGit("commit", "-m", "independent nested module");
+      const independentNestedHead = runGit("rev-parse", "HEAD");
+
+      rmSync(join(target, "go.mod"));
+      rmSync(join(target, "nested"), { recursive: true });
+      mkdirSync(join(target, "nested"));
+      writeFileSync(join(target, "nested", "go.mod"), "module example.com/nested\n\ngo 1.28.0\n");
+      runGit("add", "-A");
+      runGit("commit", "-m", "nested module only");
+      const nestedOnlyHead = runGit("rev-parse", "HEAD");
+
+      writeFileSync(join(records, "1.md"), `pull_head_sha: ${workspaceHead}\n`);
+      writeFileSync(join(records, "2.md"), `pull_head_sha: ${rootHead}\n`);
+      writeFileSync(join(records, "3.md"), `pull_head_sha: ${independentNestedHead}\n`);
+      writeFileSync(join(records, "4.md"), `pull_head_sha: ${nestedOnlyHead}\n`);
+      writeFileSync(join(records, "5.md"), `pull_head_sha: ${nestedWorkspaceHead}\n`);
+      writeFileSync(join(records, "6.md"), `pull_head_sha: ${excludedNestedHead}\n`);
+      writeFileSync(join(records, "7.md"), `pull_head_sha: ${workspaceGovernedHead}\n`);
+      writeFileSync(join(records, "8.md"), `pull_head_sha: ${implicitWorkspaceHead}\n`);
+
+      const resolve = (label: string, candidates: string) => {
+        const versionFile = join(root, label, ".go-version");
+        const outputFile = join(root, `${label}-output`);
+        execFileSync("/bin/bash", ["-c", resolveGo.run ?? ""], {
+          cwd: root,
+          env: {
+            ...process.env,
+            CANDIDATES: candidates,
+            GITHUB_OUTPUT: outputFile,
+            RECORDS_DIR: records,
+            TARGET_CHECKOUT: target,
+            VERSION_FILE: versionFile,
+          },
+        });
+        return {
+          output: readFileSync(outputFile, "utf8"),
+          version: existsSync(versionFile) ? readFileSync(versionFile, "utf8").trim() : undefined,
+        };
+      };
+
+      assert.deepEqual(resolve("all-root", "[1,2]"), {
+        output:
+          "automatic=false\navailable=true\npath=" +
+          join(root, "all-root", ".go-version") +
+          "\nversion=1.27.2\n",
+        version: "1.27.2",
+      });
+      assert.deepEqual(resolve("workspace-governs", "[7]"), {
+        output:
+          "automatic=false\navailable=true\npath=" +
+          join(root, "workspace-governs", ".go-version") +
+          "\nversion=1.27.0\n",
+        version: "1.27.0",
+      });
+      assert.deepEqual(resolve("implicit-workspace", "[8]"), {
+        output:
+          "automatic=false\navailable=true\npath=" +
+          join(root, "implicit-workspace", ".go-version") +
+          "\nversion=1.18\n",
+        version: "1.18",
+      });
+      for (const [label, candidates, version] of [
+        ["mixed", "[1,3]", "1.27.2"],
+        ["missing-root", "[1,4]", "1.27.2"],
+        ["nested-workspace", "[5]", "1.21.0"],
+        ["excluded-nested", "[6]", "1.21.0"],
+      ] as const) {
+        const result = resolve(label, candidates);
+        assert.equal(result.version, version);
+        assert.match(result.output, /automatic=true/);
+        assert.match(result.output, /available=true/);
+      }
+      assert.deepEqual(resolve("rootless-only", "[4]"), {
+        output: "automatic=true\navailable=false\n",
+        version: undefined,
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
 test("exact event publication derives lifecycle receipt and final command acknowledgement from the projection", () => {
   type Step = {
     name?: string;

--- a/test/sweep-workflow.test.ts
+++ b/test/sweep-workflow.test.ts
@@ -825,7 +825,11 @@ test("exact event review publishes directly with a queue-bounded canonical fallb
   assert.match(resolveExactLiveProofGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
   assert.match(resolveExactLiveProofGo.run ?? "", /minor < 21 \? 2 : -1/);
   assert.match(resolveExactLiveProofGo.run ?? "", /compare\(versions\.at\(-1\), "1\.14\.0"\)/);
-  assert.match(resolveExactLiveProofGo.run ?? "", /printf 'golang %s\\n'/);
+  assert.equal(
+    resolveExactLiveProofGo.env?.VERSION_FILE,
+    ".artifacts/exact-live-proof-go/.go-version",
+  );
+  assert.match(resolveExactLiveProofGo.run ?? "", /printf '%s\\n'/);
   assert.equal(
     setupExactLiveProofGo.uses,
     "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16",
@@ -1583,7 +1587,11 @@ test("review shards provision Go only for inspected live-proof candidates with a
   assert.match(resolveGo.run ?? "", /replace\(\/-\.\+\$\/, ""\)/);
   assert.match(resolveGo.run ?? "", /minor < 21 \? 2 : -1/);
   assert.match(resolveGo.run ?? "", /compare\(versions\.at\(-1\), "1\.14\.0"\)/);
-  assert.match(resolveGo.run ?? "", /printf 'golang %s\\n'/);
+  assert.equal(
+    resolveGo.env?.VERSION_FILE,
+    "review-artifacts/shard-${{ matrix.shard }}/live-proof-toolchain/.go-version",
+  );
+  assert.match(resolveGo.run ?? "", /printf '%s\\n'/);
   assert.equal(setupGo.uses, "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16");
   assert.equal(
     setupGo.with?.["go-version-file"],


### PR DESCRIPTION
## What Problem This Solves

Go live-proof candidates could fail before execution when the reviewed head required a newer Go version than the review runner provided.

## Canonical Fix

The review workflow now resolves Go requirements from every runnable candidate's exact reviewed head before execution. Root `go.work` governs when present; otherwise root `go.mod` governs. Nested or rootless Go layouts retain automatic toolchain fallback, while root-only candidates keep setup-go's `GOTOOLCHAIN=local` boundary.

Both exact-item and shard paths use pinned `actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16` (`v6.5.0`), a generated version file, a `hashFiles` gate, and `cache: "false"`. Batch publication is unchanged.

## Validation

Exact head: `6ccb0a6cc56451ddc3a1c26602cea5e9af29ddb4`

- `node --test test/sweep-workflow.test.ts`: 125 passed.
- focused inherited Go environment test: passed.
- hostile global `commit.gpgsign=true` resolver fixture: passed.
- `tsc -p tsconfig.json`: passed.
- `tsc -p tsconfig.repair.json`: passed.
- `node scripts/check-docs.mjs`: passed.
- targeted oxlint, oxfmt check, and `git diff --check`: passed.
- hosted CI: https://github.com/openclaw/clawsweeper/actions/runs/33033521333 (success; `pnpm check` 7m57s).
- hosted CodeQL: https://github.com/openclaw/clawsweeper/actions/runs/33033521622 (success).

## Real Behavior Proof

Hosted branch proof: https://github.com/openclaw/clawsweeper/actions/runs/33033570286

- Workflow head: `6ccb0a6cc56451ddc3a1c26602cea5e9af29ddb4`.
- Target: `steipete/camsnap#15` at `4ac1569be4a031110eed3253d7ba155cf2fa6a84`.
- Pinned setup-go selected Go `1.26.0`; runner reported `go version go1.26.0 linux/amd64`.
- Root-only candidate retained `GOTOOLCHAIN=local`.
- Sanitized child assertion passed with `credentials=0`.
- Live-proof execution and publication succeeded.
- No `EACCES` occurred; no failed-shard artifact was created; recovery reported no failed shard jobs and nothing to requeue.

## Review Finding Disposition

- Exact-head root selection, setup-go version-file contract, suffixed toolchain normalization, Go 1.14 minimum, and `GOTOOLCHAIN` child inheritance are covered.
- Root `go.work` exclusively governs root `go.mod`; directive-less workspaces default to Go 1.18.
- Rootless, mixed, and nested Go layouts enable automatic fallback with a Go 1.21 minimum bootstrap.
- Nested paths are enumerated safely with NUL-delimited `git ls-tree -rz --name-only` in both resolvers; `-rz` is Git's combined short-option form for recursive (`-r`) plus NUL-delimited (`-z`) traversal.
- The latest ClawSweeper P1 claiming traversal was non-recursive is skipped as a false positive. The exact command is asserted for both resolver paths, and the fixture includes nested, Unicode, and newline-containing paths.
- The previous current-head proof gap is resolved by run `33033570286` above.

## Change Size

- Production workflow: +202 lines.
- Documentation: +9 lines.
- Tests: +306/-7 lines.

The positive production delta owns exact-head multi-candidate toolchain resolution for both execution paths. No runtime abstraction, publication path, or batch-publish behavior was added or changed.
