### PR TITLE
fix(review): materialize requested Codex source

### DIFF
--- a/src/clawsweeper-review-command-workflow.ts
+++ b/src/clawsweeper-review-command-workflow.ts
@@ -43,6 +43,7 @@ import { reviewContentCacheHit } from "./scheduler-policy.js";
 import type { CreateReviewCommandWorkflowDependencies } from "./clawsweeper-review-command-dependencies.js";
 import { prepareReviewCommand } from "./clawsweeper-review-preparation.js";
 import { parsePrHydrationSnapshot } from "./pr-hydration-snapshot.js";
+import { materializeRequestedReviewSource } from "./review-source-checkout.js";
 
 function reviewStartLeaseCommentUpdatedAt(
   comment: Record<string, unknown> | undefined,
@@ -1502,6 +1503,12 @@ export function createReviewCommandWorkflow(dependencies: CreateReviewCommandWor
         const codexStartedAt = Date.now();
         try {
           if (pullRequestReviewTreeFailure) throw pullRequestReviewTreeFailure;
+          materializeRequestedReviewSource({
+            targetRepo: item.repo,
+            targetDir: reviewOpenclawDir,
+            additionalPrompt,
+            allowFetch: !localRange,
+          });
           if (humanLocalReview) {
             console.error("");
             console.error("Running Codex review");

--- a/src/review-source-checkout.ts
+++ b/src/review-source-checkout.ts
@@ -1,0 +1,190 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+
+const OPENCLAW_REPO = "openclaw/openclaw";
+const CODEX_URL = "https://github.com/openai/codex.git";
+const SHA_PATTERN = "[0-9a-fA-F]{40}";
+const LOCAL_PIN_LEAD =
+  /^`?\s*(?:[,;:]\s*)?(?:at\s+|(?:and\s+)?(?:check\s+out|checkout)\s+)(?:the\s+)?exact\s+commit\b/i;
+const LOCAL_PIN = new RegExp(
+  `${LOCAL_PIN_LEAD.source}\\s+(?:(${SHA_PATTERN})|\\\`(${SHA_PATTERN})\\\`|<(${SHA_PATTERN})>|\\\`<(${SHA_PATTERN})>\\\`)(?=$|[\\s.,;:!?)}\\]\\\`])`,
+  "i",
+);
+
+export function requestedCodexRevision({
+  targetRepo,
+  additionalPrompt,
+}: {
+  targetRepo: string;
+  additionalPrompt: string;
+}): string | null {
+  if (targetRepo.trim().toLowerCase() !== OPENCLAW_REPO) return null;
+
+  const prompt = additionalPrompt.trim();
+  const pins: string[] = [];
+  let malformedExplicitPin = false;
+  const recordPin = (token: string | undefined): void => {
+    if (!token || !new RegExp(`^${SHA_PATTERN}$`).test(token)) {
+      malformedExplicitPin = true;
+      return;
+    }
+    pins.push(token.toLowerCase());
+  };
+
+  const urlLead = /https:\/\/github\.com\/openai\/codex\/(?:blob|commit|tree)\//gi;
+  for (const lead of prompt.matchAll(urlLead)) {
+    const suffix = prompt.slice(lead.index + lead[0].length);
+    recordPin(new RegExp(`^(${SHA_PATTERN})(?=$|[/#>\\s.,;:!?)}\\]\\\`])`, "i").exec(suffix)?.[1]);
+  }
+
+  const repoAtLead = /\bopenai\/codex@/gi;
+  for (const lead of prompt.matchAll(repoAtLead)) {
+    const suffix = prompt.slice(lead.index + lead[0].length);
+    recordPin(new RegExp(`^(${SHA_PATTERN})(?=$|[\\s.,;:!?)}\\]\\\`])`, "i").exec(suffix)?.[1]);
+  }
+
+  const literalRepo = /\bopenai\/codex\b/gi;
+  for (const reference of prompt.matchAll(literalRepo)) {
+    const suffix = prompt.slice(reference.index + reference[0].length);
+    if (suffix.startsWith("@") || /^\/(?:blob|commit|tree)\//i.test(suffix)) continue;
+    if (LOCAL_PIN_LEAD.test(suffix)) {
+      const localPin = LOCAL_PIN.exec(suffix);
+      recordPin(localPin?.slice(1).find(Boolean));
+    }
+  }
+
+  if (malformedExplicitPin) {
+    throw new Error("An openai/codex source request must name one exact 40-character commit SHA.");
+  }
+  if (pins.length === 0) return null;
+  if (pins.length !== 1) {
+    throw new Error("An openai/codex source request must contain exactly one explicit pin.");
+  }
+  return pins[0] ?? null;
+}
+export function materializeRequestedReviewSource(options: {
+  targetRepo: string;
+  targetDir: string;
+  additionalPrompt: string;
+  sourceUrl?: string;
+  allowFetch?: boolean;
+}): MaterializedReviewSource | null {
+  const revision = requestedCodexRevision(options);
+  if (!revision) return null;
+  return materializeCodexSource({
+    targetDir: options.targetDir,
+    revision,
+    ...(options.sourceUrl ? { sourceUrl: options.sourceUrl } : {}),
+    ...(options.allowFetch === undefined ? {} : { allowFetch: options.allowFetch }),
+  });
+}
+
+export function materializeCodexSource({
+  targetDir,
+  revision,
+  sourceUrl = CODEX_URL,
+  allowFetch = true,
+  runGit = defaultRunGit,
+}: {
+  targetDir: string;
+  revision: string;
+  sourceUrl?: string;
+  allowFetch?: boolean;
+  runGit?: (args: string[], cwd: string) => string;
+}): MaterializedReviewSource {
+  if (!/^[0-9a-f]{40}$/.test(revision)) {
+    throw new Error("Codex source revision must be an exact lowercase 40-character SHA.");
+  }
+  const target = resolve(targetDir);
+  if (!existsSync(target) || !lstatSync(target).isDirectory()) {
+    throw new Error(`Target checkout does not exist: ${target}`);
+  }
+  const parent = dirname(target);
+  const destination = join(parent, "codex");
+  if (resolve(destination) === target || basename(target) === "codex") {
+    throw new Error("The target checkout cannot occupy the reserved Codex sibling path.");
+  }
+  if (existsSync(destination)) {
+    if (lstatSync(destination).isSymbolicLink()) {
+      throw new Error("Existing Codex sibling checkout must not be a symbolic link.");
+    }
+    const head = runGit(["rev-parse", "HEAD"], destination).trim().toLowerCase();
+    const indexFlags = runGit(["ls-files", "-v", "-z"], destination)
+      .split("\0")
+      .filter(Boolean)
+      .map((entry) => entry[0]);
+    if (indexFlags.some((flag) => flag !== "H")) {
+      throw new Error("Existing Codex sibling checkout has unsafe index visibility flags.");
+    }
+    const status = runGit(
+      ["status", "--porcelain=v1", "--untracked-files=all", "--ignored=matching"],
+      destination,
+    ).trim();
+    if (head !== revision || status) {
+      throw new Error(`Existing Codex sibling checkout does not match ${revision}.`);
+    }
+    assertCodexCheckout(destination);
+    return { destination, reused: true, revision };
+  }
+
+  if (!allowFetch) {
+    throw new Error(
+      `Offline review requires a pre-provisioned exact Codex sibling checkout at ${destination}.`,
+    );
+  }
+
+  const staging = mkdtempSync(join(parent, ".codex-source-"));
+  try {
+    runGit(["init", "--quiet"], staging);
+    runGit(["remote", "add", "origin", sourceUrl], staging);
+    runGit(["fetch", "--quiet", "--depth=1", "--no-tags", "origin", revision], staging);
+    runGit(["checkout", "--quiet", "--detach", "FETCH_HEAD"], staging);
+    const head = runGit(["rev-parse", "HEAD"], staging).trim().toLowerCase();
+    if (head !== revision) {
+      throw new Error(`Codex checkout resolved ${head || "no HEAD"}, expected ${revision}.`);
+    }
+    if (runGit(["status", "--porcelain"], staging).trim()) {
+      throw new Error("Codex source checkout is not clean after materialization.");
+    }
+    assertCodexCheckout(staging);
+    renameSync(staging, destination);
+    return { destination, reused: false, revision };
+  } catch (error) {
+    rmSync(staging, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+type MaterializedReviewSource = {
+  destination: string;
+  reused: boolean;
+  revision: string;
+};
+
+function assertCodexCheckout(directory: string): void {
+  const agentsPath = join(directory, "AGENTS.md");
+  if (!existsSync(agentsPath) || !lstatSync(agentsPath).isFile()) {
+    throw new Error("Pinned Codex source checkout is missing its root AGENTS.md.");
+  }
+  if (!readFileSync(agentsPath, "utf8").trim()) {
+    throw new Error("Pinned Codex root AGENTS.md is empty.");
+  }
+}
+
+function defaultRunGit(args: string[], cwd: string): string {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 120_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args[0] ?? "command"} failed (${result.status ?? "unknown"}): ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout;
+}

--- a/test/review-source-checkout.test.ts
+++ b/test/review-source-checkout.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+
+import {
+  materializeCodexSource,
+  materializeRequestedReviewSource,
+  requestedCodexRevision,
+} from "../dist/review-source-checkout.js";
+
+const CODEX_REVISION = "f1087ff151b06e781ecb086068d45fcc62d02da3";
+const OTHER_REVISION = "0123456789abcdef0123456789abcdef01234567";
+const ACTUAL_REVIEW_REQUEST = `The reviewer itself must obtain or clone openai/codex, check out exact commit ${CODEX_REVISION}, and personally inspect codex-rs/core/src/tasks/mod.rs.`;
+
+test("pinned Codex source request accepts only the closed maintainer grammar", () => {
+  for (const additionalPrompt of [
+    ACTUAL_REVIEW_REQUEST,
+    `Inspect openai/codex at exact commit ${CODEX_REVISION}.`,
+    `Inspect \`openai/codex\` at exact commit \`${CODEX_REVISION}\`.`,
+    `Inspect \`openai/codex\` at exact commit \`<${CODEX_REVISION}>\`.`,
+    `Inspect openai/codex@${CODEX_REVISION}.`,
+    `Inspect \`openai/codex@${CODEX_REVISION}\`.`,
+    `Inspect https://github.com/openai/codex/commit/${CODEX_REVISION}.`,
+    `Inspect <https://github.com/openai/codex/commit/${CODEX_REVISION}>.`,
+    `Inspect https://github.com/openai/codex/commit/${CODEX_REVISION}#diff-source.`,
+    `Inspect https://github.com/openai/codex/tree/${CODEX_REVISION}/codex-rs/core/src/tasks.`,
+    `Inspect https://github.com/openai/codex/blob/${CODEX_REVISION}/codex-rs/core/src/tasks/mod.rs.`,
+  ]) {
+    assert.equal(
+      requestedCodexRevision({ targetRepo: "openclaw/openclaw", additionalPrompt }),
+      CODEX_REVISION,
+    );
+  }
+
+  assert.equal(
+    requestedCodexRevision({
+      targetRepo: "openclaw/openclaw",
+      additionalPrompt: "Inspect openai/codex as background.",
+    }),
+    null,
+  );
+  assert.equal(
+    requestedCodexRevision({
+      targetRepo: "openclaw/clawsweeper",
+      additionalPrompt: ACTUAL_REVIEW_REQUEST,
+    }),
+    null,
+  );
+});
+
+test("malformed explicit Codex pins fail closed", () => {
+  for (const additionalPrompt of [
+    "Inspect openai/codex at exact commit deadbeef.",
+    "Inspect openai/codex at exact commit.",
+    "Inspect openai/codex@deadbeef.",
+    "Inspect openai/codex@.",
+    "Inspect https://github.com/openai/codex/commit/deadbeef.",
+    "Inspect https://github.com/openai/codex/tree/.",
+  ]) {
+    assert.throws(
+      () => requestedCodexRevision({ targetRepo: "openclaw/openclaw", additionalPrompt }),
+      /must name one exact 40-character commit SHA/,
+    );
+  }
+});
+
+test("multiple explicit Codex pins fail closed", () => {
+  for (const additionalPrompt of [
+    `Inspect openai/codex at exact commit ${CODEX_REVISION}, then openai/codex@${OTHER_REVISION}.`,
+    `Compare https://github.com/openai/codex/commit/${CODEX_REVISION} with https://github.com/openai/codex/tree/${OTHER_REVISION}.`,
+    `Inspect openai/codex@${CODEX_REVISION} and openai/codex@${CODEX_REVISION}.`,
+  ]) {
+    assert.throws(
+      () => requestedCodexRevision({ targetRepo: "openclaw/openclaw", additionalPrompt }),
+      /must contain exactly one explicit pin/,
+    );
+  }
+});
+
+test("materializer creates a clean exact sibling checkout for the review worker", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-review-source-"));
+  const source = join(root, "source");
+  const target = join(root, "openclaw");
+  try {
+    mkdirSync(source);
+    mkdirSync(target);
+    assert.throws(
+      () =>
+        materializeCodexSource({
+          targetDir: target,
+          revision: "A".repeat(40),
+          sourceUrl: source,
+        }),
+      /exact lowercase 40-character SHA/,
+    );
+    git(source, "init", "--quiet");
+    git(source, "config", "user.email", "clawsweeper@example.com");
+    git(source, "config", "user.name", "ClawSweeper Test");
+    git(source, "config", "commit.gpgsign", "false");
+    writeFileSync(join(source, "AGENTS.md"), "# Codex instructions\n");
+    mkdirSync(join(source, "codex-rs", "core", "src"), { recursive: true });
+    writeFileSync(join(source, "codex-rs", "core", "src", "lib.rs"), "pub mod tasks;\n");
+    git(source, "add", ".");
+    git(source, "commit", "--quiet", "-m", "fixture");
+    const revision = git(source, "rev-parse", "HEAD").trim();
+
+    const first = materializeCodexSource({ targetDir: target, revision, sourceUrl: source });
+    assert.equal(first.destination, join(root, "codex"));
+    assert.equal(first.reused, false);
+    assert.equal(git(first.destination, "rev-parse", "HEAD").trim(), revision);
+    assert.equal(git(first.destination, "status", "--porcelain"), "");
+    assert.equal(
+      readFileSync(join(first.destination, "codex-rs", "core", "src", "lib.rs"), "utf8"),
+      "pub mod tasks;\n",
+    );
+
+    const second = materializeCodexSource({ targetDir: target, revision, sourceUrl: source });
+    assert.equal(second.reused, true);
+    const offlineReuse = materializeCodexSource({
+      targetDir: target,
+      revision,
+      sourceUrl: source,
+      allowFetch: false,
+    });
+    assert.equal(offlineReuse.reused, true);
+
+    const trackedFile = join(first.destination, "codex-rs", "core", "src", "lib.rs");
+    git(first.destination, "update-index", "--assume-unchanged", "codex-rs/core/src/lib.rs");
+    writeFileSync(trackedFile, "tampered bytes hidden from git status\n");
+    assert.equal(git(first.destination, "status", "--porcelain"), "");
+    assert.throws(
+      () => materializeCodexSource({ targetDir: target, revision, sourceUrl: source }),
+      /unsafe index visibility flags/,
+    );
+
+    const reviewTree = join(root, "review-trees", "129092");
+    mkdirSync(reviewTree, { recursive: true });
+    rmSync(first.destination, { force: true, recursive: true });
+    const actingReviewer = materializeRequestedReviewSource({
+      targetRepo: "openclaw/openclaw",
+      targetDir: reviewTree,
+      additionalPrompt: `Inspect openai/codex at exact commit ${revision}.`,
+      sourceUrl: source,
+    });
+    assert.equal(actingReviewer?.destination, join(root, "review-trees", "codex"));
+    assert.equal(git(actingReviewer?.destination ?? "", "rev-parse", "HEAD").trim(), revision);
+
+    rmSync(actingReviewer?.destination ?? "", { force: true, recursive: true });
+    assert.throws(
+      () =>
+        materializeRequestedReviewSource({
+          targetRepo: "openclaw/openclaw",
+          targetDir: reviewTree,
+          additionalPrompt: `Inspect openai/codex at exact commit ${revision}.`,
+          sourceUrl: source,
+          allowFetch: false,
+        }),
+      /Offline review requires a pre-provisioned exact Codex sibling checkout/,
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("the common review runtime materializes requested source in the acting checkout", () => {
+  const source = readFileSync("src/clawsweeper-review-command-workflow.ts", "utf8");
+  const materialize = source.indexOf("materializeRequestedReviewSource({");
+  const runCodex = source.indexOf("decision = runCodex({", materialize);
+  assert.ok(materialize > 0, "runtime materializer call");
+  assert.ok(runCodex > materialize, "materializer precedes Codex in the common review runtime");
+  assert.match(source.slice(materialize, runCodex), /allowFetch: !localRange/);
+});
+
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}


### PR DESCRIPTION
## Summary

- materialize `openai/codex` as a clean sibling checkout when an OpenClaw maintainer exact-review request pins one exact commit
- recognize only the closed request grammar: a local `openai/codex` exact-commit directive, `openai/codex@SHA`, or a canonical GitHub commit/tree/blob URL
- fail closed on malformed or multiple explicit pins while preserving offline local-range safety

## Behavior proof

- Claim: the acting ClawSweeper review worker receives a clean sibling Codex checkout at the exact requested 40-character commit before Codex starts.
- Exercised surface: common review-command workflow and source materializer.
- Scenario: the exact maintainer request for `openai/codex` commit `f1087ff151b06e781ecb086068d45fcc62d02da3`, plus local fixture repositories covering first materialization, exact reuse, hidden-index rejection, and offline missing-checkout rejection.
- Observable result: the sibling checkout resolves to the requested detached commit, is clean, contains root `AGENTS.md`, and is present before `runCodex`; malformed/multiple pins throw.
- Commands:
  - `pnpm run build:all`
  - `node --test test/review-source-checkout.test.ts test/review-command-workflow.test.ts test/review-reliability-workflow.test.ts`
  - `pnpm exec oxlint src/review-source-checkout.ts test/review-source-checkout.test.ts --tsconfig tsconfig.json --type-aware --deny-warnings --report-unused-disable-directives -D correctness -D preserve-caught-error`
  - `pnpm exec oxfmt --check src/review-source-checkout.ts test/review-source-checkout.test.ts`
  - `git diff --check`
- Result: build and all 11 focused tests passed; lint, formatting, and diff checks passed.
- Review: fresh `codex --yolo review --uncommitted` was argv-verified and completed clean after its two accepted Markdown/URL-terminator findings were repaired.
- Limits: the proof uses a local Git source fixture for deterministic clone/reuse safety; an earlier direct materialization check also resolved the requested public Codex commit. The unrelated full unit suite invoked during review was interrupted in long-running pre-existing apply tests and is not claimed as green.

### Redacted real-worker Crabbox trace

- Exact PR head under proof: `c34e0ffd2ff7b338ef24ab6ec8a4d7ca11e025da` (tree `4c87f9f168f07a41f1fcf5ec26896a64476c9081`).
- Provider: Crabbox `local-container` 0.46.0, image `debian:bookworm`, Docker context `colima-mainframe`.
- Lease/run: `cbx_13ef389a155b` / `run_7019d82313ea` (stopped).
- Exact production command:
  ```text
  pnpm run review -- --local-only --target-repo openclaw/openclaw --target-dir /work/crabbox/cbx_13ef389a155b/fresh-pr-openclaw-clawsweeper-1248/.crabbox/pr1248-real-worker-proof/target --item-number 129092 --artifact-dir /work/crabbox/cbx_13ef389a155b/fresh-pr-openclaw-clawsweeper-1248/.crabbox/pr1248-real-worker-proof/review-artifacts --additional-prompt Personally\ inspect\ openai/codex\ at\ exact\ commit\ f1087ff151b06e781ecb086068d45fcc62d02da3\ before\ returning\ this\ fixed\ public\ review\ verdict. --codex-timeout-ms 120000 --batch-size 1 --max-pages 1
  ```
- Ordered trace: the sibling was absent before review; the real review worktree was created; Codex started in `review-artifacts/review-trees/129092`; Codex then read its sibling `review-artifacts/review-trees/codex` at exact HEAD `f1087ff151b06e781ecb086068d45fcc62d02da3`, tree `85183d6c932b8eba2ac3d77018bfda7c918d4206`, clean; the review completed in 8 seconds with `decision=keep_open`, `confidence=high`, `action=kept_open`.
- Codex read proof includes root `AGENTS.md` and `codex-rs/core/src/tasks/mod.rs` lines 279–288 from the pinned checkout. Secret-environment-name scan was empty.
- Transparent validator note: the production review succeeded, then the external proof script exited 1 because its post-validator checked the stale root `.crabbox/pr1248-real-worker-proof/codex/.git`. Production correctly places the sibling beside the per-item review worktree at `review-artifacts/review-trees/codex`. The wrong-root assertion fired after `review-exit-zero` and `codex-read-present`; it did not invalidate the production materialization, Codex read, or review result. It did prevent copying the ephemeral prompt/report/output files, so those contents are not claimed as retained.
- Redacted retained artifact SHA-256:
  - proof script: `a7edd0a13f8cb62c978255af58950ab12a622ad931eb97bbd3bc4f1b78d28d6b`
  - failure bundle: `e2ee311f201cd11b888dc03ac93913175d63d24103398518bd6b4eeb52856447`
  - recovered result: `2a8c16a4c4bbc0b5115e1f7db609c2b7ef6503761d93720051ab617046119d83`
  - timeline: `3fe6a25b827516e822a0ae49eec07e5a089d56057086222993b2681c2583a5ba`
  - Codex read: `9211cbc42815c17ab84cfbcc8429d46c8c4eb30154d87924d6ccbbf98705a3ca`
  - review stderr/result trace: `f6f1f5cc98e06de584a9f35c775a5cb3a8e4b098daa2462bad78c098fd57ae50`
  - exact worker command: `7f1e666985044fd17646e91ba78ec4e8e09fcdb2001159379021bb2cd0de6514`
  - runtime-file ledger: `e83ad0f243d51b621b3750513bf564b31a325956bb8745c0c9e199eca6c0ba6a`

## Scope

OpenClaw Bay is unaffected: this changes only the private review-worker checkout preparation path and exposes no public status or control surface.

No merge or automerge is requested.
