### PR TITLE
fix(publication): stop retrying verified stale review artifacts

### DIFF
--- a/src/repair/event-apply-proof.ts
+++ b/src/repair/event-apply-proof.ts
@@ -32,6 +32,8 @@ const GUARDED_OPEN_ACTIONS = new Set([
 ]);
 
 const LEGACY_TUPLELESS_REVIEW_LEASE_REASON = "local report has no durable lease identity";
+const NEWER_DURABLE_REVIEW_TUPLE_REASON =
+  /^live durable review tuple is newer than the local report: comment lease=([1-9][0-9]*), report lease=([1-9][0-9]*)$/;
 // The durable queue rejects retry deadlines beyond two hours. Leave a small
 // margin for worker/queue clock skew; a still-active long lease is sampled
 // again at this bounded deadline instead of rejecting the completion.
@@ -91,6 +93,7 @@ export function exactEventRoutingDeferred({
 
 export type ExactEventApplyDisposition =
   | "applied"
+  | "superseded"
   | "terminal_policy_noop"
   | "source_drift"
   | "close_coverage_deferred"
@@ -138,6 +141,9 @@ export function exactEventApplyProof(
     (entry) => entry.action === "skipped_changed_since_review",
   );
   const hasSourceDrift = sourceDriftActions.length > 0;
+  const hasStaleReviewTuple = exactActions.some(
+    (entry) => entry.action === "skipped_stale_review_comment_sync",
+  );
   const sourceDrift =
     hasSourceDrift &&
     sourceDriftActions.every((entry) => entry.sourceDriftVerified) &&
@@ -160,6 +166,10 @@ export function exactEventApplyProof(
     soleExactAction === "kept_open" && soleExactResult?.activeReviewLeaseVerified === true
       ? normalizedReviewLeaseRetryAt(soleExactResult.activeReviewLeaseExpiresAt)
       : null;
+  const supersededByNewerDurableReviewTuple =
+    soleExactAction === "skipped_stale_review_comment_sync" &&
+    soleExactResult !== null &&
+    hasStrictlyNewerDurableReviewTuple(soleExactResult.reason);
   return {
     exactActions,
     syncedCount,
@@ -182,14 +192,30 @@ export function exactEventApplyProof(
       ? sourceDrift
         ? "source_drift"
         : "unproven"
-      : closeCoverageDeferred
-        ? "close_coverage_deferred"
-        : terminalPolicyNoop
-          ? "terminal_policy_noop"
-          : syncedCount + terminalCount > 0
-            ? "applied"
-            : "unproven",
+      : hasStaleReviewTuple
+        ? supersededByNewerDurableReviewTuple
+          ? "superseded"
+          : "unproven"
+        : closeCoverageDeferred
+          ? "close_coverage_deferred"
+          : terminalPolicyNoop
+            ? "terminal_policy_noop"
+            : syncedCount + terminalCount > 0
+              ? "applied"
+              : "unproven",
   };
+}
+
+function hasStrictlyNewerDurableReviewTuple(reason: string): boolean {
+  const match = NEWER_DURABLE_REVIEW_TUPLE_REASON.exec(reason);
+  if (!match) return false;
+  const liveLeaseCommentId = Number(match[1]);
+  const reportLeaseCommentId = Number(match[2]);
+  return (
+    Number.isSafeInteger(liveLeaseCommentId) &&
+    Number.isSafeInteger(reportLeaseCommentId) &&
+    liveLeaseCommentId > reportLeaseCommentId
+  );
 }
 
 function normalizedReviewLeaseRetryAt(value: string): string | null {

--- a/src/repair/publish-event-result.ts
+++ b/src/repair/publish-event-result.ts
@@ -229,6 +229,15 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     exactEventPublication: options.exactEventPublication,
     legacyTuplelessReviewLease,
   });
+  const summary = () =>
+    writeSummary({
+      targetRepo: options.targetRepo,
+      itemNumber: options.itemNumber,
+      syncedCount,
+      closedCount,
+      missingCount,
+      closeReasons: options.closeReasons,
+    });
   const rateLimitYield = exactActions.find(
     (action) =>
       action.action === "skipped_runtime_budget" &&
@@ -241,6 +250,17 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     console.log(
       `Requeueing ${options.targetRepo}#${options.itemNumber}: legacy exact artifact lacks its durable review lease tuple`,
     );
+  }
+  if (applyDisposition === "superseded") {
+    console.log(
+      `Completing ${options.targetRepo}#${options.itemNumber} as superseded: a newer durable review tuple is already live`,
+    );
+    if (options.batchMutationOutput) {
+      writeBatchMutationResult(options.batchMutationOutput, { kind: "superseded" });
+    }
+    writePublicationCompletionOutputs("superseded", "remote_newer_tuple");
+    summary();
+    return;
   }
   const deferredCloseCoverageExpected = applyDisposition === "close_coverage_deferred";
   if (activeReviewLeaseRetryAt !== null) {
@@ -266,10 +286,11 @@ async function publishEventResult(options: EventOptions): Promise<void> {
     }
   }
   if (
-    syncedCount + closedCount + missingCount === 0 &&
-    guardedOpenAction === null &&
-    !requeueLatestExpected &&
-    !deferredCloseCoverageExpected
+    (applyDisposition === "unproven" && guardedOpenAction === null && !requeueLatestExpected) ||
+    (syncedCount + closedCount + missingCount === 0 &&
+      guardedOpenAction === null &&
+      !requeueLatestExpected &&
+      !deferredCloseCoverageExpected)
   ) {
     const observed =
       exactActions
@@ -280,15 +301,6 @@ async function publishEventResult(options: EventOptions): Promise<void> {
       `Event review for ${options.targetRepo}#${options.itemNumber} was not applied; actions: ${observed}`,
     );
   }
-  const summary = () =>
-    writeSummary({
-      targetRepo: options.targetRepo,
-      itemNumber: options.itemNumber,
-      syncedCount,
-      closedCount,
-      missingCount,
-      closeReasons: options.closeReasons,
-    });
   const routableSyncExpected =
     syncedCount > 0 &&
     closedCount === 0 &&

--- a/test/repair/event-apply-proof.test.ts
+++ b/test/repair/event-apply-proof.test.ts
@@ -385,6 +385,7 @@ test("exact event proof completes live-shaped deterministic guarded-open results
     );
 
     assert.equal(proof.guardedOpenAction, action);
+    assert.equal(proof.disposition, "unproven");
     assert.equal(proof.latestRevisionRequeueRequired, false);
   }
 });
@@ -402,7 +403,7 @@ test("exact event proof keeps changed-since-review on the latest-revision requeu
   assert.equal(proof.latestRevisionRequeueRequired, true);
 });
 
-test("exact event proof requeues only the guarded legacy tuple-less artifact path", () => {
+test("exact event proof supersedes only a verified strictly newer durable tuple", () => {
   const legacy = exactEventApplyProof(
     [
       eventApplyAction({
@@ -419,7 +420,8 @@ test("exact event proof requeues only the guarded legacy tuple-less artifact pat
       eventApplyAction({
         number: 42,
         action: "skipped_stale_review_comment_sync",
-        reason: "live durable review comment is newer than the local report",
+        reason:
+          "live durable review tuple is newer than the local report: comment lease=9200, report lease=9100",
       }),
     ],
     42,
@@ -427,6 +429,7 @@ test("exact event proof requeues only the guarded legacy tuple-less artifact pat
 
   assert.equal(legacy.legacyTuplelessReviewLease, true);
   assert.equal(newerVerdict.legacyTuplelessReviewLease, false);
+  assert.equal(newerVerdict.disposition, "superseded");
   assert.equal(
     eventApplyRequeueLatestExpected({
       disposition: legacy.disposition,
@@ -443,6 +446,47 @@ test("exact event proof requeues only the guarded legacy tuple-less artifact pat
     }),
     false,
   );
+});
+
+test("exact event proof fails closed for ambiguous newer-tuple claims", () => {
+  const reasons = [
+    "live durable review tuple is newer than the local report: comment lease=9100, report lease=9100",
+    "live durable review tuple is newer than the local report: comment lease=9000, report lease=9100",
+    "live durable review tuple is newer than the local report: comment lease=invalid, report lease=9100",
+    "live durable review tuple is newer than the local report: comment lease=9007199254740992, report lease=9100",
+    "live durable review comment is newer than the local report",
+  ];
+  for (const reason of reasons) {
+    const proof = exactEventApplyProof(
+      [
+        eventApplyAction({
+          number: 42,
+          action: "skipped_stale_review_comment_sync",
+          reason,
+        }),
+      ],
+      42,
+    );
+    assert.equal(proof.disposition, "unproven", reason);
+  }
+
+  const mixed = exactEventApplyProof(
+    [
+      eventApplyAction({
+        number: 42,
+        action: "skipped_stale_review_comment_sync",
+        reason:
+          "live durable review tuple is newer than the local report: comment lease=9200, report lease=9100",
+      }),
+      eventApplyAction({
+        number: 42,
+        action: "review_comment_synced",
+        durableReviewSynced: true,
+      }),
+    ],
+    42,
+  );
+  assert.equal(mixed.disposition, "unproven");
 });
 
 test("guarded-open proof rejects mismatches, extra results, and transient skips", () => {

--- a/test/repair/stale-event-disposition.test.ts
+++ b/test/repair/stale-event-disposition.test.ts
@@ -56,3 +56,26 @@ test("publish-event-result exits terminally on a stale preflight instead of thro
   );
   assert.ok(!preflightBlock.includes("throw new Error"));
 });
+
+test("publish-event-result terminalizes a verified newer live durable tuple", () => {
+  const source = readFileSync("src/repair/publish-event-result.ts", "utf8");
+  const start = source.indexOf('if (applyDisposition === "superseded")');
+  const end = source.indexOf(
+    'const deferredCloseCoverageExpected = applyDisposition === "close_coverage_deferred"',
+    start,
+  );
+  assert.ok(start >= 0 && end > start);
+  const block = source.slice(start, end);
+  assert.match(
+    block,
+    /writeBatchMutationResult\(options\.batchMutationOutput, \{\s*kind: "superseded"/,
+  );
+  assert.match(block, /writePublicationCompletionOutputs\("superseded", "remote_newer_tuple"\)/);
+  assert.match(block, /summary\(\)/);
+  assert.match(block, /return/);
+  assert.doesNotMatch(block, /publishSnapshot|prepareBatchMutation|runApplyDecisions/);
+  assert.match(
+    source,
+    /applyDisposition === "unproven" &&\s*guardedOpenAction === null &&\s*!requeueLatestExpected/,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the publication worker would retry an obsolete exact-review artifact after apply-time verification found that a strictly newer durable review tuple was already live.

## Why This Change Was Made

The publisher now terminalizes only one exact `skipped_stale_review_comment_sync` result whose canonical reason contains safe positive durable lease comment IDs with `live > report`. Legacy tupleless artifacts still requeue the latest revision. Equal, reversed, malformed, mixed, or otherwise unverified results fail closed.

The terminal path exits before mutation planning or publication, emits batch kind `superseded`, and reports `completion_kind=superseded` with `reason_code=remote_newer_tuple`.

## User Impact

Operators no longer spend publication retries on a review artifact that has been proven obsolete by a newer durable review. The newer live review remains authoritative, and no replacement review or GitHub mutation is started.

## OpenClaw Bay Impact

Bay is unaffected. This change uses the existing `superseded` terminal lifecycle and reason code; it does not add or change a Bay data contract, navigation surface, or action.

## Documentation Impact

No documentation change is required. The public workflow and operator contract are unchanged, and `CHANGELOG.md` is release-owned for normal repair work.

## Evidence

- Signed head: `25565772df3c5dd6a414ed5132cff5a4bc6580da`
- Focused proof: 21/21 `event-apply-proof` and `stale-event-disposition` tests passed.
- Affected review set: 194/194 build, workflow, apply, batch, and repair tests passed.
- Static proof: main, repair, and dashboard TypeScript builds; scoped oxlint; scoped oxfmt; `git diff --check`; privacy scan.
- Containment retry: 31 relevant assertions passed serially with 4 platform skips after the broad repair target at concurrency 8 hit a subprocess timeout under host contention.
- Codex review: the dirty-tree review found and fixed a guarded-open regression; the committed-range review found no remaining issue.
- Production delta: `+58/-20`, net `+38`. The growth implements a fail-closed lifecycle invariant: strict durable tuple proof plus terminal completion before mutation planning. Tests are `+69/-2`.

## Real Behavior Proof

**Claim:** A verified strictly newer live durable tuple completes the stale artifact as superseded without GitHub mutation or a new review, while legacy tupleless, ambiguous/mixed, and guarded-open paths retain their existing behavior.

**Exercised surface:** The built `dist/repair/publish-event-result.js` runtime, including apply-artifact/apply-decision result ingestion and batch outcome/output emission.

**Scenario and environment:** Node 26.7.0, isolated temporary record store, owned fake apply CLI, exact event publication enabled, batch mutation output enabled, no GitHub credentials or API calls.

**Command:** A bounded `node --input-type=module` harness spawned the built publisher for four fixtures.

**Observed result:**

```json
{
  "status": "passed",
  "superseded": {
    "exit": 0,
    "batch_kind": "superseded",
    "completion_kind": "superseded",
    "reason_code": "remote_newer_tuple",
    "apply_phases": ["apply-artifacts", "apply-decisions"]
  },
  "legacy": {
    "exit": 0,
    "batch_kind": "eligible",
    "requeue_latest": true
  },
  "mixed": {
    "exit": 1,
    "batch_kind": "permanent_failure",
    "reason_code": "unknown_failure"
  },
  "guarded": {
    "exit": 0,
    "batch_kind": "eligible",
    "guarded_open_action": "skipped_protected_label"
  },
  "github_mutations": 0,
  "new_reviews": 0
}
```

**Artifact or trace:** The harness asserted the emitted batch JSON, GitHub output file, process exit status, and invoked apply phases, then removed its owned temporary fixtures.

**Limits:** This proves the built publisher and completion contract locally. It does not deploy the worker, mutate a live queue, or exercise live GitHub publication; exact-head hosted CI and ClawSweeper review cover the submitted branch.
