### PR TITLE
fix(apply): bound report retention and ledger finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ checkpoint, and status-only commits are intentionally omitted.
 
 ### Fixed
 
+- Bounded apply/proof/comment-sync record retention to selected records and paired dependencies, avoiding unrelated archive loads during ledger finalization without changing close guards.
+- Kept projected GitHub reads out of the durable ETag cache so incompatible response shapes cannot hide requested reviewers from close guards. Thanks @goutamadwant! (#1242)
+- Normalized unexpected exact-review failures at the Worker boundary without weakening Durable Object transaction rollback. Thanks @yetval and @vincentkoc! (#1240)
 - Terminal live verification preserves successful commands when a marker is not observed, reports that distinction truthfully, and still rejects real command failures and timeouts.
 - Replaced public Worker exception text with endpoint-owned error codes and bounded direct-publication rejection categories, preserving distinct operational fingerprints without exposing submitted values or stack traces.
 - Replaced terminal live proof's authenticated `xvfb-run` wrapper with a TCP-disabled local Xvfb display so readiness probes and recording can connect without X authorization failures.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -691,6 +691,16 @@ position. Coverage proof, live-state refresh, freshness checks, and close gates
 remain unchanged. Explicit targeted apply runs keep their requested item set and
 ordering policy.
 
+Apply keeps selected report bodies in memory and loads independently reviewed
+paired records only when a close guard requests them. Exact-event publication
+does not expand its selected set. Broad apply still sorts the complete open
+candidate set; it no longer loads a second copy for paired lookups. Finalization
+reloads only requested, result, and unfinished/in-flight item records from the
+open and closed directories, rather than retaining the archive. This includes
+partial failures and runtime-budget yields and does not change cursor ordering,
+close eligibility, canonical baselines, or ledger identities. OpenClaw Bay needs
+no change: the public status, record, and ledger contracts are unchanged.
+
 Before a close-mode apply run starts, the workflow summarizes the selected close
 candidate mix by quality bucket in the status detail. Buckets such as
 implemented-on-main, duplicate/superseded, needs PR close proof,

--- a/scripts/e2e/apply-memory-gh.cjs
+++ b/scripts/e2e/apply-memory-gh.cjs
@@ -1,0 +1,110 @@
+// Secretless, fail-closed transport: all writes are local fixture state.
+const fs = require("node:fs");
+const path = require("node:path");
+const root = process.env.APPLY_MEMORY_CASE;
+const raw = process.argv.slice(2);
+const args = raw[0] === "--repo" ? raw.slice(2) : raw;
+const endpoint = args.includes("-i") ? args[args.indexOf("-i") + 1] : args[1] || "";
+const method = args.includes("--method") ? args[args.indexOf("--method") + 1] : "GET";
+fs.appendFileSync(path.join(root, "requests.jsonl"), `${JSON.stringify({ args, method })}\n`);
+const match = endpoint.match(/\/issues\/(\d+)(?:\/|$)/);
+const number = Number(match?.[1]);
+const commentPath = path.join(root, `comment-${number}.json`);
+const output = (value) => {
+  if (args.includes("-i")) process.stdout.write("HTTP/2 200\n\n");
+  console.log(JSON.stringify(value));
+};
+if (number === 102 && process.env.APPLY_MEMORY_INTERRUPT) {
+  if (process.env.APPLY_MEMORY_INTERRUPT === "budget") {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);
+  }
+  console.error("fixture interrupted second item (HTTP 422)");
+  process.exit(1);
+}
+if (args[0] === "api" && /\/issues\/\d+\/comments(?:\?|$)/.test(endpoint)) {
+  if (method === "POST") {
+    const payload = JSON.parse(fs.readFileSync(args[args.indexOf("--input") + 1], "utf8"));
+    const comment = {
+      id: 9000 + number,
+      html_url: `https://github.com/openclaw/openclaw/issues/${number}#issuecomment-${9000 + number}`,
+      created_at: "2026-08-02T00:00:00Z",
+      updated_at: "2026-08-02T00:00:00Z",
+      user: { login: "clawsweeper[bot]" },
+      body: payload.body,
+    };
+    fs.writeFileSync(commentPath, JSON.stringify(comment));
+    output(comment);
+  } else if (method === "GET") {
+    output([fs.existsSync(commentPath) ? [JSON.parse(fs.readFileSync(commentPath, "utf8"))] : []]);
+  } else throw new Error(`unexpected comment mutation: ${method}`);
+} else if (args[0] === "api" && /\/issues\/\d+\/timeline(?:\?|$)/.test(endpoint)) {
+  output([[]]);
+} else if (args[0] === "api" && /\/issues\/\d+$/.test(endpoint) && method === "GET") {
+  const isPull = process.env.APPLY_MEMORY_KIND === "pull_request";
+  output({
+    number,
+    title: "Memory proof",
+    body: "",
+    html_url: `https://github.com/openclaw/openclaw/${isPull ? "pull" : "issues"}/${number}`,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at:
+      process.env.APPLY_MEMORY_DRIFT && number >= 121
+        ? "2026-05-02T00:00:00Z"
+        : "2026-05-01T00:00:00Z",
+    closed_at: null,
+    state: "open",
+    locked: false,
+    active_lock_reason: null,
+    author_association: "CONTRIBUTOR",
+    user: { login: "reporter" },
+    labels: isPull
+      ? ["security"]
+      : ["security", "issue-rating: 🦀 challenger crab", "clawsweeper:current-main-repro"],
+    comments: fs.existsSync(commentPath) ? 1 : 0,
+    pull_request: isPull
+      ? { url: `https://api.github.com/repos/openclaw/openclaw/pulls/${number}` }
+      : null,
+  });
+} else if (args[0] === "api" && /\/pulls\/\d+$/.test(endpoint) && method === "GET") {
+  output({ head: { sha: "a".repeat(40) }, base: { ref: "main" }, merged: false, state: "open" });
+} else if (
+  args[0] === "api" &&
+  /\/pulls\/\d+\/(files|commits|comments|reviews)(?:\?|$)/.test(endpoint) &&
+  method === "GET"
+) {
+  output([[]]);
+} else if (
+  args[0] === "api" &&
+  endpoint === "graphql" &&
+  args.some((arg) => arg.includes("reviewThreads"))
+) {
+  output({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+        },
+      },
+    },
+  });
+} else if (args[0] === "issue" && args[1] === "view") {
+  output({ closedByPullRequestsReferences: [] });
+} else if (
+  args[0] === "api" &&
+  /\/commits\/[a-f0-9]+\/check-runs\?/.test(endpoint) &&
+  method === "GET"
+) {
+  output({ total_count: 0, check_runs: [] });
+} else if (
+  args[0] === "api" &&
+  /\/commits\/[a-f0-9]+\/status(?:\?|$)/.test(endpoint) &&
+  method === "GET"
+) {
+  output({ total_count: 0, statuses: [] });
+} else if (args[0] === "api" && endpoint.startsWith("search/issues?") && method === "GET") {
+  output({ items: [] });
+} else if (args[0] === "label" || (args[0] === "issue" && args[1] === "edit")) {
+  output({});
+} else {
+  throw new Error(`unexpected fixture request: ${JSON.stringify(args)}`);
+}

--- a/scripts/e2e/apply-memory-observer.cjs
+++ b/scripts/e2e/apply-memory-observer.cjs
@@ -1,0 +1,66 @@
+// Observe the built CLI without changing record contents or its memory limit.
+const fs = require("node:fs");
+const net = require("node:net");
+const childProcess = require("node:child_process");
+const { syncBuiltinESMExports } = require("node:module");
+
+net.Socket.prototype.connect = () => {
+  throw new Error("apply memory proof forbids network access");
+};
+globalThis.fetch = () => {
+  throw new Error("apply memory proof forbids fetch");
+};
+
+if (process.argv[1]?.endsWith("/dist/clawsweeper.js")) {
+  for (const method of ["spawn", "spawnSync", "execFile", "execFileSync"]) {
+    const original = childProcess[method];
+    childProcess[method] = (command, args, ...rest) => {
+      // The ledger uses these local process-identity probes on macOS.
+      const ledgerProbe = ["/usr/bin/python3", "/usr/sbin/sysctl", "/bin/ps"].includes(command);
+      if (
+        !ledgerProbe &&
+        (command !== process.execPath || args[0] !== process.env.APPLY_MEMORY_TRANSPORT)
+      ) {
+        throw new Error(`apply memory proof forbids subprocess: ${command}`);
+      }
+      return original(command, args, ...rest);
+    };
+  }
+  const originalRead = fs.readFileSync;
+  const counts = { items: 0, closed: 0, bytes: 0 };
+  const firstStacks = {};
+  let peakHeapUsed = 0;
+  let peakRss = 0;
+  const save = () => {
+    const memory = process.memoryUsage();
+    peakHeapUsed = Math.max(peakHeapUsed, memory.heapUsed);
+    peakRss = Math.max(peakRss, memory.rss);
+    fs.writeFileSync(
+      process.env.APPLY_MEMORY_METRICS,
+      JSON.stringify({
+        counts,
+        peakHeapUsed,
+        peakRss,
+        maxRSSKiB: process.resourceUsage().maxRSS,
+        firstStacks,
+      }),
+    );
+  };
+  fs.readFileSync = (file, ...args) => {
+    const value = originalRead(file, ...args);
+    const path = String(file);
+    const match = path.startsWith(process.env.APPLY_MEMORY_RECORDS)
+      ? path.match(/\/(items|closed)\/\d+\.md$/)
+      : null;
+    if (match) {
+      counts[match[1]] += 1;
+      counts.bytes += Buffer.byteLength(value);
+      firstStacks[match[1]] ??= new Error(`first ${match[1]} read`).stack;
+      if ((counts.items + counts.closed) % 10 === 0) save();
+    }
+    return value;
+  };
+  process.on("exit", save);
+  save();
+}
+syncBuiltinESMExports();

--- a/scripts/e2e/apply-memory.mjs
+++ b/scripts/e2e/apply-memory.mjs
@@ -1,0 +1,401 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { implementedCloseReport } from "../../test/helpers.ts";
+
+// node scripts/e2e/apply-memory.mjs OUTPUT BUILD_ROOT LABEL [SCENARIO] [--expect-baseline-oom]
+// BUILD_ROOT contains dist, config, schema, prompts, package.json and node_modules.
+// Output must be disposable: it contains generated corpus and isolated runtime copies.
+function main() {
+  const args = process.argv.slice(2);
+  const expectBaselineOom = args.at(-1) === "--expect-baseline-oom";
+  if (expectBaselineOom) args.pop();
+  const [outputArg, buildArg, label, onlyScenario] = args;
+  if (!outputArg || !buildArg || !/^[a-z0-9-]+$/.test(label ?? "")) {
+    throw new Error(
+      "usage: apply-memory.mjs OUTPUT BUILD_ROOT LABEL [SCENARIO] [--expect-baseline-oom]",
+    );
+  }
+  assert.ok(args.length <= 4, "too many arguments");
+  const scenarios = ["proof", "comment-sync", "partial", "budget", "exact", "empty", "broad"];
+  if (onlyScenario) assert.ok(scenarios.includes(onlyScenario));
+  if (expectBaselineOom)
+    assert.ok(onlyScenario, "expected baseline OOM requires one explicit scenario");
+  mkdirSync(resolve(outputArg), { recursive: true });
+  // The CLI entry-point check compares argv with import.meta.url; resolve macOS /tmp.
+  const output = realpathSync(resolve(outputArg));
+  const build = resolve(buildArg);
+  const transport = fileURLToPath(new URL("./apply-memory-gh.cjs", import.meta.url));
+  const observer = fileURLToPath(new URL("./apply-memory-observer.cjs", import.meta.url));
+  const corpus = join(output, "corpus");
+  ensureMemoryCorpus(corpus);
+
+  const summary = [];
+  for (const scenario of onlyScenario ? [onlyScenario] : scenarios) {
+    const root = join(output, `${label}-${scenario}`);
+    assert.ok(!existsSync(root), `refusing to overwrite proof case ${root}`);
+    const runtime = join(root, "runtime");
+    mkdirSync(runtime, { recursive: true });
+    for (const name of ["dist", "config", "schema", "prompts", "package.json"]) {
+      cpSync(join(build, name), join(runtime, name), { recursive: true });
+    }
+    symlinkSync(join(build, "node_modules"), join(runtime, "node_modules"), "dir");
+    const records = join(root, "records");
+    const itemsDir = join(records, "items");
+    const closedDir = join(records, "closed");
+    mkdirSync(itemsDir, { recursive: true });
+    symlinkSync(join(corpus, "closed"), closedDir, "dir");
+    if (scenario !== "broad") {
+      for (const name of readdirSync(join(corpus, "items"))) {
+        symlinkSync(join(corpus, "items", name), join(itemsDir, name));
+      }
+    }
+    const count = ["comment-sync", "broad", "partial", "budget"].includes(scenario)
+      ? 40
+      : scenario === "empty"
+        ? 0
+        : 2;
+    const numbers = Array.from({ length: count }, (_, index) => 101 + index);
+    for (const number of numbers) {
+      writeFileSync(
+        join(itemsDir, `${number}.md`),
+        implementedCloseReport({
+          repository: "openclaw/openclaw",
+          number,
+          title: "Memory proof",
+          type: scenario === "proof" ? "pull_request" : "issue",
+          reviewed_at: "2026-05-01T03:00:00Z",
+          action_taken: "skipped_protected_label",
+          labels: JSON.stringify(
+            scenario === "proof"
+              ? ["security"]
+              : ["security", "issue-rating: 🦀 challenger crab", "clawsweeper:current-main-repro"],
+          ),
+          author_association: "CONTRIBUTOR",
+        }),
+      );
+    }
+    const reportPath = join(root, "apply-report.json");
+    const cursorPath = join(root, "cursor.json");
+    const metricsPath = join(root, "memory.json");
+    mkdirSync(join(root, "ledger"));
+    const args = [
+      "--max-old-space-size=256",
+      "--require",
+      observer,
+      join(runtime, "dist/clawsweeper.js"),
+      "apply-decisions",
+      "--target-repo",
+      "openclaw/openclaw",
+      "--skip-dashboard",
+      "--apply-kind",
+      "all",
+      "--record-root",
+      runtime,
+      "--items-dir",
+      itemsDir,
+      "--closed-dir",
+      closedDir,
+      "--plans-dir",
+      join(records, "plans"),
+      "--report-path",
+      reportPath,
+      "--artifact-dir",
+      join(root, "artifacts"),
+      "--cursor-trace",
+      cursorPath,
+      "--canonical-record-baseline-dir",
+      join(root, "baselines"),
+      "--close-delay-ms",
+      "0",
+      "--processed-limit",
+      "40",
+      "--progress-every",
+      "1",
+      ...(scenario === "broad"
+        ? []
+        : ["--item-numbers", numbers.length ? numbers.join(",") : "99"]),
+      ...(scenario === "proof"
+        ? ["--dry-run", "--limit", "2", "--event-apply-proof"]
+        : ["--sync-comments-only", "--limit", "0"]),
+      ...(scenario === "exact" ? ["--exact-event-publication"] : []),
+      ...(scenario === "budget" ? ["--max-runtime-ms", "3000"] : []),
+    ];
+    // Deliberately do not inherit credentials, provider configuration, hooks, or PATH shims.
+    const env = {
+      PATH: "/usr/bin:/bin",
+      TMPDIR: root,
+      GH_BIN: process.execPath,
+      GH_BIN_ARGS: JSON.stringify([transport]),
+      APPLY_MEMORY_CASE: root,
+      APPLY_MEMORY_RECORDS: records,
+      APPLY_MEMORY_METRICS: metricsPath,
+      APPLY_MEMORY_TRANSPORT: transport,
+      ...(["comment-sync", "broad"].includes(scenario) ? { APPLY_MEMORY_DRIFT: "1" } : {}),
+      APPLY_MEMORY_KIND: scenario === "proof" ? "pull_request" : "issue",
+      ...(scenario === "partial" || scenario === "budget"
+        ? { APPLY_MEMORY_INTERRUPT: scenario }
+        : {}),
+      CLAWSWEEPER_ACTION_LEDGER_FORCE: "1",
+      CLAWSWEEPER_ACTION_LEDGER_OUTPUT_ROOT: join(root, "ledger"),
+      CLAWSWEEPER_ACTION_LEDGER_PARTITION_DATE: "2026-08-27",
+      GITHUB_REPOSITORY: "openclaw/clawsweeper",
+      GITHUB_SHA: "afe976209aa58a5629041b42b66f6ee11b2812a7",
+      GITHUB_WORKFLOW: "apply-memory-proof",
+      GITHUB_JOB: scenario,
+      GITHUB_RUN_ID: "1",
+      GITHUB_RUN_ATTEMPT: "1",
+    };
+    writeFileSync(
+      join(root, "command.json"),
+      JSON.stringify({ node: process.execPath, version: process.version, args, env }, null, 2),
+    );
+    const started = Date.now();
+    const result = spawnSync(process.execPath, args, {
+      cwd: runtime,
+      env,
+      encoding: "utf8",
+      timeout: 120000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    writeFileSync(join(root, "stdout.log"), result.stdout ?? "");
+    writeFileSync(join(root, "stderr.log"), result.stderr ?? "");
+    const report = existsSync(reportPath) ? JSON.parse(readFileSync(reportPath)) : null;
+    const cursor = existsSync(cursorPath) ? JSON.parse(readFileSync(cursorPath)) : null;
+    const memory = JSON.parse(readFileSync(metricsPath));
+    const events = [];
+    const readEvents = (dir) => {
+      if (!existsSync(dir)) return;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) readEvents(path);
+        else if (entry.name.endsWith(".jsonl"))
+          events.push(
+            ...readFileSync(path, "utf8")
+              .trim()
+              .split("\n")
+              .filter(Boolean)
+              .map((line) => JSON.parse(line)),
+          );
+      }
+    };
+    readEvents(join(root, "ledger"));
+    const row = {
+      provider: "local-process",
+      node: process.version,
+      platform: `${process.platform}/${process.arch}`,
+      heapLimitMiB: 256,
+      expectation: expectBaselineOom ? "baseline-oom" : "candidate-success",
+      buildSha256: Object.fromEntries(
+        [
+          "clawsweeper-apply-decision-workflow.js",
+          "clawsweeper-apply-records.js",
+          "clawsweeper-apply-close-guards.js",
+        ].map((name) => [
+          name,
+          createHash("sha256")
+            .update(readFileSync(join(runtime, "dist", name)))
+            .digest("hex"),
+        ]),
+      ),
+      scenario,
+      exit: result.status,
+      signal: result.signal,
+      error: result.error?.message,
+      elapsedMs: Date.now() - started,
+      memory,
+      resultCount: report?.length ?? 0,
+      actions: report?.reduce(
+        (counts, item) => ({ ...counts, [item.action]: (counts[item.action] ?? 0) + 1 }),
+        {},
+      ),
+      cursor,
+      eventCount: events.length,
+      batchTerminal: events.find(
+        (event) => event.event_type === "apply.batch" && event.action.status !== "started",
+      ),
+      commentsWritten: readdirSync(root).filter((name) => /^comment-\d+\.json$/.test(name)).length,
+    };
+    try {
+      const baselineOom = assertMemoryProcessOutcome(result, {
+        expectBaselineOom,
+        expectedStatus: scenario === "partial" ? 1 : 0,
+      });
+      if (!baselineOom) {
+        assert.doesNotMatch(
+          result.stderr,
+          /unexpected fixture request|best-effort finalization failed/,
+        );
+        assert.ok(row.batchTerminal, "the real ledger must finalize, even with no candidates");
+        assert.ok(report && cursor, "the CLI must write its report and cursor");
+        assert.equal(memory.counts.closed, 0, "unrelated archived bodies must not be read");
+        const terminalItems = events.filter(
+          (event) =>
+            event.event_type === "apply.action" &&
+            event.action.status !== "started" &&
+            event.subject.number,
+        );
+        assert.ok(terminalItems.every((event) => numbers.includes(event.subject.number)));
+        if (["comment-sync", "broad"].includes(scenario)) {
+          assert.deepEqual(row.actions, {
+            review_comment_synced: 20,
+            skipped_changed_since_review: 20,
+          });
+          assert.equal(row.commentsWritten, 20);
+          assert.deepEqual(cursor.examined_item_numbers, numbers);
+          assert.equal(row.batchTerminal.action.mutation, true);
+        } else if (scenario === "proof") {
+          assert.deepEqual(row.actions, { skipped_protected_label: 2 });
+          assert.equal(row.commentsWritten, 0);
+        } else if (scenario === "partial") {
+          assert.equal(row.commentsWritten, 1);
+          assert.equal(row.batchTerminal.attributes.partial, true);
+          assert.equal(row.batchTerminal.action.mutation, true);
+          assert.ok(
+            terminalItems.some((event) => event.subject.number === 102 && event.action.retryable),
+          );
+          assert.ok(
+            !report.some((item) => item.number === 102),
+            "in-flight identity must survive without a result row",
+          );
+        } else if (scenario === "budget") {
+          assert.equal(row.batchTerminal.action.status, "yielded");
+          const interrupted = report.find(
+            (item) => item.number > 0 && item.action === "skipped_runtime_budget",
+          );
+          assert.ok(interrupted);
+          assert.ok(!cursor.examined_item_numbers.includes(interrupted.number));
+          assert.ok(
+            terminalItems.some(
+              (event) =>
+                event.subject.number === interrupted.number && event.action.status === "yielded",
+            ),
+          );
+        } else if (scenario === "empty") {
+          assert.deepEqual(report, []);
+          assert.equal(row.batchTerminal.action.status, "skipped");
+        } else if (scenario === "exact") {
+          assert.deepEqual(row.actions, { kept_open: 2 });
+          assert.ok(
+            report.every(
+              (item) =>
+                item.reason === "exact event review artifact lacks a durable reviewed revision",
+            ),
+          );
+        }
+      }
+      row.validation = { passed: true };
+    } catch (error) {
+      row.validation = { passed: false, error: String(error) };
+      throw error;
+    } finally {
+      writeFileSync(join(root, "result.json"), JSON.stringify(row, null, 2));
+      summary.push(row);
+      writeFileSync(
+        join(output, `${label}${onlyScenario ? `-${onlyScenario}` : ""}-summary.json`),
+        JSON.stringify(summary, null, 2),
+      );
+      console.log(
+        JSON.stringify({
+          scenario,
+          exit: row.exit,
+          signal: row.signal,
+          memory: memory.peakHeapUsed,
+          reads: memory.counts,
+          actions: row.actions,
+          comments: row.commentsWritten,
+          expectation: row.expectation,
+          validation: row.validation,
+        }),
+      );
+    }
+  }
+}
+
+export function assertMemoryProcessOutcome(
+  result,
+  { expectBaselineOom = false, expectedStatus = 0 } = {},
+) {
+  assert.equal(result.error, undefined, result.error?.message);
+  const oom = result.signal === "SIGABRT" && /heap out of memory/.test(result.stderr ?? "");
+  if (expectBaselineOom) {
+    assert.ok(oom, "baseline measurement must fail with the expected heap OOM");
+    assert.equal(result.status, null);
+    return true;
+  }
+  assert.equal(result.signal, null, `candidate process failed: ${result.signal}\n${result.stderr}`);
+  assert.equal(result.status, expectedStatus, result.stderr);
+  return false;
+}
+
+const corpusSpec = { open: 5500, archived: 12000, bytesPerRecord: 32768 };
+const retained = (number) => {
+  const header = `---\nrepository: openclaw/openclaw\nnumber: ${number}\ntype: issue\nreview_status: complete\ndecision: keep_open\naction_taken: kept_open\n---\n\n## Summary\n\n`;
+  return (
+    header +
+    "Retained review evidence and command output.\n"
+      .repeat(800)
+      .slice(0, corpusSpec.bytesPerRecord - header.length)
+  );
+};
+
+export function ensureMemoryCorpus(corpus) {
+  const manifest = {
+    ...corpusSpec,
+    sampleSha256: createHash("sha256").update(retained(100000)).digest("hex"),
+  };
+  const corpusStat = lstatSync(corpus, { throwIfNoEntry: false });
+  if (corpusStat) {
+    assert.ok(corpusStat.isDirectory(), `refusing unowned corpus path ${corpus}`);
+    const manifestPath = join(corpus, "manifest.json");
+    assert.ok(
+      lstatSync(manifestPath, { throwIfNoEntry: false })?.isFile(),
+      `refusing unowned corpus without a regular manifest: ${corpus}`,
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(manifestPath, "utf8")),
+      manifest,
+      "refusing corpus with an invalid manifest",
+    );
+    for (const section of ["items", "closed"]) {
+      assert.ok(
+        lstatSync(join(corpus, section)).isDirectory(),
+        "corpus section must be a real directory",
+      );
+    }
+    assert.equal(
+      createHash("sha256")
+        .update(readFileSync(join(corpus, "items", "100000.md")))
+        .digest("hex"),
+      manifest.sampleSha256,
+      "corpus sample does not match manifest",
+    );
+    return;
+  }
+  // Claim a fresh path exclusively; an interrupted generation is not reusable.
+  mkdirSync(corpus);
+  for (const section of ["items", "closed"]) mkdirSync(join(corpus, section));
+  for (let index = 0; index < corpusSpec.open + corpusSpec.archived; index++) {
+    const section = index < corpusSpec.open ? "items" : "closed";
+    writeFileSync(join(corpus, section, `${100000 + index}.md`), retained(100000 + index), {
+      flag: "wx",
+    });
+  }
+  writeFileSync(join(corpus, "manifest.json"), JSON.stringify(manifest, null, 2), { flag: "wx" });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href)
+  main();

--- a/src/clawsweeper-apply-close-guards.ts
+++ b/src/clawsweeper-apply-close-guards.ts
@@ -143,7 +143,7 @@ interface ApplyCloseGuardContext {
   minAgeDescription: string;
   minAgeMs: number;
   number: number;
-  openFileEntryByNumber: ReadonlyMap<number, ReportEntry>;
+  openReportEntry: (number: number) => ReportEntry | undefined;
   processedLimit: number;
   repo: string;
   requiredMaintainerDecision: MaintainerDecision | null;
@@ -171,7 +171,7 @@ export function createApplyCloseGuards(
     minAgeDescription,
     minAgeMs,
     number,
-    openFileEntryByNumber,
+    openReportEntry,
     processedLimit,
     repo,
     requiredMaintainerDecision,
@@ -326,7 +326,7 @@ export function createApplyCloseGuards(
       processedCount + 2 <= processedLimit &&
       currentCloseGatesPassed()
     ) {
-      const counterpartEntry = openFileEntryByNumber.get(counterpartNumber);
+      const counterpartEntry = openReportEntry(counterpartNumber);
       if (counterpartEntry) {
         const counterpartMarkdown = readFileSync(counterpartEntry.path, "utf8");
         const counterpartMaintainerDecisionBlocked =

--- a/src/clawsweeper-apply-decision-workflow.ts
+++ b/src/clawsweeper-apply-decision-workflow.ts
@@ -293,6 +293,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     };
     const {
       applyReportEntriesForDir,
+      createOpenReportLookup,
       captureApplyCanonicalBaseline,
       syncDecisionPacketMarkdown,
       writeReportMarkdown,
@@ -331,12 +332,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
     );
     const files = fileEntries.map((entry) => entry.name);
     const boundedExactSelection = exactEventPublication && requestedItemNumberSet.size > 0;
-    // Exact-event publication handles one leased item and cannot pair-close with
-    // limit=1. Keep unrelated canonical records out of this memory-bounded path.
-    const allOpenFileEntries = boundedExactSelection
-      ? fileEntries
-      : applyReportEntriesForDir(itemsDir, "items", false);
-    const openFileEntryByNumber = new Map(allOpenFileEntries.map((entry) => [entry.number, entry]));
+    const openReportEntry = createOpenReportLookup(fileEntries, boundedExactSelection);
     const pairedIssueCloseoutReportKeys = new Set<string>();
     const closedThisRun = new Set<string>();
     const authorPrBudgetClosesThisRun = new Map<string, number>();
@@ -399,12 +395,16 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       } catch (error) {
         publicationError = error;
       }
-      const finalEntryNumbers = boundedExactSelection
-        ? new Set([
-            ...requestedItemNumberSet,
-            ...results.flatMap((result) => (result.number > 0 ? [result.number] : [])),
-          ])
-        : undefined;
+      // Reload current run evidence, including interrupted paired mutations, without
+      // retaining unrelated open records or the full archived history.
+      const finalEntryNumbers = new Set([
+        ...requestedItemNumberSet,
+        ...results.flatMap((result) => (result.number > 0 ? [result.number] : [])),
+        ...[...applyLedger.items.values()]
+          .filter((state) => state.started && !state.terminal)
+          .map((state) => state.entry.number),
+        ...(activeApplyItem ? [activeApplyItem.number] : []),
+      ]);
       const finalEntries = new Map<number, ReportEntry>();
       for (const finalEntry of [
         ...reportEntriesForDir(itemsDir, finalEntryNumbers),
@@ -507,7 +507,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
       let markdown = entry.markdown;
       const repo = entry.repo;
       const number = entry.number;
-      let mutationLedgerEntry = entry;
+      let mutationLedgerEntry: ReportEntry = entry;
       const liveReadGeneration = new LiveReadGeneration();
       setGuardReadGeneration(liveReadGeneration);
       const fetchApplyItem = (
@@ -740,7 +740,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         renameSync(path, closedPath);
       };
       const archivePairedIssue = (issueNumber: number): void => {
-        const pairedEntry = openFileEntryByNumber.get(issueNumber);
+        const pairedEntry = openReportEntry(issueNumber);
         if (!pairedEntry) {
           throw new Error(`missing independently reviewed linked issue report #${issueNumber}`);
         }
@@ -774,7 +774,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         pairedIssueCloseoutReportKeys.add(pairCloseKey(pairedEntry.repo, issueNumber));
       };
       const pairedIssueCanonicalProvenanceBlock = (issueNumber: number): string | null => {
-        const pairedEntry = openFileEntryByNumber.get(issueNumber);
+        const pairedEntry = openReportEntry(issueNumber);
         if (!pairedEntry) return "implemented-on-main paired closeout requires an independently reviewed linked issue report";
         const parentFixedPrNumber = frontMatterValue(markdown, "fixed_pr_number");
         const parentFixedPrUrl = frontMatterValue(markdown, "fixed_pr_url");
@@ -798,7 +798,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         return null;
       };
       const withPairedIssueMutationLedger = <T>(issueNumber: number, operation: () => T): T => {
-        const pairedEntry = openFileEntryByNumber.get(issueNumber);
+        const pairedEntry = openReportEntry(issueNumber);
         if (!pairedEntry) throw new Error(`missing independently reviewed linked issue report #${issueNumber}`);
         const previousMutationLedgerEntry = mutationLedgerEntry;
         const previousActiveApplyItem = activeApplyItem;
@@ -1355,7 +1355,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         minAgeDescription,
         minAgeMs,
         number,
-        openFileEntryByNumber,
+        openReportEntry,
         processedLimit,
         repo,
         requiredMaintainerDecision,
@@ -2447,7 +2447,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         options: { onOperationCompleted?: () => void } = {},
       ): T =>
         withPairedIssueMutationLedger(pairedNumber, () => {
-        const pairedEntry = openFileEntryByNumber.get(pairedNumber);
+        const pairedEntry = openReportEntry(pairedNumber);
         if (!pairedEntry) {
           throw new ApplyMutationReviewGuardError(
             `missing independently reviewed linked issue report #${pairedNumber}`,
@@ -2639,13 +2639,13 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
         canStartPairedIssueClose: (pairedNumber, pairedKind) =>
           applyLedger.items.has(pairCloseKey(repo, pairedNumber)) &&
           canStartSameAuthorPairCloseInThisRun(pairedNumber, pairedKind),
-        pairedIssueMarkdown: (pairedNumber) => openFileEntryByNumber.get(pairedNumber)?.markdown ?? null,
+        pairedIssueMarkdown: (pairedNumber) => openReportEntry(pairedNumber)?.markdown ?? null,
         pairedIssueReviewUpdatedAt: (pairedNumber) => {
-          const pairedMarkdown = openFileEntryByNumber.get(pairedNumber)?.markdown;
+          const pairedMarkdown = openReportEntry(pairedNumber)?.markdown;
           return pairedMarkdown ? frontMatterValue(pairedMarkdown, "item_updated_at") ?? null : null;
         },
         pairedIssueDurableReviewCommentUpdatedAt: (pairedNumber) => {
-          const pairedMarkdown = openFileEntryByNumber.get(pairedNumber)?.markdown;
+          const pairedMarkdown = openReportEntry(pairedNumber)?.markdown;
           if (!pairedMarkdown) return null;
           const pairedCloseReason = reportDecision(
             pairedMarkdown,
@@ -2699,7 +2699,7 @@ export function createApplyDecisionWorkflow(dependencies: CreateApplyDecisionWor
           results.push(result);
           logProgress(`${simulated ? "would close" : "closed"} linked issue #${result.number}`);
           closedThisRun.add(pairCloseKey(repo, result.number));
-          const pairedEntry = openFileEntryByNumber.get(result.number);
+          const pairedEntry = openReportEntry(result.number);
           const pairedState = pairedEntry
             ? startApplyActionLedgerItem(applyLedger, pairedEntry)
             : null;

--- a/src/clawsweeper-apply-records.ts
+++ b/src/clawsweeper-apply-records.ts
@@ -43,7 +43,6 @@ export function createApplyRecordOperations({
   const applyReportEntriesForDir = (
     dir: string,
     location: "items" | "closed",
-    filterRequested = true,
   ): Array<
     ReportEntry & {
       location: "items" | "closed";
@@ -51,22 +50,35 @@ export function createApplyRecordOperations({
       applyCheckedAt: number;
     }
   > =>
-    reportEntriesForDir(
-      dir,
-      filterRequested && requestedItemNumberSet.size > 0 ? requestedItemNumberSet : undefined,
-    )
+    reportEntriesForDir(dir, requestedItemNumberSet.size > 0 ? requestedItemNumberSet : undefined)
       .filter(
         (entry) =>
           entry.repo === targetRepo() &&
-          (!filterRequested ||
-            requestedItemNumberSet.size === 0 ||
-            requestedItemNumberSet.has(entry.number)),
+          (requestedItemNumberSet.size === 0 || requestedItemNumberSet.has(entry.number)),
       )
       .map((entry) => ({
         ...entry,
         location,
         ...applyQueueSortFields(entry.markdown, syncCommentsOnly, applyKind),
       }));
+
+  const createOpenReportLookup = (entries: readonly ReportEntry[], selectedOnly: boolean) => {
+    const byNumber = new Map<number, ReportEntry | undefined>(
+      entries.map((entry) => [entry.number, entry]),
+    );
+    return (number: number): ReportEntry | undefined => {
+      if (!byNumber.has(number) && !selectedOnly) {
+        // Paired-close guards need independent evidence, not the entire open corpus.
+        byNumber.set(
+          number,
+          reportEntriesForDir(itemsDir, new Set([number])).find(
+            (entry) => entry.repo === targetRepo(),
+          ),
+        );
+      }
+      return byNumber.get(number);
+    };
+  };
 
   const captureApplyCanonicalBaseline = (reportPath: string): void => {
     if (dryRun || !canonicalBaselineDir) return;
@@ -118,6 +130,7 @@ export function createApplyRecordOperations({
 
   return {
     applyReportEntriesForDir,
+    createOpenReportLookup,
     captureApplyCanonicalBaseline,
     syncDecisionPacketMarkdown,
     writeReportMarkdown,

--- a/test/apply-cursor-trace.test.ts
+++ b/test/apply-cursor-trace.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
+import { createApplyRecordOperations } from "../dist/clawsweeper-apply-records.js";
+import { repositoryProfileFor } from "../dist/repository-profiles.js";
 
 import {
   implementedCloseReport,
@@ -11,6 +13,60 @@ import {
   withMockGh,
   workPlanCandidateReport,
 } from "./helpers.ts";
+
+test("apply resolves only requested paired dependencies and preserves selected snapshots", () => {
+  const selected = {
+    number: 20,
+    name: "20.md",
+    path: "items/20.md",
+    repo: "openclaw/openclaw",
+    markdown: "selected snapshot",
+  };
+  const paired = {
+    ...selected,
+    number: 21,
+    name: "21.md",
+    path: "items/21.md",
+    markdown: "independent paired review",
+  };
+  const reads: number[][] = [];
+  const records = createApplyRecordOperations({
+    applyKind: "all",
+    applyQueueSortFields: () => ({ priority: 0, applyCheckedAt: 0 }),
+    canonicalBaselineDir: "",
+    closedDir: "closed",
+    decisionPacketsDir: "packets",
+    dryRun: true,
+    itemsDir: "items",
+    numberForMarkdownFile: (name) => Number(name.replace(".md", "")),
+    plansDir: "plans",
+    profile: repositoryProfileFor("openclaw/openclaw"),
+    recordRoot: ".",
+    requestedItemNumberSet: new Set([20]),
+    syncCommentsOnly: false,
+    targetRepo: () => "openclaw/openclaw",
+    reportEntriesForDir: (_dir, numbers) => {
+      assert.ok(numbers, "paired lookup must always be bounded");
+      reads.push([...numbers]);
+      return numbers.has(21)
+        ? [paired]
+        : numbers.has(22)
+          ? [{ ...paired, number: 22, repo: "other/repo" }]
+          : [];
+    },
+  });
+  const lookup = records.createOpenReportLookup([selected], false);
+  assert.equal(lookup(20), selected);
+  assert.equal(lookup(21), paired);
+  assert.equal(lookup(21), paired);
+  assert.equal(lookup(22), undefined);
+  assert.equal(lookup(23), undefined);
+  assert.equal(lookup(23), undefined);
+  assert.deepEqual(reads, [[21], [22], [23]]);
+  const exactLookup = records.createOpenReportLookup([selected], true);
+  assert.equal(exactLookup(21), undefined);
+  assert.deepEqual(reads, [[21], [22], [23]]);
+});
 
 test("apply-decisions preserves auto-selected order and traces only examined records", () => {
   const root = mkdtempSync(tmpPrefix);
@@ -167,50 +223,59 @@ test("apply-decisions runs the numeric comment-sync frontier before ascending ur
   }
 });
 
-test("exact-event apply does not read unrelated canonical records", () => {
-  const root = mkdtempSync(tmpPrefix);
-  try {
-    const itemsDir = join(root, "items");
-    const closedDir = join(root, "closed");
-    const plansDir = join(root, "plans");
-    const reportPath = join(root, "apply-report.json");
-    mkdirSync(itemsDir, { recursive: true });
-    mkdirSync(plansDir, { recursive: true });
-    writeFileSync(
-      join(itemsDir, "20.md"),
-      workPlanCandidateReport({
-        repository: "openclaw/openclaw",
-        number: 20,
-        local_checkout_access: "unverified",
-        decision: "keep_open",
-        action_taken: "kept_open",
-      }),
-      "utf8",
-    );
-    symlinkSync(join(root, "missing-record.md"), join(itemsDir, "999.md"));
+for (const mode of ["exact-event", "proof", "comment-sync", "broad", "empty"] as const) {
+  test(`${mode} apply does not read unrelated canonical records`, () => {
+    const root = mkdtempSync(tmpPrefix);
+    try {
+      const itemsDir = join(root, "items");
+      const closedDir = join(root, "closed");
+      const plansDir = join(root, "plans");
+      const reportPath = join(root, "apply-report.json");
+      mkdirSync(itemsDir, { recursive: true });
+      mkdirSync(closedDir, { recursive: true });
+      mkdirSync(plansDir, { recursive: true });
+      writeFileSync(
+        join(itemsDir, "20.md"),
+        workPlanCandidateReport({
+          repository: "openclaw/openclaw",
+          number: 20,
+          local_checkout_access: "unverified",
+          decision: "keep_open",
+          action_taken: "kept_open",
+        }),
+        "utf8",
+      );
+      if (mode !== "broad") {
+        symlinkSync(join(root, "missing-record.md"), join(itemsDir, "999.md"));
+      }
+      symlinkSync(join(root, "missing-record.md"), join(closedDir, "998.md"));
 
-    runApplyDecisionsForTest({
-      itemsDir,
-      closedDir,
-      plansDir,
-      reportPath,
-      extraArgs: [
-        "--target-repo",
-        "openclaw/openclaw",
-        "--item-numbers",
-        "20",
-        "--exact-event-publication",
-        "--limit",
-        "1",
-      ],
-    });
+      runApplyDecisionsForTest({
+        itemsDir,
+        closedDir,
+        plansDir,
+        reportPath,
+        extraArgs: [
+          "--target-repo",
+          "openclaw/openclaw",
+          "--skip-dashboard",
+          ...(mode === "broad" ? [] : ["--item-numbers", mode === "empty" ? "21" : "20"]),
+          ...(mode === "exact-event" ? ["--exact-event-publication"] : []),
+          ...(mode === "proof" ? ["--dry-run"] : []),
+          ...(mode === "comment-sync" ? ["--sync-comments-only"] : []),
+          "--limit",
+          "1",
+        ],
+      });
 
-    const report = JSON.parse(readFileSync(reportPath, "utf8"));
-    assert.equal(report[0]?.number, 20);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
+      const report = JSON.parse(readFileSync(reportPath, "utf8"));
+      if (mode === "empty") assert.deepEqual(report, []);
+      else assert.equal(report[0]?.number, 20);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
 
 test("apply-decisions keeps close-limit candidates out of the cursor trace", () => {
   const root = mkdtempSync(tmpPrefix);

--- a/test/apply-memory-harness.test.ts
+++ b/test/apply-memory-harness.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { assertMemoryProcessOutcome } from "../scripts/e2e/apply-memory.mjs";
+
+const harness = new URL("../scripts/e2e/apply-memory.mjs", import.meta.url);
+
+test("memory proof subprocess rejects candidate OOM and only accepts explicitly expected baseline OOM", () => {
+  const oom = { status: null, signal: "SIGABRT", stderr: "FATAL ERROR: heap out of memory" };
+  for (const expectBaselineOom of [false, true]) {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        [
+          `import { assertMemoryProcessOutcome } from ${JSON.stringify(harness.href)};`,
+          `assertMemoryProcessOutcome(${JSON.stringify(oom)}, ${JSON.stringify({ expectBaselineOom })});`,
+        ].join("\n"),
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, expectBaselineOom ? 0 : 1, result.stderr);
+    if (!expectBaselineOom) assert.match(result.stderr, /candidate process failed: SIGABRT/);
+  }
+});
+
+test("baseline OOM mode rejects success, other failures, and timeouts", () => {
+  for (const result of [
+    { status: 0, signal: null, stderr: "" },
+    { status: 1, signal: null, stderr: "heap out of memory" },
+    { status: null, signal: "SIGABRT", stderr: "ordinary abort" },
+    { status: null, signal: "SIGTERM", stderr: "heap out of memory" },
+    { status: null, signal: "SIGABRT", stderr: "heap out of memory", error: new Error("timeout") },
+  ]) {
+    assert.throws(() => assertMemoryProcessOutcome(result, { expectBaselineOom: true }));
+  }
+  assert.equal(assertMemoryProcessOutcome({ status: 0, signal: null }), false);
+  assert.equal(
+    assertMemoryProcessOutcome({ status: 1, signal: null }, { expectedStatus: 1 }),
+    false,
+  );
+  assert.throws(() => assertMemoryProcessOutcome({ status: 1, signal: null }));
+});
+
+test("memory proof refuses unowned corpus without changing numeric or unrelated sentinels", () => {
+  const root = mkdtempSync(join(tmpdir(), "clawsweeper-memory-sentinel-"));
+  try {
+    const corpus = join(root, "corpus");
+    mkdirSync(join(corpus, "items"), { recursive: true });
+    const numericSentinel = join(corpus, "items", "100000.md");
+    const otherSentinel = join(corpus, "keep.txt");
+    writeFileSync(numericSentinel, "unowned numeric record\n");
+    writeFileSync(otherSentinel, "unrelated artifact\n");
+    for (const manifest of [
+      undefined,
+      "not json",
+      JSON.stringify({ open: 5500, archived: 12000, bytesPerRecord: 32768 }),
+    ]) {
+      if (manifest !== undefined) writeFileSync(join(corpus, "manifest.json"), manifest);
+      const before = readdirSync(corpus, { recursive: true });
+      const result = spawnSync(
+        process.execPath,
+        [fileURLToPath(harness), root, ".", "sentinel", "empty"],
+        { encoding: "utf8" },
+      );
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /refusing unowned corpus|invalid manifest|SyntaxError/);
+      assert.deepEqual(readdirSync(corpus, { recursive: true }), before);
+      assert.equal(readFileSync(numericSentinel, "utf8"), "unowned numeric record\n");
+      assert.equal(readFileSync(otherSentinel, "utf8"), "unrelated artifact\n");
+      if (manifest !== undefined)
+        assert.equal(readFileSync(join(corpus, "manifest.json"), "utf8"), manifest);
+      assert.deepEqual(readdirSync(root), ["corpus"]);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test(
+  "memory proof refuses a dangling corpus symlink before creating its target",
+  { skip: process.platform === "win32" },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "clawsweeper-memory-symlink-"));
+    try {
+      symlinkSync(join(root, "missing"), join(root, "corpus"), "dir");
+      const result = spawnSync(
+        process.execPath,
+        [fileURLToPath(harness), root, ".", "symlink", "empty"],
+        { encoding: "utf8" },
+      );
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /refusing unowned corpus path/);
+      assert.deepEqual(readdirSync(root), ["corpus"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/apply-runtime-budget.test.ts
+++ b/test/apply-runtime-budget.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
@@ -28,6 +36,8 @@ function runtimeBudgetFixture(number: number) {
   const reportPath = join(root, "apply-report.json");
   const cursorTracePath = join(root, "apply-cursor-trace.json");
   mkdirSync(itemsDir, { recursive: true });
+  mkdirSync(closedDir, { recursive: true });
+  symlinkSync(join(root, "unavailable-archive.md"), join(closedDir, "999.md"));
   mkdirSync(plansDir, { recursive: true });
   writeFileSync(join(itemsDir, `${number}.md`), implementedCloseReport({ number }), "utf8");
   return { root, itemsDir, closedDir, plansDir, reportPath, cursorTracePath };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where scheduled proof and comment-sync runs can exhaust the JavaScript heap even with a small selected batch. Apply eagerly retained unrelated open reports for paired lookups, then reloaded every open and archived report during finalization. That could leave accepted comment writes without a finalized action-ledger batch.

## Why This Change Was Made

Paired lookups now load and cache only explicitly referenced independent records, including missing lookups, while preserving the exact-event selection restriction. Finalization reloads only requested/result records and started, nonterminal, or in-flight ledger items from the open and closed locations. Broad candidate ordering, original snapshots, cursor progress, canonical baselines/CAS, paired evidence, close guards, and ledger identities remain unchanged. The fix stays in apply ownership; the shared report reader, policy, public schema, credentials, heap settings, and workflow limits are untouched.

## User Impact

Small apply/proof/comment-sync batches avoid retaining unrelated report bodies or loading the full archive when completing or yielding. This reduces memory pressure without making additional items eligible for closing. Untargeted apply still retains its complete selected open set.

## OpenClaw Bay Impact

OpenClaw Bay is unaffected: no public API, schema, UI, or published status contract changes, and no action controls are added.

## Documentation Impact

Updated the active [scheduler reference](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/docs/scheduler.md) with the apply retention/finalization contract and added the fix to [CHANGELOG.md](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/CHANGELOG.md). The scheduler reference remains owned by ClawSweeper maintainers, with planner/runtime source and the sweep workflow as its source of truth; changes to apply selection, paired lookup, or ledger finalization trigger updates. This proof verifies the changed apply scope at `673c0f160a251637eef13b5d8cc01213eabd0706`, not every scheduler operation.

Two additional changelog credit lines are maintainer housekeeping for already-landed https://github.com/openclaw/clawsweeper/pull/1242 and https://github.com/openclaw/clawsweeper/pull/1240 from the same health session; they do not alter contributor branches or add their implementation to this diff.

## Evidence

Final head: `673c0f160a251637eef13b5d8cc01213eabd0706`. Tested base: `4a6f9ecb165edc400996fb3bb58c1a56d6133bd2`. This is one commit on current `main`, including integration with the newly landed ETag fix.

The final-head Node 24 build passed. All **60 focused tests passed**, with zero failures, cancellations, or skips: memory boundaries and harness safety, cursor/budget handling, same-author paired-close controls, action-ledger controls, and the ETag broker integration. `git diff --check` passed. The independent precommit Codex review was clean after the harness OOM/ownership findings were fixed; the reviewed source, tests, and hardened harness hashes stayed unchanged through the rebase. The only post-review edit was the two maintainer changelog credit lines.

The prior full local `pnpm run check` is **not green**: 3,693 passed / 48 failed / 9 skipped, with exactly the same 48 baseline failures in unchanged tests. Inherited `fetch.prune=true` deletes fixture `origin/main`; a task-local configuration demonstrated the ref-preservation cause. Separately, deliberately offline validation uses a fresh isolated cache that cannot resolve fixture pnpm 10.33.0 from the pnpm 11 launcher. No test, pin, offline control, budget, timeout, global Git configuration, or unrelated source was weakened. That full check was not rerun on the final head because the identical environment blockers remain. Prior static/lint checks passed; they do not waive the local full-check failure.

Hosted exact-head [CI 33032661025](https://github.com/openclaw/clawsweeper/actions/runs/33032661025) is now **green**: full `pnpm check`, sparse repair build, and Windows Codex launcher all passed at `673c0f160a251637eef13b5d8cc01213eabd0706`. The fresh independent committed-branch Codex review against base `4a6f9ecb165edc400996fb3bb58c1a56d6133bd2` is also clean. The local baseline fixture failures above remain disclosed; hosted success does not relabel that local run. Current-head-and-body ClawSweeper review remains the final discussion/readiness gate.

## Real Behavior Proof

**Claim:** report retention and finalization no longer scale with unrelated stored history for targeted apply, while controlled outcomes and ledger identities are preserved; broad apply avoids the archive-wide finalization reload.

**Surface and environment:** the real built CLI runs as a subprocess against a filesystem Markdown corpus and writes real canonical baselines, reports, cursors, and immutable ledger events. GitHub is a fail-closed local fixture transport. Provider is `local-process`, macOS arm64, Node v24.19.0, pinned pnpm 11.10.0. All seven scenarios ran serially at the unchanged **256 MiB V8 heap ceiling and 120-second per-case timeout**. No full suite ran concurrently. No Crabbox provider, image, lease, Linux run, or hosted GitHub runtime proof is claimed.

**Corpus:** 5,500 unrelated open records and 12,000 archived records, 32 KiB each, plus the selected records. The broad archive control uses 40 open records and the same 12,000-record archive. The harness owns its generated corpus and refuses unowned corpus paths or overwriting an existing case. The child receives no ambient credentials; the observer rejects network access and non-fixture subprocesses except the existing local macOS ledger identity probes.

Executed commands (Node 24 selected on PATH; no baseline-OOM acceptance flag for the candidate):

```sh
PATH=/opt/homebrew/opt/node@24/bin:$PATH corepack pnpm --version
# 11.10.0
PATH=/opt/homebrew/opt/node@24/bin:$PATH corepack pnpm run build
PATH=/opt/homebrew/opt/node@24/bin:$PATH node --test \
  test/apply-memory-harness.test.ts test/apply-cursor-trace.test.ts \
  test/apply-runtime-budget.test.ts test/apply-same-author-pair-close.test.ts \
  test/clawsweeper-action-ledger.test.ts test/github-etag-read-broker.test.ts
/opt/homebrew/opt/node@24/bin/node scripts/e2e/apply-memory.mjs \
  /tmp/clawsweeper-apply-memory-final-673c0f160a25 . committed-673c0f160a25-serial
```

Use a fresh output directory or label to reproduce. Each subprocess uses `--skip-dashboard`, temporary records/report/cursor/baseline/closed paths, explicit item selection except the bounded 40-record broad control, and the committed transport/observer.

**Observed results:** the harness exited 0; all seven scenario gates passed on the final head. The partial-failure process intentionally exits 1 and passes only when its in-flight ledger identity and partial outcome are preserved. Every scenario finalized its ledger and read zero archived bodies.

| Scenario | CLI exit | Sampled heap MiB | Open / archive body reads | Ledger events | Seconds | Gate |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| proof | 0 | 16.53 | 8 / 0 | 7 | 2.120 | pass |
| comment-sync | 0 | 25.38 | 160 / 0 | 163 | 61.685 | pass |
| partial | 1 | 23.36 | 82 / 0 | 11 | 3.640 | pass |
| budget | 0 | 19.61 | 81 / 0 | 9 | 2.772 | pass |
| exact | 0 | 15.62 | 8 / 0 | 7 | 2.045 | pass |
| empty | 0 | 20.34 | 0 / 0 | 3 | 1.397 | pass |
| broad | 0 | 26.26 | 160 / 0 | 163 | 52.644 | pass |

Both 40-record sync scenarios preserved 20 accepted fixture comments, 20 source-drift skips, all 40 cursor numbers, and 163 ledger events. The other gates check protected-label skips without comments, partial-failure identity absent from the result row, runtime-budget yield with resumable cursor, fail-closed exact-event missing-revision behavior, and zero-candidate finalization. Candidate OOM, signal, timeout, arbitrary process failure, unexpected fixture requests, or finalization failure fails the harness. Expected-baseline-OOM mode is explicit and separate; it never accepts timeouts.

Historical controls on `afe976209aa58a5629041b42b66f6ee11b2812a7` established the allocation defects at the same heap ceiling: the two-PR case aborted after its protected-label outcomes at 251.83 MiB sampled heap without finalizing the ledger; the broad archive case aborted after 20 fixture comment writes and 20 drift skips, having read 6,770 archived bodies without finalization. Its captured allocation path was `finishApply -> reportEntriesForDir -> Array.map -> readFileSync`. The two-PR control was repeated with the hardened runner: default mode rejected the OOM, while explicit expected-OOM mode accepted only that expected abort. The archive baseline remains the historical allocation control, not a freshly rerun final-head baseline.

An earlier replay concurrent with the full suite timed out at 120 seconds and remains failed evidence. It was not relabeled green and no limit was raised. The table above is the fresh serial replay of the committed head.

**Durable trace and provenance:** the inline table and JSON below record the executed results and source/build digests; no local-only artifact is required to inspect this evidence. Every scenario's copied runtime matched these three built-module digests. The committed [runner](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/scripts/e2e/apply-memory.mjs), [fixture transport](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/scripts/e2e/apply-memory-gh.cjs), [observer](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/scripts/e2e/apply-memory-observer.cjs), and [harness safety tests](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/test/apply-memory-harness.test.ts) define the commands and fail-closed gates. Source at the tested head: [decision workflow](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/src/clawsweeper-apply-decision-workflow.ts), [record ownership](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/src/clawsweeper-apply-records.ts), and [close guards](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/src/clawsweeper-apply-close-guards.ts).

```json
{
  "head": "673c0f160a251637eef13b5d8cc01213eabd0706",
  "base": "4a6f9ecb165edc400996fb3bb58c1a56d6133bd2",
  "provider": "local-process",
  "platform": "darwin/arm64",
  "node": "v24.19.0",
  "pnpm": "11.10.0",
  "heapLimitMiB": 256,
  "timeoutMs": 120000,
  "serial": true,
  "harnessExit": 0,
  "sourceSha256": {
    "src/clawsweeper-apply-close-guards.ts": "83aacd3d4a6908c89687d9d05f39cd7edcdbfb28908d88bbc355052bfc3160d7",
    "src/clawsweeper-apply-decision-workflow.ts": "4e48883d7615cfce1855e9dc6c6c04359fc7d79539c414740149ac2695844cf2",
    "src/clawsweeper-apply-records.ts": "85d2cb273ccdea738f4cbb9041272bfe26587a780460fedec10e19c60c0caa67"
  },
  "buildSha256": {
    "clawsweeper-apply-decision-workflow.js": "4d0cc2cc8df1a319f6c820c35807dab84f814d22ebfde39714f6536d40622364",
    "clawsweeper-apply-records.js": "44a06d884974461117fb28b9cbd40c272acde615693d069bd384f021f8631ff1",
    "clawsweeper-apply-close-guards.js": "d44e52836384c25256aca0955d69bcad9b3652602b2c6bec47ffe93a6b85ced2"
  }
}
```

**Limits:** sampled heap values are observations, not continuous maxima; aborted-baseline observations are lower bounds. This controlled corpus proves the allocation fix, not the sole cause of the production heap failures or complete production recovery. The protected PR dry-run does not invoke Codex coverage proof or close PRs. Paired-close mutation preservation comes from separate focused integration controls, not the memory harness. Exact publication exercises the fail-closed missing-revision path. The harness `GITHUB_SHA` is synthetic ledger identity; the actual commit and source/build digests above establish candidate provenance. No mass corpus, raw logs, or agent transcript is published. No deployment, live GitHub closure, live model proof, or post-deployment health result is claimed.


## Finding Disposition

**Rejected: “Remove release-owned CHANGELOG entries.”** This finding applies the policy of a different repository. This PR targets `openclaw/clawsweeper`, not `openclaw/openclaw`. [AGENTS.md lines 50–51](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/AGENTS.md#L50-L51) explicitly make the **OpenClaw** changelog release-owned. [CONTRIBUTING.md lines 16–19](https://github.com/openclaw/clawsweeper/blob/673c0f160a251637eef13b5d8cc01213eabd0706/CONTRIBUTING.md#L16-L19) scope that restriction to an `openclaw/openclaw` target and separately direct ClawSweeper changes to this repository's release-note policy. These three entries are maintainer-authored ClawSweeper release context, including credit for the two fixes already landed during this health session. They do not edit OpenClaw's changelog, publish a release, or alter contributor branches. They remain intentionally.

The only code-related merge risk is the existing availability boundary; focused, paired/CAS/cursor controls, exact-head full CI, and seven controlled runtime scenarios cover it without changing close eligibility. No runtime finding remains accepted or unresolved.

The automated live-verification wrapper reported a 30-second previous-command timeout even though its captured built-CLI result shows `scenario: proof`, exit 0, zero archive reads, and `validation.passed: true`. That wrapper outcome remains a failed attempt; it is not relabeled green. The independent seven-scenario final-head runtime proof above remains the executed proof package, and the durable review already assessed it as sufficient. This metadata-only update requires a fresh review of the current body, not a change to the proven runtime or its safety controls.
